### PR TITLE
perf(trtllm): publisher off request-loop + batched KV walk

### DIFF
--- a/components/src/dynamo/trtllm/publisher.py
+++ b/components/src/dynamo/trtllm/publisher.py
@@ -212,6 +212,12 @@ class ZmqKvEventPublisher:
 class ManagedThread(threading.Thread):
     """
     A thread that runs a task and handles errors.
+
+    Each ManagedThread owns a private asyncio event loop. Previously the thread
+    submitted its coroutine to a captured request-handler loop via
+    run_coroutine_threadsafe(), making publisher work compete with HTTP request
+    handling on the same event loop. Now the publisher's polling work runs on
+    a dedicated loop in a real OS thread, decoupled from the request loop.
     """
 
     def __init__(
@@ -226,59 +232,86 @@ class ManagedThread(threading.Thread):
         self.task = task
         self.error_queue = error_queue
         self.kwargs = kwargs
+        # `loop` is accepted for ABI compatibility but is no longer used: the
+        # thread constructs and owns its own loop in run().
         self.loop = loop
         self.daemon = True
-        self._current_future: Optional[concurrent.futures.Future] = None
+        self._owned_loop: Optional[asyncio.AbstractEventLoop] = None
 
         self._stop_event = threading.Event()
 
     def set_loop(self, loop: asyncio.AbstractEventLoop) -> None:
+        # ABI-preserving no-op; see class docstring.
         self.loop = loop
 
     def run(self) -> None:
-        while not self._stop_event.is_set():
-            task: Optional[
-                Union[Callable[..., Awaitable[bool]], weakref.WeakMethod]
-            ] = self.task
-            if isinstance(task, weakref.WeakMethod):
-                task = task()
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        self._owned_loop = loop
+
+        try:
+            while not self._stop_event.is_set():
+                task: Optional[
+                    Union[Callable[..., Awaitable[bool]], weakref.WeakMethod]
+                ] = self.task
+                if isinstance(task, weakref.WeakMethod):
+                    task = task()
+                    if task is None:
+                        # Normally, this should not happen.
+                        logging.warning("WeakMethod is expired.")
+                        break
+
                 if task is None:
-                    # Normally, this should not happen.
-                    logging.warning("WeakMethod is expired.")
                     break
 
-            if task is None:
-                break
+                try:
+                    coro = task(**self.kwargs)
+                    if not asyncio.iscoroutine(coro):
+                        logging.error(f"Task {task} did not return a coroutine")
+                        break
 
+                    loop.run_until_complete(coro)
+                except (asyncio.CancelledError, concurrent.futures.CancelledError):
+                    logging.debug(f"Thread {self.name} was cancelled")
+                    break
+                except Exception as e:
+                    logging.error(
+                        f"Error in thread {self.name}: {e}\n{traceback.format_exc()}"
+                    )
+                    if self.error_queue is not None:
+                        self.error_queue.put(e)
+        finally:
             try:
-                if self.loop is None:
-                    logging.error("[ManagedThread] Loop not initialized!")
-                    break
-
-                # Call the task function to get the coroutine
-                coro = task(**self.kwargs)
-                if not asyncio.iscoroutine(coro):
-                    logging.error(f"Task {task} did not return a coroutine")
-                    break
-
-                self._current_future = asyncio.run_coroutine_threadsafe(coro, self.loop)
-                _ = self._current_future.result()
-            except (asyncio.CancelledError, concurrent.futures.CancelledError):
-                logging.debug(f"Thread {self.name} was cancelled")
-                break
-            except Exception as e:
-                logging.error(
-                    f"Error in thread {self.name}: {e}\n{traceback.format_exc()}"
-                )
-                if self.error_queue is not None:
-                    self.error_queue.put(e)
+                loop.run_until_complete(loop.shutdown_asyncgens())
+            except Exception:
+                pass
+            loop.close()
+            self._owned_loop = None
 
         logging.info(f"Thread {self.name} stopped.")
 
     def stop(self) -> None:
         self._stop_event.set()
-        if self._current_future and not self._current_future.done():
-            self._current_future.cancel()
+        # If the owned loop is still alive, schedule a task cancellation onto it
+        # so any in-flight polling coroutine breaks out of `await sleep()`. This
+        # is only needed when the upstream Publisher._stop_event hasn't been set
+        # before stop() — normally cleanup() sets that first and the coroutine
+        # exits naturally on its next iteration check.
+        owned_loop = self._owned_loop
+        if owned_loop is not None and not owned_loop.is_closed():
+            try:
+                owned_loop.call_soon_threadsafe(self._cancel_running_tasks)
+            except RuntimeError:
+                # Loop already stopped/closed; nothing more to do.
+                pass
+
+    def _cancel_running_tasks(self) -> None:
+        """Cancel any running task on the owned loop. Runs in the loop's thread."""
+        loop = self._owned_loop
+        if loop is None:
+            return
+        for task in asyncio.all_tasks(loop):
+            task.cancel()
 
 
 class Publisher:
@@ -685,20 +718,18 @@ class Publisher:
             self.update_max_window_size(event)
 
     def start(self) -> None:
+        # Each ManagedThread owns its own asyncio loop now, so we no longer
+        # capture the request-handler loop and pass it via set_loop(). The
+        # threads run their polling coroutines on private loops, off the
+        # request loop.
         if (
             self.publish_kv_cache_events_thread
             and not self.publish_kv_cache_events_thread.is_alive()
         ):
-            # REVISIT
-            # [NOTE:] TRTLLM needs the stats to be collected on the same loop as the request handler.
-            self._stats_loop = asyncio.get_running_loop()
-            self.publish_kv_cache_events_thread.set_loop(self._stats_loop)
             self.publish_kv_cache_events_thread.start()
             logging.debug("Started kv cache events thread")
 
         if self.publish_stats_thread and not self.publish_stats_thread.is_alive():
-            self._stats_loop = asyncio.get_running_loop()
-            self.publish_stats_thread.set_loop(self._stats_loop)
             self.publish_stats_thread.start()
             logging.debug("Started stats thread")
 

--- a/components/src/dynamo/trtllm/publisher.py
+++ b/components/src/dynamo/trtllm/publisher.py
@@ -585,53 +585,62 @@ class Publisher:
 
         data = event["data"]
         if data["type"] == "stored":
+            # Tighter per-block walk: inner per-token .append() loop replaced
+            # with extend(comprehension); attribute lookups
+            # (`self.kv_block_size`, `self.partial_block_hashes`) hoisted to
+            # locals so the tight loop avoids LOAD_ATTR per iteration. mm_keys
+            # handling skipped entirely when absent. For ISL=2048 / 32-token
+            # blocks this trims ~64x32=2048 Python ops per prefill to ~64 ops
+            # plus a single fused comprehension, reducing GIL-held time on
+            # the publisher thread (which would otherwise contend with HTTP
+            # request handling under load).
             self.processing_initial_created_events = False
             parent_hash = _to_signed_i64(data["parent_hash"])
             token_ids: list[int] = []
             num_block_tokens: list[int] = []
             block_hashes: list[int] = []
             block_mm_infos: list[dict | None] = []
+            kv_block_size = self.kv_block_size
+            partial_block_hashes = self.partial_block_hashes
             for block in data["blocks"]:
-                token_num_in_block = len(block["tokens"])
-                block_hash = _to_signed_i64(block["block_hash"])
-                if token_num_in_block > self.kv_block_size:
+                block_tokens = block["tokens"]
+                token_num_in_block = len(block_tokens)
+                if token_num_in_block > kv_block_size:
                     logging.error(
-                        f"Block {block_hash} contains {token_num_in_block} tokens, which is greater than kv_block_size {self.kv_block_size}"
+                        f"Block contains {token_num_in_block} tokens, which is greater than kv_block_size {kv_block_size}"
                     )
                     return
+                block_hash = _to_signed_i64(block["block_hash"])
                 if block_hash is None:
                     logging.warning(
                         f"Skipping block with None hash containing {token_num_in_block} tokens"
                     )
                     continue
-                if token_num_in_block < self.kv_block_size:
-                    logging.debug(
-                        f"Early stop when block {block_hash} containing {token_num_in_block} tokens not equal to kv_block_size {self.kv_block_size}"
-                    )
-                    self.partial_block_hashes.add(block_hash)
+                if token_num_in_block < kv_block_size:
+                    partial_block_hashes.add(block_hash)
                     break
                 num_block_tokens.append(token_num_in_block)
                 block_hashes.append(block_hash)
-                for token in block["tokens"]:
-                    token_ids.append(int(token["token_id"]))
+                token_ids.extend(int(t["token_id"]) for t in block_tokens)
 
-                # Extract multimodal hash info for this block
-                # {"mm_keys": [{"type":"mm_key","hash":"<hex>","start_offset":N}]}
-                mm_keys = block.get("mm_keys", [])
-                mm_hashes = [
-                    int(mm_key["hash"][:16], 16)
-                    for mm_key in mm_keys
-                    if mm_key.get("type") == "mm_key" and mm_key.get("hash")
-                ]
-                if mm_hashes:
-                    block_mm_infos.append(
-                        {
-                            "mm_objects": [
-                                {"mm_hash": mm_hash, "offsets": []}
-                                for mm_hash in mm_hashes
-                            ]
-                        }
-                    )
+                mm_keys = block.get("mm_keys")
+                if mm_keys:
+                    mm_hashes = [
+                        int(mk["hash"][:16], 16)
+                        for mk in mm_keys
+                        if mk.get("type") == "mm_key" and mk.get("hash")
+                    ]
+                    if mm_hashes:
+                        block_mm_infos.append(
+                            {
+                                "mm_objects": [
+                                    {"mm_hash": h, "offsets": []}
+                                    for h in mm_hashes
+                                ]
+                            }
+                        )
+                    else:
+                        block_mm_infos.append(None)
                 else:
                     block_mm_infos.append(None)
 

--- a/components/src/dynamo/trtllm/publisher.py
+++ b/components/src/dynamo/trtllm/publisher.py
@@ -634,8 +634,7 @@ class Publisher:
                         block_mm_infos.append(
                             {
                                 "mm_objects": [
-                                    {"mm_hash": h, "offsets": []}
-                                    for h in mm_hashes
+                                    {"mm_hash": h, "offsets": []} for h in mm_hashes
                                 ]
                             }
                         )


### PR DESCRIPTION
## Summary

Two commits + a style fixup that target a TTFT regression when
`--publish-events-and-metrics` is on. Measured on Qwen3-8B / TP=2 /
ISL=2048 / OSL=128 / c=1 against
`nvcr.io/nvstaging/ai-dynamo/tensorrtllm-runtime:1.1.0rc8-cuda13`
(2× H100 NVL):

- enabling the flag adds **+148.17 ms** TTFT (117.93 → 266.10 ms) and
  inflates std from 2.64 ms to 59.43 ms with occasional 350+ ms tail
  spikes;
- with this PR, enabling the flag adds **+0.64 ms** (117.93 → 118.57 ms)
  and std stays at 2.66 ms — matching the no-flag baseline within
  0.02 ms.

Net effect: ~99.6% of the regression is gone, and the stochastic-tail
behavior collapses to deterministic scheduling.

## Mechanism

The Dynamo TRT-LLM publisher (KV-cache-events thread + worker-stats
thread) currently runs its polling work on the captured request handler
event loop. Both threads submit their polling coroutines back onto that
loop via `asyncio.run_coroutine_threadsafe(coro, captured_loop).result()`,
so the OS thread is just a scheduler — the actual `get_stats_async` /
`get_kv_cache_events_async` plus per-event handling runs on the request
loop and contends with HTTP request handling.

Two changes:

| Commit | What it changes | Why |
|---|---|---|
| `c3ad7d202a` | `ManagedThread.run()` constructs and owns its own `asyncio.new_event_loop()` per thread, replacing the captured-loop submission. The change is at the `ManagedThread` class level so both publisher threads benefit. | Eliminates the publisher-vs-HTTP loop contention. |
| `d6e3f99858` | `_handle_kv_event` "stored" branch tightened: per-token `for ... append(...)` loop replaced with `extend(comprehension)`, attribute lookups hoisted to locals, `mm_keys` block skipped when absent. Control flow preserved. | Reduces GIL-held time on the publisher thread; even on a separate thread, the GIL still backpressures the request handler. |
| `d86a818808` | `style: apply pre-commit formatting` (1-line wrap fix). | Pre-commit normalization. |

## Validation

aiperf A/B/C, N=1 per condition, 200 reqs streaming.

| Cond | Worker overlay | Worker flag | Avg TTFT (ms) | std | Δ baseline |
|---|---|---|---|---|---|
| **A — Baseline** | (stock image) | (none) | **117.93** | 2.64 | (base) |
| **B — Control** | (stock image) | `--publish-events-and-metrics` | **266.10** | 59.43 | **+148.17** |
| **C — Treatment** | this PR's `publisher.py` overlaid | `--publish-events-and-metrics` | **118.57** | 2.66 | **+0.64** |

Δ(C, A) = +0.64 ms — net cost of publishing+fix vs baseline.
Δ(C, B) = −147.53 ms — fix's isolated benefit, holding the flag constant.
Tail collapse: B's max=357.71 ms vs C's max=128.85 ms.

## Test plan

- [x] Existing trtllm backend unit tests
- [x] Manual: A/B/C comparison (above)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread lifecycle management for better stability and resource cleanup.
  * Enhanced event processing to reduce overhead and improve performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->