### PR TITLE
chore(container): bump tensorrt-llm pin from 1.3.0rc11 to 1.3.0rc13

### DIFF
--- a/container/context.yaml
+++ b/container/context.yaml
@@ -105,10 +105,10 @@ trtllm:
   python_version: "3.12"
   index_url: https://pypi.nvidia.com/
   pip_wheel_dir: /tmp/trtllm_wheel/
-  pip_wheel: tensorrt-llm==1.3.0rc11
+  pip_wheel: tensorrt-llm==1.3.0rc13
   trtllm_wheel_image: nvcr.io/nvidia/tensorrt-llm/release:${TENSORRTLLM_PIP_WHEEL#*==}
 
-  github_trtllm_commit: v1.3.0rc11
+  github_trtllm_commit: v1.3.0rc13
   torch_version: 2.11.0a0+eb65b36914.nv26.2
   torch_tensorrt_version: 2.11.0a0
   torchvision_version: 0.25.0a0+1e53952f.nv26.2.44259020

--- a/container/deps/requirements.common.txt
+++ b/container/deps/requirements.common.txt
@@ -30,7 +30,7 @@ tensorboard>=2.19.0,<2.21.0
 tensorboardX==2.6.2.2
 # Transformers version constraint for container builds
 # - vLLM 0.11.0: >=4.55.2, vLLM 0.11.2: >=4.56.0,<5
-# - TensorRT-LLM 1.3.0rc11: ==4.57.3
+# - TensorRT-LLM 1.3.0rc13: ==4.57.3
 # - SGLang 0.5.8: ==4.57.1
 # Using >=4.56.0 to satisfy all frameworks
 transformers>=4.56.0

--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -34,7 +34,7 @@ The following table shows the backend framework versions included with each Dyna
 
 | **Dynamo** | **SGLang** | **TensorRT-LLM** | **vLLM** | **NIXL** |
 | :--- | :--- | :--- | :--- | :--- |
-| **main (ToT)** | `0.5.10.post1` | `1.3.0rc11` | `0.20.0` | `0.10.1` |
+| **main (ToT)** | `0.5.10.post1` | `1.3.0rc13` | `0.20.0` | `0.10.1` |
 | **v1.1.0-dev.3** *(experimental, partial)* | `0.5.10.post1` | `1.3.0rc11` | `0.19.0` | `0.10.1` |
 | **v1.1.0-dev.2** *(experimental, partial)* | `0.5.9` | `1.3.0rc9` | `0.19.0` | `0.10.1` |
 | **v1.1.0-dev.1** *(experimental)* | `0.5.9` | `1.3.0rc5.post1` | `0.17.1` | `0.10.1` |


### PR DESCRIPTION
## Summary

Bump the default `tensorrt-llm` PyPI pin in `container/context.yaml` from `1.3.0rc11` (tagged 2026-04-07) to `1.3.0rc13` (tagged 2026-04-26). rc13 is the first published release tag that includes [NVIDIA/TensorRT-LLM#12976](https://github.com/NVIDIA/TensorRT-LLM/pull/12976) ("Fix compute token accounting for KV cache reuse with context chunking"), the C++ admission fix for [NVIDIA/TensorRT-LLM#13318](https://github.com/NVIDIA/TensorRT-LLM/issues/13318).

## Tag-by-tag verification

Verified by checking `cpp/tensorrt_llm/batch_manager/microBatchScheduler.cpp` on each tag tree:

| Tag | Date | `reuse_adjusted_compute` count | Has admission fix? |
|---|---|---|---|
| `v1.3.0rc11` (`4e69c14f7`) | 2026-04-07 | 0 | ❌ |
| `v1.3.0rc12` (`61cef212a`) | 2026-04-16 | 0 | ❌ (rc12 was cut 2 days before #12976 merged) |
| `v1.3.0rc13` (`b9ce4b69d`) | 2026-04-26 | 10 (1 static helper def + 9 call sites) | ✅ |

So rc11 → rc13 is the smallest possible jump that brings in the upstream fix. rc12 is intentionally skipped — it does not include the fix.

## Why this matters

Without the C++ admission fix, dynamo + TRT-LLM under workloads that combine `enable_chunked_prefill: true`, `enable_block_reuse: true`, and tight `max_num_tokens` can hit:

```
AssertionError: total_num_tokens (N) should be less than or equal to max_num_tokens (M)
```

(reproducible on rc11 with Qwen3-4B / GB200 + multi-turn-chat replay at qps≥12; for the same workload, an image built with the rc13 wheel does not crash). The bug is C++-side: chunked-prefill non-first-chunk admissions were over-admitted relative to `max_num_tokens` because the scheduler did not subtract the discounted reuse cost correctly. PR #12976 fixes the math at admission time.

## Files changed

- `container/context.yaml` — `pip_wheel: tensorrt-llm==1.3.0rc11` → `rc13` and `github_trtllm_commit: v1.3.0rc11` → `v1.3.0rc13` (the second key drives the URL we curl `install_tensorrt.sh` from in `container/templates/trtllm_framework.Dockerfile:129`).
- `container/deps/requirements.common.txt` — comment-only update on the `transformers` constraint line (rc11 → rc13; same `==4.57.3` constraint applies, no actual `transformers` pin change).
- `docs/reference/support-matrix.md` — bump the `**main (ToT)**` row's TRT-LLM column from `1.3.0rc11` → `1.3.0rc13`. The historical `v1.1.0-dev.3` row stays at `1.3.0rc11` because that release shipped with rc11 — that is a fact about the past.

`docs/reference/release-artifacts.md` is intentionally **not** changed: every `1.3.0rc11` reference in that file is in the `v1.1.0-dev.3` release-history section (lines 169 / 587 / 594), describing what that past release shipped — historical, not ToT.

## Verification done locally

- ARM64 (GB200) container built with this change pulls `tensorrt-llm==1.3.0rc13` from `pypi.nvidia.com` cleanly. `has_trtllm_context: "0"` path; no custom wheel.
- The shipped `libtensorrt_llm.so` matches the rc13 release wheel (provenance confirms #12976's C++ admission fix is compiled in; the helper is `static` and inlined by the optimizer so symbol-grep is unreliable, but byte-identity against the rc13 wheel establishes presence).
- A separate harsh-load repro on the resulting image is in progress.

## Test plan

- [ ] CI: `trtllm-pipeline` (covers TRT-LLM container-build + smoke test against rc13)
- [ ] CI: `pre-commit` (no Python changes; should be a no-op)
- [ ] Manual: pull the resulting `dynamo-trtllm` container, run a known-good aggregated-serving smoke test on Qwen3-4B / 1× GB200, confirm `/v1/chat/completions` returns 200.
- [ ] Manual: rerun the issue #13318 harsh-config repro (multi-prefix multi-turn at qps≈18 with `max_num_tokens=4096`) and confirm zero `AssertionError: total_num_tokens > max_num_tokens` events.

## Related

- Upstream issue: NVIDIA/TensorRT-LLM#13318
- Upstream fix: NVIDIA/TensorRT-LLM#12976 (already merged to TRT-LLM main, 2026-04-18)
- Backport-to-rc13: included in `v1.3.0rc13` release tag (2026-04-26)
- Upstream PR for the Python re-validation safety net (still OPEN against TRT-LLM main): NVIDIA/TensorRT-LLM#13601 — defense-in-depth on top of #12976; not required for this dynamo-side bump