### PR TITLE
chore(audit): align telemetry sink init and shutdown

### DIFF
--- a/lib/llm/src/audit/config.rs
+++ b/lib/llm/src/audit/config.rs
@@ -3,25 +3,36 @@
 
 use std::sync::OnceLock;
 
-#[derive(Clone, Copy)]
+use dynamo_runtime::config::environment_names::llm::audit as env_audit;
+
+const DEFAULT_CAPACITY: usize = 1024;
+
+#[derive(Clone, Copy, Debug)]
 pub struct AuditPolicy {
     pub enabled: bool,
     pub force_logging: bool,
+    pub capacity: usize,
 }
 
 static POLICY: OnceLock<AuditPolicy> = OnceLock::new();
 
 /// Audit is enabled if we have at least one sink
-pub fn init_from_env() -> AuditPolicy {
+fn load_from_env() -> AuditPolicy {
+    let capacity = std::env::var(env_audit::DYN_AUDIT_CAPACITY)
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|v| *v > 0)
+        .unwrap_or(DEFAULT_CAPACITY);
     AuditPolicy {
-        enabled: std::env::var("DYN_AUDIT_SINKS").is_ok(),
-        force_logging: std::env::var("DYN_AUDIT_FORCE_LOGGING")
+        enabled: std::env::var(env_audit::DYN_AUDIT_SINKS).is_ok(),
+        force_logging: std::env::var(env_audit::DYN_AUDIT_FORCE_LOGGING)
             .ok()
             .and_then(|v| v.parse::<bool>().ok())
             .unwrap_or(false),
+        capacity,
     }
 }
 
 pub fn policy() -> AuditPolicy {
-    *POLICY.get_or_init(init_from_env)
+    *POLICY.get_or_init(load_from_env)
 }

--- a/lib/llm/src/audit/mod.rs
+++ b/lib/llm/src/audit/mod.rs
@@ -6,3 +6,24 @@ pub mod config;
 pub mod handle;
 pub mod sink;
 pub mod stream;
+
+use tokio_util::sync::CancellationToken;
+
+pub use config::{AuditPolicy, policy};
+
+pub async fn init_from_env() -> anyhow::Result<()> {
+    init_from_env_with_shutdown(CancellationToken::new()).await
+}
+
+pub async fn init_from_env_with_shutdown(shutdown: CancellationToken) -> anyhow::Result<()> {
+    let policy = policy();
+    if !policy.enabled {
+        return Ok(());
+    }
+
+    bus::init(policy.capacity);
+    sink::spawn_workers_from_env(shutdown).await?;
+
+    tracing::info!(capacity = policy.capacity, "Audit initialized");
+    Ok(())
+}

--- a/lib/llm/src/audit/sink.rs
+++ b/lib/llm/src/audit/sink.rs
@@ -4,9 +4,11 @@
 use anyhow::Context as _;
 use async_nats::jetstream;
 use async_trait::async_trait;
+use dynamo_runtime::config::environment_names::llm::audit as env_audit;
 use dynamo_runtime::transports::nats;
 use std::sync::Arc;
 use tokio::sync::broadcast;
+use tokio_util::sync::CancellationToken;
 
 use super::{bus, handle::AuditRecord};
 
