### PR TITLE
fix(launch): propagate child exit codes in wait_any_exit (#8883)

### DIFF
--- a/examples/common/launch_utils.sh
+++ b/examples/common/launch_utils.sh
@@ -75,9 +75,19 @@ wait_any_exit() {
         echo "wait_any_exit: no background processes found (script bug: did you forget '&'?)" >&2
         exit 1
     fi
-    wait -n
-    local _rc=$?
+    # Problem: a failing background child should propagate its non-zero
+    # exit code, but the script always exited 0. Two bash interactions
+    # colluded — `set -e` killed the script before `_rc` was captured,
+    # and the EXIT trap's `kill 0` looped SIGTERM back through the
+    # `trap 'exit 0' TERM INT` set above, zeroing the captured code.
+    #
+    # Fix: `wait -n || _rc=$?` quiets `set -e` for that one line, and
+    # re-arming the TERM/INT trap to `exit $_rc` after capture means the
+    # boomerang SIGTERM still ends with the right code.
+    local _rc=0
+    wait -n || _rc=$?
     echo "A background process exited with code $_rc"
+    trap "exit $_rc" TERM INT
     exit "$_rc"
 }
 


### PR DESCRIPTION
#### Overview:

Cherry-pick of [#8883](https://github.com/ai-dynamo/dynamo/pull/8883) onto `release/1.1.0`. Without this, Dynamo example launches on the 1.1.0 line silently report success (exit 0) when a backend dies, breaking CI gating + release validation. Two-line fix to `wait_any_exit` so the real exit code reaches the script's exit.

#### Details:

- Clean cherry-pick of commit `8d8146f8` from main. No conflicts.
- One file: `examples/common/launch_utils.sh` (+12/-2).
- Verified locally on `release/1.1.0` base — repro from DIS-1903 returns 23 with the fix applied (was 0 without).

#### Where should the reviewer start?

`examples/common/launch_utils.sh:72-92`.

#### Related Issues:

Cherry-pick of #8883. Closes DIS-1903 on `release/1.1.0`.

/coderabbit profile chill
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8920" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
