### PR TITLE
feat(self-host): worker hosts metadata files via system_status_server (gh-8749)

### DIFF
--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -264,7 +264,7 @@ fn lora_name_to_id(lora_name: &str) -> i32 {
 /// For LoRA mode, both `lora_name` and `base_model_path` must be provided together.
 /// Providing only one of them will result in an error.
 #[pyfunction]
-#[pyo3(signature = (model_input, model_type, endpoint, model_path, model_name=None, context_length=None, kv_cache_block_size=None, router_config=None, runtime_config=None, user_data=None, custom_template_path=None, media_decoder=None, media_fetcher=None, lora_name=None, base_model_path=None))]
+#[pyo3(signature = (model_input, model_type, endpoint, model_path, model_name=None, context_length=None, kv_cache_block_size=None, router_config=None, runtime_config=None, user_data=None, custom_template_path=None, media_decoder=None, media_fetcher=None, lora_name=None, base_model_path=None, self_host_metadata=None))]
 #[allow(clippy::too_many_arguments)]
 fn register_model<'p>(
     py: Python<'p>,
@@ -283,6 +283,7 @@ fn register_model<'p>(
     media_fetcher: Option<MediaFetcher>,
     lora_name: Option<&str>,
     base_model_path: Option<&str>,
+    self_host_metadata: Option<bool>,
 ) -> PyResult<Bound<'p, PyAny>> {
     // Validate Prefill model type requirements
     if model_type.inner == llm_rs::model_type::ModelType::Prefill
@@ -406,6 +407,10 @@ fn register_model<'p>(
             .custom_template_path(custom_template_path_owned)
             .media_decoder(media_decoder.map(|m| m.inner))
             .media_fetcher(media_fetcher.map(|m| m.inner));
+        // Absence falls through to the DYN_SELF_HOST_METADATA env var default.
+        if let Some(enabled) = self_host_metadata {
+            builder.self_host_metadata(enabled);
+        }
 
         let mut local_model = builder.build().await.map_err(to_pyerr)?;
 

