### PR TITLE
fix: track KVBM v2 G3→G2 in its own onboard metric

### DIFF
--- a/deploy/observability/grafana_dashboards/kvbm.json
+++ b/deploy/observability/grafana_dashboards/kvbm.json
@@ -19,7 +19,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 3,
+  "id": 2,
   "links": [],
   "panels": [
     {
@@ -807,6 +807,104 @@
         "x": 12,
         "y": 35
       },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "kvbm_onboard_blocks_d2h",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Onboard Blocks - Disk to Host",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 43
+      },
       "id": 8,
       "options": {
         "legend": {
@@ -835,7 +933,7 @@
           "useBackend": false
         }
       ],
-      "title": "Onboard Blocks - Disk to Device",
+      "title": "Onboard Blocks - Disk to Device (Bypass Host)",
       "type": "timeseries"
     }
   ],
@@ -854,5 +952,5 @@
   "timezone": "browser",
   "title": "KVBM Dashboard",
   "uid": "3f679257-70a5-402c-92b4-05382337b548",
-  "version": 3
+  "version": 6
 }

--- a/lib/kvbm-common/src/lib.rs
+++ b/lib/kvbm-common/src/lib.rs
@@ -28,12 +28,21 @@ pub enum LogicalLayoutHandle {
 }
 
 /// Compatibility transfer routes used by KVBM metrics.
+///
+/// Letter convention is direction-dependent: `h` is always host (G2);
+/// `d` resolves by adjacency. In offload routes (going down) `d` adjacent
+/// to `h` is *device* (G1); `d` opposite `h` is *disk* (G3). In onboard
+/// routes (going up) the polarity flips: `d` adjacent to `h` is *disk*
+/// (G3); `d` opposite `h` is *device* (G1). So `OnboardD2H` is the
+/// disk→host (G3→G2) staging step, distinct from `OffloadD2H` which is
+/// device→host (G1→G2).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum KvbmTransferRoute {
     OffloadD2H,
     OffloadH2D,
     OffloadD2D,
     OffloadD2O,
+    OnboardD2H,
     OnboardH2D,
     OnboardD2D,
     OnboardO2D,
@@ -47,6 +56,7 @@ impl KvbmTransferRoute {
             Self::OffloadH2D => "h2d",
             Self::OffloadD2D => "d2d",
             Self::OffloadD2O => "d2o",
+            Self::OnboardD2H => "d2h",
             Self::OnboardH2D => "h2d",
             Self::OnboardD2D => "d2d",
             Self::OnboardO2D => "o2d",
@@ -57,7 +67,7 @@ impl KvbmTransferRoute {
     pub fn operation_label(&self) -> &'static str {
         match self {
             Self::OffloadD2H | Self::OffloadH2D | Self::OffloadD2D | Self::OffloadD2O => "offload",
-            Self::OnboardH2D | Self::OnboardD2D | Self::OnboardO2D => "onboard",
+            Self::OnboardD2H | Self::OnboardH2D | Self::OnboardD2D | Self::OnboardO2D => "onboard",
         }
     }
 }

