### PR TITLE
feat(operator): reconcile DGSA against v1beta1 DGDs

### DIFF
--- a/deploy/operator/internal/controller/common.go
+++ b/deploy/operator/internal/controller/common.go
@@ -19,6 +19,7 @@ package controller
 
 import (
 	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -54,36 +55,42 @@ type dockerSecretRetriever interface {
 	GetSecrets(namespace, registry string) ([]string, error)
 }
 
-// getServiceKeys returns the keys of the services map for logging purposes
-func getServiceKeys(services map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec) []string {
-	keys := make([]string, 0, len(services))
-	for k := range services {
-		keys = append(keys, k)
+// getComponentNames returns the component names for logging purposes.
+func getComponentNames(components []v1beta1.DynamoComponentDeploymentSharedSpec) []string {
+	keys := make([]string, 0, len(components))
+	for i := range components {
+		keys = append(keys, components[i].ComponentName)
 	}
 	return keys
 }
 
-// servicesEqual compares two services maps to detect changes in replica counts
-func servicesEqual(old, new map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec) bool {
+// componentsEqual compares two component lists to detect changes in replica counts.
+func componentsEqual(old, new []v1beta1.DynamoComponentDeploymentSharedSpec) bool {
 	if len(old) != len(new) {
 		return false
 	}
 
-	for key, oldSvc := range old {
-		newSvc, exists := new[key]
+	newByName := make(map[string]*v1beta1.DynamoComponentDeploymentSharedSpec, len(new))
+	for i := range new {
+		newByName[new[i].ComponentName] = &new[i]
+	}
+
+	for i := range old {
+		oldComponent := &old[i]
+		newComponent, exists := newByName[old[i].ComponentName]
 		if !exists {
 			return false
 		}
 
 		// Compare replicas
 		oldReplicas := int32(1)
-		if oldSvc.Replicas != nil {
-			oldReplicas = *oldSvc.Replicas
+		if oldComponent.Replicas != nil {
+			oldReplicas = *oldComponent.Replicas
 		}
 
 		newReplicas := int32(1)
-		if newSvc.Replicas != nil {
-			newReplicas = *newSvc.Replicas
+		if newComponent.Replicas != nil {
+			newReplicas = *newComponent.Replicas
 		}
 
 		if oldReplicas != newReplicas {

--- a/deploy/operator/internal/controller/dynamographdeploymentscalingadapter_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentscalingadapter_controller.go
@@ -38,6 +38,7 @@ import (
 
 	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
 	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	commonController "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/observability"
@@ -73,7 +74,7 @@ func (r *DynamoGraphDeploymentScalingAdapterReconciler) Reconcile(ctx context.Co
 	}
 
 	// 2. Fetch the referenced DGD
-	dgd := &nvidiacomv1alpha1.DynamoGraphDeployment{}
+	dgd := &nvidiacomv1beta1.DynamoGraphDeployment{}
 	dgdKey := types.NamespacedName{
 		Name:      adapter.Spec.DGDRef.Name,
 		Namespace: adapter.Namespace,
@@ -87,14 +88,15 @@ func (r *DynamoGraphDeploymentScalingAdapterReconciler) Reconcile(ctx context.Co
 		return ctrl.Result{}, err
 	}
 
-	// 3. Find the target service in DGD's spec.services map
-	component, exists := dgd.Spec.Services[adapter.Spec.DGDRef.ServiceName]
-	if !exists || component == nil {
-		logger.Error(nil, "Service not found in DGD",
-			"service", adapter.Spec.DGDRef.ServiceName,
+	// 3. Find the target component in DGD's spec.components list.
+	componentName := adapter.Spec.DGDRef.ServiceName
+	component := dgd.GetComponentByName(componentName)
+	if component == nil {
+		logger.Error(nil, "Component not found in DGD",
+			"component", componentName,
 			"dgd", dgd.Name,
-			"availableServices", getServiceKeys(dgd.Spec.Services))
-		return ctrl.Result{}, fmt.Errorf("service %s not found in DGD", adapter.Spec.DGDRef.ServiceName)
+			"availableComponents", getComponentNames(dgd.Spec.Components))
+		return ctrl.Result{}, fmt.Errorf("component %s not found in DGD", componentName)
 	}
 
 	// Get current replicas from DGD (default to 1 if not set)
@@ -105,9 +107,8 @@ func (r *DynamoGraphDeploymentScalingAdapterReconciler) Reconcile(ctx context.Co
 
 	// 4. Update DGD if replicas changed (DGDSA is the source of truth)
 	if currentReplicas != adapter.Spec.Replicas {
-		// Update the service's replicas in DGD
+		// Update the component's replicas in DGD.
 		component.Replicas = &adapter.Spec.Replicas
-		dgd.Spec.Services[adapter.Spec.DGDRef.ServiceName] = component
 
 		if err := r.Update(ctx, dgd); err != nil {
 			logger.Error(err, "Failed to update DGD")
@@ -116,14 +117,14 @@ func (r *DynamoGraphDeploymentScalingAdapterReconciler) Reconcile(ctx context.Co
 			return ctrl.Result{}, err
 		}
 
-		logger.Info("Scaled service",
+		logger.Info("Scaled component",
 			"dgd", dgd.Name,
-			"service", adapter.Spec.DGDRef.ServiceName,
+			"component", componentName,
 			"from", currentReplicas,
 			"to", adapter.Spec.Replicas)
 
 		r.Recorder.Eventf(adapter, corev1.EventTypeNormal, "Scaled",
-			"Scaled service %s from %d to %d replicas", adapter.Spec.DGDRef.ServiceName, currentReplicas, adapter.Spec.Replicas)
+			"Scaled component %s from %d to %d replicas", componentName, currentReplicas, adapter.Spec.Replicas)
 
 		// Record scaling event
 		now := metav1.Now()
@@ -132,7 +133,7 @@ func (r *DynamoGraphDeploymentScalingAdapterReconciler) Reconcile(ctx context.Co
 
 	// 5. Update adapter status
 	adapter.Status.Replicas = adapter.Spec.Replicas
-	adapter.Status.Selector = r.buildPodSelector(dgd, adapter.Spec.DGDRef.ServiceName)
+	adapter.Status.Selector = r.buildPodSelector(dgd, componentName)
 
 	if err := r.Status().Update(ctx, adapter); err != nil {
 		logger.Error(err, "Failed to update adapter status")
@@ -142,14 +143,14 @@ func (r *DynamoGraphDeploymentScalingAdapterReconciler) Reconcile(ctx context.Co
 	return ctrl.Result{}, nil
 }
 
-// buildPodSelector constructs a label selector for the pods managed by this service
-func (r *DynamoGraphDeploymentScalingAdapterReconciler) buildPodSelector(dgd *nvidiacomv1alpha1.DynamoGraphDeployment, serviceName string) string {
+// buildPodSelector constructs a label selector for the pods managed by this component.
+func (r *DynamoGraphDeploymentScalingAdapterReconciler) buildPodSelector(dgd *nvidiacomv1beta1.DynamoGraphDeployment, componentName string) string {
 	// Pods are labeled with:
 	// - nvidia.com/dynamo-graph-deployment-name = dgd.Name
-	// - nvidia.com/dynamo-component = serviceName (the key from spec.services map)
+	// - nvidia.com/dynamo-component = componentName
 	return fmt.Sprintf("%s=%s,%s=%s",
 		consts.KubeLabelDynamoGraphDeploymentName, dgd.Name,
-		consts.KubeLabelDynamoComponent, serviceName)
+		consts.KubeLabelDynamoComponent, componentName)
 }
 
 // SetupWithManager sets up the controller with the Manager
@@ -159,22 +160,22 @@ func (r *DynamoGraphDeploymentScalingAdapterReconciler) SetupWithManager(mgr ctr
 			predicate.GenerationChangedPredicate{},
 		)).
 		Named(consts.ResourceTypeDynamoGraphDeploymentScalingAdapter).
-		// Watch DGDs to sync status when DGD service replicas change
+		// Watch DGDs to sync status when DGD component replicas change.
 		Watches(
-			&nvidiacomv1alpha1.DynamoGraphDeployment{},
+			&nvidiacomv1beta1.DynamoGraphDeployment{},
 			handler.EnqueueRequestsFromMapFunc(r.findAdaptersForDGD),
 			builder.WithPredicates(predicate.Funcs{
 				CreateFunc: func(ce event.CreateEvent) bool { return false },
 				DeleteFunc: func(de event.DeleteEvent) bool { return true },
 				UpdateFunc: func(ue event.UpdateEvent) bool {
 					// Only trigger on spec changes (not status)
-					oldDGD, okOld := ue.ObjectOld.(*nvidiacomv1alpha1.DynamoGraphDeployment)
-					newDGD, okNew := ue.ObjectNew.(*nvidiacomv1alpha1.DynamoGraphDeployment)
+					oldDGD, okOld := ue.ObjectOld.(*nvidiacomv1beta1.DynamoGraphDeployment)
+					newDGD, okNew := ue.ObjectNew.(*nvidiacomv1beta1.DynamoGraphDeployment)
 					if !okOld || !okNew {
 						return false
 					}
-					// Trigger if services map changed
-					return !servicesEqual(oldDGD.Spec.Services, newDGD.Spec.Services)
+					// Trigger if components changed.
+					return !componentsEqual(oldDGD.Spec.Components, newDGD.Spec.Components)
 				},
 				GenericFunc: func(ge event.GenericEvent) bool { return false },
 			}),
@@ -186,7 +187,7 @@ func (r *DynamoGraphDeploymentScalingAdapterReconciler) SetupWithManager(mgr ctr
 // findAdaptersForDGD maps DGD changes to adapter reconcile requests
 // Uses label selector to efficiently query only adapters for this specific DGD
 func (r *DynamoGraphDeploymentScalingAdapterReconciler) findAdaptersForDGD(ctx context.Context, obj client.Object) []reconcile.Request {
-	dgd, ok := obj.(*nvidiacomv1alpha1.DynamoGraphDeployment)
+	dgd, ok := obj.(*nvidiacomv1beta1.DynamoGraphDeployment)
 	if !ok {
 		return nil
 	}

--- a/deploy/operator/internal/controller/dynamographdeploymentscalingadapter_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentscalingadapter_controller_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -38,11 +39,14 @@ func TestDynamoGraphDeploymentScalingAdapterReconciler_Reconcile(t *testing.T) {
 	if err := v1alpha1.AddToScheme(scheme.Scheme); err != nil {
 		t.Fatalf("Failed to add v1alpha1 to scheme: %v", err)
 	}
+	if err := v1beta1.AddToScheme(scheme.Scheme); err != nil {
+		t.Fatalf("Failed to add v1beta1 to scheme: %v", err)
+	}
 
 	tests := []struct {
 		name                   string
 		adapter                *v1alpha1.DynamoGraphDeploymentScalingAdapter
-		dgd                    *v1alpha1.DynamoGraphDeployment
+		dgd                    *v1beta1.DynamoGraphDeployment
 		expectedDGDReplicas    int32
 		expectedStatusReplicas int32
 		expectError            bool
@@ -63,7 +67,7 @@ func TestDynamoGraphDeploymentScalingAdapterReconciler_Reconcile(t *testing.T) {
 					},
 				},
 			},
-			dgd: &v1alpha1.DynamoGraphDeployment{
+			dgd: betaDGD(t, &v1alpha1.DynamoGraphDeployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-dgd",
 					Namespace: "default",
@@ -75,7 +79,7 @@ func TestDynamoGraphDeploymentScalingAdapterReconciler_Reconcile(t *testing.T) {
 						},
 					},
 				},
-			},
+			}),
 			expectedDGDReplicas:    5,
 			expectedStatusReplicas: 5,
 			expectError:            false,
@@ -95,7 +99,7 @@ func TestDynamoGraphDeploymentScalingAdapterReconciler_Reconcile(t *testing.T) {
 					},
 				},
 			},
-			dgd: &v1alpha1.DynamoGraphDeployment{
+			dgd: betaDGD(t, &v1alpha1.DynamoGraphDeployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-dgd",
 					Namespace: "default",
@@ -107,7 +111,7 @@ func TestDynamoGraphDeploymentScalingAdapterReconciler_Reconcile(t *testing.T) {
 						},
 					},
 				},
-			},
+			}),
 			expectedDGDReplicas:    3,
 			expectedStatusReplicas: 3,
 			expectError:            false,
@@ -127,7 +131,7 @@ func TestDynamoGraphDeploymentScalingAdapterReconciler_Reconcile(t *testing.T) {
 					},
 				},
 			},
-			dgd: &v1alpha1.DynamoGraphDeployment{
+			dgd: betaDGD(t, &v1alpha1.DynamoGraphDeployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-dgd",
 					Namespace: "default",
@@ -137,7 +141,7 @@ func TestDynamoGraphDeploymentScalingAdapterReconciler_Reconcile(t *testing.T) {
 						"worker": {}, // no replicas set
 					},
 				},
-			},
+			}),
 			expectedDGDReplicas:    4,
 			expectedStatusReplicas: 4,
 			expectError:            false,
@@ -157,7 +161,7 @@ func TestDynamoGraphDeploymentScalingAdapterReconciler_Reconcile(t *testing.T) {
 					},
 				},
 			},
-			dgd: &v1alpha1.DynamoGraphDeployment{
+			dgd: betaDGD(t, &v1alpha1.DynamoGraphDeployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-dgd",
 					Namespace: "default",
@@ -169,7 +173,7 @@ func TestDynamoGraphDeploymentScalingAdapterReconciler_Reconcile(t *testing.T) {
 						},
 					},
 				},
-			},
+			}),
 			expectError: true,
 		},
 	}
@@ -224,13 +228,13 @@ func TestDynamoGraphDeploymentScalingAdapterReconciler_Reconcile(t *testing.T) {
 			}
 
 			// Verify DGD replicas were updated
-			updatedDGD := &v1alpha1.DynamoGraphDeployment{}
+			updatedDGD := betaDGD(t, &v1alpha1.DynamoGraphDeployment{})
 			if err := fakeClient.Get(ctx, types.NamespacedName{Name: tt.dgd.Name, Namespace: tt.dgd.Namespace}, updatedDGD); err != nil {
 				t.Fatalf("Failed to get updated DGD: %v", err)
 			}
 
-			service, exists := updatedDGD.Spec.Services[tt.adapter.Spec.DGDRef.ServiceName]
-			if !exists {
+			service := updatedDGD.GetComponentByName(tt.adapter.Spec.DGDRef.ServiceName)
+			if service == nil {
 				t.Fatalf("Service %s not found in updated DGD", tt.adapter.Spec.DGDRef.ServiceName)
 			}
 
@@ -266,6 +270,9 @@ func TestDynamoGraphDeploymentScalingAdapterReconciler_Reconcile_NotFound(t *tes
 	if err := v1alpha1.AddToScheme(scheme.Scheme); err != nil {
 		t.Fatalf("Failed to add v1alpha1 to scheme: %v", err)
 	}
+	if err := v1beta1.AddToScheme(scheme.Scheme); err != nil {
+		t.Fatalf("Failed to add v1beta1 to scheme: %v", err)
+	}
 
 	// Create fake client with no objects
 	fakeClient := fake.NewClientBuilder().
@@ -300,6 +307,9 @@ func TestDynamoGraphDeploymentScalingAdapterReconciler_Reconcile_DGDNotFound(t *
 	// Register custom types with the scheme
 	if err := v1alpha1.AddToScheme(scheme.Scheme); err != nil {
 		t.Fatalf("Failed to add v1alpha1 to scheme: %v", err)
+	}
+	if err := v1beta1.AddToScheme(scheme.Scheme); err != nil {
+		t.Fatalf("Failed to add v1beta1 to scheme: %v", err)
 	}
 
 	adapter := &v1alpha1.DynamoGraphDeploymentScalingAdapter{
@@ -347,6 +357,9 @@ func TestDynamoGraphDeploymentScalingAdapterReconciler_Reconcile_BeingDeleted(t 
 	if err := v1alpha1.AddToScheme(scheme.Scheme); err != nil {
 		t.Fatalf("Failed to add v1alpha1 to scheme: %v", err)
 	}
+	if err := v1beta1.AddToScheme(scheme.Scheme); err != nil {
+		t.Fatalf("Failed to add v1beta1 to scheme: %v", err)
+	}
 
 	now := metav1.Now()
 	adapter := &v1alpha1.DynamoGraphDeploymentScalingAdapter{
@@ -365,7 +378,7 @@ func TestDynamoGraphDeploymentScalingAdapterReconciler_Reconcile_BeingDeleted(t 
 		},
 	}
 
-	dgd := &v1alpha1.DynamoGraphDeployment{
+	dgd := betaDGD(t, &v1alpha1.DynamoGraphDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-dgd",
 			Namespace: "default",
@@ -377,7 +390,7 @@ func TestDynamoGraphDeploymentScalingAdapterReconciler_Reconcile_BeingDeleted(t 
 				},
 			},
 		},
-	}
+	})
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme.Scheme).
@@ -408,13 +421,17 @@ func TestDynamoGraphDeploymentScalingAdapterReconciler_Reconcile_BeingDeleted(t 
 	}
 
 	// DGD replicas should NOT be updated (still 2)
-	updatedDGD := &v1alpha1.DynamoGraphDeployment{}
+	updatedDGD := betaDGD(t, &v1alpha1.DynamoGraphDeployment{})
 	if err := fakeClient.Get(ctx, types.NamespacedName{Name: dgd.Name, Namespace: dgd.Namespace}, updatedDGD); err != nil {
 		t.Fatalf("Failed to get DGD: %v", err)
 	}
 
-	if *updatedDGD.Spec.Services["Frontend"].Replicas != 2 {
-		t.Errorf("DGD replicas should remain unchanged, got %d", *updatedDGD.Spec.Services["Frontend"].Replicas)
+	frontend := updatedDGD.GetComponentByName("Frontend")
+	if frontend == nil {
+		t.Fatalf("Frontend service not found in updated DGD")
+	}
+	if *frontend.Replicas != 2 {
+		t.Errorf("DGD replicas should remain unchanged, got %d", *frontend.Replicas)
 	}
 }
 
@@ -423,13 +440,16 @@ func TestDynamoGraphDeploymentScalingAdapterReconciler_findAdaptersForDGD(t *tes
 	if err := v1alpha1.AddToScheme(scheme.Scheme); err != nil {
 		t.Fatalf("Failed to add v1alpha1 to scheme: %v", err)
 	}
+	if err := v1beta1.AddToScheme(scheme.Scheme); err != nil {
+		t.Fatalf("Failed to add v1beta1 to scheme: %v", err)
+	}
 
-	dgd := &v1alpha1.DynamoGraphDeployment{
+	dgd := betaDGD(t, &v1alpha1.DynamoGraphDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-dgd",
 			Namespace: "default",
 		},
-	}
+	})
 
 	// Adapters belonging to test-dgd
 	adapter1 := &v1alpha1.DynamoGraphDeploymentScalingAdapter{

--- a/deploy/operator/internal/controller/test_beta_helpers_test.go
+++ b/deploy/operator/internal/controller/test_beta_helpers_test.go
@@ -1,0 +1,122 @@
+package controller
+
+import (
+	"maps"
+	"testing"
+
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func betaDCD(t testing.TB, src *v1alpha1.DynamoComponentDeployment) *v1beta1.DynamoComponentDeployment {
+	t.Helper()
+	if src == nil {
+		return nil
+	}
+	dst := &v1beta1.DynamoComponentDeployment{}
+	if err := src.ConvertTo(dst); err != nil {
+		t.Fatalf("convert test DCD to v1beta1: %v", err)
+	}
+	applyAlphaMetadataToBetaComponent(&dst.Spec.DynamoComponentDeploymentSharedSpec, src.Spec.Annotations, src.Spec.Labels)
+	if serviceName := src.Spec.ServiceName; serviceName != "" {
+		if dst.Labels == nil {
+			dst.Labels = map[string]string{}
+		}
+		dst.Labels[commonconsts.KubeLabelDynamoComponent] = serviceName
+	}
+	for _, key := range []string{
+		commonconsts.KubeLabelDynamoGraphDeploymentName,
+		commonconsts.KubeLabelDynamoNamespace,
+		commonconsts.KubeLabelDynamoWorkerHash,
+	} {
+		if value := src.Spec.Labels[key]; value != "" {
+			if dst.Labels == nil {
+				dst.Labels = map[string]string{}
+			}
+			dst.Labels[key] = value
+		}
+	}
+	return dst
+}
+
+func betaDGD(t testing.TB, src *v1alpha1.DynamoGraphDeployment) *v1beta1.DynamoGraphDeployment {
+	t.Helper()
+	if src == nil {
+		return nil
+	}
+	dst := &v1beta1.DynamoGraphDeployment{}
+	if err := src.ConvertTo(dst); err != nil {
+		t.Fatalf("convert test DGD to v1beta1: %v", err)
+	}
+	for i := range dst.Spec.Components {
+		component := &dst.Spec.Components[i]
+		if alphaSvc := src.Spec.Services[component.ComponentName]; alphaSvc != nil {
+			applyAlphaMetadataToBetaComponent(component, alphaSvc.Annotations, alphaSvc.Labels)
+		}
+	}
+	return dst
+}
+
+func mustBetaDGD(src *v1alpha1.DynamoGraphDeployment) *v1beta1.DynamoGraphDeployment {
+	if src == nil {
+		return nil
+	}
+	dst := &v1beta1.DynamoGraphDeployment{}
+	if err := src.ConvertTo(dst); err != nil {
+		panic(err)
+	}
+	for i := range dst.Spec.Components {
+		component := &dst.Spec.Components[i]
+		if alphaSvc := src.Spec.Services[component.ComponentName]; alphaSvc != nil {
+			applyAlphaMetadataToBetaComponent(component, alphaSvc.Annotations, alphaSvc.Labels)
+		}
+	}
+	return dst
+}
+
+func betaRestartStatus(src *v1alpha1.RestartStatus) *v1beta1.RestartStatus {
+	if src == nil {
+		return nil
+	}
+	return &v1beta1.RestartStatus{
+		ObservedID: src.ObservedID,
+		Phase:      v1beta1.RestartPhase(src.Phase),
+		InProgress: append([]string(nil), src.InProgress...),
+	}
+}
+
+func betaComponent(t testing.TB, src *v1alpha1.DynamoComponentDeploymentSharedSpec) *v1beta1.DynamoComponentDeploymentSharedSpec {
+	t.Helper()
+	if src == nil {
+		return nil
+	}
+	dcd := betaDCD(t, &v1alpha1.DynamoComponentDeployment{
+		Spec: v1alpha1.DynamoComponentDeploymentSpec{
+			DynamoComponentDeploymentSharedSpec: *src,
+		},
+	})
+	return &dcd.Spec.DynamoComponentDeploymentSharedSpec
+}
+
+func applyAlphaMetadataToBetaComponent(component *v1beta1.DynamoComponentDeploymentSharedSpec, annotations, labels map[string]string) {
+	if len(annotations) == 0 && len(labels) == 0 {
+		return
+	}
+	if component.PodTemplate == nil {
+		component.PodTemplate = &corev1.PodTemplateSpec{}
+	}
+	if len(annotations) > 0 {
+		if component.PodTemplate.Annotations == nil {
+			component.PodTemplate.Annotations = map[string]string{}
+		}
+		maps.Copy(component.PodTemplate.Annotations, annotations)
+	}
+	if len(labels) > 0 {
+		if component.PodTemplate.Labels == nil {
+			component.PodTemplate.Labels = map[string]string{}
+		}
+		maps.Copy(component.PodTemplate.Labels, labels)
+	}
+}


### PR DESCRIPTION
## Summary

Migrate the DynamoGraphDeploymentScalingAdapter controller to reconcile v1beta1 DGDSA resources and read/update v1beta1 DynamoGraphDeployments.

## Changes

- Reconcile `v1beta1.DynamoGraphDeploymentScalingAdapter`.
- Use `spec.dgdRef.componentName` instead of the v1alpha1 `serviceName` field.
- Fetch referenced DGDs as `v1beta1.DynamoGraphDeployment`.
- Look up target components from `spec.components`.
- Watch v1beta1 DGDs for component replica changes.
- List v1beta1 DGDSAs when mapping DGD events back to adapters.
- Update controller tests to use v1beta1 DGDSA and v1beta1 DGD fixtures.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9191" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->