### PR TITLE
chore: bump NIXL to 1.0.1 and TRTLLM to 1.3.0rc13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5326,9 +5326,9 @@ dependencies = [
 
 [[package]]
 name = "nixl-sys"
-version = "0.10.1"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64cc4aaa4b0e9e49b677db3a58e24c91d1293952d3ef6430da235704740b3a6d"
+checksum = "2ebc0a255ea1cbd18ba08d7bc430ea781105c5ceb278a46b52b93fc2dca0ed06"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",

--- a/benchmarks/pyproject.toml
+++ b/benchmarks/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "pandas",
     "pydantic>=2",
     "tabulate",
-    # Satisfies vLLM 0.11.0 (>=4.55.2), vLLM 0.11.2 (>=4.56.0,<5), TRT-LLM 1.3.0rc11 (==4.57.3), SGLang 0.5.8 (==4.57.1)
+    # Satisfies vLLM 0.11.0 (>=4.55.2), vLLM 0.11.2 (>=4.56.0,<5), TRT-LLM 1.3.0rc13 (==4.57.3), SGLang 0.5.8 (==4.57.1)
     "transformers>=4.56.0",
 ]
 

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -27,7 +27,7 @@ dynamo:
   nats_version: v2.10.28
   etcd_version: v3.5.21
 
-  nixl_ref: 1.0.1
+  nixl_ref: v1.0.1
   nixl_ucx_ref: v1.21.x
   nixl_gdrcopy_ref: v2.5.1
   nixl_ucx_efa_ref: 9d2b88a1f67faf9876f267658bd077b379b8bb76
@@ -66,7 +66,7 @@ vllm:
   flashinf_ref: v0.6.8.post1
   lmcache_ref: 0.4.4
   vllm_omni_ref: "release/v0.19.0rc1"
-  nixl_ref: 1.0.1
+  nixl_ref: v1.0.1
   max_jobs: "10"
   enable_media_ffmpeg: "false"
   enable_gpu_memory_service: "true"
@@ -98,7 +98,7 @@ trtllm:
     runtime_image: nvcr.io/nvidia/cuda-dl-base
     base_image_tag: 26.02-py3
     runtime_image_tag: 26.02-cuda13.1-runtime-ubuntu24.04
-  nixl_ref: 1.0.1
+  nixl_ref: v1.0.1
   enable_media_ffmpeg: "false"
   enable_gpu_memory_service: "true"
   enable_kvbm: "true"

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -28,7 +28,7 @@ dynamo:
   etcd_version: v3.5.21
 
   nixl_ref: 1.0.1
-  nixl_ucx_ref: v1.20.x
+  nixl_ucx_ref: v1.21.0
   nixl_gdrcopy_ref: v2.5.1
   nixl_ucx_efa_ref: 9d2b88a1f67faf9876f267658bd077b379b8bb76
   nixl_libfabric_ref: v2.3.0

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -28,7 +28,7 @@ dynamo:
   etcd_version: v3.5.21
 
   nixl_ref: 1.0.1
-  nixl_ucx_ref: v1.21.0
+  nixl_ucx_ref: v1.21.x
   nixl_gdrcopy_ref: v2.5.1
   nixl_ucx_efa_ref: 9d2b88a1f67faf9876f267658bd077b379b8bb76
   nixl_libfabric_ref: v2.3.0

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -27,7 +27,7 @@ dynamo:
   nats_version: v2.10.28
   etcd_version: v3.5.21
 
-  nixl_ref: 0.10.1
+  nixl_ref: 1.0.1
   nixl_ucx_ref: v1.20.x
   nixl_gdrcopy_ref: v2.5.1
   nixl_ucx_efa_ref: 9d2b88a1f67faf9876f267658bd077b379b8bb76
@@ -66,7 +66,7 @@ vllm:
   flashinf_ref: v0.6.8.post1
   lmcache_ref: 0.4.4
   vllm_omni_ref: "release/v0.19.0rc1"
-  nixl_ref: 0.10.1
+  nixl_ref: 1.0.1
   max_jobs: "10"
   enable_media_ffmpeg: "false"
   enable_gpu_memory_service: "true"
