### PR TITLE
test(revalidate): feat(kv-router): make approximate pruning TTL-only #8893

### DIFF
--- a/components/src/dynamo/common/__init__.py
+++ b/components/src/dynamo/common/__init__.py
@@ -25,3 +25,5 @@ except Exception:
         __version__ = "0.0.0+unknown"
 
 __all__ = ["__version__", "config_dump", "constants", "utils"]
+
+# ci-health probe 375542bfcaf 2026-04-30T18:14:05Z

--- a/lib/runtime/src/runtime.rs
+++ b/lib/runtime/src/runtime.rs
@@ -391,3 +391,5 @@ impl Drop for RuntimeType {
         }
     }
 }
+
+// ci-health probe 375542bfcaf 2026-04-30T18:14:05Z


### PR DESCRIPTION
Re-validating that PR #8893 by Yan Ru Pei did not regress, by re-running against a trivial placebo diff:

```
feat(kv-router): make approximate pruning TTL-only
```

Branch deleted on green; kept on failure for diagnosis.

Drafts are skipped by CodeRabbit per repo `.coderabbit.yaml`.