### PR TITLE
test: stabilize vLLM GPU-parallel CI scheduling

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,8 @@ _gpu_parallel_gpus_key: pytest.StashKey[list[dict]] = pytest.StashKey()
 _gpu_indices_key: pytest.StashKey[list[int] | None] = pytest.StashKey()
 _gpu_slots_key: pytest.StashKey[int | None] = pytest.StashKey()
 
+_GPU_PARALLEL_DOWNLOADS_READY_ENV = "DYNAMO_GPU_PARALLEL_DOWNLOADS_READY"
+
 
 def pytest_addoption(parser: pytest.Parser) -> None:
     """Add shared command-line options for all tests.
@@ -261,15 +263,51 @@ def pytest_runtestloop(session: pytest.Session) -> bool | None:
     if config.getoption("skip_service_restart", default=None):
         extra_args.append("--skip-service-restart")
 
-    rc = run_parallel(
-        test_ids=test_ids,
-        meta=meta,
-        max_vram_gib=vram_limit,
-        num_slots=num_slots,
-        gpu_indices=gpu_indices,
-        extra_pytest_args=extra_args or None,
-        stream=is_stream,
-    )
+    old_downloads_ready = os.environ.get(_GPU_PARALLEL_DOWNLOADS_READY_ENV)
+    old_hf_offline = os.environ.get("HF_HUB_OFFLINE")
+    downloads_ready = False
+    if models_dir is None:
+        selected_fixtures = {
+            fixture
+            for item in session.items
+            for fixture in getattr(item, "fixturenames", ())
+        }
+        needs_models = "predownload_models" in selected_fixtures
+        needs_tokenizers = "predownload_tokenizers" in selected_fixtures
+        if needs_models or needs_tokenizers:
+            models = getattr(config, "models_to_download", None)
+            models = sorted(models) if models else None
+            model_list = ", ".join(models) if models else "default test models"
+            with FileLock(_download_lock_path):
+                if needs_models:
+                    print(f"GPU parallel: pre-downloading models: {model_list}")
+                    download_models(model_list=models)
+                else:
+                    print(f"GPU parallel: pre-downloading tokenizers: {model_list}")
+                    download_models(model_list=models, ignore_weights=True)
+            _enable_offline_with_mistral_patch()
+            os.environ[_GPU_PARALLEL_DOWNLOADS_READY_ENV] = "1"
+            downloads_ready = True
+
+    try:
+        rc = run_parallel(
+            test_ids=test_ids,
+            meta=meta,
+            max_vram_gib=vram_limit,
+            num_slots=num_slots,
+            gpu_indices=gpu_indices,
+            extra_pytest_args=extra_args or None,
+            stream=is_stream,
+        )
+    finally:
+        if downloads_ready:
+            _disable_offline_with_mistral_patch()
+            if old_hf_offline is not None:
+                os.environ["HF_HUB_OFFLINE"] = old_hf_offline
+            if old_downloads_ready is None:
+                os.environ.pop(_GPU_PARALLEL_DOWNLOADS_READY_ENV, None)
+            else:
+                os.environ[_GPU_PARALLEL_DOWNLOADS_READY_ENV] = old_downloads_ready
 
     if rc != 0:
         session.testsfailed = 1
@@ -402,13 +440,18 @@ def predownload_models(pytestconfig, _models_dir_env):
     if pytestconfig.getoption("--models-dir"):
         yield
         return
+    if os.environ.get(_GPU_PARALLEL_DOWNLOADS_READY_ENV) == "1":
+        yield
+        return
+
     models = getattr(pytestconfig, "models_to_download", None)
+    models = sorted(models) if models else None
     with FileLock(_download_lock_path):
         if models:
             logging.info(
                 f"Downloading {len(models)} models needed for collected tests\nModels: {models}"
             )
-            download_models(model_list=list(models))
+            download_models(model_list=models)
         else:
             download_models()
 
@@ -432,13 +475,18 @@ def predownload_tokenizers(pytestconfig, _models_dir_env):
     if pytestconfig.getoption("--models-dir"):
         yield
         return
+    if os.environ.get(_GPU_PARALLEL_DOWNLOADS_READY_ENV) == "1":
+        yield
+        return
+
     models = getattr(pytestconfig, "models_to_download", None)
+    models = sorted(models) if models else None
     with FileLock(_download_lock_path):
         if models:
             logging.info(
                 f"Downloading tokenizers for {len(models)} models needed for collected tests\nModels: {models}"
             )
-            download_models(model_list=list(models), ignore_weights=True)
+            download_models(model_list=models, ignore_weights=True)
         else:
             download_models(ignore_weights=True)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -266,28 +266,19 @@ def pytest_runtestloop(session: pytest.Session) -> bool | None:
     old_downloads_ready = os.environ.get(_GPU_PARALLEL_DOWNLOADS_READY_ENV)
     old_hf_offline = os.environ.get("HF_HUB_OFFLINE")
     downloads_ready = False
-    if models_dir is None:
-        selected_fixtures = {
-            fixture
-            for item in session.items
-            for fixture in getattr(item, "fixturenames", ())
-        }
-        needs_models = "predownload_models" in selected_fixtures
-        needs_tokenizers = "predownload_tokenizers" in selected_fixtures
-        if needs_models or needs_tokenizers:
-            models = getattr(config, "models_to_download", None)
-            models = sorted(models) if models else None
-            model_list = ", ".join(models) if models else "default test models"
-            with FileLock(_download_lock_path):
-                if needs_models:
-                    print(f"GPU parallel: pre-downloading models: {model_list}")
-                    download_models(model_list=models)
-                else:
-                    print(f"GPU parallel: pre-downloading tokenizers: {model_list}")
-                    download_models(model_list=models, ignore_weights=True)
-            _enable_offline_with_mistral_patch()
-            os.environ[_GPU_PARALLEL_DOWNLOADS_READY_ENV] = "1"
-            downloads_ready = True
+    if models_dir is None and any(
+        "predownload_models" in getattr(item, "fixturenames", ())
+        for item in session.items
+    ):
+        models = getattr(config, "models_to_download", None)
+        models = sorted(models) if models else None
+        model_list = ", ".join(models) if models else "default test models"
+        with FileLock(_download_lock_path):
+            print(f"GPU parallel: pre-downloading models: {model_list}")
+            download_models(model_list=models)
+        _enable_offline_with_mistral_patch()
+        os.environ[_GPU_PARALLEL_DOWNLOADS_READY_ENV] = "1"
+        downloads_ready = True
 
     try:
         rc = run_parallel(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -271,11 +271,10 @@ def pytest_runtestloop(session: pytest.Session) -> bool | None:
         for item in session.items
     ):
         models = getattr(config, "models_to_download", None)
-        model_list = list(models) if models else None
-        model_names = ", ".join(model_list) if model_list else "default test models"
+        model_names = ", ".join(models) if models else "default test models"
         with FileLock(_download_lock_path):
             print(f"GPU parallel: pre-downloading models: {model_names}")
-            download_models(model_list=model_list)
+            download_models(model_list=list(models) if models else None)
         _enable_offline_with_mistral_patch()
         os.environ[_GPU_PARALLEL_DOWNLOADS_READY_ENV] = "1"
         downloads_ready = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -271,11 +271,11 @@ def pytest_runtestloop(session: pytest.Session) -> bool | None:
         for item in session.items
     ):
         models = getattr(config, "models_to_download", None)
-        models = sorted(models) if models else None
-        model_list = ", ".join(models) if models else "default test models"
+        model_list = list(models) if models else None
+        model_names = ", ".join(model_list) if model_list else "default test models"
         with FileLock(_download_lock_path):
-            print(f"GPU parallel: pre-downloading models: {model_list}")
-            download_models(model_list=models)
+            print(f"GPU parallel: pre-downloading models: {model_names}")
+            download_models(model_list=model_list)
         _enable_offline_with_mistral_patch()
         os.environ[_GPU_PARALLEL_DOWNLOADS_READY_ENV] = "1"
         downloads_ready = True
@@ -436,13 +436,12 @@ def predownload_models(pytestconfig, _models_dir_env):
         return
 
     models = getattr(pytestconfig, "models_to_download", None)
-    models = sorted(models) if models else None
     with FileLock(_download_lock_path):
         if models:
             logging.info(
                 f"Downloading {len(models)} models needed for collected tests\nModels: {models}"
             )
-            download_models(model_list=models)
+            download_models(model_list=list(models))
         else:
             download_models()
 
@@ -471,13 +470,12 @@ def predownload_tokenizers(pytestconfig, _models_dir_env):
         return
 
     models = getattr(pytestconfig, "models_to_download", None)
-    models = sorted(models) if models else None
     with FileLock(_download_lock_path):
         if models:
             logging.info(
                 f"Downloading tokenizers for {len(models)} models needed for collected tests\nModels: {models}"
             )
-            download_models(model_list=models, ignore_weights=True)
+            download_models(model_list=list(models), ignore_weights=True)
         else:
             download_models(ignore_weights=True)
 

--- a/tests/frontend/test_vllm.py
+++ b/tests/frontend/test_vllm.py
@@ -235,9 +235,9 @@ def _validate_chat_response(response: requests.Response) -> Dict[str, Any]:
     return response_json
 
 
-# Measured using: tests/utils/profile_pytest.py tests/frontend/test_vllm.py::test_reasoning_effort
-@pytest.mark.profiled_vram_gib(20.4)  # actual profiled peak
 # TODO: profile with --kv-bytes once pre-existing 500 panic is fixed (JoinError::Panic "Cannot drop a runtime in a context where blocking is not allowed")
+# TODO: re-enable GPU-parallel scheduling with profiled_vram_gib(20.4)
+# once this has a bounded --kv-bytes profile.
 @pytest.mark.timeout(300)  # 3x observed ~70s wall time, rounded up
 @pytest.mark.post_merge
 def test_reasoning_effort(
@@ -304,9 +304,9 @@ def test_reasoning_effort(
         )
 
 
-# Measured using: tests/utils/profile_pytest.py tests/frontend/test_vllm.py::test_tool_calling
-@pytest.mark.profiled_vram_gib(20.4)  # actual profiled peak
 # TODO: profile with --kv-bytes once pre-existing 500 panic is fixed (JoinError::Panic "Cannot drop a runtime in a context where blocking is not allowed")
+# TODO: re-enable GPU-parallel scheduling with profiled_vram_gib(20.4)
+# once this has a bounded --kv-bytes profile.
 @pytest.mark.timeout(113)  # 3x observed 37.4s wall time
 @pytest.mark.post_merge
 def test_tool_calling(
@@ -349,9 +349,9 @@ def test_tool_calling(
     ), "Expected get_current_weather tool to be called"
 
 
-# Measured using: tests/utils/profile_pytest.py tests/frontend/test_vllm.py::test_tool_calling_second_round
-@pytest.mark.profiled_vram_gib(20.4)  # actual profiled peak
 # TODO: profile with --kv-bytes once pre-existing 500 panic is fixed (JoinError::Panic "Cannot drop a runtime in a context where blocking is not allowed")
+# TODO: re-enable GPU-parallel scheduling with profiled_vram_gib(20.4)
+# once this has a bounded --kv-bytes profile.
 @pytest.mark.timeout(115)  # 3x observed 38.1s wall time
 @pytest.mark.nightly
 def test_tool_calling_second_round(
@@ -416,9 +416,9 @@ def test_tool_calling_second_round(
     ), "Expected response to include temperature information from tool call result (20°C)"
 
 
-# Measured using: tests/utils/profile_pytest.py tests/frontend/test_vllm.py::test_reasoning
-@pytest.mark.profiled_vram_gib(20.4)  # actual profiled peak
 # TODO: profile with --kv-bytes once pre-existing 500 panic is fixed (JoinError::Panic "Cannot drop a runtime in a context where blocking is not allowed")
+# TODO: re-enable GPU-parallel scheduling with profiled_vram_gib(20.4)
+# once this has a bounded --kv-bytes profile.
 @pytest.mark.timeout(131)  # 3x observed 43.4s wall time
 @pytest.mark.nightly
 def test_reasoning(request, start_services: ServicePorts, predownload_models) -> None:

--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -25,8 +25,9 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
         topologies={
             "agg": TopologyConfig(
                 marks=[pytest.mark.post_merge],
+                # TODO: re-enable GPU-parallel scheduling with
+                # profiled_vram_gib=9.6 once this has a bounded --kv-bytes profile.
                 timeout_s=220,
-                profiled_vram_gib=9.6,
             ),
             "e_pd": TopologyConfig(
                 marks=[pytest.mark.post_merge],
@@ -113,8 +114,9 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
         topologies={
             "agg": TopologyConfig(
                 marks=[pytest.mark.post_merge],
+                # TODO: re-enable GPU-parallel scheduling with
+                # profiled_vram_gib=12.0 once this has a bounded --kv-bytes profile.
                 timeout_s=300,
-                profiled_vram_gib=12.0,
             ),
         },
         request_payloads=[make_image_payload(["green"])],


### PR DESCRIPTION
## Summary
- keep currently unbounded vLLM tests in the sequential GPU bucket by removing `profiled_vram_gib` where a deterministic `requested_vllm_kv_cache_bytes` cap is not available
- preserve measured VRAM values in comments/TODOs so the tests can be re-profiled without starting from scratch
- predownload selected models once in the GPU-parallel parent process before launching per-test pytest subprocesses
- have child `predownload_models` / `predownload_tokenizers` fixtures skip only when the parent model predownload ran; tokenizer-only tests keep their existing behavior

## Why
GPU-parallel runs each selected test in its own pytest subprocess. Recent logs showed router tests timing out in setup while waiting on `/tmp/pytest_model_download.lock`, because multiple child processes were entering `predownload_models` at the same time.

This change warms the selected model cache once before scheduling child processes, then signals those children that the model download fixture has already been handled. It avoids intra-run lock contention without expanding the scope to tokenizer-only mocker/frontend tests.

The sequential marker cleanup is intentionally conservative: tests without deterministic KV-cache caps, or tests blocked by the pre-existing frontend 500 panic, stay sequential for now.

## Validation
- `git diff --check`
- `python3 -m py_compile tests/conftest.py`
- `pre-commit run --files tests/conftest.py` in the vLLM runtime container, with `RUFF_CACHE_DIR=/tmp/ruff-cache`
- synthetic GPU-parallel smoke in `dynamoci.azurecr.io/ai-dynamo/dynamo:bb43fadaed743f4efa99c1431059eefbefe93b2b-vllm-runtime-cuda12-amd64`, after installing `container/deps/requirements.test.txt`; verified the parent calls `download_models(..., ignore_weights=False)` once and the child pytest subprocess sees the ready flag plus offline mode

## Caveat
This coordinates model predownload inside one GPU-parallel pytest invocation. It does not protect against unrelated jobs or processes writing to the same shared Hugging Face cache outside this run.