### PR TITLE
fix(kvbm v2): config-driven KV layout, stricter shape inference

### DIFF
--- a/lib/bindings/kvbm/python/kvbm/v2/vllm/schedulers/worker.py
+++ b/lib/bindings/kvbm/python/kvbm/v2/vllm/schedulers/worker.py
@@ -23,6 +23,7 @@ bind happens later, when the leader's `initialize_workers()` RPC drives
 from __future__ import annotations
 
 from dataclasses import dataclass
+import math
 from typing import TYPE_CHECKING, Optional
 
 import kvbm
@@ -39,32 +40,78 @@ class KvTensorLayout:
     """Semantic description of the KV cache tensor layout.
 
     Python derives this from VllmConfig (which has the model architecture)
-    so that Rust doesn't have to guess from raw tensor shapes.
+    so that Rust does not need to guess from raw tensor shapes.
 
-    For MLA models, outer_dim and inner_dim are set explicitly because Rust's
-    shape-based inference cannot distinguish the fused KV latent axis from the
-    block/page axis. For standard attention the fields are None, which tells
-    Rust to fall back to its own contiguity-based inference (already correct).
+    For both MLA and standard attention, dimensions are computed explicitly
+    from vLLM config and passed down to Rust. Tensor shape is only used for
+    sanity validation (e.g., block-axis presence / packed-tail checks).
 
     Mirrors the v1 helper in
     lib/bindings/kvbm/python/kvbm/vllm_integration/connector_worker.py.
     """
 
-    outer_dim: Optional[int]  # None = let Rust infer; 1 for MLA
-    inner_dim: Optional[int]  # None = let Rust infer; head_size for MLA
+    outer_dim: Optional[int]
+    inner_dim: Optional[int]
 
     @classmethod
     def from_vllm_config(
-        cls, shape: "torch.Size", use_mla: bool = False
+        cls,
+        vllm_config: "VllmConfig",
+        shape: "torch.Size",
+        num_device_blocks: int,
+        use_mla: bool = False,
     ) -> "KvTensorLayout":
         if use_mla:
             # MLA tensors are 3D: [num_blocks, page_size, head_size].
             # No outer_dim axis — K and V are fused into a single latent.
             return cls(outer_dim=1, inner_dim=int(shape[-1]))
-        # Standard attention: Rust already infers outer_dim/inner_dim correctly
-        # from tensor shape. Don't guess here — the block dimension can be at
-        # position 0 or 1 depending on the attention backend.
-        return cls(outer_dim=None, inner_dim=None)
+        # Standard attention:
+        # - outer_dim is K/V axis = 2
+        # - inner_dim is per-rank kv width = num_local_kv_heads * head_size
+        total_kv_heads = int(vllm_config.model_config.get_total_num_kv_heads())
+        head_size = int(vllm_config.model_config.get_head_size())
+        tp_size = int(vllm_config.parallel_config.tensor_parallel_size)
+        if tp_size <= 0:
+            raise ValueError(f"Invalid tensor_parallel_size={tp_size}")
+        if total_kv_heads % tp_size != 0:
+            raise ValueError(
+                "Cannot derive per-rank KV heads from config: "
+                f"total_num_kv_heads={total_kv_heads}, tensor_parallel_size={tp_size}"
+            )
+
+        local_kv_heads = total_kv_heads // tp_size
+        outer_dim = 2
+        inner_dim = local_kv_heads * head_size
+        if inner_dim <= 0:
+            raise ValueError(
+                "Invalid standard attention inner_dim derived from config: "
+                f"inner_dim={inner_dim}, local_kv_heads={local_kv_heads}, "
+                f"head_size={head_size}"
+            )
+
+        # Sanity checks against actual tensor shape so we fail loudly if vLLM
+        # changes layout semantics.
+        if len(shape) < 4:
+            raise ValueError(
+                "Standard attention KV tensor must have >=4 dims; "
+                f"got shape={tuple(shape)}"
+            )
+        if int(shape[0]) < num_device_blocks and int(shape[1]) < num_device_blocks:
+            raise ValueError(
+                "Cannot locate num_device_blocks in standard KV tensor shape; "
+                f"shape[:2]={tuple(shape[:2])}, num_device_blocks={num_device_blocks}"
+            )
+
+        inferred_inner_from_shape = int(math.prod(shape[3:]))
+        if inferred_inner_from_shape != inner_dim:
+            raise ValueError(
+                "KV layout mismatch between vLLM config and tensor shape: "
+                f"config_inner_dim={inner_dim}, shape_inner_dim={inferred_inner_from_shape}, "
+                f"shape={tuple(shape)}, total_num_kv_heads={total_kv_heads}, "
+                f"head_size={head_size}, tp_size={tp_size}"
+            )
+
+        return cls(outer_dim=outer_dim, inner_dim=inner_dim)
 
 
 # Import KvbmRuntime and ConnectorWorker from Rust bindings (requires v2 feature)
@@ -212,26 +259,31 @@ class SchedulerConnectorWorker:
                 "Hybrid models with different KV cache shapes are not supported yet."
             )
 
