### PR TITLE
test(vllm): add Qwen3.5-0.8B mm coverage and port b64 tests onto the profile system

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -511,13 +511,16 @@ Tests must be deterministic. A flaky test -- one that sometimes passes and somet
    The server is launched once and stays up across attempts; only the request/response is re-issued. Set `max_attempts` on the payload:
    ```python
    # tests/serve/multimodal_profiles/vllm.py
-   request_payloads=[
-       make_image_payload(
-           ["green", "white", "black", "purple", "red", ...],
-           max_attempts=3,  # known-flaky model output; see comment above
+   tests=[
+       MmCase(
+           payload=make_image_payload(
+               ["green", "white", "black", "purple", "red", ...],
+               max_attempts=3,  # known-flaky model output; see comment above
+           )
        )
    ],
    ```
+   For background on the `MultimodalModelProfile → TopologyConfig → MmCase` shape, see [`tests/serve/multimodal_profiles/README.md`](serve/multimodal_profiles/README.md).
    - The factory functions (`make_image_payload`, `make_video_payload`, `chat_payload`, ...) accept a `max_attempts: int` kwarg that lands on `BasePayload.max_attempts`.
    - `tests/serve/common.py:run_serve_deployment` wraps the `send_request` + `check_response` pair in a small inline retry loop, catching `ResponseValidationError` with exponential backoff (1.0 → 1.5 → 2.25 → ... seconds, factor 1.5).
    - Cost: each attempt is ~one inference call (a few seconds), not a server restart. The 60-90s server startup is amortized across all attempts.

--- a/tests/serve/multimodal_profiles/README.md
+++ b/tests/serve/multimodal_profiles/README.md
@@ -1,0 +1,165 @@
+# Multimodal Profile System
+
+This directory holds the per-backend lists of multimodal serving tests
+(one file per backend — currently `vllm.py`). Each file declares a
+`<BACKEND>_MULTIMODAL_PROFILES` list that
+`tests/serve/test_<backend>.py` flattens into pytest configs via
+`make_multimodal_configs(...)`.
+
+## Why
+
+Before the profile system, every multimodal test was a hand-written
+`VLLMConfig(...)` block in `tests/serve/test_vllm.py`. Adding a new
+model, a new topology, or a new payload variant required copy-pasting
+~40 lines and keeping the marks / timeouts / `script_args` /
+`request_payloads` aligned by hand. The profile system declares the
+*shape* (model, topology, payload) and lets one generator build all
+the configs.
+
+## Three-layer hierarchy
+
+```
+MultimodalModelProfile           ← one HF model
+  └─ topologies: dict[str, TopologyConfig]
+       └─ TopologyConfig         ← one deployment shape (agg / e_pd / epd / p_d / ...)
+            └─ tests: list[MmCase]
+                 └─ MmCase       ← one concrete test case (payload + per-case overrides)
+```
+
+Each layer adds something the layer above can't:
+
+| Layer | Owns | Why this layer? |
+|-------|------|-----------------|
+| `MultimodalModelProfile` | `name`, `short_name`, `gpu_marker`, `extra_vllm_args`, `gated`, `marks` | Per-model facts that are constant across topologies (HF id, default GPU class, model-wide pytest marks like `gated`). |
+| `TopologyConfig` | `marks`, `timeout_s`, `delayed_start`, `profiled_vram_gib`, `requested_vllm_kv_cache_bytes`, `single_gpu` / `two_gpu`, `gpu_marker` override, `env` | Per-topology launch shape (how the deployment is wired — e.g. `agg` is one process, `epd` is encode + prefill + decode on three GPUs). The shape determines GPU count, VRAM bounds, and timeout. |
+| `MmCase` | `payload`, `suffix`, `extra_script_args`, per-case `marks` / `timeout_s` / `env` overrides | Per-test variation within a topology — same launch shape, different payload (HTTP-URL vs b64-inline vs video) or different launch flag (e.g. `--frontend-decoding`). |
+
+The topology key (`"agg"`, `"e_pd"`, etc.) is what `make_multimodal_configs`
+looks up in `<BACKEND>_TOPOLOGY_SCRIPTS` to find the launch script.
+**Multiple topology keys can map to the same script** — see the
+`agg`/`agg_video` and `epd`/`epd_video` pairs in `vllm.py`. The split
+exists because video tests need different VRAM bounds / timeouts /
+`delayed_start` than image tests, even though both run
+`agg_multimodal.sh`.
+
+## What gets generated
+
+For each `(profile, topology, case)` triple, `make_multimodal_configs`
+emits one `EngineConfig` keyed:
+
+```
+mm_{topology}_{profile.short_name}[_{case.suffix}]
+```
+
+So `qwen3-vl-2b` running on the `agg` topology with two MmCases
+(`""` and `"b64"`) produces:
+
+```
+mm_agg_qwen3-vl-2b
+mm_agg_qwen3-vl-2b_b64
+```
+
+Marks attached to each EngineConfig are layered, in this order
+(later wins on conflicts that pytest cares about — pytest just
+collects all marks):
+
+1. GPU marker (`gpu_1` / `gpu_2` / `gpu_4`) — from `topology.gpu_marker`
+   or falling back to `profile.gpu_marker`
+2. `pytest.mark.timeout(...)` — from `case.timeout_s` if set, else
+   `topology.timeout_s`
+3. Case marks (`case.marks`) if non-empty, else topology marks
+   (`topology.marks`) — case overrides topology entirely
+4. `profiled_vram_gib(...)` and `requested_vllm_kv_cache_bytes(...)`
+   if set on the topology
+5. `skipif(DYN_HF_GATED_MODELS_ENABLED unset)` if `profile.gated`
+6. Profile-wide marks (`profile.marks`)
+
+## End-to-end example
+
+```python
+# tests/serve/multimodal_profiles/vllm.py
+
+VLLM_TOPOLOGY_SCRIPTS = {
+    "agg": "agg_multimodal.sh",
+    "agg_video": "agg_multimodal.sh",   # same script, different config row
+    "e_pd": "disagg_multimodal_e_pd.sh",
+    "epd": "disagg_multimodal_epd.sh",
+    "epd_video": "disagg_multimodal_epd.sh",
+    "p_d": "disagg_multimodal_p_d.sh",
+}
+
+VLLM_MULTIMODAL_PROFILES = [
+    MultimodalModelProfile(
+        name="Qwen/Qwen3-VL-2B-Instruct",
+        short_name="qwen3-vl-2b",
+        topologies={
+            "agg": TopologyConfig(
+                marks=[pytest.mark.post_merge],
+                timeout_s=220,
+                tests=[
+                    MmCase(payload=make_image_payload(["green"])),
+                    MmCase(suffix="b64", payload=make_image_payload_b64(["green"])),
+                    MmCase(
+                        suffix="frontend_decoding",
+                        payload=make_image_payload(["green"]),
+                        extra_script_args=["--frontend-decoding"],
+                    ),
+                ],
+            ),
+            "agg_video": TopologyConfig(
+                marks=[pytest.mark.pre_merge],
+                timeout_s=600,
+                delayed_start=60,
+                profiled_vram_gib=8.2,
+                requested_vllm_kv_cache_bytes=1_719_075_000,
+                tests=[MmCase(payload=make_video_payload(["red", "static", "still"]))],
+            ),
+            ...
+        },
+    ),
+    ...
+]
+```
+
+Expands to:
+
+```
+mm_agg_qwen3-vl-2b                           # post_merge, gpu_1, t=220, image
+mm_agg_qwen3-vl-2b_b64                       # post_merge, gpu_1, t=220, b64-image
+mm_agg_qwen3-vl-2b_frontend_decoding         # post_merge, gpu_1, t=220, image, --frontend-decoding
+mm_agg_video_qwen3-vl-2b                     # pre_merge,  gpu_1, t=600, video, kv-bounded
+...
+```
+
+Each becomes one `VLLMConfig(...)` instance with the right
+`script_name`, `script_args`, `marks`, `request_payloads`, and `env`,
+and is wired into `vllm_configs` in `tests/serve/test_vllm.py`.
+
+## Adding a new variant
+
+| Want to add... | Where it goes |
+|----------------|---------------|
+| A new model | New `MultimodalModelProfile(...)` entry in `VLLM_MULTIMODAL_PROFILES` |
+| A new topology shape (e.g. tensor-parallel) | New entry in `VLLM_TOPOLOGY_SCRIPTS` + a corresponding launch script in `examples/backends/vllm/launch/` |
+| A new test case for an existing topology (e.g. test the same model with a different payload) | New `MmCase(...)` in that topology's `tests` list |
+| A new topology bound (e.g. video needs longer timeout) | New `TopologyConfig` keyed by a distinct topology key (`agg_video`) — multiple keys can map to the same launch script |
+| A new launch flag for one case only | `MmCase(extra_script_args=[...], ...)` |
+
+## Layered helpers in `tests/utils/multimodal.py`
+
+`tests/utils/multimodal.py` holds the dataclasses (`MmCase`,
+`TopologyConfig`, `MultimodalModelProfile`), the generator
+(`make_multimodal_configs`), and the payload factories shared across
+profiles:
+
+- `make_image_payload(expected_colors, *, max_attempts=1)` — HTTP-URL
+  color-identification payload using the standard test image
+- `make_image_payload_b64(expected_colors)` — same prompt, but inlines
+  the LFS-tracked PNG as a `data:image/png;base64,...` URL.
+  Materialization is deferred to first `.body` read so pytest
+  collection doesn't fail when LFS hasn't pulled the image yet
+- `make_video_payload(expected_phrases)` — local test video
+- `make_audio_payload(expected_phrases)` — remote test WAV
+
+Backend-specific files (`vllm.py`, future `trtllm.py`, etc.) compose
+these factories with `MmCase`s; they don't define their own.

