### PR TITLE
test(revalidate): test(kv-router): cover Mooncake approx TTL drain #8947

### DIFF
--- a/components/src/dynamo/common/__init__.py
+++ b/components/src/dynamo/common/__init__.py
@@ -25,3 +25,5 @@ except Exception:
         __version__ = "0.0.0+unknown"
 
 __all__ = ["__version__", "config_dump", "constants", "utils"]
+
+# revalidate dbf38cb642d 2026-05-01T09:56:04Z

--- a/lib/runtime/src/runtime.rs
+++ b/lib/runtime/src/runtime.rs
@@ -391,3 +391,5 @@ impl Drop for RuntimeType {
         }
     }
 }
+
+// revalidate dbf38cb642d 2026-05-01T09:56:04Z


### PR DESCRIPTION
Re-validating that PR #8947 by Yan Ru Pei did not regress, by re-running against a trivial placebo diff:

```
test(kv-router): cover Mooncake approx TTL drain
```

Branch deleted on green; kept on failure for diagnosis.

Drafts are skipped by CodeRabbit per repo `.coderabbit.yaml`.