### PR TITLE
test(revalidate): fix(vllm): fix prefill cancellation log race in _monitor_abort [DYN-2880] #8768

### DIFF
--- a/components/src/dynamo/common/__init__.py
+++ b/components/src/dynamo/common/__init__.py
@@ -25,3 +25,5 @@ except Exception:
         __version__ = "0.0.0+unknown"
 
 __all__ = ["__version__", "config_dump", "constants", "utils"]
+
+# revalidate 0db98859f46 2026-05-04T14:56:03Z

--- a/lib/runtime/src/runtime.rs
+++ b/lib/runtime/src/runtime.rs
@@ -391,3 +391,5 @@ impl Drop for RuntimeType {
         }
     }
 }
+
+// revalidate 0db98859f46 2026-05-04T14:56:03Z


### PR DESCRIPTION
Re-validating that PR #8768 by Tzu-Ling Kan did not regress, by re-running against a trivial placebo diff:

```
fix(vllm): fix prefill cancellation log race in _monitor_abort [DYN-2880]
```

Branch deleted on green; kept on failure for diagnosis.

Drafts are skipped by CodeRabbit per repo `.coderabbit.yaml`.