### PR TITLE
feat(examples): add ComfyUI integration with Dynamo (custom nodes + workflows)

### DIFF
--- a/examples/comfyui/README.md
+++ b/examples/comfyui/README.md
@@ -1,0 +1,104 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# ComfyUI Integration
+
+A [ComfyUI](https://github.com/comfy-org/ComfyUI) custom node pack that drives
+Dynamo's OpenAI-compatible `/v1/images/generations` and `/v1/videos` endpoints.
+Output comes back as a native `IMAGE` / `VIDEO` so the rest of the graph
+(`SaveImage`, `SaveVideo`, downstream nodes) consumes it unchanged. No
+checkpoint loads inside ComfyUI.
+
+## Install
+
+```bash
+# 1. Backend
+bash examples/backends/vllm/launch/agg_omni_flux2_klein.sh   # image
+bash examples/backends/vllm/launch/agg_omni_video.sh          # video
+
+# 2. Node pack into ComfyUI
+cp -r examples/comfyui/node_pack ~/ComfyUI/custom_nodes/comfyui-dynamo
+
+# 3. Workflow library into ComfyUI
+mkdir -p ~/ComfyUI/user/default/workflows
+cp examples/comfyui/workflows/registered/*.json \
+   ~/ComfyUI/user/default/workflows/
+
+# 4. ComfyUI
+cd ~/ComfyUI && python main.py --listen 127.0.0.1 --port 8188
+```
+
+Open `http://127.0.0.1:8188`, left sidebar &rarr; Workflows &rarr; double-click
+any `Dynamo_*` &rarr; **Queue**.
+
+The node pack uses only stdlib + torch/numpy/PIL (already shipped by ComfyUI),
+so no extra `pip install` is needed.
+
+## Workflows
+
+Four UI-format workflows in [`workflows/registered/`](./workflows/registered/),
+one per I/O combination. Each starts with a `DynamoEndpointConfig` node so
+swapping the Dynamo URL is one widget edit per workflow.
+
+| File | I/O | Default model |
+|---|---|---|
+| `Dynamo_TextToImage.json`  | text &rarr; image           | `black-forest-labs/FLUX.2-klein-4B` |
+| `Dynamo_ImageEdit.json`    | image + text &rarr; image   | `black-forest-labs/FLUX.2-klein-4B` |
+| `Dynamo_TextToVideo.json`  | text &rarr; video           | `Wan-AI/Wan2.2-TI2V-5B-Diffusers`   |
+| `Dynamo_ImageToVideo.json` | image + text &rarr; video   | `Wan-AI/Wan2.2-TI2V-5B-Diffusers`   |
+
+Three matching API-format workflows in [`workflows/api/`](./workflows/api/) for
+headless `POST /prompt` automation.
+
+ComfyUI reads the registered workflows live from `user/default/workflows/`; no
+restart needed after dropping a new file in.
+
+## Nodes
+
+Available under the **Dynamo** category in the right-click Add Node menu.
+
+| Node | Output |
+|---|---|
+| `Dynamo Endpoint Config` | `DYNAMO_ENDPOINT` (`base_url`, `api_key`, `timeout_s`) |
+| `Dynamo Text-to-Image`   | `IMAGE` |
+| `Dynamo Image Edit`      | `IMAGE` |
+| `Dynamo Text-to-Video`   | `VIDEO` |
+| `Dynamo Image-to-Video`  | `VIDEO` |
+| `Dynamo List Models`     | JSON string |
+
+Every generation node has its own `base_url` / `api_key` widgets, but wiring an
+`endpoint` socket from `Dynamo Endpoint Config` overrides them &mdash; one source
+of truth per workflow.
+
+## Pointing at a different Dynamo
+
+Edit the `base_url` widget on the `Dynamo Endpoint Config` node and save the
+workflow (Ctrl+S). For Dynamo behind a reverse proxy with auth, set `api_key`
+on the same node; the node pack sends `Authorization: Bearer <key>` on every
+request.
+
+For headless automation the same applies on the API-format workflows in
+[`workflows/api/`](./workflows/api/).
+
+## Defaults
+
+- `response_format` defaults to `"b64_json"` in every shipped workflow. Dynamo's
+  protocol default is `"url"`, but unless the worker was launched with
+  `--media-output-http-url` and an HTTP file server is in front of the storage
+  path, the URL is `file://` and unreachable from a remote ComfyUI.
+- Float widgets (`guidance_scale`, `boundary_ratio`, `guidance_scale_2`) use
+  `-1.0` as the "use model default" sentinel so a literal `0.0`
+  (CFG-distilled FLUX-klein, DMD2) is forwarded verbatim.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `comfyui-dynamo` missing from ComfyUI startup log | Path must be `<ComfyUI>/custom_nodes/comfyui-dynamo/__init__.py`, not nested. |
+| `Dynamo returned a file:// URL` | Set the node's `response_format` widget to `b64_json`. |
+| Connection refused on port 8000 | Dynamo isn't listening, or it bound to `127.0.0.1` and ComfyUI is remote. Use `DYN_HTTP_HOST=0.0.0.0`. |
+| `value_not_in_list` on `size` widget | The widget is a fixed COMBO. Image: `512x512` / `768x768` / `1024x1024` / `1024x1792` / `1792x1024`. Video: `832x480` / `480x832` / `1280x720` / `720x1280`. |
+| Long video hangs to socket timeout | Bump `timeout_s` on the video node and the endpoint config (default 1800 s). |
+| `model` not found | Hit `GET /v1/models` (or use the `Dynamo List Models` node) and copy the exact ID into the `model` widget. |

--- a/examples/comfyui/node_pack/README.md
+++ b/examples/comfyui/node_pack/README.md
@@ -1,0 +1,53 @@
+# comfyui-dynamo
+
+ComfyUI custom nodes for [NVIDIA Dynamo](https://github.com/ai-dynamo/dynamo)'s
+OpenAI-compatible image and video endpoints.
+
+## Install
+
+```bash
+cp -r comfyui-dynamo /path/to/ComfyUI/custom_nodes/
+# restart ComfyUI
+```
+
+No extra Python deps &mdash; uses only stdlib + `torch` / `numpy` / `Pillow`, all
+of which ship with ComfyUI.
+
+## Nodes
+
+| Node | Inputs | Outputs |
+|---|---|---|
+| `Dynamo Endpoint Config` | `base_url`, `api_key`, `timeout_s` | `endpoint` (DYNAMO_ENDPOINT) |
+| `Dynamo Text-to-Image` | prompt, model, size, n, steps, guidance, seed, negative_prompt | `IMAGE` |
+| `Dynamo Image Edit` | `IMAGE`, prompt, model, size, steps, guidance, seed | `IMAGE` |
+| `Dynamo Text-to-Video` | prompt, model, size, num_frames, fps, steps, guidance, seed | `VIDEO`, video path |
+| `Dynamo Image-to-Video` | `IMAGE`, prompt, model, size, num_frames, fps, steps, guidance, boundary_ratio, guidance_scale_2 | `VIDEO`, video path |
+| `Dynamo List Models` | `base_url` | JSON string |
+
+Each generation node accepts an optional `endpoint` socket (from
+`Dynamo Endpoint Config`) which overrides the inline `base_url`/`api_key`/`timeout_s`
+widgets. Wire one config node into a graph to keep many generation nodes consistent.
+
+## Defaults
+
+- `response_format` defaults to `b64_json`. **Don't change this** unless your Dynamo
+  worker is launched with `--media-output-http-url` and an HTTP file server backs the
+  configured filesystem path. Otherwise Dynamo's default `url` returns `file://` URLs
+  unreachable from a remote ComfyUI.
+- `base_url` defaults to `http://localhost:8000` (Dynamo's `DYN_HTTP_PORT`).
+- `seed = -1` and any zero-valued `nvext` field are omitted from the request so the
+  worker uses its model defaults.
+
+## Mapping to Dynamo schemas
+
+The widgets translate to fields on `NvCreateImageRequest` / `NvCreateVideoRequest`:
+
+| Widget | Goes to | Dynamo path |
+|---|---|---|
+| `model`, `prompt`, `size`, `n`, `response_format` | top-level | `lib/llm/src/protocols/openai/images.rs:16` |
+| `negative_prompt`, `steps`, `guidance_scale`, `seed` | `nvext` | `image_protocol.py:13` |
+| `num_frames`, `fps`, `boundary_ratio`, `guidance_scale_2` | `nvext` (video only) | `video_protocol.py:16` |
+
+## License
+
+Apache-2.0 (matches Dynamo).

--- a/examples/comfyui/node_pack/__init__.py
+++ b/examples/comfyui/node_pack/__init__.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from .nodes_dynamo import (
+    DynamoEndpointConfig,
+    DynamoImageEdit,
+    DynamoImageToVideo,
+    DynamoListModels,
+    DynamoTextToImage,
+    DynamoTextToVideo,
+)
+
+NODE_CLASS_MAPPINGS = {
+    "DynamoEndpointConfig": DynamoEndpointConfig,
+    "DynamoTextToImage": DynamoTextToImage,
+    "DynamoImageEdit": DynamoImageEdit,
+    "DynamoTextToVideo": DynamoTextToVideo,
+    "DynamoImageToVideo": DynamoImageToVideo,
+    "DynamoListModels": DynamoListModels,
+}
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "DynamoEndpointConfig": "Dynamo Endpoint Config",
+    "DynamoTextToImage": "Dynamo Text-to-Image",
+    "DynamoImageEdit": "Dynamo Image Edit",
+    "DynamoTextToVideo": "Dynamo Text-to-Video",
+    "DynamoImageToVideo": "Dynamo Image-to-Video",
+    "DynamoListModels": "Dynamo List Models",
+}
+
+__all__ = ["NODE_CLASS_MAPPINGS", "NODE_DISPLAY_NAME_MAPPINGS"]

--- a/examples/comfyui/node_pack/nodes_dynamo.py
+++ b/examples/comfyui/node_pack/nodes_dynamo.py
@@ -1,0 +1,630 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""ComfyUI nodes that call NVIDIA Dynamo's OpenAI-compatible endpoints.
+
+Endpoints used:
+  POST /v1/images/generations  (NvCreateImageRequest -> NvImagesResponse)
+  POST /v1/images/edits        (NvCreateImageRequest with input_reference)
+  POST /v1/videos              (NvCreateVideoRequest -> NvVideosResponse)
+  GET  /v1/models
+
+Pure stdlib + torch/numpy/PIL (already shipped by ComfyUI). No external deps.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import json
+import tempfile
+import urllib.error
+import urllib.request
+from typing import Any
+
+import numpy as np
+import torch
+from PIL import Image
+
+DEFAULT_BASE_URL = "http://localhost:8000"
+DEFAULT_TIMEOUT_S = 600
+SIZE_PRESETS_IMAGE = ["512x512", "768x768", "1024x1024", "1024x1792", "1792x1024"]
+SIZE_PRESETS_VIDEO = ["832x480", "480x832", "1280x720", "720x1280"]
+
+
+# ---------------------------------------------------------------------------
+# tensor / bytes helpers
+# ---------------------------------------------------------------------------
+
+
+def _bytes_to_image_tensor(buf: bytes) -> torch.Tensor:
+    """PNG/JPEG bytes -> ComfyUI IMAGE tensor (1, H, W, C) float32 in [0, 1]."""
+    img = Image.open(io.BytesIO(buf)).convert("RGB")
+    arr = np.asarray(img).astype(np.float32) / 255.0
+    return torch.from_numpy(arr).unsqueeze(0)
+
+
+def _image_tensor_to_b64_png(t: torch.Tensor) -> str:
+    """ComfyUI IMAGE tensor (B, H, W, C) -> base64 PNG (first frame)."""
+    if t.ndim == 4:
+        t = t[0]
+    arr = (t.detach().cpu().clamp(0, 1).numpy() * 255.0).astype(np.uint8)
+    img = Image.fromarray(arr)
+    out = io.BytesIO()
+    img.save(out, format="PNG")
+    return base64.b64encode(out.getvalue()).decode("ascii")
+
+
+def _http_post_json(url: str, payload: dict, headers: dict, timeout: int) -> dict:
+    body = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(url, data=body, method="POST")
+    req.add_header("Content-Type", "application/json")
+    for k, v in headers.items():
+        req.add_header(k, v)
+    ctx = (
+        f"model={payload.get('model')!r} prompt={(payload.get('prompt') or '')[:200]!r}"
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"Dynamo {e.code} from {url}: {detail} ({ctx})") from e
+    except urllib.error.URLError as e:
+        raise RuntimeError(f"Dynamo unreachable at {url}: {e.reason} ({ctx})") from e
+
+
+def _http_get_json(url: str, headers: dict, timeout: int) -> dict:
+    req = urllib.request.Request(url, method="GET")
+    for k, v in headers.items():
+        req.add_header(k, v)
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def _http_get_bytes(url: str, headers: dict, timeout: int) -> bytes:
+    req = urllib.request.Request(url, method="GET")
+    for k, v in headers.items():
+        req.add_header(k, v)
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return resp.read()
+
+
+def _auth_headers(api_key: str) -> dict:
+    return {"Authorization": f"Bearer {api_key}"} if api_key else {}
+
+
+def _build_nvext(
+    *,
+    negative_prompt: str = "",
+    num_inference_steps: int = 0,
+    guidance_scale: float = -1.0,
+    seed: int = -1,
+    num_frames: int = 0,
+    fps: int = 0,
+    boundary_ratio: float = -1.0,
+    guidance_scale_2: float = -1.0,
+) -> dict:
+    """Build nvext payload. Float fields use -1.0 as the "use model default" sentinel
+    so a literal 0.0 (e.g. CFG-distilled FLUX-klein, DMD2) is forwarded verbatim."""
+    nv: dict[str, Any] = {}
+    if negative_prompt:
+        nv["negative_prompt"] = negative_prompt
+    if num_inference_steps > 0:
+        nv["num_inference_steps"] = num_inference_steps
+    if guidance_scale >= 0:
+        nv["guidance_scale"] = guidance_scale
+    if seed >= 0:
+        nv["seed"] = seed
+    if num_frames > 0:
+        nv["num_frames"] = num_frames
+    if fps > 0:
+        nv["fps"] = fps
+    if boundary_ratio >= 0:
+        nv["boundary_ratio"] = boundary_ratio
+    if guidance_scale_2 >= 0:
+        nv["guidance_scale_2"] = guidance_scale_2
+    return nv
+
+
+def _decode_image_data(item: dict, base_url: str, headers: dict, timeout: int) -> bytes:
+    """Pull raw PNG/JPEG bytes out of an NvImagesResponse data item."""
+    if item.get("b64_json"):
+        return base64.b64decode(item["b64_json"])
+    url = item.get("url")
+    if not url:
+        raise RuntimeError(f"Dynamo response item has neither b64_json nor url: {item}")
+    if url.startswith(("http://", "https://")):
+        return _http_get_bytes(url, headers, timeout)
+    if url.startswith("file://"):
+        raise RuntimeError(
+            "Dynamo returned a file:// URL. Either request response_format=b64_json "
+            "or launch the worker with --media-output-http-url and serve the dir over HTTP."
+        )
+    raise RuntimeError(f"Unsupported Dynamo URL scheme: {url}")
+
+
+# ---------------------------------------------------------------------------
+# Endpoint Config (passes a tuple downstream so users don't repeat themselves)
+# ---------------------------------------------------------------------------
+
+
+class DynamoEndpointConfig:
+    """Bundles base_url + api_key + timeout into a single DYNAMO_ENDPOINT object."""
+
+    CATEGORY = "Dynamo"
+    RETURN_TYPES = ("DYNAMO_ENDPOINT",)
+    RETURN_NAMES = ("endpoint",)
+    FUNCTION = "build"
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "base_url": ("STRING", {"default": DEFAULT_BASE_URL}),
+                "api_key": ("STRING", {"default": ""}),
+                "timeout_s": (
+                    "INT",
+                    {"default": DEFAULT_TIMEOUT_S, "min": 5, "max": 7200},
+                ),
+            }
+        }
+
+    def build(self, base_url: str, api_key: str, timeout_s: int):
+        endpoint = {
+            "base_url": base_url.rstrip("/"),
+            "api_key": api_key.strip(),
+            "timeout_s": int(timeout_s),
+        }
+        return (endpoint,)
+
+
+def _resolve_endpoint(
+    endpoint: dict | None, base_url: str, api_key: str, timeout_s: int
+) -> dict:
+    if endpoint:
+        return endpoint
+    return {
+        "base_url": (base_url or DEFAULT_BASE_URL).rstrip("/"),
+        "api_key": api_key.strip() if api_key else "",
+        "timeout_s": int(timeout_s),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Text-to-Image
+# ---------------------------------------------------------------------------
+
+
+class DynamoTextToImage:
+    CATEGORY = "Dynamo"
+    RETURN_TYPES = ("IMAGE",)
+    RETURN_NAMES = ("images",)
+    FUNCTION = "generate"
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "model": ("STRING", {"default": "Qwen/Qwen-Image"}),
+                "prompt": ("STRING", {"default": "", "multiline": True}),
+                "size": (SIZE_PRESETS_IMAGE, {"default": "1024x1024"}),
+                "n": ("INT", {"default": 1, "min": 1, "max": 10}),
+                "steps": ("INT", {"default": 20, "min": 1, "max": 200}),
+                "guidance_scale": (
+                    "FLOAT",
+                    {"default": -1.0, "min": -1.0, "max": 20.0, "step": 0.1},
+                ),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 0xFFFFFFFF}),
+                "negative_prompt": ("STRING", {"default": "", "multiline": True}),
+                "response_format": (["b64_json", "url"], {"default": "b64_json"}),
+                "base_url": ("STRING", {"default": DEFAULT_BASE_URL}),
+                "api_key": ("STRING", {"default": ""}),
+                "timeout_s": (
+                    "INT",
+                    {"default": DEFAULT_TIMEOUT_S, "min": 5, "max": 7200},
+                ),
+            },
+            "optional": {
+                "endpoint": ("DYNAMO_ENDPOINT",),
+            },
+        }
+
+    def generate(
+        self,
+        model,
+        prompt,
+        size,
+        n,
+        steps,
+        guidance_scale,
+        seed,
+        negative_prompt,
+        response_format,
+        base_url,
+        api_key,
+        timeout_s,
+        endpoint=None,
+    ):
+        ep = _resolve_endpoint(endpoint, base_url, api_key, timeout_s)
+        headers = _auth_headers(ep["api_key"])
+        payload: dict[str, Any] = {
+            "model": model,
+            "prompt": prompt,
+            "size": size,
+            "n": int(n),
+            "response_format": response_format,
+        }
+        nv = _build_nvext(
+            negative_prompt=negative_prompt,
+            num_inference_steps=steps,
+            guidance_scale=guidance_scale,
+            seed=seed,
+        )
+        if nv:
+            payload["nvext"] = nv
+
+        url = f"{ep['base_url']}/v1/images/generations"
+        resp = _http_post_json(url, payload, headers, ep["timeout_s"])
+        items = resp.get("data") or []
+        if not items:
+            raise RuntimeError(f"Dynamo returned no images: {resp}")
+
+        tensors = [
+            _bytes_to_image_tensor(
+                _decode_image_data(item, ep["base_url"], headers, ep["timeout_s"])
+            )
+            for item in items
+        ]
+        return (torch.cat(tensors, dim=0),)
+
+
+# ---------------------------------------------------------------------------
+# Image Edit (image-to-image)
+# ---------------------------------------------------------------------------
+
+
+class DynamoImageEdit:
+    CATEGORY = "Dynamo"
+    RETURN_TYPES = ("IMAGE",)
+    RETURN_NAMES = ("images",)
+    FUNCTION = "edit"
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "image": ("IMAGE",),
+                "model": ("STRING", {"default": "Qwen/Qwen-Image"}),
+                "prompt": ("STRING", {"default": "", "multiline": True}),
+                "size": (SIZE_PRESETS_IMAGE, {"default": "1024x1024"}),
+                "steps": ("INT", {"default": 20, "min": 1, "max": 200}),
+                "guidance_scale": (
+                    "FLOAT",
+                    {"default": -1.0, "min": -1.0, "max": 20.0, "step": 0.1},
+                ),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 0xFFFFFFFF}),
+                "negative_prompt": ("STRING", {"default": "", "multiline": True}),
+                "response_format": (["b64_json", "url"], {"default": "b64_json"}),
+                "base_url": ("STRING", {"default": DEFAULT_BASE_URL}),
+                "api_key": ("STRING", {"default": ""}),
+                "timeout_s": (
+                    "INT",
+                    {"default": DEFAULT_TIMEOUT_S, "min": 5, "max": 7200},
+                ),
+            },
+            "optional": {
+                "endpoint": ("DYNAMO_ENDPOINT",),
+            },
+        }
+
+    def edit(
+        self,
+        image,
+        model,
+        prompt,
+        size,
+        steps,
+        guidance_scale,
+        seed,
+        negative_prompt,
+        response_format,
+        base_url,
+        api_key,
+        timeout_s,
+        endpoint=None,
+    ):
+        ep = _resolve_endpoint(endpoint, base_url, api_key, timeout_s)
+        headers = _auth_headers(ep["api_key"])
+        b64_input = _image_tensor_to_b64_png(image)
+        payload: dict[str, Any] = {
+            "model": model,
+            "prompt": prompt,
+            "size": size,
+            "n": 1,
+            "response_format": response_format,
+            "input_reference": f"data:image/png;base64,{b64_input}",
+        }
+        nv = _build_nvext(
+            negative_prompt=negative_prompt,
+            num_inference_steps=steps,
+            guidance_scale=guidance_scale,
+            seed=seed,
+        )
+        if nv:
+            payload["nvext"] = nv
+
+        url = f"{ep['base_url']}/v1/images/edits"
+        resp = _http_post_json(url, payload, headers, ep["timeout_s"])
+        items = resp.get("data") or []
+        if not items:
+            raise RuntimeError(f"Dynamo returned no images: {resp}")
+        tensors = [
+            _bytes_to_image_tensor(
+                _decode_image_data(item, ep["base_url"], headers, ep["timeout_s"])
+            )
+            for item in items
+        ]
+        return (torch.cat(tensors, dim=0),)
+
+
+# ---------------------------------------------------------------------------
+# Video helpers
+# ---------------------------------------------------------------------------
+
+
+def _decode_video_to_path(
+    item: dict, base_url: str, headers: dict, timeout: int
+) -> str:
+    """Return a local filesystem path containing the MP4 bytes from a video response item."""
+    if item.get("b64_json"):
+        raw = base64.b64decode(item["b64_json"])
+    elif item.get("url"):
+        url = item["url"]
+        if url.startswith(("http://", "https://")):
+            raw = _http_get_bytes(url, headers, timeout)
+        elif url.startswith("file://"):
+            raise RuntimeError(
+                "Dynamo returned a file:// URL. Either request response_format=b64_json "
+                "or launch with --media-output-http-url and an HTTP file server."
+            )
+        else:
+            raise RuntimeError(f"Unsupported URL scheme: {url}")
+    else:
+        raise RuntimeError(f"Video response item missing data: {item}")
+
+    fd, path = tempfile.mkstemp(prefix="dynamo_", suffix=".mp4")
+    with open(fd, "wb") as f:
+        f.write(raw)
+    return path
+
+
+def _wrap_video_for_comfy(path: str):
+    """Wrap an MP4 path in ComfyUI's native VIDEO type if available; else return the path string.
+
+    Stock ComfyUI exposes ``comfy_api.latest.InputImpl.VideoFromFile``. Older builds may
+    not have it, in which case downstream nodes can still consume a path string via
+    VHS / SaveVideo.
+    """
+    try:
+        from comfy_api.latest import InputImpl  # type: ignore
+
+        return InputImpl.VideoFromFile(path)
+    except Exception:
+        return path
+
+
+# ---------------------------------------------------------------------------
+# Text-to-Video
+# ---------------------------------------------------------------------------
+
+
+class DynamoTextToVideo:
+    CATEGORY = "Dynamo"
+    RETURN_TYPES = ("VIDEO", "STRING")
+    RETURN_NAMES = ("video", "video_path")
+    FUNCTION = "generate"
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "model": ("STRING", {"default": "Wan-AI/Wan2.1-T2V-1.3B-Diffusers"}),
+                "prompt": ("STRING", {"default": "", "multiline": True}),
+                "size": (SIZE_PRESETS_VIDEO, {"default": "832x480"}),
+                "num_frames": ("INT", {"default": 30, "min": 1, "max": 1024}),
+                "fps": ("INT", {"default": 24, "min": 1, "max": 120}),
+                "steps": ("INT", {"default": 20, "min": 1, "max": 200}),
+                "guidance_scale": (
+                    "FLOAT",
+                    {"default": 5.0, "min": 0.0, "max": 20.0, "step": 0.1},
+                ),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 0xFFFFFFFF}),
+                "negative_prompt": ("STRING", {"default": "", "multiline": True}),
+                "response_format": (["b64_json", "url"], {"default": "b64_json"}),
+                "base_url": ("STRING", {"default": DEFAULT_BASE_URL}),
+                "api_key": ("STRING", {"default": ""}),
+                "timeout_s": ("INT", {"default": 1200, "min": 5, "max": 7200}),
+            },
+            "optional": {
+                "endpoint": ("DYNAMO_ENDPOINT",),
+            },
+        }
+
+    def generate(
+        self,
+        model,
+        prompt,
+        size,
+        num_frames,
+        fps,
+        steps,
+        guidance_scale,
+        seed,
+        negative_prompt,
+        response_format,
+        base_url,
+        api_key,
+        timeout_s,
+        endpoint=None,
+    ):
+        ep = _resolve_endpoint(endpoint, base_url, api_key, timeout_s)
+        headers = _auth_headers(ep["api_key"])
+        payload: dict[str, Any] = {
+            "model": model,
+            "prompt": prompt,
+            "size": size,
+            "response_format": response_format,
+        }
+        nv = _build_nvext(
+            negative_prompt=negative_prompt,
+            num_inference_steps=steps,
+            guidance_scale=guidance_scale,
+            seed=seed,
+            num_frames=num_frames,
+            fps=fps,
+        )
+        if nv:
+            payload["nvext"] = nv
+
+        url = f"{ep['base_url']}/v1/videos"
+        resp = _http_post_json(url, payload, headers, ep["timeout_s"])
+        if resp.get("status") and resp["status"] not in ("completed", "succeeded"):
+            raise RuntimeError(f"Dynamo video generation failed: {resp}")
+        items = resp.get("data") or []
+        if not items:
+            raise RuntimeError(f"Dynamo returned no videos: {resp}")
+        path = _decode_video_to_path(items[0], ep["base_url"], headers, ep["timeout_s"])
+        return (_wrap_video_for_comfy(path), path)
+
+
+# ---------------------------------------------------------------------------
+# Image-to-Video
+# ---------------------------------------------------------------------------
+
+
+class DynamoImageToVideo:
+    CATEGORY = "Dynamo"
+    RETURN_TYPES = ("VIDEO", "STRING")
+    RETURN_NAMES = ("video", "video_path")
+    FUNCTION = "generate"
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "image": ("IMAGE",),
+                "model": ("STRING", {"default": "Wan-AI/Wan2.1-I2V-14B-480P"}),
+                "prompt": ("STRING", {"default": "", "multiline": True}),
+                "size": (SIZE_PRESETS_VIDEO, {"default": "832x480"}),
+                "num_frames": ("INT", {"default": 30, "min": 1, "max": 1024}),
+                "fps": ("INT", {"default": 24, "min": 1, "max": 120}),
+                "steps": ("INT", {"default": 20, "min": 1, "max": 200}),
+                "guidance_scale": (
+                    "FLOAT",
+                    {"default": 5.0, "min": 0.0, "max": 20.0, "step": 0.1},
+                ),
+                "boundary_ratio": (
+                    "FLOAT",
+                    {"default": -1.0, "min": -1.0, "max": 1.0, "step": 0.01},
+                ),
+                "guidance_scale_2": (
+                    "FLOAT",
+                    {"default": -1.0, "min": -1.0, "max": 20.0, "step": 0.1},
+                ),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 0xFFFFFFFF}),
+                "negative_prompt": ("STRING", {"default": "", "multiline": True}),
+                "response_format": (["b64_json", "url"], {"default": "b64_json"}),
+                "base_url": ("STRING", {"default": DEFAULT_BASE_URL}),
+                "api_key": ("STRING", {"default": ""}),
+                "timeout_s": ("INT", {"default": 1200, "min": 5, "max": 7200}),
+            },
+            "optional": {
+                "endpoint": ("DYNAMO_ENDPOINT",),
+            },
+        }
+
+    def generate(
+        self,
+        image,
+        model,
+        prompt,
+        size,
+        num_frames,
+        fps,
+        steps,
+        guidance_scale,
+        boundary_ratio,
+        guidance_scale_2,
+        seed,
+        negative_prompt,
+        response_format,
+        base_url,
+        api_key,
+        timeout_s,
+        endpoint=None,
+    ):
+        ep = _resolve_endpoint(endpoint, base_url, api_key, timeout_s)
+        headers = _auth_headers(ep["api_key"])
+        b64_input = _image_tensor_to_b64_png(image)
+        payload: dict[str, Any] = {
+            "model": model,
+            "prompt": prompt,
+            "size": size,
+            "response_format": response_format,
+            "input_reference": f"data:image/png;base64,{b64_input}",
+        }
+        nv = _build_nvext(
+            negative_prompt=negative_prompt,
+            num_inference_steps=steps,
+            guidance_scale=guidance_scale,
+            seed=seed,
+            num_frames=num_frames,
+            fps=fps,
+            boundary_ratio=boundary_ratio,
+            guidance_scale_2=guidance_scale_2,
+        )
+        if nv:
+            payload["nvext"] = nv
+
+        url = f"{ep['base_url']}/v1/videos"
+        resp = _http_post_json(url, payload, headers, ep["timeout_s"])
+        if resp.get("status") and resp["status"] not in ("completed", "succeeded"):
+            raise RuntimeError(f"Dynamo video generation failed: {resp}")
+        items = resp.get("data") or []
+        if not items:
+            raise RuntimeError(f"Dynamo returned no videos: {resp}")
+        path = _decode_video_to_path(items[0], ep["base_url"], headers, ep["timeout_s"])
+        return (_wrap_video_for_comfy(path), path)
+
+
+# ---------------------------------------------------------------------------
+# List models (utility)
+# ---------------------------------------------------------------------------
+
+
+class DynamoListModels:
+    CATEGORY = "Dynamo"
+    RETURN_TYPES = ("STRING",)
+    RETURN_NAMES = ("models_json",)
+    FUNCTION = "list"
+    OUTPUT_NODE = True
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "base_url": ("STRING", {"default": DEFAULT_BASE_URL}),
+                "api_key": ("STRING", {"default": ""}),
+                "timeout_s": ("INT", {"default": 30, "min": 1, "max": 600}),
+            },
+            "optional": {
+                "endpoint": ("DYNAMO_ENDPOINT",),
+            },
+        }
+
+    def list(self, base_url, api_key, timeout_s, endpoint=None):
+        ep = _resolve_endpoint(endpoint, base_url, api_key, timeout_s)
+        headers = _auth_headers(ep["api_key"])
+        resp = _http_get_json(f"{ep['base_url']}/v1/models", headers, ep["timeout_s"])
+        return (json.dumps(resp, indent=2),)

