### PR TITLE
test: add in-process query retry for flaky e2e payloads

### DIFF
--- a/examples/backends/vllm/launch/disagg_multimodal_e_pd.sh
+++ b/examples/backends/vllm/launch/disagg_multimodal_e_pd.sh
@@ -95,13 +95,32 @@ else
     DYN_PD_GPU_MEM=${DYN_PD_GPU_MEM:-0.9}
 fi
 
+# PD worker memory args: when _PROFILE_OVERRIDE_VLLM_KV_CACHE_BYTES is set,
+# build_vllm_gpu_mem_args returns "--kv-cache-memory-bytes N --gpu-memory-utilization 0.01",
+# which overrides $DYN_PD_GPU_MEM (the env knob becomes a no-op in that case).
+# Without the override env, $DYN_PD_GPU_MEM is the live cap.
 PD_GPU_MEM_ARGS=$(build_vllm_gpu_mem_args)
 if [[ -z "$PD_GPU_MEM_ARGS" ]]; then
     PD_GPU_MEM_ARGS="--gpu-memory-utilization $DYN_PD_GPU_MEM"
 fi
 
-# Start encode worker. Encode has no KV cache, so the byte-cap override is N/A
-# and we keep the fraction-based knob here.
+# Start encode worker.
+#
+# NOTE: encoder VRAM is STATIC, set by the model — $DYN_ENCODE_GPU_MEM
+# (--gpu-memory-utilization) is effectively a no-op for non-Qwen-VL models.
+# dynamo's EncodeWorkerHandler only consumes engine_args.enforce_eager;
+# load_vision_model (components/src/dynamo/vllm/multimodal_utils/model.py)
+# branches on family:
+#   - Qwen-VL: vLLM mm_encoder_only=True path, hardcoded gpu_memory_utilization=0.2
+#     and kv_cache_memory_bytes=64MiB inside the function — only the vision tower
+#     loads (small).
+#   - Everything else (e.g. LLaVA-1.5-7b): AutoModel.from_pretrained(..., fp16)
+#     loads the FULL model weights, then .visual is extracted. The fraction here
+#     is ignored.
+# Verified empirically for LLaVA-1.5-7b on RTX 6000 Ada (48 GB):
+# GPU0 peak ~13.5 GB at DYN_ENCODE_GPU_MEM=0.05, 0.5, 0.9 (identical within jitter).
+# The static peak is bounded by the model's fp16 weights (~14 GB), independent
+# of GPU size. So sizing for this script: encoder needs ~14 GB free per worker GPU.
 echo "Starting encode worker on GPU $DYN_ENCODE_WORKER_GPU (--gpu-memory-utilization $DYN_ENCODE_GPU_MEM)..."
 CUDA_VISIBLE_DEVICES=$DYN_ENCODE_WORKER_GPU \
 python -m dynamo.vllm \

--- a/examples/backends/vllm/launch/disagg_multimodal_epd.sh
+++ b/examples/backends/vllm/launch/disagg_multimodal_epd.sh
@@ -24,6 +24,16 @@ MODEL_NAME="llava-hf/llava-1.5-7b-hf"
 #   - Using lower gpu-memory-utilization fractions to share the GPU
 SINGLE_GPU=false
 
+# --two-gpu: Packs 3 workers onto 2 GPUs.
+# Layout: encode + prefill on GPU 0, decode on GPU 1. Preserves the disagg
+# semantic — prefill→decode KV transfer still crosses the GPU boundary via
+# NIXL — while halving the GPU footprint vs the default 3-GPU mode. Same
+# small-KV defaults as --single-gpu (enforce-eager, 512 MB KV, max-model-len
+# 4096, limit-mm-per-prompt 3/3/0) so it's a functional-testing knob, not a
+# perf config. Override _PROFILE_OVERRIDE_VLLM_KV_CACHE_BYTES to grow the
+# KV cap when profiling.
+TWO_GPU=false
+
 # Parse command line arguments
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -35,6 +45,10 @@ while [[ $# -gt 0 ]]; do
             SINGLE_GPU=true
             shift
             ;;
+        --two-gpu)
+            TWO_GPU=true
+            shift
+            ;;
         -h|--help)
             echo "Usage: $0 [OPTIONS]"
             echo ""
