### PR TITLE
fix: remove `compute_hash` and replace with `compute_hash_v2`

### DIFF
--- a/lib/kv-router/src/indexer/positional.rs
+++ b/lib/kv-router/src/indexer/positional.rs
@@ -513,7 +513,7 @@ impl PositionalIndexer {
         bytes[..8].copy_from_slice(&prev_seq_hash.to_le_bytes());
         bytes[8..].copy_from_slice(&current_local_hash.to_le_bytes());
 
-        crate::protocols::compute_hash(&bytes)
+        dynamo_tokens::compute_hash_v2(&bytes, crate::protocols::XXH3_SEED)
     }
 
     /// Ensure seq_hashes is computed up to and including target_pos.

--- a/lib/kv-router/src/protocols.rs
+++ b/lib/kv-router/src/protocols.rs
@@ -5,7 +5,7 @@ use std::future::Future;
 use std::ops::Range;
 use std::time::Duration;
 
-use dynamo_tokens::{SequenceHash, Token};
+use dynamo_tokens::{SequenceHash, Token, compute_hash_v2};
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use xxhash_rust::xxh3;
@@ -20,14 +20,9 @@ pub const KV_EVENT_SUBJECT: &str = "kv-events";
 /// Seed for XXH3 hashing, consistent with indexer.rs
 pub const XXH3_SEED: u64 = 1337;
 
-/// Compute hash of data using XXH3 with the standard seed.
-pub fn compute_hash(data: &[u8]) -> u64 {
-    xxh3::xxh3_64_with_seed(data, XXH3_SEED)
-}
-
 /// Compute the hash of a local block.
 pub fn compute_block_hash(data: &[u8]) -> LocalBlockHash {
-    LocalBlockHash(compute_hash(data))
+    LocalBlockHash(compute_hash_v2(data, XXH3_SEED))
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -156,7 +151,7 @@ pub fn compute_seq_hash_for_block(block_hashes: &[LocalBlockHash]) -> Vec<Sequen
                     std::mem::size_of_val(&combined),
                 )
             };
-            compute_hash(bytes)
+            compute_hash_v2(bytes, XXH3_SEED)
         };
         #[cfg(not(target_endian = "little"))]
         let seq_hash = {


### PR DESCRIPTION
`compute_hash` was unneeded wrapper
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8968" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated sequence hash computation to use external hashing library for match searching operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->