### PR TITLE
ci: Move tests with large models to post-merge and utilize better hugging face model downloading env

### DIFF
--- a/.github/actions/pytest/action.yml
+++ b/.github/actions/pytest/action.yml
@@ -157,6 +157,8 @@ runs:
         if [[ -n "${HF_TOKEN:-}" ]]; then
           DOCKER_ENV_FLAGS+=(--env "HF_TOKEN=${HF_TOKEN}")
         fi
+        # TEMP DIAGNOSTIC (revert before merge): force live stdout, dump trace on fatal signals.
+        DOCKER_ENV_FLAGS+=(--env "PYTHONUNBUFFERED=1" --env "PYTHONFAULTHANDLER=1")
         DOCKER_ENV_FLAGS+=(--env "DYNAMO_TEST_FRAMEWORK=${{ inputs.framework }}")
         DOCKER_ENV_FLAGS+=(--env "DYNAMO_TEST_PLATFORM=${{ inputs.platform_arch }}")
         DOCKER_ENV_FLAGS+=(--env "DYNAMO_TEST_TYPE=${{ inputs.test_type }}")
@@ -246,7 +248,10 @@ runs:
 
           # Construct final command with xdist parallelization (-n) and other options
           # --dist=loadscope groups tests by module/class to prevent race conditions in stateful tests
-          PYTEST_CMD="pytest ${PARALLEL_OPTS} --dist=loadscope --continue-on-collection-errors -v --tb=short --basetemp=/tmp/pytest_temp -o cache_dir=/tmp/.pytest_cache --junitxml=/workspace/test-results/${{ env.PYTEST_XML_FILE }} --alluredir=/workspace/test-results/allure-results --durations=10 -m \"${{ inputs.pytest_marks }}\""
+          # TEMP DIAGNOSTIC (revert before merge): -vv -s, live log streaming with
+          # millisecond timestamps so we can see how long each fixture / download takes.
+          # Tracking sglang gpu_1 cuda13 step that goes silent for 30 min.
+          PYTEST_CMD="pytest ${PARALLEL_OPTS} --dist=loadscope --continue-on-collection-errors -vv -s --tb=long --showlocals --log-cli-level=INFO --log-cli-format='%(asctime)s.%(msecs)03d [%(levelname)s] %(name)s: %(message)s' --log-cli-date-format='%H:%M:%S' --basetemp=/tmp/pytest_temp -o cache_dir=/tmp/.pytest_cache --junitxml=/workspace/test-results/${{ env.PYTEST_XML_FILE }} --alluredir=/workspace/test-results/allure-results --durations=10 -m \"${{ inputs.pytest_marks }}\""
         fi
 
         # Get absolute path for test-results directory and ensure it has proper permissions
@@ -259,6 +264,8 @@ runs:
         if [[ -n "${HF_TOKEN:-}" ]]; then
           DOCKER_ENV_FLAGS+=(--env "HF_TOKEN=${HF_TOKEN}")
         fi
+        # TEMP DIAGNOSTIC (revert before merge): force live stdout, dump trace on fatal signals.
+        DOCKER_ENV_FLAGS+=(--env "PYTHONUNBUFFERED=1" --env "PYTHONFAULTHANDLER=1")
         DOCKER_ENV_FLAGS+=(--env "DYNAMO_TEST_FRAMEWORK=${{ inputs.framework }}")
         DOCKER_ENV_FLAGS+=(--env "DYNAMO_TEST_PLATFORM=${{ inputs.platform_arch }}")
         DOCKER_ENV_FLAGS+=(--env "DYNAMO_TEST_TYPE=${{ inputs.test_type }}")

--- a/.github/actions/pytest/action.yml
+++ b/.github/actions/pytest/action.yml
@@ -265,6 +265,7 @@ runs:
           DOCKER_ENV_FLAGS+=(--env "HF_TOKEN=${HF_TOKEN}")
         fi
         # TEMP DIAGNOSTIC (revert before merge): force live stdout, dump trace on fatal signals.
+        DOCKER_ENV_FLAGS+=(--env "HF_HUB_ENABLE_HF_TRANSFER=1")
         DOCKER_ENV_FLAGS+=(--env "PYTHONUNBUFFERED=1" --env "PYTHONFAULTHANDLER=1")
         DOCKER_ENV_FLAGS+=(--env "DYNAMO_TEST_FRAMEWORK=${{ inputs.framework }}")
         DOCKER_ENV_FLAGS+=(--env "DYNAMO_TEST_PLATFORM=${{ inputs.platform_arch }}")