@@ -44,6 +58,7 @@ while [[ $# -gt 0 ]]; do
             echo "  --model <model_name>          Specify the VLM model to use (default: $MODEL_NAME)"
             echo "                                LLaVA 1.5 7B, Qwen2.5-VL, and Phi3V models have predefined templates"
             echo "  --single-gpu                  Pack all 3 workers on 1 GPU (for small models, e.g. 2B)"
+            echo "  --two-gpu                     Pack 3 workers on 2 GPUs (encode+prefill on GPU 0, decode on GPU 1)"
             echo "  -h, --help                    Show this help message"
             echo ""
             echo "Examples:"
@@ -51,6 +66,7 @@ while [[ $# -gt 0 ]]; do
             echo "  $0 --model microsoft/Phi-3.5-vision-instruct"
             echo "  $0 --model Qwen/Qwen2.5-VL-7B-Instruct"
             echo "  $0 --model Qwen/Qwen3-VL-2B-Instruct --single-gpu"
+            echo "  $0 --model llava-hf/llava-1.5-7b-hf --two-gpu"
             echo ""
             exit 0
             ;;
@@ -62,10 +78,17 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+if [[ "$SINGLE_GPU" == "true" && "$TWO_GPU" == "true" ]]; then
+    echo "ERROR: --single-gpu and --two-gpu are mutually exclusive" >&2
+    exit 2
+fi
+
 
 HTTP_PORT="${DYN_HTTP_PORT:-8000}"
 if [[ "$SINGLE_GPU" == "true" ]]; then
     GPU_LABEL="1 GPU"
+elif [[ "$TWO_GPU" == "true" ]]; then
+    GPU_LABEL="2 GPUs"
 else
     GPU_LABEL="3 GPUs"
 fi
@@ -83,11 +106,18 @@ PREFILL_GPU_MEM_ARGS=""
 DECODE_GPU_MEM_ARGS=""
 
 # GPU assignments (override via environment variables).
-# In single-GPU mode all 3 workers default to GPU 0.
+# Modes:
+#   --single-gpu : all 3 workers on GPU 0
+#   --two-gpu    : encode + prefill on GPU 0, decode on GPU 1
+#   default      : encode 0, prefill 1, decode 2 (3 GPUs)
 if [[ "$SINGLE_GPU" == "true" ]]; then
     DYN_ENCODE_WORKER_GPU=${DYN_ENCODE_WORKER_GPU:-0}
     DYN_PREFILL_WORKER_GPU=${DYN_PREFILL_WORKER_GPU:-0}
     DYN_DECODE_WORKER_GPU=${DYN_DECODE_WORKER_GPU:-0}
+elif [[ "$TWO_GPU" == "true" ]]; then
+    DYN_ENCODE_WORKER_GPU=${DYN_ENCODE_WORKER_GPU:-0}
+    DYN_PREFILL_WORKER_GPU=${DYN_PREFILL_WORKER_GPU:-0}
+    DYN_DECODE_WORKER_GPU=${DYN_DECODE_WORKER_GPU:-1}
 else
     DYN_ENCODE_WORKER_GPU=${DYN_ENCODE_WORKER_GPU:-0}
     DYN_PREFILL_WORKER_GPU=${DYN_PREFILL_WORKER_GPU:-1}
@@ -109,17 +139,29 @@ if [[ "$SINGLE_GPU" == "true" ]]; then
     DYN_ENCODE_GPU_MEM=${DYN_ENCODE_GPU_MEM:-0.1}
     DYN_PREFILL_GPU_MEM=${DYN_PREFILL_GPU_MEM:-0.4}
     DYN_DECODE_GPU_MEM=${DYN_DECODE_GPU_MEM:-0.4}
+elif [[ "$TWO_GPU" == "true" ]]; then
+    # encoder + prefill share GPU 0, decode alone on GPU 1
+    DYN_ENCODE_GPU_MEM=${DYN_ENCODE_GPU_MEM:-0.1}
+    DYN_PREFILL_GPU_MEM=${DYN_PREFILL_GPU_MEM:-0.7}
+    DYN_DECODE_GPU_MEM=${DYN_DECODE_GPU_MEM:-0.9}
 else
     DYN_ENCODE_GPU_MEM=${DYN_ENCODE_GPU_MEM:-0.9}
     DYN_PREFILL_GPU_MEM=${DYN_PREFILL_GPU_MEM:-0.9}
     DYN_DECODE_GPU_MEM=${DYN_DECODE_GPU_MEM:-0.9}
 fi
 
-if [[ "$SINGLE_GPU" == "true" ]]; then
+if [[ "$SINGLE_GPU" == "true" || "$TWO_GPU" == "true" ]]; then
     EXTRA_ARGS="--enforce-eager"
-    # Default KV cache cap from profiling for single-GPU worker packing; the
-    # profiler/test framework overrides via env, and gpu_utils.sh builds args.
-    : "${_PROFILE_OVERRIDE_VLLM_KV_CACHE_BYTES:=$((512 * 1024 * 1024))}"
+    # Default KV cache cap for packed worker layouts.
+    #
+    # vLLM has a preflight check: KV must hold at least one max-model-len
+    # request. For LLaVA-1.5-7b at max-model-len=4096, that's ~2 GiB
+    # minimum. 512 MB used to work for older vLLM / smaller max-model-len
+    # but vLLM 0.20+ rejects it.
+    #
+    # The profiler/test framework overrides via _PROFILE_OVERRIDE_VLLM_KV_CACHE_BYTES,
+    # and gpu_utils.sh builds args.
+    : "${_PROFILE_OVERRIDE_VLLM_KV_CACHE_BYTES:=$((2 * 1024 * 1024 * 1024))}"
     PD_EXTRA_ARGS="--max-model-len 4096 --limit-mm-per-prompt {\"image\":3,\"video\":3,\"audio\":0}"
 fi
 
@@ -132,8 +174,21 @@ else
     DECODE_GPU_MEM_ARGS="--gpu-memory-utilization $DYN_DECODE_GPU_MEM"
 fi
 
-# Start encode worker. Encode has no KV cache, so the byte-cap override is N/A
-# and we keep the fraction-based knob here.
+# Start encode worker.
+#
+# NOTE: encoder VRAM is STATIC, set by the model — $DYN_ENCODE_GPU_MEM
+# (--gpu-memory-utilization) is effectively a no-op for non-Qwen-VL models.
+# dynamo's EncodeWorkerHandler only consumes engine_args.enforce_eager;
+# load_vision_model (components/src/dynamo/vllm/multimodal_utils/model.py)
+# branches on family:
+#   - Qwen-VL: vLLM mm_encoder_only=True path, hardcoded gpu_memory_utilization=0.2
+#     and kv_cache_memory_bytes=64MiB inside the function — only the vision tower
+#     loads (small).
+#   - Everything else (e.g. LLaVA-1.5-7b): AutoModel.from_pretrained(..., fp16)
+#     loads the FULL model weights, then .visual is extracted. The fraction here
+#     is ignored.
+# For LLaVA-1.5-7b the encoder peak is ~13.5 GB regardless of GPU size or fraction
+# (verified empirically for the e_pd topology — same load path applies here).
 echo "Starting encode worker on GPU $DYN_ENCODE_WORKER_GPU (--gpu-memory-utilization $DYN_ENCODE_GPU_MEM)..."
 VLLM_NIXL_SIDE_CHANNEL_PORT=20097 CUDA_VISIBLE_DEVICES=$DYN_ENCODE_WORKER_GPU python -m dynamo.vllm --multimodal-encode-worker --enable-multimodal --model $MODEL_NAME --gpu-memory-utilization $DYN_ENCODE_GPU_MEM $EXTRA_ARGS --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080"}' &
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -506,21 +506,21 @@ Tests must be deterministic. A flaky test -- one that sometimes passes and somet
    - For tests parametrized via dataclasses, add the marker to the per-parametrization `marks=[...]` list so it only applies to the offending case.
    - Cost: `@pytest.mark.flaky` reruns the *whole* test. For e2e tests where startup costs 60-90s, three attempts can spend 5+ minutes before failing. Use 2b instead.
 
-   **2b. In-process query retry — `payload.retries`** (use for tests going through `run_serve_deployment` — e2e serving, multimodal smoke checks)
+   **2b. In-process query retry — `payload.max_attempts`** (use for tests going through `run_serve_deployment` — e2e serving, multimodal smoke checks)
 
-   The server is launched once and stays up across retries; only the request/response is re-issued. Set `retries` on the payload:
+   The server is launched once and stays up across attempts; only the request/response is re-issued. Set `max_attempts` on the payload:
    ```python
    # tests/serve/multimodal_profiles/vllm.py
    request_payloads=[
        make_image_payload(
            ["green", "white", "black", "purple", "red", ...],
-           retries=2,  # known-flaky model output; see comment above
+           max_attempts=3,  # known-flaky model output; see comment above
        )
    ],
    ```
-   - The factory functions (`make_image_payload`, `make_video_payload`, `chat_payload`, ...) accept a `retries: int` kwarg that lands on `BasePayload.retries`.
-   - `tests/serve/common.py:run_serve_deployment` wraps the `send_request` + `check_response` pair in a small inline retry loop, catching `EngineResponseError` with exponential backoff (1.0 → 1.5 → 2.25 → ... seconds, factor 1.5).
-   - Cost: each retry is ~one inference call (a few seconds), not a server restart. The 60-90s server startup is amortized across all retries.
+   - The factory functions (`make_image_payload`, `make_video_payload`, `chat_payload`, ...) accept a `max_attempts: int` kwarg that lands on `BasePayload.max_attempts`.
+   - `tests/serve/common.py:run_serve_deployment` wraps the `send_request` + `check_response` pair in a small inline retry loop, catching `ResponseValidationError` with exponential backoff (1.0 → 1.5 → 2.25 → ... seconds, factor 1.5).
+   - Cost: each attempt is ~one inference call (a few seconds), not a server restart. The 60-90s server startup is amortized across all attempts.
    - Trade-off: only re-issues the same request -- if the flake is in startup or model loading, this won't help; use 2a for those cases.
 
    **Other in-repo retry sites** (in case you need to roll your own for a different layer):

--- a/tests/README.md
+++ b/tests/README.md
@@ -487,13 +487,53 @@ All commands shown in the "Local equivalent" columns above are also documented i
 
 Tests must be deterministic. A flaky test -- one that sometimes passes and sometimes fails without code changes -- wastes CI time and erodes developer trust in the test suite. If you encounter or introduce a flaky test:
 
-1. **Fix it first.** Remove sources of non-determinism: set a fixed random seed, eliminate race conditions, mock network calls, avoid relying on execution order.
-2. **If a fix is not immediately possible**, quarantine the test to prevent it from blocking other developers:
+1. **Fix it first.** Remove sources of non-determinism: set a fixed random seed, eliminate race conditions, mock network calls, avoid relying on execution order. For LLM-output assertions, pass `temperature=0` and `seed=0` to the request so the model picks the same tokens each call.
+2. **If determinism truly isn't reachable** (model genuinely non-deterministic, an upstream library has races we don't own, etc.), retry. There are two mechanisms; pick based on what the test does.
+
+   **2a. Whole-test retry — `@pytest.mark.flaky`** (use for unit tests, parser tests, tool-calling tests, anything that doesn't launch a server)
+
+   The plugin (`pytest-rerunfailures`) is pinned in `container/deps/requirements.test.txt` and the `flaky` marker is registered in `pyproject.toml`. Apply it as narrowly as you can:
+   ```python
+   @pytest.mark.flaky(reruns=2, only_rerun=["AssertionError"])
+   def test_named_tool_choice_forces_specific_function(...):
+       ...
+   ```
+   - `reruns=2` means up to 2 retries (3 attempts total). Pick the smallest number that gets you green; don't paper over a real bug.
+   - `only_rerun=[...]` restricts retries to **content / validation failures**. Use the bare exception class name. Common values:
+     - `"AssertionError"` -- direct pytest asserts (most tool-calling and parser tests).
+     - `"EngineResponseError"` -- `tests/utils/engine_process.py` wraps the validator's `AssertionError` here.
+   - **Never** match infra exceptions (`TimeoutError`, `ConnectionError`, `RuntimeError`) -- those signal a real problem, and retrying hides it.
+   - For tests parametrized via dataclasses, add the marker to the per-parametrization `marks=[...]` list so it only applies to the offending case.
+   - Cost: `@pytest.mark.flaky` reruns the *whole* test. For e2e tests where startup costs 60-90s, three attempts can spend 5+ minutes before failing. Use 2b instead.
+
+   **2b. In-process query retry — `payload.retries`** (use for tests going through `run_serve_deployment` — e2e serving, multimodal smoke checks)
+
+   The server is launched once and stays up across retries; only the request/response is re-issued. Set `retries` on the payload:
+   ```python
+   # tests/serve/multimodal_profiles/vllm.py
+   request_payloads=[
+       make_image_payload(
+           ["green", "white", "black", "purple", "red", ...],
+           retries=2,  # known-flaky model output; see comment above
+       )
+   ],
+   ```
+   - The factory functions (`make_image_payload`, `make_video_payload`, `chat_payload`, ...) accept a `retries: int` kwarg that lands on `BasePayload.retries`.
+   - `tests/serve/common.py:run_serve_deployment` wraps the `send_request` + `check_response` pair in a small inline retry loop, catching `EngineResponseError` with exponential backoff (1.0 → 1.5 → 2.25 → ... seconds, factor 1.5).
+   - Cost: each retry is ~one inference call (a few seconds), not a server restart. The 60-90s server startup is amortized across all retries.
+   - Trade-off: only re-issues the same request -- if the flake is in startup or model loading, this won't help; use 2a for those cases.
+
+   **Other in-repo retry sites** (in case you need to roll your own for a different layer):
+   - `tests/frontend/test_frontend_api_surface_compliance.py:_retry_network_op` -- sync, network-only exception list.
+   - `tests/router/helper.py:send_request_with_retry` -- async, status-code-driven (aiohttp).
+   - `tests/utils/managed_deployment.py` -- sync connect retry with 1.5x backoff.
+   - `components/src/dynamo/planner/connectors/remote_client.py` -- sync exponential backoff (`2**attempt`).
+3. **If retry is not enough either**, quarantine the test to prevent it from blocking other developers:
    - `@pytest.mark.skip(reason="Flaky: <ticket link>")` -- disables the test entirely. Use when the test provides no signal in its current state.
    - `@pytest.mark.xfail(reason="Flaky: <ticket link>", strict=False)` -- runs the test but does not fail the suite. Use when you still want visibility into pass/fail rates while you investigate.
    - In Rust, use `#[ignore]` with a comment explaining why.
-3. **File a ticket** for every quarantined test. Flaky tests without an owner drift indefinitely.
-4. **Do not leave tests quarantined for more than one sprint.** If the root cause is elusive, delete the test and rewrite it.
+4. **File a ticket** for every retried or quarantined test. Even tests using `@pytest.mark.flaky` need an owner -- retry hides the symptom; the underlying non-determinism still exists.
+5. **Do not leave tests quarantined for more than one sprint.** If the root cause is elusive, delete the test and rewrite it. A test marked `flaky` should aim to drop the marker once the upstream determinism issue is fixed.
 
 ### Timeouts
 

--- a/tests/serve/common.py
+++ b/tests/serve/common.py
@@ -17,7 +17,7 @@ from dynamo.common.utils.paths import WORKSPACE_DIR
 from tests.conftest import ServicePorts
 from tests.utils.client import send_request
 from tests.utils.constants import DefaultPort
-from tests.utils.engine_process import EngineConfig, EngineProcess
+from tests.utils.engine_process import EngineConfig, EngineProcess, EngineResponseError
 from tests.utils.port_utils import allocate_port, deallocate_port
 
 DEFAULT_TIMEOUT = 10
@@ -185,14 +185,39 @@ def run_serve_deployment(
                     payload.system_ports = mapped_system_ports
 
                 for _ in range(payload.repeat_count):
-                    response = send_request(
-                        url=payload.url(),
-                        payload=payload.body,
-                        timeout=payload.timeout,
-                        method=payload.method,
-                        stream=payload.http_stream,
-                    )
-                    server_process.check_response(payload, response)
+                    # Re-issue the request (server stays up) on validation
+                    # failure when payload.retries > 0. See tests/README.md
+                    # "Flaky Tests" for when this is appropriate. Backoff
+                    # factor 1.5 keeps the worst-case sleep budget bounded
+                    # for retry counts up to ~6.
+                    last_err: Optional[EngineResponseError] = None
+                    for attempt in range(payload.retries + 1):
+                        try:
+                            response = send_request(
+                                url=payload.url(),
+                                payload=payload.body,
+                                timeout=payload.timeout,
+                                method=payload.method,
+                                stream=payload.http_stream,
+                            )
+                            server_process.check_response(payload, response)
+                            last_err = None
+                            break
+                        except EngineResponseError as e:
+                            last_err = e
+                            if attempt < payload.retries:
+                                wait = 1.0 * (1.5**attempt)
+                                logger.warning(
+                                    "%s request failed (attempt %d/%d): %s — retrying in %.1fs",
+                                    type(payload).__name__,
+                                    attempt + 1,
+                                    payload.retries + 1,
+                                    e,
+                                    wait,
+                                )
+                                time.sleep(wait)
+                    if last_err is not None:
+                        raise last_err
 
                 # Call final_validation if the payload has one (e.g., CachedTokensChatPayload)
                 if hasattr(payload, "final_validation"):

--- a/tests/serve/common.py
+++ b/tests/serve/common.py
@@ -190,12 +190,12 @@ def run_serve_deployment(
 
                 for _ in range(payload.repeat_count):
                     # Re-issue the request (server stays up) on validation
-                    # failure when payload.retries > 0. See tests/README.md
+                    # failure when payload.max_attempts > 1. See tests/README.md
                     # "Flaky Tests" for when this is appropriate. Backoff
                     # factor 1.5 keeps the worst-case sleep budget bounded
-                    # for retry counts up to ~6.
+                    # for max_attempts up to ~6.
                     last_err: Optional[ResponseValidationError] = None
-                    for attempt in range(payload.retries + 1):
+                    for attempt in range(payload.max_attempts):
                         try:
                             response = send_request(
                                 url=payload.url(),
@@ -209,13 +209,13 @@ def run_serve_deployment(
                             break
                         except ResponseValidationError as e:
                             last_err = e
-                            if attempt < payload.retries:
+                            if attempt < payload.max_attempts - 1:
                                 wait = 1.0 * (1.5**attempt)
                                 logger.warning(
                                     "%s request failed (attempt %d/%d): %s — retrying in %.1fs",
                                     type(payload).__name__,
                                     attempt + 1,
-                                    payload.retries + 1,
+                                    payload.max_attempts,
                                     e,
                                     wait,
                                 )

--- a/tests/serve/common.py
+++ b/tests/serve/common.py
@@ -17,7 +17,11 @@ from dynamo.common.utils.paths import WORKSPACE_DIR
 from tests.conftest import ServicePorts
 from tests.utils.client import send_request
 from tests.utils.constants import DefaultPort
-from tests.utils.engine_process import EngineConfig, EngineProcess, EngineResponseError
+from tests.utils.engine_process import (
+    EngineConfig,
+    EngineProcess,
+    ResponseValidationError,
+)
 from tests.utils.port_utils import allocate_port, deallocate_port
 
 DEFAULT_TIMEOUT = 10
@@ -190,7 +194,7 @@ def run_serve_deployment(
                     # "Flaky Tests" for when this is appropriate. Backoff
                     # factor 1.5 keeps the worst-case sleep budget bounded
                     # for retry counts up to ~6.
-                    last_err: Optional[EngineResponseError] = None
+                    last_err: Optional[ResponseValidationError] = None
                     for attempt in range(payload.retries + 1):
                         try:
                             response = send_request(
@@ -203,7 +207,7 @@ def run_serve_deployment(
                             server_process.check_response(payload, response)
                             last_err = None
                             break
-                        except EngineResponseError as e:
+                        except ResponseValidationError as e:
                             last_err = e
                             if attempt < payload.retries:
                                 wait = 1.0 * (1.5**attempt)

--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -194,7 +194,7 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                     "blue",
                     "orange",
                 ],
-                max_attempts=6,
+                max_attempts=5,
             )
         ],
     ),

--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -125,6 +125,16 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
     ),
     # [gluo NOTE] LLaVA 1.5 7B is big model and require at least 3 GPUs to run.
     # We may use less GPUs by squeezing the model onto 2 GPUs.
+    #
+    # Encoder VRAM is STATIC (~13.5 GB peak on a 48 GB RTX 6000 Ada,
+    # independent of --gpu-memory-utilization): the dynamo encode worker
+    # falls through to AutoModel.from_pretrained(..., torch_dtype=fp16) for
+    # non-Qwen-VL models and loads the full LLaVA-1.5-7b weights before
+    # extracting .visual. See disagg_multimodal_e_pd.sh and
+    # components/src/dynamo/vllm/multimodal_utils/model.py:load_vision_model.
+    # PD VRAM is bounded by --kv-cache-memory-bytes (set via
+    # requested_vllm_kv_cache_bytes marker → _PROFILE_OVERRIDE_VLLM_KV_CACHE_BYTES);
+    # without that marker, the PD fraction $DYN_PD_GPU_MEM applies.
     MultimodalModelProfile(
         name="llava-hf/llava-1.5-7b-hf",
         short_name="llava-1.5-7b",
@@ -132,12 +142,36 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
             "e_pd": TopologyConfig(
                 marks=[pytest.mark.pre_merge],
                 timeout_s=600,
-                gpu_marker="gpu_4",
+                gpu_marker="gpu_2",
+                # Profiled with `tests/utils/profile_pytest.py --gpus 0,1` on
+                # 2x RTX 6000 Ada (48 GB each). Encoder GPU peaked ~13.5 GB
+                # (static, full model fp16 load); PD GPU peaked ~19 GB
+                # (weights + KV @ 4 GB cap + activations). 2x safety on KV.
+                profiled_vram_gib=19.0,
+                requested_vllm_kv_cache_bytes=4_308_848_000,
             ),
             "epd": TopologyConfig(
                 marks=[pytest.mark.pre_merge],
                 timeout_s=600,
                 gpu_marker="gpu_4",
+                # Default 3-GPU layout: encode → GPU 0, prefill → GPU 1,
+                # decode → GPU 2. Each worker has its own GPU; per-GPU peak
+                # ~14-18 GB (single worker + weights + KV). Fits on 24 GB L4
+                # tier.
+                #
+                # The launch script also supports a 2-GPU pack via --two-gpu
+                # (TopologyConfig.two_gpu=True): encode + prefill on GPU 0,
+                # decode on GPU 1. NIXL still transfers KV from prefill→decode
+                # across the GPU boundary, so it preserves the disagg semantic.
+                # Profiled values for the 2-GPU layout (measured on RTX 6000 Ada
+                # 48 GB; not yet enabled because GPU 0 peaks at 30 GB which
+                # doesn't fit on 24 GB L4 cards):
+                #   gpu_marker="gpu_2"
+                #   two_gpu=True
+                #   profiled_vram_gib=32.2  # GPU 0 peak, encoder + prefill
+                #   requested_vllm_kv_cache_bytes=4_297_773_000  # 2× safety over min 2_148_886_016
+                # Re-enable when CI runner pool has ≥32 GB cards on at least
+                # one of the 2 slots.
             ),
         },
         # LLaVA 1.5 color naming varies across CUDA backends under vLLM 0.20;
@@ -160,7 +194,7 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                     "blue",
                     "orange",
                 ],
-                retries=5,
+                max_attempts=6,
             )
         ],
     ),

--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -142,6 +142,11 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
         },
         # LLaVA 1.5 color naming varies across CUDA backends under vLLM 0.20;
         # keep this as a multimodal serving smoke check, not a color oracle.
+        # The model also occasionally degenerates into newline-padded output
+        # (observed in CI: '\n\nWhat\n\n...' and '\n\n1') even with
+        # temperature=0; this is a known LLaVA-1.5-on-vLLM flake, so the
+        # payload retries the validation in-process (server stays up) before
+        # CI fails. See tests/README.md "Flaky Tests" — In-Process Query Retry.
         request_payloads=[
             make_image_payload(
                 [
@@ -154,7 +159,8 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                     "yellow",
                     "blue",
                     "orange",
-                ]
+                ],
+                retries=5,
             )
         ],
     ),

