### PR TITLE
test(revalidate): perf: disable Python GC when DYN_TRTLLM_SERVER_DISABLE_GC or TRTLLM_SERVER_DISABLE_GC  is set #9096

### DIFF
--- a/components/src/dynamo/common/__init__.py
+++ b/components/src/dynamo/common/__init__.py
@@ -25,3 +25,5 @@ except Exception:
         __version__ = "0.0.0+unknown"
 
 __all__ = ["__version__", "config_dump", "constants", "utils"]
+
+# revalidate 6428bea71ec 2026-05-05T05:21:15Z

--- a/lib/runtime/src/runtime.rs
+++ b/lib/runtime/src/runtime.rs
@@ -391,3 +391,5 @@ impl Drop for RuntimeType {
         }
     }
 }
+
+// revalidate 6428bea71ec 2026-05-05T05:21:15Z


### PR DESCRIPTION
Hey — this is just a re-validation run, I'm checking if anything broke in CI. Please don't merge. I'll delete this PR if it turns green.

Re-validating that PR #9096 by Richard Huo did not regress, by re-running against a trivial placebo diff:

```
perf: disable Python GC when DYN_TRTLLM_SERVER_DISABLE_GC or TRTLLM_SERVER_DISABLE_GC  is set
```
