### PR TITLE
test(revalidate): fix(profiler): enforce totalGpus budget as hard cap in rapid mode DGD generation #8617

### DIFF
--- a/components/src/dynamo/common/__init__.py
+++ b/components/src/dynamo/common/__init__.py
@@ -25,3 +25,5 @@ except Exception:
         __version__ = "0.0.0+unknown"
 
 __all__ = ["__version__", "config_dump", "constants", "utils"]
+
+# revalidate f35bdc3b0bc 2026-05-01T16:42:16Z

--- a/lib/runtime/src/runtime.rs
+++ b/lib/runtime/src/runtime.rs
@@ -391,3 +391,5 @@ impl Drop for RuntimeType {
         }
     }
 }
+
+// revalidate f35bdc3b0bc 2026-05-01T16:42:16Z


### PR DESCRIPTION
Re-validating that PR #8617 by Ashna Mehrotra did not regress, by re-running against a trivial placebo diff:

```
fix(profiler): enforce totalGpus budget as hard cap in rapid mode DGD generation
```

Branch deleted on green; kept on failure for diagnosis.

Drafts are skipped by CodeRabbit per repo `.coderabbit.yaml`.