### PR TITLE
feat(vllm): async-load worker side for EC connector (scheduler-driven)

### DIFF
--- a/benchmarks/multimodal/sweep/experiments/embedding_cache/sweep_397b.yaml
+++ b/benchmarks/multimodal/sweep/experiments/embedding_cache/sweep_397b.yaml
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Qwen3.5-397B multimodal sweep: 8K ISL, 5x 2400x1080 images, 1K OSL,
+# concurrency=10. Three labels total; only `dynamo-fd` is active by
+# default. Uncomment `vllm-serve` and/or `dynamo-fd-ec` to compare.
+
+model: Qwen/Qwen3.5-397B-A17B-FP8
+concurrencies: [10]
+osl: 1024
+conversation_num: 10
+warmup_count: 5
+port: 8000
+timeout: 2400
+output_dir: /dynamo-tmp/logs/sweep_397b
+restart_server_every_benchmark: true
+skip_plots: true
+
+env:
+  DYN_NSYS_DELAY_S: "60"
+  DYN_NSYS_DURATION_S: "1800"
+  VLLM_MM_CACHE_PROBE: "1"
+  VLLM_NVTX_SCOPES_FOR_PROFILING: "1"
+  TRANSFORMERS_MM_PROFILING: "1"
+  DYN_NVTX: "1"
+  DYN_ENABLE_RUST_NVTX: "1"
+  DYN_HTTP_BODY_LIMIT_MB: "200"
+
+input_files:
+  - /dynamo-tmp/data/10u_10t_5w_8000word_base64.jsonl
+
+configs:
+  # - label: vllm-serve
+  #   workflow: benchmarks/multimodal/sweep/workflows/vllm_serve.sh
+  #   extra_args:
+  #     - --tensor-parallel-size
+  #     - "8"
+  #     - --enable-expert-parallel
+  #     - --enable-auto-tool-choice
+  #     - --tool-call-parser
+  #     - qwen3_coder
+  #     - --reasoning-parser
+  #     - qwen3
+  #     - --mm-encoder-tp-mode
+  #     - data
+  #     - --mm-processor-cache-gb
+  #     - "60"
+  #     - --enable-prefix-caching
+  #     - --max-model-len
+  #     - "32768"
+
+  - label: dynamo-fd
+    workflow: benchmarks/multimodal/sweep/workflows/dynamo_serve.sh
+    extra_args:
+      # Frontend-decoding only, NO embedding cache. 60 GB HF processor cache.
+      - --enable-multimodal
+      - --frontend-decoding
+      - --dyn-tool-call-parser
+      - qwen3_coder
+      - --dyn-reasoning-parser
+      - qwen3
+      - --tensor-parallel-size
+      - "8"
+      - --enable-expert-parallel
+      - --mm-encoder-tp-mode
+      - data
+      - --mm-processor-cache-gb
+      - "60"
+      - --enable-prefix-caching
+      - --max-model-len
+      - "32768"
+
+  # - label: dynamo-fd-ec
+  #   workflow: benchmarks/multimodal/sweep/workflows/dynamo_serve.sh
+  #   extra_args:
+  #     # Frontend-decoding + embedding cache: 30 GB HF proc-cache + 4 GB EC per worker.
+  #     - --enable-multimodal
+  #     - --frontend-decoding
+  #     - --multimodal-embedding-cache-capacity-gb
+  #     - "4"                              # per worker; TP=8 -> ~32 GB CPU total
+  #     - --dyn-tool-call-parser
+  #     - qwen3_coder
+  #     - --dyn-reasoning-parser
+  #     - qwen3
+  #     - --tensor-parallel-size
+  #     - "8"
+  #     - --enable-expert-parallel
+  #     - --mm-encoder-tp-mode
+  #     - data
+  #     - --mm-processor-cache-gb
+  #     - "30"
+  #     - --enable-prefix-caching
+  #     - --max-model-len
+  #     - "32768"

--- a/benchmarks/multimodal/sweep/experiments/embedding_cache/sweep_397b.yaml
+++ b/benchmarks/multimodal/sweep/experiments/embedding_cache/sweep_397b.yaml
@@ -2,52 +2,51 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Qwen3.5-397B multimodal sweep: 8K ISL, 5x 2400x1080 images, 1K OSL,
-# concurrency=10. Three labels total; only `dynamo-fd` is active by
-# default. Uncomment `vllm-serve` and/or `dynamo-fd-ec` to compare.
+# concurrency=30, 3-way (vllm-serve vs dynamo-fd vs dynamo-fd-ec).
+# Dataset: 30u_3t_5w_8000word_base64.jsonl on /dynamo-tmp/data/.
 
 model: Qwen/Qwen3.5-397B-A17B-FP8
-concurrencies: [10]
+concurrencies: [30]
 osl: 1024
-conversation_num: 10
-warmup_count: 5
+conversation_num: 30
+warmup_count: 2
 port: 8000
 timeout: 2400
-output_dir: /dynamo-tmp/logs/sweep_397b
+output_dir: /dynamo-tmp/logs/04-25/sweep-397b-v3
 restart_server_every_benchmark: true
 skip_plots: true
 
 env:
-  DYN_NSYS_DELAY_S: "60"
-  DYN_NSYS_DURATION_S: "1800"
   VLLM_MM_CACHE_PROBE: "1"
   VLLM_NVTX_SCOPES_FOR_PROFILING: "1"
   TRANSFORMERS_MM_PROFILING: "1"
   DYN_NVTX: "1"
   DYN_ENABLE_RUST_NVTX: "1"
   DYN_HTTP_BODY_LIMIT_MB: "200"
+  DYN_NSYS_DIR: "/dynamo-tmp/logs/04-25/sweep-397b-v3/nsys"
 
 input_files:
-  - /dynamo-tmp/data/10u_10t_5w_8000word_base64.jsonl
+  - /dynamo-tmp/data/30u_3t_5w_8000word_base64.jsonl
 
 configs:
-  # - label: vllm-serve
-  #   workflow: benchmarks/multimodal/sweep/workflows/vllm_serve.sh
-  #   extra_args:
-  #     - --tensor-parallel-size
-  #     - "8"
-  #     - --enable-expert-parallel
-  #     - --enable-auto-tool-choice
-  #     - --tool-call-parser
-  #     - qwen3_coder
-  #     - --reasoning-parser
-  #     - qwen3
-  #     - --mm-encoder-tp-mode
-  #     - data
-  #     - --mm-processor-cache-gb
-  #     - "60"
-  #     - --enable-prefix-caching
-  #     - --max-model-len
-  #     - "32768"
+  - label: vllm-serve
+    workflow: benchmarks/multimodal/sweep/workflows/vllm_serve.sh
+    extra_args:
+      - --tensor-parallel-size
+      - "8"
+      - --enable-expert-parallel
+      - --enable-auto-tool-choice
+      - --tool-call-parser
+      - qwen3_coder
+      - --reasoning-parser
+      - qwen3
+      - --mm-encoder-tp-mode
+      - data
+      - --mm-processor-cache-gb
+      - "60"
+      - --enable-prefix-caching
+      - --max-model-len
+      - "32768"
 
   - label: dynamo-fd
     workflow: benchmarks/multimodal/sweep/workflows/dynamo_serve.sh
@@ -70,25 +69,25 @@ configs:
       - --max-model-len
       - "32768"
 
-  # - label: dynamo-fd-ec
-  #   workflow: benchmarks/multimodal/sweep/workflows/dynamo_serve.sh
-  #   extra_args:
-  #     # Frontend-decoding + embedding cache: 30 GB HF proc-cache + 4 GB EC per worker.
-  #     - --enable-multimodal
-  #     - --frontend-decoding
-  #     - --multimodal-embedding-cache-capacity-gb
-  #     - "4"                              # per worker; TP=8 -> ~32 GB CPU total
-  #     - --dyn-tool-call-parser
-  #     - qwen3_coder
-  #     - --dyn-reasoning-parser
-  #     - qwen3
-  #     - --tensor-parallel-size
-  #     - "8"
-  #     - --enable-expert-parallel
-  #     - --mm-encoder-tp-mode
-  #     - data
-  #     - --mm-processor-cache-gb
-  #     - "30"
-  #     - --enable-prefix-caching
-  #     - --max-model-len
-  #     - "32768"
+  - label: dynamo-fd-ec
+    workflow: benchmarks/multimodal/sweep/workflows/dynamo_serve.sh
+    extra_args:
+      # Frontend-decoding + embedding cache: 30 GB HF proc-cache + 4 GB EC per worker.
+      - --enable-multimodal
+      - --frontend-decoding
+      - --multimodal-embedding-cache-capacity-gb
+      - "4"                              # per worker; TP=8 -> ~32 GB CPU total
+      - --dyn-tool-call-parser
+      - qwen3_coder
+      - --dyn-reasoning-parser
+      - qwen3
+      - --tensor-parallel-size
+      - "8"
+      - --enable-expert-parallel
+      - --mm-encoder-tp-mode
+      - data
+      - --mm-processor-cache-gb
+      - "30"
+      - --enable-prefix-caching
+      - --max-model-len
+      - "32768"

--- a/benchmarks/multimodal/sweep/experiments/embedding_cache/sweep_397b.yaml
+++ b/benchmarks/multimodal/sweep/experiments/embedding_cache/sweep_397b.yaml
@@ -12,7 +12,7 @@ conversation_num: 30
 warmup_count: 2
 port: 8000
 timeout: 2400
-output_dir: /dynamo-tmp/logs/04-25/sweep-397b-v3
+output_dir: /dynamo-tmp/logs/04-27/sweep-397b-862258-iter1
 restart_server_every_benchmark: true
 skip_plots: true
 
@@ -23,7 +23,12 @@ env:
   DYN_NVTX: "1"
   DYN_ENABLE_RUST_NVTX: "1"
   DYN_HTTP_BODY_LIMIT_MB: "200"
-  DYN_NSYS_DIR: "/dynamo-tmp/logs/04-25/sweep-397b-v3/nsys"
+  DYN_NSYS_DIR: "/dynamo-tmp/logs/04-27/sweep-397b-862258-iter1/nsys"
+  # Relax NCCL watchdog so nsys-induced stalls don't SIGABRT TP workers.
+  TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC: "1800"
+  NCCL_TIMEOUT: "1800"
+  TORCH_NCCL_DUMP_ON_TIMEOUT: "1"
+  NCCL_DEBUG: "WARN"
 
 input_files:
   - /dynamo-tmp/data/30u_3t_5w_8000word_base64.jsonl
@@ -48,6 +53,7 @@ configs:
       - --max-model-len
       - "32768"
 
+  # iter5: all 3 configs enabled.
   - label: dynamo-fd
     workflow: benchmarks/multimodal/sweep/workflows/dynamo_serve.sh
     extra_args:

--- a/benchmarks/multimodal/sweep/experiments/embedding_cache/sweep_smoke_2b.yaml
+++ b/benchmarks/multimodal/sweep/experiments/embedding_cache/sweep_smoke_2b.yaml
@@ -13,7 +13,7 @@ conversation_num: 30
 warmup_count: 5
 port: 8000
 timeout: 2400
-output_dir: /dynamo-tmp/logs/04-25/2b-smoke-856213-run3
+output_dir: /dynamo-tmp/logs/04-26/2b-iter6
 restart_server_every_benchmark: true
 skip_plots: true
 
@@ -26,7 +26,12 @@ env:
   DYN_HTTP_BODY_LIMIT_MB: "200"
   # Co-locate .nsys-rep files with aiperf results instead of the default
   # date-based /dynamo-tmp/MM-DD/nsys/ dir.
-  DYN_NSYS_DIR: /dynamo-tmp/logs/04-25/2b-smoke-856213-run3/nsys
+  DYN_NSYS_DIR: /dynamo-tmp/logs/04-26/2b-iter6/nsys
+  # Relax NCCL watchdog so nsys-induced stalls don't SIGABRT TP workers.
+  TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC: "1800"
+  NCCL_TIMEOUT: "1800"
+  TORCH_NCCL_DUMP_ON_TIMEOUT: "1"
+  NCCL_DEBUG: "WARN"
 
 input_files:
   - /dynamo-tmp/data/30u_3t_5w_8000word_base64.jsonl

--- a/benchmarks/multimodal/sweep/experiments/embedding_cache/sweep_smoke_2b.yaml
+++ b/benchmarks/multimodal/sweep/experiments/embedding_cache/sweep_smoke_2b.yaml
@@ -2,17 +2,18 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Quick functionality smoke: Qwen3-VL-2B on one GPU, single concurrency, single
-# input JSONL. Verifies that aiperf, nsys, and vllm_serve.sh are wired up end
-# to end. Should finish in ~6-8 min (load + 120s nsys window + teardown).
+# input JSONL. Verifies that aiperf, nsys, and the dynamo_serve frontend/backend
+# wrapping are wired up end to end. Relies on dynamo_serve.sh's default of full
+# lifetime nsys capture — no explicit DYN_NSYS_DELAY_S / DYN_NSYS_DURATION_S.
 
 model: Qwen/Qwen3-VL-2B-Instruct
-concurrencies: [4]
-osl: 128
-conversation_num: 5
-warmup_count: 2
+concurrencies: [30]
+osl: 1000
+conversation_num: 30
+warmup_count: 5
 port: 8000
-timeout: 600
-output_dir: /dynamo-tmp/logs/04-21/smoke_2b
+timeout: 2400
+output_dir: /dynamo-tmp/logs/04-25/2b-smoke-856213-run3
 restart_server_every_benchmark: true
 skip_plots: true
 
@@ -21,19 +22,51 @@ env:
   VLLM_NVTX_SCOPES_FOR_PROFILING: "1"
   TRANSFORMERS_MM_PROFILING: "1"
   DYN_NVTX: "1"
-  DYN_NSYS_DELAY_S: "30"
-  DYN_NSYS_DURATION_S: "120"
-  DYN_NSYS_OUT: "/dynamo-tmp/logs/04-21/smoke_2b/vllm_smoke.nsys-rep"
+  DYN_ENABLE_RUST_NVTX: "1"
+  DYN_HTTP_BODY_LIMIT_MB: "200"
+  # Co-locate .nsys-rep files with aiperf results instead of the default
+  # date-based /dynamo-tmp/MM-DD/nsys/ dir.
+  DYN_NSYS_DIR: /dynamo-tmp/logs/04-25/2b-smoke-856213-run3/nsys
 
 input_files:
-  - benchmarks/multimodal/jsonl/10req_4img_40pool_400word_base64.jsonl
+  - /dynamo-tmp/data/30u_3t_5w_8000word_base64.jsonl
 
 configs:
-  - label: vllm-serve-smoke
+  - label: vllm-serve
     workflow: benchmarks/multimodal/sweep/workflows/vllm_serve.sh
     extra_args:
       - --tensor-parallel-size
       - "1"
+      - --mm-processor-cache-gb
+      - "30"
       - --enable-prefix-caching
       - --max-model-len
-      - "16384"
+      - "32768"
+
+  - label: dynamo-fd
+    workflow: benchmarks/multimodal/sweep/workflows/dynamo_serve.sh
+    extra_args:
+      - --enable-multimodal
+      - --frontend-decoding
+      - --tensor-parallel-size
+      - "1"
+      - --mm-processor-cache-gb
+      - "30"
+      - --enable-prefix-caching
+      - --max-model-len
+      - "32768"
+
+  - label: dynamo-fd-ec
+    workflow: benchmarks/multimodal/sweep/workflows/dynamo_serve.sh
+    extra_args:
+      - --enable-multimodal
+      - --frontend-decoding
+      - --multimodal-embedding-cache-capacity-gb
+      - "4"
+      - --tensor-parallel-size
+      - "1"
+      - --mm-processor-cache-gb
+      - "30"
+      - --enable-prefix-caching
+      - --max-model-len
+      - "32768"

--- a/benchmarks/multimodal/sweep/experiments/embedding_cache/sweep_smoke_2b.yaml
+++ b/benchmarks/multimodal/sweep/experiments/embedding_cache/sweep_smoke_2b.yaml
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Quick functionality smoke: Qwen3-VL-2B on one GPU, single concurrency, single
+# input JSONL. Verifies that aiperf, nsys, and vllm_serve.sh are wired up end
+# to end. Should finish in ~6-8 min (load + 120s nsys window + teardown).
+
+model: Qwen/Qwen3-VL-2B-Instruct
+concurrencies: [4]
+osl: 128
+conversation_num: 5
+warmup_count: 2
+port: 8000
+timeout: 600
+output_dir: /dynamo-tmp/logs/04-21/smoke_2b
+restart_server_every_benchmark: true
+skip_plots: true
+
+env:
+  VLLM_MM_CACHE_PROBE: "1"
+  VLLM_NVTX_SCOPES_FOR_PROFILING: "1"
+  TRANSFORMERS_MM_PROFILING: "1"
+  DYN_NVTX: "1"
+  DYN_NSYS_DELAY_S: "30"
+  DYN_NSYS_DURATION_S: "120"
+  DYN_NSYS_OUT: "/dynamo-tmp/logs/04-21/smoke_2b/vllm_smoke.nsys-rep"
+
+input_files:
+  - benchmarks/multimodal/jsonl/10req_4img_40pool_400word_base64.jsonl
+
+configs:
+  - label: vllm-serve-smoke
+    workflow: benchmarks/multimodal/sweep/workflows/vllm_serve.sh
+    extra_args:
+      - --tensor-parallel-size
+      - "1"
+      - --enable-prefix-caching
+      - --max-model-len
+      - "16384"

