### PR TITLE
feat(deepseek-v4): add vLLM GB200 disagg recipe for DeepSeek-V4-Pro

### DIFF
--- a/recipes/deepseek-v4/deepseek-v4-pro/vllm/disagg/deploy.yaml
+++ b/recipes/deepseek-v4/deepseek-v4-pro/vllm/disagg/deploy.yaml
@@ -7,25 +7,23 @@
 # Shape: 1 prefill replica + 1 decode replica, each spanning 2 GB200 nodes
 #        with 4 GPUs per node (DP=8, TP=1). Total: 4 nodes x 4 GPUs = 16 GPUs.
 #
-# Key differences from the aggregated recipe (vllm/agg/deploy.yaml):
-#   - Separate VllmPrefillWorker and VllmDecodeWorker services
-#   - DP=8 (TP=1) instead of TP=8 — each DP rank holds one FP4 model shard
-#   - NixlConnector for KV cache transfer between prefill and decode pods
-#   - UCX transport environment variables required by NixlConnector
-#   - Prefill uses expert weight offloading (offload-group-size/num-in-group/prefetch-step)
-#   - Sleep mode enabled on both workers for memory-efficient idle state
-#   - max-model-len 9280 (ISL 8k + OSL 1k headroom)
-#   - Multinode DP coordination flags are injected by the Dynamo operator:
-#     --data-parallel-hybrid-lb, --data-parallel-address,
-#     --data-parallel-size-local, --data-parallel-start-rank, and
-#     --data-parallel-rpc-port.
+# Cross-node fabric: NVLink72 (MNNVL) via ComputeDomain. UCX active-messages
+# control plane goes over TCP (eth0); bulk KV flows over MNNVL/cuda_ipc.
 #
-# Image: replace the `:my-tag` placeholder with a Dynamo + vLLM image that
-#        includes the DeepSeek-V4 stack and NixlConnector support.
-#        See `../container/README.md` for the reference build.
-#
-# Weights: served from the `model-cache` PVC populated by
-#          `../../model-cache/model-download.yaml`.
+# Prerequisites: DRA / ComputeDomain controller installed cluster-wide.
+# Image: replace `:my-tag` with a Dynamo + vLLM image (see ../container/README.md).
+# Weights: served from the `model-cache` PVC (see ../../model-cache/model-download.yaml).
+---
+apiVersion: resource.nvidia.com/v1beta1
+kind: ComputeDomain
+metadata:
+  name: dsv4-pro-compute-domain
+spec:
+  numNodes: 0
+  channel:
+    resourceClaimTemplate:
+      name: dsv4-pro-compute-domain-channel
+---
 apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
 metadata:
@@ -61,12 +59,13 @@ spec:
       sharedMemory:
         size: 200Gi
       extraPodSpec:
+        resourceClaims:
+          - name: compute-domain-channel
+            resourceClaimTemplateName: dsv4-pro-compute-domain-channel
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
           workingDir: /workspace/examples/backends/vllm
-          # DeepSeek-V4-Pro (1.6T params, FP4) with DP=8 + expert offloading.
-          # Allow ~90 min for first launch (weight sharding + FlashInfer autotune +
-          # cudagraph warmup). periodSeconds * failureThreshold = 10 * 540 = 5400s.
+          # ~90 min budget for first launch (weights + autotune + cudagraph): 10 * 540 = 5400s.
           startupProbe:
             httpGet:
               path: /health
@@ -81,10 +80,8 @@ spec:
               value: deepseek-ai/DeepSeek-V4-Pro
             - name: HF_HOME
               value: /opt/models
-            # Give the engine room to finish first-launch init.
             - name: VLLM_ENGINE_READY_TIMEOUT_S
               value: "5400"
-            # FP4 MoE and TileLang tuning for prefill
             - name: TILELANG_CLEANUP_TEMP_FILES
               value: "1"
             - name: VLLM_SPARSE_INDEXER_MAX_LOGITS_MB
@@ -93,7 +90,6 @@ spec:
               value: "2048"
             - name: VLLM_SERVER_DEV_MODE
               value: "1"
-            # NCCL settings for Blackwell NVLink collectives
             - name: VLLM_USE_NCCL_SYMM_MEM
               value: "1"
             - name: NCCL_CUMEM_ENABLE
