### PR TITLE
feat(kv-router): make approximate pruning TTL-only

### DIFF
--- a/components/src/dynamo/common/configuration/groups/kv_router_args.py
+++ b/components/src/dynamo/common/configuration/groups/kv_router_args.py
@@ -31,8 +31,6 @@ _KV_ROUTER_FIELDS: tuple[str, ...] = (
     "router_snapshot_threshold",
     "router_reset_states",
     "router_ttl_secs",
-    "router_max_tree_size",
-    "router_prune_target_ratio",
     "router_queue_threshold",
     "router_event_threads",
     "router_queue_policy",
@@ -59,8 +57,6 @@ class KvRouterConfigBase(ConfigBase):
     router_snapshot_threshold: int
     router_reset_states: bool
     router_ttl_secs: float
-    router_max_tree_size: int
-    router_prune_target_ratio: float
     router_queue_threshold: Optional[float]
     router_event_threads: int
     router_queue_policy: str
@@ -228,28 +224,6 @@ class KvRouterArgGroup(ArgGroup):
             default=120.0,
             help=(
                 "KV Router: Time-to-live in seconds for blocks when KV events are disabled. "
-                "Only used when --no-router-kv-events is set."
-            ),
-            arg_type=float,
-        )
-        add_argument(
-            g,
-            flag_name="--router-max-tree-size",
-            env_var="DYN_ROUTER_MAX_TREE_SIZE",
-            default=2**20,
-            help=(
-                "KV Router: Maximum tree size before pruning when KV events are disabled. "
-                "Only used when --no-router-kv-events is set."
-            ),
-            arg_type=int,
-        )
-        add_argument(
-            g,
-            flag_name="--router-prune-target-ratio",
-            env_var="DYN_ROUTER_PRUNE_TARGET_RATIO",
-            default=0.8,
-            help=(
-                "KV Router: Target size ratio after pruning when KV events are disabled. "
                 "Only used when --no-router-kv-events is set."
             ),
             arg_type=float,

--- a/components/src/dynamo/router/__main__.py
+++ b/components/src/dynamo/router/__main__.py
@@ -180,9 +180,7 @@ async def worker(runtime: DistributedRuntime):
         f"router_track_output_blocks={config.router_track_output_blocks}, "
         f"router_assume_kv_reuse={config.router_assume_kv_reuse}, "
         f"router_track_prefill_tokens={config.router_track_prefill_tokens}, "
-        f"router_ttl_secs={config.router_ttl_secs}, "
-        f"router_max_tree_size={config.router_max_tree_size}, "
-        f"router_prune_target_ratio={config.router_prune_target_ratio}"
+        f"router_ttl_secs={config.router_ttl_secs}"
     )
 
     kv_router_config = build_kv_router_config(config)

--- a/components/src/dynamo/router/backend_args.py
+++ b/components/src/dynamo/router/backend_args.py
@@ -27,8 +27,6 @@ class DynamoRouterConfig(ConfigBase):
     router_assume_kv_reuse: bool
     router_track_output_blocks: bool
     router_ttl_secs: float
-    router_max_tree_size: int
-    router_prune_target_ratio: float
     router_event_threads: int
 
     def validate(self) -> None:
@@ -99,7 +97,7 @@ class DynamoRouterArgGroup(ArgGroup):
             flag_name="--router-kv-events",
             env_var="DYN_ROUTER_USE_KV_EVENTS",
             default=True,
-            help="KV Router: Enable KV events from workers. When disabled (--no-router-kv-events), the router predicts cache state based on routing decisions with TTL-based expiration and pruning, rather than receiving events from workers.",
+            help="KV Router: Enable KV events from workers. When disabled (--no-router-kv-events), the router predicts cache state based on routing decisions with TTL-based expiration, rather than receiving events from workers.",
             dest="router_use_kv_events",
             obsolete_flag="--kv-events",
         )
@@ -176,27 +174,9 @@ class DynamoRouterArgGroup(ArgGroup):
 
         add_argument(
             g,
-            flag_name="--router-max-tree-size",
-            env_var="DYN_ROUTER_MAX_TREE_SIZE",
-            default=2**20,
-            help="KV Router: Maximum tree size before pruning. Only used when --no-router-kv-events is set.  When the indexer tree exceeds this size, pruning is triggered.",
-            arg_type=int,
-        )
-
-        add_argument(
-            g,
-            flag_name="--router-prune-target-ratio",
-            env_var="DYN_ROUTER_PRUNE_TARGET_RATIO",
-            default=0.8,
-            help="KV Router: Target size ratio after pruning (0.0-1.0). Only used when --no-router-kv-events is set. Determines how aggressively to prune the tree.",
-            arg_type=float,
-        )
-
-        add_argument(
-            g,
             flag_name="--router-event-threads",
             env_var="DYN_ROUTER_EVENT_THREADS",
             default=4,
-            help="KV Router: Number of event processing threads. >1 uses concurrent radix tree and thread pool for higher throughput. Ignored when --no-router-kv-events is set (approximate mode always uses single-threaded indexer with TTL/pruning).",
+            help="KV Router: Number of event processing threads. >1 uses concurrent radix tree and thread pool for higher throughput. Ignored when --no-router-kv-events is set (approximate mode uses TTL expiration).",
             arg_type=int,
         )

