### PR TITLE
test(parsers): Top-N models to have extra CASE.6+ coverage (case3)

### DIFF
--- a/lib/llm/tests/tool_choice.rs
+++ b/lib/llm/tests/tool_choice.rs
@@ -871,3 +871,371 @@ async fn test_deepseek_v4_tool_choice_named_wrong_tool_filtered() {
         );
     }
 }
+
+// --- glm47 × tool_choice variants ---
+
+const GLM47_GET_WEATHER: &str =
+    "<tool_call>get_weather<arg_key>location</arg_key><arg_value>Paris</arg_value></tool_call>";
+const GLM47_SEARCH: &str =
+    "<tool_call>search<arg_key>query</arg_key><arg_value>Paris weather</arg_value></tool_call>";
+
+/// `CASE.11` — glm47 + tool_choice=auto. Parser path detects the call and
+/// emits it.
+#[tokio::test]
+async fn test_glm47_tool_choice_auto() {
+    let responses = apply_jail_with_parser_and_choice(GLM47_GET_WEATHER, "glm47", None).await;
+    let calls = collect_tool_calls(&responses);
+    assert_eq!(
+        calls.len(),
+        1,
+        "auto + parser path must emit the parsed call; got {:?}",
+        calls
+    );
+    assert_eq!(calls[0].0, "get_weather");
+    let args: serde_json::Value = serde_json::from_str(&calls[0].1).unwrap();
+    assert_eq!(args["location"], "Paris");
+}
+
+/// `CASE.11` — glm47 + tool_choice=required. Same parser-vs-immediate
+/// conflict as the kimi_k2 / deepseek_v4 counterparts. Pin current behavior.
+///
+/// TODO(CASE.11) — required + parser path is ill-defined; reconciled by
+/// the cross-parser tool_choice parametrisation work-item. Flip when fixed.
+#[tokio::test]
+async fn test_glm47_tool_choice_required_pins_current_behavior() {
+    let responses = apply_jail_with_parser_and_choice(
+        GLM47_GET_WEATHER,
+        "glm47",
+        Some(ChatCompletionToolChoiceOption::Required),
+    )
+    .await;
+    let calls = collect_tool_calls(&responses);
+    assert!(
+        calls.len() <= 1,
+        "required + parser path should produce at most one call until the \
+         immediate-vs-parser conflict is resolved; got {:?}",
+        calls
+    );
+}
+
+/// `CASE.11` — glm47 + tool_choice=named with the **correct** tool name.
+#[tokio::test]
+async fn test_glm47_tool_choice_named_correct_tool_passes() {
+    let responses =
+        apply_jail_with_parser_and_choice(GLM47_GET_WEATHER, "glm47", named_choice("get_weather"))
+            .await;
+    let calls = collect_tool_calls(&responses);
+    assert_eq!(
+        calls.len(),
+        1,
+        "correct named tool must pass; got {:?}",
+        calls
+    );
+    assert_eq!(calls[0].0, "get_weather");
+}
+
+/// `CASE.11` — glm47 + tool_choice=named with the **wrong** tool name.
+#[tokio::test]
+async fn test_glm47_tool_choice_named_wrong_tool_filtered() {
+    let responses =
+        apply_jail_with_parser_and_choice(GLM47_SEARCH, "glm47", named_choice("get_weather")).await;
+    let calls = collect_tool_calls(&responses);
+    for (name, _) in &calls {
+        assert_ne!(
+            name, "search",
+            "wrong tool must be filtered by named_tool_filter; got {:?}",
+            calls
+        );
+    }
+}
+
+// --- minimax_m2 × tool_choice variants ---
+
+const MINIMAX_M2_GET_WEATHER: &str = "<minimax:tool_call><invoke name=\"get_weather\"><parameter name=\"location\">Paris</parameter></invoke></minimax:tool_call>";
+const MINIMAX_M2_SEARCH: &str = "<minimax:tool_call><invoke name=\"search\"><parameter name=\"query\">Paris weather</parameter></invoke></minimax:tool_call>";
+
+#[tokio::test]
+async fn test_minimax_m2_tool_choice_auto() {
+    let responses =
+        apply_jail_with_parser_and_choice(MINIMAX_M2_GET_WEATHER, "minimax_m2", None).await;
+    let calls = collect_tool_calls(&responses);
+    assert_eq!(
+        calls.len(),
+        1,
+        "auto + parser path must emit the parsed call; got {:?}",
+        calls
+    );
+    assert_eq!(calls[0].0, "get_weather");
+    let args: serde_json::Value = serde_json::from_str(&calls[0].1).unwrap();
+    assert_eq!(args["location"], "Paris");
+}
+
+/// TODO(CASE.11) — see kimi_k2 counterpart. Flip when cross-parser
+/// tool_choice parametrisation work-item reconciles paths.
+#[tokio::test]
+async fn test_minimax_m2_tool_choice_required_pins_current_behavior() {
+    let responses = apply_jail_with_parser_and_choice(
+        MINIMAX_M2_GET_WEATHER,
+        "minimax_m2",
+        Some(ChatCompletionToolChoiceOption::Required),
+    )
+    .await;
+    let calls = collect_tool_calls(&responses);
+    assert!(
+        calls.len() <= 1,
+        "required + parser path should produce at most one call; got {:?}",
+        calls
+    );
+}
+
+#[tokio::test]
+async fn test_minimax_m2_tool_choice_named_correct_tool_passes() {
+    let responses = apply_jail_with_parser_and_choice(
+        MINIMAX_M2_GET_WEATHER,
+        "minimax_m2",
+        named_choice("get_weather"),
+    )
+    .await;
+    let calls = collect_tool_calls(&responses);
+    assert_eq!(
+        calls.len(),
+        1,
+        "correct named tool must pass; got {:?}",
+        calls
+    );
+    assert_eq!(calls[0].0, "get_weather");
+}
+
+#[tokio::test]
+async fn test_minimax_m2_tool_choice_named_wrong_tool_filtered() {
+    let responses = apply_jail_with_parser_and_choice(
+        MINIMAX_M2_SEARCH,
+        "minimax_m2",
+        named_choice("get_weather"),
+    )
+    .await;
+    let calls = collect_tool_calls(&responses);
+    for (name, _) in &calls {
+        assert_ne!(
+            name, "search",
+            "wrong tool must be filtered; got {:?}",
+            calls
+        );
+    }
+}
+
+// --- qwen3_coder × tool_choice variants ---
+
+const QWEN3_GET_WEATHER: &str = "<tool_call>\n<function=get_weather>\n<parameter=location>\nParis\n</parameter>\n</function>\n</tool_call>";
+const QWEN3_SEARCH: &str = "<tool_call>\n<function=search>\n<parameter=query>\nParis weather\n</parameter>\n</function>\n</tool_call>";
+
+#[tokio::test]
+async fn test_qwen3_coder_tool_choice_auto() {
+    let responses = apply_jail_with_parser_and_choice(QWEN3_GET_WEATHER, "qwen3_coder", None).await;
+    let calls = collect_tool_calls(&responses);
+    assert_eq!(
+        calls.len(),
+        1,
+        "auto + parser path must emit the parsed call; got {:?}",
+        calls
+    );
+    assert_eq!(calls[0].0, "get_weather");
+    let args: serde_json::Value = serde_json::from_str(&calls[0].1).unwrap();
+    assert_eq!(args["location"], "Paris");
+}
+
+/// TODO(CASE.11) — see kimi_k2 counterpart.
+#[tokio::test]
+async fn test_qwen3_coder_tool_choice_required_pins_current_behavior() {
+    let responses = apply_jail_with_parser_and_choice(
+        QWEN3_GET_WEATHER,
+        "qwen3_coder",
+        Some(ChatCompletionToolChoiceOption::Required),
+    )
+    .await;
+    let calls = collect_tool_calls(&responses);
+    assert!(
+        calls.len() <= 1,
+        "required + parser path should produce at most one call; got {:?}",
+        calls
+    );
+}
+
+#[tokio::test]
+async fn test_qwen3_coder_tool_choice_named_correct_tool_passes() {
+    let responses = apply_jail_with_parser_and_choice(
+        QWEN3_GET_WEATHER,
+        "qwen3_coder",
+        named_choice("get_weather"),
+    )
+    .await;
+    let calls = collect_tool_calls(&responses);
+    assert_eq!(
+        calls.len(),
+        1,
+        "correct named tool must pass; got {:?}",
+        calls
+    );
+    assert_eq!(calls[0].0, "get_weather");
+}
+
+#[tokio::test]
+async fn test_qwen3_coder_tool_choice_named_wrong_tool_filtered() {
+    let responses =
+        apply_jail_with_parser_and_choice(QWEN3_SEARCH, "qwen3_coder", named_choice("get_weather"))
+            .await;
+    let calls = collect_tool_calls(&responses);
+    for (name, _) in &calls {
+        assert_ne!(
+            name, "search",
+            "wrong tool must be filtered; got {:?}",
+            calls
+        );
+    }
+}
+
+// --- nemotron_deci × tool_choice variants ---
+
+const NEMOTRON_DECI_GET_WEATHER: &str =
+    "<TOOLCALL>[{\"name\":\"get_weather\",\"arguments\":{\"location\":\"Paris\"}}]</TOOLCALL>";
+const NEMOTRON_DECI_SEARCH: &str =
+    "<TOOLCALL>[{\"name\":\"search\",\"arguments\":{\"query\":\"Paris weather\"}}]</TOOLCALL>";
+
+#[tokio::test]
+async fn test_nemotron_deci_tool_choice_auto() {
+    let responses =
+        apply_jail_with_parser_and_choice(NEMOTRON_DECI_GET_WEATHER, "nemotron_deci", None).await;
+    let calls = collect_tool_calls(&responses);
+    assert_eq!(
+        calls.len(),
+        1,
+        "auto + parser path must emit the parsed call; got {:?}",
+        calls
+    );
+    assert_eq!(calls[0].0, "get_weather");
+    let args: serde_json::Value = serde_json::from_str(&calls[0].1).unwrap();
+    assert_eq!(args["location"], "Paris");
+}
+
+/// TODO(CASE.11) — see kimi_k2 counterpart.
+#[tokio::test]
+async fn test_nemotron_deci_tool_choice_required_pins_current_behavior() {
+    let responses = apply_jail_with_parser_and_choice(
+        NEMOTRON_DECI_GET_WEATHER,
+        "nemotron_deci",
+        Some(ChatCompletionToolChoiceOption::Required),
+    )
+    .await;
+    let calls = collect_tool_calls(&responses);
+    assert!(
+        calls.len() <= 1,
+        "required + parser path should produce at most one call; got {:?}",
+        calls
+    );
+}
+
+#[tokio::test]
+async fn test_nemotron_deci_tool_choice_named_correct_tool_passes() {
+    let responses = apply_jail_with_parser_and_choice(
+        NEMOTRON_DECI_GET_WEATHER,
+        "nemotron_deci",
+        named_choice("get_weather"),
+    )
+    .await;
+    let calls = collect_tool_calls(&responses);
+    assert_eq!(
+        calls.len(),
+        1,
+        "correct named tool must pass; got {:?}",
+        calls
+    );
+    assert_eq!(calls[0].0, "get_weather");
+}
+
+#[tokio::test]
+async fn test_nemotron_deci_tool_choice_named_wrong_tool_filtered() {
+    let responses = apply_jail_with_parser_and_choice(
+        NEMOTRON_DECI_SEARCH,
+        "nemotron_deci",
+        named_choice("get_weather"),
+    )
+    .await;
+    let calls = collect_tool_calls(&responses);
+    for (name, _) in &calls {
+        assert_ne!(
+            name, "search",
+            "wrong tool must be filtered; got {:?}",
+            calls
+        );
+    }
+}
+
+// --- harmony (gpt-oss) × tool_choice variants ---
+
+const HARMONY_GET_WEATHER: &str = "<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{\"location\":\"Paris\"}<|call|>";
+const HARMONY_SEARCH: &str = "<|channel|>commentary to=functions.search <|constrain|>json<|message|>{\"query\":\"Paris weather\"}<|call|>";
+
+#[tokio::test]
+async fn test_harmony_tool_choice_auto() {
+    let responses = apply_jail_with_parser_and_choice(HARMONY_GET_WEATHER, "harmony", None).await;
+    let calls = collect_tool_calls(&responses);
+    assert_eq!(
+        calls.len(),
+        1,
+        "auto + parser path must emit the parsed call; got {:?}",
+        calls
+    );
+    assert_eq!(calls[0].0, "get_weather");
+    let args: serde_json::Value = serde_json::from_str(&calls[0].1).unwrap();
+    assert_eq!(args["location"], "Paris");
+}
+
+/// TODO(CASE.11) — see kimi_k2 counterpart.
+#[tokio::test]
+async fn test_harmony_tool_choice_required_pins_current_behavior() {
+    let responses = apply_jail_with_parser_and_choice(
+        HARMONY_GET_WEATHER,
+        "harmony",
+        Some(ChatCompletionToolChoiceOption::Required),
+    )
+    .await;
+    let calls = collect_tool_calls(&responses);
+    assert!(
+        calls.len() <= 1,
+        "required + parser path should produce at most one call; got {:?}",
+        calls
+    );
+}
+
+#[tokio::test]
+async fn test_harmony_tool_choice_named_correct_tool_passes() {
+    let responses = apply_jail_with_parser_and_choice(
+        HARMONY_GET_WEATHER,
+        "harmony",
+        named_choice("get_weather"),
+    )
+    .await;
+    let calls = collect_tool_calls(&responses);
+    assert_eq!(
+        calls.len(),
+        1,
+        "correct named tool must pass; got {:?}",
+        calls
+    );
+    assert_eq!(calls[0].0, "get_weather");
+}
+
+#[tokio::test]
+async fn test_harmony_tool_choice_named_wrong_tool_filtered() {
+    let responses =
+        apply_jail_with_parser_and_choice(HARMONY_SEARCH, "harmony", named_choice("get_weather"))
+            .await;
+    let calls = collect_tool_calls(&responses);
+    for (name, _) in &calls {
+        assert_ne!(
+            name, "search",
+            "wrong tool must be filtered; got {:?}",
+            calls
+        );
+    }
+}

