### PR TITLE
feat: unify per-model reasoning disable logic + wire reasoning_effort to template args

### DIFF
--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -46,7 +46,10 @@ use crate::protocols::common::preprocessor::{
 use crate::protocols::common::timing::RequestTracker;
 use crate::tokenizers::Encoding;
 
-use dynamo_parsers::{ReasoningParser, ReasoningParserType};
+use dynamo_parsers::{
+    DisableCondition, ReasoningParser, ReasoningParserType, get_disable_conditions,
+    get_reasoning_template_key,
+};
 use dynamo_runtime::engine::{AsyncEngine, AsyncEngineContextProvider, ResponseStream};
 use dynamo_runtime::pipeline::{
     AsyncEngineContext, Error, ManyOut, Operator, SingleIn, async_trait,
@@ -1280,70 +1283,58 @@ impl OpenAIPreprocessor {
             || matches!(reasoning_parser, Some("gemma4") | Some("gemma-4"))
     }
 
+    /// Override chat_template_args based on reasoning_effort
+    fn apply_reasoning_overrides_to_template_args(
+        parser_name: Option<&str>,
+        reasoning_effort: Option<&dynamo_protocols::types::ReasoningEffort>,
+        chat_template_args: &mut Option<std::collections::HashMap<String, serde_json::Value>>,
+    ) {
+        let Some(parser_name) = parser_name else {
+            return;
+        };
+
+        let enable_thinking: Option<bool> = match reasoning_effort {
+            None => None,
+            Some(dynamo_protocols::types::ReasoningEffort::None) => Some(false),
+            _ => Some(true),
+        };
+        let Some(enabled) = enable_thinking else {
+            return;
+        };
+
+        let thinking_template_key = get_reasoning_template_key(parser_name);
+
+        let args = chat_template_args.get_or_insert_with(std::collections::HashMap::new);
+        args.insert(
+            thinking_template_key.to_string(),
+            serde_json::Value::Bool(enabled),
+        );
+    }
+
     /// Check if reasoning parsing should be disabled based on per-request parameters.
-    /// For kimi_k25: disabled when chat_template_args contains "thinking": false.
-    /// For nemotron_nano: disabled when chat_template_args contains "enable_thinking": false
-    ///   or "force_nonempty_content": true.
-    /// For deepseek_r1 / deepseek_v4: disabled when chat_template_args contains
-    ///   "thinking": false or "thinking_mode": "chat" — matches the V4 formatter's
-    ///   `resolve_thinking_mode` convention, so the parser and the prompt stay in sync.
-    /// For gemma4: disabled when chat_template_args contains "enable_thinking": false.
-    ///   Gemma 4's chat template injects `<|think|>` only when `enable_thinking is
-    ///   defined and enable_thinking` (truthy), so when callers explicitly set the
-    ///   flag false the model emits no `<|channel>` markers and the parser would
-    ///   only ever fall through.
+    ///
+    /// Disable conditions are defined per-parser in `ParserConfig::disable_conditions`
+    /// Reasoning is disabled when any condition matches the provided `chat_template_args`.
     fn is_reasoning_disabled_by_request(
         reasoning_parser: Option<&str>,
         chat_template_args: Option<&std::collections::HashMap<String, serde_json::Value>>,
     ) -> bool {
-        match reasoning_parser {
-            Some("kimi_k25") => {
-                if let Some(args) = chat_template_args
-                    && let Some(thinking) = args.get("thinking")
-                {
-                    return thinking == &serde_json::Value::Bool(false);
-                }
-                false
+        let Some(name) = reasoning_parser else {
+            return false;
+        };
+        let Some(args) = chat_template_args else {
+            return false;
+        };
+
+        let conditions = get_disable_conditions(name);
+        conditions.iter().any(|cond| match cond {
+            DisableCondition::Bool(key, val) => {
+                args.get(*key) == Some(&serde_json::Value::Bool(*val))
             }
-            Some("nemotron_nano") | Some("nemotron3") => {
-                if let Some(args) = chat_template_args {
-                    if let Some(enable_thinking) = args.get("enable_thinking")
-                        && enable_thinking == &serde_json::Value::Bool(false)
-                    {
-                        return true;
-                    }
-                    if let Some(force_nonempty) = args.get("force_nonempty_content")
-                        && force_nonempty == &serde_json::Value::Bool(true)
-                    {
-                        return true;
-                    }
-                }
-                false
+            DisableCondition::Str(key, val) => {
+                args.get(*key).and_then(|v| v.as_str()) == Some(*val)
             }
-            Some("deepseek_r1") | Some("deepseek_v4") | Some("deepseek-v4")
-            | Some("deepseekv4") => {
-                if let Some(enabled) =
-                    crate::preprocessor::prompt::thinking_bool_from_args(chat_template_args)
-                {
-                    return !enabled;
-                }
-                if let Some(args) = chat_template_args
-                    && let Some(mode) = args.get("thinking_mode").and_then(|v| v.as_str())
-                {
-                    return mode == "chat";
-                }
-                false
-            }
-            Some("gemma4") | Some("gemma-4") => {
-                if let Some(enabled) =
-                    crate::preprocessor::prompt::thinking_bool_from_args(chat_template_args)
-                {
-                    return !enabled;
-                }
-                false
-            }
-            _ => false,
-        }
+        })
     }
 
     // Motivation: Each transformation on the stream should be a separate step to allow for more flexibility
@@ -1459,6 +1450,13 @@ impl
 
         // Set stream=true for internal processing (after audit capture)
         request.inner.stream = Some(true);
+
+        // Override chat_template_args based on reasoning_effort
+        Self::apply_reasoning_overrides_to_template_args(
+            self.runtime_config.reasoning_parser.as_deref(),
+            request.inner.reasoning_effort.as_ref(),
+            &mut request.chat_template_args,
+        );
 
         // create a response generator
         let response_generator = request.response_generator(context.id().to_string());
@@ -2090,6 +2088,110 @@ mod tests {
                 OpenAIPreprocessor::is_reasoning_disabled_by_request(parser, args),
                 expected,
                 "FAILED: {desc}",
+            );
+        }
+    }
+
+    #[test]
+    fn test_apply_reasoning_overrides_to_template_args() {
+        use dynamo_protocols::types::ReasoningEffort;
+
+        // (parser, effort, expected_key, expected_value, description)
+        // expected_key = None means the call should leave args unchanged.
+        let cases = [
+            // No effort → args unchanged regardless of parser
+            (
+                Some("basic"),
+                None,
+                None,
+                None,
+                "basic + no effort → args unchanged",
+            ),
+            // ReasoningEffort::None → explicitly disables reasoning
+            (
+                Some("basic"),
+                Some(ReasoningEffort::None),
+                Some("enable_thinking"),
+                Some(false),
+                "basic + None → enable_thinking=false",
+            ),
+            // Generic parsers → "enable_thinking" = true
+            (
+                Some("basic"),
+                Some(ReasoningEffort::Minimal),
+                Some("enable_thinking"),
+                Some(true),
+                "basic + Minimal → enable_thinking=true",
+            ),
+            (
+                Some("nemotron_nano"),
+                Some(ReasoningEffort::Low),
+                Some("enable_thinking"),
+                Some(true),
+                "nemotron_nano + Low → enable_thinking=true",
+            ),
+            // kimi_k25 → "thinking" = true
+            (
+                Some("kimi_k25"),
+                Some(ReasoningEffort::Medium),
+                Some("thinking"),
+                Some(true),
+                "kimi_k25 + Medium → thinking=true",
+            ),
+            // deepseek_r1 → "thinking" = true
+            (
+                Some("deepseek_r1"),
+                Some(ReasoningEffort::High),
+                Some("thinking"),
+                Some(true),
+                "deepseek_r1 + High → thinking=true",
+            ),
+        ];
+
+        for (parser, effort, expected_key, expected_value, desc) in &cases {
+            let mut args = None;
+            OpenAIPreprocessor::apply_reasoning_overrides_to_template_args(
+                *parser,
+                effort.as_ref(),
+                &mut args,
+            );
+            match (expected_key, expected_value) {
+                (None, _) => {
+                    assert!(
+                        args.is_none(),
+                        "FAILED (args should stay unchanged): {desc}"
+                    );
+                }
+                (Some(key), Some(val)) => {
+                    let map = args.as_ref().unwrap_or_else(|| {
+                        panic!("FAILED (args should be Some): {desc}");
+                    });
+                    assert_eq!(
+                        map.get(*key),
+                        Some(&serde_json::Value::Bool(*val)),
+                        "FAILED: {desc}",
+                    );
+                }
+                _ => unreachable!("bad test case: {desc}"),
+            }
+        }
+
+        // Separate check: pre-existing keys are preserved when args is already Some
+        {
+            let mut args = Some(std::collections::HashMap::from([(
+                "custom".to_string(),
+                serde_json::Value::String("keep_me".to_string()),
+            )]));
+            OpenAIPreprocessor::apply_reasoning_overrides_to_template_args(
+                Some("basic"),
+                Some(&ReasoningEffort::High),
+                &mut args,
+            );
+            let map = args.as_ref().unwrap();
+            assert_eq!(
+                map.get("custom"),
+                Some(&serde_json::Value::String("keep_me".to_string())),
+                "pre-existing keys must survive",
             );
         }
     }

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -1283,24 +1283,45 @@ impl OpenAIPreprocessor {
             || matches!(reasoning_parser, Some("gemma4") | Some("gemma-4"))
     }
 
-    /// Override chat_template_args based on reasoning_effort
+    /// Override chat_template_args based on reasoning_effort.
+    ///
+    /// Returns `InvalidArgument` when `reasoning_effort` is present and
+    /// `chat_template_args` already contains a key from the parser's
+    /// `DisableCondition` list, mixing both mechanisms is ambiguous.
     fn apply_reasoning_overrides_to_template_args(
         parser_name: Option<&str>,
         reasoning_effort: Option<&dynamo_protocols::types::ReasoningEffort>,
         chat_template_args: &mut Option<std::collections::HashMap<String, serde_json::Value>>,
-    ) {
+    ) -> Result<()> {
         let Some(parser_name) = parser_name else {
-            return;
+            return Ok(());
         };
 
         let enable_thinking: Option<bool> = match reasoning_effort {
-            None => None,
+            None => return Ok(()),
             Some(dynamo_protocols::types::ReasoningEffort::None) => Some(false),
             _ => Some(true),
         };
         let Some(enabled) = enable_thinking else {
-            return;
+            return Ok(());
         };
+
+        // Reject conflicting manual template args
+        if let Some(args) = chat_template_args.as_ref() {
+            let conditions = get_disable_conditions(parser_name);
+            for cond in &conditions {
+                let key = match cond {
+                    DisableCondition::Bool(k, _) | DisableCondition::Str(k, _) => k,
+                };
+                if args.contains_key(*key) {
+                    return Err(DynamoError::builder()
+                        .error_type(ErrorType::InvalidArgument)
+                        .message(format!("cannot combine reasoning_effort with explicit \"{key}\" in chat_template_args"))
+                        .build()
+                        .into());
+                }
+            }
+        }
 
         let thinking_template_key = get_reasoning_template_key(parser_name);
 
@@ -1309,6 +1330,7 @@ impl OpenAIPreprocessor {
             thinking_template_key.to_string(),
             serde_json::Value::Bool(enabled),
         );
+        Ok(())
     }
 
     /// Check if reasoning parsing should be disabled based on per-request parameters.
@@ -1456,7 +1478,7 @@ impl
             self.runtime_config.reasoning_parser.as_deref(),
             request.inner.reasoning_effort.as_ref(),
             &mut request.chat_template_args,
-        );
+        )?;
 
         // create a response generator
         let response_generator = request.response_generator(context.id().to_string());
