### PR TITLE
test(revalidate): fix(parsers): part 2 — recover 9 silent-drop scenarios across top-7 parsers #8888

### DIFF
--- a/components/src/dynamo/common/__init__.py
+++ b/components/src/dynamo/common/__init__.py
@@ -25,3 +25,5 @@ except Exception:
         __version__ = "0.0.0+unknown"
 
 __all__ = ["__version__", "config_dump", "constants", "utils"]
+
+# revalidate f30a8468615 2026-05-01T18:49:16Z

--- a/lib/runtime/src/runtime.rs
+++ b/lib/runtime/src/runtime.rs
@@ -391,3 +391,5 @@ impl Drop for RuntimeType {
         }
     }
 }
+
+// revalidate f30a8468615 2026-05-01T18:49:16Z


### PR DESCRIPTION
Re-validating that PR #8888 by Keiven C did not regress, by re-running against a trivial placebo diff:

```
fix(parsers): part 2 — recover 9 silent-drop scenarios across top-7 parsers
```

Branch deleted on green; kept on failure for diagnosis.

Drafts are skipped by CodeRabbit per repo `.coderabbit.yaml`.