### PR TITLE
fix(recipes): pin transformers in deepseek-v32-fp4 perf jobs (cherry-pick #8690)

### DIFF
--- a/recipes/deepseek-v32-fp4/trtllm/agg-round-robin/perf.yaml
+++ b/recipes/deepseek-v32-fp4/trtllm/agg-round-robin/perf.yaml
@@ -49,7 +49,13 @@ spec:
           echo 1024 > /proc/sys/fs/inotify/max_user_instances 2>/dev/null || true
           apt-get update && apt-get install -y curl jq procps git && apt-get clean
           # pip install git+https://github.com/ai-dynamo/aiperf.git
-          pip install aiperf==0.7.0
+          # Pin transformers==4.57.6 (verified to load the deepseek_v32 tokenizer).
+          # The trtllm-runtime base ships transformers 4.55.0; aiperf's
+          # `transformers>=4.56.0` floor would otherwise upgrade to 5.x, which lacks
+          # native support for model_type=deepseek_v32 (huggingface/transformers#41251)
+          # and fails AutoTokenizer.from_pretrained() before reading tokenizer.json.
+          # aiperf surfaces this as "Failed to load tokenizer". DYN-2878.
+          pip install "aiperf==0.7.0" "transformers==4.57.6"
           echo "aiperf installation completed"
           sysctl -w net.ipv4.ip_local_port_range="1024 65000" 2>/dev/null || true
           export COLUMNS=200

--- a/recipes/deepseek-v32-fp4/trtllm/disagg-kv-router/perf.yaml
+++ b/recipes/deepseek-v32-fp4/trtllm/disagg-kv-router/perf.yaml
@@ -49,7 +49,13 @@ spec:
           echo 1024 > /proc/sys/fs/inotify/max_user_instances 2>/dev/null || true
           apt-get update && apt-get install -y curl jq procps git && apt-get clean
           # pip install git+https://github.com/ai-dynamo/aiperf.git
-          pip install aiperf==0.7.0
+          # Pin transformers==4.57.6 (verified to load the deepseek_v32 tokenizer).
+          # The trtllm-runtime base ships transformers 4.55.0; aiperf's
+          # `transformers>=4.56.0` floor would otherwise upgrade to 5.x, which lacks
+          # native support for model_type=deepseek_v32 (huggingface/transformers#41251)
+          # and fails AutoTokenizer.from_pretrained() before reading tokenizer.json.
+          # aiperf surfaces this as "Failed to load tokenizer". DYN-2878.
+          pip install "aiperf==0.7.0" "transformers==4.57.6"
           echo "aiperf installation completed"
           sysctl -w net.ipv4.ip_local_port_range="1024 65000" 2>/dev/null || true
           export COLUMNS=200


### PR DESCRIPTION
## Summary

Cherry-pick of #8690 to `release/1.1.0`. Pins `transformers==4.57.6` in the deepseek-v32-fp4 perf recipes so the `aiperf` install step does not silently upgrade transformers to 5.x, which lacks `model_type=deepseek_v32` support and breaks tokenizer load.

Fixes DYN-2878
Fixes https://nvbugs/6109655

## Conflict resolution

`release/1.1.0` already shipped `aiperf==0.7.0` (vs. main's `0.6.0`), so the cherry-pick conflicted on the install line in both `agg-round-robin/perf.yaml` and `disagg-kv-router/perf.yaml`. Resolved by keeping `aiperf==0.7.0` from the release branch and adding the `transformers==4.57.6` pin from the upstream fix. Final line in both files:

```
pip install "aiperf==0.7.0" "transformers==4.57.6"
```

The transformers pin is the actual fix; aiperf version is unchanged from what release/1.1.0 already had.

## Original PR

- Main PR: #8690
- Merge commit: `11077f26f787e8dc8c2ea409caf31a792fb24d1e`

## Test plan

- [ ] CI passes
- [ ] QA re-runs `recipes/deepseek-v32-fp4/trtllm/disagg-kv-router/perf.yaml` and `agg-round-robin/perf.yaml` against the rc9 build and confirms perf job exits 0

Made with [Cursor](https://cursor.com)