--- a/lib/llm/src/common/checked_file.rs
+++ b/lib/llm/src/common/checked_file.rs
@@ -17,7 +17,6 @@ use url::Url;
 
 #[derive(Clone, Debug)]
 pub struct CheckedFile {
-    /// Either a path on local disk or a remote URL.
     path: Either<PathBuf, Url>,
 
     /// Checksum of the contents of path

--- a/lib/llm/src/common/checked_file.rs
+++ b/lib/llm/src/common/checked_file.rs
@@ -17,11 +17,14 @@ use url::Url;
 
 #[derive(Clone, Debug)]
 pub struct CheckedFile {
-    /// Either a path on local disk or a remote URL (usually nats object store)
+    /// Either a path on local disk or a remote URL.
     path: Either<PathBuf, Url>,
 
     /// Checksum of the contents of path
     checksum: Checksum,
+
+    /// Size of the file in bytes. `None` for legacy (pre-size) wire format.
+    size: Option<u64>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -48,11 +51,13 @@ impl CheckedFile {
         if !path.is_file() {
             anyhow::bail!("Not a file: {}", path.display());
         }
+        let size = std::fs::metadata(&path)?.len();
         let hash = b3sum(&path)?;
 
         Ok(CheckedFile {
             path: Either::Left(path),
             checksum: Checksum::blake3(hash),
+            size: Some(size),
         })
     }
 
@@ -84,6 +89,10 @@ impl CheckedFile {
 
     pub fn checksum(&self) -> &Checksum {
         &self.checksum
+    }
+
+    pub fn size(&self) -> Option<u64> {
+        self.size
     }
 
     /// Does the given file checksum to the same value as this CheckedFile?
@@ -144,12 +153,16 @@ impl Serialize for CheckedFile {
     where
         S: Serializer,
     {
-        let mut cf = serializer.serialize_struct("CheckedFile", 2)?;
+        let n = if self.size.is_some() { 3 } else { 2 };
+        let mut cf = serializer.serialize_struct("CheckedFile", n)?;
         match &self.path {
             Either::Left(path) => cf.serialize_field("path", &path)?,
             Either::Right(url) => cf.serialize_field("path", &url)?,
         };
         cf.serialize_field("checksum", &self.checksum)?;
+        if let Some(size) = self.size {
+            cf.serialize_field("size", &size)?;
+        }
         cf.end()
     }
 }
@@ -159,6 +172,8 @@ impl Serialize for CheckedFile {
 struct WireCheckedFile {
     path: String,
     checksum: Checksum,
+    #[serde(default)]
+    size: Option<u64>,
 }
 
 // Convert from the temporary struct to CheckedFile with path type logic.
@@ -169,10 +184,12 @@ impl From<WireCheckedFile> for CheckedFile {
             Ok(url) => CheckedFile {
                 path: Either::Right(url),
                 checksum: temp.checksum,
+                size: temp.size,
             },
             Err(_) => CheckedFile {
                 path: Either::Left(PathBuf::from(temp.path)),
                 checksum: temp.checksum,
+                size: temp.size,
             },
         }
     }

--- a/lib/llm/src/local_model.rs
+++ b/lib/llm/src/local_model.rs
@@ -33,6 +33,19 @@ const DEFAULT_KV_CACHE_BLOCK_SIZE: u32 = 16;
 /// 'pub' because the bindings use it for consistency.
 pub const DEFAULT_HTTP_PORT: u16 = 8080;
 
+/// Default for `LocalModelBuilder::self_host_metadata`. Truthy values opt in.
+pub const ENV_SELF_HOST_METADATA: &str = "DYN_SELF_HOST_METADATA";
+
+fn env_self_host_metadata_default() -> bool {
+    match std::env::var(ENV_SELF_HOST_METADATA) {
+        Ok(v) => matches!(
+            v.trim().to_lowercase().as_str(),
+            "1" | "true" | "yes" | "on"
+        ),
+        Err(_) => false,
+    }
+}
+
 pub struct LocalModelBuilder {
     model_path: Option<PathBuf>,
     source_path: Option<PathBuf>,
@@ -52,6 +65,7 @@ pub struct LocalModelBuilder {
     is_mocker: bool,
     extra_engine_args: Option<PathBuf>,
     runtime_config: ModelRuntimeConfig,
+    self_host_metadata: bool,
     user_data: Option<serde_json::Value>,
     custom_template_path: Option<PathBuf>,
     namespace: Option<String>,
@@ -81,6 +95,7 @@ impl Default for LocalModelBuilder {
             is_mocker: Default::default(),
             extra_engine_args: Default::default(),
             runtime_config: Default::default(),
+            self_host_metadata: env_self_host_metadata_default(),
             user_data: Default::default(),
             custom_template_path: Default::default(),
             namespace: Default::default(),
@@ -139,6 +154,13 @@ impl LocalModelBuilder {
 
     pub fn http_metrics_port(&mut self, port: Option<u16>) -> &mut Self {
         self.http_metrics_port = port;
+        self
+    }
+
+    /// Opt in or out of self-hosting MDC artifacts. Default `false`.
+    /// Set this at runtime with environment variable DYN_SELF_HOST_METADATA.
+    pub fn self_host_metadata(&mut self, enabled: bool) -> &mut Self {
+        self.self_host_metadata = enabled;
         self
     }
 
@@ -269,6 +291,7 @@ impl LocalModelBuilder {
                 namespace_prefix: self.namespace_prefix.clone(),
                 migration_limit: self.migration_limit,
                 migration_max_seq_len: self.migration_max_seq_len,
+                self_host_metadata: self.self_host_metadata,
             });
         }
 
@@ -324,6 +347,7 @@ impl LocalModelBuilder {
             namespace_prefix: self.namespace_prefix.clone(),
             migration_limit: self.migration_limit,
             migration_max_seq_len: self.migration_max_seq_len,
+            self_host_metadata: self.self_host_metadata,
         })
     }
 }
@@ -345,6 +369,7 @@ pub struct LocalModel {
     namespace_prefix: Option<String>,
     migration_limit: u32,
     migration_max_seq_len: Option<u32>,
+    self_host_metadata: bool,
 }
 
 impl LocalModel {
@@ -469,6 +494,11 @@ impl LocalModel {
             suffix_for_log
         );
 
+        if self.self_host_metadata {
+            self.move_to_self_host(endpoint.drt())
+                .context("move_to_self_host")?;
+        }
+
         let source_path = PathBuf::from(self.card.source_path());
         if !source_path.exists() {
             // The consumers of MDC (frontend) might not have the same local path as us, so
@@ -499,6 +529,75 @@ impl LocalModel {
         let _instance = discovery.register(spec).await?;
 
         Ok(())
+    }
+
+    /// Local-path slots register in the registry and get rewritten to
+    /// `http://<worker>/v1/metadata/<slug>/<filename>`. URL slots
+    /// (`hf://`, etc.) are left alone so existing transports keep working.
+    fn move_to_self_host(
+        &mut self,
+        drt: &dynamo_runtime::DistributedRuntime,
+    ) -> anyhow::Result<()> {
+        let Some(base_url) = self_host_base_url(drt)? else {
+            tracing::warn!(
+                model_slug = %self.card.slug(),
+                "self_host_metadata enabled but system_status_server is not \
+                 running (DYN_SYSTEM_PORT unset); skipping http rewrites — \
+                 set DYN_SYSTEM_PORT to enable",
+            );
+            return Ok(());
+        };
+        let model_slug = self.card.slug().to_string();
+        let registry = drt.metadata_artifacts();
+
+        let mut rewritten = 0usize;
+        for cf in self.card.iter_metadata_files_mut() {
+            let Some(local_path) = cf.path().map(Path::to_path_buf) else {
+                continue;
+            };
+            // Filename from the original path — HF cache symlinks would
+            // otherwise canonicalize to the LFS SHA1 and break downstream
+            // lookups by literal name (e.g. `parent.join("generation_config.json")`).
+            let Some(filename) = local_path
+                .file_name()
+                .and_then(|f| f.to_str())
+                .map(|s| s.to_string())
+            else {
+                continue;
+            };
+            // Canonicalize so the handler serves the resolved HF blob, not the symlink.
+            let absolute = match fs::canonicalize(&local_path) {
+                Ok(p) => p,
+                Err(err) => {
+                    tracing::warn!(
+                        path = %local_path.display(),
+                        %err,
+                        "failed to canonicalize self-host metadata path; skipping",
+                    );
+                    continue;
+                }
+            };
+
+            let url = url::Url::parse(&format!("{base_url}/v1/metadata/{model_slug}/{filename}"))?;
+            registry.register(&model_slug, &filename, absolute);
+            cf.move_to_url(url);
+            rewritten += 1;
+        }
+
+        tracing::debug!(
+            model_slug,
+            rewritten,
+            base_url,
+            "self-hosting model metadata artifacts"
+        );
+        Ok(())
+    }
+
+    /// Idempotent. Call before detach/hot-reload; otherwise the
+    /// runtime drops the registry entries with the worker process.
+    pub fn clear_self_hosted_artifacts(&self, drt: &dynamo_runtime::DistributedRuntime) {
+        drt.metadata_artifacts()
+            .unregister_model(self.card.slug().as_ref());
     }
 
     /// Helper associated function to detach a model from an endpoint
@@ -548,5 +647,52 @@ fn internal_endpoint(engine: &str) -> EndpointId {
         namespace: Slug::slugify(&uuid::Uuid::new_v4().to_string()).to_string(),
         component: engine.to_string(),
         name: "generate".to_string(),
+    }
+}
+
+/// `None` when `system_status_server` isn't running (no `DYN_SYSTEM_PORT`)
+/// — lets default-on behavior degrade gracefully without erroring.
+pub(crate) fn self_host_base_url(
+    drt: &dynamo_runtime::DistributedRuntime,
+) -> anyhow::Result<Option<String>> {
+    let Some(info) = drt.system_status_server_info() else {
+        return Ok(None);
+    };
+
+    let configured = dynamo_runtime::RuntimeConfig::from_settings()
+        .unwrap_or_default()
+        .system_host;
+    let host = match configured.as_str() {
+        "0.0.0.0" | "::" | "[::]" => {
+            dynamo_runtime::utils::ip_resolver::get_local_ip_for_advertise()
+        }
+        _ => configured,
+    };
+
+    Ok(Some(format!("http://{host}:{}", info.port())))
+}
+
+#[cfg(test)]
+mod env_self_host_metadata_tests {
+    use super::*;
+
+    #[serial_test::serial]
+    #[test]
+    fn env_default_parsing() {
+        // SAFETY: all env mutations are serialized via serial_test.
+        unsafe { std::env::remove_var(ENV_SELF_HOST_METADATA) };
+        assert!(!env_self_host_metadata_default(), "unset → default OFF");
+
+        for v in [
+            "0", "false", "FALSE", "no", "NO", "off", "OFF", "", "garbage",
+        ] {
+            unsafe { std::env::set_var(ENV_SELF_HOST_METADATA, v) };
+            assert!(!env_self_host_metadata_default(), "expected OFF for {v:?}");
+        }
+        for v in ["1", "true", "TRUE", "yes", "Yes", "on", "ON"] {
+            unsafe { std::env::set_var(ENV_SELF_HOST_METADATA, v) };
+            assert!(env_self_host_metadata_default(), "expected ON for {v:?}");
+        }
+        unsafe { std::env::remove_var(ENV_SELF_HOST_METADATA) };
     }
 }

--- a/lib/llm/src/local_model.rs
+++ b/lib/llm/src/local_model.rs
@@ -292,6 +292,7 @@ impl LocalModelBuilder {
                 migration_limit: self.migration_limit,
                 migration_max_seq_len: self.migration_max_seq_len,
                 self_host_metadata: self.self_host_metadata,
+                attached_self_host_suffix: None,
             });
         }
 
@@ -348,6 +349,7 @@ impl LocalModelBuilder {
             migration_limit: self.migration_limit,
             migration_max_seq_len: self.migration_max_seq_len,
             self_host_metadata: self.self_host_metadata,
+            attached_self_host_suffix: None,
         })
     }
 }
