### PR TITLE
test(revalidate): chore(attributions): refresh Python+Rust for sglang+vllm dsv4 (amd64) #8948

### DIFF
--- a/components/src/dynamo/common/__init__.py
+++ b/components/src/dynamo/common/__init__.py
@@ -25,3 +25,5 @@ except Exception:
         __version__ = "0.0.0+unknown"
 
 __all__ = ["__version__", "config_dump", "constants", "utils"]
+
+# revalidate abf0f9e28d2 2026-05-01T06:00:04Z

--- a/lib/runtime/src/runtime.rs
+++ b/lib/runtime/src/runtime.rs
@@ -391,3 +391,5 @@ impl Drop for RuntimeType {
         }
     }
 }
+
+// revalidate abf0f9e28d2 2026-05-01T06:00:04Z


### PR DESCRIPTION
Re-validating that PR #8948 by Tushar Sharma did not regress, by re-running against a trivial placebo diff:

```
chore(attributions): refresh Python+Rust for sglang+vllm dsv4 (amd64)
```

Branch deleted on green; kept on failure for diagnosis.

Drafts are skipped by CodeRabbit per repo `.coderabbit.yaml`.