### PR TITLE
fix(sglang): activate ReasonerGrammarBackend for thinking-on guided decoding

### DIFF
--- a/components/src/dynamo/frontend/sglang_processor.py
+++ b/components/src/dynamo/frontend/sglang_processor.py
@@ -158,6 +158,7 @@ def _preprocess_worker(
         eos_token_id,
         pre.guided_decoding,
         pre.tool_call_parser,
+        require_reasoning=pre.force_reasoning,
     )
 
     effective_reasoning_parser_name = (
@@ -180,6 +181,7 @@ def _build_dynamo_preproc(
     eos_token_id: int | None,
     guided_decoding: dict[str, Any] | None = None,
     tool_call_parser: ToolCallParserType | None = None,
+    require_reasoning: bool = False,
 ) -> dict[str, Any]:
     """Build the Dynamo preprocessed request dict from request fields."""
     max_tokens = request.get("max_completion_tokens") or request.get("max_tokens")
@@ -249,6 +251,11 @@ def _build_dynamo_preproc(
     mm_data = extract_mm_urls(request.get("messages", []))
     if mm_data:
         preproc["multi_modal_data"] = mm_data
+
+    if require_reasoning:
+        extra_args = dict(preproc.get("extra_args") or {})
+        extra_args["require_reasoning"] = True
+        preproc["extra_args"] = extra_args
 
     return preproc
 
@@ -368,6 +375,7 @@ class SglangProcessor:
                 self.eos_token_id,
                 pre.guided_decoding,
                 pre.tool_call_parser,
+                require_reasoning=pre.force_reasoning,
             )
         except InvalidArgument:
             raise

--- a/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
@@ -112,6 +112,18 @@ class TestBuildDynamoPreproc:  # FRONTEND.7 — worker subprocess preproc constr
         )
         assert result["sampling_options"]["top_k"] == 50
 