--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -4,12 +4,15 @@
 import pytest
 
 from tests.utils.multimodal import (
+    MmCase,
     MultimodalModelProfile,
     TopologyConfig,
     make_audio_payload,
     make_image_payload,
+    make_image_payload_b64,
     make_video_payload,
 )
+from tests.utils.payload_builder import chat_payload, chat_payload_default
 
 VLLM_TOPOLOGY_SCRIPTS: dict[str, str] = {
     "agg": "agg_multimodal.sh",
@@ -28,6 +31,32 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                 # TODO: re-enable GPU-parallel scheduling with
                 # profiled_vram_gib=9.6 once this has a bounded --kv-bytes profile.
                 timeout_s=220,
+                tests=[
+                    # Vanilla / baseline single-GPU multimodal smoke
+                    # (HTTP-URL image, no frontend decoding).
+                    MmCase(payload=make_image_payload(["green"])),
+                    # Vanilla inline base64 path (no Rust frontend decode).
+                    MmCase(
+                        suffix="b64",
+                        payload=make_image_payload_b64(["green"]),
+                    ),
+                    # --frontend-decoding (HTTP-URL): exercises strip_inline_data_urls
+                    # + NIXL RDMA. post_merge-only — local pre-merge builds outside
+                    # docker can pick up NIXL stubs that don't support this path;
+                    # CI post_merge runs in a container with real NIXL.
+                    MmCase(
+                        suffix="frontend_decoding",
+                        payload=make_image_payload(["green"]),
+                        extra_script_args=["--frontend-decoding"],
+                    ),
+                    # --frontend-decoding (inline base64). Same NIXL stub
+                    # caveat as the HTTP-URL variant above.
+                    MmCase(
+                        suffix="b64_frontend_decoding",
+                        payload=make_image_payload_b64(["green"]),
+                        extra_script_args=["--frontend-decoding"],
+                    ),
+                ],
             ),
             "e_pd": TopologyConfig(
                 marks=[pytest.mark.post_merge],
@@ -35,12 +64,14 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                 single_gpu=True,
                 profiled_vram_gib=15.0,
                 requested_vllm_kv_cache_bytes=4_096_361_000,
+                tests=[MmCase(payload=make_image_payload(["green"]))],
             ),
             "epd": TopologyConfig(
                 marks=[pytest.mark.post_merge],
                 timeout_s=300,
                 single_gpu=True,
                 requested_vllm_kv_cache_bytes=1_714_881_000,
+                tests=[MmCase(payload=make_image_payload(["green"]))],
             ),
             "p_d": TopologyConfig(
                 marks=[pytest.mark.post_merge],
@@ -48,9 +79,35 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                 single_gpu=True,
                 profiled_vram_gib=15.7,
                 requested_vllm_kv_cache_bytes=1_714_881_000,
+                tests=[MmCase(payload=make_image_payload(["green"]))],
             ),
         },
