### PR TITLE
fix(operator): availability-gated rolling update scale-down

### DIFF
--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -1140,7 +1140,10 @@ func (r *DynamoGraphDeploymentReconciler) reconcileDynamoComponentsDeployments(c
 
 	defaultIngressSpec := dynamo.GenerateDefaultIngressSpec(dynamoDeployment, r.Config.Ingress)
 
-	rollingUpdateCtx := r.buildRollingUpdateContext(ctx, dynamoDeployment)
+	rollingUpdateCtx, err := r.buildRollingUpdateContext(ctx, dynamoDeployment)
+	if err != nil {
+		return ReconcileResult{}, fmt.Errorf("failed to build rolling update context: %w", err)
+	}
 
 	existingRestartAnnotations, err := r.getExistingRestartAnnotationsDCD(ctx, dynamoDeployment)
 	if err != nil {

--- a/deploy/operator/internal/controller/dynamographdeployment_rollingupdate.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_rollingupdate.go
@@ -794,7 +794,7 @@ func resolveRollingUpdateParams(annotations map[string]string, desiredReplicas i
 func (r *DynamoGraphDeploymentReconciler) buildRollingUpdateContext(
 	ctx context.Context,
 	dgd *nvidiacomv1alpha1.DynamoGraphDeployment,
-) dynamo.RollingUpdateContext {
+) (dynamo.RollingUpdateContext, error) {
 	logger := log.FromContext(ctx)
 
 	newWorkerHash := dynamo.ComputeDGDWorkersSpecHash(dgd)
@@ -805,13 +805,12 @@ func (r *DynamoGraphDeploymentReconciler) buildRollingUpdateContext(
 			NewWorkerHash:     newWorkerHash,
 			OldWorkerReplicas: make(map[string]int32),
 			NewWorkerReplicas: make(map[string]int32),
-		}
+		}, nil
 	}
 
 	oldStates, err := r.getOldWorkerServiceStates(ctx, dgd, newWorkerHash)
 	if err != nil {
-		logger.Error(err, "Failed to get old worker service states, falling back to empty")
-		oldStates = make(map[string]dcdServiceState)
+		return dynamo.RollingUpdateContext{}, fmt.Errorf("failed to get old worker service states: %w", err)
 	}
 
 	oldWorkerReplicas := make(map[string]int32)
@@ -835,18 +834,21 @@ func (r *DynamoGraphDeploymentReconciler) buildRollingUpdateContext(
 		newDCD := &nvidiacomv1alpha1.DynamoComponentDeployment{}
 		if err := r.Get(ctx, types.NamespacedName{Name: newDCDName, Namespace: dgd.Namespace}, newDCD); err == nil {
 			newState = dcdServiceStateFromDCD(newDCD)
+		} else if !apierrors.IsNotFound(err) {
+			return dynamo.RollingUpdateContext{}, fmt.Errorf("failed to get new worker DCD %s: %w", newDCDName, err)
 		}
 
 		oldState := oldStates[serviceName]
 
-		// Old target: shared budget for scale-down, allocated to unhealthy cleanup then healthy drain.
 		newUnavailable := max(int32(0), newState.spec-newState.available)
+		// maxScaledDown is the maximum number of old replicas that can be scaled down
 		maxScaledDown := max(int32(0), (oldState.spec+newState.spec)-minAvailable-newUnavailable)
 		oldUnhealthy := max(int32(0), oldState.spec-oldState.available)
+		// availableSurplus is how many extra available replicas we have above minAvailable (min 0)
 		availableSurplus := max(int32(0), (oldState.available+newState.available)-minAvailable)
 		oldTarget := max(int32(0), oldState.spec-min(maxScaledDown, oldUnhealthy+availableSurplus))
 
-		// New target: surge-gated using actual pod counts (includes Terminating pods holding resources).
+		// scaleUpBudget is how many extra replicas we can scale up, based on actual pod counts
 		scaleUpBudget := max(int32(0), desired+maxSurge-oldState.actual-newState.actual)
 		newTarget := min(desired, newState.spec+scaleUpBudget)
 
@@ -869,7 +871,7 @@ func (r *DynamoGraphDeploymentReconciler) buildRollingUpdateContext(
 		NewWorkerHash:     newWorkerHash,
 		OldWorkerReplicas: oldWorkerReplicas,
 		NewWorkerReplicas: newWorkerReplicas,
-	}
+	}, nil
 }
 
 // mergeWorkerServiceStatuses merges old worker service statuses into the existing service statuses.

--- a/deploy/operator/internal/controller/dynamographdeployment_rollingupdate.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_rollingupdate.go
@@ -405,6 +405,28 @@ func (r *DynamoGraphDeploymentReconciler) completeRollingUpdate(
 	return nil
 }
 
+// dcdServiceState holds replica signals extracted from a DCD's Spec and Status.
+type dcdServiceState struct {
+	spec      int32 // Spec.Replicas (requested)
+	available int32 // Status.Service.AvailableReplicas (serving traffic)
+	actual    int32 // Status.Service.Replicas (actual pods, includes Terminating)
+}
+
+// dcdServiceStateFromDCD extracts replica signals from a single DCD.
+func dcdServiceStateFromDCD(dcd *nvidiacomv1alpha1.DynamoComponentDeployment) dcdServiceState {
+	s := dcdServiceState{}
+	if dcd.Spec.Replicas != nil {
+		s.spec = *dcd.Spec.Replicas
+	}
+	if dcd.Status.Service != nil {
+		s.actual = dcd.Status.Service.Replicas
+		if dcd.Status.Service.AvailableReplicas != nil {
+			s.available = *dcd.Status.Service.AvailableReplicas
+		}
+	}
+	return s
+}
+
 // workerServiceInfo holds ready replica count for a worker service.
 type workerServiceInfo struct {
 	readyReplicas int32
@@ -507,6 +529,30 @@ func (r *DynamoGraphDeploymentReconciler) getOldWorkerInfo(
 	}
 
 	return status, nil
+}
+
+// getOldWorkerServiceStates returns per-service old DCD state aggregated across all old generations.
+func (r *DynamoGraphDeploymentReconciler) getOldWorkerServiceStates(
+	ctx context.Context,
+	dgd *nvidiacomv1alpha1.DynamoGraphDeployment,
+	newWorkerHash string,
+) (map[string]dcdServiceState, error) {
+	oldDCDs, err := r.listOldWorkerDCDs(ctx, dgd, newWorkerHash)
+	if err != nil {
+		return nil, err
+	}
+
+	states := make(map[string]dcdServiceState)
+	for i := range oldDCDs {
+		s := dcdServiceStateFromDCD(&oldDCDs[i])
+		agg := states[oldDCDs[i].Spec.ServiceName]
+		agg.spec += s.spec
+		agg.available += s.available
+		agg.actual += s.actual
+		states[oldDCDs[i].Spec.ServiceName] = agg
+	}
+
+	return states, nil
 }
 
 // getDesiredWorkerReplicas returns the total desired replicas across all worker services.
@@ -745,18 +791,12 @@ func resolveRollingUpdateParams(annotations map[string]string, desiredReplicas i
 }
 
 // buildRollingUpdateContext creates a RollingUpdateContext.
-// It computes namespaces and pre-calculates old and new worker replica counts.
-//
-// Replica calculation:
-//   - oldReplicas = max(0, desiredReplicas - newReadyReplicas - maxUnavailable)
-//   - newReplicas = min(desiredReplicas, desiredReplicas + maxSurge - oldReplicas)
 func (r *DynamoGraphDeploymentReconciler) buildRollingUpdateContext(
 	ctx context.Context,
 	dgd *nvidiacomv1alpha1.DynamoGraphDeployment,
 ) dynamo.RollingUpdateContext {
 	logger := log.FromContext(ctx)
 
-	// Compute hashes
 	newWorkerHash := dynamo.ComputeDGDWorkersSpecHash(dgd)
 	prevWorkerHash := r.getCurrentWorkerHash(dgd)
 
@@ -768,7 +808,12 @@ func (r *DynamoGraphDeploymentReconciler) buildRollingUpdateContext(
 		}
 	}
 
-	// Pre-calculate old and new worker replicas based on new worker readiness
+	oldStates, err := r.getOldWorkerServiceStates(ctx, dgd, newWorkerHash)
+	if err != nil {
+		logger.Error(err, "Failed to get old worker service states, falling back to empty")
+		oldStates = make(map[string]dcdServiceState)
+	}
+
 	oldWorkerReplicas := make(map[string]int32)
 	newWorkerReplicas := make(map[string]int32)
 
@@ -777,52 +822,47 @@ func (r *DynamoGraphDeploymentReconciler) buildRollingUpdateContext(
 			continue
 		}
 
-		// Get desired replicas from spec
-		desiredReplicas := int32(1)
+		desired := int32(1)
 		if spec.Replicas != nil {
-			desiredReplicas = *spec.Replicas
+			desired = *spec.Replicas
 		}
 
-		maxSurge, maxUnavailable := resolveRollingUpdateParams(spec.Annotations, desiredReplicas)
+		maxSurge, maxUnavailable := resolveRollingUpdateParams(spec.Annotations, desired)
+		minAvailable := desired - maxUnavailable
 
-		// Query new DCD to get ready replicas (using hash-based naming)
+		var newState dcdServiceState
 		newDCDName := dynamo.GetDCDResourceName(dgd, serviceName, newWorkerHash)
 		newDCD := &nvidiacomv1alpha1.DynamoComponentDeployment{}
-		err := r.Get(ctx, types.NamespacedName{Name: newDCDName, Namespace: dgd.Namespace}, newDCD)
-
-		newReadyReplicas := int32(0)
-		if err == nil && newDCD.Status.Service != nil && newDCD.Status.Service.ReadyReplicas != nil {
-			newReadyReplicas = *newDCD.Status.Service.ReadyReplicas
+		if err := r.Get(ctx, types.NamespacedName{Name: newDCDName, Namespace: dgd.Namespace}, newDCD); err == nil {
+			newState = dcdServiceStateFromDCD(newDCD)
 		}
 
-		// Calculate old replicas: allow scaling down by maxUnavailable
-		// oldReplicas = max(0, desiredReplicas - newReadyReplicas - maxUnavailable)
-		oldNeeded := desiredReplicas - newReadyReplicas - maxUnavailable
-		if oldNeeded < 0 {
-			oldNeeded = 0
-		}
+		oldState := oldStates[serviceName]
 
-		// Calculate new replicas: stay within surge budget
-		// newReplicas = min(desiredReplicas, desiredReplicas + maxSurge - oldNeeded)
-		newNeeded := desiredReplicas + maxSurge - oldNeeded
-		if newNeeded > desiredReplicas {
-			newNeeded = desiredReplicas
-		}
-		if newNeeded < 0 {
-			newNeeded = 0
-		}
+		// Old target: shared budget for scale-down, allocated to unhealthy cleanup then healthy drain.
+		newUnavailable := max(int32(0), newState.spec-newState.available)
+		maxScaledDown := max(int32(0), (oldState.spec+newState.spec)-minAvailable-newUnavailable)
+		oldUnhealthy := max(int32(0), oldState.spec-oldState.available)
+		availableSurplus := max(int32(0), (oldState.available+newState.available)-minAvailable)
+		oldTarget := max(int32(0), oldState.spec-min(maxScaledDown, oldUnhealthy+availableSurplus))
 
-		newWorkerReplicas[serviceName] = newNeeded
-		oldWorkerReplicas[serviceName] = oldNeeded
+		// New target: surge-gated using actual pod counts (includes Terminating pods holding resources).
+		scaleUpBudget := max(int32(0), desired+maxSurge-oldState.actual-newState.actual)
+		newTarget := min(desired, newState.spec+scaleUpBudget)
 
-		logger.V(1).Info("Calculated worker replicas for rollingUpdate",
+		oldWorkerReplicas[serviceName] = oldTarget
+		newWorkerReplicas[serviceName] = newTarget
+
+		logger.V(1).Info("Rolling update replica calculation",
 			"service", serviceName,
-			"desired", desiredReplicas,
-			"newReady", newReadyReplicas,
+			"desired", desired,
 			"maxSurge", maxSurge,
 			"maxUnavailable", maxUnavailable,
-			"newNeeded", newNeeded,
-			"oldNeeded", oldNeeded)
+			"minAvailable", minAvailable,
+			"old", oldState,
+			"new", newState,
+			"oldTarget", oldTarget,
+			"newTarget", newTarget)
 	}
 
 	return dynamo.RollingUpdateContext{

--- a/deploy/operator/internal/controller/dynamographdeployment_rollingupdate.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_rollingupdate.go
@@ -407,21 +407,21 @@ func (r *DynamoGraphDeploymentReconciler) completeRollingUpdate(
 
 // dcdServiceState holds replica signals extracted from a DCD's Spec and Status.
 type dcdServiceState struct {
-	spec      int32 // Spec.Replicas (requested)
-	available int32 // Status.Service.AvailableReplicas (serving traffic)
-	actual    int32 // Status.Service.Replicas (actual pods, includes Terminating)
+	Spec      int32 `json:"spec"`      // DCD Spec.Replicas (declared intent)
+	Available int32 `json:"available"` // Status.Service.AvailableReplicas (serving traffic)
+	Actual    int32 `json:"actual"`    // Status.Service.Replicas (non-terminated pods, excludes Terminating)
 }
 
 // dcdServiceStateFromDCD extracts replica signals from a single DCD.
 func dcdServiceStateFromDCD(dcd *nvidiacomv1alpha1.DynamoComponentDeployment) dcdServiceState {
 	s := dcdServiceState{}
 	if dcd.Spec.Replicas != nil {
-		s.spec = *dcd.Spec.Replicas
+		s.Spec = *dcd.Spec.Replicas
 	}
 	if dcd.Status.Service != nil {
-		s.actual = dcd.Status.Service.Replicas
+		s.Actual = dcd.Status.Service.Replicas
 		if dcd.Status.Service.AvailableReplicas != nil {
-			s.available = *dcd.Status.Service.AvailableReplicas
+			s.Available = *dcd.Status.Service.AvailableReplicas
 		}
 	}
 	return s
@@ -546,9 +546,9 @@ func (r *DynamoGraphDeploymentReconciler) getOldWorkerServiceStates(
 	for i := range oldDCDs {
 		s := dcdServiceStateFromDCD(&oldDCDs[i])
 		agg := states[oldDCDs[i].Spec.ServiceName]
-		agg.spec += s.spec
-		agg.available += s.available
-		agg.actual += s.actual
+		agg.Spec += s.Spec
+		agg.Available += s.Available
+		agg.Actual += s.Actual
 		states[oldDCDs[i].Spec.ServiceName] = agg
 	}
 
@@ -840,17 +840,17 @@ func (r *DynamoGraphDeploymentReconciler) buildRollingUpdateContext(
 
 		oldState := oldStates[serviceName]
 
-		newUnavailable := max(int32(0), newState.spec-newState.available)
+		newUnavailable := max(int32(0), newState.Spec-newState.Available)
 		// maxScaledDown is the maximum number of old replicas that can be scaled down
-		maxScaledDown := max(int32(0), (oldState.spec+newState.spec)-minAvailable-newUnavailable)
-		oldUnhealthy := max(int32(0), oldState.spec-oldState.available)
+		maxScaledDown := max(int32(0), (oldState.Spec+newState.Spec)-minAvailable-newUnavailable)
+		oldUnhealthy := max(int32(0), oldState.Spec-oldState.Available)
 		// availableSurplus is how many extra available replicas we have above minAvailable (min 0)
-		availableSurplus := max(int32(0), (oldState.available+newState.available)-minAvailable)
-		oldTarget := max(int32(0), oldState.spec-min(maxScaledDown, oldUnhealthy+availableSurplus))
+		availableSurplus := max(int32(0), (oldState.Available+newState.Available)-minAvailable)
+		oldTarget := max(int32(0), oldState.Spec-min(maxScaledDown, oldUnhealthy+availableSurplus))
 
-		// scaleUpBudget is how many extra replicas we can scale up, based on actual pod counts
-		scaleUpBudget := max(int32(0), desired+maxSurge-oldState.actual-newState.actual)
-		newTarget := min(desired, newState.spec+scaleUpBudget)
+		// Surge budget uses Spec (declared intent) like K8s Deployment controller; scheduler enforces actual resource constraints.
+		scaleUpBudget := max(int32(0), desired+maxSurge-oldState.Spec-newState.Spec)
+		newTarget := min(desired, newState.Spec+scaleUpBudget)
 
 		oldWorkerReplicas[serviceName] = oldTarget
 		newWorkerReplicas[serviceName] = newTarget

--- a/deploy/operator/internal/controller/dynamographdeployment_rollingupdate_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_rollingupdate_test.go
@@ -2807,9 +2807,10 @@ func TestBuildRollingUpdateContext(t *testing.T) {
 			expectedNew: map[string]int32{"worker": 0}, // can't surge yet, need to wait for old replicas to be terminated
 		},
 		{
-			name: "old actual is greater than spec - should surge 1",
+			name: "surge budget uses spec not actual",
 			// desired=10, maxSurge=0, maxUnavailable=2
 			// old: spec=8, available=8, actual=9 | new: spec=0, available=0, actual=0
+			// Surge budget = 10+0-oldSpec(8)-newSpec(0) = 2 (actual is irrelevant for surge)
 			services: map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
 				"worker": {
 					ComponentType: consts.ComponentTypeWorker,
@@ -2826,8 +2827,8 @@ func TestBuildRollingUpdateContext(t *testing.T) {
 				}
 			},
 			newDCDs:     func(_ string) []runtime.Object { return nil },
-			expectedOld: map[string]int32{"worker": 8}, // total available is 8
-			expectedNew: map[string]int32{"worker": 1}, // only surge 1 as old actual is 9
+			expectedOld: map[string]int32{"worker": 8},
+			expectedNew: map[string]int32{"worker": 2}, // budget from Spec: 10+0-8-0=2
 		},
 		{
 			name: "old fleet degraded - should protect healthy old pods",
@@ -2873,10 +2874,12 @@ func TestBuildRollingUpdateContext(t *testing.T) {
 			expectedNew: map[string]int32{"worker": 3},
 		},
 		{
-			name: "terminating pods throttle new scale-up",
+			name: "terminating pods - surge uses spec, scheduler enforces resources",
 			// desired=10, maxSurge=3, maxUnavailable=2
 			// old: spec=5, available=5, actual=8 (3 Terminating, still holding GPUs)
 			// new: spec=5, available=5, actual=5
+			// Surge budget uses Spec: 10+3-5-5=3, newTarget=min(10,5+3)=8
+			// Scheduler prevents new pods from scheduling until GPUs are freed.
 			services: map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
 				"worker": {
 					ComponentType: consts.ComponentTypeWorker,
@@ -2894,7 +2897,7 @@ func TestBuildRollingUpdateContext(t *testing.T) {
 				}
 			},
 			expectedOld: map[string]int32{"worker": 3},
-			expectedNew: map[string]int32{"worker": 5},
+			expectedNew: map[string]int32{"worker": 8},
 		},
 		{
 			name: "multi-service independence - prefill done, decode mid-rollout",

--- a/deploy/operator/internal/controller/dynamographdeployment_rollingupdate_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_rollingupdate_test.go
@@ -60,30 +60,6 @@ func createTestDGD(name string, services map[string]*nvidiacomv1alpha1.DynamoCom
 	}
 }
 
-// createTestReconciler creates a DynamoGraphDeploymentReconciler for testing
-func createTestReconciler(objs ...runtime.Object) *DynamoGraphDeploymentReconciler {
-	scheme := runtime.NewScheme()
-	_ = nvidiacomv1alpha1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
-
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithRuntimeObjects(objs...).
-		Build()
-
-	return &DynamoGraphDeploymentReconciler{
-		Client:        fakeClient,
-		Recorder:      record.NewFakeRecorder(10),
-		Config:        &configv1alpha1.OperatorConfiguration{},
-		RuntimeConfig: &commonController.RuntimeConfig{},
-		DockerSecretRetriever: &mockDockerSecretRetriever{
-			GetSecretsFunc: func(namespace, imageName string) ([]string, error) {
-				return []string{}, nil
-			},
-		},
-	}
-}
-
 type testReconcilerOption func(*fake.ClientBuilder)
 
 // withObjects seeds the fake client with additional runtime objects beyond the DGD.
@@ -94,15 +70,13 @@ func withObjects(objs ...runtime.Object) testReconcilerOption {
 }
 
 // withInterceptor routes all client method calls through the supplied
-// interceptor.Funcs, letting tests inject API errors on specific code paths
+// interceptor.Funcs, letting tests inject API errors on specific code paths.
 func withInterceptor(funcs interceptor.Funcs) testReconcilerOption {
 	return func(b *fake.ClientBuilder) {
 		b.WithInterceptorFuncs(funcs)
 	}
 }
 
-// createTestReconcilerWithStatus builds a reconciler whose fake client supports
-// the DGD status subresource
 func createTestReconcilerWithStatus(dgd *nvidiacomv1alpha1.DynamoGraphDeployment, opts ...testReconcilerOption) *DynamoGraphDeploymentReconciler {
 	scheme := runtime.NewScheme()
 	_ = nvidiacomv1alpha1.AddToScheme(scheme)
@@ -117,8 +91,15 @@ func createTestReconcilerWithStatus(dgd *nvidiacomv1alpha1.DynamoGraphDeployment
 	}
 
 	return &DynamoGraphDeploymentReconciler{
-		Client:   builder.Build(),
-		Recorder: record.NewFakeRecorder(10),
+		Client:        builder.Build(),
+		Recorder:      record.NewFakeRecorder(10),
+		Config:        &configv1alpha1.OperatorConfiguration{},
+		RuntimeConfig: &commonController.RuntimeConfig{},
+		DockerSecretRetriever: &mockDockerSecretRetriever{
+			GetSecretsFunc: func(namespace, imageName string) ([]string, error) {
+				return []string{}, nil
+			},
+		},
 	}
 }
 
@@ -190,7 +171,7 @@ func TestShouldTriggerRollingUpdate(t *testing.T) {
 				dgd.Annotations = map[string]string{consts.AnnotationCurrentWorkerHash: tt.existingHash}
 			}
 
-			r := createTestReconciler(dgd)
+			r := createTestReconcilerWithStatus(dgd)
 			result := r.shouldTriggerRollingUpdate(dgd)
 
 			if result != tt.expected {
@@ -211,7 +192,7 @@ func TestInitializeWorkerHashIfNeeded_FirstDeploy(t *testing.T) {
 	})
 
 	// Create reconciler with DGD already in the fake client (simulates existing resource)
-	r := createTestReconciler(dgd)
+	r := createTestReconcilerWithStatus(dgd)
 	ctx := context.Background()
 
 	// Initialize the hash
@@ -242,7 +223,7 @@ func TestInitializeWorkerHashIfNeeded_AlreadyInitialized(t *testing.T) {
 	}
 
 	// Create reconciler with DGD already in the fake client
-	r := createTestReconciler(dgd)
+	r := createTestReconcilerWithStatus(dgd)
 	ctx := context.Background()
 
 	// Initialize should be a no-op
@@ -282,7 +263,7 @@ func TestSupportsManagedRollingUpdate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dgd := createTestDGD("test-dgd", tt.services)
-			r := createTestReconciler(dgd)
+			r := createTestReconcilerWithStatus(dgd)
 
 			result := r.supportsManagedRollingUpdate(dgd)
 			if result != tt.expected {
@@ -379,7 +360,7 @@ func TestGetOrCreateRollingUpdateStatus(t *testing.T) {
 			})
 			dgd.Status.RollingUpdate = tt.existingStatus
 
-			r := createTestReconciler(dgd)
+			r := createTestReconcilerWithStatus(dgd)
 			status := r.getOrCreateRollingUpdateStatus(dgd)
 
 			assert.NotNil(t, status)
@@ -428,7 +409,7 @@ func TestIsRollingUpdateInProgress(t *testing.T) {
 			})
 			dgd.Status.RollingUpdate = tt.status
 
-			r := createTestReconciler(dgd)
+			r := createTestReconcilerWithStatus(dgd)
 			result := r.isRollingUpdateInProgress(dgd)
 
 			assert.Equal(t, tt.expected, result)
@@ -499,7 +480,7 @@ func TestGetDesiredWorkerReplicas(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dgd := createTestDGD("test-dgd", tt.services)
-			r := createTestReconciler(dgd)
+			r := createTestReconcilerWithStatus(dgd)
 
 			result := r.getDesiredWorkerReplicas(dgd)
 			assert.Equal(t, tt.expected, result)
@@ -548,7 +529,7 @@ func TestDeleteOldWorkerDCDs(t *testing.T) {
 		},
 	}
 
-	r := createTestReconciler(dgd, oldDCD1, newDCD)
+	r := createTestReconcilerWithStatus(dgd, withObjects(oldDCD1, newDCD))
 	ctx := context.Background()
 
 	// Delete old worker DCDs
@@ -570,7 +551,7 @@ func TestDeleteOldWorkerDCDs_NoDCDsToDelete(t *testing.T) {
 		"worker": {ComponentType: consts.ComponentTypeWorker},
 	})
 
-	r := createTestReconciler(dgd)
+	r := createTestReconcilerWithStatus(dgd)
 	ctx := context.Background()
 
 	// Delete old worker DCDs when there are none - should not error
@@ -970,7 +951,7 @@ func TestGetWorkerInfoForWorkerHash(t *testing.T) {
 		},
 	}
 
-	r := createTestReconciler(dgd, prefillDCD, decodeDCD)
+	r := createTestReconcilerWithStatus(dgd, withObjects(prefillDCD, decodeDCD))
 	ctx := context.Background()
 
 	status, err := r.getWorkerInfoForWorkerHash(ctx, dgd, workerHash)
@@ -1176,7 +1157,7 @@ func TestAggregateOldWorkerServiceStatuses(t *testing.T) {
 			},
 		}
 
-		r := createTestReconciler(dgd, oldDCD)
+		r := createTestReconcilerWithStatus(dgd, withObjects(oldDCD))
 		ctx := context.Background()
 
 		rollingUpdateCtx := dynamo.RollingUpdateContext{
@@ -1203,7 +1184,7 @@ func TestAggregateOldWorkerServiceStatuses(t *testing.T) {
 			},
 		})
 
-		r := createTestReconciler(dgd)
+		r := createTestReconcilerWithStatus(dgd)
 		ctx := context.Background()
 
 		rollingUpdateCtx := dynamo.RollingUpdateContext{
@@ -1263,7 +1244,7 @@ func TestGetExistingRestartAnnotationsDCD(t *testing.T) {
 			},
 		}
 
-		r := createTestReconciler(dgd, frontendDCD, workerDCD)
+		r := createTestReconcilerWithStatus(dgd, withObjects(frontendDCD, workerDCD))
 		ctx := context.Background()
 
 		annotations, err := r.getExistingRestartAnnotationsDCD(ctx, dgd)
@@ -1300,7 +1281,7 @@ func TestGetExistingRestartAnnotationsDCD(t *testing.T) {
 			},
 		}
 
-		r := createTestReconciler(dgd, frontendDCD)
+		r := createTestReconcilerWithStatus(dgd, withObjects(frontendDCD))
 		ctx := context.Background()
 
 		annotations, err := r.getExistingRestartAnnotationsDCD(ctx, dgd)
@@ -1335,7 +1316,7 @@ func TestGetExistingRestartAnnotationsDCD(t *testing.T) {
 			},
 		}
 
