### PR TITLE
test(revalidate): feat(deepseek-v4): add vLLM GB200 aggregated recipes for V4-Flash and V4-Pro #8876

### DIFF
--- a/components/src/dynamo/common/__init__.py
+++ b/components/src/dynamo/common/__init__.py
@@ -25,3 +25,5 @@ except Exception:
         __version__ = "0.0.0+unknown"
 
 __all__ = ["__version__", "config_dump", "constants", "utils"]
+
+# ci-health probe 8bad68ad042 2026-04-30T17:14:04Z

--- a/lib/runtime/src/runtime.rs
+++ b/lib/runtime/src/runtime.rs
@@ -391,3 +391,5 @@ impl Drop for RuntimeType {
         }
     }
 }
+
+// ci-health probe 8bad68ad042 2026-04-30T17:14:04Z


### PR DESCRIPTION
Re-validating that PR #8876 by Biswa Panda did not regress, by re-running against a trivial placebo diff:

```
feat(deepseek-v4): add vLLM GB200 aggregated recipes for V4-Flash and V4-Pro
```

Branch deleted on green; kept on failure for diagnosis.

Drafts are skipped by CodeRabbit per repo `.coderabbit.yaml`.