### PR TITLE
DGH-703: Unified k8s test framework — phase 1 + 1.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,6 @@ package-lock.json
 # macOS
 .DS_Store
 **/.DS_Store
+
+# Test output (logs, aiperf artifacts, fault-tolerance reports) — see tests/utils/test_output.py
+test_outputs/

--- a/container/deps/vllm/install_vllm.sh
+++ b/container/deps/vllm/install_vllm.sh
@@ -277,7 +277,12 @@ if [ "$DEVICE" = "cuda" ]; then
         exit 1
     fi
     rm -rf ${INSTALLATION_DIR}/lmcache
-    echo "✓ LMCache ${LMCACHE_REF} installed from source"
+    # PR #7534 enabled the lmcache CUDA-13 path which transitively pulls
+    # nixl-cu13 1.1.0. On a CUDA-12 image (this one) we already have the
+    # source-built nixl-cu12 0.10.1; the cu13 backend is ABI-incompatible
+    # (NIXL_ERR_NOT_FOUND at backend creation). Drop it.
+    uv pip uninstall nixl-cu13 2>/dev/null || true
+    echo "✓ LMCache ${LMCACHE_REF} installed from source (nixl-cu13 removed; cu12 0.10.1 retained)"
 elif [ "$DEVICE" = "xpu" ] && [ "$ARCH" = "amd64" ]; then
     uv pip install lmcache==${LMCACHE_REF}
     echo "✓ LMCache ${LMCACHE_REF} installed from PyPI (XPU)"

--- a/dashboards/cascade-disagg.json
+++ b/dashboards/cascade-disagg.json
@@ -1,0 +1,319 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "$$hashKey": "object:1",
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      },
+      {
+        "name": "cascade-injects",
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "iconColor": "red",
+        "matchAny": false,
+        "tags": ["cascade"],
+        "type": "tags"
+      }
+    ]
+  },
+  "description": "vLLM disagg cascade scenario dashboard — per-worker queueing, KV usage, NIXL transfer time, preemptions, plus frontend TTFT/RTT.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0},
+      "id": 100,
+      "panels": [],
+      "title": "Per-worker queueing",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "palette-classic"}, "custom": {"drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 2, "fillOpacity": 5, "showPoints": "never"}, "unit": "short"},
+        "overrides": []
+      },
+      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 1},
+      "id": 1,
+      "options": {"legend": {"displayMode": "table", "placement": "right", "showLegend": true}, "tooltip": {"mode": "multi"}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "expr": "sum by (pod, dynamo_subcomponent) (vllm:num_requests_waiting{namespace=~\"$namespace\", pod=~\".*$dgd.*\"})",
+          "legendFormat": "{{pod}} ({{dynamo_subcomponent}})",
+          "refId": "A"
+        }
+      ],
+      "title": "vllm:num_requests_waiting (per worker)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "palette-classic"}, "custom": {"drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 2, "fillOpacity": 5, "showPoints": "never"}, "unit": "short"},
+        "overrides": []
+      },
+      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 1},
+      "id": 2,
+      "options": {"legend": {"displayMode": "table", "placement": "right", "showLegend": true}, "tooltip": {"mode": "multi"}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "expr": "sum by (pod, dynamo_subcomponent) (vllm:num_requests_running{namespace=~\"$namespace\", pod=~\".*$dgd.*\"})",
+          "legendFormat": "{{pod}} ({{dynamo_subcomponent}})",
+          "refId": "A"
+        }
+      ],
+      "title": "vllm:num_requests_running (per worker)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 10},
+      "id": 101,
+      "panels": [],
+      "title": "KV cache + NIXL transfer",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "palette-classic"}, "custom": {"drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 2, "fillOpacity": 5, "showPoints": "never"}, "unit": "percentunit", "max": 1, "min": 0},
+        "overrides": []
+      },
+      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 11},
+      "id": 3,
+      "options": {"legend": {"displayMode": "table", "placement": "right", "showLegend": true}, "tooltip": {"mode": "multi"}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "expr": "max by (pod, dynamo_subcomponent) (vllm:kv_cache_usage_perc{namespace=~\"$namespace\", pod=~\".*$dgd.*\"})",
+          "legendFormat": "{{pod}} ({{dynamo_subcomponent}})",
+          "refId": "A"
+        }
+      ],
+      "title": "vllm:kv_cache_usage_perc (per worker)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {"unit": "s"},
+        "overrides": []
+      },
+      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 11},
+      "id": 4,
+      "options": {"calculate": false, "cellGap": 1, "color": {"exponent": 0.5, "fill": "dark-orange", "mode": "scheme", "reverse": false, "scale": "exponential", "scheme": "Spectral", "steps": 64}, "exemplars": {"color": "rgba(255,0,255,0.7)"}, "filterValues": {"le": 1e-9}, "legend": {"show": true}, "rowsFrame": {"layout": "auto"}, "tooltip": {"mode": "single", "showColorScale": false, "yHistogram": false}, "yAxis": {"axisPlacement": "left", "reverse": false, "unit": "s"}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "expr": "sum by (le) (rate(vllm:nixl_post_time_seconds_bucket{namespace=~\"$namespace\", pod=~\".*$dgd.*\"}[1m]))",
+          "format": "heatmap",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "vllm:nixl_post_time_seconds heatmap",
+      "type": "heatmap"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 20},
+      "id": 102,
+      "panels": [],
+      "title": "NIXL counter rates + preemptions",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "palette-classic"}, "custom": {"drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 2, "fillOpacity": 5, "showPoints": "never"}, "unit": "short"},
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 21},
+      "id": 5,
+      "options": {"legend": {"displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi"}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "expr": "sum by (pod) (rate(vllm:nixl_num_failed_transfers{namespace=~\"$namespace\", pod=~\".*$dgd.*\"}[1m]))",
+          "legendFormat": "fail / {{pod}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "expr": "sum by (pod) (rate(vllm:nixl_num_kv_expired_reqs{namespace=~\"$namespace\", pod=~\".*$dgd.*\"}[1m]))",
+          "legendFormat": "expired / {{pod}}",
+          "refId": "B"
+        }
+      ],
+      "title": "NIXL failures + KV-expired (per second)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "palette-classic"}, "custom": {"drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 2, "fillOpacity": 5, "showPoints": "never"}, "unit": "short"},
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 21},
+      "id": 6,
+      "options": {"legend": {"displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi"}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "expr": "sum by (pod) (rate(vllm:num_preemptions_total{namespace=~\"$namespace\", pod=~\".*$dgd.*\"}[1m]))",
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "title": "vllm preemptions (per second)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {"color": {"mode": "palette-classic"}, "custom": {"drawStyle": "line", "lineInterpolation": "linear", "lineWidth": 2, "fillOpacity": 5, "showPoints": "never"}, "unit": "short"},
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 21},
+      "id": 7,
+      "options": {"legend": {"displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi"}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "expr": "sum by (model) (dynamo_frontend_queued_requests{namespace=~\"$namespace\", pod=~\".*$dgd.*\"})",
+          "legendFormat": "queued — {{model}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "expr": "sum by (model) (dynamo_frontend_inflight_requests{namespace=~\"$namespace\", pod=~\".*$dgd.*\"})",
+          "legendFormat": "inflight — {{model}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Frontend — queued + inflight",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 29},
+      "id": 103,
+      "panels": [],
+      "title": "Latency (TTFT, ITL, request_duration)",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
+      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 30},
+      "id": 8,
+      "options": {"legend": {"displayMode": "table", "placement": "right", "showLegend": true}, "tooltip": {"mode": "multi"}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "expr": "histogram_quantile(0.99, sum by (le, model) (rate(dynamo_frontend_time_to_first_token_seconds_bucket{namespace=~\"$namespace\", pod=~\".*$dgd.*\"}[1m])))",
+          "legendFormat": "TTFT p99 — {{model}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "expr": "histogram_quantile(0.50, sum by (le, model) (rate(dynamo_frontend_time_to_first_token_seconds_bucket{namespace=~\"$namespace\", pod=~\".*$dgd.*\"}[1m])))",
+          "legendFormat": "TTFT p50 — {{model}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "expr": "histogram_quantile(0.99, sum by (le, model) (rate(dynamo_frontend_inter_token_latency_seconds_bucket{namespace=~\"$namespace\", pod=~\".*$dgd.*\"}[1m])))",
+          "legendFormat": "ITL p99 — {{model}}",
+          "refId": "C"
+        }
+      ],
+      "title": "Frontend TTFT + ITL",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
+      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 30},
+      "id": 9,
+      "options": {"legend": {"displayMode": "table", "placement": "right", "showLegend": true}, "tooltip": {"mode": "multi"}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "expr": "histogram_quantile(0.99, sum by (le, model) (rate(dynamo_frontend_request_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\".*$dgd.*\"}[1m])))",
+          "legendFormat": "RTT p99 — {{model}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "expr": "histogram_quantile(0.50, sum by (le, model) (rate(dynamo_frontend_request_duration_seconds_bucket{namespace=~\"$namespace\", pod=~\".*$dgd.*\"}[1m])))",
+          "legendFormat": "RTT p50 — {{model}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Frontend request_duration",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": ["dynamo", "cascade", "vllm-disagg"],
+  "templating": {
+    "list": [
+      {
+        "current": {"selected": false, "text": "neelays-test", "value": "neelays-test"},
+        "datasource": {"type": "prometheus", "uid": "prometheus"},
+        "definition": "label_values(vllm:num_requests_running, namespace)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Namespace",
+        "multi": false,
+        "name": "namespace",
+        "options": [],
+        "query": {"query": "label_values(vllm:num_requests_running, namespace)", "refId": "StandardVariableQuery"},
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {"selected": false, "text": "vllm-disagg-qwen3-30b", "value": "vllm-disagg-qwen3-30b"},
+        "hide": 0,
+        "label": "DGD (substring of pod name)",
+        "name": "dgd",
+        "options": [{"selected": true, "text": "vllm-disagg-qwen3-30b", "value": "vllm-disagg-qwen3-30b"}],
+        "query": "vllm-disagg-qwen3-30b",
+        "skipUrlSync": false,
+        "type": "textbox"
+      }
+    ]
+  },
+  "time": {"from": "now-15m", "to": "now"},
+  "timepicker": {"refresh_intervals": ["5s", "10s", "30s", "1m", "5m"]},
+  "timezone": "",
+  "title": "Dynamo Cascade — vLLM Disagg",
+  "uid": "dynamo-cascade-disagg",
+  "version": 1,
+  "weekStart": ""
+}

--- a/examples/backends/mocker/deploy/disagg.yaml
+++ b/examples/backends/mocker/deploy/disagg.yaml
@@ -15,17 +15,92 @@ spec:
     Frontend:
       componentType: frontend
       replicas: 1
+      # Bump CPU/memory requests so kai-scheduler spreads pods naturally
+      # (otherwise tiny mocker pods all pack onto one node — exactly the
+      # failure mode from 2026-05-29 arm5 where 372 pods on one node took
+      # the test down when that node died). Grove operator rejects explicit
+      # topologySpreadConstraints in the user-supplied pod spec, so we
+      # achieve spread via resource pressure instead.
       extraPodSpec:
+        # Constrain to CPU-only nodes (no GPU label). Frees expensive GPU nodes
+        # for actual GPU workloads. The label discriminator is
+        # `node.dgxc.nvidia.com/has-gpu` which exists only on GPU hosts.
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+              - matchExpressions:
+                - key: node.dgxc.nvidia.com/has-gpu
+                  operator: DoesNotExist
+          podAntiAffinity:
+            # Spread same-DGD pods across hosts. Weight 100 = strong preference,
+            # but kai-scheduler still bin-packs when it has to.
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                podAffinityTerm:
+                  topologyKey: kubernetes.io/hostname
+                  labelSelector:
+                    matchLabels:
+                      app.kubernetes.io/component: pcs-podclique
         mainContainer:
           image: my-dynamo-image:my-tag
+          resources:
+            requests:
+              cpu: "2"
+              memory: "6Gi"
+            limits:
+              cpu: "4"
+              memory: "10Gi"
     prefill:
       envFromSecret: hf-token-secret
       componentType: worker
       subComponentType: prefill
       replicas: 1
+      # Transport-level envs MUST be set on workers, not just Frontend.
+      # The framework's apply_router() only writes router knobs to FE,
+      # so DYN_EVENT_PLANE etc. don't reach workers unless declared here.
+      # Without DYN_EVENT_PLANE=zmq on the worker, its EventPublisher for
+      # the kv_metrics topic falls back to NATS transport. FE (with
+      # DYN_EVENT_PLANE=zmq) ignores NATS endpoints → 0 ActiveLoad events
+      # flow → worker_monitor busy-detection stays cold (H4 FAIL) and
+      # the routing layer's threshold-based candidate exclusion is dead.
+      envs:
+        - name: DYN_EVENT_PLANE
+          value: "zmq"
+        - name: DYN_DISCOVERY_BACKEND
+          value: "kubernetes"
+        - name: DYN_STORE_KV
+          value: "mem"
       extraPodSpec:
+        # Constrain to CPU-only nodes (no GPU label). Frees expensive GPU nodes
+        # for actual GPU workloads. The label discriminator is
+        # `node.dgxc.nvidia.com/has-gpu` which exists only on GPU hosts.
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+              - matchExpressions:
+                - key: node.dgxc.nvidia.com/has-gpu
+                  operator: DoesNotExist
+          podAntiAffinity:
+            # Spread same-DGD pods across hosts. Weight 100 = strong preference,
+            # but kai-scheduler still bin-packs when it has to.
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                podAffinityTerm:
+                  topologyKey: kubernetes.io/hostname
+                  labelSelector:
+                    matchLabels:
+                      app.kubernetes.io/component: pcs-podclique
         mainContainer:
           image: my-dynamo-image:my-tag
+          resources:
+            requests:
+              cpu: "2"
+              memory: "6Gi"
+            limits:
+              cpu: "4"
+              memory: "10Gi"
           workingDir: /workspace
           command:
           - python3
@@ -33,23 +108,62 @@ spec:
           - dynamo.mocker
           args:
             - --model-path
-            - nvidia/Llama-3.1-8B-Instruct-FP8
+            - Qwen/Qwen3-30B-A3B-Instruct-2507-FP8
             - --model-name
-            - nvidia/Llama-3.1-8B-Instruct-FP8
+            - Qwen/Qwen3-30B-A3B-Instruct-2507-FP8
             - --speedup-ratio
-            - "1.0"
+            - "5.0"
             - --planner-profile-data
             - /workspace/components/src/dynamo/planner/tests/data/profiling_results/H200_TP1P_TP1D
             - --disaggregation-mode
             - prefill
+            # DIS-2147 flags removed from this template — they're only recognized
+            # by the mocker-binding-fix-dis2147 branch's mocker binary. The
+            # cascade-test branch (used for backpressure-fix builds) doesn't have
+            # DIS-2147. Re-add for E2/E3 when running on a mocker-branch image.
     decode:
       envFromSecret: hf-token-secret
       componentType: worker
       subComponentType: decode
       replicas: 1
+      # Same transport-level envs as prefill — see comment there.
+      envs:
+        - name: DYN_EVENT_PLANE
+          value: "zmq"
+        - name: DYN_DISCOVERY_BACKEND
+          value: "kubernetes"
+        - name: DYN_STORE_KV
+          value: "mem"
       extraPodSpec:
+        # Constrain to CPU-only nodes (no GPU label). Frees expensive GPU nodes
+        # for actual GPU workloads. The label discriminator is
+        # `node.dgxc.nvidia.com/has-gpu` which exists only on GPU hosts.
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+              - matchExpressions:
+                - key: node.dgxc.nvidia.com/has-gpu
+                  operator: DoesNotExist
+          podAntiAffinity:
+            # Spread same-DGD pods across hosts. Weight 100 = strong preference,
+            # but kai-scheduler still bin-packs when it has to.
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                podAffinityTerm:
+                  topologyKey: kubernetes.io/hostname
+                  labelSelector:
+                    matchLabels:
+                      app.kubernetes.io/component: pcs-podclique
         mainContainer:
           image: my-dynamo-image:my-tag
+          resources:
+            requests:
+              cpu: "2"
+              memory: "6Gi"
+            limits:
+              cpu: "4"
+              memory: "10Gi"
           workingDir: /workspace
           command:
           - python3
@@ -57,12 +171,22 @@ spec:
           - dynamo.mocker
           args:
             - --model-path
-            - nvidia/Llama-3.1-8B-Instruct-FP8
+            - Qwen/Qwen3-30B-A3B-Instruct-2507-FP8
             - --model-name
-            - nvidia/Llama-3.1-8B-Instruct-FP8
+            - Qwen/Qwen3-30B-A3B-Instruct-2507-FP8
             - --speedup-ratio
-            - "1.0"
+            - "5.0"
             - --planner-profile-data
             - /workspace/components/src/dynamo/planner/tests/data/profiling_results/H200_TP1P_TP1D
             - --disaggregation-mode
             - decode
+            # Tight decode batch — forces saturation under c=50 single-set load
+            # (Run 2 DIS-2147 fidelity). c=50 requests → 8-slot decode = guaranteed
+            # saturation → DIS-2147 prefill-stranding triggers.
+            - --max-num-seqs
+            - "8"
+            # Lower KV pool to tighten DECODE_BLOCKS gauge (0.85 of 1024 = 871);
+            # default 16384 is too large for the gauge to reflect saturation.
+            - --num-gpu-blocks-override
+            - "1024"
+            # DIS-2147 flag stripped — only mocker-branch images recognize it.

--- a/examples/backends/mocker/deploy/disagg.yaml
+++ b/examples/backends/mocker/deploy/disagg.yaml
@@ -116,15 +116,15 @@ spec:
             - --model-name
             - Qwen/Qwen3-30B-A3B-Instruct-2507-FP8
             - --speedup-ratio
-            - "5.0"
+            - "1.0"
             - --planner-profile-data
             - /workspace/components/src/dynamo/planner/tests/data/profiling_results/H200_TP1P_TP1D
             - --disaggregation-mode
             - prefill
-            # DIS-2147 flags removed from this template — they're only recognized
-            # by the mocker-binding-fix-dis2147 branch's mocker binary. The
-            # cascade-test branch (used for backpressure-fix builds) doesn't have
-            # DIS-2147. Re-add for E2/E3 when running on a mocker-branch image.
+            # prefill-KV-pinning flags removed from this template — they're only
+            # recognized by the mocker-binding-fix branch's mocker binary. The
+            # backpressure-fix mocker image doesn't carry the prefill-KV-pinning
+            # knob. Re-add for E2/E3 when running on a mocker-branch image.
     decode:
       envFromSecret: hf-token-secret
       componentType: worker
@@ -179,18 +179,18 @@ spec:
             - --model-name
             - Qwen/Qwen3-30B-A3B-Instruct-2507-FP8
             - --speedup-ratio
-            - "5.0"
+            - "1.0"
             - --planner-profile-data
             - /workspace/components/src/dynamo/planner/tests/data/profiling_results/H200_TP1P_TP1D
             - --disaggregation-mode
             - decode
-            # Tight decode batch — forces saturation under c=50 single-set load
-            # (Run 2 DIS-2147 fidelity). c=50 requests → 8-slot decode = guaranteed
-            # saturation → DIS-2147 prefill-stranding triggers.
+            # Tight decode batch — forces saturation under c=50 single-set load.
+            # c=50 requests → 8-slot decode = guaranteed saturation →
+            # prefill-KV-residency / KV-transfer abort-timeout behavior triggers.
             - --max-num-seqs
             - "8"
             # Lower KV pool to tighten DECODE_BLOCKS gauge (0.85 of 1024 = 871);
             # default 16384 is too large for the gauge to reflect saturation.
             - --num-gpu-blocks-override
             - "1024"
-            # DIS-2147 flag stripped — only mocker-branch images recognize it.
+            # prefill-KV-pinning flag stripped — only mocker-branch images recognize it.

--- a/examples/backends/mocker/deploy/disagg.yaml
+++ b/examples/backends/mocker/deploy/disagg.yaml
@@ -15,12 +15,16 @@ spec:
     Frontend:
       componentType: frontend
       replicas: 1
-      # Bump CPU/memory requests so kai-scheduler spreads pods naturally
-      # (otherwise tiny mocker pods all pack onto one node — exactly the
-      # failure mode from 2026-05-29 arm5 where 372 pods on one node took
-      # the test down when that node died). Grove operator rejects explicit
-      # topologySpreadConstraints in the user-supplied pod spec, so we
-      # achieve spread via resource pressure instead.
+      # Resources sized for cross-cluster portability — CPU pool topologies
+      # range from 4 × 192-CPU/192-Gi (aws-dev-02) to 10 × 32-CPU/64-Gi (nscale).
+      # `cpu: 1` and `memory: 3Gi` requests keep the pod schedulable even when
+      # kai-scheduler bin-packs onto a small node (3 Gi × 20 pods = 60 Gi fits
+      # in 64 Gi nscale node). Limits at cpu=4/mem=10Gi allow bursting; mocker
+      # itself typically uses 2-4 GiB resident, so OOMKill on the 10 Gi limit
+      # is unlikely. Earlier disagg.yaml used cpu=2 / mem=6Gi which on the
+      # aws-dev-02 4-node CPU pool saturated nodes at 46-set scale (2026-05-29),
+      # and on nscale's 64-GiB-per-node CPU pool triggered OutOfMemory
+      # admission rejections when kai bin-packed.
       extraPodSpec:
         # Constrain to CPU-only nodes (no GPU label). Frees expensive GPU nodes
         # for actual GPU workloads. The label discriminator is
@@ -46,8 +50,8 @@ spec:
           image: my-dynamo-image:my-tag
           resources:
             requests:
-              cpu: "2"
-              memory: "6Gi"
+              cpu: "1"
+              memory: "3Gi"
             limits:
               cpu: "4"
               memory: "10Gi"
@@ -96,8 +100,8 @@ spec:
           image: my-dynamo-image:my-tag
           resources:
             requests:
-              cpu: "2"
-              memory: "6Gi"
+              cpu: "1"
+              memory: "3Gi"
             limits:
               cpu: "4"
               memory: "10Gi"
@@ -159,8 +163,8 @@ spec:
           image: my-dynamo-image:my-tag
           resources:
             requests:
-              cpu: "2"
-              memory: "6Gi"
+              cpu: "1"
+              memory: "3Gi"
             limits:
               cpu: "4"
               memory: "10Gi"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -239,6 +239,7 @@ markers = [
     "skip_in_nightly: excludes a test from the nightly pipeline only (still runs in pre_merge/post_merge). Used via `not skip_in_nightly` in nightly-ci.yml marker filters",
     "frontend_api_surface_compliance: marks tests that validate Dynamo's HTTP API surface (Responses/Anthropic wire shape, tool-call routing) against upstream compliance harnesses",
     "weekly: marks tests to run weekly",
+    "sanity: marks fast (<15 min) sanity-only tests; CI runs these before longer suites",
     "release: marks tests to run on release pipelines",
     "gpu_0: marks tests that don't require GPU",
     "gpu_1: marks tests to run on GPU",

--- a/scripts/cascade_timeline.py
+++ b/scripts/cascade_timeline.py
@@ -1,0 +1,534 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+cascade_timeline — console "movie" of a cascade run.
+
+Reads `<run>/load/server_metrics_export.jsonl` and renders, per-pod, a
+horizontally-time-aligned view of all four cascade signals (and frontend
+TTFT/RTT/queued). Each row is a worker or frontend pod; each column is one
+sample (~1s). Sparklines run left→right across the run.
+
+This is the static "everything at once" view. For an interactive scrub-
+through, pass `--play` to step through every second printed as a Rich Live
+table.
+
+Usage:
+  scripts/cascade_timeline.py <run-dir>
+  scripts/cascade_timeline.py <run-dir> --play         # animate, 1 sample/sec
+  scripts/cascade_timeline.py <run-dir> --play --speed 10   # 10x faster
+
+Reads the same JSONL spike_view does. Where spike_view collapses to a system
+summary, this one keeps every pod visible.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+import time
+from collections import defaultdict
+from pathlib import Path
+from typing import Optional
+
+# 8-level Unicode block characters
+SPARK_CHARS = "▁▂▃▄▅▆▇█"
+
+# Metrics surfaced for workers (port 9090 endpoints)
+WORKER_METRICS = [
+    ("vllm:num_requests_running", "running"),
+    ("vllm:num_requests_waiting", "waiting"),
+    ("vllm:kv_cache_usage_perc", "kv_pct"),
+    ("vllm:nixl_post_time_seconds", "nixl_p99"),  # histogram → p99
+    ("vllm:num_preemptions_total", "preempt"),
+    # Error / failure indicators — cumulative counters, plotted as-is so
+    # rises are visible. Use `--metrics …,errors,nxl_fail,kv_exp` to pull
+    # only error tracks into the view.
+    ("vllm:nixl_num_failed_transfers", "nxl_fail"),
+    ("vllm:nixl_num_kv_expired_reqs", "kv_exp"),
+    ("vllm:request_success_total", "req_ok"),
+    # Catch-all "bad request" counter aiperf surfaces for the engine if
+    # vllm exposes it; missing on older builds, harmless if absent.
+    ("vllm:request_failures_total", "errors"),
+]
+
+# Metrics surfaced for frontend (port 8000 endpoint)
+FRONTEND_METRICS = [
+    ("dynamo_frontend_queued_requests", "queued"),
+    ("dynamo_frontend_inflight_requests", "inflight"),
+    ("dynamo_frontend_time_to_first_token_seconds", "ttft_p99"),  # histogram → p99
+    ("dynamo_frontend_request_duration_seconds", "rtt_p99"),  # histogram → p99
+    # Frontend-side error indicators
+    ("dynamo_frontend_disconnected_clients", "disc"),
+    ("dynamo_frontend_requests_total", "fe_req_total"),
+    ("dynamo_frontend_request_errors_total", "fe_errors"),
+]
+
+# Default sparkline width. Override via --width.
+DEFAULT_WIDTH = 80
+
+
+def histogram_quantile(buckets, q: float) -> Optional[float]:
+    if not buckets:
+        return None
+    ordered = []
+    items = buckets.items() if isinstance(buckets, dict) else buckets
+    for k, v in items:
+        try:
+            le = float(k) if str(k) not in ("+Inf", "Inf") else float("inf")
+        except (ValueError, TypeError):
+            continue
+        ordered.append((le, float(v)))
+    ordered.sort()
+    if not ordered or ordered[-1][1] == 0:
+        return None
+    total = ordered[-1][1]
+    target = q * total
+    prev_le, prev_count = 0.0, 0.0
+    for le, count in ordered:
+        if count >= target:
+            if le == float("inf"):
+                return prev_le
+            if count == prev_count:
+                return le
+            frac = (target - prev_count) / (count - prev_count)
+            return prev_le + frac * (le - prev_le)
+        prev_le, prev_count = le, count
+    return ordered[-1][0]
+
+
+def parse_jsonl(path: Path) -> list[dict]:
+    records = []
+    with path.open() as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError:
+                pass
+    return records
+
+
+def short_endpoint(url: str) -> str:
+    if "://" in url:
+        url = url.split("://", 1)[1]
+    return url.split("/", 1)[0]
+
+
+def build_per_pod_series(
+    records: list[dict],
+) -> dict[str, dict[str, dict[str, list[tuple[int, float]]]]]:
+    """Returns: {pod_id: {role: {metric_name: [(ts_ns, value), ...]}}}.
+
+    pod_id = endpoint_url IP:port (one pod per IP).
+    role = "frontend" / "prefill" / "decode" / "unknown".
+    Aggregation:
+      - counter/gauge with `value` field: sum across samples (e.g. across
+        dp_rank/engine labels for a single pod);
+      - histogram (`buckets` field): per-pod prior-buckets are kept, and
+        each scrape is converted to a *delta histogram* (current minus
+        prior) before computing p99 — so the rendered p99 reflects the
+        last scrape window's transfers, not all-time. First sample of
+        each pod is skipped (no baseline yet) to avoid boostrap noise.
+    """
+    series: dict[str, dict[str, dict[str, list[tuple[int, float]]]]] = defaultdict(
+        lambda: defaultdict(lambda: defaultdict(list))
+    )
+    # Track prior cumulative buckets per (pod, metric) for delta-p99 path.
+    # Key: (pod_id, metric_name) → {le_float: cumulative_count}
+    prior_buckets: dict[tuple[str, str], dict[float, float]] = {}
+
+    for rec in records:
+        ts = rec.get("timestamp_ns") or rec.get("first_byte_ns")
+        if ts is None:
+            continue
+        endpoint = rec.get("endpoint_url", "?")
+        pod_id = short_endpoint(endpoint)
+        role = "unknown"
+        if pod_id.endswith(":8000"):
+            role = "frontend"
+        for metric_name, samples in (rec.get("metrics") or {}).items():
+            samples = samples or []
+            if not samples:
+                continue
+            if role == "unknown":
+                for s in samples:
+                    labels = s.get("labels") or {}
+                    comp = labels.get("dynamo_component")
+                    if comp:
+                        role = (
+                            "decode"
+                            if comp == "backend"
+                            else ("prefill" if comp == "prefill" else "frontend")
+                        )
+                        break
+            simple_total = 0.0
+            simple_seen = False
+            agg_buckets: dict[float, float] = {}
+            for s in samples:
+                if "value" in s and s["value"] is not None:
+                    simple_total += float(s["value"])
+                    simple_seen = True
+                elif "buckets" in s and s["buckets"]:
+                    bs = s["buckets"]
+                    bs_items = bs.items() if isinstance(bs, dict) else bs
+                    for le, cnt in bs_items:
+                        try:
+                            le_f = (
+                                float(le)
+                                if str(le) not in ("+Inf", "Inf")
+                                else float("inf")
+                            )
+                        except (ValueError, TypeError):
+                            continue
+                        agg_buckets[le_f] = agg_buckets.get(le_f, 0.0) + float(cnt)
+            if simple_seen:
+                series[pod_id][role][metric_name].append((ts, simple_total))
+            elif agg_buckets:
+                # Compute delta vs prior cumulative — per-window p99
+                key = (pod_id, metric_name)
+                prior = prior_buckets.get(key, {})
+                delta: dict[float, float] = {}
+                for le_f, cum in agg_buckets.items():
+                    delta[le_f] = max(0.0, cum - prior.get(le_f, 0.0))
+                prior_buckets[key] = agg_buckets  # update baseline
+                # Skip first scrape (delta == cumulative meaningless)
+                if not prior:
+                    continue
+                p99 = histogram_quantile(delta, 0.99)
+                if p99 is not None:
+                    series[pod_id][role][metric_name].append((ts, p99))
+    return series
+
+
+def make_spark(values, width: int) -> str:
+    if not values:
+        return " " * width
+    clean = [v for v in values if v is not None]
+    if not clean:
+        return " " * width
+    lo, hi = min(clean), max(clean)
+    if lo == hi:
+        return SPARK_CHARS[3] * min(len(clean), width)
+    # Resample into width bins
+    n = len(clean)
+    if n <= width:
+        binned = clean
+    else:
+        bin_size = n / width
+        binned = []
+        for i in range(width):
+            s = int(i * bin_size)
+            e = max(int((i + 1) * bin_size), s + 1)
+            chunk = clean[s:e]
+            binned.append(sum(chunk) / len(chunk) if chunk else None)
+    span = hi - lo
+    out = []
+    for v in binned:
+        if v is None:
+            out.append(" ")
+        else:
+            idx = int((v - lo) / span * (len(SPARK_CHARS) - 1))
+            out.append(SPARK_CHARS[max(0, min(idx, len(SPARK_CHARS) - 1))])
+    return "".join(out)
+
+
+def fmt_value(v: float, kind: str) -> str:
+    if v is None or (isinstance(v, float) and math.isnan(v)):
+        return "?"
+    if kind == "kv_pct":
+        return f"{v:.1%}"
+    if kind in ("nixl_p99", "ttft_p99", "rtt_p99"):
+        if v >= 1.0:
+            return f"{v:.2f}s"
+        return f"{v * 1000:.0f}ms"
+    if v >= 100:
+        return f"{int(v)}"
+    if v >= 10:
+        return f"{v:.1f}"
+    return f"{v:.2f}"
+
+
+def role_sort_key(pod_id: str, role: str) -> tuple:
+    role_order = {"frontend": 0, "prefill": 1, "decode": 2, "unknown": 9}
+    return (role_order.get(role, 9), pod_id)
+
+
+def render_static(series: dict, width: int, time_axis_seconds: bool = True) -> str:
+    lines: list[str] = []
+    lines.append("# cascade timeline — per-pod\n")
+    if not series:
+        lines.append("(no records)\n")
+        return "".join(lines)
+
+    # Compute global time range to put under the spark
+    all_ts = []
+    for pod, roles in series.items():
+        for role, metrics_map in roles.items():
+            for metric, points in metrics_map.items():
+                for ts, _ in points:
+                    all_ts.append(ts)
+    if not all_ts:
+        return "(no timestamps)\n"
+    t0_ns, t1_ns = min(all_ts), max(all_ts)
+    span_s = (t1_ns - t0_ns) / 1e9
+    lines.append(f"\nrun span: {span_s:.0f}s  ({len(set(all_ts))} unique samples)\n\n")
+
+    # Group rows by role first, then pod
+    rows: list[tuple[str, str, str, list[float]]] = []
+    for pod_id, roles_map in series.items():
+        for role, metrics_map in roles_map.items():
+            metrics_order = FRONTEND_METRICS if role == "frontend" else WORKER_METRICS
+            for metric_name, label in metrics_order:
+                pts = metrics_map.get(metric_name, [])
+                if not pts:
+                    continue
+                values = [v for _, v in sorted(pts)]
+                rows.append((role, pod_id, label, values))
+
+    metric_display_order = [
+        "queued",
+        "inflight",
+        "ttft_p99",
+        "rtt_p99",
+        "disc",
+        "fe_req_total",
+        "fe_errors",
+        "running",
+        "waiting",
+        "kv_pct",
+        "nixl_p99",
+        "preempt",
+        "nxl_fail",
+        "kv_exp",
+        "req_ok",
+        "errors",
+    ]
+    rows.sort(
+        key=lambda r: (
+            {"frontend": 0, "prefill": 1, "decode": 2, "unknown": 9}.get(r[0], 9),
+            r[1],
+            metric_display_order.index(r[2]) if r[2] in metric_display_order else 99,
+        )
+    )
+
+    # Render
+    last_pod = None
+    for role, pod_id, label, values in rows:
+        pod_role = f"{pod_id}  [{role}]"
+        if pod_role != last_pod:
+            if last_pod is not None:
+                lines.append("\n")
+            lines.append(f"### {pod_role}\n")
+            lines.append("```\n")
+            last_pod = pod_role
+        spark = make_spark(values, width)
+        lo = min(values)
+        hi = max(values)
+        cur = values[-1] if values else None
+        lo_f = fmt_value(lo, label)
+        hi_f = fmt_value(hi, label)
+        cur_f = fmt_value(cur, label) if cur is not None else "—"
+        lines.append(
+            f"{label:<10} | {spark} | "
+            f"now={cur_f:>7s}  min={lo_f:>7s}  max={hi_f:>7s}  n={len(values)}\n"
+        )
+    if last_pod is not None:
+        lines.append("```\n")
+
+    if time_axis_seconds:
+        # Add a time-axis bar under one example sparkline (just informational)
+        marks = "".join(
+            f"{i*int(span_s/8):>8d}" if i % 1 == 0 else " " for i in range(9)
+        )
+        lines.append(f"\nTime axis (s, left→right): {marks.strip()}\n")
+    return "".join(lines)
+
+
+def render_play(series: dict, speed: float = 1.0) -> None:
+    """Animate: print one row of values per second, advancing through the run."""
+    try:
+        from rich.console import Console
+        from rich.live import Live
+        from rich.table import Table
+    except ImportError:
+        print("error: rich not installed; pip install rich", file=sys.stderr)
+        sys.exit(2)
+
+    # Build a unified time→pod→metric map
+    all_ts = sorted(
+        {
+            ts
+            for pod, roles in series.items()
+            for role, metrics in roles.items()
+            for points in metrics.values()
+            for ts, _ in points
+        }
+    )
+    if not all_ts:
+        print("(no data to animate)", file=sys.stderr)
+        return
+
+    t0 = all_ts[0]
+
+    # Bucket samples into 1s windows
+    buckets: dict[int, dict] = defaultdict(dict)  # second-offset → {(pod,metric): val}
+    for pod_id, roles_map in series.items():
+        for role, metrics_map in roles_map.items():
+            for metric_name, pts in metrics_map.items():
+                for ts, val in pts:
+                    sec = int((ts - t0) / 1e9)
+                    buckets[sec][(pod_id, role, metric_name)] = val
+
+    second_keys = sorted(buckets)
+    console = Console()
+
+    def make_table(sec: int) -> Table:
+        tbl = Table(title=f"cascade @ t={sec}s   ({sec}/{second_keys[-1]}s)")
+        tbl.add_column("pod", style="cyan")
+        tbl.add_column("role")
+        tbl.add_column("running", justify="right")
+        tbl.add_column("waiting", justify="right")
+        tbl.add_column("kv%", justify="right")
+        tbl.add_column("nixl_p99", justify="right")
+        tbl.add_column("ttft_p99", justify="right")
+        tbl.add_column("rtt_p99", justify="right")
+        # Aggregate at this second (use latest sample per pod-metric ≤ sec)
+        snapshot: dict[tuple[str, str], dict[str, float]] = defaultdict(dict)
+        for s in range(sec + 1):
+            for (pod_id, role, metric), val in buckets.get(s, {}).items():
+                snapshot[(pod_id, role)][metric] = val
+        for pod_id, role in sorted(
+            snapshot,
+            key=lambda r: (
+                {"frontend": 0, "prefill": 1, "decode": 2, "unknown": 9}.get(r[1], 9),
+                r[0],
+            ),
+        ):
+            m = snapshot[(pod_id, role)]
+            row = [
+                pod_id,
+                role,
+                fmt_value(m.get("vllm:num_requests_running"), "running"),
+                fmt_value(m.get("vllm:num_requests_waiting"), "waiting"),
+                fmt_value(m.get("vllm:kv_cache_usage_perc"), "kv_pct"),
+                fmt_value(m.get("vllm:nixl_post_time_seconds"), "nixl_p99"),
+                fmt_value(
+                    m.get("dynamo_frontend_time_to_first_token_seconds"), "ttft_p99"
+                ),
+                fmt_value(m.get("dynamo_frontend_request_duration_seconds"), "rtt_p99"),
+            ]
+            tbl.add_row(*row)
+        return tbl
+
+    with Live(console=console, refresh_per_second=max(speed, 1.0)) as live:
+        for sec in second_keys:
+            live.update(make_table(sec))
+            time.sleep(max(0.0, 1.0 / speed))
+
+
+_ALL_LABELS = [
+    "running",
+    "waiting",
+    "kv_pct",
+    "nixl_p99",
+    "preempt",
+    "nxl_fail",
+    "kv_exp",
+    "req_ok",
+    "errors",
+    "queued",
+    "inflight",
+    "ttft_p99",
+    "rtt_p99",
+    "disc",
+    "fe_req_total",
+    "fe_errors",
+]
+
+
+def _filter_metrics_by_labels(selected: set[str]) -> tuple[list, list]:
+    """Filter the global METRIC tables to only the requested label set."""
+    w = [(name, label) for name, label in WORKER_METRICS if label in selected]
+    f = [(name, label) for name, label in FRONTEND_METRICS if label in selected]
+    return w, f
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__.strip().split("\n")[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Available metrics (--metrics):\n"
+            "  worker:        running, waiting, kv_pct, nixl_p99, preempt\n"
+            "  worker errors: nxl_fail, kv_exp, req_ok, errors\n"
+            "  frontend:      queued, inflight, ttft_p99, rtt_p99\n"
+            "  frontend err:  disc, fe_req_total, fe_errors\n"
+            "  Pass a comma-separated subset to focus, or omit for all.\n"
+        ),
+    )
+    ap.add_argument("run_dir", type=Path, help="Test run directory (parent of load/)")
+    ap.add_argument("--width", type=int, default=DEFAULT_WIDTH)
+    ap.add_argument("--play", action="store_true", help="Animate (rich Live table)")
+    ap.add_argument(
+        "--speed", type=float, default=10.0, help="Playback speed (1.0 = realtime)"
+    )
+    ap.add_argument(
+        "--metrics",
+        default=None,
+        help="Comma-separated metric labels to show (e.g. 'running,waiting,nixl_p99'). "
+        "Default: all available.",
+    )
+    ap.add_argument(
+        "--list-metrics",
+        action="store_true",
+        help="Print the metric labels available for this run and exit.",
+    )
+    args = ap.parse_args()
+
+    # Apply --metrics filter to globals so all rendering paths agree.
+    if args.metrics:
+        selected = {m.strip() for m in args.metrics.split(",") if m.strip()}
+        unknown = selected - set(_ALL_LABELS)
+        if unknown:
+            print(f"error: unknown metric label(s): {sorted(unknown)}", file=sys.stderr)
+            print(f"valid: {_ALL_LABELS}", file=sys.stderr)
+            return 2
+        global WORKER_METRICS, FRONTEND_METRICS
+        WORKER_METRICS, FRONTEND_METRICS = _filter_metrics_by_labels(selected)
+
+    jsonl = args.run_dir / "load" / "server_metrics_export.jsonl"
+    if not jsonl.exists():
+        print(f"error: {jsonl} not found", file=sys.stderr)
+        return 2
+
+    if args.list_metrics:
+        records = parse_jsonl(jsonl)
+        seen: set[str] = set()
+        for rec in records:
+            for m in rec.get("metrics") or {}:
+                seen.add(m)
+        print("Prometheus families present in this run:")
+        for m in sorted(seen):
+            print(f"  {m}")
+        print("\nLabel shortcuts (use with --metrics):")
+        for lbl in _ALL_LABELS:
+            print(f"  {lbl}")
+        return 0
+
+    records = parse_jsonl(jsonl)
+    print(f"parsed {len(records)} records", file=sys.stderr)
+    series = build_per_pod_series(records)
+
+    if args.play:
+        render_play(series, speed=args.speed)
+    else:
+        sys.stdout.write(render_static(series, args.width))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run-cascade-burst.sh
+++ b/scripts/run-cascade-burst.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+# scripts/run-cascade-burst.sh — wrapper around dynamo-ft cascade_sanity_natural
+# that satisfies the strict-data-capture rule from observe's 5hr-burst handoff.
+#
+# Per observe's `the 5hr-burst test handoff`, EVERY cascade run must produce:
+#   - profile_export.jsonl / profile_export_aiperf.json / server_metrics_export.jsonl
+#   - pod_memory_growth.tsv
+#   - frontend/<pod>.log, vllmprefillworker/<pod>.log, vllmdecodeworker/<pod>.log
+#   - dgd.yaml (the actual applied DGD)
+#   - env-vars.txt (kubectl exec -- env on one FE pod + one worker pod)
+#   - image-tags.txt (per-pod image label)
+#   - aiperf-config.json (request timeout + concurrency + duration + dataset)
+#
+# Plus: per-image output dirs must be renamed immediately so the next run
+# doesn't overwrite. Last cycle's bug was the baseline cliff data getting
+# clobbered by the PR9858 run.
+#
+# Usage:
+#   run-cascade-burst.sh <image-label> <image-tag> <namespace> [knob=val[;knob2=val2…]]
+#
+# Example:
+#   run-cascade-burst.sh dis-2105 \
+#       nvcr.io/nvidian/dynamo-dev/vllm-runtime:dis-2105-v1.1.1-53f1dd83a7-neelays \
+#       neelays-test-b \
+#       DYN_TCP_WORK_QUEUE_SIZE=256
+
+set -uo pipefail
+
+LABEL="${1:-}"
+IMAGE="${2:-}"
+NS="${3:-}"
+KNOBS="${4:-}"
+
+if [[ -z "$LABEL" || -z "$IMAGE" || -z "$NS" ]]; then
+    echo "usage: $0 <image-label> <image-tag> <namespace> [knob=val[;…]]" >&2
+    exit 2
+fi
+
+# Per-launch unique output dir. Without this, two parallel runs (different
+# images, different namespaces) collide on the same local path because the
+# test name is identical — and conftest.py's auto-clean-on-rerun then wipes
+# whichever sibling started last. We learned this the hard way on 2026-05-22:
+# 3 parallel cascade tests stomped on each other's snapshot dirs and rung
+# data.
+OUTBASE_PARENT="${DYN_TEST_OUTPUT_PATH_BASE:-$HOME/.dynamo-ft/test_outputs}"
+OUTBASE="${OUTBASE_PARENT}_${LABEL}"
+TESTNAME='test_overload_cascade_sanity_natural[2-64-160-8]'
+RAW_DIR="$OUTBASE/$TESTNAME"
+FINAL_DIR="$OUTBASE/${TESTNAME}.${LABEL}"
+LOG="/tmp/cascade-burst-${LABEL}-$(date +%H%M%S).log"
+mkdir -p "$OUTBASE"
+
+echo "=== run-cascade-burst.sh ==="
+echo "  label:     $LABEL"
+echo "  image:     $IMAGE"
+echo "  namespace: $NS"
+echo "  knobs:     ${KNOBS:-<none>}"
+echo "  log:       $LOG"
+echo "  outbase:   $OUTBASE (per-launch unique)"
+echo "  raw out:   $RAW_DIR"
+echo "  final:     $FINAL_DIR"
+echo ""
+
+# Pre-flight: namespace must be empty (no leftover DGDs)
+EXISTING=$(kubectl -n "$NS" get pods --no-headers 2>/dev/null | grep -E 'vllm-q3|audit-' | wc -l)
+if (( EXISTING > 0 )); then
+    echo "ERROR: $NS has $EXISTING leftover vllm/audit pods. Clean first." >&2
+    kubectl -n "$NS" get pods --no-headers 2>&1 | head
+    exit 3
+fi
+
+# Launch test in background, with knobs injected via DYN_TEST_WORKER_KNOBS
+# and the unique per-launch output dir set explicitly. The dynamo-ft wrapper
+# falls back to a default OUTPUT_PATH only if we don't pass one; we do.
+cd "$(dirname "$0")/../tests/fault_tolerance/deploy"
+# dynamo-ft prints "PID: <n>" to stdout in --bg mode. Capture that
+# stdout to a dedicated file so we can grep it for the launch PID —
+# previous version grepped $LOG (which is the pytest log file passed to
+# --log) and found nothing, then pgrep'd a too-broad pattern that
+# matched stale residual processes from killed prior runs.
+LAUNCH_OUT="/tmp/cascade-burst-launch-${LABEL}-$(date +%H%M%S).out"
+DYN_TEST_WORKER_KNOBS="$KNOBS" \
+DYN_TEST_OUTPUT_PATH="$OUTBASE" \
+./dynamo-ft cascade_sanity_natural \
+    --image "$IMAGE" \
+    --namespace "$NS" \
+    --storage-class dgxc-enterprise-file \
+    --bg \
+    --log "$LOG" 2>&1 | tee "$LAUNCH_OUT" | tee /dev/stderr | head -10
+
+# Grab the PID dynamo-ft printed
+TEST_PID=$(grep -m1 '^PID:' "$LAUNCH_OUT" 2>/dev/null | awk '{print $2}')
+# Fallback: filter pgrep by --newest so stale residuals don't win
+for _ in 1 2 3 4 5; do
+    if [[ -z "$TEST_PID" ]]; then
+        sleep 2
+        TEST_PID=$(pgrep -nf "pytest.*cascade.*$NS" 2>/dev/null | head -1)
+    fi
+done
+if [[ -z "$TEST_PID" ]] || ! kill -0 "$TEST_PID" 2>/dev/null; then
+    echo "ERROR: could not determine live test PID. LAUNCH_OUT=$LAUNCH_OUT  LOG=$LOG" >&2
+    exit 4
+fi
+echo "  test PID:  $TEST_PID"
+
+# Wait for pods to reach Ready (8 pods for units=2 cascade DGD).
+# Capture env-vars.txt + image-tags.txt + dgd.yaml WHILE pods are alive.
+# Timeout this at 12 min in case pods stick in PodInitializing.
+echo "  waiting for pods to reach Ready..."
+deadline=$(( $(date +%s) + 720 ))
+ready=0
+while (( $(date +%s) < deadline )); do
+    READY=$(kubectl -n "$NS" get pods --no-headers 2>/dev/null \
+        | awk '/vllm-q3/ {split($2,a,"/"); if(a[1]==a[2]) c++} END{print c+0}')
+    if (( READY >= 8 )); then
+        ready=1
+        break
+    fi
+    sleep 15
+done
+
+if (( ready )); then
+    echo "  all 8 pods Ready — capturing snapshot artifacts"
+    SNAP="$RAW_DIR/.burst-snapshot-${LABEL}"
+    mkdir -p "$SNAP"
+    # image-tags.txt
+    kubectl -n "$NS" get pods -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.containers[*].image}{"\n"}{end}' \
+        > "$SNAP/image-tags.txt" 2>&1
+    # env-vars.txt — exec into one FE + one decode + one prefill, dump env
+    {
+        for podtype in frontend vllmdecodeworker vllmprefillworker; do
+            POD=$(kubectl -n "$NS" get pods --no-headers -l 'nvidia.com/dynamo-graph-deployment-name=vllm-q3-prod-units' 2>/dev/null \
+                | grep "$podtype" | head -1 | awk '{print $1}')
+            if [[ -n "$POD" ]]; then
+                echo "## $podtype ($POD)"
+                kubectl -n "$NS" exec "$POD" -c main -- env 2>/dev/null | sort
+                echo ""
+            fi
+        done
+    } > "$SNAP/env-vars.txt" 2>&1
+    # dgd.yaml
+    kubectl -n "$NS" get dynamographdeployment vllm-q3-prod-units -o yaml \
+        > "$SNAP/dgd.yaml" 2>&1
+    # aiperf-config sentinel — derive from the launch params
+    cat > "$SNAP/aiperf-config.json" <<EOF
+{
+  "test": "$TESTNAME",
+  "image_label": "$LABEL",
+  "image_tag": "$IMAGE",
+  "namespace": "$NS",
+  "knobs": "${KNOBS:-}",
+  "request_timeout_seconds": 40,
+  "warmup_concurrency": 64,
+  "cliff_concurrency": 160,
+  "cliff_duration_min": 8,
+  "captured_at": "$(date -u +%FT%TZ)"
+}
+EOF
+    echo "  snapshot: $SNAP"
+else
+    echo "  WARN: pods did not all reach Ready in 12 min; capturing what's there"
+    SNAP="$RAW_DIR/.burst-snapshot-${LABEL}"
+    mkdir -p "$SNAP"
+    kubectl -n "$NS" get pods -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.containers[*].image}{"\t"}{.status.phase}{"\n"}{end}' \
+        > "$SNAP/image-tags.txt" 2>&1
+    echo "{\"warning\":\"pods not all Ready at capture time\",\"image_label\":\"$LABEL\"}" \
+        > "$SNAP/missing-data.txt"
+fi
+
+# Wait for test completion
+echo "  waiting for test PID $TEST_PID to exit..."
+while kill -0 "$TEST_PID" 2>/dev/null; do sleep 30; done
+echo "  test exited at $(date -u +%FT%TZ)"
+
+# Brief AIPerf result peek for the live log
+tail -25 "$LOG" 2>/dev/null | grep -E 'Requests:|Errors:|Throughput:|PASSED|FAILED|short test' | head -15
+
+# Rename output dir to the per-image label
+if [[ -d "$RAW_DIR" ]]; then
+    if [[ -d "$FINAL_DIR" ]]; then
+        BACKUP="${FINAL_DIR}.prev-$(date +%s)"
+        echo "  $FINAL_DIR exists; moving aside to $BACKUP"
+        mv "$FINAL_DIR" "$BACKUP"
+    fi
+    mv "$RAW_DIR" "$FINAL_DIR"
+    echo "  renamed: $FINAL_DIR"
+else
+    echo "  WARN: $RAW_DIR not found — nothing to rename"
+fi
+
+# Final integrity check against the strict-data-capture list
+echo ""
+echo "=== strict-data-capture integrity check (final: $FINAL_DIR) ==="
+required=(
+    "pod_memory_growth.tsv"
+    "test.log.txt"
+    "frontend"
+    "vllmprefillworker"
+    "vllmdecodeworker"
+    ".burst-snapshot-${LABEL}/image-tags.txt"
+    ".burst-snapshot-${LABEL}/env-vars.txt"
+    ".burst-snapshot-${LABEL}/dgd.yaml"
+    ".burst-snapshot-${LABEL}/aiperf-config.json"
+)
+missing=()
+for f in "${required[@]}"; do
+    if [[ -e "$FINAL_DIR/$f" ]]; then
+        echo "  OK    $f"
+    else
+        echo "  MISS  $f"
+        missing+=("$f")
+    fi
+done
+
+# Per-rung data
+for rung in warmup cliff; do
+    dirs=$(find "$FINAL_DIR/load" -maxdepth 1 -type d -name "load-${rung}-*" 2>/dev/null | head -1)
+    if [[ -n "$dirs" ]]; then
+        for need in profile_export.jsonl profile_export_aiperf.json server_metrics_export.jsonl; do
+            if [[ -e "$dirs/$need" ]]; then
+                echo "  OK    $(basename "$dirs")/$need"
+            else
+                echo "  MISS  $(basename "$dirs")/$need"
+                missing+=("$(basename "$dirs")/$need")
+            fi
+        done
+    else
+        echo "  MISS  load-${rung}-*/"
+        missing+=("load-${rung}-*/")
+    fi
+done
+
+if (( ${#missing[@]} > 0 )); then
+    echo ""
+    echo "  MISSING ITEMS noted to: $FINAL_DIR/missing-data.txt"
+    printf '%s\n' "${missing[@]}" > "$FINAL_DIR/missing-data.txt"
+fi
+
+echo ""
+echo "=== DONE: $LABEL → $FINAL_DIR ==="

--- a/scripts/run-memory-burst.sh
+++ b/scripts/run-memory-burst.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# scripts/run-memory-burst.sh — wrapper around dynamo-ft kv_router_memory_stability_a4
+# that satisfies observe's strict-data-capture rule with per-launch FE-knob injection.
+#
+# Usage:
+#   run-memory-burst.sh <label> <image-tag> <namespace> [fe_knob=val[;fe_knob2=val2…]]
+
+set -uo pipefail
+
+LABEL="${1:-}"
+IMAGE="${2:-}"
+NS="${3:-}"
+FE_KNOBS="${4:-}"
+
+if [[ -z "$LABEL" || -z "$IMAGE" || -z "$NS" ]]; then
+    echo "usage: $0 <label> <image-tag> <namespace> [fe_knob=val[;…]]" >&2
+    exit 2
+fi
+
+OUTBASE_PARENT="${DYN_TEST_OUTPUT_PATH_BASE:-$HOME/.dynamo-ft/test_outputs}"
+OUTBASE="${OUTBASE_PARENT}_${LABEL}"
+TESTNAME='test_kv_router_memory_stability[a4-recommended-2-2.0-3.0-18.0-3.0-2.0]'
+RAW_DIR="$OUTBASE/$TESTNAME"
+FINAL_DIR="$OUTBASE/${TESTNAME}.${LABEL}"
+LOG="/tmp/memory-burst-${LABEL}-$(date +%H%M%S).log"
+mkdir -p "$OUTBASE"
+
+echo "=== run-memory-burst.sh ==="
+echo "  label:     $LABEL"
+echo "  image:     $IMAGE"
+echo "  namespace: $NS"
+echo "  fe knobs:  ${FE_KNOBS:-<none>}"
+echo "  log:       $LOG"
+echo "  outbase:   $OUTBASE"
+echo "  final:     $FINAL_DIR"
+
+EXISTING=$(kubectl -n "$NS" get pods --no-headers 2>/dev/null | grep -E 'vllm-q3|audit-' | wc -l)
+if (( EXISTING > 0 )); then
+    echo "ERROR: $NS has $EXISTING leftover vllm/audit pods. Clean first." >&2
+    exit 3
+fi
+
+cd "$(dirname "$0")/../tests/fault_tolerance/deploy"
+LAUNCH_OUT="/tmp/memory-burst-launch-${LABEL}-$(date +%H%M%S).out"
+DYN_TEST_FE_KNOBS="$FE_KNOBS" \
+DYN_TEST_OUTPUT_PATH="$OUTBASE" \
+./dynamo-ft kv_router_memory_stability_a4 \
+    --image "$IMAGE" \
+    --namespace "$NS" \
+    --storage-class dgxc-enterprise-file \
+    --bg \
+    --log "$LOG" 2>&1 | tee "$LAUNCH_OUT" | tee /dev/stderr | head -10
+
+# Same launch-PID-detection fix as run-cascade-burst.sh: grep
+# dynamo-ft's stdout, not the pytest log file. pgrep with -n (newest)
+# avoids matching stale residuals from prior killed runs.
+TEST_PID=$(grep -m1 '^PID:' "$LAUNCH_OUT" 2>/dev/null | awk '{print $2}')
+for _ in 1 2 3 4 5; do
+    [[ -n "$TEST_PID" ]] || { sleep 2; TEST_PID=$(pgrep -nf "pytest.*memory_stability.*$NS" 2>/dev/null | head -1); }
+done
+if [[ -z "$TEST_PID" ]] || ! kill -0 "$TEST_PID" 2>/dev/null; then
+    echo "ERROR: could not determine live test PID. LAUNCH_OUT=$LAUNCH_OUT" >&2
+    exit 4
+fi
+echo "  test PID:  $TEST_PID"
+
+# Wait for pods Ready, snapshot
+deadline=$(( $(date +%s) + 720 ))
+ready=0
+while (( $(date +%s) < deadline )); do
+    READY=$(kubectl -n "$NS" get pods --no-headers 2>/dev/null \
+        | awk '/vllm-q3/ {split($2,a,"/"); if(a[1]==a[2]) c++} END{print c+0}')
+    if (( READY >= 8 )); then ready=1; break; fi
+    sleep 15
+done
+
+if (( ready )); then
+    echo "  pods Ready — snapshot capture"
+    SNAP="$RAW_DIR/.burst-snapshot-${LABEL}"
+    mkdir -p "$SNAP"
+    kubectl -n "$NS" get pods -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.containers[*].image}{"\n"}{end}' > "$SNAP/image-tags.txt" 2>&1
+    {
+        for pt in frontend vllmdecodeworker vllmprefillworker; do
+            POD=$(kubectl -n "$NS" get pods --no-headers 2>/dev/null | grep "$pt" | head -1 | awk '{print $1}')
+            if [[ -n "$POD" ]]; then
+                echo "## $pt ($POD)"
+                kubectl -n "$NS" exec "$POD" -c main -- env 2>/dev/null | sort
+                echo ""
+            fi
+        done
+    } > "$SNAP/env-vars.txt" 2>&1
+    kubectl -n "$NS" get dynamographdeployment vllm-q3-prod-units -o yaml > "$SNAP/dgd.yaml" 2>&1
+    cat > "$SNAP/aiperf-config.json" <<EOF2
+{
+  "test": "$TESTNAME",
+  "image_label": "$LABEL",
+  "image_tag": "$IMAGE",
+  "namespace": "$NS",
+  "fe_knobs": "${FE_KNOBS:-}",
+  "captured_at": "$(date -u +%FT%TZ)"
+}
+EOF2
+fi
+
+# Wait for test exit (memory tests take ~45 min)
+while kill -0 "$TEST_PID" 2>/dev/null; do sleep 60; done
+echo "  test exited at $(date -u +%FT%TZ)"
+tail -25 "$LOG" 2>/dev/null | grep -E 'PASSED|FAILED|in [0-9]+\.' | head -3
+
+[[ -d "$RAW_DIR" ]] && {
+    [[ -d "$FINAL_DIR" ]] && mv "$FINAL_DIR" "${FINAL_DIR}.prev-$(date +%s)"
+    mv "$RAW_DIR" "$FINAL_DIR"
+    echo "  renamed: $FINAL_DIR"
+}
+echo "=== DONE: $LABEL → $FINAL_DIR ==="

--- a/scripts/spike_view.py
+++ b/scripts/spike_view.py
@@ -1,0 +1,418 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+spike_view — render per-worker time-series sparklines from aiperf server-metrics output.
+
+Reads a test-run output directory containing aiperf's server-metrics exports and
+emits a markdown report (`spike_view.md`) with one sparkline per worker per metric.
+Used for offline post-mortem of cascade-causality test runs.
+
+Inputs (any subset; will use whichever exists):
+  <run>/load/server_metrics_export.jsonl   — raw 1Hz time-series (preferred for sparklines)
+  <run>/load/server_metrics_export.json    — aggregate stats (fallback summary)
+  <run>/load/profile_export_aiperf.json    — request-side TTFT / latency summaries
+
+Output:
+  <run>/spike_view.md                      — markdown with system + per-worker sections
+
+Metrics surfaced (whatever subset is in the data):
+  - vllm:num_requests_running, vllm:num_requests_waiting (per worker, per dp_rank)
+  - vllm:kv_cache_usage_perc
+  - vllm:nixl_post_time_seconds (histogram → p99 estimate per timestep)
+  - vllm:nixl_num_failed_transfers, vllm:nixl_num_kv_expired_reqs (counters)
+  - dynamo_frontend_time_to_first_token_seconds (histogram → p99)
+  - dynamo_frontend_request_duration_seconds (histogram → p99)
+  - dynamo_frontend_queued_requests, dynamo_frontend_inflight_requests
+
+Stdlib only — no pyarrow, no pandas. Sparklines via 8-row Unicode block chars.
+
+Usage:
+  scripts/spike_view.py <run-dir>
+  scripts/spike_view.py test_outputs/test_sanity_vllm_qwen3_30b
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import statistics
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+# 8-level Unicode block characters for sparklines (▁ ▂ ▃ ▄ ▅ ▆ ▇ █)
+SPARK_CHARS = "▁▂▃▄▅▆▇█"
+
+# Metrics we care about for cascade analysis. Order = display order.
+KEY_METRICS = [
+    ("vllm:num_requests_running", "running"),
+    ("vllm:num_requests_waiting", "waiting"),
+    ("vllm:kv_cache_usage_perc", "kv_pct"),
+    ("vllm:nixl_post_time_seconds", "nixl_p99"),  # histogram → p99
+    ("vllm:nixl_num_failed_transfers", "nxl_fail"),
+    ("vllm:nixl_num_kv_expired_reqs", "kv_exp"),
+    ("dynamo_frontend_queued_requests", "fe_queued"),
+    ("dynamo_frontend_inflight_requests", "fe_inflight"),
+    ("dynamo_frontend_time_to_first_token_seconds", "ttft_p99"),  # histogram → p99
+    ("dynamo_frontend_request_duration_seconds", "rtt_p99"),  # histogram → p99
+]
+
+# Column width for sparklines. 60 chars ≈ 1 minute @ 1Hz scrape.
+SPARK_WIDTH = 60
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Sparkline rendering
+
+
+def sparkline(values: list[float], width: int = SPARK_WIDTH) -> str:
+    """Render a sequence of floats as a Unicode block-character sparkline.
+
+    Resamples to `width` columns by binning. Empty/all-NaN input → blanks.
+    """
+    if not values:
+        return " " * width
+    clean = [
+        v
+        for v in values
+        if v is not None and not (isinstance(v, float) and math.isnan(v))
+    ]
+    if not clean:
+        return " " * width
+    lo, hi = min(clean), max(clean)
+    if lo == hi:
+        # all same value: pick mid-band character
+        return SPARK_CHARS[3] * min(len(clean), width)
+    span = hi - lo
+    # Resample to width via simple binning (mean per bin)
+    n = len(values)
+    if n <= width:
+        binned = values
+    else:
+        binned = []
+        bin_size = n / width
+        for i in range(width):
+            start = int(i * bin_size)
+            end = max(int((i + 1) * bin_size), start + 1)
+            chunk = [v for v in values[start:end] if v is not None]
+            binned.append(statistics.mean(chunk) if chunk else None)
+    out = []
+    for v in binned:
+        if v is None:
+            out.append(" ")
+        else:
+            idx = int((v - lo) / span * (len(SPARK_CHARS) - 1))
+            out.append(SPARK_CHARS[max(0, min(idx, len(SPARK_CHARS) - 1))])
+    return "".join(out)
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# JSONL parsing (per-record aiperf SlimRecord format)
+#
+# Schema (from aiperf v0.7.0 src/aiperf/common/models/server_metrics_models.py):
+#   {
+#     "endpoint_url": "http://<ip>:9090/metrics",
+#     "timestamp_ns": <int>,
+#     "request_sent_ns": <int|null>,
+#     "first_byte_ns": <int|null>,
+#     "metrics": {
+#       "<metric_name>": [
+#         {
+#           "labels": {"dp_rank": "0", "dynamo_component": "prefill", ...},
+#           "value": <float>,                   # for counter/gauge
+#           "buckets": {"0.001": 0, "0.005": 12, ...},  # for histogram
+#           "sum": <float>,                     # for histogram
+#           "count": <int>,                     # for histogram
+#         }, ...
+#       ]
+#     }
+#   }
+
+
+def parse_jsonl(path: Path) -> list[dict[str, Any]]:
+    records = []
+    with path.open() as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError as e:
+                print(f"warn: skipping malformed line in {path}: {e}", file=sys.stderr)
+    return records
+
+
+def histogram_quantile(buckets: dict[str, float], q: float) -> float | None:
+    """Estimate quantile q (0..1) from a Prometheus histogram bucket dict.
+
+    Buckets are cumulative counts keyed by `le` upper bound (string representation).
+    Linear interpolation within the matching bucket; +Inf → returns the previous bound.
+    """
+    if not buckets:
+        return None
+    # Sort by le, with +Inf last
+    ordered = []
+    for k, v in buckets.items():
+        try:
+            le = float(k) if k not in ("+Inf", "Inf") else float("inf")
+        except ValueError:
+            continue
+        ordered.append((le, float(v)))
+    ordered.sort()
+    if not ordered or ordered[-1][1] == 0:
+        return None
+    total = ordered[-1][1]
+    target = q * total
+    prev_le, prev_count = 0.0, 0.0
+    for le, count in ordered:
+        if count >= target:
+            if le == float("inf"):
+                return prev_le
+            if count == prev_count:
+                return le
+            # Linear interp within the bucket
+            frac = (target - prev_count) / (count - prev_count)
+            return prev_le + frac * (le - prev_le)
+        prev_le, prev_count = le, count
+    return ordered[-1][0]
+
+
+def extract_per_endpoint_series(
+    records: list[dict[str, Any]],
+) -> dict[tuple[str, str], dict[str, list[tuple[int, float]]]]:
+    """Return: {(endpoint_url, label_signature): {metric_name: [(ts_ns, value), ...]}}.
+
+    label_signature is a stable string of the form 'dp=0,component=prefill,...'.
+    For histograms, value = p99 estimate via histogram_quantile.
+    """
+    series: dict[tuple[str, str], dict[str, list[tuple[int, float]]]] = defaultdict(
+        lambda: defaultdict(list)
+    )
+    for rec in records:
+        ts = rec.get("timestamp_ns") or rec.get("first_byte_ns")
+        if ts is None:
+            continue
+        endpoint = rec.get("endpoint_url", "?")
+        for metric_name, samples in (rec.get("metrics") or {}).items():
+            for sample in samples or []:
+                labels = sample.get("labels") or {}
+                # Build a compact signature for grouping by label combo
+                sig_parts = []
+                for k in sorted(labels):
+                    if k in ("dynamo_namespace", "model", "model_name", "engine"):
+                        continue  # mostly invariant; skip to keep label sig short
+                    sig_parts.append(f"{k}={labels[k]}")
+                sig = ",".join(sig_parts) or "_"
+                key = (endpoint, sig)
+                if "value" in sample and sample["value"] is not None:
+                    series[key][metric_name].append((ts, float(sample["value"])))
+                elif "buckets" in sample and sample["buckets"]:
+                    p99 = histogram_quantile(sample["buckets"], 0.99)
+                    if p99 is not None:
+                        series[key][metric_name].append((ts, p99))
+    return series
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Aggregate-JSON parsing (fallback when no JSONL — produces stats only, no sparklines)
+
+
+def parse_aggregate_json(path: Path) -> dict[str, list[dict[str, Any]]]:
+    """Returns {metric_name: [series_dict, ...]} from server_metrics_export.json."""
+    with path.open() as f:
+        d = json.load(f)
+    return d.get("metrics", {})
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Reporting
+
+
+def short_endpoint(url: str) -> str:
+    """http://100.67.132.189:9090/metrics  →  100.67.132.189"""
+    if "://" in url:
+        url = url.split("://", 1)[1]
+    return url.split("/", 1)[0].split(":", 1)[0]
+
+
+def short_label(sig: str) -> str:
+    parts = sig.split(",")
+    out = {}
+    for p in parts:
+        if "=" not in p:
+            continue
+        k, v = p.split("=", 1)
+        if k == "dynamo_component":
+            out["c"] = v
+        elif k == "dynamo_endpoint":
+            out["e"] = v
+        elif k == "dp_rank":
+            out["r"] = v
+    return ",".join(f"{k}={v}" for k, v in out.items()) or sig[:40]
+
+
+def render_jsonl_report(
+    series: dict[tuple[str, str], dict[str, list[tuple[int, float]]]],
+    out: Path,
+) -> None:
+    lines = ["# spike_view — per-worker time-series sparklines\n"]
+    if not series:
+        lines.append("(no records parsed; jsonl was empty or malformed)\n")
+        out.write_text("".join(lines))
+        return
+
+    # Group by endpoint, then by label signature.
+    by_endpoint: dict[str, list[tuple[str, dict]]] = defaultdict(list)
+    for (ep, sig), metrics_dict in series.items():
+        by_endpoint[ep].append((sig, metrics_dict))
+
+    # System-wide totals (sum across endpoints) for the few system-level metrics
+    lines.append("## System view\n")
+    lines.append("Sums across endpoints; one row per metric.\n\n")
+    lines.append("```\n")
+    for metric_name, label in KEY_METRICS:
+        # Sum at each unique timestamp
+        ts_to_sum: dict[int, float] = defaultdict(float)
+        seen_any = False
+        for (_, _), metrics_dict in series.items():
+            for ts, val in metrics_dict.get(metric_name, []):
+                ts_to_sum[ts] += val
+                seen_any = True
+        if not seen_any:
+            continue
+        ordered = [v for _, v in sorted(ts_to_sum.items())]
+        lo, hi = min(ordered), max(ordered)
+        spark = sparkline(ordered)
+        lines.append(
+            f"{label:<14} | {spark} | min={lo:.3g} max={hi:.3g} n={len(ordered)}\n"
+        )
+    lines.append("```\n\n")
+
+    # Per-endpoint detail
+    for ep in sorted(by_endpoint):
+        lines.append(f"## {short_endpoint(ep)}\n")
+        lines.append(f"`{ep}`\n\n")
+        for sig, metrics_dict in sorted(by_endpoint[ep]):
+            lines.append(f"### labels: `{short_label(sig)}`\n\n")
+            lines.append("```\n")
+            for metric_name, label in KEY_METRICS:
+                pts = metrics_dict.get(metric_name, [])
+                if not pts:
+                    continue
+                values = [v for _, v in sorted(pts)]
+                lo, hi = min(values), max(values)
+                spark = sparkline(values)
+                lines.append(
+                    f"{label:<14} | {spark} | min={lo:.3g} max={hi:.3g} n={len(values)}\n"
+                )
+            lines.append("```\n\n")
+    out.write_text("".join(lines))
+
+
+def render_aggregate_summary(
+    metrics: dict[str, list[dict[str, Any]]],
+    out: Path,
+) -> None:
+    """Fallback when only aggregate JSON exists — render summary stats per endpoint."""
+    lines = ["# spike_view — aggregate summary (no JSONL time-series available)\n\n"]
+    lines.append(
+        "JSONL output (`server_metrics_export.jsonl`) was not produced. "
+        "Showing aggregate stats from `server_metrics_export.json` instead — "
+        "no time-series, but per-endpoint avg/min/max/p99 still useful for sanity.\n\n"
+    )
+    # Group by endpoint for tabular display
+    rows: list[tuple[str, str, str, dict[str, float]]] = []
+    for metric_name, _ in KEY_METRICS:
+        if metric_name not in metrics:
+            continue
+        for s in metrics[metric_name].get("series", []):
+            ep = short_endpoint(s.get("endpoint_url", "?"))
+            labels = s.get("labels", {}) or {}
+            label_str = short_label(
+                ",".join(f"{k}={v}" for k, v in sorted(labels.items()))
+            )
+            stats = s.get("stats", {})
+            rows.append((ep, label_str, metric_name, stats))
+    if not rows:
+        lines.append("(no metrics matched the key list — check metric names)\n")
+        out.write_text("".join(lines))
+        return
+    # Group output by endpoint
+    by_ep: dict[str, list] = defaultdict(list)
+    for ep, lbl, metric, stats in rows:
+        by_ep[ep].append((lbl, metric, stats))
+    for ep in sorted(by_ep):
+        lines.append(f"## {ep}\n\n")
+        lines.append("| labels | metric | avg | max | p99 |\n")
+        lines.append("|---|---|---:|---:|---:|\n")
+        for lbl, metric, stats in by_ep[ep]:
+            avg = stats.get("avg", float("nan"))
+            mx = stats.get("max", float("nan"))
+            p99 = stats.get("p99", float("nan"))
+            lines.append(
+                f"| `{lbl}` | `{metric}` | {avg:.3g} | {mx:.3g} | {p99:.3g} |\n"
+            )
+        lines.append("\n")
+    out.write_text("".join(lines))
+
+
+# ────────────────────────────────────────────────────────────────────────────
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.strip().split("\n")[0])
+    ap.add_argument("run_dir", type=Path, help="Test run directory (parent of load/)")
+    ap.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="Output markdown path (default: <run_dir>/spike_view.md)",
+    )
+    ap.add_argument(
+        "--echo",
+        action="store_true",
+        help="Also print the report to stdout",
+    )
+    args = ap.parse_args()
+
+    run_dir: Path = args.run_dir
+    load_dir = run_dir / "load"
+    if not load_dir.is_dir():
+        print(f"error: {load_dir} not found", file=sys.stderr)
+        return 2
+
+    out = args.out or (run_dir / "spike_view.md")
+    jsonl = load_dir / "server_metrics_export.jsonl"
+    summary = load_dir / "server_metrics_export.json"
+
+    if jsonl.exists():
+        records = parse_jsonl(jsonl)
+        print(f"parsed {len(records)} JSONL records from {jsonl}", file=sys.stderr)
+        series = extract_per_endpoint_series(records)
+        render_jsonl_report(series, out)
+    elif summary.exists():
+        metrics = parse_aggregate_json(summary)
+        print(
+            f"warn: no JSONL — falling back to aggregate JSON ({summary})",
+            file=sys.stderr,
+        )
+        render_aggregate_summary(metrics, out)
+    else:
+        print(
+            f"error: neither {jsonl} nor {summary} exists. "
+            "Did the run pass --server-metrics-formats jsonl?",
+            file=sys.stderr,
+        )
+        return 2
+
+    print(f"wrote {out}", file=sys.stderr)
+    if args.echo:
+        sys.stdout.write(out.read_text())
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/watch_live.sh
+++ b/scripts/watch_live.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Live-watch a running cascade-console driver: pulls the load PVC's current
+# server_metrics_export.jsonl, runs cascade_timeline, repeats every 30s.
+#
+# Requires:
+#   - The driver pytest is running with `--log-pvc qwen3-30b-logs`
+#   - host has kubectl + cluster context selected
+#   - a peek pod gets created in the test namespace and reused
+#
+# Usage:
+#   scripts/watch_live.sh                                        # default ns + pvc
+#   scripts/watch_live.sh -n <ns> -p <pvc> --metrics queued,...   # full custom
+
+set -euo pipefail
+
+CTX_DEFAULT=nv-prd-dgxc.teleport.sh-dynamo-aws-dev-02
+NS_DEFAULT=neelays-test
+PVC_DEFAULT=qwen3-30b-logs
+
+CTX="$CTX_DEFAULT"
+NS="$NS_DEFAULT"
+PVC="$PVC_DEFAULT"
+METRICS="queued,inflight,ttft_p99,running,waiting,kv_pct,nixl_p99"
+INTERVAL=30
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --context|-c) CTX="$2"; shift 2 ;;
+    --namespace|-n) NS="$2"; shift 2 ;;
+    --pvc|-p) PVC="$2"; shift 2 ;;
+    --metrics|-m) METRICS="$2"; shift 2 ;;
+    --interval|-i) INTERVAL="$2"; shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+OUTDIR=$(mktemp -d)
+trap 'rm -rf "$OUTDIR"; kubectl --context "$CTX" -n "$NS" delete pod pvc-peek-watch --wait=false 2>/dev/null || true' EXIT
+
+# Spin up peek pod (idempotent)
+cat <<EOF | kubectl --context "$CTX" -n "$NS" apply -f - >/dev/null
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pvc-peek-watch
+spec:
+  restartPolicy: Never
+  containers:
+  - name: peek
+    image: alpine:3.20
+    command: ["sleep", "86400"]
+    volumeMounts:
+    - {name: logs, mountPath: /pvc}
+  volumes:
+  - name: logs
+    persistentVolumeClaim:
+      claimName: $PVC
+EOF
+
+# Wait for peek pod
+echo "waiting for peek pod ..." >&2
+until kubectl --context "$CTX" -n "$NS" get pod pvc-peek-watch \
+        -o jsonpath='{.status.phase}' 2>/dev/null | grep -q Running; do
+  sleep 1
+done
+echo "peek pod ready" >&2
+
+mkdir -p "$OUTDIR/load"
+
+while true; do
+  # Pull the current snapshot of the live JSONL
+  if kubectl --context "$CTX" -n "$NS" cp \
+        "pvc-peek-watch:/pvc/aiperf/server_metrics_export.jsonl" \
+        "$OUTDIR/load/server_metrics_export.jsonl" 2>/dev/null; then
+    sz=$(wc -l < "$OUTDIR/load/server_metrics_export.jsonl" 2>/dev/null || echo 0)
+    if [[ "$sz" -gt 0 ]]; then
+      clear
+      echo "=== live cascade view — $(date) — $sz JSONL records ==="
+      echo
+      python3 "$(dirname "$0")/cascade_timeline.py" "$OUTDIR" \
+        --metrics "$METRICS" --width 80 2>&1 | tail -200
+    else
+      echo "[$(date +%H:%M:%S)] no records yet (load Job may be initializing)"
+    fi
+  else
+    echo "[$(date +%H:%M:%S)] couldn't pull jsonl (PVC busy or path missing); retrying"
+  fi
+  sleep "$INTERVAL"
+done

--- a/tests/fault_tolerance/deploy/README.md
+++ b/tests/fault_tolerance/deploy/README.md
@@ -176,6 +176,7 @@ test_outputs/test_network_partition_vllm/
 | --- | --- | --- |
 | `DeletePod(services=[...])` | `pod.delete(force=...)`. Worker / frontend / planner — anything with the right `nvidia.com/dynamo-component` label. | Snapshots the pod manifest + `/metrics` `before_delete` so post-mortem comparisons are possible. |
 | `TerminateProcess(services, process_name, signal)` | Exec into the pod and `kill -<signal> <pid>` of a matching process (`dynamo.vllm`, `VLLM::EngineCore`, `sglang::scheduler`, …). | The kubelet restart-in-place behaviour depends on the process being PID 1 vs. a child; subprocess kills are no-ops at the container level (documented in *Backend-Specific Validations* further below). |
+| `StallProcess(services, process_name, duration=None)` | `SIGSTOP` the matching process; sleep `duration` seconds (or until `stop()` if `duration` is None); `SIGCONT` to resume. | Models a "hung worker": the process stays alive, TCP sockets and conntrack entries are preserved, kubelet doesn't notice — but it stops servicing requests. Exercises frontend timeout / health-check behaviour rather than crash recovery. |
 | `NetworkPartition(source, target, duration=None)` | Applies a `NetworkPolicy` selecting `target` pods and denying ingress from `source` pods, then schedules a privileged hostNetwork `conntrack -D` flusher Pod on the source pod's node so already-established TCP sockets are severed (k8s `NetworkPolicy` is connection-tracked; without the flush a pooled socket trivially survives). Heals on `stop()` or after `duration` seconds. | Requires a CNI that enforces NetworkPolicy (k3s kube-router, Calico, Cilium). The flusher uses `localhost:32000/netshoot:latest` by default; override with `DYN_CONNTRACK_IMAGE`. |
 | `RollingUpgrade(services, env_var=...)` | Stamps a unique env var on each named service then publishes the change so the operator rolls the underlying Deployments. | Drives the "redeploy under load" scenario. |
 | `RunCommand(services, command)` | Exec arbitrary command in matched pods. | Escape hatch for one-off injections (e.g., `pkill -STOP`, `nvidia-smi -i 0 -r`). |
@@ -223,6 +224,26 @@ Pod IP is **preserved** (kubelet restarts the container in place), so
 the frontend's TCP socket fails fast on the existing connection rather
 than waiting for re-discovery — but the model must still reload, so
 recovery time is comparable to `DeletePod`.
+
+#### StallProcess (engine hang)
+
+```mermaid
+stateDiagram-v2
+    [*] --> Healthy
+    Healthy --> SIGSTOPSent: kill -SIGSTOP dynamo.vllm
+    SIGSTOPSent --> Stopped: process suspended; pod alive, sockets open
+    Stopped --> RequestsBacklogged: in-flight requests stall on the worker; new requests queue at frontend
+    RequestsBacklogged --> ClientTimeouts: aiperf request_timeout fires; 5xx returned
+    ClientTimeouts --> SIGCONTSent: duration expires (event.stop)
+    SIGCONTSent --> Resumed: process scheduled again; queued work drains
+    Resumed --> Healthy
+```
+
+The pod, container, TCP sockets, and conntrack entries all persist
+unchanged through the stall — kubelet doesn't notice and there is no
+container restart. Distinct from `TerminateProcess` (crash) and
+`NetworkPartition` (network cut): only `StallProcess` exercises the
+"worker accepted my request and went silent" failure mode.
 
 #### NetworkPartition + conntrack flush
 

--- a/tests/fault_tolerance/deploy/README.md
+++ b/tests/fault_tolerance/deploy/README.md
@@ -24,6 +24,419 @@ unforseen failures. In order to test Dynamo we are developing a test
 suite to inject and measure the impact of different types of failure
 conditions.
 
+The suite has two layers, both pytest-driven and both running against a
+real `DynamoGraphDeployment` in a Kubernetes namespace:
+
+1. **Event-based harness** (current) — `tests/fault_tolerance/deploy/scenario.py`
+   plus `events.py`. Each test composes a deployment + a list of timed
+   events (`StartLoad`, `DeletePod`, `TerminateProcess`,
+   `NetworkPartition`, …) and emits per-test FT reports plus a
+   combined comparison table.
+2. **Legacy scenario-driven harness** — `test_deployment.py` parametrised
+   by the table in `scenarios.py`. Documented further down under
+   *Legacy scenario harness*.
+
+New tests should target the event-based harness; everything below up
+to *Legacy scenario harness* describes that path.
+
+## Event-based test harness
+
+### Component architecture
+
+```mermaid
+graph TD
+    subgraph Test["Test (pytest)"]
+        spec[DeploymentSpec.from_backend]
+        events[events: WaitForModelReady, StartLoad, fault, StopLoad, ...]
+        checks[checks: MinRequests, MaxErrors, ZeroErrors, ...]
+        reports[reports: FaultToleranceReport, ErrorBreakdownReport]
+    end
+    Test --> Scenario[run_scenario]
+    Scenario --> MD[ManagedDeployment]
+    Scenario --> Load[ManagedLoad]
+    Scenario --> EventLoop[event.timed_execute]
+    EventLoop --> MD
+    EventLoop --> Load
+    EventLoop --> NPClass[NetworkPartition]
+    NPClass --> NetPolicy[NetworkPolicy + conntrack flusher pod]
+    MD --> K8s[Kubernetes API]
+    MD --> PVC[(RWX log PVC)]
+    Load --> AIPerf[aiperf Job in-cluster]
+    AIPerf --> Frontend[Frontend pod]
+    AIPerf --> ServerMetrics[server_metrics_export.json &lt;-- aiperf scrapes /metrics ]
+    PVC --> LogExtract[end-of-run log extract Job]
+    LogExtract --> Outputs[test_outputs/test_name/...]
+    reports --> Outputs
+    Combined[scripts/aggregate-ft-reports.sh] --> Outputs
+```
+
+### Components
+
+| Module | Role |
+| --- | --- |
+| `tests/utils/managed_deployment.py` (`ManagedDeployment`) | Async context manager. Materialises the log-collection PVC, applies the `DynamoGraphDeployment`, waits for `Ready=True`, and tears everything down on exit. Captures per-pod manifests, container logs (via PVC tee), and `/metrics` snapshots. |
+| `tests/utils/managed_load.py` (`ManagedLoad`, `LoadConfig`) | Spawns an in-cluster aiperf load `Job` against the frontend service. aiperf's `--server-metrics` flag is **on by default** so the run also writes `server_metrics_export.json` (timestamped Prometheus scrape of the frontend) alongside `profile_export_aiperf.json`. |
+| `tests/fault_tolerance/deploy/events.py` | Timed events (load, faults, waits) implementing a common `Event.execute()` template with `started_at` / `ended_at` brackets that reports use to slice metrics around faults. |
+| `tests/fault_tolerance/deploy/checks.py` | Pluggable assertions (`MinRequests`, `MaxErrors`, `LoadStopped`, `LoadCompleted`, `ZeroErrors`). Run after reports so a failed assertion never blocks report generation. |
+| `tests/fault_tolerance/deploy/reports.py` | Markdown + JSON sidecar reports. `FaultToleranceReport` produces the per-fault Timing / Counts / Latency table; `ErrorBreakdownReport` summarises aiperf error types. |
+| `tests/fault_tolerance/deploy/scenario.py` (`run_scenario`) | Glue. Drives `ManagedDeployment` + events + reports + checks. |
+
+### Data flow during a run
+
+```mermaid
+graph LR
+    subgraph cluster["dynamo-test namespace"]
+        Aiperf[aiperf Job]
+        FE[Frontend pod]
+        W[Worker pod]
+        PVC[(RWX log PVC<br/>service_logs/)]
+    end
+    subgraph dyn-system["dynamo-system namespace"]
+        ETCD[(etcd)]
+        NATS[(NATS)]
+    end
+    subgraph hostnet["host network privileged pod"]
+        FlushPod[netshoot conntrack -D]
+    end
+
+    Aiperf -->|HTTP /v1/chat/completions| FE
+    FE <-->|TCP request plane| W
+    W -->|register / events| ETCD
+    W -->|publish / events| NATS
+    Aiperf -->|/metrics scrape every ~400ms| FE
+    Aiperf -->|profile_export_aiperf.json| Outputs[test_outputs/]
+    Aiperf -->|server_metrics_export.json| Outputs
+    FE -->|tee stdout/stderr| PVC
+    W -->|tee stdout/stderr| PVC
+    PVC -->|end-of-run extract Job| Outputs
+    FlushPod -.->|conntrack -D for source/target| Kernel[(node kernel<br/>conntrack table)]
+```
+
+The TCP request plane (`RequestPlaneMode::Tcp`, default) is direct
+pod-to-pod; NATS / etcd carry events and discovery, not per-request
+traffic. That distinction matters for partition design — the
+NetworkPolicy must target the request-plane edge, not the NATS edge.
+
+### Lifecycle
+
+```mermaid
+sequenceDiagram
+    participant Pytest
+    participant Scenario as run_scenario
+    participant MD as ManagedDeployment
+    participant K8s as Kubernetes API
+    participant Worker
+    participant Frontend
+    participant Load as ManagedLoad (aiperf)
+
+    Pytest->>Scenario: events, checks, reports, deployment_spec
+    Scenario->>MD: __aenter__
+    MD->>K8s: scrub namespace, create RWX log PVC
+    MD->>K8s: apply DynamoGraphDeployment
+    MD->>K8s: poll until Ready=True
+    Scenario->>Scenario: WaitForModelReady (port-forward to Frontend, poll /v1/models)
+    Scenario->>Load: StartLoad (aiperf Job, scrapes Frontend /metrics)
+    Load->>Frontend: HTTP requests
+    Frontend->>Worker: TCP request plane
+    Scenario->>K8s: fault event (DeletePod / TerminateProcess / NetworkPartition / ...)
+    Scenario->>Scenario: WaitForRecovery / Wait
+    Scenario->>Load: StopLoad
+    Scenario->>MD: __aexit__
+    MD->>K8s: extract logs from PVC, capture pod manifests + /metrics, delete deployment
+    Scenario->>Scenario: generate reports (Markdown + JSON sidecars)
+    Scenario->>Scenario: run checks (assertions)
+```
+
+Reports run **before** checks so an assertion failure never suppresses
+the run's data. Per-test artefacts land at
+`<DYN_TEST_OUTPUT_PATH>/<test_name>/`:
+
+```
+test_outputs/test_network_partition_vllm/
+├── frontend/
+│   ├── <pod>.yaml
+│   └── <pod>_<ts>.log              # tee'd from PVC
+├── vllmdecodeworker/
+│   ├── <pod>.yaml
+│   └── <pod>_<ts>.log
+├── load/
+│   ├── profile_export_aiperf.json  # request-level latencies, errors
+│   ├── server_metrics_export.json  # aiperf's Frontend /metrics scrape
+│   ├── server_metrics_export.csv
+│   ├── inputs.json
+│   └── aiperf.log
+├── fault_tolerance_report.md       # per-test Timing/Counts/Latency
+├── fault_tolerance_report.json     # machine-readable sidecar
+└── error_breakdown_report.md       # aiperf error types
+```
+
+### Supported fault events
+
+| Event | What it does | Notes |
+| --- | --- | --- |
+| `DeletePod(services=[...])` | `pod.delete(force=...)`. Worker / frontend / planner — anything with the right `nvidia.com/dynamo-component` label. | Snapshots the pod manifest + `/metrics` `before_delete` so post-mortem comparisons are possible. |
+| `TerminateProcess(services, process_name, signal)` | Exec into the pod and `kill -<signal> <pid>` of a matching process (`dynamo.vllm`, `VLLM::EngineCore`, `sglang::scheduler`, …). | The kubelet restart-in-place behaviour depends on the process being PID 1 vs. a child; subprocess kills are no-ops at the container level (documented in *Backend-Specific Validations* further below). |
+| `NetworkPartition(source, target, duration=None)` | Applies a `NetworkPolicy` selecting `target` pods and denying ingress from `source` pods, then schedules a privileged hostNetwork `conntrack -D` flusher Pod on the source pod's node so already-established TCP sockets are severed (k8s `NetworkPolicy` is connection-tracked; without the flush a pooled socket trivially survives). Heals on `stop()` or after `duration` seconds. | Requires a CNI that enforces NetworkPolicy (k3s kube-router, Calico, Cilium). The flusher uses `localhost:32000/netshoot:latest` by default; override with `DYN_CONNTRACK_IMAGE`. |
+| `RollingUpgrade(services, env_var=...)` | Stamps a unique env var on each named service then publishes the change so the operator rolls the underlying Deployments. | Drives the "redeploy under load" scenario. |
+| `RunCommand(services, command)` | Exec arbitrary command in matched pods. | Escape hatch for one-off injections (e.g., `pkill -STOP`, `nvidia-smi -i 0 -r`). |
+| `Wait(duration)`, `WaitForRecovery(timeout)`, `WaitForModelReady(timeout)`, `WaitForLogPattern(pattern, timeout)` | Time / state synchronisation between events. | `WaitForModelReady` port-forwards to the frontend and polls `/v1/models` until the deployed model is registered, so vllm/sglang model load (which can run tens of seconds beyond pod-Ready) doesn't bleed into the load window. |
+| `StartLoad(load_config)`, `StopLoad`, `WaitForLoadCompletion` | aiperf-driven load lifecycle. | aiperf's `--server-metrics` is on by default; aiperf scrapes the Frontend's `/metrics` for the duration of the run and writes timestamped stats per metric. |
+
+### Per-fault state transitions
+
+These diagrams show what the worker pod (or the worker→frontend
+connection) goes through during each fault mode. The "Healthy"
+state is "pod Ready, model registered, frontend can route requests."
+
+#### DeletePod
+
+```mermaid
+stateDiagram-v2
+    [*] --> Healthy
+    Healthy --> PodTerminating: DeletePod (force)
+    PodTerminating --> PodGone: grace period elapsed
+    PodGone --> PodPending: operator reschedules
+    PodPending --> ContainerCreating: pulling image
+    ContainerCreating --> Running: container start
+    Running --> ModelLoading: vllm engine init + KV warmup
+    ModelLoading --> Healthy: model re-registered with frontend
+```
+
+The frontend deregisters the worker on disconnect and re-discovers it
+when it reappears in etcd. Failed-after errors are dominated by
+`Model not found` 404s during the re-registration window.
+
+#### TerminateProcess (engine kill)
+
+```mermaid
+stateDiagram-v2
+    [*] --> Healthy
+    Healthy --> ProcessKilled: kill -SIGKILL dynamo.vllm
+    ProcessKilled --> ContainerExited: PID 1 exits
+    ContainerExited --> ContainerRestarting: kubelet restartPolicy
+    ContainerRestarting --> Running: same pod, new container
+    Running --> ModelLoading: vllm reload
+    ModelLoading --> Healthy: model re-registered
+```
+
+Pod IP is **preserved** (kubelet restarts the container in place), so
+the frontend's TCP socket fails fast on the existing connection rather
+than waiting for re-discovery — but the model must still reload, so
+recovery time is comparable to `DeletePod`.
+
+#### NetworkPartition + conntrack flush
+
+```mermaid
+stateDiagram-v2
+    [*] --> Healthy
+    Healthy --> Loading: StartLoad (aiperf concurrency=4)
+    Loading --> SteadyState: in-flight≈4, queue=0
+    SteadyState --> PolicyApplied: NetworkPolicy applied (source=Frontend, target=Worker)
+    PolicyApplied --> ConntrackFlushed: hostNetwork flusher Pod runs conntrack -D
+    ConntrackFlushed --> SocketsSevered: established TCP dies; new connect attempts denied
+    SocketsSevered --> QueueBuilds: HTTP queue grows; in-flight pinned at 4 retrying
+    QueueBuilds --> WorkerDeregistered: frontend marks model unavailable
+    WorkerDeregistered --> NotFoundErrors: 404 'Model not found' to clients
+    NotFoundErrors --> PolicyLifted: duration expires (event.stop)
+    PolicyLifted --> Reconnecting: new TCP handshake succeeds
+    Reconnecting --> SteadyState: queue drains; throughput burst (3-4× baseline)
+```
+
+Without the conntrack flush, the system stays in `SteadyState` for
+the full partition window — the connection-tracked TCP socket survives
+the new policy and requests keep flowing. The flush is what makes the
+partition observable as a fault.
+
+### Example test
+
+```python
+async def test_worker_kill_vllm(namespace, image, skip_service_restart, storage_class):
+    spec = DeploymentSpec.from_backend("vllm", "agg")
+    served_model = spec["VllmDecodeWorker"].model
+
+    await run_scenario(
+        deployment_spec=spec,
+        events=[
+            WaitForModelReady(timeout=600),
+            StartLoad(load_config=LoadConfig(
+                model_name=served_model,
+                tokenizer=served_model,
+                duration_minutes=2,
+                concurrency=4,
+                input_tokens_mean=128,
+                output_tokens_mean=32,
+            )),
+            Wait(duration=20),
+            DeletePod(services=["VllmDecodeWorker"]),
+            WaitForRecovery(timeout=300),
+            Wait(duration=20),
+            StopLoad(),
+        ],
+        checks=[MinRequests(min_count=20), MaxErrors(max_errors=1_000_000)],
+        reports=[FaultToleranceReport(), ErrorBreakdownReport()],
+        namespace=namespace,
+        image=image,
+        test_name="test_worker_kill_vllm",
+        skip_service_restart=skip_service_restart,
+        storage_class=storage_class,
+    )
+```
+
+### Combined comparison report
+
+`scripts/aggregate-ft-reports.sh` (in the dev vault) walks the output
+tree and merges every `fault_tolerance_report.json` + `error_breakdown_report.md`
++ `server_metrics_export.json` into one Markdown comparison file. This
+is what gets shipped to slides.
+
+```text
+# Fault-tolerance comparison — 4 scenarios
+
+## Timing across scenarios
+
+| Scenario · Failure                                                          | Startup (s) | Recovery (s) |
+|:---------------------------------------------------------------------------|------------:|:-------------|
+| test_sanity_vllm · none                                                    |       81.59 | N/A          |
+| test_worker_kill_vllm · DeletePod(VllmDecodeWorker)                        |       81.03 | 81.53        |
+| test_engine_kill_vllm · TerminateProcess(VllmDecodeWorker)                 |       81.63 | 94.04        |
+| test_network_partition_vllm · NetworkPartition(Frontend->VllmDecodeWorker) |      191.64 | 20.00        |
+
+## Request counts (pre/post fault)
+
+| Scenario · Failure                                                          | Success Before | Failed Before | Success After | Failed After |
+|:---------------------------------------------------------------------------|---------------:|--------------:|--------------:|-------------:|
+| test_sanity_vllm · none                                                    |             10 |             0 |   N/A         |   N/A        |
+| test_worker_kill_vllm · DeletePod(VllmDecodeWorker)                        |            190 |             0 |   408         | 271457       |
+| test_engine_kill_vllm · TerminateProcess(VllmDecodeWorker)                 |            207 |             0 |   279         | 312521       |
+| test_network_partition_vllm · NetworkPartition(Frontend->VllmDecodeWorker) |            144 |             0 |   609         |   7070       |
+
+## Latency (avg ms)
+
+| Scenario · Failure                                                          | Before (ms) | After (ms) |
+|:---------------------------------------------------------------------------|------------:|:-----------|
+| test_sanity_vllm · none                                                    |      182.36 | N/A        |
+| test_worker_kill_vllm · DeletePod(VllmDecodeWorker)                        |      186.13 | 180.59     |
+| test_engine_kill_vllm · TerminateProcess(VllmDecodeWorker)                 |      185.10 | 184.13     |
+| test_network_partition_vllm · NetworkPartition(Frontend->VllmDecodeWorker) |      190.93 | 186.60     |
+
+## Frontend metrics during run (from aiperf /metrics scrape)
+
+| Scenario · Failure                                                          | Inflight max | Inflight avg | Queued max | Queued p95 | Disconnected (max) |
+|:---------------------------------------------------------------------------|-------------:|-------------:|-----------:|-----------:|-------------------:|
+| test_sanity_vllm · none                                                    |            2 |          0.8 |          0 |          0 |                  0 |
+| test_worker_kill_vllm · DeletePod(VllmDecodeWorker)                        |            4 |         0.96 |          4 |          0 |                  0 |
+| test_engine_kill_vllm · TerminateProcess(VllmDecodeWorker)                 |            4 |         0.73 |          1 |          0 |                  0 |
+| test_network_partition_vllm · NetworkPartition(Frontend->VllmDecodeWorker) |            4 |         3.60 |          4 |          3 |                  0 |
+```
+
+The Frontend-metrics section comes from aiperf's built-in
+`--server-metrics` collector, which scrapes the inference endpoint's
+`/metrics` for the full duration of the run; `LoadConfig` doesn't need
+to opt in. Each scenario's `error_breakdown_report.md` is also
+inlined verbatim in the combined output so the dominant error type per
+fault (404 "Model not found" during partition, "Connection refused"
+during conntrack flush, "TCP request timed out" during pod kill) is
+visible at a glance.
+
+### Current gaps
+
+What this harness covers today, and what it doesn't:
+
+#### Fault types
+- ✅ **Pod delete** (`DeletePod`) — worker, frontend, planner.
+- ✅ **Process kill** (`TerminateProcess`) — engine cores, schedulers, detokenizers, …
+- ✅ **Binary network partition** (`NetworkPartition` + conntrack flush)  — same-namespace, source pod ↛ target pod TCP cut. Mid-load partition is visible (queue grows, 404 storms, recovery on lift).
+- ❌ **Partial-network faults** — packet loss, latency, jitter, bandwidth caps. Requires Chaos Mesh; pending the fault-injection-service work below.
+- ❌ **Cross-namespace partitions** — partition `Worker → NATS` (in `dynamo-system`) or `Frontend → etcd`. The current `NetworkPartition` only matches by `nvidia.com/dynamo-component` within the test namespace.
+- ❌ **GPU faults** — XID errors, ECC errors, CUDA toggle, kernel-launch interception, NVSentinel-driven recovery. Coming via fault-injection-service `oviya/fault-injection-api/gpu`.
+- ❌ **Disk / IO faults** — disk pressure, slow IO, ENOSPC on log PVC, etcd disk full.
+- ❌ **Memory pressure / OOM** — no controlled OOM injection.
+- ❌ **Time-skew / clock drift** — no NTP-misbehaviour scenarios.
+
+#### Topology coverage
+- ✅ **Aggregated** (`agg`) — single Frontend + single Worker. All four fault modes proven.
+- ❌ **Disaggregated** (`disagg-prefill-... -decode-...`) — mocker tests exist in `scenarios.py` (legacy), but no event-based scratch tests for prefill+decode topologies.
+- ❌ **Multi-replica** — every test uses `replicas=1`. Tests like "kill 1 of 3 decode workers and assert no error spike" are not written.
+- ❌ **Multi-model / multi-deployment** — single `DynamoGraphDeployment` per test. No cross-deployment fault scenarios.
+- ❌ **Router / KV-aware-router faults** — KV router has metric publishing over NATS; no test asserts behaviour when those events drop.
+- ❌ **Planner faults** — planner is rarely deployed in fault tests.
+
+#### Load profile coverage
+- ✅ **Steady-state low-concurrency** (`concurrency=4`, ~5 min runs).
+- ❌ **Bursty / variable-rate load** — aiperf supports `--request-rate` shapes; not yet exercised.
+- ❌ **Long-running soak** — no overnight tests; today's runs are minutes, not hours.
+- ❌ **Realistic prompt distributions** — synthetic fixed-length prompts only; no traces, no Mooncake replay.
+- ❌ **Streaming-only / completion-only mix** — `streaming=True` is hardcoded; no test asserts non-streaming behaviour under faults.
+- ❌ **Per-request timeout sensitivity sweeps** — `request_timeout_seconds` is set per-test, not parametrised.
+
+#### Observability / assertions
+- ✅ **Frontend `/metrics` time-series** via aiperf `--server-metrics` (in-cluster scrape; ~400 ms cadence).
+- ✅ **Worker `/metrics` and stdout** captured to PVC + extracted at exit.
+- ✅ **Per-fault Markdown + JSON sidecars** (`fault_tolerance_report.{md,json}`), aiperf error breakdown (`error_breakdown_report.md`), and a multi-test combined comparison via `scripts/aggregate-ft-reports.sh`.
+- ❌ **Time-correlated single timeline** — frontend metrics, worker engine logs, partition events, and aiperf request timeline are in separate files; no overlay tool.
+- ❌ **SLA assertions** — `MaxErrors=1_000_000` is the practical default for vllm fault tests because aiperf retries 30 k+ on a closed socket. Real per-mode SLA bounds (e.g. "p99 latency ≤ 1.2× baseline within 60 s of recovery") need richer checks.
+- ❌ **Recovery quality assertions** — recovery time is captured but not bounded by mode (target: pod-kill ≤ 90 s, partition recovery ≤ 5 s post-lift).
+- ⚠️ **Misleading metric**: `dynamo_frontend_model_migration_total` increments on the *initial-attempt* migratable failure even when `migration_limit=0` (no retry actually performed). Reported during the May 5 partition validation; needs renaming or a guard upstream.
+- ⚠️ **Framework `_get_pod_metrics` snapshot has a sync/async dual-method bug** — the cleanup-time scrape lands in a capitalized `Frontend/` directory while everything else is lowercased, so the snapshot file is silently lost. aiperf's continuous scrape compensates but the framework's own snapshot is unreliable. Tracked as a follow-up.
+
+#### Infrastructure constraints
+- ⚠️ **Privileged + hostNetwork pod** required for `NetworkPartition` (the `conntrack -D` flusher). Won't run on clusters with cluster-wide PSA or OPA blocking those. Mitigations: namespace exception, vcluster, or move to the fault-injection-service (which centralises the privileged daemon).
+- ⚠️ **In-cluster image registry** — defaults assume `localhost:32000` (k3s + local docker registry). On other clusters, override `DYN_CONNTRACK_IMAGE` and the test image references.
+- ⚠️ **CNI requirement** — k3s kube-router, Calico, or Cilium needed for NetworkPolicy enforcement. Plain Flannel silently no-ops the policy.
+
+### Future direction — Fault Injection Service
+
+The current `NetworkPartition` event hits two structural limits:
+
+1. It only does binary cuts. Packet loss, latency injection, jitter,
+   bandwidth caps require Chaos Mesh.
+2. It needs cluster privileges to schedule the conntrack flush Pod.
+   On clusters with cluster-wide PSA / OPA policies that ban
+   `privileged` + `hostNetwork`, the framework can't run as-is — see
+   the *vcluster* and *namespace exception* notes in the deploy
+   playbook.
+
+The follow-on `Fault Injection Service` work (Oviya Seeniraj —
+`oviya/fault-injection/dev` and friends on
+[ai-dynamo/dynamo](https://github.com/ai-dynamo/dynamo)) replaces both
+hops with a cluster-installed service:
+
+- **API service** (`tests/fault_tolerance/hardware/fault-injection-service/api-service`) —
+  HTTP API installed once into `fault-injection-system`. Tests POST
+  fault specs at it instead of creating raw NetworkPolicies.
+- **Network fault-injector DaemonSet** (`agents/network-fault-injector/`) —
+  per-node agent with the privileges the API does not. The API
+  delegates flush / partition / packet-loss work to the agent over a
+  signed channel.
+- **Chaos Mesh integration** for partial-loss and delay scenarios
+  (`NetworkChaos` CRs are issued by the API).
+- **GPU faults** (`oviya/fault-injection-api/gpu`,
+  `oviya/fault-injection/cuda-injection-tools`,
+  `oviya/fault-injection/xid79-nvsentinel-test`) — CUDA toggle, kernel
+  launch interception, NVSentinel-driven recovery from XID 79.
+- **Python client** (`oviya/fault-injection/client-library`) — drop-in
+  replacement for `NetworkPartition` and friends. Test code imports
+  the client; everything else moves into the API.
+- Pre-built example tests in `examples/`:
+  `test_partition_worker_to_nats.py`,
+  `test_partition_frontend_to_nats.py`,
+  `test_partition_worker_to_frontend.py`,
+  `test_specific_pod_to_pod_blocking.py`,
+  `test_nats_packet_loss_50_percent.py`.
+
+Once that work merges, the event-based harness should re-implement
+`NetworkPartition`, the conntrack flush, and any future GPU / packet-
+loss fault as thin wrappers around the client library — keeping the
+scenario / event abstraction here while moving the privileged
+machinery and Chaos Mesh dependency out of the test process.
+
+## Legacy scenario harness
+
+What follows is the original parametrised scenario design driving
+`test_deployment.py` via `scenarios.py`. New tests should prefer the
+event-based harness above; this section remains for callers that
+still depend on the legacy parameter sweep.
+
 ## Test Architecture
 
 The fault tolerance test suite is designed as a set of pytest

--- a/tests/fault_tolerance/deploy/README.md
+++ b/tests/fault_tolerance/deploy/README.md
@@ -398,7 +398,7 @@ What this harness covers today, and what it doesn't:
 - ❌ **SLA assertions** — `MaxErrors=1_000_000` is the practical default for vllm fault tests because aiperf retries 30 k+ on a closed socket. Real per-mode SLA bounds (e.g. "p99 latency ≤ 1.2× baseline within 60 s of recovery") need richer checks.
 - ❌ **Recovery quality assertions** — recovery time is captured but not bounded by mode (target: pod-kill ≤ 90 s, partition recovery ≤ 5 s post-lift).
 - ⚠️ **Misleading metric**: `dynamo_frontend_model_migration_total` increments on the *initial-attempt* migratable failure even when `migration_limit=0` (no retry actually performed). Reported during the May 5 partition validation; needs renaming or a guard upstream.
-- ⚠️ **Framework `_get_pod_metrics` snapshot has a sync/async dual-method bug** — the cleanup-time scrape lands in a capitalized `Frontend/` directory while everything else is lowercased, so the snapshot file is silently lost. aiperf's continuous scrape compensates but the framework's own snapshot is unreliable. Tracked as a follow-up.
+- ✅ **End-of-test `/metrics` snapshot** captured via `_capture_metrics(suffix=".final")` in `ManagedDeployment.__aexit__` for every pod across every service. Files land at `<log_dir>/<service>/<pod>_<ts>.metrics.final.log`. Periodic per-FE distribution data comes from aiperf's server-metrics scrape.
 
 #### Infrastructure constraints
 - ⚠️ **Privileged + hostNetwork pod** required for `NetworkPartition` (the `conntrack -D` flusher). Won't run on clusters with cluster-wide PSA or OPA blocking those. Mitigations: namespace exception, vcluster, or move to the fault-injection-service (which centralises the privileged daemon).

--- a/tests/fault_tolerance/deploy/TESTING.md
+++ b/tests/fault_tolerance/deploy/TESTING.md
@@ -1,0 +1,182 @@
+# Fault Tolerance Test Framework
+
+## Quick Start
+
+Copy an existing test from `test_deployment_scenario.py` and modify it.
+All tests follow the same pattern: **deploy → events → checks**.
+
+```python
+async def test_my_scenario(namespace, image, skip_service_restart, storage_class):
+    spec = DeploymentSpec.from_backend("vllm", "agg")
+    spec.set_worker_replicas(2)
+
+    await run_scenario(
+        deployment_spec=spec,
+        events=[
+            StartLoad(load_config=LoadConfig(duration_minutes=5, concurrency=8)),
+            Wait(duration=30),
+            DeletePod(services=["VllmWorker"]),
+            WaitForRecovery(timeout=300),
+            StopLoad(),
+        ],
+        checks=[
+            MaxErrors(max_errors=20),
+            MinRequests(min_count=50),
+        ],
+        namespace=namespace,
+        image=image,
+        test_name="test_my_scenario",
+        skip_service_restart=skip_service_restart,
+        storage_class=storage_class,
+    )
+```
+
+## Concepts
+
+- **DeploymentSpec**: What to deploy (backend, deployment type, replicas, image)
+- **Events**: Actions executed in sequence (start load, inject fault, wait for recovery)
+- **Checks**: Assertions validated after all events complete
+- **LoadConfig**: Parameters for the aiperf load generator
+
+## DeploymentSpec
+
+```python
+# From backend name (recommended)
+spec = DeploymentSpec.from_backend("vllm", "disagg")
+
+# From explicit YAML path
+spec = DeploymentSpec("/workspace/examples/backends/vllm/deploy/agg.yaml")
+
+# Useful properties and methods
+spec.backend                        # "vllm" (auto-detected)
+spec.worker_services()              # ["VllmPrefillWorker", "VllmDecodeWorker"]
+spec.set_worker_replicas(2)         # Set all workers to 2 replicas
+spec.set_service_replicas("X", 3)   # Set specific service replicas
+spec.set_image("my-image:tag")      # Override image for all services
+spec["VllmWorker"].replicas = 2     # Direct service access
+```
+
+## Available Events
+
+| Event | Purpose | Key Params |
+|-------|---------|------------|
+| `StartLoad` | Begin load generation | `load_config`, `name` |
+| `StopLoad` | Terminate running load early | `name` |
+| `WaitForLoadCompletion` | Wait for load to finish naturally | `name`, `timeout` |
+| `Wait` | Pause for N seconds | `duration` |
+| `DeletePod` | Kill pod(s) for a service | `services`, `force` |
+| `WaitForRecovery` | Wait for deployment to heal | `timeout` |
+| `RollingUpgrade` | Trigger rolling restart | `services` |
+| `TerminateProcess` | Kill a process inside a pod | `services`, `process_name`, `signal` |
+| `WaitForLogPattern` | Wait for regex in service logs | `service`, `pattern`, `timeout` |
+| `RunCommand` | Execute arbitrary command in pod | `services`, `command` |
+
+## Available Checks
+
+| Check | Purpose | Key Params |
+|-------|---------|------------|
+| `ZeroErrors` | Assert no errors in load results | `name` |
+| `MaxErrors` | Assert errors below threshold | `max_errors`, `name` |
+| `MinRequests` | Assert minimum successful requests | `min_count`, `name` |
+| `WasCancelled` | Assert cancellation status | `expected`, `name` |
+| `ServiceLogContains` | Assert pattern present in logs | `service`, `pattern` |
+| `ServiceLogNotContains` | Assert pattern NOT in logs | `service`, `pattern` |
+
+## Common Patterns
+
+### Smoke test (no faults)
+```python
+events=[
+    StartLoad(load_config=LoadConfig(request_count=50, concurrency=4)),
+    WaitForLoadCompletion(),
+]
+checks=[ZeroErrors(), MinRequests(min_count=50)]
+```
+
+### Pod kill + recovery
+```python
+events=[
+    StartLoad(load_config=LoadConfig(duration_minutes=5, concurrency=8)),
+    Wait(duration=30),
+    DeletePod(services=["VllmWorker"]),
+    WaitForRecovery(timeout=300),
+    Wait(duration=30),
+    StopLoad(),
+]
+checks=[MaxErrors(max_errors=20), MinRequests(min_count=50)]
+```
+
+### Rolling upgrade
+```python
+events=[
+    StartLoad(load_config=LoadConfig(duration_minutes=15, concurrency=8)),
+    Wait(duration=30),
+    RollingUpgrade(services=["TRTLLMDecodeWorker"]),
+    Wait(duration=30),
+    StopLoad(),
+]
+checks=[ZeroErrors(), MinRequests(min_count=100)]
+```
+
+### Custom fault injection
+```python
+events=[
+    StartLoad(load_config=LoadConfig(duration_minutes=5, concurrency=8)),
+    Wait(duration=30),
+    RunCommand(services=["VllmWorker"], command="stress --vm 1 --vm-bytes 2G --timeout 30s"),
+    Wait(duration=60),
+    StopLoad(),
+]
+checks=[MaxErrors(max_errors=50)]
+```
+
+## Writing Custom Events
+
+Subclass `Event` and implement `execute()` and `description`:
+
+```python
+@dataclass
+class WaitForMetric(Event):
+    """Wait for a metric condition on a service."""
+    service: str
+    metric_name: str
+    condition: str  # e.g., "> 0.9"
+    timeout: int = 300
+    name: str = ""
+    results: dict[str, Any] | None = field(default=None, init=False)
+
+    async def execute(self, ctx):
+        # Access metrics via ctx.deployment.port_forward()
+        ...
+
+    @property
+    def description(self):
+        return f"Wait for {self.metric_name} {self.condition}"
+```
+
+## Multi-backend Testing
+
+Use `@pytest.mark.parametrize` for testing across backends:
+
+```python
+@pytest.mark.parametrize("backend,deployment_type,replicas", [
+    ("vllm", "agg", 1),
+    ("trtllm", "agg", 1),
+    ("trtllm", "disagg", 2),
+])
+async def test_pod_kill(namespace, image, ..., backend, deployment_type, replicas):
+    spec = DeploymentSpec.from_backend(backend, deployment_type)
+    spec.set_worker_replicas(replicas)
+    await run_scenario(deployment_spec=spec, ...)
+```
+
+## Running Tests
+
+```bash
+# In the dev container with kubectl access:
+pytest tests/fault_tolerance/deploy/test_deployment_scenario.py \
+    -s -v \
+    --namespace my-namespace \
+    --image nvcr.io/nvidian/dynamo-dev/my-image:tag \
+    -k test_smoke_50_requests
+```

--- a/tests/fault_tolerance/deploy/TESTING.md
+++ b/tests/fault_tolerance/deploy/TESTING.md
@@ -78,7 +78,8 @@ spec["VllmWorker"].replicas = 2     # Direct service access
 | `ZeroErrors` | Assert no errors in load results | `name` |
 | `MaxErrors` | Assert errors below threshold | `max_errors`, `name` |
 | `MinRequests` | Assert minimum successful requests | `min_count`, `name` |
-| `WasCancelled` | Assert cancellation status | `expected`, `name` |
+| `LoadStopped` | Assert load was stopped early | `name` |
+| `LoadCompleted` | Assert load completed naturally | `name` |
 | `ServiceLogContains` | Assert pattern present in logs | `service`, `pattern` |
 | `ServiceLogNotContains` | Assert pattern NOT in logs | `service`, `pattern` |
 

--- a/tests/fault_tolerance/deploy/_checks_rejection.py
+++ b/tests/fault_tolerance/deploy/_checks_rejection.py
@@ -1,8 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Cascade fail-fast rejection check (Track B of the 2026-05-26 cascade
-# fail-fast handoff). Subclassed Check rather than added inline to
+# Cascade fail-fast rejection check. Subclassed Check rather than added inline to
 # checks.py to keep the cascade-rejection signal sources (AIPerf 503
 # tally + worker ``TrySendError::Full`` + Frontend ``Status code: 503``)
 # co-located in one file the next round can iterate on without churning
@@ -89,7 +88,8 @@ class RejectionFired(Check):
           plus a fall-back tally of ``error_summary`` entries in
           ``profile_export_aiperf.json``.
       (b) Worker log line ``TrySendError::Full`` — emitted by the
-          DIS-2105 patch's ``work_tx.try_send()`` rejection path. Scans
+          worker-side TCP work-queue rejection / backpressure path's
+          ``work_tx.try_send()`` rejection path. Scans
           every ``VllmPrefillWorker`` / ``VllmDecodeWorker`` log file.
       (c) Frontend log line ``Status code: 503``, **filtered to the
           load's wall-clock window** (``StartLoad.started_at`` →

--- a/tests/fault_tolerance/deploy/_checks_rejection.py
+++ b/tests/fault_tolerance/deploy/_checks_rejection.py
@@ -1,0 +1,244 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Cascade fail-fast rejection check (Track B of the 2026-05-26 cascade
+# fail-fast handoff). Subclassed Check rather than added inline to
+# checks.py to keep the cascade-rejection signal sources (AIPerf 503
+# tally + worker ``TrySendError::Full`` + Frontend ``Status code: 503``)
+# co-located in one file the next round can iterate on without churning
+# the main checks module.
+#
+# Pass criterion: ANY one of three signals fires above ``min_503_count``
+# during the named load's wall-clock window. The window comes from the
+# matching ``StartLoad`` event's ``started_at`` / ``ended_at`` so that
+# noisy bootstrap-time 503s from the Frontend's
+# ``system_status_server.rs`` health probe handler (the first ~2 min
+# after pod start, before kube readiness flips) are excluded.
+
+from __future__ import annotations
+
+import json as _json
+import os as _os
+import re as _re
+from dataclasses import dataclass
+from datetime import datetime
+from glob import escape as _glob_escape
+from glob import glob as _glob
+from typing import Optional
+
+from tests.fault_tolerance.deploy.checks import (
+    Check,
+    _get_service_logs,
+    _iter_jsonl,
+    _load_dirs_for,
+)
+
+__all__ = ["RejectionFired"]
+
+
+_TIME_RE = _re.compile(r'"time"\s*:\s*"([^"]+)"')
+
+
+def _parse_iso(ts: str) -> Optional[datetime]:
+    """Parse an ISO-8601 timestamp (Z-suffixed or with +00:00 offset).
+
+    Returns None on parse failure so the caller can skip malformed lines
+    without aborting the whole scan.
+    """
+    if not ts:
+        return None
+    s = ts.replace("Z", "+00:00")
+    try:
+        return datetime.fromisoformat(s)
+    except ValueError:
+        return None
+
+
+def _find_503_in_error(rec_error) -> bool:
+    """Return True if an AIPerf jsonl ``error`` record looks like an
+    HTTP 503. AIPerf wraps the underlying exception under ``type`` /
+    ``message`` / ``cause`` / ``cause_chain`` — match a literal '503' or
+    'Service Unavailable' anywhere in those fields.
+    """
+    if not isinstance(rec_error, dict):
+        return False
+    blob_parts = []
+    for k in ("type", "message", "cause"):
+        v = rec_error.get(k)
+        if isinstance(v, str):
+            blob_parts.append(v)
+    chain = rec_error.get("cause_chain")
+    if isinstance(chain, list):
+        blob_parts.extend(str(x) for x in chain)
+    blob = " ".join(blob_parts)
+    if "503" in blob or "Service Unavailable" in blob:
+        return True
+    return False
+
+
+@dataclass
+class RejectionFired(Check):
+    """Assert the worker-side fail-fast path fired during ``load_name``.
+
+    Cascade fail-fast pass criterion: ANY of three signals shows up
+    ≥ ``min_503_count`` times across the load's window:
+
+      (a) AIPerf-side HTTP 503 — counted from the load's
+          ``profile_export.jsonl`` ``error`` records (any record whose
+          type / message / cause mentions 503 or "Service Unavailable")
+          plus a fall-back tally of ``error_summary`` entries in
+          ``profile_export_aiperf.json``.
+      (b) Worker log line ``TrySendError::Full`` — emitted by the
+          DIS-2105 patch's ``work_tx.try_send()`` rejection path. Scans
+          every ``VllmPrefillWorker`` / ``VllmDecodeWorker`` log file.
+      (c) Frontend log line ``Status code: 503``, **filtered to the
+          load's wall-clock window** (``StartLoad.started_at`` →
+          ``StartLoad.ended_at``). Bootstrap-time 503s from the FE
+          ``system_status_server.rs`` health probe (first ~2 min after
+          pod start, before readiness flips) are NOISE and excluded.
+
+    Logs all three counts at INFO so the report shows the breakdown
+    even when only one source fires.
+    """
+
+    load_name: str
+    min_503_count: int = 1
+
+    # ------------------------------------------------------------------
+    # Signal (a): AIPerf-side 503 tally
+    # ------------------------------------------------------------------
+    def _count_aiperf_503(self, ctx) -> int:
+        total = 0
+        for ldir in _load_dirs_for(ctx, self.load_name):
+            # Per-record errors from the streaming jsonl.
+            jsonl = _os.path.join(ldir, "profile_export.jsonl")
+            for rec in _iter_jsonl(jsonl):
+                if _find_503_in_error(rec.get("error")):
+                    total += 1
+            # Summary fall-back — AIPerf 0.7.x rolls some error
+            # categories up into ``error_summary`` only.
+            summary_path = _os.path.join(ldir, "profile_export_aiperf.json")
+            if _os.path.isfile(summary_path):
+                try:
+                    with open(summary_path) as fh:
+                        data = _json.load(fh)
+                except (OSError, _json.JSONDecodeError):
+                    data = {}
+                es = data.get("error_summary") or []
+                if isinstance(es, dict):
+                    es = es.get("summary") or []
+                # Avoid double counting when a 503 entry's count would
+                # also appear in the per-record jsonl loop above: the
+                # jsonl is the source of truth when present; the summary
+                # is only consulted when the jsonl is missing.
+                if not _os.path.isfile(jsonl):
+                    for entry in es:
+                        details = entry.get("error_details") or entry.get("error") or {}
+                        if isinstance(details, dict):
+                            blob = " ".join(
+                                str(v)
+                                for v in details.values()
+                                if isinstance(v, (str, int))
+                            )
+                        else:
+                            blob = str(details)
+                        if "503" in blob or "Service Unavailable" in blob:
+                            total += int(entry.get("count") or 0)
+        return total
+
+    # ------------------------------------------------------------------
+    # Signal (b): worker TrySendError::Full
+    # ------------------------------------------------------------------
+    def _count_worker_try_send_full(self, ctx) -> int:
+        """Walk per-worker on-disk log files directly (one file per
+        pod). Cannot use ``_get_service_logs`` here because that
+        concatenates everything under one key — we want a count, not a
+        keyword search across a service-flat blob, but the count is
+        also fine via the catted blob.
+        """
+        logs = _get_service_logs(ctx)
+        total = 0
+        for svc in ("VllmPrefillWorker", "VllmDecodeWorker"):
+            text = logs.get(svc) or logs.get(svc.lower()) or ""
+            total += text.count("TrySendError::Full")
+        return total
+
+    # ------------------------------------------------------------------
+    # Signal (c): Frontend "Status code: 503", window-filtered
+    # ------------------------------------------------------------------
+    def _count_frontend_503_in_window(self, ctx) -> tuple[int, int]:
+        """Return ``(in_window, total)``. ``total`` is the raw 503 count
+        across all FE log files (debug breadcrumb so we can see how much
+        of the FE noise we're discarding).
+        """
+        load = self.get_load(ctx, self.load_name)
+        win_lo = getattr(load, "started_at", None) if load else None
+        win_hi = getattr(load, "ended_at", None) if load else None
+
+        in_window = 0
+        total = 0
+        log_dir = getattr(ctx, "log_dir", None)
+        if not log_dir or not _os.path.isdir(log_dir):
+            return 0, 0
+        # FE logs live under <log_dir>/frontend/*.log (lowercased
+        # service name, one file per pod per launch).
+        fe_dir = _os.path.join(log_dir, "frontend")
+        if not _os.path.isdir(fe_dir):
+            return 0, 0
+        for path in sorted(_glob(_os.path.join(_glob_escape(fe_dir), "*.log"))):
+            try:
+                fh = open(path, "r", errors="replace")
+            except OSError:
+                continue
+            with fh:
+                for line in fh:
+                    # Cheap pre-filter — most FE lines are not 503s.
+                    if "503" not in line:
+                        continue
+                    if "Status code: 503" not in line and '"status":"503"' not in line:
+                        continue
+                    total += 1
+                    if win_lo is None or win_hi is None:
+                        continue
+                    tm = _TIME_RE.search(line)
+                    if not tm:
+                        continue
+                    dt = _parse_iso(tm.group(1))
+                    if dt is None:
+                        continue
+                    if win_lo <= dt <= win_hi:
+                        in_window += 1
+        return in_window, total
+
+    # ------------------------------------------------------------------
+    # Check entry point
+    # ------------------------------------------------------------------
+    def validate(self, ctx) -> None:
+        aiperf_503 = self._count_aiperf_503(ctx)
+        worker_full = self._count_worker_try_send_full(ctx)
+        fe_503_in_window, fe_503_total = self._count_frontend_503_in_window(ctx)
+
+        observed = aiperf_503 + worker_full + fe_503_in_window
+        ctx.logger.info(
+            f"RejectionFired(load={self.load_name!r}): "
+            f"aiperf_503={aiperf_503} "
+            f"worker_TrySendError_Full={worker_full} "
+            f"fe_503_in_window={fe_503_in_window} "
+            f"(fe_503_total_unfiltered={fe_503_total}) "
+            f"observed_total={observed} min_required={self.min_503_count}"
+        )
+        assert observed >= self.min_503_count, (
+            f"RejectionFired: only {observed} rejection signals observed "
+            f"(aiperf_503={aiperf_503}, worker_TrySendError_Full={worker_full}, "
+            f"fe_503_in_window={fe_503_in_window}); expected ≥ "
+            f"{self.min_503_count}. The worker fail-fast path did not "
+            f"engage during load {self.load_name!r}."
+        )
+
+    @property
+    def description(self) -> str:
+        return (
+            f"≥ {self.min_503_count} rejection signal(s) (AIPerf 503 / "
+            f"worker TrySendError::Full / FE Status code:503 in-window) "
+            f"during {self.load_name!r}"
+        )

--- a/tests/fault_tolerance/deploy/_checks_workload_shape.py
+++ b/tests/fault_tolerance/deploy/_checks_workload_shape.py
@@ -1,0 +1,192 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Workload-shape verification check.
+
+Used by the H1 (radix-tree retention) discriminator pair:
+- ``no_prefix`` (L1) must produce many unique prompts (~6800) → max tree growth
+- ``same_prefix`` (L2) must collapse to a single shared prompt → min tree growth
+
+If the workload shape does NOT match what the YAML promised, any downstream
+slope comparison is meaningless. This check is intentionally FATAL — it
+raises AssertionError on mismatch so the test surfaces an invalid run before
+anyone reads MB/min numbers off of it.
+
+AIPerf 0.7.x ``profile_export.jsonl`` schema (per-request records):
+  - ``metadata.conversation_id`` — stable per-prompt identifier
+    (e.g. ``session_001309``). This is the "distinct prompt" key —
+    AIPerf reuses conversation_ids when the dataset is exhausted /
+    shared, and the field is present even though the raw prompt text
+    is not exported.
+  - ``metrics.input_sequence_length.value`` — ISL in tokens per request.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import statistics
+from dataclasses import dataclass
+from glob import escape as _glob_escape
+from glob import glob as _glob
+from typing import Optional
+
+from tests.fault_tolerance.deploy.checks import Check
+
+
+def _load_dirs_matching(ctx, load_name: Optional[str]) -> list:
+    """Return load-*/ subdirs under ctx.log_dir whose dirname contains
+    ``load_name``. Mirrors the convention used by LoadApplied (which
+    filters by basename substring).
+    """
+    log_dir = getattr(ctx, "log_dir", None)
+    if not log_dir:
+        return []
+    base = os.path.join(_glob_escape(log_dir), "load", "load-*")
+    out = sorted(_glob(base))
+    out = [p for p in out if os.path.isdir(p)]
+    if load_name is None:
+        return out
+    return [p for p in out if load_name in os.path.basename(p)]
+
+
+def _iter_profile_records(load_dir: str):
+    """Yield parsed per-request JSON records from profile_export.jsonl."""
+    path = os.path.join(load_dir, "profile_export.jsonl")
+    if not os.path.isfile(path):
+        return
+    with open(path) as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                yield json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+
+@dataclass
+class WorkloadShapeVerified(Check):
+    """Verify that the load harness actually produced the workload shape
+    the YAML promised — checked by counting distinct ``conversation_id``s
+    and computing the ISL distribution from AIPerf's per-request JSONL.
+
+    Parameters (all keyword):
+      - ``load_name``: which rung to validate (matched against load-* dir
+        basename).
+      - ``min_unique_prompts``: fail if observed distinct conversation_ids
+        is below this floor. Use on ``no_prefix`` to assert "random
+        prompts actually were random."
+      - ``max_unique_prompts``: fail if observed distinct conversation_ids
+        is above this ceiling. Use on ``same_prefix`` to assert "the
+        shared system prompt actually collapsed prompt variety."
+      - ``isl_mean_min`` / ``isl_mean_max``: sanity-check that the ISL
+        distribution didn't drift from cycle-6 baseline. The
+        no_prefix-vs-same_prefix experiment ONLY varies prefix uniqueness;
+        if ISL also changed, the slope delta is confounded.
+
+    Behaviour: logs observed unique-prompt count, ISL mean, ISL p99 at
+    INFO. Raises AssertionError when any active bound is violated.
+    """
+
+    load_name: str = "steady"
+    min_unique_prompts: Optional[int] = None
+    max_unique_prompts: Optional[int] = None
+    isl_mean_min: Optional[float] = None
+    isl_mean_max: Optional[float] = None
+
+    def validate(self, ctx) -> None:
+        load_dirs = _load_dirs_matching(ctx, self.load_name)
+        assert load_dirs, (
+            f"WorkloadShapeVerified: no load-*/ dir matched "
+            f"load_name={self.load_name!r} under {getattr(ctx, 'log_dir', None)!r}"
+        )
+
+        conv_ids: set = set()
+        isl_values: list = []
+        total_records = 0
+        for ldir in load_dirs:
+            for rec in _iter_profile_records(ldir):
+                total_records += 1
+                meta = rec.get("metadata") or {}
+                cid = meta.get("conversation_id")
+                if cid is not None:
+                    conv_ids.add(cid)
+                metrics = rec.get("metrics") or {}
+                isl_node = metrics.get("input_sequence_length") or {}
+                isl_val = isl_node.get("value")
+                if isl_val is not None:
+                    try:
+                        isl_values.append(float(isl_val))
+                    except (TypeError, ValueError):
+                        continue
+
+        assert total_records > 0, (
+            f"WorkloadShapeVerified: profile_export.jsonl had 0 parseable "
+            f"records under load_name={self.load_name!r} (dirs={load_dirs})"
+        )
+
+        unique_prompts = len(conv_ids)
+        if isl_values:
+            isl_values_sorted = sorted(isl_values)
+            isl_mean = statistics.fmean(isl_values_sorted)
+            # p99 via nearest-rank — fmean+sort is enough for a sanity gate.
+            p99_idx = max(0, int(round(0.99 * len(isl_values_sorted))) - 1)
+            isl_p99 = isl_values_sorted[p99_idx]
+        else:
+            isl_mean = float("nan")
+            isl_p99 = float("nan")
+
+        ctx.logger.info(
+            f"WorkloadShapeVerified[{self.load_name}]: "
+            f"records={total_records} unique_prompts={unique_prompts} "
+            f"isl_mean={isl_mean:.1f} isl_p99={isl_p99:.1f} "
+            f"(bounds: min_unique={self.min_unique_prompts} "
+            f"max_unique={self.max_unique_prompts} "
+            f"isl_mean_min={self.isl_mean_min} isl_mean_max={self.isl_mean_max})"
+        )
+
+        if self.min_unique_prompts is not None:
+            assert unique_prompts >= self.min_unique_prompts, (
+                f"WorkloadShapeVerified: observed {unique_prompts} unique "
+                f"conversation_ids on load {self.load_name!r}; expected "
+                f">= {self.min_unique_prompts}. Workload-shape contract "
+                f"BROKEN — downstream slope numbers are invalid."
+            )
+        if self.max_unique_prompts is not None:
+            assert unique_prompts <= self.max_unique_prompts, (
+                f"WorkloadShapeVerified: observed {unique_prompts} unique "
+                f"conversation_ids on load {self.load_name!r}; expected "
+                f"<= {self.max_unique_prompts}. Workload-shape contract "
+                f"BROKEN — downstream slope numbers are invalid."
+            )
+        if self.isl_mean_min is not None:
+            assert isl_mean >= self.isl_mean_min, (
+                f"WorkloadShapeVerified: observed ISL mean={isl_mean:.1f} "
+                f"on load {self.load_name!r}; expected >= {self.isl_mean_min}. "
+                f"ISL distribution drifted from baseline — slope delta is "
+                f"confounded by length, not just prefix uniqueness."
+            )
+        if self.isl_mean_max is not None:
+            assert isl_mean <= self.isl_mean_max, (
+                f"WorkloadShapeVerified: observed ISL mean={isl_mean:.1f} "
+                f"on load {self.load_name!r}; expected <= {self.isl_mean_max}. "
+                f"ISL distribution drifted from baseline — slope delta is "
+                f"confounded by length, not just prefix uniqueness."
+            )
+
+    @property
+    def description(self) -> str:
+        bounds = []
+        if self.min_unique_prompts is not None:
+            bounds.append(f"unique >= {self.min_unique_prompts}")
+        if self.max_unique_prompts is not None:
+            bounds.append(f"unique <= {self.max_unique_prompts}")
+        if self.isl_mean_min is not None:
+            bounds.append(f"isl_mean >= {self.isl_mean_min}")
+        if self.isl_mean_max is not None:
+            bounds.append(f"isl_mean <= {self.isl_mean_max}")
+        joined = "; ".join(bounds) if bounds else "no active bounds"
+        return f"Workload shape verified on load {self.load_name!r} ({joined})"

--- a/tests/fault_tolerance/deploy/_respoller.py
+++ b/tests/fault_tolerance/deploy/_respoller.py
@@ -1,0 +1,240 @@
+"""In-pod per-process resource sampler for ``ResourcePoller``.
+
+This is NOT imported by the framework — it is read as text and heredoc'd into
+each target pod, then launched detached (``nohup python3 /tmp/respoller.py``).
+It runs inside the worker container against that pod's own ``/proc`` + cgroup +
+local NVML, so it sees per-process memory/CPU and (node-local) per-process GPU
+that a remote client cannot.
+
+Config via env (set by the launching event):
+  RESPOLL_OUTDIR   output dir (defaults to $DYN_LOG_DIR, else /tmp/service_logs)
+  RESPOLL_INTERVAL sample interval seconds (default 5)
+  RESPOLL_INCLUDE  comma list from {mem,cpu,gpu} (default all)
+  RESPOLL_STOP     stop-marker path (default /tmp/.respoller.stop)
+
+Output (TSV, native values; %CPU and rates are differenced offline):
+  <pod>.resources.agg.tsv    one row per GPU per tick (or one blank-GPU row):
+      epoch_s pod working_set cgroup_current all_pids_rss pid1_rss
+      gpu_idx gpu_util gpu_mem_used gpu_mem_total
+  <pod>.resources.procs.tsv  one row per process per tick:
+      epoch_s pid cmd rss utime stime gpu_mem gpu_sm
+Every dimension is best-effort: a failure in one (e.g. pynvml absent) disables
+just that dimension and leaves its columns as -1/blank.
+"""
+import glob
+import os
+import sys
+import time
+
+OUTDIR = (
+    os.environ.get("RESPOLL_OUTDIR")
+    or os.environ.get("DYN_LOG_DIR")
+    or "/tmp/service_logs"
+)
+INTERVAL = float(os.environ.get("RESPOLL_INTERVAL") or "5")
+INCLUDE = set((os.environ.get("RESPOLL_INCLUDE") or "mem,cpu,gpu").split(","))
+STOP = os.environ.get("RESPOLL_STOP") or "/tmp/.respoller.stop"
+POD = os.environ.get("HOSTNAME", "unknown")
+CLK = os.sysconf("SC_CLK_TCK") if hasattr(os, "sysconf") else 100
+
+try:
+    os.makedirs(OUTDIR, exist_ok=True)
+except OSError:
+    pass
+AGG = os.path.join(OUTDIR, POD + ".resources.agg.tsv")
+PROCS = os.path.join(OUTDIR, POD + ".resources.procs.tsv")
+
+# --- GPU (best effort; node-local NVML) ---
+nvml = None
+if "gpu" in INCLUDE:
+    try:
+        import pynvml
+
+        pynvml.nvmlInit()
+        nvml = pynvml
+    except Exception as e:  # noqa: BLE001 - any failure → run without GPU
+        sys.stderr.write("respoller: pynvml unavailable, gpu disabled: %s\n" % e)
+        nvml = None
+
+
+def read_cgroup():
+    """(working_set, cgroup_current) bytes. working_set = current - inactive_file
+    (what kubelet/cAdvisor use for OOMKill). cgroup v2 with v1 fallback."""
+    try:
+        if os.path.exists("/sys/fs/cgroup/memory.current"):  # v2
+            cur = int(open("/sys/fs/cgroup/memory.current").read().strip())
+            stat_path, key = "/sys/fs/cgroup/memory.stat", "inactive_file "
+        else:  # v1
+            cur = int(
+                open("/sys/fs/cgroup/memory/memory.usage_in_bytes").read().strip()
+            )
+            stat_path, key = "/sys/fs/cgroup/memory/memory.stat", "total_inactive_file "
+        inact = 0
+        for ln in open(stat_path):
+            if ln.startswith(key):
+                inact = int(ln.split()[1])
+                break
+        return cur - inact, cur
+    except Exception:  # noqa: BLE001
+        return -1, -1
+
+
+def read_procs():
+    """list of (pid, cmd, rss_bytes, utime_jiffies, stime_jiffies) for every
+    process in the pod. cmd from /proc/PID/cmdline (full proctitle — Worker_DP0
+    vs _DP1; /proc/PID/status Name truncates at 15 chars)."""
+    out = []
+    want_cpu = "cpu" in INCLUDE
+    for d in glob.glob("/proc/[0-9]*"):
+        pid = d.rsplit("/", 1)[-1]
+        try:
+            rss = 0
+            for ln in open(d + "/status"):
+                if ln.startswith("VmRSS:"):
+                    rss = int(ln.split()[1]) * 1024
+                    break
+            try:
+                cmd = (
+                    open(d + "/cmdline", "rb")
+                    .read()
+                    .replace(b"\x00", b" ")
+                    .decode("utf-8", "replace")
+                    .strip()
+                )
+            except Exception:  # noqa: BLE001
+                cmd = ""
+            if not cmd:
+                try:
+                    cmd = "[" + open(d + "/comm").read().strip() + "]"
+                except Exception:  # noqa: BLE001
+                    cmd = "?"
+            ut = st = 0
+            if want_cpu:
+                s = open(d + "/stat").read()
+                # fields after the (comm) group: utime=14th, stime=15th (1-indexed)
+                parts = s[s.rfind(")") + 1 :].split()
+                ut, st = int(parts[11]), int(parts[12])
+            out.append((pid, cmd[:80], rss, ut, st))
+        except Exception:  # noqa: BLE001 - process exited mid-read etc.
+            continue
+    return out
+
+
+def gpu_device():
+    """list of (idx, util_pct, mem_used, mem_total) per device."""
+    rows = []
+    if not nvml:
+        return rows
+    try:
+        for i in range(nvml.nvmlDeviceGetCount()):
+            h = nvml.nvmlDeviceGetHandleByIndex(i)
+            try:
+                gu = nvml.nvmlDeviceGetUtilizationRates(h).gpu
+            except Exception:  # noqa: BLE001
+                gu = -1
+            try:
+                m = nvml.nvmlDeviceGetMemoryInfo(h)
+                mu, mt = m.used, m.total
+            except Exception:  # noqa: BLE001
+                mu = mt = -1
+            rows.append((i, gu, mu, mt))
+    except Exception:  # noqa: BLE001
+        pass
+    return rows
+
+
+_last_ts = {}
+
+
+def gpu_procs():
+    """{pid: [gpu_mem_bytes, gpu_sm_pct]}. ComputeRunningProcesses (mem) is
+    reliable; ProcessUtilization (sm) is best-effort and raises NOT_FOUND when
+    the GPU has been idle — track lastSeenTimeStamp and treat empty as no
+    recent activity."""
+    res = {}
+    if not nvml:
+        return res
+    try:
+        for i in range(nvml.nvmlDeviceGetCount()):
+            h = nvml.nvmlDeviceGetHandleByIndex(i)
+            try:
+                for p in nvml.nvmlDeviceGetComputeRunningProcesses(h):
+                    mem = getattr(p, "usedGpuMemory", None)
+                    res.setdefault(int(p.pid), [mem if mem is not None else -1, -1])
+            except Exception:  # noqa: BLE001
+                pass
+            try:
+                samples = nvml.nvmlDeviceGetProcessUtilization(h, _last_ts.get(i, 0))
+                for s in samples or []:
+                    _last_ts[i] = max(_last_ts.get(i, 0), int(s.timeStamp))
+                    res.setdefault(int(s.pid), [-1, -1])
+                    res[int(s.pid)][1] = s.smUtil
+            except Exception:  # noqa: BLE001 - NOT_FOUND when idle
+                pass
+    except Exception:  # noqa: BLE001
+        pass
+    return res
+
+
+def main():
+    with open(AGG, "w") as f:
+        f.write(
+            "# ResourcePoller clk_tck=%d include=%s\n"
+            % (CLK, ",".join(sorted(INCLUDE)))
+        )
+        f.write(
+            "epoch_s\tpod\tworking_set\tcgroup_current\tall_pids_rss\tpid1_rss"
+            "\tgpu_idx\tgpu_util\tgpu_mem_used\tgpu_mem_total\n"
+        )
+    with open(PROCS, "w") as f:
+        f.write("# ResourcePoller clk_tck=%d\n" % CLK)
+        f.write("epoch_s\tpid\tcmd\trss\tutime\tstime\tgpu_mem\tgpu_sm\n")
+    try:
+        os.unlink(STOP)
+    except OSError:
+        pass
+
+    want_proc = ("mem" in INCLUDE) or ("cpu" in INCLUDE)
+    while not os.path.exists(STOP):
+        ts = "%.3f" % time.time()
+        procs = read_procs() if want_proc else []
+        ws, cur = read_cgroup() if "mem" in INCLUDE else (-1, -1)
+        all_rss = sum(p[2] for p in procs) if procs else -1
+        pid1_rss = next((p[2] for p in procs if p[0] == "1"), -1)
+        gdev = gpu_device()
+        gproc = gpu_procs()
+        try:
+            with open(AGG, "a") as f:
+                if gdev:
+                    for idx, gu, mu, mt in gdev:
+                        f.write(
+                            "%s\t%s\t%d\t%d\t%d\t%d\t%d\t%s\t%s\t%s\n"
+                            % (ts, POD, ws, cur, all_rss, pid1_rss, idx, gu, mu, mt)
+                        )
+                else:
+                    f.write(
+                        "%s\t%s\t%d\t%d\t%d\t%d\t\t\t\t\n"
+                        % (ts, POD, ws, cur, all_rss, pid1_rss)
+                    )
+            with open(PROCS, "a") as f:
+                for pid, cmd, rss, ut, st in procs:
+                    g = gproc.get(int(pid)) if pid.isdigit() else None
+                    gm = g[0] if g else ""
+                    gs = g[1] if g else ""
+                    f.write(
+                        "%s\t%s\t%s\t%d\t%d\t%d\t%s\t%s\n"
+                        % (ts, pid, cmd, rss, ut, st, gm, gs)
+                    )
+        except Exception:  # noqa: BLE001
+            pass
+        time.sleep(INTERVAL)
+
+    if nvml:
+        try:
+            nvml.nvmlShutdown()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fault_tolerance/deploy/base_checker.py
+++ b/tests/fault_tolerance/deploy/base_checker.py
@@ -13,6 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# DEPRECATED: This module is part of the legacy test framework.
+# New tests should use the event-based framework in test_deployment_scenario.py.
+# See tests/fault_tolerance/deploy/TESTING.md for the reference guide.
+
 """Base checker class and validation context for fault tolerance testing.
 
 This module provides:

--- a/tests/fault_tolerance/deploy/checker_factory.py
+++ b/tests/fault_tolerance/deploy/checker_factory.py
@@ -13,6 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# DEPRECATED: This module is part of the legacy test framework.
+# New tests should use the event-based framework in test_deployment_scenario.py.
+# See tests/fault_tolerance/deploy/TESTING.md for the reference guide.
+
 """Factory functions for generating checker lists for scenarios.
 
 This module provides factory functions that determine which checkers

--- a/tests/fault_tolerance/deploy/checkers.py
+++ b/tests/fault_tolerance/deploy/checkers.py
@@ -13,6 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# DEPRECATED: This module is part of the legacy test framework.
+# New tests should use the event-based framework in test_deployment_scenario.py.
+# See tests/fault_tolerance/deploy/TESTING.md for the reference guide.
+
 """Concrete checker implementations for fault tolerance testing.
 
 This module provides specific checker implementations:

--- a/tests/fault_tolerance/deploy/checks.py
+++ b/tests/fault_tolerance/deploy/checks.py
@@ -1,0 +1,213 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Scenario checks for fault tolerance testing.
+
+Checks validate results after all events complete. Each check has:
+- validate(ctx): Assert conditions, raises AssertionError on failure
+- description: Human-readable description for logging
+- get_load(ctx, name): Helper to find StartLoad events by name
+
+To create a custom check, subclass Check and implement validate() and description.
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+__all__ = [
+    "Check",
+    "ZeroErrors",
+    "MaxErrors",
+    "MinRequests",
+    "WasCancelled",
+    "ServiceLogContains",
+    "ServiceLogNotContains",
+]
+
+if TYPE_CHECKING:
+    from tests.fault_tolerance.deploy.events import StartLoad
+    from tests.fault_tolerance.deploy.scenario import ScenarioContext
+
+
+# =============================================================================
+# Check Base Class
+# =============================================================================
+
+
+@dataclass
+class Check(ABC):
+    """Base class for result validation.
+
+    Checks receive ScenarioContext and can access:
+    - self.get_load(ctx, name) to find StartLoad and get results
+    - ctx.deployment.collect_service_logs() for service logs
+    """
+
+    @abstractmethod
+    def validate(self, ctx: "ScenarioContext") -> None:
+        """Validate results. Raises AssertionError on failure."""
+        pass
+
+    @property
+    @abstractmethod
+    def description(self) -> str:
+        """Human-readable description of the check."""
+        pass
+
+    def get_load(self, ctx: "ScenarioContext", name: str) -> "StartLoad | None":
+        """Find StartLoad event by name."""
+        from tests.fault_tolerance.deploy.events import StartLoad
+
+        for event in ctx.events:
+            if isinstance(event, StartLoad) and event.name == name:
+                return event
+        return None
+
+
+# =============================================================================
+# Check Implementations
+# =============================================================================
+
+
+@dataclass
+class ZeroErrors(Check):
+    """Assert zero errors in load results."""
+
+    name: str = "default"
+
+    def validate(self, ctx: "ScenarioContext") -> None:
+        load = self.get_load(ctx, self.name)
+        assert load and load.results, f"No results for load '{self.name}'"
+
+        error_result = load.results.get("error_request_count")
+        error_count = error_result.get("avg", 0) if error_result else 0
+
+        ctx.logger.info(f"ZeroErrors: error_count = {error_count}")
+        assert error_count == 0, f"Expected 0 errors, got {error_count}"
+
+    @property
+    def description(self) -> str:
+        return f"Zero errors ('{self.name}')"
+
+
+@dataclass
+class MaxErrors(Check):
+    """Assert errors below a threshold."""
+
+    max_errors: int
+    name: str = "default"
+
+    def validate(self, ctx: "ScenarioContext") -> None:
+        load = self.get_load(ctx, self.name)
+        assert load and load.results, f"No results for load '{self.name}'"
+
+        error_result = load.results.get("error_request_count")
+        error_count = error_result.get("avg", 0) if error_result else 0
+
+        ctx.logger.info(
+            f"MaxErrors: error_count = {error_count}, max = {self.max_errors}"
+        )
+        assert (
+            error_count <= self.max_errors
+        ), f"Expected at most {self.max_errors} errors, got {error_count}"
+
+    @property
+    def description(self) -> str:
+        return f"Max {self.max_errors} errors ('{self.name}')"
+
+
+@dataclass
+class MinRequests(Check):
+    """Assert minimum number of successful requests."""
+
+    min_count: int
+    name: str = "default"
+
+    def validate(self, ctx: "ScenarioContext") -> None:
+        load = self.get_load(ctx, self.name)
+        assert load and load.results, f"No results for load '{self.name}'"
+
+        request_count = load.results.get("request_count", {}).get("avg", 0)
+
+        ctx.logger.info(
+            f"MinRequests: request_count = {request_count}, min = {self.min_count}"
+        )
+        assert (
+            request_count >= self.min_count
+        ), f"Expected at least {self.min_count} requests, got {request_count}"
+
+    @property
+    def description(self) -> str:
+        return f"Min {self.min_count} requests ('{self.name}')"
+
+
+@dataclass
+class WasCancelled(Check):
+    """Assert was_cancelled flag matches expected value."""
+
+    expected: bool = True
+    name: str = "default"
+
+    def validate(self, ctx: "ScenarioContext") -> None:
+        load = self.get_load(ctx, self.name)
+        assert load and load.results, f"No results for load '{self.name}'"
+
+        was_cancelled = load.results.get("was_cancelled", False)
+
+        ctx.logger.info(
+            f"WasCancelled: was_cancelled = {was_cancelled}, expected = {self.expected}"
+        )
+        assert (
+            was_cancelled == self.expected
+        ), f"Expected was_cancelled={self.expected}, got {was_cancelled}"
+
+    @property
+    def description(self) -> str:
+        return f"was_cancelled={self.expected} ('{self.name}')"
+
+
+@dataclass
+class ServiceLogContains(Check):
+    """Assert a service log contains a pattern."""
+
+    service: str
+    pattern: str
+
+    def validate(self, ctx: "ScenarioContext") -> None:
+        logs = ctx.deployment.collect_service_logs()
+        log = logs.get(self.service, "")
+        ctx.logger.info(
+            f"ServiceLogContains: checking '{self.pattern}' in {self.service}"
+        )
+        assert self.pattern in log, (
+            f"Pattern '{self.pattern}' not found in {self.service} logs "
+            f"(log length: {len(log)} chars)"
+        )
+
+    @property
+    def description(self) -> str:
+        return f"Service '{self.service}' logs contain '{self.pattern}'"
+
+
+@dataclass
+class ServiceLogNotContains(Check):
+    """Assert a service log does NOT contain a pattern."""
+
+    service: str
+    pattern: str
+
+    def validate(self, ctx: "ScenarioContext") -> None:
+        logs = ctx.deployment.collect_service_logs()
+        log = logs.get(self.service, "")
+        ctx.logger.info(
+            f"ServiceLogNotContains: checking '{self.pattern}' NOT in {self.service}"
+        )
+        assert (
+            self.pattern not in log
+        ), f"Pattern '{self.pattern}' should NOT be in {self.service} logs but was found"
+
+    @property
+    def description(self) -> str:
+        return f"Service '{self.service}' logs do NOT contain '{self.pattern}'"

--- a/tests/fault_tolerance/deploy/checks.py
+++ b/tests/fault_tolerance/deploy/checks.py
@@ -21,7 +21,8 @@ __all__ = [
     "ZeroErrors",
     "MaxErrors",
     "MinRequests",
-    "WasCancelled",
+    "LoadStopped",
+    "LoadCompleted",
     "ServiceLogContains",
     "ServiceLogNotContains",
 ]
@@ -144,28 +145,50 @@ class MinRequests(Check):
 
 
 @dataclass
-class WasCancelled(Check):
-    """Assert was_cancelled flag matches expected value."""
+class LoadStopped(Check):
+    """Assert the load was stopped early (e.g. by a ``StopLoad`` event).
 
-    expected: bool = True
+    Pairs with ``LoadCompleted`` for the inverse case. Both read aiperf's
+    ``was_cancelled`` flag — True when the load job was terminated mid-run,
+    False when it ran to its configured request count or duration.
+    """
+
     name: str = "default"
 
     def validate(self, ctx: "ScenarioContext") -> None:
         load = self.get_load(ctx, self.name)
         assert load and load.results, f"No results for load '{self.name}'"
-
-        was_cancelled = load.results.get("was_cancelled", False)
-
-        ctx.logger.info(
-            f"WasCancelled: was_cancelled = {was_cancelled}, expected = {self.expected}"
-        )
-        assert (
-            was_cancelled == self.expected
-        ), f"Expected was_cancelled={self.expected}, got {was_cancelled}"
+        stopped = load.results.get("was_cancelled", False)
+        ctx.logger.info(f"LoadStopped: stopped = {stopped}")
+        assert stopped, "Expected load to be stopped early, but it completed naturally"
 
     @property
     def description(self) -> str:
-        return f"was_cancelled={self.expected} ('{self.name}')"
+        return f"Load stopped early ('{self.name}')"
+
+
+@dataclass
+class LoadCompleted(Check):
+    """Assert the load ran to completion (was NOT stopped early).
+
+    Pairs with ``LoadStopped``. Use after a ``WaitForLoadCompletion`` event
+    or whenever the scenario expects aiperf to finish on its own.
+    """
+
+    name: str = "default"
+
+    def validate(self, ctx: "ScenarioContext") -> None:
+        load = self.get_load(ctx, self.name)
+        assert load and load.results, f"No results for load '{self.name}'"
+        stopped = load.results.get("was_cancelled", False)
+        ctx.logger.info(f"LoadCompleted: stopped = {stopped}")
+        assert (
+            not stopped
+        ), "Expected load to complete naturally, but it was stopped early"
+
+    @property
+    def description(self) -> str:
+        return f"Load completed naturally ('{self.name}')"
 
 
 @dataclass

--- a/tests/fault_tolerance/deploy/checks.py
+++ b/tests/fault_tolerance/deploy/checks.py
@@ -12,9 +12,10 @@ Checks validate results after all events complete. Each check has:
 To create a custom check, subclass Check and implement validate() and description.
 """
 
+import re
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Optional
 
 __all__ = [
     "Check",
@@ -25,6 +26,15 @@ __all__ = [
     "LoadCompleted",
     "ServiceLogContains",
     "ServiceLogNotContains",
+    "RankProcessCount",
+    "WorkerPanics",
+    # 2026-05-03 disagg-cascade repro suite (PR #8254 panic, KV cascade, etc.)
+    "ServiceLogPatternRate",
+    "KvCacheUsagePeak",
+    "PodMemoryGrowth",
+    "CascadeAfterFault",
+    "EngineDeathDetected",
+    "RestartCountIncreased",
 ]
 
 if TYPE_CHECKING:
@@ -199,7 +209,7 @@ class ServiceLogContains(Check):
     pattern: str
 
     def validate(self, ctx: "ScenarioContext") -> None:
-        logs = ctx.deployment.collect_service_logs()
+        logs = _get_service_logs(ctx)
         log = logs.get(self.service, "")
         ctx.logger.info(
             f"ServiceLogContains: checking '{self.pattern}' in {self.service}"
@@ -215,6 +225,150 @@ class ServiceLogContains(Check):
 
 
 @dataclass
+class WorkerPanics(Check):
+    """Scan collected service logs for Rust panic strings and grade per
+    policy.
+
+    Designed as a generic detector for unhandled Rust panics in any
+    Dynamo service (frontend, workers). Originally added for PR #8254
+    (TCP panic -> warn+break), where the precondition is high-concurrency
+    load + induced TCP RST and the assertion is that no
+    ``tcp/client.rs`` / ``tcp/server.rs`` panic landed in the logs.
+
+    Policy:
+      - ``acceptable=False`` (default): assert no panic lines match.
+      - ``acceptable=True``: log the count, no assertion.
+      - ``max_count``: optional ceiling; only enforced when set. Useful
+        for "tolerate up to N panics" sweeps.
+
+    The default ``patterns`` match the standard Rust panic preamble plus
+    the two PR #8254 sites; pass your own list to narrow or broaden.
+    """
+
+    services: list
+    acceptable: bool = False
+    max_count: int | None = None
+    patterns: list = field(
+        default_factory=lambda: [
+            r"thread '.*' panicked at",
+            r"panicked at .*tcp/client\.rs",
+            r"panicked at .*tcp/server\.rs",
+            r"RUST_BACKTRACE",
+        ]
+    )
+
+    def validate(self, ctx) -> None:
+        logs = _get_service_logs(ctx)
+        compiled = [re.compile(p) for p in self.patterns]
+        hits: list[str] = []
+        per_service_counts: dict[str, int] = {}
+        for svc in self.services:
+            text = logs.get(svc, "") or ""
+            svc_hits = 0
+            for line in text.splitlines():
+                if any(c.search(line) for c in compiled):
+                    hits.append(f"{svc}: {line.strip()}")
+                    svc_hits += 1
+            per_service_counts[svc] = svc_hits
+        total = len(hits)
+        ctx.logger.info(
+            f"WorkerPanics: total={total} per-service={per_service_counts} "
+            f"(acceptable={self.acceptable}, max_count={self.max_count})"
+        )
+        # Log the first ~20 distinct hits so we can see what we got.
+        for h in hits[:20]:
+            ctx.logger.info(f"  panic-line: {h}")
+
+        if self.acceptable:
+            return  # report-only mode
+        if self.max_count is not None:
+            assert total <= self.max_count, (
+                f"WorkerPanics: {total} > max_count={self.max_count} in "
+                f"services {self.services}; first hits:\n"
+                + "\n".join(f"  - {h}" for h in hits[:20])
+            )
+        else:
+            assert total == 0, (
+                f"WorkerPanics: {total} panic line(s) found in "
+                f"services {self.services}; first hits:\n"
+                + "\n".join(f"  - {h}" for h in hits[:20])
+            )
+
+    @property
+    def description(self) -> str:
+        policy = (
+            "acceptable=yes"
+            if self.acceptable
+            else (
+                f"max={self.max_count}"
+                if self.max_count is not None
+                else "must be zero"
+            )
+        )
+        return f"WorkerPanics ({policy}) in {', '.join(self.services)}"
+
+
+@dataclass
+class RankProcessCount(Check):
+    """Assert that each pod in the named services runs exactly the expected
+    number of processes matching ``process_name``.
+
+    For a vLLM worker pod at TP=N the expected pattern is ``1 launcher
+    + N rank workers``; with ``process_name="dynamo.vllm"`` (or another
+    substring that matches both launcher and ranks) ``expected=N+1``.
+    If your matcher targets only the ranks (e.g. a tighter regex / a
+    PPID filter applied elsewhere), pass ``expected=N``.
+
+    The check exec's ``ps`` inside each pod and counts processes whose
+    command line contains ``process_name``. Per-pod actual counts are
+    logged so a mismatch shows you exactly which pod is off and by how
+    many.
+
+    Example::
+
+        RankProcessCount(
+            services=["VllmDecodeWorker", "VllmPrefillWorker"],
+            process_name="dynamo.vllm",
+            expected=3,  # launcher + 2 ranks for TP=2
+        )
+    """
+
+    services: list
+    process_name: str
+    expected: int
+
+    def validate(self, ctx) -> None:
+        service_pod_dict = ctx.deployment.get_pods(self.services)
+        failures: list[str] = []
+        for service_name, pods in service_pod_dict.items():
+            for pod in pods:
+                processes = ctx.deployment.get_processes(pod)
+                matches = [p for p in processes if self.process_name in p.command]
+                actual = len(matches)
+                ctx.logger.info(
+                    f"RankProcessCount: {service_name}/{pod.name}: "
+                    f"{actual} processes matching '{self.process_name}' "
+                    f"(expected {self.expected})"
+                )
+                if actual != self.expected:
+                    failures.append(
+                        f"{service_name}/{pod.name}: got {actual}, "
+                        f"expected {self.expected}"
+                    )
+        assert not failures, (
+            f"RankProcessCount mismatches for process '{self.process_name}':\n"
+            + "\n".join(f"  - {f}" for f in failures)
+        )
+
+    @property
+    def description(self) -> str:
+        return (
+            f"Each pod in {', '.join(self.services)} runs exactly "
+            f"{self.expected} '{self.process_name}' processes"
+        )
+
+
+@dataclass
 class ServiceLogNotContains(Check):
     """Assert a service log does NOT contain a pattern."""
 
@@ -222,7 +376,7 @@ class ServiceLogNotContains(Check):
     pattern: str
 
     def validate(self, ctx: "ScenarioContext") -> None:
-        logs = ctx.deployment.collect_service_logs()
+        logs = _get_service_logs(ctx)
         log = logs.get(self.service, "")
         ctx.logger.info(
             f"ServiceLogNotContains: checking '{self.pattern}' NOT in {self.service}"
@@ -234,3 +388,1051 @@ class ServiceLogNotContains(Check):
     @property
     def description(self) -> str:
         return f"Service '{self.service}' logs do NOT contain '{self.pattern}'"
+
+
+# =============================================================================
+# 2026-05-03 disagg-cascade repro suite
+# =============================================================================
+#
+# Six checks added 2026-05-12 for the e2e DGD scenarios that reproduce the
+# PR #8254 TCP panic, the kv-router radix_tree warning storm under
+# AGG-enum-decode, KV-saturation cascades, and the engine-hang /
+# liveness-restart signature. Each follows the same Check.validate(ctx)
+# contract as the older checks above.
+#
+# Design notes:
+# - Reading time-series data: prefer `server_metrics_export.jsonl` from any
+#   StartLoad's load-dir under `ctx.log_dir/load/load-<name>-*/` (aiperf
+#   captures one record per 1 Hz scrape per scraped endpoint). Helpers below.
+# - Reading log text: `ctx.deployment.collect_service_logs()` returns
+#   `{service_name: str}` (the catted pod logs).
+# - Reading pod status: `ctx.deployment.get_pods([service_name])` returns
+#   live Pod objects with `.raw['status']['containerStatuses']`.
+
+import json as _json  # noqa: E402
+import os as _os  # noqa: E402
+from glob import escape as _glob_escape  # noqa: E402
+from glob import glob as _glob  # noqa: E402
+
+
+def _get_service_logs(ctx) -> dict:
+    """Return per-service catted pod logs.
+
+    Prefer the pre-teardown snapshot on ``ctx.service_logs`` when
+    populated. Otherwise read from disk: the framework extracts each
+    pod's log via the PVC-extractor sidecar into
+    ``<log_dir>/<service-name-lowercase>/<podname>_<ts>.log``.
+    """
+    snap = getattr(ctx, "service_logs", None) or {}
+    if snap:
+        return snap
+
+    log_dir = getattr(ctx, "log_dir", None)
+    if not log_dir or not _os.path.isdir(log_dir):
+        return {}
+
+    out: dict = {}
+    # One sub-directory per service (lowercased name).
+    for entry in _os.listdir(log_dir):
+        sub = _os.path.join(log_dir, entry)
+        if not _os.path.isdir(sub) or entry in ("load",):
+            continue
+        # Concatenate every <pod>*.log under this service dir.
+        catted_parts = []
+        log_files = sorted(_glob(_os.path.join(_glob_escape(sub), "*.log")))
+        for f in log_files:
+            try:
+                with open(f, "r", errors="replace") as fh:
+                    catted_parts.append(fh.read())
+            except OSError:
+                continue
+        if catted_parts:
+            text = "\n".join(catted_parts)
+            # Disk dir is lowercase ("frontend", "vllmdecodeworker") but
+            # check consumers refer to services by PascalCase
+            # ("Frontend", "VllmDecodeWorker"). Map both keys to the
+            # same text so either casing resolves.
+            out[entry] = text
+            for cased in ("Frontend", "VllmDecodeWorker", "VllmPrefillWorker"):
+                if cased.lower() == entry:
+                    out[cased] = text
+                    break
+    return out
+
+
+def _find_load_dirs(ctx) -> list:
+    """Return all load-*/ subdirs of the test's log_dir (one per StartLoad).
+
+    The log_dir embeds the pytest parametrize id (``test_name[arm-id]``)
+    which contains ``[`` ``]`` — glob metacharacters that get parsed as
+    character classes and silently match nothing. Use ``glob.escape``
+    on the parent path so the bracketed test name survives intact.
+    """
+    log_dir = getattr(ctx, "log_dir", None)
+    if not log_dir:
+        return []
+    base = _os.path.join(_glob_escape(log_dir), "load", "load-*")
+    out = sorted(_glob(base))
+    return [p for p in out if _os.path.isdir(p)]
+
+
+def _iter_jsonl(path: str):
+    """Yield parsed JSON records from a JSONL file, skipping malformed rows."""
+    if not _os.path.isfile(path):
+        return
+    with open(path) as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                yield _json.loads(line)
+            except _json.JSONDecodeError:
+                continue
+
+
+def _resolve_pod_names(ctx, services: list) -> dict:
+    """Snapshot ``{service: [pod_name, ...]}`` for the given services."""
+    out = {}
+    for svc in services:
+        pods_by_svc = ctx.deployment.get_pods([svc])
+        out[svc] = sorted(p.name for p in (pods_by_svc.get(svc) or []))
+    return out
+
+
+@dataclass
+class ServiceLogPatternRate(Check):
+    """Assert a regex pattern fires at ≥ ``min_rate_per_sec`` (or == 0) in
+    the collected service logs over the entire run window.
+
+    Time-source: log lines are scanned for the first / last ISO-8601-ish
+    timestamp encountered; rate = count / (last - first).seconds. Falls
+    back to a conservative 1-second floor on the denominator if log
+    timestamps can't be parsed.
+
+    Examples::
+
+        # radix_tree storm on AGG-enum decode pod
+        ServiceLogPatternRate(
+            services=["VllmDecodeWorker"],
+            pattern=r"radix_tree\\.rs:(341|431)",
+            min_rate_per_sec=100.0,
+        )
+        # panic-burst proof on bug-image; same check with floor=0.0
+        # asserts ZERO occurrences (use ``expect_zero=True`` for clarity).
+        ServiceLogPatternRate(
+            services=["Frontend", "VllmDecodeWorker"],
+            pattern=r"panicked at .*tcp/(client|server)\\.rs",
+            min_rate_per_sec=1.0,
+        )
+    """
+
+    services: list
+    pattern: str
+    min_rate_per_sec: float = 1.0
+    expect_zero: bool = False  # invert: assert rate == 0
+
+    def validate(self, ctx) -> None:
+        compiled = re.compile(self.pattern)
+        ts_re = re.compile(r"(\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2})")
+        logs = _get_service_logs(ctx)
+        total_matches = 0
+        total_span_s = 0.0
+        per_service: dict = {}
+        for svc in self.services:
+            text = logs.get(svc, "") or ""
+            n = 0
+            first_ts = None
+            last_ts = None
+            for line in text.splitlines():
+                m = compiled.search(line)
+                if m:
+                    n += 1
+                t = ts_re.search(line)
+                if t:
+                    iso = t.group(1).replace(" ", "T")
+                    try:
+                        from datetime import datetime
+
+                        dt = datetime.fromisoformat(iso)
+                        first_ts = dt if first_ts is None else min(first_ts, dt)
+                        last_ts = dt if last_ts is None else max(last_ts, dt)
+                    except ValueError:
+                        pass
+            span = (
+                max(1.0, (last_ts - first_ts).total_seconds())
+                if (first_ts and last_ts)
+                else 1.0
+            )
+            per_service[svc] = {"matches": n, "span_s": span, "rate": n / span}
+            total_matches += n
+            total_span_s = max(total_span_s, span)
+
+        ctx.logger.info(
+            f"ServiceLogPatternRate(pattern={self.pattern!r}): "
+            f"per-service={per_service} total_matches={total_matches} "
+            f"total_span_s={total_span_s:.1f}"
+        )
+        # Aggregate rate = sum(matches) / max(span). Could change to
+        # per-service strictest, but aggregate is reasonable for "did
+        # this happen somewhere".
+        aggregate_rate = total_matches / max(1.0, total_span_s)
+
+        if self.expect_zero:
+            assert total_matches == 0, (
+                f"ServiceLogPatternRate(expect_zero=True) but found "
+                f"{total_matches} matches for {self.pattern!r} in "
+                f"services {self.services}: {per_service}"
+            )
+            return
+
+        assert aggregate_rate >= self.min_rate_per_sec, (
+            f"ServiceLogPatternRate: aggregate rate "
+            f"{aggregate_rate:.2f}/s < floor {self.min_rate_per_sec}/s "
+            f"for pattern {self.pattern!r} in services {self.services}: "
+            f"{per_service}"
+        )
+
+    @property
+    def description(self) -> str:
+        if self.expect_zero:
+            return (
+                f"Pattern {self.pattern!r} matches NONE in "
+                f"{', '.join(self.services)}"
+            )
+        return (
+            f"Pattern {self.pattern!r} fires ≥ {self.min_rate_per_sec}/s in "
+            f"{', '.join(self.services)}"
+        )
+
+
+@dataclass
+class KvCacheUsagePeak(Check):
+    """Assert at least one pod's ``vllm:kv_cache_usage_perc`` reaches
+    ``threshold`` (e.g. 0.9) within ``within_seconds`` of the pod's
+    server_metrics first-sample timestamp.
+
+    Used by the R4 replacement-KV-saturation test: after a decode pod is
+    deleted, the replacement pod schedules with a fresh KV pool; if
+    upstream prefill has a queue of pending KV transfers, that pool can
+    saturate (~99%) within minutes of the pod becoming Ready. We assert
+    that exact pattern.
+    """
+
+    services: list
+    threshold: float = 0.9
+    within_seconds: float = 240.0
+
+    def validate(self, ctx) -> None:
+        load_dirs = _find_load_dirs(ctx)
+        observed: dict = {}
+        for ldir in load_dirs:
+            jsonl = _os.path.join(ldir, "server_metrics_export.jsonl")
+            for rec in _iter_jsonl(jsonl):
+                ts_ns = rec.get("timestamp_ns")
+                metrics = rec.get("metrics", {}) or {}
+                kv = metrics.get("vllm:kv_cache_usage_perc") or []
+                for sample in kv:
+                    labels = sample.get("labels", {}) or {}
+                    pod = labels.get("pod") or rec.get("endpoint_url", "")
+                    val = sample.get("value")
+                    if val is None or ts_ns is None:
+                        continue
+                    if pod not in observed:
+                        observed[pod] = {
+                            "first_ts_ns": ts_ns,
+                            "max": float(val),
+                            "max_ts_ns": ts_ns,
+                        }
+                    else:
+                        observed[pod]["max"] = max(observed[pod]["max"], float(val))
+                        if float(val) >= self.threshold:
+                            observed[pod]["max_ts_ns"] = ts_ns
+
+        ctx.logger.info(
+            f"KvCacheUsagePeak: per-pod observations={observed} "
+            f"threshold={self.threshold} within={self.within_seconds}s"
+        )
+        winners = []
+        for pod, rec in observed.items():
+            elapsed_s = (rec["max_ts_ns"] - rec["first_ts_ns"]) / 1e9
+            if rec["max"] >= self.threshold and elapsed_s <= self.within_seconds:
+                winners.append((pod, rec["max"], elapsed_s))
+        assert winners, (
+            f"KvCacheUsagePeak: no pod in {self.services} reached "
+            f"kv_cache_usage_perc >= {self.threshold} within "
+            f"{self.within_seconds}s. Observed: {observed}"
+        )
+
+    @property
+    def description(self) -> str:
+        return (
+            f"KV cache usage peak ≥ {self.threshold} within "
+            f"{self.within_seconds}s on some {', '.join(self.services)} pod"
+        )
+
+
+@dataclass
+class PodMemoryGrowth(Check):
+    """Assert at least one pod's ``/proc/1/status:VmRSS`` grows by
+    ``growth_bytes_per_min`` over a ``window_seconds`` window during the
+    scenario.
+
+    Implementation: a background asyncio task started by the check at
+    scenario-start exec's `cat /proc/1/status` on each pod every
+    ``poll_interval_s``, parses VmRSS, and writes a TSV to
+    ``ctx.log_dir/pod_memory_growth.tsv``. validate() reads the TSV.
+
+    The background-task plumbing is in the test file (StartLoad event
+    can't host it cleanly); this check class is the assertion only.
+    Tests that need it install a ``MemoryPoller`` event into the
+    scenario events list before calling run_scenario.
+    """
+
+    services: list
+    growth_bytes_per_min: float = 1_000_000_000.0
+    window_seconds: float = 600.0
+    tsv_filename: str = "pod_memory_growth.tsv"
+    # Which column to assert on. "working_set" = kubelet cgroup view
+    # (OOMKill-correlated). "pid1_rss" = per-process attribution.
+    # Default to working_set since that's the kubelet-side signal.
+    source: str = "working_set"
+
+    def validate(self, ctx) -> None:
+        log_dir = getattr(ctx, "log_dir", None)
+        path = _os.path.join(log_dir, self.tsv_filename) if log_dir else None
+        if not path or not _os.path.isfile(path):
+            assert False, (
+                f"PodMemoryGrowth: {self.tsv_filename} not found at "
+                f"{path!r}; the test must install a MemoryPoller event "
+                f"before running the scenario."
+            )
+        # TSV columns:
+        #   v3 (current, 6 fields): epoch_s, svc, pod, container,
+        #       working_set_bytes, pid1_rss_bytes
+        #   v2 (5 fields): epoch_s, svc, pod, container, working_set_bytes
+        #   v1 (4 fields): epoch_s, svc, pod, vm_rss_kb (legacy)
+        # self.source ("working_set"|"pid1_rss") picks the column.
+        per_pod = {}
+        with open(path) as fh:
+            for line in fh:
+                parts = line.strip().split("\t")
+                if not parts or parts[0] == "epoch_s":
+                    continue
+                try:
+                    t = float(parts[0])
+                    svc = parts[1]
+                    pod = parts[2]
+                    if len(parts) >= 6:
+                        bytes_ = float(
+                            parts[5] if self.source == "pid1_rss" else parts[4]
+                        )
+                    elif len(parts) >= 5:
+                        bytes_ = float(parts[4])
+                    elif len(parts) >= 4:
+                        bytes_ = float(parts[3]) * 1024.0
+                    else:
+                        continue
+                except ValueError:
+                    continue
+                if svc not in self.services:
+                    continue
+                per_pod.setdefault(pod, []).append((t, bytes_))
+
+        max_rate_pod = None
+        max_rate = 0.0
+        for pod, series in per_pod.items():
+            series.sort()
+            # Sliding window: for each pair (t0, t1) in window, compute
+            # (rss_t1 - rss_t0) / (t1 - t0) in seconds, then × 60.
+            for i, (t0, r0) in enumerate(series):
+                for j in range(len(series) - 1, i, -1):
+                    t1, r1 = series[j]
+                    if t1 - t0 > self.window_seconds:
+                        continue
+                    span = t1 - t0
+                    if span < 30.0:
+                        continue
+                    rate_per_min = (r1 - r0) / span * 60.0
+                    if rate_per_min > max_rate:
+                        max_rate = rate_per_min
+                        max_rate_pod = pod
+                    break  # take the longest span; faster
+        ctx.logger.info(
+            f"PodMemoryGrowth: max_rate={max_rate:.0f} bytes/min "
+            f"on pod={max_rate_pod}; floor={self.growth_bytes_per_min}"
+        )
+        assert max_rate >= self.growth_bytes_per_min, (
+            f"PodMemoryGrowth: peak RSS growth {max_rate:.0f}/min < "
+            f"{self.growth_bytes_per_min:.0f}/min floor on services "
+            f"{self.services}"
+        )
+
+    @property
+    def description(self) -> str:
+        return (
+            f"At least one {', '.join(self.services)} pod's RSS grows ≥ "
+            f"{self.growth_bytes_per_min:.0g} bytes/min "
+            f"over a {self.window_seconds}s window"
+        )
+
+
+@dataclass
+class CascadeAfterFault(Check):
+    """Assert that on at least one surviving pod, after a named fault event,
+    ``vllm:num_requests_waiting`` increases by ``waiting_min_delta`` AND
+    ``vllm:request_latency_seconds`` p99 grows by ``latency_p99_min_multiplier``×.
+
+    "Surviving" = any pod in ``services`` that was NOT the named fault's
+    target. Pre-window: ``pre_seconds`` immediately before the fault.
+    Post-window: starting ``settle_seconds`` after the fault to allow the
+    cascade to develop, ending ``post_seconds`` later.
+    """
+
+    services: list
+    fault_event_name: str
+    waiting_min_delta: float = 5.0
+    latency_p99_min_multiplier: float = 2.0
+    pre_seconds: float = 120.0
+    post_seconds: float = 120.0
+    settle_seconds: float = 30.0
+
+    def _fault_ts_ns(self, ctx) -> int | None:
+        for event in ctx.events:
+            if getattr(event, "name", None) == self.fault_event_name:
+                started = getattr(event, "started_at", None)
+                if started is not None:
+                    return int(started.timestamp() * 1e9)
+        return None
+
+    def validate(self, ctx) -> None:
+        fault_ts = self._fault_ts_ns(ctx)
+        assert fault_ts is not None, (
+            f"CascadeAfterFault: could not find started_at on event "
+            f"named {self.fault_event_name!r}"
+        )
+        pre_lo = fault_ts - int(self.pre_seconds * 1e9)
+        pre_hi = fault_ts
+        post_lo = fault_ts + int(self.settle_seconds * 1e9)
+        post_hi = post_lo + int(self.post_seconds * 1e9)
+
+        per_pod = (
+            {}
+        )  # pod -> {"pre_waiting":[], "post_waiting":[], "pre_p99":[], "post_p99":[]}
+        for ldir in _find_load_dirs(ctx):
+            jsonl = _os.path.join(ldir, "server_metrics_export.jsonl")
+            for rec in _iter_jsonl(jsonl):
+                ts = rec.get("timestamp_ns")
+                if ts is None:
+                    continue
+                bucket = None
+                if pre_lo <= ts <= pre_hi:
+                    bucket = "pre"
+                elif post_lo <= ts <= post_hi:
+                    bucket = "post"
+                if bucket is None:
+                    continue
+                metrics = rec.get("metrics", {}) or {}
+                for m in ("vllm:num_requests_waiting",):
+                    for s in metrics.get(m, []) or []:
+                        labels = s.get("labels", {}) or {}
+                        pod = labels.get("pod") or rec.get("endpoint_url", "")
+                        v = s.get("value")
+                        if v is None:
+                            continue
+                        per_pod.setdefault(pod, {}).setdefault(
+                            f"{bucket}_waiting", []
+                        ).append(float(v))
+                for s in metrics.get("vllm:request_latency_seconds", []) or []:
+                    labels = s.get("labels", {}) or {}
+                    pod = labels.get("pod") or rec.get("endpoint_url", "")
+                    buckets = s.get("buckets") or {}
+                    count = s.get("count") or 0
+                    # estimate p99 by walking buckets
+                    if not buckets or not count:
+                        continue
+                    target = 0.99 * count
+                    le_sorted = sorted(
+                        [
+                            (
+                                float(k.rstrip("Inf").rstrip("+"))
+                                if k != "+Inf"
+                                else float("inf"),
+                                float(v),
+                            )
+                            for k, v in buckets.items()
+                        ],
+                        key=lambda x: x[0],
+                    )
+                    p99 = None
+                    for le, cum in le_sorted:
+                        if cum >= target:
+                            p99 = le
+                            break
+                    if p99 is None:
+                        continue
+                    per_pod.setdefault(pod, {}).setdefault(f"{bucket}_p99", []).append(
+                        p99
+                    )
+
+        # Try to identify the fault target pod from the event so we exclude it.
+        fault_target_name = None
+        for event in ctx.events:
+            if getattr(event, "name", None) == self.fault_event_name:
+                names = (
+                    getattr(event, "_targeted_pod_names", None)
+                    or getattr(event, "_deleted_names", None)
+                    or [p for _, p in getattr(event, "_stalled_pids", []) or []]
+                )
+                if names:
+                    fault_target_name = names[0] if isinstance(names, list) else names
+                break
+
+        cascade_evidence = []
+        for pod, slices in per_pod.items():
+            if fault_target_name and fault_target_name in pod:
+                continue
+            pre_w = max(slices.get("pre_waiting") or [0.0])
+            post_w = max(slices.get("post_waiting") or [0.0])
+            pre_p99 = max(slices.get("pre_p99") or [0.0]) or 0.001
+            post_p99 = max(slices.get("post_p99") or [0.0])
+            waiting_d = post_w - pre_w
+            latency_mult = post_p99 / pre_p99 if pre_p99 > 0 else float("inf")
+            if (
+                waiting_d >= self.waiting_min_delta
+                and latency_mult >= self.latency_p99_min_multiplier
+            ):
+                cascade_evidence.append((pod, pre_w, post_w, pre_p99, post_p99))
+        ctx.logger.info(
+            f"CascadeAfterFault({self.fault_event_name}): cascade survivors="
+            f"{cascade_evidence} (need waiting_d ≥ {self.waiting_min_delta} "
+            f"AND latency × {self.latency_p99_min_multiplier})"
+        )
+        assert cascade_evidence, (
+            f"CascadeAfterFault: no surviving pod in {self.services} "
+            f"showed both waiting growth ≥ {self.waiting_min_delta} AND "
+            f"latency p99 growth ≥ {self.latency_p99_min_multiplier}× "
+            f"after fault {self.fault_event_name!r}"
+        )
+
+    @property
+    def description(self) -> str:
+        return (
+            f"After fault {self.fault_event_name!r}: some survivor in "
+            f"{', '.join(self.services)} sees waiting ≥ +{self.waiting_min_delta} "
+            f"AND p99 × ≥ {self.latency_p99_min_multiplier}"
+        )
+
+
+@dataclass
+class EngineDeathDetected(Check):
+    """Detect 'engine hung but kubelet hasn't killed it yet': a window of
+    ``idle_seconds`` or more where ``vllm:request_success_total`` rate is
+    zero on a pod while aiperf load was still admitting requests.
+
+    Use this as the 'RPS collapse minutes before container restart'
+    signature when investigating whether an indirect fault drives a pod
+    into a silent-stalled state.
+
+    ``expect_zero=False`` (default) → assert ≥ 1 such window is found
+    on any pod (proves the engine-hung state was reached somewhere).
+    ``expect_zero=True`` → assert NO pod entered a sustained idle window
+    (used by R2 / sanity tests).
+    """
+
+    services: list
+    idle_seconds: float = 30.0
+    expect_zero: bool = False
+
+    def validate(self, ctx) -> None:
+        per_pod = {}
+        for ldir in _find_load_dirs(ctx):
+            jsonl = _os.path.join(ldir, "server_metrics_export.jsonl")
+            for rec in _iter_jsonl(jsonl):
+                ts = rec.get("timestamp_ns")
+                if ts is None:
+                    continue
+                for s in (rec.get("metrics", {}) or {}).get(
+                    "vllm:request_success_total", []
+                ) or []:
+                    labels = s.get("labels", {}) or {}
+                    pod = labels.get("pod") or rec.get("endpoint_url", "")
+                    v = s.get("value")
+                    if v is None:
+                        continue
+                    per_pod.setdefault(pod, []).append((ts, float(v)))
+
+        idle_windows = []  # (pod, idle_start_ts, idle_end_ts, duration_s)
+        for pod, series in per_pod.items():
+            series.sort()
+            run_start_ts = None
+            run_start_val = None
+            for ts, v in series:
+                if run_start_ts is None:
+                    run_start_ts = ts
+                    run_start_val = v
+                    continue
+                if v == run_start_val:
+                    dur_s = (ts - run_start_ts) / 1e9
+                    if dur_s >= self.idle_seconds:
+                        idle_windows.append((pod, run_start_ts, ts, dur_s))
+                else:
+                    run_start_ts = ts
+                    run_start_val = v
+
+        ctx.logger.info(
+            f"EngineDeathDetected: idle_windows ≥ {self.idle_seconds}s: "
+            f"{len(idle_windows)} found; samples={idle_windows[:3]}"
+        )
+        if self.expect_zero:
+            assert not idle_windows, (
+                f"EngineDeathDetected(expect_zero=True): "
+                f"{len(idle_windows)} sustained-zero-RPS windows ≥ "
+                f"{self.idle_seconds}s found on pods in {self.services}"
+            )
+            return
+        assert idle_windows, (
+            f"EngineDeathDetected: no pod in {self.services} entered a "
+            f"≥ {self.idle_seconds}s zero-RPS window during the run"
+        )
+
+    @property
+    def description(self) -> str:
+        suffix = (
+            "no idle windows"
+            if self.expect_zero
+            else f"≥ 1 idle window of ≥ {self.idle_seconds}s"
+        )
+        return f"{', '.join(self.services)}: {suffix}"
+
+
+@dataclass
+class RestartCountIncreased(Check):
+    """Assert that at least one pod in ``services`` had its
+    ``containerStatuses[0].restartCount`` increment during the scenario.
+
+    Reads the live pod manifests at validate() time. The ManagedDeployment
+    spec snapshot at start should be captured by tests; for simplicity
+    this check just looks for any non-zero restartCount on any matching
+    pod (since fresh DGD starts at 0).
+    """
+
+    services: list
+    expect_min_increment: int = 1
+    expect_zero: bool = False
+
+    def validate(self, ctx) -> None:
+        seen = {}
+        snapshot = getattr(ctx, "pod_restart_state", None) or {}
+        for svc in self.services:
+            if ctx.deployment is not None:
+                # Live mode — useful for in-scenario checks.
+                pods = ctx.deployment.get_pods([svc]).get(svc) or []
+                for pod in pods:
+                    statuses = (pod.raw.get("status", {}) or {}).get(
+                        "containerStatuses"
+                    ) or []
+                    if not statuses:
+                        continue
+                    rc = int(statuses[0].get("restartCount", 0))
+                    reason = (
+                        (statuses[0].get("lastState") or {}).get("terminated") or {}
+                    ).get("reason")
+                    seen[pod.name] = {"restartCount": rc, "lastReason": reason}
+            else:
+                # Post-teardown — read from the scenario-runner snapshot.
+                seen.update(snapshot.get(svc, {}))
+
+        ctx.logger.info(f"RestartCountIncreased: per-pod={seen}")
+        total = sum(v["restartCount"] for v in seen.values())
+        if self.expect_zero:
+            assert total == 0, (
+                f"RestartCountIncreased(expect_zero=True): sum of "
+                f"restartCounts = {total} across services {self.services}: "
+                f"{seen}"
+            )
+            return
+        assert total >= self.expect_min_increment, (
+            f"RestartCountIncreased: sum of restartCounts = {total} < "
+            f"{self.expect_min_increment} across services {self.services}: "
+            f"{seen}"
+        )
+
+    @property
+    def description(self) -> str:
+        if self.expect_zero:
+            return f"No container in {', '.join(self.services)} restarted"
+        return (
+            f"At least {self.expect_min_increment} container restart(s) "
+            f"across {', '.join(self.services)}"
+        )
+
+
+# =============================================================================
+# 2026-05-13 decode-overload-disagg repro verifiers
+# =============================================================================
+#
+# Five checks added for the decode-worker overload campaign that reproduces
+# the canonical disagg decode-side cascade signature shape.
+# Each fails fast if the test didn't actually drive the conditions it claims
+# to drive — they are *verifiers*, not gates, so the test author can read
+# the report and confirm load was applied, pressure was reached, and the
+# expected symptoms occurred.
+#
+# Source signals come from two places:
+#  - AIPerf-side: ``profile_export_aiperf.json`` (request_count, error_summary,
+#    latency percentiles, goodput).
+#  - Server-side: ``server_metrics_export.jsonl`` (vllm:* gauges + dynamo
+#    counters, 1Hz scrape).
+
+
+@dataclass
+class LoadApplied(Check):
+    """Assert aiperf actually issued at least ``min_requests`` requests
+    during the scenario. Fails if the load harness misbehaved — zero
+    traffic (broken endpoint, port-forward failure), job created but
+    cancelled before warmup, or the AIPerf job pod failed before
+    reporting any results.
+    """
+
+    min_requests: int = 100
+    load_name: Optional[str] = None  # filter to a specific StartLoad name
+
+    def validate(self, ctx) -> None:
+        load_dirs = _find_load_dirs(ctx)
+        observed = []
+        for ldir in load_dirs:
+            if self.load_name and self.load_name not in _os.path.basename(ldir):
+                continue
+            # AIPerf 0.7.x writes profile_export_aiperf.json directly in
+            # the load dir (no nested attempt subdirectory).
+            jpath = _os.path.join(ldir, "profile_export_aiperf.json")
+            if not _os.path.isfile(jpath):
+                continue
+            try:
+                with open(jpath) as fh:
+                    data = _json.load(fh)
+            except (_json.JSONDecodeError, OSError):
+                continue
+            # Schema is flat: top-level "request_count": {"unit": ..., "avg": N}.
+            rc_node = data.get("request_count") or {}
+            rc = int(rc_node.get("avg") or rc_node.get("count") or 0)
+            observed.append((ldir, rc))
+        total = sum(rc for _, rc in observed)
+        ctx.logger.info(
+            f"LoadApplied: per-load-dir={observed} total={total} "
+            f"min_required={self.min_requests}"
+        )
+        assert total >= self.min_requests, (
+            f"LoadApplied: only {total} requests issued across "
+            f"{len(observed)} load runs; expected at least "
+            f"{self.min_requests}. Was the endpoint reachable?"
+        )
+
+    @property
+    def description(self) -> str:
+        if self.load_name:
+            return f"Load '{self.load_name}' issued ≥ {self.min_requests} requests"
+        return f"Total requests issued ≥ {self.min_requests}"
+
+
+def _iter_server_metric(ctx, metric: str):
+    """Yield (ts_ns, pod, value) for every sample of ``metric`` across all
+    load dirs and rungs of the current scenario.
+
+    Pod identifier is taken from (in order): ``labels.pod``, the
+    ``dynamo_component`` label combined with the endpoint host
+    (so multiple workers of the same role stay distinguishable),
+    or just the endpoint_url. The vLLM Prometheus surface in
+    Dynamo 1.0.x labels samples with ``dynamo_component`` =
+    ``prefill`` | ``decode`` | ``frontend`` but does NOT include
+    a ``pod`` label — without this fallback every prefill rep
+    aliases to "prefill" and we lose the pod-level distinction.
+    """
+    for ldir in _find_load_dirs(ctx):
+        jsonl = _os.path.join(ldir, "server_metrics_export.jsonl")
+        for rec in _iter_jsonl(jsonl):
+            ts_ns = rec.get("timestamp_ns")
+            endpoint = rec.get("endpoint_url", "")
+            metrics = rec.get("metrics", {}) or {}
+            samples = metrics.get(metric) or []
+            for s in samples:
+                labels = s.get("labels", {}) or {}
+                pod = labels.get("pod")
+                if not pod:
+                    comp = labels.get("dynamo_component") or ""
+                    # Endpoint URL embeds the pod IP — use it as the
+                    # tie-breaker so two prefills don't collapse.
+                    host = endpoint
+                    pod = f"{comp}@{host}" if comp else host
+                val = s.get("value")
+                if val is None or ts_ns is None:
+                    continue
+                yield int(ts_ns), str(pod), float(val)
+
+
+@dataclass
+class RequestsRunningPeak(Check):
+    """Assert at least one decode pod's ``vllm:num_requests_running``
+    spiked to ``threshold`` and stayed there for ``sustained_seconds``.
+    Mirrors a production-class running-set spike (e.g. 40 → 246 in one minute).
+
+    Implementation: for each pod, find the longest contiguous run of
+    samples ≥ threshold. Pass if any pod's longest run ≥ sustained_seconds.
+    """
+
+    threshold: int = 200
+    sustained_seconds: float = 30.0
+
+    def validate(self, ctx) -> None:
+        per_pod: dict = {}  # pod -> [(ts_ns, val), ...]
+        for ts_ns, pod, val in _iter_server_metric(ctx, "vllm:num_requests_running"):
+            per_pod.setdefault(pod, []).append((ts_ns, val))
+        runs: dict = {}
+        for pod, series in per_pod.items():
+            series.sort()
+            best_s = 0.0
+            cur_start = None
+            cur_last = None
+            for ts_ns, v in series:
+                if v >= self.threshold:
+                    if cur_start is None:
+                        cur_start = ts_ns
+                    cur_last = ts_ns
+                else:
+                    if cur_start is not None and cur_last is not None:
+                        best_s = max(best_s, (cur_last - cur_start) / 1e9)
+                    cur_start = None
+                    cur_last = None
+            if cur_start is not None and cur_last is not None:
+                best_s = max(best_s, (cur_last - cur_start) / 1e9)
+            runs[pod] = best_s
+        ctx.logger.info(
+            f"RequestsRunningPeak: per-pod longest sustained run (s) "
+            f"at >= {self.threshold} = {runs}"
+        )
+        winners = [p for p, s in runs.items() if s >= self.sustained_seconds]
+        assert winners, (
+            f"RequestsRunningPeak: no pod sustained num_requests_running "
+            f">= {self.threshold} for >= {self.sustained_seconds}s. "
+            f"Longest run per pod: {runs}"
+        )
+
+    @property
+    def description(self) -> str:
+        return (
+            f"At least one pod's num_requests_running ≥ {self.threshold} "
+            f"for ≥ {self.sustained_seconds}s"
+        )
+
+
+@dataclass
+class RequestCancellationOccurred(Check):
+    """Assert AIPerf observed at least ``min_count`` request
+    cancellations across the run. Counts both:
+      - explicit ``--request-cancellation-rate`` aborts (error tag
+        ``RequestCancellationError``)
+      - SLA-timeout aborts (``--request-timeout-seconds``, surfaces as
+        timeout-style errors in error_summary).
+
+    Validates the disconnect/timeout pressure path is exercised — the
+    point of the campaign. If this is zero, AIPerf wasn't producing
+    the SO_LINGER=0-trigger pattern even under sustained load.
+    """
+
+    min_count: int = 10
+    load_name: Optional[str] = None
+
+    def validate(self, ctx) -> None:
+        per_run: list = []
+        for ldir in _find_load_dirs(ctx):
+            if self.load_name and self.load_name not in _os.path.basename(ldir):
+                continue
+            jpath = _os.path.join(ldir, "profile_export_aiperf.json")
+            if not _os.path.isfile(jpath):
+                continue
+            try:
+                with open(jpath) as fh:
+                    data = _json.load(fh)
+            except (_json.JSONDecodeError, OSError):
+                continue
+            err_summary = data.get("error_summary") or []
+            if isinstance(err_summary, dict):
+                err_summary = err_summary.get("summary") or []
+            cancelled = 0
+            for entry in err_summary:
+                # AIPerf 0.7.x schema:
+                #   {"error_details": {"type": "TimeoutError", ...}, "count": N}
+                # earlier versions used top-level "type" / "error".
+                details = entry.get("error_details") or {}
+                tag = str(
+                    details.get("type") or entry.get("error") or entry.get("type") or ""
+                ).lower()
+                if (
+                    "cancel" in tag
+                    or "timeout" in tag
+                    or entry.get("code") in (408, 499, 504)
+                ):
+                    cancelled += int(entry.get("count") or 0)
+            # SLA-timeout cancellations are emergent: when goodput SLO is
+            # set (e.g. request_latency:30000ms), request_count counts
+            # all completions while good_request_count counts only those
+            # within SLO. The difference is the SLA-breach count, which
+            # in our 30s-timeout regime equals AIPerf-side cancellations.
+            rc = int((data.get("request_count") or {}).get("avg") or 0)
+            gc = int((data.get("good_request_count") or {}).get("avg") or 0)
+            slo_breached = max(0, rc - gc) if gc and rc else 0
+            per_run.append((ldir, cancelled + slo_breached))
+        total = sum(c for _, c in per_run)
+        ctx.logger.info(
+            f"RequestCancellationOccurred: per-run={per_run} "
+            f"total={total} min_required={self.min_count}"
+        )
+        assert total >= self.min_count, (
+            f"RequestCancellationOccurred: only {total} "
+            f"cancellations/timeouts observed; expected ≥ {self.min_count}. "
+            f"Disconnect/timeout pressure path was not exercised."
+        )
+
+    @property
+    def description(self) -> str:
+        return f"AIPerf observed ≥ {self.min_count} cancellations/timeouts"
+
+
+@dataclass
+class ThroughputCollapse(Check):
+    """Assert at least one decode pod's ``vllm:num_requests_running``
+    dropped to 0 for ``collapse_seconds`` while frontend
+    ``vllm:num_requests_waiting`` (or aiperf-side inflight) remained > 0.
+
+    Signature of the "engine alive but unproductive" mode seen in
+    disagg cascades (engine idle for minutes while sockets pile up).
+
+    Implementation: walk per-pod num_requests_running. Find the longest
+    contiguous run of 0-samples. To require coincident upstream demand,
+    require that *some* frontend num_requests_waiting sample > 0 falls
+    inside the same window.
+    """
+
+    collapse_seconds: float = 30.0
+    require_upstream_demand: bool = True
+
+    def validate(self, ctx) -> None:
+        running: dict = {}
+        for ts_ns, pod, val in _iter_server_metric(ctx, "vllm:num_requests_running"):
+            running.setdefault(pod, []).append((ts_ns, val))
+        waiting_ts = [
+            ts_ns
+            for ts_ns, _pod, val in _iter_server_metric(
+                ctx, "vllm:num_requests_waiting"
+            )
+            if val > 0
+        ]
+        waiting_set = set(waiting_ts)
+        results: dict = {}
+        for pod, series in running.items():
+            series.sort()
+            best_s = 0.0
+            best_window = None
+            cur_start = None
+            cur_last = None
+            cur_has_demand = False
+            for ts_ns, v in series:
+                if v == 0:
+                    if cur_start is None:
+                        cur_start = ts_ns
+                    cur_last = ts_ns
+                    if ts_ns in waiting_set:
+                        cur_has_demand = True
+                else:
+                    if cur_start is not None and cur_last is not None:
+                        dur = (cur_last - cur_start) / 1e9
+                        if dur > best_s and (
+                            not self.require_upstream_demand or cur_has_demand
+                        ):
+                            best_s = dur
+                            best_window = (cur_start, cur_last)
+                    cur_start = None
+                    cur_last = None
+                    cur_has_demand = False
+            if cur_start is not None and cur_last is not None:
+                dur = (cur_last - cur_start) / 1e9
+                if dur > best_s and (
+                    not self.require_upstream_demand or cur_has_demand
+                ):
+                    best_s = dur
+                    best_window = (cur_start, cur_last)
+            results[pod] = (best_s, best_window)
+        ctx.logger.info(
+            f"ThroughputCollapse: per-pod longest 0-running window (s) "
+            f"= { {p: r[0] for p, r in results.items()} }"
+        )
+        winners = [p for p, r in results.items() if r[0] >= self.collapse_seconds]
+        assert winners, (
+            f"ThroughputCollapse: no pod sustained num_requests_running == 0 "
+            f"for >= {self.collapse_seconds}s "
+            f"({'with' if self.require_upstream_demand else 'without'} "
+            f"upstream demand). Longest collapse per pod: "
+            f"{ {p: r[0] for p, r in results.items()} }"
+        )
+
+    @property
+    def description(self) -> str:
+        return (
+            f"At least one decode pod went idle (running=0) for ≥ "
+            f"{self.collapse_seconds}s while frontend had pending work"
+        )
+
+
+@dataclass
+class SlaViolation(Check):
+    """Assert that AIPerf observed at least one SLA breach: e2e
+    request_latency p99 > ``e2e_p99_ms`` OR time_to_first_token p99
+    > ``ttft_p99_ms``. End-user impact signal — the point of driving
+    overload is that someone notices.
+
+    AIPerf 0.7.x summary has flat top-level keys; ``request_latency``
+    and ``time_to_first_token`` are dicts with percentile keys directly
+    (``p50``, ``p99``, ...) holding the value in milliseconds.
+    """
+
+    e2e_p99_ms: float = 30000.0
+    ttft_p99_ms: float = 10000.0
+    load_name: Optional[str] = None
+
+    def validate(self, ctx) -> None:
+        observed: list = []
+        for ldir in _find_load_dirs(ctx):
+            if self.load_name and self.load_name not in _os.path.basename(ldir):
+                continue
+            jpath = _os.path.join(ldir, "profile_export_aiperf.json")
+            if not _os.path.isfile(jpath):
+                continue
+            try:
+                with open(jpath) as fh:
+                    data = _json.load(fh)
+            except (_json.JSONDecodeError, OSError):
+                continue
+            e2e = (data.get("request_latency") or {}).get("p99")
+            ttft = (data.get("time_to_first_token") or {}).get("p99")
+            observed.append((ldir, e2e, ttft))
+        ctx.logger.info(
+            f"SlaViolation: per-run (e2e_p99_ms, ttft_p99_ms) = {observed} "
+            f"thresholds=(e2e>{self.e2e_p99_ms}, ttft>{self.ttft_p99_ms})"
+        )
+        violated = any(
+            (e2e is not None and float(e2e) > self.e2e_p99_ms)
+            or (ttft is not None and float(ttft) > self.ttft_p99_ms)
+            for _, e2e, ttft in observed
+        )
+        assert violated, (
+            f"SlaViolation: no run breached e2e p99 > {self.e2e_p99_ms}ms "
+            f"or TTFT p99 > {self.ttft_p99_ms}ms. Observed: {observed}"
+        )
+
+    @property
+    def description(self) -> str:
+        return (
+            f"At least one run breaches e2e p99 > {self.e2e_p99_ms}ms "
+            f"or TTFT p99 > {self.ttft_p99_ms}ms"
+        )

--- a/tests/fault_tolerance/deploy/checks.py
+++ b/tests/fault_tolerance/deploy/checks.py
@@ -609,22 +609,32 @@ class ServiceLogPatternRate(Check):
 @dataclass
 class KvCacheUsagePeak(Check):
     """Assert at least one pod's ``vllm:kv_cache_usage_perc`` reaches
-    ``threshold`` (e.g. 0.9) within ``within_seconds`` of the pod's
-    server_metrics first-sample timestamp.
+    ``threshold`` within ``within_seconds`` of the **specified load's**
+    first-sample timestamp.
 
-    Used by the R4 replacement-KV-saturation test: after a decode pod is
-    deleted, the replacement pod schedules with a fresh KV pool; if
-    upstream prefill has a queue of pending KV transfers, that pool can
-    saturate (~99%) within minutes of the pod becoming Ready. We assert
-    that exact pattern.
+    ``load_name``: anchor for ``within_seconds``. When set (e.g. "cliff"),
+    the elapsed-time clock starts at the named load's first metric
+    sample for that pod — not the FIRST load's first sample. This is
+    the right semantic for cliff-rung tests where the warmup rung
+    runs first and would otherwise push the cliff KV peak past the
+    ``within_seconds`` ceiling even when the cliff itself pegged in
+    seconds. Per observe-agent NEXT_STEPS_FOR_TEST_AGENT P1.2 (prior
+    sanity-suite-1) — S0b false-failed without this anchor.
+
+    Default behaviour (``load_name=None``) preserves the original
+    R4-replacement-KV semantics: anchor on each pod's first sample
+    across all loads.
     """
 
     services: list
     threshold: float = 0.9
     within_seconds: float = 240.0
+    load_name: Optional[str] = None
 
     def validate(self, ctx) -> None:
         load_dirs = _find_load_dirs(ctx)
+        if self.load_name:
+            load_dirs = [d for d in load_dirs if self.load_name in _os.path.basename(d)]
         observed: dict = {}
         for ldir in load_dirs:
             jsonl = _os.path.join(ldir, "server_metrics_export.jsonl")
@@ -642,33 +652,57 @@ class KvCacheUsagePeak(Check):
                         observed[pod] = {
                             "first_ts_ns": ts_ns,
                             "max": float(val),
-                            "max_ts_ns": ts_ns,
+                            # Time of FIRST crossing of threshold — what
+                            # within_seconds measures against. Stays
+                            # None until threshold is first reached.
+                            "first_cross_ts_ns": (
+                                ts_ns if float(val) >= self.threshold else None
+                            ),
                         }
                     else:
                         observed[pod]["max"] = max(observed[pod]["max"], float(val))
-                        if float(val) >= self.threshold:
-                            observed[pod]["max_ts_ns"] = ts_ns
+                        if (
+                            float(val) >= self.threshold
+                            and observed[pod]["first_cross_ts_ns"] is None
+                        ):
+                            observed[pod]["first_cross_ts_ns"] = ts_ns
 
+        anchor_desc = (
+            f"load '{self.load_name}' start"
+            if self.load_name
+            else "first sample across all loads"
+        )
         ctx.logger.info(
             f"KvCacheUsagePeak: per-pod observations={observed} "
-            f"threshold={self.threshold} within={self.within_seconds}s"
+            f"threshold={self.threshold} within={self.within_seconds}s "
+            f"anchor={anchor_desc}"
         )
+        # Pass condition: at least one pod's FIRST crossing of the
+        # threshold happened within ``within_seconds`` of the anchor's
+        # first sample. The prior implementation tracked the LAST sample
+        # ≥ threshold (effectively the end of the sustained cliff
+        # plateau) → for any sustained cliff, elapsed = full duration →
+        # false-fail. Per observe-agent NEXT_STEPS P1.2-v2 (round 2).
         winners = []
         for pod, rec in observed.items():
-            elapsed_s = (rec["max_ts_ns"] - rec["first_ts_ns"]) / 1e9
-            if rec["max"] >= self.threshold and elapsed_s <= self.within_seconds:
+            if rec["first_cross_ts_ns"] is None:
+                continue
+            elapsed_s = (rec["first_cross_ts_ns"] - rec["first_ts_ns"]) / 1e9
+            if elapsed_s <= self.within_seconds:
                 winners.append((pod, rec["max"], elapsed_s))
         assert winners, (
             f"KvCacheUsagePeak: no pod in {self.services} reached "
             f"kv_cache_usage_perc >= {self.threshold} within "
-            f"{self.within_seconds}s. Observed: {observed}"
+            f"{self.within_seconds}s of {anchor_desc}. Observed: {observed}"
         )
 
     @property
     def description(self) -> str:
+        anchor = f" (within '{self.load_name}')" if self.load_name else ""
         return (
             f"KV cache usage peak ≥ {self.threshold} within "
             f"{self.within_seconds}s on some {', '.join(self.services)} pod"
+            f"{anchor}"
         )
 
 
@@ -697,6 +731,13 @@ class PodMemoryGrowth(Check):
     # (OOMKill-correlated). "pid1_rss" = per-process attribution.
     # Default to working_set since that's the kubelet-side signal.
     source: str = "working_set"
+    # "min": assert ``max_rate >= growth_bytes_per_min`` (leak detection —
+    # original behaviour, used by fault-tolerance leak-shape tests).
+    # "max": assert ``max_rate <= growth_bytes_per_min`` (bounded-growth
+    # assertion — used by memory-stability tests to prove a recommended
+    # config doesn't leak; the field name still says ``growth`` but
+    # functions as a ceiling).
+    assert_mode: str = "min"
 
     def validate(self, ctx) -> None:
         log_dir = getattr(ctx, "log_dir", None)
@@ -758,15 +799,28 @@ class PodMemoryGrowth(Check):
                         max_rate = rate_per_min
                         max_rate_pod = pod
                     break  # take the longest span; faster
+        threshold_label = "floor" if self.assert_mode == "min" else "ceiling"
         ctx.logger.info(
-            f"PodMemoryGrowth: max_rate={max_rate:.0f} bytes/min "
-            f"on pod={max_rate_pod}; floor={self.growth_bytes_per_min}"
+            f"PodMemoryGrowth({self.assert_mode}): max_rate={max_rate:.0f} bytes/min "
+            f"on pod={max_rate_pod}; {threshold_label}={self.growth_bytes_per_min}"
         )
-        assert max_rate >= self.growth_bytes_per_min, (
-            f"PodMemoryGrowth: peak RSS growth {max_rate:.0f}/min < "
-            f"{self.growth_bytes_per_min:.0f}/min floor on services "
-            f"{self.services}"
-        )
+        if self.assert_mode == "min":
+            assert max_rate >= self.growth_bytes_per_min, (
+                f"PodMemoryGrowth: peak RSS growth {max_rate:.0f}/min < "
+                f"{self.growth_bytes_per_min:.0f}/min floor on services "
+                f"{self.services}"
+            )
+        elif self.assert_mode == "max":
+            assert max_rate <= self.growth_bytes_per_min, (
+                f"PodMemoryGrowth: peak RSS growth {max_rate:.0f}/min > "
+                f"{self.growth_bytes_per_min:.0f}/min ceiling on services "
+                f"{self.services} (worst pod: {max_rate_pod})"
+            )
+        else:
+            assert False, (
+                f"PodMemoryGrowth: invalid assert_mode {self.assert_mode!r} "
+                f"(want 'min' or 'max')"
+            )
 
     @property
     def description(self) -> str:
@@ -1069,7 +1123,7 @@ class RestartCountIncreased(Check):
 
 
 # =============================================================================
-# 2026-05-13 decode-overload-disagg repro verifiers
+# decode-overload-disagg repro verifiers
 # =============================================================================
 #
 # Five checks added for the decode-worker overload campaign that reproduces
@@ -1114,10 +1168,19 @@ class LoadApplied(Check):
                     data = _json.load(fh)
             except (_json.JSONDecodeError, OSError):
                 continue
-            # Schema is flat: top-level "request_count": {"unit": ..., "avg": N}.
+            # AIPerf summary schema:
+            #   request_count.avg        — successful requests
+            #   error_request_count.avg  — errored requests (AIPerf 0.8+)
+            # We want the TOTAL requests issued (success + error) — that's
+            # what "did the load actually reach the cluster?" boils down to.
+            # AIPerf 0.7.x omits error_request_count; AIPerf 0.8 omits
+            # request_count when all-error. Sum both nodes so either layout
+            # is counted correctly.
             rc_node = data.get("request_count") or {}
+            ec_node = data.get("error_request_count") or {}
             rc = int(rc_node.get("avg") or rc_node.get("count") or 0)
-            observed.append((ldir, rc))
+            ec = int(ec_node.get("avg") or ec_node.get("count") or 0)
+            observed.append((ldir, rc + ec))
         total = sum(rc for _, rc in observed)
         ctx.logger.info(
             f"LoadApplied: per-load-dir={observed} total={total} "
@@ -1436,3 +1499,616 @@ class SlaViolation(Check):
             f"At least one run breaches e2e p99 > {self.e2e_p99_ms}ms "
             f"or TTFT p99 > {self.ttft_p99_ms}ms"
         )
+
+
+# =============================================================================
+# Cascade-signature checks (prior cascade-repro suite)
+# =============================================================================
+#
+# Each check below reads server_metrics_export.jsonl from one named load
+# rung and asserts one piece of the cascade signature:
+#
+#   1. KvCacheUsagePeak (already above)                — KV peg
+#   2. WaitingForKVTransferExceeds                     — smoking gun (leads collapse ~60s)
+#   3. NixlXferTimeMultiplied                          — transport blow-up
+#   4. GenerationThroughputDropped                     — throughput collapse
+#   5. CliffContained                                  — S0a-only: pin stays on target
+#
+# Full mechanism context lives in the FRAMEWORK_TASK / PLAN docs in
+# dynamo-observe (the cascade-small-pool reproducer scenarios).
+
+
+def _load_dirs_for(ctx, load_name: Optional[str]) -> list:
+    """Like ``_find_load_dirs`` but optionally filters to a single load
+    name (matches the AIPerf load-dir naming convention ``load-<name>-*``).
+    """
+    dirs = _find_load_dirs(ctx)
+    if not load_name:
+        return dirs
+    return [d for d in dirs if load_name in _os.path.basename(d)]
+
+
+def _iter_named_metric(
+    ctx,
+    metric: str,
+    load_name: Optional[str] = None,
+):
+    """Yield ``(ts_ns, pod, val)`` for ``metric`` from the JSONL of one
+    named load (or all loads if ``load_name`` is None).
+
+    Pod identity follows the same convention as ``_iter_server_metric``:
+    prefer ``labels.pod``, fall back to ``<dynamo_component>@<endpoint_url>``
+    so two workers of the same role stay distinguishable when the vLLM
+    surface omits the ``pod`` label.
+    """
+    for ldir in _load_dirs_for(ctx, load_name):
+        jsonl = _os.path.join(ldir, "server_metrics_export.jsonl")
+        for rec in _iter_jsonl(jsonl):
+            ts_ns = rec.get("timestamp_ns")
+            endpoint = rec.get("endpoint_url", "")
+            metrics = rec.get("metrics", {}) or {}
+            samples = metrics.get(metric) or []
+            for s in samples:
+                labels = s.get("labels", {}) or {}
+                pod = labels.get("pod")
+                if not pod:
+                    comp = labels.get("dynamo_component") or ""
+                    pod = f"{comp}@{endpoint}" if comp else endpoint
+                val = s.get("value")
+                if val is None or ts_ns is None:
+                    continue
+                yield int(ts_ns), str(pod), float(val)
+
+
+def _per_pod_timeseries(ctx, metric: str, load_name: Optional[str] = None) -> dict:
+    """Return ``{pod: [(ts_ns, val), ...sorted]}`` for one metric."""
+    series: dict = {}
+    for ts_ns, pod, val in _iter_named_metric(ctx, metric, load_name=load_name):
+        series.setdefault(pod, []).append((ts_ns, val))
+    for pod in series:
+        series[pod].sort()
+    return series
+
+
+def _iter_histogram(ctx, metric: str, load_name: Optional[str] = None):
+    """Yield ``(ts_ns, pod, sum_val, count_val)`` for a Prometheus histogram
+    stored single-key in the server_metrics_export.
+
+    The export schema is:
+      ``metrics[<base_name>] = [{"labels": {...}, "buckets": {...},
+                                 "sum": <float>, "count": <float>}, ...]``
+
+    NOT the on-the-wire Prometheus form with ``_sum`` / ``_count`` suffix
+    keys — the Dynamo metric exporter writes a single key carrying both
+    sum and count fields per sample. Use this iterator for histograms;
+    use ``_iter_named_metric`` for counters/gauges with a ``value`` field.
+    """
+    for ldir in _load_dirs_for(ctx, load_name):
+        jsonl = _os.path.join(ldir, "server_metrics_export.jsonl")
+        for rec in _iter_jsonl(jsonl):
+            ts_ns = rec.get("timestamp_ns")
+            endpoint = rec.get("endpoint_url", "")
+            metrics = rec.get("metrics", {}) or {}
+            samples = metrics.get(metric) or []
+            for s in samples:
+                if not isinstance(s, dict):
+                    continue
+                if "sum" not in s or "count" not in s:
+                    continue
+                labels = s.get("labels", {}) or {}
+                pod = labels.get("pod")
+                if not pod:
+                    comp = labels.get("dynamo_component") or ""
+                    pod = f"{comp}@{endpoint}" if comp else endpoint
+                try:
+                    sum_val = float(s["sum"])
+                    count_val = float(s["count"])
+                except (TypeError, ValueError):
+                    continue
+                if ts_ns is None:
+                    continue
+                yield int(ts_ns), str(pod), sum_val, count_val
+
+
+def _window_average_histogram(
+    ctx,
+    metric: str,
+    load_name: Optional[str],
+    window_start_s: float,
+    window_end_s: Optional[float],
+) -> dict:
+    """Per-pod average of a Prometheus histogram (sum / count delta) over
+    a wall-clock window measured from the first sample of the named load.
+    ``window_end_s=None`` means "to end of load".
+
+    Returns ``{pod: avg_seconds}`` for pods that recorded ≥ 2 samples in
+    the window with non-zero count delta. Pods without enough data are
+    omitted, not zero-defaulted, so the caller can decide policy.
+
+    Reads via ``_iter_histogram`` which expects the single-key histogram
+    schema (``{labels, buckets, sum, count}`` per sample under one
+    metric key). The on-the-wire ``_sum`` / ``_count`` split that
+    Prometheus uses is NOT how Dynamo's exporter writes JSONL.
+    """
+    series: dict = {}
+    for ts_ns, pod, sum_val, count_val in _iter_histogram(
+        ctx, metric, load_name=load_name
+    ):
+        series.setdefault(pod, []).append((ts_ns, sum_val, count_val))
+    for pod in series:
+        series[pod].sort()
+
+    out: dict = {}
+    for pod, samples in series.items():
+        if not samples:
+            continue
+        t0 = samples[0][0]
+        win_lo = t0 + int(window_start_s * 1e9)
+        win_hi = t0 + int(window_end_s * 1e9) if window_end_s is not None else None
+        lo = hi = None
+        for ts, sm, cnt in samples:
+            if ts < win_lo:
+                continue
+            if win_hi is not None and ts > win_hi:
+                break
+            if lo is None:
+                lo = (sm, cnt)
+            hi = (sm, cnt)
+        if lo is None or hi is None:
+            continue
+        d_sum = hi[0] - lo[0]
+        d_cnt = hi[1] - lo[1]
+        if d_cnt <= 0:
+            continue
+        out[pod] = d_sum / d_cnt
+    return out
+
+
+def _counter_rate(
+    ctx,
+    metric: str,
+    load_name: Optional[str],
+    window_start_s: float,
+    window_end_s: Optional[float],
+) -> float:
+    """Aggregate per-second rate of a counter across all pods over the
+    named load's wall-clock window. Returns 0.0 if no data.
+    """
+    per_pod = _per_pod_timeseries(ctx, metric, load_name=load_name)
+    total_delta = 0.0
+    total_span_s = 0.0
+    for pod, series in per_pod.items():
+        if len(series) < 2:
+            continue
+        t0 = series[0][0]
+        lo = t0 + int(window_start_s * 1e9)
+        hi = t0 + int(window_end_s * 1e9) if window_end_s is not None else None
+        clipped = [(ts, v) for ts, v in series if ts >= lo and (hi is None or ts <= hi)]
+        if len(clipped) < 2:
+            continue
+        d_val = clipped[-1][1] - clipped[0][1]
+        d_t = (clipped[-1][0] - clipped[0][0]) / 1e9
+        if d_t <= 0:
+            continue
+        total_delta += max(0.0, d_val)
+        total_span_s = max(total_span_s, d_t)
+    if total_span_s <= 0:
+        return 0.0
+    return total_delta / total_span_s
+
+
+@dataclass
+class WaitingForKVTransferExceeds(Check):
+    """Assert the derived gauge ``inflight − running − waiting`` exceeds
+    ``threshold`` on at least one decode pod during the named load.
+
+    This is the **smoking-gun** cascade signal — it climbs from baseline
+    single-digits to hundreds-or-thousands ~60s before throughput
+    collapse, so it leads every other signature metric.
+    """
+
+    services: list
+    threshold: int = 100
+    load_name: Optional[str] = "default"
+
+    def validate(self, ctx) -> None:
+        # Join three metrics on (pod, ts_ns). Each JSONL record carries
+        # all three at the same timestamp, so per-record arithmetic
+        # works without alignment heuristics.
+        per_pod_max: dict = {}
+        for ldir in _load_dirs_for(ctx, self.load_name):
+            jsonl = _os.path.join(ldir, "server_metrics_export.jsonl")
+            for rec in _iter_jsonl(jsonl):
+                metrics = rec.get("metrics", {}) or {}
+                inflight = metrics.get("dynamo_component_inflight_requests") or []
+                running = metrics.get("vllm:num_requests_running") or []
+                waiting = metrics.get("vllm:num_requests_waiting") or []
+
+                # Index by pod for this record. ``dynamo_component_inflight_requests``
+                # has one sample per (component × ``dynamo_endpoint``) — for a
+                # single prefill worker that's ``generate`` + ``clear_kv_blocks``
+                # + ``get_perf_metrics`` (3 samples), all with the same
+                # dynamo_component label. Sum across those sub-dimensions to
+                # produce one value per pod (non-``generate`` endpoints are
+                # always 0 in practice so sum equals the ``generate``-only value).
+                def _by_pod(samples):
+                    out = {}
+                    for s in samples:
+                        labels = s.get("labels", {}) or {}
+                        pod = labels.get("pod") or (
+                            (labels.get("dynamo_component") or "")
+                            + "@"
+                            + rec.get("endpoint_url", "")
+                        )
+                        v = s.get("value")
+                        if v is not None:
+                            out[pod] = out.get(pod, 0.0) + float(v)
+                    return out
+
+                infl_by_pod = _by_pod(inflight)
+                run_by_pod = _by_pod(running)
+                wait_by_pod = _by_pod(waiting)
+                # Compute derived for every pod that has all three
+                for pod in infl_by_pod.keys() & run_by_pod.keys() & wait_by_pod.keys():
+                    derived = infl_by_pod[pod] - run_by_pod[pod] - wait_by_pod[pod]
+                    cur = per_pod_max.get(pod, float("-inf"))
+                    if derived > cur:
+                        per_pod_max[pod] = derived
+
+        winners = {p: v for p, v in per_pod_max.items() if v >= self.threshold}
+        ctx.logger.info(
+            f"WaitingForKVTransferExceeds: per-pod max={per_pod_max} "
+            f"winners={winners} threshold={self.threshold}"
+        )
+        assert winners, (
+            f"WaitingForKVTransferExceeds: no pod reached "
+            f"derived (inflight − running − waiting) ≥ {self.threshold} "
+            f"during load {self.load_name!r}; observed per-pod max: {per_pod_max}"
+        )
+
+    @property
+    def description(self) -> str:
+        return (
+            f"WaitingForKVTransfer derived gauge ≥ {self.threshold} on some "
+            f"{','.join(self.services)} pod during {self.load_name!r}"
+        )
+
+
+@dataclass
+class NixlXferTimeMultiplied(Check):
+    """Assert ``vllm:nixl_xfer_time_seconds`` per-handle average climbs
+    by ≥ ``min_multiplier``× from the warmup window to the cliff window,
+    on at least one pod.
+
+    Healthy ~50ms → cliff ~250ms+ → 5×; sanity tests run with 3× because
+    the compressed warmup window is shorter and noisier.
+    """
+
+    services: list
+    min_multiplier: float = 5.0
+    warmup_seconds: float = 300.0
+    cliff_load_name: Optional[str] = "default"
+
+    def validate(self, ctx) -> None:
+        warmup_avg = _window_average_histogram(
+            ctx,
+            "vllm:nixl_xfer_time_seconds",
+            self.cliff_load_name,
+            window_start_s=0.0,
+            window_end_s=self.warmup_seconds,
+        )
+        cliff_avg = _window_average_histogram(
+            ctx,
+            "vllm:nixl_xfer_time_seconds",
+            self.cliff_load_name,
+            window_start_s=self.warmup_seconds,
+            window_end_s=None,
+        )
+        max_ratio = 0.0
+        per_pod_ratio: dict = {}
+        for pod, w in warmup_avg.items():
+            c = cliff_avg.get(pod)
+            if c is None or w <= 0:
+                continue
+            ratio = c / w
+            per_pod_ratio[pod] = ratio
+            if ratio > max_ratio:
+                max_ratio = ratio
+        ctx.logger.info(
+            f"NixlXferTimeMultiplied: warmup_avg={warmup_avg} cliff_avg={cliff_avg} "
+            f"per_pod_ratio={per_pod_ratio} max_ratio={max_ratio:.2f}× "
+            f"threshold={self.min_multiplier:.2f}×"
+        )
+        assert max_ratio >= self.min_multiplier, (
+            f"NixlXferTimeMultiplied: max per-pod ratio {max_ratio:.2f}× < "
+            f"required {self.min_multiplier:.2f}× on load {self.cliff_load_name!r}; "
+            f"per-pod ratios: {per_pod_ratio}"
+        )
+
+    @property
+    def description(self) -> str:
+        return (
+            f"NIXL xfer_time avg grows ≥ {self.min_multiplier}× on some "
+            f"{','.join(self.services)} pod during {self.cliff_load_name!r}"
+        )
+
+
+@dataclass
+class GenerationThroughputDropped(Check):
+    """Assert ``vllm:generation_tokens`` aggregate rate drops by
+    ≥ ``min_drop_frac`` from the warmup window to the last
+    ``cliff_window_seconds`` of the named load.
+    """
+
+    services: list
+    min_drop_frac: float = 0.30
+    warmup_seconds: float = 300.0
+    cliff_window_seconds: float = 300.0
+    cliff_load_name: Optional[str] = "default"
+
+    def validate(self, ctx) -> None:
+        # Find the total load span to compute "last N seconds" window.
+        per_pod = _per_pod_timeseries(
+            ctx, "vllm:generation_tokens", load_name=self.cliff_load_name
+        )
+        if not per_pod:
+            assert False, (
+                f"GenerationThroughputDropped: no samples for "
+                f"vllm:generation_tokens on load {self.cliff_load_name!r}"
+            )
+        # Earliest first-sample and latest last-sample across pods.
+        first_ts = min(s[0][0] for s in per_pod.values() if s)
+        last_ts = max(s[-1][0] for s in per_pod.values() if s)
+        total_span_s = (last_ts - first_ts) / 1e9
+
+        warmup_rate = _counter_rate(
+            ctx,
+            "vllm:generation_tokens",
+            self.cliff_load_name,
+            window_start_s=0.0,
+            window_end_s=self.warmup_seconds,
+        )
+        cliff_start = max(self.warmup_seconds, total_span_s - self.cliff_window_seconds)
+        cliff_rate = _counter_rate(
+            ctx,
+            "vllm:generation_tokens",
+            self.cliff_load_name,
+            window_start_s=cliff_start,
+            window_end_s=None,
+        )
+        drop_frac = (warmup_rate - cliff_rate) / warmup_rate if warmup_rate > 0 else 0.0
+        ctx.logger.info(
+            f"GenerationThroughputDropped: warmup_rate={warmup_rate:.1f} tok/s "
+            f"cliff_rate={cliff_rate:.1f} tok/s drop={drop_frac:.1%} "
+            f"threshold={self.min_drop_frac:.0%} span={total_span_s:.0f}s"
+        )
+        assert drop_frac >= self.min_drop_frac, (
+            f"GenerationThroughputDropped: only {drop_frac:.1%} drop "
+            f"(warmup {warmup_rate:.1f} → cliff {cliff_rate:.1f} tok/s); "
+            f"required ≥ {self.min_drop_frac:.0%}"
+        )
+
+    @property
+    def description(self) -> str:
+        return (
+            f"Generation throughput drops ≥ {self.min_drop_frac:.0%} on "
+            f"load {self.cliff_load_name!r}"
+        )
+
+
+@dataclass
+class CliffPropagated(Check):
+    """Assert the cliff spreads to ≥ ``min_pods`` decode pods.
+
+    Counterpart to ``CliffContained``: where containment asserts the
+    pinned target alone hit the cliff, propagation asserts that under
+    natural LeastLoaded routing the cliff peer-infects multiple decodes
+    within the load window — the signature of the cross-FE blind spot.
+
+    Reads ``vllm:kv_cache_usage_perc`` per pod and counts pods whose
+    peak reached ``kv_threshold`` during the named load.
+    """
+
+    services: list
+    min_pods: int = 2
+    kv_threshold: float = 0.85
+    load_name: Optional[str] = "default"
+
+    def validate(self, ctx) -> None:
+        per_pod_max: dict = {}
+        for _ts, pod, val in _iter_named_metric(
+            ctx, "vllm:kv_cache_usage_perc", load_name=self.load_name
+        ):
+            cur = per_pod_max.get(pod, float("-inf"))
+            if val > cur:
+                per_pod_max[pod] = val
+        saturated = [p for p, v in per_pod_max.items() if v >= self.kv_threshold]
+        ctx.logger.info(
+            f"CliffPropagated: per_pod_max={per_pod_max} "
+            f"saturated_pods={saturated} min_pods={self.min_pods} "
+            f"kv_threshold={self.kv_threshold}"
+        )
+        assert len(saturated) >= self.min_pods, (
+            f"CliffPropagated: only {len(saturated)} pods reached KV ≥ "
+            f"{self.kv_threshold}; required ≥ {self.min_pods}. "
+            f"Per-pod max: {per_pod_max}"
+        )
+
+    @property
+    def description(self) -> str:
+        return (
+            f"≥ {self.min_pods} pods reach KV ≥ {self.kv_threshold} "
+            f"during {self.load_name!r}"
+        )
+
+
+@dataclass
+class CliffContained(Check):
+    """Assert the cliff stays on the nvext-pinned target replica during
+    the named load.
+
+    Looks up the pod for ``(pinned_service, pinned_replica_index)`` via
+    the same name-sorted ordering used by
+    ``ManagedDeployment.get_instance_id``, then asserts:
+      - the pinned pod's max KV ≥ ``kv_threshold``
+      - every other pod in ``services`` stays ≤ ``peer_max_kv``
+
+    Proves the WorkerPin flow actually concentrated load on the intended
+    pod (no leakage from FE fallback / non-honored nvext).
+    """
+
+    services: list
+    pinned_service: str
+    pinned_replica_index: int
+    kv_threshold: float = 0.85
+    peer_max_kv: float = 0.50
+    load_name: Optional[str] = "default"
+
+    def validate(self, ctx) -> None:
+        # Resolve the pinned pod name the same way get_instance_id does:
+        # sort by name, pick replica_index. Use only the pinned_service's
+        # pods — the cliff metric is per-pod, so we identify the pinned
+        # one by its pod name suffix appearing in the metric's pod label.
+        pods_by_svc = ctx.deployment.get_pods([self.pinned_service])
+        pods = pods_by_svc.get(self.pinned_service) or []
+        if not pods:
+            assert False, f"CliffContained: no pods for {self.pinned_service!r}"
+        pods_sorted = sorted(pods, key=lambda p: p.name)
+        if self.pinned_replica_index >= len(pods_sorted):
+            assert False, (
+                f"CliffContained: pinned_replica_index="
+                f"{self.pinned_replica_index} >= {len(pods_sorted)} pods"
+            )
+        pinned_pod_name = pods_sorted[self.pinned_replica_index].name
+
+        # Compute per-pod max KV from the metric stream. The metric's
+        # pod label sometimes carries the full pod name; sometimes it's
+        # `decode@<endpoint>`. Match the pinned name as a substring to
+        # cover both cases.
+        per_pod_max: dict = {}
+        for _ts, pod, val in _iter_named_metric(
+            ctx, "vllm:kv_cache_usage_perc", load_name=self.load_name
+        ):
+            cur = per_pod_max.get(pod, float("-inf"))
+            if val > cur:
+                per_pod_max[pod] = val
+
+        target_pods = [p for p in per_pod_max if pinned_pod_name in p]
+        target_hit = any(per_pod_max[p] >= self.kv_threshold for p in target_pods)
+        peer_violations = [
+            (p, v)
+            for p, v in per_pod_max.items()
+            if (pinned_pod_name not in p) and v > self.peer_max_kv
+        ]
+
+        ctx.logger.info(
+            f"CliffContained: pinned_pod={pinned_pod_name!r} "
+            f"target_pods_in_metrics={target_pods} per_pod_max={per_pod_max} "
+            f"target_hit={target_hit} peer_violations={peer_violations}"
+        )
+        assert target_hit, (
+            f"CliffContained: pinned pod {pinned_pod_name!r} did not reach "
+            f"KV ≥ {self.kv_threshold} (max per pod: {per_pod_max})"
+        )
+        assert not peer_violations, (
+            f"CliffContained: peer pod(s) exceeded peer_max_kv "
+            f"{self.peer_max_kv} — {peer_violations}. Pinning leaked."
+        )
+
+    @property
+    def description(self) -> str:
+        return (
+            f"Cliff stays on {self.pinned_service}#{self.pinned_replica_index} "
+            f"(KV ≥ {self.kv_threshold}); peers ≤ {self.peer_max_kv}"
+        )
+
+
+@dataclass
+class PinningContained(Check):
+    """Assert request-routing pinning kept the load on one replica only.
+
+    Generalization of ``CliffContained`` for arbitrary activity metrics
+    (not just KV pressure). Resolves the pinned pod the same way —
+    name-sorted, ``replica_index``-th — then asserts:
+
+      - peak(``metric``) on the pinned pod ≥ ``active_threshold``
+        (proves the pinned pod actually saw traffic)
+      - peak(``metric``) on every other pod of ``pinned_service``
+        ≤ ``peer_max`` (proves nvext.worker_id actually concentrated
+        the load, no leakage via FE fallback or non-honored nvext)
+
+    For prefill containment use ``vllm:num_requests_running`` —
+    a running > 0 anywhere on a prefill replica is proof it served
+    at least one prefill, so an idle peer's peak is genuinely 0.
+    """
+
+    services: list
+    pinned_service: str
+    pinned_replica_index: int
+    metric: str = "vllm:num_requests_running"
+    active_threshold: float = 1.0
+    peer_max: float = 0.0
+    load_name: Optional[str] = "default"
+
+    def validate(self, ctx) -> None:
+        pods_by_svc = ctx.deployment.get_pods([self.pinned_service])
+        pods = pods_by_svc.get(self.pinned_service) or []
+        if not pods:
+            assert False, f"PinningContained: no pods for {self.pinned_service!r}"
+        pods_sorted = sorted(pods, key=lambda p: p.name)
+        if self.pinned_replica_index >= len(pods_sorted):
+            assert False, (
+                f"PinningContained: pinned_replica_index="
+                f"{self.pinned_replica_index} >= {len(pods_sorted)} pods"
+            )
+        pinned_pod_name = pods_sorted[self.pinned_replica_index].name
+
+        per_pod_peak: dict = {}
+        for _ts, pod, val in _iter_named_metric(
+            ctx, self.metric, load_name=self.load_name
+        ):
+            cur = per_pod_peak.get(pod, float("-inf"))
+            if val > cur:
+                per_pod_peak[pod] = val
+
+        target_pods = [p for p in per_pod_peak if pinned_pod_name in p]
+        peer_pods = {p: v for p, v in per_pod_peak.items() if pinned_pod_name not in p}
+        target_active = any(
+            per_pod_peak[p] >= self.active_threshold for p in target_pods
+        )
+        peer_violations = [(p, v) for p, v in peer_pods.items() if v > self.peer_max]
+        ctx.logger.info(
+            f"PinningContained({self.metric}): pinned_pod={pinned_pod_name!r} "
+            f"per_pod_peak={per_pod_peak} active_threshold={self.active_threshold} "
+            f"peer_max={self.peer_max} target_active={target_active} "
+            f"peer_violations={peer_violations}"
+        )
+        assert target_active, (
+            f"PinningContained: pinned pod {pinned_pod_name!r} never reached "
+            f"{self.metric} ≥ {self.active_threshold} — pinning hit a dead "
+            f"replica or AIPerf isn't scraping it (peaks: {per_pod_peak})"
+        )
+        assert not peer_violations, (
+            f"PinningContained: peer pod(s) saw {self.metric} > "
+            f"{self.peer_max} — pinning leaked. Violations: {peer_violations}"
+        )
+
+    @property
+    def description(self) -> str:
+        return (
+            f"{self.metric} concentrated on "
+            f"{self.pinned_service}#{self.pinned_replica_index} "
+            f"(≥ {self.active_threshold}); peers ≤ {self.peer_max}"
+        )
+
+
+from tests.fault_tolerance.deploy._checks_rejection import (  # noqa: E402, F401
+    RejectionFired,
+)
+
+# Re-export sub-module check classes so they're visible to the auto-discovered
+# Check registry in scenario_lib/_runtime.py (which walks Check.__subclasses__()
+# after importing this module).
+from tests.fault_tolerance.deploy._checks_workload_shape import (  # noqa: E402, F401
+    WorkloadShapeVerified,
+)

--- a/tests/fault_tolerance/deploy/checks.py
+++ b/tests/fault_tolerance/deploy/checks.py
@@ -708,25 +708,24 @@ class KvCacheUsagePeak(Check):
 
 @dataclass
 class PodMemoryGrowth(Check):
-    """Assert at least one pod's ``/proc/1/status:VmRSS`` grows by
-    ``growth_bytes_per_min`` over a ``window_seconds`` window during the
-    scenario.
+    """Assert per-pod memory growth (or boundedness) over the scenario,
+    from the ``ResourcePoller`` per-pod TSVs.
 
-    Implementation: a background asyncio task started by the check at
-    scenario-start exec's `cat /proc/1/status` on each pod every
-    ``poll_interval_s``, parses VmRSS, and writes a TSV to
-    ``ctx.log_dir/pod_memory_growth.tsv``. validate() reads the TSV.
+    Implementation: ``validate()`` reads ResourcePoller's native
+    ``<log_dir>/<role>/<pod>.resources.agg.tsv`` files, picks the
+    ``working_set`` (kubelet cgroup) or ``pid1_rss`` column per
+    ``source``, and computes the max sliding-window growth rate over
+    ``window_seconds``. ``assert_mode`` ("min"/"max") decides whether
+    that rate must exceed (leak detection) or stay under (bounded-growth)
+    ``growth_bytes_per_min``.
 
-    The background-task plumbing is in the test file (StartLoad event
-    can't host it cleanly); this check class is the assertion only.
-    Tests that need it install a ``MemoryPoller`` event into the
-    scenario events list before calling run_scenario.
+    Requires a ``ResourcePoller`` event in the scenario before the load
+    rungs so the per-pod TSVs exist at validate time.
     """
 
     services: list
     growth_bytes_per_min: float = 1_000_000_000.0
     window_seconds: float = 600.0
-    tsv_filename: str = "pod_memory_growth.tsv"
     # Which column to assert on. "working_set" = kubelet cgroup view
     # (OOMKill-correlated). "pid1_rss" = per-process attribution.
     # Default to working_set since that's the kubelet-side signal.

--- a/tests/fault_tolerance/deploy/checks.py
+++ b/tests/fault_tolerance/deploy/checks.py
@@ -741,47 +741,55 @@ class PodMemoryGrowth(Check):
 
     def validate(self, ctx) -> None:
         log_dir = getattr(ctx, "log_dir", None)
-        path = _os.path.join(log_dir, self.tsv_filename) if log_dir else None
-        if not path or not _os.path.isfile(path):
-            assert False, (
-                f"PodMemoryGrowth: {self.tsv_filename} not found at "
-                f"{path!r}; the test must install a MemoryPoller event "
-                f"before running the scenario."
+        # Read ResourcePoller's native per-pod TSVs directly:
+        #   <log_dir>/<role>/<pod>.resources.agg.tsv
+        # columns: epoch_s, pod, working_set, cgroup_current, all_pids_rss,
+        #   pid1_rss, gpu_idx, gpu_util, gpu_mem_used, gpu_mem_total
+        # ``source`` ("working_set"|"pid1_rss") picks the column; the per-GPU rows
+        # (one per device per tick) are deduped by epoch. The role dir is
+        # lower-case ("vllmdecodeworker") so services match case-insensitively.
+        files = (
+            sorted(
+                _glob(_os.path.join(_glob_escape(log_dir), "*", "*.resources.agg.tsv"))
             )
-        # TSV columns:
-        #   v3 (current, 6 fields): epoch_s, svc, pod, container,
-        #       working_set_bytes, pid1_rss_bytes
-        #   v2 (5 fields): epoch_s, svc, pod, container, working_set_bytes
-        #   v1 (4 fields): epoch_s, svc, pod, vm_rss_kb (legacy)
-        # self.source ("working_set"|"pid1_rss") picks the column.
+            if log_dir
+            else []
+        )
+        assert files, (
+            f"PodMemoryGrowth: no *.resources.agg.tsv found under {log_dir!r}; "
+            f"the test must install a ResourcePoller event before the scenario."
+        )
+        col = "pid1_rss" if self.source == "pid1_rss" else "working_set"
+        want_svcs = {s.lower() for s in self.services}
         per_pod = {}
-        with open(path) as fh:
-            for line in fh:
-                parts = line.strip().split("\t")
-                if not parts or parts[0] == "epoch_s":
-                    continue
-                try:
-                    t = float(parts[0])
-                    svc = parts[1]
-                    pod = parts[2]
-                    if len(parts) >= 6:
-                        bytes_ = float(
-                            parts[5] if self.source == "pid1_rss" else parts[4]
-                        )
-                    elif len(parts) >= 5:
-                        bytes_ = float(parts[4])
-                    elif len(parts) >= 4:
-                        bytes_ = float(parts[3]) * 1024.0
-                    else:
+        for f in files:
+            svc = _os.path.basename(_os.path.dirname(f))
+            if svc.lower() not in want_svcs:
+                continue
+            header = None
+            seen = set()
+            with open(f) as fh:
+                for line in fh:
+                    line = line.rstrip("\n")
+                    if not line or line.startswith("#"):
                         continue
-                except ValueError:
-                    continue
-                # Case-insensitive: ResourcePoller's synthesized pod_memory_growth.tsv
-                # uses the lower-case role dir name (e.g. "vllmdecodeworker") while
-                # scenarios list services in CamelCase ("VllmDecodeWorker").
-                if svc.lower() not in {s.lower() for s in self.services}:
-                    continue
-                per_pod.setdefault(pod, []).append((t, bytes_))
+                    cells = line.split("\t")
+                    if header is None and cells[:1] == ["epoch_s"]:
+                        header = cells
+                        continue
+                    if header is None:
+                        continue
+                    row = dict(zip(header, cells))
+                    ep = row.get("epoch_s", "")
+                    if ep in seen:  # dedup the per-GPU rows of one tick
+                        continue
+                    seen.add(ep)
+                    try:
+                        t = float(ep)
+                        bytes_ = float(row.get(col, "-1"))
+                    except ValueError:
+                        continue
+                    per_pod.setdefault(row.get("pod", ""), []).append((t, bytes_))
 
         max_rate_pod = None
         max_rate = 0.0

--- a/tests/fault_tolerance/deploy/checks.py
+++ b/tests/fault_tolerance/deploy/checks.py
@@ -776,7 +776,10 @@ class PodMemoryGrowth(Check):
                         continue
                 except ValueError:
                     continue
-                if svc not in self.services:
+                # Case-insensitive: ResourcePoller's synthesized pod_memory_growth.tsv
+                # uses the lower-case role dir name (e.g. "vllmdecodeworker") while
+                # scenarios list services in CamelCase ("VllmDecodeWorker").
+                if svc.lower() not in {s.lower() for s in self.services}:
                     continue
                 per_pod.setdefault(pod, []).append((t, bytes_))
 

--- a/tests/fault_tolerance/deploy/client.py
+++ b/tests/fault_tolerance/deploy/client.py
@@ -13,6 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# DEPRECATED: This module is part of the legacy test framework.
+# New tests should use the event-based framework in test_deployment_scenario.py.
+# See tests/fault_tolerance/deploy/TESTING.md for the reference guide.
+
 """AI-Perf client implementation for fault tolerance testing."""
 
 import json

--- a/tests/fault_tolerance/deploy/client_factory.py
+++ b/tests/fault_tolerance/deploy/client_factory.py
@@ -13,6 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# DEPRECATED: This module is part of the legacy test framework.
+# New tests should use the event-based framework in test_deployment_scenario.py.
+# See tests/fault_tolerance/deploy/TESTING.md for the reference guide.
+
 """Factory module for selecting client implementation (legacy or AI-Perf)."""
 
 from typing import Callable

--- a/tests/fault_tolerance/deploy/conftest.py
+++ b/tests/fault_tolerance/deploy/conftest.py
@@ -35,6 +35,20 @@ def pytest_addoption(parser):
         help="Include tests that require custom builds (e.g., MoE models). "
         "By default, these tests are excluded.",
     )
+    parser.addoption(
+        "--storage-class",
+        type=str,
+        default=None,
+        help="Storage class for PVC log collection (must support RWX). "
+        "If not specified, uses cluster default.",
+    )
+    parser.addoption(
+        "--restart-services",
+        action="store_true",
+        default=False,
+        help="Restart NATS and etcd before each test. "
+        "Default is to skip restart (faster iteration).",
+    )
 
 
 def pytest_generate_tests(metafunc):
@@ -117,12 +131,19 @@ def client_type(request):
 def skip_service_restart(request):
     """Whether to skip restarting NATS and etcd services.
 
-    Fault tolerance tests default to RESTARTING services (for clean state).
-    The --skip-service-restart flag can override this behavior.
-
-    Returns:
-        If --skip-service-restart is passed: True (skip restart)
-        If flag not passed: False (FT tests restart by default)
+    Default: True (skip restart — services are assumed to be running).
+    Pass --restart-services to opt in to a clean-state restart.
+    The legacy --skip-service-restart flag is still honored if explicitly set.
     """
-    value = request.config.getoption("--skip-service-restart")
-    return value if value is not None else False  # Default: restart for FT tests
+    if request.config.getoption("--restart-services", default=False):
+        return False  # don't skip = do restart
+    skip = request.config.getoption("--skip-service-restart", default=None)
+    if skip is not None:
+        return skip
+    return True  # default: skip restart
+
+
+@pytest.fixture
+def storage_class(request):
+    """Storage class for PVC log collection (must support RWX)."""
+    return request.config.getoption("--storage-class")

--- a/tests/fault_tolerance/deploy/conftest.py
+++ b/tests/fault_tolerance/deploy/conftest.py
@@ -13,9 +13,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 import pytest
 
 from tests.fault_tolerance.deploy.scenarios import scenarios
+
+
+@pytest.fixture(autouse=True)
+def _route_outputs_to_repo(monkeypatch):
+    """Route this dir's tests' outputs to ``<cwd>/test_outputs/<test>/``.
+
+    The shared ``resolve_test_output_path`` defaults to
+    ``/tmp/dynamo_tests/`` to keep outputs out of the git tree, which is
+    fine when pytest runs on the host. Inside a dev container with the
+    worktree mounted at ``/workspace``, ``/tmp`` is container-local and
+    artifacts disappear from the host. We narrow the override to this
+    conftest so non-k8s tests on the host keep their existing default,
+    and k8s tests get one host-visible per-test directory holding load,
+    services, pod yaml, test.log.txt, and the report together.
+
+    The user-set ``DYN_TEST_OUTPUT_PATH`` always wins (we use
+    ``setdefault`` semantics via the ``not in`` guard).
+    """
+    if "DYN_TEST_OUTPUT_PATH" not in os.environ:
+        monkeypatch.setenv(
+            "DYN_TEST_OUTPUT_PATH",
+            os.path.join(os.getcwd(), "test_outputs"),
+        )
+    yield
 
 
 # Shared CLI options (--image, --namespace, --skip-service-restart) are defined in tests/conftest.py.

--- a/tests/fault_tolerance/deploy/conftest.py
+++ b/tests/fault_tolerance/deploy/conftest.py
@@ -69,6 +69,28 @@ def pytest_addoption(parser):
         "If not specified, uses cluster default.",
     )
     parser.addoption(
+        "--log-pvc",
+        type=str,
+        default=None,
+        help="Reuse an existing RWX PVC for log collection instead of "
+        "creating a fresh one. Skips both creation and cleanup. Useful "
+        "on clusters where PVC provisioning is slow (e.g. AWS FSx "
+        "takes ~7 min). The PVC must already exist in the test "
+        "namespace and be RWX. Logs accumulate across runs — clean "
+        "manually if needed.",
+    )
+    parser.addoption(
+        "--model-pvc",
+        type=str,
+        default=None,
+        help="Reuse an existing RWX PVC as the HuggingFace model cache "
+        "(mounted at /model-cache, exported as HF_HOME on workers). "
+        "Skips re-downloading large model weights between runs. The "
+        "PVC must already exist in the test namespace and be RWX. "
+        "Many shared clusters auto-provision a 'shared-model-cache' "
+        "PVC per namespace.",
+    )
+    parser.addoption(
         "--restart-services",
         action="store_true",
         default=False,
@@ -173,3 +195,15 @@ def skip_service_restart(request):
 def storage_class(request):
     """Storage class for PVC log collection (must support RWX)."""
     return request.config.getoption("--storage-class")
+
+
+@pytest.fixture
+def log_pvc(request):
+    """Existing RWX PVC name to reuse for log collection (skips create/delete)."""
+    return request.config.getoption("--log-pvc")
+
+
+@pytest.fixture
+def model_pvc(request):
+    """Existing RWX PVC name to reuse as the HF model cache (mounted on workers)."""
+    return request.config.getoption("--model-pvc")

--- a/tests/fault_tolerance/deploy/conftest.py
+++ b/tests/fault_tolerance/deploy/conftest.py
@@ -20,9 +20,19 @@ import pytest
 from tests.fault_tolerance.deploy.scenarios import scenarios
 
 
-@pytest.fixture(autouse=True)
-def _route_outputs_to_repo(monkeypatch):
+def pytest_configure(config):
     """Route this dir's tests' outputs to ``<cwd>/test_outputs/<test>/``.
+
+    Implemented as a ``pytest_configure`` hook (not an autouse fixture)
+    so the env var is set BEFORE any fixture runs — in particular before
+    the root ``tests/conftest.py``'s autouse ``logger`` fixture opens
+    its ``test.log.txt`` FileHandler. With a same-stage fixture, the
+    root fixture fires first, sees ``DYN_TEST_OUTPUT_PATH`` unset, and
+    points the FileHandler at the default ``/tmp/dynamo_tests/`` —
+    while everything inside the test body (scenario log_dir, reports)
+    correctly resolves under ``test_outputs/`` because the env var is
+    set by then. Net effect of the old fixture: ``test.log.txt``
+    ends up in a different directory from the rest of the run.
 
     The shared ``resolve_test_output_path`` defaults to
     ``/tmp/dynamo_tests/`` to keep outputs out of the git tree, which is
@@ -33,15 +43,172 @@ def _route_outputs_to_repo(monkeypatch):
     and k8s tests get one host-visible per-test directory holding load,
     services, pod yaml, test.log.txt, and the report together.
 
-    The user-set ``DYN_TEST_OUTPUT_PATH`` always wins (we use
-    ``setdefault`` semantics via the ``not in`` guard).
+    The user-set ``DYN_TEST_OUTPUT_PATH`` always wins.
     """
     if "DYN_TEST_OUTPUT_PATH" not in os.environ:
-        monkeypatch.setenv(
-            "DYN_TEST_OUTPUT_PATH",
-            os.path.join(os.getcwd(), "test_outputs"),
-        )
+        os.environ["DYN_TEST_OUTPUT_PATH"] = os.path.join(os.getcwd(), "test_outputs")
+
+
+@pytest.fixture(autouse=True)
+def _refresh_kubeconfig_if_requested():
+    """Refresh the in-container kubeconfig before each test if requested.
+
+    Gated on ``DYN_TEST_REFRESH_KUBECONFIG`` for two reasons:
+      * Most environments don't need it (k3s local kubeconfigs don't
+        rotate; gcloud / Nebius creds use a different model).
+      * Only AWS-dev via Teleport hands out short-lived (≤7h) certs that
+        a multi-hour parametrized sweep can outrun mid-run.
+
+    Set ``DYN_TEST_REFRESH_KUBECONFIG=/path/to/script`` to run that
+    script before every test. The script is expected to refresh
+    ``/root/.kube/aws-dev-stripped`` (or whatever kubeconfig the dev
+    container is using) in-place — see
+    ``~/dynamo-dev/scripts/refresh-aws-kubeconfig.sh`` for the AWS-dev
+    case. Failure is logged but does not block the test (so a
+    no-network probe doesn't hard-fail the suite).
+    """
+    script = os.environ.get("DYN_TEST_REFRESH_KUBECONFIG")
+    if script:
+        import logging
+        import subprocess
+
+        logger = logging.getLogger(__name__)
+        try:
+            r = subprocess.run([script], capture_output=True, text=True, timeout=120)
+            if r.returncode != 0:
+                logger.warning(
+                    f"DYN_TEST_REFRESH_KUBECONFIG script {script!r} failed "
+                    f"(rc={r.returncode}): {r.stderr.strip()[:500]}"
+                )
+            else:
+                logger.info(
+                    f"kubeconfig refreshed via {script}: "
+                    f"{r.stdout.strip().splitlines()[-1] if r.stdout.strip() else 'ok'}"
+                )
+        except Exception as e:
+            logger.warning(f"DYN_TEST_REFRESH_KUBECONFIG hook failed: {e}")
     yield
+
+
+@pytest.fixture
+def fault_pod(request):
+    """Resolve the pod-selection for fault-injection tests.
+
+    Source order: ``--fault-pod`` CLI flag → ``DYN_TEST_FAULT_POD`` env →
+    default ``"0"``. Returns the raw string; tests interpret it via
+    ``_parse_index_env`` (or the equivalent) so ``"all"``, ``"random"``,
+    and a specific integer all work.
+    """
+    cli = request.config.getoption("--fault-pod")
+    if cli is not None:
+        return cli
+    return os.environ.get("DYN_TEST_FAULT_POD", "0")
+
+
+@pytest.fixture
+def fault_rank(request):
+    """Resolve the rank-selection for fault-injection tests. See ``fault_pod``."""
+    cli = request.config.getoption("--fault-rank")
+    if cli is not None:
+        return cli
+    return os.environ.get("DYN_TEST_FAULT_RANK", "0")
+
+
+def _parse_concurrency_list(value):
+    """Parse a ``--fault-concurrency`` value (CSV of ints) → list[int]."""
+    parts = [p.strip() for p in str(value).split(",") if p.strip()]
+    out = [int(p) for p in parts]
+    if not out:
+        raise pytest.UsageError("--fault-concurrency cannot be empty")
+    if any(n < 1 for n in out):
+        raise pytest.UsageError(f"--fault-concurrency values must be >= 1, got {out}")
+    return out
+
+
+@pytest.fixture
+def fault_concurrency(request):
+    """Single concurrency value for a fault-injection scenario run.
+
+    If ``--fault-concurrency=N1,N2,...`` is passed, tests that consume
+    this fixture are auto-parametrized one-per-value via the
+    ``pytest_generate_tests`` hook below (each parametrization gets its
+    own ``test_outputs/<test>[N]/`` directory). The fixture itself
+    just returns the int that pytest dispatched for this run.
+    """
+    return (
+        request.param
+        if hasattr(request, "param")
+        else _resolve_fault_concurrency_default(request.config)
+    )
+
+
+def _resolve_fault_concurrency_default(config):
+    cli = config.getoption("--fault-concurrency")
+    raw = cli if cli is not None else os.environ.get("DYN_TEST_FAULT_CONCURRENCY", "18")
+    return _parse_concurrency_list(raw)[0]
+
+
+def _resolve_float_opt(config, cli_name: str, env_name: str, default: float | None):
+    """CLI > env > default. Returns float or None."""
+    cli = config.getoption(cli_name)
+    if cli is not None:
+        return float(cli)
+    env = os.environ.get(env_name)
+    if env is not None and env.strip():
+        try:
+            return float(env)
+        except ValueError:
+            pass
+    return default
+
+
+@pytest.fixture
+def request_timeout_seconds(request):
+    """Per-request aiperf timeout, in seconds. CLI > env > 300s default."""
+    return _resolve_float_opt(
+        request.config,
+        "--request-timeout-seconds",
+        "DYN_TEST_REQUEST_TIMEOUT_SECONDS",
+        300.0,
+    )
+
+
+@pytest.fixture
+def goodput_slos(request):
+    """Resolved list of aiperf --goodput SLO strings, or None.
+
+    Builds from (CLI > env > none) for each of:
+      - request_latency:<ms>          via --goodput-request-latency-ms
+      - time_to_first_token:<ms>      via --goodput-ttft-ms
+      - inter_token_latency:<ms>      via --goodput-itl-ms
+    Returns None when no SLOs are set (so aiperf doesn't compute goodput).
+    """
+    slos = []
+    rl = _resolve_float_opt(
+        request.config,
+        "--goodput-request-latency-ms",
+        "DYN_TEST_GOODPUT_REQUEST_LATENCY_MS",
+        None,
+    )
+    if rl is not None:
+        slos.append(f"request_latency:{rl}")
+    ttft = _resolve_float_opt(
+        request.config,
+        "--goodput-ttft-ms",
+        "DYN_TEST_GOODPUT_TTFT_MS",
+        None,
+    )
+    if ttft is not None:
+        slos.append(f"time_to_first_token:{ttft}")
+    itl = _resolve_float_opt(
+        request.config,
+        "--goodput-itl-ms",
+        "DYN_TEST_GOODPUT_ITL_MS",
+        None,
+    )
+    if itl is not None:
+        slos.append(f"inter_token_latency:{itl}")
+    return slos or None
 
 
 # Shared CLI options (--image, --namespace, --skip-service-restart) are defined in tests/conftest.py.
@@ -80,12 +247,24 @@ def pytest_addoption(parser):
         "--log-pvc",
         type=str,
         default=None,
-        help="Reuse an existing RWX PVC for log collection instead of "
-        "creating a fresh one. Skips both creation and cleanup. Useful "
-        "on clusters where PVC provisioning is slow (e.g. AWS FSx "
-        "takes ~7 min). The PVC must already exist in the test "
-        "namespace and be RWX. Logs accumulate across runs — clean "
-        "manually if needed.",
+        help="Reuse a named RWX PVC for log collection across multiple "
+        "tests / DGDs. If the PVC does not exist it is created on first "
+        "use; once created the framework never deletes it. Each test "
+        "writes to a unique sub-path inside the PVC, which is wiped "
+        "in-place after a successful extract. Useful on clusters where "
+        "PVC provisioning is slow (e.g. AWS FSx ≈ 7 min). Without this "
+        "flag the framework creates a fresh per-test PVC and deletes "
+        "it at teardown (current default behaviour).",
+    )
+    parser.addoption(
+        "--recreate-log-pvc",
+        action="store_true",
+        default=False,
+        help="When --log-pvc is set, delete the existing PVC first and "
+        "create a fresh one. Use this when the standing PVC is stuck "
+        "in Terminating, has accumulated other tests' data you no "
+        "longer want to keep, or you want to change its storage "
+        "class. Requires --log-pvc.",
     )
     parser.addoption(
         "--model-pvc",
@@ -116,6 +295,63 @@ def pytest_addoption(parser):
         help="Restart NATS and etcd before each test. "
         "Default is to skip restart (faster iteration).",
     )
+    parser.addoption(
+        "--fault-pod",
+        type=str,
+        default=None,
+        help="Target pod selection for fault-injection scenarios. "
+        "Accepts an integer index (e.g. '0'), 'random', or 'all'. "
+        "Overrides the DYN_TEST_FAULT_POD env var; default is '0' "
+        "(pod-0 of the targeted service).",
+    )
+    parser.addoption(
+        "--fault-rank",
+        type=str,
+        default=None,
+        help="Target rank/process selection within each pod for rank-level "
+        "fault-injection scenarios. Same grammar as --fault-pod: integer, "
+        "'random', or 'all'. Overrides DYN_TEST_FAULT_RANK; default is '0'.",
+    )
+    parser.addoption(
+        "--fault-concurrency",
+        type=str,
+        default=None,
+        help="Sustained-load concurrency for fault-injection scenarios. "
+        "Accepts a single integer (e.g. '4096') or a comma-separated list "
+        "('18,256,4096') for chained runs of the same scenario at "
+        "different load levels. Overrides DYN_TEST_FAULT_CONCURRENCY; "
+        "default is '18' (near-saturation on the N=3 prod-mirror DGD).",
+    )
+    parser.addoption(
+        "--request-timeout-seconds",
+        type=float,
+        default=None,
+        help="Per-request timeout passed to aiperf (--request-timeout-seconds). "
+        "Requests exceeding this are cancelled client-side and counted in "
+        "error_request_count. Overrides DYN_TEST_REQUEST_TIMEOUT_SECONDS.",
+    )
+    parser.addoption(
+        "--goodput-ttft-ms",
+        type=float,
+        default=None,
+        help="TTFT goodput SLO in ms (--goodput time_to_first_token:<ms>). "
+        "Requests are counted as 'good' only if TTFT ≤ this AND every other "
+        "configured goodput SLO holds. Overrides DYN_TEST_GOODPUT_TTFT_MS.",
+    )
+    parser.addoption(
+        "--goodput-itl-ms",
+        type=float,
+        default=None,
+        help="Inter-token latency goodput SLO in ms (--goodput "
+        "inter_token_latency:<ms>). Overrides DYN_TEST_GOODPUT_ITL_MS.",
+    )
+    parser.addoption(
+        "--goodput-request-latency-ms",
+        type=float,
+        default=None,
+        help="End-to-end request_latency goodput SLO in ms (--goodput "
+        "request_latency:<ms>). Overrides DYN_TEST_GOODPUT_REQUEST_LATENCY_MS.",
+    )
 
 
 def pytest_generate_tests(metafunc):
@@ -141,6 +377,19 @@ def pytest_generate_tests(metafunc):
             ids.append(scenario_name)
 
         metafunc.parametrize("scenario_name", argvalues, ids=ids)
+
+    # Expand --fault-concurrency=N1,N2,... into one parametrization per
+    # value for any test that asks for the ``fault_concurrency`` fixture.
+    # Single-value (default) still produces one test invocation as
+    # ``test[18]``; multi-value chains as ``test[18]/[256]/[4096]`` etc.
+    if "fault_concurrency" in metafunc.fixturenames:
+        raw = metafunc.config.getoption("--fault-concurrency")
+        if raw is None:
+            raw = os.environ.get("DYN_TEST_FAULT_CONCURRENCY", "18")
+        values = _parse_concurrency_list(raw)
+        metafunc.parametrize(
+            "fault_concurrency", values, indirect=True, ids=[str(n) for n in values]
+        )
 
 
 def pytest_collection_modifyitems(config, items):
@@ -223,6 +472,12 @@ def log_pvc(request):
 
 
 @pytest.fixture
+def recreate_log_pvc(request):
+    """Drop + recreate the --log-pvc PVC before this run."""
+    return request.config.getoption("--recreate-log-pvc")
+
+
+@pytest.fixture
 def model_pvc(request):
     """Existing RWX PVC name to reuse as the HF model cache (mounted on workers)."""
     return request.config.getoption("--model-pvc")
@@ -241,6 +496,7 @@ def runtime_env(
     skip_service_restart,
     storage_class,
     log_pvc,
+    recreate_log_pvc,
     model_pvc,
     prefetch_model,
 ):
@@ -261,6 +517,7 @@ def runtime_env(
         skip_service_restart=skip_service_restart,
         storage_class=storage_class,
         log_pvc=log_pvc,
+        recreate_log_pvc=recreate_log_pvc,
         model_pvc=model_pvc,
         prefetch_model=prefetch_model,
     )

--- a/tests/fault_tolerance/deploy/conftest.py
+++ b/tests/fault_tolerance/deploy/conftest.py
@@ -13,26 +13,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import os
+import sys
+from pathlib import Path
 
-import pytest
+# Ensure the repo root is on sys.path so `tests.fault_tolerance.deploy.*`
+# imports resolve when this harness runs as the standalone dynamo-ft uv
+# project (where pytest's rootdir is this directory). Path is computed from
+# __file__ so it survives moves of this file or any parent dir.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
 
-from tests.fault_tolerance.deploy.scenarios import scenarios
+# The harness uses repo-root-relative paths (e.g.
+# ``examples/backends/{backend}/deploy/agg.yaml`` in scenarios.py). Chdir
+# so those resolve whether pytest was invoked from the repo root or from
+# this directory under the dynamo-ft uv project. Side-effects on CWD-
+# sensitive code (e.g. ``DYN_TEST_OUTPUT_PATH`` default below) are
+# intentional and match the previous repo-root-invocation behavior.
+os.chdir(_REPO_ROOT)
+
+import pytest  # noqa: E402
+
+from tests.fault_tolerance.deploy.scenarios import scenarios  # noqa: E402
 
 
 def pytest_configure(config):
-    """Route this dir's tests' outputs to ``<cwd>/test_outputs/<test>/``.
-
-    Implemented as a ``pytest_configure`` hook (not an autouse fixture)
-    so the env var is set BEFORE any fixture runs — in particular before
-    the root ``tests/conftest.py``'s autouse ``logger`` fixture opens
-    its ``test.log.txt`` FileHandler. With a same-stage fixture, the
-    root fixture fires first, sees ``DYN_TEST_OUTPUT_PATH`` unset, and
-    points the FileHandler at the default ``/tmp/dynamo_tests/`` —
-    while everything inside the test body (scenario log_dir, reports)
-    correctly resolves under ``test_outputs/`` because the env var is
-    set by then. Net effect of the old fixture: ``test.log.txt``
-    ends up in a different directory from the rest of the run.
+    """Route this dir's tests' outputs to ``<cwd>/test_outputs/<test>/`` and
+    inherit the marker registry from the root pyproject.
 
     The shared ``resolve_test_output_path`` defaults to
     ``/tmp/dynamo_tests/`` to keep outputs out of the git tree, which is
@@ -47,6 +56,28 @@ def pytest_configure(config):
     """
     if "DYN_TEST_OUTPUT_PATH" not in os.environ:
         os.environ["DYN_TEST_OUTPUT_PATH"] = os.path.join(os.getcwd(), "test_outputs")
+
+    # Inherit the marker registry from the root pyproject so --strict-markers
+    # in the dynamo-ft uv project stays useful without duplicating the marker
+    # list here. Single source of truth: root pyproject.toml.
+    try:
+        import tomllib  # py3.11+
+    except ImportError:
+        import tomli as tomllib  # type: ignore
+
+    root_pp = _REPO_ROOT / "pyproject.toml"
+    try:
+        with open(root_pp, "rb") as f:
+            for marker in (
+                tomllib.load(f)
+                .get("tool", {})
+                .get("pytest", {})
+                .get("ini_options", {})
+                .get("markers", [])
+            ):
+                config.addinivalue_line("markers", marker)
+    except FileNotFoundError:
+        pass  # standalone runs without the surrounding repo still ok
 
 
 @pytest.fixture(autouse=True)
@@ -88,6 +119,34 @@ def _refresh_kubeconfig_if_requested():
         except Exception as e:
             logger.warning(f"DYN_TEST_REFRESH_KUBECONFIG hook failed: {e}")
     yield
+
+
+@pytest.fixture(autouse=True)
+def logger(request):
+    """Per-test ``test.log.txt`` file handler on the root logger.
+
+    Overrides the root ``tests/conftest.py`` fixture of the same name (pytest
+    resolves the nearest definition), so the harness works identically whether
+    run from the repo root or as the standalone dynamo-ft uv project. The
+    output dir comes from ``DYN_TEST_OUTPUT_PATH`` (set in ``pytest_configure``
+    above), so the handler always lands next to scenario logs / reports.
+    """
+    log_dir = Path(os.environ["DYN_TEST_OUTPUT_PATH"]) / request.node.name
+    log_dir.mkdir(parents=True, exist_ok=True)
+    handler = logging.FileHandler(log_dir / "test.log.txt", mode="w")
+    handler.setFormatter(
+        logging.Formatter(
+            "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+        )
+    )
+    root = logging.getLogger()
+    root.addHandler(handler)
+    try:
+        yield
+    finally:
+        handler.close()
+        root.removeHandler(handler)
 
 
 @pytest.fixture
@@ -211,9 +270,60 @@ def goodput_slos(request):
     return slos or None
 
 
-# Shared CLI options (--image, --namespace, --skip-service-restart) are defined in tests/conftest.py.
-# Only fault_tolerance-specific options are defined here.
+def _add_or_skip(parser, name, **kwargs):
+    """Register an addoption, no-op if already registered by another conftest.
+
+    Lets us declare shared options here (so the harness runs standalone under
+    the dynamo-ft uv project) without conflicting when the root
+    ``tests/conftest.py`` is also loaded (e.g., when pytest is invoked from the
+    repo root).
+    """
+    try:
+        parser.addoption(name, **kwargs)
+    except ValueError:
+        pass  # already registered upstream
+
+
+# Shared CLI options (--image, --namespace, --skip-service-restart) are also
+# defined in tests/conftest.py. We re-declare them here (via _add_or_skip)
+# so the harness works standalone under the dynamo-ft uv project, where the
+# root conftest is not loaded.
 def pytest_addoption(parser):
+    # ---- shared options (also in root tests/conftest.py) ----
+    _add_or_skip(
+        parser,
+        "--image",
+        type=str,
+        default=None,
+        help="Container image to use for deployment (overrides YAML default).",
+    )
+    _add_or_skip(
+        parser,
+        "--namespace",
+        type=str,
+        default=None,
+        help="Kubernetes namespace for deployment.",
+    )
+    _add_or_skip(
+        parser,
+        "--skip-service-restart",
+        action="store_true",
+        default=None,
+        help="Skip restarting NATS and etcd services before deployment.",
+    )
+    # ---- per-test-file CLI options ----
+    # Each test file that exposes `add_cli_options(parser)` gets its options
+    # registered here. Keeps each file's flags scoped (own pytest --help
+    # group) and avoids one giant addoption block.
+    try:
+        from tests.fault_tolerance.deploy import test_overload as _overload_mod
+
+        _overload_mod.add_cli_options(parser)
+    except Exception:
+        # Test module not importable in this environment — skip gracefully.
+        pass
+
+    # ---- fault_tolerance-specific options ----
     parser.addoption(
         "--client-type",
         type=str,

--- a/tests/fault_tolerance/deploy/conftest.py
+++ b/tests/fault_tolerance/deploy/conftest.py
@@ -322,6 +322,20 @@ def pytest_addoption(parser):
     except Exception:
         # Test module not importable in this environment — skip gracefully.
         pass
+    try:
+        from tests.fault_tolerance.deploy import (
+            test_worker_death_kv_transfer as _wdkt_mod,
+        )
+
+        _wdkt_mod.add_cli_options(parser)
+    except Exception:
+        pass
+    try:
+        from tests.fault_tolerance.deploy import test_endurance as _endurance_mod
+
+        _endurance_mod.add_cli_options(parser)
+    except Exception:
+        pass
 
     # ---- fault_tolerance-specific options ----
     parser.addoption(

--- a/tests/fault_tolerance/deploy/conftest.py
+++ b/tests/fault_tolerance/deploy/conftest.py
@@ -15,6 +15,7 @@
 
 import logging
 import os
+import shutil
 import sys
 from pathlib import Path
 
@@ -130,8 +131,19 @@ def logger(request):
     run from the repo root or as the standalone dynamo-ft uv project. The
     output dir comes from ``DYN_TEST_OUTPUT_PATH`` (set in ``pytest_configure``
     above), so the handler always lands next to scenario logs / reports.
+
+    Cleans the per-test output dir before each run unless
+    ``DYN_TEST_KEEP_PRIOR_OUTPUTS=1`` is set. Re-running the same
+    parametrize id otherwise leaves stale logs from the previous attempt
+    (different pod names / DGD run-ids) intermingled with fresh ones —
+    confusing on review. Users who want history can either pass a
+    unique ``DYN_TEST_OUTPUT_PATH`` per run (the default conftest
+    behaviour: outputs land under ``<cwd>/test_outputs/<test>/``) or
+    opt out of the clean via the env var.
     """
     log_dir = Path(os.environ["DYN_TEST_OUTPUT_PATH"]) / request.node.name
+    if log_dir.exists() and os.environ.get("DYN_TEST_KEEP_PRIOR_OUTPUTS", "0") != "1":
+        shutil.rmtree(log_dir, ignore_errors=True)
     log_dir.mkdir(parents=True, exist_ok=True)
     handler = logging.FileHandler(log_dir / "test.log.txt", mode="w")
     handler.setFormatter(

--- a/tests/fault_tolerance/deploy/conftest.py
+++ b/tests/fault_tolerance/deploy/conftest.py
@@ -55,6 +55,14 @@ def pytest_addoption(parser):
         help="Client type for load generation: 'aiperf' (default) or 'legacy'",
     )
     parser.addoption(
+        "--baseline-concurrency",
+        type=int,
+        default=8,
+        help="Initial concurrency for the cascade-console long-running driver "
+        "(test_cascade_console.py). Adjust on the fly via "
+        "`python -m tests.utils.cascade_inject load <N>`.",
+    )
+    parser.addoption(
         "--include-custom-build",
         action="store_true",
         default=False,
@@ -89,6 +97,17 @@ def pytest_addoption(parser):
         "PVC must already exist in the test namespace and be RWX. "
         "Many shared clusters auto-provision a 'shared-model-cache' "
         "PVC per namespace.",
+    )
+    parser.addoption(
+        "--prefetch-model",
+        action="store_true",
+        default=False,
+        help="Before applying the DGD, schedule a one-shot Job that "
+        "downloads every non-frontend service's model into the model "
+        "cache. Avoids the concurrent-download lock thrash that "
+        "happens when N worker pods all hit HuggingFace simultaneously "
+        "on a cold cache. Idempotent — skips models already present. "
+        "Requires --model-pvc.",
     )
     parser.addoption(
         "--restart-services",
@@ -207,3 +226,41 @@ def log_pvc(request):
 def model_pvc(request):
     """Existing RWX PVC name to reuse as the HF model cache (mounted on workers)."""
     return request.config.getoption("--model-pvc")
+
+
+@pytest.fixture
+def prefetch_model(request):
+    """Run a one-shot model-download Job before applying the DGD."""
+    return request.config.getoption("--prefetch-model")
+
+
+@pytest.fixture
+def runtime_env(
+    namespace,
+    image,
+    skip_service_restart,
+    storage_class,
+    log_pvc,
+    model_pvc,
+    prefetch_model,
+):
+    """Bundle of every CLI-driven runtime knob a scenario needs.
+
+    Tests take just this one fixture and forward it to
+    ``run_scenario(runtime_env=...)`` instead of declaring seven
+    individual fixtures. Adding a new CLI flag means: define an
+    addoption + fixture above, add the field below, and update
+    ``run_scenario`` to read it from the bundle. Test signatures
+    stay unchanged.
+    """
+    from tests.fault_tolerance.deploy.scenario import RuntimeEnv
+
+    return RuntimeEnv(
+        namespace=namespace,
+        image=image,
+        skip_service_restart=skip_service_restart,
+        storage_class=storage_class,
+        log_pvc=log_pvc,
+        model_pvc=model_pvc,
+        prefetch_model=prefetch_model,
+    )

--- a/tests/fault_tolerance/deploy/conftest.py
+++ b/tests/fault_tolerance/deploy/conftest.py
@@ -348,6 +348,12 @@ def pytest_addoption(parser):
         _endurance_mod.add_cli_options(parser)
     except Exception:
         pass
+    try:
+        from tests.fault_tolerance.deploy import test_saturation_discovery as _sat_mod
+
+        _sat_mod.add_cli_options(parser)
+    except Exception:
+        pass
 
     # ---- fault_tolerance-specific options ----
     parser.addoption(

--- a/tests/fault_tolerance/deploy/dynamo-ft
+++ b/tests/fault_tolerance/deploy/dynamo-ft
@@ -27,6 +27,12 @@
 #                                   or --no-log-pvc for fresh per-test PVC.)
 #       --no-log-pvc               (disable reuse — fresh PVC per run, auto-deleted)
 #       --recreate-log-pvc         (delete + recreate the reused PVC first)
+#       --model-cache-pvc <name>   (RWX PVC mounted on workers as HF model cache;
+#                                   default shared-model-cache. Skips HF download
+#                                   race on multi-pod startup. Override with
+#                                   $DYNAMO_FT_MODEL_CACHE_PVC or --no-model-cache.)
+#       --no-model-cache           (don't mount any model-cache PVC; workers
+#                                   re-download model weights from HF every restart)
 #       --no-prefetch-model        (skip prefetch; default is to prefetch)
 #       --no-skip-service-restart  (do restart NATS/etcd; default skips)
 #       --bg                       (run in background, write PID + log path)
@@ -50,6 +56,12 @@ STORAGE_CLASS="${DYNAMO_FT_STORAGE_CLASS:-}"
 # unless --recreate-log-pvc is passed explicitly.
 LOG_PVC="${DYNAMO_FT_LOG_PVC:-dynamo-ft-logs}"
 RECREATE_LOG_PVC=0
+# Default to a stable shared HF model cache PVC. Workers mount it and skip
+# re-downloading 30+GB model weights on every pod restart — fixes the
+# thundering-herd HF download race on multi-pod startup (units >= 2). The
+# PVC is conventionally `shared-model-cache` in neelays-test{,*-b}; users
+# can override via $DYNAMO_FT_MODEL_CACHE_PVC or disable with --no-model-cache.
+MODEL_CACHE_PVC="${DYNAMO_FT_MODEL_CACHE_PVC:-shared-model-cache}"
 LOG_FILE=""
 PREFETCH_MODEL=1
 SKIP_SERVICE_RESTART=1
@@ -84,6 +96,8 @@ while (($# > 0)); do
         --log-pvc) LOG_PVC="$2"; shift 2 ;;
         --no-log-pvc) LOG_PVC=""; shift ;;
         --recreate-log-pvc) RECREATE_LOG_PVC=1; shift ;;
+        --model-cache-pvc) MODEL_CACHE_PVC="$2"; shift 2 ;;
+        --no-model-cache) MODEL_CACHE_PVC=""; shift ;;
         --no-prefetch-model) PREFETCH_MODEL=0; shift ;;
         --no-skip-service-restart) SKIP_SERVICE_RESTART=0; shift ;;
         --bg) BG=1; shift ;;
@@ -122,6 +136,7 @@ ARGS=( "$NODEID" --namespace "$NAMESPACE" -s -v )
 [[ -n "$STORAGE_CLASS" ]]      && ARGS+=( --storage-class "$STORAGE_CLASS" )
 [[ -n "$LOG_PVC" ]]            && ARGS+=( --log-pvc "$LOG_PVC" )
 ((RECREATE_LOG_PVC))           && ARGS+=( --recreate-log-pvc )
+[[ -n "$MODEL_CACHE_PVC" ]]    && ARGS+=( --model-cache-pvc "$MODEL_CACHE_PVC" )
 ((PREFETCH_MODEL))             && ARGS+=( --prefetch-model )
 ((SKIP_SERVICE_RESTART))       && ARGS+=( --skip-service-restart )
 ARGS+=( "${EXTRA[@]}" )

--- a/tests/fault_tolerance/deploy/dynamo-ft
+++ b/tests/fault_tolerance/deploy/dynamo-ft
@@ -73,6 +73,14 @@ LIST=0
 # Add new scenarios here as the file grows.
 declare -A ALIASES=(
     [decode_overload]="test_overload.py::test_decode_overload"
+    [cascade_sanity_pinned]="test_overload.py::test_overload_cascade_sanity_pinned"
+    [cascade_sanity_natural]="test_overload.py::test_overload_cascade_sanity_natural"
+    [cascade]="test_overload.py::test_overload_cascade"
+    [kv_router_memory_stability]="test_overload.py::test_kv_router_memory_stability"
+    [kv_router_memory_stability_a4]="test_overload.py::test_kv_router_memory_stability[a4-recommended-2-2.0-3.0-18.0-3.0-2.0]"
+    [kv_router_memory_stability_ll]="test_overload.py::test_kv_router_memory_stability[least-loaded-baseline-2-2.0-3.0-18.0-3.0-2.0]"
+    [kv_router_memory_stability_a4_no_replica_sync]="test_overload.py::test_kv_router_memory_stability[a4-no-replica-sync-2-2.0-3.0-18.0-3.0-2.0]"
+    [cascade_pinned_with_bg]="test_overload.py::test_overload_cascade_pinned_with_bg"
 )
 
 print_aliases() {
@@ -147,6 +155,34 @@ if ((BG)) && [[ -z "$LOG_FILE" ]]; then
 fi
 
 cd "$SCRIPT_DIR"
+
+# ─── venv resolution (host vs container) ─────────────────────────────
+# If the in-tree .venv exists but isn't writable by the current user — the
+# typical case when the container created it as root and we're now invoking
+# from the host as a regular user — point uv at a per-user venv instead so
+# `uv run` doesn't try to refresh the root-owned tree and fail with EACCES.
+# Container runs (where the running user owns .venv) and explicit
+# UV_PROJECT_ENVIRONMENT overrides both bypass this path.
+# Detect "host running against container-touched tree": .venv exists but
+# wasn't created by us. Use as the one signal for redirecting both the
+# uv venv and the per-test outputs dir — the latter's per-test subdirs
+# are typically root-owned even when the parent looks writable, so check
+# the venv (single root-owned file) is the most reliable test.
+HOST_OVERRIDE=0
+if [[ -d "$SCRIPT_DIR/.venv" && ! -w "$SCRIPT_DIR/.venv" ]]; then
+    HOST_OVERRIDE=1
+fi
+
+if ((HOST_OVERRIDE)) && [[ -z "${UV_PROJECT_ENVIRONMENT:-}" ]]; then
+    export UV_PROJECT_ENVIRONMENT="${HOME}/.venv-dynamo-ft"
+    echo "info: in-tree .venv not writable by $(id -un); using UV_PROJECT_ENVIRONMENT=$UV_PROJECT_ENVIRONMENT" >&2
+fi
+
+if ((HOST_OVERRIDE)) && [[ -z "${DYN_TEST_OUTPUT_PATH:-}" ]]; then
+    export DYN_TEST_OUTPUT_PATH="${HOME}/.dynamo-ft/test_outputs"
+    mkdir -p "$DYN_TEST_OUTPUT_PATH"
+    echo "info: redirecting test outputs to DYN_TEST_OUTPUT_PATH=$DYN_TEST_OUTPUT_PATH" >&2
+fi
 
 if ((DRY_RUN)); then
     echo "(cd $SCRIPT_DIR && uv run pytest ${ARGS[*]@Q})"

--- a/tests/fault_tolerance/deploy/dynamo-ft
+++ b/tests/fault_tolerance/deploy/dynamo-ft
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# dynamo-ft — thin wrapper around `uv run pytest` for the overload /
+# fault-tolerance test harness. Resolves short scenario names to pytest
+# nodeids, applies sensible defaults (namespace, prefetch-model,
+# skip-service-restart), and optionally tees output to a log file you
+# can `tail -f`.
+#
+# Usage:
+#   dynamo-ft <target> [extra pytest args...]
+#
+# Targets:
+#   decode_overload                              — alias for the overload scenario
+#   test_overload.py::test_decode_overload       — explicit pytest nodeid
+#   <path>.yaml                                  — future: yaml-driven scenario
+#
+# Flags handled by the wrapper (rest pass through to pytest):
+#   -n / --namespace <ns>          (default $DYNAMO_FT_NAMESPACE or `neelays-test`)
+#   -i / --image <img>             (default $DYNAMO_FT_IMAGE; if unset the test's
+#                                   own default applies — currently vllm-runtime:1.1.1)
+#   -s / --storage-class <sc>      (default $DYNAMO_FT_STORAGE_CLASS)
+#   -l / --log <file>              (tee output to <file>; otherwise stdout)
+#       --no-prefetch-model        (skip prefetch; default is to prefetch)
+#       --no-skip-service-restart  (do restart NATS/etcd; default skips)
+#       --bg                       (run in background, write PID + log path)
+#       --list                     (print known scenario aliases and exit)
+#       --dry-run                  (print the pytest command and exit)
+#
+# Env vars:
+#   DYNAMO_FT_NAMESPACE / DYNAMO_FT_IMAGE / DYNAMO_FT_STORAGE_CLASS
+
+set -euo pipefail
+
+# ─── resolve script dir (so this works from anywhere) ────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ─── defaults from env ───────────────────────────────────────────────
+NAMESPACE="${DYNAMO_FT_NAMESPACE:-neelays-test}"
+IMAGE="${DYNAMO_FT_IMAGE:-}"
+STORAGE_CLASS="${DYNAMO_FT_STORAGE_CLASS:-}"
+LOG_FILE=""
+PREFETCH_MODEL=1
+SKIP_SERVICE_RESTART=1
+BG=0
+DRY_RUN=0
+LIST=0
+
+# ─── known aliases ────────────────────────────────────────────────────
+# Add new scenarios here as the file grows.
+declare -A ALIASES=(
+    [decode_overload]="test_overload.py::test_decode_overload"
+)
+
+print_aliases() {
+    echo "Known scenario aliases:"
+    for k in "${!ALIASES[@]}"; do
+        printf "  %-30s → %s\n" "$k" "${ALIASES[$k]}"
+    done
+}
+
+usage() { sed -n '4,/^set/p' "$0" | grep -E '^#' | sed 's/^# \?//'; }
+
+# ─── arg parsing ──────────────────────────────────────────────────────
+TARGET=""
+EXTRA=()
+while (($# > 0)); do
+    case "$1" in
+        -n | --namespace) NAMESPACE="$2"; shift 2 ;;
+        -i | --image) IMAGE="$2"; shift 2 ;;
+        -s | --storage-class) STORAGE_CLASS="$2"; shift 2 ;;
+        -l | --log) LOG_FILE="$2"; shift 2 ;;
+        --no-prefetch-model) PREFETCH_MODEL=0; shift ;;
+        --no-skip-service-restart) SKIP_SERVICE_RESTART=0; shift ;;
+        --bg) BG=1; shift ;;
+        --dry-run) DRY_RUN=1; shift ;;
+        --list) LIST=1; shift ;;
+        -h | --help) usage; exit 0 ;;
+        --)
+            shift; while (($# > 0)); do EXTRA+=("$1"); shift; done ;;
+        -*) EXTRA+=("$1"); shift ;;
+        *)
+            if [[ -z "$TARGET" ]]; then TARGET="$1"; shift
+            else EXTRA+=("$1"); shift
+            fi ;;
+    esac
+done
+
+if ((LIST)); then print_aliases; exit 0; fi
+if [[ -z "$TARGET" ]]; then echo "error: no target given (use --list to see aliases)" >&2; exit 2; fi
+
+# ─── resolve TARGET → pytest nodeid ──────────────────────────────────
+if [[ -n "${ALIASES[$TARGET]:-}" ]]; then
+    NODEID="${ALIASES[$TARGET]}"
+elif [[ "$TARGET" == *.yaml ]]; then
+    # Reserved for the YAML runner once it lands.
+    stem="$(basename "$TARGET" .yaml)"
+    NODEID="test_overload_yaml.py::test_yaml_scenario[$stem]"
+elif [[ "$TARGET" == *::* || "$TARGET" == *.py ]]; then
+    NODEID="$TARGET"
+else
+    echo "error: unknown target $TARGET" >&2; print_aliases >&2; exit 2
+fi
+
+# ─── build pytest args ───────────────────────────────────────────────
+ARGS=( "$NODEID" --namespace "$NAMESPACE" -s -v )
+[[ -n "$IMAGE" ]]              && ARGS+=( --image "$IMAGE" )
+[[ -n "$STORAGE_CLASS" ]]      && ARGS+=( --storage-class "$STORAGE_CLASS" )
+((PREFETCH_MODEL))             && ARGS+=( --prefetch-model )
+((SKIP_SERVICE_RESTART))       && ARGS+=( --skip-service-restart )
+ARGS+=( "${EXTRA[@]}" )
+
+# Default log path if --bg without --log
+if ((BG)) && [[ -z "$LOG_FILE" ]]; then
+    LOG_FILE="/tmp/dynamo-ft-$(date +%Y%m%d-%H%M%S).log"
+fi
+
+cd "$SCRIPT_DIR"
+
+if ((DRY_RUN)); then
+    echo "(cd $SCRIPT_DIR && uv run pytest ${ARGS[*]@Q})"
+    [[ -n "$LOG_FILE" ]] && echo "  → log: $LOG_FILE"
+    exit 0
+fi
+
+if ((BG)); then
+    nohup uv run pytest "${ARGS[@]}" > "$LOG_FILE" 2>&1 &
+    echo "PID: $!"
+    echo "log: $LOG_FILE"
+    echo "tail with:  tail -f $LOG_FILE"
+elif [[ -n "$LOG_FILE" ]]; then
+    uv run pytest "${ARGS[@]}" 2>&1 | tee "$LOG_FILE"
+else
+    exec uv run pytest "${ARGS[@]}"
+fi

--- a/tests/fault_tolerance/deploy/dynamo-ft
+++ b/tests/fault_tolerance/deploy/dynamo-ft
@@ -22,6 +22,11 @@
 #                                   own default applies — currently vllm-runtime:1.1.1)
 #   -s / --storage-class <sc>      (default $DYNAMO_FT_STORAGE_CLASS)
 #   -l / --log <file>              (tee output to <file>; otherwise stdout)
+#       --log-pvc <name>           (RWX PVC reused across runs; default
+#                                   dynamo-ft-logs. Override with $DYNAMO_FT_LOG_PVC
+#                                   or --no-log-pvc for fresh per-test PVC.)
+#       --no-log-pvc               (disable reuse — fresh PVC per run, auto-deleted)
+#       --recreate-log-pvc         (delete + recreate the reused PVC first)
 #       --no-prefetch-model        (skip prefetch; default is to prefetch)
 #       --no-skip-service-restart  (do restart NATS/etcd; default skips)
 #       --bg                       (run in background, write PID + log path)
@@ -40,6 +45,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 NAMESPACE="${DYNAMO_FT_NAMESPACE:-neelays-test}"
 IMAGE="${DYNAMO_FT_IMAGE:-}"
 STORAGE_CLASS="${DYNAMO_FT_STORAGE_CLASS:-}"
+# Default to a stable, reused log PVC so we don't pay FSx provisioning on
+# every run. The harness creates it on first use and never deletes it
+# unless --recreate-log-pvc is passed explicitly.
+LOG_PVC="${DYNAMO_FT_LOG_PVC:-dynamo-ft-logs}"
+RECREATE_LOG_PVC=0
 LOG_FILE=""
 PREFETCH_MODEL=1
 SKIP_SERVICE_RESTART=1
@@ -71,6 +81,9 @@ while (($# > 0)); do
         -i | --image) IMAGE="$2"; shift 2 ;;
         -s | --storage-class) STORAGE_CLASS="$2"; shift 2 ;;
         -l | --log) LOG_FILE="$2"; shift 2 ;;
+        --log-pvc) LOG_PVC="$2"; shift 2 ;;
+        --no-log-pvc) LOG_PVC=""; shift ;;
+        --recreate-log-pvc) RECREATE_LOG_PVC=1; shift ;;
         --no-prefetch-model) PREFETCH_MODEL=0; shift ;;
         --no-skip-service-restart) SKIP_SERVICE_RESTART=0; shift ;;
         --bg) BG=1; shift ;;
@@ -107,6 +120,8 @@ fi
 ARGS=( "$NODEID" --namespace "$NAMESPACE" -s -v )
 [[ -n "$IMAGE" ]]              && ARGS+=( --image "$IMAGE" )
 [[ -n "$STORAGE_CLASS" ]]      && ARGS+=( --storage-class "$STORAGE_CLASS" )
+[[ -n "$LOG_PVC" ]]            && ARGS+=( --log-pvc "$LOG_PVC" )
+((RECREATE_LOG_PVC))           && ARGS+=( --recreate-log-pvc )
 ((PREFETCH_MODEL))             && ARGS+=( --prefetch-model )
 ((SKIP_SERVICE_RESTART))       && ARGS+=( --skip-service-restart )
 ARGS+=( "${EXTRA[@]}" )

--- a/tests/fault_tolerance/deploy/engine_details.py
+++ b/tests/fault_tolerance/deploy/engine_details.py
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Per-backend engine process details — the single seam for how inference
+backends differ, so a ``StallProcess``-based repro is backend-agnostic.
+
+A scenario refers to a *semantic target* (``main`` | ``engine`` | ``worker``)
+and this module resolves it to the concrete in-pod **process-name substring**
+that ``StallProcess`` / ``TerminateProcess`` match against (the ps cmdline),
+per backend. It folds together knowledge that was scattered across
+``scenarios.py`` ``WORKER_MAP`` (backend -> service names) and
+``test_canary_rank_pause.py`` ``_RANK_PATTERNS`` (backend -> rank process names).
+
+``DEATH_TARGET`` records which target, when stalled, deterministically drives
+the engine to self-kill (-> instance_id churn) for that backend — backend-
+specific because the death mechanism differs: vllm dies via the **Worker**'s
+``sample_tokens`` RPC timeout (stalling the EngineCore only hangs at
+``shm_broadcast``, upstream of the timeout — verified 2026-06-04); sglang runs
+one ``scheduler`` process; the mocker is a single process.
+"""
+
+# backend -> {semantic target: process-name substring matched in the ps cmdline}
+ENGINE_PROCESS_NAMES: dict[str, dict[str, str]] = {
+    "vllm": {
+        "main": "dynamo.vllm",
+        "engine": "VLLM::EngineCore",
+        "worker": "VLLM::Worker",
+    },
+    "sglang": {
+        "main": "dynamo.sglang",
+        # sglang has no separate engine/worker split — the scheduler runs the model
+        "engine": "sglang::scheduler",
+        "worker": "sglang::scheduler",
+    },
+    "trtllm": {
+        "main": "dynamo.runtime",
+        "engine": "TRTLLM:EngineCore",
+        "worker": "mpi4py.futures.server",
+    },
+    "mocker": {
+        # single process — no sub-engine/worker to freeze independently
+        "main": "dynamo.mocker",
+        "engine": "dynamo.mocker",
+        "worker": "dynamo.mocker",
+    },
+}
+
+# backend -> the semantic target whose stall deterministically self-kills the
+# engine (instance_id churn). vllm = "worker" VERIFIED on real GPU 2026-06-04
+# (Worker SIGSTOP -> sample_tokens RPC timeout -> EngineDeadError -> restart);
+# the others are the documented expectation and need their own validation.
+DEATH_TARGET: dict[str, str] = {
+    "vllm": "worker",
+    "sglang": "engine",
+    "trtllm": "worker",
+    "mocker": "main",
+}
+
+# backend -> {role: k8s service name} for disagg (mirrors scenarios.py WORKER_MAP).
+WORKER_SERVICES: dict[str, dict[str, str]] = {
+    "vllm": {"decode": "VllmDecodeWorker", "prefill": "VllmPrefillWorker"},
+    "trtllm": {"decode": "TRTLLMDecodeWorker", "prefill": "TRTLLMPrefillWorker"},
+    "sglang": {"decode": "decode", "prefill": "prefill"},
+    "mocker": {"decode": "decode", "prefill": "prefill"},
+}
+
+# backend -> all rank/engine process-name substrings (folds in
+# test_canary_rank_pause._RANK_PATTERNS).
+RANK_PATTERNS: dict[str, tuple[str, ...]] = {
+    "vllm": ("VLLM::EngineCore", "EngineCoreProc"),
+    "trtllm": ("mpi4py.futures.server", "TRTLLM:EngineCore", "tensorrt_llm"),
+    "sglang": ("sglang::scheduler",),
+}
+
+
+def process_name_for(backend: str, target: str) -> str:
+    """Resolve a semantic target (``main`` | ``engine`` | ``worker``) to the
+    backend's concrete process-name substring. Raises ValueError on an unknown
+    backend or target so a mis-targeted stall fails loudly rather than no-op'ing."""
+    b = (backend or "").lower()
+    if b not in ENGINE_PROCESS_NAMES:
+        raise ValueError(
+            f"engine_details: unknown backend {backend!r} "
+            f"(known: {sorted(ENGINE_PROCESS_NAMES)})"
+        )
+    targets = ENGINE_PROCESS_NAMES[b]
+    if target not in targets:
+        raise ValueError(
+            f"engine_details: backend {b!r} has no target {target!r} "
+            f"(known: {sorted(targets)})"
+        )
+    return targets[target]
+
+
+def death_target_for(backend: str) -> str:
+    """The semantic target whose stall self-kills the engine for this backend
+    (default ``worker`` if the backend is unknown)."""
+    return DEATH_TARGET.get((backend or "").lower(), "worker")

--- a/tests/fault_tolerance/deploy/events.py
+++ b/tests/fault_tolerance/deploy/events.py
@@ -1,0 +1,442 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Scenario events for fault tolerance testing.
+
+Events are actions executed in sequence during a test scenario.
+Each event has:
+- execute(ctx): Perform the action
+- stop(ctx): Optional cleanup, called after all events execute
+- name: Event identifier (used to reference from other events)
+- results: Optional results stored after execution
+- description: Human-readable description for logging
+
+To create a custom event, subclass Event and implement execute() and description.
+"""
+
+import asyncio
+import secrets
+
+__all__ = [
+    "Event",
+    "StartLoad",
+    "StopLoad",
+    "WaitForLoadCompletion",
+    "Wait",
+    "DeletePod",
+    "WaitForRecovery",
+    "RollingUpgrade",
+    "WaitForLogPattern",
+    "TerminateProcess",
+    "RunCommand",
+]
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from tests.utils.managed_load import LoadConfig, ManagedLoad
+
+if TYPE_CHECKING:
+    from tests.fault_tolerance.deploy.scenario import ScenarioContext
+
+
+# =============================================================================
+# Event Base Class
+# =============================================================================
+
+
+@dataclass
+class Event(ABC):
+    """Base class for scenario events.
+
+    Events have:
+    - execute(ctx): Perform the action
+    - stop(ctx): Optional cleanup, called after all events execute
+    - name: Event identifier (used to find related events)
+    - results: Optional results stored after execution
+    """
+
+    # Note: name and results are defined in subclasses since dataclasses
+    # require fields with defaults to come after fields without defaults.
+
+    @abstractmethod
+    async def execute(self, ctx: "ScenarioContext") -> None:
+        """Execute the event."""
+        pass
+
+    async def stop(self, ctx: "ScenarioContext") -> None:
+        """Optional stop/cleanup. Called after all events execute."""
+        pass
+
+    @property
+    @abstractmethod
+    def description(self) -> str:
+        """Human-readable description of the event."""
+        pass
+
+
+# =============================================================================
+# Load Events
+# =============================================================================
+
+
+@dataclass
+class StartLoad(Event):
+    """Start a load test.
+
+    Creates and starts a ManagedLoad. Results are available from:
+    - stop() method (auto-called after all events)
+    - StopLoad event (for early termination)
+    - WaitForLoadCompletion event (explicit wait)
+    """
+
+    load_config: LoadConfig
+    name: str = "default"
+    results: dict[str, Any] | None = field(default=None, init=False)
+    _managed_load: ManagedLoad | None = field(default=None, init=False, repr=False)
+
+    async def execute(self, ctx: "ScenarioContext") -> None:
+        ctx.logger.info(f"Creating load '{self.name}'...")
+
+        self._managed_load = ManagedLoad(
+            namespace=ctx.namespace,
+            load_config=self.load_config,
+            pvc_name=ctx.deployment.get_log_pvc_name(),
+            endpoint_url=ctx.deployment.deployment_spec.get_in_cluster_frontend_url(
+                ctx.namespace
+            ),
+            log_dir=ctx.log_dir,
+            job_name=f"load-{self.name}-{secrets.token_hex(4)}",
+        )
+        await self._managed_load._init_kubernetes()
+        await self._managed_load.run(wait_for_completion=False)
+
+        ctx.logger.info(f"Waiting for load '{self.name}' to start...")
+        await self._managed_load.wait_for_started()
+        ctx.logger.info(f"Load '{self.name}' started")
+
+    async def stop(self, ctx: "ScenarioContext") -> None:
+        """Wait for load to complete and collect results."""
+        if self._managed_load:
+            ctx.logger.info(f"Stopping load '{self.name}'...")
+            await self._managed_load.wait_for_completion()
+            self.results = await self._managed_load.get_results()
+            await self._managed_load._cleanup()
+            self._managed_load = None
+            ctx.logger.info(f"Load '{self.name}' stopped")
+
+    def is_active(self) -> bool:
+        """Check if load is currently running."""
+        return self._managed_load is not None
+
+    @property
+    def description(self) -> str:
+        return f"Start load '{self.name}'"
+
+
+@dataclass
+class StopLoad(Event):
+    """Stop a running load early and collect results.
+
+    Use this to terminate a load before it completes naturally.
+    For loads that complete on their own, use WaitForLoadCompletion instead.
+    """
+
+    name: str = "default"
+    results: dict[str, Any] | None = field(default=None, init=False)
+
+    def _get_start_load(self, ctx: "ScenarioContext") -> StartLoad:
+        for event in ctx.events:
+            if isinstance(event, StartLoad) and event.name == self.name:
+                return event
+        raise ValueError(f"Load '{self.name}' not found")
+
+    async def execute(self, ctx: "ScenarioContext") -> None:
+        start_load = self._get_start_load(ctx)
+        if not start_load._managed_load:
+            raise ValueError(f"Load '{self.name}' not active")
+
+        ctx.logger.info(f"Stopping load '{self.name}'...")
+        await start_load._managed_load.terminate()
+        start_load.results = await start_load._managed_load.get_results()
+        await start_load._managed_load._cleanup()
+        start_load._managed_load = None
+        ctx.logger.info(f"Load '{self.name}' stopped")
+
+    @property
+    def description(self) -> str:
+        return f"Stop load '{self.name}'"
+
+
+@dataclass
+class WaitForLoadCompletion(Event):
+    """Wait for a load to complete naturally and collect results.
+
+    Use this after StartLoad to wait for the load to finish and get results.
+    """
+
+    name: str = "default"
+    timeout: int | None = None
+    results: dict[str, Any] | None = field(default=None, init=False)
+
+    def _get_start_load(self, ctx: "ScenarioContext") -> StartLoad:
+        for event in ctx.events:
+            if isinstance(event, StartLoad) and event.name == self.name:
+                return event
+        raise ValueError(f"Load '{self.name}' not found")
+
+    async def execute(self, ctx: "ScenarioContext") -> None:
+        start_load = self._get_start_load(ctx)
+        if not start_load._managed_load:
+            raise ValueError(f"Load '{self.name}' not active")
+
+        ctx.logger.info(f"Waiting for load '{self.name}' to complete...")
+        await start_load._managed_load.wait_for_completion(timeout=self.timeout)
+        start_load.results = await start_load._managed_load.get_results()
+        await start_load._managed_load._cleanup()
+        start_load._managed_load = None
+        ctx.logger.info(f"Load '{self.name}' completed")
+
+    @property
+    def description(self) -> str:
+        return f"Wait for load '{self.name}' completion"
+
+
+# =============================================================================
+# Basic Events
+# =============================================================================
+
+
+@dataclass
+class Wait(Event):
+    """Wait for a specified duration."""
+
+    duration: int  # seconds
+    name: str = ""
+    results: dict[str, Any] | None = field(default=None, init=False)
+
+    async def execute(self, ctx: "ScenarioContext") -> None:
+        ctx.logger.info(f"Waiting {self.duration}s...")
+        await asyncio.sleep(self.duration)
+
+    @property
+    def description(self) -> str:
+        return f"Wait {self.duration}s"
+
+
+@dataclass
+class DeletePod(Event):
+    """Delete pods for specified services."""
+
+    services: list[str]
+    force: bool = True
+    name: str = ""
+    results: dict[str, Any] | None = field(default=None, init=False)
+
+    async def execute(self, ctx: "ScenarioContext") -> None:
+        ctx.logger.info(f"Deleting pods for services: {self.services}")
+        service_pod_dict = ctx.deployment.get_pods(self.services)
+        for service_name, pods in service_pod_dict.items():
+            for pod in pods:
+                ctx.logger.info(f"Deleting pod {pod.name} (service: {service_name})")
+                ctx.deployment._get_pod_manifest(pod, service_name, ".before_delete")
+                ctx.deployment._get_pod_logs(pod, service_name, ".before_delete")
+                await ctx.deployment._get_pod_metrics(
+                    pod, service_name, ".before_delete"
+                )
+                pod.delete(force=self.force)
+
+    @property
+    def description(self) -> str:
+        return f"Delete pods: {', '.join(self.services)}"
+
+
+@dataclass
+class WaitForRecovery(Event):
+    """Wait for deployment to recover after a failure."""
+
+    timeout: int = 600
+    unready_timeout: int = 60
+    name: str = ""
+    results: dict[str, Any] | None = field(default=None, init=False)
+
+    async def execute(self, ctx: "ScenarioContext") -> None:
+        import time
+
+        start_time = time.time()
+        ctx.logger.info("Waiting for deployment to become unready...")
+        await ctx.deployment.wait_for_unready(
+            timeout=self.unready_timeout, log_interval=10
+        )
+        ctx.logger.info(f"Waiting for recovery (timeout: {self.timeout}s)...")
+        await ctx.deployment.wait_for_ready(timeout=self.timeout)
+        duration = time.time() - start_time
+        ctx.logger.info(f"Deployment recovered in {duration:.1f}s")
+
+    @property
+    def description(self) -> str:
+        return f"Wait for recovery (timeout: {self.timeout}s)"
+
+
+@dataclass
+class RollingUpgrade(Event):
+    """Trigger a rolling upgrade for specified services."""
+
+    services: list[str]
+    name: str = ""
+    unready_timeout: int = 60
+    ready_timeout: int = 1800
+    results: dict[str, Any] | None = field(default=None, init=False)
+
+    async def execute(self, ctx: "ScenarioContext") -> None:
+        import time
+
+        start_time = time.time()
+        ctx.logger.info(f"Triggering rolling upgrade for: {self.services}")
+
+        # Set trigger env var on each service
+        for service_name in self.services:
+            service = ctx.deployment.deployment_spec[service_name]
+            service.set_env_var("TEST_ROLLING_UPDATE_TRIGGER", secrets.token_hex(8))
+
+        await ctx.deployment.apply_service_changes(self.services)
+
+        ctx.logger.info("Waiting for CR to become unready...")
+        await ctx.deployment.wait_for_unready(
+            timeout=self.unready_timeout, log_interval=10
+        )
+
+        ctx.logger.info("Waiting for CR to become ready...")
+        await ctx.deployment.wait_for_ready(timeout=self.ready_timeout)
+
+        duration = time.time() - start_time
+        ctx.logger.info(f"Rolling upgrade completed in {duration:.1f}s")
+
+        if self.name:
+            self.results = {"services": self.services, "duration_seconds": duration}
+
+    @property
+    def description(self) -> str:
+        return f"Rolling upgrade: {', '.join(self.services)}"
+
+
+@dataclass
+class WaitForLogPattern(Event):
+    """Wait for a pattern to appear in a service's logs."""
+
+    service: str
+    pattern: str
+    name: str = ""
+    timeout: int = 300
+    results: dict[str, Any] | None = field(default=None, init=False)
+
+    async def execute(self, ctx: "ScenarioContext") -> None:
+        import re
+        import time
+
+        start_time = time.time()
+        ctx.logger.info(
+            f"Waiting for pattern '{self.pattern}' in {self.service} logs..."
+        )
+
+        # Get pods for service
+        service_pods = ctx.deployment.get_pods([self.service])
+        pods = service_pods.get(self.service, [])
+        if not pods:
+            raise ValueError(f"No pods found for service '{self.service}'")
+
+        # Compile pattern
+        regex = re.compile(self.pattern)
+
+        # Poll logs until pattern found or timeout
+        poll_interval = 2
+        while time.time() - start_time < self.timeout:
+            for pod in pods:
+                try:
+                    logs = pod.logs(since_seconds=10)
+                    if regex.search(logs):
+                        duration = time.time() - start_time
+                        ctx.logger.info(
+                            f"Pattern found in {self.service} after {duration:.1f}s"
+                        )
+                        if self.name:
+                            self.results = {
+                                "pattern": self.pattern,
+                                "service": self.service,
+                                "found_in_pod": pod.name,
+                                "duration_seconds": duration,
+                            }
+                        return
+                except Exception as e:
+                    ctx.logger.debug(f"Error reading logs from {pod.name}: {e}")
+
+            await asyncio.sleep(poll_interval)
+
+        raise TimeoutError(
+            f"Pattern '{self.pattern}' not found in {self.service} logs "
+            f"after {self.timeout}s"
+        )
+
+    @property
+    def description(self) -> str:
+        return f"Wait for '{self.pattern}' in {self.service} logs"
+
+
+@dataclass
+class TerminateProcess(Event):
+    """Terminate a process by name in service pods."""
+
+    services: list[str]
+    process_name: str  # e.g., "dynamo.runtime", "python", etc.
+    signal: str = "SIGKILL"
+    name: str = ""
+    results: dict[str, Any] | None = field(default=None, init=False)
+
+    async def execute(self, ctx: "ScenarioContext") -> None:
+        ctx.logger.info(
+            f"Terminating process '{self.process_name}' in services: {self.services}"
+        )
+        service_pod_dict = ctx.deployment.get_pods(self.services)
+        for service_name, pods in service_pod_dict.items():
+            for pod in pods:
+                processes = ctx.deployment.get_processes(pod)
+                for proc in processes:
+                    if self.process_name in proc.command:
+                        ctx.logger.info(
+                            f"Killing process {proc.pid} ({proc.command[:50]}...) "
+                            f"with {self.signal}"
+                        )
+                        proc.kill(signal=self.signal)
+                        break
+
+    @property
+    def description(self) -> str:
+        return f"Terminate '{self.process_name}' in {', '.join(self.services)}"
+
+
+@dataclass
+class RunCommand(Event):
+    """Run an arbitrary command in service pod(s).
+
+    Use for custom fault injection that doesn't have a dedicated event.
+
+    Example:
+        RunCommand(services=["VllmWorker"], command="stress --vm 1 --vm-bytes 2G --timeout 30s")
+    """
+
+    services: list[str]
+    command: str
+    name: str = ""
+    results: dict[str, Any] | None = field(default=None, init=False)
+
+    async def execute(self, ctx: "ScenarioContext") -> None:
+        service_pod_dict = ctx.deployment.get_pods(self.services)
+        for service_name, pods in service_pod_dict.items():
+            for pod in pods:
+                ctx.logger.info(f"Running '{self.command}' in {pod.name}")
+                await asyncio.to_thread(pod.exec, ["sh", "-c", self.command])
+
+    @property
+    def description(self) -> str:
+        return f"Run '{self.command[:50]}' in {', '.join(self.services)}"

--- a/tests/fault_tolerance/deploy/events.py
+++ b/tests/fault_tolerance/deploy/events.py
@@ -30,6 +30,7 @@ __all__ = [
     "RollingUpgrade",
     "WaitForLogPattern",
     "TerminateProcess",
+    "StallProcess",
     "RunCommand",
     "NetworkPartition",
     "WaitForModelReady",
@@ -437,6 +438,101 @@ class TerminateProcess(Event):
     @property
     def description(self) -> str:
         return f"Terminate '{self.process_name}' in {', '.join(self.services)}"
+
+
+@dataclass
+class StallProcess(Event):
+    """Pause a process by name in service pods (SIGSTOP), then resume (SIGCONT).
+
+    Models a "hung worker": the process stays alive — TCP sockets,
+    filesystem handles, conntrack entries are all preserved — but it
+    stops servicing requests because it doesn't get scheduled. Useful
+    for testing how the frontend handles a worker that accepts
+    connections, never replies, and eventually un-hangs (e.g. a GPU
+    deadlock that resolves itself, a long GC pause, a debugger).
+
+    Differences vs. ``TerminateProcess`` (SIGKILL):
+      * Pod IP and conntrack entries survive (no reconnect storm).
+      * No container restart — kubelet doesn't notice.
+      * The frontend sees idle TCP connections that never advance,
+        so timeout / health-check behaviour is what's exercised
+        (not crash recovery).
+
+    Behaviour:
+      * If ``duration`` is set, the event SIGSTOPs the matching
+        processes, sleeps for ``duration`` seconds, then SIGCONTs them.
+        Healing happens inside ``execute()`` so a transient stall reads
+        as a single line in the scenario.
+      * If ``duration`` is None, the stall holds until ``stop()`` runs
+        at end-of-scenario.
+
+    Example::
+
+        StallProcess(
+            services=["VllmDecodeWorker"],
+            process_name="dynamo.vllm",
+            duration=20,
+        )
+    """
+
+    services: list[str]
+    process_name: str
+    duration: float | None = None  # seconds; None = hold until scenario stop()
+    name: str = ""
+    results: dict[str, Any] | None = field(default=None, init=False)
+    _stalled_pids: list[tuple[Any, int]] = field(
+        default_factory=list, init=False, repr=False
+    )
+
+    async def execute(self, ctx: "ScenarioContext") -> None:
+        ctx.logger.info(
+            f"Stalling process '{self.process_name}' (SIGSTOP) "
+            f"in services: {self.services}"
+        )
+        service_pod_dict = ctx.deployment.get_pods(self.services)
+        for service_name, pods in service_pod_dict.items():
+            for pod in pods:
+                processes = ctx.deployment.get_processes(pod)
+                for proc in processes:
+                    if self.process_name in proc.command:
+                        ctx.logger.info(
+                            f"SIGSTOP pid={proc.pid} ({proc.command[:50]}...) "
+                            f"on pod {pod.name}"
+                        )
+                        proc.kill(signal="SIGSTOP")
+                        self._stalled_pids.append((pod, proc.pid))
+                        break
+
+        if self.duration is not None:
+            ctx.logger.info(f"StallProcess: holding for {self.duration}s, then SIGCONT")
+            try:
+                await asyncio.sleep(self.duration)
+            finally:
+                await self._resume(ctx)
+
+    async def stop(self, ctx: "ScenarioContext") -> None:
+        # When duration is set, execute() already healed the stall.
+        # Otherwise stop() resumes it at end of scenario.
+        await self._resume(ctx)
+
+    async def _resume(self, ctx: "ScenarioContext") -> None:
+        if not self._stalled_pids:
+            return
+        for pod, pid in self._stalled_pids:
+            try:
+                await asyncio.to_thread(pod.exec, ["kill", "-SIGCONT", str(pid)])
+                ctx.logger.info(f"SIGCONT pid={pid} on pod {pod.name}")
+            except Exception as e:
+                ctx.logger.warning(
+                    f"StallProcess resume failed for pid={pid} on "
+                    f"pod {pod.name}: {e}"
+                )
+        self._stalled_pids = []
+
+    @property
+    def description(self) -> str:
+        suffix = f" for {self.duration}s" if self.duration else ""
+        return f"Stall '{self.process_name}' in {', '.join(self.services)}" f"{suffix}"
 
 
 @dataclass

--- a/tests/fault_tolerance/deploy/events.py
+++ b/tests/fault_tolerance/deploy/events.py
@@ -31,10 +31,16 @@ __all__ = [
     "WaitForLogPattern",
     "TerminateProcess",
     "RunCommand",
+    "NetworkPartition",
+    "WaitForModelReady",
 ]
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
+
+import aiohttp
+from kubernetes_asyncio import client
+from kubernetes_asyncio.client import exceptions as k8s_exceptions
 
 from tests.utils.managed_load import LoadConfig, ManagedLoad
 
@@ -458,3 +464,415 @@ class RunCommand(Event):
     @property
     def description(self) -> str:
         return f"Run '{self.command[:50]}' in {', '.join(self.services)}"
+
+
+@dataclass
+class NetworkPartition(Event):
+    """Block traffic from one service's pods to another via a NetworkPolicy
+    plus a one-shot conntrack flush that severs already-established sockets.
+
+    Applies a NetworkPolicy that selects the *target* service's pods and
+    permits ingress from every pod in the namespace EXCEPT the *source*
+    service's pods, effectively cutting the source→target communication
+    path. The policy is removed at ``stop()`` so the partition lasts only
+    for the scenario.
+
+    NetworkPolicy alone is connection-tracked: established TCP sockets
+    survive policy creation and only *new* connections get blocked. The
+    Dynamo TCP request plane keeps a long-lived pooled socket between
+    Frontend and worker pods, so a partition mid-load would otherwise be
+    a no-op. After applying the policy, this event schedules a
+    privileged hostNetwork pod on the source pod's node and runs
+    ``conntrack -D`` to flush flows for both directions, forcing the
+    runtime to reconnect — and the reconnect is what the fresh policy
+    actually denies.
+
+    Requires a CNI that enforces NetworkPolicy (k3s with built-in
+    kube-router, Calico, Cilium, etc.) and an image with conntrack-tools
+    (default: ``localhost:32000/netshoot:latest``; override via
+    ``DYN_CONNTRACK_IMAGE``).
+
+    Example::
+
+        NetworkPartition(source="decode", target="Frontend")
+    """
+
+    source: str
+    target: str
+    duration: float | None = None  # seconds; None means hold until scenario stop()
+    name: str = ""
+    results: dict[str, Any] | None = field(default=None, init=False)
+    _policy_name: str = field(default="", init=False, repr=False)
+
+    async def execute(self, ctx: "ScenarioContext") -> None:
+        await self._apply_policy(ctx)
+        if self.duration is not None:
+            # Transient partition: create the cut, wait the requested
+            # window, then heal — all inside a single event so the
+            # scenario timeline stays linear ("Wait" + "DeletePod" + ...
+            # without needing a separate HealNetworkPartition step).
+            ctx.logger.info(
+                f"NetworkPartition: holding for {self.duration}s, then healing"
+            )
+            try:
+                await asyncio.sleep(self.duration)
+            finally:
+                await self._delete_policy(ctx)
+
+    async def stop(self, ctx: "ScenarioContext") -> None:
+        # When duration is set, execute() already healed the partition.
+        # When duration is None, the policy stays active until end-of-
+        # scenario and stop() is what tears it down.
+        await self._delete_policy(ctx)
+
+    async def _apply_policy(self, ctx: "ScenarioContext") -> None:
+        # Scope the policy to this deployment via the operator's stable
+        # graph-deployment-name label, then match the per-service
+        # ``nvidia.com/dynamo-component`` label (which uses the spec's
+        # service name verbatim, no per-deployment hash). The
+        # ``nvidia.com/selector`` label looks tempting but the operator
+        # appends a hash to it on workers, so cross-deployment lookups
+        # using a constructed value silently miss.
+        deployment = ctx.deployment.deployment_spec.name
+        self._policy_name = (
+            f"partition-{self.source.lower()}-{self.target.lower()}-"
+            f"{secrets.token_hex(4)}"
+        )
+        body = {
+            "apiVersion": "networking.k8s.io/v1",
+            "kind": "NetworkPolicy",
+            "metadata": {
+                "name": self._policy_name,
+                "namespace": ctx.namespace,
+                "labels": {
+                    "managed-by": "managed-deployment",
+                    "purpose": "network-partition",
+                },
+            },
+            "spec": {
+                "podSelector": {
+                    "matchLabels": {
+                        "nvidia.com/dynamo-graph-deployment-name": deployment,
+                        "nvidia.com/dynamo-component": self.target,
+                    }
+                },
+                "policyTypes": ["Ingress"],
+                "ingress": [
+                    {
+                        "from": [
+                            {
+                                "podSelector": {
+                                    "matchExpressions": [
+                                        {
+                                            "key": "nvidia.com/dynamo-graph-deployment-name",
+                                            "operator": "In",
+                                            "values": [deployment],
+                                        },
+                                        {
+                                            "key": "nvidia.com/dynamo-component",
+                                            "operator": "NotIn",
+                                            "values": [self.source],
+                                        },
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                ],
+            },
+        }
+        api = client.NetworkingV1Api()
+        await api.create_namespaced_network_policy(namespace=ctx.namespace, body=body)
+        ctx.logger.info(
+            f"Network partition active: {self.source} -X-> {self.target} "
+            f"(policy={self._policy_name})"
+        )
+
+        # Sever any existing source<->target sockets so the policy
+        # actually bites — see class docstring for why.
+        await self._flush_conntrack(ctx)
+
+    async def _flush_conntrack(self, ctx: "ScenarioContext") -> None:
+        """Run ``conntrack -D`` on the source pod's node for source<->target flows.
+
+        Picks the source pod's node, schedules a privileged hostNetwork
+        pod on that node, and flushes both directions of the
+        source<->target TCP flow from the kernel's conntrack table. The
+        flush is fire-and-forget — we wait for the flusher pod to
+        ``Succeeded`` once and then delete it. If conntrack isn't on
+        the node or the image won't pull, we log the failure but don't
+        fail the scenario; the policy is still in place and a strict
+        test can assert separately.
+        """
+        import os
+
+        src_pods = (
+            await asyncio.to_thread(ctx.deployment.get_pods, [self.source])
+        ).get(self.source) or []
+        tgt_pods = (
+            await asyncio.to_thread(ctx.deployment.get_pods, [self.target])
+        ).get(self.target) or []
+        if not src_pods or not tgt_pods:
+            ctx.logger.warning(
+                "NetworkPartition: cannot flush conntrack — missing pods "
+                f"(source={len(src_pods)}, target={len(tgt_pods)})"
+            )
+            return
+
+        src_pod = src_pods[0].raw
+        tgt_ips = [
+            p.raw.get("status", {}).get("podIP")
+            for p in tgt_pods
+            if p.raw.get("status", {}).get("podIP")
+        ]
+        src_ip = src_pod.get("status", {}).get("podIP")
+        node = src_pod.get("spec", {}).get("nodeName")
+        if not (src_ip and node and tgt_ips):
+            ctx.logger.warning(
+                "NetworkPartition: cannot flush conntrack — pod IP/node "
+                f"not yet ready (src_ip={src_ip}, node={node}, "
+                f"tgt_ips={tgt_ips})"
+            )
+            return
+
+        flusher_image = os.environ.get(
+            "DYN_CONNTRACK_IMAGE", "localhost:32000/netshoot:latest"
+        )
+        # One conntrack -D per direction per target IP. Exit 0 even if
+        # nothing matched (-D returns non-zero when 0 rows deleted, so
+        # we OR with true to keep the pod's exit code clean).
+        cmds = []
+        for tip in tgt_ips:
+            cmds.append(
+                f"conntrack -D -p tcp --orig-src {src_ip} --orig-dst {tip} || true"
+            )
+            cmds.append(
+                f"conntrack -D -p tcp --orig-src {tip} --orig-dst {src_ip} || true"
+            )
+        cmds.append("echo conntrack-flush done")
+        flusher_name = f"conntrack-flush-{secrets.token_hex(4)}"
+        body = {
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {
+                "name": flusher_name,
+                "namespace": ctx.namespace,
+                "labels": {
+                    "managed-by": "managed-deployment",
+                    "purpose": "conntrack-flush",
+                },
+            },
+            "spec": {
+                "restartPolicy": "Never",
+                "hostNetwork": True,
+                "nodeName": node,
+                "tolerations": [{"operator": "Exists"}],
+                "containers": [
+                    {
+                        "name": "flusher",
+                        "image": flusher_image,
+                        "imagePullPolicy": "IfNotPresent",
+                        "command": ["sh", "-c", " ; ".join(cmds)],
+                        "securityContext": {
+                            "privileged": True,
+                            "capabilities": {"add": ["NET_ADMIN"]},
+                        },
+                    }
+                ],
+            },
+        }
+        core = client.CoreV1Api()
+        try:
+            await core.create_namespaced_pod(namespace=ctx.namespace, body=body)
+        except k8s_exceptions.ApiException as e:
+            ctx.logger.warning(
+                f"NetworkPartition: failed to schedule conntrack flusher: {e}"
+            )
+            return
+
+        # Poll until the pod is Succeeded / Failed (cap at 30s — the
+        # actual conntrack flush is sub-second; the rest is image pull
+        # + scheduling).
+        deadline = asyncio.get_event_loop().time() + 30
+        terminal = ("Succeeded", "Failed")
+        last_phase = "Pending"
+        while asyncio.get_event_loop().time() < deadline:
+            try:
+                pod = await core.read_namespaced_pod(
+                    name=flusher_name, namespace=ctx.namespace
+                )
+                last_phase = pod.status.phase
+                if last_phase in terminal:
+                    break
+            except k8s_exceptions.ApiException:
+                pass
+            await asyncio.sleep(0.5)
+        ctx.logger.info(
+            f"NetworkPartition: conntrack flush pod {flusher_name} "
+            f"phase={last_phase}"
+        )
+        try:
+            await core.delete_namespaced_pod(
+                name=flusher_name,
+                namespace=ctx.namespace,
+                grace_period_seconds=0,
+            )
+        except k8s_exceptions.ApiException:
+            pass
+
+    async def _delete_policy(self, ctx: "ScenarioContext") -> None:
+        if not self._policy_name:
+            return
+        try:
+            api = client.NetworkingV1Api()
+            await api.delete_namespaced_network_policy(
+                name=self._policy_name, namespace=ctx.namespace
+            )
+            ctx.logger.info(f"Network partition lifted: {self._policy_name}")
+        except k8s_exceptions.ApiException as e:
+            if e.status != 404:
+                ctx.logger.warning(f"NetworkPartition cleanup: {e.status} {e.reason}")
+        self._policy_name = ""
+
+    @property
+    def description(self) -> str:
+        return f"Network partition: {self.source} -X-> {self.target}"
+
+
+@dataclass
+class WaitForModelReady(Event):
+    """Wait until the frontend lists ``model_name`` in /v1/models.
+
+    Bridges the gap between "deployment is Ready" (operator's view: all
+    pods running) and "model is actually serving" (worker has registered
+    with the frontend's discovery layer). For real workers (vllm,
+    sglang, trtllm), engine startup + KV-cache warmup + worker-to-
+    frontend discovery handshake can add tens of seconds beyond the pod
+    Ready transition. Mocker is fast enough this barely matters.
+
+    Pattern follows ``tests/router/helper.py:wait_for_frontend_ready``.
+
+    Args:
+        model_name: model identifier to look for in /v1/models. If
+            ``None``, derives from the first worker service's ``--model``
+            launch arg (i.e. ``deployment_spec[<worker>].model``).
+        timeout: seconds to wait for the model to appear before raising
+            ``TimeoutError``.
+        poll_interval: seconds between /v1/models polls.
+    """
+
+    model_name: str | None = None
+    timeout: int = 600
+    poll_interval: float = 2.0
+    name: str = ""
+    results: dict[str, Any] | None = field(default=None, init=False)
+
+    async def execute(self, ctx: "ScenarioContext") -> None:
+        import re
+
+        spec = ctx.deployment.deployment_spec
+        target_model = self.model_name
+        if target_model is None:
+            # First pass: clean ServiceSpec.model (works pre-log-wrap).
+            for service in spec.services:
+                if service.component_type != "frontend" and service.model:
+                    target_model = service.model
+                    break
+        if target_model is None:
+            # Second pass: enable_log_collection rewrites the worker
+            # command into a bash heredoc, so --model lives inside a
+            # string and ServiceSpec.model returns None. Grep the raw
+            # command text for --model/--model-path instead.
+            pattern = re.compile(r"--(?:model|model-path)[\s=]+(\S+)")
+            for service in spec.services:
+                if service.component_type == "frontend":
+                    continue
+                container = service._spec.get("extraPodSpec", {}).get(
+                    "mainContainer", {}
+                )
+                cmd_text = " ".join(container.get("command", []) or []) + " "
+                cmd_text += " ".join(container.get("args", []) or [])
+                m = pattern.search(cmd_text)
+                if m:
+                    target_model = m.group(1)
+                    break
+        if not target_model:
+            raise ValueError(
+                "WaitForModelReady: no model_name passed and no worker "
+                "service has --model/--model-path set"
+            )
+
+        # Port-forward to the frontend pod so this works whether the test
+        # runs inside the cluster (in-cluster DNS) or outside (host
+        # network — *.svc.cluster.local won't resolve). The port-forward
+        # is owned by ManagedDeployment._active_port_forwards and gets
+        # cleaned up on context exit.
+        ctx.logger.info("WaitForModelReady: looking up frontend pod...")
+        frontend_name = spec.frontend_service.name
+        pods_by_service = await asyncio.to_thread(
+            ctx.deployment.get_pods, [frontend_name]
+        )
+        frontend_pods = pods_by_service.get(frontend_name) or []
+        if not frontend_pods:
+            raise RuntimeError(
+                f"WaitForModelReady: no pods found for frontend service "
+                f"{frontend_name!r} in namespace {ctx.namespace}"
+            )
+        ctx.logger.info(
+            f"WaitForModelReady: opening port-forward to "
+            f"{frontend_pods[0].name}:{spec.port}..."
+        )
+        pf = await asyncio.to_thread(
+            ctx.deployment.port_forward, frontend_pods[0], spec.port
+        )
+        if pf is None or pf.local_port == 0:
+            raise RuntimeError(
+                f"WaitForModelReady: port-forward to "
+                f"{frontend_pods[0].name}:{spec.port} failed"
+            )
+        models_url = f"http://127.0.0.1:{pf.local_port}/v1/models"
+        ctx.logger.info(
+            f"Waiting for model '{target_model}' at {models_url} "
+            f"(timeout={self.timeout}s)"
+        )
+
+        start = asyncio.get_event_loop().time()
+        last_log = start
+        async with aiohttp.ClientSession() as session:
+            while True:
+                elapsed = asyncio.get_event_loop().time() - start
+                if elapsed > self.timeout:
+                    raise TimeoutError(
+                        f"WaitForModelReady: '{target_model}' did not appear "
+                        f"in /v1/models within {self.timeout}s"
+                    )
+                try:
+                    async with session.get(
+                        models_url,
+                        timeout=aiohttp.ClientTimeout(total=5),
+                    ) as resp:
+                        if resp.status == 200:
+                            data = await resp.json()
+                            ids = [m.get("id") for m in data.get("data", [])]
+                            if target_model in ids:
+                                ctx.logger.info(
+                                    f"Model '{target_model}' ready after "
+                                    f"{elapsed:.1f}s (registered models: {ids})"
+                                )
+                                return
+                except (aiohttp.ClientError, asyncio.TimeoutError):
+                    pass
+
+                # Heartbeat log every 10s so the user knows we're still polling.
+                if asyncio.get_event_loop().time() - last_log >= 10:
+                    ctx.logger.info(
+                        f"  still waiting for '{target_model}' "
+                        f"(elapsed {elapsed:.0f}s)"
+                    )
+                    last_log = asyncio.get_event_loop().time()
+                await asyncio.sleep(self.poll_interval)
+
+    @property
+    def description(self) -> str:
+        target = self.model_name or "(auto-detected)"
+        return f"Wait for model '{target}' in /v1/models"

--- a/tests/fault_tolerance/deploy/events.py
+++ b/tests/fault_tolerance/deploy/events.py
@@ -17,6 +17,7 @@ To create a custom event, subclass Event and implement execute() and description
 
 import asyncio
 import secrets
+from datetime import datetime, timezone
 
 __all__ = [
     "Event",
@@ -50,11 +51,15 @@ if TYPE_CHECKING:
 class Event(ABC):
     """Base class for scenario events.
 
-    Events have:
-    - execute(ctx): Perform the action
-    - stop(ctx): Optional cleanup, called after all events execute
-    - name: Event identifier (used to find related events)
-    - results: Optional results stored after execution
+    Authoring an event: subclass and implement ``execute(ctx)`` (and a
+    ``description`` property). Optionally override ``stop(ctx)`` for
+    cleanup. The framework calls ``timed_execute(ctx)`` which wraps the
+    subclass's ``execute`` with wall-clock timestamping so reports can
+    bucket aiperf records by event boundary.
+
+    Attributes set by the framework during execution:
+    - started_at / ended_at: UTC-aware wall-clock bracket populated by
+      ``timed_execute``. ``None`` until the event runs.
     """
 
     # Note: name and results are defined in subclasses since dataclasses
@@ -62,8 +67,18 @@ class Event(ABC):
 
     @abstractmethod
     async def execute(self, ctx: "ScenarioContext") -> None:
-        """Execute the event."""
+        """Subclass override — perform the event's action."""
         pass
+
+    async def timed_execute(self, ctx: "ScenarioContext") -> None:
+        """Framework entry point — runs ``execute`` and records the
+        wall-clock bracket on ``self.started_at``/``self.ended_at``.
+        """
+        self.started_at = datetime.now(timezone.utc)
+        try:
+            await self.execute(ctx)
+        finally:
+            self.ended_at = datetime.now(timezone.utc)
 
     async def stop(self, ctx: "ScenarioContext") -> None:
         """Optional stop/cleanup. Called after all events execute."""
@@ -240,8 +255,11 @@ class DeletePod(Event):
         for service_name, pods in service_pod_dict.items():
             for pod in pods:
                 ctx.logger.info(f"Deleting pod {pod.name} (service: {service_name})")
+                # Pod manifest (status/conditions/restartCount) and metrics
+                # endpoint scrape have to happen pre-delete; the PVC log
+                # tee already captures the container's stdout/stderr so we
+                # don't fetch kubectl logs here separately.
                 ctx.deployment._get_pod_manifest(pod, service_name, ".before_delete")
-                ctx.deployment._get_pod_logs(pod, service_name, ".before_delete")
                 await ctx.deployment._get_pod_metrics(
                     pod, service_name, ".before_delete"
                 )

--- a/tests/fault_tolerance/deploy/events.py
+++ b/tests/fault_tolerance/deploy/events.py
@@ -121,6 +121,29 @@ class StartLoad(Event):
     async def execute(self, ctx: "ScenarioContext") -> None:
         ctx.logger.info(f"Creating load '{self.name}'...")
 
+        # Auto-populate per-worker /metrics URLs (system_port pass-through
+        # surfaces vllm:* counters and the dynamo_component_* counters
+        # that the frontend's /metrics doesn't see). User-supplied
+        # extra_server_metrics_urls overrides.
+        if self.load_config.extra_server_metrics_urls is None:
+            spec = ctx.deployment.deployment_spec
+            urls: list[str] = []
+            for service in spec.services:
+                if service.component_type == "frontend":
+                    continue
+                pods_by_service = await asyncio.to_thread(
+                    ctx.deployment.get_pods, [service.name]
+                )
+                for pod in pods_by_service.get(service.name) or []:
+                    pod_ip = pod.raw.get("status", {}).get("podIP")
+                    if pod_ip:
+                        urls.append(f"http://{pod_ip}:{spec.system_port}/metrics")
+            if urls:
+                ctx.logger.info(
+                    f"StartLoad: auto-discovered worker /metrics URLs: {urls}"
+                )
+                self.load_config.extra_server_metrics_urls = urls
+
         self._managed_load = ManagedLoad(
             namespace=ctx.namespace,
             load_config=self.load_config,

--- a/tests/fault_tolerance/deploy/events.py
+++ b/tests/fault_tolerance/deploy/events.py
@@ -16,7 +16,9 @@ To create a custom event, subclass Event and implement execute() and description
 """
 
 import asyncio
+import json
 import random
+import re
 import secrets
 from datetime import datetime, timezone
 
@@ -39,6 +41,7 @@ __all__ = [
     "RstInjection",
     "RstFromInsidePod",
     "PodMemoryPoller",
+    "PeriodicSnapshot",
     "RANDOM",
     "ALL",
 ]
@@ -224,6 +227,9 @@ class Event(ABC):
 # =============================================================================
 
 
+_LOAD_NAME_PATTERN = re.compile(r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
+
+
 @dataclass
 class StartLoad(Event):
     """Start a load test.
@@ -239,8 +245,79 @@ class StartLoad(Event):
     results: dict[str, Any] | None = field(default=None, init=False)
     _managed_load: ManagedLoad | None = field(default=None, init=False, repr=False)
 
+    def __post_init__(self) -> None:
+        # k8s Job name = `load-{name}-{8hex}`; the user-controlled `name`
+        # must itself match RFC 1123 subdomain rules so the resulting
+        # Job name is valid. Underscores, uppercase, leading/trailing
+        # hyphens — all rejected by the k8s API at submit time with a
+        # 422. Failing here at scenario-definition time turns a 7-min-in
+        # deployment failure into an immediate AssertionError.
+        # Per observe-agent NEXT_STEPS_FOR_TEST_AGENT E.1 (post-sanity-1).
+        if not _LOAD_NAME_PATTERN.match(self.name):
+            raise ValueError(
+                f"StartLoad.name={self.name!r} violates k8s RFC 1123 "
+                "subdomain rules. Allowed: lowercase alphanumeric + "
+                "hyphens, must start and end with alphanumeric. "
+                "(Underscores and uppercase are common pitfalls.)"
+            )
+        # The full Job name (load-{name}-{8hex}) must fit in k8s's
+        # 63-char DNS label limit. Reserved: len('load-') + len('-XXXXXXXX') = 14.
+        if len(self.name) > 49:
+            raise ValueError(
+                f"StartLoad.name={self.name!r} is too long ({len(self.name)} "
+                "chars). Max 49 to fit the framework's `load-<name>-<hex>` "
+                "Job-name template within k8s's 63-char DNS label limit."
+            )
+
     async def execute(self, ctx: "ScenarioContext") -> None:
         ctx.logger.info(f"Creating load '{self.name}'...")
+
+        # WorkerPin resolution: turn (service, replica_index) into the
+        # live Dynamo instance_id(s) and stuff them into ``nvext`` via
+        # ``extra_inputs``. Done here (not at config time) because
+        # WaitForModelReady must have populated discovery state before
+        # instance_ids exist in the DynamoWorkerMetadata CRs.
+        #
+        # Wire shape: Dynamo's NvExt struct
+        # (lib/llm/src/protocols/openai/nvext.rs) has ``prefill_worker_id``
+        # and ``decode_worker_id`` as top-level u64 fields — there is no
+        # ``worker_id`` sub-object wrapper. push_router resolves
+        # ``prefill_worker_id`` for the prefill phase and
+        # ``decode_worker_id`` for decode, each falling back to
+        # ``backend_instance_id`` if unset (push_router.rs:746/751).
+        #
+        # Pass nvext as a Python dict on ``extra_inputs``; managed_load
+        # serializes the *whole* key+value as a JSON-object
+        # ``--extra-inputs '{"nvext":{...}}'`` arg (the form used by
+        # components/src/dynamo/profiler/utils/aiperf.py).
+        if self.load_config.worker_pin is not None:
+            pin = self.load_config.worker_pin
+            nvext_pin: dict = {}
+            if pin.decode_service is not None and pin.decode_replica_index is not None:
+                nvext_pin["decode_worker_id"] = await asyncio.to_thread(
+                    ctx.deployment.get_instance_id,
+                    pin.decode_service,
+                    pin.decode_replica_index,
+                )
+            if (
+                pin.prefill_service is not None
+                and pin.prefill_replica_index is not None
+            ):
+                nvext_pin["prefill_worker_id"] = await asyncio.to_thread(
+                    ctx.deployment.get_instance_id,
+                    pin.prefill_service,
+                    pin.prefill_replica_index,
+                )
+            if nvext_pin:
+                merged = dict(self.load_config.extra_inputs or {})
+                # If a caller already set nvext.* fields, layer on top
+                # rather than clobbering them.
+                existing_nvext = merged.get("nvext")
+                if isinstance(existing_nvext, dict):
+                    nvext_pin = {**existing_nvext, **nvext_pin}
+                merged["nvext"] = nvext_pin
+                self.load_config.extra_inputs = merged
+                ctx.logger.info(f"StartLoad '{self.name}': pinned nvext={nvext_pin}")
 
         # Auto-populate per-pod /metrics URLs. Workers expose dynamo_*
         # + vllm:* on system_port (9090). Frontends expose dynamo_frontend_*
@@ -446,8 +523,6 @@ class SetBusyThreshold(Event):
     results: dict[str, Any] | None = field(default=None, init=False)
 
     async def execute(self, ctx) -> None:
-        import json
-
         pods = (await asyncio.to_thread(ctx.deployment.get_pods, ["Frontend"])).get(
             "Frontend"
         ) or []
@@ -2268,3 +2343,147 @@ class PodMemoryPoller(Event):
     @property
     def description(self) -> str:
         return f"PodMemoryPoller {self.services} every {self.interval_s}s"
+
+
+@dataclass
+class PeriodicSnapshot(Event):
+    """Background event that, on a fixed interval, copies key artifacts
+    from ``ctx.log_dir`` into a timestamped subdirectory under
+    ``ctx.log_dir/snapshots/``. Designed for long-running endurance
+    scenarios where a slow drift (memory leak, queue backlog) only
+    surfaces after hours — periodic snapshots let analysis start while
+    the run is still in flight.
+
+    Snapshot directory format: ``t{minutes_since_start:04d}m_<iso>/``
+    e.g. ``t0030m_2026-05-26T22-15-03Z/``. The wall-time-minutes prefix
+    sorts naturally; the ISO suffix is human-readable.
+
+    What gets copied each tick (best-effort; missing files are skipped):
+      - ``pod_memory_growth.tsv`` — full snapshot of the PodMemoryPoller
+        TSV up to that moment
+      - ``load/load-*/profile_export*.{json,jsonl}`` — any in-progress
+        AIPerf metrics files
+      - ``load/load-*/server_metrics_export.jsonl``
+      - Last 2000 lines of each pod log under ``frontend/`` and worker
+        service directories (tail; full logs are captured at teardown)
+
+    Safety:
+      - Skips silently if ``ctx.log_dir`` is None or the snapshots dir
+        can't be created
+      - Each tick is wrapped in try/except; a copy failure on one
+        artifact doesn't abort the loop
+      - Stops cleanly on scenario teardown via the same Event ``stop()``
+        pattern as PodMemoryPoller
+
+    Hard ceiling: honors ``DYN_ENDURANCE_MAX_HOURS`` env var (default 8).
+    After that wall-time the snapshot loop stops emitting new dirs but
+    the scenario keeps running until the rung's duration completes —
+    the goal is to keep disk usage bounded, not to terminate the test.
+    """
+
+    interval_minutes: float = 30.0
+    name: str = ""
+    results: dict | None = field(default=None, init=False)
+    _task: object = field(default=None, init=False, repr=False)
+    _stop: object = field(default=None, init=False, repr=False)
+
+    async def execute(self, ctx: "ScenarioContext") -> None:
+        import glob
+        import os
+        import shutil
+        import time
+
+        log_dir = getattr(ctx, "log_dir", None)
+        if not log_dir:
+            ctx.logger.warning("PeriodicSnapshot: no ctx.log_dir; skipping")
+            return
+        snapshots_root = os.path.join(log_dir, "snapshots")
+        os.makedirs(snapshots_root, exist_ok=True)
+
+        max_hours = float(os.environ.get("DYN_ENDURANCE_MAX_HOURS", "8"))
+        max_secs = max_hours * 3600.0
+        interval_s = self.interval_minutes * 60.0
+
+        self._stop = asyncio.Event()
+        started = time.time()
+
+        def _snapshot_once(snapshot_dir: str) -> None:
+            os.makedirs(snapshot_dir, exist_ok=True)
+
+            # 1. pod_memory_growth.tsv
+            pmg = os.path.join(log_dir, "pod_memory_growth.tsv")
+            if os.path.exists(pmg):
+                try:
+                    shutil.copy2(
+                        pmg, os.path.join(snapshot_dir, "pod_memory_growth.tsv")
+                    )
+                except Exception as e:
+                    ctx.logger.warning(f"PeriodicSnapshot: copy pmg failed: {e}")
+
+            # 2. in-progress AIPerf metrics
+            for src in glob.glob(
+                os.path.join(log_dir, "load", "load-*", "profile_export*")
+            ):
+                rel = os.path.relpath(src, log_dir)
+                dst = os.path.join(snapshot_dir, rel)
+                try:
+                    os.makedirs(os.path.dirname(dst), exist_ok=True)
+                    shutil.copy2(src, dst)
+                except Exception as e:
+                    ctx.logger.warning(f"PeriodicSnapshot: copy {src} failed: {e}")
+            for src in glob.glob(
+                os.path.join(log_dir, "load", "load-*", "server_metrics_export.jsonl")
+            ):
+                rel = os.path.relpath(src, log_dir)
+                dst = os.path.join(snapshot_dir, rel)
+                try:
+                    os.makedirs(os.path.dirname(dst), exist_ok=True)
+                    shutil.copy2(src, dst)
+                except Exception as e:
+                    ctx.logger.warning(f"PeriodicSnapshot: copy {src} failed: {e}")
+
+        async def loop():
+            while not self._stop.is_set():
+                try:
+                    elapsed = time.time() - started
+                    if elapsed > max_secs:
+                        ctx.logger.warning(
+                            f"PeriodicSnapshot: hit DYN_ENDURANCE_MAX_HOURS "
+                            f"({max_hours}h); ceasing new snapshots."
+                        )
+                    else:
+                        minutes = int(elapsed / 60.0)
+                        iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%SZ")
+                        snapshot_dir = os.path.join(
+                            snapshots_root, f"t{minutes:04d}m_{iso}"
+                        )
+                        await asyncio.to_thread(_snapshot_once, snapshot_dir)
+                        ctx.logger.info(
+                            f"PeriodicSnapshot: wrote {os.path.basename(snapshot_dir)}"
+                        )
+                except Exception as e:
+                    ctx.logger.warning(f"PeriodicSnapshot loop err: {e}")
+                try:
+                    await asyncio.wait_for(self._stop.wait(), timeout=interval_s)
+                except asyncio.TimeoutError:
+                    pass
+
+        self._task = asyncio.create_task(loop())
+        ctx.logger.info(
+            f"PeriodicSnapshot: interval={self.interval_minutes}min, "
+            f"ceiling={max_hours}h, root={snapshots_root}"
+        )
+
+    async def stop(self, ctx: "ScenarioContext") -> None:
+        if self._stop is not None:
+            self._stop.set()
+        if self._task is not None:
+            try:
+                await asyncio.wait_for(self._task, timeout=15.0)
+            except asyncio.TimeoutError:
+                self._task.cancel()
+        ctx.logger.info("PeriodicSnapshot: stopped")
+
+    @property
+    def description(self) -> str:
+        return f"PeriodicSnapshot every {self.interval_minutes}min"

--- a/tests/fault_tolerance/deploy/events.py
+++ b/tests/fault_tolerance/deploy/events.py
@@ -400,6 +400,57 @@ class Wait(Event):
 
 
 @dataclass
+class SetBusyThreshold(Event):
+    """POST /busy_threshold to the Frontend service. Affects only the named
+    model. Subsequent requests will receive 503 once *all* workers for the
+    model exceed the thresholds."""
+
+    model_name: str
+    active_decode_blocks_threshold: float = 0.85
+    active_prefill_tokens_threshold_frac: float = 0.85
+    name: str = ""
+    results: dict[str, Any] | None = field(default=None, init=False)
+
+    async def execute(self, ctx) -> None:
+        import json
+
+        pods = (await asyncio.to_thread(ctx.deployment.get_pods, ["Frontend"])).get(
+            "Frontend"
+        ) or []
+        if not pods:
+            raise RuntimeError("SetBusyThreshold: no Frontend pods")
+        fe = pods[0]
+        body = {
+            "model": self.model_name,
+            "active_decode_blocks_threshold": self.active_decode_blocks_threshold,
+            "active_prefill_tokens_threshold_frac": self.active_prefill_tokens_threshold_frac,
+        }
+        pf = await asyncio.to_thread(ctx.deployment.port_forward, fe, 8000)
+        if pf is None or pf.local_port == 0:
+            raise RuntimeError(
+                f"SetBusyThreshold: port-forward to {fe.name}:8000 failed"
+            )
+        url = f"http://127.0.0.1:{pf.local_port}/busy_threshold"
+        async with aiohttp.ClientSession() as sess:
+            async with sess.post(url, json=body, timeout=30) as r:
+                txt = await r.text()
+                if r.status != 200:
+                    raise RuntimeError(
+                        f"SetBusyThreshold: POST returned {r.status}: {txt}"
+                    )
+                ctx.logger.info(f"SetBusyThreshold: {self.model_name} -> {txt}")
+                self.results = json.loads(txt)
+
+    @property
+    def description(self) -> str:
+        return (
+            f"SetBusyThreshold(model={self.model_name}, "
+            f"decode_frac={self.active_decode_blocks_threshold}, "
+            f"prefill_frac={self.active_prefill_tokens_threshold_frac})"
+        )
+
+
+@dataclass
 class DeletePod(Event):
     """Delete pods for specified services."""
 

--- a/tests/fault_tolerance/deploy/events.py
+++ b/tests/fault_tolerance/deploy/events.py
@@ -16,6 +16,7 @@ To create a custom event, subclass Event and implement execute() and description
 """
 
 import asyncio
+import random
 import secrets
 from datetime import datetime, timezone
 
@@ -34,16 +35,136 @@ __all__ = [
     "RunCommand",
     "NetworkPartition",
     "WaitForModelReady",
+    "PrintProcessTree",
+    "RstInjection",
+    "RstFromInsidePod",
+    "PodMemoryPoller",
+    "RANDOM",
+    "ALL",
 ]
-from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
 
-import aiohttp
-from kubernetes_asyncio import client
-from kubernetes_asyncio.client import exceptions as k8s_exceptions
+# Sentinels for target selection on DeletePod / StallProcess /
+# TerminateProcess. Resolution happens inside ``execute()`` so the
+# choice is logged and reproducible from the test output.
+#
+#   RANDOM  -- pick exactly one item at random
+#   ALL     -- target every item in the candidate set
+#
+# Apply to ``pod_indices`` (pod selection) and/or ``rank_index``
+# (rank/process selection within each chosen pod). For ``rank_index``
+# the legacy default of None means "first matching process" so existing
+# tests are unchanged; pass ALL to fan out to every matching rank.
+RANDOM = "random"
+ALL = "all"
 
-from tests.utils.managed_load import LoadConfig, ManagedLoad
+
+def _get_restart_count(pod) -> int:
+    """Read containerStatuses[0].restartCount from a Pod, defaulting to 0."""
+    if pod is None:
+        return -1
+    try:
+        statuses = pod.raw.get("status", {}).get("containerStatuses") or []
+        if not statuses:
+            return 0
+        return int(statuses[0].get("restartCount", 0))
+    except Exception:
+        return 0
+
+
+def _get_terminated_reason(pod) -> str | None:
+    """Return lastState.terminated.reason if present (e.g. 'OOMKilled', 'Error')."""
+    if pod is None:
+        return None
+    try:
+        statuses = pod.raw.get("status", {}).get("containerStatuses") or []
+        if not statuses:
+            return None
+        last = (statuses[0].get("lastState") or {}).get("terminated") or {}
+        return last.get("reason")
+    except Exception:
+        return None
+
+
+def _write_verification_line(ctx, line: str) -> None:
+    """Append a one-liner to ctx.log_dir/fault_verification.txt + ctx.logger."""
+    import os
+
+    ctx.logger.info(f"VERIFY: {line}")
+    log_dir = getattr(ctx, "log_dir", None)
+    if not log_dir:
+        return
+    try:
+        os.makedirs(log_dir, exist_ok=True)
+        with open(os.path.join(log_dir, "fault_verification.txt"), "a") as fh:
+            fh.write(line + "\n")
+    except Exception as e:
+        ctx.logger.warning(f"could not write fault_verification.txt: {e}")
+
+
+def _resolve_pod_selection(pods, pod_indices, logger=None):
+    """Resolve ``pod_indices`` selection against the sorted pod list.
+
+    ``pods`` is the input list (already sorted by name by callers).
+    ``pod_indices`` may be:
+      - None     → all pods (legacy default)
+      - ALL      → all pods (explicit; same as None)
+      - [i, ...] → the pods at those indices; out-of-range skipped
+      - RANDOM   → exactly one pod, chosen uniformly at random
+    """
+    if pod_indices is None or pod_indices == ALL:
+        return pods
+    if pod_indices == RANDOM:
+        if not pods:
+            return []
+        chosen = random.choice(pods)
+        if logger is not None:
+            logger.info(f"pod_indices=RANDOM resolved to pod '{chosen.name}'")
+        return [chosen]
+    return [pods[i] for i in pod_indices if 0 <= i < len(pods)]
+
+
+def _resolve_rank_selection(matches, rank_index, pod_name, logger=None):
+    """Resolve ``rank_index`` selection against the sorted-by-pid match list.
+
+    ``rank_index`` may be:
+      - None     → caller's legacy default: first match
+      - n (int)  → the nth match; out-of-range returns []
+      - RANDOM   → one match chosen uniformly at random
+      - ALL      → every match
+    Returns a list of zero or more chosen processes.
+    """
+    if not matches:
+        return []
+    if rank_index is None:
+        return [matches[0]]
+    if rank_index == ALL:
+        return list(matches)
+    if rank_index == RANDOM:
+        chosen = random.choice(matches)
+        if logger is not None:
+            logger.info(
+                f"rank_index=RANDOM resolved to pid={chosen.pid} " f"on pod {pod_name}"
+            )
+        return [chosen]
+    if 0 <= rank_index < len(matches):
+        return [matches[rank_index]]
+    if logger is not None:
+        logger.info(
+            f"rank_index={rank_index} out of range for pod "
+            f"{pod_name} ({len(matches)} matches); skipping"
+        )
+    return []
+
+
+from abc import ABC, abstractmethod  # noqa: E402
+from dataclasses import dataclass, field  # noqa: E402
+from typing import TYPE_CHECKING, Any  # noqa: E402
+
+import aiohttp  # noqa: E402
+from kubernetes_asyncio import client  # noqa: E402
+from kubernetes_asyncio.client import exceptions as k8s_exceptions  # noqa: E402
+
+from tests.utils.managed_load import LoadConfig, ManagedLoad  # noqa: E402
 
 if TYPE_CHECKING:
     from tests.fault_tolerance.deploy.scenario import ScenarioContext
@@ -121,33 +242,41 @@ class StartLoad(Event):
     async def execute(self, ctx: "ScenarioContext") -> None:
         ctx.logger.info(f"Creating load '{self.name}'...")
 
-        # Auto-populate per-worker /metrics URLs (system_port pass-through
-        # surfaces vllm:* counters and the dynamo_component_* counters
-        # that the frontend's /metrics doesn't see). User-supplied
-        # extra_server_metrics_urls overrides.
+        # Auto-populate per-pod /metrics URLs. Workers expose dynamo_*
+        # + vllm:* on system_port (9090). Frontends expose dynamo_frontend_*
+        # on spec.port (8000). User-supplied extra_server_metrics_urls
+        # overrides.
+        #
+        # Before 2026-05-12 the frontend was skipped here and only the
+        # Service URL was scraped — that returns metrics from ONE pod
+        # picked by Service round-robin per scrape, so we lost per-pod
+        # attribution in the time-series. Including each FE pod's IP
+        # gives a per-pod series like the worker side already does.
         if self.load_config.extra_server_metrics_urls is None:
             spec = ctx.deployment.deployment_spec
             urls: list[str] = []
             for service in spec.services:
-                if service.component_type == "frontend":
-                    continue
                 pods_by_service = await asyncio.to_thread(
                     ctx.deployment.get_pods, [service.name]
+                )
+                metrics_port = (
+                    spec.port
+                    if service.component_type == "frontend"
+                    else spec.system_port
                 )
                 for pod in pods_by_service.get(service.name) or []:
                     pod_ip = pod.raw.get("status", {}).get("podIP")
                     if pod_ip:
-                        urls.append(f"http://{pod_ip}:{spec.system_port}/metrics")
+                        urls.append(f"http://{pod_ip}:{metrics_port}/metrics")
             if urls:
-                ctx.logger.info(
-                    f"StartLoad: auto-discovered worker /metrics URLs: {urls}"
-                )
+                ctx.logger.info(f"StartLoad: auto-discovered /metrics URLs: {urls}")
                 self.load_config.extra_server_metrics_urls = urls
 
         self._managed_load = ManagedLoad(
             namespace=ctx.namespace,
             load_config=self.load_config,
             pvc_name=ctx.deployment.get_log_pvc_name(),
+            pvc_run_id=ctx.deployment.get_log_run_id(),
             endpoint_url=ctx.deployment.deployment_spec.get_in_cluster_frontend_url(
                 ctx.namespace
             ),
@@ -276,28 +405,92 @@ class DeletePod(Event):
 
     services: list[str]
     force: bool = True
+    # Pod selection within each service (after sort by name):
+    #   None     -> all pods (legacy default)
+    #   [i, j]   -> pods at those indices; out-of-range silently skipped
+    #   RANDOM   -> exactly one pod, chosen uniformly at random per run
+    pod_indices: list[int] | str | None = None
     name: str = ""
     results: dict[str, Any] | None = field(default=None, init=False)
 
     async def execute(self, ctx: "ScenarioContext") -> None:
         ctx.logger.info(f"Deleting pods for services: {self.services}")
+        # Pre-fault snapshot of pod-name set per service, so verify() can
+        # confirm a replacement pod appears with a NEW name.
+        baseline_names: dict[str, set] = {}
+        deleted_names: list[str] = []
         service_pod_dict = ctx.deployment.get_pods(self.services)
         for service_name, pods in service_pod_dict.items():
-            for pod in pods:
+            all_sorted = sorted(pods, key=lambda p: p.name)
+            baseline_names[service_name] = {p.name for p in all_sorted}
+            pods_to_delete = _resolve_pod_selection(
+                all_sorted, self.pod_indices, ctx.logger
+            )
+            for pod in pods_to_delete:
                 ctx.logger.info(f"Deleting pod {pod.name} (service: {service_name})")
-                # Pod manifest (status/conditions/restartCount) and metrics
-                # endpoint scrape have to happen pre-delete; the PVC log
-                # tee already captures the container's stdout/stderr so we
-                # don't fetch kubectl logs here separately.
                 ctx.deployment._get_pod_manifest(pod, service_name, ".before_delete")
                 await ctx.deployment._get_pod_metrics(
                     pod, service_name, ".before_delete"
                 )
                 pod.delete(force=self.force)
+                deleted_names.append(pod.name)
+        self._baseline_names = baseline_names
+        self._deleted_names = deleted_names
+        await self._verify(ctx)
+
+    async def _verify(self, ctx: "ScenarioContext") -> None:
+        if not self._deleted_names:
+            _write_verification_line(
+                ctx, f"DeletePod(name={self.name}): NO PODS MATCHED — no-op"
+            )
+            raise RuntimeError(
+                f"DeletePod for services {self.services} matched zero pods"
+            )
+        # Poll for replacement up to 60s.
+        deadline = asyncio.get_event_loop().time() + 60.0
+        replaced = {n: False for n in self._deleted_names}
+        while asyncio.get_event_loop().time() < deadline:
+            live = ctx.deployment.get_pods(self.services)
+            live_by_svc = {s: {p.name for p in pods} for s, pods in live.items()}
+            for name in self._deleted_names:
+                if replaced[name]:
+                    continue
+                svc = next(
+                    (s for s, names in self._baseline_names.items() if name in names),
+                    None,
+                )
+                if svc is None:
+                    continue
+                live_set = live_by_svc.get(svc, set())
+                # A replacement is "any pod in this service whose name was
+                # not in the pre-delete baseline and is not the deleted name".
+                fresh = (live_set - self._baseline_names[svc]) - set(
+                    self._deleted_names
+                )
+                if name not in live_set and fresh:
+                    replaced[name] = True
+            if all(replaced.values()):
+                break
+            await asyncio.sleep(2.0)
+        for name, ok in replaced.items():
+            _write_verification_line(
+                ctx,
+                f"DeletePod(name={self.name}) pod={name} "
+                f"{'REPLACED' if ok else 'NO-REPLACEMENT-WITHIN-60s'}",
+            )
+        missing = [n for n, ok in replaced.items() if not ok]
+        if missing:
+            raise RuntimeError(
+                f"DeletePod: no replacement appeared for {missing} within "
+                f"60s — controller may be broken or pod is stuck terminating"
+            )
 
     @property
     def description(self) -> str:
         return f"Delete pods: {', '.join(self.services)}"
+
+    _baseline_names: dict = field(default_factory=dict, init=False, repr=False)
+    _deleted_names: list = field(default_factory=list, init=False, repr=False)
 
 
 @dataclass
@@ -436,8 +629,13 @@ class TerminateProcess(Event):
     """Terminate a process by name in service pods."""
 
     services: list[str]
-    process_name: str  # e.g., "dynamo.runtime", "python", etc.
+    process_name: str  # e.g., "VLLM::Worker", "VLLM::EngineCore", "dynamo.runtime"
     signal: str = "SIGKILL"
+    # Pod / rank selection — see DeletePod and the module-level
+    # ``RANDOM`` sentinel for semantics. None = all pods / first match
+    # respectively (legacy defaults).
+    pod_indices: list[int] | str | None = None
+    rank_index: int | str | None = None
     name: str = ""
     results: dict[str, Any] | None = field(default=None, init=False)
 
@@ -445,22 +643,86 @@ class TerminateProcess(Event):
         ctx.logger.info(
             f"Terminating process '{self.process_name}' in services: {self.services}"
         )
+        # Pre-fault snapshot of (pod_name -> restartCount) so verify()
+        # can detect whether the kill actually triggered a container
+        # restart. If we never observe a count delta on any targeted
+        # pod, the fault was a silent no-op (regex matched nothing,
+        # or kubelet didn't notice).
+        baseline: dict[str, int] = {}
+        targeted: list[Any] = []
         service_pod_dict = ctx.deployment.get_pods(self.services)
         for service_name, pods in service_pod_dict.items():
+            pods = sorted(pods, key=lambda p: p.name)
+            pods = _resolve_pod_selection(pods, self.pod_indices, ctx.logger)
             for pod in pods:
                 processes = ctx.deployment.get_processes(pod)
-                for proc in processes:
-                    if self.process_name in proc.command:
-                        ctx.logger.info(
-                            f"Killing process {proc.pid} ({proc.command[:50]}...) "
-                            f"with {self.signal}"
-                        )
-                        proc.kill(signal=self.signal)
-                        break
+                matches = [p for p in processes if self.process_name in p.command]
+                matches.sort(key=lambda p: p.pid)
+                chosen = _resolve_rank_selection(
+                    matches, self.rank_index, pod.name, ctx.logger
+                )
+                if not chosen:
+                    continue
+                baseline[pod.name] = _get_restart_count(pod)
+                targeted.append(pod)
+                for proc in chosen:
+                    ctx.logger.info(
+                        f"Killing process {proc.pid} ({proc.command[:50]}...) "
+                        f"on pod {pod.name} with {self.signal}"
+                    )
+                    proc.kill(signal=self.signal)
+        # Stash for verify()
+        self._baseline_restarts = baseline
+        self._targeted_pod_names = [p.name for p in targeted]
+        # Block briefly so verify() has a fair chance to observe the
+        # restart-count bump. Kubelet typically restarts within 1-5 s.
+        if targeted:
+            await asyncio.sleep(15.0)
+        await self._verify(ctx)
+
+    async def _verify(self, ctx: "ScenarioContext") -> None:
+        if not self._targeted_pod_names:
+            _write_verification_line(
+                ctx,
+                f"TerminateProcess(name={self.name or self.process_name}): "
+                f"NO PROCESSES MATCHED — fault was a no-op",
+            )
+            raise RuntimeError(
+                f"TerminateProcess '{self.process_name}' matched zero "
+                f"processes; nothing was killed"
+            )
+        live = ctx.deployment.get_pods(self.services)
+        live_by_name = {p.name: p for pods in live.values() for p in pods}
+        results = []
+        no_bump = []
+        for name, before in self._baseline_restarts.items():
+            pod = live_by_name.get(name)
+            after = _get_restart_count(pod) if pod else -1
+            reason = _get_terminated_reason(pod) if pod else None
+            results.append((name, before, after, reason))
+            if after <= before:
+                no_bump.append(name)
+        for name, before, after, reason in results:
+            _write_verification_line(
+                ctx,
+                f"TerminateProcess(name={self.name or self.process_name}) "
+                f"pod={name} restartCount {before}->{after} "
+                f"lastTerminatedReason={reason}",
+            )
+        if no_bump:
+            raise RuntimeError(
+                f"TerminateProcess: kill sent but restartCount did NOT "
+                f"increment on pods {no_bump} within 15s — likely silent "
+                f"no-op (wrong process_name regex, or kubelet doesn't "
+                f"track this child)"
+            )
 
     @property
     def description(self) -> str:
         return f"Terminate '{self.process_name}' in {', '.join(self.services)}"
+
+    _baseline_restarts: dict = field(default_factory=dict, init=False, repr=False)
+    _targeted_pod_names: list = field(default_factory=list, init=False, repr=False)
 
 
 @dataclass
@@ -501,6 +763,10 @@ class StallProcess(Event):
     services: list[str]
     process_name: str
     duration: float | None = None  # seconds; None = hold until scenario stop()
+    # Pod / rank selection — see DeletePod / TerminateProcess and the
+    # module-level ``RANDOM`` sentinel for semantics.
+    pod_indices: list[int] | str | None = None
+    rank_index: int | str | None = None
     name: str = ""
     results: dict[str, Any] | None = field(default=None, init=False)
     _stalled_pids: list[tuple[Any, int]] = field(
@@ -514,17 +780,38 @@ class StallProcess(Event):
         )
         service_pod_dict = ctx.deployment.get_pods(self.services)
         for service_name, pods in service_pod_dict.items():
+            pods = sorted(pods, key=lambda p: p.name)
+            pods = _resolve_pod_selection(pods, self.pod_indices, ctx.logger)
             for pod in pods:
                 processes = ctx.deployment.get_processes(pod)
-                for proc in processes:
-                    if self.process_name in proc.command:
-                        ctx.logger.info(
-                            f"SIGSTOP pid={proc.pid} ({proc.command[:50]}...) "
-                            f"on pod {pod.name}"
-                        )
-                        proc.kill(signal="SIGSTOP")
-                        self._stalled_pids.append((pod, proc.pid))
-                        break
+                matches = [p for p in processes if self.process_name in p.command]
+                matches.sort(key=lambda p: p.pid)
+                chosen = _resolve_rank_selection(
+                    matches, self.rank_index, pod.name, ctx.logger
+                )
+                for proc in chosen:
+                    ctx.logger.info(
+                        f"SIGSTOP pid={proc.pid} ({proc.command[:50]}...) "
+                        f"on pod {pod.name}"
+                    )
+                    proc.kill(signal="SIGSTOP")
+                    self._stalled_pids.append((pod, proc.pid))
+
+        if not self._stalled_pids:
+            _write_verification_line(
+                ctx,
+                f"StallProcess(name={self.name or self.process_name}): "
+                f"NO PROCESSES MATCHED — fault was a no-op",
+            )
+            raise RuntimeError(
+                f"StallProcess '{self.process_name}' matched zero processes; "
+                f"nothing was stalled"
+            )
+
+        # Verify state == 'T' on each stalled pid via /proc/<pid>/stat.
+        # Tolerate transient state mismatches (e.g. 'Z' if a process
+        # exited racy) by retrying up to 3 times.
+        await self._verify_state(ctx, expected="T", phase="post-SIGSTOP")
 
         if self.duration is not None:
             ctx.logger.info(f"StallProcess: holding for {self.duration}s, then SIGCONT")
@@ -541,6 +828,7 @@ class StallProcess(Event):
     async def _resume(self, ctx: "ScenarioContext") -> None:
         if not self._stalled_pids:
             return
+        resumed_snapshot = list(self._stalled_pids)
         for pod, pid in self._stalled_pids:
             try:
                 await asyncio.to_thread(pod.exec, ["kill", "-SIGCONT", str(pid)])
@@ -551,6 +839,71 @@ class StallProcess(Event):
                     f"pod {pod.name}: {e}"
                 )
         self._stalled_pids = []
+        # Verify the resume: state should no longer be 'T'. Tolerant of
+        # process exit (state missing — also acceptable since the
+        # process is no longer stalled).
+        await self._verify_state_pairs(
+            ctx, resumed_snapshot, not_expected="T", phase="post-SIGCONT"
+        )
+
+    async def _verify_state(self, ctx, expected: str, phase: str) -> None:
+        await self._verify_state_pairs(
+            ctx, self._stalled_pids, expected=expected, phase=phase
+        )
+
+    async def _verify_state_pairs(
+        self,
+        ctx,
+        pairs,
+        *,
+        expected: str | None = None,
+        not_expected: str | None = None,
+        phase: str,
+    ) -> None:
+        """Check /proc/<pid>/stat field 3 on each (pod, pid) tuple."""
+        failures: list[str] = []
+        for pod, pid in pairs:
+            state = await self._read_proc_state(pod, pid)
+            ok = True
+            if expected is not None and state != expected:
+                ok = False
+            if not_expected is not None and state == not_expected:
+                ok = False
+            _write_verification_line(
+                ctx,
+                f"StallProcess(name={self.name or self.process_name}) "
+                f"{phase} pod={pod.name} pid={pid} state={state} "
+                f"{'OK' if ok else 'FAIL'}",
+            )
+            if not ok:
+                failures.append(f"{pod.name}/pid={pid} state={state}")
+        if failures:
+            raise RuntimeError(
+                f"StallProcess {phase} verification failed: "
+                f"{failures} (expected {expected}, "
+                f"not {not_expected})"
+            )
+
+    async def _read_proc_state(self, pod, pid: int) -> str:
+        """Return /proc/<pid>/stat field-3 single-char state, or 'missing'."""
+        try:
+            result = await asyncio.to_thread(
+                pod.exec, ["sh", "-c", f"cat /proc/{pid}/stat || echo MISSING"]
+            )
+            stdout = (
+                result.stdout.decode() if hasattr(result, "stdout") else str(result)
+            )
+            if "MISSING" in stdout or not stdout.strip():
+                return "missing"
+            # /proc/<pid>/stat format: pid (comm) state ... — comm can contain spaces,
+            # so split on ')' first to isolate the state field.
+            tail = stdout.split(")", 1)
+            if len(tail) < 2:
+                return "?"
+            after = tail[1].strip().split()
+            return after[0] if after else "?"
+        except Exception:
+            return "missing"
 
     @property
     def description(self) -> str:
@@ -583,6 +936,73 @@ class RunCommand(Event):
     @property
     def description(self) -> str:
         return f"Run '{self.command[:50]}' in {', '.join(self.services)}"
+
+
+@dataclass
+class PrintProcessTree(Event):
+    """Dump the full process tree of one or more services' pods.
+
+    Use this to identify the launcher vs the rank/worker subprocesses
+    before targeting them with StallProcess / TerminateProcess. Runs
+    ``ps -eo pid,ppid,pgid,cmd --forest`` inside each pod and logs the
+    output line-by-line.
+
+    Example::
+
+        PrintProcessTree(services=["VllmDecodeWorker", "VllmPrefillWorker"])
+    """
+
+    services: list[str]
+    name: str = ""
+    results: dict[str, Any] | None = field(default=None, init=False)
+
+    async def execute(self, ctx: "ScenarioContext") -> None:
+        import os
+
+        out_path = None
+        if getattr(ctx, "log_dir", None):
+            os.makedirs(ctx.log_dir, exist_ok=True)
+            out_path = os.path.join(ctx.log_dir, "process_tree.md")
+            fh = open(out_path, "w")
+            fh.write(f"# Process trees — {', '.join(self.services)}\n\n")
+        else:
+            fh = None
+
+        service_pod_dict = ctx.deployment.get_pods(self.services)
+        for service_name, pods in service_pod_dict.items():
+            for pod in sorted(pods, key=lambda p: p.name):
+                header = f"=== process tree: {service_name} / {pod.name} ==="
+                ctx.logger.info(header)
+                if fh:
+                    fh.write(f"\n## {service_name} / {pod.name}\n\n```\n")
+                try:
+                    result = await asyncio.to_thread(
+                        pod.exec,
+                        ["ps", "-eo", "pid,ppid,pgid,cmd", "--forest"],
+                    )
+                    stdout = (
+                        result.stdout.decode()
+                        if hasattr(result, "stdout")
+                        else str(result)
+                    )
+                    for line in stdout.splitlines():
+                        ctx.logger.info(f"  {line}")
+                        if fh:
+                            fh.write(line + "\n")
+                except Exception as e:
+                    ctx.logger.warning(f"ps failed on {pod.name}: {e}")
+                    if fh:
+                        fh.write(f"ps failed: {e}\n")
+                if fh:
+                    fh.write("```\n")
+
+        if fh:
+            fh.close()
+            ctx.logger.info(f"Process trees written to {out_path}")
+
+    @property
+    def description(self) -> str:
+        return f"Print process tree in {', '.join(self.services)}"
 
 
 @dataclass
@@ -859,6 +1279,293 @@ class NetworkPartition(Event):
 
 
 @dataclass
+class RstInjection(Event):
+    """Force TCP RSTs to/from one pod for ``duration`` seconds.
+
+    Models the precondition of PR #8254: under high concurrency, a TCP
+    stream read error (``ECONNRESET`` / "Connection reset by peer")
+    used to ``panic!`` in ``tcp/client.rs`` / ``tcp/server.rs``, killing
+    13–130 Tokio tasks per failing run. This event reproduces that
+    precondition deterministically:
+
+      1. Resolve a target pod (``pod_indices`` semantics same as the
+         other targeting events; defaults to all pods of ``service``).
+         For each chosen pod:
+      2. Find the pod's IP and the node it's scheduled on.
+      3. Schedule a privileged ``hostNetwork`` helper pod on that node
+         that installs ``iptables -A FORWARD -d <pod_ip> -p tcp
+         -j REJECT --reject-with tcp-reset`` (and a matching ``-s``
+         rule for the return path). Every TCP packet to / from the
+         target pod is replied to with an RST until the rule is
+         removed.
+      4. The helper pod sleeps for ``duration`` seconds while the
+         rule is in place, then removes it (best-effort) and exits.
+         ``stop()`` deletes the helper pod regardless.
+      5. Verification: the event waits until the helper pod reaches
+         Running (or fails loudly if it never does), and captures
+         the helper's stdout (iptables exit codes + rule list) into
+         ``ctx.log_dir/rst_injection_verification.txt`` after the
+         duration elapses. If the iptables installation failed the
+         event raises.
+
+    History: an earlier iteration of this event used ``tcpkill`` from
+    netshoot, which silently no-op'd because netshoot doesn't actually
+    ship tcpkill. The ``|| echo`` fallback masked the missing-binary
+    error and goodput came in *above* baseline — the giveaway that no
+    RSTs had actually been injected. iptables is in the base image and
+    works without external dependencies.
+
+    Example::
+
+        RstInjection(
+            service="VllmDecodeWorker",
+            pod_indices=[0],
+            duration=30.0,
+        )
+
+    Requires a CNI where pod-to-pod traffic traverses the host's
+    FORWARD chain. AWS VPC CNI does (pod traffic goes through the
+    host's networking stack on the ENI). Most overlay CNIs (Calico,
+    Cilium, kube-router) do too. Override the image via
+    ``DYN_CONNTRACK_IMAGE``.
+    """
+
+    service: str
+    duration: float = 30.0
+    pod_indices: list[int] | str | None = None
+    name: str = ""
+    results: dict[str, Any] | None = field(default=None, init=False)
+    _helper_pod_names: list[str] = field(default_factory=list, init=False, repr=False)
+
+    async def execute(self, ctx: "ScenarioContext") -> None:
+        import os
+
+        all_pods = (
+            await asyncio.to_thread(ctx.deployment.get_pods, [self.service])
+        ).get(self.service) or []
+        all_pods = sorted(all_pods, key=lambda p: p.name)
+        target_pods = _resolve_pod_selection(all_pods, self.pod_indices, ctx.logger)
+        if not target_pods:
+            ctx.logger.warning(
+                f"RstInjection: no pods to target in service '{self.service}'"
+            )
+            return
+
+        helper_image = os.environ.get(
+            "DYN_CONNTRACK_IMAGE", "localhost:32000/netshoot:latest"
+        )
+        core = client.CoreV1Api()
+
+        for pod in target_pods:
+            pod_raw = pod.raw
+            pod_ip = pod_raw.get("status", {}).get("podIP")
+            node = pod_raw.get("spec", {}).get("nodeName")
+            if not (pod_ip and node):
+                ctx.logger.warning(
+                    f"RstInjection: pod {pod.name} not ready "
+                    f"(podIP={pod_ip}, nodeName={node}); skipping"
+                )
+                continue
+
+            helper_name = f"rst-inject-{secrets.token_hex(4)}"
+            duration_int = max(1, int(self.duration))
+            # Install REJECT rules for both directions of the pod's TCP
+            # flows in the FORWARD chain. set -e so an iptables failure
+            # makes the pod exit non-zero and our verification catches
+            # it. The verification block below greps the helper's
+            # stdout for the RULE-INSTALLED line; missing → raise.
+            cmd = (
+                f"set -e; "
+                f"iptables -I FORWARD -d {pod_ip} -p tcp -j REJECT --reject-with tcp-reset; "
+                f"iptables -I FORWARD -s {pod_ip} -p tcp -j REJECT --reject-with tcp-reset; "
+                f"echo RULE-INSTALLED for {pod_ip}; "
+                f"iptables -S FORWARD | grep tcp-reset; "
+                f"sleep {duration_int}; "
+                f"iptables -D FORWARD -d {pod_ip} -p tcp -j REJECT --reject-with tcp-reset || true; "
+                f"iptables -D FORWARD -s {pod_ip} -p tcp -j REJECT --reject-with tcp-reset || true; "
+                f"echo RULE-REMOVED for {pod_ip}"
+            )
+            body = {
+                "apiVersion": "v1",
+                "kind": "Pod",
+                "metadata": {
+                    "name": helper_name,
+                    "namespace": ctx.namespace,
+                    "labels": {
+                        "managed-by": "managed-deployment",
+                        "purpose": "rst-injection",
+                        "target-pod": pod.name[:60],
+                    },
+                },
+                "spec": {
+                    "restartPolicy": "Never",
+                    "hostNetwork": True,
+                    "nodeName": node,
+                    "tolerations": [{"operator": "Exists"}],
+                    "containers": [
+                        {
+                            "name": "rst-inject",
+                            "image": helper_image,
+                            "imagePullPolicy": "IfNotPresent",
+                            "command": ["sh", "-c", cmd],
+                            "securityContext": {
+                                "privileged": True,
+                                "capabilities": {"add": ["NET_ADMIN", "NET_RAW"]},
+                            },
+                        }
+                    ],
+                },
+            }
+            try:
+                await core.create_namespaced_pod(namespace=ctx.namespace, body=body)
+                self._helper_pod_names.append(helper_name)
+                ctx.logger.info(
+                    f"RstInjection: launched {helper_name} on node {node} "
+                    f"targeting pod {pod.name} ({pod_ip}) for {duration_int}s"
+                )
+            except k8s_exceptions.ApiException as e:
+                ctx.logger.warning(
+                    f"RstInjection: failed to schedule helper for "
+                    f"pod {pod.name}: {e}"
+                )
+
+        # Verify every helper pod actually reached Running before we
+        # begin "waiting for the duration". If a pod is stuck in
+        # ImagePullBackOff or ContainerCreating, no RSTs are being
+        # injected; we want a loud failure, not silent no-op.
+        await self._wait_for_running(ctx, core)
+
+        # Hold for ``duration`` seconds so the event blocks the
+        # scenario timeline (mirrors StallProcess(duration=…)). The
+        # helper pods self-timeout to the same value; stop() then
+        # cleans them up.
+        try:
+            await asyncio.sleep(self.duration)
+        finally:
+            # Capture each helper's stdout for the verification record
+            # BEFORE we delete the pod. Grep for the RULE-INSTALLED
+            # / RULE-REMOVED sentinels.
+            await self._capture_and_verify(ctx, core)
+            await self._cleanup(ctx)
+
+    async def _wait_for_running(self, ctx: "ScenarioContext", core) -> None:
+        # 240s — AWS dev image pulls + Pod scheduling can take 60-90s
+        # on first hit; 60s was too tight and produced false negatives.
+        deadline = asyncio.get_event_loop().time() + 240.0
+        not_running = list(self._helper_pod_names)
+        while not_running and asyncio.get_event_loop().time() < deadline:
+            still = []
+            for name in not_running:
+                try:
+                    p = await core.read_namespaced_pod(
+                        name=name, namespace=ctx.namespace
+                    )
+                    phase = p.status.phase
+                    if phase == "Running" or phase == "Succeeded":
+                        ctx.logger.info(f"RstInjection: helper {name} reached {phase}")
+                        continue
+                    if phase == "Failed":
+                        ctx.logger.error(
+                            f"RstInjection: helper {name} FAILED before "
+                            f"installing rules; aborting event"
+                        )
+                        raise RuntimeError(
+                            f"RstInjection helper {name} failed to start"
+                        )
+                except k8s_exceptions.ApiException:
+                    pass
+                still.append(name)
+            not_running = still
+            if not_running:
+                await asyncio.sleep(1.0)
+        if not_running:
+            raise RuntimeError(
+                f"RstInjection: helper pods {not_running} did not reach "
+                f"Running within 60s; iptables rules never installed"
+            )
+
+    async def _capture_and_verify(self, ctx: "ScenarioContext", core) -> None:
+        import os
+
+        records = []
+        for name in self._helper_pod_names:
+            try:
+                logs = await core.read_namespaced_pod_log(
+                    name=name, namespace=ctx.namespace
+                )
+            except k8s_exceptions.ApiException as e:
+                logs = f"<read_pod_log failed: {e}>"
+            installed = "RULE-INSTALLED" in (logs or "")
+            removed = "RULE-REMOVED" in (logs or "")
+            records.append(
+                {
+                    "pod": name,
+                    "installed": installed,
+                    "removed": removed,
+                    "logs": logs or "",
+                }
+            )
+            ctx.logger.info(
+                f"RstInjection: {name} installed={installed} " f"removed={removed}"
+            )
+
+        # Persist a verification record so a post-hoc reader can confirm
+        # rules were installed without re-running anything.
+        log_dir = getattr(ctx, "log_dir", None)
+        if log_dir:
+            try:
+                os.makedirs(log_dir, exist_ok=True)
+                with open(
+                    os.path.join(log_dir, "rst_injection_verification.txt"), "w"
+                ) as fh:
+                    for r in records:
+                        fh.write(
+                            f"=== {r['pod']} installed={r['installed']} "
+                            f"removed={r['removed']} ===\n{r['logs']}\n\n"
+                        )
+            except Exception as e:
+                ctx.logger.warning(
+                    f"RstInjection: could not write verification file: {e}"
+                )
+
+        # Hard fail the event if any helper pod did not install rules.
+        not_installed = [r["pod"] for r in records if not r["installed"]]
+        if not_installed:
+            raise RuntimeError(
+                f"RstInjection: iptables rules NOT installed on helper "
+                f"pods {not_installed}; no RSTs were injected. "
+                f"See rst_injection_verification.txt for stdout."
+            )
+
+    async def stop(self, ctx: "ScenarioContext") -> None:
+        # Safety net if execute() exited early (exception path).
+        await self._cleanup(ctx)
+
+    async def _cleanup(self, ctx: "ScenarioContext") -> None:
+        if not self._helper_pod_names:
+            return
+        core = client.CoreV1Api()
+        for name in self._helper_pod_names:
+            try:
+                await core.delete_namespaced_pod(
+                    name=name,
+                    namespace=ctx.namespace,
+                    grace_period_seconds=0,
+                )
+                ctx.logger.info(f"RstInjection: deleted helper pod {name}")
+            except k8s_exceptions.ApiException:
+                pass
+        self._helper_pod_names = []
+
+    @property
+    def description(self) -> str:
+        return (
+            f"Inject TCP RSTs against {self.service} (pod_indices="
+            f"{self.pod_indices}) for {self.duration}s"
+        )
+
+
+@dataclass
 class WaitForModelReady(Event):
     """Wait until the frontend lists ``model_name`` in /v1/models.
 
@@ -995,3 +1702,484 @@ class WaitForModelReady(Event):
     def description(self) -> str:
         target = self.model_name or "(auto-detected)"
         return f"Wait for model '{target}' in /v1/models"
+
+
+# =============================================================================
+# RstFromInsidePod — true ECONNRESET via SO_LINGER=0 + partial-frame write.
+#
+# Schedules a helper Job in the namespace that runs a small Python client
+# inline. The client opens a TCP connection to a target worker pod's
+# system_port, half-writes a 24-byte TwoPartCodec frame, then closes
+# with SO_LINGER=0 → kernel sends RST instead of FIN → worker's
+# handle_reader hits Some(Err(_)) at tcp/client.rs:255 (v1.0.1) → panics.
+# Post-PR-#8254: WARN line instead.
+#
+# This is the upstream-blessed shape from
+# dynamo-observe/.../2026-05-03-tcp-client-panic-repro/arm_b_rst.py.
+# iptables-FORWARD REJECT (RstInjection) is not on the packet path on
+# AWS VPC CNI; this in-pod approach connects directly to the target
+# pod IP and is reliable.
+# =============================================================================
+
+
+_RST_CLIENT_SCRIPT = r"""
+import os, socket, struct, sys, time  # noqa: E402,E401
+host = os.environ["TARGET_HOST"]
+ports = [int(p) for p in os.environ["TARGET_PORTS"].split(",") if p.strip()]
+count = int(os.environ.get("RST_COUNT", "100"))
+inter = float(os.environ.get("RST_INTER_DELAY", "0.005"))
+partial = b"\x00\x00\x00\x10" + b"x" * 8
+print(f"[rst-client] target={host} ports={ports} count_per_port={count} delay={inter}s", flush=True)
+started = time.monotonic()
+sent = 0
+for i in range(count):
+    for port in ports:
+        try:
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", 1, 0))
+            s.settimeout(5.0)
+            s.connect((host, port))
+            s.sendall(partial)
+            time.sleep(0.05)
+            s.close()
+            sent += 1
+        except Exception as e:
+            print(f"[rst-client] i={i} port={port} err: {e!r}", flush=True)
+    time.sleep(inter)
+elapsed = time.monotonic() - started
+print(f"[rst-client] RST SENT count={sent} elapsed={elapsed:.1f}s "
+      f"rate={sent/elapsed:.1f}/s", flush=True)
+"""
+
+
+@dataclass
+class RstFromInsidePod(Event):
+    """Drive real ECONNRESET to a worker by opening many TCP connections
+    from inside the namespace and closing each with SO_LINGER=0 after a
+    partial protocol-frame write. The remote socket's read loop sees a
+    real ``Io(Os { code: 104, kind: ConnectionReset })`` — the exact
+    shape that triggers PR #8254's panic site on v1.0.1.
+
+    Distinct from ``RstInjection`` (iptables REJECT --reject-with
+    tcp-reset on the host FORWARD chain): that approach is not on the
+    packet path for AWS VPC CNI pod-to-pod traffic, so RSTs never
+    actually reach the worker socket. This event makes a normal TCP
+    socket from a helper pod IN the namespace; pod-to-pod IP routing
+    is direct and the RST always lands.
+
+    Example::
+
+        RstFromInsidePod(
+            service="VllmDecodeWorker",
+            pod_indices=[0],
+            count=200,
+            inter_delay=0.005,
+            target_port=9090,  # spec.system_port
+        )
+    """
+
+    service: str
+    pod_indices: list[int] | str | None = None
+    count: int = 100
+    inter_delay: float = 0.01
+    # target_port: int|None — if None, auto-discover Dynamo TCP server ports
+    # by reading /proc/net/tcp inside the target pod, excluding the framework's
+    # status port (9090), NIXL UCX port (5600), and OpenAI port (8000).
+    target_port: int | None = None
+    name: str = ""
+    results: dict[str, Any] | None = field(default=None, init=False)
+    _helper_pod_names: list[str] = field(default_factory=list, init=False, repr=False)
+
+    # Ports we know are NOT Dynamo's request-plane TcpStreamServer:
+    #   9090 — system_status_server (axum, /live /health /metrics)
+    #   5600 — NIXL UCX transport
+    #   8000 — Frontend OpenAI HTTP port
+    #   80, 443, 22, 53, 5601 etc — common service ports
+    _EXCLUDED_PORTS = {9090, 5600, 8000, 80, 443, 22, 53, 5601, 9092, 9093}
+
+    @staticmethod
+    def _discover_dynamo_ports(pod) -> list[int]:
+        """Read /proc/net/tcp inside the pod and return the set of TCP ports
+        in LISTEN state minus framework-known ports. The remaining set is
+        the Dynamo TcpStreamServer + dynamic etcd/NATS clients."""
+        script = (
+            "python3 -c \"with open('/proc/net/tcp') as f:\n"
+            "  next(f)\n"
+            "  for line in f:\n"
+            "    p = line.split()\n"
+            "    if p[3] == '0A':\n"
+            "      print(int(p[1].split(':')[1], 16))\""
+        )
+        result = pod.exec(["sh", "-c", script])
+        stdout = result.stdout.decode() if hasattr(result, "stdout") else str(result)
+        ports = []
+        for line in stdout.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                port = int(line)
+            except ValueError:
+                continue
+            if port in RstFromInsidePod._EXCLUDED_PORTS:
+                continue
+            if port < 10000:
+                # Below 10000 = framework/static; Dynamo TcpStreamServers
+                # bind ephemeral ports in the 32768+ range.
+                continue
+            ports.append(port)
+        return sorted(set(ports))
+
+    async def execute(self, ctx: "ScenarioContext") -> None:
+        import os
+
+        all_pods = (
+            await asyncio.to_thread(ctx.deployment.get_pods, [self.service])
+        ).get(self.service) or []
+        all_pods = sorted(all_pods, key=lambda p: p.name)
+        target_pods = _resolve_pod_selection(all_pods, self.pod_indices, ctx.logger)
+        if not target_pods:
+            ctx.logger.warning(
+                f"RstFromInsidePod: no target pods in service '{self.service}'"
+            )
+            return
+
+        # Use a generic python image — no Dynamo dep needed for the client.
+        helper_image = os.environ.get("DYN_RST_CLIENT_IMAGE", "python:3.12-slim")
+        core = client.CoreV1Api()
+
+        for pod in target_pods:
+            pod_ip = pod.raw.get("status", {}).get("podIP")
+            if not pod_ip:
+                ctx.logger.warning(
+                    f"RstFromInsidePod: {pod.name} has no podIP; skipping"
+                )
+                continue
+
+            if self.target_port is not None:
+                ports = [self.target_port]
+            else:
+                ports = await asyncio.to_thread(self._discover_dynamo_ports, pod)
+                ctx.logger.info(
+                    f"RstFromInsidePod: discovered {len(ports)} candidate "
+                    f"Dynamo TCP ports on {pod.name}: {ports[:10]}"
+                    f"{'...' if len(ports) > 10 else ''}"
+                )
+                if not ports:
+                    raise RuntimeError(
+                        f"RstFromInsidePod: no Dynamo TCP ports discovered on "
+                        f"{pod.name}; pass target_port explicitly to override"
+                    )
+
+            name = f"rst-client-{secrets.token_hex(4)}"
+            body = {
+                "apiVersion": "v1",
+                "kind": "Pod",
+                "metadata": {
+                    "name": name,
+                    "namespace": ctx.namespace,
+                    "labels": {
+                        "managed-by": "managed-deployment",
+                        "purpose": "rst-from-inside-pod",
+                        "target-pod": pod.name[:60],
+                    },
+                },
+                "spec": {
+                    "restartPolicy": "Never",
+                    "tolerations": [{"operator": "Exists"}],
+                    "containers": [
+                        {
+                            "name": "rst-client",
+                            "image": helper_image,
+                            "imagePullPolicy": "IfNotPresent",
+                            "command": ["python3", "-c", _RST_CLIENT_SCRIPT],
+                            "env": [
+                                {"name": "TARGET_HOST", "value": pod_ip},
+                                {
+                                    "name": "TARGET_PORTS",
+                                    "value": ",".join(str(p) for p in ports),
+                                },
+                                {"name": "RST_COUNT", "value": str(self.count)},
+                                {
+                                    "name": "RST_INTER_DELAY",
+                                    "value": str(self.inter_delay),
+                                },
+                            ],
+                        }
+                    ],
+                },
+            }
+            try:
+                await core.create_namespaced_pod(namespace=ctx.namespace, body=body)
+                self._helper_pod_names.append(name)
+                ctx.logger.info(
+                    f"RstFromInsidePod: launched {name} targeting {pod.name} "
+                    f"({pod_ip}:{self.target_port}) count={self.count}"
+                )
+            except k8s_exceptions.ApiException as e:
+                ctx.logger.warning(
+                    f"RstFromInsidePod: failed to schedule helper for {pod.name}: {e}"
+                )
+
+        # Wait for each helper to finish (Succeeded or Failed). Cap based
+        # on count*inter_delay + 60s buffer.
+        deadline = asyncio.get_event_loop().time() + max(
+            120.0, self.count * self.inter_delay + 60.0
+        )
+        pending = list(self._helper_pod_names)
+        while pending and asyncio.get_event_loop().time() < deadline:
+            still = []
+            for name in pending:
+                try:
+                    p = await core.read_namespaced_pod(
+                        name=name, namespace=ctx.namespace
+                    )
+                    phase = p.status.phase
+                    if phase in ("Succeeded", "Failed"):
+                        continue
+                except k8s_exceptions.ApiException:
+                    pass
+                still.append(name)
+            pending = still
+            if pending:
+                await asyncio.sleep(2.0)
+
+        # Capture stdout for verification (grep for "RST SENT count=N").
+        await self._capture(ctx, core)
+        await self._cleanup(ctx, core)
+
+    async def _capture(self, ctx, core) -> None:
+        import os
+
+        log_dir = getattr(ctx, "log_dir", None)
+        records = []
+        for name in self._helper_pod_names:
+            try:
+                logs = await core.read_namespaced_pod_log(
+                    name=name, namespace=ctx.namespace
+                )
+            except k8s_exceptions.ApiException as e:
+                logs = f"<read_pod_log failed: {e}>"
+            sent_line = next(
+                (ln for ln in (logs or "").splitlines() if "RST SENT count=" in ln), ""
+            )
+            records.append({"pod": name, "sent_line": sent_line, "logs": logs or ""})
+            ctx.logger.info(
+                f"RstFromInsidePod: {name} -> {sent_line or '<no SENT line>'}"
+            )
+        if log_dir:
+            try:
+                os.makedirs(log_dir, exist_ok=True)
+                with open(os.path.join(log_dir, "rst_from_inside_pod.txt"), "w") as fh:
+                    for r in records:
+                        fh.write(
+                            f"=== {r['pod']} ===\nSENT: {r['sent_line']}\n{r['logs']}\n\n"
+                        )
+            except Exception as e:
+                ctx.logger.warning(
+                    f"RstFromInsidePod: could not write verification file: {e}"
+                )
+        not_sent = [r["pod"] for r in records if not r["sent_line"]]
+        if not_sent:
+            raise RuntimeError(
+                f"RstFromInsidePod: helper pods {not_sent} did not emit a "
+                f"'RST SENT count=N' line; client never ran or failed to connect."
+            )
+
+    async def _cleanup(self, ctx, core) -> None:
+        for name in list(self._helper_pod_names):
+            try:
+                await core.delete_namespaced_pod(
+                    name=name, namespace=ctx.namespace, grace_period_seconds=0
+                )
+            except k8s_exceptions.ApiException:
+                pass
+        self._helper_pod_names = []
+
+    async def stop(self, ctx: "ScenarioContext") -> None:
+        core = client.CoreV1Api()
+        await self._cleanup(ctx, core)
+
+    @property
+    def description(self) -> str:
+        return (
+            f"RstFromInsidePod: {self.count} SO_LINGER=0 closes against "
+            f"{self.service}:{self.target_port}"
+        )
+
+
+# =============================================================================
+# PodMemoryPoller — records BOTH cgroup container memory (metrics.k8s.io,
+# same source kubelet uses for OOMKill decisions) AND per-process RSS
+# of pid 1 (/proc/1/status:VmRSS, via pod.exec) for each pod, on every
+# poll. Two columns let PodMemoryGrowth assert on the right signal:
+#
+#   - working_set_bytes: what kubelet sees → OOMKill-relevant.
+#   - pid1_rss_bytes: what the main binary actually maps → attribution.
+#
+# The two are usually close on single-process containers like the
+# Dynamo frontend, but diverge when child processes are large (e.g.
+# vLLM workers).
+# =============================================================================
+
+
+def _parse_k8s_quantity(s: str) -> int:
+    """Parse a k8s resource quantity like '123Mi', '12345Ki', '1Gi' to bytes."""
+    if not s:
+        return 0
+    suffixes = {
+        "Ki": 1024,
+        "Mi": 1024**2,
+        "Gi": 1024**3,
+        "Ti": 1024**4,
+        "K": 1000,
+        "M": 1000**2,
+        "G": 1000**3,
+        "T": 1000**4,
+    }
+    for suf, mult in suffixes.items():
+        if s.endswith(suf):
+            try:
+                return int(float(s[: -len(suf)]) * mult)
+            except ValueError:
+                return 0
+    try:
+        return int(s)
+    except ValueError:
+        return 0
+
+
+@dataclass
+class PodMemoryPoller(Event):
+    """Spawn a background task that on every poll, for each pod of
+    ``services``, records two memory numbers and appends a row to
+    ``ctx.log_dir/pod_memory_growth.tsv``:
+
+    Columns: ``epoch_s, service, pod, container, working_set_bytes, pid1_rss_bytes``.
+
+    - ``working_set_bytes``: from metrics.k8s.io (same as
+      `kubectl top pod`; kubelet uses this for OOMKill).
+    - ``pid1_rss_bytes``: from `/proc/1/status:VmRSS` inside the
+      container (per-process attribution).
+
+    The ``PodMemoryGrowth`` check reads either column.
+
+    Best placed right after ``WaitForModelReady`` so polling starts
+    before any fault is injected. Stops automatically when ``stop()``
+    fires at scenario teardown.
+
+    metrics-server's scrape interval is ~15s on most clusters — polling
+    faster yields duplicate working-set samples but pid1 RSS is fresh
+    every call. 15s default matches the metrics-server cadence.
+    """
+
+    services: list[str]
+    interval_s: float = 15.0
+    name: str = ""
+    results: dict[str, Any] | None = field(default=None, init=False)
+    _task: Any = field(default=None, init=False, repr=False)
+    _stop: Any = field(default=None, init=False, repr=False)
+
+    async def execute(self, ctx: "ScenarioContext") -> None:
+        import os
+
+        log_dir = getattr(ctx, "log_dir", None)
+        if not log_dir:
+            ctx.logger.warning("PodMemoryPoller: no ctx.log_dir; skipping")
+            return
+        os.makedirs(log_dir, exist_ok=True)
+        out = os.path.join(log_dir, "pod_memory_growth.tsv")
+        with open(out, "w") as fh:
+            fh.write(
+                "epoch_s\tservice\tpod\tcontainer\t"
+                "working_set_bytes\tpid1_rss_bytes\n"
+            )
+        self._stop = asyncio.Event()
+
+        custom = client.CustomObjectsApi()
+
+        async def read_working_set(pod_name):
+            """metrics.k8s.io -> dict[container_name, working_set_bytes]."""
+            try:
+                obj = await custom.get_namespaced_custom_object(
+                    group="metrics.k8s.io",
+                    version="v1beta1",
+                    namespace=ctx.namespace,
+                    plural="pods",
+                    name=pod_name,
+                )
+            except k8s_exceptions.ApiException:
+                return {}
+            return {
+                c.get("name", "?"): _parse_k8s_quantity(
+                    (c.get("usage") or {}).get("memory") or "0"
+                )
+                for c in (obj.get("containers") or [])
+            }
+
+        async def read_pid1_rss(pod):
+            """`cat /proc/1/status:VmRSS` -> bytes (or 0)."""
+            try:
+                result = await asyncio.to_thread(
+                    pod.exec,
+                    ["sh", "-c", "grep VmRSS /proc/1/status 2>/dev/null || true"],
+                )
+                stdout = (
+                    result.stdout.decode() if hasattr(result, "stdout") else str(result)
+                )
+                for ln in stdout.splitlines():
+                    if "VmRSS" in ln:
+                        for tok in ln.split():
+                            if tok.isdigit():
+                                return int(tok) * 1024  # kB → bytes
+            except Exception:
+                pass
+            return 0
+
+        async def loop():
+            import time
+
+            while not self._stop.is_set():
+                try:
+                    for svc in self.services:
+                        pods_by_svc = await asyncio.to_thread(
+                            ctx.deployment.get_pods, [svc]
+                        )
+                        for pod in pods_by_svc.get(svc) or []:
+                            ws_by_container = await read_working_set(pod.name)
+                            pid1_rss = await read_pid1_rss(pod)
+                            ts = time.time()
+                            if not ws_by_container:
+                                ws_by_container = {"?": 0}
+                            for cname, ws_bytes in ws_by_container.items():
+                                with open(out, "a") as fh:
+                                    fh.write(
+                                        f"{ts:.0f}\t{svc}\t{pod.name}\t"
+                                        f"{cname}\t{ws_bytes}\t{pid1_rss}\n"
+                                    )
+                except Exception as e:
+                    ctx.logger.warning(f"PodMemoryPoller loop err: {e}")
+                try:
+                    await asyncio.wait_for(self._stop.wait(), timeout=self.interval_s)
+                except asyncio.TimeoutError:
+                    pass
+
+        self._task = asyncio.create_task(loop())
+        ctx.logger.info(
+            f"PodMemoryPoller(metrics.k8s.io): services={self.services} "
+            f"interval={self.interval_s}s"
+        )
+
+    async def stop(self, ctx: "ScenarioContext") -> None:
+        if self._stop is not None:
+            self._stop.set()
+        if self._task is not None:
+            try:
+                await asyncio.wait_for(self._task, timeout=15.0)
+            except asyncio.TimeoutError:
+                self._task.cancel()
+        ctx.logger.info("PodMemoryPoller: stopped")
+
+    @property
+    def description(self) -> str:
+        return f"PodMemoryPoller {self.services} every {self.interval_s}s"

--- a/tests/fault_tolerance/deploy/events.py
+++ b/tests/fault_tolerance/deploy/events.py
@@ -255,19 +255,53 @@ class StartLoad(Event):
         if self.load_config.extra_server_metrics_urls is None:
             spec = ctx.deployment.deployment_spec
             urls: list[str] = []
+            shortfall: list[str] = []
             for service in spec.services:
-                pods_by_service = await asyncio.to_thread(
-                    ctx.deployment.get_pods, [service.name]
-                )
+                expected = service.replicas
+                if expected <= 0:
+                    continue
+                # Retry once with a short backoff to tolerate a transient
+                # missing podIP — pods are Ready by here, but the kr8s
+                # snapshot can race the status subresource update.
+                pods: list = []
+                for attempt in range(2):
+                    pods_by_service = await asyncio.to_thread(
+                        ctx.deployment.get_pods, [service.name]
+                    )
+                    pods = pods_by_service.get(service.name) or []
+                    ready_with_ip = [
+                        p for p in pods if p.raw.get("status", {}).get("podIP")
+                    ]
+                    if len(ready_with_ip) >= expected:
+                        pods = ready_with_ip
+                        break
+                    if attempt == 0:
+                        await asyncio.sleep(2)
                 metrics_port = (
                     spec.port
                     if service.component_type == "frontend"
                     else spec.system_port
                 )
-                for pod in pods_by_service.get(service.name) or []:
+                seen_for_service = 0
+                for pod in pods:
                     pod_ip = pod.raw.get("status", {}).get("podIP")
                     if pod_ip:
                         urls.append(f"http://{pod_ip}:{metrics_port}/metrics")
+                        seen_for_service += 1
+                ctx.logger.info(
+                    f"StartLoad: service={service.name} "
+                    f"expected_replicas={expected} pods_with_podIP={seen_for_service}"
+                )
+                if seen_for_service < expected:
+                    shortfall.append(f"{service.name}: {seen_for_service}/{expected}")
+            if shortfall:
+                raise RuntimeError(
+                    "StartLoad: auto-discovery undercount — some replicas "
+                    "missing /metrics URLs. AIPerf cannot scrape full fleet. "
+                    f"Shortfalls: {shortfall}. "
+                    "Pass an explicit LoadConfig.extra_server_metrics_urls "
+                    "or wait for all pods Ready before this event."
+                )
             if urls:
                 ctx.logger.info(f"StartLoad: auto-discovered /metrics URLs: {urls}")
                 self.load_config.extra_server_metrics_urls = urls

--- a/tests/fault_tolerance/deploy/events.py
+++ b/tests/fault_tolerance/deploy/events.py
@@ -511,6 +511,35 @@ class Wait(Event):
 
 
 @dataclass
+class CaptureMetrics(Event):
+    """Scrape ``/metrics`` from every pod and write raw text per pod.
+
+    Thin YAML wrapper around ``ManagedDeployment._capture_metrics``.
+    Output lands at ``<log_dir>/<service>/<pod>.metrics<suffix>.log`` —
+    raw Prometheus text, no parsing. Downstream verifiers / observe
+    tooling pull the metric names they care about.
+
+    The framework also auto-fires this at end-of-test (``__aexit__``,
+    suffix ``.final``) and on pod-kill (``DeletePod`` event, suffix
+    ``.before_delete``). Use this event when a scenario needs a named
+    mid-test snapshot (e.g. just before a load step-up, just after a
+    threshold change).
+    """
+
+    suffix: str = ".snapshot"
+    name: str = ""
+    results: dict[str, Any] | None = field(default=None, init=False)
+
+    async def execute(self, ctx: "ScenarioContext") -> None:
+        ctx.logger.info(f"CaptureMetrics: scraping all pods (suffix={self.suffix!r})")
+        await ctx.deployment._capture_metrics(suffix=self.suffix)
+
+    @property
+    def description(self) -> str:
+        return f"CaptureMetrics(suffix={self.suffix})"
+
+
+@dataclass
 class SetBusyThreshold(Event):
     """POST /busy_threshold to the Frontend service. Affects only the named
     model. Subsequent requests will receive 503 once *all* workers for the
@@ -589,9 +618,7 @@ class DeletePod(Event):
             for pod in pods_to_delete:
                 ctx.logger.info(f"Deleting pod {pod.name} (service: {service_name})")
                 ctx.deployment._get_pod_manifest(pod, service_name, ".before_delete")
-                await ctx.deployment._get_pod_metrics(
-                    pod, service_name, ".before_delete"
-                )
+                ctx.deployment._get_pod_metrics(pod, service_name, ".before_delete")
                 pod.delete(force=self.force)
                 deleted_names.append(pod.name)
         self._baseline_names = baseline_names
@@ -2248,13 +2275,25 @@ class PodMemoryPoller(Event):
             ctx.logger.warning("PodMemoryPoller: no ctx.log_dir; skipping")
             return
         os.makedirs(log_dir, exist_ok=True)
-        out = os.path.join(log_dir, "pod_memory_growth.tsv")
-        with open(out, "w") as fh:
-            fh.write(
-                "epoch_s\tservice\tpod\tcontainer\t"
-                "working_set_bytes\tpid1_rss_bytes\n"
-            )
+        # Per-pod memory files written to ``<log_dir>/<service>/<pod>_memory.tsv``
+        # — parallel construction with the per-pod ``<pod>_<ts>.log`` files
+        # written by the framework's log-collection pipeline. Removes the
+        # single-file contention that caused the 14s stutter on sanity Run 1
+        # and matches the canonical layout used by downstream verifier
+        # scripts. A union TSV at <log_dir>/pod_memory_growth.tsv is kept
+        # for backward compatibility — written at stop time.
+        TSV_HEADER = (
+            "epoch_s\tservice\tpod\tcontainer\t" "working_set_bytes\tpid1_rss_bytes\n"
+        )
+        # Initialize the legacy flat file too (for tooling that still reads it)
+        legacy_out = os.path.join(log_dir, "pod_memory_growth.tsv")
+        with open(legacy_out, "w") as fh:
+            fh.write(TSV_HEADER)
         self._stop = asyncio.Event()
+        self._per_pod_files: set[str] = set()  # type: ignore[name-defined]
+        self._tsv_header = TSV_HEADER
+        self._log_dir = log_dir
+        self._legacy_out = legacy_out
 
         custom = client.CustomObjectsApi()
 
@@ -2311,12 +2350,24 @@ class PodMemoryPoller(Event):
                             ts = time.time()
                             if not ws_by_container:
                                 ws_by_container = {"?": 0}
+                            # Per-pod file: <log_dir>/<service>/<pod>_memory.tsv
+                            pod_dir = os.path.join(self._log_dir, svc)
+                            os.makedirs(pod_dir, exist_ok=True)
+                            pod_file = os.path.join(pod_dir, f"{pod.name}_memory.tsv")
+                            if pod_file not in self._per_pod_files:
+                                with open(pod_file, "w") as fh:
+                                    fh.write(self._tsv_header)
+                                self._per_pod_files.add(pod_file)
                             for cname, ws_bytes in ws_by_container.items():
-                                with open(out, "a") as fh:
-                                    fh.write(
-                                        f"{ts:.0f}\t{svc}\t{pod.name}\t"
-                                        f"{cname}\t{ws_bytes}\t{pid1_rss}\n"
-                                    )
+                                row = (
+                                    f"{ts:.0f}\t{svc}\t{pod.name}\t"
+                                    f"{cname}\t{ws_bytes}\t{pid1_rss}\n"
+                                )
+                                with open(pod_file, "a") as fh:
+                                    fh.write(row)
+                                # Legacy flat file for backward compat
+                                with open(self._legacy_out, "a") as fh:
+                                    fh.write(row)
                 except Exception as e:
                     ctx.logger.warning(f"PodMemoryPoller loop err: {e}")
                 try:

--- a/tests/fault_tolerance/deploy/events.py
+++ b/tests/fault_tolerance/deploy/events.py
@@ -527,16 +527,33 @@ class CaptureMetrics(Event):
     """
 
     suffix: str = ".snapshot"
+    # When True, also write per-pod manifest (``<pod><suffix>.yaml``) + the
+    # Kubernetes Event resources (``<pod><suffix>.events.yaml``) alongside the
+    # /metrics scrape. The events.yaml surfaces pod-level issues at this capture
+    # point — probe failures, OOMKills, scheduling/BindingErrors, kill/restart
+    # reasons — which the metrics scrape alone doesn't show.
+    include_events: bool = False
     name: str = ""
     results: dict[str, Any] | None = field(default=None, init=False)
 
     async def execute(self, ctx: "ScenarioContext") -> None:
-        ctx.logger.info(f"CaptureMetrics: scraping all pods (suffix={self.suffix!r})")
-        await ctx.deployment._capture_metrics(suffix=self.suffix)
+        ctx.logger.info(
+            f"CaptureMetrics: scraping all pods (suffix={self.suffix!r}, "
+            f"include_events={self.include_events})"
+        )
+        if self.include_events:
+            # Full per-pod capture: manifest + k8s events.yaml + /metrics.
+            import asyncio
+
+            await asyncio.to_thread(
+                ctx.deployment._get_service_logs, suffix=self.suffix
+            )
+        else:
+            await ctx.deployment._capture_metrics(suffix=self.suffix)
 
     @property
     def description(self) -> str:
-        return f"CaptureMetrics(suffix={self.suffix})"
+        return f"CaptureMetrics(suffix={self.suffix}, events={self.include_events})"
 
 
 @dataclass

--- a/tests/fault_tolerance/deploy/events.py
+++ b/tests/fault_tolerance/deploy/events.py
@@ -17,6 +17,7 @@ To create a custom event, subclass Event and implement execute() and description
 
 import asyncio
 import json
+import os
 import random
 import re
 import secrets
@@ -402,10 +403,24 @@ class StartLoad(Event):
         ctx.logger.info(f"Load '{self.name}' started")
 
     async def stop(self, ctx: "ScenarioContext") -> None:
-        """Wait for load to complete and collect results."""
+        """Teardown hook: stop the load PROMPTLY and collect results.
+
+        Runs during scenario teardown, including the abort path. It must NOT
+        wait for the load to finish naturally — that is the job of the explicit
+        ``WaitForLoadCompletion`` event, which on the normal path already
+        drained the load and set ``self._managed_load = None``, making this a
+        no-op. If we reach here with a load still running (e.g. the scenario
+        aborted before ``WaitForLoadCompletion``), ``wait_for_completion()``
+        would block for the FULL remaining load duration (up to
+        ``duration_minutes*60 + 300`` s — 4800 s for a 75-min run), stalling
+        deployment teardown: the DGD delete in ``ManagedDeployment.__aexit__``
+        runs only after this returns. So ``terminate()`` instead — SIGINT →
+        SIGTERM to aiperf with a bounded wait — then collect whatever results
+        exist. ``terminate()`` is itself a no-op if the load already completed.
+        """
         if self._managed_load:
             ctx.logger.info(f"Stopping load '{self.name}'...")
-            await self._managed_load.wait_for_completion()
+            await self._managed_load.terminate()
             self.results = await self._managed_load.get_results()
             await self._managed_load._cleanup()
             self._managed_load = None
@@ -2480,15 +2495,31 @@ class PodMemoryPoller2(Event):
             'OUTDIR="${DYN_LOG_DIR:-/tmp/service_logs}"; mkdir -p "$OUTDIR"; '
             'export OUT="$OUTDIR/$(hostname).mempoller2.tsv"; '
             "rm -f /tmp/.mempoller2.stop; "
-            'printf "# PodMemoryPoller2\\tepoch_s\\tpod\\tpid1_rss_bytes\\n" > "$OUT"; '
+            'printf "# PodMemoryPoller2\\tepoch_s\\tpod\\tworking_set_bytes\\t'
+            'cgroup_current_bytes\\tall_pids_rss_bytes\\tpid1_rss_bytes\\n" > "$OUT"; '
             # date +%s.%N is fractional on GNU coreutils (the runtime images);
             # busybox date lacks %N and would emit a literal ".%N", so strip a
             # trailing non-numeric tail back to whole seconds as a fallback.
             "nohup sh -c 'while [ ! -f /tmp/.mempoller2.stop ]; do "
             'TS="$(date +%s.%N)"; case "$TS" in *N) TS="$(date +%s)";; esac; '
-            'printf "%s\\t%s\\t%s\\n" "$TS" "$(hostname)" '
-            '"$(awk "/VmRSS/{print \\$2*1024}" /proc/1/status 2>/dev/null)" '
-            '>> "$OUT" 2>/dev/null; '
+            # working_set = cgroup usage - inactive_file (what kubelet/cAdvisor
+            # use for OOMKill). cgroup v2 (memory.current) with v1 fallback.
+            "if [ -f /sys/fs/cgroup/memory.current ]; then "
+            'CUR="$(cat /sys/fs/cgroup/memory.current 2>/dev/null)"; '
+            'INACT="$(awk "/^inactive_file /{print \\$2}" /sys/fs/cgroup/memory.stat 2>/dev/null)"; '
+            "else "
+            'CUR="$(cat /sys/fs/cgroup/memory/memory.usage_in_bytes 2>/dev/null)"; '
+            'INACT="$(awk "/^total_inactive_file /{print \\$2}" /sys/fs/cgroup/memory/memory.stat 2>/dev/null)"; '
+            "fi; "
+            'WS="$(( ${CUR:-0} - ${INACT:-0} ))"; '
+            # all-pids RSS: sum VmRSS across every process in the pod (not just
+            # pid1 — the GPU worker spreads memory across EngineCore/Worker/etc.;
+            # pid1 alone is ~14% of the real footprint). Over-counts shared
+            # pages, so working_set above is the accurate non-double-counted total.
+            'ALLRSS="$(awk "/VmRSS/{s+=\\$2} END{print s*1024}" /proc/[0-9]*/status 2>/dev/null)"; '
+            'PID1="$(awk "/VmRSS/{print \\$2*1024}" /proc/1/status 2>/dev/null)"; '
+            'printf "%s\\t%s\\t%s\\t%s\\t%s\\t%s\\n" "$TS" "$(hostname)" '
+            '"$WS" "$CUR" "$ALLRSS" "$PID1" >> "$OUT" 2>/dev/null; '
             f"sleep {interval}; done' >/dev/null 2>&1 & "
             'echo "mempoller2 started pid $!"'
         )
@@ -2529,6 +2560,104 @@ class PodMemoryPoller2(Event):
     @property
     def description(self) -> str:
         return f"PodMemoryPoller2 (in-pod) {self.services} every {self.interval_s}s"
+
+
+def _load_respoller_source() -> str:
+    """Read the in-pod sampler (``_respoller.py``) as text to heredoc into target
+    pods. Kept as a sibling file (not embedded) so it stays real, lintable Python."""
+    path = os.path.join(os.path.dirname(__file__), "_respoller.py")
+    with open(path, "r") as f:
+        return f.read()
+
+
+@dataclass
+class ResourcePoller(Event):
+    """In-pod per-process resource sampler — successor to :class:`PodMemoryPoller`
+    (host-side) and :class:`PodMemoryPoller2` (in-pod, pid1-only). Launches one
+    detached python sampler (``_respoller.py``) per pod that, every
+    ``interval_s``, writes two TSVs to the pod's ``$DYN_LOG_DIR`` (carried back by
+    the existing extractor):
+
+    * ``<pod>.resources.agg.tsv`` — cgroup working_set + cgroup_current + all-pid
+      RSS sum + pid1 RSS, plus per-device GPU util/mem (one row per GPU).
+    * ``<pod>.resources.procs.tsv`` — per process: RSS, utime/stime jiffies
+      (→ %CPU offline) and per-pid GPU mem + sm%.
+
+    GPU is read via **pynvml** in-pod (``nvmlDeviceGetComputeRunningProcesses`` +
+    ``nvmlDeviceGetProcessUtilization``) — node-local, so it sees the worker's own
+    GPUs and per-process attribution that a remote client (aiperf's dcgm-exporter
+    scrape) cannot. ``include`` selects dimensions from ``{mem, cpu, gpu}``
+    (default all); each is best-effort (no pynvml → gpu columns blank, mem+cpu
+    still recorded). pid1 RSS alone is ~14% of a GPU worker's real footprint —
+    this captures the whole pod, which is why it supersedes the pid1-only pollers.
+    """
+
+    services: list[str]
+    interval_s: float = 5.0
+    include: list[str] = field(default_factory=lambda: ["mem", "cpu", "gpu"])
+    name: str = ""
+    _started_pods: Any = field(default=None, init=False, repr=False)
+
+    async def execute(self, ctx: "ScenarioContext") -> None:
+        self._started_pods = []
+        include = ",".join(self.include)
+        interval = int(self.interval_s) if self.interval_s >= 1 else 1
+        # Write the sampler to the pod via a quoted heredoc (no shell expansion of
+        # the python body), then launch it detached. nohup + redirect so the
+        # closing exec session doesn't SIGHUP/EPIPE it.
+        launch = (
+            (
+                'set -e; OUTDIR="${DYN_LOG_DIR:-/tmp/service_logs}"; mkdir -p "$OUTDIR"; '
+                "cat > /tmp/respoller.py <<'PYEOF'\n"
+            )
+            + _load_respoller_source()
+            + (
+                "\nPYEOF\n"
+                "rm -f /tmp/.respoller.stop; "
+                f'RESPOLL_OUTDIR="$OUTDIR" RESPOLL_INTERVAL={interval} '
+                f"RESPOLL_INCLUDE={include} RESPOLL_STOP=/tmp/.respoller.stop "
+                "nohup python3 /tmp/respoller.py >/tmp/respoller.out 2>&1 & "
+                'echo "respoller started pid $!"'
+            )
+        )
+        started = 0
+        for svc in self.services:
+            pods_by_svc = await asyncio.to_thread(ctx.deployment.get_pods, [svc])
+            for pod in pods_by_svc.get(svc) or []:
+                try:
+                    await asyncio.to_thread(pod.exec, ["sh", "-c", launch])
+                    self._started_pods.append((svc, pod.name))
+                    started += 1
+                except Exception as e:
+                    ctx.logger.warning(
+                        f"ResourcePoller: failed to start sampler on {pod.name}: {e}"
+                    )
+        ctx.logger.info(
+            f"ResourcePoller: launched in-pod samplers on {started} pods across "
+            f"{self.services}, interval={interval}s, include={include}. Output: "
+            f"service_logs/<role>/<pod>.resources.{{agg,procs}}.tsv on the log PVC."
+        )
+
+    async def stop(self, ctx: "ScenarioContext") -> None:
+        stop_script = "touch /tmp/.respoller.stop 2>/dev/null || true"
+        for svc in self.services:
+            try:
+                pods_by_svc = await asyncio.to_thread(ctx.deployment.get_pods, [svc])
+            except Exception:
+                continue
+            for pod in pods_by_svc.get(svc) or []:
+                try:
+                    await asyncio.to_thread(pod.exec, ["sh", "-c", stop_script])
+                except Exception:
+                    pass
+        ctx.logger.info("ResourcePoller: signalled in-pod samplers to stop")
+
+    @property
+    def description(self) -> str:
+        return (
+            f"ResourcePoller(include={','.join(self.include)}) "
+            f"{self.services} every {self.interval_s}s"
+        )
 
 
 @dataclass

--- a/tests/fault_tolerance/deploy/events.py
+++ b/tests/fault_tolerance/deploy/events.py
@@ -512,48 +512,45 @@ class Wait(Event):
 
 @dataclass
 class CaptureMetrics(Event):
-    """Scrape ``/metrics`` from every pod and write raw text per pod.
+    """Point-in-time per-pod snapshot: ``/metrics`` + pod manifest + k8s events.
 
-    Thin YAML wrapper around ``ManagedDeployment._capture_metrics``.
-    Output lands at ``<log_dir>/<service>/<pod>.metrics<suffix>.log`` —
-    raw Prometheus text, no parsing. Downstream verifiers / observe
-    tooling pull the metric names they care about.
+    Despite the name (kept for back-compat — many scenarios reference it),
+    this always captures the full point-in-time set per pod:
+      - ``<pod><suffix>.metrics<suffix>.log`` — raw Prometheus /metrics
+      - ``<pod><suffix>.yaml``                — pod object (spec + status)
+      - ``<pod><suffix>.events.yaml``         — k8s Event resources (probe
+        failures, OOMKills, scheduling/BindingErrors, kill/restart reasons)
 
-    The framework also auto-fires this at end-of-test (``__aexit__``,
-    suffix ``.final``) and on pod-kill (``DeletePod`` event, suffix
-    ``.before_delete``). Use this event when a scenario needs a named
-    mid-test snapshot (e.g. just before a load step-up, just after a
-    threshold change).
+    Events + manifest always accompany the metrics because that's the
+    diagnostic context you want whenever a capture matters — and k8s events
+    age out (~1h TTL), so capturing them at each call is the only way to
+    preserve per-phase events. Container **logs are NOT re-dumped here** — they
+    stream continuously to the log-collection PVC (tee wrapper) and are tailed
+    by ``PeriodicSnapshot``; re-dumping per-capture would just bloat the output.
+
+    The framework also auto-fires a capture at end-of-test (``__aexit__``,
+    suffix ``.final``) and on pod-kill (``DeletePod`` event, ``.before_delete``).
+    Use this event for a named mid-test snapshot (e.g. just after a fault).
     """
 
     suffix: str = ".snapshot"
-    # When True, also write per-pod manifest (``<pod><suffix>.yaml``) + the
-    # Kubernetes Event resources (``<pod><suffix>.events.yaml``) alongside the
-    # /metrics scrape. The events.yaml surfaces pod-level issues at this capture
-    # point — probe failures, OOMKills, scheduling/BindingErrors, kill/restart
-    # reasons — which the metrics scrape alone doesn't show.
-    include_events: bool = False
     name: str = ""
     results: dict[str, Any] | None = field(default=None, init=False)
 
     async def execute(self, ctx: "ScenarioContext") -> None:
         ctx.logger.info(
-            f"CaptureMetrics: scraping all pods (suffix={self.suffix!r}, "
-            f"include_events={self.include_events})"
+            f"CaptureMetrics: capturing all pods — /metrics + manifest + "
+            f"k8s events (suffix={self.suffix!r})"
         )
-        if self.include_events:
-            # Full per-pod capture: manifest + k8s events.yaml + /metrics.
-            import asyncio
+        # _get_service_logs writes /metrics + manifest + events.yaml per pod.
+        # It's sync (k8s API + file writes) → off-load from the event loop.
+        import asyncio
 
-            await asyncio.to_thread(
-                ctx.deployment._get_service_logs, suffix=self.suffix
-            )
-        else:
-            await ctx.deployment._capture_metrics(suffix=self.suffix)
+        await asyncio.to_thread(ctx.deployment._get_service_logs, suffix=self.suffix)
 
     @property
     def description(self) -> str:
-        return f"CaptureMetrics(suffix={self.suffix}, events={self.include_events})"
+        return f"CaptureMetrics(suffix={self.suffix})"
 
 
 @dataclass

--- a/tests/fault_tolerance/deploy/events.py
+++ b/tests/fault_tolerance/deploy/events.py
@@ -16,6 +16,7 @@ To create a custom event, subclass Event and implement execute() and description
 """
 
 import asyncio
+import glob
 import json
 import os
 import random
@@ -35,6 +36,8 @@ __all__ = [
     "WaitForLogPattern",
     "TerminateProcess",
     "StallProcess",
+    "StallWorker",
+    "StallEngineCore",
     "RunCommand",
     "NetworkPartition",
     "WaitForModelReady",
@@ -42,6 +45,9 @@ __all__ = [
     "RstInjection",
     "RstFromInsidePod",
     "PodMemoryPoller",
+    "PodMemoryPoller2",
+    "ResourcePoller",
+    "synthesize_pod_memory_growth_tsv",
     "PeriodicSnapshot",
     "RANDOM",
     "ALL",
@@ -977,7 +983,11 @@ class StallProcess(Event):
     """
 
     services: list[str]
-    process_name: str
+    # Explicit process-name substring (matched in the ps cmdline), OR leave it
+    # empty and set ``target`` to resolve the backend's process via
+    # engine_details — so the same scenario works across vllm/sglang/trtllm/mocker.
+    process_name: str = ""
+    target: str | None = None  # semantic: "main"|"engine"|"worker" -> engine_details
     duration: float | None = None  # seconds; None = hold until scenario stop()
     # Pod / rank selection — see DeletePod / TerminateProcess and the
     # module-level ``RANDOM`` sentinel for semantics.
@@ -989,10 +999,33 @@ class StallProcess(Event):
         default_factory=list, init=False, repr=False
     )
 
+    def _effective_process_name(self, ctx: "ScenarioContext") -> str:
+        """The concrete process-name substring to match: either the explicit
+        ``process_name``, or — if only ``target`` is set — the backend's process
+        for that semantic target, resolved via engine_details from the deployment
+        backend (so the same scenario works across vllm/sglang/trtllm/mocker)."""
+        if self.process_name:
+            return self.process_name
+        if self.target:
+            try:
+                from engine_details import process_name_for
+            except ImportError:  # when imported as a package
+                from .engine_details import process_name_for
+            backend = ctx.deployment.deployment_spec.backend
+            resolved = process_name_for(backend, self.target)
+            ctx.logger.info(
+                f"StallProcess: target={self.target!r} backend={backend!r} "
+                f"-> process_name={resolved!r}"
+            )
+            return resolved
+        raise ValueError(
+            f"StallProcess needs process_name or target (name={self.name!r})"
+        )
+
     async def execute(self, ctx: "ScenarioContext") -> None:
+        proc_name = self._effective_process_name(ctx)
         ctx.logger.info(
-            f"Stalling process '{self.process_name}' (SIGSTOP) "
-            f"in services: {self.services}"
+            f"Stalling process '{proc_name}' (SIGSTOP) " f"in services: {self.services}"
         )
         service_pod_dict = ctx.deployment.get_pods(self.services)
         for service_name, pods in service_pod_dict.items():
@@ -1000,7 +1033,7 @@ class StallProcess(Event):
             pods = _resolve_pod_selection(pods, self.pod_indices, ctx.logger)
             for pod in pods:
                 processes = ctx.deployment.get_processes(pod)
-                matches = [p for p in processes if self.process_name in p.command]
+                matches = [p for p in processes if proc_name in p.command]
                 matches.sort(key=lambda p: p.pid)
                 chosen = _resolve_rank_selection(
                     matches, self.rank_index, pod.name, ctx.logger
@@ -1124,7 +1157,30 @@ class StallProcess(Event):
     @property
     def description(self) -> str:
         suffix = f" for {self.duration}s" if self.duration else ""
-        return f"Stall '{self.process_name}' in {', '.join(self.services)}" f"{suffix}"
+        what = self.process_name or (f"target={self.target}" if self.target else "?")
+        return f"Stall '{what}' in {', '.join(self.services)}" f"{suffix}"
+
+
+@dataclass
+class StallWorker(StallProcess):
+    """:class:`StallProcess` preset to the backend's *worker* process
+    (``target='worker'``) — e.g. ``VLLM::Worker`` for vllm. For vllm this is the
+    rank whose ``sample_tokens`` RPC timeout drives the EngineCore to self-kill →
+    instance_id churn; leave ``process_name`` empty and the backend is resolved
+    at runtime via engine_details (works for sglang/trtllm/mocker too)."""
+
+    target: str | None = "worker"
+
+
+@dataclass
+class StallEngineCore(StallProcess):
+    """:class:`StallProcess` preset to the backend's *engine* process
+    (``target='engine'``) — e.g. ``VLLM::EngineCore`` for vllm. NOTE: for vllm,
+    stalling the EngineCore only hangs at ``shm_broadcast`` (no self-kill) — use
+    :class:`StallWorker` for the death/churn repro. Provided for symmetry + for
+    backends whose engine *is* the death target (see engine_details.DEATH_TARGET)."""
+
+    target: str | None = "engine"
 
 
 @dataclass
@@ -2265,303 +2321,6 @@ def _parse_k8s_quantity(s: str) -> int:
         return 0
 
 
-@dataclass
-class PodMemoryPoller(Event):
-    """Spawn a background task that on every poll, for each pod of
-    ``services``, records two memory numbers and appends a row to
-    ``ctx.log_dir/pod_memory_growth.tsv``:
-
-    Columns: ``epoch_s, service, pod, container, working_set_bytes, pid1_rss_bytes``.
-
-    - ``working_set_bytes``: from metrics.k8s.io (same as
-      `kubectl top pod`; kubelet uses this for OOMKill).
-    - ``pid1_rss_bytes``: from `/proc/1/status:VmRSS` inside the
-      container (per-process attribution).
-
-    The ``PodMemoryGrowth`` check reads either column.
-
-    Best placed right after ``WaitForModelReady`` so polling starts
-    before any fault is injected. Stops automatically when ``stop()``
-    fires at scenario teardown.
-
-    metrics-server's scrape interval is ~15s on most clusters — polling
-    faster yields duplicate working-set samples but pid1 RSS is fresh
-    every call. 15s default matches the metrics-server cadence.
-    """
-
-    services: list[str]
-    interval_s: float = 15.0
-    name: str = ""
-    results: dict[str, Any] | None = field(default=None, init=False)
-    _task: Any = field(default=None, init=False, repr=False)
-    _stop: Any = field(default=None, init=False, repr=False)
-
-    async def execute(self, ctx: "ScenarioContext") -> None:
-        import os
-
-        log_dir = getattr(ctx, "log_dir", None)
-        if not log_dir:
-            ctx.logger.warning("PodMemoryPoller: no ctx.log_dir; skipping")
-            return
-        os.makedirs(log_dir, exist_ok=True)
-        # Per-pod memory files written to ``<log_dir>/<service>/<pod>_memory.tsv``
-        # — parallel construction with the per-pod ``<pod>_<ts>.log`` files
-        # written by the framework's log-collection pipeline. Removes the
-        # single-file contention that caused the 14s stutter on sanity Run 1
-        # and matches the canonical layout used by downstream verifier
-        # scripts. A union TSV at <log_dir>/pod_memory_growth.tsv is kept
-        # for backward compatibility — written at stop time.
-        TSV_HEADER = (
-            "epoch_s\tservice\tpod\tcontainer\t" "working_set_bytes\tpid1_rss_bytes\n"
-        )
-        # Initialize the legacy flat file too (for tooling that still reads it)
-        legacy_out = os.path.join(log_dir, "pod_memory_growth.tsv")
-        with open(legacy_out, "w") as fh:
-            fh.write(TSV_HEADER)
-        self._stop = asyncio.Event()
-        self._per_pod_files: set[str] = set()  # type: ignore[name-defined]
-        self._tsv_header = TSV_HEADER
-        self._log_dir = log_dir
-        self._legacy_out = legacy_out
-
-        custom = client.CustomObjectsApi()
-
-        async def read_working_set(pod_name):
-            """metrics.k8s.io -> dict[container_name, working_set_bytes]."""
-            try:
-                obj = await custom.get_namespaced_custom_object(
-                    group="metrics.k8s.io",
-                    version="v1beta1",
-                    namespace=ctx.namespace,
-                    plural="pods",
-                    name=pod_name,
-                )
-            except k8s_exceptions.ApiException:
-                return {}
-            return {
-                c.get("name", "?"): _parse_k8s_quantity(
-                    (c.get("usage") or {}).get("memory") or "0"
-                )
-                for c in (obj.get("containers") or [])
-            }
-
-        async def read_pid1_rss(pod):
-            """`cat /proc/1/status:VmRSS` -> bytes (or 0)."""
-            try:
-                result = await asyncio.to_thread(
-                    pod.exec,
-                    ["sh", "-c", "grep VmRSS /proc/1/status 2>/dev/null || true"],
-                )
-                stdout = (
-                    result.stdout.decode() if hasattr(result, "stdout") else str(result)
-                )
-                for ln in stdout.splitlines():
-                    if "VmRSS" in ln:
-                        for tok in ln.split():
-                            if tok.isdigit():
-                                return int(tok) * 1024  # kB → bytes
-            except Exception:
-                pass
-            return 0
-
-        async def loop():
-            import time
-
-            while not self._stop.is_set():
-                try:
-                    for svc in self.services:
-                        pods_by_svc = await asyncio.to_thread(
-                            ctx.deployment.get_pods, [svc]
-                        )
-                        for pod in pods_by_svc.get(svc) or []:
-                            ws_by_container = await read_working_set(pod.name)
-                            pid1_rss = await read_pid1_rss(pod)
-                            ts = time.time()
-                            if not ws_by_container:
-                                ws_by_container = {"?": 0}
-                            # Per-pod file: <log_dir>/<service>/<pod>_memory.tsv
-                            pod_dir = os.path.join(self._log_dir, svc)
-                            os.makedirs(pod_dir, exist_ok=True)
-                            pod_file = os.path.join(pod_dir, f"{pod.name}_memory.tsv")
-                            if pod_file not in self._per_pod_files:
-                                with open(pod_file, "w") as fh:
-                                    fh.write(self._tsv_header)
-                                self._per_pod_files.add(pod_file)
-                            for cname, ws_bytes in ws_by_container.items():
-                                row = (
-                                    f"{ts:.0f}\t{svc}\t{pod.name}\t"
-                                    f"{cname}\t{ws_bytes}\t{pid1_rss}\n"
-                                )
-                                with open(pod_file, "a") as fh:
-                                    fh.write(row)
-                                # Legacy flat file for backward compat
-                                with open(self._legacy_out, "a") as fh:
-                                    fh.write(row)
-                except Exception as e:
-                    ctx.logger.warning(f"PodMemoryPoller loop err: {e}")
-                try:
-                    await asyncio.wait_for(self._stop.wait(), timeout=self.interval_s)
-                except asyncio.TimeoutError:
-                    pass
-
-        self._task = asyncio.create_task(loop())
-        ctx.logger.info(
-            f"PodMemoryPoller(metrics.k8s.io): services={self.services} "
-            f"interval={self.interval_s}s"
-        )
-
-    async def stop(self, ctx: "ScenarioContext") -> None:
-        if self._stop is not None:
-            self._stop.set()
-        if self._task is not None:
-            try:
-                await asyncio.wait_for(self._task, timeout=15.0)
-            except asyncio.TimeoutError:
-                self._task.cancel()
-        ctx.logger.info("PodMemoryPoller: stopped")
-
-    @property
-    def description(self) -> str:
-        return f"PodMemoryPoller {self.services} every {self.interval_s}s"
-
-
-@dataclass
-class PodMemoryPoller2(Event):
-    """In-pod memory sampler — the deterministic-cadence successor to
-    :class:`PodMemoryPoller` (vault task #60, "option d").
-
-    The original poller samples from the *host*: a single asyncio loop that,
-    each tick, walks every pod doing one ``metrics.k8s.io`` GET + one
-    ``kubectl exec`` of ``/proc/1/status``. At 60 pods that serialised walk
-    takes longer than the nominal ``interval_s``, so the effective cadence
-    drifts (the "14s stutter" seen on sanity Run 1), and the working-set
-    column is additionally quantised to metrics-server's ~15s scrape.
-
-    ``PodMemoryPoller2`` instead launches a **detached in-pod daemon** once
-    per pod at ``execute()`` time:
-
-    .. code-block:: sh
-
-        nohup sh -c 'while true; do
-            printf "%s\\t%s\\t%s\\n" "$(date +%s.%N)" "$HOSTNAME" \\
-                "$(awk "/VmRSS/{print \\$2*1024}" /proc/1/status)" \\
-                >> "$OUTDIR/$HOSTNAME.tsv"
-            sleep 5
-        done' &
-
-    The sampling loop and its 5 s timer live **inside** the pod, so the
-    cadence is exact regardless of pod count or host scheduling, and RSS is
-    read straight from ``/proc/1/status`` (no metrics-server quantisation).
-    Output is written to the already-mounted shared log PVC, so the existing
-    ``PvcExtractor`` pulls the per-pod TSVs back with the rest of
-    ``/tmp/service_logs`` — no new volume or extraction path needed.
-
-    Columns (no header — appended rows only): ``epoch_s, pod, pid1_rss_bytes``.
-    ``epoch_s`` is fractional (``date +%s.%N``) so inter-sample spacing can be
-    verified to confirm the deterministic cadence.
-
-    This runs in the main container (reads its own ``/proc/1``), so it needs
-    neither a sidecar container nor ``shareProcessNamespace`` — it is
-    functionally the option-d in-pod sampler with a far smaller blast radius.
-    Do not run it concurrently with ``PodMemoryPoller`` on the same pods
-    (both attribute pid1 RSS; one is enough).
-    """
-
-    services: list[str]
-    interval_s: float = 5.0
-    # Subdir under the run's service_logs root on the shared PVC. Derived
-    # in-pod from $DYN_LOG_DIR so samples co-locate with the run's logs and
-    # don't collide across runs on a reused PVC.
-    name: str = ""
-    _started_pods: Any = field(default=None, init=False, repr=False)
-
-    async def execute(self, ctx: "ScenarioContext") -> None:
-        self._started_pods = []
-        interval = int(self.interval_s) if self.interval_s >= 1 else 1
-        # In-pod sampler. Write straight into the pod's own service_logs dir
-        # ($DYN_LOG_DIR = .../service_logs/<role>) as `<pod>.mempoller2.tsv`, so
-        # the existing end-of-test service_logs extraction carries it back with
-        # the pod's logs — it lands locally at <role>/<pod>.mempoller2.tsv,
-        # beside that pod's other artifacts. (Previously it wrote to a sibling
-        # <run_root>/mempoller2/ dir that the extractor never pulled.)
-        # Marker file lets stop() find+kill exactly this daemon.
-        # NOTE on the nohup child shell: the sampling loop runs in a *new*
-        # `sh -c '...'` whose single-quoted body is NOT expanded by the parent.
-        # That child shell does not inherit non-exported parent variables, so
-        # OUT must be `export`ed. We export OUT and use `$(hostname)` so the
-        # loop body resolves them in its own env.
-        launch_script = (
-            "set -e; "
-            'OUTDIR="${DYN_LOG_DIR:-/tmp/service_logs}"; mkdir -p "$OUTDIR"; '
-            'export OUT="$OUTDIR/$(hostname).mempoller2.tsv"; '
-            "rm -f /tmp/.mempoller2.stop; "
-            'printf "# PodMemoryPoller2\\tepoch_s\\tpod\\tworking_set_bytes\\t'
-            'cgroup_current_bytes\\tall_pids_rss_bytes\\tpid1_rss_bytes\\n" > "$OUT"; '
-            # date +%s.%N is fractional on GNU coreutils (the runtime images);
-            # busybox date lacks %N and would emit a literal ".%N", so strip a
-            # trailing non-numeric tail back to whole seconds as a fallback.
-            "nohup sh -c 'while [ ! -f /tmp/.mempoller2.stop ]; do "
-            'TS="$(date +%s.%N)"; case "$TS" in *N) TS="$(date +%s)";; esac; '
-            # working_set = cgroup usage - inactive_file (what kubelet/cAdvisor
-            # use for OOMKill). cgroup v2 (memory.current) with v1 fallback.
-            "if [ -f /sys/fs/cgroup/memory.current ]; then "
-            'CUR="$(cat /sys/fs/cgroup/memory.current 2>/dev/null)"; '
-            'INACT="$(awk "/^inactive_file /{print \\$2}" /sys/fs/cgroup/memory.stat 2>/dev/null)"; '
-            "else "
-            'CUR="$(cat /sys/fs/cgroup/memory/memory.usage_in_bytes 2>/dev/null)"; '
-            'INACT="$(awk "/^total_inactive_file /{print \\$2}" /sys/fs/cgroup/memory/memory.stat 2>/dev/null)"; '
-            "fi; "
-            'WS="$(( ${CUR:-0} - ${INACT:-0} ))"; '
-            # all-pids RSS: sum VmRSS across every process in the pod (not just
-            # pid1 — the GPU worker spreads memory across EngineCore/Worker/etc.;
-            # pid1 alone is ~14% of the real footprint). Over-counts shared
-            # pages, so working_set above is the accurate non-double-counted total.
-            'ALLRSS="$(awk "/VmRSS/{s+=\\$2} END{print s*1024}" /proc/[0-9]*/status 2>/dev/null)"; '
-            'PID1="$(awk "/VmRSS/{print \\$2*1024}" /proc/1/status 2>/dev/null)"; '
-            'printf "%s\\t%s\\t%s\\t%s\\t%s\\t%s\\n" "$TS" "$(hostname)" '
-            '"$WS" "$CUR" "$ALLRSS" "$PID1" >> "$OUT" 2>/dev/null; '
-            f"sleep {interval}; done' >/dev/null 2>&1 & "
-            'echo "mempoller2 started pid $!"'
-        )
-        started = 0
-        for svc in self.services:
-            pods_by_svc = await asyncio.to_thread(ctx.deployment.get_pods, [svc])
-            for pod in pods_by_svc.get(svc) or []:
-                try:
-                    await asyncio.to_thread(pod.exec, ["sh", "-c", launch_script])
-                    self._started_pods.append((svc, pod.name))
-                    started += 1
-                except Exception as e:
-                    ctx.logger.warning(
-                        f"PodMemoryPoller2: failed to start sampler on {pod.name}: {e}"
-                    )
-        ctx.logger.info(
-            f"PodMemoryPoller2: launched in-pod samplers on {started} pods "
-            f"across {self.services}, interval={interval}s. "
-            f"Output: service_logs/<role>/<pod>.mempoller2.tsv on the log PVC "
-            f"(extracted to <role>/<pod>.mempoller2.tsv)."
-        )
-
-    async def stop(self, ctx: "ScenarioContext") -> None:
-        # Signal the in-pod loops to exit, then they flush their last sample.
-        stop_script = "touch /tmp/.mempoller2.stop 2>/dev/null || true"
-        for svc in self.services:
-            try:
-                pods_by_svc = await asyncio.to_thread(ctx.deployment.get_pods, [svc])
-            except Exception:
-                continue
-            for pod in pods_by_svc.get(svc) or []:
-                try:
-                    await asyncio.to_thread(pod.exec, ["sh", "-c", stop_script])
-                except Exception:
-                    pass
-        ctx.logger.info("PodMemoryPoller2: signalled in-pod samplers to stop")
-
-    @property
-    def description(self) -> str:
-        return f"PodMemoryPoller2 (in-pod) {self.services} every {self.interval_s}s"
-
-
 def _load_respoller_source() -> str:
     """Read the in-pod sampler (``_respoller.py``) as text to heredoc into target
     pods. Kept as a sibling file (not embedded) so it stays real, lintable Python."""
@@ -2658,6 +2417,73 @@ class ResourcePoller(Event):
             f"ResourcePoller(include={','.join(self.include)}) "
             f"{self.services} every {self.interval_s}s"
         )
+
+
+# ── PodMemoryPoller / PodMemoryPoller2 retired -> ResourcePoller ─────────────
+# The pid1-only host-side (PMP1) and in-pod (PMP2) pollers are superseded by
+# ResourcePoller (per-process mem+cpu+gpu, in-pod). The old names are kept as
+# aliases so existing Python imports + ``kind:`` references resolve to
+# ResourcePoller — field signatures are identical (services + interval_s). The
+# YAML registry also maps the old kinds (scenario_lib/_runtime.py).
+PodMemoryPoller = ResourcePoller
+PodMemoryPoller2 = ResourcePoller
+
+
+def synthesize_pod_memory_growth_tsv(log_dir: str) -> str | None:
+    """Build PMP1's legacy ``pod_memory_growth.tsv`` (v3 format) from the per-pod
+    ``<role>/<pod>.resources.agg.tsv`` files ResourcePoller writes, so the
+    ``PodMemoryGrowth`` check + ``PeriodicSnapshot`` keep working now that PMP1
+    (which produced the union file host-side) is retired. Per-GPU rows are
+    deduped (working_set / pid1_rss are pod-level, repeated per GPU row of a
+    tick). ``service`` is the role dir name (lower-case) — the check matches
+    services case-insensitively. Returns the written path, or None if no agg
+    files were found."""
+    agg_files = sorted(glob.glob(os.path.join(log_dir, "*", "*.resources.agg.tsv")))
+    if not agg_files:
+        return None
+    rows = []
+    for f in agg_files:
+        service = os.path.basename(os.path.dirname(f))
+        header = None
+        seen = set()
+        try:
+            with open(f) as fh:
+                for ln in fh:
+                    ln = ln.rstrip("\n")
+                    if not ln or ln.startswith("#"):
+                        continue
+                    cols = ln.split("\t")
+                    if header is None and cols[:1] == ["epoch_s"]:
+                        header = cols
+                        continue
+                    if header is None:
+                        continue
+                    r = dict(zip(header, cols))
+                    epoch = r.get("epoch_s", "")
+                    if epoch in seen:  # dedup per-GPU rows of one tick
+                        continue
+                    seen.add(epoch)
+                    rows.append(
+                        (
+                            epoch,
+                            service,
+                            r.get("pod", ""),
+                            "main",
+                            r.get("working_set", "-1"),
+                            r.get("pid1_rss", "-1"),
+                        )
+                    )
+        except OSError:
+            continue
+    rows.sort(key=lambda x: (x[1], x[2], x[0]))
+    out_path = os.path.join(log_dir, "pod_memory_growth.tsv")
+    with open(out_path, "w") as out:
+        out.write(
+            "epoch_s\tservice\tpod\tcontainer\tworking_set_bytes\tpid1_rss_bytes\n"
+        )
+        for r in rows:
+            out.write("\t".join(str(x) for x in r) + "\n")
+    return out_path
 
 
 @dataclass

--- a/tests/fault_tolerance/deploy/events.py
+++ b/tests/fault_tolerance/deploy/events.py
@@ -1902,7 +1902,7 @@ class WaitForModelReady(Event):
 # Post-PR-#8254: WARN line instead.
 #
 # This is the upstream-blessed shape from
-# dynamo-observe/.../2026-05-03-tcp-client-panic-repro/arm_b_rst.py.
+# an internal TCP-client-panic reproducer (in-pod RST injection).
 # iptables-FORWARD REJECT (RstInjection) is not on the packet path on
 # AWS VPC CNI; this in-pod approach connects directly to the target
 # pod IP and is reliable.
@@ -2394,6 +2394,127 @@ class PodMemoryPoller(Event):
     @property
     def description(self) -> str:
         return f"PodMemoryPoller {self.services} every {self.interval_s}s"
+
+
+@dataclass
+class PodMemoryPoller2(Event):
+    """In-pod memory sampler — the deterministic-cadence successor to
+    :class:`PodMemoryPoller` (vault task #60, "option d").
+
+    The original poller samples from the *host*: a single asyncio loop that,
+    each tick, walks every pod doing one ``metrics.k8s.io`` GET + one
+    ``kubectl exec`` of ``/proc/1/status``. At 60 pods that serialised walk
+    takes longer than the nominal ``interval_s``, so the effective cadence
+    drifts (the "14s stutter" seen on sanity Run 1), and the working-set
+    column is additionally quantised to metrics-server's ~15s scrape.
+
+    ``PodMemoryPoller2`` instead launches a **detached in-pod daemon** once
+    per pod at ``execute()`` time:
+
+    .. code-block:: sh
+
+        nohup sh -c 'while true; do
+            printf "%s\\t%s\\t%s\\n" "$(date +%s.%N)" "$HOSTNAME" \\
+                "$(awk "/VmRSS/{print \\$2*1024}" /proc/1/status)" \\
+                >> "$OUTDIR/$HOSTNAME.tsv"
+            sleep 5
+        done' &
+
+    The sampling loop and its 5 s timer live **inside** the pod, so the
+    cadence is exact regardless of pod count or host scheduling, and RSS is
+    read straight from ``/proc/1/status`` (no metrics-server quantisation).
+    Output is written to the already-mounted shared log PVC, so the existing
+    ``PvcExtractor`` pulls the per-pod TSVs back with the rest of
+    ``/tmp/service_logs`` — no new volume or extraction path needed.
+
+    Columns (no header — appended rows only): ``epoch_s, pod, pid1_rss_bytes``.
+    ``epoch_s`` is fractional (``date +%s.%N``) so inter-sample spacing can be
+    verified to confirm the deterministic cadence.
+
+    This runs in the main container (reads its own ``/proc/1``), so it needs
+    neither a sidecar container nor ``shareProcessNamespace`` — it is
+    functionally the option-d in-pod sampler with a far smaller blast radius.
+    Do not run it concurrently with ``PodMemoryPoller`` on the same pods
+    (both attribute pid1 RSS; one is enough).
+    """
+
+    services: list[str]
+    interval_s: float = 5.0
+    # Subdir under the run's service_logs root on the shared PVC. Derived
+    # in-pod from $DYN_LOG_DIR so samples co-locate with the run's logs and
+    # don't collide across runs on a reused PVC.
+    name: str = ""
+    _started_pods: Any = field(default=None, init=False, repr=False)
+
+    async def execute(self, ctx: "ScenarioContext") -> None:
+        self._started_pods = []
+        interval = int(self.interval_s) if self.interval_s >= 1 else 1
+        # In-pod sampler. Write straight into the pod's own service_logs dir
+        # ($DYN_LOG_DIR = .../service_logs/<role>) as `<pod>.mempoller2.tsv`, so
+        # the existing end-of-test service_logs extraction carries it back with
+        # the pod's logs — it lands locally at <role>/<pod>.mempoller2.tsv,
+        # beside that pod's other artifacts. (Previously it wrote to a sibling
+        # <run_root>/mempoller2/ dir that the extractor never pulled.)
+        # Marker file lets stop() find+kill exactly this daemon.
+        # NOTE on the nohup child shell: the sampling loop runs in a *new*
+        # `sh -c '...'` whose single-quoted body is NOT expanded by the parent.
+        # That child shell does not inherit non-exported parent variables, so
+        # OUT must be `export`ed. We export OUT and use `$(hostname)` so the
+        # loop body resolves them in its own env.
+        launch_script = (
+            "set -e; "
+            'OUTDIR="${DYN_LOG_DIR:-/tmp/service_logs}"; mkdir -p "$OUTDIR"; '
+            'export OUT="$OUTDIR/$(hostname).mempoller2.tsv"; '
+            "rm -f /tmp/.mempoller2.stop; "
+            'printf "# PodMemoryPoller2\\tepoch_s\\tpod\\tpid1_rss_bytes\\n" > "$OUT"; '
+            # date +%s.%N is fractional on GNU coreutils (the runtime images);
+            # busybox date lacks %N and would emit a literal ".%N", so strip a
+            # trailing non-numeric tail back to whole seconds as a fallback.
+            "nohup sh -c 'while [ ! -f /tmp/.mempoller2.stop ]; do "
+            'TS="$(date +%s.%N)"; case "$TS" in *N) TS="$(date +%s)";; esac; '
+            'printf "%s\\t%s\\t%s\\n" "$TS" "$(hostname)" '
+            '"$(awk "/VmRSS/{print \\$2*1024}" /proc/1/status 2>/dev/null)" '
+            '>> "$OUT" 2>/dev/null; '
+            f"sleep {interval}; done' >/dev/null 2>&1 & "
+            'echo "mempoller2 started pid $!"'
+        )
+        started = 0
+        for svc in self.services:
+            pods_by_svc = await asyncio.to_thread(ctx.deployment.get_pods, [svc])
+            for pod in pods_by_svc.get(svc) or []:
+                try:
+                    await asyncio.to_thread(pod.exec, ["sh", "-c", launch_script])
+                    self._started_pods.append((svc, pod.name))
+                    started += 1
+                except Exception as e:
+                    ctx.logger.warning(
+                        f"PodMemoryPoller2: failed to start sampler on {pod.name}: {e}"
+                    )
+        ctx.logger.info(
+            f"PodMemoryPoller2: launched in-pod samplers on {started} pods "
+            f"across {self.services}, interval={interval}s. "
+            f"Output: service_logs/<role>/<pod>.mempoller2.tsv on the log PVC "
+            f"(extracted to <role>/<pod>.mempoller2.tsv)."
+        )
+
+    async def stop(self, ctx: "ScenarioContext") -> None:
+        # Signal the in-pod loops to exit, then they flush their last sample.
+        stop_script = "touch /tmp/.mempoller2.stop 2>/dev/null || true"
+        for svc in self.services:
+            try:
+                pods_by_svc = await asyncio.to_thread(ctx.deployment.get_pods, [svc])
+            except Exception:
+                continue
+            for pod in pods_by_svc.get(svc) or []:
+                try:
+                    await asyncio.to_thread(pod.exec, ["sh", "-c", stop_script])
+                except Exception:
+                    pass
+        ctx.logger.info("PodMemoryPoller2: signalled in-pod samplers to stop")
+
+    @property
+    def description(self) -> str:
+        return f"PodMemoryPoller2 (in-pod) {self.services} every {self.interval_s}s"
 
 
 @dataclass

--- a/tests/fault_tolerance/deploy/events.py
+++ b/tests/fault_tolerance/deploy/events.py
@@ -2366,13 +2366,20 @@ class ResourcePoller(Event):
         # closing exec session doesn't SIGHUP/EPIPE it.
         launch = (
             (
-                'set -e; OUTDIR="${DYN_LOG_DIR:-/tmp/service_logs}"; mkdir -p "$OUTDIR"; '
+                "set -e; "
+                # Idempotent per pod: a scenario may declare two pollers (e.g. the
+                # legacy PodMemoryPoller + PodMemoryPoller2, both now aliased to
+                # ResourcePoller) — only the first launch per pod runs; the rest
+                # no-op so they don't truncate the TSV or spawn a second daemon.
+                "if [ -f /tmp/.respoller.started ]; then "
+                'echo "respoller already started on $(hostname), skipping"; exit 0; fi; '
+                'OUTDIR="${DYN_LOG_DIR:-/tmp/service_logs}"; mkdir -p "$OUTDIR"; '
                 "cat > /tmp/respoller.py <<'PYEOF'\n"
             )
             + _load_respoller_source()
             + (
                 "\nPYEOF\n"
-                "rm -f /tmp/.respoller.stop; "
+                "touch /tmp/.respoller.started; rm -f /tmp/.respoller.stop; "
                 f'RESPOLL_OUTDIR="$OUTDIR" RESPOLL_INTERVAL={interval} '
                 f"RESPOLL_INCLUDE={include} RESPOLL_STOP=/tmp/.respoller.stop "
                 "nohup python3 /tmp/respoller.py >/tmp/respoller.out 2>&1 & "
@@ -2398,7 +2405,10 @@ class ResourcePoller(Event):
         )
 
     async def stop(self, ctx: "ScenarioContext") -> None:
-        stop_script = "touch /tmp/.respoller.stop 2>/dev/null || true"
+        stop_script = (
+            "touch /tmp/.respoller.stop 2>/dev/null; "
+            "rm -f /tmp/.respoller.started 2>/dev/null; true"
+        )
         for svc in self.services:
             try:
                 pods_by_svc = await asyncio.to_thread(ctx.deployment.get_pods, [svc])

--- a/tests/fault_tolerance/deploy/events.py
+++ b/tests/fault_tolerance/deploy/events.py
@@ -44,10 +44,7 @@ __all__ = [
     "PrintProcessTree",
     "RstInjection",
     "RstFromInsidePod",
-    "PodMemoryPoller",
-    "PodMemoryPoller2",
     "ResourcePoller",
-    "synthesize_pod_memory_growth_tsv",
     "PeriodicSnapshot",
     "RANDOM",
     "ALL",
@@ -2280,21 +2277,6 @@ class RstFromInsidePod(Event):
         )
 
 
-# =============================================================================
-# PodMemoryPoller — records BOTH cgroup container memory (metrics.k8s.io,
-# same source kubelet uses for OOMKill decisions) AND per-process RSS
-# of pid 1 (/proc/1/status:VmRSS, via pod.exec) for each pod, on every
-# poll. Two columns let PodMemoryGrowth assert on the right signal:
-#
-#   - working_set_bytes: what kubelet sees → OOMKill-relevant.
-#   - pid1_rss_bytes: what the main binary actually maps → attribution.
-#
-# The two are usually close on single-process containers like the
-# Dynamo frontend, but diverge when child processes are large (e.g.
-# vLLM workers).
-# =============================================================================
-
-
 def _parse_k8s_quantity(s: str) -> int:
     """Parse a k8s resource quantity like '123Mi', '12345Ki', '1Gi' to bytes."""
     if not s:
@@ -2331,8 +2313,8 @@ def _load_respoller_source() -> str:
 
 @dataclass
 class ResourcePoller(Event):
-    """In-pod per-process resource sampler — successor to :class:`PodMemoryPoller`
-    (host-side) and :class:`PodMemoryPoller2` (in-pod, pid1-only). Launches one
+    """In-pod per-process resource sampler — the single memory/cpu/gpu poller
+    (it replaced the earlier pid1-only host-side and in-pod pollers). Launches one
     detached python sampler (``_respoller.py``) per pod that, every
     ``interval_s``, writes two TSVs to the pod's ``$DYN_LOG_DIR`` (carried back by
     the existing extractor):
@@ -2367,10 +2349,10 @@ class ResourcePoller(Event):
         launch = (
             (
                 "set -e; "
-                # Idempotent per pod: a scenario may declare two pollers (e.g. the
-                # legacy PodMemoryPoller + PodMemoryPoller2, both now aliased to
-                # ResourcePoller) — only the first launch per pod runs; the rest
-                # no-op so they don't truncate the TSV or spawn a second daemon.
+                # Idempotent per pod: a scenario may declare two ResourcePoller
+                # events (e.g. one migrated from the old dual memory pollers) —
+                # only the first launch per pod runs; the rest no-op so they don't
+                # truncate the TSV or spawn a second daemon.
                 "if [ -f /tmp/.respoller.started ]; then "
                 'echo "respoller already started on $(hostname), skipping"; exit 0; fi; '
                 'OUTDIR="${DYN_LOG_DIR:-/tmp/service_logs}"; mkdir -p "$OUTDIR"; '
@@ -2429,73 +2411,6 @@ class ResourcePoller(Event):
         )
 
 
-# ── PodMemoryPoller / PodMemoryPoller2 retired -> ResourcePoller ─────────────
-# The pid1-only host-side (PMP1) and in-pod (PMP2) pollers are superseded by
-# ResourcePoller (per-process mem+cpu+gpu, in-pod). The old names are kept as
-# aliases so existing Python imports + ``kind:`` references resolve to
-# ResourcePoller — field signatures are identical (services + interval_s). The
-# YAML registry also maps the old kinds (scenario_lib/_runtime.py).
-PodMemoryPoller = ResourcePoller
-PodMemoryPoller2 = ResourcePoller
-
-
-def synthesize_pod_memory_growth_tsv(log_dir: str) -> str | None:
-    """Build PMP1's legacy ``pod_memory_growth.tsv`` (v3 format) from the per-pod
-    ``<role>/<pod>.resources.agg.tsv`` files ResourcePoller writes, so the
-    ``PodMemoryGrowth`` check + ``PeriodicSnapshot`` keep working now that PMP1
-    (which produced the union file host-side) is retired. Per-GPU rows are
-    deduped (working_set / pid1_rss are pod-level, repeated per GPU row of a
-    tick). ``service`` is the role dir name (lower-case) — the check matches
-    services case-insensitively. Returns the written path, or None if no agg
-    files were found."""
-    agg_files = sorted(glob.glob(os.path.join(log_dir, "*", "*.resources.agg.tsv")))
-    if not agg_files:
-        return None
-    rows = []
-    for f in agg_files:
-        service = os.path.basename(os.path.dirname(f))
-        header = None
-        seen = set()
-        try:
-            with open(f) as fh:
-                for ln in fh:
-                    ln = ln.rstrip("\n")
-                    if not ln or ln.startswith("#"):
-                        continue
-                    cols = ln.split("\t")
-                    if header is None and cols[:1] == ["epoch_s"]:
-                        header = cols
-                        continue
-                    if header is None:
-                        continue
-                    r = dict(zip(header, cols))
-                    epoch = r.get("epoch_s", "")
-                    if epoch in seen:  # dedup per-GPU rows of one tick
-                        continue
-                    seen.add(epoch)
-                    rows.append(
-                        (
-                            epoch,
-                            service,
-                            r.get("pod", ""),
-                            "main",
-                            r.get("working_set", "-1"),
-                            r.get("pid1_rss", "-1"),
-                        )
-                    )
-        except OSError:
-            continue
-    rows.sort(key=lambda x: (x[1], x[2], x[0]))
-    out_path = os.path.join(log_dir, "pod_memory_growth.tsv")
-    with open(out_path, "w") as out:
-        out.write(
-            "epoch_s\tservice\tpod\tcontainer\tworking_set_bytes\tpid1_rss_bytes\n"
-        )
-        for r in rows:
-            out.write("\t".join(str(x) for x in r) + "\n")
-    return out_path
-
-
 @dataclass
 class PeriodicSnapshot(Event):
     """Background event that, on a fixed interval, copies key artifacts
@@ -2539,7 +2454,6 @@ class PeriodicSnapshot(Event):
     _stop: object = field(default=None, init=False, repr=False)
 
     async def execute(self, ctx: "ScenarioContext") -> None:
-        import glob
         import os
         import shutil
         import time

--- a/tests/fault_tolerance/deploy/events.py
+++ b/tests/fault_tolerance/deploy/events.py
@@ -2425,8 +2425,9 @@ class PeriodicSnapshot(Event):
     sorts naturally; the ISO suffix is human-readable.
 
     What gets copied each tick (best-effort; missing files are skipped):
-      - ``pod_memory_growth.tsv`` — full snapshot of the PodMemoryPoller
-        TSV up to that moment
+      - ``<role>/<pod>.resources.{agg,procs}.tsv`` — the per-pod
+        ResourcePoller TSVs (cgroup working_set / RSS / GPU series) up
+        to that moment
       - ``load/load-*/profile_export*.{json,jsonl}`` — any in-progress
         AIPerf metrics files
       - ``load/load-*/server_metrics_export.jsonl``
@@ -2439,7 +2440,7 @@ class PeriodicSnapshot(Event):
       - Each tick is wrapped in try/except; a copy failure on one
         artifact doesn't abort the loop
       - Stops cleanly on scenario teardown via the same Event ``stop()``
-        pattern as PodMemoryPoller
+        pattern as ResourcePoller
 
     Hard ceiling: honors ``DYN_ENDURANCE_MAX_HOURS`` env var (default 8).
     After that wall-time the snapshot loop stops emitting new dirs but
@@ -2475,15 +2476,17 @@ class PeriodicSnapshot(Event):
         def _snapshot_once(snapshot_dir: str) -> None:
             os.makedirs(snapshot_dir, exist_ok=True)
 
-            # 1. pod_memory_growth.tsv
-            pmg = os.path.join(log_dir, "pod_memory_growth.tsv")
-            if os.path.exists(pmg):
+            # 1. ResourcePoller per-pod TSVs: <role>/<pod>.resources.{agg,procs}.tsv
+            for src in glob.glob(
+                os.path.join(log_dir, "*", "*.resources.agg.tsv")
+            ) + glob.glob(os.path.join(log_dir, "*", "*.resources.procs.tsv")):
+                rel = os.path.relpath(src, log_dir)
+                dst = os.path.join(snapshot_dir, rel)
                 try:
-                    shutil.copy2(
-                        pmg, os.path.join(snapshot_dir, "pod_memory_growth.tsv")
-                    )
+                    os.makedirs(os.path.dirname(dst), exist_ok=True)
+                    shutil.copy2(src, dst)
                 except Exception as e:
-                    ctx.logger.warning(f"PeriodicSnapshot: copy pmg failed: {e}")
+                    ctx.logger.warning(f"PeriodicSnapshot: copy {src} failed: {e}")
 
             # 2. in-progress AIPerf metrics
             for src in glob.glob(

--- a/tests/fault_tolerance/deploy/incident_report.py
+++ b/tests/fault_tolerance/deploy/incident_report.py
@@ -1,0 +1,1382 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Normalized incident-style report for fault_tolerance/deploy tests.
+
+Produces a Markdown report with embedded PNG/HTML panels from a
+``test_outputs/<test_name>/`` (or recovered) bundle directory:
+
+  * **Throughput** — RPS + goodput per rung
+  * **Latency p99** — TTFT + RL with 20 s SLA line
+  * **Per-pod KV cache %** — one trace per pod, event markers overlaid
+  * **Per-pod queue depth** — running + waiting per pod
+  * **Errors per rung** — 503 vs TimeoutError stacked
+  * **Pod restart timeline** — restart count over time
+  * **Imbalance per rung** — peak gap / ratio / CV across per-pod metrics
+  * **Gap-over-time** — `max − min` evolution for the worst-imbalance rung
+
+Event timeline comes from parsing ``test.log.txt`` for ``Event N/M`` /
+``DeletePod`` / ``WaitForRecovery`` / etc. — no new framework
+instrumentation required.
+
+Designed to work on both *complete* bundles (recovered long-A-data)
+and *partial* bundles (kv-vs-ll-A where PVC extraction failed). Missing
+panels produce an explicit "DATA INCOMPLETE" callout instead of zeroing.
+
+Comparison mode: pass ``--compare-with <other_bundle>`` to render
+two-trace overlays on every panel + side-by-side imbalance tables.
+
+CLI:
+    python -m tests.fault_tolerance.deploy.incident_report \\
+        <bundle_dir> [--compare-with <other>] [--output-dir <dir>]
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import logging
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, Optional
+
+import plotly.graph_objects as go
+import yaml
+from plotly.subplots import make_subplots
+
+logger = logging.getLogger(__name__)
+
+
+# ───────────────────────────────────────────────────────────────────────
+# Data model
+# ───────────────────────────────────────────────────────────────────────
+
+
+@dataclasses.dataclass
+class EventMark:
+    """A timestamped event from the scenario, parsed from test.log.txt."""
+
+    ts: datetime  # absolute timestamp
+    label: str  # short label, e.g. "Event 5/16: Start load 'c216'"
+    raw: str  # full log line for context
+    kind: str = "info"  # "info" | "rung_start" | "rung_end" | "fault" | "recovery"
+    rung_name: Optional[str] = None
+    severity: str = "info"  # affects rendering color
+    detail: str = ""
+
+    @property
+    def color(self) -> str:
+        return {
+            "info": "rgba(120,120,120,0.6)",
+            "rung_start": "rgba(30,144,255,0.7)",
+            "rung_end": "rgba(30,144,255,0.5)",
+            "fault": "rgba(220,20,60,0.85)",
+            "recovery": "rgba(60,179,113,0.85)",
+        }.get(self.kind, "rgba(120,120,120,0.6)")
+
+
+@dataclasses.dataclass
+class RungData:
+    """Per-rung aggregate from profile_export_aiperf.json."""
+
+    name: str  # e.g. "c72"
+    concurrency: int
+    dir_path: Path  # the load-c<N>-<hash>/ dir
+    rps: float = 0.0
+    goodput: float = 0.0
+    ttft_p99_ms: float = 0.0
+    ttft_p50_ms: float = 0.0
+    ttft_avg_ms: float = 0.0
+    rl_p99_ms: float = 0.0
+    rl_p50_ms: float = 0.0
+    rl_avg_ms: float = 0.0
+    itl_p50_ms: float = 0.0
+    itl_p99_ms: float = 0.0
+    valid_requests: int = 0
+    error_503: int = 0
+    error_timeout: int = 0
+    has_aiperf: bool = False  # False = extraction failed for this rung
+
+    @property
+    def total_errors(self) -> int:
+        return self.error_503 + self.error_timeout
+
+    @property
+    def total_requests(self) -> int:
+        return self.valid_requests + self.total_errors
+
+
+@dataclasses.dataclass
+class PodInfo:
+    """Pod identity from manifest YAML."""
+
+    name: str
+    ip: Optional[str]
+    service: str  # "frontend" | "vllmprefillworker" | "vllmdecodeworker"
+    yaml_path: Path
+
+    @property
+    def short(self) -> str:
+        # Last 6 chars of pod name suffix — readable in plots
+        return self.name.split("-")[-1][-6:]
+
+
+@dataclasses.dataclass
+class PodMetricSample:
+    """One scrape sample of one metric on one pod."""
+
+    ts: float  # epoch ns
+    value: float
+
+
+@dataclasses.dataclass
+class Bundle:
+    """A loaded test_outputs/<test_name>/ (or recovered) bundle directory."""
+
+    root: Path
+    label: str  # human label e.g. "kv-routing" / "least-loaded"
+    test_name: str
+    rungs: list[RungData] = dataclasses.field(default_factory=list)
+    pods: list[PodInfo] = dataclasses.field(default_factory=list)
+    events: list[EventMark] = dataclasses.field(default_factory=list)
+    ip_to_svc: dict[str, str] = dataclasses.field(default_factory=dict)
+    # raw per-rung per-url per-metric sample lists
+    # samples[rung_name][svc][pod_short][metric_name] = [(ts_ns, value), ...]
+    samples: dict = dataclasses.field(default_factory=dict)
+
+
+# ───────────────────────────────────────────────────────────────────────
+# Bundle loading
+# ───────────────────────────────────────────────────────────────────────
+
+
+def _maybe_first(path: Path, glob: str) -> Optional[Path]:
+    matches = list(path.glob(glob))
+    return matches[0] if matches else None
+
+
+def _aiperf_get(j: dict, k: str, sub: str = "avg") -> float:
+    v = j.get(k) or {}
+    out = v.get(sub)
+    if isinstance(out, (int, float)):
+        return float(out)
+    return 0.0
+
+
+def _parse_aiperf_errors(aiperf_log: Path) -> tuple[int, int]:
+    """Parse the final Error summary block — returns (503_count, timeout_count)."""
+    if not aiperf_log.exists():
+        return 0, 0
+    try:
+        content = aiperf_log.read_text(errors="ignore")
+    except Exception:
+        return 0, 0
+    matches = re.findall(r"Error summary: \[(.*?)\] \(", content, re.DOTALL)
+    if not matches:
+        return 0, 0
+    last = matches[-1]
+    blocks = re.split(r"ErrorDetailsCount\(", last)
+    per_type: dict[str, int] = {}
+    for b in blocks[1:]:
+        tm = re.search(r"type='([^']+)'", b)
+        cm = re.search(r"count=(\d+)", b)
+        if tm and cm:
+            per_type[tm.group(1)] = int(cm.group(1))
+    return per_type.get("Service Unavailable", 0), per_type.get("TimeoutError", 0)
+
+
+def _parse_aiperf_valid(aiperf_log: Path) -> int:
+    if not aiperf_log.exists():
+        return 0
+    try:
+        for line in aiperf_log.open(errors="ignore"):
+            m = re.search(r"Processed (\d+) valid requests", line)
+            if m:
+                return int(m.group(1))
+    except Exception:
+        pass
+    return 0
+
+
+def _load_rungs(bundle_root: Path) -> list[RungData]:
+    """Find all `load-<name>-<hash>` dirs and parse aiperf JSON if present.
+
+    Accepts BOTH the test_overload "c<N>" naming and arbitrary names like
+    "heavy-kv" used by other scenarios.
+
+    Handles BOTH layouts:
+      bundle_root/load-<name>-<hash>/aiperf/profile_export_aiperf.json
+      bundle_root/load/load-<name>-<hash>/profile_export_aiperf.json
+    """
+    rungs: list[RungData] = []
+    candidates = list(bundle_root.glob("load/load-*-*")) + list(
+        bundle_root.glob("load-*-*")
+    )
+    for d in sorted(candidates):
+        m = re.match(r"load-(.+?)-[0-9a-f]{6,}$", d.name)
+        if not m:
+            continue
+        tag = m.group(1)
+        # `c<N>` rungs get the integer concurrency; arbitrary names get 0
+        # (used only for sort ordering, not in display).
+        cm = re.fullmatch(r"c(\d+)", tag)
+        conc = int(cm.group(1)) if cm else 0
+        # Try two possible layouts
+        aiperf_dir = d / "aiperf" if (d / "aiperf").is_dir() else d
+        pj = aiperf_dir / "profile_export_aiperf.json"
+        log = aiperf_dir / "aiperf.log"
+
+        rd = RungData(name=tag, concurrency=conc, dir_path=d)
+        if pj.is_file():
+            try:
+                j = json.loads(pj.read_text())
+            except Exception as e:
+                logger.warning(f"Failed to parse {pj}: {e}")
+                rungs.append(rd)
+                continue
+            rd.has_aiperf = True
+            rd.rps = _aiperf_get(j, "request_throughput")
+            rd.goodput = _aiperf_get(j, "goodput")
+            rd.ttft_p99_ms = _aiperf_get(j, "time_to_first_token", "p99")
+            rd.ttft_p50_ms = _aiperf_get(j, "time_to_first_token", "p50")
+            rd.ttft_avg_ms = _aiperf_get(j, "time_to_first_token", "avg")
+            rd.rl_p99_ms = _aiperf_get(j, "request_latency", "p99")
+            rd.rl_p50_ms = _aiperf_get(j, "request_latency", "p50")
+            rd.rl_avg_ms = _aiperf_get(j, "request_latency", "avg")
+            rd.itl_p50_ms = _aiperf_get(j, "inter_token_latency", "p50")
+            rd.itl_p99_ms = _aiperf_get(j, "inter_token_latency", "p99")
+            rd.valid_requests = _parse_aiperf_valid(log)
+            rd.error_503, rd.error_timeout = _parse_aiperf_errors(log)
+        rungs.append(rd)
+    rungs.sort(key=lambda r: r.concurrency)
+    return rungs
+
+
+def _load_pods(
+    bundle_root: Path, extra_search_roots: Optional[list[Path]] = None
+) -> tuple[list[PodInfo], dict[str, str]]:
+    """Parse pod manifest YAMLs to build (PodInfo list, ip→service map).
+
+    Searches under `bundle_root` AND any `extra_search_roots` for files
+    matching {frontend,vllmprefillworker,vllmdecodeworker}/*.yaml. The
+    recovered tarball lacks pod YAMLs (they live in the local
+    `test_outputs/<test>/` bundle that the framework wrote at teardown);
+    pass that as an extra root to merge."""
+    pods: list[PodInfo] = []
+    ip_to_svc: dict[str, str] = {}
+    roots = [bundle_root] + (extra_search_roots or [])
+    for root in roots:
+        if not root.is_dir():
+            continue
+        for svc in ("frontend", "vllmprefillworker", "vllmdecodeworker"):
+            for base in (root, root / "service_logs"):
+                if not (base / svc).is_dir():
+                    continue
+                for f in (base / svc).glob("*.yaml"):
+                    try:
+                        y = yaml.safe_load(f.read_text())
+                    except Exception:
+                        continue
+                    if not isinstance(y, dict) or y.get("kind") != "Pod":
+                        continue
+                    ip = (y.get("status") or {}).get("podIP")
+                    name = (y.get("metadata") or {}).get("name", "?")
+                    pods.append(PodInfo(name=name, ip=ip, service=svc, yaml_path=f))
+                    if ip:
+                        ip_to_svc[ip] = svc
+    return pods, ip_to_svc
+
+
+def _load_events(
+    bundle_root: Path, extra_search_roots: Optional[list[Path]] = None
+) -> list[EventMark]:
+    """Extract timestamped events from test.log.txt by regex.
+
+    The framework's log format is:
+      2026-05-19 20:30:38 [INFO] test_decode_overload: Event 2/16: Start load 'c72'
+
+    Searches under `bundle_root` first, then any `extra_search_roots`.
+    """
+    candidates = [bundle_root, bundle_root.parent] + (extra_search_roots or [])
+    test_log = None
+    for root in candidates:
+        cand = root / "test.log.txt"
+        if cand.is_file():
+            test_log = cand
+            break
+    if test_log is None:
+        return []
+    events: list[EventMark] = []
+    line_re = re.compile(
+        r"^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) \[\w+\] [\w\[\]\-_.]+: (.*)"
+    )
+    interesting = re.compile(
+        r"Event \d+/\d+:|DeletePod|TerminateProcess|StallProcess|WaitForRecovery"
+        r"|Load .* completed|Load .* started|StopLoad|StartLoad:|Ready condition True"
+    )
+    for raw in test_log.read_text(errors="ignore").splitlines():
+        m = line_re.match(raw)
+        if not m:
+            continue
+        msg = m.group(2)
+        if not interesting.search(msg):
+            continue
+        try:
+            ts = datetime.strptime(m.group(1), "%Y-%m-%d %H:%M:%S")
+        except ValueError:
+            continue
+        ev = EventMark(ts=ts, label=msg[:80], raw=raw)
+        # Classify
+        if "DeletePod" in msg or "TerminateProcess" in msg or "StallProcess" in msg:
+            ev.kind, ev.severity = "fault", "fault"
+        elif "WaitForRecovery" in msg:
+            ev.kind, ev.severity = "recovery", "info"
+        elif "Start load" in msg:
+            ev.kind = "rung_start"
+            rm = re.search(r"Start load '(\w+)'", msg)
+            if rm:
+                ev.rung_name = rm.group(1)
+        elif "Load '" in msg and "completed" in msg:
+            ev.kind = "rung_end"
+            rm = re.search(r"Load '(\w+)' completed", msg)
+            if rm:
+                ev.rung_name = rm.group(1)
+        events.append(ev)
+    return events
+
+
+def _load_per_pod_samples(bundle: Bundle, metrics_of_interest: Iterable[str]) -> None:
+    """Walk server_metrics_export.jsonl per rung, collect per-pod samples.
+
+    Populates bundle.samples[rung_name][svc][pod_short][metric] = [(ts_ns, value), ...]
+    """
+    metrics_set = set(metrics_of_interest)
+    for rd in bundle.rungs:
+        aiperf_dir = (
+            rd.dir_path / "aiperf" if (rd.dir_path / "aiperf").is_dir() else rd.dir_path
+        )
+        smfile = aiperf_dir / "server_metrics_export.jsonl"
+        if not smfile.is_file():
+            continue
+        rung_bucket = bundle.samples.setdefault(rd.name, {})
+        for line in smfile.open():
+            try:
+                r = json.loads(line)
+            except Exception:
+                continue
+            url = r.get("endpoint_url", "")
+            ipm = re.search(r"http://([0-9.]+):", url)
+            if not ipm:
+                continue
+            ip = ipm.group(1)
+            svc = bundle.ip_to_svc.get(ip)
+            if svc is None:
+                continue
+            ts = r.get("timestamp_ns")
+            if ts is None:
+                continue
+            metrics = r.get("metrics") or {}
+            pod_short = ip[-6:].replace(".", "")
+            svc_bucket = rung_bucket.setdefault(svc, {})
+            pod_bucket = svc_bucket.setdefault(pod_short, {})
+            for mname in metrics_set:
+                v = metrics.get(mname)
+                if not v:
+                    continue
+                # Standard vllm metric record is a list; take first entry's
+                # value (for gauges) or sum (for counters).
+                if isinstance(v, list) and v:
+                    e = v[0]
+                    if isinstance(e, dict):
+                        val = e.get("value")
+                        if val is None:
+                            val = e.get("sum")
+                        if isinstance(val, (int, float)):
+                            pod_bucket.setdefault(mname, []).append((ts, float(val)))
+
+
+# ───────────────────────────────────────────────────────────────────────
+# Imbalance computation
+# ───────────────────────────────────────────────────────────────────────
+
+
+@dataclasses.dataclass
+class ImbalanceRow:
+    rung: str
+    service: str
+    metric: str
+    pods: int
+    pod_peaks: list[float]
+    min_val: float
+    max_val: float
+    gap: float
+    ratio: float
+    cv: float
+
+    @property
+    def severity(self) -> str:
+        if self.ratio >= 1.50:
+            return "🟥"
+        if self.ratio >= 1.20:
+            return "🟨"
+        return "🟩"
+
+
+def compute_imbalance(bundle: Bundle) -> list[ImbalanceRow]:
+    """For each (rung, service, metric_of_interest) compute per-pod peak +
+    gap/ratio/CV across pods."""
+    out: list[ImbalanceRow] = []
+    # (service, metric) pairs we look at
+    targets = [
+        ("vllmdecodeworker", "vllm:kv_cache_usage_perc"),
+        ("vllmdecodeworker", "vllm:num_requests_running"),
+        ("vllmdecodeworker", "vllm:num_requests_waiting"),
+        ("vllmprefillworker", "vllm:kv_cache_usage_perc"),
+        ("vllmprefillworker", "vllm:nixl_bytes_transferred"),
+    ]
+    for rd in bundle.rungs:
+        rung_samples = bundle.samples.get(rd.name, {})
+        for svc, metric in targets:
+            svc_samples = rung_samples.get(svc, {})
+            peaks = [
+                max(v for _, v in pod_samples[metric])
+                for pod_samples in svc_samples.values()
+                if pod_samples.get(metric)
+            ]
+            if len(peaks) < 2:
+                continue
+            mean = sum(peaks) / len(peaks)
+            var = sum((p - mean) ** 2 for p in peaks) / len(peaks)
+            stddev = var**0.5
+            row = ImbalanceRow(
+                rung=rd.name,
+                service=svc,
+                metric=metric,
+                pods=len(peaks),
+                pod_peaks=sorted(peaks, reverse=True),
+                min_val=min(peaks),
+                max_val=max(peaks),
+                gap=max(peaks) - min(peaks),
+                ratio=max(peaks) / max(min(peaks), 1e-9),
+                cv=stddev / mean if mean > 0 else 0.0,
+            )
+            out.append(row)
+    return out
+
+
+# ───────────────────────────────────────────────────────────────────────
+# Plot rendering
+# ───────────────────────────────────────────────────────────────────────
+
+
+# Fixed per-arm colors. First entry = primary bundle, second = compare_with.
+# Same hue across throughput / latency / errors panels so a reader can tell
+# at a glance which arm they're looking at.
+_ARM_COLORS = ("#1f77b4", "#d62728")  # blue, crimson — high contrast
+
+
+def _arm_color(idx: int) -> str:
+    return _ARM_COLORS[idx % len(_ARM_COLORS)]
+
+
+def _png(fig: go.Figure, path: Path) -> None:
+    fig.write_html(path.with_suffix(".html"), include_plotlyjs="cdn")
+    try:
+        fig.write_image(path.with_suffix(".png"), width=1200, height=550, scale=2)
+    except Exception as e:
+        logger.warning(f"PNG export failed for {path.name}: {e}")
+
+
+def _add_event_markers(fig: go.Figure, events: list[EventMark], t0: datetime) -> None:
+    for ev in events:
+        x = (ev.ts - t0).total_seconds()
+        fig.add_vline(
+            x=x,
+            line=dict(color=ev.color, dash="dash", width=1),
+            annotation_text=ev.label.split(":")[0][:30],
+            annotation_position="top right",
+            annotation_font=dict(size=9, color=ev.color),
+        )
+
+
+def render_throughput(
+    bundle: Bundle, output_dir: Path, compare_with: Optional[Bundle] = None
+) -> Path:
+    fig = make_subplots(
+        rows=1, cols=2, subplot_titles=("Goodput RPS", "Total RPS (incl. errors)")
+    )
+    for idx, run in enumerate([bundle] + ([compare_with] if compare_with else [])):
+        color = _arm_color(idx)
+        x = [r.concurrency for r in run.rungs if r.has_aiperf]
+        fig.add_trace(
+            go.Scatter(
+                x=x,
+                y=[r.goodput for r in run.rungs if r.has_aiperf],
+                mode="lines+markers",
+                name=run.label,
+                legendgroup=run.label,
+                line=dict(width=3, color=color),
+                marker=dict(size=10, color=color),
+            ),
+            row=1,
+            col=1,
+        )
+        fig.add_trace(
+            go.Scatter(
+                x=x,
+                y=[r.rps for r in run.rungs if r.has_aiperf],
+                mode="lines+markers",
+                name=run.label,
+                legendgroup=run.label,
+                line=dict(width=3, color=color),
+                marker=dict(size=10, color=color),
+                showlegend=False,
+            ),
+            row=1,
+            col=2,
+        )
+    fig.update_xaxes(title_text="concurrency", row=1, col=1)
+    fig.update_xaxes(title_text="concurrency", row=1, col=2)
+    fig.update_yaxes(title_text="RPS", row=1, col=1)
+    fig.update_yaxes(title_text="RPS", row=1, col=2)
+    fig.update_layout(
+        title=f"Throughput — {bundle.label}"
+        + (f" vs {compare_with.label}" if compare_with else ""),
+        legend=dict(orientation="h", y=1.15),
+        height=550,
+    )
+    p = output_dir / "throughput"
+    _png(fig, p)
+    return p
+
+
+def render_latency(
+    bundle: Bundle, output_dir: Path, compare_with: Optional[Bundle] = None
+) -> Path:
+    fig = make_subplots(
+        rows=1, cols=2, subplot_titles=("TTFT p99 (s)", "Request latency p99 (s)")
+    )
+    for idx, run in enumerate([bundle] + ([compare_with] if compare_with else [])):
+        color = _arm_color(idx)
+        x = [r.concurrency for r in run.rungs if r.has_aiperf]
+        fig.add_trace(
+            go.Scatter(
+                x=x,
+                y=[r.ttft_p99_ms / 1000 for r in run.rungs if r.has_aiperf],
+                mode="lines+markers",
+                name=run.label,
+                legendgroup=run.label,
+                line=dict(width=3, color=color),
+                marker=dict(size=10, color=color),
+            ),
+            row=1,
+            col=1,
+        )
+        fig.add_trace(
+            go.Scatter(
+                x=x,
+                y=[r.rl_p99_ms / 1000 for r in run.rungs if r.has_aiperf],
+                mode="lines+markers",
+                name=run.label,
+                legendgroup=run.label,
+                line=dict(width=3, color=color),
+                marker=dict(size=10, color=color),
+                showlegend=False,
+            ),
+            row=1,
+            col=2,
+        )
+    for col in (1, 2):
+        fig.add_hline(
+            y=20,
+            line=dict(color="grey", dash="dash"),
+            annotation_text="20s SLA",
+            row=1,
+            col=col,
+        )
+    fig.update_xaxes(title_text="concurrency", row=1, col=1)
+    fig.update_xaxes(title_text="concurrency", row=1, col=2)
+    fig.update_yaxes(title_text="seconds", row=1, col=1)
+    fig.update_yaxes(title_text="seconds", row=1, col=2)
+    fig.update_layout(
+        title=f"Latency p99 — {bundle.label}"
+        + (f" vs {compare_with.label}" if compare_with else ""),
+        legend=dict(orientation="h", y=1.15),
+        height=550,
+    )
+    p = output_dir / "latency_p99"
+    _png(fig, p)
+    return p
+
+
+def render_errors(
+    bundle: Bundle, output_dir: Path, compare_with: Optional[Bundle] = None
+) -> Path:
+    fig = make_subplots(
+        rows=1,
+        cols=2,
+        subplot_titles=("Valid requests per rung", "Error rate per rung (%)"),
+    )
+    for idx, run in enumerate([bundle] + ([compare_with] if compare_with else [])):
+        color = _arm_color(idx)
+        x = [r.name for r in run.rungs if r.has_aiperf]
+        valid = [r.valid_requests for r in run.rungs if r.has_aiperf]
+        err_rate = [
+            100.0 * r.total_errors / r.total_requests if r.total_requests else 0
+            for r in run.rungs
+            if r.has_aiperf
+        ]
+        fig.add_trace(
+            go.Bar(
+                x=x,
+                y=valid,
+                name=run.label,
+                legendgroup=run.label,
+                offsetgroup=run.label,
+                marker_color=color,
+            ),
+            row=1,
+            col=1,
+        )
+        fig.add_trace(
+            go.Bar(
+                x=x,
+                y=err_rate,
+                name=run.label,
+                legendgroup=run.label,
+                offsetgroup=run.label,
+                marker_color=color,
+                showlegend=False,
+            ),
+            row=1,
+            col=2,
+        )
+    fig.update_xaxes(title_text="rung", row=1, col=1)
+    fig.update_xaxes(title_text="rung", row=1, col=2)
+    fig.update_yaxes(title_text="valid requests", row=1, col=1)
+    fig.update_yaxes(title_text="error %", row=1, col=2, range=[0, 100])
+    fig.update_layout(
+        title=f"Errors — {bundle.label}"
+        + (f" vs {compare_with.label}" if compare_with else ""),
+        barmode="group",
+        legend=dict(orientation="h", y=1.15),
+        height=550,
+    )
+    p = output_dir / "errors"
+    _png(fig, p)
+    return p
+
+
+def render_imbalance_timeseries(
+    bundle: Bundle,
+    output_dir: Path,
+    metric: str,
+    title: str,
+    fname: str,
+    ylabel: str,
+    target_service: str = "vllmdecodeworker",
+    mode: str = "absolute",
+    compare_with: Optional[Bundle] = None,
+) -> Path:
+    """Single-metric imbalance timeseries — per rung, ONE line per arm.
+
+    The line value is the "gap": `max - min` across all pods of
+    `target_service` at each scrape timestamp. With `mode="pct"` the
+    value is `(max - min) / max * 100` (percent delta of max).
+
+    Replaces the per-pod overlay chart (which became unreadable with
+    9+ pods × 2 arms). Single signal: how unbalanced is the pool over
+    time?
+    """
+    runs = [bundle] + ([compare_with] if compare_with else [])
+    rungs_present = [r.name for r in bundle.rungs if r.has_aiperf]
+    if not rungs_present:
+        fig = go.Figure()
+        fig.add_annotation(text=f"No {metric} data", showarrow=False)
+        p = output_dir / fname
+        _png(fig, p)
+        return p
+    n = len(rungs_present)
+    fig = make_subplots(rows=1, cols=n, subplot_titles=rungs_present, shared_yaxes=True)
+    for col, rung_name in enumerate(rungs_present, start=1):
+        for idx, run in enumerate(runs):
+            color = _arm_color(idx)
+            sm = run.samples.get(rung_name, {}).get(target_service, {})
+            if not sm:
+                continue
+            # Gather all timestamped (ts, value) per pod
+            pods_pts = []
+            for pod_short, m_dict in sm.items():
+                pts = m_dict.get(metric)
+                if pts:
+                    pods_pts.append(sorted(pts))
+            if not pods_pts:
+                continue
+            # `max_abs` plots the worst pod's absolute value (useful for
+            # signals like wait_for_remote_kvs where the level itself is
+            # the cascade signature). Other modes (`absolute`, `pct`) need
+            # at least 2 pods to compute imbalance.
+            if mode != "max_abs" and len(pods_pts) < 2:
+                continue
+            # Compute gap-over-time: at each timestamp, take max-min across
+            # pods (forward-fill latest known value per pod).
+            all_ts = sorted({t for pts in pods_pts for t, _ in pts})
+            if not all_ts:
+                continue
+            t0 = all_ts[0]
+            gap_x, gap_y = [], []
+            for ts in all_ts:
+                latest = []
+                for pts in pods_pts:
+                    val = None
+                    for t, v in pts:
+                        if t <= ts:
+                            val = v
+                        else:
+                            break
+                    if val is not None:
+                        latest.append(val)
+                if not latest:
+                    continue
+                if mode != "max_abs" and len(latest) < 2:
+                    continue
+                hi = max(latest)
+                lo = min(latest)
+                if mode == "pct":
+                    gap = ((hi - lo) / hi * 100.0) if hi > 1e-9 else 0.0
+                elif mode == "max_abs":
+                    gap = hi
+                else:
+                    gap = hi - lo
+                gap_x.append((ts - t0) / 1e9)
+                gap_y.append(gap)
+            if not gap_x:
+                continue
+            fig.add_trace(
+                go.Scatter(
+                    x=gap_x,
+                    y=gap_y,
+                    mode="lines",
+                    name=run.label,
+                    legendgroup=run.label,
+                    showlegend=(col == 1),
+                    line=dict(width=3, color=color),
+                ),
+                row=1,
+                col=col,
+            )
+    fig.update_xaxes(title_text="seconds in rung")
+    fig.update_yaxes(title_text=ylabel, col=1)
+    fig.update_layout(
+        title=f"{title} — gap across {target_service} pool",
+        legend=dict(orientation="h", y=-0.15),
+        height=500,
+    )
+    p = output_dir / fname
+    _png(fig, p)
+    return p
+
+
+def render_per_pod_metric(
+    bundle: Bundle,
+    output_dir: Path,
+    metric: str,
+    title: str,
+    fname: str,
+    ylabel: str,
+    target_service: str = "vllmdecodeworker",
+    compare_with: Optional[Bundle] = None,
+) -> Path:
+    """One per-pod time-series PER RUNG. Layout: one subplot per rung;
+    A bundle traces solid, compare_with traces dashed."""
+    runs = [bundle] + ([compare_with] if compare_with else [])
+    # Decide subplot layout: one column per rung
+    rungs_present = [r.name for r in bundle.rungs if r.has_aiperf]
+    if not rungs_present:
+        # Empty placeholder
+        fig = go.Figure()
+        fig.add_annotation(text=f"No {metric} data", showarrow=False)
+        p = output_dir / fname
+        _png(fig, p)
+        return p
+    n = len(rungs_present)
+    fig = make_subplots(rows=1, cols=n, subplot_titles=rungs_present, shared_yaxes=True)
+    for col, rung_name in enumerate(rungs_present, start=1):
+        for run_idx, run in enumerate(runs):
+            sm = run.samples.get(rung_name, {}).get(target_service, {})
+            if not sm:
+                continue
+            t0 = None
+            for pod_short, m_dict in sorted(sm.items()):
+                pts = m_dict.get(metric)
+                if not pts:
+                    continue
+                pts_sorted = sorted(pts)
+                if t0 is None:
+                    t0 = pts_sorted[0][0]
+                x = [(t - t0) / 1e9 for t, _ in pts_sorted]
+                y = [v for _, v in pts_sorted]
+                fig.add_trace(
+                    go.Scatter(
+                        x=x,
+                        y=y,
+                        mode="lines",
+                        name=f"{run.label}/{pod_short}" if col == 1 else None,
+                        legendgroup=f"{run.label}/{pod_short}",
+                        showlegend=(col == 1),
+                        line=dict(dash="solid" if run_idx == 0 else "dash"),
+                    ),
+                    row=1,
+                    col=col,
+                )
+    fig.update_xaxes(title_text="seconds in rung")
+    fig.update_yaxes(title_text=ylabel, col=1)
+    fig.update_layout(
+        title=f"{title} — per-pod ({target_service})"
+        + (
+            f" — {bundle.label} solid, {compare_with.label} dashed"
+            if compare_with
+            else f" — {bundle.label}"
+        ),
+        legend=dict(orientation="h", y=-0.15),
+        height=500,
+    )
+    p = output_dir / fname
+    _png(fig, p)
+    return p
+
+
+def render_gap_timeseries(
+    bundle: Bundle,
+    output_dir: Path,
+    rows: list[ImbalanceRow],
+) -> Optional[Path]:
+    """For the WORST-imbalance row in the bundle, plot per-pod time-series +
+    max−min gap line."""
+    if not rows:
+        return None
+    worst = max(rows, key=lambda r: r.ratio)
+    sm = bundle.samples.get(worst.rung, {}).get(worst.service, {})
+    if not sm:
+        return None
+    fig = go.Figure()
+    pods_pts = []
+    t0 = None
+    for pod_short, m_dict in sorted(sm.items()):
+        pts = m_dict.get(worst.metric)
+        if not pts:
+            continue
+        pts_sorted = sorted(pts)
+        if t0 is None:
+            t0 = pts_sorted[0][0]
+        pods_pts.append((pod_short, pts_sorted))
+        fig.add_trace(
+            go.Scatter(
+                x=[(t - t0) / 1e9 for t, _ in pts_sorted],
+                y=[v for _, v in pts_sorted],
+                mode="lines",
+                name=pod_short,
+                opacity=0.6,
+            )
+        )
+    # Compute gap series (re-bucket all timestamps; simple approach: at each
+    # observation timestamp, take max − min across pods present at that time)
+    if len(pods_pts) >= 2:
+        # Aggregate all timestamps and interpolate / forward-fill
+        all_ts = sorted({t for _, pts in pods_pts for t, _ in pts})
+        gap_x, gap_y = [], []
+        for ts in all_ts:
+            vals = []
+            for _, pts in pods_pts:
+                # Find sample at or before ts
+                latest = None
+                for t, v in pts:
+                    if t <= ts:
+                        latest = v
+                    else:
+                        break
+                if latest is not None:
+                    vals.append(latest)
+            if len(vals) >= 2:
+                gap_x.append((ts - t0) / 1e9)
+                gap_y.append(max(vals) - min(vals))
+        fig.add_trace(
+            go.Scatter(
+                x=gap_x,
+                y=gap_y,
+                mode="lines",
+                name="max−min gap",
+                line=dict(color="red", width=3, dash="dot"),
+            )
+        )
+    fig.update_layout(
+        title=f"Worst-imbalance gap over time — {worst.service} {worst.metric} @ {worst.rung}",
+        xaxis_title="seconds in rung",
+        yaxis_title=worst.metric,
+        height=500,
+        legend=dict(orientation="h", y=-0.15),
+    )
+    p = output_dir / "imbalance_gap_worst_rung"
+    _png(fig, p)
+    return p
+
+
+# ───────────────────────────────────────────────────────────────────────
+# Markdown assembly
+# ───────────────────────────────────────────────────────────────────────
+
+
+def _md_imbalance_table(
+    rows: list[ImbalanceRow], compare_rows: Optional[list[ImbalanceRow]] = None
+) -> str:
+    """Render imbalance table in Markdown. Highlights rows with ratio>=1.20."""
+    if not rows:
+        return (
+            "_No per-pod metrics available (single-pod test or sample data missing)._\n"
+        )
+    lines = []
+    lines.append(
+        "| sev | rung | service | metric | pods | min | max | gap | ratio | CV |"
+    )
+    lines.append(
+        "|----:|:-----|:--------|:-------|----:|----:|----:|----:|------:|----:|"
+    )
+    for r in rows:
+        # Skip "obviously balanced" rows when we have many — keep the table readable
+        if r.ratio < 1.10 and r.cv < 0.05:
+            continue
+        lines.append(
+            f"| {r.severity} | {r.rung} | {r.service.replace('vllm','')} | "
+            f"{r.metric} | {r.pods} | "
+            f"{r.min_val:.3f} | {r.max_val:.3f} | "
+            f"{r.gap:.3f} | {r.ratio:.2f} | {r.cv:.2f} |"
+        )
+    if len(lines) == 2:
+        return "_All metrics within 10% balance ratio (well-balanced)._\n"
+    return "\n".join(lines) + "\n"
+
+
+def write_report(
+    bundle: Bundle,
+    output_dir: Path,
+    compare_with: Optional[Bundle] = None,
+) -> Path:
+    """Compose Markdown + render all panels into output_dir/."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    plots_dir = output_dir / "panels"
+    plots_dir.mkdir(exist_ok=True)
+
+    # Render panels
+    p_thr = render_throughput(bundle, plots_dir, compare_with)
+    p_lat = render_latency(bundle, plots_dir, compare_with)
+    p_err = render_errors(bundle, plots_dir, compare_with)
+    # Imbalance time-series — one line per arm per rung
+    p_kv_gap = render_imbalance_timeseries(
+        bundle,
+        plots_dir,
+        metric="vllm:kv_cache_usage_perc",
+        title="Decode KV imbalance",
+        fname="imbalance_decode_kv",
+        ylabel="max − min (KV %)",
+        target_service="vllmdecodeworker",
+        mode="absolute",
+        compare_with=compare_with,
+    )
+    p_run_gap = render_imbalance_timeseries(
+        bundle,
+        plots_dir,
+        metric="vllm:num_requests_running",
+        title="Decode running-queue imbalance",
+        fname="imbalance_decode_running",
+        ylabel="max − min (running)",
+        target_service="vllmdecodeworker",
+        mode="absolute",
+        compare_with=compare_with,
+    )
+    p_wait_gap = render_imbalance_timeseries(
+        bundle,
+        plots_dir,
+        metric="vllm:num_requests_waiting",
+        title="Decode waiting-queue imbalance",
+        fname="imbalance_decode_waiting",
+        ylabel="max − min (waiting)",
+        target_service="vllmdecodeworker",
+        mode="absolute",
+        compare_with=compare_with,
+    )
+    p_pf_kv_gap = render_imbalance_timeseries(
+        bundle,
+        plots_dir,
+        metric="vllm:kv_cache_usage_perc",
+        title="Prefill KV imbalance",
+        fname="imbalance_prefill_kv",
+        ylabel="max − min (KV %)",
+        target_service="vllmprefillworker",
+        mode="absolute",
+        compare_with=compare_with,
+    )
+    # Cascade signature panels — absolute worst-pod levels, NOT imbalance.
+    # `wait_for_remote_kvs` is the deadlock signal that climbs from
+    # single digits into the thousands during a cascade. running /
+    # waiting + inflight let us cross-check the engine's view against
+    # the router's view.
+    p_wait_remote = render_imbalance_timeseries(
+        bundle,
+        plots_dir,
+        metric="derived:wait_for_remote_kvs",
+        title="Decode WAITING_FOR_REMOTE_KVS (derived)",
+        fname="cascade_wait_for_remote",
+        ylabel="max across decode pods (requests)",
+        target_service="vllmdecodeworker",
+        mode="max_abs",
+        compare_with=compare_with,
+    )
+    p_inflight = render_imbalance_timeseries(
+        bundle,
+        plots_dir,
+        metric="dynamo_component_inflight_requests",
+        title="Decode inflight (router view)",
+        fname="cascade_inflight",
+        ylabel="max across decode pods",
+        target_service="vllmdecodeworker",
+        mode="max_abs",
+        compare_with=compare_with,
+    )
+    p_running = render_imbalance_timeseries(
+        bundle,
+        plots_dir,
+        metric="vllm:num_requests_running",
+        title="Decode running (engine view)",
+        fname="cascade_running",
+        ylabel="max across decode pods",
+        target_service="vllmdecodeworker",
+        mode="max_abs",
+        compare_with=compare_with,
+    )
+    p_waiting = render_imbalance_timeseries(
+        bundle,
+        plots_dir,
+        metric="vllm:num_requests_waiting",
+        title="Decode waiting queue (engine view, excl. waiting-for-remote)",
+        fname="cascade_waiting",
+        ylabel="max across decode pods",
+        target_service="vllmdecodeworker",
+        mode="max_abs",
+        compare_with=compare_with,
+    )
+    p_kv_abs = render_imbalance_timeseries(
+        bundle,
+        plots_dir,
+        metric="vllm:kv_cache_usage_perc",
+        title="Decode KV cache usage (worst pod)",
+        fname="cascade_kv_usage",
+        ylabel="max KV %",
+        target_service="vllmdecodeworker",
+        mode="max_abs",
+        compare_with=compare_with,
+    )
+
+    # Imbalance computation
+    imb_rows = compute_imbalance(bundle)
+    cmp_rows = compute_imbalance(compare_with) if compare_with else None
+    p_gap = render_gap_timeseries(bundle, plots_dir, imb_rows)
+
+    # Compose Markdown
+    md_path = output_dir / "incident_report.md"
+    out: list[str] = []
+    out.append(f"# Incident report — {bundle.test_name}")
+    out.append("")
+    out.append(f"**Bundle:** `{bundle.root}`")
+    if compare_with:
+        out.append(f"**Compared with:** `{compare_with.root}` ({compare_with.label})")
+    out.append("")
+
+    # Verdict summary
+    n_present = sum(1 for r in bundle.rungs if r.has_aiperf)
+    n_missing = sum(1 for r in bundle.rungs if not r.has_aiperf)
+    out.append("## Headline summary")
+    out.append("")
+    out.append(f"- **Rungs with data:** {n_present}/{len(bundle.rungs)}")
+    if n_missing > 0:
+        out.append(
+            f"- **⚠ Rungs MISSING aiperf data:** {n_missing} "
+            "(PVC extraction failed — salvage manually)"
+        )
+    out.append(f"- **Pods captured (manifests):** {len(bundle.pods)}")
+    out.append(f"- **Events parsed from test.log.txt:** {len(bundle.events)}")
+    out.append("")
+
+    # Per-rung quick table
+    out.append("## Per-rung headline")
+    out.append("")
+    out.append(
+        "| rung | RPS | goodput | TTFT p99 (s) | RL p99 (s) | valid | 503 | timeout |"
+    )
+    out.append(
+        "|:----:|----:|--------:|-------------:|-----------:|------:|----:|--------:|"
+    )
+    for r in bundle.rungs:
+        if r.has_aiperf:
+            out.append(
+                f"| {r.name} | {r.rps:.2f} | {r.goodput:.2f} | "
+                f"{r.ttft_p99_ms/1000:.1f} | {r.rl_p99_ms/1000:.1f} | "
+                f"{r.valid_requests} | {r.error_503} | {r.error_timeout} |"
+            )
+        else:
+            out.append(f"| {r.name} | _no data_ | | | | | | |")
+    out.append("")
+
+    # Event timeline
+    if bundle.events:
+        out.append("## Event timeline (from test.log.txt)")
+        out.append("")
+        out.append("| time | kind | event |")
+        out.append("|:-----|:-----|:------|")
+        t0 = bundle.events[0].ts
+        for ev in bundle.events:
+            rel = (ev.ts - t0).total_seconds()
+            out.append(f"| +{int(rel):>5}s | {ev.kind} | {ev.label} |")
+        out.append("")
+
+    # Panels
+    out.append("## Throughput")
+    out.append("")
+    out.append(f"![throughput](panels/{p_thr.name}.png)")
+    out.append("")
+    out.append("## Latency p99")
+    out.append("")
+    out.append(f"![latency](panels/{p_lat.name}.png)")
+    out.append("")
+    out.append("## Errors per rung")
+    out.append("")
+    out.append(f"![errors](panels/{p_err.name}.png)")
+    out.append("")
+    out.append("## Decode KV imbalance — gap over time")
+    out.append("")
+    out.append(
+        "Single line per arm: `max − min` of `vllm:kv_cache_usage_perc` "
+        "across decode pods at each timestamp. A flat ~0 line means the "
+        "decode pool is balanced; a wide / growing gap means one decode "
+        "pod is hotter than peers."
+    )
+    out.append("")
+    out.append(f"![decode kv gap](panels/{p_kv_gap.name}.png)")
+    out.append("")
+    out.append("## Decode running-queue imbalance — gap over time")
+    out.append("")
+    out.append(f"![decode running gap](panels/{p_run_gap.name}.png)")
+    out.append("")
+    out.append("## Decode waiting-queue imbalance — gap over time")
+    out.append("")
+    out.append(f"![decode waiting gap](panels/{p_wait_gap.name}.png)")
+    out.append("")
+    out.append("## Prefill KV imbalance — gap over time")
+    out.append("")
+    out.append(f"![prefill kv gap](panels/{p_pf_kv_gap.name}.png)")
+    out.append("")
+
+    # Cascade-signature panels — these surface the WAITING_FOR_REMOTE_KVS
+    # deadlock signal that hides between the engine's `num_requests_running`
+    # and the router's `dynamo_component_inflight_requests`.
+    out.append("## Decode cascade signatures")
+    out.append("")
+    out.append(
+        "Worst-pod absolute level (not imbalance). "
+        "`derived:wait_for_remote_kvs = inflight − running − waiting` — "
+        "the deadlock signal. During a KV-pressure cascade this climbs from "
+        "single digits into the thousands, *before* `num_requests_running` "
+        "falls and *before* KV pegs at 1.0. Inflight and running are shown "
+        "alongside for cross-check (router-view vs engine-view)."
+    )
+    out.append("")
+    out.append("### WAITING_FOR_REMOTE_KVS (derived)")
+    out.append("")
+    out.append(f"![wait for remote](panels/{p_wait_remote.name}.png)")
+    out.append("")
+    out.append("### Inflight (router view) vs Running (engine view) vs Waiting")
+    out.append("")
+    out.append(f"![inflight](panels/{p_inflight.name}.png)")
+    out.append("")
+    out.append(f"![running](panels/{p_running.name}.png)")
+    out.append("")
+    out.append(f"![waiting](panels/{p_waiting.name}.png)")
+    out.append("")
+    out.append("### Decode KV cache usage (worst pod, absolute)")
+    out.append("")
+    out.append(f"![kv usage](panels/{p_kv_abs.name}.png)")
+    out.append("")
+
+    # Imbalance
+    out.append("## Pod imbalance")
+    out.append("")
+    out.append("Highlighting rows with `ratio >= 1.10` or `CV >= 0.05`.")
+    out.append("Severity: 🟩 ratio<1.20 · 🟨 1.20-1.50 · 🟥 ratio>=1.50")
+    out.append("")
+    out.append("### " + bundle.label)
+    out.append(_md_imbalance_table(imb_rows))
+    if compare_with and cmp_rows is not None:
+        out.append("### " + compare_with.label)
+        out.append(_md_imbalance_table(cmp_rows))
+    if p_gap:
+        out.append("### Gap evolution — worst-imbalance rung in primary bundle")
+        out.append("")
+        out.append(f"![gap timeseries](panels/{p_gap.name}.png)")
+        out.append("")
+
+    md_path.write_text("\n".join(out))
+    logger.info(f"wrote {md_path}")
+    return md_path
+
+
+# ───────────────────────────────────────────────────────────────────────
+# Top-level entry
+# ───────────────────────────────────────────────────────────────────────
+
+
+def load_bundle(
+    root: Path,
+    label: Optional[str] = None,
+    pod_manifests_from: Optional[Path] = None,
+) -> Bundle:
+    extras = [pod_manifests_from] if pod_manifests_from else []
+    rungs = _load_rungs(root)
+    pods, ip_to_svc = _load_pods(root, extra_search_roots=extras)
+    events = _load_events(root, extra_search_roots=extras)
+    test_name = root.name
+    b = Bundle(
+        root=root,
+        label=label or root.name,
+        test_name=test_name,
+        rungs=rungs,
+        pods=pods,
+        events=events,
+        ip_to_svc=ip_to_svc,
+    )
+    _load_per_pod_samples(
+        b,
+        metrics_of_interest={
+            "vllm:kv_cache_usage_perc",
+            "vllm:num_requests_running",
+            "vllm:num_requests_waiting",
+            "vllm:nixl_bytes_transferred",
+            # `dynamo_component_inflight_requests` is the router-side
+            # dispatched-not-completed count. Combined with running +
+            # waiting on the engine side, the gap = WAITING_FOR_REMOTE_KVS
+            # bucket — the deadlock signal that hides in stock metrics.
+            "dynamo_component_inflight_requests",
+        },
+    )
+    _derive_wait_for_remote(b)
+    return b
+
+
+def _derive_wait_for_remote(bundle: Bundle) -> None:
+    """Synthesize `derived:wait_for_remote_kvs` per decode pod.
+
+    Formula (per pod, per timestamp):
+        wait_for_remote = dynamo_component_inflight_requests
+                        - vllm:num_requests_running
+                        - vllm:num_requests_waiting
+
+    Joined on nearest-prior timestamp; written into the same samples
+    dict so the existing render_imbalance_timeseries / render path
+    just sees another decode metric.
+    """
+    for rung_name, svc_map in bundle.samples.items():
+        decode = svc_map.get("vllmdecodeworker", {})
+        for pod_short, metric_map in decode.items():
+            inflight = metric_map.get("dynamo_component_inflight_requests") or []
+            running = metric_map.get("vllm:num_requests_running") or []
+            waiting = metric_map.get("vllm:num_requests_waiting") or []
+            if not inflight or not running:
+                continue
+
+            # Build lookup dicts of (ts → val) for running/waiting; for
+            # each inflight ts, take nearest-prior running+waiting.
+            def _nearest_prior(series, ts):
+                lo, hi = 0, len(series) - 1
+                best = None
+                while lo <= hi:
+                    mid = (lo + hi) // 2
+                    if series[mid][0] <= ts:
+                        best = series[mid][1]
+                        lo = mid + 1
+                    else:
+                        hi = mid - 1
+                return best
+
+            running_sorted = sorted(running)
+            waiting_sorted = sorted(waiting)
+            derived = []
+            for ts, inflight_v in sorted(inflight):
+                run_v = _nearest_prior(running_sorted, ts)
+                wait_v = _nearest_prior(waiting_sorted, ts) or 0
+                if run_v is None:
+                    continue
+                gap = inflight_v - run_v - wait_v
+                # Clip tiny negatives from sample skew (router can briefly
+                # show inflight < running+waiting around request completion).
+                derived.append((ts, max(0.0, gap)))
+            if derived:
+                metric_map["derived:wait_for_remote_kvs"] = derived
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument(
+        "bundle", type=Path, help="Bundle dir (test_outputs/<test_name>/ or recovered)"
+    )
+    ap.add_argument(
+        "--compare-with", type=Path, help="Second bundle for A/B comparison"
+    )
+    ap.add_argument("--label", default=None, help="Label for primary bundle")
+    ap.add_argument("--compare-label", default=None, help="Label for comparison bundle")
+    ap.add_argument(
+        "--pod-manifests-from",
+        type=Path,
+        default=None,
+        help="Extra search dir for pod YAMLs + test.log.txt "
+        "(useful when running on recovered tarballs that lack manifests).",
+    )
+    ap.add_argument(
+        "--compare-pod-manifests-from",
+        type=Path,
+        default=None,
+        help="Extra search dir for comparison-bundle pod YAMLs + test.log.txt.",
+    )
+    ap.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Output dir (default: <bundle>/incident_report)",
+    )
+    ap.add_argument("-v", "--verbose", action="store_true")
+    args = ap.parse_args()
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+
+    primary = load_bundle(
+        args.bundle,
+        label=args.label or args.bundle.name,
+        pod_manifests_from=args.pod_manifests_from,
+    )
+    cmp_bundle = (
+        load_bundle(
+            args.compare_with,
+            label=args.compare_label or args.compare_with.name,
+            pod_manifests_from=args.compare_pod_manifests_from,
+        )
+        if args.compare_with
+        else None
+    )
+    out_dir = args.output_dir or (args.bundle / "incident_report")
+    md = write_report(primary, out_dir, compare_with=cmp_bundle)
+    print(f"\nWrote incident report: {md}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fault_tolerance/deploy/k8s_utils.py
+++ b/tests/fault_tolerance/deploy/k8s_utils.py
@@ -16,14 +16,18 @@
 """Kubernetes utility functions for fault tolerance testing.
 
 This module provides utilities for interacting with Kubernetes:
-- Fetching pod events
-- Listing pods in namespaces
-- Logging K8s event summaries
+- Fetching container restart counts for a pod
+- Fetching Kubernetes events for a pod
+- Detecting container restart/crash events
+
+All k8s access goes through kr8s so the harness has no kubectl system-binary
+dependency.
 """
 
-import json
 import logging
-import subprocess
+
+import kr8s
+from kr8s.objects import Pod
 
 logger = logging.getLogger(__name__)
 
@@ -32,102 +36,77 @@ def get_pod_restart_count(deployment, pod_name: str, namespace: str) -> dict:
     """Get container restart counts for a pod.
 
     Args:
-        deployment: ManagedDeployment instance
+        deployment: ManagedDeployment instance (unused; kept for API parity)
         pod_name: Name of the pod
         namespace: Kubernetes namespace
 
     Returns:
-        Dict with container names as keys and restart counts as values
-        Example: {"main": 2, "sidecar": 0}
+        Dict with container names as keys and restart counts as values.
+        Example: {"main": 2, "sidecar": 0}. Empty dict on any failure.
     """
     try:
-        cmd = [
-            "kubectl",
-            "get",
-            "pod",
-            pod_name,
-            "-n",
-            namespace,
-            "-o",
-            "json",
-        ]
+        pod = Pod.get(pod_name, namespace=namespace)
+        status = pod.raw.get("status", {}) or {}
+        container_statuses = status.get("containerStatuses", []) or []
 
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+        restart_counts = {}
+        for container in container_statuses:
+            name = container.get("name", "unknown")
+            count = container.get("restartCount", 0)
+            restart_counts[name] = count
 
-        if result.returncode == 0:
-            pod_data = json.loads(result.stdout)
-            restart_counts = {}
+            state = container.get("state", {}) or {}
+            if "running" in state and count > 0:
+                started_at = state["running"].get("startedAt", "unknown")
+                logger.info(
+                    f"Container {name} restarted {count} times, "
+                    f"last started at {started_at}"
+                )
 
-            # Get restart counts from container statuses
-            container_statuses = pod_data.get("status", {}).get("containerStatuses", [])
-            for container in container_statuses:
-                container_name = container.get("name", "unknown")
-                restart_count = container.get("restartCount", 0)
-                restart_counts[container_name] = restart_count
-
-                # Also log if container recently restarted
-                state = container.get("state", {})
-                if "running" in state and restart_count > 0:
-                    started_at = state["running"].get("startedAt", "unknown")
-                    logger.info(
-                        f"Container {container_name} restarted {restart_count} times, "
-                        f"last started at {started_at}"
-                    )
-
-            return restart_counts
+        return restart_counts
     except Exception as e:
-        logger.debug(f"Could not get pod restart count: {e}")
-
-    return {}
+        logger.debug(f"Could not get pod restart count for {pod_name}: {e}")
+        return {}
 
 
 def get_k8s_events_for_pod(deployment, pod_name: str, namespace: str) -> list:
-    """Get Kubernetes events for a specific pod using kubectl.
+    """Get Kubernetes events for a specific pod.
 
     Args:
-        deployment: ManagedDeployment instance
-        pod_name: Name of the pod (can be partial match)
+        deployment: ManagedDeployment instance (unused; kept for API parity)
+        pod_name: Name of the pod (must be an exact match — the API filters
+            on ``involvedObject.name``)
         namespace: Kubernetes namespace
 
     Returns:
-        List of event dictionaries with keys: type, reason, message, timestamp
+        List of event dictionaries with keys: type, reason, message,
+        timestamp, count. Empty list on any failure.
     """
     try:
-        # Get events for the pod using kubectl
-        cmd = [
-            "kubectl",
-            "get",
-            "events",
-            "-n",
-            namespace,
-            "--field-selector",
-            f"involvedObject.name={pod_name}",
-            "-o",
-            "json",
-        ]
-
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
-
-        if result.returncode == 0:
-            events_data = json.loads(result.stdout)
-            events = []
-            for item in events_data.get("items", []):
-                events.append(
-                    {
-                        "type": item.get("type", ""),
-                        "reason": item.get("reason", ""),
-                        "message": item.get("message", ""),
-                        "timestamp": item.get(
-                            "lastTimestamp", item.get("eventTime", "")
-                        ),
-                        "count": item.get("count", 1),
-                    }
-                )
-            return events
+        api = kr8s.api()
+        events = list(
+            api.get(
+                "events",
+                namespace=namespace,
+                field_selector=f"involvedObject.name={pod_name}",
+            )
+        )
+        out = []
+        for event in events:
+            raw = event.raw
+            out.append(
+                {
+                    "type": raw.get("type", ""),
+                    "reason": raw.get("reason", ""),
+                    "message": raw.get("message", ""),
+                    "timestamp": raw.get("lastTimestamp", raw.get("eventTime", "")),
+                    "count": raw.get("count", 1),
+                }
+            )
+        return out
     except Exception as e:
-        logger.debug(f"Could not get K8s events: {e}")
-
-    return []
+        logger.debug(f"Could not get K8s events for {pod_name}: {e}")
+        return []
 
 
 def check_container_restart_events(deployment, pod_name: str, namespace: str) -> bool:
@@ -139,23 +118,23 @@ def check_container_restart_events(deployment, pod_name: str, namespace: str) ->
     - Started: Container was restarted
 
     Args:
-        deployment: ManagedDeployment instance
+        deployment: ManagedDeployment instance (unused; kept for API parity)
         pod_name: Name of the pod
         namespace: Kubernetes namespace
 
     Returns:
-        True if restart/crash events found, False otherwise
+        True if restart/crash events found, False otherwise.
     """
     events = get_k8s_events_for_pod(deployment, pod_name, namespace)
 
-    restart_related_reasons = [
+    restart_related_reasons = {
         "BackOff",
         "CrashLoopBackOff",
         "Killing",
         "Started",
         "Unhealthy",
         "FailedMount",
-    ]
+    }
 
     found_restart = False
     for event in events:

--- a/tests/fault_tolerance/deploy/legacy_client.py
+++ b/tests/fault_tolerance/deploy/legacy_client.py
@@ -13,6 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# DEPRECATED: This module is part of the legacy test framework.
+# New tests should use the event-based framework in test_deployment_scenario.py.
+# See tests/fault_tolerance/deploy/TESTING.md for the reference guide.
+
 """Legacy custom client implementation for fault tolerance testing.
 
 This is the original client implementation that was used before migrating to AI-Perf.

--- a/tests/fault_tolerance/deploy/legacy_parse_results.py
+++ b/tests/fault_tolerance/deploy/legacy_parse_results.py
@@ -13,6 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# DEPRECATED: This module is part of the legacy test framework.
+# New tests should use the event-based framework in test_deployment_scenario.py.
+# See tests/fault_tolerance/deploy/TESTING.md for the reference guide.
+
 """Parser for legacy client results (JSONL format) in fault tolerance tests."""
 
 import argparse

--- a/tests/fault_tolerance/deploy/parse_factory.py
+++ b/tests/fault_tolerance/deploy/parse_factory.py
@@ -13,6 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# DEPRECATED: This module is part of the legacy test framework.
+# New tests should use the event-based framework in test_deployment_scenario.py.
+# See tests/fault_tolerance/deploy/TESTING.md for the reference guide.
+
 """Factory module for auto-detecting and parsing test results."""
 
 import logging

--- a/tests/fault_tolerance/deploy/parse_results.py
+++ b/tests/fault_tolerance/deploy/parse_results.py
@@ -13,6 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# DEPRECATED: This module is part of the legacy test framework.
+# New tests should use the event-based framework in test_deployment_scenario.py.
+# See tests/fault_tolerance/deploy/TESTING.md for the reference guide.
+
 """Parser for AI-Perf results in fault tolerance tests."""
 
 import argparse

--- a/tests/fault_tolerance/deploy/pyproject.toml
+++ b/tests/fault_tolerance/deploy/pyproject.toml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# dynamo-ft — standalone uv project for the Dynamo deploy fault-tolerance test
+# harness. Lets you `uv sync` and `uv run pytest ...` against a live cluster
+# without building the full Dynamo dev container. The harness drives a remote
+# k8s namespace and reads aiperf JSON artifacts; it has no `dynamo.*` imports.
+
+[project]
+name = "dynamo-ft"
+version = "0.1.0"
+description = "Dynamo deploy fault-tolerance test harness (standalone runner)."
+readme = "README.md"
+requires-python = ">=3.10,<3.13"
+license = { text = "Apache-2.0" }
+authors = [{ name = "NVIDIA Inc.", email = "sw-dl-dynamo@nvidia.com" }]
+
+dependencies = [
+    "aiohttp>=3.9",
+    "kr8s>=0.20",
+    "kubernetes>=32.0.1,<33.0.0",
+    "kubernetes_asyncio>=32.0.0,<33.0.0",
+    "numpy>=1.26",
+    "pandas>=2.1",
+    "pytest>=8.0",
+    "pytest-asyncio>=0.23",
+    "requests>=2.31",
+    "tabulate>=0.9",
+    "tomli>=2; python_version < '3.11'",
+    "typing_extensions>=4.9; python_version < '3.11'",
+]
+
+[dependency-groups]
+dev = [
+    "ruff>=0.6",
+    "ipython>=8",
+]
+
+[tool.uv]
+package = false
+managed = true
+
+[tool.pytest.ini_options]
+# Marker list is auto-imported from the root pyproject.toml in conftest.py's
+# pytest_configure, so --strict-markers stays useful without duplication here.
+addopts = ["--strict-markers", "--strict-config"]
+asyncio_mode = "auto"
+testpaths = ["."]
+log_cli = true
+log_cli_level = "INFO"

--- a/tests/fault_tolerance/deploy/reports.py
+++ b/tests/fault_tolerance/deploy/reports.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Scenario reports for fault tolerance testing.
+
+Reports have:
+- generate(ctx): Create the report after checks pass
+- description: Human-readable description
+
+Reports are run after all checks pass and can generate
+additional artifacts (HTML reports, metrics summaries, etc.)
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tests.fault_tolerance.deploy.scenario import ScenarioContext
+
+
+# =============================================================================
+# Report Base Class
+# =============================================================================
+
+
+@dataclass
+class Report(ABC):
+    """Base class for report generation.
+
+    Reports are run after checks pass and can generate
+    additional artifacts (HTML reports, metrics summaries, etc.)
+    """
+
+    @abstractmethod
+    def generate(self, ctx: "ScenarioContext") -> None:
+        """Generate the report."""
+        pass
+
+    @property
+    @abstractmethod
+    def description(self) -> str:
+        """Human-readable description of the report."""
+        pass

--- a/tests/fault_tolerance/deploy/reports.py
+++ b/tests/fault_tolerance/deploy/reports.py
@@ -72,12 +72,19 @@ class FaultToleranceReport(Report):
         # Local import avoids a circular dependency at module load.
         from tests.fault_tolerance.deploy.events import (
             DeletePod,
+            NetworkPartition,
             RollingUpgrade,
             StartLoad,
             TerminateProcess,
+            WaitForRecovery,
         )
 
-        FAULT_TYPES = (DeletePod, TerminateProcess, RollingUpgrade)
+        FAULT_TYPES = (
+            DeletePod,
+            TerminateProcess,
+            RollingUpgrade,
+            NetworkPartition,
+        )
 
         load_events = [e for e in ctx.events if isinstance(e, StartLoad)]
         if not load_events:
@@ -118,7 +125,42 @@ class FaultToleranceReport(Report):
         # so we read the value from ctx (cached pre-cleanup).
         startup_s = getattr(ctx, "startup_seconds", None)
 
-        rows = [self._row("none", records, fault_ns=None, startup_s=startup_s)]
+        # Recovery time per fault: derived from the WaitForRecovery
+        # event that immediately follows each fault in the events list.
+        # WaitForRecovery's timed_execute brackets give wall-clock for
+        # how long the deployment took to flip back to Ready after the
+        # fault. NetworkPartition's transient (duration=N) is its own
+        # recovery — partition starts and heals inside one execute call.
+        recovery_by_event_id: dict[int, float] = {}
+        for i, fe in enumerate(ctx.events):
+            if not isinstance(fe, FAULT_TYPES):
+                continue
+            # Transient partition: recovery is the partition's own
+            # in-execute window (the deployment never went non-Ready
+            # since worker pods stayed running).
+            if isinstance(fe, NetworkPartition) and fe.duration is not None:
+                recovery_by_event_id[id(fe)] = float(fe.duration)
+                continue
+            for follower in ctx.events[i + 1 :]:
+                if isinstance(follower, WaitForRecovery):
+                    s = getattr(follower, "started_at", None)
+                    e = getattr(follower, "ended_at", None)
+                    if s and e:
+                        recovery_by_event_id[id(fe)] = (e - s).total_seconds()
+                    break
+                if isinstance(follower, FAULT_TYPES):
+                    # Another fault closes this fault's recovery window.
+                    break
+
+        rows = [
+            self._row(
+                "none",
+                records,
+                fault_ns=None,
+                startup_s=startup_s,
+                recovery_s=None,
+            )
+        ]
         for fe in ctx.events:
             if not isinstance(fe, FAULT_TYPES):
                 continue
@@ -128,22 +170,43 @@ class FaultToleranceReport(Report):
             fault_ns = int(started.timestamp() * 1_000_000_000)
             label = type(fe).__name__
             services = getattr(fe, "services", None)
+            source = getattr(fe, "source", None)
+            target = getattr(fe, "target", None)
             if services:
                 label = f"{label}({','.join(services)})"
+            elif source and target:
+                label = f"{label}({source}->{target})"
             rows.append(
-                self._row(label, records, fault_ns=fault_ns, startup_s=startup_s)
+                self._row(
+                    label,
+                    records,
+                    fault_ns=fault_ns,
+                    startup_s=startup_s,
+                    recovery_s=recovery_by_event_id.get(id(fe)),
+                )
             )
 
-        table = self._render(rows)
-        ctx.logger.info("\n" + table)
+        # Render the report as three narrow sections — easier to read in
+        # a terminal or slide deck than one wide eight-column table.
+        ctx.logger.info("\n" + self._render_sections(rows, "fancy_grid"))
 
         if self.save_to_file:
-            out = os.path.join(ctx.log_dir, "fault_tolerance_report.md")
+            md_out = os.path.join(ctx.log_dir, "fault_tolerance_report.md")
+            json_out = os.path.join(ctx.log_dir, "fault_tolerance_report.json")
             try:
-                os.makedirs(os.path.dirname(out), exist_ok=True)
-                with open(out, "w") as f:
-                    f.write(table + "\n")
-                ctx.logger.info(f"FaultToleranceReport written to {out}")
+                os.makedirs(os.path.dirname(md_out), exist_ok=True)
+                with open(md_out, "w") as f:
+                    f.write(self._render_sections(rows, "pipe") + "\n")
+                ctx.logger.info(f"FaultToleranceReport written to {md_out}")
+                # JSON sidecar — makes cross-test aggregation cheap.
+                with open(json_out, "w") as f:
+                    json.dump(
+                        {"test_name": os.path.basename(ctx.log_dir), "rows": rows},
+                        f,
+                        indent=2,
+                        default=str,
+                    )
+                ctx.logger.info(f"FaultToleranceReport (JSON) written to {json_out}")
             except OSError as e:
                 ctx.logger.warning(f"FaultToleranceReport save failed: {e}")
 
@@ -157,6 +220,7 @@ class FaultToleranceReport(Report):
         records: list[dict],
         fault_ns: Optional[int],
         startup_s: Optional[float] = None,
+        recovery_s: Optional[float] = None,
     ) -> dict[str, Any]:
         """Compute a single table row.
 
@@ -197,6 +261,7 @@ class FaultToleranceReport(Report):
         return {
             "failure": label,
             "startup_s": "N/A" if startup_s is None else startup_s,
+            "recovery_s": "N/A" if recovery_s is None else recovery_s,
             "success_before": succ_b,
             "failed_before": fail_b,
             "success_after": "N/A" if fault_ns is None else succ_a,
@@ -206,27 +271,144 @@ class FaultToleranceReport(Report):
         }
 
     @staticmethod
-    def _render(rows: list[dict[str, Any]]) -> str:
-        header = (
-            "| Failure | Startup (s) | Success Before | Failed Before "
-            "| Success After | Failed After | Latency Before (ms) | Latency After (ms) |"
+    def _render_sections(rows: list[dict[str, Any]], tablefmt: str = "pipe") -> str:
+        """Render the report as three narrow sections.
+
+        Stacking sections vertically keeps each table well within an 80-
+        column terminal (and a slide column) instead of forcing horizontal
+        scroll. Sections share the failure-name column so rows align by
+        eye between them.
+        """
+        from tabulate import tabulate
+
+        def _f(v: Any) -> str:
+            return v if isinstance(v, str) else f"{v:.2f}"
+
+        timing_headers = ["Failure", "Startup (s)", "Recovery (s)"]
+        timing_body = [
+            [r["failure"], _f(r["startup_s"]), _f(r["recovery_s"])] for r in rows
+        ]
+
+        counts_headers = [
+            "Failure",
+            "Success Before",
+            "Failed Before",
+            "Success After",
+            "Failed After",
+        ]
+        counts_body = [
+            [
+                r["failure"],
+                r["success_before"],
+                r["failed_before"],
+                r["success_after"],
+                r["failed_after"],
+            ]
+            for r in rows
+        ]
+
+        latency_headers = ["Failure", "Latency Before (ms)", "Latency After (ms)"]
+        latency_body = [
+            [r["failure"], _f(r["latency_before_ms"]), _f(r["latency_after_ms"])]
+            for r in rows
+        ]
+
+        sep = "\n\n"
+        return sep.join(
+            [
+                "## Timing\n\n"
+                + tabulate(timing_body, headers=timing_headers, tablefmt=tablefmt),
+                "## Request counts (around fault)\n\n"
+                + tabulate(counts_body, headers=counts_headers, tablefmt=tablefmt),
+                "## Latency\n\n"
+                + tabulate(latency_body, headers=latency_headers, tablefmt=tablefmt),
+            ]
         )
-        sep = "|---|---|---|---|---|---|---|---|"
-        out = [header, sep]
-        for r in rows:
-            lb = f"{r['latency_before_ms']:.2f}"
-            la = (
-                r["latency_after_ms"]
-                if isinstance(r["latency_after_ms"], str)
-                else f"{r['latency_after_ms']:.2f}"
-            )
-            startup = (
-                r["startup_s"]
-                if isinstance(r["startup_s"], str)
-                else f"{r['startup_s']:.2f}"
-            )
-            out.append(
-                f"| {r['failure']} | {startup} | {r['success_before']} | {r['failed_before']} "
-                f"| {r['success_after']} | {r['failed_after']} | {lb} | {la} |"
-            )
-        return "\n".join(out)
+
+
+# =============================================================================
+# Error Breakdown Report
+# =============================================================================
+
+
+@dataclass
+class ErrorBreakdownReport(Report):
+    """Render aiperf's per-error-type breakdown for each load.
+
+    Reads ``profile_export_aiperf.json`` (the aggregate aiperf summary)
+    for each ``StartLoad`` event and emits one table per load showing
+    each distinct error type, its cause chain, and the count. Useful
+    for understanding *why* a fault scenario produced failures (request
+    timeouts, server 5xx, connection resets, etc.).
+    """
+
+    save_to_file: bool = True
+
+    def generate(self, ctx: "ScenarioContext") -> None:
+        from tests.fault_tolerance.deploy.events import StartLoad
+
+        load_events = [e for e in ctx.events if isinstance(e, StartLoad)]
+        if not load_events:
+            ctx.logger.info("ErrorBreakdownReport: no StartLoad in scenario; skipping")
+            return
+
+        sections: list[str] = []
+        for load in load_events:
+            ml = getattr(load, "_managed_load", None)
+            local_dir = (
+                getattr(ml, "local_output_dir", None) if ml else None
+            ) or os.path.join(ctx.log_dir, "load")
+            summary_path = os.path.join(local_dir, "profile_export_aiperf.json")
+            if not os.path.exists(summary_path):
+                ctx.logger.warning(f"ErrorBreakdownReport: {summary_path} not found")
+                continue
+            try:
+                with open(summary_path) as f:
+                    summary = json.load(f)
+            except (json.JSONDecodeError, OSError) as e:
+                ctx.logger.warning(f"ErrorBreakdownReport: load {load.name}: {e}")
+                continue
+
+            total_errors = (summary.get("error_request_count") or {}).get("avg", 0)
+            entries = summary.get("error_summary") or []
+            rows: list[list[Any]] = []
+            for entry in entries:
+                d = entry.get("error_details") or {}
+                rows.append(
+                    [
+                        d.get("type", "unknown"),
+                        d.get("message", ""),
+                        " → ".join(d.get("cause_chain") or []),
+                        entry.get("count", 0),
+                    ]
+                )
+            if not rows:
+                rows.append(["(none)", "—", "—", 0])
+
+            section = self._render(load.name, int(total_errors), rows, "fancy_grid")
+            ctx.logger.info("\n" + section)
+            sections.append(self._render(load.name, int(total_errors), rows, "pipe"))
+
+        if self.save_to_file and sections:
+            out = os.path.join(ctx.log_dir, "error_breakdown_report.md")
+            try:
+                os.makedirs(os.path.dirname(out), exist_ok=True)
+                with open(out, "w") as f:
+                    f.write("\n\n".join(sections) + "\n")
+                ctx.logger.info(f"ErrorBreakdownReport written to {out}")
+            except OSError as e:
+                ctx.logger.warning(f"ErrorBreakdownReport save failed: {e}")
+
+    @property
+    def description(self) -> str:
+        return "Per-load aiperf error-type breakdown"
+
+    @staticmethod
+    def _render(
+        load_name: str, total: int, rows: list[list[Any]], tablefmt: str
+    ) -> str:
+        from tabulate import tabulate
+
+        headers = ["Type", "Message", "Cause Chain", "Count"]
+        title = f"### Load '{load_name}' — total errors: {total}"
+        return f"{title}\n\n{tabulate(rows, headers=headers, tablefmt=tablefmt)}"

--- a/tests/fault_tolerance/deploy/reports.py
+++ b/tests/fault_tolerance/deploy/reports.py
@@ -12,9 +12,11 @@ Reports are run after all checks pass and can generate
 additional artifacts (HTML reports, metrics summaries, etc.)
 """
 
+import json
+import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Optional
 
 if TYPE_CHECKING:
     from tests.fault_tolerance.deploy.scenario import ScenarioContext
@@ -43,3 +45,188 @@ class Report(ABC):
     def description(self) -> str:
         """Human-readable description of the report."""
         pass
+
+
+# =============================================================================
+# Fault Tolerance Report
+# =============================================================================
+
+
+@dataclass
+class FaultToleranceReport(Report):
+    """Render a markdown table of pre/post-fault metrics, one row per fault.
+
+    Reads the per-request aiperf JSONL produced by ``StartLoad`` and slices
+    it on each fault-injection event's ``started_at`` timestamp (recorded
+    by the scenario runner). Mirrors the legacy fault-tolerance report:
+
+        | Failure | Success Before | Failed Before | Success After | Failed After | Latency Before | Latency After |
+
+    A baseline ``none`` row is always emitted; one additional row per
+    ``DeletePod`` / ``TerminateProcess`` / ``RollingUpgrade`` event.
+    """
+
+    save_to_file: bool = True
+
+    def generate(self, ctx: "ScenarioContext") -> None:
+        # Local import avoids a circular dependency at module load.
+        from tests.fault_tolerance.deploy.events import (
+            DeletePod,
+            RollingUpgrade,
+            StartLoad,
+            TerminateProcess,
+        )
+
+        FAULT_TYPES = (DeletePod, TerminateProcess, RollingUpgrade)
+
+        load_events = [e for e in ctx.events if isinstance(e, StartLoad)]
+        if not load_events:
+            ctx.logger.info("FaultToleranceReport: no StartLoad in scenario; skipping")
+            return
+
+        # Most fault scenarios run a single load; if there are several, use
+        # the first as the per-request source. (Per-load reports could be a
+        # future extension.) Fall back to the deterministic
+        # ``<log_dir>/load/`` path because StopLoad clears the
+        # ``_managed_load`` reference before reports run.
+        load = load_events[0]
+        ml = getattr(load, "_managed_load", None)
+        local_dir = (
+            getattr(ml, "local_output_dir", None) if ml else None
+        ) or os.path.join(ctx.log_dir, "load")
+        jsonl_path = os.path.join(local_dir, "profile_export.jsonl")
+        if not os.path.exists(jsonl_path):
+            ctx.logger.warning(
+                f"FaultToleranceReport: per-request log {jsonl_path} not found"
+            )
+            return
+
+        records: list[dict[str, Any]] = []
+        with open(jsonl_path) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    records.append(json.loads(line))
+                except json.JSONDecodeError:
+                    pass
+
+        # Startup time is a property of the deployment, not of any
+        # particular fault — it's the same value on every row. The
+        # deployment reference has been cleared by the time reports run,
+        # so we read the value from ctx (cached pre-cleanup).
+        startup_s = getattr(ctx, "startup_seconds", None)
+
+        rows = [self._row("none", records, fault_ns=None, startup_s=startup_s)]
+        for fe in ctx.events:
+            if not isinstance(fe, FAULT_TYPES):
+                continue
+            started = getattr(fe, "started_at", None)
+            if started is None:
+                continue
+            fault_ns = int(started.timestamp() * 1_000_000_000)
+            label = type(fe).__name__
+            services = getattr(fe, "services", None)
+            if services:
+                label = f"{label}({','.join(services)})"
+            rows.append(
+                self._row(label, records, fault_ns=fault_ns, startup_s=startup_s)
+            )
+
+        table = self._render(rows)
+        ctx.logger.info("\n" + table)
+
+        if self.save_to_file:
+            out = os.path.join(ctx.log_dir, "fault_tolerance_report.md")
+            try:
+                os.makedirs(os.path.dirname(out), exist_ok=True)
+                with open(out, "w") as f:
+                    f.write(table + "\n")
+                ctx.logger.info(f"FaultToleranceReport written to {out}")
+            except OSError as e:
+                ctx.logger.warning(f"FaultToleranceReport save failed: {e}")
+
+    @property
+    def description(self) -> str:
+        return "Fault-tolerance summary table (pre/post per fault event)"
+
+    @staticmethod
+    def _row(
+        label: str,
+        records: list[dict],
+        fault_ns: Optional[int],
+        startup_s: Optional[float] = None,
+    ) -> dict[str, Any]:
+        """Compute a single table row.
+
+        ``fault_ns=None`` means "no fault" — counts and latency span the
+        whole load window and post-fault columns are reported as ``N/A``.
+        """
+        succ_b = fail_b = succ_a = fail_a = 0
+        lat_b: list[float] = []
+        lat_a: list[float] = []
+        for r in records:
+            md = r.get("metadata", {})
+            mt = r.get("metrics", {})
+            end_ns = md.get("request_end_ns", 0)
+            # A request is a failure if aiperf cancelled it OR if it
+            # finished without producing a latency metric (which is what
+            # TimeoutError / connection-reset records look like in the
+            # JSONL — `was_cancelled` stays False but `metrics` is empty).
+            lat_record = mt.get("request_latency")
+            failed = bool(md.get("was_cancelled", False)) or not lat_record
+            lat = (lat_record or {}).get("value", 0.0)
+            before = fault_ns is None or end_ns < fault_ns
+            if before:
+                if failed:
+                    fail_b += 1
+                else:
+                    succ_b += 1
+                    lat_b.append(lat)
+            else:
+                if failed:
+                    fail_a += 1
+                else:
+                    succ_a += 1
+                    lat_a.append(lat)
+
+        def _avg(xs: list[float]) -> float:
+            return sum(xs) / len(xs) if xs else 0.0
+
+        return {
+            "failure": label,
+            "startup_s": "N/A" if startup_s is None else startup_s,
+            "success_before": succ_b,
+            "failed_before": fail_b,
+            "success_after": "N/A" if fault_ns is None else succ_a,
+            "failed_after": "N/A" if fault_ns is None else fail_a,
+            "latency_before_ms": _avg(lat_b),
+            "latency_after_ms": ("N/A" if fault_ns is None else _avg(lat_a)),
+        }
+
+    @staticmethod
+    def _render(rows: list[dict[str, Any]]) -> str:
+        header = (
+            "| Failure | Startup (s) | Success Before | Failed Before "
+            "| Success After | Failed After | Latency Before (ms) | Latency After (ms) |"
+        )
+        sep = "|---|---|---|---|---|---|---|---|"
+        out = [header, sep]
+        for r in rows:
+            lb = f"{r['latency_before_ms']:.2f}"
+            la = (
+                r["latency_after_ms"]
+                if isinstance(r["latency_after_ms"], str)
+                else f"{r['latency_after_ms']:.2f}"
+            )
+            startup = (
+                r["startup_s"]
+                if isinstance(r["startup_s"], str)
+                else f"{r['startup_s']:.2f}"
+            )
+            out.append(
+                f"| {r['failure']} | {startup} | {r['success_before']} | {r['failed_before']} "
+                f"| {r['success_after']} | {r['failed_after']} | {lb} | {la} |"
+            )
+        return "\n".join(out)

--- a/tests/fault_tolerance/deploy/reports.py
+++ b/tests/fault_tolerance/deploy/reports.py
@@ -198,10 +198,38 @@ class FaultToleranceReport(Report):
                 with open(md_out, "w") as f:
                     f.write(self._render_sections(rows, "pipe") + "\n")
                 ctx.logger.info(f"FaultToleranceReport written to {md_out}")
+                # Per-event timing block — every event in the scenario,
+                # with its description + UTC wall-clock bracket. Lets
+                # post-process tools (cascade_timeline --events, etc.)
+                # overlay event boundaries on the per-second time-series
+                # without needing to scrape pytest logs or kubectl jobs.
+                events_block = []
+                for evt in ctx.events:
+                    started = getattr(evt, "started_at", None)
+                    ended = getattr(evt, "ended_at", None)
+                    events_block.append(
+                        {
+                            "type": type(evt).__name__,
+                            "description": getattr(evt, "description", repr(evt)),
+                            "name": getattr(evt, "name", None),
+                            "started_at": started.isoformat() if started else None,
+                            "ended_at": ended.isoformat() if ended else None,
+                            "started_at_ns": (
+                                int(started.timestamp() * 1e9) if started else None
+                            ),
+                            "ended_at_ns": (
+                                int(ended.timestamp() * 1e9) if ended else None
+                            ),
+                        }
+                    )
                 # JSON sidecar — makes cross-test aggregation cheap.
                 with open(json_out, "w") as f:
                     json.dump(
-                        {"test_name": os.path.basename(ctx.log_dir), "rows": rows},
+                        {
+                            "test_name": os.path.basename(ctx.log_dir),
+                            "rows": rows,
+                            "events": events_block,
+                        },
                         f,
                         indent=2,
                         default=str,
@@ -412,3 +440,691 @@ class ErrorBreakdownReport(Report):
         headers = ["Type", "Message", "Cause Chain", "Count"]
         title = f"### Load '{load_name}' — total errors: {total}"
         return f"{title}\n\n{tabulate(rows, headers=headers, tablefmt=tablefmt)}"
+
+
+# =============================================================================
+# Per-Worker Latency Report
+# =============================================================================
+
+
+@dataclass
+class PerWorkerLatencyReport(Report):
+    """Render per-worker latency-histogram p99 tables for each StartLoad.
+
+    Reads ``server_metrics_export.jsonl`` (emitted by aiperf
+    ``--server-metrics``) from each rung's local extract dir, computes
+    the delta-histogram per pod across the rung's scrape window, and
+    extracts p50 / p95 / p99 for the vLLM engine-side latency metrics.
+
+    Lets readers attribute frontend TTFT spikes to specific workers and
+    phases. For disagg in particular this separates:
+      - prefill queue / prefill compute / NIXL post  (prefill role)
+      - decode queue / decode TTFT / NIXL xfer / ITL (decode role)
+    """
+
+    save_to_file: bool = True
+
+    # Metric -> column header. Order controls table column order.
+    # NOTE: vllm:time_to_first_token_seconds on a *decode* worker in
+    # disagg mode measures "engine arrival -> first decoded token",
+    # which includes queue wait but excludes the NIXL transfer itself
+    # (the request hits the engine queue only after NIXL completes).
+    _METRICS = [
+        ("vllm:request_queue_time_seconds", "queue"),
+        ("vllm:time_to_first_token_seconds", "ttft"),
+        ("vllm:request_prefill_time_seconds", "prefill"),
+        ("vllm:request_decode_time_seconds", "decode"),
+        ("vllm:request_inference_time_seconds", "inference"),
+        ("vllm:nixl_xfer_time_seconds", "nixl_xfer"),
+        ("vllm:nixl_post_time_seconds", "nixl_post"),
+        ("vllm:inter_token_latency_seconds", "itl"),
+        ("vllm:e2e_request_latency_seconds", "e2e"),
+    ]
+
+    def generate(self, ctx: "ScenarioContext") -> None:
+        from tests.fault_tolerance.deploy.events import StartLoad
+
+        load_events = [e for e in ctx.events if isinstance(e, StartLoad)]
+        if not load_events:
+            ctx.logger.info(
+                "PerWorkerLatencyReport: no StartLoad in scenario; skipping"
+            )
+            return
+
+        sections_screen: list[str] = []
+        sections_file: list[str] = []
+        for load in load_events:
+            ml = getattr(load, "_managed_load", None)
+            local_dir = (
+                getattr(ml, "local_output_dir", None) if ml else None
+            ) or os.path.join(ctx.log_dir, "load")
+            jsonl = os.path.join(local_dir, "server_metrics_export.jsonl")
+            if not os.path.exists(jsonl):
+                ctx.logger.warning(
+                    f"PerWorkerLatencyReport: {jsonl} not found for load "
+                    f"{load.name!r}; aiperf may not have produced server "
+                    "metrics. Pass concrete --server-metrics URLs in the "
+                    "LoadConfig if running against a non-instrumented dgd."
+                )
+                continue
+
+            by_pod = self._extract_per_worker_quantiles(jsonl)
+            if not by_pod:
+                ctx.logger.warning(
+                    f"PerWorkerLatencyReport: no worker rows for {load.name!r}"
+                )
+                continue
+
+            sections_screen.append(self._render(load.name, by_pod, "fancy_grid"))
+            sections_file.append(self._render(load.name, by_pod, "pipe"))
+            ctx.logger.info("\n" + sections_screen[-1])
+
+        if self.save_to_file and sections_file:
+            out = os.path.join(ctx.log_dir, "per_worker_latency_report.md")
+            try:
+                os.makedirs(os.path.dirname(out), exist_ok=True)
+                with open(out, "w") as f:
+                    f.write("\n\n".join(sections_file) + "\n")
+                ctx.logger.info(f"PerWorkerLatencyReport written to {out}")
+            except OSError as e:
+                ctx.logger.warning(f"PerWorkerLatencyReport save failed: {e}")
+
+    @property
+    def description(self) -> str:
+        return "Per-worker latency-histogram p99 (TTFT / queue / NIXL etc.)"
+
+    @classmethod
+    def _extract_per_worker_quantiles(
+        cls, jsonl_path: str
+    ) -> dict[str, dict[str, Any]]:
+        """Walk the rung's server-metrics JSONL, compute per-worker p50/p95/p99.
+
+        Returns ``{short_pod: {"role": str, metric_label: (p50, p95, p99), ...}}``.
+        """
+        first: dict[str, dict[str, dict]] = {}
+        last: dict[str, dict[str, dict]] = {}
+        role_by_ep: dict[str, str] = {}
+
+        with open(jsonl_path) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                ep = rec.get("endpoint_url", "")
+                if "frontend" in ep:
+                    continue
+                metrics = rec.get("metrics", {})
+                for k, _ in cls._METRICS:
+                    series_list = metrics.get(k, [])
+                    for series in series_list:
+                        bk = series.get("buckets")
+                        if not bk:
+                            continue
+                        comp = series.get("labels", {}).get("dynamo_component")
+                        if comp and ep not in role_by_ep:
+                            role_by_ep[ep] = comp
+                        first.setdefault(ep, {}).setdefault(k, bk)
+                        last.setdefault(ep, {})[k] = bk
+
+        out: dict[str, dict[str, Any]] = {}
+        for ep in sorted(last):
+            row: dict[str, Any] = {"role": role_by_ep.get(ep, "?")}
+            for k, label in cls._METRICS:
+                f_bk = first.get(ep, {}).get(k)
+                l_bk = last.get(ep, {}).get(k)
+                if not f_bk or not l_bk:
+                    row[label] = None
+                    continue
+                delta = {kk: max(0.0, l_bk.get(kk, 0) - f_bk.get(kk, 0)) for kk in l_bk}
+                row[label] = (
+                    cls._histo_quantile(delta, 0.50),
+                    cls._histo_quantile(delta, 0.95),
+                    cls._histo_quantile(delta, 0.99),
+                )
+            out[cls._short_pod(ep)] = row
+        return out
+
+    @staticmethod
+    def _short_pod(ep: str) -> str:
+        # http://100.67.X.Y:9090/metrics -> 100.67.X.Y
+        return ep.replace("http://", "").split(":")[0]
+
+    @staticmethod
+    def _histo_quantile(delta: dict[str, float], q: float):
+        """Inverse-CDF on a Prom-style cumulative histogram delta.
+
+        Returns ``float`` (seconds) on success, the string ``">{le}s"``
+        when the quantile falls in the +Inf bucket (no upper bound),
+        or ``None`` if there's no data.
+        """
+        total = delta.get("+Inf", 0)
+        items = sorted(
+            ((float(k), v) for k, v in delta.items() if k != "+Inf"),
+            key=lambda x: x[0],
+        )
+        if total <= 0 or not items:
+            return None
+        target = q * total
+        prev_le, prev_count = 0.0, 0.0
+        for le, c in items:
+            if c >= target:
+                if c == prev_count:
+                    return le
+                return prev_le + (target - prev_count) / (c - prev_count) * (
+                    le - prev_le
+                )
+            prev_le, prev_count = le, c
+        # In the +Inf bucket — no upper bound resolvable from histogram.
+        return f">{items[-1][0]:.1f}"
+
+    @classmethod
+    def _render(
+        cls,
+        load_name: str,
+        by_pod: dict[str, dict[str, Any]],
+        tablefmt: str,
+    ) -> str:
+        from tabulate import tabulate
+
+        labels = [label for _, label in cls._METRICS]
+
+        # Prefill rows first, then decode/backend, then anything else;
+        # within a role, sort lexicographically by short pod id.
+        def role_sort_key(p):
+            r = by_pod[p]["role"]
+            order = {"prefill": 0, "decode": 1, "backend": 1}.get(r, 9)
+            return (order, p)
+
+        pods = sorted(by_pod, key=role_sort_key)
+        headers = ["pod", "role"] + [f"{lbl}_p99" for lbl in labels]
+        rows = []
+        for p in pods:
+            row = [p, by_pod[p]["role"]]
+            for lbl in labels:
+                val = by_pod[p].get(lbl)
+                row.append(cls._fmt_val(val))
+            rows.append(row)
+        title = f"### Per-worker latency p99 — load '{load_name}'"
+        return f"{title}\n\n{tabulate(rows, headers=headers, tablefmt=tablefmt)}"
+
+    @staticmethod
+    def _fmt_val(val):
+        if val is None:
+            return "-"
+        # val is (p50, p95, p99) -- show p99 (table title says p99).
+        p99 = val[2]
+        if p99 is None:
+            return "-"
+        if isinstance(p99, str):
+            return p99
+        if p99 >= 1.0:
+            return f"{p99:.2f}s"
+        return f"{p99 * 1000:.0f}ms"
+
+
+# =============================================================================
+# GPU Memory Report
+# =============================================================================
+
+
+@dataclass
+class GpuMemoryReport(Report):
+    """Per-rung max GPU framebuffer usage from DCGM_FI_DEV_FB_USED.
+
+    Queries Prometheus over each StartLoad rung's wall-clock window for
+    every GPU the deployment's pods used (via DCGM's
+    `exported_namespace` / `exported_pod` labels). Emits a table of
+    max GB-used per GPU per rung and flags anything > `max_gb_per_gpu`.
+
+    Used to verify the A100-40GB emulation: with
+    `--gpu-memory-utilization=0.45` on H100-80GB, vLLM should fit
+    within ~36 GB plus a few-hundred-MB of driver / NIXL overhead;
+    anything > 40 GB means the cap isn't being honored.
+    """
+
+    save_to_file: bool = True
+    # Soft threshold — exceeding this is logged loudly but not asserted.
+    # Hard enforcement should be a separate Check (so failures don't
+    # block report emission).
+    max_gb_per_gpu: float = 40.0
+    prometheus_url: str = "http://localhost:9090"
+    # Match the namespace the deployment runs in. Read from the
+    # ScenarioContext at run time.
+    _namespace: Optional[str] = None
+    # Match pod-name substring; auto-populated from the deployment.
+    _dgd_name: Optional[str] = None
+
+    def generate(self, ctx: "ScenarioContext") -> None:
+        from tests.fault_tolerance.deploy.events import StartLoad
+
+        # Get pod name substring from the deployment spec.
+        ns = ctx.namespace
+        dgd_name = getattr(getattr(ctx, "deployment", None), "_deployment_name", None)
+        if not dgd_name and getattr(ctx, "deployment", None) is not None:
+            dgd_name = ctx.deployment.deployment_spec.name
+        # Common DGD-name pattern: pods are <dgd>-N-... ; match by substring.
+
+        load_events = [e for e in ctx.events if isinstance(e, StartLoad)]
+        if not load_events:
+            ctx.logger.info("GpuMemoryReport: no StartLoad in scenario; skipping")
+            return
+
+        rows: list[dict] = []
+        for load in load_events:
+            started = getattr(load, "started_at", None)
+            ended = getattr(load, "ended_at", None)
+            if not started or not ended:
+                continue
+            per_gpu = self._query_max_fb_used(ns, dgd_name, started, ended)
+            for label, mb in per_gpu.items():
+                rows.append({"rung": load.name, "gpu": label, "max_gb": mb / 1024.0})
+
+        if not rows:
+            ctx.logger.warning(
+                "GpuMemoryReport: no DCGM samples returned. Check Prometheus URL "
+                "(%s) and that DCGM_FI_DEV_FB_USED has labels exported_namespace=%s.",
+                self.prometheus_url,
+                ns,
+            )
+            return
+
+        # Render two views: per-(rung, pod, gpu) raw table + per-rung max.
+        screen = self._render(rows, "fancy_grid")
+        ctx.logger.info("\n" + screen)
+        if self.save_to_file:
+            out = os.path.join(ctx.log_dir, "gpu_memory_report.md")
+            try:
+                os.makedirs(os.path.dirname(out), exist_ok=True)
+                with open(out, "w") as f:
+                    f.write(self._render(rows, "pipe") + "\n")
+                ctx.logger.info(f"GpuMemoryReport written to {out}")
+            except OSError as e:
+                ctx.logger.warning(f"GpuMemoryReport save failed: {e}")
+
+        # Loud-log any GPU exceeding the threshold.
+        violators = [r for r in rows if r["max_gb"] > self.max_gb_per_gpu]
+        if violators:
+            for v in violators:
+                ctx.logger.error(
+                    "GpuMemoryReport: %s on rung %s used %.2f GB (> %.2f GB cap)",
+                    v["gpu"],
+                    v["rung"],
+                    v["max_gb"],
+                    self.max_gb_per_gpu,
+                )
+        else:
+            ctx.logger.info(
+                "GpuMemoryReport: all GPUs stayed within %.2f GB across all rungs.",
+                self.max_gb_per_gpu,
+            )
+
+    @property
+    def description(self) -> str:
+        return "Per-rung max GPU framebuffer usage (DCGM)"
+
+    def _query_max_fb_used(self, ns, dgd_name, started, ended):
+        """Return ``{<short_label>: max_MB}`` for every GPU used by the
+        DGD's pods during ``[started, ended]``."""
+        import urllib.parse
+        import urllib.request
+
+        win_s = max(1, int((ended - started).total_seconds()))
+        end_ts = int(ended.timestamp())
+        # DCGM exports `exported_namespace` and `exported_pod` labels so
+        # we can scope by deployment without touching the dgxc-alloy /
+        # gpu-operator scrape config.
+        selector = f'exported_namespace="{ns}"'
+        if dgd_name:
+            selector += f',exported_pod=~".*{dgd_name}.*"'
+        query = f"max_over_time(DCGM_FI_DEV_FB_USED{{{selector}}}[{win_s}s])"
+        url = f"{self.prometheus_url}/api/v1/query?" + urllib.parse.urlencode(
+            {"query": query, "time": end_ts}
+        )
+        try:
+            with urllib.request.urlopen(url, timeout=5) as r:
+                d = json.loads(r.read())
+        except Exception:
+            return {}
+        out: dict[str, float] = {}
+        for s in d.get("data", {}).get("result", []):
+            m = s["metric"]
+            pod = m.get("exported_pod") or "?"
+            gpu = m.get("gpu") or m.get("device") or "?"
+            # Pod tail + gpu id keeps labels short and unique
+            short = f"{pod.rsplit('-', 1)[-1]}/gpu{gpu}"
+            try:
+                v = float(s["value"][1])
+            except (TypeError, ValueError):
+                continue
+            if v > out.get(short, 0):
+                out[short] = v
+        return out
+
+    def _render(self, rows: list[dict], tablefmt: str) -> str:
+        from tabulate import tabulate
+
+        # Pivot: rows of rung × gpu showing max_gb
+        rungs = sorted({r["rung"] for r in rows}, key=self._rung_sort_key)
+        gpus = sorted({r["gpu"] for r in rows})
+        cell = {(r["rung"], r["gpu"]): r["max_gb"] for r in rows}
+        headers = ["rung"] + gpus
+        table = []
+        for rung in rungs:
+            row = [rung]
+            for g in gpus:
+                v = cell.get((rung, g))
+                row.append(f"{v:.2f}" if v is not None else "-")
+            table.append(row)
+        title = (
+            f"### GPU framebuffer max GB used per rung "
+            f"(DCGM_FI_DEV_FB_USED; cap = {self.max_gb_per_gpu:.1f} GB)"
+        )
+        return f"{title}\n\n{tabulate(table, headers=headers, tablefmt=tablefmt)}"
+
+    @staticmethod
+    def _rung_sort_key(name: str):
+        # c64, r16 etc. — sort by phase letter then numeric suffix.
+        if not name:
+            return (9, 0, name)
+        phase = name[0]
+        try:
+            n = int(name[1:])
+        except ValueError:
+            n = 0
+        order = {"c": 0, "r": 1}.get(phase, 9)
+        return (order, n, name)
+
+
+# =============================================================================
+# Error Tracking Report
+# =============================================================================
+
+
+@dataclass
+class ErrorTrackingReport(Report):
+    """One row per rung, aggregating every kind of error we can collect.
+
+    Sources:
+      - aiperf:           `error_request_count` + `error_summary` (from
+                          profile_export_aiperf.json on each rung's local dir)
+      - vLLM workers:     delta of `vllm:num_preemptions_total` /
+                          `vllm:nixl_num_failed_transfers` /
+                          `vllm:nixl_num_kv_expired_reqs` between the rung's
+                          first and last server_metrics_export.jsonl scrape
+      - k8s containers:   `increase(kube_pod_container_status_restarts_total[rung_window])`
+                          summed across DGD pods; plus the most recent
+                          `kube_pod_container_status_last_terminated_reason`
+                          (OOMKilled, Error, Completed, ...) so we know
+                          WHY a restart happened. kube-state-metrics
+                          retains the series even after pods are gone,
+                          so this works at report time too.
+    """
+
+    save_to_file: bool = True
+    prometheus_url: str = "http://localhost:9090"
+
+    def generate(self, ctx: "ScenarioContext") -> None:
+        from tests.fault_tolerance.deploy.events import StartLoad
+
+        load_events = [e for e in ctx.events if isinstance(e, StartLoad)]
+        if not load_events:
+            ctx.logger.info("ErrorTrackingReport: no StartLoad in scenario; skipping")
+            return
+
+        ns = ctx.namespace
+        dgd_name = None
+        if getattr(ctx, "deployment", None) is not None:
+            dgd_name = ctx.deployment.deployment_spec.name
+
+        rows = []
+        for load in load_events:
+            ml = getattr(load, "_managed_load", None)
+            local_dir = (
+                getattr(ml, "local_output_dir", None) if ml else None
+            ) or os.path.join(ctx.log_dir, "load")
+            row = {"rung": load.name}
+
+            # aiperf error count + breakdown
+            ai_total, ai_types = self._aiperf_errors(
+                os.path.join(local_dir, "profile_export_aiperf.json")
+            )
+            row["aiperf_errors"] = ai_total
+            row["aiperf_error_types"] = ai_types
+
+            # vLLM worker error counters (sum across pods of per-pod delta).
+            row.update(
+                self._vllm_error_deltas(
+                    os.path.join(local_dir, "server_metrics_export.jsonl")
+                )
+            )
+
+            # Container restart count + reason during the rung window.
+            started = getattr(load, "started_at", None)
+            ended = getattr(load, "ended_at", None)
+            restarts, reasons = self._container_restarts(ns, dgd_name, started, ended)
+            row["container_restarts"] = restarts
+            row["restart_reasons"] = reasons
+
+            rows.append(row)
+
+        # Append a per-pod log-file-count summary. The dyn_tee.sh
+        # wrapper suffixes each container start's log with the start
+        # time (`<pod>_<ts>.log`), so the count of log files per pod
+        # equals the number of container starts. >1 file means the
+        # container restarted at least once.
+        log_summary = self._log_file_summary(ctx.log_dir)
+
+        screen = self._render(rows, "fancy_grid") + "\n\n" + log_summary
+        ctx.logger.info("\n" + screen)
+        if self.save_to_file:
+            out = os.path.join(ctx.log_dir, "error_tracking_report.md")
+            try:
+                os.makedirs(os.path.dirname(out), exist_ok=True)
+                with open(out, "w") as f:
+                    f.write(self._render(rows, "pipe") + "\n\n" + log_summary + "\n")
+                ctx.logger.info(f"ErrorTrackingReport written to {out}")
+            except OSError as e:
+                ctx.logger.warning(f"ErrorTrackingReport save failed: {e}")
+
+    @property
+    def description(self) -> str:
+        return (
+            "Per-rung errors: aiperf error count + vLLM preemption / NIXL "
+            "failure / KV-expired counters"
+        )
+
+    @staticmethod
+    def _aiperf_errors(path: str):
+        if not os.path.exists(path):
+            return 0, ""
+        try:
+            with open(path) as f:
+                d = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            return 0, ""
+        total = int((d.get("error_request_count") or {}).get("avg", 0))
+        # Compact summary: "<count> <type>" comma-joined
+        bits = []
+        for entry in d.get("error_summary") or []:
+            t = (entry.get("error_details") or {}).get("type", "?")
+            bits.append(f"{entry.get('count', 0)} {t}")
+        return total, ", ".join(bits)
+
+    @staticmethod
+    def _vllm_error_deltas(jsonl_path: str):
+        """Per-rung sum-across-pods delta of vLLM error counters.
+
+        Returns dict with keys:
+          preemptions, nixl_failed_xfers, nixl_kv_expired
+        """
+        out = {"preemptions": 0, "nixl_failed_xfers": 0, "nixl_kv_expired": 0}
+        if not os.path.exists(jsonl_path):
+            return out
+        counters = {
+            "vllm:num_preemptions_total": "preemptions",
+            "vllm:nixl_num_failed_transfers": "nixl_failed_xfers",
+            "vllm:nixl_num_kv_expired_reqs": "nixl_kv_expired",
+        }
+        first: dict[str, dict[str, float]] = {}
+        last: dict[str, dict[str, float]] = {}
+        try:
+            with open(jsonl_path) as f:
+                for line in f:
+                    rec = json.loads(line)
+                    ep = rec.get("endpoint_url", "")
+                    if "frontend" in ep:
+                        continue
+                    for k, _label in counters.items():
+                        for s in rec.get("metrics", {}).get(k, []):
+                            v = s.get("value")
+                            if v is None:
+                                continue
+                            first.setdefault(ep, {}).setdefault(k, float(v))
+                            last.setdefault(ep, {})[k] = float(v)
+        except (json.JSONDecodeError, OSError):
+            return out
+        for ep in last:
+            f_per = first.get(ep, {})
+            l_per = last.get(ep, {})
+            for k, label in counters.items():
+                delta = l_per.get(k, 0) - f_per.get(k, 0)
+                if delta > 0:
+                    out[label] += int(delta)
+        return out
+
+    @staticmethod
+    def _log_file_summary(log_dir: str) -> str:
+        """Walk the extracted service-logs tree and count log files per pod.
+
+        With the dyn_tee.sh wrapper writing one log file per container
+        start (`<pod-name>_<unix-ts>.log`), a pod that restarted has
+        more than one file. Returns a markdown bullet list.
+        """
+        if not os.path.isdir(log_dir):
+            return "_(no log dir found for restart-artifact summary)_"
+
+        # Each component subdir (frontend / vllmprefillworker /
+        # vllmdecodeworker) contains <pod>_<ts>.log. Strip the
+        # `_<digits>.log` suffix to group log files by pod name.
+        import re
+        from collections import defaultdict
+
+        TS_SUFFIX = re.compile(r"_(\d+)\.log$")
+        per_pod: dict[str, list[str]] = defaultdict(list)
+        for root, _dirs, files in os.walk(log_dir):
+            for fn in files:
+                m = TS_SUFFIX.search(fn)
+                if not m:
+                    continue
+                pod = TS_SUFFIX.sub("", fn)
+                per_pod[pod].append(fn)
+
+        restarted = [(p, len(fs)) for p, fs in per_pod.items() if len(fs) > 1]
+        lines = [
+            "### Container-restart log-file summary",
+            "",
+            f"Total pods with log files: {len(per_pod)}",
+            f"Pods with > 1 log file (= restarted): {len(restarted)}",
+        ]
+        if restarted:
+            lines.extend(
+                [
+                    "",
+                    "| pod | log files (= container starts) | restarts |",
+                    "|---|---:|---:|",
+                ]
+            )
+            for p, count in sorted(restarted):
+                lines.append(f"| {p} | {count} | {count - 1} |")
+        else:
+            lines.append("")
+            lines.append("_All containers ran to completion without restart._")
+        return "\n".join(lines)
+
+    def _container_restarts(self, ns, dgd_name, started, ended):
+        """Query Prometheus (kube-state-metrics) for restart count +
+        most-recent-terminated reasons during ``[started, ended]``.
+
+        Returns (count: int, reasons_summary: str).
+        """
+        if started is None or ended is None or not ns:
+            return 0, ""
+        import urllib.parse
+        import urllib.request
+
+        win_s = max(1, int((ended - started).total_seconds()))
+        end_ts = int(ended.timestamp())
+        selector = f'namespace="{ns}"'
+        if dgd_name:
+            selector += f',pod=~".*{dgd_name}.*"'
+
+        def _q(query):
+            url = f"{self.prometheus_url}/api/v1/query?" + urllib.parse.urlencode(
+                {"query": query, "time": end_ts}
+            )
+            try:
+                with urllib.request.urlopen(url, timeout=5) as r:
+                    return json.loads(r.read())
+            except Exception:
+                return {}
+
+        # Sum increase over the rung window across all matching pods.
+        d = _q(
+            f"sum(increase(kube_pod_container_status_restarts_total{{{selector}}}[{win_s}s]))"
+        )
+        try:
+            total = int(round(float(d["data"]["result"][0]["value"][1])))
+        except (KeyError, IndexError, ValueError, TypeError):
+            total = 0
+
+        if total == 0:
+            return 0, ""
+
+        # Group per-pod with reason. We use last_terminated_reason as the
+        # most informative signal — its label `reason` carries
+        # OOMKilled / Error / Completed / etc.
+        d = _q(f"kube_pod_container_status_last_terminated_reason{{{selector}}} == 1")
+        reasons = {}
+        for s in d.get("data", {}).get("result", []):
+            m = s["metric"]
+            pod = m.get("pod", "?")
+            reason = m.get("reason", "?")
+            reasons[pod] = reason
+
+        bits = sorted(f"{pod.rsplit('-', 1)[-1]}:{r}" for pod, r in reasons.items())
+        return total, ", ".join(bits)
+
+    @staticmethod
+    def _render(rows: list[dict], tablefmt: str) -> str:
+        from tabulate import tabulate
+
+        headers = [
+            "rung",
+            "aiperf_errors",
+            "aiperf_error_types",
+            "preemptions",
+            "nixl_failed_xfers",
+            "nixl_kv_expired",
+            "container_restarts",
+            "restart_reasons",
+        ]
+        table = []
+        for r in rows:
+            table.append(
+                [
+                    r.get("rung", "?"),
+                    r.get("aiperf_errors", 0),
+                    r.get("aiperf_error_types", ""),
+                    r.get("preemptions", 0),
+                    r.get("nixl_failed_xfers", 0),
+                    r.get("nixl_kv_expired", 0),
+                    r.get("container_restarts", 0),
+                    r.get("restart_reasons", ""),
+                ]
+            )
+        title = "### Error tracking — per-rung aiperf + vLLM error counters + container restarts"
+        return f"{title}\n\n{tabulate(table, headers=headers, tablefmt=tablefmt)}"

--- a/tests/fault_tolerance/deploy/reports.py
+++ b/tests/fault_tolerance/deploy/reports.py
@@ -12,6 +12,7 @@ Reports are run after all checks pass and can generate
 additional artifacts (HTML reports, metrics summaries, etc.)
 """
 
+import glob
 import json
 import os
 from abc import ABC, abstractmethod
@@ -20,6 +21,40 @@ from typing import TYPE_CHECKING, Any, Optional
 
 if TYPE_CHECKING:
     from tests.fault_tolerance.deploy.scenario import ScenarioContext
+
+
+def _resolve_load_dir(ctx, load_event) -> Optional[str]:
+    """Resolve the actual on-disk dir for a StartLoad event's artifacts.
+
+    Source order:
+      1. ``load_event._managed_load.local_output_dir`` — the live path the
+         load Job extractor wrote files to. Set during StartLoad.execute,
+         cleared at StopLoad teardown.
+      2. Glob ``<ctx.log_dir>/load/load-<name>-*`` (the
+         RFC-1123-compliant directory that the framework's load Job uses)
+         and return the newest match. Necessary because StopLoad clears
+         the ``_managed_load`` attribute by the time reports run.
+
+    Returns None if neither source resolves to an existing directory.
+    """
+    ml = getattr(load_event, "_managed_load", None)
+    if ml is not None:
+        local = getattr(ml, "local_output_dir", None)
+        if local and os.path.isdir(local):
+            return local
+    log_dir = getattr(ctx, "log_dir", None)
+    if not log_dir:
+        return None
+    name = getattr(load_event, "name", None) or "default"
+    # pytest parametrize ids like ``test_x[128-6000-5]`` embed ``[``/``]``
+    # in ``log_dir`` — glob.escape on the parent prevents them from
+    # being parsed as a character class.
+    pattern = os.path.join(glob.escape(log_dir), "load", f"load-{name}-*")
+    candidates = sorted(glob.glob(pattern), key=os.path.getmtime, reverse=True)
+    for c in candidates:
+        if os.path.isdir(c):
+            return c
+    return None
 
 
 # =============================================================================
@@ -93,14 +128,16 @@ class FaultToleranceReport(Report):
 
         # Most fault scenarios run a single load; if there are several, use
         # the first as the per-request source. (Per-load reports could be a
-        # future extension.) Fall back to the deterministic
-        # ``<log_dir>/load/`` path because StopLoad clears the
-        # ``_managed_load`` reference before reports run.
+        # future extension.) ``_resolve_load_dir`` handles the case where
+        # StopLoad has cleared the ``_managed_load`` reference by globbing
+        # for ``load-<name>-*`` subdirs.
         load = load_events[0]
-        ml = getattr(load, "_managed_load", None)
-        local_dir = (
-            getattr(ml, "local_output_dir", None) if ml else None
-        ) or os.path.join(ctx.log_dir, "load")
+        local_dir = _resolve_load_dir(ctx, load)
+        if local_dir is None:
+            ctx.logger.warning(
+                f"FaultToleranceReport: no load dir found for load {load.name!r}"
+            )
+            return
         jsonl_path = os.path.join(local_dir, "profile_export.jsonl")
         if not os.path.exists(jsonl_path):
             ctx.logger.warning(
@@ -382,10 +419,12 @@ class ErrorBreakdownReport(Report):
 
         sections: list[str] = []
         for load in load_events:
-            ml = getattr(load, "_managed_load", None)
-            local_dir = (
-                getattr(ml, "local_output_dir", None) if ml else None
-            ) or os.path.join(ctx.log_dir, "load")
+            local_dir = _resolve_load_dir(ctx, load)
+            if local_dir is None:
+                ctx.logger.warning(
+                    f"ErrorBreakdownReport: no load dir for {load.name!r}"
+                )
+                continue
             summary_path = os.path.join(local_dir, "profile_export_aiperf.json")
             if not os.path.exists(summary_path):
                 ctx.logger.warning(f"ErrorBreakdownReport: {summary_path} not found")
@@ -494,10 +533,12 @@ class PerWorkerLatencyReport(Report):
         sections_screen: list[str] = []
         sections_file: list[str] = []
         for load in load_events:
-            ml = getattr(load, "_managed_load", None)
-            local_dir = (
-                getattr(ml, "local_output_dir", None) if ml else None
-            ) or os.path.join(ctx.log_dir, "load")
+            local_dir = _resolve_load_dir(ctx, load)
+            if local_dir is None:
+                ctx.logger.warning(
+                    f"PerWorkerLatencyReport: no load dir for {load.name!r}"
+                )
+                continue
             jsonl = os.path.join(local_dir, "server_metrics_export.jsonl")
             if not os.path.exists(jsonl):
                 ctx.logger.warning(
@@ -882,10 +923,12 @@ class ErrorTrackingReport(Report):
 
         rows = []
         for load in load_events:
-            ml = getattr(load, "_managed_load", None)
-            local_dir = (
-                getattr(ml, "local_output_dir", None) if ml else None
-            ) or os.path.join(ctx.log_dir, "load")
+            local_dir = _resolve_load_dir(ctx, load)
+            if local_dir is None:
+                ctx.logger.warning(
+                    f"errors-per-rung: no load dir for {load.name!r}; skipping"
+                )
+                continue
             row = {"rung": load.name}
 
             # aiperf error count + breakdown

--- a/tests/fault_tolerance/deploy/scenario.py
+++ b/tests/fault_tolerance/deploy/scenario.py
@@ -1,0 +1,241 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Scenario framework for fault tolerance testing.
+
+Provides:
+- ScenarioContext: Runtime context holding deployment, events, checks, reports
+- run_scenario(): Main entry point for running test scenarios
+
+Usage:
+    await run_scenario(
+        request=request,
+        deployment_spec=DeploymentSpec("..."),
+        events=[StartLoad(...), Wait(...), StopLoad()],
+        checks=[ZeroErrors(), MinRequests(min_count=50)],
+    )
+"""
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Optional
+
+from tests.fault_tolerance.deploy.checks import Check
+from tests.fault_tolerance.deploy.events import Event, StartLoad
+from tests.fault_tolerance.deploy.reports import Report
+from tests.utils.managed_deployment import DeploymentSpec, ManagedDeployment
+
+if TYPE_CHECKING:
+    from tests.utils.resource_monitor import ResourceMonitorConfig, ResourceSnapshot
+
+# =============================================================================
+# ScenarioContext
+# =============================================================================
+
+
+@dataclass
+class ScenarioContext:
+    """Runtime context - holds deployment, events, checks, and reports.
+
+    No helper methods - callers iterate/filter events themselves.
+
+    Note: deployment may be None after context manager exits - only use events/reports
+    data for checks and report generation.
+    """
+
+    deployment: Optional[ManagedDeployment]
+    events: list[Event]
+    checks: list[Check]
+    reports: list[Report]
+    logger: logging.Logger
+    namespace: str
+    log_dir: str
+    resource_history: list["ResourceSnapshot"] = field(default_factory=list)
+
+
+# =============================================================================
+# run_scenario() - Main Entry Point
+# =============================================================================
+
+
+async def run_scenario(
+    deployment_spec: DeploymentSpec,
+    events: list[Event],
+    checks: list[Check],
+    namespace: str,
+    image: str | None = None,
+    test_name: str | None = None,
+    skip_service_restart: bool = True,
+    storage_class: str | None = None,
+    reports: list[Report] | None = None,
+    resource_config: Optional["ResourceMonitorConfig"] = None,
+) -> ScenarioContext:
+    """
+    Run a test scenario.
+
+    Args:
+        deployment_spec: What to deploy
+        events: Actions to execute in sequence
+        checks: Validations to run after events complete
+        namespace: Kubernetes namespace
+        image: Container image override (applied to all services)
+        test_name: Test name for logging and output directory
+        skip_service_restart: Skip restarting NATS/etcd
+        storage_class: Storage class for PVC log collection
+        reports: Optional report generators
+        resource_config: Optional resource monitoring configuration
+
+    Flow:
+    1. Setup deployment
+    2. Start resource monitoring (if configured)
+    3. Execute all events
+    4. Stop all events (collects results from unfinished loads)
+    5. Stop resource monitoring (collects metrics)
+    6. [Deployment cleanup happens here - context manager exits]
+    7. Generate reports (BEFORE checks, so failures don't block reports)
+    8. Run checks (assertions happen last)
+    """
+    log_dir = test_name or "scenario"
+    logger = logging.getLogger(test_name or "scenario")
+
+    reports = reports or []
+
+    # Log scenario overview
+    logger.info("=" * 60)
+    logger.info("SCENARIO OVERVIEW")
+    logger.info("=" * 60)
+    logger.info(f"Events ({len(events)}):")
+    for i, event in enumerate(events, 1):
+        logger.info(f"  {i}. {event.description}")
+    logger.info(f"Checks ({len(checks)}):")
+    for i, check in enumerate(checks, 1):
+        logger.info(f"  {i}. {check.description}")
+    if reports:
+        logger.info(f"Reports ({len(reports)}):")
+        for i, report in enumerate(reports, 1):
+            logger.info(f"  {i}. {report.description}")
+    if resource_config:
+        logger.info("Resource monitoring: ENABLED")
+    logger.info("=" * 60)
+
+    # Apply image override
+    if image:
+        deployment_spec.set_image(image)
+
+    # Enable logging
+    deployment_spec.set_logging(True, "info")
+
+    # Enable PVC-based log collection
+    log_collection_kwargs = {
+        "pvc_size": "500Mi",
+        "container_log_dir": "/tmp/service_logs",
+    }
+    if storage_class:
+        log_collection_kwargs["storage_class"] = storage_class
+    deployment_spec.enable_log_collection(**log_collection_kwargs)
+
+    # Create context (will be populated during deployment)
+    ctx = ScenarioContext(
+        deployment=None,
+        events=events,
+        checks=checks,
+        reports=reports,
+        logger=logger,
+        namespace=namespace,
+        log_dir=log_dir,
+        resource_history=[],
+    )
+
+    # Phase 1: Deployment and event execution
+    async with ManagedDeployment(
+        namespace=namespace,
+        log_dir=log_dir,
+        deployment_spec=deployment_spec,
+        skip_service_restart=skip_service_restart,
+    ) as deployment:
+        ctx.deployment = deployment
+
+        # Start resource monitoring if configured
+        monitor = None
+        if resource_config:
+            from tests.utils.resource_monitor import ResourceMonitor
+
+            monitor = ResourceMonitor(deployment, resource_config)
+            await monitor.start()
+
+        try:
+            # Execute all events
+            logger.info("=" * 60)
+            logger.info("EXECUTING EVENTS")
+            logger.info("=" * 60)
+            for i, event in enumerate(events, 1):
+                logger.info(f"Event {i}/{len(events)}: {event.description}")
+                await event.execute(ctx)
+                logger.info(f"Event {i} completed")
+
+            # Stop all events (collects results from unfinished loads)
+            logger.info("=" * 60)
+            logger.info("STOPPING EVENTS")
+            logger.info("=" * 60)
+            for event in reversed(events):
+                await event.stop(ctx)
+
+        finally:
+            # Emergency cleanup for events
+            for event in events:
+                try:
+                    await event.stop(ctx)
+                except Exception as e:
+                    logger.warning(f"Cleanup error for {event.description}: {e}")
+
+            # Stop resource monitoring before deployment cleanup
+            if monitor:
+                logger.info("Stopping resource monitoring...")
+                ctx.resource_history = await monitor.stop()
+                await monitor.save_history_locally(log_dir)
+
+        # Log results summary (while deployment still exists)
+        logger.info("=" * 60)
+        logger.info("RESULTS SUMMARY")
+        logger.info("=" * 60)
+        for event in events:
+            if isinstance(event, StartLoad) and event.results:
+                data = event.results
+                request_count = data.get("request_count", {}).get("avg", 0)
+                error_result = data.get("error_request_count")
+                error_count = error_result.get("avg", 0) if error_result else 0
+                throughput = data.get("request_throughput", {}).get("avg", 0)
+                logger.info(f"Load '{event.name}':")
+                logger.info(f"  Requests: {request_count}")
+                logger.info(f"  Errors: {error_count}")
+                logger.info(f"  Throughput: {throughput:.2f} req/s")
+
+    # Deployment context has exited - cleanup completed
+    ctx.deployment = None  # Mark that deployment is no longer active
+
+    # Phase 2: Reports and checks (AFTER deployment cleanup)
+    # Reports run first so check failures don't block report generation
+    if reports:
+        logger.info("=" * 60)
+        logger.info("GENERATING REPORTS")
+        logger.info("=" * 60)
+        for i, report in enumerate(reports, 1):
+            logger.info(f"Report {i}/{len(reports)}: {report.description}")
+            report.generate(ctx)
+            logger.info(f"Report {i} generated")
+
+    # Checks run last (may raise AssertionError)
+    logger.info("=" * 60)
+    logger.info("RUNNING CHECKS")
+    logger.info("=" * 60)
+    for i, check in enumerate(checks, 1):
+        logger.info(f"Check {i}/{len(checks)}: {check.description}")
+        check.validate(ctx)
+        logger.info(f"Check {i} PASSED")
+
+    logger.info("=" * 60)
+    logger.info("ALL CHECKS PASSED")
+    logger.info("=" * 60)
+
+    return ctx

--- a/tests/fault_tolerance/deploy/scenario.py
+++ b/tests/fault_tolerance/deploy/scenario.py
@@ -52,6 +52,10 @@ class ScenarioContext:
     namespace: str
     log_dir: str
     resource_history: list["ResourceSnapshot"] = field(default_factory=list)
+    # Snapshot of deployment-level metrics, captured before the deployment
+    # context exits so reports can still read them (they run after the
+    # deployment reference has been cleared).
+    startup_seconds: Optional[float] = None
 
 
 # =============================================================================
@@ -171,7 +175,10 @@ async def run_scenario(
             logger.info("=" * 60)
             for i, event in enumerate(events, 1):
                 logger.info(f"Event {i}/{len(events)}: {event.description}")
-                await event.execute(ctx)
+                # timed_execute wraps the subclass's execute() with
+                # started_at/ended_at timestamps so reports can bucket
+                # time-stamped data (e.g. aiperf records) by event boundary.
+                await event.timed_execute(ctx)
                 logger.info(f"Event {i} completed")
 
             # Stop all events (collects results from unfinished loads)
@@ -210,6 +217,10 @@ async def run_scenario(
                 logger.info(f"  Requests: {request_count}")
                 logger.info(f"  Errors: {error_count}")
                 logger.info(f"  Throughput: {throughput:.2f} req/s")
+
+    # Cache deployment-level data on ctx before clearing the reference,
+    # so reports (which run after __aexit__) can still see it.
+    ctx.startup_seconds = getattr(ctx.deployment, "startup_seconds", None)
 
     # Deployment context has exited - cleanup completed
     ctx.deployment = None  # Mark that deployment is no longer active

--- a/tests/fault_tolerance/deploy/scenario.py
+++ b/tests/fault_tolerance/deploy/scenario.py
@@ -72,6 +72,8 @@ async def run_scenario(
     test_name: str | None = None,
     skip_service_restart: bool = True,
     storage_class: str | None = None,
+    log_pvc: str | None = None,
+    model_pvc: str | None = None,
     reports: list[Report] | None = None,
     resource_config: Optional["ResourceMonitorConfig"] = None,
 ) -> ScenarioContext:
@@ -137,14 +139,24 @@ async def run_scenario(
     # Enable logging
     deployment_spec.set_logging(True, "info")
 
-    # Enable PVC-based log collection
+    # Enable PVC-based log collection. If --log-pvc was passed, use
+    # that name (the framework will skip create + delete, just install
+    # the wrapper ConfigMap and verify the PVC is bound).
     log_collection_kwargs = {
         "pvc_size": "500Mi",
         "container_log_dir": "/tmp/service_logs",
     }
     if storage_class:
         log_collection_kwargs["storage_class"] = storage_class
+    if log_pvc:
+        log_collection_kwargs["pvc_name"] = log_pvc
     deployment_spec.enable_log_collection(**log_collection_kwargs)
+
+    # If --model-pvc was passed, mount that PVC as the HF model cache
+    # on every worker. Avoids re-downloading large model weights
+    # between test runs.
+    if model_pvc:
+        deployment_spec.enable_model_cache(model_pvc)
 
     # Create context (will be populated during deployment)
     ctx = ScenarioContext(
@@ -164,6 +176,7 @@ async def run_scenario(
         log_dir=log_dir,
         deployment_spec=deployment_spec,
         skip_service_restart=skip_service_restart,
+        reuse_log_pvc=bool(log_pvc),
     ) as deployment:
         ctx.deployment = deployment
 

--- a/tests/fault_tolerance/deploy/scenario.py
+++ b/tests/fault_tolerance/deploy/scenario.py
@@ -100,7 +100,14 @@ async def run_scenario(
     7. Generate reports (BEFORE checks, so failures don't block reports)
     8. Run checks (assertions happen last)
     """
-    log_dir = test_name or "scenario"
+    # Resolve the test output dir ONCE so every component (ManagedDeployment,
+    # ManagedLoad, the FaultToleranceReport, the conftest test.log handler)
+    # writes to the same canonical location. Without this, ManagedLoad lands
+    # under cwd and ManagedDeployment under /tmp/dynamo_tests, which made
+    # logs hard to find.
+    from tests.utils.test_output import resolve_test_output_path
+
+    log_dir = resolve_test_output_path(test_name or "scenario")
     logger = logging.getLogger(test_name or "scenario")
 
     reports = reports or []

--- a/tests/fault_tolerance/deploy/scenario.py
+++ b/tests/fault_tolerance/deploy/scenario.py
@@ -35,6 +35,24 @@ if TYPE_CHECKING:
 
 
 @dataclass
+class RuntimeEnv:
+    """Bundle of CLI-driven runtime knobs forwarded into ``run_scenario``.
+
+    Lets a test declare just one ``runtime_env`` fixture instead of
+    seven individual ones. Forward to ``run_scenario`` via
+    ``run_scenario(..., runtime_env=runtime_env)``.
+    """
+
+    namespace: str
+    image: Optional[str] = None
+    skip_service_restart: bool = True
+    storage_class: Optional[str] = None
+    log_pvc: Optional[str] = None
+    model_pvc: Optional[str] = None
+    prefetch_model: bool = False
+
+
+@dataclass
 class ScenarioContext:
     """Runtime context - holds deployment, events, checks, and reports.
 
@@ -67,13 +85,18 @@ async def run_scenario(
     deployment_spec: DeploymentSpec,
     events: list[Event],
     checks: list[Check],
-    namespace: str,
-    image: str | None = None,
     test_name: str | None = None,
+    runtime_env: Optional[RuntimeEnv] = None,
+    # ----- legacy individual kwargs (kept for back-compat) -----
+    # Tests written before RuntimeEnv landed pass these directly.
+    # New tests should pass ``runtime_env=runtime_env`` instead.
+    namespace: str | None = None,
+    image: str | None = None,
     skip_service_restart: bool = True,
     storage_class: str | None = None,
     log_pvc: str | None = None,
     model_pvc: str | None = None,
+    prefetch_model: bool = False,
     reports: list[Report] | None = None,
     resource_config: Optional["ResourceMonitorConfig"] = None,
 ) -> ScenarioContext:
@@ -102,6 +125,22 @@ async def run_scenario(
     7. Generate reports (BEFORE checks, so failures don't block reports)
     8. Run checks (assertions happen last)
     """
+    # Collapse runtime_env (preferred) or individual kwargs (legacy) into
+    # one source of truth. RuntimeEnv values win when both are passed.
+    if runtime_env is not None:
+        namespace = runtime_env.namespace
+        image = runtime_env.image
+        skip_service_restart = runtime_env.skip_service_restart
+        storage_class = runtime_env.storage_class
+        log_pvc = runtime_env.log_pvc
+        model_pvc = runtime_env.model_pvc
+        prefetch_model = runtime_env.prefetch_model
+    if namespace is None:
+        raise ValueError(
+            "run_scenario: namespace required. Pass either "
+            "runtime_env=runtime_env (preferred) or namespace=...."
+        )
+
     # Resolve the test output dir ONCE so every component (ManagedDeployment,
     # ManagedLoad, the FaultToleranceReport, the conftest test.log handler)
     # writes to the same canonical location. Without this, ManagedLoad lands
@@ -177,6 +216,7 @@ async def run_scenario(
         deployment_spec=deployment_spec,
         skip_service_restart=skip_service_restart,
         reuse_log_pvc=bool(log_pvc),
+        model_pvc=model_pvc if prefetch_model else None,
     ) as deployment:
         ctx.deployment = deployment
 

--- a/tests/fault_tolerance/deploy/scenario.py
+++ b/tests/fault_tolerance/deploy/scenario.py
@@ -48,6 +48,7 @@ class RuntimeEnv:
     skip_service_restart: bool = True
     storage_class: Optional[str] = None
     log_pvc: Optional[str] = None
+    recreate_log_pvc: bool = False
     model_pvc: Optional[str] = None
     prefetch_model: bool = False
 
@@ -74,6 +75,19 @@ class ScenarioContext:
     # context exits so reports can still read them (they run after the
     # deployment reference has been cleared).
     startup_seconds: Optional[float] = None
+    # Per-pod restart count + last terminated reason, snapshotted just
+    # before deployment teardown. Checks that need to inspect kubelet
+    # restart state (e.g. RestartCountIncreased) read from here because
+    # ctx.deployment is None at validate() time.
+    # Shape: {service_name: {pod_name: {"restartCount": int, "lastReason": str|None}}}
+    pod_restart_state: dict = field(default_factory=dict)
+    # Per-service catted pod logs, snapshotted just before deployment
+    # teardown. Checks that call ``collect_service_logs()`` from
+    # ``validate()`` (WorkerPanics, ServiceLogPatternRate,
+    # ServiceLogContains, ServiceLogNotContains, EngineDeathDetected)
+    # read from here when ``ctx.deployment is None``.
+    # Shape: {service_name: str}  (one big concatenated string per service)
+    service_logs: dict = field(default_factory=dict)
 
 
 # =============================================================================
@@ -95,6 +109,7 @@ async def run_scenario(
     skip_service_restart: bool = True,
     storage_class: str | None = None,
     log_pvc: str | None = None,
+    recreate_log_pvc: bool = False,
     model_pvc: str | None = None,
     prefetch_model: bool = False,
     reports: list[Report] | None = None,
@@ -133,6 +148,7 @@ async def run_scenario(
         skip_service_restart = runtime_env.skip_service_restart
         storage_class = runtime_env.storage_class
         log_pvc = runtime_env.log_pvc
+        recreate_log_pvc = runtime_env.recreate_log_pvc
         model_pvc = runtime_env.model_pvc
         prefetch_model = runtime_env.prefetch_model
     if namespace is None:
@@ -178,9 +194,12 @@ async def run_scenario(
     # Enable logging
     deployment_spec.set_logging(True, "info")
 
-    # Enable PVC-based log collection. If --log-pvc was passed, use
-    # that name (the framework will skip create + delete, just install
-    # the wrapper ConfigMap and verify the PVC is bound).
+    # Enable PVC-based log collection. The framework now always reuses a
+    # single canonical log PVC per DGD (`<dgd-name>-logs`) — created once
+    # on first run, kept bound across runs, contents cleared in-place
+    # after each extraction. The `--log-pvc` flag is retained for
+    # back-compat but no longer changes behaviour beyond overriding the
+    # PVC name.
     log_collection_kwargs = {
         "pvc_size": "500Mi",
         "container_log_dir": "/tmp/service_logs",
@@ -216,6 +235,7 @@ async def run_scenario(
         deployment_spec=deployment_spec,
         skip_service_restart=skip_service_restart,
         reuse_log_pvc=bool(log_pvc),
+        recreate_log_pvc=bool(log_pvc) and bool(recreate_log_pvc),
         model_pvc=model_pvc if prefetch_model else None,
     ) as deployment:
         ctx.deployment = deployment
@@ -281,6 +301,45 @@ async def run_scenario(
     # Cache deployment-level data on ctx before clearing the reference,
     # so reports (which run after __aexit__) can still see it.
     ctx.startup_seconds = getattr(ctx.deployment, "startup_seconds", None)
+
+    # Snapshot per-pod restart counts so post-teardown checks (e.g.
+    # RestartCountIncreased) can validate without a live deployment.
+    try:
+        services_seen = set()
+        for ev in events:
+            for attr in ("services", "service"):
+                v = getattr(ev, attr, None)
+                if isinstance(v, str):
+                    services_seen.add(v)
+                elif isinstance(v, list):
+                    services_seen.update(s for s in v if isinstance(s, str))
+        for chk in checks:
+            v = getattr(chk, "services", None)
+            if isinstance(v, list):
+                services_seen.update(s for s in v if isinstance(s, str))
+        if services_seen:
+            pods_by_svc = ctx.deployment.get_pods(list(services_seen))
+            for svc, pods in pods_by_svc.items():
+                bucket = ctx.pod_restart_state.setdefault(svc, {})
+                for pod in pods:
+                    statuses = (pod.raw.get("status", {}) or {}).get(
+                        "containerStatuses"
+                    ) or []
+                    if not statuses:
+                        continue
+                    rc = int(statuses[0].get("restartCount", 0))
+                    reason = (
+                        (statuses[0].get("lastState") or {}).get("terminated") or {}
+                    ).get("reason")
+                    bucket[pod.name] = {"restartCount": rc, "lastReason": reason}
+    except Exception as e:
+        logger.warning(f"Could not snapshot pod restart state: {e}")
+
+    # Per-service catted pod logs are NOT snapshotted in-memory pre-teardown:
+    # ManagedDeployment doesn't expose a collect_service_logs() helper.
+    # Instead the deployment's PVC extractor writes per-pod log files
+    # to <log_dir>/<service>/<pod>_<ts>.log during teardown, and
+    # _get_service_logs(ctx) in checks.py reads those files at check time.
 
     # Deployment context has exited - cleanup completed
     ctx.deployment = None  # Mark that deployment is no longer active

--- a/tests/fault_tolerance/deploy/scenario.py
+++ b/tests/fault_tolerance/deploy/scenario.py
@@ -22,7 +22,11 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Optional
 
 from tests.fault_tolerance.deploy.checks import Check
-from tests.fault_tolerance.deploy.events import Event, StartLoad
+from tests.fault_tolerance.deploy.events import (
+    Event,
+    StartLoad,
+    synthesize_pod_memory_growth_tsv,
+)
 from tests.fault_tolerance.deploy.reports import Report
 from tests.utils.managed_deployment import DeploymentSpec, ManagedDeployment
 
@@ -343,6 +347,18 @@ async def run_scenario(
 
     # Deployment context has exited - cleanup completed
     ctx.deployment = None  # Mark that deployment is no longer active
+
+    # Retired PMP1 produced pod_memory_growth.tsv host-side; ResourcePoller now
+    # writes per-pod <role>/<pod>.resources.agg.tsv (extracted during teardown).
+    # Synthesize the legacy union file from them so the PodMemoryGrowth check +
+    # downstream tooling keep working. No-op if no resource TSVs were collected.
+    try:
+        if log_dir:
+            pmg = synthesize_pod_memory_growth_tsv(log_dir)
+            if pmg:
+                logger.info(f"Synthesized {pmg} from per-pod resource TSVs")
+    except Exception as e:
+        logger.warning(f"pod_memory_growth.tsv synthesis failed: {e}")
 
     # Phase 2: Reports and checks (AFTER deployment cleanup)
     # Reports run first so check failures don't block report generation

--- a/tests/fault_tolerance/deploy/scenario.py
+++ b/tests/fault_tolerance/deploy/scenario.py
@@ -22,11 +22,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Optional
 
 from tests.fault_tolerance.deploy.checks import Check
-from tests.fault_tolerance.deploy.events import (
-    Event,
-    StartLoad,
-    synthesize_pod_memory_growth_tsv,
-)
+from tests.fault_tolerance.deploy.events import Event, StartLoad
 from tests.fault_tolerance.deploy.reports import Report
 from tests.utils.managed_deployment import DeploymentSpec, ManagedDeployment
 
@@ -347,22 +343,6 @@ async def run_scenario(
 
     # Deployment context has exited - cleanup completed
     ctx.deployment = None  # Mark that deployment is no longer active
-
-    # Retired PMP1 produced pod_memory_growth.tsv host-side; ResourcePoller now
-    # writes per-pod <role>/<pod>.resources.agg.tsv (extracted during teardown).
-    # Synthesize the legacy union file from them so the PodMemoryGrowth check +
-    # downstream tooling keep working. No-op if no resource TSVs were collected.
-    try:
-        if log_dir:
-            pmg = synthesize_pod_memory_growth_tsv(log_dir)
-            if pmg:
-                with open(pmg) as _f:
-                    n_rows = max(0, sum(1 for _ in _f) - 1)  # minus header
-                logger.info(
-                    f"Synthesized {pmg} from per-pod resource TSVs ({n_rows} rows)"
-                )
-    except Exception as e:
-        logger.warning(f"pod_memory_growth.tsv synthesis failed: {e}")
 
     # Phase 2: Reports and checks (AFTER deployment cleanup)
     # Reports run first so check failures don't block report generation

--- a/tests/fault_tolerance/deploy/scenario.py
+++ b/tests/fault_tolerance/deploy/scenario.py
@@ -356,7 +356,11 @@ async def run_scenario(
         if log_dir:
             pmg = synthesize_pod_memory_growth_tsv(log_dir)
             if pmg:
-                logger.info(f"Synthesized {pmg} from per-pod resource TSVs")
+                with open(pmg) as _f:
+                    n_rows = max(0, sum(1 for _ in _f) - 1)  # minus header
+                logger.info(
+                    f"Synthesized {pmg} from per-pod resource TSVs ({n_rows} rows)"
+                )
     except Exception as e:
         logger.warning(f"pod_memory_growth.tsv synthesis failed: {e}")
 

--- a/tests/fault_tolerance/deploy/scenario_lib/INDEX.md
+++ b/tests/fault_tolerance/deploy/scenario_lib/INDEX.md
@@ -1,0 +1,107 @@
+# Scenarios
+
+YAML-driven test scenarios consumed by `test_router_modes.py` and (future)
+sibling test files. Each subdirectory == one test "kind"; the scenario
+YAML's `kind:` field must match the parent directory name.
+
+## Layout
+
+```
+scenario_lib/
+├── _schema.py           # dataclass schema for Scenario, Deployment, Router, etc.
+├── _loader.py           # strict YAML → Scenario loader
+├── _runtime.py          # bridge: auto-discovers Event/Report/Check subclasses,
+│                        # builds the scenario's event sequence + reports
+├── INDEX.md             # this file
+├── router_memory/       # consumed by test_router_memory
+├── endurance/           # consumed by test_endurance (long-running mocker)
+└── admission_control/   # (future) consumed by test_admission_control
+```
+
+## How it works (in one paragraph)
+
+A scenario YAML carries `deployment`, `router`, `admission`, `load`,
+`events`, `reports`, `checks`, and `expectations`. The runner loads the
+YAML, builds a DeploymentSpec from the templated DGD, applies router
+and admission knobs as env-vars on the right services, then either uses
+the explicit `events:` block or generates the default
+`WaitForModelReady → PodMemoryPoller → for-each-rung(StartLoad +
+WaitForLoadCompletion)` sequence. Event/Report/Check classes are
+auto-discovered by walking `Event.__subclasses__()` /
+`Report.__subclasses__()` / `Check.__subclasses__()` at import time —
+no hardcoded registry. Adding a new class anywhere in `events.py` /
+`reports.py` / `checks.py` makes it usable in YAML immediately as
+`kind: NewClassName`.
+
+## Adding a scenario
+
+1. Pick the kind (= which test function should run it). Put the YAML
+   under `scenario_lib/<kind>/<descriptive-filename>.yaml`.
+2. Name convention: `<router_mode>__<traffic_shape>__<topology>__<backend>.yaml`.
+   E.g. `kv_prefix_aware__partial_prefix__disagg__vllm.yaml`.
+3. Required top-level fields: `kind`, `name`, `deployment`, `router`,
+   either `load` (with `rungs:`) or explicit `events:`.
+4. Optional: `admission`, `reports`, `checks`, `expectations`.
+5. `pytest --collect-only` should now show the test ID. If not, the
+   loader raised a validation error — read the test output for the
+   line/field that didn't parse.
+
+## Adding a new kind (new test type)
+
+1. Create `scenario_lib/<new_kind>/` and add at least one YAML there.
+2. In `test_router_modes.py` (or a sibling test file), add:
+   ```python
+   _MY_SCENARIOS = discover_scenarios("<new_kind>")
+   @pytest.mark.parametrize("scenario_path", _MY_SCENARIOS, ids=[p.name for p in _MY_SCENARIOS])
+   async def test_my_kind(runtime_env, request, scenario_path):
+       await _run_yaml_scenario(scenario_path)
+   ```
+
+## Current scenarios
+
+### router_memory/
+
+Memory-leak characterization across router configurations and workload
+shapes. Anchored by the cycle-6 finding that
+`DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT > 0` flips a binary leak ~27 MB/min.
+
+| Scenario | Router | Shape | Expected slope (MB/min) |
+|---|---|---|---|
+| `kv_load_aware__partial_prefix__disagg__vllm.yaml` | KV-aware, no prefix scoring | partial_prefix (37% hit) | 1.5–4.5 (negative reference) |
+| `kv_prefix_aware__partial_prefix__disagg__vllm.yaml` | KV-aware + OVERLAP=1.0 | partial_prefix | 22–32 (positive — production-default leak) |
+| `least_loaded__partial_prefix__disagg__vllm.yaml` | LeastLoaded | partial_prefix | 1.5–3.5 (control: leak NOT in LL path) |
+| `kv_prefix_aware__no_prefix__disagg__vllm.yaml` | KV-aware + OVERLAP=1.0 | no_prefix (random) | 25–80 (S-N1: H1 lever) |
+| `kv_prefix_aware__same_prefix__disagg__vllm.yaml` | KV-aware + OVERLAP=1.0 | same_prefix (shared 2K-token system prompt) | 2–28 (S-N2: H1 lever) |
+
+### endurance/
+
+Long-running mocker-backed scenarios for surfacing slow drift (memory
+leak, queue backlog) that only shows up after hours. Uses the new
+`PeriodicSnapshot` event to drop timestamped artifact bundles into
+`<log_dir>/snapshots/t{minutes:04d}m_<iso>/` so analysis can proceed
+in-flight.
+
+| Scenario | Duration | Snapshot interval | Notes |
+|---|---|---|---|
+| `endurance_mocker_smoke.yaml` | ~30 min | 5 min | Validates the machinery; coffee-break smoke test |
+| `endurance_mocker_long.yaml`  | ~6 h    | 30 min | Production-default router knobs; checks leak slope vs router_memory expectation |
+
+To run a paired A/B (e.g. OVERLAP=1.0 vs =0.0), launch dynamo-ft twice
+in two namespaces with the two scenario filenames. No automatic
+pairing framework — manual two-namespace launch keeps the framework
+simple and resource accounting clear.
+
+Set `DYN_ENDURANCE_MAX_HOURS=N` to raise the snapshot ceiling (default 8h).
+
+## Hypothesis matrix (recap from observe's leak-rootcause handoff)
+
+| Hypothesis | What's leaking | Predicted scaling |
+|---|---|---|
+| **H1** — radix tree node retention | Block nodes in DashMap + Arc<RwLock<Block>> allocations | prefix uniqueness × ISL |
+| **H2** — SchedulingRequest retention | Per-request HashMap allocations | request count |
+| **H3** — per-worker tracking growth | Per-(worker × request) tracking entries | request × N workers |
+
+The pairing of `no_prefix` vs `same_prefix` vs `partial_prefix` on the
+SAME router config (`kv_prefix_aware`) discriminates H1. Future
+scenarios in `long_isl/` and `high_qps/` shapes will discriminate H2
+and worker-count lever for H3.

--- a/tests/fault_tolerance/deploy/scenario_lib/INDEX.md
+++ b/tests/fault_tolerance/deploy/scenario_lib/INDEX.md
@@ -25,7 +25,7 @@ A scenario YAML carries `deployment`, `router`, `admission`, `load`,
 YAML, builds a DeploymentSpec from the templated DGD, applies router
 and admission knobs as env-vars on the right services, then either uses
 the explicit `events:` block or generates the default
-`WaitForModelReady → PodMemoryPoller → for-each-rung(StartLoad +
+`WaitForModelReady → ResourcePoller → for-each-rung(StartLoad +
 WaitForLoadCompletion)` sequence. Event/Report/Check classes are
 auto-discovered by walking `Event.__subclasses__()` /
 `Report.__subclasses__()` / `Check.__subclasses__()` at import time —

--- a/tests/fault_tolerance/deploy/scenario_lib/__init__.py
+++ b/tests/fault_tolerance/deploy/scenario_lib/__init__.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# YAML-driven scenario library for router-mode / leak / admission tests.
+#
+# Each scenario YAML file describes a complete test cell:
+#   - deployment (backend, topology, units, image)
+#   - router (mode + DYN_ROUTER_* knobs)
+#   - admission (optional DYN_TCP_* / DYN_VLLM_REJECT_* knobs)
+#   - load (workload shape + rung sequence) OR events (full event sequence)
+#   - reports + checks
+#   - expectations (documentation, observed history)
+#
+# Scenarios live in subdirectories of this package, one per kind:
+#   scenario_lib/router_memory/    consumed by test_router_modes::test_router_memory
+#   scenario_lib/admission_control/  consumed by test_admission_control (future)
+#   scenario_lib/endurance/        consumed by test_endurance (future)
+#
+# The subdirectory name IS the kind. The loader validates each YAML's
+# top-level ``kind:`` field matches the parent directory — misplaced
+# files fail at pytest collection time.

--- a/tests/fault_tolerance/deploy/scenario_lib/_loader.py
+++ b/tests/fault_tolerance/deploy/scenario_lib/_loader.py
@@ -146,10 +146,12 @@ def _rung(d: dict, path: Path, idx: int) -> Rung:
         if f not in d:
             raise ValueError(f"{path}: {where}.{f} is required")
     shape = _shape(d["shape"], path, f"{where}.shape") if "shape" in d else None
+    rr = d.get("request_rate")
     return Rung(
         name=d["name"],
         concurrency=int(d["concurrency"]),
         duration_minutes=float(d["duration_minutes"]),
+        request_rate=float(rr) if rr is not None else None,
         shape=shape,
     )
 

--- a/tests/fault_tolerance/deploy/scenario_lib/_loader.py
+++ b/tests/fault_tolerance/deploy/scenario_lib/_loader.py
@@ -1,0 +1,233 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# YAML → Scenario dataclass loader. Strict: unknown keys at any nesting
+# level raise a ValueError so typos surface at pytest collection time.
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from ._schema import (
+    Admission,
+    CheckSpec,
+    Deployment,
+    EventSpec,
+    ExpectedRange,
+    Load,
+    LoadCommon,
+    ReportSpec,
+    Router,
+    Rung,
+    Scenario,
+    Shape,
+)
+
+SCENARIOS_DIR = Path(__file__).parent
+
+VALID_SHAPE_TYPES = {
+    "no_prefix",
+    "same_prefix",
+    "partial_prefix",
+    "long_isl",
+    "high_qps",
+    "custom",
+}
+
+
+# --------------------------------------------------------------------------- #
+# Public API
+# --------------------------------------------------------------------------- #
+
+
+def load_scenario(path: Path) -> Scenario:
+    """Load a scenario YAML and validate. Raises ValueError on bad input."""
+    text = path.read_text()
+    raw = yaml.safe_load(text)
+    if not isinstance(raw, dict):
+        raise ValueError(f"{path}: top-level YAML must be a mapping")
+    parent_kind = path.parent.name
+    if raw.get("kind") != parent_kind:
+        raise ValueError(
+            f"{path}: kind={raw.get('kind')!r} but lives under "
+            f"{parent_kind!r}/. Move the file, or fix the kind field."
+        )
+    s = _scenario_from_dict(raw, path)
+    s.path = str(path)
+    return s
+
+
+def discover_scenarios(kind: str) -> list[Path]:
+    """Return sorted list of scenario YAML paths for the given kind
+    (= subdirectory name). Returns empty list if the subdir doesn't
+    exist (so a kind that hasn't shipped its first scenario yet
+    collects zero tests instead of erroring)."""
+    subdir = SCENARIOS_DIR / kind
+    if not subdir.is_dir():
+        return []
+    return sorted(p for p in subdir.glob("*.yaml") if not p.name.startswith("_"))
+
+
+# --------------------------------------------------------------------------- #
+# Internal: strict dict → dataclass conversion
+# --------------------------------------------------------------------------- #
+
+
+def _scenario_from_dict(raw: dict, path: Path) -> Scenario:
+    return Scenario(
+        kind=_require_str(raw, "kind", path),
+        name=_require_str(raw, "name", path),
+        description=raw.get("description", ""),
+        labels=_as_str_dict(raw.get("labels", {}), path, "labels"),
+        deployment=_deployment(raw.get("deployment", {}), path),
+        router=_router(raw.get("router", {}), path),
+        admission=_admission(raw["admission"], path) if "admission" in raw else None,
+        load=_load(raw["load"], path) if "load" in raw else None,
+        events=[_event(e, path) for e in raw.get("events", [])],
+        reports=[_report(r, path) for r in raw.get("reports", [])],
+        checks=[_check(c, path) for c in raw.get("checks", [])],
+        expectations=_expectations(raw.get("expectations", {}), path),
+    )
+
+
+def _deployment(d: dict, path: Path) -> Deployment:
+    _reject_unknown(
+        d, {f.name for f in dataclasses.fields(Deployment)}, path, "deployment"
+    )
+    if "backend" not in d:
+        raise ValueError(f"{path}: deployment.backend is required")
+    return Deployment(**d)
+
+
+def _router(d: dict, path: Path) -> Router:
+    _reject_unknown(d, {f.name for f in dataclasses.fields(Router)}, path, "router")
+    knobs = _as_str_dict(d.get("knobs", {}), path, "router.knobs")
+    return Router(mode=d.get("mode", "kv"), knobs=knobs)
+
+
+def _admission(d: dict, path: Path) -> Admission:
+    _reject_unknown(
+        d, {f.name for f in dataclasses.fields(Admission)}, path, "admission"
+    )
+    knobs = _as_str_dict(d.get("knobs", {}), path, "admission.knobs")
+    return Admission(knobs=knobs)
+
+
+def _load(d: dict, path: Path) -> Load:
+    _reject_unknown(d, {f.name for f in dataclasses.fields(Load)}, path, "load")
+    if "shape" not in d:
+        raise ValueError(f"{path}: load.shape is required")
+    shape = _shape(d["shape"], path, "load.shape")
+    rungs = [_rung(r, path, i) for i, r in enumerate(d.get("rungs", []))]
+    common = _load_common(d.get("common", {}), path)
+    return Load(shape=shape, rungs=rungs, common=common)
+
+
+def _shape(d: dict, path: Path, where: str) -> Shape:
+    _reject_unknown(d, {f.name for f in dataclasses.fields(Shape)}, path, where)
+    if "type" not in d:
+        raise ValueError(f"{path}: {where}.type is required")
+    t = d["type"]
+    if t not in VALID_SHAPE_TYPES:
+        raise ValueError(
+            f"{path}: {where}.type={t!r} not in {sorted(VALID_SHAPE_TYPES)}"
+        )
+    return Shape(**d)
+
+
+def _rung(d: dict, path: Path, idx: int) -> Rung:
+    where = f"load.rungs[{idx}]"
+    _reject_unknown(d, {f.name for f in dataclasses.fields(Rung)}, path, where)
+    for f in ("name", "concurrency", "duration_minutes"):
+        if f not in d:
+            raise ValueError(f"{path}: {where}.{f} is required")
+    shape = _shape(d["shape"], path, f"{where}.shape") if "shape" in d else None
+    return Rung(
+        name=d["name"],
+        concurrency=int(d["concurrency"]),
+        duration_minutes=float(d["duration_minutes"]),
+        shape=shape,
+    )
+
+
+def _load_common(d: dict, path: Path) -> LoadCommon:
+    _reject_unknown(
+        d, {f.name for f in dataclasses.fields(LoadCommon)}, path, "load.common"
+    )
+    return LoadCommon(**d)
+
+
+def _event(d: dict, path: Path) -> EventSpec:
+    if not isinstance(d, dict) or "kind" not in d:
+        raise ValueError(f"{path}: each event must be a mapping with a 'kind' field")
+    return EventSpec(kind=d["kind"], params={k: v for k, v in d.items() if k != "kind"})
+
+
+def _report(d: dict, path: Path) -> ReportSpec:
+    if isinstance(d, str):
+        # Shorthand: just the kind name, no params.
+        return ReportSpec(kind=d, params={})
+    if not isinstance(d, dict) or "kind" not in d:
+        raise ValueError(
+            f"{path}: each report must be a kind string or {{kind, ...}} mapping"
+        )
+    return ReportSpec(
+        kind=d["kind"], params={k: v for k, v in d.items() if k != "kind"}
+    )
+
+
+def _check(d: dict, path: Path) -> CheckSpec:
+    if not isinstance(d, dict) or "kind" not in d:
+        raise ValueError(f"{path}: each check must be a mapping with a 'kind' field")
+    return CheckSpec(kind=d["kind"], params={k: v for k, v in d.items() if k != "kind"})
+
+
+def _expectations(d: dict, path: Path) -> dict[str, ExpectedRange]:
+    out: dict[str, ExpectedRange] = {}
+    for k, v in d.items():
+        if not isinstance(v, dict):
+            raise ValueError(f"{path}: expectations.{k} must be a mapping")
+        _reject_unknown(
+            v,
+            {f.name for f in dataclasses.fields(ExpectedRange)},
+            path,
+            f"expectations.{k}",
+        )
+        out[k] = ExpectedRange(**v)
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _require_str(d: dict, key: str, path: Path) -> str:
+    if key not in d or not isinstance(d[key], str):
+        raise ValueError(f"{path}: required string field {key!r} missing")
+    return d[key]
+
+
+def _as_str_dict(v: Any, path: Path, where: str) -> dict[str, str]:
+    if not isinstance(v, dict):
+        raise ValueError(f"{path}: {where} must be a mapping")
+    out: dict[str, str] = {}
+    for k, val in v.items():
+        if not isinstance(k, str):
+            raise ValueError(f"{path}: {where} keys must be strings, got {k!r}")
+        # Coerce non-string values to strings (YAML may parse "false" as bool, etc.)
+        out[k] = str(val)
+    return out
+
+
+def _reject_unknown(d: dict, allowed: set[str], path: Path, where: str) -> None:
+    unknown = set(d.keys()) - allowed
+    if unknown:
+        raise ValueError(
+            f"{path}: unknown fields in {where}: {sorted(unknown)}. "
+            f"Allowed: {sorted(allowed)}"
+        )

--- a/tests/fault_tolerance/deploy/scenario_lib/_runtime.py
+++ b/tests/fault_tolerance/deploy/scenario_lib/_runtime.py
@@ -193,6 +193,21 @@ def apply_deployment(spec, deployment) -> None:
         for name in all_names:
             spec[name].image = deployment.image
 
+    if deployment.memory_request:
+        for name in all_names:
+            spec[name].set_memory_request(deployment.memory_request)
+
+    if deployment.cpu_request:
+        for name in all_names:
+            spec[name].set_cpu_request(deployment.cpu_request)
+
+    if deployment.model:
+        # Worker services only — the Frontend has no ``--model`` arg (the
+        # setter is a no-op there). ``served_model`` is read from the worker
+        # spec right after this, so the load + router pick up the override.
+        for name in spec.worker_services():
+            spec[name].model = deployment.model
+
     if deployment.model_cache_pvc:
         spec.enable_model_cache(deployment.model_cache_pvc)
 
@@ -327,6 +342,10 @@ def build_load_config(
         "connection_reuse_strategy": common.connection_reuse_strategy,
         "warmup_requests": common.warmup_requests,
     }
+    # Open-loop: fixed arrival rate (aiperf --request-rate); concurrency stays
+    # as a max-in-flight cap. ManagedLoad already emits --request-rate.
+    if rung.request_rate is not None:
+        kwargs["request_rate"] = rung.request_rate
     if common.goodput is not None:
         kwargs["goodput"] = list(common.goodput)
     if common.request_cancellation_rate is not None:

--- a/tests/fault_tolerance/deploy/scenario_lib/_runtime.py
+++ b/tests/fault_tolerance/deploy/scenario_lib/_runtime.py
@@ -247,12 +247,38 @@ def apply_pull_secrets(spec, secrets: list[str] = None) -> None:
                 ips.append({"name": sec})
 
 
+# Transport-level env vars that must be consistent across FE + every worker.
+# Listed here so that ``apply_router`` propagates them to ALL services, not
+# just Frontend — otherwise the FE-only setting causes the EventPublisher on
+# each worker to silently fall back to the default transport (NATS), which
+# the FE (configured for ZMQ) then ignores → 0 kv_metrics events flow worker
+# → FE → busy-detection dies → routing layer's threshold-based exclusion
+# becomes a no-op. Add new transport-level envs here, not to a worker-only
+# block.
+_TRANSPORT_LEVEL_ENVS = frozenset(
+    {
+        "DYN_EVENT_PLANE",
+        "DYN_DISCOVERY_BACKEND",
+        "DYN_STORE_KV",
+    }
+)
+
+
 def apply_router(spec, router: Router) -> None:
-    """Apply DYN_ROUTER_MODE + DYN_ROUTER_* knobs to the Frontend."""
+    """Apply DYN_ROUTER_MODE + DYN_ROUTER_* knobs to the Frontend.
+
+    Transport-level envs (see ``_TRANSPORT_LEVEL_ENVS``) are additionally
+    propagated to every worker service so the event-plane is consistent
+    across the cluster.
+    """
     fe = spec["Frontend"]
     fe.set_env_var("DYN_ROUTER_MODE", router.mode)
     for key, value in router.knobs.items():
         fe.set_env_var(key, value)
+        # Transport-level envs must be on every service, not just FE.
+        if key in _TRANSPORT_LEVEL_ENVS:
+            for svc in spec.worker_services():
+                spec[svc].set_env_var(key, value)
 
 
 def apply_admission(spec, admission: Optional[Admission]) -> None:

--- a/tests/fault_tolerance/deploy/scenario_lib/_runtime.py
+++ b/tests/fault_tolerance/deploy/scenario_lib/_runtime.py
@@ -1,0 +1,446 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Bridge between scenario YAML (declarative) and the framework's
+# imperative Event / Report / Check / LoadConfig classes.
+#
+# Design principle: NO hardcoded registries.
+# Every Event / Report / Check class is a @dataclass and inherits from
+# its base (Event / Report / Check). At import time we walk the
+# subclasses transitively and build the kind → class map automatically.
+# A YAML's ``kind: ClassName`` directly instantiates ``ClassName(**params)``.
+# Adding a new event/report/check class anywhere in the framework
+# automatically makes it available in scenario YAML — no registry edit.
+#
+# The one exception is params that aren't YAML-natural (e.g.,
+# StartLoad.load_config is a LoadConfig object). Those go through
+# small per-class adapters declared in _PARAM_ADAPTERS.
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any, Callable, Optional
+
+# Import the framework modules so __subclasses__() walks see every class.
+# Order matters only for the side-effect of importing.
+from tests.fault_tolerance.deploy import checks as _checks_mod  # noqa: F401
+from tests.fault_tolerance.deploy import events as _events_mod  # noqa: F401
+from tests.fault_tolerance.deploy import reports as _reports_mod  # noqa: F401
+from tests.fault_tolerance.deploy.checks import Check
+from tests.fault_tolerance.deploy.events import Event, StartLoad
+from tests.fault_tolerance.deploy.reports import Report
+from tests.utils.managed_load import LoadConfig
+
+from ._schema import Admission, Router, Rung, Scenario, Shape
+
+# --------------------------------------------------------------------------- #
+# Auto-discovered class registries
+# --------------------------------------------------------------------------- #
+
+
+def _all_subclasses(cls) -> list[type]:
+    """Walk the subclass tree depth-first. Skips abstract bases
+    (those with abstract methods)."""
+    out: list[type] = []
+    seen: set[type] = set()
+    stack = list(cls.__subclasses__())
+    while stack:
+        sub = stack.pop(0)
+        if sub in seen:
+            continue
+        seen.add(sub)
+        # Skip the abstract base class itself
+        if not getattr(sub, "__abstractmethods__", None):
+            out.append(sub)
+        stack.extend(sub.__subclasses__())
+    return out
+
+
+def _build_registry(base: type) -> dict[str, type]:
+    """``__name__`` → class. Last-one-wins on name collisions; if you
+    have two classes with the same __name__ in different modules, you
+    have bigger problems."""
+    return {cls.__name__: cls for cls in _all_subclasses(base)}
+
+
+EVENT_REGISTRY = _build_registry(Event)
+REPORT_REGISTRY = _build_registry(Report)
+CHECK_REGISTRY = _build_registry(Check)
+
+
+# --------------------------------------------------------------------------- #
+# Param adapters: convert YAML-native types to non-YAML kwargs (LoadConfig, etc.)
+# --------------------------------------------------------------------------- #
+#
+# Per-class adapter: (params: dict, ctx: AdapterContext) → dict.
+# Called BEFORE cls(**params). Lets us turn a YAML ``load_ref: warmup``
+# into an actual LoadConfig built from the scenario's rung definition.
+
+
+class AdapterContext:
+    """What a param adapter is allowed to see — scenario context + the
+    model name from the deployment."""
+
+    def __init__(self, scenario: Scenario, served_model: str):
+        self.scenario = scenario
+        self.served_model = served_model
+        self.rungs_by_name: dict[str, Rung] = (
+            {r.name: r for r in scenario.load.rungs}
+            if scenario.load and scenario.load.rungs
+            else {}
+        )
+
+
+def _start_load_adapter(params: dict, ctx: AdapterContext) -> dict:
+    """Resolve a ``load_ref: <rung_name>`` into a concrete LoadConfig
+    built from the named rung's shape + common settings."""
+    params = dict(params)
+    if "load_ref" in params:
+        rung_name = params.pop("load_ref")
+        rung = ctx.rungs_by_name.get(rung_name)
+        if rung is None:
+            raise ValueError(
+                f"{ctx.scenario.path}: StartLoad load_ref={rung_name!r} but "
+                f"no matching rung in load.rungs"
+            )
+        if ctx.scenario.load is None:
+            raise ValueError(
+                f"{ctx.scenario.path}: StartLoad load_ref needs scenario.load"
+            )
+        params["load_config"] = build_load_config(
+            rung,
+            ctx.scenario.load.shape,
+            ctx.scenario.load.common,
+            ctx.served_model,
+        )
+        params.setdefault("name", rung_name)
+    return params
+
+
+# kind → adapter callable. Keys are class __name__.
+_PARAM_ADAPTERS: dict[str, Callable[[dict, AdapterContext], dict]] = {
+    "StartLoad": _start_load_adapter,
+}
+
+
+# --------------------------------------------------------------------------- #
+# Generic kind → instance
+# --------------------------------------------------------------------------- #
+
+
+def _instantiate(
+    kind: str,
+    params: dict,
+    registry: dict[str, type],
+    ctx: Optional[AdapterContext] = None,
+    *,
+    scenario_path: str,
+    bucket_name: str,
+):
+    cls = registry.get(kind)
+    if cls is None:
+        raise ValueError(
+            f"{scenario_path}: unknown {bucket_name} kind {kind!r}. "
+            f"Known: {sorted(registry)}"
+        )
+    adapter = _PARAM_ADAPTERS.get(kind)
+    effective_params = adapter(params, ctx) if adapter and ctx else dict(params)
+    try:
+        return cls(**effective_params)
+    except TypeError as e:
+        # Show the field set the class actually accepts to help users
+        # diagnose "unknown kwarg" errors quickly.
+        if dataclasses.is_dataclass(cls):
+            allowed = sorted(f.name for f in dataclasses.fields(cls))
+            raise TypeError(
+                f"{scenario_path}: {bucket_name} {kind} rejected kwargs "
+                f"{sorted(effective_params)}. Allowed: {allowed}. ({e})"
+            )
+        raise
+
+
+# --------------------------------------------------------------------------- #
+# Public API used by test_router_modes.py
+# --------------------------------------------------------------------------- #
+
+
+def apply_deployment(spec, deployment) -> None:
+    """Apply deployment overrides (image, units OR explicit replicas,
+    model_cache, log_pvc).
+
+    Backend-agnostic: iterates ``spec.worker_services()`` instead of
+    hard-coding vllm service names, so mocker / trtllm / sglang scenarios
+    work via the same path.
+
+    Replica resolution order per service:
+      1. ``deployment.replicas[<service_name>]`` if set — exact value wins
+      2. Otherwise: ``template_base_replicas * deployment.units``
+
+    Mixing modes is allowed: set replicas for some services, fall back
+    to units * base for others.
+    """
+    worker_names = spec.worker_services()
+    all_names = ["Frontend"] + worker_names
+    overrides = deployment.replicas or {}
+
+    for name in all_names:
+        if name in overrides:
+            spec[name].replicas = int(overrides[name])
+        else:
+            spec[name].replicas = spec[name].replicas * deployment.units
+
+    if deployment.image:
+        for name in all_names:
+            spec[name].image = deployment.image
+
+    if deployment.model_cache_pvc:
+        spec.enable_model_cache(deployment.model_cache_pvc)
+
+
+def apply_mocker_planner_profile_fixup(spec) -> None:
+    """The bundled mocker DGD templates (examples/backends/mocker/deploy/
+    {agg,disagg}.yaml) hard-code ``--planner-profile-data <path>`` to a
+    profiler-style results directory. mocker tries to convert that
+    directory to NPZ via ``dynamo.planner.core`` which imports
+    ``pmdarima`` — not installed in the runtime images.
+
+    Mocker's ``resolve_planner_profile_data`` accepts None and returns
+    early (``npz_path=None``), causing mocker to fall back to default
+    response timing — fine for memory-leak investigation where exact
+    prefill latency isn't measured.
+
+    Cleanest fix: STRIP ``--planner-profile-data`` + its value from
+    every worker service's args list. No-op for non-mocker backends
+    (other backends don't carry this flag).
+    """
+    for svc in spec.worker_services():
+        spec_svc = spec[svc]._spec
+        main = spec_svc.get("extraPodSpec", {}).get("mainContainer", {})
+        args = main.get("args")
+        if not args or "--planner-profile-data" not in args:
+            continue
+        # Remove flag + value pair
+        idx = args.index("--planner-profile-data")
+        # value follows; if missing or starts with '-' (next flag), only strip the flag
+        if idx + 1 < len(args) and not args[idx + 1].startswith("-"):
+            del args[idx : idx + 2]
+        else:
+            del args[idx]
+
+
+def apply_pull_secrets(spec, secrets: list[str] = None) -> None:
+    """Add image pull secret(s) to every service. Necessary on shared
+    clusters (aws-dev-02, aks-dev) where private nvcr.io/nvidian/*
+    images require the org's `ngc-pull-secret` and the default SA's
+    secret list gets reset by a controller (so per-pod is the
+    reliable place to declare).
+
+    Idempotent: skips secrets already present on the service.
+    """
+    if secrets is None:
+        secrets = ["ngc-pull-secret"]
+    for name in ["Frontend"] + spec.worker_services():
+        eps = spec[name]._spec.setdefault("extraPodSpec", {})
+        ips = eps.setdefault("imagePullSecrets", [])
+        for sec in secrets:
+            if not any(s.get("name") == sec for s in ips):
+                ips.append({"name": sec})
+
+
+def apply_router(spec, router: Router) -> None:
+    """Apply DYN_ROUTER_MODE + DYN_ROUTER_* knobs to the Frontend."""
+    fe = spec["Frontend"]
+    fe.set_env_var("DYN_ROUTER_MODE", router.mode)
+    for key, value in router.knobs.items():
+        fe.set_env_var(key, value)
+
+
+def apply_admission(spec, admission: Optional[Admission]) -> None:
+    """Apply admission-control knobs to every worker service.
+    No-op if None or empty."""
+    if admission is None or not admission.knobs:
+        return
+    for svc in spec.worker_services():
+        for key, value in admission.knobs.items():
+            spec[svc].set_env_var(key, value)
+
+
+# --------------------------------------------------------------------------- #
+# Workload-shape → LoadConfig
+# --------------------------------------------------------------------------- #
+
+# Production-shaped traffic distribution (ISL/OSL pairs with realistic
+# long-tail mix). Same as the n3 routing-threshold + memory-stability default.
+_PROD_SEQ_DIST = "100,200:5;500,200:15;1000,200:20;1600,200:30;3400,200:20;7000,200:10"
+
+
+def build_load_config(
+    rung: Rung,
+    shape: Shape,
+    common,
+    served_model: str,
+) -> LoadConfig:
+    """Translate (rung, shape, common) → LoadConfig.
+
+    Shape semantics:
+      - no_prefix       — no prefix knobs → AIPerf random prompts (~0% block hit)
+      - same_prefix     — shared_system_prompt_length → ~100% prefix share
+      - partial_prefix  — pool of num_prefix_prompts × prefix_prompt_length
+      - long_isl        — large input_tokens_mean
+      - high_qps        — short input/output, high lifecycle turnover
+      - custom          — pass through what the YAML sets
+    """
+    kwargs: dict[str, Any] = {
+        "model_name": served_model,
+        "tokenizer": served_model,
+        "concurrency": rung.concurrency,
+        "duration_minutes": rung.duration_minutes,
+        "request_timeout_seconds": common.request_timeout_seconds,
+        "streaming": common.streaming,
+        "ignore_eos": common.ignore_eos,
+        "connection_reuse_strategy": common.connection_reuse_strategy,
+        "warmup_requests": common.warmup_requests,
+    }
+    if common.goodput is not None:
+        kwargs["goodput"] = list(common.goodput)
+    if common.request_cancellation_rate is not None:
+        kwargs["request_cancellation_rate"] = common.request_cancellation_rate
+    if common.aiperf_ref is not None:
+        kwargs["aiperf_ref"] = common.aiperf_ref
+
+    s = rung.shape or shape
+
+    if s.type == "no_prefix":
+        kwargs["seq_dist"] = s.seq_dist or _PROD_SEQ_DIST
+
+    elif s.type == "same_prefix":
+        kwargs["shared_system_prompt_length"] = s.shared_system_prompt_length or 2000
+        kwargs["seq_dist"] = s.seq_dist or _PROD_SEQ_DIST
+
+    elif s.type == "partial_prefix":
+        kwargs["num_prefix_prompts"] = s.num_prefix_prompts or 15
+        kwargs["prefix_prompt_length"] = s.prefix_prompt_length or 600
+        kwargs["seq_dist"] = s.seq_dist or _PROD_SEQ_DIST
+
+    elif s.type == "long_isl":
+        if s.seq_dist:
+            kwargs["seq_dist"] = s.seq_dist
+        else:
+            mean = s.input_tokens_mean or 80000
+            kwargs["input_tokens_mean"] = mean
+            kwargs["input_tokens_stddev"] = s.input_tokens_stddev or max(1, mean // 10)
+            kwargs["output_tokens_mean"] = s.output_tokens_mean or 200
+            kwargs["output_tokens_stddev"] = s.output_tokens_stddev or 20
+
+    elif s.type == "high_qps":
+        kwargs["input_tokens_mean"] = s.input_tokens_mean or 256
+        kwargs["input_tokens_stddev"] = s.input_tokens_stddev or 32
+        kwargs["output_tokens_mean"] = s.output_tokens_mean or 64
+        kwargs["output_tokens_stddev"] = s.output_tokens_stddev or 8
+
+    elif s.type == "custom":
+        if s.seq_dist:
+            kwargs["seq_dist"] = s.seq_dist
+        for attr in (
+            "num_prefix_prompts",
+            "prefix_prompt_length",
+            "shared_system_prompt_length",
+            "input_tokens_mean",
+            "input_tokens_stddev",
+            "output_tokens_mean",
+            "output_tokens_stddev",
+        ):
+            v = getattr(s, attr)
+            if v is not None:
+                kwargs[attr] = v
+
+    return LoadConfig(**kwargs)
+
+
+# --------------------------------------------------------------------------- #
+# Event / Report / Check materialisation
+# --------------------------------------------------------------------------- #
+
+
+def build_scenario_events(scenario: Scenario, served_model: str) -> list[Event]:
+    """Materialise the scenario's event sequence.
+
+    If scenario.events is non-empty, instantiate each via the auto
+    EVENT_REGISTRY (with StartLoad load_ref resolution).
+
+    Otherwise generate the canonical sequence from scenario.load.rungs:
+      1. WaitForModelReady(timeout=2400)
+      2. PodMemoryPoller(services=[Frontend, VllmPrefillWorker, VllmDecodeWorker], interval_s=10)
+      3. For each rung: StartLoad + WaitForLoadCompletion
+    """
+    if scenario.events:
+        ctx = AdapterContext(scenario, served_model)
+        return [
+            _instantiate(
+                e.kind,
+                e.params,
+                EVENT_REGISTRY,
+                ctx,
+                scenario_path=scenario.path or "<unknown>",
+                bucket_name="event",
+            )
+            for e in scenario.events
+        ]
+    return _generate_default_events(scenario, served_model)
+
+
+def _generate_default_events(scenario: Scenario, served_model: str) -> list[Event]:
+    if scenario.load is None or not scenario.load.rungs:
+        raise ValueError(
+            f"{scenario.path}: scenario has no events: and no load.rungs — "
+            f"nothing to run"
+        )
+    # Use the registry to construct so dataclass field-validation runs.
+    WaitForModelReady = EVENT_REGISTRY["WaitForModelReady"]
+    PodMemoryPoller = EVENT_REGISTRY["PodMemoryPoller"]
+    WaitForLoadCompletion = EVENT_REGISTRY["WaitForLoadCompletion"]
+
+    events: list[Event] = [
+        WaitForModelReady(timeout=2400),
+        PodMemoryPoller(
+            services=["Frontend", "VllmPrefillWorker", "VllmDecodeWorker"],
+            interval_s=10,
+        ),
+    ]
+    for rung in scenario.load.rungs:
+        load_config = build_load_config(
+            rung, scenario.load.shape, scenario.load.common, served_model
+        )
+        events.append(StartLoad(load_config=load_config, name=rung.name))
+        events.append(WaitForLoadCompletion(name=rung.name))
+    return events
+
+
+def build_reports(scenario: Scenario) -> list:
+    """Instantiate the scenario's reports via REPORT_REGISTRY."""
+    return [
+        _instantiate(
+            r.kind,
+            r.params,
+            REPORT_REGISTRY,
+            None,
+            scenario_path=scenario.path or "<unknown>",
+            bucket_name="report",
+        )
+        for r in scenario.reports
+    ]
+
+
+def build_checks(scenario: Scenario) -> list:
+    """Instantiate the scenario's checks via CHECK_REGISTRY."""
+    return [
+        _instantiate(
+            c.kind,
+            c.params,
+            CHECK_REGISTRY,
+            None,
+            scenario_path=scenario.path or "<unknown>",
+            bucket_name="check",
+        )
+        for c in scenario.checks
+    ]

--- a/tests/fault_tolerance/deploy/scenario_lib/_runtime.py
+++ b/tests/fault_tolerance/deploy/scenario_lib/_runtime.py
@@ -64,11 +64,6 @@ def _build_registry(base: type) -> dict[str, type]:
 
 
 EVENT_REGISTRY = _build_registry(Event)
-# Retired pollers: PodMemoryPoller / PodMemoryPoller2 are now aliases of
-# ResourcePoller (events.py). Map the old ``kind:`` strings so existing scenario
-# YAMLs need no edits (field signatures are identical: services + interval_s).
-EVENT_REGISTRY["PodMemoryPoller"] = EVENT_REGISTRY["ResourcePoller"]
-EVENT_REGISTRY["PodMemoryPoller2"] = EVENT_REGISTRY["ResourcePoller"]
 REPORT_REGISTRY = _build_registry(Report)
 CHECK_REGISTRY = _build_registry(Check)
 
@@ -425,7 +420,7 @@ def build_scenario_events(scenario: Scenario, served_model: str) -> list[Event]:
 
     Otherwise generate the canonical sequence from scenario.load.rungs:
       1. WaitForModelReady(timeout=2400)
-      2. PodMemoryPoller(services=[Frontend, VllmPrefillWorker, VllmDecodeWorker], interval_s=10)
+      2. ResourcePoller(services=[Frontend, VllmPrefillWorker, VllmDecodeWorker], interval_s=10)
       3. For each rung: StartLoad + WaitForLoadCompletion
     """
     if scenario.events:
@@ -452,12 +447,12 @@ def _generate_default_events(scenario: Scenario, served_model: str) -> list[Even
         )
     # Use the registry to construct so dataclass field-validation runs.
     WaitForModelReady = EVENT_REGISTRY["WaitForModelReady"]
-    PodMemoryPoller = EVENT_REGISTRY["PodMemoryPoller"]
+    ResourcePoller = EVENT_REGISTRY["ResourcePoller"]
     WaitForLoadCompletion = EVENT_REGISTRY["WaitForLoadCompletion"]
 
     events: list[Event] = [
         WaitForModelReady(timeout=2400),
-        PodMemoryPoller(
+        ResourcePoller(
             services=["Frontend", "VllmPrefillWorker", "VllmDecodeWorker"],
             interval_s=10,
         ),

--- a/tests/fault_tolerance/deploy/scenario_lib/_runtime.py
+++ b/tests/fault_tolerance/deploy/scenario_lib/_runtime.py
@@ -336,6 +336,11 @@ def build_load_config(
 
     s = rung.shape or shape
 
+    # aiperf RNG seed override (per-rung). None => LoadConfig keeps the
+    # historical default (100), so existing scenarios are byte-identical.
+    if s.random_seed is not None:
+        kwargs["random_seed"] = s.random_seed
+
     if s.type == "no_prefix":
         kwargs["seq_dist"] = s.seq_dist or _PROD_SEQ_DIST
 

--- a/tests/fault_tolerance/deploy/scenario_lib/_runtime.py
+++ b/tests/fault_tolerance/deploy/scenario_lib/_runtime.py
@@ -64,6 +64,11 @@ def _build_registry(base: type) -> dict[str, type]:
 
 
 EVENT_REGISTRY = _build_registry(Event)
+# Retired pollers: PodMemoryPoller / PodMemoryPoller2 are now aliases of
+# ResourcePoller (events.py). Map the old ``kind:`` strings so existing scenario
+# YAMLs need no edits (field signatures are identical: services + interval_s).
+EVENT_REGISTRY["PodMemoryPoller"] = EVENT_REGISTRY["ResourcePoller"]
+EVENT_REGISTRY["PodMemoryPoller2"] = EVENT_REGISTRY["ResourcePoller"]
 REPORT_REGISTRY = _build_registry(Report)
 CHECK_REGISTRY = _build_registry(Check)
 

--- a/tests/fault_tolerance/deploy/scenario_lib/_schema.py
+++ b/tests/fault_tolerance/deploy/scenario_lib/_schema.py
@@ -1,0 +1,195 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Dataclass schema for scenario YAML files. Kept independent of pydantic
+# (no extra deps) — validation lives in _loader.py.
+#
+# Schema is intentionally minimal: every field a scenario can express
+# maps to one dataclass field. The loader is strict — unknown YAML keys
+# fail to parse so typos surface at collection time.
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+
+@dataclass
+class Deployment:
+    """Where + how the deployment lands on k8s."""
+
+    backend: str  # vllm | mocker | trtllm | sglang
+    topology: str = "disagg"  # disagg | agg
+    units: int = 2  # prod-unit replica multiplier
+    image: Optional[str] = None  # full image tag; None → backend default
+    template: Optional[str] = None  # DGD template basename (without .yaml)
+    storage_class: Optional[str] = None  # falls back to cluster default
+    # Per-service replica overrides. Maps service-name → replica count.
+    # When set, these EXACT counts are used (units is ignored for those
+    # services). Useful for asymmetric topologies like ``{Frontend: 2,
+    # decode: 4}`` where the FE-to-worker ratio is part of the test.
+    replicas: Optional[dict[str, int]] = None
+    # PVC reuse knobs — None = framework default, "" = disable
+    model_cache_pvc: Optional[str] = None
+    log_pvc: Optional[str] = None
+
+
+@dataclass
+class Router:
+    """FE-side router configuration. ``mode`` sets DYN_ROUTER_MODE;
+    ``knobs`` is a key→value dict applied to the Frontend service env
+    (each entry becomes one set_env_var call on spec["Frontend"])."""
+
+    mode: str = "kv"  # DYN_ROUTER_MODE value
+    knobs: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class Admission:
+    """Admission-control knobs — applied to worker services
+    (VllmPrefillWorker + VllmDecodeWorker). Same shape as Router.knobs;
+    typical keys: DYN_TCP_WORKER_POOL_SIZE, DYN_TCP_WORK_QUEUE_SIZE,
+    DYN_VLLM_REJECT_QUEUE_THRESHOLD."""
+
+    knobs: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class Shape:
+    """Workload shape (prefix-sharing pattern, ISL distribution). ``type``
+    selects the canonical shape; the remaining fields are knobs
+    overridable per-scenario. The loader validates which fields are
+    meaningful per type."""
+
+    type: str  # no_prefix | same_prefix | partial_prefix | long_isl | high_qps | custom
+    # Prefix-cache shaping (mutually exclusive groups)
+    num_prefix_prompts: Optional[int] = None
+    prefix_prompt_length: Optional[int] = None
+    shared_system_prompt_length: Optional[int] = None
+    # ISL/OSL distribution (either seq_dist OR mean+stddev)
+    seq_dist: Optional[str] = None
+    input_tokens_mean: Optional[int] = None
+    input_tokens_stddev: Optional[int] = None
+    output_tokens_mean: Optional[int] = None
+    output_tokens_stddev: Optional[int] = None
+
+
+@dataclass
+class LoadCommon:
+    """Common LoadConfig fields applied to every rung unless the rung
+    overrides them."""
+
+    request_timeout_seconds: float = 30.0
+    streaming: bool = True
+    ignore_eos: bool = True
+    connection_reuse_strategy: str = "never"
+    warmup_requests: int = 0
+    # Optional per-LoadConfig knobs that show up in the cliff/admission
+    # scenarios — kept here so the schema covers them.
+    request_cancellation_rate: Optional[float] = None
+    goodput: Optional[list[str]] = None
+    # aiperf install spec — pip-install target inside the load Job pod.
+    # None → LoadConfig.aiperf_ref default (pinned working commit). Set
+    # per-scenario to test newer / older revisions without rebuilding
+    # any image. Format: "aiperf @ git+https://...@<commit-or-branch>".
+    aiperf_ref: Optional[str] = None
+
+
+@dataclass
+class Rung:
+    """One AIPerf job within the scenario's rung sequence."""
+
+    name: str
+    concurrency: int
+    duration_minutes: float
+    # Optional per-rung shape override. If None, the scenario's
+    # top-level shape applies.
+    shape: Optional[Shape] = None
+
+
+@dataclass
+class Load:
+    """Workload definition. Either:
+    - rungs: list of (name, concurrency, duration) — the runner
+      generates StartLoad/WaitForLoadCompletion event pairs in order
+    - OR an explicit events: list (set on Scenario) that drives the
+      sequence manually. If both are set, events: wins.
+    """
+
+    shape: Shape
+    rungs: list[Rung] = field(default_factory=list)
+    common: LoadCommon = field(default_factory=LoadCommon)
+
+
+@dataclass
+class EventSpec:
+    """Reference to a framework Event class (by name) + its kwargs.
+
+    ``kind`` matches a key in the event registry (see _events.py:
+    EVENT_REGISTRY). ``params`` is passed to the Event's constructor
+    as kwargs. Special-case: a StartLoad whose params contains
+    ``load_ref: <rung_name>`` is materialised against the matching
+    rung from the scenario's load.rungs list.
+    """
+
+    kind: str
+    params: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ReportSpec:
+    """Reference to a framework Report class + kwargs (see
+    _reports.py: REPORT_REGISTRY). Same shape as EventSpec."""
+
+    kind: str
+    params: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class CheckSpec:
+    """Reference to a framework Check class + kwargs (see _checks.py:
+    CHECK_REGISTRY). Each check produces a pass/fail row in the
+    scenario report."""
+
+    kind: str
+    params: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ExpectedRange:
+    """Documentation for an expected outcome. Not asserted by default;
+    the test framework can opt-in to range-checking via a per-kind
+    convention (see test_router_modes for the slope-vs-history check)."""
+
+    expected_range: Optional[list[float]] = None  # [low, high]
+    observed_history: list[dict[str, Any]] = field(default_factory=list)
+    notes: Optional[str] = None
+
+
+@dataclass
+class Scenario:
+    """Top-level scenario object. ``kind`` must match the parent
+    directory name (validated by the loader)."""
+
+    kind: str  # router_memory | admission_control | endurance | ad_hoc
+    name: str
+    description: str = ""
+    labels: dict[str, str] = field(default_factory=dict)
+
+    deployment: Deployment = field(default_factory=lambda: Deployment(backend="vllm"))
+    router: Router = field(default_factory=Router)
+    admission: Optional[Admission] = None
+    load: Optional[Load] = None
+
+    # Optional explicit events sequence. If empty AND load is set, the
+    # runner generates a default sequence from load.rungs.
+    events: list[EventSpec] = field(default_factory=list)
+
+    reports: list[ReportSpec] = field(default_factory=list)
+    checks: list[CheckSpec] = field(default_factory=list)
+
+    # Documentation. Keys are metric names (e.g. "fe_memory_growth_mb_per_min").
+    expectations: dict[str, ExpectedRange] = field(default_factory=dict)
+
+    # Set by the loader — the on-disk path the scenario came from.
+    path: Optional[str] = None

--- a/tests/fault_tolerance/deploy/scenario_lib/_schema.py
+++ b/tests/fault_tolerance/deploy/scenario_lib/_schema.py
@@ -32,6 +32,24 @@ class Deployment:
     # PVC reuse knobs — None = framework default, "" = disable
     model_cache_pvc: Optional[str] = None
     log_pvc: Optional[str] = None
+    # Per-pod container memory *request* override (e.g. "5Gi"), applied to
+    # every service. None → use the template's request. Raising it caps how
+    # many replicas a (bin-packing) scheduler can stack on one node, forcing
+    # spread instead of cramming a node to OOM — needed for large mocker
+    # gangs on memory-tight CPU pools.
+    memory_request: Optional[str] = None
+    # Per-pod container cpu *request* override (e.g. "500m"), applied to every
+    # service. Lowers scheduler CPU pressure so large gangs fit a shared CPU
+    # pool (mockers burst to the cpu *limit* regardless of request). None →
+    # use the template's request.
+    cpu_request: Optional[str] = None
+    # Served model override (e.g. "deepseek-ai/DeepSeek-V2-Lite"). Rewrites the
+    # ``--model`` arg on every worker service so the same shape template can
+    # serve different models without a new template. ``served_model`` (the name
+    # the load + router use) is read from the worker spec after this is applied,
+    # so the aiperf load tracks it automatically. None → use the template's
+    # ``--model``.
+    model: Optional[str] = None
 
 
 @dataclass
@@ -106,6 +124,11 @@ class Rung:
     name: str
     concurrency: int
     duration_minutes: float
+    # Open-loop arrival rate (requests/sec) → aiperf --request-rate. When set,
+    # clients arrive at this fixed rate regardless of pool health (the faithful
+    # production-traffic model for error-rate-shape repros); concurrency then
+    # acts as a max-in-flight cap. None = closed-loop (drive by concurrency).
+    request_rate: Optional[float] = None
     # Optional per-rung shape override. If None, the scenario's
     # top-level shape applies.
     shape: Optional[Shape] = None

--- a/tests/fault_tolerance/deploy/scenario_lib/_schema.py
+++ b/tests/fault_tolerance/deploy/scenario_lib/_schema.py
@@ -72,6 +72,10 @@ class Shape:
     input_tokens_stddev: Optional[int] = None
     output_tokens_mean: Optional[int] = None
     output_tokens_stddev: Optional[int] = None
+    # aiperf RNG seed override (per-rung via this shape). None => framework
+    # default (100). Lets concurrent same-shape loads draw disjoint prompt
+    # corpora (e2-pressure P-D: 3 loads, pool=5 each, seeds 1/2/3).
+    random_seed: Optional[int] = None
 
 
 @dataclass

--- a/tests/fault_tolerance/deploy/scenario_lib/endurance/endurance_mocker_long.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/endurance/endurance_mocker_long.yaml
@@ -62,7 +62,7 @@ load:
 events:
   - kind: WaitForModelReady
     timeout: 1800
-  - kind: PodMemoryPoller
+  - kind: ResourcePoller
     services: [Frontend, decode]
     interval_s: 15
   - kind: PeriodicSnapshot

--- a/tests/fault_tolerance/deploy/scenario_lib/endurance/endurance_mocker_long.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/endurance/endurance_mocker_long.yaml
@@ -1,0 +1,100 @@
+# Endurance LONG — ~6h mocker-backed scenario for surfacing slow drift
+# (FE memory leak, queue backlog, scheduler accumulation) that doesn't
+# show up in a 30-min steady-state cell. Runs at production-default
+# router knobs so the slope we measure here corresponds to production.
+#
+# Pair two of these in separate namespaces — one with the production-
+# default OVERLAP_SCORE_WEIGHT=1.0 (this file) and one with =0.0 — to
+# get a clean A/B over hours. The framework does NOT pair them
+# automatically; launch dynamo-ft twice with different --namespace and
+# --label values.
+
+kind: endurance
+name: endurance_mocker_long
+description: |
+  Multi-hour endurance scenario. Mocker-backed (cheap), single-unit
+  topology, modest concurrency, prefix-aware routing at the production
+  default. Snapshots every 30 min into snapshots/t{minutes}m_<iso>/
+  so analysis can proceed while the run continues.
+
+  Hard-ceiling on snapshot count is DYN_ENDURANCE_MAX_HOURS (default
+  8h). To extend, set DYN_ENDURANCE_MAX_HOURS=N in the job env.
+
+labels:
+  router_mode: kv_prefix_aware
+  traffic_shape: partial_prefix
+  deployment: agg
+  backend: mocker
+  duration_class: long
+  pairable: "yes"
+
+deployment:
+  backend: mocker
+  topology: agg
+  units: 1
+
+router:
+  mode: kv
+  knobs:
+    DYN_ROUTER_USE_KV_EVENTS: "false"
+    DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT: "1.0"      # production default
+    DYN_ROUTER_ASSUME_KV_REUSE: "false"
+    DYN_ROUTER_REPLICA_SYNC: "true"
+
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 15
+    prefix_prompt_length: 600
+  rungs:
+    - name: warmup
+      concurrency: 8
+      duration_minutes: 5.0
+    - name: long
+      concurrency: 24
+      duration_minutes: 355.0    # ~6h sustained
+  common:
+    request_timeout_seconds: 30
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never
+
+events:
+  - kind: WaitForModelReady
+    timeout: 1800
+  - kind: PodMemoryPoller
+    services: [Frontend, decode]
+    interval_s: 15
+  - kind: PeriodicSnapshot
+    interval_minutes: 30
+  - kind: StartLoad
+    load_ref: warmup
+  - kind: WaitForLoadCompletion
+    name: warmup
+  - kind: StartLoad
+    load_ref: long
+  - kind: WaitForLoadCompletion
+    name: long
+
+reports:
+  - FaultToleranceReport
+  - PerWorkerLatencyReport
+
+checks:
+  - kind: LoadApplied
+    load_name: long
+    min_requests: 50000
+
+expectations:
+  fe_memory_growth_mb_per_min:
+    expected_range: [22, 32]
+    notes: |
+      Per the router_memory leak-positive cell, OVERLAP_SCORE_WEIGHT=1.0
+      yields ~27 MB/min. Over 6h that compounds to ~9.7 GB — well above
+      vllm-runtime FE container's default 16Gi limit on modest VMs, so
+      a long run is THE definitive test of whether the leak is bounded.
+      If observed slope flattens after N hours, that flatten point is a
+      data point we don't have today.
+
+  snapshots_emitted_count:
+    expected_range: [11, 13]   # ~6h / 30 min interval = 12 snapshots

--- a/tests/fault_tolerance/deploy/scenario_lib/endurance/endurance_mocker_smoke.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/endurance/endurance_mocker_smoke.yaml
@@ -1,0 +1,87 @@
+# Endurance SMOKE — ~30 min mocker-backed scenario for validating the
+# endurance machinery itself: single-unit mocker, kv-prefix routing at
+# production default, a single long rung, periodic 5-min snapshots.
+#
+# Goal: confirm PeriodicSnapshot fires the expected number of times,
+# snapshot dirs land on disk, AIPerf in-progress files copy cleanly,
+# and the long load completes. Run this before committing to the
+# multi-hour endurance_mocker_long scenario.
+
+kind: endurance
+name: endurance_mocker_smoke
+description: |
+  Short endurance smoke test (~30 min) — same recipe as the long
+  variant but compressed so framework wiring can be validated in a
+  single coffee break. Mocker-backed; ~1 GPU equivalent of compute.
+
+labels:
+  router_mode: kv_prefix_aware
+  traffic_shape: partial_prefix
+  deployment: agg
+  backend: mocker
+  duration_class: smoke
+  pairable: "yes"
+
+deployment:
+  backend: mocker
+  topology: agg
+  units: 1
+
+router:
+  mode: kv
+  knobs:
+    DYN_ROUTER_USE_KV_EVENTS: "false"
+    DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT: "1.0"      # production default
+    DYN_ROUTER_ASSUME_KV_REUSE: "false"
+    DYN_ROUTER_REPLICA_SYNC: "true"
+
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 15
+    prefix_prompt_length: 600
+  rungs:
+    - name: warmup
+      concurrency: 8
+      duration_minutes: 2.0
+    - name: long
+      concurrency: 24
+      duration_minutes: 28.0
+  common:
+    request_timeout_seconds: 30
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never
+
+events:
+  - kind: WaitForModelReady
+    timeout: 1800
+  - kind: PodMemoryPoller
+    services: [Frontend, decode]
+    interval_s: 10
+  - kind: PeriodicSnapshot
+    interval_minutes: 5
+  - kind: StartLoad
+    load_ref: warmup
+  - kind: WaitForLoadCompletion
+    name: warmup
+  - kind: StartLoad
+    load_ref: long
+  - kind: WaitForLoadCompletion
+    name: long
+
+reports:
+  - FaultToleranceReport
+  - PerWorkerLatencyReport
+
+checks:
+  - kind: LoadApplied
+    load_name: long
+    min_requests: 1000
+
+expectations:
+  snapshots_emitted_count:
+    expected_range: [5, 7]      # ~30 min / 5 min interval = 5-6 snapshots
+    notes: |
+      Sanity-check that PeriodicSnapshot ticked the expected number of
+      times. Count snapshots/ subdirs after the run completes.

--- a/tests/fault_tolerance/deploy/scenario_lib/endurance/endurance_mocker_smoke.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/endurance/endurance_mocker_smoke.yaml
@@ -56,7 +56,7 @@ load:
 events:
   - kind: WaitForModelReady
     timeout: 1800
-  - kind: PodMemoryPoller
+  - kind: ResourcePoller
     services: [Frontend, decode]
     interval_s: 10
   - kind: PeriodicSnapshot

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/cascade_repro__ll_deterministic__disagg__mocker.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/cascade_repro__ll_deterministic__disagg__mocker.yaml
@@ -1,0 +1,150 @@
+# Cascade-overload reproduction — 15-unit mocker, LL routing, DETERMINISTIC tie-break.
+#
+# Image carries the full stranded-KV + admission capability set:
+#   the mocker prefill-KV-residency + KV-transfer abort-timeout behavior (prefill-KV-pinning),
+#   the combined sequence+block admission gate, and prefill-KV-residency forensic logging,
+#   together with the DYN_ROUTER_LL_DETERMINISTIC_TIES knob, per-worker LL exclusion, and
+#   worker inhibition under backpressure.
+#
+# Load = fast-ramp -> steady -> spike -> steady -> spike(cascade) -> steady -> ramp-down.
+# Goal: drive decode KV toward 100%, observe the 3-stage cascade (decode KV 100% ->
+#   prefill KV -> throughput collapse), OR confirm the stranded-KV/admission stack holds
+#   at the seq+block gate (both are valid findings — see checks).
+# Decode seq cap = 8 max-num-seqs x 15 decode = 120 concurrent decode seqs; spike-2 @ 240
+#   = 2x that. num-gpu-blocks-override=1024/worker (framework mocker defaults).
+
+kind: router_memory
+name: cascade_repro__ll_deterministic__disagg__mocker
+description: |
+  15F+30P+15D mocker-disagg, LL routing with DETERMINISTIC tie-break. Trapezoid with
+  double spike (~46 min). Forces decode KV toward 100% to reproduce (or refute) the
+  3-stage KV cascade on the full stranded-KV + admission image.
+
+labels:
+  purpose: cascade_overload_repro
+  router_mode: least_loaded_deterministic_ties
+  deployment: disagg
+  backend: mocker
+  image_label: mocker-prefill-pinning-a5c93b3331
+  cluster: nscale-dev-cluster
+
+deployment:
+  backend: mocker
+  topology: disagg
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-mocker-prefill-pinning-a5c93b3331-neelays
+  replicas:
+    Frontend: 15
+    prefill: 30
+    decode: 15
+
+router:
+  mode: least-loaded
+  knobs:
+    # THE STARTING POINT: revert reservoir-sample tie-breaks (#9516) to deterministic
+    # ordering (v1.1.1 behavior) — worst-case sticky-concentration routing.
+    DYN_ROUTER_LL_DETERMINISTIC_TIES: "1"
+    DYN_ROUTER_USE_KV_EVENTS: "false"
+    # Defensive thresholds present so we can observe whether per-worker LL exclusion /
+    # worker inhibition under backpressure engage under saturation (at lower loads they never fire).
+    DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
+    DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
+    DYN_EVENT_PLANE: "zmq"
+    DYN_DISCOVERY_BACKEND: "kubernetes"
+    DYN_STORE_KV: "mem"
+    DYN_LOG: "info,dynamo_llm::discovery::worker_monitor=debug"
+
+admission:
+  knobs:
+    DYN_TCP_WORKER_POOL_SIZE: "128"
+    DYN_TCP_WORK_QUEUE_SIZE: "5"
+    VLLM_NIXL_ABORT_REQUEST_TIMEOUT: "30"
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30"
+
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 5
+    prefix_prompt_length: 740
+    seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
+  rungs:
+    - { name: warmup,   concurrency: 10,  duration_minutes: 5.0 }
+    - { name: ramp,     concurrency: 80,  duration_minutes: 1.0 }
+    - { name: steady-1, concurrency: 80,  duration_minutes: 12.0 }
+    - { name: spike-1,  concurrency: 180, duration_minutes: 12.0 }
+    - { name: steady-2, concurrency: 80,  duration_minutes: 12.0 }
+    - { name: spike-2,  concurrency: 240, duration_minutes: 28.0 }
+    - { name: steady-3, concurrency: 80,  duration_minutes: 15.0 }
+    - { name: rampdown, concurrency: 10,  duration_minutes: 5.0 }
+  common:
+    request_timeout_seconds: 30
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never
+
+events:
+  - { kind: WaitForModelReady, timeout: 1800 }
+  - kind: ResourcePoller
+    services: [Frontend, prefill, decode]
+    interval_s: 5
+  - { kind: StartLoad, load_ref: warmup }
+  - { kind: WaitForLoadCompletion, name: warmup }
+  - { kind: StartLoad, load_ref: ramp }
+  - { kind: WaitForLoadCompletion, name: ramp }
+  - { kind: StartLoad, load_ref: steady-1 }
+  - { kind: WaitForLoadCompletion, name: steady-1 }
+  - { kind: CaptureMetrics, suffix: ".pre-spike1" }
+  - { kind: StartLoad, load_ref: spike-1 }
+  - { kind: WaitForLoadCompletion, name: spike-1 }
+  - { kind: CaptureMetrics, suffix: ".post-spike1" }
+  - { kind: StartLoad, load_ref: steady-2 }
+  - { kind: WaitForLoadCompletion, name: steady-2 }
+  - { kind: CaptureMetrics, suffix: ".pre-spike2" }
+  - { kind: StartLoad, load_ref: spike-2 }
+  - { kind: WaitForLoadCompletion, name: spike-2 }
+  - { kind: CaptureMetrics, suffix: ".post-spike2" }
+  - { kind: StartLoad, load_ref: steady-3 }
+  - { kind: WaitForLoadCompletion, name: steady-3 }
+  - { kind: StartLoad, load_ref: rampdown }
+  - { kind: WaitForLoadCompletion, name: rampdown }
+
+reports:
+  - PerWorkerLatencyReport
+  - ErrorBreakdownReport
+
+checks:
+  # Sanity: the spike actually reached the cluster.
+  - { kind: LoadApplied, load_name: spike-2, min_requests: 2000 }
+
+  # --- CASCADE-REPRODUCED evidence: decode KV pegs first, then prefill ---
+  - kind: KvCacheUsagePeak
+    services: [decode]
+    threshold: 0.99
+    within_seconds: 300
+    load_name: spike-2
+  - kind: KvCacheUsagePeak
+    services: [prefill]
+    threshold: 0.95
+    within_seconds: 600
+    load_name: spike-2
+  - kind: WaitingForKVTransferExceeds
+    services: [decode]
+    threshold: 100
+    load_name: spike-2
+  - kind: GenerationThroughputDropped
+    services: [decode]
+    min_drop_frac: 0.30
+    warmup_seconds: 300
+    cliff_window_seconds: 300
+    cliff_load_name: spike-2
+  - kind: NixlXferTimeMultiplied
+    services: [decode]
+    min_multiplier: 3.0
+    warmup_seconds: 300
+    cliff_load_name: spike-2
+  - kind: RequestsRunningPeak
+    threshold: 200
+    sustained_seconds: 30
+
+  # --- Hygiene: distinguish a true cascade from a pod crash ---
+  - { kind: WorkerPanics, services: [Frontend, prefill, decode], acceptable: true }
+  - { kind: RestartCountIncreased, services: [Frontend, prefill, decode], expect_min_increment: 0 }

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/cascade_test__kv_prefix__disagg__mocker.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/cascade_test__kv_prefix__disagg__mocker.yaml
@@ -1,0 +1,117 @@
+# Matrix arm — leak investigation (image × routing-mode matrix)
+# Image: release-1.2.0 | Routing: kv_prefix
+# Leak-POSITIVE — production-default KV+prefix on newer image
+
+kind: router_memory
+name: cascade_test__kv_prefix__disagg__mocker
+description: |
+  Matrix arm: kv_prefix routing on release-1.2.0 mocker-disagg.
+  2 FE × 2 prefill × 2 decode mocker workers, trapezoid load ~30 min.
+  Production ISL/OSL/prefix shape (partial_prefix, ~37% prefix-hit).
+
+labels:
+  image_label: cascade-test
+  router_mode: kv_prefix
+  traffic_shape: partial_prefix
+  deployment: disagg
+  backend: mocker
+
+deployment:
+  backend: mocker
+  topology: disagg
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-cascade-test-7d8eaa70a9-neelays
+  replicas:
+    Frontend: 10
+    prefill: 20
+    decode: 10
+
+router:
+  mode: kv
+  knobs:
+    DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT: "1.0"
+    DYN_ROUTER_USE_KV_EVENTS: "false"
+    DYN_ROUTER_REPLICA_SYNC: "true"
+    DYN_ROUTER_TEMPERATURE: "0.0"
+    DYN_ROUTER_TRACK_ACTIVE_BLOCKS: "true"
+
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 15
+    prefix_prompt_length: 600
+  rungs:
+    - name: warmup
+      concurrency: 40
+      duration_minutes: 1.0
+    - name: ramp1
+      concurrency: 120
+      duration_minutes: 2.5
+    - name: ramp2
+      concurrency: 180
+      duration_minutes: 2.5
+    - name: steady
+      concurrency: 120
+      duration_minutes: 18.0
+    - name: rampdown1
+      concurrency: 180
+      duration_minutes: 2.5
+    - name: rampdown2
+      concurrency: 120
+      duration_minutes: 2.5
+    - name: final
+      concurrency: 40
+      duration_minutes: 1.0
+  common:
+    request_timeout_seconds: 30
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never
+
+events:
+  - kind: WaitForModelReady
+    timeout: 900
+  - kind: PodMemoryPoller
+    services: [Frontend, prefill, decode]
+    interval_s: 15
+  - kind: StartLoad
+    load_ref: warmup
+  - kind: WaitForLoadCompletion
+    name: warmup
+  - kind: StartLoad
+    load_ref: ramp1
+  - kind: WaitForLoadCompletion
+    name: ramp1
+  - kind: StartLoad
+    load_ref: ramp2
+  - kind: WaitForLoadCompletion
+    name: ramp2
+  - kind: StartLoad
+    load_ref: steady
+  - kind: WaitForLoadCompletion
+    name: steady
+  - kind: StartLoad
+    load_ref: rampdown1
+  - kind: WaitForLoadCompletion
+    name: rampdown1
+  - kind: StartLoad
+    load_ref: rampdown2
+  - kind: WaitForLoadCompletion
+    name: rampdown2
+  - kind: StartLoad
+    load_ref: final
+  - kind: WaitForLoadCompletion
+    name: final
+
+reports:
+  - PerWorkerLatencyReport
+
+checks:
+  - kind: LoadApplied
+    load_name: steady
+    min_requests: 1000
+
+expectations:
+  fe_memory_growth_mb_per_min:
+    expected_range: [20, 35]
+    notes: |
+      Leak-POSITIVE — production-default KV+prefix on newer image.

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/cascade_test__kv_prefix__disagg__mocker.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/cascade_test__kv_prefix__disagg__mocker.yaml
@@ -70,7 +70,7 @@ load:
 events:
   - kind: WaitForModelReady
     timeout: 900
-  - kind: PodMemoryPoller
+  - kind: ResourcePoller
     services: [Frontend, prefill, decode]
     interval_s: 15
   - kind: StartLoad

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/cascade_test__kv_zero_nosync__disagg__mocker.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/cascade_test__kv_zero_nosync__disagg__mocker.yaml
@@ -73,7 +73,7 @@ load:
 events:
   - kind: WaitForModelReady
     timeout: 900
-  - kind: PodMemoryPoller
+  - kind: ResourcePoller
     services: [Frontend, prefill, decode]
     interval_s: 15
   - kind: StartLoad

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/cascade_test__kv_zero_nosync__disagg__mocker.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/cascade_test__kv_zero_nosync__disagg__mocker.yaml
@@ -1,0 +1,120 @@
+# Matrix arm — leak investigation (image × routing-mode matrix)
+# Image: release-1.2.0 | Routing: kv_pure_load
+# A4 pure-load reference on newer image
+
+kind: router_memory
+name: cascade_test__kv_zero_nosync__disagg__mocker
+description: |
+  Matrix arm: kv_pure_load routing on release-1.2.0 mocker-disagg.
+  2 FE × 2 prefill × 2 decode mocker workers, trapezoid load ~30 min.
+  Production ISL/OSL/prefix shape (partial_prefix, ~37% prefix-hit).
+
+labels:
+  image_label: cascade-test
+  router_mode: kv_zero_nosync
+  traffic_shape: partial_prefix
+  deployment: disagg
+  backend: mocker
+
+deployment:
+  backend: mocker
+  topology: disagg
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-cascade-test-7d8eaa70a9-neelays
+  replicas:
+    Frontend: 10
+    prefill: 20
+    decode: 10
+
+router:
+  mode: kv
+  knobs:
+    DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT: "0.0"
+    DYN_KV_HOST_CACHE_HIT_WEIGHT: "0.0"
+    DYN_KV_DISK_CACHE_HIT_WEIGHT: "0.0"
+    DYN_ROUTER_USE_KV_EVENTS: "false"
+    DYN_ROUTER_REPLICA_SYNC: "false"
+    DYN_ROUTER_TEMPERATURE: "0.0"
+    DYN_ROUTER_ASSUME_KV_REUSE: "false"
+    DYN_ROUTER_TRACK_ACTIVE_BLOCKS: "true"
+
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 15
+    prefix_prompt_length: 600
+  rungs:
+    - name: warmup
+      concurrency: 40
+      duration_minutes: 1.0
+    - name: ramp1
+      concurrency: 120
+      duration_minutes: 2.5
+    - name: ramp2
+      concurrency: 180
+      duration_minutes: 2.5
+    - name: steady
+      concurrency: 120
+      duration_minutes: 18.0
+    - name: rampdown1
+      concurrency: 180
+      duration_minutes: 2.5
+    - name: rampdown2
+      concurrency: 120
+      duration_minutes: 2.5
+    - name: final
+      concurrency: 40
+      duration_minutes: 1.0
+  common:
+    request_timeout_seconds: 30
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never
+
+events:
+  - kind: WaitForModelReady
+    timeout: 900
+  - kind: PodMemoryPoller
+    services: [Frontend, prefill, decode]
+    interval_s: 15
+  - kind: StartLoad
+    load_ref: warmup
+  - kind: WaitForLoadCompletion
+    name: warmup
+  - kind: StartLoad
+    load_ref: ramp1
+  - kind: WaitForLoadCompletion
+    name: ramp1
+  - kind: StartLoad
+    load_ref: ramp2
+  - kind: WaitForLoadCompletion
+    name: ramp2
+  - kind: StartLoad
+    load_ref: steady
+  - kind: WaitForLoadCompletion
+    name: steady
+  - kind: StartLoad
+    load_ref: rampdown1
+  - kind: WaitForLoadCompletion
+    name: rampdown1
+  - kind: StartLoad
+    load_ref: rampdown2
+  - kind: WaitForLoadCompletion
+    name: rampdown2
+  - kind: StartLoad
+    load_ref: final
+  - kind: WaitForLoadCompletion
+    name: final
+
+reports:
+  - PerWorkerLatencyReport
+
+checks:
+  - kind: LoadApplied
+    load_name: steady
+    min_requests: 1000
+
+expectations:
+  fe_memory_growth_mb_per_min:
+    expected_range: [1, 5]
+    notes: |
+      A4 pure-load reference on newer image.

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/cascade_test__kv_zero_sync__disagg__mocker.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/cascade_test__kv_zero_sync__disagg__mocker.yaml
@@ -73,7 +73,7 @@ load:
 events:
   - kind: WaitForModelReady
     timeout: 900
-  - kind: PodMemoryPoller
+  - kind: ResourcePoller
     services: [Frontend, prefill, decode]
     interval_s: 15
   - kind: StartLoad

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/cascade_test__kv_zero_sync__disagg__mocker.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/cascade_test__kv_zero_sync__disagg__mocker.yaml
@@ -1,0 +1,120 @@
+# Matrix arm — leak investigation (image × routing-mode matrix)
+# Image: release-1.2.0 | Routing: kv_pure_load
+# A4 pure-load reference on newer image
+
+kind: router_memory
+name: cascade_test__kv_zero_sync__disagg__mocker
+description: |
+  Matrix arm: kv_pure_load routing on release-1.2.0 mocker-disagg.
+  2 FE × 2 prefill × 2 decode mocker workers, trapezoid load ~30 min.
+  Production ISL/OSL/prefix shape (partial_prefix, ~37% prefix-hit).
+
+labels:
+  image_label: cascade-test
+  router_mode: kv_zero_sync
+  traffic_shape: partial_prefix
+  deployment: disagg
+  backend: mocker
+
+deployment:
+  backend: mocker
+  topology: disagg
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-cascade-test-7d8eaa70a9-neelays
+  replicas:
+    Frontend: 10
+    prefill: 20
+    decode: 10
+
+router:
+  mode: kv
+  knobs:
+    DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT: "0.0"
+    DYN_KV_HOST_CACHE_HIT_WEIGHT: "0.0"
+    DYN_KV_DISK_CACHE_HIT_WEIGHT: "0.0"
+    DYN_ROUTER_USE_KV_EVENTS: "false"
+    DYN_ROUTER_REPLICA_SYNC: "true"
+    DYN_ROUTER_TEMPERATURE: "0.0"
+    DYN_ROUTER_ASSUME_KV_REUSE: "false"
+    DYN_ROUTER_TRACK_ACTIVE_BLOCKS: "true"
+
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 15
+    prefix_prompt_length: 600
+  rungs:
+    - name: warmup
+      concurrency: 40
+      duration_minutes: 1.0
+    - name: ramp1
+      concurrency: 120
+      duration_minutes: 2.5
+    - name: ramp2
+      concurrency: 180
+      duration_minutes: 2.5
+    - name: steady
+      concurrency: 120
+      duration_minutes: 18.0
+    - name: rampdown1
+      concurrency: 180
+      duration_minutes: 2.5
+    - name: rampdown2
+      concurrency: 120
+      duration_minutes: 2.5
+    - name: final
+      concurrency: 40
+      duration_minutes: 1.0
+  common:
+    request_timeout_seconds: 30
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never
+
+events:
+  - kind: WaitForModelReady
+    timeout: 900
+  - kind: PodMemoryPoller
+    services: [Frontend, prefill, decode]
+    interval_s: 15
+  - kind: StartLoad
+    load_ref: warmup
+  - kind: WaitForLoadCompletion
+    name: warmup
+  - kind: StartLoad
+    load_ref: ramp1
+  - kind: WaitForLoadCompletion
+    name: ramp1
+  - kind: StartLoad
+    load_ref: ramp2
+  - kind: WaitForLoadCompletion
+    name: ramp2
+  - kind: StartLoad
+    load_ref: steady
+  - kind: WaitForLoadCompletion
+    name: steady
+  - kind: StartLoad
+    load_ref: rampdown1
+  - kind: WaitForLoadCompletion
+    name: rampdown1
+  - kind: StartLoad
+    load_ref: rampdown2
+  - kind: WaitForLoadCompletion
+    name: rampdown2
+  - kind: StartLoad
+    load_ref: final
+  - kind: WaitForLoadCompletion
+    name: final
+
+reports:
+  - PerWorkerLatencyReport
+
+checks:
+  - kind: LoadApplied
+    load_name: steady
+    min_requests: 1000
+
+expectations:
+  fe_memory_growth_mb_per_min:
+    expected_range: [1, 5]
+    notes: |
+      A4 pure-load reference on newer image.

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/cascade_test__least_loaded__disagg__mocker.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/cascade_test__least_loaded__disagg__mocker.yaml
@@ -66,7 +66,7 @@ load:
 events:
   - kind: WaitForModelReady
     timeout: 900
-  - kind: PodMemoryPoller
+  - kind: ResourcePoller
     services: [Frontend, prefill, decode]
     interval_s: 15
   - kind: StartLoad

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/cascade_test__least_loaded__disagg__mocker.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/cascade_test__least_loaded__disagg__mocker.yaml
@@ -1,0 +1,113 @@
+# Matrix arm — leak investigation (image × routing-mode matrix)
+# Image: release-1.2.0 | Routing: least_loaded
+# Leak-NEGATIVE reference on newer release/1.2.0 image
+
+kind: router_memory
+name: cascade_test__least_loaded__disagg__mocker
+description: |
+  Matrix arm: least_loaded routing on release-1.2.0 mocker-disagg.
+  2 FE × 2 prefill × 2 decode mocker workers, trapezoid load ~30 min.
+  Production ISL/OSL/prefix shape (partial_prefix, ~37% prefix-hit).
+
+labels:
+  image_label: cascade-test
+  router_mode: least_loaded
+  traffic_shape: partial_prefix
+  deployment: disagg
+  backend: mocker
+
+deployment:
+  backend: mocker
+  topology: disagg
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-cascade-test-7d8eaa70a9-neelays
+  replicas:
+    Frontend: 10
+    prefill: 20
+    decode: 10
+
+router:
+  mode: least-loaded
+  knobs:
+    DYN_ROUTER_USE_KV_EVENTS: "false"
+
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 15
+    prefix_prompt_length: 600
+  rungs:
+    - name: warmup
+      concurrency: 40
+      duration_minutes: 1.0
+    - name: ramp1
+      concurrency: 120
+      duration_minutes: 2.5
+    - name: ramp2
+      concurrency: 180
+      duration_minutes: 2.5
+    - name: steady
+      concurrency: 120
+      duration_minutes: 18.0
+    - name: rampdown1
+      concurrency: 180
+      duration_minutes: 2.5
+    - name: rampdown2
+      concurrency: 120
+      duration_minutes: 2.5
+    - name: final
+      concurrency: 40
+      duration_minutes: 1.0
+  common:
+    request_timeout_seconds: 30
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never
+
+events:
+  - kind: WaitForModelReady
+    timeout: 900
+  - kind: PodMemoryPoller
+    services: [Frontend, prefill, decode]
+    interval_s: 15
+  - kind: StartLoad
+    load_ref: warmup
+  - kind: WaitForLoadCompletion
+    name: warmup
+  - kind: StartLoad
+    load_ref: ramp1
+  - kind: WaitForLoadCompletion
+    name: ramp1
+  - kind: StartLoad
+    load_ref: ramp2
+  - kind: WaitForLoadCompletion
+    name: ramp2
+  - kind: StartLoad
+    load_ref: steady
+  - kind: WaitForLoadCompletion
+    name: steady
+  - kind: StartLoad
+    load_ref: rampdown1
+  - kind: WaitForLoadCompletion
+    name: rampdown1
+  - kind: StartLoad
+    load_ref: rampdown2
+  - kind: WaitForLoadCompletion
+    name: rampdown2
+  - kind: StartLoad
+    load_ref: final
+  - kind: WaitForLoadCompletion
+    name: final
+
+reports:
+  - PerWorkerLatencyReport
+
+checks:
+  - kind: LoadApplied
+    load_name: steady
+    min_requests: 1000
+
+expectations:
+  fe_memory_growth_mb_per_min:
+    expected_range: [1, 5]
+    notes: |
+      Leak-NEGATIVE reference on newer release/1.2.0 image.

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm1_baseline_v111.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm1_baseline_v111.yaml
@@ -81,7 +81,7 @@ load:
 events:
   - kind: WaitForModelReady
     timeout: 1800
-  - kind: PodMemoryPoller
+  - kind: ResourcePoller
     services: [Frontend, prefill, decode]
     interval_s: 5
   - kind: StartLoad

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm1_baseline_v111.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm1_baseline_v111.yaml
@@ -1,0 +1,121 @@
+# E1 Imbalance — Arm 1: Baseline (v1.1.1 release, 93 FE, LL routing)
+#
+# Production-today anchor — "what we ship today, with the imbalance we're attributing."
+# This is the SOURCE of the imbalance observation. Compared against Arms 2–5 (cascade-test
+# image + various routing knobs) to attribute imbalance into H1 (KV-unaware LL) vs H2
+# (cross-FE blind spot) contributions.
+#
+# Topology: 93 FE + 186 prefill + 93 decode = 372 mocker pods. Full AZ.
+# Routing:  LL (deterministic ties — v1.1.1 hasn't picked up reservoir-sample yet).
+# Steady:   c=C_target for 15 min. C_target comes from Stage-0 saturation discovery.
+#           Placeholder c=2400 below = production target × 0.78; ADJUST AFTER STAGE-0.
+
+kind: router_memory
+name: e1_arm1_baseline_v111
+description: |
+  E1 Arm 1 (Baseline): 93F+186P+93D mocker, LL routing on v1.1.1 release tag.
+  The production-today anchor. Imbalance signal here is what we're attributing.
+
+labels:
+  purpose: e1_imbalance_attribution
+  arm: arm1_baseline
+  router_mode: least_loaded
+  deployment: disagg
+  backend: mocker
+  image_label: v1.1.1
+
+deployment:
+  backend: mocker
+  topology: disagg
+  image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:0.1.1
+  replicas:
+    Frontend: 46
+    prefill: 92
+    decode: 46
+
+router:
+  mode: least-loaded
+  knobs:
+    # v1.1.1 defaults — no Recommended-config knobs set. Just LL.
+    DYN_EVENT_PLANE: "zmq"
+    DYN_DISCOVERY_BACKEND: "kubernetes"
+    DYN_STORE_KV: "mem"
+    DYN_LOG: "info,dynamo_runtime::transports::event_plane::zmq_transport=debug,dynamo_llm::discovery::worker_monitor=debug,dynamo_runtime::component::client=debug"
+
+admission:
+  knobs:
+    DYN_TCP_WORKER_POOL_SIZE: "128"
+    DYN_TCP_WORK_QUEUE_SIZE: "5"
+    VLLM_NIXL_ABORT_REQUEST_TIMEOUT: "30"
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30"
+
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 5
+    prefix_prompt_length: 740
+    seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
+  # Shared E1/E2/E3 load profile.
+  rungs:
+    - name: ramp-up
+      concurrency: 100
+      duration_minutes: 1.5
+    - name: steady-1
+      concurrency: 300
+      duration_minutes: 5.0
+    - name: spike
+      concurrency: 500
+      duration_minutes: 1.5
+    - name: steady-2
+      concurrency: 300
+      duration_minutes: 5.0
+    - name: ramp-down
+      concurrency: 75
+      duration_minutes: 1.0
+  common:
+    request_timeout_seconds: 30
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never
+
+events:
+  - kind: WaitForModelReady
+    timeout: 1800
+  - kind: PodMemoryPoller
+    services: [Frontend, prefill, decode]
+    interval_s: 5
+  - kind: StartLoad
+    load_ref: ramp-up
+  - kind: WaitForLoadCompletion
+    name: ramp-up
+  - kind: StartLoad
+    load_ref: steady-1
+  - kind: WaitForLoadCompletion
+    name: steady-1
+  - kind: StartLoad
+    load_ref: spike
+  - kind: WaitForLoadCompletion
+    name: spike
+  - kind: StartLoad
+    load_ref: steady-2
+  - kind: WaitForLoadCompletion
+    name: steady-2
+  - kind: StartLoad
+    load_ref: ramp-down
+  - kind: WaitForLoadCompletion
+    name: ramp-down
+
+reports:
+  - PerWorkerLatencyReport
+  - ErrorBreakdownReport
+
+checks:
+  - kind: LoadApplied
+    load_name: steady-1
+    min_requests: 5000
+  - kind: WorkerPanics
+    services: [Frontend, prefill, decode]
+    acceptable: true
+  - kind: RestartCountIncreased
+    services: [Frontend, prefill, decode]
+    expect_min_increment: 0

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm1_nscale_15set.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm1_nscale_15set.yaml
@@ -84,7 +84,7 @@ load:
 events:
   - kind: WaitForModelReady
     timeout: 1800
-  - kind: PodMemoryPoller
+  - kind: ResourcePoller
     services: [Frontend, prefill, decode]
     interval_s: 5
   - kind: StartLoad

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm1_nscale_15set.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm1_nscale_15set.yaml
@@ -1,44 +1,38 @@
-# E1 Imbalance — Arm 5: 93 FE / KV + replica-sync (Recommended config)
+# E1 Imbalance — Arm 1 (NSCALE 15-set variant, LL baseline v1.1.1)
 #
-# Both H1 and H2 mitigated. KV-aware routing + cross-FE state sync. The target config
-# we'd recommend for the production deployment. If imbalance flattens here vs Arm 4,
-# replica-sync was the missing piece. If still imbalanced, KV+sync alone isn't enough.
+# Memory-budget-aware downscale for nscale-dev CPU pool when aws-dev-02 is down.
+# 15 sets × 4 pods = 60 mocker pods × 6 GiB = ~360 GiB (~56% of nscale pool memory).
+# Trimmed rungs (8.5 min wall) so 3 serial arms fit a 1-hour window.
+#
+# Concurrency scaled to per-set load matching the 46-set baseline (15/46 ≈ 0.326).
 
 kind: router_memory
-name: e1_arm5_93fe_kv_sync
+name: e1_arm1_nscale_15set
 description: |
-  E1 Arm 5 (93 FE / KV + replica-sync): 93F+186P+93D mocker, KV routing with replica-sync.
-  Recommended config. H1 and H2 both mitigated. Target migration config.
+  E1 Arm 1 (LL baseline, v1.1.1): 15F+30P+15D mocker, LL routing.
+  Production-today anchor at nscale-15-set scale.
 
 labels:
   purpose: e1_imbalance_attribution
-  arm: arm5_93fe_kv_sync
-  router_mode: kv_recommended
+  arm: arm1_nscale_15set
+  router_mode: least_loaded
   deployment: disagg
   backend: mocker
-  image_label: cascade-test
+  image_label: v1.1.1
+  cluster: nscale-dev-cluster
 
 deployment:
   backend: mocker
   topology: disagg
-  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-cascade-test-ead461faa6-neelays
+  image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1
   replicas:
-    Frontend: 46
-    prefill: 92
-    decode: 46
+    Frontend: 15
+    prefill: 30
+    decode: 15
 
 router:
-  mode: kv
+  mode: least-loaded
   knobs:
-    # Recommended config — KV + replica-sync + load-aware (no prefix routing, no KV events)
-    DYN_ROUTER_USE_KV_EVENTS: "false"
-    DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT: "0.0"
-    DYN_ROUTER_PREFILL_LOAD_SCALE: "1.0"
-    DYN_ROUTER_QUEUE_THRESHOLD: "4.0"
-    DYN_ROUTER_QUEUE_POLICY: "fcfs"
-    DYN_ROUTER_REPLICA_SYNC: "true"   # <-- THE DIFF vs Arm 4
-    DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
-    DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
     DYN_EVENT_PLANE: "zmq"
     DYN_DISCOVERY_BACKEND: "kubernetes"
     DYN_STORE_KV: "mem"
@@ -57,27 +51,30 @@ load:
     num_prefix_prompts: 5
     prefix_prompt_length: 740
     seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
-  # Shared E1/E2/E3 load profile: ramp-up → steady-1 → spike → steady-2 → ramp-down.
-  # Mocker --speedup-ratio=5.0 (set in disagg.yaml template) means engine-side sim
-  # advances 5× faster than wall-clock; aiperf still drives load over wall-clock,
-  # so the visible effect is higher per-pod request throughput at the same target
-  # concurrency. Total wall ≈ 13.5 min per arm.
+  # Trimmed profile (8.5 min wall) so 3 arms fit a 1-hour serial budget.
+  #
+  # Concurrency calibrated from prior sanity_run1 mocker data:
+  #   3-set mocker @ c=200 (67 c/set) → p95=22.6s (4.5x SLA, heavily saturated)
+  #   3-set mocker @ c=50 (16 c/set)  → p95=6.9s  (just over 5s SLA)
+  # SLA = 5000ms (= 30s prod budget / 5x speedup-ratio).
+  # Target steady at ~8 c/set → p95 estimate ~3s (comfortably under SLA, hot
+  # enough to surface routing imbalance). Spike briefly pushes to 16 c/set.
   rungs:
     - name: ramp-up
-      concurrency: 200
-      duration_minutes: 1.5
-    - name: steady-1
-      concurrency: 600  # Conservative pre-Stage-0 — revisit after saturation discovery
-      duration_minutes: 5.0
-    - name: spike
-      concurrency: 1200
-      duration_minutes: 1.5
-    - name: steady-2
-      concurrency: 600
-      duration_minutes: 5.0
-    - name: ramp-down
-      concurrency: 150
+      concurrency: 50
       duration_minutes: 1.0
+    - name: steady-1
+      concurrency: 120
+      duration_minutes: 3.0
+    - name: spike
+      concurrency: 240
+      duration_minutes: 1.0
+    - name: steady-2
+      concurrency: 120
+      duration_minutes: 3.0
+    - name: ramp-down
+      concurrency: 30
+      duration_minutes: 0.5
   common:
     request_timeout_seconds: 30
     streaming: true
@@ -118,7 +115,7 @@ reports:
 checks:
   - kind: LoadApplied
     load_name: steady-1
-    min_requests: 5000
+    min_requests: 500
   - kind: WorkerPanics
     services: [Frontend, prefill, decode]
     acceptable: true

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm2_1fe_ll.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm2_1fe_ll.yaml
@@ -81,7 +81,7 @@ load:
 events:
   - kind: WaitForModelReady
     timeout: 1800
-  - kind: PodMemoryPoller
+  - kind: ResourcePoller
     services: [Frontend, prefill, decode]
     interval_s: 5
   - kind: StartLoad

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm2_1fe_ll.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm2_1fe_ll.yaml
@@ -1,0 +1,121 @@
+# E1 Imbalance — Arm 2: 1 FE / LL (cascade-test image)
+#
+# H1 isolation: single FE has perfect cross-FE visibility (there's only one), so any
+# decode-side imbalance observed here MUST come from LL being KV-unaware (H1), not from
+# cross-FE blind spot (H2). Decode-side CV / max-to-mean delta vs Arm 3 isolates H2.
+# Use cascade-test image so this is the routing-stack release we'd actually deploy.
+#
+# Topology: 1 FE + 186 prefill + 93 decode = 280 mocker pods. Same worker count as Arm 3
+#           so per-pod pressure is comparable. Single FE may saturate — Stage-0 confirmed
+#           C_target keeps single FE below saturation.
+
+kind: router_memory
+name: e1_arm2_1fe_ll
+description: |
+  E1 Arm 2 (1 FE / LL): isolates H1 (KV-unaware LL) by removing H2 (no cross-FE blindspot).
+  Single FE, cascade-test image. Decode-side CV here = pure H1 contribution.
+
+labels:
+  purpose: e1_imbalance_attribution
+  arm: arm2_1fe_ll
+  router_mode: least_loaded
+  deployment: disagg
+  backend: mocker
+  image_label: cascade-test
+
+deployment:
+  backend: mocker
+  topology: disagg
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-cascade-test-ead461faa6-neelays
+  replicas:
+    Frontend: 1
+    prefill: 92
+    decode: 46
+
+router:
+  mode: least-loaded
+  knobs:
+    DYN_EVENT_PLANE: "zmq"
+    DYN_DISCOVERY_BACKEND: "kubernetes"
+    DYN_STORE_KV: "mem"
+    DYN_LOG: "info,dynamo_runtime::transports::event_plane::zmq_transport=debug,dynamo_llm::discovery::worker_monitor=debug,dynamo_runtime::component::client=debug"
+
+admission:
+  knobs:
+    DYN_TCP_WORKER_POOL_SIZE: "128"
+    DYN_TCP_WORK_QUEUE_SIZE: "5"
+    VLLM_NIXL_ABORT_REQUEST_TIMEOUT: "30"
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30"
+
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 5
+    prefix_prompt_length: 740
+    seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
+  # Shared E1/E2/E3 load profile. Single FE may saturate at high concurrency;
+  # if Stage-0 shows C_max_1FE < 1500, this scenario will see early 503s on
+  # steady — that's expected and IS the H1 isolation signal.
+  rungs:
+    - name: ramp-up
+      concurrency: 100
+      duration_minutes: 1.5
+    - name: steady-1
+      concurrency: 300
+      duration_minutes: 5.0
+    - name: spike
+      concurrency: 500
+      duration_minutes: 1.5
+    - name: steady-2
+      concurrency: 300
+      duration_minutes: 5.0
+    - name: ramp-down
+      concurrency: 75
+      duration_minutes: 1.0
+  common:
+    request_timeout_seconds: 30
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never
+
+events:
+  - kind: WaitForModelReady
+    timeout: 1800
+  - kind: PodMemoryPoller
+    services: [Frontend, prefill, decode]
+    interval_s: 5
+  - kind: StartLoad
+    load_ref: ramp-up
+  - kind: WaitForLoadCompletion
+    name: ramp-up
+  - kind: StartLoad
+    load_ref: steady-1
+  - kind: WaitForLoadCompletion
+    name: steady-1
+  - kind: StartLoad
+    load_ref: spike
+  - kind: WaitForLoadCompletion
+    name: spike
+  - kind: StartLoad
+    load_ref: steady-2
+  - kind: WaitForLoadCompletion
+    name: steady-2
+  - kind: StartLoad
+    load_ref: ramp-down
+  - kind: WaitForLoadCompletion
+    name: ramp-down
+
+reports:
+  - PerWorkerLatencyReport
+  - ErrorBreakdownReport
+
+checks:
+  - kind: LoadApplied
+    load_name: steady-1
+    min_requests: 5000
+  - kind: WorkerPanics
+    services: [Frontend, prefill, decode]
+    acceptable: true
+  - kind: RestartCountIncreased
+    services: [Frontend, prefill, decode]
+    expect_min_increment: 0

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm2_nscale_15set.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm2_nscale_15set.yaml
@@ -1,42 +1,41 @@
-# E1 Imbalance — Arm 5: 93 FE / KV + replica-sync (Recommended config)
+# E1 Imbalance — Arm 2 (NSCALE 15-set variant, 1 FE / LL H2-isolation)
 #
-# Both H1 and H2 mitigated. KV-aware routing + cross-FE state sync. The target config
-# we'd recommend for the production deployment. If imbalance flattens here vs Arm 4,
-# replica-sync was the missing piece. If still imbalanced, KV+sync alone isn't enough.
+# H1 isolation: single FE has perfect cross-FE visibility (there's only one),
+# so any decode-side imbalance observed here MUST come from LL being KV-unaware
+# (H1), not from cross-FE blind spot (H2). Compared to arm3 (15 FE / LL same
+# image+knobs) decode-side CV / max-to-mean delta isolates H2 contribution.
+#
+# Same cascade-test image as arm3 + arm5; same admission thresholds. Only
+# diff vs arm3: replicas.Frontend = 1 (vs 15).
 
 kind: router_memory
-name: e1_arm5_93fe_kv_sync
+name: e1_arm2_nscale_15set
 description: |
-  E1 Arm 5 (93 FE / KV + replica-sync): 93F+186P+93D mocker, KV routing with replica-sync.
-  Recommended config. H1 and H2 both mitigated. Target migration config.
+  E1 Arm 2 (1 FE / LL, cascade-test): 1F+30P+15D mocker, LL routing.
+  H2 (cross-FE blind spot) eliminated — any imbalance here is pure H1 (KV-unaware LL).
 
 labels:
   purpose: e1_imbalance_attribution
-  arm: arm5_93fe_kv_sync
-  router_mode: kv_recommended
+  arm: arm2_nscale_15set
+  router_mode: least_loaded
   deployment: disagg
   backend: mocker
   image_label: cascade-test
+  cluster: nscale-dev-cluster
 
 deployment:
   backend: mocker
   topology: disagg
   image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-cascade-test-ead461faa6-neelays
   replicas:
-    Frontend: 46
-    prefill: 92
-    decode: 46
+    Frontend: 1   # <-- THE DIFF vs arm3 (which has 15)
+    prefill: 30
+    decode: 15
 
 router:
-  mode: kv
+  mode: least-loaded
   knobs:
-    # Recommended config — KV + replica-sync + load-aware (no prefix routing, no KV events)
-    DYN_ROUTER_USE_KV_EVENTS: "false"
-    DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT: "0.0"
-    DYN_ROUTER_PREFILL_LOAD_SCALE: "1.0"
-    DYN_ROUTER_QUEUE_THRESHOLD: "4.0"
-    DYN_ROUTER_QUEUE_POLICY: "fcfs"
-    DYN_ROUTER_REPLICA_SYNC: "true"   # <-- THE DIFF vs Arm 4
+    # Same thresholds as arm3 + arm5; only the FE count differs.
     DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
     DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
     DYN_EVENT_PLANE: "zmq"
@@ -57,27 +56,23 @@ load:
     num_prefix_prompts: 5
     prefix_prompt_length: 740
     seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
-  # Shared E1/E2/E3 load profile: ramp-up → steady-1 → spike → steady-2 → ramp-down.
-  # Mocker --speedup-ratio=5.0 (set in disagg.yaml template) means engine-side sim
-  # advances 5× faster than wall-clock; aiperf still drives load over wall-clock,
-  # so the visible effect is higher per-pod request throughput at the same target
-  # concurrency. Total wall ≈ 13.5 min per arm.
+  # Identical load profile to arm1/arm3/arm5 — only deployment shape differs.
   rungs:
     - name: ramp-up
-      concurrency: 200
-      duration_minutes: 1.5
-    - name: steady-1
-      concurrency: 600  # Conservative pre-Stage-0 — revisit after saturation discovery
-      duration_minutes: 5.0
-    - name: spike
-      concurrency: 1200
-      duration_minutes: 1.5
-    - name: steady-2
-      concurrency: 600
-      duration_minutes: 5.0
-    - name: ramp-down
-      concurrency: 150
+      concurrency: 50
       duration_minutes: 1.0
+    - name: steady-1
+      concurrency: 120
+      duration_minutes: 3.0
+    - name: spike
+      concurrency: 240
+      duration_minutes: 1.0
+    - name: steady-2
+      concurrency: 120
+      duration_minutes: 3.0
+    - name: ramp-down
+      concurrency: 30
+      duration_minutes: 0.5
   common:
     request_timeout_seconds: 30
     streaming: true
@@ -118,7 +113,7 @@ reports:
 checks:
   - kind: LoadApplied
     load_name: steady-1
-    min_requests: 5000
+    min_requests: 500
   - kind: WorkerPanics
     services: [Frontend, prefill, decode]
     acceptable: true

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm2_nscale_15set.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm2_nscale_15set.yaml
@@ -82,7 +82,7 @@ load:
 events:
   - kind: WaitForModelReady
     timeout: 1800
-  - kind: PodMemoryPoller
+  - kind: ResourcePoller
     services: [Frontend, prefill, decode]
     interval_s: 5
   - kind: StartLoad

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm3_93fe_ll.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm3_93fe_ll.yaml
@@ -76,7 +76,7 @@ load:
 events:
   - kind: WaitForModelReady
     timeout: 1800
-  - kind: PodMemoryPoller
+  - kind: ResourcePoller
     services: [Frontend, prefill, decode]
     interval_s: 5
   - kind: StartLoad

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm3_93fe_ll.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm3_93fe_ll.yaml
@@ -1,0 +1,116 @@
+# E1 Imbalance — Arm 3: 93 FE / LL (cascade-test image)
+#
+# Anchor at LL × cascade-test. Compared to Arm 1 (v1.1.1 baseline), this isolates the
+# 1.1.1 → cascade-test stack delta under LL (admission gate, abort timeout, reservoir
+# ties, etc.) — should NOT change imbalance much, since none of those touch routing
+# logic. Compared to Arm 2 (1 FE / LL), this isolates H2 (cross-FE blind spot) — same
+# routing logic + image, only difference is 93 FEs vs 1.
+
+kind: router_memory
+name: e1_arm3_93fe_ll
+description: |
+  E1 Arm 3 (93 FE / LL): 93F+186P+93D mocker, LL routing on cascade-test image.
+  Anchor for H2 isolation (compared to Arm 2's 1 FE) and 1.1.1→1.2 stack delta (vs Arm 1).
+
+labels:
+  purpose: e1_imbalance_attribution
+  arm: arm3_93fe_ll
+  router_mode: least_loaded
+  deployment: disagg
+  backend: mocker
+  image_label: cascade-test
+
+deployment:
+  backend: mocker
+  topology: disagg
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-cascade-test-ead461faa6-neelays
+  replicas:
+    Frontend: 46
+    prefill: 92
+    decode: 46
+
+router:
+  mode: least-loaded
+  knobs:
+    DYN_EVENT_PLANE: "zmq"
+    DYN_DISCOVERY_BACKEND: "kubernetes"
+    DYN_STORE_KV: "mem"
+    DYN_LOG: "info,dynamo_runtime::transports::event_plane::zmq_transport=debug,dynamo_llm::discovery::worker_monitor=debug,dynamo_runtime::component::client=debug"
+
+admission:
+  knobs:
+    DYN_TCP_WORKER_POOL_SIZE: "128"
+    DYN_TCP_WORK_QUEUE_SIZE: "5"
+    VLLM_NIXL_ABORT_REQUEST_TIMEOUT: "30"
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30"
+
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 5
+    prefix_prompt_length: 740
+    seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
+  # Shared E1/E2/E3 load profile.
+  rungs:
+    - name: ramp-up
+      concurrency: 100
+      duration_minutes: 1.5
+    - name: steady-1
+      concurrency: 300
+      duration_minutes: 5.0
+    - name: spike
+      concurrency: 500
+      duration_minutes: 1.5
+    - name: steady-2
+      concurrency: 300
+      duration_minutes: 5.0
+    - name: ramp-down
+      concurrency: 75
+      duration_minutes: 1.0
+  common:
+    request_timeout_seconds: 30
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never
+
+events:
+  - kind: WaitForModelReady
+    timeout: 1800
+  - kind: PodMemoryPoller
+    services: [Frontend, prefill, decode]
+    interval_s: 5
+  - kind: StartLoad
+    load_ref: ramp-up
+  - kind: WaitForLoadCompletion
+    name: ramp-up
+  - kind: StartLoad
+    load_ref: steady-1
+  - kind: WaitForLoadCompletion
+    name: steady-1
+  - kind: StartLoad
+    load_ref: spike
+  - kind: WaitForLoadCompletion
+    name: spike
+  - kind: StartLoad
+    load_ref: steady-2
+  - kind: WaitForLoadCompletion
+    name: steady-2
+  - kind: StartLoad
+    load_ref: ramp-down
+  - kind: WaitForLoadCompletion
+    name: ramp-down
+
+reports:
+  - PerWorkerLatencyReport
+  - ErrorBreakdownReport
+
+checks:
+  - kind: LoadApplied
+    load_name: steady-1
+    min_requests: 5000
+  - kind: WorkerPanics
+    services: [Frontend, prefill, decode]
+    acceptable: true
+  - kind: RestartCountIncreased
+    services: [Frontend, prefill, decode]
+    expect_min_increment: 0

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm3_nscale_15set.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm3_nscale_15set.yaml
@@ -85,7 +85,7 @@ load:
 events:
   - kind: WaitForModelReady
     timeout: 1800
-  - kind: PodMemoryPoller
+  - kind: ResourcePoller
     services: [Frontend, prefill, decode]
     interval_s: 5
   - kind: StartLoad

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm3_nscale_15set.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm3_nscale_15set.yaml
@@ -1,42 +1,43 @@
-# E1 Imbalance — Arm 5: 93 FE / KV + replica-sync (Recommended config)
+# E1 Imbalance — Arm 3 (NSCALE 15-set variant, LL best on cascade-test image)
 #
-# Both H1 and H2 mitigated. KV-aware routing + cross-FE state sync. The target config
-# we'd recommend for the production deployment. If imbalance flattens here vs Arm 4,
-# replica-sync was the missing piece. If still imbalanced, KV+sync alone isn't enough.
+# Memory-budget-aware downscale for nscale-dev CPU pool when aws-dev-02 is down.
+# 15 sets × 4 pods = 60 mocker pods × 6 GiB = ~360 GiB (~56% of nscale pool memory).
+# Trimmed rungs (8.5 min wall) so 3 serial arms fit a 1-hour window.
+#
+# Concurrency calibrated identically to arm1_nscale_15set so the cross-arm
+# comparison isolates routing-stack differences, not load.
 
 kind: router_memory
-name: e1_arm5_93fe_kv_sync
+name: e1_arm3_nscale_15set
 description: |
-  E1 Arm 5 (93 FE / KV + replica-sync): 93F+186P+93D mocker, KV routing with replica-sync.
-  Recommended config. H1 and H2 both mitigated. Target migration config.
+  E1 Arm 3 (LL best, cascade-test): 15F+30P+15D mocker, LL routing.
+  cascade-test image (Task #70/#75 quarantine fix). Isolates 1.1.1→1.2 stack delta vs arm1.
 
 labels:
   purpose: e1_imbalance_attribution
-  arm: arm5_93fe_kv_sync
-  router_mode: kv_recommended
+  arm: arm3_nscale_15set
+  router_mode: least_loaded
   deployment: disagg
   backend: mocker
   image_label: cascade-test
+  cluster: nscale-dev-cluster
 
 deployment:
   backend: mocker
   topology: disagg
   image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-cascade-test-ead461faa6-neelays
   replicas:
-    Frontend: 46
-    prefill: 92
-    decode: 46
+    Frontend: 15
+    prefill: 30
+    decode: 15
 
 router:
-  mode: kv
+  mode: least-loaded
   knobs:
-    # Recommended config — KV + replica-sync + load-aware (no prefix routing, no KV events)
-    DYN_ROUTER_USE_KV_EVENTS: "false"
-    DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT: "0.0"
-    DYN_ROUTER_PREFILL_LOAD_SCALE: "1.0"
-    DYN_ROUTER_QUEUE_THRESHOLD: "4.0"
-    DYN_ROUTER_QUEUE_POLICY: "fcfs"
-    DYN_ROUTER_REPLICA_SYNC: "true"   # <-- THE DIFF vs Arm 4
+    # Decode/prefill admission thresholds — active regardless of router mode
+    # (LL or KV). These exclude workers over saturation from the candidate set
+    # before LL picks the least-loaded among the survivors. Same values as arm5
+    # so the LL vs KV+sync comparison only differs in routing logic.
     DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
     DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
     DYN_EVENT_PLANE: "zmq"
@@ -57,27 +58,24 @@ load:
     num_prefix_prompts: 5
     prefix_prompt_length: 740
     seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
-  # Shared E1/E2/E3 load profile: ramp-up → steady-1 → spike → steady-2 → ramp-down.
-  # Mocker --speedup-ratio=5.0 (set in disagg.yaml template) means engine-side sim
-  # advances 5× faster than wall-clock; aiperf still drives load over wall-clock,
-  # so the visible effect is higher per-pod request throughput at the same target
-  # concurrency. Total wall ≈ 13.5 min per arm.
+  # Identical to arm1_nscale_15set / arm5_nscale_15set; load-equality is the
+  # whole point of the A/B/C comparison.
   rungs:
     - name: ramp-up
-      concurrency: 200
-      duration_minutes: 1.5
-    - name: steady-1
-      concurrency: 600  # Conservative pre-Stage-0 — revisit after saturation discovery
-      duration_minutes: 5.0
-    - name: spike
-      concurrency: 1200
-      duration_minutes: 1.5
-    - name: steady-2
-      concurrency: 600
-      duration_minutes: 5.0
-    - name: ramp-down
-      concurrency: 150
+      concurrency: 50
       duration_minutes: 1.0
+    - name: steady-1
+      concurrency: 120
+      duration_minutes: 3.0
+    - name: spike
+      concurrency: 240
+      duration_minutes: 1.0
+    - name: steady-2
+      concurrency: 120
+      duration_minutes: 3.0
+    - name: ramp-down
+      concurrency: 30
+      duration_minutes: 0.5
   common:
     request_timeout_seconds: 30
     streaming: true
@@ -118,7 +116,7 @@ reports:
 checks:
   - kind: LoadApplied
     load_name: steady-1
-    min_requests: 5000
+    min_requests: 500
   - kind: WorkerPanics
     services: [Frontend, prefill, decode]
     acceptable: true

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm3_nscale_15set.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm3_nscale_15set.yaml
@@ -11,7 +11,7 @@ kind: router_memory
 name: e1_arm3_nscale_15set
 description: |
   E1 Arm 3 (LL best, cascade-test): 15F+30P+15D mocker, LL routing.
-  cascade-test image (Task #70/#75 quarantine fix). Isolates 1.1.1→1.2 stack delta vs arm1.
+  cascade-test image (carries the worker-quarantine fix). Isolates 1.1.1→1.2 stack delta vs arm1.
 
 labels:
   purpose: e1_imbalance_attribution

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm4_93fe_kv_nosync.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm4_93fe_kv_nosync.yaml
@@ -86,7 +86,7 @@ load:
 events:
   - kind: WaitForModelReady
     timeout: 1800
-  - kind: PodMemoryPoller
+  - kind: ResourcePoller
     services: [Frontend, prefill, decode]
     interval_s: 5
   - kind: StartLoad

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm4_93fe_kv_nosync.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm4_93fe_kv_nosync.yaml
@@ -1,0 +1,126 @@
+# E1 Imbalance — Arm 4: 93 FE / KV no-sync (cascade-test image)
+#
+# H1 mitigated, H2 still present. Routing is now KV-aware (knows worker KV state),
+# but FEs each run their OWN copy of the KV router with no cross-FE sync. So 93 FEs
+# can still concurrently pick the "least-loaded" worker uncorrelatedly.
+#
+# Compared to Arm 3 (LL same topology): isolates the H1 contribution (KV-awareness).
+# Compared to Arm 5 (KV + sync): isolates replica-sync's contribution.
+
+kind: router_memory
+name: e1_arm4_93fe_kv_nosync
+description: |
+  E1 Arm 4 (93 FE / KV no-sync): 93F+186P+93D mocker, KV routing without replica-sync.
+  H1 mitigated; H2 still present. KV state per-FE, no cross-FE coordination.
+
+labels:
+  purpose: e1_imbalance_attribution
+  arm: arm4_93fe_kv_nosync
+  router_mode: kv_nosync
+  deployment: disagg
+  backend: mocker
+  image_label: cascade-test
+
+deployment:
+  backend: mocker
+  topology: disagg
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-cascade-test-ead461faa6-neelays
+  replicas:
+    Frontend: 46
+    prefill: 92
+    decode: 46
+
+router:
+  mode: kv
+  knobs:
+    # KV but NO replica-sync (H2 still present)
+    DYN_ROUTER_USE_KV_EVENTS: "false"
+    DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT: "0.0"
+    DYN_ROUTER_PREFILL_LOAD_SCALE: "1.0"
+    DYN_ROUTER_QUEUE_THRESHOLD: "4.0"
+    DYN_ROUTER_QUEUE_POLICY: "fcfs"
+    DYN_ROUTER_REPLICA_SYNC: "false"  # <-- THE DIFF vs Arm 5
+    DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
+    DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
+    DYN_EVENT_PLANE: "zmq"
+    DYN_DISCOVERY_BACKEND: "kubernetes"
+    DYN_STORE_KV: "mem"
+    DYN_LOG: "info,dynamo_runtime::transports::event_plane::zmq_transport=debug,dynamo_llm::discovery::worker_monitor=debug,dynamo_runtime::component::client=debug"
+
+admission:
+  knobs:
+    DYN_TCP_WORKER_POOL_SIZE: "128"
+    DYN_TCP_WORK_QUEUE_SIZE: "5"
+    VLLM_NIXL_ABORT_REQUEST_TIMEOUT: "30"
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30"
+
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 5
+    prefix_prompt_length: 740
+    seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
+  # Shared E1/E2/E3 load profile.
+  rungs:
+    - name: ramp-up
+      concurrency: 100
+      duration_minutes: 1.5
+    - name: steady-1
+      concurrency: 300
+      duration_minutes: 5.0
+    - name: spike
+      concurrency: 500
+      duration_minutes: 1.5
+    - name: steady-2
+      concurrency: 300
+      duration_minutes: 5.0
+    - name: ramp-down
+      concurrency: 75
+      duration_minutes: 1.0
+  common:
+    request_timeout_seconds: 30
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never
+
+events:
+  - kind: WaitForModelReady
+    timeout: 1800
+  - kind: PodMemoryPoller
+    services: [Frontend, prefill, decode]
+    interval_s: 5
+  - kind: StartLoad
+    load_ref: ramp-up
+  - kind: WaitForLoadCompletion
+    name: ramp-up
+  - kind: StartLoad
+    load_ref: steady-1
+  - kind: WaitForLoadCompletion
+    name: steady-1
+  - kind: StartLoad
+    load_ref: spike
+  - kind: WaitForLoadCompletion
+    name: spike
+  - kind: StartLoad
+    load_ref: steady-2
+  - kind: WaitForLoadCompletion
+    name: steady-2
+  - kind: StartLoad
+    load_ref: ramp-down
+  - kind: WaitForLoadCompletion
+    name: ramp-down
+
+reports:
+  - PerWorkerLatencyReport
+  - ErrorBreakdownReport
+
+checks:
+  - kind: LoadApplied
+    load_name: steady-1
+    min_requests: 5000
+  - kind: WorkerPanics
+    services: [Frontend, prefill, decode]
+    acceptable: true
+  - kind: RestartCountIncreased
+    services: [Frontend, prefill, decode]
+    expect_min_increment: 0

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm4_nscale_15set.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm4_nscale_15set.yaml
@@ -1,42 +1,48 @@
-# E1 Imbalance — Arm 5: 93 FE / KV + replica-sync (Recommended config)
+# E1 Imbalance — Arm 4 (NSCALE 15-set variant, KV no-sync)
 #
-# Both H1 and H2 mitigated. KV-aware routing + cross-FE state sync. The target config
-# we'd recommend for the production deployment. If imbalance flattens here vs Arm 4,
-# replica-sync was the missing piece. If still imbalanced, KV+sync alone isn't enough.
+# H1 mitigated, H2 still present. Routing is KV-aware (knows worker KV state),
+# but the 15 FEs each run their OWN copy of the KV router with no cross-FE sync.
+# So 15 FEs can still concurrently pick the "least-loaded" worker uncorrelatedly.
+#
+# Compared to arm3 (LL same topology): isolates the H1 contribution (KV-awareness).
+# Compared to arm5 (KV + sync): isolates replica-sync's contribution.
+#
+# Only differs from arm5 in: DYN_ROUTER_REPLICA_SYNC=false.
 
 kind: router_memory
-name: e1_arm5_93fe_kv_sync
+name: e1_arm4_nscale_15set
 description: |
-  E1 Arm 5 (93 FE / KV + replica-sync): 93F+186P+93D mocker, KV routing with replica-sync.
-  Recommended config. H1 and H2 both mitigated. Target migration config.
+  E1 Arm 4 (KV no-sync): 15F+30P+15D mocker, KV routing without replica-sync.
+  H1 mitigated, H2 still present.
 
 labels:
   purpose: e1_imbalance_attribution
-  arm: arm5_93fe_kv_sync
-  router_mode: kv_recommended
+  arm: arm4_nscale_15set
+  router_mode: kv_nosync
   deployment: disagg
   backend: mocker
   image_label: cascade-test
+  cluster: nscale-dev-cluster
 
 deployment:
   backend: mocker
   topology: disagg
   image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-cascade-test-ead461faa6-neelays
   replicas:
-    Frontend: 46
-    prefill: 92
-    decode: 46
+    Frontend: 15
+    prefill: 30
+    decode: 15
 
 router:
   mode: kv
   knobs:
-    # Recommended config — KV + replica-sync + load-aware (no prefix routing, no KV events)
+    # Same KV config as arm5 — only diff is REPLICA_SYNC=false.
     DYN_ROUTER_USE_KV_EVENTS: "false"
     DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT: "0.0"
     DYN_ROUTER_PREFILL_LOAD_SCALE: "1.0"
     DYN_ROUTER_QUEUE_THRESHOLD: "4.0"
     DYN_ROUTER_QUEUE_POLICY: "fcfs"
-    DYN_ROUTER_REPLICA_SYNC: "true"   # <-- THE DIFF vs Arm 4
+    DYN_ROUTER_REPLICA_SYNC: "false"   # <-- THE DIFF vs arm5
     DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
     DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
     DYN_EVENT_PLANE: "zmq"
@@ -57,27 +63,23 @@ load:
     num_prefix_prompts: 5
     prefix_prompt_length: 740
     seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
-  # Shared E1/E2/E3 load profile: ramp-up → steady-1 → spike → steady-2 → ramp-down.
-  # Mocker --speedup-ratio=5.0 (set in disagg.yaml template) means engine-side sim
-  # advances 5× faster than wall-clock; aiperf still drives load over wall-clock,
-  # so the visible effect is higher per-pod request throughput at the same target
-  # concurrency. Total wall ≈ 13.5 min per arm.
+  # Identical load profile to arm1/arm2/arm3/arm5.
   rungs:
     - name: ramp-up
-      concurrency: 200
-      duration_minutes: 1.5
-    - name: steady-1
-      concurrency: 600  # Conservative pre-Stage-0 — revisit after saturation discovery
-      duration_minutes: 5.0
-    - name: spike
-      concurrency: 1200
-      duration_minutes: 1.5
-    - name: steady-2
-      concurrency: 600
-      duration_minutes: 5.0
-    - name: ramp-down
-      concurrency: 150
+      concurrency: 50
       duration_minutes: 1.0
+    - name: steady-1
+      concurrency: 120
+      duration_minutes: 3.0
+    - name: spike
+      concurrency: 240
+      duration_minutes: 1.0
+    - name: steady-2
+      concurrency: 120
+      duration_minutes: 3.0
+    - name: ramp-down
+      concurrency: 30
+      duration_minutes: 0.5
   common:
     request_timeout_seconds: 30
     streaming: true
@@ -118,7 +120,7 @@ reports:
 checks:
   - kind: LoadApplied
     load_name: steady-1
-    min_requests: 5000
+    min_requests: 500
   - kind: WorkerPanics
     services: [Frontend, prefill, decode]
     acceptable: true

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm4_nscale_15set.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm4_nscale_15set.yaml
@@ -89,7 +89,7 @@ load:
 events:
   - kind: WaitForModelReady
     timeout: 1800
-  - kind: PodMemoryPoller
+  - kind: ResourcePoller
     services: [Frontend, prefill, decode]
     interval_s: 5
   - kind: StartLoad

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm5_93fe_kv_sync.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm5_93fe_kv_sync.yaml
@@ -1,0 +1,127 @@
+# E1 Imbalance — Arm 5: 93 FE / KV + replica-sync (Recommended config)
+#
+# Both H1 and H2 mitigated. KV-aware routing + cross-FE state sync. The target config
+# we'd recommend for the production deployment. If imbalance flattens here vs Arm 4,
+# replica-sync was the missing piece. If still imbalanced, KV+sync alone isn't enough.
+
+kind: router_memory
+name: e1_arm5_93fe_kv_sync
+description: |
+  E1 Arm 5 (93 FE / KV + replica-sync): 93F+186P+93D mocker, KV routing with replica-sync.
+  Recommended config. H1 and H2 both mitigated. Target migration config.
+
+labels:
+  purpose: e1_imbalance_attribution
+  arm: arm5_93fe_kv_sync
+  router_mode: kv_recommended
+  deployment: disagg
+  backend: mocker
+  image_label: cascade-test
+
+deployment:
+  backend: mocker
+  topology: disagg
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-cascade-test-ead461faa6-neelays
+  replicas:
+    Frontend: 46
+    prefill: 92
+    decode: 46
+
+router:
+  mode: kv
+  knobs:
+    # Recommended config — KV + replica-sync + load-aware (no prefix routing, no KV events)
+    DYN_ROUTER_USE_KV_EVENTS: "false"
+    DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT: "0.0"
+    DYN_ROUTER_PREFILL_LOAD_SCALE: "1.0"
+    DYN_ROUTER_QUEUE_THRESHOLD: "4.0"
+    DYN_ROUTER_QUEUE_POLICY: "fcfs"
+    DYN_ROUTER_REPLICA_SYNC: "true"   # <-- THE DIFF vs Arm 4
+    DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
+    DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
+    DYN_EVENT_PLANE: "zmq"
+    DYN_DISCOVERY_BACKEND: "kubernetes"
+    DYN_STORE_KV: "mem"
+    DYN_LOG: "info,dynamo_runtime::transports::event_plane::zmq_transport=debug,dynamo_llm::discovery::worker_monitor=debug,dynamo_runtime::component::client=debug"
+
+admission:
+  knobs:
+    DYN_TCP_WORKER_POOL_SIZE: "128"
+    DYN_TCP_WORK_QUEUE_SIZE: "5"
+    VLLM_NIXL_ABORT_REQUEST_TIMEOUT: "30"
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30"
+
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 5
+    prefix_prompt_length: 740
+    seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
+  # Shared E1/E2/E3 load profile: ramp-up → steady-1 → spike → steady-2 → ramp-down.
+  # Mocker --speedup-ratio=5.0 (set in disagg.yaml template) means engine-side sim
+  # advances 5× faster than wall-clock; aiperf still drives load over wall-clock,
+  # so the visible effect is higher per-pod request throughput at the same target
+  # concurrency. Total wall ≈ 13.5 min per arm.
+  rungs:
+    - name: ramp-up
+      concurrency: 100
+      duration_minutes: 1.5
+    - name: steady-1
+      concurrency: 300  # Conservative pre-Stage-0 — revisit after saturation discovery
+      duration_minutes: 5.0
+    - name: spike
+      concurrency: 500
+      duration_minutes: 1.5
+    - name: steady-2
+      concurrency: 300
+      duration_minutes: 5.0
+    - name: ramp-down
+      concurrency: 75
+      duration_minutes: 1.0
+  common:
+    request_timeout_seconds: 30
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never
+
+events:
+  - kind: WaitForModelReady
+    timeout: 1800
+  - kind: PodMemoryPoller
+    services: [Frontend, prefill, decode]
+    interval_s: 5
+  - kind: StartLoad
+    load_ref: ramp-up
+  - kind: WaitForLoadCompletion
+    name: ramp-up
+  - kind: StartLoad
+    load_ref: steady-1
+  - kind: WaitForLoadCompletion
+    name: steady-1
+  - kind: StartLoad
+    load_ref: spike
+  - kind: WaitForLoadCompletion
+    name: spike
+  - kind: StartLoad
+    load_ref: steady-2
+  - kind: WaitForLoadCompletion
+    name: steady-2
+  - kind: StartLoad
+    load_ref: ramp-down
+  - kind: WaitForLoadCompletion
+    name: ramp-down
+
+reports:
+  - PerWorkerLatencyReport
+  - ErrorBreakdownReport
+
+checks:
+  - kind: LoadApplied
+    load_name: steady-1
+    min_requests: 5000
+  - kind: WorkerPanics
+    services: [Frontend, prefill, decode]
+    acceptable: true
+  - kind: RestartCountIncreased
+    services: [Frontend, prefill, decode]
+    expect_min_increment: 0

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm5_93fe_kv_sync.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm5_93fe_kv_sync.yaml
@@ -87,7 +87,7 @@ load:
 events:
   - kind: WaitForModelReady
     timeout: 1800
-  - kind: PodMemoryPoller
+  - kind: ResourcePoller
     services: [Frontend, prefill, decode]
     interval_s: 5
   - kind: StartLoad

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm5_nscale_15set.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm5_nscale_15set.yaml
@@ -1,31 +1,35 @@
-# E1 Imbalance — Arm 5: 93 FE / KV + replica-sync (Recommended config)
+# E1 Imbalance — Arm 5 (NSCALE 15-set variant, Recommended: KV + replica-sync)
 #
-# Both H1 and H2 mitigated. KV-aware routing + cross-FE state sync. The target config
-# we'd recommend for the production deployment. If imbalance flattens here vs Arm 4,
-# replica-sync was the missing piece. If still imbalanced, KV+sync alone isn't enough.
+# Memory-budget-aware downscale for nscale-dev CPU pool when aws-dev-02 is down.
+# 15 sets × 4 pods = 60 mocker pods × 6 GiB = ~360 GiB (~56% of nscale pool memory).
+# Trimmed rungs (8.5 min wall) so 3 serial arms fit a 1-hour window.
+#
+# Concurrency calibrated identically to arm1_nscale_15set / arm3_nscale_15set so
+# the cross-arm comparison isolates routing-knob differences, not load.
 
 kind: router_memory
-name: e1_arm5_93fe_kv_sync
+name: e1_arm5_nscale_15set
 description: |
-  E1 Arm 5 (93 FE / KV + replica-sync): 93F+186P+93D mocker, KV routing with replica-sync.
-  Recommended config. H1 and H2 both mitigated. Target migration config.
+  E1 Arm 5 (Recommended, KV + replica-sync): 15F+30P+15D mocker.
+  Both H1 (KV-unaware LL) and H2 (cross-FE blind spot) mitigated.
 
 labels:
   purpose: e1_imbalance_attribution
-  arm: arm5_93fe_kv_sync
+  arm: arm5_nscale_15set
   router_mode: kv_recommended
   deployment: disagg
   backend: mocker
   image_label: cascade-test
+  cluster: nscale-dev-cluster
 
 deployment:
   backend: mocker
   topology: disagg
   image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-cascade-test-ead461faa6-neelays
   replicas:
-    Frontend: 46
-    prefill: 92
-    decode: 46
+    Frontend: 15
+    prefill: 30
+    decode: 15
 
 router:
   mode: kv
@@ -36,7 +40,7 @@ router:
     DYN_ROUTER_PREFILL_LOAD_SCALE: "1.0"
     DYN_ROUTER_QUEUE_THRESHOLD: "4.0"
     DYN_ROUTER_QUEUE_POLICY: "fcfs"
-    DYN_ROUTER_REPLICA_SYNC: "true"   # <-- THE DIFF vs Arm 4
+    DYN_ROUTER_REPLICA_SYNC: "true"
     DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
     DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
     DYN_EVENT_PLANE: "zmq"
@@ -57,27 +61,24 @@ load:
     num_prefix_prompts: 5
     prefix_prompt_length: 740
     seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
-  # Shared E1/E2/E3 load profile: ramp-up → steady-1 → spike → steady-2 → ramp-down.
-  # Mocker --speedup-ratio=5.0 (set in disagg.yaml template) means engine-side sim
-  # advances 5× faster than wall-clock; aiperf still drives load over wall-clock,
-  # so the visible effect is higher per-pod request throughput at the same target
-  # concurrency. Total wall ≈ 13.5 min per arm.
+  # Identical to arm1_nscale_15set / arm3_nscale_15set; load-equality is the
+  # whole point of the A/B/C comparison.
   rungs:
     - name: ramp-up
-      concurrency: 200
-      duration_minutes: 1.5
-    - name: steady-1
-      concurrency: 600  # Conservative pre-Stage-0 — revisit after saturation discovery
-      duration_minutes: 5.0
-    - name: spike
-      concurrency: 1200
-      duration_minutes: 1.5
-    - name: steady-2
-      concurrency: 600
-      duration_minutes: 5.0
-    - name: ramp-down
-      concurrency: 150
+      concurrency: 50
       duration_minutes: 1.0
+    - name: steady-1
+      concurrency: 120
+      duration_minutes: 3.0
+    - name: spike
+      concurrency: 240
+      duration_minutes: 1.0
+    - name: steady-2
+      concurrency: 120
+      duration_minutes: 3.0
+    - name: ramp-down
+      concurrency: 30
+      duration_minutes: 0.5
   common:
     request_timeout_seconds: 30
     streaming: true
@@ -118,7 +119,7 @@ reports:
 checks:
   - kind: LoadApplied
     load_name: steady-1
-    min_requests: 5000
+    min_requests: 500
   - kind: WorkerPanics
     services: [Frontend, prefill, decode]
     acceptable: true

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm5_nscale_15set.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm5_nscale_15set.yaml
@@ -88,7 +88,7 @@ load:
 events:
   - kind: WaitForModelReady
     timeout: 1800
-  - kind: PodMemoryPoller
+  - kind: ResourcePoller
     services: [Frontend, prefill, decode]
     interval_s: 5
   - kind: StartLoad

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm5_nscale_20set.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm5_nscale_20set.yaml
@@ -88,7 +88,7 @@ load:
 events:
   - kind: WaitForModelReady
     timeout: 1800
-  - kind: PodMemoryPoller
+  - kind: ResourcePoller
     services: [Frontend, prefill, decode]
     interval_s: 5
   - kind: StartLoad

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm5_nscale_20set.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm5_nscale_20set.yaml
@@ -1,42 +1,47 @@
-# E1 Imbalance — Arm 5: 93 FE / KV + replica-sync (Recommended config)
+# E1 Imbalance — Arm 5 (NSCALE 20-set variant)
 #
-# Both H1 and H2 mitigated. KV-aware routing + cross-FE state sync. The target config
-# we'd recommend for the production deployment. If imbalance flattens here vs Arm 4,
-# replica-sync was the missing piece. If still imbalanced, KV+sync alone isn't enough.
+# Memory-budget-aware downscale of e1_arm5_93fe_kv_sync.yaml for the nscale-dev
+# CPU pool (10 × 32 CPU × 64 GiB = ~320 CPU / 640 GiB total). At cpu=1 /
+# mem=6Gi requests per mocker pod, 20 sets = 80 mocker pods × 6 GiB = 480 GiB —
+# leaves ~25% memory headroom for the load Job + system pods.
+#
+# Concurrency rungs scaled by set ratio (20/46 ≈ 0.43) so per-set load matches
+# the 46-set baseline; that preserves the H1/H2 imbalance signal at smaller scale.
 
 kind: router_memory
-name: e1_arm5_93fe_kv_sync
+name: e1_arm5_nscale_20set
 description: |
-  E1 Arm 5 (93 FE / KV + replica-sync): 93F+186P+93D mocker, KV routing with replica-sync.
-  Recommended config. H1 and H2 both mitigated. Target migration config.
+  E1 Arm 5 (20 sets / KV + replica-sync), nscale variant.
+  20F+40P+20D mocker, KV routing with replica-sync, Recommended config.
+  Smaller-scale Arm 5 reproduction for CPU-pool clusters.
 
 labels:
   purpose: e1_imbalance_attribution
-  arm: arm5_93fe_kv_sync
+  arm: arm5_nscale_20set
   router_mode: kv_recommended
   deployment: disagg
   backend: mocker
   image_label: cascade-test
+  cluster: nscale-dev-cluster
 
 deployment:
   backend: mocker
   topology: disagg
   image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-cascade-test-ead461faa6-neelays
   replicas:
-    Frontend: 46
-    prefill: 92
-    decode: 46
+    Frontend: 20
+    prefill: 40
+    decode: 20
 
 router:
   mode: kv
   knobs:
-    # Recommended config — KV + replica-sync + load-aware (no prefix routing, no KV events)
     DYN_ROUTER_USE_KV_EVENTS: "false"
     DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT: "0.0"
     DYN_ROUTER_PREFILL_LOAD_SCALE: "1.0"
     DYN_ROUTER_QUEUE_THRESHOLD: "4.0"
     DYN_ROUTER_QUEUE_POLICY: "fcfs"
-    DYN_ROUTER_REPLICA_SYNC: "true"   # <-- THE DIFF vs Arm 4
+    DYN_ROUTER_REPLICA_SYNC: "true"
     DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
     DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
     DYN_EVENT_PLANE: "zmq"
@@ -57,26 +62,22 @@ load:
     num_prefix_prompts: 5
     prefix_prompt_length: 740
     seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
-  # Shared E1/E2/E3 load profile: ramp-up → steady-1 → spike → steady-2 → ramp-down.
-  # Mocker --speedup-ratio=5.0 (set in disagg.yaml template) means engine-side sim
-  # advances 5× faster than wall-clock; aiperf still drives load over wall-clock,
-  # so the visible effect is higher per-pod request throughput at the same target
-  # concurrency. Total wall ≈ 13.5 min per arm.
+  # Concurrency scaled to 20/46 of arm5 baseline so per-set load matches.
   rungs:
     - name: ramp-up
-      concurrency: 200
+      concurrency: 90
       duration_minutes: 1.5
     - name: steady-1
-      concurrency: 600  # Conservative pre-Stage-0 — revisit after saturation discovery
+      concurrency: 260
       duration_minutes: 5.0
     - name: spike
-      concurrency: 1200
+      concurrency: 520
       duration_minutes: 1.5
     - name: steady-2
-      concurrency: 600
+      concurrency: 260
       duration_minutes: 5.0
     - name: ramp-down
-      concurrency: 150
+      concurrency: 65
       duration_minutes: 1.0
   common:
     request_timeout_seconds: 30
@@ -118,7 +119,7 @@ reports:
 checks:
   - kind: LoadApplied
     load_name: steady-1
-    min_requests: 5000
+    min_requests: 500
   - kind: WorkerPanics
     services: [Frontend, prefill, decode]
     acceptable: true

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm6_nscale_15set.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm6_nscale_15set.yaml
@@ -1,0 +1,131 @@
+# E1 Imbalance — Arm 6 (NSCALE 15-set variant, LL deterministic tie-breaks)
+#
+# Identical to arm 3 (LL best, cascade-test) EXCEPT:
+#   1. Image bumped to 2462069d10 — contains the DYN_ROUTER_LL_DETERMINISTIC_TIES knob
+#      (091bbca57d) plus structured-field Selected-worker logs (baaada591c).
+#   2. DYN_ROUTER_LL_DETERMINISTIC_TIES=1 on Frontend — disables reservoir-sample
+#      tie-breaks, reverting LL to deterministic ordering (the v1.1.1 behavior).
+#
+# Hypothesis test: if arm 6 CV rebounds toward arm 1's 0.245 (vs arm 3's 0.015),
+# reservoir sampling IS the dominant mechanism behind the 16x CV drop.
+
+kind: router_memory
+name: e1_arm6_nscale_15set
+description: |
+  E1 Arm 6 (LL deterministic tie-breaks, cascade-test): 15F+30P+15D mocker, LL routing
+  with DYN_ROUTER_LL_DETERMINISTIC_TIES=1. Isolates reservoir-sample contribution
+  vs all other 1.2-stack changes between v1.1.1 and cascade-test.
+
+labels:
+  purpose: e1_imbalance_attribution
+  arm: arm6_nscale_15set
+  router_mode: least_loaded_deterministic_ties
+  deployment: disagg
+  backend: mocker
+  image_label: cascade-test-2462069d10
+  cluster: nscale-dev-cluster
+
+deployment:
+  backend: mocker
+  topology: disagg
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-cascade-test-2462069d10-neelays
+  replicas:
+    Frontend: 15
+    prefill: 30
+    decode: 15
+
+router:
+  mode: least-loaded
+  knobs:
+    # Same admission thresholds as arm 3 / arm 5 — over-threshold workers are
+    # filtered out before LL picks. Lets us cleanly isolate ONLY the
+    # reservoir-vs-deterministic tie-break delta.
+    DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
+    DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
+    # THE DIFF: revert reservoir-sample tie-breaks (PR #9516) to deterministic
+    # ordering. v1.1.1 had this behavior implicitly; cascade-test added the knob
+    # so we can toggle it on demand.
+    DYN_ROUTER_LL_DETERMINISTIC_TIES: "1"
+    DYN_EVENT_PLANE: "zmq"
+    DYN_DISCOVERY_BACKEND: "kubernetes"
+    DYN_STORE_KV: "mem"
+    DYN_LOG: "info,dynamo_runtime::transports::event_plane::zmq_transport=debug,dynamo_llm::discovery::worker_monitor=debug,dynamo_runtime::component::client=debug,dynamo_kv_router::scheduling::selector=info"
+
+admission:
+  knobs:
+    DYN_TCP_WORKER_POOL_SIZE: "128"
+    DYN_TCP_WORK_QUEUE_SIZE: "5"
+    VLLM_NIXL_ABORT_REQUEST_TIMEOUT: "30"
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30"
+
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 5
+    prefix_prompt_length: 740
+    seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
+  # Identical load profile to arm1/arm2/arm3/arm5 — load-equality is the whole
+  # point of the cross-arm comparison.
+  rungs:
+    - name: ramp-up
+      concurrency: 50
+      duration_minutes: 1.0
+    - name: steady-1
+      concurrency: 120
+      duration_minutes: 3.0
+    - name: spike
+      concurrency: 240
+      duration_minutes: 1.0
+    - name: steady-2
+      concurrency: 120
+      duration_minutes: 3.0
+    - name: ramp-down
+      concurrency: 30
+      duration_minutes: 0.5
+  common:
+    request_timeout_seconds: 30
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never
+
+events:
+  - kind: WaitForModelReady
+    timeout: 1800
+  - kind: PodMemoryPoller
+    services: [Frontend, prefill, decode]
+    interval_s: 5
+  - kind: StartLoad
+    load_ref: ramp-up
+  - kind: WaitForLoadCompletion
+    name: ramp-up
+  - kind: StartLoad
+    load_ref: steady-1
+  - kind: WaitForLoadCompletion
+    name: steady-1
+  - kind: StartLoad
+    load_ref: spike
+  - kind: WaitForLoadCompletion
+    name: spike
+  - kind: StartLoad
+    load_ref: steady-2
+  - kind: WaitForLoadCompletion
+    name: steady-2
+  - kind: StartLoad
+    load_ref: ramp-down
+  - kind: WaitForLoadCompletion
+    name: ramp-down
+
+reports:
+  - PerWorkerLatencyReport
+  - ErrorBreakdownReport
+
+checks:
+  - kind: LoadApplied
+    load_name: steady-1
+    min_requests: 500
+  - kind: WorkerPanics
+    services: [Frontend, prefill, decode]
+    acceptable: true
+  - kind: RestartCountIncreased
+    services: [Frontend, prefill, decode]
+    expect_min_increment: 0

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm6_nscale_15set.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_arm6_nscale_15set.yaml
@@ -91,7 +91,7 @@ load:
 events:
   - kind: WaitForModelReady
     timeout: 1800
-  - kind: PodMemoryPoller
+  - kind: ResourcePoller
     services: [Frontend, prefill, decode]
     interval_s: 5
   - kind: StartLoad

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_dryrun_5set_recommended.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_dryrun_5set_recommended.yaml
@@ -88,7 +88,7 @@ load:
 events:
   - kind: WaitForModelReady
     timeout: 900
-  - kind: PodMemoryPoller
+  - kind: ResourcePoller
     services: [Frontend, prefill, decode]
     interval_s: 5
   - kind: StartLoad

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_dryrun_5set_recommended.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_dryrun_5set_recommended.yaml
@@ -10,7 +10,7 @@
 # Purpose:
 #   1. Confirm 20-mocker-pod deployment lands clean on the cluster
 #   2. Confirm per-pod /metrics scrape returns valid data for every pod
-#   3. Confirm PodMemoryPoller writes per-pod TSV at 5s cadence
+#   3. Confirm ResourcePoller writes per-pod TSV at 5s cadence
 #   4. Confirm ZMQ events flow (FE active_decode_blocks gauge populated)
 #   5. Confirm aiperf load Job hits the FE service and gets non-zero throughput
 #   6. Confirm error breakdown report + per-worker latency report generate

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_dryrun_5set_recommended.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1_dryrun_5set_recommended.yaml
@@ -1,0 +1,117 @@
+# E1 Imbalance — dry-run at 5-set mocker scale (~12 min)
+#
+# Validates the framework + per-pod scrape + load drive + report pipeline END-TO-END
+# at a small but credible scale BEFORE booking the 93-set sanity-93 run.
+#
+# Topology:  5 FE + 10 prefill + 5 decode = 20 mocker pods. Single namespace.
+# Config:    Recommended (KV + replica-sync, kv-events off, scoring=0, load-scale=1.0).
+# Duration:  ~12 min total (2 min warmup at c=50, 5 min steady at c=200, ~5 min deploy/teardown).
+#
+# Purpose:
+#   1. Confirm 20-mocker-pod deployment lands clean on the cluster
+#   2. Confirm per-pod /metrics scrape returns valid data for every pod
+#   3. Confirm PodMemoryPoller writes per-pod TSV at 5s cadence
+#   4. Confirm ZMQ events flow (FE active_decode_blocks gauge populated)
+#   5. Confirm aiperf load Job hits the FE service and gets non-zero throughput
+#   6. Confirm error breakdown report + per-worker latency report generate
+#
+# Decision gate: if this passes cleanly, write the remaining 4 arms at 93-set scale
+# and launch the full E1. If it fails, fix the framework gap before scaling.
+
+kind: router_memory
+name: e1_dryrun_5set_recommended
+description: |
+  E1 imbalance dry-run at 5-set scale (5F+10P+5D mocker, Recommended config).
+  Framework + scrape + load + report pipeline end-to-end validation before 93-set.
+
+labels:
+  purpose: e1_dryrun
+  arm: dryrun
+  router_mode: kv_recommended
+  deployment: disagg
+  backend: mocker
+
+deployment:
+  backend: mocker
+  topology: disagg
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-cascade-test-ead461faa6-neelays
+  replicas:
+    Frontend: 5
+    prefill: 10
+    decode: 5
+
+router:
+  mode: kv
+  knobs:
+    # Recommended config — replica-sync ON, kv-events OFF, scoring 0 + 1.0
+    DYN_ROUTER_USE_KV_EVENTS: "false"
+    DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT: "0.0"
+    DYN_ROUTER_PREFILL_LOAD_SCALE: "1.0"
+    DYN_ROUTER_QUEUE_THRESHOLD: "4.0"
+    DYN_ROUTER_QUEUE_POLICY: "fcfs"
+    DYN_ROUTER_REPLICA_SYNC: "true"
+    DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
+    DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
+    DYN_EVENT_PLANE: "zmq"
+    DYN_DISCOVERY_BACKEND: "kubernetes"
+    DYN_STORE_KV: "mem"
+    # Tactical DEBUG so we can verify the same H3/H4 signals as Run 1 sanity
+    DYN_LOG: "info,dynamo_runtime::transports::event_plane::zmq_transport=debug,dynamo_llm::discovery::worker_monitor=debug,dynamo_runtime::component::client=debug"
+
+admission:
+  knobs:
+    DYN_TCP_WORKER_POOL_SIZE: "128"
+    DYN_TCP_WORK_QUEUE_SIZE: "5"
+    VLLM_NIXL_ABORT_REQUEST_TIMEOUT: "30"
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30"
+
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 5
+    prefix_prompt_length: 740
+    # Production 30-bucket distribution (sum=100; see sanity_run1 for normalization notes).
+    seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
+  rungs:
+    - name: warmup
+      concurrency: 50
+      duration_minutes: 2.0
+    - name: steady
+      concurrency: 200
+      duration_minutes: 5.0
+  common:
+    request_timeout_seconds: 30
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never
+
+events:
+  - kind: WaitForModelReady
+    timeout: 900
+  - kind: PodMemoryPoller
+    services: [Frontend, prefill, decode]
+    interval_s: 5
+  - kind: StartLoad
+    load_ref: warmup
+  - kind: WaitForLoadCompletion
+    name: warmup
+  - kind: StartLoad
+    load_ref: steady
+  - kind: WaitForLoadCompletion
+    name: steady
+
+reports:
+  - PerWorkerLatencyReport
+  - ErrorBreakdownReport
+
+# Minimal live checks. Per-arm imbalance analysis is post-hoc.
+checks:
+  - kind: LoadApplied
+    load_name: steady
+    min_requests: 500
+  - kind: WorkerPanics
+    services: [Frontend, prefill, decode]
+    acceptable: true
+  - kind: RestartCountIncreased
+    services: [Frontend, prefill, decode]
+    expect_min_increment: 0

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1rg_arm1_baseline_n3.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1rg_arm1_baseline_n3.yaml
@@ -1,0 +1,90 @@
+# E1 real-GPU Arm 1 (Baseline): v1.1.1, LL deterministic ties, N=3 (3FE+6P+3D, TP=2).
+# v1.1.1 LL ties are deterministic by default (reservoir sampling #9516 is a 1.2 addition).
+# Engine config from handoff (template vllm/disagg_qwen3_30b_unit_e1):
+#   prefill TP=2 max-num-seqs=64 gpu-mem=0.5; decode TP=2 max-num-seqs=256
+#   max-num-batched-tokens=256 gpu-mem=0.5; max-model-len=10240.
+# steady concurrency is 138 — filled by run-e1-realgpu.sh from the sweep.
+
+kind: router_memory
+name: e1rg_arm1_baseline
+
+labels:
+  purpose: e1_imbalance_real_gpu
+  arm: e1rg_arm1_baseline
+  router_mode: least_loaded
+  deployment: disagg
+  backend: vllm
+  cluster: aws-dev-02
+
+deployment:
+  backend: vllm
+  topology: disagg
+  units: 3
+  template: disagg_qwen3_30b_unit_e1
+  image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1
+  model_cache_pvc: shared-model-cache
+  log_pvc: dynamo-ft-logs
+
+router:
+  mode: least-loaded
+  knobs:
+    DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
+    DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
+
+admission:
+  knobs:
+    DYN_TCP_WORKER_POOL_SIZE: "128"
+    DYN_TCP_WORK_QUEUE_SIZE: "5"
+    VLLM_NIXL_ABORT_REQUEST_TIMEOUT: "30"
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30"
+
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 5
+    prefix_prompt_length: 740
+    seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
+  # C_TARGET placeholder — the run-e1-realgpu sequencer rewrites the steady
+  # concurrency to 0.8 x C_max discovered by the Stage-0 aiperf sweep.
+  rungs:
+    - name: warmup
+      concurrency: 16
+      duration_minutes: 2.0
+    - name: steady
+      concurrency: 46
+      duration_minutes: 15.0
+  common:
+    request_timeout_seconds: 30
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never
+
+events:
+  - kind: WaitForModelReady
+    timeout: 2400
+  - kind: PodMemoryPoller
+    services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
+    interval_s: 5
+  - kind: PodMemoryPoller2
+    services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
+    interval_s: 5
+  - kind: StartLoad
+    load_ref: warmup
+  - kind: WaitForLoadCompletion
+    name: warmup
+  - kind: StartLoad
+    load_ref: steady
+  - kind: WaitForLoadCompletion
+    name: steady
+
+reports:
+  - PerWorkerLatencyReport
+  - ErrorBreakdownReport
+
+checks:
+  - kind: LoadApplied
+    load_name: steady
+    min_requests: 2000
+  - kind: WorkerPanics
+    services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
+    acceptable: true

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1rg_arm1_baseline_n3.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1rg_arm1_baseline_n3.yaml
@@ -65,9 +65,6 @@ events:
   - kind: ResourcePoller
     services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
     interval_s: 5
-  - kind: ResourcePoller
-    services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
-    interval_s: 5
   - kind: StartLoad
     load_ref: warmup
   - kind: WaitForLoadCompletion

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1rg_arm1_baseline_n3.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1rg_arm1_baseline_n3.yaml
@@ -62,10 +62,10 @@ load:
 events:
   - kind: WaitForModelReady
     timeout: 2400
-  - kind: PodMemoryPoller
+  - kind: ResourcePoller
     services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
     interval_s: 5
-  - kind: PodMemoryPoller2
+  - kind: ResourcePoller
     services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
     interval_s: 5
   - kind: StartLoad

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1rg_arm2_bestll_n3.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1rg_arm2_bestll_n3.yaml
@@ -65,9 +65,6 @@ events:
   - kind: ResourcePoller
     services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
     interval_s: 5
-  - kind: ResourcePoller
-    services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
-    interval_s: 5
   - kind: StartLoad
     load_ref: warmup
   - kind: WaitForLoadCompletion

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1rg_arm2_bestll_n3.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1rg_arm2_bestll_n3.yaml
@@ -62,10 +62,10 @@ load:
 events:
   - kind: WaitForModelReady
     timeout: 2400
-  - kind: PodMemoryPoller
+  - kind: ResourcePoller
     services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
     interval_s: 5
-  - kind: PodMemoryPoller2
+  - kind: ResourcePoller
     services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
     interval_s: 5
   - kind: StartLoad

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1rg_arm2_bestll_n3.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1rg_arm2_bestll_n3.yaml
@@ -1,0 +1,90 @@
+# E1 real-GPU Arm 2 (Best-LL): 1.2 (a5c93b3331), LL reservoir ties, N=3.
+# 1.2 reservoir-sample tie-breaks are default; no env needed.
+# Engine config from handoff (template vllm/disagg_qwen3_30b_unit_e1):
+#   prefill TP=2 max-num-seqs=64 gpu-mem=0.5; decode TP=2 max-num-seqs=256
+#   max-num-batched-tokens=256 gpu-mem=0.5; max-model-len=10240.
+# steady concurrency is 138 — filled by run-e1-realgpu.sh from the sweep.
+
+kind: router_memory
+name: e1rg_arm2_bestll
+
+labels:
+  purpose: e1_imbalance_real_gpu
+  arm: e1rg_arm2_bestll
+  router_mode: least_loaded
+  deployment: disagg
+  backend: vllm
+  cluster: aws-dev-02
+
+deployment:
+  backend: vllm
+  topology: disagg
+  units: 3
+  template: disagg_qwen3_30b_unit_e1
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-mocker-prefill-pinning-a5c93b3331-neelays
+  model_cache_pvc: shared-model-cache
+  log_pvc: dynamo-ft-logs
+
+router:
+  mode: least-loaded
+  knobs:
+    DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
+    DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
+
+admission:
+  knobs:
+    DYN_TCP_WORKER_POOL_SIZE: "128"
+    DYN_TCP_WORK_QUEUE_SIZE: "5"
+    VLLM_NIXL_ABORT_REQUEST_TIMEOUT: "30"
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30"
+
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 5
+    prefix_prompt_length: 740
+    seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
+  # C_TARGET placeholder — the run-e1-realgpu sequencer rewrites the steady
+  # concurrency to 0.8 x C_max discovered by the Stage-0 aiperf sweep.
+  rungs:
+    - name: warmup
+      concurrency: 16
+      duration_minutes: 2.0
+    - name: steady
+      concurrency: 46
+      duration_minutes: 15.0
+  common:
+    request_timeout_seconds: 30
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never
+
+events:
+  - kind: WaitForModelReady
+    timeout: 2400
+  - kind: PodMemoryPoller
+    services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
+    interval_s: 5
+  - kind: PodMemoryPoller2
+    services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
+    interval_s: 5
+  - kind: StartLoad
+    load_ref: warmup
+  - kind: WaitForLoadCompletion
+    name: warmup
+  - kind: StartLoad
+    load_ref: steady
+  - kind: WaitForLoadCompletion
+    name: steady
+
+reports:
+  - PerWorkerLatencyReport
+  - ErrorBreakdownReport
+
+checks:
+  - kind: LoadApplied
+    load_name: steady
+    min_requests: 2000
+  - kind: WorkerPanics
+    services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
+    acceptable: true

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1rg_arm3_recommended_n3.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1rg_arm3_recommended_n3.yaml
@@ -71,9 +71,6 @@ events:
   - kind: ResourcePoller
     services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
     interval_s: 5
-  - kind: ResourcePoller
-    services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
-    interval_s: 5
   - kind: StartLoad
     load_ref: warmup
   - kind: WaitForLoadCompletion

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1rg_arm3_recommended_n3.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1rg_arm3_recommended_n3.yaml
@@ -1,0 +1,96 @@
+# E1 real-GPU Arm 3 (Recommended): 1.2 (a5c93b3331), KV + replica-sync, N=3.
+# Recommended config: KV-aware + replica-sync, leak knobs zeroed.
+# Engine config from handoff (template vllm/disagg_qwen3_30b_unit_e1):
+#   prefill TP=2 max-num-seqs=64 gpu-mem=0.5; decode TP=2 max-num-seqs=256
+#   max-num-batched-tokens=256 gpu-mem=0.5; max-model-len=10240.
+# steady concurrency is 138 — filled by run-e1-realgpu.sh from the sweep.
+
+kind: router_memory
+name: e1rg_arm3_recommended
+
+labels:
+  purpose: e1_imbalance_real_gpu
+  arm: e1rg_arm3_recommended
+  router_mode: kv
+  deployment: disagg
+  backend: vllm
+  cluster: aws-dev-02
+
+deployment:
+  backend: vllm
+  topology: disagg
+  units: 3
+  template: disagg_qwen3_30b_unit_e1
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-mocker-prefill-pinning-a5c93b3331-neelays
+  model_cache_pvc: shared-model-cache
+  log_pvc: dynamo-ft-logs
+
+router:
+  mode: kv
+  knobs:
+    DYN_ROUTER_USE_KV_EVENTS: "false"
+    DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT: "0.0"
+    DYN_ROUTER_PREFILL_LOAD_SCALE: "1.0"
+    DYN_ROUTER_QUEUE_THRESHOLD: "4.0"
+    DYN_ROUTER_QUEUE_POLICY: "fcfs"
+    DYN_ROUTER_REPLICA_SYNC: "true"
+    DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
+    DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
+
+admission:
+  knobs:
+    DYN_TCP_WORKER_POOL_SIZE: "128"
+    DYN_TCP_WORK_QUEUE_SIZE: "5"
+    VLLM_NIXL_ABORT_REQUEST_TIMEOUT: "30"
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30"
+
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 5
+    prefix_prompt_length: 740
+    seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
+  # C_TARGET placeholder — the run-e1-realgpu sequencer rewrites the steady
+  # concurrency to 0.8 x C_max discovered by the Stage-0 aiperf sweep.
+  rungs:
+    - name: warmup
+      concurrency: 16
+      duration_minutes: 2.0
+    - name: steady
+      concurrency: 46
+      duration_minutes: 15.0
+  common:
+    request_timeout_seconds: 30
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never
+
+events:
+  - kind: WaitForModelReady
+    timeout: 2400
+  - kind: PodMemoryPoller
+    services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
+    interval_s: 5
+  - kind: PodMemoryPoller2
+    services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
+    interval_s: 5
+  - kind: StartLoad
+    load_ref: warmup
+  - kind: WaitForLoadCompletion
+    name: warmup
+  - kind: StartLoad
+    load_ref: steady
+  - kind: WaitForLoadCompletion
+    name: steady
+
+reports:
+  - PerWorkerLatencyReport
+  - ErrorBreakdownReport
+
+checks:
+  - kind: LoadApplied
+    load_name: steady
+    min_requests: 2000
+  - kind: WorkerPanics
+    services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
+    acceptable: true

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1rg_arm3_recommended_n3.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1rg_arm3_recommended_n3.yaml
@@ -68,10 +68,10 @@ load:
 events:
   - kind: WaitForModelReady
     timeout: 2400
-  - kind: PodMemoryPoller
+  - kind: ResourcePoller
     services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
     interval_s: 5
-  - kind: PodMemoryPoller2
+  - kind: ResourcePoller
     services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
     interval_s: 5
   - kind: StartLoad

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1rg_sweep_1fe.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e1rg_sweep_1fe.yaml
@@ -1,0 +1,70 @@
+# E1 real-GPU Stage-0 saturation-discovery deployment (single FE).
+#
+# Same Best-LL 1.2 config as e1rg_arm2_bestll_n3.yaml (image
+# release-1.2.0-mocker-prefill-pinning-a5c93b3331-neelays, least-loaded,
+# 0.85 thresholds, the admission knobs) EXCEPT the replica shape is a
+# single Frontend over the N=3 worker pool (6 prefill + 3 decode). One FE
+# is what we sweep against to find per-FE C_max; the arms then run 3 FE,
+# so arm-level total concurrency = 3 x (0.8 x C_max).
+#
+# This scenario is consumed by test_saturation_discovery.py via
+# --sat-deploy-scenario e1rg_sweep_1fe. The sweep supplies its OWN load
+# (aiperf --search-space), so the load block here is a trivial placeholder
+# that the sweep ignores. It exists only to satisfy the schema and is
+# never driven (no events reference it).
+
+kind: router_memory
+name: e1rg_sweep_1fe
+
+labels:
+  purpose: e1_imbalance_real_gpu_sweep
+  arm: e1rg_sweep_1fe
+  router_mode: least_loaded
+  deployment: disagg
+  backend: vllm
+  cluster: aws-dev-02
+
+deployment:
+  backend: vllm
+  topology: disagg
+  template: disagg_qwen3_30b_unit_e1
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-mocker-prefill-pinning-a5c93b3331-neelays
+  model_cache_pvc: shared-model-cache
+  log_pvc: dynamo-ft-logs
+  # Single FE over the N=3 worker pool. Exact service names come from the
+  # template (Frontend / VllmPrefillWorker / VllmDecodeWorker).
+  replicas:
+    Frontend: 1
+    VllmPrefillWorker: 6
+    VllmDecodeWorker: 3
+
+router:
+  mode: least-loaded
+  knobs:
+    DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
+    DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
+
+admission:
+  knobs:
+    DYN_TCP_WORKER_POOL_SIZE: "128"
+    DYN_TCP_WORK_QUEUE_SIZE: "5"
+    VLLM_NIXL_ABORT_REQUEST_TIMEOUT: "30"
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30"
+
+# Trivial placeholder load. The saturation sweep ignores this and drives
+# its own aiperf --search-space load; no events reference these rungs.
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 5
+    prefix_prompt_length: 740
+    seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
+  rungs:
+    - name: unused_sweep_supplies_own_load
+      concurrency: 16
+      duration_minutes: 1.0
+  common:
+    request_timeout_seconds: 30
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_arm1_nscale_15set.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_arm1_nscale_15set.yaml
@@ -1,7 +1,7 @@
 # E2 Memory Leak — Arm 1 (v1.1.1 KV-default) — NSCALE 15-set
 #
-# Reproduces the production FE memory leak (~28.6 MB/min documented in cascade
-# RCA) on the deployed-today image with KV-aware routing at default knobs:
+# Exercises a steady FE memory-growth path (~28.6 MB/min) on the v1.1.1 image
+# with KV-aware routing at default knobs:
 # KV events ON, overlap-score-credit=1.0, prefill-load-scale=1.0.
 #
 # Same units + same load + same seq_dist as the E1 imbalance arms (15F+30P+15D,
@@ -17,7 +17,7 @@ kind: router_memory
 name: e2_arm1_nscale_15set
 description: |
   E2 Arm 1 (v1.1.1 KV-default): 15F+30P+15D mocker, KV routing, default leak knobs
-  (KV events ON, overlap=1.0, prefill-load=1.0). Reproduces the prod FE memory leak.
+  (KV events ON, overlap=1.0, prefill-load=1.0). Exercises a steady FE memory-growth path.
 
 labels:
   purpose: e2_memory_leak

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_arm1_nscale_15set.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_arm1_nscale_15set.yaml
@@ -11,7 +11,7 @@
 # short for a clean least-squares MB/min fit.
 #
 # Headline metric: least-squares slope of mean per-FE RSS (MB/min) over the
-# steady-leak rung. Collected by PodMemoryPoller @ 5s on all 15 FE pods.
+# steady-leak rung. Collected by ResourcePoller @ 5s on all 15 FE pods.
 
 kind: router_memory
 name: e2_arm1_nscale_15set

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_arm1_nscale_15set.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_arm1_nscale_15set.yaml
@@ -90,7 +90,7 @@ load:
 events:
   - kind: WaitForModelReady
     timeout: 1800
-  - kind: PodMemoryPoller
+  - kind: ResourcePoller
     services: [Frontend, prefill, decode]
     interval_s: 5
   - kind: StartLoad

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_arm1_nscale_15set.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_arm1_nscale_15set.yaml
@@ -1,42 +1,54 @@
-# E1 Imbalance — Arm 5: 93 FE / KV + replica-sync (Recommended config)
+# E2 Memory Leak — Arm 1 (v1.1.1 KV-default) — NSCALE 15-set
 #
-# Both H1 and H2 mitigated. KV-aware routing + cross-FE state sync. The target config
-# we'd recommend for the production deployment. If imbalance flattens here vs Arm 4,
-# replica-sync was the missing piece. If still imbalanced, KV+sync alone isn't enough.
+# Reproduces the production FE memory leak (~28.6 MB/min documented in cascade
+# RCA) on the deployed-today image with KV-aware routing at default knobs:
+# KV events ON, overlap-score-credit=1.0, prefill-load-scale=1.0.
+#
+# Same units + same load + same seq_dist as the E1 imbalance arms (15F+30P+15D,
+# partial_prefix, c=120 steady) so the memory comparison is apples-to-apples with
+# the routing-quality comparison. The ONLY E2-specific change vs E1 is an extended
+# 30-min steady window (the slope-measurement phase) — an 8.5-min E1 replay is too
+# short for a clean least-squares MB/min fit.
+#
+# Headline metric: least-squares slope of mean per-FE RSS (MB/min) over the
+# steady-leak rung. Collected by PodMemoryPoller @ 5s on all 15 FE pods.
 
 kind: router_memory
-name: e1_arm5_93fe_kv_sync
+name: e2_arm1_nscale_15set
 description: |
-  E1 Arm 5 (93 FE / KV + replica-sync): 93F+186P+93D mocker, KV routing with replica-sync.
-  Recommended config. H1 and H2 both mitigated. Target migration config.
+  E2 Arm 1 (v1.1.1 KV-default): 15F+30P+15D mocker, KV routing, default leak knobs
+  (KV events ON, overlap=1.0, prefill-load=1.0). Reproduces the prod FE memory leak.
 
 labels:
-  purpose: e1_imbalance_attribution
-  arm: arm5_93fe_kv_sync
-  router_mode: kv_recommended
+  purpose: e2_memory_leak
+  arm: arm1_v111_kv_default
+  router_mode: kv_default
   deployment: disagg
   backend: mocker
-  image_label: cascade-test
+  image_label: v1.1.1
+  cluster: nscale-dev-cluster
 
 deployment:
   backend: mocker
   topology: disagg
-  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-cascade-test-ead461faa6-neelays
+  image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1
   replicas:
-    Frontend: 46
-    prefill: 92
-    decode: 46
+    Frontend: 15
+    prefill: 30
+    decode: 15
 
 router:
   mode: kv
   knobs:
-    # Recommended config — KV + replica-sync + load-aware (no prefix routing, no KV events)
-    DYN_ROUTER_USE_KV_EVENTS: "false"
-    DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT: "0.0"
+    # KV-default: all leak knobs at their v1.1.1 defaults. Set explicitly for
+    # reproducibility; v1.1.1 ignores any env it doesn't recognize and falls back
+    # to the same default value, so this is safe.
+    DYN_ROUTER_USE_KV_EVENTS: "true"
+    DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT: "1.0"
     DYN_ROUTER_PREFILL_LOAD_SCALE: "1.0"
     DYN_ROUTER_QUEUE_THRESHOLD: "4.0"
     DYN_ROUTER_QUEUE_POLICY: "fcfs"
-    DYN_ROUTER_REPLICA_SYNC: "true"   # <-- THE DIFF vs Arm 4
+    # No replica-sync in the default arm.
     DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
     DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
     DYN_EVENT_PLANE: "zmq"
@@ -57,27 +69,18 @@ load:
     num_prefix_prompts: 5
     prefix_prompt_length: 740
     seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
-  # Shared E1/E2/E3 load profile: ramp-up → steady-1 → spike → steady-2 → ramp-down.
-  # Mocker --speedup-ratio=5.0 (set in disagg.yaml template) means engine-side sim
-  # advances 5× faster than wall-clock; aiperf still drives load over wall-clock,
-  # so the visible effect is higher per-pod request throughput at the same target
-  # concurrency. Total wall ≈ 13.5 min per arm.
+  # Same seq_dist + same c=120 steady as E1. The single long steady-leak rung is
+  # the measurement window; no spike (the leak is event-driven, not load-spike-driven).
   rungs:
     - name: ramp-up
-      concurrency: 200
-      duration_minutes: 1.5
-    - name: steady-1
-      concurrency: 600  # Conservative pre-Stage-0 — revisit after saturation discovery
-      duration_minutes: 5.0
-    - name: spike
-      concurrency: 1200
-      duration_minutes: 1.5
-    - name: steady-2
-      concurrency: 600
-      duration_minutes: 5.0
-    - name: ramp-down
-      concurrency: 150
+      concurrency: 50
       duration_minutes: 1.0
+    - name: steady-leak
+      concurrency: 120
+      duration_minutes: 30.0
+    - name: ramp-down
+      concurrency: 30
+      duration_minutes: 0.5
   common:
     request_timeout_seconds: 30
     streaming: true
@@ -95,17 +98,9 @@ events:
   - kind: WaitForLoadCompletion
     name: ramp-up
   - kind: StartLoad
-    load_ref: steady-1
+    load_ref: steady-leak
   - kind: WaitForLoadCompletion
-    name: steady-1
-  - kind: StartLoad
-    load_ref: spike
-  - kind: WaitForLoadCompletion
-    name: spike
-  - kind: StartLoad
-    load_ref: steady-2
-  - kind: WaitForLoadCompletion
-    name: steady-2
+    name: steady-leak
   - kind: StartLoad
     load_ref: ramp-down
   - kind: WaitForLoadCompletion
@@ -117,7 +112,7 @@ reports:
 
 checks:
   - kind: LoadApplied
-    load_name: steady-1
+    load_name: steady-leak
     min_requests: 5000
   - kind: WorkerPanics
     services: [Frontend, prefill, decode]

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_arm2_nscale_15set.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_arm2_nscale_15set.yaml
@@ -1,42 +1,51 @@
-# E1 Imbalance — Arm 5: 93 FE / KV + replica-sync (Recommended config)
+# E2 Memory Leak — Arm 2 (1.2 KV-default) — NSCALE 15-set
 #
-# Both H1 and H2 mitigated. KV-aware routing + cross-FE state sync. The target config
-# we'd recommend for the production deployment. If imbalance flattens here vs Arm 4,
-# replica-sync was the missing piece. If still imbalanced, KV+sync alone isn't enough.
+# Same default leak knobs as Arm 1 (KV events ON, overlap=1.0, prefill-load=1.0)
+# but on the 1.2 candidate image (mocker-prefill-pinning a5c93b3331). Checks
+# whether the 1.2 stack fixed the leak incidentally. The 2026-05-26 6-arm matrix
+# says it did NOT — 1.2 KV+prefix was +44.58 MB/min, ~5x WORSE than v1.1.1's
+# +9.15. This arm is the one to watch.
+#
+# Same units + load + seq_dist as Arm 1; only the image differs vs Arm 1, and
+# only the router knobs differ vs Arm 3. arm1->arm2 isolates the version delta;
+# arm2->arm3 isolates the Recommended-config fix.
 
 kind: router_memory
-name: e1_arm5_93fe_kv_sync
+name: e2_arm2_nscale_15set
 description: |
-  E1 Arm 5 (93 FE / KV + replica-sync): 93F+186P+93D mocker, KV routing with replica-sync.
-  Recommended config. H1 and H2 both mitigated. Target migration config.
+  E2 Arm 2 (1.2 KV-default): 15F+30P+15D mocker, KV routing, default leak knobs
+  (KV events ON, overlap=1.0, prefill-load=1.0). Checks whether the 1.2 stack fixed the leak incidentally (5/26 matrix says it did NOT — 1.2 KV+prefix was +44.58 MB/min, worse).
 
 labels:
-  purpose: e1_imbalance_attribution
-  arm: arm5_93fe_kv_sync
-  router_mode: kv_recommended
+  purpose: e2_memory_leak
+  arm: arm2_12_kv_default
+  router_mode: kv_default
   deployment: disagg
   backend: mocker
-  image_label: cascade-test
+  image_label: mocker-prefill-pinning-a5c93b3331
+  cluster: nscale-dev-cluster
 
 deployment:
   backend: mocker
   topology: disagg
-  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-cascade-test-ead461faa6-neelays
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-mocker-prefill-pinning-a5c93b3331-neelays
   replicas:
-    Frontend: 46
-    prefill: 92
-    decode: 46
+    Frontend: 15
+    prefill: 30
+    decode: 15
 
 router:
   mode: kv
   knobs:
-    # Recommended config — KV + replica-sync + load-aware (no prefix routing, no KV events)
-    DYN_ROUTER_USE_KV_EVENTS: "false"
-    DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT: "0.0"
+    # KV-default: all leak knobs at their v1.1.1 defaults. Set explicitly for
+    # reproducibility; v1.1.1 ignores any env it doesn't recognize and falls back
+    # to the same default value, so this is safe.
+    DYN_ROUTER_USE_KV_EVENTS: "true"
+    DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT: "1.0"
     DYN_ROUTER_PREFILL_LOAD_SCALE: "1.0"
     DYN_ROUTER_QUEUE_THRESHOLD: "4.0"
     DYN_ROUTER_QUEUE_POLICY: "fcfs"
-    DYN_ROUTER_REPLICA_SYNC: "true"   # <-- THE DIFF vs Arm 4
+    # No replica-sync in the default arm.
     DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
     DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
     DYN_EVENT_PLANE: "zmq"
@@ -57,27 +66,18 @@ load:
     num_prefix_prompts: 5
     prefix_prompt_length: 740
     seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
-  # Shared E1/E2/E3 load profile: ramp-up → steady-1 → spike → steady-2 → ramp-down.
-  # Mocker --speedup-ratio=5.0 (set in disagg.yaml template) means engine-side sim
-  # advances 5× faster than wall-clock; aiperf still drives load over wall-clock,
-  # so the visible effect is higher per-pod request throughput at the same target
-  # concurrency. Total wall ≈ 13.5 min per arm.
+  # Same seq_dist + same c=120 steady as E1. The single long steady-leak rung is
+  # the measurement window; no spike (the leak is event-driven, not load-spike-driven).
   rungs:
     - name: ramp-up
-      concurrency: 200
-      duration_minutes: 1.5
-    - name: steady-1
-      concurrency: 600  # Conservative pre-Stage-0 — revisit after saturation discovery
-      duration_minutes: 5.0
-    - name: spike
-      concurrency: 1200
-      duration_minutes: 1.5
-    - name: steady-2
-      concurrency: 600
-      duration_minutes: 5.0
-    - name: ramp-down
-      concurrency: 150
+      concurrency: 50
       duration_minutes: 1.0
+    - name: steady-leak
+      concurrency: 120
+      duration_minutes: 30.0
+    - name: ramp-down
+      concurrency: 30
+      duration_minutes: 0.5
   common:
     request_timeout_seconds: 30
     streaming: true
@@ -95,17 +95,9 @@ events:
   - kind: WaitForLoadCompletion
     name: ramp-up
   - kind: StartLoad
-    load_ref: steady-1
+    load_ref: steady-leak
   - kind: WaitForLoadCompletion
-    name: steady-1
-  - kind: StartLoad
-    load_ref: spike
-  - kind: WaitForLoadCompletion
-    name: spike
-  - kind: StartLoad
-    load_ref: steady-2
-  - kind: WaitForLoadCompletion
-    name: steady-2
+    name: steady-leak
   - kind: StartLoad
     load_ref: ramp-down
   - kind: WaitForLoadCompletion
@@ -117,7 +109,7 @@ reports:
 
 checks:
   - kind: LoadApplied
-    load_name: steady-1
+    load_name: steady-leak
     min_requests: 5000
   - kind: WorkerPanics
     services: [Frontend, prefill, decode]

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_arm2_nscale_15set.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_arm2_nscale_15set.yaml
@@ -87,7 +87,7 @@ load:
 events:
   - kind: WaitForModelReady
     timeout: 1800
-  - kind: PodMemoryPoller
+  - kind: ResourcePoller
     services: [Frontend, prefill, decode]
     interval_s: 5
   - kind: StartLoad

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_arm3_nscale_15set.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_arm3_nscale_15set.yaml
@@ -86,9 +86,6 @@ events:
   - kind: ResourcePoller
     services: [Frontend, prefill, decode]
     interval_s: 5
-  - kind: ResourcePoller
-    services: [Frontend, prefill, decode]
-    interval_s: 5
   - kind: StartLoad
     load_ref: ramp-up
   - kind: WaitForLoadCompletion

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_arm3_nscale_15set.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_arm3_nscale_15set.yaml
@@ -1,42 +1,49 @@
-# E1 Imbalance — Arm 5: 93 FE / KV + replica-sync (Recommended config)
+# E2 Memory Leak — Arm 3 (1.2 KV-recommended) — NSCALE 15-set
 #
-# Both H1 and H2 mitigated. KV-aware routing + cross-FE state sync. The target config
-# we'd recommend for the production deployment. If imbalance flattens here vs Arm 4,
-# replica-sync was the missing piece. If still imbalanced, KV+sync alone isn't enough.
+# The cascade-RCA Option-3 fix: KV events OFF (avoids the radix-tree leak path),
+# overlap-score-credit=0.0 (no prefix-overlap scoring — also a leak source at
+# non-zero), prefill-load-scale=1.0 (load-aware, the active KV-router knob),
+# replica-sync ON. Fix verified if FE memory slope ≈ 0.
+#
+# Same units + load + seq_dist as E2 arms 1/2 (and the E1 imbalance arms). Only
+# the router knobs change vs arm 2 — so the arm2→arm3 delta isolates the fix.
+# Identical to E1 arm 5 (Recommended) on the router side; differs only in the
+# extended 30-min steady-leak window for slope measurement.
 
 kind: router_memory
-name: e1_arm5_93fe_kv_sync
+name: e2_arm3_nscale_15set
 description: |
-  E1 Arm 5 (93 FE / KV + replica-sync): 93F+186P+93D mocker, KV routing with replica-sync.
-  Recommended config. H1 and H2 both mitigated. Target migration config.
+  E2 Arm 3 (1.2 KV-recommended): 15F+30P+15D mocker, KV + replica-sync, leak knobs
+  zeroed (KV events OFF, overlap=0.0, prefill-load=1.0). Verifies the leak fix.
 
 labels:
-  purpose: e1_imbalance_attribution
-  arm: arm5_93fe_kv_sync
+  purpose: e2_memory_leak
+  arm: arm3_12_kv_recommended
   router_mode: kv_recommended
   deployment: disagg
   backend: mocker
-  image_label: cascade-test
+  image_label: mocker-prefill-pinning-a5c93b3331
+  cluster: nscale-dev-cluster
 
 deployment:
   backend: mocker
   topology: disagg
-  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-cascade-test-ead461faa6-neelays
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-mocker-prefill-pinning-a5c93b3331-neelays
   replicas:
-    Frontend: 46
-    prefill: 92
-    decode: 46
+    Frontend: 15
+    prefill: 30
+    decode: 15
 
 router:
   mode: kv
   knobs:
-    # Recommended config — KV + replica-sync + load-aware (no prefix routing, no KV events)
+    # Recommended: leak knobs zeroed, replica-sync on, load-aware only.
     DYN_ROUTER_USE_KV_EVENTS: "false"
     DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT: "0.0"
     DYN_ROUTER_PREFILL_LOAD_SCALE: "1.0"
     DYN_ROUTER_QUEUE_THRESHOLD: "4.0"
     DYN_ROUTER_QUEUE_POLICY: "fcfs"
-    DYN_ROUTER_REPLICA_SYNC: "true"   # <-- THE DIFF vs Arm 4
+    DYN_ROUTER_REPLICA_SYNC: "true"
     DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
     DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
     DYN_EVENT_PLANE: "zmq"
@@ -57,27 +64,16 @@ load:
     num_prefix_prompts: 5
     prefix_prompt_length: 740
     seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
-  # Shared E1/E2/E3 load profile: ramp-up → steady-1 → spike → steady-2 → ramp-down.
-  # Mocker --speedup-ratio=5.0 (set in disagg.yaml template) means engine-side sim
-  # advances 5× faster than wall-clock; aiperf still drives load over wall-clock,
-  # so the visible effect is higher per-pod request throughput at the same target
-  # concurrency. Total wall ≈ 13.5 min per arm.
   rungs:
     - name: ramp-up
-      concurrency: 200
-      duration_minutes: 1.5
-    - name: steady-1
-      concurrency: 600  # Conservative pre-Stage-0 — revisit after saturation discovery
-      duration_minutes: 5.0
-    - name: spike
-      concurrency: 1200
-      duration_minutes: 1.5
-    - name: steady-2
-      concurrency: 600
-      duration_minutes: 5.0
-    - name: ramp-down
-      concurrency: 150
+      concurrency: 50
       duration_minutes: 1.0
+    - name: steady-leak
+      concurrency: 120
+      duration_minutes: 30.0
+    - name: ramp-down
+      concurrency: 30
+      duration_minutes: 0.5
   common:
     request_timeout_seconds: 30
     streaming: true
@@ -90,22 +86,17 @@ events:
   - kind: PodMemoryPoller
     services: [Frontend, prefill, decode]
     interval_s: 5
+  - kind: PodMemoryPoller2
+    services: [Frontend, prefill, decode]
+    interval_s: 5
   - kind: StartLoad
     load_ref: ramp-up
   - kind: WaitForLoadCompletion
     name: ramp-up
   - kind: StartLoad
-    load_ref: steady-1
+    load_ref: steady-leak
   - kind: WaitForLoadCompletion
-    name: steady-1
-  - kind: StartLoad
-    load_ref: spike
-  - kind: WaitForLoadCompletion
-    name: spike
-  - kind: StartLoad
-    load_ref: steady-2
-  - kind: WaitForLoadCompletion
-    name: steady-2
+    name: steady-leak
   - kind: StartLoad
     load_ref: ramp-down
   - kind: WaitForLoadCompletion
@@ -117,7 +108,7 @@ reports:
 
 checks:
   - kind: LoadApplied
-    load_name: steady-1
+    load_name: steady-leak
     min_requests: 5000
   - kind: WorkerPanics
     services: [Frontend, prefill, decode]

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_arm3_nscale_15set.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_arm3_nscale_15set.yaml
@@ -83,10 +83,10 @@ load:
 events:
   - kind: WaitForModelReady
     timeout: 1800
-  - kind: PodMemoryPoller
+  - kind: ResourcePoller
     services: [Frontend, prefill, decode]
     interval_s: 5
-  - kind: PodMemoryPoller2
+  - kind: ResourcePoller
     services: [Frontend, prefill, decode]
     interval_s: 5
   - kind: StartLoad

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_arm4_nscale_15set.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_arm4_nscale_15set.yaml
@@ -90,7 +90,7 @@ load:
 events:
   - kind: WaitForModelReady
     timeout: 1800
-  - kind: PodMemoryPoller
+  - kind: ResourcePoller
     services: [Frontend, prefill, decode]
     interval_s: 5
   - kind: StartLoad

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_arm4_nscale_15set.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_arm4_nscale_15set.yaml
@@ -1,42 +1,54 @@
-# E1 Imbalance — Arm 5: 93 FE / KV + replica-sync (Recommended config)
+# E2 Memory Leak — Arm 4 (1.2 KV-events OFF, overlap ON) — NSCALE 15-set
 #
-# Both H1 and H2 mitigated. KV-aware routing + cross-FE state sync. The target config
-# we'd recommend for the production deployment. If imbalance flattens here vs Arm 4,
-# replica-sync was the missing piece. If still imbalanced, KV+sync alone isn't enough.
+# Isolation arm added on top of the observe 3-arm design. Same 1.2 image as
+# arms 2/3, KV events OFF but overlap-score-weight LEFT AT 1.0. This is the
+# exact config the 2026-05-26 leak matrix used when v1.1.1 leaked +9.15 MB/min
+# (KV events were off; the leak came from the FE-side prefix-overlap scoring
+# path, not from consuming worker KV events).
+#
+# Two clean single-knob isolations:
+#   arm 2 -> arm 4 : KV events true -> false (overlap held 1.0) = KV-events contribution
+#   arm 4 -> arm 3 : overlap 1.0 -> 0.0 (events held false)     = overlap-scoring contribution
+#
+# If arm 4 leaks ~ as much as arm 2, KV events are NOT the driver (confirms 5/26);
+# if arm 3 then goes flat, overlap-score-weight is THE leak knob.
 
 kind: router_memory
-name: e1_arm5_93fe_kv_sync
+name: e2_arm4_nscale_15set
 description: |
-  E1 Arm 5 (93 FE / KV + replica-sync): 93F+186P+93D mocker, KV routing with replica-sync.
-  Recommended config. H1 and H2 both mitigated. Target migration config.
+  E2 Arm 2 (1.2 KV-default): 15F+30P+15D mocker, KV routing, default leak knobs
+  (KV events ON, overlap=1.0, prefill-load=1.0). Checks whether the 1.2 stack fixed the leak incidentally (5/26 matrix says it did NOT — 1.2 KV+prefix was +44.58 MB/min, worse).
 
 labels:
-  purpose: e1_imbalance_attribution
-  arm: arm5_93fe_kv_sync
-  router_mode: kv_recommended
+  purpose: e2_memory_leak
+  arm: arm4_12_kv_events_off_overlap_on
+  router_mode: kv_events_off_overlap_on
   deployment: disagg
   backend: mocker
-  image_label: cascade-test
+  image_label: mocker-prefill-pinning-a5c93b3331
+  cluster: nscale-dev-cluster
 
 deployment:
   backend: mocker
   topology: disagg
-  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-cascade-test-ead461faa6-neelays
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-mocker-prefill-pinning-a5c93b3331-neelays
   replicas:
-    Frontend: 46
-    prefill: 92
-    decode: 46
+    Frontend: 15
+    prefill: 30
+    decode: 15
 
 router:
   mode: kv
   knobs:
-    # Recommended config — KV + replica-sync + load-aware (no prefix routing, no KV events)
+    # KV-default: all leak knobs at their v1.1.1 defaults. Set explicitly for
+    # reproducibility; v1.1.1 ignores any env it doesn't recognize and falls back
+    # to the same default value, so this is safe.
     DYN_ROUTER_USE_KV_EVENTS: "false"
-    DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT: "0.0"
+    DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT: "1.0"
     DYN_ROUTER_PREFILL_LOAD_SCALE: "1.0"
     DYN_ROUTER_QUEUE_THRESHOLD: "4.0"
     DYN_ROUTER_QUEUE_POLICY: "fcfs"
-    DYN_ROUTER_REPLICA_SYNC: "true"   # <-- THE DIFF vs Arm 4
+    # No replica-sync in the default arm.
     DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
     DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
     DYN_EVENT_PLANE: "zmq"
@@ -57,27 +69,18 @@ load:
     num_prefix_prompts: 5
     prefix_prompt_length: 740
     seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
-  # Shared E1/E2/E3 load profile: ramp-up → steady-1 → spike → steady-2 → ramp-down.
-  # Mocker --speedup-ratio=5.0 (set in disagg.yaml template) means engine-side sim
-  # advances 5× faster than wall-clock; aiperf still drives load over wall-clock,
-  # so the visible effect is higher per-pod request throughput at the same target
-  # concurrency. Total wall ≈ 13.5 min per arm.
+  # Same seq_dist + same c=120 steady as E1. The single long steady-leak rung is
+  # the measurement window; no spike (the leak is event-driven, not load-spike-driven).
   rungs:
     - name: ramp-up
-      concurrency: 200
-      duration_minutes: 1.5
-    - name: steady-1
-      concurrency: 600  # Conservative pre-Stage-0 — revisit after saturation discovery
-      duration_minutes: 5.0
-    - name: spike
-      concurrency: 1200
-      duration_minutes: 1.5
-    - name: steady-2
-      concurrency: 600
-      duration_minutes: 5.0
-    - name: ramp-down
-      concurrency: 150
+      concurrency: 50
       duration_minutes: 1.0
+    - name: steady-leak
+      concurrency: 120
+      duration_minutes: 30.0
+    - name: ramp-down
+      concurrency: 30
+      duration_minutes: 0.5
   common:
     request_timeout_seconds: 30
     streaming: true
@@ -95,17 +98,9 @@ events:
   - kind: WaitForLoadCompletion
     name: ramp-up
   - kind: StartLoad
-    load_ref: steady-1
+    load_ref: steady-leak
   - kind: WaitForLoadCompletion
-    name: steady-1
-  - kind: StartLoad
-    load_ref: spike
-  - kind: WaitForLoadCompletion
-    name: spike
-  - kind: StartLoad
-    load_ref: steady-2
-  - kind: WaitForLoadCompletion
-    name: steady-2
+    name: steady-leak
   - kind: StartLoad
     load_ref: ramp-down
   - kind: WaitForLoadCompletion
@@ -117,7 +112,7 @@ reports:
 
 checks:
   - kind: LoadApplied
-    load_name: steady-1
+    load_name: steady-leak
     min_requests: 5000
   - kind: WorkerPanics
     services: [Frontend, prefill, decode]

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_gA_v111_baseline_pool5_n3.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_gA_v111_baseline_pool5_n3.yaml
@@ -68,9 +68,6 @@ events:
   - kind: ResourcePoller
     services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
     interval_s: 5
-  - kind: ResourcePoller
-    services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
-    interval_s: 5
   - kind: StartLoad
     load_ref: warmup
   - kind: WaitForLoadCompletion

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_gA_v111_baseline_pool5_n3.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_gA_v111_baseline_pool5_n3.yaml
@@ -1,0 +1,93 @@
+# E2-pressure Part 2 — Arm G-A (real-GPU, v1.1.1 KV-default baseline, pool=5) — N=3
+# Real-GPU equivalent of E2 Arm 3 / Part-1 P-A: confirms the 1.2 Recommended
+# memory-safety transfers to real vLLM workers (not just mocker). 60-min steady.
+# Topology + engine + steady=46 (0.8*C_max=58) carried over from the E1 real-GPU arms.
+
+kind: router_memory
+name: e2_gA_v111_baseline_pool5
+
+labels:
+  purpose: e2_pressure_realgpu
+  arm: e2_gA_v111_baseline_pool5
+  router_mode: kv
+  deployment: disagg
+  backend: vllm
+  cluster: aws-dev-02
+
+deployment:
+  backend: vllm
+  topology: disagg
+  units: 3
+  template: disagg_qwen3_30b_unit_e1
+  image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1
+  model_cache_pvc: shared-model-cache
+  log_pvc: dynamo-ft-logs
+
+router:
+  mode: kv
+  knobs:
+    DYN_ROUTER_USE_KV_EVENTS: "true"
+    DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT: "1.0"
+    DYN_ROUTER_PREFILL_LOAD_SCALE: "1.0"
+    DYN_ROUTER_QUEUE_THRESHOLD: "4.0"
+    DYN_ROUTER_QUEUE_POLICY: "fcfs"
+    DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
+    DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
+
+admission:
+  knobs:
+    DYN_TCP_WORKER_POOL_SIZE: "128"
+    DYN_TCP_WORK_QUEUE_SIZE: "5"
+    VLLM_NIXL_ABORT_REQUEST_TIMEOUT: "30"
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30"
+
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 5
+    prefix_prompt_length: 740
+    seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
+  # C_TARGET placeholder — the run-e1-realgpu sequencer rewrites the steady
+  # concurrency to 0.8 x C_max discovered by the Stage-0 aiperf sweep.
+  rungs:
+    - name: warmup
+      concurrency: 16
+      duration_minutes: 2.0
+    - name: steady
+      concurrency: 46
+      duration_minutes: 60.0
+  common:
+    request_timeout_seconds: 30
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never
+
+events:
+  - kind: WaitForModelReady
+    timeout: 2400
+  - kind: PodMemoryPoller
+    services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
+    interval_s: 5
+  - kind: PodMemoryPoller2
+    services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
+    interval_s: 5
+  - kind: StartLoad
+    load_ref: warmup
+  - kind: WaitForLoadCompletion
+    name: warmup
+  - kind: StartLoad
+    load_ref: steady
+  - kind: WaitForLoadCompletion
+    name: steady
+
+reports:
+  - PerWorkerLatencyReport
+  - ErrorBreakdownReport
+
+checks:
+  - kind: LoadApplied
+    load_name: steady
+    min_requests: 2000
+  - kind: WorkerPanics
+    services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
+    acceptable: true

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_gA_v111_baseline_pool5_n3.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_gA_v111_baseline_pool5_n3.yaml
@@ -65,10 +65,10 @@ load:
 events:
   - kind: WaitForModelReady
     timeout: 2400
-  - kind: PodMemoryPoller
+  - kind: ResourcePoller
     services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
     interval_s: 5
-  - kind: PodMemoryPoller2
+  - kind: ResourcePoller
     services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
     interval_s: 5
   - kind: StartLoad

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_gB_recommended_pool5_n3.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_gB_recommended_pool5_n3.yaml
@@ -1,0 +1,94 @@
+# E2-pressure Part 2 — Arm G-B (real-GPU, 1.2 Recommended, pool=5) — N=3
+# Real-GPU equivalent of E2 Arm 3 / Part-1 P-A: confirms the 1.2 Recommended
+# memory-safety transfers to real vLLM workers (not just mocker). 60-min steady.
+# Topology + engine + steady=46 (0.8*C_max=58) carried over from the E1 real-GPU arms.
+
+kind: router_memory
+name: e2_gB_recommended_pool5
+
+labels:
+  purpose: e2_pressure_realgpu
+  arm: e2_gB_recommended_pool5
+  router_mode: kv
+  deployment: disagg
+  backend: vllm
+  cluster: aws-dev-02
+
+deployment:
+  backend: vllm
+  topology: disagg
+  units: 3
+  template: disagg_qwen3_30b_unit_e1
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-mocker-prefill-pinning-a5c93b3331-neelays
+  model_cache_pvc: shared-model-cache
+  log_pvc: dynamo-ft-logs
+
+router:
+  mode: kv
+  knobs:
+    DYN_ROUTER_USE_KV_EVENTS: "false"
+    DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT: "0.0"
+    DYN_ROUTER_PREFILL_LOAD_SCALE: "1.0"
+    DYN_ROUTER_QUEUE_THRESHOLD: "4.0"
+    DYN_ROUTER_QUEUE_POLICY: "fcfs"
+    DYN_ROUTER_REPLICA_SYNC: "true"
+    DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
+    DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
+
+admission:
+  knobs:
+    DYN_TCP_WORKER_POOL_SIZE: "128"
+    DYN_TCP_WORK_QUEUE_SIZE: "5"
+    VLLM_NIXL_ABORT_REQUEST_TIMEOUT: "30"
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30"
+
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 5
+    prefix_prompt_length: 740
+    seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
+  # C_TARGET placeholder — the run-e1-realgpu sequencer rewrites the steady
+  # concurrency to 0.8 x C_max discovered by the Stage-0 aiperf sweep.
+  rungs:
+    - name: warmup
+      concurrency: 16
+      duration_minutes: 2.0
+    - name: steady
+      concurrency: 46
+      duration_minutes: 60.0
+  common:
+    request_timeout_seconds: 30
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never
+
+events:
+  - kind: WaitForModelReady
+    timeout: 2400
+  - kind: PodMemoryPoller
+    services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
+    interval_s: 5
+  - kind: PodMemoryPoller2
+    services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
+    interval_s: 5
+  - kind: StartLoad
+    load_ref: warmup
+  - kind: WaitForLoadCompletion
+    name: warmup
+  - kind: StartLoad
+    load_ref: steady
+  - kind: WaitForLoadCompletion
+    name: steady
+
+reports:
+  - PerWorkerLatencyReport
+  - ErrorBreakdownReport
+
+checks:
+  - kind: LoadApplied
+    load_name: steady
+    min_requests: 2000
+  - kind: WorkerPanics
+    services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
+    acceptable: true

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_gB_recommended_pool5_n3.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_gB_recommended_pool5_n3.yaml
@@ -66,10 +66,10 @@ load:
 events:
   - kind: WaitForModelReady
     timeout: 2400
-  - kind: PodMemoryPoller
+  - kind: ResourcePoller
     services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
     interval_s: 5
-  - kind: PodMemoryPoller2
+  - kind: ResourcePoller
     services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
     interval_s: 5
   - kind: StartLoad

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_gB_recommended_pool5_n3.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_gB_recommended_pool5_n3.yaml
@@ -69,9 +69,6 @@ events:
   - kind: ResourcePoller
     services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
     interval_s: 5
-  - kind: ResourcePoller
-    services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
-    interval_s: 5
   - kind: StartLoad
     load_ref: warmup
   - kind: WaitForLoadCompletion

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_gC_recommended_pool1000_n3.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_gC_recommended_pool1000_n3.yaml
@@ -1,0 +1,94 @@
+# E2-pressure Part 2 — Arm G-C (real-GPU, 1.2 Recommended, pool=1000) — N=3
+# Real-GPU equivalent of Part-1 P-C (prefix pressure): confirms the 1.2 Recommended
+# memory-safety transfers to real vLLM workers (not just mocker). 60-min steady.
+# Topology + engine + steady=46 (0.8*C_max=58) carried over from the E1 real-GPU arms.
+
+kind: router_memory
+name: e2_gC_recommended_pool1000
+
+labels:
+  purpose: e2_pressure_realgpu
+  arm: e2_gC_recommended_pool1000
+  router_mode: kv
+  deployment: disagg
+  backend: vllm
+  cluster: aws-dev-02
+
+deployment:
+  backend: vllm
+  topology: disagg
+  units: 3
+  template: disagg_qwen3_30b_unit_e1
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-mocker-prefill-pinning-a5c93b3331-neelays
+  model_cache_pvc: shared-model-cache
+  log_pvc: dynamo-ft-logs
+
+router:
+  mode: kv
+  knobs:
+    DYN_ROUTER_USE_KV_EVENTS: "false"
+    DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT: "0.0"
+    DYN_ROUTER_PREFILL_LOAD_SCALE: "1.0"
+    DYN_ROUTER_QUEUE_THRESHOLD: "4.0"
+    DYN_ROUTER_QUEUE_POLICY: "fcfs"
+    DYN_ROUTER_REPLICA_SYNC: "true"
+    DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
+    DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
+
+admission:
+  knobs:
+    DYN_TCP_WORKER_POOL_SIZE: "128"
+    DYN_TCP_WORK_QUEUE_SIZE: "5"
+    VLLM_NIXL_ABORT_REQUEST_TIMEOUT: "30"
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30"
+
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 1000
+    prefix_prompt_length: 740
+    seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
+  # C_TARGET placeholder — the run-e1-realgpu sequencer rewrites the steady
+  # concurrency to 0.8 x C_max discovered by the Stage-0 aiperf sweep.
+  rungs:
+    - name: warmup
+      concurrency: 16
+      duration_minutes: 2.0
+    - name: steady
+      concurrency: 46
+      duration_minutes: 60.0
+  common:
+    request_timeout_seconds: 30
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never
+
+events:
+  - kind: WaitForModelReady
+    timeout: 2400
+  - kind: PodMemoryPoller
+    services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
+    interval_s: 5
+  - kind: PodMemoryPoller2
+    services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
+    interval_s: 5
+  - kind: StartLoad
+    load_ref: warmup
+  - kind: WaitForLoadCompletion
+    name: warmup
+  - kind: StartLoad
+    load_ref: steady
+  - kind: WaitForLoadCompletion
+    name: steady
+
+reports:
+  - PerWorkerLatencyReport
+  - ErrorBreakdownReport
+
+checks:
+  - kind: LoadApplied
+    load_name: steady
+    min_requests: 2000
+  - kind: WorkerPanics
+    services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
+    acceptable: true

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_gC_recommended_pool1000_n3.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_gC_recommended_pool1000_n3.yaml
@@ -66,10 +66,10 @@ load:
 events:
   - kind: WaitForModelReady
     timeout: 2400
-  - kind: PodMemoryPoller
+  - kind: ResourcePoller
     services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
     interval_s: 5
-  - kind: PodMemoryPoller2
+  - kind: ResourcePoller
     services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
     interval_s: 5
   - kind: StartLoad

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_gC_recommended_pool1000_n3.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_gC_recommended_pool1000_n3.yaml
@@ -69,9 +69,6 @@ events:
   - kind: ResourcePoller
     services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
     interval_s: 5
-  - kind: ResourcePoller
-    services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
-    interval_s: 5
   - kind: StartLoad
     load_ref: warmup
   - kind: WaitForLoadCompletion

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_pA_pool5_nscale_15set.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_pA_pool5_nscale_15set.yaml
@@ -84,10 +84,10 @@ load:
 events:
   - kind: WaitForModelReady
     timeout: 1800
-  - kind: PodMemoryPoller
+  - kind: ResourcePoller
     services: [Frontend, prefill, decode]
     interval_s: 5
-  - kind: PodMemoryPoller2
+  - kind: ResourcePoller
     services: [Frontend, prefill, decode]
     interval_s: 5
   - kind: StartLoad

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_pA_pool5_nscale_15set.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_pA_pool5_nscale_15set.yaml
@@ -1,42 +1,50 @@
-# E1 Imbalance — Arm 5: 93 FE / KV + replica-sync (Recommended config)
+# E2-pressure Part 1 — Arm P-A (pool=5, E2-fidelity baseline) — NSCALE 15-set
 #
-# Both H1 and H2 mitigated. KV-aware routing + cross-FE state sync. The target config
-# we'd recommend for the production deployment. If imbalance flattens here vs Arm 4,
-# replica-sync was the missing piece. If still imbalanced, KV+sync alone isn't enough.
+# Memory-pressure prefix-pool follow-up. All four P-arms use the SAME E2 Arm 3
+# "Recommended" router config (KV events off, overlap=0.0, prefill-load=1.0,
+# replica-sync on); only the prefix-pool pressure (num_prefix_prompts) differs.
+# P-A replicates E2 Arm 3's 5-prefix pool but for a 60-min steady window (vs
+# E2's 30 min) to confirm the +0.15 MB/min plateau holds past 30 min.
+#
+# H-bounded vs H-unbounded discrimination: compare late-window (last 10 min)
+# plateau RSS across P-A(5) / P-B(100) / P-C(1000). Flat across pool sizes =>
+# bounded indexer; scales with pool size => per-prefix retention (unbounded).
 
 kind: router_memory
-name: e1_arm5_93fe_kv_sync
+name: e2_pA_pool5_nscale_15set
 description: |
-  E1 Arm 5 (93 FE / KV + replica-sync): 93F+186P+93D mocker, KV routing with replica-sync.
-  Recommended config. H1 and H2 both mitigated. Target migration config.
+  E2-pressure P-A: 15F+30P+15D mocker, Recommended router config, prefix pool=5,
+  60-min steady. Baseline for the pool-size pressure sweep (P-A/B/C).
 
 labels:
-  purpose: e1_imbalance_attribution
-  arm: arm5_93fe_kv_sync
+  purpose: e2_pressure
+  arm: pA_pool5
   router_mode: kv_recommended
+  prefix_pool: "5"
   deployment: disagg
   backend: mocker
-  image_label: cascade-test
+  image_label: mocker-prefill-pinning-a5c93b3331
+  cluster: nscale-dev-cluster
 
 deployment:
   backend: mocker
   topology: disagg
-  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-cascade-test-ead461faa6-neelays
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-mocker-prefill-pinning-a5c93b3331-neelays
   replicas:
-    Frontend: 46
-    prefill: 92
-    decode: 46
+    Frontend: 15
+    prefill: 30
+    decode: 15
 
 router:
   mode: kv
   knobs:
-    # Recommended config — KV + replica-sync + load-aware (no prefix routing, no KV events)
+    # Recommended config (same as E2 Arm 3) — identical for all P-arms.
     DYN_ROUTER_USE_KV_EVENTS: "false"
     DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT: "0.0"
     DYN_ROUTER_PREFILL_LOAD_SCALE: "1.0"
     DYN_ROUTER_QUEUE_THRESHOLD: "4.0"
     DYN_ROUTER_QUEUE_POLICY: "fcfs"
-    DYN_ROUTER_REPLICA_SYNC: "true"   # <-- THE DIFF vs Arm 4
+    DYN_ROUTER_REPLICA_SYNC: "true"
     DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
     DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
     DYN_EVENT_PLANE: "zmq"
@@ -57,27 +65,16 @@ load:
     num_prefix_prompts: 5
     prefix_prompt_length: 740
     seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
-  # Shared E1/E2/E3 load profile: ramp-up → steady-1 → spike → steady-2 → ramp-down.
-  # Mocker --speedup-ratio=5.0 (set in disagg.yaml template) means engine-side sim
-  # advances 5× faster than wall-clock; aiperf still drives load over wall-clock,
-  # so the visible effect is higher per-pod request throughput at the same target
-  # concurrency. Total wall ≈ 13.5 min per arm.
   rungs:
     - name: ramp-up
-      concurrency: 200
-      duration_minutes: 1.5
-    - name: steady-1
-      concurrency: 600  # Conservative pre-Stage-0 — revisit after saturation discovery
-      duration_minutes: 5.0
-    - name: spike
-      concurrency: 1200
-      duration_minutes: 1.5
-    - name: steady-2
-      concurrency: 600
-      duration_minutes: 5.0
+      concurrency: 20
+      duration_minutes: 2.0
+    - name: steady-leak
+      concurrency: 120
+      duration_minutes: 60.0
     - name: ramp-down
-      concurrency: 150
-      duration_minutes: 1.0
+      concurrency: 30
+      duration_minutes: 0.5
   common:
     request_timeout_seconds: 30
     streaming: true
@@ -90,22 +87,17 @@ events:
   - kind: PodMemoryPoller
     services: [Frontend, prefill, decode]
     interval_s: 5
+  - kind: PodMemoryPoller2
+    services: [Frontend, prefill, decode]
+    interval_s: 5
   - kind: StartLoad
     load_ref: ramp-up
   - kind: WaitForLoadCompletion
     name: ramp-up
   - kind: StartLoad
-    load_ref: steady-1
+    load_ref: steady-leak
   - kind: WaitForLoadCompletion
-    name: steady-1
-  - kind: StartLoad
-    load_ref: spike
-  - kind: WaitForLoadCompletion
-    name: spike
-  - kind: StartLoad
-    load_ref: steady-2
-  - kind: WaitForLoadCompletion
-    name: steady-2
+    name: steady-leak
   - kind: StartLoad
     load_ref: ramp-down
   - kind: WaitForLoadCompletion
@@ -117,7 +109,7 @@ reports:
 
 checks:
   - kind: LoadApplied
-    load_name: steady-1
+    load_name: steady-leak
     min_requests: 5000
   - kind: WorkerPanics
     services: [Frontend, prefill, decode]

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_pA_pool5_nscale_15set.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_pA_pool5_nscale_15set.yaml
@@ -87,9 +87,6 @@ events:
   - kind: ResourcePoller
     services: [Frontend, prefill, decode]
     interval_s: 5
-  - kind: ResourcePoller
-    services: [Frontend, prefill, decode]
-    interval_s: 5
   - kind: StartLoad
     load_ref: ramp-up
   - kind: WaitForLoadCompletion

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_pB_pool100_nscale_15set.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_pB_pool100_nscale_15set.yaml
@@ -84,10 +84,10 @@ load:
 events:
   - kind: WaitForModelReady
     timeout: 1800
-  - kind: PodMemoryPoller
+  - kind: ResourcePoller
     services: [Frontend, prefill, decode]
     interval_s: 5
-  - kind: PodMemoryPoller2
+  - kind: ResourcePoller
     services: [Frontend, prefill, decode]
     interval_s: 5
   - kind: StartLoad

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_pB_pool100_nscale_15set.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_pB_pool100_nscale_15set.yaml
@@ -1,42 +1,50 @@
-# E1 Imbalance — Arm 5: 93 FE / KV + replica-sync (Recommended config)
+# E2-pressure Part 1 — Arm P-A (pool=100, E2-fidelity baseline) — NSCALE 15-set
 #
-# Both H1 and H2 mitigated. KV-aware routing + cross-FE state sync. The target config
-# we'd recommend for the production deployment. If imbalance flattens here vs Arm 4,
-# replica-sync was the missing piece. If still imbalanced, KV+sync alone isn't enough.
+# Memory-pressure prefix-pool follow-up. All four P-arms use the SAME E2 Arm 3
+# "Recommended" router config (KV events off, overlap=0.0, prefill-load=1.0,
+# replica-sync on); only the prefix-pool pressure (num_prefix_prompts) differs.
+# P-A replicates E2 Arm 3's 5-prefix pool but for a 60-min steady window (vs
+# E2's 30 min) to confirm the +0.15 MB/min plateau holds past 30 min.
+#
+# H-bounded vs H-unbounded discrimination: compare late-window (last 10 min)
+# plateau RSS across P-A(5) / P-B(100) / P-C(1000). Flat across pool sizes =>
+# bounded indexer; scales with pool size => per-prefix retention (unbounded).
 
 kind: router_memory
-name: e1_arm5_93fe_kv_sync
+name: e2_pB_pool100_nscale_15set
 description: |
-  E1 Arm 5 (93 FE / KV + replica-sync): 93F+186P+93D mocker, KV routing with replica-sync.
-  Recommended config. H1 and H2 both mitigated. Target migration config.
+  E2-pressure P-A: 15F+30P+15D mocker, Recommended router config, prefix pool=100,
+  60-min steady. Baseline for the pool-size pressure sweep (P-A/B/C).
 
 labels:
-  purpose: e1_imbalance_attribution
-  arm: arm5_93fe_kv_sync
+  purpose: e2_pressure
+  arm: pB_pool100
   router_mode: kv_recommended
+  prefix_pool: "100"
   deployment: disagg
   backend: mocker
-  image_label: cascade-test
+  image_label: mocker-prefill-pinning-a5c93b3331
+  cluster: nscale-dev-cluster
 
 deployment:
   backend: mocker
   topology: disagg
-  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-cascade-test-ead461faa6-neelays
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-mocker-prefill-pinning-a5c93b3331-neelays
   replicas:
-    Frontend: 46
-    prefill: 92
-    decode: 46
+    Frontend: 15
+    prefill: 30
+    decode: 15
 
 router:
   mode: kv
   knobs:
-    # Recommended config — KV + replica-sync + load-aware (no prefix routing, no KV events)
+    # Recommended config (same as E2 Arm 3) — identical for all P-arms.
     DYN_ROUTER_USE_KV_EVENTS: "false"
     DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT: "0.0"
     DYN_ROUTER_PREFILL_LOAD_SCALE: "1.0"
     DYN_ROUTER_QUEUE_THRESHOLD: "4.0"
     DYN_ROUTER_QUEUE_POLICY: "fcfs"
-    DYN_ROUTER_REPLICA_SYNC: "true"   # <-- THE DIFF vs Arm 4
+    DYN_ROUTER_REPLICA_SYNC: "true"
     DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
     DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
     DYN_EVENT_PLANE: "zmq"
@@ -54,30 +62,19 @@ admission:
 load:
   shape:
     type: partial_prefix
-    num_prefix_prompts: 5
+    num_prefix_prompts: 100
     prefix_prompt_length: 740
     seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
-  # Shared E1/E2/E3 load profile: ramp-up → steady-1 → spike → steady-2 → ramp-down.
-  # Mocker --speedup-ratio=5.0 (set in disagg.yaml template) means engine-side sim
-  # advances 5× faster than wall-clock; aiperf still drives load over wall-clock,
-  # so the visible effect is higher per-pod request throughput at the same target
-  # concurrency. Total wall ≈ 13.5 min per arm.
   rungs:
     - name: ramp-up
-      concurrency: 200
-      duration_minutes: 1.5
-    - name: steady-1
-      concurrency: 600  # Conservative pre-Stage-0 — revisit after saturation discovery
-      duration_minutes: 5.0
-    - name: spike
-      concurrency: 1200
-      duration_minutes: 1.5
-    - name: steady-2
-      concurrency: 600
-      duration_minutes: 5.0
+      concurrency: 20
+      duration_minutes: 2.0
+    - name: steady-leak
+      concurrency: 120
+      duration_minutes: 60.0
     - name: ramp-down
-      concurrency: 150
-      duration_minutes: 1.0
+      concurrency: 30
+      duration_minutes: 0.5
   common:
     request_timeout_seconds: 30
     streaming: true
@@ -90,22 +87,17 @@ events:
   - kind: PodMemoryPoller
     services: [Frontend, prefill, decode]
     interval_s: 5
+  - kind: PodMemoryPoller2
+    services: [Frontend, prefill, decode]
+    interval_s: 5
   - kind: StartLoad
     load_ref: ramp-up
   - kind: WaitForLoadCompletion
     name: ramp-up
   - kind: StartLoad
-    load_ref: steady-1
+    load_ref: steady-leak
   - kind: WaitForLoadCompletion
-    name: steady-1
-  - kind: StartLoad
-    load_ref: spike
-  - kind: WaitForLoadCompletion
-    name: spike
-  - kind: StartLoad
-    load_ref: steady-2
-  - kind: WaitForLoadCompletion
-    name: steady-2
+    name: steady-leak
   - kind: StartLoad
     load_ref: ramp-down
   - kind: WaitForLoadCompletion
@@ -117,7 +109,7 @@ reports:
 
 checks:
   - kind: LoadApplied
-    load_name: steady-1
+    load_name: steady-leak
     min_requests: 5000
   - kind: WorkerPanics
     services: [Frontend, prefill, decode]

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_pB_pool100_nscale_15set.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_pB_pool100_nscale_15set.yaml
@@ -87,9 +87,6 @@ events:
   - kind: ResourcePoller
     services: [Frontend, prefill, decode]
     interval_s: 5
-  - kind: ResourcePoller
-    services: [Frontend, prefill, decode]
-    interval_s: 5
   - kind: StartLoad
     load_ref: ramp-up
   - kind: WaitForLoadCompletion

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_pC_pool1000_nscale_15set.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_pC_pool1000_nscale_15set.yaml
@@ -84,10 +84,10 @@ load:
 events:
   - kind: WaitForModelReady
     timeout: 1800
-  - kind: PodMemoryPoller
+  - kind: ResourcePoller
     services: [Frontend, prefill, decode]
     interval_s: 5
-  - kind: PodMemoryPoller2
+  - kind: ResourcePoller
     services: [Frontend, prefill, decode]
     interval_s: 5
   - kind: StartLoad

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_pC_pool1000_nscale_15set.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_pC_pool1000_nscale_15set.yaml
@@ -87,9 +87,6 @@ events:
   - kind: ResourcePoller
     services: [Frontend, prefill, decode]
     interval_s: 5
-  - kind: ResourcePoller
-    services: [Frontend, prefill, decode]
-    interval_s: 5
   - kind: StartLoad
     load_ref: ramp-up
   - kind: WaitForLoadCompletion

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_pC_pool1000_nscale_15set.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_pC_pool1000_nscale_15set.yaml
@@ -1,42 +1,50 @@
-# E1 Imbalance — Arm 5: 93 FE / KV + replica-sync (Recommended config)
+# E2-pressure Part 1 — Arm P-A (pool=1000, E2-fidelity baseline) — NSCALE 15-set
 #
-# Both H1 and H2 mitigated. KV-aware routing + cross-FE state sync. The target config
-# we'd recommend for the production deployment. If imbalance flattens here vs Arm 4,
-# replica-sync was the missing piece. If still imbalanced, KV+sync alone isn't enough.
+# Memory-pressure prefix-pool follow-up. All four P-arms use the SAME E2 Arm 3
+# "Recommended" router config (KV events off, overlap=0.0, prefill-load=1.0,
+# replica-sync on); only the prefix-pool pressure (num_prefix_prompts) differs.
+# P-A replicates E2 Arm 3's 5-prefix pool but for a 60-min steady window (vs
+# E2's 30 min) to confirm the +0.15 MB/min plateau holds past 30 min.
+#
+# H-bounded vs H-unbounded discrimination: compare late-window (last 10 min)
+# plateau RSS across P-A(5) / P-B(100) / P-C(1000). Flat across pool sizes =>
+# bounded indexer; scales with pool size => per-prefix retention (unbounded).
 
 kind: router_memory
-name: e1_arm5_93fe_kv_sync
+name: e2_pC_pool1000_nscale_15set
 description: |
-  E1 Arm 5 (93 FE / KV + replica-sync): 93F+186P+93D mocker, KV routing with replica-sync.
-  Recommended config. H1 and H2 both mitigated. Target migration config.
+  E2-pressure P-A: 15F+30P+15D mocker, Recommended router config, prefix pool=1000,
+  60-min steady. Baseline for the pool-size pressure sweep (P-A/B/C).
 
 labels:
-  purpose: e1_imbalance_attribution
-  arm: arm5_93fe_kv_sync
+  purpose: e2_pressure
+  arm: pC_pool1000
   router_mode: kv_recommended
+  prefix_pool: "1000"
   deployment: disagg
   backend: mocker
-  image_label: cascade-test
+  image_label: mocker-prefill-pinning-a5c93b3331
+  cluster: nscale-dev-cluster
 
 deployment:
   backend: mocker
   topology: disagg
-  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-cascade-test-ead461faa6-neelays
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-mocker-prefill-pinning-a5c93b3331-neelays
   replicas:
-    Frontend: 46
-    prefill: 92
-    decode: 46
+    Frontend: 15
+    prefill: 30
+    decode: 15
 
 router:
   mode: kv
   knobs:
-    # Recommended config — KV + replica-sync + load-aware (no prefix routing, no KV events)
+    # Recommended config (same as E2 Arm 3) — identical for all P-arms.
     DYN_ROUTER_USE_KV_EVENTS: "false"
     DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT: "0.0"
     DYN_ROUTER_PREFILL_LOAD_SCALE: "1.0"
     DYN_ROUTER_QUEUE_THRESHOLD: "4.0"
     DYN_ROUTER_QUEUE_POLICY: "fcfs"
-    DYN_ROUTER_REPLICA_SYNC: "true"   # <-- THE DIFF vs Arm 4
+    DYN_ROUTER_REPLICA_SYNC: "true"
     DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
     DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
     DYN_EVENT_PLANE: "zmq"
@@ -54,30 +62,19 @@ admission:
 load:
   shape:
     type: partial_prefix
-    num_prefix_prompts: 5
+    num_prefix_prompts: 1000
     prefix_prompt_length: 740
     seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
-  # Shared E1/E2/E3 load profile: ramp-up → steady-1 → spike → steady-2 → ramp-down.
-  # Mocker --speedup-ratio=5.0 (set in disagg.yaml template) means engine-side sim
-  # advances 5× faster than wall-clock; aiperf still drives load over wall-clock,
-  # so the visible effect is higher per-pod request throughput at the same target
-  # concurrency. Total wall ≈ 13.5 min per arm.
   rungs:
     - name: ramp-up
-      concurrency: 200
-      duration_minutes: 1.5
-    - name: steady-1
-      concurrency: 600  # Conservative pre-Stage-0 — revisit after saturation discovery
-      duration_minutes: 5.0
-    - name: spike
-      concurrency: 1200
-      duration_minutes: 1.5
-    - name: steady-2
-      concurrency: 600
-      duration_minutes: 5.0
+      concurrency: 20
+      duration_minutes: 2.0
+    - name: steady-leak
+      concurrency: 120
+      duration_minutes: 60.0
     - name: ramp-down
-      concurrency: 150
-      duration_minutes: 1.0
+      concurrency: 30
+      duration_minutes: 0.5
   common:
     request_timeout_seconds: 30
     streaming: true
@@ -90,22 +87,17 @@ events:
   - kind: PodMemoryPoller
     services: [Frontend, prefill, decode]
     interval_s: 5
+  - kind: PodMemoryPoller2
+    services: [Frontend, prefill, decode]
+    interval_s: 5
   - kind: StartLoad
     load_ref: ramp-up
   - kind: WaitForLoadCompletion
     name: ramp-up
   - kind: StartLoad
-    load_ref: steady-1
+    load_ref: steady-leak
   - kind: WaitForLoadCompletion
-    name: steady-1
-  - kind: StartLoad
-    load_ref: spike
-  - kind: WaitForLoadCompletion
-    name: spike
-  - kind: StartLoad
-    load_ref: steady-2
-  - kind: WaitForLoadCompletion
-    name: steady-2
+    name: steady-leak
   - kind: StartLoad
     load_ref: ramp-down
   - kind: WaitForLoadCompletion
@@ -117,7 +109,7 @@ reports:
 
 checks:
   - kind: LoadApplied
-    load_name: steady-1
+    load_name: steady-leak
     min_requests: 5000
   - kind: WorkerPanics
     services: [Frontend, prefill, decode]

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_pD_3x_pool5_nscale_15set.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_pD_3x_pool5_nscale_15set.yaml
@@ -113,10 +113,10 @@ load:
 events:
   - kind: WaitForModelReady
     timeout: 1800
-  - kind: PodMemoryPoller
+  - kind: ResourcePoller
     services: [Frontend, prefill, decode]
     interval_s: 5
-  - kind: PodMemoryPoller2
+  - kind: ResourcePoller
     services: [Frontend, prefill, decode]
     interval_s: 5
   - kind: StartLoad

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_pD_3x_pool5_nscale_15set.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_pD_3x_pool5_nscale_15set.yaml
@@ -1,0 +1,148 @@
+# E2-pressure Part 1 — Arm P-D (3× concurrent, disjoint-seed pool=5) — NSCALE 15-set
+#
+# Memory-pressure follow-up: replica-sync cross-FE state amplification test.
+# THREE concurrent aiperf loads against the SAME Frontend service, each pool=5
+# but with DISJOINT --random-seed (1/2/3) so the cluster sees ~15 distinct
+# prefixes via 3 separate clients, each at c=40 (total ~120). Same Recommended
+# router config + 15-set mocker topology as P-A/B/C.
+#
+# Concurrency is expressed via an EXPLICIT events list: 3 back-to-back StartLoad
+# events (non-blocking) with NO WaitForLoadCompletion between them, then the 3
+# waits afterward — so all 3 loads run simultaneously for 60 min. Each rung
+# builds its OWN LoadConfig (distinct load_ref) so there's no in-place mutation
+# aliasing across the concurrent StartLoads.
+#
+# Pass criteria: P-D plateau RSS ≈ P-A (5-prefix) => replica-sync shares only
+# routing-decision state (safe). P-D ≈ P-B (≈15-prefix level) => replica-sync
+# mirrors every FE's state into each FE (catastrophic at production FE count).
+
+kind: router_memory
+name: e2_pD_3x_pool5_nscale_15set
+description: |
+  E2-pressure P-D: 15F+30P+15D mocker, Recommended router config, 3 concurrent
+  pool=5 loads (seeds 1/2/3) @ c=40 each (~120 total), 60-min steady. Tests
+  replica-sync cross-FE state amplification.
+
+labels:
+  purpose: e2_pressure
+  arm: pD_3x_pool5
+  router_mode: kv_recommended
+  prefix_pool: "5x3-disjoint"
+  deployment: disagg
+  backend: mocker
+  image_label: mocker-prefill-pinning-a5c93b3331
+  cluster: nscale-dev-cluster
+
+deployment:
+  backend: mocker
+  topology: disagg
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-mocker-prefill-pinning-a5c93b3331-neelays
+  replicas:
+    Frontend: 15
+    prefill: 30
+    decode: 15
+
+router:
+  mode: kv
+  knobs:
+    DYN_ROUTER_USE_KV_EVENTS: "false"
+    DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT: "0.0"
+    DYN_ROUTER_PREFILL_LOAD_SCALE: "1.0"
+    DYN_ROUTER_QUEUE_THRESHOLD: "4.0"
+    DYN_ROUTER_QUEUE_POLICY: "fcfs"
+    DYN_ROUTER_REPLICA_SYNC: "true"
+    DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
+    DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
+    DYN_EVENT_PLANE: "zmq"
+    DYN_DISCOVERY_BACKEND: "kubernetes"
+    DYN_STORE_KV: "mem"
+    DYN_LOG: "info,dynamo_runtime::transports::event_plane::zmq_transport=debug,dynamo_llm::discovery::worker_monitor=debug,dynamo_runtime::component::client=debug"
+
+admission:
+  knobs:
+    DYN_TCP_WORKER_POOL_SIZE: "128"
+    DYN_TCP_WORK_QUEUE_SIZE: "5"
+    VLLM_NIXL_ABORT_REQUEST_TIMEOUT: "30"
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30"
+
+load:
+  # Base shape (used by any rung without its own shape override). The 3
+  # concurrent rungs each override with their own random_seed.
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 5
+    prefix_prompt_length: 740
+    seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
+  rungs:
+    - name: pd-seed1
+      concurrency: 40
+      duration_minutes: 60.0
+      shape:
+        type: partial_prefix
+        num_prefix_prompts: 5
+        prefix_prompt_length: 740
+        random_seed: 1
+        seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
+    - name: pd-seed2
+      concurrency: 40
+      duration_minutes: 60.0
+      shape:
+        type: partial_prefix
+        num_prefix_prompts: 5
+        prefix_prompt_length: 740
+        random_seed: 2
+        seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
+    - name: pd-seed3
+      concurrency: 40
+      duration_minutes: 60.0
+      shape:
+        type: partial_prefix
+        num_prefix_prompts: 5
+        prefix_prompt_length: 740
+        random_seed: 3
+        seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
+  common:
+    request_timeout_seconds: 30
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never
+
+# Explicit events list (overrides rung auto-generation, which would serialize).
+# Pollers start first; then 3 non-blocking StartLoads (concurrent); then the
+# 3 completion waits.
+events:
+  - kind: WaitForModelReady
+    timeout: 1800
+  - kind: PodMemoryPoller
+    services: [Frontend, prefill, decode]
+    interval_s: 5
+  - kind: PodMemoryPoller2
+    services: [Frontend, prefill, decode]
+    interval_s: 5
+  - kind: StartLoad
+    load_ref: pd-seed1
+  - kind: StartLoad
+    load_ref: pd-seed2
+  - kind: StartLoad
+    load_ref: pd-seed3
+  - kind: WaitForLoadCompletion
+    name: pd-seed1
+  - kind: WaitForLoadCompletion
+    name: pd-seed2
+  - kind: WaitForLoadCompletion
+    name: pd-seed3
+
+reports:
+  - PerWorkerLatencyReport
+  - ErrorBreakdownReport
+
+checks:
+  - kind: LoadApplied
+    load_name: pd-seed1
+    min_requests: 3000
+  - kind: WorkerPanics
+    services: [Frontend, prefill, decode]
+    acceptable: true
+  - kind: RestartCountIncreased
+    services: [Frontend, prefill, decode]
+    expect_min_increment: 0

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_pD_3x_pool5_nscale_15set.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2_pD_3x_pool5_nscale_15set.yaml
@@ -116,9 +116,6 @@ events:
   - kind: ResourcePoller
     services: [Frontend, prefill, decode]
     interval_s: 5
-  - kind: ResourcePoller
-    services: [Frontend, prefill, decode]
-    interval_s: 5
   - kind: StartLoad
     load_ref: pd-seed1
   - kind: StartLoad

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2llm_baseline_ll_v111_n3.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2llm_baseline_ll_v111_n3.yaml
@@ -1,0 +1,82 @@
+# E2 LL-vs-KV memory — Arm 1 (baseline LL): v1.1.1, least-loaded, N=3 (3FE+6P+3D, TP=2).
+# 60-min steady FE-memory test. v1.1.1 LL ties are deterministic by default.
+# Template vllm/disagg_qwen3_30b_unit_e1; steady c=46 (=0.8*C_max=58), hardcoded.
+
+kind: router_memory
+name: e2llm_baseline_ll_v111
+
+labels:
+  purpose: e2_ll_vs_kv_memory
+  arm: e2llm_baseline_ll_v111
+  router_mode: least_loaded
+  deployment: disagg
+  backend: vllm
+  cluster: aws-dev-02
+
+deployment:
+  backend: vllm
+  topology: disagg
+  units: 3
+  template: disagg_qwen3_30b_unit_e1
+  image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1
+  model_cache_pvc: shared-model-cache
+  log_pvc: dynamo-ft-logs
+
+router:
+  mode: least-loaded
+  knobs:
+    DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
+    DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
+
+admission:
+  knobs:
+    DYN_TCP_WORKER_POOL_SIZE: "128"
+    DYN_TCP_WORK_QUEUE_SIZE: "5"
+    VLLM_NIXL_ABORT_REQUEST_TIMEOUT: "30"
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30"
+
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 5
+    prefix_prompt_length: 740
+    seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
+  rungs:
+    - name: warmup
+      concurrency: 16
+      duration_minutes: 2.0
+    - name: steady
+      concurrency: 46
+      duration_minutes: 60.0
+  common:
+    request_timeout_seconds: 30
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never
+
+events:
+  - kind: WaitForModelReady
+    timeout: 2400
+  - kind: ResourcePoller
+    services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
+    interval_s: 5
+  - kind: StartLoad
+    load_ref: warmup
+  - kind: WaitForLoadCompletion
+    name: warmup
+  - kind: StartLoad
+    load_ref: steady
+  - kind: WaitForLoadCompletion
+    name: steady
+
+reports:
+  - PerWorkerLatencyReport
+  - ErrorBreakdownReport
+
+checks:
+  - kind: LoadApplied
+    load_name: steady
+    min_requests: 2000
+  - kind: WorkerPanics
+    services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
+    acceptable: true

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2llm_best_ll_n3.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2llm_best_ll_n3.yaml
@@ -1,0 +1,82 @@
+# E2 LL-vs-KV memory — Arm 2 (best LL): 1.2 (a5c93b3331), least-loaded, N=3.
+# 60-min steady FE-memory test. 1.2 reservoir-sample tie-breaks are default.
+# Template vllm/disagg_qwen3_30b_unit_e1; steady c=46 (=0.8*C_max=58), hardcoded.
+
+kind: router_memory
+name: e2llm_best_ll
+
+labels:
+  purpose: e2_ll_vs_kv_memory
+  arm: e2llm_best_ll
+  router_mode: least_loaded
+  deployment: disagg
+  backend: vllm
+  cluster: aws-dev-02
+
+deployment:
+  backend: vllm
+  topology: disagg
+  units: 3
+  template: disagg_qwen3_30b_unit_e1
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-mocker-prefill-pinning-a5c93b3331-neelays
+  model_cache_pvc: shared-model-cache
+  log_pvc: dynamo-ft-logs
+
+router:
+  mode: least-loaded
+  knobs:
+    DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
+    DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
+
+admission:
+  knobs:
+    DYN_TCP_WORKER_POOL_SIZE: "128"
+    DYN_TCP_WORK_QUEUE_SIZE: "5"
+    VLLM_NIXL_ABORT_REQUEST_TIMEOUT: "30"
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30"
+
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 5
+    prefix_prompt_length: 740
+    seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
+  rungs:
+    - name: warmup
+      concurrency: 16
+      duration_minutes: 2.0
+    - name: steady
+      concurrency: 46
+      duration_minutes: 60.0
+  common:
+    request_timeout_seconds: 30
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never
+
+events:
+  - kind: WaitForModelReady
+    timeout: 2400
+  - kind: ResourcePoller
+    services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
+    interval_s: 5
+  - kind: StartLoad
+    load_ref: warmup
+  - kind: WaitForLoadCompletion
+    name: warmup
+  - kind: StartLoad
+    load_ref: steady
+  - kind: WaitForLoadCompletion
+    name: steady
+
+reports:
+  - PerWorkerLatencyReport
+  - ErrorBreakdownReport
+
+checks:
+  - kind: LoadApplied
+    load_name: steady
+    min_requests: 2000
+  - kind: WorkerPanics
+    services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
+    acceptable: true

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2llm_kv_events_n3.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2llm_kv_events_n3.yaml
@@ -1,0 +1,89 @@
+# E2 LL-vs-KV memory — Arm 4 (KV + events): 1.2 (a5c93b3331), kv load-aware, events ON, N=3.
+# 60-min steady FE-memory test. events on, overlap-score 1.0 (default) + replica-sync on —
+# full KV-aware path; overlap-scoring/indexer is the suspected leak driver. Single-variable
+# contrast vs Arm 3 recommended (events off / overlap 0.0), replica-sync held constant.
+
+kind: router_memory
+name: e2llm_kv_events
+
+labels:
+  purpose: e2_ll_vs_kv_memory
+  arm: e2llm_kv_events
+  router_mode: kv
+  deployment: disagg
+  backend: vllm
+  cluster: aws-dev-02
+
+deployment:
+  backend: vllm
+  topology: disagg
+  units: 3
+  template: disagg_qwen3_30b_unit_e1
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-mocker-prefill-pinning-a5c93b3331-neelays
+  model_cache_pvc: shared-model-cache
+  log_pvc: dynamo-ft-logs
+
+router:
+  mode: kv
+  knobs:
+    DYN_ROUTER_USE_KV_EVENTS: "true"
+    DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT: "1.0"
+    DYN_ROUTER_PREFILL_LOAD_SCALE: "1.0"
+    DYN_ROUTER_QUEUE_THRESHOLD: "4.0"
+    DYN_ROUTER_QUEUE_POLICY: "fcfs"
+    DYN_ROUTER_REPLICA_SYNC: "true"
+    DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
+    DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
+
+admission:
+  knobs:
+    DYN_TCP_WORKER_POOL_SIZE: "128"
+    DYN_TCP_WORK_QUEUE_SIZE: "5"
+    VLLM_NIXL_ABORT_REQUEST_TIMEOUT: "30"
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30"
+
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 5
+    prefix_prompt_length: 740
+    seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
+  rungs:
+    - name: warmup
+      concurrency: 16
+      duration_minutes: 2.0
+    - name: steady
+      concurrency: 46
+      duration_minutes: 60.0
+  common:
+    request_timeout_seconds: 30
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never
+
+events:
+  - kind: WaitForModelReady
+    timeout: 2400
+  - kind: ResourcePoller
+    services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
+    interval_s: 5
+  - kind: StartLoad
+    load_ref: warmup
+  - kind: WaitForLoadCompletion
+    name: warmup
+  - kind: StartLoad
+    load_ref: steady
+  - kind: WaitForLoadCompletion
+    name: steady
+
+reports:
+  - PerWorkerLatencyReport
+  - ErrorBreakdownReport
+
+checks:
+  - kind: LoadApplied
+    load_name: steady
+    min_requests: 2000
+  - kind: WorkerPanics
+    services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
+    acceptable: true

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2llm_recommended_kv_n3.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2llm_recommended_kv_n3.yaml
@@ -1,0 +1,88 @@
+# E2 LL-vs-KV memory — Arm 3 (recommended KV): 1.2 (a5c93b3331), kv load-aware + replica-sync, N=3.
+# 60-min steady FE-memory test. KV-aware, leak knobs zeroed (events off, overlap 0.0).
+# Template vllm/disagg_qwen3_30b_unit_e1; steady c=46 (=0.8*C_max=58), hardcoded.
+
+kind: router_memory
+name: e2llm_recommended_kv
+
+labels:
+  purpose: e2_ll_vs_kv_memory
+  arm: e2llm_recommended_kv
+  router_mode: kv
+  deployment: disagg
+  backend: vllm
+  cluster: aws-dev-02
+
+deployment:
+  backend: vllm
+  topology: disagg
+  units: 3
+  template: disagg_qwen3_30b_unit_e1
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-mocker-prefill-pinning-a5c93b3331-neelays
+  model_cache_pvc: shared-model-cache
+  log_pvc: dynamo-ft-logs
+
+router:
+  mode: kv
+  knobs:
+    DYN_ROUTER_USE_KV_EVENTS: "false"
+    DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT: "0.0"
+    DYN_ROUTER_PREFILL_LOAD_SCALE: "1.0"
+    DYN_ROUTER_QUEUE_THRESHOLD: "4.0"
+    DYN_ROUTER_QUEUE_POLICY: "fcfs"
+    DYN_ROUTER_REPLICA_SYNC: "true"
+    DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
+    DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
+
+admission:
+  knobs:
+    DYN_TCP_WORKER_POOL_SIZE: "128"
+    DYN_TCP_WORK_QUEUE_SIZE: "5"
+    VLLM_NIXL_ABORT_REQUEST_TIMEOUT: "30"
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30"
+
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 5
+    prefix_prompt_length: 740
+    seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
+  rungs:
+    - name: warmup
+      concurrency: 16
+      duration_minutes: 2.0
+    - name: steady
+      concurrency: 46
+      duration_minutes: 60.0
+  common:
+    request_timeout_seconds: 30
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never
+
+events:
+  - kind: WaitForModelReady
+    timeout: 2400
+  - kind: ResourcePoller
+    services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
+    interval_s: 5
+  - kind: StartLoad
+    load_ref: warmup
+  - kind: WaitForLoadCompletion
+    name: warmup
+  - kind: StartLoad
+    load_ref: steady
+  - kind: WaitForLoadCompletion
+    name: steady
+
+reports:
+  - PerWorkerLatencyReport
+  - ErrorBreakdownReport
+
+checks:
+  - kind: LoadApplied
+    load_name: steady
+    min_requests: 2000
+  - kind: WorkerPanics
+    services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
+    acceptable: true

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2ovl_arm_a_ll_mock_n15.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2ovl_arm_a_ll_mock_n15.yaml
@@ -1,0 +1,116 @@
+# E2-overload Arm A — LL BASELINE (v1.1.1 worst-case), N=15 mocker (nscale).
+#
+# Mocker parallel of e2ovl_arm_a_ll_n5. Fully-unprotected baseline:
+#   - DYN_ROUTER_LL_DETERMINISTIC_TIES=1 (sticky tie-breaks, pre-#9516).
+#   - NO router active thresholds.
+#   - Worker TCP-gate at STOCK DEFAULTS (1500/6000), explicit -> no effective gate.
+# speedup-ratio=1.0 (bundled mocker disagg.yaml). 15 FE + 30 prefill + 15 decode.
+# C_max=561 (nscale mocker sweep). steady=393 (~0.7xC_max, clean), burst=786 (2x).
+# 120-min trapezoid, 3x bursts. SLA/timeout/goodput=15s.
+
+kind: router_memory
+name: e2ovl_arm_a_ll_mock_n15
+description: |
+  E2-overload arm A (LL baseline, mocker). 15/30/15 mocker-disagg, least-loaded
+  DETERMINISTIC ties, no thresholds, worker TCP-gate at stock defaults (explicit).
+  120-min trapezoid with 3x 2x-bursts.
+
+labels:
+  purpose: e2_overload_arm
+  arm: e2ovl_arm_a_ll_mock
+  router_mode: least_loaded_deterministic_ties
+  deployment: disagg
+  backend: mocker
+  cluster: nscale-dev-cluster
+
+deployment:
+  backend: mocker
+  topology: disagg
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-mocker-prefill-pinning-a5c93b3331-neelays
+  log_pvc: dynamo-ft-logs
+  replicas:
+    Frontend: 15
+    prefill: 30
+    decode: 15
+
+router:
+  mode: least-loaded
+  knobs:
+    DYN_ROUTER_LL_DETERMINISTIC_TIES: "1"
+    DYN_ROUTER_USE_KV_EVENTS: "false"
+    # NO DYN_ACTIVE_* thresholds.
+    DYN_EVENT_PLANE: "zmq"
+    DYN_DISCOVERY_BACKEND: "kubernetes"
+    DYN_STORE_KV: "mem"
+
+admission:
+  knobs:
+    # Stock v1.1.1 defaults, explicit (no effective gate at our loads).
+    DYN_TCP_WORKER_POOL_SIZE: "1500"
+    DYN_TCP_WORK_QUEUE_SIZE: "6000"
+    VLLM_NIXL_ABORT_REQUEST_TIMEOUT: "30"
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30"
+
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 5
+    prefix_prompt_length: 740
+    seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
+  rungs:
+    - { name: warmup,   concurrency: 16,  duration_minutes: 2.0 }
+    - { name: ramp,     concurrency: 393, duration_minutes: 1.0 }
+    - { name: steady-1, concurrency: 393, duration_minutes: 20.0 }
+    - { name: burst-1,  concurrency: 786, duration_minutes: 12.0 }
+    - { name: steady-2, concurrency: 393, duration_minutes: 20.0 }
+    - { name: burst-2,  concurrency: 786, duration_minutes: 12.0 }
+    - { name: steady-3, concurrency: 393, duration_minutes: 20.0 }
+    - { name: burst-3,  concurrency: 786, duration_minutes: 12.0 }
+    - { name: steady-4, concurrency: 393, duration_minutes: 19.0 }
+    - { name: rampdown, concurrency: 16,  duration_minutes: 2.0 }
+  common:
+    request_timeout_seconds: 15
+    goodput: ["request_latency:15000"]
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never
+
+events:
+  - { kind: WaitForModelReady, timeout: 1800 }
+  - kind: ResourcePoller
+    services: [Frontend, prefill, decode]
+    interval_s: 5
+  - { kind: StartLoad, load_ref: warmup }
+  - { kind: WaitForLoadCompletion, name: warmup }
+  - { kind: StartLoad, load_ref: ramp }
+  - { kind: WaitForLoadCompletion, name: ramp }
+  - { kind: StartLoad, load_ref: steady-1 }
+  - { kind: WaitForLoadCompletion, name: steady-1 }
+  - { kind: CaptureMetrics, suffix: ".baseline" }
+  - { kind: StartLoad, load_ref: burst-1 }
+  - { kind: WaitForLoadCompletion, name: burst-1 }
+  - { kind: CaptureMetrics, suffix: ".post-burst1" }
+  - { kind: StartLoad, load_ref: steady-2 }
+  - { kind: WaitForLoadCompletion, name: steady-2 }
+  - { kind: StartLoad, load_ref: burst-2 }
+  - { kind: WaitForLoadCompletion, name: burst-2 }
+  - { kind: CaptureMetrics, suffix: ".post-burst2" }
+  - { kind: StartLoad, load_ref: steady-3 }
+  - { kind: WaitForLoadCompletion, name: steady-3 }
+  - { kind: StartLoad, load_ref: burst-3 }
+  - { kind: WaitForLoadCompletion, name: burst-3 }
+  - { kind: CaptureMetrics, suffix: ".post-burst3" }
+  - { kind: StartLoad, load_ref: steady-4 }
+  - { kind: WaitForLoadCompletion, name: steady-4 }
+  - { kind: CaptureMetrics, suffix: ".final" }
+  - { kind: StartLoad, load_ref: rampdown }
+  - { kind: WaitForLoadCompletion, name: rampdown }
+
+reports:
+  - PerWorkerLatencyReport
+  - ErrorBreakdownReport
+
+checks:
+  - { kind: LoadApplied, load_name: burst-2, min_requests: 2000 }
+  - { kind: WorkerPanics, services: [Frontend, prefill, decode], acceptable: true }
+  - { kind: RestartCountIncreased, services: [Frontend, prefill, decode], expect_min_increment: 0 }

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2ovl_arm_a_ll_n5.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2ovl_arm_a_ll_n5.yaml
@@ -1,0 +1,132 @@
+# E2-overload Arm A — LL BASELINE (v1.1.1 worst-case), N=5 real-GPU (aws-dev-02).
+#
+# Admission-control ablation, arm 1 of 3 (A=LL-baseline / B=LL-best / C=KV-load-aware).
+# This arm is the FULLY-UNPROTECTED baseline:
+#   - DYN_ROUTER_LL_DETERMINISTIC_TIES=1  -> sticky-concentration tie-breaks
+#     (pre-#9516 v1.1.1 behavior; worst-case routing).
+#   - NO router-level active thresholds (no per-worker exclusion).
+#   - Worker TCP work-queue at the STOCK DEFAULTS (1500 pool / 6000 queue), set
+#     EXPLICITLY (not relying on code defaults). At our concurrencies (<=164) the
+#     6000-deep queue never rejects -> effectively no admission gate, like v1.1.1.
+# Shows what catastrophic degradation looks like with the admission stack OFF, so
+# arms B (LL-best) and C (KV) can be measured against it.
+#
+# Topology 5 FE + 10 prefill + 5 decode (30 GPU, prod 2:1). C_max=96 (aws N=5
+# sweep). steady=82 (0.85xC_max), burst=164 (2x steady = 1.7xC_max). 120-min:
+# warmup -> ramp -> [steady/burst]x3 -> steady -> rampdown. SLA/timeout/goodput=30s.
+
+kind: router_memory
+name: e2ovl_arm_a_ll_n5
+description: |
+  E2-overload arm A (LL baseline, v1.1.1 worst-case). 5/10/5 vllm-disagg,
+  least-loaded with DETERMINISTIC ties, no active thresholds, worker TCP-gate at
+  stock defaults (explicit). 120-min trapezoid with 3x 2x-bursts.
+
+labels:
+  purpose: e2_overload_arm
+  arm: e2ovl_arm_a_ll
+  router_mode: least_loaded_deterministic_ties
+  deployment: disagg
+  backend: vllm
+  cluster: aws-dev-02
+
+deployment:
+  backend: vllm
+  topology: disagg
+  template: disagg_qwen3_30b_unit_e1
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-mocker-prefill-pinning-a5c93b3331-neelays
+  model_cache_pvc: shared-model-cache
+  log_pvc: dynamo-ft-logs
+  replicas:
+    Frontend: 5
+    VllmPrefillWorker: 10
+    VllmDecodeWorker: 5
+
+router:
+  mode: least-loaded
+  knobs:
+    # Worst-case LL: deterministic (sticky) tie-breaks, NOT reservoir-sample.
+    DYN_ROUTER_LL_DETERMINISTIC_TIES: "1"
+    DYN_ROUTER_USE_KV_EVENTS: "false"
+    # NO DYN_ACTIVE_* thresholds — router does not exclude saturated workers.
+    # Event plane explicit (was defaulting to NATS); transport-env → FE + workers.
+    DYN_EVENT_PLANE: "zmq"
+    # Tier-1 run visibility (FE only): admission-gate engage/clear + router-queue backpressure.
+    DYN_LOG: "info,dynamo_llm::discovery::worker_monitor=debug,dynamo_kv_router::scheduling::queue=debug"
+
+admission:
+  knobs:
+    # Stock v1.1.1 defaults, set EXPLICITLY (do not rely on code defaults).
+    # 6000-deep queue never rejects at our loads -> effectively no admission gate.
+    DYN_TCP_WORKER_POOL_SIZE: "1500"
+    DYN_TCP_WORK_QUEUE_SIZE: "6000"
+    VLLM_NIXL_ABORT_REQUEST_TIMEOUT: "30"
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30"
+
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 5
+    prefix_prompt_length: 740
+    seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
+  rungs:
+    - { name: warmup,   concurrency: 16,  duration_minutes: 2.0 }
+    - { name: ramp,     concurrency: 82,  duration_minutes: 1.0 }
+    - { name: steady-1, concurrency: 82,  duration_minutes: 20.0 }
+    - { name: burst-1,  concurrency: 164, duration_minutes: 12.0 }
+    - { name: steady-2, concurrency: 82,  duration_minutes: 20.0 }
+    - { name: burst-2,  concurrency: 328, duration_minutes: 12.0 }
+    - { name: steady-3, concurrency: 82,  duration_minutes: 20.0 }
+    - { name: burst-3,  concurrency: 164, duration_minutes: 12.0 }
+    - { name: steady-4, concurrency: 82,  duration_minutes: 19.0 }
+    - { name: rampdown, concurrency: 10,  duration_minutes: 2.0 }
+  common:
+    request_timeout_seconds: 30
+    goodput: ["request_latency:30000"]
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never
+
+events:
+  - { kind: WaitForModelReady, timeout: 2400 }
+  - kind: ResourcePoller
+    services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
+    interval_s: 5
+  - { kind: StartLoad, load_ref: warmup }
+  - { kind: WaitForLoadCompletion, name: warmup }
+  - { kind: StartLoad, load_ref: ramp }
+  - { kind: WaitForLoadCompletion, name: ramp }
+  - { kind: StartLoad, load_ref: steady-1 }
+  - { kind: WaitForLoadCompletion, name: steady-1 }
+  - { kind: CaptureMetrics, suffix: ".baseline" }
+  - { kind: StartLoad, load_ref: burst-1 }
+  - { kind: WaitForLoadCompletion, name: burst-1 }
+  - { kind: CaptureMetrics, suffix: ".post-burst1" }
+  - { kind: StartLoad, load_ref: steady-2 }
+  - { kind: WaitForLoadCompletion, name: steady-2 }
+  - { kind: StartLoad, load_ref: burst-2 }
+  - { kind: WaitForLoadCompletion, name: burst-2 }
+  - { kind: CaptureMetrics, suffix: ".post-burst2" }
+  - { kind: StartLoad, load_ref: steady-3 }
+  - { kind: WaitForLoadCompletion, name: steady-3 }
+  - { kind: StartLoad, load_ref: burst-3 }
+  - { kind: WaitForLoadCompletion, name: burst-3 }
+  - { kind: CaptureMetrics, suffix: ".post-burst3" }
+  - { kind: StartLoad, load_ref: steady-4 }
+  - { kind: WaitForLoadCompletion, name: steady-4 }
+  - { kind: CaptureMetrics, suffix: ".final" }
+  - { kind: StartLoad, load_ref: rampdown }
+  - { kind: WaitForLoadCompletion, name: rampdown }
+
+reports:
+  - PerWorkerLatencyReport
+  - ErrorBreakdownReport
+
+checks:
+  # Sanity: the burst reached the cluster.
+  - { kind: LoadApplied, load_name: burst-2, min_requests: 2000 }
+  # Catastrophic-failure guards: no crashes, no pod restarts under sustained
+  # overload. KV / queue-depth / latency trajectory captured via CaptureMetrics
+  # + per-pod scrape (analysed offline), not gated here.
+  - { kind: WorkerPanics, services: [Frontend, VllmPrefillWorker, VllmDecodeWorker], acceptable: true }
+  - { kind: RestartCountIncreased, services: [Frontend, VllmPrefillWorker, VllmDecodeWorker], expect_min_increment: 0 }

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2ovl_arm_b_llbest_mock_n15.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2ovl_arm_b_llbest_mock_n15.yaml
@@ -1,0 +1,115 @@
+# E2-overload Arm B — LL-BEST (tuned least-loaded), N=15 mocker (nscale).
+#
+# Mocker parallel of e2ovl_arm_b_llbest_n5. Best-tuned LL, full admission stack:
+#   - DYN_ROUTER_LL_DETERMINISTIC_TIES=0 (reservoir #9516, explicit).
+#   - DYN_ACTIVE_* thresholds 0.85.
+#   - Worker TCP-gate tuned 128/5.
+# 15 FE + 30 prefill + 15 decode. steady=393 (~0.7xC_max=561), burst=786 (2x).
+# 120-min trapezoid, 3x bursts. SLA/timeout/goodput=15s.
+
+kind: router_memory
+name: e2ovl_arm_b_llbest_mock_n15
+description: |
+  E2-overload arm B (LL-best, mocker). 15/30/15 mocker-disagg, least-loaded
+  reservoir ties + 0.85 thresholds + tuned worker TCP-gate (128/5). 120-min
+  trapezoid with 3x 2x-bursts.
+
+labels:
+  purpose: e2_overload_arm
+  arm: e2ovl_arm_b_llbest_mock
+  router_mode: least_loaded
+  deployment: disagg
+  backend: mocker
+  cluster: nscale-dev-cluster
+
+deployment:
+  backend: mocker
+  topology: disagg
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-mocker-prefill-pinning-a5c93b3331-neelays
+  log_pvc: dynamo-ft-logs
+  replicas:
+    Frontend: 15
+    prefill: 30
+    decode: 15
+
+router:
+  mode: least-loaded
+  knobs:
+    DYN_ROUTER_LL_DETERMINISTIC_TIES: "0"
+    DYN_ROUTER_USE_KV_EVENTS: "false"
+    DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
+    DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
+    DYN_EVENT_PLANE: "zmq"
+    DYN_DISCOVERY_BACKEND: "kubernetes"
+    DYN_STORE_KV: "mem"
+
+admission:
+  knobs:
+    DYN_TCP_WORKER_POOL_SIZE: "128"
+    DYN_TCP_WORK_QUEUE_SIZE: "5"
+    VLLM_NIXL_ABORT_REQUEST_TIMEOUT: "30"
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30"
+
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 5
+    prefix_prompt_length: 740
+    seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
+  rungs:
+    - { name: warmup,   concurrency: 16,  duration_minutes: 2.0 }
+    - { name: ramp,     concurrency: 393, duration_minutes: 1.0 }
+    - { name: steady-1, concurrency: 393, duration_minutes: 20.0 }
+    - { name: burst-1,  concurrency: 786, duration_minutes: 12.0 }
+    - { name: steady-2, concurrency: 393, duration_minutes: 20.0 }
+    - { name: burst-2,  concurrency: 786, duration_minutes: 12.0 }
+    - { name: steady-3, concurrency: 393, duration_minutes: 20.0 }
+    - { name: burst-3,  concurrency: 786, duration_minutes: 12.0 }
+    - { name: steady-4, concurrency: 393, duration_minutes: 19.0 }
+    - { name: rampdown, concurrency: 16,  duration_minutes: 2.0 }
+  common:
+    request_timeout_seconds: 15
+    goodput: ["request_latency:15000"]
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never
+
+events:
+  - { kind: WaitForModelReady, timeout: 1800 }
+  - kind: ResourcePoller
+    services: [Frontend, prefill, decode]
+    interval_s: 5
+  - { kind: StartLoad, load_ref: warmup }
+  - { kind: WaitForLoadCompletion, name: warmup }
+  - { kind: StartLoad, load_ref: ramp }
+  - { kind: WaitForLoadCompletion, name: ramp }
+  - { kind: StartLoad, load_ref: steady-1 }
+  - { kind: WaitForLoadCompletion, name: steady-1 }
+  - { kind: CaptureMetrics, suffix: ".baseline" }
+  - { kind: StartLoad, load_ref: burst-1 }
+  - { kind: WaitForLoadCompletion, name: burst-1 }
+  - { kind: CaptureMetrics, suffix: ".post-burst1" }
+  - { kind: StartLoad, load_ref: steady-2 }
+  - { kind: WaitForLoadCompletion, name: steady-2 }
+  - { kind: StartLoad, load_ref: burst-2 }
+  - { kind: WaitForLoadCompletion, name: burst-2 }
+  - { kind: CaptureMetrics, suffix: ".post-burst2" }
+  - { kind: StartLoad, load_ref: steady-3 }
+  - { kind: WaitForLoadCompletion, name: steady-3 }
+  - { kind: StartLoad, load_ref: burst-3 }
+  - { kind: WaitForLoadCompletion, name: burst-3 }
+  - { kind: CaptureMetrics, suffix: ".post-burst3" }
+  - { kind: StartLoad, load_ref: steady-4 }
+  - { kind: WaitForLoadCompletion, name: steady-4 }
+  - { kind: CaptureMetrics, suffix: ".final" }
+  - { kind: StartLoad, load_ref: rampdown }
+  - { kind: WaitForLoadCompletion, name: rampdown }
+
+reports:
+  - PerWorkerLatencyReport
+  - ErrorBreakdownReport
+
+checks:
+  - { kind: LoadApplied, load_name: burst-2, min_requests: 2000 }
+  - { kind: WorkerPanics, services: [Frontend, prefill, decode], acceptable: true }
+  - { kind: RestartCountIncreased, services: [Frontend, prefill, decode], expect_min_increment: 0 }

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2ovl_arm_b_llbest_n5.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2ovl_arm_b_llbest_n5.yaml
@@ -1,0 +1,125 @@
+# E2-overload Arm B — LL-BEST (tuned least-loaded), N=5 real-GPU (aws-dev-02).
+#
+# Admission-control ablation, arm 2 of 3 (A=LL-baseline / B=LL-best / C=KV-load-aware).
+# Best-tuned LL with the FULL admission stack ON:
+#   - DYN_ROUTER_LL_DETERMINISTIC_TIES=0 -> reservoir-sample tie-breaks (#9516),
+#     set EXPLICITLY (not relying on the image default).
+#   - DYN_ACTIVE_* thresholds 0.85 -> router excludes >85%-full decode/prefill workers.
+#   - Worker TCP-gate tuned to 128 pool / 5 queue -> bounded admission, backpressure.
+# Measured against arm A (unprotected baseline) under identical 2x bursts.
+#
+# Topology 5 FE + 10 prefill + 5 decode (30 GPU, prod 2:1). steady=82 (0.85xC_max=96),
+# burst=164. 120-min trapezoid, 3x bursts. SLA/timeout/goodput=30s.
+
+kind: router_memory
+name: e2ovl_arm_b_llbest_n5
+description: |
+  E2-overload arm B (LL-best). 5/10/5 vllm-disagg, least-loaded with reservoir
+  ties + 0.85 active thresholds + tuned worker TCP-gate (128/5). 120-min
+  trapezoid with 3x 2x-bursts.
+
+labels:
+  purpose: e2_overload_arm
+  arm: e2ovl_arm_b_llbest
+  router_mode: least_loaded
+  deployment: disagg
+  backend: vllm
+  cluster: aws-dev-02
+
+deployment:
+  backend: vllm
+  topology: disagg
+  template: disagg_qwen3_30b_unit_e1
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-mocker-prefill-pinning-a5c93b3331-neelays
+  model_cache_pvc: shared-model-cache
+  log_pvc: dynamo-ft-logs
+  replicas:
+    Frontend: 5
+    VllmPrefillWorker: 10
+    VllmDecodeWorker: 5
+
+router:
+  mode: least-loaded
+  knobs:
+    # Best LL: reservoir-sample tie-breaks (#9516), set EXPLICITLY (not default).
+    DYN_ROUTER_LL_DETERMINISTIC_TIES: "0"
+    DYN_ROUTER_USE_KV_EVENTS: "false"
+    # Router-level active-threshold exclusion of near-saturated workers.
+    DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
+    DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
+    # Event plane explicit (was defaulting to NATS); transport-env → FE + workers.
+    DYN_EVENT_PLANE: "zmq"
+    # Tier-1 run visibility (FE only): admission-gate engage/clear + router-queue backpressure.
+    DYN_LOG: "info,dynamo_llm::discovery::worker_monitor=debug,dynamo_kv_router::scheduling::queue=debug"
+
+admission:
+  knobs:
+    # Tuned worker TCP work-queue gate (bounded -> backpressure under overload).
+    DYN_TCP_WORKER_POOL_SIZE: "128"
+    DYN_TCP_WORK_QUEUE_SIZE: "5"
+    VLLM_NIXL_ABORT_REQUEST_TIMEOUT: "30"
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30"
+
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 5
+    prefix_prompt_length: 740
+    seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
+  rungs:
+    - { name: warmup,   concurrency: 16,  duration_minutes: 2.0 }
+    - { name: ramp,     concurrency: 82,  duration_minutes: 1.0 }
+    - { name: steady-1, concurrency: 82,  duration_minutes: 20.0 }
+    - { name: burst-1,  concurrency: 164, duration_minutes: 12.0 }
+    - { name: steady-2, concurrency: 82,  duration_minutes: 20.0 }
+    - { name: burst-2,  concurrency: 328, duration_minutes: 12.0 }
+    - { name: steady-3, concurrency: 82,  duration_minutes: 20.0 }
+    - { name: burst-3,  concurrency: 164, duration_minutes: 12.0 }
+    - { name: steady-4, concurrency: 82,  duration_minutes: 19.0 }
+    - { name: rampdown, concurrency: 10,  duration_minutes: 2.0 }
+  common:
+    request_timeout_seconds: 30
+    goodput: ["request_latency:30000"]
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never
+
+events:
+  - { kind: WaitForModelReady, timeout: 2400 }
+  - kind: ResourcePoller
+    services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
+    interval_s: 5
+  - { kind: StartLoad, load_ref: warmup }
+  - { kind: WaitForLoadCompletion, name: warmup }
+  - { kind: StartLoad, load_ref: ramp }
+  - { kind: WaitForLoadCompletion, name: ramp }
+  - { kind: StartLoad, load_ref: steady-1 }
+  - { kind: WaitForLoadCompletion, name: steady-1 }
+  - { kind: CaptureMetrics, suffix: ".baseline" }
+  - { kind: StartLoad, load_ref: burst-1 }
+  - { kind: WaitForLoadCompletion, name: burst-1 }
+  - { kind: CaptureMetrics, suffix: ".post-burst1" }
+  - { kind: StartLoad, load_ref: steady-2 }
+  - { kind: WaitForLoadCompletion, name: steady-2 }
+  - { kind: StartLoad, load_ref: burst-2 }
+  - { kind: WaitForLoadCompletion, name: burst-2 }
+  - { kind: CaptureMetrics, suffix: ".post-burst2" }
+  - { kind: StartLoad, load_ref: steady-3 }
+  - { kind: WaitForLoadCompletion, name: steady-3 }
+  - { kind: StartLoad, load_ref: burst-3 }
+  - { kind: WaitForLoadCompletion, name: burst-3 }
+  - { kind: CaptureMetrics, suffix: ".post-burst3" }
+  - { kind: StartLoad, load_ref: steady-4 }
+  - { kind: WaitForLoadCompletion, name: steady-4 }
+  - { kind: CaptureMetrics, suffix: ".final" }
+  - { kind: StartLoad, load_ref: rampdown }
+  - { kind: WaitForLoadCompletion, name: rampdown }
+
+reports:
+  - PerWorkerLatencyReport
+  - ErrorBreakdownReport
+
+checks:
+  - { kind: LoadApplied, load_name: burst-2, min_requests: 2000 }
+  - { kind: WorkerPanics, services: [Frontend, VllmPrefillWorker, VllmDecodeWorker], acceptable: true }
+  - { kind: RestartCountIncreased, services: [Frontend, VllmPrefillWorker, VllmDecodeWorker], expect_min_increment: 0 }

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2ovl_arm_c_kv_mock_n15.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2ovl_arm_c_kv_mock_n15.yaml
@@ -1,0 +1,119 @@
+# E2-overload Arm C — KV LOAD-AWARE (recommended), N=15 mocker (nscale).
+#
+# Mocker parallel of e2ovl_arm_c_kv_n5. Recommended KV load-aware, full stack:
+#   - mode=kv, events OFF, overlap 0.0, replica-sync ON, queue threshold 4.0, fcfs.
+#   - DYN_ACTIVE_* thresholds 0.85.
+#   - Worker TCP-gate tuned 128/5.
+# 15 FE + 30 prefill + 15 decode. steady=393 (~0.7xC_max=561), burst=786 (2x).
+# 120-min trapezoid, 3x bursts. SLA/timeout/goodput=15s.
+
+kind: router_memory
+name: e2ovl_arm_c_kv_mock_n15
+description: |
+  E2-overload arm C (KV load-aware, mocker). 15/30/15 mocker-disagg, kv router
+  (events off, overlap 0.0, replica-sync) + 0.85 thresholds + tuned worker
+  TCP-gate (128/5). 120-min trapezoid with 3x 2x-bursts.
+
+labels:
+  purpose: e2_overload_arm
+  arm: e2ovl_arm_c_kv_mock
+  router_mode: kv
+  deployment: disagg
+  backend: mocker
+  cluster: nscale-dev-cluster
+
+deployment:
+  backend: mocker
+  topology: disagg
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-mocker-prefill-pinning-a5c93b3331-neelays
+  log_pvc: dynamo-ft-logs
+  replicas:
+    Frontend: 15
+    prefill: 30
+    decode: 15
+
+router:
+  mode: kv
+  knobs:
+    DYN_ROUTER_USE_KV_EVENTS: "false"
+    DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT: "0.0"
+    DYN_ROUTER_PREFILL_LOAD_SCALE: "1.0"
+    DYN_ROUTER_QUEUE_THRESHOLD: "4.0"
+    DYN_ROUTER_QUEUE_POLICY: "fcfs"
+    DYN_ROUTER_REPLICA_SYNC: "true"
+    DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
+    DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
+    DYN_EVENT_PLANE: "zmq"
+    DYN_DISCOVERY_BACKEND: "kubernetes"
+    DYN_STORE_KV: "mem"
+
+admission:
+  knobs:
+    DYN_TCP_WORKER_POOL_SIZE: "128"
+    DYN_TCP_WORK_QUEUE_SIZE: "5"
+    VLLM_NIXL_ABORT_REQUEST_TIMEOUT: "30"
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30"
+
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 5
+    prefix_prompt_length: 740
+    seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
+  rungs:
+    - { name: warmup,   concurrency: 16,  duration_minutes: 2.0 }
+    - { name: ramp,     concurrency: 393, duration_minutes: 1.0 }
+    - { name: steady-1, concurrency: 393, duration_minutes: 20.0 }
+    - { name: burst-1,  concurrency: 786, duration_minutes: 12.0 }
+    - { name: steady-2, concurrency: 393, duration_minutes: 20.0 }
+    - { name: burst-2,  concurrency: 786, duration_minutes: 12.0 }
+    - { name: steady-3, concurrency: 393, duration_minutes: 20.0 }
+    - { name: burst-3,  concurrency: 786, duration_minutes: 12.0 }
+    - { name: steady-4, concurrency: 393, duration_minutes: 19.0 }
+    - { name: rampdown, concurrency: 16,  duration_minutes: 2.0 }
+  common:
+    request_timeout_seconds: 15
+    goodput: ["request_latency:15000"]
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never
+
+events:
+  - { kind: WaitForModelReady, timeout: 1800 }
+  - kind: ResourcePoller
+    services: [Frontend, prefill, decode]
+    interval_s: 5
+  - { kind: StartLoad, load_ref: warmup }
+  - { kind: WaitForLoadCompletion, name: warmup }
+  - { kind: StartLoad, load_ref: ramp }
+  - { kind: WaitForLoadCompletion, name: ramp }
+  - { kind: StartLoad, load_ref: steady-1 }
+  - { kind: WaitForLoadCompletion, name: steady-1 }
+  - { kind: CaptureMetrics, suffix: ".baseline" }
+  - { kind: StartLoad, load_ref: burst-1 }
+  - { kind: WaitForLoadCompletion, name: burst-1 }
+  - { kind: CaptureMetrics, suffix: ".post-burst1" }
+  - { kind: StartLoad, load_ref: steady-2 }
+  - { kind: WaitForLoadCompletion, name: steady-2 }
+  - { kind: StartLoad, load_ref: burst-2 }
+  - { kind: WaitForLoadCompletion, name: burst-2 }
+  - { kind: CaptureMetrics, suffix: ".post-burst2" }
+  - { kind: StartLoad, load_ref: steady-3 }
+  - { kind: WaitForLoadCompletion, name: steady-3 }
+  - { kind: StartLoad, load_ref: burst-3 }
+  - { kind: WaitForLoadCompletion, name: burst-3 }
+  - { kind: CaptureMetrics, suffix: ".post-burst3" }
+  - { kind: StartLoad, load_ref: steady-4 }
+  - { kind: WaitForLoadCompletion, name: steady-4 }
+  - { kind: CaptureMetrics, suffix: ".final" }
+  - { kind: StartLoad, load_ref: rampdown }
+  - { kind: WaitForLoadCompletion, name: rampdown }
+
+reports:
+  - PerWorkerLatencyReport
+  - ErrorBreakdownReport
+
+checks:
+  - { kind: LoadApplied, load_name: burst-2, min_requests: 2000 }
+  - { kind: WorkerPanics, services: [Frontend, prefill, decode], acceptable: true }
+  - { kind: RestartCountIncreased, services: [Frontend, prefill, decode], expect_min_increment: 0 }

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2ovl_arm_c_kv_n5.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2ovl_arm_c_kv_n5.yaml
@@ -1,0 +1,126 @@
+# E2-overload Arm C — KV LOAD-AWARE (recommended), N=5 real-GPU (aws-dev-02).
+#
+# Admission-control ablation, arm 3 of 3 (A=LL-baseline / B=LL-best / C=KV-load-aware).
+# Recommended KV load-aware routing with the FULL admission stack ON:
+#   - mode=kv, events OFF, overlap weight 0.0 -> pure load/queue-aware (no prefix bias).
+#   - replica-sync ON (cross-FE load view), queue threshold 4.0, fcfs.
+#   - DYN_ACTIVE_* thresholds 0.85 -> router excludes near-saturated workers.
+#   - Worker TCP-gate tuned to 128 pool / 5 queue.
+# Measured against arm A (unprotected baseline) under identical 2x bursts.
+#
+# Topology 5 FE + 10 prefill + 5 decode (30 GPU, prod 2:1). steady=82 (0.85xC_max=96),
+# burst=164. 120-min trapezoid, 3x bursts. SLA/timeout/goodput=30s.
+
+kind: router_memory
+name: e2ovl_arm_c_kv_n5
+description: |
+  E2-overload arm C (KV load-aware, recommended). 5/10/5 vllm-disagg, kv router
+  (events off, overlap 0.0, replica-sync) + 0.85 active thresholds + tuned worker
+  TCP-gate (128/5). 120-min trapezoid with 3x 2x-bursts.
+
+labels:
+  purpose: e2_overload_arm
+  arm: e2ovl_arm_c_kv
+  router_mode: kv
+  deployment: disagg
+  backend: vllm
+  cluster: aws-dev-02
+
+deployment:
+  backend: vllm
+  topology: disagg
+  template: disagg_qwen3_30b_unit_e1
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-mocker-prefill-pinning-a5c93b3331-neelays
+  model_cache_pvc: shared-model-cache
+  log_pvc: dynamo-ft-logs
+  replicas:
+    Frontend: 5
+    VllmPrefillWorker: 10
+    VllmDecodeWorker: 5
+
+router:
+  mode: kv
+  knobs:
+    DYN_ROUTER_USE_KV_EVENTS: "false"
+    DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT: "0.0"
+    DYN_ROUTER_PREFILL_LOAD_SCALE: "1.0"
+    DYN_ROUTER_QUEUE_THRESHOLD: "4.0"
+    DYN_ROUTER_QUEUE_POLICY: "fcfs"
+    DYN_ROUTER_REPLICA_SYNC: "true"
+    DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
+    DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
+    # Event plane explicit (was defaulting to NATS); transport-env → FE + workers.
+    DYN_EVENT_PLANE: "zmq"
+    # Tier-1 run visibility (FE only): admission-gate engage/clear + router-queue backpressure.
+    DYN_LOG: "info,dynamo_llm::discovery::worker_monitor=debug,dynamo_kv_router::scheduling::queue=debug"
+
+admission:
+  knobs:
+    DYN_TCP_WORKER_POOL_SIZE: "128"
+    DYN_TCP_WORK_QUEUE_SIZE: "5"
+    VLLM_NIXL_ABORT_REQUEST_TIMEOUT: "30"
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30"
+
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 5
+    prefix_prompt_length: 740
+    seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
+  rungs:
+    - { name: warmup,   concurrency: 16,  duration_minutes: 2.0 }
+    - { name: ramp,     concurrency: 82,  duration_minutes: 1.0 }
+    - { name: steady-1, concurrency: 82,  duration_minutes: 20.0 }
+    - { name: burst-1,  concurrency: 164, duration_minutes: 12.0 }
+    - { name: steady-2, concurrency: 82,  duration_minutes: 20.0 }
+    - { name: burst-2,  concurrency: 328, duration_minutes: 12.0 }
+    - { name: steady-3, concurrency: 82,  duration_minutes: 20.0 }
+    - { name: burst-3,  concurrency: 164, duration_minutes: 12.0 }
+    - { name: steady-4, concurrency: 82,  duration_minutes: 19.0 }
+    - { name: rampdown, concurrency: 10,  duration_minutes: 2.0 }
+  common:
+    request_timeout_seconds: 30
+    goodput: ["request_latency:30000"]
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never
+
+events:
+  - { kind: WaitForModelReady, timeout: 2400 }
+  - kind: ResourcePoller
+    services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
+    interval_s: 5
+  - { kind: StartLoad, load_ref: warmup }
+  - { kind: WaitForLoadCompletion, name: warmup }
+  - { kind: StartLoad, load_ref: ramp }
+  - { kind: WaitForLoadCompletion, name: ramp }
+  - { kind: StartLoad, load_ref: steady-1 }
+  - { kind: WaitForLoadCompletion, name: steady-1 }
+  - { kind: CaptureMetrics, suffix: ".baseline" }
+  - { kind: StartLoad, load_ref: burst-1 }
+  - { kind: WaitForLoadCompletion, name: burst-1 }
+  - { kind: CaptureMetrics, suffix: ".post-burst1" }
+  - { kind: StartLoad, load_ref: steady-2 }
+  - { kind: WaitForLoadCompletion, name: steady-2 }
+  - { kind: StartLoad, load_ref: burst-2 }
+  - { kind: WaitForLoadCompletion, name: burst-2 }
+  - { kind: CaptureMetrics, suffix: ".post-burst2" }
+  - { kind: StartLoad, load_ref: steady-3 }
+  - { kind: WaitForLoadCompletion, name: steady-3 }
+  - { kind: StartLoad, load_ref: burst-3 }
+  - { kind: WaitForLoadCompletion, name: burst-3 }
+  - { kind: CaptureMetrics, suffix: ".post-burst3" }
+  - { kind: StartLoad, load_ref: steady-4 }
+  - { kind: WaitForLoadCompletion, name: steady-4 }
+  - { kind: CaptureMetrics, suffix: ".final" }
+  - { kind: StartLoad, load_ref: rampdown }
+  - { kind: WaitForLoadCompletion, name: rampdown }
+
+reports:
+  - PerWorkerLatencyReport
+  - ErrorBreakdownReport
+
+checks:
+  - { kind: LoadApplied, load_name: burst-2, min_requests: 2000 }
+  - { kind: WorkerPanics, services: [Frontend, VllmPrefillWorker, VllmDecodeWorker], acceptable: true }
+  - { kind: RestartCountIncreased, services: [Frontend, VllmPrefillWorker, VllmDecodeWorker], expect_min_increment: 0 }

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2ovl_sweep_mock_n15.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2ovl_sweep_mock_n15.yaml
@@ -1,0 +1,64 @@
+# E2-overload Stage-0 saturation sweep — N=15 mocker (nscale, speedup=1.0).
+#
+# Parallel to the aws N=6 real-GPU sweep. Deploys the FULL 15-FE mocker system
+# (15 FE + 30 prefill + 15 decode) at speedup-ratio=1.0 (set via the edited
+# bundled mocker disagg.yaml template — 5.0 can't saturate) and lets
+# test_saturation_discovery drive its own aiperf --search-space against the FE
+# service to find the aggregate C_max. The 3 mocker overload arms share it.
+#
+# Decode seq cap = 8 max-num-seqs x 15 decode = 120 concurrent decode seqs, so
+# C_max should land near there; the bursts (2x) then drive the admission gates.
+
+kind: router_memory
+name: e2ovl_sweep_mock_n15
+
+labels:
+  purpose: e2_overload_sweep
+  arm: e2ovl_sweep_mock_n15
+  router_mode: least_loaded
+  deployment: disagg
+  backend: mocker
+  cluster: nscale-dev-cluster
+
+deployment:
+  backend: mocker
+  topology: disagg
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-mocker-prefill-pinning-a5c93b3331-neelays
+  log_pvc: dynamo-ft-logs
+  replicas:
+    Frontend: 15
+    prefill: 30
+    decode: 15
+
+router:
+  mode: least-loaded
+  knobs:
+    DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
+    DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
+    DYN_EVENT_PLANE: "zmq"
+    DYN_DISCOVERY_BACKEND: "kubernetes"
+    DYN_STORE_KV: "mem"
+
+admission:
+  knobs:
+    DYN_TCP_WORKER_POOL_SIZE: "128"
+    DYN_TCP_WORK_QUEUE_SIZE: "5"
+    VLLM_NIXL_ABORT_REQUEST_TIMEOUT: "30"
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30"
+
+# Trivial placeholder load — the sweep ignores this and drives its own --search-space.
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 5
+    prefix_prompt_length: 740
+    seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
+  rungs:
+    - name: unused_sweep_supplies_own_load
+      concurrency: 16
+      duration_minutes: 1.0
+  common:
+    request_timeout_seconds: 86400
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2ovl_sweep_n5.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2ovl_sweep_n5.yaml
@@ -1,0 +1,72 @@
+# E2-overload Stage-0 saturation sweep — N=5 real-GPU (recommended 2:1 ratio).
+#
+# Deploys the FULL N=5 system at the recommended prefill:decode ratio (2:1):
+#   5 FE + 10 prefill + 5 decode  = 30 GPU.
+# N=6 (36 GPU) could not place reliably on aws-dev-02 while other tenants hold
+# 24 GPU (cluster 64 total) — the last gang members hit GPU fragmentation. N=5
+# leaves 10 GPU of headroom and keeps the 2:1 ratio intact (unlike trimming
+# prefill alone). 1 unit = 1 FE + 2 prefill + 1 decode.
+#
+# test_saturation_discovery.py drives its own aiperf --search-space load against
+# the Frontend SERVICE (round-robin across all 5 FEs) to find the AGGREGATE C_max
+# of the 5-FE / 5-decode system — the concurrency target the 3 overload arms
+# (LL / LL-best / KV-load-aware) share (steady ~0.85xC_max, burst 2x). Decode (5)
+# is the saturation bottleneck that sets C_max.
+#
+# Consumed via --sat-deploy-scenario e2ovl_sweep_n5. The load block below is a
+# trivial placeholder the sweep ignores (it supplies its own --search-space).
+
+kind: router_memory
+name: e2ovl_sweep_n5
+
+labels:
+  purpose: e2_overload_sweep
+  arm: e2ovl_sweep_n5
+  router_mode: least_loaded
+  deployment: disagg
+  backend: vllm
+  cluster: aws-dev-02
+
+deployment:
+  backend: vllm
+  topology: disagg
+  template: disagg_qwen3_30b_unit_e1
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-mocker-prefill-pinning-a5c93b3331-neelays
+  model_cache_pvc: shared-model-cache
+  log_pvc: dynamo-ft-logs
+  # Full N=5 topology at the recommended 2:1 ratio (10 prefill : 5 decode).
+  replicas:
+    Frontend: 5
+    VllmPrefillWorker: 10
+    VllmDecodeWorker: 5
+
+router:
+  mode: least-loaded
+  knobs:
+    DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
+    DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
+
+admission:
+  knobs:
+    DYN_TCP_WORKER_POOL_SIZE: "128"
+    DYN_TCP_WORK_QUEUE_SIZE: "5"
+    VLLM_NIXL_ABORT_REQUEST_TIMEOUT: "30"
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30"
+
+# Trivial placeholder load — the saturation sweep ignores this and drives its
+# own aiperf --search-space; no events reference these rungs.
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 5
+    prefix_prompt_length: 740
+    seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
+  rungs:
+    - name: unused_sweep_supplies_own_load
+      concurrency: 16
+      duration_minutes: 1.0
+  common:
+    request_timeout_seconds: 86400
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2ovl_sweep_n6.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/e2ovl_sweep_n6.yaml
@@ -1,0 +1,65 @@
+# E2-overload Stage-0 saturation sweep — N=6 real-GPU (full topology).
+#
+# Deploys the FULL N=6 system (6 FE + 12 prefill + 6 decode) and lets
+# test_saturation_discovery.py drive its own aiperf --search-space load against
+# the Frontend SERVICE (round-robin across all 6 FEs) to find the AGGREGATE
+# C_max of the 6-FE / 6-decode system — the concurrency target the 3 overload
+# arms (LL / LL-best / KV-load-aware) will share (steady ~0.85xC_max, burst 2x).
+#
+# Consumed via --sat-deploy-scenario e2ovl_sweep_n6. The load block below is a
+# trivial placeholder the sweep ignores (it supplies its own --search-space).
+
+kind: router_memory
+name: e2ovl_sweep_n6
+
+labels:
+  purpose: e2_overload_sweep
+  arm: e2ovl_sweep_n6
+  router_mode: least_loaded
+  deployment: disagg
+  backend: vllm
+  cluster: aws-dev-02
+
+deployment:
+  backend: vllm
+  topology: disagg
+  template: disagg_qwen3_30b_unit_e1
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-mocker-prefill-pinning-a5c93b3331-neelays
+  model_cache_pvc: shared-model-cache
+  log_pvc: dynamo-ft-logs
+  # Full N=6 topology: 6 FE over a 12-prefill + 6-decode pool.
+  replicas:
+    Frontend: 6
+    VllmPrefillWorker: 12
+    VllmDecodeWorker: 6
+
+router:
+  mode: least-loaded
+  knobs:
+    DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
+    DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
+
+admission:
+  knobs:
+    DYN_TCP_WORKER_POOL_SIZE: "128"
+    DYN_TCP_WORK_QUEUE_SIZE: "5"
+    VLLM_NIXL_ABORT_REQUEST_TIMEOUT: "30"
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30"
+
+# Trivial placeholder load — the saturation sweep ignores this and drives its
+# own aiperf --search-space; no events reference these rungs.
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 5
+    prefix_prompt_length: 740
+    seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
+  rungs:
+    - name: unused_sweep_supplies_own_load
+      concurrency: 16
+      duration_minutes: 1.0
+  common:
+    request_timeout_seconds: 86400
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/engine_stall_stale_routing__disagg__vllm.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/engine_stall_stale_routing__disagg__vllm.yaml
@@ -121,7 +121,7 @@ events:
   # ── Phase 1: single DECODE stall → reconvergence (isolated stale-routing) ──
   # 1 decode stays healthy → any 500 here is the router holding the dead id,
   # NOT loss of capacity. Watch the ramp + how long reconvergence takes.
-  - { kind: StallProcess, services: [VllmDecodeWorker], process_name: dynamo.vllm, pod_indices: [0], rank_index: 1, duration: 75 }
+  - { kind: StallProcess, services: [VllmDecodeWorker], process_name: "VLLM::EngineCore", pod_indices: [0], rank_index: 1, duration: 75 }
   - { kind: Wait, duration: 450 }                 # 7.5 min — observe decode ramp + decay
   - { kind: CaptureMetrics, suffix: ".after-decode-stall" }
 
@@ -129,7 +129,7 @@ events:
   # 1 prefill stays healthy. Proves the stale-routing 500s also come from a
   # churned PREFILL instance_id, not only decode. Carved from Phase 1's old
   # 15-min window (now 7.5 + 7.5) → no added wall time.
-  - { kind: StallProcess, services: [VllmPrefillWorker], process_name: dynamo.vllm, pod_indices: [0], rank_index: 1, duration: 75 }
+  - { kind: StallProcess, services: [VllmPrefillWorker], process_name: "VLLM::EngineCore", pod_indices: [0], rank_index: 1, duration: 75 }
   - { kind: Wait, duration: 450 }                 # 7.5 min — observe prefill ramp + decay
   - { kind: CaptureMetrics, suffix: ".after-prefill-stall" }
 
@@ -137,11 +137,11 @@ events:
   # Rolling churn (each restarts in ~60-90 s) so 1 decode + 1 prefill id churn
   # at once → overlapping stale-routing windows build the peak. One pod per role
   # at a time → never zeroes a pool → still capacity-bounded.
-  - { kind: StallProcess, services: [VllmDecodeWorker], process_name: dynamo.vllm, pod_indices: [1], rank_index: 1, duration: 75 }
+  - { kind: StallProcess, services: [VllmDecodeWorker], process_name: "VLLM::EngineCore", pod_indices: [1], rank_index: 1, duration: 75 }
   - { kind: Wait, duration: 120 }
-  - { kind: StallProcess, services: [VllmPrefillWorker], process_name: dynamo.vllm, pod_indices: [1], rank_index: 1, duration: 75 }
+  - { kind: StallProcess, services: [VllmPrefillWorker], process_name: "VLLM::EngineCore", pod_indices: [1], rank_index: 1, duration: 75 }
   - { kind: Wait, duration: 120 }
-  - { kind: StallProcess, services: [VllmDecodeWorker], process_name: dynamo.vllm, pod_indices: [0], rank_index: 1, duration: 75 }
+  - { kind: StallProcess, services: [VllmDecodeWorker], process_name: "VLLM::EngineCore", pod_indices: [0], rank_index: 1, duration: 75 }
 
   # ── Phase 4: FE rollout-restart MID-STORM (the "does bouncing the FE help?"
   # probe). Same image → rolling restart of the 3 FEs while errors are elevated.

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/engine_stall_stale_routing__disagg__vllm.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/engine_stall_stale_routing__disagg__vllm.yaml
@@ -20,8 +20,11 @@
 # never self-kills (verified: 16 min hung, RESTARTS 0). SIGSTOP'ing the Worker
 # leaves the EngineCore dispatching forwards, so it reaches the guarded
 # `sample_tokens` RPC wait → times out → dies (verified: RESTARTS 0→1, exact
-# EngineDeadError traceback). rank_index:1 → Worker_DP1 (substring "VLLM::Worker"
-# matches both Worker_DP0_EP0 and Worker_DP1_EP1).
+# EngineDeadError traceback). The stalls use the `StallWorker` helper, which
+# resolves the backend's worker process via engine_details (target='worker' →
+# "VLLM::Worker" for vllm), so swapping deployment.backend retargets the repro
+# automatically. rank_index:1 → Worker_DP1 (substring "VLLM::Worker" matches both
+# Worker_DP0_EP0 and Worker_DP1_EP1).
 #
 # Why PERMANENT stall (`duration: null`): hold the freeze until a request lands
 # and the timeout fires. With the Worker target, ANY request routed to the frozen
@@ -131,7 +134,7 @@ events:
   - { kind: CaptureMetrics, suffix: ".baseline" }  # 0 errors + KV-util ≪ 0.85
 
   # ── Phase 1: single DECODE stall (PERMANENT) → wait for the actual churn ───
-  - { kind: StallProcess, services: [VllmDecodeWorker], process_name: "VLLM::Worker", pod_indices: [0], rank_index: 1, duration: null }
+  - { kind: StallWorker, services: [VllmDecodeWorker], pod_indices: [0], rank_index: 1, duration: null }
   - { kind: WaitForRecovery, unready_timeout: 300, timeout: 600 }  # CR unready (died) → ready (restarted); logs pod warning events
   - { kind: Wait, duration: 120 }                 # observe stale-routing tail/decay
   - { kind: CaptureMetrics, suffix: ".after-decode-stall" }
@@ -139,7 +142,7 @@ events:
   # ── Phase 2: single PREFILL stall (PERMANENT) → the OTHER role churns ──────
   # With the Worker target, a single prefill forward to the frozen rank trips the
   # sample_tokens timeout → churn — no mid-forward dependence (cf. EngineCore).
-  - { kind: StallProcess, services: [VllmPrefillWorker], process_name: "VLLM::Worker", pod_indices: [0], rank_index: 1, duration: null }
+  - { kind: StallWorker, services: [VllmPrefillWorker], pod_indices: [0], rank_index: 1, duration: null }
   - { kind: WaitForRecovery, unready_timeout: 300, timeout: 600 }
   - { kind: Wait, duration: 120 }
   - { kind: CaptureMetrics, suffix: ".after-prefill-stall" }
@@ -148,9 +151,9 @@ events:
   # Stall 1 decode + 1 prefill (the not-yet-stalled pods) within ~60 s so both
   # churn at once → overlapping stale-routing windows. decode[0]+prefill[0]
   # (restarted) keep capacity → still capacity-bounded.
-  - { kind: StallProcess, services: [VllmDecodeWorker], process_name: "VLLM::Worker", pod_indices: [1], rank_index: 1, duration: null }
+  - { kind: StallWorker, services: [VllmDecodeWorker], pod_indices: [1], rank_index: 1, duration: null }
   - { kind: Wait, duration: 60 }
-  - { kind: StallProcess, services: [VllmPrefillWorker], process_name: "VLLM::Worker", pod_indices: [1], rank_index: 1, duration: null }
+  - { kind: StallWorker, services: [VllmPrefillWorker], pod_indices: [1], rank_index: 1, duration: null }
   - { kind: WaitForRecovery, unready_timeout: 300, timeout: 600 }  # both die → both restart
   - { kind: Wait, duration: 120 }
   - { kind: CaptureMetrics, suffix: ".peak" }

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/engine_stall_stale_routing__disagg__vllm.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/engine_stall_stale_routing__disagg__vllm.yaml
@@ -1,0 +1,174 @@
+# Engine-stall → instance_id churn → KV-router stale-routing 500 storm
+# (ramp → peak → slow decay). Disagg, DP=2 + EP, configurable model.
+#
+# Generic Dynamo reliability repro (no deployment-specific tuning):
+#   SIGSTOP one DP rank of a worker → the surviving rank blocks on
+#   `shm_broadcast` → its `sample_tokens`/execute_model RPC times out
+#   (VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS) → EngineCore fatal → worker pod exits 1
+#   → restart → NEW instance_id. The KV router's dispatch is single-shot
+#   (push_router.rs `direct(instance_id).await?`, no reselect) and prefix
+#   affinity keeps re-selecting the OLD (dead) id → HTTP 500 "instance not
+#   found". In disagg the router holds instance_ids for BOTH roles, so we stall
+#   prefill AND decode — each churn produces its own stale-routing 500s.
+#   Staggered stalls under steady open-loop load reproduce a gradual
+#   ramp → peak → slow self-recovery error curve.
+#
+# ── Arms (KV only) ─────────────────────────────────────────────────────────
+#   A1  KV baseline, current image          → expect the 500 storm.   [THIS FILE]
+#   A2  + reselect-on-not-found fix build    → swap deployment.image to a build
+#       that reselects when the dispatched id is gone → expect ~0 user 500s.
+#       (Run when such a build is available.)
+#
+# ── Injection robustness (see events) ─────────────────────────────────────
+#   * PRIMARY: SIGSTOP a DP rank (reproduces the exact stall→timeout→death path).
+#   * FALLBACK: if the timeout-death doesn't fire at near-idle, a SIGKILL /
+#     DeletePod forces the churn (cruder, but guarantees a new instance_id).
+#   * NEGATIVE CONTROL: a SIGTERM (graceful) — clean deregister, NO stale
+#     routing → ~0 new 500s. This isolates "abrupt death" as the cause.
+
+kind: router_memory
+name: engine_stall_stale_routing__disagg__vllm
+description: >
+  Engine-stall → instance_id churn → KV-router stale-routing 500 storm,
+  disagg DP=2+EP, configurable model. A1 = KV baseline (no reselect).
+
+labels:
+  purpose: engine_stall_stale_routing_repro
+  router_mode: kv
+  deployment: disagg
+  backend: vllm
+  arm: a1_kv_baseline_no_reselect
+
+deployment:
+  backend: vllm
+  topology: disagg
+  template: disagg_dp2_ep_unit            # shape only (disagg, DP=2, EP)
+  model: deepseek-ai/DeepSeek-V2-Lite     # CONFIGURABLE — one line to swap models
+  image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0   # latest GA release (public)
+  model_cache_pvc: shared-model-cache
+  # Disagg DP=2 ⇒ 2 GPU/worker.
+  #   3 FE (CPU) + 2 prefill (4 GPU) + 2 decode (4 GPU) = 8 GPU = 1 node.
+  # The router holds instance_ids for both roles. Each pool is 2, so stall ONE
+  # pod per role at a time → the surviving pod keeps the role's capacity (at
+  # near-idle 2 r/s it easily covers the load) while the router stale-routes to
+  # the churned id → the 500s are stale-routing, NOT lost capacity. Never stall
+  # both pods of a role at once.
+  replicas:
+    Frontend: 3                           # ≥3 FE — per-FE router state churns independently
+    VllmPrefillWorker: 2
+    VllmDecodeWorker: 2
+
+router:
+  mode: kv
+  knobs:
+    DYN_EVENT_PLANE: "zmq"                # transport-level → propagates to workers too
+    DYN_ROUTER_REPLICA_SYNC: "true"       # cross-FE router-state sync
+    DYN_ROUTER_USE_KV_EVENTS: "false"
+    DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
+    DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
+    # Tier-1 observability: worker_monitor=debug shows the instance_id
+    # add/remove churn; kv_router::scheduling shows the (stale) selection.
+    DYN_LOG: "info,dynamo_llm::discovery::worker_monitor=debug,dynamo_kv_router::scheduling=debug,dynamo_runtime::pipeline::network::egress::push_router=debug"
+
+admission:
+  knobs:
+    # The death trigger. The stall (below) is held > this so the surviving rank
+    # reliably times out → EngineCore fatal → exit. Lower to 20-30 for faster
+    # smoke cycles (keep StallProcess.duration > this).
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "60"
+
+load:
+  # Long shared prefix + small unique suffix = a RAG/agent shape where KV-router
+  # prefix affinity holds the (dead) instance_id → amplifies + slows
+  # reconvergence. ISL scaled to ~6K so a 2-decode fleet stays genuinely
+  # near-idle (so any 500 is stale-routing, not overload). For a production-scale
+  # ISL (~30K) bump shared_system_prompt_length and recalibrate the rate down.
+  shape:
+    type: custom
+    shared_system_prompt_length: 5000     # shared prefix → strong affinity
+    input_tokens_mean: 1000               # unique suffix → ISL ≈ 6K
+    input_tokens_stddev: 200
+    output_tokens_mean: 750               # OSL ≈ 750
+    output_tokens_stddev: 75
+  rungs:
+    - name: steady
+      # OPEN-LOOP near-idle: constant arrivals as workers die (the faithful
+      # error-rate-shape model). CALIBRATE: the baseline phase must show decode
+      # KV-util well below the 0.85 gate; if it saturates, lower this. 2 r/s also
+      # guarantees the stalled worker gets in-flight work within the timeout.
+      request_rate: 2.0
+      concurrency: 128                    # max-in-flight cap only
+      duration_minutes: 95.0
+  common:
+    request_timeout_seconds: 120          # ISL~6K + OSL~750 needs headroom
+    goodput: ["request_latency:120000"]
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never
+
+events:
+  - { kind: WaitForModelReady, timeout: 2400 }   # DP=2 disagg load is slow
+  # Continuous capture: snapshots FE counters + in-flight aiperf +
+  # server_metrics_export.jsonl every 0.5 min → the not-found-500 counter delta
+  # per interval IS the ramp/peak/decay curve.
+  - { kind: PeriodicSnapshot, interval_minutes: 0.5 }
+  - { kind: StartLoad, load_ref: steady }        # non-blocking, runs ~95 min
+
+  # ── Phase 0: baseline (also the near-idle calibration check) ──────────────
+  - { kind: Wait, duration: 600 }                 # 10 min healthy near-idle
+  - { kind: CaptureMetrics, suffix: ".baseline" } # confirm 0 errors + KV-util ≪ 0.85
+
+  # ── Phase 1: single DECODE stall → reconvergence (isolated stale-routing) ──
+  # 1 decode stays healthy → any 500 here is the router holding the dead id,
+  # NOT loss of capacity. Watch the ramp + how long reconvergence takes.
+  - { kind: StallProcess, services: [VllmDecodeWorker], process_name: dynamo.vllm, pod_indices: [0], rank_index: 1, duration: 75 }
+  - { kind: Wait, duration: 450 }                 # 7.5 min — observe decode ramp + decay
+  - { kind: CaptureMetrics, suffix: ".after-decode-stall" }
+
+  # ── Phase 2: single PREFILL stall → reconvergence (the OTHER role churns) ──
+  # 1 prefill stays healthy. Proves the stale-routing 500s also come from a
+  # churned PREFILL instance_id, not only decode. Carved from Phase 1's old
+  # 15-min window (now 7.5 + 7.5) → no added wall time.
+  - { kind: StallProcess, services: [VllmPrefillWorker], process_name: dynamo.vllm, pod_indices: [0], rank_index: 1, duration: 75 }
+  - { kind: Wait, duration: 450 }                 # 7.5 min — observe prefill ramp + decay
+  - { kind: CaptureMetrics, suffix: ".after-prefill-stall" }
+
+  # ── Phase 3: staggered burst across BOTH roles → the PEAK ──────────────────
+  # Rolling churn (each restarts in ~60-90 s) so 1 decode + 1 prefill id churn
+  # at once → overlapping stale-routing windows build the peak. One pod per role
+  # at a time → never zeroes a pool → still capacity-bounded.
+  - { kind: StallProcess, services: [VllmDecodeWorker], process_name: dynamo.vllm, pod_indices: [1], rank_index: 1, duration: 75 }
+  - { kind: Wait, duration: 120 }
+  - { kind: StallProcess, services: [VllmPrefillWorker], process_name: dynamo.vllm, pod_indices: [1], rank_index: 1, duration: 75 }
+  - { kind: Wait, duration: 120 }
+  - { kind: StallProcess, services: [VllmDecodeWorker], process_name: dynamo.vllm, pod_indices: [0], rank_index: 1, duration: 75 }
+
+  # ── Phase 4: FE rollout-restart MID-STORM (the "does bouncing the FE help?"
+  # probe). Same image → rolling restart of the 3 FEs while errors are elevated.
+  # Expect a NO-OP: each restarted FE rebuilds router state and re-converges to
+  # the same stale selection (or it clears — that's the finding).
+  - { kind: RollingUpgrade, services: [Frontend], name: fe-restart-mid-storm }
+  - { kind: CaptureMetrics, suffix: ".peak" }
+
+  # ── Phase 5: recovery — stop stalling, observe self-decay toward ~0 ───────
+  - { kind: Wait, duration: 1200 }                # 20 min
+  - { kind: CaptureMetrics, suffix: ".recovery" }
+
+  # ── Phase 6: SIGTERM negative control — graceful death deregisters cleanly,
+  # so the router drops the id BEFORE churn → expect ~0 new 500s. Contrasts with
+  # the abrupt SIGSTOP→timeout death above. (Fallback if SIGSTOP didn't churn:
+  # swap this to signal SIGKILL, or use a DeletePod, to force a new instance_id.)
+  - { kind: TerminateProcess, services: [VllmDecodeWorker], process_name: dynamo.vllm, signal: SIGTERM, pod_indices: [1], name: sigterm-control }
+  - { kind: Wait, duration: 300 }
+  - { kind: CaptureMetrics, suffix: ".sigterm-control" }
+
+  - { kind: WaitForLoadCompletion, name: steady }
+
+reports:
+  - FaultToleranceReport
+  - ErrorBreakdownReport
+  - PerWorkerLatencyReport
+
+checks:
+  # Workers DO crash here (that's the trigger) — panics/restarts are expected.
+  - { kind: WorkerPanics, services: [VllmPrefillWorker, VllmDecodeWorker], acceptable: true }

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/engine_stall_stale_routing__disagg__vllm.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/engine_stall_stale_routing__disagg__vllm.yaml
@@ -2,29 +2,37 @@
 # (ramp → peak → slow decay). Disagg, DP=2 + EP, configurable model.
 #
 # Generic Dynamo reliability repro (no deployment-specific tuning):
-#   SIGSTOP one DP rank of a worker → the surviving rank blocks on
-#   `shm_broadcast` → its `sample_tokens`/execute_model RPC times out
+#   SIGSTOP one DP rank of a worker and HOLD it (permanent stall, no auto-resume)
+#   → whenever the steady load next routes a request to that worker, the
+#   surviving rank blocks on the `shm_broadcast` collective waiting for the
+#   frozen rank → its execute_model/`sample_tokens` RPC times out
 #   (VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS) → EngineCore fatal → worker pod exits 1
 #   → restart → NEW instance_id. The KV router's dispatch is single-shot
 #   (push_router.rs `direct(instance_id).await?`, no reselect) and prefix
 #   affinity keeps re-selecting the OLD (dead) id → HTTP 500 "instance not
-#   found". In disagg the router holds instance_ids for BOTH roles, so we stall
-#   prefill AND decode — each churn produces its own stale-routing 500s.
-#   Staggered stalls under steady open-loop load reproduce a gradual
-#   ramp → peak → slow self-recovery error curve.
+#   found", decaying as the router reconverges.
+#
+# Why PERMANENT stall (`duration: null`): a timed SIGSTOP auto-SIGCONTs after N
+# seconds, rescuing the frozen rank if no in-flight forward happened to land in
+# that window — so a near-idle PREFILL worker rides it out and recovers
+# (observed). Holding the stall removes the rescue: the rank stays frozen until
+# a request lands and the surviving rank times out. Decode churns either way
+# (long generation keeps it mid-forward); prefill needs the permanent hold.
+#
+# Determinism + observability:
+#   * After each stall, WaitForRecovery brackets the actual churn — it waits for
+#     the CR to go UNREADY (the worker died) then READY (restarted), instead of
+#     guessing with a fixed Wait. It also LOGS pod warning events during the
+#     wait, surfacing issues (probe failures, scheduling/BindingErrors, OOM,
+#     kill reasons) at exactly the failure window. NOTE: it raises if no death
+#     occurs within unready_timeout — that itself is a finding (the stall didn't
+#     churn); generous timeouts minimize false aborts.
+#   * Each CaptureMetrics uses include_events → persists per-pod
+#     `<pod><suffix>.events.yaml` (the k8s Event resources) alongside /metrics.
 #
 # ── Arms (KV only) ─────────────────────────────────────────────────────────
 #   A1  KV baseline, current image          → expect the 500 storm.   [THIS FILE]
-#   A2  + reselect-on-not-found fix build    → swap deployment.image to a build
-#       that reselects when the dispatched id is gone → expect ~0 user 500s.
-#       (Run when such a build is available.)
-#
-# ── Injection robustness (see events) ─────────────────────────────────────
-#   * PRIMARY: SIGSTOP a DP rank (reproduces the exact stall→timeout→death path).
-#   * FALLBACK: if the timeout-death doesn't fire at near-idle, a SIGKILL /
-#     DeletePod forces the churn (cruder, but guarantees a new instance_id).
-#   * NEGATIVE CONTROL: a SIGTERM (graceful) — clean deregister, NO stale
-#     routing → ~0 new 500s. This isolates "abrupt death" as the cause.
+#   A2  + reselect-on-not-found fix build    → swap deployment.image → ~0 500s.
 
 kind: router_memory
 name: engine_stall_stale_routing__disagg__vllm
@@ -46,121 +54,104 @@ deployment:
   model: deepseek-ai/DeepSeek-V2-Lite     # CONFIGURABLE — one line to swap models
   image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0   # latest GA release (public)
   model_cache_pvc: shared-model-cache
-  # Disagg DP=2 ⇒ 2 GPU/worker.
-  #   3 FE (CPU) + 2 prefill (4 GPU) + 2 decode (4 GPU) = 8 GPU = 1 node.
-  # The router holds instance_ids for both roles. Each pool is 2, so stall ONE
-  # pod per role at a time → the surviving pod keeps the role's capacity (at
-  # near-idle 2 r/s it easily covers the load) while the router stale-routes to
-  # the churned id → the 500s are stale-routing, NOT lost capacity. Never stall
-  # both pods of a role at once.
+  # Disagg DP=2 ⇒ 2 GPU/worker. 3 FE (CPU) + 2 prefill (4 GPU) + 2 decode (4 GPU)
+  # = 8 GPU = 1 node. Each pool is 2, so stall ONE pod per role at a time and let
+  # it die+restart before stalling the next of that role → the surviving pod keeps
+  # the role's capacity (near-idle) while the router stale-routes to the churned
+  # id → the 500s are stale-routing, NOT lost capacity.
   replicas:
-    Frontend: 3                           # ≥3 FE — per-FE router state churns independently
+    Frontend: 3
     VllmPrefillWorker: 2
     VllmDecodeWorker: 2
 
 router:
   mode: kv
   knobs:
-    DYN_EVENT_PLANE: "zmq"                # transport-level → propagates to workers too
-    DYN_ROUTER_REPLICA_SYNC: "true"       # cross-FE router-state sync
+    DYN_EVENT_PLANE: "zmq"
+    DYN_ROUTER_REPLICA_SYNC: "true"
     DYN_ROUTER_USE_KV_EVENTS: "false"
     DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
     DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
-    # Tier-1 observability: worker_monitor=debug shows the instance_id
-    # add/remove churn; kv_router::scheduling shows the (stale) selection.
     DYN_LOG: "info,dynamo_llm::discovery::worker_monitor=debug,dynamo_kv_router::scheduling=debug,dynamo_runtime::pipeline::network::egress::push_router=debug"
 
 admission:
   knobs:
-    # The death trigger. The stall (below) is held > this so the surviving rank
-    # reliably times out → EngineCore fatal → exit. Lower to 20-30 for faster
-    # smoke cycles (keep StallProcess.duration > this).
+    # The death trigger: once the surviving rank blocks on the collective with
+    # the frozen rank, it dies after this.
     VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "60"
 
 load:
   # Long shared prefix + small unique suffix = a RAG/agent shape where KV-router
   # prefix affinity holds the (dead) instance_id → amplifies + slows
-  # reconvergence. ISL scaled to ~6K so a 2-decode fleet stays genuinely
-  # near-idle (so any 500 is stale-routing, not overload). For a production-scale
-  # ISL (~30K) bump shared_system_prompt_length and recalibrate the rate down.
+  # reconvergence. ISL ~6K so a 2+2 fleet stays genuinely near-idle (so any 500
+  # is stale-routing, not overload). The steady near-idle load is also what
+  # eventually lands a request on a permanently-stalled worker → triggers death.
   shape:
     type: custom
-    shared_system_prompt_length: 5000     # shared prefix → strong affinity
-    input_tokens_mean: 1000               # unique suffix → ISL ≈ 6K
+    shared_system_prompt_length: 5000
+    input_tokens_mean: 1000               # → ISL ≈ 6K
     input_tokens_stddev: 200
     output_tokens_mean: 750               # OSL ≈ 750
     output_tokens_stddev: 75
   rungs:
     - name: steady
-      # OPEN-LOOP near-idle: constant arrivals as workers die (the faithful
-      # error-rate-shape model). CALIBRATE: the baseline phase must show decode
-      # KV-util well below the 0.85 gate; if it saturates, lower this. 2 r/s also
-      # guarantees the stalled worker gets in-flight work within the timeout.
+      # OPEN-LOOP near-idle: constant arrivals + the traffic that lands on a
+      # stalled worker to trigger death. CALIBRATE: baseline must show decode
+      # KV-util ≪ 0.85. Duration covers the (variable, WaitForRecovery-paced)
+      # event schedule (~45-60 min) + slack.
       request_rate: 2.0
-      concurrency: 128                    # max-in-flight cap only
-      duration_minutes: 95.0
+      concurrency: 128
+      duration_minutes: 75.0
   common:
-    request_timeout_seconds: 120          # ISL~6K + OSL~750 needs headroom
+    request_timeout_seconds: 120
     goodput: ["request_latency:120000"]
     streaming: true
     ignore_eos: true
     connection_reuse_strategy: never
 
 events:
-  - { kind: WaitForModelReady, timeout: 2400 }   # DP=2 disagg load is slow
-  # Continuous capture: snapshots FE counters + in-flight aiperf +
-  # server_metrics_export.jsonl every 0.5 min → the not-found-500 counter delta
-  # per interval IS the ramp/peak/decay curve.
+  - { kind: WaitForModelReady, timeout: 2400 }
   - { kind: PeriodicSnapshot, interval_minutes: 0.5 }
-  - { kind: StartLoad, load_ref: steady }        # non-blocking, runs ~95 min
+  - { kind: StartLoad, load_ref: steady }        # non-blocking near-idle, ~75 min
 
-  # ── Phase 0: baseline (also the near-idle calibration check) ──────────────
-  - { kind: Wait, duration: 600 }                 # 10 min healthy near-idle
-  - { kind: CaptureMetrics, suffix: ".baseline" } # confirm 0 errors + KV-util ≪ 0.85
+  # ── Phase 0: baseline (near-idle calibration) ─────────────────────────────
+  - { kind: Wait, duration: 600 }
+  - { kind: CaptureMetrics, suffix: ".baseline", include_events: true }  # 0 errors + KV-util ≪ 0.85
 
-  # ── Phase 1: single DECODE stall → reconvergence (isolated stale-routing) ──
-  # 1 decode stays healthy → any 500 here is the router holding the dead id,
-  # NOT loss of capacity. Watch the ramp + how long reconvergence takes.
-  - { kind: StallProcess, services: [VllmDecodeWorker], process_name: "VLLM::EngineCore", pod_indices: [0], rank_index: 1, duration: 75 }
-  - { kind: Wait, duration: 450 }                 # 7.5 min — observe decode ramp + decay
-  - { kind: CaptureMetrics, suffix: ".after-decode-stall" }
+  # ── Phase 1: single DECODE stall (PERMANENT) → wait for the actual churn ───
+  - { kind: StallProcess, services: [VllmDecodeWorker], process_name: "VLLM::EngineCore", pod_indices: [0], rank_index: 1, duration: null }
+  - { kind: WaitForRecovery, unready_timeout: 300, timeout: 600 }  # CR unready (died) → ready (restarted); logs pod warning events
+  - { kind: Wait, duration: 120 }                 # observe stale-routing tail/decay
+  - { kind: CaptureMetrics, suffix: ".after-decode-stall", include_events: true }
 
-  # ── Phase 2: single PREFILL stall → reconvergence (the OTHER role churns) ──
-  # 1 prefill stays healthy. Proves the stale-routing 500s also come from a
-  # churned PREFILL instance_id, not only decode. Carved from Phase 1's old
-  # 15-min window (now 7.5 + 7.5) → no added wall time.
-  - { kind: StallProcess, services: [VllmPrefillWorker], process_name: "VLLM::EngineCore", pod_indices: [0], rank_index: 1, duration: 75 }
-  - { kind: Wait, duration: 450 }                 # 7.5 min — observe prefill ramp + decay
-  - { kind: CaptureMetrics, suffix: ".after-prefill-stall" }
-
-  # ── Phase 3: staggered burst across BOTH roles → the PEAK ──────────────────
-  # Rolling churn (each restarts in ~60-90 s) so 1 decode + 1 prefill id churn
-  # at once → overlapping stale-routing windows build the peak. One pod per role
-  # at a time → never zeroes a pool → still capacity-bounded.
-  - { kind: StallProcess, services: [VllmDecodeWorker], process_name: "VLLM::EngineCore", pod_indices: [1], rank_index: 1, duration: 75 }
+  # ── Phase 2: single PREFILL stall (PERMANENT) → the OTHER role churns ──────
+  # The permanent hold is what churns prefill at near-idle (no SIGCONT-rescue).
+  - { kind: StallProcess, services: [VllmPrefillWorker], process_name: "VLLM::EngineCore", pod_indices: [0], rank_index: 1, duration: null }
+  - { kind: WaitForRecovery, unready_timeout: 300, timeout: 600 }
   - { kind: Wait, duration: 120 }
-  - { kind: StallProcess, services: [VllmPrefillWorker], process_name: "VLLM::EngineCore", pod_indices: [1], rank_index: 1, duration: 75 }
+  - { kind: CaptureMetrics, suffix: ".after-prefill-stall", include_events: true }
+
+  # ── Phase 3: overlapping burst → the PEAK ──────────────────────────────────
+  # Stall 1 decode + 1 prefill (the not-yet-stalled pods) within ~60 s so both
+  # churn at once → overlapping stale-routing windows. decode[0]+prefill[0]
+  # (restarted) keep capacity → still capacity-bounded.
+  - { kind: StallProcess, services: [VllmDecodeWorker], process_name: "VLLM::EngineCore", pod_indices: [1], rank_index: 1, duration: null }
+  - { kind: Wait, duration: 60 }
+  - { kind: StallProcess, services: [VllmPrefillWorker], process_name: "VLLM::EngineCore", pod_indices: [1], rank_index: 1, duration: null }
+  - { kind: WaitForRecovery, unready_timeout: 300, timeout: 600 }  # both die → both restart
   - { kind: Wait, duration: 120 }
-  - { kind: StallProcess, services: [VllmDecodeWorker], process_name: "VLLM::EngineCore", pod_indices: [0], rank_index: 1, duration: 75 }
+  - { kind: CaptureMetrics, suffix: ".peak", include_events: true }
 
-  # ── Phase 4: FE rollout-restart MID-STORM (the "does bouncing the FE help?"
-  # probe). Same image → rolling restart of the 3 FEs while errors are elevated.
-  # Expect a NO-OP: each restarted FE rebuilds router state and re-converges to
-  # the same stale selection (or it clears — that's the finding).
-  - { kind: RollingUpgrade, services: [Frontend], name: fe-restart-mid-storm }
-  - { kind: CaptureMetrics, suffix: ".peak" }
+  # ── Phase 4: recovery — observe self-decay toward ~0 ──────────────────────
+  - { kind: Wait, duration: 300 }
+  - { kind: CaptureMetrics, suffix: ".recovery", include_events: true }
 
-  # ── Phase 5: recovery — stop stalling, observe self-decay toward ~0 ───────
-  - { kind: Wait, duration: 1200 }                # 20 min
-  - { kind: CaptureMetrics, suffix: ".recovery" }
-
-  # ── Phase 6: SIGTERM negative control — graceful death deregisters cleanly,
-  # so the router drops the id BEFORE churn → expect ~0 new 500s. Contrasts with
-  # the abrupt SIGSTOP→timeout death above. (Fallback if SIGSTOP didn't churn:
-  # swap this to signal SIGKILL, or use a DeletePod, to force a new instance_id.)
+  # ── Phase 5: SIGTERM negative control — graceful death deregisters cleanly,
+  # so the router drops the id BEFORE churn → expect ~0 new 500s. Targets the
+  # main process (not a rank).
   - { kind: TerminateProcess, services: [VllmDecodeWorker], process_name: dynamo.vllm, signal: SIGTERM, pod_indices: [1], name: sigterm-control }
   - { kind: Wait, duration: 300 }
-  - { kind: CaptureMetrics, suffix: ".sigterm-control" }
+  - { kind: CaptureMetrics, suffix: ".sigterm-control", include_events: true }
 
   - { kind: WaitForLoadCompletion, name: steady }
 

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/engine_stall_stale_routing__disagg__vllm.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/engine_stall_stale_routing__disagg__vllm.yaml
@@ -2,33 +2,42 @@
 # (ramp → peak → slow decay). Disagg, DP=2 + EP, configurable model.
 #
 # Generic Dynamo reliability repro (no deployment-specific tuning):
-#   SIGSTOP one DP rank of a worker and HOLD it (permanent stall, no auto-resume)
-#   → whenever the steady load next routes a request to that worker, the
-#   surviving rank blocks on the `shm_broadcast` collective waiting for the
-#   frozen rank → its execute_model/`sample_tokens` RPC times out
-#   (VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS) → EngineCore fatal → worker pod exits 1
-#   → restart → NEW instance_id. The KV router's dispatch is single-shot
-#   (push_router.rs `direct(instance_id).await?`, no reselect) and prefix
-#   affinity keeps re-selecting the OLD (dead) id → HTTP 500 "instance not
-#   found", decaying as the router reconverges.
+#   SIGSTOP the WORKER (compute) process of one DP rank and HOLD it (permanent
+#   stall, no auto-resume). When the steady load next routes a forward to that
+#   rank, its EngineCore dispatches execute_model to the frozen Worker and blocks
+#   on the `sample_tokens` RPC response → that RPC times out at
+#   VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS → EngineDeadError → EngineCore fatal →
+#   worker pod exits 1 → restart → NEW instance_id. (The surviving rank also logs
+#   the `shm_broadcast` "no block in 60s" coordination warning — the full
+#   signature.) The KV router's dispatch is single-shot (push_router.rs
+#   `direct(instance_id).await?`, no reselect) and prefix affinity keeps
+#   re-selecting the OLD (dead) id → HTTP 500 "instance not found", decaying as
+#   the router reconverges.
 #
-# Why PERMANENT stall (`duration: null`): a timed SIGSTOP auto-SIGCONTs after N
-# seconds, rescuing the frozen rank if no in-flight forward happened to land in
-# that window — so a near-idle PREFILL worker rides it out and recovers
-# (observed). Holding the stall removes the rescue: the rank stays frozen until
-# a request lands and the surviving rank times out. Decode churns either way
-# (long generation keeps it mid-forward); prefill needs the permanent hold.
+# Why the WORKER, not the EngineCore: SIGSTOP'ing the EngineCore stalls one stage
+# EARLIER — the input `shm_broadcast` distribution — which is UPSTREAM of the
+# execute_model timeout, so it just loops the shm_broadcast warning forever and
+# never self-kills (verified: 16 min hung, RESTARTS 0). SIGSTOP'ing the Worker
+# leaves the EngineCore dispatching forwards, so it reaches the guarded
+# `sample_tokens` RPC wait → times out → dies (verified: RESTARTS 0→1, exact
+# EngineDeadError traceback). rank_index:1 → Worker_DP1 (substring "VLLM::Worker"
+# matches both Worker_DP0_EP0 and Worker_DP1_EP1).
+#
+# Why PERMANENT stall (`duration: null`): hold the freeze until a request lands
+# and the timeout fires. With the Worker target, ANY request routed to the frozen
+# rank triggers death (no dependence on the surviving rank being mid-forward), so
+# both decode (long generation) and prefill (short forwards) churn reliably.
 #
 # Determinism + observability:
 #   * After each stall, WaitForRecovery brackets the actual churn — it waits for
 #     the CR to go UNREADY (the worker died) then READY (restarted), instead of
 #     guessing with a fixed Wait. It also LOGS pod warning events during the
-#     wait, surfacing issues (probe failures, scheduling/BindingErrors, OOM,
-#     kill reasons) at exactly the failure window. NOTE: it raises if no death
-#     occurs within unready_timeout — that itself is a finding (the stall didn't
-#     churn); generous timeouts minimize false aborts.
-#   * Each CaptureMetrics uses include_events → persists per-pod
-#     `<pod><suffix>.events.yaml` (the k8s Event resources) alongside /metrics.
+#     wait. NOTE: it raises if no death occurs within unready_timeout — itself a
+#     finding (the stall didn't churn); generous timeouts minimize false aborts.
+#   * Each CaptureMetrics persists per-pod `<pod><suffix>.events.yaml` (the k8s
+#     Event resources) alongside /metrics.
+#   * ResourcePoller samples per-process mem/cpu/gpu in every worker pod (5s)
+#     → service_logs/<role>/<pod>.resources.{agg,procs}.tsv.
 #
 # ── Arms (KV only) ─────────────────────────────────────────────────────────
 #   A1  KV baseline, current image          → expect the 500 storm.   [THIS FILE]
@@ -76,8 +85,8 @@ router:
 
 admission:
   knobs:
-    # The death trigger: once the surviving rank blocks on the collective with
-    # the frozen rank, it dies after this.
+    # The death trigger: once a forward is dispatched to the frozen Worker, the
+    # EngineCore's sample_tokens RPC times out after this → EngineDeadError → exit.
     VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "60"
 
 load:
@@ -111,6 +120,9 @@ load:
 
 events:
   - { kind: WaitForModelReady, timeout: 2400 }
+  # Per-process mem/cpu/gpu (pynvml) sampler in every worker pod — captures the
+  # whole-pod footprint (pid1 alone is ~14% of it) + which process holds it.
+  - { kind: ResourcePoller, services: [VllmPrefillWorker, VllmDecodeWorker], interval_s: 5 }
   - { kind: PeriodicSnapshot, interval_minutes: 0.5 }
   - { kind: StartLoad, load_ref: steady }        # non-blocking near-idle, ~75 min
 
@@ -119,14 +131,15 @@ events:
   - { kind: CaptureMetrics, suffix: ".baseline" }  # 0 errors + KV-util ≪ 0.85
 
   # ── Phase 1: single DECODE stall (PERMANENT) → wait for the actual churn ───
-  - { kind: StallProcess, services: [VllmDecodeWorker], process_name: "VLLM::EngineCore", pod_indices: [0], rank_index: 1, duration: null }
+  - { kind: StallProcess, services: [VllmDecodeWorker], process_name: "VLLM::Worker", pod_indices: [0], rank_index: 1, duration: null }
   - { kind: WaitForRecovery, unready_timeout: 300, timeout: 600 }  # CR unready (died) → ready (restarted); logs pod warning events
   - { kind: Wait, duration: 120 }                 # observe stale-routing tail/decay
   - { kind: CaptureMetrics, suffix: ".after-decode-stall" }
 
   # ── Phase 2: single PREFILL stall (PERMANENT) → the OTHER role churns ──────
-  # The permanent hold is what churns prefill at near-idle (no SIGCONT-rescue).
-  - { kind: StallProcess, services: [VllmPrefillWorker], process_name: "VLLM::EngineCore", pod_indices: [0], rank_index: 1, duration: null }
+  # With the Worker target, a single prefill forward to the frozen rank trips the
+  # sample_tokens timeout → churn — no mid-forward dependence (cf. EngineCore).
+  - { kind: StallProcess, services: [VllmPrefillWorker], process_name: "VLLM::Worker", pod_indices: [0], rank_index: 1, duration: null }
   - { kind: WaitForRecovery, unready_timeout: 300, timeout: 600 }
   - { kind: Wait, duration: 120 }
   - { kind: CaptureMetrics, suffix: ".after-prefill-stall" }
@@ -135,9 +148,9 @@ events:
   # Stall 1 decode + 1 prefill (the not-yet-stalled pods) within ~60 s so both
   # churn at once → overlapping stale-routing windows. decode[0]+prefill[0]
   # (restarted) keep capacity → still capacity-bounded.
-  - { kind: StallProcess, services: [VllmDecodeWorker], process_name: "VLLM::EngineCore", pod_indices: [1], rank_index: 1, duration: null }
+  - { kind: StallProcess, services: [VllmDecodeWorker], process_name: "VLLM::Worker", pod_indices: [1], rank_index: 1, duration: null }
   - { kind: Wait, duration: 60 }
-  - { kind: StallProcess, services: [VllmPrefillWorker], process_name: "VLLM::EngineCore", pod_indices: [1], rank_index: 1, duration: null }
+  - { kind: StallProcess, services: [VllmPrefillWorker], process_name: "VLLM::Worker", pod_indices: [1], rank_index: 1, duration: null }
   - { kind: WaitForRecovery, unready_timeout: 300, timeout: 600 }  # both die → both restart
   - { kind: Wait, duration: 120 }
   - { kind: CaptureMetrics, suffix: ".peak" }

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/engine_stall_stale_routing__disagg__vllm.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/engine_stall_stale_routing__disagg__vllm.yaml
@@ -116,20 +116,20 @@ events:
 
   # ── Phase 0: baseline (near-idle calibration) ─────────────────────────────
   - { kind: Wait, duration: 600 }
-  - { kind: CaptureMetrics, suffix: ".baseline", include_events: true }  # 0 errors + KV-util ≪ 0.85
+  - { kind: CaptureMetrics, suffix: ".baseline" }  # 0 errors + KV-util ≪ 0.85
 
   # ── Phase 1: single DECODE stall (PERMANENT) → wait for the actual churn ───
   - { kind: StallProcess, services: [VllmDecodeWorker], process_name: "VLLM::EngineCore", pod_indices: [0], rank_index: 1, duration: null }
   - { kind: WaitForRecovery, unready_timeout: 300, timeout: 600 }  # CR unready (died) → ready (restarted); logs pod warning events
   - { kind: Wait, duration: 120 }                 # observe stale-routing tail/decay
-  - { kind: CaptureMetrics, suffix: ".after-decode-stall", include_events: true }
+  - { kind: CaptureMetrics, suffix: ".after-decode-stall" }
 
   # ── Phase 2: single PREFILL stall (PERMANENT) → the OTHER role churns ──────
   # The permanent hold is what churns prefill at near-idle (no SIGCONT-rescue).
   - { kind: StallProcess, services: [VllmPrefillWorker], process_name: "VLLM::EngineCore", pod_indices: [0], rank_index: 1, duration: null }
   - { kind: WaitForRecovery, unready_timeout: 300, timeout: 600 }
   - { kind: Wait, duration: 120 }
-  - { kind: CaptureMetrics, suffix: ".after-prefill-stall", include_events: true }
+  - { kind: CaptureMetrics, suffix: ".after-prefill-stall" }
 
   # ── Phase 3: overlapping burst → the PEAK ──────────────────────────────────
   # Stall 1 decode + 1 prefill (the not-yet-stalled pods) within ~60 s so both
@@ -140,18 +140,18 @@ events:
   - { kind: StallProcess, services: [VllmPrefillWorker], process_name: "VLLM::EngineCore", pod_indices: [1], rank_index: 1, duration: null }
   - { kind: WaitForRecovery, unready_timeout: 300, timeout: 600 }  # both die → both restart
   - { kind: Wait, duration: 120 }
-  - { kind: CaptureMetrics, suffix: ".peak", include_events: true }
+  - { kind: CaptureMetrics, suffix: ".peak" }
 
   # ── Phase 4: recovery — observe self-decay toward ~0 ──────────────────────
   - { kind: Wait, duration: 300 }
-  - { kind: CaptureMetrics, suffix: ".recovery", include_events: true }
+  - { kind: CaptureMetrics, suffix: ".recovery" }
 
   # ── Phase 5: SIGTERM negative control — graceful death deregisters cleanly,
   # so the router drops the id BEFORE churn → expect ~0 new 500s. Targets the
   # main process (not a rank).
   - { kind: TerminateProcess, services: [VllmDecodeWorker], process_name: dynamo.vllm, signal: SIGTERM, pod_indices: [1], name: sigterm-control }
   - { kind: Wait, duration: 300 }
-  - { kind: CaptureMetrics, suffix: ".sigterm-control", include_events: true }
+  - { kind: CaptureMetrics, suffix: ".sigterm-control" }
 
   - { kind: WaitForLoadCompletion, name: steady }
 

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/kv_load_aware__partial_prefix__disagg__vllm.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/kv_load_aware__partial_prefix__disagg__vllm.yaml
@@ -1,0 +1,69 @@
+# Leak-NEGATIVE reference cell. KV-aware routing with prefix scoring OFF
+# (OVERLAP_SCORE_WEIGHT=0.0). Measured slope ≈ 2.9 MB/min on release/1.2.0.
+# Use as the comparison baseline for every other router_memory scenario.
+
+kind: router_memory
+name: kv_load_aware__partial_prefix__disagg__vllm
+description: |
+  KV-aware load steering with prefix scoring OFF, replica-sync ON.
+  The leak-negative reference — slope ≈ 3 MB/min is the unrelated
+  residual that's NOT in the prefix-scoring path.
+
+labels:
+  router_mode: kv_load_aware
+  traffic_shape: partial_prefix
+  deployment: disagg
+  backend: vllm
+  leak_signal: negative_reference
+
+deployment:
+  backend: vllm
+  topology: disagg
+  units: 2
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-afa8f7b7
+  model_cache_pvc: shared-model-cache
+
+router:
+  mode: kv
+  knobs:
+    DYN_ROUTER_USE_KV_EVENTS: "false"
+    DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT: "0.0"
+    DYN_ROUTER_ASSUME_KV_REUSE: "false"
+    DYN_ROUTER_REPLICA_SYNC: "true"
+    DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
+    DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
+
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 15
+    prefix_prompt_length: 600
+  rungs:
+    - name: warmup
+      concurrency: 12
+      duration_minutes: 2.0
+    - name: steady
+      concurrency: 48
+      duration_minutes: 37.0
+  common:
+    request_timeout_seconds: 30
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never
+
+reports:
+  - FaultToleranceReport
+  - ErrorBreakdownReport
+  - PerWorkerLatencyReport
+
+checks:
+  - kind: LoadApplied
+    load_name: steady
+    min_requests: 5000
+
+expectations:
+  fe_memory_growth_mb_per_min:
+    expected_range: [1.5, 4.5]
+    notes: "release/1.2.0 a4-recommended baseline measured 2.9 MB/min (2026-05-22)"
+    observed_history:
+      - {date: "2026-05-22", value: 2.90, run_id: "test_kv_router_memory_stability[a4-recommended-2-2.0-3.0-18.0-3.0-2.0]"}

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/kv_prefix_aware__no_prefix__disagg__vllm.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/kv_prefix_aware__no_prefix__disagg__vllm.yaml
@@ -1,0 +1,76 @@
+# S-N1 — unique prefixes per request, pushes radix tree to max node count.
+# Combined with the leak-positive router config, this tests whether the
+# leak rate scales with prefix uniqueness (H1: radix-tree retention).
+
+kind: router_memory
+name: kv_prefix_aware__no_prefix__disagg__vllm
+description: |
+  Same router config as the leak-positive baseline, but with AIPerf
+  random prompts (~0% block-level prefix hit). H1 prediction: leak >>
+  partial_prefix baseline (>>27 MB/min). H2/H3 prediction: ~28 MB/min.
+
+labels:
+  router_mode: kv_prefix_aware
+  traffic_shape: no_prefix
+  deployment: disagg
+  backend: vllm
+  leak_signal: positive_h1_lever
+  hypothesis: H1_radix_tree_retention
+
+deployment:
+  backend: vllm
+  topology: disagg
+  units: 2
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-afa8f7b7
+  model_cache_pvc: shared-model-cache
+
+router:
+  mode: kv
+  knobs:
+    DYN_ROUTER_USE_KV_EVENTS: "false"
+    DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT: "1.0"
+    DYN_ROUTER_ASSUME_KV_REUSE: "false"
+    DYN_ROUTER_REPLICA_SYNC: "true"
+    DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
+    DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
+
+load:
+  shape:
+    type: no_prefix      # no prefix knobs → AIPerf generates random prompts → ~0% hit
+  rungs:
+    - name: warmup
+      concurrency: 12
+      duration_minutes: 2.0
+    - name: steady
+      concurrency: 48
+      duration_minutes: 45.0
+  common:
+    request_timeout_seconds: 30
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never
+
+reports:
+  - FaultToleranceReport
+  - ErrorBreakdownReport
+  - PerWorkerLatencyReport
+
+checks:
+  - kind: LoadApplied
+    load_name: steady
+    min_requests: 5000
+  - kind: WorkloadShapeVerified
+    load_name: steady
+    min_unique_prompts: 5000     # AIPerf random prompts → expect ~6800 unique
+    isl_mean_min: 1500           # ISL distribution should match cycle 6 baseline (~1600)
+    isl_mean_max: 2000
+
+expectations:
+  fe_memory_growth_mb_per_min:
+    expected_range: [25, 80]
+    notes: |
+      H1 (radix-tree retention): >> 27 (≥ 50 MB/min)
+      H2/H3 (per-request or per-worker): ≈ 27 (same as partial_prefix)
+      The width of the expected_range reflects which hypothesis you're
+      testing — narrow it after first measurement.
+    observed_history: []

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/kv_prefix_aware__partial_prefix__disagg__vllm.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/kv_prefix_aware__partial_prefix__disagg__vllm.yaml
@@ -1,13 +1,13 @@
-# Leak-POSITIVE cell. KV-aware routing with prefix scoring AT PRODUCTION
-# DEFAULT (OVERLAP_SCORE_WEIGHT=1.0). This is the gpt-oss-120b production
+# Leak-POSITIVE cell. KV-aware routing with prefix scoring at the
+# OVERLAP_SCORE_WEIGHT=1.0 default. This is a gpt-oss-120b-class KV-aware
 # configuration; measured slope ≈ 27 MB/min on 2026-05-22.
 
 kind: router_memory
 name: kv_prefix_aware__partial_prefix__disagg__vllm
 description: |
-  KV-aware load steering + prefix scoring at production default.
-  The leak-POSITIVE case. Matches gpt-oss-120b production config and
-  reproduces the INFH-157 ~25 MB/min leak rate.
+  KV-aware load steering + prefix scoring at the OVERLAP_SCORE_WEIGHT=1.0
+  default. The leak-POSITIVE case. A gpt-oss-120b-class KV-aware
+  configuration that exercises a steady FE memory-growth path (~25 MB/min).
 
 labels:
   router_mode: kv_prefix_aware
@@ -15,7 +15,7 @@ labels:
   deployment: disagg
   backend: vllm
   leak_signal: positive
-  matches_production: gpt-oss-120b
+  reference_config: gpt-oss-120b
 
 deployment:
   backend: vllm
@@ -28,7 +28,7 @@ router:
   mode: kv
   knobs:
     DYN_ROUTER_USE_KV_EVENTS: "false"
-    DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT: "1.0"     # production default — flips prefix scoring ON
+    DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT: "1.0"     # default weight — flips prefix scoring ON
     DYN_ROUTER_ASSUME_KV_REUSE: "false"
     DYN_ROUTER_REPLICA_SYNC: "true"
     DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
@@ -71,8 +71,9 @@ expectations:
     expected_range: [22, 32]
     notes: |
       Binary on/off behaviour: any non-zero OVERLAP_SCORE_WEIGHT produces
-      ~27 MB/min (not scale-dependent). Matches INFH-157 ~25 MB/min in prod.
+      ~27 MB/min (not scale-dependent). A steady FE memory-growth signal
+      (~25 MB/min).
     observed_history:
-      - {date: "2026-05-22", value: 27.31, run_id: "vllm-q3-prod-units-1779499076-2719", knob_value: "1.0"}
-      - {date: "2026-05-22", value: 27.45, run_id: "vllm-q3-prod-units-1779408862-2841", knob_value: "2.0"}
+      - {date: "2026-05-22", value: 27.31, run_id: "vllm-q3-units-1779499076-2719", knob_value: "1.0"}
+      - {date: "2026-05-22", value: 27.45, run_id: "vllm-q3-units-1779408862-2841", knob_value: "2.0"}
       - {date: "2026-05-22", value: 28.78, run_id: "earlier-overlap-2.0", knob_value: "2.0"}

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/kv_prefix_aware__partial_prefix__disagg__vllm.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/kv_prefix_aware__partial_prefix__disagg__vllm.yaml
@@ -1,0 +1,78 @@
+# Leak-POSITIVE cell. KV-aware routing with prefix scoring AT PRODUCTION
+# DEFAULT (OVERLAP_SCORE_WEIGHT=1.0). This is the gpt-oss-120b production
+# configuration; measured slope ≈ 27 MB/min on 2026-05-22.
+
+kind: router_memory
+name: kv_prefix_aware__partial_prefix__disagg__vllm
+description: |
+  KV-aware load steering + prefix scoring at production default.
+  The leak-POSITIVE case. Matches gpt-oss-120b production config and
+  reproduces the INFH-157 ~25 MB/min leak rate.
+
+labels:
+  router_mode: kv_prefix_aware
+  traffic_shape: partial_prefix
+  deployment: disagg
+  backend: vllm
+  leak_signal: positive
+  matches_production: gpt-oss-120b
+
+deployment:
+  backend: vllm
+  topology: disagg
+  units: 2
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-afa8f7b7
+  model_cache_pvc: shared-model-cache
+
+router:
+  mode: kv
+  knobs:
+    DYN_ROUTER_USE_KV_EVENTS: "false"
+    DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT: "1.0"     # production default — flips prefix scoring ON
+    DYN_ROUTER_ASSUME_KV_REUSE: "false"
+    DYN_ROUTER_REPLICA_SYNC: "true"
+    DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
+    DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
+
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 15
+    prefix_prompt_length: 600
+  rungs:
+    - name: warmup
+      concurrency: 12
+      duration_minutes: 2.0
+    - name: steady
+      concurrency: 48
+      duration_minutes: 45.0
+  common:
+    request_timeout_seconds: 30
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never
+
+reports:
+  - FaultToleranceReport
+  - ErrorBreakdownReport
+  - PerWorkerLatencyReport
+
+checks:
+  - kind: LoadApplied
+    load_name: steady
+    min_requests: 5000
+  - kind: WorkloadShapeVerified
+    load_name: steady
+    isl_mean_min: 1400           # just sanity-check the workload shape didn't drift
+    isl_mean_max: 1900
+
+expectations:
+  fe_memory_growth_mb_per_min:
+    expected_range: [22, 32]
+    notes: |
+      Binary on/off behaviour: any non-zero OVERLAP_SCORE_WEIGHT produces
+      ~27 MB/min (not scale-dependent). Matches INFH-157 ~25 MB/min in prod.
+    observed_history:
+      - {date: "2026-05-22", value: 27.31, run_id: "vllm-q3-prod-units-1779499076-2719", knob_value: "1.0"}
+      - {date: "2026-05-22", value: 27.45, run_id: "vllm-q3-prod-units-1779408862-2841", knob_value: "2.0"}
+      - {date: "2026-05-22", value: 28.78, run_id: "earlier-overlap-2.0", knob_value: "2.0"}

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/kv_prefix_aware__same_prefix__disagg__vllm.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/kv_prefix_aware__same_prefix__disagg__vllm.yaml
@@ -1,0 +1,76 @@
+# S-N2 — single shared system prompt for every request, maximum prefix
+# sharing, minimum radix tree node growth.
+
+kind: router_memory
+name: kv_prefix_aware__same_prefix__disagg__vllm
+description: |
+  Same router config as the leak-positive baseline, but with
+  shared_system_prompt_length=2000 prepended to every request →
+  ~100% prefix overlap → minimum tree node growth.
+  H1 prediction: leak << 27 (near 3 MB/min baseline). H2/H3: still ~27.
+
+labels:
+  router_mode: kv_prefix_aware
+  traffic_shape: same_prefix
+  deployment: disagg
+  backend: vllm
+  leak_signal: positive_h1_lever
+  hypothesis: H1_radix_tree_retention
+
+deployment:
+  backend: vllm
+  topology: disagg
+  units: 2
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-afa8f7b7
+  model_cache_pvc: shared-model-cache
+
+router:
+  mode: kv
+  knobs:
+    DYN_ROUTER_USE_KV_EVENTS: "false"
+    DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT: "1.0"
+    DYN_ROUTER_ASSUME_KV_REUSE: "false"
+    DYN_ROUTER_REPLICA_SYNC: "true"
+    DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
+    DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
+
+load:
+  shape:
+    type: same_prefix
+    shared_system_prompt_length: 2000
+  rungs:
+    - name: warmup
+      concurrency: 12
+      duration_minutes: 2.0
+    - name: steady
+      concurrency: 48
+      duration_minutes: 45.0
+  common:
+    request_timeout_seconds: 30
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never
+
+reports:
+  - FaultToleranceReport
+  - ErrorBreakdownReport
+  - PerWorkerLatencyReport
+
+checks:
+  - kind: LoadApplied
+    load_name: steady
+    min_requests: 5000
+  - kind: WorkloadShapeVerified
+    load_name: steady
+    max_unique_prompts: 5        # shared_system_prompt_length=2000 should collapse to ~1
+    isl_mean_min: 1500
+    isl_mean_max: 2500           # slightly wider since shared prefix adds tokens
+
+expectations:
+  fe_memory_growth_mb_per_min:
+    expected_range: [2, 28]
+    notes: |
+      H1 (radix-tree retention): << 27 (≤ 5 MB/min — near no-leak baseline)
+      H2/H3 (per-request or per-worker): ≈ 27 MB/min
+      Wide range until first measurement; narrows the H1 vs H2 question.
+    observed_history: []

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/kvmem_leak_arm_c_n50.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/kvmem_leak_arm_c_n50.yaml
@@ -1,0 +1,136 @@
+# KV-leak scale study — LEAK ARM, N=50 mocker (nscale), KV load-aware (arm C).
+#
+# 3-HOUR sustained run to observe FE / worker RSS growth at scale under the
+# recommended KV load-aware config (the same arm-C stack validated at N=15):
+#   - mode=kv, events OFF, overlap 0.0, replica-sync ON, queue threshold 4.0, fcfs.
+#   - DYN_ACTIVE_* thresholds 0.85. Worker TCP-gate 128/5.
+# 50 FE + 100 prefill + 50 decode (200 pods). memory_request 1.5Gi (peak RSS
+# ~1.0GB; the 3Gi template request over-reserves and won't fit the ~326Gi-free
+# nscale cpu-pool at 200 pods — see reference_mocker_memory_footprint).
+# steady=700 (~0.78xC_max@50; C_max@25~=450 measured, x2 units -> ~900), burst=
+# 1400 (2x). NOT 4x — a 4x spike (2800) oversaturates like the n=25 c=600 rung
+# (3x seq-cap) and times out the load job mid-run. SLA/timeout/goodput=15s.
+# 180-min trapezoid, 3x 2x-bursts, longer steadies for the leak signal.
+
+kind: router_memory
+name: kvmem_leak_arm_c_n50
+description: |
+  KV-leak study leak arm (KV load-aware, mocker, N=50). 50/100/50 mocker-disagg,
+  kv router (events off, overlap 0.0, replica-sync) + 0.85 thresholds + tuned
+  worker TCP-gate (128/5). 180-min trapezoid with 3x 2x-bursts; sustained steady
+  windows for FE/worker memory-growth observation.
+
+labels:
+  purpose: kvmem_leak_arm
+  arm: kvmem_leak_arm_c_n50
+  router_mode: kv
+  deployment: disagg
+  backend: mocker
+  cluster: nscale-dev-cluster
+
+deployment:
+  backend: mocker
+  topology: disagg
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-mocker-prefill-pinning-a5c93b3331-neelays
+  log_pvc: dynamo-ft-logs
+  # 1.0Gi ~= the measured ~1.0GB peak RSS; 200 x 1.0 = 200Gi leaves ~126Gi margin
+  # in the ~326Gi-free nscale cpu-pool. At 1.25Gi the uneven other-tenant baseline
+  # left 8/200 pods mem-OOM on the tightest nodes; 1.0Gi raises per-node capacity
+  # to ~322 pods so the full 200-pod gang fits. Limit stays 10Gi (actual usage +
+  # any leak growth bounded per-pod; node has ample headroom at ~20 pods/node).
+  memory_request: 1.0Gi
+  # Template cpu request is 1 -> 200 CPU for the gang, but the nscale cpu-pool
+  # (10 x 32 = 320 CPU) has only ~270 free after baseline; uneven packing left
+  # 22 pods OutOfcpu at cpu=1. 500m -> 100 CPU total (huge margin); mockers are
+  # mock engines that burst to the cpu *limit* (4) regardless of request.
+  cpu_request: 500m
+  replicas:
+    Frontend: 50
+    prefill: 100
+    decode: 50
+
+router:
+  mode: kv
+  knobs:
+    DYN_ROUTER_USE_KV_EVENTS: "false"
+    DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT: "0.0"
+    DYN_ROUTER_PREFILL_LOAD_SCALE: "1.0"
+    DYN_ROUTER_QUEUE_THRESHOLD: "4.0"
+    DYN_ROUTER_QUEUE_POLICY: "fcfs"
+    DYN_ROUTER_REPLICA_SYNC: "true"
+    DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
+    DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
+    DYN_EVENT_PLANE: "zmq"
+    DYN_DISCOVERY_BACKEND: "kubernetes"
+    DYN_STORE_KV: "mem"
+
+admission:
+  knobs:
+    DYN_TCP_WORKER_POOL_SIZE: "128"
+    DYN_TCP_WORK_QUEUE_SIZE: "5"
+    VLLM_NIXL_ABORT_REQUEST_TIMEOUT: "30"
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30"
+
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 5
+    prefix_prompt_length: 740
+    seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
+  rungs:
+    - { name: warmup,   concurrency: 32,   duration_minutes: 2.0 }
+    - { name: ramp,     concurrency: 700,  duration_minutes: 1.0 }
+    - { name: steady-1, concurrency: 700,  duration_minutes: 33.0 }
+    - { name: burst-1,  concurrency: 1400, duration_minutes: 12.0 }
+    - { name: steady-2, concurrency: 700,  duration_minutes: 33.0 }
+    - { name: burst-2,  concurrency: 1400, duration_minutes: 12.0 }
+    - { name: steady-3, concurrency: 700,  duration_minutes: 33.0 }
+    - { name: burst-3,  concurrency: 1400, duration_minutes: 12.0 }
+    - { name: steady-4, concurrency: 700,  duration_minutes: 40.0 }
+    - { name: rampdown, concurrency: 32,   duration_minutes: 2.0 }
+  common:
+    request_timeout_seconds: 15
+    goodput: ["request_latency:15000"]
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never
+
+events:
+  - { kind: WaitForModelReady, timeout: 2400 }
+  - kind: ResourcePoller
+    services: [Frontend, prefill, decode]
+    interval_s: 5
+  - { kind: StartLoad, load_ref: warmup }
+  - { kind: WaitForLoadCompletion, name: warmup }
+  - { kind: StartLoad, load_ref: ramp }
+  - { kind: WaitForLoadCompletion, name: ramp }
+  - { kind: StartLoad, load_ref: steady-1 }
+  - { kind: WaitForLoadCompletion, name: steady-1 }
+  - { kind: CaptureMetrics, suffix: ".baseline" }
+  - { kind: StartLoad, load_ref: burst-1 }
+  - { kind: WaitForLoadCompletion, name: burst-1 }
+  - { kind: CaptureMetrics, suffix: ".post-burst1" }
+  - { kind: StartLoad, load_ref: steady-2 }
+  - { kind: WaitForLoadCompletion, name: steady-2 }
+  - { kind: StartLoad, load_ref: burst-2 }
+  - { kind: WaitForLoadCompletion, name: burst-2 }
+  - { kind: CaptureMetrics, suffix: ".post-burst2" }
+  - { kind: StartLoad, load_ref: steady-3 }
+  - { kind: WaitForLoadCompletion, name: steady-3 }
+  - { kind: StartLoad, load_ref: burst-3 }
+  - { kind: WaitForLoadCompletion, name: burst-3 }
+  - { kind: CaptureMetrics, suffix: ".post-burst3" }
+  - { kind: StartLoad, load_ref: steady-4 }
+  - { kind: WaitForLoadCompletion, name: steady-4 }
+  - { kind: CaptureMetrics, suffix: ".final" }
+  - { kind: StartLoad, load_ref: rampdown }
+  - { kind: WaitForLoadCompletion, name: rampdown }
+
+reports:
+  - PerWorkerLatencyReport
+  - ErrorBreakdownReport
+
+checks:
+  - { kind: LoadApplied, load_name: burst-2, min_requests: 2000 }
+  - { kind: WorkerPanics, services: [Frontend, prefill, decode], acceptable: true }
+  - { kind: RestartCountIncreased, services: [Frontend, prefill, decode], expect_min_increment: 0 }

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/kvmem_sweep_mock_n25.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/kvmem_sweep_mock_n25.yaml
@@ -1,0 +1,80 @@
+# KV-leak scale study — Stage-0 saturation sweep, N=25 mocker (nebius SHAKEOUT).
+#
+# Shakeout before N=50: validates that the full pipeline stands up at scale on
+# nebius — 25 FE + 50 prefill + 25 decode (100 pods, 100-pod kai gang, 75 worker
+# discovery CRs, ZMQ event plane, load-gen) — AND measures the aggregate C_max
+# for the KV load-aware (recommended) config at the 15s mocker SLA. If this is
+# clean, N=50 follows.
+#
+# Router = KV load-aware (recommended): same config as the eventual N=50 leak arm
+# (mode=kv, events off, overlap 0.0, replica-sync, queue-thresh 4.0, fcfs,
+# 0.85 active thresholds). speedup-ratio=1.0 (bundled mocker disagg.yaml).
+# Consumed via --sat-deploy-scenario kvmem_sweep_mock_n25 (test_saturation_discovery
+# drives its own --search-space; the load block below is an ignored placeholder).
+
+kind: router_memory
+name: kvmem_sweep_mock_n25
+
+labels:
+  purpose: kvmem_scale_sweep
+  arm: kvmem_sweep_mock_n25
+  router_mode: kv
+  deployment: disagg
+  backend: mocker
+  cluster: nebius-2
+
+deployment:
+  backend: mocker
+  topology: disagg
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-mocker-prefill-pinning-a5c93b3331-neelays
+  log_pvc: dynamo-ft-logs
+  # Measured peak mocker RSS over a full 120-min run is ~1.0GB/pod (FE 0.5,
+  # prefill/decode 1.0 — see arm-A/C pod_memory_growth.tsv). The template's
+  # 3Gi *request* is a 3x over-reservation: the n=25 OOM was nodes filling with
+  # 3Gi RESERVATIONS (admission), not real memory. 1.5Gi (peak + 50% headroom)
+  # fits n=25 (150Gi) AND n=50 (300Gi) in the ~326Gi-free cpu-pool. Limit stays
+  # 10Gi for burst headroom.
+  memory_request: 1.5Gi
+  replicas:
+    Frontend: 25
+    prefill: 50
+    decode: 25
+
+router:
+  mode: kv
+  knobs:
+    DYN_ROUTER_USE_KV_EVENTS: "false"
+    DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT: "0.0"
+    DYN_ROUTER_PREFILL_LOAD_SCALE: "1.0"
+    DYN_ROUTER_QUEUE_THRESHOLD: "4.0"
+    DYN_ROUTER_QUEUE_POLICY: "fcfs"
+    DYN_ROUTER_REPLICA_SYNC: "true"
+    DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
+    DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
+    DYN_EVENT_PLANE: "zmq"
+    DYN_DISCOVERY_BACKEND: "kubernetes"
+    DYN_STORE_KV: "mem"
+
+admission:
+  knobs:
+    DYN_TCP_WORKER_POOL_SIZE: "128"
+    DYN_TCP_WORK_QUEUE_SIZE: "5"
+    VLLM_NIXL_ABORT_REQUEST_TIMEOUT: "30"
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30"
+
+# Ignored placeholder — the sweep supplies its own --search-space.
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 5
+    prefix_prompt_length: 740
+    seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
+  rungs:
+    - name: unused_sweep_supplies_own_load
+      concurrency: 16
+      duration_minutes: 1.0
+  common:
+    request_timeout_seconds: 86400
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/kvmem_sweep_mock_n25.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/kvmem_sweep_mock_n25.yaml
@@ -29,7 +29,7 @@ deployment:
   image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-mocker-prefill-pinning-a5c93b3331-neelays
   log_pvc: dynamo-ft-logs
   # Measured peak mocker RSS over a full 120-min run is ~1.0GB/pod (FE 0.5,
-  # prefill/decode 1.0 — see arm-A/C pod_memory_growth.tsv). The template's
+  # prefill/decode 1.0 — see arm-A/C resources.agg.tsv). The template's
   # 3Gi *request* is a 3x over-reservation: the n=25 OOM was nodes filling with
   # 3Gi RESERVATIONS (admission), not real memory. 1.5Gi (peak + 50% headroom)
   # fits n=25 (150Gi) AND n=50 (300Gi) in the ~326Gi-free cpu-pool. Limit stays

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/kvmem_sweep_mock_n50.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/kvmem_sweep_mock_n50.yaml
@@ -1,0 +1,69 @@
+# KV-leak scale study — Stage-0 saturation sweep, N=50 mocker (nebius).
+#
+# After the N=25 shakeout passes. 50 FE + 100 prefill + 50 decode (200 pods,
+# 200-pod kai gang, 150 worker discovery CRs). Measures aggregate C_max for the
+# KV load-aware (recommended) config at the 15s mocker SLA — calibrates the
+# steady/burst concurrency for the 120-min leak arm (kvmem_arm_mock_n50).
+#
+# Router = KV load-aware (recommended), identical to the leak arm. speedup=1.0.
+# Consumed via --sat-deploy-scenario kvmem_sweep_mock_n50.
+
+kind: router_memory
+name: kvmem_sweep_mock_n50
+
+labels:
+  purpose: kvmem_scale_sweep
+  arm: kvmem_sweep_mock_n50
+  router_mode: kv
+  deployment: disagg
+  backend: mocker
+  cluster: nebius-2
+
+deployment:
+  backend: mocker
+  topology: disagg
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-mocker-prefill-pinning-a5c93b3331-neelays
+  log_pvc: dynamo-ft-logs
+  replicas:
+    Frontend: 50
+    prefill: 100
+    decode: 50
+
+router:
+  mode: kv
+  knobs:
+    DYN_ROUTER_USE_KV_EVENTS: "false"
+    DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT: "0.0"
+    DYN_ROUTER_PREFILL_LOAD_SCALE: "1.0"
+    DYN_ROUTER_QUEUE_THRESHOLD: "4.0"
+    DYN_ROUTER_QUEUE_POLICY: "fcfs"
+    DYN_ROUTER_REPLICA_SYNC: "true"
+    DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
+    DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
+    DYN_EVENT_PLANE: "zmq"
+    DYN_DISCOVERY_BACKEND: "kubernetes"
+    DYN_STORE_KV: "mem"
+
+admission:
+  knobs:
+    DYN_TCP_WORKER_POOL_SIZE: "128"
+    DYN_TCP_WORK_QUEUE_SIZE: "5"
+    VLLM_NIXL_ABORT_REQUEST_TIMEOUT: "30"
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30"
+
+# Ignored placeholder — the sweep supplies its own --search-space.
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 5
+    prefix_prompt_length: 740
+    seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
+  rungs:
+    - name: unused_sweep_supplies_own_load
+      concurrency: 16
+      duration_minutes: 1.0
+  common:
+    request_timeout_seconds: 86400
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/least_loaded__partial_prefix__disagg__vllm.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/least_loaded__partial_prefix__disagg__vllm.yaml
@@ -1,0 +1,66 @@
+# LeastLoaded routing baseline — no KV-router state at all. Used to
+# isolate "is the leak in the KV-router code path?" vs "is it shared
+# with LL?" — historical answer: leans KV-specific.
+
+kind: router_memory
+name: least_loaded__partial_prefix__disagg__vllm
+description: |
+  Pure pod-load steering, no KV-router state. The control cell that
+  proves whether the leak is KV-router-specific or shared with LL.
+
+labels:
+  router_mode: least_loaded
+  traffic_shape: partial_prefix
+  deployment: disagg
+  backend: vllm
+  leak_signal: control
+
+deployment:
+  backend: vllm
+  topology: disagg
+  units: 2
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-afa8f7b7
+  model_cache_pvc: shared-model-cache
+
+router:
+  mode: least-loaded
+  knobs:
+    DYN_ROUTER_USE_KV_EVENTS: "false"
+    DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
+    DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
+
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 15
+    prefix_prompt_length: 600
+  rungs:
+    - name: warmup
+      concurrency: 12
+      duration_minutes: 2.0
+    - name: steady
+      concurrency: 48
+      duration_minutes: 37.0
+  common:
+    request_timeout_seconds: 30
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never
+
+reports:
+  - FaultToleranceReport
+  - ErrorBreakdownReport
+  - PerWorkerLatencyReport
+
+checks:
+  - kind: LoadApplied
+    load_name: steady
+    min_requests: 5000
+
+expectations:
+  fe_memory_growth_mb_per_min:
+    expected_range: [1.5, 3.5]
+    notes: "LL on release/1.2.0 measured 2.32 MB/min (P0.1 in 5hr-burst)"
+    observed_history:
+      - {date: "2026-05-22", value: 2.32, run_id: "test_kv_router_memory_stability[least-loaded-baseline-2-2.0-3.0-18.0-3.0-2.0]"}
+      - {date: "2026-05-22", value: 2.64, run_id: "stock-1.1.1-LL-baseline (per observe)"}

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/release_1_2_0__kv_prefix__disagg__mocker.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/release_1_2_0__kv_prefix__disagg__mocker.yaml
@@ -1,0 +1,117 @@
+# Matrix arm — leak investigation (image × routing-mode matrix)
+# Image: release-1.2.0 | Routing: kv_prefix
+# Leak-POSITIVE — production-default KV+prefix on newer image
+
+kind: router_memory
+name: release_1_2_0__kv_prefix__disagg__mocker
+description: |
+  Matrix arm: kv_prefix routing on release-1.2.0 mocker-disagg.
+  2 FE × 2 prefill × 2 decode mocker workers, trapezoid load ~30 min.
+  Production ISL/OSL/prefix shape (partial_prefix, ~37% prefix-hit).
+
+labels:
+  image_label: release-1.2.0
+  router_mode: kv_prefix
+  traffic_shape: partial_prefix
+  deployment: disagg
+  backend: mocker
+
+deployment:
+  backend: mocker
+  topology: disagg
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-afa8f7b7
+  replicas:
+    Frontend: 10
+    prefill: 20
+    decode: 10
+
+router:
+  mode: kv
+  knobs:
+    DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT: "1.0"
+    DYN_ROUTER_USE_KV_EVENTS: "false"
+    DYN_ROUTER_REPLICA_SYNC: "true"
+    DYN_ROUTER_TEMPERATURE: "0.0"
+    DYN_ROUTER_TRACK_ACTIVE_BLOCKS: "true"
+
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 15
+    prefix_prompt_length: 600
+  rungs:
+    - name: warmup
+      concurrency: 40
+      duration_minutes: 1.0
+    - name: ramp1
+      concurrency: 120
+      duration_minutes: 2.5
+    - name: ramp2
+      concurrency: 180
+      duration_minutes: 2.5
+    - name: steady
+      concurrency: 120
+      duration_minutes: 18.0
+    - name: rampdown1
+      concurrency: 180
+      duration_minutes: 2.5
+    - name: rampdown2
+      concurrency: 120
+      duration_minutes: 2.5
+    - name: final
+      concurrency: 40
+      duration_minutes: 1.0
+  common:
+    request_timeout_seconds: 30
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never
+
+events:
+  - kind: WaitForModelReady
+    timeout: 900
+  - kind: PodMemoryPoller
+    services: [Frontend, prefill, decode]
+    interval_s: 15
+  - kind: StartLoad
+    load_ref: warmup
+  - kind: WaitForLoadCompletion
+    name: warmup
+  - kind: StartLoad
+    load_ref: ramp1
+  - kind: WaitForLoadCompletion
+    name: ramp1
+  - kind: StartLoad
+    load_ref: ramp2
+  - kind: WaitForLoadCompletion
+    name: ramp2
+  - kind: StartLoad
+    load_ref: steady
+  - kind: WaitForLoadCompletion
+    name: steady
+  - kind: StartLoad
+    load_ref: rampdown1
+  - kind: WaitForLoadCompletion
+    name: rampdown1
+  - kind: StartLoad
+    load_ref: rampdown2
+  - kind: WaitForLoadCompletion
+    name: rampdown2
+  - kind: StartLoad
+    load_ref: final
+  - kind: WaitForLoadCompletion
+    name: final
+
+reports:
+  - PerWorkerLatencyReport
+
+checks:
+  - kind: LoadApplied
+    load_name: steady
+    min_requests: 1000
+
+expectations:
+  fe_memory_growth_mb_per_min:
+    expected_range: [20, 35]
+    notes: |
+      Leak-POSITIVE — production-default KV+prefix on newer image.

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/release_1_2_0__kv_prefix__disagg__mocker.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/release_1_2_0__kv_prefix__disagg__mocker.yaml
@@ -70,7 +70,7 @@ load:
 events:
   - kind: WaitForModelReady
     timeout: 900
-  - kind: PodMemoryPoller
+  - kind: ResourcePoller
     services: [Frontend, prefill, decode]
     interval_s: 15
   - kind: StartLoad

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/release_1_2_0__kv_pure_load__disagg__mocker.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/release_1_2_0__kv_pure_load__disagg__mocker.yaml
@@ -73,7 +73,7 @@ load:
 events:
   - kind: WaitForModelReady
     timeout: 900
-  - kind: PodMemoryPoller
+  - kind: ResourcePoller
     services: [Frontend, prefill, decode]
     interval_s: 15
   - kind: StartLoad

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/release_1_2_0__kv_pure_load__disagg__mocker.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/release_1_2_0__kv_pure_load__disagg__mocker.yaml
@@ -1,0 +1,120 @@
+# Matrix arm — leak investigation (image × routing-mode matrix)
+# Image: release-1.2.0 | Routing: kv_pure_load
+# A4 pure-load reference on newer image
+
+kind: router_memory
+name: release_1_2_0__kv_pure_load__disagg__mocker
+description: |
+  Matrix arm: kv_pure_load routing on release-1.2.0 mocker-disagg.
+  2 FE × 2 prefill × 2 decode mocker workers, trapezoid load ~30 min.
+  Production ISL/OSL/prefix shape (partial_prefix, ~37% prefix-hit).
+
+labels:
+  image_label: release-1.2.0
+  router_mode: kv_pure_load
+  traffic_shape: partial_prefix
+  deployment: disagg
+  backend: mocker
+
+deployment:
+  backend: mocker
+  topology: disagg
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-afa8f7b7
+  replicas:
+    Frontend: 10
+    prefill: 20
+    decode: 10
+
+router:
+  mode: kv
+  knobs:
+    DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT: "0.0"
+    DYN_KV_HOST_CACHE_HIT_WEIGHT: "0.0"
+    DYN_KV_DISK_CACHE_HIT_WEIGHT: "0.0"
+    DYN_ROUTER_USE_KV_EVENTS: "false"
+    DYN_ROUTER_REPLICA_SYNC: "true"
+    DYN_ROUTER_TEMPERATURE: "0.0"
+    DYN_ROUTER_ASSUME_KV_REUSE: "false"
+    DYN_ROUTER_TRACK_ACTIVE_BLOCKS: "true"
+
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 15
+    prefix_prompt_length: 600
+  rungs:
+    - name: warmup
+      concurrency: 40
+      duration_minutes: 1.0
+    - name: ramp1
+      concurrency: 120
+      duration_minutes: 2.5
+    - name: ramp2
+      concurrency: 180
+      duration_minutes: 2.5
+    - name: steady
+      concurrency: 120
+      duration_minutes: 18.0
+    - name: rampdown1
+      concurrency: 180
+      duration_minutes: 2.5
+    - name: rampdown2
+      concurrency: 120
+      duration_minutes: 2.5
+    - name: final
+      concurrency: 40
+      duration_minutes: 1.0
+  common:
+    request_timeout_seconds: 30
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never
+
+events:
+  - kind: WaitForModelReady
+    timeout: 900
+  - kind: PodMemoryPoller
+    services: [Frontend, prefill, decode]
+    interval_s: 15
+  - kind: StartLoad
+    load_ref: warmup
+  - kind: WaitForLoadCompletion
+    name: warmup
+  - kind: StartLoad
+    load_ref: ramp1
+  - kind: WaitForLoadCompletion
+    name: ramp1
+  - kind: StartLoad
+    load_ref: ramp2
+  - kind: WaitForLoadCompletion
+    name: ramp2
+  - kind: StartLoad
+    load_ref: steady
+  - kind: WaitForLoadCompletion
+    name: steady
+  - kind: StartLoad
+    load_ref: rampdown1
+  - kind: WaitForLoadCompletion
+    name: rampdown1
+  - kind: StartLoad
+    load_ref: rampdown2
+  - kind: WaitForLoadCompletion
+    name: rampdown2
+  - kind: StartLoad
+    load_ref: final
+  - kind: WaitForLoadCompletion
+    name: final
+
+reports:
+  - PerWorkerLatencyReport
+
+checks:
+  - kind: LoadApplied
+    load_name: steady
+    min_requests: 1000
+
+expectations:
+  fe_memory_growth_mb_per_min:
+    expected_range: [1, 5]
+    notes: |
+      A4 pure-load reference on newer image.

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/release_1_2_0__least_loaded__disagg__mocker.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/release_1_2_0__least_loaded__disagg__mocker.yaml
@@ -66,7 +66,7 @@ load:
 events:
   - kind: WaitForModelReady
     timeout: 900
-  - kind: PodMemoryPoller
+  - kind: ResourcePoller
     services: [Frontend, prefill, decode]
     interval_s: 15
   - kind: StartLoad

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/release_1_2_0__least_loaded__disagg__mocker.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/release_1_2_0__least_loaded__disagg__mocker.yaml
@@ -1,0 +1,113 @@
+# Matrix arm — leak investigation (image × routing-mode matrix)
+# Image: release-1.2.0 | Routing: least_loaded
+# Leak-NEGATIVE reference on newer release/1.2.0 image
+
+kind: router_memory
+name: release_1_2_0__least_loaded__disagg__mocker
+description: |
+  Matrix arm: least_loaded routing on release-1.2.0 mocker-disagg.
+  2 FE × 2 prefill × 2 decode mocker workers, trapezoid load ~30 min.
+  Production ISL/OSL/prefix shape (partial_prefix, ~37% prefix-hit).
+
+labels:
+  image_label: release-1.2.0
+  router_mode: least_loaded
+  traffic_shape: partial_prefix
+  deployment: disagg
+  backend: mocker
+
+deployment:
+  backend: mocker
+  topology: disagg
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-afa8f7b7
+  replicas:
+    Frontend: 10
+    prefill: 20
+    decode: 10
+
+router:
+  mode: least-loaded
+  knobs:
+    DYN_ROUTER_USE_KV_EVENTS: "false"
+
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 15
+    prefix_prompt_length: 600
+  rungs:
+    - name: warmup
+      concurrency: 40
+      duration_minutes: 1.0
+    - name: ramp1
+      concurrency: 120
+      duration_minutes: 2.5
+    - name: ramp2
+      concurrency: 180
+      duration_minutes: 2.5
+    - name: steady
+      concurrency: 120
+      duration_minutes: 18.0
+    - name: rampdown1
+      concurrency: 180
+      duration_minutes: 2.5
+    - name: rampdown2
+      concurrency: 120
+      duration_minutes: 2.5
+    - name: final
+      concurrency: 40
+      duration_minutes: 1.0
+  common:
+    request_timeout_seconds: 30
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never
+
+events:
+  - kind: WaitForModelReady
+    timeout: 900
+  - kind: PodMemoryPoller
+    services: [Frontend, prefill, decode]
+    interval_s: 15
+  - kind: StartLoad
+    load_ref: warmup
+  - kind: WaitForLoadCompletion
+    name: warmup
+  - kind: StartLoad
+    load_ref: ramp1
+  - kind: WaitForLoadCompletion
+    name: ramp1
+  - kind: StartLoad
+    load_ref: ramp2
+  - kind: WaitForLoadCompletion
+    name: ramp2
+  - kind: StartLoad
+    load_ref: steady
+  - kind: WaitForLoadCompletion
+    name: steady
+  - kind: StartLoad
+    load_ref: rampdown1
+  - kind: WaitForLoadCompletion
+    name: rampdown1
+  - kind: StartLoad
+    load_ref: rampdown2
+  - kind: WaitForLoadCompletion
+    name: rampdown2
+  - kind: StartLoad
+    load_ref: final
+  - kind: WaitForLoadCompletion
+    name: final
+
+reports:
+  - PerWorkerLatencyReport
+
+checks:
+  - kind: LoadApplied
+    load_name: steady
+    min_requests: 1000
+
+expectations:
+  fe_memory_growth_mb_per_min:
+    expected_range: [1, 5]
+    notes: |
+      Leak-NEGATIVE reference on newer release/1.2.0 image.

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/sanity_run1_common_harness.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/sanity_run1_common_harness.yaml
@@ -1,14 +1,13 @@
-# Session-level SANITY Run 1 — common harness sanity (~5 min)
+# Session-level sanity Run 1 — common harness sanity (~5 min)
 #
-# Per observe handoff: 2026-05-28-three-experiment-validation-session.md + SANITY.md.
-# Verifies that the production-tuned Recommended config plumbing works end-to-end
+# Verifies that the Recommended config plumbing works end-to-end
 # before launching E1 (imbalance), E2 (memory leak), or E3 (cascade).
 #
-# CHANGES vs SANITY.md handoff (flag back to observe in return handoff):
+# CHANGES vs prior sanity setup:
 #   - H3 NATS -> ZMQ verification: deployment uses DYN_EVENT_PLANE=zmq, not NATS.
 #     Verified via dynamo_frontend_worker_active_decode_blocks gauge per worker
 #     (post-hoc from server_metrics_export.jsonl) + zmq_transport=debug FE log.
-#   - H4 c=50 -> c=200: organic threshold crossing at production THRESHOLD=0.85
+#   - H4 c=50 -> c=200: organic threshold crossing at THRESHOLD=0.85
 #     (3 decode mockers × c=200 / 3 = ~67 concurrent each, comfortably > 0.85).
 #
 # Run via:
@@ -36,10 +35,10 @@ labels:
 deployment:
   backend: mocker
   topology: disagg
-  # NOTE: was mocker-prefill-pinning-3951afa0e1 (image #3) but that build has a
-  # pyo3 binding bug — MockEngineArgs missing kv_transfer_abort_timeout_ms kwarg.
-  # See Task #58. Falling back to image #2 (no DIS-2147 commits, no broken
-  # codepath) — Run 1 doesn't depend on DIS-2147.
+  # NOTE: the prefill-KV-pinning image had a pyo3 binding bug —
+  # MockEngineArgs missing the kv_transfer_abort_timeout_ms kwarg.
+  # Falling back to the unpatched baseline image (no prefill-KV-pinning
+  # commits, no broken codepath) — Run 1 doesn't depend on prefill-KV-pinning.
   image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-cascade-test-69d496df9a-neelays
   replicas:
     Frontend: 3
@@ -79,9 +78,8 @@ load:
     type: partial_prefix
     num_prefix_prompts: 5
     prefix_prompt_length: 740
-    # Production 30-bucket ISL/OSL distribution (May 2026 production
-    # data, verbatim from the validation one-pager). Each ',' triple is
-    # <ISL>,<OSL>:<weight>; entries are ';'-joined. Yields the production
+    # 30-bucket ISL/OSL distribution. Each ',' triple is
+    # <ISL>,<OSL>:<weight>; entries are ';'-joined. Yields the
     # target shape: ISL p50≈2113 / p95≈7513, OSL p50≈130 / p95≈200.
     seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
   rungs:
@@ -94,7 +92,7 @@ load:
                              # accumulate + memory baseline, short enough for
                              # fast iteration cycles (was 20, dropped to 8).
   common:
-    request_timeout_seconds: 30  # Production SLA: p95 latency must stay <30s
+    request_timeout_seconds: 30  # SLA target: p95 latency must stay <30s
     streaming: true
     ignore_eos: true
     connection_reuse_strategy: never
@@ -132,5 +130,5 @@ checks:
     services: [Frontend, prefill, decode]
     expect_min_increment: 0
 
-# Post-hoc verification covers H1-H13 from the SANITY handoff.
+# Post-hoc verification covers checks H1-H13.
 # See scripts/sanity-verify.py for per-check methodology.

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/sanity_run1_common_harness.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/sanity_run1_common_harness.yaml
@@ -102,7 +102,7 @@ load:
 events:
   - kind: WaitForModelReady
     timeout: 900
-  - kind: PodMemoryPoller
+  - kind: ResourcePoller
     services: [Frontend, prefill, decode]
     interval_s: 5
   - kind: StartLoad

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/sanity_run1_common_harness.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/sanity_run1_common_harness.yaml
@@ -36,7 +36,11 @@ labels:
 deployment:
   backend: mocker
   topology: disagg
-  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-mocker-prefill-pinning-3951afa0e1-neelays
+  # NOTE: was mocker-prefill-pinning-3951afa0e1 (image #3) but that build has a
+  # pyo3 binding bug — MockEngineArgs missing kv_transfer_abort_timeout_ms kwarg.
+  # See Task #58. Falling back to image #2 (no DIS-2147 commits, no broken
+  # codepath) — Run 1 doesn't depend on DIS-2147.
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-cascade-test-69d496df9a-neelays
   replicas:
     Frontend: 3
     prefill: 6
@@ -59,7 +63,9 @@ router:
     DYN_STORE_KV: "mem"
     # SANITY-specific: tactical per-module DEBUG on FE so we can verify H3+H4
     # without inflating the whole pod's log volume.
-    DYN_LOG: "info,dynamo_runtime::transports::event_plane::zmq_transport=debug,dynamo_llm::discovery::worker_monitor=debug"
+    # worker_monitor=debug -> "Busy instances changed" + worker-removal cleanup lines
+    # component::client=debug -> "inhibiting instance {id}" when report_instance_down fires
+    DYN_LOG: "info,dynamo_runtime::transports::event_plane::zmq_transport=debug,dynamo_llm::discovery::worker_monitor=debug,dynamo_runtime::component::client=debug"
 
 admission:
   knobs:
@@ -73,17 +79,22 @@ load:
     type: partial_prefix
     num_prefix_prompts: 5
     prefix_prompt_length: 740
-    # Production ISL/OSL shape (close to p50=2000/p95=7500 prod target)
-    seq_dist: "100,200:5;500,200:15;1000,200:20;1600,200:30;3400,200:20;7000,200:10"
+    # Production 30-bucket ISL/OSL distribution (May 2026 production
+    # data, verbatim from the validation one-pager). Each ',' triple is
+    # <ISL>,<OSL>:<weight>; entries are ';'-joined. Yields the production
+    # target shape: ISL p50≈2113 / p95≈7513, OSL p50≈130 / p95≈200.
+    seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
   rungs:
     - name: warmup
       concurrency: 50
       duration_minutes: 1.0
-    - name: steady_high
+    - name: steady-high
       concurrency: 200
-      duration_minutes: 4.0
+      duration_minutes: 8.0  # sanity dwell — long enough for ZMQ events to
+                             # accumulate + memory baseline, short enough for
+                             # fast iteration cycles (was 20, dropped to 8).
   common:
-    request_timeout_seconds: 40
+    request_timeout_seconds: 30  # Production SLA: p95 latency must stay <30s
     streaming: true
     ignore_eos: true
     connection_reuse_strategy: never
@@ -99,9 +110,9 @@ events:
   - kind: WaitForLoadCompletion
     name: warmup
   - kind: StartLoad
-    load_ref: steady_high
+    load_ref: steady-high
   - kind: WaitForLoadCompletion
-    name: steady_high
+    name: steady-high
 
 reports:
   - PerWorkerLatencyReport
@@ -112,7 +123,7 @@ reports:
 # scripts/sanity-verify.py — see that script for the per-check methodology.
 checks:
   - kind: LoadApplied
-    load_name: steady_high
+    load_name: steady-high
     min_requests: 500
   - kind: WorkerPanics
     services: [Frontend, prefill, decode]
@@ -121,7 +132,5 @@ checks:
     services: [Frontend, prefill, decode]
     expect_min_increment: 0
 
-expectations:
-  notes: |
-    Post-hoc verification covers H1-H13 from the SANITY handoff.
-    See scripts/sanity-verify.py for per-check methodology.
+# Post-hoc verification covers H1-H13 from the SANITY handoff.
+# See scripts/sanity-verify.py for per-check methodology.

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/sanity_run1_common_harness.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/sanity_run1_common_harness.yaml
@@ -1,0 +1,127 @@
+# Session-level SANITY Run 1 — common harness sanity (~5 min)
+#
+# Per observe handoff: 2026-05-28-three-experiment-validation-session.md + SANITY.md.
+# Verifies that the production-tuned Recommended config plumbing works end-to-end
+# before launching E1 (imbalance), E2 (memory leak), or E3 (cascade).
+#
+# CHANGES vs SANITY.md handoff (flag back to observe in return handoff):
+#   - H3 NATS -> ZMQ verification: deployment uses DYN_EVENT_PLANE=zmq, not NATS.
+#     Verified via dynamo_frontend_worker_active_decode_blocks gauge per worker
+#     (post-hoc from server_metrics_export.jsonl) + zmq_transport=debug FE log.
+#   - H4 c=50 -> c=200: organic threshold crossing at production THRESHOLD=0.85
+#     (3 decode mockers × c=200 / 3 = ~67 concurrent each, comfortably > 0.85).
+#
+# Run via:
+#   uv run pytest test_router_modes.py -k sanity_run1 \
+#       --namespace neelays-sanity-run1 -s -v \
+#       --storage-class dgxc-enterprise-file \
+#       --log-pvc dynamo-ft-logs --model-cache-pvc shared-model-cache
+#
+# Then post-hoc analyze with:
+#   scripts/sanity-verify.py test_outputs/<test-name>/
+
+kind: router_memory
+name: sanity_run1_common_harness
+description: |
+  3-set mocker disagg, Recommended config, c=200 sustained 5 min.
+  Verifies H1-H13 setup correctness via collected data (post-hoc).
+
+labels:
+  purpose: session_sanity
+  run: 1
+  router_mode: kv_recommended
+  deployment: disagg
+  backend: mocker
+
+deployment:
+  backend: mocker
+  topology: disagg
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-mocker-prefill-pinning-3951afa0e1-neelays
+  replicas:
+    Frontend: 3
+    prefill: 6
+    decode: 3
+
+router:
+  mode: kv
+  knobs:
+    # Recommended config — replica-sync ON, kv events OFF, scoring 0 + 1.0
+    DYN_ROUTER_USE_KV_EVENTS: "false"
+    DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT: "0.0"
+    DYN_ROUTER_PREFILL_LOAD_SCALE: "1.0"
+    DYN_ROUTER_QUEUE_THRESHOLD: "4.0"
+    DYN_ROUTER_QUEUE_POLICY: "fcfs"
+    DYN_ROUTER_REPLICA_SYNC: "true"
+    DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
+    DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
+    DYN_EVENT_PLANE: "zmq"
+    DYN_DISCOVERY_BACKEND: "kubernetes"
+    DYN_STORE_KV: "mem"
+    # SANITY-specific: tactical per-module DEBUG on FE so we can verify H3+H4
+    # without inflating the whole pod's log volume.
+    DYN_LOG: "info,dynamo_runtime::transports::event_plane::zmq_transport=debug,dynamo_llm::discovery::worker_monitor=debug"
+
+admission:
+  knobs:
+    DYN_TCP_WORKER_POOL_SIZE: "128"
+    DYN_TCP_WORK_QUEUE_SIZE: "5"
+    VLLM_NIXL_ABORT_REQUEST_TIMEOUT: "30"
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30"
+
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 5
+    prefix_prompt_length: 740
+    # Production ISL/OSL shape (close to p50=2000/p95=7500 prod target)
+    seq_dist: "100,200:5;500,200:15;1000,200:20;1600,200:30;3400,200:20;7000,200:10"
+  rungs:
+    - name: warmup
+      concurrency: 50
+      duration_minutes: 1.0
+    - name: steady_high
+      concurrency: 200
+      duration_minutes: 4.0
+  common:
+    request_timeout_seconds: 40
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never
+
+events:
+  - kind: WaitForModelReady
+    timeout: 900
+  - kind: PodMemoryPoller
+    services: [Frontend, prefill, decode]
+    interval_s: 5
+  - kind: StartLoad
+    load_ref: warmup
+  - kind: WaitForLoadCompletion
+    name: warmup
+  - kind: StartLoad
+    load_ref: steady_high
+  - kind: WaitForLoadCompletion
+    name: steady_high
+
+reports:
+  - PerWorkerLatencyReport
+  - ErrorBreakdownReport
+
+# Minimal live checks — just verify the test infra itself didn't fall over.
+# H1-H13 are computed POST-HOC from the collected data by
+# scripts/sanity-verify.py — see that script for the per-check methodology.
+checks:
+  - kind: LoadApplied
+    load_name: steady_high
+    min_requests: 500
+  - kind: WorkerPanics
+    services: [Frontend, prefill, decode]
+    acceptable: true
+  - kind: RestartCountIncreased
+    services: [Frontend, prefill, decode]
+    expect_min_increment: 0
+
+expectations:
+  notes: |
+    Post-hoc verification covers H1-H13 from the SANITY handoff.
+    See scripts/sanity-verify.py for per-check methodology.

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/sanity_run2_dis2147_fidelity.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/sanity_run2_dis2147_fidelity.yaml
@@ -92,7 +92,7 @@ load:
 events:
   - kind: WaitForModelReady
     timeout: 900
-  - kind: PodMemoryPoller
+  - kind: ResourcePoller
     services: [Frontend, prefill, decode]
     interval_s: 5
   - kind: StartLoad

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/sanity_run2_dis2147_fidelity.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/sanity_run2_dis2147_fidelity.yaml
@@ -44,7 +44,7 @@ deployment:
   image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-mocker-prefill-pinning-3951afa0e1-neelays
   replicas:
     Frontend: 1
-    prefill: 1
+    prefill: 2  # production "set" is 1F+2P+1D — see one-pager scale notes
     decode: 1
 
 router:
@@ -55,7 +55,12 @@ router:
     DYN_EVENT_PLANE: "zmq"
     DYN_DISCOVERY_BACKEND: "kubernetes"
     DYN_STORE_KV: "mem"
-    DYN_LOG: "info"
+    # Elevated DEBUG on:
+    #  - prefill_router + kube discovery + watcher: Task #67 diagnostic
+    #    (which PrefillResolveDecision branch fires, MDC discovery flow)
+    #  - worker_monitor: "Busy instances changed" + worker-removal cleanup lines
+    #  - component::client: "inhibiting instance {id}" when report_instance_down fires
+    DYN_LOG: "info,dynamo_llm::kv_router::prefill_router=debug,dynamo_runtime::discovery::kube=debug,dynamo_llm::discovery::watcher=debug,dynamo_llm::discovery::worker_monitor=debug,dynamo_runtime::component::client=debug"
 
 admission:
   knobs:
@@ -69,13 +74,17 @@ load:
     type: partial_prefix
     num_prefix_prompts: 5
     prefix_prompt_length: 740
-    seq_dist: "100,200:5;500,200:15;1000,200:20;1600,200:30;3400,200:20;7000,200:10"
+    # Production 30-bucket distribution — see sanity_run1 for full notes.
+    seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
   rungs:
     - name: saturate
       concurrency: 50
-      duration_minutes: 5.0
+      duration_minutes: 25.0  # 5× the original 5-min sanity dwell so the
+                              # DIS-2147 prefill-stranding feedback loop has
+                              # time to build up + stabilize. Pairs with the
+                              # Qwen3-30B mocker config to match prod.
   common:
-    request_timeout_seconds: 60
+    request_timeout_seconds: 30  # Production SLA: p95 latency must stay <30s
     streaming: true
     ignore_eos: true
     connection_reuse_strategy: never
@@ -110,15 +119,13 @@ checks:
     services: [Frontend, prefill, decode]
     expect_min_increment: 0
 
-expectations:
-  notes: |
-    Post-hoc F1-F5 verification via scripts/sanity-verify.py:
-      F1 prefill active_decode_blocks > 0 while decode kv_util >= 0.99
-      F2 prefill_kv_pin_start <-> prefill_kv_pin_end pair on room_id
-      F3 prefill_kv_pin_end{outcome=aborted, duration_ms ~= 30000}
-      F4 ABORT_BYTE in decode logs
-      F5 prefill KV ~= 100% sustained until abort fires or decode frees
-
-    Run with image #3 (default) — expect F1-F5 PASS.
-    Run with image #2 override — expect F1+F5 FAIL (control: isolates
-    DIS-2147 as the cause of the new behavior).
+# Post-hoc F1-F5 verification via scripts/sanity-verify.py:
+#   F1 prefill active_decode_blocks > 0 while decode kv_util >= 0.99
+#   F2 prefill_kv_pin_start <-> prefill_kv_pin_end pair on room_id
+#   F3 prefill_kv_pin_end{outcome=aborted, duration_ms ~= 30000}
+#   F4 ABORT_BYTE in decode logs
+#   F5 prefill KV ~= 100% sustained until abort fires or decode frees
+#
+# Run with image #3 (default) — expect F1-F5 PASS.
+# Run with image #2 override — expect F1+F5 FAIL (control: isolates
+# DIS-2147 as the cause of the new behavior).

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/sanity_run2_dis2147_fidelity.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/sanity_run2_dis2147_fidelity.yaml
@@ -1,0 +1,124 @@
+# Session-level SANITY Run 2 — DIS-2147 fidelity gate (~10 min)
+#
+# Per observe handoff: 2026-05-28-three-experiment-validation-session.md + SANITY.md.
+# Validates DIS-2147 (mocker prefill-KV residency + abort timeout) actually
+# models production prefill-KV-pinning, vs the unpatched mocker baseline.
+#
+# CHANGES vs SANITY.md handoff (flag back to observe in return handoff):
+#   - Run 2 v1.1.1 comparison replaced with image #2 (cascade-test-69d496df9a)
+#     for cleaner controlled comparison — only DIS-2147 differs between
+#     image #3 (with-dis2147) and image #2 (no-dis2147). v1.1.1 conflates
+#     DIS-2147 absence with entire 1.1.1 → 1.2 stack delta. If observe wants
+#     the historical-baseline rope, add a third parametrize row.
+#
+# This YAML covers the with-dis2147 arm. The no-dis2147 comparison runs the
+# SAME YAML with the image overridden (in pytest, via the --image flag, or
+# via a sibling YAML if framework doesn't expose that override).
+#
+# Setup deliberately small (1 set) and decode --max-num-seqs=8 (tight) so
+# decode saturates fast — the DIS-2147 mechanism is what's under test, not
+# routing or scale.
+
+kind: router_memory
+name: sanity_run2_dis2147_fidelity
+description: |
+  1-set mocker disagg, LL routing, tight decode --max-num-seqs=8.
+  Forces decode saturation fast so DIS-2147 prefill-KV-pinning is exercised.
+  Verifies F1-F5 setup correctness via collected data (post-hoc).
+
+labels:
+  purpose: session_sanity
+  run: 2
+  router_mode: least_loaded
+  deployment: disagg
+  backend: mocker
+
+deployment:
+  backend: mocker
+  topology: disagg
+  # image #3 (with DIS-2147). For the no-dis2147 control arm, override
+  # at pytest time with --image <image #2 tag>:
+  #   pytest test_router_modes.py -k sanity_run2 \
+  #     --image nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-cascade-test-69d496df9a-neelays \
+  #     ...
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-mocker-prefill-pinning-3951afa0e1-neelays
+  replicas:
+    Frontend: 1
+    prefill: 1
+    decode: 1
+
+router:
+  # LL — DIS-2147 mechanism is what we're testing, not routing.
+  mode: least-loaded
+  knobs:
+    DYN_ROUTER_USE_KV_EVENTS: "false"
+    DYN_EVENT_PLANE: "zmq"
+    DYN_DISCOVERY_BACKEND: "kubernetes"
+    DYN_STORE_KV: "mem"
+    DYN_LOG: "info"
+
+admission:
+  knobs:
+    DYN_TCP_WORKER_POOL_SIZE: "128"
+    DYN_TCP_WORK_QUEUE_SIZE: "5"
+    VLLM_NIXL_ABORT_REQUEST_TIMEOUT: "30"
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30"
+
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 5
+    prefix_prompt_length: 740
+    seq_dist: "100,200:5;500,200:15;1000,200:20;1600,200:30;3400,200:20;7000,200:10"
+  rungs:
+    - name: saturate
+      concurrency: 50
+      duration_minutes: 5.0
+  common:
+    request_timeout_seconds: 60
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never
+
+events:
+  - kind: WaitForModelReady
+    timeout: 900
+  - kind: PodMemoryPoller
+    services: [Frontend, prefill, decode]
+    interval_s: 5
+  - kind: StartLoad
+    load_ref: saturate
+  - kind: WaitForLoadCompletion
+    name: saturate
+
+reports:
+  - PerWorkerLatencyReport
+  - ErrorBreakdownReport
+
+# Minimal live checks. F1-F5 from the SANITY handoff are computed POST-HOC
+# from the collected data by scripts/sanity-verify.py — see that script for
+# the per-check methodology (the DIS-2147 forensic events emit at
+# target=mocker::dis2147 INFO; grep + room_id-pair).
+checks:
+  - kind: LoadApplied
+    load_name: saturate
+    min_requests: 200
+  - kind: WorkerPanics
+    services: [Frontend, prefill, decode]
+    acceptable: true
+  - kind: RestartCountIncreased
+    services: [Frontend, prefill, decode]
+    expect_min_increment: 0
+
+expectations:
+  notes: |
+    Post-hoc F1-F5 verification via scripts/sanity-verify.py:
+      F1 prefill active_decode_blocks > 0 while decode kv_util >= 0.99
+      F2 prefill_kv_pin_start <-> prefill_kv_pin_end pair on room_id
+      F3 prefill_kv_pin_end{outcome=aborted, duration_ms ~= 30000}
+      F4 ABORT_BYTE in decode logs
+      F5 prefill KV ~= 100% sustained until abort fires or decode frees
+
+    Run with image #3 (default) — expect F1-F5 PASS.
+    Run with image #2 override — expect F1+F5 FAIL (control: isolates
+    DIS-2147 as the cause of the new behavior).

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/sanity_run2_prefill_kv_fidelity.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/sanity_run2_prefill_kv_fidelity.yaml
@@ -1,29 +1,29 @@
-# Session-level SANITY Run 2 — DIS-2147 fidelity gate (~10 min)
+# Session-level sanity Run 2 — prefill-KV-residency fidelity gate (~10 min)
 #
-# Per observe handoff: 2026-05-28-three-experiment-validation-session.md + SANITY.md.
-# Validates DIS-2147 (mocker prefill-KV residency + abort timeout) actually
-# models production prefill-KV-pinning, vs the unpatched mocker baseline.
+# Validates that the mocker prefill-KV-residency + KV-transfer abort-timeout
+# behavior actually models prefill-KV-pinning, vs the unpatched mocker baseline.
 #
-# CHANGES vs SANITY.md handoff (flag back to observe in return handoff):
-#   - Run 2 v1.1.1 comparison replaced with image #2 (cascade-test-69d496df9a)
-#     for cleaner controlled comparison — only DIS-2147 differs between
-#     image #3 (with-dis2147) and image #2 (no-dis2147). v1.1.1 conflates
-#     DIS-2147 absence with entire 1.1.1 → 1.2 stack delta. If observe wants
-#     the historical-baseline rope, add a third parametrize row.
+# CHANGES:
+#   - Run 2 v1.1.1 comparison replaced with the unpatched baseline image
+#     for a cleaner controlled comparison — only the prefill-KV-pinning
+#     behavior differs between the patched image (with prefill-KV-pinning)
+#     and the unpatched baseline image. The v1.1.1 comparison conflates the
+#     absence of prefill-KV-pinning with the entire 1.1.1 → 1.2 stack delta.
+#     If a historical baseline is wanted, add a third parametrize row.
 #
-# This YAML covers the with-dis2147 arm. The no-dis2147 comparison runs the
-# SAME YAML with the image overridden (in pytest, via the --image flag, or
-# via a sibling YAML if framework doesn't expose that override).
+# This YAML covers the prefill-KV-pinning arm. The unpatched-baseline
+# comparison runs the SAME YAML with the image overridden (in pytest, via the
+# --image flag, or via a sibling YAML if framework doesn't expose that override).
 #
 # Setup deliberately small (1 set) and decode --max-num-seqs=8 (tight) so
-# decode saturates fast — the DIS-2147 mechanism is what's under test, not
-# routing or scale.
+# decode saturates fast — the prefill-KV-pinning mechanism is what's under
+# test, not routing or scale.
 
 kind: router_memory
-name: sanity_run2_dis2147_fidelity
+name: sanity_run2_prefill_kv_fidelity
 description: |
   1-set mocker disagg, LL routing, tight decode --max-num-seqs=8.
-  Forces decode saturation fast so DIS-2147 prefill-KV-pinning is exercised.
+  Forces decode saturation fast so prefill-KV-pinning is exercised.
   Verifies F1-F5 setup correctness via collected data (post-hoc).
 
 labels:
@@ -36,19 +36,20 @@ labels:
 deployment:
   backend: mocker
   topology: disagg
-  # image #3 (with DIS-2147). For the no-dis2147 control arm, override
-  # at pytest time with --image <image #2 tag>:
+  # Patched image carrying the mocker prefill-KV-pinning behavior. For the
+  # unpatched-baseline control arm, override at pytest time with --image
+  # <unpatched baseline tag>:
   #   pytest test_router_modes.py -k sanity_run2 \
   #     --image nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-cascade-test-69d496df9a-neelays \
   #     ...
   image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-mocker-prefill-pinning-3951afa0e1-neelays
   replicas:
     Frontend: 1
-    prefill: 2  # production "set" is 1F+2P+1D — see one-pager scale notes
+    prefill: 2  # one "set" is 1F+2P+1D
     decode: 1
 
 router:
-  # LL — DIS-2147 mechanism is what we're testing, not routing.
+  # LL — the prefill-KV-pinning mechanism is what we're testing, not routing.
   mode: least-loaded
   knobs:
     DYN_ROUTER_USE_KV_EVENTS: "false"
@@ -56,7 +57,7 @@ router:
     DYN_DISCOVERY_BACKEND: "kubernetes"
     DYN_STORE_KV: "mem"
     # Elevated DEBUG on:
-    #  - prefill_router + kube discovery + watcher: Task #67 diagnostic
+    #  - prefill_router + kube discovery + watcher: diagnostic logging
     #    (which PrefillResolveDecision branch fires, MDC discovery flow)
     #  - worker_monitor: "Busy instances changed" + worker-removal cleanup lines
     #  - component::client: "inhibiting instance {id}" when report_instance_down fires
@@ -74,17 +75,17 @@ load:
     type: partial_prefix
     num_prefix_prompts: 5
     prefix_prompt_length: 740
-    # Production 30-bucket distribution — see sanity_run1 for full notes.
+    # 30-bucket distribution — see sanity_run1 for full notes.
     seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
   rungs:
     - name: saturate
       concurrency: 50
       duration_minutes: 25.0  # 5× the original 5-min sanity dwell so the
-                              # DIS-2147 prefill-stranding feedback loop has
-                              # time to build up + stabilize. Pairs with the
-                              # Qwen3-30B mocker config to match prod.
+                              # prefill-KV-stranding feedback loop has time to
+                              # build up + stabilize. Pairs with the Qwen3-30B
+                              # mocker config.
   common:
-    request_timeout_seconds: 30  # Production SLA: p95 latency must stay <30s
+    request_timeout_seconds: 30  # SLA: p95 latency must stay <30s
     streaming: true
     ignore_eos: true
     connection_reuse_strategy: never
@@ -104,10 +105,9 @@ reports:
   - PerWorkerLatencyReport
   - ErrorBreakdownReport
 
-# Minimal live checks. F1-F5 from the SANITY handoff are computed POST-HOC
-# from the collected data by scripts/sanity-verify.py — see that script for
-# the per-check methodology (the DIS-2147 forensic events emit at
-# target=mocker::dis2147 INFO; grep + room_id-pair).
+# Minimal live checks. F1-F5 are computed POST-HOC from the collected data by
+# scripts/sanity-verify.py — see that script for the per-check methodology
+# (the prefill-KV-residency forensic events emit at INFO; grep + room_id-pair).
 checks:
   - kind: LoadApplied
     load_name: saturate
@@ -126,6 +126,6 @@ checks:
 #   F4 ABORT_BYTE in decode logs
 #   F5 prefill KV ~= 100% sustained until abort fires or decode frees
 #
-# Run with image #3 (default) — expect F1-F5 PASS.
-# Run with image #2 override — expect F1+F5 FAIL (control: isolates
-# DIS-2147 as the cause of the new behavior).
+# Run with the patched image (default) — expect F1-F5 PASS.
+# Run with the unpatched baseline image override — expect F1+F5 FAIL
+# (control: isolates prefill-KV-pinning as the cause of the new behavior).

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/sanity_run3_gpu_n1_unit.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/sanity_run3_gpu_n1_unit.yaml
@@ -1,0 +1,126 @@
+# Session-level SANITY Run 3 — GPU N=1 unit sanity (~25 min)
+#
+# Companion to Run 1 (mocker, 3 sets) and Run 2 (mocker, 1 set DIS-2147).
+# This verifies the same plumbing items on REAL vllm workers, not mocker.
+#
+# Why this exists:
+#   - Mocker sanity can't validate vLLM-specific engine args
+#     (--max-num-batched-tokens=65536 actually takes effect on prefill).
+#   - Mocker emits events on its own cadence; this confirms real workers
+#     actually publish to ZMQ + the FE receives them.
+#   - Real /metrics endpoints expose vllm:kv_cache_usage_perc etc. that
+#     the mocker fakes.
+#   - Closest possible setup to E1/E2/E3 at minimum cost (6 GPU).
+#
+# What it does NOT cover:
+#   - F1-F5 DIS-2147 forensic events — those are mocker-only by design.
+#   - The 3-FE distribution check H2 — only 1 FE here.
+#
+# Topology: 1 unit = 1 FE + 2 prefill (TP=2, 4 GPU) + 1 decode (TP=2, 2 GPU).
+# Fits in any 6-GPU envelope.
+#
+# Image: #2 (cascade-test-69d496df9a) — production-recommendation-aligned,
+# no mocker-specific DIS-2147 (real workers don't use it).
+
+kind: router_memory
+name: sanity_run3_gpu_n1_unit
+description: |
+  Single-unit (1 FE + 2 prefill + 1 decode) real-vllm GPU sanity.
+  Verifies production-tuned engine + routing + admission on real workers.
+  c=50 sustained 5 min with production seq_dist.
+
+labels:
+  purpose: session_sanity
+  run: 3
+  router_mode: kv_recommended
+  deployment: disagg
+  backend: vllm
+
+deployment:
+  backend: vllm
+  topology: disagg
+  image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-cascade-test-69d496df9a-neelays
+  replicas:
+    Frontend: 1
+    VllmPrefillWorker: 2
+    VllmDecodeWorker: 1
+
+router:
+  mode: kv
+  knobs:
+    DYN_ROUTER_USE_KV_EVENTS: "false"
+    DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT: "0.0"
+    DYN_ROUTER_PREFILL_LOAD_SCALE: "1.0"
+    DYN_ROUTER_QUEUE_THRESHOLD: "4.0"
+    DYN_ROUTER_QUEUE_POLICY: "fcfs"
+    DYN_ROUTER_REPLICA_SYNC: "true"
+    DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD: "0.85"
+    DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC: "0.85"
+    DYN_EVENT_PLANE: "zmq"
+    DYN_DISCOVERY_BACKEND: "kubernetes"
+    DYN_STORE_KV: "mem"
+    # Tactical DEBUG (same as Run 1) so we can verify H3 + H4 via FE log
+    DYN_LOG: "info,dynamo_runtime::transports::event_plane::zmq_transport=debug,dynamo_llm::discovery::worker_monitor=debug"
+
+admission:
+  knobs:
+    DYN_TCP_WORKER_POOL_SIZE: "128"
+    DYN_TCP_WORK_QUEUE_SIZE: "5"
+    VLLM_NIXL_ABORT_REQUEST_TIMEOUT: "30"
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30"
+
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 5
+    prefix_prompt_length: 740
+    seq_dist: "100,200:5;500,200:15;1000,200:20;1600,200:30;3400,200:20;7000,200:10"
+  rungs:
+    - name: warmup
+      concurrency: 20
+      duration_minutes: 1.0
+    - name: steady
+      concurrency: 50
+      duration_minutes: 4.0
+  common:
+    request_timeout_seconds: 40
+    streaming: true
+    ignore_eos: false
+    connection_reuse_strategy: never
+
+events:
+  - kind: WaitForModelReady
+    timeout: 2400
+  - kind: PodMemoryPoller
+    services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
+    interval_s: 5
+  - kind: StartLoad
+    load_ref: warmup
+  - kind: WaitForLoadCompletion
+    name: warmup
+  - kind: StartLoad
+    load_ref: steady
+  - kind: WaitForLoadCompletion
+    name: steady
+
+reports:
+  - PerWorkerLatencyReport
+  - ErrorBreakdownReport
+
+# Minimal live checks. Full H1-H13 (minus mocker-specific) computed
+# POST-HOC via scripts/sanity-verify.py against the collected data.
+checks:
+  - kind: LoadApplied
+    load_name: steady
+    min_requests: 100
+  - kind: WorkerPanics
+    services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
+    acceptable: true
+  - kind: RestartCountIncreased
+    services: [Frontend, VllmDecodeWorker]
+    expect_min_increment: 0
+
+expectations:
+  notes: |
+    GPU N=1 sanity. ~25 min wall.
+    Post-hoc verify with scripts/sanity-verify.py. Skip F1-F5 (mocker-only).

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/sanity_run3_gpu_n1_unit.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/sanity_run3_gpu_n1_unit.yaml
@@ -98,7 +98,7 @@ load:
 events:
   - kind: WaitForModelReady
     timeout: 2400
-  - kind: PodMemoryPoller
+  - kind: ResourcePoller
     services: [Frontend, VllmPrefillWorker, VllmDecodeWorker]
     interval_s: 5
   - kind: StartLoad

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/sanity_run3_gpu_n1_unit.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/sanity_run3_gpu_n1_unit.yaml
@@ -40,6 +40,8 @@ deployment:
   backend: vllm
   topology: disagg
   image: nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-cascade-test-69d496df9a-neelays
+  # Workers need the model cache PVC mounted (Qwen3-30B FP8 weights). Pass
+  # via pytest --model-cache-pvc shared-model-cache (CLI flag wins over YAML).
   replicas:
     Frontend: 1
     VllmPrefillWorker: 2
@@ -60,7 +62,9 @@ router:
     DYN_DISCOVERY_BACKEND: "kubernetes"
     DYN_STORE_KV: "mem"
     # Tactical DEBUG (same as Run 1) so we can verify H3 + H4 via FE log
-    DYN_LOG: "info,dynamo_runtime::transports::event_plane::zmq_transport=debug,dynamo_llm::discovery::worker_monitor=debug"
+    # worker_monitor=debug -> "Busy instances changed" + worker-removal cleanup lines
+    # component::client=debug -> "inhibiting instance {id}" when report_instance_down fires
+    DYN_LOG: "info,dynamo_runtime::transports::event_plane::zmq_transport=debug,dynamo_llm::discovery::worker_monitor=debug,dynamo_runtime::component::client=debug"
 
 admission:
   knobs:
@@ -74,16 +78,19 @@ load:
     type: partial_prefix
     num_prefix_prompts: 5
     prefix_prompt_length: 740
-    seq_dist: "100,200:5;500,200:15;1000,200:20;1600,200:30;3400,200:20;7000,200:10"
+    # Production 30-bucket distribution — see sanity_run1 for full notes.
+    seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
   rungs:
     - name: warmup
       concurrency: 20
-      duration_minutes: 1.0
+      duration_minutes: 2.0
     - name: steady
       concurrency: 50
-      duration_minutes: 4.0
+      duration_minutes: 20.0  # 5× the original 4-min dwell — matches Run 1
+                              # so saturation + memory observations are
+                              # comparable across all 3 sanity arms.
   common:
-    request_timeout_seconds: 40
+    request_timeout_seconds: 30  # Production SLA: p95 latency must stay <30s
     streaming: true
     ignore_eos: false
     connection_reuse_strategy: never
@@ -120,7 +127,5 @@ checks:
     services: [Frontend, VllmDecodeWorker]
     expect_min_increment: 0
 
-expectations:
-  notes: |
-    GPU N=1 sanity. ~25 min wall.
-    Post-hoc verify with scripts/sanity-verify.py. Skip F1-F5 (mocker-only).
+# GPU N=1 sanity. ~25 min wall.
+# Post-hoc verify with scripts/sanity-verify.py. Skip F1-F5 (mocker-only).

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/sanity_run3_gpu_n1_unit.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/sanity_run3_gpu_n1_unit.yaml
@@ -1,6 +1,7 @@
 # Session-level SANITY Run 3 — GPU N=1 unit sanity (~25 min)
 #
-# Companion to Run 1 (mocker, 3 sets) and Run 2 (mocker, 1 set DIS-2147).
+# Companion to Run 1 (mocker, 3 sets) and Run 2 (mocker, 1 set exercising
+# the prefill-KV-residency + KV-transfer abort-timeout behavior).
 # This verifies the same plumbing items on REAL vllm workers, not mocker.
 #
 # Why this exists:
@@ -13,21 +14,22 @@
 #   - Closest possible setup to E1/E2/E3 at minimum cost (6 GPU).
 #
 # What it does NOT cover:
-#   - F1-F5 DIS-2147 forensic events — those are mocker-only by design.
+#   - F1-F5 prefill-KV-residency forensic events — those are mocker-only by design.
 #   - The 3-FE distribution check H2 — only 1 FE here.
 #
 # Topology: 1 unit = 1 FE + 2 prefill (TP=2, 4 GPU) + 1 decode (TP=2, 2 GPU).
 # Fits in any 6-GPU envelope.
 #
-# Image: #2 (cascade-test-69d496df9a) — production-recommendation-aligned,
-# no mocker-specific DIS-2147 (real workers don't use it).
+# Image: a KV-aware-tuned build aligned with the recommended routing config;
+# carries the real-worker engine + routing + admission knobs (no
+# mocker-specific prefill-KV-pinning — real workers don't use it).
 
 kind: router_memory
 name: sanity_run3_gpu_n1_unit
 description: |
   Single-unit (1 FE + 2 prefill + 1 decode) real-vllm GPU sanity.
-  Verifies production-tuned engine + routing + admission on real workers.
-  c=50 sustained 5 min with production seq_dist.
+  Verifies the KV-aware-tuned engine + routing + admission on real workers.
+  c=50 sustained 5 min with the reference seq_dist.
 
 labels:
   purpose: session_sanity
@@ -78,7 +80,7 @@ load:
     type: partial_prefix
     num_prefix_prompts: 5
     prefix_prompt_length: 740
-    # Production 30-bucket distribution — see sanity_run1 for full notes.
+    # Reference 30-bucket distribution — see sanity_run1 for full notes.
     seq_dist: "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
   rungs:
     - name: warmup
@@ -90,7 +92,7 @@ load:
                               # so saturation + memory observations are
                               # comparable across all 3 sanity arms.
   common:
-    request_timeout_seconds: 30  # Production SLA: p95 latency must stay <30s
+    request_timeout_seconds: 30  # SLA target: p95 latency must stay <30s
     streaming: true
     ignore_eos: false
     connection_reuse_strategy: never

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/v1_1_1__kv_prefix__disagg__mocker.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/v1_1_1__kv_prefix__disagg__mocker.yaml
@@ -1,0 +1,117 @@
+# Matrix arm — leak investigation (image × routing-mode matrix)
+# Image: v1.1.1 | Routing: kv_prefix
+# Leak-POSITIVE — production-default KV+prefix, expect ~27 MB/min
+
+kind: router_memory
+name: v1_1_1__kv_prefix__disagg__mocker
+description: |
+  Matrix arm: kv_prefix routing on v1.1.1 mocker-disagg.
+  2 FE × 2 prefill × 2 decode mocker workers, trapezoid load ~30 min.
+  Production ISL/OSL/prefix shape (partial_prefix, ~37% prefix-hit).
+
+labels:
+  image_label: v1.1.1
+  router_mode: kv_prefix
+  traffic_shape: partial_prefix
+  deployment: disagg
+  backend: mocker
+
+deployment:
+  backend: mocker
+  topology: disagg
+  image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1
+  replicas:
+    Frontend: 10
+    prefill: 20
+    decode: 10
+
+router:
+  mode: kv
+  knobs:
+    DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT: "1.0"
+    DYN_ROUTER_USE_KV_EVENTS: "false"
+    DYN_ROUTER_REPLICA_SYNC: "true"
+    DYN_ROUTER_TEMPERATURE: "0.0"
+    DYN_ROUTER_TRACK_ACTIVE_BLOCKS: "true"
+
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 15
+    prefix_prompt_length: 600
+  rungs:
+    - name: warmup
+      concurrency: 40
+      duration_minutes: 1.0
+    - name: ramp1
+      concurrency: 120
+      duration_minutes: 2.5
+    - name: ramp2
+      concurrency: 180
+      duration_minutes: 2.5
+    - name: steady
+      concurrency: 120
+      duration_minutes: 18.0
+    - name: rampdown1
+      concurrency: 180
+      duration_minutes: 2.5
+    - name: rampdown2
+      concurrency: 120
+      duration_minutes: 2.5
+    - name: final
+      concurrency: 40
+      duration_minutes: 1.0
+  common:
+    request_timeout_seconds: 30
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never
+
+events:
+  - kind: WaitForModelReady
+    timeout: 900
+  - kind: PodMemoryPoller
+    services: [Frontend, prefill, decode]
+    interval_s: 15
+  - kind: StartLoad
+    load_ref: warmup
+  - kind: WaitForLoadCompletion
+    name: warmup
+  - kind: StartLoad
+    load_ref: ramp1
+  - kind: WaitForLoadCompletion
+    name: ramp1
+  - kind: StartLoad
+    load_ref: ramp2
+  - kind: WaitForLoadCompletion
+    name: ramp2
+  - kind: StartLoad
+    load_ref: steady
+  - kind: WaitForLoadCompletion
+    name: steady
+  - kind: StartLoad
+    load_ref: rampdown1
+  - kind: WaitForLoadCompletion
+    name: rampdown1
+  - kind: StartLoad
+    load_ref: rampdown2
+  - kind: WaitForLoadCompletion
+    name: rampdown2
+  - kind: StartLoad
+    load_ref: final
+  - kind: WaitForLoadCompletion
+    name: final
+
+reports:
+  - PerWorkerLatencyReport
+
+checks:
+  - kind: LoadApplied
+    load_name: steady
+    min_requests: 1000
+
+expectations:
+  fe_memory_growth_mb_per_min:
+    expected_range: [20, 35]
+    notes: |
+      Leak-POSITIVE — production-default KV+prefix, expect ~27 MB/min.

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/v1_1_1__kv_prefix__disagg__mocker.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/v1_1_1__kv_prefix__disagg__mocker.yaml
@@ -70,7 +70,7 @@ load:
 events:
   - kind: WaitForModelReady
     timeout: 900
-  - kind: PodMemoryPoller
+  - kind: ResourcePoller
     services: [Frontend, prefill, decode]
     interval_s: 15
   - kind: StartLoad

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/v1_1_1__kv_pure_load__disagg__mocker.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/v1_1_1__kv_pure_load__disagg__mocker.yaml
@@ -73,7 +73,7 @@ load:
 events:
   - kind: WaitForModelReady
     timeout: 900
-  - kind: PodMemoryPoller
+  - kind: ResourcePoller
     services: [Frontend, prefill, decode]
     interval_s: 15
   - kind: StartLoad

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/v1_1_1__kv_pure_load__disagg__mocker.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/v1_1_1__kv_pure_load__disagg__mocker.yaml
@@ -1,0 +1,120 @@
+# Matrix arm — leak investigation (image × routing-mode matrix)
+# Image: v1.1.1 | Routing: kv_pure_load
+# A4 pure-load reference (zeroed prefix-scoring weights)
+
+kind: router_memory
+name: v1_1_1__kv_pure_load__disagg__mocker
+description: |
+  Matrix arm: kv_pure_load routing on v1.1.1 mocker-disagg.
+  2 FE × 2 prefill × 2 decode mocker workers, trapezoid load ~30 min.
+  Production ISL/OSL/prefix shape (partial_prefix, ~37% prefix-hit).
+
+labels:
+  image_label: v1.1.1
+  router_mode: kv_pure_load
+  traffic_shape: partial_prefix
+  deployment: disagg
+  backend: mocker
+
+deployment:
+  backend: mocker
+  topology: disagg
+  image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1
+  replicas:
+    Frontend: 10
+    prefill: 20
+    decode: 10
+
+router:
+  mode: kv
+  knobs:
+    DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT: "0.0"
+    DYN_KV_HOST_CACHE_HIT_WEIGHT: "0.0"
+    DYN_KV_DISK_CACHE_HIT_WEIGHT: "0.0"
+    DYN_ROUTER_USE_KV_EVENTS: "false"
+    DYN_ROUTER_REPLICA_SYNC: "true"
+    DYN_ROUTER_TEMPERATURE: "0.0"
+    DYN_ROUTER_ASSUME_KV_REUSE: "false"
+    DYN_ROUTER_TRACK_ACTIVE_BLOCKS: "true"
+
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 15
+    prefix_prompt_length: 600
+  rungs:
+    - name: warmup
+      concurrency: 40
+      duration_minutes: 1.0
+    - name: ramp1
+      concurrency: 120
+      duration_minutes: 2.5
+    - name: ramp2
+      concurrency: 180
+      duration_minutes: 2.5
+    - name: steady
+      concurrency: 120
+      duration_minutes: 18.0
+    - name: rampdown1
+      concurrency: 180
+      duration_minutes: 2.5
+    - name: rampdown2
+      concurrency: 120
+      duration_minutes: 2.5
+    - name: final
+      concurrency: 40
+      duration_minutes: 1.0
+  common:
+    request_timeout_seconds: 30
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never
+
+events:
+  - kind: WaitForModelReady
+    timeout: 900
+  - kind: PodMemoryPoller
+    services: [Frontend, prefill, decode]
+    interval_s: 15
+  - kind: StartLoad
+    load_ref: warmup
+  - kind: WaitForLoadCompletion
+    name: warmup
+  - kind: StartLoad
+    load_ref: ramp1
+  - kind: WaitForLoadCompletion
+    name: ramp1
+  - kind: StartLoad
+    load_ref: ramp2
+  - kind: WaitForLoadCompletion
+    name: ramp2
+  - kind: StartLoad
+    load_ref: steady
+  - kind: WaitForLoadCompletion
+    name: steady
+  - kind: StartLoad
+    load_ref: rampdown1
+  - kind: WaitForLoadCompletion
+    name: rampdown1
+  - kind: StartLoad
+    load_ref: rampdown2
+  - kind: WaitForLoadCompletion
+    name: rampdown2
+  - kind: StartLoad
+    load_ref: final
+  - kind: WaitForLoadCompletion
+    name: final
+
+reports:
+  - PerWorkerLatencyReport
+
+checks:
+  - kind: LoadApplied
+    load_name: steady
+    min_requests: 1000
+
+expectations:
+  fe_memory_growth_mb_per_min:
+    expected_range: [1, 5]
+    notes: |
+      A4 pure-load reference (zeroed prefix-scoring weights).

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/v1_1_1__least_loaded__disagg__mocker.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/v1_1_1__least_loaded__disagg__mocker.yaml
@@ -66,7 +66,7 @@ load:
 events:
   - kind: WaitForModelReady
     timeout: 900
-  - kind: PodMemoryPoller
+  - kind: ResourcePoller
     services: [Frontend, prefill, decode]
     interval_s: 15
   - kind: StartLoad

--- a/tests/fault_tolerance/deploy/scenario_lib/router_memory/v1_1_1__least_loaded__disagg__mocker.yaml
+++ b/tests/fault_tolerance/deploy/scenario_lib/router_memory/v1_1_1__least_loaded__disagg__mocker.yaml
@@ -1,0 +1,113 @@
+# Matrix arm — leak investigation (image × routing-mode matrix)
+# Image: v1.1.1 | Routing: least_loaded
+# Leak-NEGATIVE reference on stock v1.1.1
+
+kind: router_memory
+name: v1_1_1__least_loaded__disagg__mocker
+description: |
+  Matrix arm: least_loaded routing on v1.1.1 mocker-disagg.
+  2 FE × 2 prefill × 2 decode mocker workers, trapezoid load ~30 min.
+  Production ISL/OSL/prefix shape (partial_prefix, ~37% prefix-hit).
+
+labels:
+  image_label: v1.1.1
+  router_mode: least_loaded
+  traffic_shape: partial_prefix
+  deployment: disagg
+  backend: mocker
+
+deployment:
+  backend: mocker
+  topology: disagg
+  image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1
+  replicas:
+    Frontend: 10
+    prefill: 20
+    decode: 10
+
+router:
+  mode: least-loaded
+  knobs:
+    DYN_ROUTER_USE_KV_EVENTS: "false"
+
+load:
+  shape:
+    type: partial_prefix
+    num_prefix_prompts: 15
+    prefix_prompt_length: 600
+  rungs:
+    - name: warmup
+      concurrency: 40
+      duration_minutes: 1.0
+    - name: ramp1
+      concurrency: 120
+      duration_minutes: 2.5
+    - name: ramp2
+      concurrency: 180
+      duration_minutes: 2.5
+    - name: steady
+      concurrency: 120
+      duration_minutes: 18.0
+    - name: rampdown1
+      concurrency: 180
+      duration_minutes: 2.5
+    - name: rampdown2
+      concurrency: 120
+      duration_minutes: 2.5
+    - name: final
+      concurrency: 40
+      duration_minutes: 1.0
+  common:
+    request_timeout_seconds: 30
+    streaming: true
+    ignore_eos: true
+    connection_reuse_strategy: never
+
+events:
+  - kind: WaitForModelReady
+    timeout: 900
+  - kind: PodMemoryPoller
+    services: [Frontend, prefill, decode]
+    interval_s: 15
+  - kind: StartLoad
+    load_ref: warmup
+  - kind: WaitForLoadCompletion
+    name: warmup
+  - kind: StartLoad
+    load_ref: ramp1
+  - kind: WaitForLoadCompletion
+    name: ramp1
+  - kind: StartLoad
+    load_ref: ramp2
+  - kind: WaitForLoadCompletion
+    name: ramp2
+  - kind: StartLoad
+    load_ref: steady
+  - kind: WaitForLoadCompletion
+    name: steady
+  - kind: StartLoad
+    load_ref: rampdown1
+  - kind: WaitForLoadCompletion
+    name: rampdown1
+  - kind: StartLoad
+    load_ref: rampdown2
+  - kind: WaitForLoadCompletion
+    name: rampdown2
+  - kind: StartLoad
+    load_ref: final
+  - kind: WaitForLoadCompletion
+    name: final
+
+reports:
+  - PerWorkerLatencyReport
+
+checks:
+  - kind: LoadApplied
+    load_name: steady
+    min_requests: 1000
+
+expectations:
+  fe_memory_growth_mb_per_min:
+    expected_range: [1, 5]
+    notes: |
+      Leak-NEGATIVE reference on stock v1.1.1.

--- a/tests/fault_tolerance/deploy/scenarios.py
+++ b/tests/fault_tolerance/deploy/scenarios.py
@@ -13,6 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# DEPRECATED: This module is part of the legacy test framework.
+# New tests should use the event-based framework in test_deployment_scenario.py.
+# See tests/fault_tolerance/deploy/TESTING.md for the reference guide.
+
 import asyncio
 import logging
 import re
@@ -1265,17 +1269,11 @@ def add_token_overflow_scenarios():
         # Add arguments to appropriate workers
         if is_agg:
             # For aggregated, add only to decode worker
-            deployment_spec.add_arg_to_service(
-                decode_worker, arg_name, str(MAX_SEQ_LEN)
-            )
+            deployment_spec[decode_worker].set_arg(arg_name, str(MAX_SEQ_LEN))
         else:
             # For disaggregated, add to both prefill and decode workers
-            deployment_spec.add_arg_to_service(
-                prefill_worker, arg_name, str(MAX_SEQ_LEN)
-            )
-            deployment_spec.add_arg_to_service(
-                decode_worker, arg_name, str(MAX_SEQ_LEN)
-            )
+            deployment_spec[prefill_worker].set_arg(arg_name, str(MAX_SEQ_LEN))
+            deployment_spec[decode_worker].set_arg(arg_name, str(MAX_SEQ_LEN))
 
         # Create overflow failure
         overflow_failure = TokenOverflowFailure(

--- a/tests/fault_tolerance/deploy/templates/vllm/disagg_dp2_ep_unit.yaml
+++ b/tests/fault_tolerance/deploy/templates/vllm/disagg_dp2_ep_unit.yaml
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Disagg DP=2 + expert-parallel unit template for the engine-stall /
+# stale-routing methodology test. Shape only — the MODEL is configurable:
+# set `deployment.model` in the scenario to serve any HF model on this same
+# topology (default below is a small MoE so DP+EP is exercised cheaply).
+#
+# Why DP=2 + EP: the stall signature we reproduce is a *data-parallel* engine
+# rank going unresponsive — one rank SIGSTOPped → the surviving rank blocks on
+# `shm_broadcast` → its `sample_tokens` RPC times out → EngineCore fatal → the
+# whole worker pod exits 1 → restart → NEW instance_id. That requires ≥2 DP
+# ranks per worker (one to stall, one to time out), so every worker is DP=2
+# (2 GPU each). `--enable-expert-parallel` shards the MoE experts across the
+# two ranks, matching a multi-DP-rank MoE worker topology.
+#
+# Disagg: prefill pulls KV → decode via NixlConnector (kv_both). The KV router
+# dispatches to DECODE workers, so decode is where the churn → stale-routing
+# 500s surface. Replica counts, image, and model are overridden by the
+# scenario's deployment block.
+
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: vllm-disagg-dp2-ep
+spec:
+  services:
+    Frontend:
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+
+    VllmPrefillWorker:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      subComponentType: prefill
+      replicas: 1
+      resources:
+        requests: { gpu: "2" }
+        limits: { gpu: "2" }
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          workingDir: /workspace/examples/backends/vllm
+          command: [python3, -m, dynamo.vllm]
+          args:
+            - --model
+            - deepseek-ai/DeepSeek-V2-Lite      # configurable via deployment.model
+            - --disaggregation-mode
+            - prefill
+            - --kv-transfer-config
+            - '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
+            - --data-parallel-size
+            - "2"
+            - --enable-expert-parallel
+            - --trust-remote-code
+            - --max-model-len
+            - "32768"
+            - --enable-prefix-caching
+            - --enable-chunked-prefill
+            - --gpu-memory-utilization
+            - "0.85"
+            - --kv-events-config
+            - '{"enable_kv_cache_events":false}'
+
+    VllmDecodeWorker:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      subComponentType: decode
+      replicas: 3
+      resources:
+        requests: { gpu: "2" }
+        limits: { gpu: "2" }
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0
+          workingDir: /workspace/examples/backends/vllm
+          command: [python3, -m, dynamo.vllm]
+          args:
+            - --model
+            - deepseek-ai/DeepSeek-V2-Lite      # configurable via deployment.model
+            - --disaggregation-mode
+            - decode
+            - --kv-transfer-config
+            - '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
+            - --data-parallel-size
+            - "2"
+            - --enable-expert-parallel
+            - --trust-remote-code
+            - --max-model-len
+            - "32768"
+            - --enable-prefix-caching
+            - --enable-chunked-prefill
+            - --gpu-memory-utilization
+            - "0.85"
+            - --kv-events-config
+            - '{"enable_kv_cache_events":false}'

--- a/tests/fault_tolerance/deploy/templates/vllm/disagg_qwen3_30b_1p2d.yaml
+++ b/tests/fault_tolerance/deploy/templates/vllm/disagg_qwen3_30b_1p2d.yaml
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# vllm disagg DGD: 1 Frontend + 1 prefill (TP=2) + 2 decode (TP=2 each)
+# = 6 GPUs total; fits one 8xH100-80GB node. Model: Qwen3-30B-A3B
+# (30B-param MoE). NixlConnector with kv_role=kv_both for the
+# prefill→decode KV transfer.
+#
+# Image: dynamo v1.0.1 vllm-runtime (released).
+#
+# Sanity-config defaults below; specific repro tests override
+# --max-num-seqs / cudagraph_capture_sizes per scenario to exercise
+# documented vLLM disagg failure modes (running-batch >512 cudagraph
+# fall-off, KV-cleanup retention under transfer churn, rank-process
+# wedge propagation through shm_broadcast).
+
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: vllm-disagg-qwen3-30b-1p2d
+spec:
+  services:
+    Frontend:
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.1
+
+    VllmPrefillWorker:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      subComponentType: prefill
+      replicas: 1
+      resources:
+        requests:
+          gpu: "2"
+        limits:
+          gpu: "2"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.1
+          workingDir: /workspace/examples/backends/vllm
+          command:
+            - python3
+            - -m
+            - dynamo.vllm
+          args:
+            - --model
+            - Qwen/Qwen3-30B-A3B
+            - --disaggregation-mode
+            - prefill
+            - --kv-transfer-config
+            - '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
+            - --tensor-parallel-size
+            - "2"
+            - --max-model-len
+            - "8192"
+            # KV events disabled — matches "plain disagg" without the
+            # KV-router indexer subscriber; reduces variance when
+            # repro'ing transfer-path failure modes.
+            - --kv-events-config
+            - '{"enable_kv_cache_events":false}'
+
+    VllmDecodeWorker:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      subComponentType: decode
+      replicas: 2
+      resources:
+        requests:
+          gpu: "2"
+        limits:
+          gpu: "2"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.1
+          workingDir: /workspace/examples/backends/vllm
+          command:
+            - python3
+            - -m
+            - dynamo.vllm
+          args:
+            - --model
+            - Qwen/Qwen3-30B-A3B
+            - --disaggregation-mode
+            - decode
+            - --kv-transfer-config
+            - '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
+            - --tensor-parallel-size
+            - "2"
+            - --max-model-len
+            - "8192"
+            - --kv-events-config
+            - '{"enable_kv_cache_events":false}'

--- a/tests/fault_tolerance/deploy/templates/vllm/disagg_qwen3_30b_2p1d.yaml
+++ b/tests/fault_tolerance/deploy/templates/vllm/disagg_qwen3_30b_2p1d.yaml
@@ -1,10 +1,13 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# vllm disagg DGD: 1 Frontend + 1 prefill (TP=2) + 2 decode (TP=2 each)
+# vllm disagg DGD: 1 Frontend + 2 prefill (TP=2 each) + 1 decode (TP=2)
 # = 6 GPUs total; fits one 8xH100-80GB node. Model: Qwen3-30B-A3B
 # (30B-param MoE). NixlConnector with kv_role=kv_both for the
-# prefill→decode KV transfer.
+# prefill→decode KV transfer. The 2P:1D ratio reflects a prefill-bound
+# workload (average ISL >> average OSL — long-context / RAG /
+# ranking patterns), making prefill the dominant work and KV
+# handoffs frequent.
 #
 # Image: dynamo v1.0.1 vllm-runtime (released).
 #
@@ -17,7 +20,7 @@
 apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
 metadata:
-  name: vllm-disagg-qwen3-30b-1p2d
+  name: vllm-disagg-qwen3-30b-2p1d
 spec:
   services:
     Frontend:
@@ -31,7 +34,7 @@ spec:
       envFromSecret: hf-token-secret
       componentType: worker
       subComponentType: prefill
-      replicas: 1
+      replicas: 2
       resources:
         requests:
           gpu: "2"
@@ -66,7 +69,7 @@ spec:
       envFromSecret: hf-token-secret
       componentType: worker
       subComponentType: decode
-      replicas: 2
+      replicas: 1
       resources:
         requests:
           gpu: "2"

--- a/tests/fault_tolerance/deploy/templates/vllm/disagg_qwen3_30b_4p2d_2f.yaml
+++ b/tests/fault_tolerance/deploy/templates/vllm/disagg_qwen3_30b_4p2d_2f.yaml
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Production-scale vllm disagg DGD: 2 Frontend + 4 prefill (TP=2) + 2 decode (TP=2)
+# = 12 GPUs total; spans 2× 8×H100-80GB nodes. Model: Qwen3-30B-A3B (30B-param MoE).
+# NixlConnector with kv_role=kv_both.
+#
+# Used for cascade-causality experiments — heavy ISL (~7000 tokens) / short OSL
+# (~100 tokens) sustained load that pressures both prefill batching and the
+# decode-side KV transfer path. The 2× prefill ratio over decode reflects a
+# prefill-bound workload with frequent KV handoffs (common in long-context,
+# short-output inference patterns like retrieval / RAG / ranking).
+#
+# Image: dynamo v1.0.1 vllm-runtime (released).
+
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: vllm-disagg-qwen3-30b-4p2d
+spec:
+  services:
+    Frontend:
+      componentType: frontend
+      replicas: 2
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.1
+
+    VllmPrefillWorker:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      subComponentType: prefill
+      replicas: 4
+      resources:
+        requests:
+          gpu: "2"
+        limits:
+          gpu: "2"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.1
+          workingDir: /workspace/examples/backends/vllm
+          command:
+            - python3
+            - -m
+            - dynamo.vllm
+          args:
+            - --model
+            - Qwen/Qwen3-30B-A3B
+            - --disaggregation-mode
+            - prefill
+            - --kv-transfer-config
+            - '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
+            - --tensor-parallel-size
+            - "2"
+            - --max-model-len
+            - "8192"
+            - --kv-events-config
+            - '{"enable_kv_cache_events":false}'
+
+    VllmDecodeWorker:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      subComponentType: decode
+      replicas: 2
+      resources:
+        requests:
+          gpu: "2"
+        limits:
+          gpu: "2"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.1
+          workingDir: /workspace/examples/backends/vllm
+          command:
+            - python3
+            - -m
+            - dynamo.vllm
+          args:
+            - --model
+            - Qwen/Qwen3-30B-A3B
+            - --disaggregation-mode
+            - decode
+            - --kv-transfer-config
+            - '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
+            - --tensor-parallel-size
+            - "2"
+            - --max-model-len
+            - "8192"
+            - --kv-events-config
+            - '{"enable_kv_cache_events":false}'

--- a/tests/fault_tolerance/deploy/templates/vllm/disagg_qwen3_30b_unit_e1.yaml
+++ b/tests/fault_tolerance/deploy/templates/vllm/disagg_qwen3_30b_unit_e1.yaml
@@ -1,0 +1,219 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Close mirror of the production Qwen3-30B-A3B disagg deployment that
+# exhibits the cascade in field. Differences from prod (see
+# the production deployment notes) and rationale:
+#
+# - Hardware: prod runs A100-40GB (P4D); we run on H100-80GB and cap to
+#   ~36 GB / GPU via --gpu-memory-utilization=0.45 (= 0.9 * 40 GB).
+#   That matches prod's vLLM memory budget exactly. HBM bandwidth and
+#   FP8 tensor-core throughput on H100 still differ — we emulate KV
+#   pressure / NIXL behaviour, not raw decode TPS.
+# - Topology: prod is 102 FE / 204 PF / 102 DE (≈ 2:1 PF:DE ratio).
+#   This template encodes a **single unit** = 1 FE / 2 PF (TP=2) / 1 DE
+#   (TP=2) = 6 GPUs, fits one 8×H100-80GB node. Tests multiply each
+#   service's replica count by `runtime_env.units` (CLI: `--units N`):
+#     - N=1 → 1 FE / 2 PF / 1 DE (6 GPUs)  — isolates per-unit cascade
+#     - N=2 → 2 FE / 4 PF / 2 DE (12 GPUs) — same footprint as
+#       `disagg_qwen3_30b_4p2d_2f_prod.yaml`
+#     - N=3 → 3 FE / 6 PF / 3 DE (18 GPUs)
+#   Same PF:DE ratio as prod at every N.
+# - Image: this template targets the released vllm-runtime:1.0.1
+#   (vllm_1.0.1_0.16.0). Fork builds tracking the same vllm + Dynamo
+#   base will run with the same args.
+#
+# Everything else (model, args, FP8 GEMM env, UCX/NCCL tuning) is
+# copied verbatim from the prod DGD spec.
+
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  # Short name keeps PVC-verify Job label under the 63-char limit. Tests
+  # may suffix this with the unit count (e.g. `vllm-q3-prod-units-2`)
+  # before applying — keep the base name short to leave headroom.
+  name: vllm-q3-prod-units
+spec:
+  services:
+    Frontend:
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.1
+
+    VllmPrefillWorker:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      subComponentType: prefill
+      replicas: 2
+      resources:
+        requests:
+          gpu: "2"
+        limits:
+          gpu: "2"
+      # Per-service envs mirror the prod DGD's FP8 GEMM + UCX/NCCL
+      # tuning. Values are exact copies from the production reference DGD.
+      envs:
+        - name: VLLM_BLOCKSCALE_FP8_GEMM_FLASHINFER
+          value: "1"
+        - name: VLLM_USE_DEEP_GEMM
+          value: "1"
+        - name: VLLM_USE_DEEP_GEMM_E8M0
+          value: "1"
+        - name: VLLM_MOE_USE_DEEP_GEMM
+          value: "0"
+        - name: VLLM_USE_FLASHINFER_MOE_FP8
+          value: "0"
+        - name: UCX_MAX_RMA_LANES
+          value: "4"
+        - name: UCX_MAX_COMPONENT_MDS
+          value: "32"
+        - name: UCX_ADDRESS_VERSION
+          value: "v2"
+        - name: UCX_KEEPALIVE_INTERVAL
+          value: "inf"
+        - name: UCX_PROTO_INFO
+          value: "y"
+        - name: UCX_LOG_LEVEL
+          value: "INFO"
+        - name: NCCL_LAUNCH_MODE
+          value: "PARALLEL"
+        - name: NCCL_NET_SHARED_COMMS
+          value: "0"
+        - name: NCCL_DEBUG
+          value: "WARN"
+        # NIXL telemetry gate: nixl/src/core/nixl_agent.cpp:128-150 only
+        # records xfer/post/bytes_transferred/num_descriptors histograms
+        # when this env is set. The vLLM bundled in vllm-runtime:1.1.1
+        # predates the unconditional capture_telemetry=True path
+        # (nixl_connector.py:1082-1087 in newer vLLM), so the env var is
+        # required for `vllm:nixl_*` to be non-zero. Per observe-agent
+        # NEXT_STEPS_FOR_TEST_AGENT P0.1 (sanity-suite work).
+        - name: NIXL_TELEMETRY_ENABLE
+          value: "y"
+        # Bound the vLLM execute-model wait so a stalled engine surfaces as
+        # EngineDeadError + worker restart within 30s under cascade pressure
+        # (per memory: reference_vllm_force_engine_death). Without this the
+        # default is effectively unbounded and stalls mask the cascade signal.
+        - name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS
+          value: "30"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.1
+          workingDir: /workspace/examples/backends/vllm
+          command:
+            - python3
+            - -m
+            - dynamo.vllm
+          args:
+            - --model
+            - Qwen/Qwen3-30B-A3B-Instruct-2507-FP8
+            # vllm-runtime:1.0.1 uses --disaggregation-mode; some forks
+            # use --is-prefill-worker (functionally equivalent for vLLM disagg).
+            - --disaggregation-mode
+            - prefill
+            - --tensor-parallel-size
+            - "2"
+            - --gpu-memory-utilization
+            - "0.5"
+            - --max-model-len
+            - "10240"
+            - --max-num-seqs
+            - "64"
+            - --dyn-reasoning-parser
+            - qwen3
+            - --enable-expert-parallel
+            - --async-scheduling
+            - --disable-cascade-attn
+            - --kv-transfer-config
+            - '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
+            - --kv-events-config
+            - '{"enable_kv_cache_events":false}'
+
+    VllmDecodeWorker:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      subComponentType: decode
+      replicas: 1
+      resources:
+        requests:
+          gpu: "2"
+        limits:
+          gpu: "2"
+      envs:
+        - name: VLLM_BLOCKSCALE_FP8_GEMM_FLASHINFER
+          value: "1"
+        - name: VLLM_USE_DEEP_GEMM
+          value: "1"
+        - name: VLLM_USE_DEEP_GEMM_E8M0
+          value: "1"
+        - name: VLLM_MOE_USE_DEEP_GEMM
+          value: "0"
+        - name: VLLM_USE_FLASHINFER_MOE_FP8
+          value: "0"
+        - name: UCX_MAX_RMA_LANES
+          value: "4"
+        - name: UCX_MAX_COMPONENT_MDS
+          value: "32"
+        - name: UCX_ADDRESS_VERSION
+          value: "v2"
+        - name: UCX_KEEPALIVE_INTERVAL
+          value: "inf"
+        - name: UCX_PROTO_INFO
+          value: "y"
+        - name: UCX_LOG_LEVEL
+          value: "INFO"
+        - name: NCCL_LAUNCH_MODE
+          value: "PARALLEL"
+        - name: NCCL_NET_SHARED_COMMS
+          value: "0"
+        - name: NCCL_DEBUG
+          value: "WARN"
+        # NIXL telemetry gate: nixl/src/core/nixl_agent.cpp:128-150 only
+        # records xfer/post/bytes_transferred/num_descriptors histograms
+        # when this env is set. The vLLM bundled in vllm-runtime:1.1.1
+        # predates the unconditional capture_telemetry=True path
+        # (nixl_connector.py:1082-1087 in newer vLLM), so the env var is
+        # required for `vllm:nixl_*` to be non-zero. Per observe-agent
+        # NEXT_STEPS_FOR_TEST_AGENT P0.1 (sanity-suite work).
+        - name: NIXL_TELEMETRY_ENABLE
+          value: "y"
+        # Bound the vLLM execute-model wait so a stalled engine surfaces as
+        # EngineDeadError + worker restart within 30s under cascade pressure
+        # (per memory: reference_vllm_force_engine_death). Without this the
+        # default is effectively unbounded and stalls mask the cascade signal.
+        - name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS
+          value: "30"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.1
+          workingDir: /workspace/examples/backends/vllm
+          command:
+            - python3
+            - -m
+            - dynamo.vllm
+          args:
+            - --model
+            - Qwen/Qwen3-30B-A3B-Instruct-2507-FP8
+            - --disaggregation-mode
+            - decode
+            - --tensor-parallel-size
+            - "2"
+            - --gpu-memory-utilization
+            - "0.5"
+            - --max-model-len
+            - "10240"
+            - --max-num-seqs
+            - "256"
+            - --max-num-batched-tokens
+            - "256"
+            - --dyn-reasoning-parser
+            - qwen3
+            - --enable-expert-parallel
+            - --async-scheduling
+            - --disable-cascade-attn
+            - --kv-transfer-config
+            - '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
+            - --kv-events-config
+            - '{"enable_kv_cache_events":false}'

--- a/tests/fault_tolerance/deploy/templates/vllm/disagg_qwen3_30b_unit_prod.yaml
+++ b/tests/fault_tolerance/deploy/templates/vllm/disagg_qwen3_30b_unit_prod.yaml
@@ -3,7 +3,7 @@
 #
 # Close mirror of the production Qwen3-30B-A3B disagg deployment that
 # exhibits the cascade in field. Differences from prod (see
-# dynamo-observe/.../incidents/ads_dgd.yaml) and rationale:
+# dynamo-observe production deployment scenarios) and rationale:
 #
 # - Hardware: prod runs A100-40GB (P4D); we run on H100-80GB and cap to
 #   ~36 GB / GPU via --gpu-memory-utilization=0.45 (= 0.9 * 40 GB).
@@ -83,6 +83,15 @@ spec:
           value: "0"
         - name: NCCL_DEBUG
           value: "WARN"
+        # NIXL telemetry gate: nixl/src/core/nixl_agent.cpp:128-150 only
+        # records xfer/post/bytes_transferred/num_descriptors histograms
+        # when this env is set. The vLLM bundled in vllm-runtime:1.1.1
+        # predates the unconditional capture_telemetry=True path
+        # (nixl_connector.py:1082-1087 in newer vLLM), so the env var is
+        # required for `vllm:nixl_*` to be non-zero. Per observe-agent
+        # NEXT_STEPS_FOR_TEST_AGENT P0.1 (sanity-suite work).
+        - name: NIXL_TELEMETRY_ENABLE
+          value: "y"
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.1
@@ -155,6 +164,15 @@ spec:
           value: "0"
         - name: NCCL_DEBUG
           value: "WARN"
+        # NIXL telemetry gate: nixl/src/core/nixl_agent.cpp:128-150 only
+        # records xfer/post/bytes_transferred/num_descriptors histograms
+        # when this env is set. The vLLM bundled in vllm-runtime:1.1.1
+        # predates the unconditional capture_telemetry=True path
+        # (nixl_connector.py:1082-1087 in newer vLLM), so the env var is
+        # required for `vllm:nixl_*` to be non-zero. Per observe-agent
+        # NEXT_STEPS_FOR_TEST_AGENT P0.1 (sanity-suite work).
+        - name: NIXL_TELEMETRY_ENABLE
+          value: "y"
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.1

--- a/tests/fault_tolerance/deploy/templates/vllm/disagg_qwen3_30b_unit_prod.yaml
+++ b/tests/fault_tolerance/deploy/templates/vllm/disagg_qwen3_30b_unit_prod.yaml
@@ -19,9 +19,9 @@
 #       `disagg_qwen3_30b_4p2d_2f_prod.yaml`
 #     - N=3 → 3 FE / 6 PF / 3 DE (18 GPUs)
 #   Same PF:DE ratio as prod at every N.
-# - Image: prod runs a custom lise-dynamo image off vllm 1.0.1
-#   (vllm_1.0.1_0.16.0). We use the released vllm-runtime:1.0.1 — same
-#   vllm + Dynamo base, missing only prod's custom patches.
+# - Image: this template targets the released vllm-runtime:1.0.1
+#   (vllm_1.0.1_0.16.0). Fork builds tracking the same vllm + Dynamo
+#   base will run with the same args.
 #
 # Everything else (model, args, FP8 GEMM env, UCX/NCCL tuning) is
 # copied verbatim from the prod DGD spec.
@@ -94,9 +94,8 @@ spec:
           args:
             - --model
             - Qwen/Qwen3-30B-A3B-Instruct-2507-FP8
-            # vllm-runtime:1.0.1 uses --disaggregation-mode; the customer's
-            # lise-dynamo fork uses --is-prefill-worker (both functionally
-            # equivalent for vLLM disagg).
+            # vllm-runtime:1.0.1 uses --disaggregation-mode; some forks
+            # use --is-prefill-worker (functionally equivalent for vLLM disagg).
             - --disaggregation-mode
             - prefill
             - --tensor-parallel-size

--- a/tests/fault_tolerance/deploy/templates/vllm/disagg_qwen3_30b_unit_prod.yaml
+++ b/tests/fault_tolerance/deploy/templates/vllm/disagg_qwen3_30b_unit_prod.yaml
@@ -1,0 +1,190 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Close mirror of the production Qwen3-30B-A3B disagg deployment that
+# exhibits the cascade in field. Differences from prod (see
+# dynamo-observe/.../incidents/ads_dgd.yaml) and rationale:
+#
+# - Hardware: prod runs A100-40GB (P4D); we run on H100-80GB and cap to
+#   ~36 GB / GPU via --gpu-memory-utilization=0.45 (= 0.9 * 40 GB).
+#   That matches prod's vLLM memory budget exactly. HBM bandwidth and
+#   FP8 tensor-core throughput on H100 still differ — we emulate KV
+#   pressure / NIXL behaviour, not raw decode TPS.
+# - Topology: prod is 102 FE / 204 PF / 102 DE (≈ 2:1 PF:DE ratio).
+#   This template encodes a **single unit** = 1 FE / 2 PF (TP=2) / 1 DE
+#   (TP=2) = 6 GPUs, fits one 8×H100-80GB node. Tests multiply each
+#   service's replica count by `runtime_env.units` (CLI: `--units N`):
+#     - N=1 → 1 FE / 2 PF / 1 DE (6 GPUs)  — isolates per-unit cascade
+#     - N=2 → 2 FE / 4 PF / 2 DE (12 GPUs) — same footprint as
+#       `disagg_qwen3_30b_4p2d_2f_prod.yaml`
+#     - N=3 → 3 FE / 6 PF / 3 DE (18 GPUs)
+#   Same PF:DE ratio as prod at every N.
+# - Image: prod runs a custom lise-dynamo image off vllm 1.0.1
+#   (vllm_1.0.1_0.16.0). We use the released vllm-runtime:1.0.1 — same
+#   vllm + Dynamo base, missing only prod's custom patches.
+#
+# Everything else (model, args, FP8 GEMM env, UCX/NCCL tuning) is
+# copied verbatim from the prod DGD spec.
+
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  # Short name keeps PVC-verify Job label under the 63-char limit. Tests
+  # may suffix this with the unit count (e.g. `vllm-q3-prod-units-2`)
+  # before applying — keep the base name short to leave headroom.
+  name: vllm-q3-prod-units
+spec:
+  services:
+    Frontend:
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.1
+
+    VllmPrefillWorker:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      subComponentType: prefill
+      replicas: 2
+      resources:
+        requests:
+          gpu: "2"
+        limits:
+          gpu: "2"
+      # Per-service envs mirror the prod DGD's FP8 GEMM + UCX/NCCL
+      # tuning. Values are exact copies from ads_dgd.yaml.
+      envs:
+        - name: VLLM_BLOCKSCALE_FP8_GEMM_FLASHINFER
+          value: "1"
+        - name: VLLM_USE_DEEP_GEMM
+          value: "1"
+        - name: VLLM_USE_DEEP_GEMM_E8M0
+          value: "1"
+        - name: VLLM_MOE_USE_DEEP_GEMM
+          value: "0"
+        - name: VLLM_USE_FLASHINFER_MOE_FP8
+          value: "0"
+        - name: UCX_MAX_RMA_LANES
+          value: "4"
+        - name: UCX_MAX_COMPONENT_MDS
+          value: "32"
+        - name: UCX_ADDRESS_VERSION
+          value: "v2"
+        - name: UCX_KEEPALIVE_INTERVAL
+          value: "inf"
+        - name: UCX_PROTO_INFO
+          value: "y"
+        - name: UCX_LOG_LEVEL
+          value: "INFO"
+        - name: NCCL_LAUNCH_MODE
+          value: "PARALLEL"
+        - name: NCCL_NET_SHARED_COMMS
+          value: "0"
+        - name: NCCL_DEBUG
+          value: "WARN"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.1
+          workingDir: /workspace/examples/backends/vllm
+          command:
+            - python3
+            - -m
+            - dynamo.vllm
+          args:
+            - --model
+            - Qwen/Qwen3-30B-A3B-Instruct-2507-FP8
+            # vllm-runtime:1.0.1 uses --disaggregation-mode; the customer's
+            # lise-dynamo fork uses --is-prefill-worker (both functionally
+            # equivalent for vLLM disagg).
+            - --disaggregation-mode
+            - prefill
+            - --tensor-parallel-size
+            - "2"
+            - --gpu-memory-utilization
+            - "0.45"
+            - --max-model-len
+            - "10240"
+            - --max-num-seqs
+            - "512"
+            - --dyn-reasoning-parser
+            - qwen3
+            - --enable-expert-parallel
+            - --async-scheduling
+            - --disable-cascade-attn
+            - --kv-transfer-config
+            - '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
+            - --kv-events-config
+            - '{"enable_kv_cache_events":false}'
+
+    VllmDecodeWorker:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      subComponentType: decode
+      replicas: 1
+      resources:
+        requests:
+          gpu: "2"
+        limits:
+          gpu: "2"
+      envs:
+        - name: VLLM_BLOCKSCALE_FP8_GEMM_FLASHINFER
+          value: "1"
+        - name: VLLM_USE_DEEP_GEMM
+          value: "1"
+        - name: VLLM_USE_DEEP_GEMM_E8M0
+          value: "1"
+        - name: VLLM_MOE_USE_DEEP_GEMM
+          value: "0"
+        - name: VLLM_USE_FLASHINFER_MOE_FP8
+          value: "0"
+        - name: UCX_MAX_RMA_LANES
+          value: "4"
+        - name: UCX_MAX_COMPONENT_MDS
+          value: "32"
+        - name: UCX_ADDRESS_VERSION
+          value: "v2"
+        - name: UCX_KEEPALIVE_INTERVAL
+          value: "inf"
+        - name: UCX_PROTO_INFO
+          value: "y"
+        - name: UCX_LOG_LEVEL
+          value: "INFO"
+        - name: NCCL_LAUNCH_MODE
+          value: "PARALLEL"
+        - name: NCCL_NET_SHARED_COMMS
+          value: "0"
+        - name: NCCL_DEBUG
+          value: "WARN"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.1
+          workingDir: /workspace/examples/backends/vllm
+          command:
+            - python3
+            - -m
+            - dynamo.vllm
+          args:
+            - --model
+            - Qwen/Qwen3-30B-A3B-Instruct-2507-FP8
+            - --disaggregation-mode
+            - decode
+            - --tensor-parallel-size
+            - "2"
+            - --gpu-memory-utilization
+            - "0.45"
+            - --max-model-len
+            - "10240"
+            - --max-num-seqs
+            - "1024"
+            - --max-num-batched-tokens
+            - "1024"
+            - --dyn-reasoning-parser
+            - qwen3
+            - --enable-expert-parallel
+            - --async-scheduling
+            - --disable-cascade-attn
+            - --kv-transfer-config
+            - '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
+            - --kv-events-config
+            - '{"enable_kv_cache_events":false}'

--- a/tests/fault_tolerance/deploy/templates/vllm/disagg_qwen3_30b_unit_prod.yaml
+++ b/tests/fault_tolerance/deploy/templates/vllm/disagg_qwen3_30b_unit_prod.yaml
@@ -92,6 +92,12 @@ spec:
         # NEXT_STEPS_FOR_TEST_AGENT P0.1 (sanity-suite work).
         - name: NIXL_TELEMETRY_ENABLE
           value: "y"
+        # Bound the vLLM execute-model wait so a stalled engine surfaces as
+        # EngineDeadError + worker restart within 30s under cascade pressure
+        # (per memory: reference_vllm_force_engine_death). Without this the
+        # default is effectively unbounded and stalls mask the cascade signal.
+        - name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS
+          value: "30"
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.1
@@ -173,6 +179,12 @@ spec:
         # NEXT_STEPS_FOR_TEST_AGENT P0.1 (sanity-suite work).
         - name: NIXL_TELEMETRY_ENABLE
           value: "y"
+        # Bound the vLLM execute-model wait so a stalled engine surfaces as
+        # EngineDeadError + worker restart within 30s under cascade pressure
+        # (per memory: reference_vllm_force_engine_death). Without this the
+        # default is effectively unbounded and stalls mask the cascade signal.
+        - name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS
+          value: "30"
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.1

--- a/tests/fault_tolerance/deploy/templates/vllm/disagg_qwen3_30b_unit_prod_AGG_decode.yaml
+++ b/tests/fault_tolerance/deploy/templates/vllm/disagg_qwen3_30b_unit_prod_AGG_decode.yaml
@@ -1,0 +1,201 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Close mirror of the production Qwen3-30B-A3B disagg deployment that
+# exhibits the cascade in field. Differences from prod (see
+# dynamo-observe/.../incidents/ads_dgd.yaml) and rationale:
+#
+# - Hardware: prod runs A100-40GB (P4D); we run on H100-80GB and cap to
+#   ~36 GB / GPU via --gpu-memory-utilization=0.45 (= 0.9 * 40 GB).
+#   That matches prod's vLLM memory budget exactly. HBM bandwidth and
+#   FP8 tensor-core throughput on H100 still differ — we emulate KV
+#   pressure / NIXL behaviour, not raw decode TPS.
+# - Topology: prod is 102 FE / 204 PF / 102 DE (≈ 2:1 PF:DE ratio).
+#   This template encodes a **single unit** = 1 FE / 2 PF (TP=2) / 1 DE
+#   (TP=2) = 6 GPUs, fits one 8×H100-80GB node. Tests multiply each
+#   service's replica count by `runtime_env.units` (CLI: `--units N`):
+#     - N=1 → 1 FE / 2 PF / 1 DE (6 GPUs)  — isolates per-unit cascade
+#     - N=2 → 2 FE / 4 PF / 2 DE (12 GPUs) — same footprint as
+#       `disagg_qwen3_30b_4p2d_2f_prod.yaml`
+#     - N=3 → 3 FE / 6 PF / 3 DE (18 GPUs)
+#   Same PF:DE ratio as prod at every N.
+# - Image: prod runs a custom lise-dynamo image off vllm 1.0.1
+#   (vllm_1.0.1_0.16.0). We use the released vllm-runtime:1.0.1 — same
+#   vllm + Dynamo base, missing only prod's custom patches.
+#
+# Everything else (model, args, FP8 GEMM env, UCX/NCCL tuning) is
+# copied verbatim from the prod DGD spec.
+
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  # Short name keeps PVC-verify Job label under the 63-char limit. Tests
+  # may suffix this with the unit count (e.g. `vllm-q3-prod-units-2`)
+  # before applying — keep the base name short to leave headroom.
+  name: vllm-q3-prod-agg-units
+spec:
+  services:
+    Frontend:
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.1
+
+    VllmPrefillWorker:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      subComponentType: prefill
+      replicas: 2
+      resources:
+        requests:
+          gpu: "2"
+        limits:
+          gpu: "2"
+      # Per-service envs mirror the prod DGD's FP8 GEMM + UCX/NCCL
+      # tuning. Values are exact copies from ads_dgd.yaml.
+      envs:
+        - name: VLLM_BLOCKSCALE_FP8_GEMM_FLASHINFER
+          value: "1"
+        - name: VLLM_USE_DEEP_GEMM
+          value: "1"
+        - name: VLLM_USE_DEEP_GEMM_E8M0
+          value: "1"
+        - name: VLLM_MOE_USE_DEEP_GEMM
+          value: "0"
+        - name: VLLM_USE_FLASHINFER_MOE_FP8
+          value: "0"
+        - name: UCX_MAX_RMA_LANES
+          value: "4"
+        - name: UCX_MAX_COMPONENT_MDS
+          value: "32"
+        - name: UCX_ADDRESS_VERSION
+          value: "v2"
+        - name: UCX_KEEPALIVE_INTERVAL
+          value: "inf"
+        - name: UCX_PROTO_INFO
+          value: "y"
+        - name: UCX_LOG_LEVEL
+          value: "INFO"
+        - name: NCCL_LAUNCH_MODE
+          value: "PARALLEL"
+        - name: NCCL_NET_SHARED_COMMS
+          value: "0"
+        - name: NCCL_DEBUG
+          value: "WARN"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.1
+          workingDir: /workspace/examples/backends/vllm
+          command:
+            - python3
+            - -m
+            - dynamo.vllm
+          args:
+            - --model
+            - Qwen/Qwen3-30B-A3B-Instruct-2507-FP8
+            # vllm-runtime:1.0.1 uses --disaggregation-mode; the customer's
+            # lise-dynamo fork uses --is-prefill-worker (both functionally
+            # equivalent for vLLM disagg).
+            - --disaggregation-mode
+            - prefill
+            - --tensor-parallel-size
+            - "2"
+            - --gpu-memory-utilization
+            - "0.45"
+            - --max-model-len
+            - "10240"
+            - --max-num-seqs
+            - "512"
+            - --dyn-reasoning-parser
+            - qwen3
+            - --enable-expert-parallel
+            - --async-scheduling
+            - --disable-cascade-attn
+            - --kv-transfer-config
+            - '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
+            - --kv-events-config
+            - '{"enable_kv_cache_events":false}'
+
+    # AGG-enum variant: decode worker has kv_events ENABLED. Combined with
+    # the missing --disaggregation-mode flag (i.e. AGG enum default), this
+    # is the exact configuration that fires the 2026-05-03 radix_tree
+    # WARN storm: publisher-skip gate at main.py:316 is bypassed because
+    # disaggregation_mode != DECODE, AND not bypassed at main.py:324
+    # because enable_kv_cache_events=True. Both must hold to wire up
+    # LocalKvIndexer + drive the radix_tree warnings.
+    VllmDecodeWorker:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      subComponentType: decode
+      replicas: 1
+      resources:
+        requests:
+          gpu: "2"
+        limits:
+          gpu: "2"
+      envs:
+        - name: VLLM_BLOCKSCALE_FP8_GEMM_FLASHINFER
+          value: "1"
+        - name: VLLM_USE_DEEP_GEMM
+          value: "1"
+        - name: VLLM_USE_DEEP_GEMM_E8M0
+          value: "1"
+        - name: VLLM_MOE_USE_DEEP_GEMM
+          value: "0"
+        - name: VLLM_USE_FLASHINFER_MOE_FP8
+          value: "0"
+        - name: UCX_MAX_RMA_LANES
+          value: "4"
+        - name: UCX_MAX_COMPONENT_MDS
+          value: "32"
+        - name: UCX_ADDRESS_VERSION
+          value: "v2"
+        - name: UCX_KEEPALIVE_INTERVAL
+          value: "inf"
+        - name: UCX_PROTO_INFO
+          value: "y"
+        - name: UCX_LOG_LEVEL
+          value: "INFO"
+        - name: NCCL_LAUNCH_MODE
+          value: "PARALLEL"
+        - name: NCCL_NET_SHARED_COMMS
+          value: "0"
+        - name: NCCL_DEBUG
+          value: "WARN"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.1
+          workingDir: /workspace/examples/backends/vllm
+          command:
+            - python3
+            - -m
+            - dynamo.vllm
+          args:
+            - --model
+            - Qwen/Qwen3-30B-A3B-Instruct-2507-FP8
+            # AGG-enum variant: deliberately OMIT --disaggregation-mode
+            # so the v1.0.1 default (AGGREGATED) takes effect, which
+            # wires up the kv-events publisher + LocalKvIndexer and
+            # reproduces the 2026-05-03 radix_tree WARN storm pre-condition.
+            - --tensor-parallel-size
+            - "2"
+            - --gpu-memory-utilization
+            - "0.45"
+            - --max-model-len
+            - "10240"
+            - --max-num-seqs
+            - "1024"
+            - --max-num-batched-tokens
+            - "1024"
+            - --dyn-reasoning-parser
+            - qwen3
+            - --enable-expert-parallel
+            - --async-scheduling
+            - --disable-cascade-attn
+            - --kv-transfer-config
+            - '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
+            # AGG-enum variant: kv events ENABLED on decode so the
+            # publisher-skip gate at main.py:324 does NOT fire.
+            - --kv-events-config
+            - '{"enable_kv_cache_events":true}'

--- a/tests/fault_tolerance/deploy/templates/vllm/disagg_qwen3_30b_unit_prod_AGG_decode.yaml
+++ b/tests/fault_tolerance/deploy/templates/vllm/disagg_qwen3_30b_unit_prod_AGG_decode.yaml
@@ -19,9 +19,9 @@
 #       `disagg_qwen3_30b_4p2d_2f_prod.yaml`
 #     - N=3 → 3 FE / 6 PF / 3 DE (18 GPUs)
 #   Same PF:DE ratio as prod at every N.
-# - Image: prod runs a custom lise-dynamo image off vllm 1.0.1
-#   (vllm_1.0.1_0.16.0). We use the released vllm-runtime:1.0.1 — same
-#   vllm + Dynamo base, missing only prod's custom patches.
+# - Image: this template targets the released vllm-runtime:1.0.1
+#   (vllm_1.0.1_0.16.0). Fork builds tracking the same vllm + Dynamo
+#   base will run with the same args.
 #
 # Everything else (model, args, FP8 GEMM env, UCX/NCCL tuning) is
 # copied verbatim from the prod DGD spec.
@@ -94,9 +94,8 @@ spec:
           args:
             - --model
             - Qwen/Qwen3-30B-A3B-Instruct-2507-FP8
-            # vllm-runtime:1.0.1 uses --disaggregation-mode; the customer's
-            # lise-dynamo fork uses --is-prefill-worker (both functionally
-            # equivalent for vLLM disagg).
+            # vllm-runtime:1.0.1 uses --disaggregation-mode; some forks
+            # use --is-prefill-worker (functionally equivalent for vLLM disagg).
             - --disaggregation-mode
             - prefill
             - --tensor-parallel-size

--- a/tests/fault_tolerance/deploy/templates/vllm/disagg_same_gpu.yaml
+++ b/tests/fault_tolerance/deploy/templates/vllm/disagg_same_gpu.yaml
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Single-GPU vllm disagg deployment (Qwen3-0.6B). k8s mirror of
+# examples/backends/vllm/launch/disagg_same_gpu.sh: prefill + decode
+# co-resident on one GPU via tiny --gpu-memory-utilization, capped
+# --kv-cache-memory-bytes, and --enforce-eager. NixlConnector handles
+# the prefill->decode KV transfer so vllm:nixl_* counters register
+# on the prefill (P) instance.
+#
+# REQUIREMENTS: cluster either has >=2 GPUs (one per worker) or has
+# nvidia-device-plugin time-slicing enabled (1 physical GPU exposed
+# as N logical via sharing.timeSlicing.resources). On a single-GPU
+# node without time-slicing, the second worker will sit Pending with
+# FailedScheduling: "Insufficient nvidia.com/gpu".
+
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: vllm-disagg-same-gpu
+spec:
+  services:
+    Frontend:
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+    VllmDecodeWorker:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      subComponentType: decode
+      replicas: 1
+      envs:
+        # Distinct system_port per worker so the two prometheus servers
+        # don't collide when co-resident on the same node.
+        - name: DYN_SYSTEM_PORT
+          value: "8081"
+      resources:
+        limits:
+          gpu: "1"
+        requests:
+          custom:
+            ephemeral-storage: "2Gi"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          workingDir: /workspace/examples/backends/vllm
+          command:
+            - python3
+            - -m
+            - dynamo.vllm
+          args:
+            - --model
+            - Qwen/Qwen3-0.6B
+            - --enforce-eager
+            - --disaggregation-mode
+            - decode
+            - --kv-transfer-config
+            - '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
+            # Hard cap KV cache memory so prefill and decode can fit
+            # together on one GPU. ~976 MiB per worker, profiled-safe
+            # for Qwen3-0.6B at max-model-len 4096.
+            - --kv-cache-memory-bytes
+            - "1023525000"
+            # 0.01 keeps vLLM's startup free-memory check from
+            # rejecting the launch when a co-resident worker already
+            # holds VRAM.
+            - --gpu-memory-utilization
+            - "0.01"
+            - --max-model-len
+            - "4096"
+    VllmPrefillWorker:
+      envFromSecret: hf-token-secret
+      componentType: worker
+      subComponentType: prefill
+      replicas: 1
+      envs:
+        - name: DYN_SYSTEM_PORT
+          value: "8082"
+        # Avoid NIXL side-channel port conflict with decode (default 20096).
+        - name: VLLM_NIXL_SIDE_CHANNEL_PORT
+          value: "20097"
+      resources:
+        limits:
+          gpu: "1"
+        requests:
+          custom:
+            ephemeral-storage: "2Gi"
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          workingDir: /workspace/examples/backends/vllm
+          command:
+            - python3
+            - -m
+            - dynamo.vllm
+          args:
+            - --model
+            - Qwen/Qwen3-0.6B
+            - --enforce-eager
+            - --disaggregation-mode
+            - prefill
+            - --kv-transfer-config
+            - '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
+            - --kv-events-config
+            - '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20081","enable_kv_cache_events":true}'
+            - --kv-cache-memory-bytes
+            - "1023525000"
+            - --gpu-memory-utilization
+            - "0.01"
+            - --max-model-len
+            - "4096"

--- a/tests/fault_tolerance/deploy/templates/vllm/disagg_same_gpu.yaml
+++ b/tests/fault_tolerance/deploy/templates/vllm/disagg_same_gpu.yaml
@@ -31,11 +31,11 @@ spec:
       componentType: worker
       subComponentType: decode
       replicas: 1
-      envs:
-        # Distinct system_port per worker so the two prometheus servers
-        # don't collide when co-resident on the same node.
-        - name: DYN_SYSTEM_PORT
-          value: "8081"
+      # Note: each worker runs in its own pod with its own pod IP, so
+      # port 9090 (the default DYN_SYSTEM_PORT, also the operator's
+      # readiness/liveness probe target) doesn't collide between
+      # workers — unlike the standalone-process disagg_same_gpu.sh
+      # which needed 8081/8082.
       resources:
         limits:
           gpu: "1"
@@ -75,12 +75,10 @@ spec:
       componentType: worker
       subComponentType: prefill
       replicas: 1
-      envs:
-        - name: DYN_SYSTEM_PORT
-          value: "8082"
-        # Avoid NIXL side-channel port conflict with decode (default 20096).
-        - name: VLLM_NIXL_SIDE_CHANNEL_PORT
-          value: "20097"
+      # Same reasoning as VllmDecodeWorker: separate pods + separate
+      # pod IPs let both workers use the default ports without
+      # collision. VLLM_NIXL_SIDE_CHANNEL_PORT default (20096) is also
+      # fine since prefill and decode pods have different IPs.
       resources:
         limits:
           gpu: "1"

--- a/tests/fault_tolerance/deploy/templates/vllm/podmonitor_vllm_workers.yaml
+++ b/tests/fault_tolerance/deploy/templates/vllm/podmonitor_vllm_workers.yaml
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# PodMonitor for any Dynamo DGD's worker + frontend pods in this namespace.
+# Picked up automatically by the Prometheus operator (operator namespace
+# `prometheus-operator`); the resulting metrics are then visible in
+# Grafana at kube-prometheus-stack-grafana.monitoring.
+#
+# Targets every pod with label `nvidia.com/dynamo-component` (set by the
+# operator on every DGD-managed pod), scrapes path /metrics on the
+# Dynamo system port. The system port name is `system` on the operator-
+# created Service, and is 9090 on the pod.
+#
+# Apply once per namespace (idempotent), separate from any specific DGD:
+#   kubectl --context <ctx> -n <ns> apply -f podmonitor_vllm_workers.yaml
+
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: dynamo-workers
+  labels:
+    app.kubernetes.io/managed-by: dynamo-test-framework
+spec:
+  selector:
+    matchExpressions:
+      - key: nvidia.com/dynamo-component
+        operator: Exists
+  podMetricsEndpoints:
+    # Workers expose Dynamo + vllm engine metrics on `system:9090`.
+    - port: system
+      path: /metrics
+      interval: 5s          # fast scrape — match aiperf's 1Hz default-ish cadence
+      scrapeTimeout: 4s
+      relabelings: &relabel
+        # Surface useful labels into Prometheus so Grafana can group by them.
+        - sourceLabels: [__meta_kubernetes_pod_label_nvidia_com_dynamo_component]
+          targetLabel: dynamo_component
+        - sourceLabels: [__meta_kubernetes_pod_label_nvidia_com_dynamo_subcomponent]
+          targetLabel: dynamo_subcomponent
+        - sourceLabels: [__meta_kubernetes_pod_label_nvidia_com_dynamo_graph_deployment_name]
+          targetLabel: dgd
+        - sourceLabels: [__meta_kubernetes_pod_name]
+          targetLabel: pod
+        - sourceLabels: [__meta_kubernetes_namespace]
+          targetLabel: namespace
+    # Frontend exposes its own /metrics on `http:8000` (no separate system port).
+    - port: http
+      path: /metrics
+      interval: 5s
+      scrapeTimeout: 4s
+      relabelings: *relabel

--- a/tests/fault_tolerance/deploy/test_capacity_probe_qwen3_30b.py
+++ b/tests/fault_tolerance/deploy/test_capacity_probe_qwen3_30b.py
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Capacity probe — push the 4P:2D:2F deployment until it falls over.
+#
+# Goal: identify X*, the concurrency level where the system breaks (not just
+# where queueing onsets). Run consecutive `StartLoad` rungs at increasing
+# concurrency, sustained ISL=N(7000, σ=600) / OSL=N(100, σ=40). Each rung is
+# its own clean event boundary in the metrics; spike_view buckets them.
+#
+# Watch (in Grafana / TUI / spike_view post-run): which signal moves FIRST
+# when load crosses the breakpoint —
+#   A: prefill workers' vllm:num_requests_waiting (or dynamo_frontend_queued_requests)
+#   B: decode workers' vllm:num_requests_waiting
+#   C: vllm:nixl_post_time_seconds p99 / upper-bucket migration
+#   D: decode worker pod transitions to Failed/CrashLoopBackOff
+#
+# This is the natural-stress version of the cascade — no injected fault.
+
+import pytest
+
+from tests.fault_tolerance.deploy.checks import LoadCompleted
+from tests.fault_tolerance.deploy.events import (
+    StartLoad,
+    WaitForLoadCompletion,
+    WaitForModelReady,
+)
+from tests.fault_tolerance.deploy.reports import FaultToleranceReport
+from tests.fault_tolerance.deploy.scenario import run_scenario
+from tests.utils.managed_deployment import DeploymentSpec
+from tests.utils.managed_load import LoadConfig
+
+# Concurrency rungs. Aggressive escalation past presumed cascade point.
+# Each rung runs `_RUNG_DURATION_S` seconds before stepping up.
+# Capacity sweep: progressive degradation. c32 already over-saturates the
+# 4P:2D:2F deployment at ISL=7000/OSL=100 (NIXL p99 4.8s, KV usage 0.82,
+# RTT p99 62s observed in earlier run). Lower rungs find clean queueing-
+# onset; c48/c64 push it firmly into the bad state to show what the
+# cascade looks like before any fault is injected.
+_RUNGS = [8, 16, 24, 32, 48, 64]
+_RUNG_DURATION_S = 180  # 3 min/rung → ~18 min total at full sweep
+_ISL_MEAN = 7000
+_ISL_STDDEV = 600
+_OSL_MEAN = 100
+_OSL_STDDEV = 40
+
+
+def _load_config(model: str, concurrency: int) -> LoadConfig:
+    return LoadConfig(
+        model_name=model,
+        tokenizer=model,
+        input_tokens_mean=_ISL_MEAN,
+        input_tokens_stddev=_ISL_STDDEV,
+        output_tokens_mean=_OSL_MEAN,
+        output_tokens_stddev=_OSL_STDDEV,
+        concurrency=concurrency,
+        duration_minutes=_RUNG_DURATION_S / 60.0,
+        request_timeout_seconds=300,
+        streaming=True,
+        ignore_eos=True,
+        warmup_requests=0,
+    )
+
+
+@pytest.mark.k8s
+@pytest.mark.e2e
+@pytest.mark.weekly
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+async def test_capacity_probe_qwen3_30b(runtime_env):
+    spec = DeploymentSpec(
+        "/workspace/tests/fault_tolerance/deploy/templates/vllm/"
+        "disagg_qwen3_30b_4p2d_2f.yaml"
+    )
+    served_model = spec["VllmDecodeWorker"].model
+
+    # Build chained StartLoad / WaitForLoadCompletion events. Each rung is
+    # back-to-back; the StopLoad between them lets the framework cleanly
+    # finalize one ManagedLoad before starting the next.
+    events = [WaitForModelReady(timeout=1500)]
+    for concurrency in _RUNGS:
+        events += [
+            StartLoad(
+                load_config=_load_config(served_model, concurrency),
+                name=f"c{concurrency}",
+            ),
+            WaitForLoadCompletion(name=f"c{concurrency}"),
+        ]
+
+    await run_scenario(
+        deployment_spec=spec,
+        events=events,
+        # Don't hard-fail on errors — we WANT to see the deployment fall
+        # over and observe the cascade signature. Errors during higher
+        # rungs are the signal, not a test failure.
+        checks=[LoadCompleted(name=f"c{_RUNGS[0]}")],
+        reports=[FaultToleranceReport()],
+        test_name="test_capacity_probe_qwen3_30b",
+        runtime_env=runtime_env,
+    )

--- a/tests/fault_tolerance/deploy/test_cascade_console.py
+++ b/tests/fault_tolerance/deploy/test_cascade_console.py
@@ -1,0 +1,387 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Long-running cascade driver. Holds a 4P:2D:2F DGD open and listens on a
+# Unix socket for commands sent by the cascade_inject CLI. Lets us
+# deploy ONCE and explore the cascade interactively — adjust load,
+# inject faults, snapshot state, watch via Grafana / TUI / spike_view —
+# without paying the FSx + model-load tax for every iteration.
+#
+# Run from inside the dev container:
+#
+#   pytest tests/fault_tolerance/deploy/test_cascade_console.py \
+#     -s --namespace neelays-test --log-pvc qwen3-30b-logs \
+#     --model-pvc shared-model-cache --baseline-concurrency 8
+#
+# In another terminal (or window), drive it:
+#
+#   python -m tests.utils.cascade_inject status
+#   python -m tests.utils.cascade_inject load 16
+#   python -m tests.utils.cascade_inject stall VllmDecodeWorker --duration 30s
+#   python -m tests.utils.cascade_inject dump
+#   python -m tests.utils.cascade_inject quit
+#
+# `quit` triggers a clean teardown (DGD delete, log PVC kept).
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import secrets
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+import pytest
+
+from tests.fault_tolerance.deploy.events import StallProcess, WaitForModelReady
+from tests.fault_tolerance.deploy.scenario import RuntimeEnv, ScenarioContext
+from tests.utils.managed_deployment import DeploymentSpec, ManagedDeployment
+from tests.utils.managed_load import LoadConfig, ManagedLoad
+
+logger = logging.getLogger(__name__)
+
+# Socket path is per-DGD so multiple consoles don't collide.
+_SOCKET_FMT = "/tmp/cascade-inject-{dgd}.sock"
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# IPC server
+
+
+class CascadeConsole:
+    """Long-running command dispatcher for an open DGD."""
+
+    def __init__(
+        self,
+        ctx: ScenarioContext,
+        dgd_name: str,
+        baseline_concurrency: int,
+    ):
+        self.ctx = ctx
+        self.dgd_name = dgd_name
+        self.socket_path = Path(_SOCKET_FMT.format(dgd=dgd_name))
+        self.baseline_concurrency = baseline_concurrency
+        self.current_load: Optional[ManagedLoad] = None
+        self.active_stalls: dict[str, StallProcess] = {}  # target → event
+        self.quit_requested = asyncio.Event()
+        self.event_log_path = Path("/tmp/cascade_events.log")
+
+    async def start_load(self, concurrency: int) -> None:
+        """Stop existing load (if any) + start a fresh one at given concurrency."""
+        if self.current_load:
+            self.ctx.logger.info(
+                f"console: stopping existing load (concurrency was "
+                f"{self.current_load.load_config.concurrency})"
+            )
+            try:
+                await self.current_load.terminate()
+            except Exception as e:
+                self.ctx.logger.warning(f"terminate failed (continuing): {e}")
+            try:
+                await self.current_load._cleanup()
+            except Exception as e:
+                self.ctx.logger.warning(f"cleanup failed (continuing): {e}")
+            self.current_load = None
+
+        served_model = self.ctx.deployment.deployment_spec["VllmDecodeWorker"].model
+        # Auto-discover worker /metrics URLs.
+        spec = self.ctx.deployment.deployment_spec
+        urls: list[str] = []
+        for service in spec.services:
+            if service.component_type == "frontend":
+                continue
+            pods_by_service = await asyncio.to_thread(
+                self.ctx.deployment.get_pods, [service.name]
+            )
+            for pod in pods_by_service.get(service.name) or []:
+                pod_ip = pod.raw.get("status", {}).get("podIP")
+                if pod_ip:
+                    urls.append(f"http://{pod_ip}:{spec.system_port}/metrics")
+
+        cfg = LoadConfig(
+            model_name=served_model,
+            tokenizer=served_model,
+            input_tokens_mean=7000,
+            input_tokens_stddev=600,
+            output_tokens_mean=100,
+            output_tokens_stddev=40,
+            concurrency=concurrency,
+            duration_minutes=60.0,
+            request_timeout_seconds=300,
+            streaming=True,
+            ignore_eos=True,
+            warmup_requests=0,
+            extra_server_metrics_urls=urls or None,
+        )
+        load = ManagedLoad(
+            namespace=self.ctx.namespace,
+            load_config=cfg,
+            pvc_name=self.ctx.deployment.get_log_pvc_name(),
+            endpoint_url=self.ctx.deployment.deployment_spec.get_in_cluster_frontend_url(
+                self.ctx.namespace
+            ),
+            log_dir=self.ctx.log_dir,
+            job_name=f"load-c{concurrency}-{secrets.token_hex(4)}",
+        )
+        await load._init_kubernetes()
+        await load.run(wait_for_completion=False)
+        self.current_load = load
+        self._append_event(f"load c={concurrency} started (job={load.job_name})")
+        self.ctx.logger.info(
+            f"console: started load at concurrency={concurrency}, "
+            f"job={load.job_name}"
+        )
+
+    async def stall(
+        self,
+        target: str,
+        duration_s: float,
+        process_name: str = "dynamo.vllm",
+    ) -> None:
+        evt = StallProcess(
+            services=[target],
+            process_name=process_name,
+            duration=duration_s,
+        )
+        await evt.timed_execute(self.ctx)
+        self.active_stalls[target] = evt
+        self._append_event(f"stall {target}/{process_name} for {duration_s}s")
+
+    async def unstall(self, target: str) -> None:
+        evt = self.active_stalls.pop(target, None)
+        if evt:
+            try:
+                await evt.stop(self.ctx)
+            except Exception as e:
+                self.ctx.logger.warning(f"unstall failed: {e}")
+            self._append_event(f"unstall {target}")
+        else:
+            self.ctx.logger.warning(f"unstall: no active stall on {target}")
+
+    async def status(self) -> dict[str, Any]:
+        pods = await asyncio.to_thread(self.ctx.deployment.get_pods, None)
+        pod_summary = []
+        for service, pod_list in pods.items():
+            for pod in pod_list:
+                phase = pod.raw.get("status", {}).get("phase", "?")
+                ready = False
+                for cs in pod.raw.get("status", {}).get("containerStatuses") or []:
+                    if cs.get("name") == "main" and cs.get("ready"):
+                        ready = True
+                        break
+                pod_summary.append(
+                    {
+                        "service": service,
+                        "pod": pod.raw["metadata"]["name"],
+                        "phase": phase,
+                        "ready": ready,
+                    }
+                )
+        return {
+            "dgd": self.dgd_name,
+            "load": (
+                {
+                    "concurrency": self.current_load.load_config.concurrency,
+                    "job": self.current_load.job_name,
+                }
+                if self.current_load
+                else None
+            ),
+            "active_stalls": list(self.active_stalls),
+            "pods": pod_summary,
+        }
+
+    async def dump_snapshot(self) -> dict[str, Any]:
+        """Snapshot all pod manifests + last 200 lines of logs to <log_dir>/snapshots/<ts>/."""
+        ts = time.strftime("%Y%m%d-%H%M%S")
+        out = Path(self.ctx.log_dir) / "snapshots" / ts
+        out.mkdir(parents=True, exist_ok=True)
+        pods = await asyncio.to_thread(self.ctx.deployment.get_pods, None)
+        n_pods = 0
+        for service, pod_list in pods.items():
+            for pod in pod_list:
+                pod_name = pod.raw["metadata"]["name"]
+                (out / f"{service}_{pod_name}.manifest.json").write_text(
+                    json.dumps(pod.raw, indent=2, default=str)
+                )
+                try:
+                    log_text = await asyncio.to_thread(
+                        pod.logs, container="main", tail_lines=200
+                    )
+                    if isinstance(log_text, list):
+                        log_text = "\n".join(log_text)
+                    (out / f"{service}_{pod_name}.log").write_text(log_text or "")
+                except Exception as e:
+                    (out / f"{service}_{pod_name}.log.error").write_text(str(e))
+                n_pods += 1
+        self._append_event(f"dump → {out} ({n_pods} pods)")
+        return {"path": str(out), "pod_count": n_pods}
+
+    def _append_event(self, text: str) -> None:
+        line = f"{time.strftime('%Y-%m-%dT%H:%M:%S')}  {text}\n"
+        try:
+            with self.event_log_path.open("a") as f:
+                f.write(line)
+        except OSError:
+            pass
+
+    async def _handle_client(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        try:
+            line = await reader.readline()
+            if not line:
+                return
+            try:
+                cmd_payload = json.loads(line.decode())
+            except json.JSONDecodeError as e:
+                response = {"ok": False, "error": f"bad JSON: {e}"}
+                writer.write((json.dumps(response) + "\n").encode())
+                await writer.drain()
+                return
+
+            cmd = cmd_payload.get("cmd")
+            response: dict[str, Any] = {"ok": True}
+
+            try:
+                if cmd == "status":
+                    response.update(await self.status())
+                elif cmd == "load":
+                    n = int(cmd_payload["concurrency"])
+                    await self.start_load(n)
+                    response["concurrency"] = n
+                elif cmd == "stall":
+                    await self.stall(
+                        cmd_payload["target"],
+                        float(cmd_payload.get("duration_s", 30.0)),
+                        cmd_payload.get("process_name", "dynamo.vllm"),
+                    )
+                    response["target"] = cmd_payload["target"]
+                elif cmd == "unstall":
+                    await self.unstall(cmd_payload["target"])
+                    response["target"] = cmd_payload["target"]
+                elif cmd == "dump":
+                    response.update(await self.dump_snapshot())
+                elif cmd == "quit":
+                    self._append_event("quit (driver exiting)")
+                    self.quit_requested.set()
+                    response["msg"] = "exiting"
+                else:
+                    response["ok"] = False
+                    response["error"] = f"unknown cmd: {cmd}"
+            except Exception as e:
+                response = {"ok": False, "error": f"{type(e).__name__}: {e}"}
+                self.ctx.logger.exception(f"cmd '{cmd}' failed")
+
+            writer.write((json.dumps(response) + "\n").encode())
+            await writer.drain()
+        finally:
+            writer.close()
+            try:
+                await writer.wait_closed()
+            except Exception:
+                pass
+
+    async def serve(self) -> None:
+        if self.socket_path.exists():
+            self.socket_path.unlink()
+        server = await asyncio.start_unix_server(
+            self._handle_client, path=str(self.socket_path)
+        )
+        os.chmod(str(self.socket_path), 0o660)
+        self.ctx.logger.info(
+            f"console: listening on {self.socket_path} "
+            f"(use `python -m tests.utils.cascade_inject ...`)"
+        )
+        async with server:
+            await self.quit_requested.wait()
+            self.ctx.logger.info("console: quit received, shutting down")
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# pytest entrypoint
+
+
+@pytest.mark.k8s
+@pytest.mark.e2e
+@pytest.mark.release  # Long-running interactive driver; not for CI.
+@pytest.mark.timeout(0)
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+async def test_cascade_console(runtime_env: RuntimeEnv, request):
+    """Long-running driver; teardown only on `cascade-inject quit` or Ctrl-C."""
+    baseline = int(request.config.getoption("--baseline-concurrency", default=8))
+
+    spec = DeploymentSpec(
+        "/workspace/tests/fault_tolerance/deploy/templates/vllm/"
+        "disagg_qwen3_30b_4p2d_2f.yaml"
+    )
+    spec.set_logging(True, "info")
+
+    log_collection_kwargs: dict[str, Any] = {
+        "pvc_size": "500Mi",
+        "container_log_dir": "/tmp/service_logs",
+    }
+    if runtime_env.storage_class:
+        log_collection_kwargs["storage_class"] = runtime_env.storage_class
+    if runtime_env.log_pvc:
+        log_collection_kwargs["pvc_name"] = runtime_env.log_pvc
+    spec.enable_log_collection(**log_collection_kwargs)
+    if runtime_env.model_pvc:
+        spec.enable_model_cache(runtime_env.model_pvc)
+
+    from tests.utils.test_output import resolve_test_output_path
+
+    log_dir = resolve_test_output_path("test_cascade_console")
+    test_logger = logging.getLogger("test_cascade_console")
+
+    test_logger.info("=" * 60)
+    test_logger.info("CASCADE CONSOLE — long-running driver")
+    test_logger.info("=" * 60)
+
+    async with ManagedDeployment(
+        namespace=runtime_env.namespace,
+        log_dir=log_dir,
+        deployment_spec=spec,
+        skip_service_restart=runtime_env.skip_service_restart,
+        reuse_log_pvc=bool(runtime_env.log_pvc),
+        model_pvc=runtime_env.model_pvc if runtime_env.prefetch_model else None,
+    ) as deployment:
+        ctx = ScenarioContext(
+            deployment=deployment,
+            events=[],
+            checks=[],
+            reports=[],
+            logger=test_logger,
+            namespace=runtime_env.namespace,
+            log_dir=log_dir,
+            resource_history=[],
+        )
+
+        await WaitForModelReady(timeout=1500).timed_execute(ctx)
+
+        console = CascadeConsole(
+            ctx=ctx,
+            dgd_name=spec.name,
+            baseline_concurrency=baseline,
+        )
+        await console.start_load(baseline)
+
+        test_logger.info(
+            f"=== console ready at {console.socket_path} ===\n"
+            f"=== `python -m tests.utils.cascade_inject status` to drive it ===\n"
+            f"=== `python -m tests.utils.cascade_inject quit` (or Ctrl-C) to stop ===\n"
+        )
+
+        await console.serve()
+
+        if console.current_load:
+            try:
+                await console.current_load.terminate()
+                await console.current_load._cleanup()
+            except Exception as e:
+                test_logger.warning(f"drain load failed: {e}")

--- a/tests/fault_tolerance/deploy/test_deployment.py
+++ b/tests/fault_tolerance/deploy/test_deployment.py
@@ -1,6 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# DEPRECATED: This module is part of the legacy test framework.
+# New tests should use the event-based framework in test_deployment_scenario.py.
+# See tests/fault_tolerance/deploy/TESTING.md for the reference guide.
+
 import asyncio
 import logging
 import multiprocessing

--- a/tests/fault_tolerance/deploy/test_deployment_scenario.py
+++ b/tests/fault_tolerance/deploy/test_deployment_scenario.py
@@ -1,0 +1,306 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Fault tolerance scenario tests.
+
+Uses the scenario framework to define and run tests with:
+- events: Actions to execute (StartLoad, Wait, DeletePod, etc.)
+- checks: Validations to run after events (ZeroErrors, MinRequests, etc.)
+- reports: Optional report generation after checks pass
+"""
+
+import pytest
+
+from tests.fault_tolerance.deploy.checks import (
+    MaxErrors,
+    MinRequests,
+    WasCancelled,
+    ZeroErrors,
+)
+from tests.fault_tolerance.deploy.events import (
+    DeletePod,
+    RollingUpgrade,
+    StartLoad,
+    StopLoad,
+    TerminateProcess,
+    Wait,
+    WaitForLoadCompletion,
+    WaitForRecovery,
+)
+from tests.fault_tolerance.deploy.scenario import run_scenario
+from tests.utils.managed_deployment import DeploymentSpec
+from tests.utils.managed_load import LoadConfig
+
+
+@pytest.mark.k8s
+@pytest.mark.e2e
+@pytest.mark.weekly
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+async def test_sanity_10_requests(
+    namespace, image, skip_service_restart, storage_class
+):
+    """
+    Sanity test: deploy, send 10 requests via aiperf, verify all succeed.
+
+    This is the simplest possible end-to-end test. It validates:
+    - Deployment comes up and becomes ready
+    - aiperf can reach the frontend and get responses
+    - All 10 requests complete without errors
+    - Results are collected from PVC
+    """
+    await run_scenario(
+        deployment_spec=DeploymentSpec.from_backend("trtllm", "agg"),
+        events=[
+            StartLoad(
+                load_config=LoadConfig(
+                    request_count=10,
+                    concurrency=2,
+                    input_tokens_mean=128,
+                    output_tokens_mean=32,
+                )
+            ),
+            WaitForLoadCompletion(),
+        ],
+        checks=[
+            WasCancelled(expected=False),
+            MinRequests(min_count=10),
+            ZeroErrors(),
+        ],
+        namespace=namespace,
+        image=image,
+        test_name="test_sanity_10_requests",
+        skip_service_restart=skip_service_restart,
+        storage_class=storage_class,
+    )
+
+
+@pytest.mark.k8s
+@pytest.mark.fault_tolerance
+@pytest.mark.e2e
+@pytest.mark.weekly
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+async def test_worker_pod_kill_recovery(
+    namespace, image, skip_service_restart, storage_class
+):
+    """
+    Test worker pod kill with recovery.
+
+    Scenario:
+    1. Start load
+    2. Kill worker pod
+    3. Wait for recovery
+    4. Stop load
+    5. Assert low errors
+    """
+    await run_scenario(
+        deployment_spec=DeploymentSpec.from_backend("trtllm", "disagg"),
+        events=[
+            StartLoad(load_config=LoadConfig(duration_minutes=5, concurrency=8)),
+            Wait(duration=30),
+            DeletePod(services=["TRTLLMWorker"]),
+            WaitForRecovery(timeout=300),
+            Wait(duration=30),
+            StopLoad(),
+        ],
+        checks=[
+            MaxErrors(max_errors=20),
+            MinRequests(min_count=50),
+        ],
+        namespace=namespace,
+        image=image,
+        test_name="test_worker_pod_kill_recovery",
+        skip_service_restart=skip_service_restart,
+        storage_class=storage_class,
+    )
+
+
+@pytest.mark.k8s
+@pytest.mark.e2e
+@pytest.mark.weekly
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+async def test_smoke_50_requests(namespace, image, skip_service_restart, storage_class):
+    """
+    Basic smoke test: 50 requests with no failures.
+    """
+    await run_scenario(
+        deployment_spec=DeploymentSpec.from_backend("trtllm", "agg"),
+        events=[
+            StartLoad(load_config=LoadConfig(request_count=50, concurrency=4)),
+            WaitForLoadCompletion(),
+        ],
+        checks=[
+            WasCancelled(expected=False),
+            MinRequests(min_count=50),
+            ZeroErrors(),
+        ],
+        namespace=namespace,
+        image=image,
+        test_name="test_smoke_50_requests",
+        skip_service_restart=skip_service_restart,
+        storage_class=storage_class,
+    )
+
+
+@pytest.mark.k8s
+@pytest.mark.fault_tolerance
+@pytest.mark.e2e
+@pytest.mark.weekly
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+async def test_rolling_upgrade_zero_errors(
+    namespace, image, skip_service_restart, storage_class
+):
+    """
+    Test rolling upgrade with zero errors.
+
+    Scenario:
+    1. Start continuous load
+    2. Rolling upgrade decode workers
+    3. Rolling upgrade prefill workers
+    4. Stop load
+    5. Assert zero errors
+    """
+    spec = DeploymentSpec.from_backend("trtllm", "disagg")
+    spec.set_worker_replicas(2)
+
+    await run_scenario(
+        deployment_spec=spec,
+        events=[
+            StartLoad(load_config=LoadConfig(duration_minutes=15, concurrency=8)),
+            Wait(duration=30),
+            RollingUpgrade(services=["TRTLLMDecodeWorker"]),
+            Wait(duration=30),
+            RollingUpgrade(services=["TRTLLMPrefillWorker"]),
+            Wait(duration=30),
+            StopLoad(),
+        ],
+        checks=[
+            ZeroErrors(),
+            MinRequests(min_count=100),
+        ],
+        namespace=namespace,
+        image=image,
+        test_name="test_rolling_upgrade_zero_errors",
+        skip_service_restart=skip_service_restart,
+        storage_class=storage_class,
+    )
+
+
+@pytest.mark.k8s
+@pytest.mark.fault_tolerance
+@pytest.mark.e2e
+@pytest.mark.weekly
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+@pytest.mark.parametrize(
+    "backend,deployment_type,worker_service,process_name,replicas",
+    [
+        # TensorRT-LLM configs
+        ("trtllm", "agg", "TRTLLMWorker", "dynamo.runtime", 1),
+        ("trtllm", "agg", "TRTLLMWorker", "dynamo.runtime", 2),
+        ("trtllm", "disagg", "TRTLLMDecodeWorker", "dynamo.runtime", 1),
+        ("trtllm", "disagg", "TRTLLMDecodeWorker", "dynamo.runtime", 2),
+        # vLLM configs
+        ("vllm", "agg", "VllmWorker", "dynamo.vllm", 1),
+        ("vllm", "agg", "VllmWorker", "dynamo.vllm", 2),
+        ("vllm", "disagg", "VllmDecodeWorker", "dynamo.vllm", 1),
+        ("vllm", "disagg", "VllmDecodeWorker", "dynamo.vllm", 2),
+    ],
+)
+async def test_engine_process_termination(
+    namespace,
+    image,
+    skip_service_restart,
+    storage_class,
+    backend,
+    deployment_type,
+    worker_service,
+    process_name,
+    replicas,
+):
+    """
+    Test engine process termination with recovery.
+
+    Terminates the main engine process (not the pod) and verifies recovery.
+    """
+    spec = DeploymentSpec.from_backend(backend, deployment_type)
+    spec.set_worker_replicas(replicas)
+
+    await run_scenario(
+        deployment_spec=spec,
+        events=[
+            StartLoad(load_config=LoadConfig(duration_minutes=5, concurrency=8)),
+            Wait(duration=30),
+            TerminateProcess(services=[worker_service], process_name=process_name),
+            WaitForRecovery(timeout=300),
+            Wait(duration=30),
+            StopLoad(),
+        ],
+        checks=[
+            MaxErrors(max_errors=20),
+            MinRequests(min_count=50),
+        ],
+        namespace=namespace,
+        image=image,
+        test_name=f"test_engine_process_termination[{backend}-{deployment_type}-{replicas}]",
+        skip_service_restart=skip_service_restart,
+        storage_class=storage_class,
+    )
+
+
+@pytest.mark.k8s
+@pytest.mark.fault_tolerance
+@pytest.mark.e2e
+@pytest.mark.weekly
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+@pytest.mark.parametrize(
+    "backend,deployment_type,replicas",
+    [
+        # TensorRT-LLM configs
+        ("trtllm", "agg", 1),
+        ("trtllm", "agg", 2),
+        ("trtllm", "disagg", 1),
+        ("trtllm", "disagg", 2),
+        # vLLM configs
+        ("vllm", "agg", 1),
+        ("vllm", "agg", 2),
+        ("vllm", "disagg", 1),
+        ("vllm", "disagg", 2),
+    ],
+)
+async def test_frontend_process_termination(
+    namespace,
+    image,
+    skip_service_restart,
+    storage_class,
+    backend,
+    deployment_type,
+    replicas,
+):
+    """
+    Test frontend process termination with recovery.
+
+    Terminates the frontend process and verifies recovery.
+    """
+    spec = DeploymentSpec.from_backend(backend, deployment_type)
+    spec.set_worker_replicas(replicas)
+
+    await run_scenario(
+        deployment_spec=spec,
+        events=[
+            StartLoad(load_config=LoadConfig(duration_minutes=5, concurrency=8)),
+            Wait(duration=30),
+            TerminateProcess(services=["Frontend"], process_name="python"),
+            WaitForRecovery(timeout=300),
+            Wait(duration=30),
+            StopLoad(),
+        ],
+        checks=[
+            MaxErrors(max_errors=20),
+            MinRequests(min_count=50),
+        ],
+        namespace=namespace,
+        image=image,
+        test_name=f"test_frontend_process_termination[{backend}-{deployment_type}-{replicas}]",
+        skip_service_restart=skip_service_restart,
+        storage_class=storage_class,
+    )

--- a/tests/fault_tolerance/deploy/test_deployment_scenario.py
+++ b/tests/fault_tolerance/deploy/test_deployment_scenario.py
@@ -13,9 +13,9 @@ Uses the scenario framework to define and run tests with:
 import pytest
 
 from tests.fault_tolerance.deploy.checks import (
+    LoadCompleted,
     MaxErrors,
     MinRequests,
-    WasCancelled,
     ZeroErrors,
 )
 from tests.fault_tolerance.deploy.events import (
@@ -63,7 +63,7 @@ async def test_sanity_10_requests(
             WaitForLoadCompletion(),
         ],
         checks=[
-            WasCancelled(expected=False),
+            LoadCompleted(),
             MinRequests(min_count=10),
             ZeroErrors(),
         ],
@@ -130,7 +130,7 @@ async def test_smoke_50_requests(namespace, image, skip_service_restart, storage
             WaitForLoadCompletion(),
         ],
         checks=[
-            WasCancelled(expected=False),
+            LoadCompleted(),
             MinRequests(min_count=50),
             ZeroErrors(),
         ],

--- a/tests/fault_tolerance/deploy/test_endurance.py
+++ b/tests/fault_tolerance/deploy/test_endurance.py
@@ -1,0 +1,188 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
+"""5-hour diurnal endurance — kv vs least-loaded router comparison.
+
+Continuous up-and-down load over 5 hours to simulate a real production
+day (morning ramp, midday peak, lunch dip, evening peak, cool-down).
+Run twice with different DYN_ROUTER_MODE in parallel namespaces to A/B
+compare kv-aware routing vs least-loaded on identical workload.
+
+Each diurnal segment is a separate AIPerf rung (closed-loop with optional
+concurrency-ramp), so the existing per-rung report panels light up
+naturally — one column per segment for every metric (KV usage, running,
+waiting, inflight, derived wait-for-remote).
+"""
+
+import logging
+
+import pytest
+
+from tests.fault_tolerance.deploy.checks import MinRequests
+from tests.fault_tolerance.deploy.events import (
+    StartLoad,
+    Wait,
+    WaitForLoadCompletion,
+    WaitForModelReady,
+)
+from tests.fault_tolerance.deploy.reports import (
+    ErrorBreakdownReport,
+    FaultToleranceReport,
+)
+from tests.fault_tolerance.deploy.scenario import run_scenario
+from tests.fault_tolerance.deploy.test_overload import (
+    _apply_cluster_portability,
+    _apply_router_config,
+    _apply_topology,
+    _load_dgd,
+)
+from tests.utils.managed_load import LoadConfig
+
+logger = logging.getLogger(__name__)
+
+
+_DGD = "disagg_qwen3_30b_unit_prod"
+
+# Production-shape ISL/OSL (matches test_overload _prod_load).
+_ISL_MEAN = 1600
+_OSL_MEAN = 200
+
+# Default diurnal curve — total 5 h. Each tuple is one rung:
+#   (segment_name, start_concurrency, end_concurrency, duration_minutes)
+# When start == end the rung is a flat hold; otherwise AIPerf ramps
+# closed-loop concurrency over `duration_minutes`.
+_DEFAULT_CURVE = [
+    ("morning-ramp", 4, 24, 30),
+    ("morning-climb", 24, 96, 30),
+    ("morning-sustain", 96, 96, 60),
+    ("lunch-dip", 96, 24, 30),
+    ("offpeak-hold", 24, 24, 60),
+    ("evening-climb", 24, 96, 30),
+    ("evening-sustain", 96, 96, 30),
+    ("cool-down", 96, 4, 30),
+]
+
+_DEFAULT_UNITS = 1
+_DEFAULT_FE = 1
+_DEFAULT_PF = 2
+_DEFAULT_DE = 1
+
+
+def _segment_load(
+    *, served_model: str, c_start: int, c_end: int, minutes: float
+) -> LoadConfig:
+    """One diurnal segment as an AIPerf LoadConfig."""
+    is_ramp = c_start != c_end
+    return LoadConfig(
+        model_name=served_model,
+        tokenizer=served_model,
+        input_tokens_mean=_ISL_MEAN,
+        input_tokens_stddev=200,
+        output_tokens_mean=_OSL_MEAN,
+        concurrency=c_end if is_ramp else c_start,
+        duration_minutes=minutes,
+        request_timeout_seconds=120,
+        streaming=True,
+        ignore_eos=True,
+        warmup_requests=0,
+        connection_reuse_strategy="never",
+        concurrency_ramp_duration=(minutes * 60) if is_ramp else None,
+        warmup_concurrency=c_start if is_ramp else None,
+        warmup_duration=0 if is_ramp else None,
+    )
+
+
+def _parse_curve(raw: str):
+    """`"name:c0:c1:min,name:c0:c1:min,..."` → list of tuples."""
+    out = []
+    for piece in raw.split(","):
+        parts = [p.strip() for p in piece.split(":")]
+        if len(parts) != 4:
+            raise ValueError(f"Bad curve segment {piece!r}; expect name:c0:c1:min")
+        out.append((parts[0], int(parts[1]), int(parts[2]), float(parts[3])))
+    return out
+
+
+def add_cli_options(parser):
+    g = parser.getgroup("endurance", "5h diurnal A/B endurance scenario")
+    # Note: --units is registered by test_overload (shared topology flag).
+    g.addoption(
+        "--endurance-curve",
+        type=str,
+        default=None,
+        help="Override curve as `name:c0:c1:min,...`. Default: built-in 5h diurnal.",
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.k8s
+@pytest.mark.fault_tolerance
+@pytest.mark.e2e
+@pytest.mark.weekly
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+async def test_endurance(runtime_env, request):
+    """Drive an 8-segment diurnal curve over 5h, capture per-rung metrics.
+
+    Run twice (different `--router-mode`, different `--namespace`) in
+    parallel to A/B compare kv-aware routing vs least-loaded under
+    realistic up-and-down workload.
+    """
+    cfg = request.config
+    image = cfg.getoption("--image") or "nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1"
+    units = cfg.getoption("--units")
+    raw_curve = cfg.getoption("--endurance-curve")
+    curve = _parse_curve(raw_curve) if raw_curve else _DEFAULT_CURVE
+
+    spec = _load_dgd(_DGD)
+    _apply_topology(spec, units=units, fe=_DEFAULT_FE, pf=_DEFAULT_PF, dec=_DEFAULT_DE)
+    for svc in ("Frontend", "VllmPrefillWorker", "VllmDecodeWorker"):
+        spec[svc].image = image
+    _apply_cluster_portability(spec)
+    _apply_router_config(spec, router_mode=cfg.getoption("--router-mode"))
+
+    model_cache_pvc = cfg.getoption("--model-cache-pvc")
+    if model_cache_pvc:
+        spec.enable_model_cache(model_cache_pvc)
+
+    served_model = spec["VllmDecodeWorker"].model
+
+    total_min = sum(seg[3] for seg in curve)
+    logger.info(
+        "test_endurance: units=%d segments=%d total=%.1f min router-mode=%s",
+        units,
+        len(curve),
+        total_min,
+        cfg.getoption("--router-mode"),
+    )
+
+    events: list = [WaitForModelReady(timeout=2400)]
+    for seg_name, c0, c1, minutes in curve:
+        events.append(
+            StartLoad(
+                load_config=_segment_load(
+                    served_model=served_model,
+                    c_start=c0,
+                    c_end=c1,
+                    minutes=minutes,
+                ),
+                name=seg_name,
+            )
+        )
+        events.append(WaitForLoadCompletion(name=seg_name))
+        events.append(Wait(duration=20))  # short gap for AIPerf cleanup
+
+    router = cfg.getoption("--router-mode") or "default"
+    await run_scenario(
+        deployment_spec=spec,
+        events=events,
+        checks=[
+            # Endurance soak — just confirm the load actually ran.
+            MinRequests(min_count=1000),
+        ],
+        reports=[
+            FaultToleranceReport(),
+            ErrorBreakdownReport(),
+        ],
+        test_name=f"test_endurance[u{units}-{router}]",
+        runtime_env=runtime_env,
+    )

--- a/tests/fault_tolerance/deploy/test_engine_kill_mocker.py
+++ b/tests/fault_tolerance/deploy/test_engine_kill_mocker.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Mocker-backed engine-kill fault test. SIGKILL the mocker process so
+# the kubelet restarts the same pod's container in place; the PVC tee
+# should produce a distinct log file per incarnation. Companion to
+# test_engine_kill_vllm.py.
+
+import pytest
+
+from tests.fault_tolerance.deploy.checks import LoadStopped, MaxErrors, MinRequests
+from tests.fault_tolerance.deploy.events import (
+    StartLoad,
+    StopLoad,
+    TerminateProcess,
+    Wait,
+    WaitForRecovery,
+)
+from tests.fault_tolerance.deploy.reports import FaultToleranceReport
+from tests.fault_tolerance.deploy.scenario import run_scenario
+from tests.utils.managed_deployment import DeploymentSpec
+from tests.utils.managed_load import LoadConfig
+
+
+@pytest.mark.k8s
+@pytest.mark.fault_tolerance
+@pytest.mark.e2e
+@pytest.mark.weekly
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+async def test_engine_kill_mocker(
+    namespace, image, skip_service_restart, storage_class
+):
+    """Kill the mocker engine process; pod stays, container restarts in place."""
+    spec = DeploymentSpec.from_backend("mocker", "agg")
+    spec["decode"].set_arg(
+        "--planner-profile-data",
+        "/workspace/tests/planner/profiling_results/H200_TP1P_TP1D",
+    )
+    spec["decode"].set_arg("--startup-time", "10")
+    served_model = spec["decode"].model
+
+    await run_scenario(
+        deployment_spec=spec,
+        events=[
+            StartLoad(
+                load_config=LoadConfig(
+                    model_name=served_model,
+                    tokenizer=served_model,
+                    duration_minutes=2,
+                    concurrency=4,
+                    input_tokens_mean=128,
+                    output_tokens_mean=32,
+                )
+            ),
+            Wait(duration=15),
+            TerminateProcess(
+                services=["decode"],
+                process_name="dynamo.mocker",
+                signal="SIGKILL",
+            ),
+            WaitForRecovery(timeout=120),
+            Wait(duration=20),
+            StopLoad(),
+        ],
+        checks=[
+            LoadStopped(),
+            MinRequests(min_count=20),
+            MaxErrors(max_errors=20),
+        ],
+        reports=[FaultToleranceReport()],
+        namespace=namespace,
+        image=image,
+        test_name="test_engine_kill_mocker",
+        skip_service_restart=skip_service_restart,
+        storage_class=storage_class,
+    )

--- a/tests/fault_tolerance/deploy/test_engine_kill_vllm.py
+++ b/tests/fault_tolerance/deploy/test_engine_kill_vllm.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# vllm engine-kill fault test. SIGKILL the dynamo.vllm process inside
+# the worker pod so kubelet restarts the container in place; pod IP is
+# preserved but vllm reload still dominates recovery (~90s). Companion
+# to test_engine_kill_mocker.py.
+
+import pytest
+
+from tests.fault_tolerance.deploy.checks import MaxErrors, MinRequests
+from tests.fault_tolerance.deploy.events import (
+    StartLoad,
+    StopLoad,
+    TerminateProcess,
+    Wait,
+    WaitForModelReady,
+    WaitForRecovery,
+)
+from tests.fault_tolerance.deploy.reports import (
+    ErrorBreakdownReport,
+    FaultToleranceReport,
+)
+from tests.fault_tolerance.deploy.scenario import run_scenario
+from tests.utils.managed_deployment import DeploymentSpec
+from tests.utils.managed_load import LoadConfig
+
+
+@pytest.mark.k8s
+@pytest.mark.fault_tolerance
+@pytest.mark.e2e
+@pytest.mark.weekly
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+async def test_engine_kill_vllm(namespace, image, skip_service_restart, storage_class):
+    spec = DeploymentSpec.from_backend("vllm", "agg")
+    served_model = spec["VllmDecodeWorker"].model
+
+    await run_scenario(
+        deployment_spec=spec,
+        events=[
+            WaitForModelReady(timeout=600),
+            StartLoad(
+                load_config=LoadConfig(
+                    model_name=served_model,
+                    tokenizer=served_model,
+                    duration_minutes=2,
+                    concurrency=4,
+                    input_tokens_mean=128,
+                    output_tokens_mean=32,
+                )
+            ),
+            Wait(duration=20),
+            TerminateProcess(
+                services=["VllmDecodeWorker"],
+                process_name="dynamo.vllm",
+                signal="SIGKILL",
+            ),
+            WaitForRecovery(timeout=300),
+            Wait(duration=20),
+            StopLoad(),
+        ],
+        checks=[
+            MinRequests(min_count=20),
+            MaxErrors(max_errors=1_000_000),
+        ],
+        reports=[FaultToleranceReport(), ErrorBreakdownReport()],
+        namespace=namespace,
+        image=image,
+        test_name="test_engine_kill_vllm",
+        skip_service_restart=skip_service_restart,
+        storage_class=storage_class,
+    )

--- a/tests/fault_tolerance/deploy/test_engine_stall_mocker.py
+++ b/tests/fault_tolerance/deploy/test_engine_stall_mocker.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Mocker-backed engine-stall fault test. SIGSTOP the mocker process so
+# the worker stops servicing requests but the pod, container, and TCP
+# connections all stay alive. After 20s the process is SIGCONT'd and
+# normal service resumes. This exercises the "hung worker" path
+# (frontend sees idle sockets, no crash, no reconnect) rather than the
+# "crash + reload" path of TerminateProcess. Companion to
+# test_engine_stall_vllm.py.
+
+import pytest
+
+from tests.fault_tolerance.deploy.checks import LoadStopped, MaxErrors, MinRequests
+from tests.fault_tolerance.deploy.events import StallProcess, StartLoad, StopLoad, Wait
+from tests.fault_tolerance.deploy.reports import (
+    ErrorBreakdownReport,
+    FaultToleranceReport,
+)
+from tests.fault_tolerance.deploy.scenario import run_scenario
+from tests.utils.managed_deployment import DeploymentSpec
+from tests.utils.managed_load import LoadConfig
+
+
+@pytest.mark.k8s
+@pytest.mark.fault_tolerance
+@pytest.mark.e2e
+@pytest.mark.weekly
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+async def test_engine_stall_mocker(
+    namespace, image, skip_service_restart, storage_class
+):
+    """Pause the mocker engine process for 20s; expect inflight requests
+    to back up at the frontend, then resume cleanly when SIGCONT lands."""
+    spec = DeploymentSpec.from_backend("mocker", "agg")
+    spec["decode"].set_arg(
+        "--planner-profile-data",
+        "/workspace/tests/planner/profiling_results/H200_TP1P_TP1D",
+    )
+    # Tighten aiperf's request timeout so in-flight requests fail fast
+    # while the worker is paused, instead of hanging the full scenario.
+    served_model = spec["decode"].model
+
+    await run_scenario(
+        deployment_spec=spec,
+        events=[
+            StartLoad(
+                load_config=LoadConfig(
+                    model_name=served_model,
+                    tokenizer=served_model,
+                    duration_minutes=2,
+                    concurrency=4,
+                    input_tokens_mean=128,
+                    output_tokens_mean=32,
+                    request_timeout_seconds=10,
+                )
+            ),
+            Wait(duration=15),
+            StallProcess(
+                services=["decode"],
+                process_name="dynamo.mocker",
+                duration=20,
+            ),
+            Wait(duration=10),  # observe recovery after SIGCONT
+            StopLoad(),
+        ],
+        checks=[
+            LoadStopped(),
+            MinRequests(min_count=20),
+            # Cap permissive: the point is the FT report, not an SLA on errors.
+            MaxErrors(max_errors=1_000_000),
+        ],
+        reports=[FaultToleranceReport(), ErrorBreakdownReport()],
+        namespace=namespace,
+        image=image,
+        test_name="test_engine_stall_mocker",
+        skip_service_restart=skip_service_restart,
+        storage_class=storage_class,
+    )

--- a/tests/fault_tolerance/deploy/test_engine_stall_vllm.py
+++ b/tests/fault_tolerance/deploy/test_engine_stall_vllm.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# vllm engine-stall fault test. SIGSTOP the dynamo.vllm process for
+# 20s — the worker stops responding but the pod, container, and TCP
+# request-plane sockets all stay alive. SIGCONT resumes normal
+# service. Tests how the frontend handles a "hung" worker (idle
+# sockets, no crash, no reconnect) — distinct from the crash + reload
+# path of test_engine_kill_vllm. Companion to test_engine_stall_mocker.py.
+
+import pytest
+
+from tests.fault_tolerance.deploy.checks import LoadStopped, MaxErrors, MinRequests
+from tests.fault_tolerance.deploy.events import (
+    StallProcess,
+    StartLoad,
+    StopLoad,
+    Wait,
+    WaitForModelReady,
+)
+from tests.fault_tolerance.deploy.reports import (
+    ErrorBreakdownReport,
+    FaultToleranceReport,
+)
+from tests.fault_tolerance.deploy.scenario import run_scenario
+from tests.utils.managed_deployment import DeploymentSpec
+from tests.utils.managed_load import LoadConfig
+
+
+@pytest.mark.k8s
+@pytest.mark.fault_tolerance
+@pytest.mark.e2e
+@pytest.mark.weekly
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+async def test_engine_stall_vllm(namespace, image, skip_service_restart, storage_class):
+    spec = DeploymentSpec.from_backend("vllm", "agg")
+    served_model = spec["VllmDecodeWorker"].model
+
+    await run_scenario(
+        deployment_spec=spec,
+        events=[
+            WaitForModelReady(timeout=600),
+            StartLoad(
+                load_config=LoadConfig(
+                    model_name=served_model,
+                    tokenizer=served_model,
+                    duration_minutes=2,
+                    concurrency=4,
+                    input_tokens_mean=128,
+                    output_tokens_mean=32,
+                    request_timeout_seconds=10,
+                )
+            ),
+            Wait(duration=15),
+            StallProcess(
+                services=["VllmDecodeWorker"],
+                process_name="dynamo.vllm",
+                duration=20,
+            ),
+            Wait(duration=10),
+            StopLoad(),
+        ],
+        checks=[
+            LoadStopped(),
+            MinRequests(min_count=20),
+            MaxErrors(max_errors=1_000_000),
+        ],
+        reports=[FaultToleranceReport(), ErrorBreakdownReport()],
+        namespace=namespace,
+        image=image,
+        test_name="test_engine_stall_vllm",
+        skip_service_restart=skip_service_restart,
+        storage_class=storage_class,
+    )

--- a/tests/fault_tolerance/deploy/test_managed_deployment_teardown.py
+++ b/tests/fault_tolerance/deploy/test_managed_deployment_teardown.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Cancel-path teardown tests for ManagedDeployment.
+
+A SIGTERM / Ctrl-C / runner-cancel must tear the deployment down via
+``__aexit__`` (extract logs, delete the DGD, close the ApiClient) instead of
+stranding the deployment + leaking an "Unclosed connector". These tests stub
+the kubernetes I/O so no real cluster is touched, then assert the cleanup path
+runs under cancellation.
+"""
+import asyncio
+import logging
+import signal
+import types
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tests.utils.managed_deployment import ManagedDeployment
+
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.unit,
+    pytest.mark.pre_merge,
+    pytest.mark.gpu_0,
+    pytest.mark.parallel,
+]
+
+
+def _make_managed_deployment(tmp_path):
+    """A ManagedDeployment with every cluster-touching method stubbed."""
+    spec = types.SimpleNamespace(name="test-dgd", namespace="test-ns")
+    md = ManagedDeployment(
+        namespace="test-ns",
+        log_dir=str(tmp_path),
+        deployment_spec=spec,
+        skip_service_restart=True,
+    )
+    for name in (
+        "_init_kubernetes",
+        "_scrub_namespace",
+        "_restart_etcd",
+        "_restart_nats",
+        "_create_log_collection_pvc",
+        "_prefetch_models",
+        "_create_deployment",
+        "_wait_for_ready",
+        "_capture_metrics",
+        "_cleanup_orphaned_jobs",
+        "_cleanup_log_collection_pvc",
+        "_extract_logs_from_pvc",
+        "_delete_deployment",
+    ):
+        setattr(md, name, AsyncMock(name=name))
+    md._get_service_logs = MagicMock(name="_get_service_logs")
+    md._logger = logging.getLogger("test-md")
+    # _init_kubernetes is stubbed, so plant the ApiClient ourselves to verify
+    # __aexit__ closes it (the "Unclosed connector" fix).
+    md._api_client = AsyncMock(name="api_client")
+    return md
+
+
+async def test_cancel_during_body_runs_full_cleanup(tmp_path):
+    """Cancelling the task in the ``async with`` body must still extract logs,
+    delete the DGD, and close the client — not strand the run."""
+    md = _make_managed_deployment(tmp_path)
+    api_client = md._api_client
+    entered = asyncio.Event()
+
+    async def body():
+        async with md:
+            entered.set()
+            await asyncio.sleep(60)  # block until cancelled
+
+    task = asyncio.create_task(body())
+    await asyncio.wait_for(entered.wait(), timeout=5)
+
+    # What loop.add_signal_handler(SIGTERM, ...) would invoke on a real kill.
+    md._on_cancel_signal(signal.SIGTERM)
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    md._extract_logs_from_pvc.assert_awaited()  # logs preserved before delete
+    md._delete_deployment.assert_awaited()  # DGD removed
+    api_client.close.assert_awaited()  # no leaked aiohttp connector
+
+
+async def test_repeat_signal_is_one_shot(tmp_path):
+    """A second signal during teardown must be a no-op: cancel exactly once,
+    never re-cancel or fall through to the default terminate action."""
+    md = _make_managed_deployment(tmp_path)
+    md._main_task = MagicMock()
+    md._cancelling = False
+
+    md._on_cancel_signal(signal.SIGTERM)
+    md._on_cancel_signal(signal.SIGTERM)
+    md._on_cancel_signal(signal.SIGINT)
+
+    md._main_task.cancel.assert_called_once()
+
+
+async def test_normal_exit_still_cleans_up(tmp_path):
+    """The happy path (no cancel) must still extract + delete + close."""
+    md = _make_managed_deployment(tmp_path)
+    api_client = md._api_client
+
+    async with md:
+        pass
+
+    md._extract_logs_from_pvc.assert_awaited()
+    md._delete_deployment.assert_awaited()
+    api_client.close.assert_awaited()

--- a/tests/fault_tolerance/deploy/test_network_partition_mocker.py
+++ b/tests/fault_tolerance/deploy/test_network_partition_mocker.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Mocker-backed network-partition fault test. NetworkPolicy +
+# conntrack flush sever the Frontend<->decode TCP request plane for
+# ~20s; the policy is lifted automatically when the partition's
+# duration expires. Validates the framework's NetworkPartition event
+# and the report's pre/post bucketing for transient partitions.
+# Companion to test_network_partition_vllm.py.
+
+import pytest
+
+from tests.fault_tolerance.deploy.checks import LoadStopped, MaxErrors, MinRequests
+from tests.fault_tolerance.deploy.events import (
+    NetworkPartition,
+    StartLoad,
+    StopLoad,
+    Wait,
+)
+from tests.fault_tolerance.deploy.reports import (
+    ErrorBreakdownReport,
+    FaultToleranceReport,
+)
+from tests.fault_tolerance.deploy.scenario import run_scenario
+from tests.utils.managed_deployment import DeploymentSpec
+from tests.utils.managed_load import LoadConfig
+
+
+@pytest.mark.k8s
+@pytest.mark.fault_tolerance
+@pytest.mark.e2e
+@pytest.mark.weekly
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+async def test_network_partition_mocker(
+    namespace, image, skip_service_restart, storage_class
+):
+    """Block Frontend -> decode mid-load; verify it surfaces in the report."""
+    spec = DeploymentSpec.from_backend("mocker", "agg")
+    spec["decode"].set_arg(
+        "--planner-profile-data",
+        "/workspace/tests/planner/profiling_results/H200_TP1P_TP1D",
+    )
+    # Shorten the frontend's per-request inactivity timeout. Default is
+    # unset (= no timeout, frontend buffers forever — masks the partition
+    # at aiperf level). Setting this to 5s makes push_router give up after
+    # 5s of silence from the worker and quarantine the instance, so
+    # in-flight requests fail fast and follow-on requests see 5xx.
+    spec["Frontend"].set_env_var("DYN_HTTP_BACKEND_STREAM_TIMEOUT_SECS", "5")
+    served_model = spec["decode"].model
+
+    await run_scenario(
+        deployment_spec=spec,
+        events=[
+            StartLoad(
+                load_config=LoadConfig(
+                    model_name=served_model,
+                    tokenizer=served_model,
+                    duration_minutes=2,
+                    concurrency=4,
+                    input_tokens_mean=128,
+                    output_tokens_mean=32,
+                    # Tighten aiperf's request timeout so even if the
+                    # frontend buffers, in-flight requests give up
+                    # comfortably before the 20s partition lifts.
+                    request_timeout_seconds=10,
+                    # Force a fresh TCP connection per request so the
+                    # NetworkPolicy applied mid-load actually rejects
+                    # new flows instead of being bypassed by an existing
+                    # conntrack-tracked socket.
+                    connection_reuse_strategy="never",
+                )
+            ),
+            Wait(duration=15),
+            # Transient: partition fires, holds for 20s, heals — all
+            # inside the single event. No separate "remove" step needed.
+            NetworkPartition(source="Frontend", target="decode", duration=20),
+            Wait(duration=10),  # observe recovery after the partition heals
+            StopLoad(),
+        ],
+        checks=[
+            LoadStopped(),
+            MinRequests(min_count=20),
+            # With conntrack flush the partition severs established
+            # sockets and aiperf hammers the closed connection for 20s.
+            # The point of the test is to demonstrate the rupture and
+            # recovery, not to bound errors precisely — keep the cap
+            # permissive.
+            MaxErrors(max_errors=1_000_000),
+        ],
+        reports=[FaultToleranceReport(), ErrorBreakdownReport()],
+        namespace=namespace,
+        image=image,
+        test_name="test_network_partition_mocker",
+        skip_service_restart=skip_service_restart,
+        storage_class=storage_class,
+    )

--- a/tests/fault_tolerance/deploy/test_network_partition_vllm.py
+++ b/tests/fault_tolerance/deploy/test_network_partition_vllm.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# vllm network-partition fault test. NetworkPolicy + conntrack flush
+# sever Frontend<->VllmDecodeWorker for 20s, then the partition lifts
+# automatically. The worker keeps running but is unreachable from the
+# frontend during the window. Companion to test_network_partition_mocker.py.
+
+import pytest
+
+from tests.fault_tolerance.deploy.checks import LoadStopped, MaxErrors, MinRequests
+from tests.fault_tolerance.deploy.events import (
+    NetworkPartition,
+    StartLoad,
+    StopLoad,
+    Wait,
+    WaitForModelReady,
+)
+from tests.fault_tolerance.deploy.reports import (
+    ErrorBreakdownReport,
+    FaultToleranceReport,
+)
+from tests.fault_tolerance.deploy.scenario import run_scenario
+from tests.utils.managed_deployment import DeploymentSpec
+from tests.utils.managed_load import LoadConfig
+
+
+@pytest.mark.k8s
+@pytest.mark.fault_tolerance
+@pytest.mark.e2e
+@pytest.mark.weekly
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+async def test_network_partition_vllm(
+    namespace, image, skip_service_restart, storage_class
+):
+    spec = DeploymentSpec.from_backend("vllm", "agg")
+    spec["Frontend"].set_env_var("DYN_HTTP_BACKEND_STREAM_TIMEOUT_SECS", "5")
+    served_model = spec["VllmDecodeWorker"].model
+
+    await run_scenario(
+        deployment_spec=spec,
+        events=[
+            WaitForModelReady(timeout=600),
+            StartLoad(
+                load_config=LoadConfig(
+                    model_name=served_model,
+                    tokenizer=served_model,
+                    duration_minutes=2,
+                    concurrency=4,
+                    input_tokens_mean=128,
+                    output_tokens_mean=32,
+                    request_timeout_seconds=10,
+                    # Force a fresh TCP connection per request so the
+                    # NetworkPolicy applied mid-load actually rejects
+                    # new flows instead of being bypassed by an existing
+                    # conntrack-tracked socket.
+                    connection_reuse_strategy="never",
+                )
+            ),
+            Wait(duration=15),
+            NetworkPartition(
+                source="Frontend",
+                target="VllmDecodeWorker",
+                duration=20,
+            ),
+            Wait(duration=10),
+            StopLoad(),
+        ],
+        checks=[
+            LoadStopped(),
+            MinRequests(min_count=20),
+            MaxErrors(max_errors=1_000_000),
+        ],
+        reports=[FaultToleranceReport(), ErrorBreakdownReport()],
+        namespace=namespace,
+        image=image,
+        test_name="test_network_partition_vllm",
+        skip_service_restart=skip_service_restart,
+        storage_class=storage_class,
+    )

--- a/tests/fault_tolerance/deploy/test_overload.py
+++ b/tests/fault_tolerance/deploy/test_overload.py
@@ -165,7 +165,13 @@ def _apply_router_config(
 
 def _apply_cluster_portability(spec):
     """Pod-security + memory-budget tweaks that make this DGD run cleanly on
-    aks-dev (A100-80GB) and aws-dev-02 (H100-80GB) shared clusters."""
+    aks-dev (A100-80GB) and aws-dev-02 (H100-80GB) shared clusters.
+
+    Includes image-pull-secret wiring: aws-dev-02's `default` SA only carries
+    `acr-token-secret` (a controller resets the list on any add). We tack on
+    `ngc-pull-secret` per-service so private nvcr.io/nvidian/* images pull
+    cleanly. The secret is harmless on clusters that don't have it (k8s
+    silently ignores unknown imagePullSecrets in pod specs)."""
     # Pin Frontend to A100/H100 node pool with the GPU toleration so the
     # operator's default CPU scheduling doesn't land it on a small node.
     fe = spec["Frontend"]._spec.setdefault("extraPodSpec", {})
@@ -175,6 +181,14 @@ def _apply_cluster_portability(spec):
             {"key": "nvidia.com/gpu", "operator": "Exists", "effect": "NoSchedule"},
         ],
     )
+
+    # Add NGC private-org pull secret on every service. Default SA is reset
+    # by a controller on shared clusters; per-pod secrets bypass that.
+    for svc in ("Frontend", "VllmPrefillWorker", "VllmDecodeWorker"):
+        eps = spec[svc]._spec.setdefault("extraPodSpec", {})
+        ips = eps.setdefault("imagePullSecrets", [])
+        if not any(s.get("name") == "ngc-pull-secret" for s in ips):
+            ips.append({"name": "ngc-pull-secret"})
 
     # Full unprivileged-bypass for UCX/NIXL on cri-containerd AppArmor +
     # 64KB memlock default (OPS-4332).

--- a/tests/fault_tolerance/deploy/test_overload.py
+++ b/tests/fault_tolerance/deploy/test_overload.py
@@ -206,6 +206,21 @@ def _apply_cluster_portability(spec):
         caps.setdefault("add", []).append("IPC_LOCK")
         spec[svc].set_env_var("DYN_TEST_MEMLOCK_UNLIMITED", "1")
 
+    # Pod-level fsGroup=1000 on every service: k8s recursively chowns the
+    # mounted PVC to gid 1000 (the `dynamo` user's group in the runtime
+    # image) and SGID-bits the directories. That way, when one pod
+    # (workers, running as root) creates the per-test sub-path on a
+    # reused log PVC, the other pods (Frontend, running as uid=1000) can
+    # still write under it as group members. Avoids the perm-collision
+    # race described in dynamo-observe/.../2026-05-03-cascade-repro-results/.
+    for svc in ("Frontend", "VllmPrefillWorker", "VllmDecodeWorker"):
+        pod_sec = (
+            spec[svc]
+            ._spec.setdefault("extraPodSpec", {})
+            .setdefault("securityContext", {})
+        )
+        pod_sec.setdefault("fsGroup", 1000)
+
     # Prod runs A100-40GB; both shared clusters above run 80GB cards.
     # Halve gpu-memory-utilization to match prod KV envelope.
     for svc in ("VllmPrefillWorker", "VllmDecodeWorker"):
@@ -332,16 +347,16 @@ async def test_decode_overload(runtime_env, request):
         events=events,
         checks=[
             LoadApplied(load_name=final, min_requests=100),
-            LoadCompleted(load_name=final),
+            LoadCompleted(name=final),
             _PerPodKvImbalanceGap(services=["VllmDecodeWorker"]),
-            # Report-only goodput / SLA observations.
-            SlaViolation(
-                services=["VllmDecodeWorker"], load_name=final, acceptable=True
-            ),
+            # Report-only goodput / SLA observations. SlaViolation reads
+            # aiperf summary p99s on the named load; ServiceLogPatternRate
+            # scans frontend logs for the 504 / inter-token-latency signal.
+            SlaViolation(load_name=final, e2e_p99_ms=30000, ttft_p99_ms=10000),
             ServiceLogPatternRate(
                 services=["Frontend"],
                 pattern=r"504|GatewayTimeout|inter.token.latency",
-                acceptable=True,
+                min_rate_per_sec=0.0,
             ),
             WorkerPanics(
                 services=["VllmDecodeWorker", "VllmPrefillWorker", "Frontend"],

--- a/tests/fault_tolerance/deploy/test_overload.py
+++ b/tests/fault_tolerance/deploy/test_overload.py
@@ -1,0 +1,319 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Overload and cascade scenarios. Each test reproduces one well-defined
+# failure shape under load. Reports per-pod KV imbalance, goodput, and
+# error breakdown every run.
+#
+# Run a single scenario:
+#     uv run pytest test_overload.py::test_decode_overload \
+#       --namespace neelays-test --storage-class azurefile-csi-premium \
+#       --overload-image nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1 -s -v
+
+import os
+from dataclasses import dataclass
+
+import pytest
+
+from tests.fault_tolerance.deploy.checks import (
+    Check,
+    LoadApplied,
+    LoadCompleted,
+    RestartCountIncreased,
+    ServiceLogPatternRate,
+    SlaViolation,
+    WorkerPanics,
+    _iter_server_metric,
+)
+from tests.fault_tolerance.deploy.events import (
+    StartLoad,
+    Wait,
+    WaitForLoadCompletion,
+    WaitForModelReady,
+)
+from tests.fault_tolerance.deploy.reports import (
+    ErrorBreakdownReport,
+    ErrorTrackingReport,
+    FaultToleranceReport,
+    PerWorkerLatencyReport,
+)
+from tests.fault_tolerance.deploy.scenario import run_scenario
+from tests.utils.managed_deployment import DeploymentSpec
+from tests.utils.managed_load import LoadConfig
+
+# ─── DGD ──────────────────────────────────────────────────────────────
+# The seed DGD all scenarios use. To run against a different DGD, either
+# edit this line or override via `--overload-dgd <name>` on the CLI.
+dgd = "disagg_qwen3_30b_unit_prod"
+
+_DEFAULT_IMAGE = "nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1"
+
+# Prod-shaped traffic distribution (ISL/OSL pairs, from the 2026-05-16
+# reproducer). Same as the n3 routing-threshold test.
+_PROD_SEQ_DIST = "100,200:5;500,200:15;1000,200:20;1600,200:30;3400,200:20;7000,200:10"
+_NUM_PREFIX_PROMPTS = 15
+_PREFIX_PROMPT_LENGTH = 600
+
+# Default rung ladder. Overridable via --overload-rungs.
+_DEFAULT_RUNGS = "72,216,432"
+_DEFAULT_RUNG_MINUTES = 5.0
+
+
+# ─── CLI ──────────────────────────────────────────────────────────────
+def add_cli_options(parser):
+    """Called from the deploy conftest's pytest_addoption."""
+    g = parser.getgroup("overload", "Overload scenarios (test_overload.py)")
+    g.addoption(
+        "--overload-image",
+        default=_DEFAULT_IMAGE,
+        help=f"vllm-runtime image to test against. Default: {_DEFAULT_IMAGE}",
+    )
+    g.addoption(
+        "--overload-dgd",
+        default=dgd,
+        help=f"DGD template basename under templates/vllm/. Default: {dgd}",
+    )
+    g.addoption(
+        "--overload-units",
+        type=int,
+        default=3,
+        help="Convenience: scale frontend/prefill/decode together (prod-unit "
+        "replicas). Default 3 (3F : 6P : 3D = 18 GPUs).",
+    )
+    g.addoption(
+        "--overload-frontend-replicas",
+        type=int,
+        default=None,
+        help="Override frontend replicas (takes precedence over --overload-units).",
+    )
+    g.addoption(
+        "--overload-prefill-replicas",
+        type=int,
+        default=None,
+        help="Override prefill replicas (takes precedence over --overload-units).",
+    )
+    g.addoption(
+        "--overload-decode-replicas",
+        type=int,
+        default=None,
+        help="Override decode replicas (takes precedence over --overload-units).",
+    )
+    g.addoption(
+        "--overload-rungs",
+        default=_DEFAULT_RUNGS,
+        help=f"Comma-separated concurrency rungs. Default: {_DEFAULT_RUNGS}",
+    )
+    g.addoption(
+        "--overload-rung-minutes",
+        type=float,
+        default=_DEFAULT_RUNG_MINUTES,
+        help=f"Minutes per rung. Default: {_DEFAULT_RUNG_MINUTES}",
+    )
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────
+def _load_dgd(name: str) -> DeploymentSpec:
+    """Resolve a DGD basename to a DeploymentSpec."""
+    path = os.path.join(os.path.dirname(__file__), "templates", "vllm", f"{name}.yaml")
+    return DeploymentSpec(path)
+
+
+def _apply_topology(spec, units, fe, pf, dec):
+    """Set per-service replicas. Per-component overrides win over `units`."""
+    base = {
+        "Frontend": spec["Frontend"].replicas,
+        "VllmPrefillWorker": spec["VllmPrefillWorker"].replicas,
+        "VllmDecodeWorker": spec["VllmDecodeWorker"].replicas,
+    }
+    spec["Frontend"].replicas = fe if fe is not None else base["Frontend"] * units
+    spec["VllmPrefillWorker"].replicas = (
+        pf if pf is not None else base["VllmPrefillWorker"] * units
+    )
+    spec["VllmDecodeWorker"].replicas = (
+        dec if dec is not None else base["VllmDecodeWorker"] * units
+    )
+
+
+def _apply_cluster_portability(spec):
+    """Pod-security + memory-budget tweaks that make this DGD run cleanly on
+    aks-dev (A100-80GB) and aws-dev-02 (H100-80GB) shared clusters."""
+    # Pin Frontend to A100/H100 node pool with the GPU toleration so the
+    # operator's default CPU scheduling doesn't land it on a small node.
+    fe = spec["Frontend"]._spec.setdefault("extraPodSpec", {})
+    fe.setdefault(
+        "tolerations",
+        [
+            {"key": "nvidia.com/gpu", "operator": "Exists", "effect": "NoSchedule"},
+        ],
+    )
+
+    # Full unprivileged-bypass for UCX/NIXL on cri-containerd AppArmor +
+    # 64KB memlock default (OPS-4332).
+    for svc in ("VllmPrefillWorker", "VllmDecodeWorker"):
+        main = (
+            spec[svc]
+            ._spec.setdefault("extraPodSpec", {})
+            .setdefault("mainContainer", {})
+        )
+        secctx = main.setdefault("securityContext", {})
+        secctx["privileged"] = True
+        secctx["runAsUser"] = 0
+        secctx["appArmorProfile"] = {"type": "Unconfined"}
+        caps = secctx.setdefault("capabilities", {})
+        caps.setdefault("add", []).append("IPC_LOCK")
+        spec[svc].set_env_var("DYN_TEST_MEMLOCK_UNLIMITED", "1")
+
+    # Prod runs A100-40GB; both shared clusters above run 80GB cards.
+    # Halve gpu-memory-utilization to match prod KV envelope.
+    for svc in ("VllmPrefillWorker", "VllmDecodeWorker"):
+        spec[svc].set_arg("--gpu-memory-utilization", "0.5")
+
+
+def _parse_rungs(raw):
+    """`"72,216,432"` → `[(name, conc), ...]`. Names are `c<N>`."""
+    out = []
+    for piece in raw.split(","):
+        c = int(piece.strip())
+        out.append((f"c{c}", c))
+    return out
+
+
+def _prod_load(*, served_model, concurrency, duration_minutes, name):
+    return LoadConfig(
+        model_name=served_model,
+        tokenizer=served_model,
+        seq_dist=_PROD_SEQ_DIST,
+        num_prefix_prompts=_NUM_PREFIX_PROMPTS,
+        prefix_prompt_length=_PREFIX_PROMPT_LENGTH,
+        concurrency=concurrency,
+        duration_minutes=duration_minutes,
+        request_timeout_seconds=20,
+        streaming=True,
+        ignore_eos=True,
+        warmup_requests=0,
+        connection_reuse_strategy="never",
+        goodput=["request_latency:20000"],
+    )
+
+
+@dataclass
+class _PerPodKvImbalanceGap(Check):
+    """Report-only check that computes the per-pod max(KV-cache-usage) gap
+    across the named services. Logged for evidence; never raises."""
+
+    services: list
+
+    def validate(self, ctx) -> None:
+        peaks: dict = {}
+        for _ts, pod, val in _iter_server_metric(ctx, "vllm:kv_cache_usage_perc"):
+            cur = peaks.get(pod)
+            if cur is None or val > cur:
+                peaks[pod] = val
+        if len(peaks) < 2:
+            ctx.logger.warning(
+                f"_PerPodKvImbalanceGap: only {len(peaks)} pods observed; "
+                f"cannot compute imbalance"
+            )
+            return
+        vals = list(peaks.values())
+        gap = max(vals) - min(vals)
+        ctx.logger.info(
+            f"_PerPodKvImbalanceGap: per-pod KV peaks={peaks} "
+            f"max={max(vals):.3f} min={min(vals):.3f} gap={gap:.3f}"
+        )
+
+    @property
+    def description(self) -> str:
+        return f"Per-pod KV peak gap across {', '.join(self.services)} (report-only)"
+
+
+# ─── Scenario ─────────────────────────────────────────────────────────
+@pytest.mark.k8s
+@pytest.mark.e2e
+@pytest.mark.weekly
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+async def test_decode_overload(runtime_env, request):
+    """Drive prod-shaped load past sustainable concurrency; observe
+    per-pod KV imbalance and goodput collapse on the decode pool.
+
+    No fault injection — this is the natural-cascade scenario. Same
+    function exercises both 'bug' and 'fix' images: against an image
+    without the per-worker admission-threshold patch (PR #9692) the
+    per-pod KV peaks spread out and goodput drops; against an image with
+    the patch, the spread tightens and goodput holds longer.
+
+    CLI flags: --overload-image, --overload-units (or per-component
+    replica overrides), --overload-rungs, --overload-rung-minutes,
+    --overload-dgd.
+    """
+    cfg = request.config
+    image = cfg.getoption("--overload-image")
+    dgd_name = cfg.getoption("--overload-dgd")
+    units = cfg.getoption("--overload-units")
+    fe = cfg.getoption("--overload-frontend-replicas")
+    pf = cfg.getoption("--overload-prefill-replicas")
+    dec = cfg.getoption("--overload-decode-replicas")
+    rungs = _parse_rungs(cfg.getoption("--overload-rungs"))
+    rung_minutes = cfg.getoption("--overload-rung-minutes")
+
+    spec = _load_dgd(dgd_name)
+    _apply_topology(spec, units=units, fe=fe, pf=pf, dec=dec)
+
+    for svc in ("Frontend", "VllmPrefillWorker", "VllmDecodeWorker"):
+        spec[svc].image = image
+
+    _apply_cluster_portability(spec)
+
+    served_model = spec["VllmDecodeWorker"].model
+
+    events: list = [WaitForModelReady(timeout=2400)]
+    for name, conc in rungs:
+        events.append(
+            StartLoad(
+                load_config=_prod_load(
+                    served_model=served_model,
+                    concurrency=conc,
+                    duration_minutes=rung_minutes,
+                    name=name,
+                ),
+                name=name,
+            )
+        )
+        events.append(WaitForLoadCompletion(name=name))
+        events.append(Wait(duration=30))
+
+    final = rungs[-1][0]
+    await run_scenario(
+        deployment_spec=spec,
+        events=events,
+        checks=[
+            LoadApplied(load_name=final, min_requests=100),
+            LoadCompleted(load_name=final),
+            _PerPodKvImbalanceGap(services=["VllmDecodeWorker"]),
+            # Report-only goodput / SLA observations.
+            SlaViolation(
+                services=["VllmDecodeWorker"], load_name=final, acceptable=True
+            ),
+            ServiceLogPatternRate(
+                services=["Frontend"],
+                pattern=r"504|GatewayTimeout|inter.token.latency",
+                acceptable=True,
+            ),
+            WorkerPanics(
+                services=["VllmDecodeWorker", "VllmPrefillWorker", "Frontend"],
+                acceptable=True,
+            ),
+            RestartCountIncreased(
+                services=["VllmDecodeWorker", "Frontend"],
+                expect_min_increment=0,
+            ),
+        ],
+        reports=[
+            FaultToleranceReport(),
+            ErrorBreakdownReport(),
+            PerWorkerLatencyReport(),
+            ErrorTrackingReport(),
+        ],
+        test_name=request.node.name,
+        runtime_env=runtime_env,
+    )

--- a/tests/fault_tolerance/deploy/test_overload.py
+++ b/tests/fault_tolerance/deploy/test_overload.py
@@ -48,8 +48,8 @@ dgd = "disagg_qwen3_30b_unit_prod"
 
 _DEFAULT_IMAGE = "nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1"
 
-# Prod-shaped traffic distribution (ISL/OSL pairs, from the 2026-05-16
-# reproducer). Same as the n3 routing-threshold test.
+# Production-shaped traffic distribution (ISL/OSL pairs with realistic
+# long-tail mix). Same distribution as the n3 routing-threshold test.
 _PROD_SEQ_DIST = "100,200:5;500,200:15;1000,200:20;1600,200:30;3400,200:20;7000,200:10"
 _NUM_PREFIX_PROMPTS = 15
 _PREFIX_PROMPT_LENGTH = 600
@@ -106,6 +106,27 @@ def add_cli_options(parser):
         type=float,
         default=_DEFAULT_RUNG_MINUTES,
         help=f"Minutes per rung. Default: {_DEFAULT_RUNG_MINUTES}",
+    )
+    g.addoption(
+        "--router-mode",
+        default="kv",
+        choices=[
+            "kv",
+            "least-loaded",
+            "round-robin",
+            "random",
+            "power-of-two",
+            "direct",
+        ],
+        help="Router mode applied to Frontend (DYN_ROUTER_MODE). Default: kv",
+    )
+    g.addoption(
+        "--model-cache-pvc",
+        default="",
+        help="Mount this RWX PVC on workers as the HuggingFace model cache "
+        "(skips re-downloading 30+GB model weights on every pod restart). "
+        "On aws-dev-02 the conventional name is 'shared-model-cache' (already "
+        "provisioned in neelays-test and neelays-test-b). Empty string disables.",
     )
 
 
@@ -206,13 +227,16 @@ def _apply_cluster_portability(spec):
         caps.setdefault("add", []).append("IPC_LOCK")
         spec[svc].set_env_var("DYN_TEST_MEMLOCK_UNLIMITED", "1")
 
-    # Pod-level fsGroup=1000 on every service: k8s recursively chowns the
-    # mounted PVC to gid 1000 (the `dynamo` user's group in the runtime
-    # image) and SGID-bits the directories. That way, when one pod
-    # (workers, running as root) creates the per-test sub-path on a
-    # reused log PVC, the other pods (Frontend, running as uid=1000) can
-    # still write under it as group members. Avoids the perm-collision
-    # race described in dynamo-observe/.../2026-05-03-cascade-repro-results/.
+    # Pod-level fsGroup=1000 on every service + Frontend runAsUser=0.
+    # The prior working DGD (dynamo-observe/.../2026-05-03-cascade-repro-
+    # results/) set BOTH. Reasoning:
+    #   - fsGroup=1000 makes k8s recursively chown the mounted volume to
+    #     gid 1000 (dynamo user's group) and SGID-bit the dirs — but
+    #     that's only group membership; write is still owner-only under
+    #     default umask 022 (mode 755).
+    #   - To actually let Frontend write under root-owned parent dirs
+    #     created by workers (which need runAsUser=0 for UCX/IB), the
+    #     Frontend must also be root. fsGroup is then defense-in-depth.
     for svc in ("Frontend", "VllmPrefillWorker", "VllmDecodeWorker"):
         pod_sec = (
             spec[svc]
@@ -220,6 +244,12 @@ def _apply_cluster_portability(spec):
             .setdefault("securityContext", {})
         )
         pod_sec.setdefault("fsGroup", 1000)
+    fe_main = (
+        spec["Frontend"]
+        ._spec.setdefault("extraPodSpec", {})
+        .setdefault("mainContainer", {})
+    )
+    fe_main.setdefault("securityContext", {})["runAsUser"] = 0
 
     # Prod runs A100-40GB; both shared clusters above run 80GB cards.
     # Halve gpu-memory-utilization to match prod KV envelope.
@@ -321,7 +351,11 @@ async def test_decode_overload(runtime_env, request):
         spec[svc].image = image
 
     _apply_cluster_portability(spec)
-    _apply_router_config(spec)
+    _apply_router_config(spec, router_mode=cfg.getoption("--router-mode"))
+
+    model_cache_pvc = cfg.getoption("--model-cache-pvc")
+    if model_cache_pvc:
+        spec.enable_model_cache(model_cache_pvc)
 
     served_model = spec["VllmDecodeWorker"].model
 

--- a/tests/fault_tolerance/deploy/test_overload.py
+++ b/tests/fault_tolerance/deploy/test_overload.py
@@ -8,7 +8,7 @@
 # Run a single scenario:
 #     uv run pytest test_overload.py::test_decode_overload \
 #       --namespace neelays-test --storage-class azurefile-csi-premium \
-#       --overload-image nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1 -s -v
+#       --image nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1 -s -v
 
 import os
 from dataclasses import dataclass
@@ -43,7 +43,7 @@ from tests.utils.managed_load import LoadConfig
 
 # ─── DGD ──────────────────────────────────────────────────────────────
 # The seed DGD all scenarios use. To run against a different DGD, either
-# edit this line or override via `--overload-dgd <name>` on the CLI.
+# edit this line or override via `--dgd <name>` on the CLI.
 dgd = "disagg_qwen3_30b_unit_prod"
 
 _DEFAULT_IMAGE = "nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1"
@@ -54,57 +54,55 @@ _PROD_SEQ_DIST = "100,200:5;500,200:15;1000,200:20;1600,200:30;3400,200:20;7000,
 _NUM_PREFIX_PROMPTS = 15
 _PREFIX_PROMPT_LENGTH = 600
 
-# Default rung ladder. Overridable via --overload-rungs.
+# Default rung ladder. Overridable via --rungs.
 _DEFAULT_RUNGS = "72,216,432"
 _DEFAULT_RUNG_MINUTES = 5.0
 
 
 # ─── CLI ──────────────────────────────────────────────────────────────
+# Image override comes from the framework-shared --image flag (already
+# registered by tests/conftest.py and the deploy conftest). Test reads
+# it via request.config.getoption("--image") with a 1.1.1 fallback.
 def add_cli_options(parser):
     """Called from the deploy conftest's pytest_addoption."""
     g = parser.getgroup("overload", "Overload scenarios (test_overload.py)")
     g.addoption(
-        "--overload-image",
-        default=_DEFAULT_IMAGE,
-        help=f"vllm-runtime image to test against. Default: {_DEFAULT_IMAGE}",
-    )
-    g.addoption(
-        "--overload-dgd",
+        "--dgd",
         default=dgd,
         help=f"DGD template basename under templates/vllm/. Default: {dgd}",
     )
     g.addoption(
-        "--overload-units",
+        "--units",
         type=int,
         default=3,
         help="Convenience: scale frontend/prefill/decode together (prod-unit "
         "replicas). Default 3 (3F : 6P : 3D = 18 GPUs).",
     )
     g.addoption(
-        "--overload-frontend-replicas",
+        "--frontend-replicas",
         type=int,
         default=None,
-        help="Override frontend replicas (takes precedence over --overload-units).",
+        help="Override frontend replicas (takes precedence over --units).",
     )
     g.addoption(
-        "--overload-prefill-replicas",
+        "--prefill-replicas",
         type=int,
         default=None,
-        help="Override prefill replicas (takes precedence over --overload-units).",
+        help="Override prefill replicas (takes precedence over --units).",
     )
     g.addoption(
-        "--overload-decode-replicas",
+        "--decode-replicas",
         type=int,
         default=None,
-        help="Override decode replicas (takes precedence over --overload-units).",
+        help="Override decode replicas (takes precedence over --units).",
     )
     g.addoption(
-        "--overload-rungs",
+        "--rungs",
         default=_DEFAULT_RUNGS,
         help=f"Comma-separated concurrency rungs. Default: {_DEFAULT_RUNGS}",
     )
     g.addoption(
-        "--overload-rung-minutes",
+        "--rung-minutes",
         type=float,
         default=_DEFAULT_RUNG_MINUTES,
         help=f"Minutes per rung. Default: {_DEFAULT_RUNG_MINUTES}",
@@ -132,6 +130,37 @@ def _apply_topology(spec, units, fe, pf, dec):
     spec["VllmDecodeWorker"].replicas = (
         dec if dec is not None else base["VllmDecodeWorker"] * units
     )
+
+
+def _apply_router_config(
+    spec,
+    *,
+    decode_blocks_threshold: str = "0.85",
+    prefill_tokens_threshold_frac: str = "0.85",
+    router_mode: str = "kv",
+    overlap_score_weight: str = "0.0",
+    temperature: str = "0.0",
+    use_kv_events: str = "false",
+) -> None:
+    """Apply the final-recommended router config to the Frontend spec.
+
+    Defaults match the recipe from the 2026-05-16 cascade-reproducer doc
+    (and the joint thread close-out): per-worker admission thresholds
+    enabled at 0.85, KV-aware routing with prefix-cache weight zeroed,
+    deterministic argmin selection, no KV events. The same config is
+    applied to every comparison arm — the diff between arms is purely
+    the image (1.1.1 baseline vs 1.1.2-test with the routing fix), not
+    the router knobs.
+    """
+    fe = spec["Frontend"]
+    fe.set_env_var("DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD", decode_blocks_threshold)
+    fe.set_env_var(
+        "DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC", prefill_tokens_threshold_frac
+    )
+    fe.set_env_var("DYN_ROUTER_MODE", router_mode)
+    fe.set_env_var("DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT", overlap_score_weight)
+    fe.set_env_var("DYN_ROUTER_TEMPERATURE", temperature)
+    fe.set_env_var("DYN_ROUTER_USE_KV_EVENTS", use_kv_events)
 
 
 def _apply_cluster_portability(spec):
@@ -247,14 +276,14 @@ async def test_decode_overload(runtime_env, request):
     --overload-dgd.
     """
     cfg = request.config
-    image = cfg.getoption("--overload-image")
-    dgd_name = cfg.getoption("--overload-dgd")
-    units = cfg.getoption("--overload-units")
-    fe = cfg.getoption("--overload-frontend-replicas")
-    pf = cfg.getoption("--overload-prefill-replicas")
-    dec = cfg.getoption("--overload-decode-replicas")
-    rungs = _parse_rungs(cfg.getoption("--overload-rungs"))
-    rung_minutes = cfg.getoption("--overload-rung-minutes")
+    image = cfg.getoption("--image") or _DEFAULT_IMAGE
+    dgd_name = cfg.getoption("--dgd")
+    units = cfg.getoption("--units")
+    fe = cfg.getoption("--frontend-replicas")
+    pf = cfg.getoption("--prefill-replicas")
+    dec = cfg.getoption("--decode-replicas")
+    rungs = _parse_rungs(cfg.getoption("--rungs"))
+    rung_minutes = cfg.getoption("--rung-minutes")
 
     spec = _load_dgd(dgd_name)
     _apply_topology(spec, units=units, fe=fe, pf=pf, dec=dec)
@@ -263,6 +292,7 @@ async def test_decode_overload(runtime_env, request):
         spec[svc].image = image
 
     _apply_cluster_portability(spec)
+    _apply_router_config(spec)
 
     served_model = spec["VllmDecodeWorker"].model
 

--- a/tests/fault_tolerance/deploy/test_overload.py
+++ b/tests/fault_tolerance/deploy/test_overload.py
@@ -17,15 +17,25 @@ import pytest
 
 from tests.fault_tolerance.deploy.checks import (
     Check,
+    CliffContained,
+    CliffPropagated,
+    GenerationThroughputDropped,
+    KvCacheUsagePeak,
     LoadApplied,
     LoadCompleted,
+    NixlXferTimeMultiplied,
+    PinningContained,
+    PodMemoryGrowth,
+    RejectionFired,
     RestartCountIncreased,
     ServiceLogPatternRate,
     SlaViolation,
+    WaitingForKVTransferExceeds,
     WorkerPanics,
     _iter_server_metric,
 )
 from tests.fault_tolerance.deploy.events import (
+    PodMemoryPoller,
     StartLoad,
     Wait,
     WaitForLoadCompletion,
@@ -39,7 +49,7 @@ from tests.fault_tolerance.deploy.reports import (
 )
 from tests.fault_tolerance.deploy.scenario import run_scenario
 from tests.utils.managed_deployment import DeploymentSpec
-from tests.utils.managed_load import LoadConfig
+from tests.utils.managed_load import LoadConfig, WorkerPin
 
 # ─── DGD ──────────────────────────────────────────────────────────────
 # The seed DGD all scenarios use. To run against a different DGD, either
@@ -153,6 +163,74 @@ def _apply_topology(spec, units, fe, pf, dec):
     )
 
 
+def _apply_recommended_kv_router_config(spec) -> None:
+    """Apply the canonical A4 "recommended KV-aware" Frontend config.
+
+    This is the **prescribed production config** from the prior
+    KV-pressure cascade analysis (§A4 — `Recommendations —
+    Without code change`). Pure-load steering with cross-FE visibility:
+    KV-aware routing mode + zeroed prefix-cache scoring + cross-FE
+    replica sync. The combination closes BOTH LeastLoaded blind spots
+    (per-worker `_avail` vs `_free`, AND cross-FE-pod) at the cost of
+    no code change.
+
+    All env-var names and defaults were verified against the **v1.1.1
+    release tag** of ai-dynamo/dynamo at
+    ``components/src/dynamo/common/configuration/groups/kv_router_args.py``
+    and ``components/src/dynamo/frontend/frontend_args.py``. Every
+    value below is explicitly set even where it matches the v1.1.1
+    default so the test asserts a known-good config rather than
+    relying on shifting defaults across releases.
+
+    Cost-function logit walked through in the cascade analysis
+    (selector.rs:166-167)::
+
+        logit = prefill_load_scale × adjusted_prefill_blocks + decode_blocks
+              = 1.0 × 0 + active_decode_blocks      (overlap_weight=0)
+              = active_decode_blocks                 (argmin = least-loaded)
+
+    The two cost-function weights the cascade analysis mentions but
+    that aren't env-var-exposed in v1.1.1 — ``host_cache_hit_weight``
+    (default 0.75) and ``disk_cache_hit_weight`` (default 0.25) — are
+    multiplied through the overlap term, so with
+    ``DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT=0.0`` they contribute zero to
+    the logit regardless of their values. Leaving them at defaults is
+    correct for this config.
+    """
+    fe = spec["Frontend"]
+    # Routing mode (frontend_args.py) — KV-aware is the only mode where
+    # the load signal flows across all FE pods via the event plane.
+    fe.set_env_var("DYN_ROUTER_MODE", "kv")
+    # Pure-load steering: zero out prefix-cache scoring contribution.
+    fe.set_env_var("DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT", "0.0")
+    # No KV-cache event consumption from workers — router predicts
+    # cache state from its own routing decisions. The active_decode_blocks
+    # load signal flows regardless (via ActiveSequenceEvent on the event
+    # plane, not via vLLM KV-cache events).
+    fe.set_env_var("DYN_ROUTER_USE_KV_EVENTS", "false")
+    # **Critical**: cross-FE replica sync. v1.1.1 default is False, which
+    # leaves each FE blind to its peers' routing decisions — the exact
+    # mechanism that caused the the cross-FE cascade propagation.
+    fe.set_env_var("DYN_ROUTER_REPLICA_SYNC", "true")
+    # Deterministic argmin (no softmax-sampling exploration). Default 0,
+    # set explicitly for clarity.
+    fe.set_env_var("DYN_ROUTER_TEMPERATURE", "0.0")
+    # Active-block tracking MUST be on for the load signal. Default true,
+    # set explicitly.
+    fe.set_env_var("DYN_ROUTER_TRACK_ACTIVE_BLOCKS", "true")
+    # With overlap_weight=0 the router doesn't do prefix matching, so
+    # disable KV-reuse hash tracking to suppress the radix-tree warning
+    # storm observed at 1,200/s on a heavily-loaded pod. v1.1.1 default is
+    # True — recommendation flips it.
+    fe.set_env_var("DYN_ROUTER_ASSUME_KV_REUSE", "false")
+    # Admission shedding thresholds — the all-busy 503 floor. Activates
+    # the shedding code already in v1.1.0 (PR #7617/#7912/#8413, whose
+    # defaults are permissive sentinels). v1.1.1 defaults: 1.0 and 10.0
+    # respectively — both effectively off without these explicit sets.
+    fe.set_env_var("DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD", "0.85")
+    fe.set_env_var("DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC", "0.85")
+
+
 def _apply_router_config(
     spec,
     *,
@@ -165,7 +243,7 @@ def _apply_router_config(
 ) -> None:
     """Apply the final-recommended router config to the Frontend spec.
 
-    Defaults match the recipe from the 2026-05-16 cascade-reproducer doc
+    Defaults match the recipe from the prior cascade-reproducer doc
     (and the joint thread close-out): per-worker admission thresholds
     enabled at 0.85, KV-aware routing with prefix-cache weight zeroed,
     deterministic argmin selection, no KV events. The same config is
@@ -406,6 +484,1596 @@ async def test_decode_overload(runtime_env, request):
             ErrorBreakdownReport(),
             PerWorkerLatencyReport(),
             ErrorTrackingReport(),
+        ],
+        test_name=request.node.name,
+        runtime_env=runtime_env,
+    )
+
+
+# ─── Cascade-repro scenarios (cascade reproduction) ─────────────────────────
+# These tests reproduce the cascade-failure regime on a
+# small dev pool. Source spec lives in GitLab `neelays/dynamo-observe`
+# under the cascade-small-pool reproducer scenarios/
+# (FRAMEWORK_TASK.md + PLAN.md).
+#
+# Reuses the existing disagg_qwen3_30b_unit_prod template. The only
+# cascade-specific deltas are applied via _apply_cascade_dgd below
+# (k8s-discovery envs needed for WorkerPin, NIXL abort timer, image).
+
+_CASCADE_IMAGE = "nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1"
+
+
+def _apply_cascade_dgd(
+    spec,
+    *,
+    image: str,
+    units: int,
+    abort_timeout_s: int = 480,
+    vllm_extra_args: list[str] | None = None,
+    override_worker_knobs: str | None = None,
+):
+    """Cascade-specific overrides on top of disagg_qwen3_30b_unit_prod.
+
+    Adds the three Dynamo runtime envs required for the k8s-native
+    discovery path (so each worker pod publishes a
+    ``DynamoWorkerMetadata`` CR that ``WorkerPin`` can resolve), pins
+    the NIXL abort timer, and forces the image. ``_apply_cluster_portability``
+    and ``_apply_router_config`` are intentionally NOT called here —
+    callers compose them at the test site, same as ``test_decode_overload``.
+
+    ``vllm_extra_args``: optional list of vLLM CLI args (e.g.
+    ``["--max-num-seqs", "128"]``) appended to BOTH ``VllmPrefillWorker``
+    and ``VllmDecodeWorker``'s ``extraPodSpec.mainContainer.args``. Used
+    by the cascade fail-fast S2 / S3 experiments (2026-05-26 handoff) to
+    cap engine running-batch size and starve the cascade at the source.
+    Existing args are left untouched; if a flag is already present, the
+    helper overwrites its value (via ``ServiceSpec.set_arg``).
+
+    ``override_worker_knobs``: optional inline knob string with the same
+    semicolon-separated KEY=VALUE format as the ``DYN_TEST_WORKER_KNOBS``
+    env. When set, it WINS over the env var so per-row knob variations
+    (S3 combo: 64/16 vs S1 spike: 128/32) can be expressed in the
+    parametrize tuple directly instead of forking the launcher.
+    """
+    _apply_topology(spec, units=units, fe=None, pf=None, dec=None)
+    for svc in ("Frontend", "VllmPrefillWorker", "VllmDecodeWorker"):
+        spec[svc].image = image
+        spec[svc].set_env_var("DYN_EVENT_PLANE", "zmq")
+        spec[svc].set_env_var("DYN_DISCOVERY_BACKEND", "kubernetes")
+        spec[svc].set_env_var("DYN_STORE_KV", "mem")
+    for svc in ("VllmPrefillWorker", "VllmDecodeWorker"):
+        spec[svc].set_env_var("VLLM_NIXL_ABORT_REQUEST_TIMEOUT", str(abort_timeout_s))
+
+    # Per-test admission-control knobs. Set via env at launch time so a
+    # single test function can drive the cascade matrix from observe's
+    # 5-hr-burst handoff (DIS-2105 needs DYN_TCP_WORK_QUEUE_SIZE, PR #9858
+    # needs DYN_VLLM_REJECT_QUEUE_THRESHOLD; baseline gets neither).
+    # Format: semicolon-separated KEY=VALUE list. Empty → no overrides.
+    # Example: DYN_TEST_WORKER_KNOBS="DYN_TCP_WORK_QUEUE_SIZE=256;DYN_VLLM_REJECT_QUEUE_THRESHOLD=80"
+    knob_source = (
+        override_worker_knobs
+        if override_worker_knobs is not None
+        else os.environ.get("DYN_TEST_WORKER_KNOBS", "")
+    )
+    extra = (knob_source or "").strip()
+    if extra:
+        for kv in extra.split(";"):
+            kv = kv.strip()
+            if not kv or "=" not in kv:
+                continue
+            key, val = kv.split("=", 1)
+            for svc in ("VllmPrefillWorker", "VllmDecodeWorker"):
+                spec[svc].set_env_var(key.strip(), val.strip())
+
+    # Worker-side vLLM CLI extras (e.g. --max-num-seqs cap). Parsed in
+    # flag/value pairs and pushed through ServiceSpec.set_arg so an
+    # already-present flag is updated in place rather than appended
+    # twice. Lone flags (no value) get an empty string value, matching
+    # set_arg's behaviour for repeated flags.
+    if vllm_extra_args:
+        i = 0
+        flat_pairs: list[tuple[str, str]] = []
+        while i < len(vllm_extra_args):
+            arg = vllm_extra_args[i]
+            if i + 1 < len(vllm_extra_args) and not vllm_extra_args[i + 1].startswith(
+                "-"
+            ):
+                flat_pairs.append((arg, vllm_extra_args[i + 1]))
+                i += 2
+            else:
+                flat_pairs.append((arg, ""))
+                i += 1
+        for svc in ("VllmPrefillWorker", "VllmDecodeWorker"):
+            for flag, value in flat_pairs:
+                spec[svc].set_arg(flag, value)
+
+
+def _cascade_load(
+    *,
+    served_model: str,
+    concurrency: int,
+    duration_minutes: float,
+    name: str,
+    isl: int = 2000,
+    osl: int = 200,
+    worker_pin: WorkerPin | None = None,
+    request_cancellation_rate: float | None = None,
+) -> LoadConfig:
+    """LoadConfig shared by the cascade scenarios.
+
+    Defaults match the FRAMEWORK_TASK §3.1 spec: no warmup-requests, fresh
+    sockets per request (so any disconnect actually closes the underlying
+    TCP), goodput SLO at 20s e2e latency. ISL/OSL default to a
+    steady-state production-shape pair; override per-scenario.
+
+    ``request_cancellation_rate`` (0.0-1.0, optional): pass to AIPerf so a
+    fraction of requests get mid-flight client disconnects. Used by S1's
+    cliff rung to exercise the ``_DeferredAbort`` path + 480-s NIXL abort
+    timer — without cancellations to feed the path, the timer never fires
+    and we can't claim production-parity recovery behaviour. Per observe-
+    agent NEXT_STEPS_FOR_TEST_AGENT P0.2 (sanity-suite work).
+    """
+    return LoadConfig(
+        model_name=served_model,
+        tokenizer=served_model,
+        input_tokens_mean=isl,
+        input_tokens_stddev=max(1, isl // 10),
+        output_tokens_mean=osl,
+        output_tokens_stddev=max(1, osl // 10),
+        num_prefix_prompts=8,
+        prefix_prompt_length=512,
+        concurrency=concurrency,
+        duration_minutes=duration_minutes,
+        # 40s per observe NEXT_STEPS — last cycle's cliff p99 was ~21s and
+        # the old 20s timeout truncated slow-but-real 503 responses, making
+        # it impossible to tell "rejection fired slowly" from "didn't fire".
+        request_timeout_seconds=40,
+        streaming=True,
+        ignore_eos=True,
+        warmup_requests=0,
+        connection_reuse_strategy="never",
+        goodput=["request_latency:20000"],
+        worker_pin=worker_pin,
+        request_cancellation_rate=request_cancellation_rate,
+    )
+
+
+@pytest.mark.k8s
+@pytest.mark.e2e
+@pytest.mark.sanity
+@pytest.mark.weekly  # Lifecycle category required by report_pytest_markers
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+@pytest.mark.parametrize(
+    "concurrency,isl,duration_min",
+    [
+        # Default: cliff in ~90s at c=128 ISL=6000, hold 5 min.
+        (128, 6000, 5),
+    ],
+)
+async def test_overload_cascade_sanity_pinned(
+    runtime_env, request, concurrency, isl, duration_min
+):
+    """S0a — pinned single-pod cascade sanity (~7 min after model load).
+
+    Smallest, fastest reproduction of the per-pod cliff. Pins every
+    request to ``VllmDecodeWorker#0`` + ``VllmPrefillWorker#0`` via
+    ``nvext.worker_id`` (resolved at execute-time from the live
+    ``DynamoWorkerMetadata`` CRs). No warmup — straight to overload so
+    KV pegs within 2 min. The 5-min hold is enough to observe the
+    cascade signature without burning GPU time.
+
+    Pass = the per-pod cliff mechanism is reachable on this dev cluster.
+    Failure = stop and debug before spending budget on the full S1 demo.
+    """
+    cfg = request.config
+    image = cfg.getoption("--image") or _CASCADE_IMAGE
+
+    spec = _load_dgd("disagg_qwen3_30b_unit_prod")
+    _apply_cascade_dgd(spec, image=image, units=1, abort_timeout_s=480)
+    _apply_cluster_portability(spec)
+    # Don't call _apply_router_config — its admission-threshold defaults
+    # (0.85) would shed load before the cliff fires. The cascade plan
+    # leaves them unset so the FE inherits v1.1.1's permissive-sentinel
+    # defaults. Set only the router-mode + KV-events knobs directly.
+    # Under pinning the routing mode is moot; least-loaded matches S1.
+    spec["Frontend"].set_env_var("DYN_ROUTER_MODE", "least-loaded")
+    spec["Frontend"].set_env_var("DYN_ROUTER_USE_KV_EVENTS", "false")
+
+    model_cache_pvc = cfg.getoption("--model-cache-pvc")
+    if model_cache_pvc:
+        spec.enable_model_cache(model_cache_pvc)
+
+    served_model = spec["VllmDecodeWorker"].model
+
+    events = [
+        WaitForModelReady(timeout=2400),
+        StartLoad(
+            load_config=_cascade_load(
+                served_model=served_model,
+                concurrency=concurrency,
+                duration_minutes=duration_min,
+                name="cliff",
+                isl=isl,
+                worker_pin=WorkerPin(
+                    decode_service="VllmDecodeWorker",
+                    decode_replica_index=0,
+                    prefill_service="VllmPrefillWorker",
+                    prefill_replica_index=0,
+                ),
+            ),
+            name="cliff",
+        ),
+        WaitForLoadCompletion(name="cliff"),
+    ]
+
+    checks = [
+        LoadApplied(load_name="cliff", min_requests=100),
+        LoadCompleted(name="cliff"),
+        KvCacheUsagePeak(
+            services=["VllmDecodeWorker"],
+            threshold=0.95,
+            within_seconds=180,
+            load_name="cliff",
+        ),
+        WaitingForKVTransferExceeds(
+            services=["VllmDecodeWorker"],
+            threshold=50,
+            load_name="cliff",
+        ),
+        NixlXferTimeMultiplied(
+            services=["VllmDecodeWorker"],
+            min_multiplier=3.0,
+            warmup_seconds=30,
+            cliff_load_name="cliff",
+        ),
+        GenerationThroughputDropped(
+            services=["VllmDecodeWorker"],
+            min_drop_frac=0.30,
+            warmup_seconds=60,
+            cliff_window_seconds=120,
+            cliff_load_name="cliff",
+        ),
+        CliffContained(
+            services=["VllmDecodeWorker"],
+            pinned_service="VllmDecodeWorker",
+            pinned_replica_index=0,
+            kv_threshold=0.85,
+            peer_max_kv=0.50,
+            load_name="cliff",
+        ),
+        # Prefill containment — the real pinning test at units=1. There
+        # are 2 prefill replicas; pinning to #0 should leave #1 with
+        # zero requests-running peak. If peer prefill ever saw any
+        # in-flight requests, the nvext.worker_id pin leaked.
+        PinningContained(
+            services=["VllmPrefillWorker"],
+            pinned_service="VllmPrefillWorker",
+            pinned_replica_index=0,
+            metric="vllm:num_requests_running",
+            active_threshold=1.0,
+            peer_max=0.0,
+            load_name="cliff",
+        ),
+        # Decode containment via the same primitive — redundant with the
+        # CliffContained KV-pressure assertion at units=1 (single
+        # replica), but the assertion shape future-proofs the test if a
+        # follow-up scenario raises decode replicas while keeping the pin.
+        PinningContained(
+            services=["VllmDecodeWorker"],
+            pinned_service="VllmDecodeWorker",
+            pinned_replica_index=0,
+            metric="vllm:num_requests_running",
+            active_threshold=1.0,
+            peer_max=0.0,
+            load_name="cliff",
+        ),
+        WorkerPanics(
+            services=["VllmDecodeWorker", "VllmPrefillWorker", "Frontend"],
+            acceptable=True,
+        ),
+        RestartCountIncreased(
+            services=["VllmDecodeWorker", "Frontend"],
+            expect_min_increment=0,
+        ),
+    ]
+
+    await run_scenario(
+        deployment_spec=spec,
+        events=events,
+        checks=checks,
+        reports=[
+            FaultToleranceReport(),
+            ErrorBreakdownReport(),
+            PerWorkerLatencyReport(),
+        ],
+        test_name=request.node.name,
+        runtime_env=runtime_env,
+    )
+
+
+# ─── S0b — natural-routing minimum sanity (~10 min after model load) ───
+@pytest.mark.k8s
+@pytest.mark.e2e
+@pytest.mark.sanity
+@pytest.mark.weekly  # Lifecycle category required by report_pytest_markers
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+@pytest.mark.parametrize(
+    "units,warmup_c,cliff_c,duration_min",
+    [
+        # Default: 1-min warmup @ c=64 + 8-min hold @ c=160 on N=2 units
+        # (2F+4P+2D = 12 GPUs). c=160 across 2 decodes ≈ 80 concurrent per
+        # decode, slightly above S1's per-decode ~72 to compress wall time.
+        (2, 64, 160, 8),
+    ],
+)
+async def test_overload_cascade_sanity_natural(
+    runtime_env, request, units, warmup_c, cliff_c, duration_min
+):
+    """S0b — natural-routing minimum-topology cascade sanity (~10 min).
+
+    Smallest topology with multiple decodes + multiple FEs (N=2) that
+    proves natural LeastLoaded routing reaches the cliff regime on this
+    dev cluster. Compressed: 1-min warmup, 8-min cliff hold.
+
+    Pass = at least one decode pegs KV ≥ 0.95 under natural routing.
+    Full peer-decode infection is NOT asserted at this duration — the
+    LeastLoaded cross-FE blind spot may not propagate in 8 min, and
+    that's fine for sanity. CliffPropagated is S1's job.
+    """
+    cfg = request.config
+    image = cfg.getoption("--image") or _CASCADE_IMAGE
+
+    spec = _load_dgd("disagg_qwen3_30b_unit_prod")
+    _apply_cascade_dgd(spec, image=image, units=units, abort_timeout_s=480)
+    _apply_cluster_portability(spec)
+    # Same router knob set as S0a — natural LeastLoaded routing, no
+    # admission thresholds, no KV events. Distinguishes S0a (pinned) from
+    # S0b: only the absence of WorkerPin on the load is different.
+    spec["Frontend"].set_env_var("DYN_ROUTER_MODE", "least-loaded")
+    spec["Frontend"].set_env_var("DYN_ROUTER_USE_KV_EVENTS", "false")
+
+    model_cache_pvc = cfg.getoption("--model-cache-pvc")
+    if model_cache_pvc:
+        spec.enable_model_cache(model_cache_pvc)
+
+    served_model = spec["VllmDecodeWorker"].model
+
+    events = [
+        WaitForModelReady(timeout=2400),
+        # Sub-cliff warmup rung — proves the cluster is healthy under
+        # bounded load and establishes a baseline window for
+        # NixlXferTimeMultiplied.
+        StartLoad(
+            load_config=_cascade_load(
+                served_model=served_model,
+                concurrency=warmup_c,
+                duration_minutes=1,
+                name="warmup",
+            ),
+            name="warmup",
+        ),
+        WaitForLoadCompletion(name="warmup"),
+        Wait(duration=15),
+        # Cliff rung — natural routing decides which decode tips first.
+        StartLoad(
+            load_config=_cascade_load(
+                served_model=served_model,
+                concurrency=cliff_c,
+                duration_minutes=duration_min,
+                name="cliff",
+            ),
+            name="cliff",
+        ),
+        WaitForLoadCompletion(name="cliff"),
+    ]
+
+    checks = [
+        LoadApplied(load_name="cliff", min_requests=200),
+        LoadCompleted(name="cliff"),
+        # At least one decode must peg KV — but we don't assert WHICH one
+        # (natural routing decides). within_seconds=240 measured from
+        # cliff-rung start (KvCacheUsagePeak uses per-pod first-sample-of-load).
+        KvCacheUsagePeak(
+            services=["VllmDecodeWorker"],
+            threshold=0.95,
+            within_seconds=240,
+            load_name="cliff",
+        ),
+        WaitingForKVTransferExceeds(
+            services=["VllmDecodeWorker"],
+            threshold=100,
+            load_name="cliff",
+        ),
+        NixlXferTimeMultiplied(
+            services=["VllmDecodeWorker"],
+            min_multiplier=3.0,
+            warmup_seconds=60,  # 1-min warmup rung window
+            cliff_load_name="cliff",
+        ),
+        # NOTE: deliberately omitting CliffPropagated — at 8 min the
+        # cross-FE blind spot may not have propagated yet. Sanity passes
+        # if ONE decode cliffs; full propagation is S1's bar.
+        WorkerPanics(
+            services=["VllmDecodeWorker", "VllmPrefillWorker", "Frontend"],
+            acceptable=True,
+        ),
+        RestartCountIncreased(
+            services=["VllmDecodeWorker", "Frontend"],
+            expect_min_increment=0,
+        ),
+    ]
+
+    await run_scenario(
+        deployment_spec=spec,
+        events=events,
+        checks=checks,
+        reports=[
+            FaultToleranceReport(),
+            ErrorBreakdownReport(),
+            PerWorkerLatencyReport(),
+        ],
+        test_name=request.node.name,
+        runtime_env=runtime_env,
+    )
+
+
+# ─── Cascade fail-fast spike (S1 of 2026-05-26 fail-fast handoff) ──────
+#
+# Goal: prove the DIS-2105 TCP `work_tx.try_send()` rejection path
+# actually surfaces an HTTP 503 (or `TrySendError::Full` worker log
+# line) under a c=300 instant burst, no warmup. The prior cycle ran
+# POOL=128 / QUEUE=32 and saw zero 503s in any log — inflight pegged at
+# 128, suggesting the cap engaged silently. This test asserts the
+# observable side of the cap.
+#
+# Launcher MUST pass the DIS-2105 patched image:
+#   --image nvcr.io/nvidian/dynamo-dev/<...>/vllm-runtime:dis-2105-v1.1.1-<sha>-...
+# (Hardcoding the image would couple the test to a specific build; the
+# fallback ``_DEFAULT_IMAGE`` is stock 1.1.1 and will pass-fail this
+# test as a control arm.)
+@pytest.mark.k8s
+@pytest.mark.e2e
+@pytest.mark.sanity
+@pytest.mark.weekly  # Lifecycle category required by report_pytest_markers
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+@pytest.mark.parametrize(
+    "concurrency,duration_min",
+    [
+        # Default: c=300 instant burst, ~60s hold. Single rung, no
+        # warmup ramp — this is a spike-test, not a steady-state
+        # cascade.
+        (300, 1.0),
+    ],
+)
+async def test_overload_cascade_spike(runtime_env, request, concurrency, duration_min):
+    """Cascade fail-fast S1 spike — DIS-2105 rejection-path surfacing.
+
+    N=2 disagg topology, c=300 instant burst with no warmup. The TCP
+    worker pool defaults (overrideable via ``DYN_TEST_WORKER_KNOBS``)
+    are ``DYN_TCP_WORKER_POOL_SIZE=128, DYN_TCP_WORK_QUEUE_SIZE=32`` —
+    matching the handoff's S1 row. Pass if ANY 503-rejection signal
+    fires during the burst (AIPerf 503 OR worker
+    ``TrySendError::Full`` log line OR Frontend ``Status code: 503``
+    filtered to the load window).
+
+    The launcher is responsible for passing the DIS-2105 patched image
+    via ``--image``. Without it, ``RejectionFired`` will fail — by
+    design, since that's the whole point of the experiment.
+    """
+    cfg = request.config
+    image = cfg.getoption("--image") or _CASCADE_IMAGE
+
+    spec = _load_dgd("disagg_qwen3_30b_unit_prod")
+    # Default knobs for the S1 spike. The env var still wins so an
+    # operator can sweep POOL/QUEUE values without forking the test.
+    if not os.environ.get("DYN_TEST_WORKER_KNOBS", "").strip():
+        os.environ[
+            "DYN_TEST_WORKER_KNOBS"
+        ] = "DYN_TCP_WORKER_POOL_SIZE=128;DYN_TCP_WORK_QUEUE_SIZE=32"
+    # Optional vLLM extra args (e.g. --max-num-seqs=128 to bound running
+    # batch). Semicolon-separated FLAG=VALUE pairs in DYN_TEST_VLLM_EXTRA_ARGS.
+    # Lone flags (no value) are also supported as a bare flag with no =.
+    extra_raw = os.environ.get("DYN_TEST_VLLM_EXTRA_ARGS", "").strip()
+    vllm_extra_args: list[str] | None = None
+    if extra_raw:
+        vllm_extra_args = []
+        for tok in extra_raw.split(";"):
+            tok = tok.strip()
+            if not tok:
+                continue
+            if "=" in tok:
+                k, v = tok.split("=", 1)
+                vllm_extra_args.extend([k.strip(), v.strip()])
+            else:
+                vllm_extra_args.append(tok)
+    _apply_cascade_dgd(
+        spec,
+        image=image,
+        units=2,
+        abort_timeout_s=480,
+        vllm_extra_args=vllm_extra_args,
+    )
+    _apply_cluster_portability(spec)
+    spec["Frontend"].set_env_var("DYN_ROUTER_MODE", "least-loaded")
+    spec["Frontend"].set_env_var("DYN_ROUTER_USE_KV_EVENTS", "false")
+
+    model_cache_pvc = cfg.getoption("--model-cache-pvc")
+    if model_cache_pvc:
+        spec.enable_model_cache(model_cache_pvc)
+
+    served_model = spec["VllmDecodeWorker"].model
+
+    events = [
+        WaitForModelReady(timeout=2400),
+        # Single rung — instant burst, no warmup, no ramp.
+        StartLoad(
+            load_config=_cascade_load(
+                served_model=served_model,
+                concurrency=concurrency,
+                duration_minutes=duration_min,
+                name="cliff",
+            ),
+            name="cliff",
+        ),
+        WaitForLoadCompletion(name="cliff"),
+    ]
+
+    checks = [
+        # Sanity — confirm the burst actually got past the proxy and
+        # SOME load made it to the cluster. min_requests is small
+        # because rejection is the expected path; we still want to know
+        # the load harness didn't silently no-op.
+        LoadApplied(load_name="cliff", min_requests=10),
+        # The point of the test — at least one of three rejection
+        # signals must fire during the cliff window.
+        RejectionFired(load_name="cliff", min_503_count=1),
+    ]
+
+    await run_scenario(
+        deployment_spec=spec,
+        events=events,
+        checks=checks,
+        reports=[
+            FaultToleranceReport(),
+            ErrorBreakdownReport(),
+            PerWorkerLatencyReport(),
+        ],
+        test_name=request.node.name,
+        runtime_env=runtime_env,
+    )
+
+
+# ─── S1 — full natural-routing cascade demonstration (~75 min) ─────────
+@pytest.mark.k8s
+@pytest.mark.e2e
+@pytest.mark.weekly  # not sanity — long-running
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+@pytest.mark.parametrize(
+    "units,concurrency,duration_min,abort_timeout,vllm_max_num_seqs,override_worker_knobs",
+    [
+        # Default: production-mirror — N=3, c=216, 45-min hold, 480s NIXL timer.
+        (3, 216, 45, 480, None, None),
+        # S2 (2026-05-26 cascade fail-fast handoff): cap engine running-batch
+        # at 128 via vLLM CLI. No DIS-2105 image required — stock 1.1.1
+        # plus --max-num-seqs=128 alone is the lever. Pass if goodput
+        # holds ≥ 50% of pre-cliff OR KV peak < 0.95 (assertions live on
+        # the existing cascade-signature checks; the row exercises the
+        # cap).
+        (3, 216, 45, 480, 128, None),
+        # S3 combo: DIS-2105 image + --max-num-seqs=128 + smaller
+        # POOL/QUEUE knobs (64/16, half the S1-spike values) so the TCP
+        # rejection path engages alongside the engine-side cap. Per the
+        # handoff: launcher MUST pass --image
+        #   nvcr.io/.../vllm-runtime:dis-2105-v1.1.1-...
+        # for this row to do anything meaningful — the parametrize
+        # itself only carries the knob deltas, not the image.
+        (
+            3,
+            216,
+            45,
+            480,
+            128,
+            "DYN_TCP_WORKER_POOL_SIZE=64;DYN_TCP_WORK_QUEUE_SIZE=16",
+        ),
+        # Subsequent rows are entire S2-S6 scenarios (same test function);
+        # add them as the campaign expands. Each row keeps the framework
+        # primitives identical and only varies the cascade lever:
+        # (3, 216, 45, 30, None, None),   # S4: short abort-timer
+    ],
+)
+async def test_overload_cascade(
+    runtime_env,
+    request,
+    units,
+    concurrency,
+    duration_min,
+    abort_timeout,
+    vllm_max_num_seqs,
+    override_worker_knobs,
+):
+    """S1 — full cascade demonstration under natural LeastLoaded routing.
+
+    Drives sustained load past the per-pod cliff on a production-shape N=3
+    topology and asserts the full cascade signature: KV peg →
+    WaitingForKVTransfer pool explosion → NIXL xfer_time blow-up →
+    generation throughput collapse → cliff propagates to a second decode
+    pod within the run window.
+
+    Admission thresholds are deliberately UNSET so the FE inherits
+    v1.1.1's permissive-sentinel defaults (matches production). Setting
+    them is the mitigation tested in S3 (future row); this scenario is
+    the unmitigated baseline.
+
+    ~75 min wall (setup 15 + load 50 + teardown 10) on 18 GPUs.
+    Marked @weekly — not part of the sanity-CI lane.
+    """
+    cfg = request.config
+    image = cfg.getoption("--image") or _CASCADE_IMAGE
+
+    spec = _load_dgd("disagg_qwen3_30b_unit_prod")
+    vllm_extra_args = (
+        ["--max-num-seqs", str(vllm_max_num_seqs)]
+        if vllm_max_num_seqs is not None
+        else None
+    )
+    _apply_cascade_dgd(
+        spec,
+        image=image,
+        units=units,
+        abort_timeout_s=abort_timeout,
+        vllm_extra_args=vllm_extra_args,
+        override_worker_knobs=override_worker_knobs,
+    )
+    _apply_cluster_portability(spec)
+    spec["Frontend"].set_env_var("DYN_ROUTER_MODE", "least-loaded")
+    spec["Frontend"].set_env_var("DYN_ROUTER_USE_KV_EVENTS", "false")
+
+    model_cache_pvc = cfg.getoption("--model-cache-pvc")
+    if model_cache_pvc:
+        spec.enable_model_cache(model_cache_pvc)
+
+    served_model = spec["VllmDecodeWorker"].model
+
+    events = [
+        WaitForModelReady(timeout=2400),
+        # 5-min sub-cliff warmup at c=72 — sets the steady-state baseline
+        # for NixlXferTimeMultiplied and proves the cluster is healthy
+        # before the cliff rung. c=72 = 24 concurrent per decode at N=3,
+        # comfortably below the per-pod cliff.
+        StartLoad(
+            load_config=_cascade_load(
+                served_model=served_model,
+                concurrency=72,
+                duration_minutes=5,
+                name="warmup",
+            ),
+            name="warmup",
+        ),
+        WaitForLoadCompletion(name="warmup"),
+        Wait(duration=30),
+        # Cliff rung — the parameterized cascade target. 5% mid-flight
+        # cancellations feed the `_DeferredAbort` path so the 480-s NIXL
+        # abort timer actually fires during the 45-min hold. Without
+        # these, no requests cancel → no stranded prefill blocks → the
+        # primary production-recovery mechanism never exercises in dev.
+        # Per observe-agent NEXT_STEPS P0.2 (sanity-suite work).
+        StartLoad(
+            load_config=_cascade_load(
+                served_model=served_model,
+                concurrency=concurrency,
+                duration_minutes=duration_min,
+                name="cliff",
+                request_cancellation_rate=0.05,
+            ),
+            name="cliff",
+        ),
+        WaitForLoadCompletion(name="cliff"),
+    ]
+
+    checks = [
+        LoadApplied(load_name="cliff", min_requests=100),
+        LoadCompleted(name="cliff"),
+        # Cascade-signature sub-checks at S1 thresholds. Inlined rather
+        # than wrapped in a CascadeReached composite so a single failure
+        # gives a clean stack trace for the specific signal that missed.
+        KvCacheUsagePeak(
+            services=["VllmDecodeWorker"],
+            threshold=0.95,
+            within_seconds=600,
+            load_name="cliff",
+        ),
+        WaitingForKVTransferExceeds(
+            services=["VllmDecodeWorker"],
+            threshold=100,
+            load_name="cliff",
+        ),
+        NixlXferTimeMultiplied(
+            services=["VllmDecodeWorker"],
+            min_multiplier=5.0,
+            warmup_seconds=300,  # use the full 5-min warmup window
+            cliff_load_name="cliff",
+        ),
+        GenerationThroughputDropped(
+            services=["VllmDecodeWorker"],
+            min_drop_frac=0.30,
+            warmup_seconds=300,
+            cliff_window_seconds=300,
+            cliff_load_name="cliff",
+        ),
+        # Peer-decode infection — the LeastLoaded cross-FE blind spot
+        # signature. min_pods=2 means at least 2 of 3 decodes peg KV.
+        CliffPropagated(
+            services=["VllmDecodeWorker"],
+            min_pods=2,
+            kv_threshold=0.85,
+            load_name="cliff",
+        ),
+        WorkerPanics(
+            services=["VllmDecodeWorker", "VllmPrefillWorker", "Frontend"],
+            acceptable=True,
+        ),
+        RestartCountIncreased(
+            services=["VllmDecodeWorker", "Frontend"],
+            expect_min_increment=0,
+        ),
+    ]
+
+    await run_scenario(
+        deployment_spec=spec,
+        events=events,
+        checks=checks,
+        reports=[
+            FaultToleranceReport(),
+            ErrorBreakdownReport(),
+            PerWorkerLatencyReport(),
+        ],
+        test_name=request.node.name,
+        runtime_env=runtime_env,
+    )
+
+
+# ─── KV-router memory stability — recommended-A4 config ────────────────
+@pytest.mark.k8s
+@pytest.mark.e2e
+@pytest.mark.weekly  # ~40 min wall — not in the sanity-CI lane
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+@pytest.mark.parametrize(
+    "router_config,units,rung_c12_min,rung_c24_ramp_min,rung_c48_min,rung_c24_cool_min,rung_c12_cool_min",
+    [
+        # Default: N=2, U-shape concurrency ramp.
+        #   c=12 (warm)  2 min
+        #   c=24 (ramp)  3 min
+        #   c=48 (peak) 18 min  ← most of the run, main slope signal
+        #   c=24 (cool)  3 min  ← prove memory comes down with load
+        #   c=12 (cool)  2 min
+        # = 28 min total load + ~5×30s gaps + ~7 min model load + ~2 min
+        # teardown ≈ 40 min wall.
+        #
+        # Three router configs run head-to-head — same workload, same
+        # topology, same image, only routing differs. Lets the observe
+        # agent compare per-pod memory slopes side-by-side.
+        ("a4-recommended", 2, 2.0, 3.0, 18.0, 3.0, 2.0),
+        ("least-loaded-baseline", 2, 2.0, 3.0, 18.0, 3.0, 2.0),
+        # Round-2 P0.1: A4 minus replica-sync. Single-variable
+        # isolation of today's leak hypothesis. If FE slope drops to
+        # LL territory (~2.6 MB/min) under this arm, replica-sync's
+        # request-lifecycle accumulation (ActiveSequencesMultiWorker)
+        # is confirmed as the dominant retention path.
+        ("a4-no-replica-sync", 2, 2.0, 3.0, 18.0, 3.0, 2.0),
+    ],
+)
+async def test_kv_router_memory_stability(
+    runtime_env,
+    request,
+    router_config,
+    units,
+    rung_c12_min,
+    rung_c24_ramp_min,
+    rung_c48_min,
+    rung_c24_cool_min,
+    rung_c12_cool_min,
+):
+    """Memory-stability test for the recommended A4 KV-router config.
+
+    Drives a U-shape concurrency ramp (12 → 24 → 48 → 24 → 12) under the
+    canonical "recommended A4" Frontend config from the the cascade reproduction
+    cascade analysis. Asserts that per-pod working-set memory
+    grows at most ``ceiling`` MB/min over the run — i.e. that the
+    recommended config does NOT leak.
+
+    Why the U-shape: a leak shows as monotonic climb regardless of load
+    direction. A healthy config climbs with concurrency on the way up
+    AND comes back down on the cool-down. The single per-pod slope
+    check (over the whole run window) catches the leak case; the
+    aggregate-throughput report makes the steady-state shape visible
+    for review.
+
+    Workload: production-shaped ``_PROD_SEQ_DIST`` (long-tail ISL/OSL
+    with prefix overlap) so the KV-router actually exercises its
+    sequence-state plumbing under realistic prefill / decode mix.
+    """
+    cfg = request.config
+    image = cfg.getoption("--image") or _DEFAULT_IMAGE
+
+    spec = _load_dgd(dgd)
+    _apply_topology(spec, units=units, fe=None, pf=None, dec=None)
+    for svc in ("Frontend", "VllmPrefillWorker", "VllmDecodeWorker"):
+        spec[svc].image = image
+    _apply_cluster_portability(spec)
+
+    # Branch on the parametrize axis: A4 recommended (KV-aware + cross-FE
+    # sync + admission shedding at 0.85) vs LeastLoaded baseline (the
+    # unmitigated production arm — same admission thresholds so the only
+    # variable is the routing-mode-derived load model).
+    if router_config == "a4-recommended":
+        _apply_recommended_kv_router_config(spec)
+    elif router_config == "least-loaded-baseline":
+        fe = spec["Frontend"]
+        fe.set_env_var("DYN_ROUTER_MODE", "least-loaded")
+        fe.set_env_var("DYN_ROUTER_USE_KV_EVENTS", "false")
+        # Keep admission shedding identical to A4 so the only behavioral
+        # diff between arms is the routing-mode-derived load model.
+        fe.set_env_var("DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD", "0.85")
+        fe.set_env_var("DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC", "0.85")
+    elif router_config == "a4-no-replica-sync":
+        # Single-variable isolation: A4 recommended config with
+        # replica-sync flipped off. Everything else identical to the
+        # "a4-recommended" arm so the slope delta cleanly attributes
+        # to ActiveSequencesMultiWorker's request-lifecycle accounting.
+        # Per observe-agent NEXT_STEPS round-2 P0.1.
+        _apply_recommended_kv_router_config(spec)
+        spec["Frontend"].set_env_var("DYN_ROUTER_REPLICA_SYNC", "false")
+    else:
+        raise ValueError(f"unknown router_config: {router_config!r}")
+
+    # Per-launch FE env-var override. Mirrors the cascade-side
+    # DYN_TEST_WORKER_KNOBS pattern but for Frontend so observe's R2
+    # toggle-sweep can drive single-knob isolations from the launch
+    # env without forking the test function per toggle. Format:
+    # semicolon-separated KEY=VALUE list, empty → no overrides.
+    # Example: DYN_TEST_FE_KNOBS="DYN_ROUTER_USE_KV_EVENTS=true"
+    fe_extra = os.environ.get("DYN_TEST_FE_KNOBS", "").strip()
+    if fe_extra:
+        for kv in fe_extra.split(";"):
+            kv = kv.strip()
+            if not kv or "=" not in kv:
+                continue
+            key, val = kv.split("=", 1)
+            spec["Frontend"].set_env_var(key.strip(), val.strip())
+
+    model_cache_pvc = cfg.getoption("--model-cache-pvc")
+    if model_cache_pvc:
+        spec.enable_model_cache(model_cache_pvc)
+
+    served_model = spec["VllmDecodeWorker"].model
+
+    def _steady_load(concurrency: float, duration_minutes: float, name: str):
+        """Prod-mix LoadConfig for a single rung of the U-shape."""
+        return LoadConfig(
+            model_name=served_model,
+            tokenizer=served_model,
+            seq_dist=_PROD_SEQ_DIST,
+            num_prefix_prompts=_NUM_PREFIX_PROMPTS,
+            prefix_prompt_length=_PREFIX_PROMPT_LENGTH,
+            concurrency=int(concurrency),
+            duration_minutes=duration_minutes,
+            request_timeout_seconds=30,
+            streaming=True,
+            ignore_eos=True,
+            warmup_requests=0,
+            connection_reuse_strategy="never",
+            goodput=["request_latency:30000"],
+        )
+
+    events = [
+        WaitForModelReady(timeout=2400),
+        # Memory poller installed right after model ready so we don't
+        # pick up loader/init memory in the slope. interval_s=10 gives
+        # ~180 samples over a 30-min steady window — smooth slope, low
+        # kubectl-exec overhead.
+        PodMemoryPoller(
+            services=["Frontend", "VllmPrefillWorker", "VllmDecodeWorker"],
+            interval_s=10,
+        ),
+        StartLoad(load_config=_steady_load(12, rung_c12_min, "warmup"), name="warmup"),
+        WaitForLoadCompletion(name="warmup"),
+        StartLoad(load_config=_steady_load(24, rung_c24_ramp_min, "ramp"), name="ramp"),
+        WaitForLoadCompletion(name="ramp"),
+        StartLoad(load_config=_steady_load(48, rung_c48_min, "steady"), name="steady"),
+        WaitForLoadCompletion(name="steady"),
+        StartLoad(load_config=_steady_load(24, rung_c24_cool_min, "cool"), name="cool"),
+        WaitForLoadCompletion(name="cool"),
+        StartLoad(
+            load_config=_steady_load(12, rung_c12_cool_min, "final"), name="final"
+        ),
+        WaitForLoadCompletion(name="final"),
+    ]
+
+    # Pass criteria:
+    #   - Each rung issued enough requests to be meaningful (no AIPerf
+    #     silent failures)
+    #   - FE working-set growth ≤ 30 MB/min over the run window
+    #   - Workers ≤ 100 MB/min (vLLM internal caches are noisier)
+    #   - Zero restarts (a restart invalidates the slope)
+    #   - No worker panics
+    checks = [
+        LoadApplied(load_name="warmup", min_requests=50),
+        LoadApplied(load_name="ramp", min_requests=100),
+        LoadApplied(load_name="steady", min_requests=500),
+        LoadApplied(load_name="cool", min_requests=100),
+        LoadApplied(load_name="final", min_requests=50),
+        # window_seconds=2400 covers the entire ~30-min load span; the
+        # check's sliding-window algorithm picks the longest valid pair
+        # from each start point, so a 2-min startup ramp gets diluted
+        # rather than tripping the ceiling. A real leak shows as
+        # monotonic climb across the whole run → high overall slope.
+        PodMemoryGrowth(
+            services=["Frontend"],
+            assert_mode="max",
+            growth_bytes_per_min=30 * 1024 * 1024,  # 30 MiB/min
+            window_seconds=2400,
+            source="working_set",
+        ),
+        PodMemoryGrowth(
+            services=["VllmDecodeWorker", "VllmPrefillWorker"],
+            assert_mode="max",
+            growth_bytes_per_min=100 * 1024 * 1024,  # 100 MiB/min
+            window_seconds=2400,
+            source="working_set",
+        ),
+        RestartCountIncreased(
+            services=["Frontend", "VllmPrefillWorker", "VllmDecodeWorker"],
+            expect_min_increment=0,
+        ),
+        WorkerPanics(
+            services=["VllmDecodeWorker", "VllmPrefillWorker", "Frontend"],
+            acceptable=True,
+        ),
+    ]
+
+    await run_scenario(
+        deployment_spec=spec,
+        events=events,
+        checks=checks,
+        reports=[
+            FaultToleranceReport(),
+            ErrorBreakdownReport(),
+            PerWorkerLatencyReport(),
+        ],
+        test_name=request.node.name,
+        runtime_env=runtime_env,
+    )
+
+
+# ─── S2 / S0c — pinned single-pod overload with natural-bg traffic ─────
+@pytest.mark.k8s
+@pytest.mark.e2e
+@pytest.mark.weekly
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+@pytest.mark.parametrize(
+    "units,pin_c,pin_isl,pin_min,bg_c,bg_min",
+    [
+        # Default: N=2 (need ≥1 peer decode to observe propagation).
+        # Pin Load A onto (decode#0, prefill#0) at c=64 ISL=6000 for 10
+        # min — that pair will cliff. Concurrent Load B is natural-
+        # routing c=32 ISL=2000 for 10 min — exercises peers, MAY split
+        # some traffic onto the saturated decode#0 if the routing layer
+        # is blind to its overload (the the cross-FE blind spot).
+        (2, 64, 6000, 10.0, 32, 10.0),
+    ],
+)
+async def test_overload_cascade_pinned_with_bg(
+    runtime_env,
+    request,
+    units,
+    pin_c,
+    pin_isl,
+    pin_min,
+    bg_c,
+    bg_min,
+):
+    """Pinned cliff + natural-bg traffic — cross-FE blind-spot diagnostic.
+
+    Drives ONE decode pod into the cliff via nvext.worker_id pinning
+    while simultaneously running a moderate, natural-routing background
+    load against the rest of the pool. The diagnostic question is:
+    does the cliff stay contained on the pinned target, or does it
+    propagate to the peer decode because the FE's load model can't
+    see the saturation?
+
+    Two concurrent ``StartLoad`` events. Both AIPerf Jobs share the
+    log PVC but write to subpath-isolated dirs (each ``ManagedLoad``
+    generates a unique 8-hex job-name suffix). Each load is extracted
+    independently at scenario teardown.
+
+    Asserts only on framework health (loads ran, cliff fired on the
+    pinned target, no panics, no restarts). The propagation-vs-
+    containment classification is left to post-hoc analysis of the
+    per-pod ``server_metrics_export.jsonl`` for both loads — both
+    arms (LeastLoaded blind-spot vs A4 cross-FE visibility) yield
+    different per-pod KV-cliff signatures that an analyst can read
+    out of the JSONLs without re-running.
+    """
+    cfg = request.config
+    image = cfg.getoption("--image") or _CASCADE_IMAGE
+
+    spec = _load_dgd(dgd)
+    _apply_topology(spec, units=units, fe=None, pf=None, dec=None)
+    for svc in ("Frontend", "VllmPrefillWorker", "VllmDecodeWorker"):
+        spec[svc].image = image
+    _apply_cluster_portability(spec)
+
+    # LeastLoaded routing with NO admission shedding — the unmitigated
+    # baseline that matches the production arm. The cross-FE blind-spot
+    # only manifests in this config. To probe the recommended-A4
+    # remediation, swap to `_apply_recommended_kv_router_config(spec)`
+    # in a future parametrize row.
+    spec["Frontend"].set_env_var("DYN_ROUTER_MODE", "least-loaded")
+    spec["Frontend"].set_env_var("DYN_ROUTER_USE_KV_EVENTS", "false")
+
+    # NIXL abort timer: 30s mitigation (default 480 implicated in prior outage).
+    for svc in ("VllmPrefillWorker", "VllmDecodeWorker"):
+        spec[svc].set_env_var("VLLM_NIXL_ABORT_REQUEST_TIMEOUT", "30")
+
+    model_cache_pvc = cfg.getoption("--model-cache-pvc")
+    if model_cache_pvc:
+        spec.enable_model_cache(model_cache_pvc)
+
+    served_model = spec["VllmDecodeWorker"].model
+
+    events = [
+        WaitForModelReady(timeout=2400),
+        # Load A: pinned cliff. Concentrated on (decode#0, prefill#0).
+        # Starts first; AIPerf is up + scraping before bg load joins.
+        StartLoad(
+            load_config=_cascade_load(
+                served_model=served_model,
+                concurrency=pin_c,
+                duration_minutes=pin_min,
+                name="cliff",
+                isl=pin_isl,
+                worker_pin=WorkerPin(
+                    decode_service="VllmDecodeWorker",
+                    decode_replica_index=0,
+                    prefill_service="VllmPrefillWorker",
+                    prefill_replica_index=0,
+                ),
+            ),
+            name="cliff",
+        ),
+        # Load B: natural background. Starts right after A (no Wait
+        # in between — both AIPerf Jobs run concurrently from this
+        # point until each completes).
+        StartLoad(
+            load_config=_cascade_load(
+                served_model=served_model,
+                concurrency=bg_c,
+                duration_minutes=bg_min,
+                name="bg",
+                isl=2000,
+            ),
+            name="bg",
+        ),
+        # Wait for both loads to finish independently.
+        WaitForLoadCompletion(name="cliff"),
+        WaitForLoadCompletion(name="bg"),
+    ]
+
+    checks = [
+        # Framework-health asserts only.
+        LoadApplied(load_name="cliff", min_requests=50),
+        LoadApplied(load_name="bg", min_requests=100),
+        LoadCompleted(name="cliff"),
+        LoadCompleted(name="bg"),
+        # Sanity that the pin actually concentrated load on decode#0
+        # (KV peg = pin worked + cluster is in the cliff regime). The
+        # observe agent reads per-pod KV / W4RK / NIXL from the JSONL
+        # for both loads to classify whether the cliff stayed contained
+        # or propagated to the peer decode.
+        KvCacheUsagePeak(
+            services=["VllmDecodeWorker"],
+            threshold=0.95,
+            within_seconds=600,
+            load_name="cliff",
+        ),
+        WorkerPanics(
+            services=["VllmDecodeWorker", "VllmPrefillWorker", "Frontend"],
+            acceptable=True,
+        ),
+        RestartCountIncreased(
+            services=["VllmDecodeWorker", "Frontend"],
+            expect_min_increment=0,
+        ),
+    ]
+
+    await run_scenario(
+        deployment_spec=spec,
+        events=events,
+        checks=checks,
+        reports=[
+            FaultToleranceReport(),
+            ErrorBreakdownReport(),
+            PerWorkerLatencyReport(),
+        ],
+        test_name=request.node.name,
+        runtime_env=runtime_env,
+    )
+
+
+# ─── N=3 cascade-prevention chain-phased 4-arm demo ────────────────────
+#
+# 4 arms × 57-min cliff (cold-spike + imbalance + extended steady for memory).
+# Per the 2026-05-26-n3-cascade-prevention-demo-handoff.md (revised). All
+# arms use the prod-shape N=3 disagg topology (3 FE + 6 prefill + 3 decode).
+#
+#   A — LL no admission           v1.1.1 stock                 LeastLoaded, no admission knobs
+#   B — LL + DIS-2105 rejection   v1.1.1 + 06a9efb537           LeastLoaded + pool=32, queue=8
+#   C — KV no replica-sync        release/1.2.0                 KV zero-weight + queue=4.0, no replica sync
+#   D — KV + replica-sync         release/1.2.0                 same as C + DYN_ROUTER_REPLICA_SYNC=true
+#
+# Launch via scripts/launch-n3-cascade-prevention-demo.sh which fans out
+# to 4 namespaces and supplies per-arm --image.
+
+
+@pytest.mark.k8s
+@pytest.mark.e2e
+@pytest.mark.weekly
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+@pytest.mark.parametrize(
+    "arm_label",
+    ["A-LL", "B-LL-DIS2105", "C-KV-no-sync", "D-KV-sync"],
+)
+async def test_overload_cascade_chain_phased(runtime_env, request, arm_label):
+    """N=3 cluster-resilience demo across four admission strategies.
+
+    Workload (57 min total):
+      P-spike   1 min  idle → c=150 sudden  cold-onset (production-shape)
+      P-recov   2 min  idle                  reset
+      P0        2 min  c=24 unpinned         baseline + memory anchor
+      P1        4 min  c=80 pinned to dec#0  imbalance under cap
+      P2        3 min  P1 + c=24 unpinned    mixed-load below cliff
+      P2.5      1 min  P1 + c=80 burst       spike-on-imbalance (total c=184)
+      P3       40 min  P1 + c=24             extended steady — PRIMARY memory window
+      P4        4 min  drop pin + c=24       recovery + final memory
+
+    The pinned long load spans P1..P3 (48 min). Unpinned loads start/stop
+    per phase. PodMemoryPoller captures pod_memory_growth.tsv at 10s.
+
+    Per-arm knobs differ only in routing strategy + admission. Image
+    selected via CLI ``--image`` at launch time (no per-arm hard-coded
+    image — the launcher script supplies the right image per arm).
+    """
+    cfg = request.config
+    image = cfg.getoption("--image") or _CASCADE_IMAGE
+
+    spec = _load_dgd("disagg_qwen3_30b_unit_prod")
+
+    # Per-arm routing + admission knob set
+    vllm_extra_args = None
+    fe_knobs: dict[str, str] = {}
+
+    if arm_label == "A-LL":
+        # Stock LL, no admission. The cascade-prone baseline.
+        os.environ["DYN_TEST_WORKER_KNOBS"] = ""
+        fe_knobs = {
+            "DYN_ROUTER_MODE": "least-loaded",
+            "DYN_ROUTER_USE_KV_EVENTS": "false",
+        }
+    elif arm_label == "B-LL-DIS2105":
+        # LL + worker-side rejection (DIS-2105 fix). Image must be the
+        # 06a9efb537-built v1.1.1 base.
+        os.environ[
+            "DYN_TEST_WORKER_KNOBS"
+        ] = "DYN_TCP_WORKER_POOL_SIZE=32;DYN_TCP_WORK_QUEUE_SIZE=8"
+        fe_knobs = {
+            "DYN_ROUTER_MODE": "least-loaded",
+            "DYN_ROUTER_USE_KV_EVENTS": "false",
+        }
+    elif arm_label == "C-KV-no-sync":
+        # release/1.2.0 KV with zero scoring weights + FE queue threshold,
+        # NO cross-FE replica sync.
+        os.environ["DYN_TEST_WORKER_KNOBS"] = ""
+        fe_knobs = {
+            "DYN_ROUTER_MODE": "kv",
+            "DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT": "0.0",
+            "DYN_KV_HOST_CACHE_HIT_WEIGHT": "0.0",
+            "DYN_KV_DISK_CACHE_HIT_WEIGHT": "0.0",
+            "DYN_ROUTER_USE_KV_EVENTS": "false",
+            "DYN_ROUTER_REPLICA_SYNC": "false",
+            "DYN_ROUTER_TEMPERATURE": "0.0",
+            "DYN_ROUTER_ASSUME_KV_REUSE": "false",
+            "DYN_ROUTER_TRACK_ACTIVE_BLOCKS": "true",
+            "DYN_ROUTER_QUEUE_THRESHOLD": "4.0",
+        }
+    elif arm_label == "D-KV-sync":
+        # Same as C but WITH replica-sync — the production-proposed config.
+        os.environ["DYN_TEST_WORKER_KNOBS"] = ""
+        fe_knobs = {
+            "DYN_ROUTER_MODE": "kv",
+            "DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT": "0.0",
+            "DYN_KV_HOST_CACHE_HIT_WEIGHT": "0.0",
+            "DYN_KV_DISK_CACHE_HIT_WEIGHT": "0.0",
+            "DYN_ROUTER_USE_KV_EVENTS": "false",
+            "DYN_ROUTER_REPLICA_SYNC": "true",
+            "DYN_ROUTER_TEMPERATURE": "0.0",
+            "DYN_ROUTER_ASSUME_KV_REUSE": "false",
+            "DYN_ROUTER_TRACK_ACTIVE_BLOCKS": "true",
+            "DYN_ROUTER_QUEUE_THRESHOLD": "4.0",
+        }
+    else:
+        raise ValueError(f"unknown arm_label: {arm_label!r}")
+
+    _apply_cascade_dgd(
+        spec,
+        image=image,
+        units=3,  # N=3 disagg
+        abort_timeout_s=30,  # mitigation (default 480 implicated in prior outage)
+        vllm_extra_args=vllm_extra_args,
+    )
+    _apply_cluster_portability(spec)
+
+    # Apply per-arm FE knobs (overrides any default set by _apply_cascade_dgd)
+    for k, v in fe_knobs.items():
+        spec["Frontend"].set_env_var(k, v)
+
+    model_cache_pvc = cfg.getoption("--model-cache-pvc")
+    if model_cache_pvc:
+        spec.enable_model_cache(model_cache_pvc)
+
+    served_model = spec["VllmDecodeWorker"].model
+
+    # Phase durations (minutes) per the 2026-05-26 handoff (revised)
+    PSPIKE_MIN = 1.0
+    PRECOV_MIN = 2.0
+    P0_MIN = 2.0
+    P1_MIN = 4.0
+    P2_MIN = 3.0
+    P2_5_MIN = 1.0
+    P3_MIN = 40.0
+    P4_MIN = 4.0
+
+    # Pinned load duration: spans P1+P2+P2.5+P3 = 48 min
+    PIN_DURATION_MIN = P1_MIN + P2_MIN + P2_5_MIN + P3_MIN
+
+    pinned_workerpin = WorkerPin(
+        decode_service="VllmDecodeWorker",
+        decode_replica_index=0,
+        prefill_service="VllmPrefillWorker",
+        prefill_replica_index=0,
+    )
+
+    events = [
+        WaitForModelReady(timeout=2400),
+        # Continuous FE memory polling for the full 57-min run
+        PodMemoryPoller(
+            services=["Frontend", "VllmPrefillWorker", "VllmDecodeWorker"],
+            interval_s=10,
+        ),
+        # P-spike — cold onset (instant idle → c=150)
+        StartLoad(
+            load_config=_cascade_load(
+                served_model=served_model,
+                concurrency=150,
+                duration_minutes=PSPIKE_MIN,
+                name="p-spike",
+            ),
+            name="p-spike",
+        ),
+        WaitForLoadCompletion(name="p-spike"),
+        # P-recover — idle reset
+        Wait(duration=int(PRECOV_MIN * 60)),
+        # P0 — warmup
+        StartLoad(
+            load_config=_cascade_load(
+                served_model=served_model,
+                concurrency=24,
+                duration_minutes=P0_MIN,
+                name="p0-warmup",
+            ),
+            name="p0-warmup",
+        ),
+        WaitForLoadCompletion(name="p0-warmup"),
+        # P1 starts: long pinned load (48 min — ends after P3)
+        StartLoad(
+            load_config=_cascade_load(
+                served_model=served_model,
+                concurrency=80,
+                duration_minutes=PIN_DURATION_MIN,
+                name="pinned-imbalance",
+                worker_pin=pinned_workerpin,
+            ),
+            name="pinned-imbalance",
+        ),
+        Wait(duration=int(P1_MIN * 60)),
+        # P2 — add cross-traffic (synchronous with pinned in background)
+        StartLoad(
+            load_config=_cascade_load(
+                served_model=served_model,
+                concurrency=24,
+                duration_minutes=P2_MIN,
+                name="p2-cross",
+            ),
+            name="p2-cross",
+        ),
+        WaitForLoadCompletion(name="p2-cross"),
+        # P2.5 — spike burst on top of pinned
+        StartLoad(
+            load_config=_cascade_load(
+                served_model=served_model,
+                concurrency=80,
+                duration_minutes=P2_5_MIN,
+                name="p2-5-spike",
+            ),
+            name="p2-5-spike",
+        ),
+        WaitForLoadCompletion(name="p2-5-spike"),
+        # P3 — extended sustained mixed (40 min — memory window)
+        StartLoad(
+            load_config=_cascade_load(
+                served_model=served_model,
+                concurrency=24,
+                duration_minutes=P3_MIN,
+                name="p3-sustained",
+            ),
+            name="p3-sustained",
+        ),
+        WaitForLoadCompletion(name="p3-sustained"),
+        # Drain the pinned load (should be done; explicit for clarity)
+        WaitForLoadCompletion(name="pinned-imbalance"),
+        # P4 — recovery
+        StartLoad(
+            load_config=_cascade_load(
+                served_model=served_model,
+                concurrency=24,
+                duration_minutes=P4_MIN,
+                name="p4-recovery",
+            ),
+            name="p4-recovery",
+        ),
+        WaitForLoadCompletion(name="p4-recovery"),
+    ]
+
+    # Framework-health asserts only. The per-arm A/B/C/D comparison per
+    # the handoff is post-hoc — per-phase goodput, per-pod KV containment,
+    # 503/Timeout/504 accounting, FE memory slope.
+    checks = [
+        LoadApplied(load_name="p0-warmup", min_requests=50),
+        LoadApplied(load_name="pinned-imbalance", min_requests=10),
+        LoadApplied(load_name="p3-sustained", min_requests=500),
+        WorkerPanics(
+            services=["VllmDecodeWorker", "VllmPrefillWorker", "Frontend"],
+            acceptable=True,
+        ),
+        RestartCountIncreased(
+            services=["VllmDecodeWorker", "Frontend"],
+            expect_min_increment=0,
+        ),
+    ]
+
+    await run_scenario(
+        deployment_spec=spec,
+        events=events,
+        checks=checks,
+        reports=[
+            FaultToleranceReport(),
+            ErrorBreakdownReport(),
+            PerWorkerLatencyReport(),
+        ],
+        test_name=request.node.name,
+        runtime_env=runtime_env,
+    )
+
+
+# ─── N=3 NATURAL OVERLOAD — companion no-pin variant of chain-phased ───
+#
+# IDENTICAL to test_overload_cascade_chain_phased except: the long
+# background load (P1..P3) has NO `WorkerPin`. Same 4 arms, same
+# 57-min phase schedule, same images, same FE knobs. The only
+# variable is whether nvext-pinning is applied to the long load.
+#
+# Direct A/B against the pin-based test: same workload shape and
+# same routing config → any difference in cluster behavior between
+# the two tests isolates the pin's effect.
+
+
+@pytest.mark.k8s
+@pytest.mark.e2e
+@pytest.mark.weekly
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+@pytest.mark.parametrize(
+    "arm_label",
+    ["A-LL", "B-LL-DIS2105", "C-KV-no-sync", "D-KV-sync"],
+)
+async def test_overload_natural_overload(runtime_env, request, arm_label):
+    """N=3 routing-balance demo across 4 arms — NO pinning.
+
+    Clone of test_overload_cascade_chain_phased with `worker_pin=None`
+    on the long background load. Everything else (phases, durations,
+    concurrencies, knobs, image selection) is identical.
+
+    Headline metric is the coefficient-of-variation of per-decode
+    inflight across the 57-min run — computed post-hoc.
+    """
+    cfg = request.config
+    image = cfg.getoption("--image") or _CASCADE_IMAGE
+
+    # Per-arm knobs — IDENTICAL to chain_phased
+    vllm_extra_args = None
+    fe_knobs: dict[str, str] = {}
+
+    if arm_label == "A-LL":
+        os.environ["DYN_TEST_WORKER_KNOBS"] = ""
+        fe_knobs = {
+            "DYN_ROUTER_MODE": "least-loaded",
+            "DYN_ROUTER_USE_KV_EVENTS": "false",
+        }
+    elif arm_label == "B-LL-DIS2105":
+        os.environ[
+            "DYN_TEST_WORKER_KNOBS"
+        ] = "DYN_TCP_WORKER_POOL_SIZE=32;DYN_TCP_WORK_QUEUE_SIZE=8"
+        fe_knobs = {
+            "DYN_ROUTER_MODE": "least-loaded",
+            "DYN_ROUTER_USE_KV_EVENTS": "false",
+        }
+    elif arm_label == "C-KV-no-sync":
+        os.environ["DYN_TEST_WORKER_KNOBS"] = ""
+        fe_knobs = {
+            "DYN_ROUTER_MODE": "kv",
+            "DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT": "0.0",
+            "DYN_KV_HOST_CACHE_HIT_WEIGHT": "0.0",
+            "DYN_KV_DISK_CACHE_HIT_WEIGHT": "0.0",
+            "DYN_ROUTER_USE_KV_EVENTS": "false",
+            "DYN_ROUTER_REPLICA_SYNC": "false",
+            "DYN_ROUTER_TEMPERATURE": "0.0",
+            "DYN_ROUTER_ASSUME_KV_REUSE": "false",
+            "DYN_ROUTER_TRACK_ACTIVE_BLOCKS": "true",
+            "DYN_ROUTER_QUEUE_THRESHOLD": "4.0",
+        }
+    elif arm_label == "D-KV-sync":
+        os.environ["DYN_TEST_WORKER_KNOBS"] = ""
+        fe_knobs = {
+            "DYN_ROUTER_MODE": "kv",
+            "DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT": "0.0",
+            "DYN_KV_HOST_CACHE_HIT_WEIGHT": "0.0",
+            "DYN_KV_DISK_CACHE_HIT_WEIGHT": "0.0",
+            "DYN_ROUTER_USE_KV_EVENTS": "false",
+            "DYN_ROUTER_REPLICA_SYNC": "true",
+            "DYN_ROUTER_TEMPERATURE": "0.0",
+            "DYN_ROUTER_ASSUME_KV_REUSE": "false",
+            "DYN_ROUTER_TRACK_ACTIVE_BLOCKS": "true",
+            "DYN_ROUTER_QUEUE_THRESHOLD": "4.0",
+        }
+    else:
+        raise ValueError(f"unknown arm_label: {arm_label!r}")
+
+    spec = _load_dgd("disagg_qwen3_30b_unit_prod")
+    _apply_cascade_dgd(
+        spec,
+        image=image,
+        units=3,
+        abort_timeout_s=30,  # mitigation (default 480 implicated in prior outage)
+        vllm_extra_args=vllm_extra_args,
+    )
+    _apply_cluster_portability(spec)
+    for k, v in fe_knobs.items():
+        spec["Frontend"].set_env_var(k, v)
+
+    model_cache_pvc = cfg.getoption("--model-cache-pvc")
+    if model_cache_pvc:
+        spec.enable_model_cache(model_cache_pvc)
+
+    served_model = spec["VllmDecodeWorker"].model
+
+    # Same phase schedule as chain_phased
+    PSPIKE_MIN, PRECOV_MIN = 1.0, 2.0
+    P0_MIN, P1_MIN, P2_MIN, P2_5_MIN, P3_MIN, P4_MIN = 2.0, 4.0, 3.0, 1.0, 40.0, 4.0
+    PIN_DURATION_MIN = P1_MIN + P2_MIN + P2_5_MIN + P3_MIN  # 48 min
+
+    # NOTE: identical to chain_phased except worker_pin=None below.
+    events = [
+        WaitForModelReady(timeout=2400),
+        PodMemoryPoller(
+            services=["Frontend", "VllmPrefillWorker", "VllmDecodeWorker"],
+            interval_s=10,
+        ),
+        StartLoad(
+            load_config=_cascade_load(
+                served_model=served_model,
+                concurrency=150,
+                duration_minutes=PSPIKE_MIN,
+                name="p-spike",
+            ),
+            name="p-spike",
+        ),
+        WaitForLoadCompletion(name="p-spike"),
+        Wait(duration=int(PRECOV_MIN * 60)),
+        StartLoad(
+            load_config=_cascade_load(
+                served_model=served_model,
+                concurrency=24,
+                duration_minutes=P0_MIN,
+                name="p0-warmup",
+            ),
+            name="p0-warmup",
+        ),
+        WaitForLoadCompletion(name="p0-warmup"),
+        # The long background load — ** unpinned ** (vs chain_phased which pins this)
+        StartLoad(
+            load_config=_cascade_load(
+                served_model=served_model,
+                concurrency=80,
+                duration_minutes=PIN_DURATION_MIN,
+                name="long-background",
+                worker_pin=None,
+            ),
+            name="long-background",
+        ),
+        Wait(duration=int(P1_MIN * 60)),
+        StartLoad(
+            load_config=_cascade_load(
+                served_model=served_model,
+                concurrency=24,
+                duration_minutes=P2_MIN,
+                name="p2-cross",
+            ),
+            name="p2-cross",
+        ),
+        WaitForLoadCompletion(name="p2-cross"),
+        StartLoad(
+            load_config=_cascade_load(
+                served_model=served_model,
+                concurrency=80,
+                duration_minutes=P2_5_MIN,
+                name="p2-5-spike",
+            ),
+            name="p2-5-spike",
+        ),
+        WaitForLoadCompletion(name="p2-5-spike"),
+        StartLoad(
+            load_config=_cascade_load(
+                served_model=served_model,
+                concurrency=24,
+                duration_minutes=P3_MIN,
+                name="p3-sustained",
+            ),
+            name="p3-sustained",
+        ),
+        WaitForLoadCompletion(name="p3-sustained"),
+        WaitForLoadCompletion(name="long-background"),
+        StartLoad(
+            load_config=_cascade_load(
+                served_model=served_model,
+                concurrency=24,
+                duration_minutes=P4_MIN,
+                name="p4-recovery",
+            ),
+            name="p4-recovery",
+        ),
+        WaitForLoadCompletion(name="p4-recovery"),
+    ]
+
+    checks = [
+        LoadApplied(load_name="p0-warmup", min_requests=50),
+        LoadApplied(load_name="long-background", min_requests=10),
+        LoadApplied(load_name="p3-sustained", min_requests=500),
+        WorkerPanics(
+            services=["VllmDecodeWorker", "VllmPrefillWorker", "Frontend"],
+            acceptable=True,
+        ),
+        RestartCountIncreased(
+            services=["VllmDecodeWorker", "Frontend"],
+            expect_min_increment=0,
+        ),
+    ]
+
+    await run_scenario(
+        deployment_spec=spec,
+        events=events,
+        checks=checks,
+        reports=[
+            FaultToleranceReport(),
+            ErrorBreakdownReport(),
+            PerWorkerLatencyReport(),
         ],
         test_name=request.node.name,
         runtime_env=runtime_env,

--- a/tests/fault_tolerance/deploy/test_overload.py
+++ b/tests/fault_tolerance/deploy/test_overload.py
@@ -2078,3 +2078,682 @@ async def test_overload_natural_overload(runtime_env, request, arm_label):
         test_name=request.node.name,
         runtime_env=runtime_env,
     )
+
+
+# ─── 3-arm 2-hour A/B vs production-current baseline ───────────────────
+#
+# Per the 2026-05-27 proposal for observe review:
+#   ~/dynamo-dev/dgh-703-cascade-repro-tests/findings/
+#       2026-05-27-3arm-test-proposal-for-observe.md
+#
+# Goal: compare production-current (v1.1.1 + LL) against the cascade-test
+# image in two routing modes (LL with the full DIS-2105 / 7d8eaa70a9 /
+# 30s-NIXL stack, and KV-pure-load with the same stack). 10-phase 2-hour
+# workload from observe's 2026-05-27 handoff: warmup → light → spike →
+# moderate → wave → spike → heavy → clustered-spikes → recovery →
+# cooldown.
+#
+#   A0-true-baseline     v1.1.1 upstream        LL stock + no admission
+#   A4-LL-prod           cascade-test           LL + 503 gate (pool=256,
+#                                                q=5) + threshold=0.85 +
+#                                                30s NIXL + 30s exec
+#   R-KV-recommended     cascade-test           KV-pure-load (zero-weight,
+#                                                no kv-events, replica-
+#                                                sync) + 503 gate + thresh
+#                                                + 30s NIXL + 30s exec
+#
+# Topology: N=3 (3 FE / 6 PF TP=2 / 3 DE TP=2 = 18 GPU per arm; 3 arms =
+# 54 GPU, fits cluster's 64).
+
+
+_A0_BASELINE_IMAGE = "nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1"
+_CASCADE_TEST_IMAGE = (
+    "nvcr.io/nvidian/dynamo-dev/vllm-runtime:"
+    "release-1.2.0-cascade-test-7d8eaa70a9-neelays"
+)
+
+
+def _common_fe_knobs(router_mode: str) -> dict[str, str]:
+    """FE knobs that are identical across all 3 arms (only DYN_ROUTER_MODE
+    differs). Settings on KV-only knobs are inert on LL arms; setting them
+    everywhere keeps the configuration vector symmetric, so the arm-to-arm
+    diff is exactly (image, router-mode, presence-of-503-gate)."""
+    return {
+        "DYN_ROUTER_MODE": router_mode,
+        "DYN_ROUTER_USE_KV_EVENTS": "false",
+        "DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD": "0.85",
+        "DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT": "0.0",
+        "DYN_ROUTER_PREFILL_LOAD_SCALE": "0.0",
+        "DYN_ROUTER_QUEUE_THRESHOLD": "4.0",
+        "DYN_ROUTER_QUEUE_POLICY": "fcfs",
+        "DYN_ROUTER_REPLICA_SYNC": "true",
+    }
+
+
+@pytest.mark.k8s
+@pytest.mark.e2e
+@pytest.mark.weekly
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+@pytest.mark.parametrize(
+    "arm_label",
+    ["A0-true-baseline", "A4-LL-prod", "R-KV-recommended", "A4-tight-pool"],
+)
+async def test_overload_2hr_realistic(runtime_env, request, arm_label):
+    """2-hour A/B/R — production-current v1.1.1 vs cascade-test image in LL
+    and KV-pure-load modes, under a realistic 10-phase varying workload.
+
+    Workload (120 min total, per observe 2026-05-27 handoff):
+      P0 — warmup            5 min   ramp 0 → 80
+      P1 — light steady     25 min   c=80 (low safe band)
+      P2 — first spike       3 min   80 → 220 → 80 (above-cliff #1)
+      P3 — moderate steady  25 min   c=130 (mid safe band)
+      P4 — wave             10 min   80 ↔ 200 oscillation (5 segments)
+      P5 — second spike      3 min   130 → 260 → 130 (above-cliff #2)
+      P6 — heavy steady     25 min   c=170 (high band, sub-cliff)
+      P7 — clustered spikes  5 min   5 × c=280 spike-on-c=170 background
+      P8 — recovery         10 min   drop to c=20
+      P9 — cooldown          9 min   c=20 → 0 ramp (steady c=10)
+
+    Per-arm differences are only in (image, router-mode, 503-gate presence);
+    every other env / arg is identical across arms to isolate those three
+    variables. See the proposal doc for the full configuration table.
+
+    Pass criteria for R (per observe): goodput ≥ 95 %, decode CV < 0.05,
+    0 pods at KV ≥ 99 % for > 30 s, NIXL kv_expired_reqs < 500, FE memory
+    slope < 5 MB/min, 0 pod restarts. A0 is expected to fail several of
+    these — it's the comparison reference. A4 measured against the same
+    criteria as R to isolate routing-mode contribution.
+    """
+    cfg = request.config
+
+    # ── per-arm: image + 503-gate envs + KV-vs-LL routing mode ──
+    if arm_label == "A0-true-baseline":
+        image = _A0_BASELINE_IMAGE
+        os.environ["DYN_TEST_WORKER_KNOBS"] = ""  # no 503 gate (image lacks)
+        fe_knobs = _common_fe_knobs(router_mode="least-loaded")
+    elif arm_label == "A4-LL-prod":
+        image = _CASCADE_TEST_IMAGE
+        os.environ[
+            "DYN_TEST_WORKER_KNOBS"
+        ] = "DYN_TCP_WORKER_POOL_SIZE=256;DYN_TCP_WORK_QUEUE_SIZE=5"
+        fe_knobs = _common_fe_knobs(router_mode="least-loaded")
+    elif arm_label == "R-KV-recommended":
+        image = _CASCADE_TEST_IMAGE
+        os.environ[
+            "DYN_TEST_WORKER_KNOBS"
+        ] = "DYN_TCP_WORKER_POOL_SIZE=256;DYN_TCP_WORK_QUEUE_SIZE=5"
+        fe_knobs = _common_fe_knobs(router_mode="kv")
+    elif arm_label == "A4-tight-pool":
+        # Same as A4-LL-prod but with tightened admission gate to prevent
+        # the NIXL-stall cascade observed at Event 24/40 in the
+        # 2026-05-27 3-arm run (pool=256 == max-num-seqs filled engine,
+        # ~256 stranded sequences blocked forward progress).
+        #
+        # Sizing rationale (cycle 11 empirical: ~35 inflight per pod at
+        # c=104 steady): pool=64 ≈ 2× steady, leaves 192 of forward-progress
+        # headroom in the engine. Threshold lowered to 0.75 so mitigation 1
+        # fires before NIXL stall fills the cache.
+        image = _CASCADE_TEST_IMAGE
+        os.environ[
+            "DYN_TEST_WORKER_KNOBS"
+        ] = "DYN_TCP_WORKER_POOL_SIZE=64;DYN_TCP_WORK_QUEUE_SIZE=5"
+        fe_knobs = _common_fe_knobs(router_mode="least-loaded")
+        fe_knobs["DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD"] = "0.75"
+    else:
+        raise ValueError(f"unknown arm_label: {arm_label!r}")
+
+    spec = _load_dgd("disagg_qwen3_30b_unit_prod")
+    _apply_cascade_dgd(
+        spec,
+        image=image,
+        units=3,  # N=3 disagg
+        abort_timeout_s=30,  # VLLM_NIXL_ABORT_REQUEST_TIMEOUT
+        vllm_extra_args=None,  # engine args identical across arms
+    )
+    _apply_cluster_portability(spec)
+
+    # Apply FE knobs
+    for k, v in fe_knobs.items():
+        spec["Frontend"].set_env_var(k, v)
+
+    # VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS = 30s on both worker types (already
+    # in the template via _apply_cluster_portability if the cascade-test
+    # image is used; on A0 it's set but won't be honoured by 1.1.1's vLLM).
+    for svc in ("VllmPrefillWorker", "VllmDecodeWorker"):
+        spec[svc].set_env_var("VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS", "30")
+
+    # Wire model cache
+    model_cache_pvc = cfg.getoption("--model-cache-pvc")
+    if model_cache_pvc:
+        spec.enable_model_cache(model_cache_pvc)
+
+    served_model = spec["VllmDecodeWorker"].model
+
+    # Production-shape ISL/OSL distribution (matches observe handoff
+    # _PROD_SEQ_DIST: p50 ~1600, p99 ~7000, OSL ~200). 6 buckets with the
+    # lognormal-ish shape production traffic actually follows. Reuses the
+    # module-level constant defined above.
+    def _load(
+        name,
+        concurrency,
+        duration_minutes,
+        *,
+        warmup_concurrency=None,
+        ramp_seconds=None,
+        bursty=False,
+    ):
+        """LoadConfig with production-shape seq_dist and optional ramp /
+        bursty-arrival shaping. Wraps `_cascade_load` then overrides
+        seq_dist + ramp fields."""
+        cfg = _cascade_load(
+            served_model=served_model,
+            concurrency=concurrency,
+            duration_minutes=duration_minutes,
+            name=name,
+        )
+        cfg.seq_dist = _PROD_SEQ_DIST
+        if warmup_concurrency is not None:
+            cfg.warmup_concurrency = warmup_concurrency
+        if ramp_seconds is not None:
+            cfg.concurrency_ramp_duration = float(ramp_seconds)
+        if bursty:
+            cfg.arrival_pattern = "concurrency_burst"
+            cfg.arrival_smoothness = 0.2  # sharp peaks
+        return cfg
+
+    # ── 10-phase event list. Sequential StartLoad / WaitForLoadCompletion
+    # pairs. AIPerf has ~15-30 s setup per Job, factored into total wall.
+    events = [
+        WaitForModelReady(timeout=2400),
+        PodMemoryPoller(
+            services=["Frontend", "VllmPrefillWorker", "VllmDecodeWorker"],
+            interval_s=10,
+        ),
+        # P0 — warmup: 5 min ramp 0 → 80 using AIPerf's built-in linear
+        # ramp. Real ramp shape, not flat-c approximation.
+        StartLoad(
+            load_config=_load(
+                "p0-warmup",
+                80,
+                5.0,
+                warmup_concurrency=10,
+                ramp_seconds=240,
+            ),
+            name="p0-warmup",
+        ),
+        WaitForLoadCompletion(name="p0-warmup"),
+        # P1 — light steady: 25 min at c=80
+        StartLoad(
+            load_config=_load("p1-light-steady", 80, 25.0), name="p1-light-steady"
+        ),
+        WaitForLoadCompletion(name="p1-light-steady"),
+        # P2 — first spike: 3 min at c=220 with bursty arrivals
+        # (production cliff events are bursty, not uniform).
+        StartLoad(
+            load_config=_load("p2-first-spike", 220, 3.0, bursty=True),
+            name="p2-first-spike",
+        ),
+        WaitForLoadCompletion(name="p2-first-spike"),
+        # P3 — moderate steady: 25 min at c=130
+        StartLoad(
+            load_config=_load("p3-moderate-steady", 130, 25.0),
+            name="p3-moderate-steady",
+        ),
+        WaitForLoadCompletion(name="p3-moderate-steady"),
+        # P4 — wave: 10 min oscillation approximated as 5 × 2 min segments
+        # peaks-troughs (140 → 200 → 140 → 80 → 140) instead of continuous
+        # sine. Implementation limitation: ManagedLoad single-concurrency.
+        StartLoad(load_config=_load("p4-wave-1", 140, 2.0), name="p4-wave-1"),
+        WaitForLoadCompletion(name="p4-wave-1"),
+        StartLoad(load_config=_load("p4-wave-2", 200, 2.0), name="p4-wave-2"),
+        WaitForLoadCompletion(name="p4-wave-2"),
+        StartLoad(load_config=_load("p4-wave-3", 140, 2.0), name="p4-wave-3"),
+        WaitForLoadCompletion(name="p4-wave-3"),
+        StartLoad(load_config=_load("p4-wave-4", 80, 2.0), name="p4-wave-4"),
+        WaitForLoadCompletion(name="p4-wave-4"),
+        StartLoad(load_config=_load("p4-wave-5", 140, 2.0), name="p4-wave-5"),
+        WaitForLoadCompletion(name="p4-wave-5"),
+        # P5 — second spike: 3 min at c=260 with bursty arrivals.
+        StartLoad(
+            load_config=_load("p5-second-spike", 260, 3.0, bursty=True),
+            name="p5-second-spike",
+        ),
+        WaitForLoadCompletion(name="p5-second-spike"),
+        # P6 — heavy steady: 25 min at c=170 (high band, sub-cliff)
+        StartLoad(
+            load_config=_load("p6-heavy-steady", 170, 25.0), name="p6-heavy-steady"
+        ),
+        WaitForLoadCompletion(name="p6-heavy-steady"),
+        # P7 — clustered spikes: long-background at c=170 + 5 additive
+        # bursty spikes at c=110 (so total = 280 during spikes), each 60 s.
+        # Total wall ~5 min (5 spikes, no gap between them — back-to-back).
+        StartLoad(load_config=_load("p7-bg-170", 170, 5.0), name="p7-bg-170"),
+        StartLoad(
+            load_config=_load("p7-spike-1", 110, 1.0, bursty=True),
+            name="p7-spike-1",
+        ),
+        WaitForLoadCompletion(name="p7-spike-1"),
+        StartLoad(
+            load_config=_load("p7-spike-2", 110, 1.0, bursty=True), name="p7-spike-2"
+        ),
+        WaitForLoadCompletion(name="p7-spike-2"),
+        StartLoad(
+            load_config=_load("p7-spike-3", 110, 1.0, bursty=True), name="p7-spike-3"
+        ),
+        WaitForLoadCompletion(name="p7-spike-3"),
+        StartLoad(
+            load_config=_load("p7-spike-4", 110, 1.0, bursty=True), name="p7-spike-4"
+        ),
+        WaitForLoadCompletion(name="p7-spike-4"),
+        StartLoad(
+            load_config=_load("p7-spike-5", 110, 1.0, bursty=True), name="p7-spike-5"
+        ),
+        WaitForLoadCompletion(name="p7-spike-5"),
+        WaitForLoadCompletion(name="p7-bg-170"),
+        # P8 — recovery: 10 min at c=20 (sharp drop)
+        StartLoad(load_config=_load("p8-recovery", 20, 10.0), name="p8-recovery"),
+        WaitForLoadCompletion(name="p8-recovery"),
+        # P9 — cooldown: 9 min at c=10 (approximating ramp 20 → 0; framework
+        # doesn't support ramp-down within a single load).
+        StartLoad(load_config=_load("p9-cooldown", 10, 9.0), name="p9-cooldown"),
+        WaitForLoadCompletion(name="p9-cooldown"),
+    ]
+
+    # Pass criteria — observe's full set for R; A4 measured against same;
+    # A0 captures all metrics but expected-to-fail (no gates).
+    checks = [
+        # Framework health
+        LoadApplied(load_name="p1-light-steady", min_requests=200),
+        LoadApplied(load_name="p3-moderate-steady", min_requests=500),
+        LoadApplied(load_name="p6-heavy-steady", min_requests=500),
+        # Cascade signature gates (informational; observe analyses post-hoc)
+        WorkerPanics(
+            services=["VllmDecodeWorker", "VllmPrefillWorker", "Frontend"],
+            acceptable=True,
+        ),
+        RestartCountIncreased(
+            services=["VllmDecodeWorker", "Frontend"],
+            expect_min_increment=0,
+        ),
+    ]
+
+    await run_scenario(
+        deployment_spec=spec,
+        events=events,
+        checks=checks,
+        reports=[
+            FaultToleranceReport(),
+            ErrorBreakdownReport(),
+            PerWorkerLatencyReport(),
+        ],
+        test_name=request.node.name,
+        runtime_env=runtime_env,
+    )
+
+
+# ─── Sanity test for the 3-arm 2hr matrix ──────────────────────────────
+#
+# Short (~15 min) version of test_overload_2hr_realistic using the A4-LL-prod
+# arm config. Validates the full code path end-to-end before committing 2-3
+# hours of cluster time to the real run:
+#   - PV-rebind binding works
+#   - AIPerf job sequencing works for all 10 phase types (warmup-ramp,
+#     steady, spike, wave-segment, clustered-spike, recovery, cooldown)
+#   - Production-shape seq_dist + bursty arrivals + concurrency-ramp all
+#     produce data
+#   - Extracts complete (every load dir gets aiperf data)
+#   - Reports generate
+#
+# Run as:
+#   pytest test_overload.py::test_overload_2hr_sanity \
+#       --namespace neelays-2hr-sanity \
+#       --image nvcr.io/nvidian/dynamo-dev/vllm-runtime:release-1.2.0-cascade-test-7d8eaa70a9-neelays \
+#       -s -v --storage-class dgxc-enterprise-file \
+#       --log-pvc dynamo-ft-logs --model-cache-pvc shared-model-cache \
+#       --skip-service-restart --prefetch-model
+
+
+@pytest.mark.k8s
+@pytest.mark.e2e
+@pytest.mark.sanity
+@pytest.mark.weekly
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+async def test_overload_2hr_sanity(runtime_env, request):
+    """Short (~15 min) sanity for the 3-arm 2hr matrix. Same arm config as
+    A4-LL-prod (cascade-test image + LL + 503 gate + threshold + 30s
+    timeouts). Compressed to one short load per phase type so the full
+    code path runs end-to-end in ~15 min wall.
+
+    Pass = framework health (PVC binds, all 10 phase types run, extracts
+    succeed, reports generate). NOT a workload-correctness test — that's
+    what the full 2hr test_overload_2hr_realistic does.
+    """
+    cfg = request.config
+    image = cfg.getoption("--image") or _CASCADE_TEST_IMAGE
+
+    # A4-LL-prod config: cascade-test image + LL + 503 gate + threshold + 30s
+    os.environ[
+        "DYN_TEST_WORKER_KNOBS"
+    ] = "DYN_TCP_WORKER_POOL_SIZE=256;DYN_TCP_WORK_QUEUE_SIZE=5"
+    fe_knobs = _common_fe_knobs(router_mode="least-loaded")
+
+    spec = _load_dgd("disagg_qwen3_30b_unit_prod")
+    _apply_cascade_dgd(spec, image=image, units=3, abort_timeout_s=30)
+    _apply_cluster_portability(spec)
+    for k, v in fe_knobs.items():
+        spec["Frontend"].set_env_var(k, v)
+    for svc in ("VllmPrefillWorker", "VllmDecodeWorker"):
+        spec[svc].set_env_var("VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS", "30")
+
+    model_cache_pvc = cfg.getoption("--model-cache-pvc")
+    if model_cache_pvc:
+        spec.enable_model_cache(model_cache_pvc)
+
+    served_model = spec["VllmDecodeWorker"].model
+
+    def _load(
+        name,
+        concurrency,
+        duration_minutes,
+        *,
+        warmup_concurrency=None,
+        ramp_seconds=None,
+        bursty=False,
+    ):
+        cfg = _cascade_load(
+            served_model=served_model,
+            concurrency=concurrency,
+            duration_minutes=duration_minutes,
+            name=name,
+        )
+        cfg.seq_dist = _PROD_SEQ_DIST
+        if warmup_concurrency is not None:
+            cfg.warmup_concurrency = warmup_concurrency
+        if ramp_seconds is not None:
+            cfg.concurrency_ramp_duration = float(ramp_seconds)
+        if bursty:
+            cfg.arrival_pattern = "concurrency_burst"
+            cfg.arrival_smoothness = 0.2
+        return cfg
+
+    # Compressed workload: one short instance of each phase type.
+    # Total ~15 min: 1.5 (warmup-ramp) + 2 (steady) + 1 (spike) + 2 (wave-step)
+    #              + 2 (wave-step) + 1 (spike) + 2 (heavy) + 2 (bg+spike)
+    #              + 1 (recovery) + 1 (cooldown) ≈ 14.5 min + AIPerf overhead.
+    events = [
+        WaitForModelReady(timeout=2400),
+        PodMemoryPoller(
+            services=["Frontend", "VllmPrefillWorker", "VllmDecodeWorker"],
+            interval_s=10,
+        ),
+        # Phase-type coverage:
+        StartLoad(
+            load_config=_load(
+                "p0-warmup", 80, 1.5, warmup_concurrency=10, ramp_seconds=60
+            ),
+            name="p0-warmup",
+        ),
+        WaitForLoadCompletion(name="p0-warmup"),
+        StartLoad(
+            load_config=_load("p1-light-steady", 80, 2.0), name="p1-light-steady"
+        ),
+        WaitForLoadCompletion(name="p1-light-steady"),
+        StartLoad(
+            load_config=_load("p2-first-spike", 220, 1.0, bursty=True),
+            name="p2-first-spike",
+        ),
+        WaitForLoadCompletion(name="p2-first-spike"),
+        # Single 2-segment wave (vs 5 in full test)
+        StartLoad(load_config=_load("p4-wave-up", 200, 1.0), name="p4-wave-up"),
+        WaitForLoadCompletion(name="p4-wave-up"),
+        StartLoad(load_config=_load("p4-wave-down", 80, 1.0), name="p4-wave-down"),
+        WaitForLoadCompletion(name="p4-wave-down"),
+        StartLoad(
+            load_config=_load("p5-second-spike", 260, 1.0, bursty=True),
+            name="p5-second-spike",
+        ),
+        WaitForLoadCompletion(name="p5-second-spike"),
+        # Clustered-spike pattern: bg + 1 additive spike (vs 5 in full)
+        StartLoad(load_config=_load("p7-bg-170", 170, 2.0), name="p7-bg-170"),
+        StartLoad(
+            load_config=_load("p7-spike-1", 110, 1.0, bursty=True),
+            name="p7-spike-1",
+        ),
+        WaitForLoadCompletion(name="p7-spike-1"),
+        WaitForLoadCompletion(name="p7-bg-170"),
+        StartLoad(load_config=_load("p8-recovery", 20, 1.0), name="p8-recovery"),
+        WaitForLoadCompletion(name="p8-recovery"),
+        StartLoad(load_config=_load("p9-cooldown", 10, 1.0), name="p9-cooldown"),
+        WaitForLoadCompletion(name="p9-cooldown"),
+    ]
+
+    # Framework-health checks only — short loads, low request counts.
+    checks = [
+        LoadApplied(load_name="p1-light-steady", min_requests=50),
+        LoadApplied(load_name="p7-bg-170", min_requests=50),
+        WorkerPanics(
+            services=["VllmDecodeWorker", "VllmPrefillWorker", "Frontend"],
+            acceptable=True,
+        ),
+        RestartCountIncreased(
+            services=["VllmDecodeWorker", "Frontend"],
+            expect_min_increment=0,
+        ),
+    ]
+
+    await run_scenario(
+        deployment_spec=spec,
+        events=events,
+        checks=checks,
+        reports=[
+            FaultToleranceReport(),
+            ErrorBreakdownReport(),
+            PerWorkerLatencyReport(),
+        ],
+        test_name=request.node.name,
+        runtime_env=runtime_env,
+    )
+
+
+# ── 30-min compressed prod-config A/B/R test ────────────────────────────
+#
+# Per observe 2026-05-27-final-prod-config-test handoff (compressed from
+# their 40 min cliff to 30 min for cert-budget). Tests whether restoring
+# the prefix-scoring router signal on the 1.2 cascade-test image
+# reintroduces the cycle-6 FE memory leak. A0 is the true baseline.
+#
+# Workload: production-shape ISL/OSL (_PROD_SEQ_DIST close to prod
+# p50=2000/p95=7500) with above/below-steady stress:
+#   P0 warmup 2m → P1 c=80 4m (BELOW) → P2 c=220 bursty 1m (ABOVE cliff)
+#   → P3 c=130 4m (MID) → P4 wave 80↔200 4m → P5 c=260 bursty 1m
+#   (HARDER) → P6 c=170 6m (HIGH sub-cliff) → P7 3× c=280 spikes on
+#   170 bg 3m → P8 c=20 3m (BELOW) → P9 c=10 2m. Total 30 min.
+#
+# Engine knobs (R-cons + R-agg only — A0 stays stock 1.1.1 defaults):
+#   Prefill: --max-num-batched-tokens=65536 (THE key knob), --max-num-seqs=64,
+#            --gpu-memory-utilization=0.90
+#   Decode:  --max-num-batched-tokens=256, --max-num-seqs=256, gpu-mem=0.90
+#   Pool=256 (engine-matched), queue=32.
+
+
+@pytest.mark.k8s
+@pytest.mark.e2e
+@pytest.mark.weekly
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+@pytest.mark.parametrize(
+    "arm_label",
+    ["A0-baseline", "R-cons", "R-agg"],
+)
+async def test_overload_30min_prod_config(runtime_env, request, arm_label):
+    """30-min A/B/R: A0 baseline vs R-cons (current recommendation) vs
+    R-agg (scoring restored). See module-level comment for the workload."""
+    cfg = request.config
+
+    if arm_label == "A0-baseline":
+        image = _A0_BASELINE_IMAGE
+        os.environ["DYN_TEST_WORKER_KNOBS"] = ""
+        fe_knobs = _common_fe_knobs(router_mode="least-loaded")
+        kv_events_engine = None
+        production_tuned_engine = False
+    elif arm_label == "R-cons":
+        image = _CASCADE_TEST_IMAGE
+        os.environ[
+            "DYN_TEST_WORKER_KNOBS"
+        ] = "DYN_TCP_WORKER_POOL_SIZE=256;DYN_TCP_WORK_QUEUE_SIZE=32"
+        fe_knobs = _common_fe_knobs(router_mode="kv")
+        fe_knobs["DYN_ROUTER_USE_KV_EVENTS"] = "false"
+        fe_knobs["DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT"] = "0.0"
+        fe_knobs["DYN_ROUTER_PREFILL_LOAD_SCALE"] = "0.0"
+        kv_events_engine = "false"
+        production_tuned_engine = True
+    elif arm_label == "R-agg":
+        image = _CASCADE_TEST_IMAGE
+        os.environ[
+            "DYN_TEST_WORKER_KNOBS"
+        ] = "DYN_TCP_WORKER_POOL_SIZE=256;DYN_TCP_WORK_QUEUE_SIZE=32"
+        fe_knobs = _common_fe_knobs(router_mode="kv")
+        fe_knobs["DYN_ROUTER_USE_KV_EVENTS"] = "true"
+        fe_knobs["DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT"] = "0.4"
+        fe_knobs["DYN_ROUTER_PREFILL_LOAD_SCALE"] = "1.5"
+        kv_events_engine = "true"
+        production_tuned_engine = True
+    else:
+        raise ValueError(f"unknown arm_label: {arm_label!r}")
+
+    spec = _load_dgd("disagg_qwen3_30b_unit_prod")
+    _apply_cascade_dgd(spec, image=image, units=3, abort_timeout_s=30)
+    _apply_cluster_portability(spec)
+
+    for k, v in fe_knobs.items():
+        spec["Frontend"].set_env_var(k, v)
+
+    for svc in ("VllmPrefillWorker", "VllmDecodeWorker"):
+        spec[svc].set_env_var("VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS", "30")
+
+    if production_tuned_engine:
+        spec["VllmPrefillWorker"].set_arg("--max-num-batched-tokens", "65536")
+        spec["VllmPrefillWorker"].set_arg("--max-num-seqs", "64")
+        spec["VllmPrefillWorker"].set_arg("--gpu-memory-utilization", "0.90")
+        spec["VllmDecodeWorker"].set_arg("--max-num-batched-tokens", "256")
+        spec["VllmDecodeWorker"].set_arg("--max-num-seqs", "256")
+        spec["VllmDecodeWorker"].set_arg("--gpu-memory-utilization", "0.90")
+        if kv_events_engine is not None:
+            kv_events_arg = f'{{"enable_kv_cache_events":{kv_events_engine}}}'
+            for svc in ("VllmPrefillWorker", "VllmDecodeWorker"):
+                spec[svc].set_arg("--kv-events-config", kv_events_arg)
+
+    model_cache_pvc = cfg.getoption("--model-cache-pvc")
+    if model_cache_pvc:
+        spec.enable_model_cache(model_cache_pvc)
+
+    served_model = spec["VllmDecodeWorker"].model
+
+    def _load(
+        name,
+        concurrency,
+        duration_minutes,
+        *,
+        warmup_concurrency=None,
+        ramp_seconds=None,
+        bursty=False,
+    ):
+        c = _cascade_load(
+            served_model=served_model,
+            concurrency=concurrency,
+            duration_minutes=duration_minutes,
+            name=name,
+        )
+        c.seq_dist = _PROD_SEQ_DIST
+        if warmup_concurrency is not None:
+            c.warmup_concurrency = warmup_concurrency
+        if ramp_seconds is not None:
+            c.concurrency_ramp_duration = float(ramp_seconds)
+        if bursty:
+            c.arrival_pattern = "concurrency_burst"
+            c.arrival_smoothness = 0.2
+        return c
+
+    events = [
+        WaitForModelReady(timeout=2400),
+        PodMemoryPoller(
+            services=["Frontend", "VllmPrefillWorker", "VllmDecodeWorker"],
+            interval_s=10,
+        ),
+        StartLoad(
+            load_config=_load(
+                "p0-warmup", 80, 2.0, warmup_concurrency=10, ramp_seconds=90
+            ),
+            name="p0-warmup",
+        ),
+        WaitForLoadCompletion(name="p0-warmup"),
+        StartLoad(
+            load_config=_load("p1-light-steady", 80, 4.0), name="p1-light-steady"
+        ),
+        WaitForLoadCompletion(name="p1-light-steady"),
+        StartLoad(
+            load_config=_load("p2-first-spike", 220, 1.0, bursty=True),
+            name="p2-first-spike",
+        ),
+        WaitForLoadCompletion(name="p2-first-spike"),
+        StartLoad(
+            load_config=_load("p3-moderate-steady", 130, 4.0), name="p3-moderate-steady"
+        ),
+        WaitForLoadCompletion(name="p3-moderate-steady"),
+        StartLoad(load_config=_load("p4-wave-up", 200, 2.0), name="p4-wave-up"),
+        WaitForLoadCompletion(name="p4-wave-up"),
+        StartLoad(load_config=_load("p4-wave-down", 80, 2.0), name="p4-wave-down"),
+        WaitForLoadCompletion(name="p4-wave-down"),
+        StartLoad(
+            load_config=_load("p5-second-spike", 260, 1.0, bursty=True),
+            name="p5-second-spike",
+        ),
+        WaitForLoadCompletion(name="p5-second-spike"),
+        StartLoad(
+            load_config=_load("p6-heavy-steady", 170, 6.0), name="p6-heavy-steady"
+        ),
+        WaitForLoadCompletion(name="p6-heavy-steady"),
+        StartLoad(load_config=_load("p7-bg-170", 170, 3.0), name="p7-bg-170"),
+        StartLoad(
+            load_config=_load("p7-spike-1", 110, 1.0, bursty=True), name="p7-spike-1"
+        ),
+        WaitForLoadCompletion(name="p7-spike-1"),
+        StartLoad(
+            load_config=_load("p7-spike-2", 110, 1.0, bursty=True), name="p7-spike-2"
+        ),
+        WaitForLoadCompletion(name="p7-spike-2"),
+        StartLoad(
+            load_config=_load("p7-spike-3", 110, 1.0, bursty=True), name="p7-spike-3"
+        ),
+        WaitForLoadCompletion(name="p7-spike-3"),
+        WaitForLoadCompletion(name="p7-bg-170"),
+        StartLoad(load_config=_load("p8-recovery", 20, 3.0), name="p8-recovery"),
+        WaitForLoadCompletion(name="p8-recovery"),
+        StartLoad(load_config=_load("p9-cooldown", 10, 2.0), name="p9-cooldown"),
+        WaitForLoadCompletion(name="p9-cooldown"),
+    ]
+
+    checks = [
+        LoadApplied(load_name="p1-light-steady", min_requests=100),
+        LoadApplied(load_name="p6-heavy-steady", min_requests=200),
+        WorkerPanics(
+            services=["VllmDecodeWorker", "VllmPrefillWorker", "Frontend"],
+            acceptable=True,
+        ),
+        RestartCountIncreased(
+            services=["VllmDecodeWorker", "Frontend"],
+            expect_min_increment=0,
+        ),
+    ]
+
+    await run_scenario(
+        deployment_spec=spec,
+        events=events,
+        checks=checks,
+        reports=[
+            FaultToleranceReport(),
+            ErrorBreakdownReport(),
+            PerWorkerLatencyReport(),
+        ],
+        test_name=request.node.name,
+        runtime_env=runtime_env,
+    )

--- a/tests/fault_tolerance/deploy/test_overload.py
+++ b/tests/fault_tolerance/deploy/test_overload.py
@@ -35,7 +35,7 @@ from tests.fault_tolerance.deploy.checks import (
     _iter_server_metric,
 )
 from tests.fault_tolerance.deploy.events import (
-    PodMemoryPoller,
+    ResourcePoller,
     StartLoad,
     Wait,
     WaitForLoadCompletion,
@@ -1371,7 +1371,7 @@ async def test_kv_router_memory_stability(
         # pick up loader/init memory in the slope. interval_s=10 gives
         # ~180 samples over a 30-min steady window — smooth slope, low
         # kubectl-exec overhead.
-        PodMemoryPoller(
+        ResourcePoller(
             services=["Frontend", "VllmPrefillWorker", "VllmDecodeWorker"],
             interval_s=10,
         ),
@@ -1637,7 +1637,7 @@ async def test_overload_cascade_chain_phased(runtime_env, request, arm_label):
       P4        4 min  drop pin + c=24       recovery + final memory
 
     The pinned long load spans P1..P3 (48 min). Unpinned loads start/stop
-    per phase. PodMemoryPoller captures pod_memory_growth.tsv at 10s.
+    per phase. ResourcePoller captures pod_memory_growth.tsv at 10s.
 
     Per-arm knobs differ only in routing strategy + admission. Image
     selected via CLI ``--image`` at launch time (no per-arm hard-coded
@@ -1745,7 +1745,7 @@ async def test_overload_cascade_chain_phased(runtime_env, request, arm_label):
     events = [
         WaitForModelReady(timeout=2400),
         # Continuous FE memory polling for the full 57-min run
-        PodMemoryPoller(
+        ResourcePoller(
             services=["Frontend", "VllmPrefillWorker", "VllmDecodeWorker"],
             interval_s=10,
         ),
@@ -1972,7 +1972,7 @@ async def test_overload_natural_overload(runtime_env, request, arm_label):
     # NOTE: identical to chain_phased except worker_pin=None below.
     events = [
         WaitForModelReady(timeout=2400),
-        PodMemoryPoller(
+        ResourcePoller(
             services=["Frontend", "VllmPrefillWorker", "VllmDecodeWorker"],
             interval_s=10,
         ),
@@ -2265,7 +2265,7 @@ async def test_overload_2hr_realistic(runtime_env, request, arm_label):
     # pairs. AIPerf has ~15-30 s setup per Job, factored into total wall.
     events = [
         WaitForModelReady(timeout=2400),
-        PodMemoryPoller(
+        ResourcePoller(
             services=["Frontend", "VllmPrefillWorker", "VllmDecodeWorker"],
             interval_s=10,
         ),
@@ -2482,7 +2482,7 @@ async def test_overload_2hr_sanity(runtime_env, request):
     #              + 1 (recovery) + 1 (cooldown) ≈ 14.5 min + AIPerf overhead.
     events = [
         WaitForModelReady(timeout=2400),
-        PodMemoryPoller(
+        ResourcePoller(
             services=["Frontend", "VllmPrefillWorker", "VllmDecodeWorker"],
             interval_s=10,
         ),
@@ -2675,7 +2675,7 @@ async def test_overload_30min_prod_config(runtime_env, request, arm_label):
 
     events = [
         WaitForModelReady(timeout=2400),
-        PodMemoryPoller(
+        ResourcePoller(
             services=["Frontend", "VllmPrefillWorker", "VllmDecodeWorker"],
             interval_s=10,
         ),

--- a/tests/fault_tolerance/deploy/test_overload.py
+++ b/tests/fault_tolerance/deploy/test_overload.py
@@ -1638,7 +1638,7 @@ async def test_overload_cascade_chain_phased(runtime_env, request, arm_label):
       P4        4 min  drop pin + c=24       recovery + final memory
 
     The pinned long load spans P1..P3 (48 min). Unpinned loads start/stop
-    per phase. ResourcePoller captures pod_memory_growth.tsv at 10s.
+    per phase. ResourcePoller captures per-pod resources.agg.tsv at 10s.
 
     Per-arm knobs differ only in routing strategy + admission. Image
     selected via CLI ``--image`` at launch time (no per-arm hard-coded

--- a/tests/fault_tolerance/deploy/test_overload.py
+++ b/tests/fault_tolerance/deploy/test_overload.py
@@ -58,8 +58,9 @@ dgd = "disagg_qwen3_30b_unit_prod"
 
 _DEFAULT_IMAGE = "nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1"
 
-# Production-shaped traffic distribution (ISL/OSL pairs with realistic
-# long-tail mix). Same distribution as the n3 routing-threshold test.
+# Realistic long-tail traffic distribution (ISL/OSL pairs with a
+# realistic long-tail mix). Same distribution as the n3
+# routing-threshold test.
 _PROD_SEQ_DIST = "100,200:5;500,200:15;1000,200:20;1600,200:30;3400,200:20;7000,200:10"
 _NUM_PREFIX_PROMPTS = 15
 _PREFIX_PROMPT_LENGTH = 600
@@ -85,8 +86,9 @@ def add_cli_options(parser):
         "--units",
         type=int,
         default=3,
-        help="Convenience: scale frontend/prefill/decode together (prod-unit "
-        "replicas). Default 3 (3F : 6P : 3D = 18 GPUs).",
+        help="Convenience: scale frontend/prefill/decode together (per-unit "
+        "replicas at the 2:1 prefill:decode ratio). Default 3 "
+        "(3F : 6P : 3D = 18 GPUs).",
     )
     g.addoption(
         "--frontend-replicas",
@@ -166,7 +168,7 @@ def _apply_topology(spec, units, fe, pf, dec):
 def _apply_recommended_kv_router_config(spec) -> None:
     """Apply the canonical A4 "recommended KV-aware" Frontend config.
 
-    This is the **prescribed production config** from the prior
+    This is the **prescribed recommended config** from the prior
     KV-pressure cascade analysis (§A4 — `Recommendations —
     Without code change`). Pure-load steering with cross-FE visibility:
     KV-aware routing mode + zeroed prefix-cache scoring + cross-FE
@@ -210,7 +212,7 @@ def _apply_recommended_kv_router_config(spec) -> None:
     fe.set_env_var("DYN_ROUTER_USE_KV_EVENTS", "false")
     # **Critical**: cross-FE replica sync. v1.1.1 default is False, which
     # leaves each FE blind to its peers' routing decisions — the exact
-    # mechanism that caused the the cross-FE cascade propagation.
+    # mechanism that caused the cross-FE cascade propagation.
     fe.set_env_var("DYN_ROUTER_REPLICA_SYNC", "true")
     # Deterministic argmin (no softmax-sampling exploration). Default 0,
     # set explicitly for clarity.
@@ -243,8 +245,8 @@ def _apply_router_config(
 ) -> None:
     """Apply the final-recommended router config to the Frontend spec.
 
-    Defaults match the recipe from the prior cascade-reproducer doc
-    (and the joint thread close-out): per-worker admission thresholds
+    Defaults match the recommended cascade-mitigation recipe:
+    per-worker admission thresholds
     enabled at 0.85, KV-aware routing with prefix-cache weight zeroed,
     deterministic argmin selection, no KV events. The same config is
     applied to every comparison arm — the diff between arms is purely
@@ -306,8 +308,7 @@ def _apply_cluster_portability(spec):
         spec[svc].set_env_var("DYN_TEST_MEMLOCK_UNLIMITED", "1")
 
     # Pod-level fsGroup=1000 on every service + Frontend runAsUser=0.
-    # The prior working DGD (dynamo-observe/.../2026-05-03-cascade-repro-
-    # results/) set BOTH. Reasoning:
+    # A prior working DGD set BOTH. Reasoning:
     #   - fsGroup=1000 makes k8s recursively chown the mounted volume to
     #     gid 1000 (dynamo user's group) and SGID-bit the dirs — but
     #     that's only group membership; write is still owner-only under
@@ -329,8 +330,9 @@ def _apply_cluster_portability(spec):
     )
     fe_main.setdefault("securityContext", {})["runAsUser"] = 0
 
-    # Prod runs A100-40GB; both shared clusters above run 80GB cards.
-    # Halve gpu-memory-utilization to match prod KV envelope.
+    # The target deployment runs A100-40GB; both shared clusters above
+    # run 80GB cards. Halve gpu-memory-utilization to match the 40GB
+    # KV envelope.
     for svc in ("VllmPrefillWorker", "VllmDecodeWorker"):
         spec[svc].set_arg("--gpu-memory-utilization", "0.5")
 
@@ -399,7 +401,7 @@ class _PerPodKvImbalanceGap(Check):
 @pytest.mark.weekly
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 async def test_decode_overload(runtime_env, request):
-    """Drive prod-shaped load past sustainable concurrency; observe
+    """Drive realistically-shaped load past sustainable concurrency; observe
     per-pod KV imbalance and goodput collapse on the decode pool.
 
     No fault injection — this is the natural-cascade scenario. Same
@@ -492,9 +494,7 @@ async def test_decode_overload(runtime_env, request):
 
 # ─── Cascade-repro scenarios (cascade reproduction) ─────────────────────────
 # These tests reproduce the cascade-failure regime on a
-# small dev pool. Source spec lives in GitLab `neelays/dynamo-observe`
-# under the cascade-small-pool reproducer scenarios/
-# (FRAMEWORK_TASK.md + PLAN.md).
+# small dev pool.
 #
 # Reuses the existing disagg_qwen3_30b_unit_prod template. The only
 # cascade-specific deltas are applied via _apply_cascade_dgd below
@@ -524,7 +524,7 @@ def _apply_cascade_dgd(
     ``vllm_extra_args``: optional list of vLLM CLI args (e.g.
     ``["--max-num-seqs", "128"]``) appended to BOTH ``VllmPrefillWorker``
     and ``VllmDecodeWorker``'s ``extraPodSpec.mainContainer.args``. Used
-    by the cascade fail-fast S2 / S3 experiments (2026-05-26 handoff) to
+    by the cascade fail-fast S2 / S3 experiments to
     cap engine running-batch size and starve the cascade at the source.
     Existing args are left untouched; if a flag is already present, the
     helper overwrites its value (via ``ServiceSpec.set_arg``).
@@ -545,9 +545,9 @@ def _apply_cascade_dgd(
         spec[svc].set_env_var("VLLM_NIXL_ABORT_REQUEST_TIMEOUT", str(abort_timeout_s))
 
     # Per-test admission-control knobs. Set via env at launch time so a
-    # single test function can drive the cascade matrix from observe's
-    # 5-hr-burst handoff (DIS-2105 needs DYN_TCP_WORK_QUEUE_SIZE, PR #9858
-    # needs DYN_VLLM_REJECT_QUEUE_THRESHOLD; baseline gets neither).
+    # single test function can drive the cascade matrix under a sustained
+    # burst (the TCP work-queue rejection path needs DYN_TCP_WORK_QUEUE_SIZE,
+    # PR #9858 needs DYN_VLLM_REJECT_QUEUE_THRESHOLD; baseline gets neither).
     # Format: semicolon-separated KEY=VALUE list. Empty → no overrides.
     # Example: DYN_TEST_WORKER_KNOBS="DYN_TCP_WORK_QUEUE_SIZE=256;DYN_VLLM_REJECT_QUEUE_THRESHOLD=80"
     knob_source = (
@@ -601,17 +601,16 @@ def _cascade_load(
 ) -> LoadConfig:
     """LoadConfig shared by the cascade scenarios.
 
-    Defaults match the FRAMEWORK_TASK §3.1 spec: no warmup-requests, fresh
+    Defaults: no warmup-requests, fresh
     sockets per request (so any disconnect actually closes the underlying
     TCP), goodput SLO at 20s e2e latency. ISL/OSL default to a
-    steady-state production-shape pair; override per-scenario.
+    steady-state, realistic ISL/OSL pair; override per-scenario.
 
     ``request_cancellation_rate`` (0.0-1.0, optional): pass to AIPerf so a
     fraction of requests get mid-flight client disconnects. Used by S1's
     cliff rung to exercise the ``_DeferredAbort`` path + 480-s NIXL abort
     timer — without cancellations to feed the path, the timer never fires
-    and we can't claim production-parity recovery behaviour. Per observe-
-    agent NEXT_STEPS_FOR_TEST_AGENT P0.2 (sanity-suite work).
+    and we can't claim realistic recovery behaviour.
     """
     return LoadConfig(
         model_name=served_model,
@@ -624,7 +623,7 @@ def _cascade_load(
         prefix_prompt_length=512,
         concurrency=concurrency,
         duration_minutes=duration_minutes,
-        # 40s per observe NEXT_STEPS — last cycle's cliff p99 was ~21s and
+        # 40s — an earlier cycle's cliff p99 was ~21s and
         # the old 20s timeout truncated slow-but-real 503 responses, making
         # it impossible to tell "rejection fired slowly" from "didn't fire".
         request_timeout_seconds=40,
@@ -917,17 +916,18 @@ async def test_overload_cascade_sanity_natural(
     )
 
 
-# ─── Cascade fail-fast spike (S1 of 2026-05-26 fail-fast handoff) ──────
+# ─── Cascade fail-fast spike (S1) ──────────────────────────────────────
 #
-# Goal: prove the DIS-2105 TCP `work_tx.try_send()` rejection path
+# Goal: prove the TCP work-queue rejection path (`work_tx.try_send()`)
 # actually surfaces an HTTP 503 (or `TrySendError::Full` worker log
-# line) under a c=300 instant burst, no warmup. The prior cycle ran
+# line) under a c=300 instant burst, no warmup. A prior cycle ran
 # POOL=128 / QUEUE=32 and saw zero 503s in any log — inflight pegged at
 # 128, suggesting the cap engaged silently. This test asserts the
 # observable side of the cap.
 #
-# Launcher MUST pass the DIS-2105 patched image:
-#   --image nvcr.io/nvidian/dynamo-dev/<...>/vllm-runtime:dis-2105-v1.1.1-<sha>-...
+# Launcher MUST pass an image carrying the TCP work-queue rejection /
+# backpressure path:
+#   --image nvcr.io/nvidian/dynamo-dev/<...>/vllm-runtime:<...>
 # (Hardcoding the image would couple the test to a specific build; the
 # fallback ``_DEFAULT_IMAGE`` is stock 1.1.1 and will pass-fail this
 # test as a control arm.)
@@ -946,19 +946,20 @@ async def test_overload_cascade_sanity_natural(
     ],
 )
 async def test_overload_cascade_spike(runtime_env, request, concurrency, duration_min):
-    """Cascade fail-fast S1 spike — DIS-2105 rejection-path surfacing.
+    """Cascade fail-fast S1 spike — TCP work-queue rejection-path surfacing.
 
     N=2 disagg topology, c=300 instant burst with no warmup. The TCP
     worker pool defaults (overrideable via ``DYN_TEST_WORKER_KNOBS``)
-    are ``DYN_TCP_WORKER_POOL_SIZE=128, DYN_TCP_WORK_QUEUE_SIZE=32`` —
-    matching the handoff's S1 row. Pass if ANY 503-rejection signal
+    are ``DYN_TCP_WORKER_POOL_SIZE=128, DYN_TCP_WORK_QUEUE_SIZE=32``.
+    Pass if ANY 503-rejection signal
     fires during the burst (AIPerf 503 OR worker
     ``TrySendError::Full`` log line OR Frontend ``Status code: 503``
     filtered to the load window).
 
-    The launcher is responsible for passing the DIS-2105 patched image
-    via ``--image``. Without it, ``RejectionFired`` will fail — by
-    design, since that's the whole point of the experiment.
+    The launcher is responsible for passing an image carrying the TCP
+    work-queue rejection / backpressure path via ``--image``. Without
+    it, ``RejectionFired`` will fail — by design, since that's the
+    whole point of the experiment.
     """
     cfg = request.config
     image = cfg.getoption("--image") or _CASCADE_IMAGE
@@ -1051,22 +1052,21 @@ async def test_overload_cascade_spike(runtime_env, request, concurrency, duratio
 @pytest.mark.parametrize(
     "units,concurrency,duration_min,abort_timeout,vllm_max_num_seqs,override_worker_knobs",
     [
-        # Default: production-mirror — N=3, c=216, 45-min hold, 480s NIXL timer.
+        # Default: realistic-shape mirror — N=3, c=216, 45-min hold, 480s NIXL timer.
         (3, 216, 45, 480, None, None),
-        # S2 (2026-05-26 cascade fail-fast handoff): cap engine running-batch
-        # at 128 via vLLM CLI. No DIS-2105 image required — stock 1.1.1
-        # plus --max-num-seqs=128 alone is the lever. Pass if goodput
-        # holds ≥ 50% of pre-cliff OR KV peak < 0.95 (assertions live on
-        # the existing cascade-signature checks; the row exercises the
-        # cap).
+        # S2: cap engine running-batch
+        # at 128 via vLLM CLI. No work-queue-rejection image required —
+        # stock 1.1.1 plus --max-num-seqs=128 alone is the lever. Pass if
+        # goodput holds ≥ 50% of pre-cliff OR KV peak < 0.95 (assertions
+        # live on the existing cascade-signature checks; the row exercises
+        # the cap).
         (3, 216, 45, 480, 128, None),
-        # S3 combo: DIS-2105 image + --max-num-seqs=128 + smaller
-        # POOL/QUEUE knobs (64/16, half the S1-spike values) so the TCP
-        # rejection path engages alongside the engine-side cap. Per the
-        # handoff: launcher MUST pass --image
-        #   nvcr.io/.../vllm-runtime:dis-2105-v1.1.1-...
-        # for this row to do anything meaningful — the parametrize
-        # itself only carries the knob deltas, not the image.
+        # S3 combo: an image carrying the TCP work-queue rejection path +
+        # --max-num-seqs=128 + smaller POOL/QUEUE knobs (64/16, half the
+        # S1-spike values) so the TCP rejection path engages alongside the
+        # engine-side cap. Launcher MUST pass an image carrying that path
+        # via --image for this row to do anything meaningful — the
+        # parametrize itself only carries the knob deltas, not the image.
         (
             3,
             216,
@@ -1093,14 +1093,14 @@ async def test_overload_cascade(
 ):
     """S1 — full cascade demonstration under natural LeastLoaded routing.
 
-    Drives sustained load past the per-pod cliff on a production-shape N=3
+    Drives sustained load past the per-pod cliff on a realistic-shape N=3
     topology and asserts the full cascade signature: KV peg →
     WaitingForKVTransfer pool explosion → NIXL xfer_time blow-up →
     generation throughput collapse → cliff propagates to a second decode
     pod within the run window.
 
     Admission thresholds are deliberately UNSET so the FE inherits
-    v1.1.1's permissive-sentinel defaults (matches production). Setting
+    v1.1.1's permissive-sentinel defaults. Setting
     them is the mitigation tested in S3 (future row); this scenario is
     the unmitigated baseline.
 
@@ -1155,8 +1155,8 @@ async def test_overload_cascade(
         # cancellations feed the `_DeferredAbort` path so the 480-s NIXL
         # abort timer actually fires during the 45-min hold. Without
         # these, no requests cancel → no stranded prefill blocks → the
-        # primary production-recovery mechanism never exercises in dev.
-        # Per observe-agent NEXT_STEPS P0.2 (sanity-suite work).
+        # primary KV-transfer-abort recovery mechanism never exercises in
+        # dev.
         StartLoad(
             load_config=_cascade_load(
                 served_model=served_model,
@@ -1250,12 +1250,12 @@ async def test_overload_cascade(
         # teardown ≈ 40 min wall.
         #
         # Three router configs run head-to-head — same workload, same
-        # topology, same image, only routing differs. Lets the observe
-        # agent compare per-pod memory slopes side-by-side.
+        # topology, same image, only routing differs. Lets an analyst
+        # compare per-pod memory slopes side-by-side.
         ("a4-recommended", 2, 2.0, 3.0, 18.0, 3.0, 2.0),
         ("least-loaded-baseline", 2, 2.0, 3.0, 18.0, 3.0, 2.0),
-        # Round-2 P0.1: A4 minus replica-sync. Single-variable
-        # isolation of today's leak hypothesis. If FE slope drops to
+        # A4 minus replica-sync. Single-variable
+        # isolation of the leak hypothesis. If FE slope drops to
         # LL territory (~2.6 MB/min) under this arm, replica-sync's
         # request-lifecycle accumulation (ActiveSequencesMultiWorker)
         # is confirmed as the dominant retention path.
@@ -1276,8 +1276,8 @@ async def test_kv_router_memory_stability(
     """Memory-stability test for the recommended A4 KV-router config.
 
     Drives a U-shape concurrency ramp (12 → 24 → 48 → 24 → 12) under the
-    canonical "recommended A4" Frontend config from the the cascade reproduction
-    cascade analysis. Asserts that per-pod working-set memory
+    canonical "recommended A4" Frontend config from the prior cascade
+    analysis. Asserts that per-pod working-set memory
     grows at most ``ceiling`` MB/min over the run — i.e. that the
     recommended config does NOT leak.
 
@@ -1288,7 +1288,7 @@ async def test_kv_router_memory_stability(
     aggregate-throughput report makes the steady-state shape visible
     for review.
 
-    Workload: production-shaped ``_PROD_SEQ_DIST`` (long-tail ISL/OSL
+    Workload: long-tail ``_PROD_SEQ_DIST`` (realistic ISL/OSL mix
     with prefix overlap) so the KV-router actually exercises its
     sequence-state plumbing under realistic prefill / decode mix.
     """
@@ -1303,7 +1303,7 @@ async def test_kv_router_memory_stability(
 
     # Branch on the parametrize axis: A4 recommended (KV-aware + cross-FE
     # sync + admission shedding at 0.85) vs LeastLoaded baseline (the
-    # unmitigated production arm — same admission thresholds so the only
+    # unmitigated baseline arm — same admission thresholds so the only
     # variable is the routing-mode-derived load model).
     if router_config == "a4-recommended":
         _apply_recommended_kv_router_config(spec)
@@ -1320,14 +1320,13 @@ async def test_kv_router_memory_stability(
         # replica-sync flipped off. Everything else identical to the
         # "a4-recommended" arm so the slope delta cleanly attributes
         # to ActiveSequencesMultiWorker's request-lifecycle accounting.
-        # Per observe-agent NEXT_STEPS round-2 P0.1.
         _apply_recommended_kv_router_config(spec)
         spec["Frontend"].set_env_var("DYN_ROUTER_REPLICA_SYNC", "false")
     else:
         raise ValueError(f"unknown router_config: {router_config!r}")
 
     # Per-launch FE env-var override. Mirrors the cascade-side
-    # DYN_TEST_WORKER_KNOBS pattern but for Frontend so observe's R2
+    # DYN_TEST_WORKER_KNOBS pattern but for Frontend so a
     # toggle-sweep can drive single-knob isolations from the launch
     # env without forking the test function per toggle. Format:
     # semicolon-separated KEY=VALUE list, empty → no overrides.
@@ -1348,7 +1347,7 @@ async def test_kv_router_memory_stability(
     served_model = spec["VllmDecodeWorker"].model
 
     def _steady_load(concurrency: float, duration_minutes: float, name: str):
-        """Prod-mix LoadConfig for a single rung of the U-shape."""
+        """Realistic-mix LoadConfig for a single rung of the U-shape."""
         return LoadConfig(
             model_name=served_model,
             tokenizer=served_model,
@@ -1458,7 +1457,7 @@ async def test_kv_router_memory_stability(
         # min — that pair will cliff. Concurrent Load B is natural-
         # routing c=32 ISL=2000 for 10 min — exercises peers, MAY split
         # some traffic onto the saturated decode#0 if the routing layer
-        # is blind to its overload (the the cross-FE blind spot).
+        # is blind to its overload (the cross-FE blind spot).
         (2, 64, 6000, 10.0, 32, 10.0),
     ],
 )
@@ -1504,14 +1503,15 @@ async def test_overload_cascade_pinned_with_bg(
     _apply_cluster_portability(spec)
 
     # LeastLoaded routing with NO admission shedding — the unmitigated
-    # baseline that matches the production arm. The cross-FE blind-spot
+    # baseline arm. The cross-FE blind-spot
     # only manifests in this config. To probe the recommended-A4
     # remediation, swap to `_apply_recommended_kv_router_config(spec)`
     # in a future parametrize row.
     spec["Frontend"].set_env_var("DYN_ROUTER_MODE", "least-loaded")
     spec["Frontend"].set_env_var("DYN_ROUTER_USE_KV_EVENTS", "false")
 
-    # NIXL abort timer: 30s mitigation (default 480 implicated in prior outage).
+    # NIXL abort timer: 30s mitigation (the 480 default lets stranded
+    # KV transfers accumulate during a cascade).
     for svc in ("VllmPrefillWorker", "VllmDecodeWorker"):
         spec[svc].set_env_var("VLLM_NIXL_ABORT_REQUEST_TIMEOUT", "30")
 
@@ -1566,8 +1566,8 @@ async def test_overload_cascade_pinned_with_bg(
         LoadCompleted(name="cliff"),
         LoadCompleted(name="bg"),
         # Sanity that the pin actually concentrated load on decode#0
-        # (KV peg = pin worked + cluster is in the cliff regime). The
-        # observe agent reads per-pod KV / W4RK / NIXL from the JSONL
+        # (KV peg = pin worked + cluster is in the cliff regime). An
+        # analyst reads per-pod KV / W4RK / NIXL from the JSONL
         # for both loads to classify whether the cliff stayed contained
         # or propagated to the peer decode.
         KvCacheUsagePeak(
@@ -1603,13 +1603,14 @@ async def test_overload_cascade_pinned_with_bg(
 # ─── N=3 cascade-prevention chain-phased 4-arm demo ────────────────────
 #
 # 4 arms × 57-min cliff (cold-spike + imbalance + extended steady for memory).
-# Per the 2026-05-26-n3-cascade-prevention-demo-handoff.md (revised). All
-# arms use the prod-shape N=3 disagg topology (3 FE + 6 prefill + 3 decode).
+# All arms use the realistic-shape N=3 disagg topology
+# (3 FE + 6 prefill + 3 decode).
 #
-#   A — LL no admission           v1.1.1 stock                 LeastLoaded, no admission knobs
-#   B — LL + DIS-2105 rejection   v1.1.1 + 06a9efb537           LeastLoaded + pool=32, queue=8
-#   C — KV no replica-sync        release/1.2.0                 KV zero-weight + queue=4.0, no replica sync
-#   D — KV + replica-sync         release/1.2.0                 same as C + DYN_ROUTER_REPLICA_SYNC=true
+#   A — LL no admission           v1.1.1 stock     LeastLoaded, no admission knobs
+#   B — LL + TCP work-queue       v1.1.1 + work-   LeastLoaded + pool=32, queue=8
+#       rejection                 queue-rejection
+#   C — KV no replica-sync        release/1.2.0    KV zero-weight + queue=4.0, no replica sync
+#   D — KV + replica-sync         release/1.2.0    same as C + DYN_ROUTER_REPLICA_SYNC=true
 #
 # Launch via scripts/launch-n3-cascade-prevention-demo.sh which fans out
 # to 4 namespaces and supplies per-arm --image.
@@ -1621,13 +1622,13 @@ async def test_overload_cascade_pinned_with_bg(
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 @pytest.mark.parametrize(
     "arm_label",
-    ["A-LL", "B-LL-DIS2105", "C-KV-no-sync", "D-KV-sync"],
+    ["A-LL", "B-LL-reject", "C-KV-no-sync", "D-KV-sync"],
 )
 async def test_overload_cascade_chain_phased(runtime_env, request, arm_label):
     """N=3 cluster-resilience demo across four admission strategies.
 
     Workload (57 min total):
-      P-spike   1 min  idle → c=150 sudden  cold-onset (production-shape)
+      P-spike   1 min  idle → c=150 sudden  cold-onset (realistic shape)
       P-recov   2 min  idle                  reset
       P0        2 min  c=24 unpinned         baseline + memory anchor
       P1        4 min  c=80 pinned to dec#0  imbalance under cap
@@ -1659,9 +1660,9 @@ async def test_overload_cascade_chain_phased(runtime_env, request, arm_label):
             "DYN_ROUTER_MODE": "least-loaded",
             "DYN_ROUTER_USE_KV_EVENTS": "false",
         }
-    elif arm_label == "B-LL-DIS2105":
-        # LL + worker-side rejection (DIS-2105 fix). Image must be the
-        # 06a9efb537-built v1.1.1 base.
+    elif arm_label == "B-LL-reject":
+        # LL + worker-side TCP work-queue rejection. Image must carry the
+        # work-queue rejection / backpressure path on a v1.1.1 base.
         os.environ[
             "DYN_TEST_WORKER_KNOBS"
         ] = "DYN_TCP_WORKER_POOL_SIZE=32;DYN_TCP_WORK_QUEUE_SIZE=8"
@@ -1686,7 +1687,7 @@ async def test_overload_cascade_chain_phased(runtime_env, request, arm_label):
             "DYN_ROUTER_QUEUE_THRESHOLD": "4.0",
         }
     elif arm_label == "D-KV-sync":
-        # Same as C but WITH replica-sync — the production-proposed config.
+        # Same as C but WITH replica-sync — the recommended config.
         os.environ["DYN_TEST_WORKER_KNOBS"] = ""
         fe_knobs = {
             "DYN_ROUTER_MODE": "kv",
@@ -1707,7 +1708,7 @@ async def test_overload_cascade_chain_phased(runtime_env, request, arm_label):
         spec,
         image=image,
         units=3,  # N=3 disagg
-        abort_timeout_s=30,  # mitigation (default 480 implicated in prior outage)
+        abort_timeout_s=30,  # mitigation (480 default lets stranded KV transfers accumulate)
         vllm_extra_args=vllm_extra_args,
     )
     _apply_cluster_portability(spec)
@@ -1722,7 +1723,7 @@ async def test_overload_cascade_chain_phased(runtime_env, request, arm_label):
 
     served_model = spec["VllmDecodeWorker"].model
 
-    # Phase durations (minutes) per the 2026-05-26 handoff (revised)
+    # Phase durations (minutes)
     PSPIKE_MIN = 1.0
     PRECOV_MIN = 2.0
     P0_MIN = 2.0
@@ -1833,8 +1834,8 @@ async def test_overload_cascade_chain_phased(runtime_env, request, arm_label):
         WaitForLoadCompletion(name="p4-recovery"),
     ]
 
-    # Framework-health asserts only. The per-arm A/B/C/D comparison per
-    # the handoff is post-hoc — per-phase goodput, per-pod KV containment,
+    # Framework-health asserts only. The per-arm A/B/C/D comparison is
+    # post-hoc — per-phase goodput, per-pod KV containment,
     # 503/Timeout/504 accounting, FE memory slope.
     checks = [
         LoadApplied(load_name="p0-warmup", min_requests=50),
@@ -1882,7 +1883,7 @@ async def test_overload_cascade_chain_phased(runtime_env, request, arm_label):
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 @pytest.mark.parametrize(
     "arm_label",
-    ["A-LL", "B-LL-DIS2105", "C-KV-no-sync", "D-KV-sync"],
+    ["A-LL", "B-LL-reject", "C-KV-no-sync", "D-KV-sync"],
 )
 async def test_overload_natural_overload(runtime_env, request, arm_label):
     """N=3 routing-balance demo across 4 arms — NO pinning.
@@ -1907,7 +1908,7 @@ async def test_overload_natural_overload(runtime_env, request, arm_label):
             "DYN_ROUTER_MODE": "least-loaded",
             "DYN_ROUTER_USE_KV_EVENTS": "false",
         }
-    elif arm_label == "B-LL-DIS2105":
+    elif arm_label == "B-LL-reject":
         os.environ[
             "DYN_TEST_WORKER_KNOBS"
         ] = "DYN_TCP_WORKER_POOL_SIZE=32;DYN_TCP_WORK_QUEUE_SIZE=8"
@@ -1951,7 +1952,7 @@ async def test_overload_natural_overload(runtime_env, request, arm_label):
         spec,
         image=image,
         units=3,
-        abort_timeout_s=30,  # mitigation (default 480 implicated in prior outage)
+        abort_timeout_s=30,  # mitigation (480 default lets stranded KV transfers accumulate)
         vllm_extra_args=vllm_extra_args,
     )
     _apply_cluster_portability(spec)
@@ -2080,16 +2081,12 @@ async def test_overload_natural_overload(runtime_env, request, arm_label):
     )
 
 
-# ─── 3-arm 2-hour A/B vs production-current baseline ───────────────────
+# ─── 3-arm 2-hour A/B vs current-release baseline ──────────────────────
 #
-# Per the 2026-05-27 proposal for observe review:
-#   ~/dynamo-dev/dgh-703-cascade-repro-tests/findings/
-#       2026-05-27-3arm-test-proposal-for-observe.md
-#
-# Goal: compare production-current (v1.1.1 + LL) against the cascade-test
-# image in two routing modes (LL with the full DIS-2105 / 7d8eaa70a9 /
+# Goal: compare the current release (v1.1.1 + LL) against the cascade-test
+# image in two routing modes (LL with the full TCP work-queue rejection /
 # 30s-NIXL stack, and KV-pure-load with the same stack). 10-phase 2-hour
-# workload from observe's 2026-05-27 handoff: warmup → light → spike →
+# workload: warmup → light → spike →
 # moderate → wave → spike → heavy → clustered-spikes → recovery →
 # cooldown.
 #
@@ -2139,10 +2136,10 @@ def _common_fe_knobs(router_mode: str) -> dict[str, str]:
     ["A0-true-baseline", "A4-LL-prod", "R-KV-recommended", "A4-tight-pool"],
 )
 async def test_overload_2hr_realistic(runtime_env, request, arm_label):
-    """2-hour A/B/R — production-current v1.1.1 vs cascade-test image in LL
+    """2-hour A/B/R — current-release v1.1.1 vs cascade-test image in LL
     and KV-pure-load modes, under a realistic 10-phase varying workload.
 
-    Workload (120 min total, per observe 2026-05-27 handoff):
+    Workload (120 min total):
       P0 — warmup            5 min   ramp 0 → 80
       P1 — light steady     25 min   c=80 (low safe band)
       P2 — first spike       3 min   80 → 220 → 80 (above-cliff #1)
@@ -2156,9 +2153,9 @@ async def test_overload_2hr_realistic(runtime_env, request, arm_label):
 
     Per-arm differences are only in (image, router-mode, 503-gate presence);
     every other env / arg is identical across arms to isolate those three
-    variables. See the proposal doc for the full configuration table.
+    variables.
 
-    Pass criteria for R (per observe): goodput ≥ 95 %, decode CV < 0.05,
+    Pass criteria for R: goodput ≥ 95 %, decode CV < 0.05,
     0 pods at KV ≥ 99 % for > 30 s, NIXL kv_expired_reqs < 500, FE memory
     slope < 5 MB/min, 0 pod restarts. A0 is expected to fail several of
     these — it's the comparison reference. A4 measured against the same
@@ -2185,12 +2182,12 @@ async def test_overload_2hr_realistic(runtime_env, request, arm_label):
         fe_knobs = _common_fe_knobs(router_mode="kv")
     elif arm_label == "A4-tight-pool":
         # Same as A4-LL-prod but with tightened admission gate to prevent
-        # the NIXL-stall cascade observed at Event 24/40 in the
-        # 2026-05-27 3-arm run (pool=256 == max-num-seqs filled engine,
-        # ~256 stranded sequences blocked forward progress).
+        # the NIXL-stall cascade observed when pool=256 == max-num-seqs
+        # filled the engine (~256 stranded sequences blocked forward
+        # progress).
         #
-        # Sizing rationale (cycle 11 empirical: ~35 inflight per pod at
-        # c=104 steady): pool=64 ≈ 2× steady, leaves 192 of forward-progress
+        # Sizing rationale (empirically ~35 inflight per pod at c=104
+        # steady): pool=64 ≈ 2× steady, leaves 192 of forward-progress
         # headroom in the engine. Threshold lowered to 0.75 so mitigation 1
         # fires before NIXL stall fills the cache.
         image = _CASCADE_TEST_IMAGE
@@ -2229,10 +2226,9 @@ async def test_overload_2hr_realistic(runtime_env, request, arm_label):
 
     served_model = spec["VllmDecodeWorker"].model
 
-    # Production-shape ISL/OSL distribution (matches observe handoff
-    # _PROD_SEQ_DIST: p50 ~1600, p99 ~7000, OSL ~200). 6 buckets with the
-    # lognormal-ish shape production traffic actually follows. Reuses the
-    # module-level constant defined above.
+    # Realistic ISL/OSL distribution (_PROD_SEQ_DIST: p50 ~1600,
+    # p99 ~7000, OSL ~200). 6 buckets with a lognormal-ish long-tail
+    # shape. Reuses the module-level constant defined above.
     def _load(
         name,
         concurrency,
@@ -2242,7 +2238,7 @@ async def test_overload_2hr_realistic(runtime_env, request, arm_label):
         ramp_seconds=None,
         bursty=False,
     ):
-        """LoadConfig with production-shape seq_dist and optional ramp /
+        """LoadConfig with realistic-shape seq_dist and optional ramp /
         bursty-arrival shaping. Wraps `_cascade_load` then overrides
         seq_dist + ramp fields."""
         cfg = _cascade_load(
@@ -2288,7 +2284,7 @@ async def test_overload_2hr_realistic(runtime_env, request, arm_label):
         ),
         WaitForLoadCompletion(name="p1-light-steady"),
         # P2 — first spike: 3 min at c=220 with bursty arrivals
-        # (production cliff events are bursty, not uniform).
+        # (real cliff events are bursty, not uniform).
         StartLoad(
             load_config=_load("p2-first-spike", 220, 3.0, bursty=True),
             name="p2-first-spike",
@@ -2359,14 +2355,14 @@ async def test_overload_2hr_realistic(runtime_env, request, arm_label):
         WaitForLoadCompletion(name="p9-cooldown"),
     ]
 
-    # Pass criteria — observe's full set for R; A4 measured against same;
+    # Pass criteria — the full set for R; A4 measured against same;
     # A0 captures all metrics but expected-to-fail (no gates).
     checks = [
         # Framework health
         LoadApplied(load_name="p1-light-steady", min_requests=200),
         LoadApplied(load_name="p3-moderate-steady", min_requests=500),
         LoadApplied(load_name="p6-heavy-steady", min_requests=500),
-        # Cascade signature gates (informational; observe analyses post-hoc)
+        # Cascade signature gates (informational; analysed post-hoc)
         WorkerPanics(
             services=["VllmDecodeWorker", "VllmPrefillWorker", "Frontend"],
             acceptable=True,
@@ -2399,7 +2395,7 @@ async def test_overload_2hr_realistic(runtime_env, request, arm_label):
 #   - PV-rebind binding works
 #   - AIPerf job sequencing works for all 10 phase types (warmup-ramp,
 #     steady, spike, wave-segment, clustered-spike, recovery, cooldown)
-#   - Production-shape seq_dist + bursty arrivals + concurrency-ramp all
+#   - Realistic seq_dist + bursty arrivals + concurrency-ramp all
 #     produce data
 #   - Extracts complete (every load dir gets aiperf data)
 #   - Reports generate
@@ -2557,13 +2553,12 @@ async def test_overload_2hr_sanity(runtime_env, request):
 
 # ── 30-min compressed prod-config A/B/R test ────────────────────────────
 #
-# Per observe 2026-05-27-final-prod-config-test handoff (compressed from
-# their 40 min cliff to 30 min for cert-budget). Tests whether restoring
+# Compressed to 30 min for cert-budget. Tests whether restoring
 # the prefix-scoring router signal on the 1.2 cascade-test image
-# reintroduces the cycle-6 FE memory leak. A0 is the true baseline.
+# reintroduces the earlier FE memory-growth path. A0 is the true baseline.
 #
-# Workload: production-shape ISL/OSL (_PROD_SEQ_DIST close to prod
-# p50=2000/p95=7500) with above/below-steady stress:
+# Workload: realistic long-tail ISL/OSL (_PROD_SEQ_DIST,
+# p50~2000/p95~7500) with above/below-steady stress:
 #   P0 warmup 2m → P1 c=80 4m (BELOW) → P2 c=220 bursty 1m (ABOVE cliff)
 #   → P3 c=130 4m (MID) → P4 wave 80↔200 4m → P5 c=260 bursty 1m
 #   (HARDER) → P6 c=170 6m (HIGH sub-cliff) → P7 3× c=280 spikes on

--- a/tests/fault_tolerance/deploy/test_router_modes.py
+++ b/tests/fault_tolerance/deploy/test_router_modes.py
@@ -1,0 +1,276 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# YAML-driven router-mode / leak / admission test suite.
+#
+# Each scenario YAML in scenarios/<kind>/ describes a complete cell:
+# deployment (backend, topology, units, image) × router config
+# (mode + DYN_ROUTER_* knobs) × workload (shape + rungs) × reports +
+# checks + expectations.
+#
+# A scenario's ``kind:`` field selects which test function consumes it:
+#   scenarios/router_memory/    → test_router_memory
+#   scenarios/admission_control/ → test_admission_control (future)
+#   scenarios/endurance/        → test_endurance (future)
+#
+# The Event/Report/Check classes referenced by YAML are auto-discovered
+# from the framework's class hierarchy at import time — no registry
+# maintenance. Adding a new Event/Report/Check class anywhere in
+# tests/fault_tolerance/deploy/{events,reports,checks}.py automatically
+# makes it available in scenarios.
+
+import os
+
+import pytest
+
+from tests.fault_tolerance.deploy.scenario import run_scenario
+from tests.fault_tolerance.deploy.scenario_lib._loader import (
+    discover_scenarios,
+    load_scenario,
+)
+from tests.fault_tolerance.deploy.scenario_lib._runtime import (
+    apply_admission,
+    apply_deployment,
+    apply_mocker_planner_profile_fixup,
+    apply_pull_secrets,
+    apply_router,
+    build_checks,
+    build_reports,
+    build_scenario_events,
+)
+from tests.utils.managed_deployment import DeploymentSpec
+
+_TEMPLATE_DIR = os.path.join(os.path.dirname(__file__), "templates")
+
+
+def _assert_scenario_applied(spec: DeploymentSpec, scenario) -> None:
+    """Pre-deploy validation that the framework's apply_* hooks actually
+    landed the YAML's declared values on the spec. Caches a clear failure
+    BEFORE the long DGD-deploy cycle.
+
+    Asserts:
+      1. ``deployment.replicas`` overrides match the live spec
+      2. ``deployment.image`` (if set) is on every service
+      3. ``router.knobs`` are all present on the Frontend env (with str values)
+      4. ``admission.knobs`` (if set) are present on every worker service
+    """
+    import logging
+
+    log = logging.getLogger(scenario.path or "_assert_scenario_applied")
+
+    # Replicas
+    if scenario.deployment.replicas:
+        for svc, want in scenario.deployment.replicas.items():
+            got = spec[svc].replicas
+            assert got == int(want), (
+                f"{scenario.path}: deployment.replicas[{svc!r}]={want} but "
+                f"spec[{svc!r}].replicas={got} after apply_deployment"
+            )
+
+    # Image — applied to every service when deployment.image is set
+    if scenario.deployment.image:
+        for svc in ["Frontend"] + spec.worker_services():
+            got = spec[svc].image
+            assert got == scenario.deployment.image, (
+                f"{scenario.path}: deployment.image={scenario.deployment.image!r} "
+                f"but spec[{svc!r}].image={got!r}"
+            )
+
+    # Router knobs — every entry must be on Frontend env, plus DYN_ROUTER_MODE
+    fe_envs = {e.get("name"): str(e.get("value")) for e in spec["Frontend"].envs}
+    assert fe_envs.get("DYN_ROUTER_MODE") == scenario.router.mode, (
+        f"{scenario.path}: router.mode={scenario.router.mode!r} but "
+        f"Frontend DYN_ROUTER_MODE={fe_envs.get('DYN_ROUTER_MODE')!r}"
+    )
+    for k, v in scenario.router.knobs.items():
+        got = fe_envs.get(k)
+        assert got == str(v), (
+            f"{scenario.path}: router.knobs[{k!r}]={v!r} but "
+            f"Frontend env[{k!r}]={got!r}"
+        )
+
+    # Admission knobs — every entry on every worker service
+    if scenario.admission and scenario.admission.knobs:
+        for svc in spec.worker_services():
+            envs = {e.get("name"): str(e.get("value")) for e in spec[svc].envs}
+            for k, v in scenario.admission.knobs.items():
+                got = envs.get(k)
+                assert got == str(v), (
+                    f"{scenario.path}: admission.knobs[{k!r}]={v!r} but "
+                    f"{svc} env[{k!r}]={got!r}"
+                )
+
+    # Log a summary so the test output shows what was actually applied —
+    # helps diagnose "why did this arm do X?" without re-reading the YAML.
+    log.info(
+        "scenario applied: backend=%s topology=%s replicas=%s image=%s router.mode=%s router.knobs=%s",
+        scenario.deployment.backend,
+        scenario.deployment.topology,
+        {svc: spec[svc].replicas for svc in ["Frontend"] + spec.worker_services()},
+        scenario.deployment.image,
+        scenario.router.mode,
+        dict(scenario.router.knobs),
+    )
+
+
+def _load_template_spec(deployment) -> DeploymentSpec:
+    """Resolve scenario.deployment.template + backend to a DeploymentSpec.
+
+    Template lookup order:
+      1. If deployment.template is set, use <template_dir>/<backend>/<template>.yaml
+      2. Otherwise, fall back to backend-default templates:
+         - disagg → <backend>/disagg_qwen3_30b_unit_prod.yaml
+         - agg    → <backend>/agg_qwen3_30b_unit_prod.yaml
+      3. If no local template exists, fall back to the in-repo example
+         deploy yaml via DeploymentSpec.from_backend(backend, topology) —
+         this is how mocker (and any other backend without local prod
+         overlays) gets a DGD.
+    """
+    if deployment.template:
+        path = os.path.join(
+            _TEMPLATE_DIR, deployment.backend, f"{deployment.template}.yaml"
+        )
+    elif deployment.topology == "disagg":
+        path = os.path.join(
+            _TEMPLATE_DIR, deployment.backend, "disagg_qwen3_30b_unit_prod.yaml"
+        )
+    elif deployment.topology == "agg":
+        path = os.path.join(
+            _TEMPLATE_DIR, deployment.backend, "agg_qwen3_30b_unit_prod.yaml"
+        )
+    else:
+        raise ValueError(f"unknown topology {deployment.topology!r}")
+    if os.path.exists(path):
+        return DeploymentSpec(path)
+
+    # Fallback to /workspace/examples/backends/<backend>/deploy/<topology>.yaml
+    return DeploymentSpec.from_backend(deployment.backend, deployment.topology)
+
+
+async def _run_yaml_scenario(
+    scenario_path, *, runtime_env=None, test_name=None, request=None
+):
+    """Generic YAML scenario runner. Used by every test function in this
+    file; per-kind tests just pre-select a subset of scenario YAMLs and
+    call this with each.
+
+    Pre-deploy validation asserts the framework's apply_* hooks actually
+    landed the YAML's declared values on the spec. This catches typos,
+    schema drift, and apply_* regressions BEFORE the 10+ minute DGD
+    deployment cycle.
+    """
+    scenario = load_scenario(scenario_path)
+
+    # CLI override: --model-cache-pvc trumps the YAML value if non-empty.
+    # Lets pytest invocations mount the HF cache PVC across all scenarios
+    # without per-YAML wiring (R3 GPU sanity hit this when Qwen3-30B
+    # crashlooped trying to download from HF).
+    if request is not None:
+        cli_cache = request.config.getoption("--model-cache-pvc", default="") or ""
+        if cli_cache:
+            scenario.deployment.model_cache_pvc = cli_cache
+        # --image CLI override trumps the YAML's deployment.image. Same intent:
+        # one pytest invocation per image candidate without rewriting YAMLs.
+        cli_image = request.config.getoption("--image", default=None) or None
+        if cli_image:
+            scenario.deployment.image = cli_image
+
+    spec = _load_template_spec(scenario.deployment)
+    apply_deployment(spec, scenario.deployment)
+    apply_router(spec, scenario.router)
+    apply_admission(spec, scenario.admission)
+    # Shared-cluster pull-secret wiring. Idempotent; safe on clusters
+    # that don't define the secret (k8s silently ignores unknowns).
+    apply_pull_secrets(spec)
+    # Mocker template has a stale planner-profile-data path; override to
+    # the runtime-image-shipped location. No-op for non-mocker backends.
+    apply_mocker_planner_profile_fixup(spec)
+
+    _assert_scenario_applied(spec, scenario)
+
+    worker_names = spec.worker_services()
+    if not worker_names:
+        raise RuntimeError(f"DGD {scenario.deployment.backend} has no worker services")
+    served_model = spec[worker_names[0]].model
+    events = build_scenario_events(scenario, served_model)
+    reports = build_reports(scenario)
+    checks = build_checks(scenario)
+
+    await run_scenario(
+        deployment_spec=spec,
+        events=events,
+        checks=checks,
+        reports=reports,
+        runtime_env=runtime_env,
+        test_name=test_name,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Per-kind test functions
+# --------------------------------------------------------------------------- #
+#
+# Each per-kind test function pre-selects its scenarios by directory
+# name. The parametrize id is the YAML filename, so test_outputs and
+# pytest -k filtering are intuitive.
+
+
+_ROUTER_MEMORY_SCENARIOS = discover_scenarios("router_memory")
+
+
+@pytest.mark.k8s
+@pytest.mark.e2e
+@pytest.mark.weekly
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+@pytest.mark.parametrize(
+    "scenario_path",
+    _ROUTER_MEMORY_SCENARIOS,
+    ids=[p.name for p in _ROUTER_MEMORY_SCENARIOS],
+)
+async def test_router_memory(runtime_env, request, scenario_path):
+    """Memory-leak characterization across router modes × workload shapes
+    × deployment topologies. One scenario YAML per cell. Reports cover
+    FE memory growth, per-worker balance, request-level latency.
+
+    Scenarios live in scenarios/router_memory/. See INDEX.md there for
+    a human-readable list."""
+    await _run_yaml_scenario(
+        scenario_path,
+        runtime_env=runtime_env,
+        test_name=request.node.name,
+        request=request,
+    )
+
+
+_ENDURANCE_SCENARIOS = discover_scenarios("endurance")
+
+
+@pytest.mark.k8s
+@pytest.mark.e2e
+@pytest.mark.weekly
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+@pytest.mark.parametrize(
+    "scenario_path",
+    _ENDURANCE_SCENARIOS,
+    ids=[p.name for p in _ENDURANCE_SCENARIOS],
+)
+async def test_endurance(runtime_env, request, scenario_path):
+    """Long-running endurance scenarios. Mocker-backed by default so
+    cluster cost is low and the test can run for hours.
+
+    Designed to surface slow drift (memory leak, queue backlog) that
+    only becomes visible after extended uptime. The scenario uses the
+    ``PeriodicSnapshot`` event to drop timestamped artifact bundles
+    into ``<log_dir>/snapshots/`` every N minutes, so analysis can
+    proceed against in-progress data.
+
+    To pair two scenarios (e.g. router-mode A vs B), launch this test
+    twice in two different namespaces with the two YAML names. No
+    pairing framework is provided — manual two-namespace launch keeps
+    the framework simple and resource accounting clear."""
+    await _run_yaml_scenario(
+        scenario_path,
+        runtime_env=runtime_env,
+        test_name=request.node.name,
+        request=request,
+    )

--- a/tests/fault_tolerance/deploy/test_sanity_mocker.py
+++ b/tests/fault_tolerance/deploy/test_sanity_mocker.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Mocker-backed smoke test for the event-based FT harness. Uses the
+# mocker backend (bundled in every dynamo runtime image) so it runs
+# without a GPU; aiperf drives 10 requests, the deployment must serve
+# them all with zero errors. Useful as a baseline next to fault tests.
+
+import pytest
+
+from tests.fault_tolerance.deploy.checks import LoadCompleted, MinRequests, ZeroErrors
+from tests.fault_tolerance.deploy.events import StartLoad, WaitForLoadCompletion
+from tests.fault_tolerance.deploy.scenario import run_scenario
+from tests.utils.managed_deployment import DeploymentSpec
+from tests.utils.managed_load import LoadConfig
+
+
+@pytest.mark.k8s
+@pytest.mark.e2e
+@pytest.mark.weekly
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+async def test_sanity_mocker(namespace, image, skip_service_restart, storage_class):
+    spec = DeploymentSpec.from_backend("mocker", "agg")
+    # The mocker/agg.yaml hardcodes a stale planner-profile path; override
+    # to the location the runtime images actually ship with.
+    spec["decode"].set_arg(
+        "--planner-profile-data",
+        "/workspace/tests/planner/profiling_results/H200_TP1P_TP1D",
+    )
+    # Pull model from the worker's launch args so aiperf and the worker stay
+    # in sync no matter what the YAML default is.
+    served_model = spec["decode"].model
+    await run_scenario(
+        deployment_spec=spec,
+        events=[
+            StartLoad(
+                load_config=LoadConfig(
+                    model_name=served_model,
+                    tokenizer=served_model,
+                    request_count=10,
+                    concurrency=2,
+                    input_tokens_mean=128,
+                    output_tokens_mean=32,
+                )
+            ),
+            WaitForLoadCompletion(),
+        ],
+        checks=[
+            LoadCompleted(),
+            MinRequests(min_count=10),
+            ZeroErrors(),
+        ],
+        namespace=namespace,
+        image=image,
+        test_name="test_sanity_mocker",
+        skip_service_restart=skip_service_restart,
+        storage_class=storage_class,
+    )

--- a/tests/fault_tolerance/deploy/test_sanity_vllm.py
+++ b/tests/fault_tolerance/deploy/test_sanity_vllm.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# vllm + Qwen3-0.6B sanity test. Runs the framework against a real
+# vllm worker (instead of the mocker) so the baseline next to the
+# vllm fault tests reflects realistic worker behaviour. 10 requests
+# at concurrency=2; expects zero errors and load-completed.
+
+import pytest
+
+from tests.fault_tolerance.deploy.checks import LoadCompleted, MinRequests, ZeroErrors
+from tests.fault_tolerance.deploy.events import (
+    StartLoad,
+    WaitForLoadCompletion,
+    WaitForModelReady,
+)
+from tests.fault_tolerance.deploy.reports import FaultToleranceReport
+from tests.fault_tolerance.deploy.scenario import run_scenario
+from tests.utils.managed_deployment import DeploymentSpec
+from tests.utils.managed_load import LoadConfig
+
+
+@pytest.mark.k8s
+@pytest.mark.e2e
+@pytest.mark.weekly
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+async def test_sanity_vllm(namespace, image, skip_service_restart, storage_class):
+    spec = DeploymentSpec.from_backend("vllm", "agg")
+    served_model = spec["VllmDecodeWorker"].model
+    await run_scenario(
+        deployment_spec=spec,
+        events=[
+            WaitForModelReady(timeout=600),
+            StartLoad(
+                load_config=LoadConfig(
+                    model_name=served_model,
+                    tokenizer=served_model,
+                    request_count=10,
+                    concurrency=2,
+                    input_tokens_mean=128,
+                    output_tokens_mean=32,
+                )
+            ),
+            WaitForLoadCompletion(),
+        ],
+        checks=[
+            LoadCompleted(),
+            MinRequests(min_count=10),
+            ZeroErrors(),
+        ],
+        reports=[FaultToleranceReport()],
+        namespace=namespace,
+        image=image,
+        test_name="test_sanity_vllm",
+        skip_service_restart=skip_service_restart,
+        storage_class=storage_class,
+    )

--- a/tests/fault_tolerance/deploy/test_sanity_vllm_disagg.py
+++ b/tests/fault_tolerance/deploy/test_sanity_vllm_disagg.py
@@ -9,9 +9,14 @@
 # baseline that proves the disagg topology is reachable + the worker-
 # side prometheus passthrough is wired end-to-end.
 #
-# REQUIREMENTS: needs >= 2 GPUs on the node (1 for prefill + 1 for
-# decode). On a single-GPU dev cluster the prefill pod will sit
-# Pending with FailedScheduling; run on a multi-GPU node or skip.
+# Uses tests/fault_tolerance/deploy/templates/vllm/disagg_same_gpu.yaml
+# (k8s mirror of examples/backends/vllm/launch/disagg_same_gpu.sh):
+# both workers fit on one GPU via tiny --gpu-memory-utilization,
+# capped --kv-cache-memory-bytes, and --enforce-eager. Requires the
+# cluster to have either >=2 GPUs OR nvidia-device-plugin
+# time-slicing enabled (1 physical GPU exposed as N logical via
+# sharing.timeSlicing.resources) so both pods can claim
+# nvidia.com/gpu: 1.
 
 import pytest
 
@@ -34,7 +39,9 @@ from tests.utils.managed_load import LoadConfig
 async def test_sanity_vllm_disagg(
     namespace, image, skip_service_restart, storage_class
 ):
-    spec = DeploymentSpec.from_backend("vllm", "disagg")
+    spec = DeploymentSpec(
+        "/workspace/tests/fault_tolerance/deploy/templates/vllm/disagg_same_gpu.yaml"
+    )
     served_model = spec["VllmDecodeWorker"].model
     await run_scenario(
         deployment_spec=spec,

--- a/tests/fault_tolerance/deploy/test_sanity_vllm_disagg.py
+++ b/tests/fault_tolerance/deploy/test_sanity_vllm_disagg.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# vllm disagg sanity test (Qwen3-0.6B, 1 prefill + 1 decode). Exercises
+# the prefill -> decode KV-transfer path so vllm:nixl_* counters are
+# registered on the prefill worker; aiperf's --server-metrics auto-
+# scrape (driven by StartLoad enumerating worker pod IPs at execution
+# time) collects them alongside the frontend metrics. Useful as a
+# baseline that proves the disagg topology is reachable + the worker-
+# side prometheus passthrough is wired end-to-end.
+#
+# REQUIREMENTS: needs >= 2 GPUs on the node (1 for prefill + 1 for
+# decode). On a single-GPU dev cluster the prefill pod will sit
+# Pending with FailedScheduling; run on a multi-GPU node or skip.
+
+import pytest
+
+from tests.fault_tolerance.deploy.checks import LoadCompleted, MinRequests, ZeroErrors
+from tests.fault_tolerance.deploy.events import (
+    StartLoad,
+    WaitForLoadCompletion,
+    WaitForModelReady,
+)
+from tests.fault_tolerance.deploy.reports import FaultToleranceReport
+from tests.fault_tolerance.deploy.scenario import run_scenario
+from tests.utils.managed_deployment import DeploymentSpec
+from tests.utils.managed_load import LoadConfig
+
+
+@pytest.mark.k8s
+@pytest.mark.e2e
+@pytest.mark.weekly
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+async def test_sanity_vllm_disagg(
+    namespace, image, skip_service_restart, storage_class
+):
+    spec = DeploymentSpec.from_backend("vllm", "disagg")
+    served_model = spec["VllmDecodeWorker"].model
+    await run_scenario(
+        deployment_spec=spec,
+        events=[
+            WaitForModelReady(timeout=600),
+            StartLoad(
+                load_config=LoadConfig(
+                    model_name=served_model,
+                    tokenizer=served_model,
+                    request_count=20,
+                    concurrency=2,
+                    input_tokens_mean=128,
+                    output_tokens_mean=32,
+                )
+            ),
+            WaitForLoadCompletion(),
+        ],
+        checks=[
+            LoadCompleted(),
+            MinRequests(min_count=20),
+            ZeroErrors(),
+        ],
+        reports=[FaultToleranceReport()],
+        namespace=namespace,
+        image=image,
+        test_name="test_sanity_vllm_disagg",
+        skip_service_restart=skip_service_restart,
+        storage_class=storage_class,
+    )

--- a/tests/fault_tolerance/deploy/test_sanity_vllm_qwen3_30b.py
+++ b/tests/fault_tolerance/deploy/test_sanity_vllm_qwen3_30b.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Sanity test for the 1F + 1P (TP=2) + 2D (TP=2) vllm disagg topology
+# on Qwen3-30B-A3B. Verifies: PVC binding, all 4 pods reach Ready,
+# the prefill→decode NIXL KV-transfer path comes up clean, the model
+# registers on the frontend, and a small request burst returns with
+# zero errors. Baseline for the disagg failure-mode repros that
+# follow (cudagraph cliff, KV-cleanup retention, rank wedge).
+#
+# REQUIREMENTS:
+#   - >= 6 GPUs reachable (1 prefill TP=2 + 2 decode TP=2 = 6).
+#     Fits one 8xH100-80GB node; on smaller hosts use the
+#     templates/vllm/disagg_same_gpu.yaml + Qwen3-0.6B path instead.
+#   - dynamo v1.0.1 vllm-runtime image
+#     (nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.0.1).
+#   - hf-token-secret in the test namespace (Qwen3-30B-A3B is gated
+#     on HF; the secret is loaded via envFromSecret on workers).
+
+import pytest
+
+from tests.fault_tolerance.deploy.checks import LoadCompleted, MinRequests, ZeroErrors
+from tests.fault_tolerance.deploy.events import (
+    StartLoad,
+    WaitForLoadCompletion,
+    WaitForModelReady,
+)
+from tests.fault_tolerance.deploy.reports import FaultToleranceReport
+from tests.fault_tolerance.deploy.scenario import run_scenario
+from tests.utils.managed_deployment import DeploymentSpec
+from tests.utils.managed_load import LoadConfig
+
+
+@pytest.mark.k8s
+@pytest.mark.e2e
+@pytest.mark.weekly
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+async def test_sanity_vllm_qwen3_30b(
+    namespace, image, skip_service_restart, storage_class, log_pvc, model_pvc
+):
+    spec = DeploymentSpec(
+        "/workspace/tests/fault_tolerance/deploy/templates/vllm/"
+        "disagg_qwen3_30b_1p2d.yaml"
+    )
+    served_model = spec["VllmDecodeWorker"].model
+    await run_scenario(
+        deployment_spec=spec,
+        events=[
+            # Model load on Qwen3-30B is the long pole here — pull,
+            # init, KV-cache warmup. Generous timeout.
+            WaitForModelReady(timeout=1200),
+            StartLoad(
+                load_config=LoadConfig(
+                    model_name=served_model,
+                    tokenizer=served_model,
+                    request_count=10,
+                    concurrency=2,
+                    input_tokens_mean=128,
+                    output_tokens_mean=32,
+                )
+            ),
+            WaitForLoadCompletion(),
+        ],
+        checks=[
+            LoadCompleted(),
+            MinRequests(min_count=10),
+            ZeroErrors(),
+        ],
+        reports=[FaultToleranceReport()],
+        namespace=namespace,
+        image=image,
+        test_name="test_sanity_vllm_qwen3_30b",
+        skip_service_restart=skip_service_restart,
+        storage_class=storage_class,
+        log_pvc=log_pvc,
+        model_pvc=model_pvc,
+    )

--- a/tests/fault_tolerance/deploy/test_sanity_vllm_qwen3_30b.py
+++ b/tests/fault_tolerance/deploy/test_sanity_vllm_qwen3_30b.py
@@ -1,8 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Sanity test for the 1F + 1P (TP=2) + 2D (TP=2) vllm disagg topology
-# on Qwen3-30B-A3B. Verifies: PVC binding, all 4 pods reach Ready,
+# Sanity test for the 1F + 2P (TP=2 each) + 1D (TP=2) vllm disagg
+# topology on Qwen3-30B-A3B (matches the documented 2P:1D ratio for
+# prefill-bound workloads — heavy ISL, very short OSL).
+# Verifies: PVC binding, all 4 pods reach Ready,
 # the prefill→decode NIXL KV-transfer path comes up clean, the model
 # registers on the frontend, and a small request burst returns with
 # zero errors. Baseline for the disagg failure-mode repros that
@@ -35,12 +37,10 @@ from tests.utils.managed_load import LoadConfig
 @pytest.mark.e2e
 @pytest.mark.weekly
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
-async def test_sanity_vllm_qwen3_30b(
-    namespace, image, skip_service_restart, storage_class, log_pvc, model_pvc
-):
+async def test_sanity_vllm_qwen3_30b(runtime_env):
     spec = DeploymentSpec(
         "/workspace/tests/fault_tolerance/deploy/templates/vllm/"
-        "disagg_qwen3_30b_1p2d.yaml"
+        "disagg_qwen3_30b_2p1d.yaml"
     )
     served_model = spec["VllmDecodeWorker"].model
     await run_scenario(
@@ -67,11 +67,6 @@ async def test_sanity_vllm_qwen3_30b(
             ZeroErrors(),
         ],
         reports=[FaultToleranceReport()],
-        namespace=namespace,
-        image=image,
         test_name="test_sanity_vllm_qwen3_30b",
-        skip_service_restart=skip_service_restart,
-        storage_class=storage_class,
-        log_pvc=log_pvc,
-        model_pvc=model_pvc,
+        runtime_env=runtime_env,
     )

--- a/tests/fault_tolerance/deploy/test_saturation_discovery.py
+++ b/tests/fault_tolerance/deploy/test_saturation_discovery.py
@@ -5,9 +5,15 @@
 # a latency SLA. Does NOT deploy/teardown; runs aiperf against the FE
 # service in the chosen namespace.
 #
-# Sweeps a concurrency ladder, measures p95 latency on each rung, and reports
-# the highest concurrency where the SLA still held. Roll-our-own substitute for
-# aiperf's `max_concurrency_under_sla` recipe (not in the pinned aiperf version).
+# Three sweep modes:
+#   1. ladder         — fixed ascending concurrency list, stop at first SLA violation
+#   2. adaptive       — headroom-scaled step size, bisects toward the SLA boundary
+#   3. aiperf-builtin — delegate to aiperf's own `--search-space / --search-sla`
+#                       (one aiperf job; planner is monotonic-sla or bayesian)
+#
+# Modes 1 and 2 are our own driver: one aiperf job per rung, framework parses
+# the per-rung summary. Mode 3 is a single aiperf job; the recommended
+# concurrency is parsed from aiperf's search output.
 #
 # Example invocation (must be run AFTER a deployment is up in <namespace>):
 #
@@ -52,6 +58,397 @@ def _extract_quantile(summary: dict, metric: str, quantile: str) -> float | None
     return m.get(quantile)
 
 
+async def _run_aiperf_builtin(
+    *,
+    deployment,
+    namespace: str,
+    image: str | None,
+    model: str,
+    log_dir: Path,
+    search_lo: int,
+    search_hi: int,
+    search_planner: str,
+    search_max_iter: int,
+    sla_metric: str,
+    sla_quantile: str,
+    sla_ms: float,
+    rung_seconds: int,
+    warmup_seconds: int,
+    request_timeout_seconds: int = 600,
+) -> None:
+    """Single-shot aiperf invocation with --search-space / --search-sla.
+
+    Delegates the entire sweep to aiperf's own search planner. Each search
+    iteration is one internal aiperf profile run (gated by --search-max-iter).
+    We don't parse per-iteration p95 here — aiperf writes its own
+    search-summary artifact under the load job's results directory; we just
+    log the path so the operator can read it directly.
+
+    aiperf wires search-stat from the SLA quantile (e.g. 'p95'). For
+    request_latency, aiperf reports milliseconds, so --search-sla takes
+    the SLA in ms directly. Direction is 'maximize' for concurrency
+    sweeps under a latency ceiling.
+    """
+    # aiperf wants the SLA in the metric's native unit (ms for *_latency)
+    # and the search-stat in lowercase quantile form ('p95', 'avg').
+    extra_args = [
+        "--search-space",
+        f"phases.profiling.concurrency:{search_lo},{search_hi}:int",
+        "--search-metric",
+        sla_metric,
+        "--search-stat",
+        sla_quantile,
+        "--search-direction",
+        "maximize",
+        "--search-sla",
+        f"{sla_metric}:{sla_quantile}:lt:{int(sla_ms)}",
+        "--search-planner",
+        search_planner,
+        "--search-max-iterations",
+        str(search_max_iter),
+    ]
+
+    # Concurrency is the variable aiperf will tune via --search-space; we
+    # still need to set a starting value on the LoadConfig (aiperf uses
+    # --concurrency as the search-space seed when --search-space is set).
+    load_config = LoadConfig(
+        model_name=model,
+        tokenizer=model,
+        concurrency=search_lo,
+        duration_minutes=rung_seconds / 60.0,
+        warmup_duration=warmup_seconds,
+        seq_dist=(
+            "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;"
+            "500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;"
+            "1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;"
+            "1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;"
+            "3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;"
+            "7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
+        ),
+        num_prefix_prompts=5,
+        prefix_prompt_length=740,
+        streaming=True,
+        ignore_eos=True,
+        # VERY relaxed client timeout, deliberately >> the latency SLA. If the
+        # per-request timeout equals the SLA (both 30s), an overloaded request
+        # is cancelled at 30s and counted as an ERROR, so aiperf's p95 can
+        # never exceed the SLA — the search then thinks every concurrency
+        # "passes" and picks a garbage-high C_max from a 99%-erroring rung
+        # (observed: conc 1013 -> 100% errors but p95 ~28s "passed"). With a
+        # relaxed timeout, overload instead shows up as genuine high-latency
+        # successes, so p95 climbs past the SLA and the search finds the real
+        # saturation point. Default 600s (10 min); see --sat-request-timeout-seconds.
+        request_timeout_seconds=request_timeout_seconds,
+        connection_reuse_strategy="never",
+        extra_aiperf_args=extra_args,
+    )
+
+    job_name = "sat-aiperf-search"
+    ml = ManagedLoad(
+        namespace=namespace,
+        load_config=load_config,
+        pvc_name=deployment.get_log_pvc_name(),
+        pvc_run_id=deployment.get_log_run_id(),
+        endpoint_url=deployment.deployment_spec.get_in_cluster_frontend_url(namespace),
+        log_dir=str(log_dir),
+        job_name=job_name,
+    )
+    # aiperf's bayesian search runs up to ``search_max_iter`` concurrency
+    # rungs back-to-back (each ~rung_seconds + warmup_seconds) plus planner
+    # overhead. ManagedLoad's default completion timeout is derived from a
+    # SINGLE rung's duration (~390s), which is far too short for the whole
+    # search and trips a spurious TimeoutError. Wait with a search-aware
+    # budget instead.
+    # Each rung sends for ~rung_seconds then drains in-flight requests, which
+    # with the relaxed 300s client timeout can take a while near the cliff;
+    # budget generously (this is just an upper bound — aiperf exits when done).
+    search_timeout = search_max_iter * (rung_seconds + warmup_seconds) + 1800
+    _LOG.info(
+        "aiperf-builtin: waiting up to %ds for the %d-iteration search "
+        "(rung=%ds, warmup=%ds) to complete",
+        search_timeout,
+        search_max_iter,
+        rung_seconds,
+        warmup_seconds,
+    )
+    async with ml:
+        await ml.run(wait_for_completion=False)
+        await ml.wait_for_completion(timeout=search_timeout)
+
+    # aiperf's search planner writes a recommendation artifact alongside the
+    # per-iteration profile exports. Glob for likely names — schema varies by
+    # aiperf release, so we capture paths and let the operator parse.
+    job_dirs = sorted((log_dir / "load").glob(f"{job_name}-*"))
+    if job_dirs:
+        latest = job_dirs[-1]
+        candidates = list(latest.rglob("*.json"))
+        recommendation_files = [
+            p
+            for p in candidates
+            if any(tok in p.name.lower() for tok in ("search", "recommend"))
+        ]
+        _LOG.info("aiperf-builtin: artifact dir = %s", latest)
+        if recommendation_files:
+            _LOG.info(
+                "aiperf-builtin: %d candidate recommendation file(s): %s",
+                len(recommendation_files),
+                [str(p.relative_to(latest)) for p in recommendation_files],
+            )
+        else:
+            _LOG.info(
+                "aiperf-builtin: no obvious recommendation JSON. All %d json files: %s",
+                len(candidates),
+                [str(p.relative_to(latest)) for p in candidates[:20]],
+            )
+
+    summary_path = log_dir / "saturation_sweep_summary.json"
+    with open(summary_path, "w") as fh:
+        json.dump(
+            {
+                "namespace": namespace,
+                "image": image,
+                "served_model": model,
+                "mode": "aiperf-builtin",
+                "search_lo": search_lo,
+                "search_hi": search_hi,
+                "search_planner": search_planner,
+                "search_max_iterations": search_max_iter,
+                "sla_metric": sla_metric,
+                "sla_quantile": sla_quantile,
+                "sla_ms": sla_ms,
+                "rung_seconds": rung_seconds,
+                "job_name": job_name,
+                "note": (
+                    "aiperf-builtin: see job_dirs above for per-iteration outputs "
+                    "and the recommendation artifact."
+                ),
+            },
+            fh,
+            indent=2,
+        )
+    _LOG.info("aiperf-builtin: summary written: %s", summary_path)
+
+
+def _build_deploy_spec(
+    scenario_name: str, *, image: str | None, model_cache_pvc: str | None
+):
+    """Resolve a router_memory scenario name to a ready-to-deploy DeploymentSpec.
+
+    Mirrors test_router_modes._run_yaml_scenario's spec-build sequence
+    (load_scenario -> _load_template_spec -> apply_deployment/router/admission
+    -> apply_pull_secrets -> apply_mocker_planner_profile_fixup) so a deployment
+    stood up here is identical to one stood up by the router-mode suite. We do
+    NOT call run_scenario — this test owns its own ManagedDeployment lifecycle.
+
+    Returns (spec, scenario) so the caller can read scenario.deployment.log_pvc.
+    """
+    from tests.fault_tolerance.deploy.scenario_lib._loader import (
+        SCENARIOS_DIR,
+        load_scenario,
+    )
+    from tests.fault_tolerance.deploy.scenario_lib._runtime import (
+        apply_admission,
+        apply_deployment,
+        apply_mocker_planner_profile_fixup,
+        apply_pull_secrets,
+        apply_router,
+    )
+    from tests.fault_tolerance.deploy.test_router_modes import _load_template_spec
+
+    name = scenario_name
+    if not name.endswith(".yaml"):
+        name = f"{name}.yaml"
+    scenario_path = SCENARIOS_DIR / "router_memory" / name
+    if not scenario_path.exists():
+        raise FileNotFoundError(
+            f"--sat-deploy-scenario: scenario not found: {scenario_path}"
+        )
+    scenario = load_scenario(scenario_path)
+
+    # CLI overrides (parity with test_router_modes): --model-cache-pvc and
+    # --image trump the YAML's values when non-empty.
+    if model_cache_pvc:
+        scenario.deployment.model_cache_pvc = model_cache_pvc
+    if image:
+        scenario.deployment.image = image
+
+    spec = _load_template_spec(scenario.deployment)
+    apply_deployment(spec, scenario.deployment)
+    apply_router(spec, scenario.router)
+    apply_admission(spec, scenario.admission)
+    apply_pull_secrets(spec)
+    apply_mocker_planner_profile_fixup(spec)
+    return spec, scenario
+
+
+def _write_c_max_json(
+    log_dir: Path,
+    *,
+    search_lo: int,
+    search_hi: int,
+    sla_ms: float,
+    max_error_pct: float = 5.0,
+) -> None:
+    """Parse aiperf's search output for C_max and write <log_dir>/c_max.json.
+
+    Extraction is best-effort and defensive. aiperf's search-summary schema
+    varies by release, so we try several known shapes in order and log exactly
+    what we found. If nothing parses, we write c_max=0 with a "source" marker
+    so the wrapper script can detect the failure and fall back to grepping.
+
+    JSON shape written: {"c_max": int, "sla_ms": float,
+                         "search_lo": int, "search_hi": int, "source": str}
+    """
+    c_max = 0
+    source = "unparsed"
+    ERR_PCT_MAX = (
+        max_error_pct  # a rung "passes" only if <= this %% of requests errored
+    )
+
+    # aiperf-builtin search writes one dir per iteration:
+    #   <log_dir>/load/sat-aiperf-search/search_iter_*/profile_runs/run_*/profile_export_aiperf.json
+    # Each summary carries the tested concurrency
+    # (input_config.phases.profiling.concurrency), request_latency.p95 (display
+    # unit = ms, same unit as the SLA), and request vs error counts. C_max =
+    # the HIGHEST concurrency whose p95 <= sla_ms AND whose error rate is
+    # acceptable.
+    #
+    # The error gate is ESSENTIAL: under a tight client timeout an overloaded
+    # rung can report p95 < SLA computed over a handful of survivors while ~all
+    # requests error out — without the gate the search would pick a garbage-high
+    # C_max (observed: concurrency 1013 -> 100% errors but p95 ~28s "passed").
+    search_dir = log_dir / "load" / "sat-aiperf-search"
+    summaries = sorted(
+        search_dir.glob("search_iter_*/profile_runs/run_*/profile_export_aiperf.json")
+    )
+    _LOG.info(
+        "c_max parse: scanning %d iteration summaries under %s",
+        len(summaries),
+        search_dir,
+    )
+    passing: list[int] = []
+    for p in summaries:
+        try:
+            with open(p) as fh:
+                data = json.load(fh)
+        except Exception as e:  # noqa: BLE001 - defensive parse
+            _LOG.warning("c_max parse: could not read %s: %s", p, e)
+            continue
+        ic = data.get("input_config") or {}
+        # ``phases`` is a LIST of phase dicts; the tested concurrency is on the
+        # entry named "profiling" (the "warmup" entry carries the search seed).
+        conc = None
+        try:
+            for ph in ic.get("phases") or []:
+                if isinstance(ph, dict) and ph.get("name") == "profiling":
+                    conc = int(ph["concurrency"])
+                    break
+        except Exception:  # noqa: BLE001
+            conc = None
+        p95 = (data.get("request_latency") or {}).get("p95")
+        ok = (data.get("request_count") or {}).get("avg") or 0
+        err = (data.get("error_request_count") or {}).get("avg") or 0
+        tot = ok + err
+        err_pct = (100.0 * err / tot) if tot else 100.0
+        if conc is None or p95 is None:
+            continue
+        ok_sla = p95 <= sla_ms
+        ok_err = err_pct <= ERR_PCT_MAX
+        verdict = (
+            "PASS"
+            if (ok_sla and ok_err)
+            else ("FAIL-SLA" if not ok_sla else "FAIL-ERR")
+        )
+        _LOG.info(
+            "c_max parse: conc=%d p95=%.0fms ok=%d err=%d (%.1f%%) -> %s",
+            conc,
+            p95,
+            int(ok),
+            int(err),
+            err_pct,
+            verdict,
+        )
+        if ok_sla and ok_err:
+            passing.append(conc)
+
+    if passing:
+        c_max = max(passing)
+        source = str(search_dir)
+        _LOG.info(
+            "c_max parse: C_max=%d (highest concurrency with p95<=%.0fms AND err<=%.1f%%)",
+            c_max,
+            sla_ms,
+            ERR_PCT_MAX,
+        )
+    else:
+        _LOG.warning(
+            "c_max parse: NO rung passed (p95<=%.0fms AND err<=%.1f%%); writing "
+            "c_max=0. The search range may be entirely above saturation — inspect "
+            "the per-iteration summaries under %s.",
+            sla_ms,
+            ERR_PCT_MAX,
+            search_dir,
+        )
+
+    out = {
+        "c_max": c_max,
+        "sla_ms": float(sla_ms),
+        "search_lo": int(search_lo),
+        "search_hi": int(search_hi),
+        "source": source,
+    }
+    path = log_dir / "c_max.json"
+    with open(path, "w") as fh:
+        json.dump(out, fh, indent=2)
+    _LOG.info("c_max parse: wrote %s = %s", path, out)
+
+
+def _extract_c_max_from_obj(data) -> int | None:
+    """Pull a concurrency recommendation out of an aiperf JSON object.
+
+    Tries, in order, the shapes seen across aiperf releases:
+      1. top-level keys: best_concurrency / recommended_concurrency / c_max
+      2. nested "search"/"result"/"recommendation" dict with a *concurrency* key
+      3. a "concurrency" key whose sibling marks it as the SLA-passing best
+    Returns None if nothing matches. Purely defensive — never raises.
+    """
+    try:
+        if isinstance(data, dict):
+            for k in (
+                "best_concurrency",
+                "recommended_concurrency",
+                "c_max",
+                "max_concurrency",
+            ):
+                v = data.get(k)
+                if isinstance(v, (int, float)) and v > 0:
+                    return int(v)
+            for container_key in ("search", "result", "recommendation", "summary"):
+                sub = data.get(container_key)
+                if isinstance(sub, dict):
+                    nested = _extract_c_max_from_obj(sub)
+                    if nested:
+                        return nested
+            # Last resort: any int-valued key containing "concurrency".
+            for k, v in data.items():
+                if (
+                    "concurrency" in str(k).lower()
+                    and isinstance(v, (int, float))
+                    and v > 0
+                ):
+                    return int(v)
+        elif isinstance(data, list):
+            best = 0
+            for item in data:
+                nested = _extract_c_max_from_obj(item)
+                if nested and nested > best:
+                    best = nested
+            return best or None
+    except Exception:  # noqa: BLE001 - never let parse kill the test
+        return None
+    return None
+
+
 def add_cli_options(parser):
     """Pytest CLI options scoped to saturation discovery."""
     g = parser.getgroup("saturation_discovery")
@@ -77,6 +474,30 @@ def add_cli_options(parser):
         default=15,
         help="Warmup seconds at start of each rung (aiperf request_count "
         "stabilization). Counts against rung-seconds.",
+    )
+    g.addoption(
+        "--sat-request-timeout-seconds",
+        type=int,
+        default=600,
+        help="Client per-request timeout for the search load (aiperf "
+        "--request-timeout-seconds). DEFAULT 600s (10 min) — deliberately "
+        ">> the latency SLA. This is critical for a correct C_max: if the "
+        "client timeout is near the SLA, overloaded requests get cancelled "
+        "and counted as ERRORS (not high-latency successes), so the measured "
+        "p95 can never exceed the SLA and the search picks a garbage-high "
+        "C_max from a ~100%-erroring rung. A relaxed timeout lets overload "
+        "show up as honest high latency. Pass <=0 for effectively-infinite "
+        "(mapped to 24h).",
+    )
+    g.addoption(
+        "--sat-max-error-pct",
+        type=float,
+        default=5.0,
+        help="A search rung only counts toward C_max if its error rate is "
+        "<= this percent AND its p95 <= the SLA. The error gate guards "
+        "against picking a concurrency where p95 looks fine but it was "
+        "computed over a handful of survivors while the rung was failing. "
+        "Default 5%%.",
     )
     g.addoption(
         "--sat-sla-metric",
@@ -105,6 +526,91 @@ def add_cli_options(parser):
         help="Minimum aiperf request success rate per rung (1 - errors/total). "
         "Below this counts as saturated.",
     )
+    # --- Sweep mode selection ---
+    g.addoption(
+        "--sat-mode",
+        default="ladder",
+        choices=["ladder", "adaptive", "aiperf-builtin"],
+        help="Sweep strategy. 'ladder' = fixed list, stop at first violation. "
+        "'adaptive' = headroom-scaled step + bisection. "
+        "'aiperf-builtin' = single aiperf job with --search-space / --search-sla.",
+    )
+    # Back-compat shortcut: --sat-adaptive is equivalent to --sat-mode=adaptive.
+    g.addoption(
+        "--sat-adaptive",
+        action="store_true",
+        default=False,
+        help="Shortcut for --sat-mode=adaptive (kept for back-compat).",
+    )
+    g.addoption(
+        "--sat-start-concurrency",
+        type=int,
+        default=200,
+        help="Adaptive mode: initial concurrency level. Default 200.",
+    )
+    g.addoption(
+        "--sat-min-step",
+        type=int,
+        default=50,
+        help="Adaptive mode: minimum step size (per rung). Default 50.",
+    )
+    g.addoption(
+        "--sat-max-step",
+        type=int,
+        default=2000,
+        help="Adaptive mode: maximum step size (per rung). Default 2000.",
+    )
+    g.addoption(
+        "--sat-tolerance",
+        type=float,
+        default=0.05,
+        help="Adaptive mode: stop when |p95 - SLA|/SLA < tolerance. Default 0.05 (±5%).",
+    )
+    g.addoption(
+        "--sat-max-rungs",
+        type=int,
+        default=12,
+        help="Adaptive mode: hard cap on iterations. Default 12.",
+    )
+    # --- aiperf-builtin mode options ---
+    g.addoption(
+        "--sat-search-lo",
+        type=int,
+        default=50,
+        help="aiperf-builtin: lower bound of search-space concurrency. Default 50.",
+    )
+    g.addoption(
+        "--sat-search-hi",
+        type=int,
+        default=2400,
+        help="aiperf-builtin: upper bound of search-space concurrency. Default 2400.",
+    )
+    g.addoption(
+        "--sat-search-planner",
+        default="monotonic-sla",
+        choices=["monotonic-sla", "bayesian"],
+        help="aiperf-builtin: which search planner to drive the sweep. Default "
+        "monotonic-sla (binary-search-style; fastest for a single threshold). "
+        "Use bayesian for noisier metrics.",
+    )
+    g.addoption(
+        "--sat-search-max-iter",
+        type=int,
+        default=10,
+        help="aiperf-builtin: max search iterations (= aiperf profile invocations "
+        "inside the search). Default 10.",
+    )
+    # --- Optional deploy-first mode ---
+    g.addoption(
+        "--sat-deploy-scenario",
+        default=None,
+        help="Name of a router_memory scenario YAML (basename, with or without "
+        ".yaml) to DEPLOY before sweeping. When set, the test stands up that "
+        "DGD (template + replicas/image/router/admission per the YAML), waits "
+        "for ready, runs the sweep against it, and tears it down on exit. When "
+        "unset (default), behavior is unchanged: the sweep runs against a "
+        "deployment that is already standing in --namespace.",
+    )
 
 
 @pytest.mark.k8s
@@ -122,144 +628,348 @@ async def test_saturation_discovery(runtime_env, request, namespace, image):
     """
     cfg = request.config
     model = cfg.getoption("--sat-served-model")
-    ladder = [
-        int(c)
-        for c in cfg.getoption("--sat-concurrency-ladder").split(",")
-        if c.strip()
-    ]
     rung_seconds = cfg.getoption("--sat-rung-seconds")
     warmup_seconds = cfg.getoption("--sat-warmup-seconds")
+    request_timeout_seconds = cfg.getoption("--sat-request-timeout-seconds")
+    if request_timeout_seconds is None or request_timeout_seconds <= 0:
+        request_timeout_seconds = 86400  # <=0 => effectively infinite (24h)
+    max_error_pct = cfg.getoption("--sat-max-error-pct")
     sla_metric = cfg.getoption("--sat-sla-metric")
     sla_quantile = _normalize_quantile(cfg.getoption("--sat-sla-quantile"))
     sla_ms = cfg.getoption("--sat-sla-ms")
     min_success = cfg.getoption("--sat-min-success-rate")
+    # --sat-adaptive is a shortcut for --sat-mode=adaptive (back-compat).
+    mode = cfg.getoption("--sat-mode")
+    if cfg.getoption("--sat-adaptive") and mode == "ladder":
+        mode = "adaptive"
+    start_c = cfg.getoption("--sat-start-concurrency")
+    min_step = cfg.getoption("--sat-min-step")
+    max_step = cfg.getoption("--sat-max-step")
+    tolerance = cfg.getoption("--sat-tolerance")
+    max_rungs = cfg.getoption("--sat-max-rungs")
+    search_lo = cfg.getoption("--sat-search-lo")
+    search_hi = cfg.getoption("--sat-search-hi")
+    search_planner = cfg.getoption("--sat-search-planner")
+    search_max_iter = cfg.getoption("--sat-search-max-iter")
+    adaptive = mode == "adaptive"
+
+    if mode == "aiperf-builtin":
+        ladder = None
+        _LOG.info(
+            "aiperf-builtin sweep: namespace=%s model=%s search=[%d,%d] "
+            "planner=%s max_iter=%d sla=%s/%s/%dms rung=%ds",
+            namespace,
+            model,
+            search_lo,
+            search_hi,
+            search_planner,
+            search_max_iter,
+            sla_metric,
+            sla_quantile,
+            sla_ms,
+            rung_seconds,
+        )
+    elif adaptive:
+        ladder = None
+        _LOG.info(
+            "Adaptive sweep: namespace=%s model=%s start=%d sla=%s/%s/%dms "
+            "tolerance=%.2f rung=%ds step=[%d,%d]",
+            namespace,
+            model,
+            start_c,
+            sla_metric,
+            sla_quantile,
+            sla_ms,
+            tolerance,
+            rung_seconds,
+            min_step,
+            max_step,
+        )
+    else:
+        ladder = [
+            int(c)
+            for c in cfg.getoption("--sat-concurrency-ladder").split(",")
+            if c.strip()
+        ]
+        _LOG.info(
+            "Ladder sweep: namespace=%s model=%s ladder=%s sla=%s/%s/%dms rung=%ds",
+            namespace,
+            model,
+            ladder,
+            sla_metric,
+            sla_quantile,
+            sla_ms,
+            rung_seconds,
+        )
 
     log_dir = Path(f"/workspace/test_outputs/test_saturation_discovery_{namespace}")
     log_dir.mkdir(parents=True, exist_ok=True)
 
-    _LOG.info(
-        "Saturation sweep: namespace=%s model=%s ladder=%s sla=%s/%s/%dms rung=%ds",
-        namespace,
-        model,
-        ladder,
-        sla_metric,
-        sla_quantile,
-        sla_ms,
-        rung_seconds,
-    )
-
-    results: list[dict] = []
-    c_max = 0
-    saturated_at: int | None = None
-
-    for level in ladder:
-        _LOG.info(f"=== rung concurrency={level} ===")
-
-        load_config = LoadConfig(
-            model_name=model,
-            tokenizer=model,
-            concurrency=level,
-            benchmark_duration_seconds=rung_seconds,
-            warmup_duration_seconds=warmup_seconds,
-            # Match the production seq_dist shape, same as E1 arms.
-            seq_dist=(
-                "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;"
-                "500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;"
-                "1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;"
-                "1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;"
-                "3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;"
-                "7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
-            ),
-            num_prefix_prompts=5,
-            prefix_prompt_length=740,
-            streaming=True,
-            ignore_eos=True,
-            request_timeout_seconds=30,
-            connection_reuse_strategy="never",
-        )
-
-        rung_name = f"sat-c{level}"
-        ml = ManagedLoad(
-            log_dir=str(log_dir),
-            load_config=load_config,
-            namespace=namespace,
-            name=rung_name,
-            target_service_name="Frontend",
-        )
-        async with ml:
-            await ml.run(wait_for_completion=True)
-
-        # aiperf summary lives at <log_dir>/load/<job-name>/profile_export_aiperf.json
-        # ManagedLoad's run() returns a dict; we also can read the file directly.
-        try:
-            summary_path = next(
-                (log_dir / "load").glob(f"{rung_name}-*/profile_export_aiperf.json")
+    async def _run_sweep(deployment) -> None:
+        """The actual concurrency sweep. Runs against whatever deployment is
+        standing in ``namespace`` (deployed by us when --sat-deploy-scenario
+        is set, or pre-existing otherwise)."""
+        if mode == "aiperf-builtin":
+            await _run_aiperf_builtin(
+                deployment=deployment,
+                namespace=namespace,
+                image=image,
+                model=model,
+                log_dir=log_dir,
+                search_lo=search_lo,
+                search_hi=search_hi,
+                search_planner=search_planner,
+                search_max_iter=search_max_iter,
+                sla_metric=sla_metric,
+                sla_quantile=sla_quantile,
+                sla_ms=sla_ms,
+                rung_seconds=rung_seconds,
+                warmup_seconds=warmup_seconds,
+                request_timeout_seconds=request_timeout_seconds,
             )
-            with open(summary_path) as fh:
-                summary = json.load(fh)
-        except (StopIteration, FileNotFoundError) as e:
-            _LOG.error(f"rung c={level}: aiperf summary missing ({e})")
-            saturated_at = level
-            results.append({"concurrency": level, "error": "no aiperf summary"})
-            break
+            # Parse aiperf's search output → c_max.json for the wrapper.
+            _write_c_max_json(
+                log_dir,
+                search_lo=search_lo,
+                search_hi=search_hi,
+                sla_ms=sla_ms,
+                max_error_pct=max_error_pct,
+            )
+            return
+        await _run_ladder_sweep(deployment)
 
-        latency = _extract_quantile(summary, sla_metric, sla_quantile)
-        total_count = (summary.get("request_count", {}) or {}).get("avg")
-        err_count = (summary.get("error_request_count", {}) or {}).get("avg") or 0
-        success_rate = (total_count - err_count) / total_count if total_count else 0.0
+    async def _run_ladder_sweep(deployment) -> None:
+        results: list[dict] = []
+        c_max = 0
+        saturated_at: int | None = None
 
-        passed_sla = latency is not None and latency <= sla_ms
-        passed_success = success_rate >= min_success
-        passed = passed_sla and passed_success
+        # Iterator: produces concurrencies. Fixed ladder OR adaptive (state-driven).
+        def adaptive_iter():
+            c = start_c
+            # going_up: True while we believe we're still under SLA
+            going_up = True
+            for _ in range(max_rungs):
+                yield c
+                # The for-loop body in the main test sets `last_p95` via closure.
+                # We compute the next step here based on previous measurement.
+                p95 = last_p95_box[0]
+                if p95 is None:
+                    break
+                headroom = (sla_ms - p95) / sla_ms  # >0 = under SLA, <0 = over
+                if abs(headroom) < tolerance:
+                    _LOG.info(
+                        f"  → within tolerance ({abs(headroom):.3f} < {tolerance}); "
+                        f"saturation boundary ≈ {c}"
+                    )
+                    break
+                # step size scales with |headroom|; bigger gap = bigger step
+                step = int(max_step * abs(headroom))
+                step = max(min_step, min(max_step, step))
+                if headroom > 0:
+                    if not going_up:
+                        # We previously crossed SLA, now back under — halve step
+                        # to bisect toward boundary
+                        step = max(min_step, step // 2)
+                    c += step
+                    going_up = True
+                else:
+                    # Over SLA — step back, but smaller (looking for the boundary)
+                    c -= max(min_step, step // 2)
+                    going_up = False
 
-        _LOG.info(
-            f"  c={level}: {sla_metric}/{sla_quantile}={latency:.0f}ms "
-            f"(sla={sla_ms:.0f}) success_rate={success_rate:.3f} "
-            f"(min={min_success}) → {'PASS' if passed else 'SATURATED'}"
-        )
+        last_p95_box: list[float | None] = [None]
+        iterator = adaptive_iter() if adaptive else iter(ladder)
 
-        results.append(
-            {
-                "concurrency": level,
-                f"{sla_metric}_{sla_quantile}_ms": latency,
-                "success_rate": success_rate,
-                "total_requests": total_count,
-                "error_requests": err_count,
-                "passed_sla": passed_sla,
-                "passed_success": passed_success,
-                "passed": passed,
-            }
-        )
+        for level in iterator:
+            _LOG.info(f"=== rung concurrency={level} ===")
 
-        if passed:
-            c_max = level
-        else:
-            saturated_at = level
+            load_config = LoadConfig(
+                model_name=model,
+                tokenizer=model,
+                concurrency=level,
+                duration_minutes=rung_seconds / 60.0,
+                warmup_duration=warmup_seconds,
+                # Match the production seq_dist shape, same as E1 arms.
+                seq_dist=(
+                    "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;"
+                    "500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;"
+                    "1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;"
+                    "1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;"
+                    "3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;"
+                    "7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
+                ),
+                num_prefix_prompts=5,
+                prefix_prompt_length=740,
+                streaming=True,
+                ignore_eos=True,
+                request_timeout_seconds=30,
+                connection_reuse_strategy="never",
+            )
+
+            rung_name = f"sat-c{level}"
+            ml = ManagedLoad(
+                namespace=namespace,
+                load_config=load_config,
+                pvc_name=deployment.get_log_pvc_name(),
+                pvc_run_id=deployment.get_log_run_id(),
+                endpoint_url=deployment.deployment_spec.get_in_cluster_frontend_url(
+                    namespace
+                ),
+                log_dir=str(log_dir),
+                job_name=rung_name,
+            )
+            async with ml:
+                await ml.run(wait_for_completion=True)
+
+            # aiperf summary lives at <log_dir>/load/<job-name>/profile_export_aiperf.json
+            # ManagedLoad's run() returns a dict; we also can read the file directly.
+            try:
+                summary_path = next(
+                    (log_dir / "load").glob(f"{rung_name}-*/profile_export_aiperf.json")
+                )
+                with open(summary_path) as fh:
+                    summary = json.load(fh)
+            except (StopIteration, FileNotFoundError) as e:
+                _LOG.error(f"rung c={level}: aiperf summary missing ({e})")
+                saturated_at = level
+                results.append({"concurrency": level, "error": "no aiperf summary"})
+                break
+
+            latency = _extract_quantile(summary, sla_metric, sla_quantile)
+            total_count = (summary.get("request_count", {}) or {}).get("avg")
+            err_count = (summary.get("error_request_count", {}) or {}).get("avg") or 0
+            success_rate = (
+                (total_count - err_count) / total_count if total_count else 0.0
+            )
+
+            # Feed back to the adaptive iterator so the next step can scale by headroom.
+            last_p95_box[0] = latency
+
+            passed_sla = latency is not None and latency <= sla_ms
+            passed_success = success_rate >= min_success
+            passed = passed_sla and passed_success
+
             _LOG.info(
-                f"=== Saturation boundary found: C_max={c_max}, first failure at c={level} ==="
+                f"  c={level}: {sla_metric}/{sla_quantile}={latency:.0f}ms "
+                f"(sla={sla_ms:.0f}) success_rate={success_rate:.3f} "
+                f"(min={min_success}) → {'PASS' if passed else 'SATURATED'}"
             )
-            break
 
-    # Write a summary CSV that's easy to plot / share
-    summary_path = log_dir / "saturation_sweep_summary.json"
-    with open(summary_path, "w") as fh:
-        json.dump(
-            {
-                "namespace": namespace,
-                "image": image,
-                "served_model": model,
-                "sla_metric": sla_metric,
-                "sla_quantile": sla_quantile,
-                "sla_ms": sla_ms,
-                "min_success_rate": min_success,
-                "rung_seconds": rung_seconds,
-                "ladder": ladder,
-                "c_max_under_sla": c_max,
-                "saturated_at": saturated_at,
-                "rungs": results,
-            },
-            fh,
-            indent=2,
+            results.append(
+                {
+                    "concurrency": level,
+                    f"{sla_metric}_{sla_quantile}_ms": latency,
+                    "success_rate": success_rate,
+                    "total_requests": total_count,
+                    "error_requests": err_count,
+                    "passed_sla": passed_sla,
+                    "passed_success": passed_success,
+                    "passed": passed,
+                }
+            )
+
+            if passed:
+                c_max = level
+            else:
+                if saturated_at is None or level < saturated_at:
+                    saturated_at = level
+                _LOG.info(f"  ⚠ c={level} exceeded SLA (best C_max so far={c_max})")
+                # Ladder mode: stop at first failure. Adaptive mode: keep searching
+                # to bisect the boundary — the iterator's tolerance check ends it.
+                if not adaptive:
+                    break
+
+        # Write a summary CSV that's easy to plot / share
+        summary_path = log_dir / "saturation_sweep_summary.json"
+        with open(summary_path, "w") as fh:
+            json.dump(
+                {
+                    "namespace": namespace,
+                    "image": image,
+                    "served_model": model,
+                    "sla_metric": sla_metric,
+                    "sla_quantile": sla_quantile,
+                    "sla_ms": sla_ms,
+                    "min_success_rate": min_success,
+                    "rung_seconds": rung_seconds,
+                    "ladder": ladder,
+                    "c_max_under_sla": c_max,
+                    "saturated_at": saturated_at,
+                    "rungs": results,
+                },
+                fh,
+                indent=2,
+            )
+        _LOG.info(f"Summary written: {summary_path}")
+        _LOG.info(
+            f"FINAL: C_max under SLA={c_max}, saturation observed at={saturated_at}"
         )
-    _LOG.info(f"Summary written: {summary_path}")
-    _LOG.info(f"FINAL: C_max under SLA={c_max}, saturation observed at={saturated_at}")
+
+        # Ladder/adaptive: C_max is computed directly — write c_max.json so the
+        # wrapper consumes the same artifact regardless of sweep mode.
+        out = {
+            "c_max": int(c_max),
+            "sla_ms": float(sla_ms),
+            "search_lo": int(ladder[0]) if ladder else int(search_lo),
+            "search_hi": int(ladder[-1]) if ladder else int(search_hi),
+            "source": str(summary_path),
+        }
+        cmax_path = log_dir / "c_max.json"
+        with open(cmax_path, "w") as fh:
+            json.dump(out, fh, indent=2)
+        _LOG.info(f"c_max written: {cmax_path} = {out}")
+
+    # --- Optional deploy-first wrapper -------------------------------------- #
+    # When --sat-deploy-scenario is set, stand up that DGD here, wait for ready,
+    # run the sweep against it, and tear it down on context exit. Otherwise run
+    # the sweep directly against the standing deployment in --namespace.
+    deploy_scenario = cfg.getoption("--sat-deploy-scenario")
+    if not deploy_scenario:
+        # The sweep wires ManagedLoad's pvc_name/endpoint_url from a live
+        # ManagedDeployment handle, which only the deploy-first path provides.
+        raise RuntimeError(
+            "test_saturation_discovery requires --sat-deploy-scenario: the "
+            "sweep needs a ManagedDeployment handle to wire the load job's "
+            "PVC + frontend endpoint. Pass --sat-deploy-scenario <name>."
+        )
+
+    from tests.utils.managed_deployment import ManagedDeployment
+
+    cli_cache = cfg.getoption("--model-cache-pvc", default="") or ""
+    spec, scenario = _build_deploy_spec(
+        deploy_scenario, image=image, model_cache_pvc=cli_cache
+    )
+    # Mirror run_scenario's spec prep: enable logging + PVC log collection so
+    # teardown extracts pod logs the same way the router-mode suite does.
+    spec.set_logging(True, "info")
+    storage_class = cfg.getoption("--storage-class", default=None)
+    log_pvc = scenario.deployment.log_pvc or None
+    log_collection_kwargs = {
+        "pvc_size": "500Mi",
+        "container_log_dir": "/tmp/service_logs",
+    }
+    if storage_class:
+        log_collection_kwargs["storage_class"] = storage_class
+    if log_pvc:
+        log_collection_kwargs["pvc_name"] = log_pvc
+    spec.enable_log_collection(**log_collection_kwargs)
+
+    _LOG.info(
+        "deploy-first: standing up scenario=%s in namespace=%s (image=%s, "
+        "model_cache_pvc=%s) before sweep",
+        deploy_scenario,
+        namespace,
+        scenario.deployment.image,
+        scenario.deployment.model_cache_pvc,
+    )
+    async with ManagedDeployment(
+        namespace=namespace,
+        log_dir=str(log_dir),
+        deployment_spec=spec,
+        skip_service_restart=True,
+        reuse_log_pvc=bool(log_pvc),
+    ) as deployment:
+        await deployment.wait_for_ready(timeout=2400)
+        _LOG.info("deploy-first: deployment ready; starting sweep")
+        await _run_sweep(deployment)
+    _LOG.info("deploy-first: sweep complete; deployment torn down")

--- a/tests/fault_tolerance/deploy/test_saturation_discovery.py
+++ b/tests/fault_tolerance/deploy/test_saturation_discovery.py
@@ -1,0 +1,265 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Saturation discovery test — finds C_max for an EXISTING deployment under
+# a latency SLA. Does NOT deploy/teardown; runs aiperf against the FE
+# service in the chosen namespace.
+#
+# Sweeps a concurrency ladder, measures p95 latency on each rung, and reports
+# the highest concurrency where the SLA still held. Roll-our-own substitute for
+# aiperf's `max_concurrency_under_sla` recipe (not in the pinned aiperf version).
+#
+# Example invocation (must be run AFTER a deployment is up in <namespace>):
+#
+#   uv run pytest test_saturation_discovery.py \
+#       --namespace neelays-e1-arm5 \
+#       --sat-served-model Qwen/Qwen3-30B-A3B-Instruct-2507-FP8 \
+#       --sat-concurrency-ladder 200,400,800,1200,1600,2000,2400 \
+#       --sat-rung-seconds 90 \
+#       --sat-sla-ms 5000 \
+#       --sat-sla-quantile p95 \
+#       --storage-class dgxc-enterprise-file --log-pvc dynamo-ft-logs \
+#       --skip-service-restart -s -v
+#
+# For mocker deployments running at --speedup-ratio 5.0, an SLA of 5000 ms
+# (=30000 / 5x speedup) is the canonical "production-equivalent" target.
+# For real-vLLM workloads the SLA is the production p95 latency budget
+# (e.g., 30000 ms).
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+from tests.utils.managed_load import LoadConfig, ManagedLoad
+
+_LOG = logging.getLogger(__name__)
+
+
+def _normalize_quantile(q: str) -> str:
+    """Map p50/p95/p99/avg/min/max → the key in aiperf summary JSON."""
+    if q in ("avg", "p50", "p95", "p99", "min", "max"):
+        return q
+    raise ValueError(f"unknown SLA quantile: {q}")
+
+
+def _extract_quantile(summary: dict, metric: str, quantile: str) -> float | None:
+    """Read summary[metric][quantile] from the aiperf JSON shape."""
+    m = summary.get(metric, {})
+    return m.get(quantile)
+
+
+def add_cli_options(parser):
+    """Pytest CLI options scoped to saturation discovery."""
+    g = parser.getgroup("saturation_discovery")
+    g.addoption(
+        "--sat-served-model",
+        default="Qwen/Qwen3-30B-A3B-Instruct-2507-FP8",
+        help="Served model name passed to aiperf --model + --tokenizer.",
+    )
+    g.addoption(
+        "--sat-concurrency-ladder",
+        default="200,400,800,1200,1600,2000,2400",
+        help="Comma-separated concurrency levels to sweep (ascending).",
+    )
+    g.addoption(
+        "--sat-rung-seconds",
+        type=int,
+        default=90,
+        help="Seconds of steady load per rung. Default 90.",
+    )
+    g.addoption(
+        "--sat-warmup-seconds",
+        type=int,
+        default=15,
+        help="Warmup seconds at start of each rung (aiperf request_count "
+        "stabilization). Counts against rung-seconds.",
+    )
+    g.addoption(
+        "--sat-sla-metric",
+        default="request_latency",
+        choices=["request_latency", "time_to_first_token", "inter_token_latency"],
+        help="Which aiperf metric to gate on.",
+    )
+    g.addoption(
+        "--sat-sla-quantile",
+        default="p95",
+        choices=["avg", "p50", "p95", "p99"],
+        help="Which quantile of the SLA metric to gate on.",
+    )
+    g.addoption(
+        "--sat-sla-ms",
+        type=float,
+        default=5000.0,
+        help="SLA threshold in milliseconds. Below = pass. Above = saturated. "
+        "Default 5000 ms — appropriate for mocker --speedup-ratio=5.0 "
+        "(matches prod 30s budget / 5x).",
+    )
+    g.addoption(
+        "--sat-min-success-rate",
+        type=float,
+        default=0.95,
+        help="Minimum aiperf request success rate per rung (1 - errors/total). "
+        "Below this counts as saturated.",
+    )
+
+
+@pytest.mark.k8s
+@pytest.mark.e2e
+@pytest.mark.weekly
+@pytest.mark.asyncio
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+async def test_saturation_discovery(runtime_env, request, namespace, image):
+    """Sweep concurrency, find the highest rung where p95 latency stays under SLA.
+
+    Does not deploy. Assumes a deployment with a Frontend Service is already
+    running in the chosen namespace. Each rung is an independent aiperf job
+    submitted via ManagedLoad; results are collected per-rung and the test
+    reports the saturation boundary.
+    """
+    cfg = request.config
+    model = cfg.getoption("--sat-served-model")
+    ladder = [
+        int(c)
+        for c in cfg.getoption("--sat-concurrency-ladder").split(",")
+        if c.strip()
+    ]
+    rung_seconds = cfg.getoption("--sat-rung-seconds")
+    warmup_seconds = cfg.getoption("--sat-warmup-seconds")
+    sla_metric = cfg.getoption("--sat-sla-metric")
+    sla_quantile = _normalize_quantile(cfg.getoption("--sat-sla-quantile"))
+    sla_ms = cfg.getoption("--sat-sla-ms")
+    min_success = cfg.getoption("--sat-min-success-rate")
+
+    log_dir = Path(f"/workspace/test_outputs/test_saturation_discovery_{namespace}")
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    _LOG.info(
+        "Saturation sweep: namespace=%s model=%s ladder=%s sla=%s/%s/%dms rung=%ds",
+        namespace,
+        model,
+        ladder,
+        sla_metric,
+        sla_quantile,
+        sla_ms,
+        rung_seconds,
+    )
+
+    results: list[dict] = []
+    c_max = 0
+    saturated_at: int | None = None
+
+    for level in ladder:
+        _LOG.info(f"=== rung concurrency={level} ===")
+
+        load_config = LoadConfig(
+            model_name=model,
+            tokenizer=model,
+            concurrency=level,
+            benchmark_duration_seconds=rung_seconds,
+            warmup_duration_seconds=warmup_seconds,
+            # Match the production seq_dist shape, same as E1 arms.
+            seq_dist=(
+                "100,20:1;100,80:2;100,130:2;100,180:1;100,200:1;"
+                "500,20:2;500,80:5;500,130:5;500,180:2;500,200:1;"
+                "1000,20:3;1000,80:5;1000,130:5;1000,180:3;1000,200:2;"
+                "1600,20:5;1600,80:8;1600,130:8;1600,180:5;1600,200:3;"
+                "3400,20:3;3400,80:6;3400,130:6;3400,180:3;3400,200:2;"
+                "7000,20:2;7000,80:3;7000,130:3;7000,180:2;7000,200:1"
+            ),
+            num_prefix_prompts=5,
+            prefix_prompt_length=740,
+            streaming=True,
+            ignore_eos=True,
+            request_timeout_seconds=30,
+            connection_reuse_strategy="never",
+        )
+
+        rung_name = f"sat-c{level}"
+        ml = ManagedLoad(
+            log_dir=str(log_dir),
+            load_config=load_config,
+            namespace=namespace,
+            name=rung_name,
+            target_service_name="Frontend",
+        )
+        async with ml:
+            await ml.run(wait_for_completion=True)
+
+        # aiperf summary lives at <log_dir>/load/<job-name>/profile_export_aiperf.json
+        # ManagedLoad's run() returns a dict; we also can read the file directly.
+        try:
+            summary_path = next(
+                (log_dir / "load").glob(f"{rung_name}-*/profile_export_aiperf.json")
+            )
+            with open(summary_path) as fh:
+                summary = json.load(fh)
+        except (StopIteration, FileNotFoundError) as e:
+            _LOG.error(f"rung c={level}: aiperf summary missing ({e})")
+            saturated_at = level
+            results.append({"concurrency": level, "error": "no aiperf summary"})
+            break
+
+        latency = _extract_quantile(summary, sla_metric, sla_quantile)
+        total_count = (summary.get("request_count", {}) or {}).get("avg")
+        err_count = (summary.get("error_request_count", {}) or {}).get("avg") or 0
+        success_rate = (total_count - err_count) / total_count if total_count else 0.0
+
+        passed_sla = latency is not None and latency <= sla_ms
+        passed_success = success_rate >= min_success
+        passed = passed_sla and passed_success
+
+        _LOG.info(
+            f"  c={level}: {sla_metric}/{sla_quantile}={latency:.0f}ms "
+            f"(sla={sla_ms:.0f}) success_rate={success_rate:.3f} "
+            f"(min={min_success}) → {'PASS' if passed else 'SATURATED'}"
+        )
+
+        results.append(
+            {
+                "concurrency": level,
+                f"{sla_metric}_{sla_quantile}_ms": latency,
+                "success_rate": success_rate,
+                "total_requests": total_count,
+                "error_requests": err_count,
+                "passed_sla": passed_sla,
+                "passed_success": passed_success,
+                "passed": passed,
+            }
+        )
+
+        if passed:
+            c_max = level
+        else:
+            saturated_at = level
+            _LOG.info(
+                f"=== Saturation boundary found: C_max={c_max}, first failure at c={level} ==="
+            )
+            break
+
+    # Write a summary CSV that's easy to plot / share
+    summary_path = log_dir / "saturation_sweep_summary.json"
+    with open(summary_path, "w") as fh:
+        json.dump(
+            {
+                "namespace": namespace,
+                "image": image,
+                "served_model": model,
+                "sla_metric": sla_metric,
+                "sla_quantile": sla_quantile,
+                "sla_ms": sla_ms,
+                "min_success_rate": min_success,
+                "rung_seconds": rung_seconds,
+                "ladder": ladder,
+                "c_max_under_sla": c_max,
+                "saturated_at": saturated_at,
+                "rungs": results,
+            },
+            fh,
+            indent=2,
+        )
+    _LOG.info(f"Summary written: {summary_path}")
+    _LOG.info(f"FINAL: C_max under SLA={c_max}, saturation observed at={saturated_at}")

--- a/tests/fault_tolerance/deploy/test_scenario_bad_input_distribution.py
+++ b/tests/fault_tolerance/deploy/test_scenario_bad_input_distribution.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Bad-input-distribution scenario.
+#
+# Real failure mode observed in the c16 capacity probe: vllm sampling
+# rejected requests with `ValueError: min_tokens must be less than or
+# equal to max_tokens=67, got 100`. Cause: ISL stddev pushed individual
+# requests near `max_model_len` (8192). Per-request `max_tokens` budget
+# = max_model_len − ISL = 67 for that sample, but client's `min_tokens`
+# is 100 (from output_tokens_mean). vllm rejects → request fails →
+# error counter climbs.
+#
+# This scenario deliberately reproduces that. Watch on the timeline /
+# Grafana / TUI:
+#   - vllm:request_failures_total (or *errors* in cascade_timeline)
+#   - dynamo_frontend_request_errors_total
+#   - vllm:num_requests_running stays low (errors short-circuit before
+#     the engine schedules them)
+#   - latency p99 may LOOK fine because errored requests don't count
+
+import pytest
+
+from tests.fault_tolerance.deploy.checks import LoadCompleted
+from tests.fault_tolerance.deploy.events import (
+    StartLoad,
+    WaitForLoadCompletion,
+    WaitForModelReady,
+)
+from tests.fault_tolerance.deploy.reports import FaultToleranceReport
+from tests.fault_tolerance.deploy.scenario import run_scenario
+from tests.utils.managed_deployment import DeploymentSpec
+from tests.utils.managed_load import LoadConfig
+
+# ISL distribution that shoves the upper tail across the budget. With
+# max_model_len=8192 and OSL min=100, requests with ISL > 8092 fail.
+# A distribution centered at 8000 with stddev=300 will fail ~33%.
+_ISL_MEAN = 8000
+_ISL_STDDEV = 300
+_OSL_MEAN = 100
+_OSL_STDDEV = 0  # fixed, so min_tokens is unambiguous
+_DURATION_S = 300
+_CONCURRENCY = 16
+
+
+@pytest.mark.k8s
+@pytest.mark.e2e
+@pytest.mark.weekly
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+async def test_scenario_bad_input_distribution(runtime_env):
+    spec = DeploymentSpec(
+        "/workspace/tests/fault_tolerance/deploy/templates/vllm/"
+        "disagg_qwen3_30b_4p2d_2f.yaml"
+    )
+    served_model = spec["VllmDecodeWorker"].model
+
+    await run_scenario(
+        deployment_spec=spec,
+        events=[
+            WaitForModelReady(timeout=1500),
+            StartLoad(
+                load_config=LoadConfig(
+                    model_name=served_model,
+                    tokenizer=served_model,
+                    input_tokens_mean=_ISL_MEAN,
+                    input_tokens_stddev=_ISL_STDDEV,
+                    output_tokens_mean=_OSL_MEAN,
+                    output_tokens_stddev=_OSL_STDDEV,
+                    concurrency=_CONCURRENCY,
+                    duration_minutes=_DURATION_S / 60.0,
+                    request_timeout_seconds=300,
+                    streaming=True,
+                    ignore_eos=True,
+                    warmup_requests=0,
+                    # Force rigid output length so vllm rejects requests
+                    # whose ISL leaves <100 tokens of budget. Default
+                    # framework min_tokens=1 would NOT trip this.
+                    extra_inputs={"min_tokens": _OSL_MEAN},
+                ),
+                name="bad_input",
+            ),
+            WaitForLoadCompletion(name="bad_input"),
+        ],
+        # Don't gate on ZeroErrors — the *whole point* is errors. We
+        # want LoadCompleted to confirm the load ran to its planned
+        # duration; downstream analysis looks at the error metrics.
+        checks=[LoadCompleted(name="bad_input")],
+        reports=[FaultToleranceReport()],
+        test_name="test_scenario_bad_input_distribution",
+        runtime_env=runtime_env,
+    )

--- a/tests/fault_tolerance/deploy/test_scenario_cascade_repro_mocker.py
+++ b/tests/fault_tolerance/deploy/test_scenario_cascade_repro_mocker.py
@@ -1,0 +1,223 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# C1 — Cascade repro: panic flood -> degraded tokio runtime ->
+# /live handler latency grows past liveness probe timeout ->
+# kubelet SIGTERM -> pod restart -> repeat.
+#
+# Uses the mocker engine so we can scale FE/decode replicas without
+# GPUs and iterate fast. Same dynamo TCP request plane as vLLM workers
+# (panic site lives in dynamo_runtime, not engine code).
+#
+# Knobs (env vars, all optional):
+#   CASCADE_CONCURRENCY            (default 100)
+#   CASCADE_FRONTEND_REPLICAS      (default 1)
+#   CASCADE_DECODE_REPLICAS        (default 1)
+#   CASCADE_THREADS_FRONTEND       (default unset -> num_cores)
+#   CASCADE_THREADS_DECODE         (default unset -> num_cores)
+#   CASCADE_FRONTEND_CPU_LIMIT     (default unset; e.g. "500m")
+#   CASCADE_DECODE_CPU_LIMIT       (default unset; e.g. "500m")
+#   CASCADE_LIVE_PERIOD_S          (default 10  — operator default for FE; 5 for worker)
+#   CASCADE_LIVE_TIMEOUT_S         (default 1   — operator default for FE)
+#   CASCADE_LIVE_FAILURE_THRESHOLD (default 3   — operator default for FE)
+#   CASCADE_RST_BURSTS             (default 3)
+#   CASCADE_RST_DURATION_S         (default 60)
+#   CASCADE_RST_GAP_S              (default 90)
+#   CASCADE_RST_TARGET             (default "decode"; "Frontend" to flip)
+#   CASCADE_LOAD_MINUTES           (default 12)
+#
+# Image: vllm-runtime:1.0.1 (bug-present). For the regression gate,
+# pass a post-#8254 main-built image via --image.
+
+import os
+
+import pytest
+
+from tests.fault_tolerance.deploy.checks import RestartCountIncreased
+
+# Note: WorkerPanics and ServiceLogPatternRate currently break in post-teardown
+# phase because they call ctx.deployment.collect_service_logs() after
+# scenario.py sets ctx.deployment = None. Until that's fixed, we verify
+# panics by scanning extracted PVC logs at test_outputs/<test>/<svc>/*.log.
+# RestartCountIncreased reads ctx.pod_restart_state snapshot and works.
+from tests.fault_tolerance.deploy.events import (
+    RstInjection,
+    StartLoad,
+    Wait,
+    WaitForLoadCompletion,
+    WaitForModelReady,
+)
+from tests.fault_tolerance.deploy.reports import (
+    ErrorBreakdownReport,
+    ErrorTrackingReport,
+    FaultToleranceReport,
+)
+from tests.fault_tolerance.deploy.scenario import run_scenario
+from tests.utils.managed_deployment import DeploymentSpec
+from tests.utils.managed_load import LoadConfig
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    return int(raw) if raw else default
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.environ.get(name)
+    return float(raw) if raw else default
+
+
+def _env_str(name: str, default):
+    raw = os.environ.get(name)
+    return raw if raw else default
+
+
+def _apply_liveness_override(
+    service, period_s: int, timeout_s: int, failure_threshold: int, port_name: str
+) -> None:
+    """Inject a livenessProbe override into the DGD service spec.
+
+    The operator merges DGD-provided probes entirely (no partial merge),
+    so we provide the full Probe shape with our knob values. Path "/live"
+    matches the operator defaults for both Frontend and worker components.
+    """
+    service._spec["livenessProbe"] = {
+        "httpGet": {"path": "/live", "port": port_name},
+        "periodSeconds": period_s,
+        "timeoutSeconds": timeout_s,
+        "failureThreshold": failure_threshold,
+    }
+
+
+def _apply_cpu_limit(service, cpu_limit: str) -> None:
+    """Set a CPU resources.limits on this service (e.g. '500m')."""
+    service._spec.setdefault("resources", {}).setdefault("limits", {})[
+        "cpu"
+    ] = cpu_limit
+    # Mirror to requests so the pod schedules and CFS quota actually applies.
+    service._spec["resources"].setdefault("requests", {})["cpu"] = cpu_limit
+
+
+@pytest.mark.k8s
+@pytest.mark.fault_tolerance
+@pytest.mark.e2e
+@pytest.mark.k8s
+@pytest.mark.e2e
+@pytest.mark.weekly
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+async def test_cascade_repro_mocker(runtime_env, request):
+    """Cascade repro via mocker: panic flood -> /live degradation -> SIGTERM."""
+
+    spec = DeploymentSpec.from_backend("mocker", "agg")
+
+    # Drop --planner-profile-data: the template hard-codes a newer source
+    # layout path not present in vllm-runtime:1.0.1. The arg is optional in
+    # the 1.0.1 mocker (returns no profile, serves with built-in defaults).
+    _decode_args = spec["decode"]._get_args()
+    if "--planner-profile-data" in _decode_args:
+        idx = _decode_args.index("--planner-profile-data")
+        del _decode_args[idx : idx + 2]
+    spec["decode"].set_arg("--startup-time", "5")
+
+    # --- replicas ---
+    spec["Frontend"].replicas = _env_int("CASCADE_FRONTEND_REPLICAS", 1)
+    spec["decode"].replicas = _env_int("CASCADE_DECODE_REPLICAS", 1)
+
+    # --- tokio thread caps ---
+    threads_fe = os.environ.get("CASCADE_THREADS_FRONTEND")
+    if threads_fe:
+        spec["Frontend"].set_env_var("DYN_RUNTIME_NUM_WORKER_THREADS", threads_fe)
+    threads_decode = os.environ.get("CASCADE_THREADS_DECODE")
+    if threads_decode:
+        spec["decode"].set_env_var("DYN_RUNTIME_NUM_WORKER_THREADS", threads_decode)
+
+    # --- cpu limits ---
+    cpu_fe = os.environ.get("CASCADE_FRONTEND_CPU_LIMIT")
+    if cpu_fe:
+        _apply_cpu_limit(spec["Frontend"], cpu_fe)
+    cpu_decode = os.environ.get("CASCADE_DECODE_CPU_LIMIT")
+    if cpu_decode:
+        _apply_cpu_limit(spec["decode"], cpu_decode)
+
+    # --- liveness probe overrides ---
+    live_period = _env_int("CASCADE_LIVE_PERIOD_S", 10)
+    live_timeout = _env_int("CASCADE_LIVE_TIMEOUT_S", 1)
+    live_failures = _env_int("CASCADE_LIVE_FAILURE_THRESHOLD", 3)
+    _apply_liveness_override(
+        spec["Frontend"], live_period, live_timeout, live_failures, port_name="http"
+    )
+    # Worker liveness uses the "system" port (operator default), not "http".
+    _apply_liveness_override(
+        spec["decode"], live_period, live_timeout, live_failures, port_name="system"
+    )
+
+    # --- load config ---
+    served_model = spec["decode"].model
+    concurrency = _env_int("CASCADE_CONCURRENCY", 100)
+    load_minutes = _env_float("CASCADE_LOAD_MINUTES", 12.0)
+
+    cfg = LoadConfig(
+        model_name=served_model,
+        tokenizer=served_model,
+        input_tokens_mean=512,
+        input_tokens_stddev=0,
+        output_tokens_mean=2000,
+        output_tokens_stddev=0,
+        concurrency=concurrency,
+        duration_minutes=load_minutes,
+        request_timeout_seconds=120,
+        streaming=True,
+        ignore_eos=True,
+        warmup_requests=0,
+        connection_reuse_strategy="never",
+    )
+
+    # --- RST burst sequence ---
+    rst_target = _env_str("CASCADE_RST_TARGET", "decode")
+    n_bursts = _env_int("CASCADE_RST_BURSTS", 3)
+    burst_dur = _env_float("CASCADE_RST_DURATION_S", 60.0)
+    burst_gap = _env_float("CASCADE_RST_GAP_S", 90.0)
+
+    events = [
+        WaitForModelReady(timeout=600),
+        StartLoad(load_config=cfg, name="load"),
+        Wait(duration=120),  # warmup so streams are flowing
+    ]
+    for i in range(n_bursts):
+        events.append(
+            RstInjection(
+                service=rst_target,
+                pod_indices=[0],
+                duration=burst_dur,
+                name=f"rst_burst_{i}",
+            )
+        )
+        if i < n_bursts - 1:
+            events.append(Wait(duration=burst_gap))
+    events.append(WaitForLoadCompletion(name="load"))
+
+    await run_scenario(
+        deployment_spec=spec,
+        events=events,
+        checks=[
+            # The cascade signal: did the panic flood drive a kubelet
+            # liveness-probe-induced restart? Reads from ctx.pod_restart_state
+            # snapshot taken before deployment teardown; works post-teardown.
+            # Panic count itself is verified by scanning extracted PVC logs.
+            RestartCountIncreased(
+                services=["Frontend", "decode"],
+                expect_min_increment=1,
+                expect_zero=False,
+            ),
+        ],
+        reports=[
+            FaultToleranceReport(),
+            ErrorBreakdownReport(),
+            # ErrorTrackingReport records per-pod last-terminated reason —
+            # look there for "Killing" / probe-failure provenance vs panic
+            # process-death.
+            ErrorTrackingReport(),
+        ],
+        test_name=request.node.name,
+        runtime_env=runtime_env,
+    )

--- a/tests/fault_tolerance/deploy/test_scenario_decode_overload_disagg.py
+++ b/tests/fault_tolerance/deploy/test_scenario_decode_overload_disagg.py
@@ -1,0 +1,505 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Decode-worker overload reproduction — disagg-cascade shape.
+#
+# Mirrors a production-shape workload (ISL p50≈1600 / p99≈7000, OSL≈200,
+# prefix-cache hit ~37%) on the 1-FE : 2-P : 1-D unit topology that matches
+# a customer per-set design point. Six parametrized arms.
+#
+# Phase 1 — overload-only (decode-side pressure without fault injection)
+#   A — c=96 sustained ramp + 30 s SLA timeout.
+#       The base overload regime: decode KV pegs at 100%, vLLM scheduler
+#       enters preempt-recompute loop, throughput collapses ~20× vs c=24.
+#       Demonstrates the production cascade *upstream condition* without
+#       panic injection.
+#   B — A + 8 % probabilistic mid-flight cancellations (1.5 s delay).
+#       Hammers the SO_LINGER=0 close path at every request, on the client
+#       → FE direction. Note: AIPerf-side cancel = client-disconnect path,
+#       not FE↔worker close; without (F2/F3) won't panic worker.
+#   C — A + brief c=120 burst at peak.
+#       Step-shock variant of an in-cascade traffic spike pattern.
+#
+# Phase 2 — fault-injection overlays (force panic / FE-side failure)
+#   F1 — A + frontend ulimit nofile=1024 → drives FD-exhaust.
+#       Lowered FD ceiling means sustained traffic should hit `accept() Too
+#       many open files (os error 24)` at `tcp/server.rs:344`. When FE
+#       hits its FD ceiling and starts force-closing worker sockets, the
+#       SO_LINGER=0 path emits RST on the wire → decode `tcp_client.rs:255`
+#       panics.
+#   F2 — A + `kubectl rollout restart` Frontend at peak.
+#       Graceful FE close at peak load. SO_LINGER=0 on the worker-accept
+#       socket → every FE shutdown event emits RST instead of FIN → decode
+#       reader-task panic burst.
+#   F3 — A + `kubectl delete pod` Frontend at peak.
+#       Hard FE termination. Kernel-side RST on all worker sockets.
+#       Bounds the panic-burst rate; pair with F2 to attribute mechanism.
+#
+# Uses the AGG-on-decode misconfig template: decode worker omits
+# ``--disaggregation-mode`` so v1.0.1 defaults to AGGREGATED enum, which
+# wires up LocalKvIndexer on a decode pod and produces a ~1,200/sec
+# radix_tree warning storm.
+#
+# Design doc:
+#   ../../../dgh-703-unified-k8s-test-framework/findings/
+#   2026-05-13-decode-overload-repro-design.md
+
+import pytest
+
+from tests.fault_tolerance.deploy.checks import (
+    KvCacheUsagePeak,
+    LoadApplied,
+    LoadCompleted,
+    RequestCancellationOccurred,
+    RequestsRunningPeak,
+    RestartCountIncreased,
+    ServiceLogPatternRate,
+    SlaViolation,
+    ThroughputCollapse,
+    WorkerPanics,
+)
+from tests.fault_tolerance.deploy.events import (
+    DeletePod,
+    NetworkPartition,
+    RollingUpgrade,
+    SetBusyThreshold,
+    StartLoad,
+    Wait,
+    WaitForLoadCompletion,
+    WaitForModelReady,
+)
+from tests.fault_tolerance.deploy.reports import (
+    ErrorBreakdownReport,
+    ErrorTrackingReport,
+    FaultToleranceReport,
+    PerWorkerLatencyReport,
+)
+from tests.fault_tolerance.deploy.scenario import run_scenario
+from tests.utils.managed_deployment import DeploymentSpec
+from tests.utils.managed_load import LoadConfig
+
+_TEMPLATE = (
+    "/workspace/tests/fault_tolerance/deploy/templates/vllm/"
+    "disagg_qwen3_30b_unit_prod_AGG_decode.yaml"
+)
+
+
+from dataclasses import dataclass  # noqa: E402
+
+from tests.fault_tolerance.deploy.checks import Check, _iter_server_metric  # noqa: E402
+
+
+@dataclass
+class _KvCacheStaysBelow(Check):
+    """Inverse of KvCacheUsagePeak — assert every sample of
+    ``vllm:kv_cache_usage_perc`` on the named services stays at or below
+    ``ceiling``. Used to verify load-shedding is preventing overload.
+    """
+
+    services: list
+    ceiling: float = 0.85
+
+    def validate(self, ctx) -> None:
+        observed: dict = {}
+        for ts_ns, pod, val in _iter_server_metric(ctx, "vllm:kv_cache_usage_perc"):
+            cur = observed.get(pod)
+            if cur is None or val > cur:
+                observed[pod] = val
+        ctx.logger.info(
+            f"_KvCacheStaysBelow: per-pod max KV={observed} " f"ceiling={self.ceiling}"
+        )
+        breaches = {p: v for p, v in observed.items() if v > self.ceiling}
+        assert not breaches, (
+            f"_KvCacheStaysBelow: some pods exceeded KV ceiling "
+            f"{self.ceiling}: {breaches}"
+        )
+
+    @property
+    def description(self) -> str:
+        return (
+            f"KV cache usage stays at or below {self.ceiling} on "
+            f"{', '.join(self.services)} (shedding holds the line)"
+        )
+
+
+_DISAGG_SEQ_DIST = (
+    "100,200:5;500,200:15;1000,200:20;1600,200:30;3400,200:20;7000,200:10"
+)
+
+_DISAGG_NUM_PREFIX_PROMPTS = 15
+_DISAGG_PREFIX_PROMPT_LENGTH = 600
+
+
+def _disagg_load(
+    *,
+    served_model: str,
+    name: str,
+    concurrency: int,
+    duration_minutes: float,
+    ramp_seconds: float | None = None,
+    warmup_concurrency: int | None = None,
+    warmup_duration_seconds: float | None = None,
+    cancellation_rate: float | None = None,
+    cancellation_delay: float = 0.0,
+    seq_dist: str | None = None,
+) -> LoadConfig:
+    """Build a LoadConfig with the prod-shape disagg workload settings."""
+    return LoadConfig(
+        model_name=served_model,
+        tokenizer=served_model,
+        seq_dist=seq_dist or _DISAGG_SEQ_DIST,
+        num_prefix_prompts=_DISAGG_NUM_PREFIX_PROMPTS,
+        prefix_prompt_length=_DISAGG_PREFIX_PROMPT_LENGTH,
+        concurrency=concurrency,
+        concurrency_ramp_duration=ramp_seconds,
+        warmup_concurrency=warmup_concurrency,
+        warmup_duration=warmup_duration_seconds,
+        warmup_requests=0,
+        duration_minutes=duration_minutes,
+        request_timeout_seconds=30,
+        request_cancellation_rate=cancellation_rate,
+        request_cancellation_delay=cancellation_delay,
+        streaming=True,
+        ignore_eos=True,
+        connection_reuse_strategy="never",
+        goodput=["request_latency:30000"],
+    )
+
+
+@pytest.mark.k8s
+@pytest.mark.e2e
+@pytest.mark.weekly
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+@pytest.mark.parametrize(
+    "arm",
+    [
+        pytest.param("A", id="A-baseline-sla-only"),
+        pytest.param("B", id="B-baseline-plus-cancellation"),
+        pytest.param("C", id="C-baseline-plus-burst"),
+        pytest.param("F1", id="F1-fe-fd-exhaustion"),
+        pytest.param("F2", id="F2-fe-rolling-restart"),
+        pytest.param("F3", id="F3-fe-pod-delete"),
+        pytest.param("S", id="S-load-shed-prevent-overload"),
+        pytest.param("P", id="P-prefill-decode-partition"),
+        pytest.param("P2", id="P2-prefill-pod-kill"),
+        pytest.param("T1", id="T1-tokio-starved-abrupt-fe-kill"),
+    ],
+)
+async def test_decode_overload_disagg(runtime_env, request, arm):
+    spec = DeploymentSpec(_TEMPLATE)
+    served_model = spec["VllmDecodeWorker"].model
+
+    # F1: cap FE nofile at 1024 via the dyn_tee.sh wrapper. The wrapper
+    # reads DYN_TEST_NOFILE_LIMIT at startup and calls `ulimit -n N` before
+    # exec'ing the user command. K8s pod spec doesn't directly expose
+    # per-container nofile limits, so the env-var-in-wrapper path is the
+    # standard fix.
+    if arm == "F1":
+        # 1024 was insufficient at c=96 (peak FD ~246). 128 is 8x tighter;
+        # should trip accept() with margin.
+        spec["Frontend"].set_env_var("DYN_TEST_NOFILE_LIMIT", "128")
+
+    # T1: Single-threaded tokio runtime on decode. Combined with an
+    # abrupt FE kill at peak load, this should close the cascade chain:
+    # panic flood on the only worker thread → /live HTTP handler queues
+    # behind panic recovery → exceeds the 4 s liveness timeout →
+    # kubelet SIGTERM. The remaining ingredient F-3 lacked at our scale.
+    if arm == "T1":
+        spec["VllmDecodeWorker"].set_env_var("DYN_RUNTIME_NUM_WORKER_THREADS", "1")
+
+    # S: Enable load shedding on FE. Goal is to PREVENT overload —
+    # the router returns 503 once decode-busy crosses the threshold,
+    # so accepted requests still meet SLA while clients receive a
+    # fast "server busy" instead of a 30 s timeout.
+    if arm == "S":
+        fe = spec["Frontend"]
+        fe.set_env_var("DYN_ROUTER_QUEUE_THRESHOLD", "0.5")
+        fe.set_env_var("DYN_ROUTER_TRACK_PREFILL_TOKENS", "true")
+
+    # c=96 sustained at OSL=200 pegs decode KV at 100% on this topology.
+    # See findings/2026-05-13-decode-overload-repro-design.md for derivation.
+    ramp_load = _disagg_load(
+        served_model=served_model,
+        name="ramp",
+        concurrency=96,
+        duration_minutes=10.0,
+        ramp_seconds=600.0,
+        warmup_concurrency=4,
+        warmup_duration_seconds=60.0,
+        cancellation_rate=(8.0 if arm == "B" else None),
+        cancellation_delay=(1.5 if arm == "B" else 0.0),
+    )
+    # P2: bias sustain to long ISL (~7000) so NIXL transfers are slow
+    # enough that killing prefill mid-transfer is reliable. Single-bucket
+    # seq_dist forces every request to that shape.
+    sustain_seq_dist = "7000,200:100" if arm == "P2" else None
+    sustain_load = _disagg_load(
+        served_model=served_model,
+        name="sustain",
+        concurrency=96,
+        duration_minutes=15.0,
+        cancellation_rate=(8.0 if arm == "B" else None),
+        cancellation_delay=(1.5 if arm == "B" else 0.0),
+        seq_dist=sustain_seq_dist,
+    )
+
+    events: list = [WaitForModelReady(timeout=1800)]
+    # S: install the shedding threshold BEFORE load starts so the
+    # very first ramp requests can be 503'd if needed.
+    if arm == "S":
+        events.append(
+            SetBusyThreshold(
+                model_name=served_model,
+                active_decode_blocks_threshold=0.70,
+                active_prefill_tokens_threshold_frac=0.85,
+                name="install_shedding",
+            )
+        )
+    events.extend(
+        [
+            StartLoad(load_config=ramp_load, name="ramp"),
+            WaitForLoadCompletion(name="ramp"),
+            Wait(duration=15),
+            StartLoad(load_config=sustain_load, name="sustain"),
+        ]
+    )
+
+    # Fault overlay during sustain — schedule injection 5 min in
+    # (gives 1/3 of sustain to reach steady-state overload first).
+    # The Wait happens in parallel with the running StartLoad, since
+    # StartLoad returns immediately and WaitForLoadCompletion is what
+    # actually blocks on completion.
+    if arm == "C":
+        burst_load = _disagg_load(
+            served_model=served_model,
+            name="burst",
+            concurrency=120,
+            duration_minutes=1.0,
+        )
+        events.extend(
+            [
+                Wait(duration=300),  # wait into sustain
+                StartLoad(load_config=burst_load, name="burst"),
+                WaitForLoadCompletion(name="burst"),
+                WaitForLoadCompletion(name="sustain"),
+            ]
+        )
+    elif arm == "F2":
+        events.extend(
+            [
+                Wait(duration=300),
+                RollingUpgrade(services=["Frontend"], name="fe_rollout"),
+                WaitForLoadCompletion(name="sustain"),
+            ]
+        )
+    elif arm == "F3":
+        events.extend(
+            [
+                Wait(duration=300),
+                DeletePod(services=["Frontend"], name="fe_delete"),
+                WaitForLoadCompletion(name="sustain"),
+            ]
+        )
+    elif arm == "P":
+        # Prefill ↔ decode partition.
+        # NIXL is decode-pulled, so the relevant ingress direction is
+        # decode → prefill (decode initiates the NIXL handshake/pull).
+        # NetworkPolicy + conntrack-flush severs both new and existing
+        # connections; 120 s window is plenty to drive a sustained
+        # decode-side stall.
+        events.extend(
+            [
+                Wait(duration=300),
+                NetworkPartition(
+                    source="VllmDecodeWorker",
+                    target="VllmPrefillWorker",
+                    duration=120.0,
+                    name="prefill_decode_partition",
+                ),
+                WaitForLoadCompletion(name="sustain"),
+            ]
+        )
+    elif arm == "T1":
+        # Same abrupt FE kill as F-3, but on a decode pod whose tokio
+        # runtime has only one worker thread. Expect panics + /live
+        # timeout + kubelet SIGTERM → restartCount ≥ 1.
+        events.extend(
+            [
+                Wait(duration=300),
+                DeletePod(services=["Frontend"], force=True, name="t1_fe_kill"),
+                WaitForLoadCompletion(name="sustain"),
+            ]
+        )
+    elif arm == "P2":
+        # Abrupt prefill pod kill mid-sustain — 5/1 production class.
+        # At peak load decode has a deep queue of inflight requests, each
+        # waiting on an outstanding NIXL pull from a prefill peer.
+        # SIGKILLing the prefill rips its NIXL endpoint mid-handshake →
+        # decode raises `KeyError: remote_block_size` from vLLM's
+        # NixlConnector when it tries to complete those pulls.
+        # `force=True` on DeletePod => --grace-period=0 hard kill.
+        events.extend(
+            [
+                Wait(duration=300),
+                DeletePod(
+                    services=["VllmPrefillWorker"],
+                    force=True,
+                    pod_indices=[0],
+                    name="prefill_kill",
+                ),
+                WaitForLoadCompletion(name="sustain"),
+            ]
+        )
+    else:
+        events.append(WaitForLoadCompletion(name="sustain"))
+
+    # Gating checks — common to all arms.
+    if arm == "S":
+        # Shedding flips the polarity of every overload check: we want
+        # to PROVE the system stayed within bounds despite the same
+        # offered load. The 503-firing check is implemented via
+        # ServiceLogPatternRate below.
+        checks: list = [
+            LoadApplied(load_name="sustain", min_requests=500),
+            # On accepted (non-503) requests, AIPerf's request_latency
+            # only includes successful streams. p99 < 30 s = SLA held.
+            # SlaViolation passes if breached; we want it NOT to pass.
+            # No direct "InverseSla" check — assert via report instead;
+            # this arm runs with goodput SLO == 30 s so good_request_count
+            # / request_count is the metric.
+        ]
+    else:
+        checks = [
+            # 1. Cheap guard: some load went through. 100 floor accommodates
+            #    severe overload (A2 had 158 sustained reqs in 15 min).
+            LoadApplied(load_name="sustain", min_requests=100),
+            # 2. Decode KV reached or passed the disagg-cascade-class production peak.
+            KvCacheUsagePeak(
+                services=["VllmDecodeWorker"], threshold=0.80, within_seconds=1800
+            ),
+            # 3. Some pod's vllm-batch hit a meaningful running-count plateau.
+            #    Under KV pin, "running" is small (vllm preempt-recomputes),
+            #    so threshold=10 with 30s window catches the regime where
+            #    the engine is actively chewing a stable cohort, not idle.
+            RequestsRunningPeak(threshold=10, sustained_seconds=30.0),
+            # 4. Client-side disconnect / SLA-timeout pressure observed.
+            RequestCancellationOccurred(
+                load_name="sustain",
+                min_count=(100 if arm == "B" else 25),
+            ),
+            # 5. SLA breach — end-user impact signal.
+            SlaViolation(load_name="sustain", e2e_p99_ms=30000.0, ttft_p99_ms=10000.0),
+            # 6. Throughput collapse — engine spent ≥ 30 s at running=0
+            #    while frontend had pending work.
+            ThroughputCollapse(collapse_seconds=30.0),
+        ]
+
+    # Phase-2-specific assertions.
+    if arm == "F1":
+        # We expect FE to log the FD-exhaustion signature.
+        checks.append(
+            ServiceLogPatternRate(
+                services=["Frontend"],
+                pattern=r"accept\(\).*Too many open files|os error 24",
+                min_rate_per_sec=0.0,
+                expect_zero=False,
+            )
+        )
+    if arm == "S":
+        # FE should be returning 503 to clients above the busy threshold.
+        # The Rust frontend logs the queue-exceeded WARN at the
+        # busy_threshold handler; rate is the proof shedding fired.
+        checks.append(
+            ServiceLogPatternRate(
+                services=["Frontend"],
+                pattern=r"all workers.*busy|queue.*threshold|503 Service Unavailable",
+                min_rate_per_sec=0.1,
+                expect_zero=False,
+            )
+        )
+        # Decode KV should stay BELOW the busy threshold (we set 0.70).
+        # Use a slightly relaxed ceiling (0.80) to allow transient bursts.
+        # Inverse semantics — wrap in a small inline helper.
+        checks.append(_KvCacheStaysBelow(services=["VllmDecodeWorker"], ceiling=0.85))
+    if arm in ("F2", "F3"):
+        # FE shutdown via rollout/delete fires SO_LINGER=0 RST →
+        # decode `tcp_client.rs:255` panic burst should appear.
+        checks.append(
+            ServiceLogPatternRate(
+                services=["VllmDecodeWorker"],
+                pattern=r"panicked at .*tcp/client\.rs:255",
+                min_rate_per_sec=0.0,
+                expect_zero=False,
+            )
+        )
+    if arm == "T1":
+        # Full cascade closure: decode container should have been
+        # SIGTERMed by kubelet after /live timeouts during the panic
+        # flood. restartCount ≥ 1 is the proof.
+        checks.append(
+            RestartCountIncreased(services=["VllmDecodeWorker"], expect_min_increment=1)
+        )
+        # And the panic burst itself should be visible.
+        checks.append(
+            ServiceLogPatternRate(
+                services=["VllmDecodeWorker"],
+                pattern=r"panicked at .*tcp/client\.rs:255",
+                min_rate_per_sec=0.0,
+                expect_zero=False,
+            )
+        )
+    if arm in ("P", "P2"):
+        # P  — NetworkPolicy-based prefill↔decode partition.
+        # P2 — abrupt prefill SIGKILL mid-transfer (ISL=7000 sustain).
+        # Both should produce NIXL-side failures on decode. Looking for:
+        # 1. Decode raises KeyError on remote_block_size (D-3 production
+        #    class — vLLM's NIXL connector failing block lookup).
+        # 2. NIXL connector / UCX-level errors on either side.
+        # 3. The vllm:nixl_num_kv_expired_reqs_total counter climbs
+        #    (KV blocks aborted because peer disappeared).
+        checks.append(
+            ServiceLogPatternRate(
+                services=["VllmDecodeWorker", "VllmPrefillWorker"],
+                pattern=(
+                    r"KeyError: ['\"]?remote_block_size|"
+                    r"nixl.*(error|fail)|"
+                    r"UCX.*(ERROR|err)|"
+                    r"NixlConnector.*Exception"
+                ),
+                min_rate_per_sec=0.0,
+                expect_zero=False,
+            )
+        )
+
+    # Bonus signatures — informational, never gating.
+    checks.extend(
+        [
+            ServiceLogPatternRate(
+                services=["VllmDecodeWorker"],
+                pattern=r"radix_tree\.rs:(341|431)",
+                min_rate_per_sec=0.5,
+            ),
+            WorkerPanics(
+                services=["VllmDecodeWorker", "Frontend"],
+                acceptable=True,
+            ),
+            RestartCountIncreased(
+                services=["VllmDecodeWorker"], expect_min_increment=0
+            ),
+            LoadCompleted(name="sustain"),
+        ]
+    )
+
+    await run_scenario(
+        deployment_spec=spec,
+        events=events,
+        checks=checks,
+        reports=[
+            FaultToleranceReport(),
+            ErrorBreakdownReport(),
+            PerWorkerLatencyReport(),
+            ErrorTrackingReport(),
+        ],
+        test_name=request.node.name,
+        runtime_env=runtime_env,
+    )

--- a/tests/fault_tolerance/deploy/test_scenario_decode_overload_disagg.py
+++ b/tests/fault_tolerance/deploy/test_scenario_decode_overload_disagg.py
@@ -4,8 +4,8 @@
 # Decode-worker overload reproduction — disagg-cascade shape.
 #
 # Mirrors a production-shape workload (ISL p50≈1600 / p99≈7000, OSL≈200,
-# prefix-cache hit ~37%) on the 1-FE : 2-P : 1-D unit topology that matches
-# a customer per-set design point. Six parametrized arms.
+# prefix-cache hit ~37%) on the 1-FE : 2-P : 1-D unit topology. Six
+# parametrized arms.
 #
 # Phase 1 — overload-only (decode-side pressure without fault injection)
 #   A — c=96 sustained ramp + 30 s SLA timeout.
@@ -331,7 +331,7 @@ async def test_decode_overload_disagg(runtime_env, request, arm):
             ]
         )
     elif arm == "P2":
-        # Abrupt prefill pod kill mid-sustain — 5/1 production class.
+        # Abrupt prefill pod kill mid-sustain — peer-disappearance class.
         # At peak load decode has a deep queue of inflight requests, each
         # waiting on an outstanding NIXL pull from a prefill peer.
         # SIGKILLing the prefill rips its NIXL endpoint mid-handshake →

--- a/tests/fault_tolerance/deploy/test_scenario_n3_v110_routing_threshold_compare.py
+++ b/tests/fault_tolerance/deploy/test_scenario_n3_v110_routing_threshold_compare.py
@@ -3,9 +3,7 @@
 #
 # v1.1.0 head-to-head — three arms covering routing + threshold space.
 #
-# Per the dynamo-observe KV-routing test plan
-# (deployments/amazon-ads/2026-05-16-kv-routing-test-plan.md), the
-# rejection-thresholds env vars alone CAN'T prevent per-worker KV
+# Rejection-thresholds env vars alone CAN'T prevent per-worker KV
 # imbalance: under the default `round-robin` (or `least-loaded`) router,
 # requests are dispatched by stream count, not actual KV pressure. One
 # decode pod can sit at 100% KV while peers stay cool — the all-busy
@@ -27,7 +25,7 @@
 #   C. kv_route_threshold      | kv             | 0.85/0.85  | yes (overlap=0, T=0)
 #
 # All three: vllm-runtime:1.1.0, kv-events OFF on all workers
-# (matches the production AZ-c configuration).
+# (matches the prefill-events-disabled production config under test).
 #
 # Ladder per arm:
 #   1. Pre-warm phase (2 min, c=30, ISL=8K low-OSL) to bias KV pressure

--- a/tests/fault_tolerance/deploy/test_scenario_n3_v110_routing_threshold_compare.py
+++ b/tests/fault_tolerance/deploy/test_scenario_n3_v110_routing_threshold_compare.py
@@ -1,0 +1,407 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# v1.1.0 head-to-head — three arms covering routing + threshold space.
+#
+# Per the dynamo-observe KV-routing test plan
+# (deployments/amazon-ads/2026-05-16-kv-routing-test-plan.md), the
+# rejection-thresholds env vars alone CAN'T prevent per-worker KV
+# imbalance: under the default `round-robin` (or `least-loaded`) router,
+# requests are dispatched by stream count, not actual KV pressure. One
+# decode pod can sit at 100% KV while peers stay cool — the all-busy
+# 503 floor only fires when *every* worker is above threshold.
+#
+# Switching to `--router-mode kv` with all prefix-match weights zeroed
+# turns selection into pure argmin on `active_decode_blocks`. The router
+# routes around hot workers until peers catch up, then thresholds keep
+# overall fleet within bounds with 503s only at true saturation.
+#
+# Three arms (all on N=3: 3 FE : 6 PF TP=2 : 3 DE TP=2 = 18 GPUs).
+# `--max-num-seqs=256` is held constant across all three arms so the only
+# moving variable is routing+threshold:
+#
+#   arm                       | router-mode    | thresholds | KV-zeroed
+#   --------------------------+----------------+------------+---------
+#   A. baseline_no_threshold   | default (RR)   | unset      | n/a
+#   B. threshold_only          | default (RR)   | 0.85/0.85  | n/a
+#   C. kv_route_threshold      | kv             | 0.85/0.85  | yes (overlap=0, T=0)
+#
+# All three: vllm-runtime:1.1.0, kv-events OFF on all workers
+# (matches the production AZ-c configuration).
+#
+# Ladder per arm:
+#   1. Pre-warm phase (2 min, c=30, ISL=8K low-OSL) to bias KV pressure
+#      unevenly across decode pods under RR. Skipped on arm A (cascade
+#      is the story, not imbalance).
+#   2. Steady rungs: c=72, 144, 216, 288, 432 — 10 min each.
+#
+# Pass criteria summary:
+#   Arm A (baseline_no_threshold): cascade at upper rungs (KV ≥ 0.95, SLA breach).
+#   Arm B (threshold_only):
+#       - decode pods do NOT all stay below 0.90 → imbalance gap ≥ 30pp
+#         (max-min per-pod KV across decode pods on rung 4-5)
+#       - 503 rate may be near zero even with thresholds set
+#       - SLA breach observed on the hot pod
+#   Arm C (kv_route_threshold):
+#       - per-pod KV imbalance gap ≤ 15pp on every rung
+#       - 503 fires only when ALL pods are over threshold (rung 5)
+#       - SLA held until full-fleet saturation
+
+import pytest
+
+from tests.fault_tolerance.deploy.checks import (
+    Check,
+    KvCacheUsagePeak,
+    LoadApplied,
+    LoadCompleted,
+    RestartCountIncreased,
+    ServiceLogPatternRate,
+    SlaViolation,
+    WorkerPanics,
+    _iter_server_metric,
+)
+from tests.fault_tolerance.deploy.events import (
+    StartLoad,
+    Wait,
+    WaitForLoadCompletion,
+    WaitForModelReady,
+)
+from tests.fault_tolerance.deploy.reports import (
+    ErrorBreakdownReport,
+    ErrorTrackingReport,
+    FaultToleranceReport,
+    PerWorkerLatencyReport,
+)
+from tests.fault_tolerance.deploy.scenario import run_scenario
+from tests.utils.managed_deployment import DeploymentSpec
+from tests.utils.managed_load import LoadConfig
+
+_TEMPLATE = (
+    "/workspace/tests/fault_tolerance/deploy/templates/vllm/"
+    "disagg_qwen3_30b_unit_prod.yaml"
+)
+
+_V110_IMAGE = "nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.0"
+
+_PROD_SEQ_DIST = "100,200:5;500,200:15;1000,200:20;1600,200:30;3400,200:20;7000,200:10"
+_NUM_PREFIX_PROMPTS = 15
+_PREFIX_PROMPT_LENGTH = 600
+
+# Single-bucket warmup shape — long ISL, short OSL — creates concentrated
+# KV pressure that decays slowly. Drives initial per-worker asymmetry.
+_PREWARM_SEQ_DIST = "8000,50:100"
+
+# Cluster-wide closed-loop concurrency rungs (N=3 = 3 FE pods).
+# Per-set: 24, 48, 72, 96, 144. Design point ~96/set; rung 5 = 1.5× design.
+_RUNGS = [
+    ("c72", 72, 10.0),
+    ("c144", 144, 10.0),
+    ("c216", 216, 10.0),
+    ("c288", 288, 10.0),
+    ("c432", 432, 10.0),
+]
+
+
+from dataclasses import dataclass  # noqa: E402
+
+
+@dataclass
+class _KvCacheStaysBelow(Check):
+    """Assert every sample of ``vllm:kv_cache_usage_perc`` on the named
+    services stays at or below ``ceiling``."""
+
+    services: list
+    ceiling: float = 0.90
+
+    def validate(self, ctx) -> None:
+        observed: dict = {}
+        for ts_ns, pod, val in _iter_server_metric(ctx, "vllm:kv_cache_usage_perc"):
+            cur = observed.get(pod)
+            if cur is None or val > cur:
+                observed[pod] = val
+        ctx.logger.info(
+            f"_KvCacheStaysBelow: per-pod max KV={observed} " f"ceiling={self.ceiling}"
+        )
+        breaches = {p: v for p, v in observed.items() if v > self.ceiling}
+        assert not breaches, (
+            f"_KvCacheStaysBelow: pods exceeded KV ceiling "
+            f"{self.ceiling}: {breaches}"
+        )
+
+    @property
+    def description(self) -> str:
+        return (
+            f"KV cache usage stays ≤ {self.ceiling} on "
+            f"{', '.join(self.services)} (routing/shedding holds the line)"
+        )
+
+
+@dataclass
+class _KvImbalanceGap(Check):
+    """Compute per-pod max(``vllm:kv_cache_usage_perc``) across the named
+    services. Assert that ``max(per-pod peaks) - min(per-pod peaks)`` is
+    either below ``max_gap`` (proves rebalancing) or above ``min_gap``
+    (proves imbalance reproduced)."""
+
+    services: list
+    max_gap: float | None = None
+    min_gap: float | None = None
+
+    def validate(self, ctx) -> None:
+        observed: dict = {}
+        for ts_ns, pod, val in _iter_server_metric(ctx, "vllm:kv_cache_usage_perc"):
+            cur = observed.get(pod)
+            if cur is None or val > cur:
+                observed[pod] = val
+        if len(observed) < 2:
+            ctx.logger.warning(
+                f"_KvImbalanceGap: only {len(observed)} pods observed; "
+                f"cannot compute imbalance"
+            )
+            return
+        peaks = list(observed.values())
+        gap = max(peaks) - min(peaks)
+        ctx.logger.info(
+            f"_KvImbalanceGap: per-pod peaks={observed} "
+            f"max={max(peaks):.3f} min={min(peaks):.3f} gap={gap:.3f}"
+        )
+        if self.max_gap is not None:
+            assert gap <= self.max_gap, (
+                f"_KvImbalanceGap: gap {gap:.3f} > max_gap {self.max_gap} "
+                f"(per-pod peaks={observed})"
+            )
+        if self.min_gap is not None:
+            assert gap >= self.min_gap, (
+                f"_KvImbalanceGap: gap {gap:.3f} < min_gap {self.min_gap} "
+                f"(per-pod peaks={observed}) — imbalance not reproduced"
+            )
+
+    @property
+    def description(self) -> str:
+        if self.max_gap is not None and self.min_gap is None:
+            return (
+                f"Per-pod KV peak gap across {', '.join(self.services)} "
+                f"≤ {self.max_gap} (routing rebalanced)"
+            )
+        if self.min_gap is not None and self.max_gap is None:
+            return (
+                f"Per-pod KV peak gap across {', '.join(self.services)} "
+                f"≥ {self.min_gap} (imbalance reproduced)"
+            )
+        return f"KV-pod imbalance gap on {', '.join(self.services)}"
+
+
+def _scale_to_units(spec, units):
+    for service in ("Frontend", "VllmPrefillWorker", "VllmDecodeWorker"):
+        spec[service].replicas = spec[service].replicas * units
+
+
+def _prod_load(*, served_model, concurrency, duration_minutes, name, seq_dist=None):
+    return LoadConfig(
+        model_name=served_model,
+        tokenizer=served_model,
+        seq_dist=seq_dist or _PROD_SEQ_DIST,
+        num_prefix_prompts=_NUM_PREFIX_PROMPTS,
+        prefix_prompt_length=_PREFIX_PROMPT_LENGTH,
+        concurrency=concurrency,
+        duration_minutes=duration_minutes,
+        request_timeout_seconds=20,
+        streaming=True,
+        ignore_eos=True,
+        warmup_requests=0,
+        connection_reuse_strategy="never",
+        goodput=["request_latency:20000"],
+    )
+
+
+_ARMS = [
+    pytest.param("baseline_no_threshold", id="baseline_no_threshold"),
+    pytest.param("threshold_only", id="threshold_only"),
+    pytest.param("kv_route_threshold", id="kv_route_threshold"),
+]
+
+
+@pytest.mark.k8s
+@pytest.mark.e2e
+@pytest.mark.weekly
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+@pytest.mark.parametrize("arm", _ARMS)
+async def test_n3_v110_routing_threshold_compare(runtime_env, request, arm):
+    spec = DeploymentSpec(_TEMPLATE)
+    _scale_to_units(spec, units=3)
+
+    # Pin all arms to v1.1.0 (templates default to v1.0.1).
+    for svc in ("Frontend", "VllmPrefillWorker", "VllmDecodeWorker"):
+        spec[svc].image = _V110_IMAGE
+
+    # aks-dev: pin Frontend to the A100 node pool (1.87 TB ephemeral).
+    fe_pod = spec["Frontend"]._spec.setdefault("extraPodSpec", {})
+    fe_pod["nodeSelector"] = {"nvidia.com/gpu.product": "NVIDIA-A100-SXM4-80GB"}
+    fe_pod["tolerations"] = [
+        {"key": "nvidia.com/gpu", "operator": "Exists", "effect": "NoSchedule"},
+    ]
+
+    # aks-dev: full unprivileged-bypass recipe for UCX/NIXL on
+    # cri-containerd AppArmor + 64KB memlock default (OPS-4332).
+    for svc in ("VllmPrefillWorker", "VllmDecodeWorker"):
+        main = (
+            spec[svc]
+            ._spec.setdefault("extraPodSpec", {})
+            .setdefault("mainContainer", {})
+        )
+        secctx = main.setdefault("securityContext", {})
+        secctx["privileged"] = True
+        secctx["runAsUser"] = 0
+        secctx["appArmorProfile"] = {"type": "Unconfined"}
+        caps = secctx.setdefault("capabilities", {})
+        caps.setdefault("add", []).append("IPC_LOCK")
+        spec[svc].set_env_var("DYN_TEST_MEMLOCK_UNLIMITED", "1")
+
+    # aks-dev runs A100-80GB; production runs A100-40GB. Halve the
+    # gpu-memory-utilization so per-GPU effective KV envelope matches prod.
+    for svc in ("VllmPrefillWorker", "VllmDecodeWorker"):
+        spec[svc].set_arg("--gpu-memory-utilization", "0.5")
+
+    served_model = spec["VllmDecodeWorker"].model
+
+    # ----- arm-specific config -----
+    # --max-num-seqs held constant at 256 across all arms — the variable
+    # is purely routing + threshold settings.
+    spec["VllmPrefillWorker"].set_arg("--max-num-seqs", "256")
+    spec["VllmDecodeWorker"].set_arg("--max-num-seqs", "256")
+
+    fe = spec["Frontend"]
+    # Threshold envs — both threshold arms.
+    if arm in ("threshold_only", "kv_route_threshold"):
+        fe.set_env_var("DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD", "0.85")
+        fe.set_env_var("DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD_FRAC", "0.85")
+
+    # KV-mode routing config — arm C only.
+    # Use env vars (NOT set_arg on the FE) — `set_arg` initialises an
+    # empty args list that clobbers the framework's default
+    # `python3 -m dynamo.frontend` injection. Env vars achieve the same
+    # configuration without touching the CLI argv plane.
+    if arm == "kv_route_threshold":
+        fe.set_env_var("DYN_ROUTER_MODE", "kv")
+        fe.set_env_var("DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT", "0.0")
+        fe.set_env_var("DYN_ROUTER_TEMPERATURE", "0.0")
+        # DYN_ROUTER_USE_KV_EVENTS=false matches --no-router-kv-events.
+        fe.set_env_var("DYN_ROUTER_USE_KV_EVENTS", "false")
+
+    # ----- Events: optional pre-warm, then rung ladder -----
+    events: list = [WaitForModelReady(timeout=2400)]
+
+    # Pre-warm only for the two threshold arms — they're the ones where
+    # imbalance is the question. Skip for baseline (cascade dominates).
+    if arm in ("threshold_only", "kv_route_threshold"):
+        prewarm = _prod_load(
+            served_model=served_model,
+            concurrency=30,
+            duration_minutes=2.0,
+            name="prewarm",
+            seq_dist=_PREWARM_SEQ_DIST,
+        )
+        events.append(StartLoad(load_config=prewarm, name="prewarm"))
+        events.append(WaitForLoadCompletion(name="prewarm"))
+        events.append(Wait(duration=30))  # let KV pressure stabilize
+
+    for name, conc, dur in _RUNGS:
+        cfg = _prod_load(
+            served_model=served_model,
+            concurrency=conc,
+            duration_minutes=dur,
+            name=name,
+        )
+        events.append(StartLoad(load_config=cfg, name=name))
+        events.append(WaitForLoadCompletion(name=name))
+        events.append(Wait(duration=30))
+
+    # ----- Checks per arm -----
+    final = _RUNGS[-1][0]
+    common_panics = WorkerPanics(
+        services=["VllmDecodeWorker", "VllmPrefillWorker", "Frontend"],
+        acceptable=True,
+    )
+
+    if arm == "baseline_no_threshold":
+        # Baseline: establish the max / steady-state RPS the cluster can
+        # sustain at a 20 s SLA. No thresholds, default routing. Climbing
+        # the rungs measures where goodput plateaus and where SLA starts
+        # to breach — that knee is the ceiling all other arms get
+        # compared against.
+        checks = [
+            LoadApplied(load_name=final, min_requests=100),
+            # Restarts informational only — baseline may or may not crash.
+            RestartCountIncreased(
+                services=["VllmDecodeWorker"], expect_min_increment=0
+            ),
+            RestartCountIncreased(services=["Frontend"], expect_min_increment=0),
+            LoadCompleted(name=final),
+            common_panics,
+        ]
+    elif arm == "threshold_only":
+        # Imbalance reproduction: thresholds are set but routing is
+        # round-robin so one pod gets hot while peers stay cool.
+        # Expectations:
+        #  - At least one decode pod over the threshold ceiling.
+        #  - Per-pod gap ≥ 30 pp (imbalance reproduced).
+        #  - SLA still breached on the hot pod.
+        #  - 503 rate may be near zero — all-busy gate doesn't fire
+        #    because only one pod is over.
+        checks = [
+            LoadApplied(load_name=final, min_requests=500),
+            KvCacheUsagePeak(
+                services=["VllmDecodeWorker"],
+                threshold=0.90,  # at least one pod hits this
+                within_seconds=3600,
+            ),
+            _KvImbalanceGap(services=["VllmDecodeWorker"], min_gap=0.30),
+            SlaViolation(load_name=final, e2e_p99_ms=20000.0, ttft_p99_ms=10000.0),
+            RestartCountIncreased(
+                services=["VllmDecodeWorker"], expect_min_increment=0
+            ),
+            RestartCountIncreased(services=["Frontend"], expect_min_increment=0),
+            LoadCompleted(name=final),
+            common_panics,
+        ]
+    else:  # kv_route_threshold
+        # Load-aware routing with thresholds. Pass criteria:
+        #  - Every decode pod stays ≤ 0.90 (routing rebalances).
+        #  - Per-pod gap ≤ 0.15 (within 15 pp of each other).
+        #  - 503 fires only when ALL pods are simultaneously over the
+        #    threshold (rung 5 saturates everyone).
+        #  - Zero restarts.
+        checks = [
+            LoadApplied(load_name=final, min_requests=500),
+            _KvCacheStaysBelow(services=["VllmDecodeWorker"], ceiling=0.95),
+            _KvImbalanceGap(services=["VllmDecodeWorker"], max_gap=0.15),
+            RestartCountIncreased(
+                services=["VllmDecodeWorker"], expect_min_increment=0
+            ),
+            RestartCountIncreased(services=["Frontend"], expect_min_increment=0),
+            RestartCountIncreased(
+                services=["VllmPrefillWorker"], expect_min_increment=0
+            ),
+            ServiceLogPatternRate(
+                services=["Frontend"],
+                pattern=r"all workers.*busy|busy_threshold|503 Service Unavailable",
+                min_rate_per_sec=0.05,
+                expect_zero=False,
+            ),
+            LoadCompleted(name=final),
+            common_panics,
+        ]
+
+    await run_scenario(
+        deployment_spec=spec,
+        events=events,
+        checks=checks,
+        reports=[
+            FaultToleranceReport(),
+            ErrorBreakdownReport(),
+            PerWorkerLatencyReport(),
+            ErrorTrackingReport(),
+        ],
+        test_name=request.node.name,
+        runtime_env=runtime_env,
+    )

--- a/tests/fault_tolerance/deploy/test_scenario_n3_v110_routing_threshold_compare.py
+++ b/tests/fault_tolerance/deploy/test_scenario_n3_v110_routing_threshold_compare.py
@@ -47,6 +47,8 @@
 #       - 503 fires only when ALL pods are over threshold (rung 5)
 #       - SLA held until full-fleet saturation
 
+import os
+
 import pytest
 
 from tests.fault_tolerance.deploy.checks import (
@@ -76,12 +78,17 @@ from tests.fault_tolerance.deploy.scenario import run_scenario
 from tests.utils.managed_deployment import DeploymentSpec
 from tests.utils.managed_load import LoadConfig
 
-_TEMPLATE = (
-    "/workspace/tests/fault_tolerance/deploy/templates/vllm/"
-    "disagg_qwen3_30b_unit_prod.yaml"
+_TEMPLATE = os.path.join(
+    os.path.dirname(__file__),
+    "templates",
+    "vllm",
+    "disagg_qwen3_30b_unit_prod.yaml",
 )
 
-_V110_IMAGE = "nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.0"
+_V110_IMAGE = os.environ.get(
+    "OVERLOAD_VLLM_IMAGE",
+    "nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1",
+)
 
 _PROD_SEQ_DIST = "100,200:5;500,200:15;1000,200:20;1600,200:30;3400,200:20;7000,200:10"
 _NUM_PREFIX_PROMPTS = 15

--- a/tests/fault_tolerance/deploy/test_worker_death_kv_transfer.py
+++ b/tests/fault_tolerance/deploy/test_worker_death_kv_transfer.py
@@ -1,0 +1,281 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Worker death mid-KV-transfer — reliable cascade reproduction.
+
+Forces a prefill peer to disappear while it is in the middle of NIXL
+KV transfers to the decode worker, then measures the cascade. A
+`DeletePod(VllmPrefillWorker, force=True)` mid-transfer with sustained
+heavy-prefill load drives the paired decode worker into engine death
+— UCX `ucp_requests` pool warnings followed by many `raise output`
+exceptions in vLLM's `generate_tokens` / `_abort_monitor` path. Same
+NIXL-peer-disappearance class as a prefill-process exit under load.
+
+The forcing function is **ISL=7000 tokens**: heavy prefill drives big
+prefill→decode KV transfers continuously, so killing a prefill mid-NIXL
+is the common case rather than a race.
+
+Scoped to the smallest meaningful disagg topology (units=1 → 1 FE + 2
+PF + 1 DE) so the cascade signal is observable on a 5-GPU footprint.
+"""
+
+import logging
+
+import pytest
+
+from tests.fault_tolerance.deploy.checks import MaxErrors, MinRequests, WorkerPanics
+from tests.fault_tolerance.deploy.events import (
+    DeletePod,
+    StartLoad,
+    StopLoad,
+    Wait,
+    WaitForModelReady,
+    WaitForRecovery,
+)
+from tests.fault_tolerance.deploy.reports import (
+    ErrorBreakdownReport,
+    FaultToleranceReport,
+)
+from tests.fault_tolerance.deploy.scenario import run_scenario
+from tests.fault_tolerance.deploy.test_overload import (
+    _apply_cluster_portability,
+    _apply_router_config,
+    _apply_topology,
+    _load_dgd,
+)
+from tests.utils.managed_load import LoadConfig
+
+logger = logging.getLogger(__name__)
+
+
+# DGD template shared with test_overload — production-shape disagg unit.
+_DGD = "disagg_qwen3_30b_unit_prod"
+
+# Forcing-function workload: heavy prefill drives continuous prefill→decode
+# KV transfers. ISL=7000 / OSL=100 is the heavy-prefill / light-decode
+# regime that keeps NIXL transfer pipelines saturated end-to-end.
+_ISL_TOKENS = 7000
+_OSL_TOKENS = 100
+
+# Smallest meaningful disagg footprint for parametrized service-kill.
+# 1 FE + 2 PF (TP=2) + 1 DE (TP=2) = 4 pods, 5 GPUs.
+# Two prefills lets us kill one and keep one peer serving so the
+# kill-versus-recover dynamic is observable.
+_DEFAULT_UNITS = 1
+_DEFAULT_FE = 1
+_DEFAULT_PF = 2
+_DEFAULT_DE = 1
+
+# Saturation point chosen so the decode hits KV=1.00 with ~c in-flight
+# requests at the moment of the kill — every one holds live NIXL block
+# references back to the prefills, so killing one prefill maximises the
+# lost-reference set.
+_DEFAULT_CONCURRENCY = 96
+
+# Closed-loop ramp 4→c over 600s, then sustain 5 min, then kill
+# mid-sustain. Default total load duration = ramp + pre-kill sustain
+# + post-kill recovery soak.
+_DEFAULT_RAMP_S = 600
+_DEFAULT_WARMUP_C = 4
+_DEFAULT_PRE_KILL_SUSTAIN_S = 300  # 5-min sustain before the kill
+_DEFAULT_POST_KILL_RECOVERY_S = 300  # observation + recovery soak
+_LOAD_DURATION_MIN = (
+    _DEFAULT_RAMP_S + _DEFAULT_PRE_KILL_SUSTAIN_S + _DEFAULT_POST_KILL_RECOVERY_S
+) / 60
+
+
+def _kv_transfer_load(
+    *,
+    served_model: str,
+    concurrency: int,
+    duration_minutes: float,
+    ramp_duration_s: float = 0,
+    warmup_concurrency: int = 0,
+) -> LoadConfig:
+    """Fixed-ISL load that maximises prefill→decode KV transfer volume.
+
+    Distinct from `_prod_load` (test_overload): no prefix-cache shaping
+    (uniform prompts → bigger NIXL transfers), no `seq_dist` (fixed ISL
+    means every request hits the worst case).
+
+    When `ramp_duration_s > 0`, AIPerf ramps closed-loop concurrency
+    from `warmup_concurrency` (or 1) up to `concurrency` over
+    `ramp_duration_s` seconds — drives KV-saturation buildup before
+    the kill so the lost-reference set is large.
+    """
+    return LoadConfig(
+        model_name=served_model,
+        tokenizer=served_model,
+        input_tokens_mean=_ISL_TOKENS,
+        input_tokens_stddev=200,
+        output_tokens_mean=_OSL_TOKENS,
+        concurrency=concurrency,
+        duration_minutes=duration_minutes,
+        request_timeout_seconds=120,
+        streaming=True,
+        ignore_eos=True,
+        warmup_requests=0,
+        connection_reuse_strategy="never",
+        concurrency_ramp_duration=ramp_duration_s if ramp_duration_s > 0 else None,
+        warmup_concurrency=warmup_concurrency if warmup_concurrency > 0 else None,
+        warmup_duration=60 if warmup_concurrency > 0 else None,
+    )
+
+
+def add_cli_options(parser):
+    g = parser.getgroup(
+        "worker-death-kv-transfer", "Worker death mid-KV-transfer scenario"
+    )
+    # Note: --units is registered by test_overload (shared topology flag).
+    g.addoption(
+        "--wd-concurrency",
+        type=int,
+        default=_DEFAULT_CONCURRENCY,
+        help=f"Concurrency during fault window. Default: {_DEFAULT_CONCURRENCY}",
+    )
+    g.addoption(
+        "--wd-isl-tokens",
+        type=int,
+        default=_ISL_TOKENS,
+        help=f"Mean input tokens. Default: {_ISL_TOKENS} (forces heavy KV transfer)",
+    )
+    g.addoption(
+        "--wd-target-service",
+        default="VllmPrefillWorker",
+        choices=["VllmPrefillWorker", "VllmDecodeWorker", "Frontend"],
+        help="Which service to kill mid-transfer. Default: VllmPrefillWorker",
+    )
+    g.addoption(
+        "--wd-ramp-s",
+        type=int,
+        default=_DEFAULT_RAMP_S,
+        help=f"Closed-loop ramp duration before sustain. Default: {_DEFAULT_RAMP_S}s. Set 0 to disable.",
+    )
+    g.addoption(
+        "--wd-warmup-c",
+        type=int,
+        default=_DEFAULT_WARMUP_C,
+        help=f"Starting concurrency for the ramp. Default: {_DEFAULT_WARMUP_C}",
+    )
+    g.addoption(
+        "--wd-pre-kill-sustain-s",
+        type=int,
+        default=_DEFAULT_PRE_KILL_SUSTAIN_S,
+        help=f"Time at full concurrency before kill. Default: {_DEFAULT_PRE_KILL_SUSTAIN_S}s",
+    )
+    g.addoption(
+        "--wd-post-kill-recovery-s",
+        type=int,
+        default=_DEFAULT_POST_KILL_RECOVERY_S,
+        help=f"Observation soak after kill. Default: {_DEFAULT_POST_KILL_RECOVERY_S}s",
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.k8s
+@pytest.mark.fault_tolerance
+@pytest.mark.e2e
+@pytest.mark.weekly
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+async def test_worker_death_kv_transfer(runtime_env, request):
+    """Drive heavy KV-transfer load, kill one target-service pod mid-flight,
+    measure cascade signature + recovery.
+
+    Expected signature when saturated: killing one prefill with ISL=7000
+    sustained drives the paired decode to engine death within seconds
+    (UCX pool warnings + many `raise output` exceptions). Whether a
+    given image survives that cascade (via migration support / better
+    NIXL handling) is what this test answers.
+    """
+    cfg = request.config
+    image = cfg.getoption("--image") or "nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.1"
+    units = cfg.getoption("--units")
+    concurrency = cfg.getoption("--wd-concurrency")
+    target_service = cfg.getoption("--wd-target-service")
+    isl = cfg.getoption("--wd-isl-tokens")
+    ramp_s = cfg.getoption("--wd-ramp-s")
+    warmup_c = cfg.getoption("--wd-warmup-c")
+    pre_kill_s = cfg.getoption("--wd-pre-kill-sustain-s")
+    post_kill_s = cfg.getoption("--wd-post-kill-recovery-s")
+
+    # Total AIPerf load duration spans ramp + pre-kill sustain + post-kill soak.
+    load_duration_min = (ramp_s + pre_kill_s + post_kill_s) / 60
+
+    spec = _load_dgd(_DGD)
+    _apply_topology(spec, units=units, fe=_DEFAULT_FE, pf=_DEFAULT_PF, dec=_DEFAULT_DE)
+    for svc in ("Frontend", "VllmPrefillWorker", "VllmDecodeWorker"):
+        spec[svc].image = image
+    _apply_cluster_portability(spec)
+    _apply_router_config(spec, router_mode=cfg.getoption("--router-mode"))
+
+    model_cache_pvc = cfg.getoption("--model-cache-pvc")
+    if model_cache_pvc:
+        spec.enable_model_cache(model_cache_pvc)
+
+    served_model = spec["VllmDecodeWorker"].model
+
+    logger.info(
+        "test_worker_death_kv_transfer: units=%d target=%s c=%d isl=%d",
+        units,
+        target_service,
+        concurrency,
+        isl,
+    )
+
+    await run_scenario(
+        deployment_spec=spec,
+        events=[
+            WaitForModelReady(timeout=2400),
+            StartLoad(
+                load_config=_kv_transfer_load(
+                    served_model=served_model,
+                    concurrency=concurrency,
+                    duration_minutes=load_duration_min,
+                    ramp_duration_s=ramp_s,
+                    warmup_concurrency=warmup_c,
+                ),
+                name="heavy-kv",
+            ),
+            # Ramp + pre-kill sustain — get to KV saturation BEFORE killing.
+            # The cascade only reproduces when decode is at KV=1.00 with
+            # a full in-flight queue at the moment of the kill.
+            Wait(duration=ramp_s + pre_kill_s),
+            # The fault: kill one pod of the target service mid-NIXL.
+            # `force=True` skips graceful shutdown so in-flight transfers
+            # are abruptly broken (the reliable repro condition).
+            DeletePod(
+                services=[target_service],
+                force=True,
+                pod_indices=[0],
+                name="kill-mid-transfer",
+            ),
+            # Post-kill recovery soak — replacement-pod cold start
+            # (vLLM WorkerProc init can take ~60s + model load).
+            Wait(duration=post_kill_s),
+            WaitForRecovery(timeout=600),
+            StopLoad(),
+        ],
+        checks=[
+            # Minimum signal that load actually ran
+            MinRequests(min_count=50),
+            # Allow significant errors during fault window — what matters
+            # is recovery, not absence of failures. Tighten later once we
+            # have baseline data.
+            MaxErrors(max_errors=1_000_000),
+            # Pods that survive should NOT panic on the peer's death.
+            # Decode is expected to self-terminate cleanly via Runtime
+            # shutdown rather than panic. `acceptable=True` for now;
+            # tighten once the test image is past PR #8254 (tcp/client
+            # ConnectionReset panic fix).
+            WorkerPanics(
+                services=["VllmPrefillWorker", "VllmDecodeWorker", "Frontend"],
+                acceptable=True,
+            ),
+        ],
+        reports=[
+            FaultToleranceReport(),
+            ErrorBreakdownReport(),
+        ],
+        test_name=f"test_worker_death_kv_transfer[{target_service}-u{units}-c{concurrency}]",
+        runtime_env=runtime_env,
+    )

--- a/tests/fault_tolerance/deploy/test_worker_kill_mocker.py
+++ b/tests/fault_tolerance/deploy/test_worker_kill_mocker.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Mocker-backed pod-delete fault test. Mid-load DeletePod on the decode
+# worker; the framework's WaitForRecovery + FaultToleranceReport
+# captures recovery time and the pre/post-fault request and latency
+# delta. Companion to test_worker_kill_vllm.py.
+
+import pytest
+
+from tests.fault_tolerance.deploy.checks import LoadStopped, MaxErrors, MinRequests
+from tests.fault_tolerance.deploy.events import (
+    DeletePod,
+    StartLoad,
+    StopLoad,
+    Wait,
+    WaitForRecovery,
+)
+from tests.fault_tolerance.deploy.reports import FaultToleranceReport
+from tests.fault_tolerance.deploy.scenario import run_scenario
+from tests.utils.managed_deployment import DeploymentSpec
+from tests.utils.managed_load import LoadConfig
+
+
+@pytest.mark.k8s
+@pytest.mark.fault_tolerance
+@pytest.mark.e2e
+@pytest.mark.weekly
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+async def test_worker_kill_mocker(
+    namespace, image, skip_service_restart, storage_class
+):
+    """Inject a single decode-pod kill mid-load and produce the report."""
+    spec = DeploymentSpec.from_backend("mocker", "agg")
+    spec["decode"].set_arg(
+        "--planner-profile-data",
+        "/workspace/tests/planner/profiling_results/H200_TP1P_TP1D",
+    )
+    # Make the mocker simulate a slow worker boot so the post-fault
+    # window is long enough for in-flight requests to actually fail
+    # (rather than just stalling under the frontend's buffering).
+    spec["decode"].set_arg("--startup-time", "30")
+    served_model = spec["decode"].model
+
+    await run_scenario(
+        deployment_spec=spec,
+        events=[
+            StartLoad(
+                load_config=LoadConfig(
+                    model_name=served_model,
+                    tokenizer=served_model,
+                    duration_minutes=2,
+                    concurrency=4,
+                    input_tokens_mean=128,
+                    output_tokens_mean=32,
+                )
+            ),
+            Wait(duration=15),
+            DeletePod(services=["decode"]),
+            WaitForRecovery(timeout=120),
+            Wait(duration=20),
+            StopLoad(),
+        ],
+        checks=[
+            # StopLoad explicitly terminates the load mid-run, so cancelled
+            # is the expected outcome here (the alternative is to let the
+            # load run to its natural duration end which would slow the
+            # test for no extra signal).
+            LoadStopped(),
+            MinRequests(min_count=20),
+            MaxErrors(max_errors=20),
+        ],
+        reports=[FaultToleranceReport()],
+        namespace=namespace,
+        image=image,
+        test_name="test_worker_kill_mocker",
+        skip_service_restart=skip_service_restart,
+        storage_class=storage_class,
+    )

--- a/tests/fault_tolerance/deploy/test_worker_kill_vllm.py
+++ b/tests/fault_tolerance/deploy/test_worker_kill_vllm.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# vllm pod-delete fault test. Mid-load DeletePod on the
+# VllmDecodeWorker; the framework's WaitForRecovery + FaultToleranceReport
+# captures recovery time (vllm reload dominates, ~80-90s) and the pre/
+# post-fault request and latency delta on a real worker. Companion to
+# test_worker_kill_mocker.py.
+
+import pytest
+
+from tests.fault_tolerance.deploy.checks import MaxErrors, MinRequests
+from tests.fault_tolerance.deploy.events import (
+    DeletePod,
+    StartLoad,
+    StopLoad,
+    Wait,
+    WaitForModelReady,
+    WaitForRecovery,
+)
+from tests.fault_tolerance.deploy.reports import (
+    ErrorBreakdownReport,
+    FaultToleranceReport,
+)
+from tests.fault_tolerance.deploy.scenario import run_scenario
+from tests.utils.managed_deployment import DeploymentSpec
+from tests.utils.managed_load import LoadConfig
+
+
+@pytest.mark.k8s
+@pytest.mark.fault_tolerance
+@pytest.mark.e2e
+@pytest.mark.weekly
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+async def test_worker_kill_vllm(namespace, image, skip_service_restart, storage_class):
+    spec = DeploymentSpec.from_backend("vllm", "agg")
+    served_model = spec["VllmDecodeWorker"].model
+
+    await run_scenario(
+        deployment_spec=spec,
+        events=[
+            WaitForModelReady(timeout=600),
+            StartLoad(
+                load_config=LoadConfig(
+                    model_name=served_model,
+                    tokenizer=served_model,
+                    duration_minutes=2,
+                    concurrency=4,
+                    input_tokens_mean=128,
+                    output_tokens_mean=32,
+                )
+            ),
+            Wait(duration=20),
+            DeletePod(services=["VllmDecodeWorker"]),
+            WaitForRecovery(timeout=300),
+            Wait(duration=20),
+            StopLoad(),
+        ],
+        checks=[
+            # No LoadStopped check — vllm startup + recovery can exceed
+            # the load duration, in which case the load completes
+            # naturally rather than being stopped early.
+            MinRequests(min_count=20),
+            # vllm worker recovery can take >30s; aiperf retries the dead
+            # endpoint at high rate so absolute error count is huge but
+            # each is a 404. The point of this test is the report, not
+            # the threshold. Keep the cap permissive so the test can
+            # render its FT report.
+            MaxErrors(max_errors=1_000_000),
+        ],
+        reports=[FaultToleranceReport(), ErrorBreakdownReport()],
+        namespace=namespace,
+        image=image,
+        test_name="test_worker_kill_vllm",
+        skip_service_restart=skip_service_restart,
+        storage_class=storage_class,
+    )

--- a/tests/fault_tolerance/deploy/uv.lock
+++ b/tests/fault_tolerance/deploy/uv.lock
@@ -1,0 +1,1487 @@
+version = 1
+revision = 2
+requires-python = ">=3.10, <3.13"
+resolution-markers = [
+    "python_full_version >= '3.11' and sys_platform == 'win32'",
+    "python_full_version >= '3.11' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.11'",
+]
+
+[[package]]
+name = "aiohappyeyeballs"
+version = "2.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/30/f84a107a9c4331c14b2b586036f40965c128aa4fee4dda5d3d51cb14ad54/aiohappyeyeballs-2.6.1.tar.gz", hash = "sha256:c3f9d0113123803ccadfdf3f0faa505bc78e6a72d1cc4806cbd719826e943558", size = 22760, upload-time = "2025-03-12T01:42:48.764Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/15/5bf3b99495fb160b63f95972b81750f18f7f4e02ad051373b669d17d44f2/aiohappyeyeballs-2.6.1-py3-none-any.whl", hash = "sha256:f349ba8f4b75cb25c99c5c2d84e997e485204d2902a9597802b0371f09331fb8", size = 15265, upload-time = "2025-03-12T01:42:47.083Z" },
+]
+
+[[package]]
+name = "aiohttp"
+version = "3.13.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohappyeyeballs" },
+    { name = "aiosignal" },
+    { name = "async-timeout", marker = "python_full_version < '3.11'" },
+    { name = "attrs" },
+    { name = "frozenlist" },
+    { name = "multidict" },
+    { name = "propcache" },
+    { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/9a/152096d4808df8e4268befa55fba462f440f14beab85e8ad9bf990516918/aiohttp-3.13.5.tar.gz", hash = "sha256:9d98cc980ecc96be6eb4c1994ce35d28d8b1f5e5208a23b421187d1209dbb7d1", size = 7858271, upload-time = "2026-03-31T22:01:03.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/85/cebc47ee74d8b408749073a1a46c6fcba13d170dc8af7e61996c6c9394ac/aiohttp-3.13.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:02222e7e233295f40e011c1b00e3b0bd451f22cf853a0304c3595633ee47da4b", size = 750547, upload-time = "2026-03-31T21:56:30.024Z" },
+    { url = "https://files.pythonhosted.org/packages/05/98/afd308e35b9d3d8c9ec54c0918f1d722c86dc17ddfec272fcdbcce5a3124/aiohttp-3.13.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bace460460ed20614fa6bc8cb09966c0b8517b8c58ad8046828c6078d25333b5", size = 503535, upload-time = "2026-03-31T21:56:31.935Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/4d/926c183e06b09d5270a309eb50fbde7b09782bfd305dec1e800f329834fb/aiohttp-3.13.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8f546a4dc1e6a5edbb9fd1fd6ad18134550e096a5a43f4ad74acfbd834fc6670", size = 497830, upload-time = "2026-03-31T21:56:33.654Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d6/f47d1c690f115a5c2a5e8938cce4a232a5be9aac5c5fb2647efcbbbda333/aiohttp-3.13.5-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c86969d012e51b8e415a8c6ce96f7857d6a87d6207303ab02d5d11ef0cad2274", size = 1682474, upload-time = "2026-03-31T21:56:35.513Z" },
+    { url = "https://files.pythonhosted.org/packages/01/44/056fd37b1bb52eac760303e5196acc74d9d546631b035704ae5927f7b4ac/aiohttp-3.13.5-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:b6f6cd1560c5fa427e3b6074bb24d2c64e225afbb7165008903bd42e4e33e28a", size = 1655259, upload-time = "2026-03-31T21:56:37.843Z" },
+    { url = "https://files.pythonhosted.org/packages/91/9f/78eb1a20c1c28ae02f6a3c0f4d7b0dcc66abce5290cadd53d78ce3084175/aiohttp-3.13.5-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:636bc362f0c5bbc7372bc3ae49737f9e3030dbce469f0f422c8f38079780363d", size = 1736204, upload-time = "2026-03-31T21:56:39.822Z" },
+    { url = "https://files.pythonhosted.org/packages/de/6c/d20d7de23f0b52b8c1d9e2033b2db1ac4dacbb470bb74c56de0f5f86bb4f/aiohttp-3.13.5-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6a7cbeb06d1070f1d14895eeeed4dac5913b22d7b456f2eb969f11f4b3993796", size = 1826198, upload-time = "2026-03-31T21:56:41.378Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/86/a6f3ff1fd795f49545a7c74b2c92f62729135d73e7e4055bf74da5a26c82/aiohttp-3.13.5-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bca9ef7517fd7874a1a08970ae88f497bf5c984610caa0bf40bd7e8450852b95", size = 1681329, upload-time = "2026-03-31T21:56:43.374Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/68/84cd3dab6b7b4f3e6fe9459a961acb142aaab846417f6e8905110d7027e5/aiohttp-3.13.5-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:019a67772e034a0e6b9b17c13d0a8fe56ad9fb150fc724b7f3ffd3724288d9e5", size = 1560023, upload-time = "2026-03-31T21:56:45.031Z" },
+    { url = "https://files.pythonhosted.org/packages/41/2c/db61b64b0249e30f954a65ab4cb4970ced57544b1de2e3c98ee5dc24165f/aiohttp-3.13.5-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:f34ecee82858e41dd217734f0c41a532bd066bcaab636ad830f03a30b2a96f2a", size = 1652372, upload-time = "2026-03-31T21:56:47.075Z" },
+    { url = "https://files.pythonhosted.org/packages/25/6f/e96988a6c982d047810c772e28c43c64c300c943b0ed5c1c0c4ce1e1027c/aiohttp-3.13.5-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:4eac02d9af4813ee289cd63a361576da36dba57f5a1ab36377bc2600db0cbb73", size = 1662031, upload-time = "2026-03-31T21:56:48.835Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/26/a56feace81f3d347b4052403a9d03754a0ab23f7940780dada0849a38c92/aiohttp-3.13.5-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:4beac52e9fe46d6abf98b0176a88154b742e878fdf209d2248e99fcdf73cd297", size = 1708118, upload-time = "2026-03-31T21:56:50.833Z" },
+    { url = "https://files.pythonhosted.org/packages/78/6e/b6173a8ff03d01d5e1a694bc06764b5dad1df2d4ed8f0ceec12bb3277936/aiohttp-3.13.5-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:c180f480207a9b2475f2b8d8bd7204e47aec952d084b2a2be58a782ffcf96074", size = 1548667, upload-time = "2026-03-31T21:56:52.81Z" },
+    { url = "https://files.pythonhosted.org/packages/16/13/13296ffe2c132d888b3fe2c195c8b9c0c24c89c3fa5cc2c44464dc23b22e/aiohttp-3.13.5-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:2837fb92951564d6339cedae4a7231692aa9f73cbc4fb2e04263b96844e03b4e", size = 1724490, upload-time = "2026-03-31T21:56:54.541Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1f1c287f4a79782ef36e5a6e62954c85343bc30470d862d30bd5f26c9fa2/aiohttp-3.13.5-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:d9010032a0b9710f58012a1e9c222528763d860ba2ee1422c03473eab47703e7", size = 1667109, upload-time = "2026-03-31T21:56:56.21Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/42/8461a2aaf60a8f4ea4549a4056be36b904b0eb03d97ca9a8a2604681a500/aiohttp-3.13.5-cp310-cp310-win32.whl", hash = "sha256:7c4b6668b2b2b9027f209ddf647f2a4407784b5d88b8be4efcc72036f365baf9", size = 439478, upload-time = "2026-03-31T21:56:58.292Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/71/06956304cb5ee439dfe8d86e1b2e70088bd88ed1ced1f42fb29e5d855f0e/aiohttp-3.13.5-cp310-cp310-win_amd64.whl", hash = "sha256:cd3db5927bf9167d5a6157ddb2f036f6b6b0ad001ac82355d43e97a4bde76d76", size = 462047, upload-time = "2026-03-31T21:57:00.257Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/a20c4ac64aeaef1679e25c9983573618ff765d7aa829fa2b84ae7573169e/aiohttp-3.13.5-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7ab7229b6f9b5c1ba4910d6c41a9eb11f543eadb3f384df1b4c293f4e73d44d6", size = 757513, upload-time = "2026-03-31T21:57:02.146Z" },
+    { url = "https://files.pythonhosted.org/packages/75/0a/39fa6c6b179b53fcb3e4b3d2b6d6cad0180854eda17060c7218540102bef/aiohttp-3.13.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8f14c50708bb156b3a3ca7230b3d820199d56a48e3af76fa21c2d6087190fe3d", size = 506748, upload-time = "2026-03-31T21:57:04.275Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ec/e38ce072e724fd7add6243613f8d1810da084f54175353d25ccf9f9c7e5a/aiohttp-3.13.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e7d2f8616f0ff60bd332022279011776c3ac0faa0f1b463f7bb12326fbc97a1c", size = 501673, upload-time = "2026-03-31T21:57:06.208Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/ba/3bc7525d7e2beaa11b309a70d48b0d3cfc3c2089ec6a7d0820d59c657053/aiohttp-3.13.5-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2567b72e1ffc3ab25510db43f355b29eeada56c0a622e58dcdb19530eb0a3cb", size = 1763757, upload-time = "2026-03-31T21:57:07.882Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/ab/e87744cf18f1bd78263aba24924d4953b41086bd3a31d22452378e9028a0/aiohttp-3.13.5-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:fb0540c854ac9c0c5ad495908fdfd3e332d553ec731698c0e29b1877ba0d2ec6", size = 1720152, upload-time = "2026-03-31T21:57:09.946Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/f3/ed17a6f2d742af17b50bae2d152315ed1b164b07a5fd5cc1754d99e4dfa5/aiohttp-3.13.5-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c9883051c6972f58bfc4ebb2116345ee2aa151178e99c3f2b2bbe2af712abd13", size = 1818010, upload-time = "2026-03-31T21:57:12.157Z" },
+    { url = "https://files.pythonhosted.org/packages/53/06/ecbc63dc937192e2a5cb46df4d3edb21deb8225535818802f210a6ea5816/aiohttp-3.13.5-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2294172ce08a82fb7c7273485895de1fa1186cc8294cfeb6aef4af42ad261174", size = 1907251, upload-time = "2026-03-31T21:57:14.023Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/a5/0521aa32c1ddf3aa1e71dcc466be0b7db2771907a13f18cddaa45967d97b/aiohttp-3.13.5-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3a807cabd5115fb55af198b98178997a5e0e57dead43eb74a93d9c07d6d4a7dc", size = 1759969, upload-time = "2026-03-31T21:57:16.146Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/78/a38f8c9105199dd3b9706745865a8a59d0041b6be0ca0cc4b2ccf1bab374/aiohttp-3.13.5-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aa6d0d932e0f39c02b80744273cd5c388a2d9bc07760a03164f229c8e02662f6", size = 1616871, upload-time = "2026-03-31T21:57:17.856Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/41/27392a61ead8ab38072105c71aa44ff891e71653fe53d576a7067da2b4e8/aiohttp-3.13.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:60869c7ac4aaabe7110f26499f3e6e5696eae98144735b12a9c3d9eae2b51a49", size = 1739844, upload-time = "2026-03-31T21:57:19.679Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/55/5564e7ae26d94f3214250009a0b1c65a0c6af4bf88924ccb6fdab901de28/aiohttp-3.13.5-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:26d2f8546f1dfa75efa50c3488215a903c0168d253b75fba4210f57ab77a0fb8", size = 1731969, upload-time = "2026-03-31T21:57:22.006Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/c5/705a3929149865fc941bcbdd1047b238e4a72bcb215a9b16b9d7a2e8d992/aiohttp-3.13.5-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:f1162a1492032c82f14271e831c8f4b49f2b6078f4f5fc74de2c912fa225d51d", size = 1795193, upload-time = "2026-03-31T21:57:24.256Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/19/edabed62f718d02cff7231ca0db4ef1c72504235bc467f7b67adb1679f48/aiohttp-3.13.5-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:8b14eb3262fad0dc2f89c1a43b13727e709504972186ff6a99a3ecaa77102b6c", size = 1606477, upload-time = "2026-03-31T21:57:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/de/fc/76f80ef008675637d88d0b21584596dc27410a990b0918cb1e5776545b5b/aiohttp-3.13.5-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:ca9ac61ac6db4eb6c2a0cd1d0f7e1357647b638ccc92f7e9d8d133e71ed3c6ac", size = 1813198, upload-time = "2026-03-31T21:57:28.316Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/67/5b3ac26b80adb20ea541c487f73730dc8fa107d632c998f25bbbab98fcda/aiohttp-3.13.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:7996023b2ed59489ae4762256c8516df9820f751cf2c5da8ed2fb20ee50abab3", size = 1752321, upload-time = "2026-03-31T21:57:30.549Z" },
+    { url = "https://files.pythonhosted.org/packages/88/06/e4a2e49255ea23fa4feeb5ab092d90240d927c15e47b5b5c48dff5a9ce29/aiohttp-3.13.5-cp311-cp311-win32.whl", hash = "sha256:77dfa48c9f8013271011e51c00f8ada19851f013cde2c48fca1ba5e0caf5bb06", size = 439069, upload-time = "2026-03-31T21:57:32.388Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/43/8c7163a596dab4f8be12c190cf467a1e07e4734cf90eebb39f7f5d53fc6a/aiohttp-3.13.5-cp311-cp311-win_amd64.whl", hash = "sha256:d3a4834f221061624b8887090637db9ad4f61752001eae37d56c52fddade2dc8", size = 462859, upload-time = "2026-03-31T21:57:34.455Z" },
+    { url = "https://files.pythonhosted.org/packages/be/6f/353954c29e7dcce7cf00280a02c75f30e133c00793c7a2ed3776d7b2f426/aiohttp-3.13.5-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:023ecba036ddd840b0b19bf195bfae970083fd7024ce1ac22e9bba90464620e9", size = 748876, upload-time = "2026-03-31T21:57:36.319Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/1b/428a7c64687b3b2e9cd293186695affc0e1e54a445d0361743b231f11066/aiohttp-3.13.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:15c933ad7920b7d9a20de151efcd05a6e38302cbf0e10c9b2acb9a42210a2416", size = 499557, upload-time = "2026-03-31T21:57:38.236Z" },
+    { url = "https://files.pythonhosted.org/packages/29/47/7be41556bfbb6917069d6a6634bb7dd5e163ba445b783a90d40f5ac7e3a7/aiohttp-3.13.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab2899f9fa2f9f741896ebb6fa07c4c883bfa5c7f2ddd8cf2aafa86fa981b2d2", size = 500258, upload-time = "2026-03-31T21:57:39.923Z" },
+    { url = "https://files.pythonhosted.org/packages/67/84/c9ecc5828cb0b3695856c07c0a6817a99d51e2473400f705275a2b3d9239/aiohttp-3.13.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a60eaa2d440cd4707696b52e40ed3e2b0f73f65be07fd0ef23b6b539c9c0b0b4", size = 1749199, upload-time = "2026-03-31T21:57:41.938Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/d3/3c6d610e66b495657622edb6ae7c7fd31b2e9086b4ec50b47897ad6042a9/aiohttp-3.13.5-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:55b3bdd3292283295774ab585160c4004f4f2f203946997f49aac032c84649e9", size = 1721013, upload-time = "2026-03-31T21:57:43.904Z" },
+    { url = "https://files.pythonhosted.org/packages/49/a0/24409c12217456df0bae7babe3b014e460b0b38a8e60753d6cb339f6556d/aiohttp-3.13.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2b2355dc094e5f7d45a7bb262fe7207aa0460b37a0d87027dcf21b5d890e7d5", size = 1781501, upload-time = "2026-03-31T21:57:46.285Z" },
+    { url = "https://files.pythonhosted.org/packages/98/9d/b65ec649adc5bccc008b0957a9a9c691070aeac4e41cea18559fef49958b/aiohttp-3.13.5-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b38765950832f7d728297689ad78f5f2cf79ff82487131c4d26fe6ceecdc5f8e", size = 1878981, upload-time = "2026-03-31T21:57:48.734Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d8/8d44036d7eb7b6a8ec4c5494ea0c8c8b94fbc0ed3991c1a7adf230df03bf/aiohttp-3.13.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b18f31b80d5a33661e08c89e202edabf1986e9b49c42b4504371daeaa11b47c1", size = 1767934, upload-time = "2026-03-31T21:57:51.171Z" },
+    { url = "https://files.pythonhosted.org/packages/31/04/d3f8211f273356f158e3464e9e45484d3fb8c4ce5eb2f6fe9405c3273983/aiohttp-3.13.5-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:33add2463dde55c4f2d9635c6ab33ce154e5ecf322bd26d09af95c5f81cfa286", size = 1566671, upload-time = "2026-03-31T21:57:53.326Z" },
+    { url = "https://files.pythonhosted.org/packages/41/db/073e4ebe00b78e2dfcacff734291651729a62953b48933d765dc513bf798/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:327cc432fdf1356fb4fbc6fe833ad4e9f6aacb71a8acaa5f1855e4b25910e4a9", size = 1705219, upload-time = "2026-03-31T21:57:55.385Z" },
+    { url = "https://files.pythonhosted.org/packages/48/45/7dfba71a2f9fd97b15c95c06819de7eb38113d2cdb6319669195a7d64270/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:7c35b0bf0b48a70b4cb4fc5d7bed9b932532728e124874355de1a0af8ec4bc88", size = 1743049, upload-time = "2026-03-31T21:57:57.341Z" },
+    { url = "https://files.pythonhosted.org/packages/18/71/901db0061e0f717d226386a7f471bb59b19566f2cae5f0d93874b017271f/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:df23d57718f24badef8656c49743e11a89fd6f5358fa8a7b96e728fda2abf7d3", size = 1749557, upload-time = "2026-03-31T21:57:59.626Z" },
+    { url = "https://files.pythonhosted.org/packages/08/d5/41eebd16066e59cd43728fe74bce953d7402f2b4ddfdfef2c0e9f17ca274/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:02e048037a6501a5ec1f6fc9736135aec6eb8a004ce48838cb951c515f32c80b", size = 1558931, upload-time = "2026-03-31T21:58:01.972Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e6/4a799798bf05740e66c3a1161079bda7a3dd8e22ca392481d7a7f9af82a6/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:31cebae8b26f8a615d2b546fee45d5ffb76852ae6450e2a03f42c9102260d6fe", size = 1774125, upload-time = "2026-03-31T21:58:04.007Z" },
+    { url = "https://files.pythonhosted.org/packages/84/63/7749337c90f92bc2cb18f9560d67aa6258c7060d1397d21529b8004fcf6f/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:888e78eb5ca55a615d285c3c09a7a91b42e9dd6fc699b166ebd5dee87c9ccf14", size = 1732427, upload-time = "2026-03-31T21:58:06.337Z" },
+    { url = "https://files.pythonhosted.org/packages/98/de/cf2f44ff98d307e72fb97d5f5bbae3bfcb442f0ea9790c0bf5c5c2331404/aiohttp-3.13.5-cp312-cp312-win32.whl", hash = "sha256:8bd3ec6376e68a41f9f95f5ed170e2fcf22d4eb27a1f8cb361d0508f6e0557f3", size = 433534, upload-time = "2026-03-31T21:58:08.712Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ca/eadf6f9c8fa5e31d40993e3db153fb5ed0b11008ad5d9de98a95045bed84/aiohttp-3.13.5-cp312-cp312-win_amd64.whl", hash = "sha256:110e448e02c729bcebb18c60b9214a87ba33bac4a9fa5e9a5f139938b56c6cb1", size = 460446, upload-time = "2026-03-31T21:58:10.945Z" },
+]
+
+[[package]]
+name = "aiosignal"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "frozenlist" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl", hash = "sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e", size = 7490, upload-time = "2025-07-03T22:54:42.156Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "idna" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "asttokens"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/a5/8e3f9b6771b0b408517c82d97aed8f2036509bc247d46114925e32fe33f0/asttokens-3.0.1.tar.gz", hash = "sha256:71a4ee5de0bde6a31d64f6b13f2293ac190344478f081c3d1bccfcf5eacb0cb7", size = 62308, upload-time = "2025-11-15T16:43:48.578Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl", hash = "sha256:15a3ebc0f43c2d0a50eeafea25e19046c68398e487b9f1f5b517f7c0f40f976a", size = 27047, upload-time = "2025-11-15T16:43:16.109Z" },
+]
+
+[[package]]
+name = "async-timeout"
+version = "5.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/ae/136395dfbfe00dfc94da3f3e136d0b13f394cba8f4841120e34226265780/async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3", size = 9274, upload-time = "2024-11-06T16:41:39.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/ba/e2081de779ca30d473f21f5b30e0e737c438205440784c7dfc81efc2b029/async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c", size = 6233, upload-time = "2024-11-06T16:41:37.9Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
+name = "cachetools"
+version = "7.1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8f/c1/67cfb86aa21144796ff51068326d467fbef8ee42f8d08a3a8a926106cf0c/cachetools-7.1.3.tar.gz", hash = "sha256:135cfe944bc3c1e805505f65dae0bef375a2f96261171ab66c79ef77d0bda39d", size = 45780, upload-time = "2026-05-18T18:21:03.819Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/52/8ff5c1a3b2e821ced9b2998fba3ee29aa4525c0bf51e5ee55dd6f61a4ed5/cachetools-7.1.3-py3-none-any.whl", hash = "sha256:9876787e2346e20584d5cca236cb5d49d04e7193de91646f230725b2e1e8b804", size = 16763, upload-time = "2026-05-18T18:21:02.386Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.4.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/d7/516d984057745a6cd96575eea814fe1edd6646ee6efd552fb7b0921dec83/cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44", size = 184283, upload-time = "2025-09-08T23:22:08.01Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/84/ad6a0b408daa859246f57c03efd28e5dd1b33c21737c2db84cae8c237aa5/cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49", size = 180504, upload-time = "2025-09-08T23:22:10.637Z" },
+    { url = "https://files.pythonhosted.org/packages/50/bd/b1a6362b80628111e6653c961f987faa55262b4002fcec42308cad1db680/cffi-2.0.0-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:53f77cbe57044e88bbd5ed26ac1d0514d2acf0591dd6bb02a3ae37f76811b80c", size = 208811, upload-time = "2025-09-08T23:22:12.267Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/27/6933a8b2562d7bd1fb595074cf99cc81fc3789f6a6c05cdabb46284a3188/cffi-2.0.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3e837e369566884707ddaf85fc1744b47575005c0a229de3327f8f9a20f4efeb", size = 216402, upload-time = "2025-09-08T23:22:13.455Z" },
+    { url = "https://files.pythonhosted.org/packages/05/eb/b86f2a2645b62adcfff53b0dd97e8dfafb5c8aa864bd0d9a2c2049a0d551/cffi-2.0.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5eda85d6d1879e692d546a078b44251cdd08dd1cfb98dfb77b670c97cee49ea0", size = 203217, upload-time = "2025-09-08T23:22:14.596Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/e0/6cbe77a53acf5acc7c08cc186c9928864bd7c005f9efd0d126884858a5fe/cffi-2.0.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9332088d75dc3241c702d852d4671613136d90fa6881da7d770a483fd05248b4", size = 203079, upload-time = "2025-09-08T23:22:15.769Z" },
+    { url = "https://files.pythonhosted.org/packages/98/29/9b366e70e243eb3d14a5cb488dfd3a0b6b2f1fb001a203f653b93ccfac88/cffi-2.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc7de24befaeae77ba923797c7c87834c73648a05a4bde34b3b7e5588973a453", size = 216475, upload-time = "2025-09-08T23:22:17.427Z" },
+    { url = "https://files.pythonhosted.org/packages/21/7a/13b24e70d2f90a322f2900c5d8e1f14fa7e2a6b3332b7309ba7b2ba51a5a/cffi-2.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cf364028c016c03078a23b503f02058f1814320a56ad535686f90565636a9495", size = 218829, upload-time = "2025-09-08T23:22:19.069Z" },
+    { url = "https://files.pythonhosted.org/packages/60/99/c9dc110974c59cc981b1f5b66e1d8af8af764e00f0293266824d9c4254bc/cffi-2.0.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e11e82b744887154b182fd3e7e8512418446501191994dbf9c9fc1f32cc8efd5", size = 211211, upload-time = "2025-09-08T23:22:20.588Z" },
+    { url = "https://files.pythonhosted.org/packages/49/72/ff2d12dbf21aca1b32a40ed792ee6b40f6dc3a9cf1644bd7ef6e95e0ac5e/cffi-2.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8ea985900c5c95ce9db1745f7933eeef5d314f0565b27625d9a10ec9881e1bfb", size = 218036, upload-time = "2025-09-08T23:22:22.143Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/cc/027d7fb82e58c48ea717149b03bcadcbdc293553edb283af792bd4bcbb3f/cffi-2.0.0-cp310-cp310-win32.whl", hash = "sha256:1f72fb8906754ac8a2cc3f9f5aaa298070652a0ffae577e0ea9bd480dc3c931a", size = 172184, upload-time = "2025-09-08T23:22:23.328Z" },
+    { url = "https://files.pythonhosted.org/packages/33/fa/072dd15ae27fbb4e06b437eb6e944e75b068deb09e2a2826039e49ee2045/cffi-2.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:b18a3ed7d5b3bd8d9ef7a8cb226502c6bf8308df1525e1cc676c3680e7176739", size = 182790, upload-time = "2025-09-08T23:22:24.752Z" },
+    { url = "https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe", size = 184344, upload-time = "2025-09-08T23:22:26.456Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c", size = 180560, upload-time = "2025-09-08T23:22:28.197Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", size = 209613, upload-time = "2025-09-08T23:22:29.475Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93", size = 216476, upload-time = "2025-09-08T23:22:31.063Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/7f/55fecd70f7ece178db2f26128ec41430d8720f2d12ca97bf8f0a628207d5/cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5", size = 203374, upload-time = "2025-09-08T23:22:32.507Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ef/a7b77c8bdc0f77adc3b46888f1ad54be8f3b7821697a7b89126e829e676a/cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664", size = 202597, upload-time = "2025-09-08T23:22:34.132Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26", size = 215574, upload-time = "2025-09-08T23:22:35.443Z" },
+    { url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9", size = 218971, upload-time = "2025-09-08T23:22:36.805Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/49/fa72cebe2fd8a55fbe14956f9970fe8eb1ac59e5df042f603ef7c8ba0adc/cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414", size = 211972, upload-time = "2025-09-08T23:22:38.436Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743", size = 217078, upload-time = "2025-09-08T23:22:39.776Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/c0/015b25184413d7ab0a410775fdb4a50fca20f5589b5dab1dbbfa3baad8ce/cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5", size = 172076, upload-time = "2025-09-08T23:22:40.95Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5", size = 182820, upload-time = "2025-09-08T23:22:42.463Z" },
+    { url = "https://files.pythonhosted.org/packages/95/5c/1b493356429f9aecfd56bc171285a4c4ac8697f76e9bbbbb105e537853a1/cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d", size = 177635, upload-time = "2025-09-08T23:22:43.623Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/08/0f303cb0b529e456bb116f2d50565a482694fbb94340bf56d44677e7ed03/charset_normalizer-3.4.7-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cdd68a1fb318e290a2077696b7eb7a21a49163c455979c639bf5a5dcdc46617d", size = 315182, upload-time = "2026-04-02T09:25:40.673Z" },
+    { url = "https://files.pythonhosted.org/packages/24/47/b192933e94b546f1b1fe4df9cc1f84fcdbf2359f8d1081d46dd029b50207/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e17b8d5d6a8c47c85e68ca8379def1303fd360c3e22093a807cd34a71cd082b8", size = 209329, upload-time = "2026-04-02T09:25:42.354Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b4/01fa81c5ca6141024d89a8fc15968002b71da7f825dd14113207113fabbd/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:511ef87c8aec0783e08ac18565a16d435372bc1ac25a91e6ac7f5ef2b0bff790", size = 231230, upload-time = "2026-04-02T09:25:44.281Z" },
+    { url = "https://files.pythonhosted.org/packages/20/f7/7b991776844dfa058017e600e6e55ff01984a063290ca5622c0b63162f68/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:007d05ec7321d12a40227aae9e2bc6dca73f3cb21058999a1df9e193555a9dcc", size = 225890, upload-time = "2026-04-02T09:25:45.475Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e7/bed0024a0f4ab0c8a9c64d4445f39b30c99bd1acd228291959e3de664247/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cf29836da5119f3c8a8a70667b0ef5fdca3bb12f80fd06487cfa575b3909b393", size = 216930, upload-time = "2026-04-02T09:25:46.58Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ab/b18f0ab31cdd7b3ddb8bb76c4a414aeb8160c9810fdf1bc62f269a539d87/charset_normalizer-3.4.7-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:12d8baf840cc7889b37c7c770f478adea7adce3dcb3944d02ec87508e2dcf153", size = 202109, upload-time = "2026-04-02T09:25:48.031Z" },
+    { url = "https://files.pythonhosted.org/packages/82/e5/7e9440768a06dfb3075936490cb82dbf0ee20a133bf0dd8551fa096914ec/charset_normalizer-3.4.7-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d560742f3c0d62afaccf9f41fe485ed69bd7661a241f86a3ef0f0fb8b1a397af", size = 214684, upload-time = "2026-04-02T09:25:49.245Z" },
+    { url = "https://files.pythonhosted.org/packages/71/94/8c61d8da9f062fdf457c80acfa25060ec22bf1d34bbeaca4350f13bcfd07/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b14b2d9dac08e28bb8046a1a0434b1750eb221c8f5b87a68f4fa11a6f97b5e34", size = 212785, upload-time = "2026-04-02T09:25:50.671Z" },
+    { url = "https://files.pythonhosted.org/packages/66/cd/6e9889c648e72c0ab2e5967528bb83508f354d706637bc7097190c874e13/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:bc17a677b21b3502a21f66a8cc64f5bfad4df8a0b8434d661666f8ce90ac3af1", size = 203055, upload-time = "2026-04-02T09:25:51.802Z" },
+    { url = "https://files.pythonhosted.org/packages/92/2e/7a951d6a08aefb7eb8e1b54cdfb580b1365afdd9dd484dc4bee9e5d8f258/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:750e02e074872a3fad7f233b47734166440af3cdea0add3e95163110816d6752", size = 232502, upload-time = "2026-04-02T09:25:53.388Z" },
+    { url = "https://files.pythonhosted.org/packages/58/d5/abcf2d83bf8e0a1286df55cd0dc1d49af0da4282aa77e986df343e7de124/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:4e5163c14bffd570ef2affbfdd77bba66383890797df43dc8b4cc7d6f500bf53", size = 214295, upload-time = "2026-04-02T09:25:54.765Z" },
+    { url = "https://files.pythonhosted.org/packages/47/3a/7d4cd7ed54be99973a0dc176032cba5cb1f258082c31fa6df35cff46acfc/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:6ed74185b2db44f41ef35fd1617c5888e59792da9bbc9190d6c7300617182616", size = 227145, upload-time = "2026-04-02T09:25:55.904Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/98/3a45bf8247889cf28262ebd3d0872edff11565b2a1e3064ccb132db3fbb0/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:94e1885b270625a9a828c9793b4d52a64445299baa1fea5a173bf1d3dd9a1a5a", size = 218884, upload-time = "2026-04-02T09:25:57.074Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/80/2e8b7f8915ed5c9ef13aa828d82738e33888c485b65ebf744d615040c7ea/charset_normalizer-3.4.7-cp310-cp310-win32.whl", hash = "sha256:6785f414ae0f3c733c437e0f3929197934f526d19dfaa75e18fdb4f94c6fb374", size = 148343, upload-time = "2026-04-02T09:25:58.199Z" },
+    { url = "https://files.pythonhosted.org/packages/35/1b/3b8c8c77184af465ee9ad88b5aea46ea6b2e1f7b9dc9502891e37af21e30/charset_normalizer-3.4.7-cp310-cp310-win_amd64.whl", hash = "sha256:6696b7688f54f5af4462118f0bfa7c1621eeb87154f77fa04b9295ce7a8f2943", size = 159174, upload-time = "2026-04-02T09:25:59.322Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/feb40dca40dbb21e0a908801782d9288c64fc8d8e562c2098e9994c8c21b/charset_normalizer-3.4.7-cp310-cp310-win_arm64.whl", hash = "sha256:66671f93accb62ed07da56613636f3641f1a12c13046ce91ffc923721f23c008", size = 147805, upload-time = "2026-04-02T09:26:00.756Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7641bb8895e77f921102f72833904dcd9901df5d6d72a2ab8f31d04b7e51e4e7", size = 309705, upload-time = "2026-04-02T09:26:02.191Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/53/58c29116c340e5456724ecd2fff4196d236b98f3da97b404bc5e51ac3493/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:202389074300232baeb53ae2569a60901f7efadd4245cf3a3bf0617d60b439d7", size = 206419, upload-time = "2026-04-02T09:26:03.583Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/e8146dc6591a37a00e5144c63f29fb7c97a734ea8a111190783c0e60ab63/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:30b8d1d8c52a48c2c5690e152c169b673487a2a58de1ec7393196753063fcd5e", size = 227901, upload-time = "2026-04-02T09:26:04.738Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/73/77486c4cd58f1267bf17db420e930c9afa1b3be3fe8c8b8ebbebc9624359/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:532bc9bf33a68613fd7d65e4b1c71a6a38d7d42604ecf239c77392e9b4e8998c", size = 222742, upload-time = "2026-04-02T09:26:06.36Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/fa/f74eb381a7d94ded44739e9d94de18dc5edc9c17fb8c11f0a6890696c0a9/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2fe249cb4651fd12605b7288b24751d8bfd46d35f12a20b1ba33dea122e690df", size = 214061, upload-time = "2026-04-02T09:26:08.347Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/92/42bd3cefcf7687253fb86694b45f37b733c97f59af3724f356fa92b8c344/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:65bcd23054beab4d166035cabbc868a09c1a49d1efe458fe8e4361215df40265", size = 199239, upload-time = "2026-04-02T09:26:09.823Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/3d/069e7184e2aa3b3cddc700e3dd267413dc259854adc3380421c805c6a17d/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:08e721811161356f97b4059a9ba7bafb23ea5ee2255402c42881c214e173c6b4", size = 210173, upload-time = "2026-04-02T09:26:10.953Z" },
+    { url = "https://files.pythonhosted.org/packages/62/51/9d56feb5f2e7074c46f93e0ebdbe61f0848ee246e2f0d89f8e20b89ebb8f/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e060d01aec0a910bdccb8be71faf34e7799ce36950f8294c8bf612cba65a2c9e", size = 209841, upload-time = "2026-04-02T09:26:12.142Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/59/893d8f99cc4c837dda1fe2f1139079703deb9f321aabcb032355de13b6c7/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:38c0109396c4cfc574d502df99742a45c72c08eff0a36158b6f04000043dbf38", size = 200304, upload-time = "2026-04-02T09:26:13.711Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/1d/ee6f3be3464247578d1ed5c46de545ccc3d3ff933695395c402c21fa6b77/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:1c2a768fdd44ee4a9339a9b0b130049139b8ce3c01d2ce09f67f5a68048d477c", size = 229455, upload-time = "2026-04-02T09:26:14.941Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bb/8fb0a946296ea96a488928bdce8ef99023998c48e4713af533e9bb98ef07/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:1a87ca9d5df6fe460483d9a5bbf2b18f620cbed41b432e2bddb686228282d10b", size = 210036, upload-time = "2026-04-02T09:26:16.478Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/bc/015b2387f913749f82afd4fcba07846d05b6d784dd16123cb66860e0237d/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:d635aab80466bc95771bb78d5370e74d36d1fe31467b6b29b8b57b2a3cd7d22c", size = 224739, upload-time = "2026-04-02T09:26:17.751Z" },
+    { url = "https://files.pythonhosted.org/packages/17/ab/63133691f56baae417493cba6b7c641571a2130eb7bceba6773367ab9ec5/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ae196f021b5e7c78e918242d217db021ed2a6ace2bc6ae94c0fc596221c7f58d", size = 216277, upload-time = "2026-04-02T09:26:18.981Z" },
+    { url = "https://files.pythonhosted.org/packages/06/6d/3be70e827977f20db77c12a97e6a9f973631a45b8d186c084527e53e77a4/charset_normalizer-3.4.7-cp311-cp311-win32.whl", hash = "sha256:adb2597b428735679446b46c8badf467b4ca5f5056aae4d51a19f9570301b1ad", size = 147819, upload-time = "2026-04-02T09:26:20.295Z" },
+    { url = "https://files.pythonhosted.org/packages/20/d9/5f67790f06b735d7c7637171bbfd89882ad67201891b7275e51116ed8207/charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl", hash = "sha256:8e385e4267ab76874ae30db04c627faaaf0b509e1ccc11a95b3fc3e83f855c00", size = 159281, upload-time = "2026-04-02T09:26:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/83/6413f36c5a34afead88ce6f66684d943d91f233d76dd083798f9602b75ae/charset_normalizer-3.4.7-cp311-cp311-win_arm64.whl", hash = "sha256:d4a48e5b3c2a489fae013b7589308a40146ee081f6f509e047e0e096084ceca1", size = 147843, upload-time = "2026-04-02T09:26:22.901Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "48.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920", size = 832984, upload-time = "2026-05-04T22:59:38.133Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/3d/01f6dd9190170a5a241e0e98c2d04be3664a9e6f5b9b872cde63aff1c3dd/cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6", size = 8001587, upload-time = "2026-05-04T22:57:36.803Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c", size = 4690433, upload-time = "2026-05-04T22:57:40.373Z" },
+    { url = "https://files.pythonhosted.org/packages/90/04/673510ed51ddff56575f306cf1617d80411ee76831ccd3097599140efdfe/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3", size = 4710620, upload-time = "2026-05-04T22:57:42.935Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5", size = 4696283, upload-time = "2026-05-04T22:57:45.294Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/29/174b9dfb60b12d59ecfc6cfa04bc88c21b42a54f01b8aae09bb6e51e4c7f/cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c", size = 5296573, upload-time = "2026-05-04T22:57:47.933Z" },
+    { url = "https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f", size = 4743677, upload-time = "2026-05-04T22:57:50.067Z" },
+    { url = "https://files.pythonhosted.org/packages/30/be/eef653013d5c63b6a490529e0316f9ac14a37602965d4903efed1399f32b/cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25", size = 4330808, upload-time = "2026-05-04T22:57:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602", size = 4695941, upload-time = "2026-05-04T22:57:54.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/dc/7303087450c2ec9e7fbb750e17c2abfbc658f23cbd0e54009509b7cc4091/cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c", size = 5252579, upload-time = "2026-05-04T22:57:57.207Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5", size = 4743326, upload-time = "2026-05-04T22:57:59.535Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d8/5b833bad13016f562ab9d063d68199a4bd121d18458e439515601d3357ec/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321", size = 4826672, upload-time = "2026-05-04T22:58:01.996Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e1/7074eb8bf3c135558c73fc2bcf0f5633f912e6fb87e868a55c454080ef09/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74", size = 4972574, upload-time = "2026-05-04T22:58:03.968Z" },
+    { url = "https://files.pythonhosted.org/packages/04/70/e5a1b41d325f797f39427aa44ef8baf0be500065ab6d8e10369d850d4a4f/cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4", size = 3294868, upload-time = "2026-05-04T22:58:06.467Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ac/8ac51b4a5fc5932eb7ee5c517ba7dc8cd834f0048962b6b352f00f41ebf9/cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7", size = 3817107, upload-time = "2026-05-04T22:58:08.845Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/63/61d4a4e1c6b6bab6ce1e213cd36a24c415d90e76d78c5eb8577c5541d2e8/cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86", size = 7983482, upload-time = "2026-05-04T22:58:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e", size = 4683266, upload-time = "2026-05-04T22:58:46.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f", size = 4696228, upload-time = "2026-05-04T22:58:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/73/f808fbae9514bd91b47875b003f13e284c8c6bdfd904b7944e803937eec1/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7", size = 4689097, upload-time = "2026-05-04T22:58:50.9Z" },
+    { url = "https://files.pythonhosted.org/packages/93/01/d86632d7d28db8ae83221995752eeb6639ffb374c2d22955648cf8d52797/cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832", size = 5283582, upload-time = "2026-05-04T22:58:53.017Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e1/50edc7a50334807cc4791fc4a0ce7468b4a1416d9138eab358bfc9a3d70b/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c", size = 4730479, upload-time = "2026-05-04T22:58:55.611Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/af/99a582b1b1641ff5911ac559beb45097cf79efd4ead4657f578ef1af2d47/cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a", size = 4326481, upload-time = "2026-05-04T22:58:57.607Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ee/89aa26a06ef0a7d7611788ffd571a7c50e368cc6a4d5eef8b4884e866edb/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a", size = 4688713, upload-time = "2026-05-04T22:59:00.077Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ba/bcb1b0bb7a33d4c7c0c4d4c7874b4a62ae4f56113a5f4baefa362dfb1f0f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a", size = 5238165, upload-time = "2026-05-04T22:59:02.317Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/70/ca4003b1ce5ca3dc3186ada51908c8a9b9ff7d5cab83cc0d43ee14ec144f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239", size = 4729947, upload-time = "2026-05-04T22:59:05.255Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/4ec7cf774207905aef1a8d11c3750d5a1db805eb380ee4e16df317870128/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c", size = 4822059, upload-time = "2026-05-04T22:59:07.802Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117, upload-time = "2026-05-04T22:59:12.019Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100, upload-time = "2026-05-04T22:59:14.884Z" },
+    { url = "https://files.pythonhosted.org/packages/be/d2/024b5e06be9d44cb021fb0e1a03d34d63989cf56a0fe62f3dfbab695b9b4/cryptography-48.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:84cf79f0dc8b36ac5da873481716e87aef31fcfa0444f9e1d8b4b2cece142855", size = 3950391, upload-time = "2026-05-04T22:59:17.415Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/17/3861e17c56fa0fd37491a14a8673fdb77c57fc5693cafe745ea8b06dba75/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:fdfef35d751d510fcef5252703621574364fec16418c4a1e5e1055248401054b", size = 4637126, upload-time = "2026-05-04T22:59:20.197Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/0a/7e226dbff530f21480727eb764973a7bff2b912f8e15cd4f129e71b56d1d/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:0890f502ddf7d9c6426129c3f49f5c0a39278ed7cd6322c8755ffca6ee675a13", size = 4667270, upload-time = "2026-05-04T22:59:22.647Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/f2/5a72274ca9f1b2a8b44a662ee0bf1b435909deb473d6f97bcd035bcdbc71/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:ecde28a596bead48b0cfd2a1b4416c3d43074c2d785e3a398d7ec1fc4d0f7fbb", size = 4636797, upload-time = "2026-05-04T22:59:24.912Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/e1/48cedb2fe63626e91ded1edad159e2a4fb8b6906c4425eb7749673077ce7/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:4defde8685ae324a9eb9d818717e93b4638ef67070ac9bc15b8ca85f63048355", size = 4666800, upload-time = "2026-05-04T22:59:27.474Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ca/7e8365deec19afb2b2c7be7c1c0aa8f99633b54e90c570999acda93260fc/cryptography-48.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:db63bf618e5dea46c07de12e900fe1cdd2541e6dc9dbae772a70b7d4d4765f6a", size = 3739536, upload-time = "2026-05-04T22:59:29.61Z" },
+]
+
+[[package]]
+name = "decorator"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/8b/32f9823da46cde7df2087faa08cd98d01b908f8dcab982cdba9c84e85355/decorator-5.3.1.tar.gz", hash = "sha256:4cbcdd55a6efadb9dbea26b858f4fb3264567b52d69ca0d25b721b553f60ea82", size = 58084, upload-time = "2026-05-18T06:03:28.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/7f/798705f5296a58ca505d600456748d1be48078eac8a7050d8a98bc9edb89/decorator-5.3.1-py3-none-any.whl", hash = "sha256:f47fe6fdbd2edd623ecfe36875d37aba411624e2670dd395dddae1358689bb3c", size = 10365, upload-time = "2026-05-18T06:03:26.517Z" },
+]
+
+[[package]]
+name = "durationpy"
+version = "0.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/a4/e44218c2b394e31a6dd0d6b095c4e1f32d0be54c2a4b250032d717647bab/durationpy-0.10.tar.gz", hash = "sha256:1fa6893409a6e739c9c72334fc65cca1f355dbdd93405d30f726deb5bde42fba", size = 3335, upload-time = "2025-05-17T13:52:37.26Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/0d/9feae160378a3553fa9a339b0e9c1a048e147a4127210e286ef18b730f03/durationpy-0.10-py3-none-any.whl", hash = "sha256:3b41e1b601234296b4fb368338fdcd3e13e0b4fb5b67345948f4f2bf9868b286", size = 3922, upload-time = "2025-05-17T13:52:36.463Z" },
+]
+
+[[package]]
+name = "dynamo-ft"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "kr8s" },
+    { name = "kubernetes" },
+    { name = "kubernetes-asyncio" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "requests" },
+    { name = "tabulate" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "ipython", version = "8.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "ipython", version = "9.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "aiohttp", specifier = ">=3.9" },
+    { name = "kr8s", specifier = ">=0.20" },
+    { name = "kubernetes", specifier = ">=32.0.1,<33.0.0" },
+    { name = "kubernetes-asyncio", specifier = ">=32.0.0,<33.0.0" },
+    { name = "numpy", specifier = ">=1.26" },
+    { name = "pandas", specifier = ">=2.1" },
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-asyncio", specifier = ">=0.23" },
+    { name = "requests", specifier = ">=2.31" },
+    { name = "tabulate", specifier = ">=0.9" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.9" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "ipython", specifier = ">=8" },
+    { name = "ruff", specifier = ">=0.6" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "executing"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
+]
+
+[[package]]
+name = "frozenlist"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/f5/c831fac6cc817d26fd54c7eaccd04ef7e0288806943f7cc5bbf69f3ac1f0/frozenlist-1.8.0.tar.gz", hash = "sha256:3ede829ed8d842f6cd48fc7081d7a41001a56f1f38603f9d49bf3020d59a31ad", size = 45875, upload-time = "2025-10-06T05:38:17.865Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/4a/557715d5047da48d54e659203b9335be7bfaafda2c3f627b7c47e0b3aaf3/frozenlist-1.8.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b37f6d31b3dcea7deb5e9696e529a6aa4a898adc33db82da12e4c60a7c4d2011", size = 86230, upload-time = "2025-10-06T05:35:23.699Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/fb/c85f9fed3ea8fe8740e5b46a59cc141c23b842eca617da8876cfce5f760e/frozenlist-1.8.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ef2b7b394f208233e471abc541cc6991f907ffd47dc72584acee3147899d6565", size = 49621, upload-time = "2025-10-06T05:35:25.341Z" },
+    { url = "https://files.pythonhosted.org/packages/63/70/26ca3f06aace16f2352796b08704338d74b6d1a24ca38f2771afbb7ed915/frozenlist-1.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a88f062f072d1589b7b46e951698950e7da00442fc1cacbe17e19e025dc327ad", size = 49889, upload-time = "2025-10-06T05:35:26.797Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ed/c7895fd2fde7f3ee70d248175f9b6cdf792fb741ab92dc59cd9ef3bd241b/frozenlist-1.8.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f57fb59d9f385710aa7060e89410aeb5058b99e62f4d16b08b91986b9a2140c2", size = 219464, upload-time = "2025-10-06T05:35:28.254Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/83/4d587dccbfca74cb8b810472392ad62bfa100bf8108c7223eb4c4fa2f7b3/frozenlist-1.8.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:799345ab092bee59f01a915620b5d014698547afd011e691a208637312db9186", size = 221649, upload-time = "2025-10-06T05:35:29.454Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/c6/fd3b9cd046ec5fff9dab66831083bc2077006a874a2d3d9247dea93ddf7e/frozenlist-1.8.0-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c23c3ff005322a6e16f71bf8692fcf4d5a304aaafe1e262c98c6d4adc7be863e", size = 219188, upload-time = "2025-10-06T05:35:30.951Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/80/6693f55eb2e085fc8afb28cf611448fb5b90e98e068fa1d1b8d8e66e5c7d/frozenlist-1.8.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8a76ea0f0b9dfa06f254ee06053d93a600865b3274358ca48a352ce4f0798450", size = 231748, upload-time = "2025-10-06T05:35:32.101Z" },
+    { url = "https://files.pythonhosted.org/packages/97/d6/e9459f7c5183854abd989ba384fe0cc1a0fb795a83c033f0571ec5933ca4/frozenlist-1.8.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c7366fe1418a6133d5aa824ee53d406550110984de7637d65a178010f759c6ef", size = 236351, upload-time = "2025-10-06T05:35:33.834Z" },
+    { url = "https://files.pythonhosted.org/packages/97/92/24e97474b65c0262e9ecd076e826bfd1d3074adcc165a256e42e7b8a7249/frozenlist-1.8.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:13d23a45c4cebade99340c4165bd90eeb4a56c6d8a9d8aa49568cac19a6d0dc4", size = 218767, upload-time = "2025-10-06T05:35:35.205Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/bf/dc394a097508f15abff383c5108cb8ad880d1f64a725ed3b90d5c2fbf0bb/frozenlist-1.8.0-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:e4a3408834f65da56c83528fb52ce7911484f0d1eaf7b761fc66001db1646eff", size = 235887, upload-time = "2025-10-06T05:35:36.354Z" },
+    { url = "https://files.pythonhosted.org/packages/40/90/25b201b9c015dbc999a5baf475a257010471a1fa8c200c843fd4abbee725/frozenlist-1.8.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:42145cd2748ca39f32801dad54aeea10039da6f86e303659db90db1c4b614c8c", size = 228785, upload-time = "2025-10-06T05:35:37.949Z" },
+    { url = "https://files.pythonhosted.org/packages/84/f4/b5bc148df03082f05d2dd30c089e269acdbe251ac9a9cf4e727b2dbb8a3d/frozenlist-1.8.0-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:e2de870d16a7a53901e41b64ffdf26f2fbb8917b3e6ebf398098d72c5b20bd7f", size = 230312, upload-time = "2025-10-06T05:35:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/db/4b/87e95b5d15097c302430e647136b7d7ab2398a702390cf4c8601975709e7/frozenlist-1.8.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:20e63c9493d33ee48536600d1a5c95eefc870cd71e7ab037763d1fbb89cc51e7", size = 217650, upload-time = "2025-10-06T05:35:40.377Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/70/78a0315d1fea97120591a83e0acd644da638c872f142fd72a6cebee825f3/frozenlist-1.8.0-cp310-cp310-win32.whl", hash = "sha256:adbeebaebae3526afc3c96fad434367cafbfd1b25d72369a9e5858453b1bb71a", size = 39659, upload-time = "2025-10-06T05:35:41.863Z" },
+    { url = "https://files.pythonhosted.org/packages/66/aa/3f04523fb189a00e147e60c5b2205126118f216b0aa908035c45336e27e4/frozenlist-1.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:667c3777ca571e5dbeb76f331562ff98b957431df140b54c85fd4d52eea8d8f6", size = 43837, upload-time = "2025-10-06T05:35:43.205Z" },
+    { url = "https://files.pythonhosted.org/packages/39/75/1135feecdd7c336938bd55b4dc3b0dfc46d85b9be12ef2628574b28de776/frozenlist-1.8.0-cp310-cp310-win_arm64.whl", hash = "sha256:80f85f0a7cc86e7a54c46d99c9e1318ff01f4687c172ede30fd52d19d1da1c8e", size = 39989, upload-time = "2025-10-06T05:35:44.596Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/03/077f869d540370db12165c0aa51640a873fb661d8b315d1d4d67b284d7ac/frozenlist-1.8.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:09474e9831bc2b2199fad6da3c14c7b0fbdd377cce9d3d77131be28906cb7d84", size = 86912, upload-time = "2025-10-06T05:35:45.98Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b5/7610b6bd13e4ae77b96ba85abea1c8cb249683217ef09ac9e0ae93f25a91/frozenlist-1.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:17c883ab0ab67200b5f964d2b9ed6b00971917d5d8a92df149dc2c9779208ee9", size = 50046, upload-time = "2025-10-06T05:35:47.009Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/ef/0e8f1fe32f8a53dd26bdd1f9347efe0778b0fddf62789ea683f4cc7d787d/frozenlist-1.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:fa47e444b8ba08fffd1c18e8cdb9a75db1b6a27f17507522834ad13ed5922b93", size = 50119, upload-time = "2025-10-06T05:35:48.38Z" },
+    { url = "https://files.pythonhosted.org/packages/11/b1/71a477adc7c36e5fb628245dfbdea2166feae310757dea848d02bd0689fd/frozenlist-1.8.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2552f44204b744fba866e573be4c1f9048d6a324dfe14475103fd51613eb1d1f", size = 231067, upload-time = "2025-10-06T05:35:49.97Z" },
+    { url = "https://files.pythonhosted.org/packages/45/7e/afe40eca3a2dc19b9904c0f5d7edfe82b5304cb831391edec0ac04af94c2/frozenlist-1.8.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:957e7c38f250991e48a9a73e6423db1bb9dd14e722a10f6b8bb8e16a0f55f695", size = 233160, upload-time = "2025-10-06T05:35:51.729Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/aa/7416eac95603ce428679d273255ffc7c998d4132cfae200103f164b108aa/frozenlist-1.8.0-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:8585e3bb2cdea02fc88ffa245069c36555557ad3609e83be0ec71f54fd4abb52", size = 228544, upload-time = "2025-10-06T05:35:53.246Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/3d/2a2d1f683d55ac7e3875e4263d28410063e738384d3adc294f5ff3d7105e/frozenlist-1.8.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:edee74874ce20a373d62dc28b0b18b93f645633c2943fd90ee9d898550770581", size = 243797, upload-time = "2025-10-06T05:35:54.497Z" },
+    { url = "https://files.pythonhosted.org/packages/78/1e/2d5565b589e580c296d3bb54da08d206e797d941a83a6fdea42af23be79c/frozenlist-1.8.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c9a63152fe95756b85f31186bddf42e4c02c6321207fd6601a1c89ebac4fe567", size = 247923, upload-time = "2025-10-06T05:35:55.861Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/c3/65872fcf1d326a7f101ad4d86285c403c87be7d832b7470b77f6d2ed5ddc/frozenlist-1.8.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b6db2185db9be0a04fecf2f241c70b63b1a242e2805be291855078f2b404dd6b", size = 230886, upload-time = "2025-10-06T05:35:57.399Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/76/ac9ced601d62f6956f03cc794f9e04c81719509f85255abf96e2510f4265/frozenlist-1.8.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:f4be2e3d8bc8aabd566f8d5b8ba7ecc09249d74ba3c9ed52e54dc23a293f0b92", size = 245731, upload-time = "2025-10-06T05:35:58.563Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/49/ecccb5f2598daf0b4a1415497eba4c33c1e8ce07495eb07d2860c731b8d5/frozenlist-1.8.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:c8d1634419f39ea6f5c427ea2f90ca85126b54b50837f31497f3bf38266e853d", size = 241544, upload-time = "2025-10-06T05:35:59.719Z" },
+    { url = "https://files.pythonhosted.org/packages/53/4b/ddf24113323c0bbcc54cb38c8b8916f1da7165e07b8e24a717b4a12cbf10/frozenlist-1.8.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:1a7fa382a4a223773ed64242dbe1c9c326ec09457e6b8428efb4118c685c3dfd", size = 241806, upload-time = "2025-10-06T05:36:00.959Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/fb/9b9a084d73c67175484ba2789a59f8eebebd0827d186a8102005ce41e1ba/frozenlist-1.8.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:11847b53d722050808926e785df837353bd4d75f1d494377e59b23594d834967", size = 229382, upload-time = "2025-10-06T05:36:02.22Z" },
+    { url = "https://files.pythonhosted.org/packages/95/a3/c8fb25aac55bf5e12dae5c5aa6a98f85d436c1dc658f21c3ac73f9fa95e5/frozenlist-1.8.0-cp311-cp311-win32.whl", hash = "sha256:27c6e8077956cf73eadd514be8fb04d77fc946a7fe9f7fe167648b0b9085cc25", size = 39647, upload-time = "2025-10-06T05:36:03.409Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/f5/603d0d6a02cfd4c8f2a095a54672b3cf967ad688a60fb9faf04fc4887f65/frozenlist-1.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:ac913f8403b36a2c8610bbfd25b8013488533e71e62b4b4adce9c86c8cea905b", size = 44064, upload-time = "2025-10-06T05:36:04.368Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/16/c2c9ab44e181f043a86f9a8f84d5124b62dbcb3a02c0977ec72b9ac1d3e0/frozenlist-1.8.0-cp311-cp311-win_arm64.whl", hash = "sha256:d4d3214a0f8394edfa3e303136d0575eece0745ff2b47bd2cb2e66dd92d4351a", size = 39937, upload-time = "2025-10-06T05:36:05.669Z" },
+    { url = "https://files.pythonhosted.org/packages/69/29/948b9aa87e75820a38650af445d2ef2b6b8a6fab1a23b6bb9e4ef0be2d59/frozenlist-1.8.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:78f7b9e5d6f2fdb88cdde9440dc147259b62b9d3b019924def9f6478be254ac1", size = 87782, upload-time = "2025-10-06T05:36:06.649Z" },
+    { url = "https://files.pythonhosted.org/packages/64/80/4f6e318ee2a7c0750ed724fa33a4bdf1eacdc5a39a7a24e818a773cd91af/frozenlist-1.8.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:229bf37d2e4acdaf808fd3f06e854a4a7a3661e871b10dc1f8f1896a3b05f18b", size = 50594, upload-time = "2025-10-06T05:36:07.69Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/94/5c8a2b50a496b11dd519f4a24cb5496cf125681dd99e94c604ccdea9419a/frozenlist-1.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f833670942247a14eafbb675458b4e61c82e002a148f49e68257b79296e865c4", size = 50448, upload-time = "2025-10-06T05:36:08.78Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/bd/d91c5e39f490a49df14320f4e8c80161cfcce09f1e2cde1edd16a551abb3/frozenlist-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:494a5952b1c597ba44e0e78113a7266e656b9794eec897b19ead706bd7074383", size = 242411, upload-time = "2025-10-06T05:36:09.801Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/83/f61505a05109ef3293dfb1ff594d13d64a2324ac3482be2cedc2be818256/frozenlist-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96f423a119f4777a4a056b66ce11527366a8bb92f54e541ade21f2374433f6d4", size = 243014, upload-time = "2025-10-06T05:36:11.394Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/cb/cb6c7b0f7d4023ddda30cf56b8b17494eb3a79e3fda666bf735f63118b35/frozenlist-1.8.0-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3462dd9475af2025c31cc61be6652dfa25cbfb56cbbf52f4ccfe029f38decaf8", size = 234909, upload-time = "2025-10-06T05:36:12.598Z" },
+    { url = "https://files.pythonhosted.org/packages/31/c5/cd7a1f3b8b34af009fb17d4123c5a778b44ae2804e3ad6b86204255f9ec5/frozenlist-1.8.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c4c800524c9cd9bac5166cd6f55285957fcfc907db323e193f2afcd4d9abd69b", size = 250049, upload-time = "2025-10-06T05:36:14.065Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/01/2f95d3b416c584a1e7f0e1d6d31998c4a795f7544069ee2e0962a4b60740/frozenlist-1.8.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d6a5df73acd3399d893dafc71663ad22534b5aa4f94e8a2fabfe856c3c1b6a52", size = 256485, upload-time = "2025-10-06T05:36:15.39Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/03/024bf7720b3abaebcff6d0793d73c154237b85bdf67b7ed55e5e9596dc9a/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:405e8fe955c2280ce66428b3ca55e12b3c4e9c336fb2103a4937e891c69a4a29", size = 237619, upload-time = "2025-10-06T05:36:16.558Z" },
+    { url = "https://files.pythonhosted.org/packages/69/fa/f8abdfe7d76b731f5d8bd217827cf6764d4f1d9763407e42717b4bed50a0/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:908bd3f6439f2fef9e85031b59fd4f1297af54415fb60e4254a95f75b3cab3f3", size = 250320, upload-time = "2025-10-06T05:36:17.821Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/3c/b051329f718b463b22613e269ad72138cc256c540f78a6de89452803a47d/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:294e487f9ec720bd8ffcebc99d575f7eff3568a08a253d1ee1a0378754b74143", size = 246820, upload-time = "2025-10-06T05:36:19.046Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/ae/58282e8f98e444b3f4dd42448ff36fa38bef29e40d40f330b22e7108f565/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:74c51543498289c0c43656701be6b077f4b265868fa7f8a8859c197006efb608", size = 250518, upload-time = "2025-10-06T05:36:20.763Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/96/007e5944694d66123183845a106547a15944fbbb7154788cbf7272789536/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:776f352e8329135506a1d6bf16ac3f87bc25b28e765949282dcc627af36123aa", size = 239096, upload-time = "2025-10-06T05:36:22.129Z" },
+    { url = "https://files.pythonhosted.org/packages/66/bb/852b9d6db2fa40be96f29c0d1205c306288f0684df8fd26ca1951d461a56/frozenlist-1.8.0-cp312-cp312-win32.whl", hash = "sha256:433403ae80709741ce34038da08511d4a77062aa924baf411ef73d1146e74faf", size = 39985, upload-time = "2025-10-06T05:36:23.661Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/af/38e51a553dd66eb064cdf193841f16f077585d4d28394c2fa6235cb41765/frozenlist-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:34187385b08f866104f0c0617404c8eb08165ab1272e884abc89c112e9c00746", size = 44591, upload-time = "2025-10-06T05:36:24.958Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/06/1dc65480ab147339fecc70797e9c2f69d9cea9cf38934ce08df070fdb9cb/frozenlist-1.8.0-cp312-cp312-win_arm64.whl", hash = "sha256:fe3c58d2f5db5fbd18c2987cba06d51b0529f52bc3a6cdc33d3f4eab725104bd", size = 40102, upload-time = "2025-10-06T05:36:26.333Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409, upload-time = "2025-10-06T05:38:16.721Z" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.53.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/ad/ff781329bbbdc0974a098d996e89c9e1f7024262f9e3eec442fbb9ad1ac6/google_auth-2.53.0.tar.gz", hash = "sha256:e7e6aa16f6bee7b2b264830fd04f08087a1d5a836df516251a5d15327b246c9c", size = 335844, upload-time = "2026-05-15T20:53:07.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/c9/db44165ba7c581268c6d46017ef63339110378305062830104fc7fa144cb/google_auth-2.53.0-py3-none-any.whl", hash = "sha256:6e7449917c599b35126a99ec268ec6880301f2fea41dce198fe8fd83ff642b68", size = 246071, upload-time = "2026-05-15T20:53:05.609Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "httpx-ws"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore" },
+    { name = "httpx" },
+    { name = "wsproto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/cd/ca91a07ae446451f7476bf3fcc909e98cb942ff032ebfda0e3fe449aca7b/httpx_ws-0.9.0.tar.gz", hash = "sha256:797373326f70eec1ae96f6e43ae9f12002fd7d73aee139a4985eaab964338a08", size = 107105, upload-time = "2026-03-28T14:11:10.781Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/f8/a6bc80313a9e93c888fa10534dfce2ad76ff86911b6f485777ce6de6a073/httpx_ws-0.9.0-py3-none-any.whl", hash = "sha256:71640d2fb1bf9a225775015b33cd755cfd4c5f7e21c885192fe3adc4c387b248", size = 15759, upload-time = "2026-03-28T14:11:11.887Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "ipython"
+version = "8.39.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version < '3.11'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "jedi", marker = "python_full_version < '3.11'" },
+    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
+    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
+    { name = "pygments", marker = "python_full_version < '3.11'" },
+    { name = "stack-data", marker = "python_full_version < '3.11'" },
+    { name = "traitlets", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/18/f8598d287006885e7136451fdea0755af4ebcbfe342836f24deefaed1164/ipython-8.39.0.tar.gz", hash = "sha256:4110ae96012c379b8b6db898a07e186c40a2a1ef5d57a7fa83166047d9da7624", size = 5513971, upload-time = "2026-03-27T10:02:13.94Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/56/4cc7fc9e9e3f38fd324f24f8afe0ad8bb5fa41283f37f1aaf9de0612c968/ipython-8.39.0-py3-none-any.whl", hash = "sha256:bb3c51c4fa8148ab1dea07a79584d1c854e234ea44aa1283bcb37bc75054651f", size = 831849, upload-time = "2026-03-27T10:02:07.846Z" },
+]
+
+[[package]]
+name = "ipython"
+version = "9.13.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.11' and sys_platform == 'win32'",
+    "python_full_version >= '3.11' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version >= '3.11'" },
+    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
+    { name = "jedi", marker = "python_full_version >= '3.11'" },
+    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
+    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
+    { name = "psutil", marker = "python_full_version >= '3.11'" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "stack-data", marker = "python_full_version >= '3.11'" },
+    { name = "traitlets", marker = "python_full_version >= '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/87cda5842cf5c31837c06ddb588e11c3c35d8ece89b7a0108c06b8c9b00a/ipython-9.13.0.tar.gz", hash = "sha256:7e834b6afc99f020e3f05966ced34792f40267d64cb1ea9043886dab0dde5967", size = 4430549, upload-time = "2026-04-24T12:24:55.221Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/86/3060e8029b7cc505cce9a0137431dda81d0a3fde93a8f0f50ee0bf37a795/ipython-9.13.0-py3-none-any.whl", hash = "sha256:57f9d4639e20818d328d287c7b549af3d05f12486ea8f2e7f73e52a36ec4d201", size = 627274, upload-time = "2026-04-24T12:24:53.038Z" },
+]
+
+[[package]]
+name = "ipython-pygments-lexers"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl", hash = "sha256:a9462224a505ade19a605f71f8fa63c2048833ce50abc86768a0d81d876dc81c", size = 8074, upload-time = "2025-01-17T11:24:33.271Z" },
+]
+
+[[package]]
+name = "jedi"
+version = "0.20.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "parso" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/b7/a3635f6a2d7cf5b5dd98064fc1d5fbbafcb25477bcea204a3a92145d158b/jedi-0.20.0.tar.gz", hash = "sha256:c3f4ccbd276696f4b19c54618d4fb18f9fc24b0aef02acf704b23f487daa1011", size = 3119416, upload-time = "2026-05-01T23:38:47.814Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/93/242e2eab5fe682ffcb8b0084bde703a41d51e17ee0f3a31ff0d9d813620a/jedi-0.20.0-py2.py3-none-any.whl", hash = "sha256:7bdd9c2634f56713299976f4cbd59cb3fa92165cc5e05ea811fb253480728b67", size = 4884812, upload-time = "2026-05-01T23:38:43.919Z" },
+]
+
+[[package]]
+name = "kr8s"
+version = "0.20.15"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "cachetools" },
+    { name = "cryptography" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.12'" },
+    { name = "httpx" },
+    { name = "httpx-ws" },
+    { name = "packaging" },
+    { name = "python-box" },
+    { name = "python-jsonpath" },
+    { name = "pyyaml" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/20/55/ca9ff53d97413a0dca36c30da80750415350876aa23ea8a762a0b06c6d1f/kr8s-0.20.15.tar.gz", hash = "sha256:484d5206bbebd48f8cc00dd3ed749d4419294d2f08cd50c6232114cf62ed6d3a", size = 2839774, upload-time = "2026-01-16T15:23:42.645Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/08/4247abe88116c1e59dd9b62992d8a69b7178f4046c85cca03eda7e3d87e3/kr8s-0.20.15-py3-none-any.whl", hash = "sha256:eacc6eb72b6354d932a1e22c0cb698c88adbd815c36164c24c2232a69dfabe40", size = 87670, upload-time = "2026-01-16T15:23:40.593Z" },
+]
+
+[[package]]
+name = "kubernetes"
+version = "32.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "durationpy" },
+    { name = "google-auth" },
+    { name = "oauthlib" },
+    { name = "python-dateutil" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "requests-oauthlib" },
+    { name = "six" },
+    { name = "urllib3" },
+    { name = "websocket-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b7/e8/0598f0e8b4af37cd9b10d8b87386cf3173cb8045d834ab5f6ec347a758b3/kubernetes-32.0.1.tar.gz", hash = "sha256:42f43d49abd437ada79a79a16bd48a604d3471a117a8347e87db693f2ba0ba28", size = 946691, upload-time = "2025-02-18T21:06:34.148Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/10/9f8af3e6f569685ce3af7faab51c8dd9d93b9c38eba339ca31c746119447/kubernetes-32.0.1-py2.py3-none-any.whl", hash = "sha256:35282ab8493b938b08ab5526c7ce66588232df00ef5e1dbe88a419107dc10998", size = 1988070, upload-time = "2025-02-18T21:06:31.391Z" },
+]
+
+[[package]]
+name = "kubernetes-asyncio"
+version = "32.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "certifi" },
+    { name = "python-dateutil" },
+    { name = "pyyaml" },
+    { name = "six" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/74/6d454c06c44acbe2dba10aaddb87e6a8a980055308d4052aa408da280095/kubernetes_asyncio-32.3.2.tar.gz", hash = "sha256:a4b6da1dbfa16e87ab8df6898f54fa03f651591a502bd6480a647d5513a580bf", size = 1032557, upload-time = "2025-04-30T21:59:34.121Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/bf/8d9ae183b3bee0811f633411d3e3de4bcc58eefb81021b3e2fdcc1d1e26b/kubernetes_asyncio-32.3.2-py3-none-any.whl", hash = "sha256:3584e6358571e686ea1396fc310890263c58fa41c084a841a9609a54ad05de62", size = 1984148, upload-time = "2025-04-30T21:59:32.254Z" },
+]
+
+[[package]]
+name = "matplotlib-inline"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/c0/9f7c9a46090390368a4d7bcb76bb87a4a36c421e4c0792cdb53486ffac7a/matplotlib_inline-0.2.2.tar.gz", hash = "sha256:72f3fe8fce36b70d4a5b612f899090cd0401deddc4ea90e1572b9f4bfb058c79", size = 8150, upload-time = "2026-05-08T17:33:33.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/09/5b161152e2d90f7b87f781c2e1267494aef9c32498df793f73ad0a0a494a/matplotlib_inline-0.2.2-py3-none-any.whl", hash = "sha256:3c821cf1c209f59fb2d2d64abbf5b23b67bcb2210d663f9918dd851c6da1fcf6", size = 9534, upload-time = "2026-05-08T17:33:32.055Z" },
+]
+
+[[package]]
+name = "multidict"
+version = "6.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/c2/c2d94cbe6ac1753f3fc980da97b3d930efe1da3af3c9f5125354436c073d/multidict-6.7.1.tar.gz", hash = "sha256:ec6652a1bee61c53a3e5776b6049172c53b6aaba34f18c9ad04f82712bac623d", size = 102010, upload-time = "2026-01-26T02:46:45.979Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/0b/19348d4c98980c4851d2f943f8ebafdece2ae7ef737adcfa5994ce8e5f10/multidict-6.7.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:c93c3db7ea657dd4637d57e74ab73de31bccefe144d3d4ce370052035bc85fb5", size = 77176, upload-time = "2026-01-26T02:42:59.784Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/04/9de3f8077852e3d438215c81e9b691244532d2e05b4270e89ce67b7d103c/multidict-6.7.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:974e72a2474600827abaeda71af0c53d9ebbc3c2eb7da37b37d7829ae31232d8", size = 44996, upload-time = "2026-01-26T02:43:01.674Z" },
+    { url = "https://files.pythonhosted.org/packages/31/5c/08c7f7fe311f32e83f7621cd3f99d805f45519cd06fafb247628b861da7d/multidict-6.7.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:cdea2e7b2456cfb6694fb113066fd0ec7ea4d67e3a35e1f4cbeea0b448bf5872", size = 44631, upload-time = "2026-01-26T02:43:03.169Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/7f/0e3b1390ae772f27501199996b94b52ceeb64fe6f9120a32c6c3f6b781be/multidict-6.7.1-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:17207077e29342fdc2c9a82e4b306f1127bf1ea91f8b71e02d4798a70bb99991", size = 242561, upload-time = "2026-01-26T02:43:04.733Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/f4/8719f4f167586af317b69dd3e90f913416c91ca610cac79a45c53f590312/multidict-6.7.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4f49cb5661344764e4c7c7973e92a47a59b8fc19b6523649ec9dc4960e58a03", size = 242223, upload-time = "2026-01-26T02:43:06.695Z" },
+    { url = "https://files.pythonhosted.org/packages/47/ab/7c36164cce64a6ad19c6d9a85377b7178ecf3b89f8fd589c73381a5eedfd/multidict-6.7.1-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a9fc4caa29e2e6ae408d1c450ac8bf19892c5fca83ee634ecd88a53332c59981", size = 222322, upload-time = "2026-01-26T02:43:08.472Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/79/a25add6fb38035b5337bc5734f296d9afc99163403bbcf56d4170f97eb62/multidict-6.7.1-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c5f0c21549ab432b57dcc82130f388d84ad8179824cc3f223d5e7cfbfd4143f6", size = 254005, upload-time = "2026-01-26T02:43:10.127Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/7b/64a87cf98e12f756fc8bd444b001232ffff2be37288f018ad0d3f0aae931/multidict-6.7.1-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7dfb78d966b2c906ae1d28ccf6e6712a3cd04407ee5088cd276fe8cb42186190", size = 251173, upload-time = "2026-01-26T02:43:11.731Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/ac/b605473de2bb404e742f2cc3583d12aedb2352a70e49ae8fce455b50c5aa/multidict-6.7.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9b0d9b91d1aa44db9c1f1ecd0d9d2ae610b2f4f856448664e01a3b35899f3f92", size = 243273, upload-time = "2026-01-26T02:43:13.063Z" },
+    { url = "https://files.pythonhosted.org/packages/03/65/11492d6a0e259783720f3bc1d9ea55579a76f1407e31ed44045c99542004/multidict-6.7.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:dd96c01a9dcd4889dcfcf9eb5544ca0c77603f239e3ffab0524ec17aea9a93ee", size = 238956, upload-time = "2026-01-26T02:43:14.843Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/a7/7ee591302af64e7c196fb63fe856c788993c1372df765102bd0448e7e165/multidict-6.7.1-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:067343c68cd6612d375710f895337b3a98a033c94f14b9a99eff902f205424e2", size = 233477, upload-time = "2026-01-26T02:43:16.025Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/99/c109962d58756c35fd9992fed7f2355303846ea2ff054bb5f5e9d6b888de/multidict-6.7.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:5884a04f4ff56c6120f6ccf703bdeb8b5079d808ba604d4d53aec0d55dc33568", size = 243615, upload-time = "2026-01-26T02:43:17.84Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/5f/1973e7c771c86e93dcfe1c9cc55a5481b610f6614acfc28c0d326fe6bfad/multidict-6.7.1-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:8affcf1c98b82bc901702eb73b6947a1bfa170823c153fe8a47b5f5f02e48e40", size = 249930, upload-time = "2026-01-26T02:43:19.06Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/a5/f170fc2268c3243853580203378cd522446b2df632061e0a5409817854c7/multidict-6.7.1-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:0d17522c37d03e85c8098ec8431636309b2682cf12e58f4dbc76121fb50e4962", size = 243807, upload-time = "2026-01-26T02:43:20.286Z" },
+    { url = "https://files.pythonhosted.org/packages/de/01/73856fab6d125e5bc652c3986b90e8699a95e84b48d72f39ade6c0e74a8c/multidict-6.7.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:24c0cf81544ca5e17cfcb6e482e7a82cd475925242b308b890c9452a074d4505", size = 239103, upload-time = "2026-01-26T02:43:21.508Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/46/f1220bd9944d8aa40d8ccff100eeeee19b505b857b6f603d6078cb5315b0/multidict-6.7.1-cp310-cp310-win32.whl", hash = "sha256:d82dd730a95e6643802f4454b8fdecdf08667881a9c5670db85bc5a56693f122", size = 41416, upload-time = "2026-01-26T02:43:22.703Z" },
+    { url = "https://files.pythonhosted.org/packages/68/00/9b38e272a770303692fc406c36e1a4c740f401522d5787691eb38a8925a8/multidict-6.7.1-cp310-cp310-win_amd64.whl", hash = "sha256:cf37cbe5ced48d417ba045aca1b21bafca67489452debcde94778a576666a1df", size = 46022, upload-time = "2026-01-26T02:43:23.77Z" },
+    { url = "https://files.pythonhosted.org/packages/64/65/d8d42490c02ee07b6bbe00f7190d70bb4738b3cce7629aaf9f213ef730dd/multidict-6.7.1-cp310-cp310-win_arm64.whl", hash = "sha256:59bc83d3f66b41dac1e7460aac1d196edc70c9ba3094965c467715a70ecb46db", size = 43238, upload-time = "2026-01-26T02:43:24.882Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/f1/a90635c4f88fb913fbf4ce660b83b7445b7a02615bda034b2f8eb38fd597/multidict-6.7.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7ff981b266af91d7b4b3793ca3382e53229088d193a85dfad6f5f4c27fc73e5d", size = 76626, upload-time = "2026-01-26T02:43:26.485Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/9b/267e64eaf6fc637a15b35f5de31a566634a2740f97d8d094a69d34f524a4/multidict-6.7.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:844c5bca0b5444adb44a623fb0a1310c2f4cd41f402126bb269cd44c9b3f3e1e", size = 44706, upload-time = "2026-01-26T02:43:27.607Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a4/d45caf2b97b035c57267791ecfaafbd59c68212004b3842830954bb4b02e/multidict-6.7.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f2a0a924d4c2e9afcd7ec64f9de35fcd96915149b2216e1cb2c10a56df483855", size = 44356, upload-time = "2026-01-26T02:43:28.661Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/d2/0a36c8473f0cbaeadd5db6c8b72d15bbceeec275807772bfcd059bef487d/multidict-6.7.1-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:8be1802715a8e892c784c0197c2ace276ea52702a0ede98b6310c8f255a5afb3", size = 244355, upload-time = "2026-01-26T02:43:31.165Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/16/8c65be997fd7dd311b7d39c7b6e71a0cb449bad093761481eccbbe4b42a2/multidict-6.7.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2e2d2ed645ea29f31c4c7ea1552fcfd7cb7ba656e1eafd4134a6620c9f5fdd9e", size = 246433, upload-time = "2026-01-26T02:43:32.581Z" },
+    { url = "https://files.pythonhosted.org/packages/01/fb/4dbd7e848d2799c6a026ec88ad39cf2b8416aa167fcc903baa55ecaa045c/multidict-6.7.1-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:95922cee9a778659e91db6497596435777bd25ed116701a4c034f8e46544955a", size = 225376, upload-time = "2026-01-26T02:43:34.417Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/8a/4a3a6341eac3830f6053062f8fbc9a9e54407c80755b3f05bc427295c2d0/multidict-6.7.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6b83cabdc375ffaaa15edd97eb7c0c672ad788e2687004990074d7d6c9b140c8", size = 257365, upload-time = "2026-01-26T02:43:35.741Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a2/dd575a69c1aa206e12d27d0770cdf9b92434b48a9ef0cd0d1afdecaa93c4/multidict-6.7.1-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:38fb49540705369bab8484db0689d86c0a33a0a9f2c1b197f506b71b4b6c19b0", size = 254747, upload-time = "2026-01-26T02:43:36.976Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/56/21b27c560c13822ed93133f08aa6372c53a8e067f11fbed37b4adcdac922/multidict-6.7.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:439cbebd499f92e9aa6793016a8acaa161dfa749ae86d20960189f5398a19144", size = 246293, upload-time = "2026-01-26T02:43:38.258Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/a4/23466059dc3854763423d0ad6c0f3683a379d97673b1b89ec33826e46728/multidict-6.7.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6d3bc717b6fe763b8be3f2bee2701d3c8eb1b2a8ae9f60910f1b2860c82b6c49", size = 242962, upload-time = "2026-01-26T02:43:40.034Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/67/51dd754a3524d685958001e8fa20a0f5f90a6a856e0a9dcabff69be3dbb7/multidict-6.7.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:619e5a1ac57986dbfec9f0b301d865dddf763696435e2962f6d9cf2fdff2bb71", size = 237360, upload-time = "2026-01-26T02:43:41.752Z" },
+    { url = "https://files.pythonhosted.org/packages/64/3f/036dfc8c174934d4b55d86ff4f978e558b0e585cef70cfc1ad01adc6bf18/multidict-6.7.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:0b38ebffd9be37c1170d33bc0f36f4f262e0a09bc1aac1c34c7aa51a7293f0b3", size = 245940, upload-time = "2026-01-26T02:43:43.042Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/20/6214d3c105928ebc353a1c644a6ef1408bc5794fcb4f170bb524a3c16311/multidict-6.7.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:10ae39c9cfe6adedcdb764f5e8411d4a92b055e35573a2eaa88d3323289ef93c", size = 253502, upload-time = "2026-01-26T02:43:44.371Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e2/c653bc4ae1be70a0f836b82172d643fcf1dade042ba2676ab08ec08bff0f/multidict-6.7.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:25167cc263257660290fba06b9318d2026e3c910be240a146e1f66dd114af2b0", size = 247065, upload-time = "2026-01-26T02:43:45.745Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/11/a854b4154cd3bd8b1fd375e8a8ca9d73be37610c361543d56f764109509b/multidict-6.7.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:128441d052254f42989ef98b7b6a6ecb1e6f708aa962c7984235316db59f50fa", size = 241870, upload-time = "2026-01-26T02:43:47.054Z" },
+    { url = "https://files.pythonhosted.org/packages/13/bf/9676c0392309b5fdae322333d22a829715b570edb9baa8016a517b55b558/multidict-6.7.1-cp311-cp311-win32.whl", hash = "sha256:d62b7f64ffde3b99d06b707a280db04fb3855b55f5a06df387236051d0668f4a", size = 41302, upload-time = "2026-01-26T02:43:48.753Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/68/f16a3a8ba6f7b6dc92a1f19669c0810bd2c43fc5a02da13b1cbf8e253845/multidict-6.7.1-cp311-cp311-win_amd64.whl", hash = "sha256:bdbf9f3b332abd0cdb306e7c2113818ab1e922dc84b8f8fd06ec89ed2a19ab8b", size = 45981, upload-time = "2026-01-26T02:43:49.921Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ad/9dd5305253fa00cd3c7555dbef69d5bf4133debc53b87ab8d6a44d411665/multidict-6.7.1-cp311-cp311-win_arm64.whl", hash = "sha256:b8c990b037d2fff2f4e33d3f21b9b531c5745b33a49a7d6dbe7a177266af44f6", size = 43159, upload-time = "2026-01-26T02:43:51.635Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/9c/f20e0e2cf80e4b2e4b1c365bf5fe104ee633c751a724246262db8f1a0b13/multidict-6.7.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a90f75c956e32891a4eda3639ce6dd86e87105271f43d43442a3aedf3cddf172", size = 76893, upload-time = "2026-01-26T02:43:52.754Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/cf/18ef143a81610136d3da8193da9d80bfe1cb548a1e2d1c775f26b23d024a/multidict-6.7.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3fccb473e87eaa1382689053e4a4618e7ba7b9b9b8d6adf2027ee474597128cd", size = 45456, upload-time = "2026-01-26T02:43:53.893Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/65/1caac9d4cd32e8433908683446eebc953e82d22b03d10d41a5f0fefe991b/multidict-6.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b0fa96985700739c4c7853a43c0b3e169360d6855780021bfc6d0f1ce7c123e7", size = 43872, upload-time = "2026-01-26T02:43:55.041Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/3b/d6bd75dc4f3ff7c73766e04e705b00ed6dbbaccf670d9e05a12b006f5a21/multidict-6.7.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:cb2a55f408c3043e42b40cc8eecd575afa27b7e0b956dfb190de0f8499a57a53", size = 251018, upload-time = "2026-01-26T02:43:56.198Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/80/c959c5933adedb9ac15152e4067c702a808ea183a8b64cf8f31af8ad3155/multidict-6.7.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eb0ce7b2a32d09892b3dd6cc44877a0d02a33241fafca5f25c8b6b62374f8b75", size = 258883, upload-time = "2026-01-26T02:43:57.499Z" },
+    { url = "https://files.pythonhosted.org/packages/86/85/7ed40adafea3d4f1c8b916e3b5cc3a8e07dfcdcb9cd72800f4ed3ca1b387/multidict-6.7.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c3a32d23520ee37bf327d1e1a656fec76a2edd5c038bf43eddfa0572ec49c60b", size = 242413, upload-time = "2026-01-26T02:43:58.755Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/57/b8565ff533e48595503c785f8361ff9a4fde4d67de25c207cd0ba3befd03/multidict-6.7.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9c90fed18bffc0189ba814749fdcc102b536e83a9f738a9003e569acd540a733", size = 268404, upload-time = "2026-01-26T02:44:00.216Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/50/9810c5c29350f7258180dfdcb2e52783a0632862eb334c4896ac717cebcb/multidict-6.7.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:da62917e6076f512daccfbbde27f46fed1c98fee202f0559adec8ee0de67f71a", size = 269456, upload-time = "2026-01-26T02:44:02.202Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/8d/5e5be3ced1d12966fefb5c4ea3b2a5b480afcea36406559442c6e31d4a48/multidict-6.7.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bfde23ef6ed9db7eaee6c37dcec08524cb43903c60b285b172b6c094711b3961", size = 256322, upload-time = "2026-01-26T02:44:03.56Z" },
+    { url = "https://files.pythonhosted.org/packages/31/6e/d8a26d81ac166a5592782d208dd90dfdc0a7a218adaa52b45a672b46c122/multidict-6.7.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3758692429e4e32f1ba0df23219cd0b4fc0a52f476726fff9337d1a57676a582", size = 253955, upload-time = "2026-01-26T02:44:04.845Z" },
+    { url = "https://files.pythonhosted.org/packages/59/4c/7c672c8aad41534ba619bcd4ade7a0dc87ed6b8b5c06149b85d3dd03f0cd/multidict-6.7.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:398c1478926eca669f2fd6a5856b6de9c0acf23a2cb59a14c0ba5844fa38077e", size = 251254, upload-time = "2026-01-26T02:44:06.133Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/bd/84c24de512cbafbdbc39439f74e967f19570ce7924e3007174a29c348916/multidict-6.7.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:c102791b1c4f3ab36ce4101154549105a53dc828f016356b3e3bcae2e3a039d3", size = 252059, upload-time = "2026-01-26T02:44:07.518Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/ba/f5449385510825b73d01c2d4087bf6d2fccc20a2d42ac34df93191d3dd03/multidict-6.7.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:a088b62bd733e2ad12c50dad01b7d0166c30287c166e137433d3b410add807a6", size = 263588, upload-time = "2026-01-26T02:44:09.382Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/11/afc7c677f68f75c84a69fe37184f0f82fce13ce4b92f49f3db280b7e92b3/multidict-6.7.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:3d51ff4785d58d3f6c91bdbffcb5e1f7ddfda557727043aa20d20ec4f65e324a", size = 259642, upload-time = "2026-01-26T02:44:10.73Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/17/ebb9644da78c4ab36403739e0e6e0e30ebb135b9caf3440825001a0bddcb/multidict-6.7.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc5907494fccf3e7d3f94f95c91d6336b092b5fc83811720fae5e2765890dfba", size = 251377, upload-time = "2026-01-26T02:44:12.042Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/a4/840f5b97339e27846c46307f2530a2805d9d537d8b8bd416af031cad7fa0/multidict-6.7.1-cp312-cp312-win32.whl", hash = "sha256:28ca5ce2fd9716631133d0e9a9b9a745ad7f60bac2bccafb56aa380fc0b6c511", size = 41887, upload-time = "2026-01-26T02:44:14.245Z" },
+    { url = "https://files.pythonhosted.org/packages/80/31/0b2517913687895f5904325c2069d6a3b78f66cc641a86a2baf75a05dcbb/multidict-6.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcee94dfbd638784645b066074b338bc9cc155d4b4bffa4adce1615c5a426c19", size = 46053, upload-time = "2026-01-26T02:44:15.371Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/5b/aba28e4ee4006ae4c7df8d327d31025d760ffa992ea23812a601d226e682/multidict-6.7.1-cp312-cp312-win_arm64.whl", hash = "sha256:ba0a9fb644d0c1a2194cf7ffb043bd852cea63a57f66fbd33959f7dae18517bf", size = 43307, upload-time = "2026-01-26T02:44:16.852Z" },
+    { url = "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl", hash = "sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56", size = 12319, upload-time = "2026-01-26T02:46:44.004Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.2.6"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/21/7d2a95e4bba9dc13d043ee156a356c0a8f0c6309dff6b21b4d71a073b8a8/numpy-2.2.6.tar.gz", hash = "sha256:e29554e2bef54a90aa5cc07da6ce955accb83f21ab5de01a62c8478897b264fd", size = 20276440, upload-time = "2025-05-17T22:38:04.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3e/ed6db5be21ce87955c0cbd3009f2803f59fa08df21b5df06862e2d8e2bdd/numpy-2.2.6-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b412caa66f72040e6d268491a59f2c43bf03eb6c96dd8f0307829feb7fa2b6fb", size = 21165245, upload-time = "2025-05-17T21:27:58.555Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c2/4b9221495b2a132cc9d2eb862e21d42a009f5a60e45fc44b00118c174bff/numpy-2.2.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8e41fd67c52b86603a91c1a505ebaef50b3314de0213461c7a6e99c9a3beff90", size = 14360048, upload-time = "2025-05-17T21:28:21.406Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/77/dc2fcfc66943c6410e2bf598062f5959372735ffda175b39906d54f02349/numpy-2.2.6-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:37e990a01ae6ec7fe7fa1c26c55ecb672dd98b19c3d0e1d1f326fa13cb38d163", size = 5340542, upload-time = "2025-05-17T21:28:30.931Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/4f/1cb5fdc353a5f5cc7feb692db9b8ec2c3d6405453f982435efc52561df58/numpy-2.2.6-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:5a6429d4be8ca66d889b7cf70f536a397dc45ba6faeb5f8c5427935d9592e9cf", size = 6878301, upload-time = "2025-05-17T21:28:41.613Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/17/96a3acd228cec142fcb8723bd3cc39c2a474f7dcf0a5d16731980bcafa95/numpy-2.2.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:efd28d4e9cd7d7a8d39074a4d44c63eda73401580c5c76acda2ce969e0a38e83", size = 14297320, upload-time = "2025-05-17T21:29:02.78Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/63/3de6a34ad7ad6646ac7d2f55ebc6ad439dbbf9c4370017c50cf403fb19b5/numpy-2.2.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc7b73d02efb0e18c000e9ad8b83480dfcd5dfd11065997ed4c6747470ae8915", size = 16801050, upload-time = "2025-05-17T21:29:27.675Z" },
+    { url = "https://files.pythonhosted.org/packages/07/b6/89d837eddef52b3d0cec5c6ba0456c1bf1b9ef6a6672fc2b7873c3ec4e2e/numpy-2.2.6-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:74d4531beb257d2c3f4b261bfb0fc09e0f9ebb8842d82a7b4209415896adc680", size = 15807034, upload-time = "2025-05-17T21:29:51.102Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c8/dc6ae86e3c61cfec1f178e5c9f7858584049b6093f843bca541f94120920/numpy-2.2.6-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8fc377d995680230e83241d8a96def29f204b5782f371c532579b4f20607a289", size = 18614185, upload-time = "2025-05-17T21:30:18.703Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/c5/0064b1b7e7c89137b471ccec1fd2282fceaae0ab3a9550f2568782d80357/numpy-2.2.6-cp310-cp310-win32.whl", hash = "sha256:b093dd74e50a8cba3e873868d9e93a85b78e0daf2e98c6797566ad8044e8363d", size = 6527149, upload-time = "2025-05-17T21:30:29.788Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/dd/4b822569d6b96c39d1215dbae0582fd99954dcbcf0c1a13c61783feaca3f/numpy-2.2.6-cp310-cp310-win_amd64.whl", hash = "sha256:f0fd6321b839904e15c46e0d257fdd101dd7f530fe03fd6359c1ea63738703f3", size = 12904620, upload-time = "2025-05-17T21:30:48.994Z" },
+    { url = "https://files.pythonhosted.org/packages/da/a8/4f83e2aa666a9fbf56d6118faaaf5f1974d456b1823fda0a176eff722839/numpy-2.2.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f9f1adb22318e121c5c69a09142811a201ef17ab257a1e66ca3025065b7f53ae", size = 21176963, upload-time = "2025-05-17T21:31:19.36Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/2b/64e1affc7972decb74c9e29e5649fac940514910960ba25cd9af4488b66c/numpy-2.2.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c820a93b0255bc360f53eca31a0e676fd1101f673dda8da93454a12e23fc5f7a", size = 14406743, upload-time = "2025-05-17T21:31:41.087Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/9f/0121e375000b5e50ffdd8b25bf78d8e1a5aa4cca3f185d41265198c7b834/numpy-2.2.6-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:3d70692235e759f260c3d837193090014aebdf026dfd167834bcba43e30c2a42", size = 5352616, upload-time = "2025-05-17T21:31:50.072Z" },
+    { url = "https://files.pythonhosted.org/packages/31/0d/b48c405c91693635fbe2dcd7bc84a33a602add5f63286e024d3b6741411c/numpy-2.2.6-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:481b49095335f8eed42e39e8041327c05b0f6f4780488f61286ed3c01368d491", size = 6889579, upload-time = "2025-05-17T21:32:01.712Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b8/7f0554d49b565d0171eab6e99001846882000883998e7b7d9f0d98b1f934/numpy-2.2.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b64d8d4d17135e00c8e346e0a738deb17e754230d7e0810ac5012750bbd85a5a", size = 14312005, upload-time = "2025-05-17T21:32:23.332Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/dd/2238b898e51bd6d389b7389ffb20d7f4c10066d80351187ec8e303a5a475/numpy-2.2.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba10f8411898fc418a521833e014a77d3ca01c15b0c6cdcce6a0d2897e6dbbdf", size = 16821570, upload-time = "2025-05-17T21:32:47.991Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6c/44d0325722cf644f191042bf47eedad61c1e6df2432ed65cbe28509d404e/numpy-2.2.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:bd48227a919f1bafbdda0583705e547892342c26fb127219d60a5c36882609d1", size = 15818548, upload-time = "2025-05-17T21:33:11.728Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/9d/81e8216030ce66be25279098789b665d49ff19eef08bfa8cb96d4957f422/numpy-2.2.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9551a499bf125c1d4f9e250377c1ee2eddd02e01eac6644c080162c0c51778ab", size = 18620521, upload-time = "2025-05-17T21:33:39.139Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/fd/e19617b9530b031db51b0926eed5345ce8ddc669bb3bc0044b23e275ebe8/numpy-2.2.6-cp311-cp311-win32.whl", hash = "sha256:0678000bb9ac1475cd454c6b8c799206af8107e310843532b04d49649c717a47", size = 6525866, upload-time = "2025-05-17T21:33:50.273Z" },
+    { url = "https://files.pythonhosted.org/packages/31/0a/f354fb7176b81747d870f7991dc763e157a934c717b67b58456bc63da3df/numpy-2.2.6-cp311-cp311-win_amd64.whl", hash = "sha256:e8213002e427c69c45a52bbd94163084025f533a55a59d6f9c5b820774ef3303", size = 12907455, upload-time = "2025-05-17T21:34:09.135Z" },
+    { url = "https://files.pythonhosted.org/packages/82/5d/c00588b6cf18e1da539b45d3598d3557084990dcc4331960c15ee776ee41/numpy-2.2.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:41c5a21f4a04fa86436124d388f6ed60a9343a6f767fced1a8a71c3fbca038ff", size = 20875348, upload-time = "2025-05-17T21:34:39.648Z" },
+    { url = "https://files.pythonhosted.org/packages/66/ee/560deadcdde6c2f90200450d5938f63a34b37e27ebff162810f716f6a230/numpy-2.2.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:de749064336d37e340f640b05f24e9e3dd678c57318c7289d222a8a2f543e90c", size = 14119362, upload-time = "2025-05-17T21:35:01.241Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/65/4baa99f1c53b30adf0acd9a5519078871ddde8d2339dc5a7fde80d9d87da/numpy-2.2.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:894b3a42502226a1cac872f840030665f33326fc3dac8e57c607905773cdcde3", size = 5084103, upload-time = "2025-05-17T21:35:10.622Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/89/e5a34c071a0570cc40c9a54eb472d113eea6d002e9ae12bb3a8407fb912e/numpy-2.2.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:71594f7c51a18e728451bb50cc60a3ce4e6538822731b2933209a1f3614e9282", size = 6625382, upload-time = "2025-05-17T21:35:21.414Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/35/8c80729f1ff76b3921d5c9487c7ac3de9b2a103b1cd05e905b3090513510/numpy-2.2.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f2618db89be1b4e05f7a1a847a9c1c0abd63e63a1607d892dd54668dd92faf87", size = 14018462, upload-time = "2025-05-17T21:35:42.174Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/3d/1e1db36cfd41f895d266b103df00ca5b3cbe965184df824dec5c08c6b803/numpy-2.2.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd83c01228a688733f1ded5201c678f0c53ecc1006ffbc404db9f7a899ac6249", size = 16527618, upload-time = "2025-05-17T21:36:06.711Z" },
+    { url = "https://files.pythonhosted.org/packages/61/c6/03ed30992602c85aa3cd95b9070a514f8b3c33e31124694438d88809ae36/numpy-2.2.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:37c0ca431f82cd5fa716eca9506aefcabc247fb27ba69c5062a6d3ade8cf8f49", size = 15505511, upload-time = "2025-05-17T21:36:29.965Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/25/5761d832a81df431e260719ec45de696414266613c9ee268394dd5ad8236/numpy-2.2.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fe27749d33bb772c80dcd84ae7e8df2adc920ae8297400dabec45f0dedb3f6de", size = 18313783, upload-time = "2025-05-17T21:36:56.883Z" },
+    { url = "https://files.pythonhosted.org/packages/57/0a/72d5a3527c5ebffcd47bde9162c39fae1f90138c961e5296491ce778e682/numpy-2.2.6-cp312-cp312-win32.whl", hash = "sha256:4eeaae00d789f66c7a25ac5f34b71a7035bb474e679f410e5e1a94deb24cf2d4", size = 6246506, upload-time = "2025-05-17T21:37:07.368Z" },
+    { url = "https://files.pythonhosted.org/packages/36/fa/8c9210162ca1b88529ab76b41ba02d433fd54fecaf6feb70ef9f124683f1/numpy-2.2.6-cp312-cp312-win_amd64.whl", hash = "sha256:c1f9540be57940698ed329904db803cf7a402f3fc200bfe599334c9bd84a40b2", size = 12614190, upload-time = "2025-05-17T21:37:26.213Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/3b/d94a75f4dbf1ef5d321523ecac21ef23a3cd2ac8b78ae2aac40873590229/numpy-2.2.6-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0b605b275d7bd0c640cad4e5d30fa701a8d59302e127e5f79138ad62762c3e3d", size = 21040391, upload-time = "2025-05-17T21:44:35.948Z" },
+    { url = "https://files.pythonhosted.org/packages/17/f4/09b2fa1b58f0fb4f7c7963a1649c64c4d315752240377ed74d9cd878f7b5/numpy-2.2.6-pp310-pypy310_pp73-macosx_14_0_x86_64.whl", hash = "sha256:7befc596a7dc9da8a337f79802ee8adb30a552a94f792b9c9d18c840055907db", size = 6786754, upload-time = "2025-05-17T21:44:47.446Z" },
+    { url = "https://files.pythonhosted.org/packages/af/30/feba75f143bdc868a1cc3f44ccfa6c4b9ec522b36458e738cd00f67b573f/numpy-2.2.6-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce47521a4754c8f4593837384bd3424880629f718d87c5d44f8ed763edd63543", size = 16643476, upload-time = "2025-05-17T21:45:11.871Z" },
+    { url = "https://files.pythonhosted.org/packages/37/48/ac2a9584402fb6c0cd5b5d1a91dcf176b15760130dd386bbafdbfe3640bf/numpy-2.2.6-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:d042d24c90c41b54fd506da306759e06e568864df8ec17ccc17e9e884634fd00", size = 12812666, upload-time = "2025-05-17T21:45:31.426Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.4.6"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.11' and sys_platform == 'win32'",
+    "python_full_version >= '3.11' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/49/ec46835a70be8fa6446c495126ac84fdb28cb2558e1620ffb87a10c8b64c/numpy-2.4.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0280e0356c0829a18d9de1cb7eee50ec22ca639878d7240307ca0943d73cd2c4", size = 16969194, upload-time = "2026-05-18T23:33:13.503Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0d/f5957185c0ee2f3e12f78715aa9e3b353fd83633316c8532b38faa37e3f6/numpy-2.4.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:110f8b71aacb688ec69062bb7f6938a0f8acb01b7c1c4beb453c65b6d234584d", size = 14964111, upload-time = "2026-05-18T23:33:17.795Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/40/40a40ee0ddf7ceb782c49af278894b686e586d65d8c1889c8b5da01a3d7d/numpy-2.4.6-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:4cfe66903cc32a9921a6733d96b19bb6abf310397581bbad89c228f5abaf0ee8", size = 5469159, upload-time = "2026-05-18T23:33:20.654Z" },
+    { url = "https://files.pythonhosted.org/packages/63/13/f9a8046535cb21deae82f8d03de9617e08882d274fad2539630761888228/numpy-2.4.6-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:8155154c7c691289fe18f510b5d4657c68c67989f293f0535a91360392ff6538", size = 6798936, upload-time = "2026-05-18T23:33:22.987Z" },
+    { url = "https://files.pythonhosted.org/packages/33/a8/6fa8c1a345a8c85dbb21932c447bee07c30a2c2a3f31e369c0a84b300147/numpy-2.4.6-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ab0a9c4ffb1a6d95ef519fe4247dba8eb6b18ad93999f76b7f657039acabd47", size = 15966692, upload-time = "2026-05-18T23:33:26.62Z" },
+    { url = "https://files.pythonhosted.org/packages/02/03/74fe2a4cb3817d94d86402f2506554130a2f01414e299b5a843e5a8a957f/numpy-2.4.6-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:89cd468399cfd2504718f0ba50e410dca55a170b61a02ad92bb18c8a65186e93", size = 16918164, upload-time = "2026-05-18T23:33:29.955Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/80/3615be3313f7e7696609bc194b9f0101da809df79e859bdb84e0cd043f46/numpy-2.4.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c2d37ab77531417474168eb79d6d80b14f821a966818505d03013d0833edb7a8", size = 17322877, upload-time = "2026-05-18T23:33:34.724Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/ac/a691e0fe2675e370d0e08ff905adc49a1c8830e8cae03efe4477e92cd55d/numpy-2.4.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f407cb6b8e9d6d8c626bc73c945db1706035af8fd632295547bf1c9e46d092d6", size = 18651487, upload-time = "2026-05-18T23:33:38.217Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a7/9bc1cd626d7bf6869bfedf27b91b6ab5dd607758bf8e959d6fa80c6a59cb/numpy-2.4.6-cp311-cp311-win32.whl", hash = "sha256:ddea102b48f9e339f3948bf22040944184627a30fdf7f858667673b9c5f033c8", size = 6233945, upload-time = "2026-05-18T23:33:41.331Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/31/7fc6239c12bce7e931463251cca4426c465e1876ba3cc785402ef4dd8f4e/numpy-2.4.6-cp311-cp311-win_amd64.whl", hash = "sha256:1e254a00cdf42b1e4d5b3d68d33af63268d41340d8885df2ab6470f2e1500147", size = 12608406, upload-time = "2026-05-18T23:33:44.131Z" },
+    { url = "https://files.pythonhosted.org/packages/27/83/140f85a466595a16382996a1bf06b2b54bcd597488921b0c9daaeeda72af/numpy-2.4.6-cp311-cp311-win_arm64.whl", hash = "sha256:ed9749eef4cbd126da3dc1d6bcb3a57f5eb7ac6a6484146bdbf743f552dfc577", size = 10479528, upload-time = "2026-05-18T23:33:50.725Z" },
+    { url = "https://files.pythonhosted.org/packages/95/2a/3d7b5ac8aac24feaf9ad7ed58f45b0bbc06d37e4338ae84c9f2298b570f9/numpy-2.4.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:001fbb8e08d942dd57599e781f2472269ee7f2755fae407b4f67b2f0b17da3f1", size = 16689119, upload-time = "2026-05-18T23:33:54.065Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/12/92c4c131527599e8288d6918e888d88726f84d805d784b771f32408aeaef/numpy-2.4.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ebfb099f8dcf083deef3ac1ca4c1503f387cf76296fcb3816b66f5ecb5f54fdb", size = 14699246, upload-time = "2026-05-18T23:33:57.621Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/fe/c0a6b7b2ca128a8fb228575147073b660656734b8ebe4d76c8fd748dcc79/numpy-2.4.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:3213d622a0283a39a93d188f3cf72b26862df52fbb4ca3697f51705016523d41", size = 5204410, upload-time = "2026-05-18T23:34:00.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d4/9770d14ba719432bb90a421bfd443872ed0f70f7264b64bec12ea363d5fd/numpy-2.4.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:357cc07a6d7b0b182ff02249616a03742827ebb1277546b5c7cd7f7620a45698", size = 6551240, upload-time = "2026-05-18T23:34:02.852Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c6/50a46a6205feba2343f1d6d17438107c5dc491ed1c736e6ea68689fd906b/numpy-2.4.6-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f9fb9157b4ce2971008323afe46053787b526ef624fea915b261468a8421a0f", size = 15671012, upload-time = "2026-05-18T23:34:05.485Z" },
+    { url = "https://files.pythonhosted.org/packages/99/60/14115e6364fa676c5397c2ad3004e527e9aa487abf5d0706ec81bbd08529/numpy-2.4.6-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90f9849678c75fe7afa2d348ac842c168b0a4d3d61919687216dfc547976d853", size = 16645538, upload-time = "2026-05-18T23:34:09.265Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/c5/693cbe59e57db94d2231fa519ca3978dc9e19da5a8f088588f5c6e947ff2/numpy-2.4.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c1a2af6c6ef86344a6b0db6b97834208bf598db514f2b155042439b62605601a", size = 17020706, upload-time = "2026-05-18T23:34:13.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/fc/85b7c4eff9b4966ade25c2273cf7e7012e92366c032058653934b37de044/numpy-2.4.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e5805d5a22fd19c8ccff10a9561f9df94436b0545619ea579db2d3c35294bce2", size = 18368541, upload-time = "2026-05-18T23:34:17.024Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/81/e1b27545deedce7f4a0b348618c6b62d74e36a4dc9ccd42f3eb2f85eee32/numpy-2.4.6-cp312-cp312-win32.whl", hash = "sha256:e3eeb0aabd6bd5ce64faae67e9935203a6991b4bc2a485a767fbafb2c5125f45", size = 5962825, upload-time = "2026-05-18T23:34:20.3Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ca/feab00bd44aa5fe1ad2c18f08b4d3bb92e26484b0b1d1443897809ed528c/numpy-2.4.6-cp312-cp312-win_amd64.whl", hash = "sha256:d8e8286dd7cea7895157318d1b91cdacac64c479f3cbc8dce548331728484751", size = 12321687, upload-time = "2026-05-18T23:34:23.095Z" },
+    { url = "https://files.pythonhosted.org/packages/63/cf/5a6d34850a39d1093558564f77ee8e8e0bee5061151b8f05a55711001ec7/numpy-2.4.6-cp312-cp312-win_arm64.whl", hash = "sha256:4081eb135ac24158bd51cdfbef16f1c64df7063b1143f24731387137c092bec8", size = 10221482, upload-time = "2026-05-18T23:34:25.876Z" },
+    { url = "https://files.pythonhosted.org/packages/de/12/b422cc84439adc0d00de605bf4a308890ae5c26f2c71fbd73e5d08fbb0dd/numpy-2.4.6-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:55cced7c52e981362f708ad635198e97a752dfba412cc03c23bbf3bd8d5cd662", size = 16847511, upload-time = "2026-05-18T23:36:50.673Z" },
+    { url = "https://files.pythonhosted.org/packages/44/53/f481bef68011740f8849418d82db07230e825013f31f4eef5ba5b805316a/numpy-2.4.6-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:d6da64deb6b8ed903e7560180a92f2d804ee1ba5eeb849ac2748b8c1aba1f6d7", size = 14889064, upload-time = "2026-05-18T23:36:53.879Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/57/42ed575c10ced8af951d426bc4e1f8aff16fd851db33f067036215a7f860/numpy-2.4.6-pp311-pypy311_pp73-macosx_14_0_arm64.whl", hash = "sha256:68a5124b13fa6cc2086764a20005d30bc0548146f7f5322f02fce212ca14317f", size = 5394157, upload-time = "2026-05-18T23:36:57.194Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/ef/f66cc724fcc36c1e364c67f51ae9146090b8b584f27d58b97fdae3edd737/numpy-2.4.6-pp311-pypy311_pp73-macosx_14_0_x86_64.whl", hash = "sha256:948424b06129ce883307e8cff868c31396d8dc7630a59c61d70d98dbe70f222c", size = 6708728, upload-time = "2026-05-18T23:36:59.575Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/9c/c531f2293b91265d8b48e9b329f54fdd7ffae73cb4134ea10cca4237e9cc/numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5dbbdb29840ca3d91ee0fece42fc29278886d908280bfec0a5846c6f901a3eb0", size = 15798374, upload-time = "2026-05-18T23:37:02.674Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/b0/413077f6b1153ed3cba361401c6783bbad6114804a000cc22eb71c13e190/numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8ad03c0965fb3c692200e74d458ca28c1dbb4ce96f9a479a8aa041ad5fabca02", size = 16747286, upload-time = "2026-05-18T23:37:06.327Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ce/e5ec180bc41812edcd8daeb8639d205622c0e8c02259d8ab25a0201b3c2a/numpy-2.4.6-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:2803abfebfc990042cd494d8ce2d5f82e9d847af6d35ec486923aa19dbad5e73", size = 12504263, upload-time = "2026-05-18T23:37:09.715Z" },
+]
+
+[[package]]
+name = "oauthlib"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pandas"
+version = "2.3.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
+    { name = "pytz", marker = "python_full_version < '3.11'" },
+    { name = "tzdata", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/f7/f425a00df4fcc22b292c6895c6831c0c8ae1d9fac1e024d16f98a9ce8749/pandas-2.3.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:376c6446ae31770764215a6c937f72d917f214b43560603cd60da6408f183b6c", size = 11555763, upload-time = "2025-09-29T23:16:53.287Z" },
+    { url = "https://files.pythonhosted.org/packages/13/4f/66d99628ff8ce7857aca52fed8f0066ce209f96be2fede6cef9f84e8d04f/pandas-2.3.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e19d192383eab2f4ceb30b412b22ea30690c9e618f78870357ae1d682912015a", size = 10801217, upload-time = "2025-09-29T23:17:04.522Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/03/3fc4a529a7710f890a239cc496fc6d50ad4a0995657dccc1d64695adb9f4/pandas-2.3.3-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5caf26f64126b6c7aec964f74266f435afef1c1b13da3b0636c7518a1fa3e2b1", size = 12148791, upload-time = "2025-09-29T23:17:18.444Z" },
+    { url = "https://files.pythonhosted.org/packages/40/a8/4dac1f8f8235e5d25b9955d02ff6f29396191d4e665d71122c3722ca83c5/pandas-2.3.3-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dd7478f1463441ae4ca7308a70e90b33470fa593429f9d4c578dd00d1fa78838", size = 12769373, upload-time = "2025-09-29T23:17:35.846Z" },
+    { url = "https://files.pythonhosted.org/packages/df/91/82cc5169b6b25440a7fc0ef3a694582418d875c8e3ebf796a6d6470aa578/pandas-2.3.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:4793891684806ae50d1288c9bae9330293ab4e083ccd1c5e383c34549c6e4250", size = 13200444, upload-time = "2025-09-29T23:17:49.341Z" },
+    { url = "https://files.pythonhosted.org/packages/10/ae/89b3283800ab58f7af2952704078555fa60c807fff764395bb57ea0b0dbd/pandas-2.3.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:28083c648d9a99a5dd035ec125d42439c6c1c525098c58af0fc38dd1a7a1b3d4", size = 13858459, upload-time = "2025-09-29T23:18:03.722Z" },
+    { url = "https://files.pythonhosted.org/packages/85/72/530900610650f54a35a19476eca5104f38555afccda1aa11a92ee14cb21d/pandas-2.3.3-cp310-cp310-win_amd64.whl", hash = "sha256:503cf027cf9940d2ceaa1a93cfb5f8c8c7e6e90720a2850378f0b3f3b1e06826", size = 11346086, upload-time = "2025-09-29T23:18:18.505Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/fa/7ac648108144a095b4fb6aa3de1954689f7af60a14cf25583f4960ecb878/pandas-2.3.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:602b8615ebcc4a0c1751e71840428ddebeb142ec02c786e8ad6b1ce3c8dec523", size = 11578790, upload-time = "2025-09-29T23:18:30.065Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/35/74442388c6cf008882d4d4bdfc4109be87e9b8b7ccd097ad1e7f006e2e95/pandas-2.3.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8fe25fc7b623b0ef6b5009149627e34d2a4657e880948ec3c840e9402e5c1b45", size = 10833831, upload-time = "2025-09-29T23:38:56.071Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/e4/de154cbfeee13383ad58d23017da99390b91d73f8c11856f2095e813201b/pandas-2.3.3-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b468d3dad6ff947df92dcb32ede5b7bd41a9b3cceef0a30ed925f6d01fb8fa66", size = 12199267, upload-time = "2025-09-29T23:18:41.627Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c9/63f8d545568d9ab91476b1818b4741f521646cbdd151c6efebf40d6de6f7/pandas-2.3.3-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b98560e98cb334799c0b07ca7967ac361a47326e9b4e5a7dfb5ab2b1c9d35a1b", size = 12789281, upload-time = "2025-09-29T23:18:56.834Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/00/a5ac8c7a0e67fd1a6059e40aa08fa1c52cc00709077d2300e210c3ce0322/pandas-2.3.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37b5848ba49824e5c30bedb9c830ab9b7751fd049bc7914533e01c65f79791", size = 13240453, upload-time = "2025-09-29T23:19:09.247Z" },
+    { url = "https://files.pythonhosted.org/packages/27/4d/5c23a5bc7bd209231618dd9e606ce076272c9bc4f12023a70e03a86b4067/pandas-2.3.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:db4301b2d1f926ae677a751eb2bd0e8c5f5319c9cb3f88b0becbbb0b07b34151", size = 13890361, upload-time = "2025-09-29T23:19:25.342Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/59/712db1d7040520de7a4965df15b774348980e6df45c129b8c64d0dbe74ef/pandas-2.3.3-cp311-cp311-win_amd64.whl", hash = "sha256:f086f6fe114e19d92014a1966f43a3e62285109afe874f067f5abbdcbb10e59c", size = 11348702, upload-time = "2025-09-29T23:19:38.296Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/fb/231d89e8637c808b997d172b18e9d4a4bc7bf31296196c260526055d1ea0/pandas-2.3.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d21f6d74eb1725c2efaa71a2bfc661a0689579b58e9c0ca58a739ff0b002b53", size = 11597846, upload-time = "2025-09-29T23:19:48.856Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/bd/bf8064d9cfa214294356c2d6702b716d3cf3bb24be59287a6a21e24cae6b/pandas-2.3.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3fd2f887589c7aa868e02632612ba39acb0b8948faf5cc58f0850e165bd46f35", size = 10729618, upload-time = "2025-09-29T23:39:08.659Z" },
+    { url = "https://files.pythonhosted.org/packages/57/56/cf2dbe1a3f5271370669475ead12ce77c61726ffd19a35546e31aa8edf4e/pandas-2.3.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ecaf1e12bdc03c86ad4a7ea848d66c685cb6851d807a26aa245ca3d2017a1908", size = 11737212, upload-time = "2025-09-29T23:19:59.765Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/63/cd7d615331b328e287d8233ba9fdf191a9c2d11b6af0c7a59cfcec23de68/pandas-2.3.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b3d11d2fda7eb164ef27ffc14b4fcab16a80e1ce67e9f57e19ec0afaf715ba89", size = 12362693, upload-time = "2025-09-29T23:20:14.098Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/de/8b1895b107277d52f2b42d3a6806e69cfef0d5cf1d0ba343470b9d8e0a04/pandas-2.3.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a68e15f780eddf2b07d242e17a04aa187a7ee12b40b930bfdd78070556550e98", size = 12771002, upload-time = "2025-09-29T23:20:26.76Z" },
+    { url = "https://files.pythonhosted.org/packages/87/21/84072af3187a677c5893b170ba2c8fbe450a6ff911234916da889b698220/pandas-2.3.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:371a4ab48e950033bcf52b6527eccb564f52dc826c02afd9a1bc0ab731bba084", size = 13450971, upload-time = "2025-09-29T23:20:41.344Z" },
+    { url = "https://files.pythonhosted.org/packages/86/41/585a168330ff063014880a80d744219dbf1dd7a1c706e75ab3425a987384/pandas-2.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:a16dcec078a01eeef8ee61bf64074b4e524a2a3f4b3be9326420cabe59c4778b", size = 10992722, upload-time = "2025-09-29T23:20:54.139Z" },
+]
+
+[[package]]
+name = "pandas"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.11' and sys_platform == 'win32'",
+    "python_full_version >= '3.11' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
+    { name = "tzdata", marker = "(python_full_version >= '3.11' and sys_platform == 'emscripten') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/87/4341c6252d1c47b08768c3d25ac487362bf403f0313ddae4a2a26c9b1b4c/pandas-3.0.3.tar.gz", hash = "sha256:696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc", size = 4651414, upload-time = "2026-05-11T18:54:29.21Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/16/b5c76b838fd9bf6ce84d3a53346b8874ec05c5f0040d75ef2c320100cd2a/pandas-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:455f6f8139d4282188f526868dbc3c828470e88a3d9d59a891bd46a455f21b98", size = 10338495, upload-time = "2026-05-11T18:52:11.558Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/b0/a4ffc4ae74d2d822200dcc46898987d8eb6032d1e2b219cae39da6f5cbcc/pandas-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4e15135e2ee5df1063313e2425ceef8ac0f4ae775893815b0923651b806a5639", size = 9938250, upload-time = "2026-05-11T18:52:17.005Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b2/3323601a52caee42c019e370090ca4544b241437240ca04f786cce82b0cf/pandas-3.0.3-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:05f1f1752b8533ea03f7f39a9c15b1a058d067bb48f4748948e7a8691e0510f2", size = 10770558, upload-time = "2026-05-11T18:52:19.865Z" },
+    { url = "https://files.pythonhosted.org/packages/32/f1/bbecd2f867b97abebe0f9b53d750f862251b40337e061b36676ded3d920f/pandas-3.0.3-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8a1e45c80cceb3b4a21bc5939d52e8cbd8d9b7305309219d59e9754d9ce09e27", size = 11274611, upload-time = "2026-05-11T18:52:22.622Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/4f/eafabf2d5fae5adf143b4d18d3706c5efdc368a7c4eb1ee8a3eddabbd0f6/pandas-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:14da8316da4d0c5a77618425996bfb1248ca87fc2c1486e6fde4652bd18b5824", size = 11784670, upload-time = "2026-05-11T18:52:25.4Z" },
+    { url = "https://files.pythonhosted.org/packages/49/44/1eb20389301b57b19cc099a1c2f662501f72f08a65f912d05822613c1532/pandas-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a55066a0505dae0ba2b50a46637db34b46f9094c65c5d4800794ef6335010938", size = 12353708, upload-time = "2026-05-11T18:52:28.139Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/62/c321f13b5ba1819fc8dca456c7fce578da2dcfecff1abbf0eaddf8406c0f/pandas-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:6674ab18ad8c57802867264b00e15e7bb904700cdd9046e3b2fa1fce237439ea", size = 9907609, upload-time = "2026-05-11T18:52:30.982Z" },
+    { url = "https://files.pythonhosted.org/packages/53/85/1b7f563ebc6357c27233a02a96b589bcce1fa9c6eb89fb4f0e56421d277e/pandas-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:5cc09a68b3120e0f54870dede8287a7bb1fa463907e4fcec1ea77cab6179bf7a", size = 9165596, upload-time = "2026-05-11T18:52:33.334Z" },
+    { url = "https://files.pythonhosted.org/packages/24/f1/392f8c5bfc16f66a0d2d41561c01627c228fe7ed2a0d056ef11315042570/pandas-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fed2ff7fd9779120e388e285fc029bd5cf9490cdd2e4166a9ee22c0e49a9ab09", size = 10357846, upload-time = "2026-05-11T18:52:36.143Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/3d/b16412745651e855f357e5e66930248688378853a6e2698a214e331fba1f/pandas-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b168fc218fd80a6cbdbdbc1a97ddc7889ed057d7eb45f50d866ceab5f39904c4", size = 9899550, upload-time = "2026-05-11T18:52:38.976Z" },
+    { url = "https://files.pythonhosted.org/packages/31/a8/fa2535168fffcedf67f4f6de28d2dd903a747ca7c8ea6989451aaeb3a92f/pandas-3.0.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0383c72c75cdcca61a9e116e611143902dbfd08bff356829c2f6d1cf40a9ca8c", size = 10412965, upload-time = "2026-05-11T18:52:41.915Z" },
+    { url = "https://files.pythonhosted.org/packages/65/b6/09b01cdbc15224e2850365192d17b7bdebb8bdbd8780ed221fcdf0d9a515/pandas-3.0.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6dc0b3fd2169c9157deed50b4d519553a3655c8c6a96027136d654592be973a9", size = 10894600, upload-time = "2026-05-11T18:52:45.02Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/a4/2eb28f2fccb4ced4a2c79ab2a5dee9ade1ebf44922ebad6fea158c9f95d4/pandas-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7e65d5407dc0b394f509699650e4a2ec01c0514f21850f453fa60f3be79a5dbf", size = 11422824, upload-time = "2026-05-11T18:52:48.058Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/45/830bb57f533a4604b355e07edcb8ea18cf88b5f94e5fca92f27052d7c597/pandas-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f8894dc474d648fe7b6ff0ca9b0bd73950d19952bc1a6534540762c5d79d305c", size = 11950889, upload-time = "2026-05-11T18:52:50.905Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/c5/fc1b368f303087d20e8c9bf3d6ceb186263cfac0ade735cd938538bea839/pandas-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:c7be265b62cef88e253a941e4698604973736dcfe242fdb5198f0f7bc473cdcc", size = 9755463, upload-time = "2026-05-11T18:52:53.386Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bd/fda8f9705b1b09c6ebe14bfc0fa0e4ec8584d54ea673628f157ff55131af/pandas-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:557409bc4178e70ee8d9ddb494798e51ebf6ea59330f6be22c51bab2a7db6c49", size = 9066158, upload-time = "2026-05-11T18:52:56.038Z" },
+]
+
+[[package]]
+name = "parso"
+version = "0.8.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/4b/90c937815137d43ce71ba043cd3566221e9df6b9c805f24b5d138c9d40a7/parso-0.8.7.tar.gz", hash = "sha256:eaaac4c9fdd5e9e8852dc778d2d7405897ec510f2a298071453e5e3a07914bb1", size = 401824, upload-time = "2026-05-01T23:13:02.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/5d/8268b644392ee874ee82a635cd0df1773de230bde356c38de28e298392cc/parso-0.8.7-py2.py3-none-any.whl", hash = "sha256:a8926eb2a1b915486941fdbd31e86a4baf88fe8c210f25f2f35ecec5b574ca1c", size = 107025, upload-time = "2026-05-01T23:12:58.867Z" },
+]
+
+[[package]]
+name = "pexpect"
+version = "4.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ptyprocess", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523", size = 63772, upload-time = "2023-11-25T06:56:14.81Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "prompt-toolkit"
+version = "3.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
+
+[[package]]
+name = "propcache"
+version = "0.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/44/c87281c333769159c50594f22610f77398a47ccbfbbf23074e744e86f87c/propcache-0.5.2.tar.gz", hash = "sha256:01c4fc7480cd0598bb4b57022df55b9ca296da7fc5a8760bd8451a7e63a7d427", size = 50208, upload-time = "2026-05-08T21:02:12.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/56/030b7b4719d53085722893e0009dffb9236aa10bca1b12121bdc5626ef16/propcache-0.5.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d5a81be28596d6559f6131ef33e10200de6e17643b3c74ce03f9eb103be6ae8b", size = 93417, upload-time = "2026-05-08T20:59:15.597Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/55/1140a8e067b8ec093a18a4ae7bb0045d9db65da38a08618ddc5e2f1994aa/propcache-0.5.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:29cbaac5ea0212663e6845e04b5e188d5a6ae6dd919810ac835bf1d3b42c3f4c", size = 53847, upload-time = "2026-05-08T20:59:17.096Z" },
+    { url = "https://files.pythonhosted.org/packages/20/42/0e7443c90310498561addf346e7d57fe3c6ba1914e1ba938b5464c7bbfd2/propcache-0.5.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6bf3be92233808fcd338eba0fb4d0b59ec5772af4f4ecfcec450d1bfc0f8b5eb", size = 53512, upload-time = "2026-05-08T20:59:18.64Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/db/cf51a71bab2009517d1a7f0ee07657e3bd446c4d69f67e6966cf17bcf956/propcache-0.5.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2f8ea531c794b9d6274acd4e8d2c2ebcac590a4361d27482edd3010b79f1325e", size = 58068, upload-time = "2026-05-08T20:59:20.683Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/43/39b6bdee9699fa1e1641c519feeb64a67e2a9f93bb465c70776b37a7333f/propcache-0.5.2-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:decfca4c79dd53ebab484b00cc4b6717d8c369f86e74aa4ca395a64ac651495e", size = 61020, upload-time = "2026-05-08T20:59:22.112Z" },
+    { url = "https://files.pythonhosted.org/packages/26/0b/843726fbb0a29a8c5684fdb25971823638399f31e52e9d1f06a02dc9aa6b/propcache-0.5.2-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4621064bbf28fa77ff64dd5d94367c04684c67d3a5bf1dff25f0cd0d98a38f3b", size = 62732, upload-time = "2026-05-08T20:59:23.805Z" },
+    { url = "https://files.pythonhosted.org/packages/39/6e/899fed76dc1942b8a64193a4f059d7f1a2c7ef65085e8a9366ed8ec0d199/propcache-0.5.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b96db7141a592cbc968daf1feea83a118e6ab378af4abbc72b248c895414c22d", size = 60140, upload-time = "2026-05-08T20:59:25.389Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/09/3da4be9b5b879219ad234aa535b3dd4a080ed1ad48d3a73ca07a9e798f22/propcache-0.5.2-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1ca071adabaab6e9219924bbe00af821f1ee7de113a9eca1cdc292de3d120f4d", size = 60400, upload-time = "2026-05-08T20:59:27.238Z" },
+    { url = "https://files.pythonhosted.org/packages/60/2f/09b72b874a9aa0044faf52a69807a6ed618e267ceaa9ec4a63195fa5b504/propcache-0.5.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:e4294d04a94dcab1b3bccd8b66d962dcad411a1d19414b2a41d1445f1de32ad0", size = 58155, upload-time = "2026-05-08T20:59:28.48Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/37/97489848c54c95578045473954f10956d619ce6a09e7ac137b71cdcb698b/propcache-0.5.2-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:a0e399a2eccb91ed18721f86aa85757727400b6865c89e88934781deb9c8498b", size = 57037, upload-time = "2026-05-08T20:59:30.146Z" },
+    { url = "https://files.pythonhosted.org/packages/22/db/6c695285ccfc49012743ee9c98212b8c5dd0aed7b63cfd816d4a0f7a1601/propcache-0.5.2-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:823581fd5cb08b12a48bfa11fe962a7916766b6170c17b028fbdf762b85eb9bf", size = 61103, upload-time = "2026-05-08T20:59:31.626Z" },
+    { url = "https://files.pythonhosted.org/packages/98/a9/1e500401ca593b0bdb6bf75a70bc2d723835fd53360edff6af70692c7546/propcache-0.5.2-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:949c91d1a990cf3b2e8188dfcfb25005e0b834a06c63fa4ef9f360878ce21ecf", size = 60394, upload-time = "2026-05-08T20:59:32.829Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/87/f638b6e375eae0f30a1a2325d8b34fd85fdc785bb9960cf805f3bf1ec69a/propcache-0.5.2-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:cc1177027eda740fdb152706bd215a3f124e3eea15afc39f2cb9fe351b50619e", size = 63084, upload-time = "2026-05-08T20:59:35.964Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/18/884573f5d97b6d9eba68de759a82c901b7e39d7904d30f7b8d58d42d2a12/propcache-0.5.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:b05d643f944a8c3c4bd86d65ffd87bf3264b617f87791940302bc474d2ff5274", size = 60999, upload-time = "2026-05-08T20:59:38.481Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/1a/c3915eb059ceec9e758a56e4cfd955292bc0f201be2176a46b76d94b303a/propcache-0.5.2-cp310-cp310-win32.whl", hash = "sha256:8114f28879e0904748e831c3a7774261bd9e75f49be089f389a76f959dcd13fe", size = 39036, upload-time = "2026-05-08T20:59:40.323Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/02/1dfd5607501a602d19c1c449d2d193b7d1c611f9246b4059026a1189a80e/propcache-0.5.2-cp310-cp310-win_amd64.whl", hash = "sha256:5fcb98e7598b1ee0addab320d90f65b530297a867dbfe9de52ea838077e16e3d", size = 42190, upload-time = "2026-05-08T20:59:42.232Z" },
+    { url = "https://files.pythonhosted.org/packages/57/93/f71588ad08b3e6f4b555b5ef215808a3c02b042d0151ad82fa6f15be677a/propcache-0.5.2-cp310-cp310-win_arm64.whl", hash = "sha256:04dc2390d9edbbaef7461f33322555976ffddf0b650a038649d026358714e6c5", size = 38545, upload-time = "2026-05-08T20:59:44.087Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/f1/8a8cc1c2c7e7934ab77e0163414f736fadbc0f5e8dd9673b952355ac175b/propcache-0.5.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:74b70780220e2dd89175ca24b81b68b67c83db499ae611e7f2313cb329801c78", size = 90744, upload-time = "2026-05-08T20:59:45.799Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f4/651b1225e976bd1a2ba5cfba0c29d096581c2636b437e3a9a7ab6276270a/propcache-0.5.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a4840ab0ae0216d952f4b53dc6d0b992bfc2bedbfe360bdd9b548bc184c08959", size = 52033, upload-time = "2026-05-08T20:59:47.408Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a8/8ede85d6aa1f79fc7dc2f8fd2c8d65920b8272c3892903c8a1affde48cfb/propcache-0.5.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c6844ba6364fb12f403928a82cfd295ab103a2b315c77c747b2dbe4a41894ea7", size = 52754, upload-time = "2026-05-08T20:59:49.202Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/fe/b3551b41bbc2f5b5bb088fc6920567cd43101253e68fbaa261339eb96fe1/propcache-0.5.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2293949b855ce597f2826452d17c2d545fb5622379c4ea6fdf525e9b8e8a2511", size = 57573, upload-time = "2026-05-08T20:59:50.778Z" },
+    { url = "https://files.pythonhosted.org/packages/83/27/ab851ebd1b7172e3e161f5f8d39e315d54a91bea246f01f4d872d3376aef/propcache-0.5.2-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0fd59b5af35f74da48d905dcbad55449ba13be91823cb05a9bd590bbf5b61660", size = 60645, upload-time = "2026-05-08T20:59:52.227Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7d/466b3d18022e9897cbda9c735c493c5bd747d7a4c6f5ea1480b4cec434b6/propcache-0.5.2-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:29f9309a2e42b0d273be006fdb4be2d6c39a47f6f57d8fb1cf9f81481df81b66", size = 61563, upload-time = "2026-05-08T20:59:53.866Z" },
+    { url = "https://files.pythonhosted.org/packages/27/1b/16ab7f2cf2041da2f60d156ba64c2484eadf9168075b4ff43c3ef60045af/propcache-0.5.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5aaa2b923c1944ac8febd6609cb373540a5563e7cbcb0fd770f75dace2eb817b", size = 58888, upload-time = "2026-05-08T20:59:55.457Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/67/bb777ffd907633563bf35fd859c4ce97b0512c32f4633cf5d1eb7c33512b/propcache-0.5.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:66ea454f095ddf5b6b14f56c064c0941c4788be11e18d2464cf643bf7203ff67", size = 59253, upload-time = "2026-05-08T20:59:57.075Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/42/64f8d90b73fd9cdc1499b48057ff6d9cd2a98a25734c9bb62ecf07e87061/propcache-0.5.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:95f1e3f4760d404b13c9976c0229b2b49a3c8e2c62a9ce92efdd2b11ada75e3f", size = 57558, upload-time = "2026-05-08T20:59:58.602Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/02/dba5bc03c9041f2092ea55a449caf5dfe68352c6654511b29ba0654ddb69/propcache-0.5.2-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:85341b12b9d55bad0bded24cac341bb34289469e03a11f3f583ea1cc1db0326c", size = 55007, upload-time = "2026-05-08T20:59:59.837Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c0/43f649c7aa2a77a3b100d84e9dea3a483120ecb608bfe36ce49eaff517fe/propcache-0.5.2-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:26a4dca084132874e639895c3135dfad5eb20bae209f62d1aeb31b03e601c3c0", size = 60355, upload-time = "2026-05-08T21:00:01.144Z" },
+    { url = "https://files.pythonhosted.org/packages/83/c0/435dafd27f1cb4a495381dae60e25883ccfe4020bb72818e8184c1678092/propcache-0.5.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:3b199b9b2b3d6a7edf3183ba8a9a137a22b97f7df525feb5ae1eccf026d2a9c6", size = 59057, upload-time = "2026-05-08T21:00:02.401Z" },
+    { url = "https://files.pythonhosted.org/packages/53/ae/6e292df9135d659944e96cb3389258e4a663e5b2b5f6c217ef0ddc8d2f73/propcache-0.5.2-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:e59bc9e66329185b93dab73f210f1a37f81cb40f321501db8017c9aea15dba27", size = 61938, upload-time = "2026-05-08T21:00:03.638Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/42/314ebc50d8159055411fd6b0bda322ff510e4b1f7d2e4927940ad0f6af20/propcache-0.5.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:552ffadf6ad409844bc5919c42a0a83d88314cedddaea0e41e80a8b8fffe881f", size = 59731, upload-time = "2026-05-08T21:00:04.881Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/9b/2da6dee38871c3c8772fabc2758325a5c9077d6d18c597737dc04dd884cd/propcache-0.5.2-cp311-cp311-win32.whl", hash = "sha256:cd416c1de191973c52ff1a12a57446bfc7642797b282d7caf2162d7d1b8aa9a0", size = 38966, upload-time = "2026-05-08T21:00:06.511Z" },
+    { url = "https://files.pythonhosted.org/packages/42/4e/f17363fb58c0afe05b067361cb6d86ed2d29de6506779a27547c4d183075/propcache-0.5.2-cp311-cp311-win_amd64.whl", hash = "sha256:44e488ef40dbb452700b2b1f8188934121f6648f52c295055662d2191959ff82", size = 42135, upload-time = "2026-05-08T21:00:08.088Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/eb/6af6685077d22e8b33358d3c548e3282706a0b3cd85044ffba4e5dd08e3b/propcache-0.5.2-cp311-cp311-win_arm64.whl", hash = "sha256:54adaa85a22078d1e306304a40984dc5be99d599bf3dc0a24dc98f7daeab89ab", size = 38381, upload-time = "2026-05-08T21:00:09.692Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/cb/e27bc2b2737a0bb49962b275efa051e8f1c35a936df7d5139b6b658b7dc9/propcache-0.5.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:806719138ecd720339a12410fb9614ac9b2b2d3a5fdf8235d56981c36f4039ba", size = 95887, upload-time = "2026-05-08T21:00:11.277Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/13/b8ae04c59392f8d11c6cd9fb4011d1dc7c86b81225c770280300e259ffe1/propcache-0.5.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:db2b80ea58eab4f86b2beec3cc8b39e8ff9276ac20e96b7cce43c8ae84cd6b5a", size = 54654, upload-time = "2026-05-08T21:00:12.604Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/7d/49777a3e20b55863d4794384a38acd460c04157b0a00f8602b0d508b8431/propcache-0.5.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e5cbfac9f61484f7e9f3597775500cd3ebe8274e9b050c38f9525c77c97520bf", size = 55190, upload-time = "2026-05-08T21:00:13.935Z" },
+    { url = "https://files.pythonhosted.org/packages/44/c7/085d0cd63062e84044e3f05797749c3f8e3938ff3aeb0eb2f69d43fafc91/propcache-0.5.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5dbc581d2814337da56222fab8dc5f161cd798a434e49bac27930aaef798e144", size = 59995, upload-time = "2026-05-08T21:00:15.526Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/42/32cf8e3009e92b2645cf1e944f701e8ea4e924dffde1ee26db860bcbf7e4/propcache-0.5.2-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:857187f381f88c8e2fa2fe56ab94879d011b883d5a2ee5a1b60a8cd2a06846d9", size = 63422, upload-time = "2026-05-08T21:00:16.824Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/1b/f112433f99fc979431b87a39ef169e3f8df070d99a72792c56d6937ac48b/propcache-0.5.2-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:178b4a2cdaac1818e2bf1c5a99b94383fa73ea5382e032a48dec07dc5668dc42", size = 64342, upload-time = "2026-05-08T21:00:18.362Z" },
+    { url = "https://files.pythonhosted.org/packages/14/15/5574111ae50dd6e879456888c0eadd4c5a869959775854e18e18a6b345f3/propcache-0.5.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6f328175a2cde1f0ff2c4ed8ce968b9dcfb55f3a7153f39e2957ed994da13476", size = 61639, upload-time = "2026-05-08T21:00:19.692Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/da/4d775080b1490c0ae604acda868bd71aabe3a89ed16f2aa4339eb8a283e7/propcache-0.5.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5671d09a36b06d0fd4a3da0fccbcae360e9b1570924171a15e9e0997f0249fba", size = 61588, upload-time = "2026-05-08T21:00:21.155Z" },
+    { url = "https://files.pythonhosted.org/packages/04/ac/f076982cbe2195ee9cf32de5a1e46951d9fb399fc207f390562dd0fd8fb2/propcache-0.5.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:80168e2ebe4d3ec6599d10ad8f520304ae1cad9b6c5a95372aef1b66b7bfb53a", size = 60029, upload-time = "2026-05-08T21:00:22.713Z" },
+    { url = "https://files.pythonhosted.org/packages/70/60/189be62e0dd898dce3b331e1b8c7a543cd3a405ac0c81fe8ee8a9d5d77e1/propcache-0.5.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:45f11346f884bc47444f6e6647131055844134c3175b629f84952e2b5cd62b64", size = 56774, upload-time = "2026-05-08T21:00:24.001Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/9e/93377b9c7939c1ffae98f878dee955efadfd638078bc86dbc21f9d52f651/propcache-0.5.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:8e778ebd44ef4f66ed60a0416b06b489687db264a9c0b3620362f26489492913", size = 63532, upload-time = "2026-05-08T21:00:25.545Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f9/590ef6cfb9b8028d516d287812ece32bb0bc5f11fbb9c8bf6b2e6313fec8/propcache-0.5.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:c0cb9ed24c8964e172768d455a38254c2dd8a552905729ce006cad3d3dda59b1", size = 61592, upload-time = "2026-05-08T21:00:27.186Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/5e/70958b3034c297a630bba2f17ca7abc2d5f39a803ad7e370ab79d1ecd022/propcache-0.5.2-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:1d1ad32d9d4355e2be65574fd0bfd3677e7066b009cd5b9b2dee8aa6a6393b33", size = 64788, upload-time = "2026-05-08T21:00:28.8Z" },
+    { url = "https://files.pythonhosted.org/packages/12/fd/77fe5936d8c3086ca9048f7f415f122ed82e53884a9ec193646b42deef06/propcache-0.5.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c80f4ba3e8f00189165999a742ee526ebeccedf6c3f7beb0c7df821e9772435a", size = 62514, upload-time = "2026-05-08T21:00:30.098Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/74/66bd798b5b3be70aa1b391f5cc9d6a0a5532d7fd3b19ec0b213e72e6ad9d/propcache-0.5.2-cp312-cp312-win32.whl", hash = "sha256:8c7972d8f193740d9175f0998ab38717e6cd322d5935c5b0fef8c0d323fd9031", size = 39018, upload-time = "2026-05-08T21:00:31.622Z" },
+    { url = "https://files.pythonhosted.org/packages/61/7c/5c0d34aa3024694d6dcb9271cdbdd08c4e47c1c0ad95ec7e7bc74cdea145/propcache-0.5.2-cp312-cp312-win_amd64.whl", hash = "sha256:d9ee8826a7d47863a08ac44e1a5f611a462eefc3a194b492da242128bec75b42", size = 42322, upload-time = "2026-05-08T21:00:32.918Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/91/875812f1a3feb20ceba818ef39fbe4d92f1081e04ac815c822496d0d038b/propcache-0.5.2-cp312-cp312-win_arm64.whl", hash = "sha256:2800a4a8ead6b28cccd1ec54b59346f0def7922ee1c7598e8499c733cfbb7c84", size = 38172, upload-time = "2026-05-08T21:00:35.124Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/ed/1cdcab6ba3d6ab7feca11fc14f0eeea80755bb53ef4e892079f31b10a25f/propcache-0.5.2-py3-none-any.whl", hash = "sha256:be1ddfcbb376e3de5d2e2db1d58d6d67463e6b4f9f040c000de8e300295465fe", size = 14036, upload-time = "2026-05-08T21:02:10.673Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
+]
+
+[[package]]
+name = "ptyprocess"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/e5/16ff212c1e452235a90aeb09066144d0c5a6a8c0834397e03f5224495c4e/ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220", size = 70762, upload-time = "2020-12-28T15:15:30.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35", size = 13993, upload-time = "2020-12-28T15:15:28.35Z" },
+]
+
+[[package]]
+name = "pure-eval"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42", size = 19752, upload-time = "2024-07-21T12:58:21.801Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0", size = 11842, upload-time = "2024-07-21T12:58:20.04Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
+    { name = "pytest" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "python-box"
+version = "7.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/0f/34e7ee0a72f1464b4c7a2e8bafb389f230477256af586bc82bcfad85295a/python_box-7.4.1.tar.gz", hash = "sha256:e412e36c25fca8223560516d53ef6c7993591c3b0ec8bb4ec582bf7defdd79f0", size = 49859, upload-time = "2026-02-21T16:21:16.008Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/7f/0ff288dedf965f504de7a8d9d7353f7b7e57bf18ce9beb328bad49dff026/python_box-7.4.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e724eb25bfda0f1dbbe79c8a35ce8877d8ad7afbdd9396757c6f509f0e742f8c", size = 1877032, upload-time = "2026-02-21T16:21:59.509Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/d0/e211693f3ac4f11b553f214fcf2a2687be42052ad6905832258d451003b7/python_box-7.4.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ee7bb8b0c4d1a07f12454a1edc1a936c4bf952adead3eb40c38aee600a2b605b", size = 4307977, upload-time = "2026-02-21T16:26:01.465Z" },
+    { url = "https://files.pythonhosted.org/packages/47/94/94690a217ecb1333a8d796698176456bc03cdf707d903a6bd1aab022a497/python_box-7.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:526dcc3d82a6957b177313e8704ede431b9add0209b76d716eb232c9a5d283e5", size = 1317804, upload-time = "2026-02-21T16:21:58.2Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/a8/c8bcd3ff0905ec549273ea3485e6b9f2039f57baab419123fb18f964f829/python_box-7.4.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:3f76dad8be9d57d65a3edc792b952f7afe3991515aa6eba616cf5efb2fbb2e0c", size = 1870869, upload-time = "2026-02-21T16:21:34.16Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/bc/9382766d388e258363a18a094e251d2624e3c524614c733d1afa989d9770/python_box-7.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c66582f41a94d46cb0896d468b0efebf9bc4c3a5634cd15373d871767c2e741d", size = 4494287, upload-time = "2026-02-21T16:26:03.131Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/cf/b9d1d4550615f69f6f9c72767f026543442739e5c56adf6f844b50d88251/python_box-7.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:43c62f66d694eb6410f51eb2eb5726f9b466e6f685e5dc90b5cd11f7b3047362", size = 1321085, upload-time = "2026-02-21T16:22:01.093Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/d9/d05f317b38b42253422d8483f5d7dc16d382c99ddc253e426639a0f2f235/python_box-7.4.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:dfb91effff00d9e23486c4f0db3b19e03d602ebb7c9e20fc6a287c704fad2552", size = 1849441, upload-time = "2026-02-21T16:21:37.314Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/a3/383eb3d658f36c6e531c8cf1e348ccb4b5031231df4aeb7742bb159a3166/python_box-7.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b7f977f00e715b030cee6ffef2322ff8ce100ffbf1dbcc4ef91099c75752d5f8", size = 4485153, upload-time = "2026-02-21T16:26:04.507Z" },
+    { url = "https://files.pythonhosted.org/packages/65/f9/5de3c18415dd6f5286f00e6539c0ae3cceb1c6aaf28d1d5f17b0b568c97f/python_box-7.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:2ca9a18fd15326bc267e9cc7e0e6e3a0cb78d11507940f43f687adf7e156d882", size = 1295520, upload-time = "2026-02-21T16:22:26.192Z" },
+    { url = "https://files.pythonhosted.org/packages/06/a6/5d3f3abf46b37aa44b1f6788d287c8b4f2319b55013191dddf25b9e6d62c/python_box-7.4.1-py3-none-any.whl", hash = "sha256:a3b0d84d003882fb6abe505b1b883b3a5dcbf226b0fe168d24bc5ff75d9826e5", size = 30402, upload-time = "2026-02-21T16:21:14.78Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-jsonpath"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/e5/07f99c0fb448eeb2c9db5e817f8a9c43e3f4a7b59934adbe421a39677025/python_jsonpath-2.0.2.tar.gz", hash = "sha256:41abb6660b3ee54d5ae77e4b0e901049fb1662ad90de241f038df47edc75ee60", size = 49672, upload-time = "2026-01-06T08:21:01.194Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/2c/c1282c47a8bb641c3068f47780c5f1f5c97cdc39cda3ec507c64c029764e/python_jsonpath-2.0.2-py3-none-any.whl", hash = "sha256:3f8ab612f815ce10c03bf0deaede87235f3381b109a60b4a22744069953627e3", size = 64071, upload-time = "2026-01-06T08:20:59.751Z" },
+]
+
+[[package]]
+name = "pytz"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/46/dd499ec9038423421951e4fad73051febaa13d2df82b4064f87af8b8c0c3/pytz-2026.2.tar.gz", hash = "sha256:0e60b47b29f21574376f218fe21abc009894a2321ea16c6754f3cad6eb7cdd6a", size = 320861, upload-time = "2026-05-04T01:35:29.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/dd/96da98f892250475bdf2328112d7468abdd4acc7b902b6af23f4ed958ea0/pytz-2026.2-py2.py3-none-any.whl", hash = "sha256:04156e608bee23d3792fd45c94ae47fae1036688e75032eea2e3bf0323d1f126", size = 510141, upload-time = "2026-05-04T01:35:27.408Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/a0/39350dd17dd6d6c6507025c0e53aef67a9293a6d37d3511f23ea510d5800/pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b", size = 184227, upload-time = "2025-09-25T21:31:46.04Z" },
+    { url = "https://files.pythonhosted.org/packages/05/14/52d505b5c59ce73244f59c7a50ecf47093ce4765f116cdb98286a71eeca2/pyyaml-6.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956", size = 174019, upload-time = "2025-09-25T21:31:47.706Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f7/0e6a5ae5599c838c696adb4e6330a59f463265bfa1e116cfd1fbb0abaaae/pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8", size = 740646, upload-time = "2025-09-25T21:31:49.21Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/3a/61b9db1d28f00f8fd0ae760459a5c4bf1b941baf714e207b6eb0657d2578/pyyaml-6.0.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:66291b10affd76d76f54fad28e22e51719ef9ba22b29e1d7d03d6777a9174198", size = 840793, upload-time = "2025-09-25T21:31:50.735Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1e/7acc4f0e74c4b3d9531e24739e0ab832a5edf40e64fbae1a9c01941cabd7/pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c7708761fccb9397fe64bbc0395abcae8c4bf7b0eac081e12b809bf47700d0b", size = 770293, upload-time = "2025-09-25T21:31:51.828Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/ef/abd085f06853af0cd59fa5f913d61a8eab65d7639ff2a658d18a25d6a89d/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:418cf3f2111bc80e0933b2cd8cd04f286338bb88bdc7bc8e6dd775ebde60b5e0", size = 732872, upload-time = "2025-09-25T21:31:53.282Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/15/2bc9c8faf6450a8b3c9fc5448ed869c599c0a74ba2669772b1f3a0040180/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5e0b74767e5f8c593e8c9b5912019159ed0533c70051e9cce3e8b6aa699fcd69", size = 758828, upload-time = "2025-09-25T21:31:54.807Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/00/531e92e88c00f4333ce359e50c19b8d1de9fe8d581b1534e35ccfbc5f393/pyyaml-6.0.3-cp310-cp310-win32.whl", hash = "sha256:28c8d926f98f432f88adc23edf2e6d4921ac26fb084b028c733d01868d19007e", size = 142415, upload-time = "2025-09-25T21:31:55.885Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fa/926c003379b19fca39dd4634818b00dec6c62d87faf628d1394e137354d4/pyyaml-6.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:bdb2c67c6c1390b63c6ff89f210c8fd09d9a1217a465701eac7316313c915e4c", size = 158561, upload-time = "2025-09-25T21:31:57.406Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "oauthlib" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/21/a7d5c126d5b557715ef81098f3db2fe20f622a039ff2e626af28d674ab80/ruff-0.15.13.tar.gz", hash = "sha256:f9d89f17f7ba7fb2ed42921f0df75da797a9a5d71bc39049e2c687cf2baf44b7", size = 4678180, upload-time = "2026-05-14T13:44:37.869Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/61/11d458dc6ac22504fd8e237b29dfd40504c7fbbcc8930402cfe51a8e63ed/ruff-0.15.13-py3-none-linux_armv6l.whl", hash = "sha256:444b580fc72fd6887e650acd3e575e18cdc79dbcf42fb4030b491057921f61f8", size = 10738279, upload-time = "2026-05-14T13:44:18.7Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ca/caa871ee7be718c45256fada4e16a218ee3e33f0c4a46b729a60a24912e6/ruff-0.15.13-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6590d009e7cb7ebf36f83dbdd44a3fa48a0994ff6f1cdc1b08006abe58f98dc7", size = 11124798, upload-time = "2026-05-14T13:44:06.427Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/19/43f5f2e568dddde567fc41f8471f9432c09563e19d3e617a48cfa52f8f0a/ruff-0.15.13-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1c26d2f66163deeb6e08d8b39fbbe983ce3c71cea06a6d7591cfd1421793c629", size = 10460761, upload-time = "2026-05-14T13:44:04.375Z" },
+    { url = "https://files.pythonhosted.org/packages/99/df/cf938cd6de3003178f03ad7c1ea2a6c099468c03a35037985070b37e76be/ruff-0.15.13-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9dbd6f94b434f896308e4d57fb7bfde0d02b99f7a64b3bdab0fdfa6a864203a5", size = 10804451, upload-time = "2026-05-14T13:44:25.221Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/7d/5d0973129b154ded2225729169d7068f26b467760b146493fde138415f23/ruff-0.15.13-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf3259f3be4d181bda591da5db2571aed6853c6a048157756448020bc6c5cd22", size = 10534285, upload-time = "2026-05-14T13:44:08.888Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/e3/6b999bbc66cd51e5f073842bc2a3995e99c5e0e72e16b15e7261f7abf57a/ruff-0.15.13-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae9c17e5eb4430c154e76abc25d79a318190f5a997f38fb6b114416c5319ffc9", size = 11312063, upload-time = "2026-05-14T13:44:11.274Z" },
+    { url = "https://files.pythonhosted.org/packages/af/5a/642639e9f5db04f1e97fbd6e091c6fd20725bdf072fb114d00eefb9e6eb8/ruff-0.15.13-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2e2e39bff6c341f4b577a21b801326fab0b11847f48fcaa83f00a113c9b3cb55", size = 12183079, upload-time = "2026-05-14T13:44:01.634Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4c/7585735f6b53b0f12de13618b2f7d250a844f018822efc899df2e7b8295f/ruff-0.15.13-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e8d9a8e08013542e94d3220bc5b62cc3e5ef87c5f74bff367d3fac14fab013e6", size = 11440833, upload-time = "2026-05-14T13:43:59.043Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/31/bf1a0803d077e679cfeee5f2f67290a0fa79c7385b5d9a8c17b9db2c48f0/ruff-0.15.13-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc411dfebe5eebe55ce041c6ae080eb7668955e866daa2fbb16692a784f1c4ca", size = 11434486, upload-time = "2026-05-14T13:44:27.761Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/4e/62c9b999875d4f14db80f277c030578f5e249c9852d65b7ac7ad0b43c041/ruff-0.15.13-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:768494eb08b9cee54e2fd27969966f74db5a57f6eaa7a90fcb3306af34dfc4bd", size = 11385189, upload-time = "2026-05-14T13:44:13.704Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/89/7e959047a104df3eb12863447c110140191fc5b6c4f379ea2e803fcdb0e4/ruff-0.15.13-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:fb75f9a3a7e42ffe117d734494e6c5e5cb3565d66e12612cb63d0e572a41a5b6", size = 10781380, upload-time = "2026-05-14T13:43:56.734Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/52/5fd18f3b88cab63e88aa11516b3b4e1e5f720e5c330f8dbe5c26210f41f8/ruff-0.15.13-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8cb74dd33bb2f6613faf7fc03b660053b5ac4f80e706d5788c6335e2a8048d51", size = 10540605, upload-time = "2026-05-14T13:44:20.748Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e0/9e35f338990d3e41a82875ff7053ffe97541dae81c9d02143177f381d572/ruff-0.15.13-py3-none-musllinux_1_2_i686.whl", hash = "sha256:7ef823f817fcd191dc934e984be9cf4094f808effa16f2542ad8e821ba02bbf2", size = 11036554, upload-time = "2026-05-14T13:44:16.256Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/13/070fb048c24080fba188f66371e2a92785be257ad02242066dc7255ac6e9/ruff-0.15.13-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:f345a13937bd7f09f6f5d19fa0721b0c103e00e7f62bc67089a8e5e037719e0b", size = 11528133, upload-time = "2026-05-14T13:44:22.808Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/8c/b1e1666aef7fc6555094d73ae6cd981701781ae85b97ceefc0eebd0b4668/ruff-0.15.13-py3-none-win32.whl", hash = "sha256:4044f94208b3b05ba0fc4a4abd0558cf4d6459bd18325eead7fd8cc66f909b41", size = 10721455, upload-time = "2026-05-14T13:44:35.697Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/a6/870a3e8a50590bb92be184ad928c2922f088b00d9dc5c5ec7b924ee08c22/ruff-0.15.13-py3-none-win_amd64.whl", hash = "sha256:7064884d442b7d477b4e7473d12da7f08851d2b1982763c5d3f388a19468a1a4", size = 11900409, upload-time = "2026-05-14T13:44:30.389Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/36/9c015cd052fca743dae8cb2aeb16b551444787467db42ceab0fc968865af/ruff-0.15.13-py3-none-win_arm64.whl", hash = "sha256:2471da9bd1068c8c064b5fd9c0c4b6dddffd6369cb1cd68b29993b1709ff1b21", size = 11179336, upload-time = "2026-05-14T13:44:33.026Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "stack-data"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asttokens" },
+    { name = "executing" },
+    { name = "pure-eval" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707, upload-time = "2023-09-30T13:58:05.479Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521, upload-time = "2023-09-30T13:58:03.53Z" },
+]
+
+[[package]]
+name = "tabulate"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/58/8c37dea7bbf769b20d58e7ace7e5edfe65b849442b00ffcdd56be88697c6/tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d", size = 91754, upload-time = "2026-03-04T18:55:34.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3", size = 39814, upload-time = "2026-03-04T18:55:31.284Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "traitlets"
+version = "5.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/22/40f55b26baeab80c2d7b3f1db0682f8954e4617fee7d90ce634022ef05c6/traitlets-5.15.0.tar.gz", hash = "sha256:4fead733f81cf1c4c938e06f8ca4633896833c9d89eff878159457f4d4392971", size = 163197, upload-time = "2026-05-06T08:05:58.016Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/98/a9937a969d018a23badfea0b381f66783649d48e0ea6c41923265c3cbeb3/traitlets-5.15.0-py3-none-any.whl", hash = "sha256:fb36a18867a6803deab09f3c5e0fa81bb7b26a5c9e82501c9933f759166eff40", size = 85877, upload-time = "2026-05-06T08:05:55.853Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/ee/afaf0f85a9a18fe47a67f1e4422ed6cf1fe642f0ae0a2f81166231303c52/wcwidth-0.7.0.tar.gz", hash = "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0", size = 182132, upload-time = "2026-05-02T16:04:12.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/52/e465037f5375f43533d1a80b6923955201596a99142ed524d77b571a1418/wcwidth-0.7.0-py3-none-any.whl", hash = "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2", size = 110825, upload-time = "2026-05-02T16:04:11.033Z" },
+]
+
+[[package]]
+name = "websocket-client"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
+]
+
+[[package]]
+name = "wsproto"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/79/12135bdf8b9c9367b8701c2c19a14c913c120b882d50b014ca0d38083c2c/wsproto-1.3.2.tar.gz", hash = "sha256:b86885dcf294e15204919950f666e06ffc6c7c114ca900b060d6e16293528294", size = 50116, upload-time = "2025-11-20T18:18:01.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/f5/10b68b7b1544245097b2a1b8238f66f2fc6dcaeb24ba5d917f52bd2eed4f/wsproto-1.3.2-py3-none-any.whl", hash = "sha256:61eea322cdf56e8cc904bd3ad7573359a242ba65688716b0710a5eb12beab584", size = 24405, upload-time = "2025-11-20T18:18:00.454Z" },
+]
+
+[[package]]
+name = "yarl"
+version = "1.23.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "multidict" },
+    { name = "propcache" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/23/6e/beb1beec874a72f23815c1434518bfc4ed2175065173fb138c3705f658d4/yarl-1.23.0.tar.gz", hash = "sha256:53b1ea6ca88ebd4420379c330aea57e258408dd0df9af0992e5de2078dc9f5d5", size = 194676, upload-time = "2026-03-01T22:07:53.373Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/0d/9cc638702f6fc3c7a3685bcc8cf2a9ed7d6206e932a49f5242658047ef51/yarl-1.23.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cff6d44cb13d39db2663a22b22305d10855efa0fa8015ddeacc40bc59b9d8107", size = 123764, upload-time = "2026-03-01T22:04:09.7Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/35/5a553687c5793df5429cd1db45909d4f3af7eee90014888c208d086a44f0/yarl-1.23.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e4c53f8347cd4200f0d70a48ad059cabaf24f5adc6ba08622a23423bc7efa10d", size = 86282, upload-time = "2026-03-01T22:04:11.892Z" },
+    { url = "https://files.pythonhosted.org/packages/68/2e/c5a2234238f8ce37a8312b52801ee74117f576b1539eec8404a480434acc/yarl-1.23.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2a6940a074fb3c48356ed0158a3ca5699c955ee4185b4d7d619be3c327143e05", size = 86053, upload-time = "2026-03-01T22:04:13.292Z" },
+    { url = "https://files.pythonhosted.org/packages/74/3f/bbd8ff36fb038622797ffbaf7db314918bb4d76f1cc8a4f9ca7a55fe5195/yarl-1.23.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ed5f69ce7be7902e5c70ea19eb72d20abf7d725ab5d49777d696e32d4fc1811d", size = 99395, upload-time = "2026-03-01T22:04:15.133Z" },
+    { url = "https://files.pythonhosted.org/packages/77/04/9516bc4e269d2a3ec9c6779fcdeac51ce5b3a9b0156f06ac7152e5bba864/yarl-1.23.0-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:389871e65468400d6283c0308e791a640b5ab5c83bcee02a2f51295f95e09748", size = 92143, upload-time = "2026-03-01T22:04:16.829Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/63/88802d1f6b1cb1fc67d67a58cd0cf8a1790de4ce7946e434240f1d60ab4a/yarl-1.23.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:dda608c88cf709b1d406bdfcd84d8d63cff7c9e577a403c6108ce8ce9dcc8764", size = 107643, upload-time = "2026-03-01T22:04:18.519Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/db/4f9b838f4d8bdd6f0f385aed8bbf21c71ed11a0b9983305c302cbd557815/yarl-1.23.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8c4fe09e0780c6c3bf2b7d4af02ee2394439d11a523bbcf095cf4747c2932007", size = 108700, upload-time = "2026-03-01T22:04:20.373Z" },
+    { url = "https://files.pythonhosted.org/packages/50/12/95a1d33f04a79c402664070d43b8b9f72dc18914e135b345b611b0b1f8cc/yarl-1.23.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:31c9921eb8bd12633b41ad27686bbb0b1a2a9b8452bfdf221e34f311e9942ed4", size = 102769, upload-time = "2026-03-01T22:04:23.055Z" },
+    { url = "https://files.pythonhosted.org/packages/86/65/91a0285f51321369fd1a8308aa19207520c5f0587772cfc2e03fc2467e90/yarl-1.23.0-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5f10fd85e4b75967468af655228fbfd212bdf66db1c0d135065ce288982eda26", size = 101114, upload-time = "2026-03-01T22:04:25.031Z" },
+    { url = "https://files.pythonhosted.org/packages/58/80/c7c8244fc3e5bc483dc71a09560f43b619fab29301a0f0a8f936e42865c7/yarl-1.23.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:dbf507e9ef5688bada447a24d68b4b58dd389ba93b7afc065a2ba892bea54769", size = 98883, upload-time = "2026-03-01T22:04:27.281Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e7/71ca9cc9ca79c0b7d491216177d1aed559d632947b8ffb0ee60f7d8b23e3/yarl-1.23.0-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:85e9beda1f591bc73e77ea1c51965c68e98dafd0fec72cdd745f77d727466716", size = 94172, upload-time = "2026-03-01T22:04:28.554Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/3f/6c6c8a0fe29c26fb2db2e8d32195bb84ec1bfb8f1d32e7f73b787fcf349b/yarl-1.23.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:0e1fdaa14ef51366d7757b45bde294e95f6c8c049194e793eedb8387c86d5993", size = 107010, upload-time = "2026-03-01T22:04:30.385Z" },
+    { url = "https://files.pythonhosted.org/packages/56/38/12730c05e5ad40a76374d440ed8b0899729a96c250516d91c620a6e38fc2/yarl-1.23.0-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:75e3026ab649bf48f9a10c0134512638725b521340293f202a69b567518d94e0", size = 100285, upload-time = "2026-03-01T22:04:31.752Z" },
+    { url = "https://files.pythonhosted.org/packages/34/92/6a7be9239f2347234e027284e7a5f74b1140cc86575e7b469d13fba1ebfe/yarl-1.23.0-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:80e6d33a3d42a7549b409f199857b4fb54e2103fc44fb87605b6663b7a7ff750", size = 108230, upload-time = "2026-03-01T22:04:33.844Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/81/4aebccfa9376bd98b9d8bfad20621a57d3e8cfc5b8631c1fa5f62cdd03f4/yarl-1.23.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5ec2f42d41ccbd5df0270d7df31618a8ee267bfa50997f5d720ddba86c4a83a6", size = 103008, upload-time = "2026-03-01T22:04:35.856Z" },
+    { url = "https://files.pythonhosted.org/packages/38/0f/0b4e3edcec794a86b853b0c6396c0a888d72dfce19b2d88c02ac289fb6c1/yarl-1.23.0-cp310-cp310-win32.whl", hash = "sha256:debe9c4f41c32990771be5c22b56f810659f9ddf3d63f67abfdcaa2c6c9c5c1d", size = 83073, upload-time = "2026-03-01T22:04:38.268Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/71/ad95c33da18897e4c636528bbc24a1dd23fe16797de8bc4ec667b8db0ba4/yarl-1.23.0-cp310-cp310-win_amd64.whl", hash = "sha256:ab5f043cb8a2d71c981c09c510da013bc79fd661f5c60139f00dd3c3cc4f2ffb", size = 87328, upload-time = "2026-03-01T22:04:39.558Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/14/dfa369523c79bccf9c9c746b0a63eb31f65db9418ac01275f7950962e504/yarl-1.23.0-cp310-cp310-win_arm64.whl", hash = "sha256:263cd4f47159c09b8b685890af949195b51d1aa82ba451c5847ca9bc6413c220", size = 82463, upload-time = "2026-03-01T22:04:41.454Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/aa/60da938b8f0997ba3a911263c40d82b6f645a67902a490b46f3355e10fae/yarl-1.23.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:b35d13d549077713e4414f927cdc388d62e543987c572baee613bf82f11a4b99", size = 123641, upload-time = "2026-03-01T22:04:42.841Z" },
+    { url = "https://files.pythonhosted.org/packages/24/84/e237607faf4e099dbb8a4f511cfd5efcb5f75918baad200ff7380635631b/yarl-1.23.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cbb0fef01f0c6b38cb0f39b1f78fc90b807e0e3c86a7ff3ce74ad77ce5c7880c", size = 86248, upload-time = "2026-03-01T22:04:44.757Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/0d/71ceabc14c146ba8ee3804ca7b3d42b1664c8440439de5214d366fec7d3a/yarl-1.23.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dc52310451fc7c629e13c4e061cbe2dd01684d91f2f8ee2821b083c58bd72432", size = 85988, upload-time = "2026-03-01T22:04:46.365Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/6c/4a90d59c572e46b270ca132aca66954f1175abd691f74c1ef4c6711828e2/yarl-1.23.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b2c6b50c7b0464165472b56b42d4c76a7b864597007d9c085e8b63e185cf4a7a", size = 100566, upload-time = "2026-03-01T22:04:47.639Z" },
+    { url = "https://files.pythonhosted.org/packages/49/fb/c438fb5108047e629f6282a371e6e91cf3f97ee087c4fb748a1f32ceef55/yarl-1.23.0-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:aafe5dcfda86c8af00386d7781d4c2181b5011b7be3f2add5e99899ea925df05", size = 92079, upload-time = "2026-03-01T22:04:48.925Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/13/d269aa1aed3e4f50a5a103f96327210cc5fa5dd2d50882778f13c7a14606/yarl-1.23.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9ee33b875f0b390564c1fb7bc528abf18c8ee6073b201c6ae8524aca778e2d83", size = 108741, upload-time = "2026-03-01T22:04:50.838Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/115b16f22c37ea4437d323e472945bea97301c8ec6089868fa560abab590/yarl-1.23.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4c41e021bc6d7affb3364dc1e1e5fa9582b470f283748784bd6ea0558f87f42c", size = 108099, upload-time = "2026-03-01T22:04:52.499Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/64/c53487d9f4968045b8afa51aed7ca44f58b2589e772f32745f3744476c82/yarl-1.23.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:99c8a9ed30f4164bc4c14b37a90208836cbf50d4ce2a57c71d0f52c7fb4f7598", size = 102678, upload-time = "2026-03-01T22:04:55.176Z" },
+    { url = "https://files.pythonhosted.org/packages/85/59/cd98e556fbb2bf8fab29c1a722f67ad45c5f3447cac798ab85620d1e70af/yarl-1.23.0-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f2af5c81a1f124609d5f33507082fc3f739959d4719b56877ab1ee7e7b3d602b", size = 100803, upload-time = "2026-03-01T22:04:56.588Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c0/b39770b56d4a9f0bb5f77e2f1763cd2d75cc2f6c0131e3b4c360348fcd65/yarl-1.23.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6b41389c19b07c760c7e427a3462e8ab83c4bb087d127f0e854c706ce1b9215c", size = 100163, upload-time = "2026-03-01T22:04:58.492Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/64/6980f99ab00e1f0ff67cb84766c93d595b067eed07439cfccfc8fb28c1a6/yarl-1.23.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:1dc702e42d0684f42d6519c8d581e49c96cefaaab16691f03566d30658ee8788", size = 93859, upload-time = "2026-03-01T22:05:00.268Z" },
+    { url = "https://files.pythonhosted.org/packages/38/69/912e6c5e146793e5d4b5fe39ff5b00f4d22463dfd5a162bec565ac757673/yarl-1.23.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:0e40111274f340d32ebcc0a5668d54d2b552a6cca84c9475859d364b380e3222", size = 108202, upload-time = "2026-03-01T22:05:02.273Z" },
+    { url = "https://files.pythonhosted.org/packages/59/97/35ca6767524687ad64e5f5c31ad54bc76d585585a9fcb40f649e7e82ffed/yarl-1.23.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:4764a6a7588561a9aef92f65bda2c4fb58fe7c675c0883862e6df97559de0bfb", size = 99866, upload-time = "2026-03-01T22:05:03.597Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/1c/1a3387ee6d73589f6f2a220ae06f2984f6c20b40c734989b0a44f5987308/yarl-1.23.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:03214408cfa590df47728b84c679ae4ef00be2428e11630277be0727eba2d7cc", size = 107852, upload-time = "2026-03-01T22:05:04.986Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/b8/35c0750fcd5a3f781058bfd954515dd4b1eab45e218cbb85cf11132215f1/yarl-1.23.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:170e26584b060879e29fac213e4228ef063f39128723807a312e5c7fec28eff2", size = 102919, upload-time = "2026-03-01T22:05:06.397Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/1c/9a1979aec4a81896d597bcb2177827f2dbee3f5b7cc48b2d0dadb644b41d/yarl-1.23.0-cp311-cp311-win32.whl", hash = "sha256:51430653db848d258336cfa0244427b17d12db63d42603a55f0d4546f50f25b5", size = 82602, upload-time = "2026-03-01T22:05:08.444Z" },
+    { url = "https://files.pythonhosted.org/packages/93/22/b85eca6fa2ad9491af48c973e4c8cf6b103a73dbb271fe3346949449fca0/yarl-1.23.0-cp311-cp311-win_amd64.whl", hash = "sha256:bf49a3ae946a87083ef3a34c8f677ae4243f5b824bfc4c69672e72b3d6719d46", size = 87461, upload-time = "2026-03-01T22:05:10.145Z" },
+    { url = "https://files.pythonhosted.org/packages/93/95/07e3553fe6f113e6864a20bdc53a78113cda3b9ced8784ee52a52c9f80d8/yarl-1.23.0-cp311-cp311-win_arm64.whl", hash = "sha256:b39cb32a6582750b6cc77bfb3c49c0f8760dc18dc96ec9fb55fbb0f04e08b928", size = 82336, upload-time = "2026-03-01T22:05:11.554Z" },
+    { url = "https://files.pythonhosted.org/packages/88/8a/94615bc31022f711add374097ad4144d569e95ff3c38d39215d07ac153a0/yarl-1.23.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1932b6b8bba8d0160a9d1078aae5838a66039e8832d41d2992daa9a3a08f7860", size = 124737, upload-time = "2026-03-01T22:05:12.897Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/6f/c6554045d59d64052698add01226bc867b52fe4a12373415d7991fdca95d/yarl-1.23.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:411225bae281f114067578891bc75534cfb3d92a3b4dfef7a6ca78ba354e6069", size = 87029, upload-time = "2026-03-01T22:05:14.376Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/725ecc166d53438bc88f76822ed4b1e3b10756e790bafd7b523fe97c322d/yarl-1.23.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:13a563739ae600a631c36ce096615fe307f131344588b0bc0daec108cdb47b25", size = 86310, upload-time = "2026-03-01T22:05:15.71Z" },
+    { url = "https://files.pythonhosted.org/packages/99/30/58260ed98e6ff7f90ba84442c1ddd758c9170d70327394a6227b310cd60f/yarl-1.23.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9cbf44c5cb4a7633d078788e1b56387e3d3cf2b8139a3be38040b22d6c3221c8", size = 97587, upload-time = "2026-03-01T22:05:17.384Z" },
+    { url = "https://files.pythonhosted.org/packages/76/0a/8b08aac08b50682e65759f7f8dde98ae8168f72487e7357a5d684c581ef9/yarl-1.23.0-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:53ad387048f6f09a8969631e4de3f1bf70c50e93545d64af4f751b2498755072", size = 92528, upload-time = "2026-03-01T22:05:18.804Z" },
+    { url = "https://files.pythonhosted.org/packages/52/07/0b7179101fe5f8385ec6c6bb5d0cb9f76bd9fb4a769591ab6fb5cdbfc69a/yarl-1.23.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4a59ba56f340334766f3a4442e0efd0af895fae9e2b204741ef885c446b3a1a8", size = 105339, upload-time = "2026-03-01T22:05:20.235Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/8a/36d82869ab5ec829ca8574dfcb92b51286fcfb1e9c7a73659616362dc880/yarl-1.23.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:803a3c3ce4acc62eaf01eaca1208dcf0783025ef27572c3336502b9c232005e7", size = 105061, upload-time = "2026-03-01T22:05:22.268Z" },
+    { url = "https://files.pythonhosted.org/packages/66/3e/868e5c3364b6cee19ff3e1a122194fa4ce51def02c61023970442162859e/yarl-1.23.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a3d2bff8f37f8d0f96c7ec554d16945050d54462d6e95414babaa18bfafc7f51", size = 100132, upload-time = "2026-03-01T22:05:23.638Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/26/9c89acf82f08a52cb52d6d39454f8d18af15f9d386a23795389d1d423823/yarl-1.23.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c75eb09e8d55bceb4367e83496ff8ef2bc7ea6960efb38e978e8073ea59ecb67", size = 99289, upload-time = "2026-03-01T22:05:25.749Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/54/5b0db00d2cb056922356104468019c0a132e89c8d3ab67d8ede9f4483d2a/yarl-1.23.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:877b0738624280e34c55680d6054a307aa94f7d52fa0e3034a9cc6e790871da7", size = 96950, upload-time = "2026-03-01T22:05:27.318Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/40/10fa93811fd439341fad7e0718a86aca0de9548023bbb403668d6555acab/yarl-1.23.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:b5405bb8f0e783a988172993cfc627e4d9d00432d6bbac65a923041edacf997d", size = 93960, upload-time = "2026-03-01T22:05:28.738Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/d2/8ae2e6cd77d0805f4526e30ec43b6f9a3dfc542d401ac4990d178e4bf0cf/yarl-1.23.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1c3a3598a832590c5a3ce56ab5576361b5688c12cb1d39429cf5dba30b510760", size = 104703, upload-time = "2026-03-01T22:05:30.438Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/0c/b3ceacf82c3fe21183ce35fa2acf5320af003d52bc1fcf5915077681142e/yarl-1.23.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:8419ebd326430d1cbb7efb5292330a2cf39114e82df5cc3d83c9a0d5ebeaf2f2", size = 98325, upload-time = "2026-03-01T22:05:31.835Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/e0/12900edd28bdab91a69bd2554b85ad7b151f64e8b521fe16f9ad2f56477a/yarl-1.23.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:be61f6fff406ca40e3b1d84716fde398fc08bc63dd96d15f3a14230a0973ed86", size = 105067, upload-time = "2026-03-01T22:05:33.358Z" },
+    { url = "https://files.pythonhosted.org/packages/15/61/74bb1182cf79c9bbe4eb6b1f14a57a22d7a0be5e9cedf8e2d5c2086474c3/yarl-1.23.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3ceb13c5c858d01321b5d9bb65e4cf37a92169ea470b70fec6f236b2c9dd7e34", size = 100285, upload-time = "2026-03-01T22:05:35.4Z" },
+    { url = "https://files.pythonhosted.org/packages/69/7f/cd5ef733f2550de6241bd8bd8c3febc78158b9d75f197d9c7baa113436af/yarl-1.23.0-cp312-cp312-win32.whl", hash = "sha256:fffc45637bcd6538de8b85f51e3df3223e4ad89bccbfca0481c08c7fc8b7ed7d", size = 82359, upload-time = "2026-03-01T22:05:36.811Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/be/25216a49daeeb7af2bec0db22d5e7df08ed1d7c9f65d78b14f3b74fd72fc/yarl-1.23.0-cp312-cp312-win_amd64.whl", hash = "sha256:f69f57305656a4852f2a7203efc661d8c042e6cc67f7acd97d8667fb448a426e", size = 87674, upload-time = "2026-03-01T22:05:38.171Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/35/aeab955d6c425b227d5b7247eafb24f2653fedc32f95373a001af5dfeb9e/yarl-1.23.0-cp312-cp312-win_arm64.whl", hash = "sha256:6e87a6e8735b44816e7db0b2fbc9686932df473c826b0d9743148432e10bb9b9", size = 81879, upload-time = "2026-03-01T22:05:40.006Z" },
+    { url = "https://files.pythonhosted.org/packages/69/68/c8739671f5699c7dc470580a4f821ef37c32c4cb0b047ce223a7f115757f/yarl-1.23.0-py3-none-any.whl", hash = "sha256:a2df6afe50dea8ae15fa34c9f824a3ee958d785fd5d089063d960bae1daa0a3f", size = 48288, upload-time = "2026-03-01T22:07:51.388Z" },
+]

--- a/tests/utils/cascade_inject.py
+++ b/tests/utils/cascade_inject.py
@@ -1,0 +1,282 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+cascade_inject — CLI for live fault injection against a long-running
+Dynamo deployment driven by test_cascade_console.py.
+
+The driver test (`test_cascade_console.py`) holds the deployment open and
+exposes a Unix socket at /tmp/cascade-inject-<dgd>.sock. This CLI sends
+JSON commands to that socket and prints the response.
+
+Subcommands all dispatch to existing event classes in tests/fault_tolerance/
+deploy/events.py — the CLI doesn't re-implement faults, just packages them.
+
+Examples (run from anywhere with access to the socket file):
+
+    cascade_inject stall VllmDecodeWorker --duration 30s
+    cascade_inject unstall VllmDecodeWorker
+    cascade_inject partition VllmDecodeWorker VllmPrefillWorker
+    cascade_inject memhog vllm-disagg-...-vllmdecodeworker-XYZ --gb 20 --duration 60s
+    cascade_inject kill vllm-disagg-...-vllmdecodeworker-XYZ
+    cascade_inject load 64
+    cascade_inject dump
+    cascade_inject status
+    cascade_inject quit
+
+Each command also writes a line to /tmp/cascade_events.log (which the TUI
+tails) and POSTs a Grafana annotation if GRAFANA_URL + GRAFANA_TOKEN are set.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import socket
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+DEFAULT_SOCKET_FMT = "/tmp/cascade-inject-{dgd}.sock"
+DEFAULT_EVENT_LOG = Path("/tmp/cascade_events.log")
+
+
+def _socket_path(dgd: str | None, override: str | None) -> Path:
+    if override:
+        return Path(override)
+    if not dgd:
+        # Look for the only socket matching the pattern
+        candidates = list(Path("/tmp").glob("cascade-inject-*.sock"))
+        if len(candidates) == 1:
+            return candidates[0]
+        if not candidates:
+            raise SystemExit(
+                "no cascade-inject sockets found in /tmp; pass --dgd or --socket"
+            )
+        raise SystemExit(
+            f"multiple cascade-inject sockets ({[c.name for c in candidates]}); "
+            "pass --dgd or --socket"
+        )
+    return Path(DEFAULT_SOCKET_FMT.format(dgd=dgd))
+
+
+def send_command(sock_path: Path, payload: dict) -> dict:
+    """Connect to the driver, send one JSON line, read one JSON line back."""
+    if not sock_path.exists():
+        raise SystemExit(
+            f"socket {sock_path} not found — is test_cascade_console running?"
+        )
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    s.connect(str(sock_path))
+    try:
+        s.sendall((json.dumps(payload) + "\n").encode())
+        # Read until newline
+        buf = bytearray()
+        while True:
+            chunk = s.recv(4096)
+            if not chunk:
+                break
+            buf.extend(chunk)
+            if b"\n" in buf:
+                break
+        line, _, _ = buf.partition(b"\n")
+        return json.loads(line.decode()) if line else {}
+    finally:
+        s.close()
+
+
+def append_event_log(text: str, log_path: Path = DEFAULT_EVENT_LOG) -> None:
+    ts = time.strftime("%Y-%m-%dT%H:%M:%S", time.localtime())
+    line = f"{ts}  {text}"
+    try:
+        with log_path.open("a") as f:
+            f.write(line + "\n")
+    except OSError:
+        pass  # event log is best-effort
+
+
+def post_grafana_annotation(
+    text: str,
+    tags: list[str],
+    grafana_url: str | None,
+    token: str | None,
+) -> None:
+    """Best-effort POST to /api/annotations. Silent on failure."""
+    if not grafana_url or not token:
+        return
+    try:
+        import urllib.request
+
+        body = json.dumps(
+            {
+                "time": int(time.time() * 1000),
+                "tags": tags,
+                "text": text,
+            }
+        ).encode()
+        req = urllib.request.Request(
+            url=f"{grafana_url.rstrip('/')}/api/annotations",
+            data=body,
+            method="POST",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+            },
+        )
+        urllib.request.urlopen(req, timeout=2.0).close()
+    except Exception:
+        pass  # annotations are best-effort; don't break the inject flow
+
+
+def _parse_duration(s: str) -> float:
+    """Parse '30s', '5m', '500ms', or bare seconds → float seconds."""
+    s = s.strip()
+    if s.endswith("ms"):
+        return float(s[:-2]) / 1000.0
+    if s.endswith("s"):
+        return float(s[:-1])
+    if s.endswith("m"):
+        return float(s[:-1]) * 60.0
+    return float(s)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.strip().split("\n")[0])
+    ap.add_argument("--dgd", help="DynamoGraphDeployment name (used to find socket)")
+    ap.add_argument(
+        "--socket",
+        help="Override socket path (default: /tmp/cascade-inject-<dgd>.sock)",
+    )
+    ap.add_argument(
+        "--event-log",
+        type=Path,
+        default=DEFAULT_EVENT_LOG,
+        help="Append-only event log file (read by cascade_tui)",
+    )
+
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    # stall
+    p_stall = sub.add_parser("stall", help="SIGSTOP a worker (rank or whole pod)")
+    p_stall.add_argument(
+        "target", help="Service name (e.g. VllmDecodeWorker) or pod name"
+    )
+    p_stall.add_argument(
+        "--duration",
+        default="30s",
+        help="Auto-unstall after this duration. Default 30s.",
+    )
+    p_stall.add_argument(
+        "--process-name",
+        default="dynamo.vllm",
+        help="Substring of the process command to match (default 'dynamo.vllm' = the vllm engine).",
+    )
+
+    # unstall
+    p_unstall = sub.add_parser("unstall", help="SIGCONT a previously stalled worker")
+    p_unstall.add_argument("target", help="Service or pod name")
+
+    # partition
+    p_part = sub.add_parser("partition", help="NetworkPolicy drop between two services")
+    p_part.add_argument("src", help="Source pod or service name")
+    p_part.add_argument("dst", help="Destination pod or service name")
+    p_part.add_argument("--duration", default="30s")
+
+    # unpartition
+    sub.add_parser("unpartition", help="Remove the partition NetworkPolicy")
+
+    # memhog
+    p_mem = sub.add_parser("memhog", help="GPU memory pressure on a pod's node")
+    p_mem.add_argument("target_pod")
+    p_mem.add_argument("--gb", type=float, default=20.0)
+    p_mem.add_argument("--duration", default="60s")
+
+    # kill
+    p_kill = sub.add_parser("kill", help="Force-delete a worker pod")
+    p_kill.add_argument("target_pod")
+
+    # load
+    p_load = sub.add_parser("load", help="Live concurrency change")
+    p_load.add_argument("concurrency", type=int)
+
+    # dump
+    p_dump = sub.add_parser(
+        "dump", help="Snapshot pod manifests + recent logs to log_dir/snapshots/<ts>/"
+    )
+    p_dump.add_argument(
+        "--service",
+        action="append",
+        help="Filter to specific service(s); repeat for multiple",
+    )
+
+    # status
+    sub.add_parser("status", help="Show DGD pod state + last metrics tick")
+
+    # quit
+    sub.add_parser("quit", help="Stop the driver and tear down the deployment")
+
+    args = ap.parse_args()
+    sock_path = _socket_path(args.dgd, args.socket)
+
+    # Build the JSON payload
+    cmd = args.cmd
+    payload: dict[str, Any] = {"cmd": cmd}
+    if cmd == "stall":
+        payload.update(
+            target=args.target,
+            duration_s=_parse_duration(args.duration),
+            process_name=args.process_name,
+        )
+        log_text = f"stall {args.target}/{args.process_name} for {args.duration}"
+    elif cmd == "unstall":
+        payload.update(target=args.target)
+        log_text = f"unstall {args.target}"
+    elif cmd == "partition":
+        payload.update(
+            src=args.src, dst=args.dst, duration_s=_parse_duration(args.duration)
+        )
+        log_text = f"partition {args.src} → {args.dst} for {args.duration}"
+    elif cmd == "unpartition":
+        log_text = "unpartition"
+    elif cmd == "memhog":
+        payload.update(
+            target_pod=args.target_pod,
+            gb=args.gb,
+            duration_s=_parse_duration(args.duration),
+        )
+        log_text = f"memhog {args.target_pod} {args.gb}GB for {args.duration}"
+    elif cmd == "kill":
+        payload.update(target_pod=args.target_pod)
+        log_text = f"kill {args.target_pod}"
+    elif cmd == "load":
+        payload.update(concurrency=args.concurrency)
+        log_text = f"load → concurrency={args.concurrency}"
+    elif cmd == "dump":
+        payload.update(services=args.service or [])
+        log_text = f"dump {args.service or 'all'}"
+    elif cmd == "status":
+        log_text = "status"
+    elif cmd == "quit":
+        log_text = "quit"
+    else:
+        log_text = cmd
+
+    # Send + print response
+    response = send_command(sock_path, payload)
+    print(json.dumps(response, indent=2))
+
+    # Side effects: event log + Grafana annotation
+    if cmd not in ("status",):  # don't pollute the log with status checks
+        append_event_log(log_text, args.event_log)
+        post_grafana_annotation(
+            text=log_text,
+            tags=["cascade", cmd],
+            grafana_url=os.environ.get("GRAFANA_URL"),
+            token=os.environ.get("GRAFANA_TOKEN"),
+        )
+
+    return 0 if response.get("ok", True) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/utils/cascade_tui.py
+++ b/tests/utils/cascade_tui.py
@@ -1,0 +1,549 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+cascade_tui — local TUI for live observation of a Dynamo DGD's per-worker metrics.
+
+Standalone: needs only kubectl + a kubeconfig. No Grafana required. Scrapes each
+worker pod's :9090/metrics directly via kubectl port-forward, parses with aiperf's
+ServerMetricsDataCollector, and renders a textual app showing per-worker:
+
+    pod | component | dp_rank | running | waiting | kv_pct | nixl_p99 | preempt
+
+with 60-sample sparklines underneath each numeric column.
+
+Tails an event log file (default `/tmp/cascade_events.log`) for fault-injection
+markers from the cascade_inject CLI; events show up as bottom-pane log lines and
+mark the next sample on the sparkline.
+
+Press `q` or Ctrl-C to quit. Press `r/w/k/n` to swap the sparkline focus metric
+(running/waiting/kv/nixl).
+
+Usage (from dev container with /root/.kube mounted):
+
+    KUBECONFIG=/root/.kube/config python -m tests.utils.cascade_tui \\
+        --context nv-prd-dgxc.teleport.sh-dynamo-aws-dev-02 \\
+        --namespace neelays-test \\
+        --dgd vllm-disagg-qwen3-30b-2p1d
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import contextlib
+import logging
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger("cascade_tui")
+
+# textual imports gated so --help works even on hosts without textual.
+try:
+    from textual.app import App, ComposeResult
+    from textual.widgets import DataTable, Footer, Header, Log
+
+    HAVE_TEXTUAL = True
+except ImportError:
+    HAVE_TEXTUAL = False
+
+try:
+    from aiperf.common.models import ErrorDetails
+    from aiperf.server_metrics.data_collector import ServerMetricsDataCollector
+
+    HAVE_AIPERF = True
+except ImportError:
+    HAVE_AIPERF = False
+
+
+# Histogram quantile estimator — same as scripts/spike_view.py
+def histogram_quantile(buckets, q: float) -> Optional[float]:
+    if not buckets:
+        return None
+    ordered = []
+    for k, v in buckets.items() if isinstance(buckets, dict) else buckets:
+        try:
+            le = float(k) if k not in ("+Inf", "Inf") else float("inf")
+        except (ValueError, TypeError):
+            continue
+        ordered.append((le, float(v)))
+    ordered.sort()
+    if not ordered or ordered[-1][1] == 0:
+        return None
+    total = ordered[-1][1]
+    target = q * total
+    prev_le, prev_count = 0.0, 0.0
+    for le, count in ordered:
+        if count >= target:
+            if le == float("inf"):
+                return prev_le
+            if count == prev_count:
+                return le
+            frac = (target - prev_count) / (count - prev_count)
+            return prev_le + frac * (le - prev_le)
+        prev_le, prev_count = le, count
+    return ordered[-1][0]
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Pod discovery + port-forward helpers
+
+
+@dataclass
+class Worker:
+    """A single Dynamo worker pod we're scraping."""
+
+    pod_name: str
+    pod_ip: str
+    component: str  # "frontend" / "prefill" / "decode" (from labels)
+    subcomponent: str  # operator's subComponentType
+    local_port: int = 0  # set when port-forward is established
+    pf_proc: Optional[subprocess.Popen] = None
+    collector: Optional[object] = None
+    # Latest scraped values
+    running: float = 0.0
+    waiting: float = 0.0
+    kv_pct: float = 0.0
+    nixl_p99: float = 0.0
+    preempt_total: float = 0.0
+    last_update: float = 0.0
+    # Rolling history for sparklines (1 sample/sec, ~60s)
+    history_running: deque = field(default_factory=lambda: deque(maxlen=60))
+    history_waiting: deque = field(default_factory=lambda: deque(maxlen=60))
+    history_kv: deque = field(default_factory=lambda: deque(maxlen=60))
+    history_nixl: deque = field(default_factory=lambda: deque(maxlen=60))
+
+
+async def discover_workers(
+    namespace: str, dgd_name: str, kube_context: Optional[str]
+) -> list[Worker]:
+    """List pods matching the DGD label and produce Worker descriptors."""
+    from kubernetes_asyncio import client, config
+
+    if kube_context:
+        await config.load_kube_config(context=kube_context)
+    else:
+        await config.load_kube_config()
+
+    v1 = client.CoreV1Api()
+    label_selector = f"nvidia.com/dynamo-graph-deployment-name={dgd_name}"
+    pods = await v1.list_namespaced_pod(
+        namespace=namespace, label_selector=label_selector
+    )
+    workers = []
+    for p in pods.items:
+        if p.status.phase != "Running":
+            continue
+        labels = p.metadata.labels or {}
+        comp = labels.get("nvidia.com/dynamo-component", "?")
+        sub = labels.get("nvidia.com/dynamo-subcomponent", "")
+        workers.append(
+            Worker(
+                pod_name=p.metadata.name,
+                pod_ip=p.status.pod_ip or "",
+                component=comp,
+                subcomponent=sub,
+            )
+        )
+    await v1.api_client.close()
+    return workers
+
+
+def _free_port() -> int:
+    """Reserve a random free local port. (Not race-safe but good enough.)"""
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def start_port_forward(
+    worker: Worker, namespace: str, kube_context: Optional[str]
+) -> None:
+    """Spawn `kubectl port-forward` from a free local port to pod's :9090."""
+    if not shutil.which("kubectl"):
+        raise RuntimeError("kubectl not on PATH — needed for port-forward")
+    worker.local_port = _free_port()
+    cmd = ["kubectl"]
+    if kube_context:
+        cmd += ["--context", kube_context]
+    cmd += [
+        "-n",
+        namespace,
+        "port-forward",
+        f"pod/{worker.pod_name}",
+        f"{worker.local_port}:9090",
+    ]
+    # Discard kubectl's stdout/stderr — chatty; we observe via scraping.
+    worker.pf_proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        stdin=subprocess.DEVNULL,
+    )
+
+
+def stop_port_forward(worker: Worker) -> None:
+    if worker.pf_proc and worker.pf_proc.poll() is None:
+        worker.pf_proc.terminate()
+        try:
+            worker.pf_proc.wait(timeout=2.0)
+        except subprocess.TimeoutExpired:
+            worker.pf_proc.kill()
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Metric extraction from a ServerMetricsRecord
+
+
+METRIC_RUNNING = "vllm:num_requests_running"
+METRIC_WAITING = "vllm:num_requests_waiting"
+METRIC_KV = "vllm:kv_cache_usage_perc"
+METRIC_NIXL_HIST = "vllm:nixl_post_time_seconds"
+METRIC_PREEMPT = "vllm:num_preemptions_total"
+
+
+def update_worker_from_record(worker: Worker, record) -> None:
+    """Pull our 5 metrics out of an aiperf ServerMetricsRecord and update worker state."""
+    metrics = getattr(record, "metrics", None)
+    if not metrics:
+        return
+
+    def first_value(family_name: str) -> Optional[float]:
+        family = metrics.get(family_name)
+        if not family or not getattr(family, "samples", None):
+            return None
+        # If multiple samples (e.g. labeled per dp_rank), aggregate by sum
+        total = 0.0
+        seen = False
+        for s in family.samples:
+            if getattr(s, "value", None) is not None:
+                total += float(s.value)
+                seen = True
+        return total if seen else None
+
+    def first_histogram_p99(family_name: str) -> Optional[float]:
+        family = metrics.get(family_name)
+        if not family or not getattr(family, "samples", None):
+            return None
+        # Aggregate over all samples — sum buckets
+        agg_buckets: dict[float, float] = {}
+        for s in family.samples:
+            buckets = getattr(s, "buckets", None) or {}
+            if isinstance(buckets, dict):
+                items = buckets.items()
+            else:
+                items = buckets
+            for le, cnt in items:
+                try:
+                    le_f = float(le) if str(le) not in ("+Inf", "Inf") else float("inf")
+                except (ValueError, TypeError):
+                    continue
+                agg_buckets[le_f] = agg_buckets.get(le_f, 0.0) + float(cnt)
+        if not agg_buckets:
+            return None
+        return histogram_quantile(agg_buckets, 0.99)
+
+    r = first_value(METRIC_RUNNING)
+    if r is not None:
+        worker.running = r
+        worker.history_running.append(r)
+    w = first_value(METRIC_WAITING)
+    if w is not None:
+        worker.waiting = w
+        worker.history_waiting.append(w)
+    k = first_value(METRIC_KV)
+    if k is not None:
+        worker.kv_pct = k
+        worker.history_kv.append(k)
+    n = first_histogram_p99(METRIC_NIXL_HIST)
+    if n is not None:
+        worker.nixl_p99 = n
+        worker.history_nixl.append(n)
+    p = first_value(METRIC_PREEMPT)
+    if p is not None:
+        worker.preempt_total = p
+    worker.last_update = time.time()
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Sparkline rendering for the table cells
+
+SPARK_CHARS = "▁▂▃▄▅▆▇█"
+
+
+def render_spark(values, width: int = 16) -> str:
+    if not values:
+        return " " * width
+    clean = list(values)
+    if not clean:
+        return " " * width
+    lo, hi = min(clean), max(clean)
+    if lo == hi:
+        return SPARK_CHARS[3] * min(len(clean), width)
+    span = hi - lo
+    n = len(clean)
+    if n <= width:
+        binned = clean
+    else:
+        # Take the latest `width` samples (deque is already capped at maxlen=60 elsewhere)
+        binned = list(clean)[-width:]
+    out = []
+    for v in binned:
+        idx = int((v - lo) / span * (len(SPARK_CHARS) - 1))
+        out.append(SPARK_CHARS[max(0, min(idx, len(SPARK_CHARS) - 1))])
+    return "".join(out)
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Textual app
+
+
+if HAVE_TEXTUAL:
+
+    class CascadeTUI(App):
+        """Live per-worker metrics + event log."""
+
+        CSS = """
+        Screen { layout: vertical; }
+        #workers-table { height: 1fr; }
+        #event-log { height: 10; }
+        """
+        BINDINGS = [
+            ("q", "quit", "Quit"),
+            ("ctrl+c", "quit", "Quit"),
+        ]
+
+        def __init__(
+            self,
+            namespace: str,
+            dgd: str,
+            kube_context: Optional[str],
+            event_log_path: Optional[Path],
+        ):
+            super().__init__()
+            self.namespace = namespace
+            self.dgd = dgd
+            self.kube_context = kube_context
+            self.event_log_path = event_log_path
+            self.workers: list[Worker] = []
+            self._poll_task: Optional[asyncio.Task] = None
+            self._evtlog_task: Optional[asyncio.Task] = None
+            self._evtlog_pos = 0
+
+        def compose(self) -> ComposeResult:
+            yield Header()
+            yield DataTable(id="workers-table", zebra_stripes=True, cursor_type="row")
+            yield Log(id="event-log", highlight=True)
+            yield Footer()
+
+        async def on_mount(self) -> None:
+            tbl = self.query_one("#workers-table", DataTable)
+            tbl.add_column("pod", width=42)
+            tbl.add_column("comp", width=10)
+            tbl.add_column("running", width=24)
+            tbl.add_column("waiting", width=24)
+            tbl.add_column("kv%", width=24)
+            tbl.add_column("nixl_p99 (ms)", width=24)
+            tbl.add_column("preempts", width=10)
+
+            evt = self.query_one("#event-log", Log)
+            evt.write_line(
+                f"discovering pods for DGD={self.dgd} in {self.namespace} ..."
+            )
+            try:
+                self.workers = await discover_workers(
+                    self.namespace, self.dgd, self.kube_context
+                )
+            except Exception as e:
+                evt.write_line(f"ERROR discovering pods: {e}")
+                self.workers = []
+
+            evt.write_line(f"found {len(self.workers)} running pod(s)")
+            for w in self.workers:
+                tbl.add_row(
+                    w.pod_name,
+                    w.component,
+                    "—",
+                    "—",
+                    "—",
+                    "—",
+                    "—",
+                    key=w.pod_name,
+                )
+
+            # Establish port-forwards
+            for w in self.workers:
+                try:
+                    start_port_forward(w, self.namespace, self.kube_context)
+                    evt.write_line(
+                        f"port-forward → {w.pod_name} ({w.component}) "
+                        f"localhost:{w.local_port} → :9090"
+                    )
+                except Exception as e:
+                    evt.write_line(f"port-forward failed for {w.pod_name}: {e}")
+
+            # Give port-forwards a moment to come up before scraping starts
+            await asyncio.sleep(2.0)
+            self._poll_task = asyncio.create_task(self._poll_loop())
+            if self.event_log_path:
+                self._evtlog_task = asyncio.create_task(self._tail_event_log())
+
+        async def _poll_loop(self) -> None:
+            """1Hz scrape of every worker via aiperf collector."""
+            assert HAVE_AIPERF, "aiperf not importable; cannot scrape"
+
+            async def record_cb(records, collector_id: str):
+                # Find the worker by collector_id
+                for w in self.workers:
+                    if str(w.local_port) in collector_id:
+                        for rec in records:
+                            update_worker_from_record(w, rec)
+                        break
+
+            async def error_cb(err: "ErrorDetails", collector_id: str):
+                evt = self.query_one("#event-log", Log)
+                evt.write_line(f"scrape error [{collector_id}]: {err}")
+
+            # Init one collector per worker
+            for w in self.workers:
+                if not w.local_port:
+                    continue
+                w.collector = ServerMetricsDataCollector(
+                    endpoint_url=f"http://127.0.0.1:{w.local_port}/metrics",
+                    collection_interval=1.0,
+                    reachability_timeout=5.0,
+                    record_callback=record_cb,
+                    error_callback=error_cb,
+                    collector_id=f"worker_{w.local_port}",
+                )
+                try:
+                    await w.collector.initialize()
+                    await w.collector.start()
+                except Exception as e:
+                    self.query_one("#event-log", Log).write_line(
+                        f"collector start failed [{w.pod_name}]: {e}"
+                    )
+
+            # Periodic refresh of the table from worker state
+            tbl = self.query_one("#workers-table", DataTable)
+            while not self.is_paused if hasattr(self, "is_paused") else True:
+                for w in self.workers:
+                    self._refresh_row(tbl, w)
+                await asyncio.sleep(1.0)
+
+        def _refresh_row(self, tbl, w: Worker) -> None:
+            spark_w = 16
+            running_cell = (
+                f"{w.running:>5.0f}  {render_spark(w.history_running, spark_w)}"
+            )
+            waiting_cell = (
+                f"{w.waiting:>5.0f}  {render_spark(w.history_waiting, spark_w)}"
+            )
+            kv_cell = f"{w.kv_pct:>5.1%}  {render_spark(w.history_kv, spark_w)}"
+            nixl_ms = w.nixl_p99 * 1000.0 if w.nixl_p99 else 0.0
+            nixl_cell = f"{nixl_ms:>5.1f}  {render_spark(w.history_nixl, spark_w)}"
+            preempt_cell = f"{int(w.preempt_total)}"
+            try:
+                tbl.update_cell(w.pod_name, "running", running_cell)
+                tbl.update_cell(w.pod_name, "waiting", waiting_cell)
+                tbl.update_cell(w.pod_name, "kv%", kv_cell)
+                tbl.update_cell(w.pod_name, "nixl_p99 (ms)", nixl_cell)
+                tbl.update_cell(w.pod_name, "preempts", preempt_cell)
+            except Exception:
+                pass  # row may be transiently unavailable
+
+        async def _tail_event_log(self) -> None:
+            """Tail the cascade-inject event log file and stream lines into the Log widget."""
+            evt_widget = self.query_one("#event-log", Log)
+            path = self.event_log_path
+            assert path is not None
+            # Wait for the file to exist
+            while not path.exists():
+                await asyncio.sleep(1.0)
+            self._evtlog_pos = path.stat().st_size  # only show new lines from now
+            while True:
+                try:
+                    new_size = path.stat().st_size
+                    if new_size > self._evtlog_pos:
+                        with path.open() as f:
+                            f.seek(self._evtlog_pos)
+                            chunk = f.read()
+                            self._evtlog_pos = f.tell()
+                        for line in chunk.splitlines():
+                            if line.strip():
+                                evt_widget.write_line(f"[event] {line}")
+                    elif new_size < self._evtlog_pos:
+                        # File rotated/truncated
+                        self._evtlog_pos = 0
+                except FileNotFoundError:
+                    pass
+                await asyncio.sleep(1.0)
+
+        async def on_unmount(self) -> None:
+            if self._poll_task:
+                self._poll_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await self._poll_task
+            for w in self.workers:
+                if w.collector:
+                    with contextlib.suppress(Exception):
+                        await w.collector.stop()
+                stop_port_forward(w)
+
+
+# ────────────────────────────────────────────────────────────────────────────
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.strip().split("\n")[0])
+    ap.add_argument("--namespace", required=True)
+    ap.add_argument("--dgd", required=True, help="DynamoGraphDeployment name")
+    ap.add_argument(
+        "--context",
+        default=os.environ.get("KUBE_CONTEXT") or None,
+        help="Kubeconfig context (default: current)",
+    )
+    ap.add_argument(
+        "--event-log",
+        type=Path,
+        default=Path("/tmp/cascade_events.log"),
+        help="Path to event log file written by cascade-inject CLI",
+    )
+    ap.add_argument(
+        "--no-event-log",
+        action="store_true",
+        help="Don't tail an event log",
+    )
+    args = ap.parse_args()
+
+    if not HAVE_TEXTUAL:
+        print("error: textual not installed; pip install textual", file=sys.stderr)
+        return 2
+    if not HAVE_AIPERF:
+        print(
+            "error: aiperf not importable; pip install aiperf>=0.7.0",
+            file=sys.stderr,
+        )
+        return 2
+
+    logging.basicConfig(level=logging.WARNING)
+    app = CascadeTUI(
+        namespace=args.namespace,
+        dgd=args.dgd,
+        kube_context=args.context,
+        event_log_path=None if args.no_event_log else args.event_log,
+    )
+    app.run()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/utils/cascade_tui.py
+++ b/tests/utils/cascade_tui.py
@@ -54,8 +54,10 @@ except ImportError:
     HAVE_TEXTUAL = False
 
 try:
-    from aiperf.common.models import ErrorDetails
-    from aiperf.server_metrics.data_collector import ServerMetricsDataCollector
+    from aiperf.common.models import ErrorDetails  # noqa: F401
+    from aiperf.server_metrics.data_collector import (  # noqa: F401
+        ServerMetricsDataCollector,
+    )
 
     HAVE_AIPERF = True
 except ImportError:
@@ -110,14 +112,31 @@ class Worker:
     running: float = 0.0
     waiting: float = 0.0
     kv_pct: float = 0.0
+    nixl_p50: float = 0.0
     nixl_p99: float = 0.0
     preempt_total: float = 0.0
+    ttft_p50: float = 0.0
+    ttft_p99: float = 0.0
+    itl_p50: float = 0.0
+    itl_p99: float = 0.0
+    e2e_p50: float = 0.0
+    e2e_p99: float = 0.0
+    rps: float = 0.0
+    mem_mib: float = 0.0
     last_update: float = 0.0
+    # Counter-tracking for RPS (delta / time)
+    _last_req_count: float = 0.0
+    _last_req_t: float = 0.0
     # Rolling history for sparklines (1 sample/sec, ~60s)
     history_running: deque = field(default_factory=lambda: deque(maxlen=60))
     history_waiting: deque = field(default_factory=lambda: deque(maxlen=60))
     history_kv: deque = field(default_factory=lambda: deque(maxlen=60))
     history_nixl: deque = field(default_factory=lambda: deque(maxlen=60))
+    history_ttft: deque = field(default_factory=lambda: deque(maxlen=60))
+    history_itl: deque = field(default_factory=lambda: deque(maxlen=60))
+    history_e2e: deque = field(default_factory=lambda: deque(maxlen=60))
+    history_rps: deque = field(default_factory=lambda: deque(maxlen=60))
+    history_mem: deque = field(default_factory=lambda: deque(maxlen=60))
 
 
 async def discover_workers(
@@ -164,13 +183,24 @@ def _free_port() -> int:
     return port
 
 
+def _remote_metrics_port(worker: Worker) -> int:
+    """Frontend pods expose /metrics on :8000 (OpenAI port shared with
+    dynamo_frontend_* gauges); worker pods (Prefill/Decode) publish
+    vllm:* metrics on :9090."""
+    if worker.component == "Frontend":
+        return 8000
+    return 9090
+
+
 def start_port_forward(
     worker: Worker, namespace: str, kube_context: Optional[str]
 ) -> None:
-    """Spawn `kubectl port-forward` from a free local port to pod's :9090."""
+    """Spawn `kubectl port-forward` from a free local port to pod's
+    metrics port (8000 for Frontend, 9090 for workers)."""
     if not shutil.which("kubectl"):
         raise RuntimeError("kubectl not on PATH — needed for port-forward")
     worker.local_port = _free_port()
+    remote_port = _remote_metrics_port(worker)
     cmd = ["kubectl"]
     if kube_context:
         cmd += ["--context", kube_context]
@@ -179,7 +209,7 @@ def start_port_forward(
         namespace,
         "port-forward",
         f"pod/{worker.pod_name}",
-        f"{worker.local_port}:9090",
+        f"{worker.local_port}:{remote_port}",
     ]
     # Discard kubectl's stdout/stderr — chatty; we observe via scraping.
     worker.pf_proc = subprocess.Popen(
@@ -274,6 +304,246 @@ def update_worker_from_record(worker: Worker, record) -> None:
 
 
 # ────────────────────────────────────────────────────────────────────────────
+# Direct HTTP scrape — replaces aiperf ServerMetricsDataCollector
+# Robust against aiperf API drift; parses Prometheus exposition format inline.
+
+
+def _parse_prom_text(text: str) -> dict:
+    """Minimal Prometheus exposition-format parser.
+
+    Returns ``{metric_name: {(label_tuple): value}}`` for gauges/counters,
+    plus ``{metric_name + "_bucket": {(label_tuple_without_le, le): count}}``
+    for histograms. Skips HELP/TYPE comments and malformed lines.
+
+    Far simpler than pulling in `prometheus_client` — we only need a handful
+    of metric families and don't care about distinguishing gauge from counter.
+    """
+    out: dict = {}
+    for line in text.splitlines():
+        if not line or line[0] == "#":
+            continue
+        # name{labels} value [timestamp]
+        if "{" in line:
+            name, rest = line.split("{", 1)
+            labels_str, val_str = rest.split("}", 1)
+            val_str = val_str.strip().split()[0]
+            try:
+                val = float(val_str)
+            except ValueError:
+                continue
+            labels = {}
+            for kv in labels_str.split(","):
+                if "=" not in kv:
+                    continue
+                k, v = kv.split("=", 1)
+                labels[k.strip()] = v.strip().strip('"')
+            out.setdefault(name, []).append((labels, val))
+        else:
+            try:
+                name, val_str = line.split(maxsplit=1)
+                val = float(val_str.split()[0])
+            except ValueError:
+                continue
+            out.setdefault(name, []).append(({}, val))
+    return out
+
+
+def _sum_gauge(samples: list, **filter_labels) -> Optional[float]:
+    """Sum values across all samples matching the optional label filters."""
+    if not samples:
+        return None
+    total = 0.0
+    seen = False
+    for labels, val in samples:
+        if any(labels.get(k) != v for k, v in filter_labels.items()):
+            continue
+        total += val
+        seen = True
+    return total if seen else None
+
+
+def _histogram_p99(buckets_samples: list) -> Optional[float]:
+    """Compute p99 from Prometheus histogram bucket samples (le-labeled).
+
+    Aggregates across all label sets by summing bucket counts per `le`.
+    """
+    if not buckets_samples:
+        return None
+    agg: dict[float, float] = {}
+    for labels, val in buckets_samples:
+        le = labels.get("le")
+        if le is None:
+            continue
+        try:
+            le_f = float("inf") if le in ("+Inf", "Inf") else float(le)
+        except ValueError:
+            continue
+        agg[le_f] = agg.get(le_f, 0.0) + val
+    if not agg:
+        return None
+    return histogram_quantile(agg, 0.99)
+
+
+def _histogram_quantiles(buckets_samples: list, *quantiles) -> dict:
+    """Compute multiple quantiles from one aggregated bucket-set.
+
+    Avoids re-walking the per-label samples for each quantile. Returns
+    ``{q: value}`` for each requested q (default p50, p99 if none given).
+    """
+    if not buckets_samples:
+        return {}
+    if not quantiles:
+        quantiles = (0.5, 0.99)
+    agg: dict[float, float] = {}
+    for labels, val in buckets_samples:
+        le = labels.get("le")
+        if le is None:
+            continue
+        try:
+            le_f = float("inf") if le in ("+Inf", "Inf") else float(le)
+        except ValueError:
+            continue
+        agg[le_f] = agg.get(le_f, 0.0) + val
+    if not agg:
+        return {}
+    return {q: histogram_quantile(agg, q) for q in quantiles}
+
+
+async def scrape_worker_metrics_http(worker: Worker, session) -> None:
+    """Fetch /metrics from worker.local_port and update the Worker state.
+
+    Handles both worker pods (vllm:* metrics on :9090) and Frontend pods
+    (dynamo_frontend_* + dynamo_component_router_* on :8000). Uses aiohttp
+    for non-blocking I/O so the textual app stays responsive.
+    """
+    import aiohttp
+
+    url = f"http://localhost:{worker.local_port}/metrics"
+    try:
+        async with session.get(url, timeout=aiohttp.ClientTimeout(total=2.0)) as resp:
+            text = await resp.text()
+    except Exception:
+        return  # transient — try again next tick
+    parsed = _parse_prom_text(text)
+
+    now = time.time()
+    if worker.component == "Frontend":
+        # FE columns — running=active, waiting=disconnects, nixl_p99=N/A
+        # (FE has no NIXL but column header reserved for worker-mode).
+        active = _sum_gauge(parsed.get("dynamo_frontend_active_requests", []))
+        if active is not None:
+            worker.running = active
+            worker.history_running.append(active)
+        disc = _sum_gauge(parsed.get("dynamo_frontend_disconnected_clients", []))
+        if disc is not None:
+            worker.waiting = disc
+            worker.history_waiting.append(disc)
+        ttft_q = _histogram_quantiles(
+            parsed.get("dynamo_component_router_time_to_first_token_seconds_bucket", [])
+        )
+        if 0.5 in ttft_q:
+            worker.ttft_p50 = ttft_q[0.5] or 0.0
+        if 0.99 in ttft_q:
+            worker.ttft_p99 = ttft_q[0.99] or 0.0
+            worker.history_ttft.append(worker.ttft_p99)
+        itl_q = _histogram_quantiles(
+            parsed.get("dynamo_component_router_inter_token_latency_seconds_bucket", [])
+        )
+        if 0.5 in itl_q:
+            worker.itl_p50 = itl_q[0.5] or 0.0
+        if 0.99 in itl_q:
+            worker.itl_p99 = itl_q[0.99] or 0.0
+            worker.history_itl.append(worker.itl_p99)
+        e2e_q = _histogram_quantiles(
+            parsed.get("dynamo_frontend_request_duration_seconds_bucket", [])
+        )
+        if 0.5 in e2e_q:
+            worker.e2e_p50 = e2e_q[0.5] or 0.0
+        if 0.99 in e2e_q:
+            worker.e2e_p99 = e2e_q[0.99] or 0.0
+            worker.history_e2e.append(worker.e2e_p99)
+        # RPS: delta of dynamo_frontend_request_duration_seconds_count / dt
+        req_count = _sum_gauge(
+            parsed.get("dynamo_frontend_request_duration_seconds_count", [])
+        )
+        if req_count is not None:
+            if worker._last_req_t > 0:
+                dt = now - worker._last_req_t
+                worker.rps = (
+                    max(0.0, (req_count - worker._last_req_count) / dt)
+                    if dt > 0
+                    else 0.0
+                )
+                worker.history_rps.append(worker.rps)
+            worker._last_req_count = req_count
+            worker._last_req_t = now
+        stalls = _sum_gauge(parsed.get("dynamo_frontend_event_loop_stall_total", []))
+        if stalls is not None:
+            worker.preempt_total = stalls
+    else:
+        # Worker pods — vllm:* gauges + histograms.
+        r = _sum_gauge(parsed.get(METRIC_RUNNING, []))
+        if r is not None:
+            worker.running = r
+            worker.history_running.append(r)
+        w = _sum_gauge(parsed.get(METRIC_WAITING, []))
+        if w is not None:
+            worker.waiting = w
+            worker.history_waiting.append(w)
+        k = _sum_gauge(parsed.get(METRIC_KV, []))
+        if k is not None:
+            worker.kv_pct = k
+            worker.history_kv.append(k)
+        nixl_q = _histogram_quantiles(parsed.get(f"{METRIC_NIXL_HIST}_bucket", []))
+        if 0.5 in nixl_q:
+            worker.nixl_p50 = nixl_q[0.5] or 0.0
+        if 0.99 in nixl_q:
+            worker.nixl_p99 = nixl_q[0.99] or 0.0
+            worker.history_nixl.append(worker.nixl_p99)
+        ttft_q = _histogram_quantiles(
+            parsed.get("vllm:time_to_first_token_seconds_bucket", [])
+        )
+        if 0.5 in ttft_q:
+            worker.ttft_p50 = ttft_q[0.5] or 0.0
+        if 0.99 in ttft_q:
+            worker.ttft_p99 = ttft_q[0.99] or 0.0
+            worker.history_ttft.append(worker.ttft_p99)
+        itl_q = _histogram_quantiles(
+            parsed.get("vllm:inter_token_latency_seconds_bucket", [])
+        )
+        if 0.5 in itl_q:
+            worker.itl_p50 = itl_q[0.5] or 0.0
+        if 0.99 in itl_q:
+            worker.itl_p99 = itl_q[0.99] or 0.0
+            worker.history_itl.append(worker.itl_p99)
+        e2e_q = _histogram_quantiles(
+            parsed.get("vllm:e2e_request_latency_seconds_bucket", [])
+        )
+        if 0.5 in e2e_q:
+            worker.e2e_p50 = e2e_q[0.5] or 0.0
+        if 0.99 in e2e_q:
+            worker.e2e_p99 = e2e_q[0.99] or 0.0
+            worker.history_e2e.append(worker.e2e_p99)
+        # RPS from vllm:request_success_total (sum over finished_reason labels)
+        req_count = _sum_gauge(parsed.get("vllm:request_success_total", []))
+        if req_count is not None:
+            if worker._last_req_t > 0:
+                dt = now - worker._last_req_t
+                worker.rps = (
+                    max(0.0, (req_count - worker._last_req_count) / dt)
+                    if dt > 0
+                    else 0.0
+                )
+                worker.history_rps.append(worker.rps)
+            worker._last_req_count = req_count
+            worker._last_req_t = now
+        p = _sum_gauge(parsed.get(METRIC_PREEMPT, []))
+        if p is not None:
+            worker.preempt_total = p
+    worker.last_update = now
+
+
+# ────────────────────────────────────────────────────────────────────────────
 # Sparkline rendering for the table cells
 
 SPARK_CHARS = "▁▂▃▄▅▆▇█"
@@ -333,7 +603,7 @@ if HAVE_TEXTUAL:
             self.dgd = dgd
             self.kube_context = kube_context
             self.event_log_path = event_log_path
-            self.workers: list[Worker] = []
+            self.dgd_workers: list[Worker] = []
             self._poll_task: Optional[asyncio.Task] = None
             self._evtlog_task: Optional[asyncio.Task] = None
             self._evtlog_pos = 0
@@ -346,28 +616,37 @@ if HAVE_TEXTUAL:
 
         async def on_mount(self) -> None:
             tbl = self.query_one("#workers-table", DataTable)
-            tbl.add_column("pod", width=42)
-            tbl.add_column("comp", width=10)
-            tbl.add_column("running", width=24)
-            tbl.add_column("waiting", width=24)
-            tbl.add_column("kv%", width=24)
-            tbl.add_column("nixl_p99 (ms)", width=24)
-            tbl.add_column("preempts", width=10)
+            # Explicit column keys so update_cell(row_key, col_key, ...)
+            # in _refresh_row resolves cleanly. Without `key=` textual
+            # uses internal generated keys and update_cell silently fails.
+            # Slim columns to fit a wider set. p99-latency in ms.
+            tbl.add_column("pod", width=42, key="pod")
+            tbl.add_column("comp", width=8, key="comp")
+            tbl.add_column("run", width=14, key="running")
+            tbl.add_column("wait", width=14, key="waiting")
+            tbl.add_column("kv%", width=14, key="kv%")
+            tbl.add_column("rps", width=10, key="rps")
+            tbl.add_column("ttft 50/99 ms", width=18, key="ttft")
+            tbl.add_column("itl 50/99 ms", width=18, key="itl")
+            tbl.add_column("e2e 50/99 ms", width=18, key="e2e")
+            tbl.add_column("nixl 50/99 ms", width=18, key="nixl")
+            tbl.add_column("mem MiB", width=10, key="mem MiB")
+            tbl.add_column("preempts", width=8, key="preempts")
 
             evt = self.query_one("#event-log", Log)
             evt.write_line(
                 f"discovering pods for DGD={self.dgd} in {self.namespace} ..."
             )
             try:
-                self.workers = await discover_workers(
+                self.dgd_workers = await discover_workers(
                     self.namespace, self.dgd, self.kube_context
                 )
             except Exception as e:
                 evt.write_line(f"ERROR discovering pods: {e}")
-                self.workers = []
+                self.dgd_workers = []
 
-            evt.write_line(f"found {len(self.workers)} running pod(s)")
-            for w in self.workers:
+            evt.write_line(f"found {len(self.dgd_workers)} running pod(s)")
+            for w in self.dgd_workers:
                 tbl.add_row(
                     w.pod_name,
                     w.component,
@@ -376,16 +655,23 @@ if HAVE_TEXTUAL:
                     "—",
                     "—",
                     "—",
+                    "—",
+                    "—",
+                    "—",
+                    "—",
+                    "—",
                     key=w.pod_name,
                 )
 
-            # Establish port-forwards
-            for w in self.workers:
+            # Establish port-forwards. Different remote port per component:
+            # Frontend → :8000 (where dynamo_frontend_* + router metrics
+            # are served), workers → :9090 (vllm:* gauges).
+            for w in self.dgd_workers:
                 try:
                     start_port_forward(w, self.namespace, self.kube_context)
                     evt.write_line(
                         f"port-forward → {w.pod_name} ({w.component}) "
-                        f"localhost:{w.local_port} → :9090"
+                        f"localhost:{w.local_port} → :{_remote_metrics_port(w)}"
                     )
                 except Exception as e:
                     evt.write_line(f"port-forward failed for {w.pod_name}: {e}")
@@ -397,68 +683,139 @@ if HAVE_TEXTUAL:
                 self._evtlog_task = asyncio.create_task(self._tail_event_log())
 
         async def _poll_loop(self) -> None:
-            """1Hz scrape of every worker via aiperf collector."""
-            assert HAVE_AIPERF, "aiperf not importable; cannot scrape"
+            """1 Hz direct HTTP scrape of every worker via aiohttp.
 
-            async def record_cb(records, collector_id: str):
-                # Find the worker by collector_id
-                for w in self.workers:
-                    if str(w.local_port) in collector_id:
-                        for rec in records:
-                            update_worker_from_record(w, rec)
-                        break
+            Replaces the (broken under aiperf 0.8) ServerMetricsDataCollector
+            path with a direct Prometheus-text fetch + parser. Same Worker
+            state objects updated; table refresh tick stays at 1 Hz.
+            """
+            import aiohttp
 
-            async def error_cb(err: "ErrorDetails", collector_id: str):
-                evt = self.query_one("#event-log", Log)
-                evt.write_line(f"scrape error [{collector_id}]: {err}")
-
-            # Init one collector per worker
-            for w in self.workers:
-                if not w.local_port:
-                    continue
-                w.collector = ServerMetricsDataCollector(
-                    endpoint_url=f"http://127.0.0.1:{w.local_port}/metrics",
-                    collection_interval=1.0,
-                    reachability_timeout=5.0,
-                    record_callback=record_cb,
-                    error_callback=error_cb,
-                    collector_id=f"worker_{w.local_port}",
-                )
-                try:
-                    await w.collector.initialize()
-                    await w.collector.start()
-                except Exception as e:
-                    self.query_one("#event-log", Log).write_line(
-                        f"collector start failed [{w.pod_name}]: {e}"
-                    )
-
-            # Periodic refresh of the table from worker state
+            evt = self.query_one("#event-log", Log)
             tbl = self.query_one("#workers-table", DataTable)
-            while not self.is_paused if hasattr(self, "is_paused") else True:
-                for w in self.workers:
-                    self._refresh_row(tbl, w)
-                await asyncio.sleep(1.0)
+
+            session = aiohttp.ClientSession()
+
+            async def poll_memory():
+                """Poll kubectl top every 10s for per-pod RSS."""
+                while True:
+                    try:
+                        cmd = [
+                            "kubectl",
+                            "-n",
+                            self.namespace,
+                            "top",
+                            "pod",
+                            "--no-headers",
+                        ]
+                        if self.kube_context:
+                            cmd[:0] = []  # context lives in kubeconfig already
+                        proc = await asyncio.create_subprocess_exec(
+                            *cmd,
+                            stdout=asyncio.subprocess.PIPE,
+                            stderr=asyncio.subprocess.DEVNULL,
+                        )
+                        out, _ = await proc.communicate()
+                        for line in out.decode().splitlines():
+                            parts = line.split()
+                            if len(parts) < 3:
+                                continue
+                            pod_name, _, mem_str = parts[0], parts[1], parts[2]
+                            for w in self.dgd_workers:
+                                if w.pod_name != pod_name:
+                                    continue
+                                # mem_str like "1234Mi" or "1Gi"
+                                try:
+                                    if mem_str.endswith("Mi"):
+                                        m = float(mem_str[:-2])
+                                    elif mem_str.endswith("Gi"):
+                                        m = float(mem_str[:-2]) * 1024
+                                    else:
+                                        m = float(mem_str) / 1048576.0
+                                    w.mem_mib = m
+                                    w.history_mem.append(m)
+                                except ValueError:
+                                    pass
+                                break
+                    except Exception:
+                        pass
+                    await asyncio.sleep(10.0)
+
+            mem_task = asyncio.create_task(poll_memory())
+            try:
+                fail_count: dict[str, int] = {}
+                while True:
+                    # Fan-out concurrent scrapes; gather lets one slow pod
+                    # not block the others.
+                    tasks = []
+                    for w in self.dgd_workers:
+                        if not w.local_port:
+                            continue
+                        tasks.append(scrape_worker_metrics_http(w, session))
+                    if tasks:
+                        results = await asyncio.gather(*tasks, return_exceptions=True)
+                        for w, res in zip(self.dgd_workers, results):
+                            if isinstance(res, Exception):
+                                key = w.pod_name
+                                fail_count[key] = fail_count.get(key, 0) + 1
+                                if fail_count[key] == 5:
+                                    evt.write_line(
+                                        f"scrape error [{w.pod_name}]: {res} "
+                                        "(suppressing further reports)"
+                                    )
+                    for w in self.dgd_workers:
+                        self._refresh_row(tbl, w)
+                    await asyncio.sleep(1.0)
+            finally:
+                mem_task.cancel()
+                await session.close()
 
         def _refresh_row(self, tbl, w: Worker) -> None:
-            spark_w = 16
+            spark_w = 8
             running_cell = (
-                f"{w.running:>5.0f}  {render_spark(w.history_running, spark_w)}"
+                f"{w.running:>4.0f} {render_spark(w.history_running, spark_w)}"
             )
             waiting_cell = (
-                f"{w.waiting:>5.0f}  {render_spark(w.history_waiting, spark_w)}"
+                f"{w.waiting:>4.0f} {render_spark(w.history_waiting, spark_w)}"
             )
-            kv_cell = f"{w.kv_pct:>5.1%}  {render_spark(w.history_kv, spark_w)}"
-            nixl_ms = w.nixl_p99 * 1000.0 if w.nixl_p99 else 0.0
-            nixl_cell = f"{nixl_ms:>5.1f}  {render_spark(w.history_nixl, spark_w)}"
+            kv_cell = f"{w.kv_pct:>5.1%} {render_spark(w.history_kv, spark_w)}"
+            rps_cell = f"{w.rps:>5.1f}"
+
+            def _fmt_pair(p50, p99, hist):
+                p50_ms = p50 * 1000.0 if p50 else 0.0
+                p99_ms = p99 * 1000.0 if p99 else 0.0
+                return f"{p50_ms:>4.0f}/{p99_ms:>4.0f} {render_spark(hist, 6)}"
+
+            ttft_cell = _fmt_pair(w.ttft_p50, w.ttft_p99, w.history_ttft)
+            itl_cell = _fmt_pair(w.itl_p50, w.itl_p99, w.history_itl)
+            e2e_cell = _fmt_pair(w.e2e_p50, w.e2e_p99, w.history_e2e)
+            nixl_cell = _fmt_pair(w.nixl_p50, w.nixl_p99, w.history_nixl)
+            mem_cell = f"{w.mem_mib:>5.0f}"
             preempt_cell = f"{int(w.preempt_total)}"
             try:
                 tbl.update_cell(w.pod_name, "running", running_cell)
                 tbl.update_cell(w.pod_name, "waiting", waiting_cell)
                 tbl.update_cell(w.pod_name, "kv%", kv_cell)
-                tbl.update_cell(w.pod_name, "nixl_p99 (ms)", nixl_cell)
+                tbl.update_cell(w.pod_name, "rps", rps_cell)
+                tbl.update_cell(w.pod_name, "ttft", ttft_cell)
+                tbl.update_cell(w.pod_name, "itl", itl_cell)
+                tbl.update_cell(w.pod_name, "e2e", e2e_cell)
+                tbl.update_cell(w.pod_name, "nixl", nixl_cell)
+                tbl.update_cell(w.pod_name, "mem MiB", mem_cell)
                 tbl.update_cell(w.pod_name, "preempts", preempt_cell)
-            except Exception:
-                pass  # row may be transiently unavailable
+            except Exception as e:
+                # Surface the first failure per pod to the event log so we
+                # can debug; subsequent ones swallowed to avoid spam.
+                key = ("_refresh_err", w.pod_name)
+                if not getattr(self, "_seen_refresh_err", set()):
+                    self._seen_refresh_err = set()
+                if key not in self._seen_refresh_err:
+                    self._seen_refresh_err.add(key)
+                    try:
+                        evt = self.query_one("#event-log", Log)
+                        evt.write_line(f"refresh err [{w.pod_name}]: {e}")
+                    except Exception:
+                        pass
 
         async def _tail_event_log(self) -> None:
             """Tail the cascade-inject event log file and stream lines into the Log widget."""
@@ -492,7 +849,7 @@ if HAVE_TEXTUAL:
                 self._poll_task.cancel()
                 with contextlib.suppress(asyncio.CancelledError):
                     await self._poll_task
-            for w in self.workers:
+            for w in self.dgd_workers:
                 if w.collector:
                     with contextlib.suppress(Exception):
                         await w.collector.stop()

--- a/tests/utils/k8s_helpers.py
+++ b/tests/utils/k8s_helpers.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared Kubernetes client initialization helpers."""
+
+import logging
+import os
+
+from kubernetes_asyncio import client, config
+
+logger = logging.getLogger(__name__)
+
+
+async def init_kubernetes_clients(
+    need_custom_api: bool = False,
+    need_apps_api: bool = False,
+):
+    """Initialize Kubernetes API clients.
+
+    Uses KUBECONFIG env var -> in-cluster config -> default kubeconfig fallback.
+
+    Args:
+        need_custom_api: If True, also return CustomObjectsApi (for CRD operations)
+        need_apps_api: If True, also return AppsV1Api (for StatefulSet operations)
+
+    Returns:
+        Tuple of (core_api, batch_api, custom_api_or_None, apps_api_or_None, in_cluster)
+    """
+    in_cluster = False
+    kubeconfig_path = os.environ.get("KUBECONFIG")
+
+    if kubeconfig_path and os.path.exists(kubeconfig_path):
+        logger.info(f"Loading kubeconfig from KUBECONFIG: {kubeconfig_path}")
+        await config.load_kube_config(config_file=kubeconfig_path)
+        logger.info("Successfully loaded kubeconfig from KUBECONFIG")
+    else:
+        try:
+            logger.info("Attempting in-cluster kubernetes config")
+            config.load_incluster_config()
+            in_cluster = True
+            logger.info("Successfully loaded in-cluster kubernetes config")
+        except Exception as e:
+            logger.warning(
+                f"In-cluster config failed ({type(e).__name__}: {e}), "
+                f"falling back to default kubeconfig (~/.kube/config)"
+            )
+            await config.load_kube_config()
+            logger.info("Successfully loaded default kubeconfig")
+
+    k8s_client = client.ApiClient()
+    core_api = client.CoreV1Api(k8s_client)
+    batch_api = client.BatchV1Api(k8s_client)
+    custom_api = client.CustomObjectsApi(k8s_client) if need_custom_api else None
+    apps_api = client.AppsV1Api() if need_apps_api else None
+
+    return core_api, batch_api, custom_api, apps_api, in_cluster

--- a/tests/utils/managed_deployment.py
+++ b/tests/utils/managed_deployment.py
@@ -1177,28 +1177,24 @@ class ManagedDeployment:
         return result
 
     def get_pod_manifest_logs_metrics(self, service_name: str, pod: Pod, suffix=""):
-        directory = os.path.join(self.log_dir, service_name)
-        os.makedirs(directory, exist_ok=True)
+        """Capture per-pod artifacts at a point in time.
 
+        Writes the pod manifest and an HTTP-metrics scrape only. The
+        container's stdout/stderr is already captured continuously to
+        the log-collection PVC by the tee wrapper, so we don't grab
+        ``pod.logs()`` here — it would just duplicate what the PVC has.
+        That also avoids empty ``.previous.log`` files (the kubectl
+        previous-incarnation log only has content when the SAME pod's
+        container restarted in place; for our DeletePod scenarios the
+        replacement pod never has a previous incarnation).
+        """
+        directory = os.path.join(self.log_dir, service_name.lower())
+        os.makedirs(directory, exist_ok=True)
         try:
             with open(os.path.join(directory, f"{pod.name}{suffix}.yaml"), "w") as f:
                 f.write(pod.to_yaml())
         except Exception as e:
             self._logger.error(e)
-        try:
-            with open(os.path.join(directory, f"{pod.name}{suffix}.log"), "w") as f:
-                f.write("\n".join(pod.logs()))
-        except Exception as e:
-            self._logger.error(e)
-        try:
-            previous_logs = pod.logs(previous=True)
-            with open(
-                os.path.join(directory, f"{pod.name}{suffix}.previous.log"), "w"
-            ) as f:
-                f.write("\n".join(previous_logs))
-        except Exception as e:
-            self._logger.debug(e)
-
         self._get_pod_metrics(pod, service_name, suffix)
 
     def _get_service_logs(self, service_name=None, suffix=""):
@@ -1627,8 +1623,13 @@ class ManagedDeployment:
             raise
 
     def _get_pod_manifest(self, pod: Pod, service_name: str, suffix: str = ""):
-        """Save pod manifest YAML to log_dir/<service>/<pod>.yaml."""
-        directory = os.path.join(self.log_dir, service_name)
+        """Save pod manifest YAML to log_dir/<service>/<pod>.yaml.
+
+        Service dir is lowercased so it overlays the PVC-extracted log
+        paths (the tee wrapper uses lowercase service names) — every
+        per-pod artifact (manifest, metrics, stdout) lives in one dir.
+        """
+        directory = os.path.join(self.log_dir, service_name.lower())
         os.makedirs(directory, exist_ok=True)
         try:
             with open(os.path.join(directory, f"{pod.name}{suffix}.yaml"), "w") as f:
@@ -1714,11 +1715,14 @@ class ManagedDeployment:
     async def _get_pod_metrics(
         self, pod: Pod, service_name: str, suffix="", use_services_dir: bool = False
     ):
-        """Fetch HTTP metrics. Async - needs exec for timestamp."""
-        if use_services_dir:
-            directory = os.path.join(self.log_dir, "services", service_name.lower())
-        else:
-            directory = os.path.join(self.log_dir, service_name)
+        """Fetch HTTP metrics. Async - needs exec for timestamp.
+
+        Writes alongside the per-pod manifest in the lowercased service
+        dir so all per-pod artifacts (manifest, metrics, stdout) are
+        under one dir per pod. ``use_services_dir`` is kept for back-
+        compat callers but the result is the same path either way.
+        """
+        directory = os.path.join(self.log_dir, service_name.lower())
         os.makedirs(directory, exist_ok=True)
 
         port = (
@@ -2053,9 +2057,12 @@ class ManagedDeployment:
                 self._logger.warning("No PVC name found for log extraction")
                 return
 
-            services_dir = os.path.join(self.log_dir, "services")
-            os.makedirs(services_dir, exist_ok=True)
-
+            # Extract the PVC contents directly into the test output root.
+            # The PVC tee writes to ``service_logs/<service-lower>/<pod>.log``,
+            # so when we extract from sub_path=service_logs the resulting
+            # files land at ``<log_dir>/<service-lower>/<pod>.log`` —
+            # overlaying the manifest/metrics paths so each per-pod dir
+            # holds stdout, manifest, and metrics together.
             extractor = PvcExtractor(namespace=self.namespace, logger=self._logger)
             await extractor.init()
 
@@ -2064,12 +2071,12 @@ class ManagedDeployment:
                 sub_path="service_logs",
                 container_path=self.container_log_dir,
                 file_patterns=["*.log"],
-                local_output_dir=services_dir,
+                local_output_dir=self.log_dir,
             )
 
             if result.get("success"):
                 self._logger.info(
-                    f"Extracted {result.get('file_count', 0)} log files to {services_dir}"
+                    f"Extracted {result.get('file_count', 0)} log files to {self.log_dir}"
                 )
             else:
                 self._logger.warning(

--- a/tests/utils/managed_deployment.py
+++ b/tests/utils/managed_deployment.py
@@ -241,46 +241,58 @@ class ServiceSpec:
 
     # ----- Log collection -----
     def enable_log_collection(self, log_dir: str, pvc_name: str):
-        """Wrap this service's command to tee output into a PVC-mounted log dir."""
+        """Capture stdout+stderr to a per-pod log file on the PVC without
+        parsing the user's command.
+
+        Strategy: prepend a fixed wrapper at argv[0]. The user's original
+        command + args are concatenated (raw, no shell parsing) into
+        ``args`` and execve'd by the wrapper via ``exec "$@"``. Inserts
+        only at well-defined seams in the spec (command/args list,
+        volume mounts, env vars, init containers) — never edits the
+        text of any user-supplied string.
+
+        The wrapper script itself is shipped via a per-namespace
+        ConfigMap (managed by ManagedDeployment._install_log_wrapper_configmap)
+        and copied into a shared emptyDir by a tiny init container.
+        """
         main_container = self._spec.get("extraPodSpec", {}).get("mainContainer", {})
         existing_command = main_container.get("command", [])
-        if (
-            len(existing_command) >= 3
-            and existing_command[:2] == ["/bin/bash", "-c"]
-            and "tee -a" in existing_command[2]
-        ):
+        if existing_command[:1] == [self._WRAPPER_PATH]:
             return  # already wrapped
 
         main_container = self._ensure_path("extraPodSpec", "mainContainer")
-        original_command = main_container.get("command", [])
-        original_args = main_container.get("args", [])
+        original_command = main_container.get("command", []) or []
+        original_args = main_container.get("args", []) or []
         if not original_command and not original_args:
             original_command = ["python3"]
             original_args = (
                 ["-m", "dynamo.frontend"] if self.component_type == "frontend" else []
             )
 
-        # shlex.join shell-quotes each arg so e.g. JSON literals like
-        # --kv-transfer-config '{"kv_connector":"NixlConnector",...}'
-        # survive being pasted into the bash -c heredoc; a naive
-        # " ".join would let bash interpret the braces as brace-
-        # expansion and the inner quotes would be stripped.
-        full_command = shlex.join(original_command + original_args)
+        # KEY INVARIANT: we do not modify any element of original_command
+        # or original_args. We only reorder the arrays. argv[0] becomes
+        # the wrapper; the original command + args follow, passed
+        # directly to execve via `exec "$@"` in the wrapper. JSON
+        # literals, shell metacharacters, anything goes.
+        main_container["command"] = [self._WRAPPER_PATH]
+        main_container["args"] = list(original_command) + list(original_args)
+
         service_log_dir = f"{log_dir}/service_logs/{self._name.lower()}"
 
-        template_path = os.path.join(
-            os.path.dirname(os.path.abspath(__file__)), "templates", "log_wrapper.sh"
-        )
-        with open(template_path) as f:
-            wrapper_script = f.read()
-        wrapper_script = wrapper_script.replace("{{SERVICE_LOG_DIR}}", service_log_dir)
-        wrapper_script = wrapper_script.replace("{{FULL_COMMAND}}", full_command)
-
-        main_container["command"] = ["/bin/bash", "-c", wrapper_script]
-        if "args" in main_container:
-            del main_container["args"]
-
+        # The log PVC is operator-managed: service-level volumeMounts
+        # tells the operator to provision the corresponding volume on
+        # our behalf.
         self._add_volume_mount(pvc_name, log_dir)
+        # The wrapper-staging emptyDir is NOT operator-managed: we
+        # mount it directly on mainContainer (kubelet-level) and
+        # declare the volume in extraPodSpec.volumes ourselves. Mixing
+        # the two layers causes the operator to also generate a volume
+        # of the same name → "Duplicate value" error on Deployment apply.
+        main_vmounts = main_container.setdefault("volumeMounts", [])
+        if not any(m.get("name") == self._WRAPPER_VOLUME for m in main_vmounts):
+            main_vmounts.append(
+                {"name": self._WRAPPER_VOLUME, "mountPath": self._WRAPPER_DIR}
+            )
         self._add_env_var(
             "POD_NAME", value_from={"fieldRef": {"fieldPath": "metadata.name"}}
         )
@@ -288,6 +300,73 @@ class ServiceSpec:
             "POD_NAMESPACE",
             value_from={"fieldRef": {"fieldPath": "metadata.namespace"}},
         )
+        self._add_env_var("DYN_LOG_DIR", value=service_log_dir)
+
+        extra_pod_spec = self._ensure_path("extraPodSpec")
+
+        # 1. Stage the wrapper script from the namespace ConfigMap into
+        #    the shared emptyDir so the main container can exec it.
+        init_containers = extra_pod_spec.setdefault("initContainers", [])
+        if not any(c.get("name") == "stage-log-wrapper" for c in init_containers):
+            init_containers.append(
+                {
+                    "name": "stage-log-wrapper",
+                    "image": "busybox:1.36",
+                    "command": [
+                        "sh",
+                        "-c",
+                        (
+                            f"cp /cm/dyn_tee.sh {self._WRAPPER_PATH} && "
+                            f"chmod +x {self._WRAPPER_PATH}"
+                        ),
+                    ],
+                    "volumeMounts": [
+                        {"name": self._WRAPPER_CM_VOLUME, "mountPath": "/cm"},
+                        {"name": self._WRAPPER_VOLUME, "mountPath": self._WRAPPER_DIR},
+                    ],
+                }
+            )
+
+        # 2. chmod 1777 the log mount. Some CSI drivers (fsx.csi.aws.com
+        #    Lustre) don't honour pod fsGroup, leaving the volume root
+        #    as root:root 0755 — the non-root main container then can't
+        #    mkdir its per-pod log subdir. Sticky 1777 mirrors /tmp.
+        #    NFS / k3s local-path / nfs-rwx honour fsGroup correctly so
+        #    this is a no-op there.
+        if not any(c.get("name") == "log-pvc-chmod" for c in init_containers):
+            init_containers.append(
+                {
+                    "name": "log-pvc-chmod",
+                    "image": "busybox:1.36",
+                    "command": ["sh", "-c", f"chmod 1777 {log_dir} || true"],
+                    "securityContext": {"runAsUser": 0, "runAsGroup": 0},
+                    "volumeMounts": [{"name": pvc_name, "mountPath": log_dir}],
+                }
+            )
+
+        # 3. Volumes: ConfigMap (read-only), shared emptyDir (rw to
+        #    init, ro fine for main since wrapper is exec'd not edited).
+        volumes = extra_pod_spec.setdefault("volumes", [])
+        if not any(v.get("name") == self._WRAPPER_CM_VOLUME for v in volumes):
+            volumes.append(
+                {
+                    "name": self._WRAPPER_CM_VOLUME,
+                    "configMap": {
+                        "name": self._WRAPPER_CM_NAME,
+                        "defaultMode": 0o755,
+                    },
+                }
+            )
+        if not any(v.get("name") == self._WRAPPER_VOLUME for v in volumes):
+            volumes.append({"name": self._WRAPPER_VOLUME, "emptyDir": {}})
+
+    # Constants for the log-wrapper machinery — kept on the class so
+    # ManagedDeployment can read them when applying the ConfigMap.
+    _WRAPPER_CM_NAME = "dyn-log-wrapper"
+    _WRAPPER_CM_VOLUME = "dyn-log-wrapper-cm"
+    _WRAPPER_VOLUME = "dyn-log-wrapper"
+    _WRAPPER_DIR = "/dyn-wrapper"
+    _WRAPPER_PATH = "/dyn-wrapper/dyn_tee.sh"
 
     # ----- ported from _2 (full surface area) -----
     def set_readiness_probe(
@@ -1796,8 +1875,56 @@ class ManagedDeployment:
         # this implicit means pods get stuck in Pending instead of giving us
         # an actionable error here.
         await self._verify_pvc_binding(pvc_name)
+        # Apply the ConfigMap that ships the dyn_tee.sh wrapper. Pods
+        # reference it via volume → emptyDir → main container; without
+        # it, log collection pods would CrashLoop on missing wrapper.
+        await self._install_log_wrapper_configmap()
         self._log_collection_pvc_created = True
         return pvc_name
+
+    async def _install_log_wrapper_configmap(self) -> None:
+        """Apply the ConfigMap that holds the dyn_tee.sh log-tee wrapper.
+
+        Idempotent — safe to call on every test run. The ConfigMap is
+        per-namespace so concurrent tests in the same namespace see the
+        same content.
+        """
+        wrapper_path = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            "templates",
+            "dyn_tee.sh",
+        )
+        with open(wrapper_path) as f:
+            wrapper_script = f.read()
+
+        cm_name = ServiceSpec._WRAPPER_CM_NAME
+        body = {
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {
+                "name": cm_name,
+                "namespace": self.namespace,
+                "labels": {
+                    "managed-by": "managed-deployment",
+                    "purpose": "log-wrapper",
+                },
+            },
+            "data": {"dyn_tee.sh": wrapper_script},
+        }
+        assert self._core_api is not None
+        try:
+            await self._core_api.read_namespaced_config_map(
+                name=cm_name, namespace=self.namespace
+            )
+            await self._core_api.replace_namespaced_config_map(
+                name=cm_name, namespace=self.namespace, body=body
+            )
+        except exceptions.ApiException as e:
+            if e.status != 404:
+                raise
+            await self._core_api.create_namespaced_config_map(
+                namespace=self.namespace, body=body
+            )
 
     # ----- ported from _2 (full surface area) -----
     def _load_template(self, template_name: str) -> str:
@@ -1910,7 +2037,7 @@ class ManagedDeployment:
             local_output_dir=local_output_dir,
         )
 
-    async def _verify_pvc_binding(self, pvc_name: str, timeout: int = 60):
+    async def _verify_pvc_binding(self, pvc_name: str, timeout: int = 600):
         """Verify PVC can be bound by creating a dummy job that mounts it.
 
         This ensures the storage class supports RWX before proceeding with deployment.
@@ -1919,7 +2046,10 @@ class ManagedDeployment:
 
         Args:
             pvc_name: Name of the PVC to verify
-            timeout: Maximum time to wait for binding in seconds
+            timeout: Maximum time to wait for binding in seconds. Default 600s
+                accommodates FSx-class provisioners (AWS dgxc-enterprise-file
+                takes 5-10 min to spin up an actual filesystem); fast classes
+                like nfs-rwx / k3s local-path bind in seconds either way.
 
         Raises:
             RuntimeError: If PVC cannot be bound within timeout

--- a/tests/utils/managed_deployment.py
+++ b/tests/utils/managed_deployment.py
@@ -260,7 +260,12 @@ class ServiceSpec:
                 ["-m", "dynamo.frontend"] if self.component_type == "frontend" else []
             )
 
-        full_command = " ".join(original_command + original_args)
+        # shlex.join shell-quotes each arg so e.g. JSON literals like
+        # --kv-transfer-config '{"kv_connector":"NixlConnector",...}'
+        # survive being pasted into the bash -c heredoc; a naive
+        # " ".join would let bash interpret the braces as brace-
+        # expansion and the inner quotes would be stripped.
+        full_command = shlex.join(original_command + original_args)
         service_log_dir = f"{log_dir}/service_logs/{self._name.lower()}"
 
         template_path = os.path.join(

--- a/tests/utils/managed_deployment.py
+++ b/tests/utils/managed_deployment.py
@@ -368,6 +368,30 @@ class ServiceSpec:
     _WRAPPER_DIR = "/dyn-wrapper"
     _WRAPPER_PATH = "/dyn-wrapper/dyn_tee.sh"
 
+    def enable_model_cache(
+        self, pvc_name: str, mount_path: str = "/model-cache"
+    ) -> None:
+        """Mount an existing RWX PVC as the HuggingFace model cache.
+
+        Sets HF_HOME (and the legacy TRANSFORMERS_CACHE / HF_HUB_CACHE
+        vars) on the service so vLLM / dynamo's downloader uses the
+        shared cache for model weight downloads. Skips re-downloading
+        large model weights between test runs.
+
+        Caller (DeploymentSpec.enable_model_cache) is responsible for
+        ensuring the PVC exists and is RWX. The mount is added at the
+        service level (operator-managed, mirrors how the log PVC is
+        mounted) so the operator handles volume creation.
+        """
+        self._add_volume_mount(pvc_name, mount_path)
+        self._add_env_var("HF_HOME", value=mount_path)
+        self._add_env_var("HF_HUB_CACHE", value=mount_path)
+        self._add_env_var("TRANSFORMERS_CACHE", value=mount_path)
+        # hf_transfer accelerates large-file downloads (Qwen3-30B + LLM
+        # tokenizer indexes are big enough to benefit). Costs nothing
+        # when the cache is warm.
+        self._add_env_var("HF_HUB_ENABLE_HF_TRANSFER", value="1")
+
     # ----- ported from _2 (full surface area) -----
     def set_readiness_probe(
         self,
@@ -720,6 +744,38 @@ class DeploymentSpec:
         for service in target_services:
             service.enable_log_collection(container_log_dir, pvc_name)
 
+    def enable_model_cache(
+        self,
+        pvc_name: str,
+        mount_path: str = "/model-cache",
+        worker_services_only: bool = True,
+    ) -> None:
+        """Mount an existing RWX PVC as the HF model cache on workers.
+
+        Caller-supplied PVC must already exist in the test namespace
+        and be RWX. Avoids re-downloading large model weights across
+        test runs. Many shared clusters auto-provision a per-namespace
+        ``shared-model-cache`` PVC; pass that name here to use it.
+
+        Adds an entry to ``spec.pvcs`` with ``create: False`` so the
+        operator does not try to provision it.
+        """
+        if "pvcs" not in self._deployment_spec["spec"]:
+            self._deployment_spec["spec"]["pvcs"] = []
+        if not any(
+            p.get("name") == pvc_name for p in self._deployment_spec["spec"]["pvcs"]
+        ):
+            self._deployment_spec["spec"]["pvcs"].append(
+                {"name": pvc_name, "create": False}
+            )
+        targets = (
+            [s for s in self.services if s.component_type != "frontend"]
+            if worker_services_only
+            else self.services
+        )
+        for service in targets:
+            service.enable_model_cache(pvc_name, mount_path)
+
     # ----- ported from _2 (full surface area) -----
 
 
@@ -801,6 +857,11 @@ class ManagedDeployment:
     # the service containing component_type: Frontend determines what is actually the frontend service
     frontend_service_name: str = "Frontend"
     skip_service_restart: bool = False
+    # When True, the log-collection PVC is assumed to already exist;
+    # _create_log_collection_pvc skips create + verify (just installs
+    # the wrapper ConfigMap), and _cleanup_log_collection_pvc skips
+    # delete. Set when the user passes --log-pvc.
+    reuse_log_pvc: bool = False
 
     _custom_api: Optional[client.CustomObjectsApi] = None
     _core_api: Optional[client.CoreV1Api] = None
@@ -1415,12 +1476,21 @@ class ManagedDeployment:
             self._logger.debug(f"scrub: list CRs failed: {e}")
 
         # 2. Delete log-collection PVCs (labelled by enable_log_collection).
+        # Skip the user-supplied PVC when --log-pvc is set: it's not ours
+        # to delete.
+        reused_pvc = (
+            getattr(self.deployment_spec, "_log_collection_pvc_name", None)
+            if self.reuse_log_pvc
+            else None
+        )
         try:
             pvcs = await self._core_api.list_namespaced_persistent_volume_claim(
                 namespace=self.namespace,
                 label_selector="purpose=log-collection",
             )
             for pvc in pvcs.items:
+                if reused_pvc and pvc.metadata.name == reused_pvc:
+                    continue
                 try:
                     await self._core_api.delete_namespaced_persistent_volume_claim(
                         name=pvc.metadata.name, namespace=self.namespace
@@ -1816,7 +1886,9 @@ class ManagedDeployment:
 
         No-op when the spec did not enable log collection. Recreates the PVC
         on every run so log content from a previous run does not leak into
-        this one.
+        this one — UNLESS ``reuse_log_pvc`` is set, in which case the PVC
+        is assumed to already exist (skip create + verify, just install the
+        wrapper ConfigMap).
 
         Returns the PVC name on success, or ``None`` when log collection is
         not configured.
@@ -1830,6 +1902,34 @@ class ManagedDeployment:
         )
 
         assert self._core_api is not None, "Kubernetes API not initialized"
+
+        if self.reuse_log_pvc:
+            self._logger.info(
+                f"Reusing existing log-collection PVC {pvc_name} "
+                f"(skip create + verify; --log-pvc was set)"
+            )
+            try:
+                pvc = await self._core_api.read_namespaced_persistent_volume_claim(
+                    name=pvc_name, namespace=self.namespace
+                )
+            except exceptions.ApiException as e:
+                if e.status == 404:
+                    raise RuntimeError(
+                        f"--log-pvc {pvc_name!r} does not exist in namespace "
+                        f"{self.namespace!r}; either create it first or omit "
+                        f"the flag to let the framework provision a fresh one."
+                    ) from None
+                raise
+            if pvc.status.phase != "Bound":
+                raise RuntimeError(
+                    f"--log-pvc {pvc_name!r} is in phase {pvc.status.phase}, "
+                    f"expected Bound. Resolve the binding before re-running."
+                )
+            await self._install_log_wrapper_configmap()
+            self._log_collection_pvc_created = True
+            self._log_collection_pvc_verified = True
+            return pvc_name
+
         self._logger.info(
             f"Creating log-collection PVC {pvc_name} ({pvc_size}, "
             f"sc={storage_class or 'cluster-default'}, RWX)"
@@ -2220,8 +2320,17 @@ class ManagedDeployment:
     async def _cleanup_log_collection_pvc(self):
         """
         Clean up the log collection PVC if we created it.
+
+        Skipped when ``reuse_log_pvc`` is set — the PVC was provided by
+        the user; we don't own its lifecycle.
         """
         if not self._log_collection_pvc_created:
+            return
+        if self.reuse_log_pvc:
+            self._logger.info(
+                "Skipping log-collection PVC delete (--log-pvc set; "
+                "reusing user-managed PVC)"
+            )
             return
 
         pvc_name = getattr(

--- a/tests/utils/managed_deployment.py
+++ b/tests/utils/managed_deployment.py
@@ -6,6 +6,7 @@ import logging
 import os
 import re
 import secrets
+import shlex
 import time
 from dataclasses import dataclass, field
 from typing import Any, List, Literal, Optional
@@ -104,7 +105,7 @@ class ServiceSpec:
             container["args"] = []
         args = container["args"]
         if isinstance(args, str):
-            args = args.split()
+            args = shlex.split(args)
             container["args"] = args
         return args
 
@@ -177,6 +178,112 @@ class ServiceSpec:
         args.extend(["--tensor-parallel-size", str(value)])
         self.gpus = value
 
+    # ----- Spec helpers (DGH-703) -----
+    def _ensure_path(self, *keys):
+        """Ensure a nested dict path exists, returning the innermost dict."""
+        d = self._spec
+        for key in keys:
+            if key not in d:
+                d[key] = {}
+            d = d[key]
+        return d
+
+    @property
+    def component_type(self) -> Optional[str]:
+        """Service component type (e.g. ``frontend`` for the frontend service)."""
+        return self._spec.get("componentType")
+
+    # ----- Args -----
+    def set_arg(self, arg_name: str, arg_value: str):
+        """Set or override a command-line argument for this service.
+
+        If the argument already exists, its value is updated. Otherwise it is appended.
+
+        Args:
+            arg_name: Argument name (e.g. ``"--max-model-len"``)
+            arg_value: Argument value (e.g. ``"4096"``)
+        """
+        container = self._ensure_path("extraPodSpec", "mainContainer")
+        if "args" not in container:
+            container["args"] = []
+        args = container["args"]
+        if isinstance(args, str):
+            args = shlex.split(args)
+            container["args"] = args
+        for i, arg in enumerate(args):
+            if arg == arg_name:
+                if i + 1 < len(args) and not args[i + 1].startswith("-"):
+                    args[i + 1] = arg_value
+                else:
+                    args.insert(i + 1, arg_value)
+                return
+        args.extend([arg_name, arg_value])
+
+    # ----- Volume mounts and env vars -----
+    def _add_volume_mount(self, name: str, mount_point: str):
+        """Add a volume mount if not already present."""
+        if "volumeMounts" not in self._spec:
+            self._spec["volumeMounts"] = []
+        if not any(m.get("name") == name for m in self._spec["volumeMounts"]):
+            self._spec["volumeMounts"].append({"name": name, "mountPoint": mount_point})
+
+    def _add_env_var(self, name: str, value=None, value_from=None):
+        """Add an env var if not already present."""
+        if "envs" not in self._spec:
+            self._spec["envs"] = []
+        if not any(e.get("name") == name for e in self._spec["envs"]):
+            env: dict[str, Any] = {"name": name}
+            if value_from:
+                env["valueFrom"] = value_from
+            elif value is not None:
+                env["value"] = value
+            self._spec["envs"].append(env)
+
+    # ----- Log collection -----
+    def enable_log_collection(self, log_dir: str, pvc_name: str):
+        """Wrap this service's command to tee output into a PVC-mounted log dir."""
+        main_container = self._spec.get("extraPodSpec", {}).get("mainContainer", {})
+        existing_command = main_container.get("command", [])
+        if (
+            len(existing_command) >= 3
+            and existing_command[:2] == ["/bin/bash", "-c"]
+            and "tee -a" in existing_command[2]
+        ):
+            return  # already wrapped
+
+        main_container = self._ensure_path("extraPodSpec", "mainContainer")
+        original_command = main_container.get("command", [])
+        original_args = main_container.get("args", [])
+        if not original_command and not original_args:
+            original_command = ["python3"]
+            original_args = (
+                ["-m", "dynamo.frontend"] if self.component_type == "frontend" else []
+            )
+
+        full_command = " ".join(original_command + original_args)
+        service_log_dir = f"{log_dir}/service_logs/{self._name.lower()}"
+
+        template_path = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), "templates", "log_wrapper.sh"
+        )
+        with open(template_path) as f:
+            wrapper_script = f.read()
+        wrapper_script = wrapper_script.replace("{{SERVICE_LOG_DIR}}", service_log_dir)
+        wrapper_script = wrapper_script.replace("{{FULL_COMMAND}}", full_command)
+
+        main_container["command"] = ["/bin/bash", "-c", wrapper_script]
+        if "args" in main_container:
+            del main_container["args"]
+
+        self._add_volume_mount(pvc_name, log_dir)
+        self._add_env_var(
+            "POD_NAME", value_from={"fieldRef": {"fieldPath": "metadata.name"}}
+        )
+        self._add_env_var(
+            "POD_NAMESPACE",
+            value_from={"fieldRef": {"fieldPath": "metadata.namespace"}},
+        )
+
 
 class DeploymentSpec:
     def __init__(
@@ -185,6 +292,7 @@ class DeploymentSpec:
         """Load the deployment YAML file"""
         with open(base, "r") as f:
             self._deployment_spec = yaml.safe_load(f)
+        self._base_path = base
         self._endpoint = endpoint
         self._port = port
         self._system_port = system_port
@@ -430,6 +538,111 @@ class DeploymentSpec:
         """Save updated deployment to file"""
         with open(out_file, "w") as f:
             yaml.safe_dump(self._deployment_spec, f, default_flow_style=False)
+
+    # ----- DGH-703 unified-framework APIs -----
+    @classmethod
+    def from_backend(
+        cls,
+        backend: str,
+        deployment_type: str = "agg",
+        workspace_dir: str = "/workspace",
+        **kwargs,
+    ) -> "DeploymentSpec":
+        """Create a DeploymentSpec from a backend name and deployment type.
+
+        Args:
+            backend: Backend name (``"vllm"``, ``"trtllm"``, ``"sglang"``, ``"mocker"``)
+            deployment_type: Deployment shape (``"agg"``, ``"disagg"``, ...)
+            workspace_dir: Workspace root containing ``examples/backends/<backend>/deploy/``
+            **kwargs: Forwarded to :class:`DeploymentSpec` (``endpoint``, ``port``, ...)
+
+        Example::
+
+            spec = DeploymentSpec.from_backend("vllm", "disagg")
+            spec.set_worker_replicas(2)
+        """
+        yaml_path = (
+            f"{workspace_dir}/examples/backends/{backend}/deploy/{deployment_type}.yaml"
+        )
+        return cls(yaml_path, **kwargs)
+
+    @property
+    def backend(self) -> str:
+        """Auto-detect backend from the YAML path or service names.
+
+        Returns one of ``"vllm"``, ``"trtllm"``, ``"sglang"``, ``"mocker"``,
+        or ``"unknown"`` if neither path nor service names match.
+        """
+        if hasattr(self, "_base_path") and self._base_path:
+            path = self._base_path.lower()
+            for name in ("vllm", "trtllm", "sglang", "mocker"):
+                if f"/backends/{name}/" in path or f"/{name}/" in path:
+                    return name
+        service_names = " ".join(s.name.lower() for s in self.services)
+        for name in ("vllm", "trtllm", "sglang", "mocker"):
+            if name in service_names:
+                return name
+        return "unknown"
+
+    def worker_services(self) -> list[str]:
+        """Return worker service names — services whose ``componentType`` is not ``frontend``."""
+        return [s.name for s in self.services if s.component_type != "frontend"]
+
+    def set_worker_replicas(self, replicas: int) -> None:
+        """Set ``replicas`` for every worker service."""
+        for name in self.worker_services():
+            self[name].replicas = replicas
+
+    def enable_log_collection(
+        self,
+        pvc_name: Optional[str] = None,
+        pvc_size: str = "1Gi",
+        storage_class: Optional[str] = None,
+        container_log_dir: str = "/tmp/service_logs",
+        enable_all_services: bool = True,
+        service_names: Optional[list[str]] = None,
+    ) -> None:
+        """Enable PVC-backed log collection for this deployment.
+
+        Creates an RWX PVC declaration in the deployment spec and wraps every
+        target service's command to tee output into ``container_log_dir``. The
+        PVC itself is materialized later by :class:`ManagedDeployment`.
+
+        Requires a storage class that supports ReadWriteMany; if absent, the
+        deployment will fail at PVC binding time.
+        """
+        if enable_all_services:
+            target_services = self.services
+        else:
+            target_services = [self[name] for name in (service_names or [])]
+
+        if pvc_name is None:
+            timestamp = int(time.time())
+            rand_suffix = secrets.randbelow(9000) + 1000
+            pvc_name = f"{self.name}-logs-{timestamp}-{rand_suffix}"
+
+        self._log_collection_pvc_name = pvc_name
+        self._log_collection_pvc_size = pvc_size
+        self._log_collection_storage_class = storage_class
+        self._log_collection_container_dir = container_log_dir
+
+        if "pvcs" not in self._deployment_spec["spec"]:
+            self._deployment_spec["spec"]["pvcs"] = []
+
+        # Drop any prior log PVCs so reruns don't accumulate stale entries.
+        self._deployment_spec["spec"]["pvcs"] = [
+            pvc
+            for pvc in self._deployment_spec["spec"]["pvcs"]
+            if not pvc.get("name", "").endswith("-logs-pvc")
+            and pvc.get("name") != pvc_name
+        ]
+        # ``create: False`` — ManagedDeployment provisions the PVC explicitly.
+        self._deployment_spec["spec"]["pvcs"].append(
+            {"name": pvc_name, "create": False}
+        )
+
+        for service in target_services:
+            service.enable_log_collection(container_log_dir, pvc_name)
 
 
 class PodProcess:

--- a/tests/utils/managed_deployment.py
+++ b/tests/utils/managed_deployment.py
@@ -284,6 +284,64 @@ class ServiceSpec:
             value_from={"fieldRef": {"fieldPath": "metadata.namespace"}},
         )
 
+    # ----- ported from _2 (full surface area) -----
+    def set_readiness_probe(
+        self,
+        period_seconds: int = 10,
+        initial_delay_seconds: int = 0,
+        timeout_seconds: int = 4,
+        failure_threshold: int = 3,
+        path: str = "/health",
+        port: int = 9090,
+    ):
+        """Set readiness probe configuration for this service.
+
+        Args:
+            period_seconds: How often to perform the probe (default: 10)
+            initial_delay_seconds: Delay before first probe (default: 0)
+            timeout_seconds: Probe timeout (default: 4)
+            failure_threshold: Failures before marking unready (default: 3)
+            path: HTTP path to probe (default: "/health")
+            port: Port to probe (default: 9090 for workers, use 8000 for frontend)
+        """
+        self._spec["readinessProbe"] = {
+            "httpGet": {
+                "path": path,
+                "port": port,
+            },
+            "periodSeconds": period_seconds,
+            "initialDelaySeconds": initial_delay_seconds,
+            "timeoutSeconds": timeout_seconds,
+            "failureThreshold": failure_threshold,
+        }
+
+    def set_termination_grace_period(self, seconds: int = 60):
+        """Set termination grace period for this service's pods.
+
+        Args:
+            seconds: Grace period in seconds (default: 60)
+        """
+        self._ensure_path("extraPodSpec")["terminationGracePeriodSeconds"] = seconds
+
+    def set_env_var(self, name: str, value: str):
+        """Set an environment variable on this service.
+
+        If the environment variable already exists, update its value.
+        Otherwise, add a new environment variable.
+
+        Args:
+            name: Name of the environment variable
+            value: Value of the environment variable
+        """
+        envs = self.envs or []
+        for env in envs:
+            if env.get("name") == name:
+                env["value"] = value
+                self.envs = envs
+                return
+        envs.append({"name": name, "value": value})
+        self.envs = envs
+
 
 class DeploymentSpec:
     def __init__(
@@ -310,6 +368,28 @@ class DeploymentSpec:
     def port(self) -> int:
         """Deployment port"""
         return self._port
+
+    @property
+    def frontend_service(self) -> "ServiceSpec":
+        """Return the first service whose componentType is ``frontend``."""
+        for service in self.services:
+            if service.component_type == "frontend":
+                return service
+        raise LookupError(
+            f"Deployment {self.name} has no service with componentType 'frontend'"
+        )
+
+    def get_in_cluster_frontend_url(self, namespace: str) -> str:
+        """Compute the in-cluster URL of the frontend service.
+
+        The DNS name follows the operator's service-naming convention
+        ``<deployment>-<service>.<namespace>.svc.cluster.local``.
+        """
+        return (
+            f"http://{self.name.lower()}-"
+            f"{self.frontend_service.name.lower()}."
+            f"{namespace.lower()}.svc.cluster.local:{self.port}"
+        )
 
     @property
     def system_port(self) -> int:
@@ -421,34 +501,6 @@ class DeploymentSpec:
 
         return {"jsonl_enabled": jsonl_enabled, "log_level": log_level}
 
-    def set_service_env_var(self, service_name: str, name: str, value: str):
-        """
-        Set an environment variable for a specific service
-        """
-        service = self.get_service(service_name)
-        envs = service.envs if service.envs is not None else []
-
-        # if env var already exists, update it
-        for env in envs:
-            if env["name"] == name:
-                env["value"] = value
-                service.envs = envs  # Save back to trigger the setter
-                return
-
-        # if env var does not exist, add it
-        envs.append({"name": name, "value": value})
-        service.envs = envs  # Save back to trigger the setter
-
-    def get_service_env_vars(self, service_name: str) -> list[dict]:
-        """
-        Get all environment variables for a specific service
-
-        Returns:
-            List of environment variable dicts (e.g., [{"name": "VAR", "value": "val"}])
-        """
-        service = self.get_service(service_name)
-        return service.envs
-
     @property
     def services(self) -> list[ServiceSpec]:
         """List of ServiceSpec objects"""
@@ -466,73 +518,13 @@ class DeploymentSpec:
     def spec(self):
         return self._deployment_spec
 
-    def add_arg_to_service(self, service_name: str, arg_name: str, arg_value: str):
-        """
-        Add or override a command-line argument for a specific service
-
-        Args:
-            service_name: Name of the service (e.g., "VllmDecodeWorker", "TRTLLMWorker")
-            arg_name: Argument name (e.g., "--max-model-len", "--max-seq-len")
-            arg_value: Argument value (e.g., "1024")
-        """
-        service = self.get_service(service_name)
-        service_spec = service._spec
-
-        # Ensure args list exists
-        if "extraPodSpec" not in service_spec:
-            service_spec["extraPodSpec"] = {"mainContainer": {}}
-        if "mainContainer" not in service_spec["extraPodSpec"]:
-            service_spec["extraPodSpec"]["mainContainer"] = {}
-        if "args" not in service_spec["extraPodSpec"]["mainContainer"]:
-            service_spec["extraPodSpec"]["mainContainer"]["args"] = []
-
-        args_list = service_spec["extraPodSpec"]["mainContainer"]["args"]
-
-        # Convert to list if needed (sometimes it's a single string)
-        if isinstance(args_list, str):
-            import shlex
-
-            args_list = shlex.split(args_list)
-            service_spec["extraPodSpec"]["mainContainer"]["args"] = args_list
-
-        # Find existing argument
-        arg_index = None
-        for i, arg in enumerate(args_list):
-            if arg == arg_name:
-                arg_index = i
-                break
-
-        if arg_index is not None:
-            # Argument found, check if it has a value
-            if arg_index + 1 < len(args_list) and not args_list[
-                arg_index + 1
-            ].startswith("-"):
-                # Has a value, replace it
-                args_list[arg_index + 1] = arg_value
-            else:
-                # No value after the argument, insert the value
-                args_list.insert(arg_index + 1, arg_value)
-        else:
-            # Add new argument
-            args_list.extend([arg_name, arg_value])
-
-    def get_service(self, service_name: str) -> ServiceSpec:
-        """
-        Get a specific service from the deployment spec
-        """
-        if service_name not in self._deployment_spec["spec"]["services"]:
-            raise ValueError(f"Service '{service_name}' not found in deployment spec")
-
-        return ServiceSpec(
-            service_name, self._deployment_spec["spec"]["services"][service_name]
-        )
-
     def set_service_replicas(self, service_name: str, replicas: int):
+        """Convenience wrapper around ``spec[name].replicas = N``.
+
+        Kept for legacy callers; new code should use the per-service form
+        directly so different workers can carry different replica counts.
         """
-        Set the number of replicas for a specific service
-        """
-        service = self.get_service(service_name)
-        service.replicas = replicas
+        self[service_name].replicas = replicas
 
     def save(self, out_file: str):
         """Save updated deployment to file"""
@@ -644,6 +636,8 @@ class DeploymentSpec:
         for service in target_services:
             service.enable_log_collection(container_log_dir, pvc_name)
 
+    # ----- ported from _2 (full surface area) -----
+
 
 class PodProcess:
     def __init__(self, pod: Pod, line: str):
@@ -737,6 +731,18 @@ class ManagedDeployment:
     def __post_init__(self):
         self._deployment_name = self.deployment_spec.name
         self.log_dir = resolve_test_output_path(self.log_dir)
+        # Lifecycle bookkeeping for the log-collection PVC. Cleanup paths
+        # check these before doing work so a failed PVC create doesn't try
+        # to clean up something that was never made.
+        self._log_collection_pvc_created = False
+        self._log_collection_pvc_verified = False
+        # Mirror DeploymentSpec.enable_log_collection's container_log_dir so
+        # the extractor and per-pod log paths agree.
+        self.container_log_dir = "/tmp/service_logs"
+        # Initial deployment startup time (seconds). Populated by the first
+        # ``_wait_for_ready`` success in ``__aenter__``; ``None`` means we
+        # haven't reached Ready yet.
+        self.startup_seconds: Optional[float] = None
 
     async def _init_kubernetes(self):
         """Initialize kubernetes client.
@@ -891,15 +897,22 @@ class ManagedDeployment:
                     observed_ready_condition_val == str(desired_ready_condition_val)
                     and observed_state_val == desired_state_val
                 ):
+                    elapsed = time.time() - start_time
                     self._logger.info(f"Current deployment state: {current_state}")
                     self._logger.info(f"Current conditions: {conditions}")
-                    self._logger.info(
-                        f"Elapsed time: {time.time() - start_time:.1f}s / {timeout}s"
-                    )
+                    self._logger.info(f"Elapsed time: {elapsed:.1f}s / {timeout}s")
 
                     self._logger.info(
                         f"Deployment {self._deployment_name} has Ready condition {desired_ready_condition_val} and state {desired_state_val}"
                     )
+                    # Capture the FIRST observed ready elapsed-time as the
+                    # deployment's startup time. Later waits (e.g. after a
+                    # rolling-upgrade) leave this untouched.
+                    if (
+                        desired_ready_condition_val is True
+                        and getattr(self, "startup_seconds", None) is None
+                    ):
+                        self.startup_seconds = elapsed
                     return True
                 else:
                     if attempt % log_interval == 0:
@@ -1081,37 +1094,23 @@ class ManagedDeployment:
                 raise
 
     async def trigger_rolling_upgrade(self, service_names: list[str]):
-        """
-        Triggers a rolling update for a list of services
-        This is a dummy update - sets an env var on the service
-        """
+        """Trigger a rolling upgrade by stamping a unique env var on each
+        named service and then publishing the change via
+        :py:meth:`apply_service_changes`.
 
+        The env var is a no-op for the worker process; its purpose is to
+        change the pod template so the operator rolls the deployment.
+        """
         if not service_names:
             raise ValueError(
                 "service_names cannot be empty for trigger_rolling_upgrade"
             )
-
-        patch_body: dict[str, Any] = {"spec": {"services": {}}}
-
         for service_name in service_names:
-            self.deployment_spec.set_service_env_var(
-                service_name, "TEST_ROLLING_UPDATE_TRIGGER", secrets.token_hex(8)
+            self.deployment_spec[service_name].set_env_var(
+                "TEST_ROLLING_UPDATE_TRIGGER", secrets.token_hex(8)
             )
-
-            updated_envs = self.deployment_spec.get_service_env_vars(service_name)
-            patch_body["spec"]["services"][service_name] = {"envs": updated_envs}
-
         try:
-            assert self._custom_api is not None, "Kubernetes API not initialized"
-            await self._custom_api.patch_namespaced_custom_object(
-                group="nvidia.com",
-                version="v1alpha1",
-                namespace=self.namespace,
-                plural="dynamographdeployments",
-                name=self._deployment_name,
-                body=patch_body,
-                _content_type="application/merge-patch+json",
-            )
+            await self.apply_service_changes(service_names)
         except exceptions.ApiException as e:
             self._logger.info(
                 f"Failed to patch deployment {self._deployment_name}: {e}"
@@ -1250,8 +1249,14 @@ class ManagedDeployment:
                 f.write(content)
 
     async def _delete_deployment(self):
-        """
-        Delete the DynamoGraphDeployment CR.
+        """Delete the DynamoGraphDeployment CR and wait for it to fully drain.
+
+        Two-stage wait so a subsequent ``_create_deployment`` never races a
+        prior incarnation:
+          1. Wait for the CR itself to disappear from the API.
+          2. Wait for the pods labeled with this deployment to terminate.
+        Without this, leftover pods from a previous (especially failed) run
+        keep cycling alongside the new ones.
         """
         try:
             if self._deployment_name and self._custom_api is not None:
@@ -1265,6 +1270,158 @@ class ManagedDeployment:
         except exceptions.ApiException as e:
             if e.status != 404:  # Ignore if already deleted
                 raise
+
+        await self._wait_for_cr_deleted()
+        await self._wait_for_pods_terminated()
+
+    async def _scrub_namespace(self) -> None:
+        """Wipe prior-run artifacts from the test namespace.
+
+        Deletes every ``DynamoGraphDeployment`` in the namespace, the
+        log-collection PVCs left behind by past failed runs, and any
+        leftover ``load-*`` / ``pvc-extract-*`` / ``*-verify-*`` jobs.
+        Then waits for all pods labeled with this deployment to drain so
+        the new run starts on a clean slate.
+
+        Called from ``__aenter__`` so test authors don't have to remember
+        to scrub between runs — the framework guarantees a clean baseline.
+        """
+        if self._custom_api is None or self._core_api is None:
+            return
+
+        # 1. Delete all DynamoGraphDeployments in the namespace.
+        try:
+            cr_list = await self._custom_api.list_namespaced_custom_object(
+                group="nvidia.com",
+                version="v1alpha1",
+                namespace=self.namespace,
+                plural="dynamographdeployments",
+            )
+            for item in cr_list.get("items", []):
+                name = item.get("metadata", {}).get("name")
+                if not name:
+                    continue
+                try:
+                    await self._custom_api.delete_namespaced_custom_object(
+                        group="nvidia.com",
+                        version="v1alpha1",
+                        namespace=self.namespace,
+                        plural="dynamographdeployments",
+                        name=name,
+                    )
+                    self._logger.info(f"scrub: deleted prior CR {name}")
+                except exceptions.ApiException as e:
+                    if e.status != 404:
+                        self._logger.debug(f"scrub: CR {name}: {e}")
+        except exceptions.ApiException as e:
+            self._logger.debug(f"scrub: list CRs failed: {e}")
+
+        # 2. Delete log-collection PVCs (labelled by enable_log_collection).
+        try:
+            pvcs = await self._core_api.list_namespaced_persistent_volume_claim(
+                namespace=self.namespace,
+                label_selector="purpose=log-collection",
+            )
+            for pvc in pvcs.items:
+                try:
+                    await self._core_api.delete_namespaced_persistent_volume_claim(
+                        name=pvc.metadata.name, namespace=self.namespace
+                    )
+                    self._logger.info(
+                        f"scrub: deleted prior log PVC {pvc.metadata.name}"
+                    )
+                except exceptions.ApiException as e:
+                    if e.status != 404:
+                        self._logger.debug(f"scrub: PVC {pvc.metadata.name}: {e}")
+        except exceptions.ApiException as e:
+            self._logger.debug(f"scrub: list PVCs failed: {e}")
+
+        # 3. Delete leftover jobs (load runners, log extractors, PVC-verify probes).
+        try:
+            batch_api = client.BatchV1Api()
+            jobs = await batch_api.list_namespaced_job(namespace=self.namespace)
+            stale_prefixes = ("load-", "pvc-extract-")
+            stale_substrs = ("-verify-",)
+            for job in jobs.items:
+                name = job.metadata.name
+                if not (
+                    any(name.startswith(p) for p in stale_prefixes)
+                    or any(s in name for s in stale_substrs)
+                ):
+                    continue
+                try:
+                    await batch_api.delete_namespaced_job(
+                        name=name,
+                        namespace=self.namespace,
+                        propagation_policy="Background",
+                    )
+                    self._logger.info(f"scrub: deleted prior job {name}")
+                except exceptions.ApiException as e:
+                    if e.status != 404:
+                        self._logger.debug(f"scrub: job {name}: {e}")
+        except exceptions.ApiException as e:
+            self._logger.debug(f"scrub: list jobs failed: {e}")
+
+        # 4. Wait for prior pods labeled with this deployment to drain.
+        await self._wait_for_pods_terminated()
+
+    async def _wait_for_cr_deleted(self, timeout: int = 120):
+        """Poll the apiserver until the CR returns 404."""
+        if not self._deployment_name or self._custom_api is None:
+            return
+        start = time.time()
+        while (time.time() - start) < timeout:
+            try:
+                await self._custom_api.get_namespaced_custom_object(
+                    group="nvidia.com",
+                    version="v1alpha1",
+                    namespace=self.namespace,
+                    plural="dynamographdeployments",
+                    name=self._deployment_name,
+                )
+                await asyncio.sleep(2)
+            except exceptions.ApiException as e:
+                if e.status == 404:
+                    return
+                raise
+        self._logger.warning(
+            f"CR {self._deployment_name} deletion timed out after {timeout}s"
+        )
+
+    async def _wait_for_pods_terminated(self, timeout: int = 120):
+        """Wait until no non-terminal pods remain for this deployment.
+
+        The operator's pods are labeled with ``nvidia.com/selector=<deployment>-<service>``
+        for each service; we walk every service and wait on each label set.
+        """
+        if self._core_api is None:
+            return
+        start = time.time()
+        services = [s.name for s in self.deployment_spec.services]
+        while (time.time() - start) < timeout:
+            still_running: list[str] = []
+            for service_name in services:
+                selector = f"nvidia.com/selector={self._deployment_name}-{service_name.lower()}"
+                try:
+                    pods = await self._core_api.list_namespaced_pod(
+                        namespace=self.namespace, label_selector=selector
+                    )
+                except exceptions.ApiException as e:
+                    self._logger.debug(f"list pods failed for {selector}: {e}")
+                    continue
+                for p in pods.items:
+                    if p.status.phase not in ("Succeeded", "Failed"):
+                        still_running.append(p.metadata.name)
+            if not still_running:
+                return
+            self._logger.info(
+                f"Waiting for {len(still_running)} prior pods to terminate: "
+                f"{still_running[:3]}{'…' if len(still_running) > 3 else ''}"
+            )
+            await asyncio.sleep(2)
+        self._logger.warning(
+            f"Pod termination timed out after {timeout}s — proceeding anyway"
+        )
 
     def port_forward(
         self, pod: Pod, remote_port: int, max_connection_attempts: int = 3
@@ -1364,7 +1521,21 @@ class ManagedDeployment:
                     self._logger.debug(f"Error stopping port forward: {e}")
             self._active_port_forwards.clear()
         finally:
+            # Drain logs from PVC BEFORE deleting deployment + PVC, so we
+            # never lose a run's logs to a teardown race.
+            try:
+                await self._extract_logs_from_pvc()
+            except Exception as e:
+                self._logger.warning(f"log extraction failed: {e}")
+            try:
+                await self._cleanup_orphaned_jobs()
+            except Exception as e:
+                self._logger.warning(f"orphaned job cleanup failed: {e}")
             await self._delete_deployment()
+            try:
+                await self._cleanup_log_collection_pvc()
+            except Exception as e:
+                self._logger.warning(f"log PVC cleanup failed: {e}")
 
     async def __aenter__(self):
         try:
@@ -1374,11 +1545,21 @@ class ManagedDeployment:
             logging.getLogger("httpx").setLevel(logging.WARNING)
             await self._init_kubernetes()
 
-            # Run delete deployment and service restarts in parallel
-            tasks = [self._delete_deployment()]
+            # Scrub the namespace clean of any state left over from prior
+            # runs (failed-mid-test deployments, orphan PVCs, stale load
+            # jobs). Without this, residual pods can sit alongside the
+            # current run's pods and confuse readiness checks.
+            tasks = [self._scrub_namespace()]
             if not self.skip_service_restart:
                 tasks.extend([self._restart_etcd(), self._restart_nats()])
             await asyncio.gather(*tasks)
+
+            # Materialize the log-collection PVC declared by
+            # DeploymentSpec.enable_log_collection. The spec carries the PVC
+            # by reference (`create: false`) so the operator does not try to
+            # create it; ManagedDeployment owns its lifecycle so the PVC and
+            # the deployment go up and come down together.
+            await self._create_log_collection_pvc()
 
             await self._create_deployment()
             await self._wait_for_ready()
@@ -1390,6 +1571,540 @@ class ManagedDeployment:
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         await self._cleanup()
+
+    async def wait_for_ready(self, timeout: int = 1800, sleep=1, log_interval=60):
+        """Public alias used by events.WaitForRecovery and RollingUpgrade.
+
+        Same semantics as the private :py:meth:`_wait_for_ready` — waits for
+        the DynamoGraphDeployment to reach Ready=True / state=successful.
+        """
+        return await self._wait_for_ready(
+            timeout=timeout, sleep=sleep, log_interval=log_interval
+        )
+
+    def get_log_pvc_name(self) -> Optional[str]:
+        """Return the configured log-collection PVC name, or None if not enabled.
+
+        ManagedLoad uses this to mount the same PVC for storing aiperf
+        artifacts so a single download job can collect everything.
+        """
+        return getattr(self.deployment_spec, "_log_collection_pvc_name", None)
+
+    async def apply_service_changes(self, service_names: list[str]):
+        """Push whatever in-memory mutations have been made on the named
+        services to the cluster, in a single merge-patch.
+
+        The caller mutates services via ``ServiceSpec`` setters (``image``,
+        ``replicas``, ``set_env_var``, ``set_arg``, …); this method then
+        publishes those changes. We push each service's full spec dict and
+        let the apiserver's merge-patch semantics overlay them on the CR —
+        unchanged fields on the server are preserved, mutated ones win.
+
+        Used by RollingUpgrade and any other event that needs the operator
+        to reconcile after spec edits.
+        """
+        if not service_names:
+            raise ValueError("service_names cannot be empty for apply_service_changes")
+        patch_body: dict = {"spec": {"services": {}}}
+        for service_name in service_names:
+            service = self.deployment_spec[service_name]
+            patch_body["spec"]["services"][service_name] = service._spec
+        assert self._custom_api is not None, "Kubernetes API not initialized"
+        try:
+            await self._custom_api.patch_namespaced_custom_object(
+                group="nvidia.com",
+                version="v1alpha1",
+                namespace=self.namespace,
+                plural="dynamographdeployments",
+                name=self._deployment_name,
+                body=patch_body,
+                _content_type="application/merge-patch+json",
+            )
+        except exceptions.ApiException as e:
+            self._logger.info(
+                f"Failed to patch deployment {self._deployment_name}: {e}"
+            )
+            raise
+
+    def _get_pod_manifest(self, pod: Pod, service_name: str, suffix: str = ""):
+        """Save pod manifest YAML to log_dir/<service>/<pod>.yaml."""
+        directory = os.path.join(self.log_dir, service_name)
+        os.makedirs(directory, exist_ok=True)
+        try:
+            with open(os.path.join(directory, f"{pod.name}{suffix}.yaml"), "w") as f:
+                f.write(pod.to_yaml())
+        except Exception as e:
+            self._logger.error(e)
+
+    async def _create_log_collection_pvc(self) -> Optional[str]:
+        """Create the RWX log-collection PVC referenced by DeploymentSpec.
+
+        No-op when the spec did not enable log collection. Recreates the PVC
+        on every run so log content from a previous run does not leak into
+        this one.
+
+        Returns the PVC name on success, or ``None`` when log collection is
+        not configured.
+        """
+        pvc_name = getattr(self.deployment_spec, "_log_collection_pvc_name", None)
+        if not pvc_name:
+            return None
+        pvc_size = getattr(self.deployment_spec, "_log_collection_pvc_size", "1Gi")
+        storage_class = getattr(
+            self.deployment_spec, "_log_collection_storage_class", None
+        )
+
+        assert self._core_api is not None, "Kubernetes API not initialized"
+        self._logger.info(
+            f"Creating log-collection PVC {pvc_name} ({pvc_size}, "
+            f"sc={storage_class or 'cluster-default'}, RWX)"
+        )
+
+        # Delete any prior incarnation so this run starts clean.
+        try:
+            await self._core_api.read_namespaced_persistent_volume_claim(
+                name=pvc_name, namespace=self.namespace
+            )
+            await self._core_api.delete_namespaced_persistent_volume_claim(
+                name=pvc_name, namespace=self.namespace
+            )
+            await asyncio.sleep(2)
+        except exceptions.ApiException as e:
+            if e.status != 404:
+                raise
+
+        pvc_spec: dict = {
+            "apiVersion": "v1",
+            "kind": "PersistentVolumeClaim",
+            "metadata": {
+                "name": pvc_name,
+                "namespace": self.namespace,
+                "labels": {
+                    "managed-by": "managed-deployment",
+                    "deployment": self.deployment_spec.name,
+                    "purpose": "log-collection",
+                },
+            },
+            "spec": {
+                "accessModes": ["ReadWriteMany"],
+                "resources": {"requests": {"storage": pvc_size}},
+            },
+        }
+        if storage_class:
+            pvc_spec["spec"]["storageClassName"] = storage_class
+
+        await self._core_api.create_namespaced_persistent_volume_claim(
+            namespace=self.namespace, body=pvc_spec
+        )
+        # Fast-fail if storage class doesn't actually deliver RWX — leaving
+        # this implicit means pods get stuck in Pending instead of giving us
+        # an actionable error here.
+        await self._verify_pvc_binding(pvc_name)
+        self._log_collection_pvc_created = True
+        return pvc_name
+
+    # ----- ported from _2 (full surface area) -----
+    def _load_template(self, template_name: str) -> str:
+        """Load a template file from the templates directory."""
+        template_dir = os.path.join(os.path.dirname(__file__), "templates")
+        template_path = os.path.join(template_dir, template_name)
+        with open(template_path, "r") as f:
+            return f.read()
+
+    async def _get_pod_metrics(
+        self, pod: Pod, service_name: str, suffix="", use_services_dir: bool = False
+    ):
+        """Fetch HTTP metrics. Async - needs exec for timestamp."""
+        if use_services_dir:
+            directory = os.path.join(self.log_dir, "services", service_name.lower())
+        else:
+            directory = os.path.join(self.log_dir, service_name)
+        os.makedirs(directory, exist_ok=True)
+
+        port = (
+            self.deployment_spec.port
+            if service_name == self.frontend_service_name
+            else self.deployment_spec.system_port
+        )
+
+        pf = self.port_forward(pod, port)
+        if not pf:
+            self._logger.error(f"Unable to get metrics for {service_name}")
+            return
+
+        content = None
+        try:
+            response = requests.get(
+                f"http://localhost:{pf.local_port}/metrics", timeout=30
+            )
+            content = response.text
+        except Exception as e:
+            self._logger.error(str(e))
+
+        if content:
+            timestamp = await self._get_container_timestamp(pod)
+            filename = f"{pod.name}_{timestamp}.metrics{suffix}.log"
+            with open(os.path.join(directory, filename), "w") as f:
+                f.write(content)
+
+    async def _exec_in_pod(
+        self, pod: Pod, command: List[str], timeout: float = 10.0
+    ) -> Any:
+        """Execute command in pod with timeout.
+
+        Args:
+            pod: The pod to execute the command in
+            command: Command as a list of strings
+            timeout: Timeout in seconds
+
+        Returns:
+            The exec result with stdout, stderr, and returncode
+        """
+        return await asyncio.wait_for(
+            asyncio.create_task(asyncio.to_thread(pod.exec, command)),
+            timeout=timeout,
+        )
+
+    async def _get_container_timestamp(self, pod: Pod) -> str:
+        """Read container start timestamp written by wrapper script.
+
+        The wrapper script writes the timestamp to /tmp/.{pod_name}.start_time
+        This ensures exact match with service log filenames.
+        """
+        try:
+            result = await self._exec_in_pod(
+                pod, ["cat", f"/tmp/.{pod.name}.start_time"], timeout=5.0
+            )
+            return result.stdout.decode().strip()
+        except Exception:
+            # Fallback if timestamp file doesn't exist
+            return str(int(time.time()))
+
+    async def download_volume_logs_now(self, local_output_dir=None):
+        """Download service logs from PVC immediately.
+
+        Creates a temporary extraction job, downloads logs, and cleans up.
+
+        Args:
+            local_output_dir: Local directory to save logs (defaults to log_dir/services_manual)
+
+        Returns:
+            dict: Extraction results
+        """
+        if local_output_dir is None:
+            local_output_dir = os.path.join(self.log_dir, "services_manual")
+
+        pvc_name = getattr(self.deployment_spec, "_log_collection_pvc_name", None)
+        if not pvc_name:
+            return {"success": False, "error": "No PVC configured for log collection"}
+
+        from tests.utils.pvc_extractor import PvcExtractor
+
+        extractor = PvcExtractor(namespace=self.namespace, logger=self._logger)
+        await extractor.init()
+
+        return await extractor.extract(
+            pvc_name=pvc_name,
+            sub_path="service_logs",
+            container_path=self.container_log_dir,
+            file_patterns=["*.log"],
+            local_output_dir=local_output_dir,
+        )
+
+    async def _verify_pvc_binding(self, pvc_name: str, timeout: int = 60):
+        """Verify PVC can be bound by creating a dummy job that mounts it.
+
+        This ensures the storage class supports RWX before proceeding with deployment.
+        If the PVC can't be bound (e.g., storage class doesn't support RWX), this
+        will fail fast rather than leaving pods in Pending state.
+
+        Args:
+            pvc_name: Name of the PVC to verify
+            timeout: Maximum time to wait for binding in seconds
+
+        Raises:
+            RuntimeError: If PVC cannot be bound within timeout
+        """
+        job_name = f"{pvc_name}-verify-{secrets.token_hex(4)}"
+        storage_class = getattr(
+            self.deployment_spec, "_log_collection_storage_class", "unknown"
+        )
+        binding_issue_logged = False
+        self._logger.info(
+            f"Verifying PVC {pvc_name} can be bound (storage class: {storage_class})..."
+        )
+
+        # Create a minimal job that just mounts the PVC and exits
+        job_spec = {
+            "apiVersion": "batch/v1",
+            "kind": "Job",
+            "metadata": {
+                "name": job_name,
+                "namespace": self.namespace,
+            },
+            "spec": {
+                "backoffLimit": 0,
+                "ttlSecondsAfterFinished": 60,
+                "template": {
+                    "spec": {
+                        "restartPolicy": "Never",
+                        "containers": [
+                            {
+                                "name": "verify",
+                                "image": "busybox:1.35",
+                                "command": [
+                                    "sh",
+                                    "-c",
+                                    "echo 'PVC mounted successfully' && ls -la /mnt",
+                                ],
+                                "volumeMounts": [
+                                    {"name": "test-volume", "mountPath": "/mnt"}
+                                ],
+                            }
+                        ],
+                        "volumes": [
+                            {
+                                "name": "test-volume",
+                                "persistentVolumeClaim": {"claimName": pvc_name},
+                            }
+                        ],
+                    }
+                },
+            },
+        }
+
+        batch_api = client.BatchV1Api()
+        job_created = False
+        verification_error = None
+
+        try:
+            # Create the verification job
+            await batch_api.create_namespaced_job(
+                namespace=self.namespace, body=job_spec
+            )
+            job_created = True
+            self._logger.info(f"Created PVC verification job: {job_name}")
+
+            # Wait for job to complete (pod started = PVC bound)
+            start_time = time.time()
+            while (time.time() - start_time) < timeout:
+                try:
+                    job = await batch_api.read_namespaced_job(
+                        name=job_name, namespace=self.namespace
+                    )
+
+                    # Check if job succeeded
+                    if job.status.succeeded and job.status.succeeded > 0:
+                        self._logger.info(
+                            f"PVC {pvc_name} verified - bound successfully"
+                        )
+                        self._log_collection_pvc_verified = True
+                        return
+
+                    # Check if job failed
+                    if job.status.failed and job.status.failed > 0:
+                        verification_error = RuntimeError(
+                            "PVC verification job failed - storage class may not support RWX"
+                        )
+                        break
+
+                    # Check pod status for more details
+                    pods = await self._core_api.list_namespaced_pod(
+                        namespace=self.namespace,
+                        label_selector=f"job-name={job_name}",
+                    )
+                    if pods.items:
+                        pod = pods.items[0]
+                        phase = pod.status.phase
+                        if phase == "Running" or phase == "Succeeded":
+                            self._logger.info(
+                                f"PVC {pvc_name} is binding (pod phase: {phase})"
+                            )
+                        elif phase == "Pending":
+                            # Check for PVC binding issues (only log once)
+                            if not binding_issue_logged:
+                                for condition in pod.status.conditions or []:
+                                    if (
+                                        condition.type == "PodScheduled"
+                                        and condition.status == "False"
+                                    ):
+                                        if (
+                                            "unbound"
+                                            in (condition.message or "").lower()
+                                        ):
+                                            self._logger.error(
+                                                f"PVC BINDING FAILED: {pvc_name} cannot be bound. "
+                                                f"Storage class '{storage_class}' likely does not support "
+                                                f"ReadWriteMany (RWX) access mode."
+                                            )
+                                            binding_issue_logged = True
+
+                except exceptions.ApiException as e:
+                    if e.status != 404:
+                        self._logger.warning(f"Error checking verification job: {e}")
+
+                await asyncio.sleep(2)
+            else:
+                # Timeout reached
+                verification_error = RuntimeError(
+                    f"PVC '{pvc_name}' failed to bind within {timeout}s.\n"
+                    f"Storage class '{storage_class}' does not support ReadWriteMany (RWX) access mode.\n"
+                    f"Multi-pod log collection requires RWX. Please use a different storage class."
+                )
+
+        except exceptions.ApiException as e:
+            self._logger.error(f"Failed to create PVC verification job: {e}")
+            raise
+
+        finally:
+            # Always cleanup the verification job and its pods
+            if job_created:
+                try:
+                    self._logger.info(f"Cleaning up PVC verification job: {job_name}")
+                    # Use Foreground propagation to ensure pods are deleted too
+                    await batch_api.delete_namespaced_job(
+                        name=job_name,
+                        namespace=self.namespace,
+                        body=client.V1DeleteOptions(propagation_policy="Foreground"),
+                    )
+                    # Wait briefly for cleanup to complete
+                    for _ in range(10):
+                        try:
+                            await batch_api.read_namespaced_job(
+                                name=job_name, namespace=self.namespace
+                            )
+                            await asyncio.sleep(1)
+                        except exceptions.ApiException as e:
+                            if e.status == 404:
+                                break
+                    self._logger.info(f"PVC verification job {job_name} cleaned up")
+                except Exception as cleanup_error:
+                    self._logger.warning(
+                        f"Failed to cleanup verification job {job_name}: {cleanup_error}"
+                    )
+
+        # Raise any verification error after cleanup
+        if verification_error:
+            raise verification_error
+
+    async def _cleanup_log_collection_pvc(self):
+        """
+        Clean up the log collection PVC if we created it.
+        """
+        if not self._log_collection_pvc_created:
+            return
+
+        pvc_name = getattr(
+            self.deployment_spec, "_log_collection_pvc_name", "dynamo-logs-pvc"
+        )
+
+        try:
+            await self._core_api.delete_namespaced_persistent_volume_claim(
+                name=pvc_name, namespace=self.namespace
+            )
+            self._logger.info(f"Cleaned up log collection PVC {pvc_name}")
+
+        except client.ApiException as e:
+            if e.status != 404:  # Not found is acceptable during cleanup
+                self._logger.warning(f"Failed to cleanup PVC {pvc_name}: {e}")
+
+    async def _cleanup_all_resources(self):
+        """
+        Comprehensive cleanup of all resources created by this deployment.
+
+        Order for volume log collection:
+        1. Delete deployment (pods exit gracefully, write final logs to PVC)
+        2. Wait for pods to terminate
+        3. Create download job to extract logs from PVC
+        4. Extract logs
+        5. Delete download job
+        6. Delete PVC
+        """
+        try:
+            # Delete the main deployment first (pods write final logs to PVC on exit)
+            self._logger.info("Deleting deployment...")
+            await self._delete_deployment()
+
+            # Wait for pods to terminate, then extract logs from PVC
+            self._logger.info("Waiting for pods to terminate...")
+            await self._wait_for_pods_terminated()
+            await self._extract_logs_from_pvc()
+            await self._cleanup_log_collection_pvc()
+
+            # Clean up any orphaned jobs related to this deployment
+            await self._cleanup_orphaned_jobs()
+
+        except Exception as e:
+            self._logger.warning(f"Error during comprehensive cleanup: {e}")
+
+    async def _extract_logs_from_pvc(self):
+        """Extract service logs from PVC using PvcExtractor."""
+        if not self._log_collection_pvc_verified:
+            self._logger.info(
+                "Skipping log extraction - PVC was not successfully bound"
+            )
+            return
+
+        try:
+            from tests.utils.pvc_extractor import PvcExtractor
+
+            pvc_name = getattr(self.deployment_spec, "_log_collection_pvc_name", None)
+            if not pvc_name:
+                self._logger.warning("No PVC name found for log extraction")
+                return
+
+            services_dir = os.path.join(self.log_dir, "services")
+            os.makedirs(services_dir, exist_ok=True)
+
+            extractor = PvcExtractor(namespace=self.namespace, logger=self._logger)
+            await extractor.init()
+
+            result = await extractor.extract(
+                pvc_name=pvc_name,
+                sub_path="service_logs",
+                container_path=self.container_log_dir,
+                file_patterns=["*.log"],
+                local_output_dir=services_dir,
+            )
+
+            if result.get("success"):
+                self._logger.info(
+                    f"Extracted {result.get('file_count', 0)} log files to {services_dir}"
+                )
+            else:
+                self._logger.warning(
+                    f"Log extraction failed: {result.get('error', 'Unknown error')}"
+                )
+
+        except Exception as e:
+            self._logger.warning(f"Error extracting logs from PVC: {e}")
+
+    async def _cleanup_orphaned_jobs(self):
+        """Clean up any jobs that might be left behind."""
+        try:
+            # Get all jobs in the namespace that are related to this deployment
+            batch_api = client.BatchV1Api()
+            jobs = await batch_api.list_namespaced_job(
+                namespace=self.namespace,
+                label_selector=f"deployment={self.deployment_spec.name}",
+            )
+
+            for job in jobs.items:
+                job_name = job.metadata.name
+                try:
+                    # Delete the job with cascade to clean up pods
+                    await batch_api.delete_namespaced_job(
+                        name=job_name,
+                        namespace=self.namespace,
+                        body=client.V1DeleteOptions(propagation_policy="Background"),
+                    )
+                    self._logger.info(f"Cleaned up orphaned job: {job_name}")
+                except client.ApiException as e:
+                    if e.status != 404:
+                        self._logger.warning(f"Failed to cleanup job {job_name}: {e}")
+
+        except Exception as e:
+            self._logger.warning(f"Error cleaning up orphaned jobs: {e}")
 
 
 class ManagedDGDR:

--- a/tests/utils/managed_deployment.py
+++ b/tests/utils/managed_deployment.py
@@ -1029,17 +1029,35 @@ class ManagedDeployment:
             return []
 
     async def _get_pod_events(self) -> List[str]:
-        """Fetch warning events for pods in this deployment's namespace."""
+        """Fetch warning events for pods owned by THIS deployment only.
+
+        Filters by the current deployment's pod names so events from prior
+        runs (verify-jobs, killed pods, etc.) don't leak into the current
+        run's status output. K8s namespace events linger for ~1 hour and
+        without this filter the log fills up with unrelated stale entries.
+        """
         try:
             assert self._core_api is not None, "Kubernetes API not initialized"
+            label = f"nvidia.com/dynamo-graph-deployment-name={self._deployment_name}"
+            pods = await self._core_api.list_namespaced_pod(
+                self.namespace, label_selector=label
+            )
+            current_pod_names = {p.metadata.name for p in pods.items}
+            if not current_pod_names:
+                return []
             events = await self._core_api.list_namespaced_event(self.namespace)
             warnings = []
             for event in events.items:
-                if event.type != "Normal" and event.involved_object.kind == "Pod":
-                    name = event.involved_object.name or "unknown"
-                    reason = event.reason or ""
-                    msg = event.message or ""
-                    warnings.append(f"{name}: {reason} - {msg}")
+                if event.type == "Normal":
+                    continue
+                if event.involved_object.kind != "Pod":
+                    continue
+                name = event.involved_object.name or "unknown"
+                if name not in current_pod_names:
+                    continue
+                reason = event.reason or ""
+                msg = event.message or ""
+                warnings.append(f"{name}: {reason} - {msg}")
             return warnings[-10:]
         except Exception as e:
             self._logger.debug(f"Failed to collect pod events: {e}")
@@ -1361,6 +1379,69 @@ class ManagedDeployment:
         # 4. Wait for prior pods labeled with this deployment to drain.
         await self._wait_for_pods_terminated()
 
+        # 5. Verify post-condition: no DGDs, no log-collection PVCs, no
+        # stale test jobs left in the namespace. Anything else (the GPU
+        # operator's pods, NATS, etcd, the user's other namespaced work)
+        # is intentionally left alone — we only assert we're not racing
+        # leftover state from previous test runs of THIS suite.
+        await self._verify_namespace_scrubbed()
+
+    async def _verify_namespace_scrubbed(self) -> None:
+        """Assert the namespace has no leftover test artifacts post-scrub.
+
+        Items with ``deletionTimestamp`` are skipped — they've been told
+        to delete and are draining (e.g. PVCs detaching from terminating
+        pods). The post-scrub waits should have caught most of those, but
+        kubelet finalization can still take a beat. We only raise when
+        a fresh, undeleted artifact remains.
+        """
+        if self._custom_api is None or self._core_api is None:
+            return
+        leftovers: list[str] = []
+
+        def _alive(meta: dict) -> bool:
+            return not meta.get("deletionTimestamp")
+
+        try:
+            cr_list = await self._custom_api.list_namespaced_custom_object(
+                group="nvidia.com",
+                version="v1alpha1",
+                namespace=self.namespace,
+                plural="dynamographdeployments",
+            )
+            for item in cr_list.get("items", []):
+                meta = item.get("metadata", {})
+                if _alive(meta) and meta.get("name"):
+                    leftovers.append(f"DGD/{meta['name']}")
+        except exceptions.ApiException:
+            pass
+        try:
+            pvcs = await self._core_api.list_namespaced_persistent_volume_claim(
+                namespace=self.namespace, label_selector="purpose=log-collection"
+            )
+            for pvc in pvcs.items:
+                if pvc.metadata.deletion_timestamp is None:
+                    leftovers.append(f"PVC/{pvc.metadata.name}")
+        except exceptions.ApiException:
+            pass
+        try:
+            batch_api = client.BatchV1Api()
+            jobs = await batch_api.list_namespaced_job(namespace=self.namespace)
+            for job in jobs.items:
+                if job.metadata.deletion_timestamp is not None:
+                    continue
+                name = job.metadata.name
+                if name.startswith(("load-", "pvc-extract-")) or "-verify-" in name:
+                    leftovers.append(f"Job/{name}")
+        except exceptions.ApiException:
+            pass
+        if leftovers:
+            raise RuntimeError(
+                "scrub did not leave a clean namespace; leftover test "
+                f"artifacts: {leftovers}"
+            )
+        self._logger.info("scrub: namespace verified clean")
+
     async def _wait_for_cr_deleted(self, timeout: int = 120):
         """Poll the apiserver until the CR returns 404."""
         if not self._deployment_name or self._custom_api is None:
@@ -1532,6 +1613,15 @@ class ManagedDeployment:
                 await self._cleanup_log_collection_pvc()
             except Exception as e:
                 self._logger.warning(f"log PVC cleanup failed: {e}")
+            # Final scrub: catch anything orphan / waiting that the
+            # targeted cleanups above missed (verify-jobs that didn't
+            # complete, deployments that snuck in, etc.). Mirror of the
+            # entry-side scrub so we leave the namespace exactly as
+            # clean as we found it.
+            try:
+                await self._scrub_namespace()
+            except Exception as e:
+                self._logger.warning(f"final scrub failed: {e}")
 
     async def __aenter__(self):
         try:
@@ -1833,7 +1923,6 @@ class ManagedDeployment:
         storage_class = getattr(
             self.deployment_spec, "_log_collection_storage_class", "unknown"
         )
-        binding_issue_logged = False
         self._logger.info(
             f"Verifying PVC {pvc_name} can be bound (storage class: {storage_class})..."
         )
@@ -1925,23 +2014,25 @@ class ManagedDeployment:
                                 f"PVC {pvc_name} is binding (pod phase: {phase})"
                             )
                         elif phase == "Pending":
-                            # Check for PVC binding issues (only log once)
-                            if not binding_issue_logged:
-                                for condition in pod.status.conditions or []:
-                                    if (
-                                        condition.type == "PodScheduled"
-                                        and condition.status == "False"
-                                    ):
-                                        if (
-                                            "unbound"
-                                            in (condition.message or "").lower()
-                                        ):
-                                            self._logger.error(
-                                                f"PVC BINDING FAILED: {pvc_name} cannot be bound. "
-                                                f"Storage class '{storage_class}' likely does not support "
-                                                f"ReadWriteMany (RWX) access mode."
-                                            )
-                                            binding_issue_logged = True
+                            # The verify-job's pod legitimately sits in
+                            # Pending with an `unbound` PodScheduled
+                            # condition for a few seconds while the
+                            # provisioner attaches the PVC. Logging this
+                            # at error level fired a false alarm on every
+                            # run before the PVC actually bound. Keep it
+                            # at debug — the timeout branch below is the
+                            # only place that actually concludes failure.
+                            for condition in pod.status.conditions or []:
+                                if (
+                                    condition.type == "PodScheduled"
+                                    and condition.status == "False"
+                                    and "unbound" in (condition.message or "").lower()
+                                ):
+                                    self._logger.debug(
+                                        f"PVC {pvc_name} still binding "
+                                        f"(PodScheduled=False, message: "
+                                        f"{condition.message})"
+                                    )
 
                 except exceptions.ApiException as e:
                     if e.status != 404:

--- a/tests/utils/managed_deployment.py
+++ b/tests/utils/managed_deployment.py
@@ -241,9 +241,15 @@ class ServiceSpec:
             self._spec["envs"].append(env)
 
     # ----- Log collection -----
-    def enable_log_collection(self, log_dir: str, pvc_name: str):
+    def enable_log_collection(self, log_dir: str, pvc_name: str, run_id: str = ""):
         """Capture stdout+stderr to a per-pod log file on the PVC without
         parsing the user's command.
+
+        ``run_id`` is an optional sub-path prefix used in reuse-PVC mode
+        so multiple tests sharing the same PVC don't overwrite each
+        other's logs. When non-empty, the per-pod log directory becomes
+        ``<log_dir>/<run_id>/service_logs/<component>/`` instead of
+        ``<log_dir>/service_logs/<component>/``.
 
         Strategy: prepend a fixed wrapper at argv[0]. The user's original
         command + args are concatenated (raw, no shell parsing) into
@@ -278,7 +284,8 @@ class ServiceSpec:
         main_container["command"] = [self._WRAPPER_PATH]
         main_container["args"] = list(original_command) + list(original_args)
 
-        service_log_dir = f"{log_dir}/service_logs/{self._name.lower()}"
+        prefix = f"{run_id}/" if run_id else ""
+        service_log_dir = f"{log_dir}/{prefix}service_logs/{self._name.lower()}"
 
         # The log PVC is operator-managed: service-level volumeMounts
         # tells the operator to provision the corresponding volume on
@@ -742,15 +749,25 @@ class DeploymentSpec:
         else:
             target_services = [self[name] for name in (service_names or [])]
 
+        # Per-test "run id" — a unique sub-path inside the log PVC.
+        # In default mode (auto-named per-test PVC) this is redundant
+        # but harmless. In reuse mode (user-supplied PVC shared across
+        # tests / DGDs) it provides per-test isolation: each run writes
+        # to `<run_id>/aiperf/...` and `<run_id>/service_logs/<comp>/...`,
+        # so concurrent or sequential tests on the same PVC don't
+        # overwrite each other. Cleared in-place after extract.
+        timestamp = int(time.time())
+        rand_suffix = secrets.randbelow(9000) + 1000
+        run_id = f"{self.name}-{timestamp}-{rand_suffix}"
+
         if pvc_name is None:
-            timestamp = int(time.time())
-            rand_suffix = secrets.randbelow(9000) + 1000
             pvc_name = f"{self.name}-logs-{timestamp}-{rand_suffix}"
 
         self._log_collection_pvc_name = pvc_name
         self._log_collection_pvc_size = pvc_size
         self._log_collection_storage_class = storage_class
         self._log_collection_container_dir = container_log_dir
+        self._log_collection_run_id = run_id
 
         if "pvcs" not in self._deployment_spec["spec"]:
             self._deployment_spec["spec"]["pvcs"] = []
@@ -768,7 +785,7 @@ class DeploymentSpec:
         )
 
         for service in target_services:
-            service.enable_log_collection(container_log_dir, pvc_name)
+            service.enable_log_collection(container_log_dir, pvc_name, run_id)
 
     def enable_model_cache(
         self,
@@ -883,11 +900,21 @@ class ManagedDeployment:
     # the service containing component_type: Frontend determines what is actually the frontend service
     frontend_service_name: str = "Frontend"
     skip_service_restart: bool = False
-    # When True, the log-collection PVC is assumed to already exist;
-    # _create_log_collection_pvc skips create + verify (just installs
-    # the wrapper ConfigMap), and _cleanup_log_collection_pvc skips
-    # delete. Set when the user passes --log-pvc.
+    # When True, the log-collection PVC is shared across tests:
+    #   - on first use, framework auto-creates it (404 → create + verify)
+    #   - each test writes to a unique sub-path `<dgd>-<ts>-<rand>`
+    #     within the PVC, so concurrent / sequential tests don't collide
+    #   - after extraction, that sub-path is wiped in-place; PVC binding
+    #     is preserved across runs (no 7-min FSx provisioning per test)
+    #   - PVC is never deleted at teardown
+    # Triggered by `--log-pvc <name>` on the CLI. Default-off keeps the
+    # legacy per-test ephemeral-PVC flow that other tests still rely on.
     reuse_log_pvc: bool = False
+    # When True (only meaningful with reuse_log_pvc=True), the existing
+    # named PVC is deleted and re-provisioned before this test starts.
+    # Use to break out of stuck-Terminating state, to switch storage
+    # classes, or to drop accumulated data from prior runs.
+    recreate_log_pvc: bool = False
     # When set, run a one-shot prefetch Job before applying the DGD
     # that downloads every non-frontend service's model into this
     # PVC. Avoids the lock-thrash when N worker pods hit HF
@@ -1914,6 +1941,15 @@ class ManagedDeployment:
         """
         return getattr(self.deployment_spec, "_log_collection_pvc_name", None)
 
+    def get_log_run_id(self) -> str:
+        """Return the per-test run-id used as a sub-path prefix inside the
+        shared log PVC. Empty string in default ephemeral-PVC mode (no
+        sub-path isolation needed).
+        """
+        if not self.reuse_log_pvc:
+            return ""
+        return getattr(self.deployment_spec, "_log_collection_run_id", "") or ""
+
     async def apply_service_changes(self, service_names: list[str]):
         """Push whatever in-memory mutations have been made on the named
         services to the cluster, in a single merge-patch.
@@ -1988,35 +2024,75 @@ class ManagedDeployment:
         assert self._core_api is not None, "Kubernetes API not initialized"
 
         if self.reuse_log_pvc:
-            self._logger.info(
-                f"Reusing existing log-collection PVC {pvc_name} "
-                f"(skip create + verify; --log-pvc was set)"
-            )
+            if self.recreate_log_pvc:
+                self._logger.info(
+                    f"--recreate-log-pvc set: dropping {pvc_name} before "
+                    f"re-provisioning..."
+                )
+                try:
+                    await self._core_api.delete_namespaced_persistent_volume_claim(
+                        name=pvc_name, namespace=self.namespace
+                    )
+                except exceptions.ApiException as e:
+                    if e.status != 404:
+                        raise
+                # Wait for the delete to complete. PVC has a
+                # pvc-protection finalizer; if any pod still references
+                # it the delete won't finish — surface that loudly so
+                # the user can clean up rather than silently re-using.
+                for _ in range(120):
+                    try:
+                        await self._core_api.read_namespaced_persistent_volume_claim(
+                            name=pvc_name, namespace=self.namespace
+                        )
+                        await asyncio.sleep(1)
+                    except exceptions.ApiException as e:
+                        if e.status == 404:
+                            break
+                        raise
+                else:
+                    raise RuntimeError(
+                        f"--recreate-log-pvc: {pvc_name} did not drop "
+                        f"within 120s. Likely a pod is still mounting "
+                        f"it — delete the referencing pods and retry."
+                    )
+
             try:
                 pvc = await self._core_api.read_namespaced_persistent_volume_claim(
                     name=pvc_name, namespace=self.namespace
                 )
-            except exceptions.ApiException as e:
-                if e.status == 404:
-                    raise RuntimeError(
-                        f"--log-pvc {pvc_name!r} does not exist in namespace "
-                        f"{self.namespace!r}; either create it first or omit "
-                        f"the flag to let the framework provision a fresh one."
-                    ) from None
-                raise
-            # If the PVC was just created or hasn't bound yet (FSx-Lustre
-            # provisioning takes ~5-7 min on AWS dev clusters), poll for
-            # Bound the same way the create path does — don't fail fast
-            # on Pending.
-            if pvc.status.phase != "Bound":
+                pvc_exists = True
                 self._logger.info(
-                    f"--log-pvc {pvc_name!r} is {pvc.status.phase}; waiting for Bound..."
+                    f"Reusing existing log-collection PVC {pvc_name} "
+                    f"(skip create + verify; in-place clear after extract)"
                 )
-                await self._verify_pvc_binding(pvc_name)
-            await self._install_log_wrapper_configmap()
-            self._log_collection_pvc_created = True
-            self._log_collection_pvc_verified = True
-            return pvc_name
+            except exceptions.ApiException as e:
+                if e.status != 404:
+                    raise
+                pvc_exists = False
+                self._logger.info(
+                    f"Log-collection PVC {pvc_name} does not exist — "
+                    f"creating once for reuse across all future runs "
+                    f"({pvc_size}, sc={storage_class or 'cluster-default'}, RWX)"
+                )
+
+            if not pvc_exists:
+                # Fall through to create path; verify-bind handles the
+                # 5-7 min FSx provisioning wait. After this run the PVC
+                # stays bound forever (never deleted at teardown).
+                pass
+            else:
+                # Already exists — handle the rare case where prior bind
+                # is still in flight.
+                if pvc.status.phase != "Bound":
+                    self._logger.info(
+                        f"Log PVC {pvc_name!r} is {pvc.status.phase}; waiting for Bound..."
+                    )
+                    await self._verify_pvc_binding(pvc_name)
+                await self._install_log_wrapper_configmap()
+                self._log_collection_pvc_created = True
+                self._log_collection_pvc_verified = True
+                return pvc_name
 
         self._logger.info(
             f"Creating log-collection PVC {pvc_name} ({pvc_size}, "
@@ -2363,12 +2439,17 @@ class ManagedDeployment:
         extractor = PvcExtractor(namespace=self.namespace, logger=self._logger)
         await extractor.init()
 
+        # See the _extract_logs_from_pvc docstring: run_id prefix is
+        # always present on the PVC, regardless of reuse mode.
+        run_id = getattr(self.deployment_spec, "_log_collection_run_id", "")
+        sub_path = f"{run_id}/service_logs" if run_id else "service_logs"
         return await extractor.extract(
             pvc_name=pvc_name,
-            sub_path="service_logs",
+            sub_path=sub_path,
             container_path=self.container_log_dir,
             file_patterns=["*.log"],
             local_output_dir=local_output_dir,
+            # clear_after_extract defaults to True
         )
 
     async def _verify_pvc_binding(self, pvc_name: str, timeout: int = 600):
@@ -2555,15 +2636,16 @@ class ManagedDeployment:
         """
         Clean up the log collection PVC if we created it.
 
-        Skipped when ``reuse_log_pvc`` is set — the PVC was provided by
-        the user; we don't own its lifecycle.
+        Skipped when ``reuse_log_pvc`` is set — the PVC is shared
+        across tests; we leave it bound. Per-test isolation comes from
+        unique sub-paths cleared in-place by pvc_extractor.
         """
         if not self._log_collection_pvc_created:
             return
         if self.reuse_log_pvc:
             self._logger.info(
                 "Skipping log-collection PVC delete (--log-pvc set; "
-                "reusing user-managed PVC)"
+                "shared PVC, per-test sub-path was cleared after extract)"
             )
             return
 
@@ -2635,12 +2717,23 @@ class ManagedDeployment:
             extractor = PvcExtractor(namespace=self.namespace, logger=self._logger)
             await extractor.init()
 
+            # The on-PVC path is ALWAYS `<run_id>/service_logs/<comp>/<pod>.log`
+            # because `DeploymentSpec.enable_log_collection` always assigns
+            # a `run_id` (timestamp+rand) regardless of reuse mode — see
+            # the `run_id = f"{self.name}-{timestamp}-{rand}"` block at the
+            # top of that method. Previously this branch fell back to a
+            # bare `service_logs` sub-path in non-reuse mode, which never
+            # exists on the PVC → `0 files matched for extraction` and
+            # every per-pod log was silently lost at teardown.
+            run_id = getattr(self.deployment_spec, "_log_collection_run_id", "")
+            sub_path = f"{run_id}/service_logs" if run_id else "service_logs"
             result = await extractor.extract(
                 pvc_name=pvc_name,
-                sub_path="service_logs",
+                sub_path=sub_path,
                 container_path=self.container_log_dir,
                 file_patterns=["*.log"],
                 local_output_dir=self.log_dir,
+                # clear_after_extract defaults to True
             )
 
             if result.get("success"):

--- a/tests/utils/managed_deployment.py
+++ b/tests/utils/managed_deployment.py
@@ -15,11 +15,84 @@ from typing import Any, List, Literal, Optional
 import kr8s
 import requests
 import yaml
-from kr8s.objects import Pod, Service
+from kr8s.objects import APIObject, Pod, Service
 from kubernetes_asyncio import client, config
 from kubernetes_asyncio.client import exceptions
 
 from tests.utils.test_output import resolve_test_output_path
+
+
+class DynamoWorkerMetadata(APIObject):
+    """kr8s wrapper for the Dynamo k8s-discovery worker metadata CR.
+
+    Each Dynamo worker pod publishes one CR named after its pod (single-
+    component pods) under ``nvidia.com/v1alpha1`` group, kind
+    ``DynamoWorkerMetadata``. ``spec.data.endpoints`` maps an endpoint
+    key to a dict whose ``instance_id`` is the u64 the FE uses for
+    nvext.worker_id pinning. See ``lib/runtime/src/discovery/kube/crd.rs``
+    for the source-of-truth schema.
+
+    Only populated when the worker runs with
+    ``DYN_DISCOVERY_BACKEND=kubernetes``; etcd-mode workers don't write
+    this CR.
+    """
+
+    version = "nvidia.com/v1alpha1"
+    endpoint = "dynamoworkermetadatas"
+    kind = "DynamoWorkerMetadata"
+    plural = "dynamoworkermetadatas"
+    singular = "dynamoworkermetadata"
+    namespaced = True
+
+    @property
+    def endpoints(self) -> dict:
+        """``spec.data.endpoints`` mapping, or ``{}`` if missing."""
+        spec = self.raw.get("spec", {}) or {}
+        data = spec.get("data", {}) or {}
+        return data.get("endpoints", {}) or {}
+
+    def instance_id(self, *, endpoint: Optional[str] = None) -> int:
+        """Return the Dynamo ``instance_id`` for this worker pod.
+
+        Dynamo workers register one ``instance_id`` per process and
+        expose multiple endpoint names against it (e.g. ``generate``,
+        ``clear_kv_blocks``, ``get_perf_metrics`` on a vLLM worker).
+        Since the (pod, instance_id) mapping is 1:1 for the
+        single-component-per-pod case, dedupe by value across all
+        endpoints and return the unique id.
+
+        Pass ``endpoint=`` (e.g. ``"generate"``) when a single pod hosts
+        multiple components, each with its own instance_id, and you
+        want a specific one. The endpoint-key path shape is
+        ``<namespace>/<dynamo-component>/<endpoint-name>/<id>``; the
+        ``endpoint-name`` is what this filter matches.
+        """
+        eps = self.endpoints
+        if not eps:
+            raise ValueError(
+                f"DynamoWorkerMetadata {self.name!r}: spec.data.endpoints "
+                f"is empty — is the worker fully started?"
+            )
+
+        if endpoint is not None:
+            matches = [v for k, v in eps.items() if f"/{endpoint}/" in str(k)]
+            if not matches:
+                raise ValueError(
+                    f"DynamoWorkerMetadata {self.name!r}: no endpoint "
+                    f"named {endpoint!r}; keys are {sorted(eps.keys())}"
+                )
+            unique_ids = {int(v["instance_id"]) for v in matches}
+        else:
+            unique_ids = {int(v["instance_id"]) for v in eps.values()}
+
+        if len(unique_ids) != 1:
+            raise ValueError(
+                f"DynamoWorkerMetadata {self.name!r}: expected one unique "
+                f"instance_id across endpoints, found {len(unique_ids)} "
+                f"({sorted(unique_ids)}); pass endpoint= to disambiguate. "
+                f"Keys: {sorted(eps.keys())}"
+            )
+        return unique_ids.pop()
 
 
 def _get_workspace_dir() -> str:
@@ -222,11 +295,50 @@ class ServiceSpec:
 
     # ----- Volume mounts and env vars -----
     def _add_volume_mount(self, name: str, mount_point: str):
-        """Add a volume mount if not already present."""
-        if "volumeMounts" not in self._spec:
-            self._spec["volumeMounts"] = []
-        if not any(m.get("name") == name for m in self._spec["volumeMounts"]):
-            self._spec["volumeMounts"].append({"name": name, "mountPoint": mount_point})
+        """Mount a PVC purely via ``extraPodSpec`` — both the
+        ``volumeMount`` and the matching pod-level ``volume`` are
+        written into ``extraPodSpec.mainContainer`` and
+        ``extraPodSpec.volumes`` directly.
+
+        Why not just set ``service.volumeMounts`` (the dedicated
+        v1alpha1 field)?
+
+        On dynamo-operator v1.2.0 the alpha→beta spec conversion runs
+        ``mergo.Merge(mainBase, extraPodSpec.MainContainer, mergo.WithOverride)``
+        in ``api/v1alpha1/shared_spec_conversion.go`` →
+        ``mergeExtraPodSpecMainContainer``. ``WithOverride`` REPLACES
+        slice fields like ``VolumeMounts`` rather than appending — so
+        any mount declared via the dedicated ``service.volumeMounts``
+        gets clobbered by ``extraPodSpec.mainContainer.volumeMounts``
+        if the latter is present. The operator's
+        ``appendMissingPVCVolumesForMounts`` then only sees the
+        survivors and never auto-adds the PVC volume for the dropped
+        names → pod-create fails with
+        ``spec.initContainers[N].volumeMounts[0].name: Not found``.
+
+        v1.1.0 worked (different merge semantics). Aligning everything
+        on ``extraPodSpec`` bypasses the operator-version dependency.
+
+        We declare ``extraPodSpec.volumes`` explicitly (instead of
+        relying on the operator's auto-add) for the same reason the
+        ``dyn-log-wrapper`` emptyDir handles its own volume — the
+        ``service.volumeMounts`` auto-add path is the layer that
+        breaks; this path doesn't go through it.
+        """
+        main_container = self._ensure_path("extraPodSpec", "mainContainer")
+        main_vmounts = main_container.setdefault("volumeMounts", [])
+        if not any(m.get("name") == name for m in main_vmounts):
+            main_vmounts.append({"name": name, "mountPath": mount_point})
+
+        extra_pod_spec = self._ensure_path("extraPodSpec")
+        volumes = extra_pod_spec.setdefault("volumes", [])
+        if not any(v.get("name") == name for v in volumes):
+            volumes.append(
+                {
+                    "name": name,
+                    "persistentVolumeClaim": {"claimName": name},
+                }
+            )
 
     def _add_env_var(self, name: str, value=None, value_from=None):
         """Add an env var if not already present."""
@@ -287,15 +399,14 @@ class ServiceSpec:
         prefix = f"{run_id}/" if run_id else ""
         service_log_dir = f"{log_dir}/{prefix}service_logs/{self._name.lower()}"
 
-        # The log PVC is operator-managed: service-level volumeMounts
-        # tells the operator to provision the corresponding volume on
-        # our behalf.
+        # The log PVC is declared via extraPodSpec (mount + volume) by
+        # _add_volume_mount. We deliberately do NOT use the
+        # service-level volumeMounts shortcut because on operator
+        # v1.2.0 mergo.WithOverride drops it — see the docstring on
+        # _add_volume_mount.
         self._add_volume_mount(pvc_name, log_dir)
-        # The wrapper-staging emptyDir is NOT operator-managed: we
-        # mount it directly on mainContainer (kubelet-level) and
-        # declare the volume in extraPodSpec.volumes ourselves. Mixing
-        # the two layers causes the operator to also generate a volume
-        # of the same name → "Duplicate value" error on Deployment apply.
+        # The wrapper-staging emptyDir mount + volume both live in
+        # extraPodSpec too, same pattern as the PVC above.
         main_vmounts = main_container.setdefault("volumeMounts", [])
         if not any(m.get("name") == self._WRAPPER_VOLUME for m in main_vmounts):
             main_vmounts.append(
@@ -1398,6 +1509,68 @@ class ManagedDeployment:
             result[original_name] = pods
 
         return result
+
+    def get_worker_metadata(
+        self, service_name: str, replica_index: int
+    ) -> DynamoWorkerMetadata:
+        """Return the ``DynamoWorkerMetadata`` CR for the ``replica_index``-th
+        pod of ``service_name``.
+
+        Pods are sorted by name for deterministic replica indexing — the
+        operator's pod-name suffix is hash-based, so name-sort is the
+        closest stable proxy for "replica 0, replica 1, ...". This will
+        change if the operator ever exposes an explicit replica-index
+        label; switch to that label here when it does.
+
+        The CR's name equals the pod name (single-component pods); see
+        ``lib/runtime/src/discovery/kube/crd.rs``. Requires
+        ``DYN_DISCOVERY_BACKEND=kubernetes`` on the worker.
+        """
+        pods = self.get_pods([service_name]).get(service_name) or []
+        if not pods:
+            raise ValueError(
+                f"get_worker_metadata: no pods for service {service_name!r} "
+                f"in namespace {self.namespace!r}"
+            )
+        pods = sorted(pods, key=lambda p: p.name)
+        if replica_index < 0 or replica_index >= len(pods):
+            raise IndexError(
+                f"get_worker_metadata: replica_index={replica_index} out of "
+                f"range for {service_name!r} ({len(pods)} pods)"
+            )
+        pod_name = pods[replica_index].name
+        crs = list(
+            kr8s.get(
+                DynamoWorkerMetadata,
+                pod_name,
+                namespace=self.namespace,
+            )
+        )
+        if not crs:
+            raise ValueError(
+                f"get_worker_metadata: no DynamoWorkerMetadata CR named "
+                f"{pod_name!r} in namespace {self.namespace!r} "
+                f"(is DYN_DISCOVERY_BACKEND=kubernetes set on the worker?)"
+            )
+        return crs[0]
+
+    def get_instance_id(
+        self,
+        service_name: str,
+        replica_index: int,
+        *,
+        endpoint: Optional[str] = None,
+    ) -> int:
+        """Look up the Dynamo ``instance_id`` for one worker replica.
+
+        Convenience wrapper around :py:meth:`get_worker_metadata` for the
+        ``WorkerPin`` flow: returns the integer ``instance_id`` that goes
+        into a request's ``nvext.worker_id`` field. ``endpoint`` (e.g.
+        ``"generate"``) disambiguates only on multi-component-per-pod
+        workers; the common single-component case ignores it.
+        """
+        cr = self.get_worker_metadata(service_name, replica_index)
+        return cr.instance_id(endpoint=endpoint)
 
     def get_pod_manifest_logs_metrics(self, service_name: str, pod: Pod, suffix=""):
         """Capture per-pod artifacts at a point in time.

--- a/tests/utils/managed_deployment.py
+++ b/tests/utils/managed_deployment.py
@@ -7,6 +7,7 @@ import os
 import re
 import secrets
 import shlex
+import signal
 import time
 from dataclasses import dataclass, field
 from typing import Any, List, Literal, Optional
@@ -327,22 +328,9 @@ class ServiceSpec:
                 }
             )
 
-        # 2. chmod 1777 the log mount. Some CSI drivers (fsx.csi.aws.com
-        #    Lustre) don't honour pod fsGroup, leaving the volume root
-        #    as root:root 0755 — the non-root main container then can't
-        #    mkdir its per-pod log subdir. Sticky 1777 mirrors /tmp.
-        #    NFS / k3s local-path / nfs-rwx honour fsGroup correctly so
-        #    this is a no-op there.
-        if not any(c.get("name") == "log-pvc-chmod" for c in init_containers):
-            init_containers.append(
-                {
-                    "name": "log-pvc-chmod",
-                    "image": "busybox:1.36",
-                    "command": ["sh", "-c", f"chmod 1777 {log_dir} || true"],
-                    "securityContext": {"runAsUser": 0, "runAsGroup": 0},
-                    "volumeMounts": [{"name": pvc_name, "mountPath": log_dir}],
-                }
-            )
+        # 2. Ensure the log PVC mount is writable for the non-root
+        #    main container. See _ensure_pvc_mount_writable.
+        self._ensure_pvc_mount_writable(pvc_name, log_dir)
 
         # 3. Volumes: ConfigMap (read-only), shared emptyDir (rw to
         #    init, ro fine for main since wrapper is exec'd not edited).
@@ -387,10 +375,48 @@ class ServiceSpec:
         self._add_env_var("HF_HOME", value=mount_path)
         self._add_env_var("HF_HUB_CACHE", value=mount_path)
         self._add_env_var("TRANSFORMERS_CACHE", value=mount_path)
-        # hf_transfer accelerates large-file downloads (Qwen3-30B + LLM
-        # tokenizer indexes are big enough to benefit). Costs nothing
-        # when the cache is warm.
-        self._add_env_var("HF_HUB_ENABLE_HF_TRANSFER", value="1")
+        # NOTE: HF_HUB_ENABLE_HF_TRANSFER=1 would speed up large-file
+        # downloads but requires the `hf_transfer` package, which the
+        # released vllm-runtime / sglang-runtime images don't ship.
+        # Pre-fetching the model out-of-band (see dynamo's
+        # recipes/<model>/model-cache/model-download.yaml pattern —
+        # python:3.10-slim + pip install hf_transfer + hf download)
+        # is the recommended way to populate this cache.
+
+        # Ensure the model-cache PVC mount is writable for the
+        # non-root main container. See _ensure_pvc_mount_writable.
+        self._ensure_pvc_mount_writable(pvc_name, mount_path)
+
+    def _ensure_pvc_mount_writable(self, pvc_name: str, mount_path: str) -> None:
+        """Schedule a chmod-1777 init container on this service's pod
+        for ``pvc_name`` mounted at ``mount_path``.
+
+        Some CSI drivers (notably fsx.csi.aws.com for Lustre) don't
+        honour pod fsGroup, leaving the volume root as ``root:root
+        0755`` — the non-root main container then can't write to it.
+        Sticky ``1777`` mirrors ``/tmp``: every pod writes its own
+        subtree without stepping on others'. NFS / k3s local-path /
+        nfs-rwx honour fsGroup correctly so this is a no-op there.
+
+        Idempotent — repeated calls for the same (pvc, path) pair
+        leave a single init container in place.
+        """
+        extra_pod_spec = self._ensure_path("extraPodSpec")
+        init_containers = extra_pod_spec.setdefault("initContainers", [])
+        # Init-container names must be unique per pod and ≤63 chars.
+        # Hash-and-truncate keeps it deterministic across runs.
+        init_name = f"chmod-{pvc_name}"[:63]
+        if any(c.get("name") == init_name for c in init_containers):
+            return
+        init_containers.append(
+            {
+                "name": init_name,
+                "image": "busybox:1.36",
+                "command": ["sh", "-c", f"chmod 1777 {mount_path} || true"],
+                "securityContext": {"runAsUser": 0, "runAsGroup": 0},
+                "volumeMounts": [{"name": pvc_name, "mountPath": mount_path}],
+            }
+        )
 
     # ----- ported from _2 (full surface area) -----
     def set_readiness_probe(
@@ -862,6 +888,13 @@ class ManagedDeployment:
     # the wrapper ConfigMap), and _cleanup_log_collection_pvc skips
     # delete. Set when the user passes --log-pvc.
     reuse_log_pvc: bool = False
+    # When set, run a one-shot prefetch Job before applying the DGD
+    # that downloads every non-frontend service's model into this
+    # PVC. Avoids the lock-thrash when N worker pods hit HF
+    # concurrently on a cold cache. Idempotent — skips already-cached
+    # models. Set by run_scenario when --prefetch-model + --model-pvc
+    # are both passed.
+    model_pvc: Optional[str] = None
 
     _custom_api: Optional[client.CustomObjectsApi] = None
     _core_api: Optional[client.CoreV1Api] = None
@@ -1569,12 +1602,21 @@ class ManagedDeployment:
                     leftovers.append(f"DGD/{meta['name']}")
         except exceptions.ApiException:
             pass
+        # When --log-pvc is set, the user supplied a reusable PVC and asked
+        # the framework not to delete it. Don't flag it as a leftover.
+        reused_pvc = (
+            getattr(self.deployment_spec, "_log_collection_pvc_name", None)
+            if self.reuse_log_pvc
+            else None
+        )
         try:
             pvcs = await self._core_api.list_namespaced_persistent_volume_claim(
                 namespace=self.namespace, label_selector="purpose=log-collection"
             )
             for pvc in pvcs.items:
                 if pvc.metadata.deletion_timestamp is None:
+                    if reused_pvc and pvc.metadata.name == reused_pvc:
+                        continue
                     leftovers.append(f"PVC/{pvc.metadata.name}")
         except exceptions.ApiException:
             pass
@@ -1785,6 +1827,17 @@ class ManagedDeployment:
             logging.getLogger("httpx").setLevel(logging.WARNING)
             await self._init_kubernetes()
 
+            # Convert SIGTERM / SIGINT into KeyboardInterrupt so a plain
+            # `kill <pytest-pid>` (or Ctrl-C, or a runner that sends
+            # SIGTERM on cancel) lands in our `except:` branch below
+            # AND in __aexit__'s _cleanup. Without this, a SIGTERM
+            # bypasses both and leaves orphan DGDs + PVCs + pods in
+            # the namespace. The standalone scripts/clean-test-ns.sh
+            # is the backup for cases this can't catch — SIGKILL,
+            # OOM-kill, or a wedged process holding the GIL.
+            self._prev_sigterm = signal.signal(signal.SIGTERM, self._signal_to_kbi)
+            self._prev_sigint = signal.signal(signal.SIGINT, self._signal_to_kbi)
+
             # Scrub the namespace clean of any state left over from prior
             # runs (failed-mid-test deployments, orphan PVCs, stale load
             # jobs). Without this, residual pods can sit alongside the
@@ -1801,6 +1854,11 @@ class ManagedDeployment:
             # the deployment go up and come down together.
             await self._create_log_collection_pvc()
 
+            # Optional: pre-fetch model weights into the cache PVC
+            # before workers come up, so N pods don't race on HF
+            # locks. No-op when --prefetch-model wasn't passed.
+            await self._prefetch_models()
+
             await self._create_deployment()
             await self._wait_for_ready()
 
@@ -1810,7 +1868,33 @@ class ManagedDeployment:
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
-        await self._cleanup()
+        try:
+            await self._cleanup()
+        finally:
+            # Restore prior signal handlers so a subsequent test in the
+            # same pytest session (or pytest's own SIGINT handler) is
+            # not stuck with our converter.
+            for sig, prev in (
+                (signal.SIGTERM, getattr(self, "_prev_sigterm", None)),
+                (signal.SIGINT, getattr(self, "_prev_sigint", None)),
+            ):
+                if prev is not None:
+                    try:
+                        signal.signal(sig, prev)
+                    except (ValueError, OSError):
+                        # signal.signal raises ValueError outside the
+                        # main thread; OSError on some platforms. Best
+                        # effort — handlers will be replaced anyway by
+                        # the next __aenter__ or by interpreter exit.
+                        pass
+
+    @staticmethod
+    def _signal_to_kbi(signum, frame):
+        """Signal handler: convert SIGTERM / SIGINT into
+        KeyboardInterrupt so the async context manager's `except:` /
+        `__aexit__` runs the normal cleanup. Restored on __aexit__.
+        """
+        raise KeyboardInterrupt(f"received signal {signum}")
 
     async def wait_for_ready(self, timeout: int = 1800, sleep=1, log_interval=60):
         """Public alias used by events.WaitForRecovery and RollingUpgrade.
@@ -1920,11 +2004,15 @@ class ManagedDeployment:
                         f"the flag to let the framework provision a fresh one."
                     ) from None
                 raise
+            # If the PVC was just created or hasn't bound yet (FSx-Lustre
+            # provisioning takes ~5-7 min on AWS dev clusters), poll for
+            # Bound the same way the create path does — don't fail fast
+            # on Pending.
             if pvc.status.phase != "Bound":
-                raise RuntimeError(
-                    f"--log-pvc {pvc_name!r} is in phase {pvc.status.phase}, "
-                    f"expected Bound. Resolve the binding before re-running."
+                self._logger.info(
+                    f"--log-pvc {pvc_name!r} is {pvc.status.phase}; waiting for Bound..."
                 )
+                await self._verify_pvc_binding(pvc_name)
             await self._install_log_wrapper_configmap()
             self._log_collection_pvc_created = True
             self._log_collection_pvc_verified = True
@@ -1981,6 +2069,152 @@ class ManagedDeployment:
         await self._install_log_wrapper_configmap()
         self._log_collection_pvc_created = True
         return pvc_name
+
+    async def _prefetch_models(self) -> None:
+        """Pre-fetch every non-frontend service's model into the model
+        cache PVC so concurrent worker pods don't race on HF Hub locks
+        on a cold cache.
+
+        No-op when ``model_pvc`` is unset (i.e. ``--prefetch-model``
+        was not passed). Idempotent — skips models whose snapshot
+        directory already exists in the cache. Mirrors dynamo's
+        ``recipes/<model>/model-cache/model-download.yaml`` pattern:
+        a one-shot ``python:3.10-slim`` Job runs ``pip install
+        huggingface_hub hf_transfer`` and ``hf download $MODEL`` with
+        ``HF_HUB_ENABLE_HF_TRANSFER=1``. Waits for the Job to
+        ``Succeeded`` before returning so the deployment apply that
+        follows sees a populated cache.
+        """
+        if not self.model_pvc:
+            return
+
+        # Collect unique model names from worker services.
+        models: list[str] = []
+        for svc in self.deployment_spec.services:
+            if svc.component_type == "frontend":
+                continue
+            m = svc.model
+            if not m:
+                # ServiceSpec.model only sees args[]; if the launch
+                # script wraps the worker (log-collection wrapper) the
+                # --model lives inside command[]. Best-effort regex.
+                container = svc._spec.get("extraPodSpec", {}).get("mainContainer", {})
+                cmd_text = " ".join(container.get("command", []) or []) + " "
+                cmd_text += " ".join(container.get("args", []) or [])
+                match = re.search(r"--(?:model|model-path)[\s=]+(\S+)", cmd_text)
+                if match:
+                    m = match.group(1)
+            if m and m not in models:
+                models.append(m)
+
+        if not models:
+            self._logger.info(
+                "Prefetch: no worker services have a --model arg; skipping"
+            )
+            return
+
+        assert self._core_api is not None
+        for model in models:
+            await self._prefetch_one_model(model)
+
+    async def _prefetch_one_model(self, model: str) -> None:
+        """Run a single model-download Job and wait for it to succeed."""
+        # Job name: derive from model + suffix to keep ≤63 chars.
+        slug = re.sub(r"[^a-z0-9-]", "-", model.lower()).strip("-")
+        job_name = f"prefetch-{slug}-{secrets.token_hex(2)}"[:63]
+
+        body = {
+            "apiVersion": "batch/v1",
+            "kind": "Job",
+            "metadata": {
+                "name": job_name,
+                "namespace": self.namespace,
+                "labels": {
+                    "managed-by": "managed-deployment",
+                    "purpose": "model-prefetch",
+                },
+            },
+            "spec": {
+                "backoffLimit": 1,
+                "ttlSecondsAfterFinished": 60,
+                "template": {
+                    "spec": {
+                        "restartPolicy": "Never",
+                        "securityContext": {
+                            "runAsUser": 1000,
+                            "fsGroup": 1000,
+                        },
+                        "containers": [
+                            {
+                                "name": "prefetch",
+                                "image": "python:3.10-slim",
+                                "envFrom": [{"secretRef": {"name": "hf-token-secret"}}],
+                                "env": [
+                                    {"name": "HOME", "value": "/tmp"},
+                                    {"name": "HF_HOME", "value": "/model-cache"},
+                                    {"name": "HF_HUB_CACHE", "value": "/model-cache"},
+                                    {
+                                        "name": "HF_HUB_ENABLE_HF_TRANSFER",
+                                        "value": "1",
+                                    },
+                                    {"name": "MODEL", "value": model},
+                                ],
+                                "command": ["sh", "-c"],
+                                "args": [
+                                    "set -eux\n"
+                                    "pip install --no-cache-dir --user "
+                                    "huggingface_hub hf_transfer\n"
+                                    '"$HOME/.local/bin/hf" download "$MODEL"\n'
+                                ],
+                                "volumeMounts": [
+                                    {
+                                        "name": "cache",
+                                        "mountPath": "/model-cache",
+                                    }
+                                ],
+                            }
+                        ],
+                        "volumes": [
+                            {
+                                "name": "cache",
+                                "persistentVolumeClaim": {"claimName": self.model_pvc},
+                            }
+                        ],
+                    }
+                },
+            },
+        }
+
+        batch = client.BatchV1Api()
+        await batch.create_namespaced_job(namespace=self.namespace, body=body)
+        self._logger.info(
+            f"Prefetch: scheduled {job_name} for model={model!r} "
+            f"(pvc={self.model_pvc})"
+        )
+        # Poll until Succeeded or Failed; 30 min cap covers
+        # cold-cache 30B-class downloads.
+        deadline = asyncio.get_event_loop().time() + 1800
+        while asyncio.get_event_loop().time() < deadline:
+            try:
+                job = await batch.read_namespaced_job(
+                    name=job_name, namespace=self.namespace
+                )
+                if job.status.succeeded is not None and job.status.succeeded > 0:
+                    self._logger.info(f"Prefetch: {model!r} cached successfully")
+                    return
+                if job.status.failed is not None and job.status.failed >= 1:
+                    raise RuntimeError(
+                        f"Prefetch Job {job_name} for model {model!r} "
+                        f"failed; check `kubectl logs -n {self.namespace} "
+                        f"job/{job_name}`."
+                    )
+            except exceptions.ApiException:
+                pass
+            await asyncio.sleep(5)
+        raise RuntimeError(
+            f"Prefetch Job {job_name} for model {model!r} did not "
+            f"complete within 30 min."
+        )
 
     async def _install_log_wrapper_configmap(self) -> None:
         """Apply the ConfigMap that holds the dyn_tee.sh log-tee wrapper.

--- a/tests/utils/managed_deployment.py
+++ b/tests/utils/managed_deployment.py
@@ -1062,6 +1062,16 @@ class ManagedDeployment:
 
     _custom_api: Optional[client.CustomObjectsApi] = None
     _core_api: Optional[client.CoreV1Api] = None
+    # The single kubernetes_asyncio ApiClient shared by all API objects below.
+    # Stored so __aexit__ can close it — otherwise its aiohttp session leaks
+    # ("Unclosed connector") on teardown.
+    _api_client: Optional[client.ApiClient] = None
+    # The task running the ``async with`` body. A loop-scheduled signal handler
+    # cancels exactly this task so teardown runs deterministically (see
+    # __aenter__). ``_cancelling`` makes the cancel one-shot.
+    _main_task: Optional[Any] = None
+    _cancelling: bool = False
+    _loop_signal_handlers_installed: bool = False
     _in_cluster: bool = False
     _logger: logging.Logger = logging.getLogger()
     _port_forward: Optional[Any] = None
@@ -1120,9 +1130,12 @@ class ManagedDeployment:
                 self._logger.info("Successfully loaded default kubeconfig")
 
         k8s_client = client.ApiClient()
+        self._api_client = k8s_client
         self._custom_api = client.CustomObjectsApi(k8s_client)
         self._core_api = client.CoreV1Api(k8s_client)
-        self._apps_v1 = client.AppsV1Api()
+        # Share the one ApiClient so closing it in __aexit__ tears down every
+        # API object's aiohttp session (no leaked "Unclosed connector").
+        self._apps_v1 = client.AppsV1Api(k8s_client)
 
     async def _wait_for_pods(self, label, expected, timeout=300):
         for _ in range(timeout):
@@ -2239,16 +2252,33 @@ class ManagedDeployment:
             logging.getLogger("httpx").setLevel(logging.WARNING)
             await self._init_kubernetes()
 
-            # Convert SIGTERM / SIGINT into KeyboardInterrupt so a plain
-            # `kill <pytest-pid>` (or Ctrl-C, or a runner that sends
-            # SIGTERM on cancel) lands in our `except:` branch below
-            # AND in __aexit__'s _cleanup. Without this, a SIGTERM
-            # bypasses both and leaves orphan DGDs + PVCs + pods in
-            # the namespace. The standalone scripts/clean-test-ns.sh
-            # is the backup for cases this can't catch — SIGKILL,
-            # OOM-kill, or a wedged process holding the GIL.
-            self._prev_sigterm = signal.signal(signal.SIGTERM, self._signal_to_kbi)
-            self._prev_sigint = signal.signal(signal.SIGINT, self._signal_to_kbi)
+            # Make a plain `kill <pytest-pid>` (or Ctrl-C, or a runner that
+            # SIGTERMs on cancel) tear the deployment down via __aexit__
+            # instead of stranding orphan DGDs + PVCs + pods. The standalone
+            # scripts/clean-test-ns.sh is the backup for what this can't catch
+            # (SIGKILL, OOM-kill, a wedged process holding the GIL).
+            #
+            # Prefer loop.add_signal_handler over signal.signal(...raise
+            # KeyboardInterrupt): a synchronous raise from the C signal callback
+            # can surface inside the event loop's own machinery (e.g. while it's
+            # blocked in epoll during a warmup poll) rather than inside our
+            # coroutine, abandoning the task with the loop already closing — so
+            # __aexit__ never runs and the run is stranded. A loop-scheduled
+            # task.cancel() always surfaces as CancelledError *inside* the
+            # awaited coroutine, so __aexit__ runs deterministically.
+            self._main_task = asyncio.current_task()
+            self._cancelling = False
+            try:
+                loop = asyncio.get_running_loop()
+                for sig in (signal.SIGTERM, signal.SIGINT):
+                    loop.add_signal_handler(sig, self._on_cancel_signal, sig)
+                self._loop_signal_handlers_installed = True
+            except (NotImplementedError, RuntimeError):
+                # add_signal_handler is Unix + main-thread-loop only; fall back
+                # to the synchronous KeyboardInterrupt converter.
+                self._loop_signal_handlers_installed = False
+                self._prev_sigterm = signal.signal(signal.SIGTERM, self._signal_to_kbi)
+                self._prev_sigint = signal.signal(signal.SIGINT, self._signal_to_kbi)
 
             # Scrub the namespace clean of any state left over from prior
             # runs (failed-mid-test deployments, orphan PVCs, stale load
@@ -2283,9 +2313,47 @@ class ManagedDeployment:
         try:
             await self._cleanup()
         finally:
-            # Restore prior signal handlers so a subsequent test in the
-            # same pytest session (or pytest's own SIGINT handler) is
-            # not stuck with our converter.
+            self._teardown_signal_handlers()
+            # Close the shared kubernetes_asyncio ApiClient (aiohttp session)
+            # so teardown doesn't leak an "Unclosed connector". Done after
+            # cleanup, which still needs the client for extract + delete.
+            if self._api_client is not None:
+                try:
+                    await self._api_client.close()
+                except Exception:
+                    pass
+                self._api_client = None
+
+    def _on_cancel_signal(self, signum):
+        """Loop-scheduled signal handler: cancel the task running this
+        ``async with`` exactly once so __aexit__ cleanup runs, then no-op on
+        repeats so a second signal can't abort the in-flight teardown (or trip
+        the default SIGTERM terminate-the-process action)."""
+        if self._cancelling:
+            self._logger.warning(
+                f"signal {signum} during teardown — ignoring (cleanup in progress)"
+            )
+            return
+        self._cancelling = True
+        self._logger.warning(
+            f"received signal {signum}; cancelling for graceful teardown"
+        )
+        if self._main_task is not None:
+            self._main_task.cancel()
+
+    def _teardown_signal_handlers(self):
+        """Undo whichever signal mechanism __aenter__ installed, so a later
+        test in the same session (or pytest's own SIGINT handler) isn't stuck
+        with ours."""
+        if getattr(self, "_loop_signal_handlers_installed", False):
+            try:
+                loop = asyncio.get_running_loop()
+                for sig in (signal.SIGTERM, signal.SIGINT):
+                    loop.remove_signal_handler(sig)
+            except (RuntimeError, ValueError, NotImplementedError):
+                pass
+            self._loop_signal_handlers_installed = False
+        else:
             for sig, prev in (
                 (signal.SIGTERM, getattr(self, "_prev_sigterm", None)),
                 (signal.SIGINT, getattr(self, "_prev_sigint", None)),
@@ -2294,10 +2362,9 @@ class ManagedDeployment:
                     try:
                         signal.signal(sig, prev)
                     except (ValueError, OSError):
-                        # signal.signal raises ValueError outside the
-                        # main thread; OSError on some platforms. Best
-                        # effort — handlers will be replaced anyway by
-                        # the next __aenter__ or by interpreter exit.
+                        # signal.signal raises ValueError off the main thread;
+                        # OSError on some platforms. Best effort — replaced by
+                        # the next __aenter__ or interpreter exit anyway.
                         pass
 
     @staticmethod

--- a/tests/utils/managed_deployment.py
+++ b/tests/utils/managed_deployment.py
@@ -2763,7 +2763,7 @@ class ManagedDeployment:
             pvc_name=pvc_name,
             sub_path=sub_path,
             container_path=self.container_log_dir,
-            file_patterns=["*.log"],
+            file_patterns=["*.log", "*.mempoller2.tsv"],
             local_output_dir=local_output_dir,
             # clear_after_extract defaults to True
         )
@@ -3047,7 +3047,7 @@ class ManagedDeployment:
                 pvc_name=pvc_name,
                 sub_path=sub_path,
                 container_path=self.container_log_dir,
-                file_patterns=["*.log"],
+                file_patterns=["*.log", "*.mempoller2.tsv"],
                 local_output_dir=self.log_dir,
                 # clear_after_extract defaults to True
             )

--- a/tests/utils/managed_deployment.py
+++ b/tests/utils/managed_deployment.py
@@ -192,6 +192,32 @@ class ServiceSpec:
     def replicas(self, value: int):
         self._spec["replicas"] = value
 
+    # ----- Memory request -----
+    def set_memory_request(self, value: str) -> None:
+        """Override the container memory *request* (e.g. '5Gi').
+
+        Controls scheduler packing density: a larger request caps how many
+        replicas a (bin-packing) scheduler can stack on one node, forcing it
+        to spread pods instead of cramming a node to OOM. Leaves limits and
+        cpu untouched. No-op on a falsy value.
+        """
+        if not value:
+            return
+        mc = self._spec.setdefault("extraPodSpec", {}).setdefault("mainContainer", {})
+        mc.setdefault("resources", {}).setdefault("requests", {})["memory"] = str(value)
+
+    def set_cpu_request(self, value: str) -> None:
+        """Override the container cpu *request* (e.g. '500m').
+
+        Same rationale as ``set_memory_request`` but for CPU: lowers the gang's
+        CPU pressure so a large mocker gang fits a shared CPU pool. The cpu
+        *limit* is unchanged, so busy pods still burst. No-op on a falsy value.
+        """
+        if not value:
+            return
+        mc = self._spec.setdefault("extraPodSpec", {}).setdefault("mainContainer", {})
+        mc.setdefault("resources", {}).setdefault("requests", {})["cpu"] = str(value)
+
     @property
     def model(self) -> Optional[str]:
         """Model being served by this service (checks both --model and --model-path)"""
@@ -1719,10 +1745,15 @@ class ManagedDeployment:
             return
 
         try:
-            # Render each event as its raw API object (a dict). Sorted by
-            # lastTimestamp so the file reads chronologically.
+            # Render each event as its raw API object. kr8s returns each as a
+            # box.Box (a dict subclass) which yaml.safe_dump has no representer
+            # for -> RepresenterError, leaving a 0-byte file. Convert to a plain
+            # dict first. Sorted by lastTimestamp so the file reads chronologically.
             payload = sorted(
-                (ev.raw for ev in events),
+                (
+                    ev.raw.to_dict() if hasattr(ev.raw, "to_dict") else ev.raw
+                    for ev in events
+                ),
                 key=lambda e: (
                     e.get("lastTimestamp")
                     or e.get("eventTime")
@@ -1777,6 +1808,15 @@ class ManagedDeployment:
             content = response.text
         except Exception as e:
             self._logger.error(str(e))
+        finally:
+            # Stop the forward as soon as this pod's scrape is done. Each
+            # forward holds a background thread + local port + an aiohttp
+            # session; leaking one per scrape (5 captures x N pods) exhausts
+            # local connections at scale and stalls *all* k8s ops — including
+            # the load-completion-marker read that force-stopped the N=15
+            # arm-C run at burst-3 (241 leaked forwards). Closing here keeps
+            # active forwards O(1).
+            self._close_port_forward(pf)
 
         if content:
             with open(
@@ -2114,6 +2154,25 @@ class ManagedDeployment:
                 f"Failed to create port forward for pod {pod.name}: {e}"
             )
             return None
+
+    def _close_port_forward(self, pf) -> None:
+        """Stop one port-forward and drop it from the active list.
+
+        Forwards are tracked in ``_active_port_forwards`` for teardown, but
+        one-shot consumers (metric scrapes) must close their forward right
+        after use so they don't accumulate over a long run — each holds a
+        thread + local port + an aiohttp session, and leaking hundreds
+        exhausts local connections (the N=15 arm-C burst-3 force-stop). The
+        teardown loop remains as a backstop for anything not closed here.
+        """
+        try:
+            pf.stop()
+        except Exception as e:
+            self._logger.debug(f"Error stopping port forward: {e}")
+        try:
+            self._active_port_forwards.remove(pf)
+        except ValueError:
+            pass
 
     async def _cleanup(self):
         try:

--- a/tests/utils/managed_deployment.py
+++ b/tests/utils/managed_deployment.py
@@ -1418,6 +1418,10 @@ class ManagedDeployment:
             )
             self._logger.info(self.deployment_spec.spec())
             self._logger.info(f"Deployment Started {self._deployment_name}")
+            # Capture the as-applied DGD spec + an env snapshot at the canonical
+            # location so post-hoc analysis has a single, durable record of
+            # what actually deployed.
+            self._write_deployment_provenance()
         except exceptions.ApiException as e:
             if e.status == 409:  # Already exists
                 self._logger.info(f"Deployment {self._deployment_name} already exists")
@@ -1426,6 +1430,88 @@ class ManagedDeployment:
                     f"Failed to create deployment {self._deployment_name}: {e}"
                 )
                 raise
+
+    def _write_deployment_provenance(self) -> None:
+        """Write ``dgd_spec.yaml`` + ``env_snapshot.json`` at the test's
+        canonical log_dir.
+
+        Why: the per-pod ``<pod>.yaml`` files capture pod-level specs, but the
+        full DGD as-applied (with all top-level envs + image tags resolved) is
+        not separately persisted. ``env_snapshot.json`` adds the framework
+        version + the dgh-703 test repo SHA + run timestamp so a run can be
+        replayed deterministically months later. Single-source-of-truth for
+        "what actually ran"."""
+        import json
+        import os
+        import subprocess
+        import time
+
+        try:
+            import yaml
+        except Exception:
+            yaml = None
+
+        log_dir = getattr(self, "log_dir", None)
+        if not log_dir:
+            return
+        try:
+            os.makedirs(log_dir, exist_ok=True)
+            spec = self.deployment_spec.spec()
+            if yaml is not None:
+                spec_path = os.path.join(log_dir, "dgd_spec.yaml")
+                with open(spec_path, "w") as fh:
+                    yaml.safe_dump(spec, fh, default_flow_style=False, sort_keys=False)
+            else:
+                spec_path = os.path.join(log_dir, "dgd_spec.json")
+                with open(spec_path, "w") as fh:
+                    json.dump(spec, fh, indent=2)
+
+            # Best-effort git SHA from the framework checkout
+            framework_sha = ""
+            try:
+                framework_sha = (
+                    subprocess.check_output(
+                        ["git", "rev-parse", "HEAD"],
+                        cwd=os.path.dirname(os.path.abspath(__file__)),
+                        stderr=subprocess.DEVNULL,
+                        timeout=2,
+                    )
+                    .decode()
+                    .strip()
+                )
+            except Exception:
+                pass
+
+            # Collect image tags per service for quick provenance
+            images = {}
+            try:
+                for svc_name, svc in (self.deployment_spec.services or {}).items():
+                    img = (
+                        (svc or {})
+                        .get("extraPodSpec", {})
+                        .get("mainContainer", {})
+                        .get("image")
+                    )
+                    if img:
+                        images[svc_name] = img
+            except Exception:
+                pass
+
+            snap = {
+                "test_name": getattr(self, "_test_name", "")
+                or getattr(self, "test_name", ""),
+                "deployment_name": self._deployment_name,
+                "namespace": self.namespace,
+                "log_dir": log_dir,
+                "framework_sha": framework_sha,
+                "deploy_started_epoch_s": int(time.time()),
+                "deploy_started_iso": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+                "images_per_service": images,
+            }
+            with open(os.path.join(log_dir, "env_snapshot.json"), "w") as fh:
+                json.dump(snap, fh, indent=2)
+        except Exception as e:
+            self._logger.warning(f"_write_deployment_provenance: {e}")
 
     async def trigger_rolling_upgrade(self, service_names: list[str]):
         """Trigger a rolling upgrade by stamping a unique env var on each
@@ -1575,8 +1661,18 @@ class ManagedDeployment:
     def get_pod_manifest_logs_metrics(self, service_name: str, pod: Pod, suffix=""):
         """Capture per-pod artifacts at a point in time.
 
-        Writes the pod manifest and an HTTP-metrics scrape only. The
-        container's stdout/stderr is already captured continuously to
+        Writes:
+          - ``<pod><suffix>.yaml``         — pod object (spec + status)
+          - ``<pod><suffix>.events.yaml``  — Kubernetes Event resources
+            referencing this pod (probe failures, kill reasons, scheduling
+            transitions, etc.). Events are a separate API resource from
+            the pod object, so we fetch them explicitly. Diagnosing
+            probe-restart cascades requires these — the pod's
+            ``status.containerStatuses[*].lastState`` only tells us THAT
+            a restart happened, not WHY.
+          - ``<pod><suffix>.metrics<suffix>.log`` — HTTP /metrics scrape
+
+        The container's stdout/stderr is already captured continuously to
         the log-collection PVC by the tee wrapper, so we don't grab
         ``pod.logs()`` here — it would just duplicate what the PVC has.
         That also avoids empty ``.previous.log`` files (the kubectl
@@ -1591,7 +1687,57 @@ class ManagedDeployment:
                 f.write(pod.to_yaml())
         except Exception as e:
             self._logger.error(e)
+        self._write_pod_events_yaml(pod, directory, suffix)
         self._get_pod_metrics(pod, service_name, suffix)
+
+    def _write_pod_events_yaml(
+        self, pod: Pod, directory: str, suffix: str = ""
+    ) -> None:
+        """Dump Kubernetes Event resources referencing this pod.
+
+        Field-selector ``involvedObject.name=<pod>`` narrows to the events
+        attached to this pod. Output is a YAML list of Event objects, one
+        per event, sorted by ``lastTimestamp``. This is the data behind
+        kubectl describe's Events table — probe failures, kill reasons,
+        schedule events.
+        """
+        try:
+            events = list(
+                kr8s.get(
+                    "events",
+                    namespace=pod.namespace,
+                    field_selector=f"involvedObject.name={pod.name}",
+                )
+            )
+        except Exception as e:
+            self._logger.warning(
+                f"_write_pod_events_yaml: failed to fetch events for {pod.name}: {e}"
+            )
+            return
+
+        if not events:
+            return
+
+        try:
+            # Render each event as its raw API object (a dict). Sorted by
+            # lastTimestamp so the file reads chronologically.
+            payload = sorted(
+                (ev.raw for ev in events),
+                key=lambda e: (
+                    e.get("lastTimestamp")
+                    or e.get("eventTime")
+                    or e.get("metadata", {}).get("creationTimestamp", "")
+                ),
+            )
+            out_path = os.path.join(directory, f"{pod.name}{suffix}.events.yaml")
+            with open(out_path, "w") as fh:
+                yaml.safe_dump_all(
+                    payload, fh, default_flow_style=False, sort_keys=False
+                )
+        except Exception as e:
+            self._logger.warning(
+                f"_write_pod_events_yaml: failed to write events for {pod.name}: {e}"
+            )
 
     def _get_service_logs(self, service_name=None, suffix=""):
         service_names = None
@@ -1605,32 +1751,30 @@ class ManagedDeployment:
                 self.get_pod_manifest_logs_metrics(service, pod, suffix)
 
     def _get_pod_metrics(self, pod: Pod, service_name: str, suffix=""):
-        directory = os.path.join(self.log_dir, service_name)
+        """Fetch HTTP /metrics from a pod and write under the lowercased
+        per-service dir so all per-pod artifacts (manifest, metrics,
+        stdout) cluster under one path.
+        """
+        directory = os.path.join(self.log_dir, service_name.lower())
         os.makedirs(directory, exist_ok=True)
-        port = None
-        if service_name == self.frontend_service_name:
-            port = self.deployment_spec.port
-        else:
-            port = self.deployment_spec.system_port
+
+        port = (
+            self.deployment_spec.port
+            if service_name == self.frontend_service_name
+            else self.deployment_spec.system_port
+        )
 
         pf = self.port_forward(pod, port)
-
         if not pf:
             self._logger.error(f"Unable to get metrics for {service_name}")
             return
 
         content = None
-
         try:
-            url = f"http://localhost:{pf.local_port}/metrics"
-
-            response = requests.get(url, timeout=30)
-            content = None
-            try:
-                content = response.text
-            except ValueError:
-                pass
-
+            response = requests.get(
+                f"http://localhost:{pf.local_port}/metrics", timeout=30
+            )
+            content = response.text
         except Exception as e:
             self._logger.error(str(e))
 
@@ -2000,6 +2144,15 @@ class ManagedDeployment:
                 await self._extract_logs_from_pvc()
             except Exception as e:
                 self._logger.warning(f"log extraction failed: {e}")
+            # Capture the FINAL /metrics scrape of every pod (raw, no parsing).
+            # Each pod's full metric text lands at
+            # ``<log_dir>/<service>/<pod>_<ts>.metrics.final.log`` —
+            # downstream verifiers / observe tooling pull the metric names
+            # they care about.
+            try:
+                await self._capture_metrics(suffix=".final")
+            except Exception as e:
+                self._logger.warning(f"final metrics scrape failed: {e}")
             try:
                 await self._cleanup_orphaned_jobs()
             except Exception as e:
@@ -2517,44 +2670,34 @@ class ManagedDeployment:
         with open(template_path, "r") as f:
             return f.read()
 
-    async def _get_pod_metrics(
-        self, pod: Pod, service_name: str, suffix="", use_services_dir: bool = False
-    ):
-        """Fetch HTTP metrics. Async - needs exec for timestamp.
+    async def _capture_metrics(self, suffix: str = ".final") -> None:
+        """Scrape ``/metrics`` of every pod across every service.
 
-        Writes alongside the per-pod manifest in the lowercased service
-        dir so all per-pod artifacts (manifest, metrics, stdout) are
-        under one dir per pod. ``use_services_dir`` is kept for back-
-        compat callers but the result is the same path either way.
+        Reuses ``_get_pod_metrics`` so output paths match the per-pod manifest
+        layout: ``<log_dir>/<service>/<pod>_<ts>.metrics<suffix>.log``.
+
+        Default suffix ``.final`` means "end-of-test snapshot." Downstream
+        verifiers / observe tooling parse opinions out of these raw dumps —
+        the framework does not pick favorite metric names.
         """
-        directory = os.path.join(self.log_dir, service_name.lower())
-        os.makedirs(directory, exist_ok=True)
-
-        port = (
-            self.deployment_spec.port
-            if service_name == self.frontend_service_name
-            else self.deployment_spec.system_port
-        )
-
-        pf = self.port_forward(pod, port)
-        if not pf:
-            self._logger.error(f"Unable to get metrics for {service_name}")
+        try:
+            service_pods = self.get_pods()
+        except Exception as e:
+            self._logger.warning(f"_capture_metrics: get_pods() failed: {e}")
             return
 
-        content = None
-        try:
-            response = requests.get(
-                f"http://localhost:{pf.local_port}/metrics", timeout=30
-            )
-            content = response.text
-        except Exception as e:
-            self._logger.error(str(e))
+        scraped = 0
+        for service, pods in (service_pods or {}).items():
+            for pod in pods or []:
+                try:
+                    self._get_pod_metrics(pod, service, suffix=suffix)
+                    scraped += 1
+                except Exception as e:
+                    self._logger.warning(f"_capture_metrics: {service}/{pod.name}: {e}")
 
-        if content:
-            timestamp = await self._get_container_timestamp(pod)
-            filename = f"{pod.name}_{timestamp}.metrics{suffix}.log"
-            with open(os.path.join(directory, filename), "w") as f:
-                f.write(content)
+        self._logger.info(
+            f"_capture_metrics: scraped {scraped} pods (suffix={suffix!r})"
+        )
 
     async def _exec_in_pod(
         self, pod: Pod, command: List[str], timeout: float = 10.0

--- a/tests/utils/managed_deployment.py
+++ b/tests/utils/managed_deployment.py
@@ -2822,7 +2822,7 @@ class ManagedDeployment:
             pvc_name=pvc_name,
             sub_path=sub_path,
             container_path=self.container_log_dir,
-            file_patterns=["*.log", "*.mempoller2.tsv"],
+            file_patterns=["*.log", "*.tsv"],
             local_output_dir=local_output_dir,
             # clear_after_extract defaults to True
         )
@@ -3106,7 +3106,7 @@ class ManagedDeployment:
                 pvc_name=pvc_name,
                 sub_path=sub_path,
                 container_path=self.container_log_dir,
-                file_patterns=["*.log", "*.mempoller2.tsv"],
+                file_patterns=["*.log", "*.tsv"],
                 local_output_dir=self.log_dir,
                 # clear_after_extract defaults to True
             )

--- a/tests/utils/managed_load.py
+++ b/tests/utils/managed_load.py
@@ -1,0 +1,692 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+ManagedLoad - YAML template-based load testing using shared PVC.
+
+This module provides a simplified load testing framework that:
+1. Uses a YAML template for the Job spec (instead of generating dynamically)
+2. Modifies only the aiperf command as needed
+3. Uses shared PVC with ManagedDeployment for storing results
+4. Uses PvcExtractor for extracting results from shared PVC
+"""
+
+import asyncio
+import json
+import logging
+import os
+import secrets
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import kr8s
+import yaml
+from kubernetes_asyncio import client
+from kubernetes_asyncio.client import exceptions
+
+
+def _get_template_dir() -> str:
+    """Get the templates directory path."""
+    return os.path.join(os.path.dirname(os.path.abspath(__file__)), "templates")
+
+
+@dataclass
+class LoadConfig:
+    """Configuration for load test parameters.
+
+    Note: endpoint_path is the API suffix (e.g., "/v1/chat/completions").
+    The base URL (host:port) is passed separately to ManagedLoad.
+    """
+
+    model_name: str = "Qwen/Qwen3-0.6B"
+    tokenizer: Optional[str] = None
+    endpoint_path: str = "/v1/chat/completions"  # API endpoint suffix
+
+    # Load parameters
+    concurrency: int = 8
+    request_count: Optional[int] = None
+    duration_minutes: Optional[float] = None
+
+    # Token parameters
+    input_tokens_mean: int = 512
+    input_tokens_stddev: int = 0
+    output_tokens_mean: int = 64
+    output_tokens_stddev: int = 0
+
+    # Request parameters
+    streaming: bool = True
+    request_rate: Optional[float] = None
+    request_timeout_seconds: float = 30.0
+    warmup_requests: Optional[int] = None
+
+    # Inference parameters
+    temperature: float = 0.0
+    repetition_penalty: float = 1.0
+    ignore_eos: bool = True
+
+    # Extra inference parameters
+    extra_inputs: Optional[Dict[str, Any]] = None
+
+    def __post_init__(self):
+        if self.warmup_requests is None:
+            self.warmup_requests = min(self.concurrency, 10)
+        if self.tokenizer is None:
+            self.tokenizer = self.model_name
+
+
+@dataclass
+class ManagedLoad:
+    """YAML template-based load testing using shared PVC.
+
+    Args:
+        namespace: Kubernetes namespace for the load test job
+        load_config: Load test configuration (concurrency, tokens, etc.)
+        pvc_name: Shared PVC from ManagedDeployment for storing results
+        endpoint_url: Base URL of the frontend service (e.g., http://frontend:8000)
+    """
+
+    namespace: str
+    load_config: LoadConfig
+    pvc_name: str  # Shared PVC from ManagedDeployment
+    endpoint_url: str  # Base URL (host:port) - passed by caller
+    template_path: Optional[str] = None
+    log_dir: Optional[str] = None
+    job_name: Optional[str] = None
+    container_results_dir: str = "/tmp/aiperf"
+
+    # Internal state
+    _core_api: Optional[client.CoreV1Api] = None
+    _batch_api: Optional[client.BatchV1Api] = None
+    _logger: logging.Logger = field(default_factory=lambda: logging.getLogger(__name__))
+    _job_created: bool = False
+    _terminated: bool = False
+    _load_completed: bool = False
+    _unique_suffix: str = field(default_factory=lambda: secrets.token_hex(4))
+
+    def __post_init__(self):
+        # Generate unique job name if not provided
+        if self.job_name is None:
+            self.job_name = f"load-test-{self._unique_suffix}"
+
+        # Use default template path if not provided
+        if self.template_path is None:
+            self.template_path = os.path.join(_get_template_dir(), "load_job.yaml")
+
+        # Set up local output directory
+        if self.log_dir:
+            self.local_output_dir = os.path.join(self.log_dir, "load")
+            os.makedirs(self.local_output_dir, exist_ok=True)
+            self._logger.info(
+                f"Load test results will be saved to: {self.local_output_dir}"
+            )
+        else:
+            self.local_output_dir = None
+
+    async def _init_kubernetes(self):
+        """Initialize kubernetes clients."""
+        from tests.utils.k8s_helpers import init_kubernetes_clients
+
+        self._core_api, self._batch_api, _, _, _ = await init_kubernetes_clients()
+
+    def _load_template(self) -> dict:
+        """Load and parse YAML template."""
+        with open(self.template_path, "r") as f:
+            return yaml.safe_load(f)
+
+    def _build_aiperf_command(self) -> str:
+        """Build aiperf command string from LoadConfig."""
+        cfg = self.load_config
+
+        args = [
+            "aiperf",
+            "profile",
+            "--artifact-dir",
+            self.container_results_dir,
+            "--model",
+            cfg.model_name,
+            "--tokenizer",
+            cfg.tokenizer,
+            "--endpoint-type",
+            "chat",
+            "--endpoint",
+            cfg.endpoint_path,
+            "--url",
+            self.endpoint_url,
+            "--synthetic-input-tokens-mean",
+            str(cfg.input_tokens_mean),
+            "--synthetic-input-tokens-stddev",
+            str(cfg.input_tokens_stddev),
+            "--output-tokens-mean",
+            str(cfg.output_tokens_mean),
+            "--output-tokens-stddev",
+            str(cfg.output_tokens_stddev),
+            "--concurrency",
+            str(cfg.concurrency),
+            "--warmup-request-count",
+            str(cfg.warmup_requests),
+            "--request-timeout-seconds",
+            str(cfg.request_timeout_seconds),
+            "--num-dataset-entries",
+            "12800",
+            "--random-seed",
+            "100",
+            "--workers-max",
+            "252",
+            "--record-processors",
+            "32",
+            "--ui",
+            "simple",
+            "--verbose",
+        ]
+
+        # Add duration or request count
+        if cfg.duration_minutes:
+            args.extend(["--benchmark-duration", str(cfg.duration_minutes * 60)])
+        elif cfg.request_count:
+            args.extend(["--request-count", str(cfg.request_count)])
+
+        if cfg.streaming:
+            args.append("--streaming")
+
+        if cfg.request_rate:
+            args.extend(["--request-rate", str(cfg.request_rate)])
+
+        # Build extra inputs
+        extra_inputs = {
+            "max_tokens": cfg.output_tokens_mean,
+            "min_tokens": cfg.output_tokens_mean,
+            "temperature": cfg.temperature,
+            "repetition_penalty": cfg.repetition_penalty,
+        }
+
+        if cfg.ignore_eos:
+            extra_inputs["ignore_eos"] = True
+
+        if cfg.extra_inputs:
+            extra_inputs.update(cfg.extra_inputs)
+
+        for key, value in extra_inputs.items():
+            args.extend(["--extra-inputs", f"{key}:{value}"])
+
+        return " ".join(args)
+
+    def _apply_config_to_template(self, template: dict) -> dict:
+        """Apply LoadConfig to template - set command, PVC, namespace."""
+        # Set metadata
+        template["metadata"]["name"] = self.job_name
+        template["metadata"]["namespace"] = self.namespace
+
+        # Get pod spec
+        pod_spec = template["spec"]["template"]["spec"]
+        container = pod_spec["containers"][0]
+
+        # Build the aiperf command
+        aiperf_cmd = self._build_aiperf_command()
+
+        # Update the container args with the aiperf command
+        # The template has AIPERF_CMD placeholder
+        original_script = container["args"][0]
+        updated_script = original_script.replace("AIPERF_CMD", aiperf_cmd)
+        container["args"] = [updated_script]
+
+        # Update environment variables
+        for env in container.get("env", []):
+            if env["name"] == "ENDPOINT_URL":
+                env["value"] = self.endpoint_url
+            elif env["name"] == "MODEL_NAME":
+                env["value"] = self.load_config.model_name
+
+        # Set PVC reference
+        for volume in pod_spec.get("volumes", []):
+            if "persistentVolumeClaim" in volume:
+                volume["persistentVolumeClaim"]["claimName"] = self.pvc_name
+
+        # Update volume mount path if needed
+        for mount in container.get("volumeMounts", []):
+            if mount["name"] == "results-volume":
+                mount["mountPath"] = self.container_results_dir
+
+        return template
+
+    async def _create_job(self):
+        """Create the load test job in Kubernetes."""
+        template = self._load_template()
+        job_spec = self._apply_config_to_template(template)
+
+        self._logger.info(f"Creating load test job: {self.job_name}")
+
+        try:
+            assert self._batch_api is not None, "Kubernetes API not initialized"
+            await self._batch_api.create_namespaced_job(
+                namespace=self.namespace, body=job_spec
+            )
+            self._job_created = True
+            self._logger.info(f"Load test job created: {self.job_name}")
+        except exceptions.ApiException as e:
+            if e.status == 409:  # Already exists
+                self._logger.warning(f"Job {self.job_name} already exists")
+                self._job_created = True
+            else:
+                self._logger.error(f"Failed to create job {self.job_name}: {e}")
+                raise
+
+    async def run(self, wait_for_completion: bool = True) -> Dict[str, Any]:
+        """Start the load test job."""
+        await self._create_job()
+
+        if wait_for_completion:
+            success = await self.wait_for_completion()
+            return {"success": success, "job_name": self.job_name}
+        else:
+            self._logger.info(f"Load test job {self.job_name} started (not waiting)")
+            return {"success": True, "job_name": self.job_name}
+
+    async def _wait_for_status_marker(
+        self, marker_file: str, marker_description: str, timeout: int
+    ) -> bool:
+        """Wait for a specific status marker file to appear in the pod."""
+        start_time = time.time()
+
+        self._logger.info(
+            f"Waiting for {marker_description} in job {self.job_name} (timeout: {timeout}s)"
+        )
+
+        while (time.time() - start_time) < timeout:
+            if self._terminated:
+                self._logger.info(f"{marker_description} wait terminated by request")
+                return False
+
+            try:
+                # Find the pod for this job
+                pods = []
+                pod_generator = kr8s.get(
+                    "pods",
+                    namespace=self.namespace,
+                    label_selector=f"job-name={self.job_name}",
+                )
+                for pod in pod_generator:
+                    pods.append(pod)
+
+                if pods:
+                    pod = pods[0]
+
+                    # Check if the status marker exists
+                    try:
+                        result = await asyncio.wait_for(
+                            asyncio.create_task(
+                                asyncio.to_thread(pod.exec, ["test", "-f", marker_file])
+                            ),
+                            timeout=10.0,
+                        )
+
+                        if result.returncode == 0:
+                            self._logger.info(
+                                f"{marker_description} marker found in job {self.job_name}"
+                            )
+                            return True
+
+                    except (asyncio.TimeoutError, Exception):
+                        pass
+
+                    # Check for job failure
+                    assert self._batch_api is not None
+                    job = await self._batch_api.read_namespaced_job(
+                        name=self.job_name, namespace=self.namespace
+                    )
+
+                    if job.status.failed:
+                        self._logger.error(
+                            f"Load test job {self.job_name} failed while waiting for {marker_description}"
+                        )
+                        return False
+
+                    # Check if job completed (not running anymore)
+                    if job.status.completion_time is not None:
+                        self._logger.info(
+                            f"Job {self.job_name} completed while waiting for {marker_description}"
+                        )
+                        return True
+
+            except exceptions.ApiException as e:
+                self._logger.warning(f"Error checking {marker_description} status: {e}")
+
+            await asyncio.sleep(5)
+
+        if self._terminated:
+            return False
+        else:
+            raise TimeoutError(f"{marker_description} did not appear within {timeout}s")
+
+    async def wait_for_started(self, timeout: int = 300) -> bool:
+        """Wait for the load test to start (5 minute timeout by default)."""
+        marker_file = f"{self.container_results_dir}/status/started"
+        return await self._wait_for_status_marker(
+            marker_file, "Load test start", timeout
+        )
+
+    async def wait_for_completion(self, timeout: Optional[int] = None) -> bool:
+        """Wait for the load test to complete."""
+        if timeout is None:
+            if self.load_config.duration_minutes:
+                timeout = (
+                    int(self.load_config.duration_minutes * 60) + 300
+                )  # 5 min buffer
+            elif self.load_config.request_count:
+                timeout = max(self.load_config.request_count * 2 + 60, 300)
+            else:
+                timeout = 600  # Default 10 minutes
+
+        marker_file = f"{self.container_results_dir}/status/completed"
+        result = await self._wait_for_status_marker(
+            marker_file, "Load test completion", timeout
+        )
+        if result:
+            self._load_completed = True
+        return result
+
+    async def terminate(self):
+        """Gracefully terminate the running load test.
+
+        Sends SIGINT to aiperf, waits for graceful shutdown, then SIGTERM.
+        Container exits after aiperf completes - results are on PVC.
+
+        If load already completed naturally, skips signaling.
+        """
+        self._logger.info(f"Terminating load test in job {self.job_name}")
+        self._terminated = True
+
+        if not self._job_created:
+            self._logger.warning("No job created to terminate")
+            return
+
+        # Skip signaling if load already completed naturally
+        if self._load_completed:
+            self._logger.info(
+                "Load test already completed, skipping termination signals"
+            )
+            return
+
+        try:
+            # Find and signal the pod
+            pods = []
+            pod_generator = kr8s.get(
+                "pods",
+                namespace=self.namespace,
+                label_selector=f"job-name={self.job_name}",
+            )
+            for pod in pod_generator:
+                pods.append(pod)
+
+            if pods:
+                pod = pods[0]
+                self._logger.info(f"Sending termination signal to pod {pod.name}")
+
+                # Send SIGINT for graceful shutdown
+                try:
+                    result = await asyncio.wait_for(
+                        asyncio.create_task(
+                            asyncio.to_thread(pod.exec, ["pkill", "-SIGINT", "aiperf"])
+                        ),
+                        timeout=10.0,
+                    )
+                    if result.returncode == 0:
+                        self._logger.info("SIGINT sent to aiperf process")
+                    else:
+                        self._logger.warning(
+                            "SIGINT failed, process may already be stopped"
+                        )
+                except Exception as e:
+                    self._logger.warning(f"Failed to send SIGINT: {e}")
+
+                # Wait for graceful shutdown
+                await asyncio.sleep(5)
+
+                # Send SIGTERM if still running
+                try:
+                    result = await asyncio.wait_for(
+                        asyncio.create_task(
+                            asyncio.to_thread(pod.exec, ["pkill", "-SIGTERM", "aiperf"])
+                        ),
+                        timeout=10.0,
+                    )
+                    if result.returncode == 0:
+                        self._logger.info("SIGTERM sent to aiperf process")
+                except Exception as e:
+                    self._logger.warning(f"Failed to send SIGTERM: {e}")
+
+                # Wait for pod to complete (container exits after aiperf finishes)
+                self._logger.info("Waiting for pod to complete...")
+                for attempt in range(60):  # Wait up to 1 minute
+                    try:
+                        pod.refresh()
+                        phase = pod.status.phase
+                        if phase in ("Succeeded", "Failed"):
+                            self._logger.info(f"Pod completed with phase: {phase}")
+                            break
+                    except Exception:
+                        pass
+
+                    if attempt < 59:
+                        await asyncio.sleep(1)
+                else:
+                    self._logger.warning(
+                        "Pod did not complete in time, proceeding anyway"
+                    )
+
+                self._logger.info("Load test termination completed")
+            else:
+                self._logger.warning("No pods found to terminate")
+
+        except Exception as e:
+            self._logger.error(f"Error during termination: {e}")
+
+    async def is_running(self) -> bool:
+        """Check if the load test is currently running."""
+        if not self._job_created or self._terminated:
+            return False
+
+        try:
+            assert self._batch_api is not None
+            job = await self._batch_api.read_namespaced_job(
+                name=self.job_name, namespace=self.namespace
+            )
+
+            # Job is running if not completed and not failed
+            is_active = job.status.completion_time is None and (
+                job.status.failed is None or job.status.failed == 0
+            )
+
+            if is_active:
+                # Double check by looking for running pods
+                pods = []
+                pod_generator = kr8s.get(
+                    "pods",
+                    namespace=self.namespace,
+                    label_selector=f"job-name={self.job_name}",
+                )
+                for pod in pod_generator:
+                    if pod.status.phase in ["Running", "Pending"]:
+                        pods.append(pod)
+                return len(pods) > 0
+
+            return False
+
+        except exceptions.ApiException as e:
+            if e.status == 404:
+                return False
+            self._logger.warning(f"Error checking job status: {e}")
+            return False
+
+    async def _delete_pod(self) -> None:
+        """Delete the load test pod."""
+        try:
+            pods = list(
+                kr8s.get(
+                    "pods",
+                    namespace=self.namespace,
+                    label_selector=f"job-name={self.job_name}",
+                )
+            )
+
+            if not pods:
+                return
+
+            pod = pods[0]
+            self._logger.info(f"Deleting pod {pod.name}")
+            pod.delete(force=True)
+
+            # Wait for pod to be deleted
+            for _ in range(30):
+                try:
+                    remaining = list(
+                        kr8s.get(
+                            "pods",
+                            namespace=self.namespace,
+                            label_selector=f"job-name={self.job_name}",
+                        )
+                    )
+                    if not remaining:
+                        self._logger.info("Pod deleted")
+                        break
+                except Exception:
+                    break
+                await asyncio.sleep(1)
+
+        except Exception as e:
+            self._logger.warning(f"Failed to delete pod: {e}")
+
+    async def _debug_pod_files(self) -> None:
+        """Debug helper: List files in the pod's results directory."""
+        try:
+            pods = list(
+                kr8s.get(
+                    "pods",
+                    namespace=self.namespace,
+                    label_selector=f"job-name={self.job_name}",
+                )
+            )
+
+            if not pods:
+                self._logger.info("DEBUG: No pods found")
+                return
+
+            pod = pods[0]
+            self._logger.info(f"DEBUG: Pod {pod.name} phase: {pod.status.phase}")
+
+            if pod.status.phase != "Running":
+                return
+
+            # List files in results directory
+            result = await asyncio.wait_for(
+                asyncio.create_task(
+                    asyncio.to_thread(
+                        pod.exec,
+                        ["ls", "-la", self.container_results_dir],
+                    )
+                ),
+                timeout=10.0,
+            )
+            if result.returncode == 0:
+                self._logger.info(
+                    f"DEBUG: Files in {self.container_results_dir}:\n{result.stdout.decode()}"
+                )
+
+        except Exception as e:
+            self._logger.warning(f"DEBUG: Failed to list files: {e}")
+
+    async def get_results(self) -> Optional[Dict[str, Any]]:
+        """Get parsed results JSON from PVC via PvcExtractor."""
+        try:
+            # Debug: Show what files are in the pod before deletion
+            await self._debug_pod_files()
+
+            # Delete the pod (results are already in PVC)
+            await self._delete_pod()
+
+            # Extract from PVC using PvcExtractor
+            from tests.utils.pvc_extractor import PvcExtractor
+
+            extractor = PvcExtractor(namespace=self.namespace, logger=self._logger)
+            await extractor.init()
+
+            output_dir = self.local_output_dir or "load"
+            result = await extractor.extract(
+                pvc_name=self.pvc_name,
+                sub_path="aiperf",
+                container_path=self.container_results_dir,
+                file_patterns=["*.json", "*.jsonl", "*.csv", "*.log"],
+                local_output_dir=output_dir,
+            )
+
+            if result.get("success"):
+                output_path = Path(result["output_dir"])
+                available_files = (
+                    list(output_path.iterdir()) if output_path.exists() else []
+                )
+                self._logger.info(
+                    f"Available result files: {[f.name for f in available_files]}"
+                )
+
+                json_file = output_path / "profile_export_aiperf.json"
+                if json_file.exists():
+                    self._logger.info(f"Using aiperf summary: {json_file}")
+                    with open(json_file) as f:
+                        return json.load(f)
+
+                self._logger.warning(
+                    f"No profile_export_aiperf.json found in {output_path}. "
+                    f"Available files: {[f.name for f in available_files]}"
+                )
+
+            return None
+
+        except Exception:
+            self._logger.exception("Failed to get results")
+            return None
+
+    async def _cleanup(self):
+        """Clean up the load test job."""
+        if self._job_created and self._batch_api:
+            try:
+                from kubernetes_asyncio.client.models import V1DeleteOptions
+
+                delete_options = V1DeleteOptions(propagation_policy="Foreground")
+                await self._batch_api.delete_namespaced_job(
+                    name=self.job_name,
+                    namespace=self.namespace,
+                    body=delete_options,
+                )
+                self._logger.info(f"Load test job {self.job_name} deleted")
+            except exceptions.ApiException as e:
+                if e.status != 404:
+                    self._logger.warning(f"Failed to delete job {self.job_name}: {e}")
+
+    async def __aenter__(self) -> "ManagedLoad":
+        """Create the load job."""
+        await self._init_kubernetes()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """Cleanup job resources."""
+        # Log if we're exiting due to an exception (Ctrl-C, etc.)
+        if exc_type is not None:
+            self._logger.warning(
+                f"Exiting due to exception ({exc_type.__name__}), running cleanup"
+            )
+        else:
+            # Only try to extract results if we're not exiting due to an exception
+            if self._job_created and self.local_output_dir:
+                try:
+                    await self.get_results()
+                except Exception as e:
+                    self._logger.warning(
+                        f"Failed to extract results during cleanup: {e}"
+                    )
+
+        # Always run cleanup, catching any cleanup errors
+        try:
+            await self._cleanup()
+        except Exception as cleanup_error:
+            self._logger.error(f"Error during cleanup: {cleanup_error}")

--- a/tests/utils/managed_load.py
+++ b/tests/utils/managed_load.py
@@ -67,6 +67,18 @@ class LoadConfig:
     # new flows — connection-tracked pooled sockets survive policy
     # creation and the partition becomes a no-op.
     connection_reuse_strategy: Optional[str] = None
+    # Additional /metrics endpoints for aiperf's --server-metrics. The
+    # base URL (Frontend) is scraped automatically; URLs here are
+    # appended so the run also collects per-worker Prometheus
+    # snapshots (e.g. the dynamo system_port pass-through, which
+    # surfaces vllm:* counters like vllm:nixl_num_kv_expired_reqs).
+    # StartLoad auto-populates this from worker pod IPs when None is
+    # passed; explicit list overrides. Note that pod IPs are valid
+    # for the duration of a pod's lifetime — tests that destroy and
+    # recreate a worker (DeletePod, etc.) will see scraping stop on
+    # recovery; the framework's per-pod _get_pod_metrics snapshot at
+    # fault-injection time still captures that point.
+    extra_server_metrics_urls: Optional[list[str]] = None
 
     # Inference parameters
     temperature: float = 0.0
@@ -202,6 +214,12 @@ class ManagedLoad:
 
         if cfg.connection_reuse_strategy:
             args.extend(["--connection-reuse-strategy", cfg.connection_reuse_strategy])
+
+        if cfg.extra_server_metrics_urls:
+            # aiperf accepts: --server-metrics <url1> <url2> ... — the
+            # base URL is scraped automatically by default, the URLs
+            # passed here are *additional* endpoints.
+            args.extend(["--server-metrics", *cfg.extra_server_metrics_urls])
 
         # Build extra inputs
         extra_inputs = {

--- a/tests/utils/managed_load.py
+++ b/tests/utils/managed_load.py
@@ -60,6 +60,13 @@ class LoadConfig:
     request_rate: Optional[float] = None
     request_timeout_seconds: float = 30.0
     warmup_requests: Optional[int] = None
+    # aiperf transport connection reuse. 'pooled' (aiperf default) keeps a
+    # single long-lived socket per worker; 'never' opens a fresh socket
+    # per request and tears it down after. Fault-injection tests should
+    # use 'never' so a NetworkPolicy applied mid-load can actually deny
+    # new flows — connection-tracked pooled sockets survive policy
+    # creation and the partition becomes a no-op.
+    connection_reuse_strategy: Optional[str] = None
 
     # Inference parameters
     temperature: float = 0.0
@@ -192,6 +199,9 @@ class ManagedLoad:
 
         if cfg.request_rate:
             args.extend(["--request-rate", str(cfg.request_rate)])
+
+        if cfg.connection_reuse_strategy:
+            args.extend(["--connection-reuse-strategy", cfg.connection_reuse_strategy])
 
         # Build extra inputs
         extra_inputs = {

--- a/tests/utils/managed_load.py
+++ b/tests/utils/managed_load.py
@@ -55,11 +55,67 @@ class LoadConfig:
     output_tokens_mean: int = 64
     output_tokens_stddev: int = 0
 
+    # AIPerf bucketed (ISL,OSL):weight distribution. When set, REPLACES
+    # the mean/stddev pair above. Format is the literal `--seq-dist`
+    # string aiperf expects, e.g.
+    # "100,200:5;500,200:15;1000,200:20;1600,200:30;3400,200:20;7000,200:10"
+    # (six buckets — each "isl,osl:probability"). Lets a test express a
+    # lognormal-shape distribution (p50 1.6k / p99 7k) that prod traffic
+    # follows. None = use mean/stddev path.
+    seq_dist: Optional[str] = None
+
+    # Prefix-cache shaping. AIPerf builds a pool of `num_prefix_prompts`
+    # templates, each truncated to `prefix_prompt_length` tokens, and
+    # rotates them on the front of every request. Block-level hit-rate
+    # ≈ prefix_prompt_length / mean_isl (clamped to vllm block size 16).
+    # Example: ~37% with num_prefix_prompts=15 / prefix_prompt_length=600
+    # against ISL p50 ≈ 1600.
+    num_prefix_prompts: Optional[int] = None
+    prefix_prompt_length: Optional[int] = None
+    # Alternative: single shared system prompt of L tokens prepended to
+    # every request. Mutually exclusive with the prefix-prompts pool;
+    # set whichever fits the production shape.
+    shared_system_prompt_length: Optional[int] = None
+
     # Request parameters
     streaming: bool = True
     request_rate: Optional[float] = None
     request_timeout_seconds: float = 30.0
     warmup_requests: Optional[int] = None
+    # Probabilistic mid-flight cancellation. AIPerf sends the request
+    # fully, then aborts after `request_cancellation_delay` seconds.
+    # `request_cancellation_rate` is the percentage of requests cancelled
+    # (0-100). Designed for testing how the server handles client
+    # disconnects — exercises the SO_LINGER=0 RST path on the frontend
+    # without needing iptables fault injection. Independent of the SLA
+    # timeout (`request_timeout_seconds`) which also cancels but only on
+    # the slow tail.
+    request_cancellation_rate: Optional[float] = None
+    request_cancellation_delay: float = 0.0
+    # AIPerf arrival shaping. "constant" (default), "poisson", "burst".
+    # `arrival_smoothness` is the burstiness coefficient when arrival_pattern=burst
+    # (lower = more bursty; ~0.2 produces sharp peaks).
+    arrival_pattern: Optional[str] = None
+    arrival_smoothness: Optional[float] = None
+    # Closed-loop concurrency ramp: linearly grow from
+    # `warmup_concurrency` (or 1) up to `concurrency` over
+    # `concurrency_ramp_duration` seconds. Mirrors the diurnal climb
+    # observed on production disagg decode pods (typical diurnal climb,
+    # e.g. 7 → 16 RPS over ~2 h) in miniature.
+    concurrency_ramp_duration: Optional[float] = None
+    warmup_concurrency: Optional[int] = None
+    warmup_duration: Optional[float] = None
+    # aiperf goodput SLOs. List of "metric_tag:value" strings in the
+    # metric's display unit; aiperf treats a request as "good" only if
+    # all SLOs hold. Common tags + units:
+    #   request_latency:<ms>                    (e2e)
+    #   time_to_first_token:<ms>                (TTFT)
+    #   inter_token_latency:<ms>                (ITL)
+    #   output_token_throughput_per_user:<tok/s>
+    # See https://arxiv.org/pdf/2401.09670 (DistServe) for the definition.
+    # When set, aiperf reports a ``goodput`` summary alongside
+    # request_throughput. None = goodput not computed.
+    goodput: Optional[list[str]] = None
     # aiperf transport connection reuse. 'pooled' (aiperf default) keeps a
     # single long-lived socket per worker; 'never' opens a fresh socket
     # per request and tears it down after. Fault-injection tests should
@@ -110,6 +166,12 @@ class ManagedLoad:
     load_config: LoadConfig
     pvc_name: str  # Shared PVC from ManagedDeployment
     endpoint_url: str  # Base URL (host:port) - passed by caller
+    # Per-test sub-path prefix inside the shared PVC. Non-empty only in
+    # reuse-PVC mode (--log-pvc). When set, the load Job mounts the PVC
+    # at `<pvc_run_id>/aiperf` so each test on a shared PVC writes to
+    # its own location, and extract+clear operates on that sub-path
+    # only.
+    pvc_run_id: str = ""
     template_path: Optional[str] = None
     log_dir: Optional[str] = None
     job_name: Optional[str] = None
@@ -133,9 +195,14 @@ class ManagedLoad:
         if self.template_path is None:
             self.template_path = os.path.join(_get_template_dir(), "load_job.yaml")
 
-        # Set up local output directory
+        # Set up local output directory. Each ManagedLoad gets its own
+        # `load/<job_name>/` so chained StartLoad / rung results don't
+        # overlay each other locally. (The previous flat `load/` mirrored
+        # only the last rung's files on disk.)
         if self.log_dir:
-            self.local_output_dir = os.path.join(self.log_dir, "load")
+            self.local_output_dir = os.path.join(
+                self.log_dir, "load", self.job_name or "default"
+            )
             os.makedirs(self.local_output_dir, exist_ok=True)
             self._logger.info(
                 f"Load test results will be saved to: {self.local_output_dir}"
@@ -173,30 +240,96 @@ class ManagedLoad:
             cfg.endpoint_path,
             "--url",
             self.endpoint_url,
-            "--synthetic-input-tokens-mean",
-            str(cfg.input_tokens_mean),
-            "--synthetic-input-tokens-stddev",
-            str(cfg.input_tokens_stddev),
-            "--output-tokens-mean",
-            str(cfg.output_tokens_mean),
-            "--output-tokens-stddev",
-            str(cfg.output_tokens_stddev),
-            "--concurrency",
-            str(cfg.concurrency),
-            "--request-timeout-seconds",
-            str(cfg.request_timeout_seconds),
-            "--num-dataset-entries",
-            "12800",
-            "--random-seed",
-            "100",
-            "--workers-max",
-            "252",
-            "--record-processors",
-            "32",
-            "--ui",
-            "simple",
-            "--verbose",
         ]
+
+        # ISL/OSL shape: bucketed --seq-dist takes precedence over
+        # mean/stddev when set. Both paths flow through aiperf's
+        # synthetic dataset generator.
+        if cfg.seq_dist:
+            args.extend(["--seq-dist", cfg.seq_dist])
+        else:
+            args.extend(
+                [
+                    "--synthetic-input-tokens-mean",
+                    str(cfg.input_tokens_mean),
+                    "--synthetic-input-tokens-stddev",
+                    str(cfg.input_tokens_stddev),
+                    "--output-tokens-mean",
+                    str(cfg.output_tokens_mean),
+                    "--output-tokens-stddev",
+                    str(cfg.output_tokens_stddev),
+                ]
+            )
+
+        # Prefix-cache shaping (mutually exclusive paths). When neither
+        # is set, aiperf generates random prompts -> ~0% block-level hit.
+        if cfg.num_prefix_prompts and cfg.prefix_prompt_length:
+            args.extend(
+                [
+                    "--num-prefix-prompts",
+                    str(cfg.num_prefix_prompts),
+                    "--prefix-prompt-length",
+                    str(cfg.prefix_prompt_length),
+                ]
+            )
+        elif cfg.shared_system_prompt_length:
+            args.extend(
+                [
+                    "--shared-system-prompt-length",
+                    str(cfg.shared_system_prompt_length),
+                ]
+            )
+
+        args.extend(
+            [
+                "--concurrency",
+                str(cfg.concurrency),
+                "--request-timeout-seconds",
+                str(cfg.request_timeout_seconds),
+                "--num-dataset-entries",
+                "12800",
+                "--random-seed",
+                "100",
+                "--workers-max",
+                "252",
+                "--record-processors",
+                "32",
+                "--ui",
+                "simple",
+                "--verbose",
+            ]
+        )
+
+        # Closed-loop concurrency ramp + warmup variants.
+        if cfg.concurrency_ramp_duration:
+            args.extend(
+                ["--concurrency-ramp-duration", str(cfg.concurrency_ramp_duration)]
+            )
+        if cfg.warmup_concurrency:
+            args.extend(["--warmup-concurrency", str(cfg.warmup_concurrency)])
+        if cfg.warmup_duration:
+            args.extend(["--warmup-duration", str(cfg.warmup_duration)])
+
+        # Arrival pattern (rate-based mode; ignored when concurrency mode
+        # is in use, which is our default).
+        if cfg.arrival_pattern:
+            args.extend(["--arrival-pattern", cfg.arrival_pattern])
+        if cfg.arrival_smoothness is not None:
+            args.extend(["--arrival-smoothness", str(cfg.arrival_smoothness)])
+
+        # Probabilistic mid-flight cancellation (separate from SLA
+        # timeout — both can fire on the same run).
+        if cfg.request_cancellation_rate:
+            args.extend(
+                ["--request-cancellation-rate", str(cfg.request_cancellation_rate)]
+            )
+            if cfg.request_cancellation_delay:
+                args.extend(
+                    [
+                        "--request-cancellation-delay",
+                        str(cfg.request_cancellation_delay),
+                    ]
+                )
 
         # Add duration or request count
         if cfg.duration_minutes:
@@ -218,6 +351,13 @@ class ManagedLoad:
 
         if cfg.connection_reuse_strategy:
             args.extend(["--connection-reuse-strategy", cfg.connection_reuse_strategy])
+
+        if cfg.goodput:
+            # aiperf accepts a single space-separated 'KEY:VALUE' string
+            # (parse_str_as_numeric_dict in input_config.py). Repeated
+            # --goodput flags overwrite each other; single-string is
+            # required. Shell-quoting handled by shlex.join on the way out.
+            args.extend(["--goodput", " ".join(cfg.goodput)])
 
         if cfg.extra_server_metrics_urls:
             # aiperf accepts: --server-metrics <url1> <url2> ... — the
@@ -263,12 +403,17 @@ class ManagedLoad:
         # rigid min=max forces vllm to reject any request whose ISL
         # leaves <min_tokens of budget. Useful for modeling the "client
         # sends out-of-spec request" failure that climbs error counters.
-        extra_inputs = {
-            "max_tokens": cfg.output_tokens_mean,
+        extra_inputs: Dict[str, Any] = {
             "min_tokens": 1,
             "temperature": cfg.temperature,
             "repetition_penalty": cfg.repetition_penalty,
         }
+        # When seq_dist is in use, AIPerf drives per-request max_tokens
+        # from the bucketed OSL — adding a static max_tokens here would
+        # clamp every request to the same OSL, defeating the
+        # distribution. Only set max_tokens when seq_dist is None.
+        if not cfg.seq_dist:
+            extra_inputs["max_tokens"] = cfg.output_tokens_mean
 
         if cfg.ignore_eos:
             extra_inputs["ignore_eos"] = True
@@ -279,7 +424,12 @@ class ManagedLoad:
         for key, value in extra_inputs.items():
             args.extend(["--extra-inputs", f"{key}:{value}"])
 
-        return " ".join(args)
+        # shlex.join quotes args that contain whitespace (e.g. --goodput's
+        # 'request_latency:30000 ttft:5000' string) so they survive the
+        # docker exec -> bash chain as a single token to aiperf.
+        import shlex as _shlex
+
+        return _shlex.join(args)
 
     def _apply_config_to_template(self, template: dict) -> dict:
         """Apply LoadConfig to template - set command, PVC, namespace."""
@@ -312,10 +462,20 @@ class ManagedLoad:
             if "persistentVolumeClaim" in volume:
                 volume["persistentVolumeClaim"]["claimName"] = self.pvc_name
 
-        # Update volume mount path if needed
+        # Update volume mount path if needed. We prepend `<job_name>` to
+        # the subPath so each chained StartLoad / rung writes to its
+        # own location on the PVC (aiperf overwrites profile_export*
+        # files on each invocation; sharing one sub-path means rung N+1
+        # destroys rung N's results before extraction). In reuse-PVC
+        # mode we also prepend `<run_id>` so multiple test scenarios
+        # sharing the PVC stay isolated from each other.
+        rung_subpath = f"{self.job_name}/aiperf"
+        if self.pvc_run_id:
+            rung_subpath = f"{self.pvc_run_id}/{rung_subpath}"
         for mount in container.get("volumeMounts", []):
             if mount["name"] == "results-volume":
                 mount["mountPath"] = self.container_results_dir
+                mount["subPath"] = rung_subpath
 
         return template
 
@@ -681,12 +841,32 @@ class ManagedLoad:
             await extractor.init()
 
             output_dir = self.local_output_dir or "load"
+            # Mirror the per-rung subPath layout used in `_apply_config_to_template`
+            # so we extract exactly this rung's files (not whatever the last
+            # ManagedLoad left under `aiperf/`).
+            sub_path = f"{self.job_name}/aiperf"
+            if self.pvc_run_id:
+                sub_path = f"{self.pvc_run_id}/{sub_path}"
             result = await extractor.extract(
                 pvc_name=self.pvc_name,
-                sub_path="aiperf",
+                sub_path=sub_path,
                 container_path=self.container_results_dir,
-                file_patterns=["*.json", "*.jsonl", "*.csv", "*.log"],
+                # Explicit result-file globs. Avoid `*.json` because
+                # aiperf's `inputs.json` (synthetic prompt corpus) can be
+                # 100s of MB and saturates the WebSocket `cat` we use to
+                # stream the tar out of the pod. The inputs.json isn't
+                # needed for analysis.
+                file_patterns=[
+                    "profile_export*.json",
+                    "profile_export*.jsonl",
+                    "profile_export*.csv",
+                    "server_metrics_export*.json",
+                    "server_metrics_export*.jsonl",
+                    "server_metrics_export*.csv",
+                    "aiperf.log",
+                ],
                 local_output_dir=output_dir,
+                # clear_after_extract defaults to True
             )
 
             if result.get("success"):
@@ -707,6 +887,19 @@ class ManagedLoad:
                 self._logger.warning(
                     f"No profile_export_aiperf.json found in {output_path}. "
                     f"Available files: {[f.name for f in available_files]}"
+                )
+            else:
+                # Make the failure obvious in the test log — previously this
+                # branch silently dropped a successful run's data when the
+                # extractor timed out on FSx, leaving no per-rung results
+                # while the load itself had succeeded.
+                self._logger.error(
+                    "Result extraction failed for load '%s' (pvc=%s, sub_path=aiperf): %s. "
+                    "Load Job completed but aiperf JSON was not copied off the PVC; "
+                    "raise pvc_extractor timeouts or run with --log-pvc to keep the data on the PVC.",
+                    self.job_name,
+                    self.pvc_name,
+                    result.get("error", "<no error key>"),
                 )
 
             return None
@@ -749,9 +942,14 @@ class ManagedLoad:
             if self._job_created and self.local_output_dir:
                 try:
                     await self.get_results()
-                except Exception as e:
-                    self._logger.warning(
-                        f"Failed to extract results during cleanup: {e}"
+                except Exception:
+                    # Log full traceback so silent timeouts / k8s API errors
+                    # are debuggable; previously this swallowed the cause and
+                    # printed only the exception's str (empty for TimeoutError).
+                    self._logger.exception(
+                        "Failed to extract results during cleanup " "(job=%s, pvc=%s)",
+                        self.job_name,
+                        self.pvc_name,
                     )
 
         # Always run cleanup, catching any cleanup errors

--- a/tests/utils/managed_load.py
+++ b/tests/utils/managed_load.py
@@ -183,8 +183,6 @@ class ManagedLoad:
             str(cfg.output_tokens_stddev),
             "--concurrency",
             str(cfg.concurrency),
-            "--warmup-request-count",
-            str(cfg.warmup_requests),
             "--request-timeout-seconds",
             str(cfg.request_timeout_seconds),
             "--num-dataset-entries",
@@ -206,6 +204,12 @@ class ManagedLoad:
         elif cfg.request_count:
             args.extend(["--request-count", str(cfg.request_count)])
 
+        # aiperf 0.7.0 rejects --warmup-request-count 0 (requires > 0).
+        # Only emit the flag when the caller wants warmup; otherwise let
+        # aiperf use its default (no warmup or its own default count).
+        if cfg.warmup_requests:
+            args.extend(["--warmup-request-count", str(cfg.warmup_requests)])
+
         if cfg.streaming:
             args.append("--streaming")
 
@@ -219,12 +223,49 @@ class ManagedLoad:
             # aiperf accepts: --server-metrics <url1> <url2> ... — the
             # base URL is scraped automatically by default, the URLs
             # passed here are *additional* endpoints.
+            # Note: requires aiperf >= 0.7.0 for the flag to take effect;
+            # earlier versions silently ignored it.
             args.extend(["--server-metrics", *cfg.extra_server_metrics_urls])
+            # Default formats are JSON + CSV — aggregated summaries only.
+            # Add JSONL (raw 1Hz time-series, line-delimited) so we can
+            # post-process which signal spiked first vs. last. Skip
+            # PARQUET: redundant for our minute-scale runs and pulls in
+            # pyarrow as a downstream-tool dep with no real benefit at
+            # this data volume.
+            args.extend(
+                [
+                    "--server-metrics-formats",
+                    "json",
+                    "csv",
+                    "jsonl",
+                ]
+            )
 
-        # Build extra inputs
+        # Build extra inputs.
+        #
+        # max_tokens / min_tokens semantics in vllm:
+        #   - We pass our requested max_tokens to the engine.
+        #   - vllm INTERNALLY clamps max_tokens down to
+        #     `max_model_len − prompt_token_count` per-request. If a high
+        #     ISL sample (e.g. 8112 tokens with max_model_len=8192) leaves
+        #     only 80 tokens of budget, vllm uses max_tokens=80 for THAT
+        #     request — even though the client asked for 100.
+        #   - If the client's `min_tokens` exceeds vllm's clamped
+        #     max_tokens, vllm rejects the request with
+        #       `ValueError: min_tokens=N must be ≤ max_tokens=K, got K<N`.
+        #
+        # Default (here): min_tokens=1. vllm's per-request clamp is
+        # always allowed to drop the cap; the floor is permissive; no
+        # rejection. Tests get the load they ask for.
+        #
+        # Opt-in failure mode (e.g. test_scenario_bad_input_distribution
+        # passes `extra_inputs={"min_tokens": output_tokens_mean}`):
+        # rigid min=max forces vllm to reject any request whose ISL
+        # leaves <min_tokens of budget. Useful for modeling the "client
+        # sends out-of-spec request" failure that climbs error counters.
         extra_inputs = {
             "max_tokens": cfg.output_tokens_mean,
-            "min_tokens": cfg.output_tokens_mean,
+            "min_tokens": 1,
             "temperature": cfg.temperature,
             "repetition_penalty": cfg.repetition_penalty,
         }
@@ -389,7 +430,7 @@ class ManagedLoad:
 
     async def wait_for_started(self, timeout: int = 300) -> bool:
         """Wait for the load test to start (5 minute timeout by default)."""
-        marker_file = f"{self.container_results_dir}/status/started"
+        marker_file = f"{self.container_results_dir}/status/{self.job_name}/started"
         return await self._wait_for_status_marker(
             marker_file, "Load test start", timeout
         )
@@ -406,7 +447,7 @@ class ManagedLoad:
             else:
                 timeout = 600  # Default 10 minutes
 
-        marker_file = f"{self.container_results_dir}/status/completed"
+        marker_file = f"{self.container_results_dir}/status/{self.job_name}/completed"
         result = await self._wait_for_status_marker(
             marker_file, "Load test completion", timeout
         )

--- a/tests/utils/managed_load.py
+++ b/tests/utils/managed_load.py
@@ -33,6 +33,27 @@ def _get_template_dir() -> str:
 
 
 @dataclass
+class WorkerPin:
+    """Pin every request to a specific (service, replica_index) pair.
+
+    The role+index tuple is resolved at StartLoad.execute() time against
+    the live ManagedDeployment — the framework reads the matching pod's
+    ``DynamoWorkerMetadata`` CR (nvidia.com/v1alpha1) and injects the
+    discovered ``instance_id`` into the request's ``nvext.worker_id``
+    block. Either or both phases may be pinned; an unpinned phase is
+    chosen by the FE's normal routing.
+
+    Requires ``DYN_DISCOVERY_BACKEND=kubernetes`` on the workers so the
+    DynamoWorkerMetadata CRs exist; with the etcd backend they don't.
+    """
+
+    decode_service: Optional[str] = None
+    decode_replica_index: Optional[int] = None
+    prefill_service: Optional[str] = None
+    prefill_replica_index: Optional[int] = None
+
+
+@dataclass
 class LoadConfig:
     """Configuration for load test parameters.
 
@@ -143,6 +164,11 @@ class LoadConfig:
 
     # Extra inference parameters
     extra_inputs: Optional[Dict[str, Any]] = None
+
+    # Pin every request to a specific (service, replica_index) pair via
+    # nvext.worker_id. Resolved at StartLoad.execute() time by reading
+    # the matching pod's DynamoWorkerMetadata CR. None = no pinning.
+    worker_pin: Optional[WorkerPin] = None
 
     def __post_init__(self):
         if self.warmup_requests is None:
@@ -422,7 +448,19 @@ class ManagedLoad:
             extra_inputs.update(cfg.extra_inputs)
 
         for key, value in extra_inputs.items():
-            args.extend(["--extra-inputs", f"{key}:{value}"])
+            # Two AIPerf wire formats for --extra-inputs:
+            #   - flat scalar: `key:value` (e.g. `max_tokens:200`)
+            #   - JSON object: `{"key": <value>}` (e.g.
+            #     `{"nvext":{"prefill_worker_id":123,"decode_worker_id":456}}`)
+            # The JSON form is required to express nested objects like
+            # `nvext.*` — see components/src/dynamo/profiler/utils/aiperf.py:65
+            # for the canonical example. Detect dicts and route them to
+            # the JSON path so `extra_inputs={"nvext": {...}}` works as
+            # the caller expects.
+            if isinstance(value, dict):
+                args.extend(["--extra-inputs", json.dumps({key: value})])
+            else:
+                args.extend(["--extra-inputs", f"{key}:{value}"])
 
         # shlex.join quotes args that contain whitespace (e.g. --goodput's
         # 'request_latency:30000 ttft:5000' string) so they survive the

--- a/tests/utils/managed_load.py
+++ b/tests/utils/managed_load.py
@@ -178,6 +178,20 @@ class LoadConfig:
     # Extra inference parameters
     extra_inputs: Optional[Dict[str, Any]] = None
 
+    # Raw passthrough for aiperf CLI flags that the framework doesn't model
+    # as first-class fields. Items are appended verbatim to the aiperf
+    # invocation after all framework-built args. Used by callers that need
+    # access to aiperf's experimental flags (e.g. `--search-space`,
+    # `--search-sla`, `--search-planner`) without bloating LoadConfig
+    # with per-flag fields. None = no passthrough.
+    extra_aiperf_args: Optional[list[str]] = None
+
+    # aiperf synthetic-dataset / prefix-pool RNG seed. None preserves the
+    # historical default (100) so existing runs are byte-identical. Set
+    # per-load to de-correlate the prompt corpus across otherwise-identical
+    # concurrent loads (e.g. e2-pressure P-D's 3 disjoint-seed clients).
+    random_seed: Optional[int] = None
+
     # Pin every request to a specific (service, replica_index) pair via
     # nvext.worker_id. Resolved at StartLoad.execute() time by reading
     # the matching pod's DynamoWorkerMetadata CR. None = no pinning.
@@ -328,7 +342,7 @@ class ManagedLoad:
                 "--num-dataset-entries",
                 "12800",
                 "--random-seed",
-                "100",
+                str(cfg.random_seed if cfg.random_seed is not None else 100),
                 "--workers-max",
                 "252",
                 "--record-processors",
@@ -474,6 +488,10 @@ class ManagedLoad:
                 args.extend(["--extra-inputs", json.dumps({key: value})])
             else:
                 args.extend(["--extra-inputs", f"{key}:{value}"])
+
+        # Raw passthrough — append last so callers can override / extend.
+        if cfg.extra_aiperf_args:
+            args.extend(cfg.extra_aiperf_args)
 
         # shlex.join quotes args that contain whitespace (e.g. --goodput's
         # 'request_latency:30000 ttft:5000' string) so they survive the
@@ -930,6 +948,30 @@ class ManagedLoad:
                 self._logger.info(
                     f"Available result files: {[f.name for f in available_files]}"
                 )
+
+                # Reclaim PVC space between arms: on a SHARED (reuse) PVC the
+                # raw aiperf .jsonl (profile_export.jsonl + server_metrics ≈
+                # several GB/arm) accumulates and eventually fills the PVC,
+                # crash-looping the next arm's pods. Now that the extract
+                # succeeded AND the data is verified present locally (≥1
+                # non-empty file), drop this arm's sub-path from the PVC. If
+                # anything is off (no/empty local files), deliberately SKIP
+                # the clear so the data is retained for a manual pull.
+                if self.pvc_run_id:
+                    local_ok = any(
+                        f.is_file() and f.stat().st_size > 0 for f in available_files
+                    )
+                    if local_ok:
+                        await extractor.clear_subpath(self.pvc_name, sub_path)
+                    else:
+                        self._logger.warning(
+                            "clear-after-extract: extract reported success but "
+                            "no non-empty local files in %s — RETAINING %s/%s "
+                            "on the PVC for manual pull.",
+                            output_path,
+                            self.pvc_name,
+                            sub_path,
+                        )
 
                 json_file = output_path / "profile_export_aiperf.json"
                 if json_file.exists():

--- a/tests/utils/managed_load.py
+++ b/tests/utils/managed_load.py
@@ -651,6 +651,16 @@ class ManagedLoad:
 
             except exceptions.ApiException as e:
                 self._logger.warning(f"Error checking {marker_description} status: {e}")
+            except Exception as e:
+                # Transient infra blips (e.g. a Teleport proxy 500 on the kr8s
+                # API-version negotiation, connection resets) must NOT kill a
+                # long-running poll. kr8s raises ServerError / httpx.HTTPStatusError,
+                # which are not exceptions.ApiException, so they previously escaped
+                # this loop and failed the whole test. Log and retry next tick;
+                # a genuinely persistent failure still surfaces as TimeoutError.
+                self._logger.warning(
+                    f"Transient error checking {marker_description} status, will retry: {e}"
+                )
 
             await asyncio.sleep(5)
 

--- a/tests/utils/managed_load.py
+++ b/tests/utils/managed_load.py
@@ -156,6 +156,19 @@ class LoadConfig:
     # recovery; the framework's per-pod _get_pod_metrics snapshot at
     # fault-injection time still captures that point.
     extra_server_metrics_urls: Optional[list[str]] = None
+    # aiperf install spec passed to `pip install` inside the load Job pod.
+    # Default: a known-working main commit that supports the --concurrency
+    # list sweep flag (needed for E1 / E3 capacity discovery). Override
+    # per-scenario via this field (also exposed in YAML as `aiperf_ref`)
+    # to test newer / older revisions without rebuilding any image.
+    # Examples:
+    #   "aiperf" (latest PyPI release — lacks sweep flag as of 2026-05-28)
+    #   "aiperf @ git+https://github.com/ai-dynamo/aiperf@main" (moving tip)
+    #   "aiperf @ git+https://github.com/ai-dynamo/aiperf@<commit-sha>" (pinned)
+    aiperf_ref: str = (
+        "aiperf @ git+https://github.com/ai-dynamo/aiperf@"
+        "f93b2ad84d1407f632b84c3fb9d2df7156607654"
+    )
 
     # Inference parameters
     temperature: float = 0.0
@@ -494,6 +507,8 @@ class ManagedLoad:
                 env["value"] = self.endpoint_url
             elif env["name"] == "MODEL_NAME":
                 env["value"] = self.load_config.model_name
+            elif env["name"] == "AIPERF_SPEC":
+                env["value"] = self.load_config.aiperf_ref
 
         # Set PVC reference
         for volume in pod_spec.get("volumes", []):

--- a/tests/utils/pvc_extractor.py
+++ b/tests/utils/pvc_extractor.py
@@ -1,0 +1,386 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+PvcExtractor - Unified PVC file extraction via temporary download jobs.
+
+Replaces duplicate extraction logic in ManagedDeployment and ManagedLoad.
+Pattern: create busybox job → mount PVC → tar files → cat to local → extract → cleanup.
+"""
+
+import asyncio
+import logging
+import os
+import secrets
+import tarfile
+from pathlib import Path
+from typing import Optional
+
+import kr8s
+from kubernetes_asyncio import client
+from kubernetes_asyncio.client import exceptions
+
+from tests.utils.k8s_helpers import init_kubernetes_clients
+
+logger = logging.getLogger(__name__)
+
+
+class PvcExtractor:
+    """Extracts files from a K8s PVC via a temporary download job.
+
+    Usage:
+        extractor = PvcExtractor(namespace="my-ns")
+        await extractor.init()
+
+        # Extract service logs
+        result = await extractor.extract(
+            pvc_name="my-pvc",
+            sub_path="service_logs",
+            container_path="/tmp/service_logs",
+            file_patterns=["*.log"],
+            local_output_dir="/local/path/services",
+        )
+
+        # Extract load results (same class, different sub_path)
+        result = await extractor.extract(
+            pvc_name="my-pvc",
+            sub_path="aiperf",
+            container_path="/tmp/aiperf",
+            file_patterns=["*.json", "*.jsonl", "*.csv", "*.log"],
+            local_output_dir="/local/path/load",
+        )
+    """
+
+    def __init__(self, namespace: str, logger: Optional[logging.Logger] = None):
+        self.namespace = namespace
+        self._logger = logger or logging.getLogger(__name__)
+        self._batch_api: Optional[client.BatchV1Api] = None
+        self._core_api: Optional[client.CoreV1Api] = None
+        self._active_jobs: list[str] = []
+
+    async def init(self):
+        """Initialize Kubernetes clients."""
+        self._core_api, self._batch_api, _, _, _ = await init_kubernetes_clients()
+
+    async def extract(
+        self,
+        pvc_name: str,
+        sub_path: str,
+        container_path: str,
+        file_patterns: list[str],
+        local_output_dir: str,
+        job_prefix: str = "pvc-extract",
+        ready_timeout: int = 60,
+        tar_timeout: int = 30,
+        cat_timeout: int = 60,
+    ) -> dict:
+        """Extract files from a PVC to a local directory.
+
+        Creates a temporary busybox job that mounts the PVC, tars matching files,
+        and streams the archive back for local extraction.
+
+        Args:
+            pvc_name: Name of the PVC to extract from
+            sub_path: PVC sub-path to mount (e.g., "service_logs", "aiperf")
+            container_path: Mount path inside the container
+            file_patterns: File glob patterns to include (e.g., ["*.log", "*.json"])
+            local_output_dir: Local directory to extract files into
+            job_prefix: Prefix for the job name
+            ready_timeout: Seconds to wait for job pod to be ready
+            tar_timeout: Seconds to wait for tar creation
+            cat_timeout: Seconds to wait for tar download
+
+        Returns:
+            dict with keys: success, file_count, extracted_files, output_dir, error
+        """
+        os.makedirs(local_output_dir, exist_ok=True)
+        job_name = f"{job_prefix}-{secrets.token_hex(4)}"
+
+        try:
+            # Step 1: Check PVC exists
+            if not await self._pvc_exists(pvc_name):
+                return {
+                    "success": False,
+                    "error": f"PVC {pvc_name} does not exist",
+                    "output_dir": local_output_dir,
+                }
+
+            # Step 2: Create download job
+            await self._create_download_job(
+                job_name, pvc_name, sub_path, container_path
+            )
+
+            # Step 3: Wait for pod to be ready
+            pod = await self._wait_for_ready(job_name, ready_timeout)
+            if pod is None:
+                return {
+                    "success": False,
+                    "error": "Download job pod did not become ready",
+                    "output_dir": local_output_dir,
+                }
+
+            # Step 4: Create tar archive on-demand
+            find_expr = self._build_find_expr(file_patterns)
+            tar_script = f"""
+cd {container_path} 2>/dev/null || exit 1
+FILE_LIST=$(find . -type f {find_expr} | sort)
+FILE_COUNT=$(echo "$FILE_LIST" | grep -c . || echo 0)
+echo "FILE_COUNT:$FILE_COUNT"
+if [ "$FILE_COUNT" -gt 0 ]; then
+    echo "$FILE_LIST" | tar -czf /tmp/download/archive.tar.gz -T -
+    echo "TAR_CREATED:true"
+else
+    echo "TAR_CREATED:false"
+fi
+"""
+            tar_result = await asyncio.wait_for(
+                asyncio.to_thread(pod.exec, ["sh", "-c", tar_script]),
+                timeout=tar_timeout,
+            )
+
+            output = tar_result.stdout.decode() if tar_result.stdout else ""
+            file_count = 0
+            tar_created = False
+            for line in output.split("\n"):
+                if line.startswith("FILE_COUNT:"):
+                    try:
+                        file_count = int(line.split(":")[1].strip())
+                    except ValueError:
+                        pass
+                elif line.startswith("TAR_CREATED:"):
+                    tar_created = line.split(":")[1].strip() == "true"
+
+            self._logger.info(
+                f"PVC {pvc_name}/{sub_path}: {file_count} files, tar_created={tar_created}"
+            )
+
+            # Step 5: Download and extract tar
+            extracted_files = []
+            if file_count > 0 and tar_created:
+                cat_result = await asyncio.wait_for(
+                    asyncio.to_thread(
+                        pod.exec, ["cat", "/tmp/download/archive.tar.gz"]
+                    ),
+                    timeout=cat_timeout,
+                )
+
+                if cat_result.returncode != 0:
+                    raise RuntimeError(
+                        f"Failed to download archive (exit code {cat_result.returncode})"
+                    )
+
+                local_archive = Path(local_output_dir) / "archive.tar.gz"
+                local_archive.write_bytes(cat_result.stdout)
+
+                with tarfile.open(local_archive, "r:gz") as tar:
+                    tar.extractall(path=local_output_dir, filter="data")
+                    extracted_files = tar.getnames()
+
+                local_archive.unlink()
+
+                self._logger.info(
+                    f"Extracted {len(extracted_files)} files to {local_output_dir}"
+                )
+            else:
+                self._logger.info("No files matched for extraction")
+
+            # Step 6: Cleanup
+            await self._delete_job(job_name)
+
+            return {
+                "success": True,
+                "file_count": file_count,
+                "extracted_files": extracted_files,
+                "output_dir": local_output_dir,
+            }
+
+        except Exception as e:
+            self._logger.error(f"PVC extraction failed: {e}")
+            # Best-effort cleanup
+            await self._delete_job(job_name)
+            return {
+                "success": False,
+                "error": str(e),
+                "output_dir": local_output_dir,
+            }
+
+    async def cleanup(self):
+        """Delete any remaining download jobs."""
+        for job_name in list(self._active_jobs):
+            await self._delete_job(job_name)
+
+    # --- Internal methods ---
+
+    @staticmethod
+    def _build_find_expr(patterns: list[str]) -> str:
+        """Build a find -name expression from glob patterns.
+
+        Example: ["*.log", "*.json"] -> '\\( -name "*.log" -o -name "*.json" \\)'
+        """
+        if not patterns:
+            return ""
+        parts = [f'-name "{p}"' for p in patterns]
+        return "\\( " + " -o ".join(parts) + " \\)"
+
+    async def _pvc_exists(self, pvc_name: str) -> bool:
+        """Check if a PVC exists in the namespace."""
+        try:
+            assert self._core_api is not None
+            await self._core_api.read_namespaced_persistent_volume_claim(
+                name=pvc_name, namespace=self.namespace
+            )
+            return True
+        except exceptions.ApiException as e:
+            if e.status == 404:
+                return False
+            self._logger.warning(f"Error checking PVC {pvc_name}: {e}")
+            return False
+
+    async def _create_download_job(
+        self,
+        job_name: str,
+        pvc_name: str,
+        sub_path: str,
+        container_path: str,
+    ):
+        """Create a busybox job that mounts the PVC and waits for extraction commands."""
+        download_script = f"""#!/bin/sh
+set -e
+mkdir -p /tmp/download
+echo "ready" > /tmp/download/job_ready.txt
+echo "=== DOWNLOAD JOB READY ==="
+while true; do
+    FILE_COUNT=$(find {container_path} -type f 2>/dev/null | wc -l)
+    echo "[$(date '+%H:%M:%S')] Download job alive - $FILE_COUNT files available"
+    sleep 60
+done
+"""
+        job_spec = {
+            "apiVersion": "batch/v1",
+            "kind": "Job",
+            "metadata": {
+                "name": job_name,
+                "namespace": self.namespace,
+                "labels": {
+                    "app": "pvc-extractor",
+                    "managed-by": "pvc-extractor",
+                },
+            },
+            "spec": {
+                "backoffLimit": 0,
+                "template": {
+                    "metadata": {
+                        "labels": {
+                            "app": "pvc-extractor",
+                            "job-name": job_name,
+                        }
+                    },
+                    "spec": {
+                        "restartPolicy": "Never",
+                        "containers": [
+                            {
+                                "name": "download",
+                                "image": "busybox:1.35",
+                                "command": ["/bin/sh", "-c", download_script],
+                                "volumeMounts": [
+                                    {
+                                        "name": "pvc-volume",
+                                        "mountPath": container_path,
+                                        "subPath": sub_path,
+                                        "readOnly": True,
+                                    }
+                                ],
+                                "resources": {
+                                    "requests": {"cpu": "100m", "memory": "128Mi"},
+                                    "limits": {"cpu": "500m", "memory": "512Mi"},
+                                },
+                            }
+                        ],
+                        "volumes": [
+                            {
+                                "name": "pvc-volume",
+                                "persistentVolumeClaim": {
+                                    "claimName": pvc_name,
+                                },
+                            }
+                        ],
+                    },
+                },
+            },
+        }
+
+        try:
+            assert self._batch_api is not None
+            await self._batch_api.create_namespaced_job(
+                namespace=self.namespace, body=job_spec
+            )
+            self._active_jobs.append(job_name)
+            self._logger.info(f"Download job created: {job_name}")
+        except exceptions.ApiException as e:
+            if e.status == 409:
+                self._logger.warning(f"Download job {job_name} already exists")
+                self._active_jobs.append(job_name)
+            else:
+                raise
+
+    async def _wait_for_ready(self, job_name: str, timeout: int = 60):
+        """Wait for the download job pod to be ready and return it."""
+        for attempt in range(timeout):
+            try:
+                pods = list(
+                    kr8s.get(
+                        "pods",
+                        namespace=self.namespace,
+                        label_selector=f"job-name={job_name}",
+                    )
+                )
+
+                if pods:
+                    pod = pods[0]
+                    try:
+                        result = await asyncio.wait_for(
+                            asyncio.to_thread(
+                                pod.exec,
+                                ["test", "-f", "/tmp/download/job_ready.txt"],
+                            ),
+                            timeout=5.0,
+                        )
+                        if result.returncode == 0:
+                            return pod
+                    except Exception:
+                        pass
+            except Exception:
+                pass
+
+            if attempt % 10 == 9:
+                self._logger.info(
+                    f"Waiting for download job... (attempt {attempt + 1}/{timeout})"
+                )
+            await asyncio.sleep(1)
+
+        self._logger.warning(
+            f"Download job {job_name} did not become ready in {timeout}s"
+        )
+        return None
+
+    async def _delete_job(self, job_name: str):
+        """Delete a job with foreground propagation."""
+        if job_name not in self._active_jobs:
+            return
+
+        try:
+            from kubernetes_asyncio.client.models import V1DeleteOptions
+
+            assert self._batch_api is not None
+            await self._batch_api.delete_namespaced_job(
+                name=job_name,
+                namespace=self.namespace,
+                body=V1DeleteOptions(propagation_policy="Foreground"),
+            )
+            self._logger.info(f"Download job {job_name} deleted")
+        except exceptions.ApiException as e:
+            if e.status != 404:
+                self._logger.warning(f"Failed to delete job {job_name}: {e}")
+
+        if job_name in self._active_jobs:
+            self._active_jobs.remove(job_name)

--- a/tests/utils/pvc_extractor.py
+++ b/tests/utils/pvc_extractor.py
@@ -12,6 +12,7 @@ import asyncio
 import logging
 import os
 import secrets
+import shutil
 import tarfile
 from pathlib import Path
 from typing import Optional
@@ -71,8 +72,8 @@ class PvcExtractor:
         local_output_dir: str,
         job_prefix: str = "pvc-extract",
         ready_timeout: int = 60,
-        tar_timeout: int = 30,
-        cat_timeout: int = 60,
+        tar_timeout: int = 600,
+        cat_timeout: int = 120,
     ) -> dict:
         """Extract files from a PVC to a local directory.
 
@@ -87,7 +88,10 @@ class PvcExtractor:
             local_output_dir: Local directory to extract files into
             job_prefix: Prefix for the job name
             ready_timeout: Seconds to wait for job pod to be ready
-            tar_timeout: Seconds to wait for tar creation
+            tar_timeout: Upper bound (cap) on tar-creation timeout. The actual
+                wait is computed dynamically from observed source size
+                (see _GZIP_BYTES_PER_SEC); ``tar_timeout`` is the safety cap so
+                a runaway gzip can't hang the test indefinitely.
             cat_timeout: Seconds to wait for tar download
 
         Returns:
@@ -119,40 +123,112 @@ class PvcExtractor:
                     "output_dir": local_output_dir,
                 }
 
-            # Step 4: Create tar archive on-demand
+            # Step 4: Two-phase tar creation.
+            #
+            # Phase A — discover (fast, fixed 30s budget): list matching
+            # files + measure their total size, write the list to a temp
+            # file so phase B can reuse it without re-running find. We
+            # deliberately keep this phase small so we don't burn the
+            # cap before we even know what we're dealing with.
+            #
+            # Phase B — tar+gzip with a *computed* timeout based on the
+            # observed source size. The user-supplied ``tar_timeout``
+            # parameter is the safety cap; the actual wait is
+            #   max(60, ceil(src_bytes / _GZIP_BYTES_PER_SEC) + 60)
+            # then clamped to tar_timeout. This means:
+            #   - 200 MB rung → ~80s timeout (instead of 600s ceiling)
+            #   - 1.1 GB steady → ~170s timeout (vs the 30s that broke us)
+            #   - 10 GB cliff → would compute ~1100s but capped at 600s
+            # The 60s floor covers very small rungs where overhead dominates.
             find_expr = self._build_find_expr(file_patterns)
-            tar_script = f"""
+            discover_script = f"""
 cd {container_path} 2>/dev/null || exit 1
 FILE_LIST=$(find . -type f {find_expr} | sort)
 FILE_COUNT=$(echo "$FILE_LIST" | grep -c . || echo 0)
 echo "FILE_COUNT:$FILE_COUNT"
 if [ "$FILE_COUNT" -gt 0 ]; then
-    echo "$FILE_LIST" | tar -czf /tmp/download/archive.tar.gz -T -
-    echo "TAR_CREATED:true"
-else
-    echo "TAR_CREATED:false"
+    BYTES=$(echo "$FILE_LIST" | xargs -r du -cb 2>/dev/null | tail -1 | awk '{{print $1}}')
+    echo "SOURCE_BYTES:$BYTES"
+    echo "$FILE_LIST" > /tmp/download/files.txt
 fi
 """
-            tar_result = await asyncio.wait_for(
-                asyncio.to_thread(pod.exec, ["sh", "-c", tar_script]),
-                timeout=tar_timeout,
+            discover_result = await asyncio.wait_for(
+                asyncio.to_thread(pod.exec, ["sh", "-c", discover_script]),
+                timeout=30,
             )
 
-            output = tar_result.stdout.decode() if tar_result.stdout else ""
             file_count = 0
-            tar_created = False
-            for line in output.split("\n"):
+            source_bytes = 0
+            for line in (
+                discover_result.stdout.decode() if discover_result.stdout else ""
+            ).split("\n"):
                 if line.startswith("FILE_COUNT:"):
                     try:
                         file_count = int(line.split(":")[1].strip())
                     except ValueError:
                         pass
-                elif line.startswith("TAR_CREATED:"):
-                    tar_created = line.split(":")[1].strip() == "true"
+                elif line.startswith("SOURCE_BYTES:"):
+                    try:
+                        source_bytes = int(line.split(":")[1].strip())
+                    except ValueError:
+                        pass
 
-            self._logger.info(
-                f"PVC {pvc_name}/{sub_path}: {file_count} files, tar_created={tar_created}"
-            )
+            tar_created = False
+            tar_bytes = 0
+
+            if file_count > 0:
+                # Compute dynamic tar timeout from observed size.
+                computed_timeout = max(
+                    60,
+                    int(source_bytes / self._GZIP_BYTES_PER_SEC) + 60,
+                )
+                effective_timeout = min(computed_timeout, tar_timeout)
+
+                self._logger.info(
+                    f"PVC {pvc_name}/{sub_path}: {file_count} files, "
+                    f"src={source_bytes / 1024 / 1024:.1f}MiB, "
+                    f"tar_timeout={effective_timeout}s "
+                    f"(computed={computed_timeout}s, cap={tar_timeout}s)"
+                )
+
+                # IMPORTANT: tar runs in a *fresh* shell from a separate
+                # `pod.exec`, so CWD is `/` — not container_path. files.txt
+                # holds relative paths like `./profile_export.json`, which
+                # tar would look up from `/` and silently produce an empty
+                # archive (header+footer only, ~10 KiB), then TAR_CREATED
+                # would still say true. Always `cd container_path` first;
+                # also make tar/stat failures observable rather than
+                # swallowed by the unconditional echo.
+                tar_script = f"""
+set -e
+cd {container_path}
+tar -czf /tmp/download/archive.tar.gz -T /tmp/download/files.txt
+echo "TAR_CREATED:true"
+TAR_BYTES=$(stat -c %s /tmp/download/archive.tar.gz 2>/dev/null || echo 0)
+echo "TAR_BYTES:$TAR_BYTES"
+"""
+                tar_result = await asyncio.wait_for(
+                    asyncio.to_thread(pod.exec, ["sh", "-c", tar_script]),
+                    timeout=effective_timeout,
+                )
+
+                for line in (
+                    tar_result.stdout.decode() if tar_result.stdout else ""
+                ).split("\n"):
+                    if line.startswith("TAR_CREATED:"):
+                        tar_created = line.split(":")[1].strip() == "true"
+                    elif line.startswith("TAR_BYTES:"):
+                        try:
+                            tar_bytes = int(line.split(":")[1].strip())
+                        except ValueError:
+                            pass
+
+                self._logger.info(
+                    f"PVC {pvc_name}/{sub_path}: tar.gz={tar_bytes / 1024 / 1024:.1f}MiB, "
+                    f"tar_created={tar_created}"
+                )
+            else:
+                self._logger.info(f"PVC {pvc_name}/{sub_path}: 0 files matched")
 
             # Step 5: Download and extract tar
             #
@@ -199,12 +275,17 @@ fi
             }
 
         except Exception as e:
-            self._logger.error(f"PVC extraction failed: {e}")
+            # Include exception type — empty str(e) is common for
+            # asyncio.TimeoutError and ExceptionGroup, which is exactly
+            # what we hit on the S1 3.2 GB cliff extraction and were
+            # left guessing at because the original log read
+            # ``PVC extraction failed: `` with no body.
+            self._logger.error(f"PVC extraction failed: {type(e).__name__}: {e}")
             # Best-effort cleanup
             await self._delete_job(job_name)
             return {
                 "success": False,
-                "error": str(e),
+                "error": f"{type(e).__name__}: {e}",
                 "output_dir": local_output_dir,
             }
 
@@ -215,16 +296,32 @@ fi
 
     # --- Internal methods ---
 
-    # Chunk size for the split-then-fetch download path. 100 MiB keeps
-    # each chunk's transfer under the Teleport-proxied WebSocket's
-    # working window (we lost 150+ MB single-shot streams on
-    # 2026-05-19). Smaller = more chunks = more pod.exec round-trips;
-    # larger = closer to the failure mode we're avoiding.
-    _CHUNK_BYTES = 100 * 1024 * 1024
+    # Conservative gzip throughput estimate (bytes/sec) used to scale the
+    # tar-creation timeout to observed source size. Real busybox `tar -czf`
+    # on aiperf jsonl payloads measured ~25-50 MB/s in prior rungs;
+    # we use 10 MB/s as a pessimistic baseline so the computed timeout
+    # has headroom even on a busy node. A 1.1 GB rung → ~170s computed
+    # budget; the rescue extraction completed in ~30s, so we have 5x margin.
+    _GZIP_BYTES_PER_SEC = 10 * 1024 * 1024
+
+    # Chunk size for the split-then-fetch download path. 50 MiB keeps
+    # each chunk's transfer comfortably under the Teleport-proxied
+    # WebSocket's working window — we empirically saw 124 MiB single
+    # transfers die with "websocket: close 1006" in prior runs (this
+    # was a 3.2 GB cliff-load JSONL on the S1 cascade test), and the
+    # original 100 MiB ceiling was right at that failure edge. Manual
+    # rescue at 50 MiB succeeded on all 5 chunks. Smaller = more
+    # round-trips but each chunk fits inside both the WS window and the
+    # per-chunk timeout with headroom for jitter.
+    _CHUNK_BYTES = 50 * 1024 * 1024
 
     # Per-chunk retry budget. Each failed chunk gets re-fetched
-    # independently — the archive is not rebuilt.
-    _CHUNK_MAX_RETRIES = 4
+    # independently — the archive is not rebuilt. Bumped 4 → 8 alongside
+    # the A.3 streaming refactor: with the in-memory buffer eliminated,
+    # the dominant failure mode shifts from "chunk too big" to "transient
+    # network blip", which retries fix cleanly. Total grace at linear
+    # 2*attempt backoff: 2+4+6+...+16 = 72 seconds across 8 attempts.
+    _CHUNK_MAX_RETRIES = 8
 
     async def _download_archive_chunked(
         self,
@@ -271,35 +368,71 @@ fi
             f"_download_archive_chunked: split into {len(part_names)} part(s)"
         )
 
-        # Step B: cat each part separately with retry
+        # Step B: stream each part directly to a per-chunk tempfile,
+        # then append to the main archive only on success.
+        #
+        # kr8s `Pod.exec(stdout=BinaryIO, capture_output=False)` writes
+        # the WebSocket exec stdout into the file handle as bytes arrive
+        # — no full-chunk in-memory buffering. Earlier versions of this
+        # method captured cat_result.stdout (50 MiB of bytes in Python
+        # memory per chunk), which interacted badly with Teleport-proxied
+        # WebSocket framing under load and surfaced as TimeoutError on
+        # the asyncio.wait_for. Streaming to disk lets the kernel buffer
+        # at TCP-receive size, decouples timing of the WS read loop from
+        # the Python event loop, and keeps memory use ~constant
+        # regardless of chunk size. Verified on the S1 cliff (3.2 GB
+        # raw / 224 MB gz) in prior runs — see the cascade reproduction work
+        # vault findings/related-investigations.md for the failure case.
+        #
+        # We stage each chunk in a sibling tempfile (`.part-<idx>.tmp`)
+        # so a chunk that fails mid-stream can be retried without
+        # corrupting the main archive. Successful chunks get appended
+        # to the main archive via shutil.copyfileobj (16 KiB kernel
+        # buffer), then the tempfile is unlinked.
         try:
             # Truncate the local file before appending parts
             local_path.write_bytes(b"")
             for idx, part_name in enumerate(part_names):
+                chunk_tmp = local_path.parent / (f".{local_path.name}.chunk-{idx}.tmp")
                 last_err: Optional[Exception] = None
                 for attempt in range(1, self._CHUNK_MAX_RETRIES + 1):
                     try:
-                        cat_result = await asyncio.wait_for(
-                            asyncio.to_thread(pod.exec, ["cat", part_name]),
-                            timeout=cat_timeout,
-                        )
+                        # Fresh tempfile each attempt — discard any
+                        # partial bytes from a prior failed try.
+                        chunk_tmp.unlink(missing_ok=True)
+                        with chunk_tmp.open("wb") as chunk_fh:
+                            cat_result = await asyncio.wait_for(
+                                asyncio.to_thread(
+                                    pod.exec,
+                                    ["cat", part_name],
+                                    stdout=chunk_fh,
+                                    capture_output=False,
+                                ),
+                                timeout=cat_timeout,
+                            )
                         if cat_result.returncode != 0:
                             raise RuntimeError(
                                 f"cat returned rc={cat_result.returncode}"
                             )
-                        # Append this chunk to the local archive
-                        with local_path.open("ab") as fh:
-                            fh.write(cat_result.stdout)
-                        self._logger.debug(
+                        chunk_bytes = chunk_tmp.stat().st_size
+                        # Append this chunk's tempfile to the main archive.
+                        with local_path.open("ab") as out:
+                            with chunk_tmp.open("rb") as inp:
+                                shutil.copyfileobj(inp, out)
+                        chunk_tmp.unlink(missing_ok=True)
+                        self._logger.info(
                             f"  chunk {idx + 1}/{len(part_names)} "
-                            f"({len(cat_result.stdout)} bytes) try {attempt} ✓"
+                            f"({chunk_bytes:,} bytes) try {attempt} ✓"
                         )
                         break
                     except Exception as e:  # noqa: BLE001
                         last_err = e
+                        partial = chunk_tmp.stat().st_size if chunk_tmp.exists() else 0
+                        chunk_tmp.unlink(missing_ok=True)
                         self._logger.warning(
-                            f"  chunk {idx + 1}/{len(part_names)} attempt {attempt} "
-                            f"failed: {type(e).__name__}: {e}"
+                            f"  chunk {idx + 1}/{len(part_names)} attempt "
+                            f"{attempt} failed after {partial:,} streamed "
+                            f"bytes: {type(e).__name__}: {e}"
                         )
                         if attempt < self._CHUNK_MAX_RETRIES:
                             await asyncio.sleep(2 * attempt)

--- a/tests/utils/pvc_extractor.py
+++ b/tests/utils/pvc_extractor.py
@@ -155,22 +155,26 @@ fi
             )
 
             # Step 5: Download and extract tar
+            #
+            # IMPORTANT: a single `pod.exec(["cat", <tar>])` buffers the
+            # entire tar in the kr8s/k8s python client's response and
+            # rides on one long-lived WebSocket. Through Teleport-proxied
+            # kubectl streams, that connection dies with "websocket:
+            # close 1006 (abnormal closure): unexpected EOF" for tars
+            # over ~150 MB — we lost 10/10 long-run rungs (~645 MB each)
+            # to this on 2026-05-19. The fix is split-server-side +
+            # per-chunk fetch: each chunk's transfer is short enough to
+            # dodge the Teleport WebSocket close, and a failed chunk can
+            # be retried without redownloading the whole archive.
             extracted_files = []
             if file_count > 0 and tar_created:
-                cat_result = await asyncio.wait_for(
-                    asyncio.to_thread(
-                        pod.exec, ["cat", "/tmp/download/archive.tar.gz"]
-                    ),
-                    timeout=cat_timeout,
-                )
-
-                if cat_result.returncode != 0:
-                    raise RuntimeError(
-                        f"Failed to download archive (exit code {cat_result.returncode})"
-                    )
-
                 local_archive = Path(local_output_dir) / "archive.tar.gz"
-                local_archive.write_bytes(cat_result.stdout)
+                await self._download_archive_chunked(
+                    pod=pod,
+                    remote_path="/tmp/download/archive.tar.gz",
+                    local_path=local_archive,
+                    cat_timeout=cat_timeout,
+                )
 
                 with tarfile.open(local_archive, "r:gz") as tar:
                     tar.extractall(path=local_output_dir, filter="data")
@@ -210,6 +214,113 @@ fi
             await self._delete_job(job_name)
 
     # --- Internal methods ---
+
+    # Chunk size for the split-then-fetch download path. 100 MiB keeps
+    # each chunk's transfer under the Teleport-proxied WebSocket's
+    # working window (we lost 150+ MB single-shot streams on
+    # 2026-05-19). Smaller = more chunks = more pod.exec round-trips;
+    # larger = closer to the failure mode we're avoiding.
+    _CHUNK_BYTES = 100 * 1024 * 1024
+
+    # Per-chunk retry budget. Each failed chunk gets re-fetched
+    # independently — the archive is not rebuilt.
+    _CHUNK_MAX_RETRIES = 4
+
+    async def _download_archive_chunked(
+        self,
+        pod,
+        remote_path: str,
+        local_path: Path,
+        cat_timeout: int,
+    ) -> None:
+        """Download a remote archive in chunks and reassemble locally.
+
+        Step A: split the archive server-side into 100 MiB parts.
+        Step B: cat each part separately via pod.exec, with per-chunk
+                retry. Each chunk is short enough that the Teleport
+                proxied WebSocket survives.
+        Step C: concatenate parts into ``local_path``.
+        Step D: clean up parts on the pod.
+
+        Replaces a single ``cat`` of the full archive, which buffers
+        the entire tar in memory and rides one long-lived WebSocket
+        — that stream dies for ~150+ MB tars through Teleport.
+        """
+
+        # Step A: split server-side
+        split_script = (
+            "set -e\n"
+            f"split -b {self._CHUNK_BYTES} {remote_path} {remote_path}.part-\n"
+            f"ls {remote_path}.part-* | sort\n"
+        )
+        split_result = await asyncio.wait_for(
+            asyncio.to_thread(pod.exec, ["sh", "-c", split_script]),
+            timeout=60,
+        )
+        if split_result.returncode != 0:
+            err = (split_result.stderr or b"").decode("utf-8", errors="replace")
+            raise RuntimeError(f"split failed (rc={split_result.returncode}): {err}")
+        part_names = [
+            line.strip()
+            for line in split_result.stdout.decode(
+                "utf-8", errors="replace"
+            ).splitlines()
+            if line.strip()
+        ]
+        self._logger.info(
+            f"_download_archive_chunked: split into {len(part_names)} part(s)"
+        )
+
+        # Step B: cat each part separately with retry
+        try:
+            # Truncate the local file before appending parts
+            local_path.write_bytes(b"")
+            for idx, part_name in enumerate(part_names):
+                last_err: Optional[Exception] = None
+                for attempt in range(1, self._CHUNK_MAX_RETRIES + 1):
+                    try:
+                        cat_result = await asyncio.wait_for(
+                            asyncio.to_thread(pod.exec, ["cat", part_name]),
+                            timeout=cat_timeout,
+                        )
+                        if cat_result.returncode != 0:
+                            raise RuntimeError(
+                                f"cat returned rc={cat_result.returncode}"
+                            )
+                        # Append this chunk to the local archive
+                        with local_path.open("ab") as fh:
+                            fh.write(cat_result.stdout)
+                        self._logger.debug(
+                            f"  chunk {idx + 1}/{len(part_names)} "
+                            f"({len(cat_result.stdout)} bytes) try {attempt} ✓"
+                        )
+                        break
+                    except Exception as e:  # noqa: BLE001
+                        last_err = e
+                        self._logger.warning(
+                            f"  chunk {idx + 1}/{len(part_names)} attempt {attempt} "
+                            f"failed: {type(e).__name__}: {e}"
+                        )
+                        if attempt < self._CHUNK_MAX_RETRIES:
+                            await asyncio.sleep(2 * attempt)
+                else:
+                    raise RuntimeError(
+                        f"chunk {idx + 1}/{len(part_names)} ({part_name}) failed "
+                        f"after {self._CHUNK_MAX_RETRIES} attempts: {last_err}"
+                    )
+        finally:
+            # Step D: best-effort cleanup of the parts on the pod
+            try:
+                await asyncio.wait_for(
+                    asyncio.to_thread(
+                        pod.exec, ["sh", "-c", f"rm -f {remote_path}.part-*"]
+                    ),
+                    timeout=30,
+                )
+            except Exception as e:  # noqa: BLE001
+                self._logger.debug(
+                    f"_download_archive_chunked: cleanup of parts failed (non-fatal): {e}"
+                )
 
     @staticmethod
     def _build_find_expr(patterns: list[str]) -> str:

--- a/tests/utils/pvc_extractor.py
+++ b/tests/utils/pvc_extractor.py
@@ -72,7 +72,7 @@ class PvcExtractor:
         local_output_dir: str,
         job_prefix: str = "pvc-extract",
         ready_timeout: int = 60,
-        tar_timeout: int = 600,
+        tar_timeout: int = 1800,
         cat_timeout: int = 120,
     ) -> dict:
         """Extract files from a PVC to a local directory.

--- a/tests/utils/pvc_extractor.py
+++ b/tests/utils/pvc_extractor.py
@@ -14,6 +14,7 @@ import os
 import secrets
 import shutil
 import tarfile
+import time
 from pathlib import Path
 from typing import Optional
 
@@ -71,7 +72,7 @@ class PvcExtractor:
         file_patterns: list[str],
         local_output_dir: str,
         job_prefix: str = "pvc-extract",
-        ready_timeout: int = 60,
+        ready_timeout: int = 240,
         tar_timeout: int = 1800,
         cat_timeout: int = 120,
     ) -> dict:
@@ -109,13 +110,26 @@ class PvcExtractor:
                     "output_dir": local_output_dir,
                 }
 
-            # Step 2: Create download job
-            await self._create_download_job(
-                job_name, pvc_name, sub_path, container_path
-            )
+            # Steps 2+3: Create download job and wait for its pod to be ready,
+            # with one retry. A single download pod can get wedged on transient
+            # scheduling / image-pull stalls on a busy node; rather than lose
+            # the (already-collected) data, tear the stuck job down and try once
+            # more with a fresh job before giving up.
+            pod = None
+            for create_attempt in range(2):
+                await self._create_download_job(
+                    job_name, pvc_name, sub_path, container_path
+                )
+                pod = await self._wait_for_ready(job_name, ready_timeout)
+                if pod is not None:
+                    break
+                self._logger.warning(
+                    f"Download job {job_name} not ready (attempt "
+                    f"{create_attempt + 1}/2); recreating."
+                )
+                await self._delete_job(job_name)
+                job_name = f"{job_prefix}-{secrets.token_hex(4)}"
 
-            # Step 3: Wait for pod to be ready
-            pod = await self._wait_for_ready(job_name, ready_timeout)
             if pod is None:
                 return {
                     "success": False,
@@ -455,6 +469,102 @@ echo "TAR_BYTES:$TAR_BYTES"
                     f"_download_archive_chunked: cleanup of parts failed (non-fatal): {e}"
                 )
 
+    async def clear_subpath(self, pvc_name: str, sub_path: str) -> bool:
+        """Delete everything under ``sub_path`` on ``pvc_name`` (RW mount).
+
+        Used to reclaim space after a *verified* extract — the download job
+        mounts read-only, so freeing the raw aiperf .jsonl needs a separate
+        read-write job. Caller is responsible for only invoking this once the
+        data is confirmed safe locally; on any failure here we simply leave
+        the data on the PVC (returns False) so nothing is lost.
+        """
+        job_name = f"pvc-clear-{secrets.token_hex(4)}"
+        mount_path = "/data"
+        script = (
+            f'echo "clearing {mount_path}"; '
+            f"rm -rf {mount_path}/* {mount_path}/.[!.]* 2>/dev/null; "
+            "echo CLEAR_DONE"
+        )
+        job_spec = {
+            "apiVersion": "batch/v1",
+            "kind": "Job",
+            "metadata": {
+                "name": job_name,
+                "namespace": self.namespace,
+                "labels": {"app": "pvc-extractor", "managed-by": "pvc-extractor"},
+            },
+            "spec": {
+                "backoffLimit": 0,
+                "ttlSecondsAfterFinished": 120,
+                "template": {
+                    "metadata": {"labels": {"app": "pvc-extractor"}},
+                    "spec": {
+                        "restartPolicy": "Never",
+                        "containers": [
+                            {
+                                "name": "clear",
+                                "image": "busybox:1.35",
+                                "command": ["/bin/sh", "-c", script],
+                                "volumeMounts": [
+                                    {
+                                        "name": "pvc-volume",
+                                        "mountPath": mount_path,
+                                        "subPath": sub_path,
+                                    }
+                                ],
+                                "resources": {
+                                    "requests": {"cpu": "50m", "memory": "64Mi"},
+                                    "limits": {"cpu": "500m", "memory": "256Mi"},
+                                },
+                            }
+                        ],
+                        "volumes": [
+                            {
+                                "name": "pvc-volume",
+                                "persistentVolumeClaim": {"claimName": pvc_name},
+                            }
+                        ],
+                    },
+                },
+            },
+        }
+        try:
+            assert self._batch_api is not None
+            self._active_jobs.append(job_name)
+            await self._batch_api.create_namespaced_job(
+                namespace=self.namespace, body=job_spec
+            )
+            # Wait for completion (rm of even a few GB is fast on a mounted PVC).
+            deadline = time.monotonic() + 120
+            while time.monotonic() < deadline:
+                job = await self._batch_api.read_namespaced_job(
+                    name=job_name, namespace=self.namespace
+                )
+                if job.status.succeeded:
+                    self._logger.info(f"Cleared PVC sub-path {pvc_name}/{sub_path}")
+                    await self._delete_job(job_name)
+                    return True
+                if job.status.failed:
+                    self._logger.warning(
+                        f"Clear job {job_name} failed; leaving "
+                        f"{pvc_name}/{sub_path} on the PVC."
+                    )
+                    await self._delete_job(job_name)
+                    return False
+                await asyncio.sleep(2)
+            self._logger.warning(
+                f"Clear job {job_name} did not finish in 120s; leaving "
+                f"{pvc_name}/{sub_path} on the PVC."
+            )
+            await self._delete_job(job_name)
+            return False
+        except Exception as e:  # noqa: BLE001
+            self._logger.warning(
+                f"clear_subpath({pvc_name}/{sub_path}) failed: {e}; "
+                "data retained on PVC."
+            )
+            return False
+
     @staticmethod
     def _build_find_expr(patterns: list[str]) -> str:
         """Build a find -name expression from glob patterns.
@@ -567,9 +677,28 @@ done
             else:
                 raise
 
-    async def _wait_for_ready(self, job_name: str, timeout: int = 60):
-        """Wait for the download job pod to be ready and return it."""
-        for attempt in range(timeout):
+    async def _wait_for_ready(self, job_name: str, timeout: int = 240):
+        """Wait for the download job pod to be ready and return it.
+
+        Deadline-based (wall-clock), not iteration-based: each poll does an
+        ``exec`` that can itself take several seconds, so a fixed iteration
+        count silently under-spends the budget. We loop until ``timeout``
+        seconds of real time have elapsed.
+
+        The download pod has to be scheduled, pull the busybox image, and
+        start before it can write ``job_ready.txt``. On a busy node (e.g. a
+        60-pod deployment competing for the same CPU nodes) scheduling +
+        image-pull alone can exceed a minute, so the default is generous.
+
+        On timeout we log the pod's actual phase and any warning events so
+        the failure is diagnosable (FailedScheduling, ImagePullBackOff, …)
+        instead of an opaque "did not become ready".
+        """
+        deadline = time.monotonic() + timeout
+        last_phase = None
+        next_progress = time.monotonic() + 15
+        pod = None
+        while time.monotonic() < deadline:
             try:
                 pods = list(
                     kr8s.get(
@@ -581,31 +710,66 @@ done
 
                 if pods:
                     pod = pods[0]
-                    try:
-                        result = await asyncio.wait_for(
-                            asyncio.to_thread(
-                                pod.exec,
-                                ["test", "-f", "/tmp/download/job_ready.txt"],
-                            ),
-                            timeout=5.0,
-                        )
-                        if result.returncode == 0:
-                            return pod
-                    except Exception:
-                        pass
+                    phase = (getattr(pod, "status", None) or {}).get("phase")
+                    if phase != last_phase:
+                        self._logger.info(f"Download job {job_name} pod phase: {phase}")
+                        last_phase = phase
+                    # Only probe for the ready marker once the container is
+                    # actually running — exec into a Pending pod just throws.
+                    if phase == "Running":
+                        try:
+                            result = await asyncio.wait_for(
+                                asyncio.to_thread(
+                                    pod.exec,
+                                    ["test", "-f", "/tmp/download/job_ready.txt"],
+                                ),
+                                timeout=5.0,
+                            )
+                            if result.returncode == 0:
+                                return pod
+                        except Exception:
+                            pass
             except Exception:
                 pass
 
-            if attempt % 10 == 9:
+            if time.monotonic() >= next_progress:
+                remaining = int(deadline - time.monotonic())
                 self._logger.info(
-                    f"Waiting for download job... (attempt {attempt + 1}/{timeout})"
+                    f"Waiting for download job {job_name}... "
+                    f"(phase={last_phase}, {remaining}s left)"
                 )
-            await asyncio.sleep(1)
+                next_progress = time.monotonic() + 15
+            await asyncio.sleep(2)
 
+        # Timed out — surface the pod's real state for diagnosis.
         self._logger.warning(
-            f"Download job {job_name} did not become ready in {timeout}s"
+            f"Download job {job_name} did not become ready in {timeout}s "
+            f"(last phase={last_phase})"
         )
+        await self._log_pod_diagnostics(job_name, pod)
         return None
+
+    async def _log_pod_diagnostics(self, job_name: str, pod):
+        """Best-effort dump of pod status + warning events on a stuck job."""
+        try:
+            if pod is not None:
+                status = getattr(pod, "status", None) or {}
+                self._logger.warning(
+                    f"  pod phase={status.get('phase')} "
+                    f"conditions={status.get('conditions')}"
+                )
+                for cs in status.get("containerStatuses", []) or []:
+                    self._logger.warning(f"  container state: {cs.get('state')}")
+            assert self._core_api is not None
+            events = await self._core_api.list_namespaced_event(
+                namespace=self.namespace,
+                field_selector=f"involvedObject.name={job_name}",
+            )
+            for ev in events.items[-10:]:
+                if ev.type == "Warning":
+                    self._logger.warning(f"  event: {ev.reason}: {ev.message}")
+        except Exception as e:  # noqa: BLE001
+            self._logger.debug(f"_log_pod_diagnostics failed (non-fatal): {e}")
 
     async def _delete_job(self, job_name: str):
         """Delete a job with foreground propagation."""

--- a/tests/utils/resource_monitor.py
+++ b/tests/utils/resource_monitor.py
@@ -1,0 +1,436 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Resource monitoring for ManagedDeployment.
+
+Provides CPU, memory, and GPU metrics collection for pods in a deployment.
+Supports both context manager and explicit start/stop patterns.
+"""
+
+import asyncio
+import json
+import os
+import time
+from dataclasses import asdict, dataclass
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+if TYPE_CHECKING:
+    from kr8s.objects import Pod
+
+    from tests.utils.managed_deployment import ManagedDeployment
+
+
+@dataclass
+class ResourceSnapshot:
+    """Single resource usage snapshot for a pod."""
+
+    timestamp: float
+    pod_name: str
+    service_name: str
+
+    # Memory (bytes)
+    memory_used_bytes: int
+    memory_total_bytes: int
+    memory_available_bytes: int
+
+    # CPU (percentage, calculated from /proc/stat delta)
+    cpu_usage_percent: float
+
+    # GPU (optional, per-GPU list)
+    # Each dict: {index, memory_used_mb, memory_total_mb, utilization_percent}
+    gpu_metrics: Optional[List[dict]] = None
+
+
+@dataclass
+class ResourceMonitorConfig:
+    """Configuration for resource monitoring."""
+
+    enabled: bool = False
+    interval_seconds: float = 10.0
+    include_gpu: bool = True
+    write_to_pvc: bool = True
+    pvc_base_dir: str = "/tmp/service_logs/service_logs"  # Same as service logs
+
+
+class ResourceMonitor:
+    """Resource monitoring for a ManagedDeployment.
+
+    Supports both context manager and explicit start/stop patterns.
+
+    Usage (context manager):
+        async with ResourceMonitor(deployment, config) as monitor:
+            # monitoring runs in background
+            ...
+        # monitor.history contains all snapshots
+
+    Usage (explicit):
+        monitor = ResourceMonitor(deployment, config)
+        await monitor.start()
+        ...
+        history = await monitor.stop()
+    """
+
+    def __init__(
+        self,
+        deployment: "ManagedDeployment",
+        config: Optional[ResourceMonitorConfig] = None,
+    ):
+        self._deployment = deployment
+        self._config = config or ResourceMonitorConfig(enabled=True)
+        self._history: List[ResourceSnapshot] = []
+        self._task: Optional[asyncio.Task] = None
+        self._prev_cpu_stats: Dict[str, dict] = {}
+        self._logger = deployment._logger
+
+    async def __aenter__(self) -> "ResourceMonitor":
+        await self.start()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        await self.stop()
+
+    @property
+    def history(self) -> List[ResourceSnapshot]:
+        """All collected resource snapshots."""
+        return self._history
+
+    @property
+    def config(self) -> ResourceMonitorConfig:
+        """Current monitoring configuration."""
+        return self._config
+
+    async def start(self):
+        """Start background resource monitoring task."""
+        self._history = []
+        self._prev_cpu_stats = {}
+        self._task = asyncio.create_task(self._monitoring_loop())
+        self._logger.info(
+            f"Started resource monitoring (interval={self._config.interval_seconds}s, "
+            f"gpu={self._config.include_gpu}, write_to_pvc={self._config.write_to_pvc})"
+        )
+
+    async def stop(self) -> List[ResourceSnapshot]:
+        """Stop background monitoring and return collected history.
+
+        Returns:
+            List of all collected ResourceSnapshots
+        """
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+
+        self._logger.info(
+            f"Stopped resource monitoring, collected {len(self._history)} snapshots"
+        )
+        return self._history
+
+    async def save_history_locally(self, log_dir: str):
+        """Save resource monitoring history to local log directory.
+
+        Args:
+            log_dir: Directory to save the metrics file
+        """
+        if not self._history:
+            return
+
+        try:
+            metrics_file = os.path.join(log_dir, "resource_metrics.json")
+            with open(metrics_file, "w") as f:
+                json.dump([asdict(s) for s in self._history], f, indent=2)
+            self._logger.info(
+                f"Saved {len(self._history)} resource snapshots to {metrics_file}"
+            )
+        except Exception as e:
+            self._logger.warning(f"Failed to save resource history: {e}")
+
+    async def _monitoring_loop(self):
+        """Background loop that collects resource metrics periodically."""
+        while True:
+            try:
+                snapshots = await self.get_all_resource_usage()
+
+                # Store snapshots in history (PVC writing happens in get_pod_resource_usage)
+                for service_snapshots in snapshots.values():
+                    self._history.extend(service_snapshots)
+
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                self._logger.warning(f"Resource monitoring error: {e}")
+
+            await asyncio.sleep(self._config.interval_seconds)
+
+    async def _exec_in_pod(
+        self, pod: "Pod", command: List[str], timeout: float = 10.0
+    ) -> Any:
+        """Execute command in pod with timeout.
+
+        Args:
+            pod: The pod to execute the command in
+            command: Command as a list of strings
+            timeout: Timeout in seconds
+
+        Returns:
+            The exec result with stdout, stderr, and returncode
+        """
+        return await asyncio.wait_for(
+            asyncio.create_task(asyncio.to_thread(pod.exec, command)),
+            timeout=timeout,
+        )
+
+    async def _get_container_timestamp(self, pod: "Pod") -> str:
+        """Read container start timestamp written by wrapper script.
+
+        The wrapper script writes the timestamp to /tmp/.{pod_name}.start_time
+        This ensures exact match with service log filenames.
+        """
+        try:
+            result = await self._exec_in_pod(
+                pod, ["cat", f"/tmp/.{pod.name}.start_time"], timeout=5.0
+            )
+            return result.stdout.decode().strip()
+        except Exception:
+            # Fallback if timestamp file doesn't exist (shouldn't happen normally)
+            return str(int(time.time()))
+
+    async def _write_snapshot_to_pod(
+        self, pod: "Pod", snapshot: ResourceSnapshot, service_name: str
+    ):
+        """Write a single snapshot to the pod's resource usage file.
+
+        Writes immediately to the same pod where metrics were collected.
+        File: {pvc_base_dir}/{service}/{pod_name}_{timestamp}.resource_usage.jsonl
+        """
+        try:
+            # Read timestamp from file written by wrapper script
+            timestamp = await self._get_container_timestamp(pod)
+
+            service_dir = f"{self._config.pvc_base_dir}/{service_name.lower()}"
+            output_file = f"{service_dir}/{pod.name}_{timestamp}.resource_usage.jsonl"
+            json_line = json.dumps(asdict(snapshot))
+            escaped_json = json_line.replace("'", "'\\''")
+            await self._exec_in_pod(
+                pod,
+                [
+                    "sh",
+                    "-c",
+                    f"mkdir -p {service_dir} && echo '{escaped_json}' >> {output_file}",
+                ],
+                timeout=5.0,
+            )
+        except Exception as e:
+            self._logger.debug(f"Failed to write resource snapshot to {pod.name}: {e}")
+
+    def _parse_meminfo(self, meminfo_output: str) -> dict:
+        """Parse /proc/meminfo output.
+
+        Args:
+            meminfo_output: Raw output from cat /proc/meminfo
+
+        Returns:
+            dict with 'total', 'available', 'used' keys (all in bytes)
+        """
+        values = {}
+        for line in meminfo_output.strip().split("\n"):
+            parts = line.split()
+            if len(parts) >= 2:
+                key = parts[0].rstrip(":")
+                # Values are in kB, convert to bytes
+                value = int(parts[1]) * 1024
+                values[key] = value
+
+        return {
+            "total": values.get("MemTotal", 0),
+            "available": values.get("MemAvailable", 0),
+            "used": values.get("MemTotal", 0) - values.get("MemAvailable", 0),
+        }
+
+    def _parse_nvidia_smi(self, output: str) -> List[dict]:
+        """Parse nvidia-smi CSV output.
+
+        Args:
+            output: Output from nvidia-smi --query-gpu=... --format=csv,noheader,nounits
+
+        Returns:
+            List of dicts with GPU metrics
+        """
+        gpus = []
+        for line in output.strip().split("\n"):
+            if not line.strip():
+                continue
+            parts = [p.strip() for p in line.split(",")]
+            if len(parts) >= 4:
+                try:
+                    gpus.append(
+                        {
+                            "index": int(parts[0]),
+                            "memory_used_mb": int(parts[1]),
+                            "memory_total_mb": int(parts[2]),
+                            "utilization_percent": int(parts[3]),
+                        }
+                    )
+                except ValueError:
+                    # Skip lines that can't be parsed
+                    continue
+        return gpus
+
+    def _calculate_cpu_usage(self, pod_name: str, proc_stat: str) -> float:
+        """Calculate CPU usage from /proc/stat (requires previous sample for delta).
+
+        Args:
+            pod_name: Pod name for tracking previous stats
+            proc_stat: Raw output from cat /proc/stat
+
+        Returns:
+            CPU usage percentage (0-100)
+        """
+        # Parse first line: cpu user nice system idle iowait irq softirq
+        first_line = proc_stat.strip().split("\n")[0]
+        parts = first_line.split()[1:]  # Skip "cpu" label
+        values = [int(p) for p in parts[:7]]
+
+        idle = values[3] + values[4]  # idle + iowait
+        total = sum(values)
+
+        # Calculate delta from previous sample
+        prev = self._prev_cpu_stats.get(pod_name, {"total": total, "idle": idle})
+        prev_total = prev.get("total", total)
+        prev_idle = prev.get("idle", idle)
+
+        # Store current values for next calculation
+        self._prev_cpu_stats[pod_name] = {"total": total, "idle": idle}
+
+        total_delta = total - prev_total
+        idle_delta = idle - prev_idle
+
+        if total_delta == 0:
+            return 0.0
+
+        return 100.0 * (1.0 - idle_delta / total_delta)
+
+    def _get_service_for_pod(self, pod: "Pod") -> str:
+        """Get service name for a pod from its labels.
+
+        Args:
+            pod: The pod object
+
+        Returns:
+            Service name or 'unknown'
+        """
+        # Try to get service name from labels
+        labels = pod.labels or {}
+
+        # Check for nvidia.com/selector label (format: deployment-servicename)
+        selector = labels.get("nvidia.com/selector", "")
+        deployment_name = self._deployment._deployment_name
+        if selector and deployment_name:
+            # Extract service name from selector (e.g., "my-deploy-frontend" -> "frontend")
+            prefix = f"{deployment_name}-"
+            if selector.startswith(prefix):
+                return selector[len(prefix) :]
+
+        return "unknown"
+
+    async def get_pod_resource_usage(
+        self, pod: "Pod", service_name: str, include_gpu: bool = True
+    ) -> Optional[ResourceSnapshot]:
+        """Get current resource usage for a single pod via exec.
+
+        Args:
+            pod: The pod to query
+            service_name: Name of the service this pod belongs to
+            include_gpu: Whether to include GPU metrics (default True)
+
+        Returns:
+            ResourceSnapshot with current metrics, or None if failed
+        """
+        try:
+            # Memory via /proc/meminfo
+            mem_result = await self._exec_in_pod(pod, ["cat", "/proc/meminfo"])
+            memory = self._parse_meminfo(mem_result.stdout.decode())
+
+            # CPU via /proc/stat
+            cpu_result = await self._exec_in_pod(pod, ["cat", "/proc/stat"])
+            cpu_usage = self._calculate_cpu_usage(pod.name, cpu_result.stdout.decode())
+
+            # Determine if GPU metrics should be collected
+            should_include_gpu = (
+                include_gpu if self._config is None else self._config.include_gpu
+            )
+
+            # GPU via nvidia-smi (if enabled and available)
+            gpu_metrics = None
+            if should_include_gpu:
+                try:
+                    gpu_result = await self._exec_in_pod(
+                        pod,
+                        [
+                            "nvidia-smi",
+                            "--query-gpu=index,memory.used,memory.total,utilization.gpu",
+                            "--format=csv,noheader,nounits",
+                        ],
+                        timeout=5.0,
+                    )
+                    if gpu_result.returncode == 0:
+                        gpu_metrics = self._parse_nvidia_smi(gpu_result.stdout.decode())
+                except Exception:
+                    # nvidia-smi not available, that's okay
+                    pass
+
+            snapshot = ResourceSnapshot(
+                timestamp=time.time(),
+                pod_name=pod.name,
+                service_name=service_name,
+                memory_used_bytes=memory["used"],
+                memory_total_bytes=memory["total"],
+                memory_available_bytes=memory["available"],
+                cpu_usage_percent=cpu_usage,
+                gpu_metrics=gpu_metrics,
+            )
+
+            # Write to PVC immediately if enabled (to the SAME pod)
+            if self._config.write_to_pvc:
+                await self._write_snapshot_to_pod(pod, snapshot, service_name)
+
+            return snapshot
+
+        except Exception as e:
+            self._logger.warning(f"Failed to get resource usage for {pod.name}: {e}")
+            return None
+
+    async def get_all_resource_usage(
+        self, include_gpu: bool = True
+    ) -> Dict[str, List[ResourceSnapshot]]:
+        """Get resource usage for all pods in all services.
+
+        Args:
+            include_gpu: Whether to include GPU metrics (default True)
+
+        Returns:
+            Dict mapping service name to list of ResourceSnapshots
+        """
+        results: Dict[str, List[ResourceSnapshot]] = {}
+
+        service_pods = self._deployment.get_pods()
+
+        for service_name, pods in service_pods.items():
+            results[service_name] = []
+            for pod in pods:
+                # Only query running pods
+                if pod.status.phase != "Running":
+                    continue
+                try:
+                    snapshot = await self.get_pod_resource_usage(
+                        pod, service_name, include_gpu=include_gpu
+                    )
+                    if snapshot:
+                        results[service_name].append(snapshot)
+                except Exception as e:
+                    self._logger.warning(f"Failed to get resources for {pod.name}: {e}")
+
+        return results

--- a/tests/utils/templates/dyn_tee.sh
+++ b/tests/utils/templates/dyn_tee.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Pipe-through wrapper: tee stdout+stderr to a per-pod logfile on the
+# mounted PVC without parsing or modifying the user's command. The
+# user command lives in $@ and is execve'd directly — no shell
+# interpretation of args, no quoting hazard, no shlex.join needed.
+#
+# Wraps via:
+#   container.command = ["/shared/dyn-tee.sh"]
+#   container.args    = <original command> + <original args>   # raw
+#
+# Required env:
+#   DYN_LOG_DIR  — absolute path of the per-service log directory
+#                  (e.g. /tmp/service_logs/service_logs/frontend)
+#   POD_NAME     — pod name (Downward API ref)
+#
+set -euo pipefail
+mkdir -p "$DYN_LOG_DIR"
+TS=$(date +%s)
+LOG_FILE="$DYN_LOG_DIR/${POD_NAME:-pod}_${TS}.log"
+# Line-buffered tee so SIGKILL still flushes the last line.
+exec > >(stdbuf -oL tee -a "$LOG_FILE")
+exec 2>&1
+# execve directly — replaces this bash with the user's command, so
+# kubelet's SIGTERM goes straight to the user process (PID 1).
+exec "$@"

--- a/tests/utils/templates/dyn_tee.sh
+++ b/tests/utils/templates/dyn_tee.sh
@@ -17,6 +17,30 @@
 #   POD_NAME     — pod name (Downward API ref)
 #
 set -euo pipefail
+
+# Optional per-pod resource-limit override.
+# Set DYN_TEST_NOFILE_LIMIT to the desired soft+hard nofile limit (e.g. 1024)
+# to force file-descriptor exhaustion at small scale — useful for
+# reproducing the F-1 frontend FD-exhaustion incident class.
+# Defaults to whatever the container runtime grants (typically ~1M).
+if [ -n "${DYN_TEST_NOFILE_LIMIT:-}" ]; then
+    # Reduce both soft and hard limits. Without -H the soft limit can
+    # be raised again at runtime; we want a hard ceiling.
+    ulimit -n "${DYN_TEST_NOFILE_LIMIT}" || true
+    ulimit -Hn "${DYN_TEST_NOFILE_LIMIT}" 2>/dev/null || true
+    echo "[dyn_tee] DYN_TEST_NOFILE_LIMIT applied: soft=$(ulimit -n) hard=$(ulimit -Hn)" >&2
+fi
+
+# Raise RLIMIT_MEMLOCK so UCX/NIXL can allocate IB completion queues.
+# On AKS clusters with the cri-containerd AppArmor profile + 64KB default
+# memlock, only a root container with privileged + IPC_LOCK + appArmor
+# Unconfined can actually call ulimit -l. See OPS-4332.
+if [ -n "${DYN_TEST_MEMLOCK_UNLIMITED:-}" ]; then
+    ulimit -l unlimited 2>/dev/null && \
+        echo "[dyn_tee] memlock raised: $(ulimit -l)" >&2 || \
+        echo "[dyn_tee] WARN: ulimit -l unlimited failed (cap=$(ulimit -l))" >&2
+fi
+
 mkdir -p "$DYN_LOG_DIR"
 TS=$(date +%s)
 LOG_FILE="$DYN_LOG_DIR/${POD_NAME:-pod}_${TS}.log"

--- a/tests/utils/templates/load_job.yaml
+++ b/tests/utils/templates/load_job.yaml
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Template for aiperf load testing Job
+# Fields marked with TEMPLATE_ are replaced at runtime by ManagedLoad
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: TEMPLATE_JOB_NAME
+  namespace: TEMPLATE_NAMESPACE
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 3600  # Auto-cleanup after 1 hour
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: aiperf
+          image: python:3.12-slim
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+              set -e
+
+              echo "=== Installing dependencies ==="
+              apt-get update && apt-get install -y --no-install-recommends curl jq procps && apt-get clean
+              pip install --quiet aiperf
+
+              echo "=== Creating output directories ==="
+              mkdir -p /tmp/aiperf/status
+
+              echo "=== Waiting for model '${MODEL_NAME}' to be available ==="
+              MAX_RETRIES=120
+              RETRY_COUNT=0
+              while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+                # Check if the specific model is listed in /v1/models response
+                if curl -s --max-time 5 "${ENDPOINT_URL}/v1/models" | \
+                   jq -e --arg model "${MODEL_NAME}" '.data[]? | select(.id == $model)' > /dev/null 2>&1; then
+                  echo "✅ Model '${MODEL_NAME}' is available"
+                  break
+                fi
+                RETRY_COUNT=$((RETRY_COUNT + 1))
+                echo "[$(date '+%H:%M:%S')] Waiting for model '${MODEL_NAME}'... ($RETRY_COUNT/$MAX_RETRIES)"
+                sleep 5
+              done
+
+              if [ $RETRY_COUNT -eq $MAX_RETRIES ]; then
+                echo "ERROR: Model '${MODEL_NAME}' not available after $MAX_RETRIES attempts"
+                echo "Checking endpoint response:"
+                curl -s "${ENDPOINT_URL}/v1/models" | head -100
+                exit 1
+              fi
+
+              echo "=== Starting aiperf load test ==="
+              touch /tmp/aiperf/status/started
+
+              # Define signal handler to keep container alive when aiperf is terminated
+              # (matches ManagedAIPerfDeployment pattern for graceful shutdown)
+              cleanup_handler() {
+                  echo "Container received signal, keeping alive for artifact extraction..."
+                  if [ -n "$AIPERF_PID" ]; then
+                      echo "Waiting for aiperf process $AIPERF_PID to finish..."
+                      wait $AIPERF_PID
+                      AIPERF_EXIT_CODE=$?
+                      echo "aiperf process finished with exit code: $AIPERF_EXIT_CODE"
+                      echo "$AIPERF_EXIT_CODE" > /tmp/aiperf/status/exit_code
+                  fi
+              }
+              trap cleanup_handler SIGTERM SIGINT
+
+              # Run aiperf with tee to BOTH stdout AND log file (like ManagedDeployment)
+              # This keeps output visible for debugging while also saving to PVC
+              set +e
+              AIPERF_CMD > >(tee -a /tmp/aiperf/aiperf.log) 2>&1 &
+              AIPERF_PID=$!
+              echo "aiperf started with PID: $AIPERF_PID"
+
+              # Wait for aiperf to complete (or be terminated by signal)
+              wait $AIPERF_PID
+              AIPERF_EXIT_CODE=$?
+              set -e
+
+              # Brief delay to ensure all file writes complete (matches ManagedAIPerfDeployment)
+              sleep 2
+
+              echo "$AIPERF_EXIT_CODE" > /tmp/aiperf/status/exit_code
+              touch /tmp/aiperf/status/completed
+
+              echo "=== aiperf completed with exit code: $AIPERF_EXIT_CODE ==="
+
+              # List generated files for debugging
+              echo "=== Generated files ==="
+              ls -la /tmp/aiperf/
+
+              # Results are on PVC - download job will extract them
+              # No need to keep container alive
+              echo "=== Container exiting, results available on PVC ==="
+          env:
+            - name: ENDPOINT_URL
+              value: "TEMPLATE_ENDPOINT_URL"
+            - name: MODEL_NAME
+              value: "TEMPLATE_MODEL_NAME"
+            - name: PYTHONUNBUFFERED
+              value: "1"
+          volumeMounts:
+            - name: results-volume
+              mountPath: /tmp/aiperf
+              subPath: aiperf  # Write to aiperf/ subdirectory on PVC, not root
+      volumes:
+        - name: results-volume
+          persistentVolumeClaim:
+            claimName: TEMPLATE_PVC_NAME

--- a/tests/utils/templates/load_job.yaml
+++ b/tests/utils/templates/load_job.yaml
@@ -28,7 +28,18 @@ spec:
               pip install --quiet aiperf
 
               echo "=== Creating output directories ==="
-              mkdir -p /tmp/aiperf/status
+              # Per-Job marker path under /tmp/aiperf/status/<job-name>/.
+              # This avoids the stale-marker race when the PVC is reused
+              # across chained loads — the framework's wait_for_completion
+              # checks the per-job path, which only this Job's pod creates.
+              # We also still wipe the loose top-level files so chained
+              # loads don't read each other's exports.
+              JOB_NAME="${HOSTNAME%-*}"  # strip random pod suffix → job-name
+              JOB_STATUS_DIR=/tmp/aiperf/status/${JOB_NAME}
+              rm -rf /tmp/aiperf/aiperf.log \
+                     /tmp/aiperf/server_metrics_export.* \
+                     /tmp/aiperf/profile_export*
+              mkdir -p "${JOB_STATUS_DIR}"
 
               echo "=== Waiting for model '${MODEL_NAME}' to be available ==="
               MAX_RETRIES=120
@@ -53,7 +64,7 @@ spec:
               fi
 
               echo "=== Starting aiperf load test ==="
-              touch /tmp/aiperf/status/started
+              touch "${JOB_STATUS_DIR}/started"
 
               # Define signal handler to keep container alive when aiperf is terminated
               # (matches ManagedAIPerfDeployment pattern for graceful shutdown)
@@ -64,7 +75,7 @@ spec:
                       wait $AIPERF_PID
                       AIPERF_EXIT_CODE=$?
                       echo "aiperf process finished with exit code: $AIPERF_EXIT_CODE"
-                      echo "$AIPERF_EXIT_CODE" > /tmp/aiperf/status/exit_code
+                      echo "$AIPERF_EXIT_CODE" > "${JOB_STATUS_DIR}/exit_code"
                   fi
               }
               trap cleanup_handler SIGTERM SIGINT
@@ -84,8 +95,8 @@ spec:
               # Brief delay to ensure all file writes complete (matches ManagedAIPerfDeployment)
               sleep 2
 
-              echo "$AIPERF_EXIT_CODE" > /tmp/aiperf/status/exit_code
-              touch /tmp/aiperf/status/completed
+              echo "$AIPERF_EXIT_CODE" > "${JOB_STATUS_DIR}/exit_code"
+              touch "${JOB_STATUS_DIR}/completed"
 
               echo "=== aiperf completed with exit code: $AIPERF_EXIT_CODE ==="
 

--- a/tests/utils/templates/load_job.yaml
+++ b/tests/utils/templates/load_job.yaml
@@ -24,8 +24,13 @@ spec:
               set -e
 
               echo "=== Installing dependencies ==="
-              apt-get update && apt-get install -y --no-install-recommends curl jq procps && apt-get clean
-              pip install --quiet aiperf
+              apt-get update && apt-get install -y --no-install-recommends curl jq procps git && apt-get clean
+              # AIPERF_SPEC is templated by ManagedLoad from LoadConfig.aiperf_ref.
+              # Default: pin to a known-working main commit that supports the
+              # --concurrency list sweep flag. Override per-scenario via the
+              # `aiperf_ref` LoadConfig field (also exposed in scenario YAML).
+              echo "Installing aiperf from: ${AIPERF_SPEC}"
+              pip install --quiet "${AIPERF_SPEC}"
 
               echo "=== Creating output directories ==="
               # Per-Job marker path under /tmp/aiperf/status/<job-name>/.
@@ -114,6 +119,8 @@ spec:
               value: "TEMPLATE_MODEL_NAME"
             - name: PYTHONUNBUFFERED
               value: "1"
+            - name: AIPERF_SPEC
+              value: "TEMPLATE_AIPERF_SPEC"
           volumeMounts:
             - name: results-volume
               mountPath: /tmp/aiperf

--- a/tests/utils/templates/log_download_job.yaml
+++ b/tests/utils/templates/log_download_job.yaml
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Template for log download Job
+# Fields marked with TEMPLATE_ are replaced at runtime by ManagedDeployment
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: TEMPLATE_JOB_NAME
+  namespace: TEMPLATE_NAMESPACE
+  labels:
+    app: log-download
+    managed-by: managed-deployment
+    deployment: TEMPLATE_DEPLOYMENT_NAME
+spec:
+  backoffLimit: 1
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        app: log-download
+        job-name: TEMPLATE_JOB_NAME
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: log-downloader
+          image: busybox:1.35
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -e
+
+              echo "=== LOG DOWNLOAD JOB STARTED at $(date --iso-8601=seconds) ==="
+              echo "Deployment: TEMPLATE_DEPLOYMENT_NAME"
+              echo "Namespace: TEMPLATE_NAMESPACE"
+              echo "Container log dir: TEMPLATE_CONTAINER_LOG_DIR"
+              echo "Job name: TEMPLATE_JOB_NAME"
+
+              # Create archive directory
+              mkdir -p /tmp/log_archive
+
+              if [ ! -d "TEMPLATE_CONTAINER_LOG_DIR" ]; then
+                  echo "Log directory TEMPLATE_CONTAINER_LOG_DIR does not exist, creating it..."
+                  mkdir -p TEMPLATE_CONTAINER_LOG_DIR
+              fi
+
+              # Mark job as ready (tar will be created on-demand at extraction time)
+              echo "ready" > /tmp/log_archive/job_ready.txt
+
+              echo "=== LOG DOWNLOAD JOB READY at $(date --iso-8601=seconds) ==="
+              echo "Waiting for extraction signal. Logs will be archived on-demand."
+
+              # Keep container alive for extraction
+              while true; do
+                  LOG_COUNT=$(find TEMPLATE_CONTAINER_LOG_DIR -name "*.log" -type f 2>/dev/null | wc -l)
+                  echo "[$(date '+%H:%M:%S')] Log download job alive - $LOG_COUNT log files available"
+                  sleep 60
+              done
+          volumeMounts:
+            - name: service-logs
+              mountPath: TEMPLATE_CONTAINER_LOG_DIR
+              subPath: service_logs  # Only access service_logs/ subdirectory on PVC
+              readOnly: true
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+      volumes:
+        - name: service-logs
+          persistentVolumeClaim:
+            claimName: TEMPLATE_PVC_NAME

--- a/tests/utils/templates/log_wrapper.sh
+++ b/tests/utils/templates/log_wrapper.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+TIMESTAMP=$(date +%s)
+echo $TIMESTAMP > /tmp/.${POD_NAME}.start_time
+mkdir -p {{SERVICE_LOG_DIR}}
+LOG_FILE="{{SERVICE_LOG_DIR}}/${POD_NAME}_${TIMESTAMP}.log"
+exec {{FULL_COMMAND}} > >(tee -a "$LOG_FILE") 2>&1


### PR DESCRIPTION
## Summary

Implements **DGH-703 (DEP: Unified K8s Test Framework for Dynamo)** as 4 commits — phase 1 (the framework + freeze of legacy) and phase 1.5 (full surface port + reliable lifecycle + fault report).

Tracks: [GH#7767](https://github.com/ai-dynamo/dynamo/issues/7767), Linear DGH-703.

## What's in this PR

### Phase 1 (3 existing commits)
- `refactor(tests)`: shared k8s infrastructure (`k8s_helpers`, `pvc_extractor`, `managed_load`, additive `ManagedDeployment` APIs, shlex consistency)
- `feat(tests)`: event-based declarative framework (`events`, `checks`, `scenario`, `test_deployment_scenario`, `TESTING.md`, resource monitor, conftest UNION)
- `chore(tests)`: deprecation headers freezing 10 legacy FT files

### Phase 1.5 (new commit `c968d1c0b7`)
- Ports the missing surface from `_2` so the framework runs end-to-end
- Reliable cleanup: `_wait_for_cr_deleted` + `_wait_for_pods_terminated` + `_scrub_namespace` + wired-in lifecycle helpers
- `Event.timed_execute` template stamps `started_at`/`ended_at` so reports can bucket time-stamped data
- New `FaultToleranceReport` renders the legacy-style markdown table:
    `| Failure | Startup (s) | Success Before | Failed Before | Success After | Failed After | Latency Before (ms) | Latency After (ms) |`
- Generalized `apply_service_changes` to publish full `ServiceSpec` (image / replicas / args / envs / …) instead of just envs
- Drops 0-caller per-service delegators on `DeploymentSpec`; mutations go through `spec[name]` directly

### Verified locally
- 3× sanity-test passes (mocker backend, k3s)
- 2× fault-test passes (DeletePod + FaultToleranceReport renders correctly with non-zero pre/post buckets)

## Out of scope (filed as follow-ups)
- Recovery time column (needs `mgr.collect_timeline()` reading pod-status conditions)
- Frontend behavior: the frontend buffers requests indefinitely when no worker is ready, so aiperf only sees its own task-cancellation timeouts. Filing a separate frontend issue — *not* a framework problem.
- Switch RWX shared PVC → per-pod RWO PVCs OR fluent-bit sidecar (eliminates the RWX storage requirement)

## Test plan
- [x] `pytest --collect-only tests/fault_tolerance/deploy/test_deployment_scenario.py` — confirms imports + parametrization (20 tests collected)
- [x] Run `test_sanity_mocker` against k3s with mocker backend — passes
- [x] Run `test_worker_kill_mocker` (DeletePod scenario) — passes, report rendered
- [ ] Run on Nebius cluster against real trtllm/sglang/vllm runtime (separate; this PR is phase-1 framework infra)

## Notes
- Stays **draft** until reviewers confirm Phase 1 scope