### PR TITLE
fix: drop hardcoded 4k max_output_tokens default in Responses API

### DIFF
--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -1537,12 +1537,9 @@ async fn responses(
     // return a 503 if the service is not ready
     check_ready(&state)?;
 
-    // Apply template values if present, with sensible defaults for the Responses API.
-    // Unlike chat completions where backends may have their own defaults, the Responses API
-    // should provide a generous default to avoid truncated responses (especially with
-    // reasoning models that emit <think> tokens).
-    const DEFAULT_MAX_OUTPUT_TOKENS: u32 = 4096;
-
+    // Apply template values if present. When no template and no client-supplied
+    // max_output_tokens, leave it as None and let the underlying engine apply its
+    // own default — matching the chat completions path.
     if let Some(template) = template {
         if request.inner.model.as_deref().unwrap_or("").is_empty() {
             request.inner.model = Some(template.model.clone());
@@ -1553,8 +1550,6 @@ async fn responses(
         if request.inner.max_output_tokens.is_none() {
             request.inner.max_output_tokens = Some(template.max_completion_tokens);
         }
-    } else if request.inner.max_output_tokens.is_none() {
-        request.inner.max_output_tokens = Some(DEFAULT_MAX_OUTPUT_TOKENS);
     }
     tracing::trace!("Received responses request: {:?}", request.inner);
 


### PR DESCRIPTION
## Summary

When neither a `RequestTemplate` nor the client supplies `max_output_tokens`, the Responses API handler currently injects a hardcoded `4096` default. This PR removes that floor and lets the underlying engine apply its own default — matching the existing chat completions handler behavior.

## Motivation

The 4k default was introduced in 8cb47d04 (#6089) with the rationale of providing a "generous default to avoid truncated responses (especially with reasoning models that emit `<think>` tokens)."

In practice 4k is **not** generous for reasoning models — Qwen3, DeepSeek-R1, and similar routinely emit `<think>` traces that alone exceed 4k tokens, causing silent truncation when clients omit `max_output_tokens`. The chat completions handler, in contrast, leaves `max_completion_tokens=None` to flow through to the engine, which applies its configured default (typically `max_model_len - prompt_len` or a server-configured value). This PR brings the two endpoints back into symmetry.

## Behavior change

Before:
- No template, no `max_output_tokens` in request → forced to `4096`.

After:
- No template, no `max_output_tokens` in request → left as `None`, engine decides.
- Template path is unchanged: `template.max_completion_tokens` still applied when the client doesn't specify.

The load-bearing assumption is that engines apply sensible defaults when `max_output_tokens=None` — same assumption chat completions has been operating under since before this default was introduced.

## Test plan

- [ ] CI (cargo build / clippy / unit tests)
- [ ] Local Responses-API smoke against a reasoning model with no `max_output_tokens` set — confirm output is not truncated at 4k
- [ ] Regression: Responses-API call with explicit `max_output_tokens` still respects the value
- [ ] Regression: Responses-API call with a `RequestTemplate.max_completion_tokens` still applies the template value when the client omits the field

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated how maximum output token limits are applied in API responses. The system now better leverages template configurations and downstream defaults instead of applying a fixed default value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->