--- a/benchmarks/multimodal/sweep/orchestrator.py
+++ b/benchmarks/multimodal/sweep/orchestrator.py
@@ -3,13 +3,27 @@
 
 from __future__ import annotations
 
+import uuid
 from pathlib import Path
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from .config import BenchmarkConfig, SweepConfig, input_file_tag, resolve_repo_root
 from .dataset_shape import count_session_ids
 from .runner import run_aiperf_single
 from .server import ServerManager
+
+
+def _restart_env(base: Dict[str, str], label: str) -> Dict[str, str]:
+    """Per-restart env with a unique DYN_NAMESPACE.
+
+    Belt-and-suspenders for the cross-iteration discovery leak: even if
+    ServerManager.stop() somehow misses a stale v1/instances or v1/mdc
+    entry, the next server boots into its own etcd subtree and cannot
+    observe it. Respects an explicit DYN_NAMESPACE in the user's yaml env.
+    """
+    env = dict(base)
+    env.setdefault("DYN_NAMESPACE", f"sweep-{label}-{uuid.uuid4().hex[:8]}")
+    return env
 
 
 def _resolve_workflow(workflow: str, repo_root: Path) -> str:
@@ -150,7 +164,7 @@ def _run_config(
             workflow_script=workflow_abs,
             model=config.model,
             extra_args=bench_cfg.extra_args,
-            env_overrides=env_overrides,
+            env_overrides=_restart_env(env_overrides, bench_cfg.label),
         )
 
     try:
@@ -165,7 +179,7 @@ def _run_config(
                     workflow_script=workflow_abs,
                     model=config.model,
                     extra_args=bench_cfg.extra_args,
-                    env_overrides=env_overrides,
+                    env_overrides=_restart_env(env_overrides, bench_cfg.label),
                 )
 
             try:

--- a/benchmarks/multimodal/sweep/runner.py
+++ b/benchmarks/multimodal/sweep/runner.py
@@ -86,6 +86,11 @@ def run_aiperf_single(
     print(f"  aiperf {sweep_mode}={sweep_value} -> {artifact_dir}", flush=True)
     proc = subprocess.run(cmd, capture_output=True, text=True)
 
+    # Multi-GB aiperf debug artifact (every prompt + every base64 image
+    # sent); regenerable from --input-file. Drop it so multi-config
+    # sweeps don't silently bleed scratch.
+    (artifact_dir / "inputs.json").unlink(missing_ok=True)
+
     if proc.returncode != 0:
         print(f"  aiperf FAILED (exit {proc.returncode})", flush=True)
         for stream_name, stream in [("stderr", proc.stderr), ("stdout", proc.stdout)]:

--- a/benchmarks/multimodal/sweep/server.py
+++ b/benchmarks/multimodal/sweep/server.py
@@ -8,7 +8,24 @@ import signal
 import subprocess
 import time
 from pathlib import Path
-from typing import List, Optional
+from typing import Dict, List, Optional
+
+
+# Shutdown protocol timings.
+#
+# dynamo_serve.sh's cleanup() loops up to 300 s waiting for both nsys
+# instances to finalize; vllm_serve.sh has the same 300 s budget for its
+# single nsys. Add a 30 s margin for python's
+# graceful_shutdown_with_discovery (5 s grace + drain + runtime.shutdown),
+# which runs in parallel with nsys finalize.
+_GRACEFUL_STOP_TIMEOUT_SECS = 330
+
+# After the wrapper exits, let etcd revoke the primary lease (TTL = 10 s in
+# lib/runtime/src/transports/etcd.rs) before the next config starts. Without
+# this drain, the next frontend can observe stale v1/instances and v1/mdc
+# entries from the prior backend → readiness false-positive and routing to
+# dead TCP ports.
+_LEASE_DRAIN_SECS = 12
 
 
 class ServerManager:
@@ -32,7 +49,7 @@ class ServerManager:
         workflow_script: str,
         model: str,
         extra_args: Optional[List[str]] = None,
-        env_overrides: Optional[dict] = None,
+        env_overrides: Optional[Dict[str, str]] = None,
     ) -> None:
         """Launch the workflow script and block until the model is served."""
         if self.is_running:
@@ -96,30 +113,136 @@ class ServerManager:
         raise TimeoutError(f"Server did not become ready within {self.timeout}s")
 
     def stop(self) -> None:
-        """Stop the server by killing its process group."""
+        """Stop the server, finalize nsys, and let the etcd lease drain.
+
+        Protocol (matches the trap design in
+        benchmarks/multimodal/sweep/workflows/{vllm,dynamo}_serve.sh):
+
+        1. SIGINT directly to the wrapper script (NOT killpg). The wrapper's
+           ``trap cleanup INT TERM`` then forwards SIGINT to each nsys —
+           nsys's documented graceful-finalize signal. Broadcasting SIGTERM
+           via killpg races the trap and may hit nsys with an undocumented
+           direct SIGTERM, skipping finalize and leaving an unrecoverable
+           .qdstrm.
+        2. Wait up to ``_GRACEFUL_STOP_TIMEOUT_SECS`` for the wrapper to exit
+           naturally. That covers python's graceful_shutdown_with_discovery
+           + both nsys finalizes within the wrapper's own 300 s budget.
+        3. On timeout, tree-kill: walk /proc to enumerate every descendant
+           PID — including subprocesses that called setsid() and escaped the
+           wrapper's pgid (vLLM's EngineCore). killpg alone leaves those
+           orphaned, holding /dev/shm regions, GPU memory, and the etcd
+           lease keepalive task. That orphan state is what poisons the next
+           config's startup.
+        4. Sleep ``_LEASE_DRAIN_SECS`` so etcd revokes the primary 10 s lease
+           before the next config's frontend enumerates discovery.
+        """
         if self._process is None:
             return
 
         pid = self._process.pid
         print(f"Stopping server (PID {pid})...", flush=True)
 
+        # (1) Targeted SIGINT to the wrapper.
         try:
-            os.killpg(pid, signal.SIGTERM)
-        except (ProcessLookupError, PermissionError):
-            try:
-                self._process.terminate()
-            except (ProcessLookupError, PermissionError):
-                pass
+            self._process.send_signal(signal.SIGINT)
+        except ProcessLookupError:
+            pass
 
+        # (2) Wait for the wrapper-driven cleanup to finish.
         try:
-            self._process.wait(timeout=15)
+            self._process.wait(timeout=_GRACEFUL_STOP_TIMEOUT_SECS)
         except subprocess.TimeoutExpired:
+            # (3) Escalate.
+            print(
+                f"  graceful stop timed out after {_GRACEFUL_STOP_TIMEOUT_SECS}s; "
+                f"tree-killing descendants",
+                flush=True,
+            )
+            _tree_kill(pid)
             try:
-                os.killpg(pid, signal.SIGKILL)
-            except (ProcessLookupError, PermissionError):
+                self._process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
                 pass
-            self._process.wait(timeout=5)
 
         print(f"Server stopped (PID {pid}).", flush=True)
         self._process = None
-        time.sleep(5)
+
+        # (4) Lease drain.
+        time.sleep(_LEASE_DRAIN_SECS)
+
+
+def _read_ppid(pid: int) -> Optional[int]:
+    """Return the parent PID of ``pid`` from /proc, or None if unreadable.
+
+    /proc/<pid>/stat fields are space-separated, but field 2 (``comm``) is
+    parenthesised and can contain spaces or parens. Parse by locating the
+    final ')' and reading from there.
+    """
+    try:
+        with open(f"/proc/{pid}/stat") as f:
+            stat = f.read()
+    except OSError:
+        return None
+    close_idx = stat.rfind(")")
+    if close_idx < 0:
+        return None
+    after = stat[close_idx + 1 :].split()
+    if len(after) < 2:
+        return None
+    try:
+        return int(after[1])
+    except ValueError:
+        return None
+
+
+def _descendants(root_pid: int) -> List[int]:
+    """Walk /proc to collect every descendant PID of ``root_pid``.
+
+    Captures setsid'd subprocesses that have escaped the original pgid —
+    those are unreachable via os.killpg() but still show up in /proc with
+    their parent (or PID 1, after reparenting). Linux-only; on non-Linux
+    callers should fall back to killpg/kill at the root.
+    """
+    if not os.path.isdir("/proc"):
+        return []
+    try:
+        entries = os.listdir("/proc")
+    except OSError:
+        return []
+
+    children: Dict[int, List[int]] = {}
+    for entry in entries:
+        if not entry.isdigit():
+            continue
+        pid_int = int(entry)
+        ppid = _read_ppid(pid_int)
+        if ppid is None:
+            continue
+        children.setdefault(ppid, []).append(pid_int)
+
+    out: List[int] = []
+    stack = [root_pid]
+    while stack:
+        p = stack.pop()
+        for c in children.get(p, []):
+            out.append(c)
+            stack.append(c)
+    return out
+
+
+def _tree_kill(root_pid: int) -> None:
+    """SIGKILL ``root_pid`` and every descendant, regardless of pgid."""
+    for child_pid in _descendants(root_pid):
+        try:
+            os.kill(child_pid, signal.SIGKILL)
+        except (ProcessLookupError, PermissionError):
+            pass
+    # Belt: also reap the pgid in case the /proc walk missed something.
+    try:
+        os.killpg(root_pid, signal.SIGKILL)
+    except (ProcessLookupError, PermissionError):
+        pass
+    try:
+        os.kill(root_pid, signal.SIGKILL)
+    except (ProcessLookupError, PermissionError):
+        pass

--- a/benchmarks/multimodal/sweep/server.py
+++ b/benchmarks/multimodal/sweep/server.py
@@ -75,10 +75,11 @@ class ServerManager:
         )
 
         while time.monotonic() < deadline:
-            if not self.is_running:
+            rc = self._process.poll() if self._process is not None else None
+            if rc is not None:
                 raise RuntimeError(
-                    "Server process exited unexpectedly during startup "
-                    f"(exit code {self._process.returncode})."
+                    f"Workflow script exited with code {rc} before server ready; "
+                    "see stderr above."
                 )
             try:
                 req = urllib.request.Request(url)

--- a/benchmarks/multimodal/sweep/workflows/dynamo_serve.sh
+++ b/benchmarks/multimodal/sweep/workflows/dynamo_serve.sh
@@ -42,9 +42,19 @@ export VLLM_MM_CACHE_PROBE=1
 # Both finalize in parallel → total wall time = max(fe, be), fits in the
 # orchestrator's 180 s SIGKILL budget. Mirrors vllm_serve.sh's proven pattern.
 NSYS_BIN="${DYN_NSYS_BIN:-/opt/nvidia/nsight-systems-cli/2026.2.1/bin/nsys}"
-NSYS_DIR="${DYN_NSYS_DIR:-/dynamo-tmp/logs/sweep_nsys_dynamo}"
-NSYS_DELAY_S="${DYN_NSYS_DELAY_S:-60}"      # skip only nsys-agent startup noise
-NSYS_DURATION_S="${DYN_NSYS_DURATION_S:-1500}"  # covers 2B smoke + 397B runs
+# Default groups reps by day under /dynamo-tmp/MM-DD/nsys/ to match the
+# sweep yaml's `output_dir: /dynamo-tmp/MM-DD/<slug>` pattern. Override with
+# DYN_NSYS_DIR (e.g. yaml env) if you want them alongside aiperf outputs.
+NSYS_DIR="${DYN_NSYS_DIR:-/dynamo-tmp/$(date +%m-%d)/nsys}"
+# Default: nsys captures the full process lifetime. delay=0 starts tracing
+# immediately; duration=86400 (24 h) means --duration never fires, so
+# nsys only stops when the orchestrator sends SIGINT (see --kill=sigterm
+# below) and finalizes cleanly. Keeps model load in the trace and avoids
+# the windowed-capture footgun where --duration expires mid-load and kills
+# the engine core. Override via DYN_NSYS_DELAY_S / DYN_NSYS_DURATION_S only
+# when you specifically need a shorter window.
+NSYS_DELAY_S="${DYN_NSYS_DELAY_S:-0}"
+NSYS_DURATION_S="${DYN_NSYS_DURATION_S:-86400}"
 
 # Redirect nsys's intermediate staging (.qdstrm) from /tmp/nsys-<uid>/ to
 # scratch. Container /tmp is a Pyxis overlay and evaporates when the SLURM
@@ -95,9 +105,8 @@ if [[ "$DISABLE_NSYS" == "1" ]]; then
     FE_PREFIX=()
     BE_PREFIX=()
 else
