### PR TITLE
docs: clarify GPU Memory Service status

### DIFF
--- a/deploy/operator/config/samples/nvidia.com_v1alpha1_dynamocheckpoint.yaml
+++ b/deploy/operator/config/samples/nvidia.com_v1alpha1_dynamocheckpoint.yaml
@@ -27,7 +27,8 @@ spec:
     dtype: "bfloat16"
     maxModelLen: 2048
 
-  # Optional: enable GMS-specific checkpoint capture and restore helpers.
+  # GMS-specific checkpoint capture and restore is temporarily disabled
+  # because of known GPU driver restore issues. Keep this false.
   gpuMemoryService:
     enabled: false
 

--- a/docs/fault-tolerance/README.md
+++ b/docs/fault-tolerance/README.md
@@ -15,6 +15,7 @@ Fault tolerance in Dynamo operates at multiple levels:
 |-------|-----------|---------|
 | **Request** | Migration, Cancellation | Handle in-flight request failures |
 | **Worker** | Health Checks, Graceful Shutdown | Detect and recover from worker failures |
+| **Engine Process** | [Shadow Engine Failover](../kubernetes/shadow-engine-failover.md) | Active/passive recovery for same-node engine-process failures in Kubernetes |
 | **System** | Load Shedding, Request Rejection | Prevent system overload |
 | **Infrastructure** | etcd HA, NATS resilience | Handle infrastructure component failures |
 
@@ -69,6 +70,10 @@ Dynamo provides multiple health check mechanisms:
 - **Engine Monitoring**: Automatic shutdown on engine failure detection
 
 See [Health Checks](../observability/health-checks.md) for details.
+
+### Shadow Engine Failover
+
+For Kubernetes deployments, [Shadow Engine Failover](../kubernetes/shadow-engine-failover.md) can help with same-node recovery from unknown backend engine or software-process failures. It uses GPU Memory Service to keep model weights resident while a standby or replacement engine attaches. It does not preserve in-flight requests or KV cache state, and it does not cover GPU or node loss.
 
 ## Configuration Quick Reference
 
@@ -127,6 +132,7 @@ See [Fault Tolerance Testing](testing.md) for details.
 ## Related Documentation
 
 - [Observability](../observability/README.md) - Metrics and monitoring
+- [Shadow Engine Failover](../kubernetes/shadow-engine-failover.md) - Same-node active/passive engine failover for Kubernetes deployments
 - [Distributed Runtime](../design-docs/distributed-runtime.md) - Service discovery architecture
 - [Event Plane](../design-docs/event-plane.md) - Pub/sub for KV cache events and worker metrics
 - [Discovery Plane](../design-docs/discovery-plane.md) - Service discovery and coordination

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -92,6 +92,8 @@ navigation:
             path: kubernetes/inference-gateway.md
           - page: Snapshot
             path: kubernetes/snapshot.md
+          - page: Shadow Engine Failover
+            path: kubernetes/shadow-engine-failover.md
           - page: Disagg Communication
             path: kubernetes/disagg-communication-guide.md
       - section: Observability (K8s)