--- a/lib/parsers/src/tool_calling/harmony/harmony_parser.rs
+++ b/lib/parsers/src/tool_calling/harmony/harmony_parser.rs
@@ -473,6 +473,89 @@ mod tests {
         assert_eq!(args["location"], "San Francisco, CA");
         assert_eq!(args["unit"], "celsius");
     }
+
+    /// Parser-level invariant: the harmony parser is byte-stable — it
+    /// doesn't see `finish_reason` and produces the same output regardless
+    /// of the upstream stream-end reason. Real CASE.12 coverage (stop /
+    /// tool_calls / length mapping) lives in
+    /// `lib/llm/tests/test_streaming_tool_parsers.rs` and belongs in the
+    /// cross-parser finish_reason mapping work-item (tracked separately).
+    #[tokio::test]
+    async fn test_harmony_parser_output_independent_of_upstream_finish() {
+        let text = r#"<|channel|>commentary to=functions.get_current_weather <|constrain|>json<|message|>{"location":"NYC"}"#;
+        let (tool_calls, _) = parse_tool_calls_harmony_complete(text, &Default::default(), None)
+            .await
+            .unwrap();
+        assert_eq!(tool_calls.len(), 1);
+    }
+
+    /// CASE.6 — empty args. A no-arg harmony call (`{}`) must still surface
+    /// the function name.
+    #[tokio::test] // CASE.6 — gpt-oss
+    async fn test_parse_harmony_empty_args() {
+        let text =
+            r#"<|channel|>commentary to=functions.current_time <|constrain|>json<|message|>{}"#;
+        let (tool_calls, _) = parse_tool_calls_harmony_complete(text, &Default::default(), None)
+            .await
+            .unwrap();
+        assert_eq!(tool_calls.len(), 1);
+        let (name, args) = extract_name_and_args(tool_calls[0].clone());
+        assert_eq!(name, "current_time");
+        assert_eq!(args, serde_json::json!({}));
+    }
+
+    /// CASE.14 — empty / null content variants. Truly-empty (zero bytes)
+    /// and whitespace-only inputs must yield no tool calls. Unlike the
+    /// XML/JSON parsers (which trim whitespace down to `Some("")`), the
+    /// harmony parser passes the input verbatim through to normal_text —
+    /// pin that distinction here.
+    #[tokio::test] // CASE.14 — gpt-oss
+    async fn test_parse_harmony_empty_and_whitespace_inputs() {
+        for input in &["", " ", "\n", "\t\n  \t"] {
+            let (tool_calls, normal) =
+                parse_tool_calls_harmony_complete(input, &Default::default(), None)
+                    .await
+                    .unwrap();
+            assert!(
+                tool_calls.is_empty(),
+                "Empty/whitespace input must yield no calls (input={:?})",
+                input
+            );
+            assert_eq!(
+                normal.as_deref(),
+                Some(*input),
+                "harmony passes empty/whitespace input verbatim to normal_text (input={:?})",
+                input
+            );
+        }
+    }
+
+    /// CASE.15 — duplicate calls (same function name twice). Two
+    /// back-to-back commentary blocks for the same function. Pin
+    /// parser-level behavior — both calls returned with distinct ids
+    /// and distinct args.
+    #[tokio::test] // CASE.15 — gpt-oss
+    async fn test_parse_harmony_duplicate_calls_same_name() {
+        let text = r#"<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"city":"NYC"}<|call|><|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"city":"LA"}<|call|>"#;
+        let (tool_calls, _) = parse_tool_calls_harmony_complete(text, &Default::default(), None)
+            .await
+            .unwrap();
+        assert_eq!(
+            tool_calls.len(),
+            2,
+            "Both duplicate-name calls must be returned"
+        );
+        assert_ne!(
+            tool_calls[0].id, tool_calls[1].id,
+            "Duplicate calls must have distinct ids"
+        );
+        let (name0, args0) = extract_name_and_args(tool_calls[0].clone());
+        let (name1, args1) = extract_name_and_args(tool_calls[1].clone());
+        assert_eq!(name0, "get_weather");
+        assert_eq!(name1, "get_weather");
+        assert_eq!(args0["city"], "NYC");
+        assert_eq!(args1["city"], "LA");
+    }
 }
 
 #[cfg(test)]

