### PR TITLE
test(revalidate): ci: Use shared model cache for GPU tests #8850

### DIFF
--- a/components/src/dynamo/common/__init__.py
+++ b/components/src/dynamo/common/__init__.py
@@ -25,3 +25,5 @@ except Exception:
         __version__ = "0.0.0+unknown"
 
 __all__ = ["__version__", "config_dump", "constants", "utils"]
+
+# revalidate 9dfc3353ecd 2026-05-01T20:35:04Z

--- a/lib/runtime/src/runtime.rs
+++ b/lib/runtime/src/runtime.rs
@@ -391,3 +391,5 @@ impl Drop for RuntimeType {
         }
     }
 }
+
+// revalidate 9dfc3353ecd 2026-05-01T20:35:04Z


### PR DESCRIPTION
Re-validating that PR #8850 by Dillon Cullinan did not regress, by re-running against a trivial placebo diff:

```
ci: Use shared model cache for GPU tests
```

Branch deleted on green; kept on failure for diagnosis.

Drafts are skipped by CodeRabbit per repo `.coderabbit.yaml`.