### PR TITLE
fix(container): include pytest in runtime validation images

### DIFF
--- a/container/deps/requirements.validation.txt
+++ b/container/deps/requirements.validation.txt
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Minimal validation substrate for compute-session runtime images.
+# Full test/dev dependencies stay in requirements.test.txt and requirements.dev.txt.
+pytest==8.4.2

--- a/container/templates/dynamo_runtime.Dockerfile
+++ b/container/templates/dynamo_runtime.Dockerfile
@@ -135,10 +135,12 @@ RUN git lfs install
 # Install runtime dependencies (common + planner + frontend).
 # Frontend deps (tritonclient + grpcio/protobuf pins) are installed here so the resolver
 # sees all constraints in one pass, avoiding grpcio downgrades in the test layer.
-# Test and dev dependencies are NOT installed here — they go in the test and dev images.
+# Full test and dev dependencies are NOT installed here — they go in the test and dev images.
+# requirements.validation.txt is the minimal compute-session validation substrate.
 RUN --mount=type=bind,source=./container/deps/requirements.common.txt,target=/tmp/requirements.common.txt \
     --mount=type=bind,source=./container/deps/requirements.planner.txt,target=/tmp/requirements.planner.txt \
     --mount=type=bind,source=./container/deps/requirements.frontend.txt,target=/tmp/requirements.frontend.txt \
+    --mount=type=bind,source=./container/deps/requirements.validation.txt,target=/tmp/requirements.validation.txt \
     --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sharing=locked \
     export UV_CACHE_DIR=/home/dynamo/.cache/uv UV_GIT_LFS=1 UV_HTTP_TIMEOUT=300 UV_HTTP_RETRIES=5 && \
     uv pip install \
@@ -146,7 +148,8 @@ RUN --mount=type=bind,source=./container/deps/requirements.common.txt,target=/tm
         --extra-index-url https://download.pytorch.org/whl/cu130 \
         --requirement /tmp/requirements.common.txt \
         --requirement /tmp/requirements.planner.txt \
-        --requirement /tmp/requirements.frontend.txt
+        --requirement /tmp/requirements.frontend.txt \
+        --requirement /tmp/requirements.validation.txt
 
 # TODO: skip /workspace COPY for dev/local-dev (bind-mounted from host, gets shadowed)
 # Copy workspace source code

--- a/container/templates/sglang_runtime.Dockerfile
+++ b/container/templates/sglang_runtime.Dockerfile
@@ -58,6 +58,12 @@ RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     export PIP_CACHE_DIR=/root/.cache/pip && \
     pip install --break-system-packages --no-deps "accelerate==1.13.0"
 
+# Minimal compute-session validation substrate. Full test/dev dependencies stay
+# in the test and dev images, but runtime images still need the pytest launcher
+# when the factory validates source-mounted focused Python checks.
+RUN --mount=type=bind,source=./container/deps/requirements.validation.txt,target=/tmp/requirements.validation.txt \
+    pip install --break-system-packages --requirement /tmp/requirements.validation.txt
+
 # Install gpu_memory_service wheel if enabled (all targets)
 ARG ENABLE_GPU_MEMORY_SERVICE
 RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \

--- a/container/templates/trtllm_runtime.Dockerfile
+++ b/container/templates/trtllm_runtime.Dockerfile
@@ -273,11 +273,13 @@ RUN --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sh
         if [ -n "$GMS_WHEEL" ]; then uv pip install "$GMS_WHEEL"; fi; \
     fi
 
-# Install runtime dependencies (common + benchmarks).
-# Test and dev dependencies are NOT installed here — they go in the test and dev images.
+# Install runtime dependencies (common + benchmarks) plus the minimal
+# compute-session validation substrate. Full test/dev dependencies stay in the
+# test and dev images.
 # --no-cache is intentional: mixed indexes (PyPI + PyTorch CUDA wheels) risk serving stale/wrong-variant cached wheels
 RUN --mount=type=bind,source=./container/deps/requirements.common.txt,target=/tmp/requirements.common.txt \
     --mount=type=bind,source=./container/deps/requirements.benchmark.txt,target=/tmp/requirements.benchmark.txt \
+    --mount=type=bind,source=./container/deps/requirements.validation.txt,target=/tmp/requirements.validation.txt \
     export UV_GIT_LFS=1 UV_HTTP_TIMEOUT=300 UV_HTTP_RETRIES=5 && \
     uv pip install \
         --no-cache \
@@ -285,6 +287,7 @@ RUN --mount=type=bind,source=./container/deps/requirements.common.txt,target=/tm
         --extra-index-url https://download.pytorch.org/whl/cu130 \
         --requirement /tmp/requirements.common.txt \
         --requirement /tmp/requirements.benchmark.txt \
+        --requirement /tmp/requirements.validation.txt \
         cupy-cuda13x && \
     # nvidia-cutlass-dsl-libs-base==4.4.1 (transitive dep) ships a stub cute/experimental/__init__.py
     # that unconditionally raises NotImplementedError, crashing TRT-LLM on import. cutlass-dsl==4.3.4

--- a/container/templates/vllm_runtime.Dockerfile
+++ b/container/templates/vllm_runtime.Dockerfile
@@ -344,16 +344,20 @@ RUN if [ "${ENABLE_MODELEXPRESS_P2P}" = "true" ]; then \
 {% endif %}
 
 # Install runtime dependencies (common + vllm-specific + benchmarks).
-# Test and dev dependencies are NOT installed here — they go in the test and dev images.
+# Full test and dev dependencies are NOT installed here — they go in the test
+# and dev images. requirements.validation.txt is the minimal compute-session
+# validation substrate.
 RUN --mount=type=bind,source=./container/deps/requirements.common.txt,target=/tmp/requirements.common.txt \
     --mount=type=bind,source=./container/deps/requirements.vllm.txt,target=/tmp/requirements.vllm.txt \
     --mount=type=bind,source=./container/deps/requirements.benchmark.txt,target=/tmp/requirements.benchmark.txt \
+    --mount=type=bind,source=./container/deps/requirements.validation.txt,target=/tmp/requirements.validation.txt \
     --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sharing=locked \
     export UV_CACHE_DIR=/home/dynamo/.cache/uv UV_GIT_LFS=1 UV_HTTP_TIMEOUT=300 UV_HTTP_RETRIES=5 && \
     uv pip install \
         --requirement /tmp/requirements.common.txt \
         --requirement /tmp/requirements.vllm.txt \
-        --requirement /tmp/requirements.benchmark.txt
+        --requirement /tmp/requirements.benchmark.txt \
+        --requirement /tmp/requirements.validation.txt
 
 # Copy tests, deploy, lib, and the vllm/common/mocker component subtrees for CI.
 # Pattern: COPY --chmod=775 <path>; chmod g+w <path> done later as root because COPY --chmod only affects <path>/*, not <path>


### PR DESCRIPTION
## Summary

- add a minimal runtime validation requirements file with pytest
- install that minimal validation substrate in Dynamo, vLLM, TRT-LLM, and SGLang runtime images
- keep full dev/test dependencies confined to the dev and test images

## Why

Factory compute-session validation can run focused Python validation commands against runtime images. Those commands currently fail before exercising the change when the image lacks the pytest launcher.

## Validation

- git diff --check for the scoped container files
- commit hooks passed

No implementation tests added.