### PR TITLE
fix(container): copy auditwheel .libs shadow dirs into sglang venv

### DIFF
--- a/container/templates/dev.Dockerfile
+++ b/container/templates/dev.Dockerfile
@@ -282,7 +282,7 @@ COPY --from=wheel_builder --chown=dynamo:0 --chmod=775 /workspace/.venv/bin/matu
 COPY --from=ghcr.io/astral-sh/uv:0.10.7 /uv /tmp/uv-binary
 RUN mkdir -p /opt/dynamo/venv && \
     python3 -m venv --system-site-packages /opt/dynamo/venv && \
-    cp -r /usr/local/lib/python${PYTHON_VERSION}/dist-packages/* \
+    cp -r /usr/local/lib/python${PYTHON_VERSION}/dist-packages/. \
           /opt/dynamo/venv/lib/python${PYTHON_VERSION}/site-packages/ && \
     chmod -R g+w /opt/dynamo/venv/lib/python${PYTHON_VERSION}/site-packages/ && \
     cp /tmp/uv-binary /opt/dynamo/venv/bin/uv && \


### PR DESCRIPTION
#### Overview:

So while building the sglang cu13 dev image and trying to run `python -m dynamo.sglang`, I saw `import nixl` blow up with `ImportError: libnixl.so: cannot open shared object file` — even though the upstream lmsysorg/sglang image had nixl working fine.

#### Details:

I was able to repro by running `docker run --rm --entrypoint /bin/bash <upstream-sglang-image> -lc 'python3 -c "import nixl"'` against the bare upstream (works) and against our dynamo sglang dev image (blows up), and then noticed `libnixl.so` was missing from the venv even though it existed elsewhere on the image. So I decided to look into it and it was that our dev/local-dev stage merges `/usr/local/lib/python3.12/dist-packages/*` into the venv site-packages, and I realized the shell glob `*` silently skips dotfiles — so the auditwheel shadow dir `.nixl_cu13.mesonpy.libs/` (with `libnixl.so`, `libserdes.so`, etc.) was getting dropped on the floor every build. The fix was to change `dist-packages/*` to `dist-packages/.` — one character, the POSIX form that copies hidden entries too. I then re-built and re-ran, and it was fixed: `import nixl` works, `ldd .../nixl_cu13/_bindings.so` resolves `libnixl.so` and `libserdes.so` from the venv shadow dir, and both cu12.9 and cu13.0 sglang paths come up clean. I think this should cover it well. vllm and trtllm aren't affected because their venv doesn't go through this dist-packages merge step.

#### Where should the reviewer start?

`container/templates/dev.Dockerfile` (1-line diff)

#### Related Issues:

[OPS-4860](https://linear.app/nvidia/issue/OPS-4860)

/coderabbit profile chill
