### PR TITLE
test(revalidate): docs: add DYN_EVENT_PLANE=zmq to hello_world example commands #8847

### DIFF
--- a/components/src/dynamo/common/__init__.py
+++ b/components/src/dynamo/common/__init__.py
@@ -25,3 +25,5 @@ except Exception:
         __version__ = "0.0.0+unknown"
 
 __all__ = ["__version__", "config_dump", "constants", "utils"]
+
+# ci-health probe 86a942a1496 2026-04-30T15:23:21Z

--- a/lib/runtime/src/runtime.rs
+++ b/lib/runtime/src/runtime.rs
@@ -391,3 +391,5 @@ impl Drop for RuntimeType {
         }
     }
 }
+
+// ci-health probe 86a942a1496 2026-04-30T15:23:21Z


### PR DESCRIPTION
Re-validating that PR #8847 by Dan Gil did not regress, by re-running against a trivial placebo diff:

```
docs: add DYN_EVENT_PLANE=zmq to hello_world example commands
```

Branch deleted on green; kept on failure for diagnosis.

Drafts are skipped by CodeRabbit per repo `.coderabbit.yaml`.