--- a/examples/comfyui/node_pack/pyproject.toml
+++ b/examples/comfyui/node_pack/pyproject.toml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[project]
+name = "comfyui-dynamo"
+version = "0.1.0"
+description = "ComfyUI nodes that drive NVIDIA Dynamo's OpenAI-compatible image/video endpoints."
+requires-python = ">=3.10"
+license = { text = "Apache-2.0" }
+dependencies = []
+
+[project.urls]
+Repository = "https://github.com/ai-dynamo/dynamo"
+
+[tool.comfy]
+PublisherId = "nvidia-dynamo"
+DisplayName = "Dynamo"

--- a/examples/comfyui/workflows/api/dynamo_i2v.json
+++ b/examples/comfyui/workflows/api/dynamo_i2v.json
@@ -1,0 +1,45 @@
+{
+  "1": {
+    "class_type": "DynamoEndpointConfig",
+    "inputs": {
+      "base_url": "http://localhost:8000",
+      "api_key": "",
+      "timeout_s": 1800
+    }
+  },
+  "2": {
+    "class_type": "LoadImage",
+    "inputs": {
+      "image": "first_frame.png"
+    }
+  },
+  "3": {
+    "class_type": "DynamoImageToVideo",
+    "inputs": {
+      "image": ["2", 0],
+      "model": "Wan-AI/Wan2.1-I2V-14B-480P",
+      "prompt": "the subject smiles and waves at the camera",
+      "size": "832x480",
+      "num_frames": 30,
+      "fps": 24,
+      "steps": 20,
+      "guidance_scale": 5.0,
+      "boundary_ratio": 0.5,
+      "guidance_scale_2": 5.0,
+      "seed": 42,
+      "negative_prompt": "static, low quality",
+      "response_format": "b64_json",
+      "base_url": "http://localhost:8000",
+      "api_key": "",
+      "timeout_s": 1800,
+      "endpoint": ["1", 0]
+    }
+  },
+  "4": {
+    "class_type": "SaveVideo",
+    "inputs": {
+      "filename_prefix": "dynamo_i2v",
+      "video": ["3", 0]
+    }
+  }
+}

