### PR TITLE
Extract agent-trace state builder into a helper

### DIFF
--- a/lib/llm/src/agents/trace/integration.rs
+++ b/lib/llm/src/agents/trace/integration.rs
@@ -3,16 +3,23 @@
 
 //! Dynamo LLM integration helpers for agent trace records.
 
+use std::pin::Pin;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use dynamo_runtime::DistributedRuntime;
+use dynamo_runtime::pipeline::Context;
+use dynamo_runtime::protocols::annotated::Annotated;
 use dynamo_runtime::transports::event_plane::EventSubscriber;
+use futures::Stream;
 
+use crate::agents::context::AgentContext;
 use crate::agents::trace::{
     AgentRequestMetrics, AgentToolEventRelay, AgentTracePolicy, AgentTraceRecord,
     DEFAULT_TOOL_EVENTS_TOPIC, WorkerInfo,
 };
 use crate::local_model::LocalModel;
+use crate::protocols::common::preprocessor::PreprocessedRequest;
 use crate::protocols::common::timing::RequestTracker;
 
 /// Record token counts needed by agent trace request-end records.
@@ -81,6 +88,76 @@ pub(crate) fn request_metrics(
             .and_then(|timing| timing.router_queue_depth.map(|v| v as u64)),
         worker,
     }
+}
+
+pub(crate) struct AgentTraceRequestEndState {
+    pub agent_context: AgentContext,
+    pub request_model: String,
+    pub request_tracker: Option<Arc<RequestTracker>>,
+    pub x_request_id: Option<String>,
+}
+
+pub(crate) fn build_agent_trace_request_end_state(
+    common_request: &PreprocessedRequest,
+    tracker: &Option<Arc<RequestTracker>>,
+    context: &Context<()>,
+) -> Option<AgentTraceRequestEndState> {
+    if !super::is_enabled() {
+        return None;
+    }
+    let agent_context = common_request.agent_context.clone()?;
+    let x_request_id = dynamo_runtime::logging::get_distributed_tracing_context()
+        .and_then(|c| c.x_request_id)
+        .or_else(|| {
+            context
+                .get::<String>(super::X_REQUEST_ID_CONTEXT_KEY)
+                .ok()
+                .map(|v| v.as_ref().clone())
+        });
+    Some(AgentTraceRequestEndState {
+        agent_context,
+        request_model: common_request.model.clone(),
+        request_tracker: tracker.clone(),
+        x_request_id,
+    })
+}
+
+pub(crate) fn wrap_agent_trace_request_end_stream<Resp>(
+    stream: Pin<Box<dyn Stream<Item = Annotated<Resp>> + Send>>,
+    trace_state: Option<AgentTraceRequestEndState>,
+    request_id: String,
+) -> Pin<Box<dyn Stream<Item = Annotated<Resp>> + Send>>
+where
+    Resp: Send + 'static,
+{
+    let Some(AgentTraceRequestEndState {
+        agent_context,
+        request_model,
+        request_tracker,
+        x_request_id,
+    }) = trace_state
+    else {
+        return stream;
+    };
+
+    let (stream, done_fut) = crate::telemetry::stream::notify_on_completion(stream);
+    tokio::spawn(async move {
+        done_fut.await;
+        if request_tracker.is_none() {
+            tracing::warn!(
+                request_id,
+                "agent_context present but request tracker is missing; emitting partial trace"
+            );
+        }
+        let metrics = super::request_metrics(
+            request_id,
+            x_request_id,
+            request_model,
+            request_tracker.as_deref(),
+        );
+        super::emit_request_end(agent_context, metrics);
+    });
+    stream
 }
 
 pub(crate) async fn start_tool_event_ingest_from_policy(

--- a/lib/llm/src/agents/trace/mod.rs
+++ b/lib/llm/src/agents/trace/mod.rs
@@ -14,7 +14,8 @@ use crate::telemetry::bus::TelemetryBus;
 
 pub use config::{AgentTracePolicy, is_enabled, policy};
 pub(crate) use integration::{
-    record_llm_metric_tokens, request_metrics, start_tool_event_ingest_from_policy,
+    build_agent_trace_request_end_state, record_llm_metric_tokens, request_metrics,
+    start_tool_event_ingest_from_policy, wrap_agent_trace_request_end_stream,
 };
 pub(crate) use record::validate_tool_record;
 pub use record::{emit_request_end, publish_tool_record};

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -219,6 +219,31 @@ impl OpenAIPreprocessor {
         }))
     }
 
