### PR TITLE
fix: drop webhook cert commonName to avoid 64-byte CN limit (#8736)

### DIFF
--- a/deploy/helm/charts/platform/components/operator/templates/webhook-certificates.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/webhook-certificates.yaml
@@ -83,7 +83,8 @@ spec:
   secretName: {{ .Values.webhook.certificateSecret.name }}
   duration: {{ .Values.webhook.certManager.certificate.duration }}
   renewBefore: {{ .Values.webhook.certManager.certificate.renewBefore }}
-  commonName: {{ include "dynamo-operator.fullname" . }}-webhook-service.{{ .Release.Namespace }}.svc
+  # commonName intentionally omitted: the FQDN below can exceed the 64-byte X.509 CN limit
+  # for longer release names / namespaces. Identity is asserted via the DNS SANs (RFC 6125).
   dnsNames:
   - {{ include "dynamo-operator.fullname" . }}-webhook-service
   - {{ include "dynamo-operator.fullname" . }}-webhook-service.{{ .Release.Namespace }}.svc


### PR DESCRIPTION
#### Overview:

The dynamo-operator webhook serving `Certificate` sets `spec.commonName` to a value that can exceed cert-manager / X.509's 64-byte CommonName cap. With the documented release name `dynamo-platform` in namespace `dynamo-system`, the rendered string is **65 bytes**, so the cert-manager admission webhook rejects the install with:

```
admission webhook "webhook.cert-manager.io" denied the request: spec.commonName: Too long: may not be more than 64 bytes
```

The chart install/upgrade then loops, and the operator pod stays stuck because `webhook-server-cert` is never created (matching the failure described in #8736).

#### Details:

Remove the `commonName` field from the webhook serving `Certificate` in `deploy/helm/charts/platform/components/operator/templates/webhook-certificates.yaml`. The same FQDN is already declared as a DNS SAN three lines below, so identity is preserved:

```yaml
dnsNames:
  - <fullname>-webhook-service
  - <fullname>-webhook-service.<namespace>.svc
  - <fullname>-webhook-service.<namespace>.svc.<clusterDomain>
```

Per RFC 6125 §6.4.4 (and the CA/Browser Forum Baseline Requirements §7.1.4.2.2), TLS clients that find DNS SANs must ignore CN entirely — so dropping the field is a no-op for validation while removing the 64-byte ceiling. A two-line YAML comment is left in place so a future maintainer doesn't reintroduce the field without understanding the constraint.

The bootstrap/root-CA `Certificate` higher in the same file is unchanged: its CN is `<fullname>-root-ca` (≈40 bytes for the documented release name) and it has no SANs, so the CN is required there.

#### Where should the reviewer start?

- `deploy/helm/charts/platform/components/operator/templates/webhook-certificates.yaml` — only file touched. Diff is 3 lines (1 removed, 2 comment lines added).

Suggested manual repro / verification:

```bash
helm template dynamo-platform deploy/helm/charts/platform \
  --namespace dynamo-system \
  --set "dynamo-operator.webhook.certManager.enabled=true" \
  --show-only charts/dynamo-operator/templates/webhook-certificates.yaml
```

Before this PR the rendered webhook `Certificate` contains a 65-byte `commonName`; after this PR the field is gone and the SANs remain.

#### Related Issues:

- Closes GitHub issue: #8736
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8848" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook certificate validation to prioritize DNS-based identity verification, enhancing the security and reliability of webhook communications within the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->