### PR TITLE
fix: fix the tool calling special token leakage issue 

### DIFF
--- a/lib/llm/src/protocols/openai/chat_completions/jail.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/jail.rs
@@ -932,30 +932,90 @@ impl JailedStream {
                     tools_slice,
                 )
                 .await;
-                if let Ok((tool_calls, normal_text)) = parse_result
-                    && !tool_calls.is_empty()
-                {
-                    // If a named tool filter is set (tool_choice=named + parser path), reject
-                    // tool calls that don't match the required tool name.
-                    let tool_calls = if let Some(ref required_name) = self.named_tool_name {
-                        let filtered: Vec<_> = tool_calls
-                            .into_iter()
-                            .filter(|tc| tc.function.name == *required_name)
-                            .collect();
-                        if filtered.is_empty() {
-                            tracing::warn!(
-                                required = %required_name,
-                                "tool_choice=named: parser emitted no matching tool calls; dropping jail output"
+                match parse_result {
+                    Ok((tool_calls, normal_text)) if !tool_calls.is_empty() => {
+                        // If a named tool filter is set (tool_choice=named + parser path), reject
+                        // tool calls that don't match the required tool name.
+                        let tool_calls = if let Some(ref required_name) = self.named_tool_name {
+                            let filtered: Vec<_> = tool_calls
+                                .into_iter()
+                                .filter(|tc| tc.function.name == *required_name)
+                                .collect();
+                            if filtered.is_empty() {
+                                tracing::warn!(
+                                    required = %required_name,
+                                    "tool_choice=named: parser emitted no matching tool calls; dropping jail output"
+                                );
+                            }
+                            filtered
+                        } else {
+                            tool_calls
+                        };
+
+                        if tool_calls.is_empty() {
+                            // All parsed calls were filtered out — emit the parser's stripped
+                            // normal_text, not accumulated_content (which still contains the
+                            // raw tool-call markers).
+                            return create_choice_stream(
+                                choice_index,
+                                Some(Role::Assistant),
+                                normal_text.as_deref().unwrap_or(""),
+                                None,
+                                base_choice.finish_reason,
+                                base_choice.stop_reason.clone(),
+                                base_choice.logprobs.clone(),
                             );
                         }
-                        filtered
-                    } else {
-                        tool_calls
-                    };
 
-                    if tool_calls.is_empty() {
-                        // All parsed calls were for the wrong tool — return content choice
-                        return create_choice_stream(
+                        // Convert to streaming format
+                        let tool_call_chunks: Vec<ChatCompletionMessageToolCallChunk> =
+                            tool_calls
+                                .into_iter()
+                                .enumerate()
+                                .map(|(idx, tool_call)| ChatCompletionMessageToolCallChunk {
+                                    index: (tool_call_offset + idx) as u32,
+                                    id: Some(tool_call.id),
+                                    r#type: Some(FunctionType::Function),
+                                    function: Some(FunctionCallStream {
+                                        name: Some(tool_call.function.name),
+                                        arguments: Some(tool_call.function.arguments),
+                                    }),
+                                })
+                                .collect();
+                        create_choice_stream(
+                            choice_index,
+                            Some(Role::Assistant),
+                            normal_text.as_deref().unwrap_or(""),
+                            Some(tool_call_chunks),
+                            None,
+                            None,
+                            base_choice.logprobs.clone(),
+                        )
+                    }
+                    Ok((_, normal_text)) => {
+                        // Parser succeeded but extracted no structured tool calls — typically
+                        // a malformed/truncated tool-call section (missing tool_call_end,
+                        // corrupted function id, etc.). Emit the parser's stripped
+                        // normal_text rather than accumulated_content, which still contains
+                        // the raw special-token markers and would leak them to the user.
+                        create_choice_stream(
+                            choice_index,
+                            Some(Role::Assistant),
+                            normal_text.as_deref().unwrap_or(""),
+                            None,
+                            base_choice.finish_reason,
+                            base_choice.stop_reason.clone(),
+                            base_choice.logprobs.clone(),
+                        )
+                    }
+                    Err(e) => {
+                        // Parser couldn't run at all — last-resort fallback to the raw
+                        // buffer so a misconfigured parser doesn't silently drop output.
+                        tracing::warn!(
+                            error = %e,
+                            "tool-call parser errored; emitting raw buffered content as fallback"
+                        );
+                        create_choice_stream(
                             choice_index,
                             Some(Role::Assistant),
                             accumulated_content,
@@ -963,46 +1023,9 @@ impl JailedStream {
                             base_choice.finish_reason,
                             base_choice.stop_reason.clone(),
                             base_choice.logprobs.clone(),
-                        );
+                        )
                     }
-
-                    // Convert to streaming format
-                    let tool_call_chunks: Vec<ChatCompletionMessageToolCallChunk> = tool_calls
-                        .into_iter()
-                        .enumerate()
-                        .map(|(idx, tool_call)| ChatCompletionMessageToolCallChunk {
-                            index: (tool_call_offset + idx) as u32,
-                            id: Some(tool_call.id),
-                            r#type: Some(FunctionType::Function),
-                            function: Some(FunctionCallStream {
-                                name: Some(tool_call.function.name),
-                                arguments: Some(tool_call.function.arguments),
-                            }),
-                        })
-                        .collect();
-                    // Create choice with tool calls
-                    let choice = create_choice_stream(
-                        choice_index,
-                        Some(Role::Assistant),
-                        normal_text.as_deref().unwrap_or(""),
-                        Some(tool_call_chunks),
-                        None,
-                        None,
-                        base_choice.logprobs.clone(),
-                    );
-                    return choice;
                 }
-
-                // No tool calls found or parsing failed, return content choice
-                create_choice_stream(
-                    choice_index,
-                    Some(Role::Assistant),
-                    accumulated_content,
-                    None,
-                    base_choice.finish_reason,
-                    base_choice.stop_reason.clone(),
-                    base_choice.logprobs.clone(),
-                )
             }
             JailMode::Immediate { format } => {
                 // tool_choice=required/named path (SGLang/vLLM-style).
@@ -1841,5 +1864,47 @@ mod tests {
             "Trailing text 'Done!' should appear in output. Got text: {:?}",
             all_text
         );
+    }
+
+    /// Regression: a kimi_k2 tool-call section truncated before `<|tool_call_end|>`
+    /// (a common live-traffic pattern when the model hits max_tokens or EOS mid-call)
+    /// must NOT leak the raw special-token markers into the user-visible content
+    /// field. The parser correctly returns no tool_calls and an empty normal_text;
+    /// previously the jail discarded that and emitted the raw accumulated buffer.
+    #[tokio::test]
+    async fn test_kimi_k2_truncated_tool_call_does_not_leak_markers() {
+        let jail = JailedStream::builder().tool_call_parser("kimi_k2").build();
+
+        // Missing <|tool_call_end|> and <|tool_calls_section_end|> — the section
+        // body gets consumed by the parser but yields zero structured calls.
+        let chunks = vec![text_chunk(
+            "<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{\"location\":\"NYC\"}",
+        )];
+
+        let input_stream = Box::pin(stream::iter(chunks));
+        let output_stream = jail.apply_with_finish_reason(input_stream);
+
+        let responses: Vec<_> = output_stream.collect().await;
+
+        let tool_calls = collect_tool_calls(&responses);
+        assert!(
+            tool_calls.is_empty(),
+            "Truncated section should yield no tool calls, got {:?}",
+            tool_calls
+        );
+
+        let all_text = collect_text_content(&responses);
+        for marker in [
+            "<|tool_calls_section_begin|>",
+            "<|tool_call_begin|>",
+            "<|tool_call_argument_begin|>",
+            "<|tool_call_end|>",
+            "<|tool_calls_section_end|>",
+        ] {
+            assert!(
+                !all_text.contains(marker),
+                "Raw kimi_k2 marker {marker:?} leaked into user-visible content: {all_text:?}"
+            );
+        }
     }
 }

--- a/lib/llm/src/protocols/openai/chat_completions/jail.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/jail.rs
@@ -968,20 +968,19 @@ impl JailedStream {
                         }
 
                         // Convert to streaming format
-                        let tool_call_chunks: Vec<ChatCompletionMessageToolCallChunk> =
-                            tool_calls
-                                .into_iter()
-                                .enumerate()
-                                .map(|(idx, tool_call)| ChatCompletionMessageToolCallChunk {
-                                    index: (tool_call_offset + idx) as u32,
-                                    id: Some(tool_call.id),
-                                    r#type: Some(FunctionType::Function),
-                                    function: Some(FunctionCallStream {
-                                        name: Some(tool_call.function.name),
-                                        arguments: Some(tool_call.function.arguments),
-                                    }),
-                                })
-                                .collect();
+                        let tool_call_chunks: Vec<ChatCompletionMessageToolCallChunk> = tool_calls
+                            .into_iter()
+                            .enumerate()
+                            .map(|(idx, tool_call)| ChatCompletionMessageToolCallChunk {
+                                index: (tool_call_offset + idx) as u32,
+                                id: Some(tool_call.id),
+                                r#type: Some(FunctionType::Function),
+                                function: Some(FunctionCallStream {
+                                    name: Some(tool_call.function.name),
+                                    arguments: Some(tool_call.function.arguments),
+                                }),
+                            })
+                            .collect();
                         create_choice_stream(
                             choice_index,
                             Some(Role::Assistant),

--- a/lib/llm/src/protocols/openai/chat_completions/jail.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/jail.rs
@@ -1008,16 +1008,18 @@ impl JailedStream {
                         )
                     }
                     Err(e) => {
-                        // Parser couldn't run at all — last-resort fallback to the raw
-                        // buffer so a misconfigured parser doesn't silently drop output.
+                        // Parser errored — emit empty content rather than the raw buffer.
+                        // accumulated_content may still contain tool-call markers, and
+                        // surfacing those to the user is the leak we're guarding against.
+                        // The warn! gives operators visibility into the failure.
                         tracing::warn!(
                             error = %e,
-                            "tool-call parser errored; emitting raw buffered content as fallback"
+                            "tool-call parser errored; dropping buffered content to avoid marker leak"
                         );
                         create_choice_stream(
                             choice_index,
                             Some(Role::Assistant),
-                            accumulated_content,
+                            "",
                             None,
                             base_choice.finish_reason,
                             base_choice.stop_reason.clone(),

--- a/lib/llm/src/protocols/openai/chat_completions/jail.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/jail.rs
@@ -992,15 +992,27 @@ impl JailedStream {
                         )
                     }
                     Ok((_, normal_text)) => {
-                        // Parser succeeded but extracted no structured tool calls — typically
-                        // a malformed/truncated tool-call section (missing tool_call_end,
-                        // corrupted function id, etc.). Emit the parser's stripped
-                        // normal_text rather than accumulated_content, which still contains
-                        // the raw special-token markers and would leak them to the user.
+                        // Parser succeeded but extracted no structured tool calls. The parser
+                        // signals which sub-case via normal_text:
+                        //   - Some(""):  parser detected markers but couldn't form a complete
+                        //                call (e.g. kimi truncated mid-arg, or start token with
+                        //                no valid JSON). Drop the buffer — accumulated_content
+                        //                still has the raw markers and would leak.
+                        //   - otherwise: parser saw no markers (false positive entry, e.g.
+                        //                mistral on a stray `{` in prose, or default `<tool_call>`
+                        //                token when manual sequences are configured). Pass
+                        //                accumulated_content through verbatim — it's regular text
+                        //                and may carry leading/trailing whitespace the parser
+                        //                would have trimmed.
+                        let content = if normal_text.as_deref() == Some("") {
+                            ""
+                        } else {
+                            accumulated_content
+                        };
                         create_choice_stream(
                             choice_index,
                             Some(Role::Assistant),
-                            normal_text.as_deref().unwrap_or(""),
+                            content,
                             None,
                             base_choice.finish_reason,
                             base_choice.stop_reason.clone(),

--- a/lib/llm/src/protocols/openai/chat_completions/jail.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/jail.rs
@@ -1865,46 +1865,4 @@ mod tests {
             all_text
         );
     }
-
-    /// Regression: a kimi_k2 tool-call section truncated before `<|tool_call_end|>`
-    /// (a common live-traffic pattern when the model hits max_tokens or EOS mid-call)
-    /// must NOT leak the raw special-token markers into the user-visible content
-    /// field. The parser correctly returns no tool_calls and an empty normal_text;
-    /// previously the jail discarded that and emitted the raw accumulated buffer.
-    #[tokio::test]
-    async fn test_kimi_k2_truncated_tool_call_does_not_leak_markers() {
-        let jail = JailedStream::builder().tool_call_parser("kimi_k2").build();
-
-        // Missing <|tool_call_end|> and <|tool_calls_section_end|> — the section
-        // body gets consumed by the parser but yields zero structured calls.
-        let chunks = vec![text_chunk(
-            "<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{\"location\":\"NYC\"}",
-        )];
-
-        let input_stream = Box::pin(stream::iter(chunks));
-        let output_stream = jail.apply_with_finish_reason(input_stream);
-
-        let responses: Vec<_> = output_stream.collect().await;
-
-        let tool_calls = collect_tool_calls(&responses);
-        assert!(
-            tool_calls.is_empty(),
-            "Truncated section should yield no tool calls, got {:?}",
-            tool_calls
-        );
-
-        let all_text = collect_text_content(&responses);
-        for marker in [
-            "<|tool_calls_section_begin|>",
-            "<|tool_call_begin|>",
-            "<|tool_call_argument_begin|>",
-            "<|tool_call_end|>",
-            "<|tool_calls_section_end|>",
-        ] {
-            assert!(
-                !all_text.contains(marker),
-                "Raw kimi_k2 marker {marker:?} leaked into user-visible content: {all_text:?}"
-            );
-        }
-    }
 }

--- a/lib/llm/tests/test_streaming_tool_parsers.rs
+++ b/lib/llm/tests/test_streaming_tool_parsers.rs
@@ -1418,8 +1418,8 @@ mod tests {
         assert_eq!(aggregated.tool_calls.len(), 2);
     }
 
-    /// Repro for the production leak observed against kimi-k2-6 on
-    /// `astraprd01-ocp-pdx04`: the model stops mid-argument with
+    /// Repro for the production leak observed against kimi-k2-6: the
+    /// model stops mid-argument with
     /// `finish_reason: stop` (not max_tokens), having emitted
     /// `<|tool_calls_section_begin|>`, `<|tool_call_begin|>`, the function id,
     /// `<|tool_call_argument_begin|>`, and the JSON value — but **never**
@@ -1465,21 +1465,15 @@ mod tests {
             "Truly truncated call (no call_end) should not produce structured tool_calls"
         );
 
-        // Critical: the jail MUST NOT re-emit the raw `<|tool_calls_section_begin|>`
-        // / `<|tool_call_begin|>` / `<|tool_call_argument_begin|>` markers as
-        // user-visible content. Before the fix, these leaked through.
-        let leaked_markers = [
-            "<|tool_calls_section_begin|>",
-            "<|tool_call_begin|>",
-            "<|tool_call_argument_begin|>",
-        ];
-        for marker in leaked_markers {
-            assert!(
-                !aggregated.normal_content.contains(marker),
-                "Internal special-token marker {marker:?} leaked to user-visible content. \
-                 Got normal_content: {:?}",
-                aggregated.normal_content
-            );
-        }
+        // The parser consumes the section body, so normal_text is expected
+        // to be empty. Asserting equality (not just marker-absence) locks the
+        // contract: any future regression that produced *other* garbage in
+        // normal_text would still fail this assertion.
+        assert!(
+            aggregated.normal_content.is_empty(),
+            "Truncated tool-call section should produce empty normal_content. \
+             Got: {:?}",
+            aggregated.normal_content
+        );
     }
 }

--- a/lib/llm/tests/test_streaming_tool_parsers.rs
+++ b/lib/llm/tests/test_streaming_tool_parsers.rs
@@ -1418,6 +1418,10 @@ mod tests {
         assert_eq!(aggregated.tool_calls.len(), 2);
     }
 
+    /// `CASE.5` + `CASE.8` + `CASE.16` — kimi-k2 truncated mid-argument
+    /// (no `<|tool_call_end|>`), streaming, customer regression. Also
+    /// validates `CASE.12` finish_reason=stop passthrough.
+    ///
     /// Repro for the production leak observed against kimi-k2-6: the
     /// model stops mid-argument with
     /// `finish_reason: stop` (not max_tokens), having emitted

--- a/lib/llm/tests/test_streaming_tool_parsers.rs
+++ b/lib/llm/tests/test_streaming_tool_parsers.rs
@@ -1475,5 +1475,13 @@ mod tests {
              Got: {:?}",
             aggregated.normal_content
         );
+
+        // finish_reason should pass through unchanged from the source chunk
+        // (Stop in this case). Locks the contract that the no-tool-calls
+        // branch doesn't remap the reason.
+        assert!(
+            validate_finish_reason(&output_chunks, FinishReason::Stop),
+            "finish_reason should pass through as Stop when no tool calls are emitted"
+        );
     }
 }