--- a/tests/utils/engine_process.py
+++ b/tests/utils/engine_process.py
@@ -28,6 +28,19 @@ class EngineResponseError(Exception):
     pass
 
 
+class ResponseValidationError(EngineResponseError):
+    """Validation/assertion failure during process_response.
+
+    Subset of EngineResponseError raised only when payload.process_response
+    asserts on response content (the case the in-process retry was designed
+    for). Status (non-200) and handler errors continue to raise the parent
+    EngineResponseError so they surface immediately and aren't masked by
+    payload.retries.
+    """
+
+    pass
+
+
 class EngineLogError(Exception):
     """Custom exception for engine log validation errors"""
 
@@ -110,7 +123,7 @@ class EngineProcess(ManagedProcess):
                 else content,
             )
         except AssertionError as e:
-            raise EngineResponseError(str(e))
+            raise ResponseValidationError(str(e))
         except Exception as e:
             raise EngineResponseError(f"Failed to handle response: {e}")
 

--- a/tests/utils/engine_process.py
+++ b/tests/utils/engine_process.py
@@ -35,7 +35,7 @@ class ResponseValidationError(EngineResponseError):
     asserts on response content (the case the in-process retry was designed
     for). Status (non-200) and handler errors continue to raise the parent
     EngineResponseError so they surface immediately and aren't masked by
