### PR TITLE
docs: add DYN_EVENT_PLANE=zmq to hello_world example commands - CP #8847

### DIFF
--- a/examples/custom_backend/hello_world/README.md
+++ b/examples/custom_backend/hello_world/README.md
@@ -57,17 +57,18 @@ Dynamo must be installed. No external services are required for local developmen
 First, start the backend service:
 ```bash
 cd examples/custom_backend/hello_world
-DYN_DISCOVERY_BACKEND=file python hello_world.py
+DYN_DISCOVERY_BACKEND=file DYN_EVENT_PLANE=zmq python hello_world.py
 ```
 
 Second, in a separate terminal, run the client:
 ```bash
 cd examples/custom_backend/hello_world
-DYN_DISCOVERY_BACKEND=file python client.py
+DYN_DISCOVERY_BACKEND=file DYN_EVENT_PLANE=zmq python client.py
 ```
 
-> **Note**: Setting `DYN_DISCOVERY_BACKEND=file` uses file-based discovery instead of etcd.
-> Both the backend and client must use the same discovery backend to discover each other.
+> **Note**: Setting `DYN_DISCOVERY_BACKEND=file` uses file-based discovery instead of etcd,
+> and `DYN_EVENT_PLANE=zmq` uses ZMQ instead of NATS for the event plane.
+> Both the backend and client must use the same settings to discover each other.
 
 The client will connect to the backend service and print the streaming results.
 


### PR DESCRIPTION
## Summary
- Cherry-pick of #8847 to release/1.1.0
- Adds missing DYN_EVENT_PLANE=zmq environment variable to hello_world example commands so they work out of the box without NATS

Fixes DYN-2743
Fixes https://nvbugs/6094394

## Original PR
- Main PR: #8847
- Merge commit: 86a942a14964

## Test plan
- [ ] CI passes
- [ ] Verified fix works on release branch

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8869" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
