### PR TITLE
fix(operator): preserve alpha replica status conversion

### DIFF
--- a/deploy/operator/api/v1alpha1/dynamocomponentdeployment_conversion.go
+++ b/deploy/operator/api/v1alpha1/dynamocomponentdeployment_conversion.go
@@ -159,8 +159,9 @@ func restoreDCDAlphaOnlyStatusFromSaved(dstStatus *DynamoComponentDeploymentStat
 	if preservedStatus != nil && len(dstStatus.PodSelector) == 0 && len(preservedStatus.PodSelector) > 0 {
 		dstStatus.PodSelector = maps.Clone(preservedStatus.PodSelector)
 	}
-	if preservedStatus != nil && shouldRestoreSavedComponentName(dstStatus.Service, preservedStatus.Service) {
+	if preservedStatus != nil && shouldRestoreSavedServiceReplicaStatus(dstStatus.Service, preservedStatus.Service) {
 		dstStatus.Service.ComponentName = preservedStatus.Service.ComponentName
+		dstStatus.Service.ComponentNames = slices.Clone(preservedStatus.Service.ComponentNames)
 	}
 }
 

--- a/deploy/operator/api/v1alpha1/dynamocomponentdeployment_conversion_test.go
+++ b/deploy/operator/api/v1alpha1/dynamocomponentdeployment_conversion_test.go
@@ -691,6 +691,88 @@ func TestDCD_RoundTrip_Status(t *testing.T) {
 	}
 }
 
+func TestDCD_FromV1alpha1_StatusComponentNameWithoutComponentNames(t *testing.T) {
+	src := &DynamoComponentDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "status-alpha", Namespace: "ns"},
+		Status: DynamoComponentDeploymentStatus{
+			Service: &ServiceReplicaStatus{
+				ComponentName:   "dcd-current",
+				Replicas:        1,
+				UpdatedReplicas: 1,
+			},
+		},
+	}
+	beta := &v1beta1.DynamoComponentDeployment{}
+	if err := src.ConvertTo(beta); err != nil {
+		t.Fatalf("ConvertTo: %v", err)
+	}
+	got := &DynamoComponentDeployment{}
+	if err := got.ConvertFrom(beta); err != nil {
+		t.Fatalf("ConvertFrom: %v", err)
+	}
+	if got.Status.Service.ComponentName != "dcd-current" {
+		t.Fatalf("componentName = %q, want dcd-current", got.Status.Service.ComponentName)
+	}
+	if len(got.Status.Service.ComponentNames) != 0 {
+		t.Fatalf("componentNames = %#v, want empty", got.Status.Service.ComponentNames)
+	}
+}
+
+func TestDCD_FromExistingHubStatusPreservationRestoresComponentName(t *testing.T) {
+	hub := &v1beta1.DynamoComponentDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "status-existing-hub", Namespace: "ns"},
+		Status: v1beta1.DynamoComponentDeploymentStatus{
+			Component: &v1beta1.ComponentReplicaStatus{
+				Replicas:        1,
+				UpdatedReplicas: 1,
+			},
+		},
+	}
+	if err := setJSONAnnOnObj(&hub.ObjectMeta, annDCDStatus, &DynamoComponentDeploymentStatus{
+		Service: &ServiceReplicaStatus{
+			ComponentName: "dcd-current",
+		},
+	}); err != nil {
+		t.Fatalf("set status annotation: %v", err)
+	}
+
+	got := &DynamoComponentDeployment{}
+	if err := got.ConvertFrom(hub); err != nil {
+		t.Fatalf("ConvertFrom: %v", err)
+	}
+	if got.Status.Service.ComponentName != "dcd-current" {
+		t.Fatalf("componentName = %q, want dcd-current", got.Status.Service.ComponentName)
+	}
+	if len(got.Status.Service.ComponentNames) != 0 {
+		t.Fatalf("componentNames = %#v, want empty", got.Status.Service.ComponentNames)
+	}
+}
+
+func TestDCD_IntermediateHubStatusComponentNamesWinOverPreservedSpoke(t *testing.T) {
+	src := &DynamoComponentDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "status-edit", Namespace: "ns"},
+		Status: DynamoComponentDeploymentStatus{
+			Service: &ServiceReplicaStatus{
+				ComponentName: "dcd-old",
+			},
+		},
+	}
+	hub := &v1beta1.DynamoComponentDeployment{}
+	if err := src.ConvertTo(hub); err != nil {
+		t.Fatalf("ConvertTo: %v", err)
+	}
+
+	hub.Status.Component.ComponentNames = []string{"dcd-new"}
+
+	restored := &DynamoComponentDeployment{}
+	if err := restored.ConvertFrom(hub); err != nil {
+		t.Fatalf("ConvertFrom: %v", err)
+	}
+	if got := restored.Status.Service.ComponentName; got != "dcd-new" {
+		t.Fatalf("componentName = %q, want dcd-new", got)
+	}
+}
+
 // TestDCD_FromV1alpha1_SparseSpokeSaveCarriesAlphaOnlyFields exercises the
 // v1alpha1-only fields preserved through the sparse DCD spoke annotation.
 // Fields that flow through podTemplate decomposition (EnvFromSecret,

