### PR TITLE
test(revalidate): test(kv-router): add Mooncake overlap parity check #8884

### DIFF
--- a/components/src/dynamo/common/__init__.py
+++ b/components/src/dynamo/common/__init__.py
@@ -25,3 +25,5 @@ except Exception:
         __version__ = "0.0.0+unknown"
 
 __all__ = ["__version__", "config_dump", "constants", "utils"]
+
+# ci-health probe 3a9394ea5cb 2026-04-30T04:35:12Z

--- a/lib/runtime/src/runtime.rs
+++ b/lib/runtime/src/runtime.rs
@@ -391,3 +391,5 @@ impl Drop for RuntimeType {
         }
     }
 }
+
+// ci-health probe 3a9394ea5cb 2026-04-30T04:35:12Z


### PR DESCRIPTION
Re-validating that PR #8884 by Yan Ru Pei did not regress, by re-running against a trivial placebo diff:

```
test(kv-router): add Mooncake overlap parity check
```

Branch deleted on green; kept on failure for diagnosis.

Drafts are skipped by CodeRabbit per repo `.coderabbit.yaml`.