### PR TITLE
fix(operator): Preserve legacy DGD worker hash across v1beta1 conversion

### DIFF
--- a/deploy/operator/api/CONVERSION.md
+++ b/deploy/operator/api/CONVERSION.md
@@ -64,6 +64,39 @@ return preserved if annotation exists
 
 ## Structural Helpers
 
+Conversion policy belongs in the API conversion package. Do not put conversion
+logic in controllers, internal helper packages, or compatibility wrappers. If a
+controller temporarily needs converted data while versions are being reconciled,
+it should call the same conversion function that the real conversion path uses.
+Read-only getters are acceptable outside the API package; conversion helpers
+are not.
+
+Exported conversion helpers in the `v1alpha1` package use the spoke type name:
+
+```go
+func ConvertTo<TypeName>(src *v1beta1.HubType, dst *TypeName)
+func ConvertFrom<TypeName>(src *TypeName, dst *v1beta1.HubType)
+```
+
+Do not include `V1alpha1` in these names; the package already says that. Do not
+add wrapper functions with alternative names. Callers that need this behavior
+should call the structural helper directly.
+
+The paired `ConvertTo<TypeName>` and `ConvertFrom<TypeName>` functions must use
+the same structural signature: source pointer first, destination pointer second,
+and an optional typed context argument only at the end. The destination must be
+non-nil and owned by the caller. The conversion function writes into `dst`; it
+does not allocate `dst`, does not accept `**T`, and does not encode absence by
+assigning nil. Callers perform nil, disabled, zero, or absence checks before
+calling the helper and allocate destination subobjects explicitly.
+
+Conversion helpers must mirror the API type structure. If a converted type has
+a nested sub-struct that needs conversion, add the corresponding structural
+`ConvertTo<SubStruct>` and `ConvertFrom<SubStruct>` pair as well. Do not skip a
+sub-struct and inline its conversion somewhere else because it currently looks
+small. The point is to make every conversion edge systematic, discoverable, and
+usable by both generated-style conversion flow and temporary controller code.
+
 Conversion helpers should generally follow a `src`, `dst`, `restored`, `save`,
 `ctx` shape:
 
@@ -130,6 +163,19 @@ as `preserve` for conversion policy: use `restore` when reading `restored`, and
 
 Preservation annotations exist only to make unrepresentable data survive a
 round trip through a version that cannot express it natively.
+
+Preservation annotations are private to conversion code. Only API conversion
+code and its conversion tests may know their keys or payload shape. Controllers,
+reconcilers, webhooks, internal helper packages, and general API helpers must
+not read, write, delete, filter, decode, encode, branch on, or expose them.
+Do not define shared constants, prefixes, string literals, getters, predicates,
+or wrapper helpers for conversion annotations outside the conversion package.
+
+Non-conversion code may copy Kubernetes metadata opaquely as part of normal
+object handling, but it must not identify or interpret individual conversion
+annotations. If non-conversion code needs data that currently appears only in a
+preservation annotation, add or call a real conversion helper instead of
+decoding the annotation.
 
 It is acceptable for the annotation payload to include representable fields as
 context. Restore code must explicitly ignore those fields unless they are needed
@@ -292,11 +338,24 @@ For each helper:
 - Are named-list fields matched by their list-map key, never by index?
 - Is the save payload sparse?
 - Are origin annotations used only as hints, not as shortcuts?
+- Are conversion annotations private to conversion code and absent from
+  controllers/internal helpers?
 - Are nil and empty shapes preserved where round-trip tests require them?
 
 ## Mutability
 
 Conversion functions must not mutate their input object.
+
+`src` and `dst` may share backing data when the converted value can be assigned
+as-is. Do not add `DeepCopy` calls only because a field came from `src`.
+Aliasing is acceptable when the conversion code treats the shared value as
+read-only after assignment.
+
+Use `DeepCopy` only when the conversion needs an independently mutable value:
+for example, before editing, appending to, sorting, normalizing, clearing,
+merging into, or otherwise mutating a value that came from `src`. This applies
+equally to direct mutation through `src` and indirect mutation through a `dst`
+field that aliases `src`; both violate the "do not mutate input" invariant.
 
 The round-trip fuzz tests snapshot inputs through YAML before conversion because
 marshalling observes the actual in-memory shape, including aliasing bugs that a

--- a/deploy/operator/api/v1alpha1/dynamographdeployment_conversion.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeployment_conversion.go
@@ -72,6 +72,13 @@ func (src *DynamoGraphDeployment) ConvertTo(dstRaw conversion.Hub) error {
 	}
 	hubOrigin := restoredHubSpec != nil
 	scrubDGDInternalAnnotations(&dst.ObjectMeta)