+    fn build_agent_trace_request_end_state(
+        common_request: &PreprocessedRequest,
+        tracker: &Option<Arc<RequestTracker>>,
+        context: &dynamo_runtime::pipeline::Context<()>,
+    ) -> Option<AgentTraceRequestEndState> {
+        if !crate::agents::trace::is_enabled() {
+            return None;
+        }
+        let agent_context = common_request.agent_context.clone()?;
+        let x_request_id = dynamo_runtime::logging::get_distributed_tracing_context()
+            .and_then(|c| c.x_request_id)
+            .or_else(|| {
+                context
+                    .get::<String>(crate::agents::trace::X_REQUEST_ID_CONTEXT_KEY)
+                    .ok()
+                    .map(|v| v.as_ref().clone())
+            });
+        Some(AgentTraceRequestEndState {
+            agent_context,
+            request_model: common_request.model.clone(),
+            request_tracker: tracker.clone(),
+            x_request_id,
+        })
+    }
+
     fn wrap_agent_trace_request_end_stream<Resp>(
         stream: Pin<Box<dyn Stream<Item = Annotated<Resp>> + Send>>,
         trace_state: Option<AgentTraceRequestEndState>,
@@ -1510,28 +1535,8 @@ impl
             .preprocess_request(&request, tracker.as_deref())
             .await?;
         tracing::trace!(request = ?common_request, prompt_injected_reasoning, "Pre-processed request");
-        let trace_state = if crate::agents::trace::is_enabled() {
-            common_request.agent_context.clone().map(|agent_context| {
-                let request_model = common_request.model.clone();
-                let request_tracker = tracker.clone();
-                let x_request_id = dynamo_runtime::logging::get_distributed_tracing_context()
-                    .and_then(|context| context.x_request_id)
-                    .or_else(|| {
-                        context
-                            .get::<String>(crate::agents::trace::X_REQUEST_ID_CONTEXT_KEY)
-                            .ok()
-                            .map(|value| value.as_ref().clone())
-                    });
-                AgentTraceRequestEndState {
-                    agent_context,
-                    request_model,
-                    request_tracker,
-                    x_request_id,
-                }
-            })
-        } else {
-            None
-        };
+        let trace_state =
+            Self::build_agent_trace_request_end_state(&common_request, &tracker, &context);
         let trace_tokens_enabled = trace_state.is_some();
 
         // Attach the timing tracker to the request so downstream components can record metrics
@@ -1672,28 +1677,8 @@ impl
 
         let mut common_request = builder.build()?;
 
-        let trace_state = if crate::agents::trace::is_enabled() {
-            common_request.agent_context.clone().map(|agent_context| {
-                let request_model = common_request.model.clone();
-                let request_tracker = tracker.clone();
-                let x_request_id = dynamo_runtime::logging::get_distributed_tracing_context()
-                    .and_then(|context| context.x_request_id)
-                    .or_else(|| {
-                        context
-                            .get::<String>(crate::agents::trace::X_REQUEST_ID_CONTEXT_KEY)
-                            .ok()
-                            .map(|value| value.as_ref().clone())
-                    });
-                AgentTraceRequestEndState {
-                    agent_context,
-                    request_model,
-                    request_tracker,
-                    x_request_id,
-                }
-            })
-        } else {
-            None
-        };
+        let trace_state =
+            Self::build_agent_trace_request_end_state(&common_request, &tracker, &context);
         let trace_tokens_enabled = trace_state.is_some();
 
         // Attach the timing tracker to the request so downstream components can record metrics

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -37,7 +37,6 @@ use std::borrow::Cow;
 use std::{collections::HashMap, pin::Pin, sync::Arc};
 use tracing;
 
-use crate::agents::context::AgentContext;
 use crate::model_card::{ModelDeploymentCard, ModelInfo};
 use crate::preprocessor::media::MediaLoader;
 use crate::preprocessor::prompt::OAIChatLikeRequest;
@@ -146,13 +145,6 @@ struct ReasoningState {
     reasoning_parser: Option<Box<dyn ReasoningParser>>,
 }
 
-struct AgentTraceRequestEndState {
-    agent_context: AgentContext,
-    request_model: String,
-    request_tracker: Option<Arc<RequestTracker>>,
-    x_request_id: Option<String>,
-}
-
 pub struct OpenAIPreprocessor {
     mdcsum: String,
     formatter: Arc<dyn OAIPromptFormatter>,
@@ -217,69 +209,6 @@ impl OpenAIPreprocessor {
             media_loader,
             context_length,
         }))
