### PR TITLE
feat: change default KVBM v2 G2 to G3 policy and min_lfu_count for better UX

### DIFF
--- a/docs/components/kvbm/kvbm-v2-guide.md
+++ b/docs/components/kvbm/kvbm-v2-guide.md
@@ -93,7 +93,33 @@ DYN_KVBM_CPU_CACHE_GB=20 \
     --enforce-eager
 ```
 
+### Offload Policies
 
+KVBM v2 runs two independent offload pipelines; each filters blocks through a list of policies (implicit AND). Defaults are:
+
+| Tier | Default | Rationale |
+|------|---------|-----------|
+| G1→G2 | `presence` | Offload any GPU block not already on host and not already in flight. |
+| G2→G3 | `presence` | Offload any host block not already on disk and not already in flight. |
+
+Available policy types:
+
+- `pass_all` — no filtering, every block is offloaded
+- `presence` — skip blocks already in the destination tier or currently in flight
+- `presence_lfu` — `presence` plus a TinyLFU access-count threshold; offloads when `count > min_lfu_count` (default `1`)
+
+Override per tier via env vars (the value is JSON):
+
+```bash
+# Opt into LFU-on-admission for G2→G3 (useful when disk write bandwidth is precious, or SSD lifespan is a concern)
+KVBM_OFFLOAD_G2_TO_G3_POLICIES='["presence_lfu"]'
+
+# Tune the LFU threshold (default 1; e.g. require 4+ hits before offload)
+KVBM_OFFLOAD_G2_TO_G3_PRESENCE_LFU_MIN_LFU_COUNT=3
+
+# Force every block through (helpful for smoke-testing or observing G3 traffic)
+KVBM_OFFLOAD_G2_TO_G3_POLICIES='["pass_all"]'
+```
 
 ## Benchmarking
 

--- a/lib/kvbm-config/README.md
+++ b/lib/kvbm-config/README.md
@@ -120,7 +120,7 @@ Policy types: `pass_all`, `presence`, `presence_lfu`
 |---|---|---|---|---|
 | `offload.g1_to_g2.policies` | `Vec<PolicyType>` | `[]` | `KVBM_OFFLOAD_G1_TO_G2_POLICIES` | Empty = engine applies tier-specific defaults |
 | `offload.g1_to_g2.presence` | `PresenceFilterConfig` | `{}` | | Config for `presence` policy (currently no params) |
-| `offload.g1_to_g2.presence_lfu.min_lfu_count` | `u32` | `8` | | Min access count before offload |
+| `offload.g1_to_g2.presence_lfu.min_lfu_count` | `u32` | `1` | | Offload when count > this (default fires on 2nd hit) |
 | `offload.g1_to_g2.min_priority` | `i32` | `0` | `KVBM_OFFLOAD_G1_TO_G2_MIN_PRIORITY` | Prefix-contiguous offload priority threshold |
 | `offload.g1_to_g2.max_concurrent_transfers` | `Option<usize>` | None | `KVBM_OFFLOAD_G1_TO_G2_MAX_CONCURRENT_TRANSFERS` | None = engine default (4) |
 | `offload.g1_to_g2.max_batch_size` | `Option<usize>` | None | `KVBM_OFFLOAD_G1_TO_G2_MAX_BATCH_SIZE` | None = engine default (16) |
@@ -131,7 +131,7 @@ Policy types: `pass_all`, `presence`, `presence_lfu`
 |---|---|---|---|---|
 | `offload.g2_to_g3.policies` | `Vec<PolicyType>` | `[]` | `KVBM_OFFLOAD_G2_TO_G3_POLICIES` | Empty = engine applies tier-specific defaults |
 | `offload.g2_to_g3.presence` | `PresenceFilterConfig` | `{}` | | Config for `presence` policy |
-| `offload.g2_to_g3.presence_lfu.min_lfu_count` | `u32` | `8` | | Min access count before offload |
+| `offload.g2_to_g3.presence_lfu.min_lfu_count` | `u32` | `1` | | Offload when count > this (default fires on 2nd hit) |
 | `offload.g2_to_g3.min_priority` | `i32` | `0` | `KVBM_OFFLOAD_G2_TO_G3_MIN_PRIORITY` | Prefix-contiguous offload priority threshold |
 | `offload.g2_to_g3.max_concurrent_transfers` | `Option<usize>` | None | `KVBM_OFFLOAD_G2_TO_G3_MAX_CONCURRENT_TRANSFERS` | None = engine default |
 | `offload.g2_to_g3.max_batch_size` | `Option<usize>` | None | `KVBM_OFFLOAD_G2_TO_G3_MAX_BATCH_SIZE` | None = engine default |

--- a/lib/kvbm-config/src/offload.rs
+++ b/lib/kvbm-config/src/offload.rs
@@ -28,7 +28,7 @@
 //!     },
 //!     "g2_to_g3": {
 //!       "policies": ["presence_lfu"],
-//!       "presence_lfu": { "min_lfu_count": 8 }
+//!       "presence_lfu": { "min_lfu_count": 1 }
 //!     }
 //!   }
 //! }
@@ -59,8 +59,18 @@ pub enum PolicyType {
 pub struct PresenceFilterConfig {}
 
 /// Default LFU count threshold.
+///
+/// The filter passes when `count > min_lfu_count`. The TinyLFU sketch counts
+/// every register and prefix re-match, so:
+/// - `0` → first registration triggers offload (effectively no LFU gating)
+/// - `1` → second hit triggers offload (matches KVBM v1's `FrequencyFilter`
+///   default of `min_offload_frequency = 2`)
+/// - higher values → require more re-matches before promoting
+///
+/// Default `1` matches v1 UX: a block crosses to the next tier the moment a
+/// second request prefix-matches it.
 fn default_min_lfu_count() -> u32 {
-    8
+    1
 }
 
 /// Configuration for presence + LFU filter.
@@ -71,12 +81,12 @@ fn default_min_lfu_count() -> u32 {
 pub struct PresenceLfuFilterConfig {
     /// Minimum LFU count threshold for offload.
     ///
-    /// Blocks must have been accessed more than this many times to be
-    /// considered for offload. This prevents offloading rarely-used blocks.
+    /// A block is offloaded when its access count is **strictly greater** than
+    /// this value. The TinyLFU sketch counts each register and prefix re-match.
     ///
-    /// Default: 8
+    /// Default: 1 (block crosses on the second hit, matching KVBM v1).
     #[serde(default = "default_min_lfu_count")]
-    #[validate(range(min = 1))]
+    #[validate(range(min = 0))]
     pub min_lfu_count: u32,
 }
 
@@ -168,7 +178,7 @@ mod tests {
         // Empty policies - engine applies tier-specific defaults
         assert!(config.g1_to_g2.policies.is_empty());
         assert!(config.g2_to_g3.policies.is_empty());
-        assert_eq!(config.g2_to_g3.presence_lfu.min_lfu_count, 8);
+        assert_eq!(config.g2_to_g3.presence_lfu.min_lfu_count, 1);
     }
 
     #[test]
@@ -221,8 +231,8 @@ mod tests {
     fn test_default_lfu_threshold() {
         let json = r#"{"policies": ["presence_lfu"]}"#;
         let config: TierOffloadConfig = serde_json::from_str(json).unwrap();
-        // Should use default of 8
-        assert_eq!(config.presence_lfu.min_lfu_count, 8);
+        // Should use default of 1 (offload on second hit, matching KVBM v1)
+        assert_eq!(config.presence_lfu.min_lfu_count, 1);
     }
 
     #[test]

--- a/lib/kvbm-connector/src/connector/leader/init.rs
+++ b/lib/kvbm-connector/src/connector/leader/init.rs
@@ -486,7 +486,7 @@ impl ConnectorLeader {
             .build();
 
         // Build G2→G3 policy from config (or defaults if not configured).
-        // Default: Presence — symmetric with G1→G2. Promote any block not already
+        // Default: Presence — symmetric with G1→G2. Offload any block not already
         // on disk and not already in flight; let G3's eviction backend handle
         // cold-block churn under pressure. Opt into LFU-on-admission for
         // workloads where disk write amplification matters by setting

--- a/lib/kvbm-connector/src/connector/leader/init.rs
+++ b/lib/kvbm-connector/src/connector/leader/init.rs
@@ -485,12 +485,16 @@ impl ConnectorLeader {
             .auto_chain(has_downstream_tier)
             .build();
 
-        // Build G2→G3 policy from config (or defaults if not configured)
-        // Default: PresenceLfu filter for presence + LFU frequency check (pending auto-wired)
+        // Build G2→G3 policy from config (or defaults if not configured).
+        // Default: Presence — symmetric with G1→G2. Promote any block not already
+        // on disk and not already in flight; let G3's eviction backend handle
+        // cold-block churn under pressure. Opt into LFU-on-admission for
+        // workloads where disk write amplification matters by setting
+        // KVBM_OFFLOAD_G2_TO_G3_POLICIES='["presence_lfu"]'.
         let g2_to_g3_config = if offload_config.g2_to_g3.policies.is_empty() {
-            tracing::debug!("No G2→G3 policies configured, using default: [PresenceLfu]");
+            tracing::debug!("No G2→G3 policies configured, using default: [Presence]");
             kvbm_config::TierOffloadConfig {
-                policies: vec![kvbm_config::PolicyType::PresenceLfu],
+                policies: vec![kvbm_config::PolicyType::Presence],
                 ..Default::default()
             }
         } else {

--- a/lib/kvbm-engine/src/offload/policy.rs
+++ b/lib/kvbm-engine/src/offload/policy.rs
@@ -377,9 +377,9 @@ impl<Src: BlockMetadata, Dst: BlockMetadata> OffloadPolicy<Src> for PresenceFilt
 ///
 /// # Example
 /// ```ignore