--- a/examples/comfyui/workflows/api/dynamo_t2i.json
+++ b/examples/comfyui/workflows/api/dynamo_t2i.json
@@ -1,0 +1,35 @@
+{
+  "1": {
+    "class_type": "DynamoEndpointConfig",
+    "inputs": {
+      "base_url": "http://localhost:8000",
+      "api_key": "",
+      "timeout_s": 600
+    }
+  },
+  "2": {
+    "class_type": "DynamoTextToImage",
+    "inputs": {
+      "model": "Qwen/Qwen-Image",
+      "prompt": "a red apple on a white table, studio lighting",
+      "size": "1024x1024",
+      "n": 1,
+      "steps": 20,
+      "guidance_scale": 5.0,
+      "seed": 42,
+      "negative_prompt": "blurry, low quality",
+      "response_format": "b64_json",
+      "base_url": "http://localhost:8000",
+      "api_key": "",
+      "timeout_s": 600,
+      "endpoint": ["1", 0]
+    }
+  },
+  "3": {
+    "class_type": "SaveImage",
+    "inputs": {
+      "filename_prefix": "dynamo_t2i",
+      "images": ["2", 0]
+    }
+  }
+}

--- a/examples/comfyui/workflows/api/dynamo_t2v.json
+++ b/examples/comfyui/workflows/api/dynamo_t2v.json
@@ -1,0 +1,36 @@
+{
+  "1": {
+    "class_type": "DynamoEndpointConfig",
+    "inputs": {
+      "base_url": "http://localhost:8000",
+      "api_key": "",
+      "timeout_s": 1800
+    }
+  },
+  "2": {
+    "class_type": "DynamoTextToVideo",
+    "inputs": {
+      "model": "Wan-AI/Wan2.1-T2V-1.3B-Diffusers",
+      "prompt": "a dog running on a sunny beach, cinematic",
+      "size": "832x480",
+      "num_frames": 30,
+      "fps": 24,
+      "steps": 20,
+      "guidance_scale": 5.0,
+      "seed": 42,
+      "negative_prompt": "static, low quality",
+      "response_format": "b64_json",
+      "base_url": "http://localhost:8000",
+      "api_key": "",
+      "timeout_s": 1800,
+      "endpoint": ["1", 0]
+    }
+  },
+  "3": {
+    "class_type": "SaveVideo",
+    "inputs": {
+      "filename_prefix": "dynamo_t2v",
+      "video": ["2", 0]
+    }
+  }
+}

