### PR TITLE
perf(vllm): async DtoH/HtoD for multimodal embedding-cache connector

### DIFF
--- a/components/src/dynamo/vllm/multimodal_utils/multimodal_embedding_cache_connector.py
+++ b/components/src/dynamo/vllm/multimodal_utils/multimodal_embedding_cache_connector.py
@@ -34,16 +34,38 @@ class MultimodalEmbeddingCacheConnectorMetadata(ECConnectorMetadata):
     evicts: list[str] = field(default_factory=list)
 
 
+@dataclass
+class _CpuEntry:
+    """Worker-side CPU-resident embedding with async-save / async-load lifetime tracking.
+
+    save_done resolves when the DtoH copy on _save_stream has finished writing
+    cpu_tensor; pending_loads carries one event per in-flight HtoD reading from
+    cpu_tensor on the compute stream. Both are queried (never synchronized) by
+    the reaper so eviction never blocks the hot path. is_pinned distinguishes
+    the async/pinned path from the sync/pageable cap-fallback path; load and
+    reap branch on it.
+    """
+
+    cpu_tensor: torch.Tensor
+    save_done: torch.cuda.Event
+    pending_loads: list[torch.cuda.Event] = field(default_factory=list)
+    nbytes: int = 0
+    is_pinned: bool = True
+
+
 class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
     """EC connector with scheduler-authoritative CPU embedding cache.
 
     The scheduler maintains a logical LRU cache (OrderedDict) and issues
     load/save/evict commands to the worker via ECConnectorMetadata. The
-    worker holds a plain dict[str, Tensor] on CPU and obeys commands
+    worker holds a plain dict[str, _CpuEntry] on CPU and obeys commands
     without independent caching decisions.
 
-    This mirrors vLLM's EncoderCacheManager pattern: the scheduler is the
-    single source of truth for cache state; the worker is a plain dict storage.
+    Worker-side DtoH (save) runs on a dedicated CUDA stream with pinned
+    host buffers; HtoD (load) runs on the compute stream and waits on the
+    save event before reading. Evict is non-blocking — entries are
+    retired and reaped lazily once their save_done and any pending_loads
+    have resolved.
     """
 
     def __init__(self, vllm_config: "VllmConfig", role: ECConnectorRole) -> None:
@@ -62,16 +84,13 @@ class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
                 "ec_transfer_config must be set for DynamoMultimodalEmbeddingCacheConnector"
             )
 
-        if "multimodal_embedding_cache_capacity_gb" not in (
-            transfer_config.ec_connector_extra_config or {}
-        ):
+        extra_config = transfer_config.ec_connector_extra_config or {}
+        if "multimodal_embedding_cache_capacity_gb" not in extra_config:
             raise ValueError(
                 "multimodal_embedding_cache_capacity_gb must be set in "
                 "ec_connector_extra_config for DynamoMultimodalEmbeddingCacheConnector"
             )
-        capacity_gb: float = transfer_config.ec_connector_extra_config[
-            "multimodal_embedding_cache_capacity_gb"
-        ]
+        capacity_gb: float = extra_config["multimodal_embedding_cache_capacity_gb"]
 
         # --- Scheduler-side: logical LRU for CPU embedding cache ---
         # Mirrors EncoderCacheManager but for the CPU tier, tracking bytes.
@@ -89,15 +108,36 @@ class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
         self._saves_this_step: set[str] = set()
         self._evicts_this_step: set[str] = set()
 
