### PR TITLE
fix: add retry to tool calling integration tests as the model might not be deterministic

### DIFF
--- a/container/deps/requirements.test.txt
+++ b/container/deps/requirements.test.txt
@@ -37,6 +37,7 @@ pytest-forked==1.6.0
 pytest-httpserver==1.1.3
 pytest-md-report==0.7.0
 pytest-order==1.3.0
+pytest-rerunfailures==16.1
 pytest-timeout==2.4.0
 pytest-xdist==3.8.0
 requests==2.32.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -289,6 +289,7 @@ markers = [
     "asyncio: asyncio test marker",
     # Third-party plugin markers
     "timeout: test timeout in seconds (pytest-timeout plugin)",
+    "flaky: rerun a flaky test on failure (pytest-rerunfailures plugin)",
 ]
 
 # Linting/formatting

--- a/tests/frontend/test_tool_calling_sglang.py
+++ b/tests/frontend/test_tool_calling_sglang.py
@@ -15,6 +15,7 @@ Validates:
 
 from __future__ import annotations
 
+import functools
 import json
 import logging
 import os
@@ -656,12 +657,37 @@ def assistant_tool_message_from_result(result: StreamResult) -> dict[str, Any]:
     }
 
 
+def retry_on_assertion(test_func):
+    """Retry a test once if it raises ``AssertionError``.
+
+    Why: model output is non-deterministic, and a single unlucky generation
+    can flip an assertion that would pass on a re-roll. Retrying once
+    smooths over that variance without masking real regressions, which
+    would fail both attempts.
+    """
+
+    @functools.wraps(test_func)
+    def wrapper(*args, **kwargs):
+        try:
+            return test_func(*args, **kwargs)
+        except AssertionError as exc:
+            logger.warning(
+                "Test %s failed first attempt with AssertionError: %s. Retrying once.",
+                test_func.__name__,
+                exc,
+            )
+            return test_func(*args, **kwargs)
+
+    return wrapper
+
+
 # ---------------------------------------------------------------------------
 # Protocol / contract tests
 # ---------------------------------------------------------------------------
 
 
 class TestToolCallingProtocol:
