### PR TITLE
test(revalidate): feat(trtllm): unified worker honors --extra-engine-args / --override-engine-args #8886

### DIFF
--- a/components/src/dynamo/common/__init__.py
+++ b/components/src/dynamo/common/__init__.py
@@ -25,3 +25,5 @@ except Exception:
         __version__ = "0.0.0+unknown"
 
 __all__ = ["__version__", "config_dump", "constants", "utils"]
+
+# revalidate c39a477aeb7 2026-05-01T08:35:04Z

--- a/lib/runtime/src/runtime.rs
+++ b/lib/runtime/src/runtime.rs
@@ -391,3 +391,5 @@ impl Drop for RuntimeType {
         }
     }
 }
+
+// revalidate c39a477aeb7 2026-05-01T08:35:04Z


### PR DESCRIPTION
Re-validating that PR #8886 by Keiven C did not regress, by re-running against a trivial placebo diff:

```
feat(trtllm): unified worker honors --extra-engine-args / --override-engine-args
```

Branch deleted on green; kept on failure for diagnosis.

Drafts are skipped by CodeRabbit per repo `.coderabbit.yaml`.