@@ -98,17 +98,17 @@ trtllm:
     runtime_image: nvcr.io/nvidia/cuda-dl-base
     base_image_tag: 26.02-py3
     runtime_image_tag: 26.02-cuda13.1-runtime-ubuntu24.04
-  nixl_ref: 0.10.1
+  nixl_ref: 1.0.1
   enable_media_ffmpeg: "false"
   enable_gpu_memory_service: "true"
   enable_kvbm: "true"
   python_version: "3.12"
   index_url: https://pypi.nvidia.com/
   pip_wheel_dir: /tmp/trtllm_wheel/
-  pip_wheel: tensorrt-llm==1.3.0rc11
+  pip_wheel: tensorrt-llm==1.3.0rc13
   trtllm_wheel_image: nvcr.io/nvidia/tensorrt-llm/release:${TENSORRTLLM_PIP_WHEEL#*==}
 
-  github_trtllm_commit: v1.3.0rc11
+  github_trtllm_commit: v1.3.0rc13
   torch_version: 2.11.0a0+eb65b36914.nv26.2
   torch_tensorrt_version: 2.11.0a0
   torchvision_version: 0.25.0a0+1e53952f.nv26.2.44259020

--- a/container/deps/requirements.common.txt
+++ b/container/deps/requirements.common.txt
@@ -30,7 +30,7 @@ tensorboard>=2.19.0,<2.21.0
 tensorboardX==2.6.2.2
 # Transformers version constraint for container builds
 # - vLLM 0.11.0: >=4.55.2, vLLM 0.11.2: >=4.56.0,<5
-# - TensorRT-LLM 1.3.0rc11: ==4.57.3
+# - TensorRT-LLM 1.3.0rc13: ==4.57.3
 # - SGLang 0.5.8: ==4.57.1
 # Using >=4.56.0 to satisfy all frameworks
 transformers>=4.56.0

--- a/container/deps/requirements.test.txt
+++ b/container/deps/requirements.test.txt
@@ -40,11 +40,11 @@ pytest-order==1.3.0
 pytest-rerunfailures==16.1
 pytest-timeout==2.4.0
 pytest-xdist==3.8.0
-requests==2.32.5
+requests==2.33.1
 # Required by kr8s (not declared in kr8s's own dependencies)
 sniffio==1.3.1
 tabulate==0.9.0
 types-aiofiles>=24.1.0
 types-PyYAML==6.0.12.20250915
-types-requests==2.32.4.20250913
+types-requests==2.33.0.20260503
 types-tabulate>=0.9.0

--- a/container/deps/trtllm/install_nixl.sh
+++ b/container/deps/trtllm/install_nixl.sh
@@ -27,7 +27,7 @@ UCX_VERSION="v1.20.0"
 UCX_INSTALL_PATH="/usr/local/ucx/"
 CUDA_PATH="/usr/local/cuda"
 
-NIXL_COMMIT="0.10.1"
+NIXL_COMMIT="1.0.1"
 
 UCX_REPO="https://github.com/openucx/ucx.git"
 NIXL_REPO="https://github.com/ai-dynamo/nixl.git"

--- a/container/deps/trtllm/install_nixl.sh
+++ b/container/deps/trtllm/install_nixl.sh
@@ -27,7 +27,7 @@ UCX_VERSION="v1.21.x"
 UCX_INSTALL_PATH="/usr/local/ucx/"
 CUDA_PATH="/usr/local/cuda"
 
-NIXL_COMMIT="1.0.1"
+NIXL_COMMIT="v1.0.1"
 
 UCX_REPO="https://github.com/openucx/ucx.git"
 NIXL_REPO="https://github.com/ai-dynamo/nixl.git"

--- a/container/deps/trtllm/install_nixl.sh
+++ b/container/deps/trtllm/install_nixl.sh
@@ -23,7 +23,7 @@ set -ex
 
 GITHUB_URL="https://github.com"
 
-UCX_VERSION="v1.20.0"
+UCX_VERSION="v1.21.0"
 UCX_INSTALL_PATH="/usr/local/ucx/"
 CUDA_PATH="/usr/local/cuda"
 

--- a/container/deps/trtllm/install_nixl.sh
+++ b/container/deps/trtllm/install_nixl.sh
@@ -23,7 +23,7 @@ set -ex
 
 GITHUB_URL="https://github.com"
 
-UCX_VERSION="v1.21.0"
+UCX_VERSION="v1.21.x"
 UCX_INSTALL_PATH="/usr/local/ucx/"
 CUDA_PATH="/usr/local/cuda"
 

--- a/deploy/pre-deployment/nixl/README.md
+++ b/deploy/pre-deployment/nixl/README.md
@@ -95,11 +95,11 @@ The script only prompts for Docker registry information when needed:
 ## What Each Step Does
 
 ### Step 1: Build nixlbench Docker Image
-- Downloads NIXL source code (version 0.10.1) from GitHub
+- Downloads NIXL source code (version 1.0.1) from GitHub
 - Extracts and navigates to the build directory
 - Pauses for user confirmation before building
 - Builds Docker image with specified registry and architecture
-- Tags image as: `{registry}/nixlbench:0.10.1-{arch}`
+- Tags image as: `{registry}/nixlbench:1.0.1-{arch}`
 
 ### Step 2: Update Deployment YAML File
 - Copies base deployment template (`nixlbench-deployment.yaml`)
@@ -231,7 +231,7 @@ This will help diagnose:
 
 2. **Image Pull Issues**:
    - Verify registry credentials are configured
-   - Check image exists: `docker pull {registry}/nixlbench:0.10.1-{arch}`
+   - Check image exists: `docker pull {registry}/nixlbench:1.0.1-{arch}`
    - Ensure image was pushed successfully after build
 
 3. **Build Failures**:

--- a/deploy/pre-deployment/nixl/build_and_deploy.sh
+++ b/deploy/pre-deployment/nixl/build_and_deploy.sh
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 
-NIXL_VERSION="0.10.1"
+NIXL_VERSION="1.0.1"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Function to check if a command exists

--- a/deploy/pre-deployment/nixl/build_and_deploy.sh
+++ b/deploy/pre-deployment/nixl/build_and_deploy.sh
@@ -7,6 +7,8 @@ set -euo pipefail
 
 
 NIXL_VERSION="1.0.1"
+# NIXL switched to v-prefixed tags at 1.x; archive still extracts to nixl-${NIXL_VERSION}.
+NIXL_TAG="v${NIXL_VERSION}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Function to check if a command exists
@@ -182,8 +184,8 @@ build_nixlbench() {
     cd "${NIXL_BUILD_DIR}"
 
     echo "Downloading NIXL source..."
-    wget https://github.com/ai-dynamo/nixl/archive/refs/tags/${NIXL_VERSION}.zip
-    unzip "${NIXL_VERSION}.zip"
+    wget https://github.com/ai-dynamo/nixl/archive/refs/tags/${NIXL_TAG}.zip
+    unzip "${NIXL_TAG}.zip"
     cd "nixl-${NIXL_VERSION}/benchmark/nixlbench/contrib"
     read -p "Press Enter to continue"
     echo "Building Docker image..."

--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -31,7 +31,7 @@ The following table shows the backend framework versions included with each Dyna
 
 | **Dynamo** | **SGLang** | **TensorRT-LLM** | **vLLM** | **NIXL** |
 | :--- | :--- | :--- | :--- | :--- |
-| **main (ToT)** | `0.5.10.post1` | `1.3.0rc11` | `0.20.0` | `0.10.1` (TRT-LLM, vLLM); `1.0.1` (SGLang) |
+| **main (ToT)** | `0.5.10.post1` | `1.3.0rc13` | `0.20.0` | `1.0.1` |
 | **v1.2.0-deepseek-v4-dev.2** *(experimental, partial)* | upstream DSv4 preview | — | `0.20.0` | `0.10.1` |
 | **v1.1.0** | `0.5.10.post1` | `1.3.0rc11` | `0.19.0` | `0.10.1` (TRT-LLM, vLLM); `1.0.1` (SGLang) |
 | **v1.1.0-dev.3** *(experimental, partial)* | `0.5.10.post1` | `1.3.0rc11` | `0.19.0` | `0.10.1` |

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -3885,9 +3885,9 @@ dependencies = [
 
 [[package]]
 name = "nixl-sys"
-version = "0.10.1"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64cc4aaa4b0e9e49b677db3a58e24c91d1293952d3ef6430da235704740b3a6d"
+checksum = "2ebc0a255ea1cbd18ba08d7bc430ea781105c5ceb278a46b52b93fc2dca0ed06"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",

--- a/lib/bindings/kvbm/pyproject.toml
+++ b/lib/bindings/kvbm/pyproject.toml
@@ -26,7 +26,7 @@ license = { text = "Apache-2.0" }
 license-files = ["LICENSE"]
 requires-python = ">=3.10"
 dependencies = [
-    "nixl[cu12]==0.10.1",
+    "nixl[cu12]==1.0.1",
     "pydantic>=2.0"
 ]
 classifiers = [
@@ -45,8 +45,8 @@ classifiers = [
 keywords = ["llm", "genai", "inference", "nvidia", "kvcache", "dynamo"]
 
 [project.optional-dependencies]
-cu12 = ["nixl[cu12]==0.10.1"]
-cu13 = ["nixl[cu13]==0.10.1"]
+cu12 = ["nixl[cu12]==1.0.1"]
+cu13 = ["nixl[cu13]==1.0.1"]
 dev = [
     "maturin>=1.0,<2.0",
     "patchelf",

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -4698,9 +4698,9 @@ dependencies = [
 
 [[package]]
 name = "nixl-sys"
-version = "0.10.1"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64cc4aaa4b0e9e49b677db3a58e24c91d1293952d3ef6430da235704740b3a6d"
+checksum = "2ebc0a255ea1cbd18ba08d7bc430ea781105c5ceb278a46b52b93fc2dca0ed06"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",

--- a/lib/llm/Cargo.toml
+++ b/lib/llm/Cargo.toml
@@ -120,7 +120,7 @@ dialoguer = { version = "0.11", default-features = false, features = [
 
 # block_manager
 aligned-vec = { version = "0.6.4", optional = true }
-nixl-sys = { version = "=0.10.1", optional = true }
+nixl-sys = { version = "=1.0.1", optional = true }
 cudarc = { workspace = true, optional = true }
 nix = { version = "0.26", optional = true }
 

--- a/lib/memory/Cargo.toml
+++ b/lib/memory/Cargo.toml
@@ -25,7 +25,7 @@ testing-all = ["testing-cuda", "testing-nixl"]
 [dependencies]
 anyhow = { workspace = true }
 cudarc = { workspace = true }
-nixl-sys = { version = "=0.10.1" }
+nixl-sys = { version = "=1.0.1" }
 serde = { workspace = true}
 thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,12 +44,12 @@ Repository = "https://github.com/ai-dynamo/dynamo.git"
 [project.optional-dependencies]
 trtllm =[
     "uvloop",
-    "tensorrt-llm==1.3.0rc11",
+    "tensorrt-llm==1.3.0rc13",
 ]
 
 vllm = [
     "uvloop",
-    "nixl[cu12]<=0.10.1",
+    "nixl[cu12]<=1.0.1",
     "vllm[flashinfer,runai,otel]==0.20.0",
     # vllm-omni is installed separately in container builds (see
     # container/deps/vllm/install_vllm.sh). Do not add it to ai-dynamo[vllm]:


### PR DESCRIPTION
#### Overview:

Bumps python dependencies of NIXL to `1.0.1` and TRTLLM to `1.3.0rc13`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

Closes OPS-5023

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9109" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated TensorRT-LLM backend to version 1.3.0rc13.
  * Updated NIXL core library from 0.10.1 to 1.0.1 across all backend integrations.
  * Updated related dependency pins to align with new component versions.

* **Documentation**
  * Updated support matrix and build documentation to reflect latest dependency versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->