### PR TITLE
feat(parsers): cross-impl parser-parity harness (Method 2)

### DIFF
--- a/lib/bindings/python/rust/parsers.rs
+++ b/lib/bindings/python/rust/parsers.rs
@@ -4,7 +4,7 @@
 use dynamo_parsers::reasoning::get_available_reasoning_parsers;
 use dynamo_parsers::tool_calling::ToolDefinition;
 use dynamo_parsers::tool_calling::parsers::{
-    detect_and_parse_tool_call, get_available_tool_parsers,
+    detect_and_parse_tool_call_with_recovery, get_available_tool_parsers,
 };
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
@@ -23,6 +23,13 @@ pub fn get_reasoning_parser_names() -> Vec<&'static str> {
 }
 
 /// Parse tool calls from a model output string using the specified parser.
+///
+/// Uses the finalize / non-streaming aggregate path
+/// (`detect_and_parse_tool_call_with_recovery`) so this binding mirrors what
+/// Dynamo emits at end-of-response, including EOF-recovery for missing
+/// end-token / truncated-JSON inputs. The streaming-safe variant (recovery
+/// disabled) is intentionally NOT exposed here — it would compare the wrong
+/// Dynamo behavior for batch-shaped fixtures (e.g. PARSER.batch.5).
 ///
 /// Args:
 ///     parser_name: Parser name (e.g. "kimi_k25"). Empty string falls back to default.
@@ -54,10 +61,13 @@ pub fn parse_tool_call<'py>(
     };
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        let (calls, normal_text) =
-            detect_and_parse_tool_call(&message, parser_str.as_deref(), tools.as_deref())
-                .await
-                .map_err(|e| PyValueError::new_err(format!("{e}")))?;
+        let (calls, normal_text) = detect_and_parse_tool_call_with_recovery(
+            &message,
+            parser_str.as_deref(),
+            tools.as_deref(),
+        )
+        .await
+        .map_err(|e| PyValueError::new_err(format!("{e}")))?;
 
         let result = serde_json::json!({
             "calls": calls,

--- a/lib/bindings/python/rust/parsers.rs
+++ b/lib/bindings/python/rust/parsers.rs
@@ -2,10 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use dynamo_parsers::reasoning::get_available_reasoning_parsers;
-use dynamo_parsers::tool_calling::parsers::get_available_tool_parsers;
+use dynamo_parsers::tool_calling::ToolDefinition;
+use dynamo_parsers::tool_calling::parsers::{
+    detect_and_parse_tool_call, get_available_tool_parsers,
+};
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
+use serde_json::Value;
 
-/// Get list of available  parser names
+/// Get list of available tool parser names
 #[pyfunction]
 pub fn get_tool_parser_names() -> Vec<&'static str> {
     get_available_tool_parsers()
@@ -17,9 +22,89 @@ pub fn get_reasoning_parser_names() -> Vec<&'static str> {
     get_available_reasoning_parsers()
 }
 
+/// Parse tool calls from a model output string using the specified parser.
+///
+/// Args:
+///     parser_name: Parser name (e.g. "kimi_k25"). Empty string falls back to default.
+///     message:     Model output text to parse.
+///     tools_json:  Optional JSON-serialized list of tool definitions in the form
+///                  `[{"name": "...", "parameters": {...}}, ...]`. Used by parsers
+///                  that need schema-aware coercion (e.g. XML family).
+///
+/// Returns (awaited):
+///     JSON-serialized string `{"calls": [...], "normal_text": str | null}` where
+///     each entry in `calls` is `{"id", "type", "function": {"name", "arguments"}}`
+///     and `arguments` is a JSON-serialized string (matching the parser's wire output).
+///
+/// Raises:
+///     ValueError on parser failure or malformed `tools_json`.
+#[pyfunction]
+#[pyo3(signature = (parser_name, message, tools_json=None))]
+pub fn parse_tool_call<'py>(
+    py: Python<'py>,
+    parser_name: String,
+    message: String,
+    tools_json: Option<String>,
+) -> PyResult<Bound<'py, PyAny>> {
+    let tools = parse_tools_json(tools_json.as_deref())?;
+    let parser_str = if parser_name.is_empty() {
+        None
+    } else {
+        Some(parser_name)
+    };
+
+    pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        let (calls, normal_text) =
+            detect_and_parse_tool_call(&message, parser_str.as_deref(), tools.as_deref())
+                .await
+                .map_err(|e| PyValueError::new_err(format!("{e}")))?;
+
+        let result = serde_json::json!({
+            "calls": calls,
+            "normal_text": normal_text,
+        });
+        Ok(result.to_string())
+    })
+}
+
+/// Convert OpenAI-style or flat tools JSON into `Vec<ToolDefinition>`.
+///
+/// Accepts either of these shapes per element:
+/// - `{"name": "fn", "parameters": {...}}`                                       (flat)
+/// - `{"type": "function", "function": {"name": "fn", "parameters": {...}}}`    (OpenAI)
+fn parse_tools_json(tools_json: Option<&str>) -> PyResult<Option<Vec<ToolDefinition>>> {
+    let Some(raw) = tools_json else {
+        return Ok(None);
+    };
+    let parsed: Value = serde_json::from_str(raw)
+        .map_err(|e| PyValueError::new_err(format!("invalid tools_json: {e}")))?;
+    let arr = parsed
+        .as_array()
+        .ok_or_else(|| PyValueError::new_err("tools_json must be a JSON array"))?;
+
+    let mut defs = Vec::with_capacity(arr.len());
+    for (i, t) in arr.iter().enumerate() {
+        // OpenAI wraps the schema in `function`; fall back to flat shape.
+        let inner = t.get("function").unwrap_or(t);
+        let name = inner
+            .get("name")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| {
+                PyValueError::new_err(format!(
+                    "tools_json[{i}] requires a string `name` field (or `function.name`)"
+                ))
+            })?
+            .to_string();
+        let parameters = inner.get("parameters").cloned();
+        defs.push(ToolDefinition { name, parameters });
+    }
+    Ok(Some(defs))
+}
+
 /// Add parsers module functions to the Python module
 pub fn add_to_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(get_tool_parser_names, m)?)?;
     m.add_function(wrap_pyfunction!(get_reasoning_parser_names, m)?)?;
+    m.add_function(wrap_pyfunction!(parse_tool_call, m)?)?;
     Ok(())
 }

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -32,6 +32,31 @@ def get_reasoning_parser_names() -> list[str]:
     """Get list of available reasoning parser names."""
     ...
 
+async def parse_tool_call(
+    parser_name: str,
+    message: str,
+    tools_json: Optional[str] = None,
+) -> str:
+    """Parse tool calls from a model output string using the specified parser.
+
+    Args:
+        parser_name: Parser name (e.g. "kimi_k25"). Empty string falls back to default.
+        message:     Model output text to parse.
+        tools_json:  Optional JSON-serialized list of tool definitions in the form
+                     `[{"name": "...", "parameters": {...}}, ...]` (or OpenAI shape
+                     with `{"function": {...}}` wrapper). Used by parsers that need
+                     schema-aware coercion (e.g. XML family).
+
+    Returns:
+        JSON-serialized string `{"calls": [...], "normal_text": str | None}`.
+        Each entry in `calls` is `{"id", "type", "function": {"name", "arguments"}}`
+        with `arguments` itself a JSON-serialized string.
+
+    Raises:
+        ValueError on parser failure or malformed `tools_json`.
+    """
+    ...
+
 def run_kv_indexer(args: List[str]) -> None:
     """Run the KV indexer with the given arguments."""
     ...

--- a/tests/parity/README.md
+++ b/tests/parity/README.md
@@ -117,34 +117,34 @@ They're stacked diagnostics:
 
 ## Current parity status (M2, batch mode)
 
-`ok` = matches the YAML expected output. `X` = divergence recorded
+`✓` = matches the YAML expected output. `X` = divergence recorded
 in `KNOWN_DIVERGENCES` (xfailed, not silenced). `n/a` = the impl has
 no parser registered for that family. `dynamo` rows are always `ok`
 because Dynamo is the regenerator's oracle.
 
 | family#impl            |  1  |  2  |  3  |  4  |  5  |  6  |  7  |  8  |  9  | 10  |
 |--------------------------|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-| kimi_k2#dynamo         | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  |
-| kimi_k2#vllm           | ok  | ok  | ok  | ok  | ok  | ok  | ok  |  X  | ok  | ok  |
-| kimi_k2#sglang         | ok  | ok  | ok  |  X  | ok  | ok  | ok  |  X  | ok  | ok  |
-| qwen3_coder#dynamo     | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  |
-| qwen3_coder#vllm       | ok  | ok  | ok  |  X  |  X  | ok  | ok  |  X  | ok  | ok  |
-| qwen3_coder#sglang     | ok  | ok  | ok  |  X  |  X  | ok  | ok  |  X  | ok  | ok  |
-| glm47#dynamo           | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  |
-| glm47#vllm             | ok  | ok  | ok  | ok  | ok  | ok  | ok  |  X  | ok  | ok  |
-| glm47#sglang           | ok  | ok  | ok  | ok  | ok  | ok  | ok  |  X  | ok  | ok  |
-| deepseek_v3_1#dynamo   | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  |
-| deepseek_v3_1#vllm     | ok  | ok  | ok  |  X  |  X  | ok  | ok  | ok  | ok  | ok  |
-| deepseek_v3_1#sglang   | ok  | ok  | ok  | ok  |  X  | ok  | ok  |  X  | ok  | ok  |
-| harmony#dynamo         | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  |
+| kimi_k2#dynamo         | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   |
+| kimi_k2#vllm           | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   |  X  | ✓   | ✓   |
+| kimi_k2#sglang         | ✓   | ✓   | ✓   |  X  | ✓   | ✓   | ✓   |  X  | ✓   | ✓   |
+| qwen3_coder#dynamo     | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   |
+| qwen3_coder#vllm       | ✓   | ✓   | ✓   |  X  |  X  | ✓   | ✓   |  X  | ✓   | ✓   |
+| qwen3_coder#sglang     | ✓   | ✓   | ✓   |  X  |  X  | ✓   | ✓   |  X  | ✓   | ✓   |
+| glm47#dynamo           | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   |
+| glm47#vllm             | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   |  X  | ✓   | ✓   |
+| glm47#sglang           | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   |  X  | ✓   | ✓   |
+| deepseek_v3_1#dynamo   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   |
+| deepseek_v3_1#vllm     | ✓   | ✓   | ✓   |  X  |  X  | ✓   | ✓   | ✓   | ✓   | ✓   |
+| deepseek_v3_1#sglang   | ✓   | ✓   | ✓   | ✓   |  X  | ✓   | ✓   |  X  | ✓   | ✓   |
+| harmony#dynamo         | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   |
 | harmony#vllm           | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a |
-| harmony#sglang         |  X  |  X  | ok  |  X  |  X  |  X  |  X  |  X  | ok  |  X  |
-| minimax_m2#dynamo      | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  |
-| minimax_m2#vllm        | ok  | ok  | ok  |  X  | ok  | ok  | ok  |  X  | ok  | ok  |
-| minimax_m2#sglang      | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  |
-| nemotron_deci#dynamo   | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  |
+| harmony#sglang         |  X  |  X  | ✓   |  X  |  X  |  X  |  X  |  X  | ✓   |  X  |
+| minimax_m2#dynamo      | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   |
+| minimax_m2#vllm        | ✓   | ✓   | ✓   |  X  | ✓   | ✓   | ✓   |  X  | ✓   | ✓   |
+| minimax_m2#sglang      | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   |
+| nemotron_deci#dynamo   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   |
 | nemotron_deci#vllm     | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a |