-    payload.retries.
+    payload.max_attempts.
     """
 
     pass

--- a/tests/utils/multimodal.py
+++ b/tests/utils/multimodal.py
@@ -31,14 +31,14 @@ AUDIO_TEST_URL = (
 
 
 def make_image_payload(
-    expected_response: list[str], *, retries: int = 0
+    expected_response: list[str], *, max_attempts: int = 1
 ) -> ChatPayload:
     """Standard image color-identification payload using MULTIMODAL_IMG_URL.
 
-    ``retries`` controls in-process re-send on validation failure inside
-    ``run_serve_deployment`` — set >0 only for known-flaky multimodal
+    ``max_attempts`` is the cap on validation attempts inside
+    ``run_serve_deployment`` — set >1 only for known-flaky multimodal
     smoke checks (see tests/README.md "Flaky Tests"). The server stays
-    up across retries; only the request/response is re-issued.
+    up across attempts; only the request/response is re-issued.
     """
     return chat_payload(
         [
@@ -56,7 +56,7 @@ def make_image_payload(
         expected_response=expected_response,
         temperature=0.0,
         max_tokens=100,
-        retries=retries,
+        max_attempts=max_attempts,
     )
 
 
@@ -111,6 +111,7 @@ class TopologyConfig:
     directory: Optional[str] = None  # override profile-level directory
     gpu_marker: Optional[str] = None  # override profile-level gpu_marker
     single_gpu: bool = False  # append --single-gpu to script_args
+    two_gpu: bool = False  # append --two-gpu to script_args (epd only)
     env: dict[str, str] = field(default_factory=dict)  # extra env vars for subprocess
 
 
@@ -160,6 +161,8 @@ def make_multimodal_configs(
         script_args = ["--model", profile.name] + profile.extra_vllm_args
         if topo_cfg.single_gpu:
             script_args.append("--single-gpu")
+        if topo_cfg.two_gpu:
+            script_args.append("--two-gpu")
 
         gpu = topo_cfg.gpu_marker or profile.gpu_marker
         marks: list[Any] = [

--- a/tests/utils/multimodal.py
+++ b/tests/utils/multimodal.py
@@ -30,8 +30,16 @@ AUDIO_TEST_URL = (
 # ---------------------------------------------------------------------------
 
 
-def make_image_payload(expected_response: list[str]) -> ChatPayload:
-    """Standard image color-identification payload using MULTIMODAL_IMG_URL."""
+def make_image_payload(
+    expected_response: list[str], *, retries: int = 0
+) -> ChatPayload:
+    """Standard image color-identification payload using MULTIMODAL_IMG_URL.
+
+    ``retries`` controls in-process re-send on validation failure inside
+    ``run_serve_deployment`` — set >0 only for known-flaky multimodal
+    smoke checks (see tests/README.md "Flaky Tests"). The server stays
+    up across retries; only the request/response is re-issued.
+    """
     return chat_payload(
         [
             {
@@ -48,6 +56,7 @@ def make_image_payload(expected_response: list[str]) -> ChatPayload:
         expected_response=expected_response,
         temperature=0.0,
         max_tokens=100,
+        retries=retries,
     )
 
 

--- a/tests/utils/payload_builder.py
+++ b/tests/utils/payload_builder.py
@@ -264,7 +264,7 @@ def chat_payload(
     top_logprobs: Optional[int] = None,
     extra_body: Optional[Dict[str, Any]] = None,
     expected_num_choices: Optional[int] = None,
-    retries: int = 0,
+    max_attempts: int = 1,
 ) -> ChatPayload:
     body: Dict[str, Any] = {
         "messages": [
@@ -297,7 +297,7 @@ def chat_payload(
             expected_log=expected_log or [],
             expected_response=expected_response or [],
             expected_num_choices=expected_num_choices,
-            retries=retries,
+            max_attempts=max_attempts,
         )
     else:
         return ChatPayload(
@@ -306,7 +306,7 @@ def chat_payload(
             expected_log=expected_log or [],
             expected_response=expected_response or [],
             expected_num_choices=expected_num_choices,
-            retries=retries,
+            max_attempts=max_attempts,
         )
 
 

--- a/tests/utils/payload_builder.py
+++ b/tests/utils/payload_builder.py
@@ -264,6 +264,7 @@ def chat_payload(
     top_logprobs: Optional[int] = None,
     extra_body: Optional[Dict[str, Any]] = None,
     expected_num_choices: Optional[int] = None,
+    retries: int = 0,
 ) -> ChatPayload:
     body: Dict[str, Any] = {
         "messages": [
@@ -296,6 +297,7 @@ def chat_payload(
             expected_log=expected_log or [],
             expected_response=expected_response or [],
             expected_num_choices=expected_num_choices,
+            retries=retries,
         )
     else:
         return ChatPayload(
@@ -304,6 +306,7 @@ def chat_payload(
             expected_log=expected_log or [],
             expected_response=expected_response or [],
             expected_num_choices=expected_num_choices,
+            retries=retries,
         )
 
 

--- a/tests/utils/payloads.py
+++ b/tests/utils/payloads.py
@@ -39,6 +39,12 @@ class BasePayload:
     body: Dict[str, Any]
     expected_response: List[Any]  # Can be List[str] or List[List[str]] for alternatives
     expected_log: List[str]
+    # Number of times to send this exact request in sequence. Each call must
+    # pass validation independently. Use >1 for cache/repeatability tests
+    # (e.g., CachedTokensChatPayload asserts a cache hit on the 2nd+ call).
+    # Independent of max_attempts: repeat_count=N means "N independent
+    # successes required"; max_attempts=N means "at least one success out of
+    # N tries".
     repeat_count: int = 1
     timeout: int = 60
 
@@ -52,12 +58,12 @@ class BasePayload:
     system_ports: list[int] = field(default_factory=list)
     # When True, the HTTP request is made with stream=True (for SSE responses).
     http_stream: bool = False
-    # Validation-failure retries inside run_serve_deployment. ``0`` (default)
-    # disables retry — first validation failure surfaces immediately. Set >0
-    # only when the test target is non-deterministic and you've confirmed via
-    # tests/README.md "Flaky Tests" that retry is the right mitigation; the
-    # underlying flakiness still needs a tracking ticket.
-    retries: int = 0
+    # Maximum number of attempts for validation inside run_serve_deployment.
+    # ``1`` (default) means no retry — first validation failure surfaces
+    # immediately. Set >1 only when the test target is non-deterministic and
+    # you've confirmed via tests/README.md "Flaky Tests" that retry is the
+    # right mitigation; the underlying flakiness still needs a tracking ticket.
+    max_attempts: int = 1
 
     def url(self) -> str:
         ep = self.endpoint.lstrip("/")

--- a/tests/utils/payloads.py
+++ b/tests/utils/payloads.py
@@ -52,6 +52,12 @@ class BasePayload:
     system_ports: list[int] = field(default_factory=list)
     # When True, the HTTP request is made with stream=True (for SSE responses).
     http_stream: bool = False
+    # Validation-failure retries inside run_serve_deployment. ``0`` (default)
+    # disables retry — first validation failure surfaces immediately. Set >0
+    # only when the test target is non-deterministic and you've confirmed via
+    # tests/README.md "Flaky Tests" that retry is the right mitigation; the
+    # underlying flakiness still needs a tracking ticket.
+    retries: int = 0
 
     def url(self) -> str:
         ep = self.endpoint.lstrip("/")

--- a/tests/utils/profile_pytest.py
+++ b/tests/utils/profile_pytest.py
@@ -92,6 +92,29 @@ _PLATEAU_MIN_SAMPLES = 3
 _EARLY_STOP_RANGE_MIB = 768  # 0.75 GiB
 
 
+def _parse_gpu_list(s: str) -> list[int]:
+    """Parse "0" or "0,1" or "0, 1, 2" into [0], [0, 1], [0, 1, 2].
+
+    Used for --gpus: a single int (single-GPU profile) or a comma-separated
+    list (multi-GPU profile, e.g. disagg tests with separate encode/PD workers).
+    The list becomes the subprocess CUDA_VISIBLE_DEVICES so the test sees only
+    those GPUs, in that order (CUDA index 0 maps to physical index s[0], etc.).
+    """
+    if not s:
+        raise argparse.ArgumentTypeError("expected non-empty GPU list")
+    try:
+        result = [int(x.strip()) for x in s.split(",") if x.strip() != ""]
+    except ValueError as e:
+        raise argparse.ArgumentTypeError(f"invalid GPU list {s!r}: {e}")
+    if not result:
+        raise argparse.ArgumentTypeError(f"empty GPU list after parsing {s!r}")
+    if any(i < 0 for i in result):
+        raise argparse.ArgumentTypeError(f"GPU indices must be >= 0 (got {s!r})")
+    if len(result) != len(set(result)):
+        raise argparse.ArgumentTypeError(f"duplicate GPU indices in {s!r}")
+    return result
+
+
 def _extract_model_from_markers(pytest_args: list[str]) -> str | None:
     """Extract the model name from @pytest.mark.model(...) via pytest-json-report.
 