--- a/deploy/operator/api/v1alpha1/dynamographdeployment_conversion.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeployment_conversion.go
@@ -271,8 +271,9 @@ func restoreDGDAlphaOnlyStatusFromSaved(dstStatus *DynamoGraphDeploymentStatus, 
 		if !ok {
 			continue
 		}
-		if shouldRestoreSavedComponentName(&dstSvc, &savedSvc) {
+		if shouldRestoreSavedServiceReplicaStatus(&dstSvc, &savedSvc) {
 			dstSvc.ComponentName = savedSvc.ComponentName
+			dstSvc.ComponentNames = slices.Clone(savedSvc.ComponentNames)
 		}
 		dstStatus.Services[name] = dstSvc
 	}
@@ -322,10 +323,27 @@ func serviceStatusComponentNameNeedsPreservation(src *ServiceReplicaStatus) bool
 	return src.ComponentNames[len(src.ComponentNames)-1] != src.ComponentName
 }
 
-func shouldRestoreSavedComponentName(dst, saved *ServiceReplicaStatus) bool {
-	return serviceStatusComponentNameNeedsPreservation(saved) &&
-		dst != nil &&
-		dst.ComponentName != saved.ComponentName
+func shouldRestoreSavedServiceReplicaStatus(dst, saved *ServiceReplicaStatus) bool {
+	if !serviceStatusComponentNameNeedsPreservation(saved) || dst == nil {
+		return false
+	}
+	if slices.Equal(dst.ComponentNames, componentNamesToHub(saved)) {
+		return true
+	}
+	return saved.ComponentName != "" &&
+		len(saved.ComponentNames) == 0 &&
+		len(dst.ComponentNames) == 0
+}
+
+func componentNamesToHub(src *ServiceReplicaStatus) []string {
+	if src == nil {
+		return nil
+	}
+	componentNames := slices.Clone(src.ComponentNames)
+	if len(componentNames) == 0 && src.ComponentName != "" {
+		componentNames = []string{src.ComponentName}
+	}
+	return componentNames
 }
 
 func restoreDGDSpokeAnnotations(obj metav1.Object) (*DynamoGraphDeploymentSpec, *DynamoGraphDeploymentStatus, error) {
@@ -649,7 +667,7 @@ func convertReplicaStatusToHub(src *ServiceReplicaStatus, dst *v1beta1.Component
 	}
 	*dst = v1beta1.ComponentReplicaStatus{
 		ComponentKind:   v1beta1.ComponentKind(src.ComponentKind),
-		ComponentNames:  slices.Clone(src.ComponentNames),
+		ComponentNames:  componentNamesToHub(src),
 		Replicas:        src.Replicas,
 		UpdatedReplicas: src.UpdatedReplicas,
 	}

--- a/deploy/operator/api/v1alpha1/dynamographdeployment_conversion_test.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeployment_conversion_test.go
@@ -384,6 +384,64 @@ func TestDGD_IntermediateHubStatusComponentNamesWinOverPreservedSpoke(t *testing
 	}
 }
 
+func TestDGD_FromV1alpha1_StatusComponentNameWithoutComponentNames(t *testing.T) {
+	src := &DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "status-alpha", Namespace: "ns"},
+		Status: DynamoGraphDeploymentStatus{
+			Services: map[string]ServiceReplicaStatus{
+				"worker": {
+					ComponentName:   "worker-current",
+					Replicas:        1,
+					UpdatedReplicas: 1,
+				},
+			},
+		},
+	}
+	got := roundTripFromV1alpha1(t, src)
+	status := got.Status.Services["worker"]
+	if status.ComponentName != "worker-current" {
+		t.Fatalf("componentName = %q, want worker-current", status.ComponentName)
+	}
+	if len(status.ComponentNames) != 0 {
+		t.Fatalf("componentNames = %#v, want empty", status.ComponentNames)
+	}
+}
+
+func TestDGD_FromExistingHubStatusPreservationRestoresComponentName(t *testing.T) {
+	hub := &v1beta1.DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "status-existing-hub", Namespace: "ns"},
+		Status: v1beta1.DynamoGraphDeploymentStatus{
+			Components: map[string]v1beta1.ComponentReplicaStatus{
+				"worker": {
+					Replicas:        1,
+					UpdatedReplicas: 1,
+				},
+			},
+		},
+	}
+	if err := setJSONAnnOnObj(&hub.ObjectMeta, annDGDStatus, &DynamoGraphDeploymentStatus{
+		Services: map[string]ServiceReplicaStatus{
+			"worker": {
+				ComponentName: "worker-current",
+			},
+		},
+	}); err != nil {
+		t.Fatalf("set status annotation: %v", err)
+	}
+
+	got := &DynamoGraphDeployment{}
+	if err := got.ConvertFrom(hub); err != nil {
+		t.Fatalf("ConvertFrom: %v", err)
+	}
+	status := got.Status.Services["worker"]
+	if status.ComponentName != "worker-current" {
+		t.Fatalf("componentName = %q, want worker-current", status.ComponentName)
+	}
+	if len(status.ComponentNames) != 0 {
+		t.Fatalf("componentNames = %#v, want empty", status.ComponentNames)
+	}
+}
+
 func TestDGD_RoundTrip_SpecLevelFields(t *testing.T) {
 	src := &v1beta1.DynamoGraphDeployment{
 		ObjectMeta: metav1.ObjectMeta{Name: "spec", Namespace: "ns"},


### PR DESCRIPTION
## Summary

Fix v1alpha1 ↔ v1beta1 status conversion for `ServiceReplicaStatus` / `ComponentReplicaStatus`.

This preserves legacy v1alpha1 `status.service.componentName` / `status.services[*].componentName` values when `componentNames` was absent, while still allowing intermediate v1beta1 `componentNames` updates to win during conversion back to v1alpha1.

## Why

v1beta1 represents replica status using `componentNames`, while v1alpha1 also has the legacy scalar `componentName`.

The previous conversion synthesized `componentNames` from `componentName`, then converted back with that synthesized value present. That changed v1alpha1 round trips by turning:

```yaml
componentName: worker-current
componentNames: []
```

into:

```yaml
componentName: worker-current
componentNames:
  - worker-current
```

This broke conversion fuzz round-trip tests and could create noisy status mutations for existing v1alpha1 objects.

## Changes

- Convert legacy v1alpha1 componentName into hub componentNames when needed.
- Preserve the original v1alpha1 status shape in the spoke annotation.
- Restore the preserved v1alpha1 componentName / componentNames only when the hub status still matches the conversion-generated value.
- Allow genuine intermediate v1beta1 componentNames changes to win.
- Add DGD and DCD conversion tests for:
  - v1alpha1 status with componentName but no componentNames
  - v1beta1 intermediate status edits overriding preserved v1alpha1 status



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved preservation of component configuration and service replica status during API version conversions to ensure deployment metadata is retained accurately.

* **Tests**
  * Added comprehensive test coverage for API version conversion scenarios to verify proper handling of component naming across different API versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->