@@ -104,12 +100,17 @@ spec:
               value: "1"
             - name: NCCL_P2P_LEVEL
               value: NVL
+            - name: NCCL_STORE_TIMEOUT
+              value: "7200"
+            - name: NCCL_SOCKET_IFNAME
+              value: eth0
+            - name: NVIDIA_GDRCOPY
+              value: "1"
             - name: GLOO_SOCKET_IFNAME
               value: eth0
-            # UCX transport settings required by NixlConnector for cross-pod KV transfer
+            # UCX_TLS must include an AM-capable transport (tcp); cuda_ipc/cuda_copy
+            # are memory-type-only and cannot carry NIXL's UCX control plane.
             - name: UCX_MEMTYPE_CACHE
-              value: "n"
-            - name: UCX_MEMTYPE_REG_WHOLE
               value: "n"
             - name: UCX_TLS
               value: cuda_copy,cuda_ipc,tcp
@@ -120,7 +121,14 @@ spec:
             - -c
           args:
             - |
-              python3 -m dynamo.vllm \
+              # Park a TCP listener on :29500 so the operator's wait-for-leader-mp
+              # init container probe succeeds (vLLM hybrid-lb uses an OS-assigned port).
+              nohup python3 -u -c 'import socketserver
+              class H(socketserver.BaseRequestHandler):
+                  def handle(self): self.request.close()
+              socketserver.TCPServer.allow_reuse_address = True
+              socketserver.TCPServer(("0.0.0.0", 29500), H).serve_forever()' >/dev/null 2>&1 &
+              exec python3 -m dynamo.vllm \
                 --model "${MODEL_PATH}" \
                 --served-model-name "${SERVED_MODEL_NAME}" \
                 --trust-remote-code \
@@ -157,6 +165,8 @@ spec:
           gpu: "4"
         requests:
           gpu: "4"
+        claims:
+          - name: compute-domain-channel
     VllmDecodeWorker:
       componentType: worker
       subComponentType: decode
@@ -167,11 +177,12 @@ spec:
       sharedMemory:
         size: 200Gi
       extraPodSpec:
+        resourceClaims:
+          - name: compute-domain-channel
+            resourceClaimTemplateName: dsv4-pro-compute-domain-channel
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
           workingDir: /workspace/examples/backends/vllm
-          # Allow ~90 min for first launch.
-          # periodSeconds * failureThreshold = 10 * 540 = 5400s.
           startupProbe:
             httpGet:
               path: /health
@@ -186,14 +197,12 @@ spec:
               value: deepseek-ai/DeepSeek-V4-Pro
             - name: HF_HOME
               value: /opt/models
-            # Give the engine room to finish first-launch init.
             - name: VLLM_ENGINE_READY_TIMEOUT_S
               value: "5400"
             - name: TILELANG_CLEANUP_TEMP_FILES
               value: "1"
             - name: VLLM_SERVER_DEV_MODE
               value: "1"
-            # NCCL settings for Blackwell NVLink collectives
             - name: VLLM_USE_NCCL_SYMM_MEM
               value: "1"
             - name: NCCL_CUMEM_ENABLE
@@ -204,12 +213,15 @@ spec:
               value: "1"
             - name: NCCL_P2P_LEVEL
               value: NVL
+            - name: NCCL_STORE_TIMEOUT
+              value: "7200"
+            - name: NCCL_SOCKET_IFNAME
+              value: eth0
+            - name: NVIDIA_GDRCOPY
+              value: "1"
             - name: GLOO_SOCKET_IFNAME
               value: eth0
-            # UCX transport settings required by NixlConnector for cross-pod KV transfer
             - name: UCX_MEMTYPE_CACHE
-              value: "n"
-            - name: UCX_MEMTYPE_REG_WHOLE
               value: "n"
             - name: UCX_TLS
               value: cuda_copy,cuda_ipc,tcp
@@ -220,7 +232,12 @@ spec:
             - -c
           args:
             - |
-              python3 -m dynamo.vllm \
+              nohup python3 -u -c 'import socketserver
+              class H(socketserver.BaseRequestHandler):
+                  def handle(self): self.request.close()
+              socketserver.TCPServer.allow_reuse_address = True
+              socketserver.TCPServer(("0.0.0.0", 29500), H).serve_forever()' >/dev/null 2>&1 &
+              exec python3 -m dynamo.vllm \
                 --model "${MODEL_PATH}" \
                 --served-model-name "${SERVED_MODEL_NAME}" \
                 --trust-remote-code \
