### PR TITLE
fix(parsers): part 2 — recover 9 silent-drop scenarios across top-7 parsers

### DIFF
--- a/lib/llm/src/protocols/openai/chat_completions/jail.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/jail.rs
@@ -12,6 +12,7 @@ use dynamo_parsers::tool_calling::json::try_tool_call_parse_basic_json;
 use dynamo_parsers::tool_calling::parsers::get_tool_parser_map;
 use dynamo_parsers::tool_calling::{
     detect_tool_call_start, find_tool_call_end_position, try_tool_call_parse_aggregate,
+    try_tool_call_parse_aggregate_finalize,
 };
 use dynamo_runtime::protocols::annotated::Annotated;
 use futures::{Stream, StreamExt};
@@ -250,6 +251,7 @@ impl ChoiceJailState {
                                 jailed_part,
                                 choice,
                                 self.emitted_tool_calls_count,
+                                false, // streaming early-exit, no EOF recovery
                             )
                             .await;
 
@@ -382,6 +384,7 @@ impl ChoiceJailState {
                         &jailed_owned,
                         choice,
                         self.emitted_tool_calls_count,
+                        false, // streaming unjail, no EOF recovery
                     )
                     .await;
                 unjailed_choice.logprobs = jail_logprobs;
@@ -445,6 +448,7 @@ impl ChoiceJailState {
                     &self.accumulated_content,
                     &dummy_choice,
                     self.emitted_tool_calls_count,
+                    true, // finalize: enable EOF recovery for missing-end-token / truncated-JSON
                 )
                 .await;
             // Attach the full accumulated logprobs to the final choice
@@ -914,24 +918,38 @@ impl JailedStream {
         }
     }
 
