### PR TITLE
fix: deepseek v4 inter-leaved tool and reasoning parser

### DIFF
--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -772,6 +772,23 @@ impl OpenAIPreprocessor {
     where
         S: Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send + 'static,
     {
+        // Kimi K2.5 tool-continuation turns produce the final user-facing
+        // answer directly from the tool result. If the prompt happened to end
+        // with `<think>`, starting the force-reasoning parser in reasoning mode
+        // mislabels that answer as reasoning_content. DeepSeek V4 is the
+        // opposite: its formatter can seed `<think>` for post-tool turns and
+        // the model may emit only the closing `</think>`, so preserving the
+        // injected-reasoning signal is required to avoid leaking the close tag.
+        let last_is_tool = matches!(
+            request.inner.messages.last(),
+            Some(ChatCompletionRequestMessage::Tool(_))
+        );
+        let suppress_reasoning_after_tool = last_is_tool
+            && matches!(
+                self.runtime_config.reasoning_parser.as_deref(),
+                Some("kimi_k25")
+            );
+
         // tool_choice=required/named forces the backend into guided decoding,
         // which constrains output to a bare JSON shape with no reasoning
         // wrapper. Running the reasoning parser on that output is both
@@ -791,6 +808,7 @@ impl OpenAIPreprocessor {
                 self.runtime_config.reasoning_parser.as_deref(),
                 request.chat_template_args.as_ref(),
             )
+            && !suppress_reasoning_after_tool
             && !tool_choice_forces_guided_json;
 
         // Reasoning Content Parsing Transformation Step

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -772,18 +772,6 @@ impl OpenAIPreprocessor {
     where
         S: Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send + 'static,
     {
-        // Tool-continuation turns (last message role=tool) gate the force-
-        // reasoning flag off: the model produces the final user-facing answer
-        // directly from the tool result and typically does not re-enter
-        // reasoning, so leaving the parser in forced-reasoning mode would
-        // mislabel the final answer as reasoning_content. Matches SGLang's
-        // observed behavior for Kimi K2.5 tool-result follow-ups.
-        let last_is_tool = matches!(
-            request.inner.messages.last(),
-            Some(ChatCompletionRequestMessage::Tool(_))
-        );
-        let prompt_injected_reasoning = prompt_injected_reasoning && !last_is_tool;
-
         // tool_choice=required/named forces the backend into guided decoding,
         // which constrains output to a bare JSON shape with no reasoning
         // wrapper. Running the reasoning parser on that output is both

--- a/lib/llm/tests/postprocessor_parsing_stream.rs
+++ b/lib/llm/tests/postprocessor_parsing_stream.rs
@@ -416,6 +416,75 @@ async fn postprocessor_parsing_stream_deepseek_v4_tool_continuation_keeps_inject
     );
 }
 
+/// Regression for Kimi K2.5 tool-continuation turns.
+///
+/// Kimi K2.5 direct answers after tool results should remain normal content.
+/// The `last_is_tool` guard from PR #8442 must still suppress forced
+/// prompt-injected reasoning for Kimi, even though DeepSeek V4 preserves it.
+#[tokio::test]
+async fn postprocessor_parsing_stream_kimi_k25_tool_continuation_suppresses_injected_reasoning() {
+    let preprocessor = build_preprocessor(Some("kimi_k25"), None);
+    let request: NvCreateChatCompletionRequest = serde_json::from_value(serde_json::json!({
+        "messages": [
+            {"role": "user", "content": "Create and run a hello-world script."},
+            {
+                "role": "assistant",
+                "tool_calls": [{
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "run_python",
+                        "arguments": "{\"path\":\"/tmp/hello.py\"}"
+                    }
+                }]
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": "Hello, world!"
+            }
+        ],
+        "model": "moonshotai/Kimi-K2.5-Instruct",
+        "stream": true
+    }))
+    .unwrap();
+
+    let input_chunks = vec![
+        mock_content_chunk("Done. Output: `Hello, world!`"),
+        mock_final_chunk(),
+    ];
+
+    let input_stream = stream::iter(input_chunks.into_iter().map(Annotated::from_data));
+    let output_stream = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, true)
+        .expect("postprocessor_parsing_stream should build");
+
+    let output_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> =
+        output_stream.collect().await;
+
+    let mut reasoning = String::new();
+    let mut content = String::new();
+    for output in &output_chunks {
+        let Some(data) = output.data.as_ref() else {
+            continue;
+        };
+        for choice in &data.inner.choices {
+            if let Some(r) = &choice.delta.reasoning_content {
+                reasoning.push_str(r);
+            }
+            if let Some(c) = &choice.delta.content {
+                content.push_str(get_text(c));
+            }
+        }
+    }
+
+    assert_eq!(
+        reasoning, "",
+        "direct post-tool Kimi answer must not be mislabeled as reasoning_content",
+    );
+    assert_eq!(content, "Done. Output: `Hello, world!`");
+}
+
 /// Regression: MiniMax + tool_choice=required + SGLang guided decoding.
 ///
 /// The reasoning parser (minimax_append_think) synthesizes a `<think>` opener