-		r := createTestReconciler(dgd, frontendDCD)
+		r := createTestReconcilerWithStatus(dgd, withObjects(frontendDCD))
 		ctx := context.Background()
 
 		annotations, err := r.getExistingRestartAnnotationsDCD(ctx, dgd)
@@ -1374,7 +1355,7 @@ func TestCheckComponentServiceFullyUpdated(t *testing.T) {
 			},
 		}
 
-		r := createTestReconciler(dgd, workerDCD)
+		r := createTestReconcilerWithStatus(dgd, withObjects(workerDCD))
 		ctx := context.Background()
 
 		isReady, reason := r.checkComponentServiceFullyUpdated(ctx, dgd, "worker")
@@ -1406,7 +1387,7 @@ func TestCheckComponentServiceFullyUpdated(t *testing.T) {
 			},
 		}
 
-		r := createTestReconciler(dgd, frontendDCD)
+		r := createTestReconcilerWithStatus(dgd, withObjects(frontendDCD))
 		ctx := context.Background()
 
 		isReady, reason := r.checkComponentServiceFullyUpdated(ctx, dgd, "frontend")
@@ -1439,7 +1420,7 @@ func TestCheckComponentServiceFullyUpdated(t *testing.T) {
 			},
 		}
 
-		r := createTestReconciler(dgd, workerDCD)
+		r := createTestReconcilerWithStatus(dgd, withObjects(workerDCD))
 		ctx := context.Background()
 
 		isReady, reason := r.checkComponentServiceFullyUpdated(ctx, dgd, "worker")
