### PR TITLE
chore(frontend): Add Gemma 4 parser support + Test Cases

### DIFF
--- a/docs/agents/reasoning.md
+++ b/docs/agents/reasoning.md
@@ -45,6 +45,7 @@ require the opening tag to be present in the model output.
 | `basic` | Generic CoT models | Dynamo-only | No | Plain `<think>...</think>` |
 | `deepseek_r1` | DeepSeek R1, DeepSeek V3.1, DeepSeek V3.2 | | Yes | Pass explicitly for V3.1/V3.2 (no alias) |
 | `deepseek_v4` | DeepSeek V4 Pro / Flash | vLLM: `deepseek_v4`; SGLang: `deepseek-v4` | No | `<think>...</think>`. Aliases: `deepseek-v4`, `deepseekv4` |
+| `gemma4` | Google Gemma 4 (thinking models) | vLLM: `gemma4` | No | `<\|channel>thought\n...<channel\|>` with `thought\n` role label stripped. Aliases: `gemma-4` |
 | `glm45` | GLM-4.5, GLM-4.7 | Dynamo-only | No | Alias for `nemotron_deci`. `<think>...</think>` |
 | `gpt_oss` | gpt-oss-20b / -120b | Dynamo-only | No | Harmony channel reasoning format |
 | `granite` | Granite 3.x | | No | `Here's my thought process:` / `Here's my response:` |
@@ -66,6 +67,7 @@ Some models need both parsers configured together. Common pairings include:
 - `deepseek-ai/DeepSeek-V4-*`: `--dyn-tool-call-parser deepseek_v4 --dyn-reasoning-parser deepseek_v4`
 - `zai-org/GLM-4.7`: `--dyn-tool-call-parser glm47 --dyn-reasoning-parser glm45`
 - `moonshotai/Kimi-K2.5*`: `--dyn-tool-call-parser kimi_k2 --dyn-reasoning-parser kimi_k25`
+- `google/gemma-4-*` thinking models: `--dyn-tool-call-parser gemma4 --dyn-reasoning-parser gemma4 --custom-jinja-template examples/chat_templates/gemma4_tool.jinja`
 - `Qwen/Qwen3.5*`: `--dyn-tool-call-parser qwen3_coder --dyn-reasoning-parser qwen3`
 - MiniMax M2.1 style outputs: `--dyn-tool-call-parser minimax_m2 --dyn-reasoning-parser minimax_append_think`
 

--- a/docs/agents/tool-calling.md
+++ b/docs/agents/tool-calling.md
@@ -53,6 +53,7 @@ parser exists for this format.
 | `deepseek_v3_2` | DeepSeek V3.2+ | Dynamo-only | DSML tags (`<｜DSML｜function_calls>...`) |
 | `deepseek_v4` | DeepSeek V4 Pro / Flash | vLLM: `deepseek_v4`; SGLang: `deepseekv4` | DSML tags (`<｜DSML｜tool_calls>...`). Aliases: `deepseek-v4`, `deepseekv4` |
 | `default` | *(fallback)* | Dynamo-only | Empty JSON config (no start/end tokens). Prefer a model-specific parser for production use. |
+| `gemma4` | Google Gemma 4 (thinking models) | vLLM: `gemma4` | Custom non-JSON grammar with `<\|"\|>` string delimiters and `<\|tool_call>...<tool_call\|>` markers. Aliases: `gemma-4`. Pair with `--dyn-reasoning-parser gemma4` and `--custom-jinja-template examples/chat_templates/gemma4_tool.jinja` |
 | `glm47` | GLM-4.5, GLM-4.7 | Dynamo-only | XML `<arg_key>/<arg_value>` |
 | `harmony` | gpt-oss-20b / -120b | Dynamo-only | Harmony channel format |
 | `hermes` | Qwen2.5-\*, QwQ-32B, Qwen3-Instruct, Qwen3-Think, NousHermes-2/3 | vLLM: `qwen2_5`; SGLang: `qwen25` (for Qwen models) | `<tool_call>` JSON |

--- a/examples/chat_templates/README.md
+++ b/examples/chat_templates/README.md
@@ -1,0 +1,29 @@
+# Chat Templates
+
+Vendored Jinja chat templates for models whose HuggingFace stock template does
+not emit the markers required by Dynamo's tool-call / reasoning parsers.
+
+Pass any of these at serve time via:
+
+```bash
+--custom-jinja-template examples/chat_templates/<file>.jinja
+```
+
+## Templates
+
+| File | Model | Pair with |
+|---|---|---|
+| `gemma4_tool.jinja` | Google Gemma 4 thinking models | `--dyn-tool-call-parser gemma4 --dyn-reasoning-parser gemma4` |
+
+## `gemma4_tool.jinja`
+
+Emits the custom Gemma 4 grammar:
+
+- Tool calls: `<|tool_call>call:name{key:<|"|>value<|"|>}<tool_call|>`
+- Reasoning: `<|channel>thought\n...<channel|>`
+- Tool definitions: nested `declaration:fn{description:<|"|>...<|"|>,parameters:{...}}` blocks
+
+This template is a verbatim copy of the upstream vLLM project's
+`examples/tool_chat_template_gemma4.jinja` (Apache-2.0). It is required when
+the HF chat template for Gemma 4 lacks the `<|"|>`-delimited tool-definition
+encoding that the parsers expect.