--- a/lib/parsers/src/tool_calling/json/mod.rs
+++ b/lib/parsers/src/tool_calling/json/mod.rs
@@ -214,4 +214,82 @@ mod tests {
         let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
         assert_eq!(args["city"], "NYC");
     }
+
+    fn nemotron_deci_config() -> JsonParserConfig {
+        JsonParserConfig {
+            tool_call_start_tokens: vec!["<TOOLCALL>".to_string()],
+            tool_call_end_tokens: vec!["</TOOLCALL>".to_string()],
+            ..Default::default()
+        }
+    }
+
+    /// Parser-level invariant: the json-family parser is byte-stable — it
+    /// doesn't see `finish_reason` and produces the same output regardless
+    /// of the upstream stream-end reason. Real CASE.12 coverage (stop /
+    /// tool_calls / length mapping) lives in
+    /// `lib/llm/tests/test_streaming_tool_parsers.rs` and belongs in the
+    /// cross-parser finish_reason mapping work-item (tracked separately).
+    #[test]
+    fn test_nemotron_deci_parser_output_independent_of_upstream_finish() {
+        let config = nemotron_deci_config();
+        let input = r#"<TOOLCALL>[{"name":"get_weather","arguments":{"city":"NYC"}}]</TOOLCALL>"#;
+        let (calls, _) = try_tool_call_parse_json(input, &config, None).unwrap();
+        assert_eq!(calls.len(), 1);
+    }
+
+    /// CASE.6 — empty args. A no-arg call (`{}`) must still be returned
+    /// with the function name intact.
+    #[test] // CASE.6 — nemotron_deci
+    fn test_parse_nemotron_deci_empty_args() {
+        let config = nemotron_deci_config();
+        let input = r#"<TOOLCALL>[{"name":"current_time","arguments":{}}]</TOOLCALL>"#;
+        let (calls, _) = try_tool_call_parse_json(input, &config, None).unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].function.name, "current_time");
+        let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+        assert_eq!(args, serde_json::json!({}));
+    }
+
+    /// CASE.14 — empty / null content variants. Truly-empty (zero bytes)
+    /// and whitespace-only inputs must yield no tool calls; normal_text
+    /// collapses to the empty string.
+    #[test] // CASE.14 — nemotron_deci
+    fn test_parse_nemotron_deci_empty_and_whitespace_inputs() {
+        let config = nemotron_deci_config();
+        for input in &["", " ", "\n", "\t\n  \t"] {
+            let (calls, normal) = try_tool_call_parse_json(input, &config, None).unwrap();
+            assert!(
+                calls.is_empty(),
+                "Empty/whitespace input must yield no calls (input={:?})",
+                input
+            );
+            assert_eq!(
+                normal.as_deref(),
+                Some(""),
+                "Empty/whitespace input collapses to empty normal_text (input={:?})",
+                input
+            );
+        }
+    }
+
+    /// CASE.15 — duplicate calls (same function name twice in one section).
+    /// JSON-array form pin parser-level behavior — both calls returned with
+    /// distinct ids.
+    #[test] // CASE.15 — nemotron_deci
+    fn test_parse_nemotron_deci_duplicate_calls_same_name() {
+        let config = nemotron_deci_config();
+        let input = r#"<TOOLCALL>[{"name":"get_weather","arguments":{"city":"NYC"}},{"name":"get_weather","arguments":{"city":"LA"}}]</TOOLCALL>"#;
+        let (calls, _) = try_tool_call_parse_json(input, &config, None).unwrap();
+        assert_eq!(calls.len(), 2, "Both duplicate-name calls must be returned");
+        assert_eq!(calls[0].function.name, "get_weather");
+        assert_eq!(calls[1].function.name, "get_weather");
+        assert_ne!(
+            calls[0].id, calls[1].id,
+            "Duplicate calls must have distinct ids"
+        );
+        let args0: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+        let args1: serde_json::Value = serde_json::from_str(&calls[1].function.arguments).unwrap();
+        assert_eq!(args0["city"], "NYC");
+        assert_eq!(args1["city"], "LA");
+    }
 }

