### PR TITLE
test(revalidate): docs: agentic harnesses blog post — prompt stability, reasoning fidelity, streaming dispatch #7561

### DIFF
--- a/components/src/dynamo/common/__init__.py
+++ b/components/src/dynamo/common/__init__.py
@@ -25,3 +25,5 @@ except Exception:
         __version__ = "0.0.0+unknown"
 
 __all__ = ["__version__", "config_dump", "constants", "utils"]
+
+# revalidate da5c37fcc54 2026-05-04T00:35:03Z

--- a/lib/runtime/src/runtime.rs
+++ b/lib/runtime/src/runtime.rs
@@ -391,3 +391,5 @@ impl Drop for RuntimeType {
         }
     }
 }
+
+// revalidate da5c37fcc54 2026-05-04T00:35:03Z


### PR DESCRIPTION
Re-validating that PR #7561 by MatejKosec did not regress, by re-running against a trivial placebo diff:

```
docs: agentic harnesses blog post — prompt stability, reasoning fidelity, streaming dispatch
```

Branch deleted on green; kept on failure for diagnosis.

Drafts are skipped by CodeRabbit per repo `.coderabbit.yaml`.