### PR TITLE
test(revalidate): fix: use latency ratio as minimum floor #8861

### DIFF
--- a/components/src/dynamo/common/__init__.py
+++ b/components/src/dynamo/common/__init__.py
@@ -25,3 +25,5 @@ except Exception:
         __version__ = "0.0.0+unknown"
 
 __all__ = ["__version__", "config_dump", "constants", "utils"]
+
+# revalidate b5d73a24ed1 2026-05-01T07:21:04Z

--- a/lib/runtime/src/runtime.rs
+++ b/lib/runtime/src/runtime.rs
@@ -391,3 +391,5 @@ impl Drop for RuntimeType {
         }
     }
 }
+
+// revalidate b5d73a24ed1 2026-05-01T07:21:04Z


### PR DESCRIPTION
Re-validating that PR #8861 by hhzhang16 did not regress, by re-running against a trivial placebo diff:

```
fix: use latency ratio as minimum floor
```

Branch deleted on green; kept on failure for diagnosis.

Drafts are skipped by CodeRabbit per repo `.coderabbit.yaml`.