### PR TITLE
test(revalidate): ci: allow workflow_dispatch on post-merge with framework filter #8808

### DIFF
--- a/components/src/dynamo/common/__init__.py
+++ b/components/src/dynamo/common/__init__.py
@@ -25,3 +25,5 @@ except Exception:
         __version__ = "0.0.0+unknown"
 
 __all__ = ["__version__", "config_dump", "constants", "utils"]
+
+# ci-health probe 765e779c191 2026-04-30T17:28:05Z

--- a/lib/runtime/src/runtime.rs
+++ b/lib/runtime/src/runtime.rs
@@ -391,3 +391,5 @@ impl Drop for RuntimeType {
         }
     }
 }
+
+// ci-health probe 765e779c191 2026-04-30T17:28:05Z


### PR DESCRIPTION
Re-validating that PR #8808 by Anant Sharma did not regress, by re-running against a trivial placebo diff:

```
ci: allow workflow_dispatch on post-merge with framework filter
```

Branch deleted on green; kept on failure for diagnosis.

Drafts are skipped by CodeRabbit per repo `.coderabbit.yaml`.