### PR TITLE
test(revalidate): fix: bump AIC replay test timeout to 120s #8889

### DIFF
--- a/components/src/dynamo/common/__init__.py
+++ b/components/src/dynamo/common/__init__.py
@@ -25,3 +25,5 @@ except Exception:
         __version__ = "0.0.0+unknown"
 
 __all__ = ["__version__", "config_dump", "constants", "utils"]
+
+# ci-health probe 33439616978 2026-04-30T04:49:11Z

--- a/lib/runtime/src/runtime.rs
+++ b/lib/runtime/src/runtime.rs
@@ -391,3 +391,5 @@ impl Drop for RuntimeType {
         }
     }
 }
+
+// ci-health probe 33439616978 2026-04-30T04:49:11Z


### PR DESCRIPTION
Re-validating that PR #8889 by Yongming Ding did not regress, by re-running against a trivial placebo diff:

```
fix: bump AIC replay test timeout to 120s
```

Branch deleted on green; kept on failure for diagnosis.

Drafts are skipped by CodeRabbit per repo `.coderabbit.yaml`.