--- a/lib/llm/tests/postprocessor_parsing_stream.rs
+++ b/lib/llm/tests/postprocessor_parsing_stream.rs
@@ -342,6 +342,80 @@ fn mock_final_chunk() -> NvCreateChatCompletionStreamResponse {
     }
 }
 
+/// Regression for DeepSeek V4 tool-continuation turns.
+///
+/// The V4 formatter seeds `<think>` into the prompt after a merged tool result,
+/// so the completion starts inside a reasoning block and does not emit an
+/// opening `<think>`. `postprocessor_parsing_stream` must preserve the
+/// prompt-injected reasoning signal even when the original request's last
+/// message is `role=tool`.
+#[tokio::test]
+async fn postprocessor_parsing_stream_deepseek_v4_tool_continuation_keeps_injected_reasoning() {
+    let preprocessor = build_preprocessor(Some("deepseek_v4"), None);
+    let request: NvCreateChatCompletionRequest = serde_json::from_value(serde_json::json!({
+        "messages": [
+            {"role": "user", "content": "Create and run a hello-world script."},
+            {
+                "role": "assistant",
+                "tool_calls": [{
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "run_python",
+                        "arguments": "{\"path\":\"/tmp/hello.py\"}"
+                    }
+                }]
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": "Hello, world!"
+            }
+        ],
+        "model": "deepseek-ai/DeepSeek-V4-Pro",
+        "stream": true
+    }))
+    .unwrap();
+
+    let input_chunks = vec![
+        mock_content_chunk("The script ran successfully."),
+        mock_content_chunk("</think>"),
+        mock_content_chunk("Done. Output: `Hello, world!`"),
+        mock_final_chunk(),
+    ];
+
+    let input_stream = stream::iter(input_chunks.into_iter().map(Annotated::from_data));
+    let output_stream = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, true)
+        .expect("postprocessor_parsing_stream should build");
+
+    let output_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> =
+        output_stream.collect().await;
+
+    let mut reasoning = String::new();
+    let mut content = String::new();
+    for output in &output_chunks {
+        let Some(data) = output.data.as_ref() else {
+            continue;
+        };
+        for choice in &data.inner.choices {
+            if let Some(r) = &choice.delta.reasoning_content {
+                reasoning.push_str(r);
+            }
+            if let Some(c) = &choice.delta.content {
+                content.push_str(get_text(c));
+            }
+        }
+    }
+
+    assert_eq!(reasoning, "The script ran successfully.");
+    assert_eq!(content, "Done. Output: `Hello, world!`");
+    assert!(
+        !content.contains("</think>"),
+        "literal closing tag leaked into content: {content:?}"
+    );
+}
+
 /// Regression: MiniMax + tool_choice=required + SGLang guided decoding.
 ///
 /// The reasoning parser (minimax_append_think) synthesizes a `<think>` opener

--- a/lib/llm/tests/test_reasoning_parser.rs
+++ b/lib/llm/tests/test_reasoning_parser.rs
@@ -807,4 +807,98 @@ mod tests {
         assert!(all_normal_content.contains("I'll check the weather for you"));
         assert!(found_tool_calls, "Should have found tool calls");
     }
