### PR TITLE
fix: drop registry-backed buildkit cache from docker-remote-build

### DIFF
--- a/.github/actions/docker-remote-build/action.yml
+++ b/.github/actions/docker-remote-build/action.yml
@@ -112,41 +112,6 @@ runs:
         echo "📝 Build log will be saved to: ${BUILD_LOG_FILE}"
 
         # Collect optional overrides provided by the workflow
-        # Set base cache args and set --cache-to if this is a main commit
-        CACHE_ARGS=""
-        if [[ "${{ inputs.target }}" != "frontend" ]]; then
-          BASE_CACHE_TAG="${{ inputs.framework }}-cuda${CUDA_VERSION_MAJOR}-${PLATFORM_SAFE}-cache"
-          if [ -n "${{ inputs.tag_suffix }}" ]; then
-            PRIMARY_CACHE_TAG="${BASE_CACHE_TAG%-cache}-${{ inputs.tag_suffix }}-cache"
-            # Read the suffixed (e.g. test-specific) cache first, then fall back to
-            # the base image cache so layers shared with the normal build are reused.
-            CACHE_ARGS="--cache-from type=registry,ref=${ECR_HOSTNAME}/ai-dynamo/dynamo:main-${PRIMARY_CACHE_TAG} "
-            CACHE_ARGS+="--cache-from type=registry,ref=${ECR_HOSTNAME}/ai-dynamo/dynamo:main-${BASE_CACHE_TAG} "
-            CACHE_ARGS+="--cache-from type=registry,ref=${ECR_HOSTNAME}/ai-dynamo/dynamo:release-${BASE_CACHE_TAG} "
-            if [[ "$GITHUB_REF_NAME" == "main" ]]; then
-              CACHE_ARGS+="--cache-to type=registry,ref=${ECR_HOSTNAME}/ai-dynamo/dynamo:main-${PRIMARY_CACHE_TAG},mode=max "
-            fi
-          else
-            CACHE_TAG="$BASE_CACHE_TAG"
-            CACHE_ARGS="--cache-from type=registry,ref=${ECR_HOSTNAME}/ai-dynamo/dynamo:main-${CACHE_TAG} "
-            CACHE_ARGS+="--cache-from type=registry,ref=${ECR_HOSTNAME}/ai-dynamo/dynamo:release-${CACHE_TAG} "
-            if [[ "$GITHUB_REF_NAME" =~ ^release ]]; then
-              # Release branches also use release cache
-              CACHE_ARGS+="--cache-to type=registry,ref=${ECR_HOSTNAME}/ai-dynamo/dynamo:release-${CACHE_TAG},mode=max "
-            elif [[ "$GITHUB_REF_NAME" == "main" ]]; then
-              CACHE_ARGS+="--cache-to type=registry,ref=${ECR_HOSTNAME}/ai-dynamo/dynamo:main-${CACHE_TAG},mode=max "
-            fi
-          fi
-        else
-          CACHE_TAG="${{ inputs.target }}-cuda${CUDA_VERSION_MAJOR}-${PLATFORM_SAFE}-cache"
-          CACHE_ARGS="--cache-from type=registry,ref=${ECR_HOSTNAME}/ai-dynamo/dynamo:main-${CACHE_TAG} "
-          if [[ "$GITHUB_REF_NAME" == "main" ]]; then
-            CACHE_ARGS+="--cache-to type=registry,ref=${ECR_HOSTNAME}/ai-dynamo/dynamo:main-${CACHE_TAG},mode=max "
-          fi
-        fi
-
-        echo "$CACHE_ARGS"
-        # Collect optional overrides provided by the workflow
         if [ "${{ inputs.no_cache }}" == "true" ]; then
           EXTRA_ARGS+=" --no-cache"
         fi
@@ -206,7 +171,7 @@ runs:
           --tag "$IMAGE_TAG" \
           --platform "${PLATFORM_FLAG}" \
           -f ./container/rendered.Dockerfile \
-          $TARGET_ARG $CACHE_ARGS $EXTRA_ARGS $SECRET_ARGS . 2>&1 | tee "${BUILD_LOG_FILE}"
+          $TARGET_ARG $EXTRA_ARGS $SECRET_ARGS . 2>&1 | tee "${BUILD_LOG_FILE}"
 
         BUILD_EXIT_CODE=${PIPESTATUS[0]}
 


### PR DESCRIPTION
The --cache-from type=registry pulls were stalling multi-arch builds for 9-18 minutes per cross-stage COPY on the cold-side worker, while the warm-side arch hit ~100% cache from the local snapshotter anyway. route_buildkit.sh deterministically pins each framework x cuda x arch combo to a small candidate pod pool, so local-cache hit rate is high enough that the registry cache was net overhead. sccache (S3-backed) still covers individual Rust/C++ compile units regardless.

Removes both --cache-from and --cache-to; with no readers, cache-to writes were dead weight. The no_cache input and --no-cache flag are unchanged for nightly regression detection.

ref: OPS-4984

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed registry-based build caching from Docker build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->