### PR TITLE
perf: disable Python GC when DYN_TRTLLM_SERVER_DISABLE_GC or TRTLLM_SERVER_DISABLE_GC  is set

### DIFF
--- a/components/src/dynamo/trtllm/main.py
+++ b/components/src/dynamo/trtllm/main.py
@@ -2,7 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import gc
 import logging
+import os
 from typing import Callable, Coroutine
 
 import uvloop
@@ -80,6 +82,10 @@ def _make_drain_callback(
 
 async def worker():
     config = parse_args()
+
+    if os.getenv("TRTLLM_SERVER_DISABLE_GC", "0") == "1":
+        gc.disable()
+        logging.info("Python cyclic GC disabled (TRTLLM_SERVER_DISABLE_GC=1)")
 
     shutdown_event = asyncio.Event()
     runtime, loop = create_runtime(

--- a/components/src/dynamo/trtllm/main.py
+++ b/components/src/dynamo/trtllm/main.py
@@ -4,14 +4,13 @@
 import asyncio
 import gc
 import logging
-import os
 from typing import Callable, Coroutine
 
 import uvloop
 
 from dynamo.common.utils.graceful_shutdown import install_signal_handlers
 from dynamo.common.utils.runtime import create_runtime
-from dynamo.runtime.logging import configure_dynamo_logging
+from dynamo.runtime.logging import configure_dynamo_logging, get_bool_env_var
 from dynamo.trtllm.args import parse_args
 from dynamo.trtllm.constants import DisaggregationMode
 from dynamo.trtllm.workers import init_worker
@@ -83,9 +82,13 @@ def _make_drain_callback(
 async def worker():
     config = parse_args()
 
-    if os.getenv("TRTLLM_SERVER_DISABLE_GC", "0") == "1":
+    if get_bool_env_var("DYN_TRTLLM_SERVER_DISABLE_GC") or get_bool_env_var(
+        "TRTLLM_SERVER_DISABLE_GC"
+    ):
         gc.disable()
-        logging.info("Python cyclic GC disabled (TRTLLM_SERVER_DISABLE_GC=1)")
+        logging.info(
+            "Python cyclic GC disabled (DYN_TRTLLM_SERVER_DISABLE_GC or TRTLLM_SERVER_DISABLE_GC is set)"
+        )
 
     shutdown_event = asyncio.Event()
     runtime, loop = create_runtime(

--- a/docs/backends/trtllm/trtllm-reference-guide.md
+++ b/docs/backends/trtllm/trtllm-reference-guide.md
@@ -70,6 +70,17 @@ See the instructions here: [Running KVBM in TensorRT-LLM](../../components/kvbm/
 
 TensorRT-LLM exposes Prometheus metrics for monitoring inference performance. For detailed metrics reference, collection setup, and Grafana integration, see the [Observability Guide](./trtllm-observability.md).
 
+## Disabling Python Cyclic GC for high concurrency benchmarks
+
+Dynamo with TensorRT-LLM exposes `DYN_TRTLLM_SERVER_DISABLE_GC` to match the behavior of `TRTLLM_SERVER_DISABLE_GC` in `trtllm-serve`. When set, the TensorRT-LLM worker disables Python's cyclic garbage collector at startup so that generational GC pauses do not land on the request hot path. Reference-counted deallocation still runs normally — only the cycle collector is turned off.
+
+```bash
+export DYN_TRTLLM_SERVER_DISABLE_GC=1
+```
+
+This is most useful for high-concurrency benchmarks, where it boosts throughput and stabilizes TTFT/ITL measurements by removing GC-induced tail-latency spikes.
+
+
 ## Known Issues and Mitigations
 
 For known issues, workarounds, and mitigations, see the [Known Issues and Mitigations](./trtllm-known-issues.md) page.


### PR DESCRIPTION
#### Overview:

We’ve seen that Dynamo’s TRT-LLM performance cannot match trtllm-serve at high concurrency, such as 8192. After some digging, it turns out that trtllm-serve normally disables garbage collection on both the server and worker. However, TRTLLM_SERVER_DISABLE_GC is not currently effective for the Dynamo worker.

This change adds support for disabling garbage collection when TRT-LLM’s TRTLLM_SERVER_DISABLE_GC is set, because the worker uvloop can stall when garbage collection kicks in.

#### Details:

TRT-LLM normally sets both TRTLLM_SERVER_DISABLE_GC=1 and TRTLLM_WORKER_DISABLE_GC=1 in all benchmarks. However, for dynamo.trtllm, only TRTLLM_WORKER_DISABLE_GC=1 is effective because Dynamo only integrates the TRT-LLM engine.

We need to make TRTLLM_SERVER_DISABLE_GC=1 effective as well, so that the process responsible for accepting requests and performing pre/post-processing is not stalled by Python garbage collection. This should allow Dynamo to match the performance of trtllm-serve.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional environment variable to disable Python cyclic garbage collection during TRT-LLM server startup for improved performance in specific deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->