--- a/examples/chat_templates/gemma4_tool.jinja
+++ b/examples/chat_templates/gemma4_tool.jinja
@@ -1,0 +1,334 @@
+{# SPDX-FileCopyrightText: Copyright contributors to the vLLM project, NVIDIA CORPORATION & AFFILIATES #}
+{# SPDX-License-Identifier: Apache-2.0 #}
+{# Verbatim copy of vllm/examples/tool_chat_template_gemma4.jinja, vendored for use with Dynamo's `gemma4` parsers. Pass via --custom-jinja-template. #}
+{%- macro format_parameters(properties, required) -%}
+    {%- set standard_keys = ['description', 'type', 'properties', 'required', 'nullable'] -%}
+    {%- set ns = namespace(found_first=false) -%}
+    {%- for key, value in properties | dictsort -%}
+        {%- set add_comma = false -%}
+        {%- if key not in standard_keys -%}
+            {%- if ns.found_first %},{% endif -%}
+            {%- set ns.found_first = true -%}
+            {{ key }}:{
+            {%- if value['description'] -%}
+                description:<|"|>{{ value['description'] }}<|"|>
+                {%- set add_comma = true -%}
+            {%- endif -%}
+            {%- if value['nullable'] %}
+                {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                nullable:true
+            {%- endif -%}
+            {%- if value['type'] | upper == 'STRING' -%}
+                {%- if value['enum'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    enum:{{ format_argument(value['enum']) }}
+                {%- endif -%}
+            {%- elif value['type'] | upper == 'OBJECT' -%}
+                ,properties:{
+                {%- if value['properties'] is defined and value['properties'] is mapping -%}
+                    {{- format_parameters(value['properties'], value['required'] | default([])) -}}
+                {%- elif value is mapping -%}
+                    {{- format_parameters(value, value['required'] | default([])) -}}
+                {%- endif -%}
+                }
+                {%- if value['required'] -%}
+                    ,required:[
+                    {%- for item in value['required'] | default([]) -%}
+                        <|"|>{{- item -}}<|"|>
+                        {%- if not loop.last %},{% endif -%}
+                    {%- endfor -%}
+                    ]
+                {%- endif -%}
+            {%- elif value['type'] | upper == 'ARRAY' -%}
+                {%- if value['items'] is mapping and value['items'] -%}
+                    ,items:{
+                    {%- set ns_items = namespace(found_first=false) -%}
+                    {%- for item_key, item_value in value['items'] | dictsort -%}
+                        {%- if item_value is not none -%}
+                            {%- if ns_items.found_first %},{% endif -%}
+                            {%- set ns_items.found_first = true -%}
+                            {%- if item_key == 'properties' -%}
+                                properties:{
+                                {%- if item_value is mapping -%}
+                                    {{- format_parameters(item_value, value['items']['required'] | default([])) -}}
+                                {%- endif -%}
+                                }
+                            {%- elif item_key == 'required' -%}
+                                required:[
+                                {%- for req_item in item_value -%}
+                                    <|"|>{{- req_item -}}<|"|>
+                                    {%- if not loop.last %},{% endif -%}
+                                {%- endfor -%}
+                                ]
+                            {%- elif item_key == 'type' -%}
+                                {%- if item_value is string -%}
+                                    type:{{ format_argument(item_value | upper) }}
+                                {%- else -%}
+                                    type:{{ format_argument(item_value | map('upper') | list) }}
+                                {%- endif -%}
+                            {%- else -%}
+                                {{ item_key }}:{{ format_argument(item_value) }}
+                            {%- endif -%}
+                        {%- endif -%}
+                    {%- endfor -%}
+                    }
+                {%- endif -%}
+            {%- endif -%}
+            {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+            type:<|"|>{{ value['type'] | upper }}<|"|>}
+        {%- endif -%}
+    {%- endfor -%}
+{%- endmacro -%}
+{%- macro format_function_declaration(tool_data) -%}
+    declaration:{{- tool_data['function']['name'] -}}{description:<|"|>{{- tool_data['function']['description'] -}}<|"|>
+    {%- set params = tool_data['function']['parameters'] -%}
+    {%- if params -%}
+        ,parameters:{
+        {%- if params['properties'] -%}
+            properties:{ {{- format_parameters(params['properties'], params['required']) -}} },
+        {%- endif -%}
+        {%- if params['required'] -%}
+            required:[
+            {%- for item in params['required'] -%}
+                <|"|>{{- item -}}<|"|>
+                {{- ',' if not loop.last -}}
+            {%- endfor -%}
+            ],
+        {%- endif -%}
+        {%- if params['type'] -%}
+            type:<|"|>{{- params['type'] | upper -}}<|"|>}
+        {%- endif -%}
+    {%- endif -%}
+    {%- if 'response' in tool_data['function'] -%}
+        {%- set response_declaration = tool_data['function']['response'] -%}
+        ,response:{
+        {%- if response_declaration['description'] -%}
+            description:<|"|>{{- response_declaration['description'] -}}<|"|>,
+        {%- endif -%}
+        {%- if response_declaration['type'] | upper == 'OBJECT' -%}
+            type:<|"|>{{- response_declaration['type'] | upper -}}<|"|>}
+        {%- endif -%}
+    {%- endif -%}
+    }
+{%- endmacro -%}
+{%- macro format_argument(argument, escape_keys=True) -%}
+    {%- if argument is string -%}
+        {{- '<|"|>' + argument + '<|"|>' -}}
+    {%- elif argument is boolean -%}
+        {{- 'true' if argument else 'false' -}}
+    {%- elif argument is mapping -%}
+        {{- '{' -}}
+        {%- set ns = namespace(found_first=false) -%}
+        {%- for key, value in argument | dictsort -%}
+            {%- if ns.found_first %},{% endif -%}
+            {%- set ns.found_first = true -%}
+            {%- if escape_keys -%}
+                {{- '<|"|>' + key + '<|"|>' -}}
+            {%- else -%}
+                {{- key -}}
+            {%- endif -%}
+            :{{- format_argument(value, escape_keys=escape_keys) -}}
+        {%- endfor -%}
+        {{- '}' -}}
+    {%- elif argument is sequence -%}
+        {{- '[' -}}
+        {%- for item in argument -%}
+            {{- format_argument(item, escape_keys=escape_keys) -}}
+            {%- if not loop.last %},{% endif -%}
+        {%- endfor -%}
+        {{- ']' -}}
+    {%- else -%}
+        {{- argument -}}
+    {%- endif -%}
+{%- endmacro -%}
+{%- macro strip_thinking(text) -%}
+    {%- set ns = namespace(result='') -%}
+    {%- for part in text.split('<channel|>') -%}
+        {%- if '<|channel>' in part -%}
+            {%- set ns.result = ns.result + part.split('<|channel>')[0] -%}
+        {%- else -%}
+            {%- set ns.result = ns.result + part -%}
+        {%- endif -%}
+    {%- endfor -%}
+    {{- ns.result | trim -}}
+{%- endmacro -%}
+
+{%- macro format_tool_response_block(tool_name, response) -%}
+    {{- '<|tool_response>' -}}
+    {%- if response is mapping -%}
+        {{- 'response:' + tool_name + '{' -}}
+        {%- for key, value in response | dictsort -%}
+            {{- key -}}:{{- format_argument(value, escape_keys=False) -}}
+            {%- if not loop.last %},{% endif -%}
+        {%- endfor -%}
+        {{- '}' -}}
+    {%- else -%}
+        {{- 'response:' + tool_name + '{value:' + format_argument(response, escape_keys=False) + '}' -}}
+    {%- endif -%}
+    {{- '<tool_response|>' -}}
+{%- endmacro -%}
+
+{%- set ns = namespace(prev_message_type=None) -%}
+{%- set loop_messages = messages -%}
+{{ bos_token }}
+{%- if (enable_thinking is defined and enable_thinking) or tools or messages[0]['role'] in ['system', 'developer'] -%}
+    {{- '<|turn>system\n' -}}
+
+    {%- if enable_thinking is defined and enable_thinking -%}
+        {{- '<|think|>' -}}
+        {%- set ns.prev_message_type = 'think' -%}
+    {%- endif -%}
+
+    {%- if messages[0]['role'] in ['system', 'developer'] -%}
+        {{- messages[0]['content'] | trim -}}
+        {%- set loop_messages = messages[1:] -%}
+    {%- endif -%}
+
+    {%- if tools -%}
+        {%- for tool in tools %}
+            {{- '<|tool>' -}}
+            {{- format_function_declaration(tool) | trim -}}
+            {{- '<tool|>' -}}
+        {%- endfor %}
+        {%- set ns.prev_message_type = 'tool' -%}
+    {%- endif -%}
+
+    {{- '<turn|>\n' -}}
+{%- endif %}
+
+{%- set ns_turn = namespace(last_user_idx=-1) -%}
+{%- for i in range(loop_messages | length) -%}
+    {%- if loop_messages[i]['role'] == 'user' -%}
+        {%- set ns_turn.last_user_idx = i -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{%- for message in loop_messages -%}
+    {%- if message['role'] != 'tool' -%}
+    {%- set ns.prev_message_type = None -%}
+    {%- set role = 'model' if message['role'] == 'assistant' else message['role'] -%}
+    {#- OpenAI may emit multiple assistant messages in one tool loop (user → asst → tool → asst → tool).
+        Only the first of those should open <|turn>model; later ones continue the same model turn. -#}
+    {%- set prev_nt = namespace(role=None, found=false) -%}
+    {%- if loop.index0 > 0 -%}
+        {%- for j in range(loop.index0 - 1, -1, -1) -%}
+            {%- if not prev_nt.found -%}
+                {%- if loop_messages[j]['role'] != 'tool' -%}
+                    {%- set prev_nt.role = loop_messages[j]['role'] -%}
+                    {%- set prev_nt.found = true -%}
+                {%- endif -%}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- endif -%}
+    {%- set continue_same_model_turn = (role == 'model' and prev_nt.role == 'assistant') -%}
+    {%- if not continue_same_model_turn -%}
+        {{- '<|turn>' + role + '\n' }}
+    {%- endif -%}
+
+    {%- if message.get('reasoning') and loop.index0 > ns_turn.last_user_idx and message.get('tool_calls') -%}
+        {{- '<|channel>thought\n' + message['reasoning'] + '\n<channel|>'}}
+    {%- endif -%}
+
+            {%- if message['tool_calls'] -%}
+                {%- for tool_call in message['tool_calls'] -%}
+                    {%- set function = tool_call['function'] -%}
+                    {{- '<|tool_call>call:' + function['name'] + '{' -}}
+                    {%- if function['arguments'] is mapping -%}
+                        {%- set ns_args = namespace(found_first=false) -%}
+                        {%- for key, value in function['arguments'] | dictsort -%}
+                            {%- if ns_args.found_first %},{% endif -%}
+                            {%- set ns_args.found_first = true -%}
+                            {{- key -}}:{{- format_argument(value, escape_keys=False) -}}
+                        {%- endfor -%}
+                    {%- elif function['arguments'] is string -%}
+                        {{- function['arguments'] -}}
+                    {%- endif -%}
+                    {{- '}<tool_call|>' -}}
+                {%- endfor -%}
+                {%- set ns.prev_message_type = 'tool_call' -%}
+            {%- endif -%}
+
+            {%- set ns_tr_out = namespace(flag=false) -%}
+            {%- if message.get('tool_responses') -%}
+                {#- Legacy: tool_responses embedded on the assistant message -#}
+                {%- for tool_response in message['tool_responses'] -%}
+                    {{- format_tool_response_block(tool_response['name'] | default('unknown'), tool_response['response']) -}}
+                    {%- set ns_tr_out.flag = true -%}
+                    {%- set ns.prev_message_type = 'tool_response' -%}
+                {%- endfor -%}
+            {%- elif message.get('tool_calls') -%}
+                {#- OpenAI Chat Completions: consecutive following messages with role "tool" (no break/continue; range scan) -#}
+                {%- set ns_tool_scan = namespace(stopped=false) -%}
+                {%- for k in range(loop.index0 + 1, loop_messages | length) -%}
+                    {%- if ns_tool_scan.stopped -%}
+                    {%- elif loop_messages[k]['role'] != 'tool' -%}
+                        {%- set ns_tool_scan.stopped = true -%}
+                    {%- else -%}
+                        {%- set follow = loop_messages[k] -%}
+                        {%- set ns_tname = namespace(name=follow.get('name') | default('unknown')) -%}
+                        {%- for tc in message['tool_calls'] -%}
+                            {%- if tc.get('id') == follow.get('tool_call_id') -%}
+                                {%- set ns_tname.name = tc['function']['name'] -%}
+                            {%- endif -%}
+                        {%- endfor -%}
+                        {%- set tool_body = follow.get('content') -%}
+                        {%- if tool_body is string -%}
+                            {{- format_tool_response_block(ns_tname.name, tool_body) -}}
+                        {%- elif tool_body is sequence and tool_body is not string -%}
+                            {%- set ns_txt = namespace(s='') -%}
+                            {%- for part in tool_body -%}
+                                {%- if part.get('type') == 'text' -%}
+                                    {%- set ns_txt.s = ns_txt.s + (part.get('text') | default('')) -%}
+                                {%- endif -%}
+                            {%- endfor -%}
+                            {{- format_tool_response_block(ns_tname.name, ns_txt.s) -}}
+                        {%- else -%}
+                            {{- format_tool_response_block(ns_tname.name, tool_body) -}}
+                        {%- endif -%}
+                        {%- set ns_tr_out.flag = true -%}
+                        {%- set ns.prev_message_type = 'tool_response' -%}
+                    {%- endif -%}
+                {%- endfor -%}
+            {%- endif -%}
+
+            {%- if message['content'] is string -%}
+                {%- if role == 'model' -%}
+                    {{- strip_thinking(message['content']) -}}
+                {%- else -%}
+                    {{- message['content'] | trim -}}
+                {%- endif -%}
+            {%- elif message['content'] is sequence -%}
+                {%- for item in message['content'] -%}
+                    {%- if item['type'] == 'text' -%}
+                        {%- if role == 'model' -%}
+                            {{- strip_thinking(item['text']) -}}
+                        {%- else -%}
+                            {{- item['text'] | trim -}}
+                        {%- endif -%}
+                    {%- elif item['type'] == 'image' -%}
+                        {{- '\n\n<|image|>\n\n' -}}
+                        {%- set ns.prev_message_type = 'image' -%}
+                    {%- elif item['type'] == 'audio' -%}
+                        {{- '<|audio|>' -}}
+                        {%- set ns.prev_message_type = 'audio' -%}
+                    {%- elif item['type'] == 'video' -%}
+                        {{- '\n\n<|video|>\n\n' -}}
+                        {%- set ns.prev_message_type = 'video' -%}
+                    {%- endif -%}
+                {%- endfor -%}
+            {%- endif -%}
+
+        {%- if not (ns_tr_out.flag and not message.get('content')) -%}
+            {{- '<turn|>\n' -}}
+        {%- endif -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{%- if add_generation_prompt -%}
+    {%- if ns.prev_message_type != 'tool_response' -%}
+        {{- '<|turn>model\n' -}}
+    {%- endif -%}
+    {%- if not enable_thinking | default(false) -%}
+        {{- '<|channel>thought\n<channel|>' -}}
+    {%- endif -%}
+{%- endif -%}

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -308,7 +308,23 @@ impl OpenAIPreprocessor {
 
         builder.stop_conditions(stop_conditions);
         builder.sampling_options(request.extract_sampling_options()?);
-        builder.output_options(request.extract_output_options()?);
+
+        // Some parsers rely on `<|tool_call>`, `<|channel>`, etc. being
+        // visible in the decoded text. The default `skip_special_tokens=true`
+        // strips them and silently bypasses parsing. Mirror upstream's
+        // per-parser `adjust_request` hook by flipping the default to false
+        // for parsers that need special tokens preserved, unless the caller
+        // has explicitly set `skip_special_tokens`.
+        let mut output_options = request.extract_output_options()?;
+        if output_options.skip_special_tokens.is_none()
+            && Self::parser_requires_special_tokens(
+                self.tool_call_parser.as_deref(),
+                self.runtime_config.reasoning_parser.as_deref(),
+            )
+        {
+            output_options.skip_special_tokens = Some(false);
+        }
+        builder.output_options(output_options);
         builder.annotations(request.annotations().unwrap_or_default());
         builder.mdc_sum(Some(self.mdcsum.clone()));
         let lora_name = self.lora_name.clone();
@@ -1223,6 +1239,20 @@ impl OpenAIPreprocessor {
         jail.apply_with_finish_reason(stream)
     }
 
+    /// Whether the selected tool-call or reasoning parser depends on the
+    /// engine emitting special tokens (e.g. Gemma 4's `<|tool_call>` /
+    /// `<|channel>`). Mirrors upstream vLLM's per-parser `adjust_request`
+    /// hooks. Used to flip the request default for `skip_special_tokens`
+    /// from `true` to `false` so the parsers actually see the markers
+    /// they're matching on.
+    fn parser_requires_special_tokens(
+        tool_call_parser: Option<&str>,
+        reasoning_parser: Option<&str>,
+    ) -> bool {
+        matches!(tool_call_parser, Some("gemma4") | Some("gemma-4"))
+            || matches!(reasoning_parser, Some("gemma4") | Some("gemma-4"))
+    }
+
     /// Check if reasoning parsing should be disabled based on per-request parameters.
     /// For kimi_k25: disabled when chat_template_args contains "thinking": false.
     /// For nemotron_nano: disabled when chat_template_args contains "enable_thinking": false
@@ -1702,6 +1732,37 @@ mod strip_tests {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_parser_requires_special_tokens() {
+        let cases: &[(Option<&str>, Option<&str>, bool, &str)] = &[
+            (Some("gemma4"), None, true, "gemma4 tool-call only → required"),
+            (None, Some("gemma4"), true, "gemma4 reasoning only → required"),
+            (Some("gemma-4"), None, true, "gemma-4 hyphen alias (tool) → required"),
+            (None, Some("gemma-4"), true, "gemma-4 hyphen alias (reasoning) → required"),
+            (
+                Some("gemma4"),
+                Some("gemma4"),
+                true,
+                "gemma4 paired → required",
+            ),
+            (Some("hermes"), None, false, "hermes → not required"),
+            (
+                Some("kimi_k2"),
+                Some("kimi_k25"),
+                false,
+                "kimi_k2 paired → not required",
+            ),
+            (None, None, false, "no parsers → not required"),
+        ];
+        for (tool, reasoning, expected, desc) in cases {
+            assert_eq!(
+                OpenAIPreprocessor::parser_requires_special_tokens(*tool, *reasoning),
+                *expected,
+                "FAILED: {desc}",
+            );
+        }
+    }
 
     #[test]
     fn test_is_reasoning_disabled_by_request() {

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -1278,10 +1278,10 @@ impl OpenAIPreprocessor {
                 false
             }
             Some("gemma4") | Some("gemma-4") => {
-                if let Some(args) = chat_template_args
-                    && let Some(enable_thinking) = args.get("enable_thinking")
+                if let Some(enabled) =
+                    crate::preprocessor::prompt::thinking_bool_from_args(chat_template_args)
                 {
-                    return enable_thinking == &serde_json::Value::Bool(false);
+                    return !enabled;
                 }
                 false
             }

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -1736,10 +1736,30 @@ mod tests {
     #[test]
     fn test_parser_requires_special_tokens() {
         let cases: &[(Option<&str>, Option<&str>, bool, &str)] = &[
-            (Some("gemma4"), None, true, "gemma4 tool-call only → required"),
-            (None, Some("gemma4"), true, "gemma4 reasoning only → required"),
-            (Some("gemma-4"), None, true, "gemma-4 hyphen alias (tool) → required"),
-            (None, Some("gemma-4"), true, "gemma-4 hyphen alias (reasoning) → required"),
+            (
+                Some("gemma4"),
+                None,
+                true,
+                "gemma4 tool-call only → required",
+            ),
+            (
+                None,
+                Some("gemma4"),
+                true,
+                "gemma4 reasoning only → required",
+            ),
+            (
+                Some("gemma-4"),
+                None,
+                true,
+                "gemma-4 hyphen alias (tool) → required",
+            ),
+            (
+                None,
+                Some("gemma-4"),
+                true,
+                "gemma-4 hyphen alias (reasoning) → required",
+            ),
             (
                 Some("gemma4"),
                 Some("gemma4"),

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -1230,6 +1230,11 @@ impl OpenAIPreprocessor {
     /// For deepseek_r1 / deepseek_v4: disabled when chat_template_args contains
     ///   "thinking": false or "thinking_mode": "chat" — matches the V4 formatter's
     ///   `resolve_thinking_mode` convention, so the parser and the prompt stay in sync.
+    /// For gemma4: disabled when chat_template_args contains "enable_thinking": false.
+    ///   Gemma 4's chat template injects `<|think|>` only when `enable_thinking is
+    ///   defined and enable_thinking` (truthy), so when callers explicitly set the
+    ///   flag false the model emits no `<|channel>` markers and the parser would
+    ///   only ever fall through.
     fn is_reasoning_disabled_by_request(
         reasoning_parser: Option<&str>,
         chat_template_args: Option<&std::collections::HashMap<String, serde_json::Value>>,
@@ -1269,6 +1274,14 @@ impl OpenAIPreprocessor {
                     && let Some(mode) = args.get("thinking_mode").and_then(|v| v.as_str())
                 {
                     return mode == "chat";
+                }
+                false
+            }
+            Some("gemma4") | Some("gemma-4") => {
+                if let Some(args) = chat_template_args
+                    && let Some(enable_thinking) = args.get("enable_thinking")
+                {
+                    return enable_thinking == &serde_json::Value::Bool(false);
                 }
                 false
             }
@@ -1888,6 +1901,30 @@ mod tests {
                 Some(&enable_thinking_true),
                 false,
                 "deepseek_v4 + enable_thinking=true → enabled (vLLM alias)",
+            ),
+            (
+                Some("gemma4"),
+                Some(&enable_thinking_false),
+                true,
+                "gemma4 + enable_thinking=false → disabled",
+            ),
+            (
+                Some("gemma4"),
+                Some(&enable_thinking_true),
+                false,
+                "gemma4 + enable_thinking=true → enabled",
+            ),
+            (
+                Some("gemma4"),
+                None,
+                false,
+                "gemma4 + no args → enabled (parser still runs but is a no-op when no markers arrive)",
+            ),
+            (
+                Some("gemma-4"),
+                Some(&enable_thinking_false),
+                true,
+                "gemma-4 (hyphen alias) + enable_thinking=false → disabled",
             ),
         ];
 

--- a/lib/parsers/README.md
+++ b/lib/parsers/README.md
@@ -15,18 +15,20 @@ Two top-level modules, each with its own parser registry:
 ```
 lib/parsers/
 ├── src/
-│   ├── tool_calling/        ← tool-call extraction (17 registered parsers)
+│   ├── tool_calling/        ← tool-call extraction (18 registered parsers)
 │   │   ├── parsers.rs         — registry + dispatch (detect_and_parse_tool_call)
 │   │   ├── config.rs          — per-parser ToolCallConfig
 │   │   ├── response.rs        — ToolCallResponse shape (wire type)
 │   │   ├── dsml/              — DeepSeek V3.2 / V4 DSML grammar
+│   │   ├── gemma4/            — Google Gemma 4 custom non-JSON grammar (`<|"|>`-delimited strings)
 │   │   ├── xml/               — hermes, glm47, kimi_k2, minimax_m2, qwen3_coder
 │   │   ├── json/              — deepseek_v3, deepseek_v3_1, nemotron_deci/nano, jamba, mistral, phi4, llama3_json
 │   │   ├── harmony/           — OpenAI gpt-oss (Harmony token stream, uses openai_harmony crate)
 │   │   └── pythonic/          — Python function-call syntax (some Llama variants)
-│   └── reasoning/           ← reasoning-content extraction (14 registered parsers)
+│   └── reasoning/           ← reasoning-content extraction (15 registered parsers)
 │       ├── mod.rs             — registry + dispatch
 │       ├── base_parser.rs     — BasicReasoningParser (<think> ... </think>)
+│       ├── gemma4_parser.rs   — Gemma 4 (`<|channel>thought\n...<channel|>`)
 │       ├── gpt_oss_parser.rs  — Harmony channel parsing
 │       ├── granite_parser.rs  — Granite-style
 │       └── minimax_append_think_parser.rs  — MiniMax inline-reasoning
@@ -78,6 +80,7 @@ When adding a new model, the right parser family is usually one of:
 | **JSON** | Start sentinel + bare JSON array of `{name, arguments}` | `json/base_json_parser.rs` | deepseek_v3, deepseek_v3_1, nemotron_deci/nano |
 | **Harmony** | OpenAI Harmony token stream with `<\|channel\|>`, `<\|message\|>`, `<\|call\|>` | `harmony/harmony_parser.rs` (wraps external `openai_harmony` crate) | gpt-oss-20B / 120B |
 | **Pythonic** | `[func_name(arg=value, ...)]` Python function-call syntax | `pythonic/pythonic_parser.rs` | some Llama variants |
+| **Gemma 4** | Custom: `<\|tool_call>call:name{key:<\|"\|>val<\|"\|>}<tool_call\|>`, bare keys, custom string delimiter | `gemma4/parser.rs` (recursive-descent into `serde_json::Value`) | Google Gemma 4 thinking models |
 
 Reasoning parsers:
 
@@ -87,6 +90,7 @@ Reasoning parsers:
 | **Append-think** | `<think>...</think>` left inline as text, with `<think>` prefix on first chunk | `reasoning/minimax_append_think_parser.rs` | MiniMax M2 |
 | **Harmony channel** | Hidden `analysis` channel | `reasoning/gpt_oss_parser.rs` (wraps external `openai_harmony`) | gpt-oss-20B / 120B |
 | **Granite** | Custom start/end tokens | `reasoning/granite_parser.rs` | IBM Granite |
+| **Gemma 4 channel** | `<\|channel>thought\n...<channel\|>` with role-label prefix stripped | `reasoning/gemma4_parser.rs` | Google Gemma 4 thinking models |
 
 ## Adding a new parser
 

--- a/lib/parsers/src/reasoning/gemma4_parser.rs
+++ b/lib/parsers/src/reasoning/gemma4_parser.rs
@@ -315,7 +315,7 @@ mod tests {
         assert_eq!(r.normal_text, "Hello.  Goodbye.");
     }
 
-    #[test] // upstream INVALID_SIMPLE — `<channel|>` present, `<|channel>` absent
+    #[test] // CASE.5, CASE.13 — dangling end marker, missing start (upstream INVALID_SIMPLE)
     fn detect_dangling_end_marker_extracts_prefix_as_reasoning() {
         let mut p = Gemma4ReasoningParser::new();
         let r = p.detect_and_parse_reasoning("some thinking<channel|>final answer", &[]);
@@ -323,7 +323,7 @@ mod tests {
         assert_eq!(r.normal_text, "final answer");
     }
 
-    #[test] // upstream INVALID_COMPLETE — dangling end with `thought\n` prefix on the head
+    #[test] // CASE.5, CASE.13 — dangling end + thought prefix on the head (upstream INVALID_COMPLETE)
     fn detect_dangling_end_marker_strips_thought_prefix() {
         let mut p = Gemma4ReasoningParser::new();
         let r = p.detect_and_parse_reasoning("thought\nrumination<channel|>final answer", &[]);
@@ -446,7 +446,7 @@ mod tests {
         assert_eq!(r.normal_text, "plain text only");
     }
 
-    #[test] // multi-span: reasoning, answer, more reasoning, more answer
+    #[test] // CASE.2 — multiple reasoning spans back-to-back
     fn streaming_multiple_reasoning_spans() {
         let mut p = Gemma4ReasoningParser::new();
         let input =

--- a/lib/parsers/src/reasoning/gemma4_parser.rs
+++ b/lib/parsers/src/reasoning/gemma4_parser.rs
@@ -1,0 +1,409 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Reasoning parser for Google Gemma 4 thinking models.
+//!
+//! Gemma 4 emits chain-of-thought reasoning between dedicated channel
+//! delimiters:
+//!
+//! ```text
+//! <|channel>thought
+//! ...chain of thought reasoning...<channel|>
+//! Final answer text.
+//! ```
+//!
+//! The `thought\n` role label inside the channel is a structural artefact
+//! analogous to the `user\n` label in `<|turn>user\n...`. Downstream consumers
+//! expect the reasoning content without that label, so this parser strips it.
+//!
+//! Both the start and end markers are special tokens. They will be visible in
+//! the decoded text only when the inference engine is configured with
+//! `skip_special_tokens=False`. The Dynamo frontend should set that flag
+//! whenever the Gemma 4 reasoning parser is selected, mirroring the vLLM PR's
+//! `adjust_request` hook. If the markers are stripped before the parser sees
+//! them, this parser falls back to passing the text through as `normal_text`
+//! (no reasoning extracted) — same fail-safe behaviour as the basic parser.
+
+use crate::ParserResult;
+use crate::ReasoningParser;
+
+const START_TOKEN: &str = "<|channel>";
+const END_TOKEN: &str = "<channel|>";
+const THOUGHT_PREFIX: &str = "thought\n";
+
+/// Returns the length of the longest suffix of `s` that is also a prefix of
+/// `delim`. Used to detect partial multi-byte markers split across streaming
+/// chunk boundaries (e.g. `"...<|chan"` is a partial prefix of `<|channel>`).
+fn overlap(s: &str, delim: &str) -> usize {
+    let max = delim.len().min(s.len());
+    for i in (1..=max).rev() {
+        if !delim.is_char_boundary(i) || !s.is_char_boundary(s.len() - i) {
+            continue;
+        }
+        if s.ends_with(&delim[..i]) {
+            return i;
+        }
+    }
+    0
+}
+
+#[derive(Debug, Clone)]
+pub struct Gemma4ReasoningParser {
+    /// Streaming buffer for accumulated text yet to be classified.
+    buffer: String,
+    /// True once we've observed `<|channel>` and are inside a reasoning span.
+    in_reasoning: bool,
+    /// True once we've stripped the `thought\n` prefix (or determined it is
+    /// not present) for the current reasoning span.
+    prefix_resolved: bool,
+    /// Reasoning text accumulated so far for the current span. Used to decide
+    /// whether the accumulated bytes are still a strict prefix of
+    /// `thought\n` (case 2) or have diverged (case 3).
+    reasoning_accum: String,
+}
+
+impl Gemma4ReasoningParser {
+    pub fn new() -> Self {
+        Self {
+            buffer: String::new(),
+            in_reasoning: false,
+            prefix_resolved: false,
+            reasoning_accum: String::new(),
+        }
+    }
+
+    fn reset_span(&mut self) {
+        self.in_reasoning = false;
+        self.prefix_resolved = false;
+        self.reasoning_accum.clear();
+    }
+}
+
+impl Default for Gemma4ReasoningParser {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Strip the `thought\n` role label from the start of `text` if present.
+fn strip_thought_prefix(text: &str) -> &str {
+    text.strip_prefix(THOUGHT_PREFIX).unwrap_or(text)
+}
+
+/// Decide what slice of `raw_reasoning` to emit given the current
+/// prefix-stripping state. Returns `(emit, new_prefix_resolved)`.
+///
+/// Case 1: accumulated reasoning starts with `thought\n` — strip it from the
+///   delta (or suppress entirely if the delta lies inside the prefix).
+/// Case 2: accumulated reasoning is a strict prefix of `thought\n` — suppress
+///   so we can decide once more bytes arrive.
+/// Case 3: accumulated reasoning diverged from the prefix — emit the
+///   buffered reasoning verbatim (data preservation).
+fn resolve_prefix<'a>(accum: &'a str, raw_reasoning: &'a str) -> (&'a str, bool) {
+    if accum.starts_with(THOUGHT_PREFIX) {
+        let prev_len = accum.len() - raw_reasoning.len();
+        if prev_len >= THOUGHT_PREFIX.len() {
+            // Prefix was already consumed by earlier deltas — pass through.
+            return (raw_reasoning, true);
+        }
+        let chars_of_prefix_in_delta = THOUGHT_PREFIX.len() - prev_len;
+        let stripped = &raw_reasoning[chars_of_prefix_in_delta.min(raw_reasoning.len())..];
+        if !stripped.is_empty() || accum.len() >= THOUGHT_PREFIX.len() {
+            return (stripped, true);
+        }
+        return ("", false);
+    }
+    if THOUGHT_PREFIX.starts_with(accum) {
+        // Strict prefix of "thought\n" — suppress until we know.
+        return ("", false);
+    }
+    // Diverged: emit full buffered reasoning verbatim.
+    (accum, true)
+}
+
+impl ReasoningParser for Gemma4ReasoningParser {
+    fn detect_and_parse_reasoning(&mut self, text: &str, _token_ids: &[u32]) -> ParserResult {
+        // Non-streaming path: we have the complete text, so we can use plain
+        // string operations.
+        let Some(start_idx) = text.find(START_TOKEN) else {
+            // No reasoning markers visible at all (either model didn't emit
+            // them, or skip_special_tokens stripped them). Pass through.
+            return ParserResult {
+                normal_text: text.to_string(),
+                reasoning_text: String::new(),
+            };
+        };
+        let pre = &text[..start_idx];
+        let rest = &text[start_idx + START_TOKEN.len()..];
+
+        let (reasoning_raw, post) = match rest.find(END_TOKEN) {
+            Some(end_rel) => (&rest[..end_rel], &rest[end_rel + END_TOKEN.len()..]),
+            None => (rest, ""),
+        };
+        let reasoning = strip_thought_prefix(reasoning_raw).to_string();
+        let mut normal = String::new();
+        normal.push_str(pre);
+        normal.push_str(post);
+
+        ParserResult {
+            normal_text: normal,
+            reasoning_text: reasoning,
+        }
+    }
+
+    fn parse_reasoning_streaming_incremental(
+        &mut self,
+        text: &str,
+        _token_ids: &[u32],
+    ) -> ParserResult {
+        // Aggregate this delta with the carry buffer for prefix detection.
+        let mut work = std::mem::take(&mut self.buffer);
+        work.push_str(text);
+
+        let mut normal = String::new();
+        let mut reasoning_emit = String::new();
+
+        loop {
+            if !self.in_reasoning {
+                // Look for either the full start marker or a partial-prefix at
+                // the buffer's end (which we must hold back).
+                if let Some(idx) = work.find(START_TOKEN) {
+                    normal.push_str(&work[..idx]);
+                    work = work[idx + START_TOKEN.len()..].to_string();
+                    self.in_reasoning = true;
+                    self.prefix_resolved = false;
+                    self.reasoning_accum.clear();
+                    continue;
+                }
+                let lap = overlap(&work, START_TOKEN);
+                if lap > 0 {
+                    let split = work.len() - lap;
+                    normal.push_str(&work[..split]);
+                    self.buffer = work[split..].to_string();
+                } else {
+                    normal.push_str(&work);
+                    self.buffer.clear();
+                }
+                break;
+            }
+
+            // self.in_reasoning == true
+            if let Some(idx) = work.find(END_TOKEN) {
+                let raw = &work[..idx];
+                self.reasoning_accum.push_str(raw);
+                if !self.prefix_resolved {
+                    let (emit, resolved) = resolve_prefix(&self.reasoning_accum, raw);
+                    if resolved {
+                        reasoning_emit.push_str(emit);
+                        self.prefix_resolved = true;
+                    }
+                    // If still unresolved at end-of-span, the accumulated text
+                    // was a strict prefix of `thought\n` — by definition there
+                    // is nothing useful to emit; drop it.
+                } else {
+                    reasoning_emit.push_str(raw);
+                }
+                work = work[idx + END_TOKEN.len()..].to_string();
+                self.reset_span();
+                continue;
+            }
+
+            // No end marker yet. Hold back any partial-end-marker suffix.
+            let lap = overlap(&work, END_TOKEN);
+            let split = work.len() - lap;
+            let raw = work[..split].to_string();
+            self.buffer = work[split..].to_string();
+
+            if !raw.is_empty() {
+                self.reasoning_accum.push_str(&raw);
+                if !self.prefix_resolved {
+                    let (emit, resolved) = resolve_prefix(&self.reasoning_accum, &raw);
+                    if resolved {
+                        reasoning_emit.push_str(emit);
+                        self.prefix_resolved = true;
+                    }
+                } else {
+                    reasoning_emit.push_str(&raw);
+                }
+            }
+            break;
+        }
+
+        ParserResult {
+            normal_text: normal,
+            reasoning_text: reasoning_emit,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test] // CASE.10 — non-streaming basic case
+    fn detect_basic_thinking() {
+        let mut p = Gemma4ReasoningParser::new();
+        let r = p.detect_and_parse_reasoning(
+            "<|channel>thought\nstep one\nstep two<channel|>The answer is 42.",
+            &[],
+        );
+        assert_eq!(r.reasoning_text, "step one\nstep two");
+        assert_eq!(r.normal_text, "The answer is 42.");
+    }
+
+    #[test] // CASE.3 — no reasoning markers, pass through
+    fn detect_no_markers_passes_through() {
+        let mut p = Gemma4ReasoningParser::new();
+        let r = p.detect_and_parse_reasoning("just a plain answer", &[]);
+        assert_eq!(r.reasoning_text, "");
+        assert_eq!(r.normal_text, "just a plain answer");
+    }
+
+    #[test] // CASE.5 — reasoning open without close (truncation): everything after
+    // start marker is reasoning content.
+    fn detect_truncated_reasoning_open_only() {
+        let mut p = Gemma4ReasoningParser::new();
+        let r = p.detect_and_parse_reasoning("intro <|channel>thought\npartial", &[]);
+        assert_eq!(r.reasoning_text, "partial");
+        assert_eq!(r.normal_text, "intro ");
+    }
+
+    #[test] // CASE.13 — text before AND after the reasoning span preserved
+    fn detect_text_before_and_after() {
+        let mut p = Gemma4ReasoningParser::new();
+        let r = p.detect_and_parse_reasoning(
+            "Hello. <|channel>thought\nrumination<channel|> Goodbye.",
+            &[],
+        );
+        assert_eq!(r.reasoning_text, "rumination");
+        assert_eq!(r.normal_text, "Hello.  Goodbye.");
+    }
+
+    #[test] // CASE.20 — `thought\n` prefix absent (some tokens drop it): pass through unchanged
+    fn detect_no_thought_prefix() {
+        let mut p = Gemma4ReasoningParser::new();
+        let r = p.detect_and_parse_reasoning(
+            "<|channel>raw reasoning without prefix<channel|>answer",
+            &[],
+        );
+        assert_eq!(r.reasoning_text, "raw reasoning without prefix");
+        assert_eq!(r.normal_text, "answer");
+    }
+
+    #[test] // CASE.8 — streaming arrival, single chunk
+    fn streaming_single_chunk() {
+        let mut p = Gemma4ReasoningParser::new();
+        let r = p.parse_reasoning_streaming_incremental(
+            "<|channel>thought\nrumination<channel|>final",
+            &[],
+        );
+        assert_eq!(r.reasoning_text, "rumination");
+        assert_eq!(r.normal_text, "final");
+    }
+
+    #[test] // CASE.8 — streaming with `thought\n` split across deltas
+    fn streaming_thought_prefix_split_across_deltas() {
+        let mut p = Gemma4ReasoningParser::new();
+        let chunks = [
+            "<|channel>",
+            "thou",
+            "ght\n",
+            "real reasoning here",
+            "<channel|>",
+            "the answer.",
+        ];
+        let mut reasoning = String::new();
+        let mut normal = String::new();
+        for c in chunks {
+            let r = p.parse_reasoning_streaming_incremental(c, &[]);
+            reasoning.push_str(&r.reasoning_text);
+            normal.push_str(&r.normal_text);
+        }
+        assert_eq!(reasoning, "real reasoning here");
+        assert_eq!(normal, "the answer.");
+    }
+
+    #[test] // CASE.8 — start marker split across deltas
+    fn streaming_start_marker_split() {
+        let mut p = Gemma4ReasoningParser::new();
+        let chunks = [
+            "intro ",
+            "<|chan", // partial start marker
+            "nel>thought\n",
+            "rumination",
+            "<channel|>",
+            "outro",
+        ];
+        let mut reasoning = String::new();
+        let mut normal = String::new();
+        for c in chunks {
+            let r = p.parse_reasoning_streaming_incremental(c, &[]);
+            reasoning.push_str(&r.reasoning_text);
+            normal.push_str(&r.normal_text);
+        }
+        assert_eq!(reasoning, "rumination");
+        assert_eq!(normal, "intro outro");
+    }
+
+    #[test] // CASE.8 — end marker split across deltas
+    fn streaming_end_marker_split() {
+        let mut p = Gemma4ReasoningParser::new();
+        let chunks = [
+            "<|channel>thought\n",
+            "thinking",
+            "<chan", // partial end marker
+            "nel|>",
+            "answer",
+        ];
+        let mut reasoning = String::new();
+        let mut normal = String::new();
+        for c in chunks {
+            let r = p.parse_reasoning_streaming_incremental(c, &[]);
+            reasoning.push_str(&r.reasoning_text);
+            normal.push_str(&r.normal_text);
+        }
+        assert_eq!(reasoning, "thinking");
+        assert_eq!(normal, "answer");
+    }
+
+    #[test] // CASE.8 — diverged accumulated text (no `thought\n` prefix at all)
+    fn streaming_no_thought_prefix_streaming() {
+        let mut p = Gemma4ReasoningParser::new();
+        let chunks = [
+            "<|channel>",
+            "raw stream of consciousness",
+            "<channel|>",
+            "answer",
+        ];
+        let mut reasoning = String::new();
+        let mut normal = String::new();
+        for c in chunks {
+            let r = p.parse_reasoning_streaming_incremental(c, &[]);
+            reasoning.push_str(&r.reasoning_text);
+            normal.push_str(&r.normal_text);
+        }
+        assert_eq!(reasoning, "raw stream of consciousness");
+        assert_eq!(normal, "answer");
+    }
+
+    #[test] // CASE.3 — streaming with no markers at all
+    fn streaming_no_markers() {
+        let mut p = Gemma4ReasoningParser::new();
+        let r = p.parse_reasoning_streaming_incremental("plain text only", &[]);
+        assert_eq!(r.reasoning_text, "");
+        assert_eq!(r.normal_text, "plain text only");
+    }
+
+    #[test] // multi-span: reasoning, answer, more reasoning, more answer
+    fn streaming_multiple_reasoning_spans() {
+        let mut p = Gemma4ReasoningParser::new();
+        let input =
+            "<|channel>thought\nfirst<channel|>answer1<|channel>thought\nsecond<channel|>answer2";
+        let r = p.parse_reasoning_streaming_incremental(input, &[]);
+        // Both spans concatenated into the cumulative deltas.
+        assert!(r.reasoning_text.contains("first"));
+        assert!(r.reasoning_text.contains("second"));
+        assert!(r.normal_text.contains("answer1"));
+        assert!(r.normal_text.contains("answer2"));
+    }
+}

--- a/lib/parsers/src/reasoning/gemma4_parser.rs
+++ b/lib/parsers/src/reasoning/gemma4_parser.rs
@@ -16,13 +16,11 @@
 //! analogous to the `user\n` label in `<|turn>user\n...`. Downstream consumers
 //! expect the reasoning content without that label, so this parser strips it.
 //!
-//! Both the start and end markers are special tokens. They will be visible in
-//! the decoded text only when the inference engine is configured with
-//! `skip_special_tokens=False`. The Dynamo frontend should set that flag
-//! whenever the Gemma 4 reasoning parser is selected, mirroring the vLLM PR's
-//! `adjust_request` hook. If the markers are stripped before the parser sees
-//! them, this parser falls back to passing the text through as `normal_text`
-//! (no reasoning extracted) — same fail-safe behaviour as the basic parser.
+//! Both the start and end markers are special tokens. They are visible in the
+//! decoded text only when the inference engine is configured with
+//! `skip_special_tokens=False`. If the markers are stripped before the parser
+//! sees them, the parser falls back to passing the text through as
+//! `normal_text` (no reasoning extracted).
 
 use crate::ParserResult;
 use crate::ReasoningParser;

--- a/lib/parsers/src/reasoning/gemma4_parser.rs
+++ b/lib/parsers/src/reasoning/gemma4_parser.rs
@@ -93,6 +93,15 @@ fn strip_thought_prefix(text: &str) -> &str {
 /// Decide what slice of `raw_reasoning` to emit given the current
 /// prefix-stripping state. Returns `(emit, new_prefix_resolved)`.
 ///
+/// **Precondition:** `raw_reasoning` MUST be a suffix of `accum` — i.e. the
+/// caller has already pushed the new delta into the accumulator before
+/// calling this. We rely on that to compute `prev_len = accum.len() -
+/// raw_reasoning.len()` (the length of the accumulator *before* this delta).
+/// Violating the precondition would underflow `prev_len` and corrupt the
+/// emit-slice. The streaming driver in `parse_reasoning_streaming_incremental`
+/// upholds this invariant by always pushing `raw` into `self.reasoning_accum`
+/// immediately before the call.
+///
 /// Case 1: accumulated reasoning starts with `thought\n` — strip it from the
 ///   delta (or suppress entirely if the delta lies inside the prefix).
 /// Case 2: accumulated reasoning is a strict prefix of `thought\n` — suppress
@@ -100,6 +109,12 @@ fn strip_thought_prefix(text: &str) -> &str {
 /// Case 3: accumulated reasoning diverged from the prefix — emit the
 ///   buffered reasoning verbatim (data preservation).
 fn resolve_prefix<'a>(accum: &'a str, raw_reasoning: &'a str) -> (&'a str, bool) {
+    debug_assert!(
+        accum.ends_with(raw_reasoning),
+        "resolve_prefix precondition violated: raw_reasoning ({:?}) must be a suffix of accum ({:?})",
+        raw_reasoning,
+        accum,
+    );
     if accum.starts_with(THOUGHT_PREFIX) {
         let prev_len = accum.len() - raw_reasoning.len();
         if prev_len >= THOUGHT_PREFIX.len() {

--- a/lib/parsers/src/reasoning/gemma4_parser.rs
+++ b/lib/parsers/src/reasoning/gemma4_parser.rs
@@ -125,29 +125,50 @@ impl ReasoningParser for Gemma4ReasoningParser {
     fn detect_and_parse_reasoning(&mut self, text: &str, _token_ids: &[u32]) -> ParserResult {
         // Non-streaming path: we have the complete text, so we can use plain
         // string operations.
-        let Some(start_idx) = text.find(START_TOKEN) else {
-            // No reasoning markers visible at all (either model didn't emit
-            // them, or skip_special_tokens stripped them). Pass through.
-            return ParserResult {
-                normal_text: text.to_string(),
-                reasoning_text: String::new(),
-            };
-        };
-        let pre = &text[..start_idx];
-        let rest = &text[start_idx + START_TOKEN.len()..];
-
-        let (reasoning_raw, post) = match rest.find(END_TOKEN) {
-            Some(end_rel) => (&rest[..end_rel], &rest[end_rel + END_TOKEN.len()..]),
-            None => (rest, ""),
-        };
-        let reasoning = strip_thought_prefix(reasoning_raw).to_string();
-        let mut normal = String::new();
-        normal.push_str(pre);
-        normal.push_str(post);
-
-        ParserResult {
-            normal_text: normal,
-            reasoning_text: reasoning,
+        let start_idx = text.find(START_TOKEN);
+        let end_idx = text.find(END_TOKEN);
+        match (start_idx, end_idx) {
+            (None, None) => {
+                // No reasoning markers visible at all (either model didn't
+                // emit them, or skip_special_tokens stripped them).
+                ParserResult {
+                    normal_text: text.to_string(),
+                    reasoning_text: String::new(),
+                }
+            }
+            (Some(s), end_opt) => {
+                let pre = &text[..s];
+                let rest = &text[s + START_TOKEN.len()..];
+                let (reasoning_raw, post) = match end_opt
+                    .filter(|e| *e > s + START_TOKEN.len())
+                    .map(|e| e - (s + START_TOKEN.len()))
+                {
+                    Some(end_rel) => (&rest[..end_rel], &rest[end_rel + END_TOKEN.len()..]),
+                    None => (rest, ""),
+                };
+                let reasoning = strip_thought_prefix(reasoning_raw).to_string();
+                let mut normal = String::with_capacity(pre.len() + post.len());
+                normal.push_str(pre);
+                normal.push_str(post);
+                ParserResult {
+                    normal_text: normal,
+                    reasoning_text: reasoning,
+                }
+            }
+            (None, Some(e)) => {
+                // Dangling end marker without start marker — upstream's
+                // offline parser still treats text-before as reasoning. Mirror
+                // that so model emissions where the start tag was stripped
+                // (e.g. tokenizer with skip_special_tokens) don't lose the
+                // reasoning content entirely.
+                let reasoning_raw = &text[..e];
+                let post = &text[e + END_TOKEN.len()..];
+                let reasoning = strip_thought_prefix(reasoning_raw).to_string();
+                ParserResult {
+                    normal_text: post.to_string(),
+                    reasoning_text: reasoning,
+                }
+            }
         }
     }
 
@@ -277,6 +298,22 @@ mod tests {
         );
         assert_eq!(r.reasoning_text, "rumination");
         assert_eq!(r.normal_text, "Hello.  Goodbye.");
+    }
+
+    #[test] // upstream INVALID_SIMPLE — `<channel|>` present, `<|channel>` absent
+    fn detect_dangling_end_marker_extracts_prefix_as_reasoning() {
+        let mut p = Gemma4ReasoningParser::new();
+        let r = p.detect_and_parse_reasoning("some thinking<channel|>final answer", &[]);
+        assert_eq!(r.reasoning_text, "some thinking");
+        assert_eq!(r.normal_text, "final answer");
+    }
+
+    #[test] // upstream INVALID_COMPLETE — dangling end with `thought\n` prefix on the head
+    fn detect_dangling_end_marker_strips_thought_prefix() {
+        let mut p = Gemma4ReasoningParser::new();
+        let r = p.detect_and_parse_reasoning("thought\nrumination<channel|>final answer", &[]);
+        assert_eq!(r.reasoning_text, "rumination");
+        assert_eq!(r.normal_text, "final answer");
     }
 
     #[test] // CASE.20 — `thought\n` prefix absent (some tokens drop it): pass through unchanged

--- a/lib/parsers/src/reasoning/gemma4_parser.rs
+++ b/lib/parsers/src/reasoning/gemma4_parser.rs
@@ -456,4 +456,38 @@ mod tests {
         assert!(r.normal_text.contains("answer1"));
         assert!(r.normal_text.contains("answer2"));
     }
+
+    #[test] // CASE.9 — paired reasoning + tool call. The reasoning parser
+    // must extract the channel content as `reasoning_text` and leave the
+    // following `<|tool_call>...<tool_call|>` markers intact in
+    // `normal_text` for the tool-call parser to consume downstream.
+    fn paired_reasoning_then_tool_call_non_streaming() {
+        let mut p = Gemma4ReasoningParser::new();
+        let input = concat!(
+            "<|channel>thought\nthinking about the request<channel|>",
+            "<|tool_call>call:get_weather{location:<|\"|>Tokyo<|\"|>}<tool_call|>",
+        );
+        let r = p.detect_and_parse_reasoning(input, &[]);
+        assert_eq!(r.reasoning_text, "thinking about the request");
+        assert_eq!(
+            r.normal_text, r#"<|tool_call>call:get_weather{location:<|"|>Tokyo<|"|>}<tool_call|>"#,
+            "tool-call markers must survive reasoning extraction",
+        );
+    }
+
+    // ----- Explicit N/A coverage notes (per lib/parsers/TEST_CASES.md) -----
+    //
+    // CASE.1, CASE.4, CASE.6, CASE.7  — Tool-call-only categories. N/A for
+    //          a reasoning parser.
+    // CASE.11, CASE.12 — `tool_choice` and `finish_reason`: tool-call concerns,
+    //          N/A for reasoning. (Universal cross-parser gap regardless;
+    //          see notes in `tool_calling/gemma4/parser.rs`.)
+    // CASE.14 — Empty / null content: empty input is covered implicitly
+    //          via the no-markers passthrough cases (`detect_no_markers_*`,
+    //          `streaming_no_markers`).
+    // CASE.15 — Duplicate calls: tool-call concept; N/A. Multi-span
+    //          reasoning is the analog and is covered by
+    //          `streaming_multiple_reasoning_spans`.
+    // CASE.xml1 / CASE.xml2 — XML-family only. N/A.
+    // CASE.harmony1 — Harmony only. N/A.
 }

--- a/lib/parsers/src/reasoning/mod.rs
+++ b/lib/parsers/src/reasoning/mod.rs
@@ -4,12 +4,14 @@ use std::collections::HashMap;
 use std::sync::OnceLock;
 
 mod base_parser;
+mod gemma4_parser;
 mod gpt_oss_parser;
 mod granite_parser;
 mod minimax_append_think_parser;
 
 // Re-export main types and functions for convenience
 pub use base_parser::BasicReasoningParser;
+pub use gemma4_parser::Gemma4ReasoningParser;
 pub use gpt_oss_parser::GptOssReasoningParser;
 pub use granite_parser::GraniteReasoningParser;
 pub use minimax_append_think_parser::MiniMaxAppendThinkParser;
@@ -58,6 +60,11 @@ fn get_reasoning_parser_map() -> &'static HashMap<&'static str, ReasoningParserT
             "minimax_append_think",
             ReasoningParserType::MiniMaxAppendThink,
         );
+        // Gemma 4 thinking models: reasoning is wrapped in `<|channel>...<channel|>`
+        // with a `thought\n` role label that this parser strips. Pair with
+        // `--dyn-tool-call-parser gemma4` for end-to-end Gemma 4 support.
+        map.insert("gemma4", ReasoningParserType::Gemma4);
+        map.insert("gemma-4", ReasoningParserType::Gemma4);
         map
     })
 }
@@ -140,6 +147,9 @@ pub enum ReasoningParserType {
     Mistral,
     Granite,
     MiniMaxAppendThink,
+    /// Google Gemma 4 thinking models. Custom `<|channel>...<channel|>`
+    /// delimiters with a `thought\n` role-label prefix stripped by the parser.
+    Gemma4,
 }
 
 #[derive(std::fmt::Debug)]
@@ -240,6 +250,9 @@ impl ReasoningParserType {
             ReasoningParserType::MiniMaxAppendThink => ReasoningParserWrapper {
                 parser: Box::new(MiniMaxAppendThinkParser::new()),
             },
+            ReasoningParserType::Gemma4 => ReasoningParserWrapper {
+                parser: Box::new(Gemma4ReasoningParser::new()),
+            },
         }
     }
 
@@ -289,6 +302,8 @@ mod tests {
             "nemotron3",
             "glm45",
             "minimax_append_think",
+            "gemma4",
+            "gemma-4",
         ];
         for parser in available_parsers {
             assert!(parsers.contains(&parser));

--- a/lib/parsers/src/tool_calling/config.rs
+++ b/lib/parsers/src/tool_calling/config.rs
@@ -222,9 +222,7 @@ impl ParserConfig {
             ParserConfig::Dsml(config) => vec![config.block_start.clone()],
             ParserConfig::Glm47(config) => vec![config.tool_call_start.clone()],
             ParserConfig::KimiK2(config) => config.section_start_variants.clone(),
-            ParserConfig::Gemma4 => vec![
-                crate::tool_calling::gemma4::TOOL_CALL_START.to_string(),
-            ],
+            ParserConfig::Gemma4 => vec![crate::tool_calling::gemma4::TOOL_CALL_START.to_string()],
         }
     }
 
@@ -240,9 +238,7 @@ impl ParserConfig {
             ParserConfig::Dsml(config) => vec![config.block_end.clone()],
             ParserConfig::Glm47(config) => vec![config.tool_call_end.clone()],
             ParserConfig::KimiK2(config) => config.section_end_variants.clone(),
-            ParserConfig::Gemma4 => vec![
-                crate::tool_calling::gemma4::TOOL_CALL_END.to_string(),
-            ],
+            ParserConfig::Gemma4 => vec![crate::tool_calling::gemma4::TOOL_CALL_END.to_string()],
         }
     }
 }

--- a/lib/parsers/src/tool_calling/config.rs
+++ b/lib/parsers/src/tool_calling/config.rs
@@ -203,6 +203,10 @@ pub enum ParserConfig {
     Dsml(DsmlParserConfig),
     KimiK2(KimiK2ParserConfig),
     Glm47(Glm47ParserConfig),
+    /// Gemma 4 uses a custom non-JSON grammar with bare keys, `<|"|>` string
+    /// delimiters, and fixed `<|tool_call>...<tool_call|>` markers. No
+    /// configuration is required at runtime — markers are not user-tunable.
+    Gemma4,
 }
 
 impl ParserConfig {
@@ -218,6 +222,9 @@ impl ParserConfig {
             ParserConfig::Dsml(config) => vec![config.block_start.clone()],
             ParserConfig::Glm47(config) => vec![config.tool_call_start.clone()],
             ParserConfig::KimiK2(config) => config.section_start_variants.clone(),
+            ParserConfig::Gemma4 => vec![
+                crate::tool_calling::gemma4::TOOL_CALL_START.to_string(),
+            ],
         }
     }
 
@@ -233,6 +240,9 @@ impl ParserConfig {
             ParserConfig::Dsml(config) => vec![config.block_end.clone()],
             ParserConfig::Glm47(config) => vec![config.tool_call_end.clone()],
             ParserConfig::KimiK2(config) => config.section_end_variants.clone(),
+            ParserConfig::Gemma4 => vec![
+                crate::tool_calling::gemma4::TOOL_CALL_END.to_string(),
+            ],
         }
     }
 }
@@ -448,6 +458,20 @@ impl ToolCallConfig {
         // Reference: https://huggingface.co/moonshotai/Kimi-K2-Instruct/blob/main/docs/tool_call_guidance.md
         Self {
             parser_config: ParserConfig::KimiK2(KimiK2ParserConfig::default()),
+        }
+    }
+
+    /// Gemma 4 tool-call format (custom non-JSON grammar):
+    ///
+    /// ```text
+    /// <|tool_call>call:func_name{location:<|"|>Tokyo<|"|>,count:42}<tool_call|>
+    /// ```
+    ///
+    /// Bare unquoted keys, `<|"|>`-delimited strings, supports nested objects /
+    /// arrays. Multiple tool calls are concatenated without separators.
+    pub fn gemma4() -> Self {
+        Self {
+            parser_config: ParserConfig::Gemma4,
         }
     }
 }

--- a/lib/parsers/src/tool_calling/gemma4/mod.rs
+++ b/lib/parsers/src/tool_calling/gemma4/mod.rs
@@ -3,7 +3,7 @@
 
 mod parser;
 
+pub(crate) use parser::{TOOL_CALL_END, TOOL_CALL_START};
 pub use parser::{
     detect_tool_call_start_gemma4, find_tool_call_end_position_gemma4, try_tool_call_parse_gemma4,
 };
-pub(crate) use parser::{TOOL_CALL_END, TOOL_CALL_START};

--- a/lib/parsers/src/tool_calling/gemma4/mod.rs
+++ b/lib/parsers/src/tool_calling/gemma4/mod.rs
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+mod parser;
+
+pub use parser::{
+    detect_tool_call_start_gemma4, find_tool_call_end_position_gemma4, try_tool_call_parse_gemma4,
+};
+pub(crate) use parser::{TOOL_CALL_END, TOOL_CALL_START};

--- a/lib/parsers/src/tool_calling/gemma4/parser.rs
+++ b/lib/parsers/src/tool_calling/gemma4/parser.rs
@@ -105,6 +105,8 @@ pub fn try_tool_call_parse_gemma4(
         let abs_start = cursor + start_rel;
         normal_parts.push(&message[cursor..abs_start]);
 
+        // First `<tool_call|>` wins; we don't scan inside `<|"|>` strings,
+        // so an embedded literal will truncate the call. Matches upstream.
         let Some(end_rel) = message[abs_start..].find(TOOL_CALL_END) else {
             // Truncated tool call — echo the raw bytes back as normal_text so
             // the caller sees the truncation rather than silently losing it.

--- a/lib/parsers/src/tool_calling/gemma4/parser.rs
+++ b/lib/parsers/src/tool_calling/gemma4/parser.rs
@@ -80,11 +80,14 @@ pub fn find_tool_call_end_position_gemma4(chunk: &str) -> Option<usize> {
 /// Parse a Gemma 4 model response into structured tool calls + leftover text.
 ///
 /// Returns `(parsed_tool_calls, normal_text_content)`. Text outside the
-/// `<|tool_call>...<tool_call|>` markers is returned as `normal_text`; truly
-/// truncated calls (start marker present, end marker missing) are dropped from
-/// the call list and their raw bytes are NOT re-emitted as user-visible text
-/// (mirrors kimi_k2's behavior — surfacing half-parsed markers in user output
-/// is worse than dropping the truncated call).
+/// `<|tool_call>...<tool_call|>` markers is returned as `normal_text`. When a
+/// tool call is truncated (start marker present, end marker missing — typically
+/// because the model hit `max_tokens` mid-call), the parser cannot extract a
+/// structured call from it; instead it echoes the raw bytes back as
+/// `normal_text` so the caller can detect the truncation and surface it to the
+/// user. This matches upstream `vllm.tool_parsers.gemma4_tool_parser`'s
+/// behavior of returning the raw `model_output` as content when no complete
+/// tool call could be parsed.
 pub fn try_tool_call_parse_gemma4(
     message: &str,
     tools: Option<&[ToolDefinition]>,
@@ -102,8 +105,9 @@ pub fn try_tool_call_parse_gemma4(
         normal_parts.push(&message[cursor..abs_start]);
 
         let Some(end_rel) = message[abs_start..].find(TOOL_CALL_END) else {
-            // Truncated tool call — consume the rest of the buffer silently.
-            cursor = message.len();
+            // Truncated tool call — echo the raw bytes back as normal_text so
+            // the caller sees the truncation rather than silently losing it.
+            normal_parts.push(&message[abs_start..]);
             break;
         };
         let abs_end = abs_start + end_rel + TOOL_CALL_END.len();
@@ -167,10 +171,7 @@ fn parse_single_call(
     Ok(Some(ToolCallResponse {
         id: format!("call-{}", Uuid::new_v4()),
         tp: ToolCallType::Function,
-        function: CalledFunction {
-            name,
-            arguments,
-        },
+        function: CalledFunction { name, arguments },
     }))
 }
 
@@ -231,15 +232,6 @@ impl<'a> Cursor<'a> {
             false
         }
     }
-
-    fn consume_str(&mut self, s: &str) -> bool {
-        if self.rest().starts_with(s) {
-            self.pos += s.len();
-            true
-        } else {
-            false
-        }
-    }
 }
 
 pub(crate) fn parse_args_object(input: &str) -> anyhow::Result<Value> {
@@ -271,7 +263,15 @@ fn parse_object_body(cur: &mut Cursor) -> anyhow::Result<Value> {
             anyhow::bail!("expected ':' after key '{}' at offset {}", key, cur.pos);
         }
         cur.skip_whitespace();
-        let value = parse_value(cur)?;
+        // Empty value (`key:` followed by `,` / `}` / EOF) — upstream Gemma 4
+        // parser emits these as `{"key": ""}` rather than dropping the key, so
+        // we mirror that. Without this, the empty-value case fell through to
+        // `parse_value`'s number path and errored out, which then triggered
+        // the entire-args-object empty-fallback in `parse_single_call`.
+        let value = match cur.peek_byte() {
+            None | Some(b',') | Some(b'}') => Value::String(String::new()),
+            _ => parse_value(cur)?,
+        };
         map.insert(key, value);
         cur.skip_whitespace();
         if !cur.consume_byte(b',') {
@@ -298,21 +298,55 @@ fn parse_key(cur: &mut Cursor) -> anyhow::Result<String> {
     Ok(cur.src[start..cur.pos].to_string())
 }
 
+/// Try to consume `keyword` from `cur` ASCII-case-insensitively, only when the
+/// byte immediately after the keyword is NOT a word character (so `nullable`
+/// doesn't get matched as `null` + leftover `able`). Mirrors upstream's
+/// `value_str.lower() in ("null", ...)` after isolating the bare token.
+fn try_consume_keyword(cur: &mut Cursor, keyword: &str) -> bool {
+    let bytes = cur.src.as_bytes();
+    let kw = keyword.as_bytes();
+    let end = cur.pos + kw.len();
+    if end > bytes.len() {
+        return false;
+    }
+    if !bytes[cur.pos..end].eq_ignore_ascii_case(kw) {
+        return false;
+    }
+    if let Some(&next) = bytes.get(end)
+        && (next.is_ascii_alphanumeric() || next == b'_')
+    {
+        return false;
+    }
+    cur.pos = end;
+    true
+}
+
 fn parse_value(cur: &mut Cursor) -> anyhow::Result<Value> {
     cur.skip_whitespace();
 
     // Delimited string: <|"|>...<|"|>
+    //
+    // If the closing delimiter is missing (model hit `max_tokens` mid-string),
+    // upstream takes "everything after the opening delimiter" as the value.
+    // We mirror that — refusing to parse here would lose the entire args
+    // object via the outer empty-fallback, which is worse than echoing a
+    // truncated tail.
     if cur.rest().starts_with(STRING_DELIM) {
-        let open_at = cur.pos;
         cur.pos += STRING_DELIM.len();
         let body_start = cur.pos;
-        let Some(end_rel) = cur.src[body_start..].find(STRING_DELIM) else {
-            anyhow::bail!("unterminated <|\"|> string starting at offset {open_at}");
-        };
-        let body_end = body_start + end_rel;
-        let s = cur.src[body_start..body_end].to_string();
-        cur.pos = body_end + STRING_DELIM.len();
-        return Ok(Value::String(s));
+        match cur.src[body_start..].find(STRING_DELIM) {
+            Some(end_rel) => {
+                let body_end = body_start + end_rel;
+                let s = cur.src[body_start..body_end].to_string();
+                cur.pos = body_end + STRING_DELIM.len();
+                return Ok(Value::String(s));
+            }
+            None => {
+                let s = cur.src[body_start..].to_string();
+                cur.pos = cur.src.len();
+                return Ok(Value::String(s));
+            }
+        }
     }
 
     // Object
@@ -330,18 +364,20 @@ fn parse_value(cur: &mut Cursor) -> anyhow::Result<Value> {
         return parse_array(cur);
     }
 
-    // Booleans / nulls (case-sensitive match — Gemma 4 emits lowercase, but we
-    // accept the same null-aliases vLLM does for parity with offline parsing).
-    if cur.consume_str("true") {
+    // Booleans / nulls. Upstream `_parse_gemma4_value` lowercases the token
+    // before comparing, accepting any-case `null`/`none`/`nil`. We do the same
+    // by peeking the next 3–4 word bytes and matching case-insensitively.
+    if try_consume_keyword(cur, "true") {
         return Ok(Value::Bool(true));
     }
-    if cur.consume_str("false") {
+    if try_consume_keyword(cur, "false") {
         return Ok(Value::Bool(false));
     }
-    for null_token in ["null", "none", "nil", "None", "NULL", "Nil"] {
-        if cur.consume_str(null_token) {
-            return Ok(Value::Null);
-        }
+    if try_consume_keyword(cur, "null")
+        || try_consume_keyword(cur, "none")
+        || try_consume_keyword(cur, "nil")
+    {
+        return Ok(Value::Null);
     }
 
     // Number
@@ -428,7 +464,10 @@ mod tests {
         let text = "<|tool_call>call:f{}<tool_call|>more";
         let pos = find_tool_call_end_position_gemma4(text).unwrap();
         assert_eq!(&text[pos..], "more");
-        assert_eq!(find_tool_call_end_position_gemma4("<|tool_call>call:f{"), None);
+        assert_eq!(
+            find_tool_call_end_position_gemma4("<|tool_call>call:f{"),
+            None
+        );
     }
 
     #[test] // CASE.1 — single string argument
@@ -512,21 +551,28 @@ mod tests {
 
     #[test] // CASE.3 — no tool calls at all
     fn parse_no_tool_calls() {
-        let (calls, normal) =
-            try_tool_call_parse_gemma4("just plain prose here", None).unwrap();
+        let (calls, normal) = try_tool_call_parse_gemma4("just plain prose here", None).unwrap();
         assert_eq!(calls.len(), 0);
         assert_eq!(normal, Some("just plain prose here".to_string()));
     }
 
-    #[test] // CASE.5, CASE.16 — truncated mid-args is dropped, complete prior calls survive
-    fn truncated_call_dropped_complete_prior_survives() {
+    #[test] // CASE.5, CASE.16 — complete prior calls survive; truncated tail is echoed
+    fn truncated_tail_echoed_complete_prior_survives() {
         let input = concat!(
             "<|tool_call>call:complete{x:1}<tool_call|>",
             "<|tool_call>call:partial{y:<|\"|>incomp", // no end marker
         );
-        let (calls, _normal) = try_tool_call_parse_gemma4(input, None).unwrap();
+        let (calls, normal) = try_tool_call_parse_gemma4(input, None).unwrap();
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0].function.name, "complete");
+        // Truncated bytes are surfaced rather than silently dropped — matches
+        // upstream `vllm.tool_parsers.gemma4_tool_parser.extract_tool_calls`
+        // when no complete tool call could be parsed past the start marker.
+        let normal = normal.unwrap();
+        assert!(
+            normal.contains("<|tool_call>call:partial"),
+            "expected truncated bytes echoed in normal_text, got: {normal:?}"
+        );
     }
 
     #[test] // CASE.4 — malformed args body falls back to empty object, call still emitted
@@ -542,9 +588,18 @@ mod tests {
     #[test] // CASE.21 — function names with hyphens, dots, underscores
     fn parse_function_names_with_special_chars() {
         for (input, expected_name) in [
-            ("<|tool_call>call:list-tasklists{}<tool_call|>", "list-tasklists"),
-            ("<|tool_call>call:mcp__portal__search-doc{}<tool_call|>", "mcp__portal__search-doc"),
-            ("<|tool_call>call:my.namespaced.fn{}<tool_call|>", "my.namespaced.fn"),
+            (
+                "<|tool_call>call:list-tasklists{}<tool_call|>",
+                "list-tasklists",
+            ),
+            (
+                "<|tool_call>call:mcp__portal__search-doc{}<tool_call|>",
+                "mcp__portal__search-doc",
+            ),
+            (
+                "<|tool_call>call:my.namespaced.fn{}<tool_call|>",
+                "my.namespaced.fn",
+            ),
         ] {
             let (calls, _) = try_tool_call_parse_gemma4(input, None).unwrap();
             assert_eq!(calls.len(), 1, "input: {input}");
@@ -635,8 +690,64 @@ mod tests {
     }
 
     #[test]
-    fn args_grammar_unterminated_string_errors() {
-        let err = parse_args_object(r#"x:<|"|>oops"#).unwrap_err();
-        assert!(err.to_string().contains("unterminated"));
+    fn args_grammar_unterminated_string_takes_remainder() {
+        // Upstream Gemma 4 parser: when the closing <|"|> is missing,
+        // everything after the opening delimiter becomes the value. We mirror
+        // that so a truncated trailing arg doesn't lose all earlier args via
+        // the entire-args-object error fallback.
+        let v = parse_args_object(r#"x:<|"|>oops"#).unwrap();
+        assert_eq!(v["x"], "oops");
+    }
+
+    #[test] // upstream test_empty_value
+    fn args_grammar_empty_value_yields_empty_string() {
+        let v = parse_args_object("x:,y:1").unwrap();
+        assert_eq!(v["x"], "");
+        assert_eq!(v["y"], 1);
+    }
+
+    #[test] // upstream test_empty_value at end-of-args
+    fn args_grammar_trailing_empty_value() {
+        let v = parse_args_object("x:1,y:").unwrap();
+        assert_eq!(v["x"], 1);
+        assert_eq!(v["y"], "");
+    }
+
+    #[test] // case-insensitive null aliases (upstream `value_str.lower() in (...)`)
+    fn args_grammar_null_aliases_case_insensitive() {
+        for variant in [
+            "null", "NULL", "Null", "none", "NONE", "None", "nil", "NIL", "Nil",
+        ] {
+            let body = format!("x:{variant}");
+            let v = parse_args_object(&body).unwrap();
+            assert_eq!(v["x"], Value::Null, "variant: {variant}");
+        }
+    }
+
+    #[test] // ensure `nullable` (or other word-suffixed identifiers) doesn't
+    // get mis-matched as the keyword `null` plus leftovers.
+    fn args_grammar_keyword_prefix_not_consumed() {
+        // `nullable` starts with "null" but is not the null keyword. Without
+        // the trailing-word-char guard, `null` would match and `able` would
+        // leak into the next-token parse. The recursive-descent argument
+        // grammar treats this as a number-parse error → empty-fallback at the
+        // entry, but inside an array we want the nested parser to fail
+        // cleanly, not silently produce Null.
+        let err = parse_args_object("x:nullable").unwrap_err();
+        // Bare identifiers after a `:` are not valid Gemma 4 values, so we
+        // expect a parse error rather than a Null match.
+        let _ = err; // exact message not asserted, only that it errors
+    }
+
+    #[test] // upstream test_incomplete_tool_call equivalent
+    fn incomplete_tool_call_echoes_raw_bytes() {
+        let input = "<|tool_call>call:foo{x:1";
+        let (calls, normal) = try_tool_call_parse_gemma4(input, None).unwrap();
+        assert_eq!(calls.len(), 0);
+        let normal = normal.unwrap();
+        assert!(
+            normal.contains("<|tool_call>call:foo"),
+            "expected raw bytes echoed; got: {normal:?}"
+        );
     }
 }

--- a/lib/parsers/src/tool_calling/gemma4/parser.rs
+++ b/lib/parsers/src/tool_calling/gemma4/parser.rs
@@ -665,32 +665,32 @@ mod tests {
 
     // Argument-grammar unit tests (parse_args_object directly)
 
-    #[test]
+    #[test] // CASE.6 — empty args at the grammar entry point
     fn args_grammar_empty() {
         let v = parse_args_object("").unwrap();
         assert_eq!(v, serde_json::json!({}));
     }
 
-    #[test]
+    #[test] // CASE.7 — string with comma/colon/brace literals
     fn args_grammar_string_with_special_chars() {
         let v = parse_args_object(r#"x:<|"|>has,comma:and{brace}<|"|>"#).unwrap();
         assert_eq!(v["x"], "has,comma:and{brace}");
     }
 
-    #[test]
+    #[test] // CASE.7 — deeply nested object value
     fn args_grammar_deeply_nested() {
         let v = parse_args_object("a:{b:{c:{d:{e:1}}}}").unwrap();
         assert_eq!(v["a"]["b"]["c"]["d"]["e"], 1);
     }
 
-    #[test]
+    #[test] // CASE.7 — array of objects
     fn args_grammar_array_of_objects() {
         let v = parse_args_object(r#"items:[{n:<|"|>x<|"|>},{n:<|"|>y<|"|>}]"#).unwrap();
         assert_eq!(v["items"][0]["n"], "x");
         assert_eq!(v["items"][1]["n"], "y");
     }
 
-    #[test]
+    #[test] // CASE.4, CASE.5 — truncated string-arg recovery (mirrors upstream)
     fn args_grammar_unterminated_string_takes_remainder() {
         // Upstream Gemma 4 parser: when the closing <|"|> is missing,
         // everything after the opening delimiter becomes the value. We mirror
@@ -700,21 +700,21 @@ mod tests {
         assert_eq!(v["x"], "oops");
     }
 
-    #[test] // upstream test_empty_value
+    #[test] // CASE.4 — empty value mid-args (upstream test_empty_value)
     fn args_grammar_empty_value_yields_empty_string() {
         let v = parse_args_object("x:,y:1").unwrap();
         assert_eq!(v["x"], "");
         assert_eq!(v["y"], 1);
     }
 
-    #[test] // upstream test_empty_value at end-of-args
+    #[test] // CASE.4 — empty value at end-of-args (upstream test_empty_value)
     fn args_grammar_trailing_empty_value() {
         let v = parse_args_object("x:1,y:").unwrap();
         assert_eq!(v["x"], 1);
         assert_eq!(v["y"], "");
     }
 
-    #[test] // case-insensitive null aliases (upstream `value_str.lower() in (...)`)
+    #[test] // CASE.7 — typed-value null variants, case-insensitive (upstream `value_str.lower() in (...)`)
     fn args_grammar_null_aliases_case_insensitive() {
         for variant in [
             "null", "NULL", "Null", "none", "NONE", "None", "nil", "NIL", "Nil",
@@ -725,8 +725,7 @@ mod tests {
         }
     }
 
-    #[test] // ensure `nullable` (or other word-suffixed identifiers) doesn't
-    // get mis-matched as the keyword `null` plus leftovers.
+    #[test] // CASE.4 — keyword-prefix must not partial-match (`nullable` vs `null`)
     fn args_grammar_keyword_prefix_not_consumed() {
         // `nullable` starts with "null" but is not the null keyword. Without
         // the trailing-word-char guard, `null` would match and `able` would
@@ -740,7 +739,7 @@ mod tests {
         let _ = err; // exact message not asserted, only that it errors
     }
 
-    #[test] // upstream test_incomplete_tool_call equivalent
+    #[test] // CASE.5 — missing end-marker, raw bytes echoed (upstream test_incomplete_tool_call)
     fn incomplete_tool_call_echoes_raw_bytes() {
         let input = "<|tool_call>call:foo{x:1";
         let (calls, normal) = try_tool_call_parse_gemma4(input, None).unwrap();

--- a/lib/parsers/src/tool_calling/gemma4/parser.rs
+++ b/lib/parsers/src/tool_calling/gemma4/parser.rs
@@ -1,0 +1,642 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Reference implementations:
+// https://github.com/vllm-project/vllm/pull/.../vllm/tool_parsers/gemma4_tool_parser.py
+//
+// Gemma 4 uses a custom non-JSON serialization format for tool calls:
+//
+//     <|tool_call>call:func_name{key:<|"|>value<|"|>,num:42}<tool_call|>
+//
+// Strings are delimited by `<|"|>`, keys are bare (unquoted), nested objects
+// and arrays are supported, and multiple tool calls are concatenated without
+// separators. The parser converts this grammar into JSON-shaped arguments so
+// downstream callers see the same `serde_json::Value` shape as every other
+// parser family.
+
+use std::sync::OnceLock;
+
+use regex::Regex;
+use serde_json::{Map, Value};
+use uuid::Uuid;
+
+use super::super::ToolDefinition;
+use super::super::response::{CalledFunction, ToolCallResponse, ToolCallType};
+
+pub(crate) const TOOL_CALL_START: &str = "<|tool_call>";
+pub(crate) const TOOL_CALL_END: &str = "<tool_call|>";
+pub(crate) const STRING_DELIM: &str = "<|\"|>";
+const CALL_PREFIX: &str = "call:";
+
+static TOOL_CALL_REGEX: OnceLock<Regex> = OnceLock::new();
+
+/// Captures the function-name + raw-args body of a single complete tool call.
+/// `(?s)` enables dot-all so nested arg bodies that span newlines parse correctly.
+fn tool_call_regex() -> &'static Regex {
+    TOOL_CALL_REGEX.get_or_init(|| {
+        let pattern = format!(
+            r"(?s){}{}(?P<name>[\w\-\.]+)\{{(?P<args>.*?)\}}{}",
+            regex::escape(TOOL_CALL_START),
+            regex::escape(CALL_PREFIX),
+            regex::escape(TOOL_CALL_END),
+        );
+        Regex::new(&pattern).expect("Failed to compile gemma4 tool call regex")
+    })
+}
+
+/// Detect whether `chunk` contains the start of a Gemma 4 tool call, including
+/// partial-prefix matches at the chunk boundary so streaming pipelines can hold
+/// off emitting bytes that may belong to a tool-call marker.
+pub fn detect_tool_call_start_gemma4(chunk: &str) -> bool {
+    if chunk.contains(TOOL_CALL_START) {
+        return true;
+    }
+    for i in 1..TOOL_CALL_START.len() {
+        if !TOOL_CALL_START.is_char_boundary(i) {
+            continue;
+        }
+        if chunk.ends_with(&TOOL_CALL_START[..i]) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Returns the position immediately after the *last* `<tool_call|>` end marker
+/// in `chunk`, or `None` if no end marker has arrived yet (caller should keep
+/// accumulating). Mirrors the kimi_k2 / dsml convention so the streaming jail
+/// behaves consistently across parser families.
+pub fn find_tool_call_end_position_gemma4(chunk: &str) -> Option<usize> {
+    let mut last_end: Option<usize> = None;
+    let mut search_from = 0;
+    while let Some(pos) = chunk[search_from..].find(TOOL_CALL_END) {
+        let abs = search_from + pos + TOOL_CALL_END.len();
+        last_end = Some(abs);
+        search_from = abs;
+    }
+    last_end
+}
+
+/// Parse a Gemma 4 model response into structured tool calls + leftover text.
+///
+/// Returns `(parsed_tool_calls, normal_text_content)`. Text outside the
+/// `<|tool_call>...<tool_call|>` markers is returned as `normal_text`; truly
+/// truncated calls (start marker present, end marker missing) are dropped from
+/// the call list and their raw bytes are NOT re-emitted as user-visible text
+/// (mirrors kimi_k2's behavior — surfacing half-parsed markers in user output
+/// is worse than dropping the truncated call).
+pub fn try_tool_call_parse_gemma4(
+    message: &str,
+    tools: Option<&[ToolDefinition]>,
+) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
+    let mut calls = Vec::new();
+    let mut normal_parts = Vec::new();
+    let mut cursor = 0;
+
+    while cursor < message.len() {
+        let Some(start_rel) = message[cursor..].find(TOOL_CALL_START) else {
+            normal_parts.push(&message[cursor..]);
+            break;
+        };
+        let abs_start = cursor + start_rel;
+        normal_parts.push(&message[cursor..abs_start]);
+
+        let Some(end_rel) = message[abs_start..].find(TOOL_CALL_END) else {
+            // Truncated tool call — consume the rest of the buffer silently.
+            cursor = message.len();
+            break;
+        };
+        let abs_end = abs_start + end_rel + TOOL_CALL_END.len();
+        let block = &message[abs_start..abs_end];
+
+        if let Some(call) = parse_single_call(block, tools)? {
+            calls.push(call);
+        }
+
+        cursor = abs_end;
+    }
+
+    let normal_text = normal_parts.join("").trim().to_string();
+    let normal_content = if normal_text.is_empty() {
+        Some(String::new())
+    } else {
+        Some(normal_text)
+    };
+
+    Ok((calls, normal_content))
+}
+
+fn parse_single_call(
+    block: &str,
+    tools: Option<&[ToolDefinition]>,
+) -> anyhow::Result<Option<ToolCallResponse>> {
+    let Some(caps) = tool_call_regex().captures(block) else {
+        return Ok(None);
+    };
+    let name = caps
+        .name("name")
+        .map(|m| m.as_str().to_string())
+        .unwrap_or_default();
+    if name.is_empty() {
+        return Ok(None);
+    }
+    let args_raw = caps.name("args").map(|m| m.as_str()).unwrap_or("");
+
+    if let Some(tools) = tools
+        && !tools.iter().any(|t| t.name == name)
+    {
+        tracing::warn!(
+            "Tool '{}' is not defined in the tools list (Gemma 4 parser).",
+            name
+        );
+    }
+
+    let args_value = match parse_args_object(args_raw) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(
+                "Failed to parse Gemma 4 args for '{}': {}. Falling back to empty object.",
+                name,
+                e
+            );
+            Value::Object(Map::new())
+        }
+    };
+    let arguments = serde_json::to_string(&args_value)?;
+
+    Ok(Some(ToolCallResponse {
+        id: format!("call-{}", Uuid::new_v4()),
+        tp: ToolCallType::Function,
+        function: CalledFunction {
+            name,
+            arguments,
+        },
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// Recursive-descent parser for the Gemma 4 argument grammar
+// ---------------------------------------------------------------------------
+//
+// Grammar (informal):
+//
+//   args     = (entry ("," entry)*)?
+//   entry    = key ":" value
+//   key      = bare-identifier (no quoting in Gemma 4 emit)
+//   value    = string | number | bool | null | object | array
+//   string   = "<|\"|>" .* "<|\"|>"
+//   number   = -? [0-9]+ ( "." [0-9]+ )?
+//   bool     = "true" | "false"
+//   null     = "null" | "none" | "nil"
+//   object   = "{" args "}"
+//   array    = "[" (value ("," value)*)? "]"
+//
+// We parse straight into `serde_json::Value` so the rest of the pipeline sees
+// the same shape every other parser produces.
+
+struct Cursor<'a> {
+    src: &'a str,
+    pos: usize,
+}
+
+impl<'a> Cursor<'a> {
+    fn new(src: &'a str) -> Self {
+        Self { src, pos: 0 }
+    }
+
+    fn rest(&self) -> &'a str {
+        &self.src[self.pos..]
+    }
+
+    fn eof(&self) -> bool {
+        self.pos >= self.src.len()
+    }
+
+    fn skip_whitespace(&mut self) {
+        let bytes = self.src.as_bytes();
+        while self.pos < bytes.len() && bytes[self.pos].is_ascii_whitespace() {
+            self.pos += 1;
+        }
+    }
+
+    fn peek_byte(&self) -> Option<u8> {
+        self.src.as_bytes().get(self.pos).copied()
+    }
+
+    fn consume_byte(&mut self, b: u8) -> bool {
+        if self.peek_byte() == Some(b) {
+            self.pos += 1;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn consume_str(&mut self, s: &str) -> bool {
+        if self.rest().starts_with(s) {
+            self.pos += s.len();
+            true
+        } else {
+            false
+        }
+    }
+}
+
+pub(crate) fn parse_args_object(input: &str) -> anyhow::Result<Value> {
+    let mut cur = Cursor::new(input);
+    cur.skip_whitespace();
+    let val = parse_object_body(&mut cur)?;
+    cur.skip_whitespace();
+    if !cur.eof() {
+        anyhow::bail!(
+            "trailing characters after Gemma 4 args object at offset {}: {:?}",
+            cur.pos,
+            cur.rest()
+        );
+    }
+    Ok(val)
+}
+
+fn parse_object_body(cur: &mut Cursor) -> anyhow::Result<Value> {
+    let mut map = Map::new();
+    cur.skip_whitespace();
+    if cur.eof() || cur.peek_byte() == Some(b'}') {
+        return Ok(Value::Object(map));
+    }
+    loop {
+        cur.skip_whitespace();
+        let key = parse_key(cur)?;
+        cur.skip_whitespace();
+        if !cur.consume_byte(b':') {
+            anyhow::bail!("expected ':' after key '{}' at offset {}", key, cur.pos);
+        }
+        cur.skip_whitespace();
+        let value = parse_value(cur)?;
+        map.insert(key, value);
+        cur.skip_whitespace();
+        if !cur.consume_byte(b',') {
+            break;
+        }
+    }
+    Ok(Value::Object(map))
+}
+
+fn parse_key(cur: &mut Cursor) -> anyhow::Result<String> {
+    let bytes = cur.src.as_bytes();
+    let start = cur.pos;
+    while cur.pos < bytes.len() {
+        let b = bytes[cur.pos];
+        if b.is_ascii_alphanumeric() || b == b'_' || b == b'-' || b == b'.' {
+            cur.pos += 1;
+        } else {
+            break;
+        }
+    }
+    if cur.pos == start {
+        anyhow::bail!("expected bare key at offset {}", start);
+    }
+    Ok(cur.src[start..cur.pos].to_string())
+}
+
+fn parse_value(cur: &mut Cursor) -> anyhow::Result<Value> {
+    cur.skip_whitespace();
+
+    // Delimited string: <|"|>...<|"|>
+    if cur.rest().starts_with(STRING_DELIM) {
+        let open_at = cur.pos;
+        cur.pos += STRING_DELIM.len();
+        let body_start = cur.pos;
+        let Some(end_rel) = cur.src[body_start..].find(STRING_DELIM) else {
+            anyhow::bail!("unterminated <|\"|> string starting at offset {open_at}");
+        };
+        let body_end = body_start + end_rel;
+        let s = cur.src[body_start..body_end].to_string();
+        cur.pos = body_end + STRING_DELIM.len();
+        return Ok(Value::String(s));
+    }
+
+    // Object
+    if cur.consume_byte(b'{') {
+        let v = parse_object_body(cur)?;
+        cur.skip_whitespace();
+        if !cur.consume_byte(b'}') {
+            anyhow::bail!("expected '}}' to close object at offset {}", cur.pos);
+        }
+        return Ok(v);
+    }
+
+    // Array
+    if cur.consume_byte(b'[') {
+        return parse_array(cur);
+    }
+
+    // Booleans / nulls (case-sensitive match — Gemma 4 emits lowercase, but we
+    // accept the same null-aliases vLLM does for parity with offline parsing).
+    if cur.consume_str("true") {
+        return Ok(Value::Bool(true));
+    }
+    if cur.consume_str("false") {
+        return Ok(Value::Bool(false));
+    }
+    for null_token in ["null", "none", "nil", "None", "NULL", "Nil"] {
+        if cur.consume_str(null_token) {
+            return Ok(Value::Null);
+        }
+    }
+
+    // Number
+    parse_number(cur)
+}
+
+fn parse_array(cur: &mut Cursor) -> anyhow::Result<Value> {
+    let mut items = Vec::new();
+    cur.skip_whitespace();
+    if cur.consume_byte(b']') {
+        return Ok(Value::Array(items));
+    }
+    loop {
+        cur.skip_whitespace();
+        items.push(parse_value(cur)?);
+        cur.skip_whitespace();
+        if cur.consume_byte(b']') {
+            return Ok(Value::Array(items));
+        }
+        if !cur.consume_byte(b',') {
+            anyhow::bail!("expected ',' or ']' in array at offset {}", cur.pos);
+        }
+    }
+}
+
+fn parse_number(cur: &mut Cursor) -> anyhow::Result<Value> {
+    let start = cur.pos;
+    let bytes = cur.src.as_bytes();
+    if cur.peek_byte() == Some(b'-') {
+        cur.pos += 1;
+    }
+    let int_start = cur.pos;
+    while cur.pos < bytes.len() && bytes[cur.pos].is_ascii_digit() {
+        cur.pos += 1;
+    }
+    if cur.pos == int_start {
+        anyhow::bail!(
+            "expected value at offset {} but got: {:?}",
+            start,
+            &cur.src[start..]
+        );
+    }
+    let mut is_float = false;
+    if cur.peek_byte() == Some(b'.') {
+        is_float = true;
+        cur.pos += 1;
+        while cur.pos < bytes.len() && bytes[cur.pos].is_ascii_digit() {
+            cur.pos += 1;
+        }
+    }
+    let lex = &cur.src[start..cur.pos];
+    if is_float {
+        let f: f64 = lex.parse()?;
+        Ok(serde_json::json!(f))
+    } else {
+        let i: i64 = lex.parse()?;
+        Ok(serde_json::json!(i))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn extract_first(input: &str) -> (String, Value) {
+        let (calls, _) = try_tool_call_parse_gemma4(input, None).unwrap();
+        assert_eq!(calls.len(), 1, "expected exactly one tool call");
+        let args: Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+        (calls[0].function.name.clone(), args)
+    }
+
+    #[test] // CASE.20 — detection helper
+    fn detect_full_and_partial_start() {
+        assert!(detect_tool_call_start_gemma4("<|tool_call>"));
+        assert!(detect_tool_call_start_gemma4("blah <|tool_call>"));
+        assert!(detect_tool_call_start_gemma4("<|tool_"));
+        assert!(detect_tool_call_start_gemma4("<|"));
+        assert!(!detect_tool_call_start_gemma4("nothing here"));
+        assert!(!detect_tool_call_start_gemma4("toolcall"));
+    }
+
+    #[test] // CASE.20 — end-position helper
+    fn find_end_returns_position_after_last_marker() {
+        let text = "<|tool_call>call:f{}<tool_call|>more";
+        let pos = find_tool_call_end_position_gemma4(text).unwrap();
+        assert_eq!(&text[pos..], "more");
+        assert_eq!(find_tool_call_end_position_gemma4("<|tool_call>call:f{"), None);
+    }
+
+    #[test] // CASE.1 — single string argument
+    fn parse_single_string_argument() {
+        let input = r#"<|tool_call>call:get_weather{location:<|"|>Tokyo<|"|>}<tool_call|>"#;
+        let (name, args) = extract_first(input);
+        assert_eq!(name, "get_weather");
+        assert_eq!(args["location"], "Tokyo");
+    }
+
+    #[test] // CASE.1, CASE.7 — multiple typed arguments
+    fn parse_multiple_typed_arguments() {
+        let input = r#"<|tool_call>call:f{loc:<|"|>San Francisco, CA<|"|>,unit:<|"|>celsius<|"|>,count:42,flag:true,nope:null}<tool_call|>"#;
+        let (name, args) = extract_first(input);
+        assert_eq!(name, "f");
+        assert_eq!(args["loc"], "San Francisco, CA");
+        assert_eq!(args["unit"], "celsius");
+        assert_eq!(args["count"], 42);
+        assert_eq!(args["flag"], true);
+        assert_eq!(args["nope"], Value::Null);
+    }
+
+    #[test] // CASE.6 — empty argument object
+    fn parse_no_arg_call() {
+        let input = "<|tool_call>call:get_time{}<tool_call|>";
+        let (name, args) = extract_first(input);
+        assert_eq!(name, "get_time");
+        assert!(args.as_object().unwrap().is_empty());
+    }
+
+    #[test] // CASE.7 — nested object value
+    fn parse_nested_object_value() {
+        let input = r#"<|tool_call>call:f{cfg:{ssl:true,pool:{min:5,max:20}}}<tool_call|>"#;
+        let (_name, args) = extract_first(input);
+        assert_eq!(args["cfg"]["ssl"], true);
+        assert_eq!(args["cfg"]["pool"]["min"], 5);
+        assert_eq!(args["cfg"]["pool"]["max"], 20);
+    }
+
+    #[test] // CASE.7 — array of strings
+    fn parse_array_of_strings() {
+        let input = r#"<|tool_call>call:f{tags:[<|"|>a<|"|>,<|"|>b<|"|>,<|"|>c<|"|>]}<tool_call|>"#;
+        let (_name, args) = extract_first(input);
+        assert_eq!(args["tags"], serde_json::json!(["a", "b", "c"]));
+    }
+
+    #[test] // CASE.7 — array of mixed primitives
+    fn parse_array_of_mixed_primitives() {
+        let input = "<|tool_call>call:f{xs:[1,2,3.5,true,false,null]}<tool_call|>";
+        let (_name, args) = extract_first(input);
+        assert_eq!(args["xs"][0], 1);
+        assert_eq!(args["xs"][1], 2);
+        assert!((args["xs"][2].as_f64().unwrap() - 3.5).abs() < 1e-9);
+        assert_eq!(args["xs"][3], true);
+        assert_eq!(args["xs"][4], false);
+        assert_eq!(args["xs"][5], Value::Null);
+    }
+
+    #[test] // CASE.2 — multiple parallel calls, zero spacing
+    fn parse_multiple_parallel_calls() {
+        let input = concat!(
+            "<|tool_call>call:a{x:1}<tool_call|>",
+            "<|tool_call>call:b{y:<|\"|>two<|\"|>}<tool_call|>",
+            "<|tool_call>call:c{}<tool_call|>",
+        );
+        let (calls, normal) = try_tool_call_parse_gemma4(input, None).unwrap();
+        assert_eq!(calls.len(), 3);
+        assert_eq!(calls[0].function.name, "a");
+        assert_eq!(calls[1].function.name, "b");
+        assert_eq!(calls[2].function.name, "c");
+        assert_eq!(normal, Some(String::new()));
+    }
+
+    #[test] // CASE.13 — surrounding normal text preserved
+    fn parse_with_surrounding_text() {
+        let input = r#"Sure thing. <|tool_call>call:f{x:1}<tool_call|> All set."#;
+        let (calls, normal) = try_tool_call_parse_gemma4(input, None).unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(normal, Some("Sure thing.  All set.".to_string()));
+    }
+
+    #[test] // CASE.3 — no tool calls at all
+    fn parse_no_tool_calls() {
+        let (calls, normal) =
+            try_tool_call_parse_gemma4("just plain prose here", None).unwrap();
+        assert_eq!(calls.len(), 0);
+        assert_eq!(normal, Some("just plain prose here".to_string()));
+    }
+
+    #[test] // CASE.5, CASE.16 — truncated mid-args is dropped, complete prior calls survive
+    fn truncated_call_dropped_complete_prior_survives() {
+        let input = concat!(
+            "<|tool_call>call:complete{x:1}<tool_call|>",
+            "<|tool_call>call:partial{y:<|\"|>incomp", // no end marker
+        );
+        let (calls, _normal) = try_tool_call_parse_gemma4(input, None).unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].function.name, "complete");
+    }
+
+    #[test] // CASE.4 — malformed args body falls back to empty object, call still emitted
+    fn malformed_args_falls_back_to_empty_object() {
+        let input = "<|tool_call>call:f{garbage no colons here}<tool_call|>";
+        let (calls, _) = try_tool_call_parse_gemma4(input, None).unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].function.name, "f");
+        let args: Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+        assert!(args.as_object().unwrap().is_empty());
+    }
+
+    #[test] // CASE.21 — function names with hyphens, dots, underscores
+    fn parse_function_names_with_special_chars() {
+        for (input, expected_name) in [
+            ("<|tool_call>call:list-tasklists{}<tool_call|>", "list-tasklists"),
+            ("<|tool_call>call:mcp__portal__search-doc{}<tool_call|>", "mcp__portal__search-doc"),
+            ("<|tool_call>call:my.namespaced.fn{}<tool_call|>", "my.namespaced.fn"),
+        ] {
+            let (calls, _) = try_tool_call_parse_gemma4(input, None).unwrap();
+            assert_eq!(calls.len(), 1, "input: {input}");
+            assert_eq!(calls[0].function.name, expected_name);
+        }
+    }
+
+    #[test] // CASE.7 — angle brackets / HTML inside string values
+    fn parse_html_in_string_value() {
+        let input = r#"<|tool_call>call:render{html:<|"|><div class="x"><h1>Hi</h1></div><|"|>}<tool_call|>"#;
+        let (_name, args) = extract_first(input);
+        assert_eq!(args["html"], "<div class=\"x\"><h1>Hi</h1></div>");
+    }
+
+    #[test] // CASE.7 — newlines inside string values
+    fn parse_newlines_in_string_value() {
+        let input = "<|tool_call>call:f{body:<|\"|>line1\nline2\nline3<|\"|>}<tool_call|>";
+        let (_name, args) = extract_first(input);
+        assert_eq!(args["body"], "line1\nline2\nline3");
+    }
+
+    #[test] // CASE.22 — whitespace tolerance inside args
+    fn parse_with_internal_whitespace() {
+        let input = r#"<|tool_call>call:f{ x : 1 , y : <|"|>z<|"|> }<tool_call|>"#;
+        let (_name, args) = extract_first(input);
+        assert_eq!(args["x"], 1);
+        assert_eq!(args["y"], "z");
+    }
+
+    #[test] // CASE.7 — negative numbers and floats
+    fn parse_signed_numbers_and_floats() {
+        let input = "<|tool_call>call:f{a:-1,b:-2.5,c:0,d:0.0}<tool_call|>";
+        let (_name, args) = extract_first(input);
+        assert_eq!(args["a"], -1);
+        assert!((args["b"].as_f64().unwrap() - -2.5).abs() < 1e-9);
+        assert_eq!(args["c"], 0);
+        assert!((args["d"].as_f64().unwrap()).abs() < 1e-9);
+    }
+
+    #[test] // CASE.21 — tool validation warns but doesn't drop
+    fn parse_with_tool_validation() {
+        let input = r#"<|tool_call>call:get_weather{x:1}<tool_call|>"#;
+        let tools = vec![ToolDefinition {
+            name: "get_weather".to_string(),
+            parameters: None,
+        }];
+        let (calls, _) = try_tool_call_parse_gemma4(input, Some(&tools)).unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].function.name, "get_weather");
+    }
+
+    #[test] // CASE.24 — empty wrapper between calls
+    fn parse_empty_text_between_calls() {
+        let input = concat!(
+            "<|tool_call>call:a{}<tool_call|>",
+            "<|tool_call>call:b{}<tool_call|>",
+        );
+        let (calls, normal) = try_tool_call_parse_gemma4(input, None).unwrap();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(normal, Some(String::new()));
+    }
+
+    // Argument-grammar unit tests (parse_args_object directly)
+
+    #[test]
+    fn args_grammar_empty() {
+        let v = parse_args_object("").unwrap();
+        assert_eq!(v, serde_json::json!({}));
+    }
+
+    #[test]
+    fn args_grammar_string_with_special_chars() {
+        let v = parse_args_object(r#"x:<|"|>has,comma:and{brace}<|"|>"#).unwrap();
+        assert_eq!(v["x"], "has,comma:and{brace}");
+    }
+
+    #[test]
+    fn args_grammar_deeply_nested() {
+        let v = parse_args_object("a:{b:{c:{d:{e:1}}}}").unwrap();
+        assert_eq!(v["a"]["b"]["c"]["d"]["e"], 1);
+    }
+
+    #[test]
+    fn args_grammar_array_of_objects() {
+        let v = parse_args_object(r#"items:[{n:<|"|>x<|"|>},{n:<|"|>y<|"|>}]"#).unwrap();
+        assert_eq!(v["items"][0]["n"], "x");
+        assert_eq!(v["items"][1]["n"], "y");
+    }
+
+    #[test]
+    fn args_grammar_unterminated_string_errors() {
+        let err = parse_args_object(r#"x:<|"|>oops"#).unwrap_err();
+        assert!(err.to_string().contains("unterminated"));
+    }
+}

--- a/lib/parsers/src/tool_calling/gemma4/parser.rs
+++ b/lib/parsers/src/tool_calling/gemma4/parser.rs
@@ -725,4 +725,83 @@ mod tests {
         let pos = find_tool_call_end_position_gemma4(input).unwrap();
         assert_eq!(&input[pos..], " trailing");
     }
+
+    #[test] // CASE.9 — paired reasoning span + tool call in the same emission
+    // (in production the reasoning parser runs first and strips `<|channel>`,
+    // but the tool-call parser must remain correct if it sees the full
+    // emission, e.g. when reasoning parsing is disabled).
+    fn paired_reasoning_and_tool_call_in_same_emission() {
+        let input = concat!(
+            "<|channel>thought\nthinking about the request<channel|>",
+            "<|tool_call>call:get_weather{location:<|\"|>Tokyo<|\"|>}<tool_call|>",
+        );
+        let (calls, normal) = try_tool_call_parse_gemma4(input, None).unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].function.name, "get_weather");
+        let args: Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+        assert_eq!(args["location"], "Tokyo");
+        // The reasoning span is preserved as normal_text — the tool-call parser
+        // doesn't try to interpret `<|channel>` markers itself.
+        assert!(normal.unwrap().contains("<|channel>thought"));
+    }
+
+    #[test] // CASE.14 — empty input, no tool calls
+    fn empty_input_yields_zero_calls_empty_content() {
+        let (calls, normal) = try_tool_call_parse_gemma4("", None).unwrap();
+        assert_eq!(calls.len(), 0);
+        assert_eq!(normal, Some(String::new()));
+    }
+
+    #[test] // CASE.14 — `null` argument values round-trip as JSON null
+    fn null_argument_values_preserved() {
+        let input = "<|tool_call>call:f{x:null,y:none,z:nil}<tool_call|>";
+        let (calls, _) = try_tool_call_parse_gemma4(input, None).unwrap();
+        assert_eq!(calls.len(), 1);
+        let args: Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+        assert_eq!(args["x"], Value::Null);
+        assert_eq!(args["y"], Value::Null);
+        assert_eq!(args["z"], Value::Null);
+    }
+
+    #[test] // CASE.15 — duplicate calls to the same function name. Both must
+    // appear with distinct IDs; client decides whether duplicate invocation
+    // is intended.
+    fn duplicate_tool_call_same_name() {
+        let input = concat!(
+            "<|tool_call>call:get_weather{location:<|\"|>Tokyo<|\"|>}<tool_call|>",
+            "<|tool_call>call:get_weather{location:<|\"|>NYC<|\"|>}<tool_call|>",
+        );
+        let (calls, _) = try_tool_call_parse_gemma4(input, None).unwrap();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].function.name, "get_weather");
+        assert_eq!(calls[1].function.name, "get_weather");
+        assert_ne!(
+            calls[0].id, calls[1].id,
+            "duplicate calls need distinct IDs"
+        );
+        let args0: Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+        let args1: Value = serde_json::from_str(&calls[1].function.arguments).unwrap();
+        assert_eq!(args0["location"], "Tokyo");
+        assert_eq!(args1["location"], "NYC");
+    }
+
+    // ----- Explicit N/A coverage notes (per lib/parsers/TEST_CASES.md) -----
+    //
+    // CASE.8  — Streaming token-by-token assembly: indirect. The Gemma 4
+    //           parser exposes only the synchronous extraction path; the
+    //           streaming jail (`tools.rs::try_tool_call_parse_stream`) drives
+    //           it via `detect_tool_call_start_gemma4` and
+    //           `find_tool_call_end_position_gemma4`, both covered by CASE.20
+    //           tests above. Same pattern as kimi_k2.
+    // CASE.11 — `tool_choice` (auto / required / named / none): universal gap
+    //           in the repo as of 2026-04 — the cross-parser suites at
+    //           `lib/llm/tests/{tool_choice.rs,parallel_tool_call_integration.rs,
+    //           tool_choice_finish_reasons.rs}` run `hermes` only. Adding
+    //           Gemma 4 to those suites is a separate parametrization PR.
+    // CASE.12 — `finish_reason` semantics: same universal gap; lives in
+    //           `lib/llm/tests/tool_choice_finish_reasons.rs`, hermes-only
+    //           today.
+    // CASE.xml1 / CASE.xml2 — XML-family only. N/A — Gemma 4 uses a custom
+    //           non-JSON, non-XML grammar.
+    // CASE.harmony1 — Harmony only. N/A.
 }

--- a/lib/parsers/src/tool_calling/gemma4/parser.rs
+++ b/lib/parsers/src/tool_calling/gemma4/parser.rs
@@ -1,8 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// Reference implementations:
-// https://github.com/vllm-project/vllm/pull/.../vllm/tool_parsers/gemma4_tool_parser.py
+// Reference implementation (upstream merged 2026-04-02 via vLLM PR #38826,
+// follow-up #39027):
+// https://github.com/vllm-project/vllm/blob/main/vllm/tool_parsers/gemma4_tool_parser.py
 //
 // Gemma 4 uses a custom non-JSON serialization format for tool calls:
 //

--- a/lib/parsers/src/tool_calling/gemma4/parser.rs
+++ b/lib/parsers/src/tool_calling/gemma4/parser.rs
@@ -1,19 +1,15 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// Reference implementation (upstream merged 2026-04-02 via vLLM PR #38826,
-// follow-up #39027):
+// Reference implementation:
 // https://github.com/vllm-project/vllm/blob/main/vllm/tool_parsers/gemma4_tool_parser.py
 //
-// Gemma 4 uses a custom non-JSON serialization format for tool calls:
+// Gemma 4 tool-call grammar (custom, non-JSON):
 //
 //     <|tool_call>call:func_name{key:<|"|>value<|"|>,num:42}<tool_call|>
 //
-// Strings are delimited by `<|"|>`, keys are bare (unquoted), nested objects
-// and arrays are supported, and multiple tool calls are concatenated without
-// separators. The parser converts this grammar into JSON-shaped arguments so
-// downstream callers see the same `serde_json::Value` shape as every other
-// parser family.
+// `<|"|>`-delimited strings, bare unquoted keys, nested objects/arrays,
+// multiple calls concatenated without separators.
 
 use std::sync::OnceLock;
 
@@ -63,65 +59,88 @@ pub fn detect_tool_call_start_gemma4(chunk: &str) -> bool {
     false
 }
 
-/// Returns the position immediately after the *last* `<tool_call|>` end marker
-/// in `chunk`, or `None` if no end marker has arrived yet (caller should keep
-/// accumulating). Mirrors the kimi_k2 / dsml convention so the streaming jail
-/// behaves consistently across parser families.
+/// Returns the position immediately after the last *complete* tool-call match
+/// in `chunk`, or `None` if no complete call has arrived yet (caller should
+/// keep accumulating). The regex requires `}<tool_call|>` adjacency, so a bare
+/// `<tool_call|>` literal embedded inside a `<|"|>` string value does not
+/// false-trigger a "section complete" signal here — matches upstream.
 pub fn find_tool_call_end_position_gemma4(chunk: &str) -> Option<usize> {
-    let mut last_end: Option<usize> = None;
-    let mut search_from = 0;
-    while let Some(pos) = chunk[search_from..].find(TOOL_CALL_END) {
-        let abs = search_from + pos + TOOL_CALL_END.len();
-        last_end = Some(abs);
-        search_from = abs;
-    }
-    last_end
+    tool_call_regex().find_iter(chunk).last().map(|m| m.end())
 }
 
 /// Parse a Gemma 4 model response into structured tool calls + leftover text.
 ///
-/// Returns `(parsed_tool_calls, normal_text_content)`. Text outside the
-/// `<|tool_call>...<tool_call|>` markers is returned as `normal_text`. When a
-/// tool call is truncated (start marker present, end marker missing — typically
-/// because the model hit `max_tokens` mid-call), the parser cannot extract a
-/// structured call from it; instead it echoes the raw bytes back as
-/// `normal_text` so the caller can detect the truncation and surface it to the
-/// user. This matches upstream `vllm.tool_parsers.gemma4_tool_parser`'s
-/// behavior of returning the raw `model_output` as content when no complete
-/// tool call could be parsed.
+/// Returns `(parsed_tool_calls, normal_text_content)`. Text outside any
+/// `<|tool_call>call:NAME{...}<tool_call|>` match is returned as `normal_text`.
+/// When a tool call is truncated (start marker present but no `}<tool_call|>`
+/// terminator — typically because the model hit `max_tokens` mid-call), the
+/// regex finds no match and the raw bytes after the start marker are echoed
+/// back as `normal_text` so the caller can detect the truncation and surface
+/// it to the user.
+///
+/// Mirrors upstream's `extract_tool_calls` in `vllm/tool_parsers/
+/// gemma4_tool_parser.py`, which uses `tool_call_regex.findall(model_output)`
+/// directly. The `}<tool_call|>` adjacency requirement in the regex means
+/// embedded `<tool_call|>` literals inside string-typed args (e.g. a
+/// `description` field documenting the tool-call format) don't truncate the
+/// match prematurely.
 pub fn try_tool_call_parse_gemma4(
     message: &str,
     tools: Option<&[ToolDefinition]>,
 ) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
+    let regex = tool_call_regex();
     let mut calls = Vec::new();
     let mut normal_parts = Vec::new();
     let mut cursor = 0;
 
-    while cursor < message.len() {
-        let Some(start_rel) = message[cursor..].find(TOOL_CALL_START) else {
-            normal_parts.push(&message[cursor..]);
-            break;
-        };
-        let abs_start = cursor + start_rel;
-        normal_parts.push(&message[cursor..abs_start]);
+    for caps in regex.captures_iter(message) {
+        let whole = caps.get(0).expect("capture 0 always present");
+        normal_parts.push(&message[cursor..whole.start()]);
+        cursor = whole.end();
 
-        // First `<tool_call|>` wins; we don't scan inside `<|"|>` strings,
-        // so an embedded literal will truncate the call. Matches upstream.
-        let Some(end_rel) = message[abs_start..].find(TOOL_CALL_END) else {
-            // Truncated tool call — echo the raw bytes back as normal_text so
-            // the caller sees the truncation rather than silently losing it.
-            normal_parts.push(&message[abs_start..]);
-            break;
-        };
-        let abs_end = abs_start + end_rel + TOOL_CALL_END.len();
-        let block = &message[abs_start..abs_end];
+        let name = caps
+            .name("name")
+            .map(|m| m.as_str().to_string())
+            .unwrap_or_default();
+        if name.is_empty() {
+            continue;
+        }
+        let args_raw = caps.name("args").map(|m| m.as_str()).unwrap_or("");
 
-        if let Some(call) = parse_single_call(block, tools)? {
-            calls.push(call);
+        if let Some(tools) = tools
+            && !tools.iter().any(|t| t.name == name)
+        {
+            tracing::warn!(
+                "Tool '{}' is not defined in the tools list (Gemma 4 parser).",
+                name
+            );
         }
 
-        cursor = abs_end;
+        let args_value = match parse_args_object(args_raw) {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!(
+                    "Failed to parse Gemma 4 args for '{}': {}. Falling back to empty object.",
+                    name,
+                    e
+                );
+                Value::Object(Map::new())
+            }
+        };
+        let arguments = serde_json::to_string(&args_value)?;
+
+        calls.push(ToolCallResponse {
+            id: format!("call-{}", Uuid::new_v4()),
+            tp: ToolCallType::Function,
+            function: CalledFunction { name, arguments },
+        });
     }
+
+    // Anything after the last complete match — including a truncated
+    // `<|tool_call>call:...` with no closing `}<tool_call|>` — is returned to
+    // the caller as `normal_text` so model truncation is visible rather than
+    // silently swallowed.
+    normal_parts.push(&message[cursor..]);
 
     let normal_text = normal_parts.join("").trim().to_string();
     let normal_content = if normal_text.is_empty() {
@@ -131,51 +150,6 @@ pub fn try_tool_call_parse_gemma4(
     };
 
     Ok((calls, normal_content))
-}
-
-fn parse_single_call(
-    block: &str,
-    tools: Option<&[ToolDefinition]>,
-) -> anyhow::Result<Option<ToolCallResponse>> {
-    let Some(caps) = tool_call_regex().captures(block) else {
-        return Ok(None);
-    };
-    let name = caps
-        .name("name")
-        .map(|m| m.as_str().to_string())
-        .unwrap_or_default();
-    if name.is_empty() {
-        return Ok(None);
-    }
-    let args_raw = caps.name("args").map(|m| m.as_str()).unwrap_or("");
-
-    if let Some(tools) = tools
-        && !tools.iter().any(|t| t.name == name)
-    {
-        tracing::warn!(
-            "Tool '{}' is not defined in the tools list (Gemma 4 parser).",
-            name
-        );
-    }
-
-    let args_value = match parse_args_object(args_raw) {
-        Ok(v) => v,
-        Err(e) => {
-            tracing::warn!(
-                "Failed to parse Gemma 4 args for '{}': {}. Falling back to empty object.",
-                name,
-                e
-            );
-            Value::Object(Map::new())
-        }
-    };
-    let arguments = serde_json::to_string(&args_value)?;
-
-    Ok(Some(ToolCallResponse {
-        id: format!("call-{}", Uuid::new_v4()),
-        tp: ToolCallType::Function,
-        function: CalledFunction { name, arguments },
-    }))
 }
 
 // ---------------------------------------------------------------------------
@@ -266,11 +240,7 @@ fn parse_object_body(cur: &mut Cursor) -> anyhow::Result<Value> {
             anyhow::bail!("expected ':' after key '{}' at offset {}", key, cur.pos);
         }
         cur.skip_whitespace();
-        // Empty value (`key:` followed by `,` / `}` / EOF) — upstream Gemma 4
-        // parser emits these as `{"key": ""}` rather than dropping the key, so
-        // we mirror that. Without this, the empty-value case fell through to
-        // `parse_value`'s number path and errored out, which then triggered
-        // the entire-args-object empty-fallback in `parse_single_call`.
+        // `key:` with no value emits `{"key": ""}` (matches upstream).
         let value = match cur.peek_byte() {
             None | Some(b',') | Some(b'}') => Value::String(String::new()),
             _ => parse_value(cur)?,
@@ -301,10 +271,8 @@ fn parse_key(cur: &mut Cursor) -> anyhow::Result<String> {
     Ok(cur.src[start..cur.pos].to_string())
 }
 
-/// Try to consume `keyword` from `cur` ASCII-case-insensitively, only when the
-/// byte immediately after the keyword is NOT a word character (so `nullable`
-/// doesn't get matched as `null` + leftover `able`). Mirrors upstream's
-/// `value_str.lower() in ("null", ...)` after isolating the bare token.
+/// Consume `keyword` ASCII-case-insensitively, only when the next byte is not
+/// a word character (so `nullable` doesn't match `null` + leftover `able`).
 fn try_consume_keyword(cur: &mut Cursor, keyword: &str) -> bool {
     let bytes = cur.src.as_bytes();
     let kw = keyword.as_bytes();
@@ -327,13 +295,8 @@ fn try_consume_keyword(cur: &mut Cursor, keyword: &str) -> bool {
 fn parse_value(cur: &mut Cursor) -> anyhow::Result<Value> {
     cur.skip_whitespace();
 
-    // Delimited string: <|"|>...<|"|>
-    //
-    // If the closing delimiter is missing (model hit `max_tokens` mid-string),
-    // upstream takes "everything after the opening delimiter" as the value.
-    // We mirror that — refusing to parse here would lose the entire args
-    // object via the outer empty-fallback, which is worse than echoing a
-    // truncated tail.
+    // Delimited string `<|"|>...<|"|>`. If the closing delimiter is missing
+    // (model truncation), take everything after the opener as the value.
     if cur.rest().starts_with(STRING_DELIM) {
         cur.pos += STRING_DELIM.len();
         let body_start = cur.pos;
@@ -367,9 +330,7 @@ fn parse_value(cur: &mut Cursor) -> anyhow::Result<Value> {
         return parse_array(cur);
     }
 
-    // Booleans / nulls. Upstream `_parse_gemma4_value` lowercases the token
-    // before comparing, accepting any-case `null`/`none`/`nil`. We do the same
-    // by peeking the next 3–4 word bytes and matching case-insensitively.
+    // Booleans + null aliases (case-insensitive).
     if try_consume_keyword(cur, "true") {
         return Ok(Value::Bool(true));
     }
@@ -729,16 +690,8 @@ mod tests {
 
     #[test] // CASE.4 — keyword-prefix must not partial-match (`nullable` vs `null`)
     fn args_grammar_keyword_prefix_not_consumed() {
-        // `nullable` starts with "null" but is not the null keyword. Without
-        // the trailing-word-char guard, `null` would match and `able` would
-        // leak into the next-token parse. The recursive-descent argument
-        // grammar treats this as a number-parse error → empty-fallback at the
-        // entry, but inside an array we want the nested parser to fail
-        // cleanly, not silently produce Null.
-        let err = parse_args_object("x:nullable").unwrap_err();
-        // Bare identifiers after a `:` are not valid Gemma 4 values, so we
-        // expect a parse error rather than a Null match.
-        let _ = err; // exact message not asserted, only that it errors
+        // `nullable` must not be parsed as `null` + leftover `able`.
+        let _ = parse_args_object("x:nullable").unwrap_err();
     }
 
     #[test] // CASE.5 — missing end-marker, raw bytes echoed (upstream test_incomplete_tool_call)
@@ -751,5 +704,25 @@ mod tests {
             normal.contains("<|tool_call>call:foo"),
             "expected raw bytes echoed; got: {normal:?}"
         );
+    }
+
+    #[test] // CASE.7 — `<tool_call|>` literal inside a string-typed argument
+    // must not truncate the call. The extraction regex requires
+    // `}<tool_call|>` adjacency, so a bare embedded marker is safe.
+    fn embedded_tool_call_marker_in_string_value() {
+        let input = r#"<|tool_call>call:render{html:<|"|><tool_call|> example<|"|>}<tool_call|>"#;
+        let (calls, _) = try_tool_call_parse_gemma4(input, None).unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].function.name, "render");
+        let args: Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+        assert_eq!(args["html"], "<tool_call|> example");
+    }
+
+    #[test] // CASE.20 — find_tool_call_end_position must respect the regex's
+    // `}<tool_call|>` adjacency, not just bare `<tool_call|>` occurrences.
+    fn find_end_position_skips_embedded_marker() {
+        let input = r#"<|tool_call>call:render{html:<|"|><tool_call|>x<|"|>}<tool_call|> trailing"#;
+        let pos = find_tool_call_end_position_gemma4(input).unwrap();
+        assert_eq!(&input[pos..], " trailing");
     }
 }

--- a/lib/parsers/src/tool_calling/mod.rs
+++ b/lib/parsers/src/tool_calling/mod.rs
@@ -5,6 +5,7 @@ use serde_json::Value;
 
 pub mod config;
 pub mod dsml;
+pub mod gemma4;
 pub mod harmony;
 pub mod json;
 pub mod parsers;
@@ -27,6 +28,7 @@ pub use config::{
     JsonParserConfig, KimiK2ParserConfig, ParserConfig, ToolCallConfig, XmlParserConfig,
 };
 pub use dsml::try_tool_call_parse_dsml;
+pub use gemma4::try_tool_call_parse_gemma4;
 pub use harmony::parse_tool_calls_harmony_complete;
 pub use json::try_tool_call_parse_json;
 pub use parsers::{

--- a/lib/parsers/src/tool_calling/parsers.rs
+++ b/lib/parsers/src/tool_calling/parsers.rs
@@ -6,6 +6,9 @@ use super::config::{ParserConfig, ToolCallConfig};
 use super::dsml::{
     detect_tool_call_start_dsml, find_tool_call_end_position_dsml, try_tool_call_parse_dsml,
 };
+use super::gemma4::{
+    detect_tool_call_start_gemma4, find_tool_call_end_position_gemma4, try_tool_call_parse_gemma4,
+};
 use super::harmony::{
     detect_tool_call_start_harmony, find_tool_call_end_position_harmony,
     parse_tool_calls_harmony_complete,
@@ -51,6 +54,8 @@ pub fn get_tool_parser_map() -> &'static HashMap<&'static str, ToolCallConfig> {
         map.insert("minimax_m2", ToolCallConfig::minimax_m2());
         map.insert("glm47", ToolCallConfig::glm47());
         map.insert("kimi_k2", ToolCallConfig::kimi_k2());
+        map.insert("gemma4", ToolCallConfig::gemma4());
+        map.insert("gemma-4", ToolCallConfig::gemma4());
         map.insert("default", ToolCallConfig::default());
         map.insert("nemotron_nano", ToolCallConfig::qwen3_coder()); // nemotron nano follows qwen3_coder format
         map.insert("qwen25", ToolCallConfig::hermes()); // qwen2.5 uses the same <tool_call>...</tool_call> format as hermes
@@ -101,6 +106,10 @@ pub async fn try_tool_call_parse(
         ParserConfig::KimiK2(kimi_config) => {
             let (results, normal_content) =
                 try_tool_call_parse_kimi_k2(message, kimi_config, tools)?;
+            Ok((results, normal_content))
+        }
+        ParserConfig::Gemma4 => {
+            let (results, normal_content) = try_tool_call_parse_gemma4(message, tools)?;
             Ok((results, normal_content))
         }
     }
@@ -159,6 +168,7 @@ pub fn detect_tool_call_start(chunk: &str, parser_str: Option<&str>) -> anyhow::
             ParserConfig::KimiK2(kimi_config) => {
                 Ok(detect_tool_call_start_kimi_k2(chunk, kimi_config))
             }
+            ParserConfig::Gemma4 => Ok(detect_tool_call_start_gemma4(chunk)),
         },
         None => anyhow::bail!(
             "Parser '{}' is not implemented. Available parsers: {:?}",
@@ -211,6 +221,7 @@ pub fn find_tool_call_end_position(chunk: &str, parser_str: Option<&str>) -> Opt
             ParserConfig::KimiK2(kimi_config) => {
                 find_tool_call_end_position_kimi_k2(chunk, kimi_config)
             }
+            ParserConfig::Gemma4 => find_tool_call_end_position_gemma4(chunk),
         },
         None => Some(chunk.len()),
     }
@@ -253,6 +264,8 @@ mod tests {
             "minimax_m2",
             "glm47",
             "kimi_k2",
+            "gemma4",
+            "gemma-4",
             "qwen25",
         ];
         for parser in available_parsers {


### PR DESCRIPTION
#### Overview:

Add tool-call and reasoning parsers for Google **Gemma 4** thinking models to Dynamo's frontend, plus a vendored chat template. With this change, Dynamo's native preprocessor (mode A in `docs/agents/chat-processor-options.md`) can serve any Gemma 4 deployment that runs on vLLM ≥ v0.19.0 (where Gemma 4 support landed via vllm-project/vllm#38826 and #39027) end-to-end with structured `tool_calls` and `reasoning_content`.

Gemma 4's serialization grammar does not match any existing Dynamo parser family, so this PR introduces a new `Gemma4` variant in `ParserConfig` rather than force-fitting it into JSON/XML/DSML. The grammar uses bare unquoted keys, a custom `<|"|>` string delimiter, and fixed `<|tool_call>...<tool_call|>` markers:

```
<|tool_call>call:get_weather{location:<|"|>Tokyo<|"|>,unit:<|"|>celsius<|"|>,count:5}<tool_call|>
```

Reasoning is wrapped between channel markers with a `thought\n` role-label prefix that this parser strips:

```
<|channel>thought
...chain of thought reasoning...<channel|>
Final answer text.
```

Recommended pairing for a Gemma 4 deployment:

```bash
--dyn-tool-call-parser gemma4 \
--dyn-reasoning-parser gemma4 \
--custom-jinja-template examples/chat_templates/gemma4_tool.jinja
```

#### Details:

The PR is two commits to make the upstream-diff alignments easy to review separately from the initial port.

**Commit 1 — `chore(frontend): Add Gemma 4 parser support + Test Cases`**

New files:
- `lib/parsers/src/tool_calling/gemma4/{mod.rs,parser.rs}` — recursive-descent parser for the Gemma 4 argument grammar (booleans, numbers, `<|"|>`-delimited strings, nested objects, arrays) emitting `serde_json::Value`. Inline `#[cfg(test)]` coverage of CASE.1–CASE.24 from `lib/parsers/TEST_CASES.md`.
- `lib/parsers/src/reasoning/gemma4_parser.rs` — `Gemma4ReasoningParser` implementing the `ReasoningParser` trait directly (mirrors `granite_parser.rs` shape) with `<|channel>...<channel|>` delimiters, `thought\n` prefix stripping (the 3-case streaming logic from upstream's reasoning parser), and partial-marker overlap detection at chunk boundaries.
- `examples/chat_templates/gemma4_tool.jinja` — verbatim copy of upstream vLLM `examples/tool_chat_template_gemma4.jinja` with SPDX attribution. Required because the stock HF Gemma 4 chat template does not emit the `<|"|>`-delimited tool-definition encoding the parser expects.
- `examples/chat_templates/README.md` — per-template usage notes.

Modified files:
- `lib/parsers/src/tool_calling/{config.rs,parsers.rs,mod.rs}` — added `ParserConfig::Gemma4` variant, `ToolCallConfig::gemma4()` factory, registered names `gemma4` (alias `gemma-4`), and dispatched `try_tool_call_parse_gemma4` / `detect_tool_call_start_gemma4` / `find_tool_call_end_position_gemma4` from the central registry.
- `lib/parsers/src/reasoning/mod.rs` — added `ReasoningParserType::Gemma4` variant and registered the same names.
- `lib/parsers/README.md` — bumped parser counts (17 → 18 tool-call, 14 → 15 reasoning) and added rows in the parser-family cheat sheets.
- `docs/agents/{tool-calling,reasoning}.md` — added parser-table rows and the recommended-pairing line.

**Commit 2 — `fix(frontend): align Gemma 4 parsers with upstream vLLM main`**

Behavior-diff against upstream vLLM `main` (recently-merged Gemma 4 PRs and bugfix follow-ups) surfaced four real bugs in the initial port plus one reasoning-parser gap and one preprocessor optimization gap. All fixed:

1. **Null-keyword case-insensitivity** (`parser.rs`) — upstream's `_parse_gemma4_value` does `value_str.lower() in ("null","none","nil")`. The first-pass port hard-coded a small set of mixed-case spellings and missed `NONE`, `Nul`, etc. Replaced with `try_consume_keyword` that does ASCII-case-insensitive matching with a trailing-word-char guard so `nullable` doesn't get mis-matched as `null` plus leftovers.
2. **Unterminated `<|"|>` string in args** (`parser.rs`) — upstream's `_parse_gemma4_args:146-149` takes "everything after the opening delimiter" as the value when the closing delimiter is missing. The first-pass port bailed instead, which then triggered the entire-args-object empty-fallback in `parse_single_call` — i.e. a single truncated trailing arg silently lost ALL prior args. Now mirrors upstream.
3. **Empty value `key:` followed by `,`/`}`/EOF** (`parser.rs`) — upstream's `_parse_gemma4_args:128-131` emits `{"key": ""}`. The first-pass port errored out of `parse_value` and dropped the whole args object. Detect this case in `parse_object_body` and insert an empty-string.
4. **Truncated tool call** (`parser.rs`) — upstream `extract_tool_calls:421-424` returns the raw `model_output` as content when no complete tool call could be parsed. The first-pass port consumed those bytes silently, hiding model truncation from callers. Now echoes the bytes back as `normal_text`.
5. **Reasoning: dangling end marker** (`gemma4_parser.rs`) — when `<channel|>` is present but `<|channel>` is absent (tokenizer with `skip_special_tokens=True` strips the start token), upstream's offline parser still extracts text-before as reasoning. Added a `(None, Some(end))` match arm.
6. **`is_reasoning_disabled_by_request` polish** (`lib/llm/src/preprocessor.rs`) — added `gemma4`/`gemma-4` recognition with `enable_thinking: false` short-circuit, matching the existing pattern for `kimi_k25` / `deepseek_v4` / `nemotron_nano`. Without this, the parser still ran on every chunk just to fall through (since no `<|channel>` markers arrive when the chat template doesn't inject `<|think|>`).

One intentional divergence from upstream: between-call text is preserved (`Sure thing. <call> All set.` → `"Sure thing.  All set."`) rather than dropped, because that matches the established `kimi_k2_parser.rs` pattern in the rest of Dynamo's parser registry. Documented inline.

#### Where should the reviewer start?

1. **`lib/parsers/src/tool_calling/gemma4/parser.rs`** — the centerpiece. Pay particular attention to:
   - The recursive-descent `Cursor` / `parse_object_body` / `parse_value` / `parse_array` / `parse_number` / `try_consume_keyword` chain (lines ~198–402). The grammar parses straight into `serde_json::Value`.
   - `try_tool_call_parse_gemma4` (lines ~91–131) for the outer call-extraction loop and the truncated-call echo behavior.
   - The `#[cfg(test)] mod tests` block — 31 tests covering CASE.1–CASE.24 plus targeted cases from upstream's `tests/tool_parsers/test_gemma4_tool_parser.py` (`test_unterminated_string`, `test_empty_value`, `test_incomplete_tool_call`, parallel calls, function names with hyphens/dots, HTML/newlines in string values, case-insensitive null aliases, keyword-prefix non-consumption).
2. **`lib/parsers/src/reasoning/gemma4_parser.rs`** — 12 tests including the new `detect_dangling_end_marker_*` cases that mirror upstream's `INVALID_SIMPLE` / `INVALID_COMPLETE` test fixtures, plus the streaming `thought\n` prefix-split-across-deltas cases.
3. **`lib/parsers/src/tool_calling/config.rs`** — the new `ParserConfig::Gemma4` unit variant and the `ToolCallConfig::gemma4()` factory. The variant is unit (no per-instance config) because Gemma 4's markers are fixed and not user-tunable, unlike `KimiK2ParserConfig` / `Glm47ParserConfig`.
4. **`lib/parsers/src/tool_calling/parsers.rs`** — the registry/dispatch edits: `map.insert("gemma4", ...)` + the new dispatch arm in `try_tool_call_parse` and the partial-prefix detection arm in `detect_tool_call_start`.
5. **`lib/llm/src/preprocessor.rs`** — only the `is_reasoning_disabled_by_request` table entry plus four parametric test cases. Worth glancing at to confirm it follows the existing `kimi_k25` / `deepseek_v4` pattern.
6. **`examples/chat_templates/gemma4_tool.jinja`** — verbatim copy of upstream vLLM's template, only a 3-line SPDX/comment header added at the top. Reviewers can `diff` against `https://github.com/vllm-project/vllm/blob/main/examples/tool_chat_template_gemma4.jinja` to verify.

#### Validation:

- `cargo build -p dynamo-parsers` — clean (0 errors, 0 warnings).
- `cargo test -p dynamo-parsers --lib gemma4` — **44/44 pass**.
- `cargo test -p dynamo-parsers` (full crate) — **443 pass, 5 ignored**, no regressions in other parsers.
- `cargo fmt --check --all` — workspace clean.
- `cargo clippy -p dynamo-parsers` — no warnings on the new code (one pre-existing warning in `glm47_parser.rs:177`, untouched by this PR).
- `pre-commit run --files <13 changed files>` — all hooks pass (codespell, case-conflict, merge-conflict, mixed-line-ending, trailing-whitespace, pytest-marker-report).
- `cargo test -p dynamo-llm --lib is_reasoning_disabled_by_request` — could not run on the development host because the `dynamo-llm` crate has a pre-existing macOS link error (`libstdc++` not available on modern macOS, replaced by `libc++`). The four new parametric test cases are small and surgical, mirroring the existing pattern for `kimi_k25` and `deepseek_v4`; CI on Linux will exercise them.

#### Out of scope (explicit non-goals — file as follow-ups if desired):

- Native Rust chat-template formatter for Gemma 4 (analogous to `lib/llm/src/preprocessor/prompt/deepseek_v4.rs`). The vendored jinja covers Phase 1 via `--custom-jinja-template`; a native formatter is a several-day port of the 333-line jinja and not blocking.
- SGLang frontend wiring (`components/src/dynamo/frontend/sglang_prepost.py`). Only relevant for `--dyn-chat-processor sglang` (mode C). Whether SGLang has its own `gemma4` parser is a separate question.
- Streaming-jail integration tests under `lib/llm/tests/data/vllm/gemma4/`. Those need real captured chunks from a Gemma 4 vLLM deployment; will follow up after a real-world capture.
- Backporting to older Dynamo release branches.

#### Watch list (upstream vLLM bugfix PRs the maintainers may want to track):

The vLLM Gemma 4 parsers are still settling — there are several open bugfix PRs touching internals (#39484 STRING_DELIM leak, #39311 nested-array bracket handling, #39070 argument truncation, #39588 selective reasoning, #39885 multi-turn streaming leak, #39570 chat-template HF resync). The public marker contract and parser name `gemma4` are stable, so this PR is unaffected, but the vendored jinja may want a periodic re-sync against upstream once #39570 lands. Filing a tracking issue is recommended.

#### AI-Generated Code Disclosure:

Per Dynamo's contribution guide (`docs/contribution-guide.md` §AI-Generated Code): AI assistance was used to draft this change. Every changed line was manually reviewed against the upstream vLLM reference implementations (`vllm/tool_parsers/gemma4_tool_parser.py`, `vllm/reasoning/gemma4_reasoning_parser.py`, `examples/tool_chat_template_gemma4.jinja`) and against the analog Dynamo parsers (`kimi_k2_parser.rs`, `granite_parser.rs`, `dsml/parser.rs`). The submitter understands and can defend every line of the change end-to-end, including the recursive-descent grammar parser, the streaming `thought\n` prefix-stripping state machine, and the four upstream-diff fixes in commit 2.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to GitHub issue: #8851

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8852" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Gemma 4 models with tool-calling and reasoning parsing capabilities
  * New custom Jinja chat template for Gemma 4 tool formatting

* **Documentation**
  * Added documentation for Gemma 4 tool-calling and reasoning parsers
  * Added README guide for custom Jinja chat templates with Gemma 4 example

<!-- end of auto-generated comment: release notes by coderabbit.ai -->