--- a/examples/comfyui/workflows/registered/Dynamo_ImageEdit.json
+++ b/examples/comfyui/workflows/registered/Dynamo_ImageEdit.json
@@ -1,0 +1,92 @@
+{
+  "last_node_id": 4,
+  "last_link_id": 3,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "DynamoEndpointConfig",
+      "pos": [50, 100],
+      "size": [320, 110],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {"name": "endpoint", "type": "DYNAMO_ENDPOINT", "links": [1], "slot_index": 0}
+      ],
+      "properties": {"Node name for S&R": "DynamoEndpointConfig"},
+      "widgets_values": ["http://localhost:8000", "", 600]
+    },
+    {
+      "id": 2,
+      "type": "LoadImage",
+      "pos": [50, 260],
+      "size": [320, 320],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {"name": "IMAGE", "type": "IMAGE", "links": [2], "slot_index": 0},
+        {"name": "MASK", "type": "MASK", "links": null}
+      ],
+      "properties": {"Node name for S&R": "LoadImage"},
+      "widgets_values": ["example.png", "image"]
+    },
+    {
+      "id": 3,
+      "type": "DynamoImageEdit",
+      "pos": [420, 100],
+      "size": [380, 540],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [
+        {"name": "image", "type": "IMAGE", "link": 2},
+        {"name": "endpoint", "type": "DYNAMO_ENDPOINT", "link": 1}
+      ],
+      "outputs": [
+        {"name": "images", "type": "IMAGE", "links": [3], "slot_index": 0}
+      ],
+      "properties": {"Node name for S&R": "DynamoImageEdit"},
+      "widgets_values": [
+        "black-forest-labs/FLUX.2-klein-4B",
+        "make it look like a watercolor painting",
+        "1024x1024",
+        4,
+        3.5,
+        42,
+        "fixed",
+        "",
+        "b64_json",
+        "http://localhost:8000",
+        "",
+        600
+      ]
+    },
+    {
+      "id": 4,
+      "type": "SaveImage",
+      "pos": [840, 100],
+      "size": [320, 270],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [
+        {"name": "images", "type": "IMAGE", "link": 3}
+      ],
+      "outputs": [],
+      "properties": {"Node name for S&R": "SaveImage"},
+      "widgets_values": ["dynamo_edit"]
+    }
+  ],
+  "links": [
+    [1, 1, 0, 3, 1, "DYNAMO_ENDPOINT"],
+    [2, 2, 0, 3, 0, "IMAGE"],
+    [3, 3, 0, 4, 0, "IMAGE"]
+  ],
+  "groups": [],
+  "config": {},
+  "extra": {},
+  "version": 0.4
+}

