### PR TITLE
test(revalidate): fix(ci): build aws stage for EFA images instead of stopping at runtime #8970

### DIFF
--- a/components/src/dynamo/common/__init__.py
+++ b/components/src/dynamo/common/__init__.py
@@ -25,3 +25,5 @@ except Exception:
         __version__ = "0.0.0+unknown"
 
 __all__ = ["__version__", "config_dump", "constants", "utils"]
+
+# revalidate 819a6029472 2026-05-01T16:07:04Z

--- a/lib/runtime/src/runtime.rs
+++ b/lib/runtime/src/runtime.rs
@@ -391,3 +391,5 @@ impl Drop for RuntimeType {
         }
     }
 }
+
+// revalidate 819a6029472 2026-05-01T16:07:04Z


### PR DESCRIPTION
Re-validating that PR #8970 by Jie Hao did not regress, by re-running against a trivial placebo diff:

```
fix(ci): build aws stage for EFA images instead of stopping at runtime
```

Branch deleted on green; kept on failure for diagnosis.

Drafts are skipped by CodeRabbit per repo `.coderabbit.yaml`.