+	if hash, ok := getAnnFromObj(&src.ObjectMeta, annCurrentWorkerHash); ok && hash != "" {
+		legacyHash, err := computeLegacyDGDWorkersSpecHash(src)
+		if err != nil {
+			return fmt.Errorf("compute legacy DGD worker hash: %w", err)
+		}
+		setAnnOnObj(&dst.ObjectMeta, AnnotationDGDLegacyWorkerHash, legacyHash)
+	}
 
 	ctx := dgdConversionContext{
 		includeOriginSplits: !hubOrigin,
@@ -518,6 +525,7 @@ func scrubDGDInternalAnnotations(obj metav1.Object) {
 	for _, key := range []string{
 		annDGDSpec,
 		annDGDStatus,
+		AnnotationDGDLegacyWorkerHash,
 	} {
 		delAnnFromObj(obj, key)
 	}

--- a/deploy/operator/api/v1alpha1/dynamographdeployment_conversion.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeployment_conversion.go
@@ -73,9 +73,9 @@ func (src *DynamoGraphDeployment) ConvertTo(dstRaw conversion.Hub) error {
 	hubOrigin := restoredHubSpec != nil
 	scrubDGDInternalAnnotations(&dst.ObjectMeta)
 	if hash, ok := getAnnFromObj(&src.ObjectMeta, annCurrentWorkerHash); ok && hash != "" {
-		legacyHash, err := computeLegacyDGDWorkersSpecHash(src)
+		legacyHash, err := ComputeV1alpha1DGDWorkersSpecHash(src)
 		if err != nil {
-			return fmt.Errorf("compute legacy DGD worker hash: %w", err)
+			return fmt.Errorf("compute v1alpha1 DGD worker hash: %w", err)
 		}
 		setAnnOnObj(&dst.ObjectMeta, AnnotationDGDLegacyWorkerHash, legacyHash)
 	}

--- a/deploy/operator/api/v1alpha1/dynamographdeployment_conversion.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeployment_conversion.go
@@ -73,7 +73,7 @@ func (src *DynamoGraphDeployment) ConvertTo(dstRaw conversion.Hub) error {
 	hubOrigin := restoredHubSpec != nil
 	scrubDGDInternalAnnotations(&dst.ObjectMeta)
 	if hash, ok := getAnnFromObj(&src.ObjectMeta, annCurrentWorkerHash); ok && hash != "" {
-		legacyHash, err := ComputeV1alpha1DGDWorkersSpecHash(src)
+		legacyHash, err := ComputeDGDWorkersSpecHash(src)
 		if err != nil {
 			return fmt.Errorf("compute v1alpha1 DGD worker hash: %w", err)
 		}

--- a/deploy/operator/api/v1alpha1/legacy_worker_hash.go
+++ b/deploy/operator/api/v1alpha1/legacy_worker_hash.go
@@ -17,10 +17,17 @@ const (
 	annCurrentWorkerHash          = "nvidia.com/current-worker-hash"
 )
 
-func computeLegacyDGDWorkersSpecHash(dgd *DynamoGraphDeployment) (string, error) {
+// ComputeV1alpha1DGDWorkersSpecHash computes the worker hash used by the
+// v1alpha1 DGD controller before v1beta1 conversion. ConvertTo stores this
+// value on the v1beta1 hub object so the v1beta1 controller can migrate
+// existing v1alpha1 hashes without rolling workers.
+//
+// Keep this in the api/v1alpha1 package so conversion can call it without an
+// api/v1alpha1 -> internal/dynamo -> api/v1alpha1 import cycle.
+func ComputeV1alpha1DGDWorkersSpecHash(dgd *DynamoGraphDeployment) (string, error) {
 	var workerNames []string
 	for name, spec := range dgd.Spec.Services {
-		if spec != nil && isLegacyWorkerComponent(spec.ComponentType) {
+		if spec != nil && isV1alpha1WorkerComponent(spec.ComponentType) {
 			workerNames = append(workerNames, name)
 		}
 	}
@@ -28,7 +35,7 @@ func computeLegacyDGDWorkersSpecHash(dgd *DynamoGraphDeployment) (string, error)
 
 	hashInputs := make(map[string]DynamoComponentDeploymentSharedSpec)
 	for _, name := range workerNames {
-		hashInputs[name] = stripLegacyNonPodTemplateFields(dgd.Spec.Services[name])
+		hashInputs[name] = stripV1alpha1NonPodTemplateFields(dgd.Spec.Services[name])
 	}
 
 	data, err := json.Marshal(hashInputs)
@@ -40,11 +47,11 @@ func computeLegacyDGDWorkersSpecHash(dgd *DynamoGraphDeployment) (string, error)
 	return hex.EncodeToString(hash[:])[:8], nil
 }
 
-func isLegacyWorkerComponent(componentType string) bool {
+func isV1alpha1WorkerComponent(componentType string) bool {
 	return componentType == "worker" || componentType == "prefill" || componentType == "decode"
 }
 
-func stripLegacyNonPodTemplateFields(spec *DynamoComponentDeploymentSharedSpec) DynamoComponentDeploymentSharedSpec {
+func stripV1alpha1NonPodTemplateFields(spec *DynamoComponentDeploymentSharedSpec) DynamoComponentDeploymentSharedSpec {
 	stripped := *spec
 
 	stripped.Annotations = nil

--- a/deploy/operator/api/v1alpha1/legacy_worker_hash.go
+++ b/deploy/operator/api/v1alpha1/legacy_worker_hash.go
@@ -1,0 +1,64 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package v1alpha1
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"sort"
+)
+
+const (
+	AnnotationDGDLegacyWorkerHash = "nvidia.com/dgd-legacy-worker-hash"
+	annCurrentWorkerHash          = "nvidia.com/current-worker-hash"
+)
+
+func computeLegacyDGDWorkersSpecHash(dgd *DynamoGraphDeployment) (string, error) {
+	var workerNames []string
+	for name, spec := range dgd.Spec.Services {
+		if spec != nil && isLegacyWorkerComponent(spec.ComponentType) {
+			workerNames = append(workerNames, name)
+		}
+	}
+	sort.Strings(workerNames)
+
+	hashInputs := make(map[string]DynamoComponentDeploymentSharedSpec)
+	for _, name := range workerNames {
+		hashInputs[name] = stripLegacyNonPodTemplateFields(dgd.Spec.Services[name])
+	}
+
+	data, err := json.Marshal(hashInputs)
+	if err != nil {
+		return "", err
+	}
+
+	hash := sha256.Sum256(data)
+	return hex.EncodeToString(hash[:])[:8], nil
+}
+
+func isLegacyWorkerComponent(componentType string) bool {
+	return componentType == "worker" || componentType == "prefill" || componentType == "decode"
+}
+
+func stripLegacyNonPodTemplateFields(spec *DynamoComponentDeploymentSharedSpec) DynamoComponentDeploymentSharedSpec {
+	stripped := *spec
+
+	stripped.Annotations = nil
+	stripped.Labels = nil
+	stripped.ServiceName = ""
+	stripped.ComponentType = ""
+	stripped.SubComponentType = ""
+	stripped.DynamoNamespace = nil
+	stripped.Replicas = nil
+	stripped.Autoscaling = nil //nolint:staticcheck // SA1019: intentionally matching the old v1alpha1 worker hash
+	stripped.ScalingAdapter = nil
+	stripped.Ingress = nil
+	stripped.ModelRef = nil
+	stripped.EPPConfig = nil
+
+	return stripped
+}

--- a/deploy/operator/api/v1alpha1/legacy_worker_hash.go
+++ b/deploy/operator/api/v1alpha1/legacy_worker_hash.go
@@ -17,14 +17,14 @@ const (
 	annCurrentWorkerHash          = "nvidia.com/current-worker-hash"
 )
 
-// ComputeV1alpha1DGDWorkersSpecHash computes the worker hash used by the
+// ComputeDGDWorkersSpecHash computes the worker hash used by the
 // v1alpha1 DGD controller before v1beta1 conversion. ConvertTo stores this
 // value on the v1beta1 hub object so the v1beta1 controller can migrate
 // existing v1alpha1 hashes without rolling workers.
 //
 // Keep this in the api/v1alpha1 package so conversion can call it without an
 // api/v1alpha1 -> internal/dynamo -> api/v1alpha1 import cycle.
-func ComputeV1alpha1DGDWorkersSpecHash(dgd *DynamoGraphDeployment) (string, error) {
+func ComputeDGDWorkersSpecHash(dgd *DynamoGraphDeployment) (string, error) {
 	var workerNames []string
 	for name, spec := range dgd.Spec.Services {
 		if spec != nil && isV1alpha1WorkerComponent(spec.ComponentType) {

--- a/deploy/operator/api/v1alpha1/legacy_worker_hash.go
+++ b/deploy/operator/api/v1alpha1/legacy_worker_hash.go
@@ -9,6 +9,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"sort"
 )
 
@@ -25,6 +26,10 @@ const (
 // Keep this in the api/v1alpha1 package so conversion can call it without an
 // api/v1alpha1 -> internal/dynamo -> api/v1alpha1 import cycle.
 func ComputeDGDWorkersSpecHash(dgd *DynamoGraphDeployment) (string, error) {
+	if dgd == nil {
+		return "", fmt.Errorf("nil DynamoGraphDeployment")
+	}
+
 	var workerNames []string
 	for name, spec := range dgd.Spec.Services {
 		if spec != nil && isV1alpha1WorkerComponent(spec.ComponentType) {

--- a/deploy/operator/api/v1alpha1/legacy_worker_hash_test.go
+++ b/deploy/operator/api/v1alpha1/legacy_worker_hash_test.go
@@ -73,6 +73,12 @@ func TestComputeDGDWorkersSpecHashGolden(t *testing.T) {
 	}
 }
 
+func TestComputeDGDWorkersSpecHashNil(t *testing.T) {
+	if _, err := ComputeDGDWorkersSpecHash(nil); err == nil {
+		t.Fatal("ComputeDGDWorkersSpecHash(nil) error = nil, want error")
+	}
+}
+
 func TestDGDConvertToPreservesLegacyWorkerHashCompatibleWithControllerHash(t *testing.T) {
 	src := legacyWorkerHashDGD()
 	src.Annotations = map[string]string{

--- a/deploy/operator/api/v1alpha1/legacy_worker_hash_test.go
+++ b/deploy/operator/api/v1alpha1/legacy_worker_hash_test.go
@@ -1,0 +1,237 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package v1alpha1
+
+import (
+	"testing"
+
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+const currentWorkerHashAnnotation = "nvidia.com/current-worker-hash"
+
+func TestComputeLegacyDGDWorkersSpecHashGolden(t *testing.T) {
+	tests := []struct {
+		name string
+		dgd  *DynamoGraphDeployment
+		want string
+	}{
+		{
+			name: "worker",
+			dgd:  legacyWorkerHashDGD(),
+			want: "9b66accc",
+		},
+		{
+			name: "resource metadata and non-workers ignored",
+			dgd:  legacyWorkerHashDGDWithResourceMetadataAndNonWorkerChanges(),
+			want: "9b66accc",
+		},
+		{
+			name: "pod metadata included",
+			dgd:  legacyWorkerHashDGDWithPodMetadataChanges(),
+			want: "af8a6c60",
+		},
+		{
+			name: "all worker component types",
+			dgd: &DynamoGraphDeployment{
+				Spec: DynamoGraphDeploymentSpec{
+					Services: map[string]*DynamoComponentDeploymentSharedSpec{
+						"decode":  {ComponentType: commonconsts.ComponentTypeDecode, Envs: []corev1.EnvVar{{Name: "ROLE", Value: "decode"}}},
+						"prefill": {ComponentType: commonconsts.ComponentTypePrefill, Envs: []corev1.EnvVar{{Name: "ROLE", Value: "prefill"}}},
+						"worker":  {ComponentType: commonconsts.ComponentTypeWorker, Envs: []corev1.EnvVar{{Name: "ROLE", Value: "worker"}}},
+					},
+				},
+			},
+			want: "b175ee30",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got1, err := computeLegacyDGDWorkersSpecHash(tt.dgd)
+			if err != nil {
+				t.Fatalf("computeLegacyDGDWorkersSpecHash: %v", err)
+			}
+			got2, err := computeLegacyDGDWorkersSpecHash(tt.dgd)
+			if err != nil {
+				t.Fatalf("second computeLegacyDGDWorkersSpecHash: %v", err)
+			}
+			if got1 != got2 {
+				t.Fatalf("hash is not stable: first %q, second %q", got1, got2)
+			}
+			if got1 != tt.want {
+				t.Fatalf("computeLegacyDGDWorkersSpecHash() = %q, want golden %q", got1, tt.want)
+			}
+		})
+	}
+}
+
+func TestDGDConvertToPreservesLegacyWorkerHashCompatibleWithControllerHash(t *testing.T) {
+	src := legacyWorkerHashDGD()
+	src.Annotations = map[string]string{
+		currentWorkerHashAnnotation: "stale-controller-hash",
+	}
+
+	expected, err := computeLegacyDGDWorkersSpecHash(src)
+	if err != nil {
+		t.Fatalf("computeLegacyDGDWorkersSpecHash: %v", err)
+	}
+	hub := &v1beta1.DynamoGraphDeployment{}
+	if err := src.ConvertTo(hub); err != nil {
+		t.Fatalf("ConvertTo: %v", err)
+	}
+
+	got := hub.Annotations[AnnotationDGDLegacyWorkerHash]
+	if got != expected {
+		t.Fatalf("%s = %q, want legacy hash %q", AnnotationDGDLegacyWorkerHash, got, expected)
+	}
+	if got == src.Annotations[currentWorkerHashAnnotation] {
+		t.Fatalf("%s copied stale %s value instead of recomputing from spec", AnnotationDGDLegacyWorkerHash, currentWorkerHashAnnotation)
+	}
+}
+
+func TestDGDConvertToSkipsLegacyWorkerHashWithoutCurrentWorkerHash(t *testing.T) {
+	src := legacyWorkerHashDGD()
+
+	hub := &v1beta1.DynamoGraphDeployment{}
+	if err := src.ConvertTo(hub); err != nil {
+		t.Fatalf("ConvertTo: %v", err)
+	}
+	if _, ok := hub.Annotations[AnnotationDGDLegacyWorkerHash]; ok {
+		t.Fatalf("unexpected %s annotation without %s trigger: %v", AnnotationDGDLegacyWorkerHash, currentWorkerHashAnnotation, hub.Annotations)
+	}
+}
+
+func TestDGDLegacyWorkerHashTracksPodMetadata(t *testing.T) {
+	baseHash := preservedLegacyWorkerHash(t, legacyWorkerHashDGD())
+
+	mutated := legacyWorkerHashDGDWithPodMetadataChanges()
+
+	if got := preservedLegacyWorkerHash(t, mutated); got == baseHash {
+		t.Fatalf("pod metadata change did not change preserved legacy worker hash: %q", got)
+	}
+}
+
+func TestDGDLegacyWorkerHashIgnoresResourceMetadataAndNonWorkers(t *testing.T) {
+	baseHash := preservedLegacyWorkerHash(t, legacyWorkerHashDGD())
+
+	mutated := legacyWorkerHashDGDWithResourceMetadataAndNonWorkerChanges()
+
+	if got := preservedLegacyWorkerHash(t, mutated); got != baseHash {
+		t.Fatalf("non-pod-template metadata/non-worker changes changed preserved legacy worker hash: got %q, want %q", got, baseHash)
+	}
+}
+
+func TestDGDConvertFromDropsLegacyWorkerHash(t *testing.T) {
+	hub := &v1beta1.DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "legacy-worker-hash",
+			Namespace: "ns",
+			Annotations: map[string]string{
+				AnnotationDGDLegacyWorkerHash: "deadbeef",
+				"user":                        "kept",
+			},
+		},
+		Spec: v1beta1.DynamoGraphDeploymentSpec{
+			Components: []v1beta1.DynamoComponentDeploymentSharedSpec{
+				{
+					ComponentName: "worker",
+					ComponentType: v1beta1.ComponentTypeWorker,
+				},
+			},
+		},
+	}
+
+	spoke := &DynamoGraphDeployment{}
+	if err := spoke.ConvertFrom(hub); err != nil {
+		t.Fatalf("ConvertFrom: %v", err)
+	}
+	if _, ok := spoke.Annotations[AnnotationDGDLegacyWorkerHash]; ok {
+		t.Fatalf("%s leaked back to v1alpha1 annotations: %v", AnnotationDGDLegacyWorkerHash, spoke.Annotations)
+	}
+	if got := spoke.Annotations["user"]; got != "kept" {
+		t.Fatalf("user annotation = %q, want kept", got)
+	}
+}
+
+func preservedLegacyWorkerHash(t *testing.T, src *DynamoGraphDeployment) string {
+	t.Helper()
+	if src.Annotations == nil {
+		src.Annotations = map[string]string{}
+	}
+	src.Annotations[currentWorkerHashAnnotation] = "existing-controller-hash"
+
+	expected, err := computeLegacyDGDWorkersSpecHash(src)
+	if err != nil {
+		t.Fatalf("computeLegacyDGDWorkersSpecHash: %v", err)
+	}
+	hub := &v1beta1.DynamoGraphDeployment{}
+	if err := src.ConvertTo(hub); err != nil {
+		t.Fatalf("ConvertTo: %v", err)
+	}
+	got := hub.Annotations[AnnotationDGDLegacyWorkerHash]
+	if got == "" {
+		t.Fatalf("missing %s annotation in hub annotations: %v", AnnotationDGDLegacyWorkerHash, hub.Annotations)
+	}
+	if got != expected {
+		t.Fatalf("%s = %q, want legacy hash %q", AnnotationDGDLegacyWorkerHash, got, expected)
+	}
+	return got
+}
+
+func legacyWorkerHashDGD() *DynamoGraphDeployment {
+	return &DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "legacy-worker-hash",
+			Namespace: "ns",
+		},
+		Spec: DynamoGraphDeploymentSpec{
+			Services: map[string]*DynamoComponentDeploymentSharedSpec{
+				"frontend": {
+					ComponentType: commonconsts.ComponentTypeFrontend,
+					Envs:          []corev1.EnvVar{{Name: "FRONTEND_ONLY", Value: "ignored"}},
+				},
+				"worker": {
+					ComponentType: commonconsts.ComponentTypeWorker,
+					Annotations:   map[string]string{"resource": "base"},
+					Labels:        map[string]string{"resource": "base"},
+					Replicas:      ptr.To(int32(2)),
+					Envs:          []corev1.EnvVar{{Name: "MODEL", Value: "llama"}},
+					ExtraPodMetadata: &ExtraPodMetadata{
+						Labels:      map[string]string{"rollout": "base"},
+						Annotations: map[string]string{"checksum/config": "base"},
+					},
+				},
+			},
+		},
+	}
+}
+
+func legacyWorkerHashDGDWithPodMetadataChanges() *DynamoGraphDeployment {
+	mutated := legacyWorkerHashDGD()
+	mutated.Spec.Services["worker"].ExtraPodMetadata = &ExtraPodMetadata{
+		Labels:      map[string]string{"rollout": "changed"},
+		Annotations: map[string]string{"checksum/config": "changed"},
+	}
+	return mutated
+}
+
+func legacyWorkerHashDGDWithResourceMetadataAndNonWorkerChanges() *DynamoGraphDeployment {
+	mutated := legacyWorkerHashDGD()
+	mutated.Spec.Services["worker"].Annotations = map[string]string{"resource": "changed"}
+	mutated.Spec.Services["worker"].Labels = map[string]string{"resource": "changed"}
+	mutated.Spec.Services["worker"].Replicas = ptr.To(int32(99))
+	mutated.Spec.Services["worker"].Ingress = &IngressSpec{
+		Enabled: true,
+		Host:    "changed.example.com",
+	}
+	mutated.Spec.Services["frontend"].Envs = []corev1.EnvVar{{Name: "FRONTEND_ONLY", Value: "changed"}}
+	return mutated
+}

--- a/deploy/operator/api/v1alpha1/legacy_worker_hash_test.go
+++ b/deploy/operator/api/v1alpha1/legacy_worker_hash_test.go
@@ -17,7 +17,7 @@ import (
 
 const currentWorkerHashAnnotation = "nvidia.com/current-worker-hash"
 
-func TestComputeV1alpha1DGDWorkersSpecHashGolden(t *testing.T) {
+func TestComputeDGDWorkersSpecHashGolden(t *testing.T) {
 	tests := []struct {
 		name string
 		dgd  *DynamoGraphDeployment
@@ -55,19 +55,19 @@ func TestComputeV1alpha1DGDWorkersSpecHashGolden(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got1, err := ComputeV1alpha1DGDWorkersSpecHash(tt.dgd)
+			got1, err := ComputeDGDWorkersSpecHash(tt.dgd)
 			if err != nil {
-				t.Fatalf("ComputeV1alpha1DGDWorkersSpecHash: %v", err)
+				t.Fatalf("ComputeDGDWorkersSpecHash: %v", err)
 			}
-			got2, err := ComputeV1alpha1DGDWorkersSpecHash(tt.dgd)
+			got2, err := ComputeDGDWorkersSpecHash(tt.dgd)
 			if err != nil {
-				t.Fatalf("second ComputeV1alpha1DGDWorkersSpecHash: %v", err)
+				t.Fatalf("second ComputeDGDWorkersSpecHash: %v", err)
 			}
 			if got1 != got2 {
 				t.Fatalf("hash is not stable: first %q, second %q", got1, got2)
 			}
 			if got1 != tt.want {
-				t.Fatalf("ComputeV1alpha1DGDWorkersSpecHash() = %q, want golden %q", got1, tt.want)
+				t.Fatalf("ComputeDGDWorkersSpecHash() = %q, want golden %q", got1, tt.want)
 			}
 		})
 	}
@@ -79,9 +79,9 @@ func TestDGDConvertToPreservesLegacyWorkerHashCompatibleWithControllerHash(t *te
 		currentWorkerHashAnnotation: "stale-controller-hash",
 	}
 
-	expected, err := ComputeV1alpha1DGDWorkersSpecHash(src)
+	expected, err := ComputeDGDWorkersSpecHash(src)
 	if err != nil {
-		t.Fatalf("ComputeV1alpha1DGDWorkersSpecHash: %v", err)
+		t.Fatalf("ComputeDGDWorkersSpecHash: %v", err)
 	}
 	hub := &v1beta1.DynamoGraphDeployment{}
 	if err := src.ConvertTo(hub); err != nil {
@@ -168,9 +168,9 @@ func preservedLegacyWorkerHash(t *testing.T, src *DynamoGraphDeployment) string 
 	}
 	src.Annotations[currentWorkerHashAnnotation] = "existing-controller-hash"
 
-	expected, err := ComputeV1alpha1DGDWorkersSpecHash(src)
+	expected, err := ComputeDGDWorkersSpecHash(src)
 	if err != nil {
-		t.Fatalf("ComputeV1alpha1DGDWorkersSpecHash: %v", err)
+		t.Fatalf("ComputeDGDWorkersSpecHash: %v", err)
 	}
 	hub := &v1beta1.DynamoGraphDeployment{}
 	if err := src.ConvertTo(hub); err != nil {

--- a/deploy/operator/api/v1alpha1/legacy_worker_hash_test.go
+++ b/deploy/operator/api/v1alpha1/legacy_worker_hash_test.go
@@ -17,7 +17,7 @@ import (
 
 const currentWorkerHashAnnotation = "nvidia.com/current-worker-hash"
 
-func TestComputeLegacyDGDWorkersSpecHashGolden(t *testing.T) {
+func TestComputeV1alpha1DGDWorkersSpecHashGolden(t *testing.T) {
 	tests := []struct {
 		name string
 		dgd  *DynamoGraphDeployment
@@ -55,19 +55,19 @@ func TestComputeLegacyDGDWorkersSpecHashGolden(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got1, err := computeLegacyDGDWorkersSpecHash(tt.dgd)
+			got1, err := ComputeV1alpha1DGDWorkersSpecHash(tt.dgd)
 			if err != nil {
-				t.Fatalf("computeLegacyDGDWorkersSpecHash: %v", err)
+				t.Fatalf("ComputeV1alpha1DGDWorkersSpecHash: %v", err)
 			}
-			got2, err := computeLegacyDGDWorkersSpecHash(tt.dgd)
+			got2, err := ComputeV1alpha1DGDWorkersSpecHash(tt.dgd)
 			if err != nil {
-				t.Fatalf("second computeLegacyDGDWorkersSpecHash: %v", err)
+				t.Fatalf("second ComputeV1alpha1DGDWorkersSpecHash: %v", err)
 			}
 			if got1 != got2 {
 				t.Fatalf("hash is not stable: first %q, second %q", got1, got2)
 			}
 			if got1 != tt.want {
-				t.Fatalf("computeLegacyDGDWorkersSpecHash() = %q, want golden %q", got1, tt.want)
+				t.Fatalf("ComputeV1alpha1DGDWorkersSpecHash() = %q, want golden %q", got1, tt.want)
 			}
 		})
 	}
@@ -79,9 +79,9 @@ func TestDGDConvertToPreservesLegacyWorkerHashCompatibleWithControllerHash(t *te
 		currentWorkerHashAnnotation: "stale-controller-hash",
 	}
 
-	expected, err := computeLegacyDGDWorkersSpecHash(src)
+	expected, err := ComputeV1alpha1DGDWorkersSpecHash(src)
 	if err != nil {
-		t.Fatalf("computeLegacyDGDWorkersSpecHash: %v", err)
+		t.Fatalf("ComputeV1alpha1DGDWorkersSpecHash: %v", err)
 	}
 	hub := &v1beta1.DynamoGraphDeployment{}
 	if err := src.ConvertTo(hub); err != nil {
@@ -168,9 +168,9 @@ func preservedLegacyWorkerHash(t *testing.T, src *DynamoGraphDeployment) string 
 	}
 	src.Annotations[currentWorkerHashAnnotation] = "existing-controller-hash"
 
-	expected, err := computeLegacyDGDWorkersSpecHash(src)
+	expected, err := ComputeV1alpha1DGDWorkersSpecHash(src)
 	if err != nil {
-		t.Fatalf("computeLegacyDGDWorkersSpecHash: %v", err)
+		t.Fatalf("ComputeV1alpha1DGDWorkersSpecHash: %v", err)
 	}
 	hub := &v1beta1.DynamoGraphDeployment{}
 	if err := src.ConvertTo(hub); err != nil {

--- a/deploy/operator/api/v1alpha1/shared_spec_conversion.go
+++ b/deploy/operator/api/v1alpha1/shared_spec_conversion.go
@@ -792,17 +792,23 @@ func sharedHubSpecSaveIsZero(save *v1beta1.DynamoComponentDeploymentSharedSpec) 
 // Shared-memory
 // ---------------------------------------------------------------------------
 
-func convertSharedMemoryTo(src *SharedMemorySpec, dst *v1beta1.DynamoComponentDeploymentSharedSpec) error {
+// ConvertToV1beta1SharedMemorySize converts the v1alpha1 shared-memory struct
+// into the v1beta1 scalar representation.
+func ConvertToV1beta1SharedMemorySize(src *SharedMemorySpec) *resource.Quantity {
 	if src == nil {
 		return nil
 	}
 	if src.Disabled {
-		dst.SharedMemorySize = ptr.To(resource.MustParse("0"))
+		return ptr.To(resource.MustParse("0"))
+	}
+	if src.Size.IsZero() {
 		return nil
 	}
-	if !src.Size.IsZero() {
-		dst.SharedMemorySize = ptr.To(src.Size.DeepCopy())
-	}
+	return ptr.To(src.Size.DeepCopy())
+}
+
+func convertSharedMemoryTo(src *SharedMemorySpec, dst *v1beta1.DynamoComponentDeploymentSharedSpec) error {
+	dst.SharedMemorySize = ConvertToV1beta1SharedMemorySize(src)
 	return nil
 }
 
@@ -928,6 +934,128 @@ func checkpointModeFromV1beta1(mode v1beta1.CheckpointMode) CheckpointMode {
 	}
 }
 
+// ConvertToV1beta1GPUMemoryService converts the v1alpha1 GMS config into the
+// v1beta1 experimental GMS config. Disabled v1alpha1 configs are represented
+// by absence in v1beta1.
+func ConvertToV1beta1GPUMemoryService(src *GPUMemoryServiceSpec) *v1beta1.GPUMemoryServiceSpec {
+	if src == nil || !src.Enabled {
+		return nil
+	}
+	return &v1beta1.GPUMemoryServiceSpec{
+		Mode:            gmsModeToV1beta1(src.Mode),
+		DeviceClassName: src.DeviceClassName,
+	}
+}
+
+// ConvertToV1alpha1GPUMemoryService converts the v1beta1 experimental GMS
+// config into the v1alpha1 enabled config.
+func ConvertToV1alpha1GPUMemoryService(src *v1beta1.GPUMemoryServiceSpec) *GPUMemoryServiceSpec {
+	if src == nil {
+		return nil
+	}
+	return &GPUMemoryServiceSpec{
+		Enabled:         true,
+		Mode:            gmsModeFromV1beta1(src.Mode),
+		DeviceClassName: src.DeviceClassName,
+	}
+}
+
+// ConvertToV1beta1Failover converts the v1alpha1 failover config into the
+// v1beta1 experimental failover config. Disabled v1alpha1 configs are
+// represented by absence in v1beta1.
+func ConvertToV1beta1Failover(src *FailoverSpec) *v1beta1.FailoverSpec {
+	if src == nil || !src.Enabled {
+		return nil
+	}
+	return &v1beta1.FailoverSpec{
+		Mode:       gmsModeToV1beta1(src.Mode),
+		NumShadows: src.NumShadows,
+	}
+}
+
+// ConvertToV1alpha1Failover converts the v1beta1 experimental failover config
+// into the v1alpha1 enabled config.
+func ConvertToV1alpha1Failover(src *v1beta1.FailoverSpec) *FailoverSpec {
+	if src == nil {
+		return nil
+	}
+	return &FailoverSpec{
+		Enabled:    true,
+		Mode:       gmsModeFromV1beta1(src.Mode),
+		NumShadows: src.NumShadows,
+	}
+}
+
+// ConvertToV1beta1ComponentCheckpoint converts the v1alpha1 checkpoint config
+// into the v1beta1 experimental checkpoint config. Disabled v1alpha1 configs
+// are represented by absence in v1beta1.
+func ConvertToV1beta1ComponentCheckpoint(src *ServiceCheckpointConfig) *v1beta1.ComponentCheckpointConfig {
+	if src == nil || !src.Enabled {
+		return nil
+	}
+	dst := &v1beta1.ComponentCheckpointConfig{
+		Mode:     checkpointModeToV1beta1(src.Mode),
+		Identity: ConvertToV1beta1CheckpointIdentity(src.Identity),
+	}
+	if src.CheckpointRef != nil {
+		dst.CheckpointRef = ptr.To(*src.CheckpointRef)
+	}
+	return dst
+}
+
+// ConvertToV1alpha1ComponentCheckpoint converts the v1beta1 experimental
+// checkpoint config into the v1alpha1 enabled config.
+func ConvertToV1alpha1ComponentCheckpoint(src *v1beta1.ComponentCheckpointConfig) *ServiceCheckpointConfig {
+	if src == nil {
+		return nil
+	}
+	dst := &ServiceCheckpointConfig{
+		Enabled:  true,
+		Mode:     checkpointModeFromV1beta1(src.Mode),
+		Identity: ConvertToV1alpha1CheckpointIdentity(src.Identity),
+	}
+	if src.CheckpointRef != nil {
+		dst.CheckpointRef = ptr.To(*src.CheckpointRef)
+	}
+	return dst
+}
+
+// ConvertToV1beta1CheckpointIdentity converts checkpoint identity fields from
+// v1alpha1 to v1beta1.
+func ConvertToV1beta1CheckpointIdentity(src *DynamoCheckpointIdentity) *v1beta1.DynamoCheckpointIdentity {
+	if src == nil {
+		return nil
+	}
+	return &v1beta1.DynamoCheckpointIdentity{
+		Model:                src.Model,
+		BackendFramework:     src.BackendFramework,
+		DynamoVersion:        src.DynamoVersion,
+		TensorParallelSize:   src.TensorParallelSize,
+		PipelineParallelSize: src.PipelineParallelSize,
+		Dtype:                src.Dtype,
+		MaxModelLen:          src.MaxModelLen,
+		ExtraParameters:      src.ExtraParameters,
+	}
+}
+
+// ConvertToV1alpha1CheckpointIdentity converts checkpoint identity fields from
+// v1beta1 to v1alpha1.
+func ConvertToV1alpha1CheckpointIdentity(src *v1beta1.DynamoCheckpointIdentity) *DynamoCheckpointIdentity {
+	if src == nil {
+		return nil
+	}
+	return &DynamoCheckpointIdentity{
+		Model:                src.Model,
+		BackendFramework:     src.BackendFramework,
+		DynamoVersion:        src.DynamoVersion,
+		TensorParallelSize:   src.TensorParallelSize,
+		PipelineParallelSize: src.PipelineParallelSize,
+		Dtype:                src.Dtype,
+		MaxModelLen:          src.MaxModelLen,
+		ExtraParameters:      src.ExtraParameters,
+	}
+}
+
 func convertExperimentalTo(src *DynamoComponentDeploymentSharedSpec, dst *v1beta1.DynamoComponentDeploymentSharedSpec) {
 	var exp *v1beta1.ExperimentalSpec
 	ensureExp := func() *v1beta1.ExperimentalSpec {
@@ -937,28 +1065,16 @@ func convertExperimentalTo(src *DynamoComponentDeploymentSharedSpec, dst *v1beta
 		return exp
 	}
 
-	if src.GPUMemoryService != nil {
-		if src.GPUMemoryService.Enabled {
-			ensureExp().GPUMemoryService = &v1beta1.GPUMemoryServiceSpec{
-				Mode:            gmsModeToV1beta1(src.GPUMemoryService.Mode),
-				DeviceClassName: src.GPUMemoryService.DeviceClassName,
-			}
-		}
+	if gms := ConvertToV1beta1GPUMemoryService(src.GPUMemoryService); gms != nil {
+		ensureExp().GPUMemoryService = gms
 	}
 
-	if src.Failover != nil {
-		if src.Failover.Enabled {
-			ensureExp().Failover = &v1beta1.FailoverSpec{
-				Mode:       gmsModeToV1beta1(src.Failover.Mode),
-				NumShadows: src.Failover.NumShadows,
-			}
-		}
+	if failover := ConvertToV1beta1Failover(src.Failover); failover != nil {
+		ensureExp().Failover = failover
 	}
 
-	if src.Checkpoint != nil {
-		if src.Checkpoint.Enabled {
-			ensureExp().Checkpoint = checkpointToV1beta1(src.Checkpoint)
-		}
+	if checkpoint := ConvertToV1beta1ComponentCheckpoint(src.Checkpoint); checkpoint != nil {
+		ensureExp().Checkpoint = checkpoint
 	}
 
 	dst.Experimental = exp
@@ -966,74 +1082,16 @@ func convertExperimentalTo(src *DynamoComponentDeploymentSharedSpec, dst *v1beta
 
 func convertExperimentalFrom(src *v1beta1.DynamoComponentDeploymentSharedSpec, dst *DynamoComponentDeploymentSharedSpec) {
 	if src.Experimental != nil && src.Experimental.GPUMemoryService != nil {
-		dst.GPUMemoryService = &GPUMemoryServiceSpec{
-			Enabled:         true,
-			Mode:            gmsModeFromV1beta1(src.Experimental.GPUMemoryService.Mode),
-			DeviceClassName: src.Experimental.GPUMemoryService.DeviceClassName,
-		}
+		dst.GPUMemoryService = ConvertToV1alpha1GPUMemoryService(src.Experimental.GPUMemoryService)
 	}
 
 	if src.Experimental != nil && src.Experimental.Failover != nil {
-		dst.Failover = &FailoverSpec{
-			Enabled:    true,
-			Mode:       gmsModeFromV1beta1(src.Experimental.Failover.Mode),
-			NumShadows: src.Experimental.Failover.NumShadows,
-		}
+		dst.Failover = ConvertToV1alpha1Failover(src.Experimental.Failover)
 	}
 
 	if src.Experimental != nil && src.Experimental.Checkpoint != nil {
-		dst.Checkpoint = checkpointFromV1beta1(src.Experimental.Checkpoint, true)
+		dst.Checkpoint = ConvertToV1alpha1ComponentCheckpoint(src.Experimental.Checkpoint)
 	}
-}
-
-func checkpointToV1beta1(src *ServiceCheckpointConfig) *v1beta1.ComponentCheckpointConfig {
-	dst := &v1beta1.ComponentCheckpointConfig{
-		Mode: checkpointModeToV1beta1(src.Mode),
-	}
-	// Deep-copy CheckpointRef so the v1alpha1 and v1beta1 objects do not
-	// share the same *string. A shared pointer would let a mutation on one
-	// side surface on the other after conversion, which violates the
-	// conversion-webhook contract.
-	if src.CheckpointRef != nil {
-		dst.CheckpointRef = ptr.To(*src.CheckpointRef)
-	}
-	if src.Identity != nil {
-		dst.Identity = &v1beta1.DynamoCheckpointIdentity{
-			Model:                src.Identity.Model,
-			BackendFramework:     src.Identity.BackendFramework,
-			DynamoVersion:        src.Identity.DynamoVersion,
-			TensorParallelSize:   src.Identity.TensorParallelSize,
-			PipelineParallelSize: src.Identity.PipelineParallelSize,
-			Dtype:                src.Identity.Dtype,
-			MaxModelLen:          src.Identity.MaxModelLen,
-			ExtraParameters:      src.Identity.ExtraParameters,
-		}
-	}
-	return dst
-}
-
-func checkpointFromV1beta1(src *v1beta1.ComponentCheckpointConfig, enabled bool) *ServiceCheckpointConfig {
-	dst := &ServiceCheckpointConfig{
-		Enabled: enabled,
-		Mode:    checkpointModeFromV1beta1(src.Mode),
-	}
-	// Deep-copy CheckpointRef -- see checkpointToV1beta1 for the rationale.
-	if src.CheckpointRef != nil {
-		dst.CheckpointRef = ptr.To(*src.CheckpointRef)
-	}
-	if src.Identity != nil {
-		dst.Identity = &DynamoCheckpointIdentity{
-			Model:                src.Identity.Model,
-			BackendFramework:     src.Identity.BackendFramework,
-			DynamoVersion:        src.Identity.DynamoVersion,
-			TensorParallelSize:   src.Identity.TensorParallelSize,
-			PipelineParallelSize: src.Identity.PipelineParallelSize,
-			Dtype:                src.Identity.Dtype,
-			MaxModelLen:          src.Identity.MaxModelLen,
-			ExtraParameters:      src.Identity.ExtraParameters,
-		}
-	}
-	return dst
 }
 
 // ---------------------------------------------------------------------------

--- a/deploy/operator/api/v1alpha1/shared_spec_conversion.go
+++ b/deploy/operator/api/v1alpha1/shared_spec_conversion.go
@@ -792,46 +792,50 @@ func sharedHubSpecSaveIsZero(save *v1beta1.DynamoComponentDeploymentSharedSpec) 
 // Shared-memory
 // ---------------------------------------------------------------------------
 
-// ConvertToV1beta1SharedMemorySize converts the v1alpha1 shared-memory struct
-// into the v1beta1 scalar representation.
-func ConvertToV1beta1SharedMemorySize(src *SharedMemorySpec) *resource.Quantity {
-	if src == nil {
-		return nil
-	}
+// ConvertFromSharedMemorySpec converts the shared-memory struct into the
+// v1beta1 scalar representation.
+func ConvertFromSharedMemorySpec(src *SharedMemorySpec, dst *resource.Quantity) {
 	if src.Disabled {
-		return ptr.To(resource.MustParse("0"))
+		*dst = resource.MustParse("0")
+		return
 	}
-	if src.Size.IsZero() {
-		return nil
-	}
-	return ptr.To(src.Size.DeepCopy())
+	*dst = src.Size
 }
 
 func convertSharedMemoryTo(src *SharedMemorySpec, dst *v1beta1.DynamoComponentDeploymentSharedSpec) error {
-	dst.SharedMemorySize = ConvertToV1beta1SharedMemorySize(src)
+	if src != nil && (src.Disabled || !src.Size.IsZero()) {
+		dst.SharedMemorySize = &resource.Quantity{}
+		ConvertFromSharedMemorySpec(src, dst.SharedMemorySize)
+	}
 	return nil
 }
 
-func convertSharedMemoryFrom(src *resource.Quantity, dst *DynamoComponentDeploymentSharedSpec) {
-	if src == nil {
-		return
-	}
+// ConvertToSharedMemorySpec converts the v1beta1 shared-memory scalar
+// representation into the shared-memory struct.
+func ConvertToSharedMemorySpec(src *resource.Quantity, dst *SharedMemorySpec) {
 	if src.Sign() == 0 {
 		// Canonical v1beta1 "size=0" <-> v1alpha1 Disabled=true. See
 		// convertSharedMemoryTo for the forward direction.
 		//
-		// Size is carried as the DeepCopy of the incoming canonical Quantity
-		// (not the Go zero value) so that every apply produces a spec that is
-		// reflect.DeepEqual to what's in etcd. A bare Quantity{} and a
-		// JSON-round-tripped Quantity serialize identically to "0" but differ
-		// in internal state (Format, cached string), and the API server's
-		// generation-bump check uses DeepEqual -- so emitting a bare
-		// Quantity{} here would cause every `kubectl apply` to bump
-		// `.metadata.generation` even though the spec is byte-identical.
-		dst.SharedMemory = &SharedMemorySpec{Disabled: true, Size: src.DeepCopy()}
+		// Size carries the incoming canonical Quantity value (not the Go zero
+		// value) so that every apply produces a spec that is reflect.DeepEqual
+		// to what's in etcd. A bare Quantity{} and a JSON-round-tripped
+		// Quantity serialize identically to "0" but differ in internal state
+		// (Format, cached string), and the API server's generation-bump check
+		// uses DeepEqual -- so emitting a bare Quantity{} here would cause
+		// every `kubectl apply` to bump `.metadata.generation` even though the
+		// spec is byte-identical.
+		*dst = SharedMemorySpec{Disabled: true, Size: *src}
 		return
 	}
-	dst.SharedMemory = &SharedMemorySpec{Size: src.DeepCopy()}
+	*dst = SharedMemorySpec{Size: *src}
+}
+
+func convertSharedMemoryFrom(src *resource.Quantity, dst *DynamoComponentDeploymentSharedSpec) {
+	if src != nil {
+		dst.SharedMemory = &SharedMemorySpec{}
+		ConvertToSharedMemorySpec(src, dst.SharedMemory)
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -934,99 +938,82 @@ func checkpointModeFromV1beta1(mode v1beta1.CheckpointMode) CheckpointMode {
 	}
 }
 
-// ConvertToV1beta1GPUMemoryService converts the v1alpha1 GMS config into the
-// v1beta1 experimental GMS config. Disabled v1alpha1 configs are represented
-// by absence in v1beta1.
-func ConvertToV1beta1GPUMemoryService(src *GPUMemoryServiceSpec) *v1beta1.GPUMemoryServiceSpec {
-	if src == nil || !src.Enabled {
-		return nil
-	}
-	return &v1beta1.GPUMemoryServiceSpec{
+// ConvertFromGPUMemoryServiceSpec converts an enabled GMS config into the
+// v1beta1 experimental GMS config. Disabled configs are represented by absence
+// in v1beta1 and are skipped by the caller.
+func ConvertFromGPUMemoryServiceSpec(src *GPUMemoryServiceSpec, dst *v1beta1.GPUMemoryServiceSpec) {
+	*dst = v1beta1.GPUMemoryServiceSpec{
 		Mode:            gmsModeToV1beta1(src.Mode),
 		DeviceClassName: src.DeviceClassName,
 	}
 }
 
-// ConvertToV1alpha1GPUMemoryService converts the v1beta1 experimental GMS
-// config into the v1alpha1 enabled config.
-func ConvertToV1alpha1GPUMemoryService(src *v1beta1.GPUMemoryServiceSpec) *GPUMemoryServiceSpec {
-	if src == nil {
-		return nil
-	}
-	return &GPUMemoryServiceSpec{
+// ConvertToGPUMemoryServiceSpec converts the v1beta1 experimental GMS config
+// into the GMS config.
+func ConvertToGPUMemoryServiceSpec(src *v1beta1.GPUMemoryServiceSpec, dst *GPUMemoryServiceSpec) {
+	*dst = GPUMemoryServiceSpec{
 		Enabled:         true,
 		Mode:            gmsModeFromV1beta1(src.Mode),
 		DeviceClassName: src.DeviceClassName,
 	}
 }
 
-// ConvertToV1beta1Failover converts the v1alpha1 failover config into the
-// v1beta1 experimental failover config. Disabled v1alpha1 configs are
-// represented by absence in v1beta1.
-func ConvertToV1beta1Failover(src *FailoverSpec) *v1beta1.FailoverSpec {
-	if src == nil || !src.Enabled {
-		return nil
-	}
-	return &v1beta1.FailoverSpec{
+// ConvertFromFailoverSpec converts an enabled failover config into the v1beta1
+// experimental failover config. Disabled configs are represented by absence in
+// v1beta1 and are skipped by the caller.
+func ConvertFromFailoverSpec(src *FailoverSpec, dst *v1beta1.FailoverSpec) {
+	*dst = v1beta1.FailoverSpec{
 		Mode:       gmsModeToV1beta1(src.Mode),
 		NumShadows: src.NumShadows,
 	}
 }
 
-// ConvertToV1alpha1Failover converts the v1beta1 experimental failover config
-// into the v1alpha1 enabled config.
-func ConvertToV1alpha1Failover(src *v1beta1.FailoverSpec) *FailoverSpec {
-	if src == nil {
-		return nil
-	}
-	return &FailoverSpec{
+// ConvertToFailoverSpec converts the v1beta1 experimental failover config into
+// the failover config.
+func ConvertToFailoverSpec(src *v1beta1.FailoverSpec, dst *FailoverSpec) {
+	*dst = FailoverSpec{
 		Enabled:    true,
 		Mode:       gmsModeFromV1beta1(src.Mode),
 		NumShadows: src.NumShadows,
 	}
 }
 
-// ConvertToV1beta1ComponentCheckpoint converts the v1alpha1 checkpoint config
-// into the v1beta1 experimental checkpoint config. Disabled v1alpha1 configs
-// are represented by absence in v1beta1.
-func ConvertToV1beta1ComponentCheckpoint(src *ServiceCheckpointConfig) *v1beta1.ComponentCheckpointConfig {
-	if src == nil || !src.Enabled {
-		return nil
-	}
-	dst := &v1beta1.ComponentCheckpointConfig{
-		Mode:     checkpointModeToV1beta1(src.Mode),
-		Identity: ConvertToV1beta1CheckpointIdentity(src.Identity),
+// ConvertFromServiceCheckpointConfig converts an enabled checkpoint config into
+// the v1beta1 experimental checkpoint config. Disabled configs are represented
+// by absence in v1beta1 and are skipped by the caller.
+func ConvertFromServiceCheckpointConfig(src *ServiceCheckpointConfig, dst *v1beta1.ComponentCheckpointConfig) {
+	*dst = v1beta1.ComponentCheckpointConfig{
+		Mode: checkpointModeToV1beta1(src.Mode),
 	}
 	if src.CheckpointRef != nil {
-		dst.CheckpointRef = ptr.To(*src.CheckpointRef)
+		dst.CheckpointRef = src.CheckpointRef
 	}
-	return dst
+	if src.Identity != nil {
+		dst.Identity = &v1beta1.DynamoCheckpointIdentity{}
+		ConvertFromDynamoCheckpointIdentity(src.Identity, dst.Identity)
+	}
 }
 
-// ConvertToV1alpha1ComponentCheckpoint converts the v1beta1 experimental
-// checkpoint config into the v1alpha1 enabled config.
-func ConvertToV1alpha1ComponentCheckpoint(src *v1beta1.ComponentCheckpointConfig) *ServiceCheckpointConfig {
-	if src == nil {
-		return nil
-	}
-	dst := &ServiceCheckpointConfig{
-		Enabled:  true,
-		Mode:     checkpointModeFromV1beta1(src.Mode),
-		Identity: ConvertToV1alpha1CheckpointIdentity(src.Identity),
+// ConvertToServiceCheckpointConfig converts the v1beta1 experimental checkpoint
+// config into the checkpoint config.
+func ConvertToServiceCheckpointConfig(src *v1beta1.ComponentCheckpointConfig, dst *ServiceCheckpointConfig) {
+	*dst = ServiceCheckpointConfig{
+		Enabled: true,
+		Mode:    checkpointModeFromV1beta1(src.Mode),
 	}
 	if src.CheckpointRef != nil {
-		dst.CheckpointRef = ptr.To(*src.CheckpointRef)
+		dst.CheckpointRef = src.CheckpointRef
 	}
-	return dst
+	if src.Identity != nil {
+		dst.Identity = &DynamoCheckpointIdentity{}
+		ConvertToDynamoCheckpointIdentity(src.Identity, dst.Identity)
+	}
 }
 
-// ConvertToV1beta1CheckpointIdentity converts checkpoint identity fields from
-// v1alpha1 to v1beta1.
-func ConvertToV1beta1CheckpointIdentity(src *DynamoCheckpointIdentity) *v1beta1.DynamoCheckpointIdentity {
-	if src == nil {
-		return nil
-	}
-	return &v1beta1.DynamoCheckpointIdentity{
+// ConvertFromDynamoCheckpointIdentity converts checkpoint identity fields to
+// v1beta1.
+func ConvertFromDynamoCheckpointIdentity(src *DynamoCheckpointIdentity, dst *v1beta1.DynamoCheckpointIdentity) {
+	*dst = v1beta1.DynamoCheckpointIdentity{
 		Model:                src.Model,
 		BackendFramework:     src.BackendFramework,
 		DynamoVersion:        src.DynamoVersion,
@@ -1038,13 +1025,10 @@ func ConvertToV1beta1CheckpointIdentity(src *DynamoCheckpointIdentity) *v1beta1.
 	}
 }
 
-// ConvertToV1alpha1CheckpointIdentity converts checkpoint identity fields from
-// v1beta1 to v1alpha1.
-func ConvertToV1alpha1CheckpointIdentity(src *v1beta1.DynamoCheckpointIdentity) *DynamoCheckpointIdentity {
-	if src == nil {
-		return nil
-	}
-	return &DynamoCheckpointIdentity{
+// ConvertToDynamoCheckpointIdentity converts checkpoint identity fields from
+// v1beta1.
+func ConvertToDynamoCheckpointIdentity(src *v1beta1.DynamoCheckpointIdentity, dst *DynamoCheckpointIdentity) {
+	*dst = DynamoCheckpointIdentity{
 		Model:                src.Model,
 		BackendFramework:     src.BackendFramework,
 		DynamoVersion:        src.DynamoVersion,
@@ -1065,16 +1049,19 @@ func convertExperimentalTo(src *DynamoComponentDeploymentSharedSpec, dst *v1beta
 		return exp
 	}
 
-	if gms := ConvertToV1beta1GPUMemoryService(src.GPUMemoryService); gms != nil {
-		ensureExp().GPUMemoryService = gms
+	if src.GPUMemoryService != nil && src.GPUMemoryService.Enabled {
+		ensureExp().GPUMemoryService = &v1beta1.GPUMemoryServiceSpec{}
+		ConvertFromGPUMemoryServiceSpec(src.GPUMemoryService, exp.GPUMemoryService)
 	}
 
-	if failover := ConvertToV1beta1Failover(src.Failover); failover != nil {
-		ensureExp().Failover = failover
+	if src.Failover != nil && src.Failover.Enabled {
+		ensureExp().Failover = &v1beta1.FailoverSpec{}
+		ConvertFromFailoverSpec(src.Failover, exp.Failover)
 	}
 
-	if checkpoint := ConvertToV1beta1ComponentCheckpoint(src.Checkpoint); checkpoint != nil {
-		ensureExp().Checkpoint = checkpoint
+	if src.Checkpoint != nil && src.Checkpoint.Enabled {
+		ensureExp().Checkpoint = &v1beta1.ComponentCheckpointConfig{}
+		ConvertFromServiceCheckpointConfig(src.Checkpoint, exp.Checkpoint)
 	}
 
 	dst.Experimental = exp
@@ -1082,15 +1069,18 @@ func convertExperimentalTo(src *DynamoComponentDeploymentSharedSpec, dst *v1beta
 
 func convertExperimentalFrom(src *v1beta1.DynamoComponentDeploymentSharedSpec, dst *DynamoComponentDeploymentSharedSpec) {
 	if src.Experimental != nil && src.Experimental.GPUMemoryService != nil {
-		dst.GPUMemoryService = ConvertToV1alpha1GPUMemoryService(src.Experimental.GPUMemoryService)
+		dst.GPUMemoryService = &GPUMemoryServiceSpec{}
+		ConvertToGPUMemoryServiceSpec(src.Experimental.GPUMemoryService, dst.GPUMemoryService)
 	}
 
 	if src.Experimental != nil && src.Experimental.Failover != nil {
-		dst.Failover = ConvertToV1alpha1Failover(src.Experimental.Failover)
+		dst.Failover = &FailoverSpec{}
+		ConvertToFailoverSpec(src.Experimental.Failover, dst.Failover)
 	}
 
 	if src.Experimental != nil && src.Experimental.Checkpoint != nil {
-		dst.Checkpoint = ConvertToV1alpha1ComponentCheckpoint(src.Experimental.Checkpoint)
+		dst.Checkpoint = &ServiceCheckpointConfig{}
+		ConvertToServiceCheckpointConfig(src.Experimental.Checkpoint, dst.Checkpoint)
 	}
 }
 

--- a/deploy/operator/api/v1alpha1/shared_spec_conversion_bugs_test.go
+++ b/deploy/operator/api/v1alpha1/shared_spec_conversion_bugs_test.go
@@ -22,11 +22,55 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
 	v1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 )
+
+func TestConvertToServiceCheckpointConfigSetsNilIdentity(t *testing.T) {
+	var got ServiceCheckpointConfig
+	ConvertToServiceCheckpointConfig(&v1beta1.ComponentCheckpointConfig{
+		Mode:          v1beta1.CheckpointMode("auto"),
+		CheckpointRef: ptr.To("checkpoint"),
+	}, &got)
+	if got.Identity != nil {
+		t.Fatalf("ConvertToServiceCheckpointConfig().Identity = %#v, want nil", got.Identity)
+	}
+}
+
+func TestConvertFromSharedMemorySpec(t *testing.T) {
+	size := resource.MustParse("2Gi")
+	tests := []struct {
+		name string
+		src  *SharedMemorySpec
+		want string
+	}{
+		{name: "nil"},
+		{name: "zero size", src: &SharedMemorySpec{}},
+		{name: "disabled", src: &SharedMemorySpec{Disabled: true}, want: "0"},
+		{name: "size", src: &SharedMemorySpec{Size: size}, want: "2Gi"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got v1beta1.DynamoComponentDeploymentSharedSpec
+			if err := convertSharedMemoryTo(tt.src, &got); err != nil {
+				t.Fatalf("convertSharedMemoryTo() error = %v", err)
+			}
+			if tt.want == "" {
+				if got.SharedMemorySize != nil {
+					t.Fatalf("convertSharedMemoryTo().SharedMemorySize = %s, want nil", got.SharedMemorySize.String())
+				}
+				return
+			}
+			if got.SharedMemorySize == nil || got.SharedMemorySize.String() != tt.want {
+				t.Fatalf("convertSharedMemoryTo().SharedMemorySize = %v, want %s", got.SharedMemorySize, tt.want)
+			}
+		})
+	}
+}
 
 func addGeneratedFrontendSidecarHubOnlySecurityContext(t *testing.T, podTemplate *corev1.PodTemplateSpec) {
 	t.Helper()

--- a/deploy/operator/api/v1beta1/common.go
+++ b/deploy/operator/api/v1beta1/common.go
@@ -40,6 +40,17 @@ const (
 	ComponentTypeEPP      ComponentType = "epp"
 )
 
+const (
+	DynamoGraphDeploymentConditionTypeAvailable            = "Available"
+	DynamoGraphDeploymentConditionTypeDynamoComponentReady = "DynamoComponentReady"
+
+	ConditionTypeTopologyLevelsAvailable      = "TopologyLevelsAvailable"
+	ConditionReasonAllTopologyLevelsAvailable = "AllTopologyLevelsAvailable"
+	ConditionReasonTopologyLevelsUnavailable  = "TopologyLevelsUnavailable"
+	ConditionReasonTopologyDefinitionNotFound = "TopologyDefinitionNotFound"
+	ConditionReasonTopologyConditionPending   = "TopologyConditionPending"
+)
+
 // CompilationCacheConfig configures a PVC-backed compilation cache for a component.
 // The operator handles backend-specific mount paths and environment variables so
 // users do not need to hand-wire them into the pod template.

--- a/deploy/operator/api/v1beta1/dynamocomponentdeployment_types.go
+++ b/deploy/operator/api/v1beta1/dynamocomponentdeployment_types.go
@@ -292,6 +292,36 @@ func (s *DynamoComponentDeploymentSharedSpec) GetNumberOfNodes() int32 {
 	return 1
 }
 
+// IsInterPodGMSEnabled reports whether the inter-pod GMS layout is requested.
+func (s *DynamoComponentDeploymentSharedSpec) IsInterPodGMSEnabled() bool {
+	return s.Experimental != nil &&
+		s.Experimental.GPUMemoryService != nil &&
+		s.Experimental.GPUMemoryService.Mode == GMSModeInterPod
+}
+
+// IsInterPodFailoverEnabled reports whether inter-pod GMS failover is configured.
+func (s *DynamoComponentDeploymentSharedSpec) IsInterPodFailoverEnabled() bool {
+	return s.Experimental != nil &&
+		s.Experimental.Failover != nil &&
+		s.Experimental.Failover.Mode == GMSModeInterPod
+}
+
+// GetNumShadows returns the configured number of inter-pod failover shadow engines.
+func (s *DynamoComponentDeploymentSharedSpec) GetNumShadows() int32 {
+	if !s.IsInterPodFailoverEnabled() {
+		return 0
+	}
+	if s.Experimental.Failover.NumShadows < 1 {
+		return 1
+	}
+	return s.Experimental.Failover.NumShadows
+}
+
+// GetTotalEnginePods returns the primary engine plus any configured shadows.
+func (s *DynamoComponentDeploymentSharedSpec) GetTotalEnginePods() int32 {
+	return s.GetNumShadows() + 1
+}
+
 // IsFrontendComponent reports whether this DCD is the Dynamo frontend component.
 func (s *DynamoComponentDeployment) IsFrontendComponent() bool {
 	return s.Spec.ComponentType == ComponentTypeFrontend
@@ -350,7 +380,11 @@ func (s *DynamoComponentDeployment) GetComponentStatuses() map[string]ComponentR
 	if s.Status.Component == nil {
 		return map[string]ComponentReplicaStatus{}
 	}
-	return map[string]ComponentReplicaStatus{s.GetName(): *s.Status.Component}
+	componentName := s.Spec.ComponentName
+	if componentName == "" {
+		componentName = s.GetName()
+	}
+	return map[string]ComponentReplicaStatus{componentName: *s.Status.Component}
 }
 
 // GetState returns "ready" or "not_ready" based on status conditions.

--- a/deploy/operator/internal/dynamo/hash.go
+++ b/deploy/operator/internal/dynamo/hash.go
@@ -42,7 +42,7 @@ import (
 //
 // Only worker components (prefill, decode, worker) are included in the hash.
 func ComputeDGDWorkersSpecHash(dgd *v1alpha1.DynamoGraphDeployment) string {
-	hash, err := v1alpha1.ComputeV1alpha1DGDWorkersSpecHash(dgd)
+	hash, err := v1alpha1.ComputeDGDWorkersSpecHash(dgd)
 	if err != nil {
 		// Fallback to empty hash on error (shouldn't happen with valid input)
 		return "00000000"

--- a/deploy/operator/internal/dynamo/hash.go
+++ b/deploy/operator/internal/dynamo/hash.go
@@ -18,11 +18,6 @@
 package dynamo
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
-	"encoding/json"
-	"sort"
-
 	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 )
 
@@ -47,58 +42,10 @@ import (
 //
 // Only worker components (prefill, decode, worker) are included in the hash.
 func ComputeDGDWorkersSpecHash(dgd *v1alpha1.DynamoGraphDeployment) string {
-	// Collect worker specs in sorted order for deterministic hashing
-	var workerNames []string
-	for name, spec := range dgd.Spec.Services {
-		if spec != nil && IsWorkerComponent(spec.ComponentType) {
-			workerNames = append(workerNames, name)
-		}
-	}
-	sort.Strings(workerNames)
-
-	// Build hash input map (sorted keys for determinism)
-	hashInputs := make(map[string]v1alpha1.DynamoComponentDeploymentSharedSpec)
-	for _, name := range workerNames {
-		spec := dgd.Spec.Services[name]
-		hashInputs[name] = stripNonPodTemplateFields(spec)
-	}
-
-	// Serialize to JSON (Go's encoding/json sorts map keys)
-	data, err := json.Marshal(hashInputs)
+	hash, err := v1alpha1.ComputeV1alpha1DGDWorkersSpecHash(dgd)
 	if err != nil {
 		// Fallback to empty hash on error (shouldn't happen with valid input)
 		return "00000000"
 	}
-
-	// Compute SHA256 and take first 8 characters for readability
-	hash := sha256.Sum256(data)
-	return hex.EncodeToString(hash[:])[:8]
-}
-
-// stripNonPodTemplateFields returns a copy of the spec with fields that do NOT affect
-// the pod template zeroed out. The remaining fields are all pod-template-affecting and
-// will be included in the hash.
-//
-// This is an exclusion-based approach: new fields added to DynamoComponentDeploymentSharedSpec
-// are included in the hash by default. Only fields explicitly listed here are excluded.
-func stripNonPodTemplateFields(spec *v1alpha1.DynamoComponentDeploymentSharedSpec) v1alpha1.DynamoComponentDeploymentSharedSpec {
-	// Start with a shallow copy of the full spec
-	stripped := *spec
-
-	// Zero out fields that do NOT affect the pod template.
-	// These are identity, scaling, networking, and metadata fields.
-	stripped.Annotations = nil
-	stripped.Labels = nil
-	stripped.ServiceName = ""
-	stripped.ComponentType = ""
-	stripped.SubComponentType = ""
-	stripped.DynamoNamespace = nil
-	stripped.Replicas = nil
-	stripped.Autoscaling = nil //nolint:staticcheck // SA1019: intentionally clearing deprecated field for backward compatibility
-	stripped.ScalingAdapter = nil
-	stripped.Ingress = nil
-	stripped.ModelRef = nil
-	stripped.EPPConfig = nil
-
-	return stripped
+	return hash
 }

--- a/deploy/operator/internal/dynamo/hash_test.go
+++ b/deploy/operator/internal/dynamo/hash_test.go
@@ -175,51 +175,6 @@ func TestComputeDGDWorkersSpecHash_AllWorkerTypes(t *testing.T) {
 	assert.NotEqual(t, base, ComputeDGDWorkersSpecHash(dgd))
 }
 
-func TestStripNonPodTemplateFields(t *testing.T) {
-	spec := &v1alpha1.DynamoComponentDeploymentSharedSpec{
-		ServiceName:      "svc",
-		ComponentType:    commonconsts.ComponentTypeWorker,
-		SubComponentType: "sub",
-		DynamoNamespace:  ptr.To("ns"),
-		Replicas:         ptr.To(int32(3)),
-		Autoscaling:      &v1alpha1.Autoscaling{}, //nolint:staticcheck // SA1019: testing backward compatibility with deprecated field
-		ScalingAdapter:   &v1alpha1.ScalingAdapter{},
-		Ingress:          &v1alpha1.IngressSpec{Enabled: true},
-		ModelRef:         &v1alpha1.ModelReference{Name: "m"},
-		EPPConfig:        &v1alpha1.EPPConfig{},
-		Annotations:      map[string]string{"a": "b"},
-		Labels:           map[string]string{"c": "d"},
-		// Pod-affecting fields
-		Envs:                  []corev1.EnvVar{{Name: "Z"}, {Name: "A"}},
-		GlobalDynamoNamespace: true,
-	}
-	stripped := stripNonPodTemplateFields(spec)
-
-	// Excluded fields are zeroed
-	assert.Empty(t, stripped.ServiceName)
-	assert.Empty(t, stripped.ComponentType)
-	assert.Empty(t, stripped.SubComponentType)
-	assert.Nil(t, stripped.DynamoNamespace)
-	assert.Nil(t, stripped.Replicas)
-	assert.Nil(t, stripped.Autoscaling) //nolint:staticcheck // SA1019: testing backward compatibility with deprecated field
-	assert.Nil(t, stripped.ScalingAdapter)
-	assert.Nil(t, stripped.Ingress)
-	assert.Nil(t, stripped.ModelRef)
-	assert.Nil(t, stripped.EPPConfig)
-	assert.Nil(t, stripped.Annotations)
-	assert.Nil(t, stripped.Labels)
-
-	// Included fields are preserved
-	assert.True(t, stripped.GlobalDynamoNamespace)
-	assert.Len(t, stripped.Envs, 2)
-	// Envs are not sorted
-	assert.Equal(t, "Z", stripped.Envs[0].Name)
-	assert.Equal(t, "A", stripped.Envs[1].Name)
-
-	// Original spec is not mutated
-	assert.Equal(t, "svc", spec.ServiceName)
-}
-
 func TestSortEnvVars(t *testing.T) {
 	envs := []corev1.EnvVar{{Name: "C"}, {Name: "A"}, {Name: "B"}}
 	sorted := sortEnvVars(envs)

--- a/deploy/operator/internal/dynamo/ingress_types.go
+++ b/deploy/operator/internal/dynamo/ingress_types.go
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package dynamo
+
+// IngressTLSSpec is the internal TLS subset used when preserving v1alpha1
+// ingress behavior while the controllers reconcile v1beta1 objects.
+type IngressTLSSpec struct {
+	SecretName string `json:"secretName,omitempty"`
+}
+
+// IngressSpec is an internal controller compatibility shape for ingress config.
+// It is intentionally not part of the v1beta1 API; it lets the migrated
+// controllers keep reconciling ingress and virtual service resources from
+// preserved v1alpha1 payloads and operator-level defaults.
+type IngressSpec struct {
+	Enabled                    bool              `json:"enabled,omitempty"`
+	Host                       string            `json:"host,omitempty"`
+	UseVirtualService          bool              `json:"useVirtualService,omitempty"`
+	VirtualServiceGateway      *string           `json:"virtualServiceGateway,omitempty"`
+	HostPrefix                 *string           `json:"hostPrefix,omitempty"`
+	Annotations                map[string]string `json:"annotations,omitempty"`
+	Labels                     map[string]string `json:"labels,omitempty"`
+	TLS                        *IngressTLSSpec   `json:"tls,omitempty"`
+	HostSuffix                 *string           `json:"hostSuffix,omitempty"`
+	IngressControllerClassName *string           `json:"ingressControllerClassName,omitempty"`
+}
+
+// IsVirtualServiceEnabled reports whether this ingress config should reconcile
+// an Istio VirtualService in addition to, or instead of, a Kubernetes Ingress.
+func (i *IngressSpec) IsVirtualServiceEnabled() bool {
+	if i == nil {
+		return false
+	}
+	return i.Enabled && i.UseVirtualService && i.VirtualServiceGateway != nil
+}

--- a/deploy/operator/internal/dynamo/v1beta1_helpers.go
+++ b/deploy/operator/internal/dynamo/v1beta1_helpers.go
@@ -1,0 +1,299 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package dynamo
+
+import (
+	"encoding/json"
+	"maps"
+	"strings"
+
+	v1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+const (
+	preservedDCDAnnotationPrefix           = "nvidia.com/dcd-"
+	preservedDCDAlphaSpecAnnotation        = "nvidia.com/dcd-spec"
+	preservedDCDServiceNameAnnotation      = preservedDCDAnnotationPrefix + "service-name"
+	preservedDCDDynamoNamespaceAnnotation  = preservedDCDAnnotationPrefix + "dynamo-namespace"
+	preservedDCDSubComponentTypeAnnotation = preservedDCDAnnotationPrefix + "sub-component-type"
+	PreservedDCDAnnotationsAnnotation      = preservedDCDAnnotationPrefix + "annotations"
+	PreservedDCDLabelsAnnotation           = preservedDCDAnnotationPrefix + "labels"
+	PreservedDCDIngressAnnotation          = preservedDCDAnnotationPrefix + "ingress"
+)
+
+func IsPreservedDCDAnnotation(key string) bool {
+	return strings.HasPrefix(key, preservedDCDAnnotationPrefix)
+}
+
+func ComponentsByName(dgd *v1beta1.DynamoGraphDeployment) map[string]*v1beta1.DynamoComponentDeploymentSharedSpec {
+	components := make(map[string]*v1beta1.DynamoComponentDeploymentSharedSpec, len(dgd.Spec.Components))
+	for i := range dgd.Spec.Components {
+		component := &dgd.Spec.Components[i]
+		components[component.ComponentName] = component
+	}
+	return components
+}
+
+func GetPodTemplateAnnotations(component *v1beta1.DynamoComponentDeploymentSharedSpec) map[string]string {
+	if component == nil || component.PodTemplate == nil {
+		return nil
+	}
+	return component.PodTemplate.Annotations
+}
+
+func GetPodTemplateLabels(component *v1beta1.DynamoComponentDeploymentSharedSpec) map[string]string {
+	if component == nil || component.PodTemplate == nil {
+		return nil
+	}
+	return component.PodTemplate.Labels
+}
+
+func GetMainContainer(component *v1beta1.DynamoComponentDeploymentSharedSpec) *corev1.Container {
+	if component == nil || component.PodTemplate == nil {
+		return nil
+	}
+	for i := range component.PodTemplate.Spec.Containers {
+		if component.PodTemplate.Spec.Containers[i].Name == commonconsts.MainContainerName {
+			return &component.PodTemplate.Spec.Containers[i]
+		}
+	}
+	return nil
+}
+
+func GetMainContainerResources(component *v1beta1.DynamoComponentDeploymentSharedSpec) corev1.ResourceRequirements {
+	if main := GetMainContainer(component); main != nil {
+		return main.Resources
+	}
+	return corev1.ResourceRequirements{}
+}
+
+func GetGPUMemoryService(component *v1beta1.DynamoComponentDeploymentSharedSpec) *v1beta1.GPUMemoryServiceSpec {
+	if component == nil || component.Experimental == nil {
+		return nil
+	}
+	return component.Experimental.GPUMemoryService
+}
+
+func GetCheckpoint(component *v1beta1.DynamoComponentDeploymentSharedSpec) *v1beta1.ComponentCheckpointConfig {
+	if component == nil || component.Experimental == nil {
+		return nil
+	}
+	return component.Experimental.Checkpoint
+}
+
+func ToAlphaCheckpointConfig(src *v1beta1.ComponentCheckpointConfig) *v1alpha1.ServiceCheckpointConfig {
+	if src == nil {
+		return nil
+	}
+	dst := &v1alpha1.ServiceCheckpointConfig{
+		Enabled:       true,
+		Mode:          v1alpha1.CheckpointMode(src.Mode),
+		CheckpointRef: src.CheckpointRef,
+		Identity:      ToAlphaCheckpointIdentity(src.Identity),
+	}
+	return dst
+}
+
+func ToAlphaCheckpointIdentity(src *v1beta1.DynamoCheckpointIdentity) *v1alpha1.DynamoCheckpointIdentity {
+	if src == nil {
+		return nil
+	}
+	return &v1alpha1.DynamoCheckpointIdentity{
+		Model:                src.Model,
+		BackendFramework:     src.BackendFramework,
+		DynamoVersion:        src.DynamoVersion,
+		TensorParallelSize:   src.TensorParallelSize,
+		PipelineParallelSize: src.PipelineParallelSize,
+		Dtype:                src.Dtype,
+		MaxModelLen:          src.MaxModelLen,
+		ExtraParameters:      src.ExtraParameters,
+	}
+}
+
+func ToAlphaGPUMemoryService(src *v1beta1.GPUMemoryServiceSpec) *v1alpha1.GPUMemoryServiceSpec {
+	if src == nil {
+		return nil
+	}
+	return &v1alpha1.GPUMemoryServiceSpec{
+		Enabled:         true,
+		Mode:            v1alpha1.GPUMemoryServiceMode(src.Mode),
+		DeviceClassName: src.DeviceClassName,
+	}
+}
+
+func ToBetaSharedMemorySize(src *v1alpha1.SharedMemorySpec) *resource.Quantity {
+	if src == nil {
+		return nil
+	}
+	if src.Disabled {
+		zero := resource.MustParse("0")
+		return &zero
+	}
+	if src.Size.IsZero() {
+		return nil
+	}
+	size := src.Size.DeepCopy()
+	return &size
+}
+
+func GetDCDComponentName(dcd *v1beta1.DynamoComponentDeployment) string {
+	if dcd == nil {
+		return ""
+	}
+	if dcd.Spec.ComponentName != "" {
+		return dcd.Spec.ComponentName
+	}
+	if dcd.Labels != nil {
+		if componentName := dcd.Labels[commonconsts.KubeLabelDynamoComponent]; componentName != "" {
+			return componentName
+		}
+	}
+	if serviceName := dcd.GetAnnotations()[preservedDCDServiceNameAnnotation]; serviceName != "" {
+		return serviceName
+	}
+	return dcd.Name
+}
+
+func GetDCDDynamoNamespace(dcd *v1beta1.DynamoComponentDeployment) string {
+	if dcd == nil {
+		return ""
+	}
+	if spec := getDCDPreservedAlphaSpec(dcd); spec != nil {
+		if spec.DynamoNamespace != nil {
+			return *spec.DynamoNamespace
+		}
+	} else if dynamoNamespace := dcd.GetAnnotations()[preservedDCDDynamoNamespaceAnnotation]; dynamoNamespace != "" {
+		return dynamoNamespace
+	}
+	if dcd.Labels != nil {
+		if dynamoNamespace := dcd.Labels[commonconsts.KubeLabelDynamoNamespace]; dynamoNamespace != "" {
+			return dynamoNamespace
+		}
+	}
+	parentName := dcd.GetParentGraphDeploymentName()
+	if parentName == "" {
+		parentName = dcd.Name
+	}
+	return v1beta1.ComputeDynamoNamespace(dcd.Spec.GlobalDynamoNamespace, dcd.GetNamespace(), parentName)
+}
+
+func GetDCDSubComponentType(dcd *v1beta1.DynamoComponentDeployment) string {
+	if dcd == nil {
+		return ""
+	}
+	if spec := getDCDPreservedAlphaSpec(dcd); spec != nil {
+		return spec.SubComponentType
+	}
+	if subComponentType := dcd.GetAnnotations()[preservedDCDSubComponentTypeAnnotation]; subComponentType != "" {
+		return subComponentType
+	}
+	return ""
+}
+
+func GetDCDPreservedAlphaAnnotations(dcd *v1beta1.DynamoComponentDeployment) map[string]string {
+	if spec := getDCDPreservedAlphaSpec(dcd); spec != nil {
+		return maps.Clone(spec.Annotations)
+	}
+	if values := getDCDPreservedStringMapAnnotation(dcd, PreservedDCDAnnotationsAnnotation); values != nil {
+		return values
+	}
+	return nil
+}
+
+func GetDCDPreservedAlphaLabels(dcd *v1beta1.DynamoComponentDeployment) map[string]string {
+	if spec := getDCDPreservedAlphaSpec(dcd); spec != nil {
+		return maps.Clone(spec.Labels)
+	}
+	if values := getDCDPreservedStringMapAnnotation(dcd, PreservedDCDLabelsAnnotation); values != nil {
+		return values
+	}
+	return nil
+}
+
+func GetDCDPreservedAlphaIngressSpec(dcd *v1beta1.DynamoComponentDeployment) (IngressSpec, bool, error) {
+	if dcd == nil {
+		return IngressSpec{}, false, nil
+	}
+	spec := getDCDPreservedAlphaSpec(dcd)
+	if spec != nil {
+		if spec.Ingress == nil {
+			return IngressSpec{}, false, nil
+		}
+		data, err := json.Marshal(spec.Ingress)
+		if err != nil {
+			return IngressSpec{}, false, err
+		}
+		var ingressSpec IngressSpec
+		if err := json.Unmarshal(data, &ingressSpec); err != nil {
+			return IngressSpec{}, false, err
+		}
+		return ingressSpec, true, nil
+	}
+	raw := dcd.GetAnnotations()[PreservedDCDIngressAnnotation]
+	if raw == "" {
+		return IngressSpec{}, false, nil
+	}
+	var ingressSpec IngressSpec
+	if err := json.Unmarshal([]byte(raw), &ingressSpec); err != nil {
+		return IngressSpec{}, false, err
+	}
+	return ingressSpec, true, nil
+}
+
+func getDCDPreservedStringMapAnnotation(dcd *v1beta1.DynamoComponentDeployment, key string) map[string]string {
+	if dcd == nil {
+		return nil
+	}
+	raw := dcd.GetAnnotations()[key]
+	if raw == "" {
+		return nil
+	}
+	var values map[string]string
+	if err := json.Unmarshal([]byte(raw), &values); err != nil {
+		return nil
+	}
+	return values
+}
+
+func getDCDPreservedAlphaSpec(dcd *v1beta1.DynamoComponentDeployment) *v1alpha1.DynamoComponentDeploymentSharedSpec {
+	if dcd == nil {
+		return nil
+	}
+	raw := dcd.GetAnnotations()[preservedDCDAlphaSpecAnnotation]
+	if raw == "" {
+		return nil
+	}
+	var envelope struct {
+		Spec *v1alpha1.DynamoComponentDeploymentSpec `json:"spec"`
+	}
+	if err := json.Unmarshal([]byte(raw), &envelope); err == nil && envelope.Spec != nil {
+		return &envelope.Spec.DynamoComponentDeploymentSharedSpec
+	}
+	var spec v1alpha1.DynamoComponentDeploymentSpec
+	if err := json.Unmarshal([]byte(raw), &spec); err != nil {
+		return nil
+	}
+	return &spec.DynamoComponentDeploymentSharedSpec
+}
+
+func mergeLowPriorityMetadata(dst, src map[string]string) map[string]string {
+	if len(src) == 0 {
+		return dst
+	}
+	if dst == nil {
+		dst = map[string]string{}
+	}
+	for k, v := range src {
+		if _, exists := dst[k]; !exists {
+			dst[k] = v
+		}
+	}
+	return dst
+}

--- a/deploy/operator/internal/dynamo/v1beta1_helpers.go
+++ b/deploy/operator/internal/dynamo/v1beta1_helpers.go
@@ -89,58 +89,19 @@ func GetCheckpoint(component *v1beta1.DynamoComponentDeploymentSharedSpec) *v1be
 }
 
 func ToAlphaCheckpointConfig(src *v1beta1.ComponentCheckpointConfig) *v1alpha1.ServiceCheckpointConfig {
-	if src == nil {
-		return nil
-	}
-	dst := &v1alpha1.ServiceCheckpointConfig{
-		Enabled:       true,
-		Mode:          v1alpha1.CheckpointMode(src.Mode),
-		CheckpointRef: src.CheckpointRef,
-		Identity:      ToAlphaCheckpointIdentity(src.Identity),
-	}
-	return dst
+	return v1alpha1.ConvertToV1alpha1ComponentCheckpoint(src)
 }
 
 func ToAlphaCheckpointIdentity(src *v1beta1.DynamoCheckpointIdentity) *v1alpha1.DynamoCheckpointIdentity {
-	if src == nil {
-		return nil
-	}
-	return &v1alpha1.DynamoCheckpointIdentity{
-		Model:                src.Model,
-		BackendFramework:     src.BackendFramework,
-		DynamoVersion:        src.DynamoVersion,
-		TensorParallelSize:   src.TensorParallelSize,
-		PipelineParallelSize: src.PipelineParallelSize,
-		Dtype:                src.Dtype,
-		MaxModelLen:          src.MaxModelLen,
-		ExtraParameters:      src.ExtraParameters,
-	}
+	return v1alpha1.ConvertToV1alpha1CheckpointIdentity(src)
 }
 
 func ToAlphaGPUMemoryService(src *v1beta1.GPUMemoryServiceSpec) *v1alpha1.GPUMemoryServiceSpec {
-	if src == nil {
-		return nil
-	}
-	return &v1alpha1.GPUMemoryServiceSpec{
-		Enabled:         true,
-		Mode:            v1alpha1.GPUMemoryServiceMode(src.Mode),
-		DeviceClassName: src.DeviceClassName,
-	}
+	return v1alpha1.ConvertToV1alpha1GPUMemoryService(src)
 }
 
 func ToBetaSharedMemorySize(src *v1alpha1.SharedMemorySpec) *resource.Quantity {
-	if src == nil {
-		return nil
-	}
-	if src.Disabled {
-		zero := resource.MustParse("0")
-		return &zero
-	}
-	if src.Size.IsZero() {
-		return nil
-	}
-	size := src.Size.DeepCopy()
-	return &size
+	return v1alpha1.ConvertToV1beta1SharedMemorySize(src)
 }
 
 func GetDCDComponentName(dcd *v1beta1.DynamoComponentDeployment) string {

--- a/deploy/operator/internal/dynamo/v1beta1_helpers.go
+++ b/deploy/operator/internal/dynamo/v1beta1_helpers.go
@@ -6,31 +6,10 @@
 package dynamo
 
 import (
-	"encoding/json"
-	"maps"
-	"strings"
-
-	v1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 )
-
-const (
-	preservedDCDAnnotationPrefix           = "nvidia.com/dcd-"
-	preservedDCDAlphaSpecAnnotation        = "nvidia.com/dcd-spec"
-	preservedDCDServiceNameAnnotation      = preservedDCDAnnotationPrefix + "service-name"
-	preservedDCDDynamoNamespaceAnnotation  = preservedDCDAnnotationPrefix + "dynamo-namespace"
-	preservedDCDSubComponentTypeAnnotation = preservedDCDAnnotationPrefix + "sub-component-type"
-	PreservedDCDAnnotationsAnnotation      = preservedDCDAnnotationPrefix + "annotations"
-	PreservedDCDLabelsAnnotation           = preservedDCDAnnotationPrefix + "labels"
-	PreservedDCDIngressAnnotation          = preservedDCDAnnotationPrefix + "ingress"
-)
-
-func IsPreservedDCDAnnotation(key string) bool {
-	return strings.HasPrefix(key, preservedDCDAnnotationPrefix)
-}
 
 func ComponentsByName(dgd *v1beta1.DynamoGraphDeployment) map[string]*v1beta1.DynamoComponentDeploymentSharedSpec {
 	components := make(map[string]*v1beta1.DynamoComponentDeploymentSharedSpec, len(dgd.Spec.Components))
@@ -88,22 +67,6 @@ func GetCheckpoint(component *v1beta1.DynamoComponentDeploymentSharedSpec) *v1be
 	return component.Experimental.Checkpoint
 }
 
-func ToAlphaCheckpointConfig(src *v1beta1.ComponentCheckpointConfig) *v1alpha1.ServiceCheckpointConfig {
-	return v1alpha1.ConvertToV1alpha1ComponentCheckpoint(src)
-}
-
-func ToAlphaCheckpointIdentity(src *v1beta1.DynamoCheckpointIdentity) *v1alpha1.DynamoCheckpointIdentity {
-	return v1alpha1.ConvertToV1alpha1CheckpointIdentity(src)
-}
-
-func ToAlphaGPUMemoryService(src *v1beta1.GPUMemoryServiceSpec) *v1alpha1.GPUMemoryServiceSpec {
-	return v1alpha1.ConvertToV1alpha1GPUMemoryService(src)
-}
-
-func ToBetaSharedMemorySize(src *v1alpha1.SharedMemorySpec) *resource.Quantity {
-	return v1alpha1.ConvertToV1beta1SharedMemorySize(src)
-}
-
 func GetDCDComponentName(dcd *v1beta1.DynamoComponentDeployment) string {
 	if dcd == nil {
 		return ""
@@ -116,22 +79,12 @@ func GetDCDComponentName(dcd *v1beta1.DynamoComponentDeployment) string {
 			return componentName
 		}
 	}
-	if serviceName := dcd.GetAnnotations()[preservedDCDServiceNameAnnotation]; serviceName != "" {
-		return serviceName
-	}
 	return dcd.Name
 }
 
 func GetDCDDynamoNamespace(dcd *v1beta1.DynamoComponentDeployment) string {
 	if dcd == nil {
 		return ""
-	}
-	if spec := getDCDPreservedAlphaSpec(dcd); spec != nil {
-		if spec.DynamoNamespace != nil {
-			return *spec.DynamoNamespace
-		}
-	} else if dynamoNamespace := dcd.GetAnnotations()[preservedDCDDynamoNamespaceAnnotation]; dynamoNamespace != "" {
-		return dynamoNamespace
 	}
 	if dcd.Labels != nil {
 		if dynamoNamespace := dcd.Labels[commonconsts.KubeLabelDynamoNamespace]; dynamoNamespace != "" {
@@ -143,105 +96,6 @@ func GetDCDDynamoNamespace(dcd *v1beta1.DynamoComponentDeployment) string {
 		parentName = dcd.Name
 	}
 	return v1beta1.ComputeDynamoNamespace(dcd.Spec.GlobalDynamoNamespace, dcd.GetNamespace(), parentName)
-}
-
-func GetDCDSubComponentType(dcd *v1beta1.DynamoComponentDeployment) string {
-	if dcd == nil {
-		return ""
-	}
-	if spec := getDCDPreservedAlphaSpec(dcd); spec != nil {
-		return spec.SubComponentType
-	}
-	if subComponentType := dcd.GetAnnotations()[preservedDCDSubComponentTypeAnnotation]; subComponentType != "" {
-		return subComponentType
-	}
-	return ""
-}
-
-func GetDCDPreservedAlphaAnnotations(dcd *v1beta1.DynamoComponentDeployment) map[string]string {
-	if spec := getDCDPreservedAlphaSpec(dcd); spec != nil {
-		return maps.Clone(spec.Annotations)
-	}
-	if values := getDCDPreservedStringMapAnnotation(dcd, PreservedDCDAnnotationsAnnotation); values != nil {
-		return values
-	}
-	return nil
-}
-
-func GetDCDPreservedAlphaLabels(dcd *v1beta1.DynamoComponentDeployment) map[string]string {
-	if spec := getDCDPreservedAlphaSpec(dcd); spec != nil {
-		return maps.Clone(spec.Labels)
-	}
-	if values := getDCDPreservedStringMapAnnotation(dcd, PreservedDCDLabelsAnnotation); values != nil {
-		return values
-	}
-	return nil
-}
-
-func GetDCDPreservedAlphaIngressSpec(dcd *v1beta1.DynamoComponentDeployment) (IngressSpec, bool, error) {
-	if dcd == nil {
-		return IngressSpec{}, false, nil
-	}
-	spec := getDCDPreservedAlphaSpec(dcd)
-	if spec != nil {
-		if spec.Ingress == nil {
-			return IngressSpec{}, false, nil
-		}
-		data, err := json.Marshal(spec.Ingress)
-		if err != nil {
-			return IngressSpec{}, false, err
-		}
-		var ingressSpec IngressSpec
-		if err := json.Unmarshal(data, &ingressSpec); err != nil {
-			return IngressSpec{}, false, err
-		}
-		return ingressSpec, true, nil
-	}
-	raw := dcd.GetAnnotations()[PreservedDCDIngressAnnotation]
-	if raw == "" {
-		return IngressSpec{}, false, nil
-	}
-	var ingressSpec IngressSpec
-	if err := json.Unmarshal([]byte(raw), &ingressSpec); err != nil {
-		return IngressSpec{}, false, err
-	}
-	return ingressSpec, true, nil
-}
-
-func getDCDPreservedStringMapAnnotation(dcd *v1beta1.DynamoComponentDeployment, key string) map[string]string {
-	if dcd == nil {
-		return nil
-	}
-	raw := dcd.GetAnnotations()[key]
-	if raw == "" {
-		return nil
-	}
-	var values map[string]string
-	if err := json.Unmarshal([]byte(raw), &values); err != nil {
-		return nil
-	}
-	return values
-}
-
-func getDCDPreservedAlphaSpec(dcd *v1beta1.DynamoComponentDeployment) *v1alpha1.DynamoComponentDeploymentSharedSpec {
-	if dcd == nil {
-		return nil
-	}
-	raw := dcd.GetAnnotations()[preservedDCDAlphaSpecAnnotation]
-	if raw == "" {
-		return nil
-	}
-	var envelope struct {
-		Spec *v1alpha1.DynamoComponentDeploymentSpec `json:"spec"`
-	}
-	if err := json.Unmarshal([]byte(raw), &envelope); err == nil && envelope.Spec != nil {
-		return &envelope.Spec.DynamoComponentDeploymentSharedSpec
-	}
-	var spec v1alpha1.DynamoComponentDeploymentSpec
-	if err := json.Unmarshal([]byte(raw), &spec); err != nil {
-		return nil
-	}
-	return &spec.DynamoComponentDeploymentSharedSpec
 }
 
 func mergeLowPriorityMetadata(dst, src map[string]string) map[string]string {

--- a/deploy/operator/internal/dynamo/v1beta1_helpers.go
+++ b/deploy/operator/internal/dynamo/v1beta1_helpers.go
@@ -12,6 +12,10 @@ import (
 )
 
 func ComponentsByName(dgd *v1beta1.DynamoGraphDeployment) map[string]*v1beta1.DynamoComponentDeploymentSharedSpec {
+	if dgd == nil {
+		return map[string]*v1beta1.DynamoComponentDeploymentSharedSpec{}
+	}
+
 	components := make(map[string]*v1beta1.DynamoComponentDeploymentSharedSpec, len(dgd.Spec.Components))
 	for i := range dgd.Spec.Components {
 		component := &dgd.Spec.Components[i]

--- a/deploy/operator/internal/dynamo/v1beta1_helpers_test.go
+++ b/deploy/operator/internal/dynamo/v1beta1_helpers_test.go
@@ -9,6 +9,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+func TestComponentsByNameNil(t *testing.T) {
+	if got := ComponentsByName(nil); len(got) != 0 {
+		t.Fatalf("ComponentsByName(nil) = %#v, want empty map", got)
+	}
+}
+
 func TestGetDCDComponentNamePrefersSpecOverLegacyMetadata(t *testing.T) {
 	dcd := &v1beta1.DynamoComponentDeployment{
 		ObjectMeta: metav1.ObjectMeta{

--- a/deploy/operator/internal/dynamo/v1beta1_helpers_test.go
+++ b/deploy/operator/internal/dynamo/v1beta1_helpers_test.go
@@ -1,16 +1,12 @@
 package dynamo
 
 import (
-	"encoding/json"
 	"maps"
 	"testing"
 
-	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 )
 
 func TestGetDCDComponentNamePrefersSpecOverLegacyMetadata(t *testing.T) {
@@ -19,9 +15,6 @@ func TestGetDCDComponentNamePrefersSpecOverLegacyMetadata(t *testing.T) {
 			Name: "metadata-name",
 			Labels: map[string]string{
 				commonconsts.KubeLabelDynamoComponent: "label-component",
-			},
-			Annotations: map[string]string{
-				preservedDCDServiceNameAnnotation: "annotation-component",
 			},
 		},
 		Spec: v1beta1.DynamoComponentDeploymentSpec{
@@ -54,24 +47,9 @@ func TestGetDCDComponentNameLegacyFallbacks(t *testing.T) {
 					Labels: map[string]string{
 						commonconsts.KubeLabelDynamoComponent: "label-component",
 					},
-					Annotations: map[string]string{
-						preservedDCDServiceNameAnnotation: "annotation-component",
-					},
 				},
 			},
 			want: "label-component",
-		},
-		{
-			name: "annotation",
-			dcd: &v1beta1.DynamoComponentDeployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "metadata-name",
-					Annotations: map[string]string{
-						preservedDCDServiceNameAnnotation: "annotation-component",
-					},
-				},
-			},
-			want: "annotation-component",
 		},
 		{
 			name: "metadata name",
@@ -91,167 +69,6 @@ func TestGetDCDComponentNameLegacyFallbacks(t *testing.T) {
 	}
 }
 
-func TestPreservedAlphaSpecTakesPrecedenceOverLegacyCarrierAnnotations(t *testing.T) {
-	dynamoNamespace := "canonical-namespace"
-	alphaSpec := v1alpha1.DynamoComponentDeploymentSpec{
-		DynamoComponentDeploymentSharedSpec: v1alpha1.DynamoComponentDeploymentSharedSpec{
-			Annotations:      map[string]string{"canonical-annotation": "kept"},
-			Labels:           map[string]string{"canonical-label": "kept"},
-			DynamoNamespace:  &dynamoNamespace,
-			SubComponentType: "canonical-sub",
-			Ingress: &v1alpha1.IngressSpec{
-				Enabled:                    true,
-				Host:                       "canonical.example.com",
-				IngressControllerClassName: ptr.To("nginx"),
-			},
-		},
-	}
-	dcd := dcdWithPreservedAlphaSpec(t, alphaSpec, true)
-	dcd.Labels = map[string]string{
-		commonconsts.KubeLabelDynamoNamespace: "label-namespace",
-	}
-	dcd.Annotations[preservedDCDDynamoNamespaceAnnotation] = "stale-namespace"
-	dcd.Annotations[preservedDCDSubComponentTypeAnnotation] = "stale-sub"
-	dcd.Annotations[PreservedDCDAnnotationsAnnotation] = mustJSON(t, map[string]string{"stale-annotation": "ignored"})
-	dcd.Annotations[PreservedDCDLabelsAnnotation] = mustJSON(t, map[string]string{"stale-label": "ignored"})
-	dcd.Annotations[PreservedDCDIngressAnnotation] = mustJSON(t, IngressSpec{Enabled: true, Host: "stale.example.com"})
-
-	if got := GetDCDDynamoNamespace(dcd); got != "canonical-namespace" {
-		t.Fatalf("GetDCDDynamoNamespace() = %q, want canonical-namespace", got)
-	}
-	if got := GetDCDSubComponentType(dcd); got != "canonical-sub" {
-		t.Fatalf("GetDCDSubComponentType() = %q, want canonical-sub", got)
-	}
-	if got, want := GetDCDPreservedAlphaAnnotations(dcd), alphaSpec.Annotations; !maps.Equal(got, want) {
-		t.Fatalf("GetDCDPreservedAlphaAnnotations() = %#v, want %#v", got, want)
-	}
-	if got, want := GetDCDPreservedAlphaLabels(dcd), alphaSpec.Labels; !maps.Equal(got, want) {
-		t.Fatalf("GetDCDPreservedAlphaLabels() = %#v, want %#v", got, want)
-	}
-	ingressSpec, ok, err := GetDCDPreservedAlphaIngressSpec(dcd)
-	if err != nil {
-		t.Fatalf("GetDCDPreservedAlphaIngressSpec() error = %v", err)
-	}
-	if !ok || !ingressSpec.Enabled || ingressSpec.Host != "canonical.example.com" || ingressSpec.IngressControllerClassName == nil || *ingressSpec.IngressControllerClassName != "nginx" {
-		t.Fatalf("GetDCDPreservedAlphaIngressSpec() = (%#v, %v), want canonical ingress", ingressSpec, ok)
-	}
-}
-
-func TestPreservedAlphaHelpersFallbackToLegacyCarrierAnnotations(t *testing.T) {
-	dcd := &v1beta1.DynamoComponentDeployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "dcd",
-			Namespace: "test-ns",
-			Annotations: map[string]string{
-				preservedDCDDynamoNamespaceAnnotation:  "legacy-namespace",
-				preservedDCDSubComponentTypeAnnotation: "legacy-sub",
-				PreservedDCDAnnotationsAnnotation:      mustJSON(t, map[string]string{"legacy-annotation": "kept"}),
-				PreservedDCDLabelsAnnotation:           mustJSON(t, map[string]string{"legacy-label": "kept"}),
-				PreservedDCDIngressAnnotation:          mustJSON(t, IngressSpec{Enabled: true, Host: "legacy.example.com"}),
-			},
-			Labels: map[string]string{
-				commonconsts.KubeLabelDynamoNamespace: "label-namespace",
-			},
-		},
-	}
-
-	if got := GetDCDDynamoNamespace(dcd); got != "legacy-namespace" {
-		t.Fatalf("GetDCDDynamoNamespace() = %q, want legacy-namespace", got)
-	}
-	if got := GetDCDSubComponentType(dcd); got != "legacy-sub" {
-		t.Fatalf("GetDCDSubComponentType() = %q, want legacy-sub", got)
-	}
-	if got, want := GetDCDPreservedAlphaAnnotations(dcd), map[string]string{"legacy-annotation": "kept"}; !maps.Equal(got, want) {
-		t.Fatalf("GetDCDPreservedAlphaAnnotations() = %#v, want %#v", got, want)
-	}
-	if got, want := GetDCDPreservedAlphaLabels(dcd), map[string]string{"legacy-label": "kept"}; !maps.Equal(got, want) {
-		t.Fatalf("GetDCDPreservedAlphaLabels() = %#v, want %#v", got, want)
-	}
-	ingressSpec, ok, err := GetDCDPreservedAlphaIngressSpec(dcd)
-	if err != nil {
-		t.Fatalf("GetDCDPreservedAlphaIngressSpec() error = %v", err)
-	}
-	if !ok || ingressSpec.Host != "legacy.example.com" {
-		t.Fatalf("GetDCDPreservedAlphaIngressSpec() = (%#v, %v), want legacy ingress", ingressSpec, ok)
-	}
-}
-
-func TestGetDCDPreservedAlphaSpecSupportsEnvelopeAndRawSpec(t *testing.T) {
-	dynamoNamespace := "raw-namespace"
-	alphaSpec := v1alpha1.DynamoComponentDeploymentSpec{
-		DynamoComponentDeploymentSharedSpec: v1alpha1.DynamoComponentDeploymentSharedSpec{
-			DynamoNamespace:  &dynamoNamespace,
-			SubComponentType: "raw-sub",
-		},
-	}
-
-	envelopeDCD := dcdWithPreservedAlphaSpec(t, alphaSpec, true)
-	if got := getDCDPreservedAlphaSpec(envelopeDCD); got == nil || got.SubComponentType != "raw-sub" {
-		t.Fatalf("envelope getDCDPreservedAlphaSpec() = %#v, want raw-sub", got)
-	}
-
-	rawDCD := dcdWithPreservedAlphaSpec(t, alphaSpec, false)
-	if got := getDCDPreservedAlphaSpec(rawDCD); got == nil || got.DynamoNamespace == nil || *got.DynamoNamespace != "raw-namespace" {
-		t.Fatalf("raw getDCDPreservedAlphaSpec() = %#v, want raw-namespace", got)
-	}
-}
-
-func TestGetDCDPreservedAlphaIngressSpecReturnsMalformedAnnotationError(t *testing.T) {
-	dcd := &v1beta1.DynamoComponentDeployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Annotations: map[string]string{
-				PreservedDCDIngressAnnotation: "{",
-			},
-		},
-	}
-
-	if _, _, err := GetDCDPreservedAlphaIngressSpec(dcd); err == nil {
-		t.Fatalf("GetDCDPreservedAlphaIngressSpec() error = nil, want malformed JSON error")
-	}
-}
-
-func TestToAlphaCheckpointConfigSetsNilIdentityThroughConverter(t *testing.T) {
-	got := ToAlphaCheckpointConfig(&v1beta1.ComponentCheckpointConfig{
-		Mode:          v1beta1.CheckpointMode("auto"),
-		CheckpointRef: ptr.To("checkpoint"),
-	})
-	if got == nil {
-		t.Fatalf("ToAlphaCheckpointConfig() = nil")
-	}
-	if got.Identity != nil {
-		t.Fatalf("ToAlphaCheckpointConfig().Identity = %#v, want nil", got.Identity)
-	}
-}
-
-func TestToBetaSharedMemorySize(t *testing.T) {
-	size := resource.MustParse("2Gi")
-	tests := []struct {
-		name string
-		src  *v1alpha1.SharedMemorySpec
-		want string
-	}{
-		{name: "nil"},
-		{name: "zero size", src: &v1alpha1.SharedMemorySpec{}},
-		{name: "disabled", src: &v1alpha1.SharedMemorySpec{Disabled: true}, want: "0"},
-		{name: "size", src: &v1alpha1.SharedMemorySpec{Size: size}, want: "2Gi"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := ToBetaSharedMemorySize(tt.src)
-			if tt.want == "" {
-				if got != nil {
-					t.Fatalf("ToBetaSharedMemorySize() = %s, want nil", got.String())
-				}
-				return
-			}
-			if got == nil || got.String() != tt.want {
-				t.Fatalf("ToBetaSharedMemorySize() = %v, want %s", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestMergeLowPriorityMetadata(t *testing.T) {
 	got := mergeLowPriorityMetadata(
 		map[string]string{"existing": "kept", "shared": "winner"},
@@ -261,33 +78,4 @@ func TestMergeLowPriorityMetadata(t *testing.T) {
 	if !maps.Equal(got, want) {
 		t.Fatalf("mergeLowPriorityMetadata() = %#v, want %#v", got, want)
 	}
-}
-
-func dcdWithPreservedAlphaSpec(t *testing.T, spec v1alpha1.DynamoComponentDeploymentSpec, envelope bool) *v1beta1.DynamoComponentDeployment {
-	t.Helper()
-
-	var value any = spec
-	if envelope {
-		value = struct {
-			Spec v1alpha1.DynamoComponentDeploymentSpec `json:"spec"`
-		}{Spec: spec}
-	}
-	return &v1beta1.DynamoComponentDeployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "dcd",
-			Annotations: map[string]string{
-				preservedDCDAlphaSpecAnnotation: mustJSON(t, value),
-			},
-		},
-	}
-}
-
-func mustJSON(t *testing.T, value any) string {
-	t.Helper()
-
-	data, err := json.Marshal(value)
-	if err != nil {
-		t.Fatalf("json.Marshal(%#v) error = %v", value, err)
-	}
-	return string(data)
 }

--- a/deploy/operator/internal/dynamo/v1beta1_helpers_test.go
+++ b/deploy/operator/internal/dynamo/v1beta1_helpers_test.go
@@ -1,0 +1,293 @@
+package dynamo
+
+import (
+	"encoding/json"
+	"maps"
+	"testing"
+
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+func TestGetDCDComponentNamePrefersSpecOverLegacyMetadata(t *testing.T) {
+	dcd := &v1beta1.DynamoComponentDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "metadata-name",
+			Labels: map[string]string{
+				commonconsts.KubeLabelDynamoComponent: "label-component",
+			},
+			Annotations: map[string]string{
+				preservedDCDServiceNameAnnotation: "annotation-component",
+			},
+		},
+		Spec: v1beta1.DynamoComponentDeploymentSpec{
+			DynamoComponentDeploymentSharedSpec: v1beta1.DynamoComponentDeploymentSharedSpec{
+				ComponentName: "spec-component",
+			},
+		},
+	}
+
+	if got, want := GetDCDComponentName(dcd), "spec-component"; got != want {
+		t.Fatalf("GetDCDComponentName() = %q, want %q", got, want)
+	}
+}
+
+func TestGetDCDComponentNameLegacyFallbacks(t *testing.T) {
+	tests := []struct {
+		name string
+		dcd  *v1beta1.DynamoComponentDeployment
+		want string
+	}{
+		{
+			name: "nil",
+			want: "",
+		},
+		{
+			name: "label",
+			dcd: &v1beta1.DynamoComponentDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "metadata-name",
+					Labels: map[string]string{
+						commonconsts.KubeLabelDynamoComponent: "label-component",
+					},
+					Annotations: map[string]string{
+						preservedDCDServiceNameAnnotation: "annotation-component",
+					},
+				},
+			},
+			want: "label-component",
+		},
+		{
+			name: "annotation",
+			dcd: &v1beta1.DynamoComponentDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "metadata-name",
+					Annotations: map[string]string{
+						preservedDCDServiceNameAnnotation: "annotation-component",
+					},
+				},
+			},
+			want: "annotation-component",
+		},
+		{
+			name: "metadata name",
+			dcd: &v1beta1.DynamoComponentDeployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "metadata-name"},
+			},
+			want: "metadata-name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetDCDComponentName(tt.dcd); got != tt.want {
+				t.Fatalf("GetDCDComponentName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPreservedAlphaSpecTakesPrecedenceOverLegacyCarrierAnnotations(t *testing.T) {
+	dynamoNamespace := "canonical-namespace"
+	alphaSpec := v1alpha1.DynamoComponentDeploymentSpec{
+		DynamoComponentDeploymentSharedSpec: v1alpha1.DynamoComponentDeploymentSharedSpec{
+			Annotations:      map[string]string{"canonical-annotation": "kept"},
+			Labels:           map[string]string{"canonical-label": "kept"},
+			DynamoNamespace:  &dynamoNamespace,
+			SubComponentType: "canonical-sub",
+			Ingress: &v1alpha1.IngressSpec{
+				Enabled:                    true,
+				Host:                       "canonical.example.com",
+				IngressControllerClassName: ptr.To("nginx"),
+			},
+		},
+	}
+	dcd := dcdWithPreservedAlphaSpec(t, alphaSpec, true)
+	dcd.Labels = map[string]string{
+		commonconsts.KubeLabelDynamoNamespace: "label-namespace",
+	}
+	dcd.Annotations[preservedDCDDynamoNamespaceAnnotation] = "stale-namespace"
+	dcd.Annotations[preservedDCDSubComponentTypeAnnotation] = "stale-sub"
+	dcd.Annotations[PreservedDCDAnnotationsAnnotation] = mustJSON(t, map[string]string{"stale-annotation": "ignored"})
+	dcd.Annotations[PreservedDCDLabelsAnnotation] = mustJSON(t, map[string]string{"stale-label": "ignored"})
+	dcd.Annotations[PreservedDCDIngressAnnotation] = mustJSON(t, IngressSpec{Enabled: true, Host: "stale.example.com"})
+
+	if got := GetDCDDynamoNamespace(dcd); got != "canonical-namespace" {
+		t.Fatalf("GetDCDDynamoNamespace() = %q, want canonical-namespace", got)
+	}
+	if got := GetDCDSubComponentType(dcd); got != "canonical-sub" {
+		t.Fatalf("GetDCDSubComponentType() = %q, want canonical-sub", got)
+	}
+	if got, want := GetDCDPreservedAlphaAnnotations(dcd), alphaSpec.Annotations; !maps.Equal(got, want) {
+		t.Fatalf("GetDCDPreservedAlphaAnnotations() = %#v, want %#v", got, want)
+	}
+	if got, want := GetDCDPreservedAlphaLabels(dcd), alphaSpec.Labels; !maps.Equal(got, want) {
+		t.Fatalf("GetDCDPreservedAlphaLabels() = %#v, want %#v", got, want)
+	}
+	ingressSpec, ok, err := GetDCDPreservedAlphaIngressSpec(dcd)
+	if err != nil {
+		t.Fatalf("GetDCDPreservedAlphaIngressSpec() error = %v", err)
+	}
+	if !ok || !ingressSpec.Enabled || ingressSpec.Host != "canonical.example.com" || ingressSpec.IngressControllerClassName == nil || *ingressSpec.IngressControllerClassName != "nginx" {
+		t.Fatalf("GetDCDPreservedAlphaIngressSpec() = (%#v, %v), want canonical ingress", ingressSpec, ok)
+	}
+}
+
+func TestPreservedAlphaHelpersFallbackToLegacyCarrierAnnotations(t *testing.T) {
+	dcd := &v1beta1.DynamoComponentDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dcd",
+			Namespace: "test-ns",
+			Annotations: map[string]string{
+				preservedDCDDynamoNamespaceAnnotation:  "legacy-namespace",
+				preservedDCDSubComponentTypeAnnotation: "legacy-sub",
+				PreservedDCDAnnotationsAnnotation:      mustJSON(t, map[string]string{"legacy-annotation": "kept"}),
+				PreservedDCDLabelsAnnotation:           mustJSON(t, map[string]string{"legacy-label": "kept"}),
+				PreservedDCDIngressAnnotation:          mustJSON(t, IngressSpec{Enabled: true, Host: "legacy.example.com"}),
+			},
+			Labels: map[string]string{
+				commonconsts.KubeLabelDynamoNamespace: "label-namespace",
+			},
+		},
+	}
+
+	if got := GetDCDDynamoNamespace(dcd); got != "legacy-namespace" {
+		t.Fatalf("GetDCDDynamoNamespace() = %q, want legacy-namespace", got)
+	}
+	if got := GetDCDSubComponentType(dcd); got != "legacy-sub" {
+		t.Fatalf("GetDCDSubComponentType() = %q, want legacy-sub", got)
+	}
+	if got, want := GetDCDPreservedAlphaAnnotations(dcd), map[string]string{"legacy-annotation": "kept"}; !maps.Equal(got, want) {
+		t.Fatalf("GetDCDPreservedAlphaAnnotations() = %#v, want %#v", got, want)
+	}
+	if got, want := GetDCDPreservedAlphaLabels(dcd), map[string]string{"legacy-label": "kept"}; !maps.Equal(got, want) {
+		t.Fatalf("GetDCDPreservedAlphaLabels() = %#v, want %#v", got, want)
+	}
+	ingressSpec, ok, err := GetDCDPreservedAlphaIngressSpec(dcd)
+	if err != nil {
+		t.Fatalf("GetDCDPreservedAlphaIngressSpec() error = %v", err)
+	}
+	if !ok || ingressSpec.Host != "legacy.example.com" {
+		t.Fatalf("GetDCDPreservedAlphaIngressSpec() = (%#v, %v), want legacy ingress", ingressSpec, ok)
+	}
+}
+
+func TestGetDCDPreservedAlphaSpecSupportsEnvelopeAndRawSpec(t *testing.T) {
+	dynamoNamespace := "raw-namespace"
+	alphaSpec := v1alpha1.DynamoComponentDeploymentSpec{
+		DynamoComponentDeploymentSharedSpec: v1alpha1.DynamoComponentDeploymentSharedSpec{
+			DynamoNamespace:  &dynamoNamespace,
+			SubComponentType: "raw-sub",
+		},
+	}
+
+	envelopeDCD := dcdWithPreservedAlphaSpec(t, alphaSpec, true)
+	if got := getDCDPreservedAlphaSpec(envelopeDCD); got == nil || got.SubComponentType != "raw-sub" {
+		t.Fatalf("envelope getDCDPreservedAlphaSpec() = %#v, want raw-sub", got)
+	}
+
+	rawDCD := dcdWithPreservedAlphaSpec(t, alphaSpec, false)
+	if got := getDCDPreservedAlphaSpec(rawDCD); got == nil || got.DynamoNamespace == nil || *got.DynamoNamespace != "raw-namespace" {
+		t.Fatalf("raw getDCDPreservedAlphaSpec() = %#v, want raw-namespace", got)
+	}
+}
+
+func TestGetDCDPreservedAlphaIngressSpecReturnsMalformedAnnotationError(t *testing.T) {
+	dcd := &v1beta1.DynamoComponentDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				PreservedDCDIngressAnnotation: "{",
+			},
+		},
+	}
+
+	if _, _, err := GetDCDPreservedAlphaIngressSpec(dcd); err == nil {
+		t.Fatalf("GetDCDPreservedAlphaIngressSpec() error = nil, want malformed JSON error")
+	}
+}
+
+func TestToAlphaCheckpointConfigSetsNilIdentityThroughConverter(t *testing.T) {
+	got := ToAlphaCheckpointConfig(&v1beta1.ComponentCheckpointConfig{
+		Mode:          v1beta1.CheckpointMode("auto"),
+		CheckpointRef: ptr.To("checkpoint"),
+	})
+	if got == nil {
+		t.Fatalf("ToAlphaCheckpointConfig() = nil")
+	}
+	if got.Identity != nil {
+		t.Fatalf("ToAlphaCheckpointConfig().Identity = %#v, want nil", got.Identity)
+	}
+}
+
+func TestToBetaSharedMemorySize(t *testing.T) {
+	size := resource.MustParse("2Gi")
+	tests := []struct {
+		name string
+		src  *v1alpha1.SharedMemorySpec
+		want string
+	}{
+		{name: "nil"},
+		{name: "zero size", src: &v1alpha1.SharedMemorySpec{}},
+		{name: "disabled", src: &v1alpha1.SharedMemorySpec{Disabled: true}, want: "0"},
+		{name: "size", src: &v1alpha1.SharedMemorySpec{Size: size}, want: "2Gi"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ToBetaSharedMemorySize(tt.src)
+			if tt.want == "" {
+				if got != nil {
+					t.Fatalf("ToBetaSharedMemorySize() = %s, want nil", got.String())
+				}
+				return
+			}
+			if got == nil || got.String() != tt.want {
+				t.Fatalf("ToBetaSharedMemorySize() = %v, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMergeLowPriorityMetadata(t *testing.T) {
+	got := mergeLowPriorityMetadata(
+		map[string]string{"existing": "kept", "shared": "winner"},
+		map[string]string{"shared": "ignored", "new": "added"},
+	)
+	want := map[string]string{"existing": "kept", "shared": "winner", "new": "added"}
+	if !maps.Equal(got, want) {
+		t.Fatalf("mergeLowPriorityMetadata() = %#v, want %#v", got, want)
+	}
+}
+
+func dcdWithPreservedAlphaSpec(t *testing.T, spec v1alpha1.DynamoComponentDeploymentSpec, envelope bool) *v1beta1.DynamoComponentDeployment {
+	t.Helper()
+
+	var value any = spec
+	if envelope {
+		value = struct {
+			Spec v1alpha1.DynamoComponentDeploymentSpec `json:"spec"`
+		}{Spec: spec}
+	}
+	return &v1beta1.DynamoComponentDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "dcd",
+			Annotations: map[string]string{
+				preservedDCDAlphaSpecAnnotation: mustJSON(t, value),
+			},
+		},
+	}
+}
+
+func mustJSON(t *testing.T, value any) string {
+	t.Helper()
+
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("json.Marshal(%#v) error = %v", value, err)
+	}
+	return string(data)
+}


### PR DESCRIPTION
**Overview**
Preserves the pre-v1beta1 DGD worker hash during conversion so existing v1alpha1 deployments do not roll workers simply because the operator starts reconciling the v1beta1 API shape.

**Details**

Captures the legacy v1alpha1 worker hash when converting a DGD to the v1beta1 hub.
Stores that value in an internal annotation on the hub object.
Removes the internal compatibility annotation when converting back to v1alpha1.
Keeps the legacy hash computation isolated to the conversion layer.
Propagates hash computation errors instead of silently using a sentinel value.
**Why**
The v1beta1 worker hash uses a different canonical input than the old v1alpha1 struct hash. Without preserving the old hash, existing v1alpha1 DGDs could trigger unnecessary worker rolling updates after an operator upgrade.
<!-- devin-review-badge-begin -->

This PR also touches shared conversion helpers because the legacy hash is written during v1alpha1 -> v1beta1 conversion. The helper changes are intentionally scoped to the conversion path and keep the v1alpha1 worker-hash computation reusable instead of duplicating controller hash logic.

Controller migration contract:

- Existing v1alpha1 objects may already have `nvidia.com/current-worker-hash`.
- During v1alpha1 -> v1beta1 conversion, we recompute the v1alpha1 worker hash and store it as `nvidia.com/dgd-legacy-worker-hash`.
- A follow-up v1beta1 controller change must treat `current-worker-hash == dgd-legacy-worker-hash` as an already-current legacy rollout, avoid rolling workers, and then migrate `current-worker-hash` to the v1beta1 hash.

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9210" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Infrastructure**
  * Enhanced API version conversion to properly manage legacy worker configurations with improved hashing and data isolation, ensuring integrity across versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->