### PR TITLE
test(revalidate): feat: [vLLM] use model family lookup for encode related handling in EPD use case #8973

### DIFF
--- a/components/src/dynamo/common/__init__.py
+++ b/components/src/dynamo/common/__init__.py
@@ -25,3 +25,5 @@ except Exception:
         __version__ = "0.0.0+unknown"
 
 __all__ = ["__version__", "config_dump", "constants", "utils"]
+
+# revalidate 75f25d64d70 2026-05-01T23:28:04Z

--- a/lib/runtime/src/runtime.rs
+++ b/lib/runtime/src/runtime.rs
@@ -391,3 +391,5 @@ impl Drop for RuntimeType {
         }
     }
 }
+
+// revalidate 75f25d64d70 2026-05-01T23:28:04Z


### PR DESCRIPTION
Re-validating that PR #8973 by GuanLuo did not regress, by re-running against a trivial placebo diff:

```
feat: [vLLM] use model family lookup for encode related handling in EPD use case
```

Branch deleted on green; kept on failure for diagnosis.

Drafts are skipped by CodeRabbit per repo `.coderabbit.yaml`.