### PR TITLE
test(revalidate): chore: Update DeepSeek v4 recipes with public dev.2 images #8971

### DIFF
--- a/components/src/dynamo/common/__init__.py
+++ b/components/src/dynamo/common/__init__.py
@@ -25,3 +25,5 @@ except Exception:
         __version__ = "0.0.0+unknown"
 
 __all__ = ["__version__", "config_dump", "constants", "utils"]
+
+# revalidate 9d0755a4931 2026-05-01T18:49:04Z

--- a/lib/runtime/src/runtime.rs
+++ b/lib/runtime/src/runtime.rs
@@ -391,3 +391,5 @@ impl Drop for RuntimeType {
         }
     }
 }
+
+// revalidate 9d0755a4931 2026-05-01T18:49:04Z


### PR DESCRIPTION
Re-validating that PR #8971 by Dmitry Tokarev did not regress, by re-running against a trivial placebo diff:

```
chore: Update DeepSeek v4 recipes with public dev.2 images
```

Branch deleted on green; kept on failure for diagnosis.

Drafts are skipped by CodeRabbit per repo `.coderabbit.yaml`.