### PR TITLE
perf: bump the worker concurrency limit by raising the default tcp worker pool size

### DIFF
--- a/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
+++ b/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
@@ -29,11 +29,11 @@ use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
 
 /// Default worker pool size for TCP request handling
-const DEFAULT_WORKER_POOL_SIZE: usize = 1500;
+const DEFAULT_WORKER_POOL_SIZE: usize = 10000;
 
 /// Default work queue size for TCP request handling
 /// this is 4X the worker pool size to handle burst traffic
-const DEFAULT_WORK_QUEUE_SIZE: usize = 6000;
+const DEFAULT_WORK_QUEUE_SIZE: usize = 40000;
 
 /// Get worker pool size from environment or use default
 fn get_worker_pool_size() -> usize {


### PR DESCRIPTION
#### Overview:

bump the worker concurrency limit by raising the default tcp worker pool size

#### Details:

The default DEFAULT_WORKER_POOL_SIZE has become the effective "max concurrent requests a worker could handle at the same time". This might confuse the users when they start benchmarking with concurrency > 1500 and see huge perf drop. 

Normally the user won't benchmark > 8196 concurrency, so pin 10000 as the limit for now.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9090" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased default capacity limits for TCP shared endpoints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->