--- a/examples/comfyui/workflows/registered/Dynamo_ImageToVideo.json
+++ b/examples/comfyui/workflows/registered/Dynamo_ImageToVideo.json
@@ -1,0 +1,211 @@
+{
+  "last_node_id": 4,
+  "last_link_id": 3,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "DynamoEndpointConfig",
+      "pos": [
+        50,
+        100
+      ],
+      "size": [
+        320,
+        130
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "endpoint",
+          "type": "DYNAMO_ENDPOINT",
+          "links": [
+            1
+          ],
+          "slot_index": 0
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "DynamoEndpointConfig"
+      },
+      "widgets_values": [
+        "http://localhost:8000",
+        "",
+        1800
+      ]
+    },
+    {
+      "id": 4,
+      "type": "LoadImage",
+      "pos": [
+        50,
+        290
+      ],
+      "size": [
+        320,
+        320
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            3
+          ],
+          "slot_index": 0
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": [
+        "example.png",
+        "image"
+      ]
+    },
+    {
+      "id": 2,
+      "type": "DynamoImageToVideo",
+      "pos": [
+        420,
+        100
+      ],
+      "size": [
+        400,
+        620
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 3
+        },
+        {
+          "name": "endpoint",
+          "type": "DYNAMO_ENDPOINT",
+          "link": 1,
+          "shape": 7
+        }
+      ],
+      "outputs": [
+        {
+          "name": "video",
+          "type": "VIDEO",
+          "links": [
+            2
+          ],
+          "slot_index": 0
+        },
+        {
+          "name": "video_path",
+          "type": "STRING",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "DynamoImageToVideo"
+      },
+      "widgets_values": [
+        "Wan-AI/Wan2.2-TI2V-5B-Diffusers",
+        "the subject moves smoothly, cinematic motion",
+        "832x480",
+        17,
+        16,
+        20,
+        5.0,
+        -1.0,
+        -1.0,
+        42,
+        "fixed",
+        "",
+        "b64_json",
+        "http://localhost:8000",
+        "",
+        1800
+      ]
+    },
+    {
+      "id": 3,
+      "type": "SaveVideo",
+      "pos": [
+        860,
+        100
+      ],
+      "size": [
+        320,
+        200
+      ],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "video",
+          "type": "VIDEO",
+          "link": 2
+        }
+      ],
+      "outputs": [],
+      "properties": {
+        "Node name for S&R": "SaveVideo"
+      },
+      "widgets_values": [
+        "dynamo_i2v",
+        "mp4",
+        "h264"
+      ]
+    }
+  ],
+  "links": [
+    [
+      1,
+      1,
+      0,
+      2,
+      1,
+      "DYNAMO_ENDPOINT"
+    ],
+    [
+      2,
+      2,
+      0,
+      3,
+      0,
+      "VIDEO"
+    ],
+    [
+      3,
+      4,
+      0,
+      2,
+      0,
+      "IMAGE"
+    ]
+  ],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 1.0,
+      "offset": [
+        0,
+        0
+      ]
+    }
+  },
+  "version": 0.4
+}