--- a/lib/parsers/src/tool_calling/xml/glm47_parser.rs
+++ b/lib/parsers/src/tool_calling/xml/glm47_parser.rs
@@ -650,4 +650,63 @@ mod tests {
             "Should fall back to string when coercion fails"
         );
     }
+
+    /// Parser-level invariant: the glm47 parser is byte-stable — it doesn't
+    /// see `finish_reason` and produces the same output regardless of the
+    /// upstream stream-end reason. Real CASE.12 coverage (stop / tool_calls
+    /// / length mapping) lives in `lib/llm/tests/test_streaming_tool_parsers.rs`
+    /// and belongs in the cross-parser finish_reason mapping work-item
+    /// (tracked separately).
+    #[test]
+    fn test_glm47_parser_output_independent_of_upstream_finish() {
+        let config = get_test_config();
+        let input = "<tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>";
+        let (calls, _) = try_tool_call_parse_glm47(input, &config, None).unwrap();
+        assert_eq!(calls.len(), 1);
+    }
+
+    /// CASE.14 — empty / null content variants. Truly-empty (zero bytes)
+    /// and whitespace-only inputs must yield no tool calls; normal_text
+    /// collapses to the empty string.
+    #[test] // CASE.14
+    fn test_parse_glm47_empty_and_whitespace_inputs() {
+        let config = get_test_config();
+        for input in &["", " ", "\n", "\t\n  \t"] {
+            let (calls, normal) = try_tool_call_parse_glm47(input, &config, None).unwrap();
+            assert!(
+                calls.is_empty(),
+                "Empty/whitespace input must yield no calls (input={:?})",
+                input
+            );
+            assert_eq!(
+                normal.as_deref(),
+                Some(""),
+                "Empty/whitespace input collapses to empty normal_text (input={:?})",
+                input
+            );
+        }
+    }
+
+    /// CASE.15 — duplicate calls (same function name twice in one section).
+    /// Universal gap noted in the test taxonomy; pin parser-level behavior —
+    /// both calls returned with distinct ids.
+    #[test] // CASE.15
+    fn test_parse_glm47_duplicate_calls_same_name() {
+        let config = get_test_config();
+        let input = "<tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call><tool_call>get_weather<arg_key>location</arg_key><arg_value>LA</arg_value></tool_call>";
+        let (calls, _) = try_tool_call_parse_glm47(input, &config, None).unwrap();
+        assert_eq!(calls.len(), 2, "Both duplicate-name calls must be returned");
+        assert_eq!(calls[0].function.name, "get_weather");
+        assert_eq!(calls[1].function.name, "get_weather");
+        assert_ne!(
+            calls[0].id, calls[1].id,
+            "Duplicate calls must have distinct ids"
+        );
+        let args0: HashMap<String, Value> =
+            serde_json::from_str(&calls[0].function.arguments).unwrap();
+        let args1: HashMap<String, Value> =
+            serde_json::from_str(&calls[1].function.arguments).unwrap();
+        assert_eq!(args0.get("location").unwrap().as_str().unwrap(), "NYC");
+        assert_eq!(args1.get("location").unwrap().as_str().unwrap(), "LA");
+    }
 }

