### PR TITLE
fix: [DYN-2883] Triton backend directory default (cherry-pick #8697)

### DIFF
--- a/examples/backends/tritonserver/Dockerfile
+++ b/examples/backends/tritonserver/Dockerfile
@@ -11,6 +11,7 @@ FROM ${DYNAMO_BASE_IMAGE} AS dynamo_base
 COPY --from=triton_source /opt/tritonserver /opt/tritonserver
 COPY --from=triton_source /usr/local/dcgm /usr/local/dcgm
 COPY --from=triton_source /lib/x86_64-linux-gnu/libdcgm*.so* /lib/x86_64-linux-gnu/
+ENV BACKEND_DIR=/opt/tritonserver/backends
 ENV LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/local/cuda/lib64:/opt/tritonserver/lib:/opt/tritonserver/backends:/usr/local/dcgm/lib64
 ENV PATH=/opt/tritonserver/bin:$PATH
 

--- a/examples/backends/tritonserver/README.md
+++ b/examples/backends/tritonserver/README.md
@@ -129,6 +129,7 @@ Options:
 
 | Variable | Description | Default |
 |----------|-------------|---------|
+| `BACKEND_DIR` | Path to Triton backends. The container image sets this to `/opt/tritonserver/backends`; local source builds use `backends/`. | `backends/` |
 | `DYN_DISCOVERY_BACKEND` | Discovery backend: `kubernetes`, `etcd`, `file`, or `mem` | `file` |
 | `DYN_LOG` | Log level (debug, info, warn, error) | `info` |
 | `DYN_HTTP_PORT` | Frontend HTTP port | `8000` |

--- a/examples/backends/tritonserver/launch/identity.sh
+++ b/examples/backends/tritonserver/launch/identity.sh
@@ -23,7 +23,7 @@ TRITON_DIR="$(dirname "$SCRIPT_DIR")"
 # Default values
 MODEL_NAME="identity"
 MODEL_REPO="${TRITON_DIR}/model_repo"
-BACKEND_DIR="${TRITON_DIR}/backends"
+BACKEND_DIR="${BACKEND_DIR:-${TRITON_DIR}/backends}"
 LOG_VERBOSE=1
 DISCOVERY_BACKEND="${DYN_DISCOVERY_BACKEND:-file}"  # Default to file-based discovery (no etcd required)
 
@@ -65,6 +65,7 @@ while [[ $# -gt 0 ]]; do
             echo "  -h, --help                  Show this help message"
             echo ""
             echo "Environment variables:"
+            echo "  BACKEND_DIR             Override default Triton backends path"
             echo "  DYN_DISCOVERY_BACKEND  Discovery backend (default: file)"
             echo "  DYN_HTTP_PORT    Frontend HTTP port (default: 8000)"
             echo "  DYN_SYSTEM_PORT  Worker metrics port (default: 8081)"
@@ -126,4 +127,3 @@ python3 "${TRITON_DIR}/src/tritonworker.py" \
     --backend-directory "$BACKEND_DIR" \
     --log-verbose "$LOG_VERBOSE" \
     "${EXTRA_ARGS[@]}"
-


### PR DESCRIPTION
Cherry-pick of #8697 into release/1.1.0.

Fixes [NVBug 6110392](https://nvbugs/6110392) - Triton backend launch issue.

Original PR: #8697 by @nealvaidya

## Summary
- Set `BACKEND_DIR=/opt/tritonserver/backends` in the Triton worker container image.
- Let `launch/identity.sh` honor `BACKEND_DIR` from the environment while preserving the local source-build fallback.
- Document the container/local backend directory behavior in the Triton example README.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8871" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
