### PR TITLE
build(sglang): re-add upstream termplotlib uninstall in runtime image

### DIFF
--- a/container/templates/sglang_runtime.Dockerfile
+++ b/container/templates/sglang_runtime.Dockerfile
@@ -9,6 +9,14 @@
 
 FROM ${RUNTIME_IMAGE}:${RUNTIME_IMAGE_TAG} AS runtime
 
+# Strip GPL-3.0-or-later termplotlib bench helper that the upstream lmsysorg/sglang
+# runtime image installs in its docker/Dockerfile. termplotlib is only used by
+# sglang's bench_serving --plot path, which is gated by importlib.util.find_spec
+# and not exercised by Dynamo. Dropping it keeps the runtime image free of strong
+# copyleft Python packages. v1.0.0 had the same uninstall; it was removed by
+# accident when the runtime image was slimmed in #7850 and needs to stay.
+RUN pip uninstall -y --break-system-packages termplotlib || true
+
 WORKDIR /workspace
 
 # Install NATS and ETCD


### PR DESCRIPTION
## Summary

Re-adds the explicit `pip uninstall -y termplotlib` step that v1.0.0's `sglang_runtime.Dockerfile` carried but that was inadvertently removed in #7850 (`build(sglang): slim runtime image`).

## Why

The upstream `lmsysorg/sglang` runtime image installs `termplotlib` ([sgl-project/sglang `docker/Dockerfile` line 529](https://github.com/sgl-project/sglang/blob/v0.5.10.post1/docker/Dockerfile#L529)) alongside `pandas`, `matplotlib`, and `tabulate`. `termplotlib` is **GPL-3.0-or-later** (confirmed via PyPI metadata and upstream `LICENSE`).

It is only consumed by sglang's `bench_serving --plot` path, and the import is gated by `importlib.util.find_spec("termplotlib")` ([sglang `bench_serving.py` L54](https://github.com/sgl-project/sglang/blob/v0.5.10.post1/python/sglang/bench_serving.py#L54)). Dynamo does not use this code path. v1.0.0's `sglang_runtime.Dockerfile` stripped it for that reason; the slim-image refactor in #7850 dropped the cleanup, so v1.1.0rc9 sglang-runtime now ships a strong-copyleft Python package that is dead code for us.

## How it was caught

The SBOM + attribution pipeline introduced in #8654 was used to diff v1.0.0 against v1.1.0rc9. `termplotlib 0.3.9 GPL-3.0-or-later` shows up only in `sglang-runtime` and only in v1.1.0rc9. Trace:

- Installed at `/usr/local/lib/python3.12/dist-packages/termplotlib-0.3.9.dist-info/`
- Not a PyPI transitive of any of the 298 Python packages in the image (verified via `requires_dist` scan)
- First absent in v1.0.0 because `sglang_runtime.Dockerfile` carried `RUN pip uninstall -y termplotlib`
- Removed by commit `2075eb679f` (PR #7850, Apr 3 2026)

## Change

```dockerfile
FROM ${RUNTIME_IMAGE}:${RUNTIME_IMAGE_TAG} AS runtime

# Strip GPL-3.0-or-later termplotlib bench helper that the upstream lmsysorg/sglang
# runtime image installs in its docker/Dockerfile. termplotlib is only used by
# sglang's bench_serving --plot path, which is gated by importlib.util.find_spec
# and not exercised by Dynamo. Dropping it keeps the runtime image free of strong
# copyleft Python packages. v1.0.0 had the same uninstall; it was removed by
# accident when the runtime image was slimmed in #7850 and needs to stay.
RUN pip uninstall -y --break-system-packages termplotlib || true
```

Placed right after `FROM` so subsequent layers and the final image are clean. `|| true` guards against future upstream sglang images that don't ship it.

## Risk

Negligible. termplotlib is dead code for Dynamo's runtime; Dynamo's `components/src/dynamo/sglang/*` does not import it, and sglang's own runtime paths only touch it from `bench_serving --plot`.

## Test plan

- [ ] Build `sglang-runtime:1.1.0rc10` (or next RC) and confirm `pip show termplotlib` returns "package not found"
- [ ] Re-run the SBOM pipeline (#8654) on the new RC and confirm `termplotlib` is absent from `attribution.csv` and `ATTRIBUTIONS-Python.md` for `sglang-runtime`
- [ ] Verify `sglang-runtime` startup and a basic decode/prefill flow are unaffected (termplotlib is only used behind `bench_serving --plot`)

## Follow-up

A matching change should land on `main` so the next minor release branch starts clean. Tracking separately.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9044" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