--- a/docs/kubernetes/README.md
+++ b/docs/kubernetes/README.md
@@ -214,6 +214,7 @@ Key customization points include:
 - **[Service Discovery](service-discovery.md)** - Discovery backends and configuration
 - **[Helm Charts](https://github.com/ai-dynamo/dynamo/tree/main/deploy/helm/README.md)** - For advanced users
 - **[Snapshot](snapshot.md)** - Fast pod startup with checkpoint/restore
+- **[Shadow Engine Failover](shadow-engine-failover.md)** - Experimental active/passive engine failover using GPU Memory Service
 - **[GitOps Deployment with FluxCD](fluxcd.md)** - For advanced users
 - **[Logging](observability/logging.md)** - For logging setup
 - **[Multinode Deployment](deployment/multinode-deployment.md)** - For multinode deployment

--- a/docs/kubernetes/shadow-engine-failover.md
+++ b/docs/kubernetes/shadow-engine-failover.md
@@ -1,0 +1,233 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: Shadow Engine Failover
+---
+
+> ⚠️ **Experimental Feature**: Shadow Engine Failover is an opt-in preview
+> feature. It depends on GPU Memory Service (GMS), Dynamic Resource Allocation
+> (DRA), and backend-specific support. Its API shape and behavior may change,
+> and the failover state machine is still settling. Use it only for
+> non-production evaluation unless you have validated the exact backend,
+> topology, and failure mode in your cluster.
+
+## Overview
+
+Use Shadow Engine Failover when you want a standby engine to take over after an
+unknown backend engine or software-process failure while the GPU and node remain
+healthy. The goal is to avoid paying a full model weight reload after a
+same-node process failure.
+
+Shadow Engine Failover is the Kubernetes workflow. GPU Memory Service is the
+enabling mechanism underneath it: GMS owns the GPU-resident model weights, and
+the active and standby engines attach to those weights through DRA.
+
+This is separate from [Dynamo Snapshot](snapshot.md). Snapshot captures and
+restores a process image with CRIU and `cuda-checkpoint`. Shadow Engine Failover
+keeps model weights resident in GPU memory so a standby or replacement engine
+can attach after selected process-level failures. They both target recovery
+latency, but they solve different problems and are not interchangeable.
+
+## Failure Recovery Flow
+
+The following diagram illustrates same-node process-level recovery:
+
+```text
+┌──────────────────────── Same healthy node + GPU ───────────────────────┐
+│                                                                        │
+│  Before failure                                                        │
+│  ┌──────────────┐      attach/use      ┌───────────────────────────┐   │
+│  │ Engine A     │ ───────────────────▶ │ GMS-owned model weights   │   │
+│  │ active       │                      │ resident in GPU memory    │   │
+│  └──────┬───────┘                      └────────────┬──────────────┘   │
+│         │                                           ▲                  │
+│         │                                           │ attach/use       │
+│         │ unknown software/engine failure           │                  │
+│         ▼                                           │                  │
+│  ┌──────────────┐                            ┌──────┴───────┐          │
+│  │ Engine A     │ exits                      │ Engine B     │          │
+│  └──────────────┘                            │ shadow       │          │
+│                                              └──────┬───────┘          │
+│                                                     │ takeover         │
+│                                                     ▼                  │
+│                                              ┌──────────────┐          │
+│                                              │ Engine B     │          │
+│                                              │ active       │          │
+│                                              └──────────────┘          │
+│                                                                        │
+└────────────────────────────────────────────────────────────────────────┘
+```
+
+**How it works:**
+
+1. The operator creates active and standby engine containers or pods for the
+   worker, depending on the selected failover mode.
+2. The engines share GPU access through DRA and attach to model weights owned by
+   GMS.
+3. An unknown software or engine failure terminates the active engine, while the
+   GMS process, GPU, and node remain healthy.
+4. The standby or replacement engine takes over and attaches to the resident
+   GMS-owned weights instead of performing a full weight reload.
+5. In-flight requests and KV cache state are not preserved. If the GPU, node, or
+   GMS process is lost, the replacement worker must use the normal rescheduling
+   and model-load path.
+
+## When to Use It Today
+
+- Use it to evaluate same-node recovery from unknown vLLM engine or
+  software-process failures.
+- Use it when the cost you are trying to avoid is loading another independent
+  copy of model weights into GPU memory.
+- Use the GMS-only examples to validate backend weight loading through GMS, not
+  as a complete failover workflow.
+- Do not use it for hardware failure, GPU loss, node loss, cross-node recovery,
+  in-flight request recovery, or KV-cache recovery.
+- Do not combine it with Snapshot restore. Snapshot plus GMS is not yet
+  available.
+
+## GPU Memory Service
+
+GMS moves ownership of GPU-resident model weights out of the engine process and
+into a separate GPU memory service. In the failover workflow, this lets the
+active and standby engines share the same weight memory boundary instead of
+loading independent copies.
+
+Direct GMS enablement is useful for backend integration testing and
+sleep/wake-style lifecycle experiments. By itself, it does not configure
+active/passive failover; use the `failover` field for the shadow engine flow.
+
+## Prerequisites
+
+- Kubernetes 1.32 or newer with DRA enabled.
+- NVIDIA GPU DRA driver installed.
+- A matching DRA `DeviceClass`, defaulting to `gpu.nvidia.com`.
+- A supported backend image. The current failover examples are vLLM-focused.
+- Backend command-line support for GMS loading, such as `--load-format gms`.
+- Enough GPU memory for the GMS processes and active or standby engines sharing
+  the device.
+
+## Limitations
+
+- It is not a general checkpoint/restore system.
+- It is not a hardware fault tolerance mechanism for GPU, node, or rack loss.
+- It does not diagnose or fix the backend failure.
+- It does not preserve in-flight requests, network sockets, or KV cache state.
+- It does not make Snapshot restore supported for GPU memory workloads.
+- Snapshot plus GMS is temporarily blocked by admission because of known GPU
+  driver restore issues.
+- It is not covered by the normal v1beta1 compatibility guarantees while it
+  lives under `experimental`.
+
+## API Placement
+
+For `v1alpha1` `DynamoGraphDeployment`, GMS and failover are service-level
+fields:
+
+```yaml
+gpuMemoryService:
+  enabled: true
+failover:
+  enabled: true
+```
+
+For `v1beta1`, preview fields are grouped under `experimental` to make the
+stability contract explicit:
+
+```yaml
+experimental:
+  gpuMemoryService:
+    mode: IntraPod
+  failover:
+    mode: IntraPod
+```
+
+See the [API reference](api-reference.md) for the exact schema supported by your
+CRD version.
+
+## Basic Shadow Engine Failover Example
+
+Failover builds on GMS. In intra-pod mode, the operator clones the worker's main
+container into active and standby engine containers that share GPUs through DRA
+and the GMS sidecar. The standby engine takes over when the active engine fails.
+
+```yaml
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: vllm-agg-failover
+  annotations:
+    nvidia.com/dynamo-kube-discovery-mode: container
+spec:
+  services:
+    VllmWorker:
+      componentType: worker
+      replicas: 1
+      resources:
+        limits:
+          gpu: "2"
+      gpuMemoryService:
+        enabled: true
+      failover:
+        enabled: true
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          args:
+            - --model
+            - Qwen/Qwen3-0.6B
+            - --tensor-parallel-size
+            - "2"
+            - --load-format
+            - gms
+```
+
+See the [vLLM failover example](https://github.com/ai-dynamo/dynamo/blob/main/examples/backends/vllm/deploy/agg_failover.yaml)
+for the full manifest.
+
+## Basic GMS Example
+
+The worker must request GPUs through the normal Dynamo service resources, enable
+`gpuMemoryService`, and run a backend command that can load from GMS.
+
+```yaml
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: vllm-agg-gms
+spec:
+  services:
+    VllmWorker:
+      componentType: worker
+      replicas: 1
+      resources:
+        limits:
+          gpu: "1"
+      gpuMemoryService:
+        enabled: true
+      extraPodSpec:
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+          workingDir: /workspace/examples/backends/vllm
+          command:
+            - python3
+            - -m
+            - dynamo.vllm
+          args:
+            - --model
+            - Qwen/Qwen3-0.6B
+            - --load-format
+            - gms
+```
+
+Working GMS-only examples:
+
+- [vLLM GMS example](https://github.com/ai-dynamo/dynamo/blob/main/examples/backends/vllm/deploy/agg_gms.yaml)
+- [SGLang GMS example](https://github.com/ai-dynamo/dynamo/blob/main/examples/backends/sglang/deploy/agg_gms.yaml)
+
+## Related Documentation
+
+- [Snapshot](snapshot.md)
+- [API Reference](api-reference.md)
+- [vLLM failover example](https://github.com/ai-dynamo/dynamo/blob/main/examples/backends/vllm/deploy/agg_failover.yaml)
+- [vLLM GMS example](https://github.com/ai-dynamo/dynamo/blob/main/examples/backends/vllm/deploy/agg_gms.yaml)
+- [SGLang GMS example](https://github.com/ai-dynamo/dynamo/blob/main/examples/backends/sglang/deploy/agg_gms.yaml)

--- a/docs/kubernetes/snapshot.md
+++ b/docs/kubernetes/snapshot.md
@@ -23,7 +23,7 @@ title: Snapshot
 
 - x86_64 (`amd64`) GPU nodes
 - NVIDIA driver 580.xx or newer on the target GPU nodes (590.xx or newer if testing multi-GPU snapshots)
-- vLLM or SGLang backend today
+- vLLM backend today, with limited preview support
 - `ReadWriteMany` storage for cross-node restore
 - **CRI-O / OpenShift:** set `runtime.type=crio` on the snapshot chart (and `openshift.enabled=true` on OpenShift). Defaults are for containerd; see the chart README for sockets and Helm flags.
 
@@ -145,15 +145,7 @@ spec:
             ...
 ```
 
-If this checkpoint should capture and restore GPU Memory Service helpers, set:
-
-```yaml
-spec:
-  gpuMemoryService:
-    enabled: true
-```
-
-`spec.gpuMemoryService` is outside `spec.identity`, so it does not change the checkpoint identity hash.
+Leave `spec.gpuMemoryService.enabled` unset or `false`. Snapshot plus GPU Memory Service is not yet available, and admission rejects `DynamoCheckpoint` objects with `spec.gpuMemoryService.enabled: true`. See [Shadow Engine Failover](shadow-engine-failover.md) for the current GMS support status.
 
 For a full working example, see [deploy/operator/config/samples/nvidia.com_v1alpha1_dynamocheckpoint.yaml](https://github.com/ai-dynamo/dynamo/blob/main/deploy/operator/config/samples/nvidia.com_v1alpha1_dynamocheckpoint.yaml).
 
@@ -275,7 +267,7 @@ spec:
         ...
 ```
 
-Auto mode only hashes `checkpoint.identity`. If you need GMS-specific checkpoint behavior, configure it on the `DynamoCheckpoint` object with `spec.gpuMemoryService.enabled`.
+Auto mode only hashes `checkpoint.identity`. GMS-specific checkpoint behavior is not yet available.
 
 Useful inspection commands:
 
@@ -295,9 +287,7 @@ kubectl patch dgd vllm-auto-demo -n ${NAMESPACE} --type=merge \
 
 ## Failover Restore
 
-Dynamo supports both intra-pod and inter-pod failover restore topologies. In
-operator-managed deployments, the operator prepares the restore workload
-automatically. Users enable failover in the `DynamoGraphDeployment` spec.
+Failover restore is not yet available. The current Snapshot flow does not support Snapshot plus GMS, so do not use failover restore as a supported checkpoint/restore path. For current GMS and active/passive failover guidance, see [Shadow Engine Failover](shadow-engine-failover.md).
 
 ## Lower-Level Testing With `snapshotctl`
 
@@ -358,7 +348,7 @@ Checkpoints are uniquely identified by a **16-character SHA256 hash** (64 bits) 
 | Field | Required | Affects Hash | Example |
 |-------|----------|-------------|---------|
 | `model` | ✓ | ✓ | `meta-llama/Llama-3-8B` |
-| `backendFramework` | ✓ | ✓ | `sglang`, `vllm` |
+| `backendFramework` | ✓ | ✓ | `vllm` |
 | `dynamoVersion` | | ✓ | `0.9.0`, `1.0.0` |
 | `tensorParallelSize` | | ✓ | `1`, `2`, `4`, `8` |
 | `pipelineParallelSize` | | ✓ | `1`, `2` |
@@ -411,8 +401,10 @@ status:
 
 ## Limitations
 
-- **LLM workers only**: checkpoint/restore supports LLM decode and prefill workers. Specialized workers such as multimodal, embedding, and diffusion are not supported.
-- **Multi-GPU remains preview**: tensor-parallel configurations are exercised in internal testing, but they are not yet a broadly supported production path across clusters.
+- **Backend support is limited**: checkpoint/restore currently supports vLLM workers only, and that support is still a limited preview.
+- **Worker coverage is narrow**: specialized workers such as multimodal, embedding, and diffusion are not supported.
+- **Multi-GPU remains preview**: vLLM tensor-parallel configurations have limited validation and are not yet a broadly supported path across clusters.
+- **GMS restore is not yet available**: Snapshot plus GPU Memory Service is blocked by admission.
 - **Network state is sensitive**: restore is sensitive to live TCP socket state. Loopback bootstrap/control sockets are the most reliable path today.
 - **Privileged DaemonSet required**: `snapshot-agent` must run privileged to execute CRIU and `cuda-checkpoint`. Workload pods do not need to be privileged.
 
@@ -462,10 +454,11 @@ If the manifest already carries snapshot target metadata, it must agree with the
 ## Planned Features
 
 - Stabilize multi-GPU support
-- TensorRT-LLM support
+- Additional backend support
 - Alternative storage backends
 
 ## Related Documentation
 
 - [Installation Guide](installation-guide.md)
+- [Shadow Engine Failover](shadow-engine-failover.md)
 - [API Reference](api-reference.md)


### PR DESCRIPTION
## Summary

- Add a GPU Memory Service Kubernetes docs page that explains when to use GMS today, when not to use it, and how it relates to Snapshot and failover.
- Update Snapshot docs to stop telling users to enable `spec.gpuMemoryService.enabled`, since Snapshot plus GMS is currently rejected by admission because of GPU driver restore issues.
- Link the new page from the Kubernetes docs nav and README, and update the DynamoCheckpoint sample comment to keep GMS checkpoint capture disabled.

## Why

The current Snapshot docs made GMS checkpoint/restore look user-ready even though the operator now blocks that path. The new page makes the experimental status explicit and gives users a clearer decision point for GMS, Snapshot, and failover.

## Validation

- `git diff --check`
- `git diff --cached --check`
- `ruby -e "require 'yaml'; YAML.load_file('docs/index.yml'); puts 'docs/index.yml ok'"`
- verified internal doc targets exist for `gpu-memory-service.md`, `snapshot.md`, and `api-reference.md`

Note: `fern` is not installed in this local environment, so I did not run `fern check` or `fern docs broken-links`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive GPU Memory Service documentation explaining same-node recovery behavior and current limitations
  * Updated navigation to include GPU Memory Service deployment guide
  * Clarified that GPU Memory Service is temporarily disabled with Snapshot due to GPU driver restore issues

* **Chores**
  * Updated sample configuration with guidance notes for GPU Memory Service

<!-- end of auto-generated comment: release notes by coderabbit.ai -->