### PR TITLE
fix: use latency ratio as minimum floor

### DIFF
--- a/components/src/dynamo/planner/config/planner_config.py
+++ b/components/src/dynamo/planner/config/planner_config.py
@@ -160,6 +160,9 @@ class PlannerConfig(BaseModel):
 
     @model_validator(mode="after")
     def _validate_config(self) -> "PlannerConfig":
+        if self.ttft <= 0:
+            raise ValueError(f"ttft must be > 0, got {self.ttft}")
+
         if self.report_interval_hours is not None:
             if (
                 not math.isfinite(self.report_interval_hours)

--- a/components/src/dynamo/planner/core/throughput_scaling.py
+++ b/components/src/dynamo/planner/core/throughput_scaling.py
@@ -178,14 +178,19 @@ class ThroughputScalingMixin:
             logger.warning("Prefill perf model not ready, skipping throughput scaling")
             self._diag_throughput_reason = "model_not_ready"
             return None
+        sla_floor = 1
         if ttft_ms > self._config.ttft:
             logger.warning(
                 f"Prefill TTFT SLA not met: {ttft_ms:.1f}ms > {self._config.ttft:.1f}ms"
             )
+            # Latency-driven floor
+            sla_floor = math.ceil(ttft_ms / self._config.ttft)
 
         self._diag_engine_rps_prefill = engine_rps
 
-        result = max(math.ceil(demand_rps / engine_rps), self._config.min_endpoint)
+        result = max(
+            math.ceil(demand_rps / engine_rps), sla_floor, self._config.min_endpoint
+        )
         logger.info(
             f"Prefill: {demand_rps:.2f} rps / {engine_rps:.2f} = {result}, est_ttft={ttft_ms:.1f}ms"
         )

--- a/components/src/dynamo/planner/tests/unit/test_state_machine.py
+++ b/components/src/dynamo/planner/tests/unit/test_state_machine.py
@@ -412,6 +412,37 @@ class TestThroughputScaling:
         assert core._throughput_lower_bound_d >= 1
         assert effects.diagnostics.throughput_decision_reason == "set_lower_bound"
 
+    def test_ttft_sla_floor_overrides_throughput_ratio_under_backpressure(self):
+        """Regression: when demand_rps << engine_rps (backpressure), the latency
+        violation must still drive scale-up rather than resolving to 1."""
+        # ttft_sla=200ms; regression gives wt(1000 tokens) ≈ 1.002s → ttft≈1002ms.
+        # sla_floor = ceil(1002/200) = 6.  With near-zero demand the raw
+        # ceil(demand_rps/engine_rps) would return 1 without the fix.
+        core = _make_core(
+            mode="prefill",
+            enable_load_scaling=False,
+            enable_throughput_scaling=True,
+            ttft=200.0,
+        )
+        _train_prefill_regression(core)
+
+        # Tiny demand to reproduce the backpressure equilibrium
+        core._observe_traffic(
+            TrafficObservation(duration_s=60, num_req=1, isl=1000, osl=150)
+        )
+
+        tick = TickInput(
+            now_s=60.0,
+            traffic=TrafficObservation(duration_s=60, num_req=1, isl=1000, osl=150),
+            worker_counts=WorkerCounts(ready_num_prefill=1),
+        )
+        effects = core.on_tick(_tick_for(tick), tick)
+        assert effects.scale_to is not None
+        # ceil(demand_rps/engine_rps) = ceil(0.017/1.0) = 1 without the floor.
+        # With the SLA floor: ceil(1002/200) = 6.
+        assert effects.scale_to.num_prefill is not None
+        assert effects.scale_to.num_prefill >= 6
+
     def test_next_tick_scheduled_after_traffic(self):
         core = _make_core(mode="prefill")
         tick = TickInput(


### PR DESCRIPTION
## Summary
- Cherry-pick of #8861 to release/1.1.0
- Planner uses the predicted-TTFT-vs-target latency ratio as a minimum floor for prefill replica scaling. Under backpressure `demand_rps` cannot signal saturation via the throughput ratio alone, so without this floor `ceil(demand_rps / engine_rps)` always rounds to 1. Now, if predicted TTFT exceeds the target, the planner scales to at least `ceil(predicted_ttft / target_ttft)` replicas.

Fixes DYN-2887

## Original PR
- Main PR: #8861
- Merge commit: b5d73a24ed1d4f946dc597a0b5b1d137c3f46e90

## Test plan
- [ ] CI passes
- [ ] Planner unit test (`test_state_machine.py`) covers SLA-driven scaling under backpressure

Made with [Cursor](https://cursor.com)