### PR TITLE
test(revalidate): fix(gpt-oss): empty reasoning_content with bounded KV cache #9050

### DIFF
--- a/components/src/dynamo/common/__init__.py
+++ b/components/src/dynamo/common/__init__.py
@@ -25,3 +25,5 @@ except Exception:
         __version__ = "0.0.0+unknown"
 
 __all__ = ["__version__", "config_dump", "constants", "utils"]
+
+# revalidate c4c5d161ba8 2026-05-05T17:35:06Z

--- a/lib/runtime/src/runtime.rs
+++ b/lib/runtime/src/runtime.rs
@@ -391,3 +391,5 @@ impl Drop for RuntimeType {
         }
     }
 }
+
+// revalidate c4c5d161ba8 2026-05-05T17:35:06Z


### PR DESCRIPTION
Hey — this is just a re-validation run, I'm checking if anything broke in CI. Please don't merge. I'll delete this PR if it turns green.

Re-validating that PR #9050 by Keiven C did not regress, by re-running against a trivial placebo diff:

```
fix(gpt-oss): empty reasoning_content with bounded KV cache
```