### PR TITLE
fix(sglang): enable guided decoding in aggregated serving (#8843)

### DIFF
--- a/components/src/dynamo/sglang/llm_engine.py
+++ b/components/src/dynamo/sglang/llm_engine.py
@@ -9,6 +9,7 @@ and feature gap details.
 
 from __future__ import annotations
 
+import json
 import logging
 import sys
 from collections.abc import AsyncGenerator
@@ -32,11 +33,13 @@ logger = logging.getLogger(__name__)
 
 
 class SglangLLMEngine(LLMEngine):
-    def __init__(self, server_args):
+    def __init__(self, server_args, dynamo_args):
         self.server_args = server_args
+        self.dynamo_args = dynamo_args
         self.engine = None
         self._input_param_manager = None
         self._skip_tokenizer_init = server_args.skip_tokenizer_init
+        self._use_sglang_tokenizer = dynamo_args.use_sglang_tokenizer
 
     @classmethod
     async def from_args(
@@ -47,12 +50,10 @@ class SglangLLMEngine(LLMEngine):
         dynamo_args = config.dynamo_args
 
         model_input = (
-            ModelInput.Text
-            if not server_args.skip_tokenizer_init
-            else ModelInput.Tokens
+            ModelInput.Text if dynamo_args.use_sglang_tokenizer else ModelInput.Tokens
         )
 
-        engine = cls(server_args)
+        engine = cls(server_args, dynamo_args)
         worker_config = WorkerConfig.from_runtime_config(
             dynamo_args,
             model_name=server_args.model_path,
@@ -177,7 +178,7 @@ class SglangLLMEngine(LLMEngine):
             logger.info("SGLang engine shutdown")
 
     def _build_sampling_params(self, request: GenerateRequest) -> dict:
-        if self._skip_tokenizer_init:
+        if not self._use_sglang_tokenizer:
             sampling_opts = request.get("sampling_options", {})
             stop_conditions = request.get("stop_conditions", {})
             param_mapping = {
@@ -186,6 +187,9 @@ class SglangLLMEngine(LLMEngine):
                 "top_k": sampling_opts.get("top_k"),
                 "max_new_tokens": stop_conditions.get("max_tokens"),
                 "ignore_eos": stop_conditions.get("ignore_eos"),
+                **self._get_guided_decoding_params(
+                    sampling_opts.get("guided_decoding")
+                ),
             }
         else:
             param_mapping = {
@@ -193,13 +197,27 @@ class SglangLLMEngine(LLMEngine):
                 "top_p": request.get("top_p"),
                 "top_k": request.get("top_k"),
                 "max_new_tokens": request.get("max_tokens"),
+                **self._get_guided_decoding_params(request.get("guided_decoding")),
             }
         return {k: v for k, v in param_mapping.items() if v is not None}
+
+    @staticmethod
+    def _get_guided_decoding_params(guided_decoding: object) -> dict:
+        if isinstance(guided_decoding, dict):
+            json_schema = guided_decoding.get("json")
+            if json_schema is not None:
+                return {"json_schema": json.dumps(json_schema)}
+            structural_tag = guided_decoding.get("structural_tag")
+            if structural_tag is not None:
+                if hasattr(structural_tag, "model_dump"):
+                    structural_tag = structural_tag.model_dump()
+                return {"structural_tag": json.dumps(structural_tag)}
+        return {}
 
     def _get_input_param(self, request: GenerateRequest) -> dict:
         assert self._input_param_manager is not None, "Engine not initialized"
         request_input = self._input_param_manager.get_input_param(
-            request, use_tokenizer=not self._skip_tokenizer_init
+            request, use_tokenizer=self._use_sglang_tokenizer
         )
         return {
             "prompt" if isinstance(request_input, str) else "input_ids": request_input

--- a/examples/backends/sglang/launch/agg.sh
+++ b/examples/backends/sglang/launch/agg.sh
@@ -83,7 +83,6 @@ python3 -m "$WORKER_MODULE" \
   --page-size 16 \
   --tp 1 \
   --trust-remote-code \
-  --skip-tokenizer-init \
   --enable-metrics \
   --disable-piecewise-cuda-graph \
   $GPU_MEM_ARGS \

--- a/tests/serve/test_sglang.py
+++ b/tests/serve/test_sglang.py
@@ -26,6 +26,7 @@ from tests.utils.payload_builder import (
     completion_payload_default,
     embedding_payload,
     embedding_payload_default,
+    guided_decoding_chat_payload_default,
     metric_payload_default,
     responses_payload_default,
     responses_stream_payload_default,
@@ -86,6 +87,7 @@ sglang_configs = {
             completion_payload_default(),
             responses_payload_default(),
             responses_stream_payload_default(),
+            guided_decoding_chat_payload_default(),
             metric_payload_default(min_num_requests=6, backend="sglang"),
         ],
     ),
@@ -107,6 +109,7 @@ sglang_configs = {
         request_payloads=[
             chat_payload_default(),
             completion_payload_default(),
+            guided_decoding_chat_payload_default(),
         ],
     ),
     "disaggregated": SGLangConfig(

--- a/tests/utils/payload_builder.py
+++ b/tests/utils/payload_builder.py
@@ -14,6 +14,7 @@ from tests.utils.payloads import (
     CompletionPayload,
     CompletionPayloadWithLogprobs,
     EmbeddingPayload,
+    GuidedDecodingChatPayload,
     LMCacheMetricsPayload,
     MetricsPayload,
     ResponsesPayload,
@@ -111,6 +112,36 @@ def cached_tokens_chat_payload(
         expected_response=expected_response
         or ["Aeloria", "Eldoria", "explorer", "ancient", "character", "background"],
         min_cached_tokens=min_cached_tokens,
+    )
+
+
+def guided_decoding_chat_payload_default(
+    repeat_count: int = 1,
+    max_tokens: int = 32,
+    temperature: float = 0.0,
+) -> GuidedDecodingChatPayload:
+    """Create a json_schema guided decoding chat payload."""
+    schema = {
+        "type": "object",
+        "properties": {"answer": {"type": "string"}},
+        "required": ["answer"],
+    }
+    return GuidedDecodingChatPayload(
+        body={
+            "messages": [
+                {"role": "user", "content": "What is 2+2? Return only JSON."},
+            ],
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {"name": "answer_schema", "schema": schema},
+            },
+        },
+        repeat_count=repeat_count,
+        expected_log=[],
+        expected_response=[],
+        required_keys=["answer"],
     )
 
 

--- a/tests/utils/payloads.py
+++ b/tests/utils/payloads.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import logging
 import math
 import re
@@ -297,6 +298,37 @@ class ToolCallingChatPayload(ChatPayload):
                 )
             else:
                 logger.info(f"Found expected keywords in tool args: {found}")
+
+
+@dataclass
+class GuidedDecodingChatPayload(ChatPayload):
+    """ChatPayload that validates a json_schema response_format produces valid JSON."""
+
+    def __init__(self, *args, required_keys: Optional[List[str]] = None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.required_keys = required_keys or []
+
+    def validate(self, response, content: str) -> None:
+        try:
+            parsed = json.loads(content)
+        except (json.JSONDecodeError, TypeError) as e:
+            raise AssertionError(
+                "Guided decoding response is not valid JSON — grammar backend "
+                f"likely disabled. Content: {content!r}"
+            ) from e
+
+        assert isinstance(parsed, dict), (
+            "Guided decoding response should be a JSON object, "
+            f"got {type(parsed).__name__}: {content!r}"
+        )
+
+        for key in self.required_keys:
+            assert key in parsed, (
+                f"Guided decoding response missing required key {key!r}. "
+                f"Parsed: {parsed}"
+            )
+
+        logger.info(f"Guided decoding validation passed: {parsed}")
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- Cherry-pick of #8843 to release/1.1.0
- Enables SGLang guided decoding in agg.sh launch script
- Conflict resolved in tests/utils/payloads.py (added `import base64` and `import json` to release branch's payloads.py which was missing them)

Fixes DYN-2912
Fixes https://nvbugs/6120017

## Original PR
- Main PR: #8843
- Merge commit: c41824764cf8de1cd715f08dd4437c25325ff37a

## Test plan
- [ ] CI passes
- [ ] Verified guided decoding works on release branch

Made with [Cursor](https://cursor.com)