### PR TITLE
feat(trtllm): unified worker honors --extra-engine-args / --override-engine-args

### DIFF
--- a/components/src/dynamo/trtllm/llm_engine.py
+++ b/components/src/dynamo/trtllm/llm_engine.py
@@ -34,7 +34,7 @@ from dynamo.common.backend.worker import WorkerConfig
 from dynamo.llm import ModelInput
 from dynamo.trtllm.args import parse_args
 from dynamo.trtllm.engine import Backend, TensorRTLLMEngine
-from dynamo.trtllm.utils.trtllm_utils import deep_update
+from dynamo.trtllm.utils.trtllm_utils import deep_update, warn_override_collisions
 
 logger = logging.getLogger(__name__)
 
@@ -109,6 +109,7 @@ class TrtllmLLMEngine(LLMEngine):
                 )
                 sys.exit(1)
             logging.info("Applying engine arg overrides: %s", overrides)
+            warn_override_collisions(engine_args, overrides)
             deep_update(engine_args, overrides)
 
         # Pull the *post-override* values from engine_args so the engine instance

--- a/components/src/dynamo/trtllm/llm_engine.py
+++ b/components/src/dynamo/trtllm/llm_engine.py
@@ -111,13 +111,16 @@ class TrtllmLLMEngine(LLMEngine):
             logging.info("Applying engine arg overrides: %s", overrides)
             deep_update(engine_args, overrides)
 
+        # Pull the *post-override* values from engine_args so the engine instance
+        # (and the EngineConfig the frontend reads in start()) stays in sync with
+        # what the underlying TRT-LLM engine actually got.
         engine = cls(
             engine_args=engine_args,
             model_name=config.model,
             served_model_name=config.served_model_name,
-            max_seq_len=config.max_seq_len,
-            max_batch_size=config.max_batch_size,
-            max_num_tokens=config.max_num_tokens,
+            max_seq_len=engine_args.get("max_seq_len", config.max_seq_len),
+            max_batch_size=engine_args.get("max_batch_size", config.max_batch_size),
+            max_num_tokens=engine_args.get("max_num_tokens", config.max_num_tokens),
             kv_block_size=config.kv_block_size,
         )
         worker_config = WorkerConfig.from_runtime_config(

--- a/components/src/dynamo/trtllm/llm_engine.py
+++ b/components/src/dynamo/trtllm/llm_engine.py
@@ -10,13 +10,16 @@ and feature gap details.
 from __future__ import annotations
 
 import dataclasses
+import json
 import logging
 import re
+import sys
 from collections.abc import AsyncGenerator
 from typing import Any
 
 from tensorrt_llm.llmapi import KvCacheConfig, SchedulerConfig
 from tensorrt_llm.llmapi.llm import SamplingParams
+from tensorrt_llm.llmapi.llm_utils import update_llm_args_with_extra_options
 from tensorrt_llm.sampling_params import GuidedDecodingParams
 from torch.cuda import device_count
 
@@ -31,6 +34,7 @@ from dynamo.common.backend.worker import WorkerConfig
 from dynamo.llm import ModelInput
 from dynamo.trtllm.args import parse_args
 from dynamo.trtllm.engine import Backend, TensorRTLLMEngine
+from dynamo.trtllm.utils.trtllm_utils import deep_update
 
 logger = logging.getLogger(__name__)
 
@@ -80,6 +84,32 @@ class TrtllmLLMEngine(LLMEngine):
             "max_beam_width": config.max_beam_width,
             "max_batch_size": config.max_batch_size,
         }