@@ -811,7 +834,7 @@ def _find_min_vram(
     recommend: bool = True,
     csv_path: str | None = None,
     kv_bytes_mode: bool = False,
-    gpu_index: int = 0,
+    gpu_indices: list[int] | None = None,
 ) -> int:
     """Binary search to find the minimum VRAM a test needs.
 
@@ -823,24 +846,43 @@ def _find_min_vram(
       TensorRT-LLM: bisects _PROFILE_OVERRIDE_TRTLLM_MAX_TOTAL_TOKENS (tokens)
       All use the same _KV_SAFETY_FACTOR (2x) and the same bisect loop.
       The only differences are env var name, units, display, and bounds.
+
+    Multi-GPU profiling: pass gpu_indices=[0,1,...] for disagg tests where
+    workers pin themselves to separate CUDA indices via the launch script.
+    The subprocess sees those host GPUs in order (CUDA index 0 = first
+    selected). The bisection's KV cap is per-process (applies to whichever
+    worker has a KV cache); peak VRAM is reported per-GPU and the marker
+    output uses the max across selected GPUs (status quo single-GPU
+    behavior).
     """
+    if gpu_indices is None:
+        gpu_indices = [0]
     is_sglang = _is_sglang_test(pytest_args)
     is_trtllm = _is_trtllm_test(pytest_args)
 
     gpu_info = _query_gpu_stats()
     if not gpu_info:
         raise RuntimeError("NVML returned no GPU data")