--- a/.github/actions/pytest/action.yml
+++ b/.github/actions/pytest/action.yml
@@ -265,7 +265,7 @@ runs:
           DOCKER_ENV_FLAGS+=(--env "HF_TOKEN=${HF_TOKEN}")
         fi
         # TEMP DIAGNOSTIC (revert before merge): force live stdout, dump trace on fatal signals.
-        DOCKER_ENV_FLAGS+=(--env "HF_HUB_ENABLE_HF_TRANSFER=1")
+        DOCKER_ENV_FLAGS+=(--env "HF_XET_HIGH_PERFORMANCE=1")
         DOCKER_ENV_FLAGS+=(--env "PYTHONUNBUFFERED=1" --env "PYTHONFAULTHANDLER=1")
         DOCKER_ENV_FLAGS+=(--env "DYNAMO_TEST_FRAMEWORK=${{ inputs.framework }}")
         DOCKER_ENV_FLAGS+=(--env "DYNAMO_TEST_PLATFORM=${{ inputs.platform_arch }}")

--- a/.github/actions/pytest/action.yml
+++ b/.github/actions/pytest/action.yml
@@ -157,8 +157,6 @@ runs:
         if [[ -n "${HF_TOKEN:-}" ]]; then
           DOCKER_ENV_FLAGS+=(--env "HF_TOKEN=${HF_TOKEN}")
         fi
-        # TEMP DIAGNOSTIC (revert before merge): force live stdout, dump trace on fatal signals.
-        DOCKER_ENV_FLAGS+=(--env "PYTHONUNBUFFERED=1" --env "PYTHONFAULTHANDLER=1")
         DOCKER_ENV_FLAGS+=(--env "DYNAMO_TEST_FRAMEWORK=${{ inputs.framework }}")
         DOCKER_ENV_FLAGS+=(--env "DYNAMO_TEST_PLATFORM=${{ inputs.platform_arch }}")
         DOCKER_ENV_FLAGS+=(--env "DYNAMO_TEST_TYPE=${{ inputs.test_type }}")
@@ -248,10 +246,7 @@ runs:
 
           # Construct final command with xdist parallelization (-n) and other options
           # --dist=loadscope groups tests by module/class to prevent race conditions in stateful tests
-          # TEMP DIAGNOSTIC (revert before merge): -vv -s, live log streaming with
-          # millisecond timestamps so we can see how long each fixture / download takes.
-          # Tracking sglang gpu_1 cuda13 step that goes silent for 30 min.
-          PYTEST_CMD="pytest ${PARALLEL_OPTS} --dist=loadscope --continue-on-collection-errors -vv -s --tb=long --showlocals --log-cli-level=INFO --log-cli-format='%(asctime)s.%(msecs)03d [%(levelname)s] %(name)s: %(message)s' --log-cli-date-format='%H:%M:%S' --basetemp=/tmp/pytest_temp -o cache_dir=/tmp/.pytest_cache --junitxml=/workspace/test-results/${{ env.PYTEST_XML_FILE }} --alluredir=/workspace/test-results/allure-results --durations=10 -m \"${{ inputs.pytest_marks }}\""
+          PYTEST_CMD="pytest ${PARALLEL_OPTS} --dist=loadscope --continue-on-collection-errors -v --tb=short --basetemp=/tmp/pytest_temp -o cache_dir=/tmp/.pytest_cache --junitxml=/workspace/test-results/${{ env.PYTEST_XML_FILE }} --alluredir=/workspace/test-results/allure-results --durations=10 -m \"${{ inputs.pytest_marks }}\""
         fi
 
         # Get absolute path for test-results directory and ensure it has proper permissions
@@ -264,9 +259,7 @@ runs:
         if [[ -n "${HF_TOKEN:-}" ]]; then
           DOCKER_ENV_FLAGS+=(--env "HF_TOKEN=${HF_TOKEN}")
         fi
-        # TEMP DIAGNOSTIC (revert before merge): force live stdout, dump trace on fatal signals.
         DOCKER_ENV_FLAGS+=(--env "HF_XET_HIGH_PERFORMANCE=1")
-        DOCKER_ENV_FLAGS+=(--env "PYTHONUNBUFFERED=1" --env "PYTHONFAULTHANDLER=1")
         DOCKER_ENV_FLAGS+=(--env "DYNAMO_TEST_FRAMEWORK=${{ inputs.framework }}")
         DOCKER_ENV_FLAGS+=(--env "DYNAMO_TEST_PLATFORM=${{ inputs.platform_arch }}")
         DOCKER_ENV_FLAGS+=(--env "DYNAMO_TEST_TYPE=${{ inputs.test_type }}")

--- a/container/deps/requirements.test.txt
+++ b/container/deps/requirements.test.txt
@@ -3,8 +3,6 @@
 
 # Test-only dependencies — installed in test and dev containers, NOT in runtime.
 