@@ -1475,7 +1456,7 @@ func TestInitializeWorkerHashIfNeeded_LegacyDCDsMigration(t *testing.T) {
 		},
 	}
 
-	r := createTestReconciler(dgd, legacyWorkerDCD)
+	r := createTestReconcilerWithStatus(dgd, withObjects(legacyWorkerDCD))
 	ctx := context.Background()
 
 	err := r.initializeWorkerHashIfNeeded(ctx, dgd)
@@ -1556,7 +1537,7 @@ func TestInitializeWorkerHashIfNeeded_LegacyMultipleWorkers(t *testing.T) {
 		},
 	}
 
-	r := createTestReconciler(dgd, legacyPrefillDCD, legacyDecodeDCD, frontendDCD)
+	r := createTestReconcilerWithStatus(dgd, withObjects(legacyPrefillDCD, legacyDecodeDCD, frontendDCD))
 	ctx := context.Background()
 
 	err := r.initializeWorkerHashIfNeeded(ctx, dgd)
@@ -1603,7 +1584,7 @@ func TestFindLegacyWorkerDCDs(t *testing.T) {
 			},
 		}
 
-		r := createTestReconciler(dgd, legacyDCD)
+		r := createTestReconcilerWithStatus(dgd, withObjects(legacyDCD))
 		ctx := context.Background()
 
 		result, err := r.findLegacyWorkerDCDs(ctx, dgd)