-        request_payloads=[make_image_payload(["green"])],
+    ),
+    MultimodalModelProfile(
+        name="Qwen/Qwen3.5-0.8B",
+        short_name="qwen3.5-0.8b",
+        topologies={
+            "agg": TopologyConfig(
+                marks=[pytest.mark.post_merge],
+                timeout_s=600,
+                profiled_vram_gib=4.0,
+                tests=[
+                    # HTTP-URL color test on hybrid Mamba/full-attention VL.
+                    # post_merge — qwen3-vl-2b carries the pre_merge baseline.
+                    MmCase(payload=make_image_payload(["green"])),
+                    # Inline-base64 + --frontend-decoding (NIXL RDMA path) on
+                    # the hybrid Mamba/full-attention VL. post_merge for the
+                    # same NIXL-stub reason as qwen3-vl-2b's frontend_decoding
+                    # cases — see that topology for the rationale.
+                    MmCase(
+                        suffix="b64_frontend_decoding",
+                        payload=make_image_payload_b64(["green"]),
+                        extra_script_args=["--frontend-decoding"],
+                        marks=[pytest.mark.post_merge],
+                    ),
+                ],
+            ),
+        },
     ),
     MultimodalModelProfile(
         name="Qwen/Qwen3-VL-2B-Instruct",
@@ -58,10 +115,11 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
         topologies={
             "agg": TopologyConfig(
                 marks=[pytest.mark.pre_merge],
-                timeout_s=720,
+                timeout_s=600,
                 delayed_start=60,
                 profiled_vram_gib=8.2,
                 requested_vllm_kv_cache_bytes=1_719_075_000,
+                tests=[MmCase(payload=make_video_payload(["red", "static", "still"]))],
             ),
             "epd": TopologyConfig(
                 marks=[pytest.mark.post_merge],
@@ -70,22 +128,9 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                 single_gpu=True,
                 profiled_vram_gib=19.7,
                 requested_vllm_kv_cache_bytes=1_714_881_000,
+                tests=[MmCase(payload=make_video_payload(["red", "static", "still"]))],
             ),
         },
-        request_payloads=[make_video_payload(["red", "static", "still"])],
-    ),
-    MultimodalModelProfile(
-        name="Qwen/Qwen2.5-VL-7B-Instruct",
-        short_name="qwen2.5-vl-7b",
-        topologies={
-            "agg": TopologyConfig(
-                marks=[pytest.mark.post_merge],
-                timeout_s=360,
-                profiled_vram_gib=19.9,
-                requested_vllm_kv_cache_bytes=922_354_000,
-            ),
-        },
-        request_payloads=[make_image_payload(["purple"])],
     ),
     # Audio: uses agg topology with DYN_CHAT_PROCESSOR=vllm because the Rust
     # Jinja engine cannot render multimodal content arrays (audio_url).
@@ -103,9 +148,9 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                 ],
                 timeout_s=600,
                 env={"DYN_CHAT_PROCESSOR": "vllm"},
+                tests=[MmCase(payload=make_audio_payload(["Hester", "Pynne"]))],
             ),
         },
-        request_payloads=[make_audio_payload(["Hester", "Pynne"])],
         extra_vllm_args=["--max-model-len", "7232"],
     ),
     # Non-Qwen VLM coverage
@@ -118,9 +163,9 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                 # TODO: re-enable GPU-parallel scheduling with
                 # profiled_vram_gib=12.0 once this has a bounded --kv-bytes profile.
                 timeout_s=300,
+                tests=[MmCase(payload=make_image_payload(["green"]))],
             ),
         },
-        request_payloads=[make_image_payload(["green"])],
         extra_vllm_args=["--dtype", "bfloat16"],
     ),
     # [gluo NOTE] LLaVA 1.5 7B is big model and require at least 3 GPUs to run.
@@ -135,10 +180,56 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
     # PD VRAM is bounded by --kv-cache-memory-bytes (set via
     # requested_vllm_kv_cache_bytes marker → _PROFILE_OVERRIDE_VLLM_KV_CACHE_BYTES);
     # without that marker, the PD fraction $DYN_PD_GPU_MEM applies.
