### PR TITLE
feat(mocker): publish tiered KV events for G2 offload

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -116,6 +116,10 @@ jobs:
       working-directory: ${{ matrix.dir }}
       # NOTE: --all-targets doesn't run doc tests
       run: cargo test --locked --all-targets
+    - name: Run KVBM offload Mooncake trace test
+      if: matrix.dir == '.'
+      working-directory: ${{ matrix.dir }}
+      run: cargo test --locked -p dynamo-bench --test mooncake_trace --features mocker-kvbm-offload -- --nocapture
 
   rust-clippy:
     needs: changed-files

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -163,6 +163,10 @@ jobs:
     - name: Run Clippy Checks
       working-directory: ${{ matrix.dir }}
       run: cargo clippy --no-deps --all-targets -- -D warnings
+    - name: Run KVBM offload Mooncake trace clippy
+      if: matrix.dir == '.'
+      working-directory: ${{ matrix.dir }}
+      run: cargo clippy --no-deps -p dynamo-bench --test mooncake_trace --features mocker-kvbm-offload -- -D warnings
     - name: Install and Run cargo-machete
       working-directory: ${{ matrix.dir }}
       run: |

--- a/lib/bench/Cargo.toml
+++ b/lib/bench/Cargo.toml
@@ -11,6 +11,10 @@ homepage.workspace = true
 repository.workspace = true
 description = "Lightweight HTTP benchmarks for Dynamo endpoints"
 
+[features]
+default = []
+mocker-kvbm-offload = ["dynamo-mocker/kvbm-offload"]
+
 [[bench]]
 name = "multiturn_bench"
 path = "multiturn_bench.rs"