-    if gpu_index >= len(gpu_info):
-        raise RuntimeError(
-            f"GPU {gpu_index} not found (available: 0..{len(gpu_info) - 1})"
-        )
-    used_mib = gpu_info[gpu_index][1]
-    total_mib = gpu_info[gpu_index][2]
-    free_mib = total_mib - used_mib
+    for idx in gpu_indices:
+        if idx >= len(gpu_info):
+            raise RuntimeError(
+                f"GPU {idx} not found (available: 0..{len(gpu_info) - 1})"
+            )
+    # Per-GPU stats for the selected set. For the initial probe we use the
+    # SMALLEST free across selected GPUs so the kv-bytes cap doesn't OOM
+    # the tightest GPU.
+    selected_used_mib = [gpu_info[i][1] for i in gpu_indices]
+    selected_total_mib = [gpu_info[i][2] for i in gpu_indices]
+    selected_free_mib = [t - u for u, t in zip(selected_used_mib, selected_total_mib)]
+    used_mib = max(selected_used_mib)  # for "hogged" warning, pick worst GPU
+    total_mib = min(selected_total_mib)  # report smallest GPU's size
+    free_mib = min(selected_free_mib)
     total_gib = total_mib / 1024
 
-    # Base env: pin subprocess to the selected GPU
-    _gpu_env = {"CUDA_VISIBLE_DEVICES": str(gpu_index)}
+    # Base env: pin subprocess to the selected GPU(s). Multi-GPU is comma-separated;
+    # the launch script's per-worker CUDA_VISIBLE_DEVICES indices remap to the
+    # subprocess's view (e.g. host GPU 5 becomes CUDA index 0 if it's first in the list).
+    _gpu_env = {"CUDA_VISIBLE_DEVICES": ",".join(str(i) for i in gpu_indices)}
 
     model_name = _extract_model_from_markers(pytest_args)
 
@@ -854,11 +896,28 @@ def _find_min_vram(
     else:
         mode_label = "KV TOKENS (SGLang)"
     print(f"\n--- FIND MINIMUM {mode_label} (binary search) ---")
-    print(f"  GPU total : {total_gib:.1f} GiB")
-    print(
-        f"  GPU free  : {free_mib / 1024:.1f} GiB  "
-        f"(in use: {used_mib / 1024:.1f} GiB)"
-    )
+    if len(gpu_indices) == 1:
+        print(f"  GPU total : {total_gib:.1f} GiB")
+        print(
+            f"  GPU free  : {free_mib / 1024:.1f} GiB  "
+            f"(in use: {used_mib / 1024:.1f} GiB)"
+        )
+    else:
+        print(
+            f"  GPUs      : {gpu_indices} (subprocess sees them as CUDA 0..{len(gpu_indices) - 1})"
+        )
+        for i, gi in enumerate(gpu_indices):
+            t = selected_total_mib[i]
+            u = selected_used_mib[i]
+            f = selected_free_mib[i]
+            print(
+                f"  GPU {gi:>2}    : {t / 1024:.1f} GiB total, "
+                f"{f / 1024:.1f} GiB free (in use: {u / 1024:.1f} GiB)"
+            )
+        print(
+            f"  Min free  : {free_mib / 1024:.1f} GiB  "
+            f"(used for KV-bytes initial probe sizing)"
+        )
     print(f"  Test      : {' '.join(pytest_args)}")
     if model_name:
         print(f"  Model     : {model_name}")
@@ -1348,12 +1407,16 @@ def main(argv: list[str] | None = None) -> int:
         "Outputs @pytest.mark.requested_vllm_kv_cache_bytes(N).",
     )
     parser.add_argument(
-        "--gpu",
         "--gpus",
-        type=int,
-        default=0,
-        help="GPU index to profile on (default: 0). "
-        "Sets CUDA_VISIBLE_DEVICES for the subprocess.",
+        "--gpu",
+        dest="gpus",
+        type=_parse_gpu_list,
+        default=[0],
+        metavar="N[,M,...]",
+        help="GPU index or comma-separated list to profile on (default: 0). "
+        "Sets CUDA_VISIBLE_DEVICES for the subprocess. For disagg multi-worker "
+        "tests where the launch script pins workers to separate GPUs, pass all "
+        "indices (e.g. --gpus 0,1) so the subprocess can see them.",
     )
 
     raw = argv if argv is not None else sys.argv[1:]
@@ -1377,25 +1440,29 @@ def main(argv: list[str] | None = None) -> int:
         if looks_like_test_path and not os.path.exists(test_path):
             parser.error(f"Test path does not exist: {test_path}")
 
-    gpu_idx = args.gpu
+    gpu_indices: list[int] = args.gpus
     gpu_info = _query_gpu_stats()
     if not gpu_info:
         raise RuntimeError("NVML returned no GPU data")
