### PR TITLE
feat(snapshot): add manual restore trigger

### DIFF
--- a/deploy/operator/internal/checkpoint/checkpoint_test.go
+++ b/deploy/operator/internal/checkpoint/checkpoint_test.go
@@ -787,7 +787,7 @@ func TestInjectCheckpointIntoPodSpec(t *testing.T) {
 			errMsg  string
 		}{
 			{"hash empty and identity nil", testPodSpec(), &CheckpointInfo{Enabled: true, Ready: true}, fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(testSnapshotAgentDaemonSet()).Build(), "identity is nil"},
-			{"no containers", &corev1.PodSpec{}, testInfo(), fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(testSnapshotAgentDaemonSet()).Build(), "restore target container"},
+			{"no containers", &corev1.PodSpec{}, testInfo(), fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(testSnapshotAgentDaemonSet()).Build(), "restore targets"},
 			{"snapshot daemonset missing", testPodSpec(), testInfo(), fake.NewClientBuilder().WithScheme(testScheme()).Build(), "no snapshot-agent daemonset found"},
 		} {
 			t.Run(tc.name, func(t *testing.T) {

--- a/deploy/operator/internal/checkpoint/checkpoint_test.go
+++ b/deploy/operator/internal/checkpoint/checkpoint_test.go
@@ -622,6 +622,7 @@ func TestInjectCheckpointIntoPodSpec(t *testing.T) {
 			corev1.EnvVar{Name: EnvLocalSSDRoots, Value: "/mnt/nvme0/gms,/mnt/nvme1/gms"},
 			corev1.EnvVar{Name: EnvShardSizeBytes, Value: "1073741824"},
 			corev1.EnvVar{Name: EnvRestoreTriggerFile, Value: "/etc/podinfo/snapshot_restore_trigger"},
+			corev1.EnvVar{Name: EnvRestoreTriggerAnnotation, Value: snapshotprotocol.RestoreTriggerAnnotation},
 		)
 		info := &CheckpointInfo{Enabled: true, Ready: true, Hash: testHash, GPUMemoryService: &nvidiacomv1alpha1.GPUMemoryServiceSpec{Enabled: true}}
 		reader := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(testSnapshotAgentDaemonSet()).Build()
@@ -660,6 +661,7 @@ func TestInjectCheckpointIntoPodSpec(t *testing.T) {
 		assert.Equal(t, "/mnt/nvme0/gms,/mnt/nvme1/gms", env["GMS_LOCAL_SSD_ROOTS"])
 		assert.Equal(t, "1073741824", env["GMS_SHARD_SIZE_BYTES"])
 		assert.Equal(t, "/etc/podinfo/snapshot_restore_trigger", env["GMS_RESTORE_TRIGGER_FILE"])
+		assert.Equal(t, snapshotprotocol.RestoreTriggerAnnotation, env["GMS_RESTORE_TRIGGER_ANNOTATION"])
 		assert.Equal(t, "/checkpoints/gms/"+testHash+"/versions/1", info.GMSArtifactDir)
 		assert.Equal(t, []string{"python3", "-m", "gpu_memory_service.cli.server"}, gmsServer.Command)
 		assert.Equal(t, []string{"python3", "-m", "gpu_memory_service.cli.snapshot.loader"}, loader.Command)

--- a/deploy/operator/internal/checkpoint/checkpoint_test.go
+++ b/deploy/operator/internal/checkpoint/checkpoint_test.go
@@ -313,7 +313,6 @@ func TestApplyRestorePodMetadataWithStorageConfig(t *testing.T) {
 		storageConfig,
 	))
 
-	assert.Equal(t, "true", labels[snapshotprotocol.RestoreTargetLabel])
 	assert.Equal(t, testHash, labels[snapshotprotocol.CheckpointIDLabel])
 	assert.Equal(t, snapshotprotocol.StorageTypePVC, annotations[snapshotprotocol.CheckpointStorageTypeAnnotation])
 	assert.Equal(t, "/snapshots", annotations[snapshotprotocol.CheckpointStorageBasePathAnnotation])
@@ -502,6 +501,7 @@ func TestInjectCheckpointIntoPodSpec(t *testing.T) {
 		assert.Equal(t, "metadata.labels['"+consts.KubeLabelDynamoComponentType+"']", fields[consts.PodInfoFileDynComponent])
 		assert.Equal(t, "metadata.labels['"+consts.KubeLabelDynamoGraphDeploymentName+"']", fields[consts.PodInfoFileDynParentDGDName])
 		assert.Equal(t, consts.PodInfoFieldPodNamespace, fields[consts.PodInfoFileDynParentDGDNamespace])
+		assert.Equal(t, "metadata.annotations['"+snapshotprotocol.RestoreTriggerAnnotation+"']", fields[consts.PodInfoFileSnapshotRestoreTrigger])
 
 		mountPaths := map[string]string{}
 		for _, mount := range podSpec.Containers[0].VolumeMounts {
@@ -621,6 +621,7 @@ func TestInjectCheckpointIntoPodSpec(t *testing.T) {
 			corev1.EnvVar{Name: EnvLoadWorkers, Value: "32"},
 			corev1.EnvVar{Name: EnvLocalSSDRoots, Value: "/mnt/nvme0/gms,/mnt/nvme1/gms"},
 			corev1.EnvVar{Name: EnvShardSizeBytes, Value: "1073741824"},
+			corev1.EnvVar{Name: EnvRestoreTriggerFile, Value: "/etc/podinfo/snapshot_restore_trigger"},
 		)
 		info := &CheckpointInfo{Enabled: true, Ready: true, Hash: testHash, GPUMemoryService: &nvidiacomv1alpha1.GPUMemoryServiceSpec{Enabled: true}}
 		reader := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(testSnapshotAgentDaemonSet()).Build()
@@ -647,6 +648,7 @@ func TestInjectCheckpointIntoPodSpec(t *testing.T) {
 		assert.Equal(t, gms.SharedMountPath, mounts[gms.SharedVolumeName])
 		assert.Equal(t, "/mnt/nvme0", mounts["nvme0"])
 		assert.Equal(t, "/mnt/nvme1", mounts["nvme1"])
+		assert.Equal(t, consts.PodInfoMountPath, mounts[consts.PodInfoVolumeName])
 
 		env := map[string]string{}
 		for _, item := range loader.Env {
@@ -657,6 +659,7 @@ func TestInjectCheckpointIntoPodSpec(t *testing.T) {
 		assert.Equal(t, "32", env["GMS_LOAD_WORKERS"])
 		assert.Equal(t, "/mnt/nvme0/gms,/mnt/nvme1/gms", env["GMS_LOCAL_SSD_ROOTS"])
 		assert.Equal(t, "1073741824", env["GMS_SHARD_SIZE_BYTES"])
+		assert.Equal(t, "/etc/podinfo/snapshot_restore_trigger", env["GMS_RESTORE_TRIGGER_FILE"])
 		assert.Equal(t, "/checkpoints/gms/"+testHash+"/versions/1", info.GMSArtifactDir)
 		assert.Equal(t, []string{"python3", "-m", "gpu_memory_service.cli.server"}, gmsServer.Command)
 		assert.Equal(t, []string{"python3", "-m", "gpu_memory_service.cli.snapshot.loader"}, loader.Command)
@@ -1000,6 +1003,20 @@ func TestApplyRestorePodMetadata_FailoverTargets(t *testing.T) {
 		RestoreTargetContainers: []string{"engine-0", "engine-1"},
 	})
 	assert.Equal(t, "engine-0,engine-1", annotations[snapshotprotocol.TargetContainersAnnotation])
+}
+
+func TestApplyRestorePodMetadata_PreservesManualRestoreMode(t *testing.T) {
+	labels := map[string]string{}
+	annotations := map[string]string{
+		snapshotprotocol.RestoreModeAnnotation:    snapshotprotocol.RestoreModeManual,
+		snapshotprotocol.RestoreTriggerAnnotation: "stale",
+	}
+
+	ApplyRestorePodMetadata(labels, annotations, &CheckpointInfo{Enabled: true, Ready: true, Hash: testHash})
+
+	assert.Equal(t, snapshotprotocol.RestoreModeManual, annotations[snapshotprotocol.RestoreModeAnnotation])
+	_, ok := annotations[snapshotprotocol.RestoreTriggerAnnotation]
+	assert.False(t, ok, "stale restore trigger must be cleared when restore metadata is restamped")
 }
 
 func TestApplyRestorePodMetadata_DisabledClearsAnnotation(t *testing.T) {

--- a/deploy/operator/internal/checkpoint/gms.go
+++ b/deploy/operator/internal/checkpoint/gms.go
@@ -45,6 +45,9 @@ const (
 	EnvLocalSSDRoots = "GMS_LOCAL_SSD_ROOTS"
 	// EnvShardSizeBytes controls GMS save shard size / local SSD stripe size.
 	EnvShardSizeBytes = "GMS_SHARD_SIZE_BYTES"
+	// EnvRestoreTriggerFile makes the restore loader wait for a non-empty token
+	// in a Downward API file before starting weight transfer.
+	EnvRestoreTriggerFile = "GMS_RESTORE_TRIGGER_FILE"
 )
 
 type GMSCheckpointStorage struct {
@@ -86,6 +89,8 @@ func EnsureGMSRestoreSidecars(
 	loader := gms.Container(GMSLoaderContainer, GMSCheckpointLoaderModule, sidecarSource.Image)
 	addGMSStorageMounts(&loader, storage)
 	addGMSLocalSSDVolumeMounts(&loader, sidecarSource)
+	EnsurePodInfoVolume(podSpec)
+	EnsurePodInfoMount(&loader)
 	loader.Env = append(loader.Env,
 		corev1.EnvVar{Name: EnvCheckpointDir, Value: storage.ControlDir},
 		PodUIDEnvVar(),
@@ -192,7 +197,7 @@ func gmsCheckpointPassThroughEnvVars(mainContainer *corev1.Container) []corev1.E
 	var result []corev1.EnvVar
 	for _, env := range mainContainer.Env {
 		switch env.Name {
-		case EnvTransferBackend, EnvLoadWorkers, EnvSaveWorkers, EnvLocalSSDRoots, EnvShardSizeBytes:
+		case EnvTransferBackend, EnvLoadWorkers, EnvSaveWorkers, EnvLocalSSDRoots, EnvShardSizeBytes, EnvRestoreTriggerFile:
 			result = append(result, env)
 		}
 	}

--- a/deploy/operator/internal/checkpoint/gms.go
+++ b/deploy/operator/internal/checkpoint/gms.go
@@ -48,6 +48,9 @@ const (
 	// EnvRestoreTriggerFile makes the restore loader wait for a non-empty token
 	// in a Downward API file before starting weight transfer.
 	EnvRestoreTriggerFile = "GMS_RESTORE_TRIGGER_FILE"
+	// EnvRestoreTriggerAnnotation makes the restore loader poll the pod
+	// annotation directly through the Kubernetes API before starting transfer.
+	EnvRestoreTriggerAnnotation = "GMS_RESTORE_TRIGGER_ANNOTATION"
 )
 
 type GMSCheckpointStorage struct {
@@ -197,7 +200,7 @@ func gmsCheckpointPassThroughEnvVars(mainContainer *corev1.Container) []corev1.E
 	var result []corev1.EnvVar
 	for _, env := range mainContainer.Env {
 		switch env.Name {
-		case EnvTransferBackend, EnvLoadWorkers, EnvSaveWorkers, EnvLocalSSDRoots, EnvShardSizeBytes, EnvRestoreTriggerFile:
+		case EnvTransferBackend, EnvLoadWorkers, EnvSaveWorkers, EnvLocalSSDRoots, EnvShardSizeBytes, EnvRestoreTriggerFile, EnvRestoreTriggerAnnotation:
 			result = append(result, env)
 		}
 	}

--- a/deploy/operator/internal/checkpoint/podinfo.go
+++ b/deploy/operator/internal/checkpoint/podinfo.go
@@ -5,6 +5,7 @@ package checkpoint
 
 import (
 	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -66,6 +67,12 @@ func EnsurePodInfoVolume(podSpec *corev1.PodSpec) {
 						Path: commonconsts.PodInfoFileDynParentDGDNamespace,
 						FieldRef: &corev1.ObjectFieldSelector{
 							FieldPath: commonconsts.PodInfoFieldPodNamespace,
+						},
+					},
+					{
+						Path: commonconsts.PodInfoFileSnapshotRestoreTrigger,
+						FieldRef: &corev1.ObjectFieldSelector{
+							FieldPath: "metadata.annotations['" + snapshotprotocol.RestoreTriggerAnnotation + "']",
 						},
 					},
 				},

--- a/deploy/operator/internal/checkpoint/podspec.go
+++ b/deploy/operator/internal/checkpoint/podspec.go
@@ -20,6 +20,7 @@ package checkpoint
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
 	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
@@ -67,7 +68,8 @@ func ApplyRestorePodMetadataWithStorageConfig(
 		}
 	}
 
-	snapshotprotocol.ApplyRestoreTargetMetadata(labels, annotations, enabled, hash, artifactVersion)
+	manualTrigger := annotations != nil && strings.TrimSpace(annotations[snapshotprotocol.RestoreModeAnnotation]) == snapshotprotocol.RestoreModeManual
+	snapshotprotocol.ApplyRestoreTargetMetadata(labels, annotations, enabled, manualTrigger, hash, artifactVersion)
 	if annotations != nil {
 		delete(annotations, snapshotprotocol.TargetContainersAnnotation)
 		delete(annotations, snapshotprotocol.CheckpointStorageTypeAnnotation)

--- a/deploy/operator/internal/checkpoint/podspec.go
+++ b/deploy/operator/internal/checkpoint/podspec.go
@@ -119,6 +119,18 @@ func resolvePodInfoContainers(podSpec *corev1.PodSpec, targets []string) []*core
 	return out
 }
 
+func RequireMainContainer(podSpec *corev1.PodSpec) (*corev1.Container, error) {
+	if podSpec == nil {
+		return nil, fmt.Errorf("pod spec is nil")
+	}
+	for i := range podSpec.Containers {
+		if podSpec.Containers[i].Name == commonconsts.MainContainerName {
+			return &podSpec.Containers[i], nil
+		}
+	}
+	return nil, fmt.Errorf("pod spec has no container named %q", commonconsts.MainContainerName)
+}
+
 func InjectCheckpointIntoPodSpec(
 	ctx context.Context,
 	reader ctrlclient.Reader,

--- a/deploy/operator/internal/consts/consts.go
+++ b/deploy/operator/internal/consts/consts.go
@@ -190,6 +190,7 @@ const (
 	PodInfoFileDynComponent             = "dyn_component"
 	PodInfoFileDynParentDGDName         = "dyn_parent_dgd_k8s_name"
 	PodInfoFileDynParentDGDNamespace    = "dyn_parent_dgd_k8s_namespace"
+	PodInfoFileSnapshotRestoreTrigger   = "snapshot_restore_trigger"
 
 	// Worker hash rolling-update annotations are controller-owned annotations on
 	// DynamoGraphDeployment. They record the active worker generation and must not

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
@@ -923,6 +923,7 @@ func (r *DynamoComponentDeploymentReconciler) generatePodTemplateSpec(ctx contex
 	podLabels := dynamo.GetDCDKubeLabels(dcd)
 	podAnnotations := dynamo.GetDCDKubeAnnotations(dcd)
 	kubeName := dcd.Name
+	resourceAnnotations := getResourceAnnotations(dcd)
 
 	// Convert user-provided metrics annotation into controller-managed label
 	// By default (no annotation), metrics are enabled

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
@@ -23,6 +23,8 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"slices"
+	"strings"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -42,6 +44,7 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dra"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/observability"
+	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -1006,6 +1009,12 @@ func (r *DynamoComponentDeploymentReconciler) generatePodTemplateSpec(ctx contex
 		podLabels[commonconsts.KubeLabelDynamoDiscoveryEnabled] = commonconsts.KubeLabelValueTrue
 	}
 
+	// The benchmark-only manual restore mode is configured on the DCD
+	// resource annotations by the DGD controller. Preserve it before restore
+	// metadata stamping so snapshot-agent can wait for the explicit trigger.
+	if strings.TrimSpace(resourceAnnotations[snapshotprotocol.RestoreModeAnnotation]) == snapshotprotocol.RestoreModeManual {
+		podAnnotations[snapshotprotocol.RestoreModeAnnotation] = snapshotprotocol.RestoreModeManual
+	}
 	// Restore labels are operator-controlled state. Clear stale values after
 	// metadata merge and only reapply them when checkpoint material is ready.
 	if err := checkpoint.ApplyRestorePodMetadataWithStorageConfig(podLabels, podAnnotations, checkpointInfo, r.Config.Checkpoint.Storage); err != nil {

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"fmt"
 	"maps"
-	"slices"
 	"strings"
 	"time"
 

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -1676,6 +1676,45 @@ func TestDynamoComponentDeploymentReconciler_generatePodTemplateSpec_RestoreLabe
 		}
 	})
 
+	t.Run("ready checkpoint preserves manual restore mode from resource annotations", func(t *testing.T) {
+		identity := v1alpha1.DynamoCheckpointIdentity{Model: "test-model", BackendFramework: "vllm"}
+		checkpointName, err := checkpoint.ComputeIdentityHash(identity)
+		if err != nil {
+			t.Fatalf("ComputeIdentityHash failed: %v", err)
+		}
+		dcd := makeDCD(checkpointName)
+		dcd.Spec.Annotations = map[string]string{
+			snapshotprotocol.RestoreModeAnnotation: " manual ",
+		}
+		ckpt := &v1alpha1.DynamoCheckpoint{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      checkpointName,
+				Namespace: "default",
+			},
+			Spec: v1alpha1.DynamoCheckpointSpec{Identity: identity},
+			Status: v1alpha1.DynamoCheckpointStatus{
+				Phase: v1alpha1.DynamoCheckpointPhaseReady,
+			},
+		}
+
+		r := makeReconciler(dcd, ckpt)
+		podTemplateSpec, err := r.generatePodTemplateSpec(
+			context.Background(),
+			generateResourceOption{dynamoComponentDeployment: dcd},
+			dynamo.RoleMain,
+		)
+		if err != nil {
+			t.Fatalf("generatePodTemplateSpec failed: %v", err)
+		}
+
+		if got := podTemplateSpec.Annotations[snapshotprotocol.RestoreModeAnnotation]; got != snapshotprotocol.RestoreModeManual {
+			t.Fatalf("expected %s=manual annotation, got %q", snapshotprotocol.RestoreModeAnnotation, got)
+		}
+		if _, ok := podTemplateSpec.Annotations[snapshotprotocol.RestoreTriggerAnnotation]; ok {
+			t.Fatalf("restore trigger should not be stamped before the harness patches it")
+		}
+	})
+
 	t.Run("ready gms checkpoint injects gms restore sidecars", func(t *testing.T) {
 		t.Setenv(commonconsts.DynamoOperatorAllowGMSSnapshotEnvVar, "1")
 		identity := v1alpha1.DynamoCheckpointIdentity{Model: "test-model", BackendFramework: "vllm"}

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -1683,7 +1683,10 @@ func TestDynamoComponentDeploymentReconciler_generatePodTemplateSpec_RestoreLabe
 			t.Fatalf("ComputeIdentityHash failed: %v", err)
 		}
 		dcd := makeDCD(checkpointName)
-		dcd.Spec.Annotations = map[string]string{
+		if dcd.Spec.PodTemplate == nil {
+			dcd.Spec.PodTemplate = &corev1.PodTemplateSpec{}
+		}
+		dcd.Spec.PodTemplate.Annotations = map[string]string{
 			snapshotprotocol.RestoreModeAnnotation: " manual ",
 		}
 		ckpt := &v1alpha1.DynamoCheckpoint{

--- a/deploy/snapshot/cmd/snapshotctl/checkpoint.go
+++ b/deploy/snapshot/cmd/snapshotctl/checkpoint.go
@@ -37,6 +37,7 @@ type result struct {
 	CheckpointLocation string
 	CheckpointJob      string
 	RestorePod         string
+	RestoreTrigger     string
 	Status             string
 }
 

--- a/deploy/snapshot/cmd/snapshotctl/main.go
+++ b/deploy/snapshot/cmd/snapshotctl/main.go
@@ -30,6 +30,8 @@ func run(args []string) error {
 		return runCheckpoint(args[1:])
 	case "restore":
 		return runRestore(args[1:])
+	case "trigger-restore":
+		return runTriggerRestore(args[1:])
 	case "help", "-h", "--help":
 		printUsage()
 		return nil
@@ -94,6 +96,7 @@ func runRestore(args []string) error {
 	kubeContext := flags.String("kube-context", "", "Kubernetes context override")
 	checkpointID := flags.String("checkpoint-id", "", "Checkpoint ID to restore")
 	containers := flags.String("containers", "", "Required. Comma-separated target container names to restore the checkpoint into. May be omitted if the manifest/pod already sets the nvidia.com/snapshot-target-containers annotation")
+	manualTrigger := flags.Bool("manual-trigger", false, "Create or patch the restore target but wait for trigger-restore before starting restore")
 
 	if err := flags.Parse(args); err != nil {
 		return err
@@ -107,17 +110,22 @@ func runRestore(args []string) error {
 
 	snapshotctlLog.Info("Running restore", "manifest", *manifest, "pod", *podName, "namespace", *namespace, "checkpoint_id", *checkpointID)
 	result, err := runRestoreFlow(context.Background(), restoreOptions{
-		ManifestPath: *manifest,
-		PodName:      *podName,
-		Namespace:    *namespace,
-		KubeContext:  *kubeContext,
-		CheckpointID: *checkpointID,
-		Containers:   *containers,
+		ManifestPath:  *manifest,
+		PodName:       *podName,
+		Namespace:     *namespace,
+		KubeContext:   *kubeContext,
+		CheckpointID:  *checkpointID,
+		Containers:    *containers,
+		ManualTrigger: *manualTrigger,
 	})
 	if err != nil {
 		return err
 	}
-	snapshotctlLog.Info("Restore requested", "pod", result.RestorePod, "checkpoint_id", result.CheckpointID)
+	if result.Status == restoreStatusPendingTrigger {
+		snapshotctlLog.Info("Restore target is waiting for manual trigger", "pod", result.RestorePod, "checkpoint_id", result.CheckpointID)
+	} else {
+		snapshotctlLog.Info("Restore requested", "pod", result.RestorePod, "checkpoint_id", result.CheckpointID)
+	}
 
 	fmt.Printf("status=%s\n", result.Status)
 	fmt.Printf("namespace=%s\n", result.Namespace)
@@ -134,9 +142,12 @@ func printUsage() {
 Subcommands:
   checkpoint
   restore
+  trigger-restore
 
 Examples:
   snapshotctl checkpoint --manifest /tmp/vllm-worker-pod.yaml --container main
+  snapshotctl restore --manifest /tmp/sglang-worker-pod.yaml --checkpoint-id manual-snapshot-123 --containers main --manual-trigger
+  snapshotctl trigger-restore --pod snapshot-manual-restore
   snapshotctl restore --manifest /tmp/sglang-worker-pod.yaml --checkpoint-id manual-snapshot-123 --containers main
   snapshotctl restore --pod existing-restore-target --checkpoint-id manual-snapshot-123 --containers engine-0,engine-1
 `)

--- a/deploy/snapshot/cmd/snapshotctl/restore.go
+++ b/deploy/snapshot/cmd/snapshotctl/restore.go
@@ -15,13 +15,16 @@ import (
 )
 
 type restoreOptions struct {
-	ManifestPath string
-	PodName      string
-	Namespace    string
-	KubeContext  string
-	CheckpointID string
-	Containers   string
+	ManifestPath  string
+	PodName       string
+	Namespace     string
+	KubeContext   string
+	CheckpointID  string
+	Containers    string
+	ManualTrigger bool
 }
+
+const restoreStatusPendingTrigger = "pending_trigger"
 
 func runRestoreFlow(ctx context.Context, opts restoreOptions) (*result, error) {
 	createPodFromManifest := strings.TrimSpace(opts.ManifestPath) != ""
@@ -100,6 +103,7 @@ func runRestoreFlow(ctx context.Context, opts restoreOptions) (*result, error) {
 			ArtifactVersion: snapshotprotocol.DefaultCheckpointArtifactVersion,
 			Storage:         resolvedStorage,
 			SeccompProfile:  snapshotprotocol.DefaultSeccompLocalhostProfile,
+			ManualTrigger:   opts.ManualTrigger,
 		})
 		if err != nil {
 			return nil, err
@@ -132,7 +136,7 @@ func runRestoreFlow(ctx context.Context, opts restoreOptions) (*result, error) {
 		for key, value := range pod.Annotations {
 			annotations[key] = value
 		}
-		snapshotprotocol.ApplyRestoreTargetMetadata(labels, annotations, true, checkpointID, snapshotprotocol.DefaultCheckpointArtifactVersion)
+		snapshotprotocol.ApplyRestoreTargetMetadata(labels, annotations, true, opts.ManualTrigger, checkpointID, snapshotprotocol.DefaultCheckpointArtifactVersion)
 		annotations[snapshotprotocol.TargetContainersAnnotation] = targetValue
 		if err := snapshotprotocol.ValidateRestorePodSpec(&pod.Spec, annotations, resolvedStorage, snapshotprotocol.DefaultSeccompLocalhostProfile); err != nil {
 			return nil, fmt.Errorf("restore target pod %s/%s is not snapshot-compatible: %w", namespace, podName, err)
@@ -151,12 +155,16 @@ func runRestoreFlow(ctx context.Context, opts restoreOptions) (*result, error) {
 		}
 	}
 
+	status := "requested"
+	if opts.ManualTrigger {
+		status = restoreStatusPendingTrigger
+	}
 	return &result{
 		Name:               podName,
 		Namespace:          namespace,
 		CheckpointID:       checkpointID,
 		CheckpointLocation: resolvedStorage.Location,
 		RestorePod:         podName,
-		Status:             "requested",
+		Status:             status,
 	}, nil
 }

--- a/deploy/snapshot/cmd/snapshotctl/trigger_restore.go
+++ b/deploy/snapshot/cmd/snapshotctl/trigger_restore.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
+)
+
+type triggerRestoreOptions struct {
+	PodName     string
+	Namespace   string
+	KubeContext string
+}
+
+func runTriggerRestore(args []string) error {
+	flags := flag.NewFlagSet("trigger-restore", flag.ContinueOnError)
+	flags.SetOutput(os.Stderr)
+
+	podName := flags.String("pod", "", "Restore target pod name")
+	namespace := flags.String("namespace", "", "Namespace override; defaults to the current kube context namespace")
+	kubeContext := flags.String("kube-context", "", "Kubernetes context override")
+
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if len(flags.Args()) != 0 {
+		return fmt.Errorf("unexpected arguments: %v", flags.Args())
+	}
+	if strings.TrimSpace(*podName) == "" {
+		return fmt.Errorf("--pod is required")
+	}
+
+	result, err := runTriggerRestoreFlow(context.Background(), triggerRestoreOptions{
+		PodName:     *podName,
+		Namespace:   *namespace,
+		KubeContext: *kubeContext,
+	})
+	if err != nil {
+		return err
+	}
+
+	snapshotctlLog.Info("Restore trigger submitted", "pod", result.RestorePod, "trigger", result.RestoreTrigger)
+	fmt.Printf("status=triggered\n")
+	fmt.Printf("namespace=%s\n", result.Namespace)
+	fmt.Printf("restore_pod=%s\n", result.RestorePod)
+	fmt.Printf("restore_trigger=%s\n", result.RestoreTrigger)
+	return nil
+}
+
+func runTriggerRestoreFlow(ctx context.Context, opts triggerRestoreOptions) (*result, error) {
+	clientset, currentNamespace, err := loadClientset(opts.KubeContext)
+	if err != nil {
+		return nil, err
+	}
+	namespace := currentNamespace
+	if namespace == "" {
+		namespace = corev1.NamespaceDefault
+	}
+	if strings.TrimSpace(opts.Namespace) != "" {
+		namespace = strings.TrimSpace(opts.Namespace)
+	}
+
+	podName := strings.TrimSpace(opts.PodName)
+	pod, err := clientset.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("get restore target pod %s/%s: %w", namespace, podName, err)
+	}
+	if pod.Labels[snapshotprotocol.CheckpointIDLabel] == "" {
+		return nil, fmt.Errorf("pod %s/%s is not marked as a restore target", namespace, podName)
+	}
+	if strings.TrimSpace(pod.Annotations[snapshotprotocol.RestoreModeAnnotation]) != snapshotprotocol.RestoreModeManual {
+		return nil, fmt.Errorf("pod %s/%s is not configured for manual restore", namespace, podName)
+	}
+
+	trigger := fmt.Sprintf("%d", time.Now().UTC().UnixNano())
+	patch, err := json.Marshal(map[string]any{
+		"metadata": map[string]any{
+			"annotations": map[string]string{
+				snapshotprotocol.RestoreTriggerAnnotation: trigger,
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("encode restore trigger patch: %w", err)
+	}
+	if _, err := clientset.CoreV1().Pods(namespace).Patch(ctx, podName, types.MergePatchType, patch, metav1.PatchOptions{}); err != nil {
+		return nil, fmt.Errorf("patch restore trigger on pod %s/%s: %w", namespace, podName, err)
+	}
+
+	return &result{
+		Name:           podName,
+		Namespace:      namespace,
+		RestorePod:     podName,
+		RestoreTrigger: trigger,
+		Status:         "triggered",
+	}, nil
+}

--- a/deploy/snapshot/internal/controller/controller.go
+++ b/deploy/snapshot/internal/controller/controller.go
@@ -139,7 +139,10 @@ func (w *NodeController) Run(ctx context.Context) error {
 	go ckptFactory.Start(w.stopCh)
 	syncFuncs = append(syncFuncs, ckptInformer.HasSynced)
 
-	// Restore pods carry a checkpoint ID but are not checkpoint sources.
+	// Restore informer: pods that carry a checkpoint-id label but are not
+	// themselves the checkpoint source. A single set-based selector
+	// expresses this without a dedicated "is restore target" boolean
+	// label parallel to the target-containers annotation.
 	restoreSel, err := labels.Parse(snapshotprotocol.CheckpointIDLabel + ",!" + snapshotprotocol.CheckpointSourceLabel)
 	if err != nil {
 		return fmt.Errorf("failed to build restore label selector: %w", err)
@@ -273,29 +276,32 @@ func (w *NodeController) reconcileRestorePod(ctx context.Context, pod *corev1.Po
 		return
 	}
 
+	restoreMode := strings.TrimSpace(pod.Annotations[snapshotprotocol.RestoreModeAnnotation])
+	restoreTrigger := strings.TrimSpace(pod.Annotations[snapshotprotocol.RestoreTriggerAnnotation])
+	if restoreMode == snapshotprotocol.RestoreModeManual && restoreTrigger == "" {
+		w.log.V(1).Info("Restore pod is waiting for manual trigger", "pod", podKey)
+		return
+	}
+
 	targets, err := snapshotprotocol.TargetContainersFromAnnotations(pod.Annotations, 1, 0)
 	if err != nil {
 		w.log.Error(err, "Restore pod missing target-containers annotation", "pod", podKey)
 		return
 	}
-	for _, containerName := range targets {
-		if _, err := snapshotprotocol.RestoreStatusAnnotationKeysFor(containerName); err != nil {
-			w.log.Error(
-				err,
-				"Restore target container name cannot be used in restore status annotation key",
-				"pod", podKey,
-				"container", containerName,
-			)
-			return
-		}
-	}
 
+	// For each target container: check if kubelet has a running container
+	// for it, check the per-container status annotation, and schedule a
+	// goroutine when (a) we see a fresh containerd ID and (b) the status is
+	// not already terminal for that ID.
 	for _, containerName := range targets {
 		w.maybeStartRestoreForContainer(ctx, pod, containerName, checkpointID, podKey)
 	}
 }
 
-// maybeStartRestoreForContainer starts one restore worker per fresh container.
+// maybeStartRestoreForContainer handles one named target container in a
+// restore pod. It is a no-op when the container has not been scheduled by
+// kubelet yet, or when the agent has already recorded a terminal status for
+// the current containerd container ID.
 func (w *NodeController) maybeStartRestoreForContainer(
 	ctx context.Context,
 	pod *corev1.Pod,
@@ -376,13 +382,22 @@ func (w *NodeController) startRestoreForContainer(
 	checkpointID string,
 	podKey string,
 ) {
-	annotationKeys, err := snapshotprotocol.RestoreStatusAnnotationKeysFor(containerName)
-	if err != nil {
-		w.log.Error(err, "Restore target container name cannot be used in restore status annotation key", "pod", podKey, "container", containerName)
-		return
+	restoreTrigger := strings.TrimSpace(pod.Annotations[snapshotprotocol.RestoreTriggerAnnotation])
+	if strings.TrimSpace(pod.Annotations[snapshotprotocol.RestoreModeAnnotation]) == snapshotprotocol.RestoreModeManual {
+		if restoreTrigger == "" {
+			w.log.V(1).Info("Restore target is waiting for manual trigger",
+				"pod", podKey,
+				"container", containerName,
+			)
+			return
+		}
+		if strings.TrimSpace(pod.Annotations[snapshotprotocol.RestoreProcessedTriggerAnnotationFor(containerName)]) == restoreTrigger {
+			return
+		}
 	}
-	annotationStatus := pod.Annotations[annotationKeys.Status]
-	annotationContainerID := pod.Annotations[annotationKeys.ContainerID]
+
+	annotationStatus := pod.Annotations[snapshotprotocol.RestoreStatusAnnotationFor(containerName)]
+	annotationContainerID := pod.Annotations[snapshotprotocol.RestoreContainerIDAnnotationFor(containerName)]
 	if annotationContainerID == containerID && (annotationStatus == snapshotprotocol.RestoreStatusCompleted || annotationStatus == snapshotprotocol.RestoreStatusFailed) {
 		return
 	}
@@ -425,11 +440,12 @@ func (w *NodeController) startRestoreForContainer(
 		"pod", podKey,
 		"checkpoint_id", checkpointID,
 		"container", containerName,
+		"trigger", restoreTrigger,
 	)
 	emitPodEvent(ctx, w.clientset, w.log, pod, "snapshot", corev1.EventTypeNormal, "RestoreRequested", fmt.Sprintf("Restore requested from checkpoint %s for container %s", checkpointID, containerName))
 
 	go func() {
-		if err := w.runRestore(ctx, pod, containerName, containerID, checkpointID, checkpointLocation, restoreAttemptKey, startedAt); err != nil {
+		if err := w.runRestore(ctx, pod, containerName, containerID, checkpointID, checkpointLocation, restoreTrigger, restoreAttemptKey, startedAt); err != nil {
 			opLog := w.log.WithValues("pod", podKey, "checkpoint_id", checkpointID, "container", containerName)
 			opLog.Error(err, "Restore controller worker failed")
 			emitPodEvent(ctx, w.clientset, opLog, pod, "snapshot", corev1.EventTypeWarning, "RestoreWorkerFailed", err.Error())
@@ -604,7 +620,7 @@ func (w *NodeController) runCheckpoint(ctx context.Context, pod *corev1.Pod, job
 // startup probe waits on the restore-complete sentinel, then its normal
 // readiness probe (if any) decides when the container is ready. The pod only
 // becomes Ready once every restored and cold-started container is ready.
-func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, containerName, containerID, checkpointID string, checkpointLocation checkpointLocations, restoreAttemptKey string, startedAt time.Time) error {
+func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, containerName, containerID, checkpointID string, checkpointLocation checkpointLocations, restoreTrigger string, restoreAttemptKey string, startedAt time.Time) error {
 	releaseOnExit := true
 	defer func() {
 		if releaseOnExit {
@@ -620,9 +636,12 @@ func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, contai
 	podKey := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
 	log := w.log.WithValues("pod", podKey, "checkpoint_id", checkpointID, "container_id", containerID)
 	setRestoreStatus := func(value string) error {
-		annotations, err := snapshotprotocol.RestoreStatusAnnotations(containerName, value, containerID)
-		if err != nil {
-			return err
+		annotations := map[string]string{
+			snapshotprotocol.RestoreStatusAnnotationFor(containerName):      value,
+			snapshotprotocol.RestoreContainerIDAnnotationFor(containerName): containerID,
+		}
+		if restoreTrigger != "" {
+			annotations[snapshotprotocol.RestoreProcessedTriggerAnnotationFor(containerName)] = restoreTrigger
 		}
 		if err := annotatePod(ctx, w.clientset, log, pod, annotations); err != nil {
 			if value == snapshotprotocol.RestoreStatusCompleted || value == snapshotprotocol.RestoreStatusFailed {
@@ -650,7 +669,7 @@ func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, contai
 		return fmt.Errorf("failed to annotate pod with restore in_progress: %w", err)
 	}
 
-	// Run the restore orchestrator (inspect + nsrestore).
+	// Step 1: Run the restore orchestrator (inspect + nsrestore)
 	req := executor.RestoreRequest{
 		CheckpointID:                checkpointID,
 		CheckpointLocation:          checkpointLocation.HostPath,
@@ -679,8 +698,9 @@ func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, contai
 		}
 		return nil
 	}
-	// Any PID inside the container mount namespace reaches the control
-	// volume through /host/proc/<pid>/root.
+	// Step 2: Write restore-complete sentinel. placeholderHostPID came back
+	// from executor.Restore — any PID inside the container's mount namespace
+	// reaches /snapshot-control via /host/proc/<pid>/root.
 	if err := snapshotruntime.WriteControlSentinel(placeholderHostPID, snapshotprotocol.RestoreCompleteFile); err != nil {
 		log.Error(err, "Failed to write restore-complete sentinel")
 		emitPodEvent(ctx, w.clientset, log, pod, "snapshot", corev1.EventTypeWarning, "RestoreFailed", err.Error())

--- a/deploy/snapshot/internal/controller/controller.go
+++ b/deploy/snapshot/internal/controller/controller.go
@@ -288,6 +288,17 @@ func (w *NodeController) reconcileRestorePod(ctx context.Context, pod *corev1.Po
 		w.log.Error(err, "Restore pod missing target-containers annotation", "pod", podKey)
 		return
 	}
+	for _, containerName := range targets {
+		if _, err := snapshotprotocol.RestoreStatusAnnotationKeysFor(containerName); err != nil {
+			w.log.Error(
+				err,
+				"Restore target container name cannot be used in restore status annotation key",
+				"pod", podKey,
+				"container", containerName,
+			)
+			return
+		}
+	}
 
 	// For each target container: check if kubelet has a running container
 	// for it, check the per-container status annotation, and schedule a
@@ -382,6 +393,12 @@ func (w *NodeController) startRestoreForContainer(
 	checkpointID string,
 	podKey string,
 ) {
+	annotationKeys, err := snapshotprotocol.RestoreStatusAnnotationKeysFor(containerName)
+	if err != nil {
+		w.log.Error(err, "Restore target container name cannot be used in restore status annotation key", "pod", podKey, "container", containerName)
+		return
+	}
+
 	restoreTrigger := strings.TrimSpace(pod.Annotations[snapshotprotocol.RestoreTriggerAnnotation])
 	if strings.TrimSpace(pod.Annotations[snapshotprotocol.RestoreModeAnnotation]) == snapshotprotocol.RestoreModeManual {
 		if restoreTrigger == "" {
@@ -391,13 +408,13 @@ func (w *NodeController) startRestoreForContainer(
 			)
 			return
 		}
-		if strings.TrimSpace(pod.Annotations[snapshotprotocol.RestoreProcessedTriggerAnnotationFor(containerName)]) == restoreTrigger {
+		if strings.TrimSpace(pod.Annotations[annotationKeys.ProcessedTrigger]) == restoreTrigger {
 			return
 		}
 	}
 
-	annotationStatus := pod.Annotations[snapshotprotocol.RestoreStatusAnnotationFor(containerName)]
-	annotationContainerID := pod.Annotations[snapshotprotocol.RestoreContainerIDAnnotationFor(containerName)]
+	annotationStatus := pod.Annotations[annotationKeys.Status]
+	annotationContainerID := pod.Annotations[annotationKeys.ContainerID]
 	if annotationContainerID == containerID && (annotationStatus == snapshotprotocol.RestoreStatusCompleted || annotationStatus == snapshotprotocol.RestoreStatusFailed) {
 		return
 	}
@@ -636,12 +653,16 @@ func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, contai
 	podKey := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
 	log := w.log.WithValues("pod", podKey, "checkpoint_id", checkpointID, "container_id", containerID)
 	setRestoreStatus := func(value string) error {
-		annotations := map[string]string{
-			snapshotprotocol.RestoreStatusAnnotationFor(containerName):      value,
-			snapshotprotocol.RestoreContainerIDAnnotationFor(containerName): containerID,
+		annotations, err := snapshotprotocol.RestoreStatusAnnotations(containerName, value, containerID)
+		if err != nil {
+			return err
 		}
 		if restoreTrigger != "" {
-			annotations[snapshotprotocol.RestoreProcessedTriggerAnnotationFor(containerName)] = restoreTrigger
+			annotationKeys, err := snapshotprotocol.RestoreStatusAnnotationKeysFor(containerName)
+			if err != nil {
+				return err
+			}
+			annotations[annotationKeys.ProcessedTrigger] = restoreTrigger
 		}
 		if err := annotatePod(ctx, w.clientset, log, pod, annotations); err != nil {
 			if value == snapshotprotocol.RestoreStatusCompleted || value == snapshotprotocol.RestoreStatusFailed {

--- a/deploy/snapshot/internal/controller/controller_test.go
+++ b/deploy/snapshot/internal/controller/controller_test.go
@@ -728,6 +728,36 @@ func TestReconcileRestorePod(t *testing.T) {
 	}
 }
 
+func TestReconcileRestorePodRejectsTargetNameThatCannotFitStatusAnnotation(t *testing.T) {
+	checkpointID := "abc123"
+	containerName := "restore-target-with-long-name-123456"
+	w := makeTestController(t)
+	dir := filepath.Join(w.config.Storage.BasePath, checkpointID, "versions", snapshotprotocol.DefaultCheckpointArtifactVersion)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("failed to create checkpoint dir: %v", err)
+	}
+
+	pod := makePod(
+		"test-pod",
+		"default",
+		testNodeName,
+		corev1.PodRunning,
+		false,
+		map[string]string{snapshotprotocol.CheckpointIDLabel: checkpointID},
+		map[string]string{snapshotprotocol.TargetContainersAnnotation: containerName},
+	)
+	pod.Spec.Containers[0].Name = containerName
+	pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+		Name:        containerName,
+		ContainerID: "containerd://" + testContainerID,
+	}}
+
+	w.reconcileRestorePod(context.Background(), pod)
+	if len(w.inFlight) != 0 {
+		t.Fatalf("expected restore not to start for overlong annotation key, got inFlight=%v", w.inFlight)
+	}
+}
+
 func TestReconcileRestorePodResolvesContainerBeforePodStatus(t *testing.T) {
 	labels := map[string]string{
 		snapshotprotocol.CheckpointIDLabel: "abc123",

--- a/deploy/snapshot/internal/controller/controller_test.go
+++ b/deploy/snapshot/internal/controller/controller_test.go
@@ -464,6 +464,9 @@ func TestReconcileRestorePod(t *testing.T) {
 		hash                  string
 		annotationStatus      string
 		annotationContainerID string
+		restoreMode           string
+		restoreTrigger        string
+		processedTrigger      string
 		createDir             bool // whether to create the checkpoint dir on disk
 		preSeed               bool
 		want                  bool
@@ -555,6 +558,51 @@ func TestReconcileRestorePod(t *testing.T) {
 			want:                  false,
 		},
 		{
+			name:        "manual restore waits for trigger",
+			nodeName:    testNodeName,
+			phase:       corev1.PodRunning,
+			ready:       false,
+			hash:        "abc123",
+			restoreMode: snapshotprotocol.RestoreModeManual,
+			createDir:   true,
+			want:        false,
+		},
+		{
+			name:           "manual restore starts after trigger",
+			nodeName:       testNodeName,
+			phase:          corev1.PodRunning,
+			ready:          false,
+			hash:           "abc123",
+			restoreMode:    snapshotprotocol.RestoreModeManual,
+			restoreTrigger: "trigger-1",
+			createDir:      true,
+			want:           true,
+		},
+		{
+			name:             "manual restore ignores consumed trigger",
+			nodeName:         testNodeName,
+			phase:            corev1.PodRunning,
+			ready:            false,
+			hash:             "abc123",
+			restoreMode:      snapshotprotocol.RestoreModeManual,
+			restoreTrigger:   "trigger-1",
+			processedTrigger: "trigger-1",
+			createDir:        true,
+			want:             false,
+		},
+		{
+			name:             "manual restore allows fresh trigger",
+			nodeName:         testNodeName,
+			phase:            corev1.PodRunning,
+			ready:            false,
+			hash:             "abc123",
+			restoreMode:      snapshotprotocol.RestoreModeManual,
+			restoreTrigger:   "trigger-2",
+			processedTrigger: "trigger-1",
+			createDir:        true,
+			want:             true,
+		},
+		{
 			name:                  "completed for previous container retries",
 			nodeName:              testNodeName,
 			phase:                 corev1.PodRunning,
@@ -622,10 +670,22 @@ func TestReconcileRestorePod(t *testing.T) {
 
 			w := makeTestController(t)
 			var annotations map[string]string
-			if tc.annotationStatus != "" {
-				annotations = map[string]string{
-					snapshotprotocol.RestoreStatusAnnotationPrefix + "main":      tc.annotationStatus,
-					snapshotprotocol.RestoreContainerIDAnnotationPrefix + "main": tc.annotationContainerID,
+			if tc.annotationStatus != "" || tc.restoreMode != "" || tc.restoreTrigger != "" || tc.processedTrigger != "" {
+				annotations = map[string]string{}
+				if tc.annotationStatus != "" {
+					annotations[snapshotprotocol.RestoreStatusAnnotationFor("main")] = tc.annotationStatus
+				}
+				if tc.annotationContainerID != "" {
+					annotations[snapshotprotocol.RestoreContainerIDAnnotationFor("main")] = tc.annotationContainerID
+				}
+				if tc.restoreMode != "" {
+					annotations[snapshotprotocol.RestoreModeAnnotation] = tc.restoreMode
+				}
+				if tc.restoreTrigger != "" {
+					annotations[snapshotprotocol.RestoreTriggerAnnotation] = tc.restoreTrigger
+				}
+				if tc.processedTrigger != "" {
+					annotations[snapshotprotocol.RestoreProcessedTriggerAnnotationFor("main")] = tc.processedTrigger
 				}
 			}
 
@@ -665,36 +725,6 @@ func TestReconcileRestorePod(t *testing.T) {
 				time.Sleep(50 * time.Millisecond)
 			}
 		})
-	}
-}
-
-func TestReconcileRestorePodRejectsTargetNameThatCannotFitStatusAnnotation(t *testing.T) {
-	checkpointID := "abc123"
-	containerName := "restore-target-with-long-name-123456"
-	w := makeTestController(t)
-	dir := filepath.Join(w.config.Storage.BasePath, checkpointID, "versions", snapshotprotocol.DefaultCheckpointArtifactVersion)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		t.Fatalf("failed to create checkpoint dir: %v", err)
-	}
-
-	pod := makePod(
-		"test-pod",
-		"default",
-		testNodeName,
-		corev1.PodRunning,
-		false,
-		map[string]string{snapshotprotocol.CheckpointIDLabel: checkpointID},
-		map[string]string{snapshotprotocol.TargetContainersAnnotation: containerName},
-	)
-	pod.Spec.Containers[0].Name = containerName
-	pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
-		Name:        containerName,
-		ContainerID: "containerd://" + testContainerID,
-	}}
-
-	w.reconcileRestorePod(context.Background(), pod)
-	if len(w.inFlight) != 0 {
-		t.Fatalf("expected restore not to start for overlong annotation key, got inFlight=%v", w.inFlight)
 	}
 }
 

--- a/deploy/snapshot/protocol/common.go
+++ b/deploy/snapshot/protocol/common.go
@@ -7,15 +7,25 @@ import (
 	"fmt"
 	"strings"
 
-	"k8s.io/apimachinery/pkg/util/validation"
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (
+	// CheckpointSourceLabel tags the Job pod template (i.e. the pod whose
+	// checkpoint gets written to disk). The snapshot agent's checkpoint
+	// informer selects on this label.
 	CheckpointSourceLabel = "nvidia.com/snapshot-is-checkpoint-source"
 
-	// Restore pods carry CheckpointIDLabel without CheckpointSourceLabel.
-	CheckpointIDLabel  = "nvidia.com/snapshot-checkpoint-id"
-	RestoreTargetLabel = "nvidia.com/snapshot-is-restore-target"
+	// CheckpointIDLabel is the 16-character identity hash (or a generated
+	// manual ID for snapshotctl flows). Both the checkpoint Job pod and
+	// the restore pod carry it; the CheckpointSourceLabel is what
+	// distinguishes them.
+	//
+	// Restore pods are therefore selected as
+	//   CheckpointIDLabel exists AND NOT CheckpointSourceLabel exists
+	// which is cleaner than carrying a redundant "is restore target"
+	// boolean label in parallel with the target-containers annotation.
+	CheckpointIDLabel = "nvidia.com/snapshot-checkpoint-id"
 
 	CheckpointArtifactVersionAnnotation = "nvidia.com/snapshot-artifact-version"
 
@@ -33,17 +43,37 @@ const (
 	// both user-facing paths (DynamoCheckpoint Jobs and DGD restore pods).
 	TargetContainersAnnotation = "nvidia.com/snapshot-target-containers"
 
+	// RestoreModeAnnotation opts a restore target into benchmark-controlled
+	// restore triggering. The default path ignores RestoreTriggerAnnotation.
+	RestoreModeAnnotation    = "nvidia.com/snapshot-restore-mode"
+	RestoreModeManual        = "manual"
+	RestoreTriggerAnnotation = "nvidia.com/snapshot-restore-trigger"
+
+	// CheckpointStatusAnnotation is written by snapshot-agent on the
+	// checkpoint Job once the (single) target container's checkpoint either
+	// completes or fails. Watched by the operator and snapshotctl.
 	CheckpointStatusAnnotation = "nvidia.com/snapshot-checkpoint-status"
 
-	// Full keys are nvidia.com/snapshot-restore-status.<containerName>.
+	// RestoreStatusAnnotationPrefix is the prefix for per-container restore
+	// status annotations written by snapshot-agent onto the restore pod.
+	// The full key is "nvidia.com/snapshot-restore-status.<containerName>",
+	// one per target container. Use RestoreStatusAnnotationFor to build it.
 	RestoreStatusAnnotationPrefix = "nvidia.com/snapshot-restore-status."
 
-	// Full keys are nvidia.com/snapshot-restore-container-id.<containerName>.
+	// RestoreContainerIDAnnotationPrefix is the prefix for per-container
+	// containerd container-ID annotations used to dedupe restore attempts
+	// across kubelet container restarts. Full key is
+	// "nvidia.com/snapshot-restore-container-id.<containerName>".
 	RestoreContainerIDAnnotationPrefix = "nvidia.com/snapshot-restore-container-id."
 
 	// Legacy unscoped restore status keys, cleared when stamping fresh metadata.
 	RestoreStatusAnnotation      = "nvidia.com/snapshot-restore-status"
 	RestoreContainerIDAnnotation = "nvidia.com/snapshot-restore-container-id"
+
+	// RestoreProcessedTriggerAnnotationPrefix stores the last consumed manual
+	// trigger per target container so a pod restart does not replay the same
+	// benchmark trigger unless the harness writes a fresh token.
+	RestoreProcessedTriggerAnnotationPrefix = "nvidia.com/snapshot-restore-processed-trigger."
 
 	CheckpointStorageTypeAnnotation     = "nvidia.com/snapshot-storage-type"
 	CheckpointStorageBasePathAnnotation = "nvidia.com/snapshot-storage-base-path"
@@ -67,9 +97,16 @@ type Storage struct {
 	BasePath string
 }
 
-type RestoreStatusAnnotationKeys struct {
-	Status      string
-	ContainerID string
+// findContainerByName returns a pointer to the named container in the slice,
+// or nil if not found. Used by the protocol helpers to look up target
+// containers declared in the snapshot-target-containers annotation.
+func findContainerByName(containers []corev1.Container, name string) *corev1.Container {
+	for i := range containers {
+		if containers[i].Name == name {
+			return &containers[i]
+		}
+	}
+	return nil
 }
 
 func ArtifactVersion(version string) string {
@@ -102,7 +139,26 @@ func ResolveRestoreStorage(checkpointID string, version string, location string,
 	return resolved, nil
 }
 
-// FormatTargetContainers renders the canonical annotation value.
+// RestoreStatusAnnotationFor returns the per-container restore status
+// annotation key. Safe to call with any container name.
+func RestoreStatusAnnotationFor(containerName string) string {
+	return RestoreStatusAnnotationPrefix + containerName
+}
+
+// RestoreContainerIDAnnotationFor returns the per-container containerd-ID
+// annotation key used by the restore dedupe path.
+func RestoreContainerIDAnnotationFor(containerName string) string {
+	return RestoreContainerIDAnnotationPrefix + containerName
+}
+
+func RestoreProcessedTriggerAnnotationFor(containerName string) string {
+	return RestoreProcessedTriggerAnnotationPrefix + containerName
+}
+
+// FormatTargetContainers renders a target-container list into the canonical
+// comma-separated annotation value. Whitespace is trimmed, empty names are
+// dropped, and duplicates are preserved in input order (callers are
+// responsible for providing a sensible list).
 func FormatTargetContainers(names []string) string {
 	cleaned := make([]string, 0, len(names))
 	for _, name := range names {
@@ -115,7 +171,10 @@ func FormatTargetContainers(names []string) string {
 	return strings.Join(cleaned, ",")
 }
 
-// ParseTargetContainers trims names and rejects empty or duplicate entries.
+// ParseTargetContainers returns the list of target container names encoded
+// in the nvidia.com/snapshot-target-containers annotation, in order. A
+// missing or empty annotation returns an empty slice; callers decide whether
+// that is an error. Whitespace is trimmed and duplicate names are rejected.
 func ParseTargetContainers(value string) ([]string, error) {
 	value = strings.TrimSpace(value)
 	if value == "" {
@@ -138,7 +197,10 @@ func ParseTargetContainers(value string) ([]string, error) {
 	return out, nil
 }
 
-// TargetContainersFromAnnotations requires the target list and enforces bounds.
+// TargetContainersFromAnnotations reads the target-container list from an
+// annotation map. It enforces the snapshot contract: the annotation is
+// required, and at least minCount / at most maxCount names must be present
+// (maxCount == 0 means "no upper bound").
 func TargetContainersFromAnnotations(annotations map[string]string, minCount, maxCount int) ([]string, error) {
 	raw, ok := annotations[TargetContainersAnnotation]
 	if !ok || strings.TrimSpace(raw) == "" {
@@ -157,60 +219,50 @@ func TargetContainersFromAnnotations(annotations map[string]string, minCount, ma
 	return names, nil
 }
 
-func RestoreStatusAnnotationKeysFor(containerName string) (RestoreStatusAnnotationKeys, error) {
-	keys := RestoreStatusAnnotationKeys{
-		Status:      RestoreStatusAnnotationPrefix + containerName,
-		ContainerID: RestoreContainerIDAnnotationPrefix + containerName,
-	}
-	for _, annotationKey := range []string{keys.Status, keys.ContainerID} {
-		if errs := validation.IsQualifiedName(annotationKey); len(errs) > 0 {
-			return RestoreStatusAnnotationKeys{}, fmt.Errorf("container name %q cannot be used in restore status annotation key %q: %s", containerName, annotationKey, strings.Join(errs, "; "))
-		}
-	}
-	return keys, nil
-}
-
-func RestoreStatusAnnotations(containerName, status, containerID string) (map[string]string, error) {
-	keys, err := RestoreStatusAnnotationKeysFor(containerName)
-	if err != nil {
-		return nil, err
-	}
-	return map[string]string{
-		keys.Status:      status,
-		keys.ContainerID: containerID,
-	}, nil
-}
-
+// clearRestoreStatusKeys drops every restore status annotation from the map.
+// Used when re-applying restore-target metadata before a new restore so stale
+// values from a previous run do not leak into observation.
 func clearRestoreStatusKeys(annotations map[string]string) {
 	delete(annotations, "nvidia.com/snapshot-restore-status")
 	delete(annotations, "nvidia.com/snapshot-restore-container-id")
 	for key := range annotations {
 		if strings.HasPrefix(key, RestoreStatusAnnotationPrefix) ||
-			strings.HasPrefix(key, RestoreContainerIDAnnotationPrefix) {
+			strings.HasPrefix(key, RestoreContainerIDAnnotationPrefix) ||
+			strings.HasPrefix(key, RestoreProcessedTriggerAnnotationPrefix) {
 			delete(annotations, key)
 		}
 	}
 }
 
-// ApplyRestoreTargetMetadata resets restore metadata and stamps checkpoint ID.
-// The caller owns TargetContainersAnnotation.
-func ApplyRestoreTargetMetadata(labels map[string]string, annotations map[string]string, enabled bool, checkpointID string, artifactVersion string) {
+// ApplyRestoreTargetMetadata resets restore-related labels/annotations and
+// (when enabled) stamps the checkpoint-id label + artifact version
+// annotation. A pod is identified as a restore target by the snapshot agent
+// via (CheckpointIDLabel present, CheckpointSourceLabel absent); there is
+// no dedicated "is restore target" label. The nvidia.com/snapshot-target-
+// containers annotation is the caller's responsibility: the operator stamps
+// it based on failover vs non-failover intent, snapshotctl stamps it from
+// --containers, etc. This helper never touches it so callers can set it
+// before or after with no ordering surprise.
+func ApplyRestoreTargetMetadata(labels map[string]string, annotations map[string]string, enabled bool, manualTrigger bool, checkpointID string, artifactVersion string) {
 	delete(labels, CheckpointSourceLabel)
-	delete(labels, RestoreTargetLabel)
 	delete(labels, CheckpointIDLabel)
 	delete(annotations, CheckpointArtifactVersionAnnotation)
 	delete(annotations, CheckpointStatusAnnotation)
+	delete(annotations, RestoreModeAnnotation)
+	delete(annotations, RestoreTriggerAnnotation)
 	clearRestoreStatusKeys(annotations)
 
 	if !enabled {
 		return
 	}
 
-	labels[RestoreTargetLabel] = "true"
 	if checkpointID != "" {
 		labels[CheckpointIDLabel] = checkpointID
 	}
 	annotations[CheckpointArtifactVersionAnnotation] = ArtifactVersion(artifactVersion)
+	if manualTrigger {
+		annotations[RestoreModeAnnotation] = RestoreModeManual
+	}
 }
 
 func ApplyCheckpointStorageMetadata(annotations map[string]string, storage Storage) {
@@ -234,7 +286,6 @@ func ApplyCheckpointStorageMetadata(annotations map[string]string, storage Stora
 }
 
 func applyCheckpointSourceMetadata(labels map[string]string, annotations map[string]string, checkpointID string, artifactVersion string) {
-	delete(labels, RestoreTargetLabel)
 	delete(labels, CheckpointIDLabel)
 	delete(annotations, CheckpointArtifactVersionAnnotation)
 

--- a/deploy/snapshot/protocol/common.go
+++ b/deploy/snapshot/protocol/common.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
 )
 
 const (
@@ -97,6 +98,12 @@ type Storage struct {
 	BasePath string
 }
 
+type RestoreStatusAnnotationKeys struct {
+	Status           string
+	ContainerID      string
+	ProcessedTrigger string
+}
+
 // findContainerByName returns a pointer to the named container in the slice,
 // or nil if not found. Used by the protocol helpers to look up target
 // containers declared in the snapshot-target-containers annotation.
@@ -153,6 +160,31 @@ func RestoreContainerIDAnnotationFor(containerName string) string {
 
 func RestoreProcessedTriggerAnnotationFor(containerName string) string {
 	return RestoreProcessedTriggerAnnotationPrefix + containerName
+}
+
+func RestoreStatusAnnotationKeysFor(containerName string) (RestoreStatusAnnotationKeys, error) {
+	keys := RestoreStatusAnnotationKeys{
+		Status:           RestoreStatusAnnotationPrefix + containerName,
+		ContainerID:      RestoreContainerIDAnnotationPrefix + containerName,
+		ProcessedTrigger: RestoreProcessedTriggerAnnotationPrefix + containerName,
+	}
+	for _, annotationKey := range []string{keys.Status, keys.ContainerID, keys.ProcessedTrigger} {
+		if errs := validation.IsQualifiedName(annotationKey); len(errs) > 0 {
+			return RestoreStatusAnnotationKeys{}, fmt.Errorf("container name %q cannot be used in restore status annotation key %q: %s", containerName, annotationKey, strings.Join(errs, "; "))
+		}
+	}
+	return keys, nil
+}
+
+func RestoreStatusAnnotations(containerName, status, containerID string) (map[string]string, error) {
+	keys, err := RestoreStatusAnnotationKeysFor(containerName)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]string{
+		keys.Status:      status,
+		keys.ContainerID: containerID,
+	}, nil
 }
 
 // FormatTargetContainers renders a target-container list into the canonical

--- a/deploy/snapshot/protocol/constants_test.go
+++ b/deploy/snapshot/protocol/constants_test.go
@@ -5,7 +5,6 @@ package protocol
 
 import (
 	"reflect"
-	"strings"
 	"testing"
 )
 
@@ -15,19 +14,22 @@ func TestApplyRestoreTargetMetadata(t *testing.T) {
 		CheckpointIDLabel:     "old",
 	}
 	annotations := map[string]string{
-		CheckpointArtifactVersionAnnotation:             "old",
-		CheckpointStatusAnnotation:                      "completed",
-		RestoreStatusAnnotationPrefix + "main":          "failed",
-		RestoreStatusAnnotationPrefix + "engine-1":      "completed",
-		RestoreContainerIDAnnotationPrefix + "main":     "dead-container",
-		RestoreContainerIDAnnotationPrefix + "engine-1": "dead-container",
-		"nvidia.com/snapshot-restore-status":            "completed",
-		"nvidia.com/snapshot-restore-container-id":      "dead-container",
+		CheckpointArtifactVersionAnnotation:          "old",
+		CheckpointStatusAnnotation:                   "completed",
+		RestoreStatusAnnotationFor("main"):           "failed",
+		RestoreStatusAnnotationFor("engine-1"):       "completed",
+		RestoreContainerIDAnnotationFor("main"):      "dead-container",
+		RestoreContainerIDAnnotationFor("engine-1"):  "dead-container",
+		RestoreModeAnnotation:                        RestoreModeManual,
+		RestoreTriggerAnnotation:                     "stale-trigger",
+		RestoreProcessedTriggerAnnotationFor("main"): "stale-trigger",
+		"nvidia.com/snapshot-restore-status":         "completed",
+		"nvidia.com/snapshot-restore-container-id":   "dead-container",
 		// Preserve the target-containers annotation across ApplyRestoreTargetMetadata.
 		TargetContainersAnnotation: "main",
 	}
 
-	ApplyRestoreTargetMetadata(labels, annotations, true, "hash", "2")
+	ApplyRestoreTargetMetadata(labels, annotations, true, true, "hash", "2")
 
 	if labels[CheckpointIDLabel] != "hash" {
 		t.Fatalf("expected checkpoint hash label, got %#v", labels)
@@ -42,10 +44,12 @@ func TestApplyRestoreTargetMetadata(t *testing.T) {
 		t.Fatalf("checkpoint status annotation was not cleared: %#v", annotations)
 	}
 	for _, key := range []string{
-		RestoreStatusAnnotationPrefix + "main",
-		RestoreStatusAnnotationPrefix + "engine-1",
-		RestoreContainerIDAnnotationPrefix + "main",
-		RestoreContainerIDAnnotationPrefix + "engine-1",
+		RestoreStatusAnnotationFor("main"),
+		RestoreStatusAnnotationFor("engine-1"),
+		RestoreContainerIDAnnotationFor("main"),
+		RestoreContainerIDAnnotationFor("engine-1"),
+		RestoreTriggerAnnotation,
+		RestoreProcessedTriggerAnnotationFor("main"),
 		"nvidia.com/snapshot-restore-status",
 		"nvidia.com/snapshot-restore-container-id",
 	} {
@@ -56,6 +60,9 @@ func TestApplyRestoreTargetMetadata(t *testing.T) {
 	if got := annotations[TargetContainersAnnotation]; got != "main" {
 		t.Fatalf("target-containers annotation must be preserved, got %q", got)
 	}
+	if got := annotations[RestoreModeAnnotation]; got != RestoreModeManual {
+		t.Fatalf("expected manual restore mode, got %q", got)
+	}
 }
 
 func TestApplyRestoreTargetMetadataDisabledClearsState(t *testing.T) {
@@ -63,13 +70,16 @@ func TestApplyRestoreTargetMetadataDisabledClearsState(t *testing.T) {
 		CheckpointIDLabel: "hash",
 	}
 	annotations := map[string]string{
-		CheckpointArtifactVersionAnnotation:         "2",
-		CheckpointStatusAnnotation:                  "completed",
-		RestoreStatusAnnotationPrefix + "main":      "failed",
-		RestoreContainerIDAnnotationPrefix + "main": "dead-container",
+		CheckpointArtifactVersionAnnotation:          "2",
+		CheckpointStatusAnnotation:                   "completed",
+		RestoreStatusAnnotationFor("main"):           "failed",
+		RestoreContainerIDAnnotationFor("main"):      "dead-container",
+		RestoreModeAnnotation:                        RestoreModeManual,
+		RestoreTriggerAnnotation:                     "stale-trigger",
+		RestoreProcessedTriggerAnnotationFor("main"): "stale-trigger",
 	}
 
-	ApplyRestoreTargetMetadata(labels, annotations, false, "", "")
+	ApplyRestoreTargetMetadata(labels, annotations, false, false, "", "")
 
 	if _, ok := labels[CheckpointIDLabel]; ok {
 		t.Fatalf("checkpoint hash label was not cleared: %#v", labels)
@@ -80,11 +90,20 @@ func TestApplyRestoreTargetMetadataDisabledClearsState(t *testing.T) {
 	if _, ok := annotations[CheckpointStatusAnnotation]; ok {
 		t.Fatalf("checkpoint status annotation was not cleared: %#v", annotations)
 	}
-	if _, ok := annotations[RestoreStatusAnnotationPrefix+"main"]; ok {
+	if _, ok := annotations[RestoreStatusAnnotationFor("main")]; ok {
 		t.Fatalf("per-container restore status was not cleared: %#v", annotations)
 	}
-	if _, ok := annotations[RestoreContainerIDAnnotationPrefix+"main"]; ok {
+	if _, ok := annotations[RestoreContainerIDAnnotationFor("main")]; ok {
 		t.Fatalf("per-container restore container id was not cleared: %#v", annotations)
+	}
+	if _, ok := annotations[RestoreModeAnnotation]; ok {
+		t.Fatalf("restore mode was not cleared: %#v", annotations)
+	}
+	if _, ok := annotations[RestoreTriggerAnnotation]; ok {
+		t.Fatalf("restore trigger was not cleared: %#v", annotations)
+	}
+	if _, ok := annotations[RestoreProcessedTriggerAnnotationFor("main")]; ok {
+		t.Fatalf("processed restore trigger was not cleared: %#v", annotations)
 	}
 }
 
@@ -156,30 +175,6 @@ func TestTargetContainersFromAnnotationsBounds(t *testing.T) {
 	}
 	if _, err := TargetContainersFromAnnotations(map[string]string{TargetContainersAnnotation: "a,a"}, 1, 0); err == nil {
 		t.Fatalf("expected dup rejection")
-	}
-}
-
-func TestRestoreStatusAnnotations(t *testing.T) {
-	got, err := RestoreStatusAnnotations("engine-1", RestoreStatusCompleted, "container-id")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	want := map[string]string{
-		RestoreStatusAnnotationPrefix + "engine-1":      RestoreStatusCompleted,
-		RestoreContainerIDAnnotationPrefix + "engine-1": "container-id",
-	}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("got %#v, want %#v", got, want)
-	}
-}
-
-func TestRestoreStatusAnnotationsRejectsInvalidContainerName(t *testing.T) {
-	_, err := RestoreStatusAnnotations(strings.Repeat("a", 200), RestoreStatusInProgress, "container-id")
-	if err == nil {
-		t.Fatalf("expected invalid annotation key error")
-	}
-	if !strings.Contains(err.Error(), "restore status annotation key") {
-		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/deploy/snapshot/protocol/restore.go
+++ b/deploy/snapshot/protocol/restore.go
@@ -29,6 +29,7 @@ type PodOptions struct {
 	ArtifactVersion string
 	Storage         Storage
 	SeccompProfile  string
+	ManualTrigger   bool
 }
 
 // NewRestorePod shapes every annotated target container for restore.
@@ -40,7 +41,7 @@ func NewRestorePod(pod *corev1.Pod, opts PodOptions) (*corev1.Pod, error) {
 	if pod.Annotations == nil {
 		pod.Annotations = map[string]string{}
 	}
-	ApplyRestoreTargetMetadata(pod.Labels, pod.Annotations, true, opts.CheckpointID, opts.ArtifactVersion)
+	ApplyRestoreTargetMetadata(pod.Labels, pod.Annotations, true, opts.ManualTrigger, opts.CheckpointID, opts.ArtifactVersion)
 	if err := PrepareRestorePodSpec(&pod.Spec, pod.Annotations, opts.Storage, opts.SeccompProfile, true); err != nil {
 		return nil, err
 	}

--- a/lib/gpu_memory_service/cli/snapshot/loader.py
+++ b/lib/gpu_memory_service/cli/snapshot/loader.py
@@ -60,7 +60,10 @@ GMS_TRANSFER_BACKEND_ENV = "GMS_TRANSFER_BACKEND"
 GMS_POD_UID_ENV = "GMS_POD_UID"
 GMS_WEIGHTS_CHECKPOINT_DIR_ENV = "GMS_WEIGHTS_CHECKPOINT_DIR"
 GMS_RESTORE_TRIGGER_FILE_ENV = "GMS_RESTORE_TRIGGER_FILE"
+GMS_RESTORE_TRIGGER_ANNOTATION_ENV = "GMS_RESTORE_TRIGGER_ANNOTATION"
 RESTORE_TRIGGER_POLL_SECONDS = 0.05
+K8S_API_TIMEOUT_SECONDS = 2.0
+SERVICE_ACCOUNT_DIR = Path("/var/run/secrets/kubernetes.io/serviceaccount")
 
 
 def _load_device(
@@ -114,13 +117,8 @@ def _clear_completion_sentinel(checkpoint_dir: str) -> None:
         pass
 
 
-def _wait_for_restore_trigger() -> None:
-    trigger_file = os.environ.get(GMS_RESTORE_TRIGGER_FILE_ENV, "").strip()
-    if not trigger_file:
-        return
-
-    path = Path(trigger_file)
-    _startup_log("restore_trigger_wait_start", f"path={path}")
+def _wait_for_restore_trigger_file(path: Path) -> None:
+    _startup_log("restore_trigger_file_wait_start", f"path={path}")
     while True:
         try:
             trigger = path.read_text(encoding="utf-8").strip()
@@ -128,9 +126,104 @@ def _wait_for_restore_trigger() -> None:
             trigger = ""
         if trigger:
             logger.info("Observed GMS restore trigger: file=%s token=%s", path, trigger)
-            _startup_log("restore_trigger_wait_done", f"token={trigger}")
+            _startup_log("restore_trigger_file_wait_done", f"token={trigger}")
             return
         time.sleep(RESTORE_TRIGGER_POLL_SECONDS)
+
+
+def _k8s_pod_annotation_reader(annotation: str):
+    import json
+    import ssl
+    from urllib import parse, request
+
+    host = os.environ.get("KUBERNETES_SERVICE_HOST", "").strip()
+    port = os.environ.get("KUBERNETES_SERVICE_PORT_HTTPS", "").strip() or "443"
+    pod_name = os.environ.get("HOSTNAME", "").strip()
+    namespace = (SERVICE_ACCOUNT_DIR / "namespace").read_text(encoding="utf-8").strip()
+    token = (SERVICE_ACCOUNT_DIR / "token").read_text(encoding="utf-8").strip()
+    if not host or not pod_name or not namespace or not token:
+        raise RuntimeError(
+            "missing Kubernetes service host, pod name, namespace, or service account token"
+        )
+
+    url = (
+        f"https://{host}:{port}/api/v1/namespaces/"
+        f"{parse.quote(namespace, safe='')}/pods/{parse.quote(pod_name, safe='')}"
+    )
+    ca_path = SERVICE_ACCOUNT_DIR / "ca.crt"
+    context = (
+        ssl.create_default_context(cafile=str(ca_path))
+        if ca_path.exists()
+        else ssl.create_default_context()
+    )
+
+    def read_annotation() -> str:
+        req = request.Request(
+            url,
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        with request.urlopen(
+            req,
+            context=context,
+            timeout=K8S_API_TIMEOUT_SECONDS,
+        ) as resp:
+            pod = json.loads(resp.read())
+        annotations = pod.get("metadata", {}).get("annotations") or {}
+        return str(annotations.get(annotation, "")).strip()
+
+    return namespace, pod_name, read_annotation
+
+
+def _wait_for_restore_trigger_annotation(annotation: str) -> bool:
+    try:
+        namespace, pod_name, read_annotation = _k8s_pod_annotation_reader(annotation)
+    except Exception as exc:
+        logger.warning(
+            "Unable to configure GMS restore trigger annotation watch: annotation=%s error=%s",
+            annotation,
+            exc,
+        )
+        return False
+
+    _startup_log(
+        "restore_trigger_k8s_wait_start",
+        f"annotation={annotation} pod={namespace}/{pod_name}",
+    )
+    next_error_log = 0.0
+    while True:
+        try:
+            trigger = read_annotation()
+        except Exception as exc:
+            now = time.monotonic()
+            if now >= next_error_log:
+                logger.warning(
+                    "Waiting for GMS restore trigger annotation failed: annotation=%s error=%s",
+                    annotation,
+                    exc,
+                )
+                next_error_log = now + 5.0
+            trigger = ""
+        if trigger:
+            logger.info(
+                "Observed GMS restore trigger: annotation=%s token=%s",
+                annotation,
+                trigger,
+            )
+            _startup_log("restore_trigger_k8s_wait_done", f"token={trigger}")
+            return True
+        time.sleep(RESTORE_TRIGGER_POLL_SECONDS)
+
+
+def _wait_for_restore_trigger() -> None:
+    annotation = os.environ.get(GMS_RESTORE_TRIGGER_ANNOTATION_ENV, "").strip()
+    if annotation and _wait_for_restore_trigger_annotation(annotation):
+        return
+
+    trigger_file = os.environ.get(GMS_RESTORE_TRIGGER_FILE_ENV, "").strip()
+    if not trigger_file:
+        return
+
+    _wait_for_restore_trigger_file(Path(trigger_file))
 
 
 def _list_checkpoint_devices(checkpoint_dir: str) -> list[int]:

--- a/lib/gpu_memory_service/cli/snapshot/loader.py
+++ b/lib/gpu_memory_service/cli/snapshot/loader.py
@@ -59,6 +59,8 @@ GMS_LOAD_COMPLETE_FILE_ENV = "GMS_LOAD_COMPLETE_FILE"
 GMS_TRANSFER_BACKEND_ENV = "GMS_TRANSFER_BACKEND"
 GMS_POD_UID_ENV = "GMS_POD_UID"
 GMS_WEIGHTS_CHECKPOINT_DIR_ENV = "GMS_WEIGHTS_CHECKPOINT_DIR"
+GMS_RESTORE_TRIGGER_FILE_ENV = "GMS_RESTORE_TRIGGER_FILE"
+RESTORE_TRIGGER_POLL_SECONDS = 0.05
 
 
 def _load_device(
@@ -112,6 +114,25 @@ def _clear_completion_sentinel(checkpoint_dir: str) -> None:
         pass
 
 
+def _wait_for_restore_trigger() -> None:
+    trigger_file = os.environ.get(GMS_RESTORE_TRIGGER_FILE_ENV, "").strip()
+    if not trigger_file:
+        return
+
+    path = Path(trigger_file)
+    _startup_log("restore_trigger_wait_start", f"path={path}")
+    while True:
+        try:
+            trigger = path.read_text(encoding="utf-8").strip()
+        except FileNotFoundError:
+            trigger = ""
+        if trigger:
+            logger.info("Observed GMS restore trigger: file=%s token=%s", path, trigger)
+            _startup_log("restore_trigger_wait_done", f"token={trigger}")
+            return
+        time.sleep(RESTORE_TRIGGER_POLL_SECONDS)
+
+
 def _list_checkpoint_devices(checkpoint_dir: str) -> list[int]:
     devices: list[int] = []
     for child in Path(checkpoint_dir).iterdir():
@@ -157,6 +178,7 @@ def main() -> None:
     _startup_log("clear_sentinel_start")
     _clear_completion_sentinel(control_dir)
     _startup_log("clear_sentinel_done")
+    _wait_for_restore_trigger()
     _startup_log("discover_devices_start")
     devices = _list_checkpoint_devices(checkpoint_dir)
     _startup_log(


### PR DESCRIPTION
## Summary

Adds an opt-in manual restore trigger for benchmark coordination, stacked on #9045.

- Adds manual restore mode so snapshot-agent can stage restore targets without immediately starting `nsrestore`.
- Keeps default restore behavior unchanged unless `nvidia.com/snapshot-restore-mode=manual` is set or `snapshotctl restore --manual-trigger` is used.
- Tracks consumed trigger tokens per restore target container so a benchmark trigger is not replayed after container restarts.
- Adds `snapshotctl trigger-restore` to submit a fresh trigger token.
- Allows GMS loader benchmarking to wait on the same restore trigger, either through the projected Downward API file (`GMS_RESTORE_TRIGGER_FILE`) or direct Pod annotation polling (`GMS_RESTORE_TRIGGER_ANNOTATION`).
- Rebased on the updated snapshot+GMS stack after the #8833/#8900/#9045 validation fixes.

## Notes

This PR is intentionally stacked on #8900/#9045 and is meant for benchmark coordination. It should not be folded into the base GMS transfer-backend PR.

The API trigger path is specifically for tighter benchmark alignment: snapshot-agent and gms-loader can both observe `nvidia.com/snapshot-restore-trigger` through the Kubernetes API instead of mixing API watch and Downward API file projection.

## Validation

- `cd deploy/snapshot && go test ./protocol ./internal/controller ./cmd/snapshotctl/...`
- `cd deploy/operator && go test ./internal/checkpoint`
- `PYTHONPATH=lib python3 -m py_compile lib/gpu_memory_service/cli/snapshot/loader.py`
- `git diff --check`
- nscale clean smoke: `gms-local-ssd-pinned-manual-trigger-api-clean-qwen3-06b-l9nsv-20260503T080350Z`
  - Qwen/Qwen3-0.6B, same-node `l9nsv`, `GMS_TRANSFER_BACKEND=local-ssd-pinned`
  - post-restore inference returned coherent output with `finish_reason=stop`
  - `gms_load_start` was about `19ms` after snapshot-agent detection and about `123ms` before `nsrestore_start`
- Final rebuilt-stack validation in namespace `schwinns`:
  - vLLM and SGLang `Qwen/Qwen3-0.6B` snapshot+GMS restore passed for intra-pod and inter-pod GMS.
  - vLLM `Qwen/Qwen2.5-72B-Instruct` default-PVC timing passed: restore-agent wall `3.833s`, GMS load `19.31s`.
  - SGLang `Qwen/Qwen2.5-72B-Instruct` default-PVC timing passed: restore-agent wall `3.982s`, GMS load `22.204s`.

Attempted `cd deploy/operator && go test ./internal/checkpoint ./internal/controller`; `internal/checkpoint` passed, but `internal/controller` could not start envtest because `../../bin/k8s/1.29.0-linux-amd64/etcd` is missing in this worktree.


## 2026-05-12 rebase update

Rebased this stack layer onto the refreshed #9045/#8900/#8833 stack. Conflict fixes kept main's new DCD metadata helper flow and reapplied the manual restore trigger behavior:

- preserve `nvidia.com/snapshot-restore-mode=manual` from DCD resource/pod-template annotations before checkpoint restore metadata stamping
- adapt the manual restore propagation test to the v1beta1 DCD `podTemplate.annotations` shape

Validated after restacking:

- `go test ./internal/dynamo ./internal/checkpoint ./internal/gms -count=1 -v`
- `go test ./internal/controller -count=1 -v` with local envtest assets



## 2026-05-12 Final Stack Rebuild

No additional code changes were needed in this layer after the latest restack. The rebuilt top-stack validation from commit `f5c920d1166b` kept the manual/API restore-trigger layer stacked cleanly above the GMS restore-target and transfer-backend changes.


## 2026-05-13 Restack Update

Rebased and pushed this layer at `20bb16aca1e` above the decoupled #8833/#8900/#9045 stack. No additional code changes were required in this PR; the manual/API restore trigger behavior remains benchmark-only and independent of the GMS sentinel removal.

Included in the rebuilt-stack validation from top commit `42f4cccb5e6f`:

- vLLM and SGLang `Qwen/Qwen3-0.6B` snapshot+intra-pod GMS restore passed with no explicit `gms_ro_connect_timeout_ms`.
- Snapshot-agent completed restore after `nsrestore`; GMS loader commit remained out of band and the workload resumed via the GMS RO lock path.