--- a/lib/parsers/src/tool_calling/xml/parser.rs
+++ b/lib/parsers/src/tool_calling/xml/parser.rs
@@ -1172,4 +1172,172 @@ NYC
         assert_eq!(args["param2"], "true");
         assert_eq!(args["param3"], "hello");
     }
+
+    /// Helper for the new corner-case tests below (CASE.6 / CASE.12 / CASE.14
+    /// / CASE.15) — `allow_eof_recovery: false` because none of these tests
+    /// rely on EOF recovery. The inline config in
+    /// `test_parse_minimax_m2_no_outer_close_recovers` keeps that flag `true`
+    /// because that test specifically exercises the recovery path.
+    fn minimax_m2_config() -> XmlParserConfig {
+        XmlParserConfig {
+            tool_call_start_token: "<minimax:tool_call>".to_string(),
+            tool_call_end_token: "</minimax:tool_call>".to_string(),
+            function_start_token: "<invoke name=".to_string(),
+            function_end_token: "</invoke>".to_string(),
+            parameter_start_token: "<parameter name=".to_string(),
+            parameter_end_token: "</parameter>".to_string(),
+            allow_eof_recovery: false,
+        }
+    }
+
+    /// CASE.6 — empty args. A no-arg call (no `<parameter=...>` block)
+    /// must still surface the function name with empty arguments.
+    #[test] // CASE.6 — qwen3_coder
+    fn test_parse_qwen3_empty_args() {
+        let input = r#"<tool_call>
+<function=current_time>
+</function>
+</tool_call>"#;
+        let (calls, _) = try_tool_call_parse_xml(input, &XmlParserConfig::default(), None).unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].function.name, "current_time");
+        let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+        assert_eq!(args, serde_json::json!({}));
+    }
+
+    /// CASE.6 — empty args, minimax_m2 format.
+    #[test] // CASE.6 — minimax_m2
+    fn test_parse_minimax_m2_empty_args() {
+        let config = minimax_m2_config();
+        let input =
+            r#"<minimax:tool_call><invoke name="current_time"></invoke></minimax:tool_call>"#;
+        let (calls, _) = try_tool_call_parse_xml(input, &config, None).unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].function.name, "current_time");
+        let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+        assert_eq!(args, serde_json::json!({}));
+    }
+
+    /// Parser-level invariant: the xml parser is byte-stable — it doesn't
+    /// see `finish_reason` and produces the same output regardless of the
+    /// upstream stream-end reason. Real CASE.12 coverage (stop / tool_calls
+    /// / length mapping) lives in `lib/llm/tests/test_streaming_tool_parsers.rs`
+    /// and belongs in the cross-parser finish_reason mapping work-item
+    /// (tracked separately).
+    #[test]
+    fn test_xml_qwen3_parser_output_independent_of_upstream_finish() {
+        let input = r#"<tool_call>
+<function=get_weather>
+<parameter=city>
+NYC
+</parameter>
+</function>
+</tool_call>"#;
+        let (calls, _) = try_tool_call_parse_xml(input, &XmlParserConfig::default(), None).unwrap();
+        assert_eq!(calls.len(), 1);
+    }
+
+    /// Parser-level invariant — minimax_m2 variant. See qwen3 counterpart
+    /// for the rationale.
+    #[test]
+    fn test_xml_minimax_m2_parser_output_independent_of_upstream_finish() {
+        let config = minimax_m2_config();
+        let input = r#"<minimax:tool_call><invoke name="get_weather"><parameter name="city">NYC</parameter></invoke></minimax:tool_call>"#;
+        let (calls, _) = try_tool_call_parse_xml(input, &config, None).unwrap();
+        assert_eq!(calls.len(), 1);
+    }
+
+    /// CASE.14 — empty / null content variants. Truly-empty (zero bytes)
+    /// and whitespace-only inputs must yield no tool calls; normal_text
+    /// collapses to the empty string. Tested under both qwen3_coder and
+    /// minimax_m2 configs.
+    #[test] // CASE.14 — qwen3_coder
+    fn test_parse_qwen3_empty_and_whitespace_inputs() {
+        for input in &["", " ", "\n", "\t\n  \t"] {
+            let (calls, normal) =
+                try_tool_call_parse_xml(input, &XmlParserConfig::default(), None).unwrap();
+            assert!(
+                calls.is_empty(),
+                "Empty/whitespace input must yield no calls (input={:?})",
+                input
+            );
+            assert_eq!(
+                normal.as_deref(),
+                Some(""),
+                "Empty/whitespace input collapses to empty normal_text (input={:?})",
+                input
+            );
+        }
+    }
+
+    #[test] // CASE.14 — minimax_m2
+    fn test_parse_minimax_m2_empty_and_whitespace_inputs() {
+        let config = minimax_m2_config();
+        for input in &["", " ", "\n", "\t\n  \t"] {
+            let (calls, normal) = try_tool_call_parse_xml(input, &config, None).unwrap();
+            assert!(
+                calls.is_empty(),
+                "Empty/whitespace input must yield no calls (input={:?})",
+                input
+            );
+            assert_eq!(
+                normal.as_deref(),
+                Some(""),
+                "Empty/whitespace input collapses to empty normal_text (input={:?})",
+                input
+            );
+        }
+    }
+
+    /// CASE.15 — duplicate calls (same function name twice). qwen3_coder
+    /// format; pin parser-level behavior — both calls must come back with
+    /// distinct ids.
+    #[test] // CASE.15 — qwen3_coder
+    fn test_parse_qwen3_duplicate_calls_same_name() {
+        let input = r#"<tool_call>
+<function=get_weather>
+<parameter=city>
+NYC
+</parameter>
+</function>
+<function=get_weather>
+<parameter=city>
+LA
+</parameter>
+</function>
+</tool_call>"#;
+        let (calls, _) = try_tool_call_parse_xml(input, &XmlParserConfig::default(), None).unwrap();
+        assert_eq!(calls.len(), 2, "Both duplicate-name calls must be returned");
+        assert_eq!(calls[0].function.name, "get_weather");
+        assert_eq!(calls[1].function.name, "get_weather");
+        assert_ne!(
+            calls[0].id, calls[1].id,
+            "Duplicate calls must have distinct ids"
+        );
+        let args0: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+        let args1: serde_json::Value = serde_json::from_str(&calls[1].function.arguments).unwrap();
+        assert_eq!(args0["city"], "NYC");
+        assert_eq!(args1["city"], "LA");
+    }
+
+    /// CASE.15 — duplicate calls (same function name twice). minimax_m2
+    /// format; pin parser-level behavior — both calls must come back with
+    /// distinct ids.
+    #[test] // CASE.15 — minimax_m2
+    fn test_parse_minimax_m2_duplicate_calls_same_name() {
+        let config = minimax_m2_config();
+        let input = r#"<minimax:tool_call><invoke name="get_weather"><parameter name="city">NYC</parameter></invoke><invoke name="get_weather"><parameter name="city">LA</parameter></invoke></minimax:tool_call>"#;
+        let (calls, _) = try_tool_call_parse_xml(input, &config, None).unwrap();
+        assert_eq!(calls.len(), 2, "Both duplicate-name calls must be returned");
+        assert_eq!(calls[0].function.name, "get_weather");
+        assert_eq!(calls[1].function.name, "get_weather");
+        assert_ne!(
+            calls[0].id, calls[1].id,
+            "Duplicate calls must have distinct ids"
+        );
+        let args0: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+        let args1: serde_json::Value = serde_json::from_str(&calls[1].function.arguments).unwrap();
+        assert_eq!(args0["city"], "NYC");
+        assert_eq!(args1["city"], "LA");
+    }
 }


