### PR TITLE
fix(operator): default v1beta1 DCD name

### DIFF
--- a/deploy/helm/charts/platform/components/operator/crds/nvidia.com_dynamocomponentdeployments.yaml
+++ b/deploy/helm/charts/platform/components/operator/crds/nvidia.com_dynamocomponentdeployments.yaml
@@ -19993,7 +19993,6 @@ spec:
                   type: string
               required:
                 - backendFramework
-                - name
               type: object
               x-kubernetes-validations:
                 - message: eppConfig may only be set when type is epp

--- a/deploy/helm/charts/platform/components/operator/templates/webhook-configuration.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/webhook-configuration.yaml
@@ -233,6 +233,40 @@ webhooks:
     service:
       name: {{ include "dynamo-operator.fullname" . }}-webhook-service
       namespace: {{ .Release.Namespace }}
+      path: /mutate-nvidia-com-v1beta1-dynamocomponentdeployment
+  failurePolicy: {{ .Values.webhook.failurePolicy }}
+  matchPolicy: Exact
+  name: mdynamocomponentdeploymentv1beta1.kb.io
+  {{- if .Values.webhook.namespaceSelector }}
+  namespaceSelector:
+    {{- toYaml .Values.webhook.namespaceSelector | nindent 4 }}
+  {{- else if .Values.namespaceRestriction.enabled }}
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: {{ .Release.Namespace }}
+  {{- end }}
+  rules:
+  - apiGroups:
+    - nvidia.com
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    resources:
+    - dynamocomponentdeployments
+  sideEffects: None
+  timeoutSeconds: {{ .Values.webhook.timeoutSeconds }}
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    {{- if and (not .Values.webhook.certManager.enabled) .Values.webhook.certificateSecret.external }}
+    {{- if .Values.webhook.caBundle }}
+    caBundle: {{ .Values.webhook.caBundle }}
+    {{- end }}
+    {{- end }}
+    service:
+      name: {{ include "dynamo-operator.fullname" . }}-webhook-service
+      namespace: {{ .Release.Namespace }}
       path: /mutate-nvidia-com-v1beta1-dynamographdeploymentrequest
   failurePolicy: {{ .Values.webhook.failurePolicy }}
   name: mdynamographdeploymentrequestv1beta1.kb.io
@@ -255,4 +289,3 @@ webhooks:
     - dynamographdeploymentrequests
   sideEffects: None
   timeoutSeconds: {{ .Values.webhook.timeoutSeconds }}
-