@@ -2154,7 +2176,8 @@ mod tests {
                 *parser,
                 effort.as_ref(),
                 &mut args,
-            );
+            )
+            .unwrap();
             match (expected_key, expected_value) {
                 (None, _) => {
                     assert!(
@@ -2186,12 +2209,64 @@ mod tests {
                 Some("basic"),
                 Some(&ReasoningEffort::High),
                 &mut args,
-            );
+            )
+            .unwrap();
             let map = args.as_ref().unwrap();
             assert_eq!(
                 map.get("custom"),
                 Some(&serde_json::Value::String("keep_me".to_string())),
                 "pre-existing keys must survive",
+            );
+        }
+
+        // Conflict: reasoning_effort + explicit disable key → error
+        {
+            let mut args = Some(std::collections::HashMap::from([(
+                "thinking".to_string(),
+                serde_json::Value::Bool(true),
+            )]));
+            let result = OpenAIPreprocessor::apply_reasoning_overrides_to_template_args(
+                Some("deepseek_r1"),
+                Some(&ReasoningEffort::High),
+                &mut args,
+            );
+            assert!(
+                result.is_err(),
+                "reasoning_effort + explicit thinking key must be rejected",
+            );
+        }
+
+        // Conflict: reasoning_effort + thinking_mode string key → error
+        {
+            let mut args = Some(std::collections::HashMap::from([(
+                "thinking_mode".to_string(),
+                serde_json::Value::String("chat".to_string()),
+            )]));
+            let result = OpenAIPreprocessor::apply_reasoning_overrides_to_template_args(
+                Some("deepseek_v4"),
+                Some(&ReasoningEffort::None),
+                &mut args,
+            );
+            assert!(
+                result.is_err(),
+                "reasoning_effort + explicit thinking_mode key must be rejected",
+            );
+        }
+
+        // No conflict: reasoning_effort without any disable keys → ok
+        {
+            let mut args = Some(std::collections::HashMap::from([(
+                "unrelated_key".to_string(),
+                serde_json::Value::Bool(true),
+            )]));
+            let result = OpenAIPreprocessor::apply_reasoning_overrides_to_template_args(
+                Some("deepseek_r1"),
+                Some(&ReasoningEffort::High),
+                &mut args,
+            );
+            assert!(
+                result.is_ok(),
+                "reasoning_effort + unrelated keys must be accepted",
             );
         }
     }

