### PR TITLE
test(revalidate): fix(recipes): use --enforce-disagg for GLM-5 frontend args #8914

### DIFF
--- a/components/src/dynamo/common/__init__.py
+++ b/components/src/dynamo/common/__init__.py
@@ -25,3 +25,5 @@ except Exception:
         __version__ = "0.0.0+unknown"
 
 __all__ = ["__version__", "config_dump", "constants", "utils"]
+
+# revalidate 8f4353c5280 2026-05-01T03:21:08Z

--- a/lib/runtime/src/runtime.rs
+++ b/lib/runtime/src/runtime.rs
@@ -391,3 +391,5 @@ impl Drop for RuntimeType {
         }
     }
 }
+
+// revalidate 8f4353c5280 2026-05-01T03:21:08Z


### PR DESCRIPTION
Re-validating that PR #8914 by William Arnold did not regress, by re-running against a trivial placebo diff:

```
fix(recipes): use --enforce-disagg for GLM-5 frontend args
```

Branch deleted on green; kept on failure for diagnosis.

Drafts are skipped by CodeRabbit per repo `.coderabbit.yaml`.