--- a/examples/comfyui/workflows/registered/Dynamo_TextToImage.json
+++ b/examples/comfyui/workflows/registered/Dynamo_TextToImage.json
@@ -1,0 +1,111 @@
+{
+  "last_node_id": 3,
+  "last_link_id": 2,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "DynamoEndpointConfig",
+      "pos": [50, 100],
+      "size": [320, 130],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "endpoint",
+          "type": "DYNAMO_ENDPOINT",
+          "links": [1],
+          "slot_index": 0
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "DynamoEndpointConfig"
+      },
+      "widgets_values": [
+        "http://localhost:8000",
+        "",
+        600
+      ]
+    },
+    {
+      "id": 2,
+      "type": "DynamoTextToImage",
+      "pos": [400, 100],
+      "size": [380, 520],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "endpoint",
+          "type": "DYNAMO_ENDPOINT",
+          "link": 1,
+          "shape": 7
+        }
+      ],
+      "outputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "links": [2],
+          "slot_index": 0
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "DynamoTextToImage"
+      },
+      "widgets_values": [
+        "black-forest-labs/FLUX.2-klein-4B",
+        "a corgi puppy standing on a sunlit hilltop, cinematic photo",
+        "768x768",
+        1,
+        4,
+        3.5,
+        42,
+        "fixed",
+        "blurry, low quality",
+        "b64_json",
+        "http://localhost:8000",
+        "",
+        600
+      ]
+    },
+    {
+      "id": 3,
+      "type": "SaveImage",
+      "pos": [820, 100],
+      "size": [320, 270],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 2
+        }
+      ],
+      "outputs": [],
+      "properties": {
+        "Node name for S&R": "SaveImage"
+      },
+      "widgets_values": [
+        "dynamo_t2i"
+      ]
+    }
+  ],
+  "links": [
+    [1, 1, 0, 2, 0, "DYNAMO_ENDPOINT"],
+    [2, 2, 0, 3, 0, "IMAGE"]
+  ],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 1.0,
+      "offset": [0, 0]
+    }
+  },
+  "version": 0.4
+}

