### PR TITLE
fix: bump AIC replay test timeout to 120s

### DIFF
--- a/lib/bindings/python/tests/replay/test_replay_aic_parity.py
+++ b/lib/bindings/python/tests/replay/test_replay_aic_parity.py
@@ -50,7 +50,7 @@ def test_run_synthetic_concurrency_replay_matches_aic_static_point_no_prefix(
     )
 
 
-@pytest.mark.timeout(30)
+@pytest.mark.timeout(120)
 @pytest.mark.parametrize(
     (
         "backend_name",


### PR DESCRIPTION
#### Overview:

This AIC replay test can occasionally exceed the current 30s timeout, for example:

https://github.com/ai-dynamo/dynamo/actions/runs/25112984987/job/73635377341?pr=8768
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8889" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Adjusted test timeout parameters to allow longer execution time for specific test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->