### PR TITLE
test(revalidate): test(parsers): DIS-1842 — DSv4 + Kimi K2 unit-test coverage gaps #8946

### DIFF
--- a/components/src/dynamo/common/__init__.py
+++ b/components/src/dynamo/common/__init__.py
@@ -25,3 +25,5 @@ except Exception:
         __version__ = "0.0.0+unknown"
 
 __all__ = ["__version__", "config_dump", "constants", "utils"]
+
+# revalidate 85c128101e0 2026-05-01T15:21:04Z

--- a/lib/runtime/src/runtime.rs
+++ b/lib/runtime/src/runtime.rs
@@ -391,3 +391,5 @@ impl Drop for RuntimeType {
         }
     }
 }
+
+// revalidate 85c128101e0 2026-05-01T15:21:04Z


### PR DESCRIPTION
Re-validating that PR #8946 by Keiven C did not regress, by re-running against a trivial placebo diff:

```
test(parsers): DIS-1842 — DSv4 + Kimi K2 unit-test coverage gaps
```

Branch deleted on green; kept on failure for diagnosis.

Drafts are skipped by CodeRabbit per repo `.coderabbit.yaml`.