### PR TITLE
test(revalidate): fix: [DYN-2883] Triton backend directory default #8697

### DIFF
--- a/components/src/dynamo/common/__init__.py
+++ b/components/src/dynamo/common/__init__.py
@@ -25,3 +25,5 @@ except Exception:
         __version__ = "0.0.0+unknown"
 
 __all__ = ["__version__", "config_dump", "constants", "utils"]
+
+# ci-health probe 4ffb07fab3d 2026-04-30T00:57:47Z

--- a/lib/runtime/src/runtime.rs
+++ b/lib/runtime/src/runtime.rs
@@ -391,3 +391,5 @@ impl Drop for RuntimeType {
         }
     }
 }
+
+// ci-health probe 4ffb07fab3d 2026-04-30T00:57:47Z


### PR DESCRIPTION
Re-validating that PR #8697 by Neal Vaidya did not regress, by re-running against a trivial placebo diff:

```
fix: [DYN-2883] Triton backend directory default
```

Branch deleted on green; kept on failure for diagnosis.

Drafts are skipped by CodeRabbit per repo `.coderabbit.yaml`.