--- a/lib/bench/kv_router/common/mod.rs
+++ b/lib/bench/kv_router/common/mod.rs
@@ -20,8 +20,10 @@ pub use mooncake_trace::{
 pub use progress::make_progress_bar;
 pub use replay::{
     NoopSequencePublisher, WorkerReplayArtifacts, default_mock_engine_args,
-    generate_replay_artifacts, maybe_rescale_ready_span,
+    generate_replay_artifacts, generate_replay_artifacts_with_args, maybe_rescale_ready_span,
 };
+#[cfg(feature = "mocker-kvbm-offload")]
+pub use replay::{g2_mock_engine_args, generate_g2_replay_artifacts_with_capacity};
 pub use results::{
     BenchmarkResults, BenchmarkRun, PercentileStats, compute_benchmark_run,
     print_benchmark_results_percentiles,

--- a/lib/bench/kv_router/common/replay.rs
+++ b/lib/bench/kv_router/common/replay.rs
@@ -36,6 +36,28 @@ pub fn default_mock_engine_args(
         .build()?)
 }
 
+#[cfg(feature = "mocker-kvbm-offload")]
+#[allow(dead_code)]
+pub fn g2_mock_engine_args(
+    num_gpu_blocks: usize,
+    block_size: usize,
+    num_g2_blocks: usize,
+) -> anyhow::Result<MockEngineArgs> {
+    Ok(MockEngineArgs::builder()
+        .num_gpu_blocks(num_gpu_blocks)
+        .block_size(block_size)
+        .speedup_ratio(10.0)
+        .enable_prefix_caching(true)
+        .max_num_batched_tokens(None)
+        .max_num_seqs(None)
+        .num_g2_blocks(Some(num_g2_blocks))
+        .kv_bytes_per_token(Some(1))
+        .offload_batch_size(Some(32))
+        .bandwidth_g1_to_g2_gbps(Some(14.0))
+        .bandwidth_g2_to_g1_gbps(Some(14.0))
+        .build()?)
+}
+
 fn replay_worker_trace(
     trace: Trace,
     sched_args: MockEngineArgs,
@@ -55,14 +77,12 @@ fn replay_worker_trace(
     Ok(artifacts)
 }
 
-pub async fn generate_replay_artifacts(
+pub async fn generate_replay_artifacts_with_args(
     traces: &[Trace],
-    num_gpu_blocks: usize,
-    block_size: u32,
+    sched_args: MockEngineArgs,
     trace_simulation_duration_ms: Option<u64>,
 ) -> anyhow::Result<Vec<WorkerReplayArtifacts>> {
     println!("Generating events...");
-    let sched_args = default_mock_engine_args(num_gpu_blocks, block_size as usize)?;
     let progress = make_progress_bar(Some(
         traces
             .iter()
@@ -129,4 +149,27 @@ pub async fn generate_replay_artifacts(
     println!("Remove events: {}", num_removed_events);
 
     Ok(artifacts)
+}
+
+pub async fn generate_replay_artifacts(
+    traces: &[Trace],
+    num_gpu_blocks: usize,
+    block_size: u32,
+    trace_simulation_duration_ms: Option<u64>,
+) -> anyhow::Result<Vec<WorkerReplayArtifacts>> {
+    let sched_args = default_mock_engine_args(num_gpu_blocks, block_size as usize)?;
+    generate_replay_artifacts_with_args(traces, sched_args, trace_simulation_duration_ms).await
+}
+
+#[cfg(feature = "mocker-kvbm-offload")]
+#[allow(dead_code)]
+pub async fn generate_g2_replay_artifacts_with_capacity(
+    traces: &[Trace],
+    num_gpu_blocks: usize,
+    num_g2_blocks: usize,
+    block_size: u32,
+    trace_simulation_duration_ms: Option<u64>,
+) -> anyhow::Result<Vec<WorkerReplayArtifacts>> {
+    let sched_args = g2_mock_engine_args(num_gpu_blocks, block_size as usize, num_g2_blocks)?;
+    generate_replay_artifacts_with_args(traces, sched_args, trace_simulation_duration_ms).await
 }

--- a/lib/bench/kv_router/mooncake_shared.rs
+++ b/lib/bench/kv_router/mooncake_shared.rs
@@ -10,7 +10,7 @@ use dynamo_kv_router::LocalBlockHash;
 use dynamo_kv_router::indexer::pruning::PruneConfig;
 use dynamo_kv_router::indexer::{KvIndexer, KvIndexerInterface, KvIndexerMetrics};
 use dynamo_kv_router::protocols::{
-    KvCacheEvent, KvCacheEventData, RouterEvent, TokensWithHashes, WorkerWithDpRank,
+    KvCacheEvent, KvCacheEventData, RouterEvent, StorageTier, TokensWithHashes, WorkerWithDpRank,
 };
 use dynamo_kv_router::{
     AnchorAwareBranchShardedIndexer, BranchShardedIndexer, ConcurrentRadixTree,
@@ -313,8 +313,14 @@ pub struct MooncakeBenchmarkConfig {
 #[derive(Clone)]
 enum WorkerTraceEntry {
     Request(Vec<LocalBlockHash>),
-    Event(KvCacheEvent),
-    ApproxWrite { tokens: Vec<u32>, num_blocks: usize },
+    Event {
+        event: KvCacheEvent,
+        storage_tier: StorageTier,
+    },
+    ApproxWrite {
+        tokens: Vec<u32>,
+        num_blocks: usize,
+    },
 }
 
 /// A timestamped entry in a worker's benchmark trace, used to replay requests
@@ -374,7 +380,10 @@ fn merge_event_worker_trace(
         },
         |event| WorkerTrace {
             timestamp_us: event.timestamp_us,
-            entry: WorkerTraceEntry::Event(event.event.clone()),
+            entry: WorkerTraceEntry::Event {
+                event: event.event.clone(),
+                storage_tier: event.storage_tier,
+            },
         },
     )
 }
@@ -487,7 +496,7 @@ pub(crate) fn prepare_scaled_benchmark(
                 totals.request_blocks += hashes.len();
                 seq_pool.push(hashes.clone());
             }
-            WorkerTraceEntry::Event(event) => {
+            WorkerTraceEntry::Event { event, .. } => {
                 totals.events += 1;
                 totals.event_blocks += match &event.data {
                     KvCacheEventData::Stored(store) => store.blocks.len(),
@@ -576,10 +585,19 @@ pub(crate) async fn run_prepared_benchmark(
                         indexer.find_matches(request).await?;
                         Ok::<Option<u64>, anyhow::Error>(Some(start.elapsed().as_nanos() as u64))
                     }
-                    WorkerTraceEntry::Event(event) => {
-                        indexer
-                            .apply_event(RouterEvent::new(worker_id as u64, event))
-                            .await;
+                    WorkerTraceEntry::Event {
+                        event,
+                        storage_tier,
+                    } => {
+                        if storage_tier.is_gpu() {
+                            indexer
+                                .apply_event(RouterEvent::with_storage_tier(
+                                    worker_id as u64,
+                                    event,
+                                    storage_tier,
+                                ))
+                                .await;
+                        }
                         Ok(None)
                     }
                     WorkerTraceEntry::ApproxWrite { tokens, .. } => {

--- a/lib/bench/tests/mooncake_trace.rs
+++ b/lib/bench/tests/mooncake_trace.rs
@@ -3,6 +3,10 @@
 
 mod support;
 
+#[cfg(feature = "mocker-kvbm-offload")]
+#[path = "support/mooncake_g2_lower_tier.rs"]
+mod g2_lower_tier;
+
 #[path = "../kv_router/common/mod.rs"]
 mod common;
 
@@ -15,11 +19,17 @@ use std::sync::Arc;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
 
+#[cfg(feature = "mocker-kvbm-offload")]
+use common::generate_g2_replay_artifacts_with_capacity;
 use common::{WorkerReplayArtifacts, generate_replay_artifacts, process_mooncake_trace};
 use dynamo_kv_router::LocalBlockHash;
 use dynamo_kv_router::indexer::pruning::PruneConfig;
 use dynamo_kv_router::indexer::{KvIndexerInterface, KvIndexerMetrics};
-use dynamo_kv_router::protocols::{KvCacheEvent, RouterEvent, TokensWithHashes, WorkerWithDpRank};
+#[cfg(feature = "mocker-kvbm-offload")]
+use dynamo_kv_router::protocols::KvCacheEventData;
+use dynamo_kv_router::protocols::{
+    KvCacheEvent, RouterEvent, StorageTier, TokensWithHashes, WorkerWithDpRank,
+};
 use dynamo_mocker::loadgen::{SessionTrace, Trace, TurnTrace};
 use mooncake_shared::{
     MooncakeBenchmarkConfig, MooncakeBenchmarkInput, MooncakeIndexerConfig, run_benchmark,
@@ -31,13 +41,20 @@ const NUM_GPU_BLOCKS: usize = 16384;
 const NUM_UNIQUE_INFERENCE_WORKERS: usize = 10;
 const BENCHMARK_DURATION_MS: u64 = 2000;
 const NUM_EVENT_WORKERS: usize = 4;
+#[cfg(feature = "mocker-kvbm-offload")]
+const G2_TEST_NUM_GPU_BLOCKS: usize = 512;
+#[cfg(feature = "mocker-kvbm-offload")]
+const G2_TEST_NUM_G2_BLOCKS: usize = 16_384;
 
 type NormalizedOverlapScores = BTreeMap<WorkerWithDpRank, u32>;
 
 #[derive(Clone)]
 enum ReplayEntryKind {
     Request(Vec<LocalBlockHash>),
-    Event(KvCacheEvent),
+    Event {
+        event: KvCacheEvent,
+        storage_tier: StorageTier,
+    },
     ApproxWrite(Vec<u32>),
 }
 
@@ -62,7 +79,10 @@ fn collect_replay_entries(artifacts: &[WorkerReplayArtifacts]) -> Vec<ReplayEntr
             timestamp_us: event.timestamp_us,
             worker_id: worker_id as u64,
             kind_rank: 1,
-            kind: ReplayEntryKind::Event(event.event.clone()),
+            kind: ReplayEntryKind::Event {
+                event: event.event.clone(),
+                storage_tier: event.storage_tier,
+            },
         }));
     }
     entries.sort_by_key(|entry| (entry.timestamp_us, entry.kind_rank, entry.worker_id));
@@ -156,10 +176,19 @@ async fn collect_overlap_scores_for_replay(
                     let overlap = indexer.find_matches(request.clone()).await?;
                     scores.push(overlap.scores.into_iter().collect());
                 }
-                ReplayEntryKind::Event(event) => {
-                    indexer
-                        .apply_event(RouterEvent::new(entries[idx].worker_id, event.clone()))
-                        .await;
+                ReplayEntryKind::Event {
+                    event,
+                    storage_tier,
+                } => {
+                    if storage_tier.is_gpu() {
+                        indexer
+                            .apply_event(RouterEvent::with_storage_tier(
+                                entries[idx].worker_id,
+                                event.clone(),
+                                *storage_tier,
+                            ))
+                            .await;
+                    }
                 }
                 ReplayEntryKind::ApproxWrite(tokens) => {
                     let mut tokens_with_hashes = TokensWithHashes::new(tokens.clone(), BLOCK_SIZE);
@@ -282,6 +311,30 @@ async fn route_approx_writes(
     }
 
     Ok(())
+}
+
+#[cfg(feature = "mocker-kvbm-offload")]
+#[derive(Clone, Copy, Debug, Default)]
+struct HostPinnedEventCounts {
+    stored: usize,
+    removed: usize,
+}
+
+#[cfg(feature = "mocker-kvbm-offload")]
+fn count_host_pinned_events(artifacts: &[WorkerReplayArtifacts]) -> HostPinnedEventCounts {
+    let mut counts = HostPinnedEventCounts::default();
+    for event in artifacts
+        .iter()
+        .flat_map(|artifact| artifact.kv_events.iter())
+        .filter(|event| event.storage_tier == StorageTier::HostPinned)
+    {
+        match &event.event.data {
+            KvCacheEventData::Stored(_) => counts.stored += 1,
+            KvCacheEventData::Removed(_) => counts.removed += 1,
+            KvCacheEventData::Cleared => {}
+        }
+    }
+    counts
 }
 
 #[test]
@@ -517,6 +570,81 @@ async fn mooncake_trace_replays_without_warnings_across_indexer_variants() -> an
     }
 
     assert_overlap_score_parity(&variants, &traces, &artifacts).await?;
+
+    Ok(())
+}
+
+#[cfg(feature = "mocker-kvbm-offload")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mooncake_trace_g2_events_replay_through_host_pinned_lower_tier() -> anyhow::Result<()> {
+    let warning_count = support::warning_counter(&["dynamo_kv_router::indexer", "dynamo_mocker"]);
+    support::reset_warning_count(&warning_count);
+
+    let fixture = support::fixture_path("mooncake_trace_1000.jsonl")?;
+    let traces = process_mooncake_trace(&fixture, BLOCK_SIZE, 1, 1, 1, 42)?;
+    let artifacts = generate_g2_replay_artifacts_with_capacity(
+        &traces,
+        G2_TEST_NUM_GPU_BLOCKS,
+        G2_TEST_NUM_G2_BLOCKS,
+        BLOCK_SIZE,
+        None,
+    )
+    .await?;
+    let counts = count_host_pinned_events(&artifacts);
+
+    assert!(
+        counts.stored > 0,
+        "mooncake G2 artifact generation should capture HostPinned Stored events; counts={counts:?}"
+    );
+    let (reference_scores, crtc_scores, host_pinned_dumped_events) =
+        g2_lower_tier::collect_tiered_replay_scores(&artifacts).await?;
+    let device_only_scores = collect_overlap_scores_for_replay(
+        &MooncakeIndexerConfig::concurrent_radix_tree_compressed(NUM_EVENT_WORKERS),
+        &traces,
+        &artifacts,
+        MooncakeReplayMode::KvEvents,
+    )
+    .await?;
+
+    assert!(
+        host_pinned_dumped_events > 0,
+        "HostPinned lower-tier indexer should retain replayed G2 state"
+    );
+    assert_eq!(
+        crtc_scores.len(),
+        reference_scores.len(),
+        "CRTC lower-tier replay produced a different request count than the reference replay"
+    );
+    assert_eq!(
+        crtc_scores.len(),
+        device_only_scores.len(),
+        "tiered replay produced a different request count than device-only replay"
+    );
+    assert!(
+        crtc_scores
+            .iter()
+            .zip(device_only_scores.iter())
+            .any(|(tiered, device_only)| {
+                g2_lower_tier::score_sum(tiered) > g2_lower_tier::score_sum(device_only)
+            }),
+        "HostPinned lower-tier replay should improve at least one mooncake request over device-only replay"
+    );
+
+    for (request_idx, (actual, expected)) in
+        crtc_scores.iter().zip(reference_scores.iter()).enumerate()
+    {
+        assert_eq!(
+            actual, expected,
+            "CRTC lower-tier additive overlap diverged from reference at replay request {request_idx}"
+        );
+    }
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert_eq!(
+        warning_count.load(Ordering::Relaxed),
+        0,
+        "G2 HostPinned lower-tier replay emitted warn/error logs from dynamo_kv_router::indexer or dynamo_mocker"
+    );
 
     Ok(())
 }

--- a/lib/bench/tests/support/mooncake_g2_lower_tier.rs
+++ b/lib/bench/tests/support/mooncake_g2_lower_tier.rs
@@ -1,0 +1,283 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use dynamo_kv_router::ConcurrentRadixTreeCompressed;
+use dynamo_kv_router::LocalBlockHash;
+use dynamo_kv_router::indexer::{
+    KvIndexer, KvIndexerInterface, KvIndexerMetrics, LowerTierContinuation, LowerTierIndexer,
+    MatchDetails, ThreadPoolIndexer,
+};
+use dynamo_kv_router::protocols::{KvCacheEvent, KvCacheEventData, RouterEvent, StorageTier};
+use rustc_hash::FxHashMap;
+use tokio_util::sync::CancellationToken;
+
+use super::{
+    BLOCK_SIZE, NUM_EVENT_WORKERS, NormalizedOverlapScores, ReplayEntryKind, WorkerReplayArtifacts,
+    collect_replay_entries,
+};
+
+fn additive_device_and_host_pinned_scores(
+    device_details: MatchDetails,
+    request: &[LocalBlockHash],
+    host_pinned: &LowerTierIndexer,
+) -> NormalizedOverlapScores {
+    let mut scores = device_details.overlap_scores.scores;
+    let mut continuations = FxHashMap::default();
+
+    for (worker, device_blocks) in &scores {
+        let Some(last_hash) = device_details.last_matched_hashes.get(worker) else {
+            continue;
+        };
+        let start_pos = *device_blocks as usize;
+        if start_pos < request.len() {
+            continuations.insert(*worker, LowerTierContinuation::new(start_pos, *last_hash));
+        }
+    }
+
+    if let Some(first_hash) = request.first() {
+        for worker in host_pinned.root_workers(*first_hash) {
+            continuations
+                .entry(worker)
+                .or_insert_with(|| LowerTierContinuation::from_root(0));
+        }
+    }
+
+    for (worker, host_blocks) in host_pinned.query_contiguous_hits(request, &continuations) {
+        if host_blocks == 0 {
+            continue;
+        }
+        let host_blocks = u32::try_from(host_blocks).unwrap_or(u32::MAX);
+        scores
+            .entry(worker)
+            .and_modify(|score| *score = score.saturating_add(host_blocks))
+            .or_insert(host_blocks);
+    }
+
+    scores.into_iter().filter(|(_, score)| *score > 0).collect()
+}
+
+struct ReferenceTieredReplay {
+    primary: KvIndexer,
+    host_pinned: ThreadPoolIndexer<LowerTierIndexer>,
+}
+
+impl ReferenceTieredReplay {
+    fn new() -> Self {
+        Self {
+            primary: KvIndexer::new(
+                CancellationToken::new(),
+                BLOCK_SIZE,
+                Arc::new(KvIndexerMetrics::new_unregistered()),
+            ),
+            host_pinned: ThreadPoolIndexer::new(
+                LowerTierIndexer::new(),
+                NUM_EVENT_WORKERS,
+                BLOCK_SIZE,
+            ),
+        }
+    }
+
+    async fn apply_event(&self, worker_id: u64, event: KvCacheEvent, storage_tier: StorageTier) {
+        if matches!(&event.data, KvCacheEventData::Cleared) {
+            self.primary
+                .apply_event(RouterEvent::with_storage_tier(
+                    worker_id,
+                    event.clone(),
+                    StorageTier::Device,
+                ))
+                .await;
+            self.host_pinned
+                .apply_event(RouterEvent::with_storage_tier(
+                    worker_id,
+                    event,
+                    StorageTier::HostPinned,
+                ))
+                .await;
+            return;
+        }
+
+        match storage_tier {
+            StorageTier::Device => {
+                self.primary
+                    .apply_event(RouterEvent::with_storage_tier(
+                        worker_id,
+                        event,
+                        storage_tier,
+                    ))
+                    .await;
+            }
+            StorageTier::HostPinned => {
+                self.host_pinned
+                    .apply_event(RouterEvent::with_storage_tier(
+                        worker_id,
+                        event,
+                        storage_tier,
+                    ))
+                    .await;
+            }
+            StorageTier::Disk | StorageTier::External => {}
+        }
+    }
+
+    async fn find_matches(
+        &self,
+        request: &[LocalBlockHash],
+    ) -> anyhow::Result<NormalizedOverlapScores> {
+        let details = self.primary.find_match_details(request.to_vec()).await?;
+        Ok(additive_device_and_host_pinned_scores(
+            details,
+            request,
+            self.host_pinned.backend(),
+        ))
+    }
+
+    async fn flush(&self) {
+        let _ = self.primary.flush().await;
+        self.host_pinned.flush().await;
+    }
+
+    fn shutdown(&self) {
+        self.primary.shutdown();
+        self.host_pinned.shutdown();
+    }
+}
+
+struct CrtcLowerTierReplay {
+    primary: ThreadPoolIndexer<ConcurrentRadixTreeCompressed>,
+    host_pinned: ThreadPoolIndexer<LowerTierIndexer>,
+}
+
+impl CrtcLowerTierReplay {
+    fn new() -> Self {
+        Self {
+            primary: ThreadPoolIndexer::new_with_metrics(
+                ConcurrentRadixTreeCompressed::new(),
+                NUM_EVENT_WORKERS,
+                BLOCK_SIZE,
+                Some(Arc::new(KvIndexerMetrics::new_unregistered())),
+            ),
+            host_pinned: ThreadPoolIndexer::new(
+                LowerTierIndexer::new(),
+                NUM_EVENT_WORKERS,
+                BLOCK_SIZE,
+            ),
+        }
+    }
+
+    async fn apply_event(&self, worker_id: u64, event: KvCacheEvent, storage_tier: StorageTier) {
+        if matches!(&event.data, KvCacheEventData::Cleared) {
+            self.primary
+                .apply_event(RouterEvent::with_storage_tier(
+                    worker_id,
+                    event.clone(),
+                    StorageTier::Device,
+                ))
+                .await;
+            self.host_pinned
+                .apply_event(RouterEvent::with_storage_tier(
+                    worker_id,
+                    event,
+                    StorageTier::HostPinned,
+                ))
+                .await;
+            return;
+        }
+
+        match storage_tier {
+            StorageTier::Device => {
+                self.primary
+                    .apply_event(RouterEvent::with_storage_tier(
+                        worker_id,
+                        event,
+                        storage_tier,
+                    ))
+                    .await;
+            }
+            StorageTier::HostPinned => {
+                self.host_pinned
+                    .apply_event(RouterEvent::with_storage_tier(
+                        worker_id,
+                        event,
+                        storage_tier,
+                    ))
+                    .await;
+            }
+            StorageTier::Disk | StorageTier::External => {}
+        }
+    }
+
+    fn find_matches(&self, request: &[LocalBlockHash]) -> NormalizedOverlapScores {
+        let details = self
+            .primary
+            .backend()
+            .find_match_details_impl(request, false);
+        additive_device_and_host_pinned_scores(details, request, self.host_pinned.backend())
+    }
+
+    async fn flush(&self) {
+        self.primary.flush().await;
+        self.host_pinned.flush().await;
+    }
+
+    fn shutdown(&self) {
+        self.primary.shutdown();
+        self.host_pinned.shutdown();
+    }
+}
+
+pub(crate) async fn collect_tiered_replay_scores(
+    artifacts: &[WorkerReplayArtifacts],
+) -> anyhow::Result<(
+    Vec<NormalizedOverlapScores>,
+    Vec<NormalizedOverlapScores>,
+    usize,
+)> {
+    let reference = ReferenceTieredReplay::new();
+    let crtc_lower_tier = CrtcLowerTierReplay::new();
+    let entries = collect_replay_entries(artifacts);
+    let mut reference_scores = Vec::new();
+    let mut crtc_scores = Vec::new();
+    let mut idx = 0;
+
+    while idx < entries.len() {
+        let timestamp_us = entries[idx].timestamp_us;
+        while idx < entries.len() && entries[idx].timestamp_us == timestamp_us {
+            match &entries[idx].kind {
+                ReplayEntryKind::Request(request) => {
+                    reference_scores.push(reference.find_matches(request).await?);
+                    crtc_scores.push(crtc_lower_tier.find_matches(request));
+                }
+                ReplayEntryKind::Event {
+                    event,
+                    storage_tier,
+                } => {
+                    reference
+                        .apply_event(entries[idx].worker_id, event.clone(), *storage_tier)
+                        .await;
+                    crtc_lower_tier
+                        .apply_event(entries[idx].worker_id, event.clone(), *storage_tier)
+                        .await;
+                }
+                ReplayEntryKind::ApproxWrite(_) => {
+                    anyhow::bail!("approximate writes are not part of KV-event replay artifacts")
+                }
+            }
+            idx += 1;
+        }
+        reference.flush().await;
+        crtc_lower_tier.flush().await;
+    }
+
+    crtc_lower_tier.flush().await;
+    let host_pinned_events = crtc_lower_tier.host_pinned.dump_events().await?.len();
+    reference.shutdown();
+    crtc_lower_tier.shutdown();
+
+    Ok((reference_scores, crtc_scores, host_pinned_events))
+}
+
+pub(crate) fn score_sum(scores: &NormalizedOverlapScores) -> u64 {
+    scores.values().map(|score| u64::from(*score)).sum()
+}

--- a/lib/kv-router/src/protocols.rs
+++ b/lib/kv-router/src/protocols.rs
@@ -243,6 +243,17 @@ impl StorageTier {
             .unwrap_or(Self::Device)
     }
 
+    /// Canonical wire-format medium string. `None` for the default GPU tier so
+    /// existing consumers that omit the field continue to round-trip.
+    pub fn to_kv_medium(self) -> Option<&'static str> {
+        match self {
+            Self::Device => None,
+            Self::HostPinned => Some("CPU_PINNED"),
+            Self::Disk => Some("DISK"),
+            Self::External => Some("EXTERNAL"),
+        }
+    }
+
     pub fn is_gpu(self) -> bool {
         matches!(self, Self::Device)
     }

--- a/lib/llm/src/kv_router/publisher/mod.rs
+++ b/lib/llm/src/kv_router/publisher/mod.rs
@@ -368,6 +368,21 @@ impl KvEventPublisher {
         }
     }
 
+    pub fn publish_with_storage_tier(
+        &self,
+        event: KvCacheEvent,
+        storage_tier: StorageTier,
+    ) -> Result<(), mpsc::error::SendError<KvCacheEvent>> {
+        let placement_event = PlacementEvent::new(
+            Placement::local_worker(self.worker_id, event.dp_rank, storage_tier),
+            event,
+        );
+        match self.tx.send(placement_event) {
+            Ok(()) => Ok(()),
+            Err(err) => Err(mpsc::error::SendError(err.0.event)),
+        }
+    }
+
     pub fn next_event_id(&self) -> u64 {
         self.next_event_id.fetch_add(1, Ordering::SeqCst)
     }

--- a/lib/llm/src/mocker.rs
+++ b/lib/llm/src/mocker.rs
@@ -18,7 +18,7 @@ use crate::protocols::common::llm_backend::{LLMEngineOutput, PreprocessedRequest
 use anyhow::Result;
 use bytes::Bytes;
 use dashmap::DashMap;
-use dynamo_kv_router::protocols::{KvCacheEvent, KvCacheEventData};
+use dynamo_kv_router::protocols::{KvCacheEvent, KvCacheEventData, StorageTier};
 use dynamo_mocker::common::bootstrap::{BootstrapServer, connect_to_prefill};
 use dynamo_mocker::common::protocols::{
     DirectRequest, KvCacheEventSink, KvEventPublishers, MockEngineArgs, OutputSignal, RawKvEvent,
@@ -58,6 +58,16 @@ impl KvCacheEventSink for KvEventSinkAdapter {
             .publish(event)
             .map_err(|e| anyhow::anyhow!("Failed to send KV event: {}", e))
     }
+
+    fn publish_with_storage_tier(
+        &self,
+        event: KvCacheEvent,
+        storage_tier: StorageTier,
+    ) -> anyhow::Result<()> {
+        self.0
+            .publish_with_storage_tier(event, storage_tier)
+            .map_err(|e| anyhow::anyhow!("Failed to send KV event: {}", e))
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -72,10 +82,14 @@ enum ZmqRawKvEvent {
         parent_block_hash: Option<u64>,
         token_ids: Vec<u32>,
         block_size: u32,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        medium: Option<&'static str>,
         group_idx: u32,
     },
     BlockRemoved {
         block_hashes: Vec<u64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        medium: Option<&'static str>,
         group_idx: u32,
     },
 }
@@ -196,6 +210,7 @@ impl ZmqKvEventSink {
                             &msg.event,
                             msg.block_token_ids.as_deref(),
                             block_size,
+                            msg.storage_tier,
                         );
                         if events.is_empty() {
                             continue;
@@ -256,7 +271,9 @@ fn convert_to_zmq_events(
     event: &KvCacheEvent,
     block_token_ids: Option<&[Vec<u32>]>,
     block_size: u32,
+    storage_tier: StorageTier,
 ) -> Vec<ZmqRawKvEvent> {
+    let medium = storage_tier.to_kv_medium();
     match &event.data {
         KvCacheEventData::Stored(store_data) => {
             let block_hashes: Vec<u64> = store_data.blocks.iter().map(|b| b.block_hash.0).collect();
@@ -279,6 +296,7 @@ fn convert_to_zmq_events(
                 parent_block_hash,
                 token_ids,
                 block_size,
+                medium,
                 group_idx: 0,
             }]
         }
@@ -286,6 +304,7 @@ fn convert_to_zmq_events(
             let block_hashes: Vec<u64> = remove_data.block_hashes.iter().map(|h| h.0).collect();
             vec![ZmqRawKvEvent::BlockRemoved {
                 block_hashes,
+                medium,
                 group_idx: 0,
             }]
         }
@@ -846,4 +865,59 @@ pub async fn make_mocker_engine(
         AnnotatedMockEngine::new(MockEngine::new(args), distributed_runtime, endpoint_id);
 
     Ok(Arc::new(annotated_engine))
+}
+
+#[cfg(test)]
+mod tests {
+    use dynamo_kv_router::protocols::{
+        ExternalSequenceBlockHash, KvCacheStoreData, KvCacheStoredBlockData, LocalBlockHash,
+    };
+
+    use super::*;
+
+    fn stored_event() -> KvCacheEvent {
+        KvCacheEvent {
+            event_id: 1,
+            data: KvCacheEventData::Stored(KvCacheStoreData {
+                parent_hash: None,
+                start_position: None,
+                blocks: vec![KvCacheStoredBlockData {
+                    block_hash: ExternalSequenceBlockHash(10),
+                    tokens_hash: LocalBlockHash(100),
+                    mm_extra_info: None,
+                }],
+            }),
+            dp_rank: 0,
+        }
+    }
+
+    #[test]
+    fn host_pinned_zmq_stored_event_carries_medium() {
+        let events = convert_to_zmq_events(
+            &stored_event(),
+            Some(&[vec![1, 2, 3, 4]]),
+            4,
+            StorageTier::HostPinned,
+        );
+
+        let [ZmqRawKvEvent::BlockStored { medium, .. }] = events.as_slice() else {
+            panic!("expected one BlockStored event");
+        };
+        assert_eq!(*medium, Some("CPU_PINNED"));
+    }
+
+    #[test]
+    fn device_zmq_stored_event_omits_medium() {
+        let events = convert_to_zmq_events(
+            &stored_event(),
+            Some(&[vec![1, 2, 3, 4]]),
+            4,
+            StorageTier::Device,
+        );
+
+        let [ZmqRawKvEvent::BlockStored { medium, .. }] = events.as_slice() else {
+            panic!("expected one BlockStored event");
+        };
+        assert_eq!(*medium, None);
+    }
 }

--- a/lib/mocker/src/common/protocols.rs
+++ b/lib/mocker/src/common/protocols.rs
@@ -11,7 +11,7 @@ use uuid::Uuid;
 use validator::Validate;
 
 use crate::common::perf_model::PerfModel;
-use dynamo_kv_router::protocols::KvCacheEvent;
+use dynamo_kv_router::protocols::{KvCacheEvent, StorageTier};
 use dynamo_tokens::blocks::UniqueBlock;
 use dynamo_tokens::{BlockHash, PositionalLineageHash, SequenceHash, Token};
 
@@ -36,6 +36,14 @@ pub enum MockerEvictionBackend {
 /// This abstracts the runtime dependency so mocker components can remain generic.
 pub trait KvCacheEventSink: Send + Sync {
     fn publish(&self, event: KvCacheEvent) -> anyhow::Result<()>;
+
+    fn publish_with_storage_tier(
+        &self,
+        event: KvCacheEvent,
+        _storage_tier: StorageTier,
+    ) -> anyhow::Result<()> {
+        self.publish(event)
+    }
 }
 
 /// Raw KV event payload used by transport-specific publishers such as the
@@ -44,6 +52,7 @@ pub trait KvCacheEventSink: Send + Sync {
 pub struct RawKvEvent {
     pub event: KvCacheEvent,
     pub block_token_ids: Option<Vec<Vec<u32>>>,
+    pub storage_tier: StorageTier,
 }
 
 /// Trait for publishing transport-specific raw KV event payloads.
@@ -82,14 +91,24 @@ impl KvEventPublishers {
         event: KvCacheEvent,
         block_token_ids: Option<&[Vec<u32>]>,
     ) -> anyhow::Result<()> {
+        self.publish_with_storage_tier(event, block_token_ids, StorageTier::Device)
+    }
+
+    pub fn publish_with_storage_tier(
+        &self,
+        event: KvCacheEvent,
+        block_token_ids: Option<&[Vec<u32>]>,
+        storage_tier: StorageTier,
+    ) -> anyhow::Result<()> {
         if let Some(sink) = self.event_sink.as_ref() {
-            sink.publish(event.clone())?;
+            sink.publish_with_storage_tier(event.clone(), storage_tier)?;
         }
 
         if let Some(sink) = self.raw_sink.as_ref() {
             sink.publish(RawKvEvent {
                 event,
                 block_token_ids: block_token_ids.map(|token_ids| token_ids.to_vec()),
+                storage_tier,
             })?;
         }
 

--- a/lib/mocker/src/common/sequence.rs
+++ b/lib/mocker/src/common/sequence.rs
@@ -168,6 +168,14 @@ impl ActiveSequence {
         &self.plhs
     }
 
+    pub fn block_token_ids(&self) -> Vec<Vec<u32>> {
+        self.tokens
+            .blocks()
+            .iter()
+            .map(|block| block.tokens().to_vec())
+            .collect()
+    }
+
     /// Commit a successful allocation by advancing `num_allocated_tokens`.
     pub fn commit_allocation(&mut self, cumulative_tokens: usize) {
         self.num_allocated_tokens = cumulative_tokens;

--- a/lib/mocker/src/kv_manager/kvbm_backend.rs
+++ b/lib/mocker/src/kv_manager/kvbm_backend.rs
@@ -36,7 +36,7 @@ use std::sync::Mutex;
 
 use dynamo_kv_router::protocols::{
     ExternalSequenceBlockHash, KvCacheEvent, KvCacheEventData, KvCacheRemoveData, KvCacheStoreData,
-    KvCacheStoredBlockData, LocalBlockHash,
+    KvCacheStoredBlockData, LocalBlockHash, StorageTier,
 };
 use dynamo_tokens::blocks::UniqueBlock;
 use dynamo_tokens::{BlockHash, PositionalLineageHash, SequenceHash};
@@ -52,7 +52,9 @@ use crate::common::protocols::{
 };
 use crate::common::sequence::ActiveSequence;
 #[cfg(feature = "kvbm-offload")]
-use crate::kvbm_offload::{MockOffloadEngine, SwapInHandle};
+use crate::kvbm_offload::{
+    G2BlockEventMetadata, G2OffloadBlock, G2RouterEvent, MockOffloadEngine, SwapInHandle,
+};
 
 /// Outcome of [`KvManager::try_batch_swap_in`]. The caller uses this to
 /// decide whether to park the request on a pending-swap-in queue or to
@@ -79,6 +81,14 @@ pub enum BatchSwapInOutcome {
 #[cfg(feature = "kvbm-offload")]
 pub struct SwapInRegistrationOutcome {
     pub consumed_entries: usize,
+}
+
+#[cfg(feature = "kvbm-offload")]
+pub(crate) struct SwapInRegistrationBlock {
+    pub(crate) seq_hash: SequenceHash,
+    pub(crate) plh: PositionalLineageHash,
+    pub(crate) local_hash: BlockHash,
+    pub(crate) token_ids: Option<Vec<u32>>,
 }
 
 #[cfg(feature = "kvbm-offload")]
@@ -117,11 +127,17 @@ enum G1AllocationAttempt {
     },
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 struct RegisteredBlockInfo {
     seq_hash: SequenceHash,
     #[cfg_attr(not(feature = "kvbm-offload"), allow(dead_code))]
     block_id: usize,
+    #[cfg_attr(not(feature = "kvbm-offload"), allow(dead_code))]
+    parent_hash: Option<SequenceHash>,
+    #[cfg_attr(not(feature = "kvbm-offload"), allow(dead_code))]
+    local_hash: BlockHash,
+    #[cfg_attr(not(feature = "kvbm-offload"), allow(dead_code))]
+    token_ids: Option<Vec<u32>>,
 }
 
 /// Synchronous G1 KV block manager backed by `kvbm-logical::BlockManager<G1>`.
@@ -257,11 +273,15 @@ impl KvManager {
     /// the next enqueue measures the active-set size. No-op when no
     /// engine is attached.
     #[cfg(feature = "kvbm-offload")]
-    pub fn tick_offload_engine(&self, now_ms: f64) {
-        if let Some(engine_arc) = self.offload_engine.as_ref() {
+    pub fn tick_offload_engine(&mut self, now_ms: f64) {
+        let g2_events = if let Some(engine_arc) = self.offload_engine.as_ref() {
             let engine = engine_arc.lock().expect("offload engine mutex poisoned");
             engine.tick(now_ms);
-        }
+            engine.drain_g2_router_events()
+        } else {
+            Vec::new()
+        };
+        self.publish_g2_router_events(g2_events);
     }
 
     /// Earliest pending completion time across offload + onboard links,
@@ -281,20 +301,21 @@ impl KvManager {
     /// that must remain unavailable until the simulated source copy finishes.
     #[cfg(feature = "kvbm-offload")]
     fn enqueue_evictions_to_g2(
-        &self,
-        evicted: &[(usize, PositionalLineageHash)],
+        &mut self,
+        evicted: &[G2OffloadBlock],
         source_slots: Vec<MutableBlock<G1>>,
-    ) {
+    ) -> Vec<G2RouterEvent> {
         let Some(engine_arc) = self.offload_engine.as_ref() else {
             drop(source_slots);
-            return;
+            return Vec::new();
         };
         if evicted.is_empty() {
             drop(source_slots);
-            return;
+            return Vec::new();
         }
         let mut engine = engine_arc.lock().expect("offload engine mutex poisoned");
-        engine.enqueue_g1_evictions_holding_sources(evicted, source_slots, None);
+        engine.enqueue_g1_evictions_with_metadata(evicted, source_slots, None);
+        engine.drain_g2_router_events()
     }
 
     /// Register a batch of completed G2-swapped-in blocks into the G1
@@ -305,67 +326,66 @@ impl KvManager {
     /// advance the parent cursor so later fresh suffix stores publish the same
     /// router tree shape as `process_use`.
     #[cfg(feature = "kvbm-offload")]
-    pub fn register_swapped_in_blocks(
+    pub(crate) fn register_swapped_in_blocks(
         &mut self,
-        entries: &[(SequenceHash, PositionalLineageHash, BlockHash)],
+        entries: Vec<SwapInRegistrationBlock>,
         initial_parent_hash: Option<SequenceHash>,
         destination_slots: Vec<MutableBlock<G1>>,
     ) -> SwapInRegistrationOutcome {
-        let mut stored_seq_hashes = Vec::with_capacity(entries.len());
-        let mut stored_local_hashes = Vec::with_capacity(entries.len());
+        let total_entries = entries.len();
+        let mut stored_seq_hashes = Vec::with_capacity(total_entries);
+        let mut stored_local_hashes = Vec::with_capacity(total_entries);
+        let mut stored_token_ids = Vec::with_capacity(total_entries);
         let mut stored_parent_hash = initial_parent_hash;
+        let mut metadata_parent_hash = initial_parent_hash;
         let mut consumed_entries = 0usize;
         let mut destination_slots = destination_slots.into_iter();
 
-        for (seq_hash, plh, local_hash) in entries {
+        for entry in entries {
             let Some(mutable) = destination_slots.next() else {
                 tracing::warn!(
                     consumed_entries,
-                    entries = entries.len(),
+                    entries = total_entries,
                     "kvbm-offload: swap-in registration ran out of reserved G1 slots"
                 );
                 break;
             };
-            if self.active_full.contains_key(seq_hash) {
+            if self.active_full.contains_key(&entry.seq_hash) {
                 drop(mutable);
                 if !stored_seq_hashes.is_empty() {
-                    let full_blocks = std::mem::take(&mut stored_seq_hashes);
-                    let local_hashes = std::mem::take(&mut stored_local_hashes);
-                    self.publish_kv_event(
-                        full_blocks,
-                        &local_hashes,
+                    self.publish_swap_in_stored_batch(
+                        &mut stored_seq_hashes,
+                        &mut stored_local_hashes,
+                        &mut stored_token_ids,
                         stored_parent_hash,
-                        true,
-                        None,
                     );
                 }
-                stored_parent_hash = Some(*seq_hash);
+                stored_parent_hash = Some(entry.seq_hash);
+                metadata_parent_hash = Some(entry.seq_hash);
                 consumed_entries += 1;
                 continue;
             }
             let presence = self
                 .block_manager
                 .block_registry()
-                .check_presence::<G1>(&[*plh]);
+                .check_presence::<G1>(&[entry.plh]);
             if presence.first().is_some_and(|(_, p)| *p) {
                 drop(mutable);
                 if !stored_seq_hashes.is_empty() {
-                    let full_blocks = std::mem::take(&mut stored_seq_hashes);
-                    let local_hashes = std::mem::take(&mut stored_local_hashes);
-                    self.publish_kv_event(
-                        full_blocks,
-                        &local_hashes,
+                    self.publish_swap_in_stored_batch(
+                        &mut stored_seq_hashes,
+                        &mut stored_local_hashes,
+                        &mut stored_token_ids,
                         stored_parent_hash,
-                        true,
-                        None,
                     );
                 }
-                stored_parent_hash = Some(*seq_hash);
+                stored_parent_hash = Some(entry.seq_hash);
+                metadata_parent_hash = Some(entry.seq_hash);
                 consumed_entries += 1;
                 continue;
             }
             let complete = mutable
-                .stage(*plh, self.block_size)
+                .stage(entry.plh, self.block_size)
                 .expect("stage failed during swap-in registration");
             let immutable = self.block_manager.register_block(complete);
             let block_id = immutable.block_id();
@@ -373,29 +393,62 @@ impl KvManager {
             // inactive pool, where `process_use`'s `match_blocks`
             // later reactivates it.
             drop(immutable);
+            // Clone token_ids only when downstream still needs both copies
+            // (registry + publish batch). The publish batch takes ownership.
+            let registry_token_ids = entry.token_ids.clone();
+            if let Some(token_ids) = entry.token_ids {
+                stored_token_ids.push(token_ids);
+            }
             self.registered_blocks.insert(
-                *plh,
+                entry.plh,
                 RegisteredBlockInfo {
-                    seq_hash: *seq_hash,
+                    seq_hash: entry.seq_hash,
                     block_id,
+                    parent_hash: metadata_parent_hash,
+                    local_hash: entry.local_hash,
+                    token_ids: registry_token_ids,
                 },
             );
-            stored_seq_hashes.push(*seq_hash);
-            stored_local_hashes.push(*local_hash);
+            stored_seq_hashes.push(entry.seq_hash);
+            stored_local_hashes.push(entry.local_hash);
+            metadata_parent_hash = Some(entry.seq_hash);
             consumed_entries += 1;
         }
 
         if !stored_seq_hashes.is_empty() {
-            self.publish_kv_event(
-                stored_seq_hashes,
-                &stored_local_hashes,
+            self.publish_swap_in_stored_batch(
+                &mut stored_seq_hashes,
+                &mut stored_local_hashes,
+                &mut stored_token_ids,
                 stored_parent_hash,
-                true,
-                None,
             );
         }
 
         SwapInRegistrationOutcome { consumed_entries }
+    }
+
+    #[cfg(feature = "kvbm-offload")]
+    fn publish_swap_in_stored_batch(
+        &mut self,
+        stored_seq_hashes: &mut Vec<SequenceHash>,
+        stored_local_hashes: &mut Vec<BlockHash>,
+        stored_token_ids: &mut Vec<Vec<u32>>,
+        parent_hash: Option<SequenceHash>,
+    ) {
+        if stored_seq_hashes.is_empty() {
+            return;
+        }
+
+        let full_blocks = std::mem::take(stored_seq_hashes);
+        let local_hashes = std::mem::take(stored_local_hashes);
+        let token_ids = if stored_token_ids.len() == full_blocks.len() {
+            Some(std::mem::take(stored_token_ids))
+        } else {
+            stored_token_ids.clear();
+            None
+        };
+
+        self.publish_kv_event(full_blocks, &local_hashes, parent_hash, true, token_ids);
     }
 
     /// Try to satisfy a request's remaining prefix via a G2→G1 swap-in.
@@ -453,6 +506,25 @@ impl KvManager {
         parent_hash: Option<u64>,
         is_store: bool,
         token_ids: Option<Vec<Vec<u32>>>,
+    ) {
+        self.publish_kv_event_for_tier(
+            full_blocks,
+            local_hashes,
+            parent_hash,
+            is_store,
+            token_ids,
+            StorageTier::Device,
+        );
+    }
+
+    fn publish_kv_event_for_tier(
+        &mut self,
+        full_blocks: Vec<SequenceHash>,
+        local_hashes: &[BlockHash],
+        parent_hash: Option<u64>,
+        is_store: bool,
+        token_ids: Option<Vec<Vec<u32>>>,
+        storage_tier: StorageTier,
     ) {
         if full_blocks.is_empty() {
             return;
@@ -515,11 +587,40 @@ impl KvManager {
             dp_rank: self.dp_rank,
         };
 
-        if let Err(e) = self
-            .kv_event_publishers
-            .publish(event, token_ids.as_deref())
-        {
+        if let Err(e) = self.kv_event_publishers.publish_with_storage_tier(
+            event,
+            token_ids.as_deref(),
+            storage_tier,
+        ) {
             tracing::warn!("Failed to publish KV event: {e}");
+        }
+    }
+
+    #[cfg(feature = "kvbm-offload")]
+    fn publish_g2_router_events(&mut self, events: Vec<G2RouterEvent>) {
+        for event in events {
+            match event {
+                G2RouterEvent::Stored(meta) => {
+                    self.publish_kv_event_for_tier(
+                        vec![meta.seq_hash],
+                        &[meta.local_hash],
+                        meta.parent_hash,
+                        true,
+                        meta.token_ids.map(|ids| vec![ids]),
+                        StorageTier::HostPinned,
+                    );
+                }
+                G2RouterEvent::Removed { seq_hash } => {
+                    self.publish_kv_event_for_tier(
+                        vec![seq_hash],
+                        &[],
+                        None,
+                        false,
+                        None,
+                        StorageTier::HostPinned,
+                    );
+                }
+            }
         }
     }
 
@@ -720,6 +821,12 @@ impl KvManager {
             local_hashes.len(),
             expected_full_blocks,
         );
+        assert!(
+            token_ids.is_none_or(|ids| ids.len() == expected_full_blocks),
+            "Use: token_ids must be absent or match FullBlock count ({} vs {})",
+            token_ids.map_or(0, |ids| ids.len()),
+            expected_full_blocks,
+        );
 
         let mut blocks_stored = Vec::<SequenceHash>::new();
         let mut stored_local_hashes = Vec::<BlockHash>::new();
@@ -729,12 +836,20 @@ impl KvManager {
         let mut blocked_source_slots = Vec::<MutableBlock<G1>>::new();
 
         let mut parent_block: Option<&UniqueBlock> = parent;
+        let mut metadata_parent_hash: Option<SequenceHash> = match parent {
+            None => None,
+            Some(UniqueBlock::FullBlock(block)) => Some(*block),
+            Some(UniqueBlock::PartialBlock(_)) => panic!("parent block cannot be partial"),
+        };
         let mut plh_idx = 0usize;
         let mut allocated = 0usize;
 
         for (i, block) in blocks.iter().enumerate() {
+            let mut current_full_idx: Option<usize> = None;
             let outcome = match block {
                 UniqueBlock::FullBlock(seq_hash) => {
+                    let full_idx = plh_idx;
+                    current_full_idx = Some(full_idx);
                     // Active hit — bump refcount by cloning the first handle.
                     if let Some(vec) = self.active_full.get_mut(seq_hash) {
                         let cloned = vec[0].clone();
@@ -796,6 +911,12 @@ impl KvManager {
                                 RegisteredBlockInfo {
                                     seq_hash: *seq_hash,
                                     block_id,
+                                    parent_hash: metadata_parent_hash,
+                                    local_hash: local_hashes
+                                        .get(full_idx)
+                                        .copied()
+                                        .unwrap_or_default(),
+                                    token_ids: token_ids.and_then(|ids| ids.get(full_idx).cloned()),
                                 },
                             );
                             UseOutcome::NewStore
@@ -857,16 +978,21 @@ impl KvManager {
                     // block *before* the first newly-stored one.
                     if let UniqueBlock::FullBlock(seq_hash) = block {
                         blocks_stored.push(*seq_hash);
-                        if let Some(lh) = local_hashes.get(i) {
+                        let full_idx =
+                            current_full_idx.expect("NewStore is only emitted for full blocks");
+                        if let Some(lh) = local_hashes.get(full_idx) {
                             stored_local_hashes.push(*lh);
                         }
                         if let (Some(ref mut stids), Some(ids)) =
                             (stored_token_ids.as_mut(), token_ids)
                         {
-                            stids.push(ids[i].clone());
+                            stids.push(ids[full_idx].clone());
                         }
                     }
                 }
+            }
+            if let UniqueBlock::FullBlock(seq_hash) = block {
+                metadata_parent_hash = Some(*seq_hash);
             }
             allocated += 1;
         }
@@ -920,11 +1046,20 @@ impl KvManager {
             };
             evicted_seq_hashes.push(info.seq_hash);
             #[cfg(feature = "kvbm-offload")]
-            offload_blocks.push((info.block_id, plh));
+            offload_blocks.push(G2OffloadBlock {
+                block_id: info.block_id,
+                plh,
+                metadata: G2BlockEventMetadata {
+                    seq_hash: info.seq_hash,
+                    parent_hash: info.parent_hash,
+                    local_hash: info.local_hash,
+                    token_ids: info.token_ids,
+                },
+            });
         }
 
         #[cfg(feature = "kvbm-offload")]
-        {
+        let g2_events = {
             if !source_slots.is_empty() && source_slots.len() != offload_blocks.len() {
                 tracing::warn!(
                     source_slots = source_slots.len(),
@@ -932,14 +1067,17 @@ impl KvManager {
                     "kvbm-offload: source-slot hold count does not match offload block count"
                 );
             }
-            self.enqueue_evictions_to_g2(&offload_blocks, source_slots);
-        }
+            self.enqueue_evictions_to_g2(&offload_blocks, source_slots)
+        };
         #[cfg(not(feature = "kvbm-offload"))]
         drop(source_slots);
 
         if !evicted_seq_hashes.is_empty() {
             self.publish_kv_event(evicted_seq_hashes, &[], None, false, None);
         }
+
+        #[cfg(feature = "kvbm-offload")]
+        self.publish_g2_router_events(g2_events);
     }
 
     fn process_deref(&mut self, blocks: &[UniqueBlock]) {
@@ -998,8 +1136,16 @@ impl KvManager {
             let immutable = self.block_manager.register_block(complete);
             let block_id = immutable.block_id();
             self.active_full.insert(seq_hash, vec![immutable]);
-            self.registered_blocks
-                .insert(plh, RegisteredBlockInfo { seq_hash, block_id });
+            self.registered_blocks.insert(
+                plh,
+                RegisteredBlockInfo {
+                    seq_hash,
+                    block_id,
+                    parent_hash,
+                    local_hash,
+                    token_ids: token_ids.clone(),
+                },
+            );
             true
         };
 
@@ -1204,6 +1350,26 @@ mod tests {
         let mut mgr = make_mgr(10, 16);
         assert_eq!(use_full(&mut mgr, 1, plh(100)), 1);
         assert_eq!(mgr.num_active_blocks(), 1);
+    }
+
+    #[test]
+    fn use_rejects_short_token_ids_before_mutating_state() {
+        let (mut mgr, sink) = make_mgr_capturing(10, 4);
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            mgr.process(&MoveBlock::Use(
+                vec![UniqueBlock::FullBlock(1), UniqueBlock::FullBlock(2)],
+                vec![101, 102],
+                vec![plh(100), plh(200)],
+                Some(vec![vec![1, 2, 3, 4]]),
+                None,
+            ));
+        }));
+
+        assert!(result.is_err());
+        assert_eq!(mgr.num_active_blocks(), 0);
+        assert!(mgr.active_full.is_empty());
+        assert!(sink.events.lock().unwrap().is_empty());
     }
 
     #[test]
@@ -1707,11 +1873,24 @@ mod tests {
             SwapInSlotReservation::NoCapacity => panic!("fresh manager should have capacity"),
         };
 
-        let entries = vec![(12, plh(12), 120), (13, plh(13), 130)];
-        let outcome = mgr.register_swapped_in_blocks(&entries, Some(11), slots);
+        let entries = vec![
+            SwapInRegistrationBlock {
+                seq_hash: 12,
+                plh: plh(12),
+                local_hash: 120,
+                token_ids: Some(vec![1; 16]),
+            },
+            SwapInRegistrationBlock {
+                seq_hash: 13,
+                plh: plh(13),
+                local_hash: 130,
+                token_ids: Some(vec![2; 16]),
+            },
+        ];
+        let entries_len = entries.len();
+        let outcome = mgr.register_swapped_in_blocks(entries, Some(11), slots);
         assert_eq!(
-            outcome.consumed_entries,
-            entries.len(),
+            outcome.consumed_entries, entries_len,
             "all reserved swap-in slots should be consumed"
         );
 
@@ -1895,7 +2074,179 @@ mod tests {
     #[cfg(feature = "kvbm-offload")]
     mod offload {
         use super::*;
+        use crate::common::protocols::{RawKvEvent, RawKvEventSink};
         use crate::kvbm_offload::{KvbmOffloadConfig, MockOffloadEngine};
+        use std::sync::{Arc, Mutex};
+
+        #[derive(Default)]
+        struct TierCapturingSink {
+            events: Mutex<Vec<(StorageTier, KvCacheEvent)>>,
+        }
+
+        impl TierCapturingSink {
+            fn clear(&self) {
+                self.events.lock().unwrap().clear();
+            }
+
+            fn take(&self) -> Vec<(StorageTier, KvCacheEvent)> {
+                std::mem::take(&mut *self.events.lock().unwrap())
+            }
+        }
+
+        impl KvCacheEventSink for TierCapturingSink {
+            fn publish(&self, event: KvCacheEvent) -> anyhow::Result<()> {
+                self.publish_with_storage_tier(event, StorageTier::Device)
+            }
+
+            fn publish_with_storage_tier(
+                &self,
+                event: KvCacheEvent,
+                storage_tier: StorageTier,
+            ) -> anyhow::Result<()> {
+                self.events.lock().unwrap().push((storage_tier, event));
+                Ok(())
+            }
+        }
+
+        #[derive(Default)]
+        struct RawCapturingSink {
+            events: Mutex<Vec<RawKvEvent>>,
+        }
+
+        impl RawCapturingSink {
+            fn clear(&self) {
+                self.events.lock().unwrap().clear();
+            }
+
+            fn take(&self) -> Vec<RawKvEvent> {
+                std::mem::take(&mut *self.events.lock().unwrap())
+            }
+        }
+
+        impl RawKvEventSink for RawCapturingSink {
+            fn publish(&self, event: RawKvEvent) -> anyhow::Result<()> {
+                self.events.lock().unwrap().push(event);
+                Ok(())
+            }
+        }
+
+        fn make_mgr_tier_capturing(
+            capacity: usize,
+            block_size: usize,
+        ) -> (KvManager, Arc<TierCapturingSink>) {
+            let sink = Arc::new(TierCapturingSink::default());
+            let publishers = KvEventPublishers::new(Some(sink.clone() as _), None);
+            (
+                KvManager::new_with_event_sink(capacity, block_size, publishers, 0),
+                sink,
+            )
+        }
+
+        fn make_mgr_raw_capturing(
+            capacity: usize,
+            block_size: usize,
+        ) -> (KvManager, Arc<RawCapturingSink>) {
+            let sink = Arc::new(RawCapturingSink::default());
+            let publishers = KvEventPublishers::new(None, Some(sink.clone() as _));
+            (
+                KvManager::new_with_event_sink(capacity, block_size, publishers, 0),
+                sink,
+            )
+        }
+
+        fn attach_test_offload_engine(
+            mgr: &mut KvManager,
+            num_g2_blocks: usize,
+            block_size_tokens: usize,
+        ) {
+            let config = KvbmOffloadConfig {
+                num_g2_blocks,
+                block_size_tokens,
+                block_size_bytes: Some(1_000_000),
+                bandwidth_g1_to_g2_gbps: 1.0,
+                ..Default::default()
+            };
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(1)
+                .enable_all()
+                .build()
+                .unwrap();
+            let mut engine = rt
+                .block_on(MockOffloadEngine::new(config))
+                .expect("engine build");
+            engine.attach_runtime(rt);
+            mgr.attach_new_offload_engine(engine);
+        }
+
+        fn use_full_with_hash(
+            mgr: &mut KvManager,
+            seq_hash: u64,
+            p: PositionalLineageHash,
+            local_hash: BlockHash,
+            token_ids: Vec<u32>,
+        ) -> usize {
+            mgr.process(&MoveBlock::Use(
+                vec![UniqueBlock::FullBlock(seq_hash)],
+                vec![local_hash],
+                vec![p],
+                Some(vec![token_ids]),
+                None,
+            ))
+        }
+
+        fn has_removed(
+            events: &[(StorageTier, KvCacheEvent)],
+            storage_tier: StorageTier,
+            seq_hash: u64,
+        ) -> bool {
+            events.iter().any(|(tier, event)| {
+                *tier == storage_tier
+                    && matches!(
+                        &event.data,
+                        KvCacheEventData::Removed(data)
+                            if data.block_hashes.contains(&ExternalSequenceBlockHash(seq_hash))
+                    )
+            })
+        }
+
+        fn stored_block(
+            events: &[(StorageTier, KvCacheEvent)],
+            storage_tier: StorageTier,
+            seq_hash: u64,
+        ) -> Option<KvCacheStoredBlockData> {
+            events.iter().find_map(|(tier, event)| {
+                if *tier != storage_tier {
+                    return None;
+                }
+                let KvCacheEventData::Stored(data) = &event.data else {
+                    return None;
+                };
+                data.blocks
+                    .iter()
+                    .find(|block| block.block_hash == ExternalSequenceBlockHash(seq_hash))
+                    .cloned()
+            })
+        }
+
+        fn raw_stored_with_token_ids(
+            events: &[RawKvEvent],
+            storage_tier: StorageTier,
+            seq_hash: u64,
+            token_ids: &[u32],
+        ) -> bool {
+            let expected_token_ids = vec![token_ids.to_vec()];
+            events.iter().any(|event| {
+                event.storage_tier == storage_tier
+                    && event.block_token_ids.as_ref() == Some(&expected_token_ids)
+                    && matches!(
+                        &event.event.data,
+                        KvCacheEventData::Stored(data)
+                            if data.blocks.iter().any(|block| {
+                                block.block_hash == ExternalSequenceBlockHash(seq_hash)
+                            })
+                    )
+            })
+        }
 
         #[test]
         fn fresh_manager_has_no_offload_engine() {
@@ -1913,6 +2264,131 @@ mod tests {
                 .expect("engine build");
             mgr.attach_new_offload_engine(engine);
             assert!(mgr.has_offload_engine());
+        }
+
+        #[test]
+        fn g2_completion_publishes_host_pinned_stored_event() {
+            let (mut mgr, sink) = make_mgr_tier_capturing(1, 4);
+            attach_test_offload_engine(&mut mgr, 1, 4);
+
+            assert_eq!(
+                use_full_with_hash(&mut mgr, 1, plh(1), 101, vec![1, 2, 3, 4]),
+                1
+            );
+            deref_full(&mut mgr, 1);
+            sink.clear();
+
+            // Capacity pressure evicts block 1 from G1 and starts G1→G2.
+            assert_eq!(
+                use_full_with_hash(&mut mgr, 2, plh(2), 202, vec![5, 6, 7, 8]),
+                0
+            );
+            let immediate = sink.take();
+            assert!(
+                has_removed(&immediate, StorageTier::Device, 1),
+                "G1 eviction should publish a Device-tier Removed event"
+            );
+            assert!(
+                stored_block(&immediate, StorageTier::HostPinned, 1).is_none(),
+                "G2 Stored must not publish before the transfer completes"
+            );
+
+            let deadline = mgr
+                .earliest_offload_deadline()
+                .expect("G1→G2 offload should expose a completion deadline");
+            mgr.tick_offload_engine(deadline);
+
+            let completed = sink.take();
+            let stored = stored_block(&completed, StorageTier::HostPinned, 1)
+                .expect("G2 completion should publish HostPinned Stored");
+            assert_eq!(stored.tokens_hash, LocalBlockHash(101));
+        }
+
+        #[test]
+        fn g2_eviction_publishes_host_pinned_removed_event() {
+            let (mut mgr, sink) = make_mgr_tier_capturing(1, 4);
+            attach_test_offload_engine(&mut mgr, 1, 4);
+
+            assert_eq!(
+                use_full_with_hash(&mut mgr, 1, plh(1), 101, vec![1, 2, 3, 4]),
+                1
+            );
+            deref_full(&mut mgr, 1);
+            assert_eq!(
+                use_full_with_hash(&mut mgr, 2, plh(2), 202, vec![5, 6, 7, 8]),
+                0
+            );
+            let deadline = mgr
+                .earliest_offload_deadline()
+                .expect("first G1→G2 offload should expose a deadline");
+            mgr.tick_offload_engine(deadline);
+
+            // Now block 1 is resident in G2. Admit block 2 into G1, then evict
+            // it to the one-block G2 tier; this must evict block 1 from G2.
+            assert_eq!(
+                use_full_with_hash(&mut mgr, 2, plh(2), 202, vec![5, 6, 7, 8]),
+                1
+            );
+            deref_full(&mut mgr, 2);
+            sink.clear();
+
+            assert_eq!(
+                use_full_with_hash(&mut mgr, 3, plh(3), 303, vec![9, 10, 11, 12]),
+                0
+            );
+            let deadline = mgr
+                .earliest_offload_deadline()
+                .expect("second G1→G2 offload should expose a deadline");
+            mgr.tick_offload_engine(deadline);
+
+            let events = sink.take();
+            assert!(
+                has_removed(&events, StorageTier::HostPinned, 1),
+                "G2 capacity eviction should publish HostPinned Removed"
+            );
+            assert!(
+                stored_block(&events, StorageTier::HostPinned, 2).is_some(),
+                "second G2 completion should publish HostPinned Stored for block 2"
+            );
+        }
+
+        #[test]
+        fn reoffloaded_swapped_in_block_keeps_token_ids_for_g2_raw_event() {
+            let (mut mgr, sink) = make_mgr_raw_capturing(1, 4);
+            attach_test_offload_engine(&mut mgr, 1, 4);
+
+            let slots = match mgr.reserve_swap_in_destination_slots(1) {
+                SwapInSlotReservation::Reserved(slots) => slots,
+                SwapInSlotReservation::BlockedOnG1Offload => {
+                    panic!("fresh manager should not need G1 offload")
+                }
+                SwapInSlotReservation::NoCapacity => panic!("fresh manager should have capacity"),
+            };
+            let token_ids = vec![1, 2, 3, 4];
+            let entries = vec![SwapInRegistrationBlock {
+                seq_hash: 1,
+                plh: plh(1),
+                local_hash: 101,
+                token_ids: Some(token_ids.clone()),
+            }];
+            let outcome = mgr.register_swapped_in_blocks(entries, None, slots);
+            assert_eq!(outcome.consumed_entries, 1);
+            sink.clear();
+
+            assert_eq!(
+                use_full_with_hash(&mut mgr, 2, plh(2), 202, vec![5, 6, 7, 8]),
+                0
+            );
+            let deadline = mgr
+                .earliest_offload_deadline()
+                .expect("G1→G2 offload should expose a deadline");
+            mgr.tick_offload_engine(deadline);
+
+            let events = sink.take();
+            assert!(
+                raw_stored_with_token_ids(&events, StorageTier::HostPinned, 1, &token_ids),
+                "re-offloaded swapped-in block should preserve token ids for HostPinned raw Stored"
+            );
         }
 
         #[test]

--- a/lib/mocker/src/kv_manager/kvbm_backend.rs
+++ b/lib/mocker/src/kv_manager/kvbm_backend.rs
@@ -496,6 +496,26 @@ impl KvManager {
         }
     }
 
+    /// Hold the G1 prefix that admission used when deciding to swap in only a
+    /// G2 suffix. The returned guards keep those blocks out of the inactive
+    /// eviction pool until the pending swap-in publishes its Device events.
+    #[cfg(feature = "kvbm-offload")]
+    pub(crate) fn try_pin_g1_prefix(
+        &mut self,
+        prefix_plhs: &[PositionalLineageHash],
+    ) -> Option<Vec<ImmutableBlock<G1>>> {
+        if prefix_plhs.is_empty() {
+            return Some(Vec::new());
+        }
+
+        let pins = self.block_manager.match_blocks(prefix_plhs);
+        if pins.len() == prefix_plhs.len() {
+            Some(pins)
+        } else {
+            None
+        }
+    }
+
     /// Emit a `Stored` or `Removed` KV event to the router.
     /// Ported verbatim from the old `vllm_backend::publish_kv_event` to
     /// preserve KV-aware routing semantics (parent_hash chaining, token_ids).

--- a/lib/mocker/src/kvbm_offload/engine.rs
+++ b/lib/mocker/src/kvbm_offload/engine.rs
@@ -6,8 +6,8 @@
 //!
 //! Construction is `async` (velo's `Messenger` needs a short TCP warmup).
 //! The hot-path methods ([`tick`](MockOffloadEngine::tick),
-//! [`enqueue_g1_evictions`](MockOffloadEngine::enqueue_g1_evictions),
-//! [`try_onboard_prefix`](MockOffloadEngine::try_onboard_prefix),
+//! [`prepare_onboard_prefix`](MockOffloadEngine::prepare_onboard_prefix),
+//! [`start_onboard_prefix`](MockOffloadEngine::start_onboard_prefix),
 //! [`earliest_pending_deadline`](MockOffloadEngine::earliest_pending_deadline))
 //! are synchronous. `tick` drives PS completion using `now_ms` supplied by
 //! the caller — live replay feeds wall-clock time, offline replay feeds
@@ -15,12 +15,17 @@
 
 use std::future::Future;
 use std::net::TcpListener;
+use std::pin::Pin;
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll};
 use std::time::Duration;
 
 use anyhow::Result;
+use dynamo_tokens::{BlockHash, SequenceHash as RouterSequenceHash};
+use futures::Stream;
 use futures::stream::{FuturesUnordered, StreamExt};
+use futures::task::noop_waker_ref;
 
 use kvbm_engine::leader::{FindMatchesOptions, InstanceLeader, Leader, StagingMode};
 use kvbm_engine::offload::{
@@ -30,8 +35,10 @@ use kvbm_engine::offload::{
 use kvbm_engine::worker::Worker;
 use kvbm_engine::{BlockId, G1 as EngineG1, G2, SequenceHash};
 use kvbm_logical::blocks::{ImmutableBlock, MutableBlock};
+use kvbm_logical::events::{EventsManager, KvCacheEvent as LogicalKvCacheEvent};
 use kvbm_logical::manager::{BlockManager, FrequencyTrackingCapacity};
 use kvbm_logical::registry::BlockRegistry;
+use rustc_hash::FxHashMap;
 
 use crate::common::protocols::G1 as MockerG1;
 
@@ -42,7 +49,7 @@ use super::worker::MockWorker;
 // mock worker's Notify. The timeout is only a hang guard for pipeline bugs.
 const PIPELINE_BARRIER_TIMEOUT: Duration = Duration::from_secs(1);
 
-/// Handle returned by [`MockOffloadEngine::try_onboard_prefix`]. Scheduler
+/// Handle returned by [`MockOffloadEngine::start_onboard_prefix`]. Scheduler
 /// parks one per deferred request and polls
 /// [`is_complete`](Self::is_complete) each pass; the bit is flipped by
 /// [`MockOffloadEngine::tick`] when the underlying transfer drains from
@@ -83,6 +90,32 @@ impl PreparedSwapIn {
     pub fn block_count(&self) -> usize {
         self.g2_blocks.len()
     }
+}
+
+/// Router-facing metadata for a block that may become resident in G2.
+///
+/// kvbm-engine indexes G2 by [`SequenceHash`] (a positional lineage hash),
+/// while the router protocol needs the external sequence hash plus the local
+/// token hash edge that reconstructs lower-tier continuations.
+#[derive(Clone, Debug)]
+pub(crate) struct G2BlockEventMetadata {
+    pub(crate) seq_hash: RouterSequenceHash,
+    pub(crate) parent_hash: Option<RouterSequenceHash>,
+    pub(crate) local_hash: BlockHash,
+    pub(crate) token_ids: Option<Vec<u32>>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct G2OffloadBlock {
+    pub(crate) block_id: BlockId,
+    pub(crate) plh: SequenceHash,
+    pub(crate) metadata: G2BlockEventMetadata,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum G2RouterEvent {
+    Stored(G2BlockEventMetadata),
+    Removed { seq_hash: RouterSequenceHash },
 }
 
 struct PendingG1ToG2 {
@@ -130,6 +163,8 @@ pub struct MockOffloadEngine {
     registry: Arc<BlockRegistry>,
     g2_manager: Arc<BlockManager<G2>>,
     pending_g1_to_g2: Mutex<Vec<PendingG1ToG2>>,
+    g2_event_stream: Mutex<Pin<Box<dyn Stream<Item = LogicalKvCacheEvent> + Send>>>,
+    g2_event_metadata: Mutex<FxHashMap<SequenceHash, G2BlockEventMetadata>>,
 
     /// Runtime the engine owns for kvbm-engine background pipeline /
     /// session-receiver tasks. Keeping this runtime on the engine lets both
@@ -145,7 +180,9 @@ impl MockOffloadEngine {
     /// runtime and calls this via `block_on`.
     pub async fn new(config: KvbmOffloadConfig) -> Result<Self> {
         let messenger = create_local_messenger().await?;
-        let registry = Arc::new(build_registry());
+        let g2_events_manager = Arc::new(EventsManager::builder().build());
+        let g2_event_stream = Box::pin(g2_events_manager.subscribe());
+        let registry = Arc::new(build_registry(g2_events_manager));
         let g2_manager = Arc::new(build_g2_block_manager(
             config.num_g2_blocks,
             config.block_size_tokens,
@@ -194,6 +231,8 @@ impl MockOffloadEngine {
             registry,
             g2_manager,
             pending_g1_to_g2: Mutex::new(Vec::new()),
+            g2_event_stream: Mutex::new(g2_event_stream),
+            g2_event_metadata: Mutex::new(FxHashMap::default()),
             _runtime: None,
         })
     }
@@ -211,14 +250,68 @@ impl MockOffloadEngine {
         self._runtime = Some(rt);
     }
 
+    fn remember_g2_event_metadata(&self, blocks: &[G2OffloadBlock]) {
+        let mut metadata = self
+            .g2_event_metadata
+            .lock()
+            .expect("G2 event metadata mutex poisoned");
+        for block in blocks {
+            metadata.insert(block.plh, block.metadata.clone());
+        }
+    }
+
+    fn drain_g2_lifecycle_events(&self) -> Vec<LogicalKvCacheEvent> {
+        let mut stream = self
+            .g2_event_stream
+            .lock()
+            .expect("G2 event stream mutex poisoned");
+        let mut events = Vec::new();
+        let mut cx = Context::from_waker(noop_waker_ref());
+        while let Poll::Ready(Some(event)) = stream.as_mut().poll_next(&mut cx) {
+            events.push(event);
+        }
+        events
+    }
+
+    /// Drain kvbm-logical G2 lifecycle notifications and translate them into
+    /// router-tier events. The caller owns event IDs and publishing.
+    pub(crate) fn drain_g2_router_events(&self) -> Vec<G2RouterEvent> {
+        let lifecycle_events = self.drain_g2_lifecycle_events();
+        if lifecycle_events.is_empty() {
+            return Vec::new();
+        }
+
+        let mut metadata = self
+            .g2_event_metadata
+            .lock()
+            .expect("G2 event metadata mutex poisoned");
+        let mut router_events = Vec::new();
+        for event in lifecycle_events {
+            match event {
+                LogicalKvCacheEvent::Create(plh) => {
+                    if let Some(meta) = metadata.get(&plh).cloned() {
+                        router_events.push(G2RouterEvent::Stored(meta));
+                    }
+                }
+                LogicalKvCacheEvent::Remove(plh) => {
+                    if let Some(meta) = metadata.remove(&plh) {
+                        router_events.push(G2RouterEvent::Removed {
+                            seq_hash: meta.seq_hash,
+                        });
+                    }
+                }
+            }
+        }
+        router_events
+    }
+
     async fn with_barrier_timeout<F>(wait: F) -> bool
     where
         F: Future<Output = bool>,
     {
-        match tokio::time::timeout(PIPELINE_BARRIER_TIMEOUT, wait).await {
-            Ok(done) => done,
-            Err(_) => false,
-        }
+        tokio::time::timeout(PIPELINE_BARRIER_TIMEOUT, wait)
+            .await
+            .unwrap_or_default()
     }
 
     fn wait_on_attached_runtime<F>(&self, wait: F) -> bool
@@ -447,28 +540,30 @@ impl MockOffloadEngine {
         self.worker.earliest_finish()
     }
 
-    /// Enqueue a G1→G2 eviction as an `ExternalBlock` reference.
-    pub fn enqueue_g1_eviction(
+    /// Enqueue a burst of G1→G2 evictions with router metadata that will be
+    /// used to publish HostPinned-tier events when G2 lifecycle notifications
+    /// arrive.
+    pub(crate) fn enqueue_g1_evictions_with_metadata(
         &mut self,
-        block_id: BlockId,
-        seq_hash: SequenceHash,
+        evicted: &[G2OffloadBlock],
+        source_slots: Vec<MutableBlock<MockerG1>>,
         now_ms: Option<f64>,
     ) {
-        self.enqueue_g1_evictions(&[(block_id, seq_hash)], now_ms);
-    }
-
-    /// Enqueue a burst of G1→G2 evictions as `ExternalBlock` references.
-    pub fn enqueue_g1_evictions(
-        &mut self,
-        evicted: &[(BlockId, SequenceHash)],
-        now_ms: Option<f64>,
-    ) {
-        self.enqueue_g1_evictions_holding_sources(evicted, Vec::new(), now_ms);
+        if evicted.is_empty() {
+            drop(source_slots);
+            return;
+        }
+        self.remember_g2_event_metadata(evicted);
+        let engine_blocks: Vec<_> = evicted
+            .iter()
+            .map(|block| (block.block_id, block.plh))
+            .collect();
+        self.enqueue_g1_evictions_holding_sources(&engine_blocks, source_slots, now_ms);
     }
 
     /// Enqueue a burst of G1→G2 evictions and hold the reset source slots
     /// until the simulated transfer reaches a terminal state.
-    pub fn enqueue_g1_evictions_holding_sources(
+    fn enqueue_g1_evictions_holding_sources(
         &mut self,
         evicted: &[(BlockId, SequenceHash)],
         source_slots: Vec<MutableBlock<MockerG1>>,
@@ -518,20 +613,6 @@ impl MockOffloadEngine {
         if handle.is_complete() {
             self.prune_releasable_g1_to_g2_sources();
         }
-    }
-
-    /// Attempt to swap in the longest contiguous G2-resident prefix of
-    /// `plhs`. Returns `None` when `plhs` is empty or G2 holds none of
-    /// them. Otherwise pins the matched G2 blocks, reserves the onboard
-    /// bandwidth immediately, and returns a [`SwapInHandle`] that keeps those
-    /// G2 blocks pinned for the transfer's lifetime.
-    pub fn try_onboard_prefix(
-        &mut self,
-        plhs: &[SequenceHash],
-        now_ms: Option<f64>,
-    ) -> Option<SwapInHandle> {
-        let prepared = self.prepare_onboard_prefix(plhs)?;
-        Some(self.start_onboard_prefix(prepared, now_ms))
     }
 
     /// Find and pin the longest G2-resident prefix without reserving G2→G1
@@ -591,19 +672,9 @@ impl MockOffloadEngine {
         }
     }
 
-    #[doc(hidden)]
-    pub fn worker(&self) -> &Arc<MockWorker> {
-        &self.worker
-    }
-
-    #[doc(hidden)]
-    pub fn offload_engine(&self) -> &OffloadEngine {
-        &self.engine
-    }
-
     /// Test-only accessor: integration tests outside this module
     /// register synthetic G2 blocks (allocate → stage → register)
-    /// through it so [`try_onboard_prefix`](Self::try_onboard_prefix)
+    /// through it so [`prepare_onboard_prefix`](Self::prepare_onboard_prefix)
     /// has something to match.
     #[cfg(test)]
     pub(crate) fn g2_manager(&self) -> &Arc<BlockManager<G2>> {
@@ -643,9 +714,10 @@ async fn create_local_messenger() -> Result<Arc<velo::Messenger>> {
     Ok(messenger)
 }
 
-fn build_registry() -> BlockRegistry {
+fn build_registry(events_manager: Arc<EventsManager>) -> BlockRegistry {
     BlockRegistry::builder()
         .frequency_tracker(FrequencyTrackingCapacity::Medium.create_tracker())
+        .event_manager(events_manager)
         .build()
 }
 
@@ -674,9 +746,9 @@ mod tests {
             .await
             .expect("construction should succeed");
 
-        assert!(engine.offload_engine().has_g1_to_g2());
-        assert!(!engine.offload_engine().has_g2_to_g3());
-        assert!(!engine.offload_engine().has_g2_to_g4());
+        assert!(engine.engine.has_g1_to_g2());
+        assert!(!engine.engine.has_g2_to_g3());
+        assert!(!engine.engine.has_g2_to_g4());
         assert_eq!(engine.earliest_pending_deadline(), None);
     }
 
@@ -705,15 +777,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn try_onboard_prefix_empty_input_returns_none() {
+    async fn prepare_onboard_prefix_empty_input_returns_none() {
         let mut engine = MockOffloadEngine::new(KvbmOffloadConfig::default())
             .await
             .unwrap();
-        assert!(engine.try_onboard_prefix(&[], None).is_none());
+        assert!(engine.prepare_onboard_prefix(&[]).is_none());
     }
 
     #[tokio::test]
-    async fn try_onboard_prefix_returns_none_when_g2_empty() {
+    async fn prepare_onboard_prefix_returns_none_when_g2_empty() {
         use dynamo_tokens::PositionalLineageHash;
         let mut engine = MockOffloadEngine::new(KvbmOffloadConfig::default())
             .await
@@ -721,17 +793,17 @@ mod tests {
         let hashes: Vec<SequenceHash> = (0..5)
             .map(|i| PositionalLineageHash::new(i as u64, None, 0))
             .collect();
-        assert!(engine.try_onboard_prefix(&hashes, None).is_none());
+        assert!(engine.prepare_onboard_prefix(&hashes).is_none());
     }
 
     /// End-to-end: register a G2 block directly in the engine's
-    /// `g2_manager`, call `try_onboard_prefix`, and verify (a) the handle
-    /// is produced, (b) the reservation is reflected in
+    /// `g2_manager`, call the prepare/start swap-in path, and verify (a) the
+    /// handle is produced, (b) the reservation is reflected in
     /// `earliest_pending_deadline`, (c) `tick` past the finish time
     /// flips the completion bit, and (d) the handle pins the G2 block
     /// via RAII.
     #[tokio::test]
-    async fn try_onboard_prefix_pins_g2_blocks_until_handle_drops() {
+    async fn start_onboard_prefix_pins_g2_blocks_until_handle_drops() {
         use dynamo_tokens::PositionalLineageHash;
         use kvbm_logical::MutableBlock;
         let config = KvbmOffloadConfig {
@@ -756,9 +828,10 @@ mod tests {
             .expect("G2 stage");
         drop(engine.g2_manager.register_block(complete));
 
-        let handle = engine
-            .try_onboard_prefix(&[plh], Some(0.0))
-            .expect("G2 prefix match must produce a handle");
+        let prepared = engine
+            .prepare_onboard_prefix(&[plh])
+            .expect("G2 prefix match must produce a prepared swap-in");
+        let handle = engine.start_onboard_prefix(prepared, Some(0.0));
         assert_eq!(handle.block_count(), 1);
         assert!(!handle.is_complete());
 

--- a/lib/mocker/src/kvbm_offload/engine.rs
+++ b/lib/mocker/src/kvbm_offload/engine.rs
@@ -29,14 +29,15 @@ use futures::task::noop_waker_ref;
 
 use kvbm_engine::leader::{FindMatchesOptions, InstanceLeader, Leader, StagingMode};
 use kvbm_engine::offload::{
-    ExternalBlock, OffloadEngine, PipelineBuilder, PresenceFilter, SourceBlocks, TransferHandle,
-    TransferStatus,
+    ExternalBlock, OffloadEngine, PendingTracker, PipelineBuilder, PresenceFilter, SourceBlocks,
+    TransferHandle, TransferStatus,
 };
 use kvbm_engine::worker::Worker;
 use kvbm_engine::{BlockId, G1 as EngineG1, G2, SequenceHash};
 use kvbm_logical::blocks::{ImmutableBlock, MutableBlock};
 use kvbm_logical::events::{EventsManager, KvCacheEvent as LogicalKvCacheEvent};
 use kvbm_logical::manager::{BlockManager, FrequencyTrackingCapacity};
+use kvbm_logical::pools::BlockDuplicationPolicy;
 use kvbm_logical::registry::BlockRegistry;
 use rustc_hash::FxHashMap;
 
@@ -209,10 +210,12 @@ impl MockOffloadEngine {
                 .build()?,
         );
 
+        let g1_to_g2_pending = Arc::new(PendingTracker::new());
+        let g1_to_g2_presence = PresenceFilter::<EngineG1, G2>::new(registry.clone())
+            .with_pending_tracker(g1_to_g2_pending.clone());
         let g1_to_g2_pipeline = PipelineBuilder::<EngineG1, G2>::new()
-            .policy(Arc::new(PresenceFilter::<EngineG1, G2>::new(
-                registry.clone(),
-            )))
+            .policy(Arc::new(g1_to_g2_presence))
+            .pending_tracker(g1_to_g2_pending)
             .batch_size(config.offload_batch_size)
             .max_concurrent_transfers(config.offload_batch_size)
             .build();
@@ -730,6 +733,7 @@ fn build_g2_block_manager(
         .block_count(block_count)
         .block_size(block_size_tokens)
         .registry(registry.clone())
+        .duplication_policy(BlockDuplicationPolicy::Reject)
         .with_lineage_backend()
         .build()
         .expect("BlockManager<G2> should build with valid config")

--- a/lib/mocker/src/kvbm_offload/mod.rs
+++ b/lib/mocker/src/kvbm_offload/mod.rs
@@ -17,5 +17,6 @@ pub mod worker;
 
 pub use bandwidth_sharing_model::{BandwidthSharingModel, TransferId};
 pub use config::KvbmOffloadConfig;
+pub(crate) use engine::{G2BlockEventMetadata, G2OffloadBlock, G2RouterEvent};
 pub use engine::{MockOffloadEngine, SwapInHandle};
 pub use worker::{MockWorker, TransferDirection};

--- a/lib/mocker/src/kvbm_offload/worker.rs
+++ b/lib/mocker/src/kvbm_offload/worker.rs
@@ -158,8 +158,8 @@ impl MockWorker {
     }
 
     /// Update the worker's notion of current simulation time. Engine calls
-    /// this at the start of `tick(now_ms)` and before every `enqueue_*` /
-    /// `try_onboard_prefix` so transfer reservation reads a fresh `now_ms`
+    /// this at the start of `tick(now_ms)` and before every enqueue/start
+    /// operation so transfer reservation reads a fresh `now_ms`
     /// inside `execute_local_transfer`.
     pub fn set_now_ms(&self, now_ms: f64) {
         self.now_us.store(ms_to_us(now_ms), Ordering::Release);

--- a/lib/mocker/src/replay/artifacts.rs
+++ b/lib/mocker/src/replay/artifacts.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use dynamo_kv_router::protocols::KvCacheEvent;
+use dynamo_kv_router::protocols::{KvCacheEvent, StorageTier};
 use uuid::Uuid;
 
 use crate::common::protocols::OutputSignal;
@@ -26,6 +26,7 @@ pub struct ReplayTimedOutputSignal {
 #[derive(Debug, Clone)]
 pub struct ReplayTimedKvEvent {
     pub event: KvCacheEvent,
+    pub storage_tier: StorageTier,
     pub timestamp_us: u64,
 }
 

--- a/lib/mocker/src/replay/offline/components/router.rs
+++ b/lib/mocker/src/replay/offline/components/router.rs
@@ -99,6 +99,10 @@ impl SyncReplayIndexer {
     }
 
     fn apply_event(&mut self, event: RouterEvent) -> Result<()> {
+        // TODO: support lower tier events in replay indexer
+        if !event.storage_tier.is_gpu() {
+            return Ok(());
+        }
         self.tree.apply_event(event).map_err(Into::into)
     }
 
@@ -666,9 +670,13 @@ mod tests {
 
     use dynamo_kv_router::PrefillLoadEstimator;
     use dynamo_kv_router::config::{KvRouterConfig, RouterPrefillLoadModel};
+    use dynamo_kv_router::protocols::{
+        ExternalSequenceBlockHash, KvCacheEvent, KvCacheEventData, KvCacheStoreData,
+        KvCacheStoredBlockData, LocalBlockHash, RouterEvent, StorageTier, WorkerId,
+    };
     use uuid::Uuid;
 
-    use super::{OfflineReplayRouter, WorkerAdmission};
+    use super::{OfflineReplayRouter, SyncReplayIndexer, WorkerAdmission};
     use crate::common::protocols::{DirectRequest, MockEngineArgs};
     use crate::replay::ReplayPrefillLoadEstimator;
 
@@ -730,6 +738,46 @@ mod tests {
             dp_rank: 0,
             arrival_timestamp_ms: Some(0.0),
         }
+    }
+
+    fn store_event(
+        worker_id: WorkerId,
+        event_id: u64,
+        tokens_hash: u64,
+        storage_tier: StorageTier,
+    ) -> RouterEvent {
+        RouterEvent::with_storage_tier(
+            worker_id,
+            KvCacheEvent {
+                event_id,
+                data: KvCacheEventData::Stored(KvCacheStoreData {
+                    parent_hash: None,
+                    start_position: None,
+                    blocks: vec![KvCacheStoredBlockData {
+                        block_hash: ExternalSequenceBlockHash(event_id),
+                        tokens_hash: LocalBlockHash(tokens_hash),
+                        mm_extra_info: None,
+                    }],
+                }),
+                dp_rank: 0,
+            },
+            storage_tier,
+        )
+    }
+
+    #[test]
+    fn lower_tier_events_do_not_enter_offline_primary_index() {
+        let mut indexer = SyncReplayIndexer::new(64);
+
+        indexer
+            .apply_event(store_event(7, 1, 101, StorageTier::HostPinned))
+            .unwrap();
+        assert_eq!(indexer.debug_snapshot().total_cached_blocks, 0);
+
+        indexer
+            .apply_event(store_event(7, 2, 101, StorageTier::Device))
+            .unwrap();
+        assert_eq!(indexer.debug_snapshot().total_cached_blocks, 1);
     }
 
     #[test]

--- a/lib/mocker/src/replay/offline/entrypoints.rs
+++ b/lib/mocker/src/replay/offline/entrypoints.rs
@@ -86,6 +86,7 @@ pub(crate) fn generate_trace_worker_artifacts(
         artifacts
             .kv_events
             .extend(pass.kv_events.into_iter().map(|event| ReplayTimedKvEvent {
+                storage_tier: event.storage_tier,
                 event: event.event,
                 timestamp_us: kv_event_timestamp_us,
             }));

--- a/lib/mocker/src/replay/online/router.rs
+++ b/lib/mocker/src/replay/online/router.rs
@@ -11,7 +11,9 @@ use dynamo_kv_router::config::KvRouterConfig;
 use dynamo_kv_router::indexer::{
     KvIndexer, KvIndexerInterface, KvIndexerMetrics, ThreadPoolIndexer,
 };
-use dynamo_kv_router::protocols::{BlockHashOptions, OverlapScores, RouterEvent, WorkerId};
+use dynamo_kv_router::protocols::{
+    BlockHashOptions, OverlapScores, RouterEvent, StorageTier, WorkerId,
+};
 use dynamo_kv_router::scheduling::TierOverlapBlocks;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
@@ -34,6 +36,10 @@ enum ReplayIndexer {
 
 impl ReplayIndexer {
     async fn apply_event(&self, event: RouterEvent) {
+        // TODO: support lower tier events in replay indexer
+        if !event.storage_tier.is_gpu() {
+            return;
+        }
         match self {
             Self::Single(indexer) => indexer.apply_event(event).await,
             Self::Concurrent(indexer) => indexer.apply_event(event).await,
@@ -93,6 +99,20 @@ impl KvCacheEventSink for ReplayKvEventSink {
     fn publish(&self, event: dynamo_kv_router::protocols::KvCacheEvent) -> anyhow::Result<()> {
         self.event_tx
             .send(RouterEvent::new(self.worker_id, event))
+            .map_err(|_| anyhow!("replay router event channel closed"))
+    }
+
+    fn publish_with_storage_tier(
+        &self,
+        event: dynamo_kv_router::protocols::KvCacheEvent,
+        storage_tier: StorageTier,
+    ) -> anyhow::Result<()> {
+        self.event_tx
+            .send(RouterEvent::with_storage_tier(
+                self.worker_id,
+                event,
+                storage_tier,
+            ))
             .map_err(|_| anyhow!("replay router event channel closed"))
     }
 }
@@ -363,5 +383,69 @@ impl ReplayRouter {
             Self::RoundRobin(_) => Vec::new(),
             Self::Kv(router) => router.debug_potential_loads(isl_tokens, track_prefill_tokens),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dynamo_kv_router::protocols::{
+        ExternalSequenceBlockHash, KvCacheEvent, KvCacheEventData, KvCacheStoreData,
+        KvCacheStoredBlockData, LocalBlockHash, StorageTier, WorkerWithDpRank,
+        compute_block_hash_for_seq,
+    };
+
+    use super::*;
+
+    fn store_event(
+        worker_id: WorkerId,
+        event_id: u64,
+        tokens_hash: LocalBlockHash,
+        storage_tier: StorageTier,
+    ) -> RouterEvent {
+        RouterEvent::with_storage_tier(
+            worker_id,
+            KvCacheEvent {
+                event_id,
+                data: KvCacheEventData::Stored(KvCacheStoreData {
+                    parent_hash: None,
+                    start_position: None,
+                    blocks: vec![KvCacheStoredBlockData {
+                        block_hash: ExternalSequenceBlockHash(event_id),
+                        tokens_hash,
+                        mm_extra_info: None,
+                    }],
+                }),
+                dp_rank: 0,
+            },
+            storage_tier,
+        )
+    }
+
+    #[tokio::test]
+    async fn replay_indexer_ignores_lower_tier_events_for_primary_overlap() {
+        let worker = WorkerWithDpRank::new(7, 0);
+        let tokens = vec![1, 2, 3, 4];
+        let tokens_hash = compute_block_hash_for_seq(&tokens, 4, BlockHashOptions::default())[0];
+        let indexer = create_replay_indexer(4, 1);
+
+        indexer
+            .apply_event(store_event(7, 1, tokens_hash, StorageTier::HostPinned))
+            .await;
+        indexer.flush().await;
+        let matches = indexer
+            .find_matches_for_request(&tokens, None)
+            .await
+            .unwrap();
+        assert_eq!(matches.scores.get(&worker), None);
+
+        indexer
+            .apply_event(store_event(7, 2, tokens_hash, StorageTier::Device))
+            .await;
+        indexer.flush().await;
+        let matches = indexer
+            .find_matches_for_request(&tokens, None)
+            .await
+            .unwrap();
+        assert_eq!(matches.scores.get(&worker), Some(&1));
     }
 }

--- a/lib/mocker/src/scheduler/kv_event_sink.rs
+++ b/lib/mocker/src/scheduler/kv_event_sink.rs
@@ -4,7 +4,7 @@
 use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
-use dynamo_kv_router::protocols::{KvCacheEvent, RouterEvent, WorkerId};
+use dynamo_kv_router::protocols::{KvCacheEvent, RouterEvent, StorageTier, WorkerId};
 
 use crate::common::protocols::{
     ForwardPassSnapshot, FpmPublisher, KvCacheEventSink, KvEventPublishers, RawKvEvent,
@@ -44,6 +44,19 @@ impl KvCacheEventSink for RouterEventCaptureSink {
         self.buffer.push(RouterEvent::new(self.worker_id, event));
         Ok(())
     }
+
+    fn publish_with_storage_tier(
+        &self,
+        event: KvCacheEvent,
+        storage_tier: StorageTier,
+    ) -> Result<()> {
+        self.buffer.push(RouterEvent::with_storage_tier(
+            self.worker_id,
+            event,
+            storage_tier,
+        ));
+        Ok(())
+    }
 }
 
 /// Returns the capture buffer plus a sink handle that can be passed into a
@@ -65,6 +78,7 @@ pub(crate) fn capture_router_event_sink(
 pub(crate) struct DeferredKvPublish {
     pub(crate) event: KvCacheEvent,
     pub(crate) block_token_ids: Option<Vec<Vec<u32>>>,
+    pub(crate) storage_tier: StorageTier,
 }
 
 /// Captures raw KV publishes for the live `python -m dynamo.mocker` and online
@@ -79,10 +93,16 @@ pub(crate) struct DeferredKvPublishBuffer {
 }
 
 impl DeferredKvPublishBuffer {
-    pub(crate) fn push(&self, event: KvCacheEvent, block_token_ids: Option<Vec<Vec<u32>>>) {
+    pub(crate) fn push(
+        &self,
+        event: KvCacheEvent,
+        block_token_ids: Option<Vec<Vec<u32>>>,
+        storage_tier: StorageTier,
+    ) {
         self.events.lock().unwrap().push(DeferredKvPublish {
             event,
             block_token_ids,
+            storage_tier,
         });
     }
 
@@ -100,7 +120,16 @@ struct DeferredKvEventSink {
 
 impl KvCacheEventSink for DeferredKvEventSink {
     fn publish(&self, event: KvCacheEvent) -> Result<()> {
-        self.buffer.push(event, None);
+        self.buffer.push(event, None, StorageTier::Device);
+        Ok(())
+    }
+
+    fn publish_with_storage_tier(
+        &self,
+        event: KvCacheEvent,
+        storage_tier: StorageTier,
+    ) -> Result<()> {
+        self.buffer.push(event, None, storage_tier);
         Ok(())
     }
 }
@@ -116,6 +145,7 @@ impl RawKvEventSink for DeferredRawKvEventSink {
         if let Some(last) = events.last_mut()
             && last.event.event_id == event.event.event_id
             && last.event.dp_rank == event.event.dp_rank
+            && last.storage_tier == event.storage_tier
         {
             last.block_token_ids = event.block_token_ids;
             return Ok(());
@@ -124,6 +154,7 @@ impl RawKvEventSink for DeferredRawKvEventSink {
         events.push(DeferredKvPublish {
             event: event.event,
             block_token_ids: event.block_token_ids,
+            storage_tier: event.storage_tier,
         });
         Ok(())
     }
@@ -154,7 +185,11 @@ pub(crate) fn publish_deferred_kv_events(
     events: Vec<DeferredKvPublish>,
 ) {
     for event in events {
-        if let Err(error) = sinks.publish(event.event, event.block_token_ids.as_deref()) {
+        if let Err(error) = sinks.publish_with_storage_tier(
+            event.event,
+            event.block_token_ids.as_deref(),
+            event.storage_tier,
+        ) {
             tracing::warn!("Failed to forward buffered KV event: {error}");
         }
     }

--- a/lib/mocker/src/scheduler/test_utils.rs
+++ b/lib/mocker/src/scheduler/test_utils.rs
@@ -10,7 +10,8 @@ use dynamo_kv_router::indexer::{
     METRIC_STATUS_OK, METRIC_STATUS_PARENT_NOT_FOUND, METRIC_WARNING_DUPLICATE_STORE,
 };
 use dynamo_kv_router::protocols::{
-    KvCacheEvent, KvCacheEventData, LocalBlockHash, RouterEvent, WorkerId, WorkerWithDpRank,
+    KvCacheEvent, KvCacheEventData, LocalBlockHash, RouterEvent, StorageTier, WorkerId,
+    WorkerWithDpRank,
 };
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
@@ -188,6 +189,20 @@ impl KvCacheEventSink for TestKvEventSink {
     fn publish(&self, event: KvCacheEvent) -> anyhow::Result<()> {
         self.event_tx
             .send(RouterEvent::new(self.worker_id, event))
+            .map_err(|_| anyhow!("router test event channel closed"))
+    }
+
+    fn publish_with_storage_tier(
+        &self,
+        event: KvCacheEvent,
+        storage_tier: StorageTier,
+    ) -> anyhow::Result<()> {
+        self.event_tx
+            .send(RouterEvent::with_storage_tier(
+                self.worker_id,
+                event,
+                storage_tier,
+            ))
             .map_err(|_| anyhow!("router test event channel closed"))
     }
 }

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use dynamo_kv_router::protocols::WorkerId;
 use dynamo_tokens::blocks::UniqueBlock;
 #[cfg(feature = "kvbm-offload")]
-use kvbm_logical::MutableBlock;
+use kvbm_logical::{ImmutableBlock, MutableBlock};
 use rustc_hash::{FxHashMap, FxHashSet};
 use tokio::sync::mpsc;
 use uuid::Uuid;
@@ -219,12 +219,14 @@ impl SchedulerState {
 /// cached in G1 at park time; the swap-in covers the next
 /// `handle.block_count()` blocks starting at that offset. We need this
 /// to register the right slice of the request's PLHs into G1 inactive
-/// after the transfer completes.
+/// after the transfer completes. `_prefix_pins` keeps that cached prefix
+/// resident until the suffix can publish Device-tier Stored events against it.
 #[cfg(feature = "kvbm-offload")]
 pub(crate) struct AwaitingSwapIn {
     pub(crate) uuid: Uuid,
     pub(crate) handle: crate::kvbm_offload::SwapInHandle,
     pub(crate) destination_slots: Vec<MutableBlock<G1>>,
+    pub(crate) _prefix_pins: Vec<ImmutableBlock<G1>>,
     pub(crate) skip_blocks: usize,
 }
 
@@ -489,6 +491,10 @@ impl VllmCore {
         if remaining_plhs.is_empty() {
             return SwapInAdmissionAttempt::NoHit;
         }
+        let prefix_pins = match self.kv_manager.try_pin_g1_prefix(&plhs[..skip_blocks]) {
+            Some(pins) => pins,
+            None => return SwapInAdmissionAttempt::NoHit,
+        };
         let (handle, destination_slots) = match self
             .kv_manager
             .try_batch_swap_in(remaining_plhs, Some(now_ms))
@@ -507,6 +513,7 @@ impl VllmCore {
             uuid,
             handle,
             destination_slots,
+            _prefix_pins: prefix_pins,
             skip_blocks,
         });
         SwapInAdmissionAttempt::Parked

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -21,6 +21,8 @@ use crate::common::protocols::{
 use crate::common::sequence::ActiveSequence;
 use crate::common::utils::compute_prefill_handoff_delay_ms;
 use crate::kv_manager::KvManager;
+#[cfg(feature = "kvbm-offload")]
+use crate::kv_manager::kvbm_backend::SwapInRegistrationBlock;
 use crate::replay::TraceCollector;
 use crate::scheduler::{
     AdmissionEvent, CapturedRouterEventBuffer, EnginePassResult, ForwardPassSnapshot,
@@ -409,14 +411,21 @@ impl VllmCore {
             let unique = request.sequence.unique_blocks();
             let plhs = request.sequence.positional_lineage_hashes();
             let local_hashes = request.sequence.block_hashes();
+            let token_ids = request.sequence.block_token_ids();
             unique
                 .iter()
                 .zip(plhs.iter())
                 .zip(local_hashes.iter())
+                .zip(token_ids.iter())
                 .skip(skip)
                 .take(count)
-                .filter_map(|((block, plh), local)| match block {
-                    UniqueBlock::FullBlock(seq_hash) => Some((*seq_hash, *plh, *local)),
+                .filter_map(|(((block, plh), local), token_ids)| match block {
+                    UniqueBlock::FullBlock(seq_hash) => Some(SwapInRegistrationBlock {
+                        seq_hash: *seq_hash,
+                        plh: *plh,
+                        local_hash: *local,
+                        token_ids: Some(token_ids.clone()),
+                    }),
                     UniqueBlock::PartialBlock(_) => None,
                 })
                 .collect()
@@ -434,14 +443,12 @@ impl VllmCore {
                 _ => None,
             }
         };
-        let outcome = self.kv_manager.register_swapped_in_blocks(
-            &entries,
-            parent_hash,
-            aws.destination_slots,
-        );
+        let entries_len = entries.len();
+        let outcome =
+            self.kv_manager
+                .register_swapped_in_blocks(entries, parent_hash, aws.destination_slots);
         debug_assert_eq!(
-            outcome.consumed_entries,
-            entries.len(),
+            outcome.consumed_entries, entries_len,
             "reserved destination slots should cover every swapped-in block"
         );
         self.state.prepend_waiting(aws.uuid);
@@ -619,10 +626,10 @@ impl VllmCore {
         // but the worker still has blocked requests or pending source-slot
         // releases, so `is_done()` never triggers.
         #[cfg(feature = "kvbm-offload")]
-        if end_ms <= now_ms {
-            if let Some(deadline) = self.kv_manager.earliest_offload_deadline() {
-                end_ms = deadline.max(now_ms);
-            }
+        if end_ms <= now_ms
+            && let Some(deadline) = self.kv_manager.earliest_offload_deadline()
+        {
+            end_ms = deadline.max(now_ms);
         }
 
         let fpm = self.compute_fpm(&scheduled, (end_ms - now_ms) / 1000.0);

--- a/lib/mocker/src/scheduler/vllm/tests.rs
+++ b/lib/mocker/src/scheduler/vllm/tests.rs
@@ -1391,7 +1391,7 @@ mod offload {
             .sequence
             .positional_lineage_hashes();
         assert_eq!(plhs.len(), 1, "test request should have one full block");
-        seed_g2_blocks(engine.g2_manager(), &plhs);
+        seed_g2_blocks(engine.g2_manager(), plhs);
 
         core.kv_manager.attach_new_offload_engine(engine);
         let mut collector = crate::replay::TraceCollector::default();
@@ -1473,7 +1473,7 @@ mod offload {
             .sequence
             .positional_lineage_hashes();
         assert_eq!(plhs.len(), 1, "test request should have one full block");
-        seed_g2_blocks(engine.g2_manager(), &plhs);
+        seed_g2_blocks(engine.g2_manager(), plhs);
         core.kv_manager.attach_new_offload_engine(engine);
 
         let mut collector = crate::replay::TraceCollector::default();
@@ -1649,7 +1649,7 @@ mod offload {
             .positional_lineage_hashes();
         assert!(!plhs.is_empty(), "test sequence must have full blocks");
 
-        seed_g2_blocks(engine.g2_manager(), &plhs);
+        seed_g2_blocks(engine.g2_manager(), plhs);
         core.kv_manager.attach_new_offload_engine(engine);
 
         // Pass 1 (t=0.0): admission detects G2 prefix, parks the
@@ -1698,7 +1698,7 @@ mod offload {
     /// Replaying the same synthetic G2-offload trace twice with the same
     /// `now_ms` sequence must produce byte-identical scheduler behaviour.
     /// Live/offline mode is a caller concern: the engine sees only the
-    /// timestamps passed into `tick` / `try_onboard_prefix`.
+    /// timestamps passed into `tick` and swap-in start.
     #[tokio::test]
     async fn equivalence_replayed_twice_with_g2_offload() {
         use std::sync::{Arc, Mutex};
@@ -1799,7 +1799,7 @@ mod offload {
                 .unwrap()
                 .sequence
                 .positional_lineage_hashes();
-            seed_g2_blocks(engine.g2_manager(), &plhs);
+            seed_g2_blocks(engine.g2_manager(), plhs);
             core.kv_manager.attach_new_offload_engine(engine);
 
             // Drive 5 passes at well-separated `now_ms`. Pass 1 parks

--- a/lib/mocker/src/scheduler/vllm/tests.rs
+++ b/lib/mocker/src/scheduler/vllm/tests.rs
@@ -1300,7 +1300,7 @@ mod offload {
     use kvbm_logical::manager::BlockManager;
     use uuid::Uuid;
 
-    use crate::common::protocols::{DirectRequest, MockEngineArgs};
+    use crate::common::protocols::{DirectRequest, MockEngineArgs, MoveBlock};
     use crate::kvbm_offload::{KvbmOffloadConfig, MockOffloadEngine};
 
     use super::super::core::VllmCore;
@@ -1497,6 +1497,75 @@ mod offload {
         assert!(
             core.state.waiting.contains(&cold_uuid),
             "cold request should remain waiting for G1 capacity"
+        );
+    }
+
+    /// A partial G2 swap-in is scheduled from the first G1 miss onward. The
+    /// already-cached G1 prefix must stay pinned while the transfer is pending,
+    /// otherwise G1 eviction can remove the parent block before the suffix
+    /// publishes its Device-tier `Stored` event.
+    #[tokio::test]
+    async fn partial_g2_swap_in_pins_cached_g1_prefix() {
+        let block_size = 4;
+        let args = MockEngineArgs::builder()
+            .num_gpu_blocks(3)
+            .block_size(block_size)
+            .max_num_batched_tokens(Some(64))
+            .max_num_seqs(Some(4))
+            .enable_chunked_prefill(true)
+            .enable_prefix_caching(true)
+            .speedup_ratio(0.0)
+            .build()
+            .unwrap();
+        let mut core = VllmCore::new(args);
+        let config = KvbmOffloadConfig {
+            block_size_tokens: block_size,
+            block_size_bytes: Some(1_000_000),
+            bandwidth_g2_to_g1_gbps: 1.0,
+            ..Default::default()
+        };
+        let engine = MockOffloadEngine::new(config).await.expect("engine build");
+        engine.tick(0.0);
+
+        let uuid = Uuid::new_v4();
+        core.receive(DirectRequest {
+            tokens: (0..(block_size * 3) as u32).collect(),
+            max_output_tokens: 2,
+            uuid: Some(uuid),
+            dp_rank: 0,
+            arrival_timestamp_ms: None,
+        });
+        let (prefix_signal, plhs) = {
+            let request = core.state.requests.get(&uuid).unwrap();
+            (
+                request
+                    .sequence
+                    .prepare_allocation(block_size * 2)
+                    .expect("prefix allocation signal"),
+                request.sequence.positional_lineage_hashes().to_vec(),
+            )
+        };
+        let prefix_blocks = match &prefix_signal {
+            MoveBlock::Use(blocks, ..) => blocks.clone(),
+            _ => panic!("expected prefix Use signal"),
+        };
+        assert_eq!(core.kv_manager.process(&prefix_signal), 2);
+        assert_eq!(core.kv_manager.process(&MoveBlock::Deref(prefix_blocks)), 1);
+
+        assert_eq!(plhs.len(), 3, "test request should have three full blocks");
+        seed_g2_blocks(engine.g2_manager(), &plhs[2..]);
+        core.kv_manager.attach_new_offload_engine(engine);
+
+        let mut collector = crate::replay::TraceCollector::default();
+        let pass = core.execute_pass(&mut collector, 0.0);
+
+        assert_eq!(pass.admissions.len(), 0);
+        assert_eq!(core.requests_awaiting_swap_in.len(), 1);
+        assert_eq!(core.requests_awaiting_swap_in[0]._prefix_pins.len(), 2);
+        assert_eq!(
+            core.kv_manager.num_active_blocks(),
+            3,
+            "two cached prefix blocks plus one destination slot must be pinned"
         );
     }
 


### PR DESCRIPTION
#### Overview:

Publish tiered KV events for G2 offload:

- When blocks land in G2, the mocker now publishes `HostPinned` `Stored` events. 
- When blocks leave G2, it publishes `HostPinned` `Removed` event.

Replay does **not** use lower-tier/G2 events for scheduling decisions yet, because those indexers are not lower-tier aware. Follow-up PRs will be needed  to update`SyncReplayIndexer` and `ReplayIndexer`

#### Details:

- Added tier-aware KV event publishing:
  - `KvCacheEventSink::publish_with_storage_tier(...)`
  - `KvEventPublishers::publish_with_storage_tier(...)`
  - `RawKvEvent.storage_tier`
  - default `publish(...)` remains `StorageTier::Device`
- Added canonical `StorageTier::to_kv_medium()` next to `from_kv_medium()` and use it for ZMQ raw events.
  - `Device` still omits `medium`
  - `HostPinned` publishes `CPU_PINNED`
- Updated `KvManager` to publish:
  - `Device Removed` when a block leaves G1
  - `HostPinned Stored` when the G1->G2 transfer completes
  - `HostPinned Removed` when G2 evicts/removes the block
- Changed swap-in registration to carry `SwapInRegistrationBlock` metadata, including token ids, as re-offloaded swapped-in blocks need.

#### Where should the reviewer start?

- `lib/mocker/src/kv_manager/kvbm_backend.rs`
  - `publish_g2_router_events`
  - G1 eviction handling
  - swap-in registration/token-id preservation
- `lib/mocker/src/kvbm_offload/engine.rs`
  - G2 metadata tracking
  - G2 lifecycle event draining
- `lib/mocker/src/common/protocols.rs` and `lib/llm/src/kv_router/publisher/mod.rs`
  - tier-aware event publishing surface
- Tests in `kvbm_backend.rs`
  - `g2_completion_publishes_host_pinned_stored_event`
  - `g2_eviction_publishes_host_pinned_removed_event`
  - `reoffloaded_swapped_in_block_keeps_token_ids_for_g2_raw_event`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: https://github.com/ai-dynamo/dynamo/issues/8190, https://github.com/ai-dynamo/dynamo/pull/8184

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8961" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented storage-tier awareness for KV cache event publishing, enabling events to be associated with specific storage tiers (device memory or host-pinned) and properly routed based on tier.

* **Tests**
  * Extended testing to validate storage-tier event publishing, filtering, and proper event categorization by tier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->