@@ -1632,7 +1613,7 @@ func TestFindLegacyWorkerDCDs(t *testing.T) {
 			},
 		}
 
-		r := createTestReconciler(dgd, frontendDCD)
+		r := createTestReconcilerWithStatus(dgd, withObjects(frontendDCD))
 		ctx := context.Background()
 
 		result, err := r.findLegacyWorkerDCDs(ctx, dgd)
@@ -1661,7 +1642,7 @@ func TestFindLegacyWorkerDCDs(t *testing.T) {
 			},
 		}
 
-		r := createTestReconciler(dgd, hashedDCD)
+		r := createTestReconcilerWithStatus(dgd, withObjects(hashedDCD))
 		ctx := context.Background()
 
 		result, err := r.findLegacyWorkerDCDs(ctx, dgd)
@@ -1689,7 +1670,7 @@ func TestFindLegacyWorkerDCDs(t *testing.T) {
 			},
 		}
 
-		r := createTestReconciler(dgd, otherDGDWorkerDCD)
+		r := createTestReconcilerWithStatus(dgd, withObjects(otherDGDWorkerDCD))
 		ctx := context.Background()
 
 		result, err := r.findLegacyWorkerDCDs(ctx, dgd)
@@ -1702,7 +1683,7 @@ func TestFindLegacyWorkerDCDs(t *testing.T) {
 			"worker": {ComponentType: consts.ComponentTypeWorker},
 		})
 
-		r := createTestReconciler(dgd)
+		r := createTestReconcilerWithStatus(dgd)
 		ctx := context.Background()
 
 		result, err := r.findLegacyWorkerDCDs(ctx, dgd)
@@ -1735,7 +1716,7 @@ func TestListOldWorkerDCDs(t *testing.T) {
 			},
 		}
 
-		r := createTestReconciler(dgd, legacyDCD)
+		r := createTestReconcilerWithStatus(dgd, withObjects(legacyDCD))
 		ctx := context.Background()
 
 		result, err := r.listOldWorkerDCDs(ctx, dgd, "newhash1")
@@ -1766,7 +1747,7 @@ func TestListOldWorkerDCDs(t *testing.T) {
 			},
 		}
 
-		r := createTestReconciler(dgd, currentDCD)
+		r := createTestReconcilerWithStatus(dgd, withObjects(currentDCD))
 		ctx := context.Background()
 
 		result, err := r.listOldWorkerDCDs(ctx, dgd, "abc12345")
@@ -1815,7 +1796,7 @@ func TestListOldWorkerDCDs(t *testing.T) {
 			},
 		}
 
-		r := createTestReconciler(dgd, frontendDCD, workerDCD)
+		r := createTestReconcilerWithStatus(dgd, withObjects(frontendDCD, workerDCD))
 		ctx := context.Background()
 
 		result, err := r.listOldWorkerDCDs(ctx, dgd, testNewWorkerHash)
@@ -1853,7 +1834,7 @@ func TestScaleOldWorkerDCDs_LegacyDCDs(t *testing.T) {
 			},
 		}
 
-		r := createTestReconciler(dgd, legacyDCD)
+		r := createTestReconcilerWithStatus(dgd, withObjects(legacyDCD))
 		ctx := context.Background()
 
 		rollingUpdateCtx := dynamo.RollingUpdateContext{
@@ -1877,7 +1858,7 @@ func TestScaleOldWorkerDCDs_LegacyDCDs(t *testing.T) {
 			"worker": {ComponentType: consts.ComponentTypeWorker},
 		})
 
-		r := createTestReconciler(dgd)
+		r := createTestReconcilerWithStatus(dgd)
 		ctx := context.Background()
 
 		// Empty OldWorkerReplicas = not in progress
@@ -1917,7 +1898,7 @@ func TestScaleOldWorkerDCDs_LegacyDCDs(t *testing.T) {
 			},
 		}
 
-		r := createTestReconciler(dgd, legacyDCD)
+		r := createTestReconcilerWithStatus(dgd, withObjects(legacyDCD))
 		ctx := context.Background()
 
 		rollingUpdateCtx := dynamo.RollingUpdateContext{
@@ -1973,7 +1954,7 @@ func TestAggregateOldWorkerServiceStatuses_LegacyDCDs(t *testing.T) {
 			},
 		}
 
-		r := createTestReconciler(dgd, legacyDCD)
+		r := createTestReconcilerWithStatus(dgd, withObjects(legacyDCD))
 		ctx := context.Background()
 
 		rollingUpdateCtx := dynamo.RollingUpdateContext{
@@ -1999,7 +1980,7 @@ func TestAggregateOldWorkerServiceStatuses_LegacyDCDs(t *testing.T) {
 			},
 		})
 
-		r := createTestReconciler(dgd)
+		r := createTestReconcilerWithStatus(dgd)
 		ctx := context.Background()
 
 		rollingUpdateCtx := dynamo.RollingUpdateContext{
@@ -2053,7 +2034,7 @@ func TestDeleteOldWorkerDCDs_LegacyDCDs(t *testing.T) {
 		},
 	}
 
-	r := createTestReconciler(dgd, legacyDCD, newDCD)
+	r := createTestReconcilerWithStatus(dgd, withObjects(legacyDCD, newDCD))
 	ctx := context.Background()
 
 	err := r.deleteOldWorkerDCDs(ctx, dgd, "abc12345")
@@ -2124,7 +2105,7 @@ func TestDeleteOldWorkerDCDs_MultipleGenerations(t *testing.T) {
 		},
 	}
 
-	r := createTestReconciler(dgd, legacyDCD, genBDCD, currentDCD)
+	r := createTestReconcilerWithStatus(dgd, withObjects(legacyDCD, genBDCD, currentDCD))
 	ctx := context.Background()
 
 	err := r.deleteOldWorkerDCDs(ctx, dgd, "hashcccc")
@@ -2198,7 +2179,7 @@ func TestListOldWorkerDCDs_ExcludesCurrentHash(t *testing.T) {
 		},
 	}
 
-	r := createTestReconciler(dgd, genADCD, genBDCD, genCDCD)
+	r := createTestReconcilerWithStatus(dgd, withObjects(genADCD, genBDCD, genCDCD))
 	ctx := context.Background()
 
 	result, err := r.listOldWorkerDCDs(ctx, dgd, "hashcccc")
@@ -2261,7 +2242,7 @@ func TestScaleOldWorkerDCDs_MultipleOldGenerations(t *testing.T) {
 		},
 	}
 
-	r := createTestReconciler(dgd, genADCD, genBDCD)
+	r := createTestReconcilerWithStatus(dgd, withObjects(genADCD, genBDCD))
 	ctx := context.Background()
 
 	// oldNeeded = 2: newest old (B) should get 2, oldest (A) should get 0
@@ -2349,7 +2330,7 @@ func TestAggregateOldWorkerServiceStatuses_MultipleOldGenerations(t *testing.T) 
 		},
 	}
 
-	r := createTestReconciler(dgd, genADCD, genBDCD)
+	r := createTestReconcilerWithStatus(dgd, withObjects(genADCD, genBDCD))
 	ctx := context.Background()
 
 	rollingUpdateCtx := dynamo.RollingUpdateContext{

--- a/deploy/operator/internal/controller/dynamographdeployment_rollingupdate_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_rollingupdate_test.go
@@ -19,6 +19,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"sort"
 	"testing"
 
@@ -30,7 +31,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
 	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
@@ -78,6 +81,44 @@ func createTestReconciler(objs ...runtime.Object) *DynamoGraphDeploymentReconcil
 				return []string{}, nil
 			},
 		},
+	}
+}
+
+type testReconcilerOption func(*fake.ClientBuilder)
+
+// withObjects seeds the fake client with additional runtime objects beyond the DGD.
+func withObjects(objs ...runtime.Object) testReconcilerOption {
+	return func(b *fake.ClientBuilder) {
+		b.WithRuntimeObjects(objs...)
+	}
+}
+
+// withInterceptor routes all client method calls through the supplied
+// interceptor.Funcs, letting tests inject API errors on specific code paths
+func withInterceptor(funcs interceptor.Funcs) testReconcilerOption {
+	return func(b *fake.ClientBuilder) {
+		b.WithInterceptorFuncs(funcs)
+	}
+}
+
+// createTestReconcilerWithStatus builds a reconciler whose fake client supports
+// the DGD status subresource
+func createTestReconcilerWithStatus(dgd *nvidiacomv1alpha1.DynamoGraphDeployment, opts ...testReconcilerOption) *DynamoGraphDeploymentReconciler {
+	scheme := runtime.NewScheme()
+	_ = nvidiacomv1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	builder := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(dgd).
+		WithStatusSubresource(&nvidiacomv1alpha1.DynamoGraphDeployment{})
+	for _, opt := range opts {
+		opt(builder)
+	}
+
+	return &DynamoGraphDeploymentReconciler{
+		Client:   builder.Build(),
+		Recorder: record.NewFakeRecorder(10),
 	}
 }
 
