### PR TITLE
ci: evaluate cleaning stale PRs

### DIFF
--- a/.github/workflows/stale_cleaner.yml
+++ b/.github/workflows/stale_cleaner.yml
@@ -14,6 +14,7 @@ name: 'Close stale issues and PRs'
 on:
   schedule:
     - cron: '30 9 * * *'
+  workflow_dispatch:
 
 permissions:
   actions: write
@@ -34,5 +35,6 @@ jobs:
           delete-branch: true
           days-before-stale: 30
           days-before-close: 5
+          operations-per-run: 300
           any-of-issue-labels: 'bug'
           exempt-issue-labels: 'backlog'


### PR DESCRIPTION
Closes OPS-5025
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9168" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced repository maintenance workflow with support for manual triggering and configured operational limits for stale state processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->