-        # --- Worker-side: dumb CPU tensor store ---
-        self._cpu_store: dict[str, torch.Tensor] = {}
+        # --- Worker-side: async DtoH/HtoD state ---
+        self._pin_memory: bool = bool(extra_config.get("pin_memory", True))
+        self._pinned_overhead_pct: float = float(
+            extra_config.get("pinned_overhead_pct", 25.0)
+        )
+        self._pinned_cap_bytes: int = int(
+            self._capacity_bytes * (1.0 + self._pinned_overhead_pct / 100.0)
+        )
+        self._log_every_n_steps: int = int(
+            extra_config.get("ec_log_every_n_steps", 100)
+        )
+
+        self._cpu_store: dict[str, _CpuEntry] = {}
+        self._retired: list[_CpuEntry] = []
+        self._save_stream: torch.cuda.Stream | None = None
+        self._device: torch.device | None = None
+        self._pinned_bytes_active: int = 0
+        self._pinned_bytes_retired: int = 0
+        self._already_done_event: torch.cuda.Event | None = None
+        self._step_counter: int = 0
 
         logger.info(
             "DynamoMultimodalEmbeddingCacheConnector initialized: "
-            "capacity_gb=%.2f, capacity_bytes=%d, bytes_per_embed=%d",
+            "capacity_gb=%.2f, capacity_bytes=%d, bytes_per_embed=%d, "
+            "pin_memory=%s, pinned_cap_bytes=%d",
             capacity_gb,
             self._capacity_bytes,
             self._bytes_per_embed,
+            self._pin_memory,
+            self._pinned_cap_bytes,
         )
 
     # ==============================
@@ -189,6 +229,28 @@ class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
     # it simply obeys the scheduler's load/save/evict commands.
     # ==============================
 
+    def _ensure_streams(self, device: torch.device) -> None:
+        """Lazily create the save stream and lock the connector to a device.
+
+        The sentinel `_already_done_event` is recorded on the save stream and
+        synchronized once so subsequent .query() calls always return True. We
+        use it as save_done for sync-DtoH (pageable fallback) entries so the
+        load path branches uniformly without an `is_pinned` check on every
+        load.
+        """
+        if self._save_stream is None:
+            self._device = device
+            self._save_stream = torch.cuda.Stream(device=device)
+            sentinel = torch.cuda.Event()
+            sentinel.record(self._save_stream)
+            self._save_stream.synchronize()
+            self._already_done_event = sentinel
+        else:
+            assert device == self._device, (
+                f"EC connector bound to device {self._device} "
+                f"but received tensor on {device}"
+            )
+
     def start_load_caches(
         self, encoder_cache: dict[str, torch.Tensor], **kwargs
     ) -> None:
@@ -198,25 +260,79 @@ class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
         metadata = self._get_connector_metadata()
         assert isinstance(metadata, MultimodalEmbeddingCacheConnectorMetadata)
 
+        compute = torch.cuda.current_stream()
+        self._ensure_streams(compute.device)
+
         for mm_hash in metadata.loads:
             if mm_hash in encoder_cache:
                 continue
-            if mm_hash in self._cpu_store:
-                encoder_cache[mm_hash] = self._cpu_store[mm_hash].to(
-                    "cuda", non_blocking=True
-                )
-            else:
+            entry = self._cpu_store.get(mm_hash)
+            if entry is None:
                 logger.warning(
                     "start_load_caches: hash %s not in cpu_store, skipping", mm_hash
                 )
+                continue
+
+            # Make compute wait for the prior DtoH on save_stream. For pageable
+            # entries the sentinel event is already-resolved, so this is a no-op.
+            compute.wait_event(entry.save_done)
+
+            # HtoD on compute. Genuinely async for pinned; PyTorch silently
+            # falls back to sync for pageable, which is correct for that path.
+            gpu_tensor = entry.cpu_tensor.to(
+                device=compute.device, non_blocking=entry.is_pinned
+            )
+
+            # Symmetric record_stream on the destination: tells the caching
+            # allocator the new tensor's storage is consumed by compute, so
+            # if vLLM pops encoder_cache[h] before compute is done, the GPU
+            # buffer is not reused early.
+            gpu_tensor.record_stream(compute)
+
+            load_done = torch.cuda.Event()
+            load_done.record(compute)
+            entry.pending_loads.append(load_done)
+
+            encoder_cache[mm_hash] = gpu_tensor
 
         for mm_hash in metadata.evicts:
-            self._cpu_store.pop(mm_hash, None)
+            entry = self._cpu_store.pop(mm_hash, None)
+            if entry is not None:
+                if entry.is_pinned:
+                    self._pinned_bytes_active -= entry.nbytes
+                    self._pinned_bytes_retired += entry.nbytes
+                self._retired.append(entry)
+
+        self._prune_active_load_events()
+        self._reap_retired()
+
+        self._step_counter += 1
+        if self._step_counter % self._log_every_n_steps == 0:
+            logger.info(
+                "EC pinned bytes: active=%d retired=%d cap=%d "
+                "(entries=%d retired_count=%d)",
+                self._pinned_bytes_active,
+                self._pinned_bytes_retired,
+                self._pinned_cap_bytes,
+                len(self._cpu_store),
+                len(self._retired),
+            )
 
     def save_caches(
         self, encoder_cache: dict[str, torch.Tensor], mm_hash: str, **kwargs
     ) -> None:
-        """Copy a newly computed embedding from GPU encoder_cache to CPU store."""
+        """Copy a newly computed embedding from GPU encoder_cache to CPU store.
+
+        Pinned path: queue an async DtoH on _save_stream after waiting on
+        compute, record save_done, hand the entry to _cpu_store immediately
+        (load path will gate on save_done). The pinned-bytes accounting tracks
+        active vs retired separately so the reaper can release retired bytes
+        once both save and any pending loads have drained.
+
+        Sync fallback (pin_memory=False or over-cap): a pageable .cpu() copy
+        with the always-resolved sentinel as save_done, accounted as
+        is_pinned=False so the budget is not double-counted.
+        """
         metadata = self._get_connector_metadata()
         assert isinstance(metadata, MultimodalEmbeddingCacheConnectorMetadata)
 
@@ -230,4 +346,87 @@ class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
                 mm_hash,
             )
             return
-        self._cpu_store[mm_hash] = encoder_cache[mm_hash].cpu()
+
+        src = encoder_cache[mm_hash]
+        if not src.is_contiguous():
+            logger.debug(
+                "save_caches: non-contiguous source for hash %s, materializing",
+                mm_hash,
+            )
+            src = src.contiguous()
+
+        self._ensure_streams(src.device)
+        nbytes = src.numel() * src.element_size()
+
+        over_cap = (
+            self._pinned_bytes_active + self._pinned_bytes_retired + nbytes
+            > self._pinned_cap_bytes
+        )
+        use_pinned = self._pin_memory and not over_cap
+
+        if use_pinned:
+            cpu_buf = torch.empty(
+                src.shape, dtype=src.dtype, device="cpu", pin_memory=True
+            )
+            compute = torch.cuda.current_stream(src.device)
+            assert self._save_stream is not None
+            self._save_stream.wait_stream(compute)
+            with torch.cuda.stream(self._save_stream):
+                cpu_buf.copy_(src, non_blocking=True)
+                # Symmetric record_stream on the source: protects the GPU
+                # source memory in case vLLM pops encoder_cache[h] before the
+                # async DtoH finishes.
+                src.record_stream(self._save_stream)
+            save_done = torch.cuda.Event()
+            save_done.record(self._save_stream)
+            self._cpu_store[mm_hash] = _CpuEntry(
+                cpu_tensor=cpu_buf,
+                save_done=save_done,
+                nbytes=nbytes,
+                is_pinned=True,
+            )
+            self._pinned_bytes_active += nbytes
+        else:
+            if over_cap:
+                logger.warning(
+                    "save_caches: pinned budget exceeded "
+                    "(active=%d retired=%d new=%d cap=%d); "
+                    "falling back to sync DtoH for hash %s",
+                    self._pinned_bytes_active,
+                    self._pinned_bytes_retired,
+                    nbytes,
+                    self._pinned_cap_bytes,
+                    mm_hash,
+                )
+            assert self._already_done_event is not None
+            self._cpu_store[mm_hash] = _CpuEntry(
+                cpu_tensor=src.cpu(),
+                save_done=self._already_done_event,
+                nbytes=nbytes,
+                is_pinned=False,
+            )
+
+        self._reap_retired()
+
+    def _prune_active_load_events(self) -> None:
+        """Drop resolved load events from active entries to bound the list size."""
+        for entry in self._cpu_store.values():
+            if entry.pending_loads:
+                entry.pending_loads = [e for e in entry.pending_loads if not e.query()]
+
+    def _reap_retired(self) -> None:
+        """Release retired entries whose save and all pending loads have drained.
+
+        Never blocks — uses event.query() only. Safe to call from save_caches
+        and start_load_caches.
+        """
+        if not self._retired:
+            return
+        still_pending: list[_CpuEntry] = []
+        for entry in self._retired:
+            if entry.save_done.query() and all(e.query() for e in entry.pending_loads):
+                if entry.is_pinned:
+                    self._pinned_bytes_retired -= entry.nbytes
+                continue
+            still_pending.append(entry)
+        self._retired = still_pending