@@ -252,3 +269,5 @@ spec:
           gpu: "4"
         requests:
           gpu: "4"
+        claims:
+          - name: compute-domain-channel

--- a/recipes/deepseek-v4/deepseek-v4-pro/vllm/disagg/deploy.yaml
+++ b/recipes/deepseek-v4/deepseek-v4-pro/vllm/disagg/deploy.yaml
@@ -42,6 +42,8 @@ spec:
       volumeMounts:
         - name: model-cache
           mountPoint: /opt/models
+      sharedMemory:
+        size: 40Gi
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
@@ -102,6 +104,8 @@ spec:
               value: "1"
             - name: NCCL_P2P_LEVEL
               value: NVL
+            - name: GLOO_SOCKET_IFNAME
+              value: eth0
             # UCX transport settings required by NixlConnector for cross-pod KV transfer
             - name: UCX_MEMTYPE_CACHE
               value: "n"
@@ -200,6 +204,8 @@ spec:
               value: "1"
             - name: NCCL_P2P_LEVEL
               value: NVL
+            - name: GLOO_SOCKET_IFNAME
+              value: eth0
             # UCX transport settings required by NixlConnector for cross-pod KV transfer
             - name: UCX_MEMTYPE_CACHE
               value: "n"

--- a/recipes/deepseek-v4/deepseek-v4-pro/vllm/disagg/deploy.yaml
+++ b/recipes/deepseek-v4/deepseek-v4-pro/vllm/disagg/deploy.yaml
@@ -1,0 +1,248 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# DynamoGraphDeployment for deepseek-ai/DeepSeek-V4-Pro on vLLM,
+# disaggregated prefill/decode serving.
+#
+# Shape: 1 prefill replica + 1 decode replica, each spanning 2 GB200 nodes
+#        with 4 GPUs per node (DP=8, TP=1). Total: 4 nodes x 4 GPUs = 16 GPUs.
+#
+# Key differences from the aggregated recipe (vllm/agg/deploy.yaml):
+#   - Separate VllmPrefillWorker and VllmDecodeWorker services
+#   - DP=8 (TP=1) instead of TP=8 — each DP rank holds one FP4 model shard
+#   - NixlConnector for KV cache transfer between prefill and decode pods
+#   - UCX transport environment variables required by NixlConnector
+#   - Prefill uses expert weight offloading (offload-group-size/num-in-group/prefetch-step)
+#   - Sleep mode enabled on both workers for memory-efficient idle state
+#   - max-model-len 9280 (ISL 8k + OSL 1k headroom)
+#   - Multinode DP coordination flags are injected by the Dynamo operator:
+#     --data-parallel-hybrid-lb, --data-parallel-address,
+#     --data-parallel-size-local, --data-parallel-start-rank, and
+#     --data-parallel-rpc-port.
+#
+# Image: replace the `:my-tag` placeholder with a Dynamo + vLLM image that
+#        includes the DeepSeek-V4 stack and NixlConnector support.
+#        See `../container/README.md` for the reference build.
+#
+# Weights: served from the `model-cache` PVC populated by
+#          `../../model-cache/model-download.yaml`.
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: dsv4-pro-disagg
+spec:
+  backendFramework: vllm
+  pvcs:
+    - name: model-cache
+      create: false
+  services:
+    Frontend:
+      componentType: frontend
+      replicas: 1
+      volumeMounts:
+        - name: model-cache
+          mountPoint: /opt/models
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          workingDir: /workspace/examples/backends/vllm
+          env:
+            - name: HF_HOME
+              value: /opt/models
+    VllmPrefillWorker:
+      componentType: worker
+      subComponentType: prefill
+      envFromSecret: hf-token-secret
+      volumeMounts:
+        - name: model-cache
+          mountPoint: /opt/models
+      sharedMemory:
+        size: 200Gi
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          workingDir: /workspace/examples/backends/vllm
+          # DeepSeek-V4-Pro (1.6T params, FP4) with DP=8 + expert offloading.
+          # Allow ~90 min for first launch (weight sharding + FlashInfer autotune +
+          # cudagraph warmup). periodSeconds * failureThreshold = 10 * 540 = 5400s.
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 9090
+            periodSeconds: 10
+            timeoutSeconds: 10
+            failureThreshold: 540
+          env:
+            - name: SERVED_MODEL_NAME
+              value: deepseek-ai/DeepSeek-V4-Pro
+            - name: MODEL_PATH
+              value: deepseek-ai/DeepSeek-V4-Pro
+            - name: HF_HOME
+              value: /opt/models
+            # Give the engine room to finish first-launch init.
+            - name: VLLM_ENGINE_READY_TIMEOUT_S
+              value: "5400"
+            # FP4 MoE and TileLang tuning for prefill
+            - name: TILELANG_CLEANUP_TEMP_FILES
+              value: "1"
+            - name: VLLM_SPARSE_INDEXER_MAX_LOGITS_MB
+              value: "1024"
+            - name: VLLM_MAX_TOKENS_PER_EXPERT_FP4_MOE
+              value: "2048"
+            - name: VLLM_SERVER_DEV_MODE
+              value: "1"
+            # NCCL settings for Blackwell NVLink collectives
+            - name: VLLM_USE_NCCL_SYMM_MEM
+              value: "1"
+            - name: NCCL_CUMEM_ENABLE
+              value: "1"
+            - name: NCCL_MNNVL_ENABLE
+              value: "1"
+            - name: NCCL_NVLS_ENABLE
+              value: "1"
+            - name: NCCL_P2P_LEVEL
+              value: NVL
+            # UCX transport settings required by NixlConnector for cross-pod KV transfer
+            - name: UCX_MEMTYPE_CACHE
+              value: "n"
+            - name: UCX_MEMTYPE_REG_WHOLE
+              value: "n"
+            - name: UCX_TLS
+              value: cuda_copy,cuda_ipc,tcp
+            - name: UCX_CUDA_IPC_ENABLE_MNNVL
+              value: "y"
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - |
+              python3 -m dynamo.vllm \
+                --model "${MODEL_PATH}" \
+                --served-model-name "${SERVED_MODEL_NAME}" \
+                --trust-remote-code \
+                --kv-cache-dtype fp8 \
+                --block-size 256 \
+                --tensor-parallel-size 1 \
+                --pipeline-parallel-size 1 \
+                --data-parallel-size 8 \
+                --disaggregation-mode prefill \
+                --enable-expert-parallel \
+                --enforce-eager \
+                --max-model-len 9280 \
+                --max-num-seqs 16 \
+                --max-num-batched-tokens 32768 \
+                --no-enable-prefix-caching \
+                --no-enable-flashinfer-autotune \
+                --no-async-scheduling \
+                --gpu-memory-utilization 0.8 \
+                --no-disable-hybrid-kv-cache-manager \
+                --enable-sleep-mode \
+                --numa-bind \
+                --offload-group-size 3 \
+                --offload-num-in-group 1 \
+                --offload-prefetch-step 2 \
+                --tokenizer-mode deepseek_v4 \
+                --dyn-reasoning-parser deepseek_v4 \
+                --dyn-tool-call-parser deepseek_v4 \
+                --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
+      replicas: 1
+      multinode:
+        nodeCount: 2
+      resources:
+        limits:
+          gpu: "4"
+        requests:
+          gpu: "4"
+    VllmDecodeWorker:
+      componentType: worker
+      subComponentType: decode
+      envFromSecret: hf-token-secret
+      volumeMounts:
+        - name: model-cache
+          mountPoint: /opt/models
+      sharedMemory:
+        size: 200Gi
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          workingDir: /workspace/examples/backends/vllm
+          # Allow ~90 min for first launch.
+          # periodSeconds * failureThreshold = 10 * 540 = 5400s.
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 9090
+            periodSeconds: 10
+            timeoutSeconds: 10
+            failureThreshold: 540
+          env:
+            - name: SERVED_MODEL_NAME
+              value: deepseek-ai/DeepSeek-V4-Pro
+            - name: MODEL_PATH
+              value: deepseek-ai/DeepSeek-V4-Pro
+            - name: HF_HOME
+              value: /opt/models
+            # Give the engine room to finish first-launch init.
+            - name: VLLM_ENGINE_READY_TIMEOUT_S
+              value: "5400"
+            - name: TILELANG_CLEANUP_TEMP_FILES
+              value: "1"
+            - name: VLLM_SERVER_DEV_MODE
+              value: "1"
+            # NCCL settings for Blackwell NVLink collectives
+            - name: VLLM_USE_NCCL_SYMM_MEM
+              value: "1"
+            - name: NCCL_CUMEM_ENABLE
+              value: "1"
+            - name: NCCL_MNNVL_ENABLE
+              value: "1"
+            - name: NCCL_NVLS_ENABLE
+              value: "1"
+            - name: NCCL_P2P_LEVEL
+              value: NVL
+            # UCX transport settings required by NixlConnector for cross-pod KV transfer
+            - name: UCX_MEMTYPE_CACHE
+              value: "n"
+            - name: UCX_MEMTYPE_REG_WHOLE
+              value: "n"
+            - name: UCX_TLS
+              value: cuda_copy,cuda_ipc,tcp
+            - name: UCX_CUDA_IPC_ENABLE_MNNVL
+              value: "y"
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - |
+              python3 -m dynamo.vllm \
+                --model "${MODEL_PATH}" \
+                --served-model-name "${SERVED_MODEL_NAME}" \
+                --trust-remote-code \
+                --kv-cache-dtype fp8 \
+                --block-size 256 \
+                --tensor-parallel-size 1 \
+                --pipeline-parallel-size 1 \
+                --data-parallel-size 8 \
+                --enable-expert-parallel \
+                --max-model-len 9280 \
+                --max-num-seqs 128 \
+                --max-cudagraph-capture-size 128 \
+                --max-num-batched-tokens 128 \
+                --no-enable-prefix-caching \
+                --gpu-memory-utilization 0.9 \
+                --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY","mode":0}' \
+                --stream-interval 50 \
+                --no-disable-hybrid-kv-cache-manager \
+                --enable-sleep-mode \
+                --tokenizer-mode deepseek_v4 \
+                --dyn-reasoning-parser deepseek_v4 \
+                --dyn-tool-call-parser deepseek_v4 \
+                --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
+      replicas: 1
+      multinode:
+        nodeCount: 2
+      resources:
+        limits:
+          gpu: "4"
+        requests:
+          gpu: "4"

