### PR TITLE
docs(observability): document component metric labels, names, endpoints, and error types

### DIFF
--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -67,15 +67,15 @@ Dynamo exposes metrics in Prometheus Exposition Format text at the `/metrics` HT
 ```
 # HELP dynamo_component_requests_total Total requests processed
 # TYPE dynamo_component_requests_total counter
-dynamo_component_requests_total{dynamo_namespace="default",dynamo_component="worker",dynamo_endpoint="generate"} 42
+dynamo_component_requests_total{dynamo_namespace="default",dynamo_component="backend",dynamo_endpoint="generate"} 42
 
 # HELP dynamo_component_request_duration_seconds Request processing time
 # TYPE dynamo_component_request_duration_seconds histogram
-dynamo_component_request_duration_seconds_bucket{dynamo_namespace="default",dynamo_component="worker",dynamo_endpoint="generate",le="0.005"} 10
-dynamo_component_request_duration_seconds_bucket{dynamo_namespace="default",dynamo_component="worker",dynamo_endpoint="generate",le="0.01"} 15
-dynamo_component_request_duration_seconds_bucket{dynamo_namespace="default",dynamo_component="worker",dynamo_endpoint="generate",le="+Inf"} 42
-dynamo_component_request_duration_seconds_sum{dynamo_namespace="default",dynamo_component="worker",dynamo_endpoint="generate"} 2.5
-dynamo_component_request_duration_seconds_count{dynamo_namespace="default",dynamo_component="worker",dynamo_endpoint="generate"} 42
+dynamo_component_request_duration_seconds_bucket{dynamo_namespace="default",dynamo_component="backend",dynamo_endpoint="generate",le="0.005"} 10
+dynamo_component_request_duration_seconds_bucket{dynamo_namespace="default",dynamo_component="backend",dynamo_endpoint="generate",le="0.01"} 15
+dynamo_component_request_duration_seconds_bucket{dynamo_namespace="default",dynamo_component="backend",dynamo_endpoint="generate",le="+Inf"} 42
+dynamo_component_request_duration_seconds_sum{dynamo_namespace="default",dynamo_component="backend",dynamo_endpoint="generate"} 2.5
+dynamo_component_request_duration_seconds_count{dynamo_namespace="default",dynamo_component="backend",dynamo_endpoint="generate"} 42
 ```
 
 ### Metric Categories

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -112,6 +112,7 @@ The core Dynamo backend system exposes metrics at the `/metrics` endpoint with t
 - `dynamo_component_request_bytes_total`: Total bytes received in requests (counter)
 - `dynamo_component_request_duration_seconds`: Request processing time (histogram)
 - `dynamo_component_requests_total`: Total requests processed (counter)
