### PR TITLE
fix: add 15m timeout to shared compliance scan workflow

### DIFF
--- a/.github/workflows/shared-compliance.yml
+++ b/.github/workflows/shared-compliance.yml
@@ -26,6 +26,11 @@ on:
         description: 'Target platforms to test as a JSON array'
         required: true
         type: string
+      compliance_timeout_minutes:
+        description: 'Timeout in minutes for the compliance scan job'
+        required: false
+        type: number
+        default: 15
     secrets:
       AWS_DEFAULT_REGION:
         required: true
@@ -49,6 +54,7 @@ jobs:
     # cuda_version not empty -- name: cuda12, linux/amd64
     # cuda_version empty -- name: cpu, linux/amd64
     name: Compliance ${{ matrix.cuda_version == '' && 'cpu' || format('cuda{0}', matrix.cuda_version) }}, ${{ matrix.platform }}
+    timeout-minutes: ${{ inputs.compliance_timeout_minutes }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2


### PR DESCRIPTION
shared-compliance.yml had no timeout-minutes set on the compliance job, so scans inherited GitHub's default 6h job limit and could hold runners indefinitely. Mirror the just-merged shared-build-image.yml fix (#9106) by exposing a compliance_timeout_minutes input (default 15) and applying it on the job.

ref: OPS-4984
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable timeout for compliance job execution. Users can now set a custom timeout duration (defaults to 15 minutes) when running compliance workflows, providing better control over job execution limits and accommodating diverse project requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->