--- a/lib/llm/tests/test_streaming_tool_parsers.rs
+++ b/lib/llm/tests/test_streaming_tool_parsers.rs
@@ -1417,4 +1417,69 @@ mod tests {
         );
         assert_eq!(aggregated.tool_calls.len(), 2);
     }
+
+    /// Repro for the production leak observed against kimi-k2-6 on
+    /// `astraprd01-ocp-pdx04`: the model stops mid-argument with
+    /// `finish_reason: stop` (not max_tokens), having emitted
+    /// `<|tool_calls_section_begin|>`, `<|tool_call_begin|>`, the function id,
+    /// `<|tool_call_argument_begin|>`, and the JSON value — but **never**
+    /// emitting `<|tool_call_end|>` or `<|tool_calls_section_end|>`. This is
+    /// the most common failure mode under heavy concurrent load (multi-worker
+    /// batching causes occasional EOS-token confusion at the close-of-arg
+    /// boundary).
+    ///
+    /// The parser correctly returns 0 tool calls (no complete call found,
+    /// since `<|tool_call_end|>` is required by the kimi_k2 regex) and an
+    /// empty `normal_text` (the section body is consumed). Before the fix,
+    /// the jail's `create_tool_call_choice` ignored `normal_text` and emitted
+    /// the raw `accumulated_content` (with all special-token markers) as
+    /// plain user-visible content — leaking internal protocol tokens to the
+    /// client and breaking downstream agents that expect either a clean
+    /// `tool_calls` array or clean text.
+    #[tokio::test]
+    async fn test_kimi_k2_streaming_truncated_mid_argument_no_call_end() {
+        let chunks = vec![
+            make_chunk("<|tool_calls_section_begin|>", None),
+            make_chunk("<|tool_call_begin|>functions.Write:42", None),
+            make_chunk("<|tool_call_argument_begin|>", None),
+            make_chunk(
+                r#"{"file_path":"/app/main.rs","content":"fn main() {}"}"#,
+                None,
+            ),
+            // Stream ends here — model self-terminated without emitting
+            // <|tool_call_end|> or <|tool_calls_section_end|>.
+            make_chunk("", Some(FinishReason::Stop)),
+        ];
+
+        let input_stream = stream::iter(chunks);
+        let output_chunks =
+            parse_response_stream(input_stream, true, false, Some("kimi_k2".to_string()), None)
+                .await;
+
+        let aggregated = aggregate_content_from_chunks(&output_chunks);
+
+        // The parser cannot recover a structured tool call without
+        // <|tool_call_end|>, so tool_calls is expected to be empty.
+        assert!(
+            !aggregated.has_tool_calls,
+            "Truly truncated call (no call_end) should not produce structured tool_calls"
+        );
+
+        // Critical: the jail MUST NOT re-emit the raw `<|tool_calls_section_begin|>`
+        // / `<|tool_call_begin|>` / `<|tool_call_argument_begin|>` markers as
+        // user-visible content. Before the fix, these leaked through.
+        let leaked_markers = [
+            "<|tool_calls_section_begin|>",
+            "<|tool_call_begin|>",
+            "<|tool_call_argument_begin|>",
+        ];
+        for marker in leaked_markers {
+            assert!(
+                !aggregated.normal_content.contains(marker),
+                "Internal special-token marker {marker:?} leaked to user-visible content. \
+                 Got normal_content: {:?}",
+                aggregated.normal_content
+            );
+        }
+    }
 }


### PR DESCRIPTION
#### Overview:

kimi-k2.6 might leak raw internal protocol tokens (<|tool_calls_section_begin|>, <|tool_call_begin|>,
<|tool_call_argument_begin|>, …) into the content field of OpenAI Chat
Completions responses, with empty tool_calls. 

Fix is only emitting the normal_text rather than the entire accumulated tokens if tool calling parsing is interruptted.

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

Related: DIS-1716


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of incomplete streaming tool calls to prevent internal protocol markers from being exposed to users.
  * Enhanced error handling when tool-call parsing encounters failures, ensuring output is properly managed.

* **Tests**
  * Added regression test for incomplete streaming tool-call scenarios to ensure markers are not leaked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->