### PR TITLE
fix(ci): pin hf-xet<1.5 to fix model download failures

### DIFF
--- a/container/deps/requirements.test.txt
+++ b/container/deps/requirements.test.txt
@@ -16,8 +16,8 @@ coverage[toml]==7.13.1
 # For IFEval dataset loading in kvbm tests
 datasets==4.4.1
 filelock==3.25.1
-# For faster model downloads
-hf-xet
+# For faster model downloads (pin <1.5 until huggingface_hub adapts to new XetSession API)
+hf-xet<1.5
 # For Kubernetes operations in deploy tests
 kr8s==0.20.13
 kubernetes_asyncio==32.0.0


### PR DESCRIPTION
## Problem

hf-xet 1.5.0 (released 2026-05-06) deprecated the `hf_xet.download_files()` API that `huggingface_hub`'s `snapshot_download()` relies on internally. This causes **all tests requiring model pre-download** to fail with:

```
RuntimeError: Failed to pre-download required Hugging Face models:
hf_xet.download_files() is deprecated. Use XetSession().new_file_download_group().start_download_file() instead.
```

Affected models: Qwen/Qwen2-VL-2B-Instruct, Qwen/Qwen3-0.6B, Qwen/Qwen2.5-VL-7B-Instruct, deepseek-ai/deepseek-llm-7b-base

Result: 31 test errors (all from fixture `predownload_models` in `tests/conftest.py:389`)

## Root Cause

`hf-xet` is unpinned in `container/deps/requirements.test.txt`. The newly released 1.5.0 broke backward compatibility with current `huggingface_hub` by converting a deprecation warning into a hard error.

## Fix

Pin `hf-xet<1.5` until `huggingface_hub` releases a version compatible with the new `XetSession` API.

## Verification

- Tested locally: `pip install hf-xet<1.5 && python -c "from huggingface_hub import snapshot_download; snapshot_download('Qwen/Qwen3-0.6B', ignore_patterns=['*.safetensors'])"` succeeds
- Previous CI runs (before 2026-05-06) with hf-xet 1.4.3 passed model downloads successfully
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9203" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test environment dependencies to ensure compatibility with recent API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->