### PR TITLE
test(revalidate): test(sglang): bump embedding_agg-2 timeout to 300s for L4 CI cold-load #9042

### DIFF
--- a/components/src/dynamo/common/__init__.py
+++ b/components/src/dynamo/common/__init__.py
@@ -25,3 +25,5 @@ except Exception:
         __version__ = "0.0.0+unknown"
 
 __all__ = ["__version__", "config_dump", "constants", "utils"]
+
+# revalidate 882375b9828 2026-05-03T05:28:04Z

--- a/lib/runtime/src/runtime.rs
+++ b/lib/runtime/src/runtime.rs
@@ -391,3 +391,5 @@ impl Drop for RuntimeType {
         }
     }
 }
+
+// revalidate 882375b9828 2026-05-03T05:28:04Z


### PR DESCRIPTION
Hey — this is just a re-validation run, I'm checking if anything broke in CI. Please don't merge. I'll delete this PR if it turns green.

Re-validating that PR #9042 by Keiven C did not regress, by re-running against a trivial placebo diff:

```
test(sglang): bump embedding_agg-2 timeout to 300s for L4 CI cold-load
```
