### PR TITLE
feat(operator): expose podLabels and podAnnotations on controller-manager

### DIFF
--- a/deploy/helm/charts/platform/components/operator/templates/deployment.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/deployment.yaml
@@ -42,9 +42,15 @@ spec:
       labels:
         control-plane: controller-manager
       {{- include "dynamo-operator.selectorLabels" . | nindent 8 }}
+        {{- with .Values.controllerManager.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       annotations:
         kubectl.kubernetes.io/default-container: manager
         checksum/config: {{ include (print $.Template.BasePath "/operator-config.yaml") . | sha256sum }}
+        {{- with .Values.controllerManager.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/deploy/helm/charts/platform/components/operator/values.yaml
+++ b/deploy/helm/charts/platform/components/operator/values.yaml
@@ -50,6 +50,18 @@ controllerManager:
   tolerations: []
   affinity: {}
 
+  # -- Extra labels to add to the controller-manager pod template.
+  # Useful for unified service tagging conventions
+  # (e.g. Datadog `tags.datadoghq.com/manager.{service,env,version}`)
+  # and external selectors that target the controller pods directly.
+  podLabels: {}
+
+  # -- Extra annotations to add to the controller-manager pod template.
+  # Useful for autodiscovery integrations that key off pod annotations
+  # (e.g. Datadog `ad.datadoghq.com/manager.checks`, Prometheus
+  # `prometheus.io/scrape`) without forking the chart.
+  podAnnotations: {}
+
   # Leader election configuration
   leaderElection:
     # Leader election ID for cluster-wide coordination


### PR DESCRIPTION
#### Overview:

Adds two values keys on the `dynamo-operator` subchart so users can inject pod-level labels and annotations onto the controller-manager Deployment without forking the chart:

- `controllerManager.podLabels` — merged into the pod template `labels:`
- `controllerManager.podAnnotations` — merged into the pod template `annotations:`

Both default to `{}`; rendering is unchanged when unset.

#### Details:

- `values.yaml`: new `controllerManager.podLabels: {}` and `controllerManager.podAnnotations: {}` keys, documented.
- `templates/deployment.yaml`: render the values maps under the existing pod template `labels:` and `annotations:` blocks via `{{- with ... | toYaml | nindent 8 }}`, preserving all existing static keys (`control-plane`, `kubectl.kubernetes.io/default-container`, `checksum/config`, and the chart selector labels).
- No behavior change when the values are empty (default).

Motivation: the pod template's `labels:` and `annotations:` blocks were previously hardcoded, which blocked common observability integrations:

- Datadog autodiscovery via `ad.datadoghq.com/<container>.checks`, `ad.datadoghq.com/<container>.logs` (annotations).
- Datadog Unified Service Tagging via `tags.datadoghq.com/<container>.{service,env,version}` (labels).
- Prometheus pod-level scrape annotations.

The service-endpoints AD path can't filter cleanly to a single container, and the `crd-apply` init container shares the manager image, so per-pod metadata is the cleanest discovery surface. This matches the `extraPodMetadata.{labels,annotations}` pattern already used by DGDs for worker/frontend pods.

Verified locally:

- `helm template` with default values — pod template metadata unchanged.
- `helm template --set-string 'controllerManager.podLabels.tags\.datadoghq\.com/manager\.service=dynamo-operator' --set-string 'controllerManager.podAnnotations.ad\.datadoghq\.com/manager\.checks=hi'` — both keys appear under the existing labels/annotations.
- `helm lint` clean.

#### Where should the reviewer start?

- [`deploy/helm/charts/platform/components/operator/templates/deployment.yaml`](deploy/helm/charts/platform/components/operator/templates/deployment.yaml) — 6-line addition under the existing `labels:` and `annotations:` blocks.
- [`deploy/helm/charts/platform/components/operator/values.yaml`](deploy/helm/charts/platform/components/operator/values.yaml) — new `podLabels: {}` and `podAnnotations: {}` keys on `controllerManager`.

#### Related Issues:

None.