### PR TITLE
fix(profiler): match operator's multinode service-name length rule (#8480)

### DIFF
--- a/components/src/dynamo/profiler/profile_sla.py
+++ b/components/src/dynamo/profiler/profile_sla.py
@@ -329,9 +329,7 @@ def _longest_grove_combined_length(
         # where N = node_count - 1 for multinode GMS.
         longest_pclq = f"{lower}-{_GROVE_ROLE_SUFFIX_GMS}-0"
         if is_multinode:
-            worker_pclq = (
-                f"{lower}-{_GROVE_ROLE_SUFFIX_WORKER}-{node_count - 1}"
-            )
+            worker_pclq = f"{lower}-{_GROVE_ROLE_SUFFIX_WORKER}-{node_count - 1}"
             if len(worker_pclq) > len(longest_pclq):
                 longest_pclq = worker_pclq
         combined = len(dgd_name) + len(lower) + len(longest_pclq)
@@ -352,9 +350,7 @@ def _longest_grove_combined_length(
 
     # Single-node, non-GMS: only DGD + PodClique.
     combined = len(dgd_name) + len(lower)
-    formula = (
-        f"DGD ({len(dgd_name)}) + PodClique '{lower}' ({len(lower)})"
-    )
+    formula = f"DGD ({len(dgd_name)}) + PodClique '{lower}' ({len(lower)})"
     return combined, formula
 
 
@@ -396,9 +392,7 @@ def _validate_dgd_service_name_lengths(
     services = dgd_spec.get("spec", {}).get("services", {})
     violations = []
     for svc_name, svc_spec in services.items():
-        combined, formula = _longest_grove_combined_length(
-            dgd_name, svc_name, svc_spec
-        )
+        combined, formula = _longest_grove_combined_length(dgd_name, svc_name, svc_spec)
         if combined > _MAX_COMBINED_RESOURCE_NAME_LENGTH:
             violations.append(f"'{svc_name}': {formula} = {combined}")
 

--- a/components/src/dynamo/profiler/profile_sla.py
+++ b/components/src/dynamo/profiler/profile_sla.py
@@ -280,13 +280,95 @@ def _write_final_output(ops: ProfilerOperationalConfig, final_config: Any) -> bo
 
 
 _MAX_COMBINED_RESOURCE_NAME_LENGTH = 45
+_GROVE_ROLE_SUFFIX_LEADER = "ldr"
+_GROVE_ROLE_SUFFIX_WORKER = "wkr"
+_GROVE_ROLE_SUFFIX_GMS = "gms"
+
+
+def _service_layout(svc_spec: Any) -> tuple[bool, bool, int]:
+    """Parse (is_multinode, is_gms_inter_pod, node_count) from a profiler service spec dict.
+
+    Mirrors GetNumberOfNodes / IsInterPodGMSEnabled on
+    DynamoComponentDeploymentSharedSpec (deploy/operator/api/v1alpha1/...).
+    """
+    if not isinstance(svc_spec, dict):
+        return False, False, 1
+    node_count = 1
+    multinode = svc_spec.get("multinode")
+    if isinstance(multinode, dict):
+        nc = multinode.get("nodeCount", 1)
+        if isinstance(nc, int) and nc > 0:
+            node_count = nc
+    gms = svc_spec.get("gpuMemoryService")
+    is_gms = (
+        isinstance(gms, dict)
+        and gms.get("enabled") is True
+        and gms.get("mode") == "InterPod"
+    )
+    return node_count > 1, is_gms, node_count
+
+
+def _longest_grove_combined_length(
+    dgd_name: str, svc_name: str, svc_spec: Any
+) -> tuple[int, str]:
+    """Compute the longest combined Grove resource name length for a service.
+
+    Mirrors the rule enforced by the operator's admission webhook in
+    deploy/operator/internal/webhook/validation/dynamographdeployment.go
+    (validateServiceNameLength). The combined length is what Grove validates
+    against its 45-character cap when generating PodCliqueSet / PodCliqueScalingGroup
+    / PodClique resources, so the profiler must reject the same shape early.
+
+    Returns (combined_length, human_readable_formula).
+    """
+    lower = svc_name.lower()
+    is_multinode, is_gms, node_count = _service_layout(svc_spec)
+
+    if is_gms:
+        # GMS layout: PCSG name = lower(svc); longest PCLQ is max(lower-gms-0, lower-wkr-N)
+        # where N = node_count - 1 for multinode GMS.
+        longest_pclq = f"{lower}-{_GROVE_ROLE_SUFFIX_GMS}-0"
+        if is_multinode:
+            worker_pclq = (
+                f"{lower}-{_GROVE_ROLE_SUFFIX_WORKER}-{node_count - 1}"
+            )
+            if len(worker_pclq) > len(longest_pclq):
+                longest_pclq = worker_pclq
+        combined = len(dgd_name) + len(lower) + len(longest_pclq)
+        formula = (
+            f"DGD ({len(dgd_name)}) + PCSG '{lower}' ({len(lower)}) "
+            f"+ longest PodClique '{longest_pclq}' ({len(longest_pclq)})"
+        )
+        return combined, formula
+
+    if is_multinode:
+        leader_pclq = f"{lower}-{_GROVE_ROLE_SUFFIX_LEADER}"
+        combined = len(dgd_name) + len(lower) + len(leader_pclq)
+        formula = (
+            f"DGD ({len(dgd_name)}) + PCSG '{lower}' ({len(lower)}) "
+            f"+ leader PodClique '{leader_pclq}' ({len(leader_pclq)})"
+        )
+        return combined, formula
+
+    # Single-node, non-GMS: only DGD + PodClique.
+    combined = len(dgd_name) + len(lower)
+    formula = (
+        f"DGD ({len(dgd_name)}) + PodClique '{lower}' ({len(lower)})"
+    )
+    return combined, formula
 
 
 def _validate_dgd_service_name_lengths(
     dgdr: DynamoGraphDeploymentRequestSpec,
     final_config: Any,
 ) -> None:
-    """Raise ValueError if any DGD name + service name would exceed the 45-char pod-naming limit."""
+    """Raise ValueError if any service would exceed Grove's 45-character combined-name cap.
+
+    Mirrors the rule the operator's admission webhook enforces in
+    validateServiceNameLength. Catching this in the profiler converts a confusing
+    post-deploy admission rejection (DGDR loops in Deploying for ~30s) into an
+    immediate, actionable error during profile generation. (Issue #8480.)
+    """
     dgdr_name = os.environ.get("DGDR_NAME", "")
     dgd_spec = final_config[-1] if isinstance(final_config, list) else final_config
 
@@ -313,19 +395,20 @@ def _validate_dgd_service_name_lengths(
             return
     services = dgd_spec.get("spec", {}).get("services", {})
     violations = []
-    for svc_name in services:
-        combined = len(dgd_name) + len(svc_name)
+    for svc_name, svc_spec in services.items():
+        combined, formula = _longest_grove_combined_length(
+            dgd_name, svc_name, svc_spec
+        )
         if combined > _MAX_COMBINED_RESOURCE_NAME_LENGTH:
-            violations.append(
-                f"'{svc_name}' ({len(svc_name)}): combined length {combined}"
-            )
+            violations.append(f"'{svc_name}': {formula} = {combined}")
 
     if violations:
         raise ValueError(
             f"DGD name '{dgd_name}' (length {len(dgd_name)}) combined with service "
             f"name(s) exceeds the {_MAX_COMBINED_RESOURCE_NAME_LENGTH}-character "
-            f"pod-naming limit. Shorten the DGDR name '{dgdr_name}'. "
-            f"Violations: {'; '.join(violations)}"
+            f"Grove pod-naming limit. Shorten the DGDR name "
+            f"'{dgdr_name or '(from config)'}', the DGD name override, or the "
+            f"service names. Violations: {'; '.join(violations)}"
         )
 
 

--- a/components/src/dynamo/profiler/tests/unit/test_helpers_profile_sla.py
+++ b/components/src/dynamo/profiler/tests/unit/test_helpers_profile_sla.py
@@ -1238,3 +1238,198 @@ class TestValidateDgdServiceNameLengths:
         config = self._make_final_config(["svc"])
         with pytest.raises(ValueError, match="pod-naming limit"):
             _validate_dgd_service_name_lengths(dgdr, config)
+
+    # --- Multinode + GMS rules (mirror operator-side validateServiceNameLength) ---
+
+    def test_multinode_uses_leader_podclique_in_combined_length(self, monkeypatch):
+        """Multinode services must include the leader PodClique ('svc-ldr') in the combined-length check.
+
+        The previous formula only checked dgd + svc, which under-rejected cases that
+        the operator's admission webhook would later reject. Reproduces issue #8480:
+        dgd 'trtllm-disagg' (13) + svc 'TRTLLMDecodeWorker' (18) + 'trtllmdecodeworker-ldr' (22) = 53.
+        """
+        from dynamo.profiler.profile_sla import _validate_dgd_service_name_lengths
+
+        monkeypatch.setenv("DGDR_NAME", "trtllm-disagg")
+        # DGDR_NAME 'trtllm-disagg' (13) → operator path would compute dgd_name = 'trtllm-disagg-dgd' (17),
+        # so override the DGD name to land exactly on the 13-char dgd from the issue.
+        from dynamo.profiler.utils.dgdr_v1beta1_types import OverridesSpec
+
+        dgdr = DynamoGraphDeploymentRequestSpec(
+            backend="trtllm",
+            hardware=HardwareSpec(totalGpus=1),
+            model="meta-llama/Llama-2-7b",
+            overrides=OverridesSpec(
+                dgd={"metadata": {"name": "trtllm-disagg"}}
+            ),
+        )
+        config = {
+            "spec": {
+                "services": {
+                    "TRTLLMDecodeWorker": {"multinode": {"nodeCount": 2}},
+                }
+            }
+        }
+        with pytest.raises(ValueError) as exc_info:
+            _validate_dgd_service_name_lengths(dgdr, config)
+        msg = str(exc_info.value)
+        # Error must surface the exact length and mention the leader PCLQ component.
+        assert "53" in msg, msg
+        assert "leader PodClique" in msg, msg
+        assert "trtllmdecodeworker-ldr" in msg, msg
+
+    def test_multinode_passes_when_within_limit(self, monkeypatch):
+        """Multinode service that fits the rule must not raise."""
+        from dynamo.profiler.profile_sla import _validate_dgd_service_name_lengths
+        from dynamo.profiler.utils.dgdr_v1beta1_types import OverridesSpec
+
+        monkeypatch.setenv("DGDR_NAME", "x")
+        # dgd 'short' (5) + svc 'decode' (6) + 'decode-ldr' (10) = 21 ≤ 45
+        dgdr = DynamoGraphDeploymentRequestSpec(
+            backend="sglang",
+            hardware=HardwareSpec(totalGpus=1),
+            model="meta-llama/Llama-2-7b",
+            overrides=OverridesSpec(dgd={"metadata": {"name": "short"}}),
+        )
+        config = {
+            "spec": {
+                "services": {"decode": {"multinode": {"nodeCount": 4}}}
+            }
+        }
+        _validate_dgd_service_name_lengths(dgdr, config)  # must not raise
+
+    def test_gms_uses_longest_podclique_with_high_node_count(self, monkeypatch):
+        """For high node counts, GMS layout's worker PCLQ (svc-wkr-N) can exceed svc-gms-0 and must drive the check."""
+        from dynamo.profiler.profile_sla import _validate_dgd_service_name_lengths
+        from dynamo.profiler.utils.dgdr_v1beta1_types import OverridesSpec
+
+        monkeypatch.setenv("DGDR_NAME", "x")
+        # dgd (12) + PCSG 'enginegroup' (11) + 'enginegroup-wkr-99' (18) = 41 ≤ 45
+        # but with dgd 16 chars, would be 45; with 17 → 46 violation.
+        dgd_name = "x" * 17
+        dgdr = DynamoGraphDeploymentRequestSpec(
+            backend="vllm",
+            hardware=HardwareSpec(totalGpus=1),
+            model="meta-llama/Llama-2-7b",
+            overrides=OverridesSpec(dgd={"metadata": {"name": dgd_name}}),
+        )
+        config = {
+            "spec": {
+                "services": {
+                    "enginegroup": {
+                        "multinode": {"nodeCount": 100},
+                        "gpuMemoryService": {
+                            "enabled": True,
+                            "mode": "InterPod",
+                        },
+                    },
+                }
+            }
+        }
+        with pytest.raises(ValueError) as exc_info:
+            _validate_dgd_service_name_lengths(dgdr, config)
+        msg = str(exc_info.value)
+        assert "enginegroup-wkr-99" in msg, msg
+        # Worker PCLQ (18) must be picked over gms-0 (13) for this node count.
+        assert "enginegroup-gms-0" not in msg, msg
+
+    def test_gms_single_node_uses_gms_podclique(self, monkeypatch):
+        """Single-node GMS still emits a 'svc-gms-0' PodClique that must factor into the check."""
+        from dynamo.profiler.profile_sla import _validate_dgd_service_name_lengths
+        from dynamo.profiler.utils.dgdr_v1beta1_types import OverridesSpec
+
+        monkeypatch.setenv("DGDR_NAME", "x")
+        # dgd (29) + 'svc' (3) + 'svc-gms-0' (9) = 41 ≤ 45 → passes
+        dgdr_passes = DynamoGraphDeploymentRequestSpec(
+            backend="vllm",
+            hardware=HardwareSpec(totalGpus=1),
+            model="meta-llama/Llama-2-7b",
+            overrides=OverridesSpec(dgd={"metadata": {"name": "x" * 29}}),
+        )
+        config = {
+            "spec": {
+                "services": {
+                    "svc": {
+                        "gpuMemoryService": {
+                            "enabled": True,
+                            "mode": "InterPod",
+                        },
+                    },
+                }
+            }
+        }
+        _validate_dgd_service_name_lengths(dgdr_passes, config)  # must not raise
+
+        # dgd (34) + 'svc' (3) + 'svc-gms-0' (9) = 46 → fails
+        dgdr_fails = DynamoGraphDeploymentRequestSpec(
+            backend="vllm",
+            hardware=HardwareSpec(totalGpus=1),
+            model="meta-llama/Llama-2-7b",
+            overrides=OverridesSpec(dgd={"metadata": {"name": "x" * 34}}),
+        )
+        with pytest.raises(ValueError, match="svc-gms-0"):
+            _validate_dgd_service_name_lengths(dgdr_fails, config)
+
+    def test_gms_disabled_is_ignored(self, monkeypatch):
+        """gpuMemoryService.enabled=false or mode!=InterPod should fall through to the non-GMS path."""
+        from dynamo.profiler.profile_sla import _validate_dgd_service_name_lengths
+        from dynamo.profiler.utils.dgdr_v1beta1_types import OverridesSpec
+
+        monkeypatch.setenv("DGDR_NAME", "x")
+        dgdr = DynamoGraphDeploymentRequestSpec(
+            backend="vllm",
+            hardware=HardwareSpec(totalGpus=1),
+            model="meta-llama/Llama-2-7b",
+            overrides=OverridesSpec(dgd={"metadata": {"name": "dgd"}}),
+        )
+        # Single-node, GMS disabled → 'dgd' (3) + 'svc' (3) = 6, no PCSG/PCLQ overhead
+        config = {
+            "spec": {
+                "services": {
+                    "svc": {
+                        "gpuMemoryService": {
+                            "enabled": False,
+                            "mode": "InterPod",
+                        },
+                    },
+                }
+            }
+        }
+        _validate_dgd_service_name_lengths(dgdr, config)  # must not raise
+
+        # GMS Local mode is not the inter-pod layout; should also fall through.
+        config["spec"]["services"]["svc"]["gpuMemoryService"] = {
+            "enabled": True,
+            "mode": "Local",
+        }
+        _validate_dgd_service_name_lengths(dgdr, config)  # must not raise
+
+    def test_existing_message_still_lists_violations(self, monkeypatch):
+        """Backwards-compat: violations include service name and combined length, multiple violations are joined."""
+        from dynamo.profiler.profile_sla import _validate_dgd_service_name_lengths
+        from dynamo.profiler.utils.dgdr_v1beta1_types import OverridesSpec
+
+        monkeypatch.setenv("DGDR_NAME", "x")
+        dgdr = DynamoGraphDeploymentRequestSpec(
+            backend="trtllm",
+            hardware=HardwareSpec(totalGpus=1),
+            model="meta-llama/Llama-2-7b",
+            overrides=OverridesSpec(
+                dgd={"metadata": {"name": "trtllm-disagg"}}
+            ),
+        )
+        config = {
+            "spec": {
+                "services": {
+                    "TRTLLMDecodeWorker": {"multinode": {"nodeCount": 2}},
+                    "TRTLLMPrefillWorker": {"multinode": {"nodeCount": 2}},
+                    "Frontend": {},  # short, must not appear in violations
+                }
+            }
+        }
+        with pytest.raises(ValueError) as exc_info:
+            _validate_dgd_service_name_lengths(dgdr, config)
+        msg = str(exc_info.value)
+        assert "TRTLLMDecodeWorker" in msg
+        assert "TRTLLMPrefillWorker" in msg
+        assert "Frontend" not in msg

--- a/components/src/dynamo/profiler/tests/unit/test_helpers_profile_sla.py
+++ b/components/src/dynamo/profiler/tests/unit/test_helpers_profile_sla.py
@@ -1259,9 +1259,7 @@ class TestValidateDgdServiceNameLengths:
             backend="trtllm",
             hardware=HardwareSpec(totalGpus=1),
             model="meta-llama/Llama-2-7b",
-            overrides=OverridesSpec(
-                dgd={"metadata": {"name": "trtllm-disagg"}}
-            ),
+            overrides=OverridesSpec(dgd={"metadata": {"name": "trtllm-disagg"}}),
         )
         config = {
             "spec": {
@@ -1291,11 +1289,7 @@ class TestValidateDgdServiceNameLengths:
             model="meta-llama/Llama-2-7b",
             overrides=OverridesSpec(dgd={"metadata": {"name": "short"}}),
         )
-        config = {
-            "spec": {
-                "services": {"decode": {"multinode": {"nodeCount": 4}}}
-            }
-        }
+        config = {"spec": {"services": {"decode": {"multinode": {"nodeCount": 4}}}}}
         _validate_dgd_service_name_lengths(dgdr, config)  # must not raise
 
     def test_gms_uses_longest_podclique_with_high_node_count(self, monkeypatch):
@@ -1414,9 +1408,7 @@ class TestValidateDgdServiceNameLengths:
             backend="trtllm",
             hardware=HardwareSpec(totalGpus=1),
             model="meta-llama/Llama-2-7b",
-            overrides=OverridesSpec(
-                dgd={"metadata": {"name": "trtllm-disagg"}}
-            ),
+            overrides=OverridesSpec(dgd={"metadata": {"name": "trtllm-disagg"}}),
         )
         config = {
             "spec": {


### PR DESCRIPTION
#### Overview:

The profiler's `_validate_dgd_service_name_lengths` checks only `len(dgd) + len(service)`, but the operator's admission webhook actually validates `len(dgd) + len(lower(service)) + len(longest PodClique name)` for multinode and inter-pod GMS services. The mismatch lets multinode TRT-LLM disagg DGDs through the profiler gate, only to be rejected by the operator webhook ~30 seconds later — leaving the DGDR looping in `Deploying` indefinitely (issue #8480).

For the documented `trtllm-disagg` + `TRTLLMDecodeWorker` case from the issue:

| Layer | Formula | Value |
|---|---|---|
| Profiler validator (before this PR) | `len(dgd) + len(svc)` | 13 + 18 = **31** ✓ passes |
| Operator webhook (`validateServiceNameLength`) | `len(dgd) + len(lower(svc)) + len('lower-ldr')` | 13 + 18 + 22 = **53** ✗ rejects |

End result: the user gets `admission webhook denied: combined resource name length 53 exceeds 45-character limit` after the DGDR has already been admitted — confusing failure mode 30s into deployment.

#### Details:

- Rewrites `_validate_dgd_service_name_lengths` in [components/src/dynamo/profiler/profile_sla.py](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/profiler/profile_sla.py) to mirror the operator-side rule in [validateServiceNameLength](https://github.com/ai-dynamo/dynamo/blob/main/deploy/operator/internal/webhook/validation/dynamographdeployment.go#L398) exactly. Two new pure helpers:
  - `_service_layout(svc_spec)` parses `(is_multinode, is_gms_inter_pod, node_count)` from the profiler service spec dict (mirrors `GetNumberOfNodes` + `IsInterPodGMSEnabled` on `DynamoComponentDeploymentSharedSpec`).
  - `_longest_grove_combined_length(dgd, svc, spec)` returns `(combined, formula)` for the three Grove paths the operator distinguishes (single-node, multinode non-GMS leader-PCLQ, GMS with `gms-0` vs `wkr-N` selection for high node counts).
- Error messages now include the per-violation breakdown — e.g. `'TRTLLMDecodeWorker': DGD (13) + PCSG 'trtllmdecodeworker' (18) + leader PodClique 'trtllmdecodeworker-ldr' (22) = 53` — so the offending name component is immediately visible.
- Six new unit tests in `test_helpers_profile_sla.py::TestValidateDgdServiceNameLengths` exercise the multinode leader path, GMS single-node `gms-0`, GMS multinode high-N worker selection, GMS-disabled fall-through, multi-violation message composition, and a positive case that the rewritten formula reduces to the previous behavior for short single-node services.

The underlying TRT-LLM constant rename in `components/src/dynamo/planner/config/backend_components.py` (`TRTLLMDecodeWorker` → shorter, mirroring the SGLang precedent at [backend_components.py:42](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/planner/config/backend_components.py#L42) which already uses `prefill`/`decode` for exactly this reason) is intentionally **not** in this PR. Those identifiers also appear as `services:` map keys in user-facing recipes (`recipes/qwen3-235b-a22b-fp8/trtllm/disagg/...`) and examples (`examples/backends/trtllm/deploy/...`) — renaming them is a backwards-incompatible change with a different review surface and risk profile. This PR closes the validator/operator divergence; a separate PR can land the constant rename when the team is ready to break those YAML keys.

Likewise, the third option from the issue (using `computeDGDName()` in the operator deploy path so `spec.overrides.dgd.metadata.name` is honored) is a Go-side fix in a different file and is out of scope here.

#### Where should the reviewer start?

- `components/src/dynamo/profiler/profile_sla.py` — the rewritten validator and two helpers. Compare `_longest_grove_combined_length` against the Go-side `validateServiceNameLength` branches.
- `components/src/dynamo/profiler/tests/unit/test_helpers_profile_sla.py` — new test cases under `TestValidateDgdServiceNameLengths`. The first new test (`test_multinode_uses_leader_podclique_in_combined_length`) reproduces the issue's exact failure (combined length 53) and asserts the validator now catches it pre-deploy.

#### Related Issues:

- Closes GitHub issue: #8480
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8898" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened service name length validation to match operator webhook requirements, ensuring consistency across deployments. Error messages now provide detailed guidance on naming formulas and configuration fallback options.

* **Tests**
  * Added comprehensive unit tests for service name validation, covering multinode deployments and GPU memory service configurations across different operational modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->