--- a/lib/parsers/src/reasoning/mod.rs
+++ b/lib/parsers/src/reasoning/mod.rs
@@ -21,16 +21,76 @@ pub use minimax_append_think_parser::MiniMaxAppendThinkParser;
 /// `KimiK2ParserConfig::default().section_start` in `crate::tool_calling::config`.
 pub(crate) const KIMI_K2_TOOL_SECTION_BEGIN: &str = "<|tool_calls_section_begin|>";
 
-static REASONING_PARSER_MAP: OnceLock<HashMap<&'static str, ReasoningParserType>> = OnceLock::new();
+static REASONING_PARSER_MAP: OnceLock<HashMap<&'static str, ParserConfig>> = OnceLock::new();
+
+/// A condition under which reasoning parsing is disabled for a given model.
+///
+/// Each variant describes a (key, value) pair in chat_template_args:
+/// when the arg matches, reasoning is considered disabled.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DisableCondition {
+    /// Reasoning is disabled when `args[key] == Bool(value)`.
+    Bool(&'static str, bool),
+    /// Reasoning is disabled when `args[key] == String(value)`.
+    Str(&'static str, &'static str),
+}
+
+#[derive(Debug, Clone)]
+struct ParserConfig {
+    parser_type: ReasoningParserType,
+    disable_conditions: Vec<DisableCondition>,
+}
+
+impl ParserConfig {
+    fn new(parser_type: ReasoningParserType) -> Self {
+        Self {
+            parser_type,
+            disable_conditions: vec![DisableCondition::Bool("enable_thinking", false)],
+        }
+    }
+
+    fn with_key(parser_type: ReasoningParserType, key: &'static str) -> Self {
+        Self {
+            parser_type,
+            disable_conditions: vec![DisableCondition::Bool(key, false)],
+        }
+    }
+
+    fn with_conditions(
+        parser_type: ReasoningParserType,
+        conditions: Vec<DisableCondition>,
+    ) -> Self {
+        Self {
+            parser_type,
+            disable_conditions: conditions,
+        }
+    }
+}
 
 /// Initialize the global reasoning parser map
