### PR TITLE
test(kv-router): add Mooncake overlap parity check

### DIFF
--- a/lib/bench/tests/mooncake_trace.rs
+++ b/lib/bench/tests/mooncake_trace.rs
@@ -9,14 +9,16 @@ mod common;
 #[path = "../kv_router/mooncake_shared.rs"]
 mod mooncake_shared;
 
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::io::Write;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
 
-use common::{generate_replay_artifacts, process_mooncake_trace};
+use common::{WorkerReplayArtifacts, generate_replay_artifacts, process_mooncake_trace};
+use dynamo_kv_router::LocalBlockHash;
 use dynamo_kv_router::indexer::KvIndexerMetrics;
+use dynamo_kv_router::protocols::{KvCacheEvent, RouterEvent, WorkerWithDpRank};
 use dynamo_mocker::loadgen::{SessionTrace, Trace, TurnTrace};
 use mooncake_shared::{MooncakeBenchmarkConfig, MooncakeIndexerConfig, run_benchmark};
 use tempfile::NamedTempFile;
@@ -26,6 +28,113 @@ const NUM_GPU_BLOCKS: usize = 16384;
 const NUM_UNIQUE_INFERENCE_WORKERS: usize = 10;
 const BENCHMARK_DURATION_MS: u64 = 2000;
 const NUM_EVENT_WORKERS: usize = 4;
+
+type NormalizedOverlapScores = BTreeMap<WorkerWithDpRank, u32>;
+
+#[derive(Clone)]
+enum ReplayEntryKind {
+    Request(Vec<LocalBlockHash>),
+    Event(KvCacheEvent),
+}
+
+#[derive(Clone)]
+struct ReplayEntry {
+    timestamp_us: u64,
+    worker_id: u64,
+    kind_rank: u8,
+    kind: ReplayEntryKind,
+}
+
+fn collect_replay_entries(artifacts: &[WorkerReplayArtifacts]) -> Vec<ReplayEntry> {
+    let mut entries = Vec::new();
+    for (worker_id, artifact) in artifacts.iter().enumerate() {
+        entries.extend(artifact.requests.iter().map(|request| ReplayEntry {
+            timestamp_us: request.timestamp_us,
+            worker_id: worker_id as u64,
+            kind_rank: 0,
+            kind: ReplayEntryKind::Request(request.replay_hashes.local_block_hashes.clone()),
+        }));
+        entries.extend(artifact.kv_events.iter().map(|event| ReplayEntry {
+            timestamp_us: event.timestamp_us,
+            worker_id: worker_id as u64,
+            kind_rank: 1,
+            kind: ReplayEntryKind::Event(event.event.clone()),
+        }));
+    }
+    entries.sort_by_key(|entry| (entry.timestamp_us, entry.kind_rank, entry.worker_id));
+    entries
+}
+
+async fn collect_overlap_scores_for_replay(
+    config: &MooncakeIndexerConfig,
+    artifacts: &[WorkerReplayArtifacts],
+) -> anyhow::Result<Vec<NormalizedOverlapScores>> {
+    let indexer = config.build(BLOCK_SIZE, Arc::new(KvIndexerMetrics::new_unregistered()));
+    let entries = collect_replay_entries(artifacts);
+    let mut scores = Vec::new();
+    let mut idx = 0;
+
+    while idx < entries.len() {
+        let timestamp_us = entries[idx].timestamp_us;
+        while idx < entries.len() && entries[idx].timestamp_us == timestamp_us {
+            match &entries[idx].kind {
+                ReplayEntryKind::Request(request) => {
+                    let overlap = indexer.find_matches(request.clone()).await?;
+                    scores.push(overlap.scores.into_iter().collect());
+                }
+                ReplayEntryKind::Event(event) => {
+                    indexer
+                        .apply_event(RouterEvent::new(entries[idx].worker_id, event.clone()))
+                        .await;
+                }
+            }
+            idx += 1;
+        }
+        indexer.flush().await;
+    }
+
+    indexer.shutdown();
+    Ok(scores)
+}
+
+async fn assert_overlap_score_parity(
+    variants: &[MooncakeIndexerConfig],
+    artifacts: &[WorkerReplayArtifacts],
+) -> anyhow::Result<()> {
+    let mut expected_name = None;
+    let mut expected_scores = Vec::new();
+
+    for config in variants {
+        let actual_scores = collect_overlap_scores_for_replay(config, artifacts).await?;
+        if expected_name.is_none() {
+            expected_name = Some(config.short_name().to_string());
+            expected_scores = actual_scores;
+            continue;
+        }
+
+        assert_eq!(
+            actual_scores.len(),
+            expected_scores.len(),
+            "{} produced a different number of request overlap results than {}",
+            config.short_name(),
+            expected_name.as_deref().unwrap()
+        );
+
+        for (request_idx, (actual, expected)) in
+            actual_scores.iter().zip(expected_scores.iter()).enumerate()
+        {
+            assert_eq!(
+                actual,
+                expected,
+                "{} overlap scores diverged from {} at replay request {request_idx}",
+                config.short_name(),
+                expected_name.as_deref().unwrap()
+            );
+        }
+    }
+
+    Ok(())
+}
 
 #[test]
 fn process_mooncake_trace_expands_and_duplicates_hash_space() -> anyhow::Result<()> {
@@ -152,7 +261,7 @@ async fn mooncake_trace_replays_without_warnings_across_indexer_variants() -> an
         MooncakeIndexerConfig::concurrent_radix_tree_compressed(NUM_EVENT_WORKERS),
     ];
 
