### PR TITLE
feat: Remove deprecated dynamoNamespace references from docs and examples

### DIFF
--- a/deploy/operator/docs/crd-ref-docs-config.yaml
+++ b/deploy/operator/docs/crd-ref-docs-config.yaml
@@ -24,6 +24,7 @@ processor:
     - "metadata.resourceVersion"
     - "metadata.selfLink"
     - "metadata.uid"
+    - "dynamoNamespace"
     - "status.conditions[*].lastTransitionTime"
     - "status.observedGeneration"
     - "TypeMeta$"

--- a/docs/benchmarks/kv-router-ab-testing.md
+++ b/docs/benchmarks/kv-router-ab-testing.md
@@ -117,7 +117,6 @@ metadata:
 spec:
   services:
     Frontend:
-      dynamoNamespace: vllm-agg-no-router
       componentType: frontend
       replicas: 1
       extraPodSpec:
@@ -130,7 +129,6 @@ spec:
                   fieldPath: metadata.uid
     VllmDecodeWorker:
       envFromSecret: hf-token-secret
-      dynamoNamespace: vllm-agg-no-router
       componentType: worker
       replicas: 8
       resources:
@@ -208,7 +206,6 @@ metadata:
 spec:
   services:
     Frontend:
-      dynamoNamespace: vllm-agg-router
       componentType: frontend
       replicas: 1
       extraPodSpec:
@@ -224,7 +221,6 @@ spec:
           value: kv  # KEY DIFFERENCE: Enable KV Smart Router
     VllmDecodeWorker:
       envFromSecret: hf-token-secret
-      dynamoNamespace: vllm-agg-router
       componentType: worker
       replicas: 8
       resources:

--- a/docs/components/router/router-examples.md
+++ b/docs/components/router/router-examples.md
@@ -120,7 +120,6 @@ metadata:
 spec:
   services:
     Frontend:
-      dynamoNamespace: my-namespace
       componentType: frontend
       replicas: 1
       envs:

--- a/docs/components/router/router-guide.md
+++ b/docs/components/router/router-guide.md
@@ -107,7 +107,6 @@ metadata:
 spec:
   services:
     Frontend:
-      dynamoNamespace: my-namespace
       componentType: frontend
       replicas: 1
       envs:

--- a/docs/kubernetes/api-reference.md
+++ b/docs/kubernetes/api-reference.md
@@ -382,7 +382,6 @@ _Appears in:_
 | `serviceName` _string_ | The name of the component |  |  |
 | `componentType` _string_ | ComponentType indicates the role of this component (for example, "main"). |  |  |
 | `subComponentType` _string_ | SubComponentType indicates the sub-role of this component (for example, "prefill"). |  |  |
