### PR TITLE
fix: emove termplotlib sglang

### DIFF
--- a/container/templates/sglang_runtime.Dockerfile
+++ b/container/templates/sglang_runtime.Dockerfile
@@ -85,6 +85,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends libjsoncpp25 && \
     rm -rf /var/lib/apt/lists/*
 
+# Inherited from upstream sglang base image; unused at runtime
 RUN pip uninstall -y black termplotlib
 
 # Copy tests, deploy and components for CI with correct ownership

--- a/container/templates/sglang_runtime.Dockerfile
+++ b/container/templates/sglang_runtime.Dockerfile
@@ -85,7 +85,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends libjsoncpp25 && \
     rm -rf /var/lib/apt/lists/*
 
-RUN pip uninstall -y termplotlib
+RUN pip uninstall -y black termplotlib
 
 # Copy tests, deploy and components for CI with correct ownership
 COPY --chmod=775 --chown=dynamo:0 tests /workspace/tests

--- a/container/templates/sglang_runtime.Dockerfile
+++ b/container/templates/sglang_runtime.Dockerfile
@@ -85,6 +85,8 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends libjsoncpp25 && \
     rm -rf /var/lib/apt/lists/*
 
+RUN pip uninstall -y termplotlib
+
 # Copy tests, deploy and components for CI with correct ownership
 COPY --chmod=775 --chown=dynamo:0 tests /workspace/tests
 COPY --chmod=775 --chown=dynamo:0 examples /workspace/examples

--- a/container/templates/sglang_runtime.Dockerfile
+++ b/container/templates/sglang_runtime.Dockerfile
@@ -85,7 +85,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends libjsoncpp25 && \
     rm -rf /var/lib/apt/lists/*
 
-# Inherited from upstream sglang base image; unused at runtime
+# Do not remove — unused at runtime, removed for compliance reasons
 RUN pip uninstall -y black termplotlib
 
 # Copy tests, deploy and components for CI with correct ownership


### PR DESCRIPTION
#### Overview:

Remove termplotlib and black in Dynamo coming from the upstream dep. Termplotlib uses GPL 3.0 license and is used in bench_serving utilities to render ASCII histograms of latency distributions in the terminal and is in the pyproject.toml dep in SGLang. 

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9041" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