-    if gpu_idx >= len(gpu_info):
-        raise RuntimeError(
-            f"GPU {gpu_idx} not found (available: 0..{len(gpu_info) - 1})"
-        )
+    for idx in gpu_indices:
+        if idx >= len(gpu_info):
+            raise RuntimeError(
+                f"GPU {idx} not found (available: 0..{len(gpu_info) - 1})"
+            )
 
-    used_mib = gpu_info[gpu_idx][1]
-    total_mib = gpu_info[gpu_idx][2]
-    hogged_pct = used_mib / total_mib * 100
-    if hogged_pct > 10:
-        print(
-            f"\nWARNING: GPU {gpu_idx}: {used_mib / 1024:.1f} GiB ({hogged_pct:.0f}%) "
-            f"of GPU memory is already in use! Results may be inaccurate.\n"
-        )
+    for idx in gpu_indices:
+        used_mib_i = gpu_info[idx][1]
+        total_mib_i = gpu_info[idx][2]
+        hogged_pct = used_mib_i / total_mib_i * 100
+        if hogged_pct > 10:
+            print(
+                f"\nWARNING: GPU {idx}: {used_mib_i / 1024:.1f} GiB ({hogged_pct:.0f}%) "
+                f"of GPU memory is already in use! Results may be inaccurate.\n"
+            )
 
-    gpu_env = {"CUDA_VISIBLE_DEVICES": str(gpu_idx)}
+    # Multi-GPU: pass comma-separated list so the launch script's per-worker
+    # CUDA_VISIBLE_DEVICES indices map within the subprocess view.
+    gpu_env = {"CUDA_VISIBLE_DEVICES": ",".join(str(i) for i in gpu_indices)}
 
     if not args.no_find_min_vram:
         return _find_min_vram(
@@ -1406,7 +1473,7 @@ def main(argv: list[str] | None = None) -> int:
             recommend=not args.no_recommend,
             csv_path=args.csv,
             kv_bytes_mode=args.kv_bytes,
-            gpu_index=gpu_idx,
+            gpu_indices=gpu_indices,
         )
 
     model_name = _extract_model_from_markers(pytest_args)

--- a/tests/utils/profile_pytest.py
+++ b/tests/utils/profile_pytest.py
@@ -92,29 +92,6 @@ _PLATEAU_MIN_SAMPLES = 3
 _EARLY_STOP_RANGE_MIB = 768  # 0.75 GiB
 
 
-def _parse_gpu_list(s: str) -> list[int]:
-    """Parse "0" or "0,1" or "0, 1, 2" into [0], [0, 1], [0, 1, 2].
-
-    Used for --gpus: a single int (single-GPU profile) or a comma-separated
-    list (multi-GPU profile, e.g. disagg tests with separate encode/PD workers).
-    The list becomes the subprocess CUDA_VISIBLE_DEVICES so the test sees only
-    those GPUs, in that order (CUDA index 0 maps to physical index s[0], etc.).
-    """
-    if not s:
-        raise argparse.ArgumentTypeError("expected non-empty GPU list")
-    try:
-        result = [int(x.strip()) for x in s.split(",") if x.strip() != ""]
-    except ValueError as e:
-        raise argparse.ArgumentTypeError(f"invalid GPU list {s!r}: {e}")
-    if not result:
-        raise argparse.ArgumentTypeError(f"empty GPU list after parsing {s!r}")
-    if any(i < 0 for i in result):
-        raise argparse.ArgumentTypeError(f"GPU indices must be >= 0 (got {s!r})")
-    if len(result) != len(set(result)):
-        raise argparse.ArgumentTypeError(f"duplicate GPU indices in {s!r}")
-    return result
-
-
 def _extract_model_from_markers(pytest_args: list[str]) -> str | None:
     """Extract the model name from @pytest.mark.model(...) via pytest-json-report.
 
@@ -834,7 +811,7 @@ def _find_min_vram(
     recommend: bool = True,
     csv_path: str | None = None,
     kv_bytes_mode: bool = False,
-    gpu_indices: list[int] | None = None,
+    gpu_index: int = 0,
 ) -> int:
     """Binary search to find the minimum VRAM a test needs.
 