+    #
+    # LLaVA 1.5 color naming varies across CUDA backends under vLLM 0.20;
+    # keep this as a multimodal serving smoke check, not a color oracle.
+    # The model also occasionally degenerates into newline-padded output
+    # (observed in CI: '\n\nWhat\n\n...' and '\n\n1') even with
+    # temperature=0; this is a known LLaVA-1.5-on-vLLM flake, so the
+    # 9-color payload below uses max_attempts=5 to retry validation
+    # in-process before CI fails. See tests/README.md "Flaky Tests" —
+    # In-Process Query Retry.
     MultimodalModelProfile(
         name="llava-hf/llava-1.5-7b-hf",
         short_name="llava-1.5-7b",
         topologies={
+            "agg": TopologyConfig(
+                # nightly-only: 7B 1-GPU footprint is tight (vram=19.2 GiB).
+                # Exercises a different image (coco bus) + a string-content
+                # smoke check that the multimodal templating handles.
+                marks=[pytest.mark.nightly],
+                timeout_s=360,
+                gpu_marker="gpu_1",
+                profiled_vram_gib=19.2,
+                requested_vllm_kv_cache_bytes=4_318_854_000,  # 2x safety over min=2_159_426_560
+                tests=[
+                    MmCase(
+                        payload=chat_payload(
+                            [
+                                {"type": "text", "text": "What is in this image?"},
+                                {
+                                    "type": "image_url",
+                                    "image_url": {
+                                        "url": "http://images.cocodataset.org/test2017/000000155781.jpg"
+                                    },
+                                },
+                            ],
+                            repeat_count=1,
+                            expected_response=["bus"],
+                            temperature=0.0,
+                        ),
+                    ),
+                    # String content (not array) — verifies string → array
+                    # conversion for multimodal templates. Just validate no error.
+                    MmCase(
+                        suffix="default",
+                        payload=chat_payload_default(
+                            repeat_count=1,
+                            expected_response=[],
+                        ),
+                    ),
+                ],
+            ),
             "e_pd": TopologyConfig(
                 marks=[pytest.mark.pre_merge],
                 timeout_s=600,
@@ -149,6 +240,24 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                 # (weights + KV @ 4 GB cap + activations). 2x safety on KV.
                 profiled_vram_gib=19.0,
                 requested_vllm_kv_cache_bytes=4_308_848_000,
+                tests=[
+                    MmCase(
+                        payload=make_image_payload(
+                            [
+                                "green",
+                                "white",
+                                "black",
+                                "purple",
+                                "red",
+                                "pink",
+                                "yellow",
+                                "blue",
+                                "orange",
+                            ],
+                            max_attempts=5,
+                        )
+                    )
+                ],
             ),
             "epd": TopologyConfig(
                 marks=[pytest.mark.pre_merge],
@@ -172,30 +281,25 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                 #   requested_vllm_kv_cache_bytes=4_297_773_000  # 2× safety over min 2_148_886_016
                 # Re-enable when CI runner pool has ≥32 GB cards on at least
                 # one of the 2 slots.
+                tests=[
+                    MmCase(
+                        payload=make_image_payload(
+                            [
+                                "green",
+                                "white",
+                                "black",
+                                "purple",
+                                "red",
+                                "pink",
+                                "yellow",
+                                "blue",
+                                "orange",
+                            ],
+                            max_attempts=5,
+                        )
+                    )
+                ],
             ),
         },
-        # LLaVA 1.5 color naming varies across CUDA backends under vLLM 0.20;
-        # keep this as a multimodal serving smoke check, not a color oracle.
-        # The model also occasionally degenerates into newline-padded output
-        # (observed in CI: '\n\nWhat\n\n...' and '\n\n1') even with
-        # temperature=0; this is a known LLaVA-1.5-on-vLLM flake, so the
-        # payload retries the validation in-process (server stays up) before
-        # CI fails. See tests/README.md "Flaky Tests" — In-Process Query Retry.
-        request_payloads=[
-            make_image_payload(
-                [
-                    "green",
-                    "white",
-                    "black",
-                    "purple",
-                    "red",
-                    "pink",
-                    "yellow",
-                    "blue",
-                    "orange",
-                ],
-                max_attempts=5,
-            )
-        ],
     ),
 ]

--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -14,10 +14,34 @@ from tests.utils.multimodal import (
 )
 from tests.utils.payload_builder import chat_payload, chat_payload_default
 
+# LLaVA 1.5 color-identification reference set: the model legitimately
+# emits these colors (though the order/subset varies across CUDA backends
+# under vLLM 0.20). Reused by every LLaVA topology that runs the standard
+# color-identification payload.
+_LLAVA_EXPECTED_COLORS = [
+    "green",
+    "white",
+    "black",
+    "purple",
+    "red",
+    "pink",
+    "yellow",
+    "blue",
+    "orange",
+]
+
+# Multiple topology keys can map to the same shell script — the topology
+# key is what makes the EngineConfig name unique; the script is just the
+# launcher. ``agg_video`` and ``epd_video`` reuse ``agg_multimodal.sh`` /
+# ``disagg_multimodal_epd.sh`` so video-specific TopologyConfigs (longer
+# timeout, delayed_start, video-only VRAM bounds) can live alongside the
+# image variants on the same model profile.
 VLLM_TOPOLOGY_SCRIPTS: dict[str, str] = {
     "agg": "agg_multimodal.sh",
+    "agg_video": "agg_multimodal.sh",
     "e_pd": "disagg_multimodal_e_pd.sh",
     "epd": "disagg_multimodal_epd.sh",
+    "epd_video": "disagg_multimodal_epd.sh",
     "p_d": "disagg_multimodal_p_d.sh",
 }
 
@@ -58,6 +82,14 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                     ),
                 ],
             ),
+            "agg_video": TopologyConfig(
+                marks=[pytest.mark.pre_merge],
+                timeout_s=600,
+                delayed_start=60,
+                profiled_vram_gib=8.2,
+                requested_vllm_kv_cache_bytes=1_719_075_000,
+                tests=[MmCase(payload=make_video_payload(["red", "static", "still"]))],
+            ),
             "e_pd": TopologyConfig(
                 marks=[pytest.mark.post_merge],
                 timeout_s=340,
@@ -72,6 +104,15 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                 single_gpu=True,
                 requested_vllm_kv_cache_bytes=1_714_881_000,
                 tests=[MmCase(payload=make_image_payload(["green"]))],
+            ),
+            "epd_video": TopologyConfig(
+                marks=[pytest.mark.post_merge],
+                timeout_s=600,
+                delayed_start=60,
+                single_gpu=True,
+                profiled_vram_gib=19.7,
+                requested_vllm_kv_cache_bytes=1_714_881_000,
+                tests=[MmCase(payload=make_video_payload(["red", "static", "still"]))],
             ),
             "p_d": TopologyConfig(
                 marks=[pytest.mark.post_merge],
@@ -106,29 +147,6 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                         marks=[pytest.mark.post_merge],
                     ),
                 ],