+    @retry_on_assertion
     def test_stream_has_required_chunk_shape(self, client: OpenAI, model: str):
         stream = client.chat.completions.create(
             model=model,
@@ -690,6 +716,7 @@ class TestToolCallingProtocol:
         assert chunk_count > 0
         assert saw_finish, "stream never emitted a finish_reason"
 
+    @retry_on_assertion
     def test_single_tool_call_schema_valid(self, client: OpenAI, model: str):
         result = stream_chat(
             client,
@@ -708,6 +735,7 @@ class TestToolCallingProtocol:
         assert isinstance(args["city"], str)
         assert args["city"]
 
+    @retry_on_assertion
     def test_tool_choice_required_forces_a_tool_call(self, client: OpenAI, model: str):
         result = stream_chat(
             client,
@@ -736,6 +764,7 @@ class TestToolCallingProtocol:
                     required_field in args
                 ), f"{fn_name} missing required field {required_field!r}"
 
+    @retry_on_assertion
     def test_tool_choice_none_suppresses_tool_calls(self, client: OpenAI, model: str):
         result = stream_chat(
             client,
@@ -748,6 +777,7 @@ class TestToolCallingProtocol:
         assert result.tool_calls == []
         assert result.content.strip()
 
+    @retry_on_assertion
     def test_named_tool_choice_forces_specific_function(
         self, client: OpenAI, model: str
     ):
@@ -764,6 +794,7 @@ class TestToolCallingProtocol:
         for tc in result.tool_calls:
             parse_and_validate_tool_call(tc, schema, expected_name="get_weather")
 
+    @retry_on_assertion
     def test_parallel_multi_tool_request_includes_all_expected_tools(
         self, client: OpenAI, model: str
     ):
@@ -794,6 +825,7 @@ class TestToolCallingProtocol:
             names.add(tc["function"]["name"])
         assert len(names) >= 2, f"expected at least 2 distinct tools, got {names}"
 
+    @retry_on_assertion
     def test_array_argument_schema_valid(self, client: OpenAI, model: str):
         tools = [
             {
@@ -840,6 +872,7 @@ class TestToolCallingProtocol:
         assert isinstance(args["recipients"], list)
         assert len(args["recipients"]) >= 3
 
+    @retry_on_assertion
     def test_no_tools_is_plain_text(self, client: OpenAI, model: str):
         result = stream_chat(
             client,
@@ -857,6 +890,7 @@ class TestToolCallingProtocol:
 
 
 class TestToolCallingMultiTurn:
+    @retry_on_assertion
     def test_tool_result_is_consumed_and_final_answer_is_text(
         self, client: OpenAI, model: str
     ):
@@ -895,6 +929,7 @@ class TestToolCallingMultiTurn:
         assert second.content.strip()
         assert "15" in second.content or "cloud" in second.content.lower()
 
+    @retry_on_assertion
     def test_chained_tool_use_search_then_calculate(self, client: OpenAI, model: str):
         schemas = tool_schema_map(TOOLS_SEARCH + TOOLS_CALCULATOR)
         messages: list[dict[str, Any]] = [
@@ -966,6 +1001,7 @@ class TestToolCallingMultiTurn:
             assert step2.tool_calls == []
             assert "1396000" in step2.content.replace(",", "")
 
+    @retry_on_assertion
     def test_multiple_prior_tool_results_synthesize_to_text(
         self, client: OpenAI, model: str
     ):
@@ -1027,6 +1063,7 @@ class TestToolCallingMultiTurn:
 
 
 class TestToolCallingModelBehavior:
+    @retry_on_assertion
     def test_many_tools_prefers_calculator_for_math_question(
         self, client: OpenAI, model: str
     ):
@@ -1043,6 +1080,7 @@ class TestToolCallingModelBehavior:
             assert len(result.tool_calls) >= 1
             assert result.tool_calls[0]["function"]["name"] == "calculate"
 
+    @retry_on_assertion
     def test_unicode_arguments_are_preserved(self, client: OpenAI, model: str):
         result = stream_chat(
             client,
@@ -1063,6 +1101,7 @@ class TestToolCallingModelBehavior:
             )
             assert args["city"]
 
+    @retry_on_assertion
     def test_system_instruction_encourages_tool_use(self, client: OpenAI, model: str):
         result = stream_chat(
             client,

--- a/tests/frontend/test_tool_calling_sglang.py
+++ b/tests/frontend/test_tool_calling_sglang.py
@@ -15,7 +15,6 @@ Validates:
 
 from __future__ import annotations
 
-import functools
 import json
 import logging
 import os
@@ -657,37 +656,12 @@ def assistant_tool_message_from_result(result: StreamResult) -> dict[str, Any]:
     }
 
 
-def retry_on_assertion(test_func):
-    """Retry a test once if it raises ``AssertionError``.
-
-    Why: model output is non-deterministic, and a single unlucky generation
-    can flip an assertion that would pass on a re-roll. Retrying once
-    smooths over that variance without masking real regressions, which
-    would fail both attempts.
-    """
-
-    @functools.wraps(test_func)
-    def wrapper(*args, **kwargs):
-        try:
-            return test_func(*args, **kwargs)
-        except AssertionError as exc:
-            logger.warning(
-                "Test %s failed first attempt with AssertionError: %s. Retrying once.",
-                test_func.__name__,
-                exc,
-            )
-            return test_func(*args, **kwargs)
-
-    return wrapper
-
-
 # ---------------------------------------------------------------------------
 # Protocol / contract tests
 # ---------------------------------------------------------------------------
 
 
 class TestToolCallingProtocol:
-    @retry_on_assertion
     def test_stream_has_required_chunk_shape(self, client: OpenAI, model: str):
         stream = client.chat.completions.create(
             model=model,
@@ -695,6 +669,8 @@ class TestToolCallingProtocol:
             tools=TOOLS_WEATHER,
             stream=True,
             max_tokens=256,
+            temperature=0,
+            seed=0,
         )
 
         chunk_count = 0
@@ -716,13 +692,14 @@ class TestToolCallingProtocol:
         assert chunk_count > 0
         assert saw_finish, "stream never emitted a finish_reason"
 
-    @retry_on_assertion
     def test_single_tool_call_schema_valid(self, client: OpenAI, model: str):
         result = stream_chat(
             client,
             model,
             messages=[{"role": "user", "content": "What's the weather in Tokyo?"}],
             tools=TOOLS_WEATHER,
+            temperature=0,
+            seed=0,
         )
         assert_finish_reason(result, {"tool_calls"})
         assert len(result.tool_calls) >= 1
@@ -735,7 +712,6 @@ class TestToolCallingProtocol:
         assert isinstance(args["city"], str)
         assert args["city"]
 
-    @retry_on_assertion
     def test_tool_choice_required_forces_a_tool_call(self, client: OpenAI, model: str):
         result = stream_chat(
             client,
@@ -743,6 +719,8 @@ class TestToolCallingProtocol:
             messages=[{"role": "user", "content": "Hello there."}],
             tools=TOOLS_WEATHER,
             tool_choice="required",
+            temperature=0,
+            seed=0,
         )
         assert_finish_reason(result, {"tool_calls"})
         assert len(result.tool_calls) >= 1
@@ -764,7 +742,6 @@ class TestToolCallingProtocol:
                     required_field in args
                 ), f"{fn_name} missing required field {required_field!r}"
 
-    @retry_on_assertion
     def test_tool_choice_none_suppresses_tool_calls(self, client: OpenAI, model: str):
         result = stream_chat(
             client,
@@ -772,12 +749,14 @@ class TestToolCallingProtocol:
             messages=[{"role": "user", "content": "What's the weather in Paris?"}],
             tools=TOOLS_WEATHER,
             tool_choice="none",
+            temperature=0,
+            seed=0,
         )
         assert_finish_reason(result, {"stop"})
         assert result.tool_calls == []
         assert result.content.strip()
 
-    @retry_on_assertion
+    @pytest.mark.flaky(reruns=2, only_rerun=["AssertionError"])
     def test_named_tool_choice_forces_specific_function(
         self, client: OpenAI, model: str
     ):
@@ -794,7 +773,7 @@ class TestToolCallingProtocol:
         for tc in result.tool_calls:
             parse_and_validate_tool_call(tc, schema, expected_name="get_weather")
 
-    @retry_on_assertion
+    @pytest.mark.flaky(reruns=2, only_rerun=["AssertionError"])
     def test_parallel_multi_tool_request_includes_all_expected_tools(
         self, client: OpenAI, model: str
     ):
@@ -825,7 +804,7 @@ class TestToolCallingProtocol:
             names.add(tc["function"]["name"])
         assert len(names) >= 2, f"expected at least 2 distinct tools, got {names}"
 
-    @retry_on_assertion
+    @pytest.mark.flaky(reruns=2, only_rerun=["AssertionError"])
     def test_array_argument_schema_valid(self, client: OpenAI, model: str):
         tools = [
             {
@@ -872,7 +851,7 @@ class TestToolCallingProtocol:
         assert isinstance(args["recipients"], list)
         assert len(args["recipients"]) >= 3
 
-    @retry_on_assertion
+    @pytest.mark.flaky(reruns=2, only_rerun=["AssertionError"])
     def test_no_tools_is_plain_text(self, client: OpenAI, model: str):
         result = stream_chat(
             client,
@@ -890,7 +869,7 @@ class TestToolCallingProtocol:
 
 
 class TestToolCallingMultiTurn:
-    @retry_on_assertion
+    @pytest.mark.flaky(reruns=2, only_rerun=["AssertionError"])
     def test_tool_result_is_consumed_and_final_answer_is_text(
         self, client: OpenAI, model: str
     ):
@@ -929,7 +908,7 @@ class TestToolCallingMultiTurn:
         assert second.content.strip()
         assert "15" in second.content or "cloud" in second.content.lower()
 
-    @retry_on_assertion
+    @pytest.mark.flaky(reruns=2, only_rerun=["AssertionError"])
     def test_chained_tool_use_search_then_calculate(self, client: OpenAI, model: str):
         schemas = tool_schema_map(TOOLS_SEARCH + TOOLS_CALCULATOR)
         messages: list[dict[str, Any]] = [
@@ -1001,7 +980,7 @@ class TestToolCallingMultiTurn:
             assert step2.tool_calls == []
             assert "1396000" in step2.content.replace(",", "")
 
-    @retry_on_assertion
+    @pytest.mark.flaky(reruns=2, only_rerun=["AssertionError"])
     def test_multiple_prior_tool_results_synthesize_to_text(
         self, client: OpenAI, model: str
     ):
@@ -1063,7 +1042,7 @@ class TestToolCallingMultiTurn:
 
 
 class TestToolCallingModelBehavior:
-    @retry_on_assertion
+    @pytest.mark.flaky(reruns=2, only_rerun=["AssertionError"])
     def test_many_tools_prefers_calculator_for_math_question(
         self, client: OpenAI, model: str
     ):
@@ -1080,7 +1059,7 @@ class TestToolCallingModelBehavior:
             assert len(result.tool_calls) >= 1
             assert result.tool_calls[0]["function"]["name"] == "calculate"
 
-    @retry_on_assertion
+    @pytest.mark.flaky(reruns=2, only_rerun=["AssertionError"])
     def test_unicode_arguments_are_preserved(self, client: OpenAI, model: str):
         result = stream_chat(
             client,
@@ -1101,7 +1080,7 @@ class TestToolCallingModelBehavior:
             )
             assert args["city"]
 
-    @retry_on_assertion
+    @pytest.mark.flaky(reruns=2, only_rerun=["AssertionError"])
     def test_system_instruction_encourages_tool_use(self, client: OpenAI, model: str):
         result = stream_chat(
             client,


### PR DESCRIPTION
#### Overview:

add retry to tool calling integration tests as the model might not be deterministic

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8862" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by implementing automatic retry logic for intermittent assertion failures in tool-calling and model-behavior tests, reducing flakiness in end-to-end testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->