### PR TITLE
fix: avoid doubled model path when pvcModelPath is unset

### DIFF
--- a/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
+++ b/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
@@ -22,7 +22,10 @@ try:
     from dynamo.profiler.utils.config_modifiers.parallelization_mapping import (
         PickedParallelConfig,
     )
-    from dynamo.profiler.utils.config_modifiers.protocol import apply_dgd_overrides
+    from dynamo.profiler.utils.config_modifiers.protocol import (
+        BaseConfigModifier,
+        apply_dgd_overrides,
+    )
     from dynamo.profiler.utils.defaults import SearchStrategy
     from dynamo.profiler.utils.dgdr_v1beta1_types import (
         DynamoGraphDeploymentRequestSpec,
@@ -439,3 +442,102 @@ async def test_run_profile_applies_dgd_overrides_before_interpolation(
         "tolerations"
         not in base_dgd["spec"]["services"]["VllmDecodeWorker"]["extraPodSpec"]
     )
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for #8568: pvc_name without pvcModelPath should NOT double
+# the model path.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("backend", ["vllm", "sglang", "trtllm"])
+def test_build_dgd_config_pvc_without_model_path_uses_hf_model_name(
+    backend,
+) -> None:
+    """When pvc_name is set but model_path is None (no pvcModelPath), workers
+    must receive the HF model ID — not the mount path — and the PVC must still
+    be mounted on all services.
+
+    Regression test for https://github.com/ai-dynamo/dynamo/issues/8568
+    """
+    modifier = CONFIG_MODIFIERS[backend]
+    pvc_name = "model-cache"
+    pvc_mount_path = "/opt/model-cache"
+    model_name = "Qwen/Qwen3-32B"
+
+    dgd_config = modifier.build_dgd_config(
+        mode="agg",
+        model_name=model_name,
+        image=f"nvcr.io/nvidia/ai-dynamo/{backend}-runtime:1.1.0",
+        agg_cli_args=["--tp", "4"],
+        agg_replicas=1,
+        agg_gpus=4,
+        pvc_name=pvc_name,
+        pvc_mount_path=pvc_mount_path,
+        # model_path is intentionally omitted (pvcModelPath not set)
+    )
+
+    services = dgd_config["spec"]["services"]
+
+    # Workers must use HF model ID, NOT the mount path or a doubled path.
+    for svc_name, svc in services.items():
+        if svc_name in BaseConfigModifier._NON_WORKER_SERVICES:
+            continue
+        args = svc.get("extraPodSpec", {}).get("mainContainer", {}).get("args", [])
+        flat_args = " ".join(args) if args else ""
+        assert pvc_mount_path not in flat_args, (
+            f"Worker '{svc_name}' model arg should be the HF model ID, "
+            f"not the PVC mount path. args={args}"
+        )
+
+    # PVC must be declared in spec.pvcs
+    pvcs = dgd_config["spec"].get("pvcs", [])
+    pvc_names = [p["name"] for p in pvcs if isinstance(p, dict)]
+    assert pvc_name in pvc_names, f"PVC '{pvc_name}' not found in spec.pvcs"
+
+    # Every service must have a volumeMount for the PVC
+    for svc_name, svc in services.items():
+        vms = svc.get("volumeMounts", [])
+        mount_names = [vm["name"] for vm in vms if isinstance(vm, dict)]
+        assert (
+            pvc_name in mount_names
+        ), f"Service '{svc_name}' is missing volumeMount for PVC '{pvc_name}'"
+
+
+@pytest.mark.parametrize("backend", ["vllm", "sglang", "trtllm"])
+def test_build_dgd_config_pvc_with_model_path_uses_pvc_path(backend) -> None:
+    """When both pvc_name and model_path are set (pvcModelPath provided),
+    workers must receive the full PVC path — not the HF model ID.
+
+    Ensures the explicit-pvcModelPath path still works after the fix.
+    """
+    modifier = CONFIG_MODIFIERS[backend]
+    pvc_name = "model-cache"
+    pvc_mount_path = "/opt/model-cache"
+    model_name = "Qwen/Qwen3-32B"
+    model_path = "/opt/model-cache/snapshots/abc123"
+
+    dgd_config = modifier.build_dgd_config(
+        mode="agg",
+        model_name=model_name,
+        image=f"nvcr.io/nvidia/ai-dynamo/{backend}-runtime:1.1.0",
+        agg_cli_args=["--tp", "4"],
+        agg_replicas=1,
+        agg_gpus=4,
+        pvc_name=pvc_name,
+        pvc_mount_path=pvc_mount_path,
+        model_path=model_path,
+    )
+
+    services = dgd_config["spec"]["services"]
+
+    # Workers must use the explicit PVC model path
+    for svc_name, svc in services.items():
+        if svc_name in BaseConfigModifier._NON_WORKER_SERVICES:
+            continue
+        args = svc.get("extraPodSpec", {}).get("mainContainer", {}).get("args", [])
+        flat_args = " ".join(args) if args else ""
+        assert model_path in flat_args, (
+            f"Worker '{svc_name}' should use PVC model path '{model_path}'. "
+            f"args={args}"
+        )

--- a/components/src/dynamo/profiler/utils/config_modifiers/protocol.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/protocol.py
@@ -543,8 +543,10 @@ class BaseConfigModifier:
 
         # Update model (handles worker args + frontend patching)
         effective_model_path = model_path or model_name
-        if pvc_name and pvc_mount_path:
-            # Derive pvc_path from effective_model_path by stripping the mount prefix
+        if pvc_name and pvc_mount_path and model_path:
+            # pvcModelPath was explicitly provided — model weights live at a
+            # known path inside the PVC.  Let update_model_from_pvc handle
+            # volume mount + CLI patching.
             pvc_path = ""
             if effective_model_path and effective_model_path.startswith(pvc_mount_path):
                 pvc_path = effective_model_path[len(pvc_mount_path) :].strip("/")
@@ -554,6 +556,17 @@ class BaseConfigModifier:
                 pvc_name=pvc_name,
                 pvc_mount_path=pvc_mount_path,
                 pvc_path=pvc_path,
+            )
+        elif pvc_name and pvc_mount_path:
+            # PVC configured as an HF cache directory (no explicit model path
+            # within it).  Mount the PVC so workers can find cached weights,
+            # but keep the HF model ID as the worker model argument.
+            cls._ensure_spec_pvc(cfg, pvc_name)
+            for _svc_name, svc in cfg.spec.services.items():
+                cls._ensure_service_volume_mount(svc, pvc_name, pvc_mount_path)
+            result = cls.update_model(
+                cfg.model_dump(),
+                model_name=model_name,
             )
         else:
             result = cls.update_model(


### PR DESCRIPTION
## Summary

- Fixes a bug where `build_dgd_config()` doubled the model path (e.g. `/opt/model-cache/opt/model-cache`) when a DGDR specifies `modelCache.pvcName` without `pvcModelPath`
- When `pvcModelPath` is unset, the PVC is now mounted as an HF cache directory while workers receive the HF model ID (e.g. `Qwen/Qwen3-32B`) instead of the mount path
- Adds regression tests for both the no-pvcModelPath and explicit-pvcModelPath cases across vllm and sglang backends

Fixes #8568

## Root Cause

In `build_dgd_config()`, the condition `if pvc_name and pvc_mount_path` was always true when `modelCache` was configured (since `pvcMountPath` defaults to `/opt/model-cache`). This caused `update_model_from_pvc()` to be called with an empty `pvc_path`, resolving the model path to just the PVC mount point. The operator then applied PVC mount-path logic again on top, producing doubled paths.

## Fix

Split the PVC branch into two cases:
1. **`pvcModelPath` set** (`model_path is not None`): existing `update_model_from_pvc()` path — model weights live at a known path inside the PVC
2. **`pvcModelPath` unset** (`model_path is None`): mount the PVC for HF cache, but keep the HF model ID as the worker model argument via `update_model()`

## Test plan

- [x] Verified old code produces `--model /opt/model-cache` (bug confirmed)
- [x] Verified fix produces `--model Qwen/Qwen3-32B` with PVC still mounted
- [x] Verified explicit `pvcModelPath` path still works correctly
- [x] Added parametrized regression tests for vllm and sglang backends
- [ ] CI: profiler unit tests pass
- [ ] Manual: deploy DGDR with `modelCache.pvcName` only (no `pvcModelPath`)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PVC configuration handling to correctly distinguish between scenarios with and without explicit model paths, ensuring proper reference to either HuggingFace model IDs or PVC-stored models.

* **Tests**
  * Added comprehensive test coverage for PVC mounting configurations across multiple backend types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->