--- a/deploy/operator/Makefile
+++ b/deploy/operator/Makefile
@@ -84,6 +84,8 @@ manifests: controller-gen yq ## Generate WebhookConfiguration, ClusterRole and C
 	for file in config/crd/bases/*.yaml; do \
 		$(YQ) eval '(.. | select(has("extraPodSpec")) | .extraPodSpec.required) |= (. - ["containers"])' -i --indent 2 $$file || exit 1; \
 	done
+	echo "Removing name from standalone v1beta1 DynamoComponentDeployment required fields"
+	$(YQ) eval '(.spec.versions[] | select(.name == "v1beta1") | .schema.openAPIV3Schema.properties.spec.required) |= (. - ["name"])' -i --indent 2 config/crd/bases/nvidia.com_dynamocomponentdeployments.yaml
 	echo "Fixing PluginSpec parameters field: json.RawMessage needs x-kubernetes-preserve-unknown-fields instead of type: string"
 	for file in config/crd/bases/*.yaml; do \
 		$(YQ) eval '(.. | select(has("parameters")) | .parameters | select(has("format") and .format == "byte")) |= (del(.format) | del(.type) | .x-kubernetes-preserve-unknown-fields = true)' -i --indent 2 $$file || exit 1; \

--- a/deploy/operator/cmd/main.go
+++ b/deploy/operator/cmd/main.go
@@ -788,6 +788,11 @@ func registerWebhooks(
 
 	setupLog.Info("Registering defaulting webhooks")
 
+	dcdDefaulter := webhookdefaulting.NewDCDDefaulter()
+	if err := dcdDefaulter.RegisterWithManager(mgr); err != nil {
+		return fmt.Errorf("unable to register DynamoComponentDeployment defaulting webhook: %w", err)
+	}
+
 	dgdDefaulter := webhookdefaulting.NewDGDDefaulter(operatorVersion)
 	if err := dgdDefaulter.RegisterWithManager(mgr); err != nil {
 		return fmt.Errorf("unable to register DynamoGraphDeployment defaulting webhook: %w", err)

--- a/deploy/operator/config/crd/bases/nvidia.com_dynamocomponentdeployments.yaml
+++ b/deploy/operator/config/crd/bases/nvidia.com_dynamocomponentdeployments.yaml
@@ -19993,7 +19993,6 @@ spec:
                   type: string
               required:
                 - backendFramework
-                - name
               type: object
               x-kubernetes-validations:
                 - message: eppConfig may only be set when type is epp

--- a/deploy/operator/internal/webhook/defaulting/dynamocomponentdeployment_handler.go
+++ b/deploy/operator/internal/webhook/defaulting/dynamocomponentdeployment_handler.go
@@ -1,0 +1,79 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package defaulting
+
+import (
+	"context"
+	"fmt"
+
+	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+const (
+	dcdDefaultingWebhookName = "dynamocomponentdeployment-defaulting-webhook"
+	dcdDefaultingWebhookPath = "/mutate-nvidia-com-v1beta1-dynamocomponentdeployment"
+)
+
+// DCDDefaulter is a mutating webhook handler for v1beta1 DynamoComponentDeployment.
+type DCDDefaulter struct{}
+
+// NewDCDDefaulter creates a new DCDDefaulter.
+func NewDCDDefaulter() *DCDDefaulter {
+	return &DCDDefaulter{}
+}
+
+// Default implements admission.CustomDefaulter.
+// On CREATE, standalone v1beta1 DCDs default spec.name from metadata.name.
+func (d *DCDDefaulter) Default(ctx context.Context, obj runtime.Object) error {
+	logger := log.FromContext(ctx).WithName(dcdDefaultingWebhookName)
+
+	dcd, ok := obj.(*nvidiacomv1beta1.DynamoComponentDeployment)
+	if !ok {
+		return fmt.Errorf("expected DynamoComponentDeployment but got %T", obj)
+	}
+
+	req, err := admission.RequestFromContext(ctx)
+	if err != nil {
+		logger.Error(err, "failed to get admission request from context, skipping defaulting")
+		return nil
+	}
+
+	if req.Operation == admissionv1.Create && dcd.Spec.ComponentName == "" && dcd.Name != "" {
+		dcd.Spec.ComponentName = dcd.Name
+		logger.Info("defaulted spec.name from metadata.name",
+			"name", dcd.Name,
+			"namespace", dcd.Namespace,
+		)
+	}
+
+	return nil
+}
+
+// RegisterWithManager registers the DCD defaulting webhook with the manager.
+func (d *DCDDefaulter) RegisterWithManager(mgr manager.Manager) error {
+	webhook := admission.
+		WithCustomDefaulter(mgr.GetScheme(), &nvidiacomv1beta1.DynamoComponentDeployment{}, d).
+		WithRecoverPanic(true)
+	mgr.GetWebhookServer().Register(dcdDefaultingWebhookPath, webhook)
+	return nil
+}

--- a/deploy/operator/internal/webhook/defaulting/dynamocomponentdeployment_handler_test.go
+++ b/deploy/operator/internal/webhook/defaulting/dynamocomponentdeployment_handler_test.go
@@ -1,0 +1,97 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package defaulting
+
+import (
+	"context"
+	"testing"
+
+	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestDCDDefaulter_DefaultsComponentNameOnCreate(t *testing.T) {
+	tests := []struct {
+		name string
+		ctx  context.Context
+		dcd  *nvidiacomv1beta1.DynamoComponentDeployment
+		want string
+	}{
+		{
+			name: "CREATE defaults empty spec name from metadata name",
+			ctx:  admissionCtx(admissionv1.Create),
+			dcd: &nvidiacomv1beta1.DynamoComponentDeployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "worker"},
+			},
+			want: "worker",
+		},
+		{
+			name: "CREATE preserves explicit spec name",
+			ctx:  admissionCtx(admissionv1.Create),
+			dcd: &nvidiacomv1beta1.DynamoComponentDeployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "worker"},
+				Spec: nvidiacomv1beta1.DynamoComponentDeploymentSpec{
+					DynamoComponentDeploymentSharedSpec: nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec{
+						ComponentName: "custom",
+					},
+				},
+			},
+			want: "custom",
+		},
+		{
+			name: "UPDATE does not default empty spec name",
+			ctx:  admissionCtx(admissionv1.Update),
+			dcd: &nvidiacomv1beta1.DynamoComponentDeployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "worker"},
+			},
+			want: "",
+		},
+		{
+			name: "missing admission request skips defaulting gracefully",
+			ctx:  context.Background(),
+			dcd: &nvidiacomv1beta1.DynamoComponentDeployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "worker"},
+			},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defaulter := NewDCDDefaulter()
+
+			if err := defaulter.Default(tt.ctx, tt.dcd); err != nil {
+				t.Fatalf("Default() unexpected error: %v", err)
+			}
+
+			if got := tt.dcd.Spec.ComponentName; got != tt.want {
+				t.Fatalf("spec.name = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDCDDefaulter_DefaultRejectsWrongType(t *testing.T) {
+	defaulter := NewDCDDefaulter()
+
+	if err := defaulter.Default(admissionCtx(admissionv1.Create), &corev1.Pod{}); err == nil {
+		t.Fatal("Default() error = nil, want type error")
+	}
+}


### PR DESCRIPTION
**Summary**
- Make standalone v1beta1 DynamoComponentDeployment `spec.name` optional in the generated CRD schema while keeping embedded DGD `spec.components[].name` required.
- Add a v1beta1 DynamoComponentDeployment mutating defaulter that sets `spec.name` from `metadata.name` on CREATE when omitted.
- Register the defaulter in the operator manager and add the corresponding Helm mutating webhook rule with `matchPolicy: Exact`.
- Cover create/update/missing-context/default-preservation behavior with focused defaulting tests.

**Why**
The v1beta1 DCD API documents standalone `spec.name` as defaulted from `metadata.name`, but the generated standalone DCD CRD schema marked the field required. That breaks both the documented UX and client-side schema validation: a schema-aware client can reject this object before the mutating webhook ever runs.

```yaml
apiVersion: nvidia.com/v1beta1
kind: DynamoComponentDeployment
metadata:
  name: worker
spec:
  backendFramework: vllm
  type: worker
```

After this change, the standalone DCD CRD allows the omitted field, and admission mutates it to:

```yaml
spec:
  name: worker
  backendFramework: vllm
  type: worker
```

Embedded DGD components still require `name` because it is the `spec.components` list-map key:

```yaml
spec:
  components:
  - name: worker
    type: worker
```

**Prompt trail**
- Review found that standalone v1beta1 DCD creates omitting `spec.name` are rejected despite the API comment saying the field is defaulted from `metadata.name`.
- We noted that a required OpenAPI field can fail client-side validation before server-side defaulting, so the fix needs a CRD schema patch in addition to the mutating webhook.
- Keep the fix scoped to this defaulting issue and do not touch DGDR.
- Keep the diff minimal: add the DCD defaulter, register it, expose the matching Helm webhook rule, patch only the standalone DCD v1beta1 required list, and add focused tests.

**Verification**
- `make manifests`
- `go test ./internal/webhook/defaulting ./cmd -count=1`
- `helm template test deploy/helm/charts/platform/components/operator --set discoveryBackend=kubernetes --show-only templates/webhook-configuration.yaml`

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9083" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->