--- a/examples/comfyui/workflows/registered/Dynamo_TextToVideo.json
+++ b/examples/comfyui/workflows/registered/Dynamo_TextToVideo.json
@@ -1,0 +1,119 @@
+{
+  "last_node_id": 3,
+  "last_link_id": 2,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "DynamoEndpointConfig",
+      "pos": [50, 100],
+      "size": [320, 130],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "endpoint",
+          "type": "DYNAMO_ENDPOINT",
+          "links": [1],
+          "slot_index": 0
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "DynamoEndpointConfig"
+      },
+      "widgets_values": [
+        "http://localhost:8000",
+        "",
+        1800
+      ]
+    },
+    {
+      "id": 2,
+      "type": "DynamoTextToVideo",
+      "pos": [400, 100],
+      "size": [380, 560],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "endpoint",
+          "type": "DYNAMO_ENDPOINT",
+          "link": 1,
+          "shape": 7
+        }
+      ],
+      "outputs": [
+        {
+          "name": "video",
+          "type": "VIDEO",
+          "links": [2],
+          "slot_index": 0
+        },
+        {
+          "name": "video_path",
+          "type": "STRING",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "DynamoTextToVideo"
+      },
+      "widgets_values": [
+        "Wan-AI/Wan2.2-TI2V-5B-Diffusers",
+        "a small wave breaking on a sunny beach, slow motion, cinematic",
+        "832x480",
+        17,
+        16,
+        16,
+        5.0,
+        42,
+        "fixed",
+        "",
+        "b64_json",
+        "http://localhost:8000",
+        "",
+        1800
+      ]
+    },
+    {
+      "id": 3,
+      "type": "SaveVideo",
+      "pos": [820, 100],
+      "size": [320, 200],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "video",
+          "type": "VIDEO",
+          "link": 2
+        }
+      ],
+      "outputs": [],
+      "properties": {
+        "Node name for S&R": "SaveVideo"
+      },
+      "widgets_values": [
+        "dynamo_t2v",
+        "mp4",
+        "h264"
+      ]
+    }
+  ],
+  "links": [
+    [1, 1, 0, 2, 0, "DYNAMO_ENDPOINT"],
+    [2, 2, 0, 3, 0, "VIDEO"]
+  ],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 1.0,
+      "offset": [0, 0]
+    }
+  },
+  "version": 0.4
+}