@@ -537,26 +578,6 @@ func TestDeleteOldWorkerDCDs_NoDCDsToDelete(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// createTestReconcilerWithStatus creates a reconciler with status subresource support.
-func createTestReconcilerWithStatus(dgd *nvidiacomv1alpha1.DynamoGraphDeployment, objs ...runtime.Object) *DynamoGraphDeploymentReconciler {
-	scheme := runtime.NewScheme()
-	_ = nvidiacomv1alpha1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
-
-	allObjs := append([]runtime.Object{dgd}, objs...)
-
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithRuntimeObjects(allObjs...).
-		WithStatusSubresource(&nvidiacomv1alpha1.DynamoGraphDeployment{}).
-		Build()
-
-	return &DynamoGraphDeploymentReconciler{
-		Client:   fakeClient,
-		Recorder: record.NewFakeRecorder(10),
-	}
-}
-
 func TestContinueRollingUpdate_UpdatedServicesPartialCompletion(t *testing.T) {
 	oldWorkerHash := testOldWorkerHash
 	newWorkerHash := testNewWorkerHash
@@ -649,7 +670,7 @@ func TestContinueRollingUpdate_UpdatedServicesPartialCompletion(t *testing.T) {
 		},
 	}
 
-	r := createTestReconcilerWithStatus(dgd, newPrefillDCD, newDecodeDCD, oldDecodeDCD)
+	r := createTestReconcilerWithStatus(dgd, withObjects(newPrefillDCD, newDecodeDCD, oldDecodeDCD))
 	ctx := context.Background()
 
 	rollingUpdateStatus := dgd.Status.RollingUpdate
@@ -733,7 +754,7 @@ func TestContinueRollingUpdate_AggregateReadyButPerServiceNot(t *testing.T) {
 	}
 
 	// No old DCDs — old workers are fully scaled down
-	r := createTestReconcilerWithStatus(dgd, newPrefillDCD, newDecodeDCD)
+	r := createTestReconcilerWithStatus(dgd, withObjects(newPrefillDCD, newDecodeDCD))
 	ctx := context.Background()
 
 	rollingUpdateStatus := r.getOrCreateRollingUpdateStatus(dgd)
@@ -881,7 +902,7 @@ func TestContinueRollingUpdate_AllServicesUpdated(t *testing.T) {
 
 	// No old DCDs (all scaled down and removed)
 
-	r := createTestReconcilerWithStatus(dgd, newPrefillDCD, newDecodeDCD)
+	r := createTestReconcilerWithStatus(dgd, withObjects(newPrefillDCD, newDecodeDCD))
 	ctx := context.Background()
 
 	err := r.continueRollingUpdate(ctx, dgd, newWorkerHash)
@@ -2438,7 +2459,7 @@ func TestContinueRollingUpdate_CascadingSpecChange(t *testing.T) {
 		},
 	}
 
-	r := createTestReconcilerWithStatus(dgd, genADCD, genBDCD, genCDCD)
+	r := createTestReconcilerWithStatus(dgd, withObjects(genADCD, genBDCD, genCDCD))
 	ctx := context.Background()
 
 	err := r.continueRollingUpdate(ctx, dgd, newWorkerHash)
@@ -2662,7 +2683,7 @@ func TestReconcileRollingUpdate_NewRollingUpdate(t *testing.T) {
 		},
 	}
 
-	r := createTestReconcilerWithStatus(dgd, newDCD)
+	r := createTestReconcilerWithStatus(dgd, withObjects(newDCD))
 
 	// When computed hash != current hash and no DCDs exist with computed hash, start rollout.
 	err := r.reconcileRollingUpdate(context.Background(), dgd)
