### PR TITLE
fix(ci): build aws stage for EFA images instead of stopping at runtime

### DIFF
--- a/.github/workflows/shared-build-image.yml
+++ b/.github/workflows/shared-build-image.yml
@@ -279,7 +279,7 @@ jobs:
           image_tag: ${{ steps.calculate-target-tag.outputs.image_uri }}
           framework: ${{ inputs.framework }}
           target: ${{ inputs.target }}
-          build_target: ${{ inputs.target }}
+          build_target: ${{ (inputs.make_efa && (inputs.target == 'runtime' || inputs.target == 'dev')) && 'aws' || inputs.target }}
           platform: ${{ inputs.platform }}
           cuda_version: ${{ matrix.cuda_version }}
           aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}


### PR DESCRIPTION
#### Overview:

 Fix the `*-efa-build` jobs (vllm, sglang, trtllm) so they actually produce EFA-equipped images. Since #8739 these jobs have been silently shipping non-EFA images that just had `-efa` in the tag.

#### Details:

In the rendered Dockerfile, the `aws` stage (`FROM ${EFA_BASE_IMAGE} AS aws` — where `efa_installer.sh` runs) sits between `runtime` and `runtime_test`. With `--target runtime` BuildKit stops at `runtime` and never reaches `aws`, so the AWS EFA installer never executes.

The fix is to change the target if make_efa is enabled, and target is 'runtime' or 'dev'

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8970" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated image build configuration to properly handle EFA (Elastic Fabric Adapter) support, ensuring correct build targets are selected when EFA is enabled for runtime and development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->