### PR TITLE
feat(benchmarks): emit image_uuids in jsonl generator for vLLM cached-mm

### DIFF
--- a/benchmarks/multimodal/jsonl/args.py
+++ b/benchmarks/multimodal/jsonl/args.py
@@ -41,6 +41,13 @@ def _common_parser() -> argparse.ArgumentParser:
         default=None,
         help="Random seed for reproducible generation (default: time-based)",
     )
+    p.add_argument(
+        "--uuid",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Emit `image_uuids` parallel to `images` in each JSONL row (default: False). "
+        "Pass --uuid to enable for aiperf --mm-cache-mode {uuid-only,uuid-and-strip} runs.",
+    )
     return p
 
 

--- a/benchmarks/multimodal/jsonl/generate_images.py
+++ b/benchmarks/multimodal/jsonl/generate_images.py
@@ -3,9 +3,9 @@
 
 """Utilities for generating and sampling image pools."""
 
-import hashlib
 import json
 import random
+import uuid as _uuid
 from pathlib import Path
 
 import numpy as np
@@ -15,12 +15,17 @@ from PIL import Image
 def compute_image_uuid(ref: str) -> str:
     """Stable UUID for an image reference (path or URL).
 
-    Used for vLLM cached-multimodal-input UUIDs (the `uuid` per content part
-    in the OpenAI chat-completions extension). Same `ref` → same UUID across
-    runs, so the server's processor cache survives benchmark restarts.
+    Used as the `uuid` field on chat-completion `image_url` content parts —
+    a vLLM extension to the OpenAI-compat schema (see vLLM's
+    `multi_modal_uuids` / `mm_processor_cache`). Same `ref` → same UUID
+    across runs, so the server's processor cache survives benchmark
+    restarts.
+
+    Returns a hyphenated UUID string. Dynamo's chat parser enforces strict
+    UUID format at the wire boundary, so this MUST be a valid UUID — we
+    use UUIDv5 in the OID namespace for determinism.
     """
-    digest = hashlib.sha256(ref.encode("utf-8")).hexdigest()
-    return f"img-{digest[:16]}"
+    return str(_uuid.uuid5(_uuid.NAMESPACE_OID, ref))
 
 
 def generate_image_pool_base64(

--- a/benchmarks/multimodal/jsonl/generate_images.py
+++ b/benchmarks/multimodal/jsonl/generate_images.py
@@ -3,12 +3,24 @@
 
 """Utilities for generating and sampling image pools."""
 
+import hashlib
 import json
 import random
 from pathlib import Path
 
 import numpy as np
 from PIL import Image
+
+
+def compute_image_uuid(ref: str) -> str:
+    """Stable UUID for an image reference (path or URL).
+
+    Used for vLLM cached-multimodal-input UUIDs (the `uuid` per content part
+    in the OpenAI chat-completions extension). Same `ref` → same UUID across
+    runs, so the server's processor cache survives benchmark restarts.
+    """
+    digest = hashlib.sha256(ref.encode("utf-8")).hexdigest()
+    return f"img-{digest[:16]}"
 
 
 def generate_image_pool_base64(

--- a/benchmarks/multimodal/jsonl/main.py
+++ b/benchmarks/multimodal/jsonl/main.py
@@ -22,6 +22,7 @@ from pathlib import Path
 import numpy as np
 from args import parse_args
 from generate_images import (
+    compute_image_uuid,
     generate_image_pool_base64,
     generate_image_pool_http,
     sample_slots,
@@ -64,8 +65,14 @@ def run_single_turn(
             user_text = generate_filler(py_rng, args.user_text_tokens)
             start = i * images_per_request
             images = slot_refs[start : start + images_per_request]
+            image_uuids = [compute_image_uuid(ref) for ref in images]
             line = json.dumps(
-                {"text": user_text, "images": images}, separators=(",", ":")
+                {
+                    "text": user_text,
+                    "images": images,
+                    "image_uuids": image_uuids,
+                },
+                separators=(",", ":"),
             )
             f.write(line + "\n")
 
@@ -107,6 +114,7 @@ def run_sliding_window(
                     "session_id": f"user_{user_idx}",
                     "text": generate_filler(py_rng, args.user_text_tokens),
                     "images": window,
+                    "image_uuids": [compute_image_uuid(ref) for ref in window],
                 }
                 f.write(json.dumps(entry, separators=(",", ":")) + "\n")
 

--- a/benchmarks/multimodal/jsonl/main.py
+++ b/benchmarks/multimodal/jsonl/main.py
@@ -65,16 +65,10 @@ def run_single_turn(
             user_text = generate_filler(py_rng, args.user_text_tokens)
             start = i * images_per_request
             images = slot_refs[start : start + images_per_request]
-            image_uuids = [compute_image_uuid(ref) for ref in images]
-            line = json.dumps(
-                {
-                    "text": user_text,
-                    "images": images,
-                    "image_uuids": image_uuids,
-                },
-                separators=(",", ":"),
-            )
-            f.write(line + "\n")
+            row: dict = {"text": user_text, "images": images}
+            if args.uuid:
+                row["image_uuids"] = [compute_image_uuid(ref) for ref in images]
+            f.write(json.dumps(row, separators=(",", ":")) + "\n")
 
     print(f"Wrote {num_requests} requests to {output_path}")
 
@@ -110,12 +104,13 @@ def run_sliding_window(
             for user_idx in range(num_users):
                 offset = user_idx * images_per_user + turn_idx
                 window = pool[offset : offset + window_size]
-                entry = {
+                entry: dict = {
                     "session_id": f"user_{user_idx}",
                     "text": generate_filler(py_rng, args.user_text_tokens),
                     "images": window,
-                    "image_uuids": [compute_image_uuid(ref) for ref in window],
                 }
+                if args.uuid:
+                    entry["image_uuids"] = [compute_image_uuid(ref) for ref in window]
                 f.write(json.dumps(entry, separators=(",", ":")) + "\n")
 
     print(f"Wrote {total_requests} requests ({num_users} sessions) to {output_path}")


### PR DESCRIPTION
## Why

A stable UUID per image lets vLLM short-circuit the HF processor pipeline on cache hits, so the cache survives benchmark restarts and any image reuse across turns/sessions hits. Pairs with [ai-dynamo/aiperf#869](https://github.com/ai-dynamo/aiperf/pull/869) (`--mm-cache-mode {off, uuid-only, uuid-and-strip}`).

## What Change

- Add `compute_image_uuid(ref)` returning `uuid5(NAMESPACE_OID, ref)` — deterministic hyphenated UUID per path/URL.
- Add `--uuid` / `--no-uuid` (default: off) on both `single-turn` and `sliding-window`.
- When on, emit `image_uuids` parallel to `images` in every JSONL row.
- Default-off keeps baseline `--mm-cache-mode off` JSONL byte-identical to pre-PR shape.

## Test Plan

- Default → `['images', 'text']`; `--uuid` adds `image_uuids`; `--no-uuid` byte-identical to default.
- Sliding-window `--uuid`: 6 unique imgs, 2 cross-turn reuses, 0 UUID collisions.
- UUIDs stable across re-runs with same seed; round-trips through aiperf `SingleTurn.image_uuids`.
- Output format is hyphenated 8-4-4-4-12 (e.g. `508e1a09-5ecd-528a-8ce5-f7c6720baf17`) so dynamo's chat parser (PR #8957) accepts it.