### PR TITLE
test: fail prefix roundtrip when no traces are tested

### DIFF
--- a/benchmarks/prefix_data_generator/tests/test_roundtrip_hashes.py
+++ b/benchmarks/prefix_data_generator/tests/test_roundtrip_hashes.py
@@ -97,6 +97,7 @@ class TestRoundtripHashes:
             # Phase 2: Test roundtrip
             roundtrip_hasher = RollingHasher(block_size=DEFAULT_BLOCK_SIZE)
             mismatches = []
+            generation_failures = []
             tested = 0
 
             for i, trace in enumerate(traces):
@@ -113,6 +114,7 @@ class TestRoundtripHashes:
                     )
                 except Exception as e:
                     print(f"  Trace {i}: Generation failed - {e}")
+                    generation_failures.append((i, str(e)))
                     continue
 
                 # Step 2: Re-encode text (simulates what server does)
@@ -141,6 +143,19 @@ class TestRoundtripHashes:
                     )
 
             print(f"\nTested {tested} traces with hash_ids")
+
+            if tested == 0:
+                failure_details = ""
+                if generation_failures:
+                    preview = "; ".join(
+                        f"trace {i}: {error}"
+                        for i, error in generation_failures[:5]
+                    )
+                    failure_details = f" Generation failures: {preview}"
+                pytest.fail(
+                    "No traces were successfully tested for hash roundtrip."
+                    f"{failure_details}"
+                )
 
             # Report results
             if mismatches:

--- a/benchmarks/prefix_data_generator/tests/test_roundtrip_hashes.py
+++ b/benchmarks/prefix_data_generator/tests/test_roundtrip_hashes.py
@@ -148,8 +148,7 @@ class TestRoundtripHashes:
                 failure_details = ""
                 if generation_failures:
                     preview = "; ".join(
-                        f"trace {i}: {error}"
-                        for i, error in generation_failures[:5]
+                        f"trace {i}: {error}" for i, error in generation_failures[:5]
                     )
                     failure_details = f" Generation failures: {preview}"
                 pytest.fail(

--- a/benchmarks/prefix_data_generator/tests/test_roundtrip_hashes.py
+++ b/benchmarks/prefix_data_generator/tests/test_roundtrip_hashes.py
@@ -21,10 +21,15 @@ import tempfile
 import urllib.request
 
 import pytest
-from aiperf.common.config import PromptConfig
-from aiperf.common.tokenizer import Tokenizer
-from aiperf.dataset.generator import PromptGenerator
-from aiperf.dataset.synthesis.rolling_hasher import RollingHasher
+
+try:
+    from aiperf.common.config import PromptConfig
+    from aiperf.common.exceptions import ConfigurationError
+    from aiperf.common.tokenizer import Tokenizer
+    from aiperf.dataset.generator import PromptGenerator
+    from aiperf.dataset.synthesis.rolling_hasher import RollingHasher
+except ImportError:
+    pytest.skip("aiperf not installed; skipping tests", allow_module_level=True)
 
 # Mooncake trace URL
 MOONCAKE_TRACE_URL = "https://raw.githubusercontent.com/kvcache-ai/Mooncake/main/FAST25-release/arxiv-trace/mooncake_trace.jsonl"
@@ -47,6 +52,7 @@ def download_mooncake_trace(output_path: str, num_lines: int = 100) -> None:
 class TestRoundtripHashes:
     """Test hash consistency through aiperf's PromptGenerator."""
 
+    @pytest.mark.timeout(120)
     def test_hash_roundtrip_direct(self):
         """
         Direct test using PromptGenerator:
@@ -112,7 +118,7 @@ class TestRoundtripHashes:
                     generated_text = prompt_generator.generate(
                         mean=input_length, hash_ids=original_hash_ids
                     )
-                except Exception as e:
+                except ConfigurationError as e:
                     print(f"  Trace {i}: Generation failed - {e}")
                     generation_failures.append((i, str(e)))
                     continue


### PR DESCRIPTION
## Summary

- Track generation failures in the prefix hash roundtrip test.
- Fail the test if no traces are successfully exercised.
- Preserve existing mismatch reporting when traces do run.

Closes #9094.

## Validation

- `python -m py_compile benchmarks/prefix_data_generator/tests/test_roundtrip_hashes.py`
- `git diff --check ai-dynamo/main...HEAD`

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9095" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved error tracking and reporting in hash validation tests to separately identify generation failures from mismatches, providing clearer diagnostic messages when tests encounter issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->