### PR TITLE
feat(global_router): add routing_priority pool fallback chain

### DIFF
--- a/components/src/dynamo/global_router/README.md
+++ b/components/src/dynamo/global_router/README.md
@@ -215,42 +215,43 @@ Priority is set by the client via the NVIDIA OpenAI extension:
 }
 ```
 
-### Priority-Based Pool Override
+### Pool Fallback Chain (`routing_priority`)
 
-Both prefill and decode strategies support optional `priority_overrides` rules.
-When a request carries a priority value (from `nvext.agent_hints.priority`), the
-global router evaluates the override rules **after** the grid lookup. The first
-rule whose `[min_priority, max_priority]` range contains the request priority
-wins, and the request is routed to that rule's `target_pool` instead of the
-grid result. If no rule matches (or no priority is present), the grid result
-is used as normal.
+Each strategy supports an optional `routing_priority` field — an ordered list of
+pool indices to try in sequence. When set, it **replaces** the grid lookup and
+`priority_overrides` for that strategy. The handler attempts the first pool;
+if `client.generate()` raises before any tokens have been streamed back, the
+handler falls back to the next pool in the list, and so on.
 
-This is useful for straggler mitigation in RL workloads: the RL framework can
-tag slow requests with a high priority, and the global router redirects them to
-a dedicated min-latency pool.
+Use this when you want a simple "send everything to Pool A; fall back to Pool B
+if A is unreachable" deployment without authoring a 2D grid.
 
 ```jsonc
