### PR TITLE
fix(llm): bind agent tool event ingest

### DIFF
--- a/docs/agents/agent-context.md
+++ b/docs/agents/agent-context.md
@@ -52,8 +52,8 @@ This writes files like:
 /tmp/dynamo-agent-trace.000001.jsonl.gz
 ```
 
-To ingest harness tool events, also configure the local ZMQ endpoint that the
-harness will publish on:
+To ingest harness tool events, also configure the local ZMQ endpoint that Dynamo
+will bind. Harness processes connect to this endpoint as producers:
 
 ```bash
 export DYN_AGENT_TRACE_TOOL_EVENTS_ZMQ_ENDPOINT=tcp://127.0.0.1:20390
@@ -73,8 +73,8 @@ Then start any Dynamo OpenAI-compatible backend.
 | `DYN_AGENT_TRACE_JSONL_FLUSH_INTERVAL_MS`  |                  No                  | `1000`      | JSONL periodic flush interval. For `jsonl_gz`, each flush appends a complete gzip member.                                                         |
 | `DYN_AGENT_TRACE_JSONL_GZ_ROLL_BYTES`      |                  No                  | `268435456` | `jsonl_gz` segment roll threshold in uncompressed bytes.                                                                                          |
 | `DYN_AGENT_TRACE_JSONL_GZ_ROLL_LINES`      |                  No                  | unset       | Optional `jsonl_gz` segment roll threshold in records.                                                                                            |
-| `DYN_AGENT_TRACE_TOOL_EVENTS_ZMQ_ENDPOINT` |                  No                  | unset       | Local ZMQ endpoint for harness tool events. Setting this enables tool event ingestion.                                                            |
-| `DYN_AGENT_TRACE_TOOL_EVENTS_ZMQ_TOPIC`    |                  No                  | unset       | Optional ZMQ topic filter for harness tool events.                                                                                                |
+| `DYN_AGENT_TRACE_TOOL_EVENTS_ZMQ_ENDPOINT` |                  No                  | unset       | Local ZMQ PULL endpoint that Dynamo binds for harness tool events. Setting this enables tool event ingestion.                                      |
+| `DYN_AGENT_TRACE_TOOL_EVENTS_ZMQ_TOPIC`    |                  No                  | unset       | Optional topic filter applied to the first ZMQ message frame.                                                                                     |
 
 </details>
 
@@ -138,10 +138,10 @@ def instrument_llm_request(kwargs, agent_context):
 
 ## Step 3: Send Tool Events to Dynamo
 
-Harnesses bind a long-lived local ZMQ PUB socket and publish tool lifecycle
-records on the configured endpoint. Dynamo accepts `tool_start`, `tool_end`, and
-`tool_error` records from the harness and writes them to the same trace stream
-as LLM request records.
+Harnesses connect a long-lived local ZMQ PUSH socket and publish tool lifecycle
+records to the endpoint Dynamo binds. Dynamo accepts `tool_start`, `tool_end`,
+and `tool_error` records from the harness and writes them to the same trace
+stream as LLM request records.
 
 The ZMQ wire format is:
 
