### PR TITLE
fix: bump requests to 2.33.1 in test image to match runtime

### DIFF
--- a/container/deps/requirements.test.txt
+++ b/container/deps/requirements.test.txt
@@ -40,7 +40,7 @@ pytest-order==1.3.0
 pytest-rerunfailures==16.1
 pytest-timeout==2.4.0
 pytest-xdist==3.8.0
-requests==2.32.5
+requests==2.33.1
 # Required by kr8s (not declared in kr8s's own dependencies)
 sniffio==1.3.1
 tabulate==0.9.0


### PR DESCRIPTION
The test stage was pinning requests==2.32.5 while the runtime image installs 2.33.1 transitively. The downgrade pulled in the older requests version whose import-time check asserts chardet<6.0.0, and chardet 6.0.0.post1 is now resolved as a transitive of test deps, tripping pyproject.toml's filterwarnings=["error"] and breaking conftest collection across all framework test images.

ref: OPS-4984
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test dependencies to the latest stable version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->