--- a/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_multimodal_embedding_cache_connector_cuda.py
+++ b/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_multimodal_embedding_cache_connector_cuda.py
@@ -1,0 +1,368 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CUDA-side unit tests for DynamoMultimodalEmbeddingCacheConnector.
+
+These tests exercise the worker-side async-save / async-load lifecycle:
+DtoH on a dedicated stream with pinned host buffers, HtoD on compute with
+record_stream protection, retired-list reaping gated on save+load events,
+and the pinned-budget cap fallback.
+
+Markers: gpu_1 (single CUDA device required). The CPU-only scheduler-side
+tests live in test_vllm_multimodal_embedding_cache_connector.py.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+from dynamo.vllm.multimodal_utils import multimodal_embedding_cache_connector as mod
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.vllm,
+    pytest.mark.gpu_1,
+    pytest.mark.multimodal,
+]
+
+
+def _make_vllm_config(
+    capacity_gb: float = 0.001,
+    pin_memory: bool = True,
+    pinned_overhead_pct: float = 25.0,
+) -> MagicMock:
+    config = MagicMock()
+    config.ec_transfer_config.ec_connector_extra_config = {
+        "multimodal_embedding_cache_capacity_gb": capacity_gb,
+        "pin_memory": pin_memory,
+        "pinned_overhead_pct": pinned_overhead_pct,
+    }
+    config.model_config.get_hidden_size.return_value = 64
+    config.model_config.dtype = torch.float16
+    return config
+
+
+def _make_connector(
+    capacity_gb: float = 0.001,
+    pin_memory: bool = True,
+    pinned_overhead_pct: float = 25.0,
+) -> mod.DynamoMultimodalEmbeddingCacheConnector:
+    with patch.object(mod.ECConnectorBase, "__init__", return_value=None):
+        return mod.DynamoMultimodalEmbeddingCacheConnector(
+            vllm_config=_make_vllm_config(
+                capacity_gb=capacity_gb,
+                pin_memory=pin_memory,
+                pinned_overhead_pct=pinned_overhead_pct,
+            ),
+            role=MagicMock(),
+        )
+
+
+def _set_metadata(
+    conn: mod.DynamoMultimodalEmbeddingCacheConnector,
+    *,
+    loads: list[str] | None = None,
+    saves: list[str] | None = None,
+    evicts: list[str] | None = None,
+) -> mod.MultimodalEmbeddingCacheConnectorMetadata:
+    md = mod.MultimodalEmbeddingCacheConnectorMetadata(
+        loads=loads or [],
+        saves=saves or [],
+        evicts=evicts or [],
+    )
+    conn._get_connector_metadata = lambda: md  # type: ignore[method-assign]
+    return md
+
+
+@pytest.fixture(scope="module")
+def device() -> torch.device:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+    return torch.device("cuda", torch.cuda.current_device())
+
+
+class TestSaveLoadRoundTrip:
+    """Save → load → encoder_cache equality on the pinned and pageable paths."""
+
+    def _save_then_load(
+        self,
+        conn: mod.DynamoMultimodalEmbeddingCacheConnector,
+        device: torch.device,
+        mm_hash: str,
+        src: torch.Tensor,
+    ) -> torch.Tensor:
+        encoder_cache: dict[str, torch.Tensor] = {mm_hash: src}
+        _set_metadata(conn, saves=[mm_hash])
+        conn.save_caches(encoder_cache, mm_hash)
+
+        encoder_cache.pop(mm_hash)
+        _set_metadata(conn, loads=[mm_hash])
+        conn.start_load_caches(encoder_cache)
+
+        torch.cuda.synchronize(device)
+        return encoder_cache[mm_hash]
+
+    def test_pinned_path(self, device):
+        conn = _make_connector(pin_memory=True)
+        src = torch.randn(8, 64, dtype=torch.float16, device=device)
+        loaded = self._save_then_load(conn, device, "h0", src)
+
+        assert loaded.device == device
+        assert torch.equal(loaded, src)
+        assert conn._cpu_store["h0"].is_pinned is True
+        assert conn._cpu_store["h0"].cpu_tensor.is_pinned()
+        assert conn._pinned_bytes_active == src.numel() * src.element_size()
+
+    def test_pageable_path(self, device):
+        conn = _make_connector(pin_memory=False)
+        src = torch.randn(8, 64, dtype=torch.float16, device=device)
+        loaded = self._save_then_load(conn, device, "h0", src)
+
+        assert torch.equal(loaded, src)
+        assert conn._cpu_store["h0"].is_pinned is False
+        assert not conn._cpu_store["h0"].cpu_tensor.is_pinned()
+        # Pageable path is never accounted against the pinned budget.
+        assert conn._pinned_bytes_active == 0
+
+
+class TestRetiredReaping:
+    """Eviction never blocks; retired entries are released only when save+loads
+    have drained. We mock event.query so the test is deterministic regardless
+    of how fast the device is."""
+
+    def _stub_event(self, query_result: bool) -> MagicMock:
+        event = MagicMock(spec=torch.cuda.Event)
+        event.query.return_value = query_result
+        return event
+
+    def test_evict_does_not_free_pending_save(self, device):
+        conn = _make_connector(pin_memory=True)
+        src = torch.randn(4, 64, dtype=torch.float16, device=device)
+
+        encoder_cache: dict[str, torch.Tensor] = {"h0": src}
+        _set_metadata(conn, saves=["h0"])
+        conn.save_caches(encoder_cache, "h0")
+
+        # Force save_done to look unfinished, then evict.
+        entry = conn._cpu_store["h0"]
+        entry.save_done = self._stub_event(False)
+        nbytes = entry.nbytes
+
+        _set_metadata(conn, evicts=["h0"])
+        conn.start_load_caches({})
+
+        # Bytes moved active → retired but the entry is still on _retired
+        # because its save event has not resolved.
+        assert "h0" not in conn._cpu_store
+        assert len(conn._retired) == 1
+        assert conn._pinned_bytes_active == 0
+        assert conn._pinned_bytes_retired == nbytes
+
+        # Resolve the event; reap drains the entry and clears retired bytes.
+        conn._retired[0].save_done = self._stub_event(True)
+        conn._reap_retired()
+        assert conn._retired == []
+        assert conn._pinned_bytes_retired == 0
+
+    def test_evict_does_not_free_pending_load(self, device):
+        conn = _make_connector(pin_memory=True)
+        src = torch.randn(4, 64, dtype=torch.float16, device=device)
+
+        encoder_cache: dict[str, torch.Tensor] = {"h0": src}
+        _set_metadata(conn, saves=["h0"])
+        conn.save_caches(encoder_cache, "h0")
+
+        # Inject an unfinished pending load; save_done resolved (real event).
+        entry = conn._cpu_store["h0"]
+        torch.cuda.synchronize(device)
+        unresolved = self._stub_event(False)
+        entry.pending_loads.append(unresolved)
+
+        _set_metadata(conn, evicts=["h0"])
+        conn.start_load_caches({})
+
+        assert len(conn._retired) == 1
+        assert conn._pinned_bytes_retired == entry.nbytes
+
+        # Pending load remains; reap is a no-op.
+        conn._reap_retired()
+        assert len(conn._retired) == 1
+
+        # Resolve the load; reap drains.
+        unresolved.query.return_value = True
+        conn._reap_retired()
+        assert conn._retired == []
+        assert conn._pinned_bytes_retired == 0
+
+
+class TestRecordStream:
+    """Verify that the GPU source (save) tensor has record_stream invoked with
+    the save stream. The destination-side record_stream is exercised
+    functionally by TestRoundTripUnderConsumerPop.
+
+    Tensor instance attributes shadow methods in CPython attribute lookup, so
+    we can spy by assigning a closure to src.record_stream directly.
+    """
+
+    def test_save_records_src_on_save_stream(self, device):
+        conn = _make_connector(pin_memory=True)
+        src = torch.randn(4, 64, dtype=torch.float16, device=device)
+
+        record_calls: list[torch.cuda.Stream] = []
+        original = src.record_stream
+
+        def capture(stream):
+            record_calls.append(stream)
+            return original(stream)
+
+        src.record_stream = capture  # type: ignore[method-assign]
+
+        encoder_cache: dict[str, torch.Tensor] = {"h0": src}
+        _set_metadata(conn, saves=["h0"])
+        conn.save_caches(encoder_cache, "h0")
+
+        assert len(record_calls) == 1
+        assert record_calls[0] is conn._save_stream
+
+
+class TestRoundTripUnderConsumerPop:
+    """Functional regression for record_stream protection.
+
+    Source-side: while the async DtoH is in flight, vLLM pops encoder_cache[h]
+    and drops its reference. The caching allocator could reuse the GPU source
+    storage immediately; src.record_stream(save_stream) is what holds it alive
+    until save_done resolves. After sync, the CPU copy must still equal the
+    original.
+
+    Destination-side: while compute is mid-kernel using the loaded GPU
+    tensor, vLLM pops encoder_cache[h]. gpu_tensor.record_stream(compute)
+    keeps the destination storage alive until compute drains. The matmul
+    result must still equal the reference.
+    """
+
+    def test_save_pop_then_sync_content_correct(self, device):
+        conn = _make_connector(pin_memory=True)
+        original = torch.randn(64, 64, dtype=torch.float16, device=device)
+        src = original.clone()
+
+        encoder_cache: dict[str, torch.Tensor] = {"h0": src}
+        _set_metadata(conn, saves=["h0"])
+        conn.save_caches(encoder_cache, "h0")
+
+        del encoder_cache["h0"]
+        del src
+
+        # Allocator pressure on compute before we sync save_stream.
+        for _ in range(8):
+            _ = torch.randn(64, 64, dtype=torch.float16, device=device)
+
+        torch.cuda.synchronize(device)
+        cpu_buf = conn._cpu_store["h0"].cpu_tensor
+        assert torch.equal(cpu_buf, original.cpu())
+
+    def test_load_pop_then_compute_consumer_correct(self, device):
+        conn = _make_connector(pin_memory=True)
+        original = torch.randn(64, 64, dtype=torch.float16, device=device)
+
+        encoder_cache: dict[str, torch.Tensor] = {"h0": original.clone()}
+        _set_metadata(conn, saves=["h0"])
+        conn.save_caches(encoder_cache, "h0")
+        encoder_cache.pop("h0")
+        torch.cuda.synchronize(device)
+
+        _set_metadata(conn, loads=["h0"])
+        conn.start_load_caches(encoder_cache)
+
+        # Queue a compute consumer on the loaded tensor; this is enqueued on
+        # the compute stream right after the HtoD. The result owns its own
+        # storage but its computation still reads from gpu_tensor's storage.
+        gpu_tensor = encoder_cache["h0"]
+        result = gpu_tensor.float() @ gpu_tensor.float().t()
+
+        # Drop both references to gpu_tensor's storage.
+        del encoder_cache["h0"]
+        del gpu_tensor
+
+        # Allocator pressure before sync. Without record_stream(compute) on the
+        # gpu_tensor, the allocator could reuse the storage while the matmul
+        # is still reading from it.
+        for _ in range(8):
+            _ = torch.randn(64, 64, dtype=torch.float16, device=device)
+
+        torch.cuda.synchronize(device)
+        expected = original.float() @ original.float().t()
+        assert torch.allclose(result, expected, rtol=1e-3, atol=1e-3)
+
+
+class TestMixedHitsAndMisses:
+    def test_mixed_step(self, device):
+        conn = _make_connector(pin_memory=True)
+        # Pre-populate one entry to be loaded.
+        src_a = torch.randn(4, 64, dtype=torch.float16, device=device)
+        src_b = torch.randn(4, 64, dtype=torch.float16, device=device)
+
+        _set_metadata(conn, saves=["a"])
+        conn.save_caches({"a": src_a}, "a")
+        torch.cuda.synchronize(device)
+
+        # Now simulate one step: load "a" from CPU, save "b" newly computed.
+        # Note: save and load happen via different metadata in real vLLM, so we
+        # exercise them sequentially — first save (per-hash), then load.
+        _set_metadata(conn, saves=["b"])
+        conn.save_caches({"b": src_b}, "b")
+
+        encoder_cache: dict[str, torch.Tensor] = {}
+        _set_metadata(conn, loads=["a"])
+        conn.start_load_caches(encoder_cache)
+        torch.cuda.synchronize(device)
+
+        assert torch.equal(encoder_cache["a"], src_a)
+        assert "a" in conn._cpu_store
+        assert "b" in conn._cpu_store
+
+
+class TestPinnedCapFallback:
+    """When the pinned budget would be exceeded the next save takes the
+    pageable sync path. The breaching entry must be flagged is_pinned=False
+    and must NOT be added to the pinned-bytes counter."""
+
+    def test_over_cap_falls_back(self, device):
+        # Use overhead=0 so the cap equals capacity_bytes exactly. Each save
+        # is 4×64×2 = 512 bytes; cap is set to 512 bytes too. First save:
+        # 0+0+512 > 512 is False → pinned. Second save: 512+0+512 > 512 is
+        # True → pageable fallback.
+        conn = _make_connector(capacity_gb=512 / (1024**3), pinned_overhead_pct=0.0)
+
+        src1 = torch.randn(4, 64, dtype=torch.float16, device=device)
+        src2 = torch.randn(4, 64, dtype=torch.float16, device=device)
+
+        _set_metadata(conn, saves=["h1"])
+        conn.save_caches({"h1": src1}, "h1")
+        first_active = conn._pinned_bytes_active
+
+        _set_metadata(conn, saves=["h2"])
+        conn.save_caches({"h2": src2}, "h2")
+        torch.cuda.synchronize(device)
+
+        # First entry is pinned and counted; second is pageable and uncounted.
+        assert conn._cpu_store["h1"].is_pinned is True
+        assert conn._cpu_store["h2"].is_pinned is False
+        assert conn._pinned_bytes_active == first_active
+        assert torch.equal(conn._cpu_store["h2"].cpu_tensor, src2.cpu())
+
+
+class TestSingleDeviceLock:
+    def test_second_device_assertion(self, device):
+        if torch.cuda.device_count() < 2:
+            pytest.skip("Requires ≥2 CUDA devices")
+
+        conn = _make_connector(pin_memory=True)
+        src0 = torch.randn(4, 64, dtype=torch.float16, device=torch.device("cuda", 0))
+        _set_metadata(conn, saves=["h0"])
+        conn.save_caches({"h0": src0}, "h0")
+
+        src1 = torch.randn(4, 64, dtype=torch.float16, device=torch.device("cuda", 1))
+        _set_metadata(conn, saves=["h1"])
+        with pytest.raises(AssertionError, match="bound to device"):
+            conn.save_caches({"h1": src1}, "h1")


### PR DESCRIPTION
## Why

The multimodal embedding-cache connector did its DtoH (`save`) and HtoD (`load`) on the compute stream with synchronous `.cpu()` and a blocking `.to('cuda')`. That tax landed inside `vit_forward`, inflating cache-miss latency and serializing eviction against in-flight copies.

## What Change

- Save runs DtoH on a dedicated CUDA stream into a pinned host buffer; load runs HtoD on compute, gated by `compute.wait_event(save_done)`.
- `record_stream` on both the GPU source (save) and destination (load) holds storage alive across vLLM `encoder_cache` pops.
- Evict is non-blocking — entries move to a retired list and are reaped when `save_done` and all `pending_loads` query True.
- Pinned-budget cap with a sync pageable fallback (`is_pinned=False`, no double-counting) prevents host-memory blowup; connector-only change, no vLLM mods.

## Test Plan

- 9 new CUDA tests (`gpu_1`): pinned/pageable round-trip, retired reaping (save+load gating), `record_stream` source/dest, mixed step, cap fallback.
- 6 existing scheduler-side tests still green.
- Repro: `pytest -q components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_multimodal_embedding_cache_connector{,_cuda}.py`