### PR TITLE
test(revalidate): perf(trtllm): publisher off request-loop + batched KV walk #8892

### DIFF
--- a/components/src/dynamo/common/__init__.py
+++ b/components/src/dynamo/common/__init__.py
@@ -25,3 +25,5 @@ except Exception:
         __version__ = "0.0.0+unknown"
 
 __all__ = ["__version__", "config_dump", "constants", "utils"]
+
+# ci-health probe 6121b2dc91d 2026-04-30T18:00:12Z

--- a/lib/runtime/src/runtime.rs
+++ b/lib/runtime/src/runtime.rs
@@ -391,3 +391,5 @@ impl Drop for RuntimeType {
         }
     }
 }
+
+// ci-health probe 6121b2dc91d 2026-04-30T18:00:12Z


### PR DESCRIPTION
Re-validating that PR #8892 by Yuewei Na did not regress, by re-running against a trivial placebo diff:

```
perf(trtllm): publisher off request-loop + batched KV walk
```

Branch deleted on green; kept on failure for diagnosis.

Drafts are skipped by CodeRabbit per repo `.coderabbit.yaml`.