### PR TITLE
feat(operator): add v1beta1 controller helper plumbing

### DIFF
--- a/deploy/operator/api/v1beta1/common.go
+++ b/deploy/operator/api/v1beta1/common.go
@@ -40,6 +40,17 @@ const (
 	ComponentTypeEPP      ComponentType = "epp"
 )
 
+const (
+	DynamoGraphDeploymentConditionTypeAvailable            = "Available"
+	DynamoGraphDeploymentConditionTypeDynamoComponentReady = "DynamoComponentReady"
+
+	ConditionTypeTopologyLevelsAvailable      = "TopologyLevelsAvailable"
+	ConditionReasonAllTopologyLevelsAvailable = "AllTopologyLevelsAvailable"
+	ConditionReasonTopologyLevelsUnavailable  = "TopologyLevelsUnavailable"
+	ConditionReasonTopologyDefinitionNotFound = "TopologyDefinitionNotFound"
+	ConditionReasonTopologyConditionPending   = "TopologyConditionPending"
+)
+
 // CompilationCacheConfig configures a PVC-backed compilation cache for a component.
 // The operator handles backend-specific mount paths and environment variables so
 // users do not need to hand-wire them into the pod template.

--- a/deploy/operator/api/v1beta1/dynamocomponentdeployment_types.go
+++ b/deploy/operator/api/v1beta1/dynamocomponentdeployment_types.go
@@ -292,6 +292,36 @@ func (s *DynamoComponentDeploymentSharedSpec) GetNumberOfNodes() int32 {
 	return 1
 }
 
+// IsInterPodGMSEnabled reports whether the inter-pod GMS layout is requested.
+func (s *DynamoComponentDeploymentSharedSpec) IsInterPodGMSEnabled() bool {
+	return s.Experimental != nil &&
+		s.Experimental.GPUMemoryService != nil &&
+		s.Experimental.GPUMemoryService.Mode == GMSModeInterPod
+}
+
+// IsInterPodFailoverEnabled reports whether inter-pod GMS failover is configured.
+func (s *DynamoComponentDeploymentSharedSpec) IsInterPodFailoverEnabled() bool {
+	return s.Experimental != nil &&
+		s.Experimental.Failover != nil &&
+		s.Experimental.Failover.Mode == GMSModeInterPod
+}
+
+// GetNumShadows returns the configured number of inter-pod failover shadow engines.
+func (s *DynamoComponentDeploymentSharedSpec) GetNumShadows() int32 {
+	if !s.IsInterPodFailoverEnabled() {
+		return 0
+	}
+	if s.Experimental.Failover.NumShadows < 1 {
+		return 1
+	}
+	return s.Experimental.Failover.NumShadows
+}
+
+// GetTotalEnginePods returns the primary engine plus any configured shadows.
+func (s *DynamoComponentDeploymentSharedSpec) GetTotalEnginePods() int32 {
+	return s.GetNumShadows() + 1
+}
+
 // IsFrontendComponent reports whether this DCD is the Dynamo frontend component.
 func (s *DynamoComponentDeployment) IsFrontendComponent() bool {
 	return s.Spec.ComponentType == ComponentTypeFrontend
@@ -350,7 +380,11 @@ func (s *DynamoComponentDeployment) GetComponentStatuses() map[string]ComponentR
 	if s.Status.Component == nil {
 		return map[string]ComponentReplicaStatus{}
 	}
-	return map[string]ComponentReplicaStatus{s.GetName(): *s.Status.Component}
+	componentName := s.Spec.ComponentName
+	if componentName == "" {
+		componentName = s.GetName()
+	}
+	return map[string]ComponentReplicaStatus{componentName: *s.Status.Component}
 }
 
 // GetState returns "ready" or "not_ready" based on status conditions.

--- a/deploy/operator/internal/dynamo/ingress_types.go
+++ b/deploy/operator/internal/dynamo/ingress_types.go
@@ -5,10 +5,16 @@
 
 package dynamo
 
+// IngressTLSSpec is the internal TLS subset used when preserving v1alpha1
+// ingress behavior while the controllers reconcile v1beta1 objects.
 type IngressTLSSpec struct {
 	SecretName string `json:"secretName,omitempty"`
 }
 