+- `dynamo_component_errors_total`: Total errors encountered while handling a request (counter, labeled with `error_type`). See [Component Error Types](#component-error-types).
 - `dynamo_component_response_bytes_total`: Total bytes sent in responses (counter)
 - `dynamo_component_uptime_seconds`: DistributedRuntime uptime (gauge). Automatically updated before each Prometheus scrape on both the frontend (`/metrics` on port 8000) and the system status server (`/metrics` on `DYN_SYSTEM_PORT` when set).
 
@@ -121,6 +122,75 @@ The core Dynamo backend system exposes metrics at the `/metrics` endpoint with t
 DYN_SYSTEM_PORT=8081 python -m dynamo.vllm --model <model>
 curl http://localhost:8081/metrics
 ```
+
+#### Component Labels
+
+Backend `dynamo_component_*` series carry two groups of labels: the ones the Dynamo runtime emits, and the ones Prometheus/Kubernetes attach during scraping.
+
+**Emitted by Dynamo (present in the metric itself):**
+
+| Label | Description | Example |
+|-------|-------------|---------|
+| `dynamo_namespace` | The Dynamo runtime namespace — the logical scope shared by every component (frontend / router / prefill / decode) in one deployment. **Not** the K8s namespace. | `dynamo_cloud_vllm_v1_disagg_router_071de157` |
+| `dynamo_component` | Service role: see [Component Names](#component-names) below. | `backend`, `prefill`, `router` |
+| `dynamo_endpoint` | The RPC within that component: see [Endpoint Names](#endpoint-names) below. | `generate`, `clear_kv_blocks`, `worker_kv_indexer_query_dp0` |
+| `model` | The model being served (OpenAI-style label). Present on inference endpoints; absent on internal endpoints like `worker_kv_indexer_query_dp{N}`. | `Qwen/Qwen3-0.6B` |
+| `model_name` | Same model identifier under a second label name, kept for engine-native and dashboard back-compat. | `Qwen/Qwen3-0.6B` |
+| `error_type` | Only on `dynamo_component_errors_total` — the failure category. See [Component Error Types](#component-error-types). | `generate`, `publish_response` |
+
+**Injected by Prometheus / Kubernetes (added by the scraper, not in the metric itself):**
+
+| Label | Description | Example |
+|-------|-------------|---------|
+| `instance` | Scrape target as `<podIP>:<metricsPort>`. | `192.168.133.236:9090` |
+| `pod` | Kubernetes pod name; the per-replica disambiguator. | `vllm-v1-disagg-router-vllmdecodeworker-...` |
+| `container` | Container name inside the pod (usually `main`). | `main` |
+| `namespace` | Kubernetes namespace the pod runs in. **Not** the same as `dynamo_namespace`. | `dynamo-cloud` |
+| `job` | Prometheus scrape-job name, `<k8s-namespace>/<service-name>`. | `dynamo-cloud/dynamo-worker` |
+| `endpoint` | Named port on the K8s `Service` that Prometheus scraped. **Not** the same as `dynamo_endpoint`. | `system` |
+
+> **Watch out for these collisions:**
+> - `dynamo_namespace` (Dynamo deployment scope) vs. `namespace` (K8s namespace).
+> - `dynamo_endpoint` (Dynamo RPC) vs. `endpoint` (K8s Service port name).
+
+#### Component Names
+
+Values you will see in the `dynamo_component` label:
+
+| Value | Meaning |
+|-------|---------|
+| `frontend` | The HTTP frontend (`python -m dynamo.frontend`). |
+| `router` | The KV router. |
+| `planner` | The planner component. |
+| `prefill` | The prefill worker in disaggregated serving. |
+| `backend` | The decode worker in disaggregated serving (vLLM, SGLang, mocker), **or** the combined worker in aggregated mode. |
+| `tensorrt_llm` | The decode worker in disaggregated serving for TRT-LLM. |
+| `encode` | Multimodal encoder worker. |
+
+> The name `backend` for the decode worker is historical and will likely be renamed to `decode` in a future release.
+
+#### Endpoint Names
+
+Values you will see in the `dynamo_endpoint` label on backend workers:
+
+| Value | Meaning |
+|-------|---------|
+| `generate` | Main inference RPC; one increment per request received. On a prefill worker this counts prefill-stage `generate` calls (one per request the router routes through); on a decode worker this counts decode-stage `generate` calls. |
+| `clear_kv_blocks` | Admin RPC to flush the worker's KV cache. Registered on both prefill and decode workers. |
+| `worker_kv_indexer_query_dp{N}` | KV-router queries to the worker's local KV indexer about its cached prefix blocks. One endpoint per data-parallel rank (`_dp0`, `_dp1`, …). Appears on the worker that owns the prefix caches the router consults — in disaggregated serving that is the prefill worker. |
+
+#### Component Error Types
+
+The `dynamo_component_errors_total` counter is labeled with `error_type`, identifying which stage of request handling failed:
+
+| `error_type` | Stage | Meaning |
+|--------------|-------|---------|
+| `deserialization` | Ingress | Could not parse the incoming request payload. |
+| `invalid_message` | Ingress | Wire-format violation in the incoming message. |
+| `response_stream` | Pre-generate | The worker received the request but could not open the response stream back to the frontend (transport problem before `generate` was called). |
+| `generate` | Engine | The engine's `generate()` itself returned an error. This is the counter that reflects engine/inference failures. |
+| `publish_response` | Streaming | The engine produced response chunks but the worker could not push one of them back to the frontend (write failed mid-stream). **Also fires on client cancellation** — the frontend disconnecting before the stream finishes — so this counter can be inflated by user-aborted requests. |
+| `publish_final` | Teardown | All response chunks were sent, but the worker could not deliver the final stream-complete marker. The connection died right at the end. |
 
 ### Specialized Component Metrics
 

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -127,15 +127,26 @@ curl http://localhost:8081/metrics
 
 Backend `dynamo_component_*` series carry two groups of labels: the ones the Dynamo runtime emits, and the ones Prometheus/Kubernetes attach during scraping.
 
-**Emitted by Dynamo (present in the metric itself):**
+**Auto-injected by the Dynamo runtime** (added by `create_metric()` in `lib/runtime/src/metrics.rs` for every metric registered through the namespace/component/endpoint hierarchy):
 
 | Label | Description | Example |
 |-------|-------------|---------|
-| `dynamo_namespace` | The Dynamo runtime namespace — the logical scope shared by every component (frontend / router / prefill / decode) in one deployment. **Not** the K8s namespace. | `dynamo_cloud_vllm_v1_disagg_router_071de157` |
+| `dynamo_namespace` | The Dynamo runtime namespace — the logical scope shared by every component (router / prefill / decode / encode) in one deployment. **Not** the K8s namespace. | `dynamo_cloud_vllm_v1_disagg_router_071de157` |
 | `dynamo_component` | Service role: see [Component Names](#component-names) below. | `backend`, `prefill`, `router` |
 | `dynamo_endpoint` | The RPC within that component: see [Endpoint Names](#endpoint-names) below. | `generate`, `clear_kv_blocks`, `worker_kv_indexer_query_dp0` |
-| `model` | The model being served (OpenAI-style label). Present on inference endpoints; absent on internal endpoints like `worker_kv_indexer_query_dp{N}`. | `Qwen/Qwen3-0.6B` |
-| `model_name` | Same model identifier under a second label name, kept for engine-native and dashboard back-compat. | `Qwen/Qwen3-0.6B` |
+| `worker_id` | Hex-encoded discovery instance ID of the endpoint, providing a stable per-worker identity that does not depend on Kubernetes. Injected only when the endpoint hierarchy has a connection ID. | `1a2b3c4d` |
+
+**Added at registration time by backend code** (passed via `metrics_labels=` when the worker calls `serve_endpoint()` — not auto-injected, so presence depends on the backend):
+
+| Label | Description | Example |
+|-------|-------------|---------|
+| `model` | The model being served (OpenAI-style label). Added by vLLM, SGLang, and TRT-LLM workers on inference endpoints; absent on internal endpoints like `worker_kv_indexer_query_dp{N}`. | `Qwen/Qwen3-0.6B` |
+| `model_name` | Same model identifier under a second label name, retained for engine-native and dashboard back-compat. Added by vLLM and TRT-LLM workers; **not** added by SGLang. | `Qwen/Qwen3-0.6B` |
+
+**Added by the metric itself**:
+
+| Label | Description | Example |
+|-------|-------------|---------|
 | `error_type` | Only on `dynamo_component_errors_total` — the failure category. See [Component Error Types](#component-error-types). | `generate`, `publish_response` |
 
 **Injected by Prometheus / Kubernetes (added by the scraper, not in the metric itself):**
@@ -155,19 +166,22 @@ Backend `dynamo_component_*` series carry two groups of labels: the ones the Dyn
 
 #### Component Names
 
-Values you will see in the `dynamo_component` label:
+Values you will see in the `dynamo_component` label on `dynamo_component_*` series. The HTTP frontend (`python -m dynamo.frontend`) is **not** in this list — it exposes its own `dynamo_frontend_*` metric family, not `dynamo_component_*`.
 
 | Value | Meaning |
 |-------|---------|
-| `frontend` | The HTTP frontend (`python -m dynamo.frontend`). |
-| `router` | The KV router. |
-| `planner` | The planner component. |
-| `prefill` | The prefill worker in disaggregated serving. |
-| `backend` | The decode worker in disaggregated serving (vLLM, SGLang, mocker), **or** the combined worker in aggregated mode. |
+| `router` | The standalone KV router (`python -m dynamo.router`). |
+| `Planner` | The planner component (`python -m dynamo.planner`). Note the capital `P`. |
+| `prefill` | The prefill worker in disaggregated serving (all backends). |
+| `backend` | The decode worker in disaggregated serving for vLLM, SGLang, and the mocker, **and** the combined worker for vLLM in aggregated mode. |
 | `tensorrt_llm` | The decode worker in disaggregated serving for TRT-LLM. |
-| `encode` | Multimodal encoder worker. |
+| `tensorrt_llm_encode` | The encode worker for TRT-LLM. |
+| `encode` | The encode worker for vLLM. |
+| `diffusion` | The diffusion worker for TRT-LLM. |
 
-> The name `backend` for the decode worker is historical and will likely be renamed to `decode` in a future release.
+Internal subsystems (e.g. `kvbm` from the block manager, `sequences` from the KV router) also create components and may appear in `dynamo_component_*` series. The default for vLLM/SGLang can be overridden by passing `--endpoint dyn://<ns>.<component>.<endpoint>` on the worker command line.
+
+> The name `backend` for the decode worker is historical. The runtime has a TODO to introduce a `decode` constant and migrate to it (see `lib/runtime/src/metrics/prometheus_names.rs::component_names`).
 
 #### Endpoint Names
 


### PR DESCRIPTION
## Summary

Extends `docs/observability/metrics.md` (Backend Component Metrics section) so users no longer have to ask in Slack what the labels and series mean.

- Full label reference for `dynamo_component_*` series, split between Dynamo-emitted (`dynamo_namespace`, `dynamo_component`, `dynamo_endpoint`, `model`, `model_name`, `error_type`) and Prometheus/Kubernetes-injected (`instance`, `pod`, `container`, `namespace`, `job`, `endpoint`), with the `dynamo_namespace` vs `namespace` and `dynamo_endpoint` vs `endpoint` collisions called out.
- Enumeration of `dynamo_component` values: `frontend`, `router`, `planner`, `prefill`, `backend`, `tensorrt_llm`, `encode` — noting that `backend` is the decode worker for vLLM/SGLang and the combined worker in aggregated mode (and is likely to be renamed to `decode`).
- Enumeration of `dynamo_endpoint` values: `generate`, `clear_kv_blocks`, `worker_kv_indexer_query_dp{N}`.
- Adds `dynamo_component_errors_total` to the metric list and a new subsection documenting all six `error_type` values (`deserialization`, `invalid_message`, `response_stream`, `generate`, `publish_response`, `publish_final`) and their semantics — including that `publish_response` also fires on client cancellation.

Triggered by user feedback that none of this was documented and that operators were having to ask the team to interpret what they were seeing in dashboards.

## Test plan

- [ ] Render `docs/observability/metrics.md` and verify tables render correctly
- [ ] Verify cross-reference anchors (`#component-error-types`, `#component-names`, `#endpoint-names`) resolve
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8834" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Extended metrics documentation with a new component error counter metric and its label semantics.
  * Added comprehensive label documentation for component metrics, distinguishing between runtime-emitted and platform-injected labels.
  * Included warnings about potential label name collisions and enumerated valid label values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->