-    NSYS_COMMON=(
+    NSYS_BASE=(
         "$NSYS_BIN" profile
-        --trace=nvtx,cuda
         --sample=none
         --cpuctxsw=none
         --delay="$NSYS_DELAY_S"
@@ -108,10 +117,21 @@ else
         --kill=sigterm
         --force-overwrite=true
     )
-    echo "[nsys] frontend -> $FRONTEND_OUT" >&2
-    echo "[nsys] backend  -> $BACKEND_OUT" >&2
-    FE_PREFIX=("${NSYS_COMMON[@]}" -o "$FRONTEND_OUT")
-    BE_PREFIX=("${NSYS_COMMON[@]}" -o "$BACKEND_OUT")
+    # Frontend is pure Rust-over-TCP with no CUDA activity. nsys drops NVTX
+    # events from processes that issue zero CUDA API calls — adding `cuda`
+    # to the trace list keeps the NVTX channel alive even when no CUDA
+    # events are recorded. See research/profiling.md.
+    NSYS_FE_TRACE=(--trace=nvtx,cuda)
+    # Backend (vLLM workers) issues CUDA every step → NVTX channel stays
+    # alive without `cuda` in the trace list. Dropping `cuda` collapses the
+    # qdstrm size by orders of magnitude, which keeps nsys finalize inside
+    # the 150 s cleanup() budget on 397B / 8 TP runs (otherwise the .qdstrm
+    # gets killed mid-merge and is unrecoverable). See research/profiling.md.
+    NSYS_BE_TRACE=(--trace=nvtx)
+    echo "[nsys] frontend -> $FRONTEND_OUT (trace=nvtx,cuda)" >&2
+    echo "[nsys] backend  -> $BACKEND_OUT (trace=nvtx)" >&2
+    FE_PREFIX=("${NSYS_BASE[@]}" "${NSYS_FE_TRACE[@]}" -o "$FRONTEND_OUT")
+    BE_PREFIX=("${NSYS_BASE[@]}" "${NSYS_BE_TRACE[@]}" -o "$BACKEND_OUT")
 fi
 
 # Infra (etcd + nats) is expected to be already running on the allocation

--- a/benchmarks/multimodal/sweep/workflows/dynamo_serve.sh
+++ b/benchmarks/multimodal/sweep/workflows/dynamo_serve.sh
@@ -125,11 +125,11 @@ else
     # Backend (vLLM workers) issues CUDA every step → NVTX channel stays
     # alive without `cuda` in the trace list. Dropping `cuda` collapses the
     # qdstrm size by orders of magnitude, which keeps nsys finalize inside
-    # the 150 s cleanup() budget on 397B / 8 TP runs (otherwise the .qdstrm
+    # the 300 s cleanup() budget on 397B / 8 TP runs (otherwise the .qdstrm
     # gets killed mid-merge and is unrecoverable). See research/profiling.md.
-    NSYS_BE_TRACE=(--trace=nvtx)
+    NSYS_BE_TRACE=(--trace=nvtx,cuda)
     echo "[nsys] frontend -> $FRONTEND_OUT (trace=nvtx,cuda)" >&2
-    echo "[nsys] backend  -> $BACKEND_OUT (trace=nvtx)" >&2
+    echo "[nsys] backend  -> $BACKEND_OUT (trace=nvtx,cuda)" >&2
     FE_PREFIX=("${NSYS_BASE[@]}" "${NSYS_FE_TRACE[@]}" -o "$FRONTEND_OUT")
     BE_PREFIX=("${NSYS_BASE[@]}" "${NSYS_BE_TRACE[@]}" -o "$BACKEND_OUT")
 fi
@@ -158,9 +158,11 @@ cleanup() {
     for pid in "$FE_NSYS_PID" "$BE_NSYS_PID"; do
         [[ -n "$pid" && "$pid" -gt 0 ]] && kill -INT "$pid" 2>/dev/null || true
     done
-    # Shared 150 s deadline — both nsys instances finalize in parallel, so
-    # wall time = max(fe, be), under the orchestrator's 180 s SIGKILL budget.
-    for _ in $(seq 1 150); do
+    # Shared 300 s deadline — both nsys instances finalize in parallel, so
+    # wall time = max(fe, be), under the orchestrator's 330 s SIGKILL budget.
+    # Bumped from 150 s after iter4 dynamo-fd-ec orphaned a 990 MB qdstrm
+    # mid-finalize when backend trace was flipped to nvtx,cuda.
+    for _ in $(seq 1 300); do
         any_alive=0
         for pid in "$FE_NSYS_PID" "$BE_NSYS_PID"; do
             [[ -n "$pid" && "$pid" -gt 0 ]] && kill -0 "$pid" 2>/dev/null && any_alive=1

--- a/benchmarks/multimodal/sweep/workflows/dynamo_serve.sh
+++ b/benchmarks/multimodal/sweep/workflows/dynamo_serve.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Dynamo serve workflow: frontend + backend, each wrapped in its own
+# nsys instance. Prerequisites: etcd + nats-server started inline below
+# if not already running.
+#
+# Usage (by orchestrator): bash dynamo_serve.sh --model <model> [extra vllm args...]
+
+MODEL=""
+EXTRA_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --model) MODEL="$2"; shift 2 ;;
+        *) EXTRA_ARGS+=("$1"); shift ;;
+    esac
+done
+
+if [[ -z "$MODEL" ]]; then
+    echo "ERROR: --model is required" >&2
+    exit 1
+fi
+
+# NVTX gates:
+# - DYN_NVTX=1 enables Python `mm:*` markers in the worker.
+# - DYN_ENABLE_RUST_NVTX=1 enables the Rust nvtx markers (preprocess.*,
+#   codec.*, detokenize). Requires libnvToolsExt.so.1 at runtime —
+#   supplied by `apt install libnvtoolsext1` (not shipped by the
+#   container's cuda-nvtx-12-9 package, which is NVTX3 headers only).
+# - VLLM_MM_CACHE_PROBE=1 activates v3 [mmproc]/[mmcache] probes in
+#   the vllm-overlay site-packages.
+export DYN_NVTX=1
+export DYN_ENABLE_RUST_NVTX=1
+export VLLM_NVTX_SCOPES_FOR_PROFILING=1
+export VLLM_MM_CACHE_PROBE=1
+
+# nsys wrapping: long duration + --kill=sigterm. On orchestrator shutdown
+# (SIGINT from server.py:stop()), cleanup() forwards SIGINT to BOTH nsys
+# instances; nsys stops tracing, kills its subtree, finalizes the .nsys-rep.
+# Both finalize in parallel → total wall time = max(fe, be), fits in the
+# orchestrator's 180 s SIGKILL budget. Mirrors vllm_serve.sh's proven pattern.
+NSYS_BIN="${DYN_NSYS_BIN:-/opt/nvidia/nsight-systems-cli/2026.2.1/bin/nsys}"
+NSYS_DIR="${DYN_NSYS_DIR:-/dynamo-tmp/logs/sweep_nsys_dynamo}"
+NSYS_DELAY_S="${DYN_NSYS_DELAY_S:-60}"      # skip only nsys-agent startup noise
+NSYS_DURATION_S="${DYN_NSYS_DURATION_S:-1500}"  # covers 2B smoke + 397B runs
+
+# Redirect nsys's intermediate staging (.qdstrm) from /tmp/nsys-<uid>/ to
+# scratch. Container /tmp is a Pyxis overlay and evaporates when the SLURM
+# job ends — so an orphaned .qdstrm (from a finalize that got SIGKILL'd)
+# is unrecoverable if it stays there. With TMPDIR on /dynamo-tmp the .qdstrm
+# survives container teardown and can be recovered later via a newer nsys
+# that ships `qdstrm-importer`.
+export TMPDIR="${DYN_NSYS_TMPDIR:-/dynamo-tmp/nsys-staging}"
+mkdir -p "$TMPDIR"
+
+mkdir -p "$NSYS_DIR"
+TS=$(date +%Y%m%d_%H%M%S)
+FRONTEND_OUT="$NSYS_DIR/frontend_$TS.nsys-rep"
+BACKEND_OUT="$NSYS_DIR/backend_$TS.nsys-rep"
+
+# DYN_DISABLE_NSYS=1 — run frontend + backend without nsys wrapping (perf sweeps).
+# Skip the install check entirely; FE_PREFIX / BE_PREFIX are left empty below so
+# the python -m invocations run directly.
+DISABLE_NSYS="${DYN_DISABLE_NSYS:-0}"
+if [[ "$DISABLE_NSYS" == "1" ]]; then
+    echo "[nsys] DYN_DISABLE_NSYS=1 — running frontend+backend without nsys wrap" >&2
+fi
+
+# Auto-install nsys from the mounted .deb if missing. Fail fast if the .deb
+# isn't available or the install fails — mirrors vllm_serve.sh:78-101. A
+# silent "run without nsys" fallback would leave the orchestrator timing out
+# on readiness with no trace artifact, which is the footgun we're avoiding.
+if [[ "$DISABLE_NSYS" != "1" && ! -x "$NSYS_BIN" ]]; then
+    NSYS_DEB=$(ls /nsys/NsightSystems-linux-cli-public-*.deb 2>/dev/null | head -1)
+    if [[ -n "$NSYS_DEB" ]]; then
+        echo "[nsys] $NSYS_BIN missing; installing from $NSYS_DEB" >&2
+        DEBIAN_FRONTEND=noninteractive apt-get update >&2 || true
+        DEBIAN_FRONTEND=noninteractive apt-get install -y "$NSYS_DEB" >&2 || {
+            echo "[nsys] apt install $NSYS_DEB failed; falling back to dpkg -i + apt --fix-broken" >&2
+            dpkg -i "$NSYS_DEB" >&2 || true
+            DEBIAN_FRONTEND=noninteractive apt-get -y --fix-broken install >&2 || {
+                echo "[nsys] FATAL: all install paths failed; refusing to run without profiling" >&2
+                exit 1
+            }
+        }
+    else
+        echo "[nsys] FATAL: $NSYS_BIN not executable and no .deb at /nsys/ — refusing to run without profiling" >&2
+        exit 1
+    fi
+fi
+
+if [[ "$DISABLE_NSYS" == "1" ]]; then
+    FE_PREFIX=()
+    BE_PREFIX=()
+else
+    NSYS_COMMON=(
+        "$NSYS_BIN" profile
+        --trace=nvtx,cuda
+        --sample=none
+        --cpuctxsw=none
+        --delay="$NSYS_DELAY_S"
+        --duration="$NSYS_DURATION_S"
+        # --kill=sigterm: on SIGINT, nsys STOPS tracing, sends SIGTERM to its
+        # children (incl. re-parented TP workers on the backend side), waits
+        # for them to exit, then finalizes.
+        --kill=sigterm
+        --force-overwrite=true
+    )
+    echo "[nsys] frontend -> $FRONTEND_OUT" >&2
+    echo "[nsys] backend  -> $BACKEND_OUT" >&2
+    FE_PREFIX=("${NSYS_COMMON[@]}" -o "$FRONTEND_OUT")
+    BE_PREFIX=("${NSYS_COMMON[@]}" -o "$BACKEND_OUT")
+fi
+
+# Infra (etcd + nats) is expected to be already running on the allocation
+# (cloud-session starts them in a separate tmux window on container
+# attach). If they're not, a fallback start runs here — but without
+# deleting /tmp/etcd or /tmp/nats so a live infra isn't wiped out.
+if ! curl -sf http://localhost:2379/health > /dev/null 2>&1; then
+    echo "[dynamo_serve] etcd not responding — starting fallback" >&2
+    etcd --listen-client-urls http://0.0.0.0:2379 \
+         --advertise-client-urls http://0.0.0.0:2379 \
+         --data-dir /tmp/etcd > /dev/null 2>&1 &
+    nats-server -js -m 8222 -p 4222 -sd /tmp/nats > /dev/null 2>&1 &
+    sleep 2
+fi
+
+FE_NSYS_PID=0
+BE_NSYS_PID=0
+
+# Install the trap BEFORE launching children so a fast orchestrator SIGINT
+# during the startup window is still forwarded to nsys. cleanup() is a safe
+# no-op while PIDs are still 0.
+cleanup() {
+    echo "[dynamo-serve] signal received; SIGINT -> nsys (FE=$FE_NSYS_PID BE=$BE_NSYS_PID) for graceful finalize" >&2
+    for pid in "$FE_NSYS_PID" "$BE_NSYS_PID"; do
+        [[ -n "$pid" && "$pid" -gt 0 ]] && kill -INT "$pid" 2>/dev/null || true
+    done
+    # Shared 150 s deadline — both nsys instances finalize in parallel, so
+    # wall time = max(fe, be), under the orchestrator's 180 s SIGKILL budget.
+    for _ in $(seq 1 150); do
+        any_alive=0
+        for pid in "$FE_NSYS_PID" "$BE_NSYS_PID"; do
+            [[ -n "$pid" && "$pid" -gt 0 ]] && kill -0 "$pid" 2>/dev/null && any_alive=1
+        done
+        [[ "$any_alive" -eq 0 ]] && break
+        sleep 1
+    done
+    exit 0
+}
+trap cleanup INT TERM
+
+"${FE_PREFIX[@]}" python -m dynamo.frontend &
+FE_NSYS_PID=$!
+
+"${BE_PREFIX[@]}" python -m dynamo.vllm \
+    --model "$MODEL" \
+    "${EXTRA_ARGS[@]}" &
+BE_NSYS_PID=$!
+
+# Wait for both nsys instances.
+# - If orchestrator signals us first, cleanup() forwards and exits.
+# - If --duration=$NSYS_DURATION_S elapses, both nsys auto-stop. We drop
+#   into the idle loop so the orchestrator's eventual SIGINT still has a
+#   well-defined target (this bash).
+# - If either nsys exits early with an error (e.g., engine init failure),
+#   we surface that to the orchestrator instead of idling forever — lets
+#   ServerManager.start() observe startup failures rather than timing out
+#   on readiness.
+wait "$FE_NSYS_PID"; FE_EXIT=$?
+wait "$BE_NSYS_PID"; BE_EXIT=$?
+if [[ "$FE_EXIT" -ne 0 || "$BE_EXIT" -ne 0 ]]; then
+    WALL=$(date +%s)
+    echo "[dynamo-serve] early exit: FE_EXIT=$FE_EXIT BE_EXIT=$BE_EXIT wall=$WALL" >&2
+    # If we exited this early, nsys likely didn't run its full --duration
+    # window. Report non-zero so the orchestrator doesn't wait until its
+    # readiness timeout for a diagnosis.
+    exit 1
+fi
+while sleep 60; do :; done

--- a/benchmarks/multimodal/sweep/workflows/vllm_serve.sh
+++ b/benchmarks/multimodal/sweep/workflows/vllm_serve.sh
@@ -98,9 +98,16 @@ fi
 if [[ "$DISABLE_NSYS" == "1" ]]; then
     NSYS_PREFIX=()
 else