+    def test_require_reasoning_forwards_backend_extra_args(self):
+        """Reasoning-gated guided decoding must reach the SGLang backend."""
+        result = _build_dynamo_preproc(
+            {"model": "test"},
+            prompt_token_ids=[1],
+            model_name="test",
+            eos_token_id=None,
+            require_reasoning=True,
+        )
+        assert result["extra_args"]["require_reasoning"] is True
+        assert "prompt_injected_reasoning" not in result["extra_args"]
+
     def test_sampling_options_from_request(self):
         """All sampling fields are projected from request."""
         request = {

--- a/components/src/dynamo/sglang/args.py
+++ b/components/src/dynamo/sglang/args.py
@@ -30,6 +30,24 @@ from dynamo.sglang.backend_args import DynamoSGLangArgGroup, DynamoSGLangConfig
 configure_dynamo_logging()
 
 
+_DYN_TO_SGLANG_REASONING_PARSER = {
+    "deepseek_r1": "deepseek-r1",
+    "deepseek_v3": "deepseek-v3",
+    "deepseek_v3_1": "deepseek-v3",
+    "deepseek_v3_2": "deepseek-v3",
+    "deepseek_v4": "deepseek-v4",
+    "deepseekv4": "deepseek-v4",
+    "gemma-4": "gemma4",
+    "gpt_oss": "gpt-oss",
+    "kimi_k25": "kimi_k2",
+    "minimax_append_think": "minimax-append-think",
+    "nemotron_nano": "nemotron_3",
+    "nemotron3": "nemotron_3",
+    "nemotron_v3": "nemotron_3",
+    "nemotron_deci": "glm45",
+}
+
+
 class DynamoConfig(DynamoRuntimeConfig, DynamoSGLangConfig):
     """Combined configuration container for SGLang server and Dynamo args."""
 
@@ -79,10 +97,42 @@ def _preprocess_for_encode_config(
 def _validate_parser_flags(
     sglang_val: Optional[str], dynamo_val: Optional[str], name: str
 ) -> None:
-    """Validate that --{name} (SGLang) and --dyn-{name} (Dynamo) are not both set."""
+    """Validate parser flag combinations."""
+    if name == "reasoning-parser" and sglang_val and dynamo_val:
+        expected_sglang_val = _DYN_TO_SGLANG_REASONING_PARSER.get(
+            dynamo_val, dynamo_val
+        )
+        if sglang_val != expected_sglang_val:
+            logging.error(
+                "Cannot use different --reasoning-parser (%s) and "
+                "--dyn-reasoning-parser (%s) values. Expected SGLang parser "
+                "%s for Dynamo parser %s.",
+                sglang_val,
+                dynamo_val,
+                expected_sglang_val,
+                dynamo_val,
+            )
+            sys.exit(1)
+        return
     if sglang_val and dynamo_val:
         logging.error(f"Cannot use both --{name} and --dyn-{name}.")
         sys.exit(1)
+
+
+def _mirror_dyn_reasoning_parser_to_sglang(
+    parsed_args: argparse.Namespace, dynamo_config: DynamoSGLangConfig
+) -> None:
+    """Use Dynamo's reasoning parser to activate SGLang's reasoner gate."""
+    dyn_parser = dynamo_config.dyn_reasoning_parser
+    if dyn_parser and not getattr(parsed_args, "reasoning_parser", None):
+        sglang_parser = _DYN_TO_SGLANG_REASONING_PARSER.get(dyn_parser, dyn_parser)
+        parsed_args.reasoning_parser = sglang_parser
+        logging.info(
+            "Mirroring --dyn-reasoning-parser=%s to SGLang --reasoning-parser=%s "
+            "so guided decoding is gated until the reasoning end token.",
+            dyn_parser,
+            sglang_parser,
+        )
 
 
 def _has_cli_flag(args: list[str], flag: str) -> bool:
@@ -295,6 +345,7 @@ async def parse_args(args: list[str]) -> Config:
         dynamo_config.dyn_reasoning_parser,
         "reasoning-parser",
     )
+    _mirror_dyn_reasoning_parser_to_sglang(parsed_args, dynamo_config)
 
     if dynamo_config.custom_jinja_template and dynamo_config.use_sglang_tokenizer:
         logging.error(

--- a/components/src/dynamo/sglang/llm_engine.py
+++ b/components/src/dynamo/sglang/llm_engine.py
@@ -59,6 +59,10 @@ from dynamo.sglang.capacity import (
     runtime_capacity,
 )
 from dynamo.sglang.publisher import format_zmq_endpoint
+from dynamo.sglang.reasoning import (
+    install_require_reasoning_proxy,
+    require_reasoning_context,
+)
 
 if TYPE_CHECKING:
     from dynamo._core.backend import EngineMetrics  # type: ignore[import-not-found]
@@ -149,6 +153,7 @@ class SglangLLMEngine(LLMEngine):
         del worker_id  # SGLang bootstrap uses host/port/room triples
 
         self.engine = sgl.Engine(server_args=self.server_args)
+        install_require_reasoning_proxy(self.engine)
 
         tokenizer = (
             self.engine.tokenizer_manager.tokenizer
@@ -289,19 +294,22 @@ class SglangLLMEngine(LLMEngine):
             "SGLang",
         )
 
-        stream = await self.engine.async_generate(
-            **input_param,
-            sampling_params=sampling_params,
-            stream=True,
-            rid=context.trace_id,
-            data_parallel_rank=sgl_dp_rank,
-            **telemetry.engine_trace_kwargs(
-                context,
-                kwarg_name="external_trace_header",
-                enabled=self.enable_trace,
-            ),
-            **bootstrap_kwargs,
-        )
+        with require_reasoning_context(
+            self._has_reasoning_parser(), dict(request), input_param
+        ):
+            stream = await self.engine.async_generate(
+                **input_param,
+                sampling_params=sampling_params,
+                stream=True,
+                rid=context.trace_id,
+                data_parallel_rank=sgl_dp_rank,
+                **telemetry.engine_trace_kwargs(
+                    context,
+                    kwarg_name="external_trace_header",
+                    enabled=self.enable_trace,
+                ),
+                **bootstrap_kwargs,
+            )
 
         # ORDER MATTERS: async_generate must register the room (the await
         # above) before we yield the bootstrap chunk — otherwise the
@@ -719,3 +727,9 @@ class SglangLLMEngine(LLMEngine):
         return {
             "prompt" if isinstance(request_input, str) else "input_ids": request_input
         }
+
+    def _has_reasoning_parser(self) -> bool:
+        return bool(
+            getattr(self.server_args, "reasoning_parser", None)
+            or getattr(self.dynamo_args, "dyn_reasoning_parser", None)
+        )

--- a/components/src/dynamo/sglang/reasoning.py
+++ b/components/src/dynamo/sglang/reasoning.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import contextvars
+import functools
+import threading
+from contextlib import contextmanager
+from typing import Any, Dict
+
+_DYN_REQUIRE_REASONING_CV: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "dynamo_sglang_require_reasoning", default=False
+)
+_REQUIRE_REASONING_PROXY_LOCK = threading.Lock()
+
+
+def install_require_reasoning_proxy(engine: Any) -> None:
+    """Set SGLang GenerateReqInput.require_reasoning from a per-request context."""
+    tm = getattr(engine, "tokenizer_manager", None)
+    if tm is None or getattr(tm, "_dynamo_require_reasoning_wrapped", False):
+        return
+
+    with _REQUIRE_REASONING_PROXY_LOCK:
+        if getattr(tm, "_dynamo_require_reasoning_wrapped", False):
+            return
+
+        original = tm.generate_request
+
+        @functools.wraps(original)
+        def _wrapped(obj, request):
+            if _DYN_REQUIRE_REASONING_CV.get():
+                obj.require_reasoning = True
+            return original(obj, request)
+
+        tm._dynamo_require_reasoning_wrapped = True  # type: ignore[attr-defined]
+        tm.generate_request = _wrapped  # type: ignore[assignment]
+
+
+def request_requires_reasoning(
+    has_reasoning_parser: bool, request: Dict[str, Any], input_param: Dict[str, Any]
+) -> bool:
+    if not has_reasoning_parser:
+        return False
+
+    extra_args = request.get("extra_args") or {}
+    if isinstance(extra_args, dict) and (
+        extra_args.get("require_reasoning")
+        or extra_args.get("prompt_injected_reasoning")
+    ):
+        return True
+
+    prompt = input_param.get("prompt")
+    return isinstance(prompt, str) and prompt.rstrip().endswith("<think>")
+
+
+@contextmanager
+def require_reasoning_context(
+    has_reasoning_parser: bool, request: Dict[str, Any], input_param: Dict[str, Any]
+):
+    token = _DYN_REQUIRE_REASONING_CV.set(
+        request_requires_reasoning(has_reasoning_parser, request, input_param)
+    )
+    try:
+        yield
+    finally:
+        _DYN_REQUIRE_REASONING_CV.reset(token)

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -44,6 +44,10 @@ from dynamo.llm.exceptions import EngineShutdown
 from dynamo.runtime import DistributedRuntime
 from dynamo.sglang.args import Config
 from dynamo.sglang.publisher import DynamoSglangPublisher
+from dynamo.sglang.reasoning import (
+    install_require_reasoning_proxy,
+    require_reasoning_context,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -720,6 +724,7 @@ class BaseWorkerHandler(LoraMixin, RLMixin, BaseGenerativeHandler[RequestT, Resp
         self.enable_trace = getattr(config.server_args, "enable_trace", False)
 
         if engine is not None:
+            install_require_reasoning_proxy(engine)
             self.input_param_manager = InputParamManager(
                 self.engine.tokenizer_manager.tokenizer
                 if self.use_sglang_tokenizer
@@ -1058,6 +1063,19 @@ class BaseWorkerHandler(LoraMixin, RLMixin, BaseGenerativeHandler[RequestT, Resp
         return {
             "prompt" if isinstance(request_input, str) else "input_ids": request_input
         }
+
+    def _has_reasoning_parser(self) -> bool:
+        return bool(
+            getattr(self.config.server_args, "reasoning_parser", None)
+            or getattr(self.config.dynamo_args, "dyn_reasoning_parser", None)
+        )
+
+    def _require_reasoning_context(
+        self, request: Dict[str, Any], input_param: Dict[str, Any]
+    ):
+        return require_reasoning_context(
+            self._has_reasoning_parser(), request, input_param
+        )
 
     def _session_kwargs(self, request: Dict[str, Any]) -> Dict[str, Any]:
         if not getattr(self.config.server_args, "enable_streaming_session", False):

--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -466,22 +466,23 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             routing = request.get("routing") or {}
             dp_rank = routing.get("dp_rank")
 
-            decode = await self.engine.async_generate(
-                **input_param,
-                sampling_params=sampling_params,
-                stream=True,
-                **self._routed_experts_kwargs,
-                bootstrap_host=bootstrap_info["bootstrap_host"],
-                bootstrap_port=bootstrap_info["bootstrap_port"],
-                bootstrap_room=bootstrap_info["bootstrap_room"],
-                external_trace_header=trace_header,
-                rid=trace_id,
-                data_parallel_rank=dp_rank,
-                **self._session_kwargs(request),
-                lora_path=lora_path,
-                **logprob_kwargs,
-                **self._priority_kwargs(priority),
-            )
+            with self._require_reasoning_context(request, input_param):
+                decode = await self.engine.async_generate(
+                    **input_param,
+                    sampling_params=sampling_params,
+                    stream=True,
+                    **self._routed_experts_kwargs,
+                    bootstrap_host=bootstrap_info["bootstrap_host"],
+                    bootstrap_port=bootstrap_info["bootstrap_port"],
+                    bootstrap_room=bootstrap_info["bootstrap_room"],
+                    external_trace_header=trace_header,
+                    rid=trace_id,
+                    data_parallel_rank=dp_rank,
+                    **self._session_kwargs(request),
+                    lora_path=lora_path,
+                    **logprob_kwargs,
+                    **self._priority_kwargs(priority),
+                )
 
             if not self.use_sglang_tokenizer:
                 async for out in self._process_token_stream(
@@ -525,21 +526,22 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             routing = request.get("routing") or {}
             dp_rank = routing.get("dp_rank")
 
-            agg = await self.engine.async_generate(
-                **input_param,
-                image_data=image_data,
-                video_data=video_data,
-                sampling_params=sampling_params,
-                stream=True,
-                **self._routed_experts_kwargs,
-                external_trace_header=trace_header,
-                rid=trace_id,
-                data_parallel_rank=dp_rank,
-                **self._session_kwargs(request),
-                lora_path=lora_path,
-                **logprob_kwargs,
-                **self._priority_kwargs(priority),
-            )
+            with self._require_reasoning_context(request, input_param):
+                agg = await self.engine.async_generate(
+                    **input_param,
+                    image_data=image_data,
+                    video_data=video_data,
+                    sampling_params=sampling_params,
+                    stream=True,
+                    **self._routed_experts_kwargs,
+                    external_trace_header=trace_header,
+                    rid=trace_id,
+                    data_parallel_rank=dp_rank,
+                    **self._session_kwargs(request),
+                    lora_path=lora_path,
+                    **logprob_kwargs,
+                    **self._priority_kwargs(priority),
+                )
             if not self.use_sglang_tokenizer:
                 async for out in self._process_token_stream(
                     agg,

--- a/components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py
@@ -145,20 +145,21 @@ class PrefillWorkerHandler(BaseWorkerHandler):
                 f"Prefill request {context.id()} will use LoRA adapter: {lora_path}"
             )
 
-        results = await self.engine.async_generate(
-            **input_param,
-            sampling_params=sampling_params,
-            stream=True,
-            bootstrap_host=bootstrap_host,
-            bootstrap_port=bootstrap_port,
-            bootstrap_room=bootstrap_room,
-            external_trace_header=trace_header,
-            rid=trace_id,
-            data_parallel_rank=dp_rank,
-            **self._session_kwargs(inner_request),
-            lora_path=lora_path,
-            **self._priority_kwargs(priority),
-        )
+        with self._require_reasoning_context(inner_request, input_param):
+            results = await self.engine.async_generate(
+                **input_param,
+                sampling_params=sampling_params,
+                stream=True,
+                bootstrap_host=bootstrap_host,
+                bootstrap_port=bootstrap_port,
+                bootstrap_room=bootstrap_room,
+                external_trace_header=trace_header,
+                rid=trace_id,
+                data_parallel_rank=dp_rank,
+                **self._session_kwargs(inner_request),
+                lora_path=lora_path,
+                **self._priority_kwargs(priority),
+            )
 
         if inner_request.get(HEALTH_CHECK_KEY):
             # Canary: stream engine output so the Rust canary sees scheduler output.

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -7,6 +7,11 @@ from types import SimpleNamespace
 
 import pytest
 
+from dynamo.sglang.reasoning import (
+    _DYN_REQUIRE_REASONING_CV,
+    install_require_reasoning_proxy,
+    request_requires_reasoning,
+)
 from dynamo.sglang.request_handlers.llm.decode_handler import (
     DecodeWorkerHandler,
     _extract_media_urls,
@@ -119,6 +124,93 @@ def test_openai_stop_sampling_params_maps_token_id_stop_array():
     assert _openai_stop_sampling_params({"stop_token_ids": [32, 34]}) == {
         "stop_token_ids": [32, 34]
     }
+
+
+def test_validate_parser_flags_allows_matching_reasoning_parsers():
+    from dynamo.sglang.args import _validate_parser_flags
+
+    _validate_parser_flags("qwen3", "qwen3", "reasoning-parser")
+    _validate_parser_flags("kimi_k2", "kimi_k25", "reasoning-parser")
+
+
+def test_validate_parser_flags_rejects_mismatched_reasoning_parsers():
+    from dynamo.sglang.args import _validate_parser_flags
+
+    with pytest.raises(SystemExit):
+        _validate_parser_flags("qwen3", "glm45", "reasoning-parser")
+
+
+def test_mirror_dyn_reasoning_parser_to_sglang():
+    from dynamo.sglang.args import _mirror_dyn_reasoning_parser_to_sglang
+
+    parsed_args = SimpleNamespace(reasoning_parser=None)
+    dynamo_config = SimpleNamespace(dyn_reasoning_parser="qwen3")
+
+    _mirror_dyn_reasoning_parser_to_sglang(parsed_args, dynamo_config)
+
+    assert parsed_args.reasoning_parser == "qwen3"
+
+
+def test_mirror_dyn_reasoning_parser_to_sglang_translates_alias():
+    from dynamo.sglang.args import _mirror_dyn_reasoning_parser_to_sglang
+
+    parsed_args = SimpleNamespace(reasoning_parser=None)
+    dynamo_config = SimpleNamespace(dyn_reasoning_parser="nemotron_deci")
+
+    _mirror_dyn_reasoning_parser_to_sglang(parsed_args, dynamo_config)
+
+    assert parsed_args.reasoning_parser == "glm45"
+
+
+def test_request_requires_reasoning_from_frontend_extra_args():
+    assert request_requires_reasoning(
+        True,
+        {"extra_args": {"prompt_injected_reasoning": True}},
+        {"input_ids": [1, 2, 3]},
+    )
+    assert request_requires_reasoning(
+        True,
+        {"extra_args": {"require_reasoning": True}},
+        {"input_ids": [1, 2, 3]},
+    )
+    assert not request_requires_reasoning(
+        False,
+        {"extra_args": {"prompt_injected_reasoning": True}},
+        {"prompt": "<think>"},
+    )
+
+
+def test_request_requires_reasoning_prompt_fallback():
+    assert request_requires_reasoning(True, {}, {"prompt": "hello\n<think>"})
+    assert not request_requires_reasoning(True, {}, {"prompt": "hello\n</think>"})
+
+
+class _GenerateReqInputStub:
+    require_reasoning = False
+
+
+class _TokenizerManagerStub:
+    def __init__(self):
+        self.last_obj = None
+
+    def generate_request(self, obj, request):
+        self.last_obj = obj
+        return object()
+
+
+def test_require_reasoning_proxy_sets_sglang_request_flag():
+    tm = _TokenizerManagerStub()
+    engine = SimpleNamespace(tokenizer_manager=tm)
+    install_require_reasoning_proxy(engine)
+
+    token = _DYN_REQUIRE_REASONING_CV.set(True)
+    try:
+        obj = _GenerateReqInputStub()
+        tm.generate_request(obj, object())
+    finally:
+        _DYN_REQUIRE_REASONING_CV.reset(token)
+
+    assert obj.require_reasoning is True
 
 
 def _new_decode_handler(*, use_sglang_tokenizer: bool = False):

--- a/components/src/dynamo/sglang/tests/test_sglang_trace_propagation.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_trace_propagation.py
@@ -59,6 +59,8 @@ def _make_engine(async_generate, enable_trace: bool) -> SglangLLMEngine:
     engine.engine = SimpleNamespace(async_generate=async_generate)
     engine.serving_mode = DisaggregationMode.AGGREGATED
     engine.enable_trace = enable_trace
+    engine.server_args = SimpleNamespace(reasoning_parser=None)
+    engine.dynamo_args = SimpleNamespace(dyn_reasoning_parser=None)
     # Single-rank defaults: validate_global_dp_rank(None, 0, 1, ...) -> None.
     engine._dp_start = 0
     engine._dp_size = 1
@@ -68,8 +70,10 @@ def _make_engine(async_generate, enable_trace: bool) -> SglangLLMEngine:
     return engine
 
 
-async def _drain(engine: SglangLLMEngine, ctx: _FakeContext) -> None:
-    async for _ in engine.generate({"token_ids": [1, 2, 3]}, ctx):
+async def _drain(
+    engine: SglangLLMEngine, ctx: _FakeContext, request: dict | None = None
+) -> None:
+    async for _ in engine.generate(request or {"token_ids": [1, 2, 3]}, ctx):
         pass
 
 
@@ -108,3 +112,28 @@ async def test_gates_off_when_enable_trace_false():
 
     # kwarg omitted (engine_trace_kwargs returns {} when enabled=False).
     assert "external_trace_header" not in captured
+
+
+async def test_sets_require_reasoning_context_from_frontend_extra_args():
+    from dynamo.sglang.reasoning import _DYN_REQUIRE_REASONING_CV
+
+    observed: list[bool] = []
+
+    async def fake_async_generate(**kwargs):
+        observed.append(_DYN_REQUIRE_REASONING_CV.get())
+        return _empty_async_iter()
+
+    engine = _make_engine(fake_async_generate, enable_trace=False)
+    engine.server_args = SimpleNamespace(reasoning_parser="qwen3")
+
+    await _drain(
+        engine,
+        _FakeContext(),
+        {
+            "token_ids": [1, 2, 3],
+            "extra_args": {"prompt_injected_reasoning": True},
+        },
+    )
+
+    assert observed == [True]
+    assert _DYN_REQUIRE_REASONING_CV.get() is False

--- a/lib/llm/PREPROCESSOR_CASES.md
+++ b/lib/llm/PREPROCESSOR_CASES.md
@@ -46,7 +46,9 @@ gpt-oss before the harmony/gpt_oss whitelist landed.
 Some parsers should be turned **off** based on `chat_template_args` in
 the request. The exact arg name and value varies per family:
 
-- `kimi_k25` — `thinking: false`
+- `kimi_k2` / `kimi_k25` — `thinking: false`
+- `qwen3` / `glm45` / `nemotron_deci` / `nemotron_3` / `interns1` —
+  `enable_thinking: false`
 - `nemotron_nano` / `nemotron3` / `nemotron_v3` —
   `enable_thinking: false` OR `force_nonempty_content: true`
 - `deepseek_r1` / `deepseek_v4` — `thinking: false` OR

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -2280,7 +2280,10 @@ impl OpenAIPreprocessor {
     }
 
     /// Check if reasoning parsing should be disabled based on per-request parameters.
-    /// For kimi_k25: disabled when chat_template_args contains "thinking": false.
+    /// For kimi_k2 / kimi_k25: disabled when chat_template_args contains
+    ///   "thinking": false.
+    /// For qwen3 / glm45 / nemotron_deci / nemotron_3 / interns1:
+    ///   disabled when chat_template_args contains "enable_thinking": false.
     /// For Nemotron force-reasoning aliases: disabled when chat_template_args
     ///   contains "enable_thinking": false or "force_nonempty_content": true.
     /// For deepseek_r1 / deepseek_v4: disabled when chat_template_args contains
@@ -2301,6 +2304,27 @@ impl OpenAIPreprocessor {
                     && let Some(thinking) = args.get("thinking")
                 {
                     return thinking == &serde_json::Value::Bool(false);
+                }
+                false
+            }
+            Some("kimi_k2") => {
+                if let Some(args) = chat_template_args
+                    && let Some(thinking) = args.get("thinking").and_then(|v| v.as_bool())
+                {
+                    return !thinking;
+                }
+                false
+            }
+            Some("qwen3")
+            | Some("glm45")
+            | Some("nemotron_deci")
+            | Some("nemotron_3")
+            | Some("interns1") => {
+                if let Some(args) = chat_template_args
+                    && let Some(enable_thinking) =
+                        args.get("enable_thinking").and_then(|v| v.as_bool())
+                {
+                    return !enable_thinking;
                 }
                 false
             }
@@ -2342,6 +2366,66 @@ impl OpenAIPreprocessor {
                 false
             }
             _ => false,
+        }
+    }
+
+    /// Whether SGLang's guided decoding backend should keep grammar constraints
+    /// gated until the model emits the reasoning end marker.
+    ///
+    /// This is not exactly the same as `!is_reasoning_disabled_by_request`:
+    /// some parsers are safe to run as no-op postprocessors by default, but
+    /// SGLang should only enable its reasoner gate when the request is actually
+    /// in a thinking mode.
+    fn requires_sglang_reasoning_gate(
+        reasoning_parser: Option<&str>,
+        chat_template_args: Option<&std::collections::HashMap<String, serde_json::Value>>,
+    ) -> bool {
+        match reasoning_parser {
+            None => false,
+            Some("deepseek-v3")
+            | Some("deepseek_v3")
+            | Some("deepseek_v3_1")
+            | Some("deepseek_v3_2") => {
+                if let Some(args) = chat_template_args
+                    && let Some(thinking) = args.get("thinking").and_then(|v| v.as_bool())
+                {
+                    return thinking;
+                }
+                false
+            }
+            Some("gemma4") | Some("gemma-4") => {
+                if let Some(args) = chat_template_args
+                    && let Some(enable_thinking) =
+                        args.get("enable_thinking").and_then(|v| v.as_bool())
+                {
+                    return enable_thinking;
+                }
+                false
+            }
+            Some("kimi_k2") => {
+                if let Some(args) = chat_template_args
+                    && let Some(thinking) = args.get("thinking").and_then(|v| v.as_bool())
+                {
+                    return thinking;
+                }
+                true
+            }
+            Some("qwen3")
+            | Some("glm45")
+            | Some("nemotron_deci")
+            | Some("nemotron_3")
+            | Some("interns1") => {
+                if let Some(args) = chat_template_args
+                    && let Some(enable_thinking) =
+                        args.get("enable_thinking").and_then(|v| v.as_bool())
+                {
+                    return enable_thinking;
+                }
+                true
+            }
+            Some(parser) => {
+                !Self::is_reasoning_disabled_by_request(Some(parser), chat_template_args)
+            }
         }
     }
 
@@ -2622,6 +2706,32 @@ impl
             &mut common_request,
             prompt_injected_reasoning,
         )?;
+
+        let require_reasoning = common_request.sampling_options.guided_decoding.is_some()
+            && Self::requires_sglang_reasoning_gate(
+                self.runtime_config.reasoning_parser.as_deref(),
+                request.chat_template_args.as_ref(),
+            );
+
+        if prompt_injected_reasoning || require_reasoning {
+            let extra_args = common_request
+                .extra_args
+                .get_or_insert_with(|| serde_json::json!({}));
+            if let Some(extra_args) = extra_args.as_object_mut() {
+                if prompt_injected_reasoning {
+                    extra_args.insert(
+                        "prompt_injected_reasoning".to_string(),
+                        serde_json::Value::Bool(true),
+                    );
+                }
+                if require_reasoning {
+                    extra_args.insert(
+                        "require_reasoning".to_string(),
+                        serde_json::Value::Bool(true),
+                    );
+                }
+            }
+        }
 
         tracing::trace!(request = ?common_request, prompt_injected_reasoning, "Pre-processed request");
         let trace_state = crate::agents::trace::build_agent_trace_request_end_state(
@@ -3182,6 +3292,37 @@ mod tests {
                 false,
                 "kimi_k25 + empty args → enabled",
             ),
+            (
+                Some("qwen3"),
+                Some(&enable_thinking_false),
+                true,
+                "qwen3 + enable_thinking=false → disabled",
+            ),
+            (
+                Some("qwen3"),
+                Some(&enable_thinking_true),
+                false,
+                "qwen3 + enable_thinking=true → enabled",
+            ),
+            (Some("qwen3"), None, false, "qwen3 + no args → enabled"),
+            (
+                Some("glm45"),
+                Some(&enable_thinking_false),
+                true,
+                "glm45 + enable_thinking=false → disabled",
+            ),
+            (
+                Some("nemotron_deci"),
+                Some(&enable_thinking_false),
+                true,
+                "nemotron_deci + enable_thinking=false → disabled",
+            ),
+            (
+                Some("nemotron_3"),
+                Some(&enable_thinking_false),
+                true,
+                "nemotron_3 + enable_thinking=false → disabled",
+            ),
             // deepseek_r1 uses "thinking" bool or "thinking_mode" string
             (
                 Some("deepseek_r1"),
@@ -3359,6 +3500,97 @@ mod tests {
         for (parser, args, expected, desc) in cases {
             assert_eq!(
                 OpenAIPreprocessor::is_reasoning_disabled_by_request(parser, args),
+                expected,
+                "FAILED: {desc}",
+            );
+        }
+    }
+
+    #[test]
+    fn test_requires_sglang_reasoning_gate() {
+        let thinking_true = {
+            let mut m = std::collections::HashMap::new();
+            m.insert("thinking".to_string(), serde_json::Value::Bool(true));
+            m
+        };
+        let thinking_false = {
+            let mut m = std::collections::HashMap::new();
+            m.insert("thinking".to_string(), serde_json::Value::Bool(false));
+            m
+        };
+        let enable_thinking_true = {
+            let mut m = std::collections::HashMap::new();
+            m.insert("enable_thinking".to_string(), serde_json::Value::Bool(true));
+            m
+        };
+        let enable_thinking_false = {
+            let mut m = std::collections::HashMap::new();
+            m.insert(
+                "enable_thinking".to_string(),
+                serde_json::Value::Bool(false),
+            );
+            m
+        };
+
+        let cases = [
+            (None, None, false, "no parser -> no gate"),
+            (Some("qwen3"), None, true, "qwen3 defaults to thinking"),
+            (
+                Some("qwen3"),
+                Some(&enable_thinking_false),
+                false,
+                "qwen3 + enable_thinking=false -> no gate",
+            ),
+            (
+                Some("glm45"),
+                Some(&enable_thinking_true),
+                true,
+                "glm45 + enable_thinking=true -> gate",
+            ),
+            (
+                Some("nemotron_deci"),
+                None,
+                true,
+                "nemotron_deci defaults to thinking",
+            ),
+            (
+                Some("nemotron_3"),
+                Some(&enable_thinking_false),
+                false,
+                "nemotron_3 + enable_thinking=false -> no gate",
+            ),
+            (Some("kimi_k2"), None, true, "kimi_k2 defaults to thinking"),
+            (
+                Some("kimi_k2"),
+                Some(&thinking_false),
+                false,
+                "kimi_k2 + thinking=false -> no gate",
+            ),
+            (Some("gemma4"), None, false, "gemma4 is opt-in"),
+            (
+                Some("gemma4"),
+                Some(&enable_thinking_true),
+                true,
+                "gemma4 + enable_thinking=true -> gate",
+            ),
+            (Some("deepseek-v3"), None, false, "deepseek-v3 is opt-in"),
+            (
+                Some("deepseek_v3"),
+                Some(&thinking_true),
+                true,
+                "deepseek_v3 + thinking=true -> gate",
+            ),
+            (
+                Some("basic"),
+                None,
+                true,
+                "unknown/default parser follows parser-disabled gate",
+            ),
+        ];
+
+        for (parser, args, expected, desc) in cases {
+            assert_eq!(
+                OpenAIPreprocessor::requires_sglang_reasoning_gate(parser, args),
                 expected,
                 "FAILED: {desc}",
             );


### PR DESCRIPTION
## Summary

Fix SGLang guided decoding for reasoning models served through Dynamo.

When Dynamo sends a guided-decoding request, such as `response_format=json_schema`, to SGLang with a reasoning parser enabled, SGLang needs `GenerateReqInput.require_reasoning=True`. That lets SGLang generate free-form reasoning first, then activate the JSON/schema grammar after the reasoning end token, for example `</think>`.

Dynamo bypasses SGLang's OpenAI serving layer and calls `Engine.async_generate()` directly, so this per-request bit was not reaching SGLang. For Qwen3, `enable_thinking=true` does not append a literal `<think>` to the prompt, so prompt-suffix detection alone is not enough.

## Fix

- Mirror `--dyn-reasoning-parser` into SGLang `--reasoning-parser`, translating aliases where Dynamo and SGLang names differ.
- Set backend `extra_args.require_reasoning=true` for guided-decoding requests when a reasoning parser is configured and the request has not opted out of thinking.
- Install a small SGLang adapter around `tokenizer_manager.generate_request` so Dynamo can set `GenerateReqInput.require_reasoning` before SGLang initializes the guided backend.
- Cover both the unified `SglangLLMEngine.generate()` path and existing prefill/decode handler paths.

## Reproducer

Test environment:

```text
Model: Qwen/Qwen3-0.6B
SGLang: 0.5.10.post1
Dynamo frontend: default dynamo.frontend path
Worker: dynamo.sglang.unified_main
```

Container launch shape:

```bash
docker run -d \
  --network host \
  --ipc host \
  --gpus device=0 \
  --ulimit memlock=-1 \
  --ulimit stack=67108864 \
  -e HF_HOME=/hf-cache \
  -e DYN_SYSTEM_PORT=18001 \
  <dynamo-sglang-runtime-image> \
  bash -lc '
python3 -m dynamo.frontend \
  --http-port 18000 \
  --discovery-backend file \
  --request-plane tcp \
  --event-plane zmq &

python3 -m dynamo.sglang.unified_main \
  --model-path Qwen/Qwen3-0.6B \
  --served-model-name Qwen/Qwen3-0.6B \
  --tp 1 \
  --trust-remote-code \
  --grammar-backend xgrammar \
  --dyn-reasoning-parser qwen3 \
  --skip-server-warmup \
  --discovery-backend file \
  --request-plane tcp \
  --event-plane zmq
'
```

Request:

```json
{
  "model": "Qwen/Qwen3-0.6B",
  "messages": [
    {
      "role": "user",
      "content": "Think for one short sentence. Then close the thinking block and answer only with a JSON object. What is the capital of France?"
    }
  ],
  "temperature": 0,
  "max_tokens": 512,
  "chat_template_args": {
    "enable_thinking": true
  },
  "response_format": {
    "type": "json_schema",
    "json_schema": {
      "name": "capital_answer",
      "schema": {
        "type": "object",
        "properties": {
          "answer": { "type": "string" }
        },
        "required": ["answer"],
        "additionalProperties": false
      },
      "strict": true
    }
  }
}
```

Send the request:

```bash
curl -fsS \
  -H 'Content-Type: application/json' \
  -d @request.json \
  http://127.0.0.1:18000/v1/chat/completions
```

## Validation

Using the launch shape above with the same model and request:

Before fix:

```json
{
  "content": "{\"answer\": \"Paris\"}",
  "reasoning_content": null,
  "finish_reason": "stop"
}
```

After fix:

```json
{
  "content": "{ \"answer\": \"Paris\" }",
  "reasoning_content": "\nOkay, the user is asking for the capital of France. Let me think. France's capital is Paris. I need to make sure that's correct. I remember that Paris is the main city in France, and it's the largest city in the country. So the answer should be Paris. Now, I need to put this into a JSON object. The key should be \"capital\" and the value is \"Paris\". I need to close the thinking block and just return the JSON. Let me double-check to avoid any mistakes. Yep, that's right. The capital of France is Paris.\n",
  "finish_reason": "stop"
}
```

The baseline produced schema-valid JSON but no separated reasoning. The fixed branch produced schema-valid final content and non-empty `reasoning_content`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-request reasoning control, allowing dynamic enable/disable of model reasoning on a per-request basis.
  * Extended reasoning parser support for additional models: Qwen3, GLM-4.5, Nemotron Deci, Nemotron 3, and Interns 1.
  * Implemented automatic reasoning context detection based on request parameters and prompt patterns.

* **Documentation**
  * Updated preprocessor documentation to reflect expanded reasoning-parser support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/8940?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->