### PR TITLE
test(parsers): harden top-7 parsers with 5 more corner-case tests

### DIFF
--- a/lib/parsers/src/tool_calling/harmony/harmony_parser.rs
+++ b/lib/parsers/src/tool_calling/harmony/harmony_parser.rs
@@ -275,7 +275,7 @@ mod tests {
     // envelope still gives the parser enough context to recover the call —
     // this test pins that recovery behavior. The bare-envelope variant
     // (no preceding analysis block) currently does NOT recover, but adding
-    // a test for that is a parser-change discussion (see DIS-1842 / DIS-1832).
+    // a test for that is a parser-change discussion.
     // Pin current behavior on two back-to-back commentary blocks. The
     // harmony parser today does NOT extract both calls — the second
     // `<|start|>assistant<|channel|>commentary` block is left in normal

--- a/lib/parsers/src/tool_calling/harmony/harmony_parser.rs
+++ b/lib/parsers/src/tool_calling/harmony/harmony_parser.rs
@@ -270,7 +270,50 @@ mod tests {
         assert_eq!(args["location"], "San Francisco");
     }
 
-    #[tokio::test] // CASE.4, CASE.19
+    // Harmony's `<|call|>` plays the role of an outer end-token. When
+    // max_tokens fires before it lands, the existing `analysis ... <|end|>`
+    // envelope still gives the parser enough context to recover the call —
+    // this test pins that recovery behavior. The bare-envelope variant
+    // (no preceding analysis block) currently does NOT recover, but adding
+    // a test for that is a parser-change discussion (see DIS-1842 / DIS-1832).
+    // Pin current behavior on two back-to-back commentary blocks. The
+    // harmony parser today does NOT extract both calls — the second
+    // `<|start|>assistant<|channel|>commentary` block is left in normal
+    // content. Same failure class as CASE.5: parser drops in-flight work,
+    // customer sees HTTP 200 with fewer tool_calls than the model emitted.
+    // Promoting this to recovery is a parser change.
+    #[tokio::test] // CASE.2 — gpt-oss
+    async fn test_parse_harmony_multiple_calls_silent_drop() {
+        let text = r#"<|start|>assistant<|channel|>commentary to=functions.a <|constrain|>json<|message|>{"x":1}<|call|><|start|>assistant<|channel|>commentary to=functions.b <|constrain|>json<|message|>{"y":2}<|call|>"#;
+        let (tool_calls, _normal) =
+            parse_tool_calls_harmony_complete(text, &Default::default(), None)
+                .await
+                .unwrap();
+        assert_eq!(
+            tool_calls.len(),
+            0,
+            "harmony today drops both calls when two commentary blocks appear back-to-back"
+        );
+    }
+
+    // Pin current behavior on truncated JSON args. harmony today drops the
+    // call entirely rather than falling back to a string-form arguments or
+    // surfacing an explicit error.
+    #[tokio::test] // CASE.4 — gpt-oss
+    async fn test_parse_harmony_truncated_json_silent_drop() {
+        let text = r#"<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC<|call|>"#;
+        let (tool_calls, _normal) =
+            parse_tool_calls_harmony_complete(text, &Default::default(), None)
+                .await
+                .unwrap();
+        assert_eq!(
+            tool_calls.len(),
+            0,
+            "harmony today drops the call when JSON args are truncated mid-value"
+        );
+    }
+
+    #[tokio::test] // CASE.4, CASE.5, CASE.19
     async fn test_parse_tool_calls_harmony_without_call_token() {
         let text = r#"<|channel|>analysis<|message|>We need to call get_weather function. The user asks "What's the weather like in San Francisco in Celsius?" So location: "San Francisco, CA" unit: "celsius". Let's call function.<|end|><|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"San Francisco, CA","unit":"celsius"}"#;
         let (tool_calls, normal_content) =

--- a/lib/parsers/src/tool_calling/json/mod.rs
+++ b/lib/parsers/src/tool_calling/json/mod.rs
@@ -149,4 +149,76 @@ mod tests {
             "should stop at end of first complete call when second is incomplete"
         );
     }
+
+    // Pin current Nemotron behavior when </TOOLCALL> is absent due to
+    // max_tokens / EOS truncation. The JSON-family parser today silently
+    // drops the in-flight call — the failure mode TEST_CASES.md / DIS-1842 /
+    // DIS-1832 flag. Promoting to recovery (matching Kimi K2's behavior)
+    // would be a parser change.
+    #[test] // CASE.5 — nemotron_deci
+    fn test_parse_nemotron_deci_no_outer_close_silent_drop() {
+        let config = JsonParserConfig {
+            tool_call_start_tokens: vec!["<TOOLCALL>".to_string()],
+            tool_call_end_tokens: vec!["</TOOLCALL>".to_string()],
+            ..Default::default()
+        };
+        // JSON array fully complete; only outer </TOOLCALL> missing.
+        let input = r#"<TOOLCALL>[{"name":"get_weather","arguments":{"city":"NYC"}}]"#;
+
+        let (calls, normal_text) = try_tool_call_parse_json(input, &config, None).unwrap();
+        assert_eq!(
+            calls.len(),
+            0,
+            "nemotron_deci today drops the in-flight call when </TOOLCALL> is missing"
+        );
+        assert_eq!(normal_text, Some(input.to_string()));
+    }
+
+    // Verifies multi-call works correctly for nemotron_deci. The shared
+    // dispatcher tests this at the integration layer (see
+    // `parsers.rs::test_detect_and_parse_tool_call_default_parser_nemotron_deci_multiple`),
+    // but no parser-level test pinned it. This test makes the contract
+    // visible at the per-parser surface so a JSON-family refactor can't
+    // silently break parallel-call extraction without a per-parser failure.
+    #[test] // CASE.2 — nemotron_deci
+    fn test_parse_nemotron_deci_multiple_calls() {
+        let config = JsonParserConfig {
+            tool_call_start_tokens: vec!["<TOOLCALL>".to_string()],
+            tool_call_end_tokens: vec!["</TOOLCALL>".to_string()],
+            ..Default::default()
+        };
+        // Two calls in a single <TOOLCALL>...</TOOLCALL> block, JSON array form.
+        let input = r#"<TOOLCALL>[{"name":"get_weather","arguments":{"city":"NYC"}},{"name":"get_time","arguments":{"tz":"EST"}}]</TOOLCALL>"#;
+
+        let (calls, normal_text) = try_tool_call_parse_json(input, &config, None).unwrap();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].function.name, "get_weather");
+        assert_eq!(calls[1].function.name, "get_time");
+        assert_eq!(normal_text, Some("".to_string()));
+    }
+
+    // Pin current behavior when JSON args are truncated mid-value (e.g.
+    // max_tokens fires inside `"city":"NYC` with no closing quote). The
+    // outer </TOOLCALL> is also absent here — same shape as a real
+    // truncation. nemotron_deci silently drops the call today; the same
+    // class of bug as CASE.5. Distinct from existing fallback-to-string
+    // tests on other parsers, which exercise syntactically-bad-but-complete
+    // JSON, not truncation.
+    #[test] // CASE.4 — nemotron_deci
+    fn test_parse_nemotron_deci_truncated_json_silent_drop() {
+        let config = JsonParserConfig {
+            tool_call_start_tokens: vec!["<TOOLCALL>".to_string()],
+            tool_call_end_tokens: vec!["</TOOLCALL>".to_string()],
+            ..Default::default()
+        };
+        let input = r#"<TOOLCALL>[{"name":"get_weather","arguments":{"city":"NYC</TOOLCALL>"#;
+
+        let (calls, normal_text) = try_tool_call_parse_json(input, &config, None).unwrap();
+        assert_eq!(
+            calls.len(),
+            0,
+            "nemotron_deci today drops calls with truncated JSON args"
+        );
+        assert_eq!(normal_text, Some(input.to_string()));
+    }
 }

