### PR TITLE
[release/1.1.0] fix: Only read prompt embeds from request if globally enabled (cherry-pick #8248)

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -1480,6 +1480,22 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         embedding_sequence_length = None
 
         if "prompt_embeds" in request and request["prompt_embeds"]:
+            if not self.config.engine_args.enable_prompt_embeds:
+                msg = (
+                    "Set `--enable-prompt-embeds` to allow `prompt_embeds` in request."
+                )
+                logger.error(
+                    f"Rejected prompt_embeds for {log_prefix.lower().strip() or 'request'} "
+                    f"{request_id}: {msg}"
+                )
+                return (
+                    None,
+                    None,
+                    {
+                        "finish_reason": f"error: Invalid prompt_embeds: {msg}",
+                        "token_ids": [],
+                    },
+                )
             try:
                 (
                     prompt,


### PR DESCRIPTION
Cherry-pick of #8248 into release/1.1.0.

Original commit on `main`: 0d5bf022ef04e5743407d3b57e9d5b81e7b6e0a0 (author @grahamking).

ORCHESTRA critical security fix per ThreatOps report (2026-05-01). Companion to #9013 — gates the prompt-embeds request field behind a global enable flag so attacker payloads can't reach the loader unless an operator explicitly opts in.

Depends on: #9013 (cherry-pick of #8228) — please merge in that order.

Clean cherry-pick — no conflicts.