### PR TITLE
fix(recipes): use --enforce-disagg for GLM-5 frontend args

### DIFF
--- a/recipes/glm-5-nvfp4/sglang/disagg/deploy.yaml
+++ b/recipes/glm-5-nvfp4/sglang/disagg/deploy.yaml
@@ -39,7 +39,7 @@ spec:
           args:
             - -m
             - dynamo.frontend
-            - --no-decode-fallback
+            - --enforce-disagg
           env:
             - name: POD_UID
               valueFrom:


### PR DESCRIPTION
#### Overview:

The GLM-5 SGLang disagg deploy manifest passes a non-existent `--no-decode-fallback` flag to `dynamo.frontend`, which would fail at startup. This PR replaces it with the correct `--enforce-disagg` flag.

#### Details:

In `recipes/glm-5-nvfp4/sglang/disagg/deploy.yaml`, swap `--no-decode-fallback` for `--enforce-disagg` (the actual flag defined in `components/src/dynamo/common/configuration/groups/router_args.py`).

#### Where should the reviewer start?

- `recipes/glm-5-nvfp4/sglang/disagg/deploy.yaml`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- N/A