+// IngressSpec is an internal controller compatibility shape for ingress config.
+// It is intentionally not part of the v1beta1 API; it lets the migrated
+// controllers keep reconciling ingress and virtual service resources from
+// preserved v1alpha1 payloads and operator-level defaults.
 type IngressSpec struct {
 	Enabled                    bool              `json:"enabled,omitempty"`
 	Host                       string            `json:"host,omitempty"`
@@ -22,6 +28,8 @@ type IngressSpec struct {
 	IngressControllerClassName *string           `json:"ingressControllerClassName,omitempty"`
 }
 
+// IsVirtualServiceEnabled reports whether this ingress config should reconcile
+// an Istio VirtualService in addition to, or instead of, a Kubernetes Ingress.
 func (i *IngressSpec) IsVirtualServiceEnabled() bool {
 	if i == nil {
 		return false

--- a/deploy/operator/internal/dynamo/ingress_types.go
+++ b/deploy/operator/internal/dynamo/ingress_types.go
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package dynamo
+
+type IngressTLSSpec struct {
+	SecretName string `json:"secretName,omitempty"`
+}
+
+type IngressSpec struct {
+	Enabled                    bool              `json:"enabled,omitempty"`
+	Host                       string            `json:"host,omitempty"`
+	UseVirtualService          bool              `json:"useVirtualService,omitempty"`
+	VirtualServiceGateway      *string           `json:"virtualServiceGateway,omitempty"`
+	HostPrefix                 *string           `json:"hostPrefix,omitempty"`
+	Annotations                map[string]string `json:"annotations,omitempty"`
+	Labels                     map[string]string `json:"labels,omitempty"`
+	TLS                        *IngressTLSSpec   `json:"tls,omitempty"`
+	HostSuffix                 *string           `json:"hostSuffix,omitempty"`
+	IngressControllerClassName *string           `json:"ingressControllerClassName,omitempty"`
+}
+
+func (i *IngressSpec) IsVirtualServiceEnabled() bool {
+	if i == nil {
+		return false
+	}
+	return i.Enabled && i.UseVirtualService && i.VirtualServiceGateway != nil
+}

--- a/deploy/operator/internal/dynamo/v1beta1_helpers.go
+++ b/deploy/operator/internal/dynamo/v1beta1_helpers.go
@@ -1,0 +1,322 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package dynamo
+
+import (
+	"encoding/json"
+	"maps"
+	"strings"
+
+	v1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+const (
+	preservedDCDAnnotationPrefix           = "nvidia.com/dcd-"
+	preservedDCDAlphaSpecAnnotation        = "nvidia.com/dcd-spec"
+	preservedDCDServiceNameAnnotation      = preservedDCDAnnotationPrefix + "service-name"
+	preservedDCDDynamoNamespaceAnnotation  = preservedDCDAnnotationPrefix + "dynamo-namespace"
+	preservedDCDSubComponentTypeAnnotation = preservedDCDAnnotationPrefix + "sub-component-type"
+	PreservedDCDAnnotationsAnnotation      = preservedDCDAnnotationPrefix + "annotations"
+	PreservedDCDLabelsAnnotation           = preservedDCDAnnotationPrefix + "labels"
+	PreservedDCDIngressAnnotation          = preservedDCDAnnotationPrefix + "ingress"
+)
+
+func IsPreservedDCDAnnotation(key string) bool {
+	return strings.HasPrefix(key, preservedDCDAnnotationPrefix)
+}
+
+func ComponentsByName(dgd *v1beta1.DynamoGraphDeployment) map[string]*v1beta1.DynamoComponentDeploymentSharedSpec {
+	components := make(map[string]*v1beta1.DynamoComponentDeploymentSharedSpec, len(dgd.Spec.Components))
+	for i := range dgd.Spec.Components {
+		component := &dgd.Spec.Components[i]
+		components[component.ComponentName] = component
+	}
+	return components
+}
+
+func GetPodTemplateAnnotations(component *v1beta1.DynamoComponentDeploymentSharedSpec) map[string]string {
+	if component == nil || component.PodTemplate == nil {
+		return nil
+	}
+	return component.PodTemplate.Annotations
+}
+
+func GetPodTemplateLabels(component *v1beta1.DynamoComponentDeploymentSharedSpec) map[string]string {
+	if component == nil || component.PodTemplate == nil {
+		return nil
+	}
+	return component.PodTemplate.Labels
+}
+
+func ensurePodTemplate(component *v1beta1.DynamoComponentDeploymentSharedSpec) *corev1.PodTemplateSpec {
+	if component.PodTemplate == nil {
+		component.PodTemplate = &corev1.PodTemplateSpec{}
+	}
+	if component.PodTemplate.Labels == nil {
+		component.PodTemplate.Labels = map[string]string{}
+	}
+	if component.PodTemplate.Annotations == nil {
+		component.PodTemplate.Annotations = map[string]string{}
+	}
+	return component.PodTemplate
+}
+
+func ensureMainContainer(podTemplate *corev1.PodTemplateSpec) *corev1.Container {
+	for i := range podTemplate.Spec.Containers {
+		if podTemplate.Spec.Containers[i].Name == commonconsts.MainContainerName {
+			return &podTemplate.Spec.Containers[i]
+		}
+	}
+	podTemplate.Spec.Containers = append([]corev1.Container{{Name: commonconsts.MainContainerName}}, podTemplate.Spec.Containers...)
+	return &podTemplate.Spec.Containers[0]
+}
+
+func GetMainContainer(component *v1beta1.DynamoComponentDeploymentSharedSpec) *corev1.Container {
+	if component == nil || component.PodTemplate == nil {
+		return nil
+	}
+	for i := range component.PodTemplate.Spec.Containers {
+		if component.PodTemplate.Spec.Containers[i].Name == commonconsts.MainContainerName {
+			return &component.PodTemplate.Spec.Containers[i]
+		}
+	}
+	return nil
+}
+
+func GetMainContainerResources(component *v1beta1.DynamoComponentDeploymentSharedSpec) corev1.ResourceRequirements {
+	if main := GetMainContainer(component); main != nil {
+		return main.Resources
+	}
+	return corev1.ResourceRequirements{}
+}
+
+func GetGPUMemoryService(component *v1beta1.DynamoComponentDeploymentSharedSpec) *v1beta1.GPUMemoryServiceSpec {
+	if component == nil || component.Experimental == nil {
+		return nil
+	}
+	return component.Experimental.GPUMemoryService
+}
+
+func GetCheckpoint(component *v1beta1.DynamoComponentDeploymentSharedSpec) *v1beta1.ComponentCheckpointConfig {
+	if component == nil || component.Experimental == nil {
+		return nil
+	}
+	return component.Experimental.Checkpoint
+}
+
+func ToAlphaCheckpointConfig(src *v1beta1.ComponentCheckpointConfig) *v1alpha1.ServiceCheckpointConfig {
+	if src == nil {
+		return nil
+	}
+	dst := &v1alpha1.ServiceCheckpointConfig{
+		Enabled:       true,
+		Mode:          v1alpha1.CheckpointMode(src.Mode),
+		CheckpointRef: src.CheckpointRef,
+		Identity:      ToAlphaCheckpointIdentity(src.Identity),
+	}
+	return dst
+}
+
+func ToAlphaCheckpointIdentity(src *v1beta1.DynamoCheckpointIdentity) *v1alpha1.DynamoCheckpointIdentity {
+	if src == nil {
+		return nil
+	}
+	return &v1alpha1.DynamoCheckpointIdentity{
+		Model:                src.Model,
+		BackendFramework:     src.BackendFramework,
+		DynamoVersion:        src.DynamoVersion,
+		TensorParallelSize:   src.TensorParallelSize,
+		PipelineParallelSize: src.PipelineParallelSize,
+		Dtype:                src.Dtype,
+		MaxModelLen:          src.MaxModelLen,
+		ExtraParameters:      src.ExtraParameters,
+	}
+}
+
+func ToAlphaGPUMemoryService(src *v1beta1.GPUMemoryServiceSpec) *v1alpha1.GPUMemoryServiceSpec {
+	if src == nil {
+		return nil
+	}
+	return &v1alpha1.GPUMemoryServiceSpec{
+		Enabled:         true,
+		Mode:            v1alpha1.GPUMemoryServiceMode(src.Mode),
+		DeviceClassName: src.DeviceClassName,
+	}
+}
+
+func ToBetaSharedMemorySize(src *v1alpha1.SharedMemorySpec) *resource.Quantity {
+	if src == nil {
+		return nil
+	}
+	if src.Disabled {
+		zero := resource.MustParse("0")
+		return &zero
+	}
+	if src.Size.IsZero() {
+		return nil
+	}
+	size := src.Size.DeepCopy()
+	return &size
+}
+
+func GetDCDComponentName(dcd *v1beta1.DynamoComponentDeployment) string {
+	if dcd == nil {
+		return ""
+	}
+	if dcd.Spec.ComponentName != "" {
+		return dcd.Spec.ComponentName
+	}
+	if dcd.Labels != nil {
+		if componentName := dcd.Labels[commonconsts.KubeLabelDynamoComponent]; componentName != "" {
+			return componentName
+		}
+	}
+	if serviceName := dcd.GetAnnotations()[preservedDCDServiceNameAnnotation]; serviceName != "" {
+		return serviceName
+	}
+	return dcd.Name
+}
+
+func GetDCDDynamoNamespace(dcd *v1beta1.DynamoComponentDeployment) string {
+	if dcd == nil {
+		return ""
+	}
+	if spec := getDCDPreservedAlphaSpec(dcd); spec != nil {
+		if spec.DynamoNamespace != nil {
+			return *spec.DynamoNamespace
+		}
+	} else if dynamoNamespace := dcd.GetAnnotations()[preservedDCDDynamoNamespaceAnnotation]; dynamoNamespace != "" {
+		return dynamoNamespace
+	}
+	if dcd.Labels != nil {
+		if dynamoNamespace := dcd.Labels[commonconsts.KubeLabelDynamoNamespace]; dynamoNamespace != "" {
+			return dynamoNamespace
+		}
+	}
+	parentName := dcd.GetParentGraphDeploymentName()
+	if parentName == "" {
+		parentName = dcd.Name
+	}
+	return v1beta1.ComputeDynamoNamespace(dcd.Spec.GlobalDynamoNamespace, dcd.GetNamespace(), parentName)
+}
+
+func GetDCDSubComponentType(dcd *v1beta1.DynamoComponentDeployment) string {
+	if dcd == nil {
+		return ""
+	}
+	if spec := getDCDPreservedAlphaSpec(dcd); spec != nil {
+		return spec.SubComponentType
+	}
+	if subComponentType := dcd.GetAnnotations()[preservedDCDSubComponentTypeAnnotation]; subComponentType != "" {
+		return subComponentType
+	}
+	return ""
+}
+
+func GetDCDPreservedAlphaAnnotations(dcd *v1beta1.DynamoComponentDeployment) map[string]string {
+	if spec := getDCDPreservedAlphaSpec(dcd); spec != nil {
+		return maps.Clone(spec.Annotations)
+	}
+	if values := getDCDPreservedStringMapAnnotation(dcd, PreservedDCDAnnotationsAnnotation); values != nil {
+		return values
+	}
+	return nil
+}
+
+func GetDCDPreservedAlphaLabels(dcd *v1beta1.DynamoComponentDeployment) map[string]string {
+	if spec := getDCDPreservedAlphaSpec(dcd); spec != nil {
+		return maps.Clone(spec.Labels)
+	}
+	if values := getDCDPreservedStringMapAnnotation(dcd, PreservedDCDLabelsAnnotation); values != nil {
+		return values
+	}
+	return nil
+}
+
+func GetDCDPreservedAlphaIngressSpec(dcd *v1beta1.DynamoComponentDeployment) (IngressSpec, bool, error) {
+	if dcd == nil {
+		return IngressSpec{}, false, nil
+	}
+	spec := getDCDPreservedAlphaSpec(dcd)
+	if spec != nil {
+		if spec.Ingress == nil {
+			return IngressSpec{}, false, nil
+		}
+		data, err := json.Marshal(spec.Ingress)
+		if err != nil {
+			return IngressSpec{}, false, err
+		}
+		var ingressSpec IngressSpec
+		if err := json.Unmarshal(data, &ingressSpec); err != nil {
+			return IngressSpec{}, false, err
+		}
+		return ingressSpec, true, nil
+	}
+	raw := dcd.GetAnnotations()[PreservedDCDIngressAnnotation]
+	if raw == "" {
+		return IngressSpec{}, false, nil
+	}
+	var ingressSpec IngressSpec
+	if err := json.Unmarshal([]byte(raw), &ingressSpec); err != nil {
+		return IngressSpec{}, false, err
+	}
+	return ingressSpec, true, nil
+}
+
+func getDCDPreservedStringMapAnnotation(dcd *v1beta1.DynamoComponentDeployment, key string) map[string]string {
+	if dcd == nil {
+		return nil
+	}
+	raw := dcd.GetAnnotations()[key]
+	if raw == "" {
+		return nil
+	}
+	var values map[string]string
+	if err := json.Unmarshal([]byte(raw), &values); err != nil {
+		return nil
+	}
+	return values
+}
+
+func getDCDPreservedAlphaSpec(dcd *v1beta1.DynamoComponentDeployment) *v1alpha1.DynamoComponentDeploymentSharedSpec {
+	if dcd == nil {
+		return nil
+	}
+	raw := dcd.GetAnnotations()[preservedDCDAlphaSpecAnnotation]
+	if raw == "" {
+		return nil
+	}
+	var envelope struct {
+		Spec *v1alpha1.DynamoComponentDeploymentSpec `json:"spec"`
+	}
+	if err := json.Unmarshal([]byte(raw), &envelope); err == nil && envelope.Spec != nil {
+		return &envelope.Spec.DynamoComponentDeploymentSharedSpec
+	}
+	var spec v1alpha1.DynamoComponentDeploymentSpec
+	if err := json.Unmarshal([]byte(raw), &spec); err != nil {
+		return nil
+	}
+	return &spec.DynamoComponentDeploymentSharedSpec
+}
+
+func mergeLowPriorityMetadata(dst, src map[string]string) map[string]string {
+	if len(src) == 0 {
+		return dst
+	}
+	if dst == nil {
+		dst = map[string]string{}
+	}
+	for k, v := range src {
+		if _, exists := dst[k]; !exists {
+			dst[k] = v
+		}
+	}
+	return dst
+}

--- a/deploy/operator/internal/dynamo/v1beta1_helpers.go
+++ b/deploy/operator/internal/dynamo/v1beta1_helpers.go
@@ -55,29 +55,6 @@ func GetPodTemplateLabels(component *v1beta1.DynamoComponentDeploymentSharedSpec
 	return component.PodTemplate.Labels
 }
 
-func ensurePodTemplate(component *v1beta1.DynamoComponentDeploymentSharedSpec) *corev1.PodTemplateSpec {
-	if component.PodTemplate == nil {
-		component.PodTemplate = &corev1.PodTemplateSpec{}
-	}
-	if component.PodTemplate.Labels == nil {
-		component.PodTemplate.Labels = map[string]string{}
-	}
-	if component.PodTemplate.Annotations == nil {
-		component.PodTemplate.Annotations = map[string]string{}
-	}
-	return component.PodTemplate
-}
-
-func ensureMainContainer(podTemplate *corev1.PodTemplateSpec) *corev1.Container {
-	for i := range podTemplate.Spec.Containers {
-		if podTemplate.Spec.Containers[i].Name == commonconsts.MainContainerName {
-			return &podTemplate.Spec.Containers[i]
-		}
-	}
-	podTemplate.Spec.Containers = append([]corev1.Container{{Name: commonconsts.MainContainerName}}, podTemplate.Spec.Containers...)
-	return &podTemplate.Spec.Containers[0]
-}
-
 func GetMainContainer(component *v1beta1.DynamoComponentDeploymentSharedSpec) *corev1.Container {
 	if component == nil || component.PodTemplate == nil {
 		return nil

--- a/deploy/operator/internal/dynamo/v1beta1_helpers_test.go
+++ b/deploy/operator/internal/dynamo/v1beta1_helpers_test.go
@@ -1,0 +1,293 @@
+package dynamo
+
+import (
+	"encoding/json"
+	"maps"
+	"testing"
+
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+func TestGetDCDComponentNamePrefersSpecOverLegacyMetadata(t *testing.T) {
+	dcd := &v1beta1.DynamoComponentDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "metadata-name",
+			Labels: map[string]string{
+				commonconsts.KubeLabelDynamoComponent: "label-component",
+			},
+			Annotations: map[string]string{
+				preservedDCDServiceNameAnnotation: "annotation-component",
+			},
+		},
+		Spec: v1beta1.DynamoComponentDeploymentSpec{
+			DynamoComponentDeploymentSharedSpec: v1beta1.DynamoComponentDeploymentSharedSpec{
+				ComponentName: "spec-component",
+			},
+		},
+	}
+
+	if got, want := GetDCDComponentName(dcd), "spec-component"; got != want {
+		t.Fatalf("GetDCDComponentName() = %q, want %q", got, want)
+	}
+}
+
+func TestGetDCDComponentNameLegacyFallbacks(t *testing.T) {
+	tests := []struct {
+		name string
+		dcd  *v1beta1.DynamoComponentDeployment
+		want string
+	}{
+		{
+			name: "nil",
+			want: "",
+		},
+		{
+			name: "label",
+			dcd: &v1beta1.DynamoComponentDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "metadata-name",
+					Labels: map[string]string{
+						commonconsts.KubeLabelDynamoComponent: "label-component",
+					},
+					Annotations: map[string]string{
+						preservedDCDServiceNameAnnotation: "annotation-component",
+					},
+				},
+			},
+			want: "label-component",
+		},
+		{
+			name: "annotation",
+			dcd: &v1beta1.DynamoComponentDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "metadata-name",
+					Annotations: map[string]string{
+						preservedDCDServiceNameAnnotation: "annotation-component",
+					},
+				},
+			},
+			want: "annotation-component",
+		},
+		{
+			name: "metadata name",
+			dcd: &v1beta1.DynamoComponentDeployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "metadata-name"},
+			},
+			want: "metadata-name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetDCDComponentName(tt.dcd); got != tt.want {
+				t.Fatalf("GetDCDComponentName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPreservedAlphaSpecTakesPrecedenceOverLegacyCarrierAnnotations(t *testing.T) {
+	dynamoNamespace := "canonical-namespace"
+	alphaSpec := v1alpha1.DynamoComponentDeploymentSpec{
+		DynamoComponentDeploymentSharedSpec: v1alpha1.DynamoComponentDeploymentSharedSpec{
+			Annotations:      map[string]string{"canonical-annotation": "kept"},
+			Labels:           map[string]string{"canonical-label": "kept"},
+			DynamoNamespace:  &dynamoNamespace,
+			SubComponentType: "canonical-sub",
+			Ingress: &v1alpha1.IngressSpec{
+				Enabled:                    true,
+				Host:                       "canonical.example.com",
+				IngressControllerClassName: ptr.To("nginx"),
+			},
+		},
+	}
+	dcd := dcdWithPreservedAlphaSpec(t, alphaSpec, true)
+	dcd.Labels = map[string]string{
+		commonconsts.KubeLabelDynamoNamespace: "label-namespace",
+	}
+	dcd.Annotations[preservedDCDDynamoNamespaceAnnotation] = "stale-namespace"
+	dcd.Annotations[preservedDCDSubComponentTypeAnnotation] = "stale-sub"
+	dcd.Annotations[PreservedDCDAnnotationsAnnotation] = mustJSON(t, map[string]string{"stale-annotation": "ignored"})
+	dcd.Annotations[PreservedDCDLabelsAnnotation] = mustJSON(t, map[string]string{"stale-label": "ignored"})
+	dcd.Annotations[PreservedDCDIngressAnnotation] = mustJSON(t, IngressSpec{Enabled: true, Host: "stale.example.com"})
+
+	if got := GetDCDDynamoNamespace(dcd); got != "canonical-namespace" {
+		t.Fatalf("GetDCDDynamoNamespace() = %q, want canonical-namespace", got)
+	}
+	if got := GetDCDSubComponentType(dcd); got != "canonical-sub" {
+		t.Fatalf("GetDCDSubComponentType() = %q, want canonical-sub", got)
+	}
+	if got, want := GetDCDPreservedAlphaAnnotations(dcd), alphaSpec.Annotations; !maps.Equal(got, want) {
+		t.Fatalf("GetDCDPreservedAlphaAnnotations() = %#v, want %#v", got, want)
+	}
+	if got, want := GetDCDPreservedAlphaLabels(dcd), alphaSpec.Labels; !maps.Equal(got, want) {
+		t.Fatalf("GetDCDPreservedAlphaLabels() = %#v, want %#v", got, want)
+	}
+	ingressSpec, ok, err := GetDCDPreservedAlphaIngressSpec(dcd)
+	if err != nil {
+		t.Fatalf("GetDCDPreservedAlphaIngressSpec() error = %v", err)
+	}
+	if !ok || !ingressSpec.Enabled || ingressSpec.Host != "canonical.example.com" || ingressSpec.IngressControllerClassName == nil || *ingressSpec.IngressControllerClassName != "nginx" {
+		t.Fatalf("GetDCDPreservedAlphaIngressSpec() = (%#v, %v), want canonical ingress", ingressSpec, ok)
+	}
+}
+
+func TestPreservedAlphaHelpersFallbackToLegacyCarrierAnnotations(t *testing.T) {
+	dcd := &v1beta1.DynamoComponentDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dcd",
+			Namespace: "test-ns",
+			Annotations: map[string]string{
+				preservedDCDDynamoNamespaceAnnotation:  "legacy-namespace",
+				preservedDCDSubComponentTypeAnnotation: "legacy-sub",
+				PreservedDCDAnnotationsAnnotation:      mustJSON(t, map[string]string{"legacy-annotation": "kept"}),
+				PreservedDCDLabelsAnnotation:           mustJSON(t, map[string]string{"legacy-label": "kept"}),
+				PreservedDCDIngressAnnotation:          mustJSON(t, IngressSpec{Enabled: true, Host: "legacy.example.com"}),
+			},
+			Labels: map[string]string{
+				commonconsts.KubeLabelDynamoNamespace: "label-namespace",
+			},
+		},
+	}
+
+	if got := GetDCDDynamoNamespace(dcd); got != "legacy-namespace" {
+		t.Fatalf("GetDCDDynamoNamespace() = %q, want legacy-namespace", got)
+	}
+	if got := GetDCDSubComponentType(dcd); got != "legacy-sub" {
+		t.Fatalf("GetDCDSubComponentType() = %q, want legacy-sub", got)
+	}
+	if got, want := GetDCDPreservedAlphaAnnotations(dcd), map[string]string{"legacy-annotation": "kept"}; !maps.Equal(got, want) {
+		t.Fatalf("GetDCDPreservedAlphaAnnotations() = %#v, want %#v", got, want)
+	}
+	if got, want := GetDCDPreservedAlphaLabels(dcd), map[string]string{"legacy-label": "kept"}; !maps.Equal(got, want) {
+		t.Fatalf("GetDCDPreservedAlphaLabels() = %#v, want %#v", got, want)
+	}
+	ingressSpec, ok, err := GetDCDPreservedAlphaIngressSpec(dcd)
+	if err != nil {
+		t.Fatalf("GetDCDPreservedAlphaIngressSpec() error = %v", err)
+	}
+	if !ok || ingressSpec.Host != "legacy.example.com" {
+		t.Fatalf("GetDCDPreservedAlphaIngressSpec() = (%#v, %v), want legacy ingress", ingressSpec, ok)
+	}
+}
+
+func TestGetDCDPreservedAlphaSpecSupportsEnvelopeAndRawSpec(t *testing.T) {
+	dynamoNamespace := "raw-namespace"
+	alphaSpec := v1alpha1.DynamoComponentDeploymentSpec{
+		DynamoComponentDeploymentSharedSpec: v1alpha1.DynamoComponentDeploymentSharedSpec{
+			DynamoNamespace:  &dynamoNamespace,
+			SubComponentType: "raw-sub",
+		},
+	}
+
+	envelopeDCD := dcdWithPreservedAlphaSpec(t, alphaSpec, true)
+	if got := getDCDPreservedAlphaSpec(envelopeDCD); got == nil || got.SubComponentType != "raw-sub" {
+		t.Fatalf("envelope getDCDPreservedAlphaSpec() = %#v, want raw-sub", got)
+	}
+
+	rawDCD := dcdWithPreservedAlphaSpec(t, alphaSpec, false)
+	if got := getDCDPreservedAlphaSpec(rawDCD); got == nil || got.DynamoNamespace == nil || *got.DynamoNamespace != "raw-namespace" {
+		t.Fatalf("raw getDCDPreservedAlphaSpec() = %#v, want raw-namespace", got)
+	}
+}
+
+func TestGetDCDPreservedAlphaIngressSpecReturnsMalformedAnnotationError(t *testing.T) {
+	dcd := &v1beta1.DynamoComponentDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				PreservedDCDIngressAnnotation: "{",
+			},
+		},
+	}
+
+	if _, _, err := GetDCDPreservedAlphaIngressSpec(dcd); err == nil {
+		t.Fatalf("GetDCDPreservedAlphaIngressSpec() error = nil, want malformed JSON error")
+	}
+}
+
+func TestToAlphaCheckpointConfigSetsNilIdentityThroughConverter(t *testing.T) {
+	got := ToAlphaCheckpointConfig(&v1beta1.ComponentCheckpointConfig{
+		Mode:          v1beta1.CheckpointMode("auto"),
+		CheckpointRef: ptr.To("checkpoint"),
+	})
+	if got == nil {
+		t.Fatalf("ToAlphaCheckpointConfig() = nil")
+	}
+	if got.Identity != nil {
+		t.Fatalf("ToAlphaCheckpointConfig().Identity = %#v, want nil", got.Identity)
+	}
+}
+
+func TestToBetaSharedMemorySize(t *testing.T) {
+	size := resource.MustParse("2Gi")
+	tests := []struct {
+		name string
+		src  *v1alpha1.SharedMemorySpec
+		want string
+	}{
+		{name: "nil"},
+		{name: "zero size", src: &v1alpha1.SharedMemorySpec{}},
+		{name: "disabled", src: &v1alpha1.SharedMemorySpec{Disabled: true}, want: "0"},
+		{name: "size", src: &v1alpha1.SharedMemorySpec{Size: size}, want: "2Gi"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ToBetaSharedMemorySize(tt.src)
+			if tt.want == "" {
+				if got != nil {
+					t.Fatalf("ToBetaSharedMemorySize() = %s, want nil", got.String())
+				}
+				return
+			}
+			if got == nil || got.String() != tt.want {
+				t.Fatalf("ToBetaSharedMemorySize() = %v, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMergeLowPriorityMetadata(t *testing.T) {
+	got := mergeLowPriorityMetadata(
+		map[string]string{"existing": "kept", "shared": "winner"},
+		map[string]string{"shared": "ignored", "new": "added"},
+	)
+	want := map[string]string{"existing": "kept", "shared": "winner", "new": "added"}
+	if !maps.Equal(got, want) {
+		t.Fatalf("mergeLowPriorityMetadata() = %#v, want %#v", got, want)
+	}
+}
+
+func dcdWithPreservedAlphaSpec(t *testing.T, spec v1alpha1.DynamoComponentDeploymentSpec, envelope bool) *v1beta1.DynamoComponentDeployment {
+	t.Helper()
+
+	var value any = spec
+	if envelope {
+		value = struct {
+			Spec v1alpha1.DynamoComponentDeploymentSpec `json:"spec"`
+		}{Spec: spec}
+	}
+	return &v1beta1.DynamoComponentDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "dcd",
+			Annotations: map[string]string{
+				preservedDCDAlphaSpecAnnotation: mustJSON(t, value),
+			},
+		},
+	}
+}
+
+func mustJSON(t *testing.T, value any) string {
+	t.Helper()
+
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("json.Marshal(%#v) error = %v", value, err)
+	}
+	return string(data)
+}


### PR DESCRIPTION
This MR adds the shared v1beta1 helper layer needed by the remaining controller migration work.

**Overview**
Introduces reusable helpers for working with the v1beta1 DGD/DCD API shape, including component naming, ingress normalization, shared metadata handling, pod-template accessors, and v1alpha1 compatibility shims.

**Details**

Adds v1beta1 helper utilities under internal/dynamo.
Adds shared ingress helper types used by both DGD and DCD reconciliation paths.
Adds tests for the new helper behavior.
Keeps compatibility logic centralized so later controller MRs can avoid duplicating v1alpha1 preservation/defaulting rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for inter-pod GPU memory service and failover configuration management.
  * Introduced new deployment condition types and topology-level availability tracking for enhanced operational visibility.
  * Expanded ingress configuration capabilities with TLS and virtual service support.
  * Improved component naming and deployment status tracking mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->