### PR TITLE
ci: add dynamo-pipeline to clean-k8s-builder needs

### DIFF
--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -510,7 +510,7 @@ jobs:
     name: Clean K8s builder if exists
     runs-on: prod-default-small-v2
     if: always()
-    needs: [vllm-build, sglang-build, trtllm-build, create-fresh-builder]
+    needs: [vllm-build, sglang-build, trtllm-build, dynamo-pipeline, create-fresh-builder]
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
#### Overview:

Add `dynamo-pipeline` to the `needs` list of the `clean-k8s-builder` job in the nightly CI workflow so that the builder cleanup does not run before `dynamo-pipeline` finishes.

#### Details:

The `clean-k8s-builder` job was missing `dynamo-pipeline` in its `needs` array. This caused the K8s builder to be torn down while `dynamo-pipeline` was still running, leading to build failures on nightly runs.

#### Where should the reviewer start?

`.github/workflows/nightly-ci.yml` — the `clean-k8s-builder` job's `needs` field (line ~513).

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to nightly CI instability


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline job dependency ordering to ensure proper execution sequencing of build and cleanup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->