### PR TITLE
chore(dsv4-sglang): cherry-pick #8929 onto release/1.2.0-sglang-deepseek-v4-dev.2

### DIFF
--- a/recipes/deepseek-v4/container/sglang/Dockerfile.dsv4.sglang.b200
+++ b/recipes/deepseek-v4/container/sglang/Dockerfile.dsv4.sglang.b200
@@ -38,6 +38,10 @@ ENV PYTHONPATH=/workspace/sglang/python:/workspace/components/src
 ENV SGLANG_JIT_DEEPGEMM_PRECOMPILE=0 \
     SGLANG_JIT_DEEPGEMM_FAST_WARMUP=1
 
+# TODO: move this up (consolidate with the apt-get block above) after the release.
+RUN apt-get purge -y libx264-164 libx265-199 libde265-0 libavcodec60 libxvidcore4 \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /workspace
 
 ENTRYPOINT []


### PR DESCRIPTION
## Summary
- Cherry-pick of #8929 (commit `b6aa006d`) onto `release/1.2.0-sglang-deepseek-v4-dev.2`.
- Minor post-base cleanup pass on the dsv4-sglang b200 image.

## Test plan
- [ ] Build `Dockerfile.dsv4.sglang.b200` end-to-end on this branch and verify the image still launches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8933" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
