### PR TITLE
feat: KVBM v2 G2-bypass mode for direct G1 <--> G3 GDS transfers

### DIFF
--- a/docs/components/kvbm/kvbm-v2-guide.md
+++ b/docs/components/kvbm/kvbm-v2-guide.md
@@ -65,6 +65,44 @@ vllm serve --kv-transfer-config '{"kv_connector":"DynamoConnector","kv_role":"kv
 
 ## Configuration
 
+### Cache Tier Configuration
+
+Configure KVBM v2 cache tiers using environment variables. The v2 binding maps these env vars through the v1-compat layer onto the resolved cache config, so the user-facing UX matches v1 exactly:
+
+```bash
+# Option 1: CPU cache only (GPU → CPU offloading)
+export DYN_KVBM_CPU_CACHE_GB=4    # 4GB of pinned CPU memory
+
+# Option 2: CPU + Disk cache (GPU → CPU → Disk tiered offloading)
+export DYN_KVBM_CPU_CACHE_GB=4
+export DYN_KVBM_DISK_CACHE_GB=8   # 8GB of disk
+
+# Option 3: Disk cache only — enables host-bypass mode
+#          (GPU ↔ Disk direct via GDS, bypassing CPU memory)
+export DYN_KVBM_DISK_CACHE_GB=8
+```
+
+You can also specify exact block counts instead of GB:
+
+- `DYN_KVBM_CPU_CACHE_OVERRIDE_NUM_BLOCKS`
+- `DYN_KVBM_DISK_CACHE_OVERRIDE_NUM_BLOCKS`
+
+> [!NOTE]
+> KVBM is a write-through cache; capacities should grow with each enabled tier — `DYN_KVBM_CPU_CACHE_GB ≥ <GPU KV cache size>` and `DYN_KVBM_DISK_CACHE_GB ≥ DYN_KVBM_CPU_CACHE_GB`. Misconfiguring the CPU cache below the GPU cache size causes offload churn rather than a benefit.
+
+#### Host-Bypass Mode (Disk-Only)
+
+Setting `DYN_KVBM_DISK_CACHE_GB` *without* `DYN_KVBM_CPU_CACHE_GB` (or with an explicit `DYN_KVBM_CPU_CACHE_GB=0`) enables host-bypass mode. In this mode:
+
+- **Offload** moves blocks directly **G1 (GPU) → G3 (Disk)** via GDS — no G2 staging.
+- **Onboard** moves disk hits directly **G3 → G1** via GDS — no G3→G2→G1 staging.
+- **GDS support is required.** KVBM probes for GDS at startup; if the probe fails, the first transfer errors loudly so the misconfiguration is visible immediately.
+
+**Current scope limits in host-bypass mode:**
+
+- **Onboard mode must be `Inter`** (the default). `Intra` mode uses a layer-by-layer CudaStream load that expects G2 sources, so it cannot serve directly from disk. Combining `KVBM_ONBOARD_MODE=intra` with bypass is rejected at startup with a clear error — use `Inter` whenever bypass is in effect.
+- **No remote search.** Bypass is local-only. The remote-search protocol assumes G2 destinations for staging; a deployment that engages both falls through to the standard staging path, which will surface a missing-G2-destination error rather than silently misroute disk traffic.
+
 ### Onboard Mode
 
 KVBM v2 supports two onboarding modes that control how KV cache blocks are loaded from host (G2) to device (G1) memory:

--- a/lib/kvbm-config/src/cache.rs
+++ b/lib/kvbm-config/src/cache.rs
@@ -101,6 +101,17 @@ impl HostCacheConfig {
     pub fn is_enabled(&self) -> bool {
         self.num_blocks.is_some() || self.cache_size_gb.is_some()
     }
+
+    /// Check if host cache is configured with a positive size.
+    ///
+    /// Treats `Some(0)` and `Some(0.0)` as "not configured" — matching v1's
+    /// `should_bypass_cpu_cache()` behavior so an explicit zero env var
+    /// (e.g. `DYN_KVBM_CPU_CACHE_GB=0`) enables bypass instead of allocating
+    /// an empty G2 tier.
+    pub fn has_positive_size(&self) -> bool {
+        self.cache_size_gb.is_some_and(|gb| gb > 0.0)
+            || self.num_blocks.is_some_and(|n| n > 0)
+    }
 }
 
 /// Disk cache configuration (G3 tier - persistent storage).
@@ -166,6 +177,15 @@ impl DiskCacheConfig {
     pub fn is_enabled(&self) -> bool {
         self.num_blocks.is_some() || self.cache_size_gb.is_some()
     }
+
+    /// Check if disk cache is configured with a positive size.
+    ///
+    /// See [`HostCacheConfig::has_positive_size`] for the rationale on
+    /// treating `Some(0)` / `Some(0.0)` as not configured.
+    pub fn has_positive_size(&self) -> bool {
+        self.cache_size_gb.is_some_and(|gb| gb > 0.0)
+            || self.num_blocks.is_some_and(|n| n > 0)
+    }
 }
 
 /// Top-level cache configuration.
@@ -194,6 +214,29 @@ pub struct CacheConfig {
     /// Can be set via env var: `KVBM_CACHE_PARALLELISM=tensor_parallel|replicated_data`
     #[serde(default)]
     pub parallelism: ParallelismMode,
+}
+
+impl CacheConfig {
+    /// Whether the G2 (host) tier should be bypassed for direct G1↔G3 transfers.
+    ///
+    /// Returns `true` when:
+    /// - Disk (G3) is configured with a positive size, AND
+    /// - Host (G2) is unconfigured or has zero size.
+    ///
+    /// This mirrors the v1 behavior of [`should_bypass_cpu_cache`] in
+    /// `lib/llm/src/block_manager/config.rs`: setting only `DYN_KVBM_DISK_CACHE_GB`
+    /// (without `DYN_KVBM_CPU_CACHE_GB`) enables direct G1↔G3 paths via GDS.
+    /// The env vars flow through `v1_compat.rs` into the resolved config, so
+    /// the user-facing UX is identical to v1.
+    pub fn bypass_host_cache(&self) -> bool {
+        let host_sized = self.host.has_positive_size();
+        let disk_sized = self
+            .disk
+            .as_ref()
+            .map(|d| d.has_positive_size())
+            .unwrap_or(false);
+        disk_sized && !host_sized
+    }
 }
 
 #[cfg(test)]
