### PR TITLE
fix: parse_cpulist accepts empty cpulist for memory-only NUMA nodes

### DIFF
--- a/lib/memory/src/numa/topology.rs
+++ b/lib/memory/src/numa/topology.rs
@@ -113,7 +113,16 @@ impl NumaTopology {
 fn parse_cpulist(cpulist: &str) -> Result<Vec<usize>, String> {
     let mut cpus = Vec::new();
 
+    // Empty cpulist = memory-only NUMA node (no CPUs), valid on Grace/GB200
+    if cpulist.is_empty() {
+        return Ok(cpus);
+    }
+
     for part in cpulist.split(',') {
+        let part = part.trim();
+        if part.is_empty() {
+            continue;
+        }
         if part.contains('-') {
             // Range: "0-15"
             let range: Vec<&str> = part.split('-').collect();
@@ -233,9 +242,23 @@ mod tests {
 
     #[test]
     fn test_parse_cpulist_empty() {
-        // Edge case: empty cpulist
-        let result = parse_cpulist("");
-        assert!(result.is_err() || result.unwrap().is_empty());
+        // Memory-only NUMA nodes have empty cpulist (e.g., GB200 nodes 2-33)
+        let cpus = parse_cpulist("").unwrap();
+        assert!(cpus.is_empty());
+    }
+
+    #[test]
+    fn test_parse_cpulist_gb200_grace() {
+        // GB200: 34 NUMA nodes, only node0 and node1 have CPUs
+        let cpus0 = parse_cpulist("0-71").unwrap();
+        assert_eq!(cpus0.len(), 72);
+
+        let cpus1 = parse_cpulist("72-143").unwrap();
+        assert_eq!(cpus1.len(), 72);
+
+        // Nodes 2-33: memory-only, empty cpulist
+        let cpus_empty = parse_cpulist("").unwrap();
+        assert!(cpus_empty.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
  Memory-only NUMA nodes (e.g., GB200 nodes 2-33) report an empty cpulist in /sys/devices/system/node/node*/cpulist. The current parser splits on "," and tries to parse each part as a CPU ID, failing on the empty string and aborting NUMA topology discovery for the whole system.

Short-circuit empty input to an empty Vec, and trim/skip empty parts inside the split loop so trailing commas or whitespace can't trip the parser. Update the existing empty-cpulist test to expect success and add a GB200-specific test covering the first two CPU-bearing nodes plus the empty memory-only nodes.

#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9046" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