--- a/lib/kvbm-engine/src/worker/physical.rs
+++ b/lib/kvbm-engine/src/worker/physical.rs
@@ -233,7 +233,7 @@ impl PhysicalWorker {
                 Some(KvbmTransferRoute::OnboardD2D)
             }
             (LogicalLayoutHandle::G3, LogicalLayoutHandle::G2) => {
-                Some(KvbmTransferRoute::OnboardD2D)
+                Some(KvbmTransferRoute::OnboardD2H)
             }
             (LogicalLayoutHandle::G1, LogicalLayoutHandle::G3) => {
                 Some(KvbmTransferRoute::OffloadD2D)

--- a/lib/kvbm-observability/src/transfer.rs
+++ b/lib/kvbm-observability/src/transfer.rs
@@ -10,13 +10,16 @@ use prometheus::{
     Gauge, HistogramOpts, HistogramVec, IntCounter, IntCounterVec, IntGaugeVec, Opts, Registry,
 };
 
-/// Exact v1-compatible metrics that existing dashboards and tests consume.
+/// V1-compatible metrics that existing dashboards and tests consume,
+/// plus v2 additions (e.g. `onboard_blocks_d2h` for the G3→G2 staging
+/// step that KVBM v2 introduces between disk hits and the GPU promotion).
 #[derive(Clone)]
 pub struct CompatMetrics {
     pub offload_blocks_d2h: IntCounter,
     pub offload_blocks_h2d: IntCounter,
     pub offload_blocks_d2d: IntCounter,
     pub offload_blocks_d2o: IntCounter,
+    pub onboard_blocks_d2h: IntCounter,
     pub onboard_blocks_h2d: IntCounter,
     pub onboard_blocks_d2d: IntCounter,
     pub onboard_blocks_o2d: IntCounter,
@@ -51,6 +54,11 @@ impl CompatMetrics {
                 "The number of offload blocks from device to object storage",
             ))
             .expect("valid metric"),
+            onboard_blocks_d2h: IntCounter::with_opts(Opts::new(
+                "kvbm_onboard_blocks_d2h",
+                "The number of onboard blocks from disk to host (G3→G2 staging step)",
+            ))
+            .expect("valid metric"),
             onboard_blocks_h2d: IntCounter::with_opts(Opts::new(
                 "kvbm_onboard_blocks_h2d",
                 "The number of onboard blocks from host to device",
@@ -58,7 +66,7 @@ impl CompatMetrics {
             .expect("valid metric"),
             onboard_blocks_d2d: IntCounter::with_opts(Opts::new(
                 "kvbm_onboard_blocks_d2d",
-                "The number of onboard blocks from disk to device",
+                "The number of onboard blocks from disk to device (G3→G1 direct, e.g. via GDS)",
             ))
             .expect("valid metric"),
             onboard_blocks_o2d: IntCounter::with_opts(Opts::new(
@@ -104,6 +112,7 @@ impl CompatMetrics {
         registry.register(Box::new(self.offload_blocks_h2d.clone()))?;
         registry.register(Box::new(self.offload_blocks_d2d.clone()))?;
         registry.register(Box::new(self.offload_blocks_d2o.clone()))?;
+        registry.register(Box::new(self.onboard_blocks_d2h.clone()))?;
         registry.register(Box::new(self.onboard_blocks_h2d.clone()))?;
         registry.register(Box::new(self.onboard_blocks_d2d.clone()))?;
         registry.register(Box::new(self.onboard_blocks_o2d.clone()))?;
@@ -122,6 +131,7 @@ impl CompatMetrics {
             KvbmTransferRoute::OffloadH2D => self.offload_blocks_h2d.inc_by(blocks),
             KvbmTransferRoute::OffloadD2D => self.offload_blocks_d2d.inc_by(blocks),
             KvbmTransferRoute::OffloadD2O => self.offload_blocks_d2o.inc_by(blocks),
+            KvbmTransferRoute::OnboardD2H => self.onboard_blocks_d2h.inc_by(blocks),
             KvbmTransferRoute::OnboardH2D => self.onboard_blocks_h2d.inc_by(blocks),
             KvbmTransferRoute::OnboardD2D => self.onboard_blocks_d2d.inc_by(blocks),
             KvbmTransferRoute::OnboardO2D => self.onboard_blocks_o2d.inc_by(blocks),
@@ -249,6 +259,7 @@ mod tests {
         let names: Vec<_> = gathered.iter().map(|mf| mf.name()).collect();
 
         assert!(names.contains(&"kvbm_offload_blocks_d2h"));
+        assert!(names.contains(&"kvbm_onboard_blocks_d2h"));
         assert!(names.contains(&"kvbm_onboard_blocks_d2d"));
         assert!(names.contains(&"kvbm_matched_tokens"));
         assert!(names.contains(&"kvbm_object_write_failures"));


### PR DESCRIPTION
#### Overview:

 Adds a new Prometheus counter `kvbm_onboard_blocks_d2h` that tracks the **G3→G2 staging step** KVBM v2 performs when serving disk-tier hits.                               
                                                                                                         
  ## Why

  KVBM v1 always served G3 hits to GPU directly via GDS (**G3→G1**), so `kvbm_onboard_blocks_d2d` ("disk 
  to device") was the correct and only counter — there was no staging step to track. KVBM v2 changed the
  onboard pipeline: disk hits are now staged through G2 (**G3→G2→G1**).                     

<img width="1173" height="583" alt="Screenshot 2026-04-29 at 11 26 31 AM" src="https://github.com/user-attachments/assets/40466e81-eab6-4305-abec-3b3222266312" />

closes [KVBM-418](https://linear.app/nvidia/issue/KVBM-418/add-the-missing-onboard-disk-to-host-metrics-to-kvbm-v2)