-    for config in variants {
+    for config in &variants {
         support::reset_warning_count(&warning_count);
 
         let metrics = Arc::new(KvIndexerMetrics::new_unregistered());
@@ -196,6 +305,8 @@ async fn mooncake_trace_replays_without_warnings_across_indexer_variants() -> an
             config.short_name()
         );
     }
+
+    assert_overlap_score_parity(&variants, &artifacts).await?;
 
     Ok(())
 }

--- a/lib/kv-router/src/indexer/concurrent_radix_tree.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree.rs
@@ -684,6 +684,9 @@ impl SyncIndexer for ConcurrentRadixTree {
                     // Should not be reached, but respond with empty to avoid blocking.
                     let _ = _sender.send(Ok(Vec::new()));
                 }
+                WorkerTask::Flush(sender) => {
+                    let _ = sender.send(());
+                }
                 WorkerTask::Terminate => {
                     break;
                 }

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed.rs
@@ -1360,6 +1360,9 @@ impl SyncIndexer for ConcurrentRadixTreeCompressed {
                 WorkerTask::DumpEvents(_sender) => {
                     let _ = _sender.send(Ok(Vec::new()));
                 }
+                WorkerTask::Flush(sender) => {
+                    let _ = sender.send(());
+                }
                 WorkerTask::Terminate => {
                     break;
                 }

--- a/lib/kv-router/src/indexer/kv_indexer.rs
+++ b/lib/kv-router/src/indexer/kv_indexer.rs
@@ -11,9 +11,9 @@ use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
 
 use super::{
-    DumpRequest, EventKind, GetWorkersRequest, KvIndexerInterface, KvIndexerMetrics, KvRouterError,
-    MatchDetails, MatchDetailsRequest, MatchRequest, PreBoundEventCounters, RadixTree,
-    RoutingDecisionRequest,
+    DumpRequest, EventKind, FlushRequest, GetWorkersRequest, KvIndexerInterface, KvIndexerMetrics,
+    KvRouterError, MatchDetails, MatchDetailsRequest, MatchRequest, PreBoundEventCounters,
+    RadixTree, RoutingDecisionRequest,
 };
 use crate::indexer::pruning::{BlockEntry, PruneConfig, PruneManager};
 use crate::protocols::*;
@@ -87,6 +87,112 @@ fn apply_event_with_prune_tracking(
     }
 }
 