@@ -370,6 +372,9 @@ pub struct LocalModel {
     migration_limit: u32,
     migration_max_seq_len: Option<u32>,
     self_host_metadata: bool,
+    /// Set by `move_to_self_host` so `clear_self_hosted_artifacts`
+    /// scopes its unregister to this model's `(slug, suffix)` only.
+    attached_self_host_suffix: Option<String>,
 }
 
 impl LocalModel {
@@ -495,7 +500,7 @@ impl LocalModel {
         );
 
         if self.self_host_metadata {
-            self.move_to_self_host(endpoint.drt())
+            self.move_to_self_host(endpoint.drt(), model_suffix.as_deref())
                 .context("move_to_self_host")?;
         }
 
@@ -532,11 +537,14 @@ impl LocalModel {
     }
 
     /// Local-path slots register in the registry and get rewritten to
-    /// `http://<worker>/v1/metadata/<slug>/<filename>`. URL slots
+    /// `http://<worker>/v1/metadata/<slug>/<suffix>/<filename>`. URL slots
     /// (`hf://`, etc.) are left alone so existing transports keep working.
+    /// `model_suffix` is the LoRA slug, or `None` for the base model
+    /// (recorded as `BASE_SUFFIX` in the registry).
     fn move_to_self_host(
         &mut self,
         drt: &dynamo_runtime::DistributedRuntime,
+        model_suffix: Option<&str>,
     ) -> anyhow::Result<()> {
         let Some(base_url) = self_host_base_url(drt)? else {
             tracing::warn!(
@@ -548,6 +556,7 @@ impl LocalModel {
             return Ok(());
         };
         let model_slug = self.card.slug().to_string();
+        let suffix = model_suffix.unwrap_or(dynamo_runtime::metadata_registry::BASE_SUFFIX);
         let registry = drt.metadata_artifacts();
 
         let mut rewritten = 0usize;
@@ -578,14 +587,18 @@ impl LocalModel {
                 }
             };
 
-            let url = url::Url::parse(&format!("{base_url}/v1/metadata/{model_slug}/{filename}"))?;
-            registry.register(&model_slug, &filename, absolute);
+            let url = url::Url::parse(&format!(
+                "{base_url}/v1/metadata/{model_slug}/{suffix}/{filename}"
+            ))?;
+            registry.register(&model_slug, suffix, &filename, absolute);
             cf.move_to_url(url);
             rewritten += 1;
         }
 
+        self.attached_self_host_suffix = Some(suffix.to_string());
         tracing::debug!(
             model_slug,
+            suffix,
             rewritten,
             base_url,
             "self-hosting model metadata artifacts"
@@ -596,8 +609,10 @@ impl LocalModel {
     /// Idempotent. Call before detach/hot-reload; otherwise the
     /// runtime drops the registry entries with the worker process.
     pub fn clear_self_hosted_artifacts(&self, drt: &dynamo_runtime::DistributedRuntime) {
-        drt.metadata_artifacts()
-            .unregister_model(self.card.slug().as_ref());
+        if let Some(suffix) = self.attached_self_host_suffix.as_deref() {
+            drt.metadata_artifacts()
+                .unregister(self.card.slug().as_ref(), suffix);
+        }
     }
 
     /// Helper associated function to detach a model from an endpoint

--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -538,31 +538,35 @@ impl ModelDeploymentCard {
         matches!(self.model_input, ModelInput::Tokens)
     }
 
-    /// Iterate every populated metadata `CheckedFile` on this MDC, in
-    /// deterministic slot order: model_info, tokenizer, prompt_formatter,
+    /// Walk populated metadata `CheckedFile` slots in deterministic
+    /// order: model_info, tokenizer, prompt_formatter,
     /// chat_template_file, gen_config.
-    pub fn iter_metadata_files(&self) -> impl Iterator<Item = &CheckedFile> {
-        let model_info = self.model_info.as_ref().map(|m| match m {
-            ModelInfoType::HfConfigJson(cf) => cf,
-        });
-        let tokenizer = self.tokenizer.as_ref().map(|t| match t {
-            TokenizerKind::HfTokenizerJson(cf) | TokenizerKind::TikTokenModel(cf) => cf,
-        });
-        let prompt_formatter = self.prompt_formatter.as_ref().map(pf_checked_file);
-        let chat_template_file = self.chat_template_file.as_ref().map(pf_checked_file);
-        let gen_config = self.gen_config.as_ref().map(|g| match g {
-            GenerationConfig::HfGenerationConfigJson(cf) => cf,
-        });
-
-        [
-            model_info,
-            tokenizer,
-            prompt_formatter,
-            chat_template_file,
-            gen_config,
-        ]
-        .into_iter()
-        .flatten()
+    pub fn iter_metadata_files(&self) -> Vec<&CheckedFile> {
+        let mut out: Vec<&CheckedFile> = Vec::with_capacity(5);
+        if let Some(m) = self.model_info.as_ref() {
+            match m {
+                ModelInfoType::HfConfigJson(cf) => out.push(cf),
+            }
+        }
+        if let Some(t) = self.tokenizer.as_ref() {
+            match t {
+                TokenizerKind::HfTokenizerJson(cf) | TokenizerKind::TikTokenModel(cf) => {
+                    out.push(cf)
+                }
+            }
+        }
+        if let Some(p) = self.prompt_formatter.as_ref() {
+            out.push(pf_checked_file(p));
+        }
+        if let Some(c) = self.chat_template_file.as_ref() {
+            out.push(pf_checked_file(c));
+        }
+        if let Some(g) = self.gen_config.as_ref() {
+            match g {
+                GenerationConfig::HfGenerationConfigJson(cf) => out.push(cf),
+            }
+        }
+        out
     }
 
     /// Mutable variant of [`Self::iter_metadata_files`].

--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -194,6 +194,22 @@ fn is_exclusively_mistral_model(directory: &Path) -> bool {
     !directory.join("config.json").exists() && directory.join("params.json").exists()
 }
 
+fn pf_checked_file(p: &PromptFormatterArtifact) -> &CheckedFile {
+    match p {
+        PromptFormatterArtifact::HfTokenizerConfigJson(cf)
+        | PromptFormatterArtifact::HfChatTemplateJinja { file: cf, .. }
+        | PromptFormatterArtifact::HfChatTemplateJson { file: cf, .. } => cf,
+    }
+}
+
+fn pf_checked_file_mut(p: &mut PromptFormatterArtifact) -> &mut CheckedFile {
+    match p {
+        PromptFormatterArtifact::HfTokenizerConfigJson(cf)
+        | PromptFormatterArtifact::HfChatTemplateJinja { file: cf, .. }
+        | PromptFormatterArtifact::HfChatTemplateJson { file: cf, .. } => cf,
+    }
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug, Builder, Default)]
 pub struct ModelDeploymentCard {
     /// Human readable model name, e.g. "Meta Llama 3.1 8B Instruct"
@@ -520,6 +536,62 @@ impl ModelDeploymentCard {
 
     pub fn requires_preprocessing(&self) -> bool {
         matches!(self.model_input, ModelInput::Tokens)
+    }
+
+    /// Iterate every populated metadata `CheckedFile` on this MDC, in
+    /// deterministic slot order: model_info, tokenizer, prompt_formatter,
+    /// chat_template_file, gen_config.
+    pub fn iter_metadata_files(&self) -> impl Iterator<Item = &CheckedFile> {
+        let model_info = self.model_info.as_ref().map(|m| match m {
+            ModelInfoType::HfConfigJson(cf) => cf,
+        });
+        let tokenizer = self.tokenizer.as_ref().map(|t| match t {
+            TokenizerKind::HfTokenizerJson(cf) | TokenizerKind::TikTokenModel(cf) => cf,
+        });
+        let prompt_formatter = self.prompt_formatter.as_ref().map(pf_checked_file);
+        let chat_template_file = self.chat_template_file.as_ref().map(pf_checked_file);
+        let gen_config = self.gen_config.as_ref().map(|g| match g {
+            GenerationConfig::HfGenerationConfigJson(cf) => cf,
+        });
+
+        [
+            model_info,
+            tokenizer,
+            prompt_formatter,
+            chat_template_file,
+            gen_config,
+        ]
+        .into_iter()
+        .flatten()
+    }
+
+    /// Mutable variant of [`Self::iter_metadata_files`].
+    pub fn iter_metadata_files_mut(&mut self) -> Vec<&mut CheckedFile> {
+        let mut out: Vec<&mut CheckedFile> = Vec::with_capacity(5);
+        if let Some(m) = self.model_info.as_mut() {
+            match m {
+                ModelInfoType::HfConfigJson(cf) => out.push(cf),
+            }
+        }
+        if let Some(t) = self.tokenizer.as_mut() {
+            match t {
+                TokenizerKind::HfTokenizerJson(cf) | TokenizerKind::TikTokenModel(cf) => {
+                    out.push(cf)
+                }
+            }
+        }
+        if let Some(p) = self.prompt_formatter.as_mut() {
+            out.push(pf_checked_file_mut(p));
+        }
+        if let Some(c) = self.chat_template_file.as_mut() {
+            out.push(pf_checked_file_mut(c));
+        }
+        if let Some(g) = self.gen_config.as_mut() {
+            match g {
+                GenerationConfig::HfGenerationConfigJson(cf) => out.push(cf),
+            }
+        }
+        out
     }
 
     /// Download the files this card needs to work: config.json, tokenizer.json, etc.

--- a/lib/runtime/src/distributed.rs
+++ b/lib/runtime/src/distributed.rs
@@ -81,6 +81,9 @@ pub struct DistributedRuntime {
     // Registry for /engine/* route callbacks
     engine_routes: crate::engine_routes::EngineRouteRegistry,
 
+    // Backs `/v1/metadata/{model_slug}/{filename}`.
+    metadata_artifacts: crate::metadata_registry::MetadataArtifactRegistry,
+
     // Resolved event transport kind — set once at construction time from
     // DYN_EVENT_PLANE + discovery backend; returned by default_event_transport_kind().
     event_transport_kind: crate::discovery::EventTransportKind,
@@ -205,6 +208,7 @@ impl DistributedRuntime {
             request_plane,
             local_endpoint_registry: crate::local_endpoint_registry::LocalEndpointRegistry::new(),
             engine_routes: crate::engine_routes::EngineRouteRegistry::new(),
+            metadata_artifacts: crate::metadata_registry::MetadataArtifactRegistry::new(),
             event_transport_kind,
         };
 
@@ -331,6 +335,10 @@ impl DistributedRuntime {
     /// Get the engine route registry for registering custom /engine/* routes
     pub fn engine_routes(&self) -> &crate::engine_routes::EngineRouteRegistry {
         &self.engine_routes
+    }
+
+    pub fn metadata_artifacts(&self) -> &crate::metadata_registry::MetadataArtifactRegistry {
+        &self.metadata_artifacts
     }
 
     pub fn connection_id(&self) -> u64 {

--- a/lib/runtime/src/distributed.rs
+++ b/lib/runtime/src/distributed.rs
@@ -81,7 +81,7 @@ pub struct DistributedRuntime {
     // Registry for /engine/* route callbacks
     engine_routes: crate::engine_routes::EngineRouteRegistry,
 
-    // Backs `/v1/metadata/{model_slug}/{filename}`.
+    // Backs `/v1/metadata/{model_slug}/{model_suffix}/{filename}`.
     metadata_artifacts: crate::metadata_registry::MetadataArtifactRegistry,
 
     // Resolved event transport kind — set once at construction time from

--- a/lib/runtime/src/lib.rs
+++ b/lib/runtime/src/lib.rs
@@ -28,6 +28,7 @@ pub mod engine_routes;
 pub mod error;
 pub mod health_check;
 pub mod local_endpoint_registry;
+pub mod metadata_registry;
 pub mod system_status_server;
 pub use system_status_server::SystemStatusServerInfo;
 pub mod distributed;

--- a/lib/runtime/src/metadata_registry.rs
+++ b/lib/runtime/src/metadata_registry.rs
@@ -1,13 +1,17 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Process-local `(slug, suffix, filename) -> PathBuf` registry backing
-//! the system_status_server's `/v1/metadata/{slug}/{suffix}/{*filename}`
-//! handler.
+//! Worker-side index from a model metadata file's identity to its
+//! on-disk path. When a worker self-hosts metadata, it registers each
+//! file here and rewrites the MDC's `CheckedFile.path` to a
+//! `/v1/metadata/{slug}/{suffix}/{filename}` URL on its own
+//! `system_status_server`. The route handler reads paths back out by
+//! the same key and streams the bytes to the frontend, which
+//! blake3-verifies them against the MDC.
 //!
-//! `suffix` partitions registrations that share a slug — typically a
-//! LoRA slug, or `"_base"` for the base model. Without it, detaching
-//! one registration would wipe entries another still serves.
+//! `suffix` is the LoRA slug (or `"_base"` for non-LoRA). It scopes
+//! each registration so detaching a LoRA doesn't unregister the base
+//! model's files (or vice versa).
 
 use std::collections::HashMap;
 use std::path::PathBuf;

--- a/lib/runtime/src/metadata_registry.rs
+++ b/lib/runtime/src/metadata_registry.rs
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Process-local `(model_slug, filename) -> PathBuf` registry backing
+//! the system_status_server's `/v1/metadata/{model_slug}/{filename}`
+//! handler.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+
+/// Cloning shares the underlying map.
+#[derive(Clone, Debug, Default)]
+pub struct MetadataArtifactRegistry {
+    entries: Arc<RwLock<HashMap<(String, String), PathBuf>>>,
+}
+
+impl MetadataArtifactRegistry {
+    pub fn new() -> Self {
+        Self {
+            entries: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    pub fn register(&self, model_slug: &str, filename: &str, path: PathBuf) {
+        let mut entries = self.entries.write();
+        entries.insert((model_slug.to_string(), filename.to_string()), path);
+        tracing::debug!(model_slug, filename, "registered metadata artifact");
+    }
+
+    pub fn get(&self, model_slug: &str, filename: &str) -> Option<PathBuf> {
+        let entries = self.entries.read();
+        entries
+            .get(&(model_slug.to_string(), filename.to_string()))
+            .cloned()
+    }
+
+    /// Drop all entries for a model.
+    pub fn unregister_model(&self, model_slug: &str) {
+        let mut entries = self.entries.write();
+        entries.retain(|(slug, _), _| slug != model_slug);
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.read().len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.read().is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn register_get_roundtrip() {
+        let reg = MetadataArtifactRegistry::new();
+        let p = PathBuf::from("/tmp/tokenizer.json");
+        reg.register("llama-3-8b", "tokenizer.json", p.clone());
+
+        assert_eq!(reg.get("llama-3-8b", "tokenizer.json"), Some(p));
+        assert!(reg.get("llama-3-8b", "missing.json").is_none());
+    }
+
+    #[test]
+    fn unregister_model_removes_only_its_entries() {
+        let reg = MetadataArtifactRegistry::new();
+        reg.register("m1", "config.json", PathBuf::from("/m1/c"));
+        reg.register("m1", "tokenizer.json", PathBuf::from("/m1/t"));
+        reg.register("m2", "config.json", PathBuf::from("/m2/c"));
+
+        reg.unregister_model("m1");
+
+        assert!(reg.get("m1", "config.json").is_none());
+        assert!(reg.get("m1", "tokenizer.json").is_none());
+        assert_eq!(reg.get("m2", "config.json"), Some(PathBuf::from("/m2/c")));
+        assert_eq!(reg.len(), 1);
+    }
+
+    #[test]
+    fn clone_shares_state() {
+        let reg = MetadataArtifactRegistry::new();
+        let reg2 = reg.clone();
+        reg.register("m", "f", PathBuf::from("/p"));
+        assert_eq!(reg2.get("m", "f"), Some(PathBuf::from("/p")));
+    }
+}

--- a/lib/runtime/src/metadata_registry.rs
+++ b/lib/runtime/src/metadata_registry.rs
@@ -104,12 +104,4 @@ mod tests {
         );
         assert_eq!(reg.len(), 1);
     }
-
-    #[test]
-    fn clone_shares_state() {
-        let reg = MetadataArtifactRegistry::new();
-        let reg2 = reg.clone();
-        reg.register("m", "_base", "f", PathBuf::from("/p"));
-        assert_eq!(reg2.get("m", "_base", "f"), Some(PathBuf::from("/p")));
-    }
 }

--- a/lib/runtime/src/metadata_registry.rs
+++ b/lib/runtime/src/metadata_registry.rs
@@ -1,9 +1,13 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Process-local `(model_slug, filename) -> PathBuf` registry backing
-//! the system_status_server's `/v1/metadata/{model_slug}/{filename}`
+//! Process-local `(slug, suffix, filename) -> PathBuf` registry backing
+//! the system_status_server's `/v1/metadata/{slug}/{suffix}/{*filename}`
 //! handler.
+//!
+//! `suffix` partitions registrations that share a slug — typically a
+//! LoRA slug, or `"_base"` for the base model. Without it, detaching
+//! one registration would wipe entries another still serves.
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -11,10 +15,18 @@ use std::sync::Arc;
 
 use parking_lot::RwLock;
 
+/// Sentinel `suffix` for non-LoRA registrations. LoRA suffixes are
+/// `Slug::slugify` outputs (`[a-z0-9_-]+`); a name that slugifies to
+/// `_base` would collide with this sentinel and is not supported.
+pub const BASE_SUFFIX: &str = "_base";
+
+/// `(slug, suffix, filename)`.
+type Key = (String, String, String);
+
 /// Cloning shares the underlying map.
 #[derive(Clone, Debug, Default)]
 pub struct MetadataArtifactRegistry {
-    entries: Arc<RwLock<HashMap<(String, String), PathBuf>>>,
+    entries: Arc<RwLock<HashMap<Key, PathBuf>>>,
 }
 
 impl MetadataArtifactRegistry {
@@ -24,23 +36,26 @@ impl MetadataArtifactRegistry {
         }
     }
 
-    pub fn register(&self, model_slug: &str, filename: &str, path: PathBuf) {
+    pub fn register(&self, slug: &str, suffix: &str, filename: &str, path: PathBuf) {
         let mut entries = self.entries.write();
-        entries.insert((model_slug.to_string(), filename.to_string()), path);
-        tracing::debug!(model_slug, filename, "registered metadata artifact");
+        entries.insert(
+            (slug.to_string(), suffix.to_string(), filename.to_string()),
+            path,
+        );
+        tracing::debug!(slug, suffix, filename, "registered metadata artifact");
     }
 
-    pub fn get(&self, model_slug: &str, filename: &str) -> Option<PathBuf> {
+    pub fn get(&self, slug: &str, suffix: &str, filename: &str) -> Option<PathBuf> {
         let entries = self.entries.read();
         entries
-            .get(&(model_slug.to_string(), filename.to_string()))
+            .get(&(slug.to_string(), suffix.to_string(), filename.to_string()))
             .cloned()
     }
 
-    /// Drop all entries for a model.
-    pub fn unregister_model(&self, model_slug: &str) {
+    /// Drop entries for a single registration scoped by `(slug, suffix)`.
+    pub fn unregister(&self, slug: &str, suffix: &str) {
         let mut entries = self.entries.write();
-        entries.retain(|(slug, _), _| slug != model_slug);
+        entries.retain(|(s, sx, _), _| !(s == slug && sx == suffix));
     }
 
     pub fn len(&self) -> usize {
@@ -60,24 +75,29 @@ mod tests {
     fn register_get_roundtrip() {
         let reg = MetadataArtifactRegistry::new();
         let p = PathBuf::from("/tmp/tokenizer.json");
-        reg.register("llama-3-8b", "tokenizer.json", p.clone());
+        reg.register("llama-3-8b", "_base", "tokenizer.json", p.clone());
 
-        assert_eq!(reg.get("llama-3-8b", "tokenizer.json"), Some(p));
-        assert!(reg.get("llama-3-8b", "missing.json").is_none());
+        assert_eq!(reg.get("llama-3-8b", "_base", "tokenizer.json"), Some(p));
+        assert!(reg.get("llama-3-8b", "_base", "missing.json").is_none());
+        assert!(reg.get("llama-3-8b", "lora-v1", "tokenizer.json").is_none());
     }
 
     #[test]
-    fn unregister_model_removes_only_its_entries() {
+    fn unregister_only_removes_matching_suffix() {
         let reg = MetadataArtifactRegistry::new();
-        reg.register("m1", "config.json", PathBuf::from("/m1/c"));
-        reg.register("m1", "tokenizer.json", PathBuf::from("/m1/t"));
-        reg.register("m2", "config.json", PathBuf::from("/m2/c"));
+        reg.register("m", "_base", "config.json", PathBuf::from("/m/c"));
+        reg.register("m", "_base", "tokenizer.json", PathBuf::from("/m/t"));
+        reg.register("m", "lora-v1", "config.json", PathBuf::from("/m/c"));
 
-        reg.unregister_model("m1");
+        reg.unregister("m", "_base");
 
-        assert!(reg.get("m1", "config.json").is_none());
-        assert!(reg.get("m1", "tokenizer.json").is_none());
-        assert_eq!(reg.get("m2", "config.json"), Some(PathBuf::from("/m2/c")));
+        assert!(reg.get("m", "_base", "config.json").is_none());
+        assert!(reg.get("m", "_base", "tokenizer.json").is_none());
+        // LoRA entry on the same slug survives detach of the base.
+        assert_eq!(
+            reg.get("m", "lora-v1", "config.json"),
+            Some(PathBuf::from("/m/c"))
+        );
         assert_eq!(reg.len(), 1);
     }
 
@@ -85,7 +105,7 @@ mod tests {
     fn clone_shares_state() {
         let reg = MetadataArtifactRegistry::new();
         let reg2 = reg.clone();
-        reg.register("m", "f", PathBuf::from("/p"));
-        assert_eq!(reg2.get("m", "f"), Some(PathBuf::from("/p")));
+        reg.register("m", "_base", "f", PathBuf::from("/p"));
+        assert_eq!(reg2.get("m", "_base", "f"), Some(PathBuf::from("/p")));
     }
 }

--- a/lib/runtime/src/system_status_server.rs
+++ b/lib/runtime/src/system_status_server.rs
@@ -216,6 +216,15 @@ pub async fn spawn_system_status_server(
             );
     }
 
+    // Self-hosted MDC files. Always mounted; empty registry → 404.
+    app = app.route(
+        "/v1/metadata/{model_slug}/{*filename}",
+        get({
+            let state = Arc::clone(&server_state);
+            move |path| metadata_file_handler(State(state), path)
+        }),
+    );
+
     let app = app
         .fallback(|| async {
             tracing::info!("[fallback handler] called");
@@ -472,6 +481,39 @@ async fn list_loras_handler(State(state): State<Arc<SystemStatusState>>) -> impl
                     count: None,
                 }),
             )
+        }
+    }
+}
+
+/// `GET /v1/metadata/{model_slug}/{filename}` — 404 on miss,
+/// 500 on read error, raw bytes on hit. Consumer blake3-verifies.
+async fn metadata_file_handler(
+    State(state): State<Arc<SystemStatusState>>,
+    Path((model_slug, filename)): Path<(String, String)>,
+) -> impl IntoResponse {
+    let path = match state.drt().metadata_artifacts().get(&model_slug, &filename) {
+        Some(p) => p,
+        None => {
+            tracing::debug!(
+                model_slug,
+                filename,
+                "metadata artifact not registered for self-host"
+            );
+            return (StatusCode::NOT_FOUND, "Not found").into_response();
+        }
+    };
+
+    match tokio::fs::read(&path).await {
+        Ok(bytes) => (StatusCode::OK, bytes).into_response(),
+        Err(err) => {
+            tracing::error!(
+                model_slug,
+                filename,
+                path = %path.display(),
+                %err,
+                "failed to read self-hosted metadata file"
+            );
+            (StatusCode::INTERNAL_SERVER_ERROR, "Failed to read file").into_response()
         }
     }
 }

--- a/lib/runtime/src/system_status_server.rs
+++ b/lib/runtime/src/system_status_server.rs
@@ -217,8 +217,10 @@ pub async fn spawn_system_status_server(
     }
 
     // Self-hosted MDC files. Always mounted; empty registry → 404.
+    // Suffix segment scopes per-registration (LoRA slug, or `_base`)
+    // so detaching one registration doesn't wipe another's entries.
     app = app.route(
-        "/v1/metadata/{model_slug}/{*filename}",
+        "/v1/metadata/{model_slug}/{model_suffix}/{*filename}",
         get({
             let state = Arc::clone(&server_state);
             move |path| metadata_file_handler(State(state), path)
@@ -485,17 +487,22 @@ async fn list_loras_handler(State(state): State<Arc<SystemStatusState>>) -> impl
     }
 }
 
-/// `GET /v1/metadata/{model_slug}/{filename}` — 404 on miss,
+/// `GET /v1/metadata/{slug}/{suffix}/{filename}` — 404 on miss,
 /// 500 on read error, raw bytes on hit. Consumer blake3-verifies.
 async fn metadata_file_handler(
     State(state): State<Arc<SystemStatusState>>,
-    Path((model_slug, filename)): Path<(String, String)>,
+    Path((model_slug, model_suffix, filename)): Path<(String, String, String)>,
 ) -> impl IntoResponse {
-    let path = match state.drt().metadata_artifacts().get(&model_slug, &filename) {
+    let path = match state
+        .drt()
+        .metadata_artifacts()
+        .get(&model_slug, &model_suffix, &filename)
+    {
         Some(p) => p,
         None => {
             tracing::debug!(
                 model_slug,
+                model_suffix,
                 filename,
                 "metadata artifact not registered for self-host"
             );
@@ -508,6 +515,7 @@ async fn metadata_file_handler(
         Err(err) => {
             tracing::error!(
                 model_slug,
+                model_suffix,
                 filename,
                 path = %path.display(),
                 %err,

--- a/tests/frontend/test_self_host_metadata.py
+++ b/tests/frontend/test_self_host_metadata.py
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""End-to-end tests for worker-self-hosted metadata files (gh-8749).
+
+Single-worker check: opt the mocker into self-host via
+`DYN_SELF_HOST_METADATA=true`, then `requests.get` the
+`/v1/metadata/{slug}/{suffix}/{filename}` route on the worker's own
+`system_status_server`. No frontend resolution involved — this only
+exercises the worker producer + HTTP route shipped in PR1 (#8855).
+
+Scope grows as later PRs land — PR2 will add frontend
+verify-and-cache assertions; PR4 will add multi-replica + LoRA cases.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+import requests
+
+from tests.frontend.conftest import MockerWorkerProcess, wait_for_http_completions_ready
+from tests.utils.constants import QWEN
+
+logger = logging.getLogger(__name__)
+
+TEST_MODEL = QWEN
+
+pytestmark = [
+    pytest.mark.gpu_0,  # mocker is CPU-only
+    pytest.mark.e2e,
+    pytest.mark.post_merge,
+    pytest.mark.model(TEST_MODEL),
+]
+
+
+_SLUG_KEEP = set("abcdefghijklmnopqrstuvwxyz0123456789-_")
+
+
+def _slugify(name: str) -> str:
+    """Mirror of `dynamo_runtime::slug::Slug::slugify` for URL construction.
+
+    Lowercase, then replace any char outside `[a-z0-9_-]` with `_`, then
+    strip leading underscores.
+    """
+    out = "".join(c if c in _SLUG_KEEP else "_" for c in name.lower())
+    return out.lstrip("_")
+
+
+@pytest.mark.timeout(120)
+def test_worker_serves_metadata_via_http(
+    request,
+    start_services_with_http,
+    predownload_tokenizers,
+) -> None:
+    """Worker advertises `/v1/metadata/...`; assert curl returns the file."""
+    frontend_port, system_port = start_services_with_http
+
+    with MockerWorkerProcess(
+        request,
+        TEST_MODEL,
+        frontend_port,
+        system_port,
+        worker_id="self-host-mocker",
+        extra_env={"DYN_SELF_HOST_METADATA": "true"},
+    ):
+        # Wait until the model registration has fully propagated through
+        # discovery — proxy for the worker having opted into self-host.
+        wait_for_http_completions_ready(frontend_port=frontend_port, model=TEST_MODEL)
+
+        slug = _slugify(TEST_MODEL)
+        suffix = "_base"  # BASE_SUFFIX in lib/runtime/src/metadata_registry.rs
+
+        url = f"http://localhost:{system_port}/v1/metadata/{slug}/{suffix}/config.json"
+        response = requests.get(url, timeout=10)
+        assert (
+            response.status_code == 200
+        ), f"GET {url} returned {response.status_code}: {response.text}"
+        # config.json is JSON — body should parse and look like a HF config.
+        parsed = json.loads(response.content)
+        assert isinstance(parsed, dict), f"expected dict, got {type(parsed)}"
+        assert (
+            "model_type" in parsed or "architectures" in parsed
+        ), f"config.json missing expected HF keys: {sorted(parsed)}"
+
+        # Unknown filename under the same (slug, suffix) → 404.
+        miss = requests.get(
+            f"http://localhost:{system_port}/v1/metadata/{slug}/{suffix}/missing.json",
+            timeout=5,
+        )
+        assert miss.status_code == 404, miss.text
+
+        logger.info(
+            "self-host metadata verified: %s/%s/config.json served from worker on port %d",
+            slug,
+            suffix,
+            system_port,
+        )


### PR DESCRIPTION
First slice of #8749. Companion to #8754, which stays open as the integration capstone — once this lands, #8754 rebases against main and the next slice (frontend verify-and-cache) extracts cleanly.

## Scope of this PR

Worker side only. Opt-in via `DYN_SELF_HOST_METADATA=true` (default OFF) or `register_model(..., self_host_metadata=True)`. When opted in, `LocalModel::attach()` walks the MDC's typed `CheckedFile` slots, registers each local-disk path in a process-local registry on `DistributedRuntime`, and rewrites `cf.path` to `http://<worker>/v1/metadata/<slug>/<filename>`. URL slots (`hf://`, etc.) are left alone so existing transports keep working.

Three commits:

1. **`feat(runtime)`** — `MetadataArtifactRegistry` + `DistributedRuntime::metadata_artifacts()` accessor + always-mounted `GET /v1/metadata/{slug}/{*filename}` route on `system_status_server` (empty registry → 404).
2. **`feat(checked-file)`** — wire-format addition: `CheckedFile.size: Option<u64>`, populated by `from_disk`, additive serde so legacy MDC bytes deserialize cleanly with `size = None`.
3. **`feat(self-host)`** — worker producer: `LocalModelBuilder::self_host_metadata` setter, `move_to_self_host`, `self_host_base_url`, `DYN_SELF_HOST_METADATA` env (default OFF), `register_model(..., self_host_metadata=...)` Python kwarg, plus `iter_metadata_files{,_mut}` slot iterators on the MDC.

## Why default OFF

The frontend verify-and-cache pipeline ships in a follow-up. Without it, a frontend seeing an `http://` URL in a custom-template slot trips the `update_dir` `is_custom` exclusion and downstream `from_mdc` fails on `path() == None`. Default-OFF means existing deployments are unaffected; opt-in users with custom templates get a clean error, not silent breakage. Default flips to ON in the capstone PR once the consumer is in place.

## What's NOT here

Deferred to follow-up PRs (tracked under #8749 / #8754):
- Frontend `resolve_metadata_files` + `BlobLock` + `stage_and_rename` + verify-and-cache.
- `update_dir` `is_custom` exclusion fix.
- Mocker e2e + multi-replica integration tests.
- Default-ON flip.

## Tests

4 unit tests:
- `metadata_registry::tests` — register/get roundtrip, unregister scope, `Arc<RwLock>` aliasing across clones.
- `local_model::env_self_host_metadata_tests::env_default_parsing` — exhaustive truthy/falsy/empty/garbage env-var parsing (serial_test gated).

No new tests for the wire-format `size` field — pre-existing `CheckedFile` round-trip tests cover it implicitly via `from_disk`. Worker→frontend e2e is intentionally deferred to the capstone PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8855" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now optionally enable self-hosting of model metadata artifacts during model registration
  * New metadata serving endpoint provides access to registered model metadata files with appropriate HTTP responses
  * File size information is now tracked for model metadata artifacts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->