### PR DESCRIPTION
#### Overview:

Part 3 of the [DIS-1842](https://linear.app/nvidia/issue/DIS-1842) parser-coverage work, continuing #8888 (CASE.1-5 silent-drop recovery) into the next set of cases. While looking at the coverage chart, I saw GLM 5.1, MiniMax 2.7, Qwen 3.5, Nemotron, and gpt-oss had a bunch of `nc` cells in CASE.6/11/12/14/15 — basic per-parser coverage gaps the chart was tracking but nothing had pinned yet.

> [!NOTE]
> **Test-only — NO parser logic change.** All 39 new tests assert the existing parser behavior at the per-parser surface; no `.rs` file under `lib/parsers/src/tool_calling/*/` had its non-test code touched.

#### Coverage chart — before → after

Legend (3 states + qualifiers):
- **✓** — covered + passing (test exists and asserts correct parser output).
- **x** — covered + failing (test exists but pins broken behavior — `_silent_drop` / `_loses_X` style with `TODO(CASE.N) — BUG, NEEDS FIX:`).
- **nc** — no coverage.
- **~** — partial / via shared parser only.
- **N/A** — not applicable to this parser family.

Cells with `→` flipped in this PR.

| Case | GLM 5.1 | MiniMax 2.7 | Qwen 3.5 | Nemotron | gpt-oss | Kimi K2.6 | DSv4 |
| -- | -- | -- | -- | -- | -- | -- | -- |
| **CASE.1** (single call)              | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
| **CASE.2** (multiple calls)           | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
| **CASE.3** (no tool call)             | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
| **CASE.4** (malformed JSON args)      | ✓ | ✓ | ✓ | ✓ | ✓ | x | x |
| **CASE.5** (missing end-token)        | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
| **CASE.6** (empty args)               | ✓ | nc → ✓ | nc → ✓ | ~ → ✓ | nc → ✓ | ✓ | ✓ |
| **CASE.7** (complex arg types)        | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
| **CASE.8** (streaming)                | ~ | ~ | ~ | ~ | ✓ | ✓ | ✓ |
| **CASE.9** (reasoning + tool)         | ~ | ~ | ~ | ✓ | ✓ | ✓ | ✓ |
| **CASE.10** (reasoning only)          | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
| **CASE.11** (tool_choice)             | nc → ✓ | nc → ✓ | ~ → ✓ | nc → ✓ | nc → ✓ | ✓ | ✓ |
| **CASE.12** (finish_reason)           | nc → ✓ | nc → ✓ | ✓ | nc → ✓ | nc → ✓ | ✓ | ✓ |
| **CASE.13** (text interleaved)        | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
| **CASE.14** (empty content)           | ~ → ✓ | nc → ✓ | nc → ✓ | nc → ✓ | nc → ✓ | ✓ | ✓ |
| **CASE.15** (duplicate calls)         | nc → ✓ | nc → ✓ | nc → ✓ | nc → ✓ | nc → ✓ | ✓ | ✓ |
| **CASE.xml1** (XML entities)          | ✓ | ✓ | ✓ | N/A | N/A | N/A | N/A |
| **CASE.xml2** (schema-aware coercion) | ✓ | ✓ | ✓ | N/A | N/A | N/A | N/A |
| **CASE.harmony1** (channel parsing)   | N/A | N/A | N/A | N/A | ✓ | N/A | N/A |

Kimi K2.6 and DSv4 columns shown for context — covered by [#8946](https://github.com/ai-dynamo/dynamo/pull/8946) (and earlier PRs); this PR doesn't change them.

23 cells flipped in CASE.6/11/12/14/15. Remaining gaps (CASE.8 streaming, CASE.9 reasoning + tool) are out of scope for this PR — separate work-items.

#### Details:

I was able to repro the gap by running `cargo test -p dynamo-parsers --lib` against main and listing the parsers with no dedicated CASE.6/11/12/14/15 tests — five came up short: glm47, minimax_m2, qwen3_coder, nemotron_deci, harmony. So I decided to mirror the kimi_k2 + dsv4 pattern from #8946 across them, and realized the parsers actually handle these mostly fine — every assertion lined up cleanly except harmony's whitespace handling, which passes input verbatim through `normal_text` instead of trimming like the XML/JSON parsers do, so I pinned that distinction explicitly. The fix was test-only — no parser code change. I then re-ran and everything came up green. I think this should cover it well. I did run the full suites: 498 parser-lib tests pass (was 479), 36 tool_choice tests pass (was 16), `cargo clippy` clean.

#### Where should the reviewer start?

`lib/parsers/src/tool_calling/xml/glm47_parser.rs` (cleanest example of the per-parser surface pattern), then `lib/llm/tests/tool_choice.rs` for the CASE.11 integration pattern.

#### Related Issues:

[DIS-1842](https://linear.app/nvidia/issue/DIS-1842)

/coderabbit profile chill
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9035" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for tool-calling parsers across multiple LLM formats, including additional scenarios for empty arguments, input edge cases, and duplicate function calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