--- a/recipes/deepseek-v4/deepseek-v4-pro/vllm/disagg/deploy.yaml
+++ b/recipes/deepseek-v4/deepseek-v4-pro/vllm/disagg/deploy.yaml
@@ -121,13 +121,8 @@ spec:
             - -c
           args:
             - |
-              # Park a TCP listener on :29500 so the operator's wait-for-leader-mp
-              # init container probe succeeds (vLLM hybrid-lb uses an OS-assigned port).
-              nohup python3 -u -c 'import socketserver
-              class H(socketserver.BaseRequestHandler):
-                  def handle(self): self.request.close()
-              socketserver.TCPServer.allow_reuse_address = True
-              socketserver.TCPServer(("0.0.0.0", 29500), H).serve_forever()' >/dev/null 2>&1 &
+              # Bind vLLM's DP coordinator on :29500 so the operator's wait-for-leader-mp
+              # init container's TCP probe is satisfied by the real RPC server.
               exec python3 -m dynamo.vllm \
                 --model "${MODEL_PATH}" \
                 --served-model-name "${SERVED_MODEL_NAME}" \
@@ -137,6 +132,7 @@ spec:
                 --tensor-parallel-size 1 \
                 --pipeline-parallel-size 1 \
                 --data-parallel-size 8 \