### PR DESCRIPTION
#### Overview:

Adds a [ComfyUI](https://github.com/comfy-org/ComfyUI) integration for Dynamo so users can drive image and video generation through a node-graph UI without ever loading a checkpoint inside ComfyUI itself. A custom node pack POSTs to Dynamo's existing OpenAI-compatible `/v1/images/generations` and `/v1/videos` endpoints; the result comes back as a native ComfyUI `IMAGE` / `VIDEO` and feeds the rest of the graph (`SaveImage` / `SaveVideo`, etc.) unchanged. Four pre-built workflows ship in the same directory, one per I/O combination.

The whole tree lives under `examples/comfyui/` &mdash; no changes to `lib/`, `components/`, or any other production code path.

#### Where should the reviewer start?

- **`examples/comfyui/README.md`** &mdash; the user-facing entry point. Section "How workflow registration works in ComfyUI" explains the UI-format / API-format split that the rest of the tree mirrors.
- **`examples/comfyui/node_pack/nodes_dynamo.py`** &mdash; six ComfyUI nodes. Of note: `_build_nvext` uses `-1.0` sentinels for `guidance_scale`, `boundary_ratio`, `guidance_scale_2` so a literal `0.0` (CFG-distilled FLUX-klein, DMD2) is forwarded verbatim. `_http_post_json` returns errors with model + prompt prefix for traceability and handles `URLError` separately so connection-refused doesn't surface as a raw stack trace.
- **`examples/comfyui/dev/dynamo_shim.py`** &mdash; the diffusers-backed stand-in. `DiffusersHolder` caches `inspect.signature(pipeline.__call__)` at load time, asserts core kwargs (`prompt`, `width`, `height`) are accepted, and warns once per dropped kwarg per pipeline. `_parse_size` returns `400` on bad input (not a silent default).
- **`examples/comfyui/workflows/registered/`** &mdash; the four UI-format workflows. The `Dynamo Endpoint Config` node at the head of each is the recommended pattern for swapping Dynamo URLs without touching downstream nodes.

#### Related Issues:

- N/A &mdash; net-new integration; no existing issue.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ComfyUI integration with NVIDIA Dynamo for image and video generation workflows, including text-to-image, text-to-video, image editing, and image-to-video capabilities.
  * Included example workflows, a development server for local testing, and comprehensive documentation for setup and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->