### PR TITLE
test(revalidate): fix(test): add missing pytest markers to video/audio protocol tests #8849

### DIFF
--- a/components/src/dynamo/common/__init__.py
+++ b/components/src/dynamo/common/__init__.py
@@ -25,3 +25,5 @@ except Exception:
         __version__ = "0.0.0+unknown"
 
 __all__ = ["__version__", "config_dump", "constants", "utils"]
+
+# ci-health probe cc1af6a90c3 2026-04-30T05:03:58Z

--- a/lib/runtime/src/runtime.rs
+++ b/lib/runtime/src/runtime.rs
@@ -391,3 +391,5 @@ impl Drop for RuntimeType {
         }
     }
 }
+
+// ci-health probe cc1af6a90c3 2026-04-30T05:03:58Z


### PR DESCRIPTION
Re-validating that PR #8849 by Krishnan Prashanth did not regress, by re-running against a trivial placebo diff:

```
fix(test): add missing pytest markers to video/audio protocol tests
```

Branch deleted on green; kept on failure for diagnosis.

Drafts are skipped by CodeRabbit per repo `.coderabbit.yaml`.