+fn apply_routing_decision_with_prune_tracking(
+    trie: &mut RadixTree,
+    routing_req: RoutingDecisionRequest,
+    prune_manager: &mut Option<PruneManager<BlockEntry>>,
+    prune_tx: &mpsc::Sender<()>,
+    event_id_counter: &mut u64,
+) {
+    let Some(pm) = prune_manager.as_mut() else {
+        return;
+    };
+
+    *event_id_counter += 1;
+
+    let hashes = routing_req
+        .local_hashes
+        .iter()
+        .zip(routing_req.sequence_hashes.iter());
+    let stored_event = KvCacheEventData::Stored(KvCacheStoreData {
+        parent_hash: None,
+        start_position: None,
+        blocks: hashes
+            .map(|(local_hash, sequence_hash)| KvCacheStoredBlockData {
+                tokens_hash: *local_hash,
+                block_hash: ExternalSequenceBlockHash(*sequence_hash),
+                mm_extra_info: None,
+            })
+            .collect(),
+    });
+
+    let event = RouterEvent::new(
+        routing_req.worker.worker_id,
+        KvCacheEvent {
+            event_id: *event_id_counter,
+            data: stored_event,
+            dp_rank: routing_req.worker.dp_rank,
+        },
+    );
+
+    if trie.apply_event(event).is_err() {
+        return;
+    }
+
+    let block_entries = routing_req
+        .sequence_hashes
+        .iter()
+        .enumerate()
+        .map(|(idx, h)| BlockEntry {
+            key: ExternalSequenceBlockHash(*h),
+            worker: routing_req.worker,
+            seq_position: idx,
+        })
+        .collect();
+    pm.insert(block_entries);
+
+    let Some(ref pc) = pm.prune_config else {
+        return;
+    };
+    let current_size = trie.current_size();
+    if current_size > pc.max_tree_size {
+        tracing::info!(
+            "Pruning: tree size ({}) exceeded max tree size ({}), scheduling pruning",
+            current_size,
+            pc.max_tree_size
+        );
+        let _ = prune_tx.try_send(());
+    }
+}
+
+struct PendingMutationReceivers<'a> {
+    event_rx: &'a mut mpsc::Receiver<RouterEvent>,
+    remove_worker_rx: &'a mut mpsc::Receiver<WorkerId>,
+    remove_worker_dp_rank_rx: &'a mut mpsc::Receiver<(WorkerId, DpRank)>,
+    routing_rx: &'a mut mpsc::Receiver<RoutingDecisionRequest>,
+}
+
+fn drain_pending_mutations(
+    trie: &mut RadixTree,
+    receivers: PendingMutationReceivers<'_>,
+    counters: &PreBoundEventCounters,
+    prune_manager: &mut Option<PruneManager<BlockEntry>>,
+    prune_tx: &mpsc::Sender<()>,
+    event_id_counter: &mut u64,
+) {
+    while let Ok(worker) = receivers.remove_worker_rx.try_recv() {
+        trie.remove_worker(worker);
+    }
+
+    while let Ok((worker_id, dp_rank)) = receivers.remove_worker_dp_rank_rx.try_recv() {
+        trie.remove_worker_dp_rank(worker_id, dp_rank);
+    }
+
+    while let Ok(event) = receivers.event_rx.try_recv() {
+        apply_event_with_prune_tracking(trie, event, counters, prune_manager, prune_tx);
+    }
+
+    while let Ok(routing_req) = receivers.routing_rx.try_recv() {
+        apply_routing_decision_with_prune_tracking(
+            trie,
+            routing_req,
+            prune_manager,
+            prune_tx,
+            event_id_counter,
+        );
+    }
+}
+
 /// The KV Indexer, managing the KV store and handling events and match requests.
 #[derive(Clone)]
 pub struct KvIndexer {
@@ -106,6 +212,8 @@ pub struct KvIndexer {
     get_workers_tx: mpsc::Sender<GetWorkersRequest>,
     /// A sender for dump requests.
     dump_tx: mpsc::Sender<DumpRequest>,
+    /// A sender for flush requests.
+    flush_tx: mpsc::Sender<FlushRequest>,
     /// A sender for routing decision requests.
     routing_tx: mpsc::Sender<RoutingDecisionRequest>,
     /// The size of the KV block this indexer can handle.
@@ -145,6 +253,7 @@ impl KvIndexer {
             mpsc::channel::<(WorkerId, DpRank)>(16);
         let (get_workers_tx, get_workers_rx) = mpsc::channel::<GetWorkersRequest>(16);
         let (dump_tx, dump_rx) = mpsc::channel::<DumpRequest>(16);
+        let (flush_tx, flush_rx) = mpsc::channel::<FlushRequest>(16);
         let (routing_tx, mut routing_rx) = mpsc::channel::<RoutingDecisionRequest>(2048);
         let (prune_tx, mut prune_rx) = mpsc::channel::<()>(1);
 
@@ -166,19 +275,20 @@ impl KvIndexer {
                 let mut remove_worker_dp_rank_rx = remove_worker_dp_rank_rx;
                 let mut get_workers_rx = get_workers_rx;
                 let mut dump_rx = dump_rx;
+                let mut flush_rx = flush_rx;
                 let mut trie = RadixTree::new_with_frequency(expiration_duration);
 
                 // Create PruneManager if prune_config is specified
-                let mut prune_manager = prune_config.map(|config| {
-                    PruneManager::<BlockEntry>::new(50, config)
-                });
+                let mut prune_manager =
+                    prune_config.map(|config| PruneManager::<BlockEntry>::new(50, config));
                 let mut event_id_counter = 0u64;
                 let counters = metrics.prebind();
 
                 loop {
                     // Create a future that sleeps until the next expiration time
                     let expiry_fut = if let Some(ref pm) = prune_manager
-                        && let Some(next_expiry) = pm.peek_next_expiry() {
+                        && let Some(next_expiry) = pm.peek_next_expiry()
+                    {
                         tokio::time::sleep_until(next_expiry)
                     } else {
                         tokio::time::sleep(Duration::MAX)
@@ -237,70 +347,48 @@ impl KvIndexer {
                         }
 
                         Some(dump_req) = dump_rx.recv() => {
-                            // Flush pending events so tree is consistent with buffer
-                            while let Ok(event) = event_rx.try_recv() {
-                                apply_event_with_prune_tracking(
-                                    &mut trie,
-                                    event,
-                                    &counters,
-                                    &mut prune_manager,
-                                    &prune_tx,
-                                );
-                            }
+                            drain_pending_mutations(
+                                &mut trie,
+                                PendingMutationReceivers {
+                                    event_rx: &mut event_rx,
+                                    remove_worker_rx: &mut remove_worker_rx,
+                                    remove_worker_dp_rank_rx: &mut remove_worker_dp_rank_rx,
+                                    routing_rx: &mut routing_rx,
+                                },
+                                &counters,
+                                &mut prune_manager,
+                                &prune_tx,
+                                &mut event_id_counter,
+                            );
                             let events = trie.dump_tree_as_events();
                             let _ = dump_req.resp.send(events);
                         }
 
-                        Some(routing_req) = routing_rx.recv() => {
-                            // Process routing decisions when TTL/pruning is enabled
-                            let Some(ref mut pm) = prune_manager else { continue };
-
-                            event_id_counter += 1;
-
-                            let hashes = routing_req.local_hashes.iter().zip(routing_req.sequence_hashes.iter());
-                            let stored_event = KvCacheEventData::Stored(KvCacheStoreData {
-                                parent_hash: None,
-                                start_position: None,
-                                blocks: hashes.map(|(local_hash, sequence_hash)| KvCacheStoredBlockData {
-                                    tokens_hash: *local_hash,
-                                    block_hash: ExternalSequenceBlockHash(*sequence_hash),
-                                mm_extra_info: None,
-                                }).collect(),
-                            });
-
-                            let event = RouterEvent::new(
-                                routing_req.worker.worker_id,
-                                KvCacheEvent {
-                                    event_id: event_id_counter,
-                                    data: stored_event,
-                                    dp_rank: routing_req.worker.dp_rank,
-                                }
+                        Some(flush_req) = flush_rx.recv() => {
+                            drain_pending_mutations(
+                                &mut trie,
+                                PendingMutationReceivers {
+                                    event_rx: &mut event_rx,
+                                    remove_worker_rx: &mut remove_worker_rx,
+                                    remove_worker_dp_rank_rx: &mut remove_worker_dp_rank_rx,
+                                    routing_rx: &mut routing_rx,
+                                },
+                                &counters,
+                                &mut prune_manager,
+                                &prune_tx,
+                                &mut event_id_counter,
                             );
+                            let _ = flush_req.resp.send(());
+                        }
 
-                            if trie.apply_event(event).is_err() {
-                                continue;
-                            }
-
-                            let block_entries: Vec<BlockEntry> = routing_req.sequence_hashes.iter().enumerate().map(|(idx, h)| {
-                                BlockEntry {
-                                    key: ExternalSequenceBlockHash(*h),
-                                    worker: routing_req.worker,
-                                    seq_position: idx,
-                                }
-                            }).collect();
-                            pm.insert(block_entries);
-
-                            // Check if we need to prune due to tree size
-                            let Some(ref pc) = pm.prune_config else { continue };
-                            let current_size = trie.current_size();
-                            if current_size > pc.max_tree_size {
-                                tracing::info!(
-                                    "Pruning: tree size ({}) exceeded max tree size ({}), scheduling pruning",
-                                    current_size,
-                                    pc.max_tree_size
-                                );
-                                let _ = prune_tx.try_send(());
-                            }
+                        Some(routing_req) = routing_rx.recv() => {
+                            apply_routing_decision_with_prune_tracking(
+                                &mut trie,
+                                routing_req,
+                                &mut prune_manager,
+                                &prune_tx,
+                                &mut event_id_counter,
+                            );
                         }
 
                         Some(req) = match_rx.recv() => {
@@ -366,6 +454,7 @@ impl KvIndexer {
             remove_worker_dp_rank_tx,
             get_workers_tx,
             dump_tx,
+            flush_tx,
             routing_tx,
             kv_block_size,
             _ref_count: Arc::new(()),
@@ -541,12 +630,15 @@ impl KvIndexerInterface for KvIndexer {
     }
     async fn flush(&self) -> usize {
         let curr_size = self.event_tx.max_capacity() - self.event_tx.capacity();
-        loop {
-            if self.event_tx.capacity() == self.event_tx.max_capacity() {
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(5)).await;
+        let (resp_tx, resp_rx) = oneshot::channel();
+        let flush_req = FlushRequest { resp: resp_tx };
+
+        if let Err(error) = self.flush_tx.send(flush_req).await {
+            tracing::error!("Failed to send flush request: {:?}", error);
+            return curr_size;
         }
+
+        let _ = resp_rx.await;
         curr_size
     }
 }

--- a/lib/kv-router/src/indexer/lower_tier.rs
+++ b/lib/kv-router/src/indexer/lower_tier.rs
@@ -523,6 +523,9 @@ impl SyncIndexer for LowerTierIndexer {
                 WorkerTask::DumpEvents(sender) => {
                     let _ = sender.send(Ok(Self::dump_events(&worker_blocks)));
                 }
+                WorkerTask::Flush(sender) => {
+                    let _ = sender.send(());
+                }
                 WorkerTask::CleanupStaleChildren => {}
                 WorkerTask::Terminate => {
                     break;

--- a/lib/kv-router/src/indexer/positional.rs
+++ b/lib/kv-router/src/indexer/positional.rs
@@ -177,6 +177,9 @@ impl SyncIndexer for PositionalIndexer {
                         tracing::warn!("Failed to send events: {:?}", e);
                     }
                 }
+                WorkerTask::Flush(sender) => {
+                    let _ = sender.send(());
+                }
                 WorkerTask::Terminate => {
                     break;
                 }

--- a/lib/kv-router/src/indexer/tests.rs
+++ b/lib/kv-router/src/indexer/tests.rs
@@ -267,12 +267,8 @@ fn make_indexer_with_metrics(
     (indexer, metrics)
 }
 
-/// Ensure queued indexer work is drained, then give a short settle window.
-/// This is intentionally conservative for tests that assert immediately
-/// after asynchronous event ingestion.
 async fn flush_and_settle(index: &dyn KvIndexerInterface) {
     index.flush().await;
-    tokio::time::sleep(Duration::from_millis(100)).await;
 }
 
 async fn query_scores(index: &dyn KvIndexerInterface, query: &[u64]) -> OverlapScores {

--- a/lib/kv-router/src/indexer/thread_pool.rs
+++ b/lib/kv-router/src/indexer/thread_pool.rs
@@ -4,7 +4,6 @@
 use std::{
     sync::{Arc, Mutex, atomic::AtomicUsize},
     thread::JoinHandle,
-    time::Duration,
 };
 
 use async_trait::async_trait;
@@ -144,19 +143,20 @@ impl<T: SyncIndexer> ThreadPoolIndexer<T> {
         Arc::clone(&self.backend)
     }
 
-    /// Wait for all worker channels to drain.
+    /// Wait until all previously queued worker tasks have completed.
     ///
-    /// Used primarily for testing and benchmarking to ensure all queued events
-    /// have been picked up by workers before checking results.
+    /// Used primarily for testing and benchmarking to ensure writes are visible
+    /// before checking results.
     pub async fn flush(&self) {
-        loop {
-            let all_empty = self.worker_event_channels.iter().all(|ch| ch.is_empty());
-
-            if all_empty {
-                break;
+        let mut receivers = Vec::new();
+        for channel in &self.worker_event_channels {
+            let (resp_tx, resp_rx) = oneshot::channel();
+            if channel.send(WorkerTask::Flush(resp_tx)).is_ok() {
+                receivers.push(resp_rx);
             }
-
-            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+        for receiver in receivers {
+            let _ = receiver.await;
         }
     }
 
@@ -365,14 +365,15 @@ impl<T: SyncIndexer> KvIndexerInterface for ThreadPoolIndexer<T> {
 
     async fn flush(&self) -> usize {
         let curr_size: usize = self.worker_event_channels.iter().map(|ch| ch.len()).sum();
-        loop {
-            let all_empty = self.worker_event_channels.iter().all(|ch| ch.is_empty());
-
-            if all_empty {
-                break;
+        let mut receivers = Vec::new();
+        for channel in &self.worker_event_channels {
+            let (resp_tx, resp_rx) = oneshot::channel();
+            if channel.send(WorkerTask::Flush(resp_tx)).is_ok() {
+                receivers.push(resp_rx);
             }
-
-            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+        for receiver in receivers {
+            let _ = receiver.await;
         }
         curr_size
     }

--- a/lib/kv-router/src/indexer/types.rs
+++ b/lib/kv-router/src/indexer/types.rs
@@ -325,6 +325,12 @@ pub struct DumpRequest {
     pub resp: oneshot::Sender<Vec<RouterEvent>>,
 }
 
+/// A request to wait until all previously submitted work is applied.
+pub struct FlushRequest {
+    /// Channel to acknowledge completion.
+    pub resp: oneshot::Sender<()>,
+}
+
 /// A request to get all workers currently tracked
 pub struct GetWorkersRequest {
     /// Channel to send the worker IDs
@@ -340,6 +346,7 @@ pub enum WorkerTask {
     /// Best-effort maintenance task for shared-state backends.
     CleanupStaleChildren,
     DumpEvents(oneshot::Sender<anyhow::Result<Vec<RouterEvent>>>),
+    Flush(oneshot::Sender<()>),
     Terminate,
 }
 


### PR DESCRIPTION
Adds overlap-score parity coverage to the Mooncake trace replay test for the existing non-sharded indexer variants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage with replay-based validation framework for request overlap scoring analysis across multiple indexer configuration variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->