### PR TITLE
feat: support renderer stop token IDs

### DIFF
--- a/lib/llm/src/protocols/openai.rs
+++ b/lib/llm/src/protocols/openai.rs
@@ -63,6 +63,10 @@ pub(crate) trait OpenAIStopConditionsProvider {
 
     fn get_stop(&self) -> Option<Vec<String>>;
 
+    fn get_stop_token_ids(&self) -> Result<Option<Vec<TokenIdType>>> {
+        Ok(None)
+    }
+
     fn nvext(&self) -> Option<&nvext::NvExt>;
 
     /// Get ignore_eos from CommonExt if the type supports it.
@@ -180,6 +184,7 @@ impl<T: OpenAIStopConditionsProvider> StopConditionsProvider for T {
         let max_tokens = self.get_max_tokens();
         let min_tokens = self.get_min_tokens();
         let stop = self.get_stop();
+        let stop_token_ids_hidden = self.get_stop_token_ids()?;
         let max_thinking_tokens = self.get_max_thinking_tokens();
 
         if let Some(stop) = &stop
@@ -195,7 +200,7 @@ impl<T: OpenAIStopConditionsProvider> StopConditionsProvider for T {
             max_tokens,
             min_tokens,
             stop,
-            stop_token_ids_hidden: None,
+            stop_token_ids_hidden,
             ignore_eos,
             max_thinking_tokens,
         })

--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -8,6 +8,7 @@ use validator::Validate;
 
 use crate::engines::ValidateRequest;
 use crate::preprocessor::media::MediaDecoder;
+use crate::types::TokenIdType;
 
 use super::{
     OpenAIOutputOptionsProvider, OpenAISamplingOptionsProvider, OpenAIStopConditionsProvider,
@@ -305,6 +306,20 @@ impl OpenAIStopConditionsProvider for NvCreateChatCompletionRequest {
             dynamo_protocols::types::Stop::String(s) => vec![s.clone()],
             dynamo_protocols::types::Stop::StringArray(arr) => arr.clone(),
         })
+    }
+
+    fn get_stop_token_ids(&self) -> anyhow::Result<Option<Vec<TokenIdType>>> {
+        let Some(value) = self.unsupported_fields.get("stop_token_ids") else {
+            return Ok(None);
+        };
+        if value.is_null() {
+            return Ok(None);
+        }
+        serde_json::from_value(value.clone())
+            .map(Some)
+            .map_err(|err| {
+                anyhow::anyhow!("stop_token_ids must be an array of unsigned token IDs: {err}")
+            })
     }
 
     /// Returns a reference to the optional `NvExt` extension, if available.

--- a/lib/llm/src/protocols/openai/validate.rs
+++ b/lib/llm/src/protocols/openai/validate.rs
@@ -137,6 +137,9 @@ const PASSTHROUGH_EXTRA_FIELDS: &[&str] = &[
     // Opt-in for `nvext.prompt_logprobs` on the response. Aliased through
     // to vLLM's `sampling_params.prompt_logprobs` in a follow-up.
     "return_prompt_logprobs",
+    // Renderer-style token stops. The OpenAI schema has string stops only,
+    // but Prime-RL/verifiers renderers already produce token IDs.
+    "stop_token_ids",
 ];
 
 /// Validates that no unsupported fields are present in the request

--- a/lib/llm/tests/test_common_ext.rs
+++ b/lib/llm/tests/test_common_ext.rs
@@ -1,13 +1,16 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use dynamo_llm::protocols::{
-    common::StopConditionsProvider,
-    openai::{
-        chat_completions::NvCreateChatCompletionRequest,
-        common_ext::{CommonExt, CommonExtProvider},
-        completions::NvCreateCompletionRequest,
-        nvext::NvExt,
+use dynamo_llm::{
+    engines::ValidateRequest,
+    protocols::{
+        common::StopConditionsProvider,
+        openai::{
+            chat_completions::NvCreateChatCompletionRequest,
+            common_ext::{CommonExt, CommonExtProvider},
+            completions::NvCreateCompletionRequest,
+            nvext::NvExt,
+        },
     },
 };
 
@@ -211,6 +214,27 @@ fn test_max_thinking_tokens_extraction() {
     let request_none: NvCreateChatCompletionRequest = serde_json::from_str(json_str_none).unwrap();
     let stop_conditions_none = request_none.extract_stop_conditions().unwrap();
     assert_eq!(stop_conditions_none.max_thinking_tokens, None);
+}
+
+#[test]
+fn test_chat_completions_stop_token_ids_extraction() {
+    let json_str = r#"{
+        "model": "test-model",
+        "messages": [{"role": "user", "content": "(token-in mode)"}],
+        "nvext": {
+            "token_data": [1, 2, 3]
+        },
+        "stop_token_ids": [151645, 151643]
+    }"#;
+
+    let request: NvCreateChatCompletionRequest = serde_json::from_str(json_str).unwrap();
+
+    request.validate().unwrap();
+    let stop_conditions = request.extract_stop_conditions().unwrap();
+    assert_eq!(
+        stop_conditions.stop_token_ids_hidden,
+        Some(vec![151645, 151643])
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Adds renderer-style `stop_token_ids` support to the Dynamo chat completions path on top of `bis/dynamo-rl`.

- accepts top-level `stop_token_ids` as an RL/verifiers passthrough field
- parses it for `NvCreateChatCompletionRequest`
- forwards it into `StopConditions.stop_token_ids_hidden`, the existing decoder path that hides stop tokens from output
- adds a request-level test covering `nvext.token_data` + `stop_token_ids` extraction

This keeps the transport on `/v1/chat/completions` with `nvext.token_data`; it does not add `/generate` or revive `/v1/chat/completions/tokens`.

## Compatibility

This is the Dynamo-side piece for Prime-RL/verifiers renderer parity. Companion verifiers PR: https://github.com/PrimeIntellect-ai/verifiers/pull/1287

## Validation

- `git diff --check`

Attempted locally:

- `cargo fmt --check` is blocked by unrelated formatting diffs already present in `bis/dynamo-rl` (`lib/llm/src/http/service/openai.rs`, `lib/llm/src/protocols/openai/chat_completions/delta.rs`).
- `RUSTC=$(rustup which --toolchain 1.90.0 rustc) $(rustup which --toolchain 1.90.0 cargo) test -p dynamo-llm --test test_common_ext test_chat_completions_stop_token_ids_extraction` starts compiling but fails on macOS-only build incompatibilities in existing `dynamo-llm` Linux storage paths (`dynamo_memory::numa`, `DiskStorage`, `fallocate`, `O_DIRECT`).