### PR TITLE
test(revalidate): fix: remove `compute_hash` and replace with `compute_hash_v2` #8968

### DIFF
--- a/components/src/dynamo/common/__init__.py
+++ b/components/src/dynamo/common/__init__.py
@@ -25,3 +25,5 @@ except Exception:
         __version__ = "0.0.0+unknown"
 
 __all__ = ["__version__", "config_dump", "constants", "utils"]
+
+# revalidate ee23de8bd97 2026-05-01T18:07:05Z

--- a/lib/runtime/src/runtime.rs
+++ b/lib/runtime/src/runtime.rs
@@ -391,3 +391,5 @@ impl Drop for RuntimeType {
         }
     }
 }
+
+// revalidate ee23de8bd97 2026-05-01T18:07:05Z


### PR DESCRIPTION
Re-validating that PR #8968 by ishandhanani did not regress, by re-running against a trivial placebo diff:

```
fix: remove `compute_hash` and replace with `compute_hash_v2`
```

Branch deleted on green; kept on failure for diagnosis.

Drafts are skipped by CodeRabbit per repo `.coderabbit.yaml`.