-fn get_reasoning_parser_map() -> &'static HashMap<&'static str, ReasoningParserType> {
+fn get_reasoning_parser_map() -> &'static HashMap<&'static str, ParserConfig> {
     REASONING_PARSER_MAP.get_or_init(|| {
+        use DisableCondition::*;
+        use ReasoningParserType::*;
+
+        let deepseek_conditions = vec![
+            Bool("thinking", false),
+            Bool("enable_thinking", false),
+            Str("thinking_mode", "chat"),
+        ];
+        let nemotron_conditions = vec![
+            Bool("enable_thinking", false),
+            Bool("force_nonempty_content", true),
+        ];
+
         let mut map = HashMap::new();
-        map.insert("deepseek_r1", ReasoningParserType::DeepseekR1);
-        map.insert("basic", ReasoningParserType::Basic);
-        map.insert("gpt_oss", ReasoningParserType::GptOss);
-        map.insert("qwen3", ReasoningParserType::Qwen);
+        map.insert(
+            "deepseek_r1",
+            ParserConfig::with_conditions(DeepseekR1, deepseek_conditions.clone()),
+        );
+        map.insert("basic", ParserConfig::new(Basic));
+        map.insert("gpt_oss", ParserConfig::new(GptOss));
+        map.insert("qwen3", ParserConfig::new(Qwen));
         // DeepSeek-V4 uses the same `<think>` / `</think>` delimiters as Qwen
         // (confirmed against deepseek-ai/DeepSeek-V4-Pro's encoding_dsv4.py)
         // so it delegates to the same `BasicReasoningParser` config today. We
@@ -44,27 +104,43 @@ fn get_reasoning_parser_map() -> &'static HashMap<&'static str, ReasoningParserT
         // the HF model / vLLM recipe / chat-template author picked. We accept
         // all three separator conventions (snake / kebab / concat) rather than
         // force a single canonical form on users.
-        map.insert("deepseek_v4", ReasoningParserType::DeepSeekV4);
-        map.insert("deepseek-v4", ReasoningParserType::DeepSeekV4);
-        map.insert("deepseekv4", ReasoningParserType::DeepSeekV4);
-        map.insert("nemotron_deci", ReasoningParserType::NemotronDeci);
-        map.insert("kimi", ReasoningParserType::Kimi);
-        map.insert("kimi_k25", ReasoningParserType::KimiK25);
-        map.insert("step3", ReasoningParserType::Step3);
-        map.insert("mistral", ReasoningParserType::Mistral);
-        map.insert("granite", ReasoningParserType::Granite);
-        map.insert("nemotron_nano", ReasoningParserType::DeepseekR1); // nemotron nano is ...</think>
-        map.insert("nemotron3", ReasoningParserType::DeepseekR1);
-        map.insert("glm45", ReasoningParserType::NemotronDeci); // GLM-4.5/5 is <think>...</think>, no force_reasoning
+        map.insert(
+            "deepseek_v4",
+            ParserConfig::with_conditions(DeepSeekV4, deepseek_conditions.clone()),
+        );
+        map.insert(
+            "deepseek-v4",
+            ParserConfig::with_conditions(DeepSeekV4, deepseek_conditions.clone()),
+        );
+        map.insert(
+            "deepseekv4",
+            ParserConfig::with_conditions(DeepSeekV4, deepseek_conditions),
+        );
+        map.insert("nemotron_deci", ParserConfig::new(NemotronDeci));
+        map.insert("kimi", ParserConfig::new(Kimi));
+        map.insert("kimi_k25", ParserConfig::with_key(KimiK25, "thinking"));
+        map.insert("step3", ParserConfig::new(Step3));
+        map.insert("mistral", ParserConfig::new(Mistral));
+        map.insert("granite", ParserConfig::new(Granite));
+
+        map.insert(
+            "nemotron_nano",
+            ParserConfig::with_conditions(DeepseekR1, nemotron_conditions.clone()),
+        );
+        map.insert(
+            "nemotron3",
+            ParserConfig::with_conditions(DeepseekR1, nemotron_conditions),
+        );
+        map.insert("glm45", ParserConfig::new(NemotronDeci)); // GLM-4.5/5 is <think>...</think>, no force_reasoning
         map.insert(
             "minimax_append_think",
-            ReasoningParserType::MiniMaxAppendThink,
+            ParserConfig::new(MiniMaxAppendThink),
         );
         // Gemma 4 thinking models: reasoning is wrapped in `<|channel>...<channel|>`
         // with a `thought\n` role label that this parser strips. Pair with
         // `--dyn-tool-call-parser gemma4` for end-to-end Gemma 4 support.
-        map.insert("gemma4", ReasoningParserType::Gemma4);
-        map.insert("gemma-4", ReasoningParserType::Gemma4);
+        map.insert("gemma4", ParserConfig::new(Gemma4));
+        map.insert("gemma-4", ParserConfig::new(Gemma4));
         map
     })
 }
@@ -72,6 +148,34 @@ fn get_reasoning_parser_map() -> &'static HashMap<&'static str, ReasoningParserT
 /// Get all available reasoning parser names
 pub fn get_available_reasoning_parsers() -> Vec<&'static str> {
     get_reasoning_parser_map().keys().copied().collect()
+}
+
+/// Returns the disable conditions for the given reasoning parser.
+///
+/// Falls back to `[DisableCondition::Bool("enable_thinking", false)]` for unknown parsers.
+pub fn get_disable_conditions(name: &str) -> Vec<DisableCondition> {
+    let normalized = name.to_lowercase();
+    get_reasoning_parser_map()
+        .get(normalized.as_str())
+        .map(|c| c.disable_conditions.clone())
+        .unwrap_or_else(|| vec![DisableCondition::Bool("enable_thinking", false)])
+}
+
+/// Returns the chat template arg key that controls reasoning for the given parser.
+///
+/// This is the first `Bool(key, false)` entry from the parser's disable conditions,
+/// used when writing overrides (e.g. mapping `reasoning_effort` to template args).
+pub fn get_reasoning_template_key(name: &str) -> &'static str {
+    let normalized = name.to_lowercase();
+    get_reasoning_parser_map()
+        .get(normalized.as_str())
+        .and_then(|c| {
+            c.disable_conditions.iter().find_map(|cond| match cond {
+                DisableCondition::Bool(key, false) => Some(*key),
+                _ => None,
+            })
+        })
+        .unwrap_or("enable_thinking")
 }
 
 #[derive(Debug, Clone, Default)]
