### PR TITLE
fix(mocker): exclude report bookkeeping from replay wall time

### DIFF
--- a/lib/mocker/src/replay/entrypoints.rs
+++ b/lib/mocker/src/replay/entrypoints.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::path::Path;
-use std::time::Instant;
 
 use anyhow::{Result, bail};
 use dynamo_kv_router::config::KvRouterConfig;
@@ -137,7 +136,6 @@ pub fn simulate_trace_file_with_router_mode_and_format(
     )?
     .normalize_session_starts()?
     .speed_up_timing(arrival_speedup_ratio)?;
-    let started_at = Instant::now();
     let report = if let Some(requests) = single_turn_mooncake_requests(trace_format, &trace)? {
         crate::replay::offline::simulate_trace(
             args,
@@ -158,7 +156,7 @@ pub fn simulate_trace_file_with_router_mode_and_format(
             router_mode,
         )?
     };
-    Ok(report.with_wall_time_ms(started_at.elapsed().as_secs_f64() * 1000.0))
+    Ok(report)
 }
 
 pub fn simulate_trace_file_disagg_with_router_mode(
@@ -213,7 +211,6 @@ pub fn simulate_trace_file_disagg_with_router_mode_and_format(
     )?
     .normalize_session_starts()?
     .speed_up_timing(arrival_speedup_ratio)?;
-    let started_at = Instant::now();
     let report = if let Some(requests) = single_turn_mooncake_requests(trace_format, &trace)? {
         crate::replay::offline::simulate_trace_disagg(
             config,
@@ -232,7 +229,7 @@ pub fn simulate_trace_file_disagg_with_router_mode_and_format(
             router_mode,
         )?
     };
-    Ok(report.with_wall_time_ms(started_at.elapsed().as_secs_f64() * 1000.0))
+    Ok(report)
 }
 
 pub fn simulate_trace_live_file(
@@ -364,7 +361,6 @@ pub fn simulate_trace_requests_with_router_mode(
         bail!("trace replay requires at least one request");
     }
 
-    let started_at = Instant::now();
     let report = crate::replay::offline::simulate_trace(
         args,
         router_config,
@@ -374,7 +370,7 @@ pub fn simulate_trace_requests_with_router_mode(
         arrival_speedup_ratio,
         router_mode,
     )?;
-    Ok(report.with_wall_time_ms(started_at.elapsed().as_secs_f64() * 1000.0))
+    Ok(report)
 }
 
 pub fn simulate_trace_requests_disagg_with_router_mode(
@@ -391,7 +387,6 @@ pub fn simulate_trace_requests_disagg_with_router_mode(
         bail!("trace replay requires at least one request");
     }
 
-    let started_at = Instant::now();
     let report = crate::replay::offline::simulate_trace_disagg(
         config,
         router_config,
@@ -400,7 +395,7 @@ pub fn simulate_trace_requests_disagg_with_router_mode(
         arrival_speedup_ratio,
         router_mode,
     )?;
-    Ok(report.with_wall_time_ms(started_at.elapsed().as_secs_f64() * 1000.0))
+    Ok(report)
 }
 
 pub fn simulate_trace_live_requests(
@@ -514,7 +509,6 @@ pub fn simulate_concurrency_file_with_router_mode_and_format(
         trace_shared_prefix_ratio,
         trace_num_prefix_groups,
     )?;
-    let started_at = Instant::now();
     let report = simulate_concurrency_workload_with_router_mode(
         args,
         router_config,
@@ -524,7 +518,7 @@ pub fn simulate_concurrency_file_with_router_mode_and_format(
         num_workers,
         router_mode,
     )?;
-    Ok(report.with_wall_time_ms(started_at.elapsed().as_secs_f64() * 1000.0))
+    Ok(report)
 }
 
 pub fn simulate_concurrency_file_disagg_with_router_mode(
@@ -572,7 +566,6 @@ pub fn simulate_concurrency_file_disagg_with_router_mode_and_format(
         trace_shared_prefix_ratio,
         trace_num_prefix_groups,
     )?;
-    let started_at = Instant::now();
     let report = simulate_concurrency_workload_disagg_with_router_mode(
         config,
         router_config,
@@ -581,7 +574,7 @@ pub fn simulate_concurrency_file_disagg_with_router_mode_and_format(
         max_in_flight,
         router_mode,
     )?;
-    Ok(report.with_wall_time_ms(started_at.elapsed().as_secs_f64() * 1000.0))
+    Ok(report)
 }
 
 pub fn simulate_concurrency_live_file(
@@ -798,7 +791,6 @@ pub fn simulate_trace_workload_with_router_mode(
 ) -> Result<TraceSimulationReport> {
     let args = args.normalized()?;
     validate_offline_replay_args(&args, num_workers, router_mode)?;
-    let started_at = Instant::now();
     let report = crate::replay::offline::simulate_trace_workload(
         args,
         router_config,
@@ -807,7 +799,7 @@ pub fn simulate_trace_workload_with_router_mode(
         num_workers,
         router_mode,
     )?;
-    Ok(report.with_wall_time_ms(started_at.elapsed().as_secs_f64() * 1000.0))
+    Ok(report)
 }
 
 pub fn simulate_trace_workload_disagg_with_router_mode(
@@ -819,7 +811,6 @@ pub fn simulate_trace_workload_disagg_with_router_mode(
 ) -> Result<TraceSimulationReport> {
     let config = config.normalized()?;
     validate_offline_disagg_replay_args(&config, router_mode)?;
-    let started_at = Instant::now();
     let report = crate::replay::offline::simulate_trace_workload_disagg(
         config,
         router_config,
@@ -827,7 +818,7 @@ pub fn simulate_trace_workload_disagg_with_router_mode(
         trace,
         router_mode,
     )?;
-    Ok(report.with_wall_time_ms(started_at.elapsed().as_secs_f64() * 1000.0))
+    Ok(report)
 }
 
 pub fn simulate_trace_live_workload(

--- a/lib/mocker/src/replay/offline/entrypoints.rs
+++ b/lib/mocker/src/replay/offline/entrypoints.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::VecDeque;
+use std::time::Instant;
 
 use anyhow::Result;
 use dynamo_kv_router::config::KvRouterConfig;
@@ -31,6 +32,16 @@ fn timestamp_us_from_ms(timestamp_ms: f64) -> u64 {
     }
 
     (timestamp_ms * 1000.0) as u64
+}
+
+fn finish_with_replay_wall_time(
+    collector: TraceCollector,
+    started_at: Instant,
+) -> TraceSimulationReport {
+    // Capture elapsed time before final report aggregation so bookkeeping such
+    // as latency sorting is not counted as replay execution.
+    let wall_time_ms = started_at.elapsed().as_secs_f64() * 1000.0;
+    collector.finish().with_wall_time_ms(wall_time_ms)
 }
 
 pub(crate) fn generate_trace_worker_artifacts(
@@ -208,6 +219,7 @@ pub(crate) fn simulate_trace_disagg(
     arrival_speedup_ratio: f64,
     router_mode: ReplayRouterMode,
 ) -> Result<TraceSimulationReport> {
+    let started_at = Instant::now();
     let pending = normalize_trace_requests(requests, arrival_speedup_ratio)?;
     let (collector, _) = DisaggRuntime::new(
         &config,
@@ -218,7 +230,7 @@ pub(crate) fn simulate_trace_disagg(
         router_mode,
     )?
     .run()?;
-    Ok(collector.finish())
+    Ok(finish_with_replay_wall_time(collector, started_at))
 }
 
 pub(crate) fn simulate_concurrency_disagg(
@@ -229,6 +241,7 @@ pub(crate) fn simulate_concurrency_disagg(
     max_in_flight: usize,
     router_mode: ReplayRouterMode,
 ) -> Result<TraceSimulationReport> {
+    let started_at = Instant::now();
     let pending = VecDeque::from(requests);
     let (collector, _) = DisaggRuntime::new(
         &config,
@@ -239,7 +252,7 @@ pub(crate) fn simulate_concurrency_disagg(
         router_mode,
     )?
     .run()?;
-    Ok(collector.finish())
+    Ok(finish_with_replay_wall_time(collector, started_at))
 }
 
 pub(crate) fn simulate_trace_workload_disagg(
@@ -249,6 +262,7 @@ pub(crate) fn simulate_trace_workload_disagg(
     trace: Trace,
     router_mode: ReplayRouterMode,
 ) -> Result<TraceSimulationReport> {
+    let started_at = Instant::now();
     let driver = WorkloadDriver::new_trace(trace, config.prefill_args.block_size)?;
     let (collector, _) = DisaggRuntime::new_workload(
         &config,
@@ -259,7 +273,7 @@ pub(crate) fn simulate_trace_workload_disagg(
         router_mode,
     )?
     .run()?;
-    Ok(collector.finish())
+    Ok(finish_with_replay_wall_time(collector, started_at))
 }
 
 pub(crate) fn simulate_concurrency_workload_disagg(
@@ -270,6 +284,7 @@ pub(crate) fn simulate_concurrency_workload_disagg(
     max_in_flight: usize,
     router_mode: ReplayRouterMode,
 ) -> Result<TraceSimulationReport> {
+    let started_at = Instant::now();
     let driver = WorkloadDriver::new_concurrency(trace, config.prefill_args.block_size)?;
     let (collector, _) = DisaggRuntime::new_workload(
         &config,
@@ -280,7 +295,7 @@ pub(crate) fn simulate_concurrency_workload_disagg(
         router_mode,
     )?
     .run()?;
-    Ok(collector.finish())
+    Ok(finish_with_replay_wall_time(collector, started_at))
 }
 
 pub(crate) fn simulate_trace_single(
@@ -288,10 +303,11 @@ pub(crate) fn simulate_trace_single(
     requests: Vec<DirectRequest>,
     arrival_speedup_ratio: f64,
 ) -> Result<TraceSimulationReport> {
+    let started_at = Instant::now();
     let args = args.normalized()?;
     let pending = normalize_trace_requests(requests, arrival_speedup_ratio)?;
     let collector = SingleRuntime::new(args, pending, SingleReplayMode::Trace).run()?;
-    Ok(collector.finish())
+    Ok(finish_with_replay_wall_time(collector, started_at))
 }
 
 pub(crate) fn simulate_concurrency_single(
@@ -299,6 +315,7 @@ pub(crate) fn simulate_concurrency_single(
     requests: Vec<DirectRequest>,
     max_in_flight: usize,
 ) -> Result<TraceSimulationReport> {
+    let started_at = Instant::now();
     let args = args.normalized()?;
     let pending = VecDeque::from(requests);
     let collector = SingleRuntime::new(
@@ -307,13 +324,14 @@ pub(crate) fn simulate_concurrency_single(
         SingleReplayMode::Concurrency { max_in_flight },
     )
     .run()?;
-    Ok(collector.finish())
+    Ok(finish_with_replay_wall_time(collector, started_at))
 }
 
 pub(crate) fn simulate_trace_workload_single(
     args: MockEngineArgs,
     trace: Trace,
 ) -> Result<TraceSimulationReport> {
+    let started_at = Instant::now();
     let args = args.normalized()?;
     let engine_block_size = args.block_size;
     let collector = SingleRuntime::new_workload(
@@ -322,7 +340,7 @@ pub(crate) fn simulate_trace_workload_single(
         SingleReplayMode::Trace,
     )
     .run()?;
-    Ok(collector.finish())
+    Ok(finish_with_replay_wall_time(collector, started_at))
 }
 
 pub(crate) fn simulate_concurrency_workload_single(
@@ -330,6 +348,7 @@ pub(crate) fn simulate_concurrency_workload_single(
     trace: Trace,
     max_in_flight: usize,
 ) -> Result<TraceSimulationReport> {
+    let started_at = Instant::now();
     let args = args.normalized()?;
     let engine_block_size = args.block_size;
     let collector = SingleRuntime::new_workload(
@@ -338,7 +357,7 @@ pub(crate) fn simulate_concurrency_workload_single(
         SingleReplayMode::Concurrency { max_in_flight },
     )
     .run()?;
-    Ok(collector.finish())
+    Ok(finish_with_replay_wall_time(collector, started_at))
 }
 
 pub(crate) fn simulate_trace_multi(
@@ -350,6 +369,7 @@ pub(crate) fn simulate_trace_multi(
     arrival_speedup_ratio: f64,
     router_mode: ReplayRouterMode,
 ) -> Result<TraceSimulationReport> {
+    let started_at = Instant::now();
     let args = args.normalized()?;
     let pending = normalize_trace_requests(requests, arrival_speedup_ratio)?;
     let (collector, _) = AggRuntime::new(
@@ -362,7 +382,7 @@ pub(crate) fn simulate_trace_multi(
         router_mode,
     )?
     .run()?;
-    Ok(collector.finish())
+    Ok(finish_with_replay_wall_time(collector, started_at))
 }
 
 pub(crate) fn simulate_concurrency_multi(
@@ -374,6 +394,7 @@ pub(crate) fn simulate_concurrency_multi(
     num_workers: usize,
     router_mode: ReplayRouterMode,
 ) -> Result<TraceSimulationReport> {
+    let started_at = Instant::now();
     let args = args.normalized()?;
     let pending = VecDeque::from(requests);
     let (collector, _) = AggRuntime::new(
@@ -386,7 +407,7 @@ pub(crate) fn simulate_concurrency_multi(
         router_mode,
     )?
     .run()?;
-    Ok(collector.finish())
+    Ok(finish_with_replay_wall_time(collector, started_at))
 }
 
 pub(crate) fn simulate_trace_workload_multi(
@@ -397,6 +418,7 @@ pub(crate) fn simulate_trace_workload_multi(
     num_workers: usize,
     router_mode: ReplayRouterMode,
 ) -> Result<TraceSimulationReport> {
+    let started_at = Instant::now();
     let args = args.normalized()?;
     let (collector, _) = AggRuntime::new_workload(
         &args,
@@ -408,7 +430,7 @@ pub(crate) fn simulate_trace_workload_multi(
         router_mode,
     )?
     .run()?;
-    Ok(collector.finish())
+    Ok(finish_with_replay_wall_time(collector, started_at))
 }
 
 pub(crate) fn simulate_concurrency_workload_multi(
@@ -420,6 +442,7 @@ pub(crate) fn simulate_concurrency_workload_multi(
     num_workers: usize,
     router_mode: ReplayRouterMode,
 ) -> Result<TraceSimulationReport> {
+    let started_at = Instant::now();
     let args = args.normalized()?;
     let (collector, _) = AggRuntime::new_workload(
         &args,
@@ -431,7 +454,7 @@ pub(crate) fn simulate_concurrency_workload_multi(
         router_mode,
     )?
     .run()?;
-    Ok(collector.finish())
+    Ok(finish_with_replay_wall_time(collector, started_at))
 }
 
 #[cfg(test)]

--- a/lib/mocker/src/replay/planner_handle.rs
+++ b/lib/mocker/src/replay/planner_handle.rs
@@ -187,10 +187,11 @@ impl PlannerReplayHandle {
 
     /// Finalize the replay and return the report.
     pub fn finalize(self) -> TraceSimulationReport {
+        let wall_time_ms = self.started_at.elapsed().as_secs_f64() * 1000.0;
         let report = match self.runtime {
             RuntimeKind::Agg(rt) => rt.finalize_report(),
             RuntimeKind::Disagg(rt) => rt.finalize_report(),
         };
-        report.with_wall_time_ms(self.started_at.elapsed().as_secs_f64() * 1000.0)
+        report.with_wall_time_ms(wall_time_ms)
     }
 }


### PR DESCRIPTION
Reports offline replay wall time before final trace collector aggregation, so the metric reflects replay execution rather than post-processing. Planner replay finalization uses the same timing boundary.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9190" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Adjusted internal timing instrumentation across simulation and replay operations for improved consistency and efficiency. Wall-clock elapsed time tracking has been reorganized and optimized across multiple simulation variants to provide better performance metrics reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->