### PR TITLE
chore(dsv4-sglang): minor base image cleanup for b200

### DIFF
--- a/recipes/deepseek-v4/container/sglang/Dockerfile.dsv4.sglang.b200
+++ b/recipes/deepseek-v4/container/sglang/Dockerfile.dsv4.sglang.b200
@@ -38,6 +38,10 @@ ENV PYTHONPATH=/workspace/sglang/python:/workspace/components/src
 ENV SGLANG_JIT_DEEPGEMM_PRECOMPILE=0 \
     SGLANG_JIT_DEEPGEMM_FAST_WARMUP=1
 
+# TODO: move this up (consolidate with the apt-get block above) after the release.
+RUN apt-get purge -y libx264-164 libx265-199 libde265-0 libavcodec60 libxvidcore4 \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /workspace
 
 ENTRYPOINT []


### PR DESCRIPTION
## Summary
- Small post-base cleanup pass on the dsv4-sglang b200 image.
- Layer placed at the end intentionally; will be folded into the upstream apt block above after the release.

## Test plan
- [ ] Build `Dockerfile.dsv4.sglang.b200` end-to-end and verify the image still launches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker image size by removing unnecessary system dependencies and cleaning up build metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->