### PR TITLE
test(revalidate): feat: Remove deprecated dynamoNamespace references from docs and examples #9101

### DIFF
--- a/components/src/dynamo/common/__init__.py
+++ b/components/src/dynamo/common/__init__.py
@@ -25,3 +25,5 @@ except Exception:
         __version__ = "0.0.0+unknown"
 
 __all__ = ["__version__", "config_dump", "constants", "utils"]
+
+# revalidate 0515d887387 2026-05-05T14:56:04Z

--- a/lib/runtime/src/runtime.rs
+++ b/lib/runtime/src/runtime.rs
@@ -391,3 +391,5 @@ impl Drop for RuntimeType {
         }
     }
 }
+
+// revalidate 0515d887387 2026-05-05T14:56:04Z


### PR DESCRIPTION
Hey — this is just a re-validation run, I'm checking if anything broke in CI. Please don't merge. I'll delete this PR if it turns green.

Re-validating that PR #9101 by Julien Mancuso did not regress, by re-running against a trivial placebo diff:

```
feat: Remove deprecated dynamoNamespace references from docs and examples
```