-    }
-
-    fn build_agent_trace_request_end_state(
-        common_request: &PreprocessedRequest,
-        tracker: &Option<Arc<RequestTracker>>,
-        context: &dynamo_runtime::pipeline::Context<()>,
-    ) -> Option<AgentTraceRequestEndState> {
-        if !crate::agents::trace::is_enabled() {
-            return None;
-        }
-        let agent_context = common_request.agent_context.clone()?;
-        let x_request_id = dynamo_runtime::logging::get_distributed_tracing_context()
-            .and_then(|c| c.x_request_id)
-            .or_else(|| {
-                context
-                    .get::<String>(crate::agents::trace::X_REQUEST_ID_CONTEXT_KEY)
-                    .ok()
-                    .map(|v| v.as_ref().clone())
-            });
-        Some(AgentTraceRequestEndState {
-            agent_context,
-            request_model: common_request.model.clone(),
-            request_tracker: tracker.clone(),
-            x_request_id,
-        })
-    }
-
-    fn wrap_agent_trace_request_end_stream<Resp>(
-        stream: Pin<Box<dyn Stream<Item = Annotated<Resp>> + Send>>,
-        trace_state: Option<AgentTraceRequestEndState>,
-        request_id: String,
-    ) -> Pin<Box<dyn Stream<Item = Annotated<Resp>> + Send>>
-    where
-        Resp: Send + 'static,
-    {
-        let Some(AgentTraceRequestEndState {
-            agent_context,
-            request_model,
-            request_tracker,
-            x_request_id,
-        }) = trace_state
-        else {
-            return stream;
-        };
-
-        let (stream, done_fut) = crate::telemetry::stream::notify_on_completion(stream);
-        tokio::spawn(async move {
-            done_fut.await;
-            if request_tracker.is_none() {
-                tracing::warn!(
-                    request_id,
-                    "agent_context present but request tracker is missing; emitting partial trace"
-                );
-            }
-            let metrics = crate::agents::trace::request_metrics(
-                request_id,
-                x_request_id,
-                request_model,
-                request_tracker.as_deref(),
-            );
-            crate::agents::trace::emit_request_end(agent_context, metrics);
-        });
-        stream
     }
 
     /// Encode a string to it's tokens
@@ -1536,7 +1465,7 @@ impl
             .await?;
         tracing::trace!(request = ?common_request, prompt_injected_reasoning, "Pre-processed request");
         let trace_state =
-            Self::build_agent_trace_request_end_state(&common_request, &tracker, &context);
+            crate::agents::trace::build_agent_trace_request_end_state(&common_request, &tracker, &context);
         let trace_tokens_enabled = trace_state.is_some();
 
         // Attach the timing tracker to the request so downstream components can record metrics
@@ -1610,7 +1539,7 @@ impl
         );
 
         let final_stream =
-            Self::wrap_agent_trace_request_end_stream(final_stream, trace_state, request_id);
+            crate::agents::trace::wrap_agent_trace_request_end_stream(final_stream, trace_state, request_id);
 
         // prepend the annotations to the response stream
         let stream = annotations_stream.chain(final_stream);
@@ -1678,7 +1607,7 @@ impl
         let mut common_request = builder.build()?;
 
         let trace_state =
-            Self::build_agent_trace_request_end_state(&common_request, &tracker, &context);
+            crate::agents::trace::build_agent_trace_request_end_state(&common_request, &tracker, &context);
         let trace_tokens_enabled = trace_state.is_some();
 
         // Attach the timing tracker to the request so downstream components can record metrics
@@ -1718,7 +1647,7 @@ impl
         );
 
         let stream =
-            Self::wrap_agent_trace_request_end_stream(Box::pin(stream), trace_state, request_id);
+            crate::agents::trace::wrap_agent_trace_request_end_stream(Box::pin(stream), trace_state, request_id);
 
         // prepend the annotations to the response stream
         let stream = annotations_stream.chain(stream);


### PR DESCRIPTION
## Summary

Suggested follow-up to #9125. Mirrors the `wrap_agent_trace_request_end_stream` extraction by also factoring the trace-state *build* into a helper, removing the ~22-line block that's currently duplicated between the chat completions and v1/completions Operator impls.

Each call site collapses to:

```rust
let trace_state =
    Self::build_agent_trace_request_end_state(&common_request, &tracker, &context);
let trace_tokens_enabled = trace_state.is_some();
```

Net: -44 / +29 lines, no behavior change.

## Test plan

- [x] \`cargo build -p dynamo-llm --lib\` clean
- [ ] CI green