-/// // Only offload blocks with LFU count > 8 that aren't in G3 or in-flight
+/// // Only offload blocks hit at least twice (count > 1) that aren't in G3 or in-flight
 /// let tracker = Arc::new(PendingTracker::new());
-/// let filter = PresenceAndLFUFilter::<G2, G3>::new(registry.clone(), 8)
+/// let filter = PresenceAndLFUFilter::<G2, G3>::new(registry.clone(), 1)
 ///     .with_pending_tracker(tracker);
 /// ```
 pub struct PresenceAndLFUFilter<Src: BlockMetadata, Dst: BlockMetadata> {
@@ -401,9 +401,9 @@ impl<Src: BlockMetadata, Dst: BlockMetadata> PresenceAndLFUFilter<Src, Dst> {
         }
     }
 
-    /// Create with default threshold of 8.
+    /// Create with default threshold of 1 (offload on second hit, matching KVBM v1).
     pub fn with_default_threshold(registry: Arc<BlockRegistry>) -> Self {
-        Self::new(registry, 8)
+        Self::new(registry, 1)
     }
 
     /// Add a pending tracker for duplicate prevention.
@@ -941,7 +941,7 @@ impl<T: BlockMetadata> OffloadPolicy<T> for PassAllPolicy<T> {
 /// let tracker = Arc::new(PendingTracker::new());
 /// let config = TierOffloadConfig {
 ///     policies: vec![PolicyType::Presence, PolicyType::PresenceLfu],
-///     presence_lfu: PresenceLfuFilterConfig { min_lfu_count: 8 },
+///     presence_lfu: PresenceLfuFilterConfig { min_lfu_count: 1 },
 ///     ..Default::default()
 /// };
 ///


### PR DESCRIPTION
### Overview:

KVBM v2's G2→G3 offload pipeline didn't fire on out-of-the-box deployments. Two defaults stacked  
  badly:                                                                                            
                                                                                                    
  - G2→G3 used `[PresenceLfu]` with `min_lfu_count = 8` — a block had to be hit 9+ times before disk
   admission.
  - The TinyLFU sketch only increments on register and prefix re-match, so single ad-hoc requests   
  (e.g. a one-off `curl`) never crossed the threshold and nothing reached G3.                       
  
  Users were forced to set `KVBM_OFFLOAD_G2_TO_G3_POLICIES='["pass_all"]'` just to observe the disk 
  tier doing anything. This PR aligns the defaults with KVBM v1's behavior.
                                                                                                    
  ## Changes                                                

  - **G2→G3 default policy: `[PresenceLfu]` → `[Presence]`**                                        
    Symmetric with G1→G2. Offload any host block not already on disk and not in flight; let G3's
  eviction backend reclaim cold blocks under capacity pressure. LFU-on-admission stays available via
   `KVBM_OFFLOAD_G2_TO_G3_POLICIES='["presence_lfu"]'` for workloads where disk write amplification
  matters.                                                                                          
                                                            
  - **`min_lfu_count` default: `8` → `1`**                                                          
    Matches KVBM v1's `FrequencyFilter` (`min_offload_frequency = 2`): a block crosses on its second
   hit. Only affects users who explicitly opt into `presence_lfu`. Validator floor lowered from `1` 
  to `0` so callers can disable LFU gating entirely while keeping the policy enabled.
                                                                                                    
  - **Docs**                                                
    - `docs/components/kvbm/kvbm-v2-guide.md`: new *Offload Policies* section documenting the
  defaults, available policy types, env-var overrides, and the TinyLFU "second hit" gotcha.         
    - `lib/kvbm-config/README.md`: updated default-value tables.

closes [KVBM-411](https://linear.app/nvidia/issue/KVBM-411/kvbm-v2-does-not-trigger-g3-offloading)