+                --data-parallel-rpc-port 29500 \
                 --disaggregation-mode prefill \
                 --enable-expert-parallel \
                 --enforce-eager \
@@ -232,11 +228,7 @@ spec:
             - -c
           args:
             - |
-              nohup python3 -u -c 'import socketserver
-              class H(socketserver.BaseRequestHandler):
-                  def handle(self): self.request.close()
-              socketserver.TCPServer.allow_reuse_address = True
-              socketserver.TCPServer(("0.0.0.0", 29500), H).serve_forever()' >/dev/null 2>&1 &
+              # See VllmPrefillWorker for the :29500 / wait-for-leader-mp rationale.
               exec python3 -m dynamo.vllm \
                 --model "${MODEL_PATH}" \
                 --served-model-name "${SERVED_MODEL_NAME}" \
@@ -246,6 +238,7 @@ spec:
                 --tensor-parallel-size 1 \
                 --pipeline-parallel-size 1 \
                 --data-parallel-size 8 \
+                --data-parallel-rpc-port 29500 \
                 --enable-expert-parallel \
                 --max-model-len 9280 \
                 --max-num-seqs 128 \

--- a/recipes/deepseek-v4/deepseek-v4-pro/vllm/disagg/perf.yaml
+++ b/recipes/deepseek-v4/deepseek-v4-pro/vllm/disagg/perf.yaml
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Perf Job for the dsv4-pro-disagg DGD: 8K input / 1K output, concurrency
+# sweep 256x512x1024
+#
+# Topology assumed (set by the matching deploy.yaml):
+#   1 prefill (DP=8 across 2 GB200 nodes) + 1 decode (DP=8 across 2 GB200 nodes)
+#     => 16 decode GPUs, c=512
+#
+# Deploy first:  kubectl -n <ns> apply -f deploy.yaml
+# Then run perf: kubectl -n <ns> apply -f perf.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: dsv4-pro-disagg-bench
+spec:
+  backoffLimit: 1
+  completions: 1
+  parallelism: 1
+  template:
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: bench
+        image: python:3.12-slim
+        securityContext:
+          allowPrivilegeEscalation: false
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: TARGET_MODEL
+          value: deepseek-ai/DeepSeek-V4-Pro
+        - name: ENDPOINT
+          value: dsv4-pro-disagg-frontend:8000
+        - name: ISL
+          value: "8192"
+        - name: OSL
+          value: "1024"
+        # Concurrency sweep — each value runs as its own aiperf profile under a
+        # per-concurrency artifact subdir. Override to a single value for a quick
+        # smoke run, e.g. CONCURRENCIES: "512".
+        - name: CONCURRENCIES
+          value: "256 512 1024"
+        - name: ARTIFACT_ROOT
+          value: /opt/models/perf/dsv4-pro-disagg-isl8k-osl1k
+        - name: TOKENIZER
+          value: deepseek-ai/DeepSeek-V4-Pro
+        - name: HF_HOME
+          value: /opt/models
+        - name: PYTHONUNBUFFERED
+          value: "1"
+        - name: COLUMNS
+          value: "200"
+        # HOME defaults to "/" for uid 1000 with no /etc/passwd entry; pip --user
+        # then tries to write /.local (read-only). Point HOME at /tmp (1777 sticky)
+        # so ~/.local resolves under a writable path.
+        - name: HOME
+          value: /tmp
+        - name: PATH
+          value: /tmp/.local/bin:/usr/local/bin:/usr/bin:/bin
+        envFrom:
+        - secretRef:
+            name: hf-token-secret
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -eu
+          # No apt-get: cluster runs us as non-root, and we don't actually need
+          # curl/jq — Python stdlib handles the readiness probe. Install aiperf
+          # into HOME=/tmp/.local via --user so it works under runAsNonRoot.
+          pip install --user -q aiperf==0.6.0 transformers==4.57.3 tokenizers==0.22.2
+
+          echo "Waiting for model at http://$ENDPOINT/v1/models..."
+          python3 - <<'PY'
+          import json, os, time, urllib.error, urllib.request
+          endpoint, target = os.environ["ENDPOINT"], os.environ["TARGET_MODEL"]
+          while True:
+              try:
+                  with urllib.request.urlopen(f"http://{endpoint}/v1/models", timeout=5) as r:
+                      data = json.load(r)
+                  if any(m.get("id") == target for m in data.get("data", [])):
+                      break
+              except (urllib.error.URLError, ValueError, KeyError):
+                  pass
+              print(f"[{time.strftime('%H:%M:%S')}] not ready, retrying in 10s...", flush=True)
+              time.sleep(10)
+          print("Model ready!", flush=True)
+          PY
+
+          for c in $CONCURRENCIES; do
+            ARTIFACT_DIR="$ARTIFACT_ROOT/c${c}"
+            mkdir -p "$ARTIFACT_DIR"
+            echo ""
+            echo "================================================================"
+            echo " concurrency=$c   isl=$ISL   osl=$OSL   artifact=$ARTIFACT_DIR"
+            echo "================================================================"
+
+            aiperf profile \
+              --artifact-dir "$ARTIFACT_DIR" \
+              --model "$TARGET_MODEL" \
+              --tokenizer "$TOKENIZER" \
+              --tokenizer-trust-remote-code \
+              --endpoint-type chat \
+              --endpoint /v1/chat/completions \
+              --streaming \
+              --url "http://$ENDPOINT" \
+              --synthetic-input-tokens-mean $ISL \
+              --synthetic-input-tokens-stddev 0 \
+              --output-tokens-mean $OSL \
+              --output-tokens-stddev 0 \
+              --extra-inputs "max_tokens:$OSL" \
+              --extra-inputs "min_tokens:$OSL" \
+              --extra-inputs "ignore_eos:true" \
+              --concurrency $c \
+              --request-count $((c * 3)) \
+              --warmup-request-count 16 \
+              --num-dataset-entries 12800 \
+              --random-seed 100 \
+              --ui simple
+          done
+
+          echo ""
+          echo "All sweeps complete. Results under $ARTIFACT_ROOT:"
+          ls -la "$ARTIFACT_ROOT"
+        volumeMounts:
+        - name: model-cache
+          mountPath: /opt/models
+        workingDir: /workspace
+      volumes:
+      - name: model-cache
+        persistentVolumeClaim:
+          claimName: model-cache