@@ -263,7 +367,7 @@ impl ReasoningParserType {
         let normalized_name = name.to_lowercase();
 
         match parser_map.get(normalized_name.as_str()) {
-            Some(parser_type) => parser_type.get_reasoning_parser(),
+            Some(config) => config.parser_type.get_reasoning_parser(),
             None => {
                 tracing::warn!(
                     parser_name = name,
@@ -572,5 +676,20 @@ mod tests {
         }
         assert_eq!(all_reasoning, "Weighing options.");
         assert_eq!(all_content, "Beijing is sunny.");
+    }
+
+    #[test]
+    fn test_get_reasoning_template_key() {
+        // Parsers that default to "enable_thinking"
+        assert_eq!(get_reasoning_template_key("basic"), "enable_thinking");
+        assert_eq!(
+            get_reasoning_template_key("nemotron_nano"),
+            "enable_thinking"
+        );
+        // Parsers that use "thinking" key
+        assert_eq!(get_reasoning_template_key("deepseek_r1"), "thinking");
+        assert_eq!(get_reasoning_template_key("kimi_k25"), "thinking");
+        // Unknown parser falls back to "enable_thinking"
+        assert_eq!(get_reasoning_template_key("nonexistent"), "enable_thinking");
     }
 }


### PR DESCRIPTION
#### Overview:

Currently, the `reasoning_effort` parameter in the Chat Completions API is accepted but has no effect on reasoning models. Users who want to control thinking behavior must manually set model-specific `chat_template_args` (e.g., `enable_thinking` for Qwen, `thinking` for DeepSeek/Kimi), which breaks OpenAI compatibility and forces users to learn per-model internals.

Additionally, `is_reasoning_disabled_by_request` uses a model-specific match block that must be extended by hand for every new parser, currently covering kimi_k25, nemotron, deepseek, and gemma4 with different key/value conventions.

This PR wires `reasoning_effort` to the correct template args and replaces the match block with a generic loop over per-parser `DisableCondition`.

#### Details:

**`lib/parsers/src/reasoning/mod.rs`**
- New `pub enum DisableCondition { Bool, Str }` – a (key, value) pair in `chat_template_args` that disables reasoning for a given parser.
- Each parser in the map declares its own conditions, e.g. DeepSeek: `[thinking=false, enable_thinking=false, thinking_mode="chat"]`.
- New `pub fn get_disable_conditions()` and `get_reasoning_template_key()` expose this configuration to the preprocessor.

**`lib/llm/src/preprocessor.rs`**
- New `apply_reasoning_overrides_to_template_args()` translates `reasoning_effort` into the correct template arg before rendering:
  - `"none"` → disable thinking
  - `"minimal"` / `"low"` / `"medium"` / `"high"` → enable thinking
  - absent → no override
- `is_reasoning_disabled_by_request()` replaced with a generic loop over `DisableCondition`, the model-specific match block is removed entirely.

#### Where should the reviewer start?

`lib/parsers/src/reasoning/mod.rs` – the `DisableCondition` enum and parser map, then `lib/llm/src/preprocessor.rs` for how they're consumed.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9154" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced reasoning effort configuration with dynamic overrides for multiple parser types.
  * Extended support for additional reasoning parser variants including DeepSeek V4 and Nemotron.

* **Refactor**
  * Streamlined reasoning disable logic from hardcoded conditions to generic, configurable implementation.

* **Tests**
  * Expanded test coverage for reasoning effort and parser configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->