### PR TITLE
chore: aiperf and aic version bump in release 1.1.0

### DIFF
--- a/ATTRIBUTIONS-Python.md
+++ b/ATTRIBUTIONS-Python.md
@@ -2158,7 +2158,7 @@ Apache License
   - `Homepage`: https://github.com/aio-libs/aiosignal
 
 
-## aiperf (0.6.0)
+## aiperf (0.7.0)
 
 ### Licenses
 License: `Apache-2.0`

--- a/benchmarks/pyproject.toml
+++ b/benchmarks/pyproject.toml
@@ -40,8 +40,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@1fe8084c817194827706947cc175107ee9e6ea25",
-    "aiperf==0.6.0",
+    "aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@3f6099ba27a12dc2d3889c00d04a888bec9bf33a",
+    "aiperf==0.7.0",
     "matplotlib",
     "networkx",
     "numpy",

--- a/container/deps/requirements.benchmark.txt
+++ b/container/deps/requirements.benchmark.txt
@@ -3,5 +3,5 @@
 
 # Benchmark and profiling tool dependencies.
 
-aiperf==0.6.0
+aiperf==0.7.0
 genai-perf==0.0.15

--- a/container/deps/requirements.planner.txt
+++ b/container/deps/requirements.planner.txt
@@ -3,7 +3,7 @@
 
 # Dependencies required by the planner, profiler, and global_planner services.
 
-aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@1fe8084c817194827706947cc175107ee9e6ea25
+aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@3f6099ba27a12dc2d3889c00d04a888bec9bf33a
 aiofiles<=25.1.0
 aiohttp>=3.9.0,<4.0
 filterpy==1.4.5

--- a/docs/benchmarks/kv-router-ab-testing.md
+++ b/docs/benchmarks/kv-router-ab-testing.md
@@ -454,7 +454,7 @@ spec:
           - -lc
           - |
             apt-get update -qq && apt-get install -y -qq tmux > /dev/null 2>&1
-            pip install -q aiperf==0.5.0
+            pip install -q aiperf==0.7.0
             echo "Benchmark pod ready (tmux + aiperf installed)."
             sleep infinity
         imagePullPolicy: IfNotPresent

--- a/recipes/deepseek-v32-fp4/trtllm/agg-round-robin/perf.yaml
+++ b/recipes/deepseek-v32-fp4/trtllm/agg-round-robin/perf.yaml
@@ -49,7 +49,7 @@ spec:
           echo 1024 > /proc/sys/fs/inotify/max_user_instances 2>/dev/null || true
           apt-get update && apt-get install -y curl jq procps git && apt-get clean
           # pip install git+https://github.com/ai-dynamo/aiperf.git
-          pip install aiperf==0.6.0
+          pip install aiperf==0.7.0
           echo "aiperf installation completed"
           sysctl -w net.ipv4.ip_local_port_range="1024 65000" 2>/dev/null || true
           export COLUMNS=200

--- a/recipes/deepseek-v32-fp4/trtllm/disagg-kv-router/perf.yaml
+++ b/recipes/deepseek-v32-fp4/trtllm/disagg-kv-router/perf.yaml
@@ -49,7 +49,7 @@ spec:
           echo 1024 > /proc/sys/fs/inotify/max_user_instances 2>/dev/null || true
           apt-get update && apt-get install -y curl jq procps git && apt-get clean
           # pip install git+https://github.com/ai-dynamo/aiperf.git
-          pip install aiperf==0.6.0
+          pip install aiperf==0.7.0
           echo "aiperf installation completed"
           sysctl -w net.ipv4.ip_local_port_range="1024 65000" 2>/dev/null || true
           export COLUMNS=200


### PR DESCRIPTION
#### Overview:

version bump for aiperf and aic in release 1.1.0

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8867" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