@@ -386,5 +429,74 @@ mod tests {
     fn test_cache_config_default_parallelism() {
         let config = CacheConfig::default();
         assert_eq!(config.parallelism, ParallelismMode::TensorParallel);
+    }
+
+    #[test]
+    fn test_bypass_host_cache_disk_only() {
+        let config = CacheConfig {
+            host: HostCacheConfig::default(),
+            disk: Some(DiskCacheConfig {
+                cache_size_gb: Some(30.0),
+                ..Default::default()
+            }),
+            parallelism: ParallelismMode::TensorParallel,
+        };
+        assert!(config.bypass_host_cache());
+    }
+
+    #[test]
+    fn test_bypass_host_cache_both_set() {
+        let config = CacheConfig {
+            host: HostCacheConfig {
+                cache_size_gb: Some(10.0),
+                ..Default::default()
+            },
+            disk: Some(DiskCacheConfig {
+                cache_size_gb: Some(30.0),
+                ..Default::default()
+            }),
+            parallelism: ParallelismMode::TensorParallel,
+        };
+        assert!(!config.bypass_host_cache());
+    }
+
+    #[test]
+    fn test_bypass_host_cache_disk_only_no_host() {
+        let config = CacheConfig {
+            host: HostCacheConfig::default(),
+            disk: None,
+            parallelism: ParallelismMode::TensorParallel,
+        };
+        assert!(!config.bypass_host_cache());
+    }
+
+    #[test]
+    fn test_bypass_host_cache_explicit_zero_host_treated_as_not_set() {
+        // Mirrors v1: DYN_KVBM_CPU_CACHE_GB=0 → bypass enabled.
+        let config = CacheConfig {
+            host: HostCacheConfig {
+                cache_size_gb: Some(0.0),
+                num_blocks: Some(0),
+            },
+            disk: Some(DiskCacheConfig {
+                cache_size_gb: Some(30.0),
+                ..Default::default()
+            }),
+            parallelism: ParallelismMode::TensorParallel,
+        };
+        assert!(config.bypass_host_cache());
+    }
+
+    #[test]
+    fn test_bypass_host_cache_zero_disk_does_not_trigger() {
+        let config = CacheConfig {
+            host: HostCacheConfig::default(),
+            disk: Some(DiskCacheConfig {
+                cache_size_gb: Some(0.0),
+                ..Default::default()
+            }),
+            parallelism: ParallelismMode::TensorParallel,
+        };
+        assert!(!config.bypass_host_cache());
     }
 }

