### PR TITLE
test(revalidate): feat(deepseek-v4): add vLLM GB200 disagg recipe for DeepSeek-V4-Pro #8811

### DIFF
--- a/components/src/dynamo/common/__init__.py
+++ b/components/src/dynamo/common/__init__.py
@@ -25,3 +25,5 @@ except Exception:
         __version__ = "0.0.0+unknown"
 
 __all__ = ["__version__", "config_dump", "constants", "utils"]
+
+# ci-health probe 3f7e857d4cf 2026-04-30T15:23:09Z

--- a/lib/runtime/src/runtime.rs
+++ b/lib/runtime/src/runtime.rs
@@ -391,3 +391,5 @@ impl Drop for RuntimeType {
         }
     }
 }
+
+// ci-health probe 3f7e857d4cf 2026-04-30T15:23:09Z


### PR DESCRIPTION
Re-validating that PR #8811 by Biswa Panda did not regress, by re-running against a trivial placebo diff:

```
feat(deepseek-v4): add vLLM GB200 disagg recipe for DeepSeek-V4-Pro
```

Branch deleted on green; kept on failure for diagnosis.

Drafts are skipped by CodeRabbit per repo `.coderabbit.yaml`.