### PR TITLE
feat: [vLLM] use model family lookup for encode related handling in EPD use case

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -66,7 +66,11 @@ from .args import Config
 from .constants import DisaggregationMode, EmbeddingTransferMode
 from .engine_monitor import VllmEngineMonitor
 from .multimodal_utils.hash_utils import compute_mm_uuids_from_images
-from .multimodal_utils.model import construct_qwen_decode_mm_data, is_qwen_vl_model
+from .multimodal_utils.model import (
+    ModelFamily,
+    construct_qwen_decode_mm_data,
+    resolve_model_family,
+)
 from .multimodal_utils.models.qwen import (
     build_qwen_embedding_params,
     load_qwen_grid_params,
@@ -2095,7 +2099,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         pre_rendered: Dict[str, Any] | None = None
         if is_decode_only:
             # Decode mode: branch on model, not data.
-            if is_qwen_vl_model(self.config.model):
+            if resolve_model_family(self.config.model) is ModelFamily.QWEN_VL:
                 # Qwen VL needs embedding_params for mRoPE initialization.
                 if embedding_params is not None:
                     multi_modal_data = construct_qwen_decode_mm_data(
@@ -2385,7 +2389,7 @@ class PrefillWorkerHandler(BaseWorkerHandler):
 
         # Cache Qwen VL grid parameters for computing image_grid_thw from
         # PIL images in the P/D path (no separate encode worker).
-        if is_qwen_vl_model(config.model):
+        if resolve_model_family(config.model) is ModelFamily.QWEN_VL:
             self._qwen_grid_params = load_qwen_grid_params(config.model)
             if self._qwen_grid_params is None and self.embedding_loader is None:
                 logger.error(
@@ -2552,7 +2556,7 @@ class PrefillWorkerHandler(BaseWorkerHandler):
     ) -> Dict[str, Any] | None:
         # [gluo NOTE] there could be different model architectures that
         # need different embedding params, will add more logic if needed
-        if not is_qwen_vl_model(self.config.model):
+        if resolve_model_family(self.config.model) is not ModelFamily.QWEN_VL:
             # For non-qwen models, vLLM doesn't trigger mm preprocess so
             # decode worker only needs expanded prompt to properly fetch KV blocks
             # from prefill.

--- a/components/src/dynamo/vllm/multimodal_handlers/encode_worker_handler.py
+++ b/components/src/dynamo/vllm/multimodal_handlers/encode_worker_handler.py
@@ -32,7 +32,7 @@ from ..multimodal_utils import (
     vLLMMultimodalRequest,
 )
 from ..multimodal_utils.embedding_cache import EmbeddingCache
-from ..multimodal_utils.model import is_qwen_vl_model
+from ..multimodal_utils.model import ModelFamily, resolve_model_family
 
 logger = logging.getLogger(__name__)
 
@@ -247,7 +247,7 @@ class EncodeWorkerHandler:
                 with _nvtx.annotate("mm:enc:split_embeddings", color="orange"):
                     # [gluo FIXME] This is specific to qwen vision processing..
                     # Split concatenated embeddings for each image item.
-                    if is_qwen_vl_model(self.model):
+                    if resolve_model_family(self.model) is ModelFamily.QWEN_VL:
                         merge_size = self.vision_encoder.spatial_merge_size
                         sizes = (
                             image_embeds["image_grid_thw"].prod(-1)

--- a/components/src/dynamo/vllm/multimodal_utils/__init__.py
+++ b/components/src/dynamo/vllm/multimodal_utils/__init__.py
@@ -10,9 +10,11 @@ from dynamo.vllm.multimodal_utils.encode_utils import (
     get_encoder_components,
 )
 from dynamo.vllm.multimodal_utils.model import (
+    ModelFamily,
     SupportedModels,
     construct_mm_data,
     load_vision_model,
+    resolve_model_family,
 )
 from dynamo.vllm.multimodal_utils.prefill_worker_utils import MultiModalEmbeddingLoader
 from dynamo.vllm.multimodal_utils.protocol import (
@@ -30,9 +32,11 @@ __all__ = [
     "get_encoder_components",
     "get_http_client",
     "ImageLoader",
+    "ModelFamily",
     "SupportedModels",
     "construct_mm_data",
     "load_vision_model",
+    "resolve_model_family",
     "MultiModalInput",
     "MultiModalGroup",
     "PatchedTokensPrompt",

--- a/components/src/dynamo/vllm/multimodal_utils/__init__.py
+++ b/components/src/dynamo/vllm/multimodal_utils/__init__.py
@@ -11,7 +11,6 @@ from dynamo.vllm.multimodal_utils.encode_utils import (
 )
 from dynamo.vllm.multimodal_utils.model import (
     ModelFamily,
-    SupportedModels,
     construct_mm_data,
     load_vision_model,
     resolve_model_family,
@@ -33,7 +32,6 @@ __all__ = [
     "get_http_client",
     "ImageLoader",
     "ModelFamily",
-    "SupportedModels",
     "construct_mm_data",
     "load_vision_model",
     "resolve_model_family",

--- a/components/src/dynamo/vllm/multimodal_utils/encode_utils.py
+++ b/components/src/dynamo/vllm/multimodal_utils/encode_utils.py
@@ -20,7 +20,7 @@ from typing import Any, Dict, Optional
 
 import torch
 
-from .model import SupportedModels, is_model_supported, is_qwen_vl_model
+from .model import ModelFamily, resolve_model_family
 
 logger = logging.getLogger(__name__)
 
@@ -106,8 +106,8 @@ def encode_image_embeddings(
         NotImplementedError: If model is not supported
     """
     with torch.no_grad():
-        # Route through the correct encoder based on model
-        if is_model_supported(model_name, SupportedModels.LLAVA_1_5_7B):
+        family = resolve_model_family(model_name)
+        if family is ModelFamily.LLAVA:
             pixel_values = image_embeds["pixel_values"].to(vision_encoder.device)
             vision_outputs = vision_encoder(pixel_values)
 
@@ -116,7 +116,7 @@ def encode_image_embeddings(
 
             embeddings = projector(vision_outputs.last_hidden_state)
 
-        elif is_qwen_vl_model(model_name):
+        elif family is ModelFamily.QWEN_VL:
             embeddings = get_qwen_image_features(vision_encoder, image_embeds)
 
         else:
@@ -146,12 +146,13 @@ def get_encoder_components(
     Raises:
         NotImplementedError: If model is not supported
     """
-    if is_model_supported(model_name, SupportedModels.LLAVA_1_5_7B):
+    family = resolve_model_family(model_name)
+    if family is ModelFamily.LLAVA:
         vision_encoder = vision_model.vision_tower
         projector = getattr(vision_model, "multi_modal_projector", None)
         return vision_encoder, projector
 
-    elif is_qwen_vl_model(model_name):
+    elif family is ModelFamily.QWEN_VL:
         vision_encoder = vision_model
         projector = None
         return vision_encoder, projector

--- a/components/src/dynamo/vllm/multimodal_utils/model.py
+++ b/components/src/dynamo/vllm/multimodal_utils/model.py
@@ -53,6 +53,14 @@ _FAMILY_ARCHITECTURES: Dict[ModelFamily, frozenset[str]] = {
             "Qwen2_5_VLForConditionalGeneration",
             "Qwen3VLForConditionalGeneration",
             "Qwen3VLMoeForConditionalGeneration",
+            # Qwen3.5 subclasses Qwen3VL in vLLM
+            # (`Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration)`)
+            # with the same `self.visual = Qwen3_VisionTransformer(...)` and an
+            # identical preprocessor (`Qwen2VLImageProcessorFast`); the encoder
+            # pipeline is inherited unchanged. Inclusion based on source +
+            # config inspection — pending empirical verification against a
+            # deployed Qwen3.5 model.
+            "Qwen3_5ForConditionalGeneration",
         }
     ),
     ModelFamily.LLAVA: frozenset({"LlavaForConditionalGeneration"}),
@@ -63,7 +71,18 @@ _FAMILY_ARCHITECTURES: Dict[ModelFamily, frozenset[str]] = {
 # long as it shares the family-level prefix; only a genuinely new family
 # (e.g. Qwen4-VL) needs a pattern added.
 _FAMILY_NAME_PATTERNS: Dict[ModelFamily, frozenset[str]] = {
-    ModelFamily.QWEN_VL: frozenset({"qwen2-vl", "qwen2.5-vl", "qwen3-vl"}),
+    ModelFamily.QWEN_VL: frozenset(
+        {
+            "qwen2-vl",
+            "qwen2.5-vl",
+            "qwen3-vl",
+            # Qwen3.5 ids omit "-vl" because it's a unified multimodal
+            # architecture; bare "qwen3.5" matches all variants. Routes to
+            # QWEN_VL via the subclass relationship documented in
+            # _FAMILY_ARCHITECTURES.
+            "qwen3.5",
+        }
+    ),
     ModelFamily.LLAVA: frozenset({"llava-1.5-7b-hf"}),
 }
 

--- a/components/src/dynamo/vllm/multimodal_utils/model.py
+++ b/components/src/dynamo/vllm/multimodal_utils/model.py
@@ -17,7 +17,7 @@ import functools
 import json
 import logging
 import os
-from enum import StrEnum
+from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 VLLM_ENCODER = int(os.getenv("VLLM_ENCODER", 1))
 
 
-class ModelFamily(StrEnum):
+class ModelFamily(str, Enum):
     """Multimodal model families dynamo's encoder pipeline knows how to dispatch."""
 
     QWEN_VL = "qwen-vl"

--- a/components/src/dynamo/vllm/multimodal_utils/model.py
+++ b/components/src/dynamo/vllm/multimodal_utils/model.py
@@ -13,10 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import logging
 import os
+from enum import StrEnum
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, FrozenSet, List, Optional
 
 import torch
 from transformers import AutoModel
@@ -31,11 +33,12 @@ VLLM_ENCODER = int(os.getenv("VLLM_ENCODER", 1))
 
 
 class SupportedModels:
-    """Supported multimodal model identifiers"""
+    """Reference data: HF identifiers per supported multimodal model.
 
-    # TODO: Replace this explicit model list with dynamic detection using
-    # HF config `architectures` field or vLLM's model registry, so any
-    # vLLM-supported VLM works without maintaining entries here.
+    Authoritative family dispatch lives in `resolve_model_family`; this
+    class is the source of truth for the human-readable HF ids that feed
+    its name-stage registry.
+    """
 
     LLAVA_1_5_7B = "llava-hf/llava-1.5-7b-hf"
     QWEN_2_VL_2B = "Qwen/Qwen2-VL-2B-Instruct"
@@ -53,113 +56,144 @@ class SupportedModels:
     QWEN_3_VL_32B_FP8 = "Qwen/Qwen3-VL-32B-Instruct-FP8"
 
 
-def normalize_model_name(model_name: str) -> str:
+class ModelFamily(StrEnum):
+    """Multimodal model families dynamo's encoder pipeline knows how to dispatch."""
+
+    QWEN_VL = "qwen-vl"
+    LLAVA = "llava"
+
+
+# Per-family architecture set (matched against `config.json` `architectures`)
+# and HF-id set (matched against normalized name strings). These are the
+# source of truth for `resolve_model_family`. The encoder reaches into vLLM
+# internals (`model.visual` for Qwen, `vision_tower` + `multi_modal_projector`
+# for LLaVA) whose attribute paths vary per family — entries here must
+# correspond to extractor logic in `encode_utils.py`.
+_FAMILY_ARCHITECTURES: Dict[ModelFamily, FrozenSet[str]] = {
+    ModelFamily.QWEN_VL: frozenset(
+        {
+            "Qwen2VLForConditionalGeneration",
+            "Qwen2_5_VLForConditionalGeneration",
+            "Qwen3VLForConditionalGeneration",
+            "Qwen3VLMoeForConditionalGeneration",
+        }
+    ),
+    ModelFamily.LLAVA: frozenset({"LlavaForConditionalGeneration"}),
+}
+
+_FAMILY_HF_IDS: Dict[ModelFamily, FrozenSet[str]] = {
+    ModelFamily.QWEN_VL: frozenset(
+        {
+            SupportedModels.QWEN_2_VL_2B,
+            SupportedModels.QWEN_2_5_VL_3B,
+            SupportedModels.QWEN_2_5_VL_7B,
+            SupportedModels.QWEN_2_5_VL_32B,
+            SupportedModels.QWEN_3_VL_2B,
+            SupportedModels.QWEN_3_VL_30B_A3B,
+            SupportedModels.QWEN_3_VL_30B_A3B_FP8,
+            SupportedModels.QWEN_3_VL_8B,
+            SupportedModels.QWEN_3_VL_8B_FP8,
+            SupportedModels.QWEN_3_VL_4B,
+            SupportedModels.QWEN_3_VL_4B_FP8,
+            SupportedModels.QWEN_3_VL_32B,
+            SupportedModels.QWEN_3_VL_32B_FP8,
+        }
+    ),
+    ModelFamily.LLAVA: frozenset({SupportedModels.LLAVA_1_5_7B}),
+}
+
+
+def _load_model_config(model_name: str) -> Optional[Dict[str, Any]]:
+    """Read `config.json` from a local model directory if available."""
+    try:
+        path = Path(model_name)
+        if not path.is_dir():
+            return None
+        config_path = path / "config.json"
+        if not config_path.is_file():
+            return None
+        return json.loads(config_path.read_text())
+    except (OSError, ValueError):
+        return None
+
+
+def _normalize_model_name(model_name: str) -> str:
+    """Normalize a model identifier toward `<org>/<model>` for substring matching.
+
+    Handles:
+      - Plain HF id: returned as-is.
+      - HF cache layout `.../models--ORG--MODEL/...`: parsed to `<org>/<model>`.
+      - Other paths: walks components for the first `<org>--<model>` segment.
+      - Anything else: returned verbatim, so callers can substring-match
+        against the full path (e.g. `/foo/qwen3-vl-2b-instruct/v2`).
     """
-    Extract and normalize model name from various formats including HuggingFace cache paths.
-
-    Args:
-        model_name: Model identifier which can be:
-            - A simple model name: "Qwen/Qwen2.5-VL-7B-Instruct"
-            - A HuggingFace cache path: "/root/.cache/huggingface/hub/models--Qwen--Qwen2.5-VL-7B-Instruct/..."
-            - A local path to a model directory
-
-    Returns:
-        Normalized model name in the format "organization/model-name"
-
-    Examples:
-        >>> normalize_model_name("Qwen/Qwen2.5-VL-7B-Instruct")
-        "Qwen/Qwen2.5-VL-7B-Instruct"
-        >>> normalize_model_name("/root/.cache/huggingface/hub/models--Qwen--Qwen2.5-VL-7B-Instruct/snapshots/...")
-        "Qwen/Qwen2.5-VL-7B-Instruct"
-    """
-    # If it's already a simple model name (org/model format), return as-is
     if "/" in model_name and not model_name.startswith("/"):
         return model_name
 
-    # Handle HuggingFace cache paths
+    # HuggingFace cache layout (".../models--ORG--MODEL/...")
     if "models--" in model_name:
-        # Extract from cache path format: models--ORG--MODEL-NAME
-        # Split on "models--" then on "--" to handle dashes in org/model names
         parts_after_models = model_name.split("models--", 1)
         if len(parts_after_models) > 1:
-            # Split the remaining part on "--" and take the last two segments
             segments = parts_after_models[1].split("--")
             if len(segments) >= 2:
-                # Take all segments except the last as org (rejoined with dashes)
-                # and the last segment (before any slash) as model name
                 org_segments = segments[:-1]
-                model_segment = segments[-1].split("/")[
-                    0
-                ]  # Remove any path after model name
+                model_segment = segments[-1].split("/")[0]
+                org = "--".join(org_segments)
+                return f"{org}/{model_segment}"
+    else:
+        # Walk path components for the first `<head>--<tail>` segment
+        for component in Path(model_name).parts:
+            if "--" in component:
+                head, _, tail = component.partition("--")
+                if head and tail:
+                    return f"{head}/{tail}"
 
-                org = "--".join(org_segments)  # Rejoin org parts with dashes
-                model = model_segment
-                return f"{org}/{model}"
-
-    # Handle local directory paths - extract the last directory name
-    path = Path(model_name)
-    if path.exists() and path.is_dir():
-        return path.name
-
-    # If no pattern matches, return the original name
     return model_name
 
 
-def is_model_supported(model_name: str, supported_model: str) -> bool:
+def resolve_model_family(model_name: str) -> Optional[ModelFamily]:
+    """Canonical answer to "which family is this model?".
+
+    Used at every dynamo callsite that dispatches by model family
+    (encoder loading, encoding pipeline, decoder mm-data construction,
+    handler-side mRoPE handling). Returns `None` for models we don't
+    know how to extract a vision encoder from — callers should raise
+    `NotImplementedError` rather than dispatch into broken code.
+
+    Resolution stages:
+      1. **Metadata.** When `model_name` is a local directory with
+         `config.json`, map its `architectures` to a registered family.
+         Authoritative when present; falls through silently on
+         missing/malformed config or unrecognized arch.
+      2. **Name.** Normalize the input and substring-match against each
+         family's HF-id set. Full `<org>/<model>` first, bare `<model>`
+         second (covers org-less paths like `/foo/qwen3-vl-2b-instruct/v2`).
     """
-    Check if a model name matches a supported model, handling various naming formats.
+    config = _load_model_config(model_name)
+    if config is not None:
+        for arch in config.get("architectures") or []:
+            for family, arch_set in _FAMILY_ARCHITECTURES.items():
+                if arch in arch_set:
+                    return family
 
-    Args:
-        model_name: The model name to check (may be path, cache name, etc.)
-        supported_model: The supported model identifier
+    normalized = _normalize_model_name(model_name).lower()
+    for family, hf_ids in _FAMILY_HF_IDS.items():
+        for hf_id in hf_ids:
+            hf_id_lower = hf_id.lower()
+            if hf_id_lower in normalized:
+                return family
+            bare = hf_id_lower.rsplit("/", 1)[-1]
+            if bare and bare in normalized:
+                return family
 
-    Returns:
-        True if the model is supported, False otherwise
-    """
-    normalized_name = normalize_model_name(model_name).lower()
-    normalized_supported = normalize_model_name(supported_model).lower()
-
-    return normalized_name == normalized_supported
-
-
-# List of all Qwen VL model variants for easy extension
-QWEN_VL_MODELS = [
-    SupportedModels.QWEN_2_VL_2B,
-    SupportedModels.QWEN_2_5_VL_3B,
-    SupportedModels.QWEN_2_5_VL_7B,
-    SupportedModels.QWEN_2_5_VL_32B,
-    SupportedModels.QWEN_3_VL_2B,
-    SupportedModels.QWEN_3_VL_30B_A3B,
-    SupportedModels.QWEN_3_VL_30B_A3B_FP8,
-    SupportedModels.QWEN_3_VL_8B,
-    SupportedModels.QWEN_3_VL_8B_FP8,
-    SupportedModels.QWEN_3_VL_4B,
-    SupportedModels.QWEN_3_VL_4B_FP8,
-    SupportedModels.QWEN_3_VL_32B,
-    SupportedModels.QWEN_3_VL_32B_FP8,
-]
-
-
-def is_qwen_vl_model(model_name: str) -> bool:
-    """
-    Check if a model is any Qwen VL variant.
-
-    Args:
-        model_name: The model name to check
-
-    Returns:
-        True if the model is a Qwen VL variant, False otherwise
-    """
-    return any(
-        is_model_supported(model_name, qwen_model) for qwen_model in QWEN_VL_MODELS
-    )
+    return None
 
 
 def load_vision_model(model_id: str, enforce_eager: bool = False) -> torch.nn.Module:
     """
     Load a vision model from a HuggingFace model ID.
     """
-    if VLLM_ENCODER and is_qwen_vl_model(model_id):
+    if VLLM_ENCODER and resolve_model_family(model_id) is ModelFamily.QWEN_VL:
         # Disable to get ViT from the same process
         update_environment_variables(
             {
@@ -210,7 +244,7 @@ def construct_mm_data(
     image_embeds = image_embeds.to(embeddings_dtype)
 
     # Model-specific image handling
-    if is_qwen_vl_model(model):
+    if resolve_model_family(model) is ModelFamily.QWEN_VL:
         return _construct_qwen_image_data(image_embeds, image_grid_thw)
     else:
         # Default image handling for other models (e.g., LLAVA_1_5_7B)

--- a/components/src/dynamo/vllm/multimodal_utils/model.py
+++ b/components/src/dynamo/vllm/multimodal_utils/model.py
@@ -32,30 +32,6 @@ logger = logging.getLogger(__name__)
 VLLM_ENCODER = int(os.getenv("VLLM_ENCODER", 1))
 
 
-class SupportedModels:
-    """Reference data: HF identifiers per supported multimodal model.
-
-    Authoritative family dispatch lives in `resolve_model_family`; this
-    class is the source of truth for the human-readable HF ids that feed
-    its name-stage registry.
-    """
-
-    LLAVA_1_5_7B = "llava-hf/llava-1.5-7b-hf"
-    QWEN_2_VL_2B = "Qwen/Qwen2-VL-2B-Instruct"
-    QWEN_2_5_VL_3B = "Qwen/Qwen2.5-VL-3B-Instruct"
-    QWEN_2_5_VL_7B = "Qwen/Qwen2.5-VL-7B-Instruct"
-    QWEN_2_5_VL_32B = "Qwen/Qwen2.5-VL-32B-Instruct"
-    QWEN_3_VL_2B = "Qwen/Qwen3-VL-2B-Instruct"
-    QWEN_3_VL_30B_A3B = "Qwen/Qwen3-VL-30B-A3B-Instruct"
-    QWEN_3_VL_30B_A3B_FP8 = "Qwen/Qwen3-VL-30B-A3B-Instruct-FP8"
-    QWEN_3_VL_8B = "Qwen/Qwen3-VL-8B-Instruct"
-    QWEN_3_VL_8B_FP8 = "Qwen/Qwen3-VL-8B-Instruct-FP8"
-    QWEN_3_VL_4B = "Qwen/Qwen3-VL-4B-Instruct"
-    QWEN_3_VL_4B_FP8 = "Qwen/Qwen3-VL-4B-Instruct-FP8"
-    QWEN_3_VL_32B = "Qwen/Qwen3-VL-32B-Instruct"
-    QWEN_3_VL_32B_FP8 = "Qwen/Qwen3-VL-32B-Instruct-FP8"
-
-
 class ModelFamily(StrEnum):
     """Multimodal model families dynamo's encoder pipeline knows how to dispatch."""
 
@@ -63,12 +39,12 @@ class ModelFamily(StrEnum):
     LLAVA = "llava"
 
 
-# Per-family architecture set (matched against `config.json` `architectures`)
-# and HF-id set (matched against normalized name strings). These are the
-# source of truth for `resolve_model_family`. The encoder reaches into vLLM
-# internals (`model.visual` for Qwen, `vision_tower` + `multi_modal_projector`
-# for LLaVA) whose attribute paths vary per family — entries here must
-# correspond to extractor logic in `encode_utils.py`.
+# Per-family registries used by `resolve_model_family`. The encoder reaches
+# into vLLM internals (`model.visual` for Qwen, `vision_tower` +
+# `multi_modal_projector` for LLaVA) whose attribute paths vary per family —
+# entries here must correspond to extractor logic in `encode_utils.py`.
+#
+# Architectures are matched verbatim against `config.json` `architectures`.
 _FAMILY_ARCHITECTURES: Dict[ModelFamily, FrozenSet[str]] = {
     ModelFamily.QWEN_VL: frozenset(
         {
@@ -81,25 +57,13 @@ _FAMILY_ARCHITECTURES: Dict[ModelFamily, FrozenSet[str]] = {
     ModelFamily.LLAVA: frozenset({"LlavaForConditionalGeneration"}),
 }
 
-_FAMILY_HF_IDS: Dict[ModelFamily, FrozenSet[str]] = {
-    ModelFamily.QWEN_VL: frozenset(
-        {
-            SupportedModels.QWEN_2_VL_2B,
-            SupportedModels.QWEN_2_5_VL_3B,
-            SupportedModels.QWEN_2_5_VL_7B,
-            SupportedModels.QWEN_2_5_VL_32B,
-            SupportedModels.QWEN_3_VL_2B,
-            SupportedModels.QWEN_3_VL_30B_A3B,
-            SupportedModels.QWEN_3_VL_30B_A3B_FP8,
-            SupportedModels.QWEN_3_VL_8B,
-            SupportedModels.QWEN_3_VL_8B_FP8,
-            SupportedModels.QWEN_3_VL_4B,
-            SupportedModels.QWEN_3_VL_4B_FP8,
-            SupportedModels.QWEN_3_VL_32B,
-            SupportedModels.QWEN_3_VL_32B_FP8,
-        }
-    ),
-    ModelFamily.LLAVA: frozenset({SupportedModels.LLAVA_1_5_7B}),
+# Name-stage substring patterns (lowercase). A new size / quantization /
+# MoE variant of an existing family doesn't require a registry change as
+# long as it shares the family-level prefix; only a genuinely new family
+# (e.g. Qwen4-VL) needs a pattern added.
+_FAMILY_NAME_PATTERNS: Dict[ModelFamily, FrozenSet[str]] = {
+    ModelFamily.QWEN_VL: frozenset({"qwen2-vl", "qwen2.5-vl", "qwen3-vl"}),
+    ModelFamily.LLAVA: frozenset({"llava-1.5-7b-hf"}),
 }
 
 
@@ -166,8 +130,10 @@ def resolve_model_family(model_name: str) -> Optional[ModelFamily]:
          Authoritative when present; falls through silently on
          missing/malformed config or unrecognized arch.
       2. **Name.** Normalize the input and substring-match against each
-         family's HF-id set. Full `<org>/<model>` first, bare `<model>`
-         second (covers org-less paths like `/foo/qwen3-vl-2b-instruct/v2`).
+         family's name patterns (e.g. `qwen2-vl`, `qwen3-vl`,
+         `llava-1.5-7b-hf`). Patterns are family-level prefixes, so new
+         sizes / quantizations of an existing family resolve without a
+         registry change.
     """
     config = _load_model_config(model_name)
     if config is not None:
@@ -177,13 +143,9 @@ def resolve_model_family(model_name: str) -> Optional[ModelFamily]:
                     return family
 
     normalized = _normalize_model_name(model_name).lower()
-    for family, hf_ids in _FAMILY_HF_IDS.items():
-        for hf_id in hf_ids:
-            hf_id_lower = hf_id.lower()
-            if hf_id_lower in normalized:
-                return family
-            bare = hf_id_lower.rsplit("/", 1)[-1]
-            if bare and bare in normalized:
+    for family, patterns in _FAMILY_NAME_PATTERNS.items():
+        for pattern in patterns:
+            if pattern in normalized:
                 return family
 
     return None

--- a/components/src/dynamo/vllm/multimodal_utils/model.py
+++ b/components/src/dynamo/vllm/multimodal_utils/model.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools
 import json
 import logging
 import os
@@ -82,15 +83,7 @@ def _load_model_config(model_name: str) -> Optional[Dict[str, Any]]:
 
 
 def _normalize_model_name(model_name: str) -> str:
-    """Normalize a model identifier toward `<org>/<model>` for substring matching.
-
-    Handles:
-      - Plain HF id: returned as-is.
-      - HF cache layout `.../models--ORG--MODEL/...`: parsed to `<org>/<model>`.
-      - Other paths: walks components for the first `<org>--<model>` segment.
-      - Anything else: returned verbatim, so callers can substring-match
-        against the full path (e.g. `/foo/qwen3-vl-2b-instruct/v2`).
-    """
+    """Normalize a model identifier toward `<org>/<model>` (or verbatim if no shape matches)."""
     if "/" in model_name and not model_name.startswith("/"):
         return model_name
 
@@ -115,6 +108,7 @@ def _normalize_model_name(model_name: str) -> str:
     return model_name
 
 
+@functools.lru_cache(maxsize=8)
 def resolve_model_family(model_name: str) -> Optional[ModelFamily]:
     """Canonical answer to "which family is this model?".
 
@@ -144,9 +138,8 @@ def resolve_model_family(model_name: str) -> Optional[ModelFamily]:
 
     normalized = _normalize_model_name(model_name).lower()
     for family, patterns in _FAMILY_NAME_PATTERNS.items():
-        for pattern in patterns:
-            if pattern in normalized:
-                return family
+        if any(pattern in normalized for pattern in patterns):
+            return family
 
     return None
 

--- a/components/src/dynamo/vllm/multimodal_utils/model.py
+++ b/components/src/dynamo/vllm/multimodal_utils/model.py
@@ -19,7 +19,7 @@ import logging
 import os
 from enum import StrEnum
 from pathlib import Path
-from typing import Any, Dict, FrozenSet, List, Optional
+from typing import Any, Dict, List, Optional
 
 import torch
 from transformers import AutoModel
@@ -46,7 +46,7 @@ class ModelFamily(StrEnum):
 # entries here must correspond to extractor logic in `encode_utils.py`.
 #
 # Architectures are matched verbatim against `config.json` `architectures`.
-_FAMILY_ARCHITECTURES: Dict[ModelFamily, FrozenSet[str]] = {
+_FAMILY_ARCHITECTURES: Dict[ModelFamily, frozenset[str]] = {
     ModelFamily.QWEN_VL: frozenset(
         {
             "Qwen2VLForConditionalGeneration",
@@ -62,7 +62,7 @@ _FAMILY_ARCHITECTURES: Dict[ModelFamily, FrozenSet[str]] = {
 # MoE variant of an existing family doesn't require a registry change as
 # long as it shares the family-level prefix; only a genuinely new family
 # (e.g. Qwen4-VL) needs a pattern added.
-_FAMILY_NAME_PATTERNS: Dict[ModelFamily, FrozenSet[str]] = {
+_FAMILY_NAME_PATTERNS: Dict[ModelFamily, frozenset[str]] = {
     ModelFamily.QWEN_VL: frozenset({"qwen2-vl", "qwen2.5-vl", "qwen3-vl"}),
     ModelFamily.LLAVA: frozenset({"llava-1.5-7b-hf"}),
 }
@@ -82,52 +82,44 @@ def _load_model_config(model_name: str) -> Optional[Dict[str, Any]]:
         return None
 
 
-def _normalize_model_name(model_name: str) -> str:
-    """Normalize a model identifier toward `<org>/<model>` (or verbatim if no shape matches)."""
-    if "/" in model_name and not model_name.startswith("/"):
-        return model_name
-
-    # HuggingFace cache layout (".../models--ORG--MODEL/...")
-    if "models--" in model_name:
-        parts_after_models = model_name.split("models--", 1)
-        if len(parts_after_models) > 1:
-            segments = parts_after_models[1].split("--")
-            if len(segments) >= 2:
-                org_segments = segments[:-1]
-                model_segment = segments[-1].split("/")[0]
-                org = "--".join(org_segments)
-                return f"{org}/{model_segment}"
-    else:
-        # Walk path components for the first `<head>--<tail>` segment
-        for component in Path(model_name).parts:
-            if "--" in component:
-                head, _, tail = component.partition("--")
-                if head and tail:
-                    return f"{head}/{tail}"
-
-    return model_name
-
-
 @functools.lru_cache(maxsize=8)
 def resolve_model_family(model_name: str) -> Optional[ModelFamily]:
-    """Canonical answer to "which family is this model?".
+    """Return the multimodal model family for the given identifier, or `None`
+    if no registered family matches.
 
-    Used at every dynamo callsite that dispatches by model family
-    (encoder loading, encoding pipeline, decoder mm-data construction,
-    handler-side mRoPE handling). Returns `None` for models we don't
-    know how to extract a vision encoder from — callers should raise
-    `NotImplementedError` rather than dispatch into broken code.
+    Resolution proceeds in two stages: a `config.json` `architectures`
+    lookup when `model_name` is a local directory with config (authoritative
+    when present), falling through to a lowercased substring scan against
+    per-family name patterns (`qwen2-vl`, `qwen3-vl`, `llava-1.5-7b-hf`).
+    Patterns are family-level prefixes, so HF ids, HF cache layouts, and
+    hand-rolled local paths are all handled by the same scan, and new
+    sizes / quantizations of an existing family resolve without a registry
+    change.
 
-    Resolution stages:
-      1. **Metadata.** When `model_name` is a local directory with
-         `config.json`, map its `architectures` to a registered family.
-         Authoritative when present; falls through silently on
-         missing/malformed config or unrecognized arch.
-      2. **Name.** Normalize the input and substring-match against each
-         family's name patterns (e.g. `qwen2-vl`, `qwen3-vl`,
-         `llava-1.5-7b-hf`). Patterns are family-level prefixes, so new
-         sizes / quantizations of an existing family resolve without a
-         registry change.
+    Args:
+        model_name: A model identifier. Accepts an HF id, an HF cache
+            snapshot path, or a local directory path (with or without
+            `config.json`, with or without an HF-cache-style parent
+            segment).
+
+    Returns:
+        The matching `ModelFamily`, or `None` if no registered family
+        matches the input.
+
+    Examples:
+        All of the following resolve to `ModelFamily.QWEN_VL`:
+
+        >>> resolve_model_family("Qwen/Qwen2-VL-2B-Instruct")
+        >>> resolve_model_family(
+        ...     "/root/.cache/huggingface/hub/"
+        ...     "models--Qwen--Qwen2-VL-2B-Instruct/snapshots/abc123"
+        ... )
+        >>> resolve_model_family("/local_store/Qwen--Qwen2-VL-2B-Instruct/v2")
+        >>> resolve_model_family("/runs/qwen2.5-vl-7b-instruct/v3")
+
+        A local directory containing `config.json` with
+        `{"architectures": ["Qwen2VLForConditionalGeneration"]}` resolves
+        via the metadata stage regardless of the directory's name.
     """
     config = _load_model_config(model_name)
     if config is not None:
@@ -136,9 +128,9 @@ def resolve_model_family(model_name: str) -> Optional[ModelFamily]:
                 if arch in arch_set:
                     return family
 
-    normalized = _normalize_model_name(model_name).lower()
+    lowered = model_name.lower()
     for family, patterns in _FAMILY_NAME_PATTERNS.items():
-        if any(pattern in normalized for pattern in patterns):
+        if any(pattern in lowered for pattern in patterns):
             return family
 
     return None

--- a/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_model.py
+++ b/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_model.py
@@ -1,13 +1,18 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Unit tests for DynamoMultimodalEmbeddingCacheConnector."""
+"""Unit tests for dynamo.vllm.multimodal_utils.model."""
 
+import json
 
 import pytest
 import torch
 
-from dynamo.vllm.multimodal_utils.model import construct_qwen_decode_mm_data
+from dynamo.vllm.multimodal_utils.model import (
+    ModelFamily,
+    construct_qwen_decode_mm_data,
+    resolve_model_family,
+)
 
 pytestmark = [
     pytest.mark.pre_merge,
@@ -41,3 +46,106 @@ class TestMultiModalUtils:
             )
             # Embedding values are randomly genearted as placehodler, we only check the shape
             assert mm_data["image"]["image_embeds"].shape == (2, 1024)
+
+
+class TestResolveModelFamily:
+    """Cases where resolution is determined entirely by the input string
+    (no filesystem state needed). Filesystem-dependent cases live in
+    `TestResolveModelFamilyOnDisk`."""
+
+    @pytest.mark.parametrize(
+        "model_name, expected",
+        [
+            pytest.param(
+                "Qwen/Qwen2-VL-2B-Instruct",
+                ModelFamily.QWEN_VL,
+                id="hf-id-qwen2-vl",
+            ),
+            pytest.param(
+                "Qwen/Qwen3-VL-2B-Instruct",
+                ModelFamily.QWEN_VL,
+                id="hf-id-qwen3-vl",
+            ),
+            pytest.param(
+                "llava-hf/llava-1.5-7b-hf",
+                ModelFamily.LLAVA,
+                id="hf-id-llava",
+            ),
+            pytest.param(
+                "/root/.cache/huggingface/hub/"
+                "models--Qwen--Qwen2-VL-2B-Instruct/snapshots/abc123",
+                ModelFamily.QWEN_VL,
+                id="hf-cache-snapshot",
+            ),
+            pytest.param(
+                "/local_store/Qwen--Qwen3-VL-2B-Instruct/v2",
+                ModelFamily.QWEN_VL,
+                id="local_store-parent-with-version",
+            ),
+            pytest.param(
+                "/local_store/qwen2.5-vl-7b-instruct/v3",
+                ModelFamily.QWEN_VL,
+                id="local_store-org-less",
+            ),
+            pytest.param("RandomOrg/RandomModel-7B", None, id="unsupported-hf-id"),
+        ],
+    )
+    def test_resolve_string_inputs(self, model_name, expected):
+        assert resolve_model_family(model_name) == expected
+
+
+class TestResolveModelFamilyOnDisk:
+    """Cases where resolution depends on filesystem state (`config.json` or
+    directory existence)."""
+
+    def write_config(self, model_dir, architectures):
+        model_dir.mkdir(parents=True)
+        (model_dir / "config.json").write_text(
+            json.dumps({"architectures": architectures})
+        )
+
+    def test_metadata_stage_qwen2_vl(self, tmp_path):
+        model_dir = tmp_path / "Qwen--Qwen2-VL-2B-Instruct" / "v2"
+        self.write_config(model_dir, ["Qwen2VLForConditionalGeneration"])
+        assert resolve_model_family(str(model_dir)) == ModelFamily.QWEN_VL
+
+    def test_metadata_stage_qwen3_vl(self, tmp_path):
+        model_dir = tmp_path / "Qwen--Qwen3-VL-2B-Instruct" / "v2"
+        self.write_config(model_dir, ["Qwen3VLForConditionalGeneration"])
+        assert resolve_model_family(str(model_dir)) == ModelFamily.QWEN_VL
+
+    def test_metadata_stage_llava(self, tmp_path):
+        model_dir = tmp_path / "llava-hf--llava-1.5-7b-hf" / "v1"
+        self.write_config(model_dir, ["LlavaForConditionalGeneration"])
+        assert resolve_model_family(str(model_dir)) == ModelFamily.LLAVA
+
+    def test_name_stage_no_config_cache_style_parent(self, tmp_path):
+        """Directory exists but has no `config.json` — name-stage path-component
+        scan should still resolve via the `Qwen--Qwen2-VL-2B-Instruct` parent."""
+        model_dir = tmp_path / "Qwen--Qwen2-VL-2B-Instruct" / "v2"
+        model_dir.mkdir(parents=True)
+        assert resolve_model_family(str(model_dir)) == ModelFamily.QWEN_VL
+
+    def test_name_stage_no_config_llava(self, tmp_path):
+        model_dir = tmp_path / "llava-hf--llava-1.5-7b-hf" / "v1"
+        model_dir.mkdir(parents=True)
+        assert resolve_model_family(str(model_dir)) == ModelFamily.LLAVA
+
+    def test_unrecognized_arch_falls_through_to_name_stage(self, tmp_path):
+        """Metadata stage misses (arch not in registry); name stage catches via
+        the `Qwen--Qwen2-VL-2B-Instruct` parent segment."""
+        model_dir = tmp_path / "Qwen--Qwen2-VL-2B-Instruct" / "v2"
+        self.write_config(model_dir, ["SomeFutureQwenVariantClass"])
+        assert resolve_model_family(str(model_dir)) == ModelFamily.QWEN_VL
+
+    def test_org_less_path_resolves_via_bare_substring(self, tmp_path):
+        """Org prefix dropped; verbatim normalization + bare-name substring
+        match resolves the family."""
+        model_dir = tmp_path / "qwen3-vl-2b-instruct" / "v2"
+        model_dir.mkdir(parents=True)
+        assert resolve_model_family(str(model_dir)) == ModelFamily.QWEN_VL
+
+    def test_unsupported_path_returns_none(self, tmp_path):
+        model_dir = tmp_path / "random-org--random-model" / "v1"
+        model_dir.mkdir(parents=True)
+        assert resolve_model_family(str(model_dir)) is None

--- a/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_model.py
+++ b/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_model.py
@@ -67,6 +67,11 @@ class TestResolveModelFamily:
                 id="hf-id-qwen3-vl",
             ),
             pytest.param(
+                "Qwen/Qwen3.5-9B",
+                ModelFamily.QWEN_VL,
+                id="hf-id-qwen3.5-unified",
+            ),
+            pytest.param(
                 "llava-hf/llava-1.5-7b-hf",
                 ModelFamily.LLAVA,
                 id="hf-id-llava",
@@ -119,6 +124,12 @@ class TestResolveModelFamilyOnDisk:
                 ["LlavaForConditionalGeneration"],
                 ModelFamily.LLAVA,
                 id="metadata-llava",
+            ),
+            pytest.param(
+                "Qwen--Qwen3.5-9B/v1",
+                ["Qwen3_5ForConditionalGeneration"],
+                ModelFamily.QWEN_VL,
+                id="metadata-qwen3.5-unified",
             ),
         ],
     )

--- a/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_model.py
+++ b/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_model.py
@@ -95,57 +95,50 @@ class TestResolveModelFamily:
 
 
 class TestResolveModelFamilyOnDisk:
-    """Cases where resolution depends on filesystem state (`config.json` or
-    directory existence)."""
+    """Cases that genuinely require filesystem state (a real `config.json` to
+    exercise the metadata stage). Cases where directory existence is irrelevant
+    to the result are covered string-only in `TestResolveModelFamily`."""
 
-    def write_config(self, model_dir, architectures):
+    @pytest.mark.parametrize(
+        "subdir, architectures, expected",
+        [
+            pytest.param(
+                "Qwen--Qwen2-VL-2B-Instruct/v2",
+                ["Qwen2VLForConditionalGeneration"],
+                ModelFamily.QWEN_VL,
+                id="metadata-qwen2-vl",
+            ),
+            pytest.param(
+                "Qwen--Qwen3-VL-2B-Instruct/v2",
+                ["Qwen3VLForConditionalGeneration"],
+                ModelFamily.QWEN_VL,
+                id="metadata-qwen3-vl",
+            ),
+            pytest.param(
+                "llava-hf--llava-1.5-7b-hf/v1",
+                ["LlavaForConditionalGeneration"],
+                ModelFamily.LLAVA,
+                id="metadata-llava",
+            ),
+        ],
+    )
+    def test_metadata_stage_resolves_family(
+        self, tmp_path, subdir, architectures, expected
+    ):
+        model_dir = tmp_path / subdir
         model_dir.mkdir(parents=True)
         (model_dir / "config.json").write_text(
             json.dumps({"architectures": architectures})
         )
-
-    def test_metadata_stage_qwen2_vl(self, tmp_path):
-        model_dir = tmp_path / "Qwen--Qwen2-VL-2B-Instruct" / "v2"
-        self.write_config(model_dir, ["Qwen2VLForConditionalGeneration"])
-        assert resolve_model_family(str(model_dir)) == ModelFamily.QWEN_VL
-
-    def test_metadata_stage_qwen3_vl(self, tmp_path):
-        model_dir = tmp_path / "Qwen--Qwen3-VL-2B-Instruct" / "v2"
-        self.write_config(model_dir, ["Qwen3VLForConditionalGeneration"])
-        assert resolve_model_family(str(model_dir)) == ModelFamily.QWEN_VL
-
-    def test_metadata_stage_llava(self, tmp_path):
-        model_dir = tmp_path / "llava-hf--llava-1.5-7b-hf" / "v1"
-        self.write_config(model_dir, ["LlavaForConditionalGeneration"])
-        assert resolve_model_family(str(model_dir)) == ModelFamily.LLAVA
-
-    def test_name_stage_no_config_cache_style_parent(self, tmp_path):
-        """Directory exists but has no `config.json` — name-stage path-component
-        scan should still resolve via the `Qwen--Qwen2-VL-2B-Instruct` parent."""
-        model_dir = tmp_path / "Qwen--Qwen2-VL-2B-Instruct" / "v2"
-        model_dir.mkdir(parents=True)
-        assert resolve_model_family(str(model_dir)) == ModelFamily.QWEN_VL
-
-    def test_name_stage_no_config_llava(self, tmp_path):
-        model_dir = tmp_path / "llava-hf--llava-1.5-7b-hf" / "v1"
-        model_dir.mkdir(parents=True)
-        assert resolve_model_family(str(model_dir)) == ModelFamily.LLAVA
+        assert resolve_model_family(str(model_dir)) == expected
 
     def test_unrecognized_arch_falls_through_to_name_stage(self, tmp_path):
-        """Metadata stage misses (arch not in registry); name stage catches via
-        the `Qwen--Qwen2-VL-2B-Instruct` parent segment."""
+        """`config.json` exists but its arch isn't in the registry — the
+        resolver must fall through to the name stage rather than return
+        None on metadata miss."""
         model_dir = tmp_path / "Qwen--Qwen2-VL-2B-Instruct" / "v2"
-        self.write_config(model_dir, ["SomeFutureQwenVariantClass"])
-        assert resolve_model_family(str(model_dir)) == ModelFamily.QWEN_VL
-
-    def test_org_less_path_resolves_via_bare_substring(self, tmp_path):
-        """Org prefix dropped; verbatim normalization + bare-name substring
-        match resolves the family."""
-        model_dir = tmp_path / "qwen3-vl-2b-instruct" / "v2"
         model_dir.mkdir(parents=True)
+        (model_dir / "config.json").write_text(
+            json.dumps({"architectures": ["SomeFutureQwenVariantClass"]})
+        )
         assert resolve_model_family(str(model_dir)) == ModelFamily.QWEN_VL
-
-    def test_unsupported_path_returns_none(self, tmp_path):
-        model_dir = tmp_path / "random-org--random-model" / "v1"
-        model_dir.mkdir(parents=True)
-        assert resolve_model_family(str(model_dir)) is None


### PR DESCRIPTION
#### Overview:

Multimodal worker startup fails for any model loaded from a local path whose final segment isn't an HF model id — e.g. `<volume>/Qwen--Qwen2-VL-2B-Instruct/v2`, a layout produced by K8s deployments that download models from a registry to a local volume. The encoder's model-support lookup uses the model-name-or-path string verbatim and only matches a hard-coded list of HF ids, so anything that doesn't already look like `<org>/<model>` raises `NotImplementedError: Model not supported: <path>`.

The narrow fix would be to teach the support check about more path shapes. But every callsite of `is_qwen_vl_model(name)` and `is_model_supported(name, SupportedModels.LLAVA_1_5_7B)` — eight in total, across `model.py`, `encode_utils.py`, `handlers.py`, and `encode_worker_handler.py` — is asking the same higher-level question: *which model family is this so I can pick the right code path?* The underlying problem is that there's no canonical answer to that question anywhere in the codebase; patching one lookup site cements the misnamed abstraction without addressing the structural issue.

This PR introduces `ModelFamily` + `resolve_model_family` as that canonical answer, converts every callsite to branch on the resolver's return, and removes the eight previously-inconsistent dispatch paths.

#### Details:

`resolve_model_family(model_name) -> Optional[ModelFamily]` resolves in two stages:

1. **Metadata.** When `model_name` is a local directory containing `config.json`, map its `architectures` field to a registered family. Authoritative when present.
2. **Name.** Lowercase the input and substring-match against family-level patterns (`qwen2-vl`, `qwen2.5-vl`, `qwen3-vl`, `llava-1.5-7b-hf`). Patterns are short enough to appear as substrings in any reasonable input format (HF id, HF cache snapshot path, `<HF-cache-name>/<version>` layout, hand-rolled `/foo/qwen3-vl-2b-instruct/v2`) without per-format normalization. New sizes / quantizations / MoE variants of an existing family resolve without a registry change.

The result is `lru_cache`-memoized per worker since `model_name` is invariant for a worker's lifetime.

Removed:
- `is_qwen_vl_model`, `is_model_supported` (callsites converted)
- `SupportedModels.QWEN_*` (13 dead per-variant entries)
- `QWEN_VL_MODELS`, `normalize_model_name` (dead helpers)

The architecture registry still lists exact class names (`Qwen2VLForConditionalGeneration` etc.) because vLLM-internals extraction varies per architecture — that's intentionally not collapsed.

#### Where should the reviewer start?

- `components/src/dynamo/vllm/multimodal_utils/model.py` — `ModelFamily`, the family registries, and `resolve_model_family`. The single new abstraction.
- `components/src/dynamo/vllm/multimodal_utils/encode_utils.py` — the most representative callsite migration; both `encode_image_embeddings` and `get_encoder_components` cascades convert.
- `components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_model.py` — parametrized table covering each input format the resolver handles.

`handlers.py` and `encode_worker_handler.py` changes are mechanical: `is_qwen_vl_model(x)` → `resolve_model_family(x) is ModelFamily.QWEN_VL` (with `is not` for the negated case in `handlers.py:2555`).

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx  <!-- file a public issue or remove this line -->

---

#### Test plan

- [x] `pytest components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_model.py` — 12 tests pass (parametrized trace table + metadata-stage on-disk + unrecognized-arch fall-through).
- [x] Pre-commit clean on host across all six changed files.
- [ ] **Reviewer:** verify the negated conversion in `handlers.py:2555` (`not is_qwen_vl_model(...)` → `... is not ModelFamily.QWEN_VL`) preserves semantics.
- [ ] **Downstream validation:** encoder worker starts cleanly on a Qwen-VL model loaded from `<HF-cache-name>/<version>` layout, e.g.:
  ```
  mkdir -p /tmp/m/Qwen--Qwen3-VL-2B-Instruct/v2
  cp -r ~/.cache/huggingface/hub/models--Qwen--Qwen3-VL-2B-Instruct/snapshots/<sha>/* \
        /tmp/m/Qwen--Qwen3-VL-2B-Instruct/v2/
  # then: --model /tmp/m/Qwen--Qwen3-VL-2B-Instruct/v2
  ```

#### Risks / known limitations

- Substring matching can false-positive within a family (e.g. a hypothetical `Qwen3-VL-2B-Instruct-Reasoning` would match Qwen-VL). Cross-family collisions aren't possible — families don't share substrings — and within-family routing is uniform, so the risk is harmless for current dispatch.
- `_load_model_config` swallows `OSError` / `ValueError` silently and falls through to the name stage. Intentional: a malformed `config.json` shouldn't break dispatch.