+    # --trace=nvtx (drop `cuda`) — vllm serve is CUDA-active so the NVTX
+    # channel survives without the `cuda` keepalive; dropping `cuda` collapses
+    # the qdstrm by ~150× (1.2 GB → 7.6 MB on 397B / 8× H100), keeps nsys
+    # finalize inside the SIGINT deadline, and matches dynamo_serve.sh's
+    # backend prefix so the two configs produce parity-sized reps. NVTX-level
+    # analysis (`nsys stats --report nvtx_sum`) is unchanged. If you need
+    # kernel-level CUDA correlation, set DYN_NSYS_TRACE=nvtx,cuda explicitly.
     NSYS_PREFIX=(
         "$NSYS_BIN" profile
-        --trace=nvtx,cuda
+        --trace="${DYN_NSYS_TRACE:-nvtx}"
         --sample=none
         --cpuctxsw=none
         --delay="$NSYS_DELAY_S"
@@ -121,7 +128,7 @@ NSYS_PID=0
 # wrappers must forward SIGINT/SIGTERM — never `trap '' INT TERM`.
 cleanup() {
     [[ "$NSYS_PID" -gt 0 ]] && kill -INT "$NSYS_PID" 2>/dev/null || true
-    for _ in $(seq 1 150); do
+    for _ in $(seq 1 300); do
         [[ "$NSYS_PID" -gt 0 ]] && kill -0 "$NSYS_PID" 2>/dev/null || break
         sleep 1
     done

--- a/benchmarks/multimodal/sweep/workflows/vllm_serve.sh
+++ b/benchmarks/multimodal/sweep/workflows/vllm_serve.sh
@@ -2,7 +2,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Minimal vllm serve wrapper for benchmark sweeps.
+# vllm serve wrapper for benchmark sweeps. Wraps the server in a single nsys
+# instance (matching dynamo_serve.sh's defaults) so the vllm-serve config
+# produces a comparable .nsys-rep alongside dynamo-fd / dynamo-fd-ec.
 # Launched by the sweep orchestrator via: bash vllm_serve.sh --model <model> [extra_args...]
 
 MODEL=""
@@ -43,9 +45,95 @@ else
     GPU_MEM_ARGS="--gpu-memory-utilization $GPU_MEM_UTIL"
 fi
 
-vllm serve "$MODEL" \
+# ---------------------------------------------------------------------------
+# nsys wrapping (mirrors dynamo_serve.sh conventions).
+# ---------------------------------------------------------------------------
+NSYS_BIN="${DYN_NSYS_BIN:-/opt/nvidia/nsight-systems-cli/2026.2.1/bin/nsys}"
+# Default groups reps by day under /dynamo-tmp/MM-DD/nsys/ to match the sweep
+# yaml's `output_dir: /dynamo-tmp/MM-DD/<slug>` pattern. Override via
+# DYN_NSYS_DIR (e.g. yaml env) to co-locate with aiperf outputs.
+NSYS_DIR="${DYN_NSYS_DIR:-/dynamo-tmp/$(date +%m-%d)/nsys}"
+# Full process lifetime capture by default. delay=0 starts tracing immediately;
+# duration=86400 (24 h) means --duration never fires. nsys only stops when the
+# orchestrator sends SIGINT (see --kill=sigterm below) and finalizes cleanly.
+# Avoids the windowed-capture footgun where --duration expires mid-load and
+# kills the engine. Override via DYN_NSYS_DELAY_S / DYN_NSYS_DURATION_S.
+NSYS_DELAY_S="${DYN_NSYS_DELAY_S:-0}"
+NSYS_DURATION_S="${DYN_NSYS_DURATION_S:-86400}"
+
+# Stage .qdstrm on scratch, not container /tmp (Pyxis overlay evaporates at
+# job end, orphaning any .qdstrm from a SIGKILL'd finalize).
+export TMPDIR="${DYN_NSYS_TMPDIR:-/dynamo-tmp/nsys-staging}"
+mkdir -p "$TMPDIR"
+mkdir -p "$NSYS_DIR"
+TS=$(date +%Y%m%d_%H%M%S)
+NSYS_OUT="$NSYS_DIR/vllm_$TS.nsys-rep"
+
+DISABLE_NSYS="${DYN_DISABLE_NSYS:-0}"
+if [[ "$DISABLE_NSYS" == "1" ]]; then
+    echo "[nsys] DYN_DISABLE_NSYS=1 — running vllm serve without nsys wrap" >&2
+fi
+
+# Auto-install nsys from the mounted .deb if missing. Fail loudly — silent
+# fall-through produces an unwrapped server and no trace artifact.
+if [[ "$DISABLE_NSYS" != "1" && ! -x "$NSYS_BIN" ]]; then
+    NSYS_DEB=$(ls /nsys/NsightSystems-linux-cli-public-*.deb 2>/dev/null | head -1)
+    if [[ -n "$NSYS_DEB" ]]; then
+        echo "[nsys] $NSYS_BIN missing; installing from $NSYS_DEB" >&2
+        DEBIAN_FRONTEND=noninteractive apt-get update >&2 || true
+        DEBIAN_FRONTEND=noninteractive apt-get install -y "$NSYS_DEB" >&2 || {
+            echo "[nsys] apt install $NSYS_DEB failed; falling back to dpkg -i + apt --fix-broken" >&2
+            dpkg -i "$NSYS_DEB" >&2 || true
+            DEBIAN_FRONTEND=noninteractive apt-get -y --fix-broken install >&2 || {
+                echo "[nsys] FATAL: all install paths failed; refusing to run without profiling" >&2
+                exit 1
+            }
+        }
+    else
+        echo "[nsys] FATAL: $NSYS_BIN not executable and no .deb at /nsys/ — refusing to run without profiling" >&2
+        exit 1
+    fi
+fi
+
+if [[ "$DISABLE_NSYS" == "1" ]]; then
+    NSYS_PREFIX=()
+else
+    NSYS_PREFIX=(
+        "$NSYS_BIN" profile
+        --trace=nvtx,cuda
+        --sample=none
+        --cpuctxsw=none
+        --delay="$NSYS_DELAY_S"
+        --duration="$NSYS_DURATION_S"
+        # --kill=sigterm: on SIGINT, nsys STOPS tracing, SIGTERMs the child,
+        # waits for exit, then finalizes the .nsys-rep.
+        --kill=sigterm
+        --force-overwrite=true
+        -o "$NSYS_OUT"
+    )
+    echo "[nsys] vllm-serve -> $NSYS_OUT" >&2
+fi
+
+NSYS_PID=0
+
+# Install the trap BEFORE launching so a fast orchestrator SIGINT during the
+# startup window is still forwarded to nsys. Per project/code.md, profiler
+# wrappers must forward SIGINT/SIGTERM — never `trap '' INT TERM`.
+cleanup() {
+    [[ "$NSYS_PID" -gt 0 ]] && kill -INT "$NSYS_PID" 2>/dev/null || true
+    for _ in $(seq 1 150); do
+        [[ "$NSYS_PID" -gt 0 ]] && kill -0 "$NSYS_PID" 2>/dev/null || break
+        sleep 1
+    done
+    exit 0
+}
+trap cleanup INT TERM
+
+"${NSYS_PREFIX[@]}" vllm serve "$MODEL" \
     --enable-log-requests \
     --max-model-len 16384 \
     $GPU_MEM_ARGS \
     "${EC_ARGS[@]}" \
-    "${EXTRA_ARGS[@]}"
+    "${EXTRA_ARGS[@]}" &
+NSYS_PID=$!
+wait "$NSYS_PID"

--- a/components/src/dynamo/vllm/multimodal_utils/multimodal_embedding_cache_connector.py
+++ b/components/src/dynamo/vllm/multimodal_utils/multimodal_embedding_cache_connector.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import logging
 from collections import OrderedDict
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
@@ -14,7 +13,9 @@ from vllm.distributed.ec_transfer.ec_connector.base import (
     ECConnectorMetadata,
     ECConnectorRole,
 )
+from vllm.logger import init_logger
 from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.utils import record_function_or_nullcontext
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
@@ -22,7 +23,9 @@ if TYPE_CHECKING:
 
 MINIMUM_VLLM_VERSION = "0.17.0"
 
-logger = logging.getLogger(__name__)
+# init_logger so we land in the vllm-handler tree inside the EngineCore
+# subprocess; logging.getLogger(__name__) drops INFO records there.
+logger = init_logger("vllm.dynamo_ec_connector")
 
 
 @dataclass
@@ -45,6 +48,8 @@ class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
     This mirrors vLLM's EncoderCacheManager pattern: the scheduler is the
     single source of truth for cache state; the worker is a plain dict storage.
     """
+
+    _log_every_n_steps: int = 100
 
     def __init__(self, vllm_config: "VllmConfig", role: ECConnectorRole) -> None:
         if Version(_vllm_version) < Version(MINIMUM_VLLM_VERSION):
@@ -89,12 +94,22 @@ class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
         self._saves_this_step: set[str] = set()
         self._evicts_this_step: set[str] = set()
 
+        # --- Scheduler-side cumulative counters (for periodic logging) ---
+        self._total_hits: int = 0
+        self._total_misses: int = 0
+        self._total_evictions: int = 0
+        self._total_loads: int = 0
+        self._total_saves: int = 0
+        self._log_step: int = 0
+
         # --- Worker-side: dumb CPU tensor store ---
         self._cpu_store: dict[str, torch.Tensor] = {}
+        self._step_counter: int = 0
 
         logger.info(
             "DynamoMultimodalEmbeddingCacheConnector initialized: "
-            "capacity_gb=%.2f, capacity_bytes=%d, bytes_per_embed=%d",
+            "role=%s, capacity_gb=%.2f, capacity_bytes=%d, bytes_per_embed=%d",
+            role.name,
             capacity_gb,
             self._capacity_bytes,
             self._bytes_per_embed,
@@ -125,10 +140,13 @@ class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
         a miss. A True return tells the scheduler to skip encoder compute and
         load the embedding from the CPU store instead.
         """
-        if identifier in self._cache_order:
-            self._cache_order.move_to_end(identifier)
-            return True
-        return False
+        with record_function_or_nullcontext("ec_connector: scheduler_has_cache_item"):
+            if identifier in self._cache_order:
+                self._cache_order.move_to_end(identifier)
+                self._total_hits += 1
+                return True
+            self._total_misses += 1
+            return False
 
     def update_state_after_alloc(self, request: "Request", index: int) -> None:
         """Record a load or save command for a multimodal feature.
@@ -141,45 +159,80 @@ class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
             then mark for GPU→CPU save so the worker persists the newly
             computed embedding. Silently skips items larger than total capacity.
         """
-        mm_hash: str = request.mm_features[index].identifier
-        num_embeds: int = request.get_num_encoder_embeds(index)
-        size_bytes: int = num_embeds * self._bytes_per_embed
-
-        if mm_hash in self._cache_order:
-            self._cache_order.move_to_end(mm_hash)
-            self._loads_this_step.add(mm_hash)
-            return
-
-        if size_bytes > self._capacity_bytes:
-            return
-
-        self._saves_this_step.add(mm_hash)
-
-        while (
-            self._num_used_bytes + size_bytes > self._capacity_bytes
-            and self._cache_order
+        with record_function_or_nullcontext(
+            "ec_connector: scheduler_update_state_after_alloc"
         ):
-            evicted_hash, evicted_bytes = self._cache_order.popitem(last=False)
-            self._num_used_bytes -= evicted_bytes
-            self._evicts_this_step.add(evicted_hash)
+            mm_hash: str = request.mm_features[index].identifier
+            num_embeds: int = request.get_num_encoder_embeds(index)
+            size_bytes: int = num_embeds * self._bytes_per_embed
 
-        self._cache_order[mm_hash] = size_bytes
-        self._num_used_bytes += size_bytes
+            if mm_hash in self._cache_order:
+                self._cache_order.move_to_end(mm_hash)
+                self._loads_this_step.add(mm_hash)
+                return
+
+            if size_bytes > self._capacity_bytes:
+                return
+
+            self._saves_this_step.add(mm_hash)
+
+            if self._num_used_bytes + size_bytes > self._capacity_bytes:
+                with record_function_or_nullcontext("ec_connector: scheduler_evict"):
+                    while (
+                        self._num_used_bytes + size_bytes > self._capacity_bytes
+                        and self._cache_order
+                    ):
+                        evicted_hash, evicted_bytes = self._cache_order.popitem(
+                            last=False
+                        )
+                        self._num_used_bytes -= evicted_bytes
+                        self._evicts_this_step.add(evicted_hash)
+                        self._total_evictions += 1
+
+            self._cache_order[mm_hash] = size_bytes
+            self._num_used_bytes += size_bytes
 
     def build_connector_meta(
         self, scheduler_output: SchedulerOutput
     ) -> ECConnectorMetadata:
         """Flush accumulated load/save/evict commands into metadata for the worker."""
-        meta = MultimodalEmbeddingCacheConnectorMetadata(
-            loads=list(self._loads_this_step),
-            saves=list(self._saves_this_step),
-            evicts=list(self._evicts_this_step),
-        )
+        with record_function_or_nullcontext("ec_connector: build_connector_meta"):
+            meta = MultimodalEmbeddingCacheConnectorMetadata(
+                loads=list(self._loads_this_step),
+                saves=list(self._saves_this_step),
+                evicts=list(self._evicts_this_step),
+            )
 
-        self._loads_this_step.clear()
-        self._saves_this_step.clear()
-        self._evicts_this_step.clear()
-        return meta
+            self._total_loads += len(self._loads_this_step)
+            self._total_saves += len(self._saves_this_step)
+
+            self._loads_this_step.clear()
+            self._saves_this_step.clear()
+            self._evicts_this_step.clear()
+
+            self._log_step += 1
+            if self._log_step % self._log_every_n_steps == 0:
+                total_lookups = self._total_hits + self._total_misses
+                hit_rate = (
+                    100.0 * self._total_hits / total_lookups if total_lookups else 0.0
+                )
+                used_gb = self._num_used_bytes / 1024**3
+                cap_gb = self._capacity_bytes / 1024**3
+                logger.info(
+                    "ec_connector stats: hits=%d misses=%d hit_rate=%.1f%% "
+                    "loads=%d saves=%d evicts=%d entries=%d used=%.2f/%.2f GB",
+                    self._total_hits,
+                    self._total_misses,
+                    hit_rate,
+                    self._total_loads,
+                    self._total_saves,
+                    self._total_evictions,
+                    len(self._cache_order),
+                    used_gb,
+                    cap_gb,
+                )
+
+            return meta
 
     # ==============================
     # Worker-side methods
@@ -199,35 +252,48 @@ class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
         assert isinstance(metadata, MultimodalEmbeddingCacheConnectorMetadata)
 
         for mm_hash in metadata.loads:
-            if mm_hash in encoder_cache:
-                continue
-            if mm_hash in self._cpu_store:
-                encoder_cache[mm_hash] = self._cpu_store[mm_hash].to(
-                    "cuda", non_blocking=True
-                )
-            else:
-                logger.warning(
-                    "start_load_caches: hash %s not in cpu_store, skipping", mm_hash
-                )
+            with record_function_or_nullcontext("ec_connector: load_item"):
+                if mm_hash in encoder_cache:
+                    continue
+                if mm_hash in self._cpu_store:
+                    with record_function_or_nullcontext("ec_connector: load_h2d"):
+                        encoder_cache[mm_hash] = self._cpu_store[mm_hash].to(
+                            "cuda", non_blocking=True
+                        )
+                else:
+                    logger.warning(
+                        "start_load_caches: hash %s not in cpu_store, skipping",
+                        mm_hash,
+                    )
 
-        for mm_hash in metadata.evicts:
-            self._cpu_store.pop(mm_hash, None)
+        if metadata.evicts:
+            with record_function_or_nullcontext("ec_connector: load_evict"):
+                for mm_hash in metadata.evicts:
+                    self._cpu_store.pop(mm_hash, None)
+
+        self._step_counter += 1
+        if self._step_counter % self._log_every_n_steps == 0:
+            logger.info(
+                "ec_connector worker: cpu_store entries=%d", len(self._cpu_store)
+            )
 
     def save_caches(
         self, encoder_cache: dict[str, torch.Tensor], mm_hash: str, **kwargs
     ) -> None:
         """Copy a newly computed embedding from GPU encoder_cache to CPU store."""
-        metadata = self._get_connector_metadata()
-        assert isinstance(metadata, MultimodalEmbeddingCacheConnectorMetadata)
+        with record_function_or_nullcontext("ec_connector: save_caches"):
+            metadata = self._get_connector_metadata()
+            assert isinstance(metadata, MultimodalEmbeddingCacheConnectorMetadata)
 
-        if mm_hash not in metadata.saves:
-            return
-        if mm_hash in self._cpu_store:
-            return
-        if mm_hash not in encoder_cache:
-            logger.warning(
-                "save_caches: hash %s in metadata.saves but not in encoder_cache",
-                mm_hash,
-            )
-            return
-        self._cpu_store[mm_hash] = encoder_cache[mm_hash].cpu()
+            if mm_hash not in metadata.saves:
+                return
+            if mm_hash in self._cpu_store:
+                return
+            if mm_hash not in encoder_cache:
+                logger.warning(
+                    "save_caches: hash %s in metadata.saves but not in encoder_cache",
+                    mm_hash,
+                )
+                return
+            with record_function_or_nullcontext("ec_connector: save_d2h"):
+                self._cpu_store[mm_hash] = encoder_cache[mm_hash].cpu()

--- a/components/src/dynamo/vllm/multimodal_utils/multimodal_embedding_cache_connector.py
+++ b/components/src/dynamo/vllm/multimodal_utils/multimodal_embedding_cache_connector.py
@@ -23,8 +23,6 @@ if TYPE_CHECKING:
 
 MINIMUM_VLLM_VERSION = "0.17.0"
 
-# init_logger so we land in the vllm-handler tree inside the EngineCore
-# subprocess; logging.getLogger(__name__) drops INFO records there.
 logger = init_logger("vllm.dynamo_ec_connector")
 
 
@@ -37,19 +35,39 @@ class MultimodalEmbeddingCacheConnectorMetadata(ECConnectorMetadata):
     evicts: list[str] = field(default_factory=list)
 
 
+@dataclass
+class _CpuEntry:
+    """Worker-side CPU-resident embedding with async-save / async-load lifetime tracking.
+
+    save_done resolves when the DtoH copy on _save_stream has finished writing
+    cpu_tensor; pending_loads carries one event per in-flight HtoD reading from
+    cpu_tensor on the compute stream. Both are queried (never synchronized) by
+    the reaper so eviction never blocks the hot path. is_pinned distinguishes
+    the async/pinned path from the sync/pageable cap-fallback path; load and
+    reap branch on it.
+    """
+
+    cpu_tensor: torch.Tensor
+    save_done: torch.cuda.Event
+    pending_loads: list[torch.cuda.Event] = field(default_factory=list)
+    nbytes: int = 0
+    is_pinned: bool = True
+
+
 class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
     """EC connector with scheduler-authoritative CPU embedding cache.
 
     The scheduler maintains a logical LRU cache (OrderedDict) and issues
     load/save/evict commands to the worker via ECConnectorMetadata. The
-    worker holds a plain dict[str, Tensor] on CPU and obeys commands
+    worker holds a plain dict[str, _CpuEntry] on CPU and obeys commands
     without independent caching decisions.
 
-    This mirrors vLLM's EncoderCacheManager pattern: the scheduler is the
-    single source of truth for cache state; the worker is a plain dict storage.
+    Worker-side DtoH (save) runs on a dedicated CUDA stream with pinned
+    host buffers; HtoD (load) runs on the compute stream and waits on the
+    save event before reading. Evict is non-blocking — entries are
+    retired and reaped lazily once their save_done and any pending_loads
+    have resolved.
     """
-
-    _log_every_n_steps: int = 100
 
     def __init__(self, vllm_config: "VllmConfig", role: ECConnectorRole) -> None:
         if Version(_vllm_version) < Version(MINIMUM_VLLM_VERSION):
@@ -67,16 +85,13 @@ class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
                 "ec_transfer_config must be set for DynamoMultimodalEmbeddingCacheConnector"
             )
 
-        if "multimodal_embedding_cache_capacity_gb" not in (
-            transfer_config.ec_connector_extra_config or {}
-        ):
+        extra_config = transfer_config.ec_connector_extra_config or {}
+        if "multimodal_embedding_cache_capacity_gb" not in extra_config:
             raise ValueError(
                 "multimodal_embedding_cache_capacity_gb must be set in "
                 "ec_connector_extra_config for DynamoMultimodalEmbeddingCacheConnector"
             )
-        capacity_gb: float = transfer_config.ec_connector_extra_config[
-            "multimodal_embedding_cache_capacity_gb"
-        ]
+        capacity_gb: float = extra_config["multimodal_embedding_cache_capacity_gb"]
 
         # --- Scheduler-side: logical LRU for CPU embedding cache ---
         # Mirrors EncoderCacheManager but for the CPU tier, tracking bytes.
@@ -102,17 +117,37 @@ class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
         self._total_saves: int = 0
         self._log_step: int = 0
 
-        # --- Worker-side: dumb CPU tensor store ---
-        self._cpu_store: dict[str, torch.Tensor] = {}
+        # --- Worker-side: async DtoH/HtoD state ---
+        self._pin_memory: bool = bool(extra_config.get("pin_memory", True))
+        self._pinned_overhead_pct: float = float(
+            extra_config.get("pinned_overhead_pct", 25.0)
+        )
+        self._pinned_cap_bytes: int = int(
+            self._capacity_bytes * (1.0 + self._pinned_overhead_pct / 100.0)
+        )
+        self._log_every_n_steps: int = int(
+            extra_config.get("ec_log_every_n_steps", 100)
+        )
+
+        self._cpu_store: dict[str, _CpuEntry] = {}
+        self._retired: list[_CpuEntry] = []
+        self._save_stream: torch.cuda.Stream | None = None
+        self._device: torch.device | None = None
+        self._pinned_bytes_active: int = 0
+        self._pinned_bytes_retired: int = 0
+        self._already_done_event: torch.cuda.Event | None = None
         self._step_counter: int = 0
 
         logger.info(
             "DynamoMultimodalEmbeddingCacheConnector initialized: "
-            "role=%s, capacity_gb=%.2f, capacity_bytes=%d, bytes_per_embed=%d",
+            "role=%s, capacity_gb=%.2f, capacity_bytes=%d, bytes_per_embed=%d, "
+            "pin_memory=%s, pinned_cap_bytes=%d",
             role.name,
             capacity_gb,
             self._capacity_bytes,
             self._bytes_per_embed,
+            self._pin_memory,
+            self._pinned_cap_bytes,
         )
 
     # ==============================
@@ -242,6 +277,28 @@ class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
     # it simply obeys the scheduler's load/save/evict commands.
     # ==============================
 
+    def _ensure_streams(self, device: torch.device) -> None:
+        """Lazily create the save stream and lock the connector to a device.
+
+        The sentinel `_already_done_event` is recorded on the save stream and
+        synchronized once so subsequent .query() calls always return True. We
+        use it as save_done for sync-DtoH (pageable fallback) entries so the
+        load path branches uniformly without an `is_pinned` check on every
+        load.
+        """
+        if self._save_stream is None:
+            self._device = device
+            self._save_stream = torch.cuda.Stream(device=device)
+            sentinel = torch.cuda.Event()
+            sentinel.record(self._save_stream)
+            self._save_stream.synchronize()
+            self._already_done_event = sentinel
+        else:
+            assert device == self._device, (
+                f"EC connector bound to device {self._device} "
+                f"but received tensor on {device}"
+            )
+
     def start_load_caches(
         self, encoder_cache: dict[str, torch.Tensor], **kwargs
     ) -> None:
@@ -251,36 +308,95 @@ class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
         metadata = self._get_connector_metadata()
         assert isinstance(metadata, MultimodalEmbeddingCacheConnectorMetadata)
 
+        compute = torch.cuda.current_stream()
+        with record_function_or_nullcontext("ec_connector: load_ensure_streams"):
+            self._ensure_streams(compute.device)
+
         for mm_hash in metadata.loads:
             with record_function_or_nullcontext("ec_connector: load_item"):
                 if mm_hash in encoder_cache:
                     continue
-                if mm_hash in self._cpu_store:
-                    with record_function_or_nullcontext("ec_connector: load_h2d"):
-                        encoder_cache[mm_hash] = self._cpu_store[mm_hash].to(
-                            "cuda", non_blocking=True
-                        )
-                else:
+                entry = self._cpu_store.get(mm_hash)
+                if entry is None:
                     logger.warning(
                         "start_load_caches: hash %s not in cpu_store, skipping",
                         mm_hash,
                     )
+                    continue
+
+                # Make compute wait for the prior DtoH on save_stream. For pageable
+                # entries the sentinel event is already-resolved, so this is a no-op.
+                with record_function_or_nullcontext(
+                    "ec_connector: load_wait_save_done"
+                ):
+                    compute.wait_event(entry.save_done)
+
+                # HtoD on compute. Genuinely async for pinned; PyTorch silently
+                # falls back to sync for pageable, which is correct for that path.
+                with record_function_or_nullcontext("ec_connector: load_h2d"):
+                    gpu_tensor = entry.cpu_tensor.to(
+                        device=compute.device, non_blocking=entry.is_pinned
+                    )
+
+                # Symmetric record_stream on the destination: tells the caching
+                # allocator the new tensor's storage is consumed by compute, so
+                # if vLLM pops encoder_cache[h] before compute is done, the GPU
+                # buffer is not reused early.
+                with record_function_or_nullcontext(
+                    "ec_connector: load_record_stream"
+                ):
+                    gpu_tensor.record_stream(compute)
+
+                with record_function_or_nullcontext(
+                    "ec_connector: load_record_event"
+                ):
+                    load_done = torch.cuda.Event()
+                    load_done.record(compute)
+                    entry.pending_loads.append(load_done)
+
+                encoder_cache[mm_hash] = gpu_tensor
 
         if metadata.evicts:
             with record_function_or_nullcontext("ec_connector: load_evict"):
                 for mm_hash in metadata.evicts:
-                    self._cpu_store.pop(mm_hash, None)
+                    entry = self._cpu_store.pop(mm_hash, None)
+                    if entry is not None:
+                        if entry.is_pinned:
+                            self._pinned_bytes_active -= entry.nbytes
+                            self._pinned_bytes_retired += entry.nbytes
+                        self._retired.append(entry)
+
+        with record_function_or_nullcontext("ec_connector: load_cleanup"):
+            self._prune_active_load_events()
+            self._reap_retired()
 
         self._step_counter += 1
         if self._step_counter % self._log_every_n_steps == 0:
             logger.info(
-                "ec_connector worker: cpu_store entries=%d", len(self._cpu_store)
+                "EC pinned bytes: active=%d retired=%d cap=%d "
+                "(entries=%d retired_count=%d)",
+                self._pinned_bytes_active,
+                self._pinned_bytes_retired,
+                self._pinned_cap_bytes,
+                len(self._cpu_store),
+                len(self._retired),
             )
 
     def save_caches(
         self, encoder_cache: dict[str, torch.Tensor], mm_hash: str, **kwargs
     ) -> None:
-        """Copy a newly computed embedding from GPU encoder_cache to CPU store."""
+        """Copy a newly computed embedding from GPU encoder_cache to CPU store.
+
+        Pinned path: queue an async DtoH on _save_stream after waiting on
+        compute, record save_done, hand the entry to _cpu_store immediately
+        (load path will gate on save_done). The pinned-bytes accounting tracks
+        active vs retired separately so the reaper can release retired bytes
+        once both save and any pending loads have drained.
+
+        Sync fallback (pin_memory=False or over-cap): a pageable .cpu() copy
+        with the always-resolved sentinel as save_done, accounted as
+        is_pinned=False so the budget is not double-counted.
+        """
         with record_function_or_nullcontext("ec_connector: save_caches"):
             metadata = self._get_connector_metadata()
             assert isinstance(metadata, MultimodalEmbeddingCacheConnectorMetadata)
@@ -295,5 +411,104 @@ class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
                     mm_hash,
                 )
                 return
-            with record_function_or_nullcontext("ec_connector: save_d2h"):
-                self._cpu_store[mm_hash] = encoder_cache[mm_hash].cpu()
+
+            src = encoder_cache[mm_hash]
+            if not src.is_contiguous():
+                logger.debug(
+                    "save_caches: non-contiguous source for hash %s, materializing",
+                    mm_hash,
+                )
+                with record_function_or_nullcontext("ec_connector: save_contiguous"):
+                    src = src.contiguous()
+
+            with record_function_or_nullcontext("ec_connector: save_ensure_streams"):
+                self._ensure_streams(src.device)
+            nbytes = src.numel() * src.element_size()
+
+            over_cap = (
+                self._pinned_bytes_active + self._pinned_bytes_retired + nbytes
+                > self._pinned_cap_bytes
+            )
+            use_pinned = self._pin_memory and not over_cap
+
+            if use_pinned:
+                with record_function_or_nullcontext(
+                    "ec_connector: save_alloc_pinned_cpu"
+                ):
+                    cpu_buf = torch.empty(
+                        src.shape, dtype=src.dtype, device="cpu", pin_memory=True
+                    )
+                compute = torch.cuda.current_stream(src.device)
+                assert self._save_stream is not None
+                with record_function_or_nullcontext(
+                    "ec_connector: save_wait_compute"
+                ):
+                    self._save_stream.wait_stream(compute)
+                with torch.cuda.stream(self._save_stream):
+                    with record_function_or_nullcontext(
+                        "ec_connector: save_d2h_async_enqueue"
+                    ):
+                        cpu_buf.copy_(src, non_blocking=True)
+                        # Symmetric record_stream on the source: protects the GPU
+                        # source memory in case vLLM pops encoder_cache[h] before the
+                        # async DtoH finishes.
+                        src.record_stream(self._save_stream)
+                with record_function_or_nullcontext(
+                    "ec_connector: save_record_event"
+                ):
+                    save_done = torch.cuda.Event()
+                    save_done.record(self._save_stream)
+                self._cpu_store[mm_hash] = _CpuEntry(
+                    cpu_tensor=cpu_buf,
+                    save_done=save_done,
+                    nbytes=nbytes,
+                    is_pinned=True,
+                )
+                self._pinned_bytes_active += nbytes
+            else:
+                if over_cap:
+                    logger.warning(
+                        "save_caches: pinned budget exceeded "
+                        "(active=%d retired=%d new=%d cap=%d); "
+                        "falling back to sync DtoH for hash %s",
+                        self._pinned_bytes_active,
+                        self._pinned_bytes_retired,
+                        nbytes,
+                        self._pinned_cap_bytes,
+                        mm_hash,
+                    )
+                assert self._already_done_event is not None
+                with record_function_or_nullcontext("ec_connector: save_d2h_sync"):
+                    cpu_tensor = src.cpu()
+                self._cpu_store[mm_hash] = _CpuEntry(
+                    cpu_tensor=cpu_tensor,
+                    save_done=self._already_done_event,
+                    nbytes=nbytes,
+                    is_pinned=False,
+                )
+
+            with record_function_or_nullcontext("ec_connector: save_reap_retired"):
+                self._reap_retired()
+
+    def _prune_active_load_events(self) -> None:
+        """Drop resolved load events from active entries to bound the list size."""
+        for entry in self._cpu_store.values():
+            if entry.pending_loads:
+                entry.pending_loads = [e for e in entry.pending_loads if not e.query()]
+
+    def _reap_retired(self) -> None:
+        """Release retired entries whose save and all pending loads have drained.
+
+        Never blocks — uses event.query() only. Safe to call from save_caches
+        and start_load_caches.
+        """
+        if not self._retired:
+            return
+        still_pending: list[_CpuEntry] = []
+        for entry in self._retired:
+            if entry.save_done.query() and all(e.query() for e in entry.pending_loads):
+                if entry.is_pinned:
+                    self._pinned_bytes_retired -= entry.nbytes
+                continue
+            still_pending.append(entry)
+        self._retired = still_pending

--- a/components/src/dynamo/vllm/multimodal_utils/multimodal_embedding_cache_connector.py
+++ b/components/src/dynamo/vllm/multimodal_utils/multimodal_embedding_cache_connector.py
@@ -15,12 +15,14 @@ from vllm.distributed.ec_transfer.ec_connector.base import (
 )
 from vllm.logger import init_logger
 from vllm.v1.core.sched.output import SchedulerOutput
-from vllm.v1.utils import record_function_or_nullcontext
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
     from vllm.v1.request import Request
 
+# Async-load support requires the WAITING_FOR_EMBEDDINGS state machine and
+# the get_finished_loads/request_async_load hooks. These land on top of the
+# upstream EC base API in this branch.
 MINIMUM_VLLM_VERSION = "0.17.0"
 
 logger = init_logger("vllm.dynamo_ec_connector")
@@ -34,6 +36,13 @@ class MultimodalEmbeddingCacheConnectorMetadata(ECConnectorMetadata):
     saves: list[str] = field(default_factory=list)
     evicts: list[str] = field(default_factory=list)
 
+    def __post_init__(self) -> None:
+        # ECConnectorMetadata base class declares ``evict_orphan: set[str]``;
+        # ensure it's initialized even when the dataclass-generated __init__
+        # bypasses the base ``__init__``.
+        if not hasattr(self, "evict_orphan"):
+            self.evict_orphan = set()
+
 
 @dataclass
 class _CpuEntry:
@@ -41,10 +50,10 @@ class _CpuEntry:
 
     save_done resolves when the DtoH copy on _save_stream has finished writing
     cpu_tensor; pending_loads carries one event per in-flight HtoD reading from
-    cpu_tensor on the compute stream. Both are queried (never synchronized) by
-    the reaper so eviction never blocks the hot path. is_pinned distinguishes
-    the async/pinned path from the sync/pageable cap-fallback path; load and
-    reap branch on it.
+    cpu_tensor on _load_stream. Both are queried (never synchronized) by the
+    reaper so eviction never blocks the hot path. is_pinned distinguishes the
+    async/pinned path from the sync/pageable cap-fallback path; load and reap
+    branch on it.
     """
 
     cpu_tensor: torch.Tensor
@@ -55,18 +64,23 @@ class _CpuEntry:
 
 
 class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
-    """EC connector with scheduler-authoritative CPU embedding cache.
+    """EC connector with scheduler-authoritative CPU embedding cache, async
+    DtoH save, and an async-load fast path.
 
-    The scheduler maintains a logical LRU cache (OrderedDict) and issues
-    load/save/evict commands to the worker via ECConnectorMetadata. The
-    worker holds a plain dict[str, _CpuEntry] on CPU and obeys commands
-    without independent caching decisions.
+    Scheduler maintains a logical LRU (OrderedDict) and issues load/save/evict
+    commands to the worker via ECConnectorMetadata. Worker holds a plain
+    ``dict[str, _CpuEntry]`` and obeys commands without independent caching
+    decisions.
 
-    Worker-side DtoH (save) runs on a dedicated CUDA stream with pinned
-    host buffers; HtoD (load) runs on the compute stream and waits on the
-    save event before reading. Evict is non-blocking — entries are
-    retired and reaped lazily once their save_done and any pending_loads
-    have resolved.
+    Worker-side DtoH (save) runs on a dedicated CUDA stream with pinned host
+    buffers; HtoD (load) runs on a second dedicated stream, gated on the save
+    event. Loads do NOT block compute — the H2D overlaps with the prior
+    step's compute and the scheduler parks the request in
+    ``WAITING_FOR_EMBEDDINGS`` until ``get_finished_loads`` reports the
+    mm_hash done.
+
+    Evict is non-blocking — entries move to a retired list and are reaped
+    lazily once their save_done and any pending_loads have queried True.
     """
 
     def __init__(self, vllm_config: "VllmConfig", role: ECConnectorRole) -> None:
@@ -117,7 +131,7 @@ class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
         self._total_saves: int = 0
         self._log_step: int = 0
 
-        # --- Worker-side: async DtoH/HtoD state ---
+        # --- Worker-side: async DtoH state ---
         self._pin_memory: bool = bool(extra_config.get("pin_memory", True))
         self._pinned_overhead_pct: float = float(
             extra_config.get("pinned_overhead_pct", 25.0)
@@ -138,6 +152,17 @@ class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
         self._already_done_event: torch.cuda.Event | None = None
         self._step_counter: int = 0
 
+        # --- Worker-side: async-load (HtoD) state ---
+        # H2D copies run on _load_stream and don't block compute. Each load
+        # records an event into _inflight_loads; get_finished_loads polls
+        # the events, moves completed tensors into encoder_cache, and
+        # reports their hashes to the scheduler so it can re-admit the
+        # request. _just_resurrected tracks same-hash orphan tensors that
+        # are already encoder_cache-resident at start_load_caches time.
+        self._inflight_loads: dict[str, tuple[torch.Tensor, torch.cuda.Event]] = {}
+        self._just_resurrected: set[str] = set()
+        self._load_stream: torch.cuda.Stream | None = None
+
         logger.info(
             "DynamoMultimodalEmbeddingCacheConnector initialized: "
             "role=%s, capacity_gb=%.2f, capacity_bytes=%d, bytes_per_embed=%d, "
@@ -156,129 +181,153 @@ class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
     # vLLM scheduler call sequence per multimodal feature:
     #
     #   1. encoder_cache_manager.check_and_update_cache(request, i)
-    #      → if True (GPU hit): skip entirely, neither method below is called.
+    #      → if True (GPU hit): skip entirely.
     #
     #   2. has_cache_item(identifier)
-    #      → if True (CPU hit):  item goes to external_load_encoder_input
-    #      → if False (CPU miss): item goes to encoder_inputs_to_schedule
+    #      → returns (True, True) on a CPU hit, opting into async-load:
+    #         scheduler parks the request in WAITING_FOR_EMBEDDINGS and
+    #         calls request_async_load(request, i) instead of the sync
+    #         update_state_after_alloc.
+    #      → (False, _) routes to the normal compute / save path.
     #
-    #   3. update_state_after_alloc(request, i) is called for both paths.
-    #      The two paths are mutually exclusive per hash within a step:
-    #      - external_load_encoder_input → mm_hash IN _cache_order  → load path
-    #      - encoder_inputs_to_schedule  → mm_hash NOT in _cache_order → save path
+    #   3. update_state_after_alloc(request, i) is called for sync-allocated
+    #      paths (current step's encoder compute or any sync external load).
+    #      For async loads, request_async_load is called instead — both
+    #      ultimately funnel into _loads_this_step / _saves_this_step.
     # ==============================
 
-    def has_cache_item(self, identifier: str) -> bool:
-        """Check if an embedding is in the CPU cache, promoting it to MRU on hit.
+    def has_cache_item(self, identifier: str) -> "tuple[bool, bool]":
+        """CPU-cache lookup, MRU-promoting on hit.
 
-        Called by the scheduler only after the GPU encoder_cache_manager reports
-        a miss. A True return tells the scheduler to skip encoder compute and
-        load the embedding from the CPU store instead.
+        Returns ``(hit, load_async)``:
+          - miss: ``(False, False)``.
+          - hit:  ``(True, True)`` — opt the request into async-load.
         """
-        with record_function_or_nullcontext("ec_connector: scheduler_has_cache_item"):
-            if identifier in self._cache_order:
-                self._cache_order.move_to_end(identifier)
-                self._total_hits += 1
-                return True
-            self._total_misses += 1
-            return False
+        if identifier in self._cache_order:
+            self._cache_order.move_to_end(identifier)
+            self._total_hits += 1
+            return True, True
+        self._total_misses += 1
+        return False, False
 
     def update_state_after_alloc(self, request: "Request", index: int) -> None:
-        """Record a load or save command for a multimodal feature.
+        """Sync-path hook (encoder compute, or sync external load).
 
-        Called by the scheduler after has_cache_item has already determined
-        the path. The _cache_order check here mirrors that decision:
-
-        CPU hit  (mm_hash in _cache_order):  mark for CPU→GPU load.
-        CPU miss (mm_hash not in _cache_order): evict LRU entries if needed,
-            then mark for GPU→CPU save so the worker persists the newly
-            computed embedding. Silently skips items larger than total capacity.
+        Called by the scheduler after ``encoder_cache_manager.allocate(request,
+        i)`` for sync external_load_encoder_input AND for the encoder-compute
+        path (where the connector records a save command). Idempotent under
+        repeated ``(request, mm_hash)`` calls; the connector deduplicates by
+        hash.
         """
-        with record_function_or_nullcontext(
-            "ec_connector: scheduler_update_state_after_alloc"
+        mm_hash: str = request.mm_features[index].identifier
+        num_embeds: int = request.get_num_encoder_embeds(index)
+        size_bytes: int = num_embeds * self._bytes_per_embed
+
+        if mm_hash in self._cache_order:
+            # Hash already in CPU store; sync external-load path requested.
+            self._cache_order.move_to_end(mm_hash)
+            self._loads_this_step.add(mm_hash)
+            return
+
+        # Miss → schedule encoder compute, mark for save.
+        if size_bytes > self._capacity_bytes:
+            return
+
+        self._saves_this_step.add(mm_hash)
+
+        while (
+            self._num_used_bytes + size_bytes > self._capacity_bytes
+            and self._cache_order
         ):
-            mm_hash: str = request.mm_features[index].identifier
-            num_embeds: int = request.get_num_encoder_embeds(index)
-            size_bytes: int = num_embeds * self._bytes_per_embed
+            evicted_hash, evicted_bytes = self._cache_order.popitem(last=False)
+            self._num_used_bytes -= evicted_bytes
+            self._evicts_this_step.add(evicted_hash)
+            self._total_evictions += 1
 
-            if mm_hash in self._cache_order:
-                self._cache_order.move_to_end(mm_hash)
-                self._loads_this_step.add(mm_hash)
-                return
+        self._cache_order[mm_hash] = size_bytes
+        self._num_used_bytes += size_bytes
 
-            if size_bytes > self._capacity_bytes:
-                return
+    def request_async_load(self, request: "Request", index: int) -> None:
+        """Async-path hook: the scheduler is parking the request in
+        ``WAITING_FOR_EMBEDDINGS`` for this mm_hash and has reserved its
+        encoder-cache slot via the inflight-async budget. The connector
+        records a load command for the worker; the worker dispatches the
+        H2D in the next ``start_load_caches`` call.
 
-            self._saves_this_step.add(mm_hash)
-
-            if self._num_used_bytes + size_bytes > self._capacity_bytes:
-                with record_function_or_nullcontext("ec_connector: scheduler_evict"):
-                    while (
-                        self._num_used_bytes + size_bytes > self._capacity_bytes
-                        and self._cache_order
-                    ):
-                        evicted_hash, evicted_bytes = self._cache_order.popitem(
-                            last=False
-                        )
-                        self._num_used_bytes -= evicted_bytes
-                        self._evicts_this_step.add(evicted_hash)
-                        self._total_evictions += 1
-
-            self._cache_order[mm_hash] = size_bytes
-            self._num_used_bytes += size_bytes
+        Idempotent under repeated calls for the same mm_hash (set semantics).
+        """
+        mm_hash: str = request.mm_features[index].identifier
+        # The hash MUST already be in the CPU store — that's the precondition
+        # has_cache_item returned True for. MRU-promote.
+        if mm_hash in self._cache_order:
+            self._cache_order.move_to_end(mm_hash)
+        else:
+            # Defensive: scheduler called us for a hash we don't have. Log
+            # and skip; the scheduler's WAITING_FOR_EMBEDDINGS will time out
+            # waiting for finished_loading and the user will see the warning.
+            logger.warning(
+                "request_async_load: %s not in CPU cache; load will not fire",
+                mm_hash,
+            )
+            return
+        self._loads_this_step.add(mm_hash)
 
     def build_connector_meta(
         self, scheduler_output: SchedulerOutput
     ) -> ECConnectorMetadata:
-        """Flush accumulated load/save/evict commands into metadata for the worker."""
-        with record_function_or_nullcontext("ec_connector: build_connector_meta"):
-            meta = MultimodalEmbeddingCacheConnectorMetadata(
-                loads=list(self._loads_this_step),
-                saves=list(self._saves_this_step),
-                evicts=list(self._evicts_this_step),
+        """Flush load/save/evict commands into metadata for the worker.
+
+        ``evict_orphan`` is appended by the scheduler after this returns
+        (see ``Scheduler._pending_orphan_evicts`` flush in ``_make_step_output``).
+        """
+        meta = MultimodalEmbeddingCacheConnectorMetadata(
+            loads=list(self._loads_this_step),
+            saves=list(self._saves_this_step),
+            evicts=list(self._evicts_this_step),
+        )
+
+        self._total_loads += len(self._loads_this_step)
+        self._total_saves += len(self._saves_this_step)
+
+        self._loads_this_step.clear()
+        self._saves_this_step.clear()
+        self._evicts_this_step.clear()
+
+        self._log_step += 1
+        if self._log_step % self._log_every_n_steps == 0:
+            total_lookups = self._total_hits + self._total_misses
+            hit_rate = (
+                100.0 * self._total_hits / total_lookups if total_lookups else 0.0
+            )
+            used_gb = self._num_used_bytes / 1024**3
+            cap_gb = self._capacity_bytes / 1024**3
+            logger.info(
+                "ec_connector stats: hits=%d misses=%d hit_rate=%.1f%% "
+                "loads=%d saves=%d evicts=%d entries=%d used=%.2f/%.2f GB",
+                self._total_hits,
+                self._total_misses,
+                hit_rate,
+                self._total_loads,
+                self._total_saves,
+                self._total_evictions,
+                len(self._cache_order),
+                used_gb,
+                cap_gb,
             )
 
-            self._total_loads += len(self._loads_this_step)
-            self._total_saves += len(self._saves_this_step)
-
-            self._loads_this_step.clear()
-            self._saves_this_step.clear()
-            self._evicts_this_step.clear()
-
-            self._log_step += 1
-            if self._log_step % self._log_every_n_steps == 0:
-                total_lookups = self._total_hits + self._total_misses
-                hit_rate = (
-                    100.0 * self._total_hits / total_lookups if total_lookups else 0.0
-                )
-                used_gb = self._num_used_bytes / 1024**3
-                cap_gb = self._capacity_bytes / 1024**3
-                logger.info(
-                    "ec_connector stats: hits=%d misses=%d hit_rate=%.1f%% "
-                    "loads=%d saves=%d evicts=%d entries=%d used=%.2f/%.2f GB",
-                    self._total_hits,
-                    self._total_misses,
-                    hit_rate,
-                    self._total_loads,
-                    self._total_saves,
-                    self._total_evictions,
-                    len(self._cache_order),
-                    used_gb,
-                    cap_gb,
-                )
-
-            return meta
+        return meta
 
     # ==============================
     # Worker-side methods
     #
     # Called by the model runner each step with the metadata produced by
-    # build_connector_meta. The worker has no caching logic of its own;
-    # it simply obeys the scheduler's load/save/evict commands.
+    # build_connector_meta. start_load_caches dispatches H2Ds on
+    # _load_stream; get_finished_loads polls events and moves completed
+    # tensors into encoder_cache before reporting their mm_hashes.
     # ==============================
 
     def _ensure_streams(self, device: torch.device) -> None:
-        """Lazily create the save stream and lock the connector to a device.
+        """Lazily create save/load streams and lock the connector to a device.
 
         The sentinel `_already_done_event` is recorded on the save stream and
         synchronized once so subsequent .query() calls always return True. We
@@ -289,6 +338,7 @@ class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
         if self._save_stream is None:
             self._device = device
             self._save_stream = torch.cuda.Stream(device=device)
+            self._load_stream = torch.cuda.Stream(device=device)
             sentinel = torch.cuda.Event()
             sentinel.record(self._save_stream)
             self._save_stream.synchronize()
@@ -302,84 +352,95 @@ class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
     def start_load_caches(
         self, encoder_cache: dict[str, torch.Tensor], **kwargs
     ) -> None:
-        """Copy cached embeddings from CPU store to GPU encoder_cache, and evict
-        entries the scheduler marked for removal.
+        """Dispatch async H2D loads, evict requested entries.
+
+        For each mm_hash in metadata.loads:
+          - already in flight  → piggyback (no-op).
+          - resurrected orphan → already in encoder_cache, queue immediate
+            completion in get_finished_loads.
+          - fresh             → enqueue H2D on _load_stream after waiting
+            on the entry's save_done event; record load_done into both
+            ``_inflight_loads`` (for completion polling) and
+            ``entry.pending_loads`` (so the reaper waits for the read to
+            complete before freeing the cpu_tensor).
+
+        H2D does NOT call ``compute.wait_event(load_done)`` — that would
+        kill the overlap. The scheduler gates re-admission on
+        ``event.query() == True`` via get_finished_loads; once that returns
+        true, the data is GPU-globally visible per CUDA programming guide
+        §3.2.5.
+
+        ``evicts`` moves entries from the CPU store to the retired list;
+        ``evict_orphan`` removes entries from the worker's encoder_cache.
         """
         metadata = self._get_connector_metadata()
         assert isinstance(metadata, MultimodalEmbeddingCacheConnectorMetadata)
 
         compute = torch.cuda.current_stream()
-        with record_function_or_nullcontext("ec_connector: load_ensure_streams"):
-            self._ensure_streams(compute.device)
+        self._ensure_streams(compute.device)
+        load_stream = self._load_stream
+        assert load_stream is not None
 
         for mm_hash in metadata.loads:
-            with record_function_or_nullcontext("ec_connector: load_item"):
-                if mm_hash in encoder_cache:
-                    continue
-                entry = self._cpu_store.get(mm_hash)
-                if entry is None:
-                    logger.warning(
-                        "start_load_caches: hash %s not in cpu_store, skipping",
-                        mm_hash,
-                    )
-                    continue
+            if mm_hash in self._inflight_loads:
+                continue  # piggyback dedup
+            if mm_hash in encoder_cache:
+                # Same-hash orphan resurrection: a previously-completed
+                # async load whose evict_orphan was cancelled by the
+                # scheduler (because a new request hit the same hash
+                # before evict shipped). Tensor is still GPU-resident in
+                # encoder_cache. Report immediate completion.
+                self._just_resurrected.add(mm_hash)
+                continue
+            entry = self._cpu_store.get(mm_hash)
+            if entry is None:
+                logger.warning(
+                    "start_load_caches: %s not in cpu_store, skipping", mm_hash
+                )
+                continue
 
-                # Make compute wait for the prior DtoH on save_stream. For pageable
-                # entries the sentinel event is already-resolved, so this is a no-op.
-                with record_function_or_nullcontext(
-                    "ec_connector: load_wait_save_done"
-                ):
-                    compute.wait_event(entry.save_done)
+            # Make load_stream wait for the prior DtoH on save_stream. For
+            # pageable entries the sentinel event is already-resolved, so
+            # this is a no-op. Pinned entries gate the read so we never
+            # H2D from a buffer the save_stream hasn't finished writing.
+            load_stream.wait_event(entry.save_done)
+            with torch.cuda.stream(load_stream):
+                gpu_tensor = entry.cpu_tensor.to(
+                    device=compute.device, non_blocking=entry.is_pinned
+                )
+            load_done = torch.cuda.Event()
+            load_done.record(load_stream)
+            entry.pending_loads.append(load_done)
+            self._inflight_loads[mm_hash] = (gpu_tensor, load_done)
 
-                # HtoD on compute. Genuinely async for pinned; PyTorch silently
-                # falls back to sync for pageable, which is correct for that path.
-                with record_function_or_nullcontext("ec_connector: load_h2d"):
-                    gpu_tensor = entry.cpu_tensor.to(
-                        device=compute.device, non_blocking=entry.is_pinned
-                    )
+        for mm_hash in metadata.evicts:
+            entry = self._cpu_store.pop(mm_hash, None)
+            if entry is not None:
+                if entry.is_pinned:
+                    self._pinned_bytes_active -= entry.nbytes
+                    self._pinned_bytes_retired += entry.nbytes
+                self._retired.append(entry)
 
-                # Symmetric record_stream on the destination: tells the caching
-                # allocator the new tensor's storage is consumed by compute, so
-                # if vLLM pops encoder_cache[h] before compute is done, the GPU
-                # buffer is not reused early.
-                with record_function_or_nullcontext(
-                    "ec_connector: load_record_stream"
-                ):
-                    gpu_tensor.record_stream(compute)
+        # Drop orphan GPU tensors whose abandoned load completed in a
+        # prior step. The scheduler queues these via _pending_orphan_evicts
+        # in _update_from_ec_xfer_finished.
+        for mm_hash in metadata.evict_orphan:
+            encoder_cache.pop(mm_hash, None)
 
-                with record_function_or_nullcontext(
-                    "ec_connector: load_record_event"
-                ):
-                    load_done = torch.cuda.Event()
-                    load_done.record(compute)
-                    entry.pending_loads.append(load_done)
-
-                encoder_cache[mm_hash] = gpu_tensor
-
-        if metadata.evicts:
-            with record_function_or_nullcontext("ec_connector: load_evict"):
-                for mm_hash in metadata.evicts:
-                    entry = self._cpu_store.pop(mm_hash, None)
-                    if entry is not None:
-                        if entry.is_pinned:
-                            self._pinned_bytes_active -= entry.nbytes
-                            self._pinned_bytes_retired += entry.nbytes
-                        self._retired.append(entry)
-
-        with record_function_or_nullcontext("ec_connector: load_cleanup"):
-            self._prune_active_load_events()
-            self._reap_retired()
+        self._prune_active_load_events()
+        self._reap_retired()
 
         self._step_counter += 1
         if self._step_counter % self._log_every_n_steps == 0:
             logger.info(
                 "EC pinned bytes: active=%d retired=%d cap=%d "
-                "(entries=%d retired_count=%d)",
+                "(entries=%d retired_count=%d inflight=%d)",
                 self._pinned_bytes_active,
                 self._pinned_bytes_retired,
                 self._pinned_cap_bytes,
                 len(self._cpu_store),
                 len(self._retired),
+                len(self._inflight_loads),
             )
 
     def save_caches(
@@ -397,98 +458,113 @@ class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
         with the always-resolved sentinel as save_done, accounted as
         is_pinned=False so the budget is not double-counted.
         """
-        with record_function_or_nullcontext("ec_connector: save_caches"):
-            metadata = self._get_connector_metadata()
-            assert isinstance(metadata, MultimodalEmbeddingCacheConnectorMetadata)
+        metadata = self._get_connector_metadata()
+        assert isinstance(metadata, MultimodalEmbeddingCacheConnectorMetadata)
 
-            if mm_hash not in metadata.saves:
-                return
-            if mm_hash in self._cpu_store:
-                return
-            if mm_hash not in encoder_cache:
-                logger.warning(
-                    "save_caches: hash %s in metadata.saves but not in encoder_cache",
-                    mm_hash,
-                )
-                return
-
-            src = encoder_cache[mm_hash]
-            if not src.is_contiguous():
-                logger.debug(
-                    "save_caches: non-contiguous source for hash %s, materializing",
-                    mm_hash,
-                )
-                with record_function_or_nullcontext("ec_connector: save_contiguous"):
-                    src = src.contiguous()
-
-            with record_function_or_nullcontext("ec_connector: save_ensure_streams"):
-                self._ensure_streams(src.device)
-            nbytes = src.numel() * src.element_size()
-
-            over_cap = (
-                self._pinned_bytes_active + self._pinned_bytes_retired + nbytes
-                > self._pinned_cap_bytes
+        if mm_hash not in metadata.saves:
+            return
+        if mm_hash in self._cpu_store:
+            return
+        if mm_hash not in encoder_cache:
+            logger.warning(
+                "save_caches: hash %s in metadata.saves but not in encoder_cache",
+                mm_hash,
             )
-            use_pinned = self._pin_memory and not over_cap
+            return
 
-            if use_pinned:
-                with record_function_or_nullcontext(
-                    "ec_connector: save_alloc_pinned_cpu"
-                ):
-                    cpu_buf = torch.empty(
-                        src.shape, dtype=src.dtype, device="cpu", pin_memory=True
-                    )
-                compute = torch.cuda.current_stream(src.device)
-                assert self._save_stream is not None
-                with record_function_or_nullcontext(
-                    "ec_connector: save_wait_compute"
-                ):
-                    self._save_stream.wait_stream(compute)
-                with torch.cuda.stream(self._save_stream):
-                    with record_function_or_nullcontext(
-                        "ec_connector: save_d2h_async_enqueue"
-                    ):
-                        cpu_buf.copy_(src, non_blocking=True)
-                        # Symmetric record_stream on the source: protects the GPU
-                        # source memory in case vLLM pops encoder_cache[h] before the
-                        # async DtoH finishes.
-                        src.record_stream(self._save_stream)
-                with record_function_or_nullcontext(
-                    "ec_connector: save_record_event"
-                ):
-                    save_done = torch.cuda.Event()
-                    save_done.record(self._save_stream)
-                self._cpu_store[mm_hash] = _CpuEntry(
-                    cpu_tensor=cpu_buf,
-                    save_done=save_done,
-                    nbytes=nbytes,
-                    is_pinned=True,
-                )
-                self._pinned_bytes_active += nbytes
-            else:
-                if over_cap:
-                    logger.warning(
-                        "save_caches: pinned budget exceeded "
-                        "(active=%d retired=%d new=%d cap=%d); "
-                        "falling back to sync DtoH for hash %s",
-                        self._pinned_bytes_active,
-                        self._pinned_bytes_retired,
-                        nbytes,
-                        self._pinned_cap_bytes,
-                        mm_hash,
-                    )
-                assert self._already_done_event is not None
-                with record_function_or_nullcontext("ec_connector: save_d2h_sync"):
-                    cpu_tensor = src.cpu()
-                self._cpu_store[mm_hash] = _CpuEntry(
-                    cpu_tensor=cpu_tensor,
-                    save_done=self._already_done_event,
-                    nbytes=nbytes,
-                    is_pinned=False,
-                )
+        src = encoder_cache[mm_hash]
+        if not src.is_contiguous():
+            logger.debug(
+                "save_caches: non-contiguous source for hash %s, materializing",
+                mm_hash,
+            )
+            src = src.contiguous()
 
-            with record_function_or_nullcontext("ec_connector: save_reap_retired"):
-                self._reap_retired()
+        self._ensure_streams(src.device)
+        nbytes = src.numel() * src.element_size()
+
+        over_cap = (
+            self._pinned_bytes_active + self._pinned_bytes_retired + nbytes
+            > self._pinned_cap_bytes
+        )
+        use_pinned = self._pin_memory and not over_cap
+
+        if use_pinned:
+            cpu_buf = torch.empty(
+                src.shape, dtype=src.dtype, device="cpu", pin_memory=True
+            )
+            compute = torch.cuda.current_stream(src.device)
+            assert self._save_stream is not None
+            self._save_stream.wait_stream(compute)
+            with torch.cuda.stream(self._save_stream):
+                cpu_buf.copy_(src, non_blocking=True)
+                # Symmetric record_stream on the source: protects the GPU
+                # source memory in case vLLM pops encoder_cache[h] before the
+                # async DtoH finishes.
+                src.record_stream(self._save_stream)
+            save_done = torch.cuda.Event()
+            save_done.record(self._save_stream)
+            self._cpu_store[mm_hash] = _CpuEntry(
+                cpu_tensor=cpu_buf,
+                save_done=save_done,
+                nbytes=nbytes,
+                is_pinned=True,
+            )
+            self._pinned_bytes_active += nbytes
+        else:
+            if over_cap:
+                logger.warning(
+                    "save_caches: pinned budget exceeded "
+                    "(active=%d retired=%d new=%d cap=%d); "
+                    "falling back to sync DtoH for hash %s",
+                    self._pinned_bytes_active,
+                    self._pinned_bytes_retired,
+                    nbytes,
+                    self._pinned_cap_bytes,
+                    mm_hash,
+                )
+            assert self._already_done_event is not None
+            self._cpu_store[mm_hash] = _CpuEntry(
+                cpu_tensor=src.cpu(),
+                save_done=self._already_done_event,
+                nbytes=nbytes,
+                is_pinned=False,
+            )
+
+        self._reap_retired()
+
+    def get_finished_loads(
+        self,
+        encoder_cache: dict[str, torch.Tensor] | None = None,
+    ) -> set[str] | None:
+        """Per-mm_hash async-load completion signal.
+
+        Returns the set of mm_hashes whose H2D has retired since the last
+        call PLUS any hashes resurrected from orphan tensors during this
+        step's start_load_caches. Each completed tensor is moved into
+        ``encoder_cache[mm_hash]`` BEFORE its hash is added to the returned
+        set, so the next consumer step's _gather_mm_embeddings sees the
+        GPU-resident tensor.
+        """
+        finished: set[str] = set(self._just_resurrected)
+        self._just_resurrected.clear()
+
+        if self._inflight_loads and encoder_cache is not None:
+            ready = [h for h, (_, ev) in self._inflight_loads.items() if ev.query()]
+            for h in ready:
+                tensor, _ = self._inflight_loads.pop(h)
+                # Per design: move the tensor into encoder_cache BEFORE
+                # reporting completion. If the request that prompted this
+                # load has aborted, the scheduler will have transitioned
+                # state to ABANDONED; on receipt of finished_loading={h}
+                # it will pop the entry and queue evict_orphan.
+                # We optimistically place the tensor here; ABANDONED clean
+                # up happens on the next step's start_load_caches via
+                # evict_orphan, which will pop encoder_cache[h] there.
+                encoder_cache[h] = tensor
+                finished.add(h)
+
+        return finished if finished else None
 
     def _prune_active_load_events(self) -> None:
         """Drop resolved load events from active entries to bound the list size."""

--- a/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_multimodal_embedding_cache_connector_cuda.py
+++ b/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_multimodal_embedding_cache_connector_cuda.py
@@ -1,0 +1,368 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CUDA-side unit tests for DynamoMultimodalEmbeddingCacheConnector.
+
+These tests exercise the worker-side async-save / async-load lifecycle:
+DtoH on a dedicated stream with pinned host buffers, HtoD on compute with
+record_stream protection, retired-list reaping gated on save+load events,
+and the pinned-budget cap fallback.
+
+Markers: gpu_1 (single CUDA device required). The CPU-only scheduler-side
+tests live in test_vllm_multimodal_embedding_cache_connector.py.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+from dynamo.vllm.multimodal_utils import multimodal_embedding_cache_connector as mod
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.vllm,
+    pytest.mark.gpu_1,
+    pytest.mark.multimodal,
+]
+
+
+def _make_vllm_config(
+    capacity_gb: float = 0.001,
+    pin_memory: bool = True,
+    pinned_overhead_pct: float = 25.0,
+) -> MagicMock:
+    config = MagicMock()
+    config.ec_transfer_config.ec_connector_extra_config = {
+        "multimodal_embedding_cache_capacity_gb": capacity_gb,
+        "pin_memory": pin_memory,
+        "pinned_overhead_pct": pinned_overhead_pct,
+    }
+    config.model_config.get_hidden_size.return_value = 64
+    config.model_config.dtype = torch.float16
+    return config
+
+
+def _make_connector(
+    capacity_gb: float = 0.001,
+    pin_memory: bool = True,
+    pinned_overhead_pct: float = 25.0,
+) -> mod.DynamoMultimodalEmbeddingCacheConnector:
+    with patch.object(mod.ECConnectorBase, "__init__", return_value=None):
+        return mod.DynamoMultimodalEmbeddingCacheConnector(
+            vllm_config=_make_vllm_config(
+                capacity_gb=capacity_gb,
+                pin_memory=pin_memory,
+                pinned_overhead_pct=pinned_overhead_pct,
+            ),
+            role=MagicMock(),
+        )
+
+
+def _set_metadata(
+    conn: mod.DynamoMultimodalEmbeddingCacheConnector,
+    *,
+    loads: list[str] | None = None,
+    saves: list[str] | None = None,
+    evicts: list[str] | None = None,
+) -> mod.MultimodalEmbeddingCacheConnectorMetadata:
+    md = mod.MultimodalEmbeddingCacheConnectorMetadata(
+        loads=loads or [],
+        saves=saves or [],
+        evicts=evicts or [],
+    )
+    conn._get_connector_metadata = lambda: md  # type: ignore[method-assign]
+    return md
+
+
+@pytest.fixture(scope="module")
+def device() -> torch.device:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+    return torch.device("cuda", torch.cuda.current_device())
+
+
+class TestSaveLoadRoundTrip:
+    """Save → load → encoder_cache equality on the pinned and pageable paths."""
+
+    def _save_then_load(
+        self,
+        conn: mod.DynamoMultimodalEmbeddingCacheConnector,
+        device: torch.device,
+        mm_hash: str,
+        src: torch.Tensor,
+    ) -> torch.Tensor:
+        encoder_cache: dict[str, torch.Tensor] = {mm_hash: src}
+        _set_metadata(conn, saves=[mm_hash])
+        conn.save_caches(encoder_cache, mm_hash)
+
+        encoder_cache.pop(mm_hash)
+        _set_metadata(conn, loads=[mm_hash])
+        conn.start_load_caches(encoder_cache)
+
+        torch.cuda.synchronize(device)
+        return encoder_cache[mm_hash]
+
+    def test_pinned_path(self, device):
+        conn = _make_connector(pin_memory=True)
+        src = torch.randn(8, 64, dtype=torch.float16, device=device)
+        loaded = self._save_then_load(conn, device, "h0", src)
+
+        assert loaded.device == device
+        assert torch.equal(loaded, src)
+        assert conn._cpu_store["h0"].is_pinned is True
+        assert conn._cpu_store["h0"].cpu_tensor.is_pinned()
+        assert conn._pinned_bytes_active == src.numel() * src.element_size()
+
+    def test_pageable_path(self, device):
+        conn = _make_connector(pin_memory=False)
+        src = torch.randn(8, 64, dtype=torch.float16, device=device)
+        loaded = self._save_then_load(conn, device, "h0", src)
+
+        assert torch.equal(loaded, src)
+        assert conn._cpu_store["h0"].is_pinned is False
+        assert not conn._cpu_store["h0"].cpu_tensor.is_pinned()
+        # Pageable path is never accounted against the pinned budget.
+        assert conn._pinned_bytes_active == 0
+
+
+class TestRetiredReaping:
+    """Eviction never blocks; retired entries are released only when save+loads
+    have drained. We mock event.query so the test is deterministic regardless
+    of how fast the device is."""
+
+    def _stub_event(self, query_result: bool) -> MagicMock:
+        event = MagicMock(spec=torch.cuda.Event)
+        event.query.return_value = query_result
+        return event
+
+    def test_evict_does_not_free_pending_save(self, device):
+        conn = _make_connector(pin_memory=True)
+        src = torch.randn(4, 64, dtype=torch.float16, device=device)
+
+        encoder_cache: dict[str, torch.Tensor] = {"h0": src}
+        _set_metadata(conn, saves=["h0"])
+        conn.save_caches(encoder_cache, "h0")
+
+        # Force save_done to look unfinished, then evict.
+        entry = conn._cpu_store["h0"]
+        entry.save_done = self._stub_event(False)
+        nbytes = entry.nbytes
+
+        _set_metadata(conn, evicts=["h0"])
+        conn.start_load_caches({})
+
+        # Bytes moved active → retired but the entry is still on _retired
+        # because its save event has not resolved.
+        assert "h0" not in conn._cpu_store
+        assert len(conn._retired) == 1
+        assert conn._pinned_bytes_active == 0
+        assert conn._pinned_bytes_retired == nbytes
+
+        # Resolve the event; reap drains the entry and clears retired bytes.
+        conn._retired[0].save_done = self._stub_event(True)
+        conn._reap_retired()
+        assert conn._retired == []
+        assert conn._pinned_bytes_retired == 0
+
+    def test_evict_does_not_free_pending_load(self, device):
+        conn = _make_connector(pin_memory=True)
+        src = torch.randn(4, 64, dtype=torch.float16, device=device)
+
+        encoder_cache: dict[str, torch.Tensor] = {"h0": src}
+        _set_metadata(conn, saves=["h0"])
+        conn.save_caches(encoder_cache, "h0")
+
+        # Inject an unfinished pending load; save_done resolved (real event).
+        entry = conn._cpu_store["h0"]
+        torch.cuda.synchronize(device)
+        unresolved = self._stub_event(False)
+        entry.pending_loads.append(unresolved)
+
+        _set_metadata(conn, evicts=["h0"])
+        conn.start_load_caches({})
+
+        assert len(conn._retired) == 1
+        assert conn._pinned_bytes_retired == entry.nbytes
+
+        # Pending load remains; reap is a no-op.
+        conn._reap_retired()
+        assert len(conn._retired) == 1
+
+        # Resolve the load; reap drains.
+        unresolved.query.return_value = True
+        conn._reap_retired()
+        assert conn._retired == []
+        assert conn._pinned_bytes_retired == 0
+
+
+class TestRecordStream:
+    """Verify that the GPU source (save) tensor has record_stream invoked with
+    the save stream. The destination-side record_stream is exercised
+    functionally by TestRoundTripUnderConsumerPop.
+
+    Tensor instance attributes shadow methods in CPython attribute lookup, so
+    we can spy by assigning a closure to src.record_stream directly.
+    """
+
+    def test_save_records_src_on_save_stream(self, device):
+        conn = _make_connector(pin_memory=True)
+        src = torch.randn(4, 64, dtype=torch.float16, device=device)
+
+        record_calls: list[torch.cuda.Stream] = []
+        original = src.record_stream
+
+        def capture(stream):
+            record_calls.append(stream)
+            return original(stream)
+
+        src.record_stream = capture  # type: ignore[method-assign]
+
+        encoder_cache: dict[str, torch.Tensor] = {"h0": src}
+        _set_metadata(conn, saves=["h0"])
+        conn.save_caches(encoder_cache, "h0")
+
+        assert len(record_calls) == 1
+        assert record_calls[0] is conn._save_stream
+
+
+class TestRoundTripUnderConsumerPop:
+    """Functional regression for record_stream protection.
+
+    Source-side: while the async DtoH is in flight, vLLM pops encoder_cache[h]
+    and drops its reference. The caching allocator could reuse the GPU source
+    storage immediately; src.record_stream(save_stream) is what holds it alive
+    until save_done resolves. After sync, the CPU copy must still equal the
+    original.
+
+    Destination-side: while compute is mid-kernel using the loaded GPU
+    tensor, vLLM pops encoder_cache[h]. gpu_tensor.record_stream(compute)
+    keeps the destination storage alive until compute drains. The matmul
+    result must still equal the reference.
+    """
+
+    def test_save_pop_then_sync_content_correct(self, device):
+        conn = _make_connector(pin_memory=True)
+        original = torch.randn(64, 64, dtype=torch.float16, device=device)
+        src = original.clone()
+
+        encoder_cache: dict[str, torch.Tensor] = {"h0": src}
+        _set_metadata(conn, saves=["h0"])
+        conn.save_caches(encoder_cache, "h0")
+
+        del encoder_cache["h0"]
+        del src
+
+        # Allocator pressure on compute before we sync save_stream.
+        for _ in range(8):
+            _ = torch.randn(64, 64, dtype=torch.float16, device=device)
+
+        torch.cuda.synchronize(device)
+        cpu_buf = conn._cpu_store["h0"].cpu_tensor
+        assert torch.equal(cpu_buf, original.cpu())
+
+    def test_load_pop_then_compute_consumer_correct(self, device):
+        conn = _make_connector(pin_memory=True)
+        original = torch.randn(64, 64, dtype=torch.float16, device=device)
+
+        encoder_cache: dict[str, torch.Tensor] = {"h0": original.clone()}
+        _set_metadata(conn, saves=["h0"])
+        conn.save_caches(encoder_cache, "h0")
+        encoder_cache.pop("h0")
+        torch.cuda.synchronize(device)
+
+        _set_metadata(conn, loads=["h0"])
+        conn.start_load_caches(encoder_cache)
+
+        # Queue a compute consumer on the loaded tensor; this is enqueued on
+        # the compute stream right after the HtoD. The result owns its own
+        # storage but its computation still reads from gpu_tensor's storage.
+        gpu_tensor = encoder_cache["h0"]
+        result = gpu_tensor.float() @ gpu_tensor.float().t()
+
+        # Drop both references to gpu_tensor's storage.
+        del encoder_cache["h0"]
+        del gpu_tensor
+
+        # Allocator pressure before sync. Without record_stream(compute) on the
+        # gpu_tensor, the allocator could reuse the storage while the matmul
+        # is still reading from it.
+        for _ in range(8):
+            _ = torch.randn(64, 64, dtype=torch.float16, device=device)
+
+        torch.cuda.synchronize(device)
+        expected = original.float() @ original.float().t()
+        assert torch.allclose(result, expected, rtol=1e-3, atol=1e-3)
+
+
+class TestMixedHitsAndMisses:
+    def test_mixed_step(self, device):
+        conn = _make_connector(pin_memory=True)
+        # Pre-populate one entry to be loaded.
+        src_a = torch.randn(4, 64, dtype=torch.float16, device=device)
+        src_b = torch.randn(4, 64, dtype=torch.float16, device=device)
+
+        _set_metadata(conn, saves=["a"])
+        conn.save_caches({"a": src_a}, "a")
+        torch.cuda.synchronize(device)
+
+        # Now simulate one step: load "a" from CPU, save "b" newly computed.
+        # Note: save and load happen via different metadata in real vLLM, so we
+        # exercise them sequentially — first save (per-hash), then load.
+        _set_metadata(conn, saves=["b"])
+        conn.save_caches({"b": src_b}, "b")
+
+        encoder_cache: dict[str, torch.Tensor] = {}
+        _set_metadata(conn, loads=["a"])
+        conn.start_load_caches(encoder_cache)
+        torch.cuda.synchronize(device)
+
+        assert torch.equal(encoder_cache["a"], src_a)
+        assert "a" in conn._cpu_store
+        assert "b" in conn._cpu_store
+
+
+class TestPinnedCapFallback:
+    """When the pinned budget would be exceeded the next save takes the
+    pageable sync path. The breaching entry must be flagged is_pinned=False
+    and must NOT be added to the pinned-bytes counter."""
+
+    def test_over_cap_falls_back(self, device):
+        # Use overhead=0 so the cap equals capacity_bytes exactly. Each save
+        # is 4×64×2 = 512 bytes; cap is set to 512 bytes too. First save:
+        # 0+0+512 > 512 is False → pinned. Second save: 512+0+512 > 512 is
+        # True → pageable fallback.
+        conn = _make_connector(capacity_gb=512 / (1024**3), pinned_overhead_pct=0.0)
+
+        src1 = torch.randn(4, 64, dtype=torch.float16, device=device)
+        src2 = torch.randn(4, 64, dtype=torch.float16, device=device)
+
+        _set_metadata(conn, saves=["h1"])
+        conn.save_caches({"h1": src1}, "h1")
+        first_active = conn._pinned_bytes_active
+
+        _set_metadata(conn, saves=["h2"])
+        conn.save_caches({"h2": src2}, "h2")
+        torch.cuda.synchronize(device)
+
+        # First entry is pinned and counted; second is pageable and uncounted.
+        assert conn._cpu_store["h1"].is_pinned is True
+        assert conn._cpu_store["h2"].is_pinned is False
+        assert conn._pinned_bytes_active == first_active
+        assert torch.equal(conn._cpu_store["h2"].cpu_tensor, src2.cpu())
+
+
+class TestSingleDeviceLock:
+    def test_second_device_assertion(self, device):
+        if torch.cuda.device_count() < 2:
+            pytest.skip("Requires ≥2 CUDA devices")
+
+        conn = _make_connector(pin_memory=True)
+        src0 = torch.randn(4, 64, dtype=torch.float16, device=torch.device("cuda", 0))
+        _set_metadata(conn, saves=["h0"])
+        conn.save_caches({"h0": src0}, "h0")
+
+        src1 = torch.randn(4, 64, dtype=torch.float16, device=torch.device("cuda", 1))
+        _set_metadata(conn, saves=["h1"])
+        with pytest.raises(AssertionError, match="bound to device"):
+            conn.save_caches({"h1": src1}, "h1")

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -28,7 +28,7 @@ use futures::stream::{self, StreamExt};
 use prompt::OAIPromptFormatter;
 use std::time::{Duration, Instant};
 
-use dynamo_runtime::dynamo_nvtx_range;
+use dynamo_runtime::{dynamo_nvtx_range, dynamo_nvtx_range_async};
 use dynamo_runtime::metrics::frontend_perf::{
     DETOKENIZE_TOKEN_COUNT, DETOKENIZE_TOTAL_US, STAGE_DURATION_SECONDS, STAGE_PREPROCESS,
     StageGuard, TEMPLATE_SECONDS, TOKENIZE_SECONDS,
@@ -482,8 +482,15 @@ impl OpenAIPreprocessor {
             }
         }
 
-        // Execute all fetch tasks
+        // Execute all fetch tasks. Uses the handle-based NVTX guard
+        // (dynamo_nvtx_range_async!) — the stack-based dynamo_nvtx_range! is
+        // unsafe across the .await below: when the tokio runtime parks this
+        // task, its push/pop depth gets entangled with other concurrent
+        // tasks that land on the same worker, producing spurious nested
+        // ranges in the nsys trace. The handle-based range uses a stored
+        // nvtxRangeId_t so the end call is not thread-local.
         if !fetch_tasks.is_empty() {
+            let _nvtx_batch = dynamo_nvtx_range_async!("mm:frontend:decode:batch");
             let loader = self.media_loader.as_ref().unwrap();
             let media_io_kwargs = request.media_io_kwargs();
             let results = futures::future::join_all(fetch_tasks.iter().map(|(_, content_part)| {

--- a/lib/llm/src/preprocessor/media/decoders/image.rs
+++ b/lib/llm/src/preprocessor/media/decoders/image.rs
@@ -4,6 +4,7 @@
 use std::io::Cursor;
 
 use anyhow::Result;
+use dynamo_runtime::dynamo_nvtx_range;
 use image::{ColorType, GenericImageView, ImageFormat, ImageReader};
 use ndarray::Array3;
 use serde::{Deserialize, Serialize};
@@ -71,7 +72,12 @@ impl Decoder for ImageDecoder {
     }
 
     fn decode(&self, data: EncodedMediaData) -> Result<DecodedMediaData> {
-        let bytes = data.into_bytes()?;
+        let _nvtx_image = dynamo_nvtx_range!("mm:frontend:decode:image");
+
+        let bytes = {
+            let _nvtx_b64 = dynamo_nvtx_range!("mm:frontend:decode:b64");
+            data.into_bytes()?
+        };
 
         let mut reader = ImageReader::new(Cursor::new(bytes)).with_guessed_format()?;
         let mut limits = image::Limits::no_limits();
@@ -82,7 +88,10 @@ impl Decoder for ImageDecoder {
 
         let format = reader.format();
 
-        let img = reader.decode()?;
+        let img = {
+            let _nvtx_px = dynamo_nvtx_range!("mm:frontend:decode:pixels");
+            reader.decode()?
+        };
         let n_channels = img.color().channel_count();
 
         let (data, color_type) = match n_channels {

--- a/lib/runtime/src/nvtx.rs
+++ b/lib/runtime/src/nvtx.rs
@@ -152,6 +152,63 @@ impl Drop for NvtxRangeGuard {
     fn drop(&mut self) {}
 }
 
+// ── Async-safe RAII guard (handle-based, not thread-local) ───────────────────
+
+/// RAII guard over a handle-based NVTX range (`nvtxRangeStart`/`nvtxRangeEnd`).
+///
+/// Unlike [`NvtxRangeGuard`] (which uses `nvtxRangePush`/`nvtxRangePop` — a
+/// thread-local LIFO stack), this guard stores an `nvtxRangeId_t` handle at
+/// start and passes it to `nvtxRangeEnd` at drop. The end call is therefore
+/// **not** tied to the starting thread, so the guard is safe to carry across
+/// `.await` points where the tokio runtime may migrate the task between
+/// worker threads.
+///
+/// Construct with [`dynamo_nvtx_range_async!`].
+#[cfg(feature = "nvtx")]
+pub struct NvtxAsyncRangeGuard {
+    id: Option<u64>,
+}
+
+/// Zero-sized no-op guard used when the `nvtx` feature is off.
+#[cfg(not(feature = "nvtx"))]
+pub struct NvtxAsyncRangeGuard;
+
+impl NvtxAsyncRangeGuard {
+    #[doc(hidden)]
+    pub fn new(name: &str) -> Self {
+        #[cfg(feature = "nvtx")]
+        {
+            let id = if NVTX_ENABLED.load(Ordering::Relaxed) {
+                Some(cudarc::nvtx::result::range_start(name))
+            } else {
+                None
+            };
+            return NvtxAsyncRangeGuard { id };
+        }
+        #[cfg(not(feature = "nvtx"))]
+        {
+            let _ = name;
+            NvtxAsyncRangeGuard {}
+        }
+    }
+}
+
+#[cfg(feature = "nvtx")]
+impl Drop for NvtxAsyncRangeGuard {
+    fn drop(&mut self) {
+        if let Some(id) = self.id.take() {
+            // SAFETY: `id` was produced by a matching `range_start` above and
+            // is ended exactly once (Drop runs at most once).
+            unsafe { cudarc::nvtx::result::range_end(id) }
+        }
+    }
+}
+
+#[cfg(not(feature = "nvtx"))]
+impl Drop for NvtxAsyncRangeGuard {
+    fn drop(&mut self) {}
+}
+
 // ── Macros ───────────────────────────────────────────────────────────────────
 
 /// Push a named NVTX range onto the calling thread's stack.
@@ -183,6 +240,29 @@ macro_rules! dynamo_nvtx_pop {
 macro_rules! dynamo_nvtx_range {
     ($name:expr) => {
         $crate::nvtx::NvtxRangeGuard::new($name)
+    };
+}
+
+/// Open a named NVTX range that closes automatically at end of scope, using
+/// the handle-based (`nvtxRangeStart`/`nvtxRangeEnd`) API.
+///
+/// Unlike [`dynamo_nvtx_range!`] (stack-based push/pop, thread-local), this
+/// variant is safe to carry across `.await` — the end call uses a stored
+/// handle and is not tied to the thread that started the range. Use this
+/// for NVTX spans that wrap async code that may park and resume on a
+/// different worker thread, or that may interleave with other concurrent
+/// tasks' ranges on the same thread.
+///
+/// ```rust,ignore
+/// let _r = dynamo_nvtx_range_async!("mm:frontend:decode:batch");
+/// let results = futures::future::join_all(...).await;  // safe across await
+/// // range closes here
+/// ```
+/// Zero-cost when the `nvtx` Cargo feature is off.
+#[macro_export]
+macro_rules! dynamo_nvtx_range_async {
+    ($name:expr) => {
+        $crate::nvtx::NvtxAsyncRangeGuard::new($name)
     };
 }
 

--- a/tests/benchmarks/multimodal/sweep/test_server.py
+++ b/tests/benchmarks/multimodal/sweep/test_server.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import signal
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from benchmarks.multimodal.sweep import server as srv
+from benchmarks.multimodal.sweep.server import ServerManager
+
+pytestmark = [pytest.mark.unit, pytest.mark.pre_merge, pytest.mark.gpu_0]
+
+
+def _mgr_with_mock_proc(mock_proc: MagicMock) -> ServerManager:
+    mgr = ServerManager()
+    mgr._process = mock_proc
+    return mgr
+
+
+def test_stop_sends_sigint_not_sigterm() -> None:
+    """stop() must send SIGINT directly to the wrapper (not SIGTERM, not killpg).
+
+    SIGINT is the documented signal that the wrapper's `trap cleanup INT TERM`
+    forwards to nsys for graceful finalize. Broadcasting SIGTERM via killpg
+    would race the trap and may skip nsys finalize.
+    """
+    proc = MagicMock(spec=subprocess.Popen)
+    proc.pid = 12345
+    proc.wait.return_value = 0
+    mgr = _mgr_with_mock_proc(proc)
+
+    with patch.object(srv, "time") as mock_time:
+        mgr.stop()
+        mock_time.sleep.assert_called_with(srv._LEASE_DRAIN_SECS)
+
+    proc.send_signal.assert_called_once_with(signal.SIGINT)
+    proc.terminate.assert_not_called()
+    proc.kill.assert_not_called()
+
+
+def test_stop_waits_full_graceful_window() -> None:
+    """stop() must wait at least the wrapper's 150 s cleanup budget."""
+    proc = MagicMock(spec=subprocess.Popen)
+    proc.pid = 12345
+    proc.wait.return_value = 0
+    mgr = _mgr_with_mock_proc(proc)
+
+    with patch.object(srv, "time"):
+        mgr.stop()
+
+    proc.wait.assert_called_once()
+    timeout = proc.wait.call_args.kwargs.get("timeout") or proc.wait.call_args.args[0]
+    assert timeout >= 150, f"wait timeout {timeout}s is below wrapper's 150s budget"
+
+
+def test_stop_tree_kills_on_timeout() -> None:
+    """If the wrapper doesn't exit, stop() escalates to tree-kill."""
+    proc = MagicMock(spec=subprocess.Popen)
+    proc.pid = 12345
+    proc.wait.side_effect = [
+        subprocess.TimeoutExpired("wrapper", srv._GRACEFUL_STOP_TIMEOUT_SECS),
+        0,
+    ]
+    mgr = _mgr_with_mock_proc(proc)
+
+    with (
+        patch.object(srv, "_tree_kill") as mock_tk,
+        patch.object(srv, "time"),
+    ):
+        mgr.stop()
+
+    mock_tk.assert_called_once_with(12345)
+
+
+def test_stop_drains_lease_after_clean_exit() -> None:
+    """The trailing sleep must equal _LEASE_DRAIN_SECS so the next config
+    cannot observe stale etcd state from the prior config's lease."""
+    proc = MagicMock(spec=subprocess.Popen)
+    proc.pid = 12345
+    proc.wait.return_value = 0
+    mgr = _mgr_with_mock_proc(proc)
+
+    with patch.object(srv, "time") as mock_time:
+        mgr.stop()
+
+    sleep_calls = [c.args[0] for c in mock_time.sleep.call_args_list]
+    assert srv._LEASE_DRAIN_SECS in sleep_calls
+    assert srv._LEASE_DRAIN_SECS >= 10, "lease drain must exceed primary lease TTL"
+
+
+def test_stop_is_noop_when_not_running() -> None:
+    mgr = ServerManager()
+    assert mgr._process is None
+    mgr.stop()  # must not raise
+
+
+def test_descendants_walks_proc_tree() -> None:
+    """_descendants returns the transitive child PIDs from /proc."""
+    fake_tree = {1000: 1, 2000: 1000, 3000: 2000, 4000: 999}
+
+    def fake_read_ppid(pid: int) -> int | None:
+        return fake_tree.get(pid)
+
+    with (
+        patch.object(srv, "_read_ppid", side_effect=fake_read_ppid),
+        patch.object(srv.os.path, "isdir", return_value=True),
+        patch.object(
+            srv.os, "listdir", return_value=[str(p) for p in fake_tree.keys()]
+        ),
+    ):
+        out = sorted(srv._descendants(1000))
+
+    assert out == [2000, 3000]

--- a/tests/report_pytest_markers.py
+++ b/tests/report_pytest_markers.py
@@ -202,6 +202,7 @@ STUB_MODULES = [
     "vllm.entrypoints.openai.engine.protocol",
     "vllm.inputs",
     "vllm.logprobs",
+    "vllm.logger",
     "vllm.lora",
     "vllm.lora.request",
     "vllm.multimodal",


### PR DESCRIPTION
## Summary

- Layers a **scheduler-driven async-load** path on top of the async DtoH/HtoD perf base. Pairs with an upstream vLLM patch that adds `WAITING_FOR_EMBEDDINGS` park-and-resume + `request_async_load` / `get_finished_loads` hooks.
- `has_cache_item` returns `(True, True)` on hit → opts into scheduler park-and-resume. `request_async_load` records the load without invoking `encoder_cache_manager.allocate`; scheduler tracks slot reservation via its inflight-async-embeds budget.
- Worker now owns a **second dedicated `_load_stream`** for HtoD (separate from the perf base's `_save_stream`). Loads gate on `entry.save_done` but deliberately do NOT issue `compute.wait_event(load_done)` — that would kill the overlap. Cross-stream visibility after `event.query() == True` is guaranteed by CUDA semantics; scheduler gates re-admission on that.
- `get_finished_loads` polls events, moves completed tensors into `encoder_cache` before reporting, emits `_just_resurrected` hashes for the same-hash orphan-rescue path. `metadata.evict_orphan` honored in `start_load_caches`.
- Stacks on top of #9102 (`qiwa/ec-async-dynamo-only`'s perf base) and #8235 (`qiwa/benchmark-repro-docs`'s instrument-only baseline). 2 connector commits.

**Difference from #9102 (`qiwa/ec-async-dynamo-only`):** that branch is connector-only (no upstream vLLM patch needed); this one requires the upstream vLLM scheduler-driven async-load patch.

## Test plan

- Run multimodal benchmark sweep on H100 with the upstream vLLM patch applied: `benchmarks/multimodal/sweep/experiments/embedding_cache/sweep_smoke_2b.yaml`
- Verify `dynamo-fd-ec` config beats `dynamo-fd` on TTFT/throughput by ≥10% on warm-cache workloads (sliding-window dataset, 30u_3t_5w)
- Validate `_load_stream` HtoD overlaps with compute in nsys (no compute stall on `entry.save_done` wait under steady state)
- Same-hash orphan-rescue: trigger via cancel mid-load, verify `_just_resurrected` path reuses the H2D buffer
- Worker-side `ec_connector worker:` periodic log shows non-blocking reaping

🤖 Generated with [Claude Code](https://claude.com/claude-code)