### PR TITLE
fix: bound retry + per-engine FPM port

### DIFF
--- a/deploy/operator/internal/dynamo/failover.go
+++ b/deploy/operator/internal/dynamo/failover.go
@@ -80,12 +80,16 @@ func buildEngineContainer(base corev1.Container, engineID int, systemPort int) c
 	}
 
 	// Env vars to remove: replaced by failover-specific values or intentionally omitted.
+	// DYN_FORWARDPASS_METRIC_PORT is removed here so we can override it per engine
+	// below — both engines share the pod network namespace, so the base value
+	// stamped by component_worker.go collides on bind.
 	removeSet := map[string]bool{
 		"DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS": true,
 		"DYN_SYSTEM_PORT":                       true,
 		"DYN_SYSTEM_ENABLED":                    true,
 		"DYN_HEALTH_CHECK_ENABLED":              true,
 		"CONTAINER_NAME":                        true,
+		"DYN_FORWARDPASS_METRIC_PORT":           true,
 	}
 
 	var filtered []corev1.EnvVar
@@ -103,6 +107,10 @@ func buildEngineContainer(base corev1.Container, engineID int, systemPort int) c
 		{Name: "DYN_SYSTEM_STARTING_HEALTH_STATUS", Value: "notready"},
 		{Name: "DYN_SYSTEM_PORT", Value: strconv.Itoa(systemPort)},
 		{Name: "DYN_SYSTEM_ENABLED", Value: "true"},
+		// Per-engine FPM port. data_parallel_index is 0 for both failover
+		// engines (orthogonal axis), so without this override both bind to
+		// the same base port and engine-1 fails with EADDRINUSE.
+		{Name: "DYN_FORWARDPASS_METRIC_PORT", Value: strconv.Itoa(commonconsts.DynamoFPMBasePort + engineID)},
 	}
 	engine.Env = append(filtered, failoverEnvs...)
 

--- a/lib/gpu_memory_service/cli/args.py
+++ b/lib/gpu_memory_service/cli/args.py
@@ -64,8 +64,9 @@ def parse_args() -> Config:
     parser.add_argument(
         "--alloc-retry-timeout",
         type=float,
-        default=None,
-        help="Optional max seconds to wait for allocation retries before failing (default: wait indefinitely).",
+        default=60.0,
+        help="Max seconds to wait for allocation retries before failing (default: 60.0). "
+        "Pass an explicit large value if you need essentially-unbounded retry.",
     )
 
     args = parser.parse_args()

--- a/lib/gpu_memory_service/server/allocations.py
+++ b/lib/gpu_memory_service/server/allocations.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 from typing import Callable, Optional
 from uuid import uuid4
 
+import torch
 from gpu_memory_service.common.cuda_utils import (
     align_to_granularity,
     cuda_ensure_initialized,
@@ -49,7 +50,7 @@ class GMSAllocationManager:
         device: int = 0,
         *,
         allocation_retry_interval: float = 0.5,
-        allocation_retry_timeout: Optional[float] = None,
+        allocation_retry_timeout: Optional[float] = 60.0,
     ):
         if allocation_retry_interval <= 0:
             raise ValueError(
@@ -124,10 +125,25 @@ class GMSAllocationManager:
                         f"tag={tag}, waited_sec={waited:.3f}"
                     )
 
+            # Visibility while retrying. Logged every iteration with elapsed
+            # time + free GPU memory, so a stuck retry loop is observable
+            # rather than silent.
+            try:
+                free_b, total_b = torch.cuda.mem_get_info(self._device)
+            except RuntimeError:
+                logger.debug(
+                    "torch.cuda.mem_get_info(%d) failed", self._device, exc_info=True
+                )
+                free_b, total_b = -1, -1
+            elapsed = time.monotonic() - started_at
             logger.warning(
-                "cuMemCreate OOM for aligned_size=%d bytes, tag=%s; retrying in %.3fs",
+                "cuMemCreate OOM for aligned_size=%d bytes, tag=%s, "
+                "elapsed=%.2fs free=%d total=%d; retrying in %.3fs",
                 aligned_size,
                 tag,
+                elapsed,
+                free_b,
+                total_b,
                 self._allocation_retry_interval,
             )
             await asyncio.sleep(self._allocation_retry_interval)


### PR DESCRIPTION
Cherry-pick of #8919 into release/1.1.0.