--- a/docs/components/frontend/configuration.md
+++ b/docs/components/frontend/configuration.md
@@ -34,8 +34,6 @@ The Rust HTTP server also reads these environment variables (not exposed as CLI 
 | `--router-temperature` | `DYN_ROUTER_TEMPERATURE` | `0.0` | Softmax temperature for worker sampling. 0 = deterministic |
 | `--router-kv-events` / `--no-router-kv-events` | `DYN_ROUTER_USE_KV_EVENTS` | `true` | Enable KV cache state events from workers. Disable for prediction-based routing |
 | `--router-ttl-secs` | `DYN_ROUTER_TTL_SECS` | `120.0` | Block TTL when KV events are disabled |
-| `--router-max-tree-size` | `DYN_ROUTER_MAX_TREE_SIZE` | `1048576` | Max radix tree size before pruning (no-events mode) |
-| `--router-prune-target-ratio` | `DYN_ROUTER_PRUNE_TARGET_RATIO` | `0.8` | Target size ratio after pruning (no-events mode) |
 | `--router-replica-sync` / `--no-router-replica-sync` | `DYN_ROUTER_REPLICA_SYNC` | `false` | Sync state across multiple router instances |
 | `--router-snapshot-threshold` | `DYN_ROUTER_SNAPSHOT_THRESHOLD` | `1000000` | Messages before triggering a snapshot |
 | `--router-reset-states` / `--no-router-reset-states` | `DYN_ROUTER_RESET_STATES` | `false` | Reset router state on startup. **Warning:** affects existing replicas |

--- a/docs/components/router/kv-event-replay-comparison.md
+++ b/docs/components/router/kv-event-replay-comparison.md
@@ -26,7 +26,7 @@ A KV event consumer (router, cache coordinator) subscribes to a live stream of b
 | **Initial sync** | Not built in — consumer starts from live stream | Tree dump (request with `start_event_id=None`) |
 | **Authoritative state** | Buffer only | RadixTree (buffer is an optimization layer) |
 | **Compression / dedup** | Events stored as-is (pre-serialized) | RadixTree compresses shared prefixes across sequences |
-| **Pruning** | Implicit via `maxlen` eviction | TTL + size-based pruning via `PruneManager` |
+| **Expiration** | Implicit via `maxlen` eviction | TTL expiration via `PruneManager` |
 | **Transport** | ZMQ PUB/SUB + ROUTER/REQ | Dynamo service RPC (request/response) |
 | **Multi-rank** | Port offset per DP rank | Separate query endpoint per DP rank |
 | **Thread model** | Background thread with queue | Single-threaded tokio runtime on dedicated OS thread |

--- a/docs/components/router/router-configuration.md
+++ b/docs/components/router/router-configuration.md
@@ -24,7 +24,7 @@ For `--router-mode device-aware-weighted`, set `DYN_ENCODER_CUDA_TO_CPU_RATIO` t
 
 ## KV Event Transport and Persistence
 
-- `--no-router-kv-events`: Disables KV event tracking. By default, the router uses KV events to monitor block creation and deletion from workers. When disabled, the router predicts cache state from routing decisions with TTL-based expiration and pruning.
+- `--no-router-kv-events`: Disables KV event tracking. By default, the router uses KV events to monitor block creation and deletion from workers. When disabled, the router predicts cache state from routing decisions with TTL-based expiration.
 - `--router-durable-kv-events`: **Deprecated.** Enables JetStream mode for KV event transport. The event-plane subscriber in local indexer mode is now the recommended path.
 - `--router-reset-states`: Only applies in JetStream mode (`--router-durable-kv-events`). Resets the router state on startup by clearing both the JetStream event stream and NATS object store, starting from a fresh state.
 - `--router-snapshot-threshold`: Only applies in JetStream mode (`--router-durable-kv-events`). Sets the number of messages in JetStream before triggering a snapshot.
@@ -40,8 +40,6 @@ For `--router-mode device-aware-weighted`, set `DYN_ENCODER_CUDA_TO_CPU_RATIO` t
 ## KV Indexer / Approx KV Indexer
 
 - `--router-ttl-secs`: Time-to-live in seconds for blocks in the router's local cache predictions. Defaults to 120.0 seconds when `--no-router-kv-events` is used.
-- `--router-max-tree-size`: Maximum tree size before pruning is triggered. Defaults to 1048576 (2^20 blocks) when `--no-router-kv-events` is used.
-- `--router-prune-target-ratio`: Target size ratio to prune down to when `--router-max-tree-size` is exceeded. Defaults to 0.8 when `--no-router-kv-events` is used.
 - `--router-event-threads`: Number of event processing threads for the KV indexer (default: 4). With KV events enabled, values greater than 1 use the concurrent radix tree; approximate mode always uses a single-threaded indexer.
 
 To implement KV event publishing for custom inference engines, see [KV Event Publishing for Custom Engines](../../integrations/kv-events-custom-engines.md).
@@ -60,7 +58,7 @@ These activate automatically with `--router-mode kv` -- no additional flags are 
 
 `--router-kv-overlap-score-weight` is the primary knob for balancing prefill efficiency against decode load. Prefill-heavy workloads benefit from a higher weight, which steers requests toward workers with better cache overlap and reduces TTFT. Decode-heavy workloads benefit from a lower weight, which distributes decode load more evenly and reduces ITL. The default of 1.0 is a reasonable starting point. This weight can also be overridden per request via `nvext.agent_hints.kv_overlap_score_weight`.
 
-Use `--no-router-kv-events` when you are not confident that your backend engine emits KV events correctly. In this mode the router falls back to approximate routing, predicting cache state from its own routing decisions with TTL-based expiration and pruning.
+Use `--no-router-kv-events` when you are not confident that your backend engine emits KV events correctly. In this mode the router falls back to approximate routing, predicting cache state from its own routing decisions with TTL-based expiration.
 
 Use `--no-router-assume-kv-reuse` in disaggregated setups where the decode worker does not reuse transferred KV cache blocks. Without this flag, the router undercounts decode blocks when duplicates exist, leading to inaccurate load estimates.
 

--- a/docs/components/router/router-operations.md
+++ b/docs/components/router/router-operations.md
@@ -134,7 +134,7 @@ State persistence depends on the event transport mode:
 
 Request-plane transport is independent of KV event transport. The request plane (`DYN_REQUEST_PLANE` or `--request-plane`) controls how requests reach workers. KV events use NATS in JetStream or NATS Core modes, or ZMQ when `--event-plane zmq` is set. With `--event-plane zmq` and `--discovery-backend file` or `mem`, the router can run without etcd or NATS. When using a NATS-based event plane, NATS is initialized automatically; set `NATS_SERVER=nats://...` to override the default `localhost:4222`.
 
-When `--router-kv-overlap-score-weight` is set to 0, no KV indexer is created and prefix matching is disabled. When `--no-router-kv-events` is set, a KV indexer is still created but no event subscriber is launched; the router predicts cache state from its own routing decisions with TTL-based expiration and pruning.
+When `--router-kv-overlap-score-weight` is set to 0, no KV indexer is created and prefix matching is disabled. When `--no-router-kv-events` is set, a KV indexer is still created but no event subscriber is launched; the router predicts cache state from its own routing decisions with TTL-based expiration.
 
 Backend KV event publishing is independent of the frontend's `--no-router-kv-events` flag. The frontend flag controls whether the router consumes events; backend flags control whether workers publish them. If the router is not consuming events, workers that still publish will waste resources but cause no harm.
 
@@ -142,6 +142,6 @@ Backend KV event publishing is independent of the frontend's `--no-router-kv-eve
 - **SGLang**: Pass `--kv-events-config` with a JSON config to enable, or omit it to keep publishing disabled.
 - **TRT-LLM**: Pass `--publish-events-and-metrics` to enable, or omit it to keep publishing disabled.
 
-The CLI args `--router-ttl-secs`, `--router-max-tree-size`, and `--router-prune-target-ratio` control local cache management when the router operates without receiving events from workers. When workers are configured to publish KV events, the router relies on worker-side eviction events and these parameters are ignored.
+The CLI arg `--router-ttl-secs` controls local cache prediction lifetime when the router operates without receiving events from workers. When workers are configured to publish KV events, the router relies on worker-side eviction events and this parameter is ignored.
 
 `--router-queue-threshold` and the busy thresholds (`--active-decode-blocks-threshold`, `--active-prefill-tokens-threshold`, `--active-prefill-tokens-threshold-frac`) serve different purposes. Busy thresholds reject a worker entirely from the candidate set when it exceeds a utilization limit. In contrast, `--router-queue-threshold` defers the entire routing decision until at least one worker has capacity, so the request is routed with the freshest load metrics. The busy thresholds can be updated at runtime without restarting the frontend via the `/busy_threshold` HTTP endpoint. For details, see [Request Rejection](../../fault-tolerance/request-rejection.md).

--- a/docs/design-docs/event-plane.md
+++ b/docs/design-docs/event-plane.md
@@ -119,7 +119,7 @@ With `--no-router-kv-events`:
 
 - The router falls back to prediction-based cache-aware routing (estimates cache state from routing decisions).
 - No NATS server or ZMQ sockets are needed.
-- TTL-based expiration and LRU pruning keep predicted state from growing stale.
+- TTL-based expiration keeps predicted state from growing stale.
 
 ## Deployment Modes
 

--- a/docs/design-docs/router-design.md
+++ b/docs/design-docs/router-design.md
@@ -131,9 +131,9 @@ The KVIndexer has a method `find_matches_for_request`, which takes in tokens and
 
 The KVIndexer supports two backend implementations, selected via `--router-event-threads`:
 
-- **Single-threaded RadixTree** (`--router-event-threads 1`): Events are processed in a dedicated single-threaded tokio runtime via channel-based dispatch. Supports TTL-based expiration and size-based pruning (for `--no-kv-events` approximate mode).
+- **Single-threaded RadixTree** (`--router-event-threads 1`): Events are processed in a dedicated single-threaded tokio runtime via channel-based dispatch. Supports TTL-based expiration for `--no-kv-events` approximate mode.
 
-- **ConcurrentRadixTree** (default, `--router-event-threads N` where N > 1): A thread-safe radix tree with a pool of N worker threads for event processing (default: 4). Uses sticky worker routing (events for the same worker always go to the same thread) to ensure per-worker event serialization. Read operations (`find_matches`) execute concurrently with writes. Does not support TTL/pruning.
+- **ConcurrentRadixTree** (default, `--router-event-threads N` where N > 1): A thread-safe radix tree with a pool of N worker threads for event processing (default: 4). Uses sticky worker routing (events for the same worker always go to the same thread) to ensure per-worker event serialization. Read operations (`find_matches`) execute concurrently with writes.
 
 ### Inter-Router Communication
 

--- a/lib/bench/kv_router/mooncake_bench.rs
+++ b/lib/bench/kv_router/mooncake_bench.rs
@@ -10,7 +10,9 @@ mod mooncake_shared;
 
 use clap::{Parser, Subcommand};
 use dynamo_kv_router::indexer::{KvIndexerInterface, KvIndexerMetrics, ShardSizeSnapshot};
-use mooncake_shared::{MooncakeBenchmarkConfig, MooncakeIndexerConfig, run_benchmark};
+use mooncake_shared::{
+    MooncakeBenchmarkConfig, MooncakeBenchmarkInput, MooncakeIndexerConfig, run_benchmark,
+};
 use serde::Serialize;
 use std::sync::Arc;
 use tokio::time::{Duration, Instant};
@@ -124,6 +126,10 @@ struct Args {
     /// trace-replay workers.  Set to 0 (default) to disable.
     #[clap(long, default_value = "0")]
     find_matches_concurrency: usize,
+
+    /// Use approximate routing-decision writes instead of offline-generated KV events.
+    #[clap(long)]
+    approx: bool,
 
     /// Output path for the shard-size CSV produced when `shard-metrics` feature
     /// is enabled.  Rows: `elapsed_ms,shard_idx,worker_count,block_count,node_count`.
@@ -367,13 +373,19 @@ async fn main() -> anyhow::Result<()> {
         args.common.num_unique_inference_workers,
         args.common.seed,
     )?;
-    let artifacts = generate_replay_artifacts(
-        &traces,
-        args.common.num_gpu_blocks,
-        args.common.block_size,
-        args.common.trace_simulation_duration_ms,
-    )
-    .await?;
+    let benchmark_input = if args.approx {
+        MooncakeBenchmarkInput::Approx(traces.clone())
+    } else {
+        MooncakeBenchmarkInput::KvEvents(
+            generate_replay_artifacts(
+                &traces,
+                args.common.num_gpu_blocks,
+                args.common.block_size,
+                args.common.trace_simulation_duration_ms,
+            )
+            .await?,
+        )
+    };
 
     let indexer_names: Vec<String> = if args.compare.is_empty() {
         vec![args.get_indexer().to_config().short_name().to_string()]
@@ -414,13 +426,20 @@ async fn main() -> anyhow::Result<()> {
 
             for &dur_ms in durations {
                 println!("\n=== Sweep: benchmark_duration_ms = {} ===", dur_ms);
-                let indexer = config.build(
-                    args.common.block_size,
-                    Arc::new(KvIndexerMetrics::new_unregistered()),
-                );
+                let indexer = if args.approx {
+                    config.build_approximate(
+                        args.common.block_size,
+                        Arc::new(KvIndexerMetrics::new_unregistered()),
+                    )?
+                } else {
+                    config.build(
+                        args.common.block_size,
+                        Arc::new(KvIndexerMetrics::new_unregistered()),
+                    )
+                };
                 let run = run_benchmark(
                     indexer,
-                    artifacts.clone(),
+                    benchmark_input.clone(),
                     MooncakeBenchmarkConfig {
                         benchmark_duration_ms: dur_ms,
                         inference_worker_duplication_factor: args
@@ -428,6 +447,7 @@ async fn main() -> anyhow::Result<()> {
                             .inference_worker_duplication_factor,
                         count_events: config.supports_remove(),
                         find_matches_concurrency: args.find_matches_concurrency,
+                        block_size: args.common.block_size,
                     },
                 )
                 .await?;
@@ -493,8 +513,6 @@ async fn main() -> anyhow::Result<()> {
         std::fs::write(&json_path, serde_json::to_string_pretty(&json_map)?)?;
         println!("Sweep results saved to {}", json_path);
     } else {
-        drop(traces);
-
         for name in &indexer_names {
             println!("\nBenchmarking indexer: {}", name);
             let config = if args.compare.is_empty() {
@@ -502,10 +520,17 @@ async fn main() -> anyhow::Result<()> {
             } else {
                 MooncakeIndexerConfig::from_short_name(name, args.num_event_workers)?
             };
-            let indexer = config.build(
-                args.common.block_size,
-                Arc::new(KvIndexerMetrics::new_unregistered()),
-            );
+            let indexer = if args.approx {
+                config.build_approximate(
+                    args.common.block_size,
+                    Arc::new(KvIndexerMetrics::new_unregistered()),
+                )?
+            } else {
+                config.build(
+                    args.common.block_size,
+                    Arc::new(KvIndexerMetrics::new_unregistered()),
+                )
+            };
 
             // Start shard-size sampler if a CSV path was provided.
             let shard_cancel = CancellationToken::new();
@@ -521,7 +546,7 @@ async fn main() -> anyhow::Result<()> {
 
             let run = run_benchmark(
                 indexer.clone(),
-                artifacts.clone(),
+                benchmark_input.clone(),
                 MooncakeBenchmarkConfig {
                     benchmark_duration_ms: args.common.benchmark_duration_ms,
                     inference_worker_duplication_factor: args
@@ -529,6 +554,7 @@ async fn main() -> anyhow::Result<()> {
                         .inference_worker_duplication_factor,
                     count_events: config.supports_remove(),
                     find_matches_concurrency: args.find_matches_concurrency,
+                    block_size: args.common.block_size,
                 },
             )
             .await?;

--- a/lib/bench/kv_router/mooncake_shared.rs
+++ b/lib/bench/kv_router/mooncake_shared.rs
@@ -7,12 +7,16 @@ use std::sync::{
 };
 
 use dynamo_kv_router::LocalBlockHash;
+use dynamo_kv_router::indexer::pruning::PruneConfig;
 use dynamo_kv_router::indexer::{KvIndexer, KvIndexerInterface, KvIndexerMetrics};
-use dynamo_kv_router::protocols::{KvCacheEvent, KvCacheEventData, RouterEvent};
+use dynamo_kv_router::protocols::{
+    KvCacheEvent, KvCacheEventData, RouterEvent, TokensWithHashes, WorkerWithDpRank,
+};
 use dynamo_kv_router::{
     BranchShardedIndexer, ConcurrentRadixTree, ConcurrentRadixTreeCompressed, PositionalIndexer,
     ThreadPoolIndexer,
 };
+use dynamo_mocker::loadgen::Trace;
 use tokio::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
 
@@ -188,6 +192,54 @@ impl MooncakeIndexerConfig {
             }
         }
     }
+
+    pub fn build_approximate(
+        &self,
+        block_size: u32,
+        metrics: Arc<KvIndexerMetrics>,
+    ) -> anyhow::Result<Arc<dyn KvIndexerInterface + Send + Sync>> {
+        let prune_config = PruneConfig::default();
+        let indexer: Arc<dyn KvIndexerInterface + Send + Sync> = match self.kind {
+            MooncakeIndexerKind::RadixTree => Arc::new(KvIndexer::new_with_frequency(
+                CancellationToken::new(),
+                None,
+                block_size,
+                metrics,
+                Some(prune_config),
+            )),
+            MooncakeIndexerKind::NestedMap => {
+                Arc::new(ThreadPoolIndexer::new_with_metrics_and_pruning(
+                    PositionalIndexer::new(self.jump_size),
+                    self.num_event_workers,
+                    block_size,
+                    Some(metrics),
+                    Some(prune_config),
+                ))
+            }
+            MooncakeIndexerKind::ConcurrentRadixTree => {
+                Arc::new(ThreadPoolIndexer::new_with_metrics_and_pruning(
+                    ConcurrentRadixTree::new(),
+                    self.num_event_workers,
+                    block_size,
+                    Some(metrics),
+                    Some(prune_config),
+                ))
+            }
+            MooncakeIndexerKind::ConcurrentRadixTreeCompressed => {
+                Arc::new(ThreadPoolIndexer::new_with_metrics_and_pruning(
+                    ConcurrentRadixTreeCompressed::new(),
+                    self.num_event_workers,
+                    block_size,
+                    Some(metrics),
+                    Some(prune_config),
+                ))
+            }
+            MooncakeIndexerKind::BranchShardedCrtc => {
+                anyhow::bail!("branch-sharded-crtc does not support approximate pruning")
+            }
+        };
+        Ok(indexer)
+    }
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -196,6 +248,7 @@ pub struct MooncakeBenchmarkConfig {
     pub inference_worker_duplication_factor: usize,
     pub count_events: bool,
     pub find_matches_concurrency: usize,
+    pub block_size: u32,
 }
 
 /// A single entry in a worker's merged benchmark timeline.
@@ -203,6 +256,7 @@ pub struct MooncakeBenchmarkConfig {
 enum WorkerTraceEntry {
     Request(Vec<LocalBlockHash>),
     Event(KvCacheEvent),
+    ApproxWrite { tokens: Vec<u32>, num_blocks: usize },
 }
 
 /// A timestamped entry in a worker's benchmark trace, used to replay requests
@@ -213,7 +267,13 @@ struct WorkerTrace {
     timestamp_us: u64,
 }
 
-fn prepare_worker_traces(
+#[derive(Clone)]
+pub enum MooncakeBenchmarkInput {
+    KvEvents(Vec<WorkerReplayArtifacts>),
+    Approx(Vec<Trace>),
+}
+
+fn prepare_event_worker_traces(
     artifacts: Vec<WorkerReplayArtifacts>,
     benchmark_duration_ms: u64,
 ) -> Vec<Vec<WorkerTrace>> {
@@ -248,12 +308,87 @@ fn prepare_worker_traces(
     )
 }
 
+fn synthesized_tokens(
+    turn: &dynamo_mocker::loadgen::TurnTrace,
+    trace_block_size: usize,
+) -> Vec<u32> {
+    let mut tokens = Vec::with_capacity(turn.input_length);
+    for &hash_id in &turn.hash_ids {
+        tokens.extend((0..trace_block_size).map(|_| hash_id as u32));
+        if tokens.len() >= turn.input_length {
+            tokens.truncate(turn.input_length);
+            break;
+        }
+    }
+    tokens
+}
+
+fn prepare_approx_worker_traces(
+    traces: Vec<Trace>,
+    block_size: u32,
+    benchmark_duration_ms: u64,
+) -> anyhow::Result<Vec<Vec<WorkerTrace>>> {
+    let mut worker_traces = Vec::with_capacity(traces.len());
+    for trace in traces {
+        let trace_block_size = trace.block_size;
+        let mut entries = Vec::new();
+        for session in trace.sessions {
+            let mut timestamp_ms = session.first_arrival_timestamp_ms.unwrap_or(0.0);
+            for (turn_idx, turn) in session.turns.into_iter().enumerate() {
+                if turn_idx > 0 {
+                    timestamp_ms += turn.delay_after_previous_ms;
+                }
+                let replay_hashes = turn.to_replay_hashes(trace_block_size, block_size as usize)?;
+                let tokens = synthesized_tokens(&turn, trace_block_size);
+                let timestamp_us = (timestamp_ms.max(0.0) * 1000.0) as u64;
+                entries.push(WorkerTrace {
+                    timestamp_us,
+                    entry: WorkerTraceEntry::Request(replay_hashes.local_block_hashes),
+                });
+                entries.push(WorkerTrace {
+                    timestamp_us,
+                    entry: WorkerTraceEntry::ApproxWrite {
+                        tokens,
+                        num_blocks: replay_hashes.sequence_hashes.len(),
+                    },
+                });
+            }
+        }
+        entries.sort_by_key(|entry| entry.timestamp_us);
+        worker_traces.push(entries);
+    }
+    Ok(rescale_trace_timestamps(
+        &worker_traces,
+        benchmark_duration_ms,
+        |entry| entry.timestamp_us,
+        |entry, timestamp_us| WorkerTrace {
+            entry: entry.entry.clone(),
+            timestamp_us,
+        },
+    ))
+}
+
+fn prepare_worker_traces(
+    input: MooncakeBenchmarkInput,
+    config: MooncakeBenchmarkConfig,
+) -> anyhow::Result<Vec<Vec<WorkerTrace>>> {
+    match input {
+        MooncakeBenchmarkInput::KvEvents(artifacts) => Ok(prepare_event_worker_traces(
+            artifacts,
+            config.benchmark_duration_ms,
+        )),
+        MooncakeBenchmarkInput::Approx(traces) => {
+            prepare_approx_worker_traces(traces, config.block_size, config.benchmark_duration_ms)
+        }
+    }
+}
+
 pub async fn run_benchmark(
     indexer: Arc<dyn KvIndexerInterface + Send + Sync>,
-    artifacts: Vec<WorkerReplayArtifacts>,
+    input: MooncakeBenchmarkInput,
     config: MooncakeBenchmarkConfig,
 ) -> anyhow::Result<BenchmarkRun> {
-    let worker_traces = prepare_worker_traces(artifacts, config.benchmark_duration_ms);
+    let worker_traces = prepare_worker_traces(input, config)?;
     let worker_traces = worker_traces.into_iter().map(Arc::new).collect::<Vec<_>>();
 
     let progress = make_progress_bar(Some(
@@ -287,6 +422,17 @@ pub async fn run_benchmark(
                             indexer
                                 .apply_event(RouterEvent::new(worker_id as u64, event))
                                 .await;
+                            Ok(None)
+                        }
+                        WorkerTraceEntry::ApproxWrite { tokens, .. } => {
+                            let mut tokens_with_hashes =
+                                TokensWithHashes::new(tokens, config.block_size);
+                            indexer
+                                .process_routing_decision_for_request(
+                                    &mut tokens_with_hashes,
+                                    WorkerWithDpRank::from_worker_id(worker_id as u64),
+                                )
+                                .await?;
                             Ok(None)
                         }
                     }
@@ -347,7 +493,7 @@ pub async fn run_benchmark(
                 .flat_map(|trace| trace.iter())
                 .filter_map(|entry| match &entry.entry {
                     WorkerTraceEntry::Request(hashes) => Some(hashes.clone()),
-                    WorkerTraceEntry::Event(_) => None,
+                    WorkerTraceEntry::Event(_) | WorkerTraceEntry::ApproxWrite { .. } => None,
                 })
                 .collect(),
         );
@@ -396,17 +542,28 @@ pub async fn run_benchmark(
         })
         .sum::<usize>()
         * config.inference_worker_duplication_factor;
+    let total_approx_writes = worker_traces
+        .iter()
+        .map(|trace| {
+            trace
+                .iter()
+                .filter(|entry| matches!(entry.entry, WorkerTraceEntry::ApproxWrite { .. }))
+                .count()
+        })
+        .sum::<usize>()
+        * config.inference_worker_duplication_factor;
 
     let total_requests = worker_traces.iter().map(|trace| trace.len()).sum::<usize>()
         * config.inference_worker_duplication_factor
-        - total_events;
+        - total_events
+        - total_approx_writes;
 
     let total_request_blocks = worker_traces
         .iter()
         .flat_map(|trace| trace.iter())
         .filter_map(|entry| match &entry.entry {
             WorkerTraceEntry::Request(hashes) => Some(hashes.len()),
-            WorkerTraceEntry::Event(_) => None,
+            WorkerTraceEntry::Event(_) | WorkerTraceEntry::ApproxWrite { .. } => None,
         })
         .sum::<usize>()
         * config.inference_worker_duplication_factor;
@@ -419,12 +576,14 @@ pub async fn run_benchmark(
                 KvCacheEventData::Stored(store) => Some(store.blocks.len()),
                 _ => Some(0),
             },
+            WorkerTraceEntry::ApproxWrite { num_blocks, .. } => Some(*num_blocks),
             WorkerTraceEntry::Request(_) => None,
         })
         .sum::<usize>()
         * config.inference_worker_duplication_factor;
 
-    let counted_events = if config.count_events { total_events } else { 0 };
+    let total_writes = total_events + total_approx_writes;
+    let counted_events = if config.count_events { total_writes } else { 0 };
     let counted_event_blocks = if config.count_events {
         total_event_blocks
     } else {

--- a/lib/bench/tests/mooncake_trace.rs
+++ b/lib/bench/tests/mooncake_trace.rs
@@ -18,9 +18,11 @@ use std::time::Duration;
 use common::{WorkerReplayArtifacts, generate_replay_artifacts, process_mooncake_trace};
 use dynamo_kv_router::LocalBlockHash;
 use dynamo_kv_router::indexer::KvIndexerMetrics;
-use dynamo_kv_router::protocols::{KvCacheEvent, RouterEvent, WorkerWithDpRank};
+use dynamo_kv_router::protocols::{KvCacheEvent, RouterEvent, TokensWithHashes, WorkerWithDpRank};
 use dynamo_mocker::loadgen::{SessionTrace, Trace, TurnTrace};
-use mooncake_shared::{MooncakeBenchmarkConfig, MooncakeIndexerConfig, run_benchmark};
+use mooncake_shared::{
+    MooncakeBenchmarkConfig, MooncakeBenchmarkInput, MooncakeIndexerConfig, run_benchmark,
+};
 use tempfile::NamedTempFile;
 
 const BLOCK_SIZE: u32 = 128;
@@ -35,6 +37,7 @@ type NormalizedOverlapScores = BTreeMap<WorkerWithDpRank, u32>;
 enum ReplayEntryKind {
     Request(Vec<LocalBlockHash>),
     Event(KvCacheEvent),
+    ApproxWrite(Vec<u32>),
 }
 
 #[derive(Clone)]
@@ -65,12 +68,82 @@ fn collect_replay_entries(artifacts: &[WorkerReplayArtifacts]) -> Vec<ReplayEntr
     entries
 }
 
+fn synthesize_tokens(turn: &TurnTrace, trace_block_size: usize) -> Vec<u32> {
+    let mut tokens = Vec::with_capacity(turn.input_length);
+    for &hash_id in &turn.hash_ids {
+        tokens.extend((0..trace_block_size).map(|_| hash_id as u32));
+        if tokens.len() >= turn.input_length {
+            tokens.truncate(turn.input_length);
+            break;
+        }
+    }
+    tokens
+}
+
+fn collect_approx_replay_entries(traces: &[Trace]) -> anyhow::Result<Vec<ReplayEntry>> {
+    let mut entries = Vec::new();
+    for (worker_id, trace) in traces.iter().enumerate() {
+        let trace_block_size = trace.block_size;
+        for session in &trace.sessions {
+            let mut timestamp_ms = session.first_arrival_timestamp_ms.unwrap_or(0.0);
+            for (turn_idx, turn) in session.turns.iter().enumerate() {
+                if turn_idx > 0 {
+                    timestamp_ms += turn.delay_after_previous_ms;
+                }
+                let replay_hashes = turn.to_replay_hashes(trace_block_size, BLOCK_SIZE as usize)?;
+                let timestamp_us = (timestamp_ms.max(0.0) * 1000.0) as u64;
+                entries.push(ReplayEntry {
+                    timestamp_us,
+                    worker_id: worker_id as u64,
+                    kind_rank: 0,
+                    kind: ReplayEntryKind::Request(replay_hashes.local_block_hashes),
+                });
+                entries.push(ReplayEntry {
+                    timestamp_us,
+                    worker_id: worker_id as u64,
+                    kind_rank: 1,
+                    kind: ReplayEntryKind::ApproxWrite(synthesize_tokens(turn, trace_block_size)),
+                });
+            }
+        }
+    }
+    entries.sort_by_key(|entry| (entry.timestamp_us, entry.kind_rank, entry.worker_id));
+    Ok(entries)
+}
+
+#[derive(Clone, Copy, Debug)]
+enum MooncakeReplayMode {
+    KvEvents,
+    Approx,
+}
+
+impl MooncakeReplayMode {
+    fn name(self) -> &'static str {
+        match self {
+            MooncakeReplayMode::KvEvents => "kv-events",
+            MooncakeReplayMode::Approx => "approx",
+        }
+    }
+}
+
 async fn collect_overlap_scores_for_replay(
     config: &MooncakeIndexerConfig,
+    traces: &[Trace],
     artifacts: &[WorkerReplayArtifacts],
+    mode: MooncakeReplayMode,
 ) -> anyhow::Result<Vec<NormalizedOverlapScores>> {
-    let indexer = config.build(BLOCK_SIZE, Arc::new(KvIndexerMetrics::new_unregistered()));
-    let entries = collect_replay_entries(artifacts);
+    let indexer = match mode {
+        MooncakeReplayMode::KvEvents => {
+            config.build(BLOCK_SIZE, Arc::new(KvIndexerMetrics::new_unregistered()))
+        }
+        MooncakeReplayMode::Approx => {
+            config.build_approximate(BLOCK_SIZE, Arc::new(KvIndexerMetrics::new_unregistered()))?
+        }
+    };
+    let entries = match mode {
+        MooncakeReplayMode::KvEvents => collect_replay_entries(artifacts),
+        MooncakeReplayMode::Approx => collect_approx_replay_entries(traces)?,
+    };
     let mut scores = Vec::new();
     let mut idx = 0;
 
@@ -87,6 +160,15 @@ async fn collect_overlap_scores_for_replay(
                         .apply_event(RouterEvent::new(entries[idx].worker_id, event.clone()))
                         .await;
                 }
+                ReplayEntryKind::ApproxWrite(tokens) => {
+                    let mut tokens_with_hashes = TokensWithHashes::new(tokens.clone(), BLOCK_SIZE);
+                    indexer
+                        .process_routing_decision_for_request(
+                            &mut tokens_with_hashes,
+                            WorkerWithDpRank::from_worker_id(entries[idx].worker_id),
+                        )
+                        .await?;
+                }
             }
             idx += 1;
         }
@@ -99,37 +181,42 @@ async fn collect_overlap_scores_for_replay(
 
 async fn assert_overlap_score_parity(
     variants: &[MooncakeIndexerConfig],
+    traces: &[Trace],
     artifacts: &[WorkerReplayArtifacts],
 ) -> anyhow::Result<()> {
     let mut expected_name = None;
     let mut expected_scores = Vec::new();
 
-    for config in variants {
-        let actual_scores = collect_overlap_scores_for_replay(config, artifacts).await?;
-        if expected_name.is_none() {
-            expected_name = Some(config.short_name().to_string());
-            expected_scores = actual_scores;
-            continue;
-        }
+    for mode in [MooncakeReplayMode::KvEvents, MooncakeReplayMode::Approx] {
+        for config in variants {
+            let actual_scores =
+                collect_overlap_scores_for_replay(config, traces, artifacts, mode).await?;
+            let actual_name = format!("{} ({})", config.short_name(), mode.name());
+            if expected_name.is_none() {
+                expected_name = Some(actual_name);
+                expected_scores = actual_scores;
+                continue;
+            }
 
-        assert_eq!(
-            actual_scores.len(),
-            expected_scores.len(),
-            "{} produced a different number of request overlap results than {}",
-            config.short_name(),
-            expected_name.as_deref().unwrap()
-        );
-
-        for (request_idx, (actual, expected)) in
-            actual_scores.iter().zip(expected_scores.iter()).enumerate()
-        {
             assert_eq!(
-                actual,
-                expected,
-                "{} overlap scores diverged from {} at replay request {request_idx}",
-                config.short_name(),
+                actual_scores.len(),
+                expected_scores.len(),
+                "{} produced a different number of request overlap results than {}",
+                actual_name,
                 expected_name.as_deref().unwrap()
             );
+
+            for (request_idx, (actual, expected)) in
+                actual_scores.iter().zip(expected_scores.iter()).enumerate()
+            {
+                assert_eq!(
+                    actual,
+                    expected,
+                    "{} overlap scores diverged from {} at replay request {request_idx}",
+                    actual_name,
+                    expected_name.as_deref().unwrap()
+                );
+            }
         }
     }
 
@@ -261,52 +348,61 @@ async fn mooncake_trace_replays_without_warnings_across_indexer_variants() -> an
         MooncakeIndexerConfig::concurrent_radix_tree_compressed(NUM_EVENT_WORKERS),
     ];
 
-    for config in &variants {
-        support::reset_warning_count(&warning_count);
+    for mode in [MooncakeReplayMode::KvEvents, MooncakeReplayMode::Approx] {
+        for config in &variants {
+            support::reset_warning_count(&warning_count);
+            let label = format!("{} ({})", config.short_name(), mode.name());
 
-        let metrics = Arc::new(KvIndexerMetrics::new_unregistered());
-        let run = {
-            let indexer = config.build(BLOCK_SIZE, Arc::clone(&metrics));
-            run_benchmark(
+            let metrics = Arc::new(KvIndexerMetrics::new_unregistered());
+            let indexer = match mode {
+                MooncakeReplayMode::KvEvents => config.build(BLOCK_SIZE, Arc::clone(&metrics)),
+                MooncakeReplayMode::Approx => {
+                    config.build_approximate(BLOCK_SIZE, Arc::clone(&metrics))?
+                }
+            };
+            let input = match mode {
+                MooncakeReplayMode::KvEvents => MooncakeBenchmarkInput::KvEvents(artifacts.clone()),
+                MooncakeReplayMode::Approx => MooncakeBenchmarkInput::Approx(traces.clone()),
+            };
+            let run = run_benchmark(
                 indexer,
-                artifacts.clone(),
+                input,
                 MooncakeBenchmarkConfig {
                     benchmark_duration_ms: BENCHMARK_DURATION_MS,
                     inference_worker_duplication_factor: 1,
                     count_events: config.supports_remove(),
                     find_matches_concurrency: 0,
+                    block_size: BLOCK_SIZE,
                 },
             )
-            .await?
-        };
+            .await?;
 
-        tokio::time::sleep(Duration::from_millis(50)).await;
+            tokio::time::sleep(Duration::from_millis(50)).await;
 
-        assert!(
-            run.kept_up,
-            "{} replay fell behind in test profile; increase BENCHMARK_DURATION_MS if this becomes too tight",
-            config.short_name()
-        );
-        assert!(
-            run.results.ops_throughput > 0.0,
-            "{} replay should record positive throughput",
-            config.short_name()
-        );
-        assert_eq!(
-            warning_count.load(Ordering::Relaxed),
-            0,
-            "{} emitted warn/error logs from dynamo_kv_router::indexer or dynamo_mocker",
-            config.short_name()
-        );
-        assert_eq!(
-            support::duplicate_store_warning_count(metrics.as_ref()),
-            0,
-            "{} recorded duplicate-store warning metrics",
-            config.short_name()
-        );
+            assert!(
+                run.kept_up,
+                "{label} replay fell behind in test profile; increase BENCHMARK_DURATION_MS if this becomes too tight"
+            );
+            assert!(
+                run.results.ops_throughput > 0.0,
+                "{label} replay should record positive throughput"
+            );
+            assert_eq!(
+                warning_count.load(Ordering::Relaxed),
+                0,
+                "{label} emitted warn/error logs from dynamo_kv_router::indexer or dynamo_mocker"
+            );
+            if matches!(mode, MooncakeReplayMode::KvEvents) {
+                assert_eq!(
+                    support::duplicate_store_warning_count(metrics.as_ref()),
+                    0,
+                    "{label} recorded duplicate-store warning metrics"
+                );
+            }
+        }
     }
 
-    assert_overlap_score_parity(&variants, &artifacts).await?;
+    assert_overlap_score_parity(&variants, &traces, &artifacts).await?;
 
     Ok(())
 }

--- a/lib/bindings/python/rust/llm/entrypoint.rs
+++ b/lib/bindings/python/rust/llm/entrypoint.rs
@@ -126,7 +126,7 @@ impl AicPerfConfig {
 #[pymethods]
 impl KvRouterConfig {
     #[new]
-    #[pyo3(signature = (overlap_score_weight=1.0, host_cache_hit_weight=0.75, disk_cache_hit_weight=0.25, router_temperature=0.0, use_kv_events=true, durable_kv_events=false, router_replica_sync=false, router_track_active_blocks=true, router_track_output_blocks=false, router_assume_kv_reuse=true, router_track_prefill_tokens=true, router_prefill_load_model="none", router_snapshot_threshold=1000000, router_reset_states=false, router_ttl_secs=120.0, router_max_tree_size=1048576, router_prune_target_ratio=0.8, router_queue_threshold=Some(4.0), router_event_threads=4, router_queue_policy="fcfs", use_remote_indexer=false, serve_indexer=false, shared_cache_multiplier=0.0, shared_cache_type="none"))]
+    #[pyo3(signature = (overlap_score_weight=1.0, host_cache_hit_weight=0.75, disk_cache_hit_weight=0.25, router_temperature=0.0, use_kv_events=true, durable_kv_events=false, router_replica_sync=false, router_track_active_blocks=true, router_track_output_blocks=false, router_assume_kv_reuse=true, router_track_prefill_tokens=true, router_prefill_load_model="none", router_snapshot_threshold=1000000, router_reset_states=false, router_ttl_secs=120.0, router_queue_threshold=Some(4.0), router_event_threads=4, router_queue_policy="fcfs", use_remote_indexer=false, serve_indexer=false, shared_cache_multiplier=0.0, shared_cache_type="none"))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         overlap_score_weight: f64,
@@ -144,8 +144,6 @@ impl KvRouterConfig {
         router_snapshot_threshold: Option<u32>,
         router_reset_states: bool,
         router_ttl_secs: f64,
-        router_max_tree_size: usize,
-        router_prune_target_ratio: f64,
         router_queue_threshold: Option<f64>,
         router_event_threads: u32,
         router_queue_policy: &str,
@@ -175,8 +173,6 @@ impl KvRouterConfig {
                 router_snapshot_threshold,
                 router_reset_states,
                 router_ttl_secs,
-                router_max_tree_size,
-                router_prune_target_ratio,
                 router_queue_threshold,
                 router_event_threads,
                 skip_initial_worker_wait: false,

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -670,8 +670,6 @@ class ApproxKvIndexer:
         endpoint: Endpoint,
         kv_block_size: int,
         router_ttl_secs: float = 120.0,
-        router_max_tree_size: int = 1048576,
-        router_prune_target_ratio: float = 0.8,
     ) -> None:
         """
         Create an `ApproxKvIndexer` object
@@ -680,8 +678,6 @@ class ApproxKvIndexer:
             component: The component to associate with this indexer
             kv_block_size: The KV cache block size
             router_ttl_secs: TTL for blocks in seconds (default: 120.0)
-            router_max_tree_size: Maximum tree size before pruning (default: 1048576, which is 2^20)
-            router_prune_target_ratio: Target size ratio after pruning (default: 0.8)
         """
         ...
 
@@ -1204,8 +1200,6 @@ class KvRouterConfig:
         router_snapshot_threshold: Optional[int] = 1000000,
         router_reset_states: bool = False,
         router_ttl_secs: float = 120.0,
-        router_max_tree_size: int = 1048576,
-        router_prune_target_ratio: float = 0.8,
         router_queue_threshold: Optional[float] = 4.0,
         router_event_threads: int = 4,
         router_queue_policy: str = "fcfs",
@@ -1235,8 +1229,6 @@ class KvRouterConfig:
             router_snapshot_threshold: Number of messages before snapshot (default: 1000000)
             router_reset_states: Reset router state on startup (default: False)
             router_ttl_secs: TTL for blocks in seconds when not using KV events (default: 120.0)
-            router_max_tree_size: Maximum tree size before pruning (default: 1048576, which is 2^20)
-            router_prune_target_ratio: Target size ratio after pruning (default: 0.8)
             router_queue_threshold: Queue threshold fraction for prefill token capacity (default: 4.0).
                 Requests are queued if all workers exceed this fraction of max_num_batched_tokens.
                 Enables priority scheduling via request priority hints.

--- a/lib/bindings/python/tests/replay/replay_utils.py
+++ b/lib/bindings/python/tests/replay/replay_utils.py
@@ -82,8 +82,6 @@ def _router_config_payload():
         "router_snapshot_threshold": 1000000,
         "router_reset_states": False,
         "router_ttl_secs": 120.0,
-        "router_max_tree_size": 1048576,
-        "router_prune_target_ratio": 0.8,
         "router_enable_cache_control": False,
         "skip_initial_worker_wait": False,
         "use_remote_indexer": False,

--- a/lib/kv-router/src/indexer/concurrent_radix_tree.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree.rs
@@ -670,6 +670,18 @@ impl SyncIndexer for ConcurrentRadixTree {
                         c.inc(kind, result);
                     }
                 }
+                WorkerTask::EventWithAck { event, resp } => {
+                    let kind = EventKind::of(&event.event.data);
+                    let result = self.apply_event(&mut lookup, event, counters.as_ref());
+                    let applied = result.is_ok();
+                    if result.is_err() {
+                        tracing::warn!("Failed to apply event: {:?}", result.as_ref().err());
+                    }
+                    if let Some(ref c) = counters {
+                        c.inc(kind, result);
+                    }
+                    let _ = resp.send(applied);
+                }
                 WorkerTask::RemoveWorker(worker_id) => {
                     self.remove_or_clear_worker_blocks(&mut lookup, worker_id, false);
                 }

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed.rs
@@ -1348,6 +1348,18 @@ impl SyncIndexer for ConcurrentRadixTreeCompressed {
                         c.inc(kind, result);
                     }
                 }
+                WorkerTask::EventWithAck { event, resp } => {
+                    let kind = EventKind::of(&event.event.data);
+                    let result = self.apply_event(&mut lookup, event, counters.as_ref());
+                    let applied = result.is_ok();
+                    if result.is_err() {
+                        tracing::warn!("Failed to apply event: {:?}", result.as_ref().err());
+                    }
+                    if let Some(ref c) = counters {
+                        c.inc(kind, result);
+                    }
+                    let _ = resp.send(applied);
+                }
                 WorkerTask::RemoveWorker(worker_id) => {
                     self.remove_or_clear_worker_blocks(&mut lookup, worker_id, false);
                 }

--- a/lib/kv-router/src/indexer/kv_indexer.rs
+++ b/lib/kv-router/src/indexer/kv_indexer.rs
@@ -15,41 +15,18 @@ use super::{
     KvRouterError, MatchDetails, MatchDetailsRequest, MatchRequest, PreBoundEventCounters,
     RadixTree, RoutingDecisionRequest,
 };
-use crate::indexer::pruning::{BlockEntry, PruneConfig, PruneManager};
+use crate::indexer::pruning::{BlockEntry, PruneConfig, WorkerPruneManager};
 use crate::protocols::*;
 use dynamo_tokens::SequenceHash;
 
-fn stored_block_entries(event: &RouterEvent) -> Option<Vec<BlockEntry>> {
-    let KvCacheEventData::Stored(ref store_data) = event.event.data else {
-        return None;
-    };
-
-    let worker = WorkerWithDpRank::new(event.worker_id, event.event.dp_rank);
-    Some(
-        store_data
-            .blocks
-            .iter()
-            .enumerate()
-            .map(|(idx, block)| BlockEntry {
-                key: block.block_hash,
-                worker,
-                seq_position: idx,
-            })
-            .collect(),
-    )
-}
-
-fn apply_event_with_prune_tracking(
+fn apply_event_with_counters(
     trie: &mut RadixTree,
     event: RouterEvent,
     counters: &PreBoundEventCounters,
-    prune_manager: &mut Option<PruneManager<BlockEntry>>,
-    prune_tx: &mpsc::Sender<()>,
 ) {
     let kind = EventKind::of(&event.event.data);
     let event_id = event.event.event_id;
     let worker_id = event.worker_id;
-    let event_for_prune = prune_manager.is_some().then(|| event.clone());
     let result = trie.apply_event_with_counters(event, Some(counters));
     let result_is_ok = result.is_ok();
     let tree_size = trie.current_size();
@@ -57,44 +34,15 @@ fn apply_event_with_prune_tracking(
         "Applied KV event to global radix tree: event_type={kind}, event_id={event_id}, worker_id={worker_id}, success={result_is_ok}, global_radix_tree_size={tree_size}"
     );
     counters.inc(kind, result);
-
-    let Some(pm) = prune_manager.as_mut() else {
-        return;
-    };
-    if !result_is_ok {
-        return;
-    }
-    let Some(ref event) = event_for_prune else {
-        return;
-    };
-    let Some(block_entries) = stored_block_entries(event) else {
-        return;
-    };
-
-    pm.insert(block_entries);
-
-    let Some(ref pc) = pm.prune_config else {
-        return;
-    };
-    let current_size = trie.current_size();
-    if current_size > pc.max_tree_size {
-        tracing::info!(
-            "Pruning: tree size ({}) exceeded max tree size ({}), scheduling pruning",
-            current_size,
-            pc.max_tree_size
-        );
-        let _ = prune_tx.try_send(());
-    }
 }
 
 fn apply_routing_decision_with_prune_tracking(
     trie: &mut RadixTree,
     routing_req: RoutingDecisionRequest,
-    prune_manager: &mut Option<PruneManager<BlockEntry>>,
-    prune_tx: &mpsc::Sender<()>,
+    prune_manager: &Option<WorkerPruneManager>,
     event_id_counter: &mut u64,
 ) {
-    let Some(pm) = prune_manager.as_mut() else {
+    let Some(pm) = prune_manager.as_ref() else {
         return;
     };
 
@@ -139,19 +87,23 @@ fn apply_routing_decision_with_prune_tracking(
             seq_position: idx,
         })
         .collect();
-    pm.insert(block_entries);
+    pm.insert_block_entries(block_entries);
+}
 
-    let Some(ref pc) = pm.prune_config else {
-        return;
-    };
-    let current_size = trie.current_size();
-    if current_size > pc.max_tree_size {
-        tracing::info!(
-            "Pruning: tree size ({}) exceeded max tree size ({}), scheduling pruning",
-            current_size,
-            pc.max_tree_size
+fn apply_prune_removes(trie: &mut RadixTree, entries: Vec<BlockEntry>, event_id_counter: &mut u64) {
+    for entry in entries {
+        *event_id_counter += 1;
+        let event = RouterEvent::new(
+            entry.worker.worker_id,
+            KvCacheEvent {
+                event_id: *event_id_counter,
+                data: KvCacheEventData::Removed(KvCacheRemoveData {
+                    block_hashes: vec![entry.key],
+                }),
+                dp_rank: entry.worker.dp_rank,
+            },
         );
-        let _ = prune_tx.try_send(());
+        let _ = trie.apply_event(event);
     }
 }
 
@@ -166,20 +118,25 @@ fn drain_pending_mutations(
     trie: &mut RadixTree,
     receivers: PendingMutationReceivers<'_>,
     counters: &PreBoundEventCounters,
-    prune_manager: &mut Option<PruneManager<BlockEntry>>,
-    prune_tx: &mpsc::Sender<()>,
+    prune_manager: &Option<WorkerPruneManager>,
     event_id_counter: &mut u64,
 ) {
     while let Ok(worker) = receivers.remove_worker_rx.try_recv() {
         trie.remove_worker(worker);
+        if let Some(pm) = prune_manager {
+            pm.remove_worker(worker);
+        }
     }
 
     while let Ok((worker_id, dp_rank)) = receivers.remove_worker_dp_rank_rx.try_recv() {
         trie.remove_worker_dp_rank(worker_id, dp_rank);
+        if let Some(pm) = prune_manager {
+            pm.remove_worker_dp_rank(WorkerWithDpRank::new(worker_id, dp_rank));
+        }
     }
 
     while let Ok(event) = receivers.event_rx.try_recv() {
-        apply_event_with_prune_tracking(trie, event, counters, prune_manager, prune_tx);
+        apply_event_with_counters(trie, event, counters);
     }
 
     while let Ok(routing_req) = receivers.routing_rx.try_recv() {
@@ -187,9 +144,13 @@ fn drain_pending_mutations(
             trie,
             routing_req,
             prune_manager,
-            prune_tx,
             event_id_counter,
         );
+    }
+
+    if let Some(pm) = prune_manager {
+        let entries = pm.drain_due_and_pending(tokio::time::Instant::now());
+        apply_prune_removes(trie, entries, event_id_counter);
     }
 }
 
@@ -230,8 +191,7 @@ impl KvIndexer {
     ///
     /// * `token` - A `CancellationToken` for managing shutdown.
     /// * `expiration_duration` - The amount of time that block usage should be buffered.
-    /// * `ttl` - The time-to-live for blocks before they expire.
-    /// * `prune_config` - Configuration for tree-size based pruning.
+    /// * `prune_config` - Optional TTL configuration for approximate-mode routing decisions.
     ///
     /// ### Returns
     ///
@@ -255,7 +215,6 @@ impl KvIndexer {
         let (dump_tx, dump_rx) = mpsc::channel::<DumpRequest>(16);
         let (flush_tx, flush_rx) = mpsc::channel::<FlushRequest>(16);
         let (routing_tx, mut routing_rx) = mpsc::channel::<RoutingDecisionRequest>(2048);
-        let (prune_tx, mut prune_rx) = mpsc::channel::<()>(1);
 
         let cancel_clone = token.clone();
 
@@ -278,22 +237,12 @@ impl KvIndexer {
                 let mut flush_rx = flush_rx;
                 let mut trie = RadixTree::new_with_frequency(expiration_duration);
 
-                // Create PruneManager if prune_config is specified
-                let mut prune_manager =
-                    prune_config.map(|config| PruneManager::<BlockEntry>::new(50, config));
+                let prune_manager = prune_config.map(WorkerPruneManager::new);
+                let mut prune_ready_rx = prune_manager.as_ref().map(|pm| pm.subscribe_ready());
                 let mut event_id_counter = 0u64;
                 let counters = metrics.prebind();
 
                 loop {
-                    // Create a future that sleeps until the next expiration time
-                    let expiry_fut = if let Some(ref pm) = prune_manager
-                        && let Some(next_expiry) = pm.peek_next_expiry()
-                    {
-                        tokio::time::sleep_until(next_expiry)
-                    } else {
-                        tokio::time::sleep(Duration::MAX)
-                    };
-
                     tokio::select! {
                         biased;
 
@@ -304,46 +253,25 @@ impl KvIndexer {
 
                         Some(worker) = remove_worker_rx.recv() => {
                             trie.remove_worker(worker);
+                            if let Some(pm) = &prune_manager {
+                                pm.remove_worker(worker);
+                            }
                         }
 
                         Some((worker_id, dp_rank)) = remove_worker_dp_rank_rx.recv() => {
                             trie.remove_worker_dp_rank(worker_id, dp_rank);
+                            if let Some(pm) = &prune_manager {
+                                pm.remove_worker_dp_rank(WorkerWithDpRank::new(worker_id, dp_rank));
+                            }
+                        }
+
+                        Some(event) = event_rx.recv() => {
+                            apply_event_with_counters(&mut trie, event, &counters);
                         }
 
                         Some(get_workers_req) = get_workers_rx.recv() => {
                             let workers = trie.get_workers();
                             let _ = get_workers_req.resp.send(workers);
-                        }
-
-                        Some(_) = prune_rx.recv() => {
-                            // Tree size-based pruning triggered
-                            let Some(ref mut pm) = prune_manager else { continue };
-                            let Ok(pruned) = pm.prune(trie.current_size()) else { continue };
-
-                            for p in pruned {
-                                event_id_counter += 1;
-                                let event = RouterEvent::new(
-                                    p.worker.worker_id,
-                                    KvCacheEvent {
-                                        event_id: event_id_counter,
-                                        data: KvCacheEventData::Removed(KvCacheRemoveData {
-                                            block_hashes: vec![p.key],
-                                        }),
-                                        dp_rank: p.worker.dp_rank,
-                                    }
-                                );
-                                let _ = trie.apply_event(event);
-                            }
-                        }
-
-                        Some(event) = event_rx.recv() => {
-                            apply_event_with_prune_tracking(
-                                &mut trie,
-                                event,
-                                &counters,
-                                &mut prune_manager,
-                                &prune_tx,
-                            );
                         }
 
                         Some(dump_req) = dump_rx.recv() => {
@@ -356,8 +284,7 @@ impl KvIndexer {
                                     routing_rx: &mut routing_rx,
                                 },
                                 &counters,
-                                &mut prune_manager,
-                                &prune_tx,
+                                &prune_manager,
                                 &mut event_id_counter,
                             );
                             let events = trie.dump_tree_as_events();
@@ -374,8 +301,7 @@ impl KvIndexer {
                                     routing_rx: &mut routing_rx,
                                 },
                                 &counters,
-                                &mut prune_manager,
-                                &prune_tx,
+                                &prune_manager,
                                 &mut event_id_counter,
                             );
                             let _ = flush_req.resp.send(());
@@ -385,10 +311,31 @@ impl KvIndexer {
                             apply_routing_decision_with_prune_tracking(
                                 &mut trie,
                                 routing_req,
-                                &mut prune_manager,
-                                &prune_tx,
+                                &prune_manager,
                                 &mut event_id_counter,
                             );
+                        }
+
+                        _ = async {
+                            if let Some(rx) = prune_ready_rx.as_mut() {
+                                let _ = rx.changed().await;
+                            } else {
+                                std::future::pending::<()>().await;
+                            }
+                        } => {
+                            if let Some(pm) = &prune_manager {
+                                loop {
+                                    let entries = pm.drain_pending_removes();
+                                    if entries.is_empty() {
+                                        break;
+                                    }
+                                    apply_prune_removes(
+                                        &mut trie,
+                                        entries,
+                                        &mut event_id_counter,
+                                    );
+                                }
+                            }
                         }
 
                         Some(req) = match_rx.recv() => {
@@ -418,26 +365,6 @@ impl KvIndexer {
                             let _ = req.resp.send(matches);
                         }
 
-                        _ = expiry_fut => {
-                            // TTL-based expiry triggered
-                            let Some(ref mut pm) = prune_manager else { continue };
-
-                            let expired = pm.pop_expired();
-                            for e in expired {
-                                event_id_counter += 1;
-                                let event = RouterEvent::new(
-                                    e.worker.worker_id,
-                                    KvCacheEvent {
-                                        event_id: event_id_counter,
-                                        data: KvCacheEventData::Removed(KvCacheRemoveData {
-                                            block_hashes: vec![e.key],
-                                        }),
-                                        dp_rank: e.worker.dp_rank,
-                                    }
-                                );
-                                let _ = trie.apply_event(event);
-                            }
-                        }
                     }
                 }
             });

--- a/lib/kv-router/src/indexer/lower_tier.rs
+++ b/lib/kv-router/src/indexer/lower_tier.rs
@@ -514,6 +514,14 @@ impl SyncIndexer for LowerTierIndexer {
                         tracing::warn!(%error, "Failed to apply lower-tier event");
                     }
                 }
+                WorkerTask::EventWithAck { event, resp } => {
+                    let result = self.apply_event(&mut worker_blocks, event);
+                    let applied = result.is_ok();
+                    if let Err(error) = result {
+                        tracing::warn!(%error, "Failed to apply lower-tier event");
+                    }
+                    let _ = resp.send(applied);
+                }
                 WorkerTask::RemoveWorker(worker_id) => {
                     self.remove_worker(&mut worker_blocks, worker_id);
                 }

--- a/lib/kv-router/src/indexer/positional.rs
+++ b/lib/kv-router/src/indexer/positional.rs
@@ -162,6 +162,18 @@ impl SyncIndexer for PositionalIndexer {
                         c.inc(kind, result);
                     }
                 }
+                WorkerTask::EventWithAck { event, resp } => {
+                    let kind = EventKind::of(&event.event.data);
+                    let result = self.apply_event(&mut worker_blocks, event, counters.as_ref());
+                    let applied = result.is_ok();
+                    if result.is_err() {
+                        tracing::warn!("Failed to apply event: {:?}", result.as_ref().err());
+                    }
+                    if let Some(ref c) = counters {
+                        c.inc(kind, result);
+                    }
+                    let _ = resp.send(applied);
+                }
                 WorkerTask::RemoveWorker(worker_id) => {
                     self.remove_or_clear_worker_blocks_impl(&mut worker_blocks, worker_id, false);
                 }

--- a/lib/kv-router/src/indexer/pruning.rs
+++ b/lib/kv-router/src/indexer/pruning.rs
@@ -20,6 +20,7 @@ use tokio_util::sync::CancellationToken;
 use crate::protocols::{ExternalSequenceBlockHash, WorkerId, WorkerWithDpRank};
 
 const HEAP_REBUILD_THRESHOLD: usize = 50;
+const WORKER_EXPIRY_HEAP_REBUILD_THRESHOLD: usize = 10;
 
 /// Block entry to be inserted in the [`PruneManager::expirations`] heap.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
@@ -317,11 +318,10 @@ impl WorkerPruneManager {
         }
 
         for (worker, worker_entries) in by_worker {
-            let state =
-                self.inner.workers.entry(worker).or_insert_with(|| {
+            let next_expiry = {
+                let state = self.inner.workers.entry(worker).or_insert_with(|| {
                     Mutex::new(WorkerPruneState::new(self.inner.config.clone()))
                 });
-            let next_expiry = {
                 let mut state = state.lock().expect("worker prune state mutex poisoned");
                 state.insert_block_entries(worker_entries, now);
                 state.peek_next_valid_expiry()
@@ -346,10 +346,10 @@ impl WorkerPruneManager {
         }
 
         for (worker, worker_entries) in by_worker {
-            let Some(state) = self.inner.workers.get(&worker) else {
-                continue;
-            };
             let next_expiry = {
+                let Some(state) = self.inner.workers.get(&worker) else {
+                    continue;
+                };
                 let mut state = state.lock().expect("worker prune state mutex poisoned");
                 for entry in &worker_entries {
                     state.remove_block_entry(entry);
@@ -442,6 +442,43 @@ impl WorkerPruneManagerInner {
             .lock()
             .expect("worker expiry index mutex poisoned")
             .push((Reverse(expiry), worker));
+        self.rebuild_worker_expiry_heap_if_needed();
+    }
+
+    fn rebuild_worker_expiry_heap_if_needed(&self) {
+        let workers_len = self.workers.len();
+        if workers_len == 0 {
+            return;
+        }
+
+        let should_rebuild = {
+            let expiries = self
+                .next_expiries
+                .lock()
+                .expect("worker expiry index mutex poisoned");
+            expiries.len() > workers_len * WORKER_EXPIRY_HEAP_REBUILD_THRESHOLD
+        };
+        if !should_rebuild {
+            return;
+        }
+
+        let mut rebuilt = BinaryHeap::new();
+        for entry in self.workers.iter() {
+            let worker = *entry.key();
+            let next_expiry = entry
+                .value()
+                .lock()
+                .expect("worker prune state mutex poisoned")
+                .peek_next_valid_expiry();
+            if let Some(next_expiry) = next_expiry {
+                rebuilt.push((Reverse(next_expiry), worker));
+            }
+        }
+
+        *self
+            .next_expiries
+            .lock()
+            .expect("worker expiry index mutex poisoned") = rebuilt;
     }
 
     fn next_global_expiry(&self) -> Option<Instant> {
@@ -483,10 +520,10 @@ impl WorkerPruneManagerInner {
         let mut expired = Vec::new();
 
         for worker in workers {
-            let Some(state) = self.workers.get(&worker) else {
-                continue;
-            };
             let (mut worker_expired, next_expiry) = {
+                let Some(state) = self.workers.get(&worker) else {
+                    continue;
+                };
                 let mut state = state.lock().expect("worker prune state mutex poisoned");
                 let expired = state.pop_expired(now);
                 let next_expiry = state.peek_next_valid_expiry();
@@ -519,6 +556,16 @@ mod tests {
     impl<T: Clone + Hash + Eq + Ord> PruneManager<T> {
         pub fn get_expiry(&self, key: &T) -> Option<&Instant> {
             self.timers.get(key)
+        }
+    }
+
+    impl WorkerPruneManager {
+        fn worker_expiry_heap_len(&self) -> usize {
+            self.inner
+                .next_expiries
+                .lock()
+                .expect("worker expiry index mutex poisoned")
+                .len()
         }
     }
 
@@ -599,5 +646,24 @@ mod tests {
 
         // entry1 < entry2 because seq_position 0 < 1
         assert!(entry1 < entry2);
+    }
+
+    #[test]
+    fn test_worker_expiry_heap_rebuilds_under_churn() {
+        let manager = WorkerPruneManager::new(PruneConfig {
+            ttl: Duration::from_secs(60),
+        });
+        let worker = WorkerWithDpRank::from_worker_id(7);
+
+        for idx in 0..=WORKER_EXPIRY_HEAP_REBUILD_THRESHOLD {
+            manager.insert_block_entries(vec![BlockEntry {
+                key: ExternalSequenceBlockHash(100 + idx as u64),
+                worker,
+                seq_position: idx,
+            }]);
+        }
+
+        assert_eq!(manager.worker_expiry_heap_len(), 1);
+        manager.shutdown();
     }
 }

--- a/lib/kv-router/src/indexer/pruning.rs
+++ b/lib/kv-router/src/indexer/pruning.rs
@@ -494,23 +494,44 @@ impl WorkerPruneManagerInner {
     }
 
     fn queue_due(&self, now: Instant) {
-        let workers: Vec<_> = self.workers.iter().map(|entry| *entry.key()).collect();
         let mut expired = Vec::new();
 
-        for worker in workers {
+        loop {
+            let Some((Reverse(expiry), worker)) = ({
+                let mut expiries = self
+                    .next_expiries
+                    .lock()
+                    .expect("worker expiry index mutex poisoned");
+                let Some((Reverse(expiry), _)) = expiries.peek().copied() else {
+                    break;
+                };
+                if expiry > now {
+                    break;
+                }
+                expiries.pop()
+            }) else {
+                break;
+            };
+
             let (mut worker_expired, next_expiry) = {
                 let Some(state) = self.workers.get(&worker) else {
                     continue;
                 };
                 let mut state = state.lock().expect("worker prune state mutex poisoned");
-                let expired = state.pop_expired(now);
-                let next_expiry = state.peek_next_valid_expiry();
-                (expired, next_expiry)
+                let next_valid = state.peek_next_valid_expiry();
+                if next_valid != Some(expiry) {
+                    (Vec::new(), next_valid)
+                } else {
+                    let expired = state.pop_expired(now);
+                    let next_expiry = state.peek_next_valid_expiry();
+                    (expired, next_expiry)
+                }
             };
-            expired.append(&mut worker_expired);
+
             if let Some(next_expiry) = next_expiry {
                 self.push_worker_expiry(worker, next_expiry);
             }
+            expired.append(&mut worker_expired);
         }
 
         if expired.is_empty() {
@@ -544,6 +565,14 @@ mod tests {
                 .lock()
                 .expect("worker expiry index mutex poisoned")
                 .len()
+        }
+    }
+
+    fn test_block(worker: WorkerWithDpRank, key: u64, seq_position: usize) -> BlockEntry {
+        BlockEntry {
+            key: ExternalSequenceBlockHash(key),
+            worker,
+            seq_position,
         }
     }
 
@@ -634,14 +663,51 @@ mod tests {
         let worker = WorkerWithDpRank::from_worker_id(7);
 
         for idx in 0..=WORKER_EXPIRY_HEAP_REBUILD_THRESHOLD {
-            manager.insert_block_entries(vec![BlockEntry {
-                key: ExternalSequenceBlockHash(100 + idx as u64),
-                worker,
-                seq_position: idx,
-            }]);
+            manager.insert_block_entries(vec![test_block(worker, 100 + idx as u64, idx)]);
         }
 
         assert_eq!(manager.worker_expiry_heap_len(), 1);
+        manager.shutdown();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_worker_expiry_queue_drains_staggered_workers() {
+        const TTL: Duration = Duration::from_secs(10);
+        let manager = WorkerPruneManager::new(PruneConfig { ttl: TTL });
+        let first_worker = WorkerWithDpRank::from_worker_id(1);
+        let second_worker = WorkerWithDpRank::from_worker_id(2);
+
+        let first = test_block(first_worker, 101, 0);
+        let second = test_block(second_worker, 202, 0);
+
+        manager.insert_block_entries(vec![first]);
+        time::advance(Duration::from_secs(5)).await;
+        manager.insert_block_entries(vec![second]);
+
+        time::advance(Duration::from_secs(5)).await;
+        assert_eq!(manager.drain_due_and_pending(Instant::now()), vec![first]);
+
+        time::advance(Duration::from_secs(5)).await;
+        assert_eq!(manager.drain_due_and_pending(Instant::now()), vec![second]);
+        manager.shutdown();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_worker_expiry_queue_ignores_stale_global_entries() {
+        const TTL: Duration = Duration::from_secs(10);
+        let manager = WorkerPruneManager::new(PruneConfig { ttl: TTL });
+        let worker = WorkerWithDpRank::from_worker_id(7);
+        let block = test_block(worker, 707, 0);
+
+        manager.insert_block_entries(vec![block]);
+        time::advance(Duration::from_secs(5)).await;
+        manager.insert_block_entries(vec![block]);
+
+        time::advance(Duration::from_secs(5)).await;
+        assert!(manager.drain_due_and_pending(Instant::now()).is_empty());
+
+        time::advance(Duration::from_secs(5)).await;
+        assert_eq!(manager.drain_due_and_pending(Instant::now()), vec![block]);
         manager.shutdown();
     }
 }

--- a/lib/kv-router/src/indexer/pruning.rs
+++ b/lib/kv-router/src/indexer/pruning.rs
@@ -7,12 +7,12 @@
 //! approximate-mode blocks in the radix tree.
 
 use std::cmp::Reverse;
-use std::collections::{BinaryHeap, HashMap, HashSet, VecDeque};
+use std::collections::{BinaryHeap, VecDeque};
 use std::hash::Hash;
 use std::sync::{Arc, Mutex};
 
 use dashmap::DashMap;
-use rustc_hash::FxBuildHasher;
+use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 use tokio::sync::watch;
 use tokio::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
@@ -71,7 +71,7 @@ impl Default for PruneConfig {
 #[derive(Debug)]
 pub struct PruneManager<K: Clone + Hash + Eq + Ord> {
     /// The source of truth. Maps a key to its current expiration instant.
-    timers: HashMap<K, Instant>,
+    timers: FxHashMap<K, Instant>,
 
     /// A max-heap of (Reverse<expiration_instant>, key) used to efficiently find the
     /// next expiring timer. Reverse<Instant> makes earlier times pop first.
@@ -91,7 +91,7 @@ impl<K: Clone + Hash + Eq + Ord> PruneManager<K> {
     pub fn new(threshold: usize, prune_config: PruneConfig) -> Self {
         let ttl = prune_config.ttl;
         PruneManager {
-            timers: HashMap::new(),
+            timers: FxHashMap::default(),
             expirations: BinaryHeap::new(),
             ttl,
             threshold,
@@ -120,6 +120,8 @@ impl<K: Clone + Hash + Eq + Ord> PruneManager<K> {
     pub fn insert_at(&mut self, keys: Vec<K>, now: Instant) {
         let expiry_time = now + self.ttl;
 
+        self.timers.reserve(keys.len());
+        self.expirations.reserve(keys.len());
         for key in keys {
             // Insert or update the authoritative time in the map.
             self.timers.insert(key.clone(), expiry_time);
@@ -290,7 +292,8 @@ impl WorkerPruneManager {
         }
 
         let now = Instant::now();
-        let mut by_worker: HashMap<WorkerWithDpRank, Vec<BlockEntry>> = HashMap::new();
+        let mut by_worker: FxHashMap<WorkerWithDpRank, Vec<BlockEntry>> =
+            FxHashMap::with_capacity_and_hasher(entries.len(), FxBuildHasher);
         for entry in entries {
             by_worker.entry(entry.worker).or_default().push(entry);
         }
@@ -317,8 +320,9 @@ impl WorkerPruneManager {
             return;
         }
 
-        let removed_entries: HashSet<_> = entries.iter().copied().collect();
-        let mut by_worker: HashMap<WorkerWithDpRank, Vec<BlockEntry>> = HashMap::new();
+        let removed_entries: FxHashSet<_> = entries.iter().copied().collect();
+        let mut by_worker: FxHashMap<WorkerWithDpRank, Vec<BlockEntry>> =
+            FxHashMap::with_capacity_and_hasher(entries.len(), FxBuildHasher);
         for entry in entries {
             by_worker.entry(entry.worker).or_default().push(*entry);
         }

--- a/lib/kv-router/src/indexer/pruning.rs
+++ b/lib/kv-router/src/indexer/pruning.rs
@@ -78,23 +78,18 @@ pub struct PruneManager<K: Clone + Hash + Eq + Ord> {
     /// An entry in this heap is "stale" if the instant does not match the one in the `timers` map.
     expirations: BinaryHeap<(Reverse<Instant>, K)>,
 
-    /// Threshold for rebuilding the heap.
-    /// The heap will be rebuilt from scratch to remove stale entries.
-    threshold: usize,
-
     /// The expiration duration of the timers.
     ttl: Duration,
 }
 
 impl<K: Clone + Hash + Eq + Ord> PruneManager<K> {
     /// Creates a new, empty PruneManager.
-    pub fn new(threshold: usize, prune_config: PruneConfig) -> Self {
+    pub fn new(prune_config: PruneConfig) -> Self {
         let ttl = prune_config.ttl;
         PruneManager {
             timers: FxHashMap::default(),
             expirations: BinaryHeap::new(),
             ttl,
-            threshold,
         }
     }
 
@@ -133,7 +128,9 @@ impl<K: Clone + Hash + Eq + Ord> PruneManager<K> {
         }
 
         // Check if we should rebuild the heap to remove stale entries
-        if !self.timers.is_empty() && self.expirations.len() > self.timers.len() * self.threshold {
+        if !self.timers.is_empty()
+            && self.expirations.len() > self.timers.len() * HEAP_REBUILD_THRESHOLD
+        {
             self.rebuild_heap();
         }
     }
@@ -195,7 +192,7 @@ struct WorkerPruneState {
 impl WorkerPruneState {
     fn new(config: PruneConfig) -> Self {
         Self {
-            timers: PruneManager::new(HEAP_REBUILD_THRESHOLD, config),
+            timers: PruneManager::new(config),
         }
     }
 
@@ -632,7 +629,7 @@ mod tests {
     async fn test_prune_manager_expiry() {
         const TTL: Duration = Duration::from_millis(50);
         let prune_config = PruneConfig { ttl: TTL };
-        let mut pm: PruneManager<u32> = PruneManager::new(50, prune_config);
+        let mut pm: PruneManager<u32> = PruneManager::new(prune_config);
 
         pm.insert(vec![1, 2, 3]);
         assert!(pm.get_expiry(&1).is_some());
@@ -654,7 +651,7 @@ mod tests {
         // Validate that reinserting an existing key extends its TTL and prevents premature expiry.
         const TTL: Duration = Duration::from_millis(50);
         let prune_config = PruneConfig { ttl: TTL };
-        let mut pm: PruneManager<u32> = PruneManager::new(50, prune_config);
+        let mut pm: PruneManager<u32> = PruneManager::new(prune_config);
 
         // Initial insert and capture the original expiry.
         pm.insert(vec![42]);

--- a/lib/kv-router/src/indexer/pruning.rs
+++ b/lib/kv-router/src/indexer/pruning.rs
@@ -63,24 +63,116 @@ impl Default for PruneConfig {
     }
 }
 
+/// Shared lazy min-heap for expiry indexes.
+///
+/// The heap may contain stale entries. Callers keep the source of truth elsewhere and
+/// validate heap entries when peeking or popping.
+#[derive(Debug)]
+struct LazyExpiryHeap<K: Clone + Ord> {
+    heap: BinaryHeap<(Reverse<Instant>, K)>,
+    threshold: usize,
+}
+
+impl<K: Clone + Ord> LazyExpiryHeap<K> {
+    fn new(threshold: usize) -> Self {
+        Self {
+            heap: BinaryHeap::new(),
+            threshold,
+        }
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.heap.len()
+    }
+
+    fn reserve(&mut self, additional: usize) {
+        self.heap.reserve(additional);
+    }
+
+    fn push(&mut self, key: K, expiry: Instant) {
+        self.heap.push((Reverse(expiry), key));
+    }
+
+    fn peek(&self) -> Option<(Instant, K)> {
+        self.heap
+            .peek()
+            .map(|(Reverse(expiry), key)| (*expiry, key.clone()))
+    }
+
+    fn pop(&mut self) -> Option<(Instant, K)> {
+        self.heap.pop().map(|(Reverse(expiry), key)| (expiry, key))
+    }
+
+    fn pop_if_top(&mut self, candidate: (Instant, &K)) -> bool {
+        let Some((expiry, key)) = self.peek() else {
+            return false;
+        };
+        if expiry == candidate.0 && key == *candidate.1 {
+            self.heap.pop();
+            true
+        } else {
+            false
+        }
+    }
+
+    fn rebuild<I>(&mut self, entries: I)
+    where
+        I: IntoIterator<Item = (K, Instant)>,
+    {
+        self.heap = entries
+            .into_iter()
+            .map(|(key, expiry)| (Reverse(expiry), key))
+            .collect();
+    }
+
+    fn should_rebuild(&self, active_len: usize) -> bool {
+        active_len > 0 && self.heap.len() > active_len * self.threshold
+    }
+
+    fn peek_valid<F>(&mut self, mut is_valid: F) -> Option<(Instant, K)>
+    where
+        F: FnMut(&K, Instant) -> bool,
+    {
+        loop {
+            let (expiry, key) = self.peek()?;
+            if is_valid(&key, expiry) {
+                return Some((expiry, key));
+            }
+            self.heap.pop();
+        }
+    }
+
+    fn pop_due_valid<F>(&mut self, now: Instant, mut is_valid: F) -> Option<(Instant, K)>
+    where
+        F: FnMut(&K, Instant) -> bool,
+    {
+        loop {
+            let (expiry, _) = self.peek()?;
+            if expiry > now {
+                return None;
+            }
+
+            let (expiry, key) = self.pop().expect("expiry heap top disappeared");
+            if is_valid(&key, expiry) {
+                return Some((expiry, key));
+            }
+        }
+    }
+}
+
 /// A data structure to manage a collection of timers, addressable by a key.
 /// This is structured as a sort of "priority queue" of keys, where the priority is the expiration time.
 /// It supports insertion as well as updating the expiration time of a key.
-/// The [`PruneManager::expirations`] heap is lazily updated to reflect the true expiration times in [`PruneManager::timers`]
+/// The expiration heap is lazily updated to reflect the true expiration times in [`PruneManager::timers`]
 /// For now, we have a fixed expiration time for all keys.
 #[derive(Debug)]
 pub struct PruneManager<K: Clone + Hash + Eq + Ord> {
     /// The source of truth. Maps a key to its current expiration instant.
     timers: FxHashMap<K, Instant>,
 
-    /// A max-heap of (Reverse<expiration_instant>, key) used to efficiently find the
-    /// next expiring timer. Reverse<Instant> makes earlier times pop first.
-    /// An entry in this heap is "stale" if the instant does not match the one in the `timers` map.
-    expirations: BinaryHeap<(Reverse<Instant>, K)>,
-
-    /// Threshold for rebuilding the heap.
-    /// The heap will be rebuilt from scratch to remove stale entries.
-    threshold: usize,
+    /// Lazily-stale heap used to efficiently find the next expiring timer.
+    expirations: LazyExpiryHeap<K>,
 
     /// The expiration duration of the timers.
     ttl: Duration,
@@ -92,19 +184,16 @@ impl<K: Clone + Hash + Eq + Ord> PruneManager<K> {
         let ttl = prune_config.ttl;
         PruneManager {
             timers: FxHashMap::default(),
-            expirations: BinaryHeap::new(),
+            expirations: LazyExpiryHeap::new(threshold),
             ttl,
-            threshold,
         }
     }
 
     /// Rebuilds the expirations heap from the timers map, removing all stale entries.
     fn rebuild_heap(&mut self) {
-        self.expirations = self
-            .timers
-            .iter()
-            .map(|(key, &expiry)| (Reverse(expiry), key.clone()))
-            .collect();
+        let timers = &self.timers;
+        self.expirations
+            .rebuild(timers.iter().map(|(key, &expiry)| (key.clone(), expiry)));
     }
 
     /// Inserts a new timer or updates an existing one for the given key.
@@ -129,11 +218,11 @@ impl<K: Clone + Hash + Eq + Ord> PruneManager<K> {
             // Push the new expiration onto the heap. If the key was updated,
             // this leaves a "stale" entry on the heap for the old time,
             // which will be ignored when it's popped.
-            self.expirations.push((Reverse(expiry_time), key));
+            self.expirations.push(key, expiry_time);
         }
 
         // Check if we should rebuild the heap to remove stale entries
-        if !self.timers.is_empty() && self.expirations.len() > self.timers.len() * self.threshold {
+        if self.expirations.should_rebuild(self.timers.len()) {
             self.rebuild_heap();
         }
     }
@@ -148,20 +237,14 @@ impl<K: Clone + Hash + Eq + Ord> PruneManager<K> {
     pub fn pop_expired(&mut self, now: Instant) -> Vec<K> {
         let mut expired_keys = Vec::new();
 
-        while let Some((Reverse(expiry_time), _)) = self.expirations.peek() {
-            // If the next timer in the heap is not yet expired, we can stop.
-            if *expiry_time > now {
-                break;
-            }
-
-            // The timer might be expired, so pop it from the heap.
-            let (Reverse(expiry_time), key) = self.expirations.pop().unwrap();
-
-            if self.timers.get(&key) == Some(&expiry_time) {
-                // This is a valid, non-stale, expired timer.
-                self.timers.remove(&key);
-                expired_keys.push(key);
-            }
+        while let Some((_, key)) = {
+            let timers = &self.timers;
+            self.expirations
+                .pop_due_valid(now, |key, expiry| timers.get(key) == Some(&expiry))
+        } {
+            // This is a valid, non-stale, expired timer.
+            self.timers.remove(&key);
+            expired_keys.push(key);
         }
 
         expired_keys
@@ -169,13 +252,10 @@ impl<K: Clone + Hash + Eq + Ord> PruneManager<K> {
 
     /// Returns the next non-stale expiry time, if it exists.
     pub fn peek_next_valid_expiry(&mut self) -> Option<Instant> {
-        while let Some((Reverse(expiry_time), key)) = self.expirations.peek() {
-            if self.timers.get(key) == Some(expiry_time) {
-                return Some(*expiry_time);
-            }
-            self.expirations.pop();
-        }
-        None
+        let timers = &self.timers;
+        self.expirations
+            .peek_valid(|key, expiry| timers.get(key) == Some(&expiry))
+            .map(|(expiry, _)| expiry)
     }
 
     pub fn len(&self) -> usize {
@@ -224,7 +304,7 @@ pub struct WorkerPruneManager {
 struct WorkerPruneManagerInner {
     config: PruneConfig,
     workers: DashMap<WorkerWithDpRank, Mutex<WorkerPruneState>, FxBuildHasher>,
-    next_expiries: Mutex<BinaryHeap<(Reverse<Instant>, WorkerWithDpRank)>>,
+    next_expiries: Mutex<LazyExpiryHeap<WorkerWithDpRank>>,
     pending_removes: Mutex<VecDeque<BlockEntry>>,
     ready_tx: watch::Sender<u64>,
     schedule_tx: watch::Sender<u64>,
@@ -244,7 +324,7 @@ impl WorkerPruneManager {
         let inner = Arc::new(WorkerPruneManagerInner {
             config,
             workers: DashMap::with_hasher(FxBuildHasher),
-            next_expiries: Mutex::new(BinaryHeap::new()),
+            next_expiries: Mutex::new(LazyExpiryHeap::new(WORKER_EXPIRY_HEAP_REBUILD_THRESHOLD)),
             pending_removes: Mutex::new(VecDeque::new()),
             ready_tx,
             schedule_tx,
@@ -298,21 +378,67 @@ impl WorkerPruneManager {
             by_worker.entry(entry.worker).or_default().push(entry);
         }
 
+        let mut should_bump_schedule = false;
         for (worker, worker_entries) in by_worker {
-            let next_expiry = {
-                let state = self.inner.workers.entry(worker).or_insert_with(|| {
-                    Mutex::new(WorkerPruneState::new(self.inner.config.clone()))
-                });
-                let mut state = state.lock().expect("worker prune state mutex poisoned");
-                state.insert_block_entries(worker_entries, now);
-                state.peek_next_valid_expiry()
-            };
-            if let Some(next_expiry) = next_expiry {
-                self.inner.push_worker_expiry(worker, next_expiry);
-            }
+            should_bump_schedule |=
+                self.insert_worker_block_entries_at(worker, worker_entries, now);
         }
 
-        self.inner.bump_schedule();
+        if should_bump_schedule {
+            self.inner.bump_schedule();
+        }
+    }
+
+    pub fn insert_worker_block_entries(&self, worker: WorkerWithDpRank, entries: Vec<BlockEntry>) {
+        if entries.is_empty() {
+            return;
+        }
+
+        if self.insert_worker_block_entries_at(worker, entries, Instant::now()) {
+            self.inner.bump_schedule();
+        }
+    }
+
+    fn insert_worker_block_entries_at(
+        &self,
+        worker: WorkerWithDpRank,
+        entries: Vec<BlockEntry>,
+        now: Instant,
+    ) -> bool {
+        let (old_next, new_next) = {
+            let state =
+                self.inner.workers.entry(worker).or_insert_with(|| {
+                    Mutex::new(WorkerPruneState::new(self.inner.config.clone()))
+                });
+            let mut state = state.lock().expect("worker prune state mutex poisoned");
+            let old_next = state.peek_next_valid_expiry();
+            state.insert_block_entries(entries, now);
+            let new_next = state.peek_next_valid_expiry();
+            (old_next, new_next)
+        };
+
+        match (old_next, new_next) {
+            (None, Some(next_expiry)) => {
+                self.inner.push_worker_expiry(worker, next_expiry);
+                true
+            }
+            (Some(old_next), Some(new_next)) if new_next < old_next => {
+                tracing::warn!(
+                    worker_id = worker.worker_id,
+                    dp_rank = worker.dp_rank,
+                    ?old_next,
+                    ?new_next,
+                    "Approximate prune expiry moved earlier during insert; rescheduling"
+                );
+                debug_assert!(
+                    new_next >= old_next,
+                    "approximate prune expiry moved earlier during insert"
+                );
+                self.inner.push_worker_expiry(worker, new_next);
+                true
+            }
+            _ => false,
+        }
     }
 
     pub fn remove_block_entries(&self, entries: &[BlockEntry]) {
@@ -423,7 +549,7 @@ impl WorkerPruneManagerInner {
         self.next_expiries
             .lock()
             .expect("worker expiry index mutex poisoned")
-            .push((Reverse(expiry), worker));
+            .push(worker, expiry);
         self.rebuild_worker_expiry_heap_if_needed();
     }
 
@@ -438,13 +564,13 @@ impl WorkerPruneManagerInner {
                 .next_expiries
                 .lock()
                 .expect("worker expiry index mutex poisoned");
-            expiries.len() > workers_len * WORKER_EXPIRY_HEAP_REBUILD_THRESHOLD
+            expiries.should_rebuild(workers_len)
         };
         if !should_rebuild {
             return;
         }
 
-        let mut rebuilt = BinaryHeap::new();
+        let mut rebuilt = LazyExpiryHeap::new(WORKER_EXPIRY_HEAP_REBUILD_THRESHOLD);
         for entry in self.workers.iter() {
             let worker = *entry.key();
             let next_expiry = entry
@@ -453,7 +579,7 @@ impl WorkerPruneManagerInner {
                 .expect("worker prune state mutex poisoned")
                 .peek_next_valid_expiry();
             if let Some(next_expiry) = next_expiry {
-                rebuilt.push((Reverse(next_expiry), worker));
+                rebuilt.push(worker, next_expiry);
             }
         }
 
@@ -469,9 +595,8 @@ impl WorkerPruneManagerInner {
                 .next_expiries
                 .lock()
                 .expect("worker expiry index mutex poisoned")
-                .peek()
-                .copied();
-            let (Reverse(expiry), worker) = candidate?;
+                .peek();
+            let (expiry, worker) = candidate?;
 
             let next_valid = self.workers.get(&worker).and_then(|state| {
                 state
@@ -488,11 +613,10 @@ impl WorkerPruneManagerInner {
                 .next_expiries
                 .lock()
                 .expect("worker expiry index mutex poisoned");
-            if expiries.peek().copied() == candidate {
-                expiries.pop();
-                if let Some(next_valid) = next_valid {
-                    expiries.push((Reverse(next_valid), worker));
-                }
+            if expiries.pop_if_top((expiry, &worker))
+                && let Some(next_valid) = next_valid
+            {
+                expiries.push(worker, next_valid);
             }
         }
     }
@@ -501,12 +625,12 @@ impl WorkerPruneManagerInner {
         let mut expired = Vec::new();
 
         loop {
-            let Some((Reverse(expiry), worker)) = ({
+            let Some((expiry, worker)) = ({
                 let mut expiries = self
                     .next_expiries
                     .lock()
                     .expect("worker expiry index mutex poisoned");
-                let Some((Reverse(expiry), _)) = expiries.peek().copied() else {
+                let Some((expiry, _)) = expiries.peek() else {
                     break;
                 };
                 if expiry > now {

--- a/lib/kv-router/src/indexer/pruning.rs
+++ b/lib/kv-router/src/indexer/pruning.rs
@@ -3,17 +3,23 @@
 
 //! Pruning and TTL utilities for KV Indexers
 //!
-//! This module provides utilities for managing TTL-based expiration and size-based pruning
-//! of blocks in the radix tree. These utilities are used by the KvIndexer to manage
-//! memory usage and keep the cache fresh.
+//! This module provides utilities for managing TTL-based expiration of
+//! approximate-mode blocks in the radix tree.
 
 use std::cmp::Reverse;
-use std::collections::{BinaryHeap, HashMap};
+use std::collections::{BinaryHeap, HashMap, HashSet, VecDeque};
 use std::hash::Hash;
-use tokio::time::{Duration, Instant};
+use std::sync::{Arc, Mutex};
 
-use super::KvRouterError;
-use crate::protocols::{ExternalSequenceBlockHash, WorkerWithDpRank};
+use dashmap::DashMap;
+use rustc_hash::FxBuildHasher;
+use tokio::sync::watch;
+use tokio::time::{Duration, Instant};
+use tokio_util::sync::CancellationToken;
+
+use crate::protocols::{ExternalSequenceBlockHash, WorkerId, WorkerWithDpRank};
+
+const HEAP_REBUILD_THRESHOLD: usize = 50;
 
 /// Block entry to be inserted in the [`PruneManager::expirations`] heap.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
@@ -34,7 +40,7 @@ impl PartialOrd for BlockEntry {
 
 impl Ord for BlockEntry {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        // Break ties by sequence position (important for pruning), then by key, then by worker.
+        // Break ties by sequence position, then by key, then by worker.
         self.seq_position
             .cmp(&other.seq_position)
             .then_with(|| self.key.cmp(&other.key))
@@ -46,20 +52,12 @@ impl Ord for BlockEntry {
 pub struct PruneConfig {
     /// Time-to-live duration for blocks before they expire.
     pub ttl: Duration,
-    /// The maximum tree size before pruning is considered.
-    pub max_tree_size: usize,
-    /// The target size ratio to prune down to when max_tree_size is exceeded.
-    /// For example, if max_tree_size is 100 and target_size_ratio is 0.5,
-    /// we will prune down to 50 nodes when max_tree_size is exceeded.
-    pub prune_target_ratio: f64,
 }
 
 impl Default for PruneConfig {
     fn default() -> Self {
         Self {
             ttl: Duration::from_secs(120), // 120 seconds
-            max_tree_size: 2usize.pow(20), // 2^20 = 1048576
-            prune_target_ratio: 0.8,       // Prune down to 80% of max
         }
     }
 }
@@ -85,9 +83,6 @@ pub struct PruneManager<K: Clone + Hash + Eq + Ord> {
 
     /// The expiration duration of the timers.
     ttl: Duration,
-
-    /// The configuration for tree-size pruning.
-    pub prune_config: Option<PruneConfig>,
 }
 
 impl<K: Clone + Hash + Eq + Ord> PruneManager<K> {
@@ -99,7 +94,6 @@ impl<K: Clone + Hash + Eq + Ord> PruneManager<K> {
             expirations: BinaryHeap::new(),
             ttl,
             threshold,
-            prune_config: Some(prune_config),
         }
     }
 
@@ -118,7 +112,12 @@ impl<K: Clone + Hash + Eq + Ord> PruneManager<K> {
     /// * `key` - The unique key for the timer.
     /// * `duration` - The duration from now when the timer should expire.
     pub fn insert(&mut self, keys: Vec<K>) {
-        let expiry_time = Instant::now() + self.ttl;
+        self.insert_at(keys, Instant::now());
+    }
+
+    /// Inserts timers using a caller-provided timestamp.
+    pub fn insert_at(&mut self, keys: Vec<K>, now: Instant) {
+        let expiry_time = now + self.ttl;
 
         for key in keys {
             // Insert or update the authoritative time in the map.
@@ -131,16 +130,20 @@ impl<K: Clone + Hash + Eq + Ord> PruneManager<K> {
         }
 
         // Check if we should rebuild the heap to remove stale entries
-        if self.expirations.len() > self.timers.len() * self.threshold {
+        if !self.timers.is_empty() && self.expirations.len() > self.timers.len() * self.threshold {
             self.rebuild_heap();
         }
     }
 
+    /// Removes a timer for the given key.
+    pub fn remove(&mut self, key: &K) -> bool {
+        self.timers.remove(key).is_some()
+    }
+
     /// Polls for expired timers and returns a list of keys for all timers
-    /// that have expired up to the current moment.
-    pub fn pop_expired(&mut self) -> Vec<K> {
+    /// that have expired up to `now`.
+    pub fn pop_expired(&mut self, now: Instant) -> Vec<K> {
         let mut expired_keys = Vec::new();
-        let now = Instant::now();
 
         while let Some((Reverse(expiry_time), _)) = self.expirations.peek() {
             // If the next timer in the heap is not yet expired, we can stop.
@@ -161,74 +164,357 @@ impl<K: Clone + Hash + Eq + Ord> PruneManager<K> {
         expired_keys
     }
 
-    /// Returns the next expiry time, if it exists.
-    pub fn peek_next_expiry(&self) -> Option<Instant> {
-        self.expirations
-            .peek()
-            .map(|(Reverse(expiry_time), _)| *expiry_time)
+    /// Returns the next non-stale expiry time, if it exists.
+    pub fn peek_next_valid_expiry(&mut self) -> Option<Instant> {
+        while let Some((Reverse(expiry_time), key)) = self.expirations.peek() {
+            if self.timers.get(key) == Some(expiry_time) {
+                return Some(*expiry_time);
+            }
+            self.expirations.pop();
+        }
+        None
     }
 
-    /// Prunes the tree if the current size is greater than the max tree size.
-    pub fn prune(&mut self, current_size: usize) -> Result<Vec<K>, KvRouterError> {
-        let max_tree_size: usize;
-        let prune_target_ratio: f64;
+    pub fn len(&self) -> usize {
+        self.timers.len()
+    }
 
-        if let Some(prune_config) = &self.prune_config {
-            max_tree_size = prune_config.max_tree_size;
-            prune_target_ratio = prune_config.prune_target_ratio;
-        } else {
-            tracing::error!("Prune was called but prune config is None. This should never happen");
-            return Err(KvRouterError::PruneFailed(
-                "prune config is missing".to_string(),
-            ));
+    pub fn is_empty(&self) -> bool {
+        self.timers.is_empty()
+    }
+}
+
+#[derive(Debug)]
+struct WorkerPruneState {
+    timers: PruneManager<BlockEntry>,
+    by_hash: HashMap<ExternalSequenceBlockHash, HashSet<BlockEntry>>,
+}
+
+impl WorkerPruneState {
+    fn new(config: PruneConfig) -> Self {
+        Self {
+            timers: PruneManager::new(HEAP_REBUILD_THRESHOLD, config),
+            by_hash: HashMap::new(),
         }
+    }
 
-        if current_size <= max_tree_size {
-            // Tree size within bounds, no pruning needed.
-            return Ok(Vec::new());
+    fn insert_block_entries(&mut self, entries: Vec<BlockEntry>, now: Instant) {
+        self.timers.insert_at(entries.clone(), now);
+        for entry in entries {
+            self.by_hash.entry(entry.key).or_default().insert(entry);
         }
+    }
 
-        tracing::info!(
-            "Pruning: tree size ({}) exceeded max tree size ({}), starting pruning",
-            current_size,
-            max_tree_size
-        );
+    fn remove_block_entry(&mut self, entry: &BlockEntry) {
+        if !self.timers.remove(entry) {
+            return;
+        }
+        if let Some(entries) = self.by_hash.get_mut(&entry.key) {
+            entries.remove(entry);
+            if entries.is_empty() {
+                self.by_hash.remove(&entry.key);
+            }
+        }
+    }
 
-        // Number of blocks that will be kept after pruning.
-        let target_size = (max_tree_size as f64 * prune_target_ratio) as usize;
-
-        let mut pruned_keys = Vec::new();
-        let mut num_pruned = 0;
-
-        while num_pruned < current_size.saturating_sub(target_size) {
-            if let Some((Reverse(expiry_time), key)) = self.expirations.pop() {
-                if self.timers.get(&key) == Some(&expiry_time) {
-                    // This is a valid, non-stale timer.
-                    self.timers.remove(&key);
-                    pruned_keys.push(key);
-                    num_pruned += 1;
+    fn pop_expired(&mut self, now: Instant) -> Vec<BlockEntry> {
+        let expired = self.timers.pop_expired(now);
+        for entry in &expired {
+            if let Some(entries) = self.by_hash.get_mut(&entry.key) {
+                entries.remove(entry);
+                if entries.is_empty() {
+                    self.by_hash.remove(&entry.key);
                 }
-            } else {
-                break;
+            }
+        }
+        expired
+    }
+
+    fn peek_next_valid_expiry(&mut self) -> Option<Instant> {
+        self.timers.peek_next_valid_expiry()
+    }
+}
+
+#[derive(Clone)]
+pub struct WorkerPruneManager {
+    inner: Arc<WorkerPruneManagerInner>,
+}
+
+struct WorkerPruneManagerInner {
+    config: PruneConfig,
+    workers: DashMap<WorkerWithDpRank, Mutex<WorkerPruneState>, FxBuildHasher>,
+    next_expiries: Mutex<BinaryHeap<(Reverse<Instant>, WorkerWithDpRank)>>,
+    pending_removes: Mutex<VecDeque<BlockEntry>>,
+    ready_tx: watch::Sender<u64>,
+    schedule_tx: watch::Sender<u64>,
+    cancel: CancellationToken,
+}
+
+impl Drop for WorkerPruneManagerInner {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+    }
+}
+
+impl WorkerPruneManager {
+    pub fn new(config: PruneConfig) -> Self {
+        let (ready_tx, _) = watch::channel(0);
+        let (schedule_tx, schedule_rx) = watch::channel(0);
+        let inner = Arc::new(WorkerPruneManagerInner {
+            config,
+            workers: DashMap::with_hasher(FxBuildHasher),
+            next_expiries: Mutex::new(BinaryHeap::new()),
+            pending_removes: Mutex::new(VecDeque::new()),
+            ready_tx,
+            schedule_tx,
+            cancel: CancellationToken::new(),
+        });
+
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            handle.spawn(Self::ttl_task(Arc::clone(&inner), schedule_rx));
+        }
+
+        Self { inner }
+    }
+
+    async fn ttl_task(inner: Arc<WorkerPruneManagerInner>, mut schedule_rx: watch::Receiver<u64>) {
+        loop {
+            let Some(next_expiry) = inner.next_global_expiry() else {
+                tokio::select! {
+                    _ = inner.cancel.cancelled() => break,
+                    changed = schedule_rx.changed() => {
+                        if changed.is_err() {
+                            break;
+                        }
+                    }
+                }
+                continue;
+            };
+
+            tokio::select! {
+                _ = inner.cancel.cancelled() => break,
+                _ = tokio::time::sleep_until(next_expiry) => {
+                    inner.queue_due(Instant::now());
+                }
+                changed = schedule_rx.changed() => {
+                    if changed.is_err() {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn insert_block_entries(&self, entries: Vec<BlockEntry>) {
+        if entries.is_empty() {
+            return;
+        }
+
+        let now = Instant::now();
+        let mut by_worker: HashMap<WorkerWithDpRank, Vec<BlockEntry>> = HashMap::new();
+        for entry in entries {
+            by_worker.entry(entry.worker).or_default().push(entry);
+        }
+
+        for (worker, worker_entries) in by_worker {
+            let state =
+                self.inner.workers.entry(worker).or_insert_with(|| {
+                    Mutex::new(WorkerPruneState::new(self.inner.config.clone()))
+                });
+            let next_expiry = {
+                let mut state = state.lock().expect("worker prune state mutex poisoned");
+                state.insert_block_entries(worker_entries, now);
+                state.peek_next_valid_expiry()
+            };
+            if let Some(next_expiry) = next_expiry {
+                self.inner.push_worker_expiry(worker, next_expiry);
             }
         }
 
-        tracing::info!("Pruning: pruned ({}) blocks from tree", num_pruned);
+        self.inner.bump_schedule();
+    }
 
-        Ok(pruned_keys)
+    pub fn remove_block_entries(&self, entries: &[BlockEntry]) {
+        if entries.is_empty() {
+            return;
+        }
+
+        let removed_entries: HashSet<_> = entries.iter().copied().collect();
+        let mut by_worker: HashMap<WorkerWithDpRank, Vec<BlockEntry>> = HashMap::new();
+        for entry in entries {
+            by_worker.entry(entry.worker).or_default().push(*entry);
+        }
+
+        for (worker, worker_entries) in by_worker {
+            let Some(state) = self.inner.workers.get(&worker) else {
+                continue;
+            };
+            let next_expiry = {
+                let mut state = state.lock().expect("worker prune state mutex poisoned");
+                for entry in &worker_entries {
+                    state.remove_block_entry(entry);
+                }
+                state.peek_next_valid_expiry()
+            };
+            if let Some(next_expiry) = next_expiry {
+                self.inner.push_worker_expiry(worker, next_expiry);
+            }
+        }
+
+        self.inner
+            .pending_removes
+            .lock()
+            .expect("pending prune remove queue mutex poisoned")
+            .retain(|entry| !removed_entries.contains(entry));
+        self.inner.bump_schedule();
+    }
+
+    pub fn remove_worker(&self, worker_id: WorkerId) {
+        let workers: Vec<_> = self
+            .inner
+            .workers
+            .iter()
+            .filter_map(|entry| {
+                let worker = *entry.key();
+                (worker.worker_id == worker_id).then_some(worker)
+            })
+            .collect();
+        for worker in workers {
+            self.inner.workers.remove(&worker);
+        }
+        self.inner
+            .pending_removes
+            .lock()
+            .expect("pending prune remove queue mutex poisoned")
+            .retain(|entry| entry.worker.worker_id != worker_id);
+        self.inner.bump_schedule();
+    }
+
+    pub fn remove_worker_dp_rank(&self, worker: WorkerWithDpRank) {
+        self.inner.workers.remove(&worker);
+        self.inner
+            .pending_removes
+            .lock()
+            .expect("pending prune remove queue mutex poisoned")
+            .retain(|entry| entry.worker != worker);
+        self.inner.bump_schedule();
+    }
+
+    pub fn drain_due_and_pending(&self, now: Instant) -> Vec<BlockEntry> {
+        self.inner.queue_due(now);
+        self.drain_pending_removes()
+    }
+
+    pub fn drain_pending_removes(&self) -> Vec<BlockEntry> {
+        self.inner
+            .pending_removes
+            .lock()
+            .expect("pending prune remove queue mutex poisoned")
+            .drain(..)
+            .collect()
+    }
+
+    pub fn subscribe_ready(&self) -> watch::Receiver<u64> {
+        self.inner.ready_tx.subscribe()
+    }
+
+    pub fn shutdown(&self) {
+        self.inner.cancel.cancel();
+    }
+}
+
+impl WorkerPruneManagerInner {
+    fn bump_sender(sender: &watch::Sender<u64>) {
+        let next = sender.borrow().wrapping_add(1);
+        let _ = sender.send(next);
+    }
+
+    fn bump_schedule(&self) {
+        Self::bump_sender(&self.schedule_tx);
+    }
+
+    fn bump_ready(&self) {
+        Self::bump_sender(&self.ready_tx);
+    }
+
+    fn push_worker_expiry(&self, worker: WorkerWithDpRank, expiry: Instant) {
+        self.next_expiries
+            .lock()
+            .expect("worker expiry index mutex poisoned")
+            .push((Reverse(expiry), worker));
+    }
+
+    fn next_global_expiry(&self) -> Option<Instant> {
+        loop {
+            let candidate = self
+                .next_expiries
+                .lock()
+                .expect("worker expiry index mutex poisoned")
+                .peek()
+                .copied();
+            let (Reverse(expiry), worker) = candidate?;
+
+            let next_valid = self.workers.get(&worker).and_then(|state| {
+                state
+                    .lock()
+                    .expect("worker prune state mutex poisoned")
+                    .peek_next_valid_expiry()
+            });
+
+            if next_valid == Some(expiry) {
+                return Some(expiry);
+            }
+
+            let mut expiries = self
+                .next_expiries
+                .lock()
+                .expect("worker expiry index mutex poisoned");
+            if expiries.peek().copied() == candidate {
+                expiries.pop();
+                if let Some(next_valid) = next_valid {
+                    expiries.push((Reverse(next_valid), worker));
+                }
+            }
+        }
+    }
+
+    fn queue_due(&self, now: Instant) {
+        let workers: Vec<_> = self.workers.iter().map(|entry| *entry.key()).collect();
+        let mut expired = Vec::new();
+
+        for worker in workers {
+            let Some(state) = self.workers.get(&worker) else {
+                continue;
+            };
+            let (mut worker_expired, next_expiry) = {
+                let mut state = state.lock().expect("worker prune state mutex poisoned");
+                let expired = state.pop_expired(now);
+                let next_expiry = state.peek_next_valid_expiry();
+                (expired, next_expiry)
+            };
+            expired.append(&mut worker_expired);
+            if let Some(next_expiry) = next_expiry {
+                self.push_worker_expiry(worker, next_expiry);
+            }
+        }
+
+        if expired.is_empty() {
+            return;
+        }
+
+        self.pending_removes
+            .lock()
+            .expect("pending prune remove queue mutex poisoned")
+            .extend(expired);
+        self.bump_ready();
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::indexer::{KvIndexer, KvIndexerInterface, KvIndexerMetrics};
-    use crate::protocols::{TokensWithHashes, WorkerId, WorkerWithDpRank};
-    use std::sync::Arc;
+    use crate::protocols::WorkerWithDpRank;
     use tokio::time::{self, Duration, Instant};
-    use tokio_util::sync::CancellationToken;
-
-    const KV_BLOCK_SIZE: u32 = 4;
 
     impl<T: Clone + Hash + Eq + Ord> PruneManager<T> {
         pub fn get_expiry(&self, key: &T) -> Option<&Instant> {
@@ -236,34 +522,11 @@ mod tests {
         }
     }
 
-    /// Helper to spin until a future evaluates to `true`, or a timeout is reached.
-    async fn spin_until<F, Fut>(timeout: Duration, mut predicate: F)
-    where
-        F: FnMut() -> Fut,
-        Fut: std::future::Future<Output = bool>,
-    {
-        let start = Instant::now();
-        const POLL: Duration = Duration::from_millis(1);
-        loop {
-            if predicate().await {
-                return;
-            }
-            if Instant::now().duration_since(start) >= timeout {
-                panic!("timeout waiting for condition");
-            }
-            time::sleep(POLL).await;
-        }
-    }
-
     /// Validate basic insert / expiry behaviour of [`PruneManager`].
     #[tokio::test]
     async fn test_prune_manager_expiry() {
         const TTL: Duration = Duration::from_millis(50);
-        let prune_config = PruneConfig {
-            ttl: TTL,
-            max_tree_size: usize::MAX, // Effectively disable size-based pruning
-            prune_target_ratio: 0.5,
-        };
+        let prune_config = PruneConfig { ttl: TTL };
         let mut pm: PruneManager<u32> = PruneManager::new(50, prune_config);
 
         pm.insert(vec![1, 2, 3]);
@@ -273,7 +536,7 @@ mod tests {
 
         // Wait until after the TTL
         time::sleep(TTL + Duration::from_millis(20)).await;
-        let expired = pm.pop_expired();
+        let expired = pm.pop_expired(Instant::now());
         assert_eq!(expired.len(), 3);
         assert!(pm.get_expiry(&1).is_none());
         assert!(pm.get_expiry(&2).is_none());
@@ -285,11 +548,7 @@ mod tests {
     async fn test_prune_manager_update_resets_ttl() {
         // Validate that reinserting an existing key extends its TTL and prevents premature expiry.
         const TTL: Duration = Duration::from_millis(50);
-        let prune_config = PruneConfig {
-            ttl: TTL,
-            max_tree_size: usize::MAX,
-            prune_target_ratio: 0.5,
-        };
+        let prune_config = PruneConfig { ttl: TTL };
         let mut pm: PruneManager<u32> = PruneManager::new(50, prune_config);
 
         // Initial insert and capture the original expiry.
@@ -310,7 +569,7 @@ mod tests {
 
         // Wait until *after* the first expiry would have fired, but *before* the new expiry.
         time::sleep(Duration::from_millis(30)).await; // 25ms already elapsed, +30ms = 55ms > first TTL
-        let expired = pm.pop_expired();
+        let expired = pm.pop_expired(Instant::now());
         assert!(
             expired.is_empty(),
             "key expired prematurely despite TTL refresh"
@@ -318,431 +577,8 @@ mod tests {
 
         // Now wait until after the second expiry should have occurred.
         time::sleep(Duration::from_millis(30)).await; // Ensure we pass the refreshed TTL
-        let expired_after = pm.pop_expired();
+        let expired_after = pm.pop_expired(Instant::now());
         assert_eq!(expired_after, vec![42]);
-    }
-
-    /// End-to-end test for [`KvIndexer`] with TTL:
-    ///   1. No matches before routing decision
-    ///   2. Matches appear after `process_routing_decision`
-    ///   3. Matches disappear after TTL expiry
-    #[tokio::test]
-    async fn test_approx_kv_indexer_basic_flow() {
-        const TTL: Duration = Duration::from_millis(200);
-        let cancel = CancellationToken::new();
-        let metrics = Arc::new(KvIndexerMetrics::new_unregistered());
-        let prune_config = PruneConfig {
-            ttl: TTL,
-            max_tree_size: usize::MAX,
-            prune_target_ratio: 0.5,
-        };
-        let indexer = KvIndexer::new_with_frequency(
-            cancel.clone(),
-            None,
-            KV_BLOCK_SIZE,
-            metrics,
-            Some(prune_config),
-        );
-
-        let tokens: Vec<u32> = vec![1, 2, 3, 4]; // Exactly one KV block
-        let worker_id: WorkerId = 0;
-
-        // 1. Before routing decision there should be no matches
-        let pre_scores = indexer
-            .find_matches_for_request(&tokens, None, None)
-            .await
-            .expect("indexer offline");
-        assert!(pre_scores.scores.is_empty());
-
-        // 2. Inform indexer about routing decision
-        let mut tokens_with_hashes = TokensWithHashes::new(tokens.clone(), KV_BLOCK_SIZE);
-        indexer
-            .process_routing_decision_for_request(
-                &mut tokens_with_hashes,
-                WorkerWithDpRank::from_worker_id(worker_id),
-            )
-            .await
-            .unwrap();
-
-        // Poll until we observe the match being registered
-        spin_until(Duration::from_millis(100), async || {
-            let s = indexer
-                .find_matches_for_request(&tokens, None, None)
-                .await
-                .unwrap();
-            s.scores
-                .get(&WorkerWithDpRank::from_worker_id(worker_id))
-                .copied()
-                == Some(1)
-        })
-        .await;
-
-        // 3. After the TTL has passed the entry should expire automatically
-        time::sleep(TTL + Duration::from_millis(50)).await;
-        let post_scores = indexer
-            .find_matches_for_request(&tokens, None, None)
-            .await
-            .unwrap();
-        assert!(post_scores.scores.is_empty());
-    }
-
-    /// Verify that `remove_worker` clears all entries for the specified worker.
-    #[tokio::test]
-    async fn test_remove_worker() {
-        const TTL: Duration = Duration::from_secs(5); // Large enough to avoid expiry during test
-        let cancel = CancellationToken::new();
-        let metrics = Arc::new(KvIndexerMetrics::new_unregistered());
-        let prune_config = PruneConfig {
-            ttl: TTL,
-            max_tree_size: usize::MAX,
-            prune_target_ratio: 0.5,
-        };
-        let indexer = KvIndexer::new_with_frequency(
-            cancel.clone(),
-            None,
-            KV_BLOCK_SIZE,
-            metrics,
-            Some(prune_config),
-        );
-
-        let tokens: Vec<u32> = vec![10, 11, 12, 13];
-        let worker_id: WorkerId = 7;
-
-        let mut tokens_with_hashes = TokensWithHashes::new(tokens.clone(), KV_BLOCK_SIZE);
-        indexer
-            .process_routing_decision_for_request(
-                &mut tokens_with_hashes,
-                WorkerWithDpRank::from_worker_id(worker_id),
-            )
-            .await
-            .unwrap();
-
-        // Wait until the worker is registered
-        spin_until(Duration::from_millis(100), async || {
-            let s = indexer
-                .find_matches_for_request(&tokens, None, None)
-                .await
-                .unwrap();
-            s.scores
-                .contains_key(&WorkerWithDpRank::from_worker_id(worker_id))
-        })
-        .await;
-
-        // Remove the worker
-        indexer.remove_worker(worker_id).await;
-
-        // Ensure the worker's entries are gone
-        spin_until(Duration::from_millis(100), async || {
-            let s = indexer
-                .find_matches_for_request(&tokens, None, None)
-                .await
-                .unwrap();
-            !s.scores
-                .contains_key(&WorkerWithDpRank::from_worker_id(worker_id))
-        })
-        .await;
-    }
-
-    /// After removing one of multiple workers that share the same block, the remaining worker's entries should persist.
-    #[tokio::test]
-    async fn test_remove_worker_preserves_other_workers() {
-        const TTL: Duration = Duration::from_secs(5); // Large enough to avoid expiry during test
-
-        let cancel = CancellationToken::new();
-        let metrics = Arc::new(KvIndexerMetrics::new_unregistered());
-        let prune_config = PruneConfig {
-            ttl: TTL,
-            max_tree_size: usize::MAX,
-            prune_target_ratio: 0.5,
-        };
-        let indexer = KvIndexer::new_with_frequency(
-            cancel.clone(),
-            None,
-            KV_BLOCK_SIZE,
-            metrics,
-            Some(prune_config),
-        );
-
-        let tokens: Vec<u32> = vec![100, 101, 102, 103];
-        let worker_0: WorkerId = 30;
-        let worker_1: WorkerId = 31;
-
-        // Register on both workers
-        let mut tokens_with_hashes = TokensWithHashes::new(tokens.clone(), KV_BLOCK_SIZE);
-        indexer
-            .process_routing_decision_for_request(
-                &mut tokens_with_hashes,
-                WorkerWithDpRank::from_worker_id(worker_0),
-            )
-            .await
-            .unwrap();
-        let mut tokens_with_hashes = TokensWithHashes::new(tokens.clone(), KV_BLOCK_SIZE);
-        indexer
-            .process_routing_decision_for_request(
-                &mut tokens_with_hashes,
-                WorkerWithDpRank::from_worker_id(worker_1),
-            )
-            .await
-            .unwrap();
-
-        // Ensure both workers are registered
-        spin_until(Duration::from_millis(100), async || {
-            let s = indexer
-                .find_matches_for_request(&tokens, None, None)
-                .await
-                .unwrap();
-            s.scores
-                .get(&WorkerWithDpRank::from_worker_id(worker_0))
-                .copied()
-                == Some(1)
-                && s.scores
-                    .get(&WorkerWithDpRank::from_worker_id(worker_1))
-                    .copied()
-                    == Some(1)
-        })
-        .await;
-
-        // Remove one worker
-        indexer.remove_worker(worker_0).await;
-
-        // Confirm the removed worker is gone, and the other remains.
-        spin_until(Duration::from_millis(100), async || {
-            let s = indexer
-                .find_matches_for_request(&tokens, None, None)
-                .await
-                .unwrap();
-            !s.scores
-                .contains_key(&WorkerWithDpRank::from_worker_id(worker_0))
-                && s.scores
-                    .get(&WorkerWithDpRank::from_worker_id(worker_1))
-                    .copied()
-                    == Some(1)
-        })
-        .await;
-    }
-
-    /// Two sequences with a shared prefix should yield overlap scores reflecting the common blocks.
-    #[tokio::test]
-    async fn test_common_prefix_overlap() {
-        const TTL: Duration = Duration::from_secs(5);
-
-        let cancel = CancellationToken::new();
-        let metrics = Arc::new(KvIndexerMetrics::new_unregistered());
-        let prune_config = PruneConfig {
-            ttl: TTL,
-            max_tree_size: usize::MAX,
-            prune_target_ratio: 0.5,
-        };
-        let indexer = KvIndexer::new_with_frequency(
-            cancel.clone(),
-            None,
-            KV_BLOCK_SIZE,
-            metrics,
-            Some(prune_config),
-        );
-
-        // Sequence A : single block
-        let seq_a: Vec<u32> = vec![1, 2, 3, 4];
-        let worker_a: WorkerId = 11;
-
-        // Register Sequence A on worker A
-        let mut tokens_with_hashes = TokensWithHashes::new(seq_a.clone(), KV_BLOCK_SIZE);
-        indexer
-            .process_routing_decision_for_request(
-                &mut tokens_with_hashes,
-                WorkerWithDpRank::from_worker_id(worker_a),
-            )
-            .await
-            .unwrap();
-
-        // Ensure the indexer has registered the block
-        spin_until(Duration::from_millis(100), async || {
-            let s = indexer
-                .find_matches_for_request(&seq_a, None, None)
-                .await
-                .unwrap();
-            s.scores
-                .get(&WorkerWithDpRank::from_worker_id(worker_a))
-                .copied()
-                == Some(1)
-        })
-        .await;
-
-        // Sequence B : shares the first block with Sequence A, plus an extra block
-        let seq_b: Vec<u32> = vec![1, 2, 3, 4, 5, 6, 7, 8];
-
-        // Query the indexer for overlaps of Sequence B (before it has been routed anywhere)
-        let overlap = indexer
-            .find_matches_for_request(&seq_b, None, None)
-            .await
-            .unwrap();
-
-        // Expect worker A to have an overlap score of 1 (shared first block)
-        assert_eq!(
-            overlap
-                .scores
-                .get(&WorkerWithDpRank::from_worker_id(worker_a)),
-            Some(&1)
-        );
-    }
-
-    /// When the same block resides on multiple workers, all should appear in the overlap scores.
-    #[tokio::test]
-    async fn test_multiple_workers_same_block() {
-        const TTL: Duration = Duration::from_secs(5);
-
-        let cancel = CancellationToken::new();
-        let metrics = Arc::new(KvIndexerMetrics::new_unregistered());
-        let prune_config = PruneConfig {
-            ttl: TTL,
-            max_tree_size: usize::MAX,
-            prune_target_ratio: 0.5,
-        };
-        let indexer = KvIndexer::new_with_frequency(
-            cancel.clone(),
-            None,
-            KV_BLOCK_SIZE,
-            metrics,
-            Some(prune_config),
-        );
-
-        let tokens: Vec<u32> = vec![9, 8, 7, 6];
-        let worker_0: WorkerId = 21;
-        let worker_1: WorkerId = 22;
-
-        // Register the same sequence on two different workers
-        let mut tokens_with_hashes = TokensWithHashes::new(tokens.clone(), KV_BLOCK_SIZE);
-        indexer
-            .process_routing_decision_for_request(
-                &mut tokens_with_hashes,
-                WorkerWithDpRank::from_worker_id(worker_0),
-            )
-            .await
-            .unwrap();
-        let mut tokens_with_hashes = TokensWithHashes::new(tokens.clone(), KV_BLOCK_SIZE);
-        indexer
-            .process_routing_decision_for_request(
-                &mut tokens_with_hashes,
-                WorkerWithDpRank::from_worker_id(worker_1),
-            )
-            .await
-            .unwrap();
-
-        // Wait until both workers are reflected in overlap scores
-        spin_until(Duration::from_millis(100), async || {
-            let s = indexer
-                .find_matches_for_request(&tokens, None, None)
-                .await
-                .unwrap();
-            s.scores
-                .get(&WorkerWithDpRank::from_worker_id(worker_0))
-                .copied()
-                == Some(1)
-                && s.scores
-                    .get(&WorkerWithDpRank::from_worker_id(worker_1))
-                    .copied()
-                    == Some(1)
-        })
-        .await;
-
-        let scores = indexer
-            .find_matches_for_request(&tokens, None, None)
-            .await
-            .unwrap();
-
-        assert_eq!(
-            scores
-                .scores
-                .get(&WorkerWithDpRank::from_worker_id(worker_0)),
-            Some(&1)
-        );
-        assert_eq!(
-            scores
-                .scores
-                .get(&WorkerWithDpRank::from_worker_id(worker_1)),
-            Some(&1)
-        );
-    }
-
-    /// Test that pruning returns empty when tree size is within the max tree size.
-    #[tokio::test]
-    async fn test_prune_manager_no_prune_when_within_bounds() {
-        const TTL: Duration = Duration::from_secs(10);
-        let prune_config = PruneConfig {
-            ttl: TTL,
-            max_tree_size: 100,
-            prune_target_ratio: 0.5,
-        };
-
-        let mut pm: PruneManager<u32> = PruneManager::new(50, prune_config);
-
-        // Insert 50 keys (well below max_tree_size of 100)
-        pm.insert((0..50).collect());
-
-        // Pruning should return empty vec when size is within bounds
-        let pruned = pm.prune(50).unwrap();
-        assert!(pruned.is_empty());
-
-        // All keys should still be present
-        for i in 0..50 {
-            assert!(pm.get_expiry(&i).is_some());
-        }
-    }
-
-    /// Test that pruning removes the oldest entries first.
-    #[tokio::test]
-    async fn test_prune_manager_prune_removes_oldest_first() {
-        const TTL: Duration = Duration::from_secs(10);
-        let prune_config = PruneConfig {
-            ttl: TTL,
-            max_tree_size: 10,
-            prune_target_ratio: 0.5,
-        };
-
-        let mut pm: PruneManager<u32> = PruneManager::new(50, prune_config);
-
-        // Insert keys one at a time with delays to ensure different timestamps
-        for i in 1..=15 {
-            pm.insert(vec![i]);
-            time::sleep(Duration::from_millis(1)).await;
-        }
-
-        // Total: 15 keys. Trigger pruning with current_size = 15
-        let pruned = pm.prune(15).unwrap();
-
-        // Should prune down to 5 (10 * 0.5), so 10 keys should be pruned (15 - 5)
-        assert_eq!(pruned.len(), 10);
-
-        // The oldest keys should be pruned first
-        for i in 1..=10 {
-            assert!(pruned.contains(&i));
-        }
-
-        // The newer keys should still be present
-        for i in 11..=15 {
-            assert!(pm.get_expiry(&i).is_some());
-        }
-    }
-
-    /// Test that pruning fails gracefully when config is None.
-    #[tokio::test]
-    async fn test_prune_manager_prune_fails_without_config() {
-        const TTL: Duration = Duration::from_secs(10);
-        let prune_config = PruneConfig {
-            ttl: TTL,
-            max_tree_size: usize::MAX,
-            prune_target_ratio: 0.5,
-        };
-        let mut pm: PruneManager<u32> = PruneManager::new(50, prune_config);
-        // Temporarily set prune_config to None to test the error case
-        pm.prune_config = None;
-
-        pm.insert(vec![1, 2, 3]);
-
-        // Pruning should fail when prune_config is None
-        let result = pm.prune(150);
-        assert!(result.is_err());
-        assert!(matches!(result, Err(KvRouterError::PruneFailed(_))));
     }
 
     /// Test that BlockEntry ordering prioritizes sequence position.
@@ -763,143 +599,5 @@ mod tests {
 
         // entry1 < entry2 because seq_position 0 < 1
         assert!(entry1 < entry2);
-    }
-
-    /// End-to-end test for [`KvIndexer`] with TTL and pruning
-    ///   0. Max tree size is 5, target size is 2 (prune_target_ratio = 0.4)
-    ///   1. Insert 5 blocks (at max_tree_size but not exceeding)
-    ///   2. Verify all 5 blocks are present
-    ///   3. Insert 6th block (exceeds threshold, triggers reactive pruning)
-    ///   4. Verify pruning occurred: 4 oldest blocks removed
-    ///   5. Verify 2 newest blocks remain
-    #[tokio::test]
-    async fn test_approx_indexer_e2e_pruning() {
-        const TTL: Duration = Duration::from_secs(60); // Long TTL to avoid expiry
-        let prune_config = PruneConfig {
-            ttl: TTL,
-            max_tree_size: 5,        // Very small to trigger pruning quickly
-            prune_target_ratio: 0.4, // target size is 5 * 0.4 = 2
-        };
-
-        let cancel = CancellationToken::new();
-        let metrics = Arc::new(KvIndexerMetrics::new_unregistered());
-        let indexer = KvIndexer::new_with_frequency(
-            cancel.clone(),
-            None,
-            KV_BLOCK_SIZE,
-            metrics,
-            Some(prune_config),
-        );
-
-        let worker = WorkerWithDpRank::from_worker_id(42);
-
-        // Insert 5 sequences (5 blocks total, at max_tree_size but not exceeding)
-        for i in 0..5 {
-            let tokens: Vec<u32> = vec![i * 10, i * 10 + 1, i * 10 + 2, i * 10 + 3];
-            let mut tokens_with_hashes = TokensWithHashes::new(tokens, KV_BLOCK_SIZE);
-            indexer
-                .process_routing_decision_for_request(&mut tokens_with_hashes, worker)
-                .await
-                .unwrap();
-            time::sleep(Duration::from_millis(1)).await; // Ensure different timestamps
-        }
-
-        // Verify all 5 blocks are present (no pruning yet)
-        for i in 0..5 {
-            let tokens: Vec<u32> = vec![i * 10, i * 10 + 1, i * 10 + 2, i * 10 + 3];
-            let scores = indexer
-                .find_matches_for_request(&tokens, None, None)
-                .await
-                .unwrap();
-            assert_eq!(
-                scores.scores.get(&worker).copied(),
-                Some(1),
-                "Block {} should be present before threshold is exceeded",
-                i
-            );
-        }
-
-        // Insert 6th block - this exceeds max_tree_size and should trigger reactive pruning
-        let tokens: Vec<u32> = vec![50, 51, 52, 53];
-        let mut tokens_with_hashes = TokensWithHashes::new(tokens, KV_BLOCK_SIZE);
-        indexer
-            .process_routing_decision_for_request(&mut tokens_with_hashes, worker)
-            .await
-            .unwrap();
-
-        // Wait for pruning to complete
-        time::sleep(Duration::from_millis(100)).await;
-
-        // After pruning, we will have exactly 2 blocks (5 * 0.4 = 2)
-        // The 2 newest blocks (i=4, i=5) will remain, oldest 4 blocks (i=0,1,2,3) will be pruned
-
-        // Verify that the 4 oldest blocks are pruned
-        for i in 0..4 {
-            let tokens: Vec<u32> = vec![i * 10, i * 10 + 1, i * 10 + 2, i * 10 + 3];
-            let scores = indexer
-                .find_matches_for_request(&tokens, None, None)
-                .await
-                .unwrap();
-            assert!(
-                scores.scores.get(&worker).copied().unwrap_or(0) == 0,
-                "Block {} should have been pruned but is still present",
-                i
-            );
-        }
-
-        // Verify the 2 newest blocks are present
-        for i in 4..6 {
-            let tokens: Vec<u32> = vec![i * 10, i * 10 + 1, i * 10 + 2, i * 10 + 3];
-            let scores = indexer
-                .find_matches_for_request(&tokens, None, None)
-                .await
-                .unwrap();
-            assert_eq!(
-                scores.scores.get(&worker).copied(),
-                Some(1),
-                "Block {} should have been present but was pruned",
-                i
-            );
-        }
-    }
-
-    /// Test that re-inserting a key updates its position in the pruning queue.
-    #[tokio::test]
-    async fn test_prune_manager_prune_reinsertion_updates_position() {
-        const TTL: Duration = Duration::from_secs(10);
-        let prune_config = PruneConfig {
-            ttl: TTL,
-            max_tree_size: 5,
-            prune_target_ratio: 0.8,
-        };
-
-        let mut pm: PruneManager<u32> = PruneManager::new(50, prune_config);
-
-        // Insert keys
-        for i in 1..=10 {
-            pm.insert(vec![i]);
-            time::sleep(Duration::from_millis(1)).await;
-        }
-
-        // Re-insert key 1 (should move it to the back of the queue)
-        pm.insert(vec![1]);
-
-        // Total: 10 unique keys. Trigger pruning: current_size = 10, target = 4, so prune 6 keys
-        // Order by expiry (oldest first): 2, 3, 4, 5, 6, 7, 8, 9, 10, 1 (re-inserted)
-        let pruned = pm.prune(10).unwrap();
-        assert_eq!(pruned.len(), 6);
-
-        // The oldest keys (2-7) should be pruned
-        for i in 2..=7 {
-            assert!(pruned.contains(&i));
-        }
-
-        // The newest keys (8-10) should still be present
-        for i in 8..=10 {
-            assert!(pm.get_expiry(&i).is_some());
-        }
-
-        // Key 1 should still be present (it was refreshed and is now near the end)
-        assert!(pm.get_expiry(&1).is_some());
     }
 }

--- a/lib/kv-router/src/indexer/pruning.rs
+++ b/lib/kv-router/src/indexer/pruning.rs
@@ -188,47 +188,25 @@ impl<K: Clone + Hash + Eq + Ord> PruneManager<K> {
 #[derive(Debug)]
 struct WorkerPruneState {
     timers: PruneManager<BlockEntry>,
-    by_hash: HashMap<ExternalSequenceBlockHash, HashSet<BlockEntry>>,
 }
 
 impl WorkerPruneState {
     fn new(config: PruneConfig) -> Self {
         Self {
             timers: PruneManager::new(HEAP_REBUILD_THRESHOLD, config),
-            by_hash: HashMap::new(),
         }
     }
 
     fn insert_block_entries(&mut self, entries: Vec<BlockEntry>, now: Instant) {
-        self.timers.insert_at(entries.clone(), now);
-        for entry in entries {
-            self.by_hash.entry(entry.key).or_default().insert(entry);
-        }
+        self.timers.insert_at(entries, now);
     }
 
     fn remove_block_entry(&mut self, entry: &BlockEntry) {
-        if !self.timers.remove(entry) {
-            return;
-        }
-        if let Some(entries) = self.by_hash.get_mut(&entry.key) {
-            entries.remove(entry);
-            if entries.is_empty() {
-                self.by_hash.remove(&entry.key);
-            }
-        }
+        self.timers.remove(entry);
     }
 
     fn pop_expired(&mut self, now: Instant) -> Vec<BlockEntry> {
-        let expired = self.timers.pop_expired(now);
-        for entry in &expired {
-            if let Some(entries) = self.by_hash.get_mut(&entry.key) {
-                entries.remove(entry);
-                if entries.is_empty() {
-                    self.by_hash.remove(&entry.key);
-                }
-            }
-        }
-        expired
+        self.timers.pop_expired(now)
     }
 
     fn peek_next_valid_expiry(&mut self) -> Option<Instant> {

--- a/lib/kv-router/src/indexer/pruning.rs
+++ b/lib/kv-router/src/indexer/pruning.rs
@@ -63,116 +63,24 @@ impl Default for PruneConfig {
     }
 }
 
-/// Shared lazy min-heap for expiry indexes.
-///
-/// The heap may contain stale entries. Callers keep the source of truth elsewhere and
-/// validate heap entries when peeking or popping.
-#[derive(Debug)]
-struct LazyExpiryHeap<K: Clone + Ord> {
-    heap: BinaryHeap<(Reverse<Instant>, K)>,
-    threshold: usize,
-}
-
-impl<K: Clone + Ord> LazyExpiryHeap<K> {
-    fn new(threshold: usize) -> Self {
-        Self {
-            heap: BinaryHeap::new(),
-            threshold,
-        }
-    }
-
-    #[cfg(test)]
-    fn len(&self) -> usize {
-        self.heap.len()
-    }
-
-    fn reserve(&mut self, additional: usize) {
-        self.heap.reserve(additional);
-    }
-
-    fn push(&mut self, key: K, expiry: Instant) {
-        self.heap.push((Reverse(expiry), key));
-    }
-
-    fn peek(&self) -> Option<(Instant, K)> {
-        self.heap
-            .peek()
-            .map(|(Reverse(expiry), key)| (*expiry, key.clone()))
-    }
-
-    fn pop(&mut self) -> Option<(Instant, K)> {
-        self.heap.pop().map(|(Reverse(expiry), key)| (expiry, key))
-    }
-
-    fn pop_if_top(&mut self, candidate: (Instant, &K)) -> bool {
-        let Some((expiry, key)) = self.peek() else {
-            return false;
-        };
-        if expiry == candidate.0 && key == *candidate.1 {
-            self.heap.pop();
-            true
-        } else {
-            false
-        }
-    }
-
-    fn rebuild<I>(&mut self, entries: I)
-    where
-        I: IntoIterator<Item = (K, Instant)>,
-    {
-        self.heap = entries
-            .into_iter()
-            .map(|(key, expiry)| (Reverse(expiry), key))
-            .collect();
-    }
-
-    fn should_rebuild(&self, active_len: usize) -> bool {
-        active_len > 0 && self.heap.len() > active_len * self.threshold
-    }
-
-    fn peek_valid<F>(&mut self, mut is_valid: F) -> Option<(Instant, K)>
-    where
-        F: FnMut(&K, Instant) -> bool,
-    {
-        loop {
-            let (expiry, key) = self.peek()?;
-            if is_valid(&key, expiry) {
-                return Some((expiry, key));
-            }
-            self.heap.pop();
-        }
-    }
-
-    fn pop_due_valid<F>(&mut self, now: Instant, mut is_valid: F) -> Option<(Instant, K)>
-    where
-        F: FnMut(&K, Instant) -> bool,
-    {
-        loop {
-            let (expiry, _) = self.peek()?;
-            if expiry > now {
-                return None;
-            }
-
-            let (expiry, key) = self.pop().expect("expiry heap top disappeared");
-            if is_valid(&key, expiry) {
-                return Some((expiry, key));
-            }
-        }
-    }
-}
-
 /// A data structure to manage a collection of timers, addressable by a key.
 /// This is structured as a sort of "priority queue" of keys, where the priority is the expiration time.
 /// It supports insertion as well as updating the expiration time of a key.
-/// The expiration heap is lazily updated to reflect the true expiration times in [`PruneManager::timers`]
+/// The [`PruneManager::expirations`] heap is lazily updated to reflect the true expiration times in [`PruneManager::timers`]
 /// For now, we have a fixed expiration time for all keys.
 #[derive(Debug)]
 pub struct PruneManager<K: Clone + Hash + Eq + Ord> {
     /// The source of truth. Maps a key to its current expiration instant.
     timers: FxHashMap<K, Instant>,
 
-    /// Lazily-stale heap used to efficiently find the next expiring timer.
-    expirations: LazyExpiryHeap<K>,
+    /// A max-heap of (Reverse<expiration_instant>, key) used to efficiently find the
+    /// next expiring timer. Reverse<Instant> makes earlier times pop first.
+    /// An entry in this heap is "stale" if the instant does not match the one in the `timers` map.
+    expirations: BinaryHeap<(Reverse<Instant>, K)>,
+
+    /// Threshold for rebuilding the heap.
+    /// The heap will be rebuilt from scratch to remove stale entries.
+    threshold: usize,
 
     /// The expiration duration of the timers.
     ttl: Duration,
@@ -184,16 +92,19 @@ impl<K: Clone + Hash + Eq + Ord> PruneManager<K> {
         let ttl = prune_config.ttl;
         PruneManager {
             timers: FxHashMap::default(),
-            expirations: LazyExpiryHeap::new(threshold),
+            expirations: BinaryHeap::new(),
             ttl,
+            threshold,
         }
     }
 
     /// Rebuilds the expirations heap from the timers map, removing all stale entries.
     fn rebuild_heap(&mut self) {
-        let timers = &self.timers;
-        self.expirations
-            .rebuild(timers.iter().map(|(key, &expiry)| (key.clone(), expiry)));
+        self.expirations = self
+            .timers
+            .iter()
+            .map(|(key, &expiry)| (Reverse(expiry), key.clone()))
+            .collect();
     }
 
     /// Inserts a new timer or updates an existing one for the given key.
@@ -218,11 +129,11 @@ impl<K: Clone + Hash + Eq + Ord> PruneManager<K> {
             // Push the new expiration onto the heap. If the key was updated,
             // this leaves a "stale" entry on the heap for the old time,
             // which will be ignored when it's popped.
-            self.expirations.push(key, expiry_time);
+            self.expirations.push((Reverse(expiry_time), key));
         }
 
         // Check if we should rebuild the heap to remove stale entries
-        if self.expirations.should_rebuild(self.timers.len()) {
+        if !self.timers.is_empty() && self.expirations.len() > self.timers.len() * self.threshold {
             self.rebuild_heap();
         }
     }
@@ -237,14 +148,20 @@ impl<K: Clone + Hash + Eq + Ord> PruneManager<K> {
     pub fn pop_expired(&mut self, now: Instant) -> Vec<K> {
         let mut expired_keys = Vec::new();
 
-        while let Some((_, key)) = {
-            let timers = &self.timers;
-            self.expirations
-                .pop_due_valid(now, |key, expiry| timers.get(key) == Some(&expiry))
-        } {
-            // This is a valid, non-stale, expired timer.
-            self.timers.remove(&key);
-            expired_keys.push(key);
+        while let Some((Reverse(expiry_time), _)) = self.expirations.peek() {
+            // If the next timer in the heap is not yet expired, we can stop.
+            if *expiry_time > now {
+                break;
+            }
+
+            // The timer might be expired, so pop it from the heap.
+            let (Reverse(expiry_time), key) = self.expirations.pop().unwrap();
+
+            if self.timers.get(&key) == Some(&expiry_time) {
+                // This is a valid, non-stale, expired timer.
+                self.timers.remove(&key);
+                expired_keys.push(key);
+            }
         }
 
         expired_keys
@@ -252,10 +169,13 @@ impl<K: Clone + Hash + Eq + Ord> PruneManager<K> {
 
     /// Returns the next non-stale expiry time, if it exists.
     pub fn peek_next_valid_expiry(&mut self) -> Option<Instant> {
-        let timers = &self.timers;
-        self.expirations
-            .peek_valid(|key, expiry| timers.get(key) == Some(&expiry))
-            .map(|(expiry, _)| expiry)
+        while let Some((Reverse(expiry_time), key)) = self.expirations.peek() {
+            if self.timers.get(key) == Some(expiry_time) {
+                return Some(*expiry_time);
+            }
+            self.expirations.pop();
+        }
+        None
     }
 
     pub fn len(&self) -> usize {
@@ -304,7 +224,7 @@ pub struct WorkerPruneManager {
 struct WorkerPruneManagerInner {
     config: PruneConfig,
     workers: DashMap<WorkerWithDpRank, Mutex<WorkerPruneState>, FxBuildHasher>,
-    next_expiries: Mutex<LazyExpiryHeap<WorkerWithDpRank>>,
+    next_expiries: Mutex<BinaryHeap<(Reverse<Instant>, WorkerWithDpRank)>>,
     pending_removes: Mutex<VecDeque<BlockEntry>>,
     ready_tx: watch::Sender<u64>,
     schedule_tx: watch::Sender<u64>,
@@ -324,7 +244,7 @@ impl WorkerPruneManager {
         let inner = Arc::new(WorkerPruneManagerInner {
             config,
             workers: DashMap::with_hasher(FxBuildHasher),
-            next_expiries: Mutex::new(LazyExpiryHeap::new(WORKER_EXPIRY_HEAP_REBUILD_THRESHOLD)),
+            next_expiries: Mutex::new(BinaryHeap::new()),
             pending_removes: Mutex::new(VecDeque::new()),
             ready_tx,
             schedule_tx,
@@ -549,7 +469,7 @@ impl WorkerPruneManagerInner {
         self.next_expiries
             .lock()
             .expect("worker expiry index mutex poisoned")
-            .push(worker, expiry);
+            .push((Reverse(expiry), worker));
         self.rebuild_worker_expiry_heap_if_needed();
     }
 
@@ -564,13 +484,13 @@ impl WorkerPruneManagerInner {
                 .next_expiries
                 .lock()
                 .expect("worker expiry index mutex poisoned");
-            expiries.should_rebuild(workers_len)
+            expiries.len() > workers_len * WORKER_EXPIRY_HEAP_REBUILD_THRESHOLD
         };
         if !should_rebuild {
             return;
         }
 
-        let mut rebuilt = LazyExpiryHeap::new(WORKER_EXPIRY_HEAP_REBUILD_THRESHOLD);
+        let mut rebuilt = BinaryHeap::new();
         for entry in self.workers.iter() {
             let worker = *entry.key();
             let next_expiry = entry
@@ -579,7 +499,7 @@ impl WorkerPruneManagerInner {
                 .expect("worker prune state mutex poisoned")
                 .peek_next_valid_expiry();
             if let Some(next_expiry) = next_expiry {
-                rebuilt.push(worker, next_expiry);
+                rebuilt.push((Reverse(next_expiry), worker));
             }
         }
 
@@ -595,8 +515,9 @@ impl WorkerPruneManagerInner {
                 .next_expiries
                 .lock()
                 .expect("worker expiry index mutex poisoned")
-                .peek();
-            let (expiry, worker) = candidate?;
+                .peek()
+                .copied();
+            let (Reverse(expiry), worker) = candidate?;
 
             let next_valid = self.workers.get(&worker).and_then(|state| {
                 state
@@ -613,10 +534,12 @@ impl WorkerPruneManagerInner {
                 .next_expiries
                 .lock()
                 .expect("worker expiry index mutex poisoned");
-            if expiries.pop_if_top((expiry, &worker))
-                && let Some(next_valid) = next_valid
-            {
-                expiries.push(worker, next_valid);
+            if expiries.peek().copied() != candidate {
+                continue;
+            }
+            expiries.pop();
+            if let Some(next_valid) = next_valid {
+                expiries.push((Reverse(next_valid), worker));
             }
         }
     }
@@ -625,12 +548,12 @@ impl WorkerPruneManagerInner {
         let mut expired = Vec::new();
 
         loop {
-            let Some((expiry, worker)) = ({
+            let Some((Reverse(expiry), worker)) = ({
                 let mut expiries = self
                     .next_expiries
                     .lock()
                     .expect("worker expiry index mutex poisoned");
-                let Some((expiry, _)) = expiries.peek() else {
+                let Some((Reverse(expiry), _)) = expiries.peek().copied() else {
                     break;
                 };
                 if expiry > now {

--- a/lib/kv-router/src/indexer/tests.rs
+++ b/lib/kv-router/src/indexer/tests.rs
@@ -229,6 +229,13 @@ fn tree_size_indexer_template(
 ) {
 }
 
+#[template]
+#[rstest]
+fn approx_indexer_template(
+    #[values("single", "flat", "concurrent", "concurrent_compressed")] variant: &str,
+) {
+}
+
 fn make_indexer(variant: &str) -> Box<dyn KvIndexerInterface> {
     let metrics = Arc::new(KvIndexerMetrics::new_unregistered());
     make_indexer_with_metrics(variant, metrics).0
@@ -267,6 +274,42 @@ fn make_indexer_with_metrics(
     (indexer, metrics)
 }
 
+fn make_approx_indexer(variant: &str, ttl: Duration) -> Box<dyn KvIndexerInterface + Sync> {
+    let token = CancellationToken::new();
+    let metrics = Arc::new(KvIndexerMetrics::new_unregistered());
+    let kv_block_size = 4;
+    let prune_config = PruneConfig { ttl };
+
+    match variant {
+        "single" => Box::new(KvIndexer::new_with_frequency(
+            token,
+            None,
+            kv_block_size,
+            metrics,
+            Some(prune_config),
+        )),
+        "flat" => Box::new(ThreadPoolIndexer::new_with_pruning(
+            PositionalIndexer::new(32),
+            4,
+            kv_block_size,
+            prune_config,
+        )),
+        "concurrent" => Box::new(ThreadPoolIndexer::new_with_pruning(
+            ConcurrentRadixTree::new(),
+            4,
+            kv_block_size,
+            prune_config,
+        )),
+        "concurrent_compressed" => Box::new(ThreadPoolIndexer::new_with_pruning(
+            ConcurrentRadixTreeCompressed::new(),
+            4,
+            kv_block_size,
+            prune_config,
+        )),
+        _ => panic!("Unknown variant: {}", variant),
+    }
+}
+
 async fn flush_and_settle(index: &dyn KvIndexerInterface) {
     index.flush().await;
 }
@@ -303,6 +346,36 @@ async fn assert_query_score_and_tree_size(
 async fn assert_no_scores(index: &dyn KvIndexerInterface, query: &[u64]) {
     let scores = query_scores(index, query).await;
     assert!(scores.scores.is_empty());
+}
+
+async fn route_approx_tokens(
+    index: &dyn KvIndexerInterface,
+    tokens: &[u32],
+    worker: WorkerWithDpRank,
+) {
+    let mut tokens_with_hashes = TokensWithHashes::new(tokens.to_vec(), 4);
+    index
+        .process_routing_decision_for_request(&mut tokens_with_hashes, worker)
+        .await
+        .unwrap();
+    flush_and_settle(index).await;
+}
+
+async fn request_scores(index: &dyn KvIndexerInterface, tokens: &[u32]) -> OverlapScores {
+    index
+        .find_matches_for_request(tokens, None, None)
+        .await
+        .unwrap()
+}
+
+async fn assert_request_score(
+    index: &dyn KvIndexerInterface,
+    tokens: &[u32],
+    worker: WorkerWithDpRank,
+    expected_score: u32,
+) {
+    let scores = request_scores(index, tokens).await;
+    assert_eq!(scores.scores.get(&worker), Some(&expected_score));
 }
 
 async fn assert_exact_scores(
@@ -870,6 +943,119 @@ mod interface_tests {
             .process_routing_decision_for_request(&mut tokens_with_hashes, worker)
             .await;
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    #[apply(approx_indexer_template)]
+    async fn test_approx_routing_decision_creates_match(variant: &str) {
+        let index = make_approx_indexer(variant, Duration::from_secs(60));
+        let tokens = vec![1, 2, 3, 4];
+        let worker = WorkerWithDpRank::new(7, 0);
+
+        route_approx_tokens(index.as_ref(), &tokens, worker).await;
+
+        assert_request_score(index.as_ref(), &tokens, worker, 1).await;
+    }
+
+    #[tokio::test]
+    #[apply(approx_indexer_template)]
+    async fn test_approx_ttl_expiry_removes_match(variant: &str) {
+        let ttl = Duration::from_millis(25);
+        let index = make_approx_indexer(variant, ttl);
+        let tokens = vec![1, 2, 3, 4];
+        let worker = WorkerWithDpRank::new(7, 0);
+
+        route_approx_tokens(index.as_ref(), &tokens, worker).await;
+        assert_request_score(index.as_ref(), &tokens, worker, 1).await;
+
+        time::sleep(ttl + Duration::from_millis(25)).await;
+        flush_and_settle(index.as_ref()).await;
+
+        let scores = request_scores(index.as_ref(), &tokens).await;
+        assert!(scores.scores.is_empty());
+    }
+
+    #[tokio::test]
+    #[apply(approx_indexer_template)]
+    async fn test_approx_remove_worker_dp_rank_cleans_prune_metadata(variant: &str) {
+        let index = make_approx_indexer(variant, Duration::from_secs(60));
+        let tokens = vec![1, 2, 3, 4];
+        let removed_worker = WorkerWithDpRank::new(7, 0);
+        let retained_worker = WorkerWithDpRank::new(7, 1);
+
+        route_approx_tokens(index.as_ref(), &tokens, removed_worker).await;
+        route_approx_tokens(index.as_ref(), &tokens, retained_worker).await;
+
+        index
+            .remove_worker_dp_rank(removed_worker.worker_id, removed_worker.dp_rank)
+            .await;
+        flush_and_settle(index.as_ref()).await;
+
+        let scores = request_scores(index.as_ref(), &tokens).await;
+        assert!(!scores.scores.contains_key(&removed_worker));
+        assert_eq!(scores.scores.get(&retained_worker), Some(&1));
+    }
+
+    #[tokio::test]
+    #[apply(approx_indexer_template)]
+    async fn test_approx_remove_worker_cleans_prune_metadata(variant: &str) {
+        let index = make_approx_indexer(variant, Duration::from_secs(60));
+        let tokens = vec![1, 2, 3, 4];
+        let removed_worker = WorkerWithDpRank::new(7, 0);
+        let retained_worker = WorkerWithDpRank::new(8, 0);
+
+        route_approx_tokens(index.as_ref(), &tokens, removed_worker).await;
+        route_approx_tokens(index.as_ref(), &tokens, retained_worker).await;
+
+        index.remove_worker(removed_worker.worker_id).await;
+        flush_and_settle(index.as_ref()).await;
+
+        let scores = request_scores(index.as_ref(), &tokens).await;
+        assert!(!scores.scores.contains_key(&removed_worker));
+        assert_eq!(scores.scores.get(&retained_worker), Some(&1));
+    }
+
+    #[tokio::test]
+    #[apply(approx_indexer_template)]
+    async fn test_kv_store_events_do_not_expire_through_approx_ttl(variant: &str) {
+        let ttl = Duration::from_millis(25);
+        let index = make_approx_indexer(variant, ttl);
+        let worker = WorkerWithDpRank::new(0, 0);
+
+        index.apply_event(make_store_event(0, &[1, 2, 3])).await;
+        flush_and_settle(index.as_ref()).await;
+        assert_score(index.as_ref(), &[1, 2, 3], worker, 3).await;
+
+        time::sleep(ttl + Duration::from_millis(25)).await;
+        flush_and_settle(index.as_ref()).await;
+
+        assert_score(index.as_ref(), &[1, 2, 3], worker, 3).await;
+    }
+
+    #[tokio::test]
+    async fn test_failed_threaded_approx_event_ack_does_not_register() {
+        let index = ThreadPoolIndexer::new_with_pruning(
+            ConcurrentRadixTree::new(),
+            1,
+            32,
+            PruneConfig {
+                ttl: Duration::from_secs(60),
+            },
+        );
+        index.shutdown();
+
+        let tokens = vec![1, 2, 3, 4];
+        let mut tokens_with_hashes = TokensWithHashes::new(tokens.clone(), 32);
+        let result = index
+            .process_routing_decision_for_request(
+                &mut tokens_with_hashes,
+                WorkerWithDpRank::new(7, 0),
+            )
+            .await;
+
+        assert!(matches!(result, Err(KvRouterError::IndexerOffline)));
+        let scores = request_scores(&index, &tokens).await;
+        assert!(scores.scores.is_empty());
     }
 
     #[tokio::test]

--- a/lib/kv-router/src/indexer/thread_pool.rs
+++ b/lib/kv-router/src/indexer/thread_pool.rs
@@ -590,11 +590,16 @@ impl<T: SyncIndexer> KvIndexerInterface for ThreadPoolIndexer<T> {
             return Ok(());
         };
 
-        let local_hashes = tokens_with_hashes.get_or_compute_block_hashes().to_vec();
-        let sequence_hashes = tokens_with_hashes.get_or_compute_seq_hashes().to_vec();
+        tokens_with_hashes.get_or_compute_seq_hashes();
+        let local_hashes = tokens_with_hashes
+            .block_hashes()
+            .expect("block hashes missing after computing sequence hashes");
+        let sequence_hashes = tokens_with_hashes
+            .seq_hashes()
+            .expect("sequence hashes missing after computing sequence hashes");
         let event_id = Self::next_synthetic_event_id(&self.synthetic_event_id);
-        let event =
-            Self::stored_event_for_hashes(worker, &local_hashes, &sequence_hashes, event_id);
+        let event = Self::stored_event_for_hashes(worker, local_hashes, sequence_hashes, event_id);
+        let prune_entries = Self::block_entries_for_hashes(worker, sequence_hashes);
         let thread_idx = Self::get_or_assign_thread_idx(
             &self.worker_assignments,
             &self.worker_assignment_count,
@@ -614,8 +619,7 @@ impl<T: SyncIndexer> KvIndexerInterface for ThreadPoolIndexer<T> {
             .await
             .map_err(|_| KvRouterError::IndexerDroppedRequest)?;
         if applied {
-            prune_manager
-                .insert_block_entries(Self::block_entries_for_hashes(worker, &sequence_hashes));
+            prune_manager.insert_worker_block_entries(worker, prune_entries);
         }
 
         Ok(())

--- a/lib/kv-router/src/indexer/thread_pool.rs
+++ b/lib/kv-router/src/indexer/thread_pool.rs
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    sync::{Arc, Mutex, atomic::AtomicUsize},
+    collections::{BTreeMap, BTreeSet},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicU64, AtomicUsize},
+    },
     thread::JoinHandle,
 };
 
@@ -14,7 +18,9 @@ use tokio::sync::oneshot;
 use super::{
     KvIndexerInterface, KvIndexerMetrics, KvRouterError, ShardSizeSnapshot, SyncIndexer, WorkerTask,
 };
+use crate::indexer::pruning::{BlockEntry, PruneConfig, WorkerPruneManager};
 use crate::protocols::*;
+use dynamo_tokens::SequenceHash;
 
 /// Generic wrapper that provides [`KvIndexerInterface`] for any [`SyncIndexer`] backend.
 ///
@@ -41,9 +47,9 @@ pub struct ThreadPoolIndexer<T: SyncIndexer> {
     backend: Arc<T>,
 
     /// Maps WorkerId to worker thread index for sticky routing.
-    worker_assignments: DashMap<WorkerId, usize, FxBuildHasher>,
+    worker_assignments: Arc<DashMap<WorkerId, usize, FxBuildHasher>>,
     /// Counter for round-robin assignment of new WorkerIds.
-    worker_assignment_count: AtomicUsize,
+    worker_assignment_count: Arc<AtomicUsize>,
 
     /// Channels to send tasks to worker threads (one per thread).
     /// Sending `WorkerTask::Terminate` signals the thread to shut down.
@@ -56,6 +62,15 @@ pub struct ThreadPoolIndexer<T: SyncIndexer> {
 
     /// Handles to worker threads for joining on shutdown.
     thread_handles: Mutex<Vec<JoinHandle<()>>>,
+
+    /// Approximate-mode TTL pruning manager. None for normal event-driven mode.
+    prune_manager: Option<WorkerPruneManager>,
+
+    /// Cancellation token for the threaded prune pump.
+    prune_pump_cancel: Option<tokio_util::sync::CancellationToken>,
+
+    /// Synthetic event IDs for approximate store/remove events.
+    synthetic_event_id: Arc<AtomicU64>,
 }
 
 impl<T: SyncIndexer> ThreadPoolIndexer<T> {
@@ -99,12 +114,40 @@ impl<T: SyncIndexer> ThreadPoolIndexer<T> {
         kv_block_size: u32,
         metrics: Option<Arc<KvIndexerMetrics>>,
     ) -> Self {
+        Self::new_with_metrics_and_pruning(backend, num_workers, kv_block_size, metrics, None)
+    }
+
+    pub fn new_with_pruning(
+        backend: T,
+        num_workers: usize,
+        kv_block_size: u32,
+        prune_config: PruneConfig,
+    ) -> Self {
+        Self::new_with_metrics_and_pruning(
+            backend,
+            num_workers,
+            kv_block_size,
+            None,
+            Some(prune_config),
+        )
+    }
+
+    pub fn new_with_metrics_and_pruning(
+        backend: T,
+        num_workers: usize,
+        kv_block_size: u32,
+        metrics: Option<Arc<KvIndexerMetrics>>,
+        prune_config: Option<PruneConfig>,
+    ) -> Self {
         assert!(num_workers > 0, "Number of workers must be greater than 0");
         super::warn_on_unit_block_size("thread_pool", kv_block_size);
 
         let backend = Arc::new(backend);
         let mut worker_event_senders = Vec::new();
         let mut thread_handles = Vec::new();
+        let worker_assignments = Arc::new(DashMap::with_hasher(FxBuildHasher));
+        let worker_assignment_count = Arc::new(AtomicUsize::new(0));
+        let synthetic_event_id = Arc::new(AtomicU64::new(0));
         for _ in 0..num_workers {
             let (event_sender, event_receiver) = flume::unbounded::<WorkerTask>();
             worker_event_senders.push(event_sender);
@@ -118,14 +161,32 @@ impl<T: SyncIndexer> ThreadPoolIndexer<T> {
             thread_handles.push(handle);
         }
 
+        let prune_manager = prune_config.map(WorkerPruneManager::new);
+        let prune_pump_cancel = prune_manager.as_ref().map(|prune_manager| {
+            let cancel = tokio_util::sync::CancellationToken::new();
+            Self::spawn_prune_pump(
+                prune_manager.clone(),
+                worker_event_senders.clone(),
+                Arc::clone(&worker_assignments),
+                Arc::clone(&worker_assignment_count),
+                num_workers,
+                Arc::clone(&synthetic_event_id),
+                cancel.clone(),
+            );
+            cancel
+        });
+
         Self {
             backend,
-            worker_assignments: DashMap::with_hasher(FxBuildHasher),
-            worker_assignment_count: AtomicUsize::new(0),
+            worker_assignments,
+            worker_assignment_count,
             worker_event_channels: worker_event_senders,
             num_workers,
             kv_block_size,
             thread_handles: Mutex::new(thread_handles),
+            prune_manager,
+            prune_pump_cancel,
+            synthetic_event_id,
         }
     }
 
@@ -160,6 +221,149 @@ impl<T: SyncIndexer> ThreadPoolIndexer<T> {
         }
     }
 
+    fn get_or_assign_thread_idx(
+        worker_assignments: &DashMap<WorkerId, usize, FxBuildHasher>,
+        worker_assignment_count: &AtomicUsize,
+        worker_id: WorkerId,
+        num_workers: usize,
+    ) -> usize {
+        *worker_assignments.entry(worker_id).or_insert_with(|| {
+            let idx = worker_assignment_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            idx % num_workers
+        })
+    }
+
+    fn next_synthetic_event_id(synthetic_event_id: &AtomicU64) -> u64 {
+        synthetic_event_id.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    }
+
+    fn block_entries_for_hashes(
+        worker: WorkerWithDpRank,
+        sequence_hashes: &[SequenceHash],
+    ) -> Vec<BlockEntry> {
+        sequence_hashes
+            .iter()
+            .enumerate()
+            .map(|(idx, h)| BlockEntry {
+                key: ExternalSequenceBlockHash(*h),
+                worker,
+                seq_position: idx,
+            })
+            .collect()
+    }
+
+    fn stored_event_for_hashes(
+        worker: WorkerWithDpRank,
+        local_hashes: &[LocalBlockHash],
+        sequence_hashes: &[SequenceHash],
+        event_id: u64,
+    ) -> RouterEvent {
+        let blocks = local_hashes
+            .iter()
+            .zip(sequence_hashes.iter())
+            .map(|(local_hash, sequence_hash)| KvCacheStoredBlockData {
+                tokens_hash: *local_hash,
+                block_hash: ExternalSequenceBlockHash(*sequence_hash),
+                mm_extra_info: None,
+            })
+            .collect();
+
+        RouterEvent::new(
+            worker.worker_id,
+            KvCacheEvent {
+                event_id,
+                data: KvCacheEventData::Stored(KvCacheStoreData {
+                    parent_hash: None,
+                    start_position: None,
+                    blocks,
+                }),
+                dp_rank: worker.dp_rank,
+            },
+        )
+    }
+
+    fn enqueue_prune_removes(
+        worker_event_channels: &[flume::Sender<WorkerTask>],
+        worker_assignments: &DashMap<WorkerId, usize, FxBuildHasher>,
+        worker_assignment_count: &AtomicUsize,
+        num_workers: usize,
+        synthetic_event_id: &AtomicU64,
+        entries: Vec<BlockEntry>,
+    ) {
+        let mut by_worker: BTreeMap<WorkerWithDpRank, BTreeSet<ExternalSequenceBlockHash>> =
+            BTreeMap::new();
+        for entry in entries {
+            by_worker.entry(entry.worker).or_default().insert(entry.key);
+        }
+
+        for (worker, hashes) in by_worker {
+            let event_id = Self::next_synthetic_event_id(synthetic_event_id);
+            let event = RouterEvent::new(
+                worker.worker_id,
+                KvCacheEvent {
+                    event_id,
+                    data: KvCacheEventData::Removed(KvCacheRemoveData {
+                        block_hashes: hashes.into_iter().collect(),
+                    }),
+                    dp_rank: worker.dp_rank,
+                },
+            );
+            let thread_idx = Self::get_or_assign_thread_idx(
+                worker_assignments,
+                worker_assignment_count,
+                worker.worker_id,
+                num_workers,
+            );
+            if let Err(error) = worker_event_channels[thread_idx].send(WorkerTask::Event(event)) {
+                tracing::warn!(
+                    thread_idx,
+                    ?error,
+                    "Failed to enqueue approximate TTL remove event"
+                );
+            }
+        }
+    }
+
+    fn spawn_prune_pump(
+        prune_manager: WorkerPruneManager,
+        worker_event_channels: Vec<flume::Sender<WorkerTask>>,
+        worker_assignments: Arc<DashMap<WorkerId, usize, FxBuildHasher>>,
+        worker_assignment_count: Arc<AtomicUsize>,
+        num_workers: usize,
+        synthetic_event_id: Arc<AtomicU64>,
+        cancel: tokio_util::sync::CancellationToken,
+    ) {
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            handle.spawn(async move {
+                let mut ready_rx = prune_manager.subscribe_ready();
+                loop {
+                    tokio::select! {
+                        _ = cancel.cancelled() => break,
+                        changed = ready_rx.changed() => {
+                            if changed.is_err() {
+                                break;
+                            }
+                            loop {
+                                let entries = prune_manager.drain_pending_removes();
+                                if entries.is_empty() {
+                                    break;
+                                }
+                                Self::enqueue_prune_removes(
+                                    &worker_event_channels,
+                                    &worker_assignments,
+                                    &worker_assignment_count,
+                                    num_workers,
+                                    &synthetic_event_id,
+                                    entries,
+                                );
+                            }
+                        }
+                    }
+                }
+            });
+        }
+    }
+
     fn maybe_enqueue_cleanup(&self, thread_idx: usize) {
         if !self.backend.try_schedule_cleanup() {
             return;
@@ -180,6 +384,13 @@ impl<T: SyncIndexer> ThreadPoolIndexer<T> {
 
 impl<T: SyncIndexer> Drop for ThreadPoolIndexer<T> {
     fn drop(&mut self) {
+        if let Some(cancel) = &self.prune_pump_cancel {
+            cancel.cancel();
+        }
+        if let Some(prune_manager) = &self.prune_manager {
+            prune_manager.shutdown();
+        }
+
         // Send Terminate to all worker threads so they exit their recv loops
         // and drop their Arc<T> clones. Then join the threads to ensure the
         // clones are actually dropped before the compiler drops `self.backend`.
@@ -232,12 +443,12 @@ impl<T: SyncIndexer> KvIndexerInterface for ThreadPoolIndexer<T> {
         let worker_id = event.worker_id;
 
         // Get or assign worker thread index using sticky round-robin
-        let thread_idx = *self.worker_assignments.entry(worker_id).or_insert_with(|| {
-            let idx = self
-                .worker_assignment_count
-                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            idx % self.num_workers
-        });
+        let thread_idx = Self::get_or_assign_thread_idx(
+            &self.worker_assignments,
+            &self.worker_assignment_count,
+            worker_id,
+            self.num_workers,
+        );
 
         // Send event to the assigned worker thread
         if let Err(e) = self.worker_event_channels[thread_idx].send(WorkerTask::Event(event)) {
@@ -253,6 +464,10 @@ impl<T: SyncIndexer> KvIndexerInterface for ThreadPoolIndexer<T> {
     }
 
     async fn remove_worker(&self, worker_id: WorkerId) {
+        if let Some(prune_manager) = &self.prune_manager {
+            prune_manager.remove_worker(worker_id);
+        }
+
         // Route to the worker's assigned thread (if any), otherwise broadcast
         // to all threads since dp_ranks may be spread across threads.
         let thread_idx = self.worker_assignments.get(&worker_id).map(|v| *v);
@@ -282,6 +497,10 @@ impl<T: SyncIndexer> KvIndexerInterface for ThreadPoolIndexer<T> {
     }
 
     async fn remove_worker_dp_rank(&self, worker_id: WorkerId, dp_rank: DpRank) {
+        if let Some(prune_manager) = &self.prune_manager {
+            prune_manager.remove_worker_dp_rank(WorkerWithDpRank::new(worker_id, dp_rank));
+        }
+
         // Broadcast to all threads — the dp_rank may be on any thread.
         // Don't remove from worker_assignments since other dp_ranks may still exist.
         for channel in &self.worker_event_channels {
@@ -291,6 +510,13 @@ impl<T: SyncIndexer> KvIndexerInterface for ThreadPoolIndexer<T> {
     }
 
     fn shutdown(&self) {
+        if let Some(cancel) = &self.prune_pump_cancel {
+            cancel.cancel();
+        }
+        if let Some(prune_manager) = &self.prune_manager {
+            prune_manager.shutdown();
+        }
+
         // Send shutdown signal to all worker threads
         for channel in self.worker_event_channels.iter() {
             let _ = channel.send(WorkerTask::Terminate);
@@ -356,24 +582,74 @@ impl<T: SyncIndexer> KvIndexerInterface for ThreadPoolIndexer<T> {
 
     async fn process_routing_decision_for_request(
         &self,
-        _tokens_with_hashes: &mut TokensWithHashes,
-        _worker: WorkerWithDpRank,
+        tokens_with_hashes: &mut TokensWithHashes,
+        worker: WorkerWithDpRank,
     ) -> Result<(), KvRouterError> {
-        // No-op: pruning not supported in ThreadPoolIndexer
+        let Some(prune_manager) = &self.prune_manager else {
+            // Approximate routing decisions are only recorded when explicitly enabled.
+            return Ok(());
+        };
+
+        let local_hashes = tokens_with_hashes.get_or_compute_block_hashes().to_vec();
+        let sequence_hashes = tokens_with_hashes.get_or_compute_seq_hashes().to_vec();
+        let event_id = Self::next_synthetic_event_id(&self.synthetic_event_id);
+        let event =
+            Self::stored_event_for_hashes(worker, &local_hashes, &sequence_hashes, event_id);
+        let thread_idx = Self::get_or_assign_thread_idx(
+            &self.worker_assignments,
+            &self.worker_assignment_count,
+            worker.worker_id,
+            self.num_workers,
+        );
+
+        let (resp_tx, resp_rx) = oneshot::channel();
+        self.worker_event_channels[thread_idx]
+            .send(WorkerTask::EventWithAck {
+                event,
+                resp: resp_tx,
+            })
+            .map_err(|_| KvRouterError::IndexerOffline)?;
+
+        let applied = resp_rx
+            .await
+            .map_err(|_| KvRouterError::IndexerDroppedRequest)?;
+        if applied {
+            prune_manager
+                .insert_block_entries(Self::block_entries_for_hashes(worker, &sequence_hashes));
+        }
+
         Ok(())
     }
 
     async fn flush(&self) -> usize {
         let curr_size: usize = self.worker_event_channels.iter().map(|ch| ch.len()).sum();
-        let mut receivers = Vec::new();
-        for channel in &self.worker_event_channels {
-            let (resp_tx, resp_rx) = oneshot::channel();
-            if channel.send(WorkerTask::Flush(resp_tx)).is_ok() {
-                receivers.push(resp_rx);
+        self.flush().await;
+
+        if let Some(prune_manager) = &self.prune_manager {
+            let entries = prune_manager.drain_due_and_pending(tokio::time::Instant::now());
+            Self::enqueue_prune_removes(
+                &self.worker_event_channels,
+                &self.worker_assignments,
+                &self.worker_assignment_count,
+                self.num_workers,
+                &self.synthetic_event_id,
+                entries,
+            );
+            self.flush().await;
+
+            let entries = prune_manager.drain_pending_removes();
+            let has_entries = !entries.is_empty();
+            Self::enqueue_prune_removes(
+                &self.worker_event_channels,
+                &self.worker_assignments,
+                &self.worker_assignment_count,
+                self.num_workers,
+                &self.synthetic_event_id,
+                entries,
+            );
+            if has_entries {
+                self.flush().await;
             }
-        }
-        for receiver in receivers {
-            let _ = receiver.await;
         }
         curr_size
     }

--- a/lib/kv-router/src/indexer/types.rs
+++ b/lib/kv-router/src/indexer/types.rs
@@ -339,6 +339,10 @@ pub struct GetWorkersRequest {
 
 pub enum WorkerTask {
     Event(RouterEvent),
+    EventWithAck {
+        event: RouterEvent,
+        resp: oneshot::Sender<bool>,
+    },
     /// Permanently remove a worker from tracking (keep_worker: false).
     RemoveWorker(WorkerId),
     /// Remove a single dp_rank for a worker.

--- a/lib/kv-router/src/scheduling/config.rs
+++ b/lib/kv-router/src/scheduling/config.rs
@@ -231,14 +231,6 @@ pub struct KvRouterConfig {
     #[validate(range(min = 0.0))]
     pub router_ttl_secs: f64,
 
-    /// Maximum tree size before pruning (only used when use_kv_events is false, default: 2^20 = 1048576)
-    #[validate(range(min = 1))]
-    pub router_max_tree_size: usize,
-
-    /// Target size ratio after pruning (only used when use_kv_events is false, default: 0.8)
-    #[validate(range(min = 0.0, max = 1.0))]
-    pub router_prune_target_ratio: f64,
-
     /// Queue threshold fraction for prefill token capacity.
     /// When set, requests are queued if all workers exceed this fraction of max_num_batched_tokens.
     /// If None, queueing is disabled and all requests go directly to ready.
@@ -299,8 +291,6 @@ impl Default for KvRouterConfig {
             router_snapshot_threshold: Some(1000000),
             router_reset_states: false,
             router_ttl_secs: 120.0,
-            router_max_tree_size: 2usize.pow(20), // 2^20 = 1048576, matches PruneConfig::default()
-            router_prune_target_ratio: 0.8,
             router_queue_threshold: Some(4.0),
             router_event_threads: 4,
             skip_initial_worker_wait: false,

--- a/lib/llm/src/kv_router/indexer/mod.rs
+++ b/lib/llm/src/kv_router/indexer/mod.rs
@@ -199,8 +199,6 @@ impl Indexer {
             let cancellation_token = component.drt().primary_token();
             let prune_config = Some(PruneConfig {
                 ttl: Duration::from_secs_f64(kv_router_config.router_ttl_secs),
-                max_tree_size: kv_router_config.router_max_tree_size,
-                prune_target_ratio: kv_router_config.router_prune_target_ratio,
             });
             return Ok(Self::KvIndexer {
                 primary: KvIndexer::new_with_frequency(


### PR DESCRIPTION
Refactors approximate-mode pruning to TTL-only worker-aware state while keeping normal KV event ingestion fire-and-forget. Removes count-based pruning configuration and enables prune-backed approximate routing across the supported indexer variants.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8893" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed `router_max_tree_size` and `router_prune_target_ratio` configuration parameters from router configuration.
  * Simplified KV cache eviction to use TTL-based expiration only; size-based pruning is no longer supported.
  * Updated approximate mode routing behavior to rely exclusively on TTL configuration.

* **Documentation**
  * Updated configuration guides and design documentation to reflect the simplified TTL-only eviction policy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->