### PR TITLE
fix(ci): Set trtllm and sglang 1 gpu test job timeout to 240 min. Reduce multi…

### DIFF
--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -141,7 +141,7 @@ jobs:
       enable_coverage: true
       run_sanity_check: false
       gpu_test_markers: vllm and (gpu_2 or gpu_4)
-      gpu_test_timeout_minutes: 120
+      gpu_test_timeout_minutes: 45
     secrets: inherit
 
   sglang-test:
@@ -159,6 +159,7 @@ jobs:
       run_cpu_only_tests: true
       cpu_only_test_markers: sglang and gpu_0
       gpu_test_markers: sglang and gpu_1
+      gpu_test_timeout_minutes: 240
     secrets: inherit
 
   sglang-multi-gpu-test:
@@ -175,7 +176,7 @@ jobs:
       enable_coverage: true
       run_sanity_check: false
       gpu_test_markers: sglang and (gpu_2 or gpu_4)
-      gpu_test_timeout_minutes: 120
+      gpu_test_timeout_minutes: 45
     secrets: inherit
 
   trtllm-test:
@@ -193,6 +194,7 @@ jobs:
       run_cpu_only_tests: true
       cpu_only_test_markers: trtllm and gpu_0
       gpu_test_markers: trtllm and gpu_1
+      gpu_test_timeout_minutes: 240
     secrets: inherit
 
   trtllm-multi-gpu-test:
@@ -209,7 +211,7 @@ jobs:
       enable_coverage: true
       run_sanity_check: false
       gpu_test_markers: trtllm and (gpu_2 or gpu_4)
-      gpu_test_timeout_minutes: 120
+      gpu_test_timeout_minutes: 45
     secrets: inherit
 
   # ============================================================================


### PR DESCRIPTION
…-gpu timeouts to 45 min

#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized GPU test timeout configurations in the continuous integration workflow to improve test efficiency and resource allocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->