### PR TITLE
feat(trtllm): bump TRT-LLM to HEAD (1.3.0rc14) and ship dynamo with a custom-wheel-by-default container build

### DIFF
--- a/container/context.yaml
+++ b/container/context.yaml
@@ -105,10 +105,10 @@ trtllm:
   python_version: "3.12"
   index_url: https://pypi.nvidia.com/
   pip_wheel_dir: /tmp/trtllm_wheel/
-  pip_wheel: tensorrt-llm==1.3.0rc11
+  pip_wheel: tensorrt-llm==1.3.0rc14
   trtllm_wheel_image: nvcr.io/nvidia/tensorrt-llm/release:${TENSORRTLLM_PIP_WHEEL#*==}
 
-  github_trtllm_commit: v1.3.0rc11
+  github_trtllm_commit: 3b7af1c21
   torch_version: 2.11.0a0+eb65b36914.nv26.2
   torch_tensorrt_version: 2.11.0a0
   torchvision_version: 0.25.0a0+1e53952f.nv26.2.44259020
@@ -120,4 +120,4 @@ trtllm:
   pytorch_triton_ver: 3.6.0+git9844da95.nv26.2
   flash_attn_version: 2.7.4.post1+nv26.2.44259020
   flashinfer_python_ver: 0.6.6
-  has_trtllm_context: "0"
+  has_trtllm_context: "1"

--- a/container/templates/trtllm_framework.Dockerfile
+++ b/container/templates/trtllm_framework.Dockerfile
@@ -7,12 +7,14 @@
 # Copy artifacts from NGC PyTorch image
 FROM ${BASE_IMAGE}:${BASE_IMAGE_TAG} AS pytorch_base
 
+{%- if context.trtllm.has_trtllm_context != "1" %}
 # Empty fallback for TRTLLM wheel image copy
 FROM alpine:3.20 AS trtllm_wheel_image_empty
 RUN mkdir -p /app/tensorrt_llm
 
 # Resolve TRTLLM wheel image (can be a stage name or a registry image)
 FROM ${TRTLLM_WHEEL_IMAGE} AS trtllm_wheel_image
+{%- endif %}
 
 ##################################################
 ########## Framework Builder Stage ##############
@@ -105,8 +107,9 @@ ARG GITHUB_TRTLLM_COMMIT
 {% if context.trtllm.has_trtllm_context == "1" %}
 # Copy only wheel files and commit info from trtllm_wheel stage from build_context
 COPY --from=trtllm_wheel / /trtllm_wheel/
-{%- endif %}
+{%- else %}
 COPY --from=trtllm_wheel_image /app/tensorrt_llm /trtllm_wheel_image/
+{%- endif %}
 
 # Cache uv downloads; uv handles its own locking for this cache.
 RUN --mount=type=cache,target=/root/.cache/uv \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ Repository = "https://github.com/ai-dynamo/dynamo.git"
 [project.optional-dependencies]
 trtllm =[
     "uvloop",
-    "tensorrt-llm==1.3.0rc11",
+    "tensorrt-llm==1.3.0rc14",
 ]
 
 vllm = [


### PR DESCRIPTION
## Summary

This PR shifts dynamo's TRT-LLM integration from "stock PyPI rc11 + nvcr release image" to "build-context wheel + TRT-LLM HEAD". It does three coupled things:

1. Bumps the `tensorrt-llm` pin from `1.3.0rc11` to `1.3.0rc14` (current `__version__` on TRT-LLM `main`) in `pyproject.toml` and `container/context.yaml`.
2. Switches the container default to the build-context wheel path: `has_trtllm_context: "0"` → `"1"`. The rendered Dockerfile now expects `--build-context trtllm_wheel=…` to be supplied at build time.
3. Bumps `github_trtllm_commit` from `v1.3.0rc11` to a pinned TRT-LLM `main` SHA (`3b7af1c21`, 2026-04-29) so `install_tensorrt.sh` matches the wheel's expected CUDA/TensorRT versions.

A precondition fix (commit 1) makes the rendered `has_trtllm_context: "1"` path independent of the published `nvcr.io/nvidia/tensorrt-llm/release:<ver>` image — which is what unblocks (2), since `1.3.0rc14` has no published release image yet.

## Why

All recent dynamo-trtllm images (the `dynamo-main-pr*` series, including the public dev images for disagg work) are already built with custom wheels. The current defaults — PyPI install of `tensorrt-llm==1.3.0rc11` + a release-image fallback — don't reflect how the framework is actually being shipped, and they require either a published release image or PyPI availability for the pinned version. Both of those gate fast iteration on TRT-LLM HEAD.

This change makes the BYO-wheel path the default, so anyone who wants to experiment with a HEAD-built TRT-LLM wheel can do so with stock dynamo render + `docker build --build-arg HAS_TRTLLM_CONTEXT=1 --build-context trtllm_wheel=…`.

## Backwards compatibility

The default flow becomes "build-context wheel required" — stock `docker build` without supplying a wheel will fail, because `1.3.0rc14` is not on PyPI yet either. Users who want the prior PyPI-fallback behaviour should pin `container/context.yaml` back to a published rc tag (`1.3.0rc13` is the latest at the time of writing).

## Commits

1. `fix(trtllm): make HAS_TRTLLM_CONTEXT=1 path independent of release image` — Jinja-gates the `trtllm_wheel_image` `FROM` stages and `COPY` on `has_trtllm_context != "1"`. Default render output is byte-identical to main; only the new `has_trtllm_context: "1"` render diverges.
2. `feat(trtllm): bump TRT-LLM pin to 1.3.0rc14 and switch container default to local wheel` — the pin bumps + default flip.

## Test plan

- [x] Render with default (post-PR `has_trtllm_context: "1"`): wheel_image stages and COPY are absent; `COPY --from=trtllm_wheel /` is present. Build no longer references `nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc14` (which doesn't exist).
- [x] Render with `has_trtllm_context: "0"` override: byte-identical to current main render (precondition fix is non-breaking).
- [x] **End-to-end build with TRT-LLM HEAD wheel.** Built TRT-LLM wheel from upstream `main` at `3b7af1c21` (no cherry-picks). Built dynamo image with this PR applied: `nvcr.io/goirlvsxnepa/llm_nim/dynamo-trtllm:pr8864-test-rc14` (`sha256:a1f3f6826b97…3e7a9b9c`). Wheel reported `Version: 1.3.0rc14`. Build succeeded with no `nvcr.io/.../release:*` reference resolved.
- [x] **Tier 1 import smoke** (with GPU runtime): `import dynamo.trtllm.{engine,workers.llm_worker,request_handlers.handler_base,health_check}` + `import tensorrt_llm` all succeed. `tensorrt_llm.__version__ == "1.3.0rc14"`.
- [x] **Tier 2 multihost disagg e2e** on dlcluster GB200 (1P:1D, Qwen3-Coder-30B-A3B, TP=1): brought up via `cluster_scripts/servers/gb200_multihost_start.sh`. `1/1` single completion + `10/10` concurrent completions all returned HTTP 200 with valid responses; prefill-node log confirms `component=prefill` for each request (disagg path actually exercised, not just aggregated). One pre-existing benign warning (`[kv cache manager] storeContextBlocks: Can not find sequence for request …`) — same as observed in the cherry-pick stack baseline; not introduced by rc14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)