-"priority_overrides": [
-    {
-        "min_priority": 10,     // inclusive lower bound
-        "max_priority": 100,    // inclusive upper bound
-        "target_pool": 1        // pool index to route to
-    }
-]
-```
-
-Priority is set by the client via the NVIDIA OpenAI extension:
-
-```json
-{
-    "messages": [...],
-    "nvext": {
-        "agent_hints": {
-            "priority": 50
-        }
-    }
+"agg_pool_selection_strategy": {
+    "ttft_min": 10, "ttft_max": 3000, "ttft_resolution": 2,
+    "itl_min": 5, "itl_max": 200, "itl_resolution": 2,
+    "agg_pool_mapping": [[0, 1], [1, 1]],
+    "routing_priority": [0, 1, 2]
 }
 ```
+
+Semantics and validation:
+
+- The list must be non-empty. Every entry must be a valid pool index for the
+  relevant pool type. Duplicates are rejected (a duplicate would just re-fail
+  the same way).
+- Fallback fires **only on setup errors** — i.e. failures raised from the
+  `client.generate(request)` call before any output has been forwarded to the
+  caller. Once a stream has started, errors propagate and no further pools are
+  tried (it would be unsafe to retry mid-stream and risk emitting duplicate or
+  inconsistent tokens to the client).
+- When `routing_priority` is set, both the grid mapping and `priority_overrides`
+  are bypassed for that strategy. The grid mapping must still be present in the
+  config (for structural validation) but its contents are inert.
+
+`routing_priority` is unrelated to the request-level `nvext.agent_hints.priority`
+integer used by `priority_overrides`. The former is a pool fallback ordering;
+the latter routes individual high-priority requests to a dedicated pool.
 
 ### Passing SLA Targets
 

--- a/components/src/dynamo/global_router/handler.py
+++ b/components/src/dynamo/global_router/handler.py
@@ -14,13 +14,52 @@ Both modes support priority-based pool overrides from agent hints.
 """
 
 import logging
-from typing import Any, AsyncGenerator, Dict, Optional
+from typing import Any, AsyncGenerator, Dict, List, Optional
 
 from dynamo.runtime import Client, DistributedRuntime
 
 from .pool_selection import load_config
 
 logger = logging.getLogger(__name__)
+
+
+async def _setup_with_fallback(
+    pool_chain: List[int],
+    namespaces: List[str],
+    clients: Dict[str, Client],
+    request: Dict[str, Any],
+    pool_kind: str,
+):
+    """Try each pool in `pool_chain` in order, returning the first stream whose
+    `client.generate(request)` setup succeeds.
+
+    The fallback boundary is the *setup* call only — once a stream is returned,
+    any later error during iteration is the caller's problem (it would be unsafe
+    to retry after partial output has already been forwarded to the client).
+
+    Returns: (stream, chosen_pool_idx). Raises the last exception if all pools
+    fail setup.
+    """
+    last_err: Optional[BaseException] = None
+    for idx in pool_chain:
+        namespace = namespaces[idx]
+        client = clients[namespace]
+        try:
+            stream = await client.generate(request)
+            if last_err is not None:
+                logger.info(
+                    f"Routing {pool_kind} request: chain {pool_chain} -> "
+                    f"accepted by pool {idx} ({namespace}) after fallback"
+                )
+            return stream, idx
+        except Exception as e:
+            last_err = e
+            logger.warning(
+                f"Routing {pool_kind} setup failed for pool {idx} ({namespace}): "
+                f"{e}; trying next in routing_priority chain"
+            )
+    assert last_err is not None  # pool_chain is guaranteed non-empty by validation
+    raise last_err
 
 
 class GlobalRouterHandler:
@@ -166,27 +205,30 @@ class GlobalRouterHandler:
         routing = request.get("routing") or {}
         priority = routing.get("priority")
 
-        # Select prefill pool
-        pool_idx = self.config.prefill_pool_selection_strategy.select_pool(
+        # Select prefill pool chain (single pool from grid, or routing_priority list)
+        pool_chain = self.config.prefill_pool_selection_strategy.select_pool_chain(
             isl=isl, ttft_target=ttft_target, priority=priority
         )
-        namespace = self.config.prefill_pool_dynamo_namespaces[pool_idx]
-        client = self.prefill_clients[namespace]
 
         logger.info(
             f"Routing prefill request: ISL={isl}, TTFT_target={ttft_target}, "
-            f"priority={priority} -> pool {pool_idx} ({namespace})"
+            f"priority={priority} -> pool chain {pool_chain}"
         )
 
-        # Forward request to local router and stream back responses
+        stream, _ = await _setup_with_fallback(
+            pool_chain=pool_chain,
+            namespaces=self.config.prefill_pool_dynamo_namespaces,
+            clients=self.prefill_clients,
+            request=request,
+            pool_kind="prefill",
+        )
+
         try:
-            stream = await client.generate(request)
             async for output in stream:
-                # Extract data from stream response object
                 data = output.data() if hasattr(output, "data") else output
                 yield data
         except Exception as e:
-            logger.error(f"Error forwarding prefill request to {namespace}: {e}")
+            logger.error(f"Error streaming prefill response: {e}")
             raise
 
     async def handle_decode(
@@ -216,30 +258,33 @@ class GlobalRouterHandler:
         routing = request.get("routing") or {}
         priority = routing.get("priority")
 
-        # Select decode pool
-        pool_idx = self.config.decode_pool_selection_strategy.select_pool(
+        # Select decode pool chain
+        pool_chain = self.config.decode_pool_selection_strategy.select_pool_chain(
             context_length=context_length,
             itl_target=itl_target,
             priority=priority,
         )
-        namespace = self.config.decode_pool_dynamo_namespaces[pool_idx]
-        client = self.decode_clients[namespace]
 
         logger.info(
             f"Routing decode request: context_length={context_length}, "
             f"ITL_target={itl_target}, priority={priority} -> "
-            f"pool {pool_idx} ({namespace})"
+            f"pool chain {pool_chain}"
         )
 
-        # Forward request to local router and stream back responses
+        stream, _ = await _setup_with_fallback(
+            pool_chain=pool_chain,
+            namespaces=self.config.decode_pool_dynamo_namespaces,
+            clients=self.decode_clients,
+            request=request,
+            pool_kind="decode",
+        )
+
         try:
-            stream = await client.generate(request)
             async for output in stream:
-                # Extract data from stream response object
                 data = output.data() if hasattr(output, "data") else output
                 yield data
         except Exception as e:
-            logger.error(f"Error forwarding decode request to {namespace}: {e}")
+            logger.error(f"Error streaming decode response: {e}")
             raise
 
     async def handle_generate(
@@ -269,26 +314,30 @@ class GlobalRouterHandler:
         routing = request.get("routing") or {}
         priority = routing.get("priority")
 
-        # Select agg pool
-        pool_idx = self.config.agg_pool_selection_strategy.select_pool(
+        # Select agg pool chain
+        pool_chain = self.config.agg_pool_selection_strategy.select_pool_chain(
             ttft_target=ttft_target, itl_target=itl_target, priority=priority
         )
-        namespace = self.config.agg_pool_dynamo_namespaces[pool_idx]
-        client = self.agg_clients[namespace]
 
         logger.info(
             f"Routing agg request: TTFT_target={ttft_target}, ITL_target={itl_target}, "
-            f"priority={priority} -> pool {pool_idx} ({namespace})"
+            f"priority={priority} -> pool chain {pool_chain}"
         )
 
-        # Forward request to local router and stream back responses
+        stream, _ = await _setup_with_fallback(
+            pool_chain=pool_chain,
+            namespaces=self.config.agg_pool_dynamo_namespaces,
+            clients=self.agg_clients,
+            request=request,
+            pool_kind="agg",
+        )
+
         try:
-            stream = await client.generate(request)
             async for output in stream:
                 data = output.data() if hasattr(output, "data") else output
                 yield data
         except Exception as e:
-            logger.error(f"Error forwarding agg request to {namespace}: {e}")
+            logger.error(f"Error streaming agg response: {e}")
             raise
 
     def get_pool_info(self) -> Dict[str, Any]:

--- a/components/src/dynamo/global_router/pool_selection.py
+++ b/components/src/dynamo/global_router/pool_selection.py
@@ -46,6 +46,35 @@ def _apply_priority_overrides(
     return base_pool
 
 
+def _validate_routing_priority(
+    routing_priority: Optional[List[int]],
+    num_pools: int,
+    label: str,
+) -> None:
+    """Validate a routing_priority pool chain.
+
+    Rules: when set, must be non-empty, every entry must be a valid pool index
+    in `[0, num_pools)`, and entries must be unique (a duplicate pool would
+    just re-fail the same way and is almost certainly a config mistake).
+    """
+    if routing_priority is None:
+        return
+    if not routing_priority:
+        raise ValueError(f"{label} routing_priority must be non-empty when set")
+    seen: set[int] = set()
+    for pos, pool_idx in enumerate(routing_priority):
+        if pool_idx < 0 or pool_idx >= num_pools:
+            raise ValueError(
+                f"{label} routing_priority[{pos}]: invalid pool index {pool_idx} "
+                f"(must be 0 to {num_pools - 1})"
+            )
+        if pool_idx in seen:
+            raise ValueError(
+                f"{label} routing_priority contains duplicate pool index {pool_idx}"
+            )
+        seen.add(pool_idx)
+
+
 @dataclass
 class PrefillPoolSelectionStrategy:
     """Strategy for selecting prefill pools based on ISL and TTFT target."""
@@ -58,6 +87,7 @@ class PrefillPoolSelectionStrategy:
     isl_resolution: int
     prefill_pool_mapping: List[List[int]]
     priority_overrides: List[PriorityPoolOverride] = field(default_factory=list)
+    routing_priority: Optional[List[int]] = None
 
     @property
     def ttft_step(self) -> float:
@@ -108,6 +138,22 @@ class PrefillPoolSelectionStrategy:
         )
         return pool_idx
 
+    def select_pool_chain(
+        self,
+        isl: int,
+        ttft_target: Optional[float] = None,
+        priority: Optional[int] = None,
+    ) -> List[int]:
+        """Return ordered chain of prefill pools to try.
+
+        If `routing_priority` is set, returns that list directly (grid and
+        priority_overrides are bypassed). Otherwise returns a single-element
+        list containing the grid result.
+        """
+        if self.routing_priority:
+            return list(self.routing_priority)
+        return [self.select_pool(isl=isl, ttft_target=ttft_target, priority=priority)]
+
     @staticmethod
     def _clamp_index(value: float, resolution: int) -> int:
         """Clamp index to valid grid range."""
@@ -126,6 +172,7 @@ class DecodePoolSelectionStrategy:
     context_length_resolution: int
     decode_pool_mapping: List[List[int]]
     priority_overrides: List[PriorityPoolOverride] = field(default_factory=list)
+    routing_priority: Optional[List[int]] = None
 
     @property
     def itl_step(self) -> float:
@@ -179,6 +226,28 @@ class DecodePoolSelectionStrategy:
         )
         return pool_idx
 
+    def select_pool_chain(
+        self,
+        context_length: int,
+        itl_target: Optional[float] = None,
+        priority: Optional[int] = None,
+    ) -> List[int]:
+        """Return ordered chain of decode pools to try.
+
+        If `routing_priority` is set, returns that list directly (grid and
+        priority_overrides are bypassed). Otherwise returns a single-element
+        list containing the grid result.
+        """
+        if self.routing_priority:
+            return list(self.routing_priority)
+        return [
+            self.select_pool(
+                context_length=context_length,
+                itl_target=itl_target,
+                priority=priority,
+            )
+        ]
+
     @staticmethod
     def _clamp_index(value: float, resolution: int) -> int:
         """Clamp index to valid grid range."""
@@ -207,6 +276,7 @@ class AggPoolSelectionStrategy:
     itl_resolution: int
     agg_pool_mapping: List[List[int]]
     priority_overrides: List[PriorityPoolOverride] = field(default_factory=list)
+    routing_priority: Optional[List[int]] = None
 
     @property
     def ttft_step(self) -> float:
@@ -258,6 +328,26 @@ class AggPoolSelectionStrategy:
             f"priority={priority} -> pool {pool_idx}"
         )
         return pool_idx
+
+    def select_pool_chain(
+        self,
+        ttft_target: Optional[float] = None,
+        itl_target: Optional[float] = None,
+        priority: Optional[int] = None,
+    ) -> List[int]:
+        """Return ordered chain of agg pools to try.
+
+        If `routing_priority` is set, returns that list directly (grid and
+        priority_overrides are bypassed). Otherwise returns a single-element
+        list containing the grid result.
+        """
+        if self.routing_priority:
+            return list(self.routing_priority)
+        return [
+            self.select_pool(
+                ttft_target=ttft_target, itl_target=itl_target, priority=priority
+            )
+        ]
 
     @staticmethod
     def _clamp_index(value: float, resolution: int) -> int:
@@ -385,6 +475,10 @@ class GlobalRouterConfig:
                     f"{override.target_pool} (must be 0 to {self.num_prefill_pools - 1})"
                 )
 
+        _validate_routing_priority(
+            prefill_strategy.routing_priority, self.num_prefill_pools, "Prefill"
+        )
+
         # Validate decode strategy
         decode_strategy = self.decode_pool_selection_strategy
         if decode_strategy.context_length_resolution <= 0:
@@ -443,6 +537,10 @@ class GlobalRouterConfig:
                     f"Decode priority_overrides[{i}]: invalid target_pool "
                     f"{override.target_pool} (must be 0 to {self.num_decode_pools - 1})"
                 )
+
+        _validate_routing_priority(
+            decode_strategy.routing_priority, self.num_decode_pools, "Decode"
+        )
 
     def _validate_agg(self) -> None:
         """Validate agg mode configuration."""
@@ -512,6 +610,10 @@ class GlobalRouterConfig:
                     f"{override.target_pool} (must be 0 to {self.num_agg_pools - 1})"
                 )
 
+        _validate_routing_priority(
+            agg_strategy.routing_priority, self.num_agg_pools, "Agg"
+        )
+
 
 def load_config(config_path: str | Path) -> GlobalRouterConfig:
     """
@@ -566,6 +668,7 @@ def _load_disagg_config(data: dict, mode: str) -> GlobalRouterConfig:
         isl_resolution=prefill_strategy_data["isl_resolution"],
         prefill_pool_mapping=prefill_strategy_data["prefill_pool_mapping"],
         priority_overrides=prefill_priority_overrides,
+        routing_priority=prefill_strategy_data.get("routing_priority"),
     )
 
     # Parse decode selection strategy
@@ -583,6 +686,7 @@ def _load_disagg_config(data: dict, mode: str) -> GlobalRouterConfig:
         context_length_resolution=decode_strategy_data["context_length_resolution"],
         decode_pool_mapping=decode_strategy_data["decode_pool_mapping"],
         priority_overrides=decode_priority_overrides,
+        routing_priority=decode_strategy_data.get("routing_priority"),
     )
 
     config = GlobalRouterConfig(
@@ -618,6 +722,7 @@ def _load_agg_config(data: dict, mode: str) -> GlobalRouterConfig:
         itl_resolution=agg_strategy_data["itl_resolution"],
         agg_pool_mapping=agg_strategy_data["agg_pool_mapping"],
         priority_overrides=agg_priority_overrides,
+        routing_priority=agg_strategy_data.get("routing_priority"),
     )
 
     config = GlobalRouterConfig(

--- a/components/src/dynamo/global_router/tests/test_routing_priority.py
+++ b/components/src/dynamo/global_router/tests/test_routing_priority.py
@@ -14,15 +14,18 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from dynamo.global_router.handler import GlobalRouterHandler, _setup_with_fallback
-from dynamo.global_router.pool_selection import (
-    AggPoolSelectionStrategy,
-    DecodePoolSelectionStrategy,
-    GlobalRouterConfig,
-    PrefillPoolSelectionStrategy,
-    PriorityPoolOverride,
-    load_config,
-)
+try:
+    from dynamo.global_router.handler import GlobalRouterHandler, _setup_with_fallback
+    from dynamo.global_router.pool_selection import (
+        AggPoolSelectionStrategy,
+        DecodePoolSelectionStrategy,
+        GlobalRouterConfig,
+        PrefillPoolSelectionStrategy,
+        PriorityPoolOverride,
+        load_config,
+    )
+except ImportError as e:
+    pytest.skip(f"Skip (missing dependency): {e}", allow_module_level=True)
 
 pytestmark = [
     pytest.mark.gpu_0,

--- a/components/src/dynamo/global_router/tests/test_routing_priority.py
+++ b/components/src/dynamo/global_router/tests/test_routing_priority.py
@@ -180,7 +180,9 @@ class TestValidationDisagg:
         _disagg_config().validate()
 
     def test_empty_chain_rejected(self):
-        with pytest.raises(ValueError, match="Prefill routing_priority must be non-empty"):
+        with pytest.raises(
+            ValueError, match="Prefill routing_priority must be non-empty"
+        ):
             _disagg_config(prefill_routing_priority=[]).validate()
 
     def test_out_of_range_rejected(self):
@@ -416,8 +418,7 @@ class TestHandlerFallback:
             prefill_chain=[0, 1],
         )
         outputs = [
-            chunk
-            async for chunk in handler.handle_prefill({"token_ids": [1, 2, 3]})
+            chunk async for chunk in handler.handle_prefill({"token_ids": [1, 2, 3]})
         ]
         assert outputs == [{"text": "hi"}]
         bad.generate.assert_awaited_once()

--- a/components/src/dynamo/global_router/tests/test_routing_priority.py
+++ b/components/src/dynamo/global_router/tests/test_routing_priority.py
@@ -1,0 +1,460 @@
+#  SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the routing_priority pool fallback chain in the global router.
+
+`routing_priority` is an optional list of pool indices configured per strategy.
+When set, it replaces grid-based selection and `priority_overrides`: the handler
+attempts each pool in order, falling back on setup errors only.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from dynamo.global_router.handler import GlobalRouterHandler, _setup_with_fallback
+from dynamo.global_router.pool_selection import (
+    AggPoolSelectionStrategy,
+    DecodePoolSelectionStrategy,
+    GlobalRouterConfig,
+    PrefillPoolSelectionStrategy,
+    PriorityPoolOverride,
+    load_config,
+)
+
+pytestmark = [
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+    pytest.mark.parallel,
+    pytest.mark.unit,
+]
+
+
+# --- Strategy helpers ---
+
+
+def _make_prefill_strategy(routing_priority=None) -> PrefillPoolSelectionStrategy:
+    return PrefillPoolSelectionStrategy(
+        ttft_min=10,
+        ttft_max=3000,
+        ttft_resolution=2,
+        isl_min=0,
+        isl_max=32000,
+        isl_resolution=2,
+        prefill_pool_mapping=[[0, 1], [0, 1]],
+        priority_overrides=[
+            PriorityPoolOverride(min_priority=1, max_priority=10, target_pool=1)
+        ],
+        routing_priority=routing_priority,
+    )
+
+
+def _make_decode_strategy(routing_priority=None) -> DecodePoolSelectionStrategy:
+    return DecodePoolSelectionStrategy(
+        itl_min=10,
+        itl_max=500,
+        itl_resolution=2,
+        context_length_min=0,
+        context_length_max=32000,
+        context_length_resolution=2,
+        decode_pool_mapping=[[0, 1], [0, 1]],
+        priority_overrides=[
+            PriorityPoolOverride(min_priority=1, max_priority=10, target_pool=1)
+        ],
+        routing_priority=routing_priority,
+    )
+
+
+def _make_agg_strategy(routing_priority=None) -> AggPoolSelectionStrategy:
+    return AggPoolSelectionStrategy(
+        ttft_min=10,
+        ttft_max=3000,
+        ttft_resolution=2,
+        itl_min=5,
+        itl_max=200,
+        itl_resolution=2,
+        agg_pool_mapping=[[0, 1], [1, 1]],
+        priority_overrides=[
+            PriorityPoolOverride(min_priority=1, max_priority=10, target_pool=0)
+        ],
+        routing_priority=routing_priority,
+    )
+
+
+# --- select_pool_chain tests ---
+
+
+class TestPrefillSelectPoolChain:
+    def test_unset_returns_single_grid_result(self):
+        strategy = _make_prefill_strategy(routing_priority=None)
+        # Grid selects 0 for ISL=100, TTFT=50
+        assert strategy.select_pool_chain(isl=100, ttft_target=50) == [0]
+
+    def test_unset_with_priority_override_uses_grid_path(self):
+        strategy = _make_prefill_strategy(routing_priority=None)
+        # priority=5 matches override -> pool 1
+        assert strategy.select_pool_chain(isl=100, ttft_target=50, priority=5) == [1]
+
+    def test_set_returns_chain_ignoring_grid(self):
+        strategy = _make_prefill_strategy(routing_priority=[2, 0, 1])
+        # Grid would pick 0; priority override would pick 1; chain wins.
+        assert strategy.select_pool_chain(isl=100, ttft_target=50, priority=5) == [
+            2,
+            0,
+            1,
+        ]
+
+    def test_chain_is_copied_not_aliased(self):
+        rp = [1, 0]
+        strategy = _make_prefill_strategy(routing_priority=rp)
+        chain = strategy.select_pool_chain(isl=100, ttft_target=50)
+        chain.append(99)
+        assert strategy.routing_priority == [1, 0]
+
+
+class TestDecodeSelectPoolChain:
+    def test_unset_returns_single_grid_result(self):
+        strategy = _make_decode_strategy(routing_priority=None)
+        assert strategy.select_pool_chain(context_length=100, itl_target=20) == [0]
+
+    def test_set_returns_chain(self):
+        strategy = _make_decode_strategy(routing_priority=[1, 0])
+        assert strategy.select_pool_chain(
+            context_length=100, itl_target=20, priority=5
+        ) == [1, 0]
+
+
+class TestAggSelectPoolChain:
+    def test_unset_returns_single_grid_result(self):
+        strategy = _make_agg_strategy(routing_priority=None)
+        # Grid mapping [[0,1],[1,1]] at ttft=50, itl=10 => pool 0
+        assert strategy.select_pool_chain(ttft_target=50, itl_target=10) == [0]
+
+    def test_set_returns_chain(self):
+        strategy = _make_agg_strategy(routing_priority=[1, 0])
+        assert strategy.select_pool_chain(
+            ttft_target=50, itl_target=10, priority=5
+        ) == [1, 0]
+
+
+# --- Validation tests ---
+
+
+def _disagg_config(**strategy_kwargs) -> GlobalRouterConfig:
+    prefill = _make_prefill_strategy(
+        routing_priority=strategy_kwargs.get("prefill_routing_priority")
+    )
+    decode = _make_decode_strategy(
+        routing_priority=strategy_kwargs.get("decode_routing_priority")
+    )
+    return GlobalRouterConfig(
+        mode="disagg",
+        num_prefill_pools=2,
+        num_decode_pools=2,
+        prefill_pool_dynamo_namespaces=["a", "b"],
+        decode_pool_dynamo_namespaces=["c", "d"],
+        prefill_pool_selection_strategy=prefill,
+        decode_pool_selection_strategy=decode,
+    )
+
+
+def _agg_config(routing_priority=None) -> GlobalRouterConfig:
+    return GlobalRouterConfig(
+        mode="agg",
+        num_agg_pools=2,
+        agg_pool_dynamo_namespaces=["a", "b"],
+        agg_pool_selection_strategy=_make_agg_strategy(
+            routing_priority=routing_priority
+        ),
+    )
+
+
+class TestValidationDisagg:
+    def test_valid_chain_passes(self):
+        _disagg_config(prefill_routing_priority=[1, 0]).validate()
+        _disagg_config(decode_routing_priority=[0, 1]).validate()
+
+    def test_unset_passes(self):
+        _disagg_config().validate()
+
+    def test_empty_chain_rejected(self):
+        with pytest.raises(ValueError, match="Prefill routing_priority must be non-empty"):
+            _disagg_config(prefill_routing_priority=[]).validate()
+
+    def test_out_of_range_rejected(self):
+        with pytest.raises(ValueError, match="invalid pool index 5"):
+            _disagg_config(prefill_routing_priority=[0, 5]).validate()
+
+    def test_negative_rejected(self):
+        with pytest.raises(ValueError, match="invalid pool index -1"):
+            _disagg_config(decode_routing_priority=[-1, 0]).validate()
+
+    def test_duplicates_rejected(self):
+        with pytest.raises(ValueError, match="duplicate pool index 1"):
+            _disagg_config(prefill_routing_priority=[1, 0, 1]).validate()
+
+
+class TestValidationAgg:
+    def test_valid_chain_passes(self):
+        _agg_config(routing_priority=[1, 0]).validate()
+
+    def test_unset_passes(self):
+        _agg_config().validate()
+
+    def test_empty_chain_rejected(self):
+        with pytest.raises(ValueError, match="Agg routing_priority must be non-empty"):
+            _agg_config(routing_priority=[]).validate()
+
+    def test_out_of_range_rejected(self):
+        with pytest.raises(ValueError, match="invalid pool index 7"):
+            _agg_config(routing_priority=[0, 7]).validate()
+
+    def test_duplicates_rejected(self):
+        with pytest.raises(ValueError, match="duplicate pool index 0"):
+            _agg_config(routing_priority=[0, 0]).validate()
+
+
+# --- JSON load round-trip ---
+
+
+def _write_config(tmp_dir: Path, config_data: dict) -> Path:
+    config_path = tmp_dir / "config.json"
+    config_path.write_text(json.dumps(config_data))
+    return config_path
+
+
+def _disagg_json(**overrides) -> dict:
+    config = {
+        "num_prefill_pools": 2,
+        "num_decode_pools": 2,
+        "prefill_pool_dynamo_namespaces": ["ns-prefill-0", "ns-prefill-1"],
+        "decode_pool_dynamo_namespaces": ["ns-decode-0", "ns-decode-1"],
+        "prefill_pool_selection_strategy": {
+            "isl_min": 0,
+            "isl_max": 32000,
+            "isl_resolution": 2,
+            "ttft_min": 10,
+            "ttft_max": 3000,
+            "ttft_resolution": 2,
+            "prefill_pool_mapping": [[0, 1], [0, 1]],
+        },
+        "decode_pool_selection_strategy": {
+            "context_length_min": 0,
+            "context_length_max": 32000,
+            "context_length_resolution": 2,
+            "itl_min": 10,
+            "itl_max": 500,
+            "itl_resolution": 2,
+            "decode_pool_mapping": [[0, 1], [0, 1]],
+        },
+    }
+    config.update(overrides)
+    return config
+
+
+class TestLoadConfig:
+    def test_disagg_loads_routing_priority(self, tmp_path):
+        config_data = _disagg_json()
+        config_data["prefill_pool_selection_strategy"]["routing_priority"] = [1, 0]
+        config_data["decode_pool_selection_strategy"]["routing_priority"] = [0, 1]
+        config = load_config(_write_config(tmp_path, config_data))
+
+        assert config.prefill_pool_selection_strategy.routing_priority == [1, 0]
+        assert config.decode_pool_selection_strategy.routing_priority == [0, 1]
+
+    def test_disagg_omitted_routing_priority_defaults_none(self, tmp_path):
+        config = load_config(_write_config(tmp_path, _disagg_json()))
+        assert config.prefill_pool_selection_strategy.routing_priority is None
+        assert config.decode_pool_selection_strategy.routing_priority is None
+
+    def test_agg_loads_routing_priority(self, tmp_path):
+        config_data = {
+            "mode": "agg",
+            "num_agg_pools": 2,
+            "agg_pool_dynamo_namespaces": ["ns-agg-0", "ns-agg-1"],
+            "agg_pool_selection_strategy": {
+                "ttft_min": 10,
+                "ttft_max": 3000,
+                "ttft_resolution": 2,
+                "itl_min": 5,
+                "itl_max": 200,
+                "itl_resolution": 2,
+                "agg_pool_mapping": [[0, 1], [1, 1]],
+                "routing_priority": [1, 0],
+            },
+        }
+        config = load_config(_write_config(tmp_path, config_data))
+        assert config.agg_pool_selection_strategy.routing_priority == [1, 0]
+
+
+# --- Handler-level fallback ---
+
+
+def _make_async_stream(items):
+    """Return an async iterator that yields the given items."""
+
+    async def _gen():
+        for item in items:
+            yield item
+
+    return _gen()
+
+
+def _make_failing_stream(exc):
+    """Return an async iterator that raises `exc` on first iteration."""
+
+    async def _gen():
+        raise exc
+        yield  # pragma: no cover — unreachable, makes this a generator
+
+    return _gen()
+
+
+@pytest.mark.asyncio
+class TestSetupWithFallback:
+    async def test_first_pool_succeeds(self):
+        client_a = MagicMock()
+        client_a.generate = AsyncMock(return_value="stream-a")
+        client_b = MagicMock()
+        client_b.generate = AsyncMock(return_value="stream-b")
+
+        stream, idx = await _setup_with_fallback(
+            pool_chain=[0, 1],
+            namespaces=["ns-a", "ns-b"],
+            clients={"ns-a": client_a, "ns-b": client_b},
+            request={"x": 1},
+            pool_kind="agg",
+        )
+        assert stream == "stream-a"
+        assert idx == 0
+        client_a.generate.assert_awaited_once()
+        client_b.generate.assert_not_called()
+
+    async def test_first_pool_fails_falls_back(self):
+        client_a = MagicMock()
+        client_a.generate = AsyncMock(side_effect=ConnectionError("nope"))
+        client_b = MagicMock()
+        client_b.generate = AsyncMock(return_value="stream-b")
+
+        stream, idx = await _setup_with_fallback(
+            pool_chain=[0, 1],
+            namespaces=["ns-a", "ns-b"],
+            clients={"ns-a": client_a, "ns-b": client_b},
+            request={"x": 1},
+            pool_kind="prefill",
+        )
+        assert stream == "stream-b"
+        assert idx == 1
+
+    async def test_all_pools_fail_raises_last(self):
+        client_a = MagicMock()
+        client_a.generate = AsyncMock(side_effect=ConnectionError("first"))
+        client_b = MagicMock()
+        client_b.generate = AsyncMock(side_effect=RuntimeError("last"))
+
+        with pytest.raises(RuntimeError, match="last"):
+            await _setup_with_fallback(
+                pool_chain=[0, 1],
+                namespaces=["ns-a", "ns-b"],
+                clients={"ns-a": client_a, "ns-b": client_b},
+                request={"x": 1},
+                pool_kind="decode",
+            )
+
+
+def _build_disagg_handler(prefill_clients, decode_clients, prefill_chain=None):
+    """Build a GlobalRouterHandler in disagg mode without invoking initialize().
+
+    Returns a handler whose prefill_clients / decode_clients are the supplied
+    mocks, so we can exercise dispatch logic without a live runtime.
+    """
+    config = GlobalRouterConfig(
+        mode="disagg",
+        num_prefill_pools=2,
+        num_decode_pools=2,
+        prefill_pool_dynamo_namespaces=["ns-prefill-0", "ns-prefill-1"],
+        decode_pool_dynamo_namespaces=["ns-decode-0", "ns-decode-1"],
+        prefill_pool_selection_strategy=_make_prefill_strategy(
+            routing_priority=prefill_chain
+        ),
+        decode_pool_selection_strategy=_make_decode_strategy(),
+    )
+    config.validate()
+    handler = GlobalRouterHandler.__new__(GlobalRouterHandler)
+    handler.runtime = None
+    handler.config = config
+    handler.model_name = "test-model"
+    handler.default_ttft_target = None
+    handler.default_itl_target = None
+    handler.prefill_clients = prefill_clients
+    handler.decode_clients = decode_clients
+    handler.agg_clients = {}
+    handler.prefill_namespace_to_idx = {
+        ns: i for i, ns in enumerate(config.prefill_pool_dynamo_namespaces)
+    }
+    handler.decode_namespace_to_idx = {
+        ns: i for i, ns in enumerate(config.decode_pool_dynamo_namespaces)
+    }
+    return handler
+
+
+@pytest.mark.asyncio
+class TestHandlerFallback:
+    async def test_prefill_fallback_on_setup_error(self):
+        # Pool 0 fails setup; pool 1 succeeds. With routing_priority=[0, 1],
+        # handler should fall through and stream pool 1's output.
+        bad = MagicMock()
+        bad.generate = AsyncMock(side_effect=ConnectionError("pool 0 down"))
+        good = MagicMock()
+        good.generate = AsyncMock(return_value=_make_async_stream([{"text": "hi"}]))
+
+        handler = _build_disagg_handler(
+            prefill_clients={"ns-prefill-0": bad, "ns-prefill-1": good},
+            decode_clients={},
+            prefill_chain=[0, 1],
+        )
+        outputs = [
+            chunk
+            async for chunk in handler.handle_prefill({"token_ids": [1, 2, 3]})
+        ]
+        assert outputs == [{"text": "hi"}]
+        bad.generate.assert_awaited_once()
+        good.generate.assert_awaited_once()
+
+    async def test_prefill_no_fallback_on_mid_stream_error(self):
+        # Pool 0 setup succeeds, but the stream raises on first iteration.
+        # Handler must propagate the error rather than fall back to pool 1.
+        bad = MagicMock()
+        bad.generate = AsyncMock(
+            return_value=_make_failing_stream(RuntimeError("mid-stream"))
+        )
+        good = MagicMock()
+        good.generate = AsyncMock(return_value=_make_async_stream([{"text": "hi"}]))
+
+        handler = _build_disagg_handler(
+            prefill_clients={"ns-prefill-0": bad, "ns-prefill-1": good},
+            decode_clients={},
+            prefill_chain=[0, 1],
+        )
+        with pytest.raises(RuntimeError, match="mid-stream"):
+            async for _ in handler.handle_prefill({"token_ids": [1, 2, 3]}):
+                pass
+        bad.generate.assert_awaited_once()
+        good.generate.assert_not_called()
+
+    async def test_prefill_all_pools_fail_raises(self):
+        bad0 = MagicMock()
+        bad0.generate = AsyncMock(side_effect=ConnectionError("first"))
+        bad1 = MagicMock()
+        bad1.generate = AsyncMock(side_effect=RuntimeError("last"))
+
+        handler = _build_disagg_handler(
+            prefill_clients={"ns-prefill-0": bad0, "ns-prefill-1": bad1},
+            decode_clients={},
+            prefill_chain=[0, 1],
+        )
+        with pytest.raises(RuntimeError, match="last"):
+            async for _ in handler.handle_prefill({"token_ids": [1, 2, 3]}):
+                pass


### PR DESCRIPTION
## Summary

Adds an optional `routing_priority` field to each pool selection strategy (prefill, decode, agg) — an ordered list of pool indices the global router will try in sequence. When set, it replaces grid-based selection and `priority_overrides` for that strategy: the handler attempts each pool's `client.generate()` in order, falling back to the next on **setup errors only**. Once a stream has started, errors propagate without further retry to avoid emitting duplicate or inconsistent tokens.

This enables a simple "send everything to Pool A; fall back to Pool B if A is unreachable" deployment without authoring a 2D grid.

```jsonc
"agg_pool_selection_strategy": {
    ...
    "routing_priority": [0, 1, 2]
}
```

## Changes

- `pool_selection.py` — new `routing_priority: Optional[List[int]]` on all three strategies; new `select_pool_chain()` returning the configured chain (or `[grid_result]` when unset); JSON loader reads the field; new `_validate_routing_priority` helper enforces non-empty / in-range / no-duplicates.
- `handler.py` — extracted `_setup_with_fallback()` helper; `handle_prefill`, `handle_decode`, `handle_generate` use `select_pool_chain()` and try each pool in order, with fallback bounded to the `client.generate()` setup call only.
- `README.md` — added "Pool Fallback Chain (`routing_priority`)" section explaining semantics, validation rules, and the distinction from request-level `nvext.agent_hints.priority`. Removed a duplicated "Priority-Based Pool Override" section while there.
- New `tests/test_routing_priority.py` — 28 unit tests covering `select_pool_chain`, validation, JSON load, `_setup_with_fallback`, and end-to-end handler fallback (success, mid-stream error propagation, all-pools-fail).

## Test plan

- [x] `pytest components/src/dynamo/global_router/tests/` — 80/80 pass (52 existing + 28 new)
- [ ] Manual smoke: bring up two mocker pools, configure `routing_priority: [0, 1]`, kill pool 0, send a request, verify it lands on pool 1 and the warning log shows pool 0 was skipped (reuse `examples/global_planner/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9114" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional routing priority chains for pool selection strategies, enabling sequential fallback to alternative pools when initial selection fails.
  * Improved initialization resilience with built-in fallback mechanisms that automatically attempt alternate pools before proceeding.

* **Documentation**
  * Updated pool-routing documentation describing the new routing priority feature, including validation rules, supported indices, and fallback behavior specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->