### PR TITLE
fix: use latency ratio as minimum floor

### DIFF
--- a/components/src/dynamo/planner/config/planner_config.py
+++ b/components/src/dynamo/planner/config/planner_config.py
@@ -182,6 +182,9 @@ class PlannerConfig(BaseModel):
 
     @model_validator(mode="after")
     def _validate_config(self) -> "PlannerConfig":
+        if self.ttft <= 0:
+            raise ValueError(f"ttft must be > 0, got {self.ttft}")
+
         if self.report_interval_hours is not None:
             if (
                 not math.isfinite(self.report_interval_hours)

--- a/components/src/dynamo/planner/core/throughput_scaling.py
+++ b/components/src/dynamo/planner/core/throughput_scaling.py
@@ -257,14 +257,19 @@ class ThroughputScalingMixin:
             logger.warning("Prefill perf model not ready, skipping throughput scaling")
             self._diag_throughput_reason = "model_not_ready"
             return None
+        sla_floor = 1
         if ttft_ms > self._config.ttft:
             logger.warning(
                 f"Prefill TTFT SLA not met: {ttft_ms:.1f}ms > {self._config.ttft:.1f}ms"
             )
+            # Latency-driven floor
+            sla_floor = math.ceil(ttft_ms / self._config.ttft)
 
         self._diag_engine_rps_prefill = engine_rps
 
-        result = max(math.ceil(demand_rps / engine_rps), self._config.min_endpoint)
+        result = max(
+            math.ceil(demand_rps / engine_rps), sla_floor, self._config.min_endpoint
+        )
         logger.info(
             f"Prefill: {demand_rps:.2f} rps / {engine_rps:.2f} = {result}, "
             f"est_ttft={ttft_ms:.1f}ms, isl_raw={isl:.1f}, "

--- a/components/src/dynamo/planner/tests/unit/test_state_machine.py
+++ b/components/src/dynamo/planner/tests/unit/test_state_machine.py
@@ -417,6 +417,37 @@ class TestThroughputScaling:
         assert core._throughput_lower_bound_d >= 1
         assert effects.diagnostics.throughput_decision_reason == "set_lower_bound"
 
+    def test_ttft_sla_floor_overrides_throughput_ratio_under_backpressure(self):
+        """Regression: when demand_rps << engine_rps (backpressure), the latency
+        violation must still drive scale-up rather than resolving to 1."""
+        # ttft_sla=200ms; regression gives wt(1000 tokens) ≈ 1.002s → ttft≈1002ms.
+        # sla_floor = ceil(1002/200) = 6.  With near-zero demand the raw
+        # ceil(demand_rps/engine_rps) would return 1 without the fix.
+        core = _make_core(
+            mode="prefill",
+            enable_load_scaling=False,
+            enable_throughput_scaling=True,
+            ttft=200.0,
+        )
+        _train_prefill_regression(core)
+
+        # Tiny demand to reproduce the backpressure equilibrium
+        core._observe_traffic(
+            TrafficObservation(duration_s=60, num_req=1, isl=1000, osl=150)
+        )
+
+        tick = TickInput(
+            now_s=60.0,
+            traffic=TrafficObservation(duration_s=60, num_req=1, isl=1000, osl=150),
+            worker_counts=WorkerCounts(ready_num_prefill=1),
+        )
+        effects = core.on_tick(_tick_for(tick), tick)
+        assert effects.scale_to is not None
+        # ceil(demand_rps/engine_rps) = ceil(0.017/1.0) = 1 without the floor.
+        # With the SLA floor: ceil(1002/200) = 6.
+        assert effects.scale_to.num_prefill is not None
+        assert effects.scale_to.num_prefill >= 6
+
     def test_next_tick_scheduled_after_traffic(self):
         core = _make_core(mode="prefill")
         tick = TickInput(


### PR DESCRIPTION
#### Overview:

Latency-driven floor: request completion rate is capped by backpressure and cannot signal saturation via the throughput ratio alone. Scale proportionally to the violation so the per-engine queue shrinks. 

#### Details:

The Planner decides how many prefill replicas to run by watching the request completion rate at the frontend (`demand_rps`) and dividing by how fast one engine can process requests (`engine_rps`). The problem is that `demand_rps` is measured at the output of the system, not the input. When the engine is overwhelmed, clients block waiting for responses and new requests stop landing until old ones finish, which causes ceil(demand_rps / engine_rps) to always rounds to 1 no matter how many clients are hammering it.

Meanwhile Planner does detect the latency violation — it predicts TTFT and logs the warning — but that signal feeds into nothing. It's a dead branch: warn, then compute the same formula that always gives 1. The fix uses the latency ratio as a floor. If the predicted TTFT is 218ms against a 200ms target, ceil(218/200) = 2 — scale to at least 2 replicas. That halves the queue per engine, which cuts the queueing component of TTFT. It's a heuristic, but it at least connects the violation signal to the decision.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8861" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Prefill replica scaling now enforces latency SLA compliance by ensuring a minimum replica count when predicted first-token latency exceeds configured targets.

* **Tests**
  * Added regression test validating SLA-driven scaling behavior under backpressure and low-demand conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->