### PR TITLE
draft: bake DSv4 TRT-LLM 49998847 + custom-wheel mode (record of dsv4-trtllm-20250505-disagg-candidate image)

### DIFF
--- a/container/context.yaml
+++ b/container/context.yaml
@@ -108,7 +108,7 @@ trtllm:
   pip_wheel: tensorrt-llm==1.3.0rc11
   trtllm_wheel_image: nvcr.io/nvidia/tensorrt-llm/release:${TENSORRTLLM_PIP_WHEEL#*==}
 
-  github_trtllm_commit: v1.3.0rc11
+  github_trtllm_commit: 49998847699fae22e7567f18489e381a43f006c7
   torch_version: 2.11.0a0+eb65b36914.nv26.2
   torch_tensorrt_version: 2.11.0a0
   torchvision_version: 0.25.0a0+1e53952f.nv26.2.44259020
@@ -120,4 +120,4 @@ trtllm:
   pytorch_triton_ver: 3.6.0+git9844da95.nv26.2
   flash_attn_version: 2.7.4.post1+nv26.2.44259020
   flashinfer_python_ver: 0.6.6
-  has_trtllm_context: "0"
+  has_trtllm_context: "1"


### PR DESCRIPTION
## Summary

Snapshot of the build inputs for the arm64 Dynamo container

`nvcr.io/nvstaging/ai-dynamo/tensorrtllm-runtime:dsv4-trtllm-20250505-disagg-candidate`

(manifest digest `sha256:fe8206357ef9ede1f011893e9641d04907a218f1abf1a14663087ff93dd1c895`).

**Not for merge** — this PR is for record-keeping / reviewer reference. The two YAML edits are deployment-specific overrides and would not normally land on `main`.

## Changes (2 lines in `container/context.yaml`)

```yaml
trtllm:
  ...
- github_trtllm_commit: v1.3.0rc11
+ github_trtllm_commit: 49998847699fae22e7567f18489e381a43f006c7
  ...
- has_trtllm_context: "0"
+ has_trtllm_context: "1"
```

### Why

- `github_trtllm_commit`: aligns the `install_tensorrt.sh` URL fetch with the SHA the bundled wheel was actually built from. Without this, the install script downloads a different version of the helper than was used at wheel-build time, which can break TRT install path resolution.
- `has_trtllm_context: "1"`: enables the `COPY --from=trtllm_wheel / /trtllm_wheel/` branch in `templates/trtllm_framework.Dockerfile`, so `docker buildx build --build-context trtllm_wheel=./trtllm_wheel` injects a custom wheel instead of pulling `tensorrt-llm==1.3.0rc11` from `pypi.nvidia.com`.

## Wheel bundled in the image

`tensorrt_llm-1.3.0rc11-cp312-cp312-linux_aarch64.whl`, SHA-256:
\`5d740090bc4054c60ae8575efeee849ee28ec0451a7e0542e00854036484566e\`

Sourced from `/lustre/share/coreai_comparch_trtllm/itabrizian/` on Lyris. Built from \`feat/deepseek_v4@49998847\` plus two local patches:

- adds `MEGAMOE_DEEPGEMM` enum value to `MoeConfig.backend`
- bumps `kv_transfer_timeout_ms` default from 60_000ms to 600_000ms (workaround for DSv4-Pro 8k/1k @ conc=512 hitting legitimate KV-transfer timeouts that crash ctx via the unsupported cancel path on `KvCacheTransceiverV2`)

## Build details

- Built on workstation via `docker buildx --platform=linux/arm64 --no-cache --push` with QEMU emulation
- Builder: `dsv4-arm64-stg` (docker-container driver, scoped to `~/.docker-nvstaging`)
- Wall-clock: 102 min (6121s)
- Pushed digest: `sha256:fe8206357ef9ede1f011893e9641d04907a218f1abf1a14663087ff93dd1c895`

## NIXL ABI verification (post-build, on Lyris GB200)

Confirmed: TRT-LLM bundles its own NIXL 0.9.0 in the wheel at \`tensorrt_llm/libs/nixl/\`. `RUNPATH` puts \`\$ORIGIN/libs/nixl\` before \`/opt/nvidia/nvda_nixl/lib/aarch64-linux-gnu\`, so TRT-LLM's transceiver resolves all NIXL symbols against its own bundled 0.9.0, isolated from Dynamo's container-built 0.10.1. No undefined-symbol risk; no ABI clash.

## Test plan

- [x] Image push to nvcr.io/nvstaging completed (digest above)
- [x] Manifest inspect: `architecture: arm64, os: linux`
- [x] NIXL ABI smoke test (RUNPATH analysis, ldd resolution) on GB200/Lyris — no missing symbols
- [ ] End-to-end DSv4-Pro disagg run @ conc=512 (next step, separate ticket)

🤖 Build artifact reference; not intended for merge.