### PR TITLE
feat(recipes): add TensorRT-LLM aggregated recipe for DeepSeek-V4-Flash

### DIFF
--- a/recipes/deepseek-v4/deepseek-v4-flash/README.md
+++ b/recipes/deepseek-v4/deepseek-v4-flash/README.md
@@ -15,6 +15,36 @@ Aggregated-serving recipe for **DeepSeek-V4-Flash** on Dynamo. Three backends ar
 
 Status: **Experimental** (Day-0). Modality: text only.
 
+## What works today
+
+All three backends serve V4-Flash's core path on B200x4: chat completion (incl. streaming), tool calling, and reasoning extraction. The main differences are about **packaging maturity** (which container you can pull vs. build) and a couple of feature caveats.
+
+| Capability | vLLM (`vllm-agg`) | SGLang (`sglang-agg`) | TensorRT-LLM (`trtllm-agg`) |
+|---|:---:|:---:|:---:|
+| **Use a prebuilt image (no build)** | ❌ build it | ✅ pull it | ❌ build it |
+| Chat completion (sync + streaming) | ✅ | ✅ | ✅ |
+| Tool calling (`message.tool_calls`) | ✅ | ✅ | ✅ |
+| Reasoning extraction (`message.reasoning_content`) | ✅ | ✅ | ✅ |
+| Speculative decoding (EAGLE MTP) | — | ✅ | — |
+| KV-cache event publishing | ✅ | ✅ | ❌ not yet |
+
+**TL;DR.** Want it running with the least friction? Pick **SGLang** — the manifest pulls a prebuilt NGC image and works as-is. The **vLLM** and **TensorRT-LLM** variants both require a one-time custom container build until V4 support lands in their public images.
+
+### Known limitations per backend
+
+**TensorRT-LLM** (`trtllm-agg`):
+- 🔧 *Custom image required for now.* The public `tensorrtllm-runtime` image will bundle V4 once [TensorRT-LLM PR #13568](https://github.com/NVIDIA/TensorRT-LLM/pull/13568) lands (lifts `TOKENIZER_ALIASES` to module level).
+- 📌 *Snapshot SHA pinned in the YAML.* `--model-path` points at a specific HuggingFace snapshot directory — a workaround for [`huggingface/transformers#44843`](https://github.com/huggingface/transformers/issues/44843) (offline-mode regression in transformers 4.57.x). If HuggingFace publishes a new commit for `deepseek-ai/DeepSeek-V4-Flash`, update the SHA in `trtllm/agg/deploy.yaml` before applying. See the pre-flight check in [TensorRT-LLM-specific notes](#tensorrt-llm-specific).
+- ❌ *KV-cache event publishing not yet supported.* V4's sparse-MLA cache manager asserts the event buffer is off, so `--publish-events-and-metrics` is intentionally omitted from the worker args.
+
+**vLLM** (`vllm-agg`):
+- 🔧 *Custom image required for now.* Render and build the standard Dynamo vLLM runtime image — see [Prerequisites](#prerequisites) step 4.
+- 🐢 *First launch is slow (~60 min)* — weight load + FlashInfer autotune + cudagraph warmup. The startup probe is sized for this.
+
+**SGLang** (`sglang-agg`):
+- ✅ *No image build needed.* The manifest pulls `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-sglang-deepseek-v4-b200-dev.1` directly.
+- 🐢 *First launch is slow (~60 min)* — weight load + DeepGEMM warmup + cudagraph warmup. The startup probe is sized for this.
+
 ## Prerequisites
 
 1. **Dynamo Platform installed** — see the [Kubernetes Deployment Guide](../../../docs/kubernetes/README.md).
@@ -37,7 +67,7 @@ Status: **Experimental** (Day-0). Modality: text only.
 
 ## Quick Start
 
-Common setup (run once — applies to both variants):
+Common setup (run once — applies to all three variants):
 
 ```bash
 export NAMESPACE=dynamo-demo
@@ -194,7 +224,7 @@ Recipe-level (per-variant) settings:
 
 ## Verifying Reasoning
 
-Same flow on both variants — same model, same `--dyn-reasoning-parser deepseek_v4`:
+Same flow on all three variants — same model, same `--dyn-reasoning-parser deepseek_v4`:
 
 ```bash
 curl -s http://localhost:8000/v1/chat/completions \
@@ -216,7 +246,7 @@ If `reasoning_content` is `null` and `</think>` appears in `content`, the reason
 
 ## Verifying Tool Calling
 
-Same flow on both variants:
+Same flow on all three variants:
 
 ```bash
 curl -s http://localhost:8000/v1/chat/completions \

--- a/recipes/deepseek-v4/deepseek-v4-flash/README.md
+++ b/recipes/deepseek-v4/deepseek-v4-flash/README.md
@@ -5,12 +5,13 @@ SPDX-License-Identifier: Apache-2.0
 
 # DeepSeek-V4-Flash Recipe
 
-Aggregated-serving recipe for **DeepSeek-V4-Flash** on Dynamo. Two backends are documented side by side: **vLLM** and **SGLang**. Both are single-replica decode-only deployments that fill 4 of 8 GPUs on a B200 node.
+Aggregated-serving recipe for **DeepSeek-V4-Flash** on Dynamo. Three backends are documented side by side: **vLLM**, **SGLang**, and **TensorRT-LLM**. All are single-replica decode-only deployments that fill 4 of 8 GPUs on a B200 node.
 
 | Variant | Backend | Manifest | GPUs | Topology | Container |
 |---------|---------|----------|------|----------|-----------|
-| **vllm-agg**   | vLLM   | [`vllm/agg/deploy.yaml`](vllm/agg/deploy.yaml)     | 4x B200 | DP=4 + Expert Parallel, TP=1                   | Standard Dynamo vLLM runtime image |
-| **sglang-agg** | SGLang | [`sglang/agg/deploy.yaml`](sglang/agg/deploy.yaml) | 4x B200 | TP=4, MXFP4 MoE via FlashInfer, EAGLE MTP 3/4 | Prebuilt NGC image; optional [custom build](../container/) |
+| **vllm-agg**   | vLLM        | [`vllm/agg/deploy.yaml`](vllm/agg/deploy.yaml)     | 4x B200 | DP=4 + Expert Parallel, TP=1                  | Standard Dynamo vLLM runtime image |
+| **sglang-agg** | SGLang      | [`sglang/agg/deploy.yaml`](sglang/agg/deploy.yaml) | 4x B200 | TP=4, MXFP4 MoE via FlashInfer, EAGLE MTP 3/4 | Prebuilt NGC image; optional [custom build](../container/) |
+| **trtllm-agg** | TensorRT-LLM | [`trtllm/agg/deploy.yaml`](trtllm/agg/deploy.yaml) | 4x B200 | TP=4 + EP=4, Attention DP, MoE backend = TRTLLM | Custom Dynamo TRT-LLM runtime image (see Notes) |
 
 Status: **Experimental** (Day-0). Modality: text only.
 
@@ -31,6 +32,8 @@ Status: **Experimental** (Day-0). Modality: text only.
      ```
 
      Then set the `image:` fields in `vllm/agg/deploy.yaml` (both the Frontend and the decode worker) to your pushed image tag.
+
+   - **TensorRT-LLM** (`trtllm-agg`): Until the public `tensorrtllm-runtime` image bundles a TRT-LLM build that includes DeepSeek V4 support (TensorRT-LLM PR [#13568](https://github.com/NVIDIA/TensorRT-LLM/pull/13568) lifts `TOKENIZER_ALIASES` to module level; see also feat/mewtwo + MR 10189), this variant requires a custom build. The build pattern (TRT-LLM wheel + Dynamo runtime overlay) is captured in the working 04/27 build flow. Set the `image:` fields in `trtllm/agg/deploy.yaml` (both the Frontend and the decode worker) to your built image tag.
 
 ## Quick Start
 
@@ -81,6 +84,20 @@ kubectl wait --for=condition=Ready pod \
   -n ${NAMESPACE} --timeout=3600s
 ```
 
+### Deploy — TensorRT-LLM (`trtllm-agg`)
+
+```bash
+# Update the `image:` fields in trtllm/agg/deploy.yaml to your custom Dynamo
+# TRT-LLM runtime image (Prerequisite 4 — TensorRT-LLM path).
+kubectl apply -f trtllm/agg/deploy.yaml -n ${NAMESPACE}
+
+# First launch of the decode worker takes up to ~60 minutes (weight load +
+# CUDA graph warmup). The startup probe is sized for this.
+kubectl wait --for=condition=Ready pod \
+  -l nvidia.com/dynamo-graph-deployment-name=dsv4-flash-trtllm-agg \
+  -n ${NAMESPACE} --timeout=3600s
+```
+
 ## Test the Deployment
 
 Port-forward the variant you deployed:
@@ -91,6 +108,9 @@ kubectl port-forward svc/dsv4-flash-agg-frontend 8000:8000 -n ${NAMESPACE}
 
 # SGLang
 kubectl port-forward svc/sglang-dsv4-flash-frontend 8000:8000 -n ${NAMESPACE}
+
+# TensorRT-LLM
+kubectl port-forward svc/dsv4-flash-trtllm-agg-frontend 8000:8000 -n ${NAMESPACE}
 ```
 
 Either way the request shape is the same — same model name, same OpenAI-compatible endpoints:
@@ -133,6 +153,27 @@ curl http://localhost:8000/v1/chat/completions \
 | `--chunked-prefill-size 4096` | Chunk long prompts at 4k tokens for steady-state decode interleaving |
 | `--disable-flashinfer-autotune` | Skip per-shape autotuning at startup; the dsv4 base ships pre-tuned defaults |
 
+### TensorRT-LLM (`trtllm/agg/deploy.yaml`)
+
+| Flag | Purpose |
+|------|---------|
+| `--dyn-reasoning-parser deepseek_v4` | Extracts chain-of-thought into `message.reasoning_content` |
+| `--dyn-tool-call-parser deepseek_v4` | Emits OpenAI-compatible structured `tool_calls` |
+| `--tensor-parallel-size 4` + `--expert-parallel-size 4` | TP and EP across the 4 GPUs (TP must equal world_size) |
+| `--max-batch-size 4`, `--max-num-tokens 8192`, `--max-seq-len 2048` | Conservative request bounds for first-launch validation |
+| `--kv-block-size 128` | V4 requires `tokens_per_block` ∈ {128, 256}; matches the engine YAML |
+| `--extra-engine-args /config/engine.yaml` | Injects the V4 LlmArgs (`custom_tokenizer: deepseek_v4`, `enable_attention_dp: true`, `moe_config.backend: TRTLLM`, etc.) |
+
+`engine.yaml` (mounted from a ConfigMap at `/config`):
+
+| Key | Why |
+|---|---|
+| `custom_tokenizer: deepseek_v4` | Routes through the V4 tokenizer alias (TRT-LLM MR 10189), avoiding HF AutoTokenizer's offline-mode trap |
+| `enable_attention_dp: true` + `attention_dp_config` | Data-parallel attention across the 4 GPUs (per V4 serving recipe) |
+| `moe_config.backend: TRTLLM` | trtllm-gen MoE kernel (PYTORCH backend fails on Blackwell) |
+| `kv_cache_config.tokens_per_block: 128`, `free_gpu_memory_fraction: 0.3` | V4 KV-cache block size; conservative memory headroom for first launch |
+| `cuda_graph_config.enable_padding: true` | Pad to compiled batch sizes to reduce capture overhead |
+
 ## Model Details
 
 | | |
@@ -143,13 +184,13 @@ curl http://localhost:8000/v1/chat/completions \
 
 Recipe-level (per-variant) settings:
 
-| | vLLM (`vllm-agg`) | SGLang (`sglang-agg`) |
-|---|---|---|
-| **Backend image** | Standard Dynamo vLLM runtime | Prebuilt `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-sglang-deepseek-v4-b200-dev.1` |
-| **Parallelism** | DP=4 + Expert Parallel, TP=1 | TP=4 |
-| **MoE backend** | vLLM's V4 expert kernel (FP4) | FlashInfer MXFP4 |
-| **KV cache** | FP8, block size 256 | engine default |
-| **Speculative decoding** | — | EAGLE MTP (3 steps / 4 draft tokens) |
+| | vLLM (`vllm-agg`) | SGLang (`sglang-agg`) | TRT-LLM (`trtllm-agg`) |
+|---|---|---|---|
+| **Backend image** | Standard Dynamo vLLM runtime | Prebuilt `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-sglang-deepseek-v4-b200-dev.1` | Custom Dynamo TRT-LLM runtime (TRT-LLM wheel from feat/mewtwo + MR 10189) |
+| **Parallelism** | DP=4 + Expert Parallel, TP=1 | TP=4 | TP=4 + EP=4 with attention DP |
+| **MoE backend** | vLLM's V4 expert kernel (FP4) | FlashInfer MXFP4 | TRT-LLM (trtllm-gen kernel) |
+| **KV cache** | FP8, block size 256 | engine default | tokens_per_block=128, free_gpu_memory_fraction=0.3 |
+| **Speculative decoding** | — | EAGLE MTP (3 steps / 4 draft tokens) | — |
 
 ## Verifying Reasoning
 
@@ -230,6 +271,21 @@ If `tool_calls` is missing and raw tool-call markers appear in `content`, confir
 - **Prebuilt image.** `sglang/agg/deploy.yaml` already references the public NGC tag `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-sglang-deepseek-v4-b200-dev.1`. To rebuild (custom Dynamo branch, different SGLang base, etc.), see [`recipes/deepseek-v4/container/README.md`](../container/README.md).
 - **DeepGEMM / FlashInfer warmup.** `SGLANG_JIT_DEEPGEMM_PRECOMPILE=0` + `SGLANG_JIT_DEEPGEMM_FAST_WARMUP=1` skip the slow precompile and use the fast warmup path. `--disable-flashinfer-autotune` skips per-shape FlashInfer autotuning at startup; the dsv4 base ships pre-tuned defaults.
 - **NCCL / Gloo.** `NCCL_CUMEM_ENABLE=1` is set for V4 NCCL collectives on Blackwell. `GLOO_SOCKET_IFNAME=eth0` pins Gloo to the standard pod interface.
+
+### TensorRT-LLM-specific
+
+- **Image is custom for now.** No public `tensorrtllm-runtime` tag bundles V4 yet. Build a TRT-LLM wheel from `feat/mewtwo` plus MR 10189, layer onto the Dynamo TRT-LLM runtime, and push to your registry. Until [TensorRT-LLM PR #13568](https://github.com/NVIDIA/TensorRT-LLM/pull/13568) lands, the wheel also needs the `TOKENIZER_ALIASES` module-level fix applied as an in-place patch (or the equivalent cherry-pick).
+- **Local snapshot path for `--model-path`.** The deploy uses a local directory under `/models/hub/.../snapshots/<sha>` rather than the canonical `deepseek-ai/DeepSeek-V4-Flash` HF id. This bypasses [`huggingface/transformers#44843`](https://github.com/huggingface/transformers/issues/44843) — the `_patch_mistral_regex → is_base_mistral → model_info` path that ignores `HF_HUB_OFFLINE=1` in transformers 4.57.2/4.57.3. Once TRT-LLM bumps to a transformers release with the fix (PRs #43603 / #45444 / #45359), revert to the HF id. The OpenAI API contract is preserved either way because `--served-model-name` registers the canonical id with the frontend.
+- **Snapshot SHA pre-flight.** Before `kubectl apply`, verify the pinned SHA still matches `refs/main` in the cache:
+  ```bash
+  kubectl exec -n ${NAMESPACE} <download-job-pod> -- \
+    cat /model-store/hub/models--deepseek-ai--DeepSeek-V4-Flash/refs/main
+  ```
+  If HF has published a new commit, update the SHA in `trtllm/agg/deploy.yaml`.
+- **`--publish-events-and-metrics` is intentionally omitted.** V4's sparse-MLA `cache_manager.py` asserts `event_buffer_max_size == 0`; the flag would set it `> 0` and crash worker init. Re-enable once V4 KV-cache supports event publishing.
+- **Default request plane is TCP (no `--request-plane nats`).** Frontend defaults TCP; if the worker is set to NATS, chat completions fail with "Invalid TCP address …" because the frontend tries to parse the NATS subject as a TCP address.
+- **TP=4 + EP=4.** TP must equal `world_size` (= GPU count). The engine YAML's `enable_attention_dp: true` data-parallelizes attention across the 4 ranks for higher concurrency.
+- **Memory + UCX/MPI tuning** (`PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`, `UCX_TLS=tcp,self,sm,cma`, `UCX_NET_DEVICES=lo`, `OMPI_MCA_btl=self,vader,tcp`, `OMPI_MCA_pml=ob1`) matches the verified 04/27 single-node config. Adjust if your cluster's UCX/MPI setup differs.
 
 ## Sibling Recipe
 

--- a/recipes/deepseek-v4/deepseek-v4-flash/README.md
+++ b/recipes/deepseek-v4/deepseek-v4-flash/README.md
@@ -15,35 +15,6 @@ Aggregated-serving recipe for **DeepSeek-V4-Flash** on Dynamo. Three backends ar
 
 Status: **Experimental** (Day-0). Modality: text only.
 
-## What works today
-
-All three backends serve V4-Flash's core path on B200x4: chat completion (incl. streaming), tool calling, and reasoning extraction. The main differences are about **packaging maturity** (which container you can pull vs. build) and a couple of feature caveats.
-
-| Capability | vLLM (`vllm-agg`) | SGLang (`sglang-agg`) | TensorRT-LLM (`trtllm-agg`) |
-|---|:---:|:---:|:---:|
-| **Use a prebuilt image (no build)** | ❌ build it | ✅ pull it | ❌ build it |
-| Chat completion (sync + streaming) | ✅ | ✅ | ✅ |
-| Tool calling (`message.tool_calls`) | ✅ | ✅ | ✅ |
-| Reasoning extraction (`message.reasoning_content`) | ✅ | ✅ | ✅ |
-| Speculative decoding (EAGLE MTP) | — | ✅ | — |
-| KV-cache event publishing | ✅ | ✅ | ❌ not yet |
-
-**TL;DR.** Want it running with the least friction? Pick **SGLang** — the manifest pulls a prebuilt NGC image and works as-is. The **vLLM** and **TensorRT-LLM** variants both require a one-time custom container build until V4 support lands in their public images.
-
-### Known limitations per backend
-
-**TensorRT-LLM** (`trtllm-agg`):
-- 🔧 *Custom image required for now.* The public `tensorrtllm-runtime` image will bundle V4 once [TensorRT-LLM PR #13568](https://github.com/NVIDIA/TensorRT-LLM/pull/13568) lands (lifts `TOKENIZER_ALIASES` to module level).
-- 📌 *Snapshot SHA pinned in the YAML.* `--model-path` points at a specific HuggingFace snapshot directory — a workaround for [`huggingface/transformers#44843`](https://github.com/huggingface/transformers/issues/44843) (offline-mode regression in transformers 4.57.x). If HuggingFace publishes a new commit for `deepseek-ai/DeepSeek-V4-Flash`, update the SHA in `trtllm/agg/deploy.yaml` before applying. See the pre-flight check in [TensorRT-LLM-specific notes](#tensorrt-llm-specific).
-- ❌ *KV-cache event publishing not yet supported.* V4's sparse-MLA cache manager asserts the event buffer is off, so `--publish-events-and-metrics` is intentionally omitted from the worker args.
-
-**vLLM** (`vllm-agg`):
-- 🔧 *Custom image required for now.* Render and build the standard Dynamo vLLM runtime image — see [Prerequisites](#prerequisites) step 4.
-- 🐢 *First launch is slow (~60 min)* — weight load + FlashInfer autotune + cudagraph warmup. The startup probe is sized for this.
-
-**SGLang** (`sglang-agg`):
-- ✅ *No image build needed.* The manifest pulls `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-sglang-deepseek-v4-b200-dev.1` directly.
-- 🐢 *First launch is slow (~60 min)* — weight load + DeepGEMM warmup + cudagraph warmup. The startup probe is sized for this.
 
 ## Prerequisites
 

--- a/recipes/deepseek-v4/deepseek-v4-flash/trtllm/agg/deploy.yaml
+++ b/recipes/deepseek-v4/deepseek-v4-flash/trtllm/agg/deploy.yaml
@@ -1,0 +1,254 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# DeepSeek-V4-Flash TensorRT-LLM DynamoGraphDeployment
+# Aggregated mode (no P/D disagg), B200x4, TP=4 + EP=4, Attention DP, MoE backend = TRTLLM (trtllm-gen kernel).
+#
+# This is the proven 2026-04-27 config from `dynamo-nscale-dev-cluster`/`yna`/`dsv4-flash-trtllm-agg`,
+# adapted for the canonical recipes/ layout. End-to-end verified (Paris/Berlin chat, multi-turn name recall);
+# tool calling and reasoning extraction wired via --dyn-*-parser flags.
+#
+# Deploy:
+#   kubectl apply -f deploy.yaml -n <namespace>
+#
+# Test:
+#   kubectl port-forward -n <namespace> svc/dsv4-flash-trtllm-agg-frontend 8000:8000
+#   curl http://localhost:8000/v1/models
+#   curl http://localhost:8000/v1/chat/completions -H 'Content-Type: application/json' \
+#     -d '{"model":"deepseek-ai/DeepSeek-V4-Flash","messages":[{"role":"user","content":"Hello"}]}'
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dsv4-flash-trtllm-config
+data:
+  engine.yaml: |
+    # TensorRT-LLM LlmArgs for DeepSeek-V4-Flash on B200 (SM100), TP=4 + EP=4.
+    # Parallelism (tensor_parallel_size, moe_expert_parallel_size) is set via CLI flags
+    # on dynamo.trtllm — do NOT duplicate here. This file is the LlmArgs subset Dynamo
+    # passes to the underlying tensorrt_llm.LLM() constructor via --extra-engine-args.
+
+    # Custom tokenizer alias — routes through MR 10189's V4 tokenizer path so we
+    # bypass HF AutoTokenizer.from_pretrained (which calls _patch_mistral_regex →
+    # is_base_mistral → HF Hub model_info, blocked by HF_HUB_OFFLINE=1).
+    custom_tokenizer: deepseek_v4
+
+    # KV cache. V4 requires tokens_per_block in {128, 256}; we use 128 (matches
+    # our --kv-block-size CLI flag).
+    kv_cache_config:
+      tokens_per_block: 128
+      free_gpu_memory_fraction: 0.3
+
+    # Attention DP (per MR 10189 README's serving recipe). Improves throughput at
+    # high concurrency by data-parallel-izing attention across the 4 GPUs.
+    enable_attention_dp: true
+    attention_dp_config:
+      batching_wait_iters: 0
+      enable_balance: true
+      timeout_iters: 60
+
+    # CUDA graphs. Padding to compiled batch sizes reduces capture overhead.
+    cuda_graph_config:
+      enable_padding: true
+
+    # MoE backend MUST be TRTLLM on Blackwell — uses the trtllm-gen kernel that
+    # MR 10186 wires up (customMoeRoutingKernels). PYTORCH backend will fail at
+    # runtime per fused_moe_trtllm_gen.py SM-version assertion.
+    moe_config:
+      backend: TRTLLM
+
+    # Request bounds. Conservative for first-launch validation; tune up after stable.
+    max_batch_size: 4
+    max_num_tokens: 8192
+
+    stream_interval: 10
+---
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: dsv4-flash-trtllm-agg
+spec:
+  services:
+    Frontend:
+      componentType: frontend
+      replicas: 1
+      volumeMounts:
+        - name: model-cache
+          mountPoint: /models
+      extraPodSpec:
+        mainContainer:
+          # Replace with your TRT-LLM Dynamo runtime image. Until the upstream
+          # tensorrtllm-runtime image bundles a TRT-LLM build that includes
+          # DeepSeek V4 support (TensorRT-LLM PR #13568 lifts TOKENIZER_ALIASES
+          # to module level; see also feat/mewtwo branch + MR 10189), this
+          # recipe expects a custom build. See recipes/deepseek-v4/container/
+          # for the build pattern.
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:my-tag
+          imagePullPolicy: Always
+          command:
+            - python3
+          args:
+            - -m
+            - dynamo.frontend
+          env:
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            # ModelExpress (Rust) on the frontend uses HF cache at $HF_HOME/hub
+            # to fetch model metadata. Pointing at the shared PVC means it
+            # resolves locally, no network needed.
+            - name: HF_HOME
+              value: /models
+            - name: HF_HUB_OFFLINE
+              value: "1"
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            periodSeconds: 10
+            timeoutSeconds: 10
+            failureThreshold: 360   # 60 min — V4 worker registration depends on worker init
+
+    decode:
+      componentType: worker
+      subComponentType: decode
+      replicas: 1
+      resources:
+        limits:
+          gpu: "4"
+      volumeMounts:
+        - name: model-cache
+          mountPoint: /models
+      sharedMemory:
+        size: 200Gi
+      extraPodSpec:
+        nodeSelector:
+          nvidia.com/gpu.product: NVIDIA-B200
+        tolerations:
+          - key: nvidia.com/gpu
+            operator: Exists
+            effect: NoSchedule
+        volumes:
+          - name: trtllm-config
+            configMap:
+              name: dsv4-flash-trtllm-config
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:my-tag
+          imagePullPolicy: Always
+          workingDir: /workspace
+          volumeMounts:
+            - name: trtllm-config
+              mountPath: /config
+              readOnly: true
+          command:
+            - python3
+            - -m
+            - dynamo.trtllm
+          args:
+            # NOTE on --model-path: passing the local snapshot directory (rather
+            # than the HF id "deepseek-ai/DeepSeek-V4-Flash") makes transformers
+            # set _is_local=True, which short-circuits _patch_mistral_regex's
+            # HF Hub model_info() call. That call is what raises
+            # OfflineModeIsEnabled in transformers 4.57.2/4.57.3 with
+            # HF_HUB_OFFLINE=1 (huggingface/transformers#44843).
+            #
+            # Once TRT-LLM bumps to a transformers release with the fix
+            # (PRs #43603 / #45444 / #45359), this can be reverted to the
+            # canonical HF id. The /v1/models response is correct either way
+            # because --served-model-name registers the canonical id.
+            #
+            # Update the snapshot SHA below if HuggingFace publishes a new
+            # commit for deepseek-ai/DeepSeek-V4-Flash. Verify with:
+            #   ls /models/hub/models--deepseek-ai--DeepSeek-V4-Flash/snapshots/
+            #   cat /models/hub/models--deepseek-ai--DeepSeek-V4-Flash/refs/main
+            - --model-path
+            - /models/hub/models--deepseek-ai--DeepSeek-V4-Flash/snapshots/6c858e71890b508e4f3fd6491f45b325580ba934
+            - --served-model-name
+            - deepseek-ai/DeepSeek-V4-Flash
+            # TP must equal GPU count (= world_size). EP equal to TP across the
+            # 4 GPUs matches our verified trtllm-serve config (and the V3.2-fp4
+            # recipe pattern).
+            - --tensor-parallel-size
+            - "4"
+            - --expert-parallel-size
+            - "4"
+            - --max-batch-size
+            - "4"
+            - --max-num-tokens
+            - "8192"
+            - --max-seq-len
+            - "2048"
+            - --kv-block-size
+            - "128"
+            - --extra-engine-args
+            - /config/engine.yaml
+            # Activate Dynamo's V4 DSML tool-call parser and V4 reasoning parser.
+            # Without these, the model's <｜DSML｜tool_calls>...</｜DSML｜tool_calls>
+            # markup and <think>...</think> blocks leak as raw content; tool_calls
+            # is null and reasoning_content is null. Aliases registered in
+            # lib/parsers/src/tool_calling/parsers.rs (PR #8665) and
+            # lib/parsers/src/reasoning/mod.rs (same PR).
+            - --dyn-tool-call-parser
+            - deepseek_v4
+            - --dyn-reasoning-parser
+            - deepseek_v4
+            # NOTE: --publish-events-and-metrics is INTENTIONALLY OMITTED.
+            # V4's sparse/deepseek_v4/cache_manager.py:181 asserts
+            # event_buffer_max_size == 0; the flag would set it > 0 and crash
+            # init with `AssertionError: event_buffer_max_size must be 0`.
+            # Re-enable once V4 KV-cache supports event publishing.
+            #
+            # No --request-plane flag — both frontend and worker default to TCP.
+            # Adding --request-plane nats here causes "Invalid TCP address"
+            # errors on chat/completions because the frontend stays on TCP.
+          env:
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            # HF cache → read weights from the PVC, never the Hub.
+            - name: HF_HOME
+              value: /models
+            - name: HF_HUB_OFFLINE
+              value: "1"
+            - name: TRITON_CACHE_DIR
+              value: /models/.triton-cache
+            # Memory + UCX/MPI tuning (verified in our 04/27 deployment).
+            - name: PYTORCH_CUDA_ALLOC_CONF
+              value: "expandable_segments:True"
+            - name: UCX_TLS
+              value: "tcp,self,sm,cma"
+            - name: UCX_NET_DEVICES
+              value: "lo"
+            - name: OMPI_MCA_btl
+              value: "self,vader,tcp"
+            - name: OMPI_MCA_pml
+              value: "ob1"
+            # NCCL — keep CUMEM enabled; single-node so no MNNVL needed.
+            - name: NCCL_CUMEM_ENABLE
+              value: "1"
+            - name: GLOO_SOCKET_IFNAME
+              value: eth0
+            # TRT-LLM perf knobs (low-risk, default-on in V3.2-fp4 recipe).
+            - name: TRTLLM_ENABLE_PDL
+              value: "1"
+            - name: TRTLLM_SERVER_DISABLE_GC
+              value: "1"
+            - name: TRTLLM_WORKER_DISABLE_GC
+              value: "1"
+            - name: TLLM_LOG_LEVEL
+              value: "INFO"
+          securityContext:
+            runAsUser: 0   # write access to /models/.triton-cache + /opt/dynamo/venv
+          startupProbe:
+            httpGet:
+              path: /live
+              port: 9090
+            periodSeconds: 60
+            timeoutSeconds: 5
+            failureThreshold: 60   # 60 min for V4 weight load + cudagraph warmup
+
+  pvcs:
+    - name: model-cache
+      create: false


### PR DESCRIPTION
## Summary

Adds a TensorRT-LLM aggregated-serving variant for DeepSeek-V4-Flash on B200x4, alongside the existing SGLang and vLLM recipes in `recipes/deepseek-v4/deepseek-v4-flash/`. Brings TRT-LLM to parity with the other two backends and fills the only V4 backend coverage gap in the repo.

- New manifest: `recipes/deepseek-v4/deepseek-v4-flash/trtllm/agg/deploy.yaml` (ConfigMap with engine YAML + DGD).
- README updated: 3-backend variant table, deploy section, flag table, TRT-LLM-specific notes (image build, transformers offline workaround, snapshot SHA pre-flight, `--publish-events-and-metrics` caveat, request-plane caveat).

## What's in the recipe

Configuration is the **proven nscale deployment** from `dynamo-nscale-dev-cluster`/`yna`/`dsv4-flash-trtllm-agg` (single replica, end-to-end verified with chat + multi-turn) plus the two parser flags that wire up V4 tool-calling and reasoning extraction in the Dynamo frontend.

## Image dependency

Recipe uses the placeholder tag `nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:my-tag`. Until the public `tensorrtllm-runtime` image bundles V4 support, deployers need a custom build; the README points at [TensorRT-LLM PR #13568](https://github.com/NVIDIA/TensorRT-LLM/pull/13568) (lifts `TOKENIZER_ALIASES` to module level) as the upstream dependency that closes the custom-build requirement.

## Test plan

- [x] YAML parses (2 docs: ConfigMap + DynamoGraphDeployment)
- [x] `kubectl apply --dry-run=client` accepts the manifest
- [x] `kubectl apply --dry-run=server` accepts against the live DGD CRD on `dynamo-nscale-dev-cluster`
- [x] End-to-end smoke test with simple curl request
- [ ] CI green
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8825" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Expanded DeepSeek-V4-Flash recipe with TensorRT-LLM backend documentation, covering deployment instructions, configuration parameters, parallelism settings, and operational guidance.

* **New Features**
  * Added TensorRT-LLM backend support for DeepSeek-V4-Flash with Kubernetes deployment manifest and engine configuration for aggregated serving mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->