### PR TITLE
test(sglang): bump embedding_agg-2 timeout to 300s for L4 CI cold-load

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -509,6 +509,29 @@ Long-running tests **must** have an explicit timeout. A test that hangs (e.g., w
 - For Rust, use `#[timeout(Duration::from_secs(300))]` or set a default timeout in `Cargo.toml`.
 - In CI, the workflow also enforces a global job timeout (see workflow YAML files). Per-test timeouts catch problems earlier and with a clearer error message than a blanket job cancellation.
 
+### When NOT to bump pytest timeouts (CI runner-poisoning)
+
+A test failing with `pytest-timeout` or `URL check failed after Ns` is **not always** a "wait longer" problem. On L4 CI runners we've observed a cascade where the *symptom* looks like a timeout but the *cause* is runner-environment exhaustion:
+
+1. Runner runs out of memory (or fills its disk during a heavy test).
+2. The OOM killer (or disk-pressure death) takes out the per-test ephemeral **etcd** instance (dynamic ports like `127.0.0.1:2387`, not the default `2379`).
+3. The Dynamo worker process tries to register endpoints / publish metrics / get a lease and fails repeatedly with:
+   ```
+   dynamo_runtime::transports::etcd::lease: Failed to establish keep-alive stream
+   error=grpc request error: code: 'The service is currently unavailable',
+   message: "tcp connect error",
+   ConnectError("tcp connect error", 127.0.0.1:2387,
+                Os { code: 111, kind: ConnectionRefused, message: "Connection refused" })
+   ```
+4. The worker never finishes startup; the test's URL health check eventually times out (often after 600s), and **every subsequent test on the same runner inherits the poisoned state** and fails in cascading ways.
+
+How to recognize the cascade vs a genuine slow cold-load:
+
+- **Cascade signal:** Multiple unrelated tests in the same job fail (e.g. `disaggregated`, `multi_node_tp_headless`, `lora_aggregated_router` all timing out at exactly 601.7s on the URL check). The CI dashboard auto-categorizes the job with `oom`, `disk-space-error`, and `etcd-error` tags simultaneously.
+- **Genuine cold-load signal:** A single specific test fails deterministically near a clean budget boundary (e.g. exactly 146.79s for a 147s budget) across many runs. Bumping that one test's timeout helps.
+
+If you see the cascade signal, **do not** bump pytest timeouts. The fix lives in CI infra (bigger runners, disk cleanup between tests, per-test runner reset) — not in the test code.
+
 ### Time Budgets
 
 - If a test exceeds its time budget (see [Test Types and Locations](#test-types-and-locations)), profile it with `pytest --durations=0` and consider mocking heavy dependencies, using a smaller model checkpoint, or moving it to a nightly/weekly pipeline with `@pytest.mark.slow`.

--- a/tests/frontend/test_tool_calling_sglang.py
+++ b/tests/frontend/test_tool_calling_sglang.py
@@ -756,6 +756,10 @@ class TestToolCallingProtocol:
         assert result.tool_calls == []
         assert result.content.strip()
 
+    # Known flake: model occasionally emits {"unit": "celcius"} (misspelled) which
+    # fails enum schema validation against ['celsius', 'fahrenheit']. Pure model-output
+    # garbage at temp=0/seed=0; reruns=2 catches most cases but the trailing 4-of-57
+    # are when both retries hit the same misspelling.
     @pytest.mark.flaky(reruns=2, only_rerun=["AssertionError"])
     def test_named_tool_choice_forces_specific_function(
         self, client: OpenAI, model: str

--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -1192,6 +1192,10 @@ def test_kv_router_bindings(
     ],
     indirect=["request_plane", "durable_kv_events"],
 )
+# Known flake (nats_core, file variants): Router and Standalone indexer occasionally
+# disagree on event count by 3-4 events (e.g. "Router 1 has 105 events, Standalone A
+# has 102 events"). Race in event-sync convergence — needs root-cause investigation,
+# not a retry.
 @pytest.mark.timeout(300)
 def test_indexers_sync(
     request,

--- a/tests/serve/test_sglang.py
+++ b/tests/serve/test_sglang.py
@@ -418,7 +418,12 @@ sglang_configs = {
             pytest.mark.requested_sglang_kv_tokens(
                 128
             ),  # KV cache cap (2x safety over min=64)
-            pytest.mark.timeout(147),  # profiled 24s on RTX 6000 Ada
+            # Qwen3-Embedding-4B (~8 GB bf16) cold-loads + warms up in 130-150s
+            # on L4 CI before the first request; the 24s "profiled" figure is
+            # the steady-state run only. 147s left no headroom for startup and
+            # blew up 100% of recent amd64 runs in `_check_url`. 300s aligns
+            # with sibling 4B-class agg configs in this file.
+            pytest.mark.timeout(300),  # profiled 24s on RTX 6000 Ada
             pytest.mark.pre_merge,
             pytest.mark.nightly,
         ],

--- a/tests/serve/test_vllm_omni.py
+++ b/tests/serve/test_vllm_omni.py
@@ -191,6 +191,10 @@ vllm_omni_configs = {
             ),
         ],
     ),
+    # Known flake (post-merge): URL check fails after 600s with "StageDiffusionProc
+    # died during handshake (exit code 143)" — the diffusion child process is
+    # SIGTERM'd before the handshake completes. Bumping the timeout will not fix this;
+    # needs investigation of why StageDiffusionProc is dying.
     "omni_t2v": VLLMOmniConfig(
         name="omni_t2v",
         directory=vllm_dir,


### PR DESCRIPTION
#### Why:

CI investigation surfaced two distinct categories of failures: (1) a real deterministic L4 cold-load fall-off on `embedding_agg-2`, and (2) a runner-environment cascade (OOM + disk-space → etcd dies → workers can't register → tests cascade-fail) that *looks* like timeouts but isn't fixable with timeout bumps. Documenting both so the next person doesn't waste cycles bumping the wrong knob.

#### What:

Real timeout fix:
- `tests/serve/test_sglang.py::test_sglang_deployment[embedding_agg-2]`: 147s → 300s. Qwen3-Embedding-4B cold-loads in 130-150s on L4; the old budget had no headroom and tripped 100% of recent amd64 runs at 146.79s.

Documentation only:
- `tests/README.md`: new "When NOT to bump pytest timeouts" subsection explaining the runner OOM → etcd → cascade pattern and how to distinguish it from a real cold-load.
- `tests/router/test_router_e2e_with_mockers.py::test_indexers_sync`: comment on the Router/Standalone event-count race (nats_core, file variants).
- `tests/frontend/test_tool_calling_sglang.py::test_named_tool_choice_forces_specific_function`: comment on the model emitting misspelled `'celcius'`.
- `tests/serve/test_vllm_omni.py::omni_t2v`: comment on `StageDiffusionProc` handshake death (exit 143) — bumping the timeout doesn't fix it.

#### Where should the reviewer start?

`tests/README.md` (new subsection), then `tests/serve/test_sglang.py` for the timeout bump.

/coderabbit profile chill