--- a/lib/parsers/src/tool_calling/json/mod.rs
+++ b/lib/parsers/src/tool_calling/json/mod.rs
@@ -152,8 +152,8 @@ mod tests {
 
     // Pin current Nemotron behavior when </TOOLCALL> is absent due to
     // max_tokens / EOS truncation. The JSON-family parser today silently
-    // drops the in-flight call — the failure mode TEST_CASES.md / DIS-1842 /
-    // DIS-1832 flag. Promoting to recovery (matching Kimi K2's behavior)
+    // drops the in-flight call — the failure mode TEST_CASES.md flags.
+    // Promoting to recovery (matching Kimi K2's behavior)
     // would be a parser change.
     #[test] // CASE.5 — nemotron_deci
     fn test_parse_nemotron_deci_no_outer_close_silent_drop() {

--- a/lib/parsers/src/tool_calling/xml/glm47_parser.rs
+++ b/lib/parsers/src/tool_calling/xml/glm47_parser.rs
@@ -450,7 +450,7 @@ mod tests {
     // Pin current behavior when the outer `</tool_call>` is absent due to
     // max_tokens / EOS truncation. GLM 4.7's parser today returns zero calls
     // and surfaces the unmatched start as normal text — the "silent drop"
-    // failure mode flagged in TEST_CASES.md / DIS-1842 / DIS-1832. Kimi K2
+    // failure mode flagged in TEST_CASES.md. Kimi K2
     // recovers in this scenario (`kimi_k2_parser::test_parse_malformed_no_section_end`);
     // GLM 4.7 does not. Promoting to recovery is a parser change, not a
     // test change — these tests catch any drift in either direction.

--- a/lib/parsers/src/tool_calling/xml/glm47_parser.rs
+++ b/lib/parsers/src/tool_calling/xml/glm47_parser.rs
@@ -447,6 +447,45 @@ mod tests {
         assert_eq!(calls.len(), 0);
     }
 
+    // Pin current behavior when the outer `</tool_call>` is absent due to
+    // max_tokens / EOS truncation. GLM 4.7's parser today returns zero calls
+    // and surfaces the unmatched start as normal text — the "silent drop"
+    // failure mode flagged in TEST_CASES.md / DIS-1842 / DIS-1832. Kimi K2
+    // recovers in this scenario (`kimi_k2_parser::test_parse_malformed_no_section_end`);
+    // GLM 4.7 does not. Promoting to recovery is a parser change, not a
+    // test change — these tests catch any drift in either direction.
+    #[test] // CASE.5
+    fn test_parse_no_end_tag_complete_args_silent_drop() {
+        let config = get_test_config();
+        // Args complete, only outer </tool_call> missing.
+        let message = "<tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value>";
+
+        let (calls, normal_text) = try_tool_call_parse_glm47(message, &config, None).unwrap();
+        assert_eq!(
+            calls.len(),
+            0,
+            "GLM 4.7 today drops the in-flight call when </tool_call> is missing"
+        );
+        // Unparsed start surfaces as normal text rather than being silently dropped.
+        assert_eq!(normal_text, Some(message.to_string()));
+    }
+
+    #[test] // CASE.5
+    fn test_parse_no_end_tag_multiple_calls_silent_drop() {
+        let config = get_test_config();
+        // Two complete inner calls, missing only the trailing </tool_call> on the second.
+        let message = "<tool_call>get_weather<arg_key>city</arg_key><arg_value>NYC</arg_value></tool_call><tool_call>get_time<arg_key>tz</arg_key><arg_value>EST</arg_value>";
+
+        let (calls, _) = try_tool_call_parse_glm47(message, &config, None).unwrap();
+        // First call is well-formed and recovered. Second call's missing close drops it.
+        assert_eq!(
+            calls.len(),
+            1,
+            "First call recovers; second call silently drops on missing </tool_call>"
+        );
+        assert_eq!(calls[0].function.name, "get_weather");
+    }
+
     #[test] // CASE.4, CASE.13
     fn test_unparseable_block_preserved_as_normal_text() {
         let config = get_test_config();

--- a/lib/parsers/src/tool_calling/xml/kimi_k2_parser.rs
+++ b/lib/parsers/src/tool_calling/xml/kimi_k2_parser.rs
@@ -455,6 +455,28 @@ mod tests {
         assert_eq!(calls[0].function.name, "get_weather");
     }
 
+    // Pin current behavior when JSON args are truncated mid-value (e.g.
+    // max_tokens fires inside `"location":"NYC` with no closing quote)
+    // INSIDE complete `<|tool_call_end|>` + `<|tool_calls_section_end|>`
+    // fences. Distinct from `test_parse_invalid_json_falls_back_to_raw_string`
+    // (which uses syntactically-bad-but-complete JSON and falls back to a
+    // raw string) and from `test_parse_truncated_mid_argument_no_section_end`
+    // (which omits the closing fences entirely). This is the
+    // "fences-complete-but-payload-truncated" cell — Kimi today drops the
+    // call instead of falling back. Promoting to fallback is a parser change.
+    #[test] // CASE.4
+    fn test_parse_truncated_json_inside_complete_fences_silent_drop() {
+        let config = default_config();
+        let input = r#"<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC<|tool_call_end|><|tool_calls_section_end|>"#;
+
+        let (calls, _) = try_tool_call_parse_kimi_k2(input, &config, None).unwrap();
+        assert_eq!(
+            calls.len(),
+            0,
+            "Kimi K2 today drops calls with truncated JSON args even when fences are complete"
+        );
+    }
+
     #[test] // CASE.5, CASE.16 (PR #8208)
     fn test_parse_malformed_no_section_end() {
         let config = default_config();

--- a/lib/parsers/src/tool_calling/xml/parser.rs
+++ b/lib/parsers/src/tool_calling/xml/parser.rs
@@ -902,6 +902,54 @@ rust programming
         assert_eq!(args["query"], "rust programming\n<parameter=limit>\n10");
     }
 
+    // Pin current behavior when the OUTER </tool_call> fence is absent due
+    // to max_tokens / EOS truncation. The qwen3_coder dialect (which uses
+    // XmlParserConfig::default()) silently drops the in-flight call today
+    // — the failure mode TEST_CASES.md / DIS-1842 / DIS-1832 flag. Distinct
+    // from `test_parse_missing_*_closing_tag` above, which exercises missing
+    // INNER close tags (a separate, already-recovering path).
+    #[test] // CASE.5 — qwen3_coder
+    fn test_parse_qwen3_no_outer_close_silent_drop() {
+        // Inner content fully complete; only outer </tool_call> missing.
+        let input = r#"<tool_call>
+<function=get_weather>
+<parameter=city>
+NYC
+</parameter>
+</function>"#;
+
+        let (calls, normal_text) =
+            try_tool_call_parse_xml(input, &XmlParserConfig::default(), None).unwrap();
+        assert_eq!(
+            calls.len(),
+            0,
+            "qwen3_coder today drops the in-flight call when </tool_call> is missing"
+        );
+        assert_eq!(normal_text, Some(input.to_string()));
+    }
+
+    #[test] // CASE.5 — minimax_m2
+    fn test_parse_minimax_m2_no_outer_close_silent_drop() {
+        let config = XmlParserConfig {
+            tool_call_start_token: "<minimax:tool_call>".to_string(),
+            tool_call_end_token: "</minimax:tool_call>".to_string(),
+            function_start_token: "<invoke name=".to_string(),
+            function_end_token: "</invoke>".to_string(),
+            parameter_start_token: "<parameter name=".to_string(),
+            parameter_end_token: "</parameter>".to_string(),
+        };
+        // Inner invoke fully closed; only outer </minimax:tool_call> missing.
+        let input = r#"<minimax:tool_call><invoke name="get_weather"><parameter name="city">NYC</parameter></invoke>"#;
+
+        let (calls, normal_text) = try_tool_call_parse_xml(input, &config, None).unwrap();
+        assert_eq!(
+            calls.len(),
+            0,
+            "minimax_m2 today drops the in-flight call when </minimax:tool_call> is missing"
+        );
+        assert_eq!(normal_text, Some(input.to_string()));
+    }
+
     #[test] // CASE.18
     fn test_schema_aware_type_conversion() {
         // This test matches the Python test_parse_streaming_increment_multiple_parameters

--- a/lib/parsers/src/tool_calling/xml/parser.rs
+++ b/lib/parsers/src/tool_calling/xml/parser.rs
@@ -905,7 +905,7 @@ rust programming
     // Pin current behavior when the OUTER </tool_call> fence is absent due
     // to max_tokens / EOS truncation. The qwen3_coder dialect (which uses
     // XmlParserConfig::default()) silently drops the in-flight call today
-    // — the failure mode TEST_CASES.md / DIS-1842 / DIS-1832 flag. Distinct
+    // — the failure mode TEST_CASES.md flags. Distinct
     // from `test_parse_missing_*_closing_tag` above, which exercises missing
     // INNER close tags (a separate, already-recovering path).
     #[test] // CASE.5 — qwen3_coder


### PR DESCRIPTION
#### Overview:

This PR does **not** modify any parser. It only adds tests that expose existing parser problems. Parser fixes come in a follow-up PR.

#### Coverage chart — CASE.1–5 × top-7 parsers

Legend: ✓ dedicated test · ✗ not properly covered · N/A not applicable

| Case | Description | Kimi K2.6 | GLM 5.1 | MiniMax 2.7 | Qwen 3.5 | Nemotron | gpt-oss | DSv4 |
|---|---|---|---|---|---|---|---|---|
| **CASE.1** | Single tool call (happy path) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
| **CASE.2** | Multiple tool calls | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ |
| **CASE.3** | No tool call (text only) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
| **CASE.4** | Malformed / partial JSON args | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ |
| **CASE.5** | Missing end-token recovery | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ |

The new tests target the ✗ cells. Most assert `calls.len() == 0` — that's what the parser does today. When the parser is fixed later, the assertion flips to `1` and the matrix updates in the same follow-up PR. Only Nemotron CASE.2 ✗ → ✓ promotes on this merge (parser already works; test was just missing).

Customer-facing symptom for the silent-drop cases: HTTP 200 with empty `tool_calls` and no error.

#### Details:

- Add CASE.5 silent-drop test for `glm47` when outer `</tool_call>` is absent (`test_parse_no_end_tag_complete_args_silent_drop`)
- Add CASE.5 partial-recovery test for `glm47` when first call is complete and second drops on missing `</tool_call>` (`test_parse_no_end_tag_multiple_calls_silent_drop`)
- Add CASE.5 silent-drop test for `qwen3_coder` via shared `xml/parser.rs` (`test_parse_qwen3_no_outer_close_silent_drop`)
- Add CASE.5 silent-drop test for `minimax_m2` with its own `XmlParserConfig` (`test_parse_minimax_m2_no_outer_close_silent_drop`)
- Add CASE.5 silent-drop test for `nemotron_deci` when outer `</TOOLCALL>` is absent (`test_parse_nemotron_deci_no_outer_close_silent_drop`)
- Relabel harmony's `test_parse_tool_calls_harmony_without_call_token` to also carry CASE.5 (it was tagged CASE.4 only despite exercising missing-`<|call|>` recovery)
- Add CASE.2 multi-call test for `nemotron_deci` pinning working behavior — promotes ✗ → ✓ on merge (`test_parse_nemotron_deci_multiple_calls`)
- Add CASE.2 silent-drop test for `harmony` when two `<|start|>assistant<|channel|>commentary` blocks appear back-to-back (`test_parse_harmony_multiple_calls_silent_drop`)
- Add CASE.4 silent-drop test for `kimi_k2` when JSON args are truncated mid-value inside otherwise complete fences (`test_parse_truncated_json_inside_complete_fences_silent_drop`)
- Add CASE.4 silent-drop test for `nemotron_deci` truncated JSON (`test_parse_nemotron_deci_truncated_json_silent_drop`)
- Add CASE.4 silent-drop test for `harmony` truncated JSON before `<|call|>` (`test_parse_harmony_truncated_json_silent_drop`)

#### Where should the reviewer start?

`lib/parsers/src/tool_calling/xml/glm47_parser.rs`, then `lib/parsers/src/tool_calling/json/mod.rs`, `lib/parsers/src/tool_calling/harmony/harmony_parser.rs`

#### Related Issues:

Relates to DIS-1842

/coderabbit profile chill