### PR TITLE
test(revalidate): fix: add FlexKVConnectorV1 to PdConnector allowed first connector types #8787

### DIFF
--- a/components/src/dynamo/common/__init__.py
+++ b/components/src/dynamo/common/__init__.py
@@ -25,3 +25,5 @@ except Exception:
         __version__ = "0.0.0+unknown"
 
 __all__ = ["__version__", "config_dump", "constants", "utils"]
+
+# ci-health probe cfafea68685 2026-04-30T00:58:15Z

--- a/lib/runtime/src/runtime.rs
+++ b/lib/runtime/src/runtime.rs
@@ -391,3 +391,5 @@ impl Drop for RuntimeType {
         }
     }
 }
+
+// ci-health probe cfafea68685 2026-04-30T00:58:15Z


### PR DESCRIPTION
Re-validating that PR #8787 by linhu-nv did not regress, by re-running against a trivial placebo diff:

```
fix: add FlexKVConnectorV1 to PdConnector allowed first connector types
```

Branch deleted on green; kept on failure for diagnosis.

Drafts are skipped by CodeRabbit per repo `.coderabbit.yaml`.