### PR TITLE
fix(operator): make DGD and DCD preservation structural

### DIFF
--- a/deploy/operator/api/v1alpha1/dynamocomponentdeployment_conversion.go
+++ b/deploy/operator/api/v1alpha1/dynamocomponentdeployment_conversion.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"maps"
 	"slices"
-	"strings"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,11 +36,11 @@ const (
 	annDCDHubSpec     = "nvidia.com/dcd-hub-spec"
 	annDCDSpokeSpec   = "nvidia.com/dcd-spoke-spec"
 	annDCDSpokeStatus = "nvidia.com/dcd-spoke-status"
-	annDCDHubOrigin   = "nvidia.com/dcd-hub-origin"
+
+	preservedDCDEmptyServiceNamePath = "serviceName"
 )
 
 type dcdConversionContext struct {
-	carrier             *annCarrier
 	objectName          string
 	includeOriginSplits bool
 }
@@ -60,17 +59,12 @@ func (src *DynamoComponentDeployment) ConvertTo(dstRaw conversion.Hub) error {
 	if raw, ok := getAnnFromObj(&dst.ObjectMeta, annDCDHubSpec); ok && raw != "" {
 		if spec, ok := restoreDCDHubSpec(raw); ok {
 			preservedHubSpec = &spec
-			delAnnFromObj(&dst.ObjectMeta, annDCDHubSpec)
 		}
 	}
-	hubOrigin := preservedHubSpec != nil || dst.ObjectMeta.Annotations[annDCDHubOrigin] == annotationTrue
-	delAnnFromObj(&dst.ObjectMeta, annDCDHubOrigin)
-	if hubOrigin {
-		scrubDCDAnnotations(&dst.ObjectMeta)
-	}
+	hubOrigin := preservedHubSpec != nil
+	scrubDCDInternalAnnotations(&dst.ObjectMeta)
 
 	ctx := dcdConversionContext{
-		carrier:             newDCDCarrier(&dst.ObjectMeta),
 		objectName:          dst.ObjectMeta.Name,
 		includeOriginSplits: !hubOrigin,
 	}
@@ -80,13 +74,13 @@ func (src *DynamoComponentDeployment) ConvertTo(dstRaw conversion.Hub) error {
 	}
 	var statusSave DynamoComponentDeploymentStatus
 	saveDCDAlphaOnlyStatus(&src.Status, &statusSave)
-	preserveSpoke := !hubOrigin ||
-		!dcdAlphaSpecSaveIsZero(&spokeSave) ||
-		!dcdAlphaStatusSaveIsZero(&statusSave)
+	emptyServiceNameSave := dcdEmptyServiceNameNeedsSave(src, dst)
+	generatedPodTemplateSave := !hubOrigin && dst.Spec.PodTemplate != nil
+	preserveSpec := generatedPodTemplateSave || emptyServiceNameSave || !dcdAlphaSpecSaveIsZero(&spokeSave)
 
 	convertDCDStatusToHub(&src.Status, &dst.Status, nil, nil, ctx)
-	if preserveSpoke {
-		preserveDCDSpoke(&spokeSave, &statusSave, dst)
+	if preserveSpec || !dcdAlphaStatusSaveIsZero(&statusSave) {
+		preserveDCDSpoke(&spokeSave, preserveSpec, emptyServiceNameSave, &statusSave, dst)
 	}
 	return nil
 }
@@ -103,35 +97,44 @@ func convertDCDSpecToHub(src *DynamoComponentDeploymentSpec, dst *v1beta1.Dynamo
 	if restored != nil {
 		preservedShared = &restored.DynamoComponentDeploymentSharedSpec
 	}
-	if preservedShared != nil && preservedShared.PodTemplate != nil {
-		ctx.carrier.set(suffixPodTemplateOrig, annotationTrue)
-	}
 	var sharedSave *DynamoComponentDeploymentSharedSpec
 	if save != nil {
 		sharedSave = &save.DynamoComponentDeploymentSharedSpec
 	}
 	sharedCtx := sharedSpecConversionContext{
-		carrier:             ctx.carrier,
 		includeOriginSplits: ctx.includeOriginSplits,
+		podTemplateOrigin:   preservedShared != nil && preservedShared.PodTemplate != nil,
 	}
 	if err := convertSharedSpecToHub(&src.DynamoComponentDeploymentSharedSpec, &dst.DynamoComponentDeploymentSharedSpec, preservedShared, sharedSave, sharedCtx); err != nil {
 		return err
 	}
 
 	// v1beta1 requires DCD.spec.name. When a v1alpha1-origin DCD omits
-	// ServiceName, fall back to ObjectMeta.Name for schema validity and leave a
-	// marker so ConvertFrom can restore the omitted v1alpha1 field.
-	if dst.ComponentName == "" && ctx.includeOriginSplits {
+	// ServiceName, fall back to ObjectMeta.Name for schema validity. The
+	// sparse spoke save records whether the v1alpha1 field was truly empty.
+	if dst.ComponentName == "" {
 		dst.ComponentName = ctx.objectName
-		ctx.carrier.set(suffixServiceName, "")
+	}
+
+	// Restore target-only fields that the live source cannot represent.
+	if restored != nil && restored.ComponentName == "" && dst.ComponentName == ctx.objectName {
+		dst.ComponentName = ""
 	}
 
 	return nil
 }
 
-func preserveDCDSpoke(specSave *DynamoComponentDeploymentSpec, statusSave *DynamoComponentDeploymentStatus, dst *v1beta1.DynamoComponentDeployment) {
-	if !dcdAlphaSpecSaveIsZero(specSave) {
-		data, err := marshalDCDSpokeSpec(specSave)
+func dcdEmptyServiceNameNeedsSave(src *DynamoComponentDeployment, dst *v1beta1.DynamoComponentDeployment) bool {
+	return src != nil &&
+		dst != nil &&
+		src.Spec.ServiceName == "" &&
+		src.ObjectMeta.Name != "" &&
+		dst.Spec.ComponentName == src.ObjectMeta.Name
+}
+
+func preserveDCDSpoke(specSave *DynamoComponentDeploymentSpec, preserveSpec bool, emptyServiceName bool, statusSave *DynamoComponentDeploymentStatus, dst *v1beta1.DynamoComponentDeployment) {
+	if preserveSpec {
+		data, err := marshalDCDSpokeSpec(specSave, emptyServiceName)
 		if err == nil {
 			setAnnOnObj(&dst.ObjectMeta, annDCDSpokeSpec, string(data))
 		}
@@ -141,27 +144,19 @@ func preserveDCDSpoke(specSave *DynamoComponentDeploymentSpec, statusSave *Dynam
 	}
 }
 
-func fillDCDSpokeFromPreserved(dstSpec *DynamoComponentDeploymentSpec, dstStatus *DynamoComponentDeploymentStatus, preservedSpec *DynamoComponentDeploymentSpec, preservedStatus *DynamoComponentDeploymentStatus, objectName string) {
-	if preservedSpec != nil && dcdPreservedSpokeSpecHasFullShape(preservedSpec) {
-		if preservedSpec.ServiceName == "" && dstSpec.ServiceName == objectName {
-			dstSpec.ServiceName = ""
-		}
+func restoreDCDAlphaOnlySpecFromSaved(dstSpec *DynamoComponentDeploymentSpec, emptyServiceName bool, objectName string) {
+	if emptyServiceName && dstSpec.ServiceName == objectName {
+		dstSpec.ServiceName = ""
 	}
+}
+
+func restoreDCDAlphaOnlyStatusFromSaved(dstStatus *DynamoComponentDeploymentStatus, preservedStatus *DynamoComponentDeploymentStatus) {
 	if preservedStatus != nil && len(dstStatus.PodSelector) == 0 && len(preservedStatus.PodSelector) > 0 {
 		dstStatus.PodSelector = maps.Clone(preservedStatus.PodSelector)
 	}
 	if preservedStatus != nil && shouldRestoreSavedComponentName(dstStatus.Service, preservedStatus.Service) {
 		dstStatus.Service.ComponentName = preservedStatus.Service.ComponentName
 	}
-}
-
-func dcdPreservedSpokeSpecHasFullShape(preservedSpec *DynamoComponentDeploymentSpec) bool {
-	if preservedSpec == nil {
-		return false
-	}
-	var sparse DynamoComponentDeploymentSpec
-	saveSharedAlphaOnlySpec(&preservedSpec.DynamoComponentDeploymentSharedSpec, &sparse.DynamoComponentDeploymentSharedSpec, true)
-	return !apiequality.Semantic.DeepEqual(*preservedSpec, sparse)
 }
 
 func dcdAlphaSpecSaveIsZero(save *DynamoComponentDeploymentSpec) bool {
@@ -200,10 +195,13 @@ func (dst *DynamoComponentDeployment) ConvertFrom(srcRaw conversion.Hub) error {
 	dst.ObjectMeta = *src.ObjectMeta.DeepCopy()
 
 	var preservedSpokeSpec *DynamoComponentDeploymentSpec
+	var preservedSpokeEmptyServiceName bool
 	var preservedSpokeStatus *DynamoComponentDeploymentStatus
+	spokeOrigin := hasDCDSpokeAnnotations(&dst.ObjectMeta)
 	if raw, ok := getAnnFromObj(&dst.ObjectMeta, annDCDSpokeSpec); ok && raw != "" {
-		if spec, ok := restoreDCDSpokeSpec(raw); ok {
+		if spec, emptyServiceName, ok := restoreDCDSpokeSpec(raw); ok {
 			preservedSpokeSpec = &spec
+			preservedSpokeEmptyServiceName = emptyServiceName
 		}
 	}
 	if status, ok := getJSONAnnFromObj[DynamoComponentDeploymentStatus](&dst.ObjectMeta, annDCDSpokeStatus); ok {
@@ -211,7 +209,6 @@ func (dst *DynamoComponentDeployment) ConvertFrom(srcRaw conversion.Hub) error {
 	}
 
 	ctx := dcdConversionContext{
-		carrier:    newDCDCarrier(&dst.ObjectMeta),
 		objectName: src.ObjectMeta.Name,
 	}
 	var hubSave v1beta1.DynamoComponentDeploymentSpec
@@ -220,34 +217,28 @@ func (dst *DynamoComponentDeployment) ConvertFrom(srcRaw conversion.Hub) error {
 	}
 
 	convertDCDStatusFromHub(&src.Status, &dst.Status, nil, nil, ctx)
-	fillDCDSpokeFromPreserved(&dst.Spec, &dst.Status, preservedSpokeSpec, preservedSpokeStatus, src.ObjectMeta.Name)
-	scrubDCDAnnotations(&dst.ObjectMeta)
-	if preservedSpokeSpec != nil || preservedSpokeStatus != nil {
-		delAnnFromObj(&dst.ObjectMeta, annDCDSpokeSpec)
-		delAnnFromObj(&dst.ObjectMeta, annDCDSpokeStatus)
-	}
-	if !dcdHubSpecSaveIsZero(&hubSave) {
+	restoreDCDAlphaOnlySpecFromSaved(&dst.Spec, preservedSpokeEmptyServiceName, src.ObjectMeta.Name)
+	restoreDCDAlphaOnlyStatusFromSaved(&dst.Status, preservedSpokeStatus)
+	scrubDCDInternalAnnotations(&dst.ObjectMeta)
+
+	if dcdHubSpecNeedsSave(src, &hubSave, !spokeOrigin) {
+		hubSave.ComponentName = src.Spec.ComponentName
 		data, err := marshalDCDHubSpec(&hubSave)
 		if err != nil {
 			return fmt.Errorf("preserve DCD hub spec: %w", err)
 		}
 		setAnnOnObj(&dst.ObjectMeta, annDCDHubSpec, string(data))
-	} else if dcdHubOriginMarkerNeeded(src) && (!hasDCDInternalAnnotations(src.ObjectMeta.Annotations) || dcdEmptyHubNameNeedsOriginMarker(src)) {
-		setAnnOnObj(&dst.ObjectMeta, annDCDHubOrigin, annotationTrue)
 	}
 	return nil
 }
 
-func dcdHubOriginMarkerNeeded(src *v1beta1.DynamoComponentDeployment) bool {
-	return src != nil && (src.Spec.ComponentName == "" || src.Spec.PodTemplate != nil)
-}
-
-func dcdEmptyHubNameNeedsOriginMarker(src *v1beta1.DynamoComponentDeployment) bool {
-	if src == nil || src.Spec.ComponentName != "" {
-		return false
-	}
-	_, hasServiceNameOrigin := newDCDCarrier(&src.ObjectMeta).get(suffixServiceName)
-	return !hasServiceNameOrigin
+func dcdHubSpecNeedsSave(src *v1beta1.DynamoComponentDeployment, save *v1beta1.DynamoComponentDeploymentSpec, saveHubOrigin bool) bool {
+	return !dcdHubSpecSaveIsZero(save) ||
+		src != nil &&
+			(src.Spec.ComponentName == "" &&
+				src.ObjectMeta.Name != "" ||
+				saveHubOrigin &&
+					src.Spec.PodTemplate != nil)
 }
 
 func convertDCDSpecFromHub(src *v1beta1.DynamoComponentDeploymentSpec, dst *DynamoComponentDeploymentSpec, restored *DynamoComponentDeploymentSpec, save *v1beta1.DynamoComponentDeploymentSpec, ctx dcdConversionContext) error {
@@ -266,17 +257,9 @@ func convertDCDSpecFromHub(src *v1beta1.DynamoComponentDeploymentSpec, dst *Dyna
 	if save != nil {
 		sharedSave = &save.DynamoComponentDeploymentSharedSpec
 	}
-	sharedCtx := sharedSpecConversionContext{
-		carrier: ctx.carrier,
-	}
+	sharedCtx := sharedSpecConversionContext{}
 	if err := convertSharedSpecFromHub(&src.DynamoComponentDeploymentSharedSpec, &dst.DynamoComponentDeploymentSharedSpec, preservedShared, sharedSave, sharedCtx); err != nil {
 		return err
-	}
-	if v, ok := ctx.carrier.get(suffixServiceName); ok {
-		if v == "" && src.ComponentName == ctx.objectName {
-			dst.ServiceName = ""
-		}
-		ctx.carrier.del(suffixServiceName)
 	}
 
 	return nil
@@ -298,36 +281,43 @@ func restoreDCDHubSpec(raw string) (v1beta1.DynamoComponentDeploymentSpec, bool)
 	})
 }
 
-func marshalDCDSpokeSpec(src *DynamoComponentDeploymentSpec) ([]byte, error) {
+func marshalDCDSpokeSpec(src *DynamoComponentDeploymentSpec, emptyServiceName bool) ([]byte, error) {
 	return marshalPreservedSpec(*src.DeepCopy(), func(spec *DynamoComponentDeploymentSpec, records *[]preservedRawJSON) {
+		if emptyServiceName {
+			*records = append(*records, preservedRawJSON{
+				Path: preservedDCDEmptyServiceNamePath,
+				Nil:  true,
+			})
+		}
 		if spec.EPPConfig != nil {
 			preserveEPPPluginParameters(spec.EPPConfig.Config, "eppConfig/config", records)
 		}
 	})
 }
 
-func restoreDCDSpokeSpec(raw string) (DynamoComponentDeploymentSpec, bool) {
-	return restorePreservedSpec(raw, func(spec *DynamoComponentDeploymentSpec, records []preservedRawJSON) {
+func restoreDCDSpokeSpec(raw string) (DynamoComponentDeploymentSpec, bool, bool) {
+	emptyServiceName := false
+	spec, ok := restorePreservedSpec(raw, func(spec *DynamoComponentDeploymentSpec, records []preservedRawJSON) {
+		for _, record := range records {
+			if record.Path == preservedDCDEmptyServiceNamePath && record.Nil {
+				emptyServiceName = true
+			}
+		}
 		if spec.EPPConfig != nil {
 			restoreEPPPluginParameters(spec.EPPConfig.Config, "eppConfig/config", records)
 		}
 	})
+	return spec, emptyServiceName, ok
 }
 
 func dcdHubSpecSaveIsZero(save *v1beta1.DynamoComponentDeploymentSpec) bool {
 	return save == nil || sharedHubSpecSaveIsZero(&save.DynamoComponentDeploymentSharedSpec)
 }
 
-func hasDCDInternalAnnotations(annotations map[string]string) bool {
-	for key := range annotations {
-		if key == annDCDHubSpec ||
-			key == annDCDSpokeSpec ||
-			key == annDCDSpokeStatus ||
-			strings.HasPrefix(key, annDCDPrefix) {
-			return true
-		}
-	}
-	return false
+func hasDCDSpokeAnnotations(obj metav1.Object) bool {
+	_, hasSpec := getAnnFromObj(obj, annDCDSpokeSpec)
+	_, hasStatus := getAnnFromObj(obj, annDCDSpokeStatus)
+	return hasSpec || hasStatus
 }
 
 //nolint:unparam // Keep the structural conversion signature; this leaf has no preserved fields.
@@ -367,8 +357,12 @@ func convertDCDStatusFromHub(src *v1beta1.DynamoComponentDeploymentStatus, dst *
 	}
 }
 
-// scrubDCDAnnotations removes any lingering "nvidia.com/dcd-*" keys that
-// shared-spec conversion did not consume.
-func scrubDCDAnnotations(obj *metav1.ObjectMeta) {
-	scrubAnnotationsByPrefix(obj, annDCDPrefix)
+func scrubDCDInternalAnnotations(obj metav1.Object) {
+	for _, key := range []string{
+		annDCDHubSpec,
+		annDCDSpokeSpec,
+		annDCDSpokeStatus,
+	} {
+		delAnnFromObj(obj, key)
+	}
 }

--- a/deploy/operator/api/v1alpha1/dynamocomponentdeployment_conversion.go
+++ b/deploy/operator/api/v1alpha1/dynamocomponentdeployment_conversion.go
@@ -76,11 +76,11 @@ func (src *DynamoComponentDeployment) ConvertTo(dstRaw conversion.Hub) error {
 	saveDCDAlphaOnlyStatus(&src.Status, &statusSave)
 	emptyServiceNameSave := dcdEmptyServiceNameNeedsSave(src, dst)
 	generatedPodTemplateSave := !hubOrigin && dst.Spec.PodTemplate != nil
-	preserveSpec := generatedPodTemplateSave || emptyServiceNameSave || !dcdAlphaSpecSaveIsZero(&spokeSave)
+	saveSpec := generatedPodTemplateSave || emptyServiceNameSave || !dcdAlphaSpecSaveIsZero(&spokeSave)
 
 	convertDCDStatusToHub(&src.Status, &dst.Status, nil, nil, ctx)
-	if preserveSpec || !dcdAlphaStatusSaveIsZero(&statusSave) {
-		preserveDCDSpoke(&spokeSave, preserveSpec, emptyServiceNameSave, &statusSave, dst)
+	if saveSpec || !dcdAlphaStatusSaveIsZero(&statusSave) {
+		saveDCDSpokeAnnotations(&spokeSave, saveSpec, emptyServiceNameSave, &statusSave, dst)
 	}
 	return nil
 }
@@ -132,8 +132,8 @@ func dcdEmptyServiceNameNeedsSave(src *DynamoComponentDeployment, dst *v1beta1.D
 		dst.Spec.ComponentName == src.ObjectMeta.Name
 }
 
-func preserveDCDSpoke(specSave *DynamoComponentDeploymentSpec, preserveSpec bool, emptyServiceName bool, statusSave *DynamoComponentDeploymentStatus, dst *v1beta1.DynamoComponentDeployment) {
-	if preserveSpec {
+func saveDCDSpokeAnnotations(specSave *DynamoComponentDeploymentSpec, saveSpec bool, emptyServiceName bool, statusSave *DynamoComponentDeploymentStatus, dst *v1beta1.DynamoComponentDeployment) {
+	if saveSpec {
 		data, err := marshalDCDSpokeSpec(specSave, emptyServiceName)
 		if err == nil {
 			setAnnOnObj(&dst.ObjectMeta, annDCDSpokeSpec, string(data))

--- a/deploy/operator/api/v1alpha1/dynamocomponentdeployment_conversion.go
+++ b/deploy/operator/api/v1alpha1/dynamocomponentdeployment_conversion.go
@@ -150,7 +150,7 @@ func fillDCDSpokeFromPreserved(dstSpec *DynamoComponentDeploymentSpec, dstStatus
 	if preservedStatus != nil && len(dstStatus.PodSelector) == 0 && len(preservedStatus.PodSelector) > 0 {
 		dstStatus.PodSelector = maps.Clone(preservedStatus.PodSelector)
 	}
-	if preservedStatus != nil && shouldRestorePreservedComponentName(dstStatus.Service, preservedStatus.Service) {
+	if preservedStatus != nil && shouldRestoreSavedComponentName(dstStatus.Service, preservedStatus.Service) {
 		dstStatus.Service.ComponentName = preservedStatus.Service.ComponentName
 	}
 }

--- a/deploy/operator/api/v1alpha1/dynamocomponentdeployment_conversion_bugs_test.go
+++ b/deploy/operator/api/v1alpha1/dynamocomponentdeployment_conversion_bugs_test.go
@@ -1,0 +1,62 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v1alpha1
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+)
+
+func TestDCD_DivergedLegacyCarrierDoesNotOverrideSparseSpokeSave(t *testing.T) {
+	savedNamespace := "saved"
+	data, err := marshalDCDSpokeSpec(&DynamoComponentDeploymentSpec{
+		DynamoComponentDeploymentSharedSpec: DynamoComponentDeploymentSharedSpec{
+			DynamoNamespace: &savedNamespace,
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal DCD spoke spec: %v", err)
+	}
+
+	hub := &v1beta1.DynamoComponentDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dcd",
+			Namespace: "ns",
+			Annotations: map[string]string{
+				annDCDSpokeSpec:                      string(data),
+				annDCDPrefix + suffixDynamoNamespace: "stale",
+			},
+		},
+		Spec: v1beta1.DynamoComponentDeploymentSpec{
+			DynamoComponentDeploymentSharedSpec: v1beta1.DynamoComponentDeploymentSharedSpec{
+				ComponentName: "dcd",
+			},
+		},
+	}
+
+	spoke := &DynamoComponentDeployment{}
+	if err := spoke.ConvertFrom(hub); err != nil {
+		t.Fatalf("ConvertFrom: %v", err)
+	}
+	if spoke.Spec.DynamoNamespace == nil || *spoke.Spec.DynamoNamespace != savedNamespace {
+		t.Fatalf("DynamoNamespace = %v, want %q from sparse save", spoke.Spec.DynamoNamespace, savedNamespace)
+	}
+}

--- a/deploy/operator/api/v1alpha1/dynamocomponentdeployment_conversion_bugs_test.go
+++ b/deploy/operator/api/v1alpha1/dynamocomponentdeployment_conversion_bugs_test.go
@@ -31,7 +31,7 @@ func TestDCD_DivergedLegacyCarrierDoesNotOverrideSparseSpokeSave(t *testing.T) {
 		DynamoComponentDeploymentSharedSpec: DynamoComponentDeploymentSharedSpec{
 			DynamoNamespace: &savedNamespace,
 		},
-	})
+	}, false)
 	if err != nil {
 		t.Fatalf("marshal DCD spoke spec: %v", err)
 	}
@@ -41,8 +41,8 @@ func TestDCD_DivergedLegacyCarrierDoesNotOverrideSparseSpokeSave(t *testing.T) {
 			Name:      "dcd",
 			Namespace: "ns",
 			Annotations: map[string]string{
-				annDCDSpokeSpec:                      string(data),
-				annDCDPrefix + suffixDynamoNamespace: "stale",
+				annDCDSpokeSpec:                   string(data),
+				"nvidia.com/dcd-dynamo-namespace": "stale",
 			},
 		},
 		Spec: v1beta1.DynamoComponentDeploymentSpec{

--- a/deploy/operator/api/v1alpha1/dynamocomponentdeployment_conversion_test.go
+++ b/deploy/operator/api/v1alpha1/dynamocomponentdeployment_conversion_test.go
@@ -46,6 +46,17 @@ func dcdRoundTripFromV1beta1(t *testing.T, src *v1beta1.DynamoComponentDeploymen
 	return out
 }
 
+func assertOnlyKnownDCDAnnotations(t *testing.T, annotations map[string]string) {
+	t.Helper()
+	for key := range annotations {
+		switch key {
+		case annDCDHubSpec, annDCDSpokeSpec, annDCDSpokeStatus:
+		default:
+			t.Fatalf("unexpected annotation %q in %v", key, annotations)
+		}
+	}
+}
+
 func TestDCD_RoundTrip_Empty(t *testing.T) {
 	src := &v1beta1.DynamoComponentDeployment{
 		ObjectMeta: metav1.ObjectMeta{Name: "empty", Namespace: "ns"},
@@ -124,8 +135,13 @@ func TestDCD_OmittedServiceNameOriginDoesNotOverrideHubEdit(t *testing.T) {
 	if hub.Spec.ComponentName != "default-name" {
 		t.Fatalf("expected omitted serviceName to default to metadata.name, got %q", hub.Spec.ComponentName)
 	}
-	if v, ok := hub.Annotations[annDCDPrefix+suffixServiceName]; !ok || v != "" {
-		t.Fatalf("expected empty service-name origin annotation, got %v", hub.Annotations)
+	assertOnlyKnownDCDAnnotations(t, hub.Annotations)
+	raw := hub.Annotations[annDCDSpokeSpec]
+	if raw == "" {
+		t.Fatalf("expected empty serviceName marker in %q, got %v", annDCDSpokeSpec, hub.Annotations)
+	}
+	if _, emptyServiceName, ok := restoreDCDSpokeSpec(raw); !ok || !emptyServiceName {
+		t.Fatalf("expected empty serviceName marker in %q payload: %s", annDCDSpokeSpec, raw)
 	}
 
 	roundTripped := &DynamoComponentDeployment{}
@@ -176,12 +192,14 @@ func TestDCD_IntermediateHubPodTemplateEditsRoundTripThroughSpoke(t *testing.T) 
 		if !ok {
 			t.Fatalf("failed to restore %q payload: %s", annDCDHubSpec, raw)
 		}
-		main, ok := findContainerByName(preserved.PodTemplate.Spec.Containers, mainContainerName)
-		if !ok {
-			t.Fatalf("expected sparse preserved main-container key, got %#v", preserved.PodTemplate)
-		}
-		if main.Image != "" {
-			t.Fatalf("representable main-container image was preserved: %#v", main)
+		if preserved.PodTemplate != nil {
+			main, ok := findContainerByName(preserved.PodTemplate.Spec.Containers, mainContainerName)
+			if !ok {
+				t.Fatalf("expected sparse preserved main-container key, got %#v", preserved.PodTemplate)
+			}
+			if main.Image != "" {
+				t.Fatalf("representable main-container image was preserved: %#v", main)
+			}
 		}
 	}
 	if spoke.Spec.ExtraPodSpec == nil || spoke.Spec.ExtraPodSpec.MainContainer == nil {
@@ -670,13 +688,12 @@ func TestDCD_RoundTrip_Status(t *testing.T) {
 	}
 }
 
-// TestDCD_FromV1alpha1_AnnotationPreservedFields exercises the v1alpha1-only
-// fields that are preserved verbatim via origin annotations on the DCD carrier
-// (prefix "nvidia.com/dcd-"). Fields that flow through podTemplate
-// decomposition (EnvFromSecret, Resources, VolumeMounts, Probes) are not
-// bitwise round-trippable v1alpha1-first and are exercised via the
-// v1beta1-first round-trip instead.
-func TestDCD_FromV1alpha1_AnnotationPreservedFields(t *testing.T) {
+// TestDCD_FromV1alpha1_SparseSpokeSaveCarriesAlphaOnlyFields exercises the
+// v1alpha1-only fields preserved through the sparse DCD spoke annotation.
+// Fields that flow through podTemplate decomposition (EnvFromSecret,
+// Resources, VolumeMounts, Probes) are exercised via the v1beta1-first
+// round-trip instead.
+func TestDCD_FromV1alpha1_SparseSpokeSaveCarriesAlphaOnlyFields(t *testing.T) {
 	dynNs := "legacy-dyn-ns"
 	src := &DynamoComponentDeployment{
 		ObjectMeta: metav1.ObjectMeta{Name: "full", Namespace: "ns"},
@@ -697,36 +714,33 @@ func TestDCD_FromV1alpha1_AnnotationPreservedFields(t *testing.T) {
 		},
 	}
 
-	// Manually drive the round-trip so we can assert that the intermediate
-	// v1beta1 object actually carries the "nvidia.com/dcd-*" origin
-	// annotations for v1alpha1-only fields (this is the contract the
-	// v1alpha1-first round-trip relies on; if the carrier silently stops
-	// emitting them, the equality check below would still pass for the
-	// wrong reason).
 	b := &v1beta1.DynamoComponentDeployment{}
 	if err := src.ConvertTo(b); err != nil {
 		t.Fatalf("ConvertTo: %v", err)
 	}
-	// Suffix list deliberately excludes "service-name" (only emitted for the
-	// standalone DCD case where v1alpha1 omitted ServiceName and v1beta1 used
-	// ObjectMeta.Name as the required ComponentName fallback)
-	// and "shared-memory-origin" (only emitted for the empty-struct edge
-	// case; SharedMemorySpec{Disabled:true} is canonically encoded as
-	// SharedMemorySize=0 without an annotation).
-	for _, suffix := range []string{
-		"sub-component-type",
-		"dynamo-namespace",
-		"autoscaling",
-		"ingress",
-		"scaling-adapter-disabled",
-		"gms-disabled-payload",
-		"annotations",
-		"labels",
-	} {
-		key := "nvidia.com/dcd-" + suffix
-		if _, ok := b.ObjectMeta.Annotations[key]; !ok {
-			t.Errorf("expected intermediate v1beta1 carrier annotation %q, got %v", key, b.ObjectMeta.Annotations)
-		}
+	assertOnlyKnownDCDAnnotations(t, b.Annotations)
+	raw := b.Annotations[annDCDSpokeSpec]
+	if raw == "" {
+		t.Fatalf("expected sparse spoke save in %q, got %v", annDCDSpokeSpec, b.Annotations)
+	}
+	saved, _, ok := restoreDCDSpokeSpec(raw)
+	if !ok {
+		t.Fatalf("failed to restore %q payload: %s", annDCDSpokeSpec, raw)
+	}
+	if saved.SubComponentType != "prefill" {
+		t.Fatalf("saved SubComponentType = %q, want prefill", saved.SubComponentType)
+	}
+	if saved.DynamoNamespace == nil || *saved.DynamoNamespace != dynNs {
+		t.Fatalf("saved DynamoNamespace = %v, want %q", saved.DynamoNamespace, dynNs)
+	}
+	if saved.Autoscaling == nil || saved.Ingress == nil || saved.ScalingAdapter == nil || saved.GPUMemoryService == nil {
+		t.Fatalf("expected alpha-only fields in sparse save, got %#v", saved)
+	}
+	if diff := cmp.Diff(src.Spec.Annotations, saved.Annotations); diff != "" {
+		t.Fatalf("saved annotations mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(src.Spec.Labels, saved.Labels); diff != "" {
+		t.Fatalf("saved labels mismatch (-want +got):\n%s", diff)
 	}
 
 	got := &DynamoComponentDeployment{}
@@ -735,77 +749,6 @@ func TestDCD_FromV1alpha1_AnnotationPreservedFields(t *testing.T) {
 	}
 	if diff := cmp.Diff(src, got, cmpopts.EquateEmpty()); diff != "" {
 		t.Errorf("round-trip mismatch (-want +got):\n%s", diff)
-	}
-}
-
-// TestDCD_ConvertFrom_ScrubsLingeringAnnotations pins the consume-then-scrub
-// contract of ConvertFrom: known-suffix "nvidia.com/dcd-*" origin annotations
-// are consumed (applied to the resulting v1alpha1 fields and then removed),
-// unknown "nvidia.com/dcd-*" annotations are scrubbed, and unrelated user
-// annotations are preserved verbatim.
-func TestDCD_ConvertFrom_ScrubsLingeringAnnotations(t *testing.T) {
-	src := &v1beta1.DynamoComponentDeployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "scrub",
-			Namespace: "ns",
-			Annotations: map[string]string{
-				// Known suffix carrying a v1alpha1-only field: must be
-				// applied to dst.Spec.DynamoNamespace AND removed from
-				// the resulting object's annotation map.
-				"nvidia.com/dcd-dynamo-namespace": "legacy-ns",
-				// Unknown suffix: nothing on the v1alpha1 side maps to
-				// it, so the scrub must drop it.
-				"nvidia.com/dcd-unknown-suffix": "stale",
-				"user/keep":                     "kept",
-			},
-		},
-		Spec: v1beta1.DynamoComponentDeploymentSpec{
-			DynamoComponentDeploymentSharedSpec: v1beta1.DynamoComponentDeploymentSharedSpec{
-				ComponentName: "scrub",
-			},
-		},
-	}
-	a := &DynamoComponentDeployment{}
-	if err := a.ConvertFrom(src); err != nil {
-		t.Fatalf("ConvertFrom: %v", err)
-	}
-	if a.Spec.DynamoNamespace == nil || *a.Spec.DynamoNamespace != "legacy-ns" {
-		t.Errorf("expected known-suffix annotation to be consumed into Spec.DynamoNamespace=legacy-ns, got %v", a.Spec.DynamoNamespace)
-	}
-	for _, k := range []string{
-		"nvidia.com/dcd-dynamo-namespace",
-		"nvidia.com/dcd-unknown-suffix",
-	} {
-		if _, present := a.ObjectMeta.Annotations[k]; present {
-			t.Errorf("nvidia.com/dcd-* annotation %q must not survive ConvertFrom: %v", k, a.ObjectMeta.Annotations)
-		}
-	}
-	if v, ok := a.ObjectMeta.Annotations["user/keep"]; !ok || v != "kept" {
-		t.Errorf("user annotations must be preserved, got %v", a.ObjectMeta.Annotations)
-	}
-}
-
-func TestDCD_ConvertFrom_DoesNotTagHubOriginWhenInternalAnnotationsExist(t *testing.T) {
-	src := &v1beta1.DynamoComponentDeployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "internal-annotation",
-			Namespace: "ns",
-			Annotations: map[string]string{
-				annDCDSpokeSpec: "corrupt",
-			},
-		},
-		Spec: v1beta1.DynamoComponentDeploymentSpec{
-			DynamoComponentDeploymentSharedSpec: v1beta1.DynamoComponentDeploymentSharedSpec{
-				ComponentName: "internal-annotation",
-			},
-		},
-	}
-	got := &DynamoComponentDeployment{}
-	if err := got.ConvertFrom(src); err != nil {
-		t.Fatalf("ConvertFrom: %v", err)
-	}
-	if _, ok := got.ObjectMeta.Annotations[annDCDHubOrigin]; ok {
-		t.Fatalf("unexpected %q annotation after internal annotation input: %v", annDCDHubOrigin, got.ObjectMeta.Annotations)
 	}
 }
 

--- a/deploy/operator/api/v1alpha1/dynamographdeployment_conversion.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeployment_conversion.go
@@ -48,15 +48,6 @@ const (
 	annDGDHubSpec     = "nvidia.com/dgd-hub-spec"
 	annDGDSpokeSpec   = "nvidia.com/dgd-spoke-spec"
 	annDGDSpokeStatus = "nvidia.com/dgd-spoke-status"
-
-	// Older conversion code wrote a full spoke-hub snapshot under this key.
-	// Current conversion never restores it, but must scrub stale copies.
-	annDGDSpokeHubLegacy = "nvidia.com/dgd-spoke-hub"
-
-	// Earlier conversion drafts used per-component DGD annotations. Current
-	// conversion only uses sparse spec/status annotations, but stale copies
-	// must be scrubbed so they cannot leak indefinitely.
-	annDGDComponentLegacyPrefix = "nvidia.com/dgd-comp-"
 )
 
 type dgdConversionContext struct {
@@ -499,11 +490,9 @@ func scrubDGDInternalAnnotations(obj metav1.Object) {
 		annDGDHubSpec,
 		annDGDSpokeSpec,
 		annDGDSpokeStatus,
-		annDGDSpokeHubLegacy,
 	} {
 		delAnnFromObj(obj, key)
 	}
-	scrubAnnotationsByPrefix(obj, annDGDComponentLegacyPrefix)
 }
 
 // convertRestartToHub / convertRestartFromHub handle the Restart struct pair,

--- a/deploy/operator/api/v1alpha1/dynamographdeployment_conversion.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeployment_conversion.go
@@ -34,9 +34,7 @@ package v1alpha1
 
 import (
 	"fmt"
-	"maps"
 	"slices"
-	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -47,27 +45,23 @@ import (
 )
 
 const (
-	annDGDNilServices = "nvidia.com/dgd-nil-services"
 	annDGDHubSpec     = "nvidia.com/dgd-hub-spec"
 	annDGDSpokeSpec   = "nvidia.com/dgd-spoke-spec"
 	annDGDSpokeStatus = "nvidia.com/dgd-spoke-status"
-	annDGDHubOrigin   = "nvidia.com/dgd-hub-origin"
 
 	// Older conversion code wrote a full spoke-hub snapshot under this key.
 	// Current conversion never restores it, but must scrub stale copies.
 	annDGDSpokeHubLegacy = "nvidia.com/dgd-spoke-hub"
+
+	// Earlier conversion drafts used per-component DGD annotations. Current
+	// conversion only uses sparse spec/status annotations, but stale copies
+	// must be scrubbed so they cannot leak indefinitely.
+	annDGDComponentLegacyPrefix = "nvidia.com/dgd-comp-"
 )
 
 type dgdConversionContext struct {
-	carrierForComponent func(componentName string) *annCarrier
 	includeOriginSplits bool
-}
-
-func (ctx dgdConversionContext) carrier(componentName string) *annCarrier {
-	if ctx.carrierForComponent == nil {
-		return nil
-	}
-	return ctx.carrierForComponent(componentName)
+	saveHubOrigin       bool
 }
 
 // ConvertTo converts this DynamoGraphDeployment (v1alpha1) into the hub
@@ -79,44 +73,28 @@ func (src *DynamoGraphDeployment) ConvertTo(dstRaw conversion.Hub) error {
 	}
 
 	dst.ObjectMeta = *src.ObjectMeta.DeepCopy()
-	var preservedHubSpec *v1beta1.DynamoGraphDeploymentSpec
+	var restoredHubSpec *v1beta1.DynamoGraphDeploymentSpec
 	if raw, ok := getAnnFromObj(&dst.ObjectMeta, annDGDHubSpec); ok && raw != "" {
 		if spec, ok := restoreDGDHubSpec(raw); ok {
-			preservedHubSpec = &spec
-			delAnnFromObj(&dst.ObjectMeta, annDGDHubSpec)
-			scrubDGDInternalAnnotations(&dst.ObjectMeta)
+			restoredHubSpec = &spec
 		}
 	}
-	hubOrigin := preservedHubSpec != nil || dst.ObjectMeta.Annotations[annDGDHubOrigin] == annotationTrue
-	delAnnFromObj(&dst.ObjectMeta, annDGDHubOrigin)
-	if hubOrigin {
-		scrubDGDInternalAnnotations(&dst.ObjectMeta)
-	}
+	hubOrigin := restoredHubSpec != nil
+	scrubDGDInternalAnnotations(&dst.ObjectMeta)
 
-	// DGD.spec.pvcs has no v1beta1 equivalent -- users now declare PVC volumes
-	// directly on podTemplate. Stash as an annotation.
-	if len(src.Spec.PVCs) > 0 {
-		setJSONAnnOnObj(&dst.ObjectMeta, annDGDPVCs, src.Spec.PVCs)
-	}
 	ctx := dgdConversionContext{
 		includeOriginSplits: !hubOrigin,
-		carrierForComponent: func(componentName string) *annCarrier {
-			return newDGDComponentCarrier(&dst.ObjectMeta, componentName)
-		},
 	}
 	var spokeSave DynamoGraphDeploymentSpec
-	if err := convertDGDSpecToHub(&src.Spec, &dst.Spec, preservedHubSpec, &spokeSave, ctx); err != nil {
+	if err := convertDGDSpecToHub(&src.Spec, &dst.Spec, restoredHubSpec, &spokeSave, ctx); err != nil {
 		return err
 	}
 	var statusSave DynamoGraphDeploymentStatus
 	saveDGDAlphaOnlyStatus(&src.Status, &statusSave)
-	preserveSpoke := !hubOrigin ||
-		!dgdAlphaSpecSaveIsZero(&spokeSave) ||
-		!dgdAlphaStatusSaveIsZero(&statusSave)
 
 	convertDGDStatusToHub(&src.Status, &dst.Status, nil, nil, ctx)
-	if preserveSpoke {
-		preserveDGDSpoke(&spokeSave, &statusSave, dst)
+	if !dgdAlphaSpecSaveIsZero(&spokeSave) || !dgdAlphaStatusSaveIsZero(&statusSave) {
+		saveDGDSpokeAnnotations(&spokeSave, &statusSave, dst)
 	}
 	return nil
 }
@@ -147,7 +125,7 @@ func convertDGDSpecToHub(src *DynamoGraphDeploymentSpec, dst *v1beta1.DynamoGrap
 	}
 
 	// Restore target-only component leaves from the preserved hub payload.
-	preservedHubComponents := preservedDGDHubComponentsByName(restored)
+	restoredHubComponents := restoredDGDHubComponentsByName(restored)
 
 	// Components: v1alpha1 map -> v1beta1 list. Prefer the preserved hub list
 	// order when it carried non-sorted order information; otherwise sort by
@@ -166,24 +144,17 @@ func convertDGDSpecToHub(src *DynamoGraphDeploymentSpec, dst *v1beta1.DynamoGrap
 				}
 				continue
 			}
-			carrier := ctx.carrier(name)
-			if carrier == nil {
-				return fmt.Errorf("component %q: missing annotation carrier", name)
-			}
-			preservedShared := preservedHubComponents[name]
-			if preservedShared != nil && preservedShared.PodTemplate != nil {
-				carrier.set(suffixPodTemplateOrig, annotationTrue)
-			}
+			restoredShared := restoredHubComponents[name]
 			var compDst v1beta1.DynamoComponentDeploymentSharedSpec
 			var compSave *DynamoComponentDeploymentSharedSpec
 			if save != nil {
 				compSave = &DynamoComponentDeploymentSharedSpec{}
 			}
 			sharedCtx := sharedSpecConversionContext{
-				carrier:             carrier,
 				includeOriginSplits: ctx.includeOriginSplits,
+				podTemplateOrigin:   restoredShared != nil && restoredShared.PodTemplate != nil,
 			}
-			if err := convertSharedSpecToHub(compSrc, &compDst, preservedShared, compSave, sharedCtx); err != nil {
+			if err := convertSharedSpecToHub(compSrc, &compDst, restoredShared, compSave, sharedCtx); err != nil {
 				return fmt.Errorf("component %q: %w", name, err)
 			}
 			// In v1alpha1 DGD, the services-map key is the canonical name and
@@ -191,11 +162,11 @@ func convertDGDSpecToHub(src *DynamoGraphDeploymentSpec, dst *v1beta1.DynamoGrap
 			// the reconciler (graph.go materialises DCDs with ServiceName =
 			// map key). Force the v1beta1 ComponentName to the map key so the
 			// +listMapKey=name invariant (and the round-trip identity) hold, and
-			// stash the (now redundant) v1alpha1 ServiceName in an origin
-			// annotation so a mismatched value still round-trips.
+			// save the (now redundant) v1alpha1 ServiceName so a mismatched
+			// value still round-trips.
 			compDst.ComponentName = name
-			if compSrc.ServiceName != "" && compSrc.ServiceName != name {
-				carrier.set(suffixServiceName, compSrc.ServiceName)
+			if save != nil && compSrc.ServiceName != "" && compSrc.ServiceName != name {
+				compSave.ServiceName = compSrc.ServiceName
 			}
 			if save != nil && !sharedAlphaSpecSaveIsZero(compSave) {
 				if save.Services == nil {
@@ -210,7 +181,7 @@ func convertDGDSpecToHub(src *DynamoGraphDeploymentSpec, dst *v1beta1.DynamoGrap
 	return nil
 }
 
-func preserveDGDSpoke(specSave *DynamoGraphDeploymentSpec, statusSave *DynamoGraphDeploymentStatus, dst *v1beta1.DynamoGraphDeployment) {
+func saveDGDSpokeAnnotations(specSave *DynamoGraphDeploymentSpec, statusSave *DynamoGraphDeploymentStatus, dst *v1beta1.DynamoGraphDeployment) {
 	if !dgdAlphaSpecSaveIsZero(specSave) {
 		data, err := marshalDGDSpokeSpec(specSave)
 		if err == nil {
@@ -222,13 +193,13 @@ func preserveDGDSpoke(specSave *DynamoGraphDeploymentSpec, statusSave *DynamoGra
 	}
 }
 
-func preservedDGDHubComponentsByName(preserved *v1beta1.DynamoGraphDeploymentSpec) map[string]*v1beta1.DynamoComponentDeploymentSharedSpec {
-	if preserved == nil || len(preserved.Components) == 0 {
+func restoredDGDHubComponentsByName(restored *v1beta1.DynamoGraphDeploymentSpec) map[string]*v1beta1.DynamoComponentDeploymentSharedSpec {
+	if restored == nil || len(restored.Components) == 0 {
 		return nil
 	}
-	out := make(map[string]*v1beta1.DynamoComponentDeploymentSharedSpec, len(preserved.Components))
-	for i := range preserved.Components {
-		out[preserved.Components[i].ComponentName] = &preserved.Components[i]
+	out := make(map[string]*v1beta1.DynamoComponentDeploymentSharedSpec, len(restored.Components))
+	for i := range restored.Components {
+		out[restored.Components[i].ComponentName] = &restored.Components[i]
 	}
 	return out
 }
@@ -263,13 +234,13 @@ func dgdComponentOrderNeedsPreservation(components []v1beta1.DynamoComponentDepl
 	return false
 }
 
-func fillDGDSpokeFromPreserved(dstSpec *DynamoGraphDeploymentSpec, dstStatus *DynamoGraphDeploymentStatus, preservedSpec *DynamoGraphDeploymentSpec, preservedStatus *DynamoGraphDeploymentStatus) {
-	if preservedSpec != nil {
+func restoreDGDAlphaOnlySpecFromSaved(dstSpec *DynamoGraphDeploymentSpec, savedSpec *DynamoGraphDeploymentSpec) {
+	if savedSpec != nil {
 		if len(dstSpec.PVCs) == 0 {
-			dstSpec.PVCs = slices.Clone(preservedSpec.PVCs)
+			dstSpec.PVCs = slices.Clone(savedSpec.PVCs)
 		}
-		for name, preservedComp := range preservedSpec.Services {
-			if preservedComp != nil {
+		for name, savedComp := range savedSpec.Services {
+			if savedComp != nil {
 				continue
 			}
 			if dstSpec.Services == nil {
@@ -280,29 +251,33 @@ func fillDGDSpokeFromPreserved(dstSpec *DynamoGraphDeploymentSpec, dstStatus *Dy
 			}
 		}
 		for name, dstComp := range dstSpec.Services {
-			if dstComp == nil || preservedSpec.Services == nil {
+			if dstComp == nil || savedSpec.Services == nil {
 				continue
 			}
-			preservedComp := preservedSpec.Services[name]
-			if preservedComp == nil {
+			savedComp := savedSpec.Services[name]
+			if savedComp == nil {
 				continue
 			}
-			if dstComp.ServiceName == "" && preservedComp.ServiceName != "" && preservedComp.ServiceName != name {
-				dstComp.ServiceName = preservedComp.ServiceName
+			if dstComp.ServiceName == "" && savedComp.ServiceName != "" && savedComp.ServiceName != name {
+				dstComp.ServiceName = savedComp.ServiceName
 			}
 		}
 	}
-	if preservedStatus != nil {
-		for name, dstSvc := range dstStatus.Services {
-			preservedSvc, ok := preservedStatus.Services[name]
-			if !ok {
-				continue
-			}
-			if shouldRestorePreservedComponentName(&dstSvc, &preservedSvc) {
-				dstSvc.ComponentName = preservedSvc.ComponentName
-			}
-			dstStatus.Services[name] = dstSvc
+}
+
+func restoreDGDAlphaOnlyStatusFromSaved(dstStatus *DynamoGraphDeploymentStatus, savedStatus *DynamoGraphDeploymentStatus) {
+	if savedStatus == nil {
+		return
+	}
+	for name, dstSvc := range dstStatus.Services {
+		savedSvc, ok := savedStatus.Services[name]
+		if !ok {
+			continue
 		}
+		if shouldRestoreSavedComponentName(&dstSvc, &savedSvc) {
+			dstSvc.ComponentName = savedSvc.ComponentName
+		}
+		dstStatus.Services[name] = dstSvc
 	}
 }
 
@@ -352,24 +327,24 @@ func serviceStatusComponentNameNeedsPreservation(src *ServiceReplicaStatus) bool
 	return src.ComponentNames[len(src.ComponentNames)-1] != src.ComponentName
 }
 
-func shouldRestorePreservedComponentName(dst, preserved *ServiceReplicaStatus) bool {
-	return serviceStatusComponentNameNeedsPreservation(preserved) &&
+func shouldRestoreSavedComponentName(dst, saved *ServiceReplicaStatus) bool {
+	return serviceStatusComponentNameNeedsPreservation(saved) &&
 		dst != nil &&
-		dst.ComponentName != preserved.ComponentName
+		dst.ComponentName != saved.ComponentName
 }
 
-func decodeDGDSpokePreserved(obj metav1.Object) (*DynamoGraphDeploymentSpec, *DynamoGraphDeploymentStatus) {
-	var preservedSpokeSpec *DynamoGraphDeploymentSpec
-	var preservedSpokeStatus *DynamoGraphDeploymentStatus
+func restoreDGDSpokeAnnotations(obj metav1.Object) (*DynamoGraphDeploymentSpec, *DynamoGraphDeploymentStatus) {
+	var restoredSpokeSpec *DynamoGraphDeploymentSpec
+	var restoredSpokeStatus *DynamoGraphDeploymentStatus
 	if raw, ok := getAnnFromObj(obj, annDGDSpokeSpec); ok && raw != "" {
 		if spec, ok := restoreDGDSpokeSpec(raw); ok {
-			preservedSpokeSpec = &spec
+			restoredSpokeSpec = &spec
 		}
 	}
 	if status, ok := getJSONAnnFromObj[DynamoGraphDeploymentStatus](obj, annDGDSpokeStatus); ok {
-		preservedSpokeStatus = &status
+		restoredSpokeStatus = &status
 	}
-	return preservedSpokeSpec, preservedSpokeStatus
+	return restoredSpokeSpec, restoredSpokeStatus
 }
 
 // ConvertFrom converts from the hub (v1beta1) DynamoGraphDeployment into this
@@ -382,66 +357,25 @@ func (dst *DynamoGraphDeployment) ConvertFrom(srcRaw conversion.Hub) error {
 
 	dst.ObjectMeta = *src.ObjectMeta.DeepCopy()
 
-	preservedSpokeSpec, preservedSpokeStatus := decodeDGDSpokePreserved(&dst.ObjectMeta)
+	spokeOrigin := hasDGDSpokeAnnotations(&dst.ObjectMeta)
+	restoredSpokeSpec, restoredSpokeStatus := restoreDGDSpokeAnnotations(&dst.ObjectMeta)
+	scrubDGDInternalAnnotations(&dst.ObjectMeta)
 
-	if _, ok := getAnnFromObj(&dst.ObjectMeta, annDGDPVCs); ok {
-		if pvcs, ok := getJSONAnnFromObj[[]PVC](&dst.ObjectMeta, annDGDPVCs); ok {
-			dst.Spec.PVCs = pvcs
-		}
-		delAnnFromObj(&dst.ObjectMeta, annDGDPVCs)
-	}
-
-	ctx := dgdConversionContext{
-		carrierForComponent: func(componentName string) *annCarrier {
-			return newDGDComponentCarrier(&dst.ObjectMeta, componentName)
-		},
-	}
+	ctx := dgdConversionContext{saveHubOrigin: !spokeOrigin}
 	var hubSave v1beta1.DynamoGraphDeploymentSpec
-	if err := convertDGDSpecFromHub(&src.Spec, &dst.Spec, preservedSpokeSpec, &hubSave, ctx); err != nil {
+	if err := convertDGDSpecFromHub(&src.Spec, &dst.Spec, restoredSpokeSpec, &hubSave, ctx); err != nil {
 		return err
-	}
-	if _, ok := getAnnFromObj(&dst.ObjectMeta, annDGDNilServices); ok {
-		if nilServices, ok := getJSONAnnFromObj[[]string](&dst.ObjectMeta, annDGDNilServices); ok {
-			if dst.Spec.Services == nil {
-				dst.Spec.Services = make(map[string]*DynamoComponentDeploymentSharedSpec, len(nilServices))
-			}
-			for _, name := range nilServices {
-				if _, exists := dst.Spec.Services[name]; !exists {
-					dst.Spec.Services[name] = nil
-				}
-			}
-		}
-		delAnnFromObj(&dst.ObjectMeta, annDGDNilServices)
 	}
 
 	convertDGDStatusFromHub(&src.Status, &dst.Status, nil, nil, ctx)
-	fillDGDSpokeFromPreserved(&dst.Spec, &dst.Status, preservedSpokeSpec, preservedSpokeStatus)
-	scrubStaleDGDAnnotations(&dst.ObjectMeta, dst.Spec.Services)
-	delAnnFromObj(&dst.ObjectMeta, annDGDSpokeHubLegacy)
-	if preservedSpokeSpec != nil || preservedSpokeStatus != nil {
-		delAnnFromObj(&dst.ObjectMeta, annDGDSpokeSpec)
-		delAnnFromObj(&dst.ObjectMeta, annDGDSpokeStatus)
-	}
+	restoreDGDAlphaOnlySpecFromSaved(&dst.Spec, restoredSpokeSpec)
+	restoreDGDAlphaOnlyStatusFromSaved(&dst.Status, restoredSpokeStatus)
 	if !dgdHubSpecSaveIsZero(&hubSave) {
 		if data, err := marshalDGDHubSpec(&hubSave); err == nil {
 			setAnnOnObj(&dst.ObjectMeta, annDGDHubSpec, string(data))
 		}
-	} else if !hasDGDInternalAnnotations(src.ObjectMeta.Annotations) && dgdHubOriginMarkerNeeded(src) {
-		setAnnOnObj(&dst.ObjectMeta, annDGDHubOrigin, annotationTrue)
 	}
 	return nil
-}
-
-func dgdHubOriginMarkerNeeded(src *v1beta1.DynamoGraphDeployment) bool {
-	if src == nil {
-		return false
-	}
-	for i := range src.Spec.Components {
-		if src.Spec.Components[i].PodTemplate != nil {
-			return true
-		}
-	}
-	return false
 }
 
 func convertDGDSpecFromHub(src *v1beta1.DynamoGraphDeploymentSpec, dst *DynamoGraphDeploymentSpec, restored *DynamoGraphDeploymentSpec, save *v1beta1.DynamoGraphDeploymentSpec, ctx dgdConversionContext) error {
@@ -480,10 +414,6 @@ func convertDGDSpecFromHub(src *v1beta1.DynamoGraphDeploymentSpec, dst *DynamoGr
 			if _, dup := dst.Services[compSrc.ComponentName]; dup {
 				return fmt.Errorf("duplicate component name %q in spec.components", compSrc.ComponentName)
 			}
-			carrier := ctx.carrier(compSrc.ComponentName)
-			if carrier == nil {
-				return fmt.Errorf("component %q: missing annotation carrier", compSrc.ComponentName)
-			}
 			compDst := &DynamoComponentDeploymentSharedSpec{}
 			var preservedShared *DynamoComponentDeploymentSharedSpec
 			if restored != nil && restored.Services != nil {
@@ -495,31 +425,27 @@ func convertDGDSpecFromHub(src *v1beta1.DynamoGraphDeploymentSpec, dst *DynamoGr
 					ComponentName: compSrc.ComponentName,
 				}
 			}
-			sharedCtx := sharedSpecConversionContext{
-				carrier: carrier,
-			}
+			sharedCtx := sharedSpecConversionContext{}
 			if err := convertSharedSpecFromHub(compSrc, compDst, preservedShared, compSave, sharedCtx); err != nil {
 				return fmt.Errorf("component %q: %w", compSrc.ComponentName, err)
 			}
 			// In v1alpha1 the services-map key is the canonical name; the
-			// per-entry ServiceName field is redundant. Restore a non-matching
-			// legacy ServiceName from the origin annotation if present;
-			// otherwise leave it empty so v1beta1-first inputs round-trip
-			// without spurious values.
-			if v, ok := carrier.get(suffixServiceName); ok {
-				compDst.ServiceName = v
-				carrier.del(suffixServiceName)
-			} else {
-				compDst.ServiceName = ""
-			}
+			// per-entry ServiceName field is redundant. Keep it empty for
+			// v1beta1-first inputs; restore saved mismatches after the full
+			// spec conversion.
+			compDst.ServiceName = ""
 			dst.Services[compSrc.ComponentName] = compDst
-			if save != nil && (preserveComponentOrder || !dgdHubComponentSaveIsZero(compSave)) {
+			if save != nil && (preserveComponentOrder || !dgdHubComponentSaveIsZero(compSave) || ctx.saveHubOrigin && dgdHubComponentOriginSaveNeeded(compSrc)) {
 				save.Components = append(save.Components, *compSave)
 			}
 		}
 	}
 
 	return nil
+}
+
+func dgdHubComponentOriginSaveNeeded(src *v1beta1.DynamoComponentDeploymentSharedSpec) bool {
+	return src != nil && src.PodTemplate != nil
 }
 
 func marshalDGDHubSpec(src *v1beta1.DynamoGraphDeploymentSpec) ([]byte, error) {
@@ -562,33 +488,22 @@ func restoreDGDSpokeSpec(raw string) (DynamoGraphDeploymentSpec, bool) {
 	})
 }
 
-func hasDGDInternalAnnotations(annotations map[string]string) bool {
-	for key := range annotations {
-		if key == annDGDPVCs ||
-			key == annDGDNilServices ||
-			key == annDGDHubSpec ||
-			key == annDGDSpokeSpec ||
-			key == annDGDSpokeStatus ||
-			strings.HasPrefix(key, annDGDCompPrefix) {
-			return true
-		}
-	}
-	return false
+func hasDGDSpokeAnnotations(obj metav1.Object) bool {
+	_, hasSpec := getAnnFromObj(obj, annDGDSpokeSpec)
+	_, hasStatus := getAnnFromObj(obj, annDGDSpokeStatus)
+	return hasSpec || hasStatus
 }
 
 func scrubDGDInternalAnnotations(obj metav1.Object) {
 	for _, key := range []string{
-		annDGDPVCs,
-		annDGDNilServices,
 		annDGDHubSpec,
 		annDGDSpokeSpec,
 		annDGDSpokeStatus,
-		annDGDHubOrigin,
 		annDGDSpokeHubLegacy,
 	} {
 		delAnnFromObj(obj, key)
 	}
-	scrubAnnotationsByPrefix(obj, annDGDCompPrefix)
+	scrubAnnotationsByPrefix(obj, annDGDComponentLegacyPrefix)
 }
 
 // convertRestartToHub / convertRestartFromHub handle the Restart struct pair,
@@ -770,40 +685,5 @@ func convertReplicaStatusFromHub(src *v1beta1.ComponentReplicaStatus, dst *Servi
 	}
 	if src.AvailableReplicas != nil {
 		dst.AvailableReplicas = ptr.To(*src.AvailableReplicas)
-	}
-}
-
-// scrubStaleDGDAnnotations removes "nvidia.com/dgd-comp-<name>-*" keys for
-// any <name> that is not present in the current components map. Annotations
-// scoped to active components are kept: they were either produced by the
-// ConvertFrom path for the next ConvertTo to read (e.g. frontend-sidecar-ref)
-// or are pass-through keys that a v1alpha1 client may rely on.
-func scrubStaleDGDAnnotations(obj *metav1.ObjectMeta, components map[string]*DynamoComponentDeploymentSharedSpec) {
-	anns := obj.GetAnnotations()
-	if len(anns) == 0 {
-		return
-	}
-	maps.DeleteFunc(anns, func(k, _ string) bool {
-		if !strings.HasPrefix(k, annDGDCompPrefix) {
-			return false
-		}
-		rest := strings.TrimPrefix(k, annDGDCompPrefix)
-		// Key format is "<annDGDCompPrefix><name>-<suffix>", but both the
-		// component name (e.g. "aa-frontend") and the suffix (e.g.
-		// "frontend-sidecar-ref") may contain hyphens, so a simple
-		// Index("-") split is unsafe. Keep the annotation if its remainder
-		// starts with "<active-component-name>-" for any current component;
-		// drop it otherwise.
-		for name := range components {
-			if strings.HasPrefix(rest, name+"-") {
-				return false
-			}
-		}
-		return true
-	})
-	if len(anns) == 0 {
-		obj.SetAnnotations(nil)
-	} else {
-		obj.SetAnnotations(anns)
 	}
 }

--- a/deploy/operator/api/v1alpha1/dynamographdeployment_conversion_bugs_test.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeployment_conversion_bugs_test.go
@@ -20,56 +20,21 @@ package v1alpha1
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 )
 
-func TestBugDGD_HubClearsPVCAnnotationDropsSavedSpokeSpec(t *testing.T) {
-	create := true
-	name := "old-model-pvc"
+func TestBugDGD_IntermediateHubAddsMainOnlyPodTemplateRoundTrips(t *testing.T) {
 	alpha := &DynamoGraphDeployment{
-		ObjectMeta: metav1.ObjectMeta{Name: "pvc"},
-		Spec: DynamoGraphDeploymentSpec{
-			PVCs: []PVC{{
-				Create:           &create,
-				Name:             &name,
-				StorageClass:     "standard",
-				Size:             resource.MustParse("10Gi"),
-				VolumeAccessMode: corev1.ReadWriteOnce,
-			}},
-		},
-	}
-
-	hub := &v1beta1.DynamoGraphDeployment{}
-	if err := alpha.ConvertTo(hub); err != nil {
-		t.Fatalf("ConvertTo() error = %v", err)
-	}
-	delete(hub.Annotations, annDGDPVCs)
-
-	spoke := &DynamoGraphDeployment{}
-	if err := spoke.ConvertFrom(hub); err != nil {
-		t.Fatalf("ConvertFrom() error = %v", err)
-	}
-	if len(spoke.Spec.PVCs) > 0 {
-		t.Fatalf("PVCs restored from stale %q: %#v", annDGDSpokeSpec, spoke.Spec.PVCs)
-	}
-}
-
-func TestBugDGD_HubClearsComponentAnnotationDropsSavedSpokeSpec(t *testing.T) {
-	alpha := &DynamoGraphDeployment{
-		ObjectMeta: metav1.ObjectMeta{Name: "component-annotation"},
+		ObjectMeta: metav1.ObjectMeta{Name: "main-only-pod-template", Namespace: "ns"},
 		Spec: DynamoGraphDeploymentSpec{
 			Services: map[string]*DynamoComponentDeploymentSharedSpec{
 				"worker": {
 					ComponentType: string(v1beta1.ComponentTypeWorker),
-					Autoscaling: &Autoscaling{
-						Enabled:     true,
-						MinReplicas: 1,
-						MaxReplicas: 4,
-					},
 				},
 			},
 		},
@@ -79,13 +44,21 @@ func TestBugDGD_HubClearsComponentAnnotationDropsSavedSpokeSpec(t *testing.T) {
 	if err := alpha.ConvertTo(hub); err != nil {
 		t.Fatalf("ConvertTo() error = %v", err)
 	}
-	delete(hub.Annotations, newDGDComponentCarrier(&hub.ObjectMeta, "worker").key(suffixAutoscaling))
+	hub.Spec.Components[0].PodTemplate = &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: mainContainerName}},
+		},
+	}
 
 	spoke := &DynamoGraphDeployment{}
 	if err := spoke.ConvertFrom(hub); err != nil {
 		t.Fatalf("ConvertFrom() error = %v", err)
 	}
-	if got := spoke.Spec.Services["worker"].Autoscaling; got != nil {
-		t.Fatalf("autoscaling restored from stale %q: %#v", annDGDSpokeSpec, got)
+	restored := &v1beta1.DynamoGraphDeployment{}
+	if err := spoke.ConvertTo(restored); err != nil {
+		t.Fatalf("ConvertTo() error = %v", err)
+	}
+	if diff := cmp.Diff(hub.Spec.Components[0].PodTemplate, restored.Spec.Components[0].PodTemplate, cmpopts.EquateEmpty()); diff != "" {
+		t.Fatalf("podTemplate mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/deploy/operator/api/v1alpha1/dynamographdeployment_conversion_bugs_test.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeployment_conversion_bugs_test.go
@@ -1,0 +1,91 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v1alpha1
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+)
+
+func TestBugDGD_HubClearsPVCAnnotationDropsSavedSpokeSpec(t *testing.T) {
+	create := true
+	name := "old-model-pvc"
+	alpha := &DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc"},
+		Spec: DynamoGraphDeploymentSpec{
+			PVCs: []PVC{{
+				Create:           &create,
+				Name:             &name,
+				StorageClass:     "standard",
+				Size:             resource.MustParse("10Gi"),
+				VolumeAccessMode: corev1.ReadWriteOnce,
+			}},
+		},
+	}
+
+	hub := &v1beta1.DynamoGraphDeployment{}
+	if err := alpha.ConvertTo(hub); err != nil {
+		t.Fatalf("ConvertTo() error = %v", err)
+	}
+	delete(hub.Annotations, annDGDPVCs)
+
+	spoke := &DynamoGraphDeployment{}
+	if err := spoke.ConvertFrom(hub); err != nil {
+		t.Fatalf("ConvertFrom() error = %v", err)
+	}
+	if len(spoke.Spec.PVCs) > 0 {
+		t.Fatalf("PVCs restored from stale %q: %#v", annDGDSpokeSpec, spoke.Spec.PVCs)
+	}
+}
+
+func TestBugDGD_HubClearsComponentAnnotationDropsSavedSpokeSpec(t *testing.T) {
+	alpha := &DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "component-annotation"},
+		Spec: DynamoGraphDeploymentSpec{
+			Services: map[string]*DynamoComponentDeploymentSharedSpec{
+				"worker": {
+					ComponentType: string(v1beta1.ComponentTypeWorker),
+					Autoscaling: &Autoscaling{
+						Enabled:     true,
+						MinReplicas: 1,
+						MaxReplicas: 4,
+					},
+				},
+			},
+		},
+	}
+
+	hub := &v1beta1.DynamoGraphDeployment{}
+	if err := alpha.ConvertTo(hub); err != nil {
+		t.Fatalf("ConvertTo() error = %v", err)
+	}
+	delete(hub.Annotations, newDGDComponentCarrier(&hub.ObjectMeta, "worker").key(suffixAutoscaling))
+
+	spoke := &DynamoGraphDeployment{}
+	if err := spoke.ConvertFrom(hub); err != nil {
+		t.Fatalf("ConvertFrom() error = %v", err)
+	}
+	if got := spoke.Spec.Services["worker"].Autoscaling; got != nil {
+		t.Fatalf("autoscaling restored from stale %q: %#v", annDGDSpokeSpec, got)
+	}
+}

--- a/deploy/operator/api/v1alpha1/dynamographdeployment_conversion_test.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeployment_conversion_test.go
@@ -72,6 +72,32 @@ func roundTripFromV1alpha1(t *testing.T, src *DynamoGraphDeployment) *DynamoGrap
 	return out
 }
 
+func assertNoDGDComponentAnnotations(t *testing.T, annotations map[string]string) {
+	t.Helper()
+	for key := range annotations {
+		if strings.HasPrefix(key, annDGDComponentLegacyPrefix) {
+			t.Fatalf("unexpected legacy DGD component annotation %q in %v", key, annotations)
+		}
+	}
+}
+
+func mustRestoreDGDSpokeServiceSave(t *testing.T, hub *v1beta1.DynamoGraphDeployment, serviceName string) *DynamoComponentDeploymentSharedSpec {
+	t.Helper()
+	raw := hub.Annotations[annDGDSpokeSpec]
+	if raw == "" {
+		t.Fatalf("expected %q in annotations, got %v", annDGDSpokeSpec, hub.Annotations)
+	}
+	saved, ok := restoreDGDSpokeSpec(raw)
+	if !ok {
+		t.Fatalf("failed to restore %q payload: %s", annDGDSpokeSpec, raw)
+	}
+	service := saved.Services[serviceName]
+	if service == nil {
+		t.Fatalf("expected service %q in sparse save, got %#v", serviceName, saved.Services)
+	}
+	return service
+}
+
 func TestDGD_RoundTrip_Empty(t *testing.T) {
 	src := &v1beta1.DynamoGraphDeployment{
 		ObjectMeta: metav1.ObjectMeta{Name: "empty", Namespace: "ns"},
@@ -165,12 +191,14 @@ func TestDGD_IntermediateHubPodTemplateEditsRoundTripThroughSpoke(t *testing.T) 
 		if len(preserved.Components) != 1 {
 			t.Fatalf("expected one preserved component, got %#v", preserved.Components)
 		}
-		main, ok := findContainerByName(preserved.Components[0].PodTemplate.Spec.Containers, mainContainerName)
-		if !ok {
-			t.Fatalf("expected sparse preserved main-container key, got %#v", preserved.Components[0].PodTemplate)
-		}
-		if main.Image != "" {
-			t.Fatalf("representable main-container image was preserved: %#v", main)
+		if preserved.Components[0].PodTemplate != nil {
+			main, ok := findContainerByName(preserved.Components[0].PodTemplate.Spec.Containers, mainContainerName)
+			if !ok {
+				t.Fatalf("expected sparse preserved main-container key, got %#v", preserved.Components[0].PodTemplate)
+			}
+			if main.Image != "" {
+				t.Fatalf("representable main-container image was preserved: %#v", main)
+			}
 		}
 	}
 	component := spoke.Spec.Services["worker"]
@@ -229,6 +257,91 @@ func TestDGD_IntermediateSpokeAlphaOnlyEditsSurvivePreservedHub(t *testing.T) {
 	}
 	if diff := cmp.Diff(spoke.Spec.PVCs, restoredSpoke.Spec.PVCs); diff != "" {
 		t.Fatalf("PVCs mismatch after preserving alpha-only edit (-want +got):\n%s", diff)
+	}
+}
+
+func TestDGD_SpokeSaveCarriesAlphaOnlyFieldsSparsely(t *testing.T) {
+	createTrue := true
+	name := "models"
+	src := &DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "sparse-spoke-save", Namespace: "ns"},
+		Spec: DynamoGraphDeploymentSpec{
+			PVCs: []PVC{{
+				Create:           &createTrue,
+				Name:             &name,
+				StorageClass:     "standard",
+				Size:             resource.MustParse("10Gi"),
+				VolumeAccessMode: corev1.ReadWriteOnce,
+			}},
+			Services: map[string]*DynamoComponentDeploymentSharedSpec{
+				"worker": {
+					ComponentType: string(v1beta1.ComponentTypeWorker),
+					Autoscaling: &Autoscaling{
+						Enabled:     true,
+						MinReplicas: 1,
+						MaxReplicas: 4,
+					},
+				},
+			},
+		},
+	}
+
+	hub := &v1beta1.DynamoGraphDeployment{}
+	if err := src.ConvertTo(hub); err != nil {
+		t.Fatalf("ConvertTo: %v", err)
+	}
+	assertNoDGDComponentAnnotations(t, hub.Annotations)
+	raw := hub.Annotations[annDGDSpokeSpec]
+	if raw == "" {
+		t.Fatalf("expected alpha-only fields in %q, got %v", annDGDSpokeSpec, hub.Annotations)
+	}
+	saved, ok := restoreDGDSpokeSpec(raw)
+	if !ok {
+		t.Fatalf("failed to restore %q payload: %s", annDGDSpokeSpec, raw)
+	}
+	if diff := cmp.Diff(src.Spec.PVCs, saved.PVCs); diff != "" {
+		t.Fatalf("PVC save mismatch (-want +got):\n%s", diff)
+	}
+	if saved.Services["worker"] == nil || saved.Services["worker"].Autoscaling == nil {
+		t.Fatalf("expected autoscaling in sparse spoke save, got %#v", saved.Services)
+	}
+}
+
+func TestDGD_SpokeSaveCarriesNilServicesSparsely(t *testing.T) {
+	src := &DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "nil-service-save", Namespace: "ns"},
+		Spec: DynamoGraphDeploymentSpec{
+			Services: map[string]*DynamoComponentDeploymentSharedSpec{
+				"nil-service": nil,
+				"worker": {
+					ComponentType: string(v1beta1.ComponentTypeWorker),
+				},
+			},
+		},
+	}
+
+	hub := &v1beta1.DynamoGraphDeployment{}
+	if err := src.ConvertTo(hub); err != nil {
+		t.Fatalf("ConvertTo: %v", err)
+	}
+	raw := hub.Annotations[annDGDSpokeSpec]
+	if raw == "" {
+		t.Fatalf("expected sparse nil-service save in %q, got %v", annDGDSpokeSpec, hub.Annotations)
+	}
+	saved, ok := restoreDGDSpokeSpec(raw)
+	if !ok {
+		t.Fatalf("failed to restore %q payload: %s", annDGDSpokeSpec, raw)
+	}
+	if len(saved.Services) != 1 || saved.Services["nil-service"] != nil {
+		t.Fatalf("expected only nil-service in sparse save, got %#v", saved.Services)
+	}
+
+	restored := &DynamoGraphDeployment{}
+	if err := restored.ConvertFrom(hub); err != nil {
+		t.Fatalf("ConvertFrom: %v", err)
+	}
+	if _, ok := restored.Spec.Services["nil-service"]; !ok || restored.Spec.Services["nil-service"] != nil {
+		t.Fatalf("nil service did not round-trip: %#v", restored.Spec.Services)
 	}
 }
 
@@ -549,7 +662,7 @@ func TestDGD_RoundTrip_ScalingAdapter(t *testing.T) {
 }
 
 // TestDGD_FromV1alpha1_PVCsPreserved verifies that legacy v1alpha1 PVCs survive
-// a v1alpha1 -> v1beta1 -> v1alpha1 round-trip via the origin annotation.
+// a v1alpha1 -> v1beta1 -> v1alpha1 round-trip via sparse spec preservation.
 func TestDGD_FromV1alpha1_PVCsPreserved(t *testing.T) {
 	createTrue := true
 	name := testModelPVCName
@@ -575,7 +688,7 @@ func TestDGD_FromV1alpha1_PVCsPreserved(t *testing.T) {
 
 // TestDGD_FromV1alpha1_DisabledExperimental verifies that v1alpha1
 // GMS/Failover/Checkpoint with Enabled=false and payloads survive the
-// round-trip via origin annotations.
+// round-trip via sparse spec preservation.
 func TestDGD_FromV1alpha1_DisabledExperimental(t *testing.T) {
 	src := &DynamoGraphDeployment{
 		ObjectMeta: metav1.ObjectMeta{Name: "disabled", Namespace: "ns"},
@@ -604,7 +717,7 @@ func TestDGD_FromV1alpha1_DisabledExperimental(t *testing.T) {
 }
 
 // TestDGD_FromV1alpha1_SubComponentType verifies that a v1alpha1-only
-// subComponentType string survives via origin annotation.
+// subComponentType string survives via sparse spec preservation.
 func TestDGD_FromV1alpha1_SubComponentType(t *testing.T) {
 	src := &DynamoGraphDeployment{
 		ObjectMeta: metav1.ObjectMeta{Name: "sub", Namespace: "ns"},
@@ -891,7 +1004,7 @@ func TestDGD_RoundTrip_SharedMemoryDisabledZero(t *testing.T) {
 }
 
 // TestDGD_FromV1alpha1_SharedMemoryEdgeCases covers the two v1alpha1-only
-// SharedMemorySpec shapes that need origin annotations to round-trip:
+// SharedMemorySpec shapes that need sparse spec preservation to round-trip:
 // Disabled=true and the empty struct &SharedMemorySpec{}.
 func TestDGD_FromV1alpha1_SharedMemoryEdgeCases(t *testing.T) {
 	cases := []struct {
@@ -923,8 +1036,7 @@ func TestDGD_FromV1alpha1_SharedMemoryEdgeCases(t *testing.T) {
 }
 
 // TestDGD_FromV1alpha1_ScalingAdapterDisabled checks that the otherwise-unreachable
-// &ScalingAdapter{Enabled:false} shape round-trips via the scaling-adapter-disabled
-// annotation.
+// &ScalingAdapter{Enabled:false} shape round-trips via sparse spec preservation.
 func TestDGD_FromV1alpha1_ScalingAdapterDisabled(t *testing.T) {
 	src := &DynamoGraphDeployment{
 		ObjectMeta: metav1.ObjectMeta{Name: "sad", Namespace: "ns"},
@@ -944,7 +1056,7 @@ func TestDGD_FromV1alpha1_ScalingAdapterDisabled(t *testing.T) {
 }
 
 // TestDGD_FromV1alpha1_CheckpointDisabled checks that Checkpoint{Enabled:false}
-// with a non-trivial payload survives via annotation.
+// with a non-trivial payload survives via sparse spec preservation.
 func TestDGD_FromV1alpha1_CheckpointDisabled(t *testing.T) {
 	ref := "my-ckpt"
 	src := &DynamoGraphDeployment{
@@ -969,7 +1081,7 @@ func TestDGD_FromV1alpha1_CheckpointDisabled(t *testing.T) {
 }
 
 // TestDGD_FromV1alpha1_DynamoNamespaceAndServiceName verifies the two simple
-// v1alpha1-only string fields round-trip via annotations.
+// v1alpha1-only string fields round-trip via sparse spec preservation.
 func TestDGD_FromV1alpha1_DynamoNamespaceAndServiceName(t *testing.T) {
 	ns := "legacy-dyn-ns"
 	src := &DynamoGraphDeployment{
@@ -993,7 +1105,7 @@ func TestDGD_FromV1alpha1_DynamoNamespaceAndServiceName(t *testing.T) {
 // TestDGD_FromV1alpha1_PerServiceAnnotationsAndLabels verifies that v1alpha1
 // per-service Annotations/Labels (which target Pod+Service+Ingress in the
 // v1alpha1 reconcile model and cannot be faithfully placed in
-// podTemplate.metadata alone) are preserved via origin annotations.
+// podTemplate.metadata alone) are preserved via sparse spec preservation.
 func TestDGD_FromV1alpha1_PerServiceAnnotationsAndLabels(t *testing.T) {
 	src := &DynamoGraphDeployment{
 		ObjectMeta: metav1.ObjectMeta{Name: "pa", Namespace: "ns"},
@@ -1089,17 +1201,97 @@ func TestDGD_FromV1alpha1_Resources_ForwardOnly(t *testing.T) {
 	}
 }
 
-// TestDGD_ConvertFrom_ScrubsLingeringAnnotations asserts that a stale
-// "nvidia.com/dgd-comp-*" annotation that does not correspond to any current
-// component is dropped by ConvertFrom. This protects users from leaking
-// origin annotations across deletions.
+func TestDGD_FromV1alpha1_EmptyResourcesRoundTrip(t *testing.T) {
+	src := &DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "empty-resources", Namespace: "ns"},
+		Spec: DynamoGraphDeploymentSpec{
+			Services: map[string]*DynamoComponentDeploymentSharedSpec{
+				"worker": {
+					ComponentType: "worker",
+					Resources:     &Resources{Claims: []corev1.ResourceClaim{}},
+				},
+			},
+		},
+	}
+
+	got := roundTripFromV1alpha1(t, src)
+	if got.Spec.Services["worker"].Resources == nil {
+		t.Fatalf("empty Resources pointer did not round-trip: %#v", got.Spec.Services["worker"])
+	}
+}
+
+func TestDGD_FromV1alpha1_UnrepresentableResourcesRoundTrip(t *testing.T) {
+	src := &DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "unrepresentable-resources", Namespace: "ns"},
+		Spec: DynamoGraphDeploymentSpec{
+			Services: map[string]*DynamoComponentDeploymentSharedSpec{
+				"worker": {
+					ComponentType: "worker",
+					Resources: &Resources{
+						Requests: &ResourceItem{CPU: "not-a-quantity"},
+						Claims:   []corev1.ResourceClaim{{Name: "gpu-claim", Request: "gpu"}},
+					},
+				},
+			},
+		},
+	}
+
+	got := roundTripFromV1alpha1(t, src)
+	if diff := cmp.Diff(src.Spec.Services["worker"].Resources, got.Spec.Services["worker"].Resources, cmpopts.EquateEmpty()); diff != "" {
+		t.Fatalf("resources mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestDGD_FromV1alpha1_EnvFromSecretRoundTrip(t *testing.T) {
+	secret := "worker-secret"
+	src := &DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "env-from-secret", Namespace: "ns"},
+		Spec: DynamoGraphDeploymentSpec{
+			Services: map[string]*DynamoComponentDeploymentSharedSpec{
+				"worker": {
+					ComponentType: "worker",
+					EnvFromSecret: &secret,
+				},
+			},
+		},
+	}
+
+	got := roundTripFromV1alpha1(t, src)
+	if diff := cmp.Diff(src, got, cmpopts.EquateEmpty()); diff != "" {
+		t.Fatalf("round-trip mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestDGD_FromV1alpha1_EmptyExtraPodSpecRoundTrip(t *testing.T) {
+	src := &DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "empty-extra-pod-spec", Namespace: "ns"},
+		Spec: DynamoGraphDeploymentSpec{
+			Services: map[string]*DynamoComponentDeploymentSharedSpec{
+				"worker": {
+					ComponentType: "worker",
+					ExtraPodSpec:  &ExtraPodSpec{},
+				},
+			},
+		},
+	}
+
+	got := roundTripFromV1alpha1(t, src)
+	if got.Spec.Services["worker"].ExtraPodSpec == nil {
+		t.Fatalf("empty ExtraPodSpec pointer did not round-trip: %#v", got.Spec.Services["worker"])
+	}
+}
+
+// TestDGD_ConvertFrom_ScrubsLingeringAnnotations asserts that legacy
+// "nvidia.com/dgd-comp-*" annotations are dropped by ConvertFrom. Current DGD
+// conversion only uses sparse spec/status annotations.
 func TestDGD_ConvertFrom_ScrubsLingeringAnnotations(t *testing.T) {
 	src := &v1beta1.DynamoGraphDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "scrub",
 			Namespace: "ns",
 			Annotations: map[string]string{
-				"nvidia.com/dgd-comp-deleted-dynamo-namespace": "stale-value",
+				"nvidia.com/dgd-comp-aa-frontend-dynamo-namespace":     "stale-value",
+				"nvidia.com/dgd-comp-aa-frontend-frontend-sidecar-ref": "stale-value",
 				"user/keep-me": "kept",
 			},
 		},
@@ -1108,9 +1300,7 @@ func TestDGD_ConvertFrom_ScrubsLingeringAnnotations(t *testing.T) {
 	if err := a.ConvertFrom(src); err != nil {
 		t.Fatalf("ConvertFrom: %v", err)
 	}
-	if _, stale := a.ObjectMeta.Annotations["nvidia.com/dgd-comp-deleted-dynamo-namespace"]; stale {
-		t.Errorf("stale dgd-comp- annotation was not scrubbed: %v", a.ObjectMeta.Annotations)
-	}
+	assertNoDGDComponentAnnotations(t, a.ObjectMeta.Annotations)
 	if v, ok := a.ObjectMeta.Annotations["user/keep-me"]; !ok || v != "kept" {
 		t.Errorf("user annotations must be preserved, got %v", a.ObjectMeta.Annotations)
 	}
@@ -1178,74 +1368,32 @@ func TestDGD_ConvertFrom_DuplicateComponentNames(t *testing.T) {
 	}
 }
 
-// TestScrubStaleDGDAnnotations_HyphenatedNames directly exercises
-// scrubStaleDGDAnnotations on cases where either the component name or the
-// origin suffix (or both) contain "-". This is a regression test for a
-// previous bug where the function split the key on the first "-" after the
-// "nvidia.com/dgd-comp-" prefix and used the leading segment as the
-// component name; that approach silently dropped origin annotations for
-// hyphenated active components such as "aa-frontend" or "bb-worker".
+// TestScrubStaleDGDAnnotations_HyphenatedNames keeps coverage for the legacy
+// per-component DGD annotation shape. Hyphenated component names and suffixes
+// must not prevent scrubbing now that DGD uses sparse spec/status annotations.
 func TestScrubStaleDGDAnnotations_HyphenatedNames(t *testing.T) {
 	type tc struct {
-		name       string
-		components map[string]*DynamoComponentDeploymentSharedSpec
-		anns       map[string]string
-		wantKept   []string
-		wantGone   []string
+		name     string
+		anns     map[string]string
+		wantKept []string
+		wantGone []string
 	}
 	cases := []tc{
 		{
-			name: "active hyphen-name component with multi-hyphen suffix is kept",
-			components: map[string]*DynamoComponentDeploymentSharedSpec{
-				"aa-frontend": {},
-			},
+			name: "hyphenated component with multi-hyphen suffix is scrubbed",
 			anns: map[string]string{
 				"nvidia.com/dgd-comp-aa-frontend-frontend-sidecar-ref": "ref",
 				"nvidia.com/dgd-comp-aa-frontend-dynamo-namespace":     "ns",
 				"user/keep-me": "kept",
 			},
-			wantKept: []string{
+			wantKept: []string{"user/keep-me"},
+			wantGone: []string{
 				"nvidia.com/dgd-comp-aa-frontend-frontend-sidecar-ref",
 				"nvidia.com/dgd-comp-aa-frontend-dynamo-namespace",
-				"user/keep-me",
 			},
 		},
 		{
-			name: "stale hyphen-name annotations are scrubbed when no match",
-			components: map[string]*DynamoComponentDeploymentSharedSpec{
-				"keeper": {},
-			},
-			anns: map[string]string{
-				"nvidia.com/dgd-comp-old-worker-frontend-sidecar-ref": "stale",
-				"nvidia.com/dgd-comp-deleted-dynamo-namespace":        "stale",
-				"nvidia.com/dgd-comp-keeper-dynamo-namespace":         "active",
-			},
-			wantKept: []string{"nvidia.com/dgd-comp-keeper-dynamo-namespace"},
-			wantGone: []string{
-				"nvidia.com/dgd-comp-old-worker-frontend-sidecar-ref",
-				"nvidia.com/dgd-comp-deleted-dynamo-namespace",
-			},
-		},
-		{
-			name: "shorter active prefix does not falsely match longer stale name",
-			components: map[string]*DynamoComponentDeploymentSharedSpec{
-				// "aa" is active; "aa-frontend" is NOT. An annotation key
-				// like "...-aa-frontend-..." is ambiguous (could be "aa"
-				// + suffix "frontend-..." OR "aa-frontend" + suffix). The
-				// scrub function treats it as "for aa" and keeps it; that
-				// is acceptable because the encoding cannot distinguish.
-				"aa": {},
-			},
-			anns: map[string]string{
-				"nvidia.com/dgd-comp-aa-frontend-sidecar-ref": "ambiguous-keep",
-				"nvidia.com/dgd-comp-zz-dynamo-namespace":     "stale",
-			},
-			wantKept: []string{"nvidia.com/dgd-comp-aa-frontend-sidecar-ref"},
-			wantGone: []string{"nvidia.com/dgd-comp-zz-dynamo-namespace"},
-		},
-		{
-			name:       "non-dgd-comp annotations are never touched",
-			components: map[string]*DynamoComponentDeploymentSharedSpec{},
+			name: "non-dgd-comp annotations are never touched",
 			anns: map[string]string{
 				"foo":                      "bar",
 				"nvidia.com/dcd-something": "kept",
@@ -1256,7 +1404,7 @@ func TestScrubStaleDGDAnnotations_HyphenatedNames(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			obj := &metav1.ObjectMeta{Annotations: maps.Clone(c.anns)}
-			scrubStaleDGDAnnotations(obj, c.components)
+			scrubDGDInternalAnnotations(obj)
 			for _, k := range c.wantKept {
 				if _, ok := obj.Annotations[k]; !ok {
 					t.Errorf("expected %q to be kept; got annotations: %v", k, obj.Annotations)
@@ -1323,11 +1471,9 @@ func intstrFromInt32(v int32) intstr.IntOrString {
 }
 
 // TestDGD_FromV1alpha1_FrontendSidecarFullRoundTrip exercises the v1alpha1-first
-// FrontendSidecar path: the full FrontendSidecarSpec is stashed under the
-// suffixFrontendSidecar origin annotation on ConvertTo (covers
-// buildPodTemplateTo's "full spec -> name reference" branch) and restored from
-// that annotation on ConvertFrom (covers decomposePodTemplate's
-// "annotation present -> unmarshal + drop container from other" branch).
+// FrontendSidecar path: the full FrontendSidecarSpec is saved sparsely on
+// ConvertTo and restored on ConvertFrom while v1beta1 carries only the name
+// reference.
 func TestDGD_FromV1alpha1_FrontendSidecarFullRoundTrip(t *testing.T) {
 	secret := "frontend-secret"
 	src := &DynamoGraphDeployment{
@@ -1376,9 +1522,10 @@ func TestDGD_FromV1alpha1_FrontendSidecarFullRoundTrip(t *testing.T) {
 	if sidecar.Image != "dynamo-frontend:1.2.3" {
 		t.Errorf("sidecar image: got %q, want %q", sidecar.Image, "dynamo-frontend:1.2.3")
 	}
-	want := "nvidia.com/dgd-comp-epp-" + suffixFrontendSidecar
-	if _, ok := b.Annotations[want]; !ok {
-		t.Errorf("expected origin annotation %q to be set, got %v", want, b.Annotations)
+	assertNoDGDComponentAnnotations(t, b.Annotations)
+	saved := mustRestoreDGDSpokeServiceSave(t, b, "epp")
+	if saved.FrontendSidecar == nil {
+		t.Fatalf("expected frontendSidecar in sparse spoke save, got %#v", saved)
 	}
 
 	got := &DynamoGraphDeployment{}
@@ -1388,16 +1535,14 @@ func TestDGD_FromV1alpha1_FrontendSidecarFullRoundTrip(t *testing.T) {
 	if diff := cmp.Diff(src, got, cmpopts.EquateEmpty()); diff != "" {
 		t.Errorf("FrontendSidecar round-trip mismatch (-want +got):\n%s", diff)
 	}
-	if _, leaked := got.Annotations["nvidia.com/dgd-comp-epp-"+suffixFrontendSidecar]; leaked {
-		t.Errorf("origin annotation was not consumed: %v", got.Annotations)
-	}
+	assertNoDGDComponentAnnotations(t, got.Annotations)
 }
 
 // TestDGD_FromV1alpha1_GMSEnabledFalseEmptyPayload targets the
-// "Enabled=false with zero-valued payload -> `{}` annotation" branch in
+// "Enabled=false with zero-valued payload -> sparse save" branch in
 // convertExperimentalTo for GPUMemoryService. The v1alpha1 pointer
 // &GPUMemoryServiceSpec{} (no Mode, no DeviceClassName) must round-trip
-// through the annotation without being collapsed to nil.
+// through sparse spec preservation without being collapsed to nil.
 func TestDGD_FromV1alpha1_GMSEnabledFalseEmptyPayload(t *testing.T) {
 	src := &DynamoGraphDeployment{
 		ObjectMeta: metav1.ObjectMeta{Name: "gms-empty", Namespace: "ns"},
@@ -1414,9 +1559,10 @@ func TestDGD_FromV1alpha1_GMSEnabledFalseEmptyPayload(t *testing.T) {
 	if err := src.ConvertTo(b); err != nil {
 		t.Fatalf("ConvertTo: %v", err)
 	}
-	key := "nvidia.com/dgd-comp-worker-" + suffixGMSDisabled
-	if v, ok := b.Annotations[key]; !ok || v != `{}` {
-		t.Errorf("expected annotation %q=%q, got %v", key, `{}`, b.Annotations)
+	assertNoDGDComponentAnnotations(t, b.Annotations)
+	saved := mustRestoreDGDSpokeServiceSave(t, b, "worker")
+	if saved.GPUMemoryService == nil || saved.GPUMemoryService.Enabled {
+		t.Fatalf("expected disabled GPUMemoryService in sparse save, got %#v", saved.GPUMemoryService)
 	}
 
 	got := roundTripFromV1alpha1(t, src)
@@ -1443,9 +1589,10 @@ func TestDGD_FromV1alpha1_FailoverEnabledFalseEmptyPayload(t *testing.T) {
 	if err := src.ConvertTo(b); err != nil {
 		t.Fatalf("ConvertTo: %v", err)
 	}
-	key := "nvidia.com/dgd-comp-worker-" + suffixFailoverDisabled
-	if v, ok := b.Annotations[key]; !ok || v != `{}` {
-		t.Errorf("expected annotation %q=%q, got %v", key, `{}`, b.Annotations)
+	assertNoDGDComponentAnnotations(t, b.Annotations)
+	saved := mustRestoreDGDSpokeServiceSave(t, b, "worker")
+	if saved.Failover == nil || saved.Failover.Enabled {
+		t.Fatalf("expected disabled Failover in sparse save, got %#v", saved.Failover)
 	}
 
 	got := roundTripFromV1alpha1(t, src)
@@ -1455,7 +1602,7 @@ func TestDGD_FromV1alpha1_FailoverEnabledFalseEmptyPayload(t *testing.T) {
 }
 
 // TestDGD_FromV1alpha1_CheckpointEnabledFalseEmptyPayload covers the same
-// "Enabled=false with zero-valued payload -> `{}` annotation" branch for the
+// "Enabled=false with zero-valued payload -> sparse save" branch for the
 // Checkpoint sibling in convertExperimentalTo.
 func TestDGD_FromV1alpha1_CheckpointEnabledFalseEmptyPayload(t *testing.T) {
 	src := &DynamoGraphDeployment{
@@ -1473,9 +1620,10 @@ func TestDGD_FromV1alpha1_CheckpointEnabledFalseEmptyPayload(t *testing.T) {
 	if err := src.ConvertTo(b); err != nil {
 		t.Fatalf("ConvertTo: %v", err)
 	}
-	key := "nvidia.com/dgd-comp-worker-" + suffixCheckpointDisabled
-	if v, ok := b.Annotations[key]; !ok || v != `{}` {
-		t.Errorf("expected annotation %q=%q, got %v", key, `{}`, b.Annotations)
+	assertNoDGDComponentAnnotations(t, b.Annotations)
+	saved := mustRestoreDGDSpokeServiceSave(t, b, "worker")
+	if saved.Checkpoint == nil || saved.Checkpoint.Enabled {
+		t.Fatalf("expected disabled Checkpoint in sparse save, got %#v", saved.Checkpoint)
 	}
 
 	got := roundTripFromV1alpha1(t, src)
@@ -1590,18 +1738,18 @@ func TestDGD_ApplyIdempotence_GenerationBump(t *testing.T) {
 }
 
 // TestDGD_ApplyIdempotence_EmptySharedMemoryOrigin pins the twin invariant for
-// the `&SharedMemorySpec{}` -> v1beta1 empty-origin annotation path. The empty
+// the `&SharedMemorySpec{}` -> v1beta1 sparse-save path. The empty
 // struct has `Size: resource.Quantity{}` which serializes to "0" (Quantity is
 // a non-pointer struct, so encoding/json's omitempty does not drop it); after
 // the etcd JSON round-trip the Size becomes a canonical zero Quantity that is
 // not reflect.DeepEqual to the Go zero value. Without the fix in
 // convertSharedMemoryFrom, every reapply of a v1beta1 object carrying the
-// empty-origin annotation would bump .metadata.generation.
+// sparse save would bump .metadata.generation.
 func TestDGD_ApplyIdempotence_EmptySharedMemoryOrigin(t *testing.T) {
 	// Seed a v1alpha1 object whose only non-default bit is SharedMemory =
 	// &SharedMemorySpec{}, then run it through ConvertTo once so the
-	// produced v1beta1 carries the "shared-memory-origin=empty" annotation
-	// we need to exercise the empty branch of convertSharedMemoryFrom.
+	// produced v1beta1 carries the sparse save we need to exercise the empty
+	// branch of convertSharedMemoryFrom.
 	a1 := &DynamoGraphDeployment{
 		ObjectMeta: metav1.ObjectMeta{Name: "shm-empty", Namespace: "ns"},
 		Spec: DynamoGraphDeploymentSpec{
@@ -1617,10 +1765,12 @@ func TestDGD_ApplyIdempotence_EmptySharedMemoryOrigin(t *testing.T) {
 	if err := a1.ConvertTo(b1); err != nil {
 		t.Fatalf("seed ConvertTo: %v", err)
 	}
-	// Sanity: the empty-origin annotation is what triggers the path we want
-	// to cover; fail loudly if future refactors break the assumption.
-	if _, ok := b1.Annotations["nvidia.com/dgd-comp-worker-shared-memory-origin"]; !ok {
-		t.Fatalf("expected shared-memory-origin=empty annotation on v1beta1, got: %#v", b1.Annotations)
+	// Sanity: the sparse spoke save is what triggers the path we want to
+	// cover; fail loudly if future refactors break the assumption.
+	assertNoDGDComponentAnnotations(t, b1.Annotations)
+	saved := mustRestoreDGDSpokeServiceSave(t, b1, "worker")
+	if saved.SharedMemory == nil {
+		t.Fatalf("expected sharedMemory in sparse spoke save, got: %#v", saved)
 	}
 
 	// First apply: ConvertFrom takes the empty branch and produces the

--- a/deploy/operator/api/v1alpha1/dynamographdeployment_conversion_test.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeployment_conversion_test.go
@@ -19,7 +19,6 @@ package v1alpha1
 
 import (
 	"encoding/json"
-	"maps"
 	"reflect"
 	"strings"
 	"testing"
@@ -72,11 +71,13 @@ func roundTripFromV1alpha1(t *testing.T, src *DynamoGraphDeployment) *DynamoGrap
 	return out
 }
 
-func assertNoDGDComponentAnnotations(t *testing.T, annotations map[string]string) {
+func assertOnlyKnownDGDAnnotations(t *testing.T, annotations map[string]string) {
 	t.Helper()
 	for key := range annotations {
-		if strings.HasPrefix(key, annDGDComponentLegacyPrefix) {
-			t.Fatalf("unexpected legacy DGD component annotation %q in %v", key, annotations)
+		switch key {
+		case annDGDHubSpec, annDGDSpokeSpec, annDGDSpokeStatus:
+		default:
+			t.Fatalf("unexpected annotation %q in %v", key, annotations)
 		}
 	}
 }
@@ -290,7 +291,7 @@ func TestDGD_SpokeSaveCarriesAlphaOnlyFieldsSparsely(t *testing.T) {
 	if err := src.ConvertTo(hub); err != nil {
 		t.Fatalf("ConvertTo: %v", err)
 	}
-	assertNoDGDComponentAnnotations(t, hub.Annotations)
+	assertOnlyKnownDGDAnnotations(t, hub.Annotations)
 	raw := hub.Annotations[annDGDSpokeSpec]
 	if raw == "" {
 		t.Fatalf("expected alpha-only fields in %q, got %v", annDGDSpokeSpec, hub.Annotations)
@@ -1281,66 +1282,6 @@ func TestDGD_FromV1alpha1_EmptyExtraPodSpecRoundTrip(t *testing.T) {
 	}
 }
 
-// TestDGD_ConvertFrom_ScrubsLingeringAnnotations asserts that legacy
-// "nvidia.com/dgd-comp-*" annotations are dropped by ConvertFrom. Current DGD
-// conversion only uses sparse spec/status annotations.
-func TestDGD_ConvertFrom_ScrubsLingeringAnnotations(t *testing.T) {
-	src := &v1beta1.DynamoGraphDeployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "scrub",
-			Namespace: "ns",
-			Annotations: map[string]string{
-				"nvidia.com/dgd-comp-aa-frontend-dynamo-namespace":     "stale-value",
-				"nvidia.com/dgd-comp-aa-frontend-frontend-sidecar-ref": "stale-value",
-				"user/keep-me": "kept",
-			},
-		},
-	}
-	a := &DynamoGraphDeployment{}
-	if err := a.ConvertFrom(src); err != nil {
-		t.Fatalf("ConvertFrom: %v", err)
-	}
-	assertNoDGDComponentAnnotations(t, a.ObjectMeta.Annotations)
-	if v, ok := a.ObjectMeta.Annotations["user/keep-me"]; !ok || v != "kept" {
-		t.Errorf("user annotations must be preserved, got %v", a.ObjectMeta.Annotations)
-	}
-}
-
-func TestDGD_ConvertFrom_ScrubsLegacySpokeHubAnnotation(t *testing.T) {
-	src := &v1beta1.DynamoGraphDeployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "legacy-spoke-hub",
-			Namespace: "ns",
-			Annotations: map[string]string{
-				annDGDSpokeHubLegacy: `{"spec":{},"status":{}}`,
-				"user/keep-me":       "kept",
-			},
-		},
-	}
-
-	spoke := &DynamoGraphDeployment{}
-	if err := spoke.ConvertFrom(src); err != nil {
-		t.Fatalf("ConvertFrom: %v", err)
-	}
-	if _, ok := spoke.Annotations[annDGDSpokeHubLegacy]; ok {
-		t.Fatalf("legacy annotation was not scrubbed from spoke: %v", spoke.Annotations)
-	}
-	if v, ok := spoke.Annotations["user/keep-me"]; !ok || v != "kept" {
-		t.Fatalf("user annotations must be preserved, got %v", spoke.Annotations)
-	}
-
-	hub := &v1beta1.DynamoGraphDeployment{}
-	if err := spoke.ConvertTo(hub); err != nil {
-		t.Fatalf("ConvertTo: %v", err)
-	}
-	if _, ok := hub.Annotations[annDGDSpokeHubLegacy]; ok {
-		t.Fatalf("legacy annotation leaked back to hub: %v", hub.Annotations)
-	}
-	if v, ok := hub.Annotations["user/keep-me"]; !ok || v != "kept" {
-		t.Fatalf("user annotations must be preserved, got %v", hub.Annotations)
-	}
-}
-
 // TestDGD_ConvertFrom_DuplicateComponentNames asserts that ConvertFrom
 // returns an error when the v1beta1 spec.components list has two entries
 // with the same componentName, instead of silently overwriting the earlier
@@ -1365,57 +1306,6 @@ func TestDGD_ConvertFrom_DuplicateComponentNames(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "duplicate component name") {
 		t.Errorf("error message should mention duplicate component name, got %q", err.Error())
-	}
-}
-
-// TestScrubStaleDGDAnnotations_HyphenatedNames keeps coverage for the legacy
-// per-component DGD annotation shape. Hyphenated component names and suffixes
-// must not prevent scrubbing now that DGD uses sparse spec/status annotations.
-func TestScrubStaleDGDAnnotations_HyphenatedNames(t *testing.T) {
-	type tc struct {
-		name     string
-		anns     map[string]string
-		wantKept []string
-		wantGone []string
-	}
-	cases := []tc{
-		{
-			name: "hyphenated component with multi-hyphen suffix is scrubbed",
-			anns: map[string]string{
-				"nvidia.com/dgd-comp-aa-frontend-frontend-sidecar-ref": "ref",
-				"nvidia.com/dgd-comp-aa-frontend-dynamo-namespace":     "ns",
-				"user/keep-me": "kept",
-			},
-			wantKept: []string{"user/keep-me"},
-			wantGone: []string{
-				"nvidia.com/dgd-comp-aa-frontend-frontend-sidecar-ref",
-				"nvidia.com/dgd-comp-aa-frontend-dynamo-namespace",
-			},
-		},
-		{
-			name: "non-dgd-comp annotations are never touched",
-			anns: map[string]string{
-				"foo":                      "bar",
-				"nvidia.com/dcd-something": "kept",
-			},
-			wantKept: []string{"foo", "nvidia.com/dcd-something"},
-		},
-	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			obj := &metav1.ObjectMeta{Annotations: maps.Clone(c.anns)}
-			scrubDGDInternalAnnotations(obj)
-			for _, k := range c.wantKept {
-				if _, ok := obj.Annotations[k]; !ok {
-					t.Errorf("expected %q to be kept; got annotations: %v", k, obj.Annotations)
-				}
-			}
-			for _, k := range c.wantGone {
-				if _, ok := obj.Annotations[k]; ok {
-					t.Errorf("expected %q to be scrubbed; got annotations: %v", k, obj.Annotations)
-				}
-			}
-		})
 	}
 }
 
@@ -1522,7 +1412,7 @@ func TestDGD_FromV1alpha1_FrontendSidecarFullRoundTrip(t *testing.T) {
 	if sidecar.Image != "dynamo-frontend:1.2.3" {
 		t.Errorf("sidecar image: got %q, want %q", sidecar.Image, "dynamo-frontend:1.2.3")
 	}
-	assertNoDGDComponentAnnotations(t, b.Annotations)
+	assertOnlyKnownDGDAnnotations(t, b.Annotations)
 	saved := mustRestoreDGDSpokeServiceSave(t, b, "epp")
 	if saved.FrontendSidecar == nil {
 		t.Fatalf("expected frontendSidecar in sparse spoke save, got %#v", saved)
@@ -1535,7 +1425,7 @@ func TestDGD_FromV1alpha1_FrontendSidecarFullRoundTrip(t *testing.T) {
 	if diff := cmp.Diff(src, got, cmpopts.EquateEmpty()); diff != "" {
 		t.Errorf("FrontendSidecar round-trip mismatch (-want +got):\n%s", diff)
 	}
-	assertNoDGDComponentAnnotations(t, got.Annotations)
+	assertOnlyKnownDGDAnnotations(t, got.Annotations)
 }
 
 // TestDGD_FromV1alpha1_GMSEnabledFalseEmptyPayload targets the
@@ -1559,7 +1449,7 @@ func TestDGD_FromV1alpha1_GMSEnabledFalseEmptyPayload(t *testing.T) {
 	if err := src.ConvertTo(b); err != nil {
 		t.Fatalf("ConvertTo: %v", err)
 	}
-	assertNoDGDComponentAnnotations(t, b.Annotations)
+	assertOnlyKnownDGDAnnotations(t, b.Annotations)
 	saved := mustRestoreDGDSpokeServiceSave(t, b, "worker")
 	if saved.GPUMemoryService == nil || saved.GPUMemoryService.Enabled {
 		t.Fatalf("expected disabled GPUMemoryService in sparse save, got %#v", saved.GPUMemoryService)
@@ -1589,7 +1479,7 @@ func TestDGD_FromV1alpha1_FailoverEnabledFalseEmptyPayload(t *testing.T) {
 	if err := src.ConvertTo(b); err != nil {
 		t.Fatalf("ConvertTo: %v", err)
 	}
-	assertNoDGDComponentAnnotations(t, b.Annotations)
+	assertOnlyKnownDGDAnnotations(t, b.Annotations)
 	saved := mustRestoreDGDSpokeServiceSave(t, b, "worker")
 	if saved.Failover == nil || saved.Failover.Enabled {
 		t.Fatalf("expected disabled Failover in sparse save, got %#v", saved.Failover)
@@ -1620,7 +1510,7 @@ func TestDGD_FromV1alpha1_CheckpointEnabledFalseEmptyPayload(t *testing.T) {
 	if err := src.ConvertTo(b); err != nil {
 		t.Fatalf("ConvertTo: %v", err)
 	}
-	assertNoDGDComponentAnnotations(t, b.Annotations)
+	assertOnlyKnownDGDAnnotations(t, b.Annotations)
 	saved := mustRestoreDGDSpokeServiceSave(t, b, "worker")
 	if saved.Checkpoint == nil || saved.Checkpoint.Enabled {
 		t.Fatalf("expected disabled Checkpoint in sparse save, got %#v", saved.Checkpoint)
@@ -1767,7 +1657,7 @@ func TestDGD_ApplyIdempotence_EmptySharedMemoryOrigin(t *testing.T) {
 	}
 	// Sanity: the sparse spoke save is what triggers the path we want to
 	// cover; fail loudly if future refactors break the assumption.
-	assertNoDGDComponentAnnotations(t, b1.Annotations)
+	assertOnlyKnownDGDAnnotations(t, b1.Annotations)
 	saved := mustRestoreDGDSpokeServiceSave(t, b1, "worker")
 	if saved.SharedMemory == nil {
 		t.Fatalf("expected sharedMemory in sparse spoke save, got: %#v", saved)

--- a/deploy/operator/api/v1alpha1/shared_spec_conversion.go
+++ b/deploy/operator/api/v1alpha1/shared_spec_conversion.go
@@ -20,19 +20,17 @@
 // DynamoComponentDeploymentSharedSpec is the payload that differs most between
 // v1alpha1 and v1beta1: v1alpha1 has ten per-service pod-configuration fields,
 // v1beta1 replaces them with a single corev1.PodTemplateSpec plus a few
-// first-class fields. The heavy lifting (podTemplate <-> flat fields,
-// experimental block, origin annotations for lossy conversions) lives here so
-// that the DGD and DCD conversion entry points stay thin.
+// first-class fields. The heavy lifting (podTemplate <-> flat fields and the
+// experimental block) lives here so that the DGD and DCD conversion entry
+// points stay thin.
 //
 // Round-trip fidelity
 //
 // Every v1beta1 field that has no v1alpha1 equivalent, and every v1alpha1
-// field that has no v1beta1 equivalent, is stashed under a reserved
-// "nvidia.com/dgd-..." or "nvidia.com/dcd-..." annotation so that
-// ConvertTo(ConvertFrom(V)) == V for every v1beta1 input V. The annotation
-// namespace is operator-managed; user-set annotations with the same prefix
-// are parsed best-effort (an unparseable value is ignored rather than
-// erroring) and dropped on ConvertFrom once consumed.
+// field that has no v1beta1 equivalent, is saved by the caller in a sparse
+// typed spec/status annotation. This file only restores from the typed
+// preserved value it receives; it does not read or write annotation side
+// channels.
 
 package v1alpha1
 
@@ -42,7 +40,6 @@ import (
 	"maps"
 	"reflect"
 	"slices"
-	"strings"
 
 	"github.com/imdario/mergo"
 	corev1 "k8s.io/api/core/v1"
@@ -70,129 +67,8 @@ const (
 	// Resources.{Requests,Limits}.GPU without specifying GPUType.
 	defaultGPUResourceName = corev1.ResourceName("nvidia.com/gpu")
 
-	annotationTrue                 = "true"
-	annotationPodTemplateGenerated = "generated"
-
-	// Shared-spec annotation key suffixes. Combined with the parent DCD
-	// object's prefix ("nvidia.com/dcd-") to form the full annotation key.
-	//
-	// suffixServiceName preserves standalone DCDs where ServiceName was omitted
-	// and v1beta1 used ObjectMeta.Name as the fallback.
-	suffixServiceName      = "service-name"
-	suffixDynamoNamespace  = "dynamo-namespace"
-	suffixAutoscaling      = "autoscaling"
-	suffixIngress          = "ingress"
-	suffixSubComponentType = "sub-component-type"
-	suffixEnvFromSecret    = "env-from-secret"
-	suffixAnnotations      = "annotations"
-	suffixLabels           = "labels"
-	suffixSharedMemOrigin  = "shared-memory-origin"
-	suffixResourcesOrigin  = "resources-origin"
-	suffixVolumeMountsOrig = "volume-mounts-origin"
-	suffixPodTemplateOrig  = "pod-template-origin"
-	suffixPodMetadataOrig  = "pod-metadata-origin"
-	suffixFrontendSidecar  = "frontend-sidecar-origin"
-	// suffixFrontendSidecarRef is used for v1beta1-first inputs that set
-	// FrontendSidecar to a container name without a v1alpha1 origin. The
-	// referenced container flows through ExtraPodSpec.PodSpec.Containers
-	// as a regular user sidecar on the v1alpha1 side.
-	suffixFrontendSidecarRef = "frontend-sidecar-ref"
-	suffixExperimentalOrig   = "experimental-origin"
-	suffixGMSDisabled        = "gms-disabled-payload"
-	suffixFailoverDisabled   = "failover-disabled-payload"
-	suffixCheckpointDisabled = "checkpoint-disabled-payload"
-	suffixScalingDisabled    = "scaling-adapter-disabled"
-
-	// DCD-scoped annotation keys (standalone DCDs carry origin data on their
-	// own metadata rather than on a parent DGD).
-	annDCDPrefix = "nvidia.com/dcd-"
+	annotationTrue = "true"
 )
-
-// annCarrier wraps a Kubernetes object's annotation bag for a standalone DCD.
-// DGD uses typed sparse spec/status annotations instead of per-component
-// annotation carriers.
-type annCarrier struct {
-	obj    metav1.Object
-	prefix string
-}
-
-// newDCDCarrier returns a carrier scoped to a standalone DCD: keys are of the
-// form "nvidia.com/dcd-<suffix>".
-func newDCDCarrier(obj metav1.Object) *annCarrier {
-	return &annCarrier{obj: obj, prefix: annDCDPrefix}
-}
-
-func (c *annCarrier) key(suffix string) string { return c.prefix + suffix }
-
-func (c *annCarrier) set(suffix, value string) {
-	if c == nil {
-		return
-	}
-	anns := c.obj.GetAnnotations()
-	if anns == nil {
-		anns = map[string]string{}
-	}
-	anns[c.key(suffix)] = value
-	c.obj.SetAnnotations(anns)
-}
-
-func (c *annCarrier) get(suffix string) (string, bool) {
-	if c == nil {
-		return "", false
-	}
-	anns := c.obj.GetAnnotations()
-	if anns == nil {
-		return "", false
-	}
-	v, ok := anns[c.key(suffix)]
-	return v, ok
-}
-
-func (c *annCarrier) del(suffix string) {
-	if c == nil {
-		return
-	}
-	anns := c.obj.GetAnnotations()
-	if anns == nil {
-		return
-	}
-	delete(anns, c.key(suffix))
-	if len(anns) == 0 {
-		c.obj.SetAnnotations(nil)
-	} else {
-		c.obj.SetAnnotations(anns)
-	}
-}
-
-func setJSONAnn(c *annCarrier, suffix string, value any) {
-	if c == nil {
-		return
-	}
-	data, err := json.Marshal(value)
-	if err != nil {
-		return
-	}
-	c.set(suffix, string(data))
-}
-
-func popJSONAnn[T any](c *annCarrier, suffix string) (T, bool) {
-	var out T
-	if c == nil {
-		return out, false
-	}
-	raw, ok := c.get(suffix)
-	if !ok {
-		return out, false
-	}
-	c.del(suffix)
-	if raw == "" {
-		return out, false
-	}
-	if err := json.Unmarshal([]byte(raw), &out); err != nil {
-		return out, false
-	}
-	return out, true
-}
 
 // setAnnOnObj is a convenience for object-level preservation annotations.
 func setAnnOnObj(obj metav1.Object, key, value string) {
@@ -256,31 +132,11 @@ func delAnnFromObj(obj metav1.Object, key string) {
 	}
 }
 
-// scrubAnnotationsByPrefix removes every annotation whose key starts with
-// prefix, collapsing the map back to nil if nothing remains. Used by the DGD
-// and DCD ConvertFrom paths to clean up any reserved origin keys that were
-// not consumed (e.g. v1alpha1 client left a stale entry).
-func scrubAnnotationsByPrefix(obj metav1.Object, prefix string) {
-	anns := obj.GetAnnotations()
-	if len(anns) == 0 {
-		return
-	}
-	maps.DeleteFunc(anns, func(k, _ string) bool {
-		return strings.HasPrefix(k, prefix)
-	})
-	if len(anns) == 0 {
-		obj.SetAnnotations(nil)
-	} else {
-		obj.SetAnnotations(anns)
-	}
-}
-
 // ---------------------------------------------------------------------------
 // Shared-spec conversion entry points
 // ---------------------------------------------------------------------------
 
 type sharedSpecConversionContext struct {
-	carrier             *annCarrier
 	includeOriginSplits bool
 	podTemplateOrigin   bool
 }
@@ -299,13 +155,6 @@ func convertSharedSpecToHub(src *DynamoComponentDeploymentSharedSpec, dst *v1bet
 	// validator, which matches the intended behaviour.
 	dst.ComponentType = v1beta1.ComponentType(src.ComponentType)
 
-	// SubComponentType has no v1beta1 equivalent -- the "prefill"/"decode"
-	// values are first-class ComponentType enum values in v1beta1. Stash the
-	// raw string on the carrier so round-trip restores the original wording.
-	if src.SubComponentType != "" && ctx.carrier != nil {
-		ctx.carrier.set(suffixSubComponentType, src.SubComponentType)
-	}
-
 	// v1alpha1 ServiceName <-> v1beta1 ComponentName: the same logical
 	// identifier, renamed at v1beta1 to align with the
 	// `spec.components` rename. For DGD components the caller overrides
@@ -313,11 +162,6 @@ func convertSharedSpecToHub(src *DynamoComponentDeploymentSharedSpec, dst *v1bet
 	// source of truth on v1alpha1); for standalone DCDs the caller falls
 	// back to ObjectMeta.Name when src.ServiceName is empty.
 	dst.ComponentName = src.ServiceName
-
-	// DynamoNamespace (deprecated) -> annotation.
-	if src.DynamoNamespace != nil && ctx.carrier != nil {
-		ctx.carrier.set(suffixDynamoNamespace, *src.DynamoNamespace)
-	}
 
 	dst.GlobalDynamoNamespace = src.GlobalDynamoNamespace
 	dst.Replicas = src.Replicas
@@ -346,12 +190,8 @@ func convertSharedSpecToHub(src *DynamoComponentDeploymentSharedSpec, dst *v1bet
 		}
 	}
 
-	if ctx.carrier != nil {
-		preserveV1Alpha1OnlySharedFields(src, ctx.carrier)
-	}
-
 	// sharedMemory <-> sharedMemorySize (lossy struct flatten).
-	if err := convertSharedMemoryTo(src.SharedMemory, dst, ctx.carrier); err != nil {
+	if err := convertSharedMemoryTo(src.SharedMemory, dst); err != nil {
 		return err
 	}
 
@@ -368,10 +208,10 @@ func convertSharedSpecToHub(src *DynamoComponentDeploymentSharedSpec, dst *v1bet
 	}
 
 	// scalingAdapter: drop Enabled bool, keep presence semantics.
-	convertScalingAdapterTo(src.ScalingAdapter, dst, ctx.carrier)
+	convertScalingAdapterTo(src.ScalingAdapter, dst)
 
 	// experimental block: gpuMemoryService, failover, checkpoint.
-	convertExperimentalTo(src, dst, ctx.carrier)
+	convertExperimentalTo(src, dst)
 
 	// Resources + envs + probes + mainContainer -> podTemplate.containers[main].
 	if err := buildPodTemplateTo(src, dst, ctx); err != nil {
@@ -383,38 +223,6 @@ func convertSharedSpecToHub(src *DynamoComponentDeploymentSharedSpec, dst *v1bet
 		saveSharedAlphaOnlySpec(src, save, ctx.includeOriginSplits)
 	}
 	return nil
-}
-
-func preserveV1Alpha1OnlySharedFields(src *DynamoComponentDeploymentSharedSpec, c *annCarrier) {
-	// Autoscaling -> annotation (deprecated, removed in v1beta1).
-	if src.Autoscaling != nil {
-		setJSONAnn(c, suffixAutoscaling, src.Autoscaling)
-	}
-	// Ingress -> annotation (removed in v1beta1).
-	if src.Ingress != nil {
-		setJSONAnn(c, suffixIngress, src.Ingress)
-	}
-	// EnvFromSecret -> podTemplate.containers[main].envFrom; preserve the
-	// pointer string so ConvertFrom can distinguish it from native envFrom.
-	if src.EnvFromSecret != nil {
-		c.set(suffixEnvFromSecret, *src.EnvFromSecret)
-	}
-	// Per-service Annotations / Labels apply beyond podTemplate.metadata.
-	if len(src.Annotations) > 0 {
-		setJSONAnn(c, suffixAnnotations, src.Annotations)
-	}
-	if len(src.Labels) > 0 {
-		setJSONAnn(c, suffixLabels, src.Labels)
-	}
-	if extraPodMetadataNeedsPreservation(src.ExtraPodMetadata) {
-		setJSONAnn(c, suffixPodMetadataOrig, src.ExtraPodMetadata)
-	}
-	if src.Resources != nil && !reflect.DeepEqual(src.Resources, resourcesFromNative(resourcesToNative(src.Resources))) {
-		setJSONAnn(c, suffixResourcesOrigin, src.Resources)
-	}
-	if len(src.VolumeMounts) > 0 && !volumeMountsRoundTripThroughHub(src.VolumeMounts) {
-		setJSONAnn(c, suffixVolumeMountsOrig, src.VolumeMounts)
-	}
 }
 
 func fillSharedAlphaOnlyFromPreserved(dst *DynamoComponentDeploymentSharedSpec, preserved *DynamoComponentDeploymentSharedSpec, mainContainerPresent bool) {
@@ -681,44 +489,22 @@ func convertSharedSpecFromHub(src *v1beta1.DynamoComponentDeploymentSharedSpec, 
 	}
 
 	dst.ServiceName = src.ComponentName
-	if ctx.carrier != nil {
-		// Restore annotation-preserved v1alpha1 fields.
-		if v, ok := ctx.carrier.get(suffixSubComponentType); ok {
-			dst.SubComponentType = v
-			ctx.carrier.del(suffixSubComponentType)
-		}
-		if v, ok := ctx.carrier.get(suffixDynamoNamespace); ok {
-			dst.DynamoNamespace = ptr.To(v)
-			ctx.carrier.del(suffixDynamoNamespace)
-		}
-		if as, ok := popJSONAnn[Autoscaling](ctx.carrier, suffixAutoscaling); ok {
-			dst.Autoscaling = &as
-		}
-		if ing, ok := popJSONAnn[IngressSpec](ctx.carrier, suffixIngress); ok {
-			dst.Ingress = &ing
-		}
-		if m, ok := popJSONAnn[map[string]string](ctx.carrier, suffixAnnotations); ok {
-			dst.Annotations = m
-		}
-		if m, ok := popJSONAnn[map[string]string](ctx.carrier, suffixLabels); ok {
-			dst.Labels = m
-		}
-	}
+
 	// sharedMemorySize -> SharedMemorySpec.
-	convertSharedMemoryFrom(src.SharedMemorySize, dst, ctx.carrier)
+	convertSharedMemoryFrom(src.SharedMemorySize, dst)
 
 	// compilationCache + podTemplate volumeMounts -> VolumeMounts.
 	convertVolumeMountsFrom(src, dst)
 
 	// experimental -> GPUMemoryService, Failover, Checkpoint.
-	convertExperimentalFrom(src, dst, ctx.carrier)
+	convertExperimentalFrom(src, dst)
 
 	// scalingAdapter presence -> Enabled=true; annotation -> Enabled=false payload.
-	convertScalingAdapterFrom(src.ScalingAdapter, dst, ctx.carrier)
+	convertScalingAdapterFrom(src.ScalingAdapter, dst)
 
 	// podTemplate -> mainContainer + extraPodSpec + extraPodMetadata +
 	// Resources + Envs + Probes (+ FrontendSidecar).
-	if err := decomposePodTemplate(src, dst, restored, ctx.carrier); err != nil {
+	if err := decomposePodTemplate(src, dst, restored); err != nil {
 		return err
 	}
 
@@ -956,60 +742,21 @@ func sharedHubSpecSaveIsZero(save *v1beta1.DynamoComponentDeploymentSharedSpec) 
 // Shared-memory
 // ---------------------------------------------------------------------------
 
-func convertSharedMemoryTo(src *SharedMemorySpec, dst *v1beta1.DynamoComponentDeploymentSharedSpec, c *annCarrier) error {
+func convertSharedMemoryTo(src *SharedMemorySpec, dst *v1beta1.DynamoComponentDeploymentSharedSpec) error {
 	if src == nil {
 		return nil
 	}
-	// Disabled=true -> size "0" (no origin annotation needed: convertSharedMemoryFrom
-	// interprets a zero quantity without origin as Disabled=true, which is the
-	// canonical meaning of sharedMemorySize=0 on the v1beta1 side).
-	// Disabled=false with Size=X -> X.
-	// Disabled=false with Size=zero -> empty struct, which has no v1beta1
-	// equivalent; stash via annotation to preserve the explicit pointer.
 	if src.Disabled {
 		dst.SharedMemorySize = ptr.To(resource.MustParse("0"))
-		if !src.Size.IsZero() {
-			setJSONAnn(c, suffixSharedMemOrigin, src)
-		}
 		return nil
 	}
-	// Not disabled, with a set size -> copy verbatim.
 	if !src.Size.IsZero() {
 		dst.SharedMemorySize = ptr.To(src.Size.DeepCopy())
-		return nil
 	}
-	// Disabled=false, Size=zero -> this is an empty struct. ConvertFrom must
-	// be able to reproduce "&SharedMemorySpec{}", distinct from a nil pointer.
-	c.set(suffixSharedMemOrigin, "empty")
 	return nil
 }
 
-func convertSharedMemoryFrom(src *resource.Quantity, dst *DynamoComponentDeploymentSharedSpec, c *annCarrier) {
-	if v, ok := c.get(suffixSharedMemOrigin); ok {
-		c.del(suffixSharedMemOrigin)
-		if src != nil && src.Sign() != 0 {
-			dst.SharedMemory = &SharedMemorySpec{Size: src.DeepCopy()}
-			return
-		}
-		if v == "empty" {
-			// A bare SharedMemorySpec{} carries Size: Quantity{}, which
-			// serializes to "0" because resource.Quantity is a non-pointer
-			// struct (encoding/json's `omitempty` does not treat structs
-			// as empty). After the etcd JSON round-trip, Size comes back
-			// as a canonical zero Quantity that is NOT reflect.DeepEqual
-			// to the Go zero value, which would cause every
-			// kubectl apply to bump `.metadata.generation`. Emit the
-			// canonical zero form directly so reapplies are idempotent.
-			// See convertSharedMemoryFrom(disabled) for the twin case.
-			dst.SharedMemory = &SharedMemorySpec{Size: resource.MustParse("0")}
-			return
-		}
-		var sharedMemory SharedMemorySpec
-		if err := json.Unmarshal([]byte(v), &sharedMemory); err == nil {
-			dst.SharedMemory = &sharedMemory
-			return
-		}
-	}
+func convertSharedMemoryFrom(src *resource.Quantity, dst *DynamoComponentDeploymentSharedSpec) {
 	if src == nil {
 		return
 	}
@@ -1068,33 +815,18 @@ func convertVolumeMountsFrom(src *v1beta1.DynamoComponentDeploymentSharedSpec, d
 // Scaling adapter (Enabled flag removed in v1beta1)
 // ---------------------------------------------------------------------------
 
-func convertScalingAdapterTo(src *ScalingAdapter, dst *v1beta1.DynamoComponentDeploymentSharedSpec, c *annCarrier) {
+func convertScalingAdapterTo(src *ScalingAdapter, dst *v1beta1.DynamoComponentDeploymentSharedSpec) {
 	if src == nil {
 		return
 	}
 	if src.Enabled {
 		dst.ScalingAdapter = &v1beta1.ScalingAdapter{}
-		return
 	}
-	// Enabled=false with a populated struct is unreachable today (no other
-	// fields on v1alpha1 ScalingAdapter) but we still record presence so the
-	// v1alpha1 -> v1beta1 -> v1alpha1 round-trip preserves the caller's
-	// explicit "&ScalingAdapter{Enabled:false}" pointer.
-	c.set(suffixScalingDisabled, annotationTrue)
 }
 
-func convertScalingAdapterFrom(src *v1beta1.ScalingAdapter, dst *DynamoComponentDeploymentSharedSpec, c *annCarrier) {
+func convertScalingAdapterFrom(src *v1beta1.ScalingAdapter, dst *DynamoComponentDeploymentSharedSpec) {
 	if src != nil {
 		dst.ScalingAdapter = &ScalingAdapter{Enabled: true}
-		// Drop any stale v1alpha1-first "disabled" annotation: v1beta1 is
-		// authoritative in this direction and an enabled v1beta1 entry
-		// must not resurrect a previous Enabled:false on the next round.
-		c.del(suffixScalingDisabled)
-		return
-	}
-	if _, ok := c.get(suffixScalingDisabled); ok {
-		dst.ScalingAdapter = &ScalingAdapter{Enabled: false}
-		c.del(suffixScalingDisabled)
 	}
 }
 
@@ -1146,17 +878,13 @@ func checkpointModeFromV1beta1(mode v1beta1.CheckpointMode) CheckpointMode {
 	}
 }
 
-func convertExperimentalTo(src *DynamoComponentDeploymentSharedSpec, dst *v1beta1.DynamoComponentDeploymentSharedSpec, c *annCarrier) {
+func convertExperimentalTo(src *DynamoComponentDeploymentSharedSpec, dst *v1beta1.DynamoComponentDeploymentSharedSpec) {
 	var exp *v1beta1.ExperimentalSpec
 	ensureExp := func() *v1beta1.ExperimentalSpec {
 		if exp == nil {
 			exp = &v1beta1.ExperimentalSpec{}
 		}
 		return exp
-	}
-	if _, ok := c.get(suffixExperimentalOrig); ok {
-		ensureExp()
-		c.del(suffixExperimentalOrig)
 	}
 
 	if src.GPUMemoryService != nil {
@@ -1165,13 +893,6 @@ func convertExperimentalTo(src *DynamoComponentDeploymentSharedSpec, dst *v1beta
 				Mode:            gmsModeToV1beta1(src.GPUMemoryService.Mode),
 				DeviceClassName: src.GPUMemoryService.DeviceClassName,
 			}
-		} else if !gmsIsZeroPayload(src.GPUMemoryService) {
-			setJSONAnn(c, suffixGMSDisabled, src.GPUMemoryService)
-		} else {
-			// Enabled=false with an otherwise-empty payload is semantically
-			// indistinguishable from absence; still preserve the explicit
-			// pointer so round-trip reproduces &GPUMemoryServiceSpec{}.
-			c.set(suffixGMSDisabled, `{}`)
 		}
 	}
 
@@ -1181,47 +902,25 @@ func convertExperimentalTo(src *DynamoComponentDeploymentSharedSpec, dst *v1beta
 				Mode:       gmsModeToV1beta1(src.Failover.Mode),
 				NumShadows: src.Failover.NumShadows,
 			}
-		} else if !failoverIsZeroPayload(src.Failover) {
-			setJSONAnn(c, suffixFailoverDisabled, src.Failover)
-		} else {
-			c.set(suffixFailoverDisabled, `{}`)
 		}
 	}
 
 	if src.Checkpoint != nil {
 		if src.Checkpoint.Enabled {
 			ensureExp().Checkpoint = checkpointToV1beta1(src.Checkpoint)
-		} else if !checkpointIsZeroPayload(src.Checkpoint) {
-			setJSONAnn(c, suffixCheckpointDisabled, src.Checkpoint)
-		} else {
-			c.set(suffixCheckpointDisabled, `{}`)
 		}
 	}
 
 	dst.Experimental = exp
 }
 
-func convertExperimentalFrom(src *v1beta1.DynamoComponentDeploymentSharedSpec, dst *DynamoComponentDeploymentSharedSpec, c *annCarrier) {
-	// For each experimental sub-block, if v1beta1 declares the feature we
-	// drop any stale "*-disabled-payload" annotation: v1beta1 is
-	// authoritative in this direction and an enabled v1beta1 entry must
-	// not resurrect a previous Enabled:false on the next round-trip.
-	if src.Experimental != nil &&
-		src.Experimental.GPUMemoryService == nil &&
-		src.Experimental.Failover == nil &&
-		src.Experimental.Checkpoint == nil {
-		c.set(suffixExperimentalOrig, annotationTrue)
-	}
+func convertExperimentalFrom(src *v1beta1.DynamoComponentDeploymentSharedSpec, dst *DynamoComponentDeploymentSharedSpec) {
 	if src.Experimental != nil && src.Experimental.GPUMemoryService != nil {
 		dst.GPUMemoryService = &GPUMemoryServiceSpec{
 			Enabled:         true,
 			Mode:            gmsModeFromV1beta1(src.Experimental.GPUMemoryService.Mode),
 			DeviceClassName: src.Experimental.GPUMemoryService.DeviceClassName,
 		}
-		c.del(suffixGMSDisabled)
-	} else if g, ok := popJSONAnn[GPUMemoryServiceSpec](c, suffixGMSDisabled); ok {
-		g.Enabled = false
-		dst.GPUMemoryService = &g
 	}
 
 	if src.Experimental != nil && src.Experimental.Failover != nil {
@@ -1230,31 +929,11 @@ func convertExperimentalFrom(src *v1beta1.DynamoComponentDeploymentSharedSpec, d
 			Mode:       gmsModeFromV1beta1(src.Experimental.Failover.Mode),
 			NumShadows: src.Experimental.Failover.NumShadows,
 		}
-		c.del(suffixFailoverDisabled)
-	} else if f, ok := popJSONAnn[FailoverSpec](c, suffixFailoverDisabled); ok {
-		f.Enabled = false
-		dst.Failover = &f
 	}
 
 	if src.Experimental != nil && src.Experimental.Checkpoint != nil {
 		dst.Checkpoint = checkpointFromV1beta1(src.Experimental.Checkpoint, true)
-		c.del(suffixCheckpointDisabled)
-	} else if cp, ok := popJSONAnn[ServiceCheckpointConfig](c, suffixCheckpointDisabled); ok {
-		cp.Enabled = false
-		dst.Checkpoint = &cp
 	}
-}
-
-func gmsIsZeroPayload(s *GPUMemoryServiceSpec) bool {
-	return s.Mode == "" && s.DeviceClassName == ""
-}
-
-func failoverIsZeroPayload(s *FailoverSpec) bool {
-	return s.Mode == "" && s.NumShadows == 0
-}
-
-func checkpointIsZeroPayload(s *ServiceCheckpointConfig) bool {
-	return s.Mode == "" && s.CheckpointRef == nil && s.Identity == nil
 }
 
 func checkpointToV1beta1(src *ServiceCheckpointConfig) *v1beta1.ComponentCheckpointConfig {
@@ -1317,31 +996,15 @@ func checkpointFromV1beta1(src *v1beta1.ComponentCheckpointConfig, enabled bool)
 // v1alpha1 controller uses at reconcile time: ExtraPodSpec.MainContainer wins
 // over dedicated fields, except for env which is additive.
 func buildPodTemplateTo(src *DynamoComponentDeploymentSharedSpec, dst *v1beta1.DynamoComponentDeploymentSharedSpec, ctx sharedSpecConversionContext) error {
-	c := ctx.carrier
-	_, podTemplateOrigin := c.get(suffixPodTemplateOrig)
-	podTemplateOrigin = podTemplateOrigin || ctx.podTemplateOrigin
-	frontendSidecarRef, hasFrontendSidecarRef := c.get(suffixFrontendSidecarRef)
-	if hasFrontendSidecarRef && !hasPodTemplateContent(src, podTemplateOrigin) {
-		dst.FrontendSidecar = ptr.To(frontendSidecarRef)
-		c.del(suffixFrontendSidecarRef)
-		return nil
-	}
-	podTpl, err := buildSharedPodTemplateFromAlpha(src, podTemplateOrigin, hasFrontendSidecarRef)
+	podTpl, err := buildSharedPodTemplateFromAlpha(src, ctx.podTemplateOrigin, false)
 	if err != nil {
 		return err
 	}
 	if podTpl == nil {
 		return nil
 	}
-	c.del(suffixPodTemplateOrig)
 
-	// FrontendSidecar: full container spec -> name reference; v1beta1-first
-	// name references are restored from the carrier.
-	setFrontendSidecarReferenceToHub(src, dst, c)
-
-	if !podTemplateOrigin && ctx.includeOriginSplits {
-		c.set(suffixPodTemplateOrig, annotationPodTemplateGenerated)
-	}
+	setFrontendSidecarReferenceToHub(src, dst)
 	dst.PodTemplate = podTpl
 	return nil
 }
@@ -1428,23 +1091,9 @@ func buildSharedPodTemplateFromAlpha(src *DynamoComponentDeploymentSharedSpec, p
 	return podTpl, nil
 }
 
-func setFrontendSidecarReferenceToHub(src *DynamoComponentDeploymentSharedSpec, dst *v1beta1.DynamoComponentDeploymentSharedSpec, c *annCarrier) {
+func setFrontendSidecarReferenceToHub(src *DynamoComponentDeploymentSharedSpec, dst *v1beta1.DynamoComponentDeploymentSharedSpec) {
 	if src.FrontendSidecar != nil {
-		// Stash origin so ConvertFrom can reproduce the full spec on the
-		// v1alpha1 side without depending on the podTemplate sidecar.
-		setJSONAnn(c, suffixFrontendSidecar, src.FrontendSidecar)
 		dst.FrontendSidecar = ptr.To(defaultFrontendSidecarContainerName)
-		// Drop any stale v1beta1-first ref annotation; the origin annotation
-		// is authoritative in this direction.
-		c.del(suffixFrontendSidecarRef)
-		return
-	}
-	if v, ok := c.get(suffixFrontendSidecarRef); ok {
-		// v1beta1-first input: the named container is already present in
-		// podTpl.Spec.Containers (via ExtraPodSpec.PodSpec.Containers).
-		// Restore the pointer without duplicating the container.
-		dst.FrontendSidecar = ptr.To(v)
-		c.del(suffixFrontendSidecarRef)
 	}
 }
 
@@ -1482,17 +1131,16 @@ func buildMainContainerFromDedicated(src *DynamoComponentDeploymentSharedSpec) c
 }
 
 // decomposePodTemplate inverts buildPodTemplateTo.
-func decomposePodTemplate(src *v1beta1.DynamoComponentDeploymentSharedSpec, dst, restored *DynamoComponentDeploymentSharedSpec, c *annCarrier) error {
+func decomposePodTemplate(src *v1beta1.DynamoComponentDeploymentSharedSpec, dst, restored *DynamoComponentDeploymentSharedSpec) error {
 	if src.PodTemplate == nil {
-		decomposeMissingPodTemplate(src, dst, restored, c)
+		decomposeMissingPodTemplate(src, dst, restored)
 		return nil
 	}
 
 	podTpl := src.PodTemplate.DeepCopy()
-	markPodTemplateOrigin(c)
 
 	// ExtraPodMetadata from podTemplate.metadata.
-	restoreExtraPodMetadataFromPodTemplate(podTpl, dst, c)
+	restoreExtraPodMetadataFromPodTemplate(podTpl, dst)
 
 	// Pick out the main container; leave everything else as podSpec sidecars.
 	var main *corev1.Container
@@ -1506,23 +1154,12 @@ func decomposePodTemplate(src *v1beta1.DynamoComponentDeploymentSharedSpec, dst,
 		other = append(other, podTpl.Spec.Containers[i])
 	}
 
-	// FrontendSidecar handling. Two cases:
-	//
-	//   a) v1alpha1 origin annotation present -> the v1alpha1 side had a full
-	//      FrontendSidecarSpec. Restore it from the annotation and drop the
-	//      corresponding container from `other` (v1alpha1 does not carry the
-	//      container in extraPodSpec.containers in this case).
-	//
-	//   b) No v1alpha1 origin annotation (v1beta1-first input). There is no
-	//      way to fit a name-only pointer into v1alpha1's schema, so we let
-	//      the referenced container flow through as a regular sidecar on
-	//      extraPodSpec.containers and stash the name under a reserved
-	//      annotation so that ConvertTo can reassemble the v1beta1 pointer
-	//      without duplicating the container.
-	other = restoreFrontendSidecarFromPodTemplate(src, dst, restored, c, other)
+	// FrontendSidecar name references have no native v1alpha1 representation.
+	// Keep v1beta1-first references in the sparse hub save; restore
+	// v1alpha1-origin sidecars from the sparse spoke save.
+	other = restoreFrontendSidecarFromPodTemplate(src, dst, restored, other)
 
-	restoreEnvFromSecretFromMain(main, dst, c)
-	restoreDedicatedFieldsFromMain(main, dst, c)
+	restoreDedicatedFieldsFromMain(main, dst)
 
 	// Put everything non-main into ExtraPodSpec. The main-container fields
 	// that v1alpha1 can represent directly have already been moved into their
@@ -1557,47 +1194,14 @@ func decomposePodTemplate(src *v1beta1.DynamoComponentDeploymentSharedSpec, dst,
 	return nil
 }
 
-func decomposeMissingPodTemplate(src *v1beta1.DynamoComponentDeploymentSharedSpec, dst, restored *DynamoComponentDeploymentSharedSpec, c *annCarrier) {
-	if meta, ok := popJSONAnn[ExtraPodMetadata](c, suffixPodMetadataOrig); ok {
-		dst.ExtraPodMetadata = &meta
-	}
-	// Restore FrontendSidecar from origin annotation even if there is no
-	// podTemplate (uncommon but possible for manual edits).
-	if fs, ok := popJSONAnn[FrontendSidecarSpec](c, suffixFrontendSidecar); ok {
-		dst.FrontendSidecar = &fs
-	}
+func decomposeMissingPodTemplate(src *v1beta1.DynamoComponentDeploymentSharedSpec, dst, restored *DynamoComponentDeploymentSharedSpec) {
 	if fs, ok := restoredDefaultFrontendSidecar(src, restored); ok {
 		dst.FrontendSidecar = fs.DeepCopy()
-		return
-	}
-	if src.FrontendSidecar != nil {
-		c.set(suffixFrontendSidecarRef, *src.FrontendSidecar)
 	}
 }
 
-func markPodTemplateOrigin(c *annCarrier) {
-	if v, ok := c.get(suffixPodTemplateOrig); ok {
-		c.del(suffixPodTemplateOrig)
-		if v != annotationPodTemplateGenerated {
-			c.set(suffixPodTemplateOrig, annotationTrue)
-		}
-		return
-	}
-	c.set(suffixPodTemplateOrig, annotationTrue)
-}
-
-func restoreExtraPodMetadataFromPodTemplate(podTpl *corev1.PodTemplateSpec, dst *DynamoComponentDeploymentSharedSpec, c *annCarrier) {
+func restoreExtraPodMetadataFromPodTemplate(podTpl *corev1.PodTemplateSpec, dst *DynamoComponentDeploymentSharedSpec) {
 	hasMetadata := len(podTpl.Annotations) > 0 || len(podTpl.Labels) > 0
-	if v, ok := c.get(suffixPodMetadataOrig); ok {
-		var meta ExtraPodMetadata
-		if err := json.Unmarshal([]byte(v), &meta); err == nil && !hasMetadata {
-			dst.ExtraPodMetadata = &meta
-		} else if hasMetadata {
-			dst.ExtraPodMetadata = extraPodMetadataFromPodTemplate(podTpl)
-		}
-		c.del(suffixPodMetadataOrig)
-		return
-	}
 	if hasMetadata {
 		dst.ExtraPodMetadata = extraPodMetadataFromPodTemplate(podTpl)
 	}
@@ -1610,7 +1214,7 @@ func extraPodMetadataFromPodTemplate(podTpl *corev1.PodTemplateSpec) *ExtraPodMe
 	}
 }
 
-func restoreFrontendSidecarFromPodTemplate(src *v1beta1.DynamoComponentDeploymentSharedSpec, dst, restored *DynamoComponentDeploymentSharedSpec, c *annCarrier, other []corev1.Container) []corev1.Container {
+func restoreFrontendSidecarFromPodTemplate(src *v1beta1.DynamoComponentDeploymentSharedSpec, dst, restored *DynamoComponentDeploymentSharedSpec, other []corev1.Container) []corev1.Container {
 	if src.FrontendSidecar == nil {
 		return other
 	}
@@ -1626,27 +1230,7 @@ func restoreFrontendSidecarFromPodTemplate(src *v1beta1.DynamoComponentDeploymen
 		dst.FrontendSidecar = fs.DeepCopy()
 		return other
 	}
-	v, ok := c.get(suffixFrontendSidecar)
-	if !ok {
-		c.set(suffixFrontendSidecarRef, sidecarName)
-		return other
-	}
-	c.del(suffixFrontendSidecar)
-
-	var fs FrontendSidecarSpec
-	if err := json.Unmarshal([]byte(v), &fs); err != nil || sidecarName != defaultFrontendSidecarContainerName {
-		c.set(suffixFrontendSidecarRef, sidecarName)
-		return other
-	}
-	ctr, ok := findContainerByName(other, sidecarName)
-	if !ok {
-		c.set(suffixFrontendSidecarRef, sidecarName)
-		return other
-	}
-	dst.FrontendSidecar = frontendSidecarSpecFromContainer(ctr, &fs)
-	return slices.DeleteFunc(other, func(candidate corev1.Container) bool {
-		return candidate.Name == sidecarName
-	})
+	return other
 }
 
 func restoredDefaultFrontendSidecar(src *v1beta1.DynamoComponentDeploymentSharedSpec, restored *DynamoComponentDeploymentSharedSpec) (*FrontendSidecarSpec, bool) {
@@ -2021,60 +1605,23 @@ func volumeMountOriginsMatchNative(origin []VolumeMount, native []corev1.VolumeM
 	return true
 }
 
-func restoreEnvFromSecretFromMain(main *corev1.Container, dst *DynamoComponentDeploymentSharedSpec, c *annCarrier) {
-	if v, ok := c.get(suffixEnvFromSecret); ok {
-		if main != nil && envFromSecretMatches(main.EnvFrom, v) {
-			dst.EnvFromSecret = ptr.To(v)
-		}
-		c.del(suffixEnvFromSecret)
-	}
-}
-
-func restoreDedicatedFieldsFromMain(main *corev1.Container, dst *DynamoComponentDeploymentSharedSpec, c *annCarrier) {
+func restoreDedicatedFieldsFromMain(main *corev1.Container, dst *DynamoComponentDeploymentSharedSpec) {
 	if main == nil {
-		c.del(suffixResourcesOrigin)
-		c.del(suffixVolumeMountsOrig)
 		return
 	}
 
-	if v, ok := c.get(suffixResourcesOrigin); ok {
-		var resources Resources
-		if err := json.Unmarshal([]byte(v), &resources); err == nil {
-			if resourceRequirementsEqual(main.Resources, resourcesToNative(&resources)) {
-				dst.Resources = &resources
-				main.Resources = corev1.ResourceRequirements{}
-			} else if native := resourcesFromNative(main.Resources); native != nil {
-				dst.Resources = native
-				main.Resources = corev1.ResourceRequirements{}
-			}
-		}
-		c.del(suffixResourcesOrigin)
-	} else if resources := resourcesFromNative(main.Resources); resources != nil {
+	if resources := resourcesFromNative(main.Resources); resources != nil {
 		dst.Resources = resources
 		main.Resources = corev1.ResourceRequirements{}
 	}
 
-	if v, ok := c.get(suffixVolumeMountsOrig); ok {
-		var volumeMounts []VolumeMount
-		if err := json.Unmarshal([]byte(v), &volumeMounts); err == nil {
-			if volumeMountOriginsMatchNative(volumeMounts, main.VolumeMounts) {
-				dst.VolumeMounts = volumeMounts
-				main.VolumeMounts = nil
-			} else {
-				restoreFlatVolumeMountsFromMain(main, dst)
-			}
-		}
-		c.del(suffixVolumeMountsOrig)
-	} else if len(main.VolumeMounts) > 0 {
+	if len(main.VolumeMounts) > 0 {
 		restoreFlatVolumeMountsFromMain(main, dst)
 	}
 
 	if len(main.Env) > 0 {
 		dst.Envs = slices.Clone(main.Env)
 		main.Env = nil
-	}
-	if dst.EnvFromSecret != nil && envFromSecretMatches(main.EnvFrom, *dst.EnvFromSecret) {
-		main.EnvFrom = nil
 	}
 	if main.LivenessProbe != nil {
 		dst.LivenessProbe = main.LivenessProbe.DeepCopy()

--- a/deploy/operator/api/v1alpha1/shared_spec_conversion.go
+++ b/deploy/operator/api/v1alpha1/shared_spec_conversion.go
@@ -357,7 +357,7 @@ func saveSharedAlphaOnlySpec(src, save *DynamoComponentDeploymentSharedSpec, inc
 		save.Checkpoint = src.Checkpoint.DeepCopy()
 		hasSave = true
 	}
-	if includeOriginSplits || hasSave || sharedMainContainerNameNeedsPreservation(src) {
+	if includeOriginSplits || hasSave || sharedMainContainerFieldOriginsNeedSave(src) {
 		saveSharedMainContainerOrigins(src, save)
 	}
 }
@@ -366,11 +366,20 @@ func sharedAlphaSpecSaveIsZero(save *DynamoComponentDeploymentSharedSpec) bool {
 	return save == nil || apiequality.Semantic.DeepEqual(*save, DynamoComponentDeploymentSharedSpec{})
 }
 
-func sharedMainContainerNameNeedsPreservation(src *DynamoComponentDeploymentSharedSpec) bool {
-	return src != nil &&
-		src.ExtraPodSpec != nil &&
-		src.ExtraPodSpec.MainContainer != nil &&
-		src.ExtraPodSpec.MainContainer.Name != ""
+func sharedMainContainerFieldOriginsNeedSave(src *DynamoComponentDeploymentSharedSpec) bool {
+	if src == nil || src.ExtraPodSpec == nil || src.ExtraPodSpec.MainContainer == nil {
+		return false
+	}
+	main := src.ExtraPodSpec.MainContainer
+
+	// These fields decompose back into dedicated v1alpha1 fields unless the
+	// sparse save records that they originated from ExtraPodSpec.MainContainer.
+	return main.Name != "" ||
+		len(main.Env) > 0 ||
+		!resourceRequirementsEqual(main.Resources, corev1.ResourceRequirements{}) ||
+		len(main.VolumeMounts) > 0 ||
+		main.LivenessProbe != nil ||
+		main.ReadinessProbe != nil
 }
 
 func saveSharedMainContainerOrigins(src, save *DynamoComponentDeploymentSharedSpec) {

--- a/deploy/operator/api/v1alpha1/shared_spec_conversion.go
+++ b/deploy/operator/api/v1alpha1/shared_spec_conversion.go
@@ -73,18 +73,11 @@ const (
 	annotationTrue                 = "true"
 	annotationPodTemplateGenerated = "generated"
 
-	// DGD-scoped (DGD spec-level + per-component) annotation keys.
-	annDGDPVCs       = "nvidia.com/dgd-pvcs"
-	annDGDCompPrefix = "nvidia.com/dgd-comp-"
-
-	// Shared-spec annotation key suffixes. Combined with the parent object's
-	// prefix ("nvidia.com/dgd-comp-<name>-" or "nvidia.com/dcd-") to form the
-	// full annotation key.
+	// Shared-spec annotation key suffixes. Combined with the parent DCD
+	// object's prefix ("nvidia.com/dcd-") to form the full annotation key.
 	//
-	// suffixServiceName preserves v1alpha1 ServiceName shapes that v1beta1's
-	// required ComponentName cannot express: DGD service entries whose
-	// ServiceName differs from the services-map key, and standalone DCDs where
-	// ServiceName was omitted and v1beta1 used ObjectMeta.Name as the fallback.
+	// suffixServiceName preserves standalone DCDs where ServiceName was omitted
+	// and v1beta1 used ObjectMeta.Name as the fallback.
 	suffixServiceName      = "service-name"
 	suffixDynamoNamespace  = "dynamo-namespace"
 	suffixAutoscaling      = "autoscaling"
@@ -115,18 +108,12 @@ const (
 	annDCDPrefix = "nvidia.com/dcd-"
 )
 
-// annCarrier wraps a Kubernetes object's annotation bag for a given logical
-// owner (a DGD service or a standalone DCD). The prefix is baked in so that
-// shared-spec helpers do not need to know whether they are serving DGD or DCD.
+// annCarrier wraps a Kubernetes object's annotation bag for a standalone DCD.
+// DGD uses typed sparse spec/status annotations instead of per-component
+// annotation carriers.
 type annCarrier struct {
 	obj    metav1.Object
 	prefix string
-}
-
-// newDGDComponentCarrier returns a carrier scoped to a named component on the
-// DGD object: keys are of the form "nvidia.com/dgd-comp-<name>-<suffix>".
-func newDGDComponentCarrier(obj metav1.Object, componentName string) *annCarrier {
-	return &annCarrier{obj: obj, prefix: annDGDCompPrefix + componentName + "-"}
 }
 
 // newDCDCarrier returns a carrier scoped to a standalone DCD: keys are of the
@@ -138,6 +125,9 @@ func newDCDCarrier(obj metav1.Object) *annCarrier {
 func (c *annCarrier) key(suffix string) string { return c.prefix + suffix }
 
 func (c *annCarrier) set(suffix, value string) {
+	if c == nil {
+		return
+	}
 	anns := c.obj.GetAnnotations()
 	if anns == nil {
 		anns = map[string]string{}
@@ -147,6 +137,9 @@ func (c *annCarrier) set(suffix, value string) {
 }
 
 func (c *annCarrier) get(suffix string) (string, bool) {
+	if c == nil {
+		return "", false
+	}
 	anns := c.obj.GetAnnotations()
 	if anns == nil {
 		return "", false
@@ -156,6 +149,9 @@ func (c *annCarrier) get(suffix string) (string, bool) {
 }
 
 func (c *annCarrier) del(suffix string) {
+	if c == nil {
+		return
+	}
 	anns := c.obj.GetAnnotations()
 	if anns == nil {
 		return
@@ -169,6 +165,9 @@ func (c *annCarrier) del(suffix string) {
 }
 
 func setJSONAnn(c *annCarrier, suffix string, value any) {
+	if c == nil {
+		return
+	}
 	data, err := json.Marshal(value)
 	if err != nil {
 		return
@@ -178,6 +177,9 @@ func setJSONAnn(c *annCarrier, suffix string, value any) {
 
 func popJSONAnn[T any](c *annCarrier, suffix string) (T, bool) {
 	var out T
+	if c == nil {
+		return out, false
+	}
 	raw, ok := c.get(suffix)
 	if !ok {
 		return out, false
@@ -192,8 +194,7 @@ func popJSONAnn[T any](c *annCarrier, suffix string) (T, bool) {
 	return out, true
 }
 
-// setAnnOnObj is a convenience for annotations that do not belong to a single
-// carrier (e.g. DGD spec-level PVCs).
+// setAnnOnObj is a convenience for object-level preservation annotations.
 func setAnnOnObj(obj metav1.Object, key, value string) {
 	anns := obj.GetAnnotations()
 	if anns == nil {
@@ -281,6 +282,7 @@ func scrubAnnotationsByPrefix(obj metav1.Object, prefix string) {
 type sharedSpecConversionContext struct {
 	carrier             *annCarrier
 	includeOriginSplits bool
+	podTemplateOrigin   bool
 }
 
 // convertSharedSpecToHub converts fields represented by both versions from src,
@@ -300,7 +302,7 @@ func convertSharedSpecToHub(src *DynamoComponentDeploymentSharedSpec, dst *v1bet
 	// SubComponentType has no v1beta1 equivalent -- the "prefill"/"decode"
 	// values are first-class ComponentType enum values in v1beta1. Stash the
 	// raw string on the carrier so round-trip restores the original wording.
-	if src.SubComponentType != "" {
+	if src.SubComponentType != "" && ctx.carrier != nil {
 		ctx.carrier.set(suffixSubComponentType, src.SubComponentType)
 	}
 
@@ -313,7 +315,7 @@ func convertSharedSpecToHub(src *DynamoComponentDeploymentSharedSpec, dst *v1bet
 	dst.ComponentName = src.ServiceName
 
 	// DynamoNamespace (deprecated) -> annotation.
-	if src.DynamoNamespace != nil {
+	if src.DynamoNamespace != nil && ctx.carrier != nil {
 		ctx.carrier.set(suffixDynamoNamespace, *src.DynamoNamespace)
 	}
 
@@ -344,8 +346,9 @@ func convertSharedSpecToHub(src *DynamoComponentDeploymentSharedSpec, dst *v1bet
 		}
 	}
 
-	// Autoscaling -> annotation (deprecated, removed in v1beta1).
-	preserveV1Alpha1OnlySharedFields(src, ctx.carrier)
+	if ctx.carrier != nil {
+		preserveV1Alpha1OnlySharedFields(src, ctx.carrier)
+	}
 
 	// sharedMemory <-> sharedMemorySize (lossy struct flatten).
 	if err := convertSharedMemoryTo(src.SharedMemory, dst, ctx.carrier); err != nil {
@@ -371,7 +374,7 @@ func convertSharedSpecToHub(src *DynamoComponentDeploymentSharedSpec, dst *v1bet
 	convertExperimentalTo(src, dst, ctx.carrier)
 
 	// Resources + envs + probes + mainContainer -> podTemplate.containers[main].
-	if err := buildPodTemplateTo(src, dst, ctx.carrier, ctx.includeOriginSplits); err != nil {
+	if err := buildPodTemplateTo(src, dst, ctx); err != nil {
 		return err
 	}
 
@@ -414,7 +417,7 @@ func preserveV1Alpha1OnlySharedFields(src *DynamoComponentDeploymentSharedSpec, 
 	}
 }
 
-func fillSharedAlphaOnlyFromPreserved(dst *DynamoComponentDeploymentSharedSpec, preserved *DynamoComponentDeploymentSharedSpec) {
+func fillSharedAlphaOnlyFromPreserved(dst *DynamoComponentDeploymentSharedSpec, preserved *DynamoComponentDeploymentSharedSpec, mainContainerPresent bool) {
 	if dst == nil || preserved == nil {
 		return
 	}
@@ -441,9 +444,10 @@ func fillSharedAlphaOnlyFromPreserved(dst *DynamoComponentDeploymentSharedSpec, 
 	if shouldRestorePreservedSharedMemory(dst.SharedMemory, preserved.SharedMemory) {
 		dst.SharedMemory = preserved.SharedMemory.DeepCopy()
 	}
-	if dst.EnvFromSecret == nil && preserved.EnvFromSecret != nil && *preserved.EnvFromSecret == "" {
-		dst.EnvFromSecret = ptr.To("")
+	if mainContainerPresent && shouldRestorePreservedResources(dst.Resources, preserved.Resources) {
+		dst.Resources = preserved.Resources.DeepCopy()
 	}
+	restoreEnvFromSecretFromPreserved(dst, preserved, mainContainerPresent)
 	if dst.ExtraPodMetadata == nil && extraPodMetadataNeedsPreservation(preserved.ExtraPodMetadata) {
 		dst.ExtraPodMetadata = preserved.ExtraPodMetadata.DeepCopy()
 	}
@@ -451,7 +455,7 @@ func fillSharedAlphaOnlyFromPreserved(dst *DynamoComponentDeploymentSharedSpec, 
 		cp := *preserved.ExtraPodSpec.DeepCopy()
 		dst.ExtraPodSpec = &cp
 	}
-	restoreMainContainerFieldOrigins(dst, preserved)
+	restoreMainContainerFieldOrigins(dst, preserved, mainContainerPresent)
 	if dst.ExtraPodSpec != nil && dst.ExtraPodSpec.MainContainer != nil &&
 		dst.ExtraPodSpec.MainContainer.Name == "" &&
 		preserved.ExtraPodSpec != nil && preserved.ExtraPodSpec.MainContainer != nil {
@@ -459,6 +463,15 @@ func fillSharedAlphaOnlyFromPreserved(dst *DynamoComponentDeploymentSharedSpec, 
 	}
 	if dst.ScalingAdapter == nil && preserved.ScalingAdapter != nil && !preserved.ScalingAdapter.Enabled {
 		dst.ScalingAdapter = preserved.ScalingAdapter.DeepCopy()
+	}
+	if dst.GPUMemoryService == nil && preserved.GPUMemoryService != nil && !preserved.GPUMemoryService.Enabled {
+		dst.GPUMemoryService = preserved.GPUMemoryService.DeepCopy()
+	}
+	if dst.Failover == nil && preserved.Failover != nil && !preserved.Failover.Enabled {
+		dst.Failover = preserved.Failover.DeepCopy()
+	}
+	if dst.Checkpoint == nil && preserved.Checkpoint != nil && !preserved.Checkpoint.Enabled {
+		dst.Checkpoint = preserved.Checkpoint.DeepCopy()
 	}
 }
 
@@ -518,6 +531,22 @@ func saveSharedAlphaOnlySpec(src, save *DynamoComponentDeploymentSharedSpec, inc
 	}
 	if src.ScalingAdapter != nil && !src.ScalingAdapter.Enabled {
 		save.ScalingAdapter = src.ScalingAdapter.DeepCopy()
+		hasSave = true
+	}
+	if src.FrontendSidecar != nil {
+		save.FrontendSidecar = src.FrontendSidecar.DeepCopy()
+		hasSave = true
+	}
+	if src.GPUMemoryService != nil && !src.GPUMemoryService.Enabled {
+		save.GPUMemoryService = src.GPUMemoryService.DeepCopy()
+		hasSave = true
+	}
+	if src.Failover != nil && !src.Failover.Enabled {
+		save.Failover = src.Failover.DeepCopy()
+		hasSave = true
+	}
+	if src.Checkpoint != nil && !src.Checkpoint.Enabled {
+		save.Checkpoint = src.Checkpoint.DeepCopy()
 		hasSave = true
 	}
 	if includeOriginSplits || hasSave || sharedMainContainerNameNeedsPreservation(src) {
@@ -600,6 +629,20 @@ func resourcesNeedPreservation(src *Resources) bool {
 	return src != nil && !reflect.DeepEqual(src, resourcesFromNative(resourcesToNative(src)))
 }
 
+func shouldRestorePreservedResources(dst, preserved *Resources) bool {
+	if !resourcesNeedPreservation(preserved) {
+		return false
+	}
+	return resourceRequirementsEqual(resourcesToNativeOrZero(dst), resourcesToNative(preserved))
+}
+
+func resourcesToNativeOrZero(src *Resources) corev1.ResourceRequirements {
+	if src == nil {
+		return corev1.ResourceRequirements{}
+	}
+	return resourcesToNative(src)
+}
+
 func extraPodMetadataNeedsPreservation(src *ExtraPodMetadata) bool {
 	return src != nil && len(src.Annotations) == 0 && len(src.Labels) == 0
 }
@@ -637,27 +680,29 @@ func convertSharedSpecFromHub(src *v1beta1.DynamoComponentDeploymentSharedSpec, 
 		}
 	}
 
-	// Restore annotation-preserved v1alpha1 fields.
-	if v, ok := ctx.carrier.get(suffixSubComponentType); ok {
-		dst.SubComponentType = v
-		ctx.carrier.del(suffixSubComponentType)
-	}
 	dst.ServiceName = src.ComponentName
-	if v, ok := ctx.carrier.get(suffixDynamoNamespace); ok {
-		dst.DynamoNamespace = ptr.To(v)
-		ctx.carrier.del(suffixDynamoNamespace)
-	}
-	if as, ok := popJSONAnn[Autoscaling](ctx.carrier, suffixAutoscaling); ok {
-		dst.Autoscaling = &as
-	}
-	if ing, ok := popJSONAnn[IngressSpec](ctx.carrier, suffixIngress); ok {
-		dst.Ingress = &ing
-	}
-	if m, ok := popJSONAnn[map[string]string](ctx.carrier, suffixAnnotations); ok {
-		dst.Annotations = m
-	}
-	if m, ok := popJSONAnn[map[string]string](ctx.carrier, suffixLabels); ok {
-		dst.Labels = m
+	if ctx.carrier != nil {
+		// Restore annotation-preserved v1alpha1 fields.
+		if v, ok := ctx.carrier.get(suffixSubComponentType); ok {
+			dst.SubComponentType = v
+			ctx.carrier.del(suffixSubComponentType)
+		}
+		if v, ok := ctx.carrier.get(suffixDynamoNamespace); ok {
+			dst.DynamoNamespace = ptr.To(v)
+			ctx.carrier.del(suffixDynamoNamespace)
+		}
+		if as, ok := popJSONAnn[Autoscaling](ctx.carrier, suffixAutoscaling); ok {
+			dst.Autoscaling = &as
+		}
+		if ing, ok := popJSONAnn[IngressSpec](ctx.carrier, suffixIngress); ok {
+			dst.Ingress = &ing
+		}
+		if m, ok := popJSONAnn[map[string]string](ctx.carrier, suffixAnnotations); ok {
+			dst.Annotations = m
+		}
+		if m, ok := popJSONAnn[map[string]string](ctx.carrier, suffixLabels); ok {
+			dst.Labels = m
+		}
 	}
 	// sharedMemorySize -> SharedMemorySpec.
 	convertSharedMemoryFrom(src.SharedMemorySize, dst, ctx.carrier)
@@ -673,11 +718,12 @@ func convertSharedSpecFromHub(src *v1beta1.DynamoComponentDeploymentSharedSpec, 
 
 	// podTemplate -> mainContainer + extraPodSpec + extraPodMetadata +
 	// Resources + Envs + Probes (+ FrontendSidecar).
-	if err := decomposePodTemplate(src, dst, ctx.carrier); err != nil {
+	if err := decomposePodTemplate(src, dst, restored, ctx.carrier); err != nil {
 		return err
 	}
 
-	fillSharedAlphaOnlyFromPreserved(dst, restored)
+	fillSharedAlphaOnlyFromPreserved(dst, restored, sharedHasMainContainer(src))
+	pruneEmptyExtraPodSpec(dst, restored)
 	if save != nil {
 		if err := saveSharedHubOnlySpec(src, dst, save); err != nil {
 			return err
@@ -834,8 +880,11 @@ func saveSharedHubOnlyPodTemplateContainers(src, projected, save *corev1.PodTemp
 }
 
 func sharedGeneratedMainContainerKeyNeedsSave(src, projected corev1.Container, projectedContainerFound bool) bool {
-	if !projectedContainerFound || src.Name != mainContainerName {
+	if src.Name != mainContainerName {
 		return false
+	}
+	if !projectedContainerFound {
+		return containerHasOnlyName(src)
 	}
 	if containerHasOnlyName(src) {
 		return true
@@ -1267,8 +1316,10 @@ func checkpointFromV1beta1(src *v1beta1.ComponentCheckpointConfig, enabled bool)
 // ExtraPodMetadata, FrontendSidecar) following the same merge precedence the
 // v1alpha1 controller uses at reconcile time: ExtraPodSpec.MainContainer wins
 // over dedicated fields, except for env which is additive.
-func buildPodTemplateTo(src *DynamoComponentDeploymentSharedSpec, dst *v1beta1.DynamoComponentDeploymentSharedSpec, c *annCarrier, includeOriginSplits bool) error {
+func buildPodTemplateTo(src *DynamoComponentDeploymentSharedSpec, dst *v1beta1.DynamoComponentDeploymentSharedSpec, ctx sharedSpecConversionContext) error {
+	c := ctx.carrier
 	_, podTemplateOrigin := c.get(suffixPodTemplateOrig)
+	podTemplateOrigin = podTemplateOrigin || ctx.podTemplateOrigin
 	frontendSidecarRef, hasFrontendSidecarRef := c.get(suffixFrontendSidecarRef)
 	if hasFrontendSidecarRef && !hasPodTemplateContent(src, podTemplateOrigin) {
 		dst.FrontendSidecar = ptr.To(frontendSidecarRef)
@@ -1288,7 +1339,7 @@ func buildPodTemplateTo(src *DynamoComponentDeploymentSharedSpec, dst *v1beta1.D
 	// name references are restored from the carrier.
 	setFrontendSidecarReferenceToHub(src, dst, c)
 
-	if !podTemplateOrigin && includeOriginSplits {
+	if !podTemplateOrigin && ctx.includeOriginSplits {
 		c.set(suffixPodTemplateOrig, annotationPodTemplateGenerated)
 	}
 	dst.PodTemplate = podTpl
@@ -1431,9 +1482,9 @@ func buildMainContainerFromDedicated(src *DynamoComponentDeploymentSharedSpec) c
 }
 
 // decomposePodTemplate inverts buildPodTemplateTo.
-func decomposePodTemplate(src *v1beta1.DynamoComponentDeploymentSharedSpec, dst *DynamoComponentDeploymentSharedSpec, c *annCarrier) error {
+func decomposePodTemplate(src *v1beta1.DynamoComponentDeploymentSharedSpec, dst, restored *DynamoComponentDeploymentSharedSpec, c *annCarrier) error {
 	if src.PodTemplate == nil {
-		decomposeMissingPodTemplate(src, dst, c)
+		decomposeMissingPodTemplate(src, dst, restored, c)
 		return nil
 	}
 
@@ -1468,7 +1519,7 @@ func decomposePodTemplate(src *v1beta1.DynamoComponentDeploymentSharedSpec, dst 
 	//      extraPodSpec.containers and stash the name under a reserved
 	//      annotation so that ConvertTo can reassemble the v1beta1 pointer
 	//      without duplicating the container.
-	other = restoreFrontendSidecarFromPodTemplate(src, dst, c, other)
+	other = restoreFrontendSidecarFromPodTemplate(src, dst, restored, c, other)
 
 	restoreEnvFromSecretFromMain(main, dst, c)
 	restoreDedicatedFieldsFromMain(main, dst, c)
@@ -1506,7 +1557,7 @@ func decomposePodTemplate(src *v1beta1.DynamoComponentDeploymentSharedSpec, dst 
 	return nil
 }
 
-func decomposeMissingPodTemplate(src *v1beta1.DynamoComponentDeploymentSharedSpec, dst *DynamoComponentDeploymentSharedSpec, c *annCarrier) {
+func decomposeMissingPodTemplate(src *v1beta1.DynamoComponentDeploymentSharedSpec, dst, restored *DynamoComponentDeploymentSharedSpec, c *annCarrier) {
 	if meta, ok := popJSONAnn[ExtraPodMetadata](c, suffixPodMetadataOrig); ok {
 		dst.ExtraPodMetadata = &meta
 	}
@@ -1514,6 +1565,10 @@ func decomposeMissingPodTemplate(src *v1beta1.DynamoComponentDeploymentSharedSpe
 	// podTemplate (uncommon but possible for manual edits).
 	if fs, ok := popJSONAnn[FrontendSidecarSpec](c, suffixFrontendSidecar); ok {
 		dst.FrontendSidecar = &fs
+	}
+	if fs, ok := restoredDefaultFrontendSidecar(src, restored); ok {
+		dst.FrontendSidecar = fs.DeepCopy()
+		return
 	}
 	if src.FrontendSidecar != nil {
 		c.set(suffixFrontendSidecarRef, *src.FrontendSidecar)
@@ -1555,11 +1610,22 @@ func extraPodMetadataFromPodTemplate(podTpl *corev1.PodTemplateSpec) *ExtraPodMe
 	}
 }
 
-func restoreFrontendSidecarFromPodTemplate(src *v1beta1.DynamoComponentDeploymentSharedSpec, dst *DynamoComponentDeploymentSharedSpec, c *annCarrier, other []corev1.Container) []corev1.Container {
+func restoreFrontendSidecarFromPodTemplate(src *v1beta1.DynamoComponentDeploymentSharedSpec, dst, restored *DynamoComponentDeploymentSharedSpec, c *annCarrier, other []corev1.Container) []corev1.Container {
 	if src.FrontendSidecar == nil {
 		return other
 	}
 	sidecarName := *src.FrontendSidecar
+	if fs, ok := restoredDefaultFrontendSidecar(src, restored); ok {
+		ctr, found := findContainerByName(other, sidecarName)
+		if found {
+			dst.FrontendSidecar = frontendSidecarSpecFromContainer(ctr, fs)
+			return slices.DeleteFunc(other, func(candidate corev1.Container) bool {
+				return candidate.Name == sidecarName
+			})
+		}
+		dst.FrontendSidecar = fs.DeepCopy()
+		return other
+	}
 	v, ok := c.get(suffixFrontendSidecar)
 	if !ok {
 		c.set(suffixFrontendSidecarRef, sidecarName)
@@ -1581,6 +1647,17 @@ func restoreFrontendSidecarFromPodTemplate(src *v1beta1.DynamoComponentDeploymen
 	return slices.DeleteFunc(other, func(candidate corev1.Container) bool {
 		return candidate.Name == sidecarName
 	})
+}
+
+func restoredDefaultFrontendSidecar(src *v1beta1.DynamoComponentDeploymentSharedSpec, restored *DynamoComponentDeploymentSharedSpec) (*FrontendSidecarSpec, bool) {
+	if src == nil ||
+		src.FrontendSidecar == nil ||
+		*src.FrontendSidecar != defaultFrontendSidecarContainerName ||
+		restored == nil ||
+		restored.FrontendSidecar == nil {
+		return nil, false
+	}
+	return restored.FrontendSidecar, true
 }
 
 func restoreSharedHubOnlyFields(dst, preserved *v1beta1.DynamoComponentDeploymentSharedSpec, src *DynamoComponentDeploymentSharedSpec) {
@@ -1715,8 +1792,16 @@ func restoreSharedHubOnlyFrontendSidecarEnvFrom(dst, preserved []corev1.EnvFromS
 }
 
 func restoreSharedPodTemplateContainerOrder(dst, preserved *corev1.PodTemplateSpec) {
-	if dst == nil || preserved == nil || len(preserved.Spec.Containers) < 2 || len(dst.Spec.Containers) < 2 {
+	if dst == nil ||
+		preserved == nil ||
+		len(preserved.Spec.Containers) < 2 ||
+		len(preserved.Spec.Containers) != len(dst.Spec.Containers) {
 		return
+	}
+	for _, container := range dst.Spec.Containers {
+		if !hasContainerNamed(preserved.Spec.Containers, container.Name) {
+			return
+		}
 	}
 	remaining := slices.Clone(dst.Spec.Containers)
 	out := make([]corev1.Container, 0, len(dst.Spec.Containers))
@@ -2152,8 +2237,54 @@ func extraPodSpecOnlyPreservesMainContainerName(eps *ExtraPodSpec) bool {
 	return containerIsEmpty(main)
 }
 
-func restoreMainContainerFieldOrigins(dst, preserved *DynamoComponentDeploymentSharedSpec) {
-	if dst == nil || preserved == nil || preserved.ExtraPodSpec == nil || preserved.ExtraPodSpec.MainContainer == nil {
+func restoreEnvFromSecretFromPreserved(dst, preserved *DynamoComponentDeploymentSharedSpec, mainContainerPresent bool) {
+	if dst == nil || preserved == nil || dst.EnvFromSecret != nil || preserved.EnvFromSecret == nil {
+		return
+	}
+	if *preserved.EnvFromSecret == "" {
+		dst.EnvFromSecret = ptr.To("")
+		return
+	}
+	if !mainContainerPresent {
+		return
+	}
+	if dst.ExtraPodSpec == nil || dst.ExtraPodSpec.MainContainer == nil {
+		return
+	}
+	if !envFromSecretMatches(dst.ExtraPodSpec.MainContainer.EnvFrom, *preserved.EnvFromSecret) {
+		return
+	}
+	dst.EnvFromSecret = ptr.To(*preserved.EnvFromSecret)
+	dst.ExtraPodSpec.MainContainer.EnvFrom = nil
+}
+
+func sharedHasMainContainer(src *v1beta1.DynamoComponentDeploymentSharedSpec) bool {
+	return src != nil &&
+		src.PodTemplate != nil &&
+		hasContainerNamed(src.PodTemplate.Spec.Containers, mainContainerName)
+}
+
+func pruneEmptyExtraPodSpec(dst, restored *DynamoComponentDeploymentSharedSpec) {
+	if dst == nil || dst.ExtraPodSpec == nil {
+		return
+	}
+	if containerIsEmpty(dst.ExtraPodSpec.MainContainer) {
+		dst.ExtraPodSpec.MainContainer = nil
+	}
+	if extraPodSpecIsZero(dst.ExtraPodSpec) {
+		if restored != nil && extraPodSpecNeedsPreservation(restored.ExtraPodSpec) {
+			return
+		}
+		dst.ExtraPodSpec = nil
+	}
+}
+
+func restoreMainContainerFieldOrigins(dst, preserved *DynamoComponentDeploymentSharedSpec, mainContainerPresent bool) {
+	if !mainContainerPresent ||
+		dst == nil ||
+		preserved == nil ||
+		preserved.ExtraPodSpec == nil ||
+		preserved.ExtraPodSpec.MainContainer == nil {
 		return
 	}
 	preservedMain := preserved.ExtraPodSpec.MainContainer
@@ -2168,8 +2299,7 @@ func restoreMainContainerFieldOrigins(dst, preserved *DynamoComponentDeploymentS
 	if apiequality.Semantic.DeepEqual(currentMain.EnvFrom, preservedSemanticMain.EnvFrom) && preserved.EnvFromSecret != nil {
 		dst.EnvFromSecret = ptr.To(*preserved.EnvFromSecret)
 	}
-	if dst.Resources != nil &&
-		resourceRequirementsEqual(currentMain.Resources, preservedSemanticMain.Resources) &&
+	if resourceRequirementsEqual(currentMain.Resources, preservedSemanticMain.Resources) &&
 		(preserved.Resources != nil || !resourceRequirementsEqual(preservedMain.Resources, corev1.ResourceRequirements{})) {
 		dst.Resources = preserved.Resources.DeepCopy()
 		ensureExtraPodSpecMainContainer(dst).Resources = *preservedMain.Resources.DeepCopy()

--- a/deploy/operator/api/v1alpha1/shared_spec_conversion_bugs_test.go
+++ b/deploy/operator/api/v1alpha1/shared_spec_conversion_bugs_test.go
@@ -340,7 +340,7 @@ func TestBugDCD_IntermediateSpokeDeletesGeneratedFrontendSidecarDropsHubOnlyCont
 		t.Fatalf("expected preserved generated frontend sidecar remainder, got %#v", preserved.PodTemplate)
 	}
 
-	// Stage 2 edit: the v1alpha1 carrier removes the generated frontend sidecar
+	// Stage 2 edit: the v1alpha1 object removes the generated frontend sidecar
 	// field but leaves preservation annotations untouched.
 	spoke.Spec.FrontendSidecar = nil
 
@@ -405,7 +405,7 @@ func TestDCD_IntermediateSpokeDeletesFrontendSidecarContainerDropsHubReference(t
 		t.Fatalf("expected sparse preserved sidecar key only, got %#v", preservedSidecar)
 	}
 
-	// Stage 2 edit: the v1alpha1 carrier removes the representable sidecar
+	// Stage 2 edit: the v1alpha1 object removes the representable sidecar
 	// container but leaves preservation annotations untouched.
 	spoke.Spec.ExtraPodSpec.PodSpec.Containers = nil
 
@@ -460,7 +460,7 @@ func TestBugDGD_IntermediateSpokeDeletesGeneratedFrontendSidecarDropsHubOnlyCont
 		t.Fatalf("expected preserved generated frontend sidecar remainder, got %#v", preserved.Components[0].PodTemplate)
 	}
 
-	// Stage 2 edit: the v1alpha1 carrier removes the generated frontend sidecar
+	// Stage 2 edit: the v1alpha1 object removes the generated frontend sidecar
 	// field but leaves preservation annotations untouched.
 	component := spoke.Spec.Services["frontend"]
 	component.FrontendSidecar = nil
@@ -533,7 +533,7 @@ func TestDGD_IntermediateSpokeDeletesFrontendSidecarContainerDropsHubReference(t
 		t.Fatalf("expected sparse preserved sidecar key only, got %#v", preservedSidecar)
 	}
 
-	// Stage 2 edit: the v1alpha1 carrier removes the representable sidecar
+	// Stage 2 edit: the v1alpha1 object removes the representable sidecar
 	// container but leaves preservation annotations untouched.
 	component.ExtraPodSpec.PodSpec.Containers = nil
 

--- a/deploy/operator/api/v1alpha1/shared_spec_conversion_bugs_test.go
+++ b/deploy/operator/api/v1alpha1/shared_spec_conversion_bugs_test.go
@@ -105,6 +105,64 @@ func TestBugDGD_HubEmptyPodTemplateRoundTrips(t *testing.T) {
 	}
 }
 
+func TestBugDGD_HubOriginSpokeMainContainerEnvSplitRoundTrips(t *testing.T) {
+	hub := &v1beta1.DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "main-container-env-split", Namespace: "ns"},
+		Spec: v1beta1.DynamoGraphDeploymentSpec{
+			Components: []v1beta1.DynamoComponentDeploymentSharedSpec{{
+				ComponentName: "worker",
+				ComponentType: v1beta1.ComponentTypeWorker,
+				PodTemplate: &corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Name: "hub-origin-template"},
+				},
+			}},
+		},
+	}
+
+	spoke := &DynamoGraphDeployment{}
+	if err := spoke.ConvertFrom(hub); err != nil {
+		t.Fatalf("ConvertFrom hub: %v", err)
+	}
+	component := spoke.Spec.Services["worker"]
+	if component == nil {
+		t.Fatalf("expected worker service after ConvertFrom: %#v", spoke.Spec.Services)
+	}
+
+	// Stage 2 edit: the v1alpha1 object intentionally splits env between the
+	// flat Envs field and the ExtraPodSpec main-container escape hatch.
+	component.Envs = []corev1.EnvVar{{Name: "FLAT", Value: "flat"}}
+	component.ExtraPodSpec = &ExtraPodSpec{
+		MainContainer: &corev1.Container{
+			Env: []corev1.EnvVar{{Name: "EXTRA", Value: "extra"}},
+		},
+	}
+
+	restoredHub := &v1beta1.DynamoGraphDeployment{}
+	if err := spoke.ConvertTo(restoredHub); err != nil {
+		t.Fatalf("ConvertTo spoke: %v", err)
+	}
+	restoredSpoke := &DynamoGraphDeployment{}
+	if err := restoredSpoke.ConvertFrom(restoredHub); err != nil {
+		t.Fatalf("ConvertFrom restored hub: %v", err)
+	}
+	restoredComponent := restoredSpoke.Spec.Services["worker"]
+	if restoredComponent == nil {
+		t.Fatalf("expected restored worker service: %#v", restoredSpoke.Spec.Services)
+	}
+	if diff := cmp.Diff(component.Envs, restoredComponent.Envs); diff != "" {
+		t.Fatalf("flat env origin mismatch (-want +got):\n%s", diff)
+	}
+	if component.ExtraPodSpec == nil || component.ExtraPodSpec.MainContainer == nil {
+		t.Fatalf("test setup lost extra main-container env: %#v", component.ExtraPodSpec)
+	}
+	if restoredComponent.ExtraPodSpec == nil || restoredComponent.ExtraPodSpec.MainContainer == nil {
+		t.Fatalf("extra main-container env collapsed into flat envs: %#v", restoredComponent)
+	}
+	if diff := cmp.Diff(component.ExtraPodSpec.MainContainer.Env, restoredComponent.ExtraPodSpec.MainContainer.Env); diff != "" {
+		t.Fatalf("extra main-container env origin mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestBugDCD_HubPodTemplateWithoutContainersRoundTrips(t *testing.T) {
 	in := &v1beta1.DynamoComponentDeployment{
 		ObjectMeta: metav1.ObjectMeta{Name: "pod-template-no-containers", Namespace: "ns"},


### PR DESCRIPTION
## Summary

Make DGD and DCD conversion preservation follow the structural sparse-save model used by the shared conversion code:

- use sparse typed spec/status annotations only for fields the opposite version cannot represent
- keep conversion structural instead of restoring shortcut snapshots or fingerprinted state
- make live representable fields authoritative over saved annotations
- remove draft-only legacy DGD/DCD carrier annotations and scrub code that never existed on `origin/main`
- keep DGD, DCD, and shared-spec helper naming aligned around typed `restore` and `save` state

## Prompt history

This PR came from a correctness review of conversion preservation semantics:

- Apply the same structural, sparse-save conversion model to the next resource kinds after the shared conversion consistency work.
- Do not use extra carrier annotations, fingerprints, or shortcut full-object restore paths.
- Preserve only unrepresentable fields; do not overlay or underlay representable fields from annotations.
- Put real bug reproductions into `*_bugs_test.go`, then fix the conversion against those cases.
- Keep the implementation pattern-following: typed restore/save state, root decode/encode, and explicit restore/save sections.
- Prefer sparse save payloads over full snapshots; named/list-like structures must carry enough key context to restore the right sub-object.
- Compare against `origin/main`; since the removed draft annotations were never shipped there, remove the constants and scrub code instead of carrying migration compatibility for PR-only state.

## Tests

Relevant checks run while building this stack:

- `go test ./api -count=1`
- `go test ./api/v1alpha1 -count=1`
- `go test ./api -run '^TestFuzzRoundTripMutability$/^DGD$' -roundtrip-fuzz-iters=10000 -roundtrip-fuzz-seed=1 -count=1`
- `go test ./api -run '^TestFuzzRoundTripMutability$/^DCD' -roundtrip-fuzz-iters=10000 -roundtrip-fuzz-seed=1 -count=1`
- `go test ./api -run '^TestFuzzRoundTrip_DCD_HubSpokeHub$' -roundtrip-fuzz-iters=10000 -roundtrip-fuzz-seed=1 -count=1`
- `go test ./api -run '^TestFuzzRoundTrip_DCD_SpokeHubSpoke$' -roundtrip-fuzz-iters=10000 -roundtrip-fuzz-seed=1 -count=1`
- `git diff --check`
