### PR TITLE
feat(operator): Migrate DGSA controller to v1beta1

### DIFF
--- a/deploy/operator/internal/controller/common.go
+++ b/deploy/operator/internal/controller/common.go
@@ -19,6 +19,7 @@ package controller
 
 import (
 	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -54,36 +55,42 @@ type dockerSecretRetriever interface {
 	GetSecrets(namespace, registry string) ([]string, error)
 }
 
-// getServiceKeys returns the keys of the services map for logging purposes
-func getServiceKeys(services map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec) []string {
-	keys := make([]string, 0, len(services))
-	for k := range services {
-		keys = append(keys, k)
+// getComponentNames returns the component names for logging purposes.
+func getComponentNames(components []v1beta1.DynamoComponentDeploymentSharedSpec) []string {
+	keys := make([]string, 0, len(components))
+	for i := range components {
+		keys = append(keys, components[i].ComponentName)
 	}
 	return keys
 }
 
-// servicesEqual compares two services maps to detect changes in replica counts
-func servicesEqual(old, new map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec) bool {
+// componentsEqual compares two component lists to detect changes in replica counts.
+func componentsEqual(old, new []v1beta1.DynamoComponentDeploymentSharedSpec) bool {
 	if len(old) != len(new) {
 		return false
 	}
 
-	for key, oldSvc := range old {
-		newSvc, exists := new[key]
+	newByName := make(map[string]*v1beta1.DynamoComponentDeploymentSharedSpec, len(new))
+	for i := range new {
+		newByName[new[i].ComponentName] = &new[i]
+	}
+
+	for i := range old {
+		oldComponent := &old[i]
+		newComponent, exists := newByName[old[i].ComponentName]
 		if !exists {
 			return false
 		}
 
 		// Compare replicas
 		oldReplicas := int32(1)
-		if oldSvc.Replicas != nil {
-			oldReplicas = *oldSvc.Replicas
+		if oldComponent.Replicas != nil {
+			oldReplicas = *oldComponent.Replicas
 		}
 
 		newReplicas := int32(1)
-		if newSvc.Replicas != nil {
-			newReplicas = *newSvc.Replicas
+		if newComponent.Replicas != nil {
+			newReplicas = *newComponent.Replicas
 		}
 
 		if oldReplicas != newReplicas {

--- a/deploy/operator/internal/controller/dynamographdeploymentscalingadapter_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentscalingadapter_controller.go
@@ -19,11 +19,11 @@ package controller
 
 import (
 	"context"
-	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
@@ -37,7 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
-	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	commonController "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/observability"
@@ -61,7 +61,7 @@ func (r *DynamoGraphDeploymentScalingAdapterReconciler) Reconcile(ctx context.Co
 	logger := log.FromContext(ctx)
 
 	// 1. Fetch the DynamoGraphDeploymentScalingAdapter
-	adapter := &nvidiacomv1alpha1.DynamoGraphDeploymentScalingAdapter{}
+	adapter := &nvidiacomv1beta1.DynamoGraphDeploymentScalingAdapter{}
 	if err := r.Get(ctx, req.NamespacedName, adapter); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
@@ -73,7 +73,7 @@ func (r *DynamoGraphDeploymentScalingAdapterReconciler) Reconcile(ctx context.Co
 	}
 
 	// 2. Fetch the referenced DGD
-	dgd := &nvidiacomv1alpha1.DynamoGraphDeployment{}
+	dgd := &nvidiacomv1beta1.DynamoGraphDeployment{}
 	dgdKey := types.NamespacedName{
 		Name:      adapter.Spec.DGDRef.Name,
 		Namespace: adapter.Namespace,
@@ -87,14 +87,15 @@ func (r *DynamoGraphDeploymentScalingAdapterReconciler) Reconcile(ctx context.Co
 		return ctrl.Result{}, err
 	}
 
-	// 3. Find the target service in DGD's spec.services map
-	component, exists := dgd.Spec.Services[adapter.Spec.DGDRef.ServiceName]
-	if !exists || component == nil {
-		logger.Error(nil, "Service not found in DGD",
-			"service", adapter.Spec.DGDRef.ServiceName,
+	// 3. Find the target component in the DGD's components list.
+	componentName := adapter.Spec.DGDRef.ComponentName
+	component := dgd.GetComponentByName(componentName)
+	if component == nil {
+		logger.Info("Component referenced by adapter not found in DGD; waiting for adapter or DGD update",
+			"component", componentName,
 			"dgd", dgd.Name,
-			"availableServices", getServiceKeys(dgd.Spec.Services))
-		return ctrl.Result{}, fmt.Errorf("service %s not found in DGD", adapter.Spec.DGDRef.ServiceName)
+			"availableComponents", getComponentNames(dgd.Spec.Components))
+		return ctrl.Result{}, nil
 	}
 
 	// Get current replicas from DGD (default to 1 if not set)
@@ -105,9 +106,8 @@ func (r *DynamoGraphDeploymentScalingAdapterReconciler) Reconcile(ctx context.Co
 
 	// 4. Update DGD if replicas changed (DGDSA is the source of truth)
 	if currentReplicas != adapter.Spec.Replicas {
-		// Update the service's replicas in DGD
+		// Update the component's replicas in DGD.
 		component.Replicas = &adapter.Spec.Replicas
-		dgd.Spec.Services[adapter.Spec.DGDRef.ServiceName] = component
 
 		if err := r.Update(ctx, dgd); err != nil {
 			logger.Error(err, "Failed to update DGD")
@@ -116,14 +116,14 @@ func (r *DynamoGraphDeploymentScalingAdapterReconciler) Reconcile(ctx context.Co
 			return ctrl.Result{}, err
 		}
 
-		logger.Info("Scaled service",
+		logger.Info("Scaled component",
 			"dgd", dgd.Name,
-			"service", adapter.Spec.DGDRef.ServiceName,
+			"component", componentName,
 			"from", currentReplicas,
 			"to", adapter.Spec.Replicas)
 
 		r.Recorder.Eventf(adapter, corev1.EventTypeNormal, "Scaled",
-			"Scaled service %s from %d to %d replicas", adapter.Spec.DGDRef.ServiceName, currentReplicas, adapter.Spec.Replicas)
+			"Scaled component %s from %d to %d replicas", componentName, currentReplicas, adapter.Spec.Replicas)
 
 		// Record scaling event
 		now := metav1.Now()
@@ -132,7 +132,7 @@ func (r *DynamoGraphDeploymentScalingAdapterReconciler) Reconcile(ctx context.Co
 
 	// 5. Update adapter status
 	adapter.Status.Replicas = adapter.Spec.Replicas
-	adapter.Status.Selector = r.buildPodSelector(dgd, adapter.Spec.DGDRef.ServiceName)
+	adapter.Status.Selector = r.buildPodSelector(dgd.Name, componentName)
 
 	if err := r.Status().Update(ctx, adapter); err != nil {
 		logger.Error(err, "Failed to update adapter status")
@@ -142,39 +142,40 @@ func (r *DynamoGraphDeploymentScalingAdapterReconciler) Reconcile(ctx context.Co
 	return ctrl.Result{}, nil
 }
 
-// buildPodSelector constructs a label selector for the pods managed by this service
-func (r *DynamoGraphDeploymentScalingAdapterReconciler) buildPodSelector(dgd *nvidiacomv1alpha1.DynamoGraphDeployment, serviceName string) string {
+// buildPodSelector constructs a label selector for the pods managed by this component.
+func (r *DynamoGraphDeploymentScalingAdapterReconciler) buildPodSelector(dgdName, componentName string) string {
 	// Pods are labeled with:
 	// - nvidia.com/dynamo-graph-deployment-name = dgd.Name
-	// - nvidia.com/dynamo-component = serviceName (the key from spec.services map)
-	return fmt.Sprintf("%s=%s,%s=%s",
-		consts.KubeLabelDynamoGraphDeploymentName, dgd.Name,
-		consts.KubeLabelDynamoComponent, serviceName)
+	// - nvidia.com/dynamo-component = componentName
+	return labels.SelectorFromSet(labels.Set{
+		consts.KubeLabelDynamoGraphDeploymentName: dgdName,
+		consts.KubeLabelDynamoComponent:           componentName,
+	}).String()
 }
 
 // SetupWithManager sets up the controller with the Manager
 func (r *DynamoGraphDeploymentScalingAdapterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&nvidiacomv1alpha1.DynamoGraphDeploymentScalingAdapter{}, builder.WithPredicates(
+		For(&nvidiacomv1beta1.DynamoGraphDeploymentScalingAdapter{}, builder.WithPredicates(
 			predicate.GenerationChangedPredicate{},
 		)).
 		Named(consts.ResourceTypeDynamoGraphDeploymentScalingAdapter).
-		// Watch DGDs to sync status when DGD service replicas change
+		// Watch DGDs to sync status when DGD component replicas change.
 		Watches(
-			&nvidiacomv1alpha1.DynamoGraphDeployment{},
+			&nvidiacomv1beta1.DynamoGraphDeployment{},
 			handler.EnqueueRequestsFromMapFunc(r.findAdaptersForDGD),
 			builder.WithPredicates(predicate.Funcs{
 				CreateFunc: func(ce event.CreateEvent) bool { return false },
 				DeleteFunc: func(de event.DeleteEvent) bool { return true },
 				UpdateFunc: func(ue event.UpdateEvent) bool {
 					// Only trigger on spec changes (not status)
-					oldDGD, okOld := ue.ObjectOld.(*nvidiacomv1alpha1.DynamoGraphDeployment)
-					newDGD, okNew := ue.ObjectNew.(*nvidiacomv1alpha1.DynamoGraphDeployment)
+					oldDGD, okOld := ue.ObjectOld.(*nvidiacomv1beta1.DynamoGraphDeployment)
+					newDGD, okNew := ue.ObjectNew.(*nvidiacomv1beta1.DynamoGraphDeployment)
 					if !okOld || !okNew {
 						return false
 					}
-					// Trigger if services map changed
-					return !servicesEqual(oldDGD.Spec.Services, newDGD.Spec.Services)
+					// Trigger if components changed.
+					return !componentsEqual(oldDGD.Spec.Components, newDGD.Spec.Components)
 				},
 				GenericFunc: func(ge event.GenericEvent) bool { return false },
 			}),
@@ -183,27 +184,26 @@ func (r *DynamoGraphDeploymentScalingAdapterReconciler) SetupWithManager(mgr ctr
 		Complete(observability.NewObservedReconciler(r, consts.ResourceTypeDynamoGraphDeploymentScalingAdapter))
 }
 
-// findAdaptersForDGD maps DGD changes to adapter reconcile requests
-// Uses label selector to efficiently query only adapters for this specific DGD
+// findAdaptersForDGD maps DGD changes to adapter reconcile requests.
 func (r *DynamoGraphDeploymentScalingAdapterReconciler) findAdaptersForDGD(ctx context.Context, obj client.Object) []reconcile.Request {
-	dgd, ok := obj.(*nvidiacomv1alpha1.DynamoGraphDeployment)
+	dgd, ok := obj.(*nvidiacomv1beta1.DynamoGraphDeployment)
 	if !ok {
 		return nil
 	}
 
-	// Use label selector to filter at API level (more efficient than in-memory filtering)
-	adapterList := &nvidiacomv1alpha1.DynamoGraphDeploymentScalingAdapterList{}
+	adapterList := &nvidiacomv1beta1.DynamoGraphDeploymentScalingAdapterList{}
 	if err := r.List(ctx, adapterList,
 		client.InNamespace(dgd.Namespace),
-		client.MatchingLabels{consts.KubeLabelDynamoGraphDeploymentName: dgd.Name},
 	); err != nil {
 		log.FromContext(ctx).Error(err, "Failed to list adapters for DGD", "dgd", dgd.Name)
 		return nil
 	}
 
-	// All returned adapters are guaranteed to belong to this DGD
 	requests := make([]reconcile.Request, 0, len(adapterList.Items))
 	for i := range adapterList.Items {
+		if adapterList.Items[i].Spec.DGDRef.Name != dgd.Name {
+			continue
+		}
 		requests = append(requests, reconcile.Request{
 			NamespacedName: types.NamespacedName{
 				Name:      adapterList.Items[i].Name,

--- a/deploy/operator/internal/controller/dynamographdeploymentscalingadapter_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentscalingadapter_controller_test.go
@@ -21,9 +21,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
@@ -35,43 +36,45 @@ import (
 
 func TestDynamoGraphDeploymentScalingAdapterReconciler_Reconcile(t *testing.T) {
 	// Register custom types with the scheme
-	if err := v1alpha1.AddToScheme(scheme.Scheme); err != nil {
-		t.Fatalf("Failed to add v1alpha1 to scheme: %v", err)
+	if err := v1beta1.AddToScheme(scheme.Scheme); err != nil {
+		t.Fatalf("Failed to add v1beta1 to scheme: %v", err)
 	}
 
 	tests := []struct {
 		name                   string
-		adapter                *v1alpha1.DynamoGraphDeploymentScalingAdapter
-		dgd                    *v1alpha1.DynamoGraphDeployment
+		adapter                *v1beta1.DynamoGraphDeploymentScalingAdapter
+		dgd                    *v1beta1.DynamoGraphDeployment
 		expectedDGDReplicas    int32
 		expectedStatusReplicas int32
 		expectError            bool
+		expectMissingComponent bool
 		expectRequeue          bool
 	}{
 		{
 			name: "updates DGD replicas when DGDSA spec differs",
-			adapter: &v1alpha1.DynamoGraphDeploymentScalingAdapter{
+			adapter: &v1beta1.DynamoGraphDeploymentScalingAdapter{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-dgd-frontend",
 					Namespace: "default",
 				},
-				Spec: v1alpha1.DynamoGraphDeploymentScalingAdapterSpec{
+				Spec: v1beta1.DynamoGraphDeploymentScalingAdapterSpec{
 					Replicas: 5,
-					DGDRef: v1alpha1.DynamoGraphDeploymentServiceRef{
-						Name:        "test-dgd",
-						ServiceName: "Frontend",
+					DGDRef: v1beta1.DynamoGraphDeploymentComponentRef{
+						Name:          "test-dgd",
+						ComponentName: "Frontend",
 					},
 				},
 			},
-			dgd: &v1alpha1.DynamoGraphDeployment{
+			dgd: &v1beta1.DynamoGraphDeployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-dgd",
 					Namespace: "default",
 				},
-				Spec: v1alpha1.DynamoGraphDeploymentSpec{
-					Services: map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{
-						"Frontend": {
-							Replicas: ptr.To(int32(2)),
+				Spec: v1beta1.DynamoGraphDeploymentSpec{
+					Components: []v1beta1.DynamoComponentDeploymentSharedSpec{
+						{
+							ComponentName: "Frontend",
+							Replicas:      ptr.To(int32(2)),
 						},
 					},
 				},
@@ -82,28 +85,29 @@ func TestDynamoGraphDeploymentScalingAdapterReconciler_Reconcile(t *testing.T) {
 		},
 		{
 			name: "no update when replicas already match",
-			adapter: &v1alpha1.DynamoGraphDeploymentScalingAdapter{
+			adapter: &v1beta1.DynamoGraphDeploymentScalingAdapter{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-dgd-frontend",
 					Namespace: "default",
 				},
-				Spec: v1alpha1.DynamoGraphDeploymentScalingAdapterSpec{
+				Spec: v1beta1.DynamoGraphDeploymentScalingAdapterSpec{
 					Replicas: 3,
-					DGDRef: v1alpha1.DynamoGraphDeploymentServiceRef{
-						Name:        "test-dgd",
-						ServiceName: "Frontend",
+					DGDRef: v1beta1.DynamoGraphDeploymentComponentRef{
+						Name:          "test-dgd",
+						ComponentName: "Frontend",
 					},
 				},
 			},
-			dgd: &v1alpha1.DynamoGraphDeployment{
+			dgd: &v1beta1.DynamoGraphDeployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-dgd",
 					Namespace: "default",
 				},
-				Spec: v1alpha1.DynamoGraphDeploymentSpec{
-					Services: map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{
-						"Frontend": {
-							Replicas: ptr.To(int32(3)),
+				Spec: v1beta1.DynamoGraphDeploymentSpec{
+					Components: []v1beta1.DynamoComponentDeploymentSharedSpec{
+						{
+							ComponentName: "Frontend",
+							Replicas:      ptr.To(int32(3)),
 						},
 					},
 				},
@@ -113,28 +117,28 @@ func TestDynamoGraphDeploymentScalingAdapterReconciler_Reconcile(t *testing.T) {
 			expectError:            false,
 		},
 		{
-			name: "uses default replicas (1) when DGD service has no replicas set",
-			adapter: &v1alpha1.DynamoGraphDeploymentScalingAdapter{
+			name: "uses default replicas (1) when DGD component has no replicas set",
+			adapter: &v1beta1.DynamoGraphDeploymentScalingAdapter{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-dgd-worker",
 					Namespace: "default",
 				},
-				Spec: v1alpha1.DynamoGraphDeploymentScalingAdapterSpec{
+				Spec: v1beta1.DynamoGraphDeploymentScalingAdapterSpec{
 					Replicas: 4,
-					DGDRef: v1alpha1.DynamoGraphDeploymentServiceRef{
-						Name:        "test-dgd",
-						ServiceName: "worker",
+					DGDRef: v1beta1.DynamoGraphDeploymentComponentRef{
+						Name:          "test-dgd",
+						ComponentName: "worker",
 					},
 				},
 			},
-			dgd: &v1alpha1.DynamoGraphDeployment{
+			dgd: &v1beta1.DynamoGraphDeployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-dgd",
 					Namespace: "default",
 				},
-				Spec: v1alpha1.DynamoGraphDeploymentSpec{
-					Services: map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{
-						"worker": {}, // no replicas set
+				Spec: v1beta1.DynamoGraphDeploymentSpec{
+					Components: []v1beta1.DynamoComponentDeploymentSharedSpec{
+						{ComponentName: "worker"}, // no replicas set
 					},
 				},
 			},
@@ -143,34 +147,36 @@ func TestDynamoGraphDeploymentScalingAdapterReconciler_Reconcile(t *testing.T) {
 			expectError:            false,
 		},
 		{
-			name: "error when service not found in DGD",
-			adapter: &v1alpha1.DynamoGraphDeploymentScalingAdapter{
+			name: "returns without retry when component not found in DGD",
+			adapter: &v1beta1.DynamoGraphDeploymentScalingAdapter{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-dgd-missing",
 					Namespace: "default",
 				},
-				Spec: v1alpha1.DynamoGraphDeploymentScalingAdapterSpec{
+				Spec: v1beta1.DynamoGraphDeploymentScalingAdapterSpec{
 					Replicas: 2,
-					DGDRef: v1alpha1.DynamoGraphDeploymentServiceRef{
-						Name:        "test-dgd",
-						ServiceName: "nonexistent",
+					DGDRef: v1beta1.DynamoGraphDeploymentComponentRef{
+						Name:          "test-dgd",
+						ComponentName: "nonexistent",
 					},
 				},
 			},
-			dgd: &v1alpha1.DynamoGraphDeployment{
+			dgd: &v1beta1.DynamoGraphDeployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-dgd",
 					Namespace: "default",
 				},
-				Spec: v1alpha1.DynamoGraphDeploymentSpec{
-					Services: map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{
-						"Frontend": {
-							Replicas: ptr.To(int32(1)),
+				Spec: v1beta1.DynamoGraphDeploymentSpec{
+					Components: []v1beta1.DynamoComponentDeploymentSharedSpec{
+						{
+							ComponentName: "Frontend",
+							Replicas:      ptr.To(int32(1)),
 						},
 					},
 				},
 			},
-			expectError: true,
+			expectError:            false,
+			expectMissingComponent: true,
 		},
 	}
 
@@ -184,7 +190,7 @@ func TestDynamoGraphDeploymentScalingAdapterReconciler_Reconcile(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().
 				WithScheme(scheme.Scheme).
 				WithObjects(initObjs...).
-				WithStatusSubresource(&v1alpha1.DynamoGraphDeploymentScalingAdapter{}).
+				WithStatusSubresource(&v1beta1.DynamoGraphDeploymentScalingAdapter{}).
 				Build()
 
 			// Create reconciler
@@ -218,33 +224,44 @@ func TestDynamoGraphDeploymentScalingAdapterReconciler_Reconcile(t *testing.T) {
 				return
 			}
 
+			if tt.expectMissingComponent {
+				updatedAdapter := &v1beta1.DynamoGraphDeploymentScalingAdapter{}
+				if err := fakeClient.Get(ctx, types.NamespacedName{Name: tt.adapter.Name, Namespace: tt.adapter.Namespace}, updatedAdapter); err != nil {
+					t.Fatalf("Failed to get adapter: %v", err)
+				}
+				if updatedAdapter.Status.Selector != "" {
+					t.Errorf("Adapter status.selector = %q, expected empty selector when component is missing", updatedAdapter.Status.Selector)
+				}
+				return
+			}
+
 			// Check requeue
 			if tt.expectRequeue && result.RequeueAfter == 0 {
 				t.Errorf("Expected requeue, but got none")
 			}
 
 			// Verify DGD replicas were updated
-			updatedDGD := &v1alpha1.DynamoGraphDeployment{}
+			updatedDGD := &v1beta1.DynamoGraphDeployment{}
 			if err := fakeClient.Get(ctx, types.NamespacedName{Name: tt.dgd.Name, Namespace: tt.dgd.Namespace}, updatedDGD); err != nil {
 				t.Fatalf("Failed to get updated DGD: %v", err)
 			}
 
-			service, exists := updatedDGD.Spec.Services[tt.adapter.Spec.DGDRef.ServiceName]
-			if !exists {
-				t.Fatalf("Service %s not found in updated DGD", tt.adapter.Spec.DGDRef.ServiceName)
+			component := updatedDGD.GetComponentByName(tt.adapter.Spec.DGDRef.ComponentName)
+			if component == nil {
+				t.Fatalf("Component %s not found in updated DGD", tt.adapter.Spec.DGDRef.ComponentName)
 			}
 
 			actualReplicas := int32(1)
-			if service.Replicas != nil {
-				actualReplicas = *service.Replicas
+			if component.Replicas != nil {
+				actualReplicas = *component.Replicas
 			}
 
 			if actualReplicas != tt.expectedDGDReplicas {
-				t.Errorf("DGD service replicas = %d, expected %d", actualReplicas, tt.expectedDGDReplicas)
+				t.Errorf("DGD component replicas = %d, expected %d", actualReplicas, tt.expectedDGDReplicas)
 			}
 
 			// Verify adapter status was updated
-			updatedAdapter := &v1alpha1.DynamoGraphDeploymentScalingAdapter{}
+			updatedAdapter := &v1beta1.DynamoGraphDeploymentScalingAdapter{}
 			if err := fakeClient.Get(ctx, types.NamespacedName{Name: tt.adapter.Name, Namespace: tt.adapter.Namespace}, updatedAdapter); err != nil {
 				t.Fatalf("Failed to get updated adapter: %v", err)
 			}
@@ -253,9 +270,12 @@ func TestDynamoGraphDeploymentScalingAdapterReconciler_Reconcile(t *testing.T) {
 				t.Errorf("Adapter status.replicas = %d, expected %d", updatedAdapter.Status.Replicas, tt.expectedStatusReplicas)
 			}
 
-			// Verify selector is set
-			if updatedAdapter.Status.Selector == "" {
-				t.Errorf("Adapter status.selector is empty, expected non-empty")
+			expectedSelector := labels.SelectorFromSet(labels.Set{
+				consts.KubeLabelDynamoGraphDeploymentName: tt.dgd.Name,
+				consts.KubeLabelDynamoComponent:           tt.adapter.Spec.DGDRef.ComponentName,
+			}).String()
+			if updatedAdapter.Status.Selector != expectedSelector {
+				t.Errorf("Adapter status.selector = %q, expected %q", updatedAdapter.Status.Selector, expectedSelector)
 			}
 		})
 	}
@@ -263,8 +283,8 @@ func TestDynamoGraphDeploymentScalingAdapterReconciler_Reconcile(t *testing.T) {
 
 func TestDynamoGraphDeploymentScalingAdapterReconciler_Reconcile_NotFound(t *testing.T) {
 	// Register custom types with the scheme
-	if err := v1alpha1.AddToScheme(scheme.Scheme); err != nil {
-		t.Fatalf("Failed to add v1alpha1 to scheme: %v", err)
+	if err := v1beta1.AddToScheme(scheme.Scheme); err != nil {
+		t.Fatalf("Failed to add v1beta1 to scheme: %v", err)
 	}
 
 	// Create fake client with no objects
@@ -298,20 +318,20 @@ func TestDynamoGraphDeploymentScalingAdapterReconciler_Reconcile_NotFound(t *tes
 
 func TestDynamoGraphDeploymentScalingAdapterReconciler_Reconcile_DGDNotFound(t *testing.T) {
 	// Register custom types with the scheme
-	if err := v1alpha1.AddToScheme(scheme.Scheme); err != nil {
-		t.Fatalf("Failed to add v1alpha1 to scheme: %v", err)
+	if err := v1beta1.AddToScheme(scheme.Scheme); err != nil {
+		t.Fatalf("Failed to add v1beta1 to scheme: %v", err)
 	}
 
-	adapter := &v1alpha1.DynamoGraphDeploymentScalingAdapter{
+	adapter := &v1beta1.DynamoGraphDeploymentScalingAdapter{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-dgd-frontend",
 			Namespace: "default",
 		},
-		Spec: v1alpha1.DynamoGraphDeploymentScalingAdapterSpec{
+		Spec: v1beta1.DynamoGraphDeploymentScalingAdapterSpec{
 			Replicas: 5,
-			DGDRef: v1alpha1.DynamoGraphDeploymentServiceRef{
-				Name:        "nonexistent-dgd",
-				ServiceName: "Frontend",
+			DGDRef: v1beta1.DynamoGraphDeploymentComponentRef{
+				Name:          "nonexistent-dgd",
+				ComponentName: "Frontend",
 			},
 		},
 	}
@@ -344,36 +364,37 @@ func TestDynamoGraphDeploymentScalingAdapterReconciler_Reconcile_DGDNotFound(t *
 
 func TestDynamoGraphDeploymentScalingAdapterReconciler_Reconcile_BeingDeleted(t *testing.T) {
 	// Register custom types with the scheme
-	if err := v1alpha1.AddToScheme(scheme.Scheme); err != nil {
-		t.Fatalf("Failed to add v1alpha1 to scheme: %v", err)
+	if err := v1beta1.AddToScheme(scheme.Scheme); err != nil {
+		t.Fatalf("Failed to add v1beta1 to scheme: %v", err)
 	}
 
 	now := metav1.Now()
-	adapter := &v1alpha1.DynamoGraphDeploymentScalingAdapter{
+	adapter := &v1beta1.DynamoGraphDeploymentScalingAdapter{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              "test-dgd-frontend",
 			Namespace:         "default",
 			DeletionTimestamp: &now,
 			Finalizers:        []string{"test-finalizer"}, // Required for deletion timestamp to be set
 		},
-		Spec: v1alpha1.DynamoGraphDeploymentScalingAdapterSpec{
+		Spec: v1beta1.DynamoGraphDeploymentScalingAdapterSpec{
 			Replicas: 5,
-			DGDRef: v1alpha1.DynamoGraphDeploymentServiceRef{
-				Name:        "test-dgd",
-				ServiceName: "Frontend",
+			DGDRef: v1beta1.DynamoGraphDeploymentComponentRef{
+				Name:          "test-dgd",
+				ComponentName: "Frontend",
 			},
 		},
 	}
 
-	dgd := &v1alpha1.DynamoGraphDeployment{
+	dgd := &v1beta1.DynamoGraphDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-dgd",
 			Namespace: "default",
 		},
-		Spec: v1alpha1.DynamoGraphDeploymentSpec{
-			Services: map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{
-				"Frontend": {
-					Replicas: ptr.To(int32(2)),
+		Spec: v1beta1.DynamoGraphDeploymentSpec{
+			Components: []v1beta1.DynamoComponentDeploymentSharedSpec{
+				{
+					ComponentName: "Frontend",
+					Replicas:      ptr.To(int32(2)),
 				},
 			},
 		},
@@ -408,23 +429,27 @@ func TestDynamoGraphDeploymentScalingAdapterReconciler_Reconcile_BeingDeleted(t 
 	}
 
 	// DGD replicas should NOT be updated (still 2)
-	updatedDGD := &v1alpha1.DynamoGraphDeployment{}
+	updatedDGD := &v1beta1.DynamoGraphDeployment{}
 	if err := fakeClient.Get(ctx, types.NamespacedName{Name: dgd.Name, Namespace: dgd.Namespace}, updatedDGD); err != nil {
 		t.Fatalf("Failed to get DGD: %v", err)
 	}
 
-	if *updatedDGD.Spec.Services["Frontend"].Replicas != 2 {
-		t.Errorf("DGD replicas should remain unchanged, got %d", *updatedDGD.Spec.Services["Frontend"].Replicas)
+	frontend := updatedDGD.GetComponentByName("Frontend")
+	if frontend == nil {
+		t.Fatalf("Frontend component not found in updated DGD")
+	}
+	if *frontend.Replicas != 2 {
+		t.Errorf("DGD replicas should remain unchanged, got %d", *frontend.Replicas)
 	}
 }
 
 func TestDynamoGraphDeploymentScalingAdapterReconciler_findAdaptersForDGD(t *testing.T) {
 	// Register custom types with the scheme
-	if err := v1alpha1.AddToScheme(scheme.Scheme); err != nil {
-		t.Fatalf("Failed to add v1alpha1 to scheme: %v", err)
+	if err := v1beta1.AddToScheme(scheme.Scheme); err != nil {
+		t.Fatalf("Failed to add v1beta1 to scheme: %v", err)
 	}
 
-	dgd := &v1alpha1.DynamoGraphDeployment{
+	dgd := &v1beta1.DynamoGraphDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-dgd",
 			Namespace: "default",
@@ -432,7 +457,7 @@ func TestDynamoGraphDeploymentScalingAdapterReconciler_findAdaptersForDGD(t *tes
 	}
 
 	// Adapters belonging to test-dgd
-	adapter1 := &v1alpha1.DynamoGraphDeploymentScalingAdapter{
+	adapter1 := &v1beta1.DynamoGraphDeploymentScalingAdapter{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-dgd-frontend",
 			Namespace: "default",
@@ -440,15 +465,15 @@ func TestDynamoGraphDeploymentScalingAdapterReconciler_findAdaptersForDGD(t *tes
 				consts.KubeLabelDynamoGraphDeploymentName: "test-dgd",
 			},
 		},
-		Spec: v1alpha1.DynamoGraphDeploymentScalingAdapterSpec{
-			DGDRef: v1alpha1.DynamoGraphDeploymentServiceRef{
-				Name:        "test-dgd",
-				ServiceName: "Frontend",
+		Spec: v1beta1.DynamoGraphDeploymentScalingAdapterSpec{
+			DGDRef: v1beta1.DynamoGraphDeploymentComponentRef{
+				Name:          "test-dgd",
+				ComponentName: "Frontend",
 			},
 		},
 	}
 
-	adapter2 := &v1alpha1.DynamoGraphDeploymentScalingAdapter{
+	adapter2 := &v1beta1.DynamoGraphDeploymentScalingAdapter{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-dgd-decode",
 			Namespace: "default",
@@ -456,16 +481,30 @@ func TestDynamoGraphDeploymentScalingAdapterReconciler_findAdaptersForDGD(t *tes
 				consts.KubeLabelDynamoGraphDeploymentName: "test-dgd",
 			},
 		},
-		Spec: v1alpha1.DynamoGraphDeploymentScalingAdapterSpec{
-			DGDRef: v1alpha1.DynamoGraphDeploymentServiceRef{
-				Name:        "test-dgd",
-				ServiceName: "decode",
+		Spec: v1beta1.DynamoGraphDeploymentScalingAdapterSpec{
+			DGDRef: v1beta1.DynamoGraphDeploymentComponentRef{
+				Name:          "test-dgd",
+				ComponentName: "decode",
+			},
+		},
+	}
+
+	// Adapter belonging to test-dgd without the optional lookup label
+	adapterUnlabeled := &v1beta1.DynamoGraphDeploymentScalingAdapter{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-dgd-worker",
+			Namespace: "default",
+		},
+		Spec: v1beta1.DynamoGraphDeploymentScalingAdapterSpec{
+			DGDRef: v1beta1.DynamoGraphDeploymentComponentRef{
+				Name:          "test-dgd",
+				ComponentName: "worker",
 			},
 		},
 	}
 
 	// Adapter belonging to different DGD
-	adapterOther := &v1alpha1.DynamoGraphDeploymentScalingAdapter{
+	adapterOther := &v1beta1.DynamoGraphDeploymentScalingAdapter{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "other-dgd-frontend",
 			Namespace: "default",
@@ -473,17 +512,34 @@ func TestDynamoGraphDeploymentScalingAdapterReconciler_findAdaptersForDGD(t *tes
 				consts.KubeLabelDynamoGraphDeploymentName: "other-dgd",
 			},
 		},
-		Spec: v1alpha1.DynamoGraphDeploymentScalingAdapterSpec{
-			DGDRef: v1alpha1.DynamoGraphDeploymentServiceRef{
-				Name:        "other-dgd",
-				ServiceName: "Frontend",
+		Spec: v1beta1.DynamoGraphDeploymentScalingAdapterSpec{
+			DGDRef: v1beta1.DynamoGraphDeploymentComponentRef{
+				Name:          "other-dgd",
+				ComponentName: "Frontend",
+			},
+		},
+	}
+
+	// Adapter with a stale/mismatched label should follow spec.dgdRef.name.
+	adapterMislabeled := &v1beta1.DynamoGraphDeploymentScalingAdapter{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mislabeled-dgd-frontend",
+			Namespace: "default",
+			Labels: map[string]string{
+				consts.KubeLabelDynamoGraphDeploymentName: "test-dgd",
+			},
+		},
+		Spec: v1beta1.DynamoGraphDeploymentScalingAdapterSpec{
+			DGDRef: v1beta1.DynamoGraphDeploymentComponentRef{
+				Name:          "other-dgd",
+				ComponentName: "Frontend",
 			},
 		},
 	}
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme.Scheme).
-		WithObjects(adapter1, adapter2, adapterOther).
+		WithObjects(adapter1, adapter2, adapterUnlabeled, adapterOther, adapterMislabeled).
 		Build()
 
 	r := &DynamoGraphDeploymentScalingAdapterReconciler{
@@ -493,15 +549,16 @@ func TestDynamoGraphDeploymentScalingAdapterReconciler_findAdaptersForDGD(t *tes
 	ctx := context.Background()
 	requests := r.findAdaptersForDGD(ctx, dgd)
 
-	// Should return 2 requests (for test-dgd adapters only)
-	if len(requests) != 2 {
-		t.Errorf("findAdaptersForDGD() returned %d requests, expected 2", len(requests))
+	// Should return 3 requests (for test-dgd adapters only)
+	if len(requests) != 3 {
+		t.Errorf("findAdaptersForDGD() returned %d requests, expected 3", len(requests))
 	}
 
 	// Verify correct adapters are returned
 	expectedNames := map[string]bool{
 		"test-dgd-frontend": true,
 		"test-dgd-decode":   true,
+		"test-dgd-worker":   true,
 	}
 
 	for _, req := range requests {


### PR DESCRIPTION
**Description**
This MR updates the DynamoGraphDeploymentScalingAdapter controller to reconcile the v1beta1 API shape.

Main changes:

- Watches/reconciles v1beta1.DynamoGraphDeploymentScalingAdapter.
- Watches referenced v1beta1.DynamoGraphDeployment objects.
- Uses spec.dgdRef.componentName and spec.components[] instead of the v1alpha1 serviceName / services API.
- Updates DGD component replica counts through the v1beta1 DGD object.
- Updates DGSA tests to use v1beta1 fixtures and coverage for uppercase component names such as Frontend.


<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9194" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Scaling adapters now directly update component replica counts within deployments, replacing the previous service-based approach.
  * Migrated controller APIs from alpha to beta version for improved stability and enhanced component management.
  * Streamlined component discovery and reference handling.

* **Tests**
  * Comprehensive test suite updated to validate new scaling workflows and API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->