### PR TITLE
docs: add DYN_EVENT_PLANE=zmq to hello_world example commands

### DIFF
--- a/examples/custom_backend/hello_world/README.md
+++ b/examples/custom_backend/hello_world/README.md
@@ -57,17 +57,18 @@ Dynamo must be installed. No external services are required for local developmen
 First, start the backend service:
 ```bash
 cd examples/custom_backend/hello_world
-DYN_DISCOVERY_BACKEND=file python hello_world.py
+DYN_DISCOVERY_BACKEND=file DYN_EVENT_PLANE=zmq python hello_world.py
 ```
 
 Second, in a separate terminal, run the client:
 ```bash
 cd examples/custom_backend/hello_world
-DYN_DISCOVERY_BACKEND=file python client.py
+DYN_DISCOVERY_BACKEND=file DYN_EVENT_PLANE=zmq python client.py
 ```
 
-> **Note**: Setting `DYN_DISCOVERY_BACKEND=file` uses file-based discovery instead of etcd.
-> Both the backend and client must use the same discovery backend to discover each other.
+> **Note**: Setting `DYN_DISCOVERY_BACKEND=file` uses file-based discovery instead of etcd,
+> and `DYN_EVENT_PLANE=zmq` uses ZMQ instead of NATS for the event plane.
+> Both the backend and client must use the same settings to discover each other.
 
 The client will connect to the backend service and print the streaming results.
 


### PR DESCRIPTION
## Summary
- The hello_world example README only set `DYN_DISCOVERY_BACKEND=file` (bypasses etcd) but omitted `DYN_EVENT_PLANE=zmq` (bypasses NATS), causing a NATS connection error when running the example as documented.
- Added `DYN_EVENT_PLANE=zmq` to both the backend and client run commands, and updated the explanatory note to cover both env vars.

## Where should the reviewer start?
`examples/custom_backend/hello_world/README.md`

## Related Issues
Fixes DYN-2743

## Test Plan
- [ ] CI passes
- [ ] Run `DYN_DISCOVERY_BACKEND=file DYN_EVENT_PLANE=zmq python hello_world.py` and verify no NATS error

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8847" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated custom backend example instructions and configuration notes to clarify that backend and client must use identical event plane and discovery backend settings for proper operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->