### PR TITLE
fix(gpt-oss): empty reasoning_content with bounded KV cache

### DIFF
--- a/lib/llm/PREPROCESSOR_CASES.md
+++ b/lib/llm/PREPROCESSOR_CASES.md
@@ -1,0 +1,166 @@
+# Frontend Preprocessor — Per-Parser Decisions
+
+Reference taxonomy for the per-request decisions the OpenAI preprocessor
+makes based on the configured tool-call / reasoning parser. Each case
+below names one decision the preprocessor takes; the **per-parser truth
+table** at the bottom records what each parser expects.
+
+This is the preprocessor-layer counterpart to
+[`lib/parsers/TEST_CASES.md`](../parsers/TEST_CASES.md). Parsers are
+unit-tested for output correctness on input shapes (CASE.\*); the
+preprocessor is unit-tested for *whether the right config knob fires for
+the right (parser, request) pair* (PRE.\*). Most preprocessor bugs are
+"forgot to add parser X to the truth table" — a parser ships, the
+preprocessor doesn't know about it, the new path silently runs with a
+wrong default and the parser sees malformed input.
+
+When adding a new parser, walk every PRE.\* row in the truth table below
+and decide the value explicitly (including `N/A`). Don't silently inherit
+the default — write the row.
+
+---
+
+## PRE.1 — `skip_special_tokens` default
+
+**Function:** `OpenAIPreprocessor::parser_requires_special_tokens`
+
+vLLM defaults to `skip_special_tokens=true` when decoding tokens to text.
+For parsers whose grammar markers (`<|channel|>`, `<|message|>`,
+`<|tool_calls_section_begin|>`, `<|think|>`, etc.) are *single special
+tokens* in the model's vocabulary, this strips the markers from the
+decoded text and the parser sees plain prose with no structure to match.
+
+The preprocessor flips the default to `false` for parsers whose markers
+are special tokens. Caller can still override explicitly via
+`output_options.skip_special_tokens`.
+
+**Wrong value silently produces:** empty `reasoning_content` /
+`tool_calls` even when the model emitted them correctly. No error path.
+This is exactly the failure mode that broke `test_reasoning_effort` for
+gpt-oss before the harmony/gpt_oss whitelist landed.
+
+## PRE.2 — Per-request reasoning gate
+
+**Function:** `OpenAIPreprocessor::is_reasoning_disabled_by_request`
+
+Some parsers should be turned **off** based on `chat_template_args` in
+the request. The exact arg name and value varies per family:
+
+- `kimi_k25` — `thinking: false`
+- `nemotron_nano` / `nemotron3` — `enable_thinking: false` OR
+  `force_nonempty_content: true`
+- `deepseek_r1` / `deepseek_v4` — `thinking: false` OR
+  `thinking_mode: "chat"` (matches V4 formatter's `resolve_thinking_mode`
+  convention; keeps parser and prompt synchronized)
+- `gemma4` — `enable_thinking: false`
+
+When the gate fires, no reasoning parser runs; the model output is
+treated as plain content.
+
+**Wrong value silently produces:** mislabeled `reasoning_content`
+(content emitted as reasoning when reasoning is actually off, or vice
+versa). Per-parser correctness — depends on each model's chat template
+behavior.
+
+## PRE.3 — Force-reasoning + tool-continuation interaction
+
+**Function:** inline gate in
+`OpenAIPreprocessor::postprocessor_parsing_stream`
+
+When the chat template injects a reasoning start token (e.g. `<think>`)
+into the prompt, the preprocessor sets `prompt_injected_reasoning=true`
+so the parser starts in reasoning mode immediately. Combined with the
+`last_is_tool` gate:
+
+- `last_is_tool == true` → force-reasoning **off** (current behavior).
+  Rationale: tool-continuation turns produce the final user-facing
+  answer directly from the tool result; force-reasoning would mislabel
+  that final answer as `reasoning_content`. Matches SGLang's observed
+  Kimi K2.5 behavior.
+- `last_is_tool == false` → force-reasoning honored.
+
+**Tension:** DSv4 disagrees with this gate — the V4 formatter *seeds*
+`<think>` into the prompt after a merged tool result, so DSv4 needs
+force-reasoning **on** even when `last_is_tool`. Tracked in
+[#8901](https://github.com/ai-dynamo/dynamo/pull/8901). Resolution
+likely requires per-parser handling of this gate (mirror PRE.2's
+match-on-parser shape) rather than a global behavior.
+
+**Wrong value silently produces:** `</think>` literal leaking into
+`content` (DSv4) or final answer mislabeled as reasoning (Kimi K2.5).
+
+## PRE.4 — `tool_choice` forcing guided JSON
+
+**Function:** inline gate in
+`OpenAIPreprocessor::postprocessor_parsing_stream`
+
+`tool_choice = required | named` forces the backend into guided
+decoding, which constrains output to bare JSON with no reasoning
+wrapper. The preprocessor turns the reasoning parser off for these cases.
+
+**Wrong value silently produces:** parsers that inject `<think>`
+unconditionally (e.g. `minimax_append_think`) contaminate the tool-call
+JSON fed into the jail.
+
+## PRE.5 — `ignore_eos` / EOS token ids
+
+**Function:** `stop_conditions.apply_ignore_eos`
+
+When `ignore_eos = true` the preprocessor does not propagate the model's
+EOS token ids; otherwise it does. Universal — not parser-specific —
+included here as a baseline reminder that the preprocessor owns this.
+
+---
+
+## Per-parser truth table
+
+Walk this table when adding a new parser. **`?`** means unverified —
+if you know the answer, fill it in.
+
+| Parser | PRE.1 needs special tokens | PRE.2 reasoning gate | PRE.3 force-reasoning override on tool-continuation | Notes |
+|---|---|---|---|---|
+| `harmony` (tool) / `gpt_oss` (reasoning) | **YES** | — | — | Channels: `<\|channel\|>analysis<\|message\|>...<\|end\|>`. gpt-oss-20B/120B. |
+| `gemma4` (tool + reasoning) | **YES** | `enable_thinking=false` | — | `<\|think\|>...<\|/think\|>`. |
+| `kimi_k25` (reasoning) | ? — markers are `<\|tool_calls_section_*\|>`, likely YES | `thinking=false` | OFF when last_is_tool (currently global) | Special-token markers in K2/K2.5/K2.6. |
+| `deepseek_v3` (tool) | ? — Unicode markers (`<｜tool_calls_section_begin｜>`); likely YES | — | — | DSv3 grammar. |
+| `deepseek_v3_2` / `deepseek_v4` (DSML) | ? — DSML markers (`<｜DSML｜tool_calls>`); likely YES | `thinking=false` / `thinking_mode=chat` | **NEEDS ON** even when last_is_tool (V4 formatter seeds `<think>`); see #8901 | DSv3.2 / DSv4 grammar. |
+| `deepseek_r1` (reasoning) | NO (uses plain `<think>`) | `thinking=false` | — | DeepSeek-R1. |
+| `nemotron_deci` (tool) / `nemotron_nano` / `nemotron3` (reasoning) | ? | `enable_thinking=false` / `force_nonempty_content=true` (nano/n3 only) | — | Nemotron family. |
+| `llama3_json` (tool) | ? — `<\|python_tag\|>` is a special token, likely YES | — | — | Llama 3.x. |
+| `hermes` (tool) | NO | — | — | Plain XML `<tool_call>...</tool_call>`. |
+| `qwen3_coder` (tool) | NO | — | — | Plain XML `<tool_call><function=...>`. |
+| `pythonic` (tool) | NO | — | — | Python list literal. |
+| `mistral` (tool) | NO | — | — | `[TOOL_CALLS]` plain text. |
+| `phi4` (tool) | NO | — | — | `functools[...]` plain text. |
+| `minimax_m2` (tool) / `minimax_append_think` (reasoning) | NO | — | OFF on `tool_choice=required/named` (universal, PRE.4) | XML markers, plain text. |
+| `glm47` (tool) | NO | — | — | Plain XML. |
+| `jamba` (tool) | NO | — | — | `<tool_calls>` plain text wrapper. |
+| `qwen` (reasoning, basic `<think>`) | NO | — | — | Plain `<think>...</think>`. |
+
+---
+
+## Adding a new parser — checklist
+
+1. PRE.1: does the parser's grammar use markers that the model's
+   tokenizer treats as special tokens? Run a quick sanity check: encode
+   the marker string with the model's tokenizer; if it returns a single
+   token id from the special-token range, **add the parser to
+   `parser_requires_special_tokens`**.
+2. PRE.2: does the parser need to be silenced based on
+   `chat_template_args`? Look at the model's chat template: does it
+   gate emission of the parser's markers on a flag like `enable_thinking`
+   / `thinking` / `thinking_mode`? If yes, add the case to
+   `is_reasoning_disabled_by_request`.
+3. PRE.3: when the previous turn is a tool call, does the model
+   re-enter reasoning (DSv4) or skip straight to answer (Kimi K2.5)?
+   Document explicitly in this table; current code uses a global gate
+   that may need to become parser-specific (see #8901).
+4. PRE.4: confirm `tool_choice = required/named` doesn't conflict with
+   the parser's behavior. Universal default is to disable reasoning
+   parsing in this case.
+5. Add a row to the truth table above with explicit values. `N/A` is
+   acceptable but must be stated, not omitted.
+6. Add a unit test in `lib/llm/src/preprocessor.rs`'s `#[cfg(test)] mod`
+   that asserts `parser_requires_special_tokens(...)` returns the
+   expected value for the new parser. Table-driven, one row per parser
+   in this doc.

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -1852,6 +1852,24 @@ mod tests {
             ),
             (Some("hermes"), None, false, "hermes → not required"),
             (
+                Some("harmony"),
+                None,
+                true,
+                "harmony tool-call only → required",
+            ),
+            (
+                None,
+                Some("gpt_oss"),
+                true,
+                "gpt_oss reasoning only → required",
+            ),
+            (
+                Some("harmony"),
+                Some("gpt_oss"),
+                true,
+                "harmony + gpt_oss paired → required",
+            ),
+            (
                 Some("kimi_k2"),
                 Some("kimi_k25"),
                 false,

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -1817,6 +1817,7 @@ mod strip_tests {
 mod tests {
     use super::*;
 
+    /// PRE.1 — `skip_special_tokens` default. See `lib/llm/PREPROCESSOR_CASES.md`.
     #[test]
     fn test_parser_requires_special_tokens() {
         let cases: &[(Option<&str>, Option<&str>, bool, &str)] = &[
@@ -1886,6 +1887,7 @@ mod tests {
         }
     }
 
+    /// PRE.2 — Per-request reasoning gate. See `lib/llm/PREPROCESSOR_CASES.md`.
     #[test]
     fn test_is_reasoning_disabled_by_request() {
         let thinking_true = {

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -1276,8 +1276,16 @@ impl OpenAIPreprocessor {
         tool_call_parser: Option<&str>,
         reasoning_parser: Option<&str>,
     ) -> bool {
-        matches!(tool_call_parser, Some("gemma4") | Some("gemma-4"))
-            || matches!(reasoning_parser, Some("gemma4") | Some("gemma-4"))
+        // gpt-oss / harmony parsers consume `<|channel|>analysis<|message|>...<|end|>`
+        // markers; without them the parser silently produces empty
+        // reasoning_content. Same shape as gemma4's `<|think|>` markers.
+        matches!(
+            tool_call_parser,
+            Some("gemma4") | Some("gemma-4") | Some("harmony")
+        ) || matches!(
+            reasoning_parser,
+            Some("gemma4") | Some("gemma-4") | Some("gpt_oss")
+        )
     }
 
     /// Check if reasoning parsing should be disabled based on per-request parameters.

--- a/lib/parsers/src/reasoning/gpt_oss_parser.rs
+++ b/lib/parsers/src/reasoning/gpt_oss_parser.rs
@@ -18,8 +18,18 @@ static GLOBAL_HARMONY_GPTOSS_ENCODING: OnceLock<Result<HarmonyEncoding, anyhow::
     OnceLock::new();
 
 fn get_harmony_encoding() -> &'static Result<HarmonyEncoding, anyhow::Error> {
-    GLOBAL_HARMONY_GPTOSS_ENCODING
-        .get_or_init(|| load_harmony_encoding(HarmonyEncodingName::HarmonyGptOss))
+    GLOBAL_HARMONY_GPTOSS_ENCODING.get_or_init(|| {
+        // load_harmony_encoding internally constructs a reqwest::blocking::Client,
+        // which builds and drops a Tokio Runtime. Dropping a Runtime from inside
+        // an async context (e.g. when this is called for the first time during
+        // an HTTP request handler) panics with "Cannot drop a runtime in a
+        // context where blocking is not allowed". Run the load on a fresh OS
+        // thread so the inner Runtime is dropped outside any async context.
+        // The init runs at most once per process via OnceLock.
+        std::thread::spawn(|| load_harmony_encoding(HarmonyEncodingName::HarmonyGptOss))
+            .join()
+            .unwrap_or_else(|_| Err(anyhow::anyhow!("harmony encoding loader thread panicked")))
+    })
 }
 
 pub struct GptOssReasoningParser {

--- a/tests/frontend/test_vllm.py
+++ b/tests/frontend/test_vllm.py
@@ -99,7 +99,14 @@ class VllmWorkerProcess(ManagedProcess):
             "32768",
         ]
 
+        # In serial runs the parallel-GPU scheduler isn't injecting this env;
+        # fall back to the test's @requested_vllm_kv_cache_bytes marker so the
+        # advertised profiled_vram_gib matches what the worker actually allocates.
         kv_bytes = os.environ.get("_PROFILE_OVERRIDE_VLLM_KV_CACHE_BYTES")
+        if not kv_bytes:
+            kv_mark = request.node.get_closest_marker("requested_vllm_kv_cache_bytes")
+            if kv_mark:
+                kv_bytes = str(int(kv_mark.args[0]))
         if kv_bytes:
             command.extend(
                 [
@@ -306,10 +313,12 @@ def test_reasoning_effort(
         )
 
 
-# TODO: profile with --kv-bytes once pre-existing 500 panic is fixed (JoinError::Panic "Cannot drop a runtime in a context where blocking is not allowed")
-# TODO: re-enable GPU-parallel scheduling with profiled_vram_gib(20.4)
-# once this has a bounded --kv-bytes profile.
-@pytest.mark.timeout(113)  # 3x observed 37.4s wall time
+# Measured using: tests/utils/profile_pytest.py tests/frontend/test_vllm.py::test_tool_calling
+@pytest.mark.profiled_vram_gib(18.7)  # actual nvidia-smi peak
+@pytest.mark.requested_vllm_kv_cache_bytes(
+    1_912_759_000
+)  # KV cache cap (2x safety over min=956_379_136)
+@pytest.mark.timeout(271)  # 6x observed 45.1s avg wall time (9 runs)
 @pytest.mark.post_merge
 def test_tool_calling(
     request, start_services: ServicePorts, predownload_models
@@ -351,10 +360,12 @@ def test_tool_calling(
     ), "Expected get_current_weather tool to be called"
 
 
-# TODO: profile with --kv-bytes once pre-existing 500 panic is fixed (JoinError::Panic "Cannot drop a runtime in a context where blocking is not allowed")
-# TODO: re-enable GPU-parallel scheduling with profiled_vram_gib(20.4)
-# once this has a bounded --kv-bytes profile.
-@pytest.mark.timeout(115)  # 3x observed 38.1s wall time
+# Measured using: tests/utils/profile_pytest.py tests/frontend/test_vllm.py::test_tool_calling_second_round
+@pytest.mark.profiled_vram_gib(18.7)  # actual nvidia-smi peak
+@pytest.mark.requested_vllm_kv_cache_bytes(
+    1_912_759_000
+)  # KV cache cap (2x safety over min=956_379_136)
+@pytest.mark.timeout(265)  # 6x observed 44.1s avg wall time (9 runs)
 @pytest.mark.nightly
 def test_tool_calling_second_round(
     request, start_services: ServicePorts, predownload_models
@@ -418,10 +429,12 @@ def test_tool_calling_second_round(
     ), "Expected response to include temperature information from tool call result (20°C)"
 
 
-# TODO: profile with --kv-bytes once pre-existing 500 panic is fixed (JoinError::Panic "Cannot drop a runtime in a context where blocking is not allowed")
-# TODO: re-enable GPU-parallel scheduling with profiled_vram_gib(20.4)
-# once this has a bounded --kv-bytes profile.
-@pytest.mark.timeout(131)  # 3x observed 43.4s wall time
+# Measured using: tests/utils/profile_pytest.py tests/frontend/test_vllm.py::test_reasoning
+@pytest.mark.profiled_vram_gib(18.7)  # actual nvidia-smi peak
+@pytest.mark.requested_vllm_kv_cache_bytes(
+    1_912_759_000
+)  # KV cache cap (2x safety over min=956_379_136)
+@pytest.mark.timeout(281)  # 6x observed 46.7s avg wall time (9 runs)
 @pytest.mark.nightly
 def test_reasoning(request, start_services: ServicePorts, predownload_models) -> None:
     """Test reasoning functionality with a mathematical problem."""

--- a/tests/frontend/test_vllm.py
+++ b/tests/frontend/test_vllm.py
@@ -235,10 +235,12 @@ def _validate_chat_response(response: requests.Response) -> Dict[str, Any]:
     return response_json
 
 
-# TODO: profile with --kv-bytes once pre-existing 500 panic is fixed (JoinError::Panic "Cannot drop a runtime in a context where blocking is not allowed")
-# TODO: re-enable GPU-parallel scheduling with profiled_vram_gib(20.4)
-# once this has a bounded --kv-bytes profile.
-@pytest.mark.timeout(300)  # 3x observed ~70s wall time, rounded up
+# Measured using: tests/utils/profile_pytest.py tests/frontend/test_vllm.py::test_reasoning_effort
+@pytest.mark.profiled_vram_gib(18.7)  # actual nvidia-smi peak
+@pytest.mark.requested_vllm_kv_cache_bytes(
+    1_912_759_000
+)  # KV cache cap (2x safety over min=956_379_136)
+@pytest.mark.timeout(378)  # 6x observed 62.8s avg wall time
 @pytest.mark.post_merge
 def test_reasoning_effort(
     request, start_services: ServicePorts, predownload_models


### PR DESCRIPTION
#### Overview:

`test_reasoning_effort` was failing for two unrelated reasons stacked. Both fixed; test re-enters the GPU-parallel scheduler.

#### Details:

- The preprocessor was stripping the special tokens that gpt-oss / harmony parsers need to find their content. Added them to the whitelist alongside gemma4.
- gpt-oss reasoning parser was crashing with a Tokio runtime-drop panic on its first lazy init from inside a chat-completion task. Now does the init on a fresh OS thread.
- Re-added `profiled_vram_gib` / KV-bytes / timeout markers on `test_reasoning_effort` — the ones #9031 stripped pending these fixes.
- Locked the whitelist behavior down with a unit test (harmony / gpt_oss rows added) so the next addition can't silently miss either one.
- New doc: `lib/llm/PREPROCESSOR_CASES.md` — per-parser preprocessor decisions, sibling to `lib/parsers/TEST_CASES.md`. Would have caught this bug at review time.

#### Where should the reviewer start?

`lib/llm/src/preprocessor.rs`, then `lib/parsers/src/reasoning/gpt_oss_parser.rs`, then `lib/llm/PREPROCESSOR_CASES.md`.

/coderabbit profile chill