### PR TITLE
test(revalidate): feat(mm): LRU media cache in Rust frontend MediaLoader #8863

### DIFF
--- a/components/src/dynamo/common/__init__.py
+++ b/components/src/dynamo/common/__init__.py
@@ -25,3 +25,5 @@ except Exception:
         __version__ = "0.0.0+unknown"
 
 __all__ = ["__version__", "config_dump", "constants", "utils"]
+
+# revalidate 27c0f4bb480 2026-05-01T16:42:04Z

--- a/lib/runtime/src/runtime.rs
+++ b/lib/runtime/src/runtime.rs
@@ -391,3 +391,5 @@ impl Drop for RuntimeType {
         }
     }
 }
+
+// revalidate 27c0f4bb480 2026-05-01T16:42:04Z


### PR DESCRIPTION
Re-validating that PR #8863 by Kris Hung did not regress, by re-running against a trivial placebo diff:

```
feat(mm): LRU media cache in Rust frontend MediaLoader
```

Branch deleted on green; kept on failure for diagnosis.

Drafts are skipped by CodeRabbit per repo `.coderabbit.yaml`.