@@ -2718,14 +2739,17 @@ func TestReconcileRollingUpdate_StuckDetection_CompletesViaCompleteRollingUpdate
 }
 
 func TestBuildRollingUpdateContext(t *testing.T) {
-	makeOldDCD := func(dgdName, serviceName, componentType string, specReplicas, statusReplicas, availableReplicas int32) *nvidiacomv1alpha1.DynamoComponentDeployment {
+	makeOldDCD := func(dgdName, serviceName, componentType, workerHash string, specReplicas, statusReplicas, availableReplicas int32) *nvidiacomv1alpha1.DynamoComponentDeployment {
+		if workerHash == "" {
+			workerHash = testOldWorkerHash
+		}
 		return &nvidiacomv1alpha1.DynamoComponentDeployment{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      dgdName + "-" + serviceName + "-" + testOldWorkerHash[:8],
+				Name:      dgdName + "-" + serviceName + "-" + workerHash[:8],
 				Namespace: "default",
 				Labels: map[string]string{
 					consts.KubeLabelDynamoGraphDeploymentName: dgdName,
-					consts.KubeLabelDynamoWorkerHash:          testOldWorkerHash,
+					consts.KubeLabelDynamoWorkerHash:          workerHash,
 				},
 			},
 			Spec: nvidiacomv1alpha1.DynamoComponentDeploymentSpec{
@@ -2780,7 +2804,7 @@ func TestBuildRollingUpdateContext(t *testing.T) {
 	}{
 		{
 			name: "normal rollout start - all old healthy, no new pods yet",
-			// desired=10, maxSurge=0, maxUnavailable=2 (20%)
+			// desired=10, maxSurge=0, maxUnavailable=2
 			// old: spec=10, available=10, actual=10 | new: spec=0, available=0, actual=0
 			services: map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
 				"worker": {
@@ -2794,12 +2818,35 @@ func TestBuildRollingUpdateContext(t *testing.T) {
 			},
 			oldDCDs: func(_ string) []runtime.Object {
 				return []runtime.Object{
-					makeOldDCD("test-dgd", "worker", consts.ComponentTypeWorker, 10, 10, 10),
+					makeOldDCD("test-dgd", "worker", consts.ComponentTypeWorker, "", 10, 10, 10),
 				}
 			},
 			newDCDs:     func(_ string) []runtime.Object { return nil },
 			expectedOld: map[string]int32{"worker": 8},
-			expectedNew: map[string]int32{"worker": 0},
+			expectedNew: map[string]int32{"worker": 0}, // can't surge yet, need to wait for old replicas to be terminated
+		},
+		{
+			name: "old actual is greater than spec - should surge 1",
+			// desired=10, maxSurge=0, maxUnavailable=2
+			// old: spec=8, available=8, actual=9 | new: spec=0, available=0, actual=0
+			services: map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				"worker": {
+					ComponentType: consts.ComponentTypeWorker,
+					Replicas:      ptr.To(int32(10)),
+					Annotations: map[string]string{
+						KubeAnnotationDeploymentRollingUpdateMaxSurge:       "0",
+						KubeAnnotationDeploymentRollingUpdateMaxUnavailable: "2",
+					},
+				},
+			},
+			oldDCDs: func(_ string) []runtime.Object {
+				return []runtime.Object{
+					makeOldDCD("test-dgd", "worker", consts.ComponentTypeWorker, "", 8, 9, 8),
+				}
+			},
+			newDCDs:     func(_ string) []runtime.Object { return nil },
+			expectedOld: map[string]int32{"worker": 8}, // total available is 8
+			expectedNew: map[string]int32{"worker": 1}, // only surge 1 as old actual is 9
 		},
 		{
 			name: "old fleet degraded - should protect healthy old pods",
@@ -2814,7 +2861,7 @@ func TestBuildRollingUpdateContext(t *testing.T) {
 			},
 			oldDCDs: func(_ string) []runtime.Object {
 				return []runtime.Object{
-					makeOldDCD("test-dgd", "worker", consts.ComponentTypeWorker, 8, 8, 4),
+					makeOldDCD("test-dgd", "worker", consts.ComponentTypeWorker, "", 8, 8, 4),
 				}
 			},
 			newDCDs: func(newHash string) []runtime.Object {
@@ -2837,7 +2884,7 @@ func TestBuildRollingUpdateContext(t *testing.T) {
 			},
 			oldDCDs: func(_ string) []runtime.Object {
 				return []runtime.Object{
-					makeOldDCD("test-dgd", "worker", consts.ComponentTypeWorker, 10, 10, 6),
+					makeOldDCD("test-dgd", "worker", consts.ComponentTypeWorker, "", 10, 10, 6),
 				}
 			},
 			newDCDs:     func(_ string) []runtime.Object { return nil },
@@ -2857,7 +2904,7 @@ func TestBuildRollingUpdateContext(t *testing.T) {
 			},
 			oldDCDs: func(_ string) []runtime.Object {
 				return []runtime.Object{
-					makeOldDCD("test-dgd", "worker", consts.ComponentTypeWorker, 5, 8, 5),
+					makeOldDCD("test-dgd", "worker", consts.ComponentTypeWorker, "", 5, 8, 5),
 				}
 			},
 			newDCDs: func(newHash string) []runtime.Object {
@@ -2867,94 +2914,6 @@ func TestBuildRollingUpdateContext(t *testing.T) {
 			},
 			expectedOld: map[string]int32{"worker": 3},
 			expectedNew: map[string]int32{"worker": 5},
-		},
-		{
-			name: "maxSurge=0 bootstrapping - must drain old before scaling up new",
-			// desired=10, maxSurge=0, maxUnavailable=2
-			// old: spec=10, available=10, actual=10 | new: spec=0, available=0, actual=0
-			services: map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
-				"worker": {
-					ComponentType: consts.ComponentTypeWorker,
-					Replicas:      ptr.To(int32(10)),
-					Annotations: map[string]string{
-						KubeAnnotationDeploymentRollingUpdateMaxSurge:       "0",
-						KubeAnnotationDeploymentRollingUpdateMaxUnavailable: "20%",
-					},
-				},
-			},
-			oldDCDs: func(_ string) []runtime.Object {
-				return []runtime.Object{
-					makeOldDCD("test-dgd", "worker", consts.ComponentTypeWorker, 10, 10, 10),
-				}
-			},
-			newDCDs:     func(_ string) []runtime.Object { return nil },
-			expectedOld: map[string]int32{"worker": 8},
-			expectedNew: map[string]int32{"worker": 0},
-		},
-		{
-			name: "maxSurge=0 second reconcile - old drained and terminated, now scale up",
-			// desired=10, maxSurge=0, maxUnavailable=2
-			// old: spec=8, available=8, actual=8 | new: spec=0, available=0, actual=0
-			services: map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
-				"worker": {
-					ComponentType: consts.ComponentTypeWorker,
-					Replicas:      ptr.To(int32(10)),
-					Annotations: map[string]string{
-						KubeAnnotationDeploymentRollingUpdateMaxSurge:       "0",
-						KubeAnnotationDeploymentRollingUpdateMaxUnavailable: "20%",
-					},
-				},
-			},
-			oldDCDs: func(_ string) []runtime.Object {
-				return []runtime.Object{
-					makeOldDCD("test-dgd", "worker", consts.ComponentTypeWorker, 8, 8, 8),
-				}
-			},
-			newDCDs:     func(_ string) []runtime.Object { return nil },
-			expectedOld: map[string]int32{"worker": 8},
-			expectedNew: map[string]int32{"worker": 2},
-		},
-		{
-			name: "catastrophic wipe - old fleet destroyed, scale up new aggressively",
-			// desired=10, maxSurge=3, maxUnavailable=2
-			// old: spec=10, available=0, actual=0 (all wiped) | new: spec=0, available=0, actual=0
-			services: map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
-				"worker": {
-					ComponentType: consts.ComponentTypeWorker,
-					Replicas:      ptr.To(int32(10)),
-				},
-			},
-			oldDCDs: func(_ string) []runtime.Object {
-				return []runtime.Object{
-					makeOldDCD("test-dgd", "worker", consts.ComponentTypeWorker, 10, 0, 0),
-				}
-			},
-			newDCDs:     func(_ string) []runtime.Object { return nil },
-			expectedOld: map[string]int32{"worker": 8},
-			expectedNew: map[string]int32{"worker": 10},
-		},
-		{
-			name: "rollout complete - new fully ready, old drained",
-			// desired=10, maxSurge=3, maxUnavailable=2
-			// old: spec=0, available=0, actual=0 | new: spec=10, available=10, actual=10
-			services: map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
-				"worker": {
-					ComponentType: consts.ComponentTypeWorker,
-					Replicas:      ptr.To(int32(10)),
-				},
-			},
-			oldDCDs: func(_ string) []runtime.Object {
-				return []runtime.Object{
-					makeOldDCD("test-dgd", "worker", consts.ComponentTypeWorker, 0, 0, 0),
-				}
-			},
-			newDCDs: func(newHash string) []runtime.Object {
-				return []runtime.Object{
-					makeNewDCD("test-dgd", "worker", consts.ComponentTypeWorker, newHash, 10, 10, 10),
-				}
-			},
-			expectedOld: map[string]int32{"worker": 0},
-			expectedNew: map[string]int32{"worker": 10},
 		},
 		{
 			name: "multi-service independence - prefill done, decode mid-rollout",
@@ -2974,8 +2933,8 @@ func TestBuildRollingUpdateContext(t *testing.T) {
 			},
 			oldDCDs: func(_ string) []runtime.Object {
 				return []runtime.Object{
-					makeOldDCD("test-dgd", "prefill", consts.ComponentTypePrefill, 0, 0, 0),
-					makeOldDCD("test-dgd", "decode", consts.ComponentTypeDecode, 6, 6, 6),
+					makeOldDCD("test-dgd", "prefill", consts.ComponentTypePrefill, "", 0, 0, 0),
+					makeOldDCD("test-dgd", "decode", consts.ComponentTypeDecode, "", 6, 6, 6),
 				}
 			},
 			newDCDs: func(newHash string) []runtime.Object {
@@ -2986,6 +2945,53 @@ func TestBuildRollingUpdateContext(t *testing.T) {
 			},
 			expectedOld: map[string]int32{"prefill": 0, "decode": 6},
 			expectedNew: map[string]int32{"prefill": 4, "decode": 4},
+		},
+		{
+			name: "new pods unavailable - hold old until new becomes Ready",
+			// desired=10, maxSurge=3, maxUnavailable=2
+			// old: spec=10, available=6, actual=10 | new: spec=4, available=0, actual=4
+			services: map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				"worker": {
+					ComponentType: consts.ComponentTypeWorker,
+					Replicas:      ptr.To(int32(10)),
+				},
+			},
+			oldDCDs: func(_ string) []runtime.Object {
+				return []runtime.Object{
+					makeOldDCD("test-dgd", "worker", consts.ComponentTypeWorker, "", 10, 10, 6),
+				}
+			},
+			newDCDs: func(newHash string) []runtime.Object {
+				return []runtime.Object{
+					makeNewDCD("test-dgd", "worker", consts.ComponentTypeWorker, newHash, 4, 4, 0),
+				}
+			},
+			expectedOld: map[string]int32{"worker": 8}, // newUnavailable shrinks scale-down budget; hold unhealthy old
+			expectedNew: map[string]int32{"worker": 4}, // no surge: actual already at desired+maxSurge-1
+		},
+		{
+			name: "multiple old generations - aggregate state across hashes",
+			// desired=10, maxSurge=3, maxUnavailable=2
+			// old (2 gens, 4+4): spec=8, available=8, actual=8 | new: spec=2, available=2, actual=2
+			services: map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				"worker": {
+					ComponentType: consts.ComponentTypeWorker,
+					Replicas:      ptr.To(int32(10)),
+				},
+			},
+			oldDCDs: func(_ string) []runtime.Object {
+				return []runtime.Object{
+					makeOldDCD("test-dgd", "worker", consts.ComponentTypeWorker, "oldhash0", 4, 4, 4),
+					makeOldDCD("test-dgd", "worker", consts.ComponentTypeWorker, testOldWorkerHash, 4, 4, 4),
+				}
+			},
+			newDCDs: func(newHash string) []runtime.Object {
+				return []runtime.Object{
+					makeNewDCD("test-dgd", "worker", consts.ComponentTypeWorker, newHash, 2, 2, 2),
+				}
+			},
+			expectedOld: map[string]int32{"worker": 6}, // aggregated across both old gens
+			expectedNew: map[string]int32{"worker": 5},
 		},
 	}
 
@@ -3009,10 +3015,11 @@ func TestBuildRollingUpdateContext(t *testing.T) {
 				objs = append(objs, tt.newDCDs(newHash)...)
 			}
 
-			r := createTestReconcilerWithStatus(dgd, objs...)
+			r := createTestReconcilerWithStatus(dgd, withObjects(objs...))
 			ctx := context.Background()
 
-			result := r.buildRollingUpdateContext(ctx, dgd)
+			result, err := r.buildRollingUpdateContext(ctx, dgd)
+			assert.NoError(t, err)
 
 			assert.Equal(t, newHash, result.NewWorkerHash)
 			for svc, expectedOld := range tt.expectedOld {
@@ -3025,4 +3032,116 @@ func TestBuildRollingUpdateContext(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBuildRollingUpdateContext_NoNewDCDExists(t *testing.T) {
+	dgd := createTestDGD("test-dgd", map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+		"worker": {
+			ComponentType: consts.ComponentTypeWorker,
+			Replicas:      ptr.To(int32(10)),
+		},
+	})
+	dgd.Annotations = map[string]string{
+		consts.AnnotationCurrentWorkerHash: testOldWorkerHash,
+	}
+
+	oldDCD := &nvidiacomv1alpha1.DynamoComponentDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-dgd-worker-" + testOldWorkerHash[:8],
+			Namespace: "default",
+			Labels: map[string]string{
+				consts.KubeLabelDynamoGraphDeploymentName: "test-dgd",
+				consts.KubeLabelDynamoWorkerHash:          testOldWorkerHash,
+			},
+		},
+		Spec: nvidiacomv1alpha1.DynamoComponentDeploymentSpec{
+			DynamoComponentDeploymentSharedSpec: nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				ComponentType: consts.ComponentTypeWorker,
+				ServiceName:   "worker",
+				Replicas:      ptr.To(int32(10)),
+			},
+		},
+		Status: nvidiacomv1alpha1.DynamoComponentDeploymentStatus{
+			Service: &nvidiacomv1alpha1.ServiceReplicaStatus{
+				Replicas:          10,
+				AvailableReplicas: ptr.To(int32(10)),
+			},
+		},
+	}
+
+	newHash := dynamo.ComputeDGDWorkersSpecHash(dgd)
+	assert.NotEqual(t, testOldWorkerHash, newHash, "test setup: computed hash must differ from old hash")
+
+	r := createTestReconcilerWithStatus(dgd, withObjects(oldDCD))
+	ctx := context.Background()
+
+	result, err := r.buildRollingUpdateContext(ctx, dgd)
+
+	assert.NoError(t, err, "IsNotFound on the new-hash DCD must not produce an error")
+	assert.Equal(t, newHash, result.NewWorkerHash)
+	// Math runs with newState={0,0,0}: drain old to minAvailable, surge new from zero.
+	assert.Equal(t, int32(8), result.OldWorkerReplicas["worker"])
+	assert.Equal(t, int32(3), result.NewWorkerReplicas["worker"])
+}
+
+func TestBuildRollingUpdateContext_ListOldDCDsError(t *testing.T) {
+	dgd := createTestDGD("test-dgd", map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+		"worker": {
+			ComponentType: consts.ComponentTypeWorker,
+			Replicas:      ptr.To(int32(10)),
+		},
+	})
+	dgd.Annotations = map[string]string{
+		consts.AnnotationCurrentWorkerHash: testOldWorkerHash,
+	}
+
+	assert.NotEqual(t, testOldWorkerHash, dynamo.ComputeDGDWorkersSpecHash(dgd),
+		"test setup: computed hash must differ so we proceed past the early-return")
+
+	injectedErr := errors.New("simulated apiserver list failure")
+	funcs := interceptor.Funcs{
+		List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+			return injectedErr
+		},
+	}
+	r := createTestReconcilerWithStatus(dgd, withInterceptor(funcs))
+	ctx := context.Background()
+
+	_, err := r.buildRollingUpdateContext(ctx, dgd)
+
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, injectedErr, "List error must be wrapped and propagated, not swallowed")
+	assert.Contains(t, err.Error(), "failed to get old worker service states",
+		"error must originate from the old-DCD List path, not some other call")
+}
+
+func TestBuildRollingUpdateContext_GetNewDCDError(t *testing.T) {
+	dgd := createTestDGD("test-dgd", map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+		"worker": {
+			ComponentType: consts.ComponentTypeWorker,
+			Replicas:      ptr.To(int32(10)),
+		},
+	})
+	dgd.Annotations = map[string]string{
+		consts.AnnotationCurrentWorkerHash: testOldWorkerHash,
+	}
+
+	require.NotEqual(t, testOldWorkerHash, dynamo.ComputeDGDWorkersSpecHash(dgd),
+		"test setup: computed hash must differ so we proceed past the early-return")
+
+	injectedErr := errors.New("simulated apiserver get failure")
+	funcs := interceptor.Funcs{
+		Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+			return injectedErr
+		},
+	}
+	r := createTestReconcilerWithStatus(dgd, withInterceptor(funcs))
+	ctx := context.Background()
+
+	_, err := r.buildRollingUpdateContext(ctx, dgd)
+
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, injectedErr, "non-NotFound Get error must be wrapped and propagated")
+	assert.Contains(t, err.Error(), "failed to get new worker DCD",
+		"error must originate from the new-DCD Get path, not some other call")
 }