+
+        # Apply --extra-engine-args (YAML) and --override-engine-args (JSON)
+        # the same way the legacy `dynamo.trtllm` worker does
+        # (workers/llm_worker.py:285-298). Without this, profiler / parallel
+        # scheduler caps like `--override-engine-args '{"kv_cache_config":
+        # {"max_tokens": N}}'` are silently ignored on the unified path,
+        # causing tests to allocate at the engine config's default fraction
+        # and OOM the GPU under parallel load.
+        if config.extra_engine_args:
+            engine_args = update_llm_args_with_extra_options(
+                engine_args, config.extra_engine_args
+            )
+        if config.override_engine_args:
+            try:
+                overrides = json.loads(config.override_engine_args)
+            except json.JSONDecodeError as e:
+                logging.error("Failed to parse override_engine_args as JSON: %s", e)
+                sys.exit(1)
+            if not isinstance(overrides, dict):
+                logging.error(
+                    "override_engine_args must be a JSON object, got %s",
+                    type(overrides).__name__,
+                )
+                sys.exit(1)
+            logging.info("Applying engine arg overrides: %s", overrides)
+            deep_update(engine_args, overrides)
 
         engine = cls(
             engine_args=engine_args,

--- a/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
@@ -21,7 +21,7 @@ if not torch.cuda.is_available():
 from dynamo.trtllm.args import Config, parse_args
 from dynamo.trtllm.constants import Modality
 from dynamo.trtllm.tests.conftest import make_cli_args_fixture
-from dynamo.trtllm.utils.trtllm_utils import deep_update
+from dynamo.trtllm.utils.trtllm_utils import deep_update, warn_override_collisions
 from dynamo.trtllm.workers.llm_worker import init_llm_worker
 
 # Get path relative to this test file
@@ -168,6 +168,50 @@ def test_deep_update_adds_new_keys():
     source = {"b": 2, "c": {"nested": 3}}
     deep_update(target, source)
     assert target == {"a": 1, "b": 2, "c": {"nested": 3}}
+
+
+# ---- Tests for trtllm_utils.warn_override_collisions ----
+
+
+def test_warn_override_collisions_logs_replaced_scalar(caplog):
+    """A scalar override that changes an existing value emits a warning."""
+    target = {"max_seq_len": 1024}
+    source = {"max_seq_len": 2048}
+    with caplog.at_level("WARNING"):
+        warn_override_collisions(target, source)
+    assert any(
+        "max_seq_len" in r.message and "1024" in r.message and "2048" in r.message
+        for r in caplog.records
+    )
+
+
+def test_warn_override_collisions_recurses_into_nested_dicts(caplog):
+    """Nested-dict overrides report the full dotted path."""
+    target = {"kv_cache_config": {"max_tokens": 1000, "free_gpu_memory_fraction": 0.85}}
+    source = {"kv_cache_config": {"max_tokens": 2592}}
+    with caplog.at_level("WARNING"):
+        warn_override_collisions(target, source)
+    assert any("kv_cache_config.max_tokens" in r.message for r in caplog.records)
+    # free_gpu_memory_fraction wasn't in source — should not warn.
+    assert not any("free_gpu_memory_fraction" in r.message for r in caplog.records)
+
+
+def test_warn_override_collisions_skips_new_keys(caplog):
+    """Keys not present in target are additions, not collisions — no warning."""
+    target = {"max_seq_len": 1024}
+    source = {"max_batch_size": 32}
+    with caplog.at_level("WARNING"):
+        warn_override_collisions(target, source)
+    assert caplog.records == []
+
+
+def test_warn_override_collisions_skips_identical_values(caplog):
+    """Override with the same value as target is a no-op — no warning."""
+    target = {"max_seq_len": 1024}
+    source = {"max_seq_len": 1024}
+    with caplog.at_level("WARNING"):
+        warn_override_collisions(target, source)
+    assert caplog.records == []
 
 
 # ---- Tests for engine_args resolution with extra/override engine args ----

--- a/components/src/dynamo/trtllm/utils/trtllm_utils.py
+++ b/components/src/dynamo/trtllm/utils/trtllm_utils.py
@@ -3,6 +3,7 @@
 
 """Shared utilities for the TRT-LLM backend."""
 
+import logging
 from collections.abc import Mapping
 from typing import Any
 
@@ -19,3 +20,22 @@ def deep_update(target: dict[str, Any], source: Mapping[str, Any]) -> None:
             deep_update(target[key], value)
         else:
             target[key] = value
+
+
+def warn_override_collisions(
+    target: Mapping[str, Any], source: Mapping[str, Any], path: str = ""
+) -> None:
+    """Log warnings for keys in *source* that will overwrite existing values in *target*."""
+    for key, new_val in source.items():
+        full_key = f"{path}.{key}" if path else key
+        if key in target:
+            old_val = target[key]
+            if isinstance(new_val, dict) and isinstance(old_val, dict):
+                warn_override_collisions(old_val, new_val, full_key)
+            elif old_val != new_val:
+                logging.warning(
+                    "override_engine_args will replace %s: %r -> %r",
+                    full_key,
+                    old_val,
+                    new_val,
+                )


### PR DESCRIPTION
#### Overview:

Bring the `dynamo.trtllm` unified worker to parity with the existing `dynamo.trtllm` worker by honoring `--extra-engine-args` (YAML) and `--override-engine-args` (JSON).

#### Details:

- Port YAML+JSON merge sequence (`update_llm_args_with_extra_options` + `deep_update`) from `workers/llm_worker.py:285-298` into `TrtllmLLMEngine.from_args`.
- Validate parsed override is a JSON object before `deep_update`; clear error otherwise.

#### Where should the reviewer start?

`components/src/dynamo/trtllm/llm_engine.py`

#### Related Issues:

Relates to OPS-4851

/coderabbit profile chill