### PR TITLE
design: Method 3 e2e parity harness (discussion)

### DIFF
--- a/tests/parser_parity/impls/e2e/__init__.py
+++ b/tests/parser_parity/impls/e2e/__init__.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""End-to-end parity wrappers — Method 3 of DIS-1906 (NOT YET IMPLEMENTED).
+
+Method 2 lives in `tests/parser_parity/impls/parser/`: in-process Python
+imports of vLLM's `ToolParser` classes and SGLang's per-module detectors,
+exercising parser logic only.
+
+Method 3 lives here: HTTP wrappers around real `vllm serve` and
+`python -m sglang.launch_server` processes. Same fixtures, different
+invocation surface — the request goes through each server's full stack
+(chat-template materialization, tokenizer round-trip, request shaping,
+streaming chunk boundaries, response assembly).
+
+What Method 3 catches that Method 2 doesn't
+-------------------------------------------
+- Tokenizer round-trip bugs: model emits tokens X, detokenizer recovers
+  Y, parser sees Y. Method 2 skips both halves.
+- Chat-template materialization: assistant-turn injection, tool-message
+  handling, system-prompt merging.
+- Streaming chunk-boundary edge cases at the SSE layer: partial-token
+  deltas, finish_reason timing, choice-index handling.
+- Request preprocessing: `tool_choice="none"` actually stripping tools
+  from the prompt; guided-decoding setup propagating correctly.
+- HTTP-shape divergences: vLLM's vs SGLang's `tool_calls[i].id` format,
+  function-arg JSON encoding, `index` field semantics.
+
+Component checklist
+-------------------
+1. Server boot: subprocess wrapper for `vllm serve` /
+   `python -m sglang.launch_server` with `--load-format dummy --device
+   cpu --enforce-eager`. CPU-only, no model weights, random init.
+   Health-check + ready-wait. Pytest session-scoped fixture so we boot
+   once per session, not per test. Cleanup on teardown (kill subprocess,
+   reap zombies, free ports).
+
+2. Forcing exact output via constrained decoding: each fixture's
+   `model_text` becomes a `guided_regex` (escape special chars, anchor
+   with `^...$`). vLLM and SGLang ship different regex engines (outlines
+   vs xgrammar) with different escape rules; some fixtures may need
+   per-engine variants. Verify tokenizer round-trip recovers the exact
+   fixture text byte-for-byte. Special tokens (`<|tool_calls_section_begin|>`
+   etc.) must be in the dummy tokenizer's vocab — fall back to splitting
+   the regex around them when not.
+
+3. HTTP client + chat shape: build request bodies with `messages` +
+   `tools` from the fixture. POST to `/v1/chat/completions` (and
+   `/v1/completions` as fallback when the chat template fights
+   constrained decoding). Parse response: `choices[0].message.tool_calls`
+   for non-streaming, accumulated SSE deltas for streaming.
+
+4. Wrapper integration: `e2e/vllm.py` and `e2e/sglang.py` expose the
+   same `parse(family, model_text, tools) -> ParseResult` interface as
+   `impls/parser/`. Same fixtures, same KNOWN_DIVERGENCES registry —
+   though entries may need an extra dimension (`mode = "method2"
+   | "method3"`) since divergences can differ by axis.
+
+5. Container + CI strategy: vLLM and SGLang run in separate containers
+   today. Either (a) run the test orchestrator in a third container that
+   talks to both via Docker network, or (b) gate Method 3 to whichever
+   container's server is local. Long startup (~30s/server) means
+   session-scoped boot. CI cost: ~1-2 min boot + per-test HTTP latency.
+
+6. Streaming variant (separate sub-track): same servers, SSE responses,
+   `parse_streaming_increment` semantics. Cross-impl streaming-chunk
+   boundary divergences are likely abundant — Method 2 can't reach them.
+
+Estimated effort
+----------------
+2-3 weeks for non-streaming Method 3 across vLLM and SGLang. Stack:
+
+    PR-A   _serve.py session fixture (vLLM only)
+    PR-B   vllm e2e wrapper + first 3-5 fixtures green
+    PR-C   sglang variant
+    PR-D   full coverage parity with Method 2
+    PR-E   streaming variant (parallel track)
+"""


### PR DESCRIPTION
**Draft / discussion only — no runtime code yet.**

#### Overview:

Scaffold for Method 3 of [DIS-1906](https://linear.app/nvidia/issue/DIS-1906) — end-to-end parity testing against real `vllm serve` and `python -m sglang.launch_server` HTTP servers. The actual implementation is staged as a follow-up PR stack; this branch is the place to discuss scope and approach.

Stacks on #9186 (Method 2 — in-process parser-class parity), which establishes the fixture format and `KNOWN_DIVERGENCES` registry that Method 3 will reuse.

#### Details:

- Add empty package `tests/parser_parity/impls/e2e/__init__.py` with the design captured as the package docstring
- No runtime code in this PR — the package import is a placeholder so pytest discovers nothing here yet
- The docstring covers:
  - Scope: what Method 3 catches that Method 2 does not (tokenizer round-trip, chat-template materialization, SSE streaming chunk boundaries, HTTP-shape divergences)
  - Component checklist: server boot, constrained decoding via `guided_regex`, HTTP client, wrapper integration, container strategy, streaming sub-track
  - Rough effort estimate and a 5-PR landing plan

#### Where should the reviewer start?

`tests/parser_parity/impls/e2e/__init__.py`

#### Open questions for discussion:

1. **Server boot**: do we boot `vllm serve` and `python -m sglang.launch_server` from inside the existing per-framework devcontainers (one server per container, only vLLM tests run in the vLLM container, etc.), or stand up a separate orchestrator container that talks to both via Docker network?
2. **Constrained decoding**: vLLM uses outlines; SGLang uses xgrammar. Some fixtures may need per-engine `guided_regex` variants. Acceptable, or do we want a shared regex layer?
3. **`--load-format dummy`**: random-init weights + constrained decoding lets us skip a real model. Do we trust this enough for the kind of bugs Method 3 is meant to find, or do we need a tiny real model (e.g., a 100M-param sentinel) to validate tokenizer behavior?
4. **Streaming as separate PR or bundled?** The streaming sub-track can run independently; bundling delays Method 3 a few extra days but produces one cohesive review.

#### Related Issues:

[DIS-1906](https://linear.app/nvidia/issue/DIS-1906)

/coderabbit profile chill