@@ -39,7 +41,7 @@ pub struct NatsSink {
 
 impl NatsSink {
     pub fn new(nats_client: dynamo_runtime::transports::nats::Client) -> Self {
-        let subject = std::env::var("DYN_AUDIT_NATS_SUBJECT")
+        let subject = std::env::var(env_audit::DYN_AUDIT_NATS_SUBJECT)
             .unwrap_or_else(|_| "dynamo.audit.v1".to_string());
         Self {
             js: nats_client.jetstream().clone(),
@@ -67,7 +69,7 @@ impl AuditSink for NatsSink {
 }
 
 async fn parse_sinks_from_env() -> anyhow::Result<Vec<Arc<dyn AuditSink>>> {
-    let cfg = std::env::var("DYN_AUDIT_SINKS").unwrap_or_else(|_| "stderr".into());
+    let cfg = std::env::var(env_audit::DYN_AUDIT_SINKS).unwrap_or_else(|_| "stderr".into());
     let mut out: Vec<Arc<dyn AuditSink>> = Vec::new();
     for name in cfg.split(',').map(|s| s.trim().to_lowercase()) {
         match name.as_str() {
@@ -76,7 +78,12 @@ async fn parse_sinks_from_env() -> anyhow::Result<Vec<Arc<dyn AuditSink>>> {
                 let nats_client = nats::ClientOptions::default()
                     .connect()
                     .await
-                    .context("Attempting to connect NATS sink from env var DYN_AUDIT_SINKS")?;
+                    .with_context(|| {
+                        format!(
+                            "Attempting to connect NATS sink from env var {}",
+                            env_audit::DYN_AUDIT_SINKS
+                        )
+                    })?;
                 out.push(Arc::new(NatsSink::new(nats_client)));
             }
             // "pg"   => out.push(Arc::new(PostgresSink::from_env())),
@@ -86,26 +93,51 @@ async fn parse_sinks_from_env() -> anyhow::Result<Vec<Arc<dyn AuditSink>>> {
     Ok(out)
 }
 
-/// spawn one worker per sink; each subscribes to the bus (off hot path)
-pub async fn spawn_workers_from_env() -> anyhow::Result<()> {
+/// Spawn one worker per sink; each subscribes to the bus (off the hot path).
+/// Workers drain remaining records and exit when `shutdown` is cancelled.
+pub async fn spawn_workers_from_env(shutdown: CancellationToken) -> anyhow::Result<()> {
     let sinks = parse_sinks_from_env().await?;
+    let sink_count = sinks.len();
     for sink in sinks {
         let name = sink.name();
         let mut rx: broadcast::Receiver<AuditRecord> = bus::subscribe();
+        let worker_shutdown = shutdown.clone();
         tokio::spawn(async move {
             loop {
-                match rx.recv().await {
-                    Ok(rec) => sink.emit(&rec).await,
-                    Err(broadcast::error::RecvError::Lagged(n)) => tracing::warn!(
-                        sink = name,
-                        dropped = n,
-                        "audit bus lagged; dropped records"
-                    ),
-                    Err(broadcast::error::RecvError::Closed) => break,
+                tokio::select! {
+                    biased;
+                    _ = worker_shutdown.cancelled() => {
+                        loop {
+                            match rx.try_recv() {
+                                Ok(rec) => sink.emit(&rec).await,
+                                Err(broadcast::error::TryRecvError::Lagged(n)) => tracing::warn!(
+                                    sink = name,
+                                    dropped = n,
+                                    "audit bus lagged during shutdown; dropped records"
+                                ),
+                                Err(
+                                    broadcast::error::TryRecvError::Empty
+                                    | broadcast::error::TryRecvError::Closed,
+                                ) => break,
+                            }
+                        }
+                        return;
+                    }
+                    msg = rx.recv() => {
+                        match msg {
+                            Ok(rec) => sink.emit(&rec).await,
+                            Err(broadcast::error::RecvError::Lagged(n)) => tracing::warn!(
+                                sink = name,
+                                dropped = n,
+                                "audit bus lagged; dropped records"
+                            ),
+                            Err(broadcast::error::RecvError::Closed) => break,
+                        }
+                    }
                 }
             }
         });
     }
-    tracing::info!("Audit sinks ready.");
+    tracing::info!(sinks = sink_count, "Audit sinks ready");
     Ok(())
 }

--- a/lib/llm/src/entrypoint/input.rs
+++ b/lib/llm/src/entrypoint/input.rs
@@ -110,15 +110,10 @@ pub async fn run_input(
         tracing::warn!(error = %e, "Agent tool event ingest initialization failed; continuing without tool traces");
     }
 
-    // Initialize audit bus + sink workers (off hot path; fan-out supported)
-    if crate::audit::config::policy().enabled {
-        let cap: usize = std::env::var("DYN_AUDIT_CAPACITY")
-            .ok()
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(1024);
-        crate::audit::bus::init(cap);
-        crate::audit::sink::spawn_workers_from_env().await?;
-        tracing::info!(cap, "Audit initialized");
+    // Initialize audit bus + sink workers (off hot path; fan-out supported).
+    // Soft-fail like trace: a failed audit sink should not bring the server down.
+    if let Err(e) = crate::audit::init_from_env_with_shutdown(drt.child_token()).await {
+        tracing::warn!(error = %e, "Audit initialization failed; continuing without audit sink");
     }
 
     match in_opt {

--- a/lib/llm/tests/audit_nats_integration.rs
+++ b/lib/llm/tests/audit_nats_integration.rs
@@ -155,7 +155,9 @@ mod tests {
                 setup_test_stream(&client, &stream_name, TEST_SUBJECT).await;
 
                 bus::init(100);
-                sink::spawn_workers_from_env().await.unwrap();
+                sink::spawn_workers_from_env(tokio_util::sync::CancellationToken::new())
+                    .await
+                    .unwrap();
                 time::sleep(Duration::from_millis(100)).await;
 
                 // Emit audit record
@@ -210,7 +212,9 @@ mod tests {
                 setup_test_stream(&client, &stream_name, TEST_SUBJECT).await;
 
                 bus::init(100);
-                sink::spawn_workers_from_env().await.unwrap();
+                sink::spawn_workers_from_env(tokio_util::sync::CancellationToken::new())
+                    .await
+                    .unwrap();
                 time::sleep(Duration::from_millis(100)).await;
 
                 // Request with store=true (should be audited)

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -313,6 +313,22 @@ pub mod llm {
         pub const HISTOGRAM_PREFIX: &str = "DYN_HISTOGRAM_";
     }
 
+    /// Audit sink configuration
+    pub mod audit {
+        /// Audit sink selection. Comma-separated values: `stderr`, `nats`.
+        /// Setting any non-empty value enables audit recording.
+        pub const DYN_AUDIT_SINKS: &str = "DYN_AUDIT_SINKS";
+
+        /// Force audit emission even when the request `store` flag is `false`.
+        pub const DYN_AUDIT_FORCE_LOGGING: &str = "DYN_AUDIT_FORCE_LOGGING";
+
+        /// In-process audit bus capacity.
+        pub const DYN_AUDIT_CAPACITY: &str = "DYN_AUDIT_CAPACITY";
+
+        /// NATS subject the JetStream audit sink publishes to.
+        pub const DYN_AUDIT_NATS_SUBJECT: &str = "DYN_AUDIT_NATS_SUBJECT";
+    }
+
     /// Agent trace configuration
     pub mod agent_trace {
         /// Agent trace sink selection. Comma-separated values: stderr,jsonl,jsonl_gz.
@@ -558,6 +574,10 @@ mod tests {
             llm::DYN_ENABLE_STREAMING_TOOL_DISPATCH,
             llm::DYN_ENABLE_STREAMING_REASONING_DISPATCH,
             llm::metrics::DYN_METRICS_PREFIX,
+            llm::audit::DYN_AUDIT_SINKS,
+            llm::audit::DYN_AUDIT_FORCE_LOGGING,
+            llm::audit::DYN_AUDIT_CAPACITY,
+            llm::audit::DYN_AUDIT_NATS_SUBJECT,
             llm::agent_trace::DYN_AGENT_TRACE_SINKS,
             llm::agent_trace::DYN_AGENT_TRACE_OUTPUT_PATH,
             llm::agent_trace::DYN_AGENT_TRACE_CAPACITY,


### PR DESCRIPTION
## Summary
Follow-up from #8789 to align audit-style sink init and shutdown with the agent trace pattern. Closes #8844.

- Centralize audit env var constants in `dynamo_runtime::config::environment_names::llm::audit` (`DYN_AUDIT_SINKS`, `DYN_AUDIT_FORCE_LOGGING`, `DYN_AUDIT_CAPACITY`, `DYN_AUDIT_NATS_SUBJECT`).
- Move `DYN_AUDIT_CAPACITY` parsing onto `AuditPolicy` instead of reading it inline in `run_input`.
- Add `audit::init_from_env` / `audit::init_from_env_with_shutdown(CancellationToken)` mirroring `agents::trace::init_from_env_with_shutdown`.
- Make `audit::sink::spawn_workers_from_env` shutdown-aware: workers `tokio::select!` on the cancellation token and drain the bus before exiting.
- Decision on init failure: soft-fail in `run_input` (`tracing::warn!`, server keeps running), matching trace. An audit sink misconfig should not take down the frontend.

`audit::bus` already uses `TelemetryBus<AuditRecord>`, so no bus migration was needed.

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy -p dynamo-runtime -p dynamo-llm --all-targets -- -D warnings`
- `cargo test -p dynamo-runtime --lib config::environment_names`
- `cargo test -p dynamo-llm --lib audit::`
- `cargo test -p dynamo-llm --lib agents::trace`
- `cargo test -p dynamo-llm --test audit_nats_integration --no-run`

## Test plan
- [ ] CI green
- [ ] (manual, requires NATS) `cargo test --test audit_nats_integration -- --ignored --nocapture --test-threads=1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor
- Refactored audit subsystem to support configurable buffer capacity and graceful cancellation-based shutdown handling.
- Audit initialization errors now continue with warnings instead of stopping operations.

## Chores
- Centralized audit environment variable naming within configuration constants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->