### PR TITLE
fix(trtllm): increment kv_transfer_success_total on decode (#8483)

### DIFF
--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -1202,15 +1202,12 @@ class HandlerBase(BaseGenerativeHandler):
                                 # Record KV transfer latency/bytes/speed from timing_metrics
                                 tm = output.request_perf_metrics.timing_metrics
                                 if tm is not None:
-                                    recorded = (
-                                        metrics_collector.record_kv_transfer_perf(tm)
-                                    )
-                                    # Only count success if a transfer actually occurred
-                                    if (
-                                        recorded
-                                        and self.disaggregation_mode
-                                        == DisaggregationMode.PREFILL
-                                    ):
+                                    # record_kv_transfer_perf() only returns True on the
+                                    # decode worker (the receiver), which observes non-zero
+                                    # kv_cache_transfer_{start,end} in timing_metrics. Count
+                                    # the success counter on the same signal so it stays in
+                                    # lock-step with the sibling histograms' _count. DYN-2781.
+                                    if metrics_collector.record_kv_transfer_perf(tm):
                                         metrics_collector.record_kv_transfer_success()
                         except Exception as e:
                             logging.warning(

--- a/components/src/dynamo/trtllm/tests/test_trtllm_additional_metrics.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_additional_metrics.py
@@ -8,6 +8,7 @@ import inspect
 import textwrap
 import unittest
 from datetime import timedelta
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from prometheus_client import CollectorRegistry, generate_latest
@@ -149,6 +150,72 @@ class TestAdditionalMetricsCollector(unittest.TestCase):
         tm_neg.kv_cache_size = 1000
         self.assertFalse(self.collector.record_kv_transfer_perf(tm_neg))
 
+    def test_kv_transfer_success_counter_fires_on_decode_path(self):
+        """DYN-2781: trtllm_kv_transfer_success_total must increment whenever
+        record_kv_transfer_perf() returns True (the decode-side signal).
+
+        Simulates the wiring in handler_base.py generate_locally() that mirrors
+        the histogram observations: if a real KV transfer is observed, count
+        one success.
+        """
+        # Non-zero timing -> record_kv_transfer_perf returns True on decode.
+        tm = MagicMock()
+        tm.kv_cache_transfer_start = timedelta(seconds=1.0)
+        tm.kv_cache_transfer_end = timedelta(seconds=1.05)
+        tm.kv_cache_size = 1_000_000_000
+
+        # This is exactly the contract handler_base.py uses post-fix.
+        if self.collector.record_kv_transfer_perf(tm):
+            self.collector.record_kv_transfer_success()
+
+        count = self.registry.get_sample_value(
+            "trtllm_kv_transfer_success_total",
+            {
+                "model_name": "test-model",
+                "disaggregation_mode": "prefill_and_decode",
+                "engine_type": "trtllm",
+            },
+        )
+        self.assertEqual(count, 1.0)
+
+        # _count of the sibling latency histogram must match the counter.
+        latency_count = self.registry.get_sample_value(
+            "trtllm_kv_transfer_latency_seconds_count",
+            {
+                "model_name": "test-model",
+                "disaggregation_mode": "prefill_and_decode",
+                "engine_type": "trtllm",
+            },
+        )
+        self.assertEqual(latency_count, 1.0)
+
+    def test_kv_transfer_success_counter_stays_zero_without_transfer(self):
+        """DYN-2781: zero timing -> perf not recorded -> counter stays 0.
+
+        Covers the prefill worker (which never observes kv_cache_transfer_*
+        timing) and aggregated deployments (no disagg at all).
+        """
+        tm = MagicMock()
+        tm.kv_cache_transfer_start = timedelta(0)
+        tm.kv_cache_transfer_end = timedelta(0)
+        tm.kv_cache_size = 0
+
+        if self.collector.record_kv_transfer_perf(tm):
+            self.collector.record_kv_transfer_success()
+
+        # Counter should not exist / be 0 for these labels.
+        count = self.registry.get_sample_value(
+            "trtllm_kv_transfer_success_total",
+            {
+                "model_name": "test-model",
+                "disaggregation_mode": "prefill_and_decode",
+                "engine_type": "trtllm",
+            },
+        )
+        # None means unobserved; Prometheus counters without .inc() do not
+        # appear as a sample row.
+        self.assertIn(count, (None, 0.0))
+
     def test_no_duplicate_metrics(self):
         """Test that removed duplicate metrics are not present."""
         output = generate_latest(self.registry).decode()
@@ -224,6 +291,90 @@ class TestHandlerBaseMetricsInstrumentation(unittest.TestCase):
         self.assertFalse(
             missing,
             f"Keys in GuidedDecodingParams but not in metrics detection: {missing}",
+        )
+
+    def test_kv_transfer_success_inc_not_gated_by_prefill(self):
+        """DYN-2781 regression test.
+
+        record_kv_transfer_success() must not be guarded by
+        DisaggregationMode.PREFILL inside generate_locally, because
+        record_kv_transfer_perf() only returns True on the decode worker.
+        Gating the success counter on PREFILL makes the two conditions
+        mutually exclusive and the counter never increments.
+        """
+        source = textwrap.dedent(inspect.getsource(HandlerBase._generate_locally_impl))
+        tree = ast.parse(source)
+        found_success_call = False
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.If):
+                continue
+            calls_success = any(
+                isinstance(stmt, ast.Expr)
+                and isinstance(stmt.value, ast.Call)
+                and isinstance(stmt.value.func, ast.Attribute)
+                and stmt.value.func.attr == "record_kv_transfer_success"
+                for stmt in node.body
+            )
+            if not calls_success:
+                continue
+            found_success_call = True
+            for sub in ast.walk(node.test):
+                if isinstance(sub, ast.Attribute) and sub.attr == "PREFILL":
+                    self.fail(
+                        "record_kv_transfer_success() is guarded by "
+                        "DisaggregationMode.PREFILL (DYN-2781)."
+                    )
+        self.assertTrue(
+            found_success_call,
+            "record_kv_transfer_success() was not found in "
+            "HandlerBase._generate_locally_impl — the instrumentation the "
+            "regression test is meant to verify has moved or been removed.",
+        )
+
+
+class TestHandlerBaseFileLevelRegression(unittest.TestCase):
+    """AST-level regression tests that do not require importing HandlerBase.
+
+    HandlerBase imports torch which needs CUDA libs at import time — on CPU-only
+    CI this class is the only place the DYN-2781 regression check actually
+    runs.
+    """
+
+    def test_kv_transfer_success_inc_not_gated_by_prefill_from_source(self):
+        handler_path = (
+            Path(__file__).resolve().parent
+            / ".."
+            / "request_handlers"
+            / "handler_base.py"
+        ).resolve()
+        tree = ast.parse(handler_path.read_text(encoding="utf-8"))
+        found_success_call = False
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.If):
+                continue
+            calls_success = any(
+                isinstance(stmt, ast.Expr)
+                and isinstance(stmt.value, ast.Call)
+                and isinstance(stmt.value.func, ast.Attribute)
+                and stmt.value.func.attr == "record_kv_transfer_success"
+                for stmt in node.body
+            )
+            if not calls_success:
+                continue
+            found_success_call = True
+            for sub in ast.walk(node.test):
+                if isinstance(sub, ast.Attribute) and sub.attr == "PREFILL":
+                    self.fail(
+                        "record_kv_transfer_success() in handler_base.py is "
+                        "guarded by DisaggregationMode.PREFILL. That gate is "
+                        "mutually exclusive with record_kv_transfer_perf() "
+                        "returning True — counter never increments (DYN-2781)."
+                    )
+        self.assertTrue(
+            found_success_call,
+            "record_kv_transfer_success() was not found in handler_base.py — "
+            "the instrumentation the regression test is meant to verify has "
+            "moved or been removed.",
         )
 
 


### PR DESCRIPTION
## Summary
- Cherry-pick of #8483 to release/1.1.0
- Increments `trtllm_kv_transfer_success_total` metric on decode worker so observability dashboards reflect successful KV transfers

Fixes DYN-2781
Fixes https://nvbugs/6099358

## Original PR
- Main PR: #8483
- Merge commit: c58750d1

## Test plan
- [ ] CI passes
- [ ] Verified metric increments on release branch

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8873" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
