### PR TITLE
fix: add build timeout minutes to shared build workflow

### DIFF
--- a/.github/workflows/shared-build-image.yml
+++ b/.github/workflows/shared-build-image.yml
@@ -121,6 +121,7 @@ jobs:
     # cuda_version not empty -- name: cuda12, linux/amd64
     # cuda_version empty -- name: cpu, linux/amd64
     name: Build multi-arch ${{ matrix.cuda_version == '' && 'cpu' || format('cuda{0}', matrix.cuda_version) }}
+    timeout-minutes: ${{ inputs.build_timeout_minutes }}
     outputs:
       target_tag_plain: ${{ steps.calculate-target-tag.outputs.target_tag_plain }}
       test_tag_plain: ${{ steps.calculate-target-tag.outputs.test_tag_plain }}


### PR DESCRIPTION
#### Overview:

This was missing after the refactor. Build timeout is job level instead of step level as there can potentially be multiple builds. The default value is already 60 minutes, which should be fine for now.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to allow timeout settings to be controlled via workflow parameters for improved CI/CD flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->