### PR TITLE
fix(launch): propagate child exit codes in wait_any_exit

### DIFF
--- a/examples/common/launch_utils.sh
+++ b/examples/common/launch_utils.sh
@@ -75,9 +75,19 @@ wait_any_exit() {
         echo "wait_any_exit: no background processes found (script bug: did you forget '&'?)" >&2
         exit 1
     fi
-    wait -n
-    local _rc=$?
+    # `wait -n` returning non-zero is the signal we want — a child failed.
+    # But `set -e` would treat that as a script error and exit before we
+    # ever read the code. The `||` tells bash "I'm handling this myself,
+    # don't kill the script."
+    local _rc=0
+    wait -n || _rc=$?
     echo "A background process exited with code $_rc"
+    # Replace the original `trap 'exit 0' TERM INT` so that when the EXIT
+    # trap's `kill 0` loops SIGTERM back to us, we re-exit with $_rc instead
+    # of clobbering it with 0. (bash defers signals received during a trap
+    # and processes them when the trap finishes, so this trap fires after
+    # the script's EXIT trap completes.)
+    trap "exit $_rc" TERM INT
     exit "$_rc"
 }
 

--- a/examples/common/launch_utils.sh
+++ b/examples/common/launch_utils.sh
@@ -75,18 +75,18 @@ wait_any_exit() {
         echo "wait_any_exit: no background processes found (script bug: did you forget '&'?)" >&2
         exit 1
     fi
-    # `wait -n` returning non-zero is the signal we want — a child failed.
-    # But `set -e` would treat that as a script error and exit before we
-    # ever read the code. The `||` tells bash "I'm handling this myself,
-    # don't kill the script."
+    # Problem: a failing background child should propagate its non-zero
+    # exit code, but the script always exited 0. Two bash interactions
+    # colluded — `set -e` killed the script before `_rc` was captured,
+    # and the EXIT trap's `kill 0` looped SIGTERM back through the
+    # `trap 'exit 0' TERM INT` set above, zeroing the captured code.
+    #
+    # Fix: `wait -n || _rc=$?` quiets `set -e` for that one line, and
+    # re-arming the TERM/INT trap to `exit $_rc` after capture means the
+    # boomerang SIGTERM still ends with the right code.
     local _rc=0
     wait -n || _rc=$?
     echo "A background process exited with code $_rc"
-    # Replace the original `trap 'exit 0' TERM INT` so that when the EXIT
-    # trap's `kill 0` loops SIGTERM back to us, we re-exit with $_rc instead
-    # of clobbering it with 0. (bash defers signals received during a trap
-    # and processes them when the trap finishes, so this trap fires after
-    # the script's EXIT trap completes.)
     trap "exit $_rc" TERM INT
     exit "$_rc"
 }


### PR DESCRIPTION
#### Overview:

Fix `wait_any_exit` so a failing child's exit code reaches the script's exit, instead of being silently overwritten with `0` by the EXIT trap's `kill 0` boomerang. Regression introduced by #7008.

#### Details:

- `wait -n || _rc=$?` — `set -e` was killing the script when `wait -n` returned non-zero, before the propagation logic could read the code.
- `trap "exit $_rc" TERM INT` rewritten after capture — the script's EXIT trap (`kill 0`) loops SIGTERM back to ourselves, and the original `trap 'exit 0' TERM INT` set at the top of `wait_any_exit` then exited `0` and clobbered `_rc`. The new trap re-exits with the captured code instead.
- Plain-English comments next to both lines, since the trap-loop interaction is non-obvious.

#### Where should the reviewer start?

`examples/common/launch_utils.sh:72-92`

#### Verification

Local repro from DIS-1903, plus a fake-python end-to-end run of `examples/backends/vllm/launch/agg.sh`, plus an external-SIGTERM teardown to confirm the original "test harness sends SIGTERM, exit 0" path still works:

| scenario | expected | bug (before fix) | fixed (got) |
|---|---|---|---|
| child exits 23 (ticket repro) | 23 | 0 ❌ | 23 ✓ |
| child exits 1 | 1 | 0 ❌ | 1 ✓ |
| external SIGTERM during `wait -n` | 0 | 0 ✓ (already correct — original design intentionally swallowed external SIGTERM with exit 0) | 0 ✓ |
| `agg.sh` + fake python (`dynamo.vllm` exits 23) | 23 | 0 ❌ | 23 ✓ |

Note for the QA author: the ticket's `setsid /tmp/repro_min.sh; echo $?` always prints 0 because **`setsid` (without `--wait`) exits 0 itself** — so it can't measure the script's real exit code. Use `setsid --wait` (or run the script directly without setsid) to capture real exit codes. The bug was real, just the harness was masking it.

#### Related Issues:

Closes DIS-1903

/coderabbit profile chill
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8883" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in the launch utility to properly propagate child process failure codes, even when interrupted by system signals. The utility now reliably preserves and reports actual child process exit codes instead of masking them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->