### PR TITLE
fix: copy GPU-parallel combined JUnit XML over parent --junitxml output

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -304,6 +304,33 @@ def pytest_runtestloop(session: pytest.Session) -> bool | None:
     return True  # we handled the test loop
 
 
+@pytest.hookimpl(trylast=True)
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    """Replace the parent's --junitxml output with the GPU-parallel combined XML.
+
+    The orchestrator runs each test as its own pytest subprocess, so the parent
+    pytest's junitxml plugin only sees collection-time skips — real per-test
+    results live in /tmp/gpu_parallel_junit/combined.xml. trylast ensures we
+    overwrite after the junitxml plugin's own pytest_sessionfinish has run.
+    """
+    config = session.config
+    if config.stash.get(_gpu_slots_key, None) is None:
+        return
+    if config.getoption("max_vram_gib", default=None) is None:
+        return
+
+    parent_junit = getattr(config.option, "xmlpath", None)
+    if not parent_junit:
+        return
+
+    from tests.utils.pytest_parallel_gpu import _JUNIT_COMBINED
+
+    if not os.path.exists(_JUNIT_COMBINED):
+        return
+
+    shutil.copyfile(_JUNIT_COMBINED, parent_junit)
+
+
 @pytest.fixture()
 def set_ucx_tls_no_mm():
     """Set UCX env defaults for all tests."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -217,8 +217,13 @@ def pytest_runtestloop(session: pytest.Session) -> bool | None:
         return None  # serial execution: let normal pytest handle it
 
     # Imports related to parallel execution must be delayed. See vram_utils pynvml note in pytest_configure for the full reasons
-    from tests.utils.pytest_parallel_gpu import run_parallel
+    from tests.utils.pytest_parallel_gpu import _JUNIT_DIR, run_parallel
     from tests.utils.vram_utils import load_test_meta
+
+    # Wipe any per-test XMLs and combined.xml left over in the shared /tmp dir
+    # by an earlier session; otherwise _aggregate_junit_xml would merge stale
+    # results, and pytest_sessionfinish (below) would publish them.
+    shutil.rmtree(_JUNIT_DIR, ignore_errors=True)
 
     # Collect test IDs from the already-filtered session items
     test_ids = [item.nodeid for item in session.items]
@@ -328,7 +333,12 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
     if not os.path.exists(_JUNIT_COMBINED):
         return
 
-    shutil.copyfile(_JUNIT_COMBINED, parent_junit)
+    try:
+        shutil.copyfile(_JUNIT_COMBINED, parent_junit)
+    except OSError as exc:
+        _logger.warning(
+            f"Failed to copy GPU-parallel JUnit XML {_JUNIT_COMBINED} -> {parent_junit}: {exc}"
+        )
 
 
 @pytest.fixture()


### PR DESCRIPTION
When --max-vram-gib + -n auto activates the GPU-parallel orchestrator in tests/conftest.py, each test runs as its own pytest subprocess writing JUnit XML into /tmp/gpu_parallel_junit/, merged into combined.xml. The parent pytest's junitxml plugin still wrote to its own --junitxml path, seeing only collection-time skips — so the artifact uploaded by .github/actions/pytest contained 1 skipped testcase regardless of how many tests actually ran.

Add a pytest_sessionfinish(trylast=True) hook that copies combined.xml over the parent's --junitxml path after the junitxml plugin finishes, so uploaded test reports reflect the real per-test results.

ref: OPS-4984


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced JUnit XML test report consolidation for GPU-parallel execution environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->