### PR TITLE
test(revalidate): ci: Explicitly set sharing mode for docker caches, move uv to locked sharing #8983

### DIFF
--- a/components/src/dynamo/common/__init__.py
+++ b/components/src/dynamo/common/__init__.py
@@ -25,3 +25,5 @@ except Exception:
         __version__ = "0.0.0+unknown"
 
 __all__ = ["__version__", "config_dump", "constants", "utils"]
+
+# revalidate 1a930ddbd98 2026-05-01T19:56:04Z

--- a/lib/runtime/src/runtime.rs
+++ b/lib/runtime/src/runtime.rs
@@ -391,3 +391,5 @@ impl Drop for RuntimeType {
         }
     }
 }
+
+// revalidate 1a930ddbd98 2026-05-01T19:56:04Z


### PR DESCRIPTION
Re-validating that PR #8983 by Dillon Cullinan did not regress, by re-running against a trivial placebo diff:

```
ci: Explicitly set sharing mode for docker caches, move uv to locked sharing
```

Branch deleted on green; kept on failure for diagnosis.

Drafts are skipped by CodeRabbit per repo `.coderabbit.yaml`.