-# For faster model downloads
-hf-xet
 # For deploy/utils async file IO used by deploy tests and profiler deployment helpers
 aiofiles<=25.1.0
 # For Allure test reporting in CI
@@ -16,6 +14,8 @@ coverage[toml]==7.13.1
 # For IFEval dataset loading in kvbm tests
 datasets==4.4.1
 filelock==3.25.1
+# For faster model downloads
+hf-xet
 # For Kubernetes operations in deploy tests
 kr8s==0.20.13
 kubernetes_asyncio==32.0.0

--- a/container/deps/requirements.test.txt
+++ b/container/deps/requirements.test.txt
@@ -4,7 +4,7 @@
 # Test-only dependencies — installed in test and dev containers, NOT in runtime.
 
 # For faster model downloads
-hf_transfer
+hf-xet
 # For deploy/utils async file IO used by deploy tests and profiler deployment helpers
 aiofiles<=25.1.0
 # For Allure test reporting in CI

--- a/container/deps/requirements.test.txt
+++ b/container/deps/requirements.test.txt
@@ -3,6 +3,8 @@
 
 # Test-only dependencies — installed in test and dev containers, NOT in runtime.
 
+# For faster model downloads
+hf_transfer
 # For deploy/utils async file IO used by deploy tests and profiler deployment helpers
 aiofiles<=25.1.0
 # For Allure test reporting in CI

--- a/tests/serve/test_sglang.py
+++ b/tests/serve/test_sglang.py
@@ -472,6 +472,7 @@ sglang_configs = {
             pytest.mark.profiled_vram_gib(19.3),
             pytest.mark.timeout(240),
             pytest.mark.pre_merge,
+            pytest.mark.skip, # Model size issues in CI, long download times leading to timeouts
         ],
         model="Tongyi-MAI/Z-Image-Turbo",
         env={},
@@ -511,6 +512,7 @@ sglang_configs = {
             pytest.mark.profiled_vram_gib(17.6),
             pytest.mark.timeout(180),
             pytest.mark.pre_merge,
+            pytest.mark.skip, # Model size issues in CI, long download times leading to timeouts
         ],
         model="Wan-AI/Wan2.1-T2V-1.3B-Diffusers",
         env={},

--- a/tests/serve/test_sglang.py
+++ b/tests/serve/test_sglang.py
@@ -365,7 +365,7 @@ sglang_configs = {
             pytest.mark.gpu_1,
             pytest.mark.profiled_vram_gib(13.3),  # same as multimodal_e_pd_qwen
             pytest.mark.timeout(360),
-            pytest.mark.pre_merge,
+            pytest.mark.post_merge,
         ],
         model="Qwen/Qwen2-VL-7B-Instruct",
         script_args=[

--- a/tests/serve/test_sglang.py
+++ b/tests/serve/test_sglang.py
@@ -471,8 +471,7 @@ sglang_configs = {
             pytest.mark.gpu_1,
             pytest.mark.profiled_vram_gib(19.3),
             pytest.mark.timeout(240),
-            pytest.mark.pre_merge,
-            pytest.mark.skip, # Model size issues in CI, long download times leading to timeouts
+            pytest.mark.nightly,
         ],
         model="Tongyi-MAI/Z-Image-Turbo",
         env={},
@@ -511,8 +510,7 @@ sglang_configs = {
             pytest.mark.gpu_1,
             pytest.mark.profiled_vram_gib(17.6),
             pytest.mark.timeout(180),
-            pytest.mark.pre_merge,
-            pytest.mark.skip, # Model size issues in CI, long download times leading to timeouts
+            pytest.mark.nightly,
         ],
         model="Wan-AI/Wan2.1-T2V-1.3B-Diffusers",
         env={},

--- a/tests/serve/test_vllm_omni.py
+++ b/tests/serve/test_vllm_omni.py
@@ -138,7 +138,7 @@ vllm_omni_configs = {
         ],
         marks=[
             pytest.mark.gpu_1,
-            pytest.mark.pre_merge,
+            pytest.mark.post_merge,
             pytest.mark.timeout(1200),
         ],
         model="Wan-AI/Wan2.2-TI2V-5B-Diffusers",


### PR DESCRIPTION
#### Overview:

Disabling tests using some large models recently as it slows down CI with large downloads.

Models were added recently with: 8679faa35d

<img width="794" height="434" alt="image" src="https://github.com/user-attachments/assets/be6a59b3-a6bd-4ff8-a400-0917f3bcf911" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled two diffusion-related test configurations in the test suite to resolve CI resource constraints and timeout issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->