### PR TITLE
test(revalidate): docs(observability): document component metric labels, names, endpoints, and error types #8834

### DIFF
--- a/components/src/dynamo/common/__init__.py
+++ b/components/src/dynamo/common/__init__.py
@@ -25,3 +25,5 @@ except Exception:
         __version__ = "0.0.0+unknown"
 
 __all__ = ["__version__", "config_dump", "constants", "utils"]
+
+# revalidate 48c6f361a55 2026-04-30T21:49:07Z

--- a/lib/runtime/src/runtime.rs
+++ b/lib/runtime/src/runtime.rs
@@ -391,3 +391,5 @@ impl Drop for RuntimeType {
         }
     }
 }
+
+// revalidate 48c6f361a55 2026-04-30T21:49:07Z


### PR DESCRIPTION
Re-validating that PR #8834 by Dr. Stefan Schimanski did not regress, by re-running against a trivial placebo diff:

```
docs(observability): document component metric labels, names, endpoints, and error types
```

Branch deleted on green; kept on failure for diagnosis.

Drafts are skipped by CodeRabbit per repo `.coderabbit.yaml`.