### PR TITLE
test(revalidate): fix: merge TRT-LLM overrides into --override-engine-args when present #9107

### DIFF
--- a/components/src/dynamo/common/__init__.py
+++ b/components/src/dynamo/common/__init__.py
@@ -25,3 +25,5 @@ except Exception:
         __version__ = "0.0.0+unknown"
 
 __all__ = ["__version__", "config_dump", "constants", "utils"]
+
+# revalidate 8db5ad2b82e 2026-05-05T06:35:15Z

--- a/lib/runtime/src/runtime.rs
+++ b/lib/runtime/src/runtime.rs
@@ -391,3 +391,5 @@ impl Drop for RuntimeType {
         }
     }
 }
+
+// revalidate 8db5ad2b82e 2026-05-05T06:35:15Z


### PR DESCRIPTION
Hey — this is just a re-validation run, I'm checking if anything broke in CI. Please don't merge. I'll delete this PR if it turns green.

Re-validating that PR #9107 by atchernych did not regress, by re-running against a trivial placebo diff:

```
fix: merge TRT-LLM overrides into --override-engine-args when present
```
