### PR TITLE
test(revalidate): fix(launch): propagate child exit codes in wait_any_exit #8883

### DIFF
--- a/components/src/dynamo/common/__init__.py
+++ b/components/src/dynamo/common/__init__.py
@@ -25,3 +25,5 @@ except Exception:
         __version__ = "0.0.0+unknown"
 
 __all__ = ["__version__", "config_dump", "constants", "utils"]
+
+# ci-health probe 8d8146f8ad6 2026-04-30T17:07:03Z

--- a/lib/runtime/src/runtime.rs
+++ b/lib/runtime/src/runtime.rs
@@ -391,3 +391,5 @@ impl Drop for RuntimeType {
         }
     }
 }
+
+// ci-health probe 8d8146f8ad6 2026-04-30T17:07:03Z


### PR DESCRIPTION
Re-validating that PR #8883 by Keiven C did not regress, by re-running against a trivial placebo diff:

```
fix(launch): propagate child exit codes in wait_any_exit
```

Branch deleted on green; kept on failure for diagnosis.

Drafts are skipped by CodeRabbit per repo `.coderabbit.yaml`.