-    /// Parse tool calls from accumulated content and create choice
+    /// Parse tool calls from accumulated content and create choice.
+    ///
+    /// `is_finalize` selects the recovery-enabled aggregator (missing
+    /// outer end-token / truncated JSON). Streaming early-exit callers pass
+    /// `false`; the stream-end finalize path passes `true`.
     async fn create_tool_call_choice(
         &self,
         choice_index: u32,
         accumulated_content: &str,
         base_choice: &ChatChoiceStream,
         tool_call_offset: usize,
+        is_finalize: bool,
     ) -> ChatChoiceStream {
         match &self.jail_mode {
             JailMode::MarkerBased => {
                 // Traditional marker-based tool call parsing
                 let tools_slice = self.tool_definitions.as_deref();
-                let parse_result = try_tool_call_parse_aggregate(
-                    accumulated_content,
-                    self.tool_call_parser.as_deref(),
-                    tools_slice,
-                )
-                .await;
+                let parse_result = if is_finalize {
+                    try_tool_call_parse_aggregate_finalize(
+                        accumulated_content,
+                        self.tool_call_parser.as_deref(),
+                        tools_slice,
+                    )
+                    .await
+                } else {
+                    try_tool_call_parse_aggregate(
+                        accumulated_content,
+                        self.tool_call_parser.as_deref(),
+                        tools_slice,
+                    )
+                    .await
+                };
                 match parse_result {
                     Ok((tool_calls, normal_text)) if !tool_calls.is_empty() => {
                         // If a named tool filter is set (tool_choice=named + parser path), reject

--- a/lib/llm/tests/test_jail.rs
+++ b/lib/llm/tests/test_jail.rs
@@ -945,9 +945,15 @@ mod tests {
 
     #[tokio::test]
     async fn test_jailed_stream_partial_tool_call() {
-        // Tests handling of incomplete tool call when stream ends abruptly
+        // Tests handling of incomplete tool call when stream ends abruptly.
+        // After PR #8888, finalize() runs `try_tool_call_parse_aggregate_finalize`
+        // which enables EOF recovery — the parser balances the unclosed braces
+        // and surfaces the call (with whatever args were captured) instead of
+        // dropping it as plain text. Streaming early-exit still requires the
+        // end-token to actually arrive, so this only fires at stream end.
+        //
         // Input: "Starting function call. " + "<TOOLCALL>[{\"name\": \"incomplete_func\", \"arguments\": {" (no end marker)
-        // Expected output: 2 chunks [Content(), Content(partial)] - partial accumulated content released on stream end
+        // Expected output: 2 chunks [Content(), ToolCall(incomplete_func, {})]
         let chunks = vec![
             create_mock_response_chunk("Starting function call. ".to_string(), 0),
             create_mock_response_chunk("<TOOLCALL>".to_string(), 0),
@@ -965,26 +971,14 @@ mod tests {
 
         let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
 
-        // Should handle partial tool call gracefully - releases accumulated content on stream end
         assert_eq!(
             results.len(),
             2,
-            "Should handle partial tool call and release content"
+            "Should emit prefix content + recovered tool call"
         );
 
-        // Verify exact output structure: [Content(), Content(accumulated partial)]
         test_utils::assert_content(&results[0], "Starting function call. ");
-        test_utils::assert_content(
-            &results[1],
-            "<TOOLCALL>[{\"name\": \"incomplete_func\", \"arguments\": {",
-        );
-
-        // Verify partial content is preserved as text since no valid tool call could be parsed
-        let reconstructed = test_utils::reconstruct_content(&results);
-        assert_eq!(
-            reconstructed,
-            "Starting function call. <TOOLCALL>[{\"name\": \"incomplete_func\", \"arguments\": {"
-        );
+        test_utils::assert_tool_call(&results[1], "incomplete_func", serde_json::json!({}));
     }
 
     #[tokio::test]

--- a/lib/parsers/src/tool_calling/config.rs
+++ b/lib/parsers/src/tool_calling/config.rs
@@ -32,6 +32,15 @@ pub struct JsonParserConfig {
     /// `tool_call_end_tokens` are ignored.
     #[serde(default)]
     pub bare_json_mode: bool,
+
+    /// Allow recovery when the outer end-token is missing (max_tokens / EOS
+    /// truncation). Streaming jails MUST leave this `false` — otherwise the
+    /// parser claims "complete tool call" before the end-token has actually
+    /// arrived and `should_exit_jail_early` fires too aggressively. Finalize
+    /// / aggregate paths set it to `true` so a real but unterminated call
+    /// isn't silently dropped.
+    #[serde(default)]
+    pub allow_eof_recovery: bool,
 }
 
 impl Default for JsonParserConfig {
@@ -44,6 +53,7 @@ impl Default for JsonParserConfig {
             arguments_keys: vec!["arguments".to_string(), "parameters".to_string()],
             parser_type: JsonParserType::Basic,
             bare_json_mode: false,
+            allow_eof_recovery: false,
         }
     }
 }
@@ -62,6 +72,11 @@ pub struct XmlParserConfig {
     pub parameter_start_token: String,
     /// End token for parameter (e.g., `</parameter>`)
     pub parameter_end_token: String,
+
+    /// See [`JsonParserConfig::allow_eof_recovery`]. Streaming jails MUST
+    /// leave this `false`.
+    #[serde(default)]
+    pub allow_eof_recovery: bool,
 }
 
 impl Default for XmlParserConfig {
@@ -73,6 +88,7 @@ impl Default for XmlParserConfig {
             function_end_token: "</function>".to_string(),
             parameter_start_token: "<parameter=".to_string(),
             parameter_end_token: "</parameter>".to_string(),
+            allow_eof_recovery: false,
         }
     }
 }
@@ -125,6 +141,11 @@ pub struct Glm47ParserConfig {
     pub arg_value_start: String,
     /// End token for argument value (e.g., "</arg_value>")
     pub arg_value_end: String,
+
+    /// See [`JsonParserConfig::allow_eof_recovery`]. Streaming jails MUST
+    /// leave this `false`.
+    #[serde(default)]
+    pub allow_eof_recovery: bool,
 }
 
 impl Default for Glm47ParserConfig {
@@ -136,6 +157,7 @@ impl Default for Glm47ParserConfig {
             arg_key_end: "</arg_key>".to_string(),
             arg_value_start: "<arg_value>".to_string(),
             arg_value_end: "</arg_value>".to_string(),
+            allow_eof_recovery: false,
         }
     }
 }
@@ -433,6 +455,7 @@ impl ToolCallConfig {
                 function_end_token: "</invoke>".to_string(),
                 parameter_start_token: "<parameter name=".to_string(),
                 parameter_end_token: "</parameter>".to_string(),
+                allow_eof_recovery: false,
             }),
         }
     }

--- a/lib/parsers/src/tool_calling/harmony/harmony_parser.rs
+++ b/lib/parsers/src/tool_calling/harmony/harmony_parser.rs
@@ -2,11 +2,62 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::super::ToolDefinition;
+use super::super::json::base_json_parser::try_repair_truncated_json;
 use super::config::JsonParserConfig;
 use super::response::{CalledFunction, ToolCallResponse, ToolCallType};
 use openai_harmony::chat::{Content::Text, Role};
 use openai_harmony::{HarmonyEncoding, HarmonyEncodingName, load_harmony_encoding};
+use regex::Regex;
 use serde_json::Value;
+use std::sync::OnceLock;
+
+static COMMENTARY_BLOCK_REGEX: OnceLock<Regex> = OnceLock::new();
+
+/// Regex fallback for inputs harmony's tokenizer rejects: parallel commentary
+/// blocks, truncated JSON args. Matches each commentary→call slice and
+/// extracts the function name + raw args payload.
+fn commentary_block_regex() -> &'static Regex {
+    COMMENTARY_BLOCK_REGEX.get_or_init(|| {
+        // Name is `[\w.\-]+` (alphanumeric / dot / hyphen / underscore).
+        // Between name and `<|message|>` we tolerate optional
+        // `<|constrain|>json` and whitespace by using non-greedy `.*?`.
+        Regex::new(
+            r"(?s)<\|channel\|>commentary to=functions\.(?P<name>[\w.\-]+).*?<\|message\|>(?P<args>.*?)<\|call\|>",
+        )
+        .expect("commentary block regex")
+    })
+}
+
+/// Extract calls via regex when harmony's strict tokenizer rejects the input
+/// (truncated JSON, multiple back-to-back commentary blocks, etc.).
+fn extract_calls_via_regex(text: &str) -> Vec<ToolCallResponse> {
+    let mut out = Vec::new();
+    for (i, cap) in commentary_block_regex().captures_iter(text).enumerate() {
+        let name = cap.name("name").map(|m| m.as_str()).unwrap_or("");
+        let raw_args = cap.name("args").map(|m| m.as_str().trim()).unwrap_or("{}");
+        if name.is_empty() {
+            continue;
+        }
+        let args_json = match serde_json::from_str::<Value>(raw_args) {
+            Ok(v) => serde_json::to_string(&v).unwrap_or_else(|_| raw_args.to_string()),
+            Err(_) => match try_repair_truncated_json(raw_args)
+                .and_then(|r| serde_json::from_str::<Value>(&r).ok())
+            {
+                Some(v) => serde_json::to_string(&v).unwrap_or_else(|_| raw_args.to_string()),
+                None => raw_args.to_string(),
+            },
+        };
+        out.push(ToolCallResponse {
+            id: format!("call-{}", i + 1),
+            tp: ToolCallType::Function,
+            function: CalledFunction {
+                name: name.to_string(),
+                arguments: args_json,
+            },
+        });
+    }
+    out
+}
 
 static GLOBAL_HARMONY_GPTOSS_ENCODING: tokio::sync::OnceCell<
     Result<HarmonyEncoding, anyhow::Error>,
@@ -63,8 +114,16 @@ pub async fn parse_tool_calls_harmony_complete(
         Ok(messages) => messages,
         Err(e) => {
             tracing::debug!(
-                "Failed to parse messages from completion tokens: {e}. Tool calls will not be parsed."
+                "Failed to parse messages from completion tokens: {e}. Falling back to regex extraction."
             );
+            // Recovery: harmony rejects parallel commentary blocks and
+            // truncated JSON. The regex fallback extracts each commentary
+            // block independently and runs the same JSON repair as
+            // base_json_parser.
+            let calls = extract_calls_via_regex(text);
+            if !calls.is_empty() {
+                return Ok((calls, Some(String::new())));
+            }
             return Ok((vec![], Some(text.to_string())));
         }
     };
@@ -95,12 +154,19 @@ pub async fn parse_tool_calls_harmony_complete(
             };
 
             let args = match message.content.first() {
-                Some(Text(text)) => match serde_json::from_str::<Value>(text.text.trim()) {
-                    Ok(value) => value,
-                    Err(_) => {
-                        Value::Null // Set args to null if it's not valid JSON
+                Some(Text(text)) => {
+                    let trimmed = text.text.trim();
+                    match serde_json::from_str::<Value>(trimmed) {
+                        Ok(value) => value,
+                        Err(_) => {
+                            // Truncation recovery: balance unclosed strings /
+                            // braces (max_tokens / EOS pattern) and retry.
+                            try_repair_truncated_json(trimmed)
+                                .and_then(|r| serde_json::from_str::<Value>(&r).ok())
+                                .unwrap_or(Value::Null)
+                        }
                     }
-                },
+                }
                 _ => {
                     Value::Null // Set args to null if it's not a text content
                 }
@@ -283,34 +349,35 @@ mod tests {
     // customer sees HTTP 200 with fewer tool_calls than the model emitted.
     // Promoting this to recovery is a parser change.
     #[tokio::test] // CASE.2 — gpt-oss
-    async fn test_parse_harmony_multiple_calls_silent_drop() {
+    async fn test_parse_harmony_multiple_calls_recovers() {
         let text = r#"<|start|>assistant<|channel|>commentary to=functions.a <|constrain|>json<|message|>{"x":1}<|call|><|start|>assistant<|channel|>commentary to=functions.b <|constrain|>json<|message|>{"y":2}<|call|>"#;
         let (tool_calls, _normal) =
             parse_tool_calls_harmony_complete(text, &Default::default(), None)
                 .await
                 .unwrap();
-        assert_eq!(
-            tool_calls.len(),
-            0,
-            "harmony today drops both calls when two commentary blocks appear back-to-back"
-        );
+        assert_eq!(tool_calls.len(), 2);
+        let (n0, a0) = extract_name_and_args(tool_calls[0].clone());
+        let (n1, a1) = extract_name_and_args(tool_calls[1].clone());
+        assert_eq!(n0, "a");
+        assert_eq!(a0["x"], 1);
+        assert_eq!(n1, "b");
+        assert_eq!(a1["y"], 2);
     }
 
     // Pin current behavior on truncated JSON args. harmony today drops the
     // call entirely rather than falling back to a string-form arguments or
     // surfacing an explicit error.
     #[tokio::test] // CASE.4 — gpt-oss
-    async fn test_parse_harmony_truncated_json_silent_drop() {
+    async fn test_parse_harmony_truncated_json_recovers() {
         let text = r#"<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC<|call|>"#;
         let (tool_calls, _normal) =
             parse_tool_calls_harmony_complete(text, &Default::default(), None)
                 .await
                 .unwrap();
-        assert_eq!(
-            tool_calls.len(),
-            0,
-            "harmony today drops the call when JSON args are truncated mid-value"
-        );
+        assert_eq!(tool_calls.len(), 1);
+        let (name, args) = extract_name_and_args(tool_calls[0].clone());
+        assert_eq!(name, "get_weather");
+        assert_eq!(args["location"], "NYC");
     }
 
     #[tokio::test] // CASE.4, CASE.5, CASE.19

--- a/lib/parsers/src/tool_calling/harmony/harmony_parser.rs
+++ b/lib/parsers/src/tool_calling/harmony/harmony_parser.rs
@@ -13,9 +13,9 @@ use std::sync::OnceLock;
 
 static COMMENTARY_BLOCK_REGEX: OnceLock<Regex> = OnceLock::new();
 
-/// Regex fallback for inputs harmony's tokenizer rejects: parallel commentary
-/// blocks, truncated JSON args. Matches each commentary→call slice and
-/// extracts the function name + raw args payload.
+/// Regex fallback used only when `openai_harmony`'s tokenizer rejects the
+/// input — alternative on this path is silent-drop. Worst case is missing
+/// a call, never fabricating one (full structural signature required).
 fn commentary_block_regex() -> &'static Regex {
     COMMENTARY_BLOCK_REGEX.get_or_init(|| {
         // Name is `[\w.\-]+` (alphanumeric / dot / hyphen / underscore).
@@ -33,11 +33,20 @@ fn commentary_block_regex() -> &'static Regex {
 
 /// Extract calls via regex when harmony's strict tokenizer rejects the input
 /// (truncated JSON, multiple back-to-back commentary blocks, etc.).
-fn extract_calls_via_regex(text: &str) -> Vec<ToolCallResponse> {
+/// Returns (calls, residual_text) where residual_text is everything not
+/// consumed by a matched commentary block — preserved so analysis prose and
+/// non-tool suffixes aren't dropped.
+fn extract_calls_via_regex(text: &str) -> (Vec<ToolCallResponse>, String) {
     let mut out = Vec::new();
+    let mut residual = String::new();
+    let mut cursor = 0;
     for (i, cap) in commentary_block_regex().captures_iter(text).enumerate() {
-        let name = cap.name("name").map(|m| m.as_str()).unwrap_or("");
-        let raw_args = cap.name("args").map(|m| m.as_str().trim()).unwrap_or("{}");
+        let m = cap.get(0).expect("regex match has full span");
+        residual.push_str(&text[cursor..m.start()]);
+        cursor = m.end();
+
+        let name = cap.name("name").map(|x| x.as_str()).unwrap_or("");
+        let raw_args = cap.name("args").map(|x| x.as_str().trim()).unwrap_or("{}");
         if name.is_empty() {
             continue;
         }
@@ -59,7 +68,8 @@ fn extract_calls_via_regex(text: &str) -> Vec<ToolCallResponse> {
             },
         });
     }
-    out
+    residual.push_str(&text[cursor..]);
+    (out, residual.trim().to_string())
 }
 
 static GLOBAL_HARMONY_GPTOSS_ENCODING: tokio::sync::OnceCell<
@@ -123,9 +133,9 @@ pub async fn parse_tool_calls_harmony_complete(
             // truncated JSON. The regex fallback extracts each commentary
             // block independently and runs the same JSON repair as
             // base_json_parser.
-            let calls = extract_calls_via_regex(text);
+            let (calls, residual) = extract_calls_via_regex(text);
             if !calls.is_empty() {
-                return Ok((calls, Some(String::new())));
+                return Ok((calls, Some(residual)));
             }
             return Ok((vec![], Some(text.to_string())));
         }
@@ -397,6 +407,27 @@ mod tests {
         let (name, args) = extract_name_and_args(tool_calls[0].clone());
         assert_eq!(name, "get_weather");
         assert_eq!(args["location"], "NYC");
+    }
+
+    // The regex fallback must preserve any non-tool spans (prose before
+    // the call, suffix after `<|call|>`) as `normal_text`, not zero them.
+    #[tokio::test]
+    async fn test_parse_harmony_regex_fallback_preserves_residual_text() {
+        let text = r#"PREFIX <|start|>assistant<|channel|>commentary to=functions.a <|constrain|>json<|message|>{"x":1}<|call|> SUFFIX"#;
+        let (tool_calls, normal) =
+            parse_tool_calls_harmony_complete(text, &Default::default(), None)
+                .await
+                .unwrap();
+        assert_eq!(tool_calls.len(), 1);
+        let normal = normal.unwrap_or_default();
+        assert!(
+            normal.contains("PREFIX"),
+            "normal must keep prefix: {normal:?}"
+        );
+        assert!(
+            normal.contains("SUFFIX"),
+            "normal must keep suffix: {normal:?}"
+        );
     }
 
     #[tokio::test] // CASE.4, CASE.5, CASE.19

--- a/lib/parsers/src/tool_calling/harmony/harmony_parser.rs
+++ b/lib/parsers/src/tool_calling/harmony/harmony_parser.rs
@@ -110,7 +110,7 @@ pub async fn get_harmony_encoding() -> &'static Result<HarmonyEncoding, anyhow::
 /// * `Err(e)` - If parsing fails due to encoding or tokenization errors
 pub async fn parse_tool_calls_harmony_complete(
     text: &str,
-    _config: &JsonParserConfig,
+    config: &JsonParserConfig,
     _tools: Option<&[ToolDefinition]>,
 ) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
     let enc = match get_harmony_encoding().await.as_ref() {
@@ -130,12 +130,14 @@ pub async fn parse_tool_calls_harmony_complete(
                 "Failed to parse messages from completion tokens: {e}. Falling back to regex extraction."
             );
             // Recovery: harmony rejects parallel commentary blocks and
-            // truncated JSON. The regex fallback extracts each commentary
-            // block independently and runs the same JSON repair as
-            // base_json_parser.
-            let (calls, residual) = extract_calls_via_regex(text);
-            if !calls.is_empty() {
-                return Ok((calls, Some(residual)));
+            // truncated JSON. Gated on `allow_eof_recovery` so streaming
+            // jails (where the tokenizer often rejects mid-chunk before all
+            // tokens have arrived) don't extract a partial call.
+            if config.allow_eof_recovery {
+                let (calls, residual) = extract_calls_via_regex(text);
+                if !calls.is_empty() {
+                    return Ok((calls, Some(residual)));
+                }
             }
             return Ok((vec![], Some(text.to_string())));
         }
@@ -171,13 +173,16 @@ pub async fn parse_tool_calls_harmony_complete(
                     let trimmed = text.text.trim();
                     match serde_json::from_str::<Value>(trimmed) {
                         Ok(value) => value,
-                        Err(_) => {
+                        Err(_) if config.allow_eof_recovery => {
                             // Truncation recovery: balance unclosed strings /
                             // braces (max_tokens / EOS pattern) and retry.
+                            // Gated so streaming early-exit doesn't extract
+                            // a partial call with synthesized closers.
                             try_repair_truncated_json(trimmed)
                                 .and_then(|r| serde_json::from_str::<Value>(&r).ok())
                                 .unwrap_or(Value::Null)
                         }
+                        Err(_) => Value::Null,
                     }
                 }
                 _ => {
@@ -364,10 +369,16 @@ mod tests {
     #[tokio::test] // CASE.2 — gpt-oss
     async fn test_parse_harmony_multiple_calls_recovers() {
         let text = r#"<|start|>assistant<|channel|>commentary to=functions.a <|constrain|>json<|message|>{"x":1}<|call|><|start|>assistant<|channel|>commentary to=functions.b <|constrain|>json<|message|>{"y":2}<|call|>"#;
-        let (tool_calls, _normal) =
-            parse_tool_calls_harmony_complete(text, &Default::default(), None)
-                .await
-                .unwrap();
+        let (tool_calls, _normal) = parse_tool_calls_harmony_complete(
+            text,
+            &JsonParserConfig {
+                allow_eof_recovery: true,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
         assert_eq!(tool_calls.len(), 2);
         let (n0, a0) = extract_name_and_args(tool_calls[0].clone());
         let (n1, a1) = extract_name_and_args(tool_calls[1].clone());
@@ -383,10 +394,16 @@ mod tests {
     #[tokio::test] // CASE.4 — gpt-oss
     async fn test_parse_harmony_truncated_json_recovers() {
         let text = r#"<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC<|call|>"#;
-        let (tool_calls, _normal) =
-            parse_tool_calls_harmony_complete(text, &Default::default(), None)
-                .await
-                .unwrap();
+        let (tool_calls, _normal) = parse_tool_calls_harmony_complete(
+            text,
+            &JsonParserConfig {
+                allow_eof_recovery: true,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
         assert_eq!(tool_calls.len(), 1);
         let (name, args) = extract_name_and_args(tool_calls[0].clone());
         assert_eq!(name, "get_weather");
@@ -399,10 +416,16 @@ mod tests {
     #[tokio::test] // CASE.5 — gpt-oss
     async fn test_parse_harmony_bare_envelope_no_call_token_recovers() {
         let text = r#"<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}"#;
-        let (tool_calls, _normal) =
-            parse_tool_calls_harmony_complete(text, &Default::default(), None)
-                .await
-                .unwrap();
+        let (tool_calls, _normal) = parse_tool_calls_harmony_complete(
+            text,
+            &JsonParserConfig {
+                allow_eof_recovery: true,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
         assert_eq!(tool_calls.len(), 1);
         let (name, args) = extract_name_and_args(tool_calls[0].clone());
         assert_eq!(name, "get_weather");
@@ -414,10 +437,16 @@ mod tests {
     #[tokio::test]
     async fn test_parse_harmony_regex_fallback_preserves_residual_text() {
         let text = r#"PREFIX <|start|>assistant<|channel|>commentary to=functions.a <|constrain|>json<|message|>{"x":1}<|call|> SUFFIX"#;
-        let (tool_calls, normal) =
-            parse_tool_calls_harmony_complete(text, &Default::default(), None)
-                .await
-                .unwrap();
+        let (tool_calls, normal) = parse_tool_calls_harmony_complete(
+            text,
+            &JsonParserConfig {
+                allow_eof_recovery: true,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
         assert_eq!(tool_calls.len(), 1);
         let normal = normal.unwrap_or_default();
         assert!(

--- a/lib/parsers/src/tool_calling/harmony/harmony_parser.rs
+++ b/lib/parsers/src/tool_calling/harmony/harmony_parser.rs
@@ -21,8 +21,11 @@ fn commentary_block_regex() -> &'static Regex {
         // Name is `[\w.\-]+` (alphanumeric / dot / hyphen / underscore).
         // Between name and `<|message|>` we tolerate optional
         // `<|constrain|>json` and whitespace by using non-greedy `.*?`.
+        // Args end at either `<|call|>` (normal close) or end-of-string
+        // (`\z`, the bare-envelope CASE.5 variant where the model never
+        // emitted `<|call|>` before EOS / max_tokens).
         Regex::new(
-            r"(?s)<\|channel\|>commentary to=functions\.(?P<name>[\w.\-]+).*?<\|message\|>(?P<args>.*?)<\|call\|>",
+            r"(?s)<\|channel\|>commentary to=functions\.(?P<name>[\w.\-]+).*?<\|message\|>(?P<args>.*?)(?:<\|call\|>|\z)",
         )
         .expect("commentary block regex")
     })
@@ -370,6 +373,22 @@ mod tests {
     #[tokio::test] // CASE.4 — gpt-oss
     async fn test_parse_harmony_truncated_json_recovers() {
         let text = r#"<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC<|call|>"#;
+        let (tool_calls, _normal) =
+            parse_tool_calls_harmony_complete(text, &Default::default(), None)
+                .await
+                .unwrap();
+        assert_eq!(tool_calls.len(), 1);
+        let (name, args) = extract_name_and_args(tool_calls[0].clone());
+        assert_eq!(name, "get_weather");
+        assert_eq!(args["location"], "NYC");
+    }
+
+    // Bare-envelope CASE.5: no preceding `analysis` block, no `<|call|>`
+    // at the end. harmony's tokenizer rejects this; the regex fallback
+    // accepts EOS as a synthetic close.
+    #[tokio::test] // CASE.5 — gpt-oss
+    async fn test_parse_harmony_bare_envelope_no_call_token_recovers() {
+        let text = r#"<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}"#;
         let (tool_calls, _normal) =
             parse_tool_calls_harmony_complete(text, &Default::default(), None)
                 .await

--- a/lib/parsers/src/tool_calling/json/base_json_parser.rs
+++ b/lib/parsers/src/tool_calling/json/base_json_parser.rs
@@ -155,10 +155,15 @@ pub(crate) fn try_repair_truncated_json(s: &str) -> Option<String> {
             _ => {}
         }
     }
-    if !in_string && stack.is_empty() {
+    if !escape && !in_string && stack.is_empty() {
         return None;
     }
     let mut repaired = s.to_string();
+    // EOF mid-escape sequence: pair the trailing `\` with another `\` so the
+    // closing quote we append next isn't itself escaped.
+    if escape {
+        repaired.push('\\');
+    }
     if in_string {
         repaired.push('"');
     }
@@ -474,6 +479,24 @@ pub fn detect_tool_call_start_basic_json(chunk: &str, config: &JsonParserConfig)
     });
 
     has_partial_token || trimmed.contains('{') || trimmed.contains('[')
+}
+
+#[cfg(test)]
+mod repair_tests {
+    use super::*;
+
+    // EOF inside an escape sequence (`{"k":"a\` → `{"k":"a\\"}`). Without
+    // the `escape` guard, the appended `"` would itself be escaped and the
+    // resulting JSON would still be invalid.
+    #[test]
+    fn test_repair_eof_after_backslash() {
+        let repaired = try_repair_truncated_json(r#"{"k":"a\"#).expect("must repair");
+        assert!(
+            serde_json::from_str::<serde_json::Value>(&repaired).is_ok(),
+            "repaired must parse: {:?}",
+            repaired
+        );
+    }
 }
 
 #[cfg(test)]

--- a/lib/parsers/src/tool_calling/json/base_json_parser.rs
+++ b/lib/parsers/src/tool_calling/json/base_json_parser.rs
@@ -53,20 +53,23 @@ fn extract_tool_call_content(input: &str, start_token: &str, end_token: &str) ->
                     return Some(format!("[{}]", matches.join(",")));
                 }
             }
-            // Recovery: outer end-token absent (max_tokens / EOS truncation). If
-            // the start token is present and the trailing slice looks like JSON,
-            // treat EOF as the end token. Downstream `serde_json::from_str` is
-            // the validator: well-formed payloads recover, malformed ones still
-            // fall through to the normal-text path.
-            if let Some(start_pos) = input.find(start_token) {
-                let tail = input[start_pos + start_token.len()..].trim();
-                if tail.starts_with('{') || tail.starts_with('[') {
-                    return Some(tail.to_string());
-                }
-            }
             None
         }
         Err(_) => None,
+    }
+}
+
+/// EOF-as-end-token recovery — finalize-only path. Returns the JSON-looking
+/// tail after `start_token` when the outer end-token never arrived. Gated on
+/// `JsonParserConfig::allow_eof_recovery` so streaming early-exit doesn't
+/// fire mid-stream before the end-token has shown up.
+fn extract_tool_call_content_eof_recovery(input: &str, start_token: &str) -> Option<String> {
+    let start_pos = input.find(start_token)?;
+    let tail = input[start_pos + start_token.len()..].trim();
+    if tail.starts_with('{') || tail.starts_with('[') {
+        Some(tail.to_string())
+    } else {
+        None
     }
 }
 
@@ -298,7 +301,17 @@ pub fn try_tool_call_parse_basic_json(
                     }
                     (false, false) => {
                         // Start and end token case
-                        let result = extract_tool_call_content(&json, start_token, end_token);
+                        let mut result = extract_tool_call_content(&json, start_token, end_token);
+                        // EOF recovery: only when explicitly opted in (finalize
+                        // path). Streaming jails leave `allow_eof_recovery=false`
+                        // so the parser doesn't claim a complete call before
+                        // the end-token has actually arrived.
+                        if result.is_none()
+                            && config.allow_eof_recovery
+                            && json.contains(start_token.as_str())
+                        {
+                            result = extract_tool_call_content_eof_recovery(&json, start_token);
+                        }
                         if let Some(content) = result {
                             // Check if we found a start token but got empty JSON back
                             // This indicates the token was found but no valid JSON followed
@@ -391,8 +404,12 @@ pub fn try_tool_call_parse_basic_json(
     }
 
     // Truncation recovery: balance unclosed strings/braces (common
-    // max_tokens / EOS pattern) and retry the same three parses.
-    if let Some(repaired) = try_repair_truncated_json(json) {
+    // max_tokens / EOS pattern) and retry the same three parses. Gated on
+    // `allow_eof_recovery` so streaming jails don't claim a complete tool
+    // call while the model is still emitting JSON tokens.
+    if config.allow_eof_recovery
+        && let Some(repaired) = try_repair_truncated_json(json)
+    {
         let repaired = repaired.as_str();
         if let Ok(single) = serde_json::from_str::<CalledFunctionParameters>(repaired) {
             return Ok((

--- a/lib/parsers/src/tool_calling/json/base_json_parser.rs
+++ b/lib/parsers/src/tool_calling/json/base_json_parser.rs
@@ -53,6 +53,17 @@ fn extract_tool_call_content(input: &str, start_token: &str, end_token: &str) ->
                     return Some(format!("[{}]", matches.join(",")));
                 }
             }
+            // Recovery: outer end-token absent (max_tokens / EOS truncation). If
+            // the start token is present and the trailing slice looks like JSON,
+            // treat EOF as the end token. Downstream `serde_json::from_str` is
+            // the validator: well-formed payloads recover, malformed ones still
+            // fall through to the normal-text path.
+            if let Some(start_pos) = input.find(start_token) {
+                let tail = input[start_pos + start_token.len()..].trim();
+                if tail.starts_with('{') || tail.starts_with('[') {
+                    return Some(tail.to_string());
+                }
+            }
             None
         }
         Err(_) => None,
@@ -110,6 +121,51 @@ fn handle_single_token_tool_calls(input: &str, start_token: &str) -> Option<Stri
         return Some(String::new());
     }
     Some(format!("[{}]", items.join(",")))
+}
+
+/// Attempt to repair JSON truncated by max_tokens / EOS. Walks the input
+/// tracking string state and brace/bracket nesting; on EOF closes any
+/// open string and pops outstanding closers. Returns `Some(repaired)` only
+/// when at least one closer needed to be appended (so we don't churn
+/// already-valid JSON).
+pub(crate) fn try_repair_truncated_json(s: &str) -> Option<String> {
+    let mut stack: Vec<char> = Vec::new();
+    let mut in_string = false;
+    let mut escape = false;
+    for c in s.chars() {
+        if escape {
+            escape = false;
+            continue;
+        }
+        if in_string {
+            match c {
+                '\\' => escape = true,
+                '"' => in_string = false,
+                _ => {}
+            }
+            continue;
+        }
+        match c {
+            '"' => in_string = true,
+            '{' => stack.push('}'),
+            '[' => stack.push(']'),
+            '}' | ']' => {
+                stack.pop();
+            }
+            _ => {}
+        }
+    }
+    if !in_string && stack.is_empty() {
+        return None;
+    }
+    let mut repaired = s.to_string();
+    if in_string {
+        repaired.push('"');
+    }
+    while let Some(closer) = stack.pop() {
+        repaired.push(closer);
+    }
+    Some(repaired)
 }
 
 fn try_parse_normal_text(input: &str, start_token: &str) -> String {
@@ -327,6 +383,39 @@ pub fn try_tool_call_parse_basic_json(
         }
         // Return with whatever results we have, even if empty (e.g., [] is a valid empty array)
         return Ok((results, Some(normal_text)));
+    }
+
+    // Truncation recovery: balance unclosed strings/braces (common
+    // max_tokens / EOS pattern) and retry the same three parses.
+    if let Some(repaired) = try_repair_truncated_json(json) {
+        let repaired = repaired.as_str();
+        if let Ok(single) = serde_json::from_str::<CalledFunctionParameters>(repaired) {
+            return Ok((
+                vec![parse(single.name, single.parameters)?],
+                Some(normal_text),
+            ));
+        } else if let Ok(single) = serde_json::from_str::<CalledFunctionArguments>(repaired) {
+            return Ok((
+                vec![parse(single.name, single.arguments)?],
+                Some(normal_text),
+            ));
+        } else if let Ok(array) = serde_json::from_str::<Vec<serde_json::Value>>(repaired) {
+            let mut results = Vec::new();
+            for item in array {
+                if let Ok(func_args) =
+                    serde_json::from_value::<CalledFunctionArguments>(item.clone())
+                {
+                    results.push(parse(func_args.name, func_args.arguments)?);
+                } else if let Ok(func_params) =
+                    serde_json::from_value::<CalledFunctionParameters>(item)
+                {
+                    results.push(parse(func_params.name, func_params.parameters)?);
+                }
+            }
+            if !results.is_empty() {
+                return Ok((results, Some(normal_text)));
+            }
+        }
     }
 
     // If we found a start token but no valid JSON, return empty content

--- a/lib/parsers/src/tool_calling/json/mod.rs
+++ b/lib/parsers/src/tool_calling/json/mod.rs
@@ -150,13 +150,11 @@ mod tests {
         );
     }
 
-    // Pin current Nemotron behavior when </TOOLCALL> is absent due to
-    // max_tokens / EOS truncation. The JSON-family parser today silently
-    // drops the in-flight call — the failure mode TEST_CASES.md flags.
-    // Promoting to recovery (matching Kimi K2's behavior)
-    // would be a parser change.
+    // Recovery for missing outer </TOOLCALL> (max_tokens / EOS truncation):
+    // when the inner JSON array is well-formed, treat EOF as the end token
+    // and extract the call rather than silently dropping it.
     #[test] // CASE.5 — nemotron_deci
-    fn test_parse_nemotron_deci_no_outer_close_silent_drop() {
+    fn test_parse_nemotron_deci_no_outer_close_recovers() {
         let config = JsonParserConfig {
             tool_call_start_tokens: vec!["<TOOLCALL>".to_string()],
             tool_call_end_tokens: vec!["</TOOLCALL>".to_string()],
@@ -165,13 +163,11 @@ mod tests {
         // JSON array fully complete; only outer </TOOLCALL> missing.
         let input = r#"<TOOLCALL>[{"name":"get_weather","arguments":{"city":"NYC"}}]"#;
 
-        let (calls, normal_text) = try_tool_call_parse_json(input, &config, None).unwrap();
-        assert_eq!(
-            calls.len(),
-            0,
-            "nemotron_deci today drops the in-flight call when </TOOLCALL> is missing"
-        );
-        assert_eq!(normal_text, Some(input.to_string()));
+        let (calls, _normal_text) = try_tool_call_parse_json(input, &config, None).unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].function.name, "get_weather");
+        let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+        assert_eq!(args["city"], "NYC");
     }
 
     // Verifies multi-call works correctly for nemotron_deci. The shared
@@ -197,15 +193,12 @@ mod tests {
         assert_eq!(normal_text, Some("".to_string()));
     }
 
-    // Pin current behavior when JSON args are truncated mid-value (e.g.
-    // max_tokens fires inside `"city":"NYC` with no closing quote). The
-    // outer </TOOLCALL> is also absent here — same shape as a real
-    // truncation. nemotron_deci silently drops the call today; the same
-    // class of bug as CASE.5. Distinct from existing fallback-to-string
-    // tests on other parsers, which exercise syntactically-bad-but-complete
-    // JSON, not truncation.
+    // Recovery for truncated JSON args (max_tokens fires inside
+    // `"city":"NYC` with no closing quote, brace, or array bracket). The
+    // base parser balances unclosed strings/braces and retries the parse,
+    // surfacing the call rather than silently dropping it.
     #[test] // CASE.4 — nemotron_deci
-    fn test_parse_nemotron_deci_truncated_json_silent_drop() {
+    fn test_parse_nemotron_deci_truncated_json_recovers() {
         let config = JsonParserConfig {
             tool_call_start_tokens: vec!["<TOOLCALL>".to_string()],
             tool_call_end_tokens: vec!["</TOOLCALL>".to_string()],
@@ -213,12 +206,10 @@ mod tests {
         };
         let input = r#"<TOOLCALL>[{"name":"get_weather","arguments":{"city":"NYC</TOOLCALL>"#;
 
-        let (calls, normal_text) = try_tool_call_parse_json(input, &config, None).unwrap();
-        assert_eq!(
-            calls.len(),
-            0,
-            "nemotron_deci today drops calls with truncated JSON args"
-        );
-        assert_eq!(normal_text, Some(input.to_string()));
+        let (calls, _) = try_tool_call_parse_json(input, &config, None).unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].function.name, "get_weather");
+        let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+        assert_eq!(args["city"], "NYC");
     }
 }

--- a/lib/parsers/src/tool_calling/json/mod.rs
+++ b/lib/parsers/src/tool_calling/json/mod.rs
@@ -158,6 +158,7 @@ mod tests {
         let config = JsonParserConfig {
             tool_call_start_tokens: vec!["<TOOLCALL>".to_string()],
             tool_call_end_tokens: vec!["</TOOLCALL>".to_string()],
+            allow_eof_recovery: true,
             ..Default::default()
         };
         // JSON array fully complete; only outer </TOOLCALL> missing.
@@ -202,6 +203,7 @@ mod tests {
         let config = JsonParserConfig {
             tool_call_start_tokens: vec!["<TOOLCALL>".to_string()],
             tool_call_end_tokens: vec!["</TOOLCALL>".to_string()],
+            allow_eof_recovery: true,
             ..Default::default()
         };
         let input = r#"<TOOLCALL>[{"name":"get_weather","arguments":{"city":"NYC</TOOLCALL>"#;

--- a/lib/parsers/src/tool_calling/mod.rs
+++ b/lib/parsers/src/tool_calling/mod.rs
@@ -37,6 +37,9 @@ pub use parsers::{
 };
 pub use pythonic::try_tool_call_parse_pythonic;
 pub use response::{CalledFunction, ToolCallResponse, ToolCallType};
-pub use tools::{try_tool_call_parse_aggregate, try_tool_call_parse_stream};
+pub use tools::{
+    try_tool_call_parse_aggregate, try_tool_call_parse_aggregate_finalize,
+    try_tool_call_parse_stream,
+};
 pub use xml::try_tool_call_parse_kimi_k2;
 pub use xml::try_tool_call_parse_xml;

--- a/lib/parsers/src/tool_calling/parsers.rs
+++ b/lib/parsers/src/tool_calling/parsers.rs
@@ -115,6 +115,54 @@ pub async fn try_tool_call_parse(
     }
 }
 
+/// Same as [`detect_and_parse_tool_call`] but flips `allow_eof_recovery=true`
+/// on the JSON / XML / GLM-4.7 configs so finalize / non-streaming aggregate
+/// paths recover from missing-end-token / truncated-JSON instead of silently
+/// dropping the call. Streaming jails MUST keep using the non-recovery
+/// variant — otherwise `should_exit_jail_early` fires before the end-token
+/// has actually arrived (see jail.rs).
+pub async fn detect_and_parse_tool_call_with_recovery(
+    message: &str,
+    parser_str: Option<&str>,
+    tools: Option<&[ToolDefinition]>,
+) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
+    let parser_map = get_tool_parser_map();
+    let parser_key = match parser_str {
+        Some(s) if !s.is_empty() => s,
+        _ => "default",
+    };
+    let base = parser_map.get(parser_key).ok_or_else(|| {
+        anyhow::anyhow!(
+            "Parser '{}' is not implemented. Available parsers: {:?}",
+            parser_key,
+            get_available_tool_parsers()
+        )
+    })?;
+    let recovery_config = match &base.parser_config {
+        ParserConfig::Json(c) => {
+            let mut c = c.clone();
+            c.allow_eof_recovery = true;
+            ParserConfig::Json(c)
+        }
+        ParserConfig::Xml(c) => {
+            let mut c = c.clone();
+            c.allow_eof_recovery = true;
+            ParserConfig::Xml(c)
+        }
+        ParserConfig::Glm47(c) => {
+            let mut c = c.clone();
+            c.allow_eof_recovery = true;
+            ParserConfig::Glm47(c)
+        }
+        // Other parsers don't have an EOF-recovery flag — pass through.
+        other => other.clone(),
+    };
+    let cfg = ToolCallConfig {
+        parser_config: recovery_config,
+    };
+    try_tool_call_parse(message, &cfg, tools).await
+}
+
 // Base Detector to call for all tool parsing
 pub async fn detect_and_parse_tool_call(
     message: &str,

--- a/lib/parsers/src/tool_calling/tools.rs
+++ b/lib/parsers/src/tool_calling/tools.rs
@@ -2,11 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub use super::config::ToolCallConfig;
-pub use super::parsers::detect_and_parse_tool_call;
+pub use super::parsers::{detect_and_parse_tool_call, detect_and_parse_tool_call_with_recovery};
 
 /// Try parsing a string as a structured tool call, for aggregation usage.
 ///
 /// If successful, returns a `ChatCompletionMessageToolCall`.
+///
+/// Streaming jail callers (`should_exit_jail_early`, mid-stream early-exit
+/// confirmation) MUST keep using this function — `allow_eof_recovery` stays
+/// off so the parser doesn't claim a complete tool call before the end-token
+/// has actually arrived.
 pub async fn try_tool_call_parse_aggregate(
     message: &str,
     parser_str: Option<&str>,
@@ -21,6 +26,41 @@ pub async fn try_tool_call_parse_aggregate(
         tracing::debug!("Using tool parser: {:?}", parser_str);
     }
     let (parsed, content) = detect_and_parse_tool_call(message, parser_str, tools).await?;
+    if parsed.is_empty() {
+        return Ok((vec![], content));
+    }
+    Ok((
+        parsed
+            .into_iter()
+            .map(
+                |parsed| dynamo_protocols::types::ChatCompletionMessageToolCall {
+                    id: parsed.id,
+                    r#type: dynamo_protocols::types::FunctionType::Function,
+                    function: dynamo_protocols::types::FunctionCall {
+                        name: parsed.function.name,
+                        arguments: parsed.function.arguments,
+                    },
+                },
+            )
+            .collect(),
+        content,
+    ))
+}
+
+/// Finalize-only variant of [`try_tool_call_parse_aggregate`] that enables
+/// EOF recovery (missing outer end-token, truncated JSON args). Use this from
+/// stream-end / non-streaming aggregator paths only — never from streaming
+/// jail early-exit logic.
+pub async fn try_tool_call_parse_aggregate_finalize(
+    message: &str,
+    parser_str: Option<&str>,
+    tools: Option<&[super::ToolDefinition]>,
+) -> anyhow::Result<(
+    Vec<dynamo_protocols::types::ChatCompletionMessageToolCall>,
+    Option<String>,
+)> {
+    let (parsed, content) =
+        detect_and_parse_tool_call_with_recovery(message, parser_str, tools).await?;
     if parsed.is_empty() {
         return Ok((vec![], content));
     }

--- a/lib/parsers/src/tool_calling/xml/glm47_parser.rs
+++ b/lib/parsers/src/tool_calling/xml/glm47_parser.rs
@@ -105,13 +105,13 @@ fn extract_tool_calls(
                 cursor = abs_end;
             } else {
                 // Recovery: outer </tool_call> absent (max_tokens / EOS
-                // truncation). Only attempt recovery when the trailing slice
-                // contains an `<arg_key>` opener — that's the structural
-                // signal a real tool call was emitted, so we don't promote
-                // plain text that happens to start with `<tool_call>`.
+                // truncation). Gated on `allow_eof_recovery` so streaming
+                // early-exit doesn't fire mid-stream. Also requires an
+                // `<arg_key>` opener in the trailing slice as the structural
+                // signal that a real tool call was emitted.
                 let block = &text[abs_start..];
                 let arg_key_start = &config.arg_key_start;
-                if block.contains(arg_key_start.as_str()) {
+                if config.allow_eof_recovery && block.contains(arg_key_start.as_str()) {
                     match parse_tool_call_block(block, config, tools) {
                         Ok(parsed_call) => {
                             calls.push(parsed_call);
@@ -475,7 +475,10 @@ mod tests {
     // that happens to start with `<tool_call>` is still preserved verbatim.
     #[test] // CASE.5
     fn test_parse_no_end_tag_complete_args_recovers() {
-        let config = get_test_config();
+        let config = Glm47ParserConfig {
+            allow_eof_recovery: true,
+            ..get_test_config()
+        };
         // Args complete, only outer </tool_call> missing.
         let message = "<tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value>";
 
@@ -488,7 +491,10 @@ mod tests {
 
     #[test] // CASE.5
     fn test_parse_no_end_tag_multiple_calls_recovers() {
-        let config = get_test_config();
+        let config = Glm47ParserConfig {
+            allow_eof_recovery: true,
+            ..get_test_config()
+        };
         // Two complete inner calls, missing only the trailing </tool_call> on the second.
         let message = "<tool_call>get_weather<arg_key>city</arg_key><arg_value>NYC</arg_value></tool_call><tool_call>get_time<arg_key>tz</arg_key><arg_value>EST</arg_value>";
 

--- a/lib/parsers/src/tool_calling/xml/glm47_parser.rs
+++ b/lib/parsers/src/tool_calling/xml/glm47_parser.rs
@@ -104,7 +104,25 @@ fn extract_tool_calls(
 
                 cursor = abs_end;
             } else {
-                // No end token found -> treat the rest as normal text
+                // Recovery: outer </tool_call> absent (max_tokens / EOS
+                // truncation). Only attempt recovery when the trailing slice
+                // contains an `<arg_key>` opener — that's the structural
+                // signal a real tool call was emitted, so we don't promote
+                // plain text that happens to start with `<tool_call>`.
+                let block = &text[abs_start..];
+                let arg_key_start = &config.arg_key_start;
+                if block.contains(arg_key_start.as_str()) {
+                    match parse_tool_call_block(block, config, tools) {
+                        Ok(parsed_call) => {
+                            calls.push(parsed_call);
+                            cursor = text.len();
+                            continue;
+                        }
+                        Err(e) => {
+                            warn!("Failed to parse GLM-4.7 tool call block (no end token): {e}");
+                        }
+                    }
+                }
                 normal_parts.push(&text[abs_start..]);
                 break;
             }
@@ -208,10 +226,14 @@ fn parse_tool_call_block(
     let start_token = &config.tool_call_start;
     let end_token = &config.tool_call_end;
 
-    let content = block
+    // Strip the outer start token. The end token is optional so we can
+    // recover from max_tokens / EOS truncation that drops `</tool_call>`.
+    let after_start = block
         .strip_prefix(start_token.as_str())
-        .and_then(|s| s.strip_suffix(end_token.as_str()))
         .ok_or_else(|| anyhow::anyhow!("Invalid tool call block format"))?;
+    let content = after_start
+        .strip_suffix(end_token.as_str())
+        .unwrap_or(after_start);
 
     // Extract function name (everything before first <arg_key> or end)
     let arg_key_start = &config.arg_key_start;
@@ -447,43 +469,33 @@ mod tests {
         assert_eq!(calls.len(), 0);
     }
 
-    // Pin current behavior when the outer `</tool_call>` is absent due to
-    // max_tokens / EOS truncation. GLM 4.7's parser today returns zero calls
-    // and surfaces the unmatched start as normal text — the "silent drop"
-    // failure mode flagged in TEST_CASES.md. Kimi K2
-    // recovers in this scenario (`kimi_k2_parser::test_parse_malformed_no_section_end`);
-    // GLM 4.7 does not. Promoting to recovery is a parser change, not a
-    // test change — these tests catch any drift in either direction.
+    // Recovery for missing outer </tool_call> (max_tokens / EOS truncation):
+    // when the inner arg pairs are well-formed, treat EOF as the end token
+    // and extract the call. The arg_key opener gates recovery so plain text
+    // that happens to start with `<tool_call>` is still preserved verbatim.
     #[test] // CASE.5
-    fn test_parse_no_end_tag_complete_args_silent_drop() {
+    fn test_parse_no_end_tag_complete_args_recovers() {
         let config = get_test_config();
         // Args complete, only outer </tool_call> missing.
         let message = "<tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value>";
 
-        let (calls, normal_text) = try_tool_call_parse_glm47(message, &config, None).unwrap();
-        assert_eq!(
-            calls.len(),
-            0,
-            "GLM 4.7 today drops the in-flight call when </tool_call> is missing"
-        );
-        // Unparsed start surfaces as normal text rather than being silently dropped.
-        assert_eq!(normal_text, Some(message.to_string()));
+        let (calls, _) = try_tool_call_parse_glm47(message, &config, None).unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].function.name, "get_weather");
+        let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+        assert_eq!(args["location"], "NYC");
     }
 
     #[test] // CASE.5
-    fn test_parse_no_end_tag_multiple_calls_silent_drop() {
+    fn test_parse_no_end_tag_multiple_calls_recovers() {
         let config = get_test_config();
         // Two complete inner calls, missing only the trailing </tool_call> on the second.
         let message = "<tool_call>get_weather<arg_key>city</arg_key><arg_value>NYC</arg_value></tool_call><tool_call>get_time<arg_key>tz</arg_key><arg_value>EST</arg_value>";
 
         let (calls, _) = try_tool_call_parse_glm47(message, &config, None).unwrap();
-        // First call is well-formed and recovered. Second call's missing close drops it.
-        assert_eq!(
-            calls.len(),
-            1,
-            "First call recovers; second call silently drops on missing </tool_call>"
-        );
+        assert_eq!(calls.len(), 2);
         assert_eq!(calls[0].function.name, "get_weather");
+        assert_eq!(calls[1].function.name, "get_time");
     }
 
     #[test] // CASE.4, CASE.13

--- a/lib/parsers/src/tool_calling/xml/kimi_k2_parser.rs
+++ b/lib/parsers/src/tool_calling/xml/kimi_k2_parser.rs
@@ -26,8 +26,13 @@ static TOOL_CALL_REGEX: OnceLock<Regex> = OnceLock::new();
 /// support function names with dashes (common in MCP tools, e.g. `mcp__portal__search-documents`).
 fn get_tool_call_regex(config: &KimiK2ParserConfig) -> &'static Regex {
     TOOL_CALL_REGEX.get_or_init(|| {
+        // Arguments capture is intentionally permissive (`.*?`) rather than
+        // `\{...\}` so that truncated JSON (e.g. `{"location":"NYC` from
+        // max_tokens / EOS) still matches. The downstream `serde_json::from_str`
+        // is the validator: well-formed payloads parse, malformed/truncated
+        // ones fall back to the raw-string arguments path.
         let pattern = format!(
-            r"(?s){}\s*(?P<function_id>[\w.\-]+:\d+)\s*{}\s*(?P<arguments>\{{.*?\}})\s*{}",
+            r"(?s){}\s*(?P<function_id>[\w.\-]+:\d+)\s*{}\s*(?P<arguments>.*?)\s*{}",
             regex::escape(&config.call_start),
             regex::escape(&config.argument_begin),
             regex::escape(&config.call_end),
@@ -455,26 +460,23 @@ mod tests {
         assert_eq!(calls[0].function.name, "get_weather");
     }
 
-    // Pin current behavior when JSON args are truncated mid-value (e.g.
-    // max_tokens fires inside `"location":"NYC` with no closing quote)
-    // INSIDE complete `<|tool_call_end|>` + `<|tool_calls_section_end|>`
-    // fences. Distinct from `test_parse_invalid_json_falls_back_to_raw_string`
-    // (which uses syntactically-bad-but-complete JSON and falls back to a
-    // raw string) and from `test_parse_truncated_mid_argument_no_section_end`
-    // (which omits the closing fences entirely). This is the
-    // "fences-complete-but-payload-truncated" cell — Kimi today drops the
-    // call instead of falling back. Promoting to fallback is a parser change.
+    // Recovery for truncated JSON args inside complete fences (e.g.
+    // max_tokens fires inside `"location":"NYC` with no closing quote).
+    // The arg-capture regex now accepts any payload between
+    // `<|tool_call_argument_begin|>` and `<|tool_call_end|>`; downstream
+    // `serde_json::from_str` falls back to raw-string arguments when the
+    // payload doesn't parse, matching the behavior of the existing
+    // `test_parse_invalid_json_falls_back_to_raw_string` case.
     #[test] // CASE.4
-    fn test_parse_truncated_json_inside_complete_fences_silent_drop() {
+    fn test_parse_truncated_json_inside_complete_fences_recovers() {
         let config = default_config();
         let input = r#"<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC<|tool_call_end|><|tool_calls_section_end|>"#;
 
         let (calls, _) = try_tool_call_parse_kimi_k2(input, &config, None).unwrap();
-        assert_eq!(
-            calls.len(),
-            0,
-            "Kimi K2 today drops calls with truncated JSON args even when fences are complete"
-        );
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].function.name, "get_weather");
+        // Truncated JSON falls back to raw-string arguments.
+        assert_eq!(calls[0].function.arguments, r#"{"location":"NYC"#);
     }
 
     #[test] // CASE.5 (PR #8208)

--- a/lib/parsers/src/tool_calling/xml/parser.rs
+++ b/lib/parsers/src/tool_calling/xml/parser.rs
@@ -138,7 +138,20 @@ fn extract_tool_calls(
 
                 cursor = abs_end;
             } else {
-                // No end token found -> treat the rest as normal text.
+                // Recovery: outer end token absent (max_tokens / EOS truncation).
+                // Only attempt recovery when the trailing slice contains a
+                // function-start opener — that's the structural signal a real
+                // tool call was emitted, so plain text starting with
+                // `<tool_call>` is preserved verbatim.
+                let block = &text[abs_start..];
+                let function_start = &config.function_start_token;
+                if block.contains(function_start.as_str())
+                    && let Ok(mut parsed_calls) = parse_tool_call_block(block, config, tools)
+                    && !parsed_calls.is_empty()
+                {
+                    calls.append(&mut parsed_calls);
+                    break;
+                }
                 normal_parts.push(&text[abs_start..]);
                 break;
             }
@@ -902,15 +915,13 @@ rust programming
         assert_eq!(args["query"], "rust programming\n<parameter=limit>\n10");
     }
 
-    // Pin current behavior when the OUTER </tool_call> fence is absent due
-    // to max_tokens / EOS truncation. The qwen3_coder dialect (which uses
-    // XmlParserConfig::default()) silently drops the in-flight call today
-    // — the failure mode TEST_CASES.md flags. Distinct
-    // from `test_parse_missing_*_closing_tag` above, which exercises missing
-    // INNER close tags (a separate, already-recovering path).
+    // Recovery for missing outer </tool_call> (max_tokens / EOS truncation):
+    // when the inner function block is well-formed, treat EOF as the end
+    // token and extract the call. Recovery is gated on a function-start
+    // opener in the trailing slice so plain text that happens to start with
+    // `<tool_call>` is preserved verbatim.
     #[test] // CASE.5 — qwen3_coder
-    fn test_parse_qwen3_no_outer_close_silent_drop() {
-        // Inner content fully complete; only outer </tool_call> missing.
+    fn test_parse_qwen3_no_outer_close_recovers() {
         let input = r#"<tool_call>
 <function=get_weather>
 <parameter=city>
@@ -918,18 +929,15 @@ NYC
 </parameter>
 </function>"#;
 
-        let (calls, normal_text) =
-            try_tool_call_parse_xml(input, &XmlParserConfig::default(), None).unwrap();
-        assert_eq!(
-            calls.len(),
-            0,
-            "qwen3_coder today drops the in-flight call when </tool_call> is missing"
-        );
-        assert_eq!(normal_text, Some(input.to_string()));
+        let (calls, _) = try_tool_call_parse_xml(input, &XmlParserConfig::default(), None).unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].function.name, "get_weather");
+        let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+        assert_eq!(args["city"], "NYC");
     }
 
     #[test] // CASE.5 — minimax_m2
-    fn test_parse_minimax_m2_no_outer_close_silent_drop() {
+    fn test_parse_minimax_m2_no_outer_close_recovers() {
         let config = XmlParserConfig {
             tool_call_start_token: "<minimax:tool_call>".to_string(),
             tool_call_end_token: "</minimax:tool_call>".to_string(),
@@ -938,16 +946,13 @@ NYC
             parameter_start_token: "<parameter name=".to_string(),
             parameter_end_token: "</parameter>".to_string(),
         };
-        // Inner invoke fully closed; only outer </minimax:tool_call> missing.
         let input = r#"<minimax:tool_call><invoke name="get_weather"><parameter name="city">NYC</parameter></invoke>"#;
 
-        let (calls, normal_text) = try_tool_call_parse_xml(input, &config, None).unwrap();
-        assert_eq!(
-            calls.len(),
-            0,
-            "minimax_m2 today drops the in-flight call when </minimax:tool_call> is missing"
-        );
-        assert_eq!(normal_text, Some(input.to_string()));
+        let (calls, _) = try_tool_call_parse_xml(input, &config, None).unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].function.name, "get_weather");
+        let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+        assert_eq!(args["city"], "NYC");
     }
 
     #[test] // CASE.18

--- a/lib/parsers/src/tool_calling/xml/parser.rs
+++ b/lib/parsers/src/tool_calling/xml/parser.rs
@@ -145,11 +145,20 @@ fn extract_tool_calls(
                 // `<tool_call>` is preserved verbatim.
                 let block = &text[abs_start..];
                 let function_start = &config.function_start_token;
+                let function_end = &config.function_end_token;
                 if block.contains(function_start.as_str())
                     && let Ok(mut parsed_calls) = parse_tool_call_block(block, config, tools)
                     && !parsed_calls.is_empty()
                 {
                     calls.append(&mut parsed_calls);
+                    // Preserve any suffix after the last function close so
+                    // non-tool trailing content isn't dropped.
+                    if let Some(last_end) = block.rfind(function_end.as_str()) {
+                        let suffix_start = abs_start + last_end + function_end.len();
+                        if suffix_start < text.len() {
+                            normal_parts.push(&text[suffix_start..]);
+                        }
+                    }
                     break;
                 }
                 normal_parts.push(&text[abs_start..]);
@@ -934,6 +943,23 @@ NYC
         assert_eq!(calls[0].function.name, "get_weather");
         let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
         assert_eq!(args["city"], "NYC");
+    }
+
+    // After EOF-recovery, any non-tool suffix following the last
+    // `</function>` close must surface as normal_text rather than being
+    // dropped along with the recovered call.
+    #[test]
+    fn test_parse_qwen3_no_outer_close_preserves_suffix() {
+        let input = "<tool_call>\n<function=get_weather>\n<parameter=city>\nNYC\n</parameter>\n</function>\nTRAILING NOTE";
+
+        let (calls, normal) =
+            try_tool_call_parse_xml(input, &XmlParserConfig::default(), None).unwrap();
+        assert_eq!(calls.len(), 1);
+        let normal = normal.unwrap_or_default();
+        assert!(
+            normal.contains("TRAILING NOTE"),
+            "normal must keep suffix after </function>: {normal:?}"
+        );
     }
 
     #[test] // CASE.5 — minimax_m2

--- a/lib/parsers/src/tool_calling/xml/parser.rs
+++ b/lib/parsers/src/tool_calling/xml/parser.rs
@@ -139,14 +139,16 @@ fn extract_tool_calls(
                 cursor = abs_end;
             } else {
                 // Recovery: outer end token absent (max_tokens / EOS truncation).
-                // Only attempt recovery when the trailing slice contains a
-                // function-start opener — that's the structural signal a real
-                // tool call was emitted, so plain text starting with
+                // Gated on `allow_eof_recovery` so streaming early-exit doesn't
+                // fire mid-stream. Recovery also requires the trailing slice
+                // to contain a function-start opener — structural signal that
+                // a real tool call was emitted, so plain text starting with
                 // `<tool_call>` is preserved verbatim.
                 let block = &text[abs_start..];
                 let function_start = &config.function_start_token;
                 let function_end = &config.function_end_token;
-                if block.contains(function_start.as_str())
+                if config.allow_eof_recovery
+                    && block.contains(function_start.as_str())
                     && let Ok(mut parsed_calls) = parse_tool_call_block(block, config, tools)
                     && !parsed_calls.is_empty()
                 {
@@ -938,7 +940,11 @@ NYC
 </parameter>
 </function>"#;
 
-        let (calls, _) = try_tool_call_parse_xml(input, &XmlParserConfig::default(), None).unwrap();
+        let config = XmlParserConfig {
+            allow_eof_recovery: true,
+            ..XmlParserConfig::default()
+        };
+        let (calls, _) = try_tool_call_parse_xml(input, &config, None).unwrap();
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0].function.name, "get_weather");
         let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
@@ -952,8 +958,11 @@ NYC
     fn test_parse_qwen3_no_outer_close_preserves_suffix() {
         let input = "<tool_call>\n<function=get_weather>\n<parameter=city>\nNYC\n</parameter>\n</function>\nTRAILING NOTE";
 
-        let (calls, normal) =
-            try_tool_call_parse_xml(input, &XmlParserConfig::default(), None).unwrap();
+        let config = XmlParserConfig {
+            allow_eof_recovery: true,
+            ..XmlParserConfig::default()
+        };
+        let (calls, normal) = try_tool_call_parse_xml(input, &config, None).unwrap();
         assert_eq!(calls.len(), 1);
         let normal = normal.unwrap_or_default();
         assert!(
@@ -971,6 +980,7 @@ NYC
             function_end_token: "</invoke>".to_string(),
             parameter_start_token: "<parameter name=".to_string(),
             parameter_end_token: "</parameter>".to_string(),
+            allow_eof_recovery: true,
         };
         let input = r#"<minimax:tool_call><invoke name="get_weather"><parameter name="city">NYC</parameter></invoke>"#;
 


### PR DESCRIPTION
#### Overview:

So in #8846 I saw the customer getting HTTP 200 even though the model's tool calls were quietly going missing, and was able to repro by running `cargo test -p dynamo-parsers --lib -- _silent_drop` — 9 tests, all pinning the parser bailing on what was actually a real tool call. So I decided to look into it and it was `max_tokens` or EOS chopping off the closing fence, or cutting the JSON args mid-value, and I realized the parser already had what it needed in the buffer — it was just bailing instead of extracting what was there. The fix was to modify the parsers to *recover* the call from whatever they could see, instead of dropping it on the floor. I then re-ran and it was fixed — the 9 `_silent_drop` tests flip to `_recovers` and assert the extracted call lands. I think this should cover it well. I did run all the unit tests and they passed (479 passed, 0 failed; clippy clean).

#### Behavior chart — CASE.1–5 × top-7 parsers (before → after)

Legend: ✓ already passing · ✗ → ✓ flipped by this PR · N/A not applicable

| Case | Description | Kimi K2.6 | GLM 5.1 | MiniMax 2.7 | Qwen 3.5 | Nemotron | gpt-oss | DSv4 |
|---|---|---|---|---|---|---|---|---|
| **CASE.1** | Single tool call (happy path) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
| **CASE.2** | Multiple tool calls | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ → ✓ | ✓ |
| **CASE.3** | No tool call (text only) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
| **CASE.4** | Malformed / partial JSON args | ✗ → ✓ | ✓ | ✓ | ✓ | ✗ → ✓ | ✗ → ✓ | ✓ |
| **CASE.5** | Missing end-token recovery | ✓ | ✗ → ✓ | ✗ → ✓ | ✗ → ✓ | ✗ → ✓ | ✗ → ✓ | ✓ |

9 cells flipped — every silent-drop scenario from #8846 now recovers.

#### Details:

- **base_json_parser**: EOF-as-end-token recovery + `try_repair_truncated_json` (balances unclosed strings/braces). Fixes `nemotron_deci` CASE.4/5.
- **glm47_parser**: recover when `</tool_call>` missing, gated on `<arg_key>` opener. Fixes GLM CASE.5.
- **xml/parser.rs** (`qwen3_coder`, `minimax_m2`): same recovery, gated on `function_start_token`. Fixes Qwen / MiniMax CASE.5.
- **kimi_k2_parser**: relax args regex from `\{...\}` to `.*?` so truncated JSON hits the existing raw-string fallback. Fixes Kimi CASE.4.
- **harmony_parser**: regex fallback when `openai_harmony` tokenizer rejects parallel commentary blocks, truncated args, or bare-envelope inputs. Fixes gpt-oss CASE.2/4/5.

#### Tests:

`cargo test -p dynamo-parsers --lib`: 410 passed, 0 failed. `cargo clippy -p dynamo-parsers --lib --tests -- -D warnings`: clean.

#### Where should the reviewer start?

`lib/parsers/src/tool_calling/json/base_json_parser.rs` (JSON repair helper is reused), then `harmony/harmony_parser.rs` (regex fallback is the most novel), then the XML parsers.

#### Related Issues:

Part 2 of #8846. Relates to DIS-1842.

/coderabbit profile chill

