### PR TITLE
chore(container): bump tensorrt-llm pin from 1.3.0rc11 to 1.3.0rc13

### DIFF
--- a/components/src/dynamo/trtllm/engines/diffusion_engine.py
+++ b/components/src/dynamo/trtllm/engines/diffusion_engine.py
@@ -281,6 +281,18 @@ class DiffusionEngine:
             seed=seed if seed is not None else random.randint(0, 2**32 - 1),
         )
 
+        # The executor normally fills None fields with pipeline defaults via
+        # _merge_defaults; we call infer() directly so we replicate that here.
+        for name, default in self._pipeline.default_generation_params.items():
+            if hasattr(req, name) and getattr(req, name) is None:
+                setattr(req, name, default)
+        specs = self._pipeline.extra_param_specs
+        if specs:
+            if req.extra_params is None:
+                req.extra_params = {}
+            for key, spec in specs.items():
+                req.extra_params.setdefault(key, spec.default)
+
         # Run the pipeline — infer() wraps forward() with torch.no_grad()
         output = self._pipeline.infer(req)
 

--- a/components/src/dynamo/trtllm/engines/diffusion_engine.py
+++ b/components/src/dynamo/trtllm/engines/diffusion_engine.py
@@ -145,7 +145,7 @@ class DiffusionEngine:
 
         Maps dynamo's DiffusionConfig fields to TensorRT-LLM's VisualGenArgs
         structure with its nested sub-configs (PipelineConfig, TorchCompileConfig,
-        CudaGraphConfig, AttentionConfig, ParallelConfig, TeaCacheConfig,
+        CudaGraphConfig, AttentionConfig, ParallelConfig, optional cache config,
         quant_config).
 
         Returns:
@@ -199,14 +199,14 @@ class DiffusionEngine:
                 dit_cfg_size=self.config.dit_cfg_size,
                 dit_fsdp_size=self.config.dit_fsdp_size,
             ),
-            teacache=TeaCacheConfig(
-                enable_teacache=self.config.enable_teacache,
-                use_ret_steps=self.config.teacache_use_ret_steps,
-                teacache_thresh=self.config.teacache_thresh,
-            ),
         )
 
         # Add optional fields
+        if self.config.enable_teacache:
+            args_kwargs["cache"] = TeaCacheConfig(
+                use_ret_steps=self.config.teacache_use_ret_steps,
+                teacache_thresh=self.config.teacache_thresh,
+            )
         if self.config.revision:
             args_kwargs["revision"] = self.config.revision
         if quant_config is not None:

--- a/components/src/dynamo/trtllm/tests/test_trtllm_video_diffusion.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_video_diffusion.py
@@ -519,6 +519,8 @@ class TestDiffusionEngineGenerate:
         engine = DiffusionEngine(config=config)
         engine._initialized = True
         engine._pipeline = MagicMock()
+        engine._pipeline.default_generation_params = {}
+        engine._pipeline.extra_param_specs = {}
         engine._pipeline.infer.return_value = SimpleNamespace(
             video=torch.zeros((1, 4, 64, 64, 3), dtype=torch.uint8),
             image=None,
@@ -535,6 +537,7 @@ class TestDiffusionEngineGenerate:
         class FakeDiffusionRequest:
             def __init__(self, **kwargs):
                 captured.update(kwargs)
+                self.extra_params = kwargs.get("extra_params")
                 for k, v in kwargs.items():
                     setattr(self, k, v)
 

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -105,10 +105,10 @@ trtllm:
   python_version: "3.12"
   index_url: https://pypi.nvidia.com/
   pip_wheel_dir: /tmp/trtllm_wheel/
-  pip_wheel: tensorrt-llm==1.3.0rc11
+  pip_wheel: tensorrt-llm==1.3.0rc13
   trtllm_wheel_image: nvcr.io/nvidia/tensorrt-llm/release:${TENSORRTLLM_PIP_WHEEL#*==}
 
-  github_trtllm_commit: v1.3.0rc11
+  github_trtllm_commit: v1.3.0rc13
   torch_version: 2.11.0a0+eb65b36914.nv26.2
   torch_tensorrt_version: 2.11.0a0
   torchvision_version: 0.25.0a0+1e53952f.nv26.2.44259020

--- a/container/deps/requirements.common.txt
+++ b/container/deps/requirements.common.txt
@@ -30,7 +30,7 @@ tensorboard>=2.19.0,<2.21.0
 tensorboardX==2.6.2.2
 # Transformers version constraint for container builds
 # - vLLM 0.11.0: >=4.55.2, vLLM 0.11.2: >=4.56.0,<5
-# - TensorRT-LLM 1.3.0rc11: ==4.57.3
+# - TensorRT-LLM 1.3.0rc13: ==4.57.3
 # - SGLang 0.5.8: ==4.57.1
 # Using >=4.56.0 to satisfy all frameworks
 transformers>=4.56.0

--- a/container/deps/requirements.test.txt
+++ b/container/deps/requirements.test.txt
@@ -10,6 +10,8 @@ allure-pytest==2.15.3
 # For MinIO/S3 operations in LoRA tests (replaces AWS CLI dependency)
 boto3==1.42.4
 boto3-stubs[s3]==1.42.9  # Type stubs for boto3 S3 client
+# requests 2.32.x rejects chardet>=6 in its compatibility check
+chardet<6
 coverage[toml]==7.13.1
 # For IFEval dataset loading in kvbm tests
 datasets==4.4.1

--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -31,7 +31,7 @@ The following table shows the backend framework versions included with each Dyna
 
 | **Dynamo** | **SGLang** | **TensorRT-LLM** | **vLLM** | **NIXL** |
 | :--- | :--- | :--- | :--- | :--- |
-| **main (ToT)** | `0.5.10.post1` | `1.3.0rc11` | `0.20.0` | `0.10.1` (TRT-LLM, vLLM); `1.0.1` (SGLang) |
+| **main (ToT)** | `0.5.10.post1` | `1.3.0rc13` | `0.20.0` | `0.10.1` (TRT-LLM, vLLM); `1.0.1` (SGLang) |
 | **v1.2.0-deepseek-v4-dev.2** *(experimental, partial)* | upstream DSv4 preview | — | `0.20.0` | `0.10.1` |
 | **v1.1.0** | `0.5.10.post1` | `1.3.0rc11` | `0.19.0` | `0.10.1` (TRT-LLM, vLLM); `1.0.1` (SGLang) |
 | **v1.1.0-dev.3** *(experimental, partial)* | `0.5.10.post1` | `1.3.0rc11` | `0.19.0` | `0.10.1` |


### PR DESCRIPTION
This is the original PR: https://github.com/ai-dynamo/dynamo/pull/8870

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9126" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TensorRT-LLM dependency from version 1.3.0rc11 to 1.3.0rc13.

* **Documentation**
  * Updated support matrix to reflect the new TensorRT-LLM version compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->