### PR TITLE
test(revalidate): test(ci): fix and re-enable trtllm + sglang gpu_1 parallel pre-merge tests #8885

### DIFF
--- a/components/src/dynamo/common/__init__.py
+++ b/components/src/dynamo/common/__init__.py
@@ -25,3 +25,5 @@ except Exception:
         __version__ = "0.0.0+unknown"
 
 __all__ = ["__version__", "config_dump", "constants", "utils"]
+
+# revalidate 844b1f4e62a 2026-05-01T17:21:04Z

--- a/lib/runtime/src/runtime.rs
+++ b/lib/runtime/src/runtime.rs
@@ -391,3 +391,5 @@ impl Drop for RuntimeType {
         }
     }
 }
+
+// revalidate 844b1f4e62a 2026-05-01T17:21:04Z


### PR DESCRIPTION
Re-validating that PR #8885 by Keiven C did not regress, by re-running against a trivial placebo diff:

```
test(ci): fix and re-enable trtllm + sglang gpu_1 parallel pre-merge tests
```

Branch deleted on green; kept on failure for diagnosis.

Drafts are skipped by CodeRabbit per repo `.coderabbit.yaml`.