@@ -149,31 +149,34 @@ The ZMQ wire format is:
 [topic, seq_be_u64, msgpack(AgentTraceRecord)]
 ```
 
-Use the same producer pattern as our KV event publisher pattern in [vllm](https://github.com/vllm-project/vllm/blob/399005a986a2b99f435919777427b6d73d36a277/vllm/distributed/kv_events.py#L103) and [SGLang](https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/disaggregation/kv_events.py): a bounded queue, a background
-publisher thread, monotonically increasing sequence numbers, and a PUB socket
-with a high-water mark. Plain ZMQ PUB/SUB is best-effort for early frames, so a
-terminal tool record should be self-contained with `started_at_unix_ms`,
-`ended_at_unix_ms`, and `duration_ms`. Keep `tool_start` for live/in-flight
+Use a bounded queue, a background publisher thread, monotonically increasing
+sequence numbers, and a PUSH socket with a high-water mark. Terminal tool
+records should be self-contained with `started_at_unix_ms`, `ended_at_unix_ms`,
+and `duration_ms` because queue pressure, process exits, or network failures can
+still drop earlier `tool_start` records. Keep `tool_start` for live/in-flight
 status, but do not require it to reconstruct completed spans.
 
-### Publisher Ownership
+### Endpoint Ownership
 
-Most framework integrations should create one exporter per harness or runtime
-instance. In-process systems, such as callback or middleware integrations, can
-emit records directly into the root queued publisher.
+Dynamo owns the shared ZMQ bind. Harnesses are producers and only connect.
 
-If a harness runs tools or subagents in child processes, do not let each child
-bind the same ZMQ endpoint. Keep the root process as the only network publisher
-and forward child records to it over the framework event bus, a multiprocessing
-queue, or a local collector. The child should forward the same normalized
-`AgentTraceRecord`; the parent handles ZMQ framing and sequence numbers.
+This direction matters for production process trees. Agent frameworks often run
+tools, subagents, plugins, or model wrappers in child processes. If every process
+that loads a tracing integration tries to bind the same local endpoint, only one
+process succeeds and the others fail during startup. With Dynamo as the single
+collector bind and all harness processes connecting as PUSH producers, parent and
+child processes can emit their own tool records independently while preserving
+their own `agent_context.program_id` and `parent_program_id`.
 
 ```text
-in-process callbacks / tool wrappers
-  -> root queued publisher -> ZMQ PUB -> Dynamo relay
+Dynamo frontend
+  -> ZMQ PULL bind -> trace bus -> sinks
 
-child process tools / subagents
-  -> process queue or event bus -> root queued publisher -> ZMQ PUB -> Dynamo relay
+parent harness process
+  -> queued ZMQ PUSH connect -> Dynamo
+
+child tool / subagent process
+  -> queued ZMQ PUSH connect -> Dynamo
 ```
 
 A compact publisher implementation is included below for harness authors that
@@ -197,9 +200,9 @@ class ZmqToolEventPublisher:
         self.topic = topic.encode("utf-8")
         self.seq = 0
         self.queue = queue.Queue(maxsize=100_000)
-        self.socket = zmq.Context.instance().socket(zmq.PUB)
+        self.socket = zmq.Context.instance().socket(zmq.PUSH)
         self.socket.set_hwm(100_000)
-        self.socket.bind(endpoint)
+        self.socket.connect(endpoint)
         self.thread = threading.Thread(target=self._run, daemon=True)
         self.thread.start()
         atexit.register(self.shutdown)
@@ -212,6 +215,7 @@ class ZmqToolEventPublisher:
         while True:
             payload = self.queue.get()
             if payload is None:
+                self.queue.task_done()
                 break
             seq = self.seq
             self.seq += 1
@@ -219,7 +223,16 @@ class ZmqToolEventPublisher:
             self.queue.task_done()
 
     def shutdown(self):
-        self.queue.put_nowait(None)
+        while True:
+            try:
+                self.queue.put_nowait(None)
+                break
+            except queue.Full:
+                try:
+                    self.queue.get_nowait()
+                    self.queue.task_done()
+                except queue.Empty:
+                    time.sleep(0.01)
         self.thread.join(timeout=1.0)
         self.socket.close(linger=0)
 ```
@@ -306,17 +319,17 @@ Dynamo runtime APIs. Framework integrations should use this shape:
 - Call one helper before each OpenAI-compatible LLM request to merge
   `extra_body.nvext.agent_context` and set `x-request-id`.
 - For LangGraph/LangChain-style in-process runtimes, implement callbacks or
