### PR TITLE
fix(llm): detokenize top_logprobs token_ids in backend (DYN-2923)

### DIFF
--- a/lib/llm/src/backend.rs
+++ b/lib/llm/src/backend.rs
@@ -66,6 +66,10 @@ struct DecoderUnfoldState {
     validate_engine_decode: bool,
     /// Set to true when a local stop condition is detected, causing the stream to end
     finished: bool,
+    /// Tokenizer used to decode top-logprob token_ids when the backend omits text
+    /// (e.g. SGLang with --skip-tokenizer-init forcibly drops it).
+    tokenizer: Tokenizer,
+    skip_special_tokens: bool,
 }
 
 impl Backend {
@@ -113,6 +117,8 @@ impl Backend {
             decoder,
             validate_engine_decode: self.validate_engine_decode,
             finished: false,
+            tokenizer: tokenizer.clone(),
+            skip_special_tokens,
         })
     }
 }
@@ -272,6 +278,33 @@ impl
                     }
                     data.text = text;
                     data.tokens = Some(tokens);
+
+                    // Per-entry decode is O(positions * top_k) per delta. Bounded in
+                    // practice (streaming: 1 * top_k <= 20) and dwarfed by serialization
+                    // on the same path, so we ship the simple version. Revisit if a
+                    // streaming flamegraph with top_logprobs=20 puts this above ~1%:
+                    // the cheapest win is a shared LRU on the Tokenizer keyed by
+                    // (token_id, skip_special_tokens) — top-k entries repeat heavily
+                    // across positions and requests. Do NOT batch as a single
+                    // decode(&[ids..]) call: BPE merge / leading-space rules differ
+                    // between single-token and sequence decode and will corrupt strings.
+                    if let Some(top_logprobs) = data.top_logprobs.as_mut() {
+                        for position in top_logprobs.iter_mut() {
+                            for entry in position.iter_mut() {
+                                if entry.token.is_none()
+                                    && let Ok(decoded) = state
+                                        .tokenizer
+                                        .decode(&[entry.token_id], state.skip_special_tokens)
+                                {
+                                    let s: String = decoded.into();
+                                    if entry.bytes.is_none() && !s.is_empty() {
+                                        entry.bytes = Some(s.as_bytes().to_vec());
+                                    }
+                                    entry.token = Some(s);
+                                }
+                            }
+                        }
+                    }
 
                     output.data = Some(data);
 


### PR DESCRIPTION
## Summary
- Cherry-pick of #8911 to release/1.1.0
- When SGLang launches with `--skip-tokenizer-init`, the SGLang `tokenizer_manager` forces `return_text_in_logprobs=False`, so `output_top_logprobs` tuples come out as `(logprob, token_id, None)`. The Python handler propagates `None` as `token`, and the Rust OpenAI converter then emits `token=""` / `bytes=null` for every `top_logprobs[]` candidate.
- Fix threads the frontend `Tokenizer` and `skip_special_tokens` through `DecoderUnfoldState` and detokenizes each `TopLogprob.token_id` whose `token` is `None`, populating `bytes` from the resulting UTF-8. Backend-agnostic — also closes the same gap if vLLM or TRT-LLM ever emit a `None` decoded token.

Fixes DYN-2923

## Original PR
- Main PR: #8911
- Merge commit: afffd941554c1a02b2f56d528a2f6f8088f71671

## Cherry-pick note
The merge-commit cherry-pick had one conflict-adjacent issue: the main version of `decoder()` constructs `DecoderUnfoldState` from a `DecoderParams` struct (`params.skip_special_tokens`), while `release/1.1.0` still takes `skip_special_tokens` as a direct function argument. Adjusted the field initializer to use the bare identifier — same intent as commit 69f3110 from the original PR, which was hand-written for this exact code shape.

## Test plan
- [ ] CI passes
- [ ] Manual: SGLang agg + Qwen3-0.6B + `logprobs:true, top_logprobs:5` returns populated `token` + `bytes` for each top entry

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8958" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
