### PR TITLE
fix(snapshot): wire gms restore to failover targets

### DIFF
--- a/deploy/operator/internal/checkpoint/checkpoint_test.go
+++ b/deploy/operator/internal/checkpoint/checkpoint_test.go
@@ -626,7 +626,6 @@ func TestInjectCheckpointIntoPodSpec(t *testing.T) {
 		reader := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(testSnapshotAgentDaemonSet()).Build()
 
 		require.NoError(t, InjectCheckpointIntoPodSpec(context.Background(), reader, testNamespace, podSpec, info, snapshotprotocol.DefaultSeccompLocalhostProfile))
-		require.NoError(t, InjectCheckpointIntoPodSpec(context.Background(), reader, testNamespace, podSpec, info, snapshotprotocol.DefaultSeccompLocalhostProfile))
 		gmsServer := findInitContainer(podSpec, gms.ServerContainerName)
 		require.NotNil(t, gmsServer)
 		loader := findContainer(podSpec, GMSLoaderContainer)
@@ -661,6 +660,72 @@ func TestInjectCheckpointIntoPodSpec(t *testing.T) {
 		assert.Equal(t, "/checkpoints/gms/"+testHash+"/versions/1", info.GMSArtifactDir)
 		assert.Equal(t, []string{"python3", "-m", "gpu_memory_service.cli.server"}, gmsServer.Command)
 		assert.Equal(t, []string{"python3", "-m", "gpu_memory_service.cli.snapshot.loader"}, loader.Command)
+	})
+
+	t.Run("ready gms failover checkpoint injects restore sidecars for every engine", func(t *testing.T) {
+		podSpec := &corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "engine-0", Image: "engine:latest", Command: []string{"python3"}, Args: []string{"-m", "dynamo.vllm"}},
+				{Name: "engine-1", Image: "engine:latest", Command: []string{"python3"}, Args: []string{"-m", "dynamo.vllm"}},
+			},
+		}
+		info := &CheckpointInfo{
+			Enabled:                 true,
+			Ready:                   true,
+			Hash:                    testHash,
+			RestoreTargetContainers: []string{"engine-0", "engine-1"},
+			GPUMemoryService:        &nvidiacomv1alpha1.GPUMemoryServiceSpec{Enabled: true},
+		}
+		reader := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(testSnapshotAgentDaemonSet()).Build()
+
+		require.NoError(t, InjectCheckpointIntoPodSpec(context.Background(), reader, testNamespace, podSpec, info, snapshotprotocol.DefaultSeccompLocalhostProfile))
+		require.NoError(t, InjectCheckpointIntoPodSpec(context.Background(), reader, testNamespace, podSpec, info, snapshotprotocol.DefaultSeccompLocalhostProfile))
+
+		gmsServer := findInitContainer(podSpec, gms.ServerContainerName)
+		require.NotNil(t, gmsServer)
+		assert.Equal(t, "engine:latest", gmsServer.Image)
+		loader := findContainer(podSpec, GMSLoaderContainer)
+		require.NotNil(t, loader)
+		assert.Equal(t, "engine:latest", loader.Image)
+
+		serverCount := 0
+		loaderCount := 0
+		for _, container := range podSpec.InitContainers {
+			if container.Name == gms.ServerContainerName {
+				serverCount++
+			}
+		}
+		for _, container := range podSpec.Containers {
+			switch container.Name {
+			case gms.ServerContainerName:
+				serverCount++
+			case GMSLoaderContainer:
+				loaderCount++
+			}
+		}
+		assert.Equal(t, 1, serverCount)
+		assert.Equal(t, 1, loaderCount)
+
+		for _, name := range []string{"engine-0", "engine-1"} {
+			c := findContainer(podSpec, name)
+			require.NotNil(t, c)
+
+			mounts := map[string]string{}
+			subPaths := map[string]string{}
+			for _, mount := range c.VolumeMounts {
+				mounts[mount.Name] = mount.MountPath
+				subPaths[mount.Name] = mount.SubPath
+			}
+			assert.Equal(t, gms.SharedMountPath, mounts[gms.SharedVolumeName], "%s GMS socket mount", name)
+			assert.Equal(t, snapshotprotocol.SnapshotControlMountPath, mounts[snapshotprotocol.SnapshotControlVolumeName], "%s snapshot control mount", name)
+			assert.Equal(t, name, subPaths[snapshotprotocol.SnapshotControlVolumeName], "%s snapshot control subPath", name)
+
+			env := map[string]string{}
+			for _, item := range c.Env {
+				env[item.Name] = item.Value
+			}
+			assert.Equal(t, gms.SharedMountPath, env[gms.EnvSocketDir], "%s GMS socket env", name)
+		}
 	})
 
 	t.Run("ready gms checkpoint can use separate artifact storage", func(t *testing.T) {

--- a/deploy/operator/internal/checkpoint/checkpoint_test.go
+++ b/deploy/operator/internal/checkpoint/checkpoint_test.go
@@ -782,7 +782,7 @@ func TestInjectCheckpointIntoPodSpec(t *testing.T) {
 			errMsg  string
 		}{
 			{"hash empty and identity nil", testPodSpec(), &CheckpointInfo{Enabled: true, Ready: true}, fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(testSnapshotAgentDaemonSet()).Build(), "identity is nil"},
-			{"no containers", &corev1.PodSpec{}, testInfo(), fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(testSnapshotAgentDaemonSet()).Build(), "restore target container"},
+			{"no containers", &corev1.PodSpec{}, testInfo(), fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(testSnapshotAgentDaemonSet()).Build(), "restore targets"},
 			{"snapshot daemonset missing", testPodSpec(), testInfo(), fake.NewClientBuilder().WithScheme(testScheme()).Build(), "no snapshot-agent daemonset found"},
 		} {
 			t.Run(tc.name, func(t *testing.T) {

--- a/deploy/operator/internal/checkpoint/gms.go
+++ b/deploy/operator/internal/checkpoint/gms.go
@@ -59,21 +59,33 @@ type GMSCheckpointStorage struct {
 // wait for its socket so restore and GMS load can start without kubelet gating.
 func EnsureGMSRestoreSidecars(
 	podSpec *corev1.PodSpec,
-	mainContainer *corev1.Container,
+	targetContainers []*corev1.Container,
 	storage GMSCheckpointStorage,
 ) {
-	if podSpec == nil || mainContainer == nil {
+	if podSpec == nil || len(targetContainers) == 0 {
 		return
 	}
 
+	var sidecarSource *corev1.Container
+	for _, targetContainer := range targetContainers {
+		if targetContainer == nil {
+			continue
+		}
+		if sidecarSource == nil {
+			sidecarSource = targetContainer
+		}
+		gms.EnsureSharedVolume(podSpec, targetContainer)
+	}
+	if sidecarSource == nil {
+		return
+	}
 	podSpec.InitContainers = removeGMSManagedContainers(podSpec.InitContainers, gms.ServerContainerName, GMSLoaderContainer)
-	gms.EnsureSharedVolume(podSpec, mainContainer)
 	ensureGMSCheckpointVolumes(podSpec, storage)
-	gms.EnsureServerSidecar(podSpec, mainContainer)
+	gms.EnsureServerSidecar(podSpec, sidecarSource)
 
-	loader := gms.Container(GMSLoaderContainer, GMSCheckpointLoaderModule, mainContainer.Image)
+	loader := gms.Container(GMSLoaderContainer, GMSCheckpointLoaderModule, sidecarSource.Image)
 	addGMSStorageMounts(&loader, storage)
-	addGMSLocalSSDVolumeMounts(&loader, mainContainer)
+	addGMSLocalSSDVolumeMounts(&loader, sidecarSource)
 	loader.Env = append(loader.Env,
 		corev1.EnvVar{Name: EnvCheckpointDir, Value: storage.ControlDir},
 		PodUIDEnvVar(),
@@ -81,7 +93,7 @@ func EnsureGMSRestoreSidecars(
 	if storage.ArtifactDir != storage.ControlDir {
 		loader.Env = append(loader.Env, corev1.EnvVar{Name: EnvWeightsCheckpointDir, Value: storage.ArtifactDir})
 	}
-	loader.Env = append(loader.Env, gmsCheckpointPassThroughEnvVars(mainContainer)...)
+	loader.Env = append(loader.Env, gmsCheckpointPassThroughEnvVars(sidecarSource)...)
 
 	podSpec.Containers = removeGMSManagedContainers(podSpec.Containers, gms.ServerContainerName, GMSLoaderContainer)
 	podSpec.Containers = append(podSpec.Containers, loader)

--- a/deploy/operator/internal/checkpoint/podspec.go
+++ b/deploy/operator/internal/checkpoint/podspec.go
@@ -117,6 +117,18 @@ func resolvePodInfoContainers(podSpec *corev1.PodSpec, targets []string) []*core
 	return out
 }
 
+func RequireMainContainer(podSpec *corev1.PodSpec) (*corev1.Container, error) {
+	if podSpec == nil {
+		return nil, fmt.Errorf("pod spec is nil")
+	}
+	for i := range podSpec.Containers {
+		if podSpec.Containers[i].Name == commonconsts.MainContainerName {
+			return &podSpec.Containers[i], nil
+		}
+	}
+	return nil, fmt.Errorf("pod spec has no container named %q", commonconsts.MainContainerName)
+}
+
 func InjectCheckpointIntoPodSpec(
 	ctx context.Context,
 	reader ctrlclient.Reader,

--- a/deploy/operator/internal/checkpoint/podspec.go
+++ b/deploy/operator/internal/checkpoint/podspec.go
@@ -88,16 +88,33 @@ func ApplyRestorePodMetadataWithStorageConfig(
 	return nil
 }
 
-func RequireMainContainer(podSpec *corev1.PodSpec) (*corev1.Container, error) {
-	if podSpec == nil {
-		return nil, fmt.Errorf("pod spec is nil")
+// restoreTargetsOrDefault returns the restore target container list for a
+// given CheckpointInfo, defaulting to the single main container for
+// non-failover workloads. Callers are expected to have already confirmed
+// that the info is non-nil, enabled, and Ready.
+func restoreTargetsOrDefault(info *CheckpointInfo) []string {
+	if info != nil && len(info.RestoreTargetContainers) > 0 {
+		return info.RestoreTargetContainers
 	}
-	for i := range podSpec.Containers {
-		if podSpec.Containers[i].Name == commonconsts.MainContainerName {
-			return &podSpec.Containers[i], nil
+	return []string{commonconsts.MainContainerName}
+}
+
+// resolvePodInfoContainer picks the container that should own the pod-info
+// downward-API mount. For pods with one restore target, that is the target
+// itself. For multi-target (failover) pods, we mount pod-info on every
+// target so each engine has the same downward-API view it would have if it
+// were the only workload container in the pod.
+func resolvePodInfoContainers(podSpec *corev1.PodSpec, targets []string) []*corev1.Container {
+	out := make([]*corev1.Container, 0, len(targets))
+	for _, name := range targets {
+		for i := range podSpec.Containers {
+			if podSpec.Containers[i].Name == name {
+				out = append(out, &podSpec.Containers[i])
+				break
+			}
 		}
 	}
-	return nil, fmt.Errorf("pod spec has no container named %q", commonconsts.MainContainerName)
+	return out
 }
 
 func InjectCheckpointIntoPodSpec(
@@ -172,11 +189,19 @@ func injectCheckpointIntoPodSpec(
 	if reader == nil {
 		return fmt.Errorf("checkpoint client is required")
 	}
-	targets := info.RestoreTargetContainers
-	if len(targets) == 0 {
-		targets = []string{commonconsts.MainContainerName}
+	targets := restoreTargetsOrDefault(info)
+	// Every named target must exist in the pod spec. Catching this here
+	// gives a clearer error than the protocol layer's generic "not found".
+	podInfoContainers := resolvePodInfoContainers(podSpec, targets)
+	if len(podInfoContainers) != len(targets) {
+		return fmt.Errorf("checkpoint restore targets %v do not all exist in pod spec", targets)
 	}
-	annotations := map[string]string{
+	// The target-containers annotation lives on the parent pod metadata
+	// (which InjectCheckpointIntoPodSpec does not see directly). For the
+	// pod-spec shaping step we synthesize the target list inline so the
+	// protocol helper shapes every target; the pod-level annotation is
+	// stamped separately by ApplyRestorePodMetadata.
+	syntheticAnnotations := map[string]string{
 		snapshotprotocol.TargetContainersAnnotation: snapshotprotocol.FormatTargetContainers(targets),
 	}
 
@@ -193,7 +218,7 @@ func injectCheckpointIntoPodSpec(
 	}
 	if err := snapshotprotocol.PrepareRestorePodSpec(
 		podSpec,
-		annotations,
+		syntheticAnnotations,
 		storage,
 		seccompProfile,
 		info.Ready,
@@ -202,17 +227,10 @@ func injectCheckpointIntoPodSpec(
 	}
 
 	EnsurePodInfoVolume(podSpec)
-	for _, name := range targets {
-		container := findPodSpecContainer(podSpec, name)
-		if container == nil {
-			return fmt.Errorf("checkpoint restore target %q does not exist in pod spec", name)
-		}
+	for _, container := range podInfoContainers {
 		EnsurePodInfoMount(container)
 	}
 	if info.Ready && info.GPUMemoryService != nil && info.GPUMemoryService.Enabled {
-		if len(info.RestoreTargetContainers) > 0 {
-			return fmt.Errorf("gpuMemoryService checkpoint restore is not supported with multiple restore targets")
-		}
 		gmsStorage, err := ResolveGMSCheckpointStorage(storage, info.GPUMemoryService)
 		if err != nil {
 			return err
@@ -221,24 +239,8 @@ func injectCheckpointIntoPodSpec(
 		if info.GPUMemoryService.Mode == nvidiacomv1alpha1.GMSModeInterPod {
 			return nil
 		}
-		mainContainer := findPodSpecContainer(podSpec, commonconsts.MainContainerName)
-		if mainContainer == nil {
-			return fmt.Errorf("gpuMemoryService enabled but no container named %q found in pod spec", commonconsts.MainContainerName)
-		}
-		EnsureGMSRestoreSidecars(podSpec, mainContainer, gmsStorage)
+		EnsureGMSRestoreSidecars(podSpec, podInfoContainers, gmsStorage)
 	}
 
-	return nil
-}
-
-func findPodSpecContainer(podSpec *corev1.PodSpec, name string) *corev1.Container {
-	if podSpec == nil {
-		return nil
-	}
-	for i := range podSpec.Containers {
-		if podSpec.Containers[i].Name == name {
-			return &podSpec.Containers[i]
-		}
-	}
 	return nil
 }

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/checkpoint"
 	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
+	gms "github.com/ai-dynamo/dynamo/deploy/operator/internal/gms"
 	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	grovev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	"github.com/google/go-cmp/cmp"
@@ -7483,6 +7484,11 @@ func TestGenerateGrovePodCliqueSet_GMSPodsAreNotCheckpointTargets(t *testing.T) 
 						Enabled: true,
 						Mode:    v1alpha1.GMSModeInterPod,
 					},
+					Failover: &v1alpha1.FailoverSpec{
+						Enabled:    true,
+						Mode:       v1alpha1.GMSModeInterPod,
+						NumShadows: 2,
+					},
 					Checkpoint: &v1alpha1.ServiceCheckpointConfig{Enabled: true},
 				},
 			},
@@ -7605,6 +7611,11 @@ func findContainerInClique(t *testing.T, clique *grovev1alpha1.PodCliqueTemplate
 			return &clique.Spec.PodSpec.Containers[i]
 		}
 	}
+	for i := range clique.Spec.PodSpec.InitContainers {
+		if clique.Spec.PodSpec.InitContainers[i].Name == name {
+			return &clique.Spec.PodSpec.InitContainers[i]
+		}
+	}
 	t.Fatalf("container %q not found in clique %q", name, clique.Name)
 	return nil
 }
@@ -7630,7 +7641,14 @@ func TestGenerateGrovePodCliqueSet_IntraPodFailoverCheckpointTargets(t *testing.
 					Resources: &v1alpha1.Resources{
 						Limits: &v1alpha1.ResourceItem{GPU: "1"},
 					},
+					ExtraPodSpec: &v1alpha1.ExtraPodSpec{
+						MainContainer: &corev1.Container{Image: "engine:latest"},
+					},
 					Failover: &v1alpha1.FailoverSpec{
+						Enabled: true,
+						Mode:    v1alpha1.GMSModeIntraPod,
+					},
+					GPUMemoryService: &v1alpha1.GPUMemoryServiceSpec{
 						Enabled: true,
 						Mode:    v1alpha1.GMSModeIntraPod,
 					},
@@ -7686,6 +7704,7 @@ func TestGenerateGrovePodCliqueSet_IntraPodFailoverCheckpointTargets(t *testing.
 			Ready:                   true,
 			Hash:                    "abc123def4567890",
 			RestoreTargetContainers: IntraPodFailoverEngineContainerNames(),
+			GPUMemoryService:        &v1alpha1.GPUMemoryServiceSpec{Enabled: true, Mode: v1alpha1.GMSModeIntraPod},
 		},
 	}
 
@@ -7701,19 +7720,36 @@ func TestGenerateGrovePodCliqueSet_IntraPodFailoverCheckpointTargets(t *testing.
 		sawDecode = true
 		assert.Equal(t, "engine-0,engine-1", clique.Annotations[snapshotprotocol.TargetContainersAnnotation],
 			"clique %q must carry snapshot-target-containers=engine-0,engine-1", clique.Name)
+		gmsServer := findContainerInClique(t, clique, gms.ServerContainerName)
+		assert.Nil(t, gmsServer.StartupProbe, "restore GMS server should not gate target container startup")
+		loader := findContainerInClique(t, clique, checkpoint.GMSLoaderContainer)
+		assert.Equal(t, []string{"python3", "-m", checkpoint.GMSCheckpointLoaderModule}, loader.Command)
 		for _, engineName := range IntraPodFailoverEngineContainerNames() {
 			c := findContainerInClique(t, clique, engineName)
 			assert.Equal(t, []string{"sleep", "infinity"}, c.Command,
 				"%s in clique %q must be shaped as a snapshot restore target", engineName, clique.Name)
+			env := map[string]string{}
+			for _, item := range c.Env {
+				env[item.Name] = item.Value
+			}
+			assert.Equal(t, gms.SharedMountPath, env[gms.EnvSocketDir],
+				"%s in clique %q must receive the GMS socket directory", engineName, clique.Name)
 			foundMount := false
+			foundGMSMount := false
 			for _, m := range c.VolumeMounts {
 				if m.Name == snapshotprotocol.SnapshotControlVolumeName {
 					foundMount = true
 					assert.Equal(t, engineName, m.SubPath,
 						"%s in clique %q must have its own subPath on the control volume", engineName, clique.Name)
 				}
+				if m.Name == gms.SharedVolumeName {
+					foundGMSMount = true
+					assert.Equal(t, gms.SharedMountPath, m.MountPath,
+						"%s in clique %q must mount the GMS socket volume", engineName, clique.Name)
+				}
 			}
 			assert.True(t, foundMount, "%s in clique %q must mount the snapshot-control volume", engineName, clique.Name)
+			assert.True(t, foundGMSMount, "%s in clique %q must mount the GMS socket volume", engineName, clique.Name)
 		}
 	}
 	assert.True(t, sawDecode, "test setup should produce the decode engine clique")


### PR DESCRIPTION
## Summary

Small operator follow-up stacked on #8900 that makes GMS restore injection use the resolved snapshot restore target containers instead of assuming the target is always `main`.

- Uses resolved snapshot restore target containers when injecting GMS restore sidecars.
- Applies GMS shared socket wiring to every restore target, including intra-pod failover engines such as `engine-0` and `engine-1`.
- Extends operator tests for regular/inter-pod `main` targets and intra-pod `engine-0,engine-1` targets with GMS restore sidecars.
- Rebased on the updated #8833/#8900 stack and adjusted the tests/imports for the current restore-target helper names.

## Validation

- `cd deploy/operator && CGO_ENABLED=0 go test -count=1 ./internal/checkpoint ./internal/dynamo`
- `cd deploy/operator && CGO_ENABLED=0 go test -count=1 -skip TestControllers ./internal/checkpoint/... ./internal/dynamo/... ./internal/controller/...`
- `cd deploy/operator && go test ./internal/webhook/validation ./internal/dynamo ./internal/checkpoint ./internal/gms -count=1` on the final rebased stack.
- Included in the rebuilt-stack nscale validation for vLLM/SGLang Qwen3-0.6B snapshot+GMS restore and Qwen2.5-72B default-PVC timing.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9045" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced checkpoint injection system to support GPU Memory Service failover restore operations for multiple target containers simultaneously, enabling more flexible deployment configurations.

* **Tests**
  * Added comprehensive test coverage for GMS failover checkpoint injection with multiple engine containers, verifying correct sidecar injection, mount configuration, and environment variable setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



## 2026-05-12 Final Stack Rebuild

No additional code changes were needed in this layer after the latest restack. The rebuilt top-stack validation from commit `f5c920d1166b` exercised the GMS restore-side injection path for both vLLM and SGLang `Qwen/Qwen3-0.6B` snapshot+GMS restores.


## 2026-05-13 Restack Update

Rebased and pushed this layer at `4da679ed5ca` above the decoupled #8833/#8900 stack. No additional code changes were required in this PR for the GMS-agnostic snapshot-agent change; the existing restore-target wiring remains stacked cleanly above the saver-exit and RO-timeout-default changes.

Included in the rebuilt-stack validation from top commit `42f4cccb5e6f`:

- vLLM `Qwen/Qwen3-0.6B` snapshot+intra-pod GMS restore passed.
- SGLang `Qwen/Qwen3-0.6B` snapshot+intra-pod GMS restore passed.
- Snapshot-agent logs had no GMS sentinel wait path; restore target annotations still reached `nvidia.com/snapshot-restore-status.main=completed`.


## 2026-05-14 Validation Update

Fixed the #9045 restack helper regression by restoring `checkpoint.RequireMainContainer` and updating the matching checkpoint test expectation. Rebuilt and pushed fresh vLLM runtime, vLLM placeholder, snapshot-agent, and operator images from `16d0b40a8143`; placeholder and snapshot-agent used `CRIU_REPO=https://github.com/dfeigin-nv/criu.git` and `CRIU_REF=add-aio-and-parallel-memfd`.

Validation on nscale DRA node `s2877` passed for vLLM `Qwen/Qwen3-0.6B`, TP=1, snapshot+intra-pod GMS:

- Checkpoint `9cd43f4e6e533816` reached `Ready`; GMS save completed in `37.48s`; snapshot-agent checkpoint wall from detection was `6.652s`.
- Restore DGD reached `successful`; GMS load completed in `1.60s`; `nsrestore` total was `4.846s`.
- `/v1/models` returned the restored model and `/v1/chat/completions` returned `PR9045_QWEN3_GMS_OK`.

Observed non-blocking issue: restored vLLM logged `EngineCoreProc.get_kv_cache_group_metadata` missing and fell back to `cache_config.block_size`; readiness and inference still passed.
