### PR TITLE
feat: wire GMS checkpoint restore flow

### DIFF
--- a/components/src/dynamo/common/utils/snapshot.py
+++ b/components/src/dynamo/common/utils/snapshot.py
@@ -30,9 +30,9 @@ SNAPSHOT_COMPLETE_FILE = "snapshot-complete"
 RESTORE_COMPLETE_FILE = "restore-complete"
 READY_FOR_CHECKPOINT_FILE = "ready-for-checkpoint"
 
-# Poll interval for the snapshot-control directory. Checkpoint and restore
-# latencies are seconds, so 100ms is negligible overhead.
-_SENTINEL_POLL_INTERVAL_SEC = 0.1
+# Poll interval for the snapshot-control directory. Restore can now be
+# GMS-bound at sub-second scale, so keep the handoff poll short.
+_SENTINEL_POLL_INTERVAL_SEC = 0.05
 
 
 class CheckpointConfig:

--- a/components/src/dynamo/sglang/tests/test_sglang_gms_memory_saver.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_gms_memory_saver.py
@@ -141,7 +141,7 @@ def test_pause_resume_routes_only_managed_tags(build_impl):
     assert weights.calls == [
         "unmap_all_vas",
         "abort",
-        ("connect", RequestedLockType.RO, 30_000),
+        ("connect", RequestedLockType.RO, None),
         "remap_all_vas",
     ]
     assert kv_cache.calls == [

--- a/components/src/dynamo/sglang/tests/test_sglang_gms_memory_saver.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_gms_memory_saver.py
@@ -46,8 +46,8 @@ class _FakeManager:
         self.calls.append("abort")
         self.granted_lock_type = None
 
-    def connect(self, lock_type) -> None:
-        self.calls.append(("connect", lock_type))
+    def connect(self, lock_type, timeout_ms=None) -> None:
+        self.calls.append(("connect", lock_type, timeout_ms))
         self.granted_lock_type = GrantedLockType(lock_type.value)
         self.is_unmapped = False
 
@@ -141,13 +141,13 @@ def test_pause_resume_routes_only_managed_tags(build_impl):
     assert weights.calls == [
         "unmap_all_vas",
         "abort",
-        ("connect", RequestedLockType.RO),
+        ("connect", RequestedLockType.RO, 30_000),
         "remap_all_vas",
     ]
     assert kv_cache.calls == [
         "unmap_all_vas",
         "abort",
-        ("connect", RequestedLockType.RW),
+        ("connect", RequestedLockType.RW, None),
         ("reallocate_all_handles", "kv_cache"),
         "remap_all_vas",
     ]

--- a/deploy/operator/api/v1alpha1/common.go
+++ b/deploy/operator/api/v1alpha1/common.go
@@ -167,15 +167,13 @@ const (
 	GMSModeIntraPod GPUMemoryServiceMode = "intraPod"
 	// GMSModeInterPod runs GMS as a separate weight server pod and one or more
 	// engine pods per rank, sharing GPUs via DRA ResourceClaims and a shared
-	// hostPath volume for UDS sockets. Only valid on FailoverSpec; the
-	// GPUMemoryServiceSpec sidecar always runs in intraPod mode.
+	// hostPath volume for UDS sockets.
 	GMSModeInterPod GPUMemoryServiceMode = "interPod"
 )
 
-// GPUMemoryServiceSpec configures the GPU Memory Service (GMS) sidecar for a worker component.
-// When enabled, the operator injects a GMS sidecar that provides shared GPU memory access
-// via DRA (Dynamic Resource Allocation). The sidecar runs two GMS processes per GPU
-// (weights + kv_cache) and communicates with the main container over UDS sockets.
+// GPUMemoryServiceSpec configures GPU Memory Service (GMS) for a worker component.
+// In intraPod mode, the operator injects a GMS server sidecar in the workload pod.
+// In interPod mode, the operator creates a dedicated GMS weight-server pod per rank.
 type GPUMemoryServiceSpec struct {
 	// Enabled activates the GMS sidecar. GPU resources on the main container
 	// are replaced with a DRA ResourceClaim for shared GPU access.

--- a/deploy/operator/internal/checkpoint/checkpoint_test.go
+++ b/deploy/operator/internal/checkpoint/checkpoint_test.go
@@ -610,30 +610,17 @@ func TestInjectCheckpointIntoPodSpec(t *testing.T) {
 
 		require.NoError(t, InjectCheckpointIntoPodSpec(context.Background(), reader, testNamespace, podSpec, info, snapshotprotocol.DefaultSeccompLocalhostProfile))
 		require.NoError(t, InjectCheckpointIntoPodSpec(context.Background(), reader, testNamespace, podSpec, info, snapshotprotocol.DefaultSeccompLocalhostProfile))
-		gmsServer := findContainer(podSpec, gms.ServerContainerName)
+		gmsServer := findInitContainer(podSpec, gms.ServerContainerName)
 		require.NotNil(t, gmsServer)
 		loader := findContainer(podSpec, GMSLoaderContainer)
 		require.NotNil(t, loader)
-		serverCount := 0
-		loaderCount := 0
-		for _, container := range podSpec.InitContainers {
-			switch container.Name {
-			case gms.ServerContainerName:
-				serverCount++
-			case GMSLoaderContainer:
-				loaderCount++
-			}
-		}
-		assert.Equal(t, 1, serverCount)
-		assert.Equal(t, 1, loaderCount)
 
-		require.Len(t, podSpec.Containers, 3)
-		assert.Equal(t, gms.ServerContainerName, podSpec.Containers[1].Name)
-		assert.Equal(t, GMSLoaderContainer, podSpec.Containers[2].Name)
-		assert.Nil(t, findInitContainer(podSpec, gms.ServerContainerName))
+		require.Len(t, podSpec.Containers, 2)
+		assert.Equal(t, GMSLoaderContainer, podSpec.Containers[1].Name)
 		assert.Nil(t, findInitContainer(podSpec, GMSLoaderContainer))
-		assert.Nil(t, gmsServer.RestartPolicy, "restore gms-server should be a regular container")
-		assert.Nil(t, gmsServer.StartupProbe, "restore gms-server should not have StartupProbe")
+		require.NotNil(t, gmsServer.RestartPolicy)
+		assert.Equal(t, corev1.ContainerRestartPolicyAlways, *gmsServer.RestartPolicy)
+		assert.NotNil(t, gmsServer.StartupProbe)
 		assert.Nil(t, loader.RestartPolicy, "restore gms-loader should be a regular container")
 
 		mounts := map[string]string{}

--- a/deploy/operator/internal/checkpoint/checkpoint_test.go
+++ b/deploy/operator/internal/checkpoint/checkpoint_test.go
@@ -646,6 +646,7 @@ func TestInjectCheckpointIntoPodSpec(t *testing.T) {
 			env[item.Name] = item.Value
 		}
 		assert.Equal(t, "/checkpoints/gms/"+testHash+"/versions/1", env["GMS_CHECKPOINT_DIR"])
+		assert.Equal(t, "/checkpoints/gms/"+testHash+"/versions/1", info.GMSArtifactDir)
 		assert.Equal(t, []string{"python3", "-m", "gpu_memory_service.cli.server"}, gmsServer.Command)
 		assert.Equal(t, []string{"python3", "-m", "gpu_memory_service.cli.snapshot.loader"}, loader.Command)
 	})
@@ -879,14 +880,36 @@ func TestApplyRestorePodMetadata_FailoverTargets(t *testing.T) {
 	assert.Equal(t, "engine-0,engine-1", annotations[snapshotprotocol.TargetContainersAnnotation])
 }
 
+func TestApplyRestorePodMetadata_GMSArtifactDir(t *testing.T) {
+	labels := map[string]string{}
+	annotations := map[string]string{}
+	ApplyRestorePodMetadata(labels, annotations, &CheckpointInfo{
+		Enabled: true,
+		Ready:   true,
+		Hash:    testHash,
+		GPUMemoryService: &nvidiacomv1alpha1.GPUMemoryServiceSpec{
+			Enabled: true,
+		},
+		GMSArtifactDir: "/checkpoints/gms/" + testHash + "/versions/1",
+	})
+	assert.Equal(t, "/checkpoints/gms/"+testHash+"/versions/1", annotations[snapshotprotocol.GMSCheckpointDirAnnotation])
+	assert.Equal(t, snapshotprotocol.GMSCompletionFileModePodUID, annotations[snapshotprotocol.GMSCompletionFileModeAnnotation])
+}
+
 func TestApplyRestorePodMetadata_DisabledClearsAnnotation(t *testing.T) {
 	labels := map[string]string{}
 	annotations := map[string]string{
-		snapshotprotocol.TargetContainersAnnotation: "stale",
+		snapshotprotocol.TargetContainersAnnotation:      "stale",
+		snapshotprotocol.GMSCheckpointDirAnnotation:      "stale",
+		snapshotprotocol.GMSCompletionFileModeAnnotation: "stale",
 	}
 	ApplyRestorePodMetadata(labels, annotations, &CheckpointInfo{Enabled: false})
 	_, ok := annotations[snapshotprotocol.TargetContainersAnnotation]
 	assert.False(t, ok, "target-containers annotation must be cleared when checkpoint disabled")
+	_, ok = annotations[snapshotprotocol.GMSCheckpointDirAnnotation]
+	assert.False(t, ok, "gms checkpoint dir annotation must be cleared when checkpoint disabled")
+	_, ok = annotations[snapshotprotocol.GMSCompletionFileModeAnnotation]
+	assert.False(t, ok, "gms completion file mode annotation must be cleared when checkpoint disabled")
 }
 
 // findContainer is a test helper that locates a container by name across both

--- a/deploy/operator/internal/checkpoint/checkpoint_test.go
+++ b/deploy/operator/internal/checkpoint/checkpoint_test.go
@@ -869,36 +869,14 @@ func TestApplyRestorePodMetadata_FailoverTargets(t *testing.T) {
 	assert.Equal(t, "engine-0,engine-1", annotations[snapshotprotocol.TargetContainersAnnotation])
 }
 
-func TestApplyRestorePodMetadata_GMSArtifactDir(t *testing.T) {
-	labels := map[string]string{}
-	annotations := map[string]string{}
-	ApplyRestorePodMetadata(labels, annotations, &CheckpointInfo{
-		Enabled: true,
-		Ready:   true,
-		Hash:    testHash,
-		GPUMemoryService: &nvidiacomv1alpha1.GPUMemoryServiceSpec{
-			Enabled: true,
-		},
-		GMSArtifactDir: "/checkpoints/gms/" + testHash + "/versions/1",
-	})
-	assert.Equal(t, "/checkpoints/gms/"+testHash+"/versions/1", annotations[snapshotprotocol.GMSCheckpointDirAnnotation])
-	assert.Equal(t, snapshotprotocol.GMSCompletionFileModePodUID, annotations[snapshotprotocol.GMSCompletionFileModeAnnotation])
-}
-
 func TestApplyRestorePodMetadata_DisabledClearsAnnotation(t *testing.T) {
 	labels := map[string]string{}
 	annotations := map[string]string{
-		snapshotprotocol.TargetContainersAnnotation:      "stale",
-		snapshotprotocol.GMSCheckpointDirAnnotation:      "stale",
-		snapshotprotocol.GMSCompletionFileModeAnnotation: "stale",
+		snapshotprotocol.TargetContainersAnnotation: "stale",
 	}
 	ApplyRestorePodMetadata(labels, annotations, &CheckpointInfo{Enabled: false})
 	_, ok := annotations[snapshotprotocol.TargetContainersAnnotation]
 	assert.False(t, ok, "target-containers annotation must be cleared when checkpoint disabled")
-	_, ok = annotations[snapshotprotocol.GMSCheckpointDirAnnotation]
-	assert.False(t, ok, "gms checkpoint dir annotation must be cleared when checkpoint disabled")
-	_, ok = annotations[snapshotprotocol.GMSCompletionFileModeAnnotation]
-	assert.False(t, ok, "gms completion file mode annotation must be cleared when checkpoint disabled")
 }
 
 // findContainer is a test helper that locates a container by name across both

--- a/deploy/operator/internal/checkpoint/checkpoint_test.go
+++ b/deploy/operator/internal/checkpoint/checkpoint_test.go
@@ -627,12 +627,14 @@ func TestInjectCheckpointIntoPodSpec(t *testing.T) {
 		assert.Equal(t, 1, serverCount)
 		assert.Equal(t, 1, loaderCount)
 
-		// Restore: server and loader are init sidecars (restartPolicy=Always)
-		assert.NotNil(t, gmsServer.RestartPolicy, "restore gms-server should have RestartPolicy")
-		assert.Equal(t, corev1.ContainerRestartPolicyAlways, *gmsServer.RestartPolicy)
+		require.Len(t, podSpec.Containers, 3)
+		assert.Equal(t, gms.ServerContainerName, podSpec.Containers[1].Name)
+		assert.Equal(t, GMSLoaderContainer, podSpec.Containers[2].Name)
+		assert.Nil(t, findInitContainer(podSpec, gms.ServerContainerName))
+		assert.Nil(t, findInitContainer(podSpec, GMSLoaderContainer))
+		assert.Nil(t, gmsServer.RestartPolicy, "restore gms-server should be a regular container")
 		assert.Nil(t, gmsServer.StartupProbe, "restore gms-server should not have StartupProbe")
-		assert.NotNil(t, loader.RestartPolicy, "restore gms-loader should have RestartPolicy")
-		assert.Equal(t, corev1.ContainerRestartPolicyAlways, *loader.RestartPolicy)
+		assert.Nil(t, loader.RestartPolicy, "restore gms-loader should be a regular container")
 
 		mounts := map[string]string{}
 		for _, mount := range loader.VolumeMounts {
@@ -920,6 +922,15 @@ func findContainer(podSpec *corev1.PodSpec, name string) *corev1.Container {
 			return &podSpec.Containers[i]
 		}
 	}
+	for i := range podSpec.InitContainers {
+		if podSpec.InitContainers[i].Name == name {
+			return &podSpec.InitContainers[i]
+		}
+	}
+	return nil
+}
+
+func findInitContainer(podSpec *corev1.PodSpec, name string) *corev1.Container {
 	for i := range podSpec.InitContainers {
 		if podSpec.InitContainers[i].Name == name {
 			return &podSpec.InitContainers[i]

--- a/deploy/operator/internal/checkpoint/checkpoint_test.go
+++ b/deploy/operator/internal/checkpoint/checkpoint_test.go
@@ -620,7 +620,7 @@ func TestInjectCheckpointIntoPodSpec(t *testing.T) {
 		assert.Nil(t, findInitContainer(podSpec, GMSLoaderContainer))
 		require.NotNil(t, gmsServer.RestartPolicy)
 		assert.Equal(t, corev1.ContainerRestartPolicyAlways, *gmsServer.RestartPolicy)
-		assert.NotNil(t, gmsServer.StartupProbe)
+		assert.Nil(t, gmsServer.StartupProbe)
 		assert.Nil(t, loader.RestartPolicy, "restore gms-loader should be a regular container")
 
 		mounts := map[string]string{}

--- a/deploy/operator/internal/checkpoint/gms.go
+++ b/deploy/operator/internal/checkpoint/gms.go
@@ -19,12 +19,15 @@ const (
 	GMSLoaderContainer = "gms-loader"
 	GMSSaverContainer  = "gms-saver"
 
-	gmsCheckpointLoaderModule = "gpu_memory_service.cli.snapshot.loader"
-	gmsCheckpointSaverModule  = "gpu_memory_service.cli.snapshot.saver"
+	GMSCheckpointLoaderModule = "gpu_memory_service.cli.snapshot.loader"
+	GMSCheckpointSaverModule  = "gpu_memory_service.cli.snapshot.saver"
 
-	// envCheckpointDir is the environment variable name for the GMS
+	// EnvCheckpointDir is the environment variable name for the GMS
 	// checkpoint artifact directory on the snapshot PVC.
-	envCheckpointDir = "GMS_CHECKPOINT_DIR"
+	EnvCheckpointDir = "GMS_CHECKPOINT_DIR"
+	// EnvPodUID exposes metadata.uid to GMS saver/loader sidecars so their
+	// completion files are unique per pod attempt.
+	EnvPodUID = "GMS_POD_UID"
 )
 
 // EnsureGMSRestoreSidecars appends restartable init sidecars for GMS restore.
@@ -54,9 +57,12 @@ func EnsureGMSRestoreSidecars(
 	server := gms.Container(gms.ServerContainerName, gms.ServerModule, mainContainer.Image)
 	server.RestartPolicy = ptr.To(corev1.ContainerRestartPolicyAlways)
 
-	loader := gms.Container(GMSLoaderContainer, gmsCheckpointLoaderModule, mainContainer.Image)
+	loader := gms.Container(GMSLoaderContainer, GMSCheckpointLoaderModule, mainContainer.Image)
 	loader.VolumeMounts = append(loader.VolumeMounts, corev1.VolumeMount{Name: snapshotprotocol.CheckpointVolumeName, MountPath: storage.BasePath})
-	loader.Env = append(loader.Env, corev1.EnvVar{Name: envCheckpointDir, Value: resolveGMSArtifactDir(storage)})
+	loader.Env = append(loader.Env,
+		corev1.EnvVar{Name: EnvCheckpointDir, Value: ResolveGMSArtifactDir(storage)},
+		PodUIDEnvVar(),
+	)
 	loader.RestartPolicy = ptr.To(corev1.ContainerRestartPolicyAlways)
 
 	podSpec.InitContainers = append(podSpec.InitContainers, server, loader)
@@ -79,14 +85,17 @@ func EnsureGMSCheckpointJobSidecars(
 		return fmt.Errorf("gms checkpoint jobs require resolved checkpoint storage")
 	}
 
-	gmsArtifactDir := resolveGMSArtifactDir(storage)
+	gmsArtifactDir := ResolveGMSArtifactDir(storage)
 
 	gms.EnsureServerSidecar(podSpec, mainContainer)
 	snapshotprotocol.InjectCheckpointVolume(podSpec, storage.PVCName)
 
-	saver := gms.Container(GMSSaverContainer, gmsCheckpointSaverModule, mainContainer.Image)
+	saver := gms.Container(GMSSaverContainer, GMSCheckpointSaverModule, mainContainer.Image)
 	saver.VolumeMounts = append(saver.VolumeMounts, corev1.VolumeMount{Name: snapshotprotocol.CheckpointVolumeName, MountPath: storage.BasePath})
-	saver.Env = append(saver.Env, corev1.EnvVar{Name: envCheckpointDir, Value: gmsArtifactDir})
+	saver.Env = append(saver.Env,
+		corev1.EnvVar{Name: EnvCheckpointDir, Value: gmsArtifactDir},
+		PodUIDEnvVar(),
+	)
 	// The saver is an init sidecar (restartPolicy=Always) so it doesn't
 	// affect pod Ready (only the worker's probe matters) and doesn't block
 	// Job completion. It saves, then sleeps until the pod terminates.
@@ -95,7 +104,18 @@ func EnsureGMSCheckpointJobSidecars(
 	return nil
 }
 
-func resolveGMSArtifactDir(storage snapshotprotocol.Storage) string {
+func PodUIDEnvVar() corev1.EnvVar {
+	return corev1.EnvVar{
+		Name: EnvPodUID,
+		ValueFrom: &corev1.EnvVarSource{
+			FieldRef: &corev1.ObjectFieldSelector{
+				FieldPath: "metadata.uid",
+			},
+		},
+	}
+}
+
+func ResolveGMSArtifactDir(storage snapshotprotocol.Storage) string {
 	// GMS data lives under /checkpoints/gms/<hash>/versions/<version>
 	// separate from the CRIU tree (/checkpoints/<hash>/versions/<version>)
 	// so the non-root saver can create directories at the PVC root.

--- a/deploy/operator/internal/checkpoint/gms.go
+++ b/deploy/operator/internal/checkpoint/gms.go
@@ -30,9 +30,10 @@ const (
 	EnvPodUID = "GMS_POD_UID"
 )
 
-// EnsureGMSRestoreSidecars appends restartable init sidecars for GMS restore.
-// The server must be ready before CRIU resumes the target process, while the
-// loader continues running alongside regular containers.
+// EnsureGMSRestoreSidecars appends GMS server + loader containers to the pod
+// spec for a checkpoint restore. They are regular containers so Kubernetes can
+// start them in parallel with the restore target; snapshot-agent only needs the
+// restore target's container ID before it can launch nsrestore.
 func EnsureGMSRestoreSidecars(
 	podSpec *corev1.PodSpec,
 	mainContainer *corev1.Container,
@@ -42,20 +43,10 @@ func EnsureGMSRestoreSidecars(
 		return
 	}
 
-	// Re-append restore sidecars in a deterministic order.
-	initContainers := podSpec.InitContainers[:0]
-	for _, container := range podSpec.InitContainers {
-		if container.Name != gms.ServerContainerName && container.Name != GMSLoaderContainer {
-			initContainers = append(initContainers, container)
-		}
-	}
-	podSpec.InitContainers = initContainers
 	gms.EnsureSharedVolume(podSpec, mainContainer)
-
 	snapshotprotocol.InjectCheckpointVolume(podSpec, storage.PVCName)
 
 	server := gms.Container(gms.ServerContainerName, gms.ServerModule, mainContainer.Image)
-	server.RestartPolicy = ptr.To(corev1.ContainerRestartPolicyAlways)
 
 	loader := gms.Container(GMSLoaderContainer, GMSCheckpointLoaderModule, mainContainer.Image)
 	loader.VolumeMounts = append(loader.VolumeMounts, corev1.VolumeMount{Name: snapshotprotocol.CheckpointVolumeName, MountPath: storage.BasePath})
@@ -63,9 +54,10 @@ func EnsureGMSRestoreSidecars(
 		corev1.EnvVar{Name: EnvCheckpointDir, Value: ResolveGMSArtifactDir(storage)},
 		PodUIDEnvVar(),
 	)
-	loader.RestartPolicy = ptr.To(corev1.ContainerRestartPolicyAlways)
 
-	podSpec.InitContainers = append(podSpec.InitContainers, server, loader)
+	podSpec.InitContainers = removeGMSRestoreSidecars(podSpec.InitContainers)
+	podSpec.Containers = removeGMSRestoreSidecars(podSpec.Containers)
+	podSpec.Containers = append(podSpec.Containers, server, loader)
 }
 
 // EnsureGMSCheckpointJobSidecars adds GMS server (init) + saver containers
@@ -122,4 +114,15 @@ func ResolveGMSArtifactDir(storage snapshotprotocol.Storage) string {
 	artifactVersion := filepath.Base(storage.Location)
 	checkpointID := filepath.Base(filepath.Dir(filepath.Dir(storage.Location)))
 	return filepath.Join(storage.BasePath, "gms", checkpointID, "versions", artifactVersion)
+}
+
+func removeGMSRestoreSidecars(containers []corev1.Container) []corev1.Container {
+	filtered := containers[:0]
+	for _, container := range containers {
+		if container.Name == gms.ServerContainerName || container.Name == GMSLoaderContainer {
+			continue
+		}
+		filtered = append(filtered, container)
+	}
+	return filtered
 }

--- a/deploy/operator/internal/checkpoint/gms.go
+++ b/deploy/operator/internal/checkpoint/gms.go
@@ -12,7 +12,6 @@ import (
 	gms "github.com/ai-dynamo/dynamo/deploy/operator/internal/gms"
 	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/utils/ptr"
 )
 
 const (
@@ -30,10 +29,9 @@ const (
 	EnvPodUID = "GMS_POD_UID"
 )
 
-// EnsureGMSRestoreSidecars appends GMS server + loader containers to the pod
-// spec for a checkpoint restore. They are regular containers so Kubernetes can
-// start them in parallel with the restore target; snapshot-agent only needs the
-// restore target's container ID before it can launch nsrestore.
+// EnsureGMSRestoreSidecars adds the GMS server init sidecar and restore loader.
+// The server startup probe gates socket readiness before the regular containers
+// start; the loader then overlaps GMS weight loading with snapshot restore.
 func EnsureGMSRestoreSidecars(
 	podSpec *corev1.PodSpec,
 	mainContainer *corev1.Container,
@@ -43,10 +41,9 @@ func EnsureGMSRestoreSidecars(
 		return
 	}
 
-	gms.EnsureSharedVolume(podSpec, mainContainer)
+	podSpec.InitContainers = removeGMSManagedContainers(podSpec.InitContainers, gms.ServerContainerName, GMSLoaderContainer)
+	gms.EnsureServerSidecar(podSpec, mainContainer)
 	snapshotprotocol.InjectCheckpointVolume(podSpec, storage.PVCName)
-
-	server := gms.Container(gms.ServerContainerName, gms.ServerModule, mainContainer.Image)
 
 	loader := gms.Container(GMSLoaderContainer, GMSCheckpointLoaderModule, mainContainer.Image)
 	loader.VolumeMounts = append(loader.VolumeMounts, corev1.VolumeMount{Name: snapshotprotocol.CheckpointVolumeName, MountPath: storage.BasePath})
@@ -55,13 +52,12 @@ func EnsureGMSRestoreSidecars(
 		PodUIDEnvVar(),
 	)
 
-	podSpec.InitContainers = removeGMSRestoreSidecars(podSpec.InitContainers)
-	podSpec.Containers = removeGMSRestoreSidecars(podSpec.Containers)
-	podSpec.Containers = append(podSpec.Containers, server, loader)
+	podSpec.Containers = removeGMSManagedContainers(podSpec.Containers, gms.ServerContainerName, GMSLoaderContainer)
+	podSpec.Containers = append(podSpec.Containers, loader)
 }
 
-// EnsureGMSCheckpointJobSidecars adds GMS server (init) + saver containers
-// to the pod spec for a checkpoint job.
+// EnsureGMSCheckpointJobSidecars adds the GMS server init sidecar and checkpoint
+// saver. The saver is a regular Job container so the Job completes after save.
 func EnsureGMSCheckpointJobSidecars(
 	podSpec *corev1.PodSpec,
 	mainContainer *corev1.Container,
@@ -79,6 +75,7 @@ func EnsureGMSCheckpointJobSidecars(
 
 	gmsArtifactDir := ResolveGMSArtifactDir(storage)
 
+	podSpec.InitContainers = removeGMSManagedContainers(podSpec.InitContainers, gms.ServerContainerName, GMSSaverContainer)
 	gms.EnsureServerSidecar(podSpec, mainContainer)
 	snapshotprotocol.InjectCheckpointVolume(podSpec, storage.PVCName)
 
@@ -88,11 +85,8 @@ func EnsureGMSCheckpointJobSidecars(
 		corev1.EnvVar{Name: EnvCheckpointDir, Value: gmsArtifactDir},
 		PodUIDEnvVar(),
 	)
-	// The saver is an init sidecar (restartPolicy=Always) so it doesn't
-	// affect pod Ready (only the worker's probe matters) and doesn't block
-	// Job completion. It saves, then sleeps until the pod terminates.
-	saver.RestartPolicy = ptr.To(corev1.ContainerRestartPolicyAlways)
-	podSpec.InitContainers = append(podSpec.InitContainers, saver)
+	podSpec.Containers = removeGMSManagedContainers(podSpec.Containers, gms.ServerContainerName, GMSSaverContainer)
+	podSpec.Containers = append(podSpec.Containers, saver)
 	return nil
 }
 
@@ -116,10 +110,15 @@ func ResolveGMSArtifactDir(storage snapshotprotocol.Storage) string {
 	return filepath.Join(storage.BasePath, "gms", checkpointID, "versions", artifactVersion)
 }
 
-func removeGMSRestoreSidecars(containers []corev1.Container) []corev1.Container {
+func removeGMSManagedContainers(containers []corev1.Container, names ...string) []corev1.Container {
+	managed := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		managed[name] = struct{}{}
+	}
+
 	filtered := containers[:0]
 	for _, container := range containers {
-		if container.Name == gms.ServerContainerName || container.Name == GMSLoaderContainer {
+		if _, ok := managed[container.Name]; ok {
 			continue
 		}
 		filtered = append(filtered, container)

--- a/deploy/operator/internal/checkpoint/podspec.go
+++ b/deploy/operator/internal/checkpoint/podspec.go
@@ -72,8 +72,6 @@ func ApplyRestorePodMetadataWithStorageConfig(
 		delete(annotations, snapshotprotocol.TargetContainersAnnotation)
 		delete(annotations, snapshotprotocol.CheckpointStorageTypeAnnotation)
 		delete(annotations, snapshotprotocol.CheckpointStorageBasePathAnnotation)
-		delete(annotations, snapshotprotocol.GMSCheckpointDirAnnotation)
-		delete(annotations, snapshotprotocol.GMSCompletionFileModeAnnotation)
 	}
 	if !enabled {
 		return nil
@@ -86,17 +84,6 @@ func ApplyRestorePodMetadataWithStorageConfig(
 	annotations[snapshotprotocol.TargetContainersAnnotation] = snapshotprotocol.FormatTargetContainers(targets)
 	if ok {
 		snapshotprotocol.ApplyCheckpointStorageMetadata(annotations, storage)
-	}
-	if checkpointInfo.GPUMemoryService != nil && checkpointInfo.GPUMemoryService.Enabled && checkpointInfo.GMSArtifactDir != "" {
-		annotations[snapshotprotocol.GMSCheckpointDirAnnotation] = checkpointInfo.GMSArtifactDir
-		if checkpointInfo.GPUMemoryService.Mode == nvidiacomv1alpha1.GMSModeInterPod {
-			annotations[snapshotprotocol.GMSCompletionFileModeAnnotation] = snapshotprotocol.GMSCompletionFileModeShared
-		} else {
-			annotations[snapshotprotocol.GMSCompletionFileModeAnnotation] = snapshotprotocol.GMSCompletionFileModePodUID
-		}
-	} else {
-		delete(annotations, snapshotprotocol.GMSCheckpointDirAnnotation)
-		delete(annotations, snapshotprotocol.GMSCompletionFileModeAnnotation)
 	}
 	return nil
 }

--- a/deploy/operator/internal/checkpoint/podspec.go
+++ b/deploy/operator/internal/checkpoint/podspec.go
@@ -230,6 +230,10 @@ func injectCheckpointIntoPodSpec(
 		if info.GPUMemoryService.Mode == nvidiacomv1alpha1.GMSModeInterPod {
 			return nil
 		}
+		// GMS today is wired to a single main container. Multi-target
+		// (failover) support for GMS is tracked separately; stick to
+		// the legacy main-container path so single-engine GMS restore
+		// continues to work.
 		mainContainer, err := RequireMainContainer(podSpec)
 		if err != nil {
 			return fmt.Errorf("gpuMemoryService enabled: %w", err)

--- a/deploy/operator/internal/checkpoint/podspec.go
+++ b/deploy/operator/internal/checkpoint/podspec.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
+	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	corev1 "k8s.io/api/core/v1"
@@ -71,6 +72,8 @@ func ApplyRestorePodMetadataWithStorageConfig(
 		delete(annotations, snapshotprotocol.TargetContainersAnnotation)
 		delete(annotations, snapshotprotocol.CheckpointStorageTypeAnnotation)
 		delete(annotations, snapshotprotocol.CheckpointStorageBasePathAnnotation)
+		delete(annotations, snapshotprotocol.GMSCheckpointDirAnnotation)
+		delete(annotations, snapshotprotocol.GMSCompletionFileModeAnnotation)
 	}
 	if !enabled {
 		return nil
@@ -83,6 +86,17 @@ func ApplyRestorePodMetadataWithStorageConfig(
 	annotations[snapshotprotocol.TargetContainersAnnotation] = snapshotprotocol.FormatTargetContainers(targets)
 	if ok {
 		snapshotprotocol.ApplyCheckpointStorageMetadata(annotations, storage)
+	}
+	if checkpointInfo.GPUMemoryService != nil && checkpointInfo.GPUMemoryService.Enabled && checkpointInfo.GMSArtifactDir != "" {
+		annotations[snapshotprotocol.GMSCheckpointDirAnnotation] = checkpointInfo.GMSArtifactDir
+		if checkpointInfo.GPUMemoryService.Mode == nvidiacomv1alpha1.GMSModeInterPod {
+			annotations[snapshotprotocol.GMSCompletionFileModeAnnotation] = snapshotprotocol.GMSCompletionFileModeShared
+		} else {
+			annotations[snapshotprotocol.GMSCompletionFileModeAnnotation] = snapshotprotocol.GMSCompletionFileModePodUID
+		}
+	} else {
+		delete(annotations, snapshotprotocol.GMSCheckpointDirAnnotation)
+		delete(annotations, snapshotprotocol.GMSCompletionFileModeAnnotation)
 	}
 	return nil
 }
@@ -209,6 +223,13 @@ func injectCheckpointIntoPodSpec(
 		EnsurePodInfoMount(container)
 	}
 	if info.Ready && info.GPUMemoryService != nil && info.GPUMemoryService.Enabled {
+		if len(info.RestoreTargetContainers) > 0 {
+			return fmt.Errorf("gpuMemoryService checkpoint restore is not supported with multiple restore targets")
+		}
+		info.GMSArtifactDir = ResolveGMSArtifactDir(storage)
+		if info.GPUMemoryService.Mode == nvidiacomv1alpha1.GMSModeInterPod {
+			return nil
+		}
 		mainContainer, err := RequireMainContainer(podSpec)
 		if err != nil {
 			return fmt.Errorf("gpuMemoryService enabled: %w", err)

--- a/deploy/operator/internal/checkpoint/resolve.go
+++ b/deploy/operator/internal/checkpoint/resolve.go
@@ -36,7 +36,14 @@ type CheckpointInfo struct {
 	ArtifactVersion  string
 	CheckpointName   string
 	Ready            bool
-	// Empty means the restore pod targets the default main container.
+	GMSArtifactDir   string
+	// RestoreTargetContainers is the list of container names in the
+	// restore pod that the snapshot agent should restore the checkpoint
+	// into. Empty means "use the default target" (the container named
+	// commonconsts.MainContainerName). The intra-pod-failover path
+	// populates this with engine-0/engine-1 so the agent restores the
+	// same checkpoint into both the primary and the shadow engine; see
+	// ApplyFailoverTargets.
 	RestoreTargetContainers []string
 }
 

--- a/deploy/operator/internal/controller/checkpoint_job.go
+++ b/deploy/operator/internal/controller/checkpoint_job.go
@@ -140,8 +140,6 @@ func buildCheckpointJob(
 		if err != nil {
 			return nil, err
 		}
-		podTemplate.Annotations[snapshotprotocol.GMSCheckpointDirAnnotation] = checkpoint.ResolveGMSArtifactDir(storage)
-		podTemplate.Annotations[snapshotprotocol.GMSCompletionFileModeAnnotation] = snapshotprotocol.GMSCompletionFileModePodUID
 		if err := checkpoint.EnsureGMSCheckpointJobSidecars(&podTemplate.Spec, mainContainer, storage); err != nil {
 			return nil, err
 		}

--- a/deploy/operator/internal/controller/checkpoint_job.go
+++ b/deploy/operator/internal/controller/checkpoint_job.go
@@ -99,6 +99,12 @@ func buildCheckpointJob(
 	)
 	dynamo.AddStandardEnvVars(mainContainer, config)
 
+	if ckpt.Spec.GPUMemoryService != nil && ckpt.Spec.GPUMemoryService.Enabled {
+		if backendFramework, err := dynamo.ParseBackendFramework(ckpt.Spec.Identity.BackendFramework); err == nil && backendFramework == dynamo.BackendFrameworkVLLM {
+			dynamo.EnsureVLLMGMSLoadFormat(mainContainer)
+		}
+	}
+
 	checkpoint.EnsurePodInfoMount(mainContainer)
 	dynamo.ApplySharedMemoryVolumeAndMount(&podTemplate.Spec, mainContainer, dynamo.ToBetaSharedMemorySize(ckpt.Spec.Job.SharedMemory))
 	// NewCheckpointJob handles control volume + readiness probe from the
@@ -134,6 +140,8 @@ func buildCheckpointJob(
 		if err != nil {
 			return nil, err
 		}
+		podTemplate.Annotations[snapshotprotocol.GMSCheckpointDirAnnotation] = checkpoint.ResolveGMSArtifactDir(storage)
+		podTemplate.Annotations[snapshotprotocol.GMSCompletionFileModeAnnotation] = snapshotprotocol.GMSCompletionFileModePodUID
 		if err := checkpoint.EnsureGMSCheckpointJobSidecars(&podTemplate.Spec, mainContainer, storage); err != nil {
 			return nil, err
 		}

--- a/deploy/operator/internal/controller/dynamocheckpoint_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocheckpoint_controller_test.go
@@ -384,6 +384,8 @@ func TestBuildCheckpointJobAddsGMSSidecars(t *testing.T) {
 		mainMounts[m.Name] = m.MountPath
 	}
 	assert.Equal(t, gms.SharedMountPath, mainMounts[gms.SharedVolumeName])
+	assert.Contains(t, main.Args, "--load-format")
+	assert.Contains(t, main.Args, "gms")
 
 	assert.Equal(t, []string{"python3", "-m", "gpu_memory_service.cli.server"}, weightsServer.Command)
 	assert.Equal(t, corev1.ContainerRestartPolicyAlways, *weightsServer.RestartPolicy)
@@ -401,6 +403,8 @@ func TestBuildCheckpointJobAddsGMSSidecars(t *testing.T) {
 		saverEnv[env.Name] = env.Value
 	}
 	assert.Equal(t, "/checkpoints/gms/"+testHash+"/versions/1", saverEnv["GMS_CHECKPOINT_DIR"])
+	assert.Equal(t, "/checkpoints/gms/"+testHash+"/versions/1", job.Spec.Template.Annotations[snapshotprotocol.GMSCheckpointDirAnnotation])
+	assert.Equal(t, snapshotprotocol.GMSCompletionFileModePodUID, job.Spec.Template.Annotations[snapshotprotocol.GMSCompletionFileModeAnnotation])
 }
 
 func TestBuildCheckpointJobInjectsStandardEnvVars(t *testing.T) {

--- a/deploy/operator/internal/controller/dynamocheckpoint_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocheckpoint_controller_test.go
@@ -369,7 +369,7 @@ func TestBuildCheckpointJobAddsGMSSidecars(t *testing.T) {
 
 	main := requireCheckpointContainer(t, job.Spec.Template.Spec.Containers, consts.MainContainerName)
 	weightsServer := requireCheckpointContainer(t, job.Spec.Template.Spec.InitContainers, gms.ServerContainerName)
-	saver := requireCheckpointContainer(t, job.Spec.Template.Spec.InitContainers, checkpoint.GMSSaverContainer)
+	saver := requireCheckpointContainer(t, job.Spec.Template.Spec.Containers, checkpoint.GMSSaverContainer)
 
 	volNames := map[string]bool{}
 	for _, v := range job.Spec.Template.Spec.Volumes {
@@ -391,6 +391,7 @@ func TestBuildCheckpointJobAddsGMSSidecars(t *testing.T) {
 	assert.Equal(t, corev1.ContainerRestartPolicyAlways, *weightsServer.RestartPolicy)
 	require.NotNil(t, weightsServer.StartupProbe)
 	assert.Equal(t, []string{"python3", "-m", "gpu_memory_service.cli.snapshot.saver"}, saver.Command)
+	assert.Nil(t, saver.RestartPolicy)
 
 	saverMounts := map[string]string{}
 	for _, m := range saver.VolumeMounts {

--- a/deploy/operator/internal/controller/dynamocheckpoint_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocheckpoint_controller_test.go
@@ -389,7 +389,7 @@ func TestBuildCheckpointJobAddsGMSSidecars(t *testing.T) {
 
 	assert.Equal(t, []string{"python3", "-m", "gpu_memory_service.cli.server"}, weightsServer.Command)
 	assert.Equal(t, corev1.ContainerRestartPolicyAlways, *weightsServer.RestartPolicy)
-	require.NotNil(t, weightsServer.StartupProbe)
+	assert.Nil(t, weightsServer.StartupProbe)
 	assert.Equal(t, []string{"python3", "-m", "gpu_memory_service.cli.snapshot.saver"}, saver.Command)
 	assert.Nil(t, saver.RestartPolicy)
 

--- a/deploy/operator/internal/controller/dynamocheckpoint_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocheckpoint_controller_test.go
@@ -404,8 +404,6 @@ func TestBuildCheckpointJobAddsGMSSidecars(t *testing.T) {
 		saverEnv[env.Name] = env.Value
 	}
 	assert.Equal(t, "/checkpoints/gms/"+testHash+"/versions/1", saverEnv["GMS_CHECKPOINT_DIR"])
-	assert.Equal(t, "/checkpoints/gms/"+testHash+"/versions/1", job.Spec.Template.Annotations[snapshotprotocol.GMSCheckpointDirAnnotation])
-	assert.Equal(t, snapshotprotocol.GMSCompletionFileModePodUID, job.Spec.Template.Annotations[snapshotprotocol.GMSCompletionFileModeAnnotation])
 }
 
 func TestBuildCheckpointJobInjectsStandardEnvVars(t *testing.T) {

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -1730,16 +1730,21 @@ func TestDynamoComponentDeploymentReconciler_generatePodTemplateSpec_RestoreLabe
 		if got := podTemplateSpec.Spec.Containers[0].Name; got != commonconsts.MainContainerName {
 			t.Fatalf("expected main container to stay first, got %q", got)
 		}
-		if got := podTemplateSpec.Spec.Containers[1].Name; got != gms.ServerContainerName {
-			t.Fatalf("expected gms-server to be a regular sidecar after main, got %q", got)
+		if got := podTemplateSpec.Spec.Containers[1].Name; got != checkpoint.GMSLoaderContainer {
+			t.Fatalf("expected gms-loader to be a regular sidecar after main, got %q", got)
 		}
-		if got := podTemplateSpec.Spec.Containers[2].Name; got != checkpoint.GMSLoaderContainer {
-			t.Fatalf("expected gms-loader to be a regular sidecar after gms-server, got %q", got)
-		}
+		foundServerInit := false
 		for _, container := range podTemplateSpec.Spec.InitContainers {
-			if container.Name == gms.ServerContainerName || container.Name == checkpoint.GMSLoaderContainer {
-				t.Fatalf("expected restore GMS containers to be regular containers, found init container %#v", container)
+			if container.Name == gms.ServerContainerName {
+				foundServerInit = true
+				continue
 			}
+			if container.Name == checkpoint.GMSLoaderContainer {
+				t.Fatalf("expected restore gms-loader to be a regular container, found init container %#v", container)
+			}
+		}
+		if !foundServerInit {
+			t.Fatalf("expected restore gms-server to be a restartable init container")
 		}
 
 		mounts := map[string]string{}
@@ -1752,11 +1757,11 @@ func TestDynamoComponentDeploymentReconciler_generatePodTemplateSpec_RestoreLabe
 		if got := gmsServer.Command; len(got) != 3 || got[0] != "python3" || got[1] != "-m" || got[2] != "gpu_memory_service.cli.server" { //nolint:goconst
 			t.Fatalf("expected weights server to run python module, got %#v", got)
 		}
-		if gmsServer.RestartPolicy != nil {
-			t.Fatalf("expected restore gms-server to be a regular container, got RestartPolicy=%#v", gmsServer.RestartPolicy)
+		if gmsServer.RestartPolicy == nil || *gmsServer.RestartPolicy != corev1.ContainerRestartPolicyAlways {
+			t.Fatalf("expected restore gms-server to be a restartable init container, got RestartPolicy=%#v", gmsServer.RestartPolicy)
 		}
-		if gmsServer.StartupProbe != nil {
-			t.Fatalf("expected restore gms-server to have no StartupProbe")
+		if gmsServer.StartupProbe == nil {
+			t.Fatalf("expected restore gms-server to have a StartupProbe")
 		}
 		if got := loader.Command; len(got) != 3 || got[0] != "python3" || got[1] != "-m" || got[2] != "gpu_memory_service.cli.snapshot.loader" {
 			t.Fatalf("expected loader to run python module, got %#v", got)

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -1760,8 +1760,8 @@ func TestDynamoComponentDeploymentReconciler_generatePodTemplateSpec_RestoreLabe
 		if gmsServer.RestartPolicy == nil || *gmsServer.RestartPolicy != corev1.ContainerRestartPolicyAlways {
 			t.Fatalf("expected restore gms-server to be a restartable init container, got RestartPolicy=%#v", gmsServer.RestartPolicy)
 		}
-		if gmsServer.StartupProbe == nil {
-			t.Fatalf("expected restore gms-server to have a StartupProbe")
+		if gmsServer.StartupProbe != nil {
+			t.Fatalf("expected restore gms-server to omit StartupProbe, got %#v", gmsServer.StartupProbe)
 		}
 		if got := loader.Command; len(got) != 3 || got[0] != "python3" || got[1] != "-m" || got[2] != "gpu_memory_service.cli.snapshot.loader" {
 			t.Fatalf("expected loader to run python module, got %#v", got)

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -1727,6 +1727,20 @@ func TestDynamoComponentDeploymentReconciler_generatePodTemplateSpec_RestoreLabe
 		require.NotNil(t, gmsServer)
 		loader := find(checkpoint.GMSLoaderContainer)
 		require.NotNil(t, loader)
+		if got := podTemplateSpec.Spec.Containers[0].Name; got != commonconsts.MainContainerName {
+			t.Fatalf("expected main container to stay first, got %q", got)
+		}
+		if got := podTemplateSpec.Spec.Containers[1].Name; got != gms.ServerContainerName {
+			t.Fatalf("expected gms-server to be a regular sidecar after main, got %q", got)
+		}
+		if got := podTemplateSpec.Spec.Containers[2].Name; got != checkpoint.GMSLoaderContainer {
+			t.Fatalf("expected gms-loader to be a regular sidecar after gms-server, got %q", got)
+		}
+		for _, container := range podTemplateSpec.Spec.InitContainers {
+			if container.Name == gms.ServerContainerName || container.Name == checkpoint.GMSLoaderContainer {
+				t.Fatalf("expected restore GMS containers to be regular containers, found init container %#v", container)
+			}
+		}
 
 		mounts := map[string]string{}
 		for _, mount := range loader.VolumeMounts {
@@ -1738,15 +1752,17 @@ func TestDynamoComponentDeploymentReconciler_generatePodTemplateSpec_RestoreLabe
 		if got := gmsServer.Command; len(got) != 3 || got[0] != "python3" || got[1] != "-m" || got[2] != "gpu_memory_service.cli.server" { //nolint:goconst
 			t.Fatalf("expected weights server to run python module, got %#v", got)
 		}
-		// Restore: gms-server and loader are init sidecars (restartPolicy=Always)
-		if gmsServer.RestartPolicy == nil || *gmsServer.RestartPolicy != corev1.ContainerRestartPolicyAlways {
-			t.Fatalf("expected restore gms-server to have RestartPolicy=Always, got %#v", gmsServer.RestartPolicy)
+		if gmsServer.RestartPolicy != nil {
+			t.Fatalf("expected restore gms-server to be a regular container, got RestartPolicy=%#v", gmsServer.RestartPolicy)
 		}
 		if gmsServer.StartupProbe != nil {
 			t.Fatalf("expected restore gms-server to have no StartupProbe")
 		}
 		if got := loader.Command; len(got) != 3 || got[0] != "python3" || got[1] != "-m" || got[2] != "gpu_memory_service.cli.snapshot.loader" {
 			t.Fatalf("expected loader to run python module, got %#v", got)
+		}
+		if loader.RestartPolicy != nil {
+			t.Fatalf("expected restore gms-loader to be a regular container, got RestartPolicy=%#v", loader.RestartPolicy)
 		}
 	})
 

--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -1759,7 +1759,7 @@ func (r *DynamoGraphDeploymentReconciler) buildCheckpointJobPodTemplate(
 	if err != nil {
 		return corev1.PodTemplateSpec{}, fmt.Errorf("failed to generate base pod spec: %w", err)
 	}
-	if backendFramework == dynamo.BackendFrameworkVLLM && component.GPUMemoryService != nil && component.GPUMemoryService.Enabled {
+	if backendFramework == dynamo.BackendFrameworkVLLM && dynamo.GetGPUMemoryService(component) != nil {
 		foundMain := false
 		for i := range podSpec.Containers {
 			if podSpec.Containers[i].Name == consts.MainContainerName {

--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -1759,6 +1759,19 @@ func (r *DynamoGraphDeploymentReconciler) buildCheckpointJobPodTemplate(
 	if err != nil {
 		return corev1.PodTemplateSpec{}, fmt.Errorf("failed to generate base pod spec: %w", err)
 	}
+	if backendFramework == dynamo.BackendFrameworkVLLM && component.GPUMemoryService != nil && component.GPUMemoryService.Enabled {
+		foundMain := false
+		for i := range podSpec.Containers {
+			if podSpec.Containers[i].Name == consts.MainContainerName {
+				dynamo.EnsureVLLMGMSLoadFormat(&podSpec.Containers[i])
+				foundMain = true
+				break
+			}
+		}
+		if !foundMain {
+			return corev1.PodTemplateSpec{}, fmt.Errorf("checkpoint job pod template has no container named %q", consts.MainContainerName)
+		}
+	}
 
 	// Override RestartPolicy for job (must be Never or OnFailure)
 	podSpec.RestartPolicy = corev1.RestartPolicyNever

--- a/deploy/operator/internal/dynamo/backend_vllm.go
+++ b/deploy/operator/internal/dynamo/backend_vllm.go
@@ -29,17 +29,14 @@ type VLLMBackend struct {
 }
 
 func (b *VLLMBackend) UpdateContainer(container *corev1.Container, numberOfNodes int32, role Role, component *v1beta1.DynamoComponentDeploymentSharedSpec, serviceName string, multinodeDeployer MultinodeDeployer) {
-	// The inter-pod GMS layout (with or without failover) requires the engine
-	// to load weights from the dedicated GMS weight-server pod rather than
-	// from disk. --load-format gms and DYN_VLLM_GMS_SHADOW_MODE activate the
-	// vLLM-side GMS client path and apply to both standalone inter-pod GMS
-	// and inter-pod GMS + failover; the "shadow mode" name is a vLLM upstream
-	// naming convention, not a statement about whether shadow pods are
-	// present.
+	// Any GMS layout requires vLLM to load weights through the GMS client.
+	// Inter-pod GMS additionally needs DYN_VLLM_GMS_SHADOW_MODE, whose name
+	// is a vLLM upstream convention rather than a statement about whether
+	// shadow pods are present.
+	if component.GPUMemoryService != nil && component.GPUMemoryService.Enabled {
+		EnsureVLLMGMSLoadFormat(container)
+	}
 	if component.IsInterPodGMSEnabled() {
-		if !containerHasArg(container, "--load-format", "gms") {
-			injectFlagsIntoContainerCommand(container, "--load-format gms", false, "vllm")
-		}
 		// DYN_VLLM_GMS_SHADOW_MODE is a vLLM-engine-specific switch (activates
 		// the vLLM-side GMS client path for shadow weight loading). It is
 		// injected here — in the vLLM backend — rather than in the backend-
@@ -97,6 +94,19 @@ func (b *VLLMBackend) UpdateContainer(container *corev1.Container, numberOfNodes
 			"use-as-compilation-cache", true,
 			"env-vars-set", true,
 			"env-vars", "VLLM_CACHE_ROOT")
+	}
+}
+
+// EnsureVLLMGMSLoadFormat injects --load-format gms into a vLLM command when
+// it is not already present. Exported so checkpoint-job template construction
+// can add the vLLM runtime flag while keeping the DGD-specific GMS sidecar/DRA
+// transforms disabled until the checkpoint controller wires them.
+func EnsureVLLMGMSLoadFormat(container *corev1.Container) {
+	if container == nil {
+		return
+	}
+	if !containerHasArg(container, "--load-format", "gms") {
+		injectFlagsIntoContainerCommand(container, "--load-format gms", false, "vllm")
 	}
 }
 

--- a/deploy/operator/internal/dynamo/backend_vllm.go
+++ b/deploy/operator/internal/dynamo/backend_vllm.go
@@ -33,7 +33,7 @@ func (b *VLLMBackend) UpdateContainer(container *corev1.Container, numberOfNodes
 	// Inter-pod GMS additionally needs DYN_VLLM_GMS_SHADOW_MODE, whose name
 	// is a vLLM upstream convention rather than a statement about whether
 	// shadow pods are present.
-	if component.GPUMemoryService != nil && component.GPUMemoryService.Enabled {
+	if GetGPUMemoryService(component) != nil {
 		EnsureVLLMGMSLoadFormat(container)
 	}
 	if component.IsInterPodGMSEnabled() {

--- a/deploy/operator/internal/dynamo/backend_vllm_test.go
+++ b/deploy/operator/internal/dynamo/backend_vllm_test.go
@@ -1088,12 +1088,12 @@ func TestVLLMBackend_UpdateContainer_InterPodGMS(t *testing.T) {
 
 func TestVLLMBackend_UpdateContainer_IntraPodGMS(t *testing.T) {
 	backend := &VLLMBackend{}
-	component := &v1alpha1.DynamoComponentDeploymentSharedSpec{
+	component := betaComponent(t, &v1alpha1.DynamoComponentDeploymentSharedSpec{
 		GPUMemoryService: &v1alpha1.GPUMemoryServiceSpec{
 			Enabled: true,
 			Mode:    v1alpha1.GMSModeIntraPod,
 		},
-	}
+	})
 	container := &corev1.Container{
 		Command: []string{"python3"},
 		Args:    []string{"-m", "dynamo.vllm"},

--- a/deploy/operator/internal/dynamo/backend_vllm_test.go
+++ b/deploy/operator/internal/dynamo/backend_vllm_test.go
@@ -1039,10 +1039,10 @@ func TestShouldUseMpBackend(t *testing.T) {
 
 // TestVLLMBackend_UpdateContainer_InterPodGMS asserts that when the inter-pod
 // GMS layout is enabled (gpuMemoryService.mode=interPod, with or without
-// failover), the vLLM backend is the one responsible for injecting both the
-// --load-format=gms flag and the DYN_VLLM_GMS_SHADOW_MODE env var. These are
-// vLLM-runtime switches and must live in the backend adapter, not in the
-// backend-agnostic GMS helpers (see gmsEngineEnvVars).
+// failover), the vLLM backend is the one responsible for injecting the
+// --load-format=gms flag and inter-pod-only DYN_VLLM_GMS_SHADOW_MODE env var.
+// These are vLLM-runtime switches and must live in the backend adapter, not in
+// the backend-agnostic GMS helpers (see gmsEngineEnvVars).
 func TestVLLMBackend_UpdateContainer_InterPodGMS(t *testing.T) {
 	backend := &VLLMBackend{}
 	component := betaComponent(t, &v1alpha1.DynamoComponentDeploymentSharedSpec{
@@ -1086,10 +1086,34 @@ func TestVLLMBackend_UpdateContainer_InterPodGMS(t *testing.T) {
 	}
 }
 
+func TestVLLMBackend_UpdateContainer_IntraPodGMS(t *testing.T) {
+	backend := &VLLMBackend{}
+	component := &v1alpha1.DynamoComponentDeploymentSharedSpec{
+		GPUMemoryService: &v1alpha1.GPUMemoryServiceSpec{
+			Enabled: true,
+			Mode:    v1alpha1.GMSModeIntraPod,
+		},
+	}
+	container := &corev1.Container{
+		Command: []string{"python3"},
+		Args:    []string{"-m", "dynamo.vllm"},
+	}
+
+	backend.UpdateContainer(container, 1, RoleMain, component, "svc", &GroveMultinodeDeployer{})
+
+	if !containerHasArg(container, "--load-format", "gms") {
+		t.Fatalf("expected --load-format gms to be injected; got args=%q", container.Args)
+	}
+	for _, e := range container.Env {
+		if e.Name == "DYN_VLLM_GMS_SHADOW_MODE" {
+			t.Fatalf("DYN_VLLM_GMS_SHADOW_MODE must not be injected for intra-pod GMS")
+		}
+	}
+}
+
 // TestVLLMBackend_UpdateContainer_NoInterPodGMS asserts the complementary
-// invariant: when inter-pod GMS failover is NOT enabled, the vLLM backend
-// must not inject the GMS-specific env var (it is meaningless outside the
-// inter-pod layout).
+// invariant: when GMS is NOT enabled, the vLLM backend must not inject the
+// inter-pod-only env var.
 func TestVLLMBackend_UpdateContainer_NoInterPodGMS(t *testing.T) {
 	backend := &VLLMBackend{}
 	component := betaComponent(t, &v1alpha1.DynamoComponentDeploymentSharedSpec{})
@@ -1100,6 +1124,9 @@ func TestVLLMBackend_UpdateContainer_NoInterPodGMS(t *testing.T) {
 
 	backend.UpdateContainer(container, 1, RoleMain, component, "svc", &GroveMultinodeDeployer{})
 
+	if containerHasArg(container, "--load-format", "gms") {
+		t.Errorf("--load-format gms must not be injected when GMS is disabled")
+	}
 	for _, e := range container.Env {
 		if e.Name == "DYN_VLLM_GMS_SHADOW_MODE" {
 			t.Errorf("DYN_VLLM_GMS_SHADOW_MODE must not be injected when inter-pod GMS is disabled")

--- a/deploy/operator/internal/dynamo/failover.go
+++ b/deploy/operator/internal/dynamo/failover.go
@@ -24,9 +24,11 @@ import (
 	"strings"
 
 	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/checkpoint"
 	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dra"
 	gmsruntime "github.com/ai-dynamo/dynamo/deploy/operator/internal/gms"
+	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	grovev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	resourcev1 "k8s.io/api/resource/v1"
@@ -139,6 +141,36 @@ func gmsWeightServerPodSpec(basePodSpec *corev1.PodSpec, rank int32, gpuCount in
 	applyGMSSharedResources(podSpec, c, rank)
 
 	return podSpec
+}
+
+func injectInterPodGMSRestoreLoader(podSpec *corev1.PodSpec, storage snapshotprotocol.Storage) {
+	if podSpec == nil || len(podSpec.Containers) == 0 {
+		return
+	}
+	mainContainer := &podSpec.Containers[0]
+	snapshotprotocol.InjectCheckpointVolume(podSpec, storage.PVCName)
+
+	for i := range podSpec.Containers {
+		if podSpec.Containers[i].Name == checkpoint.GMSLoaderContainer {
+			return
+		}
+	}
+
+	loader := corev1.Container{
+		Name:    checkpoint.GMSLoaderContainer,
+		Image:   mainContainer.Image,
+		Command: []string{"python3", "-m", checkpoint.GMSCheckpointLoaderModule},
+		Env: []corev1.EnvVar{
+			{Name: gmsruntime.EnvSocketDir, Value: gmsSharedMountPath},
+			{Name: checkpoint.EnvCheckpointDir, Value: checkpoint.ResolveGMSArtifactDir(storage)},
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{Name: gmsSharedVolumeName, MountPath: gmsSharedMountPath},
+			{Name: snapshotprotocol.CheckpointVolumeName, MountPath: storage.BasePath},
+		},
+		Resources: *mainContainer.Resources.DeepCopy(),
+	}
+	podSpec.Containers = append(podSpec.Containers, loader)
 }
 
 // gmsEngineEnvVars returns the backend-agnostic environment variables injected

--- a/deploy/operator/internal/dynamo/failover.go
+++ b/deploy/operator/internal/dynamo/failover.go
@@ -233,6 +233,11 @@ func augmentEngineForGMS(podSpec *corev1.PodSpec, rank int32, isInterPodFailover
 	removeEnvVar(c, "DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS")
 
 	applyGMSSharedResources(podSpec, c, rank)
+	// CRIU restores a process that was checkpointed with the intra-pod GMS
+	// socket path in its mount table and environment.
+	_, checkpointCompatMount := gmsSharedVolume(rank)
+	checkpointCompatMount.MountPath = gmsruntime.SharedMountPath
+	c.VolumeMounts = append(c.VolumeMounts, checkpointCompatMount)
 	if isInterPodFailover {
 		podSpec.RestartPolicy = corev1.RestartPolicyNever
 	}

--- a/deploy/operator/internal/dynamo/failover.go
+++ b/deploy/operator/internal/dynamo/failover.go
@@ -156,6 +156,14 @@ func injectInterPodGMSRestoreLoader(podSpec *corev1.PodSpec, storage snapshotpro
 		}
 	}
 
+	gmsSharedMount := corev1.VolumeMount{Name: gmsSharedVolumeName, MountPath: gmsSharedMountPath}
+	for _, mount := range mainContainer.VolumeMounts {
+		if mount.Name == gmsSharedVolumeName && mount.MountPath == gmsSharedMountPath {
+			gmsSharedMount = *mount.DeepCopy()
+			break
+		}
+	}
+
 	loader := corev1.Container{
 		Name:    checkpoint.GMSLoaderContainer,
 		Image:   mainContainer.Image,
@@ -165,7 +173,7 @@ func injectInterPodGMSRestoreLoader(podSpec *corev1.PodSpec, storage snapshotpro
 			{Name: checkpoint.EnvCheckpointDir, Value: checkpoint.ResolveGMSArtifactDir(storage)},
 		},
 		VolumeMounts: []corev1.VolumeMount{
-			{Name: gmsSharedVolumeName, MountPath: gmsSharedMountPath},
+			gmsSharedMount,
 			{Name: snapshotprotocol.CheckpointVolumeName, MountPath: storage.BasePath},
 		},
 		Resources: *mainContainer.Resources.DeepCopy(),

--- a/deploy/operator/internal/dynamo/failover_test.go
+++ b/deploy/operator/internal/dynamo/failover_test.go
@@ -159,6 +159,12 @@ func TestAugmentEngineForGMS(t *testing.T) {
 	assert.NotContains(t, c.Resources.Limits, corev1.ResourceName("nvidia.com/gpu"))
 	assert.True(t, hasToleration(podSpec, "nvidia.com/gpu"))
 	assert.True(t, hasVolume(podSpec, gmsSharedVolumeName))
+	sharedMount := findVolumeMount(c, gmsSharedMountPath)
+	require.NotNil(t, sharedMount, "engine should mount the inter-pod GMS socket path")
+	assert.Equal(t, "$(GROVE_PCSG_NAME)-$(GROVE_PCSG_INDEX)/rank-1", sharedMount.SubPathExpr)
+	compatMount := findVolumeMount(c, gms.SharedMountPath)
+	require.NotNil(t, compatMount, "engine should mount the checkpoint source GMS socket path")
+	assert.Equal(t, "$(GROVE_PCSG_NAME)-$(GROVE_PCSG_INDEX)/rank-1", compatMount.SubPathExpr)
 
 	require.Len(t, podSpec.InitContainers, 1, "should have perm-fix init container")
 	initC := podSpec.InitContainers[0]
@@ -206,6 +212,8 @@ func TestAugmentEngineForGMS_StandaloneDoesNotForceRestartNever(t *testing.T) {
 		"standalone engine still needs the shared hostPath for UDS sockets")
 	assert.True(t, hasEnvVar(podSpec.Containers[0], gms.EnvSocketDir, gmsSharedMountPath),
 		"standalone engine still needs the socket-dir env var to reach the GMS server")
+	assert.NotNil(t, findVolumeMount(podSpec.Containers[0], gms.SharedMountPath),
+		"standalone engine still needs the checkpoint source socket mount for snapshot restore")
 }
 
 func TestAugmentEngineForGMS_EmptyContainers(t *testing.T) {

--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -36,6 +36,7 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/discovery"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dra"
 	gms "github.com/ai-dynamo/dynamo/deploy/operator/internal/gms"
+	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	grovev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	"github.com/imdario/mergo"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -1830,7 +1831,29 @@ func buildCliqueForRole(p cliqueParams) (*grovev1alpha1.PodCliqueTemplateSpec, e
 		return nil, fmt.Errorf("failed to generate podSpec for role %s: %w", p.r.Name, err)
 	}
 
-	// GMS weight servers load weights fresh from disk and are not CRIU targets.
+	if p.operatorConfig.Checkpoint.Enabled && p.r.Role == RoleGMS && p.component.IsInterPodGMSEnabled() &&
+		p.checkpointInfo != nil && p.checkpointInfo.Enabled && p.checkpointInfo.Ready &&
+		p.checkpointInfo.GPUMemoryService != nil && p.checkpointInfo.GPUMemoryService.Enabled {
+		storage, err := snapshotprotocol.DiscoverAndResolveStorage(
+			p.ctx,
+			p.kubeClient,
+			p.dynamoDeployment.Namespace,
+			p.checkpointInfo.Hash,
+			p.checkpointInfo.ArtifactVersion,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to inject GMS restore loader for role %s: %w", p.r.Name, err)
+		}
+		p.checkpointInfo.GMSArtifactDir = checkpoint.ResolveGMSArtifactDir(storage)
+		injectInterPodGMSRestoreLoader(podSpec, storage)
+	}
+
+	// GMS weight-server pods are not a checkpoint/restore target: they run
+	// gpu_memory_service.cli.server (not the dynamo runtime) and have no CRIU
+	// state to capture. Shaping them as restore targets would replace the GMS
+	// wrapper command with `sleep infinity` and break the inter-pod GMS layout
+	// entirely. The companion ApplyRestorePodMetadata call below is also
+	// skipped for GMS.
 	if p.operatorConfig.Checkpoint.Enabled && p.r.Role != RoleGMS {
 		if err := checkpoint.InjectCheckpointIntoPodSpecWithStorageConfig(
 			p.ctx, p.kubeClient, p.dynamoDeployment.Namespace, podSpec, p.checkpointInfo,

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/checkpoint"
 	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
+	gms "github.com/ai-dynamo/dynamo/deploy/operator/internal/gms"
 	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	grovev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	"github.com/google/go-cmp/cmp"
@@ -7572,6 +7573,14 @@ func TestGenerateGrovePodCliqueSet_GMSPodsAreNotCheckpointTargets(t *testing.T) 
 				"engine clique %q main container must be shaped as a snapshot restore target", clique.Name)
 			assert.Equal(t, snapshotprotocol.GMSCompletionFileModeShared, clique.Annotations[snapshotprotocol.GMSCompletionFileModeAnnotation],
 				"engine clique %q must wait for the shared inter-pod GMS loader sentinel", clique.Name)
+			mountsByPath := map[string]corev1.VolumeMount{}
+			for _, mount := range mainContainer.VolumeMounts {
+				mountsByPath[mount.MountPath] = mount
+			}
+			assert.Contains(t, mountsByPath, gmsSharedMountPath,
+				"engine clique %q must mount the inter-pod GMS socket path", clique.Name)
+			assert.Contains(t, mountsByPath, gms.SharedMountPath,
+				"engine clique %q must preserve the checkpoint source GMS socket path", clique.Name)
 		}
 	}
 	assert.True(t, sawGMS, "test setup should produce at least one GMS clique")

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -7585,8 +7585,6 @@ func TestGenerateGrovePodCliqueSet_GMSPodsAreNotCheckpointTargets(t *testing.T) 
 				"engine clique %q must carry checkpoint-id label (selected by snapshot-agent restore informer)", clique.Name)
 			assert.Equal(t, []string{"sleep", "infinity"}, mainContainer.Command,
 				"engine clique %q main container must be shaped as a snapshot restore target", clique.Name)
-			assert.Equal(t, snapshotprotocol.GMSCompletionFileModeShared, clique.Annotations[snapshotprotocol.GMSCompletionFileModeAnnotation],
-				"engine clique %q must wait for the shared inter-pod GMS loader sentinel", clique.Name)
 			mountsByPath := map[string]corev1.VolumeMount{}
 			for _, mount := range mainContainer.VolumeMounts {
 				mountsByPath[mount.MountPath] = mount

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -7532,7 +7532,15 @@ func TestGenerateGrovePodCliqueSet_GMSPodsAreNotCheckpointTargets(t *testing.T) 
 	}).Build()
 
 	infoByService := map[string]*checkpoint.CheckpointInfo{
-		"decode": {Enabled: true, Ready: true, Hash: "abc123def4567890"},
+		"decode": {
+			Enabled: true,
+			Ready:   true,
+			Hash:    "abc123def4567890",
+			GPUMemoryService: &v1alpha1.GPUMemoryServiceSpec{
+				Enabled: true,
+				Mode:    v1alpha1.GMSModeInterPod,
+			},
+		},
 	}
 
 	got, err := GenerateGrovePodCliqueSet(context.Background(), betaDGD(t, dgd), controllerConfig, &controller_common.RuntimeConfig{DRAEnabled: true}, kubeClient, nil, nil, nil, infoByService)
@@ -7547,10 +7555,13 @@ func TestGenerateGrovePodCliqueSet_GMSPodsAreNotCheckpointTargets(t *testing.T) 
 
 		if strings.Contains(clique.Name, "gms") {
 			sawGMS = true
+			loader := findContainerInClique(t, clique, checkpoint.GMSLoaderContainer)
 			assert.Empty(t, targetAnnotation, "GMS clique %q must not carry snapshot-target-containers annotation", clique.Name)
 			assert.Empty(t, checkpointID, "GMS clique %q must not carry checkpoint-id label (would make it look like a restore target)", clique.Name)
 			assert.NotEqual(t, []string{"sleep", "infinity"}, mainContainer.Command,
 				"GMS clique %q main container command must not be rewritten to sleep infinity (should remain the gms wrapper)", clique.Name)
+			assert.Equal(t, []string{"python3", "-m", checkpoint.GMSCheckpointLoaderModule}, loader.Command,
+				"GMS clique %q should run the inter-pod GMS loader as a regular sidecar", clique.Name)
 		} else {
 			sawEngine = true
 			assert.Equal(t, commonconsts.MainContainerName, targetAnnotation,
@@ -7559,6 +7570,8 @@ func TestGenerateGrovePodCliqueSet_GMSPodsAreNotCheckpointTargets(t *testing.T) 
 				"engine clique %q must carry checkpoint-id label (selected by snapshot-agent restore informer)", clique.Name)
 			assert.Equal(t, []string{"sleep", "infinity"}, mainContainer.Command,
 				"engine clique %q main container must be shaped as a snapshot restore target", clique.Name)
+			assert.Equal(t, snapshotprotocol.GMSCompletionFileModeShared, clique.Annotations[snapshotprotocol.GMSCompletionFileModeAnnotation],
+				"engine clique %q must wait for the shared inter-pod GMS loader sentinel", clique.Name)
 		}
 	}
 	assert.True(t, sawGMS, "test setup should produce at least one GMS clique")

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -7563,6 +7563,20 @@ func TestGenerateGrovePodCliqueSet_GMSPodsAreNotCheckpointTargets(t *testing.T) 
 				"GMS clique %q main container command must not be rewritten to sleep infinity (should remain the gms wrapper)", clique.Name)
 			assert.Equal(t, []string{"python3", "-m", checkpoint.GMSCheckpointLoaderModule}, loader.Command,
 				"GMS clique %q should run the inter-pod GMS loader as a regular sidecar", clique.Name)
+			mainMountsByPath := map[string]corev1.VolumeMount{}
+			for _, mount := range mainContainer.VolumeMounts {
+				mainMountsByPath[mount.MountPath] = mount
+			}
+			loaderMountsByPath := map[string]corev1.VolumeMount{}
+			for _, mount := range loader.VolumeMounts {
+				loaderMountsByPath[mount.MountPath] = mount
+			}
+			require.Contains(t, mainMountsByPath, gmsSharedMountPath,
+				"GMS clique %q main container must mount the rank-scoped GMS socket path", clique.Name)
+			require.Contains(t, loaderMountsByPath, gmsSharedMountPath,
+				"GMS clique %q loader must mount the same rank-scoped GMS socket path", clique.Name)
+			assert.Equal(t, mainMountsByPath[gmsSharedMountPath].SubPathExpr, loaderMountsByPath[gmsSharedMountPath].SubPathExpr,
+				"GMS clique %q loader must see the same socket directory as the GMS server", clique.Name)
 		} else {
 			sawEngine = true
 			assert.Equal(t, commonconsts.MainContainerName, targetAnnotation,

--- a/deploy/operator/internal/gms/gms.go
+++ b/deploy/operator/internal/gms/gms.go
@@ -8,8 +8,6 @@
 package gms
 
 import (
-	"path/filepath"
-
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dra"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
@@ -33,12 +31,10 @@ const (
 
 	// ServerModule is the Python module for the GMS server entry point.
 	ServerModule = "gpu_memory_service.cli.server"
-
-	readyFile = "gms-ready"
 )
 
-// EnsureServerSidecar adds the GMS server as a restartable init sidecar with a
-// startup probe. Idempotent — safe to call from both the DGD and checkpoint paths.
+// EnsureServerSidecar adds the GMS server as a restartable init sidecar.
+// Idempotent — safe to call from both the DGD and checkpoint paths.
 func EnsureServerSidecar(podSpec *corev1.PodSpec, mainContainer *corev1.Container) {
 	if podSpec == nil || mainContainer == nil {
 		return
@@ -48,15 +44,6 @@ func EnsureServerSidecar(podSpec *corev1.PodSpec, mainContainer *corev1.Containe
 
 	sidecar := Container(ServerContainerName, ServerModule, mainContainer.Image)
 	sidecar.RestartPolicy = ptr.To(corev1.ContainerRestartPolicyAlways)
-	sidecar.StartupProbe = &corev1.Probe{
-		ProbeHandler: corev1.ProbeHandler{
-			Exec: &corev1.ExecAction{
-				Command: []string{"test", "-f", filepath.Join(SharedMountPath, readyFile)},
-			},
-		},
-		PeriodSeconds:    1,
-		FailureThreshold: 300, // 1s * 300 = 5 min
-	}
 	for i := range podSpec.InitContainers {
 		if podSpec.InitContainers[i].Name == sidecar.Name {
 			return

--- a/deploy/operator/internal/gms/gms.go
+++ b/deploy/operator/internal/gms/gms.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	// ServerContainerName is the name of the GMS server init sidecar.
+	// ServerContainerName is the name of the GMS server sidecar.
 	ServerContainerName = "gms-server"
 
 	// SharedVolumeName is the emptyDir volume shared between the GMS server

--- a/deploy/operator/internal/gms/gms_test.go
+++ b/deploy/operator/internal/gms/gms_test.go
@@ -6,7 +6,6 @@
 package gms
 
 import (
-	"path/filepath"
 	"testing"
 
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dra"
@@ -34,9 +33,7 @@ func TestEnsureServerSidecar(t *testing.T) {
 	assert.Equal(t, ServerContainerName, server.Name)
 	assert.Equal(t, []string{"python3", "-m", ServerModule}, server.Command)
 	assert.Equal(t, corev1.ContainerRestartPolicyAlways, *server.RestartPolicy)
-	require.NotNil(t, server.StartupProbe)
-	assert.Equal(t, []string{"test", "-f", filepath.Join(SharedMountPath, readyFile)},
-		server.StartupProbe.Exec.Command)
+	assert.Nil(t, server.StartupProbe)
 
 	// DRA claim on server
 	assert.Len(t, server.Resources.Claims, 1)

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment.go
@@ -338,23 +338,20 @@ func (v *DynamoGraphDeploymentValidator) validateService(ctx context.Context, se
 			consts.KubeAnnotationEnableGrove, v.deployment.Annotations[consts.KubeAnnotationEnableGrove])
 	}
 
-	// The inter-pod GMS layout is currently implemented only for vLLM (the
-	// engine relies on vLLM-specific runtime hooks like --load-format gms and
-	// DYN_VLLM_GMS_SHADOW_MODE that activate the GMS client path). Fail fast
-	// at admission rather than producing a broken deployment when another or
-	// no backend is configured — an empty BackendFramework means the operator
-	// cannot confirm the engine speaks vLLM, which is a hard prerequisite for
-	// inter-pod GMS (both standalone and with failover).
-	if service.IsInterPodGMSEnabled() &&
+	// Inter-pod failover is currently implemented only for vLLM because the
+	// failover pod transform clones vLLM engines and injects vLLM-specific
+	// shadow-mode wiring. Standalone inter-pod GMS is backend-neutral at the
+	// operator layer; each backend still has to opt into its own GMS model loader.
+	if service.IsInterPodFailoverEnabled() &&
 		v.deployment.Spec.BackendFramework != backendFrameworkVLLM {
 		detected := v.deployment.Spec.BackendFramework
 		if detected == "" {
 			detected = "<unset>"
 		}
 		return nil, fmt.Errorf(
-			"spec.services[%s]: the inter-pod GMS layout (gpuMemoryService.mode=%q) is currently supported only for vLLM (detected: %s); "+
+			"spec.services[%s]: inter-pod GMS failover is currently supported only for vLLM (detected: %s); "+
 				"set spec.backendFramework=%q",
-			serviceName, nvidiacomv1alpha1.GMSModeInterPod, detected, backendFrameworkVLLM)
+			serviceName, detected, backendFrameworkVLLM)
 	}
 
 	// Validate service name length constraints for Grove PodCliqueSet naming

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment_test.go
@@ -893,7 +893,33 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			errMsg:      "requires the Grove pathway",
 		},
 		{
-			name:         "inter-pod GMS rejected on non-vLLM backend",
+			name:         "standalone inter-pod GMS accepted on SGLang backend",
+			groveEnabled: true,
+			deployment: &nvidiacomv1alpha1.DynamoGraphDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-gms",
+					Namespace: "default",
+				},
+				Spec: nvidiacomv1alpha1.DynamoGraphDeploymentSpec{
+					BackendFramework: "sglang",
+					Services: map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+						"worker": {
+							ComponentType: consts.ComponentTypeWorker,
+							GPUMemoryService: &nvidiacomv1alpha1.GPUMemoryServiceSpec{
+								Enabled: true,
+								Mode:    nvidiacomv1alpha1.GMSModeInterPod,
+							},
+							Resources: &nvidiacomv1alpha1.Resources{
+								Limits: &nvidiacomv1alpha1.ResourceItem{GPU: "8"},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:         "inter-pod GMS failover rejected on non-vLLM backend",
 			groveEnabled: true,
 			deployment: &nvidiacomv1alpha1.DynamoGraphDeployment{
 				ObjectMeta: metav1.ObjectMeta{
@@ -923,10 +949,10 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: true,
-			errMsg:      "currently supported only for vLLM",
+			errMsg:      "inter-pod GMS failover is currently supported only for vLLM",
 		},
 		{
-			name:         "inter-pod GMS rejected when backendFramework is unset",
+			name:         "inter-pod GMS failover rejected when backendFramework is unset",
 			groveEnabled: true,
 			deployment: &nvidiacomv1alpha1.DynamoGraphDeployment{
 				ObjectMeta: metav1.ObjectMeta{
@@ -958,7 +984,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			},
 			wantErr:     true,
 			errContains: true,
-			errMsg:      "currently supported only for vLLM",
+			errMsg:      "inter-pod GMS failover is currently supported only for vLLM",
 		},
 		{
 			name: "GMS failover disabled is valid without GPU",

--- a/deploy/snapshot/internal/controller/controller.go
+++ b/deploy/snapshot/internal/controller/controller.go
@@ -505,6 +505,21 @@ func (w *NodeController) runCheckpoint(ctx context.Context, pod *corev1.Pod, job
 		}
 		return nil
 	}
+	if gmsDir := strings.TrimSpace(pod.Annotations[snapshotprotocol.GMSCheckpointDirAnnotation]); gmsDir != "" {
+		sentinel := filepath.Join(gmsDir, gmsCompletionFileName(pod, snapshotprotocol.GMSSaveCompleteFile))
+		log.Info("Waiting for GMS checkpoint saver", "sentinel", sentinel)
+		if err := waitForFile(leaseCtx, sentinel, time.Second); err != nil {
+			log.Error(err, "GMS checkpoint saver did not complete")
+			emitPodEvent(ctx, w.clientset, log, pod, "snapshot", corev1.EventTypeWarning, "CheckpointFailed", err.Error())
+			if signalErr := snapshotruntime.SendSignalToPID(log, containerPID, syscall.SIGKILL, "gms checkpoint save failed"); signalErr != nil {
+				log.Error(signalErr, "Failed to signal GMS checkpoint save failure to runtime process")
+			}
+			if statusErr := setCheckpointStatus(snapshotprotocol.CheckpointStatusFailed); statusErr != nil {
+				return statusErr
+			}
+			return nil
+		}
+	}
 
 	// Step 2: Sentinel on success. Workload observes via polling on the
 	// snapshot-control volume; containerPID is a PID inside the container's
@@ -605,6 +620,21 @@ func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, contai
 		}
 		return nil
 	}
+	if gmsDir := strings.TrimSpace(pod.Annotations[snapshotprotocol.GMSCheckpointDirAnnotation]); gmsDir != "" {
+		sentinel := filepath.Join(gmsDir, gmsCompletionFileName(pod, snapshotprotocol.GMSLoadCompleteFile))
+		log.Info("Waiting for GMS checkpoint loader", "sentinel", sentinel)
+		if err := waitForFile(restoreCtx, sentinel, time.Second); err != nil {
+			log.Error(err, "GMS checkpoint loader did not complete")
+			emitPodEvent(ctx, w.clientset, log, pod, "snapshot", corev1.EventTypeWarning, "RestoreFailed", err.Error())
+			if statusErr := setRestoreStatus(snapshotprotocol.RestoreStatusFailed); statusErr != nil {
+				return statusErr
+			}
+			if killErr := snapshotruntime.SendSignalToPID(log, placeholderHostPID, syscall.SIGKILL, "gms restore load failed"); killErr != nil {
+				return fmt.Errorf("gms restore load failed and placeholder could not be killed: %w", killErr)
+			}
+			return nil
+		}
+	}
 
 	// Any PID inside the container mount namespace reaches the control
 	// volume through /host/proc/<pid>/root.
@@ -625,6 +655,44 @@ func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, contai
 		return err
 	}
 	return nil
+}
+
+func gmsCompletionFileName(pod *corev1.Pod, base string) string {
+	if pod == nil {
+		return base
+	}
+	switch pod.Annotations[snapshotprotocol.GMSCompletionFileModeAnnotation] {
+	case snapshotprotocol.GMSCompletionFileModeShared:
+		return base
+	}
+	uid := strings.TrimSpace(string(pod.UID))
+	if uid == "" {
+		return base
+	}
+	return fmt.Sprintf("%s-%s", base, uid)
+}
+
+func waitForFile(ctx context.Context, path string, interval time.Duration) error {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		info, err := os.Stat(path)
+		switch {
+		case err == nil && !info.IsDir():
+			return nil
+		case err == nil:
+			return fmt.Errorf("%s exists but is a directory", path)
+		case !os.IsNotExist(err):
+			return fmt.Errorf("failed to stat %s: %w", path, err)
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timed out waiting for %s: %w", path, ctx.Err())
+		case <-ticker.C:
+		}
+	}
 }
 
 func (w *NodeController) tryAcquire(podKey string) bool {

--- a/deploy/snapshot/internal/controller/controller.go
+++ b/deploy/snapshot/internal/controller/controller.go
@@ -51,6 +51,8 @@ type checkpointLocations struct {
 	ContainerPath string
 }
 
+const gmsCompletionPollInterval = 50 * time.Millisecond
+
 // NewNodeController creates the node-local controller that runs inside snapshot-agent.
 func NewNodeController(
 	cfg *types.AgentConfig,
@@ -376,7 +378,7 @@ func (w *NodeController) maybeStartRestoreForContainer(
 //  2. Resolve the container ID and host PID
 //  3. Call executor.Checkpoint (inspect → configure → CUDA lock/checkpoint → CRIU dump → rootfs diff)
 //  4. Write a snapshot-complete sentinel into the pod's snapshot-control
-//     volume on success (observed by the workload via inotify), or SIGKILL
+//     volume on success (observed by the workload via polling), or SIGKILL
 //     on failure (unrecoverable CUDA-locked process)
 //  5. Mark job as completed or failed
 func (w *NodeController) runCheckpoint(ctx context.Context, pod *corev1.Pod, job *batchv1.Job, checkpointID, containerName, podKey string, startedAt time.Time) error {
@@ -508,7 +510,7 @@ func (w *NodeController) runCheckpoint(ctx context.Context, pod *corev1.Pod, job
 	if gmsDir := strings.TrimSpace(pod.Annotations[snapshotprotocol.GMSCheckpointDirAnnotation]); gmsDir != "" {
 		sentinel := filepath.Join(gmsDir, gmsCompletionFileName(pod, snapshotprotocol.GMSSaveCompleteFile))
 		log.Info("Waiting for GMS checkpoint saver", "sentinel", sentinel)
-		if err := waitForFile(leaseCtx, sentinel, time.Second); err != nil {
+		if err := waitForFile(leaseCtx, sentinel, gmsCompletionPollInterval); err != nil {
 			log.Error(err, "GMS checkpoint saver did not complete")
 			emitPodEvent(ctx, w.clientset, log, pod, "snapshot", corev1.EventTypeWarning, "CheckpointFailed", err.Error())
 			if signalErr := snapshotruntime.SendSignalToPID(log, containerPID, syscall.SIGKILL, "gms checkpoint save failed"); signalErr != nil {
@@ -543,8 +545,17 @@ func (w *NodeController) runCheckpoint(ctx context.Context, pod *corev1.Pod, job
 	return nil
 }
 
-// runRestore restores one target container. Kubernetes readiness is gated by
-// the shaped startup probe, not by the snapshot-agent worker.
+// runRestore runs the full restore workflow for a pod:
+//  1. Mark the current container instance as in_progress
+//  2. Call executor.Restore (inspect placeholder → nsrestore inside namespace)
+//  3. Write a restore-complete sentinel into the pod's snapshot-control
+//     volume to wake the workload (observed via polling)
+//  4. Mark the container instance as completed
+//
+// Kubernetes readiness is gated separately: each restore-target container's
+// startup probe waits on the restore-complete sentinel, then its normal
+// readiness probe (if any) decides when the container is ready. The pod only
+// becomes Ready once every restored and cold-started container is ready.
 func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, containerName, containerID, checkpointID string, checkpointLocation checkpointLocations, restoreAttemptKey string, startedAt time.Time) error {
 	releaseOnExit := true
 	defer func() {
@@ -623,7 +634,7 @@ func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, contai
 	if gmsDir := strings.TrimSpace(pod.Annotations[snapshotprotocol.GMSCheckpointDirAnnotation]); gmsDir != "" {
 		sentinel := filepath.Join(gmsDir, gmsCompletionFileName(pod, snapshotprotocol.GMSLoadCompleteFile))
 		log.Info("Waiting for GMS checkpoint loader", "sentinel", sentinel)
-		if err := waitForFile(restoreCtx, sentinel, time.Second); err != nil {
+		if err := waitForFile(restoreCtx, sentinel, gmsCompletionPollInterval); err != nil {
 			log.Error(err, "GMS checkpoint loader did not complete")
 			emitPodEvent(ctx, w.clientset, log, pod, "snapshot", corev1.EventTypeWarning, "RestoreFailed", err.Error())
 			if statusErr := setRestoreStatus(snapshotprotocol.RestoreStatusFailed); statusErr != nil {

--- a/deploy/snapshot/internal/controller/controller.go
+++ b/deploy/snapshot/internal/controller/controller.go
@@ -52,7 +52,6 @@ type checkpointLocations struct {
 }
 
 const (
-	gmsCompletionPollInterval        = 50 * time.Millisecond
 	restoreContainerResolveInterval  = 50 * time.Millisecond
 	restoreContainerResolveTimeout   = 30 * time.Second
 	restoreContainerResolveKeySuffix = "resolve"
@@ -572,22 +571,6 @@ func (w *NodeController) runCheckpoint(ctx context.Context, pod *corev1.Pod, job
 		}
 		return nil
 	}
-	if gmsDir := strings.TrimSpace(pod.Annotations[snapshotprotocol.GMSCheckpointDirAnnotation]); gmsDir != "" {
-		sentinel := filepath.Join(gmsDir, gmsCompletionFileName(pod, snapshotprotocol.GMSSaveCompleteFile))
-		log.Info("Waiting for GMS checkpoint saver", "sentinel", sentinel)
-		if err := waitForFile(leaseCtx, sentinel, gmsCompletionPollInterval); err != nil {
-			log.Error(err, "GMS checkpoint saver did not complete")
-			emitPodEvent(ctx, w.clientset, log, pod, "snapshot", corev1.EventTypeWarning, "CheckpointFailed", err.Error())
-			if signalErr := snapshotruntime.SendSignalToPID(log, containerPID, syscall.SIGKILL, "gms checkpoint save failed"); signalErr != nil {
-				log.Error(signalErr, "Failed to signal GMS checkpoint save failure to runtime process")
-			}
-			if statusErr := setCheckpointStatus(snapshotprotocol.CheckpointStatusFailed); statusErr != nil {
-				return statusErr
-			}
-			return nil
-		}
-	}
-
 	// Step 2: Sentinel on success. Workload observes via polling on the
 	// snapshot-control volume; containerPID is a PID inside the container's
 	// mount namespace, which is all the /host/proc/<pid>/root write path
@@ -696,22 +679,6 @@ func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, contai
 		}
 		return nil
 	}
-	if gmsDir := strings.TrimSpace(pod.Annotations[snapshotprotocol.GMSCheckpointDirAnnotation]); gmsDir != "" {
-		sentinel := filepath.Join(gmsDir, gmsCompletionFileName(pod, snapshotprotocol.GMSLoadCompleteFile))
-		log.Info("Waiting for GMS checkpoint loader", "sentinel", sentinel)
-		if err := waitForFile(restoreCtx, sentinel, gmsCompletionPollInterval); err != nil {
-			log.Error(err, "GMS checkpoint loader did not complete")
-			emitPodEvent(ctx, w.clientset, log, pod, "snapshot", corev1.EventTypeWarning, "RestoreFailed", err.Error())
-			if statusErr := setRestoreStatus(snapshotprotocol.RestoreStatusFailed); statusErr != nil {
-				return statusErr
-			}
-			if killErr := snapshotruntime.SendSignalToPID(log, placeholderHostPID, syscall.SIGKILL, "gms restore load failed"); killErr != nil {
-				return fmt.Errorf("gms restore load failed and placeholder could not be killed: %w", killErr)
-			}
-			return nil
-		}
-	}
-
 	// Any PID inside the container mount namespace reaches the control
 	// volume through /host/proc/<pid>/root.
 	if err := snapshotruntime.WriteControlSentinel(placeholderHostPID, snapshotprotocol.RestoreCompleteFile); err != nil {
@@ -731,44 +698,6 @@ func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, contai
 		return err
 	}
 	return nil
-}
-
-func gmsCompletionFileName(pod *corev1.Pod, base string) string {
-	if pod == nil {
-		return base
-	}
-	switch pod.Annotations[snapshotprotocol.GMSCompletionFileModeAnnotation] {
-	case snapshotprotocol.GMSCompletionFileModeShared:
-		return base
-	}
-	uid := strings.TrimSpace(string(pod.UID))
-	if uid == "" {
-		return base
-	}
-	return fmt.Sprintf("%s-%s", base, uid)
-}
-
-func waitForFile(ctx context.Context, path string, interval time.Duration) error {
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
-
-	for {
-		info, err := os.Stat(path)
-		switch {
-		case err == nil && !info.IsDir():
-			return nil
-		case err == nil:
-			return fmt.Errorf("%s exists but is a directory", path)
-		case !os.IsNotExist(err):
-			return fmt.Errorf("failed to stat %s: %w", path, err)
-		}
-
-		select {
-		case <-ctx.Done():
-			return fmt.Errorf("timed out waiting for %s: %w", path, ctx.Err())
-		case <-ticker.C:
-		}
-	}
 }
 
 func (w *NodeController) tryAcquire(podKey string) bool {

--- a/deploy/snapshot/internal/controller/controller.go
+++ b/deploy/snapshot/internal/controller/controller.go
@@ -188,9 +188,6 @@ func (w *NodeController) reconcileCheckpointPod(ctx context.Context, pod *corev1
 	if pod.Spec.NodeName != w.config.NodeName {
 		return
 	}
-	if !isPodReady(pod) {
-		return
-	}
 
 	podKey := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
 
@@ -218,6 +215,9 @@ func (w *NodeController) reconcileCheckpointPod(ctx context.Context, pod *corev1
 		return
 	}
 	containerName := targets[0]
+	if !isContainerReady(pod, containerName) {
+		return
+	}
 
 	if !w.tryAcquire(podKey) {
 		return

--- a/deploy/snapshot/internal/controller/controller.go
+++ b/deploy/snapshot/internal/controller/controller.go
@@ -51,7 +51,12 @@ type checkpointLocations struct {
 	ContainerPath string
 }
 
-const gmsCompletionPollInterval = 50 * time.Millisecond
+const (
+	gmsCompletionPollInterval        = 50 * time.Millisecond
+	restoreContainerResolveInterval  = 50 * time.Millisecond
+	restoreContainerResolveTimeout   = 30 * time.Second
+	restoreContainerResolveKeySuffix = "resolve"
+)
 
 // NewNodeController creates the node-local controller that runs inside snapshot-agent.
 func NewNodeController(
@@ -299,19 +304,79 @@ func (w *NodeController) maybeStartRestoreForContainer(
 	checkpointID string,
 	podKey string,
 ) {
-	containerID := ""
-	for _, cs := range pod.Status.ContainerStatuses {
-		if cs.Name != containerName || cs.ContainerID == "" {
-			continue
-		}
-		containerID = snapshotruntime.StripCRIScheme(cs.ContainerID)
-		break
-	}
+	containerID := restoreContainerIDFromStatus(pod, containerName)
 	if containerID == "" {
-		w.log.V(1).Info("Restore pod has no running container yet", "pod", podKey, "container", containerName)
+		w.maybeStartRestoreContainerResolver(ctx, pod.DeepCopy(), containerName, checkpointID, podKey)
 		return
 	}
 
+	w.startRestoreForContainer(ctx, pod, containerName, containerID, checkpointID, podKey)
+}
+
+func restoreContainerIDFromStatus(pod *corev1.Pod, containerName string) string {
+	for _, cs := range pod.Status.ContainerStatuses {
+		if cs.Name == containerName && cs.ContainerID != "" {
+			return snapshotruntime.StripCRIScheme(cs.ContainerID)
+		}
+	}
+	return ""
+}
+
+func (w *NodeController) maybeStartRestoreContainerResolver(
+	ctx context.Context,
+	pod *corev1.Pod,
+	containerName string,
+	checkpointID string,
+	podKey string,
+) {
+	resolveKey := fmt.Sprintf("%s/%s/%s", podKey, containerName, restoreContainerResolveKeySuffix)
+	if !w.tryAcquire(resolveKey) {
+		return
+	}
+
+	w.log.V(1).Info("Restore pod has no running container in Kubernetes status yet; resolving via node runtime",
+		"pod", podKey,
+		"container", containerName,
+	)
+
+	go func() {
+		defer w.release(resolveKey)
+
+		resolveCtx, cancel := context.WithTimeout(ctx, restoreContainerResolveTimeout)
+		defer cancel()
+
+		ticker := time.NewTicker(restoreContainerResolveInterval)
+		defer ticker.Stop()
+
+		for {
+			containerID, err := w.runtime.ResolveContainerIDByPod(resolveCtx, pod.Name, pod.Namespace, containerName)
+			if err == nil && containerID != "" {
+				w.startRestoreForContainer(ctx, pod, containerName, containerID, checkpointID, podKey)
+				return
+			}
+
+			select {
+			case <-resolveCtx.Done():
+				w.log.V(1).Info("Timed out resolving restore container via node runtime",
+					"pod", podKey,
+					"container", containerName,
+					"err", err,
+				)
+				return
+			case <-ticker.C:
+			}
+		}
+	}()
+}
+
+func (w *NodeController) startRestoreForContainer(
+	ctx context.Context,
+	pod *corev1.Pod,
+	containerName string,
+	containerID string,
+	checkpointID string,
+	podKey string,
+) {
 	annotationKeys, err := snapshotprotocol.RestoreStatusAnnotationKeysFor(containerName)
 	if err != nil {
 		w.log.Error(err, "Restore target container name cannot be used in restore status annotation key", "pod", podKey, "container", containerName)

--- a/deploy/snapshot/internal/controller/controller_test.go
+++ b/deploy/snapshot/internal/controller/controller_test.go
@@ -28,13 +28,21 @@ const testNodeName = "test-node"
 const testContainerID = "test-container"
 
 // fakeRuntime is a minimal Runtime implementation for controller reconciliation
-// tests. Resolve paths aren't exercised by the reconciler filter tests.
-type fakeRuntime struct{}
+// tests.
+type fakeRuntime struct {
+	containerIDByPod string
+}
 
 var _ snapshotruntime.Runtime = (*fakeRuntime)(nil)
 
 func (r *fakeRuntime) ResolveContainer(ctx context.Context, id string) (int, *specs.Spec, error) {
 	return 0, nil, errors.New("not implemented")
+}
+func (r *fakeRuntime) ResolveContainerIDByPod(ctx context.Context, pod, ns, ctr string) (string, error) {
+	if r.containerIDByPod != "" {
+		return r.containerIDByPod, nil
+	}
+	return "", errors.New("not implemented")
 }
 func (r *fakeRuntime) ResolveContainerByPod(ctx context.Context, pod, ns, ctr string) (int, *specs.Spec, error) {
 	return 0, nil, errors.New("not implemented")
@@ -688,6 +696,40 @@ func TestReconcileRestorePodRejectsTargetNameThatCannotFitStatusAnnotation(t *te
 	if len(w.inFlight) != 0 {
 		t.Fatalf("expected restore not to start for overlong annotation key, got inFlight=%v", w.inFlight)
 	}
+}
+
+func TestReconcileRestorePodResolvesContainerBeforePodStatus(t *testing.T) {
+	labels := map[string]string{
+		snapshotprotocol.CheckpointIDLabel: "abc123",
+	}
+	w := makeTestController(t)
+	w.runtime = &fakeRuntime{containerIDByPod: testContainerID}
+	clientset := w.clientset.(*fake.Clientset)
+
+	pod := makePod("test-pod", "default", testNodeName, corev1.PodRunning, false, labels, nil)
+	pod.Status.ContainerStatuses = nil
+	dir := filepath.Join(w.config.Storage.BasePath, "abc123", "versions", snapshotprotocol.DefaultCheckpointArtifactVersion)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("failed to create checkpoint dir: %v", err)
+	}
+
+	w.reconcileRestorePod(context.Background(), pod)
+
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		for _, action := range clientset.Actions() {
+			create, ok := action.(clientgotesting.CreateAction)
+			if !ok || create.GetResource().Resource != "events" {
+				continue
+			}
+			event, ok := create.GetObject().(*corev1.Event)
+			if ok && event.Reason == "RestoreRequested" {
+				return
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("expected RestoreRequested event after node-runtime container resolution; actions=%#v", clientset.Actions())
 }
 
 func TestRunCheckpointKeepsLeaseAndInFlightOnTerminalStatusPatchFailure(t *testing.T) {

--- a/deploy/snapshot/internal/controller/controller_test.go
+++ b/deploy/snapshot/internal/controller/controller_test.go
@@ -113,6 +113,9 @@ func makePod(name, namespace, nodeName string, phase corev1.PodPhase, ready bool
 		Status: corev1.PodStatus{
 			Phase:      phase,
 			Conditions: conditions,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "main", Ready: ready, ContainerID: "containerd://" + testContainerID},
+			},
 		},
 	}
 }

--- a/deploy/snapshot/internal/controller/controller_test.go
+++ b/deploy/snapshot/internal/controller/controller_test.go
@@ -794,38 +794,3 @@ func TestRunCheckpointKeepsLeaseAndInFlightOnTerminalStatusPatchFailure(t *testi
 		t.Fatalf("unexpected remaining lease holder: %#v", remainingLease.Spec.HolderIdentity)
 	}
 }
-
-func TestWaitForFile(t *testing.T) {
-	t.Run("returns when file exists", func(t *testing.T) {
-		path := filepath.Join(t.TempDir(), "sentinel")
-		if err := os.WriteFile(path, []byte("ok\n"), 0o644); err != nil {
-			t.Fatal(err)
-		}
-		if err := waitForFile(context.Background(), path, time.Millisecond); err != nil {
-			t.Fatalf("waitForFile returned error: %v", err)
-		}
-	})
-
-	t.Run("returns context error when missing", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
-		defer cancel()
-		err := waitForFile(ctx, filepath.Join(t.TempDir(), "missing"), time.Millisecond)
-		if err == nil {
-			t.Fatal("expected waitForFile to return an error")
-		}
-	})
-}
-
-func TestGMSCompletionFileName(t *testing.T) {
-	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{UID: "pod-uid"}}
-	if got := gmsCompletionFileName(pod, snapshotprotocol.GMSLoadCompleteFile); got != "gms-load-complete-pod-uid" {
-		t.Fatalf("pod uid completion file = %q", got)
-	}
-
-	pod.Annotations = map[string]string{
-		snapshotprotocol.GMSCompletionFileModeAnnotation: snapshotprotocol.GMSCompletionFileModeShared,
-	}
-	if got := gmsCompletionFileName(pod, snapshotprotocol.GMSLoadCompleteFile); got != snapshotprotocol.GMSLoadCompleteFile {
-		t.Fatalf("shared completion file = %q", got)
-	}
-}

--- a/deploy/snapshot/internal/controller/controller_test.go
+++ b/deploy/snapshot/internal/controller/controller_test.go
@@ -749,3 +749,38 @@ func TestRunCheckpointKeepsLeaseAndInFlightOnTerminalStatusPatchFailure(t *testi
 		t.Fatalf("unexpected remaining lease holder: %#v", remainingLease.Spec.HolderIdentity)
 	}
 }
+
+func TestWaitForFile(t *testing.T) {
+	t.Run("returns when file exists", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "sentinel")
+		if err := os.WriteFile(path, []byte("ok\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := waitForFile(context.Background(), path, time.Millisecond); err != nil {
+			t.Fatalf("waitForFile returned error: %v", err)
+		}
+	})
+
+	t.Run("returns context error when missing", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+		defer cancel()
+		err := waitForFile(ctx, filepath.Join(t.TempDir(), "missing"), time.Millisecond)
+		if err == nil {
+			t.Fatal("expected waitForFile to return an error")
+		}
+	})
+}
+
+func TestGMSCompletionFileName(t *testing.T) {
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{UID: "pod-uid"}}
+	if got := gmsCompletionFileName(pod, snapshotprotocol.GMSLoadCompleteFile); got != "gms-load-complete-pod-uid" {
+		t.Fatalf("pod uid completion file = %q", got)
+	}
+
+	pod.Annotations = map[string]string{
+		snapshotprotocol.GMSCompletionFileModeAnnotation: snapshotprotocol.GMSCompletionFileModeShared,
+	}
+	if got := gmsCompletionFileName(pod, snapshotprotocol.GMSLoadCompleteFile); got != snapshotprotocol.GMSLoadCompleteFile {
+		t.Fatalf("shared completion file = %q", got)
+	}
+}

--- a/deploy/snapshot/internal/controller/util.go
+++ b/deploy/snapshot/internal/controller/util.go
@@ -48,13 +48,13 @@ func podFromInformerObj(obj interface{}) (*corev1.Pod, bool) {
 	return pod, ok
 }
 
-func isPodReady(pod *corev1.Pod) bool {
+func isContainerReady(pod *corev1.Pod, containerName string) bool {
 	if pod.Status.Phase != corev1.PodRunning {
 		return false
 	}
-	for _, cond := range pod.Status.Conditions {
-		if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
-			return true
+	for _, status := range pod.Status.ContainerStatuses {
+		if status.Name == containerName {
+			return status.Ready
 		}
 	}
 	return false

--- a/deploy/snapshot/internal/runtime/oci_containerd.go
+++ b/deploy/snapshot/internal/runtime/oci_containerd.go
@@ -51,6 +51,32 @@ func (r *ContainerdRuntime) ResolveContainer(ctx context.Context, containerID st
 }
 
 func (r *ContainerdRuntime) ResolveContainerByPod(ctx context.Context, podName, podNamespace, containerName string) (int, *specs.Spec, error) {
+	container, err := r.findRunningContainerByPod(ctx, podName, podNamespace, containerName)
+	if err != nil {
+		return 0, nil, err
+	}
+	ctx = namespaces.WithNamespace(ctx, k8sNamespace)
+
+	task, err := container.Task(ctx, nil)
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to get task for container %s (pod %s/%s): %w", container.ID(), podNamespace, podName, err)
+	}
+	spec, err := container.Spec(ctx)
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to get spec for container %s (pod %s/%s): %w", container.ID(), podNamespace, podName, err)
+	}
+	return int(task.Pid()), spec, nil
+}
+
+func (r *ContainerdRuntime) ResolveContainerIDByPod(ctx context.Context, podName, podNamespace, containerName string) (string, error) {
+	container, err := r.findRunningContainerByPod(ctx, podName, podNamespace, containerName)
+	if err != nil {
+		return "", err
+	}
+	return container.ID(), nil
+}
+
+func (r *ContainerdRuntime) findRunningContainerByPod(ctx context.Context, podName, podNamespace, containerName string) (containerd.Container, error) {
 	ctx = namespaces.WithNamespace(ctx, k8sNamespace)
 
 	filter := fmt.Sprintf("labels.\"io.kubernetes.pod.name\"==%s,labels.\"io.kubernetes.pod.namespace\"==%s,labels.\"io.kubernetes.container.name\"==%s",
@@ -58,24 +84,18 @@ func (r *ContainerdRuntime) ResolveContainerByPod(ctx context.Context, podName, 
 
 	containers, err := r.client.Containers(ctx, filter)
 	if err != nil {
-		return 0, nil, fmt.Errorf("failed to list containers for pod %s/%s: %w", podNamespace, podName, err)
+		return nil, fmt.Errorf("failed to list containers for pod %s/%s: %w", podNamespace, podName, err)
 	}
 	if len(containers) == 0 {
-		return 0, nil, fmt.Errorf("no container found for pod %s/%s container %s", podNamespace, podName, containerName)
+		return nil, fmt.Errorf("no container found for pod %s/%s container %s", podNamespace, podName, containerName)
 	}
 
 	// During container restarts, both the old and new container may be listed;
 	// pick the first with a live task.
 	for _, c := range containers {
-		task, err := c.Task(ctx, nil)
-		if err != nil {
-			continue
+		if _, err := c.Task(ctx, nil); err == nil {
+			return c, nil
 		}
-		spec, err := c.Spec(ctx)
-		if err != nil {
-			continue
-		}
-		return int(task.Pid()), spec, nil
 	}
-	return 0, nil, fmt.Errorf("no running container found for pod %s/%s container %s (%d candidates)", podNamespace, podName, containerName, len(containers))
+	return nil, fmt.Errorf("no running container found for pod %s/%s container %s (%d candidates)", podNamespace, podName, containerName, len(containers))
 }

--- a/deploy/snapshot/internal/runtime/oci_crio.go
+++ b/deploy/snapshot/internal/runtime/oci_crio.go
@@ -48,6 +48,31 @@ func (r *CRIORuntime) ResolveContainer(ctx context.Context, id string) (int, *sp
 // ResolveContainerByPod picks the first RUNNING container matching the pod +
 // container-name label filter; errors if none qualify.
 func (r *CRIORuntime) ResolveContainerByPod(ctx context.Context, podName, podNamespace, containerName string) (int, *specs.Spec, error) {
+	running, err := r.findRunningContainerByPod(ctx, podName, podNamespace, containerName)
+	if err != nil {
+		return 0, nil, err
+	}
+	ctx, cancel := context.WithTimeout(ctx, crioCallTimeout)
+	defer cancel()
+
+	statusResp, err := r.svc.ContainerStatus(ctx, running.GetId(), true)
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to get status for container %s (pod %s/%s): %w", running.GetId(), podNamespace, podName, err)
+	}
+	return parseCRIOStatus(running.GetId(), statusResp.GetInfo())
+}
+
+func (r *CRIORuntime) ResolveContainerIDByPod(ctx context.Context, podName, podNamespace, containerName string) (string, error) {
+	running, err := r.findRunningContainerByPod(ctx, podName, podNamespace, containerName)
+	if err != nil {
+		return "", err
+	}
+	return running.GetId(), nil
+}
+
+// findRunningContainerByPod picks the first RUNNING container matching the pod
+// + container-name label filter; errors if none qualify.
+func (r *CRIORuntime) findRunningContainerByPod(ctx context.Context, podName, podNamespace, containerName string) (*runtimeapi.Container, error) {
 	ctx, cancel := context.WithTimeout(ctx, crioCallTimeout)
 	defer cancel()
 
@@ -60,10 +85,10 @@ func (r *CRIORuntime) ResolveContainerByPod(ctx context.Context, podName, podNam
 	}
 	containers, err := r.svc.ListContainers(ctx, filter)
 	if err != nil {
-		return 0, nil, fmt.Errorf("failed to list containers for pod %s/%s: %w", podNamespace, podName, err)
+		return nil, fmt.Errorf("failed to list containers for pod %s/%s: %w", podNamespace, podName, err)
 	}
 	if len(containers) == 0 {
-		return 0, nil, fmt.Errorf("no container found for pod %s/%s container %s", podNamespace, podName, containerName)
+		return nil, fmt.Errorf("no container found for pod %s/%s container %s", podNamespace, podName, containerName)
 	}
 
 	var running *runtimeapi.Container
@@ -74,14 +99,9 @@ func (r *CRIORuntime) ResolveContainerByPod(ctx context.Context, podName, podNam
 		}
 	}
 	if running == nil {
-		return 0, nil, fmt.Errorf("no running container found for pod %s/%s container %s (%d candidates)", podNamespace, podName, containerName, len(containers))
+		return nil, fmt.Errorf("no running container found for pod %s/%s container %s (%d candidates)", podNamespace, podName, containerName, len(containers))
 	}
-
-	statusResp, err := r.svc.ContainerStatus(ctx, running.GetId(), true)
-	if err != nil {
-		return 0, nil, fmt.Errorf("failed to get status for container %s (pod %s/%s): %w", running.GetId(), podNamespace, podName, err)
-	}
-	return parseCRIOStatus(running.GetId(), statusResp.GetInfo())
+	return running, nil
 }
 
 // crioInfo is the JSON shape CRI-O writes into ContainerStatus.Info["info"]

--- a/deploy/snapshot/internal/runtime/runtime.go
+++ b/deploy/snapshot/internal/runtime/runtime.go
@@ -24,6 +24,7 @@ const (
 // Resolve methods return non-nil *specs.Spec with PID > 0 on success, or an error.
 type Runtime interface {
 	ResolveContainer(ctx context.Context, id string) (int, *specs.Spec, error)
+	ResolveContainerIDByPod(ctx context.Context, pod, ns, ctr string) (string, error)
 	ResolveContainerByPod(ctx context.Context, pod, ns, ctr string) (int, *specs.Spec, error)
 	Close() error
 }

--- a/deploy/snapshot/protocol/common.go
+++ b/deploy/snapshot/protocol/common.go
@@ -19,18 +19,6 @@ const (
 
 	CheckpointArtifactVersionAnnotation = "nvidia.com/snapshot-artifact-version"
 
-	// GMSCheckpointDirAnnotation tells snapshot-agent where the companion
-	// GMS saver/loader sidecar writes its lifecycle sentinel on the checkpoint
-	// PVC. When absent, the snapshot flow has no GMS barrier.
-	GMSCheckpointDirAnnotation = "nvidia.com/snapshot-gms-checkpoint-dir"
-
-	// GMSCompletionFileModeAnnotation controls whether snapshot-agent waits
-	// for a pod-UID-scoped GMS completion file or for a shared file written
-	// by a separate inter-pod GMS weight-server pod.
-	GMSCompletionFileModeAnnotation = "nvidia.com/snapshot-gms-completion-file-mode"
-	GMSCompletionFileModePodUID     = "pod-uid"
-	GMSCompletionFileModeShared     = "shared"
-
 	// TargetContainersAnnotation names the container(s) a checkpoint or
 	// restore operation should act on. It is required — snapshotprotocol /
 	// snapshotctl / snapshot-agent all error out when the annotation is
@@ -70,8 +58,6 @@ const (
 	RestoreStatusInProgress   = "in_progress"
 	RestoreStatusCompleted    = "completed"
 	RestoreStatusFailed       = "failed"
-	GMSSaveCompleteFile       = "gms-save-complete"
-	GMSLoadCompleteFile       = "gms-load-complete"
 )
 
 type Storage struct {

--- a/deploy/snapshot/protocol/common.go
+++ b/deploy/snapshot/protocol/common.go
@@ -19,7 +19,30 @@ const (
 
 	CheckpointArtifactVersionAnnotation = "nvidia.com/snapshot-artifact-version"
 
-	// Required comma-separated checkpoint/restore target container list.
+	// GMSCheckpointDirAnnotation tells snapshot-agent where the companion
+	// GMS saver/loader sidecar writes its lifecycle sentinel on the checkpoint
+	// PVC. When absent, the snapshot flow has no GMS barrier.
+	GMSCheckpointDirAnnotation = "nvidia.com/snapshot-gms-checkpoint-dir"
+
+	// GMSCompletionFileModeAnnotation controls whether snapshot-agent waits
+	// for a pod-UID-scoped GMS completion file or for a shared file written
+	// by a separate inter-pod GMS weight-server pod.
+	GMSCompletionFileModeAnnotation = "nvidia.com/snapshot-gms-completion-file-mode"
+	GMSCompletionFileModePodUID     = "pod-uid"
+	GMSCompletionFileModeShared     = "shared"
+
+	// TargetContainersAnnotation names the container(s) a checkpoint or
+	// restore operation should act on. It is required — snapshotprotocol /
+	// snapshotctl / snapshot-agent all error out when the annotation is
+	// missing. Comma-separated list of container names in a single pod:
+	//
+	//   nvidia.com/snapshot-target-containers = "engine-0,engine-1"
+	//
+	// Checkpoint Jobs must carry exactly one target container (the snapshot
+	// contract captures one workload container per checkpoint). Restore pods
+	// may carry one or more target containers; the agent replays the same
+	// checkpoint into each of them. The operator stamps the annotation for
+	// both user-facing paths (DynamoCheckpoint Jobs and DGD restore pods).
 	TargetContainersAnnotation = "nvidia.com/snapshot-target-containers"
 
 	CheckpointStatusAnnotation = "nvidia.com/snapshot-checkpoint-status"
@@ -47,6 +70,8 @@ const (
 	RestoreStatusInProgress   = "in_progress"
 	RestoreStatusCompleted    = "completed"
 	RestoreStatusFailed       = "failed"
+	GMSSaveCompleteFile       = "gms-save-complete"
+	GMSLoadCompleteFile       = "gms-load-complete"
 )
 
 type Storage struct {

--- a/deploy/snapshot/protocol/restore.go
+++ b/deploy/snapshot/protocol/restore.go
@@ -86,6 +86,9 @@ func PrepareRestorePodSpec(
 		if isCheckpointReady {
 			container.Command = []string{"sleep", "infinity"}
 			container.Args = nil
+			// Restore needs the placeholder container running before nsrestore can
+			// enter its namespaces; avoid registry checks on the critical path.
+			container.ImagePullPolicy = corev1.PullIfNotPresent
 			ensureRestoreStartupProbe(container)
 		}
 	}

--- a/deploy/snapshot/protocol/restore.go
+++ b/deploy/snapshot/protocol/restore.go
@@ -92,8 +92,30 @@ func PrepareRestorePodSpec(
 	return nil
 }
 
-// ensureRestoreStartupProbe reuses the workload's probe when possible and
-// falls back to the restore-complete sentinel when the workload has no probe.
+// ensureRestoreStartupProbe installs a StartupProbe that pauses kubelet's
+// readiness check until CRIU restore completes.
+//
+// The probe is synthesized in two ways:
+//
+//   - **Synthesis from existing probe (preferred).** If the container already
+//     defines a StartupProbe, LivenessProbe, or ReadinessProbe (in that order
+//     of preference), we deep-copy it and set the retry thresholds plus the
+//     minimum probe cadence. The kubelet then runs the workload's *own* probe
+//     with effectively-infinite retries during restore — the same shape the
+//     non-failover restore path on main has used since #8403, but without the
+//     cold-start probe interval.
+//
+//   - **Sentinel-file fallback.** If the container has no Startup/Liveness/
+//     Readiness probes at all, kubelet would otherwise mark the `sleep
+//     infinity` placeholder Ready immediately and route traffic to a process
+//     that hasn't been CRIUed yet. To avoid that regression we install an
+//     exec probe that watches for the agent-written `restore-complete`
+//     sentinel file in the per-container `/snapshot-control` subPath.
+//
+// The sentinel file is also written by the agent in the synthesis case (the
+// workload's `_wait_for_sentinel` poller in components/src/dynamo/common/
+// utils/snapshot.py uses it to know when CRIU has placed it back), so the
+// signal is the same; only the kubelet-visible probe shape differs.
 func ensureRestoreStartupProbe(container *corev1.Container) {
 	startup := container.StartupProbe
 	if startup == nil {
@@ -109,6 +131,7 @@ func ensureRestoreStartupProbe(container *corev1.Container) {
 					Command: []string{"cat", filepath.Join(SnapshotControlMountPath, RestoreCompleteFile)},
 				},
 			},
+			TimeoutSeconds:   1,
 			PeriodSeconds:    1,
 			FailureThreshold: math.MaxInt32,
 			SuccessThreshold: 1,
@@ -117,6 +140,9 @@ func ensureRestoreStartupProbe(container *corev1.Container) {
 	}
 
 	startup = startup.DeepCopy()
+	startup.InitialDelaySeconds = 0
+	startup.PeriodSeconds = 1
+	startup.TimeoutSeconds = 1
 	startup.FailureThreshold = math.MaxInt32
 	startup.SuccessThreshold = 1
 	container.StartupProbe = startup

--- a/deploy/snapshot/protocol/restore_test.go
+++ b/deploy/snapshot/protocol/restore_test.go
@@ -328,9 +328,10 @@ func TestPrepareRestorePodSpecSynthesizesStartupProbeFromLiveness(t *testing.T) 
 		ProbeHandler: corev1.ProbeHandler{
 			HTTPGet: &corev1.HTTPGetAction{Path: "/livez"},
 		},
-		PeriodSeconds:    5,
-		TimeoutSeconds:   4,
-		FailureThreshold: 2,
+		InitialDelaySeconds: 9,
+		PeriodSeconds:       5,
+		TimeoutSeconds:      4,
+		FailureThreshold:    2,
 	}
 	podSpec := corev1.PodSpec{
 		Containers: []corev1.Container{{
@@ -355,12 +356,6 @@ func TestPrepareRestorePodSpecSynthesizesStartupProbeFromLiveness(t *testing.T) 
 	assertRestoreStartupGate(t, container.StartupProbe)
 	if container.StartupProbe.HTTPGet == nil || container.StartupProbe.HTTPGet.Path != "/livez" {
 		t.Fatalf("expected synthesized startup probe to inherit liveness HTTPGet handler, got %#v", container.StartupProbe)
-	}
-	if got := container.StartupProbe.PeriodSeconds; got != livenessProbe.PeriodSeconds {
-		t.Fatalf("expected startup PeriodSeconds %d (from liveness), got %d", livenessProbe.PeriodSeconds, got)
-	}
-	if got := container.StartupProbe.TimeoutSeconds; got != livenessProbe.TimeoutSeconds {
-		t.Fatalf("expected startup TimeoutSeconds %d (from liveness), got %d", livenessProbe.TimeoutSeconds, got)
 	}
 }
 
@@ -401,9 +396,6 @@ func TestPrepareRestorePodSpecSynthesizesStartupProbeFromReadiness(t *testing.T)
 		container.StartupProbe.Exec.Command[0] != "cat" || container.StartupProbe.Exec.Command[1] != "/tmp/ready" {
 		t.Fatalf("expected synthesized startup probe to inherit readiness Exec command, got %#v", container.StartupProbe)
 	}
-	if got := container.StartupProbe.PeriodSeconds; got != readinessProbe.PeriodSeconds {
-		t.Fatalf("expected startup PeriodSeconds %d (from readiness), got %d", readinessProbe.PeriodSeconds, got)
-	}
 }
 
 func TestPrepareRestorePodSpecFallsBackToSentinelWhenNoProbe(t *testing.T) {
@@ -436,22 +428,28 @@ func TestPrepareRestorePodSpecFallsBackToSentinelWhenNoProbe(t *testing.T) {
 			t.Fatalf("fallback startup probe command = %#v, want %#v", container.StartupProbe.Exec.Command, want)
 		}
 	}
-	if got := container.StartupProbe.PeriodSeconds; got != 1 {
-		t.Fatalf("expected fallback startup PeriodSeconds=1, got %d", got)
-	}
 }
 
-// assertRestoreStartupGate verifies the threshold invariants every restore
-// StartupProbe must satisfy: FailureThreshold=MaxInt32 (effectively infinite
-// retries during CRIU restore) and SuccessThreshold=1. The handler shape is
-// not checked here because ensureRestoreStartupProbe synthesizes the probe
-// from whatever Startup/Liveness/Readiness handler the workload defined; only
-// when no user probe is present does it fall back to the sentinel-cat exec
-// probe (covered by assertSentinelRestoreStartupGate).
+// assertRestoreStartupGate verifies the invariants every restore StartupProbe
+// must satisfy: no initial delay, the minimum kubelet probe cadence, effectively
+// infinite retries during CRIU restore, and SuccessThreshold=1. The handler
+// shape is not checked here because ensureRestoreStartupProbe synthesizes the
+// probe from whatever Startup/Liveness/Readiness handler the workload defined;
+// only when no user probe is present does it fall back to the sentinel-cat exec
+// probe.
 func assertRestoreStartupGate(t *testing.T, probe *corev1.Probe) {
 	t.Helper()
 	if probe == nil {
 		t.Fatalf("expected non-nil startup probe")
+	}
+	if got := probe.InitialDelaySeconds; got != 0 {
+		t.Fatalf("expected startup initial delay 0, got %d", got)
+	}
+	if got := probe.PeriodSeconds; got != 1 {
+		t.Fatalf("expected startup period 1, got %d", got)
+	}
+	if got := probe.TimeoutSeconds; got != 1 {
+		t.Fatalf("expected startup timeout 1, got %d", got)
 	}
 	if got := probe.FailureThreshold; got != math.MaxInt32 {
 		t.Fatalf("expected startup failure threshold %d, got %d", math.MaxInt32, got)

--- a/deploy/snapshot/protocol/restore_test.go
+++ b/deploy/snapshot/protocol/restore_test.go
@@ -30,13 +30,14 @@ func TestNewRestorePod(t *testing.T) {
 		Spec: corev1.PodSpec{
 			RestartPolicy: corev1.RestartPolicyAlways,
 			Containers: []corev1.Container{{
-				Name:           "main",
-				Image:          "test:latest",
-				Command:        []string{"python3", "-m", "dynamo.vllm"},
-				Args:           []string{"--model", "Qwen"},
-				ReadinessProbe: readinessProbe.DeepCopy(),
-				LivenessProbe:  livenessProbe.DeepCopy(),
-				StartupProbe:   startupProbe.DeepCopy(),
+				Name:            "main",
+				Image:           "test:latest",
+				ImagePullPolicy: corev1.PullAlways,
+				Command:         []string{"python3", "-m", "dynamo.vllm"},
+				Args:            []string{"--model", "Qwen"},
+				ReadinessProbe:  readinessProbe.DeepCopy(),
+				LivenessProbe:   livenessProbe.DeepCopy(),
+				StartupProbe:    startupProbe.DeepCopy(),
 			}},
 		},
 	}, PodOptions{
@@ -78,6 +79,9 @@ func TestNewRestorePod(t *testing.T) {
 	}
 	if main.Args != nil {
 		t.Fatalf("expected restore args to be cleared: %#v", main.Args)
+	}
+	if main.ImagePullPolicy != corev1.PullIfNotPresent {
+		t.Fatalf("expected restore image pull policy %q, got %q", corev1.PullIfNotPresent, main.ImagePullPolicy)
 	}
 	if main.ReadinessProbe == nil {
 		t.Fatalf("expected readiness probe to be preserved")
@@ -137,9 +141,9 @@ func TestNewRestorePodShapesMultipleTargets(t *testing.T) {
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
-				{Name: "engine-0", Image: "test:latest", Command: []string{"python3"}, Args: []string{"--serve"}},
-				{Name: "engine-1", Image: "test:latest", Command: []string{"python3"}, Args: []string{"--serve"}},
-				{Name: "sidecar", Image: "sidecar:latest", Command: []string{"sidecar"}, Args: []string{"run"}},
+				{Name: "engine-0", Image: "test:latest", ImagePullPolicy: corev1.PullAlways, Command: []string{"python3"}, Args: []string{"--serve"}},
+				{Name: "engine-1", Image: "test:latest", ImagePullPolicy: corev1.PullAlways, Command: []string{"python3"}, Args: []string{"--serve"}},
+				{Name: "sidecar", Image: "sidecar:latest", ImagePullPolicy: corev1.PullAlways, Command: []string{"sidecar"}, Args: []string{"run"}},
 			},
 		},
 	}, PodOptions{
@@ -165,6 +169,9 @@ func TestNewRestorePodShapesMultipleTargets(t *testing.T) {
 		if c.Args != nil {
 			t.Fatalf("expected args cleared on %s, got %#v", name, c.Args)
 		}
+		if c.ImagePullPolicy != corev1.PullIfNotPresent {
+			t.Fatalf("expected restore image pull policy %q on %s, got %q", corev1.PullIfNotPresent, name, c.ImagePullPolicy)
+		}
 		assertRestoreStartupGate(t, c.StartupProbe)
 		found := false
 		for _, m := range c.VolumeMounts {
@@ -183,6 +190,9 @@ func TestNewRestorePodShapesMultipleTargets(t *testing.T) {
 	sidecar := findRestoreContainer(t, restorePod.Spec.Containers, "sidecar")
 	if len(sidecar.Command) != 1 || sidecar.Command[0] != "sidecar" {
 		t.Fatalf("sidecar command must not be rewritten, got %#v", sidecar.Command)
+	}
+	if sidecar.ImagePullPolicy != corev1.PullAlways {
+		t.Fatalf("sidecar image pull policy must not be rewritten, got %q", sidecar.ImagePullPolicy)
 	}
 	for _, m := range sidecar.VolumeMounts {
 		if m.Name == SnapshotControlVolumeName {
@@ -241,12 +251,13 @@ func TestPrepareRestorePodSpec(t *testing.T) {
 	livenessProbe := &corev1.Probe{TimeoutSeconds: 5}
 	startupProbe := &corev1.Probe{FailureThreshold: 60}
 	podSpec.Containers = []corev1.Container{{
-		Name:           "main",
-		Command:        []string{"python3", "-m", "dynamo.vllm"},
-		Args:           []string{"--model", "Qwen"},
-		ReadinessProbe: readinessProbe.DeepCopy(),
-		LivenessProbe:  livenessProbe.DeepCopy(),
-		StartupProbe:   startupProbe.DeepCopy(),
+		Name:            "main",
+		ImagePullPolicy: corev1.PullAlways,
+		Command:         []string{"python3", "-m", "dynamo.vllm"},
+		Args:            []string{"--model", "Qwen"},
+		ReadinessProbe:  readinessProbe.DeepCopy(),
+		LivenessProbe:   livenessProbe.DeepCopy(),
+		StartupProbe:    startupProbe.DeepCopy(),
 	}}
 
 	storage := Storage{
@@ -304,6 +315,9 @@ func TestPrepareRestorePodSpec(t *testing.T) {
 	}
 	if container.Args != nil {
 		t.Fatalf("expected restore args to be cleared: %#v", container.Args)
+	}
+	if container.ImagePullPolicy != corev1.PullIfNotPresent {
+		t.Fatalf("expected restore image pull policy %q, got %q", corev1.PullIfNotPresent, container.ImagePullPolicy)
 	}
 	if container.ReadinessProbe == nil {
 		t.Fatalf("expected readiness probe to be preserved")

--- a/lib/gpu_memory_service/README.md
+++ b/lib/gpu_memory_service/README.md
@@ -611,4 +611,5 @@ To change how long a sleeping/restored engine waits for the published weights la
 --model-loader-extra-config '{"gms_ro_connect_timeout_ms": 300000}'
 ```
 
-The default is `30000` ms. Set the value to `null` to wait indefinitely.
+The default is `null`, which waits indefinitely. Set an integer value to fail
+after that many milliseconds.

--- a/lib/gpu_memory_service/README.md
+++ b/lib/gpu_memory_service/README.md
@@ -604,3 +604,11 @@ To force read-only mode (import only, never load from disk), pass `gms_read_only
 ```
 
 This forces `RO` lock mode instead of the default `RW_OR_RO` auto-detection. The engine will only import existing committed weights and fail if none are available.
+
+To change how long a sleeping/restored engine waits for the published weights layout before remapping weights, pass `gms_ro_connect_timeout_ms`:
+
+```bash
+--model-loader-extra-config '{"gms_ro_connect_timeout_ms": 300000}'
+```
+
+The default is `30000` ms. Set the value to `null` to wait indefinitely.

--- a/lib/gpu_memory_service/cli/snapshot/loader.py
+++ b/lib/gpu_memory_service/cli/snapshot/loader.py
@@ -16,6 +16,7 @@ import signal
 import sys
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
 
 from gpu_memory_service.common.cuda_utils import list_devices
 from gpu_memory_service.common.utils import get_socket_path, wait_for_weights_socket
@@ -26,6 +27,10 @@ logging.basicConfig(
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 )
 logger = logging.getLogger(__name__)
+
+DEFAULT_GMS_LOAD_COMPLETE_FILE = "gms-load-complete"
+GMS_LOAD_COMPLETE_FILE_ENV = "GMS_LOAD_COMPLETE_FILE"
+GMS_POD_UID_ENV = "GMS_POD_UID"
 
 
 def _load_device(checkpoint_dir: str, device: int, max_workers: int) -> None:
@@ -46,9 +51,40 @@ def _load_device(checkpoint_dir: str, device: int, max_workers: int) -> None:
     logger.info("GMS checkpoint loaded: device=%d elapsed=%.2fs", device, elapsed)
 
 
+def _completion_sentinel_file() -> str:
+    override = os.environ.get(GMS_LOAD_COMPLETE_FILE_ENV, "").strip()
+    if override:
+        return override
+    pod_uid = os.environ.get(GMS_POD_UID_ENV, "").strip()
+    if pod_uid:
+        return f"{DEFAULT_GMS_LOAD_COMPLETE_FILE}-{pod_uid}"
+    return DEFAULT_GMS_LOAD_COMPLETE_FILE
+
+
+def _completion_sentinel_path(checkpoint_dir: str) -> Path:
+    return Path(checkpoint_dir) / _completion_sentinel_file()
+
+
+def _clear_completion_sentinel(checkpoint_dir: str) -> None:
+    try:
+        _completion_sentinel_path(checkpoint_dir).unlink()
+    except FileNotFoundError:
+        pass
+
+
+def _write_completion_sentinel(checkpoint_dir: str) -> None:
+    path = _completion_sentinel_path(checkpoint_dir)
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path.write_text("ok\n", encoding="utf-8")
+    tmp_path.replace(path)
+    logger.info("Wrote GMS load completion sentinel: %s", path)
+
+
 def main() -> None:
     checkpoint_dir = os.environ["GMS_CHECKPOINT_DIR"]
     max_workers = int(os.environ.get("GMS_LOAD_WORKERS", "8"))
+    _clear_completion_sentinel(checkpoint_dir)
     devices = list_devices()
 
     t0 = time.monotonic()
@@ -63,6 +99,7 @@ def main() -> None:
             logger.info("Device %d load complete", dev)
     elapsed = time.monotonic() - t0
     logger.info("All %d devices loaded in %.2fs", len(devices), elapsed)
+    _write_completion_sentinel(checkpoint_dir)
     signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
 
     while True:

--- a/lib/gpu_memory_service/cli/snapshot/loader.py
+++ b/lib/gpu_memory_service/cli/snapshot/loader.py
@@ -3,9 +3,8 @@
 
 """GMS checkpoint loader entry point.
 
-Waits for the GMS server UDS socket on each device, then loads saved GMS
-state from a checkpoint directory into the running GMS servers. Devices
-are loaded in parallel to saturate PVC bandwidth.
+Loads saved GMS state from a checkpoint directory into the running GMS servers.
+Devices are loaded in parallel to saturate PVC bandwidth.
 """
 
 from __future__ import annotations
@@ -19,7 +18,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
 from gpu_memory_service.common.cuda_utils import list_devices
-from gpu_memory_service.common.utils import get_socket_path, wait_for_weights_socket
+from gpu_memory_service.common.utils import get_socket_path
 from gpu_memory_service.snapshot.storage_client import GMSStorageClient
 
 logging.basicConfig(
@@ -34,7 +33,6 @@ GMS_POD_UID_ENV = "GMS_POD_UID"
 
 
 def _load_device(checkpoint_dir: str, device: int, max_workers: int) -> None:
-    wait_for_weights_socket(device)
     input_dir = os.path.join(checkpoint_dir, f"device-{device}")
     logger.info("Loading GMS checkpoint: device=%d input_dir=%s", device, input_dir)
     t0 = time.monotonic()

--- a/lib/gpu_memory_service/cli/snapshot/saver.py
+++ b/lib/gpu_memory_service/cli/snapshot/saver.py
@@ -3,23 +3,20 @@
 
 """GMS checkpoint saver entry point.
 
-Waits for committed GMS weights on each device, then saves GPU memory state
-to the checkpoint directory. Runs as an init sidecar — sleeps after saving
-until the pod terminates.
+Saves committed GMS weights from each device to the checkpoint directory.
+Devices are saved in parallel to saturate PVC bandwidth.
 """
 
 from __future__ import annotations
 
 import logging
 import os
-import signal
-import sys
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
 from gpu_memory_service.common.cuda_utils import list_devices
-from gpu_memory_service.common.utils import get_socket_path, wait_for_weights_socket
+from gpu_memory_service.common.utils import get_socket_path
 from gpu_memory_service.snapshot.storage_client import GMSStorageClient
 
 logging.basicConfig(
@@ -34,7 +31,6 @@ GMS_POD_UID_ENV = "GMS_POD_UID"
 
 
 def _save_device(checkpoint_dir: str, device: int, max_workers: int) -> None:
-    wait_for_weights_socket(device)
     output_dir = os.path.join(checkpoint_dir, f"device-{device}")
     logger.info("Saving GMS checkpoint: device=%d output_dir=%s", device, output_dir)
     t0 = time.monotonic()
@@ -95,11 +91,7 @@ def main() -> None:
     elapsed = time.monotonic() - t0
     logger.info("All %d devices saved in %.2fs", len(devices), elapsed)
     _write_completion_sentinel(checkpoint_dir)
-
-    logger.info("Save complete; sleeping until pod terminates")
-    signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
-    while True:
-        time.sleep(3600)
+    logger.info("Save complete; exiting")
 
 
 if __name__ == "__main__":

--- a/lib/gpu_memory_service/cli/snapshot/saver.py
+++ b/lib/gpu_memory_service/cli/snapshot/saver.py
@@ -16,6 +16,7 @@ import signal
 import sys
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
 
 from gpu_memory_service.common.cuda_utils import list_devices
 from gpu_memory_service.common.utils import get_socket_path, wait_for_weights_socket
@@ -26,6 +27,10 @@ logging.basicConfig(
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 )
 logger = logging.getLogger(__name__)
+
+DEFAULT_GMS_SAVE_COMPLETE_FILE = "gms-save-complete"
+GMS_SAVE_COMPLETE_FILE_ENV = "GMS_SAVE_COMPLETE_FILE"
+GMS_POD_UID_ENV = "GMS_POD_UID"
 
 
 def _save_device(checkpoint_dir: str, device: int, max_workers: int) -> None:
@@ -42,9 +47,40 @@ def _save_device(checkpoint_dir: str, device: int, max_workers: int) -> None:
     logger.info("GMS checkpoint saved: device=%d elapsed=%.2fs", device, elapsed)
 
 
+def _completion_sentinel_file() -> str:
+    override = os.environ.get(GMS_SAVE_COMPLETE_FILE_ENV, "").strip()
+    if override:
+        return override
+    pod_uid = os.environ.get(GMS_POD_UID_ENV, "").strip()
+    if pod_uid:
+        return f"{DEFAULT_GMS_SAVE_COMPLETE_FILE}-{pod_uid}"
+    return DEFAULT_GMS_SAVE_COMPLETE_FILE
+
+
+def _completion_sentinel_path(checkpoint_dir: str) -> Path:
+    return Path(checkpoint_dir) / _completion_sentinel_file()
+
+
+def _clear_completion_sentinel(checkpoint_dir: str) -> None:
+    try:
+        _completion_sentinel_path(checkpoint_dir).unlink()
+    except FileNotFoundError:
+        pass
+
+
+def _write_completion_sentinel(checkpoint_dir: str) -> None:
+    path = _completion_sentinel_path(checkpoint_dir)
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path.write_text("ok\n", encoding="utf-8")
+    tmp_path.replace(path)
+    logger.info("Wrote GMS save completion sentinel: %s", path)
+
+
 def main() -> None:
     checkpoint_dir = os.environ["GMS_CHECKPOINT_DIR"]
     max_workers = int(os.environ.get("GMS_SAVE_WORKERS", "8"))
+    _clear_completion_sentinel(checkpoint_dir)
 
     devices = list_devices()
     logger.info("Starting GMS save for %d devices", len(devices))
@@ -58,6 +94,7 @@ def main() -> None:
             future.result()
     elapsed = time.monotonic() - t0
     logger.info("All %d devices saved in %.2fs", len(devices), elapsed)
+    _write_completion_sentinel(checkpoint_dir)
 
     logger.info("Save complete; sleeping until pod terminates")
     signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))

--- a/lib/gpu_memory_service/client/rpc.py
+++ b/lib/gpu_memory_service/client/rpc.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import logging
 import os
 import socket
+import time
 from typing import Optional, Tuple, Type, TypeVar
 
 from gpu_memory_service.common.locks import RequestedLockType
@@ -26,6 +27,9 @@ T = TypeVar("T")
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_CONNECT_TIMEOUT_MS = 300_000
+_CONNECT_RETRY_INTERVAL_SECONDS = 0.05
+
 
 class _GMSRPCTransport:
     """Raw GMS Unix socket transport."""
@@ -39,20 +43,40 @@ class _GMSRPCTransport:
     def is_connected(self) -> bool:
         return self._socket is not None
 
-    def connect(self) -> None:
-        self._socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        try:
-            self._socket.connect(self.socket_path)
-        except FileNotFoundError:
-            self._socket.close()
-            self._socket = None
-            raise ConnectionError(
-                f"GMS server not running at {self.socket_path}"
-            ) from None
-        except Exception as exc:
-            self._socket.close()
-            self._socket = None
-            raise ConnectionError(f"Failed to connect to GMS: {exc}") from exc
+    def connect(self, timeout_ms: int = 0) -> None:
+        deadline = time.monotonic() + timeout_ms / 1000
+        logged_wait = False
+        last_error: Optional[BaseException] = None
+
+        while True:
+            self._socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            try:
+                self._socket.connect(self.socket_path)
+                if logged_wait:
+                    logger.info("Connected to GMS server at %s", self.socket_path)
+                return
+            except (FileNotFoundError, ConnectionRefusedError) as exc:
+                last_error = exc
+                self._socket.close()
+                self._socket = None
+                if timeout_ms <= 0 or time.monotonic() >= deadline:
+                    raise ConnectionError(
+                        f"GMS server not running at {self.socket_path}"
+                    ) from None
+                if not logged_wait:
+                    logger.info("Waiting for GMS server at %s", self.socket_path)
+                    logged_wait = True
+                remaining = max(0.0, deadline - time.monotonic())
+                time.sleep(min(_CONNECT_RETRY_INTERVAL_SECONDS, remaining))
+            except Exception as exc:
+                self._socket.close()
+                self._socket = None
+                raise ConnectionError(f"Failed to connect to GMS: {exc}") from exc
+
+            if time.monotonic() >= deadline:
+                raise ConnectionError(
+                    f"Timed out waiting for GMS server at {self.socket_path}: {last_error}"
+                ) from None
 
     def handshake(
         self,

--- a/lib/gpu_memory_service/client/session.py
+++ b/lib/gpu_memory_service/client/session.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import logging
 from typing import List, Optional, Tuple
 
-from gpu_memory_service.client.rpc import _GMSRPCTransport
+from gpu_memory_service.client.rpc import DEFAULT_CONNECT_TIMEOUT_MS, _GMSRPCTransport
 from gpu_memory_service.common.locks import GrantedLockType, RequestedLockType
 from gpu_memory_service.common.protocol.messages import (
     AllocateRequest,
@@ -54,7 +54,10 @@ class _GMSClientSession:
     ):
         self._requested_lock_type = lock_type
         self._transport = _GMSRPCTransport(socket_path)
-        self._transport.connect()
+        connect_timeout_ms = timeout_ms
+        if connect_timeout_ms is None:
+            connect_timeout_ms = DEFAULT_CONNECT_TIMEOUT_MS
+        self._transport.connect(timeout_ms=connect_timeout_ms)
         try:
             response = self._transport.handshake(lock_type, timeout_ms)
         except Exception:

--- a/lib/gpu_memory_service/common/utils.py
+++ b/lib/gpu_memory_service/common/utils.py
@@ -10,6 +10,9 @@ from typing import NoReturn
 
 logger = logging.getLogger(__name__)
 
+GMS_GPU_UUIDS_ENV = "GMS_GPU_UUIDS"
+GMS_GPU_UUID_ENV_PREFIX = "GMS_GPU_UUID_"
+
 
 # Canonical names for GMS-related environment variables. Defined here so
 # operator code, launcher code, and engine integration code all reference
@@ -45,11 +48,47 @@ def invalidate_uuid_cache() -> None:
     _uuid_cache.clear()
 
 
+def _split_visible_device_uuids(value: str) -> list[str]:
+    return [
+        part.strip()
+        for part in value.replace(";", ",").split(",")
+        if part.strip().startswith(("GPU-", "MIG-"))
+    ]
+
+
+def _get_uuid_from_env(device: int) -> str | None:
+    direct = os.environ.get(f"{GMS_GPU_UUID_ENV_PREFIX}{device}")
+    if direct:
+        direct = direct.strip()
+        if direct:
+            return direct
+
+    ordered = os.environ.get(GMS_GPU_UUIDS_ENV)
+    if ordered:
+        uuids = [
+            part.strip()
+            for part in ordered.replace(";", ",").split(",")
+            if part.strip()
+        ]
+        if device < len(uuids):
+            return uuids[device]
+
+    # Some runtimes already expose UUIDs in visible-device order. Treat those
+    # as a free fast path, but prefer the explicit GMS_* env vars above.
+    for name in ("CUDA_VISIBLE_DEVICES", "NVIDIA_VISIBLE_DEVICES"):
+        uuids = _split_visible_device_uuids(os.environ.get(name, ""))
+        if device < len(uuids):
+            return uuids[device]
+    return None
+
+
 def get_socket_path(device: int, tag: str = "weights") -> str:
     """Get GMS socket path for the given CUDA device and tag.
 
     The socket path is based on GPU UUID, making it stable across different
     CUDA_VISIBLE_DEVICES configurations. UUIDs are cached per device index.
+    When the runtime provides GPU UUIDs through GMS_GPU_UUIDS or
+    GMS_GPU_UUID_<index>, those env vars are used instead of querying NVML.
 
     Args:
         device: CUDA device index.
@@ -60,14 +99,16 @@ def get_socket_path(device: int, tag: str = "weights") -> str:
     """
     uuid = _uuid_cache.get(device)
     if uuid is None:
-        import pynvml  # deferred: not available in all environments
+        uuid = _get_uuid_from_env(device)
+        if uuid is None:
+            import pynvml  # deferred: not available in all environments
 
-        pynvml.nvmlInit()
-        try:
-            handle = pynvml.nvmlDeviceGetHandleByIndex(device)
-            uuid = pynvml.nvmlDeviceGetUUID(handle)
-        finally:
-            pynvml.nvmlShutdown()
+            pynvml.nvmlInit()
+            try:
+                handle = pynvml.nvmlDeviceGetHandleByIndex(device)
+                uuid = pynvml.nvmlDeviceGetUUID(handle)
+            finally:
+                pynvml.nvmlShutdown()
         _uuid_cache[device] = uuid
     socket_dir = os.environ.get("GMS_SOCKET_DIR") or tempfile.gettempdir()
     return os.path.join(socket_dir, f"gms_{uuid}_{tag}.sock")

--- a/lib/gpu_memory_service/common/utils.py
+++ b/lib/gpu_memory_service/common/utils.py
@@ -112,12 +112,3 @@ def get_socket_path(device: int, tag: str = "weights") -> str:
         _uuid_cache[device] = uuid
     socket_dir = os.environ.get("GMS_SOCKET_DIR") or tempfile.gettempdir()
     return os.path.join(socket_dir, f"gms_{uuid}_{tag}.sock")
-
-
-def wait_for_weights_socket(device: int) -> None:
-    """Block until the GMS weights socket for the given device exists."""
-    import time
-
-    path = get_socket_path(device, "weights")
-    while not os.path.exists(path):
-        time.sleep(0.1)

--- a/lib/gpu_memory_service/integrations/common/utils.py
+++ b/lib/gpu_memory_service/integrations/common/utils.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 GMS_TAGS = ("weights", "kv_cache")
+DEFAULT_GMS_RO_CONNECT_TIMEOUT_MS = 30_000
 
 
 def get_gms_lock_mode(extra_config: dict):
@@ -29,6 +30,35 @@ def get_gms_lock_mode(extra_config: dict):
         logger.info("[GMS] gms_read_only=True, forcing RO mode")
         return RequestedLockType.RO
     return RequestedLockType.RW_OR_RO
+
+
+def get_gms_ro_connect_timeout_ms(extra_config: dict) -> int | None:
+    """Resolve the weight RO reconnect timeout from model_loader_extra_config."""
+    raw_timeout = extra_config.get(
+        "gms_ro_connect_timeout_ms", DEFAULT_GMS_RO_CONNECT_TIMEOUT_MS
+    )
+    if raw_timeout is None:
+        return None
+    if isinstance(raw_timeout, bool):
+        raise ValueError("gms_ro_connect_timeout_ms must be an integer or null")
+    if isinstance(raw_timeout, str):
+        value = raw_timeout.strip()
+        if value.lower() in {"none", "null"}:
+            return None
+        try:
+            timeout_ms = int(value)
+        except ValueError as exc:
+            raise ValueError(
+                "gms_ro_connect_timeout_ms must be an integer or null"
+            ) from exc
+    elif isinstance(raw_timeout, int):
+        timeout_ms = raw_timeout
+    else:
+        raise ValueError("gms_ro_connect_timeout_ms must be an integer or null")
+
+    if timeout_ms < 0:
+        raise ValueError("gms_ro_connect_timeout_ms must be non-negative")
+    return timeout_ms
 
 
 def strip_gms_model_loader_config(load_config, load_format: str):

--- a/lib/gpu_memory_service/integrations/common/utils.py
+++ b/lib/gpu_memory_service/integrations/common/utils.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 GMS_TAGS = ("weights", "kv_cache")
-DEFAULT_GMS_RO_CONNECT_TIMEOUT_MS = 30_000
+DEFAULT_GMS_RO_CONNECT_TIMEOUT_MS = None
 
 
 def get_gms_lock_mode(extra_config: dict):

--- a/lib/gpu_memory_service/integrations/sglang/__init__.py
+++ b/lib/gpu_memory_service/integrations/sglang/__init__.py
@@ -23,6 +23,7 @@ logger = logging.getLogger(__name__)
 # Module-level GMS lock mode, set by setup_gms() before loader is instantiated.
 # Read by patches.py when creating GMSMemorySaverImpl.
 _gms_lock_mode = None
+_gms_ro_connect_timeout_ms = None
 _gms_initialized = False
 
 
@@ -58,6 +59,7 @@ def setup_gms(server_args) -> Type["GMSModelLoader"]:
 
     # Resolve lock mode from model_loader_extra_config before patches fire
     global _gms_lock_mode
+    global _gms_ro_connect_timeout_ms
     extra = getattr(server_args, "model_loader_extra_config", None)
     if isinstance(extra, str):
         import json
@@ -65,9 +67,13 @@ def setup_gms(server_args) -> Type["GMSModelLoader"]:
         extra = json.loads(extra) if extra else {}
     extra = extra or {}
 
-    from gpu_memory_service.integrations.common.utils import get_gms_lock_mode
+    from gpu_memory_service.integrations.common.utils import (
+        get_gms_lock_mode,
+        get_gms_ro_connect_timeout_ms,
+    )
 
     _gms_lock_mode = get_gms_lock_mode(extra)
+    _gms_ro_connect_timeout_ms = get_gms_ro_connect_timeout_ms(extra)
 
     # Import triggers patches at module level
     from gpu_memory_service.integrations.sglang.model_loader import GMSModelLoader

--- a/lib/gpu_memory_service/integrations/sglang/memory_saver.py
+++ b/lib/gpu_memory_service/integrations/sglang/memory_saver.py
@@ -28,7 +28,11 @@ from gpu_memory_service.client.torch.allocator import (
 )
 from gpu_memory_service.common.locks import GrantedLockType, RequestedLockType
 from gpu_memory_service.common.utils import get_socket_path
-from gpu_memory_service.integrations.common.utils import GMS_TAGS, finalize_gms_write
+from gpu_memory_service.integrations.common.utils import (
+    DEFAULT_GMS_RO_CONNECT_TIMEOUT_MS,
+    GMS_TAGS,
+    finalize_gms_write,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -67,9 +71,11 @@ class GMSMemorySaverImpl:
         self,
         device_index: int,
         mode=None,
+        ro_connect_timeout_ms=DEFAULT_GMS_RO_CONNECT_TIMEOUT_MS,
     ):
         self._device = torch.device("cuda", device_index)
         self.imported_weights_bytes = 0
+        self.ro_connect_timeout_ms = ro_connect_timeout_ms
         requested_mode = mode or RequestedLockType.RW_OR_RO
         self.allocators = {
             tag: get_or_create_gms_client_memory_manager(
@@ -170,7 +176,10 @@ class GMSMemorySaverImpl:
                 continue
 
             logger.info("[GMS] Remapping %s", target_tag)
-            self.allocators[target_tag].connect(_TAG_LOCK_TYPES[target_tag])
+            timeout_ms = self.ro_connect_timeout_ms if target_tag == "weights" else None
+            self.allocators[target_tag].connect(
+                _TAG_LOCK_TYPES[target_tag], timeout_ms=timeout_ms
+            )
             if target_tag == "kv_cache":
                 # KV cache resumes into a new RW layout epoch, so the handles
                 # must be re-created before the VA range is mapped again.

--- a/lib/gpu_memory_service/integrations/sglang/patches.py
+++ b/lib/gpu_memory_service/integrations/sglang/patches.py
@@ -72,6 +72,7 @@ def patch_torch_memory_saver() -> None:
             gms_impl = GMSMemorySaverImpl(
                 device_index=device_index,
                 mode=gms_sglang._gms_lock_mode,
+                ro_connect_timeout_ms=gms_sglang._gms_ro_connect_timeout_ms,
             )
 
             # Set _impl directly (accessible via gms_impl property)

--- a/lib/gpu_memory_service/integrations/vllm/worker.py
+++ b/lib/gpu_memory_service/integrations/vllm/worker.py
@@ -31,7 +31,12 @@ from gpu_memory_service.client.torch.allocator import (
 from gpu_memory_service.common.locks import RequestedLockType
 from gpu_memory_service.common.utils import get_socket_path, is_scratch_kv_enabled
 from gpu_memory_service.integrations.common import patch_empty_cache
-from gpu_memory_service.integrations.common.utils import GMS_TAGS, get_gms_lock_mode
+from gpu_memory_service.integrations.common.utils import (
+    DEFAULT_GMS_RO_CONNECT_TIMEOUT_MS,
+    GMS_TAGS,
+    get_gms_lock_mode,
+    get_gms_ro_connect_timeout_ms,
+)
 from gpu_memory_service.integrations.vllm.model_loader import register_gms_loader
 from gpu_memory_service.integrations.vllm.patches import (
     apply_scratch_kv_patches,
@@ -78,6 +83,7 @@ class GMSWorker(Worker):
             getattr(self.vllm_config.load_config, "model_loader_extra_config", {}) or {}
         )
         mode = get_gms_lock_mode(extra)
+        self.gms_ro_connect_timeout_ms = get_gms_ro_connect_timeout_ms(extra)
         get_or_create_gms_client_memory_manager(
             get_socket_path(device, "weights"),
             device,
@@ -238,12 +244,23 @@ class GMSWorker(Worker):
             # the worker cannot serve requests without weights. sys.exit(1)
             # ensures clean termination so the orchestrator (K8s) can restart.
             try:
-                weights_manager.connect(RequestedLockType.RO, timeout_ms=30_000)
+                timeout_ms = getattr(
+                    self,
+                    "gms_ro_connect_timeout_ms",
+                    DEFAULT_GMS_RO_CONNECT_TIMEOUT_MS,
+                )
+                weights_manager.connect(RequestedLockType.RO, timeout_ms=timeout_ms)
                 weights_manager.remap_all_vas()
             except TimeoutError:
+                timeout_desc = (
+                    "without a timeout"
+                    if timeout_ms is None
+                    else f"after {timeout_ms} ms"
+                )
                 logger.error(
-                    "Fatal: timed out waiting for GMS RO lock during remap "
-                    "(GMS may be down or RW lock held indefinitely)"
+                    "Fatal: timed out waiting for GMS RO lock during remap %s "
+                    "(GMS may be down or RW lock held indefinitely)",
+                    timeout_desc,
                 )
                 sys.exit(1)
             except StaleMemoryLayoutError as e:

--- a/lib/gpu_memory_service/tests/test_client_transport.py
+++ b/lib/gpu_memory_service/tests/test_client_transport.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""GMS client transport behavior."""
+
+from __future__ import annotations
+
+import socket
+import threading
+import time
+
+import pytest
+from gpu_memory_service.client.rpc import _GMSRPCTransport
+
+
+def test_transport_connect_waits_for_socket(tmp_path):
+    socket_path = str(tmp_path / "gms.sock")
+    accepted = threading.Event()
+
+    def serve_once() -> None:
+        time.sleep(0.1)
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as server:
+            server.bind(socket_path)
+            server.listen(1)
+            conn, _ = server.accept()
+            with conn:
+                accepted.set()
+
+    thread = threading.Thread(target=serve_once)
+    thread.start()
+    try:
+        with _GMSRPCTransport(socket_path) as transport:
+            transport.connect(timeout_ms=1_000)
+            assert transport.is_connected
+        assert accepted.wait(timeout=1.0)
+    finally:
+        thread.join(timeout=1.0)
+
+
+def test_transport_connect_times_out_for_missing_socket(tmp_path):
+    start = time.monotonic()
+    with pytest.raises(ConnectionError):
+        _GMSRPCTransport(str(tmp_path / "missing.sock")).connect(timeout_ms=50)
+    assert time.monotonic() - start < 1.0

--- a/lib/gpu_memory_service/tests/test_common_utils.py
+++ b/lib/gpu_memory_service/tests/test_common_utils.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from gpu_memory_service.common.utils import get_socket_path, invalidate_uuid_cache
+
+
+@pytest.fixture(autouse=True)
+def clear_uuid_cache():
+    invalidate_uuid_cache()
+    yield
+    invalidate_uuid_cache()
+
+
+def test_get_socket_path_uses_ordered_gpu_uuid_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("GMS_SOCKET_DIR", str(tmp_path))
+    monkeypatch.setenv("GMS_GPU_UUIDS", "GPU-0000,GPU-1111")
+
+    assert get_socket_path(1) == str(tmp_path / "gms_GPU-1111_weights.sock")
+
+
+def test_get_socket_path_uses_direct_gpu_uuid_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("GMS_SOCKET_DIR", str(tmp_path))
+    monkeypatch.setenv("GMS_GPU_UUIDS", "GPU-0000,GPU-1111")
+    monkeypatch.setenv("GMS_GPU_UUID_1", "GPU-direct")
+
+    assert get_socket_path(1, "metadata") == str(
+        tmp_path / "gms_GPU-direct_metadata.sock"
+    )
+
+
+def test_get_socket_path_uses_visible_device_uuid_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("GMS_SOCKET_DIR", str(tmp_path))
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "GPU-aaaa,GPU-bbbb")
+
+    assert get_socket_path(0) == str(tmp_path / "gms_GPU-aaaa_weights.sock")

--- a/lib/gpu_memory_service/tests/test_integration_common_utils.py
+++ b/lib/gpu_memory_service/tests/test_integration_common_utils.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+pytest.importorskip("torch", reason="torch is required")
+
+from gpu_memory_service.integrations.common.utils import (  # noqa: E402
+    DEFAULT_GMS_RO_CONNECT_TIMEOUT_MS,
+    get_gms_ro_connect_timeout_ms,
+)
+
+
+@pytest.mark.parametrize(
+    ("extra_config", "expected"),
+    [
+        ({}, DEFAULT_GMS_RO_CONNECT_TIMEOUT_MS),
+        ({"gms_ro_connect_timeout_ms": 120_000}, 120_000),
+        ({"gms_ro_connect_timeout_ms": "120000"}, 120_000),
+        ({"gms_ro_connect_timeout_ms": None}, None),
+        ({"gms_ro_connect_timeout_ms": "null"}, None),
+    ],
+)
+def test_get_gms_ro_connect_timeout_ms(extra_config, expected):
+    assert get_gms_ro_connect_timeout_ms(extra_config) == expected
+
+
+@pytest.mark.parametrize("value", [True, -1, "slow", object()])
+def test_get_gms_ro_connect_timeout_ms_rejects_invalid_values(value):
+    with pytest.raises(ValueError, match="gms_ro_connect_timeout_ms"):
+        get_gms_ro_connect_timeout_ms({"gms_ro_connect_timeout_ms": value})


### PR DESCRIPTION
## Summary

Base PR for snapshot checkpoint/restore with GPU Memory Service. This is now rebased on `main` and is the base of the #8900 transfer-backend stack.

- Allows snapshot + GMS admission for non-failover services and removes the broad DynamoCheckpoint-level GMS block.
- Keeps restore/deployment validation at the DynamoGraphDeployment layer for restore-side configuration, while still blocking non-vLLM inter-pod failover.
- Injects `--load-format gms` for vLLM when GMS is enabled, including auto/manual checkpoint jobs.
- Keeps GMS saver/loader artifact sentinels for diagnostics, but snapshot-agent no longer consumes them. Checkpoint readiness is gated by `gms-saver` as a regular Job container; restore readiness is CRIU/CUDA restore completion while the workload blocks on the GMS RO lock until the loader commits.
- Stores GMS tensor artifacts on the snapshot PVC under `/checkpoints/gms/<checkpoint-hash>/versions/<artifact-version>/device-*`, separate from the CRIU tree.
- Removes the snapshot-agent GMS completion-sentinel handoff and the corresponding GMS snapshot protocol annotations.
- Adds an NVML-avoidance fast path for GMS socket UUIDs through `GMS_GPU_UUIDS`, `GMS_GPU_UUID_<index>`, or UUID-valued `CUDA_VISIBLE_DEVICES` / `NVIDIA_VISIBLE_DEVICES`.

## Validation Fixes In This PR

During nscale validation of the #8900 stack, this PR was updated with the base wiring fixes that belonged here:

- Inter-pod restore engine pods now also mount the checkpoint-source GMS socket path at `/gms-intrapod-control`; without this, snapshot-agent could not quiesce the restored workload against the checkpointed GMS socket path.
- Inter-pod `gms-loader` now reuses the same rank-scoped Grove `gms-shared` mount and `subPathExpr` as the GMS server/main containers; without this, the loader wrote to the wrong shared socket directory.
- The DGD webhook now allows standalone SGLang inter-pod GMS. It still rejects non-vLLM inter-pod failover, which is the vLLM-specific path.

## Deployment Behavior

### Intra-pod GMS

Checkpoint job:
- The operator adds the checkpoint PVC/control-volume wiring to the main worker.
- It adds `gms-server` as a restartable init sidecar with a startup probe that waits for all per-device GMS sockets.
- It adds `gms-saver` as a regular Job container. The saver waits on the GMS RO lock for committed weights, writes GMS tensors to the snapshot PVC, writes a pod-UID-scoped `gms-save-complete-*` sentinel, then exits so the Job can complete.
- snapshot-agent writes `snapshot-complete` after CRIU/CUDA checkpoint completion. Kubernetes Job completion still waits for `gms-saver` because it is a regular Job container.

Restore pod:
- The operator adds `gms-server` as a restartable init sidecar with the same socket-readiness startup probe.
- It adds `gms-loader` as a regular sidecar container on the restore target pod.
- The loader reads from the same GMS artifact directory, waits on the GMS RW lock as needed, writes a pod-UID-scoped `gms-load-complete-*` sentinel, then stays alive with the pod.
- snapshot-agent writes `restore-complete` after `nsrestore`. The restored workload then blocks in its GMS RO reconnect until `gms-loader` commits.

### Inter-pod GMS

Restore:
- The engine pod is the CRIU restore target and mounts both the live shared GMS socket path and the checkpoint-source socket path expected by the restored process.
- The dedicated RoleGMS weight-server pod gets a regular `gms-loader` sidecar that mounts the snapshot PVC and loads into the real inter-pod GMS server at `/run/gms/shared`.
- The GMS server, loader, permission init container, and engine share the same rank-scoped Grove socket subPath.
- The engine pod no longer carries a GMS completion-mode annotation for snapshot-agent. GMS load remains out of band; the restored engine resumes only after it can acquire the GMS RO lock.

Checkpoint jobs still run with a local GMS server+saver pair so the capture pod can load through GMS and persist tensors for restore.

## Validation

- `cd deploy/operator && go test ./internal/webhook/validation -run 'TestDynamoGraphDeploymentValidator' -count=1`
- `cd deploy/operator && go test ./internal/dynamo -run 'TestGenerateGrovePodCliqueSet|TestGMS|TestAugmentEngineForGMS' -count=1`
- `cd deploy/operator && go test ./internal/dynamo ./internal/checkpoint ./internal/gms -count=1`
- `python3 -m py_compile lib/gpu_memory_service/common/utils.py lib/gpu_memory_service/cli/snapshot/loader.py lib/gpu_memory_service/cli/snapshot/saver.py`
- nscale DRA validation in namespace `schwinns`:
  - vLLM `Qwen/Qwen3-0.6B` intra-pod GMS snapshot/restore passed.
  - vLLM `Qwen/Qwen3-0.6B` inter-pod GMS snapshot/restore passed.
  - SGLang `Qwen/Qwen3-0.6B` intra-pod GMS snapshot/restore passed with explicit `--load-format gms`.
  - SGLang `Qwen/Qwen3-0.6B` inter-pod GMS snapshot/restore passed after the admission and inter-pod socket fixes.

Inter-pod validation required Grove `v0.1.0-alpha.8`; the shared cluster reconciles back to `v0.1.0-alpha.6`, which prunes the shared DRA/Grove fields needed for these experiments.


## 2026-05-12 rebase update

Rebased this stack layer onto `origin/main` (`ec5edded3a8`) after the v1beta1 API migration. Conflict fixes kept the new v1beta1 shared-spec shape and reapplied the GMS snapshot/restore behavior:

- use `dynamo.GetGPUMemoryService(component)` instead of the removed direct `component.GPUMemoryService` field in vLLM backend and auto-checkpoint paths
- keep vLLM `--load-format gms` injection for any GMS layout
- preserve inter-pod-only `DYN_VLLM_GMS_SHADOW_MODE`
- adapt the vLLM GMS unit test to construct a v1beta1 component through the conversion helper

Validated after restacking:

- `go test ./internal/dynamo ./internal/checkpoint ./internal/gms -count=1 -v`
- `go test ./internal/controller -count=1 -v` with local envtest assets



## 2026-05-12 RO Timeout Update

Added `gms_ro_connect_timeout_ms` under `model_loader_extra_config` for GMS weight RO reconnects.

- Default is now `null`, so snapshot restore waits indefinitely for the GMS RO reconnect by default. A finite integer value can still be configured when fail-fast behavior is desired.
- vLLM and SGLang both apply it to the weight RO reconnect path. KV/RW reconnect remains unbounded.
- Parser coverage now accepts integer and numeric-string values and rejects bools, negatives, and non-integer strings.
- Container validation passed for the shared parser tests plus the SGLang GMS memory-saver tests.

Rebuilt and validated the full stack image line from top commit `f5c920d1166b`:

- vLLM and SGLang `Qwen/Qwen3-0.6B` snapshot+GMS checkpoint/restore passed with `gms_ro_connect_timeout_ms=300000`.
- vLLM restore loaded `59` GMS allocations / `1.17 GiB`; `gms-load-complete-*` was written after about `1.78s`; the post-restore `/no_think` request returned `VLLM_RO_TIMEOUT_OK`.
- SGLang restore loaded `60` GMS allocations / `1.19 GiB`; `gms-load-complete-*` was written after about `3.33s`; the post-restore `/no_think` request returned `SGLANG_RO_TIMEOUT_OK`.


## 2026-05-13 Snapshot-Agent/GMS Decoupling Update

Rebased and pushed this layer at `70c7654fdc3` as part of the refreshed stack. The latest changes make snapshot-agent completely GMS-agnostic:

- Removed snapshot-agent waits for `gms-save-complete-*` and `gms-load-complete-*`.
- Removed the GMS-specific snapshot protocol annotations/constants used only for those waits.
- Changed the default `gms_ro_connect_timeout_ms` to `null`, so restored workers block indefinitely on the GMS RO lock unless a finite timeout is explicitly configured.
- Checkpoint-side correctness now comes from `gms-saver` being a regular Job container that exits after save; restore-side correctness comes from the restored workload blocking on GMS RO reconnect until `gms-loader` commits.

Validation after rebuilding the top stack at `42f4cccb5e6f`:

- vLLM `Qwen/Qwen3-0.6B` snapshot+intra-pod GMS passed with no explicit `gms_ro_connect_timeout_ms`; checkpoint hash `a74ab3c1cee0728b`; post-restore chat returned `VLLM_DECOUPLE_OK`.
- SGLang `Qwen/Qwen3-0.6B` snapshot+intra-pod GMS passed with no explicit `gms_ro_connect_timeout_ms`; checkpoint hash `05149109264bf5dc`; post-restore chat returned `SGLANG_DECOUPLE_OK`.
- Snapshot-agent logs showed checkpoint/restore completion for both hashes and no `Waiting for GMS`, `gms-save-complete`, or `gms-load-complete` wait path.
