### PR TITLE
Benchmark Tokio vs flume runtime channels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2633,6 +2633,7 @@ dependencies = [
  "either",
  "etcd-client",
  "figment",
+ "flume 0.12.0",
  "futures",
  "humantime",
  "hyper-util",

--- a/benchmark-results/channel_mpsc_flume.log
+++ b/benchmark-results/channel_mpsc_flume.log
@@ -1,0 +1,73 @@
+   Compiling fastrand v2.4.1
+   Compiling spin v0.9.8
+   Compiling backon v1.6.0
+   Compiling tempfile v3.27.0
+   Compiling flume v0.12.0
+   Compiling kube-runtime v2.0.1
+   Compiling figment v0.10.19
+   Compiling kube v2.0.1
+   Compiling dynamo-runtime v1.2.0 (/home/bgreengus/dev/dynamo-worktrees/dynamo-want-benchmark-dynamo-when-using-98f072cd-039f-4068-88ac-1e514a5be9fd/lib/runtime)
+    Finished `bench` profile [optimized] target(s) in 2m 10s
+     Running benches/channel_mpsc_perf.rs (target/release/deps/channel_mpsc_perf-f0cd328311033ae0)
+Gnuplot not found, using plotters backend
+Benchmarking mpsc_bounded_spsc_flume/1
+Benchmarking mpsc_bounded_spsc_flume/1: Warming up for 3.0000 s
+
+Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 20.1s, or reduce sample count to 20.
+Benchmarking mpsc_bounded_spsc_flume/1: Collecting 100 samples in estimated 20.094 s (100 iterations)
+Benchmarking mpsc_bounded_spsc_flume/1: Analyzing
+mpsc_bounded_spsc_flume/1
+                        time:   [210.93 ms 216.01 ms 221.39 ms]
+                        thrpt:  [74.005 Kelem/s 75.850 Kelem/s 77.676 Kelem/s]
+Found 2 outliers among 100 measurements (2.00%)
+  2 (2.00%) high severe
+Benchmarking mpsc_bounded_spsc_flume/64
+Benchmarking mpsc_bounded_spsc_flume/64: Warming up for 3.0000 s
+Benchmarking mpsc_bounded_spsc_flume/64: Collecting 100 samples in estimated 5.1884 s (800 iterations)
+Benchmarking mpsc_bounded_spsc_flume/64: Analyzing
+mpsc_bounded_spsc_flume/64
+                        time:   [6.2244 ms 6.3911 ms 6.5659 ms]
+                        thrpt:  [2.4953 Melem/s 2.5636 Melem/s 2.6322 Melem/s]
+Found 4 outliers among 100 measurements (4.00%)
+  4 (4.00%) high mild
+Benchmarking mpsc_bounded_spsc_flume/1024
+Benchmarking mpsc_bounded_spsc_flume/1024: Warming up for 3.0000 s
+
+Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 9.7s, enable flat sampling, or reduce sample count to 50.
+Benchmarking mpsc_bounded_spsc_flume/1024: Collecting 100 samples in estimated 9.6975 s (5050 iterations)
+Benchmarking mpsc_bounded_spsc_flume/1024: Analyzing
+mpsc_bounded_spsc_flume/1024
+                        time:   [1.3373 ms 1.4217 ms 1.5174 ms]
+                        thrpt:  [10.798 Melem/s 11.524 Melem/s 12.251 Melem/s]
+
+Benchmarking mpsc_bounded_mpsc_flume/64
+Benchmarking mpsc_bounded_mpsc_flume/64: Warming up for 3.0000 s
+Benchmarking mpsc_bounded_mpsc_flume/64: Collecting 100 samples in estimated 9.3846 s (10k iterations)
+Benchmarking mpsc_bounded_mpsc_flume/64: Analyzing
+mpsc_bounded_mpsc_flume/64
+                        time:   [949.73 µs 990.81 µs 1.0345 ms]
+                        thrpt:  [15.838 Melem/s 16.536 Melem/s 17.251 Melem/s]
+Found 2 outliers among 100 measurements (2.00%)
+  2 (2.00%) high mild
+Benchmarking mpsc_bounded_mpsc_flume/1024
+Benchmarking mpsc_bounded_mpsc_flume/1024: Warming up for 3.0000 s
+Benchmarking mpsc_bounded_mpsc_flume/1024: Collecting 100 samples in estimated 9.9042 s (10k iterations)
+Benchmarking mpsc_bounded_mpsc_flume/1024: Analyzing
+mpsc_bounded_mpsc_flume/1024
+                        time:   [932.28 µs 966.88 µs 1.0047 ms]
+                        thrpt:  [16.308 Melem/s 16.945 Melem/s 17.574 Melem/s]
+Found 3 outliers among 100 measurements (3.00%)
+  2 (2.00%) high mild
+  1 (1.00%) high severe
+
+Benchmarking mpsc_unbounded_spsc_flume/send_recv
+Benchmarking mpsc_unbounded_spsc_flume/send_recv: Warming up for 3.0000 s
+Benchmarking mpsc_unbounded_spsc_flume/send_recv: Collecting 100 samples in estimated 11.388 s (20k iterations)
+Benchmarking mpsc_unbounded_spsc_flume/send_recv: Analyzing
+mpsc_unbounded_spsc_flume/send_recv
+                        time:   [562.08 µs 577.34 µs 593.54 µs]
+                        thrpt:  [27.604 Melem/s 28.378 Melem/s 29.149 Melem/s]
+Found 4 outliers among 100 measurements (4.00%)
+  3 (3.00%) high mild
+  1 (1.00%) high severe
+

--- a/benchmark-results/channel_mpsc_flume_expanded_caps.log
+++ b/benchmark-results/channel_mpsc_flume_expanded_caps.log
@@ -1,0 +1,204 @@
+   Compiling dynamo-runtime v1.2.0 (/home/bgreengus/dev/dynamo-worktrees/dynamo-want-benchmark-dynamo-when-using-98f072cd-039f-4068-88ac-1e514a5be9fd/lib/runtime)
+    Finished `bench` profile [optimized] target(s) in 18.03s
+     Running benches/channel_mpsc_perf.rs (target/release/deps/channel_mpsc_perf-f0cd328311033ae0)
+Gnuplot not found, using plotters backend
+Benchmarking mpsc_bounded_spsc_flume/1
+Benchmarking mpsc_bounded_spsc_flume/1: Warming up for 3.0000 s
+
+Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 17.7s, or reduce sample count to 20.
+Benchmarking mpsc_bounded_spsc_flume/1: Collecting 100 samples in estimated 17.746 s (100 iterations)
+Benchmarking mpsc_bounded_spsc_flume/1: Analyzing
+mpsc_bounded_spsc_flume/1
+                        time:   [170.02 ms 172.44 ms 175.01 ms]
+                        thrpt:  [93.620 Kelem/s 95.011 Kelem/s 96.367 Kelem/s]
+                 change:
+                        time:   [-22.443% -20.167% -17.915%] (p = 0.00 < 0.05)
+                        thrpt:  [+21.825% +25.262% +28.938%]
+                        Performance has improved.
+Found 1 outliers among 100 measurements (1.00%)
+  1 (1.00%) high mild
+Benchmarking mpsc_bounded_spsc_flume/2
+Benchmarking mpsc_bounded_spsc_flume/2: Warming up for 3.0000 s
+
+Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 11.7s, or reduce sample count to 40.
+Benchmarking mpsc_bounded_spsc_flume/2: Collecting 100 samples in estimated 11.692 s (100 iterations)
+Benchmarking mpsc_bounded_spsc_flume/2: Analyzing
+mpsc_bounded_spsc_flume/2
+                        time:   [110.14 ms 111.60 ms 113.13 ms]
+                        thrpt:  [144.83 Kelem/s 146.81 Kelem/s 148.76 Kelem/s]
+Found 2 outliers among 100 measurements (2.00%)
+  2 (2.00%) high mild
+Benchmarking mpsc_bounded_spsc_flume/4
+Benchmarking mpsc_bounded_spsc_flume/4: Warming up for 3.0000 s
+
+Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 6.8s, or reduce sample count to 70.
+Benchmarking mpsc_bounded_spsc_flume/4: Collecting 100 samples in estimated 6.7976 s (100 iterations)
+Benchmarking mpsc_bounded_spsc_flume/4: Analyzing
+mpsc_bounded_spsc_flume/4
+                        time:   [69.282 ms 71.122 ms 73.186 ms]
+                        thrpt:  [223.87 Kelem/s 230.36 Kelem/s 236.48 Kelem/s]
+Found 4 outliers among 100 measurements (4.00%)
+  3 (3.00%) high mild
+  1 (1.00%) high severe
+Benchmarking mpsc_bounded_spsc_flume/64
+Benchmarking mpsc_bounded_spsc_flume/64: Warming up for 3.0000 s
+Benchmarking mpsc_bounded_spsc_flume/64: Collecting 100 samples in estimated 5.1212 s (1000 iterations)
+Benchmarking mpsc_bounded_spsc_flume/64: Analyzing
+mpsc_bounded_spsc_flume/64
+                        time:   [5.3491 ms 5.4527 ms 5.5599 ms]
+                        thrpt:  [2.9468 Melem/s 3.0047 Melem/s 3.0629 Melem/s]
+                 change:
+                        time:   [-17.496% -14.683% -11.907%] (p = 0.00 < 0.05)
+                        thrpt:  [+13.516% +17.209% +21.206%]
+                        Performance has improved.
+Found 1 outliers among 100 measurements (1.00%)
+  1 (1.00%) high mild
+Benchmarking mpsc_bounded_spsc_flume/128
+Benchmarking mpsc_bounded_spsc_flume/128: Warming up for 3.0000 s
+Benchmarking mpsc_bounded_spsc_flume/128: Collecting 100 samples in estimated 5.0602 s (1900 iterations)
+Benchmarking mpsc_bounded_spsc_flume/128: Analyzing
+mpsc_bounded_spsc_flume/128
+                        time:   [2.6001 ms 2.6666 ms 2.7437 ms]
+                        thrpt:  [5.9716 Melem/s 6.1442 Melem/s 6.3014 Melem/s]
+Found 10 outliers among 100 measurements (10.00%)
+  4 (4.00%) high mild
+  6 (6.00%) high severe
+Benchmarking mpsc_bounded_spsc_flume/256
+Benchmarking mpsc_bounded_spsc_flume/256: Warming up for 3.0000 s
+
+Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 9.8s, enable flat sampling, or reduce sample count to 50.
+Benchmarking mpsc_bounded_spsc_flume/256: Collecting 100 samples in estimated 9.7965 s (5050 iterations)
+Benchmarking mpsc_bounded_spsc_flume/256: Analyzing
+mpsc_bounded_spsc_flume/256
+                        time:   [1.9022 ms 1.9478 ms 2.0065 ms]
+                        thrpt:  [8.1655 Melem/s 8.4116 Melem/s 8.6131 Melem/s]
+Found 7 outliers among 100 measurements (7.00%)
+  2 (2.00%) high mild
+  5 (5.00%) high severe
+Benchmarking mpsc_bounded_spsc_flume/1024
+Benchmarking mpsc_bounded_spsc_flume/1024: Warming up for 3.0000 s
+
+Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 9.9s, enable flat sampling, or reduce sample count to 50.
+Benchmarking mpsc_bounded_spsc_flume/1024: Collecting 100 samples in estimated 9.8860 s (5050 iterations)
+Benchmarking mpsc_bounded_spsc_flume/1024: Analyzing
+mpsc_bounded_spsc_flume/1024
+                        time:   [1.9180 ms 1.9396 ms 1.9604 ms]
+                        thrpt:  [8.3576 Melem/s 8.4469 Melem/s 8.5423 Melem/s]
+                 change:
+                        time:   [+11.472% +17.508% +24.175%] (p = 0.00 < 0.05)
+                        thrpt:  [-19.469% -14.899% -10.292%]
+                        Performance has regressed.
+Found 6 outliers among 100 measurements (6.00%)
+  1 (1.00%) low severe
+  2 (2.00%) low mild
+  3 (3.00%) high mild
+Benchmarking mpsc_bounded_spsc_flume/2048
+Benchmarking mpsc_bounded_spsc_flume/2048: Warming up for 3.0000 s
+
+Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 9.3s, enable flat sampling, or reduce sample count to 50.
+Benchmarking mpsc_bounded_spsc_flume/2048: Collecting 100 samples in estimated 9.2830 s (5050 iterations)
+Benchmarking mpsc_bounded_spsc_flume/2048: Analyzing
+mpsc_bounded_spsc_flume/2048
+                        time:   [1.8978 ms 1.9185 ms 1.9401 ms]
+                        thrpt:  [8.4449 Melem/s 8.5400 Melem/s 8.6330 Melem/s]
+Found 3 outliers among 100 measurements (3.00%)
+  2 (2.00%) low mild
+  1 (1.00%) high mild
+Benchmarking mpsc_bounded_spsc_flume/4096
+Benchmarking mpsc_bounded_spsc_flume/4096: Warming up for 3.0000 s
+
+Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 9.1s, enable flat sampling, or reduce sample count to 50.
+Benchmarking mpsc_bounded_spsc_flume/4096: Collecting 100 samples in estimated 9.0523 s (5050 iterations)
+Benchmarking mpsc_bounded_spsc_flume/4096: Analyzing
+mpsc_bounded_spsc_flume/4096
+                        time:   [1.7960 ms 1.8431 ms 1.8828 ms]
+                        thrpt:  [8.7021 Melem/s 8.8896 Melem/s 9.1226 Melem/s]
+Found 9 outliers among 100 measurements (9.00%)
+  3 (3.00%) low severe
+  5 (5.00%) low mild
+  1 (1.00%) high severe
+
+Benchmarking mpsc_bounded_mpsc_flume/64
+Benchmarking mpsc_bounded_mpsc_flume/64: Warming up for 3.0000 s
+
+Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.5s, enable flat sampling, or reduce sample count to 50.
+Benchmarking mpsc_bounded_mpsc_flume/64: Collecting 100 samples in estimated 8.5226 s (5050 iterations)
+Benchmarking mpsc_bounded_mpsc_flume/64: Analyzing
+mpsc_bounded_mpsc_flume/64
+                        time:   [1.3383 ms 1.4405 ms 1.5364 ms]
+                        thrpt:  [10.664 Melem/s 11.374 Melem/s 12.242 Melem/s]
+                 change:
+                        time:   [+43.377% +51.736% +60.890%] (p = 0.00 < 0.05)
+                        thrpt:  [-37.846% -34.096% -30.254%]
+                        Performance has regressed.
+Benchmarking mpsc_bounded_mpsc_flume/128
+Benchmarking mpsc_bounded_mpsc_flume/128: Warming up for 3.0000 s
+
+Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.2s, enable flat sampling, or reduce sample count to 50.
+Benchmarking mpsc_bounded_mpsc_flume/128: Collecting 100 samples in estimated 8.1767 s (5050 iterations)
+Benchmarking mpsc_bounded_mpsc_flume/128: Analyzing
+mpsc_bounded_mpsc_flume/128
+                        time:   [1.3718 ms 1.4588 ms 1.5474 ms]
+                        thrpt:  [10.588 Melem/s 11.231 Melem/s 11.943 Melem/s]
+Found 2 outliers among 100 measurements (2.00%)
+  2 (2.00%) low mild
+Benchmarking mpsc_bounded_mpsc_flume/256
+Benchmarking mpsc_bounded_mpsc_flume/256: Warming up for 3.0000 s
+
+Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.3s, enable flat sampling, or reduce sample count to 50.
+Benchmarking mpsc_bounded_mpsc_flume/256: Collecting 100 samples in estimated 8.3063 s (5050 iterations)
+Benchmarking mpsc_bounded_mpsc_flume/256: Analyzing
+mpsc_bounded_mpsc_flume/256
+                        time:   [1.6654 ms 1.7409 ms 1.8018 ms]
+                        thrpt:  [9.0933 Melem/s 9.4111 Melem/s 9.8376 Melem/s]
+Found 13 outliers among 100 measurements (13.00%)
+  13 (13.00%) low mild
+Benchmarking mpsc_bounded_mpsc_flume/1024
+Benchmarking mpsc_bounded_mpsc_flume/1024: Warming up for 3.0000 s
+
+Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.2s, enable flat sampling, or reduce sample count to 50.
+Benchmarking mpsc_bounded_mpsc_flume/1024: Collecting 100 samples in estimated 8.2229 s (5050 iterations)
+Benchmarking mpsc_bounded_mpsc_flume/1024: Analyzing
+mpsc_bounded_mpsc_flume/1024
+                        time:   [1.4075 ms 1.5161 ms 1.6274 ms]
+                        thrpt:  [10.067 Melem/s 10.807 Melem/s 11.640 Melem/s]
+                 change:
+                        time:   [+59.010% +69.689% +80.796%] (p = 0.00 < 0.05)
+                        thrpt:  [-44.689% -41.069% -37.111%]
+                        Performance has regressed.
+Benchmarking mpsc_bounded_mpsc_flume/2048
+Benchmarking mpsc_bounded_mpsc_flume/2048: Warming up for 3.0000 s
+
+Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 9.1s, enable flat sampling, or reduce sample count to 50.
+Benchmarking mpsc_bounded_mpsc_flume/2048: Collecting 100 samples in estimated 9.1070 s (5050 iterations)
+Benchmarking mpsc_bounded_mpsc_flume/2048: Analyzing
+mpsc_bounded_mpsc_flume/2048
+                        time:   [1.6667 ms 1.7260 ms 1.7814 ms]
+                        thrpt:  [9.1974 Melem/s 9.4925 Melem/s 9.8301 Melem/s]
+Found 4 outliers among 100 measurements (4.00%)
+  3 (3.00%) low mild
+  1 (1.00%) high mild
+Benchmarking mpsc_bounded_mpsc_flume/4096
+Benchmarking mpsc_bounded_mpsc_flume/4096: Warming up for 3.0000 s
+
+Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.7s, enable flat sampling, or reduce sample count to 50.
+Benchmarking mpsc_bounded_mpsc_flume/4096: Collecting 100 samples in estimated 8.6631 s (5050 iterations)
+Benchmarking mpsc_bounded_mpsc_flume/4096: Analyzing
+mpsc_bounded_mpsc_flume/4096
+                        time:   [898.06 µs 948.97 µs 1.0055 ms]
+                        thrpt:  [16.295 Melem/s 17.265 Melem/s 18.244 Melem/s]
+
+Benchmarking mpsc_unbounded_spsc_flume/send_recv
+Benchmarking mpsc_unbounded_spsc_flume/send_recv: Warming up for 3.0000 s
+Benchmarking mpsc_unbounded_spsc_flume/send_recv: Collecting 100 samples in estimated 11.277 s (15k iterations)
+Benchmarking mpsc_unbounded_spsc_flume/send_recv: Analyzing
+mpsc_unbounded_spsc_flume/send_recv
+                        time:   [627.46 µs 650.00 µs 673.28 µs]
+                        thrpt:  [24.335 Melem/s 25.206 Melem/s 26.112 Melem/s]
+                 change:
+                        time:   [-0.4262% +4.6079% +9.8258%] (p = 0.07 > 0.05)
+                        thrpt:  [-8.9467% -4.4050% +0.4280%]
+                        No change in performance detected.
+Found 1 outliers among 100 measurements (1.00%)
+  1 (1.00%) high mild
+

--- a/benchmark-results/channel_mpsc_flume_long.log
+++ b/benchmark-results/channel_mpsc_flume_long.log
@@ -1,0 +1,154 @@
+   Compiling dynamo-runtime v1.2.0 (/home/bgreengus/dev/dynamo-worktrees/dynamo-want-benchmark-dynamo-when-using-98f072cd-039f-4068-88ac-1e514a5be9fd/lib/runtime)
+    Finished `bench` profile [optimized] target(s) in 30.06s
+     Running benches/channel_mpsc_perf.rs (target/release/deps/channel_mpsc_perf-f0cd328311033ae0)
+Gnuplot not found, using plotters backend
+Benchmarking mpsc_bounded_spsc_flume/1
+Benchmarking mpsc_bounded_spsc_flume/1: Warming up for 10.000 s
+Benchmarking mpsc_bounded_spsc_flume/1: Collecting 100 samples in estimated 43.741 s (200 iterations)
+Benchmarking mpsc_bounded_spsc_flume/1: Analyzing
+mpsc_bounded_spsc_flume/1
+                        time:   [192.78 ms 197.73 ms 202.91 ms]
+                        thrpt:  [80.744 Kelem/s 82.860 Kelem/s 84.987 Kelem/s]
+Found 3 outliers among 100 measurements (3.00%)
+  3 (3.00%) high mild
+Benchmarking mpsc_bounded_spsc_flume/2
+Benchmarking mpsc_bounded_spsc_flume/2: Warming up for 10.000 s
+Benchmarking mpsc_bounded_spsc_flume/2: Collecting 100 samples in estimated 37.301 s (300 iterations)
+Benchmarking mpsc_bounded_spsc_flume/2: Analyzing
+mpsc_bounded_spsc_flume/2
+                        time:   [145.55 ms 149.24 ms 153.09 ms]
+                        thrpt:  [107.02 Kelem/s 109.78 Kelem/s 112.57 Kelem/s]
+Found 2 outliers among 100 measurements (2.00%)
+  2 (2.00%) high mild
+Benchmarking mpsc_bounded_spsc_flume/4
+Benchmarking mpsc_bounded_spsc_flume/4: Warming up for 10.000 s
+Benchmarking mpsc_bounded_spsc_flume/4: Collecting 100 samples in estimated 32.767 s (400 iterations)
+Benchmarking mpsc_bounded_spsc_flume/4: Analyzing
+mpsc_bounded_spsc_flume/4
+                        time:   [148.29 ms 169.76 ms 192.50 ms]
+                        thrpt:  [85.112 Kelem/s 96.512 Kelem/s 110.49 Kelem/s]
+Benchmarking mpsc_bounded_spsc_flume/64
+Benchmarking mpsc_bounded_spsc_flume/64: Warming up for 10.000 s
+Benchmarking mpsc_bounded_spsc_flume/64: Collecting 100 samples in estimated 30.806 s (2000 iterations)
+Benchmarking mpsc_bounded_spsc_flume/64: Analyzing
+mpsc_bounded_spsc_flume/64
+                        time:   [7.8445 ms 9.2099 ms 10.806 ms]
+                        thrpt:  [1.5162 Melem/s 1.7789 Melem/s 2.0886 Melem/s]
+Found 15 outliers among 100 measurements (15.00%)
+  2 (2.00%) high mild
+  13 (13.00%) high severe
+Benchmarking mpsc_bounded_spsc_flume/128
+Benchmarking mpsc_bounded_spsc_flume/128: Warming up for 10.000 s
+Benchmarking mpsc_bounded_spsc_flume/128: Collecting 100 samples in estimated 58.619 s (10k iterations)
+Benchmarking mpsc_bounded_spsc_flume/128: Analyzing
+mpsc_bounded_spsc_flume/128
+                        time:   [3.6662 ms 3.7887 ms 3.9350 ms]
+                        thrpt:  [4.1636 Melem/s 4.3244 Melem/s 4.4689 Melem/s]
+Found 6 outliers among 100 measurements (6.00%)
+  5 (5.00%) high mild
+  1 (1.00%) high severe
+Benchmarking mpsc_bounded_spsc_flume/256
+Benchmarking mpsc_bounded_spsc_flume/256: Warming up for 10.000 s
+Benchmarking mpsc_bounded_spsc_flume/256: Collecting 100 samples in estimated 33.251 s (15k iterations)
+Benchmarking mpsc_bounded_spsc_flume/256: Analyzing
+mpsc_bounded_spsc_flume/256
+                        time:   [2.3280 ms 2.4872 ms 2.6802 ms]
+                        thrpt:  [6.1131 Melem/s 6.5872 Melem/s 7.0378 Melem/s]
+Found 6 outliers among 100 measurements (6.00%)
+  2 (2.00%) high mild
+  4 (4.00%) high severe
+Benchmarking mpsc_bounded_spsc_flume/1024
+Benchmarking mpsc_bounded_spsc_flume/1024: Warming up for 10.000 s
+Benchmarking mpsc_bounded_spsc_flume/1024: Collecting 100 samples in estimated 33.923 s (25k iterations)
+Benchmarking mpsc_bounded_spsc_flume/1024: Analyzing
+mpsc_bounded_spsc_flume/1024
+                        time:   [1.1877 ms 1.2269 ms 1.2682 ms]
+                        thrpt:  [12.920 Melem/s 13.354 Melem/s 13.794 Melem/s]
+Found 3 outliers among 100 measurements (3.00%)
+  2 (2.00%) high mild
+  1 (1.00%) high severe
+Benchmarking mpsc_bounded_spsc_flume/2048
+Benchmarking mpsc_bounded_spsc_flume/2048: Warming up for 10.000 s
+Benchmarking mpsc_bounded_spsc_flume/2048: Collecting 100 samples in estimated 31.544 s (30k iterations)
+Benchmarking mpsc_bounded_spsc_flume/2048: Analyzing
+mpsc_bounded_spsc_flume/2048
+                        time:   [971.38 µs 1.0167 ms 1.0680 ms]
+                        thrpt:  [15.341 Melem/s 16.116 Melem/s 16.867 Melem/s]
+Found 3 outliers among 100 measurements (3.00%)
+  2 (2.00%) high mild
+  1 (1.00%) high severe
+Benchmarking mpsc_bounded_spsc_flume/4096
+Benchmarking mpsc_bounded_spsc_flume/4096: Warming up for 10.000 s
+Benchmarking mpsc_bounded_spsc_flume/4096: Collecting 100 samples in estimated 32.588 s (35k iterations)
+Benchmarking mpsc_bounded_spsc_flume/4096: Analyzing
+mpsc_bounded_spsc_flume/4096
+                        time:   [912.03 µs 951.00 µs 993.24 µs]
+                        thrpt:  [16.496 Melem/s 17.228 Melem/s 17.964 Melem/s]
+Found 3 outliers among 100 measurements (3.00%)
+  3 (3.00%) high mild
+
+Benchmarking mpsc_bounded_mpsc_flume/64
+Benchmarking mpsc_bounded_mpsc_flume/64: Warming up for 10.000 s
+Benchmarking mpsc_bounded_mpsc_flume/64: Collecting 100 samples in estimated 34.241 s (30k iterations)
+Benchmarking mpsc_bounded_mpsc_flume/64: Analyzing
+mpsc_bounded_mpsc_flume/64
+                        time:   [1.1003 ms 1.1456 ms 1.1954 ms]
+                        thrpt:  [13.706 Melem/s 14.301 Melem/s 14.891 Melem/s]
+Found 4 outliers among 100 measurements (4.00%)
+  4 (4.00%) high mild
+Benchmarking mpsc_bounded_mpsc_flume/128
+Benchmarking mpsc_bounded_mpsc_flume/128: Warming up for 10.000 s
+Benchmarking mpsc_bounded_mpsc_flume/128: Collecting 100 samples in estimated 30.846 s (30k iterations)
+Benchmarking mpsc_bounded_mpsc_flume/128: Analyzing
+mpsc_bounded_mpsc_flume/128
+                        time:   [973.71 µs 1.0066 ms 1.0400 ms]
+                        thrpt:  [15.754 Melem/s 16.276 Melem/s 16.826 Melem/s]
+Found 5 outliers among 100 measurements (5.00%)
+  3 (3.00%) high mild
+  2 (2.00%) high severe
+Benchmarking mpsc_bounded_mpsc_flume/256
+Benchmarking mpsc_bounded_mpsc_flume/256: Warming up for 10.000 s
+Benchmarking mpsc_bounded_mpsc_flume/256: Collecting 100 samples in estimated 33.637 s (30k iterations)
+Benchmarking mpsc_bounded_mpsc_flume/256: Analyzing
+mpsc_bounded_mpsc_flume/256
+                        time:   [987.38 µs 1.0172 ms 1.0493 ms]
+                        thrpt:  [15.614 Melem/s 16.107 Melem/s 16.593 Melem/s]
+Found 2 outliers among 100 measurements (2.00%)
+  2 (2.00%) high mild
+Benchmarking mpsc_bounded_mpsc_flume/1024
+Benchmarking mpsc_bounded_mpsc_flume/1024: Warming up for 10.000 s
+Benchmarking mpsc_bounded_mpsc_flume/1024: Collecting 100 samples in estimated 31.693 s (30k iterations)
+Benchmarking mpsc_bounded_mpsc_flume/1024: Analyzing
+mpsc_bounded_mpsc_flume/1024
+                        time:   [1.2666 ms 1.4042 ms 1.5296 ms]
+                        thrpt:  [10.711 Melem/s 11.668 Melem/s 12.936 Melem/s]
+Benchmarking mpsc_bounded_mpsc_flume/2048
+Benchmarking mpsc_bounded_mpsc_flume/2048: Warming up for 10.000 s
+Benchmarking mpsc_bounded_mpsc_flume/2048: Collecting 100 samples in estimated 34.192 s (25k iterations)
+Benchmarking mpsc_bounded_mpsc_flume/2048: Analyzing
+mpsc_bounded_mpsc_flume/2048
+                        time:   [1.3859 ms 1.4645 ms 1.5460 ms]
+                        thrpt:  [10.598 Melem/s 11.187 Melem/s 11.822 Melem/s]
+Found 6 outliers among 100 measurements (6.00%)
+  4 (4.00%) high mild
+  2 (2.00%) high severe
+Benchmarking mpsc_bounded_mpsc_flume/4096
+Benchmarking mpsc_bounded_mpsc_flume/4096: Warming up for 10.000 s
+Benchmarking mpsc_bounded_mpsc_flume/4096: Collecting 100 samples in estimated 30.825 s (35k iterations)
+Benchmarking mpsc_bounded_mpsc_flume/4096: Analyzing
+mpsc_bounded_mpsc_flume/4096
+                        time:   [901.36 µs 936.83 µs 974.40 µs]
+                        thrpt:  [16.814 Melem/s 17.489 Melem/s 18.177 Melem/s]
+Found 1 outliers among 100 measurements (1.00%)
+  1 (1.00%) high mild
+
+Benchmarking mpsc_unbounded_spsc_flume/send_recv
+Benchmarking mpsc_unbounded_spsc_flume/send_recv: Warming up for 10.000 s
+Benchmarking mpsc_unbounded_spsc_flume/send_recv: Collecting 100 samples in estimated 33.219 s (50k iterations)
+Benchmarking mpsc_unbounded_spsc_flume/send_recv: Analyzing
+mpsc_unbounded_spsc_flume/send_recv
+                        time:   [739.76 µs 776.21 µs 817.71 µs]
+                        thrpt:  [20.037 Melem/s 21.108 Melem/s 22.148 Melem/s]
+Found 1 outliers among 100 measurements (1.00%)
+  1 (1.00%) high mild
+

--- a/benchmark-results/channel_mpsc_summary.md
+++ b/benchmark-results/channel_mpsc_summary.md
@@ -1,0 +1,68 @@
+# Runtime MPSC Channel Benchmark Results
+
+## Summary
+
+- Added `dynamo_runtime::channels::mpsc`, a facade that uses Tokio channels by default and flume async channels with the `flume-channels` feature.
+- Routed selected runtime transport channel paths through the facade so they can be built against either backend.
+- Added the `channel_mpsc_perf` Criterion microbenchmark for bounded SPSC, bounded MPSC, and unbounded SPSC channel traffic.
+- Recorded long-run Tokio and flume measurements with the original capacities plus 2x and 4x higher caps.
+
+## Validation
+
+```bash
+cargo fmt --check
+cargo check -p dynamo-runtime --benches
+cargo check -p dynamo-runtime --features flume-channels --benches
+cargo test -p dynamo-runtime channels
+cargo test -p dynamo-runtime --features flume-channels channels
+```
+
+All validation commands passed.
+
+## Benchmark Results
+
+Date: 2026-05-01 UTC
+Base commit: `563cd37d7b9904901f668833dc2ea704d38f9e35`
+
+Commands:
+
+```bash
+cargo bench -p dynamo-runtime --bench channel_mpsc_perf -- --noplot
+cargo bench -p dynamo-runtime --features flume-channels --bench channel_mpsc_perf -- --noplot
+```
+
+Long-run settings:
+
+- Criterion warmup: 10 seconds per benchmark case
+- Criterion measurement target: 30 seconds per benchmark case
+- Bounded SPSC capacities: `1, 2, 4, 64, 128, 256, 1024, 2048, 4096`
+- Bounded MPSC capacities: `64, 128, 256, 1024, 2048, 4096`
+
+Raw logs:
+
+- `benchmark-results/channel_mpsc_tokio_long.log`
+- `benchmark-results/channel_mpsc_flume_long.log`
+- Earlier short-run logs are kept in the same directory for comparison.
+
+Criterion point estimates from the long run:
+
+| Benchmark | Tokio time | Flume time | Flume speedup | Tokio throughput | Flume throughput |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Bounded SPSC, cap 1 | 335.12 ms | 197.73 ms | 1.69x | 48.890 Kelem/s | 82.860 Kelem/s |
+| Bounded SPSC, cap 2 | 170.33 ms | 149.24 ms | 1.14x | 96.188 Kelem/s | 109.78 Kelem/s |
+| Bounded SPSC, cap 4 | 85.007 ms | 169.76 ms | 0.50x | 192.74 Kelem/s | 96.512 Kelem/s |
+| Bounded SPSC, cap 64 | 5.3372 ms | 9.2099 ms | 0.58x | 3.0698 Melem/s | 1.7789 Melem/s |
+| Bounded SPSC, cap 128 | 1.7618 ms | 3.7887 ms | 0.47x | 9.2995 Melem/s | 4.3244 Melem/s |
+| Bounded SPSC, cap 256 | 1.4689 ms | 2.4872 ms | 0.59x | 11.154 Melem/s | 6.5872 Melem/s |
+| Bounded SPSC, cap 1024 | 1.4030 ms | 1.2269 ms | 1.14x | 11.678 Melem/s | 13.354 Melem/s |
+| Bounded SPSC, cap 2048 | 1.4025 ms | 1.0167 ms | 1.38x | 11.682 Melem/s | 16.116 Melem/s |
+| Bounded SPSC, cap 4096 | 1.3573 ms | 951.00 us | 1.43x | 12.071 Melem/s | 17.228 Melem/s |
+| Bounded MPSC, cap 64 | 1.7388 ms | 1.1456 ms | 1.52x | 9.4228 Melem/s | 14.301 Melem/s |
+| Bounded MPSC, cap 128 | 1.7310 ms | 1.0066 ms | 1.72x | 9.4651 Melem/s | 16.276 Melem/s |
+| Bounded MPSC, cap 256 | 1.6653 ms | 1.0172 ms | 1.64x | 9.8384 Melem/s | 16.107 Melem/s |
+| Bounded MPSC, cap 1024 | 1.8078 ms | 1.4042 ms | 1.29x | 9.0630 Melem/s | 11.668 Melem/s |
+| Bounded MPSC, cap 2048 | 1.7146 ms | 1.4645 ms | 1.17x | 9.5558 Melem/s | 11.187 Melem/s |
+| Bounded MPSC, cap 4096 | 1.8779 ms | 936.83 us | 2.00x | 8.7246 Melem/s | 17.489 Melem/s |
+| Unbounded SPSC | 1.2724 ms | 776.21 us | 1.64x | 12.876 Melem/s | 21.108 Melem/s |
+
+Long-run takeaway: flume wins every bounded MPSC case and unbounded SPSC. For bounded SPSC, flume wins at capacity `1`, `2`, and `1024+`, while Tokio wins at capacity `4` through `256`.

--- a/benchmark-results/channel_mpsc_tokio.log
+++ b/benchmark-results/channel_mpsc_tokio.log
@@ -1,0 +1,491 @@
+   Compiling proc-macro2 v1.0.106
+   Compiling quote v1.0.45
+   Compiling unicode-ident v1.0.24
+   Compiling libc v0.2.186
+   Compiling serde_core v1.0.228
+   Compiling cfg-if v1.0.4
+   Compiling serde v1.0.228
+   Compiling memchr v2.8.0
+   Compiling pin-project-lite v0.2.17
+   Compiling smallvec v1.15.1
+   Compiling log v0.4.29
+   Compiling itoa v1.0.18
+   Compiling once_cell v1.21.4
+   Compiling parking_lot_core v0.9.12
+   Compiling futures-core v0.3.32
+   Compiling scopeguard v1.2.0
+   Compiling futures-sink v0.3.32
+   Compiling lock_api v0.4.14
+   Compiling find-msvc-tools v0.1.9
+   Compiling shlex v1.3.0
+   Compiling crossbeam-utils v0.8.21
+   Compiling zmij v1.0.21
+   Compiling futures-channel v0.3.32
+   Compiling tracing-core v0.1.36
+   Compiling futures-task v0.3.32
+   Compiling slab v0.4.12
+   Compiling futures-io v0.3.32
+   Compiling version_check v0.9.5
+   Compiling syn v2.0.117
+   Compiling equivalent v1.0.2
+   Compiling serde_json v1.0.149
+   Compiling jobserver v0.1.34
+   Compiling errno v0.3.14
+   Compiling socket2 v0.6.3
+   Compiling mio v1.1.1
+   Compiling parking_lot v0.12.5
+   Compiling signal-hook-registry v1.4.8
+   Compiling cc v1.2.61
+   Compiling zeroize v1.8.2
+   Compiling hashbrown v0.17.0
+   Compiling either v1.15.0
+   Compiling percent-encoding v2.3.2
+   Compiling autocfg v1.5.0
+   Compiling fnv v1.0.7
+   Compiling getrandom v0.2.17
+   Compiling zerocopy v0.8.48
+   Compiling num-traits v0.2.19
+   Compiling cmake v0.1.58
+   Compiling dunce v1.0.5
+   Compiling indexmap v2.14.0
+   Compiling fs_extra v1.3.0
+   Compiling rustls-pki-types v1.14.1
+   Compiling tower-service v0.3.3
+   Compiling aws-lc-sys v0.40.0
+   Compiling stable_deref_trait v1.2.1
+   Compiling httparse v1.10.1
+   Compiling base64 v0.22.1
+   Compiling try-lock v0.2.5
+   Compiling want v0.3.1
+   Compiling ring v0.17.14
+   Compiling form_urlencoded v1.2.2
+   Compiling anyhow v1.0.102
+   Compiling aws-lc-rs v1.16.3
+   Compiling httpdate v1.0.3
+   Compiling untrusted v0.9.0
+   Compiling rayon-core v1.13.0
+   Compiling subtle v2.6.1
+   Compiling heck v0.5.0
+   Compiling ipnet v2.12.0
+   Compiling mime v0.3.17
+   Compiling atomic-waker v1.1.2
+   Compiling synstructure v0.13.2
+   Compiling aho-corasick v1.1.4
+   Compiling ident_case v1.0.1
+   Compiling thiserror v2.0.18
+   Compiling rustls v0.23.39
+   Compiling ryu v1.0.23
+   Compiling strsim v0.11.1
+   Compiling regex-syntax v0.8.10
+   Compiling sync_wrapper v1.0.2
+   Compiling writeable v0.6.3
+   Compiling litemap v0.8.2
+   Compiling tower-layer v0.3.3
+   Compiling getrandom v0.4.2
+   Compiling crossbeam-epoch v0.9.18
+   Compiling generic-array v0.14.7
+   Compiling icu_properties_data v2.2.0
+   Compiling utf8_iter v1.0.4
+   Compiling serde_derive v1.0.228
+   Compiling tokio-macros v2.6.1
+   Compiling futures-macro v0.3.32
+   Compiling tracing-attributes v0.1.31
+   Compiling zerofrom-derive v0.1.7
+   Compiling futures-util v0.3.32
+   Compiling tracing v0.1.44
+   Compiling yoke-derive v0.8.2
+   Compiling zerocopy-derive v0.8.48
+   Compiling zerofrom v0.1.7
+   Compiling zerovec-derive v0.11.3
+   Compiling yoke v0.8.2
+   Compiling displaydoc v0.2.5
+   Compiling zerovec v0.11.6
+   Compiling tinystr v0.8.3
+   Compiling bytes v1.11.1
+   Compiling regex-automata v0.4.14
+   Compiling thiserror-impl v2.0.18
+   Compiling icu_locale_core v2.2.0
+   Compiling potential_utf v0.1.5
+   Compiling zerotrie v0.2.4
+   Compiling unicase v2.9.0
+   Compiling tokio v1.48.0
+   Compiling http v1.4.0
+   Compiling icu_normalizer_data v2.2.0
+   Compiling icu_provider v2.2.0
+   Compiling icu_collections v2.2.0
+   Compiling http-body v1.0.1
+   Compiling http-body-util v0.1.3
+   Compiling crossbeam-deque v0.8.6
+   Compiling itertools v0.14.0
+   Compiling rustix v1.1.4
+   Compiling thiserror v1.0.69
+   Compiling getrandom v0.3.4
+   Compiling bitflags v2.11.1
+   Compiling typenum v1.20.0
+   Compiling futures-executor v0.3.32
+   Compiling thiserror-impl v1.0.69
+   Compiling prost-derive v0.14.3
+   Compiling semver v1.0.28
+   Compiling rustc_version v0.4.1
+   Compiling icu_normalizer v2.2.0
+   Compiling icu_properties v2.2.0
+   Compiling ppv-lite86 v0.2.21
+   Compiling serde_urlencoded v0.7.1
+   Compiling crossbeam-queue v0.3.12
+   Compiling crossbeam-channel v0.5.15
+   Compiling target-lexicon v0.12.16
+   Compiling rayon v1.12.0
+   Compiling crypto-common v0.1.7
+   Compiling idna_adapter v1.2.1
+   Compiling crossbeam v0.8.4
+   Compiling block-buffer v0.10.4
+   Compiling regex v1.12.3
+   Compiling toml_datetime v0.6.11
+   Compiling serde_spanned v0.6.9
+   Compiling pin-project-internal v1.1.11
+   Compiling darling_core v0.20.11
+   Compiling tokio-util v0.7.18
+   Compiling rustversion v1.0.22
+   Compiling h2 v0.4.13
+   Compiling tower v0.5.3
+   Compiling winnow v0.7.15
+   Compiling same-file v1.0.6
+   Compiling walkdir v2.5.0
+   Compiling darling_macro v0.20.11
+   Compiling jwalk v0.8.1
+   Compiling pin-project v1.1.11
+   Compiling digest v0.10.7
+   Compiling idna v1.1.0
+   Compiling toml_edit v0.22.27
+   Compiling openssl-probe v0.2.1
+   Compiling ucd-trie v0.1.7
+   Compiling prettyplease v0.2.37
+   Compiling pulldown-cmark v0.13.3
+   Compiling cfg-expr v0.15.8
+   Compiling pest v2.8.6
+   Compiling rustls-native-certs v0.8.3
+   Compiling url v2.5.8
+   Compiling dircpy v0.3.20
+   Compiling darling v0.20.11
+   Compiling tokio-stream v0.1.18
+   Compiling hyper v1.9.0
+   Compiling toml v0.8.23
+   Compiling futures v0.3.32
+   Compiling webpki-roots v1.0.7
+   Compiling foldhash v0.1.5
+   Compiling ref-cast v1.0.25
+   Compiling iri-string v0.7.12
+   Compiling time-core v0.1.8
+   Compiling pkg-config v0.3.33
+   Compiling base64ct v1.8.3
+   Compiling powerfmt v0.2.0
+   Compiling lazy_static v1.5.0
+   Compiling num-conv v0.2.1
+   Compiling version-compare v0.2.1
+   Compiling linux-raw-sys v0.12.1
+   Compiling deranged v0.5.8
+   Compiling time-macros v0.2.27
+   Compiling system-deps v6.2.2
+   Compiling hyper-util v0.1.20
+   Compiling tower-http v0.6.8
+   Compiling prost v0.14.3
+   Compiling pem-rfc7468 v0.7.0
+   Compiling hashbrown v0.15.5
+   Compiling pest_meta v2.8.6
+   Compiling zeromq-src v0.2.6+4.3.4
+   Compiling axum-core v0.5.6
+   Compiling hyper-timeout v0.5.2
+   Compiling opentelemetry v0.31.0
+   Compiling ref-cast-impl v1.0.25
+   Compiling axum-macros v0.5.1
+   Compiling async-trait v0.1.89
+   Compiling serde_derive_internals v0.29.1
+   Compiling serde_path_to_error v0.1.20
+   Compiling rand_core v0.6.4
+   Compiling proc-macro-error-attr2 v2.0.0
+   Compiling const-oid v0.9.6
+   Compiling matchit v0.8.4
+   Compiling fixedbitset v0.5.7
+   Compiling k8s-openapi v0.26.1
+   Compiling iana-time-zone v0.1.65
+   Compiling fastrand v2.4.1
+   Compiling num_threads v0.1.7
+   Compiling chrono v0.4.44
+   Compiling petgraph v0.8.3
+   Compiling time v0.3.47
+   Compiling tempfile v3.27.0
+   Compiling axum v0.8.4
+   Compiling schemars_derive v1.2.1
+   Compiling der v0.7.10
+   Compiling proc-macro-error2 v2.0.1
+   Compiling pulldown-cmark-to-cmark v22.0.0
+   Compiling pest_generator v2.8.6
+   Compiling zmq-sys v0.12.0
+   Compiling prost-types v0.14.3
+   Compiling signature v2.2.0
+   Compiling rand_core v0.9.5
+   Compiling curve25519-dalek v4.1.3
+   Compiling mime_guess v2.0.5
+   Compiling jsonptr v0.7.1
+   Compiling derive_more-impl v2.1.1
+   Compiling concurrent-queue v2.5.0
+   Compiling num-integer v0.1.46
+   Compiling ordered-float v2.10.1
+   Compiling ahash v0.8.12
+   Compiling proc-macro2-diagnostics v0.10.1
+   Compiling cpufeatures v0.2.17
+   Compiling parking v2.2.1
+   Compiling dyn-clone v1.0.20
+   Compiling multimap v0.10.1
+   Compiling utf8parse v0.2.2
+   Compiling schemars v1.2.1
+   Compiling prost-build v0.14.3
+   Compiling anstyle-parse v1.0.0
+   Compiling event-listener v5.4.1
+   Compiling derive_more v2.1.1
+   Compiling serde-value v0.7.0
+   Compiling json-patch v4.1.0
+   Compiling pest_derive v2.8.6
+   Compiling rand_chacha v0.9.0
+   Compiling spki v0.7.3
+   Compiling rand_chacha v0.3.1
+   Compiling tonic-build v0.14.5
+   Compiling derive_builder_core v0.20.2
+   Compiling http v0.2.12
+   Compiling curve25519-dalek-derive v0.1.1
+   Compiling enum-ordinalize-derive v4.3.2
+   Compiling darling_core v0.21.3
+   Compiling anstyle-query v1.1.5
+   Compiling allocator-api2 v0.2.21
+   Compiling colorchoice v1.0.5
+   Compiling bitflags v1.3.2
+   Compiling winnow v1.0.2
+   Compiling is_terminal_polyfill v1.70.2
+   Compiling unsafe-libyaml v0.2.11
+   Compiling anstyle v1.0.14
+   Compiling yansi v1.0.1
+   Compiling toml_parser v1.1.2+spec-1.1.0
+   Compiling serde_yaml v0.9.34+deprecated
+   Compiling anstream v1.0.0
+   Compiling enum-ordinalize v4.3.2
+   Compiling derive_builder_macro v0.20.2
+   Compiling tonic-prost-build v0.14.5
+   Compiling darling_macro v0.21.3
+   Compiling rand v0.8.6
+   Compiling jsonpath-rust v0.7.5
+   Compiling pkcs8 v0.10.2
+   Compiling rand v0.9.4
+   Compiling event-listener-strategy v0.5.4
+   Compiling sha2 v0.10.9
+   Compiling num-bigint v0.4.6
+   Compiling ed25519 v2.2.3
+   Compiling sharded-slab v0.1.7
+   Compiling matchers v0.2.0
+   Compiling tracing-serde v0.2.0
+   Compiling async-stream-impl v0.3.6
+   Compiling pem v3.0.6
+   Compiling secrecy v0.10.3
+   Compiling uncased v0.9.10
+   Compiling socket2 v0.5.10
+   Compiling tracing-log v0.2.0
+   Compiling thread_local v1.1.9
+   Compiling home v0.5.12
+   Compiling portable-atomic v1.13.1
+   Compiling nu-ansi-term v0.50.3
+   Compiling protobuf v3.7.2
+   Compiling clap_lex v1.1.0
+   Compiling toml_write v0.1.2
+   Compiling zmq v0.10.0
+   Compiling toml_datetime v1.1.1+spec-1.1.0
+   Compiling toml_edit v0.25.11+spec-1.1.0
+   Compiling tracing-subscriber v0.3.23
+   Compiling clap_builder v4.6.0
+   Compiling num-rational v0.4.2
+   Compiling async-stream v0.3.6
+   Compiling kube-core v2.0.1
+   Compiling opentelemetry_sdk v0.31.0
+   Compiling ed25519-dalek v2.2.0
+   Compiling async-broadcast v0.7.2
+   Compiling signatory v0.27.1
+   Compiling etcd-client v0.17.0
+   Compiling darling v0.21.3
+   Compiling derive_builder v0.20.2
+   Compiling educe v0.6.0
+   Compiling pear_codegen v0.2.9
+   Compiling h2 v0.3.27
+   Compiling http-body v0.4.6
+   Compiling backon v1.6.0
+   Compiling num-iter v0.1.45
+   Compiling getset v0.1.6
+   Compiling protobuf-support v3.7.2
+   Compiling rstest_macros v0.23.0
+   Compiling half v2.7.1
+   Compiling neli-proc-macros v0.2.2
+   Compiling clap_derive v4.6.1
+   Compiling num-complex v0.4.6
+   Compiling blake3 v1.8.4
+   Compiling rustls-pemfile v2.2.0
+   Compiling figment v0.10.19
+   Compiling inotify-sys v0.1.5
+   Compiling hostname v0.4.2
+   Compiling bit-vec v0.6.3
+   Compiling byteorder v1.5.0
+   Compiling openssl-probe v0.1.6
+   Compiling data-encoding v2.11.0
+   Compiling prometheus v0.14.0
+   Compiling inlinable_string v0.1.15
+   Compiling plotters-backend v0.3.7
+   Compiling ciborium-io v0.2.2
+   Compiling ciborium-ll v0.2.2
+   Compiling clap v4.6.1
+   Compiling nkeys v0.4.5
+   Compiling pear v0.2.9
+   Compiling plotters-svg v0.3.7
+   Compiling neli v0.7.4
+   Compiling bit-set v0.5.3
+   Compiling rustls-native-certs v0.7.3
+   Compiling hyper v0.14.32
+   Compiling inotify v0.9.6
+   Compiling num v0.4.3
+   Compiling kube-derive v2.0.1
+   Compiling proc-macro-crate v3.5.0
+   Compiling nuid v0.5.0
+   Compiling uuid v1.23.1
+   Compiling validator_derive v0.20.0
+   Compiling itertools v0.10.5
+   Compiling tryhard v0.5.2
+   Compiling serde_nanos v0.1.4
+   Compiling serde_repr v0.1.20
+   Compiling rustls-webpki v0.102.8
+   Compiling rmp v0.8.15
+   Compiling mio v0.8.11
+   Compiling filetime v0.2.27
+   Compiling nom v8.0.0
+   Compiling encoding_rs v0.8.35
+   Compiling hashbrown v0.14.5
+   Compiling cpufeatures v0.3.0
+   Compiling glob v0.3.3
+   Compiling arrayvec v0.7.6
+   Compiling arrayref v0.3.9
+   Compiling sync_wrapper v0.1.2
+   Compiling cast v0.3.0
+   Compiling base64 v0.21.7
+   Compiling relative-path v1.9.3
+   Compiling constant_time_eq v0.4.2
+   Compiling criterion-plot v0.5.0
+   Compiling reqwest v0.11.27
+   Compiling dashmap v6.1.0
+   Compiling notify v6.1.1
+   Compiling iso8601 v0.6.3
+   Compiling rmp-serde v1.3.1
+   Compiling validator v0.20.0
+   Compiling local-ip-address v0.6.12
+   Compiling fraction v0.13.1
+   Compiling fancy-regex v0.11.0
+   Compiling plotters v0.3.7
+   Compiling ciborium v0.2.2
+   Compiling tokio-rayon v2.1.0
+   Compiling dynamo-config v1.2.0 (/home/bgreengus/dev/dynamo-worktrees/dynamo-want-benchmark-dynamo-when-using-98f072cd-039f-4068-88ac-1e514a5be9fd/lib/config)
+   Compiling opentelemetry-appender-tracing v0.31.1
+   Compiling tracing-opentelemetry v0.32.1
+   Compiling lru v0.12.5
+   Compiling arc-swap v1.9.1
+   Compiling tinytemplate v1.2.1
+   Compiling bincode v1.3.3
+   Compiling derive-getters v0.5.0
+   Compiling is-terminal v0.4.17
+   Compiling xxhash-rust v0.8.15
+   Compiling humantime v2.3.0
+   Compiling futures-timer v3.0.3
+   Compiling anes v0.1.6
+   Compiling num-cmp v0.1.0
+   Compiling async-once-cell v0.5.4
+   Compiling oorandom v11.1.5
+   Compiling bytecount v0.6.9
+   Compiling criterion v0.5.1
+   Compiling rstest v0.23.0
+   Compiling jsonschema v0.17.1
+   Compiling temp-env v0.3.6
+   Compiling stdio-override v0.2.0
+   Compiling tmq v0.5.0
+   Compiling rustls-webpki v0.103.13
+   Compiling tokio-rustls v0.26.4
+   Compiling hyper-rustls v0.27.9
+   Compiling tonic v0.14.5
+   Compiling async-nats v0.45.0
+   Compiling reqwest v0.12.28
+   Compiling kube-client v2.0.1
+   Compiling opentelemetry-http v0.31.0
+   Compiling tonic-prost v0.14.5
+   Compiling opentelemetry-proto v0.31.0
+   Compiling kube-runtime v2.0.1
+   Compiling kube v2.0.1
+   Compiling opentelemetry-otlp v0.31.1
+   Compiling dynamo-runtime v1.2.0 (/home/bgreengus/dev/dynamo-worktrees/dynamo-want-benchmark-dynamo-when-using-98f072cd-039f-4068-88ac-1e514a5be9fd/lib/runtime)
+    Finished `bench` profile [optimized] target(s) in 3m 56s
+     Running benches/channel_mpsc_perf.rs (target/release/deps/channel_mpsc_perf-d923b87412afec86)
+Gnuplot not found, using plotters backend
+Benchmarking mpsc_bounded_spsc_tokio/1
+Benchmarking mpsc_bounded_spsc_tokio/1: Warming up for 3.0000 s
+
+Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 33.1s, or reduce sample count to 10.
+Benchmarking mpsc_bounded_spsc_tokio/1: Collecting 100 samples in estimated 33.116 s (100 iterations)
+Benchmarking mpsc_bounded_spsc_tokio/1: Analyzing
+mpsc_bounded_spsc_tokio/1
+                        time:   [319.63 ms 329.63 ms 340.58 ms]
+                        thrpt:  [48.106 Kelem/s 49.705 Kelem/s 51.260 Kelem/s]
+Found 8 outliers among 100 measurements (8.00%)
+  5 (5.00%) high mild
+  3 (3.00%) high severe
+Benchmarking mpsc_bounded_spsc_tokio/64
+Benchmarking mpsc_bounded_spsc_tokio/64: Warming up for 3.0000 s
+Benchmarking mpsc_bounded_spsc_tokio/64: Collecting 100 samples in estimated 5.4625 s (600 iterations)
+Benchmarking mpsc_bounded_spsc_tokio/64: Analyzing
+mpsc_bounded_spsc_tokio/64
+                        time:   [7.5236 ms 7.9568 ms 8.4462 ms]
+                        thrpt:  [1.9398 Melem/s 2.0591 Melem/s 2.1777 Melem/s]
+Found 5 outliers among 100 measurements (5.00%)
+  3 (3.00%) high mild
+  2 (2.00%) high severe
+Benchmarking mpsc_bounded_spsc_tokio/1024
+Benchmarking mpsc_bounded_spsc_tokio/1024: Warming up for 3.0000 s
+Benchmarking mpsc_bounded_spsc_tokio/1024: Collecting 100 samples in estimated 5.1771 s (1700 iterations)
+Benchmarking mpsc_bounded_spsc_tokio/1024: Analyzing
+mpsc_bounded_spsc_tokio/1024
+                        time:   [2.3430 ms 2.5108 ms 2.6928 ms]
+                        thrpt:  [6.0843 Melem/s 6.5255 Melem/s 6.9927 Melem/s]
+Found 5 outliers among 100 measurements (5.00%)
+  4 (4.00%) high mild
+  1 (1.00%) high severe
+
+Benchmarking mpsc_bounded_mpsc_tokio/64
+Benchmarking mpsc_bounded_mpsc_tokio/64: Warming up for 3.0000 s
+Benchmarking mpsc_bounded_mpsc_tokio/64: Collecting 100 samples in estimated 5.0515 s (2000 iterations)
+Benchmarking mpsc_bounded_mpsc_tokio/64: Analyzing
+mpsc_bounded_mpsc_tokio/64
+                        time:   [2.2875 ms 2.4439 ms 2.6150 ms]
+                        thrpt:  [6.2655 Melem/s 6.7039 Melem/s 7.1623 Melem/s]
+Found 6 outliers among 100 measurements (6.00%)
+  6 (6.00%) high mild
+Benchmarking mpsc_bounded_mpsc_tokio/1024
+Benchmarking mpsc_bounded_mpsc_tokio/1024: Warming up for 3.0000 s
+
+Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.6s, enable flat sampling, or reduce sample count to 50.
+Benchmarking mpsc_bounded_mpsc_tokio/1024: Collecting 100 samples in estimated 8.6348 s (5050 iterations)
+Benchmarking mpsc_bounded_mpsc_tokio/1024: Analyzing
+mpsc_bounded_mpsc_tokio/1024
+                        time:   [1.6257 ms 1.6895 ms 1.7706 ms]
+                        thrpt:  [9.2532 Melem/s 9.6976 Melem/s 10.078 Melem/s]
+Found 10 outliers among 100 measurements (10.00%)
+  2 (2.00%) low mild
+  4 (4.00%) high mild
+  4 (4.00%) high severe
+
+Benchmarking mpsc_unbounded_spsc_tokio/send_recv
+Benchmarking mpsc_unbounded_spsc_tokio/send_recv: Warming up for 3.0000 s
+Benchmarking mpsc_unbounded_spsc_tokio/send_recv: Collecting 100 samples in estimated 11.978 s (15k iterations)
+Benchmarking mpsc_unbounded_spsc_tokio/send_recv: Analyzing
+mpsc_unbounded_spsc_tokio/send_recv
+                        time:   [1.1207 ms 1.1837 ms 1.2442 ms]
+                        thrpt:  [13.168 Melem/s 13.841 Melem/s 14.619 Melem/s]
+

--- a/benchmark-results/channel_mpsc_tokio_expanded_caps.log
+++ b/benchmark-results/channel_mpsc_tokio_expanded_caps.log
@@ -1,0 +1,226 @@
+   Compiling dynamo-runtime v1.2.0 (/home/bgreengus/dev/dynamo-worktrees/dynamo-want-benchmark-dynamo-when-using-98f072cd-039f-4068-88ac-1e514a5be9fd/lib/runtime)
+    Finished `bench` profile [optimized] target(s) in 16.83s
+     Running benches/channel_mpsc_perf.rs (target/release/deps/channel_mpsc_perf-d923b87412afec86)
+Gnuplot not found, using plotters backend
+Benchmarking mpsc_bounded_spsc_tokio/1
+Benchmarking mpsc_bounded_spsc_tokio/1: Warming up for 3.0000 s
+
+Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 34.8s, or reduce sample count to 10.
+Benchmarking mpsc_bounded_spsc_tokio/1: Collecting 100 samples in estimated 34.832 s (100 iterations)
+Benchmarking mpsc_bounded_spsc_tokio/1: Analyzing
+mpsc_bounded_spsc_tokio/1
+                        time:   [329.76 ms 333.08 ms 336.49 ms]
+                        thrpt:  [48.691 Kelem/s 49.189 Kelem/s 49.684 Kelem/s]
+                 change:
+                        time:   [-2.3172% +1.0480% +4.3614%] (p = 0.55 > 0.05)
+                        thrpt:  [-4.1791% -1.0371% +2.3721%]
+                        No change in performance detected.
+Found 1 outliers among 100 measurements (1.00%)
+  1 (1.00%) high mild
+Benchmarking mpsc_bounded_spsc_tokio/2
+Benchmarking mpsc_bounded_spsc_tokio/2: Warming up for 3.0000 s
+
+Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 17.5s, or reduce sample count to 20.
+Benchmarking mpsc_bounded_spsc_tokio/2: Collecting 100 samples in estimated 17.519 s (100 iterations)
+Benchmarking mpsc_bounded_spsc_tokio/2: Analyzing
+mpsc_bounded_spsc_tokio/2
+                        time:   [169.24 ms 171.39 ms 173.62 ms]
+                        thrpt:  [94.370 Kelem/s 95.592 Kelem/s 96.808 Kelem/s]
+Found 2 outliers among 100 measurements (2.00%)
+  2 (2.00%) high mild
+Benchmarking mpsc_bounded_spsc_tokio/4
+Benchmarking mpsc_bounded_spsc_tokio/4: Warming up for 3.0000 s
+
+Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.3s, or reduce sample count to 50.
+Benchmarking mpsc_bounded_spsc_tokio/4: Collecting 100 samples in estimated 8.3334 s (100 iterations)
+Benchmarking mpsc_bounded_spsc_tokio/4: Analyzing
+mpsc_bounded_spsc_tokio/4
+                        time:   [86.074 ms 87.709 ms 89.570 ms]
+                        thrpt:  [182.92 Kelem/s 186.80 Kelem/s 190.35 Kelem/s]
+Found 4 outliers among 100 measurements (4.00%)
+  2 (2.00%) high mild
+  2 (2.00%) high severe
+Benchmarking mpsc_bounded_spsc_tokio/64
+Benchmarking mpsc_bounded_spsc_tokio/64: Warming up for 3.0000 s
+Benchmarking mpsc_bounded_spsc_tokio/64: Collecting 100 samples in estimated 5.3995 s (1000 iterations)
+Benchmarking mpsc_bounded_spsc_tokio/64: Analyzing
+mpsc_bounded_spsc_tokio/64
+                        time:   [5.3235 ms 5.4301 ms 5.5427 ms]
+                        thrpt:  [2.9560 Melem/s 3.0173 Melem/s 3.0777 Melem/s]
+                 change:
+                        time:   [-36.030% -31.755% -27.651%] (p = 0.00 < 0.05)
+                        thrpt:  [+38.218% +46.532% +56.322%]
+                        Performance has improved.
+Found 5 outliers among 100 measurements (5.00%)
+  4 (4.00%) high mild
+  1 (1.00%) high severe
+Benchmarking mpsc_bounded_spsc_tokio/128
+Benchmarking mpsc_bounded_spsc_tokio/128: Warming up for 3.0000 s
+
+Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 9.2s, enable flat sampling, or reduce sample count to 50.
+Benchmarking mpsc_bounded_spsc_tokio/128: Collecting 100 samples in estimated 9.1908 s (5050 iterations)
+Benchmarking mpsc_bounded_spsc_tokio/128: Analyzing
+mpsc_bounded_spsc_tokio/128
+                        time:   [1.7562 ms 1.9317 ms 2.1570 ms]
+                        thrpt:  [7.5957 Melem/s 8.4817 Melem/s 9.3294 Melem/s]
+Found 10 outliers among 100 measurements (10.00%)
+  3 (3.00%) high mild
+  7 (7.00%) high severe
+Benchmarking mpsc_bounded_spsc_tokio/256
+Benchmarking mpsc_bounded_spsc_tokio/256: Warming up for 3.0000 s
+
+Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 7.3s, enable flat sampling, or reduce sample count to 50.
+Benchmarking mpsc_bounded_spsc_tokio/256: Collecting 100 samples in estimated 7.2862 s (5050 iterations)
+Benchmarking mpsc_bounded_spsc_tokio/256: Analyzing
+mpsc_bounded_spsc_tokio/256
+                        time:   [1.4758 ms 1.5268 ms 1.5812 ms]
+                        thrpt:  [10.361 Melem/s 10.731 Melem/s 11.102 Melem/s]
+Found 3 outliers among 100 measurements (3.00%)
+  3 (3.00%) high mild
+Benchmarking mpsc_bounded_spsc_tokio/1024
+Benchmarking mpsc_bounded_spsc_tokio/1024: Warming up for 3.0000 s
+
+Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 6.8s, enable flat sampling, or reduce sample count to 60.
+Benchmarking mpsc_bounded_spsc_tokio/1024: Collecting 100 samples in estimated 6.7841 s (5050 iterations)
+Benchmarking mpsc_bounded_spsc_tokio/1024: Analyzing
+mpsc_bounded_spsc_tokio/1024
+                        time:   [1.3041 ms 1.3355 ms 1.3755 ms]
+                        thrpt:  [11.911 Melem/s 12.268 Melem/s 12.564 Melem/s]
+                 change:
+                        time:   [-49.234% -45.296% -41.120%] (p = 0.00 < 0.05)
+                        thrpt:  [+69.836% +82.801% +96.981%]
+                        Performance has improved.
+Found 8 outliers among 100 measurements (8.00%)
+  5 (5.00%) high mild
+  3 (3.00%) high severe
+Benchmarking mpsc_bounded_spsc_tokio/2048
+Benchmarking mpsc_bounded_spsc_tokio/2048: Warming up for 3.0000 s
+
+Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 6.4s, enable flat sampling, or reduce sample count to 60.
+Benchmarking mpsc_bounded_spsc_tokio/2048: Collecting 100 samples in estimated 6.4278 s (5050 iterations)
+Benchmarking mpsc_bounded_spsc_tokio/2048: Analyzing
+mpsc_bounded_spsc_tokio/2048
+                        time:   [1.2990 ms 1.3210 ms 1.3462 ms]
+                        thrpt:  [12.171 Melem/s 12.402 Melem/s 12.613 Melem/s]
+Found 7 outliers among 100 measurements (7.00%)
+  2 (2.00%) high mild
+  5 (5.00%) high severe
+Benchmarking mpsc_bounded_spsc_tokio/4096
+Benchmarking mpsc_bounded_spsc_tokio/4096: Warming up for 3.0000 s
+
+Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 6.6s, enable flat sampling, or reduce sample count to 60.
+Benchmarking mpsc_bounded_spsc_tokio/4096: Collecting 100 samples in estimated 6.6392 s (5050 iterations)
+Benchmarking mpsc_bounded_spsc_tokio/4096: Analyzing
+mpsc_bounded_spsc_tokio/4096
+                        time:   [1.2490 ms 1.2971 ms 1.3489 ms]
+                        thrpt:  [12.146 Melem/s 12.631 Melem/s 13.118 Melem/s]
+Found 7 outliers among 100 measurements (7.00%)
+  6 (6.00%) high mild
+  1 (1.00%) high severe
+
+Benchmarking mpsc_bounded_mpsc_tokio/64
+Benchmarking mpsc_bounded_mpsc_tokio/64: Warming up for 3.0000 s
+
+Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.8s, enable flat sampling, or reduce sample count to 50.
+Benchmarking mpsc_bounded_mpsc_tokio/64: Collecting 100 samples in estimated 8.7534 s (5050 iterations)
+Benchmarking mpsc_bounded_mpsc_tokio/64: Analyzing
+mpsc_bounded_mpsc_tokio/64
+                        time:   [1.6804 ms 1.6976 ms 1.7136 ms]
+                        thrpt:  [9.5611 Melem/s 9.6515 Melem/s 9.7501 Melem/s]
+                 change:
+                        time:   [-36.051% -31.560% -26.664%] (p = 0.00 < 0.05)
+                        thrpt:  [+36.359% +46.114% +56.375%]
+                        Performance has improved.
+Found 13 outliers among 100 measurements (13.00%)
+  7 (7.00%) low severe
+  1 (1.00%) low mild
+  2 (2.00%) high mild
+  3 (3.00%) high severe
+Benchmarking mpsc_bounded_mpsc_tokio/128
+Benchmarking mpsc_bounded_mpsc_tokio/128: Warming up for 3.0000 s
+
+Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.3s, enable flat sampling, or reduce sample count to 50.
+Benchmarking mpsc_bounded_mpsc_tokio/128: Collecting 100 samples in estimated 8.2939 s (5050 iterations)
+Benchmarking mpsc_bounded_mpsc_tokio/128: Analyzing
+mpsc_bounded_mpsc_tokio/128
+                        time:   [1.6433 ms 1.6644 ms 1.6852 ms]
+                        thrpt:  [9.7223 Melem/s 9.8439 Melem/s 9.9703 Melem/s]
+Found 12 outliers among 100 measurements (12.00%)
+  1 (1.00%) low severe
+  7 (7.00%) low mild
+  1 (1.00%) high mild
+  3 (3.00%) high severe
+Benchmarking mpsc_bounded_mpsc_tokio/256
+Benchmarking mpsc_bounded_mpsc_tokio/256: Warming up for 3.0000 s
+
+Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.5s, enable flat sampling, or reduce sample count to 50.
+Benchmarking mpsc_bounded_mpsc_tokio/256: Collecting 100 samples in estimated 8.4780 s (5050 iterations)
+Benchmarking mpsc_bounded_mpsc_tokio/256: Analyzing
+mpsc_bounded_mpsc_tokio/256
+                        time:   [1.6589 ms 1.6707 ms 1.6830 ms]
+                        thrpt:  [9.7349 Melem/s 9.8067 Melem/s 9.8761 Melem/s]
+Found 8 outliers among 100 measurements (8.00%)
+  1 (1.00%) low severe
+  6 (6.00%) high mild
+  1 (1.00%) high severe
+Benchmarking mpsc_bounded_mpsc_tokio/1024
+Benchmarking mpsc_bounded_mpsc_tokio/1024: Warming up for 3.0000 s
+
+Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.4s, enable flat sampling, or reduce sample count to 50.
+Benchmarking mpsc_bounded_mpsc_tokio/1024: Collecting 100 samples in estimated 8.4093 s (5050 iterations)
+Benchmarking mpsc_bounded_mpsc_tokio/1024: Analyzing
+mpsc_bounded_mpsc_tokio/1024
+                        time:   [1.6549 ms 1.6933 ms 1.7329 ms]
+                        thrpt:  [9.4547 Melem/s 9.6756 Melem/s 9.9004 Melem/s]
+                 change:
+                        time:   [-1.8089% +1.8828% +5.5897%] (p = 0.32 > 0.05)
+                        thrpt:  [-5.2938% -1.8480% +1.8423%]
+                        No change in performance detected.
+Found 14 outliers among 100 measurements (14.00%)
+  2 (2.00%) low severe
+  8 (8.00%) low mild
+  3 (3.00%) high mild
+  1 (1.00%) high severe
+Benchmarking mpsc_bounded_mpsc_tokio/2048
+Benchmarking mpsc_bounded_mpsc_tokio/2048: Warming up for 3.0000 s
+
+Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 9.0s, enable flat sampling, or reduce sample count to 50.
+Benchmarking mpsc_bounded_mpsc_tokio/2048: Collecting 100 samples in estimated 8.9700 s (5050 iterations)
+Benchmarking mpsc_bounded_mpsc_tokio/2048: Analyzing
+mpsc_bounded_mpsc_tokio/2048
+                        time:   [1.6593 ms 1.7042 ms 1.7440 ms]
+                        thrpt:  [9.3948 Melem/s 9.6140 Melem/s 9.8743 Melem/s]
+Found 8 outliers among 100 measurements (8.00%)
+  6 (6.00%) low mild
+  1 (1.00%) high mild
+  1 (1.00%) high severe
+Benchmarking mpsc_bounded_mpsc_tokio/4096
+Benchmarking mpsc_bounded_mpsc_tokio/4096: Warming up for 3.0000 s
+
+Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 9.6s, enable flat sampling, or reduce sample count to 50.
+Benchmarking mpsc_bounded_mpsc_tokio/4096: Collecting 100 samples in estimated 9.5829 s (5050 iterations)
+Benchmarking mpsc_bounded_mpsc_tokio/4096: Analyzing
+mpsc_bounded_mpsc_tokio/4096
+                        time:   [1.8234 ms 1.8573 ms 1.8875 ms]
+                        thrpt:  [8.6804 Melem/s 8.8214 Melem/s 8.9856 Melem/s]
+Found 13 outliers among 100 measurements (13.00%)
+  6 (6.00%) low severe
+  4 (4.00%) low mild
+  2 (2.00%) high mild
+  1 (1.00%) high severe
+
+Benchmarking mpsc_unbounded_spsc_tokio/send_recv
+Benchmarking mpsc_unbounded_spsc_tokio/send_recv: Warming up for 3.0000 s
+Benchmarking mpsc_unbounded_spsc_tokio/send_recv: Collecting 100 samples in estimated 10.165 s (15k iterations)
+Benchmarking mpsc_unbounded_spsc_tokio/send_recv: Analyzing
+mpsc_unbounded_spsc_tokio/send_recv
+                        time:   [680.98 µs 701.88 µs 726.15 µs]
+                        thrpt:  [22.563 Melem/s 23.343 Melem/s 24.059 Melem/s]
+                 change:
+                        time:   [-36.787% -32.786% -28.677%] (p = 0.00 < 0.05)
+                        thrpt:  [+40.207% +48.779% +58.194%]
+                        Performance has improved.
+Found 7 outliers among 100 measurements (7.00%)
+  4 (4.00%) high mild
+  3 (3.00%) high severe
+

--- a/benchmark-results/channel_mpsc_tokio_long.log
+++ b/benchmark-results/channel_mpsc_tokio_long.log
@@ -1,0 +1,169 @@
+   Compiling dynamo-runtime v1.2.0 (/home/bgreengus/dev/dynamo-worktrees/dynamo-want-benchmark-dynamo-when-using-98f072cd-039f-4068-88ac-1e514a5be9fd/lib/runtime)
+    Finished `bench` profile [optimized] target(s) in 16.46s
+     Running benches/channel_mpsc_perf.rs (target/release/deps/channel_mpsc_perf-d923b87412afec86)
+Gnuplot not found, using plotters backend
+Benchmarking mpsc_bounded_spsc_tokio/1
+Benchmarking mpsc_bounded_spsc_tokio/1: Warming up for 10.000 s
+
+Warning: Unable to complete 100 samples in 30.0s. You may wish to increase target time to 33.2s, or reduce sample count to 90.
+Benchmarking mpsc_bounded_spsc_tokio/1: Collecting 100 samples in estimated 33.235 s (100 iterations)
+Benchmarking mpsc_bounded_spsc_tokio/1: Analyzing
+mpsc_bounded_spsc_tokio/1
+                        time:   [330.37 ms 335.12 ms 340.19 ms]
+                        thrpt:  [48.161 Kelem/s 48.890 Kelem/s 49.593 Kelem/s]
+Found 4 outliers among 100 measurements (4.00%)
+  4 (4.00%) high mild
+Benchmarking mpsc_bounded_spsc_tokio/2
+Benchmarking mpsc_bounded_spsc_tokio/2: Warming up for 10.000 s
+Benchmarking mpsc_bounded_spsc_tokio/2: Collecting 100 samples in estimated 35.043 s (200 iterations)
+Benchmarking mpsc_bounded_spsc_tokio/2: Analyzing
+mpsc_bounded_spsc_tokio/2
+                        time:   [168.18 ms 170.33 ms 172.70 ms]
+                        thrpt:  [94.872 Kelem/s 96.188 Kelem/s 97.421 Kelem/s]
+Found 4 outliers among 100 measurements (4.00%)
+  2 (2.00%) high mild
+  2 (2.00%) high severe
+Benchmarking mpsc_bounded_spsc_tokio/4
+Benchmarking mpsc_bounded_spsc_tokio/4: Warming up for 10.000 s
+Benchmarking mpsc_bounded_spsc_tokio/4: Collecting 100 samples in estimated 33.522 s (400 iterations)
+Benchmarking mpsc_bounded_spsc_tokio/4: Analyzing
+mpsc_bounded_spsc_tokio/4
+                        time:   [83.801 ms 85.007 ms 86.291 ms]
+                        thrpt:  [189.87 Kelem/s 192.74 Kelem/s 195.51 Kelem/s]
+Found 8 outliers among 100 measurements (8.00%)
+  6 (6.00%) high mild
+  2 (2.00%) high severe
+Benchmarking mpsc_bounded_spsc_tokio/64
+Benchmarking mpsc_bounded_spsc_tokio/64: Warming up for 10.000 s
+Benchmarking mpsc_bounded_spsc_tokio/64: Collecting 100 samples in estimated 55.782 s (10k iterations)
+Benchmarking mpsc_bounded_spsc_tokio/64: Analyzing
+mpsc_bounded_spsc_tokio/64
+                        time:   [5.2590 ms 5.3372 ms 5.4205 ms]
+                        thrpt:  [3.0226 Melem/s 3.0698 Melem/s 3.1154 Melem/s]
+Found 1 outliers among 100 measurements (1.00%)
+  1 (1.00%) high mild
+Benchmarking mpsc_bounded_spsc_tokio/128
+Benchmarking mpsc_bounded_spsc_tokio/128: Warming up for 10.000 s
+Benchmarking mpsc_bounded_spsc_tokio/128: Collecting 100 samples in estimated 35.907 s (20k iterations)
+Benchmarking mpsc_bounded_spsc_tokio/128: Analyzing
+mpsc_bounded_spsc_tokio/128
+                        time:   [1.7301 ms 1.7618 ms 1.7941 ms]
+                        thrpt:  [9.1324 Melem/s 9.2995 Melem/s 9.4698 Melem/s]
+Found 5 outliers among 100 measurements (5.00%)
+  2 (2.00%) high mild
+  3 (3.00%) high severe
+Benchmarking mpsc_bounded_spsc_tokio/256
+Benchmarking mpsc_bounded_spsc_tokio/256: Warming up for 10.000 s
+Benchmarking mpsc_bounded_spsc_tokio/256: Collecting 100 samples in estimated 36.792 s (25k iterations)
+Benchmarking mpsc_bounded_spsc_tokio/256: Analyzing
+mpsc_bounded_spsc_tokio/256
+                        time:   [1.4159 ms 1.4689 ms 1.5366 ms]
+                        thrpt:  [10.662 Melem/s 11.154 Melem/s 11.572 Melem/s]
+Found 4 outliers among 100 measurements (4.00%)
+  3 (3.00%) high mild
+  1 (1.00%) high severe
+Benchmarking mpsc_bounded_spsc_tokio/1024
+Benchmarking mpsc_bounded_spsc_tokio/1024: Warming up for 10.000 s
+Benchmarking mpsc_bounded_spsc_tokio/1024: Collecting 100 samples in estimated 34.958 s (25k iterations)
+Benchmarking mpsc_bounded_spsc_tokio/1024: Analyzing
+mpsc_bounded_spsc_tokio/1024
+                        time:   [1.3719 ms 1.4030 ms 1.4352 ms]
+                        thrpt:  [11.416 Melem/s 11.678 Melem/s 11.943 Melem/s]
+Found 4 outliers among 100 measurements (4.00%)
+  3 (3.00%) high mild
+  1 (1.00%) high severe
+Benchmarking mpsc_bounded_spsc_tokio/2048
+Benchmarking mpsc_bounded_spsc_tokio/2048: Warming up for 10.000 s
+Benchmarking mpsc_bounded_spsc_tokio/2048: Collecting 100 samples in estimated 30.003 s (20k iterations)
+Benchmarking mpsc_bounded_spsc_tokio/2048: Analyzing
+mpsc_bounded_spsc_tokio/2048
+                        time:   [1.3801 ms 1.4025 ms 1.4270 ms]
+                        thrpt:  [11.481 Melem/s 11.682 Melem/s 11.871 Melem/s]
+Found 4 outliers among 100 measurements (4.00%)
+  4 (4.00%) high mild
+Benchmarking mpsc_bounded_spsc_tokio/4096
+Benchmarking mpsc_bounded_spsc_tokio/4096: Warming up for 10.000 s
+Benchmarking mpsc_bounded_spsc_tokio/4096: Collecting 100 samples in estimated 32.571 s (25k iterations)
+Benchmarking mpsc_bounded_spsc_tokio/4096: Analyzing
+mpsc_bounded_spsc_tokio/4096
+                        time:   [1.3249 ms 1.3573 ms 1.3888 ms]
+                        thrpt:  [11.797 Melem/s 12.071 Melem/s 12.366 Melem/s]
+Found 2 outliers among 100 measurements (2.00%)
+  1 (1.00%) high mild
+  1 (1.00%) high severe
+
+Benchmarking mpsc_bounded_mpsc_tokio/64
+Benchmarking mpsc_bounded_mpsc_tokio/64: Warming up for 10.000 s
+Benchmarking mpsc_bounded_mpsc_tokio/64: Collecting 100 samples in estimated 33.763 s (20k iterations)
+Benchmarking mpsc_bounded_mpsc_tokio/64: Analyzing
+mpsc_bounded_mpsc_tokio/64
+                        time:   [1.6954 ms 1.7388 ms 1.7883 ms]
+                        thrpt:  [9.1619 Melem/s 9.4228 Melem/s 9.6640 Melem/s]
+Found 9 outliers among 100 measurements (9.00%)
+  3 (3.00%) low mild
+  3 (3.00%) high mild
+  3 (3.00%) high severe
+Benchmarking mpsc_bounded_mpsc_tokio/128
+Benchmarking mpsc_bounded_mpsc_tokio/128: Warming up for 10.000 s
+Benchmarking mpsc_bounded_mpsc_tokio/128: Collecting 100 samples in estimated 34.533 s (20k iterations)
+Benchmarking mpsc_bounded_mpsc_tokio/128: Analyzing
+mpsc_bounded_mpsc_tokio/128
+                        time:   [1.6888 ms 1.7310 ms 1.7773 ms]
+                        thrpt:  [9.2183 Melem/s 9.4651 Melem/s 9.7014 Melem/s]
+Found 7 outliers among 100 measurements (7.00%)
+  1 (1.00%) low mild
+  5 (5.00%) high mild
+  1 (1.00%) high severe
+Benchmarking mpsc_bounded_mpsc_tokio/256
+Benchmarking mpsc_bounded_mpsc_tokio/256: Warming up for 10.000 s
+Benchmarking mpsc_bounded_mpsc_tokio/256: Collecting 100 samples in estimated 34.529 s (20k iterations)
+Benchmarking mpsc_bounded_mpsc_tokio/256: Analyzing
+mpsc_bounded_mpsc_tokio/256
+                        time:   [1.6176 ms 1.6653 ms 1.7129 ms]
+                        thrpt:  [9.5652 Melem/s 9.8384 Melem/s 10.129 Melem/s]
+Found 9 outliers among 100 measurements (9.00%)
+  2 (2.00%) low mild
+  5 (5.00%) high mild
+  2 (2.00%) high severe
+Benchmarking mpsc_bounded_mpsc_tokio/1024
+Benchmarking mpsc_bounded_mpsc_tokio/1024: Warming up for 10.000 s
+Benchmarking mpsc_bounded_mpsc_tokio/1024: Collecting 100 samples in estimated 38.664 s (20k iterations)
+Benchmarking mpsc_bounded_mpsc_tokio/1024: Analyzing
+mpsc_bounded_mpsc_tokio/1024
+                        time:   [1.7568 ms 1.8078 ms 1.8671 ms]
+                        thrpt:  [8.7752 Melem/s 9.0630 Melem/s 9.3259 Melem/s]
+Found 6 outliers among 100 measurements (6.00%)
+  4 (4.00%) high mild
+  2 (2.00%) high severe
+Benchmarking mpsc_bounded_mpsc_tokio/2048
+Benchmarking mpsc_bounded_mpsc_tokio/2048: Warming up for 10.000 s
+Benchmarking mpsc_bounded_mpsc_tokio/2048: Collecting 100 samples in estimated 33.869 s (20k iterations)
+Benchmarking mpsc_bounded_mpsc_tokio/2048: Analyzing
+mpsc_bounded_mpsc_tokio/2048
+                        time:   [1.6743 ms 1.7146 ms 1.7581 ms]
+                        thrpt:  [9.3193 Melem/s 9.5558 Melem/s 9.7855 Melem/s]
+Found 4 outliers among 100 measurements (4.00%)
+  3 (3.00%) high mild
+  1 (1.00%) high severe
+Benchmarking mpsc_bounded_mpsc_tokio/4096
+Benchmarking mpsc_bounded_mpsc_tokio/4096: Warming up for 10.000 s
+Benchmarking mpsc_bounded_mpsc_tokio/4096: Collecting 100 samples in estimated 31.419 s (15k iterations)
+Benchmarking mpsc_bounded_mpsc_tokio/4096: Analyzing
+mpsc_bounded_mpsc_tokio/4096
+                        time:   [1.8344 ms 1.8779 ms 1.9244 ms]
+                        thrpt:  [8.5139 Melem/s 8.7246 Melem/s 8.9316 Melem/s]
+Found 3 outliers among 100 measurements (3.00%)
+  2 (2.00%) low mild
+  1 (1.00%) high mild
+
+Benchmarking mpsc_unbounded_spsc_tokio/send_recv
+Benchmarking mpsc_unbounded_spsc_tokio/send_recv: Warming up for 10.000 s
+Benchmarking mpsc_unbounded_spsc_tokio/send_recv: Collecting 100 samples in estimated 31.637 s (25k iterations)
+Benchmarking mpsc_unbounded_spsc_tokio/send_recv: Analyzing
+mpsc_unbounded_spsc_tokio/send_recv
+                        time:   [1.2323 ms 1.2724 ms 1.3247 ms]
+                        thrpt:  [12.368 Melem/s 12.876 Melem/s 13.295 Melem/s]
+Found 7 outliers among 100 measurements (7.00%)
+  3 (3.00%) high mild
+  4 (4.00%) high severe
+

--- a/lib/runtime/Cargo.toml
+++ b/lib/runtime/Cargo.toml
@@ -22,6 +22,7 @@ testing-etcd = [] # Tests that require an active ETCD server
 tokio-console = ["dep:console-subscriber", "tokio/tracing"]
 compute-validation = [] # Enable validation and timing for compute macros
 tcp-low-latency = [] # Enable Linux-specific TCP optimizations (TCP_QUICKACK, SO_BUSY_POLL)
+flume-channels = ["dep:flume"] # Use flume async mpsc channels behind dynamo_runtime::channels::mpsc
 # NVTX timeline annotations for Nsight Systems (compile-time off; also gated at runtime by DYN_ENABLE_RUST_NVTX).
 # Overhead: feature off = zero; feature on, env off = ~1ns AtomicBool load; feature on, env on = ~50ns/annotation.
 nvtx = ["dep:cudarc"]
@@ -81,6 +82,7 @@ bincode = { version = "1" }
 console-subscriber = { version = "0.4", optional = true }
 educe = { version = "0.6.0" }
 figment = { version = "0.10.19", features = ["env", "json", "toml", "test"] }
+flume = { version = "0.12.0", optional = true }
 notify = { version = "6.1", default-features = false, features = ["macos_fsevent"] }
 libc = { version = "0.2" }
 local-ip-address = { version = "0.6.3" }
@@ -111,4 +113,8 @@ harness = false
 
 [[bench]]
 name = "tcp_codec_perf"
+harness = false
+
+[[bench]]
+name = "channel_mpsc_perf"
 harness = false

--- a/lib/runtime/benches/channel_mpsc_perf.rs
+++ b/lib/runtime/benches/channel_mpsc_perf.rs
@@ -1,0 +1,178 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Micro-benchmarks for the runtime mpsc channel wrapper.
+//!
+//! Default Tokio backend:
+//! `cargo bench -p dynamo-runtime --bench channel_mpsc_perf`
+//!
+//! Flume backend:
+//! `cargo bench -p dynamo-runtime --features flume-channels --bench channel_mpsc_perf`
+
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use dynamo_runtime::channels::mpsc;
+use std::time::{Duration, Instant};
+
+const MESSAGES_PER_ITER: u64 = 16 * 1024;
+const MPSC_MESSAGES_PER_PRODUCER: u64 = 4 * 1024;
+const WARM_UP_TIME: Duration = Duration::from_secs(10);
+const MEASUREMENT_TIME: Duration = Duration::from_secs(30);
+
+fn runtime() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .enable_all()
+        .build()
+        .expect("failed to build benchmark runtime")
+}
+
+async fn bounded_spsc(capacity: usize, messages: u64) {
+    let (tx, mut rx) = mpsc::channel::<u64>(capacity);
+
+    let receiver = tokio::spawn(async move {
+        let mut checksum = 0_u64;
+        for _ in 0..messages {
+            checksum = checksum.wrapping_add(rx.recv().await.expect("channel closed"));
+        }
+        checksum
+    });
+
+    for i in 0..messages {
+        tx.send(i).await.expect("receiver dropped");
+    }
+
+    black_box(receiver.await.expect("receiver task failed"));
+}
+
+async fn bounded_mpsc(capacity: usize, producers: u64, messages_per_producer: u64) {
+    let (tx, mut rx) = mpsc::channel::<u64>(capacity);
+    let total_messages = producers * messages_per_producer;
+
+    let receiver = tokio::spawn(async move {
+        let mut checksum = 0_u64;
+        for _ in 0..total_messages {
+            checksum = checksum.wrapping_add(rx.recv().await.expect("channel closed"));
+        }
+        checksum
+    });
+
+    let senders = (0..producers)
+        .map(|producer| {
+            let tx = tx.clone();
+            tokio::spawn(async move {
+                for i in 0..messages_per_producer {
+                    tx.send((producer << 32) | i)
+                        .await
+                        .expect("receiver dropped");
+                }
+            })
+        })
+        .collect::<Vec<_>>();
+    drop(tx);
+
+    for sender in senders {
+        sender.await.expect("sender task failed");
+    }
+
+    black_box(receiver.await.expect("receiver task failed"));
+}
+
+async fn unbounded_spsc(messages: u64) {
+    let (tx, mut rx) = mpsc::unbounded_channel::<u64>();
+
+    let receiver = tokio::spawn(async move {
+        let mut checksum = 0_u64;
+        for _ in 0..messages {
+            checksum = checksum.wrapping_add(rx.recv().await.expect("channel closed"));
+        }
+        checksum
+    });
+
+    for i in 0..messages {
+        tx.send(i).expect("receiver dropped");
+    }
+
+    black_box(receiver.await.expect("receiver task failed"));
+}
+
+fn bench_bounded_spsc(c: &mut Criterion) {
+    let rt = runtime();
+    let mut group = c.benchmark_group(format!("mpsc_bounded_spsc_{}", mpsc::backend_name()));
+    group.warm_up_time(WARM_UP_TIME);
+    group.measurement_time(MEASUREMENT_TIME);
+    group.throughput(Throughput::Elements(MESSAGES_PER_ITER));
+
+    for capacity in [1, 2, 4, 64, 128, 256, 1024, 2048, 4096] {
+        group.bench_with_input(
+            BenchmarkId::from_parameter(capacity),
+            &capacity,
+            |b, &capacity| {
+                b.to_async(&rt).iter_custom(|iters| async move {
+                    let start = Instant::now();
+                    for _ in 0..iters {
+                        bounded_spsc(capacity, MESSAGES_PER_ITER).await;
+                    }
+                    start.elapsed()
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_bounded_mpsc(c: &mut Criterion) {
+    let rt = runtime();
+    let producers = 4;
+    let total_messages = producers * MPSC_MESSAGES_PER_PRODUCER;
+    let mut group = c.benchmark_group(format!("mpsc_bounded_mpsc_{}", mpsc::backend_name()));
+    group.warm_up_time(WARM_UP_TIME);
+    group.measurement_time(MEASUREMENT_TIME);
+    group.throughput(Throughput::Elements(total_messages));
+
+    for capacity in [64, 128, 256, 1024, 2048, 4096] {
+        group.bench_with_input(
+            BenchmarkId::from_parameter(capacity),
+            &capacity,
+            |b, &capacity| {
+                b.to_async(&rt).iter_custom(|iters| async move {
+                    let start = Instant::now();
+                    for _ in 0..iters {
+                        bounded_mpsc(capacity, producers, MPSC_MESSAGES_PER_PRODUCER).await;
+                    }
+                    start.elapsed()
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_unbounded_spsc(c: &mut Criterion) {
+    let rt = runtime();
+    let mut group = c.benchmark_group(format!("mpsc_unbounded_spsc_{}", mpsc::backend_name()));
+    group.warm_up_time(WARM_UP_TIME);
+    group.measurement_time(MEASUREMENT_TIME);
+    group.throughput(Throughput::Elements(MESSAGES_PER_ITER));
+
+    group.bench_function("send_recv", |b| {
+        b.to_async(&rt).iter_custom(|iters| async move {
+            let start = Instant::now();
+            for _ in 0..iters {
+                unbounded_spsc(MESSAGES_PER_ITER).await;
+            }
+            start.elapsed()
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_bounded_spsc,
+    bench_bounded_mpsc,
+    bench_unbounded_spsc
+);
+criterion_main!(benches);

--- a/lib/runtime/src/channels.rs
+++ b/lib/runtime/src/channels.rs
@@ -1,0 +1,449 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Channel facades used by Dynamo internals.
+//!
+//! The default implementation is Tokio's channel types. Building
+//! `dynamo-runtime` with `--features flume-channels` swaps the facade to flume
+//! for call sites that import this module.
+
+pub mod mpsc {
+    #[cfg(feature = "flume-channels")]
+    mod imp {
+        use std::fmt;
+
+        pub fn backend_name() -> &'static str {
+            "flume"
+        }
+
+        pub mod error {
+            use std::fmt;
+
+            #[derive(Debug, Clone, PartialEq, Eq)]
+            pub struct SendError<T>(pub T);
+
+            impl<T> SendError<T> {
+                pub fn into_inner(self) -> T {
+                    self.0
+                }
+            }
+
+            impl<T> fmt::Display for SendError<T> {
+                fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    f.write_str("channel closed")
+                }
+            }
+
+            impl<T: fmt::Debug> std::error::Error for SendError<T> {}
+
+            #[derive(Debug, Clone, PartialEq, Eq)]
+            pub enum TrySendError<T> {
+                Full(T),
+                Closed(T),
+            }
+
+            impl<T> TrySendError<T> {
+                pub fn into_inner(self) -> T {
+                    match self {
+                        Self::Full(value) | Self::Closed(value) => value,
+                    }
+                }
+            }
+
+            impl<T> fmt::Display for TrySendError<T> {
+                fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    match self {
+                        Self::Full(_) => f.write_str("channel full"),
+                        Self::Closed(_) => f.write_str("channel closed"),
+                    }
+                }
+            }
+
+            impl<T: fmt::Debug> std::error::Error for TrySendError<T> {}
+
+            #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+            pub enum TryRecvError {
+                Empty,
+                Disconnected,
+            }
+
+            impl fmt::Display for TryRecvError {
+                fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    match self {
+                        Self::Empty => f.write_str("channel empty"),
+                        Self::Disconnected => f.write_str("channel closed"),
+                    }
+                }
+            }
+
+            impl std::error::Error for TryRecvError {}
+        }
+
+        impl<T> From<flume::SendError<T>> for error::SendError<T> {
+            fn from(value: flume::SendError<T>) -> Self {
+                Self(value.0)
+            }
+        }
+
+        impl<T> From<flume::TrySendError<T>> for error::TrySendError<T> {
+            fn from(value: flume::TrySendError<T>) -> Self {
+                match value {
+                    flume::TrySendError::Full(value) => Self::Full(value),
+                    flume::TrySendError::Disconnected(value) => Self::Closed(value),
+                }
+            }
+        }
+
+        impl From<flume::TryRecvError> for error::TryRecvError {
+            fn from(value: flume::TryRecvError) -> Self {
+                match value {
+                    flume::TryRecvError::Empty => Self::Empty,
+                    flume::TryRecvError::Disconnected => Self::Disconnected,
+                }
+            }
+        }
+
+        pub struct Sender<T> {
+            inner: flume::Sender<T>,
+        }
+
+        impl<T> Clone for Sender<T> {
+            fn clone(&self) -> Self {
+                Self {
+                    inner: self.inner.clone(),
+                }
+            }
+        }
+
+        impl<T> fmt::Debug for Sender<T> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.debug_struct("Sender").finish_non_exhaustive()
+            }
+        }
+
+        impl<T> Sender<T> {
+            pub async fn send(&self, value: T) -> Result<(), error::SendError<T>> {
+                self.inner.send_async(value).await.map_err(Into::into)
+            }
+
+            pub fn try_send(&self, value: T) -> Result<(), error::TrySendError<T>> {
+                self.inner.try_send(value).map_err(Into::into)
+            }
+
+            pub fn is_closed(&self) -> bool {
+                self.inner.is_disconnected()
+            }
+        }
+
+        pub struct Receiver<T> {
+            inner: flume::Receiver<T>,
+        }
+
+        impl<T> fmt::Debug for Receiver<T> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.debug_struct("Receiver").finish_non_exhaustive()
+            }
+        }
+
+        impl<T> Receiver<T> {
+            pub async fn recv(&mut self) -> Option<T> {
+                self.inner.recv_async().await.ok()
+            }
+
+            pub fn try_recv(&mut self) -> Result<T, error::TryRecvError> {
+                self.inner.try_recv().map_err(Into::into)
+            }
+        }
+
+        pub struct UnboundedSender<T> {
+            inner: flume::Sender<T>,
+        }
+
+        impl<T> Clone for UnboundedSender<T> {
+            fn clone(&self) -> Self {
+                Self {
+                    inner: self.inner.clone(),
+                }
+            }
+        }
+
+        impl<T> fmt::Debug for UnboundedSender<T> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.debug_struct("UnboundedSender").finish_non_exhaustive()
+            }
+        }
+
+        impl<T> UnboundedSender<T> {
+            pub fn send(&self, value: T) -> Result<(), error::SendError<T>> {
+                self.inner.send(value).map_err(Into::into)
+            }
+
+            pub fn is_closed(&self) -> bool {
+                self.inner.is_disconnected()
+            }
+        }
+
+        pub struct UnboundedReceiver<T> {
+            inner: flume::Receiver<T>,
+        }
+
+        impl<T> fmt::Debug for UnboundedReceiver<T> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.debug_struct("UnboundedReceiver").finish_non_exhaustive()
+            }
+        }
+
+        impl<T> UnboundedReceiver<T> {
+            pub async fn recv(&mut self) -> Option<T> {
+                self.inner.recv_async().await.ok()
+            }
+
+            pub fn try_recv(&mut self) -> Result<T, error::TryRecvError> {
+                self.inner.try_recv().map_err(Into::into)
+            }
+        }
+
+        pub fn channel<T>(buffer: usize) -> (Sender<T>, Receiver<T>) {
+            let (tx, rx) = flume::bounded(buffer);
+            (Sender { inner: tx }, Receiver { inner: rx })
+        }
+
+        pub fn unbounded_channel<T>() -> (UnboundedSender<T>, UnboundedReceiver<T>) {
+            let (tx, rx) = flume::unbounded();
+            (
+                UnboundedSender { inner: tx },
+                UnboundedReceiver { inner: rx },
+            )
+        }
+    }
+
+    #[cfg(not(feature = "flume-channels"))]
+    mod imp {
+        use std::fmt;
+
+        pub fn backend_name() -> &'static str {
+            "tokio"
+        }
+
+        pub mod error {
+            use std::fmt;
+
+            #[derive(Debug, Clone, PartialEq, Eq)]
+            pub struct SendError<T>(pub T);
+
+            impl<T> SendError<T> {
+                pub fn into_inner(self) -> T {
+                    self.0
+                }
+            }
+
+            impl<T> fmt::Display for SendError<T> {
+                fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    f.write_str("channel closed")
+                }
+            }
+
+            impl<T: fmt::Debug> std::error::Error for SendError<T> {}
+
+            #[derive(Debug, Clone, PartialEq, Eq)]
+            pub enum TrySendError<T> {
+                Full(T),
+                Closed(T),
+            }
+
+            impl<T> TrySendError<T> {
+                pub fn into_inner(self) -> T {
+                    match self {
+                        Self::Full(value) | Self::Closed(value) => value,
+                    }
+                }
+            }
+
+            impl<T> fmt::Display for TrySendError<T> {
+                fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    match self {
+                        Self::Full(_) => f.write_str("channel full"),
+                        Self::Closed(_) => f.write_str("channel closed"),
+                    }
+                }
+            }
+
+            impl<T: fmt::Debug> std::error::Error for TrySendError<T> {}
+
+            #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+            pub enum TryRecvError {
+                Empty,
+                Disconnected,
+            }
+
+            impl fmt::Display for TryRecvError {
+                fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    match self {
+                        Self::Empty => f.write_str("channel empty"),
+                        Self::Disconnected => f.write_str("channel closed"),
+                    }
+                }
+            }
+
+            impl std::error::Error for TryRecvError {}
+        }
+
+        impl<T> From<tokio::sync::mpsc::error::SendError<T>> for error::SendError<T> {
+            fn from(value: tokio::sync::mpsc::error::SendError<T>) -> Self {
+                Self(value.0)
+            }
+        }
+
+        impl<T> From<tokio::sync::mpsc::error::TrySendError<T>> for error::TrySendError<T> {
+            fn from(value: tokio::sync::mpsc::error::TrySendError<T>) -> Self {
+                match value {
+                    tokio::sync::mpsc::error::TrySendError::Full(value) => Self::Full(value),
+                    tokio::sync::mpsc::error::TrySendError::Closed(value) => Self::Closed(value),
+                }
+            }
+        }
+
+        impl From<tokio::sync::mpsc::error::TryRecvError> for error::TryRecvError {
+            fn from(value: tokio::sync::mpsc::error::TryRecvError) -> Self {
+                match value {
+                    tokio::sync::mpsc::error::TryRecvError::Empty => Self::Empty,
+                    tokio::sync::mpsc::error::TryRecvError::Disconnected => Self::Disconnected,
+                }
+            }
+        }
+
+        pub struct Sender<T> {
+            inner: tokio::sync::mpsc::Sender<T>,
+        }
+
+        impl<T> Clone for Sender<T> {
+            fn clone(&self) -> Self {
+                Self {
+                    inner: self.inner.clone(),
+                }
+            }
+        }
+
+        impl<T> fmt::Debug for Sender<T> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.debug_struct("Sender").finish_non_exhaustive()
+            }
+        }
+
+        impl<T> Sender<T> {
+            pub async fn send(&self, value: T) -> Result<(), error::SendError<T>> {
+                self.inner.send(value).await.map_err(Into::into)
+            }
+
+            pub fn try_send(&self, value: T) -> Result<(), error::TrySendError<T>> {
+                self.inner.try_send(value).map_err(Into::into)
+            }
+
+            pub fn is_closed(&self) -> bool {
+                self.inner.is_closed()
+            }
+        }
+
+        pub struct Receiver<T> {
+            inner: tokio::sync::mpsc::Receiver<T>,
+        }
+
+        impl<T> fmt::Debug for Receiver<T> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.debug_struct("Receiver").finish_non_exhaustive()
+            }
+        }
+
+        impl<T> Receiver<T> {
+            pub async fn recv(&mut self) -> Option<T> {
+                self.inner.recv().await
+            }
+
+            pub fn try_recv(&mut self) -> Result<T, error::TryRecvError> {
+                self.inner.try_recv().map_err(Into::into)
+            }
+        }
+
+        pub struct UnboundedSender<T> {
+            inner: tokio::sync::mpsc::UnboundedSender<T>,
+        }
+
+        impl<T> Clone for UnboundedSender<T> {
+            fn clone(&self) -> Self {
+                Self {
+                    inner: self.inner.clone(),
+                }
+            }
+        }
+
+        impl<T> fmt::Debug for UnboundedSender<T> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.debug_struct("UnboundedSender").finish_non_exhaustive()
+            }
+        }
+
+        impl<T> UnboundedSender<T> {
+            pub fn send(&self, value: T) -> Result<(), error::SendError<T>> {
+                self.inner.send(value).map_err(Into::into)
+            }
+
+            pub fn is_closed(&self) -> bool {
+                self.inner.is_closed()
+            }
+        }
+
+        pub struct UnboundedReceiver<T> {
+            inner: tokio::sync::mpsc::UnboundedReceiver<T>,
+        }
+
+        impl<T> fmt::Debug for UnboundedReceiver<T> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.debug_struct("UnboundedReceiver").finish_non_exhaustive()
+            }
+        }
+
+        impl<T> UnboundedReceiver<T> {
+            pub async fn recv(&mut self) -> Option<T> {
+                self.inner.recv().await
+            }
+
+            pub fn try_recv(&mut self) -> Result<T, error::TryRecvError> {
+                self.inner.try_recv().map_err(Into::into)
+            }
+        }
+
+        pub fn channel<T>(buffer: usize) -> (Sender<T>, Receiver<T>) {
+            let (tx, rx) = tokio::sync::mpsc::channel(buffer);
+            (Sender { inner: tx }, Receiver { inner: rx })
+        }
+
+        pub fn unbounded_channel<T>() -> (UnboundedSender<T>, UnboundedReceiver<T>) {
+            let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+            (
+                UnboundedSender { inner: tx },
+                UnboundedReceiver { inner: rx },
+            )
+        }
+    }
+
+    pub use imp::*;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::mpsc;
+
+    #[tokio::test]
+    async fn bounded_channel_round_trips() {
+        let (tx, mut rx) = mpsc::channel(1);
+        tx.send(7).await.unwrap();
+        assert_eq!(rx.recv().await, Some(7));
+    }
+
+    #[tokio::test]
+    async fn unbounded_channel_round_trips() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        tx.send(11).unwrap();
+        assert_eq!(rx.recv().await, Some(11));
+    }
+}

