### PR TITLE
fix(test): revert compliance test to post_merge (non-gating)

### DIFF
--- a/tests/frontend/test_frontend_api_surface_compliance.py
+++ b/tests/frontend/test_frontend_api_surface_compliance.py
@@ -377,7 +377,7 @@ def _claude_cli(_tools_cache, _node_bin) -> Path:
 @pytest.mark.timeout(750)
 @pytest.mark.frontend_api_surface_compliance
 @pytest.mark.post_merge
-@pytest.mark.xfail("DYN-2924 assigned to Ishan")
+@pytest.mark.xfail(reason="DYN-2924 assigned to Ishan")
 def test_frontend_api_surface_compliance(
     request,
     runtime_services_dynamic_ports,

--- a/tests/frontend/test_frontend_api_surface_compliance.py
+++ b/tests/frontend/test_frontend_api_surface_compliance.py
@@ -376,7 +376,7 @@ def _claude_cli(_tools_cache, _node_bin) -> Path:
 # masking real hangs.
 @pytest.mark.timeout(750)
 @pytest.mark.frontend_api_surface_compliance
-@pytest.mark.pre_merge
+@pytest.mark.post_merge
 def test_frontend_api_surface_compliance(
     request,
     runtime_services_dynamic_ports,

--- a/tests/frontend/test_frontend_api_surface_compliance.py
+++ b/tests/frontend/test_frontend_api_surface_compliance.py
@@ -377,6 +377,7 @@ def _claude_cli(_tools_cache, _node_bin) -> Path:
 @pytest.mark.timeout(750)
 @pytest.mark.frontend_api_surface_compliance
 @pytest.mark.post_merge
+@pytest.mark.xfail("DYN-2924 assigned to Ishan")
 def test_frontend_api_surface_compliance(
     request,
     runtime_services_dynamic_ports,


### PR DESCRIPTION
#### Overview

Reverts the frontend API surface compliance test from `@pytest.mark.pre_merge` back to `@pytest.mark.post_merge`, restoring its original non-gating design.

This test runs `codex exec` and `claude -p` against a real Qwen3-VL-2B model and asserts the LLM actually invokes a shell tool — inherently non-deterministic. It was explicitly designed as non-gating (#8283, commit `7a3735e04c`), with the author noting: *"Marker is outside `pre_merge` so the main sglang gate job's filter doesn't pick it up."* A later cherry-pick (`df72e2bf43`) accidentally switched it to `pre_merge`, causing flaky sglang CI failures that block unrelated PRs.

#### Details

The dedicated `frontend-api-surface-compliance-check` CI job still runs it on PRs for visibility — it just won't block merge. Once the signal is consistently stable, it can be promoted back to `pre_merge`.

#### Where should the reviewer start?

Line 379 of `tests/frontend/test_frontend_api_surface_compliance.py` — one-line change from `pre_merge` to `post_merge`.

#### Test Plan

- Verified the marker change matches the original design intent from commits `401eda9d31` and `7a3735e04c`
- The dedicated non-gating CI job (`frontend-api-surface-compliance-check`) is unaffected — it uses the `frontend_api_surface_compliance` marker, not `pre_merge`
- Sglang pre-merge gate filters on `pre_merge` marker — this test will no longer be picked up


🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8856" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the timing of frontend API surface compliance validation to run at a different phase of the CI pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->