### PR TITLE
fix(operator): map prefill decode component types

### DIFF
--- a/deploy/operator/api/v1alpha1/dynamocomponentdeployment_conversion_test.go
+++ b/deploy/operator/api/v1alpha1/dynamocomponentdeployment_conversion_test.go
@@ -703,7 +703,7 @@ func TestDCD_FromV1alpha1_SparseSpokeSaveCarriesAlphaOnlyFields(t *testing.T) {
 		Spec: DynamoComponentDeploymentSpec{
 			DynamoComponentDeploymentSharedSpec: DynamoComponentDeploymentSharedSpec{
 				ComponentType:    "worker",
-				SubComponentType: "prefill",
+				SubComponentType: "custom-prefill",
 				ServiceName:      "worker-svc",
 				DynamoNamespace:  &dynNs,
 				Annotations:      map[string]string{"team": "alpha"},
@@ -730,8 +730,8 @@ func TestDCD_FromV1alpha1_SparseSpokeSaveCarriesAlphaOnlyFields(t *testing.T) {
 	if !ok {
 		t.Fatalf("failed to restore %q payload: %s", annDCDSpokeSpec, raw)
 	}
-	if saved.SubComponentType != "prefill" {
-		t.Fatalf("saved SubComponentType = %q, want prefill", saved.SubComponentType)
+	if saved.SubComponentType != "custom-prefill" {
+		t.Fatalf("saved SubComponentType = %q, want custom-prefill", saved.SubComponentType)
 	}
 	if saved.DynamoNamespace == nil || *saved.DynamoNamespace != dynNs {
 		t.Fatalf("saved DynamoNamespace = %v, want %q", saved.DynamoNamespace, dynNs)

--- a/deploy/operator/api/v1alpha1/dynamographdeployment_conversion_bugs_test.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeployment_conversion_bugs_test.go
@@ -62,3 +62,46 @@ func TestBugDGD_IntermediateHubAddsMainOnlyPodTemplateRoundTrips(t *testing.T) {
 		t.Fatalf("podTemplate mismatch (-want +got):\n%s", diff)
 	}
 }
+
+func TestBugDGD_BetaPrefillDecodeConvertFromUsesAlphaSubComponentType(t *testing.T) {
+	hub := &v1beta1.DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "disaggregated", Namespace: "ns"},
+		Spec: v1beta1.DynamoGraphDeploymentSpec{
+			Components: []v1beta1.DynamoComponentDeploymentSharedSpec{
+				{
+					ComponentName: "prefill",
+					ComponentType: v1beta1.ComponentTypePrefill,
+				},
+				{
+					ComponentName: "decode",
+					ComponentType: v1beta1.ComponentTypeDecode,
+				},
+			},
+		},
+	}
+
+	spoke := &DynamoGraphDeployment{}
+	if err := spoke.ConvertFrom(hub); err != nil {
+		t.Fatalf("ConvertFrom() error = %v", err)
+	}
+	for _, name := range []string{"prefill", "decode"} {
+		component := spoke.Spec.Services[name]
+		if component == nil {
+			t.Fatalf("expected %q service after ConvertFrom: %#v", name, spoke.Spec.Services)
+		}
+		if component.ComponentType != string(v1beta1.ComponentTypeWorker) {
+			t.Fatalf("%s componentType = %q, want worker", name, component.ComponentType)
+		}
+		if component.SubComponentType != name {
+			t.Fatalf("%s subComponentType = %q, want %q", name, component.SubComponentType, name)
+		}
+	}
+
+	restored := &v1beta1.DynamoGraphDeployment{}
+	if err := spoke.ConvertTo(restored); err != nil {
+		t.Fatalf("ConvertTo() error = %v", err)
+	}
+	if diff := cmp.Diff(hub.Spec.Components, restored.Spec.Components, cmpopts.EquateEmpty()); diff != "" {
+		t.Fatalf("components mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/deploy/operator/api/v1alpha1/dynamographdeployment_conversion_test.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeployment_conversion_test.go
@@ -717,8 +717,8 @@ func TestDGD_FromV1alpha1_DisabledExperimental(t *testing.T) {
 	}
 }
 
-// TestDGD_FromV1alpha1_SubComponentType verifies that a v1alpha1-only
-// subComponentType string survives via sparse spec preservation.
+// TestDGD_FromV1alpha1_SubComponentType verifies that a subComponentType string
+// without a v1beta1 first-class component type survives via sparse preservation.
 func TestDGD_FromV1alpha1_SubComponentType(t *testing.T) {
 	src := &DynamoGraphDeployment{
 		ObjectMeta: metav1.ObjectMeta{Name: "sub", Namespace: "ns"},
@@ -726,7 +726,7 @@ func TestDGD_FromV1alpha1_SubComponentType(t *testing.T) {
 			Services: map[string]*DynamoComponentDeploymentSharedSpec{
 				"worker": {
 					ComponentType:    "worker",
-					SubComponentType: "prefill",
+					SubComponentType: "custom-prefill",
 				},
 			},
 		},

--- a/deploy/operator/api/v1alpha1/shared_spec_conversion.go
+++ b/deploy/operator/api/v1alpha1/shared_spec_conversion.go
@@ -149,11 +149,9 @@ func convertSharedSpecToHub(src *DynamoComponentDeploymentSharedSpec, dst *v1bet
 		return nil
 	}
 
-	// ComponentType: in v1alpha1 this is a free-form string; in v1beta1 it is
-	// a strict enum. The conversion is a value copy; unknown strings become
-	// the empty enum on the v1beta1 side and will be rejected by the CRD
-	// validator, which matches the intended behaviour.
-	dst.ComponentType = v1beta1.ComponentType(src.ComponentType)
+	// ComponentType: v1beta1 promotes the legacy v1alpha1 worker subcomponent
+	// values to first-class component types.
+	dst.ComponentType = sharedComponentTypeToHub(src)
 
 	// v1alpha1 ServiceName <-> v1beta1 ComponentName: the same logical
 	// identifier, renamed at v1beta1 to align with the
@@ -301,7 +299,7 @@ func saveSharedAlphaOnlySpec(src, save *DynamoComponentDeploymentSharedSpec, inc
 	}
 	hasSave := false
 
-	if src.SubComponentType != "" {
+	if sharedSubComponentTypeNeedsSave(src) {
 		save.SubComponentType = src.SubComponentType
 		hasSave = true
 	}
@@ -376,6 +374,38 @@ func saveSharedAlphaOnlySpec(src, save *DynamoComponentDeploymentSharedSpec, inc
 
 func sharedAlphaSpecSaveIsZero(save *DynamoComponentDeploymentSharedSpec) bool {
 	return save == nil || apiequality.Semantic.DeepEqual(*save, DynamoComponentDeploymentSharedSpec{})
+}
+
+func sharedComponentTypeToHub(src *DynamoComponentDeploymentSharedSpec) v1beta1.ComponentType {
+	if src == nil {
+		return ""
+	}
+	if sharedSubComponentTypePromotesToHubComponentType(src) {
+		return v1beta1.ComponentType(src.SubComponentType)
+	}
+	return v1beta1.ComponentType(src.ComponentType)
+}
+
+func sharedComponentTypeFromHub(src v1beta1.ComponentType) (componentType string, subComponentType string) {
+	switch src {
+	case v1beta1.ComponentTypePrefill, v1beta1.ComponentTypeDecode:
+		return string(v1beta1.ComponentTypeWorker), string(src)
+	default:
+		return string(src), ""
+	}
+}
+
+func sharedSubComponentTypeNeedsSave(src *DynamoComponentDeploymentSharedSpec) bool {
+	return src != nil &&
+		src.SubComponentType != "" &&
+		!sharedSubComponentTypePromotesToHubComponentType(src)
+}
+
+func sharedSubComponentTypePromotesToHubComponentType(src *DynamoComponentDeploymentSharedSpec) bool {
+	return src != nil &&
+		src.ComponentType == string(v1beta1.ComponentTypeWorker) &&
+		(src.SubComponentType == string(v1beta1.ComponentTypePrefill) ||
+			src.SubComponentType == string(v1beta1.ComponentTypeDecode))
 }
 
 func sharedMainContainerFieldOriginsNeedSave(src *DynamoComponentDeploymentSharedSpec) bool {
@@ -486,7 +516,7 @@ func convertSharedSpecFromHub(src *v1beta1.DynamoComponentDeploymentSharedSpec, 
 		return nil
 	}
 
-	dst.ComponentType = string(src.ComponentType)
+	dst.ComponentType, dst.SubComponentType = sharedComponentTypeFromHub(src.ComponentType)
 	dst.GlobalDynamoNamespace = src.GlobalDynamoNamespace
 	dst.Replicas = src.Replicas
 


### PR DESCRIPTION
## Summary

Fix v1alpha1/v1beta1 conversion for first-class v1beta1 disaggregated component types.

What was wrong before:

- v1beta1 `type: prefill` converted to v1alpha1 `componentType: prefill` with empty `subComponentType`.
- v1beta1 `type: decode` converted to v1alpha1 `componentType: decode` with empty `subComponentType`.
- Existing planner consumers still read DGD through v1alpha1 and identify prefill/decode workers via `spec.services[*].subComponentType`, so beta-created disaggregated components were not planner-visible.

What is now right:

- v1beta1 `type: prefill|decode` converts to the legacy planner-visible v1alpha1 shape: `componentType: worker` plus `subComponentType: prefill|decode`.
- v1alpha1 `componentType: worker` plus `subComponentType: prefill|decode` converts back to first-class v1beta1 `type: prefill|decode`.
- Those representable `subComponentType` values are not saved in sparse preservation annotations.
- Non-representable custom `subComponentType` values still use sparse preservation and continue to round-trip.

## YAML Example

Before this fix, this v1beta1 object:

```yaml
apiVersion: nvidia.com/v1beta1
kind: DynamoGraphDeployment
metadata:
  name: disaggregated
spec:
  components:
  - name: prefill
    type: prefill
  - name: decode
    type: decode
```

incorrectly converted to v1alpha1 like this:

```yaml
apiVersion: nvidia.com/v1alpha1
kind: DynamoGraphDeployment
metadata:
  name: disaggregated
spec:
  services:
    prefill:
      componentType: prefill
    decode:
      componentType: decode
```

That is wrong for current planner consumers because `subComponentType` is missing.

With this fix, it converts to the planner-visible v1alpha1 shape:

```yaml
apiVersion: nvidia.com/v1alpha1
kind: DynamoGraphDeployment
metadata:
  name: disaggregated
spec:
  services:
    prefill:
      componentType: worker
      subComponentType: prefill
    decode:
      componentType: worker
      subComponentType: decode
```

Converting back to v1beta1 restores `type: prefill` / `type: decode`.

## Prompt history

This PR addresses the P1 conversion review finding that beta-created prefill/decode DGD components are not planner-visible through v1alpha1 because planner consumers still look at `spec.services[*].subComponentType`.

## Tests

- `go test ./api/v1alpha1 -count=1`
- `go test ./api -count=1`

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9082" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
