### PR TITLE
fix(recipes): use --enforce-disagg for GLM-5 frontend args

### DIFF
--- a/recipes/glm-5-nvfp4/sglang/disagg/deploy.yaml
+++ b/recipes/glm-5-nvfp4/sglang/disagg/deploy.yaml
@@ -39,7 +39,7 @@ spec:
           args:
             - -m
             - dynamo.frontend
-            - --no-decode-fallback
+            - --enforce-disagg
           env:
             - name: POD_UID
               valueFrom:


### PR DESCRIPTION
## Summary
- Cherry-pick of #8914 to release/1.1.0
- Replaces invalid `--no-decode-fallback` flag with the correct `--enforce-disagg` flag in the GLM-5 SGLang disagg deploy manifest.

## Original PR
- Main PR: #8914
- Merge commit: 8f4353c528015a98be65a4393801f8be7770ad2e

## Test plan
- [ ] CI passes

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8955" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