-| nemotron_deci#sglang   | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  |
+| nemotron_deci#sglang   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   |
 
 Tally (excluding `dynamo` since it's the oracle): 140 cells against
 the YAML expected — 95 parity, 25 divergence (xfailed), 20 n/a.

--- a/tests/parity/README.md
+++ b/tests/parity/README.md
@@ -1,0 +1,389 @@
+# Cross-impl parity test suite
+
+Shared test infrastructure for diffing parser / preprocess / postprocess
+behavior across Dynamo, vLLM, and SGLang. Today only the parser stage
+is populated (`parser/`); other stages slot in as siblings as they land.
+
+## Layout
+
+```
+tests/parity/
+├── README.md                       (this file)
+├── conftest.py                     ← session-scoped fixtures (server boots, etc.)
+├── common.py                       ← ParseResult, canonical-JSON diff, decode_arguments
+└── parser/
+    ├── fixtures/                   ← static YAML, generated from Dynamo as oracle
+    │   └── <family>/PARSER.batch.yaml
+    ├── regenerate_fixtures.py      ← (re-)build fixtures by running Dynamo's parser
+    │
+    ├── dynamo.py                   ← M2 in-process wrapper (PyO3 binding)
+    ├── vllm.py                     ← M2 in-process wrapper (ToolParserManager)
+    ├── sglang.py                   ← M2 in-process wrapper (per-module detectors)
+    ├── test_parity_parser.py       ← M2 harness (parser-class parity)
+    │
+    ├── server.py                   ← M3 subprocess boot helper
+    ├── client.py                   ← M3 HTTP client (vllm + sglang)
+    └── test_parity_e2e.py          ← M3 harness (server-stack parity over HTTP)
+```
+
+## Three methods (M1, M2, M3) — what each one really means
+
+Three increasingly-realistic ways to drive the same parser logic.
+They differ in **what's substituted vs what's real**, which decides
+which bug class each method can catch:
+
+```
+                                                  ┌─ engine ──────────┐
+                                                  │                   │
+   client ─request→ chat-template ─→ tokenize ─→ engine ─→ detokenize ─→ text ─→ PARSER ─→ tool_calls JSON ─→ client
+              ↑                                                              ↑
+              └── M1 / M3 exercise this (real)                               └── M2 starts here (skips everything left)
+                  M2 skips it (substituted by direct call)
+```
+
+### Method 1 — fallback-path test *(upcoming, next step)*
+
+**What's run:** `python -m dynamo.frontend --dyn-chat-processor <vllm|sglang>`. Dynamo's frontend chat processor delegates tool parsing to upstream's Python parser instead of Dynamo's Rust parser. Reference path is the default `python -m dynamo.frontend` (Dynamo's Rust parser).
+
+**What it surfaces:** gaps in Dynamo's Rust parser that the fallback masks; bugs in Dynamo's frontend code that wraps upstream parsers.
+
+**Status:** not yet implemented. Lives in its own harness file when added (M1 tests *Dynamo's wrapping* of upstream parsers, not parity *between* impls).
+
+### Method 2 — parser-class test (this PR's primary harness)
+
+**What's run:** in-process Python imports, all three impls in one process — no HTTP, no model, no tokenizer, no chat-template materialization:
+
+```python
+# Dynamo Rust side (via PyO3 binding)
+from dynamo._core import parse_tool_call
+result = await parse_tool_call("kimi_k2", text, tools_json)
+
+# vLLM side (native Python class)
+from vllm.tool_parsers import ToolParserManager
+parser = ToolParserManager.get_tool_parser("kimi_k2")(tokenizer=stub)
+info = parser.extract_tool_calls(text, request)
+
+# SGLang side (native Python class)
+from sglang.srt.function_call.kimik2_detector import KimiK2Detector
+result = KimiK2Detector().detect_and_parse(text, tools)
+```
+
+**What it surfaces:** parser-logic divergences between Dynamo's Rust parser class and upstream's Python parser classes. The bug class isolated from everything else in the request lifecycle.
+
+**File:** `tests/parity/parser/test_parity_parser.py`.
+
+### Method 3 — end-to-end HTTP test *(upcoming, next step — sibling PR #9189)*
+
+**What's run:** real upstream serving binaries; constrained decoding forces them to emit the fixture text:
+
+```bash
+vllm serve <model> --load-format dummy \
+  --enable-auto-tool-choice --tool-call-parser kimi_k2 --port 8001 &
+python -m sglang.launch_server --model-path <model> --load-format dummy \
+  --tool-call-parser kimi_k2 --port 8002 &
+```
+
+Both servers receive identical chat-completion requests with `structured_outputs.regex` (vLLM) / `regex` (SGLang) forcing the assistant turn to be the fixture's `model_text` byte-for-byte; the harness captures `tool_calls` JSON from each response.
+
+**What it surfaces:** server-stack divergences between vLLM's and SGLang's HTTP pipelines — request preprocessing, tokenizer round-trip, streaming chunk boundaries, response shaping — that class-level testing (M2) can't see.
+
+**File:** `tests/parity/parser/test_parity_e2e.py` (lands in #9189).
+
+### Comparison
+
+| | M1 (upcoming) | M2 (this PR) | M3 (upcoming, #9189) |
+|---|---|---|---|
+| **What's tested** | Dynamo frontend wrapping upstream parsers | parser **class**, in isolation | parser inside its **server** (full HTTP stack) |
+| **Invocation** | `python -m dynamo.frontend` subprocess | in-process Python imports | HTTP over `/v1/chat/completions` |
+| **Real engine?** | yes | no | yes (with `--load-format dummy`) |
+| **Real tokenizer?** | yes | no | yes |
+| **Real chat template?** | yes | no | yes |
+| **Real HTTP?** | yes | no | yes |
+| **Cost** | (TBD) | ~3 s for 210 tests | ~60 s for 30 tests (server boot dominates) |
+| **GPU** | yes | none | yes (`--load-format dummy` still allocates ~2.5 GiB) |
+| **CI markers** | (TBD) | `unit, pre_merge, gpu_0` | `e2e, pre_merge, gpu_1` |
+
+All three methods (when implemented) share the same fixtures,
+`ParseResult` shape, and `KNOWN_DIVERGENCES` registry pattern.
+They're stacked diagnostics:
+
+- M2 says: *"the parser class disagrees"*
+- M3 says: *"the server stack also disagrees"* (or, more usefully,
+  *"disagrees only at the server stack — parser class agrees"*,
+  which localizes the bug to chat-template / tokenizer /
+  response shaping)
+- M1 says: *"Dynamo's wrapper layer disagrees with the upstream
+  parser it's wrapping"*
+
+## Current parity status (M2, batch mode)
+
+`ok` = matches the YAML expected output. `X` = divergence recorded
+in `KNOWN_DIVERGENCES` (xfailed, not silenced). `n/a` = the impl has
+no parser registered for that family. `dynamo` rows are always `ok`
+because Dynamo is the regenerator's oracle.
+
+| family#impl            |  1  |  2  |  3  |  4  |  5  |  6  |  7  |  8  |  9  | 10  |
+|--------------------------|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| kimi_k2#dynamo         | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  |
+| kimi_k2#vllm           | ok  | ok  | ok  | ok  | ok  | ok  | ok  |  X  | ok  | ok  |
+| kimi_k2#sglang         | ok  | ok  | ok  |  X  | ok  | ok  | ok  |  X  | ok  | ok  |
+| qwen3_coder#dynamo     | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  |
+| qwen3_coder#vllm       | ok  | ok  | ok  |  X  |  X  | ok  | ok  |  X  | ok  | ok  |
+| qwen3_coder#sglang     | ok  | ok  | ok  |  X  |  X  | ok  | ok  |  X  | ok  | ok  |
+| glm47#dynamo           | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  |
+| glm47#vllm             | ok  | ok  | ok  | ok  | ok  | ok  | ok  |  X  | ok  | ok  |
+| glm47#sglang           | ok  | ok  | ok  | ok  | ok  | ok  | ok  |  X  | ok  | ok  |
+| deepseek_v3_1#dynamo   | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  |
+| deepseek_v3_1#vllm     | ok  | ok  | ok  |  X  |  X  | ok  | ok  | ok  | ok  | ok  |
+| deepseek_v3_1#sglang   | ok  | ok  | ok  | ok  |  X  | ok  | ok  |  X  | ok  | ok  |
+| harmony#dynamo         | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  |
+| harmony#vllm           | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a |
+| harmony#sglang         |  X  |  X  | ok  |  X  |  X  |  X  |  X  |  X  | ok  |  X  |
+| minimax_m2#dynamo      | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  |
+| minimax_m2#vllm        | ok  | ok  | ok  |  X  | ok  | ok  | ok  |  X  | ok  | ok  |
+| minimax_m2#sglang      | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  |
+| nemotron_deci#dynamo   | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  |
+| nemotron_deci#vllm     | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a |
+| nemotron_deci#sglang   | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  | ok  |
+
+Tally (excluding `dynamo` since it's the oracle): 140 cells against
+the YAML expected — 95 parity, 25 divergence (xfailed), 20 n/a.
+
+**Hot columns:**
+- `PARSER.batch.4` (malformed JSON) and `PARSER.batch.5` (missing
+  end-token) — recovery is impl-defined per `PARSER_CASES.md`;
+  divergences are documented rather than asserted-against.
+- `PARSER.batch.8` (interleaved normal text) — vLLM and SGLang both
+  drop the trailing text after the wrapper across XML-style families.
+- `harmony/sglang` — 8 of 10 cases divergent because SGLang's
+  `GptOssDetector` requires the strict
+  `<|start|>assistant<|channel|>commentary` envelope where Dynamo
+  accepts bare commentary.
+
+What's **not** covered yet: `PARSER.fmt.*`, `PARSER.xml.*`,
+`PARSER.harmony.*`, `PARSER.stream.*` — those case classes still
+live in Rust unit tests only and would be added to the YAML corpus
+in follow-up PRs.
+
+## Fixture file schema
+
+Each `<family>/PARSER.batch.yaml`:
+
+```yaml
+family: kimi_k2
+mode: batch
+cases:
+  PARSER.batch.1:
+    description: Single tool call (happy path)
+    model_text: |-
+      <|tool_calls_section_begin|>...
+    tools:
+    - name: ...
+      parameters: {...}
+    expected:
+      calls:
+      - name: ...
+        arguments: {...}
+      normal_text: ''
+  PARSER.batch.2: ...
+```
+
+Case keys are the full IDs from
+[`lib/parsers/PARSER_CASES.md`](../../lib/parsers/PARSER_CASES.md)
+(`PARSER.batch.1` … `PARSER.batch.10`). They match the
+`KNOWN_DIVERGENCES` keys and pytest parametrize IDs directly, so a
+single `grep PARSER.batch.5` finds the case across docs, fixtures,
+and Rust source comments.
+
+`model_text` uses YAML's literal block scalar (`|-`) so multi-line
+wire formats (XML-style families, harmony) read as the actual text
+the model would emit, not a `\n`-escaped one-liner. UTF-8 with
+`allow_unicode=True`, so DeepSeek special tokens (`｜` U+FF5C, `▁`
+U+2581) appear as literal characters rather than escape sequences.
+
+## Why families' YAMLs look so similar (and why that's the point)
+
+Open any two family files side-by-side and the case shells look
+nearly identical: same `description` strings, same `tools` schemas,
+same case keys `"1"`–`"10"`. **That's by design** — case N is the
+same logical scenario across every family:
+
+```
+case 1  =  "single happy-path call"
+case 2  =  "multiple calls"
+case 3  =  "no tool call (plain text)"
+case 4  =  "malformed JSON args"
+case 5  =  "missing end-token recovery"
+case 6  =  "empty args (no-arg call)"
+case 7  =  "complex args (nested JSON / arrays)"
+case 8  =  "interleaved normal text"
+case 9  =  "empty input"
+case 10 =  "duplicate calls (same name twice)"
+```
+
+So a reviewer can grep `PARSER.batch.4` across all 7 families and
+immediately see how each parser handles the same scenario. The
+repetition *is* the diff: it's what makes per-case cross-family
+comparison trivial.
+
+### What changes per family
+
+**1. `model_text`** — every family has its own wire format.
+`case 1` ("single happy-path call") encoded by each:
+
+| family | model_text (truncated) |
+|---|---|
+| `kimi_k2` | `<\|tool_calls_section_begin\|><\|tool_call_begin\|>functions.get_weather:0…` |
+| `qwen3_coder` | `<tool_call>\n<function=get_weather>\n<parameter=location>\nNYC\n</parameter>…` |
+| `glm47` | `<tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value>…` |
+| `deepseek_v3_1` | `<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{…}…` |
+| `harmony` | `<\|channel\|>commentary to=functions.get_weather <\|constrain\|>json<\|message\|>…` |
+| `minimax_m2` | `<minimax:tool_call>\n<invoke name="get_weather">\n<parameter name="location">…` |
+| `nemotron_deci` | `<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}]</TOOLCALL>` |
+
+**2. `expected`** — sometimes also differs, when Dynamo's per-family
+parser quirks make the same logical scenario produce different
+parsed output. Example: `case 4` (malformed input) — the
+malformations themselves vary (each is malformed in a way that's
+natural for that family's wire format), and Dynamo recovers them
+differently:
+
+```
+kimi_k2/batch.4    expected.calls[0].arguments = "{\"location\":\"NYC\""
+                   ↑ truncated raw string — Dynamo's kimi_k2 parser
+                     surfaces the malformed bytes verbatim
+
+qwen3_coder/batch.4 expected.calls[0].arguments = {"location": "NYC"}
+                   ↑ recovered into a proper dict — Dynamo's
+                     qwen3_coder parser is lenient with missing tags
+```
+
+Both are valid per-family Dynamo contracts. Cross-impl divergences
+(vLLM and SGLang doing something *different* from Dynamo on the
+same case) are tracked in each test's `KNOWN_DIVERGENCES` registry
+as `xfail` entries with a one-sentence reason.
+
+**3. `tools`** — sometimes minor parameter-name differences
+(e.g., `city` vs `location`, `unit` field present or not), carried
+over from the original Rust unit tests that seeded each family's
+fixtures.
+
+If you're *adding* a new case, mirror the case shape across all
+applicable families — the harness counts on case N meaning the
+same thing everywhere.
+
+## Regenerating fixtures
+
+Run from the repo root inside a container with `dynamo._core` built
+(M2's PyO3 binding):
+
+```bash
+# Default: non-destructive — new cases written, existing left alone.
+python3 -m tests.parity.parser.regenerate_fixtures
+
+# Refresh: re-run Dynamo for every case in INPUTS, overwrite on disk.
+# Use this only when Dynamo's parser behavior intentionally changed.
+python3 -m tests.parity.parser.regenerate_fixtures --overwrite-if-exists
+```
+
+(The `-m` invocation is required — running the script directly puts
+`tests/parity/parser/` on `sys.path`, which makes the local
+`dynamo.py` wrapper shadow the real `dynamo` package.)
+
+After regenerating, run `git diff tests/parity/parser/fixtures/` to
+review the change before staging. Cases on disk that aren't in
+`INPUTS` today are always preserved, regardless of flag, so editing
+your `INPUTS` section can't accidentally delete other contributors'
+cases.
+
+## Future stages (sibling directories)
+
+```
+tests/parity/
+├── parser/         (today)
+├── postprocess/    (future) — parser output → OpenAI wire response
+└── preprocess/     (future) — request preprocessing, chat-template
+```
+
+Each stage has its own fixtures, wrappers, and test file but
+reuses the shared `common.py` (`ParseResult`-style shape) and
+`conftest.py` (session-scoped server boots) at this level. Out of
+scope today; see `lib/parsers/PARSER_CASES.md`,
+`components/src/dynamo/frontend/tests/FRONTEND_CASES.md`, and
+`lib/parsers/PIPELINE_CASES.md` for the surrounding taxonomy that
+will guide which stages are worth adding when.
+
+## Eventual goal: YAML fixtures as the single source of truth
+
+Today there's overlap between this harness's fixtures and the
+hand-written Rust unit tests under `lib/parsers/src/tool_calling/*`
+— for the ~70 black-box "given input X, parser returns Y" tests,
+the same input + expected appears in both places (the M2 fixtures
+were originally extracted from those Rust tests by hand).
+
+The intended end state is **one set of fixtures, multiple thin
+harnesses**, in subsequent PRs:
+
+```
+tests/parity/parser/fixtures/<family>/PARSER.batch.yaml
+        │
+        ├── Python harness (M2 / M3) — already reads it
+        └── Rust harness (future)    — would read it too,
+                                       at cargo-test speed,
+                                       no Python required
+```
+
+What that buys:
+
+- **No duplicated test data.** Adding a case in YAML immediately
+  covers Dynamo (Rust harness), Dynamo-via-PyO3 (M2), and
+  vLLM/SGLang servers (M3). Today, adding a Rust test means
+  hand-mirroring the case into M2's `INPUTS` if you want
+  cross-impl coverage.
+- **Rust devs keep their fast feedback loop.** `cargo test`
+  still finishes in ~0.5 s; no Python build needed.
+- **Each impl is tested in its native language.** Closer to
+  production semantics than going through PyO3 just to assert
+  a Rust contract.
+
+What stays in Rust-only tests after the migration:
+
+- White-box tests on internal helpers (`detect_tool_call_start_*`,
+  `find_tool_call_end_position_*`, regex-fallback paths). These
+  test parser-internal state, not parity, and aren't exposed
+  via PyO3. ~120 of the ~498 Rust tests fall here.
+- Tokenizer / config / panic-class tests. Single-impl by nature.
+
+Effort sketch (separate PRs after M2 + M3 land):
+
+- **PR-X:** Rust harness that reads `PARSER.batch.yaml`, dispatches
+  to `try_tool_call_parse_<family>(...)`, asserts on `expected`.
+  ~1-2 days.
+- **PR-Y:** Mechanical migration — delete the ~70 hand-written
+  black-box Rust tests now redundant with the shared fixtures.
+  ~6 hours.
+- **PR-Z:** Same shape extended to format-conditional and
+  customer-incident regressions (~150 more cases). ~2-3 days.
+- (deferred) Streaming variant. Needs new `PARSER.stream.*`
+  schema + streaming PyO3 + streaming Rust harness. Roughly
+  the size of the original M3 work.
+
+Until then, M2 and the Rust suite both exist; for ~70 cases they
+test the same Dynamo contract through different surfaces. M2's
+real value-add is the cross-impl half (vLLM and SGLang).
+
+## Adding a new parser family
+
+1. Add the family name to Dynamo's parser registry (Rust side).
+2. Run M2's existing tests — the new family's `dynamo` wrapper
+   tests will fail because no fixtures exist yet.
+3. Add a section to `INPUTS` in `regenerate_fixtures.py` for every
+   `(family, "PARSER.batch.<n>")` you want to cover (mirror the
+   case shape from an existing family).
+4. Run the regenerator to materialize `<family>/PARSER.batch.yaml`.
+5. Add the family's vLLM and SGLang dispatch entries to
+   `_FAMILY_TO_VLLM_KEY` (`vllm.py`) and
+   `_FAMILY_TO_SGLANG_DETECTOR` (`sglang.py`).
+6. Run pytest. Any cross-impl divergences surface as failures —
+   classify each, add a one-sentence reason to `KNOWN_DIVERGENCES`,
+   and the test goes to xfail.

--- a/tests/parity/common.py
+++ b/tests/parity/common.py
@@ -51,11 +51,6 @@ def canonical(d: dict[str, Any]) -> str:
     return json.dumps(d, sort_keys=True, separators=(",", ":"))
 
 
-def diff(a: ParseResult, b: ParseResult) -> bool:
-    """Return True if the two results are equivalent under canonical compare."""
-    return canonical(a.to_dict()) == canonical(b.to_dict())
-
-
 def decode_arguments(args: Any) -> Any:
     """Decode a tool-call `arguments` field to a comparable Python value.
 

--- a/tests/parity/common.py
+++ b/tests/parity/common.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared contract types + canonical-JSON diff for parity (parser) impls.
+
+Every impl wrapper (parser-mode and e2e-mode) returns ParseResult so the
+harness can diff results uniformly.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class ParseResult:
+    """Uniform shape returned by every impl wrapper.
+
+    `calls` is a list of {"name": str, "arguments": dict}.  Argument values
+    are dicts (parsed from JSON) so canonical comparison ignores whitespace
+    differences in the wire encoding.
+    """
+
+    calls: list[dict[str, Any]] = field(default_factory=list)
+    normal_text: str | None = None
+    error: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "calls": self.calls,
+            "normal_text": self.normal_text,
+            "error": self.error,
+        }
+
+
+def _normalize_normal_text(v: Any) -> Any:
+    """Treat empty string and None as equivalent — Dynamo emits "", vLLM emits None
+    when the model produced no narration text. Both express the same semantic."""
+    if v == "" or v is None:
+        return None
+    return v
+
+
+def canonical(d: dict[str, Any]) -> str:
+    """Canonical JSON for diffing: sorted keys, no whitespace, with empty-string ↔ None
+    normalization applied to `normal_text`."""
+    if "normal_text" in d:
+        d = {**d, "normal_text": _normalize_normal_text(d["normal_text"])}
+    return json.dumps(d, sort_keys=True, separators=(",", ":"))
+
+
+def diff(a: ParseResult, b: ParseResult) -> bool:
+    """Return True if the two results are equivalent under canonical compare."""
+    return canonical(a.to_dict()) == canonical(b.to_dict())
+
+
+def decode_arguments(args: Any) -> Any:
+    """Decode a tool-call `arguments` field to a comparable Python value.
+
+    Parsers surface `arguments` slightly differently: JSON-encoded
+    string (Dynamo, vLLM), already-parsed dict (some SGLang paths),
+    or the truncated raw string verbatim on malformed input. Decode
+    JSON if it parses; otherwise return as-is so the canonical-diff
+    surfaces the mismatch rather than swallowing it.
+    """
+    if not args:
+        return {}
+    if not isinstance(args, str):
+        return args
+    try:
+        return json.loads(args)
+    except (json.JSONDecodeError, TypeError):
+        return args

--- a/tests/parity/parser/dynamo.py
+++ b/tests/parity/parser/dynamo.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""parser-mode wrapper for Dynamo's Rust parser, via the PyO3 binding."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+from dynamo._core import parse_tool_call
+from tests.parity.common import ParseResult, decode_arguments
+
+
+def parse(
+    parser_family: str,
+    raw_text: str,
+    tools: list[dict[str, Any]] | None,
+) -> ParseResult:
+    tools_json = json.dumps(tools) if tools else None
+
+    try:
+        # The PyO3 binding returns a future that registers with a running
+        # event loop, so we must call it from inside an async context.
+        async def _run() -> str:
+            return await parse_tool_call(parser_family, raw_text, tools_json)
+
+        result_json: str = asyncio.run(_run())
+    except Exception as e:
+        return ParseResult(error=f"{type(e).__name__}: {e}")
+
+    raw = json.loads(result_json)
+    calls = [
+        {
+            "name": c["function"]["name"],
+            "arguments": decode_arguments(c["function"]["arguments"]),
+        }
+        for c in raw.get("calls") or []
+    ]
+    return ParseResult(calls=calls, normal_text=raw.get("normal_text"))

--- a/tests/parity/parser/dynamo.py
+++ b/tests/parity/parser/dynamo.py
@@ -27,10 +27,10 @@ def parse(
             return await parse_tool_call(parser_family, raw_text, tools_json)
 
         result_json: str = asyncio.run(_run())
+        raw = json.loads(result_json)
     except Exception as e:
         return ParseResult(error=f"{type(e).__name__}: {e}")
 
-    raw = json.loads(result_json)
     calls = [
         {
             "name": c["function"]["name"],

--- a/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.yaml
@@ -1,0 +1,182 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: deepseek_v3
+mode: batch
+cases:
+  PARSER.batch.1:
+    description: Single tool call (happy path)
+    model_text: |-
+      <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+      ```json
+      {"location": "NYC"}
+      ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+  PARSER.batch.2:
+    description: Multiple tool calls (parallel)
+    model_text: |-
+      <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+      ```json
+      {"location": "NYC"}
+      ```<｜tool▁call▁end｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_time
+      ```json
+      {"timezone": "EST"}
+      ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    tools:
+    - *id001
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
+  PARSER.batch.3:
+    description: No tool call (plain text)
+    model_text: Hello, how can I help you today?
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: Hello, how can I help you today?
+  PARSER.batch.4:
+    description: Malformed JSON args (missing close brace)
+    model_text: |-
+      <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+      ```json
+      {"location": "NYC"
+      ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: |-
+        <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+        ```json
+        {"location": "NYC"
+        ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+  PARSER.batch.5:
+    description: Missing calls_end / call_end markers
+    model_text: |-
+      <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+      ```json
+      {"location": "NYC"}
+      ```
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: |-
+        <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+        ```json
+        {"location": "NYC"}
+        ```
+  PARSER.batch.6:
+    description: Empty args (no-arg call)
+    model_text: |-
+      <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_time
+      ```json
+      {}
+      ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    tools:
+    - name: get_time
+      parameters:
+        type: object
+        properties: {}
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.7:
+    description: Complex args (nested object + array)
+    model_text: |-
+      <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>process_data
+      ```json
+      {"items": [1, 2, 3], "config": {"nested": true}}
+      ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    tools:
+    - name: process_data
+      parameters:
+        type: object
+        properties:
+          items:
+            type: array
+          config:
+            type: object
+    expected:
+      calls:
+      - name: process_data
+        arguments:
+          items:
+          - 1
+          - 2
+          - 3
+          config:
+            nested: true
+      normal_text: ''
+  PARSER.batch.8:
+    description: Interleaved normal text
+    model_text: |-
+      The following tool call retrieves weather information: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+      ```json
+      {"location": "New York"}
+      ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: New York
+      normal_text: 'The following tool call retrieves weather information: '
+  PARSER.batch.9:
+    description: Empty input
+    model_text: ''
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''
+  PARSER.batch.10:
+    description: Duplicate calls (same name twice)
+    model_text: |-
+      <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+      ```json
+      {"location": "NYC"}
+      ```<｜tool▁call▁end｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+      ```json
+      {"location": "LA"}
+      ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''

--- a/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 family: deepseek_v3_1
 mode: batch
 cases:

--- a/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.yaml
@@ -1,0 +1,133 @@
+family: deepseek_v3_1
+mode: batch
+cases:
+  PARSER.batch.1:
+    description: Single tool call (happy path)
+    model_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+  PARSER.batch.2:
+    description: Multiple tool calls
+    model_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_time<｜tool▁sep｜>{"timezone":"EST"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    tools:
+    - *id001
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
+  PARSER.batch.3:
+    description: No tool call (plain text)
+    model_text: Hello, how can I help you today?
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: Hello, how can I help you today?
+  PARSER.batch.4:
+    description: Malformed JSON inside call
+    model_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+  PARSER.batch.5:
+    description: Missing tool_calls_end (truncation)
+    model_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜>
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜>
+  PARSER.batch.6:
+    description: Empty args (no-arg call)
+    model_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_time<｜tool▁sep｜>{}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    tools:
+    - name: get_time
+      parameters:
+        type: object
+        properties: {}
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.7:
+    description: Complex args (nested object + array)
+    model_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>process_data<｜tool▁sep｜>{"items":[1,2,3],"config":{"nested":true}}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    tools:
+    - name: process_data
+      parameters:
+        type: object
+        properties:
+          items:
+            type: array
+          config:
+            type: object
+    expected:
+      calls:
+      - name: process_data
+        arguments:
+          items:
+          - 1
+          - 2
+          - 3
+          config:
+            nested: true
+      normal_text: ''
+  PARSER.batch.8:
+    description: Interleaved normal text
+    model_text: 'The following tool call retrieves weather information: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'The following tool call retrieves weather information: '
+  PARSER.batch.9:
+    description: Empty input
+    model_text: ''
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''
+  PARSER.batch.10:
+    description: Duplicate calls (same name twice)
+    model_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"LA"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''

--- a/tests/parity/parser/fixtures/gemma4/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/gemma4/PARSER.batch.yaml
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: gemma4
+mode: batch
+cases:
+  PARSER.batch.1:
+    description: Single tool call (happy path)
+    model_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}<tool_call|>
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+  PARSER.batch.2:
+    description: Multiple tool calls (parallel)
+    model_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}<tool_call|><|tool_call>call:get_time{timezone:<|"|>EST<|"|>}<tool_call|>
+    tools:
+    - *id001
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
+  PARSER.batch.3:
+    description: No tool call (plain text)
+    model_text: Hello, how can I help you today?
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: Hello, how can I help you today?
+  PARSER.batch.4:
+    description: Malformed (missing close brace)
+    model_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|><tool_call|>
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|><tool_call|>
+  PARSER.batch.5:
+    description: Missing <tool_call|> end marker
+    model_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}
+  PARSER.batch.6:
+    description: Empty args (no-arg call)
+    model_text: <|tool_call>call:get_time{}<tool_call|>
+    tools:
+    - name: get_time
+      parameters:
+        type: object
+        properties: {}
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.7:
+    description: Complex args (nested object + array)
+    model_text: <|tool_call>call:process_data{items:[1,2,3],config:{nested:true}}<tool_call|>
+    tools:
+    - name: process_data
+      parameters:
+        type: object
+        properties:
+          items:
+            type: array
+          config:
+            type: object
+    expected:
+      calls:
+      - name: process_data
+        arguments:
+          items:
+          - 1
+          - 2
+          - 3
+          config:
+            nested: true
+      normal_text: ''
+  PARSER.batch.8:
+    description: Interleaved normal text
+    model_text: I will check that. <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}<tool_call|> Done.
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: I will check that.  Done.
+  PARSER.batch.9:
+    description: Empty input
+    model_text: ''
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''
+  PARSER.batch.10:
+    description: Duplicate calls (same name twice)
+    model_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}<tool_call|><|tool_call>call:get_weather{location:<|"|>LA<|"|>}<tool_call|>
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''

--- a/tests/parity/parser/fixtures/glm47/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/glm47/PARSER.batch.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 family: glm47
 mode: batch
 cases:

--- a/tests/parity/parser/fixtures/glm47/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/glm47/PARSER.batch.yaml
@@ -1,0 +1,131 @@
+family: glm47
+mode: batch
+cases:
+  PARSER.batch.1:
+    description: Single tool call (happy path)
+    model_text: <tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+  PARSER.batch.2:
+    description: Multiple tool calls
+    model_text: <tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call><tool_call>get_time<arg_key>timezone</arg_key><arg_value>EST</arg_value></tool_call>
+    tools:
+    - *id001
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
+  PARSER.batch.3:
+    description: No tool call (plain text)
+    model_text: Hello, how can I help you today?
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: Hello, how can I help you today?
+  PARSER.batch.4:
+    description: Malformed (missing arg_value end tag)
+    model_text: <tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</tool_call>
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.5:
+    description: Missing </tool_call> end marker
+    model_text: <tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value>
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: <tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value>
+  PARSER.batch.6:
+    description: Empty args (no-arg call)
+    model_text: <tool_call>get_time</tool_call>
+    tools:
+    - name: get_time
+      parameters:
+        type: object
+        properties: {}
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.7:
+    description: Complex args (multi-parameter)
+    model_text: <tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value><arg_key>unit</arg_key><arg_value>fahrenheit</arg_value></tool_call>
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+          unit:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          unit: fahrenheit
+          location: NYC
+      normal_text: ''
+  PARSER.batch.8:
+    description: Interleaved normal text
+    model_text: I'll check the weather. <tool_call>get_weather<arg_key>location</arg_key><arg_value>Paris</arg_value></tool_call>
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Paris
+      normal_text: I'll check the weather.
+  PARSER.batch.9:
+    description: Empty input
+    model_text: ''
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''
+  PARSER.batch.10:
+    description: Duplicate calls (same name twice)
+    model_text: <tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call><tool_call>get_weather<arg_key>location</arg_key><arg_value>LA</arg_value></tool_call>
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''

--- a/tests/parity/parser/fixtures/glm47/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/glm47/PARSER.batch.yaml
@@ -65,8 +65,11 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: <tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value>
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: null
   PARSER.batch.6:
     description: Empty args (no-arg call)
     model_text: <tool_call>get_time</tool_call>

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.yaml
@@ -1,0 +1,123 @@
+family: harmony
+mode: batch
+cases:
+  PARSER.batch.1:
+    description: Single tool call (basic complete envelope)
+    model_text: <|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+  PARSER.batch.2:
+    description: Multiple tool calls (back-to-back commentary blocks)
+    model_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|><|start|>assistant<|channel|>commentary
+      to=functions.get_time <|constrain|>json<|message|>{"timezone":"EST"}<|call|>
+    tools:
+    - *id001
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      calls: []
+      normal_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|><|start|>assistant<|channel|>commentary
+        to=functions.get_time <|constrain|>json<|message|>{"timezone":"EST"}<|call|>
+  PARSER.batch.3:
+    description: No tool call (plain text)
+    model_text: Hello, how can I help you today?
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: Hello, how can I help you today?
+  PARSER.batch.4:
+    description: Malformed (truncated JSON args)
+    model_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC<|call|>
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC<|call|>
+  PARSER.batch.5:
+    description: Missing <|call|> end marker (bare envelope)
+    model_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}
+  PARSER.batch.6:
+    description: Empty args (no-arg call)
+    model_text: <|channel|>commentary to=functions.get_time <|constrain|>json<|message|>{}
+    tools:
+    - name: get_time
+      parameters:
+        type: object
+        properties: {}
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.7:
+    description: Complex args (multi-parameter)
+    model_text: <|channel|>analysis<|message|>Need to use function get_weather.<|end|><|start|>assistant<|channel|>commentary
+      to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC","unit":"fahrenheit"}<|call|>
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+          unit:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+          unit: fahrenheit
+      normal_text: Need to use function get_weather.
+  PARSER.batch.8:
+    description: Interleaved analysis-channel text + tool call
+    model_text: <|channel|>analysis<|message|>Need to use function get_weather.<|end|><|start|>assistant<|channel|>commentary
+      to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|>
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: Need to use function get_weather.
+  PARSER.batch.9:
+    description: Empty input
+    model_text: ''
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''
+  PARSER.batch.10:
+    description: Duplicate calls (same name twice)
+    model_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|><|start|>assistant<|channel|>commentary
+      to=functions.get_weather <|constrain|>json<|message|>{"location":"LA"}<|call|>
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|><|start|>assistant<|channel|>commentary
+        to=functions.get_weather <|constrain|>json<|message|>{"location":"LA"}<|call|>

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 family: harmony
 mode: batch
 cases:

--- a/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 family: kimi_k2
 mode: batch
 cases:

--- a/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.yaml
@@ -1,0 +1,139 @@
+family: kimi_k2
+mode: batch
+cases:
+  PARSER.batch.1:
+    description: Single tool call (happy path)
+    model_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+  PARSER.batch.2:
+    description: Multiple tool calls
+    model_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_call_begin|>functions.get_time:1<|tool_call_argument_begin|>{"timezone":"EST"}<|tool_call_end|><|tool_calls_section_end|>
+    tools:
+    - *id001
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
+  PARSER.batch.3:
+    description: No tool call (plain text)
+    model_text: Hello, how can I help you today?
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: Hello, how can I help you today?
+  PARSER.batch.4:
+    description: Malformed JSON args (missing close brace)
+    model_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"<|tool_call_end|><|tool_calls_section_end|>
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments: '{"location":"NYC"'
+      normal_text: ''
+  PARSER.batch.5:
+    description: 'Missing section_end (max_tokens truncation, PR #8208)'
+    model_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|>
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+  PARSER.batch.6:
+    description: Empty args (no-arg call)
+    model_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.get_time:0<|tool_call_argument_begin|>{}<|tool_call_end|><|tool_calls_section_end|>
+    tools:
+    - name: get_time
+      parameters:
+        type: object
+        properties: {}
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.7:
+    description: Complex args (nested object + array)
+    model_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.process_data:0<|tool_call_argument_begin|>{"items":[1,2,3],"config":{"nested":true}}<|tool_call_end|><|tool_calls_section_end|>
+    tools:
+    - name: process_data
+      parameters:
+        type: object
+        properties:
+          items:
+            type: array
+          config:
+            type: object
+    expected:
+      calls:
+      - name: process_data
+        arguments:
+          items:
+          - 1
+          - 2
+          - 3
+          config:
+            nested: true
+      normal_text: ''
+  PARSER.batch.8:
+    description: Interleaved normal text
+    model_text: I'll help you with that. <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"Dallas"}<|tool_call_end|><|tool_calls_section_end|>
+      Let me check.
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Dallas
+      normal_text: I'll help you with that.  Let me check.
+  PARSER.batch.9:
+    description: Empty input
+    model_text: ''
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''
+  PARSER.batch.10:
+    description: Duplicate calls (same name twice)
+    model_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_call_begin|>functions.get_weather:1<|tool_call_argument_begin|>{"location":"LA"}<|tool_call_end|><|tool_calls_section_end|>
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''

--- a/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.yaml
@@ -1,0 +1,180 @@
+family: minimax_m2
+mode: batch
+cases:
+  PARSER.batch.1:
+    description: Single tool call (happy path)
+    model_text: |-
+      <minimax:tool_call>
+      <invoke name="get_weather">
+      <parameter name="location">NYC</parameter>
+      </invoke>
+      </minimax:tool_call>
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+  PARSER.batch.2:
+    description: Multiple tool calls
+    model_text: |-
+      <minimax:tool_call>
+      <invoke name="get_weather">
+      <parameter name="location">NYC</parameter>
+      </invoke>
+      <invoke name="get_time">
+      <parameter name="timezone">EST</parameter>
+      </invoke>
+      </minimax:tool_call>
+    tools:
+    - *id001
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
+  PARSER.batch.3:
+    description: No tool call (plain text)
+    model_text: Hello, how can I help you today?
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: Hello, how can I help you today?
+  PARSER.batch.4:
+    description: Malformed (missing closing invoke tag)
+    model_text: |-
+      <minimax:tool_call>
+      <invoke name="get_weather">
+      <parameter name="location">NYC</parameter>
+      </minimax:tool_call>
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+  PARSER.batch.5:
+    description: Missing </minimax:tool_call> end marker
+    model_text: |-
+      <minimax:tool_call>
+      <invoke name="get_weather">
+      <parameter name="location">NYC</parameter>
+      </invoke>
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: |-
+        <minimax:tool_call>
+        <invoke name="get_weather">
+        <parameter name="location">NYC</parameter>
+        </invoke>
+  PARSER.batch.6:
+    description: Empty args (no-arg call)
+    model_text: |-
+      <minimax:tool_call>
+      <invoke name="get_time">
+      </invoke>
+      </minimax:tool_call>
+    tools:
+    - name: get_time
+      parameters:
+        type: object
+        properties: {}
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.7:
+    description: Complex args (multi-parameter)
+    model_text: |-
+      <minimax:tool_call>
+      <invoke name="get_weather">
+      <parameter name="location">NYC</parameter>
+      <parameter name="unit">fahrenheit</parameter>
+      </invoke>
+      </minimax:tool_call>
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+          unit:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+          unit: fahrenheit
+      normal_text: ''
+  PARSER.batch.8:
+    description: Interleaved normal text
+    model_text: |-
+      I'll help you check the weather. <minimax:tool_call>
+      <invoke name="get_weather">
+      <parameter name="location">Tokyo</parameter>
+      </invoke>
+      </minimax:tool_call>
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Tokyo
+      normal_text: I'll help you check the weather.
+  PARSER.batch.9:
+    description: Empty input
+    model_text: ''
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''
+  PARSER.batch.10:
+    description: Duplicate calls (same name twice)
+    model_text: |-
+      <minimax:tool_call>
+      <invoke name="get_weather">
+      <parameter name="location">NYC</parameter>
+      </invoke>
+      <invoke name="get_weather">
+      <parameter name="location">LA</parameter>
+      </invoke>
+      </minimax:tool_call>
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''

--- a/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 family: minimax_m2
 mode: batch
 cases:

--- a/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.yaml
@@ -87,12 +87,11 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: |-
-        <minimax:tool_call>
-        <invoke name="get_weather">
-        <parameter name="location">NYC</parameter>
-        </invoke>
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: null
   PARSER.batch.6:
     description: Empty args (no-arg call)
     model_text: |-

--- a/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 family: nemotron_deci
 mode: batch
 cases:

--- a/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.yaml
@@ -56,16 +56,22 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC</TOOLCALL>'
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: null
   PARSER.batch.5:
     description: Missing </TOOLCALL> end marker
     model_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}]'
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}]'
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: null
   PARSER.batch.6:
     description: Empty args (no-arg call)
     model_text: '<TOOLCALL>[{"name": "get_time", "arguments": {}}]</TOOLCALL>'

--- a/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.yaml
@@ -1,0 +1,135 @@
+family: nemotron_deci
+mode: batch
+cases:
+  PARSER.batch.1:
+    description: Single tool call (happy path)
+    model_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}]</TOOLCALL>'
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+  PARSER.batch.2:
+    description: Multiple tool calls
+    model_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_time", "arguments": {"timezone":
+      "EST"}}]</TOOLCALL>'
+    tools:
+    - *id001
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
+  PARSER.batch.3:
+    description: No tool call (plain text)
+    model_text: Hello, how can I help you today?
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: Hello, how can I help you today?
+  PARSER.batch.4:
+    description: Malformed (truncated JSON inside TOOLCALL)
+    model_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC</TOOLCALL>'
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC</TOOLCALL>'
+  PARSER.batch.5:
+    description: Missing </TOOLCALL> end marker
+    model_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}]'
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}]'
+  PARSER.batch.6:
+    description: Empty args (no-arg call)
+    model_text: '<TOOLCALL>[{"name": "get_time", "arguments": {}}]</TOOLCALL>'
+    tools:
+    - name: get_time
+      parameters:
+        type: object
+        properties: {}
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.7:
+    description: Complex args (nested object + array)
+    model_text: '<TOOLCALL>[{"name": "process_data", "arguments": {"items": [1,2,3], "config": {"nested": true}}}]</TOOLCALL>'
+    tools:
+    - name: process_data
+      parameters:
+        type: object
+        properties:
+          items:
+            type: array
+          config:
+            type: object
+    expected:
+      calls:
+      - name: process_data
+        arguments:
+          items:
+          - 1
+          - 2
+          - 3
+          config:
+            nested: true
+      normal_text: ''
+  PARSER.batch.8:
+    description: Interleaved normal text
+    model_text: 'Hey How are you? <TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}]</TOOLCALL>'
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: Hey How are you?
+  PARSER.batch.9:
+    description: Empty input
+    model_text: ''
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''
+  PARSER.batch.10:
+    description: Duplicate calls (same name twice)
+    model_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_weather", "arguments":
+      {"location": "LA"}}]</TOOLCALL>'
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''

--- a/tests/parity/parser/fixtures/pythonic/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/pythonic/PARSER.batch.yaml
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: pythonic
+mode: batch
+cases:
+  PARSER.batch.1:
+    description: Single tool call (happy path)
+    model_text: '[get_weather(location="NYC")]'
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+  PARSER.batch.2:
+    description: Multiple tool calls (parallel)
+    model_text: '[get_weather(location="NYC"), get_time(timezone="EST")]'
+    tools:
+    - *id001
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
+  PARSER.batch.3:
+    description: No tool call (plain text)
+    model_text: Hello, how can I help you today?
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: Hello, how can I help you today?
+  PARSER.batch.4:
+    description: Malformed (missing closing bracket)
+    model_text: '[get_weather(location="NYC"'
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: '[get_weather(location="NYC"'
+  PARSER.batch.5:
+    description: Missing closing `]` end marker
+    model_text: '[get_weather(location="NYC")'
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: '[get_weather(location="NYC")'
+  PARSER.batch.6:
+    description: Empty args (no-arg call)
+    model_text: '[get_time()]'
+    tools:
+    - name: get_time
+      parameters:
+        type: object
+        properties: {}
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.7:
+    description: Complex args (nested dict + array)
+    model_text: '[process_data(items=[1, 2, 3], config={"nested": True})]'
+    tools:
+    - name: process_data
+      parameters:
+        type: object
+        properties:
+          items:
+            type: array
+          config:
+            type: object
+    expected:
+      calls:
+      - name: process_data
+        arguments:
+          items:
+          - 1
+          - 2
+          - 3
+          config:
+            nested: true
+      normal_text: ''
+  PARSER.batch.8:
+    description: Interleaved normal text
+    model_text: Hey yo ! [get_weather(location="NYC")] Hey yo
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: Hey yo !
+  PARSER.batch.9:
+    description: Empty input
+    model_text: ''
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''
+  PARSER.batch.10:
+    description: Duplicate calls (same name twice)
+    model_text: '[get_weather(location="NYC"), get_weather(location="LA")]'
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''

--- a/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 family: qwen3_coder
 mode: batch
 cases:

--- a/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.yaml
@@ -1,0 +1,206 @@
+family: qwen3_coder
+mode: batch
+cases:
+  PARSER.batch.1:
+    description: Single tool call (happy path)
+    model_text: |-
+      <tool_call>
+      <function=get_weather>
+      <parameter=location>
+      NYC
+      </parameter>
+      </function>
+      </tool_call>
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+  PARSER.batch.2:
+    description: Multiple tool calls
+    model_text: |-
+      <tool_call>
+      <function=get_weather>
+      <parameter=location>
+      NYC
+      </parameter>
+      </function>
+      </tool_call>
+      <tool_call>
+      <function=get_time>
+      <parameter=timezone>
+      EST
+      </parameter>
+      </function>
+      </tool_call>
+    tools:
+    - *id001
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
+  PARSER.batch.3:
+    description: No tool call (plain text)
+    model_text: Hello, how can I help you today?
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: Hello, how can I help you today?
+  PARSER.batch.4:
+    description: Malformed (missing </parameter> closing tag)
+    model_text: |-
+      <tool_call>
+      <function=get_weather>
+      <parameter=location>
+      NYC
+      </function>
+      </tool_call>
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+  PARSER.batch.5:
+    description: Missing </tool_call> end marker
+    model_text: |-
+      <tool_call>
+      <function=get_weather>
+      <parameter=location>
+      NYC
+      </parameter>
+      </function>
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: |-
+        <tool_call>
+        <function=get_weather>
+        <parameter=location>
+        NYC
+        </parameter>
+        </function>
+  PARSER.batch.6:
+    description: Empty args (no-arg call)
+    model_text: |-
+      <tool_call>
+      <function=get_time>
+      </function>
+      </tool_call>
+    tools:
+    - name: get_time
+      parameters:
+        type: object
+        properties: {}
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.7:
+    description: Complex args (multi-parameter)
+    model_text: |-
+      <tool_call>
+      <function=get_weather>
+      <parameter=location>
+      NYC
+      </parameter>
+      <parameter=unit>
+      fahrenheit
+      </parameter>
+      </function>
+      </tool_call>
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+          unit:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+          unit: fahrenheit
+      normal_text: ''
+  PARSER.batch.8:
+    description: Interleaved normal text
+    model_text: |-
+      I'll help you check the weather. <tool_call>
+      <function=get_weather>
+      <parameter=location>
+      NYC
+      </parameter>
+      </function>
+      </tool_call> Let me get that information for you.
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: I'll help you check the weather.  Let me get that information for you.
+  PARSER.batch.9:
+    description: Empty input
+    model_text: ''
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''
+  PARSER.batch.10:
+    description: Duplicate calls (same name twice)
+    model_text: |-
+      <tool_call>
+      <function=get_weather>
+      <parameter=location>
+      NYC
+      </parameter>
+      </function>
+      </tool_call>
+      <tool_call>
+      <function=get_weather>
+      <parameter=location>
+      LA
+      </parameter>
+      </function>
+      </tool_call>
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''

--- a/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.yaml
@@ -99,14 +99,11 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: |-
-        <tool_call>
-        <function=get_weather>
-        <parameter=location>
-        NYC
-        </parameter>
-        </function>
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: null
   PARSER.batch.6:
     description: Empty args (no-arg call)
     model_text: |-

--- a/tests/parity/parser/regenerate_fixtures.py
+++ b/tests/parity/parser/regenerate_fixtures.py
@@ -443,6 +443,166 @@ INPUTS: dict[tuple[str, str], dict[str, Any] | None] = {
         "text": '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_weather", "arguments": {"location": "LA"}}]</TOOLCALL>',
         "tools": [_GET_WEATHER_LOC],
     },
+    # ----- pythonic -----
+    # Format: [name(arg=val, ...), name2(...)] — Python-call-style. Also
+    # accepts <|python_start|>...<|python_end|> wrapping (e.g. Llama 4).
+    ("pythonic", "PARSER.batch.1"): {
+        "description": "Single tool call (happy path)",
+        "text": '[get_weather(location="NYC")]',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("pythonic", "PARSER.batch.2"): {
+        "description": "Multiple tool calls (parallel)",
+        "text": '[get_weather(location="NYC"), get_time(timezone="EST")]',
+        "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("pythonic", "PARSER.batch.3"): {
+        "description": "No tool call (plain text)",
+        "text": "Hello, how can I help you today?",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("pythonic", "PARSER.batch.4"): {
+        "description": "Malformed (missing closing bracket)",
+        "text": '[get_weather(location="NYC"',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("pythonic", "PARSER.batch.5"): {
+        "description": "Missing closing `]` end marker",
+        "text": '[get_weather(location="NYC")',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("pythonic", "PARSER.batch.6"): {
+        "description": "Empty args (no-arg call)",
+        "text": "[get_time()]",
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("pythonic", "PARSER.batch.7"): {
+        "description": "Complex args (nested dict + array)",
+        "text": '[process_data(items=[1, 2, 3], config={"nested": True})]',
+        "tools": [_PROCESS_DATA_NESTED],
+    },
+    ("pythonic", "PARSER.batch.8"): {
+        "description": "Interleaved normal text",
+        "text": 'Hey yo ! [get_weather(location="NYC")] Hey yo',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("pythonic", "PARSER.batch.9"): {
+        "description": "Empty input",
+        "text": "",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("pythonic", "PARSER.batch.10"): {
+        "description": "Duplicate calls (same name twice)",
+        "text": '[get_weather(location="NYC"), get_weather(location="LA")]',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    # ----- gemma4 -----
+    # Format: <|tool_call>call:NAME{key:val,...}<tool_call|>
+    # String values are wrapped with `<|"|>` literal markers (not standard JSON quotes).
+    ("gemma4", "PARSER.batch.1"): {
+        "description": "Single tool call (happy path)",
+        "text": '<|tool_call>call:get_weather{location:<|"|>NYC<|"|>}<tool_call|>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("gemma4", "PARSER.batch.2"): {
+        "description": "Multiple tool calls (parallel)",
+        "text": '<|tool_call>call:get_weather{location:<|"|>NYC<|"|>}<tool_call|><|tool_call>call:get_time{timezone:<|"|>EST<|"|>}<tool_call|>',
+        "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("gemma4", "PARSER.batch.3"): {
+        "description": "No tool call (plain text)",
+        "text": "Hello, how can I help you today?",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("gemma4", "PARSER.batch.4"): {
+        "description": "Malformed (missing close brace)",
+        "text": '<|tool_call>call:get_weather{location:<|"|>NYC<|"|><tool_call|>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("gemma4", "PARSER.batch.5"): {
+        "description": "Missing <tool_call|> end marker",
+        "text": '<|tool_call>call:get_weather{location:<|"|>NYC<|"|>}',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("gemma4", "PARSER.batch.6"): {
+        "description": "Empty args (no-arg call)",
+        "text": "<|tool_call>call:get_time{}<tool_call|>",
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("gemma4", "PARSER.batch.7"): {
+        "description": "Complex args (nested object + array)",
+        "text": "<|tool_call>call:process_data{items:[1,2,3],config:{nested:true}}<tool_call|>",
+        "tools": [_PROCESS_DATA_NESTED],
+    },
+    ("gemma4", "PARSER.batch.8"): {
+        "description": "Interleaved normal text",
+        "text": 'I will check that. <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}<tool_call|> Done.',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("gemma4", "PARSER.batch.9"): {
+        "description": "Empty input",
+        "text": "",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("gemma4", "PARSER.batch.10"): {
+        "description": "Duplicate calls (same name twice)",
+        "text": '<|tool_call>call:get_weather{location:<|"|>NYC<|"|>}<tool_call|><|tool_call>call:get_weather{location:<|"|>LA<|"|>}<tool_call|>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    # ----- deepseek_v3 (legacy) -----
+    # Format: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>NAME
+    # ```json\n{args}\n```<｜tool▁call▁end｜>...<｜tool▁calls▁end｜>
+    # Note: distinct from `deepseek_v3_1` (no markdown fence).
+    ("deepseek_v3", "PARSER.batch.1"): {
+        "description": "Single tool call (happy path)",
+        "text": '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather\n```json\n{"location": "NYC"}\n```<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("deepseek_v3", "PARSER.batch.2"): {
+        "description": "Multiple tool calls (parallel)",
+        "text": '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather\n```json\n{"location": "NYC"}\n```<｜tool▁call▁end｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_time\n```json\n{"timezone": "EST"}\n```<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
+        "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("deepseek_v3", "PARSER.batch.3"): {
+        "description": "No tool call (plain text)",
+        "text": "Hello, how can I help you today?",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("deepseek_v3", "PARSER.batch.4"): {
+        "description": "Malformed JSON args (missing close brace)",
+        "text": '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather\n```json\n{"location": "NYC"\n```<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("deepseek_v3", "PARSER.batch.5"): {
+        "description": "Missing calls_end / call_end markers",
+        "text": '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather\n```json\n{"location": "NYC"}\n```',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("deepseek_v3", "PARSER.batch.6"): {
+        "description": "Empty args (no-arg call)",
+        "text": "<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_time\n```json\n{}\n```<｜tool▁call▁end｜><｜tool▁calls▁end｜>",
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("deepseek_v3", "PARSER.batch.7"): {
+        "description": "Complex args (nested object + array)",
+        "text": '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>process_data\n```json\n{"items": [1, 2, 3], "config": {"nested": true}}\n```<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
+        "tools": [_PROCESS_DATA_NESTED],
+    },
+    ("deepseek_v3", "PARSER.batch.8"): {
+        "description": "Interleaved normal text",
+        "text": 'The following tool call retrieves weather information: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather\n```json\n{"location": "New York"}\n```<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("deepseek_v3", "PARSER.batch.9"): {
+        "description": "Empty input",
+        "text": "",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("deepseek_v3", "PARSER.batch.10"): {
+        "description": "Duplicate calls (same name twice)",
+        "text": '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather\n```json\n{"location": "NYC"}\n```<｜tool▁call▁end｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather\n```json\n{"location": "LA"}\n```<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
+        "tools": [_GET_WEATHER_LOC],
+    },
 }
 
 

--- a/tests/parity/parser/regenerate_fixtures.py
+++ b/tests/parity/parser/regenerate_fixtures.py
@@ -486,8 +486,12 @@ def _write_family_fixtures(
     family_dir.mkdir(parents=True, exist_ok=True)
     ordered = {f"PARSER.{mode}.{n}": cases[n] for n in sorted(cases, key=int)}
     out = {"family": family, "mode": mode, "cases": ordered}
+    header = (
+        "# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.\n"
+        "# SPDX-License-Identifier: Apache-2.0\n\n"
+    )
     (family_dir / f"PARSER.{mode}.yaml").write_text(
-        yaml.dump(out, sort_keys=False, allow_unicode=True, width=120),
+        header + yaml.dump(out, sort_keys=False, allow_unicode=True, width=120),
         encoding="utf-8",
     )
 

--- a/tests/parity/parser/regenerate_fixtures.py
+++ b/tests/parity/parser/regenerate_fixtures.py
@@ -1,0 +1,558 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fixture (re-)generator for the parity (parser) harness.
+
+Walks (family × case) combinations, runs each input through Dynamo's
+PyO3 parser, and writes the result as a fixture YAML. Run from the
+repo root inside a container with `dynamo._core` installed:
+
+    python3 -m tests.parity.parser.regenerate_fixtures
+
+(Run as a module — the local `dynamo.py` wrapper would shadow the
+real `dynamo` package if invoked as a script directly.)
+
+Default behavior is **non-destructive**: cases that already exist on
+disk are left alone. To refresh after an intentional Dynamo
+parser-behavior change, pass `--overwrite-if-exists`. Cases on disk
+but not in INPUTS today are always preserved (so editing INPUTS
+can't accidentally delete other contributors' cases).
+
+Cases per family follow PARSER_CASES.md. N/A combinations
+(empty INPUTS entry) are skipped.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from dynamo._core import parse_tool_call
+
+FIXTURES_ROOT = Path(__file__).parent / "fixtures"
+
+
+def _yaml_str_presenter(dumper: yaml.Dumper, data: str) -> yaml.ScalarNode:
+    """Use a literal block scalar (`|-`) for multi-line strings so
+    fixture `model_text` reads as wire-format text rather than a
+    `\\n`-escaped one-liner. Single-line strings keep the default style."""
+    if "\n" in data:
+        return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
+    return dumper.represent_scalar("tag:yaml.org,2002:str", data)
+
+
+yaml.add_representer(str, _yaml_str_presenter)
+
+# Tool definitions reused across cases. Each family picks the subset
+# of tools relevant to its case inputs.
+_GET_WEATHER_LOC = {
+    "name": "get_weather",
+    "parameters": {"type": "object", "properties": {"location": {"type": "string"}}},
+}
+_GET_WEATHER_LOC_UNIT = {
+    "name": "get_weather",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "location": {"type": "string"},
+            "unit": {"type": "string"},
+        },
+    },
+}
+_GET_TIME_TZ = {
+    "name": "get_time",
+    "parameters": {"type": "object", "properties": {"timezone": {"type": "string"}}},
+}
+_GET_TIME_NOARG = {
+    "name": "get_time",
+    "parameters": {"type": "object", "properties": {}},
+}
+_PROCESS_DATA_NESTED = {
+    "name": "process_data",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "items": {"type": "array"},
+            "config": {"type": "object"},
+        },
+    },
+}
+
+# (family, case_id) -> {"text": str, "tools": list[dict] | None, "description": str}
+# Cases marked with text=None are intentionally skipped (N/A or not yet
+# defined for that family).
+INPUTS: dict[tuple[str, str], dict[str, Any] | None] = {
+    # ----- kimi_k2 -----
+    ("kimi_k2", "PARSER.batch.1"): {
+        "description": "Single tool call (happy path)",
+        "text": '<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("kimi_k2", "PARSER.batch.2"): {
+        "description": "Multiple tool calls",
+        "text": '<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_call_begin|>functions.get_time:1<|tool_call_argument_begin|>{"timezone":"EST"}<|tool_call_end|><|tool_calls_section_end|>',
+        "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("kimi_k2", "PARSER.batch.3"): {
+        "description": "No tool call (plain text)",
+        "text": "Hello, how can I help you today?",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("kimi_k2", "PARSER.batch.4"): {
+        "description": "Malformed JSON args (missing close brace)",
+        "text": '<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"<|tool_call_end|><|tool_calls_section_end|>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("kimi_k2", "PARSER.batch.5"): {
+        "description": "Missing section_end (max_tokens truncation, PR #8208)",
+        "text": '<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("kimi_k2", "PARSER.batch.6"): {
+        "description": "Empty args (no-arg call)",
+        "text": "<|tool_calls_section_begin|><|tool_call_begin|>functions.get_time:0<|tool_call_argument_begin|>{}<|tool_call_end|><|tool_calls_section_end|>",
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("kimi_k2", "PARSER.batch.7"): {
+        "description": "Complex args (nested object + array)",
+        "text": '<|tool_calls_section_begin|><|tool_call_begin|>functions.process_data:0<|tool_call_argument_begin|>{"items":[1,2,3],"config":{"nested":true}}<|tool_call_end|><|tool_calls_section_end|>',
+        "tools": [_PROCESS_DATA_NESTED],
+    },
+    ("kimi_k2", "PARSER.batch.8"): {
+        "description": "Interleaved normal text",
+        "text": 'I\'ll help you with that. <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"Dallas"}<|tool_call_end|><|tool_calls_section_end|> Let me check.',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("kimi_k2", "PARSER.batch.9"): {
+        "description": "Empty input",
+        "text": "",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("kimi_k2", "PARSER.batch.10"): {
+        "description": "Duplicate calls (same name twice)",
+        "text": '<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_call_begin|>functions.get_weather:1<|tool_call_argument_begin|>{"location":"LA"}<|tool_call_end|><|tool_calls_section_end|>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    # ----- qwen3_coder -----
+    ("qwen3_coder", "PARSER.batch.1"): {
+        "description": "Single tool call (happy path)",
+        "text": "<tool_call>\n<function=get_weather>\n<parameter=location>\nNYC\n</parameter>\n</function>\n</tool_call>",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("qwen3_coder", "PARSER.batch.2"): {
+        "description": "Multiple tool calls",
+        "text": "<tool_call>\n<function=get_weather>\n<parameter=location>\nNYC\n</parameter>\n</function>\n</tool_call>\n<tool_call>\n<function=get_time>\n<parameter=timezone>\nEST\n</parameter>\n</function>\n</tool_call>",
+        "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("qwen3_coder", "PARSER.batch.3"): {
+        "description": "No tool call (plain text)",
+        "text": "Hello, how can I help you today?",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("qwen3_coder", "PARSER.batch.4"): {
+        "description": "Malformed (missing </parameter> closing tag)",
+        "text": "<tool_call>\n<function=get_weather>\n<parameter=location>\nNYC\n</function>\n</tool_call>",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("qwen3_coder", "PARSER.batch.5"): {
+        "description": "Missing </tool_call> end marker",
+        "text": "<tool_call>\n<function=get_weather>\n<parameter=location>\nNYC\n</parameter>\n</function>",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("qwen3_coder", "PARSER.batch.6"): {
+        "description": "Empty args (no-arg call)",
+        "text": "<tool_call>\n<function=get_time>\n</function>\n</tool_call>",
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("qwen3_coder", "PARSER.batch.7"): {
+        "description": "Complex args (multi-parameter)",
+        "text": "<tool_call>\n<function=get_weather>\n<parameter=location>\nNYC\n</parameter>\n<parameter=unit>\nfahrenheit\n</parameter>\n</function>\n</tool_call>",
+        "tools": [_GET_WEATHER_LOC_UNIT],
+    },
+    ("qwen3_coder", "PARSER.batch.8"): {
+        "description": "Interleaved normal text",
+        "text": "I'll help you check the weather. <tool_call>\n<function=get_weather>\n<parameter=location>\nNYC\n</parameter>\n</function>\n</tool_call> Let me get that information for you.",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("qwen3_coder", "PARSER.batch.9"): {
+        "description": "Empty input",
+        "text": "",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("qwen3_coder", "PARSER.batch.10"): {
+        "description": "Duplicate calls (same name twice)",
+        "text": "<tool_call>\n<function=get_weather>\n<parameter=location>\nNYC\n</parameter>\n</function>\n</tool_call>\n<tool_call>\n<function=get_weather>\n<parameter=location>\nLA\n</parameter>\n</function>\n</tool_call>",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    # ----- glm47 -----
+    ("glm47", "PARSER.batch.1"): {
+        "description": "Single tool call (happy path)",
+        "text": "<tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("glm47", "PARSER.batch.2"): {
+        "description": "Multiple tool calls",
+        "text": "<tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call><tool_call>get_time<arg_key>timezone</arg_key><arg_value>EST</arg_value></tool_call>",
+        "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("glm47", "PARSER.batch.3"): {
+        "description": "No tool call (plain text)",
+        "text": "Hello, how can I help you today?",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("glm47", "PARSER.batch.4"): {
+        "description": "Malformed (missing arg_value end tag)",
+        "text": "<tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</tool_call>",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("glm47", "PARSER.batch.5"): {
+        "description": "Missing </tool_call> end marker",
+        "text": "<tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value>",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("glm47", "PARSER.batch.6"): {
+        "description": "Empty args (no-arg call)",
+        "text": "<tool_call>get_time</tool_call>",
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("glm47", "PARSER.batch.7"): {
+        "description": "Complex args (multi-parameter)",
+        "text": "<tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value><arg_key>unit</arg_key><arg_value>fahrenheit</arg_value></tool_call>",
+        "tools": [_GET_WEATHER_LOC_UNIT],
+    },
+    ("glm47", "PARSER.batch.8"): {
+        "description": "Interleaved normal text",
+        "text": "I'll check the weather. <tool_call>get_weather<arg_key>location</arg_key><arg_value>Paris</arg_value></tool_call>",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("glm47", "PARSER.batch.9"): {
+        "description": "Empty input",
+        "text": "",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("glm47", "PARSER.batch.10"): {
+        "description": "Duplicate calls (same name twice)",
+        "text": "<tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call><tool_call>get_weather<arg_key>location</arg_key><arg_value>LA</arg_value></tool_call>",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    # ----- deepseek_v3_1 -----
+    ("deepseek_v3_1", "PARSER.batch.1"): {
+        "description": "Single tool call (happy path)",
+        "text": '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("deepseek_v3_1", "PARSER.batch.2"): {
+        "description": "Multiple tool calls",
+        "text": '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_time<｜tool▁sep｜>{"timezone":"EST"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
+        "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("deepseek_v3_1", "PARSER.batch.3"): {
+        "description": "No tool call (plain text)",
+        "text": "Hello, how can I help you today?",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("deepseek_v3_1", "PARSER.batch.4"): {
+        "description": "Malformed JSON inside call",
+        "text": '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("deepseek_v3_1", "PARSER.batch.5"): {
+        "description": "Missing tool_calls_end (truncation)",
+        "text": '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("deepseek_v3_1", "PARSER.batch.6"): {
+        "description": "Empty args (no-arg call)",
+        "text": "<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_time<｜tool▁sep｜>{}<｜tool▁call▁end｜><｜tool▁calls▁end｜>",
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("deepseek_v3_1", "PARSER.batch.7"): {
+        "description": "Complex args (nested object + array)",
+        "text": '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>process_data<｜tool▁sep｜>{"items":[1,2,3],"config":{"nested":true}}<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
+        "tools": [_PROCESS_DATA_NESTED],
+    },
+    ("deepseek_v3_1", "PARSER.batch.8"): {
+        "description": "Interleaved normal text",
+        "text": 'The following tool call retrieves weather information: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("deepseek_v3_1", "PARSER.batch.9"): {
+        "description": "Empty input",
+        "text": "",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("deepseek_v3_1", "PARSER.batch.10"): {
+        "description": "Duplicate calls (same name twice)",
+        "text": '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"LA"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    # ----- harmony -----
+    ("harmony", "PARSER.batch.1"): {
+        "description": "Single tool call (basic complete envelope)",
+        "text": '<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("harmony", "PARSER.batch.2"): {
+        "description": "Multiple tool calls (back-to-back commentary blocks)",
+        "text": '<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|><|start|>assistant<|channel|>commentary to=functions.get_time <|constrain|>json<|message|>{"timezone":"EST"}<|call|>',
+        "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("harmony", "PARSER.batch.3"): {
+        "description": "No tool call (plain text)",
+        "text": "Hello, how can I help you today?",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("harmony", "PARSER.batch.4"): {
+        "description": "Malformed (truncated JSON args)",
+        "text": '<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC<|call|>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("harmony", "PARSER.batch.5"): {
+        "description": "Missing <|call|> end marker (bare envelope)",
+        "text": '<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("harmony", "PARSER.batch.6"): {
+        "description": "Empty args (no-arg call)",
+        "text": "<|channel|>commentary to=functions.get_time <|constrain|>json<|message|>{}",
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("harmony", "PARSER.batch.7"): {
+        "description": "Complex args (multi-parameter)",
+        "text": '<|channel|>analysis<|message|>Need to use function get_weather.<|end|><|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC","unit":"fahrenheit"}<|call|>',
+        "tools": [_GET_WEATHER_LOC_UNIT],
+    },
+    ("harmony", "PARSER.batch.8"): {
+        "description": "Interleaved analysis-channel text + tool call",
+        "text": '<|channel|>analysis<|message|>Need to use function get_weather.<|end|><|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("harmony", "PARSER.batch.9"): {
+        "description": "Empty input",
+        "text": "",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("harmony", "PARSER.batch.10"): {
+        "description": "Duplicate calls (same name twice)",
+        "text": '<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|><|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"LA"}<|call|>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    # ----- minimax_m2 -----
+    ("minimax_m2", "PARSER.batch.1"): {
+        "description": "Single tool call (happy path)",
+        "text": '<minimax:tool_call>\n<invoke name="get_weather">\n<parameter name="location">NYC</parameter>\n</invoke>\n</minimax:tool_call>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("minimax_m2", "PARSER.batch.2"): {
+        "description": "Multiple tool calls",
+        "text": '<minimax:tool_call>\n<invoke name="get_weather">\n<parameter name="location">NYC</parameter>\n</invoke>\n<invoke name="get_time">\n<parameter name="timezone">EST</parameter>\n</invoke>\n</minimax:tool_call>',
+        "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("minimax_m2", "PARSER.batch.3"): {
+        "description": "No tool call (plain text)",
+        "text": "Hello, how can I help you today?",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("minimax_m2", "PARSER.batch.4"): {
+        "description": "Malformed (missing closing invoke tag)",
+        "text": '<minimax:tool_call>\n<invoke name="get_weather">\n<parameter name="location">NYC</parameter>\n</minimax:tool_call>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("minimax_m2", "PARSER.batch.5"): {
+        "description": "Missing </minimax:tool_call> end marker",
+        "text": '<minimax:tool_call>\n<invoke name="get_weather">\n<parameter name="location">NYC</parameter>\n</invoke>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("minimax_m2", "PARSER.batch.6"): {
+        "description": "Empty args (no-arg call)",
+        "text": '<minimax:tool_call>\n<invoke name="get_time">\n</invoke>\n</minimax:tool_call>',
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("minimax_m2", "PARSER.batch.7"): {
+        "description": "Complex args (multi-parameter)",
+        "text": '<minimax:tool_call>\n<invoke name="get_weather">\n<parameter name="location">NYC</parameter>\n<parameter name="unit">fahrenheit</parameter>\n</invoke>\n</minimax:tool_call>',
+        "tools": [_GET_WEATHER_LOC_UNIT],
+    },
+    ("minimax_m2", "PARSER.batch.8"): {
+        "description": "Interleaved normal text",
+        "text": 'I\'ll help you check the weather. <minimax:tool_call>\n<invoke name="get_weather">\n<parameter name="location">Tokyo</parameter>\n</invoke>\n</minimax:tool_call>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("minimax_m2", "PARSER.batch.9"): {
+        "description": "Empty input",
+        "text": "",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("minimax_m2", "PARSER.batch.10"): {
+        "description": "Duplicate calls (same name twice)",
+        "text": '<minimax:tool_call>\n<invoke name="get_weather">\n<parameter name="location">NYC</parameter>\n</invoke>\n<invoke name="get_weather">\n<parameter name="location">LA</parameter>\n</invoke>\n</minimax:tool_call>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    # ----- nemotron_deci -----
+    ("nemotron_deci", "PARSER.batch.1"): {
+        "description": "Single tool call (happy path)",
+        "text": '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}]</TOOLCALL>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("nemotron_deci", "PARSER.batch.2"): {
+        "description": "Multiple tool calls",
+        "text": '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_time", "arguments": {"timezone": "EST"}}]</TOOLCALL>',
+        "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("nemotron_deci", "PARSER.batch.3"): {
+        "description": "No tool call (plain text)",
+        "text": "Hello, how can I help you today?",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("nemotron_deci", "PARSER.batch.4"): {
+        "description": "Malformed (truncated JSON inside TOOLCALL)",
+        "text": '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC</TOOLCALL>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("nemotron_deci", "PARSER.batch.5"): {
+        "description": "Missing </TOOLCALL> end marker",
+        "text": '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}]',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("nemotron_deci", "PARSER.batch.6"): {
+        "description": "Empty args (no-arg call)",
+        "text": '<TOOLCALL>[{"name": "get_time", "arguments": {}}]</TOOLCALL>',
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("nemotron_deci", "PARSER.batch.7"): {
+        "description": "Complex args (nested object + array)",
+        "text": '<TOOLCALL>[{"name": "process_data", "arguments": {"items": [1,2,3], "config": {"nested": true}}}]</TOOLCALL>',
+        "tools": [_PROCESS_DATA_NESTED],
+    },
+    ("nemotron_deci", "PARSER.batch.8"): {
+        "description": "Interleaved normal text",
+        "text": 'Hey How are you? <TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}]</TOOLCALL>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("nemotron_deci", "PARSER.batch.9"): {
+        "description": "Empty input",
+        "text": "",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("nemotron_deci", "PARSER.batch.10"): {
+        "description": "Duplicate calls (same name twice)",
+        "text": '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_weather", "arguments": {"location": "LA"}}]</TOOLCALL>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+}
+
+
+async def _run_one(family: str, text: str, tools: list[dict] | None) -> dict[str, Any]:
+    tools_json = json.dumps(tools) if tools else None
+    result_json = await parse_tool_call(family, text, tools_json)
+    raw = json.loads(result_json)
+    calls = []
+    for c in raw.get("calls") or []:
+        args_str = c["function"]["arguments"]
+        try:
+            args = json.loads(args_str) if args_str else {}
+        except (json.JSONDecodeError, TypeError):
+            args = args_str
+        calls.append({"name": c["function"]["name"], "arguments": args})
+    return {"calls": calls, "normal_text": raw.get("normal_text") or ""}
+
+
+def _load_existing(family: str, mode: str) -> dict[str, dict[str, Any]]:
+    """Read the on-disk cases dict for `(family, mode)`, or empty if absent.
+
+    Keys on disk are full case IDs (`PARSER.batch.5`); strip the prefix
+    so internal bookkeeping stays keyed by the case number (`"5"`)."""
+    fp = FIXTURES_ROOT / family / f"PARSER.{mode}.yaml"
+    if not fp.exists():
+        return {}
+    raw = yaml.safe_load(fp.read_text(encoding="utf-8")).get("cases", {}) or {}
+    return {k.rsplit(".", 1)[1]: v for k, v in raw.items()}
+
+
+def _write_family_fixtures(
+    family: str, mode: str, cases: dict[str, dict[str, Any]]
+) -> None:
+    """Write one file per (family, mode) holding all cases for that mode.
+
+    On-disk keys are the full case ID (e.g. `PARSER.batch.5`) so they
+    match the IDs used in PARSER_CASES.md and `KNOWN_DIVERGENCES`. A
+    single `grep PARSER.batch.5` then finds the case across docs,
+    fixtures, and Rust source comments."""
+    family_dir = FIXTURES_ROOT / family
+    family_dir.mkdir(parents=True, exist_ok=True)
+    ordered = {f"PARSER.{mode}.{n}": cases[n] for n in sorted(cases, key=int)}
+    out = {"family": family, "mode": mode, "cases": ordered}
+    (family_dir / f"PARSER.{mode}.yaml").write_text(
+        yaml.dump(out, sort_keys=False, allow_unicode=True, width=120),
+        encoding="utf-8",
+    )
+
+
+async def main(overwrite_if_exists: bool = False) -> None:
+    # Group inputs by (family, mode) so we can merge with existing per file.
+    inputs_by_pair: dict[tuple[str, str], dict[str, dict[str, Any]]] = {}
+    for (family, case_id), entry in INPUTS.items():
+        if entry is None:
+            continue
+        # case_id is e.g. "PARSER.batch.5" — split into mode and number.
+        _, mode, num = case_id.split(".", 2)
+        inputs_by_pair.setdefault((family, mode), {})[num] = entry
+
+    n_written = n_skipped = n_orphan_kept = 0
+    for (family, mode), entries in inputs_by_pair.items():
+        existing = _load_existing(family, mode)
+        merged: dict[str, dict[str, Any]] = {}
+
+        # 1. Process every case the user listed in INPUTS.
+        for num, entry in entries.items():
+            if num in existing and not overwrite_if_exists:
+                merged[num] = existing[num]
+                n_skipped += 1
+                continue
+            expected = await _run_one(family, entry["text"], entry["tools"])
+            merged[num] = {
+                "description": entry["description"],
+                "model_text": entry["text"],
+                "tools": entry["tools"],
+                "expected": expected,
+            }
+            n_written += 1
+
+        # 2. Preserve any on-disk cases that aren't in INPUTS today, so a
+        #    contributor's INPUTS edit can't accidentally delete other
+        #    contributors' fixture cases.
+        for num, case in existing.items():
+            if num not in merged:
+                merged[num] = case
+                n_orphan_kept += 1
+
+        _write_family_fixtures(family, mode, merged)
+        print(f"  wrote {family}/PARSER.{mode}.yaml with {len(merged)} cases")
+
+    print(
+        f"\n{n_written} written, {n_skipped} skipped (already on disk), "
+        f"{n_orphan_kept} preserved (on disk but not in INPUTS).\n"
+        f"Pass --overwrite-if-exists to refresh the {n_skipped} skipped case(s)."
+    )
+
+
+if __name__ == "__main__":
+    import argparse
+
+    p = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    p.add_argument(
+        "--overwrite-if-exists",
+        action="store_true",
+        help=(
+            "Re-run Dynamo for cases that already exist on disk and overwrite "
+            "the recorded `expected` output. Default: skip existing cases "
+            "(adds new ones only). Use this when intentionally refreshing a "
+            "fixture after a Dynamo parser-behavior change."
+        ),
+    )
+    args = p.parse_args()
+    asyncio.run(main(overwrite_if_exists=args.overwrite_if_exists))

--- a/tests/parity/parser/sglang.py
+++ b/tests/parity/parser/sglang.py
@@ -48,14 +48,12 @@ def parse(
     if detector_cls is None:
         return ParseResult(error=f"SGLang has no detector for family={parser_family!r}")
 
-    detector = detector_cls()
-
-    # SGLang's BaseFormatDetector exposes detect_and_parse(text, tools) where
-    # tools is the OpenAI Tool[] shape. Build that wrapper if our fixture
-    # passed flat-shape definitions.
-    sg_tools = _build_tools(tools)
-
     try:
+        detector = detector_cls()
+        # SGLang's BaseFormatDetector exposes detect_and_parse(text, tools) where
+        # tools is the OpenAI Tool[] shape. Build that wrapper if our fixture
+        # passed flat-shape definitions.
+        sg_tools = _build_tools(tools)
         info = detector.detect_and_parse(raw_text, sg_tools)
     except Exception as e:
         return ParseResult(error=f"{type(e).__name__}: {e}")

--- a/tests/parity/parser/sglang.py
+++ b/tests/parity/parser/sglang.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""parser-mode wrapper for SGLang's Python tool detectors (in-process import)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+# SGLang re-exports detectors through `function_call_parser`; we go through
+# that umbrella so the import is stable across per-module renames.
+from sglang.srt.function_call.function_call_parser import (  # type: ignore[import-untyped]
+    DeepSeekV31Detector,
+    Glm47MoeDetector,
+)
+from sglang.srt.function_call.gpt_oss_detector import (
+    GptOssDetector,  # type: ignore[import-untyped]
+)
+from sglang.srt.function_call.kimik2_detector import (
+    KimiK2Detector,  # type: ignore[import-untyped]
+)
+from sglang.srt.function_call.qwen3_coder_detector import (  # type: ignore[import-untyped]
+    Qwen3CoderDetector,
+)
+
+from tests.parity.common import ParseResult, decode_arguments
+
+# Maps parser_family → SGLang detector class. SGLang doesn't have a registry-by-name
+# like vLLM; the class is imported directly.
+_FAMILY_TO_SGLANG_DETECTOR = {
+    "kimi_k2": KimiK2Detector,
+    "qwen3_coder": Qwen3CoderDetector,
+    "glm47": Glm47MoeDetector,
+    "deepseek_v3_1": DeepSeekV31Detector,
+    "harmony": GptOssDetector,
+}
+
+# Families with no SGLang detector today: minimax_m2, nemotron_deci.
+
+
+def parse(
+    parser_family: str,
+    raw_text: str,
+    tools: list[dict[str, Any]] | None,
+) -> ParseResult:
+    detector_cls = _FAMILY_TO_SGLANG_DETECTOR.get(parser_family)
+    if detector_cls is None:
+        return ParseResult(error=f"SGLang has no detector for family={parser_family!r}")
+
+    detector = detector_cls()
+
+    # SGLang's BaseFormatDetector exposes detect_and_parse(text, tools) where
+    # tools is the OpenAI Tool[] shape. Build that wrapper if our fixture
+    # passed flat-shape definitions.
+    sg_tools = _build_tools(tools)
+
+    try:
+        info = detector.detect_and_parse(raw_text, sg_tools)
+    except Exception as e:
+        return ParseResult(error=f"{type(e).__name__}: {e}")
+
+    # SGLang returns StreamingParseResult with .calls; each item exposes
+    # arguments via either .parameters or .arguments depending on version.
+    calls = [
+        {
+            "name": tc.name,
+            "arguments": decode_arguments(
+                getattr(tc, "parameters", None) or tc.arguments
+            ),
+        }
+        for tc in info.calls or []
+    ]
+    return ParseResult(calls=calls, normal_text=info.normal_text)
+
+
+def _build_tools(tools: list[dict[str, Any]] | None) -> list[Any] | None:
+    """Wrap flat tool defs as duck-typed objects with `.function.name` /
+    `.function.parameters`. SGLang detectors access these via attribute,
+    not dict subscript, so plain dicts fail with AttributeError.
+    """
+    if not tools:
+        return None
+    return [
+        SimpleNamespace(
+            function=SimpleNamespace(
+                name=(t["function"] if "function" in t else t)["name"],
+                parameters=(t["function"] if "function" in t else t).get("parameters"),
+                strict=False,
+            )
+        )
+        for t in tools
+    ]

--- a/tests/parity/parser/sglang.py
+++ b/tests/parity/parser/sglang.py
@@ -20,6 +20,9 @@ from sglang.srt.function_call.gpt_oss_detector import (
 from sglang.srt.function_call.kimik2_detector import (
     KimiK2Detector,  # type: ignore[import-untyped]
 )
+from sglang.srt.function_call.minimax_m2 import (
+    MinimaxM2Detector,  # type: ignore[import-untyped]
+)
 from sglang.srt.function_call.qwen3_coder_detector import (  # type: ignore[import-untyped]
     Qwen3CoderDetector,
 )
@@ -34,9 +37,10 @@ _FAMILY_TO_SGLANG_DETECTOR = {
     "glm47": Glm47MoeDetector,
     "deepseek_v3_1": DeepSeekV31Detector,
     "harmony": GptOssDetector,
+    "minimax_m2": MinimaxM2Detector,
 }
 
-# Families with no SGLang detector today: minimax_m2, nemotron_deci.
+# Families with no SGLang detector today: nemotron_deci.
 
 
 def parse(

--- a/tests/parity/parser/sglang.py
+++ b/tests/parity/parser/sglang.py
@@ -46,7 +46,9 @@ def parse(
 ) -> ParseResult:
     detector_cls = _FAMILY_TO_SGLANG_DETECTOR.get(parser_family)
     if detector_cls is None:
-        return ParseResult(error=f"SGLang has no detector for family={parser_family!r}")
+        return ParseResult(
+            error=f"UNAVAILABLE: SGLang has no detector for family={parser_family!r}"
+        )
 
     try:
         detector = detector_cls()

--- a/tests/parity/parser/sglang.py
+++ b/tests/parity/parser/sglang.py
@@ -8,6 +8,10 @@ from __future__ import annotations
 from types import SimpleNamespace
 from typing import Any
 
+from sglang.srt.function_call.deepseekv3_detector import (
+    DeepSeekV3Detector,  # type: ignore[import-untyped]
+)
+
 # SGLang re-exports detectors through `function_call_parser`; we go through
 # that umbrella so the import is stable across per-module renames.
 from sglang.srt.function_call.function_call_parser import (  # type: ignore[import-untyped]
@@ -23,6 +27,9 @@ from sglang.srt.function_call.kimik2_detector import (
 from sglang.srt.function_call.minimax_m2 import (
     MinimaxM2Detector,  # type: ignore[import-untyped]
 )
+from sglang.srt.function_call.pythonic_detector import (
+    PythonicDetector,  # type: ignore[import-untyped]
+)
 from sglang.srt.function_call.qwen3_coder_detector import (  # type: ignore[import-untyped]
     Qwen3CoderDetector,
 )
@@ -36,11 +43,13 @@ _FAMILY_TO_SGLANG_DETECTOR = {
     "qwen3_coder": Qwen3CoderDetector,
     "glm47": Glm47MoeDetector,
     "deepseek_v3_1": DeepSeekV31Detector,
+    "deepseek_v3": DeepSeekV3Detector,
     "harmony": GptOssDetector,
     "minimax_m2": MinimaxM2Detector,
+    "pythonic": PythonicDetector,
 }
 
-# Families with no SGLang detector today: nemotron_deci.
+# Families with no SGLang detector today: nemotron_deci, gemma4.
 
 
 def parse(

--- a/tests/parity/parser/test_parity_parser.py
+++ b/tests/parity/parser/test_parity_parser.py
@@ -117,7 +117,6 @@ KNOWN_DIVERGENCES: dict[tuple[str, str, str], str] = {
         "PARSER.batch.8",
     ): "preserves trailing space; Dynamo trims it",
     # PARSER.batch.4 (malformed) — impl-defined recovery contract.
-    ("vllm", "qwen3_coder", "PARSER.batch.4"): _RECOVERY_CONTRACT,
     ("vllm", "deepseek_v3_1", "PARSER.batch.4"): _RECOVERY_CONTRACT,
     ("vllm", "minimax_m2", "PARSER.batch.4"): _RECOVERY_CONTRACT,
     ("sglang", "kimi_k2", "PARSER.batch.4"): _RECOVERY_CONTRACT,
@@ -152,10 +151,23 @@ def _load_fixtures() -> list[tuple[str, str, dict[str, Any]]]:
 FIXTURES = _load_fixtures()
 
 
-# Per-param impl markers so CI marker filters (`pre_merge and vllm and gpu_0`,
-# `pre_merge and sglang and gpu_0`) pick up the right subset in each container.
-# `dynamo` params get no impl marker — they only run when the harness is
-# explicitly selected, since Dynamo doesn't have a per-container CI job here.
+def _marks_for(family: str, case_id: str, impl: str) -> list:
+    """Per-param marks for a parametrized case. Includes the impl marker
+    (so CI marker filters `pre_merge and vllm and gpu_0` / `... sglang ...`
+    pick up the right subset per container; `dynamo` gets no impl marker).
+
+    Adds `pytest.mark.xfail(strict=True, reason=...)` for known divergences
+    so the assertion still runs — `XPASS` (strict) flags a fix the registry
+    hasn't been updated for, instead of silently masking the new pass."""
+    marks = []
+    if impl in ("vllm", "sglang"):
+        marks.append(getattr(pytest.mark, impl))
+    div = KNOWN_DIVERGENCES.get((impl, family, case_id))
+    if div is not None:
+        marks.append(pytest.mark.xfail(strict=True, reason=f"known divergence: {div}"))
+    return marks
+
+
 @pytest.mark.parametrize(
     "family,case_id,fixture,impl_name",
     [
@@ -164,7 +176,7 @@ FIXTURES = _load_fixtures()
             c,
             fx,
             impl,
-            marks=[getattr(pytest.mark, impl)] if impl in ("vllm", "sglang") else [],
+            marks=_marks_for(f, c, impl),
             id=f"{f}/{c}#{impl}",
         )
         for (f, c, fx) in FIXTURES
@@ -181,14 +193,15 @@ def test_parity(
     if impl_fn is None:
         pytest.skip(f"{impl_name} not installed in this container")
 
-    divergence = KNOWN_DIVERGENCES.get((impl_name, family, case_id))
-    if divergence is not None:
-        pytest.xfail(f"known divergence: {divergence}")
-
     got = impl_fn(family, fixture["model_text"], fixture.get("tools"))
 
+    # Distinguish "impl has no parser registered for this family" (env-shaped:
+    # skip) from "parser raised on input" (runtime: a regression we want to
+    # see). Wrappers prefix the env case with `UNAVAILABLE:`.
     if got.error:
-        pytest.skip(f"{impl_name} unavailable for {family}: {got.error}")
+        if got.error.startswith("UNAVAILABLE:"):
+            pytest.skip(f"{impl_name} unavailable for {family}: {got.error}")
+        pytest.fail(f"{impl_name} crashed on {family}/{case_id}: {got.error}")
 
     expected = common.ParseResult(
         calls=fixture["expected"]["calls"],

--- a/tests/parity/parser/test_parity_parser.py
+++ b/tests/parity/parser/test_parity_parser.py
@@ -124,13 +124,11 @@ KNOWN_DIVERGENCES: dict[tuple[str, str, str], str] = {
     # PyO3 batch binding now uses `detect_and_parse_tool_call_with_recovery`
     # so the registered `expected` reflects the recovered call; impls that
     # still drop on the missing end-token diverge here.
-    ("vllm", "qwen3_coder", "PARSER.batch.5"): _RECOVERY_CONTRACT,
+    # vllm/sglang qwen3_coder.batch.5 both recover to the same call as
+    # Dynamo and match the new expected — intentionally NOT registered.
     ("vllm", "glm47", "PARSER.batch.5"): _RECOVERY_CONTRACT,
     ("vllm", "minimax_m2", "PARSER.batch.5"): _RECOVERY_CONTRACT,
     ("vllm", "deepseek_v3_1", "PARSER.batch.5"): _RECOVERY_CONTRACT,
-    # sglang qwen3_coder.batch.5 recovers to the same call as Dynamo, so it
-    # matches the new expected and is intentionally NOT registered as a
-    # divergence (XPASS-strict was surfacing the stale entry; removed).
     ("sglang", "glm47", "PARSER.batch.5"): _RECOVERY_CONTRACT,
     ("sglang", "minimax_m2", "PARSER.batch.5"): _RECOVERY_CONTRACT,
     ("sglang", "deepseek_v3_1", "PARSER.batch.5"): _RECOVERY_CONTRACT,

--- a/tests/parity/parser/test_parity_parser.py
+++ b/tests/parity/parser/test_parity_parser.py
@@ -106,6 +106,46 @@ KNOWN_DIVERGENCES: dict[tuple[str, str, str], str] = {
         "PARSER.batch.8",
     ): "trims trailing space from preceding normal_text",
     (
+        "sglang",
+        "deepseek_v3",
+        "PARSER.batch.8",
+    ): "trims trailing space from preceding normal_text",
+    (
+        "sglang",
+        "pythonic",
+        "PARSER.batch.8",
+    ): _TRAILING_NORMAL_TEXT_DROP,
+    (
+        "sglang",
+        "deepseek_v3",
+        "PARSER.batch.5",
+    ): _RECOVERY_CONTRACT,
+    (
+        "vllm",
+        "deepseek_v3",
+        "PARSER.batch.4",
+    ): _RECOVERY_CONTRACT,
+    (
+        "vllm",
+        "deepseek_v3",
+        "PARSER.batch.5",
+    ): _RECOVERY_CONTRACT,
+    (
+        "vllm",
+        "gemma4",
+        "PARSER.batch.8",
+    ): _TRAILING_NORMAL_TEXT_DROP,
+    # vLLM's pythonic parser rejects the whole input when the bracket-call form
+    # is surrounded by interleaved text — calls=[], normal_text=raw input.
+    # Dynamo's pythonic parser extracts the call and surfaces the surrounding
+    # text in normal_text (matches the upstream Llama 4 / pythonic_detector
+    # behavior — vLLM is the outlier here).
+    (
+        "vllm",
+        "pythonic",
+        "PARSER.batch.8",
+    ): "vLLM rejects bracket-call form when surrounded by interleaved text; Dynamo extracts the call",
+    (
         "vllm",
         "minimax_m2",
         "PARSER.batch.8",

--- a/tests/parity/parser/test_parity_parser.py
+++ b/tests/parity/parser/test_parity_parser.py
@@ -73,7 +73,6 @@ KNOWN_DIVERGENCES: dict[tuple[str, str, str], str] = {
     ("vllm", "glm47", "PARSER.batch.8"): _TRAILING_NORMAL_TEXT_DROP,
     ("sglang", "kimi_k2", "PARSER.batch.8"): _TRAILING_NORMAL_TEXT_DROP,
     ("sglang", "qwen3_coder", "PARSER.batch.8"): _TRAILING_NORMAL_TEXT_DROP,
-    ("sglang", "glm47", "PARSER.batch.8"): _TRAILING_NORMAL_TEXT_DROP,
     # SGLang's GptOssDetector requires a strict '<|start|>assistant<|channel|>commentary'
     # bot_token; bare '<|channel|>commentary' variants (PARSER.batch.1, .6, .13)
     # are not detected at all.
@@ -120,7 +119,6 @@ KNOWN_DIVERGENCES: dict[tuple[str, str, str], str] = {
     ("vllm", "deepseek_v3_1", "PARSER.batch.4"): _RECOVERY_CONTRACT,
     ("vllm", "minimax_m2", "PARSER.batch.4"): _RECOVERY_CONTRACT,
     ("sglang", "kimi_k2", "PARSER.batch.4"): _RECOVERY_CONTRACT,
-    ("sglang", "qwen3_coder", "PARSER.batch.4"): _RECOVERY_CONTRACT,
     ("sglang", "harmony", "PARSER.batch.4"): _RECOVERY_CONTRACT,
     # PARSER.batch.5 (missing end-token recovery) — impl-defined.
     ("vllm", "qwen3_coder", "PARSER.batch.5"): _RECOVERY_CONTRACT,

--- a/tests/parity/parser/test_parity_parser.py
+++ b/tests/parity/parser/test_parity_parser.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import importlib
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
 import pytest
 import yaml
@@ -27,21 +27,16 @@ pytestmark = [pytest.mark.unit, pytest.mark.pre_merge, pytest.mark.gpu_0]
 FIXTURES_ROOT = Path(__file__).parent / "fixtures"
 
 
-def _maybe_import(impl_name: str) -> Callable | None:
-    """Import an impl wrapper lazily; return None if its dependency package
-    (vllm / sglang / dynamo._core) isn't installed in this container."""
-    try:
-        mod = importlib.import_module(f"tests.parity.parser.{impl_name}")
-        return mod.parse
-    except ImportError as e:
-        print(f"[parity] skipping impl {impl_name!r}: {e}")
-        return None
-
-
-IMPLS: dict[str, Callable | None] = {
-    "dynamo": _maybe_import("dynamo"),
-    "vllm": _maybe_import("vllm"),
-    "sglang": _maybe_import("sglang"),
+# Impl name → optional package whose absence is a legitimate skip. Anything
+# else that fails inside the wrapper module (e.g. a stale `from vllm.X import
+# Y` after vLLM renamed Y) is a real bug and must surface as a test ERROR,
+# not a green skip — so we use `pytest.importorskip` inline rather than a
+# blanket `try: import X except ImportError`.
+IMPL_NAMES: tuple[str, ...] = ("dynamo", "vllm", "sglang")
+_PACKAGE: dict[str, str] = {
+    "dynamo": "dynamo._core",
+    "vllm": "vllm",
+    "sglang": "sglang",
 }
 
 
@@ -115,6 +110,11 @@ KNOWN_DIVERGENCES: dict[tuple[str, str, str], str] = {
         "minimax_m2",
         "PARSER.batch.8",
     ): "preserves trailing space; Dynamo trims it",
+    (
+        "sglang",
+        "minimax_m2",
+        "PARSER.batch.8",
+    ): "preserves trailing space; Dynamo trims it",
     # PARSER.batch.4 (malformed) — impl-defined recovery contract.
     ("vllm", "deepseek_v3_1", "PARSER.batch.4"): _RECOVERY_CONTRACT,
     ("vllm", "minimax_m2", "PARSER.batch.4"): _RECOVERY_CONTRACT,
@@ -149,21 +149,18 @@ def _load_fixtures() -> list[tuple[str, str, dict[str, Any]]]:
 FIXTURES = _load_fixtures()
 
 
-def _marks_for(family: str, case_id: str, impl: str) -> list:
-    """Per-param marks for a parametrized case. Includes the impl marker
-    (so CI marker filters `pre_merge and vllm and gpu_0` / `... sglang ...`
-    pick up the right subset per container; `dynamo` gets no impl marker).
+def _marks_for(impl: str) -> list:
+    """Per-param marks. Only the impl marker (`vllm`/`sglang`) — used by CI
+    shards to filter via `-m vllm` / `-m sglang`. `dynamo` gets no marker so
+    it runs in every shard (it's the reference we compare against).
 
-    Adds `pytest.mark.xfail(strict=True, reason=...)` for known divergences
-    so the assertion still runs — `XPASS` (strict) flags a fix the registry
-    hasn't been updated for, instead of silently masking the new pass."""
-    marks = []
+    Known-divergence xfail handling is intentionally NOT a parametrize-time
+    mark — it lives inline in the test body (see `XPASS-strict` block) so a
+    parser/runtime crash on a known-divergence case still hits `pytest.fail`
+    hard instead of being swallowed by an outer `xfail` wrapper."""
     if impl in ("vllm", "sglang"):
-        marks.append(getattr(pytest.mark, impl))
-    div = KNOWN_DIVERGENCES.get((impl, family, case_id))
-    if div is not None:
-        marks.append(pytest.mark.xfail(strict=True, reason=f"known divergence: {div}"))
-    return marks
+        return [getattr(pytest.mark, impl)]
+    return []
 
 
 @pytest.mark.parametrize(
@@ -174,11 +171,11 @@ def _marks_for(family: str, case_id: str, impl: str) -> list:
             c,
             fx,
             impl,
-            marks=_marks_for(f, c, impl),
+            marks=_marks_for(impl),
             id=f"{f}/{c}#{impl}",
         )
         for (f, c, fx) in FIXTURES
-        for impl in IMPLS
+        for impl in IMPL_NAMES
     ],
 )
 def test_parity(
@@ -187,15 +184,18 @@ def test_parity(
     fixture: dict[str, Any],
     impl_name: str,
 ) -> None:
-    impl_fn = IMPLS[impl_name]
-    if impl_fn is None:
-        pytest.skip(f"{impl_name} not installed in this container")
+    # Skip ONLY when the optional package itself is missing — wrapper-internal
+    # ImportError (e.g. a stale upstream API ref after a vLLM/SGLang rename)
+    # propagates as a real test ERROR rather than a silent green skip.
+    pytest.importorskip(_PACKAGE[impl_name])
+    parse_mod = importlib.import_module(f"tests.parity.parser.{impl_name}")
+    got = parse_mod.parse(family, fixture["model_text"], fixture.get("tools"))
 
-    got = impl_fn(family, fixture["model_text"], fixture.get("tools"))
-
-    # Distinguish "impl has no parser registered for this family" (env-shaped:
-    # skip) from "parser raised on input" (runtime: a regression we want to
-    # see). Wrappers prefix the env case with `UNAVAILABLE:`.
+    # Runtime / parser errors fail HARD. Wrappers prefix the env-shaped case
+    # ("impl has no parser registered for this family") with `UNAVAILABLE:`
+    # so we can still skip those cleanly. This check runs *before* the
+    # known-divergence xfail block below, so a crash on a known-divergence
+    # case is not masked.
     if got.error:
         if got.error.startswith("UNAVAILABLE:"):
             pytest.skip(f"{impl_name} unavailable for {family}: {got.error}")
@@ -205,11 +205,26 @@ def test_parity(
         calls=fixture["expected"]["calls"],
         normal_text=fixture["expected"].get("normal_text"),
     )
+    got_canonical = common.canonical(got.to_dict())
+    expected_canonical = common.canonical(expected.to_dict())
 
-    assert common.canonical(got.to_dict()) == common.canonical(expected.to_dict()), (
+    # Known divergences: xfail the value-diff assertion only. If the values
+    # now match, surface that as a registry-staleness failure (XPASS-strict
+    # equivalent) instead of silently passing.
+    div = KNOWN_DIVERGENCES.get((impl_name, family, case_id))
+    if div is not None:
+        if got_canonical == expected_canonical:
+            pytest.fail(
+                f"XPASS-strict: known divergence ({impl_name},{family},{case_id}) "
+                f"now matches expected — remove from KNOWN_DIVERGENCES. "
+                f"Reason was: {div}"
+            )
+        pytest.xfail(f"known divergence: {div}")
+
+    assert got_canonical == expected_canonical, (
         f"\nimpl:     {impl_name}\n"
         f"family:   {family}\n"
         f"case:     {case_id}\n"
-        f"expected: {common.canonical(expected.to_dict())}\n"
-        f"got:      {common.canonical(got.to_dict())}\n"
+        f"expected: {expected_canonical}\n"
+        f"got:      {got_canonical}\n"
     )

--- a/tests/parity/parser/test_parity_parser.py
+++ b/tests/parity/parser/test_parity_parser.py
@@ -120,10 +120,19 @@ KNOWN_DIVERGENCES: dict[tuple[str, str, str], str] = {
     ("vllm", "minimax_m2", "PARSER.batch.4"): _RECOVERY_CONTRACT,
     ("sglang", "kimi_k2", "PARSER.batch.4"): _RECOVERY_CONTRACT,
     ("sglang", "harmony", "PARSER.batch.4"): _RECOVERY_CONTRACT,
-    # PARSER.batch.5 (missing end-token recovery) — impl-defined.
+    # PARSER.batch.5 (missing end-token recovery) — impl-defined. Dynamo's
+    # PyO3 batch binding now uses `detect_and_parse_tool_call_with_recovery`
+    # so the registered `expected` reflects the recovered call; impls that
+    # still drop on the missing end-token diverge here.
     ("vllm", "qwen3_coder", "PARSER.batch.5"): _RECOVERY_CONTRACT,
+    ("vllm", "glm47", "PARSER.batch.5"): _RECOVERY_CONTRACT,
+    ("vllm", "minimax_m2", "PARSER.batch.5"): _RECOVERY_CONTRACT,
     ("vllm", "deepseek_v3_1", "PARSER.batch.5"): _RECOVERY_CONTRACT,
-    ("sglang", "qwen3_coder", "PARSER.batch.5"): _RECOVERY_CONTRACT,
+    # sglang qwen3_coder.batch.5 recovers to the same call as Dynamo, so it
+    # matches the new expected and is intentionally NOT registered as a
+    # divergence (XPASS-strict was surfacing the stale entry; removed).
+    ("sglang", "glm47", "PARSER.batch.5"): _RECOVERY_CONTRACT,
+    ("sglang", "minimax_m2", "PARSER.batch.5"): _RECOVERY_CONTRACT,
     ("sglang", "deepseek_v3_1", "PARSER.batch.5"): _RECOVERY_CONTRACT,
     ("sglang", "harmony", "PARSER.batch.5"): _RECOVERY_CONTRACT,
 }

--- a/tests/parity/parser/test_parity_parser.py
+++ b/tests/parity/parser/test_parity_parser.py
@@ -1,0 +1,204 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Parser-mode parity tests — Method 2 of the cross-impl parity (parser) effort.
+
+For each fixture, run the same input through Dynamo's Rust parser (via PyO3)
+and the upstream Python parsers (vLLM + SGLang). Diff against the recorded
+expected output and against each other.
+
+Run:
+    pytest tests/parity/parser/test_parity_parser.py -v
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from typing import Any, Callable
+
+import pytest
+import yaml
+
+from tests.parity import common
+
+pytestmark = [pytest.mark.unit, pytest.mark.pre_merge, pytest.mark.gpu_0]
+
+FIXTURES_ROOT = Path(__file__).parent / "fixtures"
+
+
+def _maybe_import(impl_name: str) -> Callable | None:
+    """Import an impl wrapper lazily; return None if its dependency package
+    (vllm / sglang / dynamo._core) isn't installed in this container."""
+    try:
+        mod = importlib.import_module(f"tests.parity.parser.{impl_name}")
+        return mod.parse
+    except ImportError as e:
+        print(f"[parity] skipping impl {impl_name!r}: {e}")
+        return None
+
+
+IMPLS: dict[str, Callable | None] = {
+    "dynamo": _maybe_import("dynamo"),
+    "vllm": _maybe_import("vllm"),
+    "sglang": _maybe_import("sglang"),
+}
+
+
+# (impl, family, case_id) -> reason. Surfaced findings from running the harness;
+# each entry is a real behavioral divergence we've chosen to document rather
+# than fix. Promote to a tracked bug before removing.
+#
+# Pattern: vLLM and SGLang both truncate normal_text at the *end* of the
+# tool-call wrapper across all XML-style parsers (kimi_k2, qwen3_coder, glm47).
+# Only Dynamo preserves text that appears after the closing wrapper token.
+_TRAILING_NORMAL_TEXT_DROP = "drops trailing normal_text after tool-call wrapper end"
+_HARMONY_REQUIRES_ASSISTANT_PREFIX = (
+    "SGLang's GptOssDetector bot_token requires '<|start|>assistant<|channel|>commentary' "
+    "envelope; Dynamo accepts the bare '<|channel|>commentary' variant"
+)
+# PARSER.batch.4 (malformed JSON) and PARSER.batch.5 (missing end-token) are
+# impl-defined recovery contracts per PARSER_CASES.md. Each parser picks its
+# own behavior (drop, recover-best-effort, fall back to string args, surface
+# error). Cross-impl parity is not expected; we record divergences as a map
+# of "what each impl does" rather than asserting one truth.
+_RECOVERY_CONTRACT = "impl-defined recovery contract (see PARSER_CASES.md)"
+
+KNOWN_DIVERGENCES: dict[tuple[str, str, str], str] = {
+    # vLLM and SGLang both truncate normal_text at the *end* of the tool-call
+    # wrapper across all XML-style parsers. Only Dynamo preserves text after
+    # the closing wrapper token.
+    ("vllm", "kimi_k2", "PARSER.batch.8"): _TRAILING_NORMAL_TEXT_DROP,
+    ("vllm", "qwen3_coder", "PARSER.batch.8"): _TRAILING_NORMAL_TEXT_DROP,
+    ("vllm", "glm47", "PARSER.batch.8"): _TRAILING_NORMAL_TEXT_DROP,
+    ("sglang", "kimi_k2", "PARSER.batch.8"): _TRAILING_NORMAL_TEXT_DROP,
+    ("sglang", "qwen3_coder", "PARSER.batch.8"): _TRAILING_NORMAL_TEXT_DROP,
+    ("sglang", "glm47", "PARSER.batch.8"): _TRAILING_NORMAL_TEXT_DROP,
+    # SGLang's GptOssDetector requires a strict '<|start|>assistant<|channel|>commentary'
+    # bot_token; bare '<|channel|>commentary' variants (PARSER.batch.1, .6, .13)
+    # are not detected at all.
+    ("sglang", "harmony", "PARSER.batch.1"): _HARMONY_REQUIRES_ASSISTANT_PREFIX,
+    ("sglang", "harmony", "PARSER.batch.6"): _HARMONY_REQUIRES_ASSISTANT_PREFIX,
+    ("sglang", "harmony", "PARSER.batch.8"): _HARMONY_REQUIRES_ASSISTANT_PREFIX,
+    # SGLang's GptOssDetector drops the analysis-channel preamble entirely;
+    # Dynamo surfaces it as normal_text.
+    (
+        "sglang",
+        "harmony",
+        "PARSER.batch.7",
+    ): "drops analysis-channel content from normal_text",
+    # Inverse of the bare-envelope finding: when the input *does* have the
+    # assistant prefix and contains back-to-back commentary blocks, SGLang
+    # extracts both calls — Dynamo's harmony parser drops them and treats the
+    # raw input as normal_text. Dynamo bug class; see harmony_parser.rs comment
+    # block above test_parse_harmony_multiple_calls_recovers.
+    (
+        "sglang",
+        "harmony",
+        "PARSER.batch.2",
+    ): "Dynamo drops back-to-back commentary blocks; SGLang extracts them",
+    (
+        "sglang",
+        "harmony",
+        "PARSER.batch.10",
+    ): "Dynamo drops back-to-back commentary blocks; SGLang extracts them",
+    # Whitespace handling on text immediately preceding the bot_token:
+    # - SGLang on deepseek_v3_1: trims one trailing space; Dynamo keeps it
+    # - vLLM on minimax_m2: keeps trailing space; Dynamo trims it (opposite
+    #   direction from deepseek)
+    (
+        "sglang",
+        "deepseek_v3_1",
+        "PARSER.batch.8",
+    ): "trims trailing space from preceding normal_text",
+    (
+        "vllm",
+        "minimax_m2",
+        "PARSER.batch.8",
+    ): "preserves trailing space; Dynamo trims it",
+    # PARSER.batch.4 (malformed) — impl-defined recovery contract.
+    ("vllm", "qwen3_coder", "PARSER.batch.4"): _RECOVERY_CONTRACT,
+    ("vllm", "deepseek_v3_1", "PARSER.batch.4"): _RECOVERY_CONTRACT,
+    ("vllm", "minimax_m2", "PARSER.batch.4"): _RECOVERY_CONTRACT,
+    ("sglang", "kimi_k2", "PARSER.batch.4"): _RECOVERY_CONTRACT,
+    ("sglang", "qwen3_coder", "PARSER.batch.4"): _RECOVERY_CONTRACT,
+    ("sglang", "harmony", "PARSER.batch.4"): _RECOVERY_CONTRACT,
+    # PARSER.batch.5 (missing end-token recovery) — impl-defined.
+    ("vllm", "qwen3_coder", "PARSER.batch.5"): _RECOVERY_CONTRACT,
+    ("vllm", "deepseek_v3_1", "PARSER.batch.5"): _RECOVERY_CONTRACT,
+    ("sglang", "qwen3_coder", "PARSER.batch.5"): _RECOVERY_CONTRACT,
+    ("sglang", "deepseek_v3_1", "PARSER.batch.5"): _RECOVERY_CONTRACT,
+    ("sglang", "harmony", "PARSER.batch.5"): _RECOVERY_CONTRACT,
+}
+
+
+def _load_fixtures() -> list[tuple[str, str, dict[str, Any]]]:
+    """Yields (family, case_id, case_dict) for every case across all families.
+
+    Schema: <family>/PARSER.<mode>.yaml holds
+        {family: "...", mode: "batch", cases: {PARSER.batch.1: {...}, ...}}
+    Case keys are the full PARSER_CASES.md ID (e.g. `PARSER.batch.1`)
+    so they match KNOWN_DIVERGENCES keys and parametrize IDs directly.
+    """
+    out = []
+    for fp in sorted(FIXTURES_ROOT.glob("*/PARSER.*.yaml")):
+        doc = yaml.safe_load(fp.read_text())
+        for case_id, case in doc["cases"].items():
+            out.append((doc["family"], case_id, case))
+    out.sort(key=lambda t: (t[0], int(t[1].rsplit(".", 1)[1])))
+    return out
+
+
+FIXTURES = _load_fixtures()
+
+
+# Per-param impl markers so CI marker filters (`pre_merge and vllm and gpu_0`,
+# `pre_merge and sglang and gpu_0`) pick up the right subset in each container.
+# `dynamo` params get no impl marker — they only run when the harness is
+# explicitly selected, since Dynamo doesn't have a per-container CI job here.
+@pytest.mark.parametrize(
+    "family,case_id,fixture,impl_name",
+    [
+        pytest.param(
+            f,
+            c,
+            fx,
+            impl,
+            marks=[getattr(pytest.mark, impl)] if impl in ("vllm", "sglang") else [],
+            id=f"{f}/{c}#{impl}",
+        )
+        for (f, c, fx) in FIXTURES
+        for impl in IMPLS
+    ],
+)
+def test_parity(
+    family: str,
+    case_id: str,
+    fixture: dict[str, Any],
+    impl_name: str,
+) -> None:
+    impl_fn = IMPLS[impl_name]
+    if impl_fn is None:
+        pytest.skip(f"{impl_name} not installed in this container")
+
+    divergence = KNOWN_DIVERGENCES.get((impl_name, family, case_id))
+    if divergence is not None:
+        pytest.xfail(f"known divergence: {divergence}")
+
+    got = impl_fn(family, fixture["model_text"], fixture.get("tools"))
+
+    if got.error:
+        pytest.skip(f"{impl_name} unavailable for {family}: {got.error}")
+
+    expected = common.ParseResult(
+        calls=fixture["expected"]["calls"],
+        normal_text=fixture["expected"].get("normal_text"),
+    )
+
+    assert common.canonical(got.to_dict()) == common.canonical(expected.to_dict()), (
+        f"\nimpl:     {impl_name}\n"
+        f"family:   {family}\n"
+        f"case:     {case_id}\n"
+        f"expected: {common.canonical(expected.to_dict())}\n"
+        f"got:      {common.canonical(got.to_dict())}\n"
+    )

--- a/tests/parity/parser/vllm.py
+++ b/tests/parity/parser/vllm.py
@@ -75,7 +75,9 @@ def parse(
 ) -> ParseResult:
     key = _FAMILY_TO_VLLM_KEY.get(parser_family)
     if key is None:
-        return ParseResult(error=f"vLLM has no parser for family={parser_family!r}")
+        return ParseResult(
+            error=f"UNAVAILABLE: vLLM has no parser for family={parser_family!r}"
+        )
 
     try:
         parser_cls = ToolParserManager.get_tool_parser(key)
@@ -87,6 +89,11 @@ def parse(
         # We construct a minimal request shape with only the tools field, since most parsers ignore the rest.
         request = _build_chat_request(tools)
         info = parser.extract_tool_calls(raw_text, request)
+    except NotImplementedError as e:
+        # Known unsupported combinations (e.g., vLLM's harmony parser requires
+        # token IDs, not text). Treat as env-unavailable so the harness skips
+        # rather than failing as a regression.
+        return ParseResult(error=f"UNAVAILABLE: {type(e).__name__}: {e}")
     except Exception as e:
         return ParseResult(error=f"{type(e).__name__}: {e}")
 

--- a/tests/parity/parser/vllm.py
+++ b/tests/parity/parser/vllm.py
@@ -79,15 +79,25 @@ def parse(
             error=f"UNAVAILABLE: vLLM has no parser for family={parser_family!r}"
         )
 
+    # Wrap flat tool defs to the OpenAI `{"type":"function","function":{...}}`
+    # shape vLLM expects, then pass through to BOTH the constructor and the
+    # request. Some parsers (e.g. hermes-style schema-aware ones) coerce or
+    # cache the schemas at __init__ from the `tools=` kwarg; passing only
+    # `request.tools` skips that path.
+    wrapped_tools = (
+        [t if "function" in t else {"type": "function", "function": t} for t in tools]
+        if tools
+        else None
+    )
     try:
         parser_cls = ToolParserManager.get_tool_parser(key)
         # vLLM's ToolParser constructor checks `if not self.model_tokenizer:` and raises
         # if falsy. None of the parsers we test actually call tokenizer methods inside
         # extract_tool_calls(), so a truthy stub satisfies the check.
-        parser: ToolParser = parser_cls(tokenizer=_StubTokenizer())
+        parser: ToolParser = parser_cls(tokenizer=_StubTokenizer(), tools=wrapped_tools)
         # vLLM's extract_tool_calls signature: (model_output, request) → ExtractedToolCallInformation.
         # We construct a minimal request shape with only the tools field, since most parsers ignore the rest.
-        request = _build_chat_request(tools)
+        request = SimpleNamespace(tools=wrapped_tools)
         info = parser.extract_tool_calls(raw_text, request)
     except NotImplementedError as e:
         # Known unsupported combinations (e.g., vLLM's harmony parser requires
@@ -102,13 +112,3 @@ def parse(
         for tc in info.tool_calls or []
     ]
     return ParseResult(calls=calls, normal_text=info.content)
-
-
-def _build_chat_request(tools: list[dict[str, Any]] | None) -> Any:
-    """Minimal duck-typed request shape — vLLM's parsers only read `.tools`."""
-    if not tools:
-        return SimpleNamespace(tools=None)
-    wrapped = [
-        t if "function" in t else {"type": "function", "function": t} for t in tools
-    ]
-    return SimpleNamespace(tools=wrapped)

--- a/tests/parity/parser/vllm.py
+++ b/tests/parity/parser/vllm.py
@@ -77,18 +77,15 @@ def parse(
     if key is None:
         return ParseResult(error=f"vLLM has no parser for family={parser_family!r}")
 
-    parser_cls = ToolParserManager.get_tool_parser(key)
-
-    # vLLM's ToolParser constructor checks `if not self.model_tokenizer:` and raises
-    # if falsy. None of the parsers we test actually call tokenizer methods inside
-    # extract_tool_calls(), so a truthy stub satisfies the check.
-    parser: ToolParser = parser_cls(tokenizer=_StubTokenizer())
-
-    # vLLM's extract_tool_calls signature: (model_output, request) → ExtractedToolCallInformation.
-    # We construct a minimal request shape with only the tools field, since most parsers ignore the rest.
-    request = _build_chat_request(tools)
-
     try:
+        parser_cls = ToolParserManager.get_tool_parser(key)
+        # vLLM's ToolParser constructor checks `if not self.model_tokenizer:` and raises
+        # if falsy. None of the parsers we test actually call tokenizer methods inside
+        # extract_tool_calls(), so a truthy stub satisfies the check.
+        parser: ToolParser = parser_cls(tokenizer=_StubTokenizer())
+        # vLLM's extract_tool_calls signature: (model_output, request) → ExtractedToolCallInformation.
+        # We construct a minimal request shape with only the tools field, since most parsers ignore the rest.
+        request = _build_chat_request(tools)
         info = parser.extract_tool_calls(raw_text, request)
     except Exception as e:
         return ParseResult(error=f"{type(e).__name__}: {e}")

--- a/tests/parity/parser/vllm.py
+++ b/tests/parity/parser/vllm.py
@@ -64,7 +64,10 @@ _FAMILY_TO_VLLM_KEY = {
     "minimax_m2": "minimax_m2",
     "glm47": "glm47",
     "deepseek_v3_1": "deepseek_v31",
+    "deepseek_v3": "deepseek_v3",
     "harmony": "openai",  # gpt-oss / harmony parser registered as "openai"
+    "pythonic": "pythonic",
+    "gemma4": "gemma4",
 }
 
 

--- a/tests/parity/parser/vllm.py
+++ b/tests/parity/parser/vllm.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""parser-mode wrapper for vLLM's Python tool parsers (in-process import)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+# vLLM's tool-parser module path settled on `vllm.tool_parsers.*` in v0.6.x;
+# the older `vllm.entrypoints.openai.tool_parsers.*` location was retained as
+# an alias for a few releases. Try the new location first.
+try:
+    from vllm.tool_parsers import (  # type: ignore[import-untyped]
+        ToolParser,
+        ToolParserManager,
+    )
+except ImportError:
+    from vllm.entrypoints.openai.tool_parsers import (  # type: ignore[import-untyped]
+        ToolParser,
+        ToolParserManager,
+    )
+
+from tests.parity.common import ParseResult, decode_arguments
+
+
+class _OmnivorousVocab(dict):
+    """Returns a non-None synthetic ID for any token lookup.
+
+    Several vLLM parsers (qwen3_coder, glm47_moe, minimax_m2, deepseekv31,
+    etc.) call `self.vocab.get(token_string)` at __init__ and refuse to
+    construct if the result is `None`. Real tokenizers return real IDs,
+    but `extract_tool_calls()` (text mode) only uses the IDs to compare
+    against `delta_token_ids`, which we never pass — so any non-None int
+    works.
+    """
+
+    def get(self, key, default=None):  # type: ignore[override]
+        return 1
+
+
+_STUB_VOCAB = _OmnivorousVocab()
+
+
+class _StubTokenizer:
+    """Truthy placeholder for vLLM parsers that do text-based extraction.
+
+    Most vLLM `extract_tool_calls()` implementations don't actually need a
+    tokenizer, but the parser __init__s look up special-token IDs via
+    `self.vocab.get(...)`. We return synthetic non-None IDs to satisfy
+    those checks; the IDs aren't used during text extraction.
+    """
+
+    def get_vocab(self) -> dict[str, int]:
+        return _STUB_VOCAB
+
+
+# Maps parser_family → vLLM's registered parser key (registered via
+# @ToolParserManager.register_module(<key>)).
+_FAMILY_TO_VLLM_KEY = {
+    "kimi_k2": "kimi_k2",
+    "qwen3_coder": "qwen3_coder",
+    "minimax_m2": "minimax_m2",
+    "glm47": "glm47",
+    "deepseek_v3_1": "deepseek_v31",
+    "harmony": "openai",  # gpt-oss / harmony parser registered as "openai"
+}
+
+
+def parse(
+    parser_family: str,
+    raw_text: str,
+    tools: list[dict[str, Any]] | None,
+) -> ParseResult:
+    key = _FAMILY_TO_VLLM_KEY.get(parser_family)
+    if key is None:
+        return ParseResult(error=f"vLLM has no parser for family={parser_family!r}")
+
+    parser_cls = ToolParserManager.get_tool_parser(key)
+
+    # vLLM's ToolParser constructor checks `if not self.model_tokenizer:` and raises
+    # if falsy. None of the parsers we test actually call tokenizer methods inside
+    # extract_tool_calls(), so a truthy stub satisfies the check.
+    parser: ToolParser = parser_cls(tokenizer=_StubTokenizer())
+
+    # vLLM's extract_tool_calls signature: (model_output, request) → ExtractedToolCallInformation.
+    # We construct a minimal request shape with only the tools field, since most parsers ignore the rest.
+    request = _build_chat_request(tools)
+
+    try:
+        info = parser.extract_tool_calls(raw_text, request)
+    except Exception as e:
+        return ParseResult(error=f"{type(e).__name__}: {e}")
+
+    calls = [
+        {"name": tc.function.name, "arguments": decode_arguments(tc.function.arguments)}
+        for tc in info.tool_calls or []
+    ]
+    return ParseResult(calls=calls, normal_text=info.content)
+
+
+def _build_chat_request(tools: list[dict[str, Any]] | None) -> Any:
+    """Minimal duck-typed request shape — vLLM's parsers only read `.tools`."""
+    if not tools:
+        return SimpleNamespace(tools=None)
+    wrapped = [
+        t if "function" in t else {"type": "function", "function": t} for t in tools
+    ]
+    return SimpleNamespace(tools=wrapped)


### PR DESCRIPTION
#### Overview:

Method 2 of [DIS-1906](https://linear.app/nvidia/issue/DIS-1906): drive Dynamo, vLLM, and SGLang parsers from the same fixtures and diff their outputs to catch cross-impl divergences.

Sibling PR #9189 ships Method 3 (same fixtures, real `vllm serve` / `sglang.launch_server` over HTTP).

Size: +2579 / -2 lines. Roughly **~1050 YAML fixtures (auto-generated) / ~1200 code / ~340 docs**.

#### What this PR produces:

- **A runnable parity harness.** `pytest tests/parity/parser/` drives Dynamo, vLLM, and SGLang parsers against the same 70 YAML fixtures and diffs their outputs against each other.
- **25 concrete cross-impl divergences**, recorded as `xfail` (not silenced) in `KNOWN_DIVERGENCES` — ready for upstream bug reports or follow-up Dynamo fixes.
- **A new PyO3 entry point** `dynamo._core.parse_tool_call(parser_name, message, tools_json)` so Dynamo's Rust parser can be driven from Python.
- **CI coverage** in two existing containers via marker filters (`pre_merge and vllm and gpu_0`, `pre_merge and sglang and gpu_0`).
- **A regenerator** (`python3 -m tests.parity.parser.regenerate_fixtures`) for refreshing fixtures after an intentional Dynamo behavior change. Non-destructive by default; `--overwrite-if-exists` to refresh.

#### Details:

- New PyO3 binding `dynamo._core.parse_tool_call` so Dynamo's Rust parser can be driven from Python alongside vLLM and SGLang
- New harness at `tests/parity/parser/` with thin per-impl wrappers; lazy imports skip cleanly in single-framework containers
- 70 YAML fixtures covering `PARSER.batch.{1..10}` × 7 families (kimi_k2, qwen3_coder, glm47, deepseek_v3_1, harmony, minimax_m2, nemotron_deci)
- Case keys are full PARSER_CASES.md IDs (`PARSER.batch.1` … `PARSER.batch.10`); pytest test IDs use `family/case#impl` so one grep finds a case across docs / fixtures / `KNOWN_DIVERGENCES` / pytest IDs / Rust source comments
- Test pass: 111 / 90 skipped / 9 xfailed in vLLM container; 34 / 160 skipped / 16 xfailed in SGLang

#### Future direction:

Eventual goal is **YAML fixtures as the single source of truth** — same files consumed by Python (this PR + M3) and a future Rust harness, replacing the ~70 black-box Rust unit tests under `lib/parsers/src/tool_calling/*` that currently overlap with these fixtures by scenario. See `tests/parity/README.md` "Eventual goal" section.

Note on scope: an audit done while preparing this PR showed that the Rust tests cover the same scenario *types* but with many input variations the YAML doesn't yet contain (kimi_k2 has 22 Rust tests for 10 YAML cases; only ~12 are byte-equivalent). A clean migration is per-test, not bulk-delete — left for the follow-up that introduces the Rust harness.

#### Where should the reviewer start?

`tests/parity/README.md`, then `tests/parity/parser/test_parity_parser.py`

#### Related Issues:

[DIS-1906](https://linear.app/nvidia/issue/DIS-1906)

/coderabbit profile chill