### PR TITLE
fix(aws.Dockerfile): install gdrcopy userspace libs

### DIFF
--- a/container/templates/aws.Dockerfile
+++ b/container/templates/aws.Dockerfile
@@ -66,6 +66,13 @@ RUN --mount=from=wheel_builder,source=/usr/local/libfabric,target=/tmp/libfabric
         echo "[aws] libfabric overlay: skipped (EFA stock ${EFA_LIBFABRIC_RAW:-unknown} >= ${REF_VER})"; \
     fi
 
+{% if device == "cuda" %}
+# Reuse the gdrcopy userspace libs built in wheel_builder. /usr/lib64 is not on
+# the default ldconfig path on Ubuntu, so register it like dev.Dockerfile does.
+COPY --from=wheel_builder /usr/lib64/libgdrapi.so* /usr/lib64/
+RUN echo "/usr/lib64" >> /etc/ld.so.conf.d/gdrcopy.conf && ldconfig
+{% endif %}
+
 {% if framework == "trtllm" %}
 # After the upstream mesonpy refactor, libplugin_LIBFABRIC.so lands under the
 # Dynamo venv while the rest of the NIXL plugin set (GDS/UCX/POSIX) remains at


### PR DESCRIPTION
Closes #9030.

UCX dlopens libgdrapi.so.2 at runtime for GPU-direct RDMA on EFA. Without it UCX fails to initialize. The kernel module is provided by the host (gdrdrv-dkms), so we just build the userspace lib from upstream gdrcopy v2.4.4.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9049" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * AWS container template updated to include NVIDIA gdrcopy (version 2.4.4) for enhanced GPU peer-to-peer memory access and direct data transfer capabilities in GPU-accelerated computing workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->