### PR TITLE
chore: Update DeepSeek v4 recipes with public dev.2 images

### DIFF
--- a/recipes/deepseek-v4/container/README.md
+++ b/recipes/deepseek-v4/container/README.md
@@ -9,14 +9,17 @@ Shared reference Dockerfiles for the DeepSeek-V4 family — used by both [`deeps
 
 | Backend | Dockerfile | Base image | Build flow |
 |---------|-----------|-----------|------------|
-| SGLang | [`sglang/Dockerfile.dsv4.sglang.b200`](sglang/Dockerfile.dsv4.sglang.b200) | `lmsysorg/sglang:deepseek-v4-blackwell` (digest-pinned, B200) | Two-stage; Dynamo runtime image as donor |
+| SGLang (B200)  | [`sglang/Dockerfile.dsv4.sglang.b200`](sglang/Dockerfile.dsv4.sglang.b200)   | `lmsysorg/sglang:deepseek-v4-blackwell` (digest-pinned, amd64)       | Two-stage; Dynamo runtime image as donor |
+| SGLang (GB200) | [`sglang/Dockerfile.dsv4.sglang.gb200`](sglang/Dockerfile.dsv4.sglang.gb200) | `lmsysorg/sglang:deepseek-v4-grace-blackwell` (digest-pinned, arm64) | Two-stage; Dynamo runtime image as donor |
 
 NVIDIA also publishes the prebuilt images for vLLM and SGLang which manifests pull directly:
 - `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0-deepseek-v4-cuda13-dev.2` (multi-arch)
 - `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-deepseek-v4-cuda13-dev.2` (arm64 only)
 - `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-deepseek-v4-cuda12-dev.2` (amd64 only)
 
-> **Optionally** Users may use the standard Dynamo vLLM runtime image — build via `container/render.py`. See [`<repo_root>/container/README.md`](../../../container/README.md).
+The `cudaXY` suffix encodes the CUDA major version baked into the image, not the hardware target.
+
+> **Optional:** users may also build the standard Dynamo vLLM runtime image via `container/render.py`. See [`<repo_root>/container/README.md`](../../../container/README.md).
 
 ## SGLang (`sglang/Dockerfile.dsv4.sglang.b200`)
 

--- a/recipes/deepseek-v4/container/README.md
+++ b/recipes/deepseek-v4/container/README.md
@@ -11,9 +11,12 @@ Shared reference Dockerfiles for the DeepSeek-V4 family — used by both [`deeps
 |---------|-----------|-----------|------------|
 | SGLang | [`sglang/Dockerfile.dsv4.sglang.b200`](sglang/Dockerfile.dsv4.sglang.b200) | `lmsysorg/sglang:deepseek-v4-blackwell` (digest-pinned, B200) | Two-stage; Dynamo runtime image as donor |
 
-For SGLang, NVIDIA also publishes the prebuilt image at `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-sglang-deepseek-v4-b200-dev.1`, which both `sglang/agg/deploy.yaml` manifests pull directly. **Most users do not need to build from source.**
+NVIDIA also publishes the prebuilt images for vLLM and SGLang which manifests pull directly:
+- `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0-deepseek-v4-cuda13-dev.2` (multi-arch)
+- `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-deepseek-v4-cuda13-dev.2` (arm64 only)
+- `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-deepseek-v4-cuda12-dev.2` (amd64 only)
 
-> **vLLM:** Use the standard Dynamo vLLM runtime image — build via `container/render.py`. See [`<repo_root>/container/README.md`](../../../container/README.md).
+> **Optionally** Users may use the standard Dynamo vLLM runtime image — build via `container/render.py`. See [`<repo_root>/container/README.md`](../../../container/README.md).
 
 ## SGLang (`sglang/Dockerfile.dsv4.sglang.b200`)
 

--- a/recipes/deepseek-v4/container/sglang/Dockerfile.dsv4.sglang.b200
+++ b/recipes/deepseek-v4/container/sglang/Dockerfile.dsv4.sglang.b200
@@ -13,7 +13,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN pip uninstall -y black termplotlib \
     && apt-get update \
     && apt-get purge -y libx264-164 libx265-199 libde265-0 libavcodec60 libxvidcore4 \
-    && rm -rf /var/lib/apt/lists/* \
     && apt list --upgradable 2>/dev/null | tail -n +2 | grep 'noble' | awk -F/ '{print $1}' | xargs -r apt-get install -y --only-upgrade \
     && rm -rf /var/lib/apt/lists/*
 

--- a/recipes/deepseek-v4/container/sglang/Dockerfile.dsv4.sglang.b200
+++ b/recipes/deepseek-v4/container/sglang/Dockerfile.dsv4.sglang.b200
@@ -12,6 +12,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN pip uninstall -y black termplotlib \
     && apt-get update \
+    && apt-get purge -y libx264-164 libx265-199 libde265-0 libavcodec60 libxvidcore4 \
+    && rm -rf /var/lib/apt/lists/* \
     && apt list --upgradable 2>/dev/null | tail -n +2 | grep 'noble' | awk -F/ '{print $1}' | xargs -r apt-get install -y --only-upgrade \
     && rm -rf /var/lib/apt/lists/*
 
@@ -31,16 +33,13 @@ RUN pip install --no-cache-dir --force-reinstall --no-deps \
     python3 -c "from dynamo._core import get_tool_parser_names; assert 'deepseek_v4' in get_tool_parser_names(), 'V4 parser missing!'; print('V4 parser verified')"
 
 COPY --from=dynamo_src /workspace/components/src/dynamo /workspace/components/src/dynamo
+COPY --from=dynamo_src /workspace/ATTRIBUTIONS-Python.md /workspace/ATTRIBUTIONS-Rust.md /workspace/ATTRIBUTIONS.md /workspace/
 
 # Avoid /workspace/sglang shadowing the dynamo Python package.
 ENV PYTHONPATH=/workspace/sglang/python:/workspace/components/src
 
 ENV SGLANG_JIT_DEEPGEMM_PRECOMPILE=0 \
     SGLANG_JIT_DEEPGEMM_FAST_WARMUP=1
-
-# TODO: move this up (consolidate with the apt-get block above) after the release.
-RUN apt-get purge -y libx264-164 libx265-199 libde265-0 libavcodec60 libxvidcore4 \
-    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /workspace
 

--- a/recipes/deepseek-v4/container/sglang/Dockerfile.dsv4.sglang.gb200
+++ b/recipes/deepseek-v4/container/sglang/Dockerfile.dsv4.sglang.gb200
@@ -1,8 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-ARG DYNAMO_SRC_IMAGE=210086341041.dkr.ecr.us-west-2.amazonaws.com/ai-dynamo/dynamo:33068cc8b2c5500622b5376ef9865144dcded9ef-sglang-runtime-cuda13
-ARG DSV4_BASE_IMAGE=lmsysorg/sglang:deepseek-v4-grace-blackwell@sha256:53af22f485af0f8d07f8ad9cf0c390921961a2631d87a0630c05aa8e0f392015
+ARG DYNAMO_SRC_IMAGE=dynamo:latest-sglang-runtime
+ARG DSV4_BASE_IMAGE=lmsysorg/sglang:deepseek-v4-grace-blackwell@sha256:7fee20a945cbb6ae26e8544a9e3dc2d50a2adbed851d8c2b02bac9e9e5c734a0
 
 FROM ${DYNAMO_SRC_IMAGE} AS dynamo_src
 
@@ -31,6 +31,7 @@ RUN pip install --no-cache-dir --force-reinstall --no-deps \
     python3 -c "from dynamo._core import get_tool_parser_names; assert 'deepseek_v4' in get_tool_parser_names(), 'V4 parser missing!'; print('V4 parser verified')"
 
 COPY --from=dynamo_src /workspace/components/src/dynamo /workspace/components/src/dynamo
+COPY --from=dynamo_src /workspace/ATTRIBUTIONS-Python.md /workspace/ATTRIBUTIONS-Rust.md /workspace/ATTRIBUTIONS.md /workspace/
 
 # Avoid /workspace/sglang shadowing the dynamo Python package.
 ENV PYTHONPATH=/workspace/sglang/python:/workspace/components/src

--- a/recipes/deepseek-v4/container/sglang/Dockerfile.dsv4.sglang.gb200
+++ b/recipes/deepseek-v4/container/sglang/Dockerfile.dsv4.sglang.gb200
@@ -1,8 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-ARG DYNAMO_SRC_IMAGE=dynamo:latest-sglang-runtime
-ARG DSV4_BASE_IMAGE=lmsysorg/sglang:deepseek-v4-grace-blackwell@sha256:7fee20a945cbb6ae26e8544a9e3dc2d50a2adbed851d8c2b02bac9e9e5c734a0
+ARG DYNAMO_SRC_IMAGE=210086341041.dkr.ecr.us-west-2.amazonaws.com/ai-dynamo/dynamo:33068cc8b2c5500622b5376ef9865144dcded9ef-sglang-runtime-cuda13
+ARG DSV4_BASE_IMAGE=lmsysorg/sglang:deepseek-v4-grace-blackwell@sha256:53af22f485af0f8d07f8ad9cf0c390921961a2631d87a0630c05aa8e0f392015
 
 FROM ${DYNAMO_SRC_IMAGE} AS dynamo_src
 

--- a/recipes/deepseek-v4/deepseek-v4-flash/README.md
+++ b/recipes/deepseek-v4/deepseek-v4-flash/README.md
@@ -25,20 +25,6 @@ Status: **Experimental** (Day-0). Modality: text only.
    - **B200 variants**: 4 B200 GPUs (x86_64).
    - **GB200 variants**: 4 GB200 GPUs (single NVL4 tray, arm64). Nodes must be labeled `nvidia.com/gpu.product=NVIDIA-GB200` and tainted `kubernetes.io/arch=arm64:NoSchedule` (the manifests carry the matching `nodeSelector` + `toleration`).
 3. **HuggingFace token** with access to `deepseek-ai/DeepSeek-V4-Flash`.
-4. **Container image.** Pick the path that matches your variant:
-
-   - **SGLang B200** (`sglang-agg`): the manifest pulls the prebuilt NGC image `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-deepseek-v4-cuda12-dev.2` directly — **no build step required.** Optionally users can build SGLang images from source (e.g. to pin a custom Dynamo branch or a different SGLang base), see the [`recipes/deepseek-v4/container/README.md`](../container/README.md).
-
-   - **SGLang GB200** (`sglang-agg-gb200`): the manifest pulls the prebuilt arm64 NGC image `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-deepseek-v4-cuda13-dev.2` directly — same story, **no build step required.**
-
-   - **vLLM** (`vllm-agg-b200` or `vllm-agg-gb200`): the manifest pulls the prebuilt NGC image `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0-deepseek-v4-cuda13-dev.2` directly — same story, **no build step required.** Optionally users can build vllm image with:
-
-     ```bash
-     container/render.py --framework vllm --target runtime --output-short-filename
-     docker build -t dynamo:latest-vllm-runtime -f container/rendered.Dockerfile .
-     ```
-
-     For the GB200 variant, build with `--platform linux/arm64` and ensure the resulting image includes an arm64 build of FlashInfer with the TRT-LLM allreduce kernels. Then set the `image:` fields in your chosen `vllm/agg_*/deploy.yaml` (both Frontend and decode worker) to your pushed image tag.
 
 ## Quick Start
 
@@ -65,8 +51,6 @@ kubectl wait --for=condition=Complete job/model-download -n ${NAMESPACE} --timeo
 ### Deploy — vLLM B200 (`vllm-agg-b200`)
 
 ```bash
-# Update the `image:` fields in vllm/agg_b200/deploy.yaml to your Dynamo + vLLM build
-# (Prerequisite 4 — vLLM path).
 kubectl apply -f vllm/agg_b200/deploy.yaml -n ${NAMESPACE}
 
 # First launch of the decode worker takes up to ~60 minutes (weight load +
@@ -79,8 +63,6 @@ kubectl wait --for=condition=Ready pod \
 ### Deploy — vLLM GB200 (`vllm-agg-gb200`)
 
 ```bash
-# Update the `image:` fields in vllm/agg_gb200/deploy.yaml to your Dynamo + vLLM
-# arm64 build (Prerequisite 4 — vLLM path).
 kubectl apply -f vllm/agg_gb200/deploy.yaml -n ${NAMESPACE}
 
 # First launch ~60 minutes; the manifest's startup probe allows for it.
@@ -92,7 +74,6 @@ kubectl wait --for=condition=Ready pod \
 ### Deploy — SGLang B200 (`sglang-agg`)
 
 ```bash
-# Manifest already points at the prebuilt NGC image — no image edit needed.
 kubectl apply -f sglang/agg/deploy.yaml -n ${NAMESPACE}
 
 # First launch of the decode worker takes up to ~60 minutes (weight load +
@@ -105,7 +86,6 @@ kubectl wait --for=condition=Ready pod \
 ### Deploy — SGLang GB200 (`sglang-agg-gb200`)
 
 ```bash
-# Manifest references the prebuilt arm64 NGC image — no image edit needed.
 kubectl apply -f sglang/agg-gb200/deploy.yaml -n ${NAMESPACE}
 
 kubectl wait --for=condition=Ready pod \
@@ -263,7 +243,6 @@ If `tool_calls` is missing and raw tool-call markers appear in `content`, confir
 
 ### vLLM-specific
 
-- **Image tag.** Both `vllm/agg_b200/deploy.yaml` and `vllm/agg_gb200/deploy.yaml` ship with `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0-deepseek-v4-cuda13-dev.2`. You can replace with your built Dynamo vLLM runtime tag — see Prerequisite 4. The GB200 manifest expects an arm64 build that includes FlashInfer with the TRT-LLM allreduce kernels.
 - **Engine-ready timeout.** `VLLM_ENGINE_READY_TIMEOUT_S=3600` matches the startup probe budget on both variants.
 - **DP stability (B200 only).** `VLLM_RANDOMIZE_DP_DUMMY_INPUTS=1` and `VLLM_SKIP_P2P_CHECK=1` mirror the DeepSeek-R1 vLLM recipe and stabilize DP dummy inputs. The GB200 variant uses TP (no DP), so `VLLM_RANDOMIZE_DP_DUMMY_INPUTS` is not set.
 - **FlashInfer TRT-LLM allreduce on GB200.** You may see a non-fatal startup warning `Failed to initialize FlashInfer Allreduce norm fusion workspace ... Flashinfer allreduce-norm fusion will be disabled`. vLLM falls back to a non-fused allreduce + RMSNorm; correctness is unaffected. To enable the fused kernel, set the compilation pass: `--compilation-config '{"mode":3,"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["all"],"pass_config":{"fuse_allreduce_rms":true}}'`.

--- a/recipes/deepseek-v4/deepseek-v4-flash/README.md
+++ b/recipes/deepseek-v4/deepseek-v4-flash/README.md
@@ -11,8 +11,8 @@ Aggregated-serving recipes for **DeepSeek-V4-Flash** on Dynamo. Two backends (**
 |---------|---------|----------|----------|----------|-----------|
 | **vllm-agg-b200**     | vLLM   | 4x B200  | [`vllm/agg_b200/deploy.yaml`](vllm/agg_b200/deploy.yaml)     | DP=4 + Expert Parallel, TP=1                   | Standard Dynamo vLLM runtime image |
 | **vllm-agg-gb200**    | vLLM   | 4x GB200 | [`vllm/agg_gb200/deploy.yaml`](vllm/agg_gb200/deploy.yaml)   | TP=4 + Expert Parallel, `deep_gemm_mega_moe`   | Standard Dynamo vLLM runtime image (arm64) |
-| **sglang-agg**        | SGLang | 4x B200  | [`sglang/agg/deploy.yaml`](sglang/agg/deploy.yaml)           | TP=4, MXFP4 MoE via FlashInfer, EAGLE MTP 3/4 | Prebuilt NGC image (`...-b200-dev.1`); optional [custom build](../container/) |
-| **sglang-agg-gb200**  | SGLang | 4x GB200 | [`sglang/agg-gb200/deploy.yaml`](sglang/agg-gb200/deploy.yaml) | TP=4, MXFP4 MoE via FlashInfer, EAGLE MTP 3/4 | Prebuilt NGC image (`...-gb200-dev.1`, arm64) |
+| **sglang-agg**        | SGLang | 4x B200  | [`sglang/agg/deploy.yaml`](sglang/agg/deploy.yaml)           | TP=4, MXFP4 MoE via FlashInfer, EAGLE MTP 3/4 | Prebuilt NGC image (`...1.2.0-deepseek-v4-cuda12-dev.2`); optional [custom build](../container/) |
+| **sglang-agg-gb200**  | SGLang | 4x GB200 | [`sglang/agg-gb200/deploy.yaml`](sglang/agg-gb200/deploy.yaml) | TP=4, MXFP4 MoE via FlashInfer, EAGLE MTP 3/4 | Prebuilt NGC image (`...1.2.0-deepseek-v4-cuda13-dev.2`, arm64) |
 
 The B200 variants fill 4 of 8 GPUs on a B200 node; the GB200 variants fill all 4 GPUs of a single GB200 NVL4 tray.
 
@@ -27,11 +27,11 @@ Status: **Experimental** (Day-0). Modality: text only.
 3. **HuggingFace token** with access to `deepseek-ai/DeepSeek-V4-Flash`.
 4. **Container image.** Pick the path that matches your variant:
 
-   - **SGLang B200** (`sglang-agg`): the manifest pulls the prebuilt NGC image `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-sglang-deepseek-v4-b200-dev.1` directly — **no build step required.** To rebuild from source (e.g. to pin a custom Dynamo branch or a different SGLang base), see the shared [`recipes/deepseek-v4/container/README.md`](../container/README.md).
+   - **SGLang B200** (`sglang-agg`): the manifest pulls the prebuilt NGC image `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-deepseek-v4-cuda12-dev.2` directly — **no build step required.** To rebuild from source (e.g. to pin a custom Dynamo branch or a different SGLang base), see the shared [`recipes/deepseek-v4/container/README.md`](../container/README.md).
 
-   - **SGLang GB200** (`sglang-agg-gb200`): the manifest pulls the prebuilt arm64 NGC image `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-sglang-deepseek-v4-gb200-dev.1` directly — same story, **no build step required.**
+   - **SGLang GB200** (`sglang-agg-gb200`): the manifest pulls the prebuilt arm64 NGC image `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-deepseek-v4-cuda13-dev.2` directly — same story, **no build step required.**
 
-   - **vLLM** (`vllm-agg-b200` or `vllm-agg-gb200`): Build the standard Dynamo vLLM runtime image per [`<repo_root>/container/README.md`](../../../container/README.md):
+   - **vLLM** (`vllm-agg-b200` or `vllm-agg-gb200`): the manifest pulls the prebuilt NGC image `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0-deepseek-v4-cuda13-dev.2` directly — **no build step required.** To rebuild from source (e.g. to pin a custom Dynamo branch or a different SGLang base), see the standard Dynamo vLLM runtime image per [`<repo_root>/container/README.md`](../../../container/README.md):
 
      ```bash
      container/render.py --framework vllm --target runtime --output-short-filename
@@ -263,14 +263,14 @@ If `tool_calls` is missing and raw tool-call markers appear in `content`, confir
 
 ### vLLM-specific
 
-- **Image tag.** Both `vllm/agg_b200/deploy.yaml` and `vllm/agg_gb200/deploy.yaml` ship with `nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag`. Replace with your built Dynamo vLLM runtime tag — see Prerequisite 4. The GB200 manifest expects an arm64 build that includes FlashInfer with the TRT-LLM allreduce kernels.
+- **Image tag.** Both `vllm/agg_b200/deploy.yaml` and `vllm/agg_gb200/deploy.yaml` ship with `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0-deepseek-v4-cuda13-dev.2"`. You can replace with your built Dynamo vLLM runtime tag — see Prerequisite 4. The GB200 manifest expects an arm64 build that includes FlashInfer with the TRT-LLM allreduce kernels.
 - **Engine-ready timeout.** `VLLM_ENGINE_READY_TIMEOUT_S=3600` matches the startup probe budget on both variants.
 - **DP stability (B200 only).** `VLLM_RANDOMIZE_DP_DUMMY_INPUTS=1` and `VLLM_SKIP_P2P_CHECK=1` mirror the DeepSeek-R1 vLLM recipe and stabilize DP dummy inputs. The GB200 variant uses TP (no DP), so `VLLM_RANDOMIZE_DP_DUMMY_INPUTS` is not set.
 - **FlashInfer TRT-LLM allreduce on GB200.** You may see a non-fatal startup warning `Failed to initialize FlashInfer Allreduce norm fusion workspace ... Flashinfer allreduce-norm fusion will be disabled`. vLLM falls back to a non-fused allreduce + RMSNorm; correctness is unaffected. To enable the fused kernel, set the compilation pass: `--compilation-config '{"mode":3,"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["all"],"pass_config":{"fuse_allreduce_rms":true}}'`.
 
 ### SGLang-specific
 
-- **Prebuilt images.** `sglang/agg/deploy.yaml` references `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-sglang-deepseek-v4-b200-dev.1` and `sglang/agg-gb200/deploy.yaml` references the arm64 sibling `...sglang-deepseek-v4-gb200-dev.1`. To rebuild either (custom Dynamo branch, different SGLang base, etc.), see [`recipes/deepseek-v4/container/README.md`](../container/README.md).
+- **Prebuilt images.** `sglang/agg/deploy.yaml` references `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-deepseek-v4-cuda12-dev.2` and `sglang/agg-gb200/deploy.yaml` references the arm64 sibling `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-deepseek-v4-cuda13-dev.2`. To rebuild either (custom Dynamo branch, different SGLang base, etc.), see [`recipes/deepseek-v4/container/README.md`](../container/README.md).
 - **DeepGEMM / FlashInfer warmup.** `SGLANG_JIT_DEEPGEMM_PRECOMPILE=0` + `SGLANG_JIT_DEEPGEMM_FAST_WARMUP=1` skip the slow precompile and use the fast warmup path. `--disable-flashinfer-autotune` skips per-shape FlashInfer autotuning at startup; the dsv4 base ships pre-tuned defaults.
 - **NCCL / Gloo.** `NCCL_CUMEM_ENABLE=1` is set for V4 NCCL collectives on Blackwell. `GLOO_SOCKET_IFNAME=eth0` pins Gloo to the standard pod interface.
 

--- a/recipes/deepseek-v4/deepseek-v4-flash/README.md
+++ b/recipes/deepseek-v4/deepseek-v4-flash/README.md
@@ -31,7 +31,7 @@ Status: **Experimental** (Day-0). Modality: text only.
 
    - **SGLang GB200** (`sglang-agg-gb200`): the manifest pulls the prebuilt arm64 NGC image `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-deepseek-v4-cuda13-dev.2` directly — same story, **no build step required.**
 
-   - **vLLM** (`vllm-agg-b200` or `vllm-agg-gb200`): the manifest pulls the prebuilt NGC image `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0-deepseek-v4-cuda13-dev.2` directly — **no build step required.** To rebuild from source (e.g. to pin a custom Dynamo branch or a different SGLang base), see the standard Dynamo vLLM runtime image per [`<repo_root>/container/README.md`](../../../container/README.md):
+   - **vLLM** (`vllm-agg-b200` or `vllm-agg-gb200`): the manifest pulls the prebuilt NGC image `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0-deepseek-v4-cuda13-dev.2` directly — same story, **no build step required.**
 
      ```bash
      container/render.py --framework vllm --target runtime --output-short-filename
@@ -187,7 +187,7 @@ Recipe-level (per-variant) settings:
 
 | | vLLM B200 (`vllm-agg-b200`) | vLLM GB200 (`vllm-agg-gb200`) | SGLang B200 (`sglang-agg`) | SGLang GB200 (`sglang-agg-gb200`) |
 |---|---|---|---|---|
-| **Backend image** | Standard Dynamo vLLM runtime | Standard Dynamo vLLM runtime (arm64) | Prebuilt `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-sglang-deepseek-v4-b200-dev.1` | Prebuilt `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-sglang-deepseek-v4-gb200-dev.1` |
+| **Backend image** | Standard Dynamo vLLM runtime | Standard Dynamo vLLM runtime (arm64) | Prebuilt `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-deepseek-v4-cuda12-dev.2` | Prebuilt `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-deepseek-v4-cuda13-dev.2` |
 | **Parallelism** | DP=4 + Expert Parallel, TP=1 | TP=4 + Expert Parallel | TP=4 | TP=4 |
 | **MoE backend** | vLLM's V4 expert kernel (FP4) | DeepGEMM mega MoE | FlashInfer MXFP4 | FlashInfer MXFP4 |
 | **KV cache** | FP8, block size 256 | FP8, block size 256 | engine default | engine default |
@@ -263,7 +263,7 @@ If `tool_calls` is missing and raw tool-call markers appear in `content`, confir
 
 ### vLLM-specific
 
-- **Image tag.** Both `vllm/agg_b200/deploy.yaml` and `vllm/agg_gb200/deploy.yaml` ship with `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0-deepseek-v4-cuda13-dev.2"`. You can replace with your built Dynamo vLLM runtime tag — see Prerequisite 4. The GB200 manifest expects an arm64 build that includes FlashInfer with the TRT-LLM allreduce kernels.
+- **Image tag.** Both `vllm/agg_b200/deploy.yaml` and `vllm/agg_gb200/deploy.yaml` ship with `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0-deepseek-v4-cuda13-dev.2`. You can replace with your built Dynamo vLLM runtime tag — see Prerequisite 4. The GB200 manifest expects an arm64 build that includes FlashInfer with the TRT-LLM allreduce kernels.
 - **Engine-ready timeout.** `VLLM_ENGINE_READY_TIMEOUT_S=3600` matches the startup probe budget on both variants.
 - **DP stability (B200 only).** `VLLM_RANDOMIZE_DP_DUMMY_INPUTS=1` and `VLLM_SKIP_P2P_CHECK=1` mirror the DeepSeek-R1 vLLM recipe and stabilize DP dummy inputs. The GB200 variant uses TP (no DP), so `VLLM_RANDOMIZE_DP_DUMMY_INPUTS` is not set.
 - **FlashInfer TRT-LLM allreduce on GB200.** You may see a non-fatal startup warning `Failed to initialize FlashInfer Allreduce norm fusion workspace ... Flashinfer allreduce-norm fusion will be disabled`. vLLM falls back to a non-fused allreduce + RMSNorm; correctness is unaffected. To enable the fused kernel, set the compilation pass: `--compilation-config '{"mode":3,"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["all"],"pass_config":{"fuse_allreduce_rms":true}}'`.

--- a/recipes/deepseek-v4/deepseek-v4-flash/README.md
+++ b/recipes/deepseek-v4/deepseek-v4-flash/README.md
@@ -9,8 +9,8 @@ Aggregated-serving recipes for **DeepSeek-V4-Flash** on Dynamo. Two backends (**
 
 | Variant | Backend | Hardware | Manifest | Topology | Container |
 |---------|---------|----------|----------|----------|-----------|
-| **vllm-agg-b200**     | vLLM   | 4x B200  | [`vllm/agg_b200/deploy.yaml`](vllm/agg_b200/deploy.yaml)     | DP=4 + Expert Parallel, TP=1                   | Standard Dynamo vLLM runtime image |
-| **vllm-agg-gb200**    | vLLM   | 4x GB200 | [`vllm/agg_gb200/deploy.yaml`](vllm/agg_gb200/deploy.yaml)   | TP=4 + Expert Parallel, `deep_gemm_mega_moe`   | Standard Dynamo vLLM runtime image (arm64) |
+| **vllm-agg-b200**     | vLLM   | 4x B200  | [`vllm/agg_b200/deploy.yaml`](vllm/agg_b200/deploy.yaml)     | DP=4 + Expert Parallel, TP=1                   | Prebuilt NGC image (`...1.2.0-deepseek-v4-cuda13-dev.2`, multi-arch) |
+| **vllm-agg-gb200**    | vLLM   | 4x GB200 | [`vllm/agg_gb200/deploy.yaml`](vllm/agg_gb200/deploy.yaml)   | TP=4 + Expert Parallel, `deep_gemm_mega_moe`   | Prebuilt NGC image (`...1.2.0-deepseek-v4-cuda13-dev.2`, multi-arch) |
 | **sglang-agg**        | SGLang | 4x B200  | [`sglang/agg/deploy.yaml`](sglang/agg/deploy.yaml)           | TP=4, MXFP4 MoE via FlashInfer, EAGLE MTP 3/4 | Prebuilt NGC image (`...1.2.0-deepseek-v4-cuda12-dev.2`); optional [custom build](../container/) |
 | **sglang-agg-gb200**  | SGLang | 4x GB200 | [`sglang/agg-gb200/deploy.yaml`](sglang/agg-gb200/deploy.yaml) | TP=4, MXFP4 MoE via FlashInfer, EAGLE MTP 3/4 | Prebuilt NGC image (`...1.2.0-deepseek-v4-cuda13-dev.2`, arm64) |
 
@@ -167,7 +167,7 @@ Recipe-level (per-variant) settings:
 
 | | vLLM B200 (`vllm-agg-b200`) | vLLM GB200 (`vllm-agg-gb200`) | SGLang B200 (`sglang-agg`) | SGLang GB200 (`sglang-agg-gb200`) |
 |---|---|---|---|---|
-| **Backend image** | Standard Dynamo vLLM runtime | Standard Dynamo vLLM runtime (arm64) | Prebuilt `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-deepseek-v4-cuda12-dev.2` | Prebuilt `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-deepseek-v4-cuda13-dev.2` |
+| **Backend image** | Prebuilt `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0-deepseek-v4-cuda13-dev.2` (multi-arch) | Prebuilt `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0-deepseek-v4-cuda13-dev.2` (multi-arch) | Prebuilt `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-deepseek-v4-cuda12-dev.2` | Prebuilt `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-deepseek-v4-cuda13-dev.2` |
 | **Parallelism** | DP=4 + Expert Parallel, TP=1 | TP=4 + Expert Parallel | TP=4 | TP=4 |
 | **MoE backend** | vLLM's V4 expert kernel (FP4) | DeepGEMM mega MoE | FlashInfer MXFP4 | FlashInfer MXFP4 |
 | **KV cache** | FP8, block size 256 | FP8, block size 256 | engine default | engine default |
@@ -243,6 +243,7 @@ If `tool_calls` is missing and raw tool-call markers appear in `content`, confir
 
 ### vLLM-specific
 
+- **Prebuilt images.** Both `vllm/agg_b200/deploy.yaml` and `vllm/agg_gb200/deploy.yaml` reference `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0-deepseek-v4-cuda13-dev.2` (multi-arch). To rebuild from source (custom Dynamo branch, different vLLM base, etc.), see [`<repo_root>/container/README.md`](../../../container/README.md).
 - **Engine-ready timeout.** `VLLM_ENGINE_READY_TIMEOUT_S=3600` matches the startup probe budget on both variants.
 - **DP stability (B200 only).** `VLLM_RANDOMIZE_DP_DUMMY_INPUTS=1` and `VLLM_SKIP_P2P_CHECK=1` mirror the DeepSeek-R1 vLLM recipe and stabilize DP dummy inputs. The GB200 variant uses TP (no DP), so `VLLM_RANDOMIZE_DP_DUMMY_INPUTS` is not set.
 - **FlashInfer TRT-LLM allreduce on GB200.** You may see a non-fatal startup warning `Failed to initialize FlashInfer Allreduce norm fusion workspace ... Flashinfer allreduce-norm fusion will be disabled`. vLLM falls back to a non-fused allreduce + RMSNorm; correctness is unaffected. To enable the fused kernel, set the compilation pass: `--compilation-config '{"mode":3,"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["all"],"pass_config":{"fuse_allreduce_rms":true}}'`.

--- a/recipes/deepseek-v4/deepseek-v4-flash/README.md
+++ b/recipes/deepseek-v4/deepseek-v4-flash/README.md
@@ -27,11 +27,11 @@ Status: **Experimental** (Day-0). Modality: text only.
 3. **HuggingFace token** with access to `deepseek-ai/DeepSeek-V4-Flash`.
 4. **Container image.** Pick the path that matches your variant:
 
-   - **SGLang B200** (`sglang-agg`): the manifest pulls the prebuilt NGC image `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-deepseek-v4-cuda12-dev.2` directly — **no build step required.** To rebuild from source (e.g. to pin a custom Dynamo branch or a different SGLang base), see the shared [`recipes/deepseek-v4/container/README.md`](../container/README.md).
+   - **SGLang B200** (`sglang-agg`): the manifest pulls the prebuilt NGC image `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-deepseek-v4-cuda12-dev.2` directly — **no build step required.** Optionally users can build SGLang images from source (e.g. to pin a custom Dynamo branch or a different SGLang base), see the [`recipes/deepseek-v4/container/README.md`](../container/README.md).
 
    - **SGLang GB200** (`sglang-agg-gb200`): the manifest pulls the prebuilt arm64 NGC image `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-deepseek-v4-cuda13-dev.2` directly — same story, **no build step required.**
 
-   - **vLLM** (`vllm-agg-b200` or `vllm-agg-gb200`): the manifest pulls the prebuilt NGC image `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0-deepseek-v4-cuda13-dev.2` directly — same story, **no build step required.**
+   - **vLLM** (`vllm-agg-b200` or `vllm-agg-gb200`): the manifest pulls the prebuilt NGC image `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0-deepseek-v4-cuda13-dev.2` directly — same story, **no build step required.** Optionally users can build vllm image with:
 
      ```bash
      container/render.py --framework vllm --target runtime --output-short-filename

--- a/recipes/deepseek-v4/deepseek-v4-flash/sglang/agg-gb200/deploy.yaml
+++ b/recipes/deepseek-v4/deepseek-v4-flash/sglang/agg-gb200/deploy.yaml
@@ -32,7 +32,7 @@ spec:
         tolerations:
         - operator: Exists
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-sglang-deepseek-v4-gb200-dev.1
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-deepseek-v4-cuda13-dev.2
           imagePullPolicy: Always
           env:
             - name: HF_HOME
@@ -66,7 +66,7 @@ spec:
         tolerations:
         - operator: Exists
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-sglang-deepseek-v4-gb200-dev.1
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-deepseek-v4-cuda13-dev.2
           imagePullPolicy: Always
           workingDir: /workspace
           command:

--- a/recipes/deepseek-v4/deepseek-v4-flash/sglang/agg/deploy.yaml
+++ b/recipes/deepseek-v4/deepseek-v4-flash/sglang/agg/deploy.yaml
@@ -27,7 +27,7 @@ spec:
           mountPoint: /models
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-sglang-deepseek-v4-b200-dev.1
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-deepseek-v4-cuda12-dev.2
           imagePullPolicy: Always
           env:
             - name: HF_HOME
@@ -63,7 +63,7 @@ spec:
             value: "true"
             effect: NoSchedule
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-sglang-deepseek-v4-b200-dev.1
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-deepseek-v4-cuda12-dev.2
           imagePullPolicy: Always
           workingDir: /workspace
           command:

--- a/recipes/deepseek-v4/deepseek-v4-flash/vllm/agg_b200/deploy.yaml
+++ b/recipes/deepseek-v4/deepseek-v4-flash/vllm/agg_b200/deploy.yaml
@@ -10,11 +10,6 @@
 # Shape: 1 replica x 4 B200 GPUs, DP=4 + Expert Parallel, TP=1.
 #        Tested on 4 of 8 GPUs per B200 node.
 #
-# Image: replace the `:my-tag` placeholder with a Dynamo + vLLM image that
-#        includes the DeepSeek-V4 stack. See `../container/README.md`
-#        for the reference build -- it overlays dynamo on
-#        vllm/vllm-openai:deepseekv4-cu130.
-#
 # Weights: served from the `model-cache` PVC populated by
 #          `../../model-cache/model-download.yaml`.
 apiVersion: nvidia.com/v1alpha1
@@ -35,7 +30,7 @@ spec:
           mountPoint: /opt/models
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0-deepseek-v4-cuda13-dev.2
           workingDir: /workspace/examples/backends/vllm
           env:
             - name: HF_HOME
@@ -53,7 +48,7 @@ spec:
         size: 200Gi
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0-deepseek-v4-cuda13-dev.2
           workingDir: /workspace/examples/backends/vllm
           # Up to ~60 min for first launch: weight load + FlashInfer autotune +
           # cudagraph warmup. periodSeconds * failureThreshold = 10 * 360 = 3600s.

--- a/recipes/deepseek-v4/deepseek-v4-flash/vllm/agg_gb200/deploy.yaml
+++ b/recipes/deepseek-v4/deepseek-v4-flash/vllm/agg_gb200/deploy.yaml
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # DeepSeek-V4-Flash on vLLM, aggregated, GB200 (TP=4 + EP, single NVL4 tray).
-# Image: replace `:my-tag` with an arm64 Dynamo + vLLM build.
 # Weights: pre-staged on the `model-cache` PVC by `../../model-cache/model-download.yaml`.
 apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
@@ -30,7 +29,7 @@ spec:
             value: arm64
             effect: NoSchedule
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0-deepseek-v4-cuda13-dev.2
           workingDir: /workspace/examples/backends/vllm
           env:
             - name: HF_HOME
@@ -56,7 +55,7 @@ spec:
             value: arm64
             effect: NoSchedule
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0-deepseek-v4-cuda13-dev.2
           workingDir: /workspace/examples/backends/vllm
           # ~60 min budget for first launch (10 * 360 = 3600s).
           startupProbe:

--- a/recipes/deepseek-v4/deepseek-v4-pro/README.md
+++ b/recipes/deepseek-v4/deepseek-v4-pro/README.md
@@ -33,7 +33,7 @@ Status: **Experimental** (Day-0). Modality: text only.
 
    - **SGLang** (`sglang-agg`): the manifest pulls the prebuilt NGC image `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-deepseek-v4-cuda12-dev.2` directly — **no build step required.** To rebuild from source (e.g. to pin a custom Dynamo branch or a different SGLang base), see the shared [`recipes/deepseek-v4/container/README.md`](../container/README.md).
 
-   - **vLLM** (`vllm-agg-b200` or `vllm-disagg-gb200`): the manifest pulls the prebuilt NGC image `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0-deepseek-v4-cuda13-dev.2` directly — **no build step required.** To rebuild from source (e.g. to pin a custom Dynamo branch or a different SGLang base), see the standard Dynamo vLLM runtime image per [`<repo_root>/container/README.md`](../../../container/README.md):
+   - **vLLM** (`vllm-agg-b200` or `vllm-disagg-gb200`): the manifest pulls the prebuilt NGC image `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0-deepseek-v4-cuda13-dev.2` directly — **no build step required.** To rebuild from source (e.g. to pin a custom Dynamo branch or a different vllm base), see the standard Dynamo vLLM runtime image per [`<repo_root>/container/README.md`](../../../container/README.md):
 
      ```bash
      container/render.py --framework vllm --target runtime --output-short-filename

--- a/recipes/deepseek-v4/deepseek-v4-pro/README.md
+++ b/recipes/deepseek-v4/deepseek-v4-pro/README.md
@@ -306,7 +306,7 @@ If `tool_calls` is missing and raw tool-call markers appear in `content`, confir
 
 ### SGLang-specific
 
-- **Prebuilt image.** `sglang/agg/deploy.yaml` already references the public NGC tag `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-sglang-deepseek-v4-b200-dev.1`. To rebuild (custom Dynamo branch, different SGLang base, etc.), see [`recipes/deepseek-v4/container/README.md`](../container/README.md).
+- **Prebuilt image.** `sglang/agg/deploy.yaml` already references the public NGC tag `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-deepseek-v4-cuda12-dev.2`. To rebuild (custom Dynamo branch, different SGLang base, etc.), see [`recipes/deepseek-v4/container/README.md`](../container/README.md).
 - **DeepGEMM / FlashInfer warmup.** `SGLANG_JIT_DEEPGEMM_PRECOMPILE=0` + `SGLANG_JIT_DEEPGEMM_FAST_WARMUP=1` skip the slow precompile and use the fast warmup path. `--disable-flashinfer-autotune` skips per-shape FlashInfer autotuning at startup; the dsv4 base ships pre-tuned defaults.
 - **NCCL / Gloo.** `NCCL_CUMEM_ENABLE=1` is set for V4 NCCL collectives on Blackwell. `GLOO_SOCKET_IFNAME=eth0` pins Gloo to the standard pod interface.
 

--- a/recipes/deepseek-v4/deepseek-v4-pro/README.md
+++ b/recipes/deepseek-v4/deepseek-v4-pro/README.md
@@ -31,9 +31,9 @@ Status: **Experimental** (Day-0). Modality: text only.
 3. **HuggingFace token** with access to `deepseek-ai/DeepSeek-V4-Pro`.
 4. **Container image.** Pick the path that matches your variant:
 
-   - **SGLang** (`sglang-agg`): the manifest pulls the prebuilt NGC image `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-sglang-deepseek-v4-b200-dev.1` directly — **no build step required.** To rebuild from source (e.g. to pin a custom Dynamo branch or a different SGLang base), see the shared [`recipes/deepseek-v4/container/README.md`](../container/README.md).
+   - **SGLang** (`sglang-agg`): the manifest pulls the prebuilt NGC image `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-deepseek-v4-cuda12-dev.2` directly — **no build step required.** To rebuild from source (e.g. to pin a custom Dynamo branch or a different SGLang base), see the shared [`recipes/deepseek-v4/container/README.md`](../container/README.md).
 
-   - **vLLM** (`vllm-agg-b200` or `vllm-disagg-gb200`): Build the standard Dynamo vLLM runtime image per [`<repo_root>/container/README.md`](../../../container/README.md):
+   - **vLLM** (`vllm-agg-b200` or `vllm-disagg-gb200`): the manifest pulls the prebuilt NGC image `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0-deepseek-v4-cuda13-dev.2` directly — **no build step required.** To rebuild from source (e.g. to pin a custom Dynamo branch or a different SGLang base), see the standard Dynamo vLLM runtime image per [`<repo_root>/container/README.md`](../../../container/README.md):
 
      ```bash
      container/render.py --framework vllm --target runtime --output-short-filename
@@ -69,8 +69,6 @@ kubectl wait --for=condition=Complete job/model-download -n ${NAMESPACE} --timeo
 ### Deploy — vLLM B200 (`vllm-agg-b200`)
 
 ```bash
-# Update the `image:` fields in vllm/agg/b200/deploy.yaml to your Dynamo + vLLM
-# build (Prerequisite 4 — vLLM path).
 kubectl apply -f vllm/agg/b200/deploy.yaml -n ${NAMESPACE}
 
 # First launch of the decode worker takes up to ~90 minutes (TP=8 weight load +
@@ -83,8 +81,6 @@ kubectl wait --for=condition=Ready pod \
 ### Deploy — vLLM GB200 agg (`vllm-agg-gb200`)
 
 ```bash
-# Update the `image:` fields in vllm/agg/gb200/deploy.yaml to your arm64
-# Dynamo + vLLM build (Prerequisite 4 — vLLM path).
 kubectl apply -f vllm/agg/gb200/deploy.yaml -n ${NAMESPACE}
 
 # First launch of the decode worker takes up to ~90 minutes (TP=8 weight load
@@ -97,8 +93,6 @@ kubectl wait --for=condition=Ready pod \
 ### Deploy — vLLM GB200 disagg (`vllm-disagg-gb200`)
 
 ```bash
-# Update the `image:` fields in vllm/disagg/gb200/deploy.yaml to your arm64
-# Dynamo + vLLM build (Prerequisite 4 — vLLM path).
 kubectl apply -f vllm/disagg/gb200/deploy.yaml -n ${NAMESPACE}
 
 # First launch of each leader takes up to ~90 minutes (DP=8 weight load +
@@ -114,7 +108,6 @@ kubectl wait --for=condition=Ready pod \
 ### Deploy — SGLang (`sglang-agg`)
 
 ```bash
-# Manifest already points at the prebuilt NGC image — no image edit needed.
 kubectl apply -f sglang/agg/deploy.yaml -n ${NAMESPACE}
 
 # First launch of the decode worker takes up to ~60 minutes (TP=8 weight load +
@@ -231,7 +224,7 @@ Recipe-level (per-variant) settings:
 
 | | vLLM (`vllm-agg`) | SGLang (`sglang-agg`) |
 |---|---|---|
-| **Backend image** | Standard Dynamo vLLM runtime | Prebuilt `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-sglang-deepseek-v4-b200-dev.1` |
+| **Backend image** | Standard Dynamo vLLM runtime | Prebuilt `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-deepseek-v4-cuda12-dev.2` |
 | **Parallelism** | TP=8, Expert Parallel enabled | TP=8 |
 | **MoE backend** | vLLM's V4 expert kernel (FP4) | FlashInfer MXFP4 |
 | **KV cache** | FP8, block size 256 | engine default |
@@ -307,7 +300,7 @@ If `tool_calls` is missing and raw tool-call markers appear in `content`, confir
 
 ### vLLM-specific
 
-- **Image tag.** All three vLLM manifests (`vllm/agg/b200/`, `vllm/agg/gb200/`, `vllm/disagg/gb200/`) ship with `nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag`. Replace with your built Dynamo vLLM runtime tag — see Prerequisite 4. Both GB200 manifests expect an arm64 build.
+- **Image tag.** All three vLLM manifests (`vllm/agg/b200/`, `vllm/agg/gb200/`, `vllm/disagg/gb200/`) ship with `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0-deepseek-v4-cuda13-dev.2`. You can replace the image with your custom built Dynamo vLLM runtime tag — see Prerequisite 4. Both GB200 manifests expect an arm64 build.
 - **Engine-ready timeout.** `VLLM_ENGINE_READY_TIMEOUT_S=5400` is set to match the startup probe budget (`failureThreshold: 540` at `periodSeconds: 10`).
 - **GB200: agg vs. disagg.** Both spread V4-Pro across two GB200 NVL4 trays via MNNVL/ComputeDomain. The agg variant runs one TP=8 group across both nodes (lower-latency, simpler topology, 2 pods); the disagg variant runs separate prefill and decode DP=8 workers (higher steady-state throughput at high concurrency, 4 pods). Use the agg variant for general-purpose serving and the disagg variant when prefill/decode separation pays off for the workload.
 

--- a/recipes/deepseek-v4/deepseek-v4-pro/README.md
+++ b/recipes/deepseek-v4/deepseek-v4-pro/README.md
@@ -29,20 +29,6 @@ Status: **Experimental** (Day-0). Modality: text only.
    - **B200 variants** (`vllm-agg-b200`, `sglang-agg`): 8 B200 GPUs available on a single node (x86_64). TP=8 fills the box.
    - **GB200 variants** (`vllm-agg-gb200`, `vllm-disagg-gb200`): **2 GB200 nodes**, each with 4 GPUs (single NVL4 tray each), connected to the **same NVLink72 clique**. Nodes must be labeled `nvidia.com/gpu.product=NVIDIA-GB200` and tainted `kubernetes.io/arch=arm64:NoSchedule`. The cluster must have the **DRA / ComputeDomain controller** installed (verify with `kubectl get crd | grep computedomain`); each manifest's `ComputeDomain` CR + `resourceClaims` are how the operator co-locates the worker pod set on the same NVLink72 fabric (the agg variant places 2 pods, the disagg variant places 4).
 3. **HuggingFace token** with access to `deepseek-ai/DeepSeek-V4-Pro`.
-4. **Container image.** Pick the path that matches your variant:
-
-   - **SGLang** (`sglang-agg`): the manifest pulls the prebuilt NGC image `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-deepseek-v4-cuda12-dev.2` directly — **no build step required.** To rebuild from source (e.g. to pin a custom Dynamo branch or a different SGLang base), see the shared [`recipes/deepseek-v4/container/README.md`](../container/README.md).
-
-   - **vLLM** (`vllm-agg-b200` or `vllm-disagg-gb200`): the manifest pulls the prebuilt NGC image `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0-deepseek-v4-cuda13-dev.2` directly — **no build step required.** To rebuild from source (e.g. to pin a custom Dynamo branch or a different vllm base), see the standard Dynamo vLLM runtime image per [`<repo_root>/container/README.md`](../../../container/README.md):
-
-     ```bash
-     container/render.py --framework vllm --target runtime --output-short-filename
-     docker build -t dynamo:latest-vllm-runtime -f container/rendered.Dockerfile .
-     ```
-
-     For the GB200 variant, build with `--platform linux/arm64`. Then set the `image:` fields in your chosen `vllm/.../deploy.yaml` (Frontend + both worker pods on disagg) to your pushed image tag.
-
-   > The Pro and Flash recipes share the same image on each backend and architecture. If you've already built the vLLM or SGLang runtime for [deepseek-v4-flash](../deepseek-v4-flash/), reuse the tag here — model selection happens at runtime via `--model` (vLLM) or `--model-path` (SGLang).
 
 ## Quick Start
 
@@ -300,7 +286,6 @@ If `tool_calls` is missing and raw tool-call markers appear in `content`, confir
 
 ### vLLM-specific
 
-- **Image tag.** All three vLLM manifests (`vllm/agg/b200/`, `vllm/agg/gb200/`, `vllm/disagg/gb200/`) ship with `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0-deepseek-v4-cuda13-dev.2`. You can replace the image with your custom built Dynamo vLLM runtime tag — see Prerequisite 4. Both GB200 manifests expect an arm64 build.
 - **Engine-ready timeout.** `VLLM_ENGINE_READY_TIMEOUT_S=5400` is set to match the startup probe budget (`failureThreshold: 540` at `periodSeconds: 10`).
 - **GB200: agg vs. disagg.** Both spread V4-Pro across two GB200 NVL4 trays via MNNVL/ComputeDomain. The agg variant runs one TP=8 group across both nodes (lower-latency, simpler topology, 2 pods); the disagg variant runs separate prefill and decode DP=8 workers (higher steady-state throughput at high concurrency, 4 pods). Use the agg variant for general-purpose serving and the disagg variant when prefill/decode separation pays off for the workload.
 

--- a/recipes/deepseek-v4/deepseek-v4-pro/README.md
+++ b/recipes/deepseek-v4/deepseek-v4-pro/README.md
@@ -9,9 +9,9 @@ Recipes for **DeepSeek-V4-Pro** on Dynamo across two backends (**vLLM**, **SGLan
 
 | Variant | Backend | Hardware | Manifest | Topology | Container |
 |---------|---------|----------|----------|----------|-----------|
-| **vllm-agg-b200**       | vLLM   | 1 node, 8x B200 | [`vllm/agg/b200/deploy.yaml`](vllm/agg/b200/deploy.yaml)         | TP=8 + Expert Parallel (single node)                                            | Standard Dynamo vLLM runtime image |
-| **vllm-agg-gb200**      | vLLM   | 2 nodes, 4x GB200 each (8 total) | [`vllm/agg/gb200/deploy.yaml`](vllm/agg/gb200/deploy.yaml)       | TP=8 + Expert Parallel cross-node, MNNVL via ComputeDomain (NVLink72)           | Standard Dynamo vLLM runtime image (arm64) |
-| **vllm-disagg-gb200**   | vLLM   | 2 nodes, 4x GB200 each (8 prefill + 8 decode = 16 total) | [`vllm/disagg/gb200/deploy.yaml`](vllm/disagg/gb200/deploy.yaml) | 1P + 1D, DP=8 + Expert Parallel per worker, MNNVL via ComputeDomain (NVLink72) | Standard Dynamo vLLM runtime image (arm64) |
+| **vllm-agg-b200**       | vLLM   | 1 node, 8x B200 | [`vllm/agg/b200/deploy.yaml`](vllm/agg/b200/deploy.yaml)         | TP=8 + Expert Parallel (single node)                                            | Prebuilt NGC image (`...1.2.0-deepseek-v4-cuda13-dev.2`, multi-arch) |
+| **vllm-agg-gb200**      | vLLM   | 2 nodes, 4x GB200 each (8 total) | [`vllm/agg/gb200/deploy.yaml`](vllm/agg/gb200/deploy.yaml)       | TP=8 + Expert Parallel cross-node, MNNVL via ComputeDomain (NVLink72)           | Prebuilt NGC image (`...1.2.0-deepseek-v4-cuda13-dev.2`, multi-arch) |
+| **vllm-disagg-gb200**   | vLLM   | 2 nodes, 4x GB200 each (8 prefill + 8 decode = 16 total) | [`vllm/disagg/gb200/deploy.yaml`](vllm/disagg/gb200/deploy.yaml) | 1P + 1D, DP=8 + Expert Parallel per worker, MNNVL via ComputeDomain (NVLink72) | Prebuilt NGC image (`...1.2.0-deepseek-v4-cuda13-dev.2`, multi-arch) |
 | **sglang-agg**          | SGLang | 1 node, 8x B200 | [`sglang/agg/deploy.yaml`](sglang/agg/deploy.yaml)               | TP=8, MXFP4 MoE via FlashInfer, EAGLE MTP 3/4                                   | Prebuilt NGC image; optional [custom build](../container/) |
 
 A perf-benchmark Job for the GB200 disagg variant is provided alongside the deploy:
@@ -210,7 +210,7 @@ Recipe-level (per-variant) settings:
 
 | | vLLM (`vllm-agg`) | SGLang (`sglang-agg`) |
 |---|---|---|
-| **Backend image** | Standard Dynamo vLLM runtime | Prebuilt `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-deepseek-v4-cuda12-dev.2` |
+| **Backend image** | Prebuilt `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0-deepseek-v4-cuda13-dev.2` (multi-arch) | Prebuilt `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-deepseek-v4-cuda12-dev.2` |
 | **Parallelism** | TP=8, Expert Parallel enabled | TP=8 |
 | **MoE backend** | vLLM's V4 expert kernel (FP4) | FlashInfer MXFP4 |
 | **KV cache** | FP8, block size 256 | engine default |
@@ -286,6 +286,7 @@ If `tool_calls` is missing and raw tool-call markers appear in `content`, confir
 
 ### vLLM-specific
 
+- **Prebuilt images.** All three vLLM manifests (`vllm/agg/b200/`, `vllm/agg/gb200/`, `vllm/disagg/gb200/`) reference `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0-deepseek-v4-cuda13-dev.2` (multi-arch). To rebuild from source (custom Dynamo branch, different vLLM base, etc.), see [`<repo_root>/container/README.md`](../../../container/README.md).
 - **Engine-ready timeout.** `VLLM_ENGINE_READY_TIMEOUT_S=5400` is set to match the startup probe budget (`failureThreshold: 540` at `periodSeconds: 10`).
 - **GB200: agg vs. disagg.** Both spread V4-Pro across two GB200 NVL4 trays via MNNVL/ComputeDomain. The agg variant runs one TP=8 group across both nodes (lower-latency, simpler topology, 2 pods); the disagg variant runs separate prefill and decode DP=8 workers (higher steady-state throughput at high concurrency, 4 pods). Use the agg variant for general-purpose serving and the disagg variant when prefill/decode separation pays off for the workload.
 

--- a/recipes/deepseek-v4/deepseek-v4-pro/sglang/agg/deploy.yaml
+++ b/recipes/deepseek-v4/deepseek-v4-pro/sglang/agg/deploy.yaml
@@ -20,7 +20,7 @@ spec:
           mountPoint: /models
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-sglang-deepseek-v4-b200-dev.1
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-deepseek-v4-cuda12-dev.2
           imagePullPolicy: Always
           env:
             - name: HF_HOME
@@ -56,7 +56,7 @@ spec:
             value: "true"
             effect: NoSchedule
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-sglang-deepseek-v4-b200-dev.1
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-deepseek-v4-cuda12-dev.2
           imagePullPolicy: Always
           workingDir: /workspace
           command:

--- a/recipes/deepseek-v4/deepseek-v4-pro/vllm/agg/b200/deploy.yaml
+++ b/recipes/deepseek-v4/deepseek-v4-pro/vllm/agg/b200/deploy.yaml
@@ -16,7 +16,6 @@
 #     --reasoning-parser deepseek_v4
 #
 # Shape: 1 replica x 8 GPUs, TP=8 + Expert Parallel. Fills a single 8-GPU node.
-##
 # Weights: served from the `model-cache` PVC populated by
 #          `../../model-cache/model-download.yaml`.
 apiVersion: nvidia.com/v1alpha1

--- a/recipes/deepseek-v4/deepseek-v4-pro/vllm/agg/b200/deploy.yaml
+++ b/recipes/deepseek-v4/deepseek-v4-pro/vllm/agg/b200/deploy.yaml
@@ -16,12 +16,7 @@
 #     --reasoning-parser deepseek_v4
 #
 # Shape: 1 replica x 8 GPUs, TP=8 + Expert Parallel. Fills a single 8-GPU node.
-#
-# Image: replace the `:my-tag` placeholder with a Dynamo + vLLM image that
-#        includes the DeepSeek-V4 stack. See `../container/README.md`
-#        for the reference build -- it overlays dynamo on
-#        vllm/vllm-openai:deepseekv4-cu130.
-#
+##
 # Weights: served from the `model-cache` PVC populated by
 #          `../../model-cache/model-download.yaml`.
 apiVersion: nvidia.com/v1alpha1
@@ -42,7 +37,7 @@ spec:
           mountPoint: /opt/models
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0-deepseek-v4-cuda13-dev.2
           workingDir: /workspace/examples/backends/vllm
           env:
             - name: HF_HOME
@@ -60,7 +55,7 @@ spec:
         size: 200Gi
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0-deepseek-v4-cuda13-dev.2
           workingDir: /workspace/examples/backends/vllm
           # DeepSeek-V4-Pro (1.6T params) is large; first launch loads weights
           # over TP=8 ranks plus FlashInfer autotune + cudagraph warmup. Allow

--- a/recipes/deepseek-v4/deepseek-v4-pro/vllm/agg/gb200/deploy.yaml
+++ b/recipes/deepseek-v4/deepseek-v4-pro/vllm/agg/gb200/deploy.yaml
@@ -11,7 +11,6 @@
 # NVLink72 (MNNVL) via ComputeDomain, not RoCE/IB.
 #
 # Prerequisites: DRA / ComputeDomain controller installed cluster-wide.
-# Image: replace `:my-tag` with a Dynamo + vLLM image (see ../container/README.md).
 # Weights: served from the `model-cache` PVC (see ../../model-cache/model-download.yaml).
 ---
 apiVersion: resource.nvidia.com/v1beta1
@@ -44,7 +43,7 @@ spec:
         size: 40Gi
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0-deepseek-v4-cuda13-dev.2
           workingDir: /workspace/examples/backends/vllm
           env:
             - name: HF_HOME
@@ -75,7 +74,7 @@ spec:
           - name: compute-domain-channel
             resourceClaimTemplateName: dsv4-pro-agg-compute-domain-channel
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0-deepseek-v4-cuda13-dev.2
           workingDir: /workspace/examples/backends/vllm
           # ~90 min budget for first launch (weights + autotune + cudagraph): 10 * 540 = 5400s.
           startupProbe:

--- a/recipes/deepseek-v4/deepseek-v4-pro/vllm/disagg/gb200/deploy.yaml
+++ b/recipes/deepseek-v4/deepseek-v4-pro/vllm/disagg/gb200/deploy.yaml
@@ -11,7 +11,6 @@
 # control plane goes over TCP (eth0); bulk KV flows over MNNVL/cuda_ipc.
 #
 # Prerequisites: DRA / ComputeDomain controller installed cluster-wide.
-# Image: replace `:my-tag` with a Dynamo + vLLM image (see ../container/README.md).
 # Weights: served from the `model-cache` PVC (see ../../model-cache/model-download.yaml).
 ---
 apiVersion: resource.nvidia.com/v1beta1
@@ -44,7 +43,7 @@ spec:
         size: 40Gi
       extraPodSpec:
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0-deepseek-v4-cuda13-dev.2
           workingDir: /workspace/examples/backends/vllm
           env:
             - name: HF_HOME
@@ -63,7 +62,7 @@ spec:
           - name: compute-domain-channel
             resourceClaimTemplateName: dsv4-pro-compute-domain-channel
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0-deepseek-v4-cuda13-dev.2
           workingDir: /workspace/examples/backends/vllm
           # ~90 min budget for first launch (weights + autotune + cudagraph): 10 * 540 = 5400s.
           startupProbe:
@@ -177,7 +176,7 @@ spec:
           - name: compute-domain-channel
             resourceClaimTemplateName: dsv4-pro-compute-domain-channel
         mainContainer:
-          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0-deepseek-v4-cuda13-dev.2
           workingDir: /workspace/examples/backends/vllm
           startupProbe:
             httpGet:


### PR DESCRIPTION
#### Overview:

What the PR does           
                  
  1. Bumps published image tags in 7 deploy manifests:
    - SGLang B200 (Flash + Pro): 1.2.0-sglang-deepseek-v4-b200-dev.1 → 1.2.0-deepseek-v4-cuda12-dev.2                                                      
    - SGLang GB200 (Flash): 1.2.0-sglang-deepseek-v4-gb200-dev.1 → 1.2.0-deepseek-v4-cuda13-dev.2                                                          
    - vLLM B200 + GB200 (all 5 manifests across Flash + Pro): vllm-runtime:my-tag placeholder → 1.2.0-deepseek-v4-cuda13-dev.2 (multi-arch)                
  2. Resolves a TODO in Dockerfile.dsv4.sglang.b200 by consolidating apt-get purge libx264-164 libx265-199 libde265-0 libavcodec60 libxvidcore4 into the   
  main apt block.                                                                                                                                          
  3. Adds attribution files (ATTRIBUTIONS{,-Python,-Rust}.md) to both b200 and gb200 SGLang images via COPY --from=dynamo_src.                             
  4. Trims redundant docs: removes "Update the image: fields..." comments now obsolete since the tag is pinned, and removes the per-variant "Container     
  image" prerequisite (Prerequisite 4) from both READMEs.


#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/8971" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned runtime container images across deployment manifests to specific DeepSeek‑V4 versions.
  * Removed placeholder image-tag guidance and simplified deployment instructions.

* **Documentation**
  * Updated READMEs and deployment docs to reference concrete, versioned runtime images and to list multiple available runtime variants.
  * Included attribution documentation inside the runtime image so shipped artifacts now contain attribution files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->