-  middleware that emit directly to the root publisher.
+  middleware that emit directly to the process-local queued publisher.
 - Emit `tool_start` and a terminal `tool_end` or `tool_error` wherever the
   harness executes model-requested tools. Include `started_at_unix_ms`,
   `ended_at_unix_ms`, and `duration_ms` on terminal records so completed spans
-  survive best-effort PUB/SUB startup loss.
+  survive dropped or missing start records.
 - Propagate context through thread pools, subprocesses, and subagent launches
   when those paths can make LLM calls or emit tool records.
 - Register a queued ZMQ publisher at process startup when tool tracing is
   enabled.
-- If tools or subagents run in subprocesses, forward normalized tool records
-  back to the root publisher instead of binding another ZMQ endpoint.
+- If tools or subagents run in subprocesses, each subprocess may create its own
+  queued PUSH publisher as long as it propagates the correct `agent_context`.
 
 You do not need custom code in every tool implementation when existing tool
 calls already pass through shared harness code. Add explicit hooks only for paths
@@ -389,13 +402,13 @@ Use `DYN_AGENT_TRACE_*` variables for the Dynamo runtime and
 
 The fork automatically attaches `nvext.agent_context` and `x-request-id` to
 ms-agent OpenAI-compatible LLM calls while an agent context is active. When
-`DYN_AGENT_TOOL_EVENTS_ZMQ_ENDPOINT` is set, the ms-agent CLI also binds a
-ZMQ PUB socket and publishes tool lifecycle records to Dynamo's tool-event
-relay. Shared tool execution paths publish directly to that root publisher;
-`agent_tools` subprocesses forward normalized tool records back to the root
-process, so subprocess isolation remains enabled without each child binding the
-endpoint. Python entrypoints that do not use the CLI lazily initialize the same
-publisher on the first tool event.
+`DYN_AGENT_TOOL_EVENTS_ZMQ_ENDPOINT` is set, the ms-agent CLI connects a ZMQ
+PUSH socket and publishes tool lifecycle records to Dynamo's tool-event relay.
+Shared tool execution paths publish directly to the process-local queued
+publisher. Subprocess tools can connect their own PUSH publishers to the same
+Dynamo endpoint as long as they propagate the active agent context. Python
+entrypoints that do not use the CLI lazily initialize the same publisher on the
+first tool event.
 
 For DeepResearch v2, keep the normal ms-agent setup: configure
 `OPENAI_BASE_URL`, `OPENAI_API_KEY`, search keys such as `EXA_API_KEY`, and the

--- a/lib/llm/src/agents/trace/relay.rs
+++ b/lib/llm/src/agents/trace/relay.rs
@@ -3,9 +3,9 @@
 
 //! Agent tool-event relay.
 //!
-//! This mirrors the FPM/KV relay shape for external harnesses: subscribe to a
-//! local raw ZMQ stream, validate the domain record, then publish it to the
-//! Dynamo event plane. The ZMQ wire format is multipart:
+//! Dynamo binds a local PULL socket so any number of external harness processes
+//! can connect with PUSH sockets, validate domain records, then publish them to
+//! the Dynamo event plane. The ZMQ wire format is multipart:
 //! `[topic, seq_be_u64, msgpack(AgentTraceRecord)]`.
 
 use anyhow::Result;
@@ -15,11 +15,11 @@ use dynamo_runtime::transports::event_plane::EventPublisher;
 use futures::StreamExt;
 use tokio_util::sync::CancellationToken;
 
-use crate::utils::zmq::{connect_sub_socket, multipart_message};
+use crate::utils::zmq::{PullSocket, bind_pull_socket, multipart_message};
 
 use super::{AgentTraceRecord, DEFAULT_TOOL_EVENTS_TOPIC};
 
-/// Relay from a local agent tool-event ZMQ PUB socket to the Dynamo event plane.
+/// Relay from local agent tool-event ZMQ PUSH producers to the Dynamo event plane.
 pub struct AgentToolEventRelay {
     cancel: CancellationToken,
 }