--- a/deploy/operator/internal/controller/dynamographdeployment_rollingupdate_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_rollingupdate_test.go
@@ -2716,3 +2716,313 @@ func TestReconcileRollingUpdate_StuckDetection_CompletesViaCompleteRollingUpdate
 	// Annotation should still have the correct hash
 	assert.Equal(t, hash, dgd.Annotations[consts.AnnotationCurrentWorkerHash])
 }
+
+func TestBuildRollingUpdateContext(t *testing.T) {
+	makeOldDCD := func(dgdName, serviceName, componentType string, specReplicas, statusReplicas, availableReplicas int32) *nvidiacomv1alpha1.DynamoComponentDeployment {
+		return &nvidiacomv1alpha1.DynamoComponentDeployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      dgdName + "-" + serviceName + "-" + testOldWorkerHash[:8],
+				Namespace: "default",
+				Labels: map[string]string{
+					consts.KubeLabelDynamoGraphDeploymentName: dgdName,
+					consts.KubeLabelDynamoWorkerHash:          testOldWorkerHash,
+				},
+			},
+			Spec: nvidiacomv1alpha1.DynamoComponentDeploymentSpec{
+				DynamoComponentDeploymentSharedSpec: nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+					ComponentType: componentType,
+					ServiceName:   serviceName,
+					Replicas:      ptr.To(specReplicas),
+				},
+			},
+			Status: nvidiacomv1alpha1.DynamoComponentDeploymentStatus{
+				Service: &nvidiacomv1alpha1.ServiceReplicaStatus{
+					Replicas:          statusReplicas,
+					AvailableReplicas: ptr.To(availableReplicas),
+				},
+			},
+		}
+	}
+
+	makeNewDCD := func(dgdName, serviceName, componentType, workerHash string, specReplicas, statusReplicas, availableReplicas int32) *nvidiacomv1alpha1.DynamoComponentDeployment {
+		return &nvidiacomv1alpha1.DynamoComponentDeployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      dgdName + "-" + serviceName + "-" + workerHash[:8],
+				Namespace: "default",
+				Labels: map[string]string{
+					consts.KubeLabelDynamoGraphDeploymentName: dgdName,
+					consts.KubeLabelDynamoWorkerHash:          workerHash,
+				},
+			},
+			Spec: nvidiacomv1alpha1.DynamoComponentDeploymentSpec{
+				DynamoComponentDeploymentSharedSpec: nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+					ComponentType: componentType,
+					ServiceName:   serviceName,
+					Replicas:      ptr.To(specReplicas),
+				},
+			},
+			Status: nvidiacomv1alpha1.DynamoComponentDeploymentStatus{
+				Service: &nvidiacomv1alpha1.ServiceReplicaStatus{
+					Replicas:          statusReplicas,
+					AvailableReplicas: ptr.To(availableReplicas),
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name        string
+		services    map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec
+		oldDCDs     func(newHash string) []runtime.Object
+		newDCDs     func(newHash string) []runtime.Object
+		expectedOld map[string]int32
+		expectedNew map[string]int32
+	}{
+		{
+			name: "normal rollout start - all old healthy, no new pods yet",
+			// desired=10, maxSurge=0, maxUnavailable=2 (20%)
+			// old: spec=10, available=10, actual=10 | new: spec=0, available=0, actual=0
+			services: map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				"worker": {
+					ComponentType: consts.ComponentTypeWorker,
+					Replicas:      ptr.To(int32(10)),
+					Annotations: map[string]string{
+						KubeAnnotationDeploymentRollingUpdateMaxSurge:       "0",
+						KubeAnnotationDeploymentRollingUpdateMaxUnavailable: "2",
+					},
+				},
+			},
+			oldDCDs: func(_ string) []runtime.Object {
+				return []runtime.Object{
+					makeOldDCD("test-dgd", "worker", consts.ComponentTypeWorker, 10, 10, 10),
+				}
+			},
+			newDCDs:     func(_ string) []runtime.Object { return nil },
+			expectedOld: map[string]int32{"worker": 8},
+			expectedNew: map[string]int32{"worker": 0},
+		},
+		{
+			name: "old fleet degraded - should protect healthy old pods",
+			// desired=10, maxSurge=3, maxUnavailable=2
+			// old: spec=8, available=4, actual=8 | new: spec=3, available=3, actual=3
+			services: map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				"worker": {
+					ComponentType: consts.ComponentTypeWorker,
+					Replicas:      ptr.To(int32(10)),
+					// Default annotations: 25% surge, 25% unavailable
+				},
+			},
+			oldDCDs: func(_ string) []runtime.Object {
+				return []runtime.Object{
+					makeOldDCD("test-dgd", "worker", consts.ComponentTypeWorker, 8, 8, 4),
+				}
+			},
+			newDCDs: func(newHash string) []runtime.Object {
+				return []runtime.Object{
+					makeNewDCD("test-dgd", "worker", consts.ComponentTypeWorker, newHash, 3, 3, 3),
+				}
+			},
+			expectedOld: map[string]int32{"worker": 5},
+			expectedNew: map[string]int32{"worker": 5},
+		},
+		{
+			name: "some unhealthy old pods - cleanup frees resources",
+			// desired=10, maxSurge=3, maxUnavailable=2
+			// old: spec=10, available=6, actual=10 | new: spec=0, available=0, actual=0
+			services: map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				"worker": {
+					ComponentType: consts.ComponentTypeWorker,
+					Replicas:      ptr.To(int32(10)),
+				},
+			},
+			oldDCDs: func(_ string) []runtime.Object {
+				return []runtime.Object{
+					makeOldDCD("test-dgd", "worker", consts.ComponentTypeWorker, 10, 10, 6),
+				}
+			},
+			newDCDs:     func(_ string) []runtime.Object { return nil },
+			expectedOld: map[string]int32{"worker": 8},
+			expectedNew: map[string]int32{"worker": 3},
+		},
+		{
+			name: "terminating pods throttle new scale-up",
+			// desired=10, maxSurge=3, maxUnavailable=2
+			// old: spec=5, available=5, actual=8 (3 Terminating, still holding GPUs)
+			// new: spec=5, available=5, actual=5
+			services: map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				"worker": {
+					ComponentType: consts.ComponentTypeWorker,
+					Replicas:      ptr.To(int32(10)),
+				},
+			},
+			oldDCDs: func(_ string) []runtime.Object {
+				return []runtime.Object{
+					makeOldDCD("test-dgd", "worker", consts.ComponentTypeWorker, 5, 8, 5),
+				}
+			},
+			newDCDs: func(newHash string) []runtime.Object {
+				return []runtime.Object{
+					makeNewDCD("test-dgd", "worker", consts.ComponentTypeWorker, newHash, 5, 5, 5),
+				}
+			},
+			expectedOld: map[string]int32{"worker": 3},
+			expectedNew: map[string]int32{"worker": 5},
+		},
+		{
+			name: "maxSurge=0 bootstrapping - must drain old before scaling up new",
+			// desired=10, maxSurge=0, maxUnavailable=2
+			// old: spec=10, available=10, actual=10 | new: spec=0, available=0, actual=0
+			services: map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				"worker": {
+					ComponentType: consts.ComponentTypeWorker,
+					Replicas:      ptr.To(int32(10)),
+					Annotations: map[string]string{
+						KubeAnnotationDeploymentRollingUpdateMaxSurge:       "0",
+						KubeAnnotationDeploymentRollingUpdateMaxUnavailable: "20%",
+					},
+				},
+			},
+			oldDCDs: func(_ string) []runtime.Object {
+				return []runtime.Object{
+					makeOldDCD("test-dgd", "worker", consts.ComponentTypeWorker, 10, 10, 10),
+				}
+			},
+			newDCDs:     func(_ string) []runtime.Object { return nil },
+			expectedOld: map[string]int32{"worker": 8},
+			expectedNew: map[string]int32{"worker": 0},
+		},
+		{
+			name: "maxSurge=0 second reconcile - old drained and terminated, now scale up",
+			// desired=10, maxSurge=0, maxUnavailable=2
+			// old: spec=8, available=8, actual=8 | new: spec=0, available=0, actual=0
+			services: map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				"worker": {
+					ComponentType: consts.ComponentTypeWorker,
+					Replicas:      ptr.To(int32(10)),
+					Annotations: map[string]string{
+						KubeAnnotationDeploymentRollingUpdateMaxSurge:       "0",
+						KubeAnnotationDeploymentRollingUpdateMaxUnavailable: "20%",
+					},
+				},
+			},
+			oldDCDs: func(_ string) []runtime.Object {
+				return []runtime.Object{
+					makeOldDCD("test-dgd", "worker", consts.ComponentTypeWorker, 8, 8, 8),
+				}
+			},
+			newDCDs:     func(_ string) []runtime.Object { return nil },
+			expectedOld: map[string]int32{"worker": 8},
+			expectedNew: map[string]int32{"worker": 2},
+		},
+		{
+			name: "catastrophic wipe - old fleet destroyed, scale up new aggressively",
+			// desired=10, maxSurge=3, maxUnavailable=2
+			// old: spec=10, available=0, actual=0 (all wiped) | new: spec=0, available=0, actual=0
+			services: map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				"worker": {
+					ComponentType: consts.ComponentTypeWorker,
+					Replicas:      ptr.To(int32(10)),
+				},
+			},
+			oldDCDs: func(_ string) []runtime.Object {
+				return []runtime.Object{
+					makeOldDCD("test-dgd", "worker", consts.ComponentTypeWorker, 10, 0, 0),
+				}
+			},
+			newDCDs:     func(_ string) []runtime.Object { return nil },
+			expectedOld: map[string]int32{"worker": 8},
+			expectedNew: map[string]int32{"worker": 10},
+		},
+		{
+			name: "rollout complete - new fully ready, old drained",
+			// desired=10, maxSurge=3, maxUnavailable=2
+			// old: spec=0, available=0, actual=0 | new: spec=10, available=10, actual=10
+			services: map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				"worker": {
+					ComponentType: consts.ComponentTypeWorker,
+					Replicas:      ptr.To(int32(10)),
+				},
+			},
+			oldDCDs: func(_ string) []runtime.Object {
+				return []runtime.Object{
+					makeOldDCD("test-dgd", "worker", consts.ComponentTypeWorker, 0, 0, 0),
+				}
+			},
+			newDCDs: func(newHash string) []runtime.Object {
+				return []runtime.Object{
+					makeNewDCD("test-dgd", "worker", consts.ComponentTypeWorker, newHash, 10, 10, 10),
+				}
+			},
+			expectedOld: map[string]int32{"worker": 0},
+			expectedNew: map[string]int32{"worker": 10},
+		},
+		{
+			name: "multi-service independence - prefill done, decode mid-rollout",
+			// prefill: desired=4, maxSurge=1, maxUnavailable=1
+			//   old: spec=0, available=0, actual=0 | new: spec=4, available=4, actual=4
+			// decode: desired=8, maxSurge=2, maxUnavailable=2
+			//   old: spec=6, available=6, actual=6 | new: spec=2, available=0, actual=2
+			services: map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				"prefill": {
+					ComponentType: consts.ComponentTypePrefill,
+					Replicas:      ptr.To(int32(4)),
+				},
+				"decode": {
+					ComponentType: consts.ComponentTypeDecode,
+					Replicas:      ptr.To(int32(8)),
+				},
+			},
+			oldDCDs: func(_ string) []runtime.Object {
+				return []runtime.Object{
+					makeOldDCD("test-dgd", "prefill", consts.ComponentTypePrefill, 0, 0, 0),
+					makeOldDCD("test-dgd", "decode", consts.ComponentTypeDecode, 6, 6, 6),
+				}
+			},
+			newDCDs: func(newHash string) []runtime.Object {
+				return []runtime.Object{
+					makeNewDCD("test-dgd", "prefill", consts.ComponentTypePrefill, newHash, 4, 4, 4),
+					makeNewDCD("test-dgd", "decode", consts.ComponentTypeDecode, newHash, 2, 2, 0),
+				}
+			},
+			expectedOld: map[string]int32{"prefill": 0, "decode": 6},
+			expectedNew: map[string]int32{"prefill": 4, "decode": 4},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dgd := createTestDGD("test-dgd", tt.services)
+			dgd.Annotations = map[string]string{
+				consts.AnnotationCurrentWorkerHash: testOldWorkerHash,
+			}
+
+			// Compute the actual new hash from the DGD spec (same as buildRollingUpdateContext does)
+			newHash := dynamo.ComputeDGDWorkersSpecHash(dgd)
+			require.NotEqual(t, testOldWorkerHash, newHash, "test setup: computed hash must differ from old hash")
+
+			// Collect all mock objects
+			var objs []runtime.Object
+			if tt.oldDCDs != nil {
+				objs = append(objs, tt.oldDCDs(newHash)...)
+			}
+			if tt.newDCDs != nil {
+				objs = append(objs, tt.newDCDs(newHash)...)
+			}
+
+			r := createTestReconcilerWithStatus(dgd, objs...)
+			ctx := context.Background()
+
+			result := r.buildRollingUpdateContext(ctx, dgd)
+
+			assert.Equal(t, newHash, result.NewWorkerHash)
+			for svc, expectedOld := range tt.expectedOld {
+				assert.Equal(t, expectedOld, result.OldWorkerReplicas[svc],
+					"old replicas for service %s", svc)
+			}
+			for svc, expectedNew := range tt.expectedNew {
+				assert.Equal(t, expectedNew, result.NewWorkerReplicas[svc],
+					"new replicas for service %s", svc)
+			}
+		})
+	}
+}