@@ -846,43 +823,24 @@ def _find_min_vram(
       TensorRT-LLM: bisects _PROFILE_OVERRIDE_TRTLLM_MAX_TOTAL_TOKENS (tokens)
       All use the same _KV_SAFETY_FACTOR (2x) and the same bisect loop.
       The only differences are env var name, units, display, and bounds.
-
-    Multi-GPU profiling: pass gpu_indices=[0,1,...] for disagg tests where
-    workers pin themselves to separate CUDA indices via the launch script.
-    The subprocess sees those host GPUs in order (CUDA index 0 = first
-    selected). The bisection's KV cap is per-process (applies to whichever
-    worker has a KV cache); peak VRAM is reported per-GPU and the marker
-    output uses the max across selected GPUs (status quo single-GPU
-    behavior).
     """
-    if gpu_indices is None:
-        gpu_indices = [0]
     is_sglang = _is_sglang_test(pytest_args)
     is_trtllm = _is_trtllm_test(pytest_args)
 
     gpu_info = _query_gpu_stats()
     if not gpu_info:
         raise RuntimeError("NVML returned no GPU data")
-    for idx in gpu_indices:
-        if idx >= len(gpu_info):
-            raise RuntimeError(
-                f"GPU {idx} not found (available: 0..{len(gpu_info) - 1})"
-            )
-    # Per-GPU stats for the selected set. For the initial probe we use the
-    # SMALLEST free across selected GPUs so the kv-bytes cap doesn't OOM
-    # the tightest GPU.
-    selected_used_mib = [gpu_info[i][1] for i in gpu_indices]
-    selected_total_mib = [gpu_info[i][2] for i in gpu_indices]
-    selected_free_mib = [t - u for u, t in zip(selected_used_mib, selected_total_mib)]
-    used_mib = max(selected_used_mib)  # for "hogged" warning, pick worst GPU
-    total_mib = min(selected_total_mib)  # report smallest GPU's size
-    free_mib = min(selected_free_mib)
+    if gpu_index >= len(gpu_info):
+        raise RuntimeError(
+            f"GPU {gpu_index} not found (available: 0..{len(gpu_info) - 1})"
+        )
+    used_mib = gpu_info[gpu_index][1]
+    total_mib = gpu_info[gpu_index][2]
+    free_mib = total_mib - used_mib
     total_gib = total_mib / 1024
 
-    # Base env: pin subprocess to the selected GPU(s). Multi-GPU is comma-separated;
-    # the launch script's per-worker CUDA_VISIBLE_DEVICES indices remap to the
-    # subprocess's view (e.g. host GPU 5 becomes CUDA index 0 if it's first in the list).
-    _gpu_env = {"CUDA_VISIBLE_DEVICES": ",".join(str(i) for i in gpu_indices)}
+    # Base env: pin subprocess to the selected GPU
+    _gpu_env = {"CUDA_VISIBLE_DEVICES": str(gpu_index)}
 
     model_name = _extract_model_from_markers(pytest_args)
 
@@ -896,28 +854,11 @@ def _find_min_vram(
     else:
         mode_label = "KV TOKENS (SGLang)"
     print(f"\n--- FIND MINIMUM {mode_label} (binary search) ---")
-    if len(gpu_indices) == 1:
-        print(f"  GPU total : {total_gib:.1f} GiB")
-        print(
-            f"  GPU free  : {free_mib / 1024:.1f} GiB  "
-            f"(in use: {used_mib / 1024:.1f} GiB)"
-        )
-    else:
-        print(
-            f"  GPUs      : {gpu_indices} (subprocess sees them as CUDA 0..{len(gpu_indices) - 1})"
-        )
-        for i, gi in enumerate(gpu_indices):
-            t = selected_total_mib[i]
-            u = selected_used_mib[i]
-            f = selected_free_mib[i]
-            print(
-                f"  GPU {gi:>2}    : {t / 1024:.1f} GiB total, "
-                f"{f / 1024:.1f} GiB free (in use: {u / 1024:.1f} GiB)"
-            )
-        print(
-            f"  Min free  : {free_mib / 1024:.1f} GiB  "
-            f"(used for KV-bytes initial probe sizing)"
-        )
+    print(f"  GPU total : {total_gib:.1f} GiB")
+    print(
+        f"  GPU free  : {free_mib / 1024:.1f} GiB  "
+        f"(in use: {used_mib / 1024:.1f} GiB)"
+    )
     print(f"  Test      : {' '.join(pytest_args)}")
     if model_name:
         print(f"  Model     : {model_name}")
@@ -1407,16 +1348,12 @@ def main(argv: list[str] | None = None) -> int:
         "Outputs @pytest.mark.requested_vllm_kv_cache_bytes(N).",
     )
     parser.add_argument(
-        "--gpus",
         "--gpu",
-        dest="gpus",
-        type=_parse_gpu_list,
-        default=[0],
-        metavar="N[,M,...]",
-        help="GPU index or comma-separated list to profile on (default: 0). "
-        "Sets CUDA_VISIBLE_DEVICES for the subprocess. For disagg multi-worker "
-        "tests where the launch script pins workers to separate GPUs, pass all "
-        "indices (e.g. --gpus 0,1) so the subprocess can see them.",
+        "--gpus",
+        type=int,
+        default=0,
+        help="GPU index to profile on (default: 0). "
+        "Sets CUDA_VISIBLE_DEVICES for the subprocess.",
     )
 
     raw = argv if argv is not None else sys.argv[1:]
@@ -1440,29 +1377,25 @@ def main(argv: list[str] | None = None) -> int:
         if looks_like_test_path and not os.path.exists(test_path):
             parser.error(f"Test path does not exist: {test_path}")
 
-    gpu_indices: list[int] = args.gpus
+    gpu_idx = args.gpu
     gpu_info = _query_gpu_stats()
     if not gpu_info:
         raise RuntimeError("NVML returned no GPU data")
-    for idx in gpu_indices:
-        if idx >= len(gpu_info):
-            raise RuntimeError(
-                f"GPU {idx} not found (available: 0..{len(gpu_info) - 1})"
-            )
+    if gpu_idx >= len(gpu_info):
+        raise RuntimeError(
+            f"GPU {gpu_idx} not found (available: 0..{len(gpu_info) - 1})"
+        )
 
-    for idx in gpu_indices:
-        used_mib_i = gpu_info[idx][1]
-        total_mib_i = gpu_info[idx][2]
-        hogged_pct = used_mib_i / total_mib_i * 100
-        if hogged_pct > 10:
-            print(
-                f"\nWARNING: GPU {idx}: {used_mib_i / 1024:.1f} GiB ({hogged_pct:.0f}%) "
-                f"of GPU memory is already in use! Results may be inaccurate.\n"
-            )
+    used_mib = gpu_info[gpu_idx][1]
+    total_mib = gpu_info[gpu_idx][2]
+    hogged_pct = used_mib / total_mib * 100
+    if hogged_pct > 10:
+        print(
+            f"\nWARNING: GPU {gpu_idx}: {used_mib / 1024:.1f} GiB ({hogged_pct:.0f}%) "
+            f"of GPU memory is already in use! Results may be inaccurate.\n"
+        )
 
-    # Multi-GPU: pass comma-separated list so the launch script's per-worker
-    # CUDA_VISIBLE_DEVICES indices map within the subprocess view.
-    gpu_env = {"CUDA_VISIBLE_DEVICES": ",".join(str(i) for i in gpu_indices)}
+    gpu_env = {"CUDA_VISIBLE_DEVICES": str(gpu_idx)}
 
     if not args.no_find_min_vram:
         return _find_min_vram(
@@ -1473,7 +1406,7 @@ def main(argv: list[str] | None = None) -> int:
             recommend=not args.no_recommend,
             csv_path=args.csv,
             kv_bytes_mode=args.kv_bytes,
-            gpu_indices=gpu_indices,
+            gpu_index=gpu_idx,
         )
 
     model_name = _extract_model_from_markers(pytest_args)


### PR DESCRIPTION
#### Overview:

Reduce LLaVA `mm_*_llava-1.5-7b` test flakiness by retrying the inference request in-process on `ResponseValidationError`, so the server stays up across attempts.

#### Details:

- Add `BasePayload.max_attempts: int = 1`, plumbed through `chat_payload` and `make_image_payload`
- `run_serve_deployment` retries `send_request` + `check_response` inline on `ResponseValidationError` (a narrow subclass of `EngineResponseError` raised only when `payload.process_response` asserts on response content) with exponential backoff (factor 1.5); status (non-200) and handler errors continue to surface immediately as `EngineResponseError`
- LLaVA tests opt in via `make_image_payload(..., max_attempts=5)`
- `tests/README.md` Flaky Tests section adds sibling subsections: whole-test (`@pytest.mark.flaky`, ~5 min/retry) vs in-process (`payload.max_attempts`, ~10 sec/attempt)
- LLaVA `e_pd` topology: shrunk gpu_4 → gpu_2 with `profiled_vram_gib=19.0` and `requested_vllm_kv_cache_bytes=4_308_848_000`; profiled on 2× RTX 6000 Ada
- `disagg_multimodal_epd.sh` gains a `--two-gpu` mode (encoder+prefill on GPU 0, decode on GPU 1) as a documented option; LLaVA `epd` stays on gpu_4 because GPU 0 peaks at ~30 GB in the 2-GPU layout, exceeding the L4 24 GB tier — 2-GPU profile values kept as commented references
- Does NOT address the separate startup-hang mode (URL 600s + `EngineDeadError` + `oom`/`etcd-error` tags) — that's the runner-poisoning cascade documented in #9042's README

#### Why not `pytest.mark.flaky` for this case?

The LLaVA flake is content-mode: the engine is healthy, but the model occasionally returns junk text (`"The Colors: The Colors: ..."` instead of a color word). With `pytest.mark.flaky`, every retry reruns the whole test — including 5 minutes of engine startup, KV-cache profiling, and worker registration — to reissue a 5-second HTTP request. In-process retry keeps the server up and re-sends just the request (~10 sec/attempt vs ~5 min/attempt, ~30× faster). `pytest.mark.flaky` is still the right tool for whole-process failures (engine OOM, port races, registration timeouts); the README spells out which to use when.

#### `repeat_count` vs `max_attempts`

Orthogonal axes, both now have docstrings on `BasePayload`:
- `repeat_count=N` — send the same request N times in sequence; **each call must pass independently**. Used for cache/replay tests (e.g., `CachedTokensChatPayload` asserts a 2nd-call cache hit).
- `max_attempts=N` — try up to N times, **stop on first pass**. Used for known-flaky outputs.

#### Related PRs

- #9188 — `tests/utils/profile_pytest.py` multi-GPU support, split out for separate review.

#### Where should the reviewer start?

`tests/README.md`, `tests/serve/common.py`, `tests/serve/multimodal_profiles/vllm.py`, `tests/utils/payloads.py`

#### Related Issues:

Closes [OPS-4520](https://linear.app/nvidia/issue/OPS-4520), [OPS-4521](https://linear.app/nvidia/issue/OPS-4521) for the content-mode flake.

/coderabbit profile chill