-| `dynamoNamespace` _string_ | DynamoNamespace is deprecated and will be removed in a future version.<br />The DGD Kubernetes namespace and DynamoGraphDeployment name are used to construct the Dynamo namespace for each component |  | Optional: \{\} <br /> |
 | `globalDynamoNamespace` _boolean_ | GlobalDynamoNamespace indicates that the Component will be placed in the global Dynamo namespace |  |  |
 | `resources` _[Resources](#resources)_ | Resources requested and limits for this component, including CPU, memory,<br />GPUs/devices, and any runtime-specific resources. |  |  |
 | `autoscaling` _[Autoscaling](#autoscaling)_ | Deprecated: This field is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter<br />with HPA, KEDA, or Planner for autoscaling instead. See docs/kubernetes/autoscaling.md<br />for migration guidance. This field will be removed in a future API version. |  |  |
@@ -426,7 +425,6 @@ _Appears in:_
 | `serviceName` _string_ | The name of the component |  |  |
 | `componentType` _string_ | ComponentType indicates the role of this component (for example, "main"). |  |  |
 | `subComponentType` _string_ | SubComponentType indicates the sub-role of this component (for example, "prefill"). |  |  |
-| `dynamoNamespace` _string_ | DynamoNamespace is deprecated and will be removed in a future version.<br />The DGD Kubernetes namespace and DynamoGraphDeployment name are used to construct the Dynamo namespace for each component |  | Optional: \{\} <br /> |
 | `globalDynamoNamespace` _boolean_ | GlobalDynamoNamespace indicates that the Component will be placed in the global Dynamo namespace |  |  |
 | `resources` _[Resources](#resources)_ | Resources requested and limits for this component, including CPU, memory,<br />GPUs/devices, and any runtime-specific resources. |  |  |
 | `autoscaling` _[Autoscaling](#autoscaling)_ | Deprecated: This field is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter<br />with HPA, KEDA, or Planner for autoscaling instead. See docs/kubernetes/autoscaling.md<br />for migration guidance. This field will be removed in a future API version. |  |  |

--- a/docs/kubernetes/autoscaling.md
+++ b/docs/kubernetes/autoscaling.md
@@ -20,12 +20,10 @@ metadata:
 spec:
   services:
     Frontend:
-      dynamoNamespace: sglang-agg
       componentType: frontend
       replicas: 1
 
     decode:
-      dynamoNamespace: sglang-agg
       componentType: worker
       replicas: 1
       resources:
@@ -244,7 +242,7 @@ Dynamo metrics include these labels for filtering:
 
 | Label | Description | Example |
 |-------|-------------|---------|
-| `dynamo_namespace` | Unique DGD identifier (`{k8s-namespace}-{dynamoNamespace}`) | `default-sglang-agg` |
+| `dynamo_namespace` | Unique DGD identifier (`{k8s-namespace}-{dgd-name}`) | `default-sglang-agg` |
 | `model` | Model being served | `Qwen/Qwen3-0.6B` |
 
 <Note>
@@ -319,7 +317,7 @@ spec:
         name: dynamo_ttft_p95_seconds
         selector:
           matchLabels:
-            dynamo_namespace: "default-sglang-agg"  # ← {namespace}-{dynamoNamespace}
+            dynamo_namespace: "default-sglang-agg"  # ← {namespace}-{dgd-name}
       target:
         type: Value
         value: "500m"  # Scale up when TTFT p95 > 500ms
@@ -750,4 +748,3 @@ If you see unstable scaling:
 - [Planner Documentation](../components/planner/planner-guide.md)
 - [Dynamo Metrics Reference](../observability/metrics.md)
 - [Prometheus and Grafana Setup](../observability/prometheus-grafana.md)
-

--- a/docs/kubernetes/deployment/create-deployment.md
+++ b/docs/kubernetes/deployment/create-deployment.md
@@ -122,7 +122,6 @@ Here's a template structure based on the examples:
 
 ```yaml
     YourWorker:
-      dynamoNamespace: your-namespace
       componentType: worker
       replicas: N
       envFromSecret: your-secrets  # e.g., hf-token-secret
@@ -216,7 +215,6 @@ To disable this behavior for a component and manually control image pull secrets
 
 ```yaml
     YourWorker:
-      dynamoNamespace: your-namespace
       componentType: worker
       annotations:
         nvidia.com/disable-image-pull-secret-discovery: "true"
@@ -225,7 +223,6 @@ To disable this behavior for a component and manually control image pull secrets
 When disabled, you can manually specify secrets as you would for a normal pod spec via:
 ```yaml
     YourWorker:
-      dynamoNamespace: your-namespace
       componentType: worker
       annotations:
         nvidia.com/disable-image-pull-secret-discovery: "true"

--- a/docs/kubernetes/deployment/dynamomodel-guide.md
+++ b/docs/kubernetes/deployment/dynamomodel-guide.md
@@ -539,7 +539,6 @@ spec:
     Frontend:
       componentType: frontend
       replicas: 1
-      dynamoNamespace: my-app
       extraPodSpec:
         mainContainer:
           image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:latest
@@ -626,4 +625,3 @@ DynamoModel provides declarative model management for Dynamo deployments:
 - Try the [Quick Start](#quick-start) example
 - Explore [Common Use Cases](#common-use-cases)
 - Check the [API Reference](../api-reference.md#dynamomodel) for advanced configuration
-

--- a/docs/kubernetes/topology-aware-scheduling.md
+++ b/docs/kubernetes/topology-aware-scheduling.md
@@ -50,7 +50,6 @@ spec:
     packDomain: zone
   services:
     VllmWorker:
-      dynamoNamespace: my-llm
       componentType: worker
       replicas: 2
       envFromSecret: hf-token-secret
@@ -64,7 +63,6 @@ spec:
           args:
             - python3 -m dynamo.vllm --model Qwen/Qwen3-0.6B
     Frontend:
-      dynamoNamespace: my-llm
       componentType: frontend
       replicas: 1
       extraPodSpec:
@@ -89,7 +87,6 @@ spec:
     topologyProfile: my-cluster-topology
   services:
     VllmWorker:
-      dynamoNamespace: my-llm
       componentType: worker
       replicas: 2
       multinode:
@@ -107,7 +104,6 @@ spec:
           args:
             - python3 -m dynamo.vllm --model meta-llama/Llama-4-Maverick-17B-128E
     Frontend:
-      dynamoNamespace: my-llm
       componentType: frontend
       replicas: 1
       extraPodSpec:
@@ -133,7 +129,6 @@ spec:
     packDomain: zone
   services:
     VllmWorker:
-      dynamoNamespace: my-llm
       componentType: worker
       replicas: 2
       multinode:
@@ -151,7 +146,6 @@ spec:
           args:
             - python3 -m dynamo.vllm --model meta-llama/Llama-4-Maverick-17B-128E
     Frontend:
-      dynamoNamespace: my-llm
       componentType: frontend
       replicas: 1
       # inherits zone from spec.topologyConstraint

--- a/examples/global_planner/README.md
+++ b/examples/global_planner/README.md
@@ -152,7 +152,7 @@ GlobalPlanner operates in one of two modes depending on whether `--managed-names
 
 ## Namespace Convention
 
-The Dynamo operator prepends the Kubernetes namespace to the DGD's `dynamoNamespace`:
+The Dynamo operator builds each Dynamo namespace from the Kubernetes namespace and DGD name:
 - K8s namespace: `my-ns`, DGD name: `gp-ctrl`
 - Dynamo namespace: `my-ns-gp-ctrl`
 


### PR DESCRIPTION
Closes DYN-2801
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9101" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment documentation to clarify that `dynamoNamespace` is now automatically computed by the operator from the Kubernetes namespace and deployment name, eliminating the need for manual specification.
  * Removed deprecated `dynamoNamespace` field from YAML examples across guides, benchmarks, and API reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->