+
+    /// Run chunks through a reasoning parser with `prompt_injected_reasoning=true`.
+    /// Mirrors `run_parser` but anchors the parser in reasoning mode from the
+    /// first chunk — used to simulate post-tool-call assistant turns where the
+    /// chat template seeded `<think>` so the model's stream begins mid-reasoning
+    /// without an explicit opening tag.
+    async fn run_parser_with_injected_reasoning(
+        chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>>,
+        parser: &str,
+    ) -> (String, String) {
+        let output_stream = OpenAIPreprocessor::parse_reasoning_content_from_stream(
+            stream::iter(chunks),
+            parser.to_string(),
+            true,
+        );
+        let mut output_stream = std::pin::pin!(output_stream);
+        let mut all_reasoning = String::new();
+        let mut all_content = String::new();
+        while let Some(item) = output_stream.next().await {
+            if let Some(ref data) = item.data {
+                for choice in &data.inner.choices {
+                    if let Some(ref r) = choice.delta.reasoning_content {
+                        all_reasoning.push_str(r);
+                    }
+                    if let Some(ref c) = choice.delta.content {
+                        all_content.push_str(get_text(c));
+                    }
+                }
+            }
+        }
+        (all_reasoning, all_content)
+    }
+
+    /// Regression test for the `</think>` leak observed against
+    /// `deepseek-ai/DeepSeek-V4-Pro` on tool-continuation turns.
+    ///
+    /// On the assistant turn that follows a `tool` message, the V4 chat
+    /// template seeds `<think>` after the merged user turn. The model
+    /// re-enters reasoning, emits `<reasoning></think><answer>` as a single
+    /// content stream, and the gateway is supposed to extract reasoning
+    /// into `reasoning_content` and place the answer in `content`.
+    ///
+    /// Bug surface: `OpenAIPreprocessor::postprocessor_parsing_stream`
+    /// previously cleared `prompt_injected_reasoning` whenever the last
+    /// request message was a tool result. That left the non-force
+    /// deepseek_v4 parser in normal mode: it never saw an opening `<think>`
+    /// (the template emitted it), so the `</think>` token was treated as
+    /// plain text and the entire stream flowed into `content`.
+    ///
+    /// This test pins the contract at the parser layer: when started with
+    /// `prompt_injected_reasoning=true`, the `</think>` token must be
+    /// consumed and the answer routed to `content`.
+    #[tokio::test]
+    async fn test_reasoning_parser_deepseek_v4_post_tool_with_prompt_injected_reasoning() {
+        // Exactly the shape we observed on the wire from the gateway: no
+        // opening `<think>` (template emitted it), reasoning text, closing
+        // `</think>`, then the user-facing answer.
+        let chunks = vec![
+            chunk("The script ran successfully and printed \"Hello, world!\"."),
+            chunk("</think>"),
+            chunk("Done. Created `/tmp/hello.py` and ran it — output: `Hello, world!`"),
+        ];
+
+        let (reasoning, content) = run_parser_with_injected_reasoning(chunks, "deepseek_v4").await;
+
+        assert_eq!(
+            reasoning, "The script ran successfully and printed \"Hello, world!\".",
+            "pre-`</think>` text must be captured as reasoning_content",
+        );
+        assert_eq!(
+            content, "Done. Created `/tmp/hello.py` and ran it — output: `Hello, world!`",
+            "post-`</think>` text must be captured as content",
+        );
+        assert!(
+            !content.contains("</think>"),
+            "literal `</think>` token must not leak into content; got: {content:?}",
+        );
+    }
+
+    /// Same scenario as above, fragmented across the `</think>` boundary in
+    /// a single chunk — guards against the parser only working when the
+    /// closing tag arrives in its own chunk.
+    #[tokio::test]
+    async fn test_reasoning_parser_deepseek_v4_post_tool_split_across_close_tag() {
+        let chunks = vec![chunk(
+            "Reasoning before the close tag.</think>Final answer here.",
+        )];
+
+        let (reasoning, content) = run_parser_with_injected_reasoning(chunks, "deepseek_v4").await;
+
+        assert_eq!(reasoning, "Reasoning before the close tag.");
+        assert_eq!(content, "Final answer here.");
+        assert!(!content.contains("</think>"));
+    }
 }


### PR DESCRIPTION
#### Overview:

Fixes DeepSeek V4 tool-continuation reasoning parsing without regressing Kimi K2.5. In the failing DSv4 flow, the request ends with a `role=tool` message and the DSv4 formatter has already seeded `<think>` into the next assistant prompt. The model can then stream reasoning text followed by `</think>` without an opening `<think>` token in the completion. If the postprocessor clears `prompt_injected_reasoning` for all tool-continuation turns, the closing tag is treated as normal content and leaks to the client.

This PR keeps DSv4 in injected-reasoning mode for that path, while preserving the Kimi K2.5 behavior introduced by `5671d8e374021ca1aeb399fa9729285903ea6645`: direct post-tool final answers for `kimi_k25` should remain normal `content`, not be mislabeled as `reasoning_content`.

#### Details:

- Removes the broad `last_is_tool` suppression that caused the DSv4 `</think>` leak.
- Reintroduces post-tool reasoning suppression specifically for `kimi_k25`, where the parser is force-reasoning and direct tool follow-up answers must bypass reasoning parsing.
- Adds a DSv4 stream regression test for `user -> assistant(tool_call) -> tool -> assistant` where the completion starts inside reasoning and emits `</think>`.
- Adds a Kimi K2.5 regression test for the same conversation shape where the final direct answer must stay in `content`.
- Keeps `tool_choice=required` / named guarded from reasoning parsing for guided-decoding JSON outputs.

#### Where should the reviewer start?

- `lib/llm/src/preprocessor.rs` — parser-specific post-tool reasoning gate.
- `lib/llm/tests/postprocessor_parsing_stream.rs` — DSv4 `</think>` leak regression and Kimi K2.5 non-regression coverage.
- `lib/llm/tests/test_reasoning_parser.rs` — parser-level DSv4 injected-reasoning tests.

#### Validation:

Ran with `CUDARC_CUDA_VERSION=12090` because local CUDA 13.2 is rejected by `cudarc 0.19.3` during build.

- `cargo test -p dynamo-llm --no-default-features --test postprocessor_parsing_stream tool_continuation -- --nocapture`
- `cargo test -p dynamo-llm --no-default-features --test test_reasoning_parser deepseek_v4_post_tool -- --nocapture`
- `cargo test -p dynamo-llm --no-default-features --test test_reasoning_parser kimi_k25 -- --nocapture`
- `cargo test -p dynamo-llm --no-default-features --test tool_choice -- --nocapture`
- `cargo test -p dynamo-parsers _v4 -- --nocapture`
- `cargo test -p dynamo-parsers tool_calling::xml::kimi_k2_parser::tests -- --nocapture`

#### Related Issues:

- Relates to #8442 / `5671d8e374021ca1aeb399fa9729285903ea6645`

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8901" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->