--- a/lib/runtime/src/lib.rs
+++ b/lib/runtime/src/lib.rs
@@ -20,6 +20,7 @@ use async_once_cell::OnceCell;
 pub mod config;
 pub use config::RuntimeConfig;
 
+pub mod channels;
 pub mod component;
 pub mod compute;
 pub mod discovery;

--- a/lib/runtime/src/pipeline/network.rs
+++ b/lib/runtime/src/pipeline/network.rs
@@ -15,6 +15,7 @@ pub mod manager;
 pub mod tcp;
 
 use crate::SystemHealth;
+use crate::channels::mpsc;
 use std::sync::{Arc, OnceLock};
 
 use anyhow::Result;
@@ -158,21 +159,24 @@ pub trait ResponseService {
 // was not an error, would indicate the RequestStreamReceiver is read
 // to receive data.
 pub struct StreamSender {
-    tx: tokio::sync::mpsc::Sender<TwoPartMessage>,
+    tx: mpsc::Sender<TwoPartMessage>,
     prologue: Option<ResponseStreamPrologue>,
 }
 
 impl StreamSender {
     pub async fn send(&self, data: Bytes) -> Result<()> {
-        Ok(self.tx.send(TwoPartMessage::from_data(data)).await?)
+        self.tx
+            .send(TwoPartMessage::from_data(data))
+            .await
+            .map_err(|e| anyhow::anyhow!(e.to_string()))
     }
 
     pub async fn send_control(&self, control: ControlMessage) -> Result<()> {
         let bytes = serde_json::to_vec(&control)?;
-        Ok(self
-            .tx
+        self.tx
             .send(TwoPartMessage::from_header(bytes.into()))
-            .await?)
+            .await
+            .map_err(|e| anyhow::anyhow!(e.to_string()))
     }
 
     #[allow(clippy::needless_update)]

--- a/lib/runtime/src/pipeline/network/tcp/client.rs
+++ b/lib/runtime/src/pipeline/network/tcp/client.rs
@@ -3,6 +3,7 @@
 
 use std::sync::Arc;
 
+use crate::channels::mpsc;
 use futures::{SinkExt, StreamExt};
 use tokio::io::{AsyncReadExt, ReadHalf, WriteHalf};
 use tokio::{
@@ -130,7 +131,7 @@ impl TcpClient {
             .map_err(|e| error!("failed to send handshake: {:?}", e))?;
 
         // set up the channel to send bytes to the transport layer
-        let (bytes_tx, bytes_rx) = tokio::sync::mpsc::channel(64);
+        let (bytes_tx, bytes_rx) = mpsc::channel(64);
 
         // forwards the bytes send from this stream to the transport layer; hold the alive_rx half of the oneshot channel
 
@@ -293,7 +294,7 @@ async fn handle_reader(
 
 async fn handle_writer(
     mut framed_writer: FramedWrite<tokio::io::WriteHalf<tokio::net::TcpStream>, TwoPartCodec>,
-    mut bytes_rx: tokio::sync::mpsc::Receiver<TwoPartMessage>,
+    mut bytes_rx: mpsc::Receiver<TwoPartMessage>,
     alive_rx: tokio::sync::oneshot::Receiver<()>,
     context: Arc<dyn AsyncEngineContext>,
 ) -> Result<FramedWrite<tokio::io::WriteHalf<tokio::net::TcpStream>, TwoPartCodec>> {
@@ -358,7 +359,7 @@ mod tests {
     use std::sync::Arc;
     use tokio::io::AsyncReadExt;
     use tokio::net::TcpStream;
-    use tokio::sync::{mpsc, oneshot};
+    use tokio::sync::oneshot;
     use tokio_util::codec::FramedRead;
 
     struct WriterHarness {

--- a/lib/runtime/src/transports/zmq.rs
+++ b/lib/runtime/src/transports/zmq.rs
@@ -16,6 +16,7 @@
 //! equivalent of a connection pool per upstream service at the cost of needing an extra internal
 //! routing step per service endpoint.
 
+use crate::channels::mpsc;
 use anyhow::{Context, Result, anyhow};
 use bytes::Bytes;
 use derive_getters::Dissolve;
@@ -23,10 +24,7 @@ use futures::{SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, sync::Arc};
 use tmq::{AsZmqSocket, Context as TmqContext, dealer, router};
-use tokio::{
-    sync::{Mutex, mpsc},
-    task::JoinHandle,
-};
+use tokio::{sync::Mutex, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
 
 pub type MultipartMessage = Vec<Vec<u8>>;
@@ -365,7 +363,7 @@ mod tests {
         let state = server.state.clone();
 
         let id = "test-request".to_string();
-        let (tx, mut rx) = tokio::sync::mpsc::channel(512);
+        let (tx, mut rx) = mpsc::channel::<Bytes>(512);
         state.lock().await.active_streams.insert(id.clone(), tx);
 
         // Create client


### PR DESCRIPTION
# Runtime MPSC Channel Benchmark Results

## Summary

- Added `dynamo_runtime::channels::mpsc`, a facade that uses Tokio channels by default and flume async channels with the `flume-channels` feature.
- Routed selected runtime transport channel paths through the facade so they can be built against either backend.
- Added the `channel_mpsc_perf` Criterion microbenchmark for bounded SPSC, bounded MPSC, and unbounded SPSC channel traffic.
- Recorded long-run Tokio and flume measurements with the original capacities plus 2x and 4x higher caps.

## Validation

```bash
cargo fmt --check
cargo check -p dynamo-runtime --benches
cargo check -p dynamo-runtime --features flume-channels --benches
cargo test -p dynamo-runtime channels
cargo test -p dynamo-runtime --features flume-channels channels
```

All validation commands passed.

## Benchmark Results

Date: 2026-05-01 UTC
Base commit: `563cd37d7b9904901f668833dc2ea704d38f9e35`

Commands:

```bash
cargo bench -p dynamo-runtime --bench channel_mpsc_perf -- --noplot
cargo bench -p dynamo-runtime --features flume-channels --bench channel_mpsc_perf -- --noplot
```

Long-run settings:

- Criterion warmup: 10 seconds per benchmark case
- Criterion measurement target: 30 seconds per benchmark case
- Bounded SPSC capacities: `1, 2, 4, 64, 128, 256, 1024, 2048, 4096`
- Bounded MPSC capacities: `64, 128, 256, 1024, 2048, 4096`

Raw logs:

- `benchmark-results/channel_mpsc_tokio_long.log`
- `benchmark-results/channel_mpsc_flume_long.log`
- Earlier short-run logs are kept in the same directory for comparison.

Criterion point estimates from the long run:

| Benchmark | Tokio time | Flume time | Flume speedup | Tokio throughput | Flume throughput |
| --- | ---: | ---: | ---: | ---: | ---: |
| Bounded SPSC, cap 1 | 335.12 ms | 197.73 ms | 1.69x | 48.890 Kelem/s | 82.860 Kelem/s |
| Bounded SPSC, cap 2 | 170.33 ms | 149.24 ms | 1.14x | 96.188 Kelem/s | 109.78 Kelem/s |
| Bounded SPSC, cap 4 | 85.007 ms | 169.76 ms | 0.50x | 192.74 Kelem/s | 96.512 Kelem/s |
| Bounded SPSC, cap 64 | 5.3372 ms | 9.2099 ms | 0.58x | 3.0698 Melem/s | 1.7789 Melem/s |
| Bounded SPSC, cap 128 | 1.7618 ms | 3.7887 ms | 0.47x | 9.2995 Melem/s | 4.3244 Melem/s |
| Bounded SPSC, cap 256 | 1.4689 ms | 2.4872 ms | 0.59x | 11.154 Melem/s | 6.5872 Melem/s |
| Bounded SPSC, cap 1024 | 1.4030 ms | 1.2269 ms | 1.14x | 11.678 Melem/s | 13.354 Melem/s |
| Bounded SPSC, cap 2048 | 1.4025 ms | 1.0167 ms | 1.38x | 11.682 Melem/s | 16.116 Melem/s |
| Bounded SPSC, cap 4096 | 1.3573 ms | 951.00 us | 1.43x | 12.071 Melem/s | 17.228 Melem/s |
| Bounded MPSC, cap 64 | 1.7388 ms | 1.1456 ms | 1.52x | 9.4228 Melem/s | 14.301 Melem/s |
| Bounded MPSC, cap 128 | 1.7310 ms | 1.0066 ms | 1.72x | 9.4651 Melem/s | 16.276 Melem/s |
| Bounded MPSC, cap 256 | 1.6653 ms | 1.0172 ms | 1.64x | 9.8384 Melem/s | 16.107 Melem/s |
| Bounded MPSC, cap 1024 | 1.8078 ms | 1.4042 ms | 1.29x | 9.0630 Melem/s | 11.668 Melem/s |
| Bounded MPSC, cap 2048 | 1.7146 ms | 1.4645 ms | 1.17x | 9.5558 Melem/s | 11.187 Melem/s |
| Bounded MPSC, cap 4096 | 1.8779 ms | 936.83 us | 2.00x | 8.7246 Melem/s | 17.489 Melem/s |
| Unbounded SPSC | 1.2724 ms | 776.21 us | 1.64x | 12.876 Melem/s | 21.108 Melem/s |

Long-run takeaway: flume wins every bounded MPSC case and unbounded SPSC. For bounded SPSC, flume wins at capacity `1`, `2`, and `1024+`, while Tokio wins at capacity `4` through `256`.
