### PR TITLE
feat: add A30 DGDR GPU SKU

### DIFF
--- a/components/src/dynamo/mocker/args.py
+++ b/components/src/dynamo/mocker/args.py
@@ -299,7 +299,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--aic-backend-version",
         type=str,
         default=None,
-        help="AIC backend engine version (e.g., '0.12.0' for vLLM, '0.5.6.post2' for SGLang). "
+        help="AIC backend engine version (e.g., '0.14.0' for vLLM, '0.5.6.post2' for SGLang). "
         "If not set, uses the default version for the backend.",
     )
     parser.add_argument(

--- a/components/src/dynamo/profiler/thorough.py
+++ b/components/src/dynamo/profiler/thorough.py
@@ -371,7 +371,7 @@ async def run_thorough(
 
     # --- Stage 1: Enumeration ---
     model_cache = dgdr.modelCache or ModelCacheSpec()
-    prefill_candidates, decode_candidates = enumerate_profiling_configs(
+    enumerated = enumerate_profiling_configs(
         model_path=model,
         system=system,
         backend=backend,
@@ -384,6 +384,7 @@ async def run_thorough(
         k8s_pvc_mount_path=model_cache.pvcMountPath,
         k8s_model_path_in_pvc=model_cache.pvcModelPath,
     )
+    prefill_candidates, decode_candidates = enumerated[:2]
 
     logger.info(
         "Enumerated %d prefill candidates, %d decode candidates",

--- a/components/src/dynamo/profiler/utils/dgdr_v1beta1_types.py
+++ b/components/src/dynamo/profiler/utils/dgdr_v1beta1_types.py
@@ -65,6 +65,7 @@ class GPUSKUType(str, Enum):
     H100PCIe = "h100_pcie"
     A100SXM = "a100_sxm"
     A100PCIe = "a100_pcie"
+    A30 = "a30"
     L40S = "l40s"
     L40 = "l40"
     L4 = "l4"

--- a/components/src/dynamo/profiler/utils/replay_optimize/constants.py
+++ b/components/src/dynamo/profiler/utils/replay_optimize/constants.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import os
 
 AIC_BACKEND_VERSIONS = {
-    "vllm": "0.12.0",
+    "vllm": "0.14.0",
     "sglang": "0.5.6.post2",
 }
 

--- a/container/deps/requirements.planner.txt
+++ b/container/deps/requirements.planner.txt
@@ -3,7 +3,7 @@
 
 # Dependencies required by the planner, profiler, and global_planner services.
 
-aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@b33a136e78f9351a7ad17db1e2a1abd7b295cc6a
+aiconfigurator[webapp] @ git+https://github.com/ai-dynamo/aiconfigurator.git@79eb16034f37e7211dd4f556448794603c3bdea3
 aiofiles<=25.1.0
 aiohttp>=3.9.0,<4.0
 filterpy==1.4.5

--- a/deploy/helm/charts/platform/components/operator/crds/nvidia.com_dynamographdeploymentrequests.yaml
+++ b/deploy/helm/charts/platform/components/operator/crds/nvidia.com_dynamographdeploymentrequests.yaml
@@ -585,6 +585,7 @@ spec:
                             - h100_pcie
                             - a100_sxm
                             - a100_pcie
+                            - a30
                             - l40s
                             - l40
                             - l4
@@ -601,6 +602,7 @@ spec:
                             - h100_pcie
                             - a100_sxm
                             - a100_pcie
+                            - a30
                             - l40s
                             - l40
                             - l4

--- a/deploy/operator/api/v1beta1/dynamographdeploymentrequest_types.go
+++ b/deploy/operator/api/v1beta1/dynamographdeploymentrequest_types.go
@@ -176,7 +176,7 @@ const (
 )
 
 // GPUSKUType is the AIC hardware system identifier for a supported GPU.
-// +kubebuilder:validation:Enum=gb200_sxm;b200_sxm;h200_sxm;h100_sxm;h100_pcie;a100_sxm;a100_pcie;l40s;l40;l4;v100_sxm;v100_pcie;t4;mi200;mi300
+// +kubebuilder:validation:Enum=gb200_sxm;b200_sxm;h200_sxm;h100_sxm;h100_pcie;a100_sxm;a100_pcie;a30;l40s;l40;l4;v100_sxm;v100_pcie;t4;mi200;mi300
 type GPUSKUType string
 
 const (
@@ -190,6 +190,7 @@ const (
 	// --- Ampere ---
 	GPUSKUTypeA100SXM  GPUSKUType = "a100_sxm"
 	GPUSKUTypeA100PCIe GPUSKUType = "a100_pcie"
+	GPUSKUTypeA30      GPUSKUType = "a30"
 	// --- Ada ---
 	GPUSKUTypeL40S GPUSKUType = "l40s"
 	GPUSKUTypeL40  GPUSKUType = "l40"
@@ -361,7 +362,7 @@ type HardwareSpec struct {
 	// choose which GPU type to use. Discovery and totalGpus are then
 	// restricted to nodes matching this SKU.
 	// +optional
-	// +kubebuilder:validation:Enum=gb200_sxm;b200_sxm;h200_sxm;h100_sxm;h100_pcie;a100_sxm;a100_pcie;l40s;l40;l4;v100_sxm;v100_pcie;t4;mi200;mi300
+	// +kubebuilder:validation:Enum=gb200_sxm;b200_sxm;h200_sxm;h100_sxm;h100_pcie;a100_sxm;a100_pcie;a30;l40s;l40;l4;v100_sxm;v100_pcie;t4;mi200;mi300
 	GPUSKU GPUSKUType `json:"gpuSku,omitempty"`
 
 	// VRAMMB is the VRAM per GPU in MiB.

--- a/deploy/operator/config/crd/bases/nvidia.com_dynamographdeploymentrequests.yaml
+++ b/deploy/operator/config/crd/bases/nvidia.com_dynamographdeploymentrequests.yaml
@@ -585,6 +585,7 @@ spec:
                             - h100_pcie
                             - a100_sxm
                             - a100_pcie
+                            - a30
                             - l40s
                             - l40
                             - l4
@@ -601,6 +602,7 @@ spec:
                             - h100_pcie
                             - a100_sxm
                             - a100_pcie
+                            - a30
                             - l40s
                             - l40
                             - l4

--- a/deploy/operator/internal/gpu/discovery.go
+++ b/deploy/operator/internal/gpu/discovery.go
@@ -86,6 +86,7 @@ const (
 	tokenH200   = "H200"
 	tokenH100   = "H100"
 	tokenA100   = "A100"
+	tokenA30    = "A30"
 	tokenL40S   = "L40S"
 	tokenL40    = "L40"
 	tokenL4     = "L4"
@@ -130,6 +131,7 @@ var gpuRules = []gpuRule{
 
 	// Ampere
 	{token: tokenA100, sxmSKU: nvidiacomv1beta1.GPUSKUTypeA100SXM, pcieSKU: nvidiacomv1beta1.GPUSKUTypeA100PCIe},
+	{token: tokenA30, singleSKU: nvidiacomv1beta1.GPUSKUTypeA30},
 
 	// Ada
 	{token: tokenL40S, singleSKU: nvidiacomv1beta1.GPUSKUTypeL40S},
@@ -172,7 +174,7 @@ type gpuCacheEntry struct {
 }
 
 // GPUDiscoveryCache caches discovery results keyed by SKU filter.
-// Bounded by the GPUSKUType enum (≤7 values incl. empty for unfiltered).
+// Bounded by the GPUSKUType enum plus empty for unfiltered discovery.
 type GPUDiscoveryCache struct {
 	mu      sync.RWMutex
 	entries map[nvidiacomv1beta1.GPUSKUType]gpuCacheEntry
@@ -917,6 +919,9 @@ func InferHardwareSystem(gpuProduct string) nvidiacomv1beta1.GPUSKUType {
 	formFactor := detectFormFactor(normalized)
 
 	for _, rule := range gpuRules {
+		if rule.token == tokenA30 && !containsModelToken(gpuProduct, tokenA30) {
+			continue
+		}
 		if strings.Contains(normalized, rule.token) {
 			if rule.singleSKU != "" {
 				return rule.singleSKU
@@ -948,6 +953,28 @@ func InferHardwareSystem(gpuProduct string) nvidiacomv1beta1.GPUSKUType {
 func normalize(input string) string {
 	s := strings.ToUpper(strings.ReplaceAll(input, strDash, strSpace))
 	return strings.ReplaceAll(s, " ", "")
+}
+
+func containsModelToken(input, token string) bool {
+	upper := strings.ToUpper(input)
+	for start := 0; start < len(upper); {
+		idx := strings.Index(upper[start:], token)
+		if idx < 0 {
+			return false
+		}
+		idx += start
+		end := idx + len(token)
+		if (idx == 0 || !isASCIIAlphaNum(upper[idx-1])) &&
+			(end == len(upper) || !isASCIIAlphaNum(upper[end])) {
+			return true
+		}
+		start = idx + 1
+	}
+	return false
+}
+
+func isASCIIAlphaNum(ch byte) bool {
+	return (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9')
 }
 
 // detectFormFactor determines the GPU form factor (e.g. SXM or PCIe)

--- a/deploy/operator/internal/gpu/discovery_test.go
+++ b/deploy/operator/internal/gpu/discovery_test.go
@@ -481,6 +481,21 @@ func TestInferHardwareSystem(t *testing.T) {
 			input:    "A100",
 			expected: nvidiacomv1beta1.GPUSKUTypeA100PCIe,
 		},
+		{
+			name:     "A30",
+			input:    "NVIDIA A30",
+			expected: nvidiacomv1beta1.GPUSKUTypeA30,
+		},
+		{
+			name:     "A30 with capacity suffix",
+			input:    "NVIDIA A30-24GB",
+			expected: nvidiacomv1beta1.GPUSKUTypeA30,
+		},
+		{
+			name:     "RTX A3000 should not match A30",
+			input:    "NVIDIA RTX A3000",
+			expected: "",
+		},
 
 		// --- Ada ---
 		{

--- a/docs/components/profiler/profiler-guide.md
+++ b/docs/components/profiler/profiler-guide.md
@@ -352,7 +352,7 @@ If GPU discovery is disabled, provide hardware config manually in the DGDR:
 spec:
   hardware:
     numGpusPerNode: 8
-    gpuSku: "H100-SXM5-80GB"
+    gpuSku: h100_sxm
     vramMb: 81920
 ```
 

--- a/docs/kubernetes/api-reference.md
+++ b/docs/kubernetes/api-reference.md
@@ -2086,7 +2086,7 @@ _Underlying type:_ _string_
 GPUSKUType is the AIC hardware system identifier for a supported GPU.
 
 _Validation:_
-- Enum: [gb200_sxm b200_sxm h200_sxm h100_sxm h100_pcie a100_sxm a100_pcie l40s l40 l4 v100_sxm v100_pcie t4 mi200 mi300]
+- Enum: [gb200_sxm b200_sxm h200_sxm h100_sxm h100_pcie a100_sxm a100_pcie a30 l40s l40 l4 v100_sxm v100_pcie t4 mi200 mi300]
 
 _Appears in:_
 - [HardwareSpec](#hardwarespec)
@@ -2100,6 +2100,7 @@ _Appears in:_
 | `h100_pcie` |  |
 | `a100_sxm` | --- Ampere ---<br /> |
 | `a100_pcie` |  |
+| `a30` |  |
 | `l40s` | --- Ada ---<br /> |
 | `l40` |  |
 | `l4` |  |
@@ -2128,7 +2129,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `gpuSku` _[GPUSKUType](#gpuskutype)_ | GPUSKU selects the GPU type to target.<br />When omitted, auto-detected by selecting the GPU with the highest<br />node count, then highest VRAM. In mixed-GPU clusters, set this to<br />choose which GPU type to use. Discovery and totalGpus are then<br />restricted to nodes matching this SKU. |  | Enum: [gb200_sxm b200_sxm h200_sxm h100_sxm h100_pcie a100_sxm a100_pcie l40s l40 l4 v100_sxm v100_pcie t4 mi200 mi300] <br />Optional: \{\} <br /> |
+| `gpuSku` _[GPUSKUType](#gpuskutype)_ | GPUSKU selects the GPU type to target.<br />When omitted, auto-detected by selecting the GPU with the highest<br />node count, then highest VRAM. In mixed-GPU clusters, set this to<br />choose which GPU type to use. Discovery and totalGpus are then<br />restricted to nodes matching this SKU. |  | Enum: [gb200_sxm b200_sxm h200_sxm h100_sxm h100_pcie a100_sxm a100_pcie a30 l40s l40 l4 v100_sxm v100_pcie t4 mi200 mi300] <br />Optional: \{\} <br /> |
 | `vramMb` _float_ | VRAMMB is the VRAM per GPU in MiB.<br />When omitted, auto-detected from cluster GPU nodes. |  | Optional: \{\} <br /> |
 | `totalGpus` _integer_ | TotalGPUs is the GPU budget for profiling and deployment.<br />The profiler uses this to determine parallelism and replica count.<br />When omitted, computed by counting GPUs on discovered nodes<br />(filtered by gpuSku when set), temporarily capped at 32 to<br />limit profiler search space. This cap may be removed in a future<br />release. Set this field explicitly to override. |  | Optional: \{\} <br /> |
 | `numGpusPerNode` _integer_ | NumGPUsPerNode is the number of GPUs per node.<br />When omitted, auto-detected from cluster GPU nodes. |  | Optional: \{\} <br /> |

--- a/docs/kubernetes/dgdr.md
+++ b/docs/kubernetes/dgdr.md
@@ -86,11 +86,12 @@ When providing hardware configuration manually, use lowercase underscore format:
 | `h100_sxm` | `H100-SXM5-80GB` |
 | `h200_sxm` | `H200-SXM-141GB` |
 | `a100_sxm` | `A100-SXM4-80GB` |
+| `a30` | `A30` |
 | `l40s` | `L40S` |
 
 All supported values: `gb200_sxm`, `b200_sxm`, `h200_sxm`, `h100_sxm`,
-`h100_pcie`, `a100_sxm`, `a100_pcie`, `l40s`, `l40`, `l4`, `v100_sxm`,
-`v100_pcie`, `t4`, `mi200`, `mi300`.
+`h100_pcie`, `a100_sxm`, `a100_pcie`, `a30`, `l40s`, `l40`, `l4`,
+`v100_sxm`, `v100_pcie`, `t4`, `mi200`, `mi300`.
 
 > [!NOTE]
 > Not all SKUs are supported by the AIC profiler for `rapid` mode. See

--- a/docs/kubernetes/model-deployment-guide.md
+++ b/docs/kubernetes/model-deployment-guide.md
@@ -107,17 +107,21 @@ The rapid strategy relies on AIC performance models. AIC currently supports:
 
 | Supported (rapid) | Not Yet Supported (use thorough) |
 |---|---|
-| H100 SXM | H100 PCIe |
-| H200 SXM | A100 PCIe |
-| A100 SXM | L4 |
-| B200 SXM | V100 (SXM/PCIe) |
-| GB200 SXM | T4 |
-| L40S | MI200, MI300 |
+| H100 SXM | V100 (SXM/PCIe) |
+| H100 PCIe | T4 |
+| H200 SXM | MI200, MI300 |
+| A100 SXM |  |
+| A100 PCIe |  |
+| A30 |  |
+| B200 SXM |  |
+| GB200 SXM |  |
+| L40S |  |
+| L4 |  |
 
 > [!NOTE]
-> If your GPU is not in the "Supported" column, rapid mode will fall back to a
-> naive config. Use `searchStrategy: thorough` for optimal results on
-> unsupported hardware.
+> Some rapid-mode SKUs use AIC estimate-only data until measured profiles are
+> available. Use `searchStrategy: thorough` when you need hardware-measured
+> profiling for an estimate-only or unsupported SKU.
 
 When specifying GPU SKUs manually, use lowercase underscore format (e.g.,
 `h100_sxm`, not `H100-SXM5-80GB`). See the

--- a/lib/bindings/python/src/dynamo/_internal/aic.py
+++ b/lib/bindings/python/src/dynamo/_internal/aic.py
@@ -10,7 +10,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 DEFAULT_BACKEND_VERSIONS = {
-    "vllm": "0.12.0",
+    "vllm": "0.14.0",
     "sglang": "0.5.6.post2",
 }
 DEFAULT_STATIC_STRIDE = 32

--- a/lib/bindings/python/tests/replay/replay_utils.py
+++ b/lib/bindings/python/tests/replay/replay_utils.py
@@ -37,7 +37,7 @@ MOONCAKE_TRACE_FIRST20 = """{"timestamp": 0, "input_length": 6755, "output_lengt
 AIC_PARITY_MODEL = "Qwen/Qwen3-32B"
 AIC_PARITY_SYSTEM = "h200_sxm"
 AIC_PARITY_VERSIONS = {
-    "vllm": "0.12.0",
+    "vllm": "0.14.0",
     "sglang": "0.5.6.post2",
 }
 AIC_PARITY_BACKENDS = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -234,6 +234,8 @@ filterwarnings = [
     # pandas 2.3 emits this from pd.concat on empty/all-NA frames; aiconfigurator hits it
     # during disagg pareto search and re-raises as RuntimeError, breaking planner tests.
     "ignore:The behavior of DataFrame concatenation with empty or all-NA entries is deprecated.*:FutureWarning",
+    # pandas 2.3 emits this from aiconfigurator pareto filtering under filterwarnings=error.
+    "ignore:Downcasting behavior in `replace` is deprecated.*:FutureWarning",
 ]
 
 

--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -75,7 +75,7 @@ PLANNER_PROFILE_DATA_DIR = (
 ROUTER_AIC_CONFIG = {
     "aic_backend": "vllm",
     "aic_system": "h200_sxm",
-    "aic_backend_version": "0.12.0",
+    "aic_backend_version": "0.14.0",
     "aic_tp_size": 1,
     "aic_model_path": "Qwen/Qwen3-32B",
 }


### PR DESCRIPTION
## Summary
- add `a30` to the DGDR `hardware.gpuSku` enum across the Go API, generated Python DGDR model, CRD, Helm CRD, and API docs
- teach GPU discovery to infer `a30` from A30 GPU product labels
- publish the updated DGDR SKU list and fix the manual hardware docs example to use `h100_sxm` instead of `H100-SXM5-80GB`
- update the rapid/AIC support matrix to include PCIe H100/A100 plus L4/A30 estimate-capable SKUs

## Related
- Paired AIC PR: https://github.com/ai-dynamo/aiconfigurator/pull/980

## Testing
- `python3 deploy/operator/api/scripts/generate_pydantic_from_go.py`
- `python3 deploy/operator/api/scripts/validate_pydantic_models.py`
- `/tmp/dynamo-black-venv/bin/black --check components/src/dynamo/profiler/utils/dgdr_v1beta1_types.py`
- `python3 -m compileall -q components/src/dynamo/profiler/utils/dgdr_v1beta1_types.py`
- `git diff --check`

Go tests not run locally: this environment does not have `go`/`gofmt` installed on PATH.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9176" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NVIDIA A30 as a supported GPU SKU across deployment requests, discovery, and selectors.

* **Bug Fixes / Improvements**
  * Improved GPU discovery to correctly detect A30 model strings and added tests to cover detection cases.

* **Documentation**
  * Updated GPU SKU docs, API reference, and support matrix to include A30 and clarify rapid deployment guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->