### PR TITLE
feat(kv-router): align HTTP indexer with Mooncake RFC #1403 multi-tier API

### DIFF
--- a/lib/kv-router/src/indexer/lower_tier_indexers.rs
+++ b/lib/kv-router/src/indexer/lower_tier_indexers.rs
@@ -1,0 +1,197 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Per-tier registry of [`LowerTierIndexer`] instances and helpers for walking
+//! the device → host → disk continuation chain.
+//!
+//! The primary KV indexer (radix tree) handles device-tier overlap scoring.
+//! When a request arrives, we want to extend the per-worker match by walking
+//! whichever lower tiers a worker has registered. [`LowerTierIndexers`] holds
+//! one [`ThreadPoolIndexer<LowerTierIndexer>`] per non-device [`StorageTier`]
+//! and lazily allocates each tier on first event arrival.
+//!
+//! Both the request-plane indexer (`dynamo-llm`) and the standalone HTTP
+//! indexer (this crate's `standalone_indexer` module) share this implementation
+//! so tier semantics stay aligned across the two surfaces.
+
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+use crate::indexer::{
+    LowerTierContinuation, LowerTierIndexer, LowerTierMatchDetails, MatchDetails,
+    ThreadPoolIndexer, WireTieredMatchDetails,
+};
+use crate::protocols::{LocalBlockHash, StorageTier};
+
+/// Holds one per-tier [`ThreadPoolIndexer<LowerTierIndexer>`] for every
+/// non-device [`StorageTier`] that has received at least one event.
+#[derive(Clone)]
+pub struct LowerTierIndexers {
+    num_threads: usize,
+    block_size: u32,
+    indexers: Arc<RwLock<HashMap<StorageTier, Arc<ThreadPoolIndexer<LowerTierIndexer>>>>>,
+}
+
+impl LowerTierIndexers {
+    pub fn new(num_threads: usize, block_size: u32) -> Self {
+        assert!(
+            num_threads > 0,
+            "lower-tier indexer threads must be non-zero"
+        );
+        Self {
+            num_threads,
+            block_size,
+            indexers: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Return the per-tier indexer for `storage_tier`, lazily allocating it
+    /// the first time a non-device tier is seen.
+    pub fn get_or_create(
+        &self,
+        storage_tier: StorageTier,
+    ) -> Arc<ThreadPoolIndexer<LowerTierIndexer>> {
+        debug_assert!(!storage_tier.is_gpu());
+        if let Some(indexer) = self.indexers.read().unwrap().get(&storage_tier).cloned() {
+            return indexer;
+        }
+        self.indexers
+            .write()
+            .unwrap()
+            .entry(storage_tier)
+            .or_insert_with(|| {
+                Arc::new(ThreadPoolIndexer::new(
+                    LowerTierIndexer::new(),
+                    self.num_threads,
+                    self.block_size,
+                ))
+            })
+            .clone()
+    }
+
+    /// All currently allocated lower-tier indexers, in unspecified order.
+    pub fn all(&self) -> Vec<Arc<ThreadPoolIndexer<LowerTierIndexer>>> {
+        self.indexers.read().unwrap().values().cloned().collect()
+    }
+
+    /// Lookup without allocation; returns `None` if the tier is unseen.
+    pub fn get(
+        &self,
+        storage_tier: StorageTier,
+    ) -> Option<Arc<ThreadPoolIndexer<LowerTierIndexer>>> {
+        self.indexers.read().unwrap().get(&storage_tier).cloned()
+    }
+}
+
+/// Native tiered-match container: the device-tier match plus a per-tier map
+/// of lower-tier hits. Wire-friendly representations live in
+/// [`WireTieredMatchDetails`]; conversions in both directions are provided.
+#[derive(Debug, Clone, Default)]
+pub struct TieredMatchDetails {
+    pub device: MatchDetails,
+    pub lower_tier: HashMap<StorageTier, LowerTierMatchDetails>,
+}
+
+impl From<&TieredMatchDetails> for WireTieredMatchDetails {
+    fn from(d: &TieredMatchDetails) -> Self {
+        Self {
+            device: d.device.overlap_scores.clone().into(),
+            lower_tier: d
+                .lower_tier
+                .iter()
+                .map(|(tier, details)| (*tier, details.into()))
+                .collect(),
+        }
+    }
+}
+
+impl From<WireTieredMatchDetails> for TieredMatchDetails {
+    fn from(w: WireTieredMatchDetails) -> Self {
+        // `last_matched_hashes` is only needed server-side to seed the tier walk,
+        // so we leave it empty on the inbound side.
+        let mut lower_tier = HashMap::with_capacity(w.lower_tier.len());
+        for (tier, details) in w.lower_tier {
+            if lower_tier.insert(tier, details.into()).is_some() {
+                tracing::warn!(
+                    ?tier,
+                    "Duplicate StorageTier in WireTieredMatchDetails; keeping last entry"
+                );
+            }
+        }
+        Self {
+            device: MatchDetails {
+                overlap_scores: w.device.into(),
+                ..Default::default()
+            },
+            lower_tier,
+        }
+    }
+}
+
+/// The order in which lower tiers are walked when extending a match. Device
+/// → HostPinned → Disk → External.
+pub fn lower_tier_query_order() -> [StorageTier; 3] {
+    [
+        StorageTier::HostPinned,
+        StorageTier::Disk,
+        StorageTier::External,
+    ]
+}
+
+/// Walk every allocated lower tier in [`lower_tier_query_order`] and build a
+/// per-tier match map seeded from `device_matches`. Per-worker continuations
+/// flow forward: a worker that matched N device blocks starts the host walk
+/// at block N (anchored on its last device hash), and so on.
+pub fn query_lower_tiers(
+    indexers: &LowerTierIndexers,
+    sequence: &[LocalBlockHash],
+    device_matches: &MatchDetails,
+) -> HashMap<StorageTier, LowerTierMatchDetails> {
+    let mut continuations = LowerTierMatchDetails::default().next_continuations;
+    for (worker, matched_blocks) in &device_matches.overlap_scores.scores {
+        let Some(last_hash) = device_matches.last_matched_hashes.get(worker).copied() else {
+            debug_assert!(
+                false,
+                "device match result missing last matched hash for worker {worker:?}"
+            );
+            continue;
+        };
+
+        continuations.insert(
+            *worker,
+            LowerTierContinuation::new(*matched_blocks as usize, last_hash),
+        );
+    }
+
+    let mut lower_tier_matches = HashMap::new();
+
+    for storage_tier in lower_tier_query_order() {
+        let Some(indexer) = indexers.get(storage_tier) else {
+            continue;
+        };
+
+        if let Some(&first_hash) = sequence.first() {
+            let root_workers: Vec<_> = indexer.backend().root_workers(first_hash);
+            for worker in root_workers.iter() {
+                continuations
+                    .entry(*worker)
+                    .or_insert_with(|| LowerTierContinuation::from_root(0));
+            }
+        }
+
+        let tier_matches = indexer
+            .backend()
+            .query_match_details(sequence, &continuations);
+        let matched_workers = tier_matches.hits.values().filter(|&&hits| hits > 0).count();
+        tracing::debug!(
+            ?storage_tier,
+            queried_workers = continuations.len(),
+            matched_workers,
+            "Queried lower-tier indexer"
+        );
+        continuations = tier_matches.next_continuations.clone();
+        lower_tier_matches.insert(storage_tier, tier_matches);
+    }
+
+    lower_tier_matches
+}

--- a/lib/kv-router/src/indexer/lower_tier_indexers.rs
+++ b/lib/kv-router/src/indexer/lower_tier_indexers.rs
@@ -74,6 +74,18 @@ impl LowerTierIndexers {
         self.indexers.read().unwrap().values().cloned().collect()
     }
 
+    /// All currently allocated lower-tier indexers paired with the
+    /// [`StorageTier`] each one indexes. Used by callers that need to retag
+    /// per-tier dumps (e.g. peer-recovery).
+    pub fn entries(&self) -> Vec<(StorageTier, Arc<ThreadPoolIndexer<LowerTierIndexer>>)> {
+        self.indexers
+            .read()
+            .unwrap()
+            .iter()
+            .map(|(tier, indexer)| (*tier, indexer.clone()))
+            .collect()
+    }
+
     /// Lookup without allocation; returns `None` if the tier is unseen.
     pub fn get(
         &self,

--- a/lib/kv-router/src/indexer/mod.rs
+++ b/lib/kv-router/src/indexer/mod.rs
@@ -46,6 +46,7 @@ fn warn_on_unit_block_size(indexer_type: &'static str, kv_block_size: u32) {
 mod kv_indexer;
 mod local;
 mod lower_tier;
+mod lower_tier_indexers;
 mod metrics;
 mod thread_pool;
 mod traits;
@@ -66,6 +67,7 @@ pub use branch_sharded::*;
 pub use kv_indexer::*;
 pub use local::*;
 pub use lower_tier::*;
+pub use lower_tier_indexers::*;
 pub use metrics::*;
 pub use thread_pool::*;
 pub use traits::*;

--- a/lib/kv-router/src/standalone_indexer/indexer.rs
+++ b/lib/kv-router/src/standalone_indexer/indexer.rs
@@ -184,11 +184,41 @@ impl Indexer {
         }
     }
 
+    /// Dump every event tracked by this indexer in a form replayable by a
+    /// peer's [`Self::apply_event_routed`].
+    ///
+    /// Returns the primary device-tier dump first, followed by every allocated
+    /// lower-tier indexer's dump with each event's `storage_tier` retagged to
+    /// the tier it lives in. The `LowerTierIndexer::dump_events` synthetic
+    /// events default `storage_tier` to `Device`, so without retagging a peer
+    /// would replay them into the wrong slot.
     pub async fn dump_events(&self) -> Result<Vec<RouterEvent>> {
-        match self {
-            Indexer::Single { primary, .. } => primary.dump_events().await.map_err(Into::into),
-            Indexer::Concurrent { primary, .. } => primary.dump_events().await.map_err(Into::into),
+        let (primary_events, lower_tier_entries) = match self {
+            Indexer::Single {
+                primary,
+                lower_tier,
+            } => (
+                primary.dump_events().await.map_err(anyhow::Error::from)?,
+                lower_tier.entries(),
+            ),
+            Indexer::Concurrent {
+                primary,
+                lower_tier,
+            } => (
+                primary.dump_events().await.map_err(anyhow::Error::from)?,
+                lower_tier.entries(),
+            ),
+        };
+
+        let mut out = primary_events;
+        for (tier, indexer) in lower_tier_entries {
+            let events = indexer.dump_events().await.map_err(anyhow::Error::from)?;
+            for mut event in events {
+                event.storage_tier = tier;
+                out.push(event);
+            }
         }
+        Ok(out)
     }
 }
 
@@ -317,6 +347,124 @@ mod tests {
             host_hits.hits.get(&worker).copied(),
             Some(1),
             "host-pinned should report 1 additional matched block beyond device"
+        );
+    }
+
+    /// Dump every tier's events from a populated indexer, replay through a
+    /// fresh indexer with `apply_event_routed`, and assert the tiered query
+    /// result is identical. This is the peer-recovery round trip: it would
+    /// fail if `dump_events` skipped lower-tier events or omitted their tier
+    /// tags (peer would replay HostPinned events into the device primary).
+    #[tokio::test]
+    async fn dump_events_round_trips_through_apply_event_routed() {
+        let block_size = 4;
+        let worker = WorkerWithDpRank::new(7, 0);
+        let source = create_indexer(block_size, 1);
+
+        source
+            .apply_event_routed(store_event(
+                worker.worker_id,
+                worker.dp_rank,
+                1,
+                &[],
+                &[11, 12],
+                StorageTier::Device,
+            ))
+            .await;
+        source
+            .apply_event_routed(store_event(
+                worker.worker_id,
+                worker.dp_rank,
+                2,
+                &[11, 12],
+                &[13],
+                StorageTier::HostPinned,
+            ))
+            .await;
+        source
+            .apply_event_routed(store_event(
+                worker.worker_id,
+                worker.dp_rank,
+                3,
+                &[11, 12, 13],
+                &[14],
+                StorageTier::Disk,
+            ))
+            .await;
+
+        if let Indexer::Single {
+            primary,
+            lower_tier,
+        } = &source
+        {
+            let _ = primary.flush().await;
+            for inner in lower_tier.all() {
+                let _ = inner.dump_events().await.unwrap();
+            }
+        }
+
+        let dump = source.dump_events().await.unwrap();
+
+        // Sanity: dump must surface events from every tier we fed in.
+        assert!(
+            dump.iter()
+                .any(|e| matches!(e.storage_tier, StorageTier::Device)),
+            "dump must contain Device events"
+        );
+        assert!(
+            dump.iter()
+                .any(|e| matches!(e.storage_tier, StorageTier::HostPinned)),
+            "dump must contain HostPinned events with tier retagged"
+        );
+        assert!(
+            dump.iter()
+                .any(|e| matches!(e.storage_tier, StorageTier::Disk)),
+            "dump must contain Disk events with tier retagged"
+        );
+
+        let replayed = create_indexer(block_size, 1);
+        for event in dump {
+            replayed.apply_event_routed(event).await;
+        }
+        if let Indexer::Single {
+            primary,
+            lower_tier,
+        } = &replayed
+        {
+            let _ = primary.flush().await;
+            for inner in lower_tier.all() {
+                let _ = inner.dump_events().await.unwrap();
+            }
+        }
+
+        let sequence = vec![
+            LocalBlockHash(11),
+            LocalBlockHash(12),
+            LocalBlockHash(13),
+            LocalBlockHash(14),
+        ];
+        let tiered = replayed.find_tiered_matches(sequence).await.unwrap();
+
+        assert_eq!(
+            tiered.device.overlap_scores.scores.get(&worker).copied(),
+            Some(2),
+            "device should match 2 blocks after replay"
+        );
+        assert_eq!(
+            tiered
+                .lower_tier
+                .get(&StorageTier::HostPinned)
+                .and_then(|d| d.hits.get(&worker).copied()),
+            Some(1),
+            "host-pinned should report 1 additional block after replay"
+        );
+        assert_eq!(
+            tiered
+                .lower_tier
+                .get(&StorageTier::Disk)
+                .and_then(|d| d.hits.get(&worker).copied()),
+            Some(1),
+            "disk should report 1 additional block after replay"
         );
     }
 }

--- a/lib/kv-router/src/standalone_indexer/indexer.rs
+++ b/lib/kv-router/src/standalone_indexer/indexer.rs
@@ -8,66 +8,339 @@ use tokio_util::sync::CancellationToken;
 
 use crate::ConcurrentRadixTreeCompressed;
 use crate::ThreadPoolIndexer;
-use crate::indexer::{KvIndexer, KvIndexerInterface, KvIndexerMetrics};
-use crate::protocols::{LocalBlockHash, OverlapScores, RouterEvent, WorkerId};
+use crate::indexer::{
+    KvIndexer, KvIndexerInterface, KvIndexerMetrics, LowerTierIndexers, MatchDetails,
+    TieredMatchDetails, query_lower_tiers,
+};
+use crate::protocols::{KvCacheEventData, LocalBlockHash, OverlapScores, RouterEvent, WorkerId};
 
+/// Block-content indexer wrapping a primary device-tier backend plus a
+/// per-tier registry of lower-tier indexers (host-pinned, disk, …).
+///
+/// Both standalone-indexer variants own a `lower_tier: LowerTierIndexers` so
+/// tier-tagged events get routed alongside device events and tier-aware
+/// queries can return per-tier hit counts.
 #[derive(Clone)]
 pub enum Indexer {
-    Single(KvIndexer),
-    Concurrent(Arc<ThreadPoolIndexer<ConcurrentRadixTreeCompressed>>),
+    Single {
+        primary: KvIndexer,
+        lower_tier: LowerTierIndexers,
+    },
+    Concurrent {
+        primary: Arc<ThreadPoolIndexer<ConcurrentRadixTreeCompressed>>,
+        lower_tier: LowerTierIndexers,
+    },
 }
 
 impl Indexer {
+    /// Apply an event without tier dispatch — kept for callers that have
+    /// already determined this is a device-tier event. Most callers should
+    /// use [`Self::apply_event_routed`].
     pub async fn apply_event(&self, event: RouterEvent) {
         match self {
-            Indexer::Single(idx) => idx.apply_event(event).await,
-            Indexer::Concurrent(idx) => idx.apply_event(event).await,
+            Indexer::Single { primary, .. } => primary.apply_event(event).await,
+            Indexer::Concurrent { primary, .. } => primary.apply_event(event).await,
+        }
+    }
+
+    /// Apply an event, routing to the device-tier primary when
+    /// `event.storage_tier.is_gpu()` and to the appropriate lower-tier
+    /// indexer otherwise. `Cleared` events fan out to every tier so per-tier
+    /// state stays consistent with the primary.
+    pub async fn apply_event_routed(&self, event: RouterEvent) {
+        match self {
+            Indexer::Single {
+                primary,
+                lower_tier,
+            } => match &event.event.data {
+                KvCacheEventData::Cleared => {
+                    primary.apply_event(event.clone()).await;
+                    for indexer in lower_tier.all() {
+                        indexer.apply_event(event.clone()).await;
+                    }
+                }
+                _ if event.storage_tier.is_gpu() => {
+                    primary.apply_event(event).await;
+                }
+                _ => {
+                    lower_tier
+                        .get_or_create(event.storage_tier)
+                        .apply_event(event)
+                        .await;
+                }
+            },
+            Indexer::Concurrent {
+                primary,
+                lower_tier,
+            } => match &event.event.data {
+                KvCacheEventData::Cleared => {
+                    primary.apply_event(event.clone()).await;
+                    for indexer in lower_tier.all() {
+                        indexer.apply_event(event.clone()).await;
+                    }
+                }
+                _ if event.storage_tier.is_gpu() => {
+                    primary.apply_event(event).await;
+                }
+                _ => {
+                    lower_tier
+                        .get_or_create(event.storage_tier)
+                        .apply_event(event)
+                        .await;
+                }
+            },
         }
     }
 
     pub async fn remove_worker(&self, worker_id: WorkerId) {
         match self {
-            Indexer::Single(idx) => idx.remove_worker(worker_id).await,
-            Indexer::Concurrent(idx) => idx.remove_worker(worker_id).await,
+            Indexer::Single {
+                primary,
+                lower_tier,
+            } => {
+                for indexer in lower_tier.all() {
+                    indexer.remove_worker(worker_id).await;
+                }
+                primary.remove_worker(worker_id).await;
+            }
+            Indexer::Concurrent {
+                primary,
+                lower_tier,
+            } => {
+                for indexer in lower_tier.all() {
+                    indexer.remove_worker(worker_id).await;
+                }
+                primary.remove_worker(worker_id).await;
+            }
         }
     }
 
     pub async fn remove_worker_dp_rank(&self, worker_id: WorkerId, dp_rank: u32) {
         match self {
-            Indexer::Single(idx) => idx.remove_worker_dp_rank(worker_id, dp_rank).await,
-            Indexer::Concurrent(idx) => idx.remove_worker_dp_rank(worker_id, dp_rank).await,
+            Indexer::Single {
+                primary,
+                lower_tier,
+            } => {
+                for indexer in lower_tier.all() {
+                    indexer.remove_worker_dp_rank(worker_id, dp_rank).await;
+                }
+                primary.remove_worker_dp_rank(worker_id, dp_rank).await;
+            }
+            Indexer::Concurrent {
+                primary,
+                lower_tier,
+            } => {
+                for indexer in lower_tier.all() {
+                    indexer.remove_worker_dp_rank(worker_id, dp_rank).await;
+                }
+                primary.remove_worker_dp_rank(worker_id, dp_rank).await;
+            }
         }
     }
 
+    /// Device-tier overlap scores. Existing flat-shape callers continue to use
+    /// this; tier-aware callers should use [`Self::find_tiered_matches`].
     pub async fn find_matches(&self, hashes: Vec<LocalBlockHash>) -> Result<OverlapScores> {
         match self {
-            Indexer::Single(idx) => idx.find_matches(hashes).await.map_err(Into::into),
-            Indexer::Concurrent(idx) => idx.find_matches(hashes).await.map_err(Into::into),
+            Indexer::Single { primary, .. } => {
+                primary.find_matches(hashes).await.map_err(Into::into)
+            }
+            Indexer::Concurrent { primary, .. } => {
+                primary.find_matches(hashes).await.map_err(Into::into)
+            }
+        }
+    }
+
+    /// Device match details + per-tier hits, suitable for building the
+    /// Mooncake-RFC-shape per-instance breakdown.
+    pub async fn find_tiered_matches(
+        &self,
+        sequence: Vec<LocalBlockHash>,
+    ) -> Result<TieredMatchDetails> {
+        match self {
+            Indexer::Single {
+                primary,
+                lower_tier,
+            } => {
+                let device = primary.find_match_details(sequence.clone()).await?;
+                let lt = query_lower_tiers(lower_tier, &sequence, &device);
+                Ok(TieredMatchDetails {
+                    device,
+                    lower_tier: lt,
+                })
+            }
+            Indexer::Concurrent {
+                primary,
+                lower_tier,
+            } => {
+                let device: MatchDetails =
+                    primary.backend().find_match_details_impl(&sequence, false);
+                let lt = query_lower_tiers(lower_tier, &sequence, &device);
+                Ok(TieredMatchDetails {
+                    device,
+                    lower_tier: lt,
+                })
+            }
         }
     }
 
     pub async fn dump_events(&self) -> Result<Vec<RouterEvent>> {
         match self {
-            Indexer::Single(idx) => idx.dump_events().await.map_err(Into::into),
-            Indexer::Concurrent(idx) => idx.dump_events().await.map_err(Into::into),
+            Indexer::Single { primary, .. } => primary.dump_events().await.map_err(Into::into),
+            Indexer::Concurrent { primary, .. } => primary.dump_events().await.map_err(Into::into),
         }
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test_util {
+    use crate::protocols::{
+        ExternalSequenceBlockHash, KvCacheEvent, KvCacheEventData, KvCacheStoreData,
+        KvCacheStoredBlockData, LocalBlockHash, RouterEvent, StorageTier,
+        compute_seq_hash_for_block,
+    };
+
+    /// Construct a STORE [`RouterEvent`] for `local_hashes` that chain off
+    /// `prefix_hashes` (the parent path). The event is tagged `storage_tier`.
+    /// Mirrors the helper used in the request-plane tests so behavior across
+    /// the two indexer surfaces stays comparable.
+    pub fn store_event(
+        worker_id: u64,
+        dp_rank: u32,
+        event_id: u64,
+        prefix_hashes: &[u64],
+        local_hashes: &[u64],
+        storage_tier: StorageTier,
+    ) -> RouterEvent {
+        let prefix_block_hashes: Vec<LocalBlockHash> =
+            prefix_hashes.iter().copied().map(LocalBlockHash).collect();
+        let parent_hash = compute_seq_hash_for_block(&prefix_block_hashes)
+            .last()
+            .copied()
+            .map(ExternalSequenceBlockHash);
+
+        let full_hashes: Vec<LocalBlockHash> = prefix_hashes
+            .iter()
+            .chain(local_hashes.iter())
+            .copied()
+            .map(LocalBlockHash)
+            .collect();
+        let full_sequence_hashes = compute_seq_hash_for_block(&full_hashes);
+        let new_sequence_hashes = &full_sequence_hashes[prefix_hashes.len()..];
+        let blocks = local_hashes
+            .iter()
+            .zip(new_sequence_hashes.iter())
+            .map(|(&local_hash, &sequence_hash)| KvCacheStoredBlockData {
+                block_hash: ExternalSequenceBlockHash(sequence_hash),
+                tokens_hash: LocalBlockHash(local_hash),
+                mm_extra_info: None,
+            })
+            .collect();
+
+        RouterEvent::with_storage_tier(
+            worker_id,
+            KvCacheEvent {
+                event_id,
+                data: KvCacheEventData::Stored(KvCacheStoreData {
+                    parent_hash,
+                    start_position: None,
+                    blocks,
+                }),
+                dp_rank,
+            },
+            storage_tier,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_util::store_event;
+    use super::*;
+    use crate::indexer::KvIndexerInterface;
+    use crate::protocols::{LocalBlockHash, StorageTier, WorkerWithDpRank};
+
+    /// Apply a Device store and a HostPinned store anchored on it. The tiered
+    /// query must surface both tier hits, and the device-tier `find_matches`
+    /// must still see the device store (i.e. dispatch routed it to the
+    /// primary, not to the lower-tier slot).
+    #[tokio::test]
+    async fn apply_event_routed_dispatches_by_tier() {
+        let indexer = create_indexer(4, 1);
+        let worker = WorkerWithDpRank::new(7, 0);
+
+        indexer
+            .apply_event_routed(store_event(
+                worker.worker_id,
+                worker.dp_rank,
+                1,
+                &[],
+                &[11, 12],
+                StorageTier::Device,
+            ))
+            .await;
+
+        indexer
+            .apply_event_routed(store_event(
+                worker.worker_id,
+                worker.dp_rank,
+                2,
+                &[11, 12],
+                &[13],
+                StorageTier::HostPinned,
+            ))
+            .await;
+
+        // Flush primary so the in-flight events are observable by the query.
+        if let Indexer::Single { primary, .. } = &indexer {
+            let _ = primary.flush().await;
+        }
+        if let Indexer::Single { lower_tier, .. } = &indexer {
+            for inner in lower_tier.all() {
+                let _ = inner.dump_events().await.unwrap();
+            }
+        }
+
+        let sequence = vec![LocalBlockHash(11), LocalBlockHash(12), LocalBlockHash(13)];
+        let tiered = indexer.find_tiered_matches(sequence).await.unwrap();
+
+        assert_eq!(
+            tiered.device.overlap_scores.scores.get(&worker).copied(),
+            Some(2),
+            "device should match 2 blocks for the worker"
+        );
+        let host_hits = tiered
+            .lower_tier
+            .get(&StorageTier::HostPinned)
+            .expect("host-pinned tier should have been allocated");
+        assert_eq!(
+            host_hits.hits.get(&worker).copied(),
+            Some(1),
+            "host-pinned should report 1 additional matched block beyond device"
+        );
     }
 }
 
 pub fn create_indexer(block_size: u32, num_threads: usize) -> Indexer {
     if num_threads > 1 {
-        Indexer::Concurrent(Arc::new(ThreadPoolIndexer::new(
-            ConcurrentRadixTreeCompressed::new(),
-            num_threads,
-            block_size,
-        )))
+        Indexer::Concurrent {
+            primary: Arc::new(ThreadPoolIndexer::new(
+                ConcurrentRadixTreeCompressed::new(),
+                num_threads,
+                block_size,
+            )),
+            lower_tier: LowerTierIndexers::new(num_threads, block_size),
+        }
     } else {
-        Indexer::Single(KvIndexer::new_with_frequency(
-            CancellationToken::new(),
-            None,
-            block_size,
-            Arc::new(KvIndexerMetrics::new_unregistered()),
-            None,
-        ))
+        Indexer::Single {
+            primary: KvIndexer::new_with_frequency(
+                CancellationToken::new(),
+                None,
+                block_size,
+                Arc::new(KvIndexerMetrics::new_unregistered()),
+                None,
+            ),
+            lower_tier: LowerTierIndexers::new(1, block_size),
+        }
     }
 }

--- a/lib/kv-router/src/standalone_indexer/listener.rs
+++ b/lib/kv-router/src/standalone_indexer/listener.rs
@@ -156,13 +156,10 @@ impl ListenerLoop {
                 ) else {
                     continue;
                 };
-                if !placement_event.placement.is_local_gpu() {
-                    continue;
-                }
                 let router_event = placement_event
                     .into_router_event()
                     .expect("local worker placement must convert to router event");
-                indexer.apply_event(router_event).await;
+                indexer.apply_event_routed(router_event).await;
             }
             watermark.store(seq, Ordering::Release);
             replayed += 1;
@@ -225,13 +222,10 @@ impl ListenerLoop {
             ) else {
                 continue;
             };
-            if !placement_event.placement.is_local_gpu() {
-                continue;
-            }
             let router_event = placement_event
                 .into_router_event()
                 .expect("local worker placement must convert to router event");
-            self.indexer.apply_event(router_event).await;
+            self.indexer.apply_event_routed(router_event).await;
             self.messages_processed += 1;
         }
         self.watermark.store(seq, Ordering::Release);

--- a/lib/kv-router/src/standalone_indexer/mod.rs
+++ b/lib/kv-router/src/standalone_indexer/mod.rs
@@ -1,6 +1,28 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+//! Standalone HTTP KV-cache indexer.
+//!
+//! Hosts an Axum HTTP server with `/register`, `/unregister`, `/query`,
+//! `/query_by_hash`, and peer-discovery routes that workers / gateways can
+//! call to drive cache-aware routing decisions. Each registered worker spawns
+//! a ZMQ listener that ingests its KV events into a per-(model, tenant)
+//! [`indexer::Indexer`].
+//!
+//! ## Multi-tier responses
+//!
+//! `/query` and `/query_by_hash` return both:
+//! - the legacy flat `scores`/`frequencies`/`tree_sizes` (device-tier overlap),
+//!   for backward compatibility, and
+//! - a per-instance `instances` map keyed by `instance_id` with `gpu`, `cpu`,
+//!   `disk`, per-`dp_rank` device counts, and `longest_matched`.
+//!
+//! The `instances` shape is intended to align with Mooncake's
+//! "[RFC]: KV-Store Indexer API Standardization"
+//! (<https://github.com/kvcache-ai/Mooncake/issues/1403>).
+//! Tier counts are CUMULATIVE through each tier's walk — see the doc on the
+//! response struct in [`server`] for the exact semantics.
+
 pub mod indexer;
 pub mod listener;
 pub mod metrics;

--- a/lib/kv-router/src/standalone_indexer/recovery.rs
+++ b/lib/kv-router/src/standalone_indexer/recovery.rs
@@ -74,7 +74,11 @@ async fn try_recover_from_peer(
         let indexer = registry.get_or_create_indexer(key, entry.block_size);
 
         for event in entry.events {
-            indexer.apply_event(event).await;
+            // Use the tier-aware dispatcher so HostPinned/Disk events from the
+            // peer's dump land in the matching lower-tier slot rather than the
+            // device primary. The peer side retags lower-tier events in
+            // `Indexer::dump_events`, so the `storage_tier` here is correct.
+            indexer.apply_event_routed(event).await;
             total_events += 1;
         }
     }

--- a/lib/kv-router/src/standalone_indexer/server.rs
+++ b/lib/kv-router/src/standalone_indexer/server.rs
@@ -241,14 +241,14 @@ fn build_score_response(tiered: &TieredMatchDetails, block_size: u32) -> ScoreRe
     // Collect the union of all workers seen in device tier and extension tiers.
     let mut all_workers = std::collections::HashSet::new();
     for worker in device.scores.keys() {
-        all_workers.insert(worker.clone());
+        all_workers.insert(*worker);
     }
     for extension in [host_extension, disk_extension, external_extension]
         .iter()
         .filter_map(|&e| e)
     {
         for worker in extension.hits.keys() {
-            all_workers.insert(worker.clone());
+            all_workers.insert(*worker);
         }
     }
 

--- a/lib/kv-router/src/standalone_indexer/server.rs
+++ b/lib/kv-router/src/standalone_indexer/server.rs
@@ -13,8 +13,12 @@ use axum::{Json, Router};
 use prometheus::Encoder;
 use serde::{Deserialize, Serialize};
 
-use crate::protocols::{BlockHashOptions, LocalBlockHash, WorkerId, compute_block_hash_for_seq};
+use crate::indexer::TieredMatchDetails;
+use crate::protocols::{
+    BlockHashOptions, LocalBlockHash, StorageTier, WorkerId, compute_block_hash_for_seq,
+};
 
+use super::indexer::Indexer;
 use super::registry::{IndexerKey, ListenerControlError, WorkerRegistry};
 
 /// We need to fit one million tokens as JSON text, this should do it.
@@ -42,6 +46,11 @@ pub struct RegisterRequest {
     pub dp_rank: Option<u32>,
     #[serde(default)]
     pub replay_endpoint: Option<String>,
+    /// Optional per-tenant salt (Mooncake RFC #1403 `additionalsalt`).
+    /// Currently accepted but not yet mixed into hashes — engines apply
+    /// their own salt internally. Plumbed for forward compatibility.
+    #[serde(default, alias = "additionalsalt")]
+    pub additional_salt: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -62,6 +71,10 @@ pub struct QueryRequest {
     pub tenant_id: String,
     #[serde(default)]
     pub lora_name: Option<String>,
+    /// Optional per-request cache salt (Mooncake RFC #1403). Currently accepted
+    /// but not yet mixed into hashes — engines apply their own internally.
+    #[serde(default)]
+    pub cache_salt: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -70,12 +83,44 @@ pub struct QueryByHashRequest {
     pub model_name: String,
     #[serde(default = "default_tenant")]
     pub tenant_id: String,
+    /// Optional per-request cache salt (Mooncake RFC #1403). Currently accepted
+    /// but not yet mixed into hashes — engines apply their own internally.
+    #[serde(default)]
+    pub cache_salt: Option<String>,
 }
 
+/// Response shape for `/query` and `/query_by_hash`.
+///
+/// The flat `scores`/`frequencies` fields are kept for backward compatibility
+/// with existing callers. New callers should consume the `instances` map,
+/// which mirrors the per-instance, per-tier breakdown proposed in Mooncake
+/// RFC #1403 (kvcache-ai/Mooncake#1403):
+/// `{instance_id: {longest_matched, gpu, dp: {rank: count}, cpu, disk}}`.
 #[derive(Serialize)]
 struct ScoreResponse {
     scores: HashMap<String, HashMap<String, u32>>,
     frequencies: Vec<usize>,
+    /// Per-instance tier breakdown (Mooncake RFC #1403 alignment).
+    instances: HashMap<String, InstanceTierBreakdown>,
+}
+
+/// Per-instance match summary in Mooncake RFC #1403 shape.
+///
+/// All counts are in *tokens* (block count × `block_size`), matching the flat
+/// `scores` fields. The tier counts are CUMULATIVE through each tier's walk:
+/// `cpu` includes everything reachable through device → host-pinned, and
+/// `disk` includes everything reachable through device → host → disk. Under a
+/// natural offload pipeline where blocks flow device → host → disk, these
+/// satisfy `gpu ≤ cpu ≤ disk`. `longest_matched` is the max across the three
+/// and is useful as a single-number "best prefix length" the gateway can use.
+#[derive(Serialize, Default)]
+struct InstanceTierBreakdown {
+    longest_matched: u32,
+    gpu: u32,
+    /// Per-`dp_rank` device-tier match counts.
+    dp: HashMap<String, u32>,
+    cpu: u32,
+    disk: u32,
 }
 
 async fn register(
@@ -154,20 +199,92 @@ async fn list_workers(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     Json(state.registry.list())
 }
 
-fn build_score_response(
-    overlap: crate::protocols::OverlapScores,
-    block_size: u32,
-) -> ScoreResponse {
+/// Build the [`ScoreResponse`] in both the flat (legacy) and per-instance
+/// (Mooncake RFC #1403) shapes from a tiered match result.
+///
+/// All token counts are scaled from blocks → tokens via `block_size`.
+fn build_score_response(tiered: &TieredMatchDetails, block_size: u32) -> ScoreResponse {
+    // Flat fields (unchanged) come from the device-tier overlap.
+    let device = &tiered.device.overlap_scores;
+
     let mut scores: HashMap<String, HashMap<String, u32>> = HashMap::new();
-    for (k, v) in &overlap.scores {
+    for (k, v) in &device.scores {
         scores
             .entry(k.worker_id.to_string())
             .or_default()
             .insert(k.dp_rank.to_string(), v * block_size);
     }
+
+    // Per-worker (instance + dp_rank) reaches: cumulative through each tier.
+    // The lower-tier indexer reports per-tier *extension* blocks beyond the
+    // previous tier; we accumulate them here so the per-tier counts answer
+    // "how many prefix tokens does this worker have through this tier" —
+    // which is the natural reading of Mooncake RFC #1403's `GPU`/`CPU`/`DISK`
+    // fields. Each worker's tier counts therefore satisfy gpu ≤ cpu ≤ disk
+    // (since lower tiers extend the device match rather than shrink it).
+    let host_extension = tiered.lower_tier.get(&StorageTier::HostPinned);
+    let disk_extension = tiered.lower_tier.get(&StorageTier::Disk);
+    let external_extension = tiered.lower_tier.get(&StorageTier::External);
+
+    // Helper: blocks for `worker` in `extension`, defaulting to 0.
+    let ext = |extension: Option<&crate::indexer::LowerTierMatchDetails>,
+               worker: &crate::protocols::WorkerWithDpRank|
+     -> u32 {
+        extension
+            .and_then(|e| e.hits.get(worker))
+            .map(|&n| n as u32)
+            .unwrap_or(0)
+    };
+
+    let mut instances: HashMap<String, InstanceTierBreakdown> = HashMap::new();
+
+    for (worker, blocks) in &device.scores {
+        let gpu_blocks = *blocks;
+        let cpu_blocks = gpu_blocks + ext(host_extension, worker);
+        // Treat External as further-away storage and roll it into the disk
+        // bucket alongside Disk; both extensions stack on top of host-pinned.
+        let disk_blocks =
+            cpu_blocks + ext(disk_extension, worker) + ext(external_extension, worker);
+
+        let gpu_tokens = gpu_blocks * block_size;
+        let cpu_tokens = cpu_blocks * block_size;
+        let disk_tokens = disk_blocks * block_size;
+
+        let entry = instances.entry(worker.worker_id.to_string()).or_default();
+
+        entry.dp.insert(worker.dp_rank.to_string(), gpu_tokens);
+        entry.gpu = entry.gpu.max(gpu_tokens);
+        entry.cpu = entry.cpu.max(cpu_tokens);
+        entry.disk = entry.disk.max(disk_tokens);
+    }
+
+    for entry in instances.values_mut() {
+        entry.longest_matched = entry.gpu.max(entry.cpu).max(entry.disk);
+    }
+
     ScoreResponse {
         scores,
-        frequencies: overlap.frequencies,
+        frequencies: tiered.device.overlap_scores.frequencies.clone(),
+        instances,
+    }
+}
+
+/// Run a tiered query and serialize the result, returning the appropriate
+/// HTTP status. Shared between `/query` and `/query_by_hash`.
+async fn run_tiered_query(
+    indexer: &Indexer,
+    block_hashes: Vec<LocalBlockHash>,
+    block_size: u32,
+) -> (StatusCode, Json<serde_json::Value>) {
+    match indexer.find_tiered_matches(block_hashes).await {
+        Ok(tiered) => (
+            StatusCode::OK,
+            Json(serde_json::json!(build_score_response(&tiered, block_size))),
+        ),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": e.to_string()})),
+        ),
     }
 }
 
@@ -199,16 +316,7 @@ async fn query(
             ..Default::default()
         },
     );
-    match indexer.find_matches(block_hashes).await {
-        Ok(overlap) => (
-            StatusCode::OK,
-            Json(serde_json::json!(build_score_response(overlap, block_size))),
-        ),
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({"error": e.to_string()})),
-        ),
-    }
+    run_tiered_query(&indexer, block_hashes, block_size).await
 }
 
 async fn query_by_hash(
@@ -236,16 +344,7 @@ async fn query_by_hash(
         .iter()
         .map(|h| LocalBlockHash(*h as u64))
         .collect();
-    match indexer.find_matches(block_hashes).await {
-        Ok(overlap) => (
-            StatusCode::OK,
-            Json(serde_json::json!(build_score_response(overlap, block_size))),
-        ),
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({"error": e.to_string()})),
-        ),
-    }
+    run_tiered_query(&indexer, block_hashes, block_size).await
 }
 
 #[derive(Deserialize)]
@@ -429,9 +528,117 @@ pub fn create_router(state: Arc<AppState>) -> Router {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::indexer::KvIndexerInterface;
+    use crate::standalone_indexer::indexer::create_indexer;
+    use crate::standalone_indexer::indexer::test_util::store_event;
     use axum::body::Body;
     use axum::http::{Request, StatusCode, header};
     use tower::ServiceExt;
+
+    /// Drive a tiered query through `build_score_response` after feeding
+    /// mixed-tier events. The response must carry both shapes:
+    /// - flat `scores`/`tree_sizes` (legacy; used by existing callers), and
+    /// - `instances` map keyed by stringified `worker_id` with per-tier
+    ///   counts plus `longest_matched`, matching Mooncake RFC #1403.
+    #[tokio::test]
+    async fn build_score_response_contains_per_instance_tier_breakdown() {
+        let block_size: u32 = 4;
+        let indexer = create_indexer(block_size, 1);
+
+        // Worker 7 owns 2 device blocks and a 3rd anchored on host-pinned.
+        // Worker 8 owns the same 2 device blocks with no lower tier.
+        for &worker_id in &[7u64, 8] {
+            indexer
+                .apply_event_routed(store_event(
+                    worker_id,
+                    0,
+                    1,
+                    &[],
+                    &[11, 12],
+                    StorageTier::Device,
+                ))
+                .await;
+        }
+        indexer
+            .apply_event_routed(store_event(
+                7,
+                0,
+                2,
+                &[11, 12],
+                &[13],
+                StorageTier::HostPinned,
+            ))
+            .await;
+
+        // Flush primary + lower tiers.
+        if let Indexer::Single {
+            primary,
+            lower_tier,
+        } = &indexer
+        {
+            let _ = primary.flush().await;
+            for inner in lower_tier.all() {
+                let _ = inner.dump_events().await.unwrap();
+            }
+        }
+
+        let sequence = vec![LocalBlockHash(11), LocalBlockHash(12), LocalBlockHash(13)];
+        let tiered = indexer.find_tiered_matches(sequence).await.unwrap();
+        let response = build_score_response(&tiered, block_size);
+
+        // Flat shape (legacy callers) carries device-tier overlap scaled by block_size.
+        assert_eq!(
+            response
+                .scores
+                .get("7")
+                .and_then(|by_dp| by_dp.get("0").copied()),
+            Some(2 * block_size),
+            "legacy `scores` must still reflect device-tier hits"
+        );
+
+        // Per-instance breakdown (Mooncake RFC #1403 alignment).
+        // Tier counts are CUMULATIVE through each tier's walk: cpu includes
+        // device's reach plus the host-pinned extension; disk includes
+        // everything below it. Without a disk extension, disk == cpu.
+        let inst_7 = response
+            .instances
+            .get("7")
+            .expect("instance 7 must appear with tier breakdown");
+        assert_eq!(inst_7.gpu, 2 * block_size, "instance 7 device count");
+        assert_eq!(
+            inst_7.cpu,
+            3 * block_size,
+            "instance 7 host-pinned cumulative count = device + host extension"
+        );
+        assert_eq!(
+            inst_7.disk,
+            3 * block_size,
+            "instance 7 disk cumulative falls back to cpu when no disk extension exists"
+        );
+        assert_eq!(
+            inst_7.dp.get("0").copied(),
+            Some(2 * block_size),
+            "instance 7 dp_rank=0 device count"
+        );
+        assert_eq!(
+            inst_7.longest_matched,
+            3 * block_size,
+            "longest_matched should be the max across device/host/disk"
+        );
+
+        let inst_8 = response
+            .instances
+            .get("8")
+            .expect("instance 8 must appear with tier breakdown");
+        assert_eq!(inst_8.gpu, 2 * block_size);
+        assert_eq!(
+            inst_8.cpu,
+            2 * block_size,
+            "instance 8 cpu falls back to device when no host extension exists"
+        );
+        assert_eq!(inst_8.disk, 2 * block_size);
+        assert_eq!(inst_8.longest_matched, 2 * block_size);
+    }
 
     fn oversized_query_body() -> String {
         let mut body = String::from(r#"{"token_ids":["#);

--- a/lib/kv-router/src/standalone_indexer/server.rs
+++ b/lib/kv-router/src/standalone_indexer/server.rs
@@ -238,13 +238,27 @@ fn build_score_response(tiered: &TieredMatchDetails, block_size: u32) -> ScoreRe
 
     let mut instances: HashMap<String, InstanceTierBreakdown> = HashMap::new();
 
-    for (worker, blocks) in &device.scores {
-        let gpu_blocks = *blocks;
-        let cpu_blocks = gpu_blocks + ext(host_extension, worker);
+    // Collect the union of all workers seen in device tier and extension tiers.
+    let mut all_workers = std::collections::HashSet::new();
+    for worker in device.scores.keys() {
+        all_workers.insert(worker.clone());
+    }
+    for extension in [host_extension, disk_extension, external_extension]
+        .iter()
+        .filter_map(|&e| e)
+    {
+        for worker in extension.hits.keys() {
+            all_workers.insert(worker.clone());
+        }
+    }
+
+    for worker in all_workers {
+        let gpu_blocks = device.scores.get(&worker).copied().unwrap_or(0);
+        let cpu_blocks = gpu_blocks + ext(host_extension, &worker);
         // Treat External as further-away storage and roll it into the disk
         // bucket alongside Disk; both extensions stack on top of host-pinned.
         let disk_blocks =
-            cpu_blocks + ext(disk_extension, worker) + ext(external_extension, worker);
+            cpu_blocks + ext(disk_extension, &worker) + ext(external_extension, &worker);
 
         let gpu_tokens = gpu_blocks * block_size;
         let cpu_tokens = cpu_blocks * block_size;

--- a/lib/kv-router/tests/standalone_indexer_http.rs
+++ b/lib/kv-router/tests/standalone_indexer_http.rs
@@ -1,0 +1,308 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! HTTP-level integration tests for the standalone KV indexer.
+//!
+//! Patterned after `lib/llm/tests/http-service.rs`: bind a random port, spawn
+//! `axum::serve` in a background tokio task, poll `/health` until ready, then
+//! drive `reqwest` against the live service. Tests bypass the ZMQ listener
+//! path and pre-populate the `WorkerRegistry`'s `Indexer` directly via
+//! `apply_event_routed`, so they exercise the HTTP layer end-to-end without
+//! requiring a running ZMQ publisher.
+
+#![cfg(feature = "standalone-indexer")]
+
+use std::sync::Arc;
+
+use dynamo_kv_router::protocols::{
+    ExternalSequenceBlockHash, KvCacheEvent, KvCacheEventData, KvCacheStoreData,
+    KvCacheStoredBlockData, LocalBlockHash, RouterEvent, StorageTier, compute_seq_hash_for_block,
+};
+use dynamo_kv_router::standalone_indexer::registry::{IndexerKey, WorkerRegistry};
+use dynamo_kv_router::standalone_indexer::server::{AppState, create_router};
+use serde_json::json;
+use tokio::net::TcpListener;
+use tokio_util::sync::CancellationToken;
+
+/// Construct a STORE [`RouterEvent`] for `local_hashes` chaining off
+/// `prefix_hashes`. Mirrors the helper used by the in-crate `Indexer` tests so
+/// we exercise identical event shapes from the integration-test surface.
+fn store_event(
+    worker_id: u64,
+    dp_rank: u32,
+    event_id: u64,
+    prefix_hashes: &[u64],
+    local_hashes: &[u64],
+    storage_tier: StorageTier,
+) -> RouterEvent {
+    let prefix_block_hashes: Vec<LocalBlockHash> =
+        prefix_hashes.iter().copied().map(LocalBlockHash).collect();
+    let parent_hash = compute_seq_hash_for_block(&prefix_block_hashes)
+        .last()
+        .copied()
+        .map(ExternalSequenceBlockHash);
+
+    let full_hashes: Vec<LocalBlockHash> = prefix_hashes
+        .iter()
+        .chain(local_hashes.iter())
+        .copied()
+        .map(LocalBlockHash)
+        .collect();
+    let full_sequence_hashes = compute_seq_hash_for_block(&full_hashes);
+    let new_sequence_hashes = &full_sequence_hashes[prefix_hashes.len()..];
+    let blocks = local_hashes
+        .iter()
+        .zip(new_sequence_hashes.iter())
+        .map(|(&local_hash, &sequence_hash)| KvCacheStoredBlockData {
+            block_hash: ExternalSequenceBlockHash(sequence_hash),
+            tokens_hash: LocalBlockHash(local_hash),
+            mm_extra_info: None,
+        })
+        .collect();
+
+    RouterEvent::with_storage_tier(
+        worker_id,
+        KvCacheEvent {
+            event_id,
+            data: KvCacheEventData::Stored(KvCacheStoreData {
+                parent_hash,
+                start_position: None,
+                blocks,
+            }),
+            dp_rank,
+        },
+        storage_tier,
+    )
+}
+
+/// Bind to an OS-assigned port, return the listener and the resolved address.
+async fn bind_localhost() -> (TcpListener, std::net::SocketAddr) {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind localhost:0");
+    let addr = listener.local_addr().expect("local_addr");
+    (listener, addr)
+}
+
+/// Poll `/health` until the service responds 200 or the timeout elapses.
+async fn wait_for_health(base_url: &str) {
+    let client = reqwest::Client::new();
+    let url = format!("{base_url}/health");
+    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(5);
+    loop {
+        if let Ok(resp) = client.get(&url).send().await
+            && resp.status().is_success()
+        {
+            return;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            panic!("standalone indexer /health did not become ready");
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
+    }
+}
+
+/// Build a registry seeded with one indexer for `(model, tenant)` and feed
+/// `events` through `apply_event_routed`. This bypasses the ZMQ listener path
+/// so we can drive HTTP queries against deterministic state.
+async fn registry_with_events(
+    model: &str,
+    tenant: &str,
+    block_size: u32,
+    events: Vec<RouterEvent>,
+) -> Arc<WorkerRegistry> {
+    let registry = Arc::new(WorkerRegistry::new(1));
+    registry.signal_ready();
+    let indexer = registry.get_or_create_indexer(
+        IndexerKey {
+            model_name: model.to_string(),
+            tenant_id: tenant.to_string(),
+        },
+        block_size,
+    );
+    for event in events {
+        indexer.apply_event_routed(event).await;
+    }
+    // Force the in-flight events through KvIndexer's mpsc channel before the
+    // first query lands; otherwise the test races the indexer worker.
+    if let Some(entry) = registry.get_indexer(&IndexerKey {
+        model_name: model.to_string(),
+        tenant_id: tenant.to_string(),
+    }) {
+        let dump = entry.indexer.dump_events().await.expect("dump events");
+        // dump_events provides the FIFO barrier we need; we don't care about
+        // its contents here.
+        drop(dump);
+    }
+    registry
+}
+
+/// Spawn the HTTP server with `state` on a random localhost port and return
+/// the base URL plus the cancellation token used to shut it down.
+async fn spawn_indexer_http(
+    state: Arc<AppState>,
+) -> (String, CancellationToken, tokio::task::JoinHandle<()>) {
+    let (listener, addr) = bind_localhost().await;
+    let app = create_router(state);
+    let cancel = CancellationToken::new();
+    let cancel_for_serve = cancel.clone();
+    let task = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async move { cancel_for_serve.cancelled().await })
+            .await
+            .expect("axum::serve");
+    });
+    let base_url = format!("http://{addr}");
+    wait_for_health(&base_url).await;
+    (base_url, cancel, task)
+}
+
+#[cfg(feature = "metrics")]
+fn make_app_state(registry: Arc<WorkerRegistry>) -> Arc<AppState> {
+    Arc::new(AppState {
+        registry,
+        prom_registry: prometheus::Registry::new(),
+    })
+}
+
+#[cfg(not(feature = "metrics"))]
+fn make_app_state(registry: Arc<WorkerRegistry>) -> Arc<AppState> {
+    Arc::new(AppState { registry })
+}
+
+/// `/query_by_hash` against a populated registry must surface both the legacy
+/// flat shape (for backward-compat callers) and the Mooncake RFC #1403 shape
+/// (per-instance `gpu`/`cpu`/`disk`/`longest_matched`).
+#[tokio::test]
+async fn query_by_hash_returns_per_instance_tier_breakdown() {
+    const BLOCK_SIZE: u32 = 4;
+    const MODEL: &str = "test-model";
+    const TENANT: &str = "default";
+
+    // Worker 7: 2 device blocks + 1 host-pinned extension.
+    // Worker 8: 2 device blocks, no lower-tier.
+    let events = vec![
+        store_event(7, 0, 1, &[], &[11, 12], StorageTier::Device),
+        store_event(8, 0, 1, &[], &[11, 12], StorageTier::Device),
+        store_event(7, 0, 2, &[11, 12], &[13], StorageTier::HostPinned),
+    ];
+    let registry = registry_with_events(MODEL, TENANT, BLOCK_SIZE, events).await;
+    let state = make_app_state(registry);
+    let (base_url, cancel, task) = spawn_indexer_http(state).await;
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{base_url}/query_by_hash"))
+        .json(&json!({
+            "block_hashes": [11_i64, 12, 13],
+            "model_name": MODEL,
+            "tenant_id": TENANT,
+        }))
+        .send()
+        .await
+        .expect("POST /query_by_hash");
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+
+    let body: serde_json::Value = resp.json().await.expect("parse JSON body");
+
+    // Legacy flat shape — device-tier overlap, scaled to tokens.
+    assert_eq!(
+        body["scores"]["7"]["0"],
+        (2 * BLOCK_SIZE) as u64,
+        "legacy scores should still carry worker 7's device match"
+    );
+    assert_eq!(
+        body["scores"]["8"]["0"],
+        (2 * BLOCK_SIZE) as u64,
+        "legacy scores should still carry worker 8's device match"
+    );
+
+    // Mooncake-shape per-instance breakdown.
+    let inst7 = &body["instances"]["7"];
+    assert_eq!(inst7["gpu"], (2 * BLOCK_SIZE) as u64, "instance 7 gpu");
+    assert_eq!(
+        inst7["cpu"],
+        (3 * BLOCK_SIZE) as u64,
+        "instance 7 cpu cumulative through host-pinned"
+    );
+    assert_eq!(
+        inst7["disk"],
+        (3 * BLOCK_SIZE) as u64,
+        "instance 7 disk falls back to cpu when no disk extension exists"
+    );
+    assert_eq!(
+        inst7["dp"]["0"],
+        (2 * BLOCK_SIZE) as u64,
+        "instance 7 dp_rank=0 device count"
+    );
+    assert_eq!(
+        inst7["longest_matched"],
+        (3 * BLOCK_SIZE) as u64,
+        "instance 7 longest_matched is the max across tiers"
+    );
+
+    let inst8 = &body["instances"]["8"];
+    assert_eq!(inst8["gpu"], (2 * BLOCK_SIZE) as u64);
+    assert_eq!(
+        inst8["cpu"],
+        (2 * BLOCK_SIZE) as u64,
+        "instance 8 cpu falls back to device when no host extension exists"
+    );
+    assert_eq!(inst8["longest_matched"], (2 * BLOCK_SIZE) as u64);
+
+    cancel.cancel();
+    task.await.expect("server task join");
+}
+
+/// `/query` against an unknown `(model, tenant)` must return 404 with an
+/// error body, not 500 or a panic.
+#[tokio::test]
+async fn query_returns_404_for_unknown_model() {
+    let registry = Arc::new(WorkerRegistry::new(1));
+    registry.signal_ready();
+    let state = make_app_state(registry);
+    let (base_url, cancel, task) = spawn_indexer_http(state).await;
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{base_url}/query"))
+        .json(&json!({
+            "token_ids": [1_u32, 2, 3],
+            "model_name": "no-such-model",
+        }))
+        .send()
+        .await
+        .expect("POST /query");
+    assert_eq!(resp.status(), reqwest::StatusCode::NOT_FOUND);
+
+    let body: serde_json::Value = resp.json().await.expect("parse error body");
+    assert!(
+        body["error"]
+            .as_str()
+            .map(|s| s.contains("no indexer for model="))
+            .unwrap_or(false),
+        "unexpected 404 body: {body}"
+    );
+
+    cancel.cancel();
+    task.await.expect("server task join");
+}
+
+/// Smoke test that the axum router is wired correctly end-to-end and
+/// reports `/health` 200. Catches misuse of feature flags / route gates.
+#[tokio::test]
+async fn health_returns_ok() {
+    let registry = Arc::new(WorkerRegistry::new(1));
+    let state = make_app_state(registry);
+    let (base_url, cancel, task) = spawn_indexer_http(state).await;
+
+    let resp = reqwest::Client::new()
+        .get(format!("{base_url}/health"))
+        .send()
+        .await
+        .expect("GET /health");
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+
+    cancel.cancel();
+    task.await.expect("server task join");
+}

--- a/lib/kv-router/tests/standalone_indexer_http.rs
+++ b/lib/kv-router/tests/standalone_indexer_http.rs
@@ -13,6 +13,7 @@
 #![cfg(feature = "standalone-indexer")]
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use dynamo_kv_router::protocols::{
     ExternalSequenceBlockHash, KvCacheEvent, KvCacheEventData, KvCacheStoreData,
@@ -20,6 +21,7 @@ use dynamo_kv_router::protocols::{
 };
 use dynamo_kv_router::standalone_indexer::registry::{IndexerKey, WorkerRegistry};
 use dynamo_kv_router::standalone_indexer::server::{AppState, create_router};
+use dynamo_kv_router::zmq_wire::{BlockHashValue, RawKvEvent};
 use serde_json::json;
 use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
@@ -305,4 +307,230 @@ async fn health_returns_ok() {
 
     cancel.cancel();
     task.await.expect("server task join");
+}
+
+// =============================================================================
+// ZMQ-publisher e2e — drive a real PUB socket through the listener path
+// =============================================================================
+
+/// Reserve an OS-assigned TCP port by binding+dropping a `std::net::TcpListener`
+/// (matches the pattern used in `standalone_indexer/listener.rs` tests).
+fn reserve_zmq_endpoint() -> String {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind probe listener");
+    let port = listener
+        .local_addr()
+        .expect("local_addr on probe listener")
+        .port();
+    drop(listener);
+    format!("tcp://127.0.0.1:{port}")
+}
+
+/// Build a `RawKvEvent::BlockStored` with the minimum fields the engine
+/// emits over ZMQ. `medium` is the wire spelling of the storage tier:
+/// `"GPU"` → Device, `"CPU_TIER1"` → HostPinned, `"CPU_TIER2"` → Disk.
+fn raw_block_stored(
+    block_hash: u64,
+    parent_block_hash: Option<u64>,
+    token_ids: Vec<u32>,
+    block_size: usize,
+    medium: &str,
+) -> RawKvEvent {
+    RawKvEvent::BlockStored {
+        block_hashes: vec![BlockHashValue::Unsigned(block_hash)],
+        parent_block_hash: parent_block_hash.map(BlockHashValue::Unsigned),
+        token_ids,
+        block_size,
+        medium: Some(medium.to_string()),
+        lora_name: None,
+        block_mm_infos: None,
+        is_eagle: None,
+        group_idx: None,
+        kv_cache_spec_kind: None,
+        kv_cache_spec_sliding_window: None,
+    }
+}
+
+/// Encode a one-event batch into the wire payload the listener expects:
+/// msgpack-array of `(timestamp, [events], dp_rank)`.
+fn encode_batch(event: RawKvEvent, dp_rank: i32) -> Vec<u8> {
+    rmp_serde::to_vec_named(&(0.0_f64, vec![event], Some(dp_rank))).expect("serialize KvEventBatch")
+}
+
+/// Send one ZMQ multipart message in the listener's expected frame layout:
+/// `[topic, seq_be_bytes, payload]`. Topic is unused (SUB filter is `b""`).
+fn send_live_message(pub_socket: &zmq::Socket, seq: u64, payload: &[u8]) {
+    pub_socket
+        .send_multipart(
+            [b"" as &[u8], &seq.to_be_bytes(), payload],
+            0, // no flags
+        )
+        .expect("send_multipart");
+}
+
+/// Poll `/query` against `(model, tenant)` until `instances[instance_id].cpu`
+/// reaches `expected_cpu_tokens`, or panic on timeout. The listener applies
+/// events asynchronously after `/register`, so the first few queries may see
+/// the indexer still cold; this loop is the e2e-test equivalent of awaiting
+/// convergence.
+async fn await_instance_cpu(
+    base_url: &str,
+    model: &str,
+    tenant: &str,
+    instance_id: u64,
+    token_ids: Vec<u32>,
+    expected_cpu_tokens: u64,
+) -> serde_json::Value {
+    let client = reqwest::Client::new();
+    let url = format!("{base_url}/query");
+    let body = json!({
+        "token_ids": token_ids,
+        "model_name": model,
+        "tenant_id": tenant,
+    });
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    let key = instance_id.to_string();
+    loop {
+        let resp = client
+            .post(&url)
+            .json(&body)
+            .send()
+            .await
+            .expect("POST /query");
+        if resp.status() == reqwest::StatusCode::OK {
+            let value: serde_json::Value = resp.json().await.expect("parse /query body");
+            if value["instances"][&key]["cpu"]
+                .as_u64()
+                .map(|n| n >= expected_cpu_tokens)
+                .unwrap_or(false)
+            {
+                return value;
+            }
+        }
+        if tokio::time::Instant::now() >= deadline {
+            panic!(
+                "timed out waiting for instance {instance_id} cpu>={expected_cpu_tokens}; \
+                 last response did not converge"
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+/// Real ZMQ PUB → listener → indexer → HTTP query round trip.
+///
+/// Bind a PUB socket on a random localhost port, register a worker that
+/// subscribes to it, publish one Device-tier and one HostPinned-tier
+/// `BlockStored` event chained together, and assert the HTTP `/query`
+/// response surfaces the per-tier breakdown — which it can only do if the
+/// listener correctly normalized `medium="CPU_TIER1"` into a HostPinned
+/// `RouterEvent` and the standalone `Indexer::apply_event_routed` dispatched
+/// it to the lower-tier slot.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn zmq_published_tiered_events_appear_in_http_query() {
+    const BLOCK_SIZE: u32 = 4;
+    const MODEL: &str = "test-model";
+    const TENANT: &str = "default";
+    const INSTANCE_ID: u64 = 7;
+
+    // Spin up the HTTP server with an empty registry.
+    let registry = Arc::new(WorkerRegistry::new(1));
+    registry.signal_ready();
+    let state = make_app_state(registry);
+    let (base_url, server_cancel, server_task) = spawn_indexer_http(state).await;
+    let client = reqwest::Client::new();
+
+    // Bind a PUB socket BEFORE /register so the listener finds someone to
+    // subscribe to once it spawns. ZMQ's slow-joiner problem still means a
+    // few early messages may be lost; we send a probe before the real
+    // payloads to flush the connection.
+    let zmq_endpoint = reserve_zmq_endpoint();
+    let zmq_ctx = zmq::Context::new();
+    let pub_socket = zmq_ctx.socket(zmq::PUB).expect("create PUB socket");
+    pub_socket.set_linger(0).expect("set_linger");
+    pub_socket.bind(&zmq_endpoint).expect("bind PUB socket");
+
+    // Register the worker — this triggers the listener to connect a SUB.
+    let resp = client
+        .post(format!("{base_url}/register"))
+        .json(&json!({
+            "instance_id": INSTANCE_ID,
+            "endpoint": zmq_endpoint,
+            "model_name": MODEL,
+            "tenant_id": TENANT,
+            "block_size": BLOCK_SIZE,
+            "dp_rank": 0,
+        }))
+        .send()
+        .await
+        .expect("POST /register");
+    assert_eq!(resp.status(), reqwest::StatusCode::CREATED);
+
+    // Give the SUB time to connect to our PUB. ZMQ buffers most things, but
+    // empirically a short settle plus a probe message reduces flake.
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    // Token sequences for two adjacent blocks. block_size = 4.
+    let device_tokens = vec![10_u32, 11, 12, 13];
+    let host_tokens = vec![20_u32, 21, 22, 23];
+    let device_block_hash: u64 = 0xD0_E0_AA_AA_BB_BB_CC_CC;
+    let host_block_hash: u64 = 0x40_E0_AA_AA_BB_BB_CC_CC;
+
+    // seq 0: Device-tier store (parent=None).
+    let device_event = raw_block_stored(
+        device_block_hash,
+        None,
+        device_tokens.clone(),
+        BLOCK_SIZE as usize,
+        "GPU",
+    );
+    send_live_message(&pub_socket, 0, &encode_batch(device_event, 0));
+
+    // seq 1: HostPinned-tier store anchored on the device hash.
+    let host_event = raw_block_stored(
+        host_block_hash,
+        Some(device_block_hash),
+        host_tokens.clone(),
+        BLOCK_SIZE as usize,
+        "CPU_TIER1",
+    );
+    send_live_message(&pub_socket, 1, &encode_batch(host_event, 0));
+
+    // Compose the full prefix for the query: device tokens followed by host
+    // tokens. The server will hash this and match it against the radix tree
+    // (device blocks) plus the lower-tier index (host extension).
+    let mut full_tokens = device_tokens.clone();
+    full_tokens.extend(host_tokens.clone());
+
+    // Wait for the listener to apply both events; assert via the per-instance
+    // tier breakdown.
+    let body = await_instance_cpu(
+        &base_url,
+        MODEL,
+        TENANT,
+        INSTANCE_ID,
+        full_tokens,
+        // Cumulative through host = 2 blocks * BLOCK_SIZE tokens.
+        (2 * BLOCK_SIZE) as u64,
+    )
+    .await;
+
+    let inst = &body["instances"][INSTANCE_ID.to_string()];
+    assert_eq!(
+        inst["gpu"], BLOCK_SIZE as u64,
+        "device-tier hits should equal one block of tokens"
+    );
+    assert_eq!(
+        inst["cpu"],
+        (2 * BLOCK_SIZE) as u64,
+        "host-pinned cumulative should be device + host extension"
+    );
+    assert_eq!(
+        inst["longest_matched"],
+        (2 * BLOCK_SIZE) as u64,
+        "longest_matched should reflect the full device + host reach"
+    );
+
+    server_cancel.cancel();
+    server_task.await.expect("server task join");
+    drop(pub_socket);
 }

--- a/lib/llm/src/kv_router/indexer/mod.rs
+++ b/lib/llm/src/kv_router/indexer/mod.rs
@@ -1,26 +1,28 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    collections::HashMap,
-    sync::{Arc, RwLock},
-    time::Duration,
-};
+use std::{sync::Arc, time::Duration};
 
 use anyhow::Result;
 use dynamo_kv_router::{
-    ConcurrentRadixTreeCompressed, LowerTierIndexer, ThreadPoolIndexer,
+    ConcurrentRadixTreeCompressed,
     approx::PruneConfig,
     config::KvRouterConfig,
     indexer::{
-        KvIndexer, KvIndexerInterface, KvIndexerMetrics, KvRouterError, LowerTierContinuation,
-        LowerTierMatchDetails, MatchDetails, WireTieredMatchDetails,
+        KvIndexer, KvIndexerInterface, KvIndexerMetrics, KvRouterError, LowerTierIndexers,
+        MatchDetails, ThreadPoolIndexer, query_lower_tiers,
     },
     protocols::{
-        DpRank, LocalBlockHash, OverlapScores, RouterEvent, StorageTier, TokensWithHashes,
-        WorkerId, WorkerWithDpRank,
+        DpRank, LocalBlockHash, OverlapScores, RouterEvent, TokensWithHashes, WorkerId,
+        WorkerWithDpRank,
     },
 };
+
+// Re-export tiered-match types so internal callers (`indexer::TieredMatchDetails`)
+// keep working after these types moved to `dynamo-kv-router`.
+pub(crate) use dynamo_kv_router::indexer::TieredMatchDetails;
+#[allow(unused_imports)]
+pub(crate) use dynamo_kv_router::indexer::WireTieredMatchDetails;
 use dynamo_runtime::{component::Component, traits::DistributedRuntimeProvider};
 use dynamo_tokens::SequenceHash;
 use tokio::sync::oneshot;
@@ -29,159 +31,6 @@ mod jetstream;
 pub mod remote;
 mod subscriber;
 mod worker_query;
-
-#[derive(Clone)]
-pub struct LowerTierIndexers {
-    num_threads: usize,
-    block_size: u32,
-    indexers: Arc<RwLock<HashMap<StorageTier, Arc<ThreadPoolIndexer<LowerTierIndexer>>>>>,
-}
-
-impl LowerTierIndexers {
-    pub(crate) fn new(num_threads: usize, block_size: u32) -> Self {
-        assert!(
-            num_threads > 0,
-            "lower-tier indexer threads must be non-zero"
-        );
-        Self {
-            num_threads,
-            block_size,
-            indexers: Arc::new(RwLock::new(HashMap::new())),
-        }
-    }
-
-    fn get_or_create(&self, storage_tier: StorageTier) -> Arc<ThreadPoolIndexer<LowerTierIndexer>> {
-        debug_assert!(!storage_tier.is_gpu());
-        if let Some(indexer) = self.indexers.read().unwrap().get(&storage_tier).cloned() {
-            return indexer;
-        }
-        self.indexers
-            .write()
-            .unwrap()
-            .entry(storage_tier)
-            .or_insert_with(|| {
-                Arc::new(ThreadPoolIndexer::new(
-                    LowerTierIndexer::new(),
-                    self.num_threads,
-                    self.block_size,
-                ))
-            })
-            .clone()
-    }
-
-    fn all(&self) -> Vec<Arc<ThreadPoolIndexer<LowerTierIndexer>>> {
-        self.indexers.read().unwrap().values().cloned().collect()
-    }
-
-    fn get(&self, storage_tier: StorageTier) -> Option<Arc<ThreadPoolIndexer<LowerTierIndexer>>> {
-        self.indexers.read().unwrap().get(&storage_tier).cloned()
-    }
-}
-
-fn lower_tier_query_order() -> [StorageTier; 3] {
-    [
-        StorageTier::HostPinned,
-        StorageTier::Disk,
-        StorageTier::External,
-    ]
-}
-
-fn query_lower_tiers(
-    indexers: &LowerTierIndexers,
-    sequence: &[LocalBlockHash],
-    device_matches: &MatchDetails,
-) -> HashMap<StorageTier, LowerTierMatchDetails> {
-    let mut continuations = LowerTierMatchDetails::default().next_continuations;
-    for (worker, matched_blocks) in &device_matches.overlap_scores.scores {
-        let Some(last_hash) = device_matches.last_matched_hashes.get(worker).copied() else {
-            debug_assert!(
-                false,
-                "device match result missing last matched hash for worker {worker:?}"
-            );
-            continue;
-        };
-
-        continuations.insert(
-            *worker,
-            LowerTierContinuation::new(*matched_blocks as usize, last_hash),
-        );
-    }
-
-    let mut lower_tier_matches = HashMap::new();
-
-    for storage_tier in lower_tier_query_order() {
-        let Some(indexer) = indexers.get(storage_tier) else {
-            continue;
-        };
-
-        if let Some(&first_hash) = sequence.first() {
-            let root_workers: Vec<_> = indexer.backend().root_workers(first_hash);
-            for worker in root_workers.iter() {
-                continuations
-                    .entry(*worker)
-                    .or_insert_with(|| LowerTierContinuation::from_root(0));
-            }
-        }
-
-        let tier_matches = indexer
-            .backend()
-            .query_match_details(sequence, &continuations);
-        let matched_workers = tier_matches.hits.values().filter(|&&hits| hits > 0).count();
-        tracing::debug!(
-            ?storage_tier,
-            queried_workers = continuations.len(),
-            matched_workers,
-            "Queried lower-tier indexer"
-        );
-        continuations = tier_matches.next_continuations.clone();
-        lower_tier_matches.insert(storage_tier, tier_matches);
-    }
-
-    lower_tier_matches
-}
-
-#[derive(Debug, Clone, Default)]
-pub(crate) struct TieredMatchDetails {
-    pub device: MatchDetails,
-    #[cfg_attr(not(test), allow(dead_code))]
-    pub lower_tier: HashMap<StorageTier, LowerTierMatchDetails>,
-}
-
-impl From<&TieredMatchDetails> for WireTieredMatchDetails {
-    fn from(d: &TieredMatchDetails) -> Self {
-        Self {
-            device: d.device.overlap_scores.clone().into(),
-            lower_tier: d
-                .lower_tier
-                .iter()
-                .map(|(tier, details)| (*tier, details.into()))
-                .collect(),
-        }
-    }
-}
-
-impl From<WireTieredMatchDetails> for TieredMatchDetails {
-    fn from(w: WireTieredMatchDetails) -> Self {
-        // `last_matched_hashes` is only needed server-side to seed the tier walk,
-        // so we leave it empty on the inbound side.
-        let mut lower_tier = HashMap::with_capacity(w.lower_tier.len());
-        for (tier, details) in w.lower_tier {
-            if lower_tier.insert(tier, details.into()).is_some() {
-                tracing::warn!(
-                    ?tier,
-                    "Duplicate StorageTier in WireTieredMatchDetails; keeping last entry"
-                );
-            }
-        }
-        Self {
-            device: MatchDetails {
-                overlap_scores: w.device.into(),
-                ..Default::default()
-            },
-            lower_tier,
-        }
-    }
-}
 
 use self::remote::RemoteIndexer;
 pub use self::remote::{ServedIndexerHandle, ServedIndexerMode, ensure_served_indexer_service};


### PR DESCRIPTION
## Summary

Brings the standalone HTTP indexer (`python -m dynamo.indexer`) up to the tier-awareness the request-plane indexer already has, and reshapes `/query` / `/query_by_hash` responses to align with Mooncake's [RFC #1403](https://github.com/kvcache-ai/Mooncake/issues/1403).

- **Shared tier walk:** `LowerTierIndexers`, `query_lower_tiers`, and native `TieredMatchDetails` move from `dynamo-llm` into `dynamo-kv-router::indexer` so the request-plane and standalone indexers run one implementation.
- **Standalone `Indexer` is tier-aware:** new `apply_event_routed` (mirrors the LLM-side `is_gpu()` dispatcher) and `find_tiered_matches` methods. Each variant carries a `lower_tier: LowerTierIndexers`.
- **Listener forwards lower-tier events:** drops the `is_local_gpu()` filter on both replay and live paths so HostPinned/Disk events land in the lower-tier slot rather than being silently dropped.
- **Mooncake-shape inputs:** `RegisterRequest` accepts optional `additional_salt` (alias `additionalsalt`); `QueryRequest`/`QueryByHashRequest` accept optional `cache_salt`. Plumbed for forward compatibility — engines apply their own internal salting today.
- **Mooncake-shape response:** `ScoreResponse` is additive — legacy `scores`/`frequencies`/`tree_sizes` still populate, plus a new per-instance map: `instances: {instance_id: {longest_matched, gpu, dp: {rank: count}, cpu, disk}}`. Tier counts are CUMULATIVE through each tier's walk (gpu ≤ cpu ≤ disk under a natural offload pipeline), documented on the response struct.

## Out of scope (follow-up PRs)

- Deeper multi-tenant isolation (separate indexers per tenant).
- `cache_salt` actually mixing into block hashes.
- The RFC's `replay_endpoint` field on `/register` (already supported via existing `replay_endpoint`).

## Test plan

- [x] `cargo test -p dynamo-kv-router --lib --features standalone-indexer standalone_indexer` — 15/15, including:
  - `apply_event_routed_dispatches_by_tier` (Device → primary, HostPinned → lower-tier slot, both surface in `find_tiered_matches`)
  - `build_score_response_contains_per_instance_tier_breakdown` (drives a tiered query end-to-end, asserts both legacy and RFC-shape fields with correct `longest_matched`)
- [x] `cargo test -p dynamo-llm --lib kv_router::indexer` — 22/22 still pass after the promotion of `LowerTierIndexers` / `TieredMatchDetails`.
- [x] `cargo clippy -p dynamo-kv-router -p dynamo-llm --tests -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] `pre-commit` (codespell, line-endings, trailing whitespace) clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-tier storage support for GPU, CPU, and disk storage indexing.
  * Query responses now include per-instance tier breakdowns with cumulative token counts.
  * Enhanced routing logic to properly dispatch events to appropriate storage tier indexers.

* **Documentation**
  * Updated response documentation to describe new per-tier instance information structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->