@@ -41,10 +41,13 @@ impl AgentToolEventRelay {
         let cancel = CancellationToken::new();
         let cancel_clone = cancel.clone();
 
+        let socket = bind_pull_socket(&zmq_endpoint).await?;
+        tracing::info!(endpoint = %zmq_endpoint, "agent tool relay: bound");
+
         let publisher = EventPublisher::for_namespace(&namespace, topic).await?;
 
         rt.spawn(async move {
-            Self::relay_loop(zmq_endpoint, zmq_topic, publisher, cancel_clone).await;
+            Self::relay_loop(socket, zmq_topic, publisher, cancel_clone).await;
         });
 
         Ok(Self { cancel })
@@ -55,20 +58,11 @@ impl AgentToolEventRelay {
     }
 
     async fn relay_loop(
-        zmq_endpoint: String,
+        mut socket: PullSocket,
         zmq_topic: Option<String>,
         publisher: EventPublisher,
         cancel: CancellationToken,
     ) {
-        let mut socket = match connect_sub_socket(&zmq_endpoint, zmq_topic.as_deref()).await {
-            Ok(socket) => socket,
-            Err(error) => {
-                tracing::error!(endpoint = %zmq_endpoint, error = %error, "agent tool relay: failed to connect");
-                return;
-            }
-        };
-        tracing::info!(endpoint = %zmq_endpoint, "agent tool relay: connected");
-
         loop {
             tokio::select! {
                 biased;
@@ -84,6 +78,17 @@ impl AgentToolEventRelay {
                                 tracing::warn!(
                                     "agent tool relay: unexpected ZMQ frame count: expected 3, got {}",
                                     frames.len()
+                                );
+                                continue;
+                            }
+
+                            if let Some(expected_topic) = zmq_topic.as_deref()
+                                && frames[0].as_slice() != expected_topic.as_bytes()
+                            {
+                                tracing::debug!(
+                                    expected_topic = expected_topic,
+                                    topic = %String::from_utf8_lossy(&frames[0]),
+                                    "agent tool relay: dropping record for unexpected topic"
                                 );
                                 continue;
                             }
@@ -143,10 +148,20 @@ mod tests {
     use crate::agents::trace::{
         AgentToolEvent, AgentToolStatus, TraceEventSource, TraceEventType, TraceSchema,
     };
-    use crate::utils::zmq::{bind_pub_socket, send_multipart};
+    use crate::utils::zmq::{connect_push_socket, send_multipart_direct};
 
     fn reserve_open_port() -> TcpListener {
         TcpListener::bind("127.0.0.1:0").expect("failed to reserve TCP port")
+    }
+
+    fn endpoint_from_listener(listener: &TcpListener) -> String {
+        format!(
+            "tcp://127.0.0.1:{}",
+            listener
+                .local_addr()
+                .expect("failed to read reserved listener address")
+                .port()
+        )
     }
 
     fn valid_record() -> AgentTraceRecord {
@@ -177,6 +192,12 @@ mod tests {
         }
     }
 
+    fn valid_record_with_tool_call_id(tool_call_id: &str) -> AgentTraceRecord {
+        let mut record = valid_record();
+        record.tool.as_mut().expect("tool event").tool_call_id = tool_call_id.to_string();
+        record
+    }
+
     #[tokio::test]
     async fn relays_zmq_tool_record_to_event_plane() -> Result<()> {
         temp_env::async_with_vars(
@@ -186,13 +207,7 @@ mod tests {
             ],
             async {
                 let reserved = reserve_open_port();
-                let endpoint = format!(
-                    "tcp://127.0.0.1:{}",
-                    reserved
-                        .local_addr()
-                        .expect("failed to read reserved listener address")
-                        .port()
-                );
+                let endpoint = endpoint_from_listener(&reserved);
                 drop(reserved);
 
                 let runtime = Runtime::from_current()?;
@@ -201,9 +216,10 @@ mod tests {
                 let namespace =
                     drt.namespace(format!("agent-tool-relay-{}", uuid::Uuid::new_v4()))?;
                 let component = namespace.component("worker")?;
-                let pub_socket = bind_pub_socket(&endpoint).await?;
                 let relay =
-                    AgentToolEventRelay::start(component, endpoint, None, None, None).await?;
+                    AgentToolEventRelay::start(component, endpoint.clone(), None, None, None)
+                        .await?;
+                let mut push_socket = connect_push_socket(&endpoint).await?;
                 let mut subscriber =
                     EventSubscriber::for_namespace(&namespace, DEFAULT_TOOL_EVENTS_TOPIC)
                         .await?
@@ -213,8 +229,8 @@ mod tests {
 
                 let payload = rmp_serde::to_vec_named(&valid_record())?;
                 for _ in 0..5 {
-                    send_multipart(
-                        &pub_socket,
+                    send_multipart_direct(
+                        &mut push_socket,
                         vec![Vec::new(), 1u64.to_be_bytes().to_vec(), payload.clone()],
                     )
                     .await?;
@@ -229,6 +245,181 @@ mod tests {
                 assert_eq!(record.event_source, TraceEventSource::Harness);
                 assert_eq!(record.agent_context.workflow_id, "run-1");
                 assert_eq!(record.tool.unwrap().tool_call_id, "tool-123");
+
+                relay.shutdown();
+                drt.shutdown();
+                Ok(())
+            },
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn relays_records_from_multiple_zmq_push_producers() -> Result<()> {
+        temp_env::async_with_vars(
+            [
+                (broker_env::DYN_ZMQ_BROKER_URL, None::<&str>),
+                (broker_env::DYN_ZMQ_BROKER_ENABLED, None::<&str>),
+            ],
+            async {
+                let reserved = reserve_open_port();
+                let endpoint = endpoint_from_listener(&reserved);
+                drop(reserved);
+
+                let runtime = Runtime::from_current()?;
+                let drt =
+                    DistributedRuntime::new(runtime, DistributedConfig::process_local()).await?;
+                let namespace =
+                    drt.namespace(format!("agent-tool-relay-{}", uuid::Uuid::new_v4()))?;
+                let component = namespace.component("worker")?;
+                let relay =
+                    AgentToolEventRelay::start(component, endpoint.clone(), None, None, None)
+                        .await?;
+                let mut first_push = connect_push_socket(&endpoint).await?;
+                let mut second_push = connect_push_socket(&endpoint).await?;
+                let mut subscriber =
+                    EventSubscriber::for_namespace(&namespace, DEFAULT_TOOL_EVENTS_TOPIC)
+                        .await?
+                        .typed::<AgentTraceRecord>();
+
+                tokio::time::sleep(Duration::from_millis(150)).await;
+
+                let first_payload =
+                    rmp_serde::to_vec_named(&valid_record_with_tool_call_id("tool-first"))?;
+                let second_payload =
+                    rmp_serde::to_vec_named(&valid_record_with_tool_call_id("tool-second"))?;
+                send_multipart_direct(
+                    &mut first_push,
+                    vec![Vec::new(), 1u64.to_be_bytes().to_vec(), first_payload],
+                )
+                .await?;
+                send_multipart_direct(
+                    &mut second_push,
+                    vec![Vec::new(), 1u64.to_be_bytes().to_vec(), second_payload],
+                )
+                .await?;
+
+                let mut tool_call_ids = Vec::new();
+                for _ in 0..2 {
+                    let (_envelope, record) = timeout(Duration::from_secs(5), subscriber.next())
+                        .await?
+                        .expect("event stream should stay open")?;
+                    tool_call_ids.push(record.tool.expect("tool event").tool_call_id);
+                }
+                tool_call_ids.sort();
+
+                assert_eq!(tool_call_ids, vec!["tool-first", "tool-second"]);
+
+                relay.shutdown();
+                drt.shutdown();
+                Ok(())
+            },
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn start_returns_error_when_zmq_pull_bind_fails() -> Result<()> {
+        temp_env::async_with_vars(
+            [
+                (broker_env::DYN_ZMQ_BROKER_URL, None::<&str>),
+                (broker_env::DYN_ZMQ_BROKER_ENABLED, None::<&str>),
+            ],
+            async {
+                let reserved = reserve_open_port();
+                let endpoint = endpoint_from_listener(&reserved);
+
+                let runtime = Runtime::from_current()?;
+                let drt =
+                    DistributedRuntime::new(runtime, DistributedConfig::process_local()).await?;
+                let namespace =
+                    drt.namespace(format!("agent-tool-relay-{}", uuid::Uuid::new_v4()))?;
+                let component = namespace.component("worker")?;
+
+                let result =
+                    AgentToolEventRelay::start(component, endpoint, None, None, None).await;
+
+                assert!(result.is_err());
+
+                drt.shutdown();
+                Ok(())
+            },
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn relay_filters_records_by_zmq_topic() -> Result<()> {
+        temp_env::async_with_vars(
+            [
+                (broker_env::DYN_ZMQ_BROKER_URL, None::<&str>),
+                (broker_env::DYN_ZMQ_BROKER_ENABLED, None::<&str>),
+            ],
+            async {
+                let reserved = reserve_open_port();
+                let endpoint = endpoint_from_listener(&reserved);
+                drop(reserved);
+
+                let runtime = Runtime::from_current()?;
+                let drt =
+                    DistributedRuntime::new(runtime, DistributedConfig::process_local()).await?;
+                let namespace =
+                    drt.namespace(format!("agent-tool-relay-{}", uuid::Uuid::new_v4()))?;
+                let component = namespace.component("worker")?;
+                let relay = AgentToolEventRelay::start(
+                    component,
+                    endpoint.clone(),
+                    Some("matching-tools".to_string()),
+                    None,
+                    None,
+                )
+                .await?;
+                let mut push_socket = connect_push_socket(&endpoint).await?;
+                let mut subscriber =
+                    EventSubscriber::for_namespace(&namespace, DEFAULT_TOOL_EVENTS_TOPIC)
+                        .await?
+                        .typed::<AgentTraceRecord>();
+
+                tokio::time::sleep(Duration::from_millis(150)).await;
+
+                let dropped_payload =
+                    rmp_serde::to_vec_named(&valid_record_with_tool_call_id("tool-dropped"))?;
+                let accepted_payload =
+                    rmp_serde::to_vec_named(&valid_record_with_tool_call_id("tool-accepted"))?;
+
+                send_multipart_direct(
+                    &mut push_socket,
+                    vec![
+                        b"other-tools".to_vec(),
+                        1u64.to_be_bytes().to_vec(),
+                        dropped_payload,
+                    ],
+                )
+                .await?;
+                send_multipart_direct(
+                    &mut push_socket,
+                    vec![
+                        b"matching-tools".to_vec(),
+                        2u64.to_be_bytes().to_vec(),
+                        accepted_payload,
+                    ],
+                )
+                .await?;
+
+                let (_envelope, record) = timeout(Duration::from_secs(5), subscriber.next())
+                    .await?
+                    .expect("event stream should stay open")?;
+
+                assert_eq!(
+                    record.tool.expect("tool event").tool_call_id,
+                    "tool-accepted"
+                );
+
+                assert!(
+                    timeout(Duration::from_millis(200), subscriber.next())
+                        .await
+                        .is_err()
+                );
 
                 relay.shutdown();
                 drt.shutdown();

--- a/lib/llm/src/utils/zmq.rs
+++ b/lib/llm/src/utils/zmq.rs
@@ -8,6 +8,7 @@ use futures::SinkExt;
 use tmq::{
     Context, Multipart, SocketBuilder,
     publish::{Publish, publish},
+    pull::{Pull, pull},
     router::{Router, router},
     subscribe::{Subscribe, subscribe},
 };
@@ -16,6 +17,7 @@ use tokio::sync::Mutex;
 pub(crate) type MultipartMessage = Vec<Vec<u8>>;
 pub(crate) type SharedPubSocket = Arc<Mutex<Publish>>;
 pub(crate) type SubSocket = Subscribe;
+pub(crate) type PullSocket = Pull;
 
 const ZMQ_RCVTIMEOUT_MS: i32 = 100;
 const ZMQ_SNDTIMEOUT_MS: i32 = 0;
@@ -70,9 +72,22 @@ pub(crate) async fn bind_pub_socket(endpoint: &str) -> Result<SharedPubSocket> {
     Ok(Arc::new(Mutex::new(socket)))
 }
 
+pub(crate) async fn bind_pull_socket(endpoint: &str) -> Result<PullSocket> {
+    let ctx = Context::new();
+    let socket = configure_receive_builder(pull(&ctx)).bind(endpoint)?;
+    Ok(socket)
+}
+
 pub(crate) async fn bind_router_socket(endpoint: &str) -> Result<Router> {
     let ctx = Context::new();
     let socket = configure_bidirectional_builder(router(&ctx)).bind(endpoint)?;
+    Ok(socket)
+}
+
+#[cfg(test)]
+pub(crate) async fn connect_push_socket(endpoint: &str) -> Result<tmq::push::Push> {
+    let ctx = Context::new();
+    let socket = configure_send_builder(tmq::push::push(&ctx)).connect(endpoint)?;
     Ok(socket)
 }
 

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -340,11 +340,11 @@ pub mod llm {
         /// Rotating gzip JSONL sink roll threshold in record lines.
         pub const DYN_AGENT_TRACE_JSONL_GZ_ROLL_LINES: &str = "DYN_AGENT_TRACE_JSONL_GZ_ROLL_LINES";
 
-        /// Local ZMQ endpoint for harness tool events.
+        /// Local ZMQ PULL endpoint Dynamo binds for harness tool events.
         pub const DYN_AGENT_TRACE_TOOL_EVENTS_ZMQ_ENDPOINT: &str =
             "DYN_AGENT_TRACE_TOOL_EVENTS_ZMQ_ENDPOINT";
 
-        /// Optional ZMQ topic filter for harness tool events.
+        /// Optional first-frame ZMQ topic filter for harness tool events.
         pub const DYN_AGENT_TRACE_TOOL_EVENTS_ZMQ_TOPIC: &str =
             "DYN_AGENT_TRACE_TOOL_EVENTS_ZMQ_TOPIC";
     }


### PR DESCRIPTION
## Overview

Change agent tool-event ZMQ ingest so Dynamo owns the bind side: Dynamo binds a local `PULL` socket, and external harnesses connect `PUSH` sockets to send tool records.

## Details

- Preserve the existing `[topic, seq_be_u64, msgpack(AgentTraceRecord)]` payload shape.
- Apply optional topic filtering inside Dynamo before decoding and publishing records.
- Bind the `PULL` socket during relay startup so endpoint conflicts return an error instead of starting a dead relay task.
- Update docs to explain why Dynamo owns the bind side: multiple Pi plugins, subagents, or tool worker processes can connect as producers without competing for the same endpoint.
- Harden the Python reference publisher shutdown path against full queues.
- Add regression coverage for multi-producer ingest, topic filtering, and bind failure propagation.

## Related Issues

None.

## Testing

- `cargo test -p dynamo-llm agents::trace --lib`
- `cargo clippy -p dynamo-llm -p dynamo-runtime --all-targets -- -D warnings`
- `cargo fmt --check && git diff --check`
- `cargo test -p dynamo-runtime test_no_duplicate_env_var_names --lib`
