### PR TITLE
fix(llm): detokenize top_logprobs token_ids in backend (DYN-2923)

### DIFF
--- a/lib/llm/src/backend.rs
+++ b/lib/llm/src/backend.rs
@@ -66,6 +66,10 @@ struct DecoderUnfoldState {
     validate_engine_decode: bool,
     /// Set to true when a local stop condition is detected, causing the stream to end
     finished: bool,
+    /// Tokenizer used to decode top-logprob token_ids when the backend omits text
+    /// (e.g. SGLang with --skip-tokenizer-init forcibly drops it).
+    tokenizer: Tokenizer,
+    skip_special_tokens: bool,
 }
 
 impl Backend {
@@ -113,6 +117,8 @@ impl Backend {
             decoder,
             validate_engine_decode: self.validate_engine_decode,
             finished: false,
+            tokenizer: tokenizer.clone(),
+            skip_special_tokens,
         })
     }
 }
@@ -272,6 +278,24 @@ impl
                     }
                     data.text = text;
                     data.tokens = Some(tokens);
+
+                    if let Some(top_logprobs) = data.top_logprobs.as_mut() {
+                        for position in top_logprobs.iter_mut() {
+                            for entry in position.iter_mut() {
+                                if entry.token.is_none()
+                                    && let Ok(decoded) = state
+                                        .tokenizer
+                                        .decode(&[entry.token_id], state.skip_special_tokens)
+                                {
+                                    let s: String = decoded.into();
+                                    if entry.bytes.is_none() && !s.is_empty() {
+                                        entry.bytes = Some(s.as_bytes().to_vec());
+                                    }
+                                    entry.token = Some(s);
+                                }
+                            }
+                        }
+                    }
 
                     output.data = Some(data);
 


### PR DESCRIPTION
## Summary

Fixes [DYN-2923](https://linear.app/) — every entry in
`logprobs.content[i].top_logprobs[]` from the SGLang backend has
`token = ""` and `bytes = null`, while only `logprob` is correct. The
selected token at `logprobs.content[i]` is unaffected. vLLM and TRT-LLM
emit correct values for the same request shape.

### Repro

Aggregated SGLang launch (`bash examples/backends/sglang/launch/agg.sh`),
then:

```bash
curl -s http://localhost:8000/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{
    "model": "Qwen/Qwen3-0.6B",
    "messages": [{"role": "user", "content": "Count from one to five."}],
    "max_tokens": 8,
    "temperature": 0.0,
    "logprobs": true,
    "top_logprobs": 5
  }' | jq '.choices[0].logprobs.content[2]'
```

Before:

```json
{
  "token": "Okay", "logprob": -0.016022734, "bytes": [79,107,97,121],
  "top_logprobs": [
    {"token": "", "logprob": -0.016022734, "bytes": null},
    {"token": "", "logprob": -4.266023,    "bytes": null},
    {"token": "", "logprob": -6.891023,    "bytes": null},
    {"token": "", "logprob": -9.266023,    "bytes": null},
    {"token": "", "logprob": -9.391023,    "bytes": null}
  ]
}
```

## Root cause

Two-layer:

1. **SGLang side** — with `--skip-tokenizer-init` (the launch script
   default), `tokenizer_manager` (line 2200-2201) forcibly clears
   `return_text_in_logprobs` because the engine has no tokenizer to
   decode with. `output_top_logprobs` comes out as
   `(logprob, token_id, None)`.
2. **Dynamo side** — `_extract_logprobs` propagates the `None` as
   `"token"`. Rust's `TopLogprob` deserializes to `token: None,
   bytes: None`. The OpenAI converter
   (`lib/llm/src/protocols/openai.rs:238`) does
   `top_lp.token.clone().unwrap_or_default()` → `""`, and
   `token_to_utf8_bytes("")` → `None`.

Selected-token text is unaffected because it's filled from
`BackendOutput.tokens`, populated by the frontend detokenizer.

vLLM and TRT-LLM are unaffected because their handlers read
`decoded_token` from per-LogProb Python objects, not from a request-level
flag.

## Fix

`lib/llm/src/backend.rs`: thread the frontend `Tokenizer` and
`skip_special_tokens` through `DecoderUnfoldState`, and detokenize each
`TopLogprob.token_id` whose `token` is `None` (and fill `bytes` from the
resulting UTF-8). Same boundary that already detokenizes the selected
tokens — the tokenizer is always present here.

Backend-agnostic — also closes the same gap if vLLM or TRT-LLM ever emit
`None` for `decoded_token`.

24 insertions to `lib/llm/src/backend.rs`, no changes elsewhere.

## Verification

After rebuild (`cd lib/bindings/python && maturin develop --uv`) and
relaunching the agg script, the repro curl returns correct token text
and bytes for each top entry:

```json
{
  "token": "Okay", "logprob": -0.016011119, "bytes": [79,107,97,121],
  "top_logprobs": [
    {"token": "Okay",    "logprob": -0.016011119, "bytes": [79,107,97,121]},
    {"token": "Alright", "logprob": -4.266011,    "bytes": [65,108,114,105,103,104,116]},
    {"token": "I",       "logprob": -6.891011,    "bytes": [73]},
    {"token": "Hmm",     "logprob": -9.266011,    "bytes": [72,109,109]},
    {"token": "The",     "logprob": -9.391011,    "bytes": [84,104,101]}
  ]
}
```

Logprobs unchanged. Selected-token output unchanged.

## Test plan

- [x] Manual: SGLang agg + Qwen3-0.6B + `logprobs:true, top_logprobs:5`
      — token + bytes populated.
- [ ] Manual: same on vLLM and TRT-LLM (no behavior change expected — they
      already emit `decoded_token`, so `entry.token.is_none()` short-circuits).
- [ ] Cargo test on `dynamo-llm` (no test changes; backend logic touched
      is in the existing detokenization path).

## Note on porting to `main`

`backend.rs` on `main` has diverged (now supports `n>1` choices via
`HashMap<u32, Decoder>` and a `DecoderParams` extractor). Targeting
`release/1.1.0` directly per Ishan's request; will port to `main` in a
follow-up PR with the equivalent change adjusted for the new structure.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8887" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