-            ),
-        },
-    ),
-    MultimodalModelProfile(
-        name="Qwen/Qwen3-VL-2B-Instruct",
-        short_name="qwen3-vl-2b-video",
-        topologies={
-            "agg": TopologyConfig(
-                marks=[pytest.mark.pre_merge],
-                timeout_s=600,
-                delayed_start=60,
-                profiled_vram_gib=8.2,
-                requested_vllm_kv_cache_bytes=1_719_075_000,
-                tests=[MmCase(payload=make_video_payload(["red", "static", "still"]))],
-            ),
-            "epd": TopologyConfig(
-                marks=[pytest.mark.post_merge],
-                timeout_s=600,
-                delayed_start=60,
-                single_gpu=True,
-                profiled_vram_gib=19.7,
-                requested_vllm_kv_cache_bytes=1_714_881_000,
-                tests=[MmCase(payload=make_video_payload(["red", "static", "still"]))],
             ),
         },
     ),
@@ -243,17 +261,7 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                 tests=[
                     MmCase(
                         payload=make_image_payload(
-                            [
-                                "green",
-                                "white",
-                                "black",
-                                "purple",
-                                "red",
-                                "pink",
-                                "yellow",
-                                "blue",
-                                "orange",
-                            ],
+                            _LLAVA_EXPECTED_COLORS,
                             max_attempts=5,
                         )
                     )
@@ -284,17 +292,7 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                 tests=[
                     MmCase(
                         payload=make_image_payload(
-                            [
-                                "green",
-                                "white",
-                                "black",
-                                "purple",
-                                "red",
-                                "pink",
-                                "yellow",
-                                "blue",
-                                "orange",
-                            ],
+                            _LLAVA_EXPECTED_COLORS,
                             max_attempts=5,
                         )
                     )

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import base64
 import dataclasses
 import logging
 import os
@@ -16,7 +15,7 @@ from tests.serve.common import (
     params_with_model_mark,
     run_serve_deployment,
 )
-from tests.serve.conftest import MULTIMODAL_IMG_URL, get_multimodal_test_image_bytes
+from tests.serve.conftest import MULTIMODAL_IMG_URL
 from tests.serve.lora_utils import MinioLoraConfig
 from tests.serve.multimodal_profiles.vllm import (
     VLLM_MULTIMODAL_PROFILES,
@@ -375,90 +374,6 @@ vllm_configs = {
             completion_payload_default(),
         ],
     ),
-    "multimodal_agg_frontend_decoding": VLLMConfig(
-        name="multimodal_agg_frontend_decoding",
-        directory=vllm_dir,
-        script_name="agg_multimodal.sh",
-        # post_merge-only: local pre-merge runs that compile outside docker
-        # can pick up NIXL stubs, which don't support the multimodal transfer
-        # path this case exercises. CI post_merge runs in a container with
-        # real NIXL, so keep this test there.
-        marks=[
-            pytest.mark.gpu_1,
-            pytest.mark.profiled_vram_gib(9.6),  # actual profiled peak with kv-bytes
-            pytest.mark.requested_vllm_kv_cache_bytes(
-                1_710_490_000
-            ),  # KV cache cap (2x safety over min=855_244_800)
-            pytest.mark.timeout(220),  # ~5x observed 43.7s; 2B model loads slower on CI
-            pytest.mark.post_merge,
-        ],
-        model="Qwen/Qwen2-VL-2B-Instruct",
-        env={"DYN_MM_ALLOW_INTERNAL": "1"},
-        script_args=[
-            "--model",
-            "Qwen/Qwen2-VL-2B-Instruct",
-            "--frontend-decoding",
-        ],
-        request_payloads=[
-            chat_payload(
-                [
-                    {
-                        "type": "text",
-                        "text": "What colors are in the following image? Respond only with the colors.",
-                    },
-                    {
-                        "type": "image_url",
-                        "image_url": {"url": MULTIMODAL_IMG_URL},
-                    },
-                ],
-                repeat_count=1,
-                expected_response=["green"],
-                temperature=0.0,
-                max_tokens=100,
-            )
-        ],
-    ),
-    "multimodal_agg_llava": VLLMConfig(
-        name="multimodal_agg_llava",
-        directory=vllm_dir,
-        script_name="agg_multimodal.sh",
-        marks=[
-            pytest.mark.gpu_1,
-            pytest.mark.profiled_vram_gib(19.2),  # actual profiled peak with kv-bytes
-            pytest.mark.requested_vllm_kv_cache_bytes(
-                4_318_854_000
-            ),  # KV cache cap (2x safety over min=2_159_426_560)
-            pytest.mark.timeout(360),  # 7B model; L4 machines need more headroom
-            pytest.mark.nightly,
-        ],
-        model="llava-hf/llava-1.5-7b-hf",
-        script_args=["--model", "llava-hf/llava-1.5-7b-hf"],
-        env={"DYN_MM_ALLOW_INTERNAL": "1"},
-        delayed_start=0,
-        timeout=360,
-        request_payloads=[
-            # HTTP URL test
-            chat_payload(
-                [
-                    {"type": "text", "text": "What is in this image?"},
-                    {
-                        "type": "image_url",
-                        "image_url": {
-                            "url": "http://images.cocodataset.org/test2017/000000155781.jpg"
-                        },
-                    },
-                ],
-                repeat_count=1,
-                expected_response=["bus"],
-                temperature=0.0,
-            ),
-            # String content test - verifies string → array conversion for multimodal templates
-            chat_payload_default(
-                repeat_count=1,
-                expected_response=[],  # Just validate no error
-            ),
-        ],
-    ),
     "aggregated_toolcalling": VLLMConfig(
         name="aggregated_toolcalling",
         directory=vllm_dir,
@@ -660,133 +575,6 @@ def test_serve_deployment(
     """
     config = dataclasses.replace(
         vllm_config_test, frontend_port=dynamo_dynamic_ports.frontend_port
-    )
-    run_serve_deployment(config, request, ports=dynamo_dynamic_ports)
-
-
-@pytest.mark.vllm
-@pytest.mark.e2e
-@pytest.mark.gpu_1
-@pytest.mark.nightly
-@pytest.mark.model("Qwen/Qwen2.5-VL-7B-Instruct")
-@pytest.mark.timeout(360)  # Match VLLMConfig.timeout for this multimodal deployment
-def test_multimodal_b64(
-    request,
-    runtime_services_dynamic_ports,
-    dynamo_dynamic_ports,
-    predownload_models,
-):
-    """
-    Test multimodal inference with base64 url passthrough.
-
-    This test is separate because it loads the required image at runtime
-    (not collection time), ensuring it only fails when actually executed.
-
-    Runs on gpu_1 alongside other single-GPU multimodal tests that use the
-    same model (mm_agg_qwen2.5-vl-7b).  The ``@pytest.mark.model`` mark is
-    kept as a safety net so the model is predownloaded even if no other
-    gpu_1 config collects this model in a given CI job.
-    """
-    # Load B64 image at test execution time (uses real PNG even if MULTIMODAL_IMG is LFS pointer)
-    b64_img = base64.b64encode(get_multimodal_test_image_bytes()).decode()
-
-    # Create payload with B64 image
-    b64_payload = chat_payload(
-        [
-            {
-                "type": "text",
-                "text": "What colors are in the following image? Respond only with the colors.",
-            },
-            {
-                "type": "image_url",
-                "image_url": {"url": f"data:image/png;base64,{b64_img}"},
-            },
-        ],
-        repeat_count=1,
-        expected_response=["purple"],
-        max_tokens=100,
-    )
-
-    # Create test config
-    config = VLLMConfig(
-        name="test_multimodal_b64",
-        directory=vllm_dir,
-        script_name="agg_multimodal.sh",
-        marks=[],  # markers at function-level
-        model="Qwen/Qwen2.5-VL-7B-Instruct",
-        script_args=["--model", "Qwen/Qwen2.5-VL-7B-Instruct"],
-        delayed_start=0,
-        timeout=360,
-        request_payloads=[b64_payload],
-    )
-
-    config = dataclasses.replace(
-        config, frontend_port=dynamo_dynamic_ports.frontend_port
-    )
-    run_serve_deployment(config, request, ports=dynamo_dynamic_ports)
-
-
-@pytest.mark.vllm
-@pytest.mark.e2e
-@pytest.mark.gpu_1
-@pytest.mark.pre_merge
-@pytest.mark.profiled_vram_gib(9.6)  # same Qwen3-VL-2B agg multimodal profile
-@pytest.mark.requested_vllm_kv_cache_bytes(922_354_000)
-@pytest.mark.timeout(220)
-def test_multimodal_b64_frontend_decoding(
-    request,
-    runtime_services_dynamic_ports,
-    dynamo_dynamic_ports,
-    predownload_models,
-):
-    """
-    Test multimodal inference with base64 images through frontend decoding path.
-
-    This exercises the Rust frontend image decode + NIXL RDMA transfer path
-    with inline base64 data: URIs (not HTTP URLs). Verifies that the
-    strip_inline_data_urls optimization does not break correctness.
-
-    HF predownload: same model is already listed via ``@pytest.mark.model`` on
-    ``test_serve_deployment[multimodal_video_agg]`` (pre_merge + gpu_1), so no
-    extra ``model`` mark is needed here for PR CI.
-    """
-    b64_img = base64.b64encode(get_multimodal_test_image_bytes()).decode()
-
-    b64_payload = chat_payload(
-        [
-            {
-                "type": "text",
-                "text": "What colors are in the following image? Respond only with the colors.",
-            },
-            {
-                "type": "image_url",
-                "image_url": {"url": f"data:image/png;base64,{b64_img}"},
-            },
-        ],
-        repeat_count=1,
-        expected_response=["green"],
-        temperature=0.0,
-        max_tokens=100,
-    )
-
-    config = VLLMConfig(
-        name="test_multimodal_b64_frontend_decoding",
-        directory=vllm_dir,
-        script_name="agg_multimodal.sh",
-        marks=[],
-        model="Qwen/Qwen3-VL-2B-Instruct",
-        script_args=[
-            "--model",
-            "Qwen/Qwen3-VL-2B-Instruct",
-            "--frontend-decoding",
-        ],
-        delayed_start=0,
-        timeout=220,
-        request_payloads=[b64_payload],
-    )
-
-    config = dataclasses.replace(
-        config, frontend_port=dynamo_dynamic_ports.frontend_port
     )
     run_serve_deployment(config, request, ports=dynamo_dynamic_ports)
 

--- a/tests/utils/multimodal.py
+++ b/tests/utils/multimodal.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import base64
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -9,7 +10,7 @@ from typing import Any, Optional, Type
 import pytest
 
 from dynamo.common.utils.paths import WORKSPACE_DIR
-from tests.serve.conftest import MULTIMODAL_IMG_URL
+from tests.serve.conftest import MULTIMODAL_IMG_URL, get_multimodal_test_image_bytes
 from tests.utils.engine_process import EngineConfig
 from tests.utils.payload_builder import chat_payload
 from tests.utils.payloads import BasePayload, ChatPayload
@@ -30,6 +31,11 @@ AUDIO_TEST_URL = (
 # ---------------------------------------------------------------------------
 
 
+_MULTIMODAL_COLOR_PROMPT = (
+    "What colors are in the following image? Respond only with the colors."
+)
+
+
 def make_image_payload(
     expected_response: list[str], *, max_attempts: int = 1
 ) -> ChatPayload:
@@ -42,11 +48,7 @@ def make_image_payload(
     """
     return chat_payload(
         [
-            {
-                "type": "text",
-                "text": "What colors are in the following image? "
-                "Respond only with the colors.",
-            },
+            {"type": "text", "text": _MULTIMODAL_COLOR_PROMPT},
             {
                 "type": "image_url",
                 "image_url": {"url": MULTIMODAL_IMG_URL},
@@ -57,6 +59,94 @@ def make_image_payload(
         temperature=0.0,
         max_tokens=100,
         max_attempts=max_attempts,
+    )
+
+
+class Base64LazyChatPayload(ChatPayload):
+    """ChatPayload variant that defers reading the multimodal test PNG until
+    the first `.body` access.
+
+    The LFS-tracked test image may be a pointer file when the workspace is
+    fresh; eager reads at module import (i.e. pytest collection) would fail
+    before pytest can apply the test's hardware preconditions. Materializing
+    on first `.body` read defers that I/O to test execution.
+    """
+
+    def __init__(
+        self,
+        *,
+        prompt: str,
+        expected_response: list[str],
+        max_tokens: int = 100,
+        temperature: float = 0.0,
+        repeat_count: int = 1,
+        timeout: int = 60,
+    ):
+        """Stash payload params for lazy body construction, then run parent init."""
+        # Initialize lazy state and the init flag BEFORE super().__init__ —
+        # the parent dataclass __init__ assigns self.body = ..., which routes
+        # through our @body.setter.
+        object.__setattr__(self, "_b64_initializing", True)
+        object.__setattr__(self, "_b64_prompt", prompt)
+        object.__setattr__(self, "_b64_max_tokens", max_tokens)
+        object.__setattr__(self, "_b64_temperature", temperature)
+        object.__setattr__(self, "_b64_storage", None)
+        object.__setattr__(self, "_b64_materialized", False)
+        super().__init__(
+            body=None,  # placeholder; replaced when .body is first read
+            expected_response=expected_response,
+            expected_log=[],
+            repeat_count=repeat_count,
+            timeout=timeout,
+        )
+        object.__setattr__(self, "_b64_initializing", False)
+
+    def _materialize_body(self) -> dict:
+        """Read the LFS image, base64-encode it, and build the chat body dict."""
+        b64 = base64.b64encode(get_multimodal_test_image_bytes()).decode()
+        ref = chat_payload(
+            [
+                {"type": "text", "text": self._b64_prompt},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": f"data:image/png;base64,{b64}"},
+                },
+            ],
+            repeat_count=1,
+            expected_response=list(self.expected_response),
+            max_tokens=self._b64_max_tokens,
+            temperature=self._b64_temperature,
+        )
+        return ref.body
+
+    @property
+    def body(self) -> dict:  # type: ignore[override]
+        """Return the chat body, materializing the base64 image on first access."""
+        if not self._b64_materialized:
+            object.__setattr__(self, "_b64_storage", self._materialize_body())
+            object.__setattr__(self, "_b64_materialized", True)
+        return self._b64_storage
+
+    @body.setter
+    def body(self, value) -> None:
+        """Store body; flip materialized so post-init writes survive next read."""
+        object.__setattr__(self, "_b64_storage", value)
+        if not getattr(self, "_b64_initializing", True):
+            object.__setattr__(self, "_b64_materialized", True)
+
+
+def make_image_payload_b64(expected_response: list[str]) -> ChatPayload:
+    """Inline-base64 PNG variant of :func:`make_image_payload`.
+
+    The image bytes are read lazily on first `.body` access so pytest
+    collection does not fail when the LFS image pointer has not been pulled.
+    """
+    return Base64LazyChatPayload(
+        prompt=_MULTIMODAL_COLOR_PROMPT,
+        expected_response=expected_response,
+        max_tokens=100,
+        temperature=0.0,
+        repeat_count=1,
     )
 
 
@@ -100,11 +190,40 @@ def make_audio_payload(expected_response: list[str]) -> ChatPayload:
 
 
 @dataclass
-class TopologyConfig:
-    """Per-topology overrides for marks, timeout, and VRAM profiling."""
+class MmCase:
+    """One test case emitted by a topology.
 
-    marks: list[Any] = field(default_factory=list)
-    timeout_s: int = 300
+    Each :class:`MmCase` produces exactly one ``EngineConfig`` keyed
+    ``mm_{topology}_{short_name}[_{suffix}]``. The case carries its own
+    payload (HTTP-URL, base64-inline, video, audio) and any per-case
+    overrides on top of the parent :class:`TopologyConfig`.
+
+    ``payload`` is the only required field; everything else either inherits
+    from the parent ``TopologyConfig`` (marks, timeout) or extends it
+    (extra script args, env overlay).
+    """
+
+    payload: BasePayload  # required — fully formed test payload
+    suffix: str = ""  # appended to config key; "" yields the bare topology key
+    extra_script_args: list[str] = field(default_factory=list)
+    marks: list[Any] = field(default_factory=list)  # if empty, inherit topology marks
+    timeout_s: Optional[int] = None  # if None, inherit topology timeout
+    env: dict[str, str] = field(
+        default_factory=dict
+    )  # extra env on top of topology env
+
+
+@dataclass
+class TopologyConfig:
+    """Per-topology overrides for marks, timeout, and VRAM profiling.
+
+    A topology must declare its tests explicitly via ``tests``. There is no
+    implicit HTTP-URL test — each test case (HTTP, b64, video, audio) is a
+    first-class :class:`MmCase` entry.
+    """
+
+    timeout_s: int = 300  # default for cases that don't override
+    marks: list[Any] = field(default_factory=list)  # default for cases
     profiled_vram_gib: Optional[float] = None
     requested_vllm_kv_cache_bytes: Optional[int] = None
     delayed_start: int = 0
@@ -113,20 +232,20 @@ class TopologyConfig:
     single_gpu: bool = False  # append --single-gpu to script_args
     two_gpu: bool = False  # append --two-gpu to script_args (epd only)
     env: dict[str, str] = field(default_factory=dict)  # extra env vars for subprocess
+    tests: list[MmCase] = field(default_factory=list)
 
 
 @dataclass
 class MultimodalModelProfile:
     """Describes a multimodal model's test-relevant properties.
 
-    Each profile generates one config per topology in ``topologies``
+    Each profile generates one config per :class:`MmCase` per topology
     via :func:`make_multimodal_configs`.
     """
 
     name: str  # HuggingFace model ID
     short_name: str  # kebab-case slug for config key
     topologies: dict[str, TopologyConfig]
-    request_payloads: list[BasePayload]
     gpu_marker: str = "gpu_1"
     extra_vllm_args: list[str] = field(default_factory=list)
     marks: list[Any] = field(default_factory=list)  # shared across all topologies
@@ -144,7 +263,11 @@ def make_multimodal_configs(
     directory: str,
     topology_scripts: dict[str, str],
 ) -> dict[str, EngineConfig]:
-    """Generate config entries for each topology in *profile*.
+    """Generate one ``EngineConfig`` per :class:`MmCase` per topology.
+
+    Each case in ``topology.tests`` produces a config keyed
+    ``mm_{topology}_{short_name}[_{case.suffix}]``. There is no implicit
+    HTTP-URL config — a topology with empty ``tests`` emits nothing.
 
     Parameters
     ----------
@@ -158,53 +281,60 @@ def make_multimodal_configs(
     configs: dict[str, EngineConfig] = {}
     for topology, topo_cfg in profile.topologies.items():
         script_name = topology_scripts[topology]
-        script_args = ["--model", profile.name] + profile.extra_vllm_args
+        base_script_args = ["--model", profile.name] + profile.extra_vllm_args
         if topo_cfg.single_gpu:
-            script_args.append("--single-gpu")
+            base_script_args.append("--single-gpu")
         if topo_cfg.two_gpu:
-            script_args.append("--two-gpu")
+            base_script_args.append("--two-gpu")
 
         gpu = topo_cfg.gpu_marker or profile.gpu_marker
-        marks: list[Any] = [
-            getattr(pytest.mark, gpu),
-            pytest.mark.timeout(topo_cfg.timeout_s),
-        ]
-        marks.extend(topo_cfg.marks)
-        if topo_cfg.profiled_vram_gib is not None:
-            marks.append(pytest.mark.profiled_vram_gib(topo_cfg.profiled_vram_gib))
-        if topo_cfg.requested_vllm_kv_cache_bytes is not None:
-            marks.append(
-                pytest.mark.requested_vllm_kv_cache_bytes(
-                    topo_cfg.requested_vllm_kv_cache_bytes
-                )
-            )
-        if profile.gated:
-            marks.append(
-                pytest.mark.skipif(
-                    not os.environ.get("DYN_HF_GATED_MODELS_ENABLED"),
-                    reason=(
-                        f"{profile.name} is gated; set DYN_HF_GATED_MODELS_ENABLED=1 "
-                        "with an HF_TOKEN that has accepted the license"
-                    ),
-                )
-            )
-        marks.extend(profile.marks)
-
-        key = f"mm_{topology}_{profile.short_name}"
-        worker_env = {
+        topo_env = {
             "DYN_MM_ALLOW_INTERNAL": "1",
             "DYN_MM_LOCAL_PATH": str(WORKSPACE_DIR),
             **topo_cfg.env,
         }
-        configs[key] = config_cls(
-            name=key,
-            directory=topo_cfg.directory or directory,
-            script_name=script_name,
-            model=profile.name,
-            script_args=script_args,
-            marks=marks,
-            delayed_start=topo_cfg.delayed_start,
-            request_payloads=profile.request_payloads,
-            env=worker_env,
-        )
+
+        for case in topo_cfg.tests:
+            key_suffix = f"_{case.suffix}" if case.suffix else ""
+            key = f"mm_{topology}_{profile.short_name}{key_suffix}"
+
+            timeout = case.timeout_s or topo_cfg.timeout_s
+            marks: list[Any] = [
+                getattr(pytest.mark, gpu),
+                pytest.mark.timeout(timeout),
+            ]
+            marks.extend(case.marks if case.marks else topo_cfg.marks)
+            if topo_cfg.profiled_vram_gib is not None:
+                marks.append(pytest.mark.profiled_vram_gib(topo_cfg.profiled_vram_gib))
+            if topo_cfg.requested_vllm_kv_cache_bytes is not None:
+                marks.append(
+                    pytest.mark.requested_vllm_kv_cache_bytes(
+                        topo_cfg.requested_vllm_kv_cache_bytes
+                    )
+                )
+            if profile.gated:
+                marks.append(
+                    pytest.mark.skipif(
+                        not os.environ.get("DYN_HF_GATED_MODELS_ENABLED"),
+                        reason=(
+                            f"{profile.name} is gated; set "
+                            "DYN_HF_GATED_MODELS_ENABLED=1 with an HF_TOKEN "
+                            "that has accepted the license"
+                        ),
+                    )
+                )
+            marks.extend(profile.marks)
+
+            configs[key] = config_cls(
+                name=key,
+                directory=topo_cfg.directory or directory,
+                script_name=script_name,
+                model=profile.name,
+                script_args=list(base_script_args) + list(case.extra_script_args),
+                marks=marks,
+                delayed_start=topo_cfg.delayed_start,
+                request_payloads=[case.payload],
+                env={**topo_env, **case.env},
+            )
+
     return configs


### PR DESCRIPTION
## Why

Adds first Qwen3.5 family coverage to the multimodal serve suite — a hybrid Mamba / full-attention VL architecture exercising a different KV-cache + attention path than the existing entries. While here, removes the three hand-rolled standalone base64 tests so every multimodal config is profile-driven and shares one dispatch path.

## What Change

- Add `Qwen3.5-0.8B` `agg` topology to the multimodal profile (`pre_merge`, `gpu_1`).
- Add `B64Variant` axis on `TopologyConfig` so any topology can emit an inline-base64 variant.
- Add `Base64LazyChatPayload` — defers PNG read past pytest collection (LFS-pointer safe).
- Port `frontend_decoding` b64 to `qwen3-vl-2b` and vanilla b64 to `qwen3.5-0.8b`; delete the standalone test functions.

## Test Plan

- `pytest tests/serve/test_vllm.py -m "pre_merge and gpu_1" --collect-only` — confirms `mm_agg_qwen3-vl-2b_b64_frontend_decoding` and `mm_agg_qwen3.5-0.8b_b64` collect cleanly (0.03 s, no LFS read).
- Smoke: `Base64LazyChatPayload` survives `deepcopy` + `with_model(...)` — single materialization, model injection preserved.
- `pytest tests/serve/test_vllm.py::test_serve_deployment[mm_agg_qwen3.5-0.8b_b64] -v` on a Blackwell GPU.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

**Tests**
* Refactored multimodal test infrastructure with improved per-case configuration structure
* Added new Qwen3.5-0.8B model test profile
* Removed Qwen2.5-VL-7B-Instruct model test profile
* Streamlined GPU E2E multimodal test suite

<!-- end of auto-generated comment: release notes by coderabbit.ai -->