-        # Derive layout semantics from the vLLM model config so Rust doesn't
-        # have to guess the outer_dim/inner_dim from potentially-ambiguous
-        # tensor shapes (MLA caches are 3D without a K/V axis).
-        use_mla = getattr(self.vllm_config.model_config, "use_mla", False)
-        layout = KvTensorLayout.from_vllm_config(shape, use_mla)
-
         # Extract parameters.
-        # Standard attention: [2 (K/V), num_blocks, ...] or [num_blocks, 2, ...]
-        #   — block dim is whichever of shape[0]/shape[1] is larger.
-        # MLA: [num_blocks, page_size, head_size] — block dim is always axis 0.
-        num_device_blocks = shape[0] if use_mla else max(shape[0], shape[1])
+        # Prefer vLLM config's GPU block count; fall back to tensor-derived only
+        # when config is unavailable (older bring-up edge cases).
+        use_mla = getattr(self.vllm_config.model_config, "use_mla", False)
+        config_gpu_blocks = self.vllm_config.cache_config.num_gpu_blocks
+        if config_gpu_blocks is None or config_gpu_blocks <= 0:
+            num_device_blocks = int(shape[0] if use_mla else max(shape[0], shape[1]))
+            print(
+                "Warning: cache_config.num_gpu_blocks unavailable; "
+                f"falling back to tensor-derived num_device_blocks={num_device_blocks}"
+            )
+        else:
+            num_device_blocks = int(config_gpu_blocks)
+
+        # Derive explicit layout semantics from vLLM model config + tensor shape.
+        layout = KvTensorLayout.from_vllm_config(
+            self.vllm_config, shape, num_device_blocks, use_mla
+        )
+
         page_size = self.vllm_config.cache_config.block_size
         dtype_width_bytes = self.kvbm_config.cache_dtype_bytes()
-
-        config_gpu_blocks = self.vllm_config.cache_config.num_gpu_blocks
-        if num_device_blocks != config_gpu_blocks:
-            print(
-                f"Warning: num_device_blocks from tensor ({num_device_blocks}) "
-                f"!= config.num_gpu_blocks ({config_gpu_blocks}). "
-                f"Using tensor-derived value."
+        if shape[0] < num_device_blocks and shape[1] < num_device_blocks:
+            raise ValueError(
+                "Cannot locate num_device_blocks in KV tensor shape; "
+                f"shape[:2]={tuple(shape[:2])}, num_gpu_blocks={num_device_blocks}"
             )
 
         # Phase 2A: Register KV caches with NIXL via Rust binding

--- a/lib/kvbm-connector/src/vllm/layout.rs
+++ b/lib/kvbm-connector/src/vllm/layout.rs
@@ -75,15 +75,30 @@ pub fn determine_kv_layout(
     }
 
     // Locate the blocks dimension from shape (independent of explicit dims).
-    let block_dim = if shape[0] >= num_device_blocks {
-        BlockDimension::BlockIsFirstDim
-    } else if shape[1] >= num_device_blocks {
-        BlockDimension::BlockIsSecondDim
-    } else {
-        bail!(
-            "Unexpected tensor shape: {:?}; expected num_device_blocks: {num_device_blocks} to be present in the first or second dimension",
-            shape
-        );
+    //
+    // Be strict on ambiguity: if both leading dimensions could be interpreted as
+    // the blocks axis we fail instead of silently picking axis 0. Silent fallback
+    // here can corrupt layout math (outer_dim/inner_dim) and under-transfer bytes.
+    let dim0_matches = shape[0] >= num_device_blocks;
+    let dim1_matches = shape[1] >= num_device_blocks;
+    let block_dim = match (dim0_matches, dim1_matches) {
+        (true, false) => BlockDimension::BlockIsFirstDim,
+        (false, true) => BlockDimension::BlockIsSecondDim,
+        (false, false) => {
+            bail!(
+                "Unexpected tensor shape: {:?}; expected num_device_blocks ({}) to be present in one of the first two dimensions",
+                shape,
+                num_device_blocks
+            );
+        }
+        (true, true) => {
+            bail!(
+                "Ambiguous tensor shape for block-dimension detection: shape[:2]={:?}, num_device_blocks={}. \
+                 Both leading dims satisfy >= num_device_blocks; cannot safely infer block axis.",
+                &shape[..2],
+                num_device_blocks
+            );
+        }
     };
 
     // Resolve outer_dim / inner_dim.


### PR DESCRIPTION
Fixes KVBM-426

  fix(kvbm v2): config-driven KV layout, stricter shape inference
  
  `worker.py` (Python): derive `outer_dim` and `inner_dim` explicitly from `VllmConfig` (`total_num_kv_heads / head_size / tensor_parallel_size`) instead of telling Rust to fall back to shape-based inference for standard attention. Add sanity checks against the actual tensor shape so a vLLM layout change fails loudly instead of silently producing wrong byte counts. Prefer `cache_config.num_gpu_blocks` over `tensor[0]/tensor[1]` heuristics for `num_device_blocks`, with a fallback for older bring-up paths.

  `layout.rs` (Rust): tighten block-dimension detection in determine_kv_layout. 
  
  Together these eliminate a class of silent layout mis-detections that produced inflated effective bandwidth in onboard transfer

#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9123" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->