--- a/lib/kvbm-config/src/lib.rs
+++ b/lib/kvbm-config/src/lib.rs
@@ -245,6 +245,11 @@ impl KvbmConfig {
     ///
     /// - Host cache (G2) enabled → UCX (used for inter-worker / remote transfers)
     /// - Disk cache (G3) enabled → POSIX, or GDS_MT when `disk.use_gds = true`
+    /// - Host-bypass mode (`bypass_host_cache() == true`) → force GDS_MT for
+    ///   direct G1↔G3 transfers, and UCX for the cross-process metadata
+    ///   exchange path (`getLocalMD`) that registers G1 (VRAM) segments. POSIX
+    ///   alone cannot register VRAM, so without these the worker fails at
+    ///   `registerMem` for `VRAM_SEG`.
     ///
     /// Idempotent and additive: only fills gaps, never removes a backend the
     /// user explicitly enabled. If no tier is enabled, leaves `nixl` untouched
@@ -253,7 +258,8 @@ impl KvbmConfig {
         let host_enabled = self.cache.host.is_enabled();
         let disk_cfg = self.cache.disk.as_ref();
         let disk_enabled = disk_cfg.is_some_and(|d| d.is_enabled());
-        let prefer_gds = disk_cfg.is_some_and(|d| d.use_gds);
+        let bypass_host = self.cache.bypass_host_cache();
+        let prefer_gds = disk_cfg.is_some_and(|d| d.use_gds) || bypass_host;
 
         if !host_enabled && !disk_enabled {
             return;
@@ -261,16 +267,26 @@ impl KvbmConfig {
 
         let nixl = self.nixl.get_or_insert_with(NixlConfig::empty);
 
-        if host_enabled && !nixl.has_backend("UCX") {
-            tracing::info!(
-                "Auto-enabling NIXL backend UCX (host cache requires it for inter-worker transfers)"
-            );
+        // UCX is needed both when G2 is real (inter-worker transfers) and in
+        // host-bypass mode (the worker still needs UCX for the metadata
+        // exchange that exposes its VRAM segments to the leader).
+        if (host_enabled || bypass_host) && !nixl.has_backend("UCX") {
+            let reason = if bypass_host {
+                "host-bypass mode requires UCX for cross-process metadata exchange"
+            } else {
+                "host cache requires UCX for inter-worker transfers"
+            };
+            tracing::info!(reason, "Auto-enabling NIXL backend UCX");
             *nixl = nixl.clone().with_backend("UCX");
         }
 
         if disk_enabled && !nixl.has_backend("POSIX") && !nixl.has_backend("GDS_MT") {
             let backend = if prefer_gds { "GDS_MT" } else { "POSIX" };
-            tracing::info!(backend, "Auto-enabling NIXL backend for disk cache");
+            tracing::info!(
+                backend,
+                bypass_host,
+                "Auto-enabling NIXL backend for disk cache"
+            );
             *nixl = nixl.clone().with_backend(backend);
         }
     }

--- a/lib/kvbm-config/src/offload.rs
+++ b/lib/kvbm-config/src/offload.rs
@@ -166,6 +166,16 @@ pub struct OffloadConfig {
     #[serde(default)]
     #[validate(nested)]
     pub g2_to_g3: TierOffloadConfig,
+
+    /// G1 (GPU) → G3 (Disk) direct offload policies (host-bypass mode).
+    ///
+    /// Only consulted when the cache config has `bypass_host_cache() == true`
+    /// (disk configured, host not). In that mode the G1→G2 + G2→G3 chain is
+    /// replaced by a single G1→G3 pipeline that uses GDS for direct GPU→disk
+    /// transfers.
+    #[serde(default)]
+    #[validate(nested)]
+    pub g1_to_g3: TierOffloadConfig,
 }
 
 #[cfg(test)]

--- a/lib/kvbm-connector/src/connector/leader/init.rs
+++ b/lib/kvbm-connector/src/connector/leader/init.rs
@@ -238,10 +238,25 @@ impl ConnectorLeader {
 
         let host_block_count = host_block_count.unwrap_or(0);
 
+        // Host-bypass mode: when disk is configured and host is not, we serve
+        // disk hits to GPU directly via GDS instead of staging through G2.
+        // InstanceLeader still requires a G2 BlockManager, but no G1→G2 /
+        // G2→G3 pipelines are wired and no onboarding routes through G2 —
+        // so we build it with a sentinel block_count of 1 (BlockManager
+        // validation rejects 0). It allocates no physical memory; it's a
+        // logical-only placeholder that will never see registered blocks.
+        let bypass_host = self.runtime.config().cache.bypass_host_cache();
+        let g2_manager_block_count = if bypass_host {
+            host_block_count.max(1)
+        } else {
+            host_block_count
+        };
+
         tracing::info!(
             host_block_count,
             ?disk_block_count,
             bytes_per_block,
+            bypass_host,
             "Computed block counts for G2/G3 tiers"
         );
 
@@ -349,14 +364,15 @@ impl ConnectorLeader {
         tracing::debug!("Block registry created");
 
         tracing::debug!(
-            host_block_count,
+            block_count = g2_manager_block_count,
             page_size = reference_config.page_size,
+            bypass_host,
             "Building G2 manager"
         );
         let logical_metrics = self.runtime.observability().logical_aggregator();
         let g2_manager = Arc::new(
             BlockManager::<G2>::builder()
-                .block_count(host_block_count)
+                .block_count(g2_manager_block_count)
                 .block_size(reference_config.page_size)
                 .registry(registry.clone())
                 .with_lineage_backend()
@@ -417,6 +433,7 @@ impl ConnectorLeader {
             .messenger(self.runtime.messenger().clone())
             .registry(registry)
             .g2_manager(g2_manager)
+            .bypass_host(bypass_host)
             .workers(
                 worker_clients
                     .into_iter()
@@ -458,70 +475,108 @@ impl ConnectorLeader {
         let offload_config = &self.runtime.config().offload;
         let runtime_handle = self.runtime.tokio();
 
-        // Build G1→G2 policy from config (or defaults if not configured)
-        // G1 is externally owned by vLLM (GPU KV cache), accessed via ExternalBlock<G1>
-        // Default: Presence filter to prevent duplicate transfers (pending auto-wired)
-        let g1_to_g2_config = if offload_config.g1_to_g2.policies.is_empty() {
-            tracing::debug!("No G1→G2 policies configured, using default: [Presence]");
-            kvbm_config::TierOffloadConfig {
-                policies: vec![kvbm_config::PolicyType::Presence],
-                ..Default::default()
-            }
-        } else {
-            offload_config.g1_to_g2.clone()
-        };
-        let g1_to_g2_pending = Arc::new(PendingTracker::new());
-        let g1_to_g2_policy = create_policy_from_config::<G1, G2>(
-            &g1_to_g2_config,
-            registry_for_offload.clone(),
-            Some(g1_to_g2_pending.clone()),
-        );
-        // Auto-chain G1→G2 completions to downstream tiers (G3 and/or G4)
-        let has_downstream_tier =
-            g3_manager_for_offload.is_some() || self.runtime.config().object.is_some();
-        let g1_to_g2_pipeline = PipelineBuilder::<G1, G2>::new()
-            .policy(g1_to_g2_policy)
-            .pending_tracker(g1_to_g2_pending)
-            .auto_chain(has_downstream_tier)
-            .build();
-
-        // Build G2→G3 policy from config (or defaults if not configured).
-        // Default: Presence — symmetric with G1→G2. Offload any block not already
-        // on disk and not already in flight; let G3's eviction backend handle
-        // cold-block churn under pressure. Opt into LFU-on-admission for
-        // workloads where disk write amplification matters by setting
-        // KVBM_OFFLOAD_G2_TO_G3_POLICIES='["presence_lfu"]'.
-        let g2_to_g3_config = if offload_config.g2_to_g3.policies.is_empty() {
-            tracing::debug!("No G2→G3 policies configured, using default: [Presence]");
-            kvbm_config::TierOffloadConfig {
-                policies: vec![kvbm_config::PolicyType::Presence],
-                ..Default::default()
-            }
-        } else {
-            offload_config.g2_to_g3.clone()
-        };
-        let g2_to_g3_pending = Arc::new(PendingTracker::new());
-        let g2_to_g3_policy = create_policy_from_config::<G2, G3>(
-            &g2_to_g3_config,
-            registry_for_offload.clone(),
-            Some(g2_to_g3_pending.clone()),
-        );
-        let g2_to_g3_pipeline = PipelineBuilder::<G2, G3>::new()
-            .policy(g2_to_g3_policy)
-            .pending_tracker(g2_to_g3_pending)
-            .build();
-
         let mut engine_builder = OffloadEngine::builder(leader.clone())
-            .with_registry(registry_for_offload)
+            .with_registry(registry_for_offload.clone())
             .with_g2_manager(g2_manager_for_offload)
-            .with_runtime(runtime_handle)
-            .with_g1_to_g2_pipeline(g1_to_g2_pipeline);
+            .with_runtime(runtime_handle);
 
-        // Conditionally add G3 pipeline if G3 manager exists
-        if let Some(g3_mgr) = g3_manager_for_offload {
+        if bypass_host {
+            // Host-bypass mode: single G1→G3 pipeline, no G2 staging.
+            // Default policy is Presence (symmetric with the non-bypass
+            // G1→G2 default). G3 manager must exist — guaranteed by the
+            // earlier disk_ok check.
+            let g1_to_g3_config = if offload_config.g1_to_g3.policies.is_empty() {
+                tracing::debug!("No G1→G3 policies configured, using default: [Presence]");
+                kvbm_config::TierOffloadConfig {
+                    policies: vec![kvbm_config::PolicyType::Presence],
+                    ..Default::default()
+                }
+            } else {
+                offload_config.g1_to_g3.clone()
+            };
+            let g1_to_g3_pending = Arc::new(PendingTracker::new());
+            let g1_to_g3_policy = create_policy_from_config::<G1, G3>(
+                &g1_to_g3_config,
+                registry_for_offload.clone(),
+                Some(g1_to_g3_pending.clone()),
+            );
+            let g1_to_g3_pipeline = PipelineBuilder::<G1, G3>::new()
+                .policy(g1_to_g3_policy)
+                .pending_tracker(g1_to_g3_pending)
+                .build();
+
+            let g3_mgr = g3_manager_for_offload.clone().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Host-bypass mode requires a configured G3 (disk) cache; got none"
+                )
+            })?;
             engine_builder = engine_builder
                 .with_g3_manager(g3_mgr)
-                .with_g2_to_g3_pipeline(g2_to_g3_pipeline);
+                .with_g1_to_g3_pipeline(g1_to_g3_pipeline);
+        } else {
+            // Standard mode: G1→G2 (with auto-chain) and G2→G3.
+            //
+            // Build G1→G2 policy from config (or defaults if not configured).
+            // G1 is externally owned by vLLM (GPU KV cache), accessed via ExternalBlock<G1>.
+            // Default: Presence filter to prevent duplicate transfers (pending auto-wired).
+            let g1_to_g2_config = if offload_config.g1_to_g2.policies.is_empty() {
+                tracing::debug!("No G1→G2 policies configured, using default: [Presence]");
+                kvbm_config::TierOffloadConfig {
+                    policies: vec![kvbm_config::PolicyType::Presence],
+                    ..Default::default()
+                }
+            } else {
+                offload_config.g1_to_g2.clone()
+            };
+            let g1_to_g2_pending = Arc::new(PendingTracker::new());
+            let g1_to_g2_policy = create_policy_from_config::<G1, G2>(
+                &g1_to_g2_config,
+                registry_for_offload.clone(),
+                Some(g1_to_g2_pending.clone()),
+            );
+            // Auto-chain G1→G2 completions to downstream tiers (G3 and/or G4)
+            let has_downstream_tier =
+                g3_manager_for_offload.is_some() || self.runtime.config().object.is_some();
+            let g1_to_g2_pipeline = PipelineBuilder::<G1, G2>::new()
+                .policy(g1_to_g2_policy)
+                .pending_tracker(g1_to_g2_pending)
+                .auto_chain(has_downstream_tier)
+                .build();
+
+            // Build G2→G3 policy from config (or defaults if not configured).
+            // Default: Presence — symmetric with G1→G2. Offload any block not already
+            // on disk and not already in flight; let G3's eviction backend handle
+            // cold-block churn under pressure. Opt into LFU-on-admission for
+            // workloads where disk write amplification matters by setting
+            // KVBM_OFFLOAD_G2_TO_G3_POLICIES='["presence_lfu"]'.
+            let g2_to_g3_config = if offload_config.g2_to_g3.policies.is_empty() {
+                tracing::debug!("No G2→G3 policies configured, using default: [Presence]");
+                kvbm_config::TierOffloadConfig {
+                    policies: vec![kvbm_config::PolicyType::Presence],
+                    ..Default::default()
+                }
+            } else {
+                offload_config.g2_to_g3.clone()
+            };
+            let g2_to_g3_pending = Arc::new(PendingTracker::new());
+            let g2_to_g3_policy = create_policy_from_config::<G2, G3>(
+                &g2_to_g3_config,
+                registry_for_offload.clone(),
+                Some(g2_to_g3_pending.clone()),
+            );
+            let g2_to_g3_pipeline = PipelineBuilder::<G2, G3>::new()
+                .policy(g2_to_g3_policy)
+                .pending_tracker(g2_to_g3_pending)
+                .build();
+
+            engine_builder = engine_builder.with_g1_to_g2_pipeline(g1_to_g2_pipeline);
+
+            // Conditionally add G3 pipeline if G3 manager exists
+            if let Some(g3_mgr) = g3_manager_for_offload {
+                engine_builder = engine_builder
+                    .with_g3_manager(g3_mgr)
+                    .with_g2_to_g3_pipeline(g2_to_g3_pipeline);
+            }
         }
 
         // Build G2→G4 object storage pipeline if configured

--- a/lib/kvbm-connector/src/connector/leader/onboard.rs
+++ b/lib/kvbm-connector/src/connector/leader/onboard.rs
@@ -51,6 +51,18 @@ impl ConnectorLeader {
         block_ids: Vec<BlockId>,
         num_external_tokens: usize,
     ) -> Result<()> {
+        // Intra-pass onboarding currently only supports G2→G1 (the worker's
+        // CudaStream layer-by-layer load expects G2 sources). Host-bypass
+        // mode has no G2 to source from, so reject the combination loudly
+        // rather than silently producing wrong results. Use Inter mode if
+        // bypass is required.
+        if self.runtime.config().cache.bypass_host_cache() {
+            bail!(
+                "Intra-pass onboarding is not supported when host (G2) cache is bypassed. \
+                 Set DYN_KVBM_CPU_CACHE_GB to enable G2, or use Inter onboard mode \
+                 (the default) which supports the bypass + GDS direct G3→G1 path."
+            );
+        }
         let shared_slot = self.get_slot(request_id)?;
         let mut slot = shared_slot.lock();
         let num_computed_tokens = slot
@@ -151,12 +163,14 @@ impl ConnectorLeader {
         let handle = self.runtime.tokio();
         let request_id = request_id.to_string();
 
+        let bypass_host = self.runtime.config().cache.bypass_host_cache();
         handle.spawn(async move {
             match execute_onboarding(
                 leader.clone(),
                 shared_slot.clone(),
                 onboard_blocks_ids.clone(),
                 staging_fut,
+                bypass_host,
             )
             .await
             {
@@ -210,6 +224,7 @@ async fn execute_onboarding(
     slot: Arc<Mutex<RequestSlot>>,
     block_ids: Vec<BlockId>,
     staging_fut: Either<Ready<Result<()>>, BoxFuture<'static, Result<()>>>,
+    bypass_host: bool,
 ) -> Result<()> {
     let g1_block_ids = block_ids;
     let start = Instant::now();
@@ -220,35 +235,49 @@ async fn execute_onboarding(
         .context("Onboarding find_session operation failed")?;
     let staging_complete = Instant::now();
 
-    let g2_blocks = slot
-        .lock()
-        .onboarding_state_mut()
-        .expect("Onboarding state not found")
-        .find_session
-        .take_g2_blocks()
-        .ok_or_else(|| anyhow::anyhow!("No G2 blocks found"))?;
+    // Pull source blocks from the find session. In host-bypass mode the
+    // Ready result carries G3 blocks (no staging happened); otherwise the
+    // AsyncSession has already staged into G2.
+    let (src_layout, src_block_ids) = {
+        let mut slot_guard = slot.lock();
+        let session = slot_guard
+            .onboarding_state_mut()
+            .expect("Onboarding state not found");
+        if bypass_host {
+            let g3_blocks = session
+                .find_session
+                .take_g3_blocks()
+                .ok_or_else(|| anyhow::anyhow!("No G3 blocks found (bypass mode)"))?;
+            let ids: Vec<BlockId> = g3_blocks.iter().map(|b| b.block_id()).collect();
+            (LogicalLayoutHandle::G3, ids)
+        } else {
+            let g2_blocks = session
+                .find_session
+                .take_g2_blocks()
+                .ok_or_else(|| anyhow::anyhow!("No G2 blocks found"))?;
+            let ids: Vec<BlockId> = g2_blocks.iter().map(|b| b.block_id()).collect();
+            (LogicalLayoutHandle::G2, ids)
+        }
+    };
 
-    let g2_block_ids: Vec<BlockId> = g2_blocks.iter().map(|b| b.block_id()).collect();
-
-    let num_blocks = g2_block_ids.len();
+    let num_blocks = src_block_ids.len();
     assert_eq!(num_blocks, g1_block_ids.len());
 
-    // All blocks are now in G2
     let instance_leader = leader.instance_leader().expect("InstanceLeader not set");
     let parallel_worker = instance_leader
         .parallel_worker()
         .ok_or_else(|| anyhow::anyhow!("No parallel worker available for local transfer"))?;
 
-    // TODO: potential optimization would be to stream G2 blocks to G1 blocks as G2 blocks are ready.
-    // The current implementation awaits all G2 blocks to be ready before executing the transfer.
-    // The balance here is when do we acquire/allocate G1 blocks as they are a precious commodity vs.,
-    // when should we start onboarding. More analysis is needed here to determine the optimal strategy.
+    // TODO: potential optimization would be to stream blocks to G1 as they
+    // become ready. The current implementation awaits all source blocks
+    // before issuing the transfer. The balance is when to acquire/allocate
+    // G1 blocks (a precious commodity) vs. when to start onboarding.
     let start_xfer = Instant::now();
     parallel_worker
         .execute_local_transfer(
-            LogicalLayoutHandle::G2,
+            src_layout,
             LogicalLayoutHandle::G1,
-            Arc::from(g2_block_ids),
+            Arc::from(src_block_ids),
             Arc::from(g1_block_ids),
             TransferOptions::default(),
         )?
@@ -260,7 +289,7 @@ async fn execute_onboarding(
         staging_ms = staging_complete.duration_since(start).as_millis() as u64,
         xfer_ms = end_xfer.duration_since(start_xfer).as_millis() as u64,
         total_ms = end_xfer.duration_since(start).as_millis() as u64,
-        src = "kvbm_engine::G2",
+        src = if bypass_host { "kvbm_engine::G3" } else { "kvbm_engine::G2" },
         dst = "kvbm_engine::G1",
         "Onboard transfer complete"
     );

--- a/lib/kvbm-connector/src/connector/leader/scheduler.rs
+++ b/lib/kvbm-connector/src/connector/leader/scheduler.rs
@@ -689,12 +689,17 @@ impl ConnectorLeader {
             return Ok(OffloadAction::NoAction);
         }
 
-        // Enqueue with precondition
-        let handle = self
+        // Enqueue with precondition. In host-bypass mode we skip the G1→G2
+        // hop entirely and use the standalone G1→G3 pipeline (GDS direct).
+        let engine = self
             .offload_engine
             .get()
-            .expect("offload engine initialized")
-            .enqueue_g1_to_g2_with_precondition(source_blocks, precondition)?;
+            .expect("offload engine initialized");
+        let handle = if self.runtime.config().cache.bypass_host_cache() {
+            engine.enqueue_g1_to_g3_with_precondition(source_blocks, precondition)?
+        } else {
+            engine.enqueue_g1_to_g2_with_precondition(source_blocks, precondition)?
+        };
 
         // Record offload in slot state
         slot.record_offload(block_mappings, handle)?;

--- a/lib/kvbm-connector/src/connector/leader/search.rs
+++ b/lib/kvbm-connector/src/connector/leader/search.rs
@@ -103,12 +103,17 @@ impl ConnectorLeader {
 
         let outcome = match &session.find_session {
             FindMatchesResult::Ready(ready) => {
-                // Ready result means immediate completion (local only, no async work)
-                let matched_blocks = ready.g2_count();
+                // Ready result means immediate completion (local only, no async work).
+                // In host-bypass mode the Ready may carry G3 blocks alongside G2;
+                // total_count covers both so matched_tokens reflects the full hit
+                // and standard (G2-only) Ready results behave unchanged.
+                let matched_blocks = ready.total_count();
                 let matched_tokens = matched_blocks * block_size;
 
                 tracing::debug!(
                     matched_blocks,
+                    g2_count = ready.g2_count(),
+                    g3_count = ready.g3_count(),
                     matched_tokens,
                     "Find completed immediately (Ready)"
                 );

--- a/lib/kvbm-connector/src/connector/worker/init/pending.rs
+++ b/lib/kvbm-connector/src/connector/worker/init/pending.rs
@@ -33,6 +33,7 @@ use crate::KvbmRuntime;
 use kvbm_common::LogicalLayoutHandle;
 use kvbm_physical::TransferManager;
 use kvbm_physical::layout::{BlockDimension, LayoutConfig, PhysicalLayoutBuilder};
+use kvbm_physical::transfer::TransferCapabilities;
 
 /// Cached state from `register_kv_caches` for deferred initialization.
 ///
@@ -154,13 +155,32 @@ impl PendingWorkerState {
             .cloned()
             .ok_or_else(|| anyhow::anyhow!("NIXL agent not found"))?;
 
-        // 1. Build TransferManager and NixlAgent
-        tracing::info!("Building TransferManager with NIXL backend");
+        // 1. Build TransferManager and NixlAgent.
+        //
+        // When the cache config requests host bypass (DYN_KVBM_DISK_CACHE_GB
+        // set, DYN_KVBM_CPU_CACHE_GB unset), enable GDS so the strategy layer
+        // selects direct G1↔G3 transfers instead of trying to stage through a
+        // G2 tier that doesn't exist. `with_gds_if_supported()` probes the
+        // host once and falls back to allow_gds=false if the probe fails — in
+        // that case the first G1↔G3 transfer will error loudly, which is the
+        // correct signal that bypass mode isn't viable on this host.
+        let bypass_host = runtime.config().cache.bypass_host_cache();
+        let capabilities = if bypass_host {
+            TransferCapabilities::default().with_gds_if_supported()
+        } else {
+            TransferCapabilities::default()
+        };
+        tracing::info!(
+            bypass_host,
+            allow_gds = capabilities.allow_gds,
+            "Building TransferManager with NIXL backend"
+        );
         let transfer_manager = TransferManager::builder()
             .event_system(runtime.event_system())
             .cuda_device_id(self.cuda_device_id)
             .tokio_runtime(TokioRuntime::Handle(runtime.tokio()))
             .observability(runtime.observability().clone())
+            .capabilities(capabilities)
             .nixl_agent(nixl_agent.clone())
             .build()?;
 
@@ -212,8 +232,12 @@ impl PendingWorkerState {
         //
         // For ReplicatedData mode: only rank 0 gets G2/G3 layouts
         // For TensorParallel mode: all workers get G2/G3 layouts
+        // For host-bypass mode (DYN_KVBM_DISK_CACHE_GB set, DYN_KVBM_CPU_CACHE_GB
+        // unset): G2 is skipped on every rank — transfers go G1↔G3 directly via
+        // GDS. G3 still gets allocated normally.
         let skip_g2_g3 =
             config.parallelism == kvbm_config::ParallelismMode::ReplicatedData && config.rank > 0;
+        let bypass_host = runtime.config().cache.bypass_host_cache();
 
         let (g2_handle, g3_handle) = if skip_g2_g3 {
             tracing::info!(
@@ -227,37 +251,46 @@ impl PendingWorkerState {
                 host_block_count = config.host_block_count,
                 disk_block_count = ?config.disk_block_count,
                 parallelism = ?config.parallelism,
+                bypass_host,
                 "Creating G2/G3 layouts via configure_additional_layouts()"
             );
 
-            let mut host_layout = self.layout_config.clone();
-            host_layout.num_blocks = config.host_block_count;
+            let g2_handle = if bypass_host {
+                tracing::info!(
+                    "Skipping G2 layout allocation (host-bypass mode: G1↔G3 direct via GDS)"
+                );
+                None
+            } else {
+                let mut host_layout = self.layout_config.clone();
+                host_layout.num_blocks = config.host_block_count;
 
-            let total_bytes = host_layout.required_bytes() as u64;
-            tracing::info!(
-                host_block_count = config.host_block_count,
-                bytes_per_block = host_layout.bytes_per_block(),
-                total_gb = total_bytes / (1024 * 1024 * 1024),
-                "Allocating pinned host memory for G2 layout"
-            );
+                let total_bytes = host_layout.required_bytes() as u64;
+                tracing::info!(
+                    host_block_count = config.host_block_count,
+                    bytes_per_block = host_layout.bytes_per_block(),
+                    total_gb = total_bytes / (1024 * 1024 * 1024),
+                    "Allocating pinned host memory for G2 layout"
+                );
 
-            let host_layout = PhysicalLayoutBuilder::new(nixl_agent.clone())
-                .with_config(host_layout)
-                .fully_contiguous()
-                .allocate_pinned(Some(self.cuda_device_id as u32))
-                .build()
-                .map_err(|e| {
-                    tracing::error!(
-                        host_block_count = config.host_block_count,
-                        total_gb = total_bytes / (1024 * 1024 * 1024),
-                        error = %e,
-                        "Failed to allocate pinned host memory for G2 layout"
-                    );
-                    e
-                })?;
+                let host_layout = PhysicalLayoutBuilder::new(nixl_agent.clone())
+                    .with_config(host_layout)
+                    .fully_contiguous()
+                    .allocate_pinned(Some(self.cuda_device_id as u32))
+                    .build()
+                    .map_err(|e| {
+                        tracing::error!(
+                            host_block_count = config.host_block_count,
+                            total_gb = total_bytes / (1024 * 1024 * 1024),
+                            error = %e,
+                            "Failed to allocate pinned host memory for G2 layout"
+                        );
+                        e
+                    })?;
 
-            let g2_handle = transfer_manager.register_layout(host_layout)?;
-            created_layouts.push(LogicalLayoutHandle::G2);
+                let handle = transfer_manager.register_layout(host_layout)?;
+                created_layouts.push(LogicalLayoutHandle::G2);
+                Some(handle)
+            };
 
             // todo: we need to get a path from the the config and create a unique file based on the velo instance_id
             let g3_handle = if let Some(disk_blocks) = config.disk_block_count {
@@ -330,7 +363,7 @@ impl PendingWorkerState {
                 None
             };
 
-            (Some(g2_handle), g3_handle)
+            (g2_handle, g3_handle)
         };
 
         // 7. Build DirectWorker with all handles via builder pattern

--- a/lib/kvbm-engine/src/leader/instance.rs
+++ b/lib/kvbm-engine/src/leader/instance.rs
@@ -114,6 +114,11 @@ pub struct InstanceLeader {
     /// Object storage client for G4 search and load operations.
     /// Leader calls has_blocks on S3 directly, coordinates workers for get_blocks.
     object_client: Option<Arc<dyn ObjectBlockOps>>,
+
+    /// When true, host (G2) is bypassed: disk hits are returned directly as
+    /// G3 blocks for G3→G1 transfer instead of staging through G2. Driven by
+    /// `kvbm_config::CacheConfig::bypass_host_cache()` at init time.
+    pub(crate) bypass_host: bool,
 }
 
 /// Builder for InstanceLeader.
@@ -128,6 +133,7 @@ pub struct InstanceLeaderBuilder {
     remote_leaders: Option<Vec<InstanceId>>,
     cached_worker_metadata: Option<Vec<SerializedLayout>>,
     object_client: Option<Arc<dyn ObjectBlockOps>>,
+    bypass_host: bool,
 }
 
 impl InstanceLeaderBuilder {
@@ -210,6 +216,15 @@ impl InstanceLeaderBuilder {
     /// The leader uses this client to:
     /// - Query S3 for block presence via `has_blocks`
     /// - Coordinate workers to load blocks from S3 via `get_blocks`
+    /// Mark this leader as running in host-bypass mode. When set, disk hits
+    /// are returned as G3 blocks for direct G3→G1 onboarding instead of being
+    /// staged through G2. Set this when the cache config has
+    /// `bypass_host_cache() == true`.
+    pub fn bypass_host(mut self, bypass: bool) -> Self {
+        self.bypass_host = bypass;
+        self
+    }
+
     pub fn object_client(mut self, client: Arc<dyn ObjectBlockOps>) -> Self {
         self.object_client = Some(client);
         self
@@ -266,6 +281,7 @@ impl InstanceLeaderBuilder {
             transport,
             session_sessions: Arc::new(DashMap::new()),
             object_client: self.object_client,
+            bypass_host: self.bypass_host,
         })
     }
 }
@@ -1176,9 +1192,32 @@ impl Leader for InstanceLeader {
         let has_object_client = self.object_client.is_some();
         let needs_remote_search =
             options.search_remote && (has_remote_leaders || has_object_client);
-        let is_ready = matched_g3_blocks.is_empty() && !needs_remote_search;
         let local_g2_count = matched_g2_blocks.len();
         let local_g3_count = matched_g3_blocks.len();
+
+        // Host-bypass short-circuit: when G2 is intentionally unconfigured we
+        // never want to take the AsyncSession + stage_g3_to_g2 path. Return
+        // immediately with both G2 (typically empty) and G3 blocks attached
+        // so the caller can issue G3→G1 directly via GDS.
+        //
+        // Bypass mode does not currently support remote search — the staging
+        // protocol owns that path and assumes G2 destinations. If a caller
+        // requests remote search under bypass, fall through to the normal
+        // AsyncSession path which will surface the missing-G2-destination
+        // error loudly rather than silently dropping disk traffic.
+        if self.bypass_host && !needs_remote_search {
+            return Ok(FindMatchesResult::Ready(ReadyResult::new_with_g3(
+                matched_g2_blocks,
+                matched_g3_blocks,
+                super::MatchBreakdown {
+                    host_blocks: local_g2_count,
+                    disk_blocks: local_g3_count,
+                    object_blocks: 0,
+                },
+            )));
+        }
+
+        let is_ready = matched_g3_blocks.is_empty() && !needs_remote_search;
 
         if is_ready {
             // No session needed - blocks owned directly by ReadyResult (RAII)

--- a/lib/kvbm-engine/src/leader/types.rs
+++ b/lib/kvbm-engine/src/leader/types.rs
@@ -8,7 +8,7 @@ use tokio::sync::{Mutex, watch};
 
 use std::sync::Arc;
 
-use crate::G2;
+use crate::{G2, G3};
 use kvbm_logical::blocks::ImmutableBlock;
 
 use super::onboarding::{OnboardingStatus, SessionHandle};
@@ -82,13 +82,37 @@ pub struct MatchBreakdown {
 pub struct ReadyResult {
     /// G2 blocks held directly via RAII
     blocks: Vec<ImmutableBlock<G2>>,
+    /// G3 blocks held directly via RAII (host-bypass mode).
+    ///
+    /// In standard mode this is always empty — disk hits become G2 blocks
+    /// after `stage_g3_to_g2` runs in the AsyncSession path. Populated only
+    /// when host-bypass is in effect and disk hits are returned for direct
+    /// G3→G1 onboarding.
+    g3_blocks: Vec<ImmutableBlock<G3>>,
     breakdown: MatchBreakdown,
 }
 
 impl ReadyResult {
-    /// Create a new ready result with G2 blocks.
+    /// Create a new ready result with G2 blocks (standard mode).
     pub fn new(blocks: Vec<ImmutableBlock<G2>>, breakdown: MatchBreakdown) -> Self {
-        Self { blocks, breakdown }
+        Self {
+            blocks,
+            g3_blocks: Vec::new(),
+            breakdown,
+        }
+    }
+
+    /// Create a new ready result with G2 + G3 blocks (host-bypass mode).
+    pub fn new_with_g3(
+        g2_blocks: Vec<ImmutableBlock<G2>>,
+        g3_blocks: Vec<ImmutableBlock<G3>>,
+        breakdown: MatchBreakdown,
+    ) -> Self {
+        Self {
+            blocks: g2_blocks,
+            g3_blocks,
+            breakdown,
+        }
     }
 
     /// Number of G2 blocks held.
@@ -96,16 +120,38 @@ impl ReadyResult {
         self.blocks.len()
     }
 
+    /// Number of G3 blocks held (host-bypass mode).
+    pub fn g3_count(&self) -> usize {
+        self.g3_blocks.len()
+    }
+
+    /// Total matched blocks across all tiers (G2 + G3).
+    pub fn total_count(&self) -> usize {
+        self.g2_count() + self.g3_count()
+    }
+
     /// Take ownership of the G2 blocks.
     ///
-    /// After calling this, the ReadyResult will be empty.
+    /// After calling this, the ReadyResult's G2 list will be empty.
     pub fn take_g2_blocks(&mut self) -> Vec<ImmutableBlock<G2>> {
         std::mem::take(&mut self.blocks)
+    }
+
+    /// Take ownership of the G3 blocks (host-bypass mode).
+    ///
+    /// After calling this, the ReadyResult's G3 list will be empty.
+    pub fn take_g3_blocks(&mut self) -> Vec<ImmutableBlock<G3>> {
+        std::mem::take(&mut self.g3_blocks)
     }
 
     /// Get a reference to the G2 blocks.
     pub fn blocks(&self) -> &[ImmutableBlock<G2>] {
         &self.blocks
+    }
+
+    /// Get a reference to the G3 blocks (host-bypass mode).
+    pub fn g3_blocks(&self) -> &[ImmutableBlock<G3>] {
+        &self.g3_blocks
     }
 
     pub fn match_breakdown(&self) -> MatchBreakdown {
@@ -262,6 +308,17 @@ impl FindMatchesResult {
         match self {
             FindMatchesResult::Ready(r) => Some(r.take_g2_blocks()),
             FindMatchesResult::AsyncSession(a) => a.blocks.try_lock().ok()?.take(),
+        }
+    }
+
+    /// Take ownership of G3 blocks if available (host-bypass mode).
+    ///
+    /// Only Ready results carry G3 blocks; AsyncSession returns `None` because
+    /// remote-search / staging paths don't currently populate the G3 holder.
+    pub fn take_g3_blocks(&mut self) -> Option<Vec<ImmutableBlock<G3>>> {
+        match self {
+            FindMatchesResult::Ready(r) => Some(r.take_g3_blocks()),
+            FindMatchesResult::AsyncSession(_) => None,
         }
     }
 

--- a/lib/kvbm-engine/src/offload/engine.rs
+++ b/lib/kvbm-engine/src/offload/engine.rs
@@ -55,13 +55,17 @@ use super::source::SourceBlocks;
 
 /// Central coordinator for offload pipelines.
 ///
-/// The engine manages multiple pipelines (G1→G2, G2→G3, G2→G4) and provides
-/// a unified interface for enqueueing blocks for offload.
+/// The engine manages multiple pipelines (G1→G2, G2→G3, G1→G3, G2→G4) and
+/// provides a unified interface for enqueueing blocks for offload.
 ///
 /// # Storage Tier Model
 ///
 /// - G1→G2: `BlockManager<G2>` destination (host memory)
 /// - G2→G3: `BlockManager<G3>` destination (disk/NVMe)
+/// - G1→G3: `BlockManager<G3>` destination (disk, bypass-host) — used when
+///   G2 is intentionally unconfigured (`cache.bypass_host_cache() == true`).
+///   Requires GDS support for direct GPU↔disk transfers; the strategy layer
+///   selects the direct path when `TransferCapabilities::allow_gds` is set.
 /// - G2→G4: ObjectBlockOps destination (object storage like S3)
 ///
 /// # Distributed G2→G4 Offloading
@@ -80,6 +84,8 @@ pub struct OffloadEngine {
     g1_to_g2: Option<Pipeline<G1, G2>>,
     /// G2→G3 pipeline (BlockManager destination)
     g2_to_g3: Option<Pipeline<G2, G3>>,
+    /// G1→G3 pipeline (BlockManager destination, host-bypass mode)
+    g1_to_g3: Option<Pipeline<G1, G3>>,
     /// G2→G4 pipeline (Object storage destination) - for local mode only
     g2_to_g4: Option<ObjectPipeline<G2>>,
     /// Active transfer tracking
@@ -137,6 +143,38 @@ impl OffloadEngine {
             .ok_or_else(|| anyhow::anyhow!("G2→G3 pipeline not configured"))?;
 
         self.enqueue_to_pipeline(pipeline, blocks.into())
+    }
+
+    /// Enqueue blocks for G1→G3 direct offload (host-bypass mode).
+    ///
+    /// Used when `cache.bypass_host_cache()` is true: blocks are written
+    /// directly to disk via GDS without staging through host memory.
+    ///
+    /// Returns a `TransferHandle` for tracking progress and cancellation.
+    pub fn enqueue_g1_to_g3(&self, blocks: impl Into<SourceBlocks<G1>>) -> Result<TransferHandle> {
+        let pipeline = self
+            .g1_to_g3
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("G1→G3 pipeline not configured"))?;
+
+        self.enqueue_to_pipeline(pipeline, blocks.into())
+    }
+
+    /// Enqueue blocks for G1→G3 direct offload with a precondition event.
+    ///
+    /// Host-bypass equivalent of `enqueue_g1_to_g2_with_precondition` — used
+    /// in scheduler offload when G2 is bypassed.
+    pub fn enqueue_g1_to_g3_with_precondition(
+        &self,
+        blocks: impl Into<SourceBlocks<G1>>,
+        precondition: Option<velo::EventHandle>,
+    ) -> Result<TransferHandle> {
+        let pipeline = self
+            .g1_to_g3
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("G1→G3 pipeline not configured"))?;
+
+        self.enqueue_to_pipeline_with_precondition(pipeline, blocks.into(), precondition)
     }
 
     /// Enqueue blocks for G2→G4 offload (object storage).
@@ -244,6 +282,11 @@ impl OffloadEngine {
         self.g2_to_g3.is_some()
     }
 
+    /// Check if G1→G3 pipeline is configured (host-bypass mode).
+    pub fn has_g1_to_g3(&self) -> bool {
+        self.g1_to_g3.is_some()
+    }
+
     /// Check if G2→G4 pipeline is configured.
     pub fn has_g2_to_g4(&self) -> bool {
         self.g2_to_g4.is_some()
@@ -263,6 +306,7 @@ pub struct OffloadEngineBuilder {
     g2_physical_layout: Option<PhysicalLayout>,
     g1_to_g2_config: Option<PipelineConfig<G1, G2>>,
     g2_to_g3_config: Option<PipelineConfig<G2, G3>>,
+    g1_to_g3_config: Option<PipelineConfig<G1, G3>>,
     /// G2→G4 uses ObjectPipelineConfig (no destination BlockManager)
     g2_to_g4_config: Option<ObjectPipelineConfig<G2>>,
     /// Optional runtime handle override (defaults to leader.runtime())
@@ -284,6 +328,7 @@ impl OffloadEngineBuilder {
             g2_physical_layout: None,
             g1_to_g2_config: None,
             g2_to_g3_config: None,
+            g1_to_g3_config: None,
             g2_to_g4_config: None,
             runtime: None,
             enable_remote_g4: false,
@@ -353,6 +398,16 @@ impl OffloadEngineBuilder {
         self
     }
 
+    /// Configure G1→G3 pipeline (host-bypass mode).
+    ///
+    /// Use this when G2 is intentionally unconfigured. Requires a G3 manager
+    /// (`with_g3_manager`) and GDS-capable transfer capabilities at the worker
+    /// side for the direct path to fire.
+    pub fn with_g1_to_g3_pipeline(mut self, config: PipelineConfig<G1, G3>) -> Self {
+        self.g1_to_g3_config = Some(config);
+        self
+    }
+
     /// Configure G2→G4 pipeline (object storage).
     ///
     /// Uses `ObjectPipelineConfig` instead of `PipelineConfig` since G4
@@ -416,6 +471,7 @@ impl OffloadEngineBuilder {
         let g2_to_g3 = if let Some(config) = self.g2_to_g3_config {
             let g3_manager = self
                 .g3_manager
+                .clone()
                 .ok_or_else(|| anyhow::anyhow!("G3 manager required for G2→G3 pipeline"))?;
 
             Some(Pipeline::new(
@@ -424,6 +480,27 @@ impl OffloadEngineBuilder {
                 g3_manager,
                 self.leader.clone(),
                 LogicalLayoutHandle::G2,
+                LogicalLayoutHandle::G3,
+                runtime.clone(),
+            ))
+        } else {
+            None
+        };
+
+        // Build G1→G3 pipeline (host-bypass) if configured.
+        // Standalone — no chain-router needed since G3 is the terminal tier.
+        let g1_to_g3 = if let Some(config) = self.g1_to_g3_config {
+            let g3_manager = self
+                .g3_manager
+                .clone()
+                .ok_or_else(|| anyhow::anyhow!("G3 manager required for G1→G3 pipeline"))?;
+
+            Some(Pipeline::new(
+                config,
+                registry.clone(),
+                g3_manager,
+                self.leader.clone(),
+                LogicalLayoutHandle::G1,
                 LogicalLayoutHandle::G3,
                 runtime.clone(),
             ))
@@ -514,6 +591,7 @@ impl OffloadEngineBuilder {
             registry,
             g1_to_g2,
             g2_to_g3,
+            g1_to_g3,
             g2_to_g4,
             transfers: Arc::new(DashMap::new()),
             _chain_router_handle: chain_router_handle,


### PR DESCRIPTION
### Summary                                                                                               
   
  Adds a host-bypass path to KVBM v2 so KV blocks can move directly between GPU (G1) and disk (G3) via     
  GPUDirect Storage, skipping the G2 (host pinned-memory) staging tier. This mirrors v1's
  `should_bypass_cpu_cache()` behavior: setting only `DYN_KVBM_DISK_CACHE_GB` (without                     
  `DYN_KVBM_CPU_CACHE_GB`) now enables direct G1↔G3 paths instead of erroring on a missing host tier.

  ### What changes

  - **Config (`kvbm-config`)**: new `CacheConfig::bypass_host_cache()` returning `true` when disk is sized 
  but host isn't. Auto-enables NIXL UCX backend (for cross-process metadata exchange) and forces `GDS_MT`
  for disk in this mode.                                                                                   
  - **Connector worker init (`worker/init/pending.rs`)**: skips G2 layout allocation in bypass mode;
  allocates G3 directly for GDS-registered I/O.                                                            
  - **Connector leader init (`leader/init.rs`)**: builds the `OffloadEngine` with a single `G1→G3` pipeline
   (no `G1→G2` / `G2→G3` wiring) when bypass is on. The `InstanceLeader` API still requires a              
  `BlockManager<G2>`, so we build it as a logical-only sentinel (`block_count=1`, no physical memory) — the
   placeholder never sees registered blocks because no traffic routes through G2.                          
  - **Onboarding (`leader/onboard.rs`, `leader/scheduler.rs`, `leader/search.rs`)**: routes disk hits as
  direct G3→G1 inter-pass onboards instead of G3→G2→G1 staging.                                            
  - **Engine offload (`offload/engine.rs`, `leader/instance.rs`, `leader/types.rs`)**: adds the `G1→G3`
  pipeline path and the `bypass_host` plumbing on `InstanceLeaderBuilder`.                                 
  - **Docs**: `docs/components/kvbm/kvbm-v2-guide.md` updated with the host-bypass section and example
  launch command. 
  
 
<img width="3432" height="1317" alt="Screenshot 2026-04-30 at 10 36 01 AM" src="https://github.com/user-attachments/assets/8034e011-47bf-49da-ac88-79a2f5b8c5b3" />

closes [KVBM-409](https://linear.app/nvidia/issue/KVBM-409/enable-kvbm-v2-support-g1-g3-bypass-g2-path)
