### PR TITLE
test(revalidate): chore: bump version references to v1.1.0 #9051

### DIFF
--- a/components/src/dynamo/common/__init__.py
+++ b/components/src/dynamo/common/__init__.py
@@ -25,3 +25,5 @@ except Exception:
         __version__ = "0.0.0+unknown"
 
 __all__ = ["__version__", "config_dump", "constants", "utils"]
+
+# revalidate cc5b2cd2964 2026-05-04T22:00:13Z

--- a/lib/runtime/src/runtime.rs
+++ b/lib/runtime/src/runtime.rs
@@ -391,3 +391,5 @@ impl Drop for RuntimeType {
         }
     }
 }
+
+// revalidate cc5b2cd2964 2026-05-04T22:00:13Z


### PR DESCRIPTION
> ## ⚠️ DO NOT MERGE THIS PR!
> This is an automated CI re-validation probe — placebo diff only, never intended to land. The branch is auto-deleted on green; kept on failure for diagnosis.

Re-validating that PR #9051 by Dan Gil did not regress, by re-running against a trivial placebo diff:

```
chore: bump version references to v1.1.0
```

Branch deleted on green; kept on failure for diagnosis.

Drafts are skipped by CodeRabbit per repo `.coderabbit.yaml`.