--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -267,10 +267,8 @@ type RollingUpdateContext struct {
 	NewWorkerHash string
 	// OldWorkerReplicas maps service name to the desired replica count for old workers.
 	// Used by the controller to patch old worker DCDs directly.
-	// Calculated as: max(0, desiredReplicas - newReadyReplicas)
 	OldWorkerReplicas map[string]int32
 	// NewWorkerReplicas maps service name to the desired replica count for new workers.
-	// Calculated as: min(desiredReplicas, newReadyReplicas + 1) to gradually scale up.
 	NewWorkerReplicas map[string]int32
 }
 

--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -378,8 +378,8 @@ func generateSingleDCD(
 	}
 
 	// during a rolling update, the replica count is determined by the rollingUpdateCtx instead of the component spec
-	if rollingUpdateCtx.InProgress() && IsWorkerComponent(component.ComponentType) && rollingUpdateCtx.NewWorkerReplicas[componentName] != 0 {
-		deployment.Spec.Replicas = ptr.To(rollingUpdateCtx.NewWorkerReplicas[componentName])
+	if newReplicas, ok := rollingUpdateCtx.NewWorkerReplicas[componentName]; rollingUpdateCtx.InProgress() && IsWorkerComponent(component.ComponentType) && ok {
+		deployment.Spec.Replicas = ptr.To(newReplicas)
 	} else if component.Replicas != nil {
 		deployment.Spec.Replicas = component.Replicas
 	}

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -7395,6 +7395,34 @@ func TestGenerateSingleDCD_NoRollingUpdate(t *testing.T) {
 	assert.Equal(t, int32(3), *dcd.Spec.Replicas)
 }
 
+// TestGenerateSingleDCD_RollingUpdateZeroReplicas verifies that when
+// NewWorkerReplicas is explicitly 0 (maxSurge=0, first reconcile), the new DCD
+// is created with 0 replicas instead of falling through to the desired count.
+func TestGenerateSingleDCD_RollingUpdateZeroReplicas(t *testing.T) {
+	dgd := &v1alpha1.DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-dgd", Namespace: "ns"},
+		Spec: v1alpha1.DynamoGraphDeploymentSpec{
+			Services: map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{
+				"decode": {ComponentType: commonconsts.ComponentTypeDecode, Replicas: ptr.To(int32(4))},
+			},
+		},
+	}
+
+	ruCtx := RollingUpdateContext{
+		NewWorkerHash:     "aabb1122",
+		OldWorkerReplicas: map[string]int32{"decode": 3},
+		NewWorkerReplicas: map[string]int32{"decode": 0},
+	}
+
+	dcds, err := GenerateDynamoComponentsDeployments(context.Background(), dgd, nil, &RestartState{}, nil, ruCtx)
+	assert.NoError(t, err)
+
+	decodeDCD := dcds["decode"]
+	assert.Equal(t, "my-dgd-decode-aabb1122", decodeDCD.Name)
+	assert.Equal(t, int32(0), *decodeDCD.Spec.Replicas,
+		"new DCD must respect NewWorkerReplicas=0, not fall through to desired=4")
+}
+
 func TestGenerateComponentContext_WorkerHashSuffix(t *testing.T) {
 	// Worker with hash label gets WorkerHashSuffix
 	component := &v1alpha1.DynamoComponentDeploymentSharedSpec{


### PR DESCRIPTION
#### Overview:

Rewrites the rolling update replica calculation in `buildRollingUpdateContext()` to fix a bug observed during a disaggregated serving graph rollout (DEP-890):

- **Bug**: The old formula `oldNeeded = desired - newReady - maxUnavailable` trusted old pods blindly. When preemption wiped out old pods (recreated with 30-min startup probes), the operator didn't notice and kept rolling, breaching maxUnavailable by 5×.

The new logic mirrors the Kubernetes Deployment controller's approach: a shared scale-down budget allocated first to unhealthy cleanup then to availability-gated healthy drain, and surge-gating based on spec replicas.

#### Details:

- `internal/controller/dynamographdeployment_rollingupdate.go`:
  - Added `dcdServiceState` struct and `dcdServiceStateFromDCD()` helper to extract replica signals (spec, available, actual) from a DCD
  - Added `getOldWorkerServiceStates()` to aggregate old DCD state across multiple generations per service
  - Rewrote `buildRollingUpdateContext()` with the new formulas; now returns an error instead of silently falling back
- `internal/controller/dynamographdeployment_controller.go`: Updated call site to handle new error return
- `internal/controller/dynamographdeployment_rollingupdate_test.go`: Added `TestBuildRollingUpdateContext` (8 table-driven cases) plus 3 standalone error/edge-case tests
- `internal/dynamo/graph.go`: Removed stale doc comments on `RollingUpdateContext` fields

#### Where should the reviewer start?

The core logic change is in `buildRollingUpdateContext()` (lines 793-875 of `dynamographdeployment_rollingupdate.go`). The test table in `TestBuildRollingUpdateContext` documents each scenario with inline formula walkthroughs.

#### Related Issues:

- Closes DEP-894
- Relates to DEP-890
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8823" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during rolling updates to promptly report context building failures.
  * Enhanced replica target calculations to incorporate comprehensive deployment status signals during rolling operations.

* **Tests**
  * Expanded test coverage including error propagation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->