### PR DESCRIPTION
#### Overview:

Adds a Kubernetes recipe for DeepSeek-V4-Pro on vLLM in disaggregated prefill/decode mode on GB200 NVL72, using DRA `ComputeDomain` for cross-node MNNVL and a tuned mid-pareto-curve configuration.

#### Details:

- New file: `recipes/deepseek-v4/deepseek-v4-pro/vllm/disagg/deploy.yaml`.
- Shape: 1 prefill + 1 decode replica, each spanning 2 GB200 nodes with 4 GPUs/node (`DP=8`, `TP=1`, `PP=1`); 16 GPUs total. Expert parallelism enabled.
- Adds a `resource.nvidia.com/v1beta1` `ComputeDomain` (`dsv4-pro-compute-domain`) and wires both workers via a `compute-domain-channel` `resourceClaim`, so cross-node tensor traffic flows over MNNVL/`cuda_ipc` while UCX active-messages control plane runs on TCP/`eth0` (`UCX_TLS=cuda_copy,cuda_ipc,tcp`, `UCX_CUDA_IPC_ENABLE_MNNVL=y`).
- KV transfer uses `NixlConnector` with `kv_role=kv_both`; FP8 KV cache, `block-size=256`, hybrid KV-cache manager enabled, sleep mode on.
- Pins `--data-parallel-rpc-port 29500` so the operator’s `wait-for-leader-mp` init container TCP probe lands on the real vLLM DP RPC server.
- Sets DeepSeek-V4 specific flags: `tokenizer-mode=deepseek_v4`, `dyn-reasoning-parser=deepseek_v4`, `dyn-tool-call-parser=deepseek_v4`.
- Prefill tuning: `enforce-eager`, `max-num-seqs=16`, `max-num-batched-tokens=32768`, `max-model-len=9280`, expert offload (`offload-group-size=3`, `offload-num-in-group=1`, `offload-prefetch-step=2`), `numa-bind`, `gpu-memory-utilization=0.8`.
- Decode tuning: `compilation-config` with `cudagraph_mode=FULL_DECODE_ONLY`, `max-cudagraph-capture-size=128`, `max-num-seqs=128`, `max-num-batched-tokens=128`, `stream-interval=50`, `gpu-memory-utilization=0.9`.
- Extends startup probes (`failureThreshold=540`, ~90 min budget) and `VLLM_ENGINE_READY_TIMEOUT_S=5400` to cover first-launch weight load + autotune + cudagraph capture.
- NCCL knobs for MNNVL: `NCCL_MNNVL_ENABLE=1`, `NCCL_NVLS_ENABLE=1`, `NCCL_CUMEM_ENABLE=1`, `NCCL_P2P_LEVEL=NVL`, `NCCL_STORE_TIMEOUT=7200`, `NCCL_SOCKET_IFNAME=eth0`.
- Frontend, model cache PVC (`create: false`), and HF token secret follow the existing recipe pattern.

#### Where should the reviewer start?

1. `recipes/deepseek-v4/deepseek-v4-pro/vllm/disagg/deploy.yaml` — the only file. Check the `ComputeDomain` + `resourceClaim` wiring, the `--data-parallel-rpc-port 29500` pin, and the prefill vs. decode flag deltas.

#### Related Issues:

- closes DIS-1851
