### PR TITLE
feat: Add initial TokenSpeed backend

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -92,6 +92,9 @@ core:
   - 'components/src/dynamo/frontend/**'
   - 'components/src/dynamo/common/**'
   - 'components/src/dynamo/gpu_memory_service/**'
+  # TODO(will): Move TokenSpeed to a dedicated framework filter once CI has
+  # TokenSpeed Docker images and backend-specific build/test jobs.
+  - 'components/src/dynamo/tokenspeed/**'
   - '*.toml'
   - '*.lock'
   - '*.py'

--- a/components/src/dynamo/common/backend/tests/test_worker.py
+++ b/components/src/dynamo/common/backend/tests/test_worker.py
@@ -17,7 +17,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from dynamo.common.backend.worker import Worker, WorkerConfig
+from dynamo.common.backend.engine import EngineConfig
+from dynamo.common.backend.worker import Worker, WorkerConfig, _model_runtime_config
 from dynamo.llm.exceptions import EngineShutdown
 
 pytestmark = [pytest.mark.unit, pytest.mark.gpu_0, pytest.mark.pre_merge]
@@ -29,6 +30,56 @@ def _make_worker() -> tuple:
     engine.cleanup = AsyncMock()
     config = WorkerConfig(namespace="test")
     return Worker(engine=engine, config=config), engine
+
+
+def test_worker_config_from_runtime_config_copies_parser_settings():
+    runtime_cfg = MagicMock()
+    runtime_cfg.namespace = "test"
+    runtime_cfg.component = None
+    runtime_cfg.endpoint = None
+    runtime_cfg.endpoint_types = "chat,completions"
+    runtime_cfg.discovery_backend = "etcd"
+    runtime_cfg.request_plane = "tcp"
+    runtime_cfg.event_plane = "nats"
+    runtime_cfg.use_kv_events = False
+    runtime_cfg.custom_jinja_template = None
+    runtime_cfg.dyn_tool_call_parser = "kimi_k2"
+    runtime_cfg.dyn_reasoning_parser = "kimi_k25"
+    runtime_cfg.exclude_tools_when_tool_choice_none = False
+    runtime_cfg.enable_local_indexer = False
+
+    config = WorkerConfig.from_runtime_config(runtime_cfg, "nvidia/Kimi-K2.5-NVFP4")
+
+    assert config.tool_call_parser == "kimi_k2"
+    assert config.reasoning_parser == "kimi_k25"
+    assert config.exclude_tools_when_tool_choice_none is False
+    assert config.enable_local_indexer is False
+
+
+def test_model_runtime_config_includes_parser_settings():
+    worker_config = WorkerConfig(
+        namespace="test",
+        tool_call_parser="kimi_k2",
+        reasoning_parser="kimi_k25",
+        exclude_tools_when_tool_choice_none=False,
+        enable_local_indexer=False,
+    )
+    engine_config = EngineConfig(
+        model="nvidia/Kimi-K2.5-NVFP4",
+        total_kv_blocks=100,
+        max_num_seqs=16,
+        max_num_batched_tokens=8192,
+    )
+
+    runtime_config = _model_runtime_config(engine_config, worker_config)
+
+    assert runtime_config.total_kv_blocks == 100
+    assert runtime_config.max_num_seqs == 16
+    assert runtime_config.max_num_batched_tokens == 8192
+    assert runtime_config.tool_call_parser == "kimi_k2"
+    assert runtime_config.reasoning_parser == "kimi_k25"
+    assert runtime_config.exclude_tools_when_tool_choice_none is False
+    assert runtime_config.enable_local_indexer is False
 
 
 def test_cleanup_after_start_calls_engine_cleanup_exactly_once():

--- a/components/src/dynamo/common/backend/worker.py
+++ b/components/src/dynamo/common/backend/worker.py
@@ -40,6 +40,10 @@ class WorkerConfig:
     event_plane: Optional[str] = None
     use_kv_events: bool = False
     custom_jinja_template: Optional[str] = None
+    tool_call_parser: Optional[str] = None
+    reasoning_parser: Optional[str] = None
+    exclude_tools_when_tool_choice_none: bool = True
+    enable_local_indexer: bool = True
     metrics_labels: list = field(default_factory=list)
 
     @classmethod
@@ -72,6 +76,12 @@ class WorkerConfig:
             "custom_jinja_template": getattr(
                 runtime_cfg, "custom_jinja_template", None
             ),
+            "tool_call_parser": getattr(runtime_cfg, "dyn_tool_call_parser", None),
+            "reasoning_parser": getattr(runtime_cfg, "dyn_reasoning_parser", None),
+            "exclude_tools_when_tool_choice_none": getattr(
+                runtime_cfg, "exclude_tools_when_tool_choice_none", True
+            ),
+            "enable_local_indexer": getattr(runtime_cfg, "enable_local_indexer", True),
         }
         if model_input is not None:
             kwargs["model_input"] = model_input
@@ -216,15 +226,7 @@ class Worker:
             raise EngineShutdown(f"Engine initialization failed: {exc}") from exc
 
         try:
-            runtime_config = ModelRuntimeConfig()
-            if engine_config.total_kv_blocks is not None:
-                runtime_config.total_kv_blocks = engine_config.total_kv_blocks
-            if engine_config.max_num_seqs is not None:
-                runtime_config.max_num_seqs = engine_config.max_num_seqs
-            if engine_config.max_num_batched_tokens is not None:
-                runtime_config.max_num_batched_tokens = (
-                    engine_config.max_num_batched_tokens
-                )
+            runtime_config = _model_runtime_config(engine_config, cfg)
 
             model_type = parse_endpoint_types(cfg.endpoint_types)
 
@@ -257,3 +259,22 @@ class Worker:
             )
         finally:
             await self._cleanup_once()
+
+
+def _model_runtime_config(
+    engine_config: EngineConfig, worker_config: WorkerConfig
+) -> ModelRuntimeConfig:
+    runtime_config = ModelRuntimeConfig()
+    if engine_config.total_kv_blocks is not None:
+        runtime_config.total_kv_blocks = engine_config.total_kv_blocks
+    if engine_config.max_num_seqs is not None:
+        runtime_config.max_num_seqs = engine_config.max_num_seqs
+    if engine_config.max_num_batched_tokens is not None:
+        runtime_config.max_num_batched_tokens = engine_config.max_num_batched_tokens
+    runtime_config.tool_call_parser = worker_config.tool_call_parser
+    runtime_config.reasoning_parser = worker_config.reasoning_parser
+    runtime_config.exclude_tools_when_tool_choice_none = (
+        worker_config.exclude_tools_when_tool_choice_none
+    )
+    runtime_config.enable_local_indexer = worker_config.enable_local_indexer
+    return runtime_config

--- a/components/src/dynamo/tokenspeed/__init__.py
+++ b/components/src/dynamo/tokenspeed/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+

--- a/components/src/dynamo/tokenspeed/__init__.py
+++ b/components/src/dynamo/tokenspeed/__init__.py
@@ -1,3 +1,2 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-

--- a/components/src/dynamo/tokenspeed/__main__.py
+++ b/components/src/dynamo/tokenspeed/__main__.py
@@ -10,4 +10,3 @@ from dynamo.tokenspeed.unified_main import main
 
 if __name__ == "__main__":
     main()
-

--- a/components/src/dynamo/tokenspeed/__main__.py
+++ b/components/src/dynamo/tokenspeed/__main__.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+if "PYTHONHASHSEED" not in os.environ:
+    os.environ["PYTHONHASHSEED"] = "0"
+
+from dynamo.tokenspeed.unified_main import main
+
+if __name__ == "__main__":
+    main()
+

--- a/components/src/dynamo/tokenspeed/args.py
+++ b/components/src/dynamo/tokenspeed/args.py
@@ -112,4 +112,3 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> Config:
 def _server_args_cls():
     module = importlib.import_module("tokenspeed.runtime.utils.server_args")
     return module.ServerArgs
-

--- a/components/src/dynamo/tokenspeed/args.py
+++ b/components/src/dynamo/tokenspeed/args.py
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Argument parsing for the TokenSpeed backend."""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import importlib
+import os
+import sys
+from typing import Any, Dict, Optional, Sequence
+
+from dynamo.common.config_dump import register_encoder
+from dynamo.common.configuration.groups.runtime_args import (
+    DynamoRuntimeArgGroup,
+    DynamoRuntimeConfig,
+)
+from dynamo.common.utils.runtime import parse_endpoint
+
+DEFAULT_ENDPOINT_COMPONENT = "backend"
+DEFAULT_ENDPOINT_NAME = "generate"
+
+
+class Config(DynamoRuntimeConfig):
+    component: str
+    use_kv_events: bool = False
+
+    model: str
+    served_model_name: Optional[str] = None
+    server_args: Any
+
+    def validate(self) -> None:
+        DynamoRuntimeConfig.validate(self)
+        self.use_kv_events = False
+
+
+@register_encoder(Config)
+def _preprocess_for_encode_config(config: Config) -> Dict[str, Any]:
+    data = dict(config.__dict__)
+    server_args = data.get("server_args")
+    if dataclasses.is_dataclass(server_args):
+        data["server_args"] = dataclasses.asdict(server_args)
+    return data
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> Config:
+    cli_args = list(argv) if argv is not None else sys.argv[1:]
+
+    parser = argparse.ArgumentParser(
+        description="Dynamo TokenSpeed worker configuration",
+        formatter_class=argparse.RawTextHelpFormatter,
+        allow_abbrev=False,
+    )
+    DynamoRuntimeArgGroup().add_arguments(parser)
+
+    server_args_cls = _server_args_cls()
+    tokenspeed_parser = argparse.ArgumentParser(add_help=False, allow_abbrev=False)
+    server_args_cls.add_cli_args(tokenspeed_parser)
+
+    # Keep TokenSpeed flags visible in --help while letting the dedicated
+    # TokenSpeed parser own them, including its positional model argument.
+    tokenspeed_group = parser.add_argument_group(
+        "TokenSpeed Engine Options. Please refer to TokenSpeed documentation for more details."
+    )
+    for action in tokenspeed_parser._actions:
+        if action.option_strings or action.dest == "model_path":
+            tokenspeed_group._group_actions.append(action)
+
+    dynamo_args, remaining = parser.parse_known_args(cli_args)
+    config = Config.from_cli_args(dynamo_args)
+
+    server_args = server_args_cls.from_cli_args(tokenspeed_parser.parse_args(remaining))
+    # Dynamo streams token deltas. TokenSpeed's raw-token streaming path needs
+    # stream_output=True to avoid cumulative token ids.
+    server_args.stream_output = True
+
+    config.model = server_args.model
+    config.served_model_name = server_args.served_model_name or server_args.model
+    server_args.served_model_name = config.served_model_name
+    config.server_args = server_args
+
+    config.validate()
+
+    if config.custom_jinja_template:
+        expanded_template_path = os.path.expanduser(
+            os.path.expandvars(config.custom_jinja_template)
+        )
+        if not os.path.isfile(expanded_template_path):
+            raise FileNotFoundError(
+                f"Custom Jinja template file not found: {expanded_template_path}"
+            )
+        config.custom_jinja_template = expanded_template_path
+    else:
+        config.custom_jinja_template = None
+
+    endpoint = (
+        config.endpoint
+        or f"dyn://{config.namespace}.{DEFAULT_ENDPOINT_COMPONENT}.{DEFAULT_ENDPOINT_NAME}"
+    )
+    parsed_namespace, parsed_component_name, parsed_endpoint_name = parse_endpoint(
+        endpoint
+    )
+    config.namespace = parsed_namespace
+    config.component = parsed_component_name
+    config.endpoint = parsed_endpoint_name
+
+    return config
+
+
+def _server_args_cls():
+    module = importlib.import_module("tokenspeed.runtime.utils.server_args")
+    return module.ServerArgs
+

--- a/components/src/dynamo/tokenspeed/args.py
+++ b/components/src/dynamo/tokenspeed/args.py
@@ -40,7 +40,7 @@ class Config(DynamoRuntimeConfig):
 def _preprocess_for_encode_config(config: Config) -> Dict[str, Any]:
     data = dict(config.__dict__)
     server_args = data.get("server_args")
-    if dataclasses.is_dataclass(server_args):
+    if dataclasses.is_dataclass(server_args) and not isinstance(server_args, type):
         data["server_args"] = dataclasses.asdict(server_args)
     return data
 

--- a/components/src/dynamo/tokenspeed/llm_engine.py
+++ b/components/src/dynamo/tokenspeed/llm_engine.py
@@ -112,9 +112,13 @@ class TokenspeedLLMEngine(LLMEngine):
             obj.rid = request_id
             self._active_rids_by_context[request_id] = [request_id]
 
+        emitted_completion_tokens = 0
         try:
             async for out in self.engine.tokenizer_manager.generate_request(obj):
-                yield convert_output_to_chunk(out)
+                delta_out, emitted_completion_tokens = _completion_delta_output(
+                    out, emitted_completion_tokens
+                )
+                yield convert_output_to_chunk(delta_out)
         finally:
             if request_id is not None:
                 self._active_rids_by_context.pop(request_id, None)
@@ -212,6 +216,38 @@ def convert_output_to_chunk(out: dict[str, Any]) -> GenerateChunk:
         }
 
     return chunk
+
+
+def _completion_delta_output(
+    out: dict[str, Any],
+    previously_emitted: int,
+) -> tuple[dict[str, Any], int]:
+    meta_info = out.get("meta_info", {}) or {}
+    completion_tokens = meta_info.get("completion_tokens")
+    if completion_tokens is None:
+        return out, previously_emitted
+
+    try:
+        total_emitted = int(completion_tokens)
+    except (TypeError, ValueError):
+        return out, previously_emitted
+
+    delta_count = max(0, total_emitted - previously_emitted)
+    output_ids = out.get("output_ids", []) or []
+    if delta_count == 0:
+        delta_ids: list[int] = []
+    elif len(output_ids) >= delta_count:
+        # TokenSpeed's first streamed output can include echoed prompt/context
+        # tokens even though meta_info.completion_tokens only counts newly
+        # generated tokens. Dynamo expects token deltas, so keep the newest
+        # completion-token suffix.
+        delta_ids = output_ids[-delta_count:]
+    else:
+        delta_ids = output_ids
+
+    delta_out = dict(out)
+    delta_out["output_ids"] = delta_ids
+    return delta_out, total_emitted
 
 
 def _guided_decoding_params(guided_decoding: dict[str, Any]) -> dict[str, Any]:

--- a/components/src/dynamo/tokenspeed/llm_engine.py
+++ b/components/src/dynamo/tokenspeed/llm_engine.py
@@ -19,6 +19,7 @@ from dynamo.common.backend.engine import (
     LLMEngine,
 )
 from dynamo.common.backend.worker import WorkerConfig
+from dynamo.common.utils.engine_response import normalize_finish_reason
 from dynamo.llm import ModelInput
 from dynamo.llm.exceptions import InvalidArgument
 from dynamo.tokenspeed.args import parse_args
@@ -67,7 +68,7 @@ class TokenspeedLLMEngine(LLMEngine):
             or getattr(self.server_args, "max_total_tokens", None)
         )
         total_kv_blocks = (
-            max_total_tokens // block_size
+            (max_total_tokens + block_size - 1) // block_size
             if max_total_tokens is not None and block_size
             else None
         )
@@ -178,7 +179,10 @@ def build_sampling_params(
     if ignore_eos is not None:
         params["ignore_eos"] = ignore_eos
 
-    stop_token_ids = stop_conditions.get("stop_token_ids_hidden")
+    stop_token_ids = _merge_stop_token_ids(
+        stop_conditions.get("stop_token_ids_hidden"),
+        stop_conditions.get("stop_token_ids"),
+    )
     if stop_token_ids:
         params["stop_token_ids"] = stop_token_ids
 
@@ -195,7 +199,9 @@ def convert_output_to_chunk(out: dict[str, Any]) -> GenerateChunk:
 
     finish_reason = meta_info.get("finish_reason")
     if finish_reason is not None:
-        chunk["finish_reason"] = _finish_reason_type(finish_reason)
+        chunk["finish_reason"] = normalize_finish_reason(
+            _finish_reason_type(finish_reason)
+        )
         prompt_tokens = int(meta_info.get("prompt_tokens") or 0)
         completion_tokens = int(meta_info.get("completion_tokens") or 0)
         chunk["completion_usage"] = {
@@ -211,25 +217,42 @@ def _guided_decoding_params(guided_decoding: dict[str, Any]) -> dict[str, Any]:
     params: dict[str, Any] = {}
 
     json_schema = guided_decoding.get("json")
+    regex = guided_decoding.get("regex")
+    choice = guided_decoding.get("choice")
+    grammar = guided_decoding.get("grammar")
+    structural_tag = guided_decoding.get("structural_tag")
+
+    if regex is None and choice:
+        valid_choices = [str(c) for c in choice if c is not None]
+        if valid_choices:
+            regex = "(" + "|".join(re.escape(c) for c in valid_choices) + ")"
+
+    constraints = {
+        "json": json_schema,
+        "regex": regex,
+        "grammar": grammar,
+        "structural_tag": structural_tag,
+    }
+    active_constraints = [
+        name for name, value in constraints.items() if value is not None
+    ]
+    if len(active_constraints) > 1:
+        raise InvalidArgument(
+            "TokenSpeed guided decoding supports one constraint at a time; "
+            f"got {', '.join(active_constraints)}"
+        )
+
     if json_schema is not None:
         params["json_schema"] = (
             json_schema if isinstance(json_schema, str) else json.dumps(json_schema)
         )
 
-    regex = guided_decoding.get("regex")
-    choice = guided_decoding.get("choice")
-    if regex is None and choice:
-        valid_choices = [str(c) for c in choice if c is not None]
-        if valid_choices:
-            regex = "(" + "|".join(re.escape(c) for c in valid_choices) + ")"
     if regex is not None:
         params["regex"] = regex
 
-    grammar = guided_decoding.get("grammar")
     if grammar is not None:
         params["ebnf"] = grammar
 
-    structural_tag = guided_decoding.get("structural_tag")
     if structural_tag is not None:
         if hasattr(structural_tag, "model_dump"):
             structural_tag = structural_tag.model_dump()
@@ -248,6 +271,17 @@ def _finish_reason_type(finish_reason: Any) -> str:
     if isinstance(finish_reason, dict):
         return str(finish_reason.get("type") or "unknown")
     return str(finish_reason)
+
+
+def _merge_stop_token_ids(*token_id_lists: Any) -> list[int]:
+    merged: list[int] = []
+    seen: set[int] = set()
+    for token_ids in token_id_lists:
+        for token_id in token_ids or []:
+            if token_id not in seen:
+                seen.add(token_id)
+                merged.append(token_id)
+    return merged
 
 
 def _validate_single_choice_sampling(request: GenerateRequest) -> None:

--- a/components/src/dynamo/tokenspeed/llm_engine.py
+++ b/components/src/dynamo/tokenspeed/llm_engine.py
@@ -1,0 +1,265 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""TokenSpeed LLMEngine implementation for the unified backend."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from collections.abc import AsyncGenerator
+from typing import Any
+
+from dynamo._core import Context
+from dynamo.common.backend.engine import (
+    EngineConfig,
+    GenerateChunk,
+    GenerateRequest,
+    LLMEngine,
+)
+from dynamo.common.backend.worker import WorkerConfig
+from dynamo.llm import ModelInput
+from dynamo.llm.exceptions import InvalidArgument
+from dynamo.tokenspeed.args import parse_args
+
+logger = logging.getLogger(__name__)
+
+
+class TokenspeedLLMEngine(LLMEngine):
+    def __init__(self, server_args: Any):
+        self.server_args = server_args
+        self.engine = None
+        self._model_max_len: int | None = None
+        self._active_rids_by_context: dict[str, list[str]] = {}
+
+    @classmethod
+    async def from_args(
+        cls, argv: list[str] | None = None
+    ) -> tuple[TokenspeedLLMEngine, WorkerConfig]:
+        config = parse_args(argv)
+        engine = cls(config.server_args)
+        worker_config = WorkerConfig.from_runtime_config(
+            config,
+            model_name=config.model,
+            served_model_name=config.served_model_name,
+            model_input=ModelInput.Tokens,
+        )
+        return engine, worker_config
+
+    async def start(self) -> EngineConfig:
+        from tokenspeed.runtime.entrypoints.engine import Engine
+
+        # The Dynamo response layer expects per-chunk token deltas.
+        self.server_args.stream_output = True
+        self.engine = Engine(server_args=self.server_args)
+
+        scheduler_info = getattr(self.engine, "scheduler_info", {}) or {}
+        self._model_max_len = _optional_int(
+            scheduler_info.get("max_model_len")
+            or getattr(getattr(self.engine, "tokenizer_manager", None), "context_len", None)
+            or getattr(self.server_args, "max_model_len", None)
+        )
+
+        block_size = _optional_int(getattr(self.server_args, "block_size", None))
+        max_total_tokens = _optional_int(
+            scheduler_info.get("max_total_num_tokens")
+            or getattr(self.server_args, "max_total_tokens", None)
+        )
+        total_kv_blocks = (
+            max_total_tokens // block_size
+            if max_total_tokens is not None and block_size
+            else None
+        )
+
+        max_num_batched_tokens = _optional_int(
+            scheduler_info.get("chunked_prefill_size")
+            or getattr(self.server_args, "chunked_prefill_size", None)
+            or getattr(self.server_args, "max_prefill_tokens", None)
+        )
+
+        return EngineConfig(
+            model=self.server_args.model,
+            served_model_name=self.server_args.served_model_name,
+            context_length=self._model_max_len,
+            kv_cache_block_size=block_size,
+            total_kv_blocks=total_kv_blocks,
+            max_num_seqs=_optional_int(
+                scheduler_info.get("max_num_seqs")
+                or getattr(self.server_args, "max_num_seqs", None)
+            ),
+            max_num_batched_tokens=max_num_batched_tokens,
+        )
+
+    async def generate(
+        self, request: GenerateRequest, context: Context
+    ) -> AsyncGenerator[GenerateChunk, None]:
+        from tokenspeed.runtime.engine.io_struct import GenerateReqInput
+
+        assert self.engine is not None, "Engine not initialized"
+
+        _validate_single_choice_sampling(request)
+        sampling_params = build_sampling_params(request, self._model_max_len)
+        token_ids = request.get("token_ids", [])
+        obj = GenerateReqInput(
+            input_ids=token_ids,
+            sampling_params=sampling_params,
+            stream=True,
+        )
+
+        request_id = context.id()
+        if request_id is not None:
+            obj.rid = request_id
+            self._active_rids_by_context[request_id] = [request_id]
+
+        try:
+            async for out in self.engine.tokenizer_manager.generate_request(obj):
+                yield convert_output_to_chunk(out)
+        finally:
+            if request_id is not None:
+                self._active_rids_by_context.pop(request_id, None)
+
+    async def abort(self, context: Context) -> None:
+        request_id = context.id()
+        if self.engine is None or request_id is None:
+            return
+
+        rids = self._active_rids_by_context.get(request_id, [request_id])
+        for rid in rids:
+            self.engine.tokenizer_manager.abort_request(rid)
+            logger.debug("Aborted TokenSpeed request %s", rid)
+
+    async def cleanup(self) -> None:
+        if self.engine is not None:
+            self.engine.shutdown()
+            logger.info("TokenSpeed engine shutdown")
+
+
+def build_sampling_params(
+    request: GenerateRequest,
+    model_max_len: int | None = None,
+) -> dict[str, Any]:
+    sampling_options = request.get("sampling_options", {}) or {}
+    stop_conditions = request.get("stop_conditions", {}) or {}
+
+    params: dict[str, Any] = {}
+
+    for key in (
+        "temperature",
+        "top_p",
+        "top_k",
+        "min_p",
+        "frequency_penalty",
+        "presence_penalty",
+        "repetition_penalty",
+        "seed",
+        "logit_bias",
+        "n",
+    ):
+        value = sampling_options.get(key)
+        if value is not None:
+            params[key] = value
+
+    guided_decoding = sampling_options.get("guided_decoding")
+    if isinstance(guided_decoding, dict):
+        params.update(_guided_decoding_params(guided_decoding))
+
+    max_tokens = stop_conditions.get("max_tokens")
+    if max_tokens is not None:
+        params["max_new_tokens"] = max_tokens
+    elif model_max_len is not None:
+        params["max_new_tokens"] = max(1, model_max_len - len(request.get("token_ids", [])))
+
+    min_tokens = stop_conditions.get("min_tokens")
+    if min_tokens is not None:
+        params["min_new_tokens"] = min_tokens
+
+    ignore_eos = stop_conditions.get("ignore_eos")
+    if ignore_eos is not None:
+        params["ignore_eos"] = ignore_eos
+
+    stop_token_ids = stop_conditions.get("stop_token_ids_hidden")
+    if stop_token_ids:
+        params["stop_token_ids"] = stop_token_ids
+
+    return params
+
+
+def convert_output_to_chunk(out: dict[str, Any]) -> GenerateChunk:
+    meta_info = out.get("meta_info", {}) or {}
+    output_idx = out.get("index") or 0
+    chunk: GenerateChunk = {
+        "index": output_idx,
+        "token_ids": out.get("output_ids", []) or [],
+    }
+
+    finish_reason = meta_info.get("finish_reason")
+    if finish_reason is not None:
+        chunk["finish_reason"] = _finish_reason_type(finish_reason)
+        prompt_tokens = int(meta_info.get("prompt_tokens") or 0)
+        completion_tokens = int(meta_info.get("completion_tokens") or 0)
+        chunk["completion_usage"] = {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": prompt_tokens + completion_tokens,
+        }
+
+    return chunk
+
+
+def _guided_decoding_params(guided_decoding: dict[str, Any]) -> dict[str, Any]:
+    params: dict[str, Any] = {}
+
+    json_schema = guided_decoding.get("json")
+    if json_schema is not None:
+        params["json_schema"] = (
+            json_schema if isinstance(json_schema, str) else json.dumps(json_schema)
+        )
+
+    regex = guided_decoding.get("regex")
+    choice = guided_decoding.get("choice")
+    if regex is None and choice:
+        valid_choices = [str(c) for c in choice if c is not None]
+        if valid_choices:
+            regex = "(" + "|".join(re.escape(c) for c in valid_choices) + ")"
+    if regex is not None:
+        params["regex"] = regex
+
+    grammar = guided_decoding.get("grammar")
+    if grammar is not None:
+        params["ebnf"] = grammar
+
+    structural_tag = guided_decoding.get("structural_tag")
+    if structural_tag is not None:
+        if hasattr(structural_tag, "model_dump"):
+            structural_tag = structural_tag.model_dump()
+        params["structural_tag"] = (
+            structural_tag
+            if isinstance(structural_tag, str)
+            else json.dumps(structural_tag)
+        )
+
+    return params
+
+
+def _finish_reason_type(finish_reason: Any) -> str:
+    if hasattr(finish_reason, "to_json"):
+        finish_reason = finish_reason.to_json()
+    if isinstance(finish_reason, dict):
+        return str(finish_reason.get("type") or "unknown")
+    return str(finish_reason)
+
+
+def _validate_single_choice_sampling(request: GenerateRequest) -> None:
+    sampling_options = request.get("sampling_options", {}) or {}
+    n = sampling_options.get("n", 1)
+    if isinstance(n, int) and not isinstance(n, bool) and n > 1:
+        raise InvalidArgument(
+            f"TokenSpeed Dynamo backend does not support n={n}; only n=1 is supported"
+        )
+
+
+def _optional_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    return int(value)

--- a/components/src/dynamo/tokenspeed/llm_engine.py
+++ b/components/src/dynamo/tokenspeed/llm_engine.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import importlib
 import json
 import logging
 import re
@@ -49,11 +50,9 @@ class TokenspeedLLMEngine(LLMEngine):
         return engine, worker_config
 
     async def start(self) -> EngineConfig:
-        from tokenspeed.runtime.entrypoints.engine import Engine
-
         # The Dynamo response layer expects per-chunk token deltas.
         self.server_args.stream_output = True
-        self.engine = Engine(server_args=self.server_args)
+        self.engine = _tokenspeed_engine_cls()(server_args=self.server_args)
 
         scheduler_info = getattr(self.engine, "scheduler_info", {}) or {}
         self._model_max_len = _optional_int(
@@ -97,14 +96,12 @@ class TokenspeedLLMEngine(LLMEngine):
     async def generate(
         self, request: GenerateRequest, context: Context
     ) -> AsyncGenerator[GenerateChunk, None]:
-        from tokenspeed.runtime.engine.io_struct import GenerateReqInput
-
         assert self.engine is not None, "Engine not initialized"
 
         _validate_single_choice_sampling(request)
         sampling_params = build_sampling_params(request, self._model_max_len)
         token_ids = request.get("token_ids", [])
-        obj = GenerateReqInput(
+        obj = _generate_req_input_cls()(
             input_ids=token_ids,
             sampling_params=sampling_params,
             stream=True,
@@ -301,3 +298,13 @@ def _optional_int(value: Any) -> int | None:
     if value is None:
         return None
     return int(value)
+
+
+def _tokenspeed_engine_cls() -> Any:
+    module = importlib.import_module("tokenspeed.runtime.entrypoints.engine")
+    return module.Engine
+
+
+def _generate_req_input_cls() -> Any:
+    module = importlib.import_module("tokenspeed.runtime.engine.io_struct")
+    return module.GenerateReqInput

--- a/components/src/dynamo/tokenspeed/llm_engine.py
+++ b/components/src/dynamo/tokenspeed/llm_engine.py
@@ -58,7 +58,9 @@ class TokenspeedLLMEngine(LLMEngine):
         scheduler_info = getattr(self.engine, "scheduler_info", {}) or {}
         self._model_max_len = _optional_int(
             scheduler_info.get("max_model_len")
-            or getattr(getattr(self.engine, "tokenizer_manager", None), "context_len", None)
+            or getattr(
+                getattr(self.engine, "tokenizer_manager", None), "context_len", None
+            )
             or getattr(self.server_args, "max_model_len", None)
         )
 
@@ -169,7 +171,9 @@ def build_sampling_params(
     if max_tokens is not None:
         params["max_new_tokens"] = max_tokens
     elif model_max_len is not None:
-        params["max_new_tokens"] = max(1, model_max_len - len(request.get("token_ids", [])))
+        params["max_new_tokens"] = max(
+            1, model_max_len - len(request.get("token_ids", []))
+        )
 
     min_tokens = stop_conditions.get("min_tokens")
     if min_tokens is not None:

--- a/components/src/dynamo/tokenspeed/tests/test_tokenspeed_llm_engine.py
+++ b/components/src/dynamo/tokenspeed/tests/test_tokenspeed_llm_engine.py
@@ -82,7 +82,7 @@ def test_build_sampling_params_maps_grammar_guided_decoding():
             "token_ids": [1],
             "sampling_options": {
                 "guided_decoding": {
-                    "grammar": "root ::= \"x\"",
+                    "grammar": 'root ::= "x"',
                 },
             },
         },

--- a/components/src/dynamo/tokenspeed/tests/test_tokenspeed_llm_engine.py
+++ b/components/src/dynamo/tokenspeed/tests/test_tokenspeed_llm_engine.py
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+
+import pytest
+
+from dynamo.tokenspeed.llm_engine import (
+    build_sampling_params,
+    convert_output_to_chunk,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.gpu_0, pytest.mark.pre_merge]
+
+
+def test_build_sampling_params_maps_dynamo_request():
+    params = build_sampling_params(
+        {
+            "token_ids": [1, 2, 3],
+            "sampling_options": {
+                "temperature": 0.2,
+                "top_p": 0.9,
+                "top_k": 20,
+                "min_p": 0.1,
+                "frequency_penalty": 0.3,
+                "presence_penalty": 0.4,
+                "repetition_penalty": 1.1,
+                "seed": 123,
+                "n": 1,
+                "guided_decoding": {
+                    "json": {"type": "object"},
+                    "choice": ["yes", "no"],
+                    "grammar": "root ::= \"x\"",
+                    "structural_tag": {"begin": "<a>", "schema": {"type": "object"}},
+                },
+            },
+            "stop_conditions": {
+                "max_tokens": 17,
+                "min_tokens": 2,
+                "ignore_eos": True,
+                "stop_token_ids_hidden": [7, 8],
+            },
+        },
+        model_max_len=100,
+    )
+
+    assert params["temperature"] == 0.2
+    assert params["top_p"] == 0.9
+    assert params["top_k"] == 20
+    assert params["min_p"] == 0.1
+    assert params["frequency_penalty"] == 0.3
+    assert params["presence_penalty"] == 0.4
+    assert params["repetition_penalty"] == 1.1
+    assert params["seed"] == 123
+    assert params["n"] == 1
+    assert params["max_new_tokens"] == 17
+    assert params["min_new_tokens"] == 2
+    assert params["ignore_eos"] is True
+    assert params["stop_token_ids"] == [7, 8]
+    assert json.loads(params["json_schema"]) == {"type": "object"}
+    assert params["regex"] == "(yes|no)"
+    assert params["ebnf"] == 'root ::= "x"'
+    assert json.loads(params["structural_tag"]) == {
+        "begin": "<a>",
+        "schema": {"type": "object"},
+    }
+
+
+def test_build_sampling_params_uses_dynamic_max_tokens():
+    params = build_sampling_params({"token_ids": [1, 2, 3]}, model_max_len=10)
+
+    assert params["max_new_tokens"] == 7
+
+
+def test_convert_output_to_chunk_maps_finish_reason_and_usage():
+    class FinishReason:
+        def to_json(self):
+            return {"type": "length", "length": 2}
+
+    chunk = convert_output_to_chunk(
+        {
+            "index": 1,
+            "output_ids": [11, 12],
+            "meta_info": {
+                "finish_reason": FinishReason(),
+                "prompt_tokens": 3,
+                "completion_tokens": 2,
+                "cached_tokens": 1,
+            },
+        }
+    )
+
+    assert chunk == {
+        "index": 1,
+        "token_ids": [11, 12],
+        "finish_reason": "length",
+        "completion_usage": {
+            "prompt_tokens": 3,
+            "completion_tokens": 2,
+            "total_tokens": 5,
+        },
+    }

--- a/components/src/dynamo/tokenspeed/tests/test_tokenspeed_llm_engine.py
+++ b/components/src/dynamo/tokenspeed/tests/test_tokenspeed_llm_engine.py
@@ -5,7 +5,9 @@ import json
 
 import pytest
 
+from dynamo.llm.exceptions import InvalidArgument
 from dynamo.tokenspeed.llm_engine import (
+    _validate_single_choice_sampling,
     build_sampling_params,
     convert_output_to_chunk,
 )
@@ -28,10 +30,7 @@ def test_build_sampling_params_maps_dynamo_request():
                 "seed": 123,
                 "n": 1,
                 "guided_decoding": {
-                    "json": {"type": "object"},
                     "choice": ["yes", "no"],
-                    "grammar": "root ::= \"x\"",
-                    "structural_tag": {"begin": "<a>", "schema": {"type": "object"}},
                 },
             },
             "stop_conditions": {
@@ -39,6 +38,7 @@ def test_build_sampling_params_maps_dynamo_request():
                 "min_tokens": 2,
                 "ignore_eos": True,
                 "stop_token_ids_hidden": [7, 8],
+                "stop_token_ids": [8, 9],
             },
         },
         model_max_len=100,
@@ -56,14 +56,75 @@ def test_build_sampling_params_maps_dynamo_request():
     assert params["max_new_tokens"] == 17
     assert params["min_new_tokens"] == 2
     assert params["ignore_eos"] is True
-    assert params["stop_token_ids"] == [7, 8]
-    assert json.loads(params["json_schema"]) == {"type": "object"}
+    assert params["stop_token_ids"] == [7, 8, 9]
     assert params["regex"] == "(yes|no)"
+
+
+def test_build_sampling_params_maps_json_guided_decoding():
+    params = build_sampling_params(
+        {
+            "token_ids": [1],
+            "sampling_options": {
+                "guided_decoding": {
+                    "json": {"type": "object"},
+                },
+            },
+        },
+        model_max_len=10,
+    )
+
+    assert json.loads(params["json_schema"]) == {"type": "object"}
+
+
+def test_build_sampling_params_maps_grammar_guided_decoding():
+    params = build_sampling_params(
+        {
+            "token_ids": [1],
+            "sampling_options": {
+                "guided_decoding": {
+                    "grammar": "root ::= \"x\"",
+                },
+            },
+        },
+        model_max_len=10,
+    )
+
     assert params["ebnf"] == 'root ::= "x"'
+
+
+def test_build_sampling_params_maps_structural_tag_guided_decoding():
+    params = build_sampling_params(
+        {
+            "token_ids": [1],
+            "sampling_options": {
+                "guided_decoding": {
+                    "structural_tag": {"begin": "<a>", "schema": {"type": "object"}},
+                },
+            },
+        },
+        model_max_len=10,
+    )
+
     assert json.loads(params["structural_tag"]) == {
         "begin": "<a>",
         "schema": {"type": "object"},
     }
+
+
+def test_build_sampling_params_rejects_multiple_guided_constraints():
+    with pytest.raises(InvalidArgument, match="one constraint"):
+        build_sampling_params(
+            {
+                "token_ids": [1],
+                "sampling_options": {
+                    "guided_decoding": {
+                        "json": {"type": "object"},
+                        "choice": ["yes", "no"],
+                    },
+                },
+            },
+            model_max_len=10,
+        )
 
 
 def test_build_sampling_params_uses_dynamic_max_tokens():
@@ -100,3 +161,25 @@ def test_convert_output_to_chunk_maps_finish_reason_and_usage():
             "total_tokens": 5,
         },
     }
+
+
+def test_convert_output_to_chunk_normalizes_abort_finish_reason():
+    chunk = convert_output_to_chunk(
+        {
+            "output_ids": [],
+            "meta_info": {
+                "finish_reason": "abort_request",
+                "prompt_tokens": 1,
+                "completion_tokens": 0,
+            },
+        }
+    )
+
+    assert chunk["finish_reason"] == "cancelled"
+
+
+def test_validate_single_choice_sampling_rejects_n_greater_than_one():
+    with pytest.raises(InvalidArgument, match="n=2"):
+        _validate_single_choice_sampling(
+            {"token_ids": [1], "sampling_options": {"n": 2}}
+        )

--- a/components/src/dynamo/tokenspeed/tests/test_tokenspeed_llm_engine.py
+++ b/components/src/dynamo/tokenspeed/tests/test_tokenspeed_llm_engine.py
@@ -7,6 +7,7 @@ import pytest
 
 from dynamo.llm.exceptions import InvalidArgument
 from dynamo.tokenspeed.llm_engine import (
+    _completion_delta_output,
     _validate_single_choice_sampling,
     build_sampling_params,
     convert_output_to_chunk,
@@ -183,3 +184,28 @@ def test_validate_single_choice_sampling_rejects_n_greater_than_one():
         _validate_single_choice_sampling(
             {"token_ids": [1], "sampling_options": {"n": 2}}
         )
+
+
+def test_completion_delta_output_strips_first_chunk_prompt_echo():
+    out = {
+        "output_ids": [10, 11, 12, 99],
+        "meta_info": {"completion_tokens": 1},
+    }
+
+    delta_out, emitted = _completion_delta_output(out, 0)
+
+    assert emitted == 1
+    assert delta_out["output_ids"] == [99]
+    assert out["output_ids"] == [10, 11, 12, 99]
+
+
+def test_completion_delta_output_preserves_later_token_delta():
+    out = {
+        "output_ids": [100],
+        "meta_info": {"completion_tokens": 2},
+    }
+
+    delta_out, emitted = _completion_delta_output(out, 1)
+
+    assert emitted == 2
+    assert delta_out["output_ids"] == [100]

--- a/components/src/dynamo/tokenspeed/unified_main.py
+++ b/components/src/dynamo/tokenspeed/unified_main.py
@@ -17,4 +17,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/components/src/dynamo/tokenspeed/unified_main.py
+++ b/components/src/dynamo/tokenspeed/unified_main.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unified entry point for the TokenSpeed backend.
+
+Usage:
+    python -m dynamo.tokenspeed <tokenspeed args>
+"""
+
+from dynamo.common.backend.run import run
+from dynamo.tokenspeed.llm_engine import TokenspeedLLMEngine
+
+
+def main():
+    run(TokenspeedLLMEngine)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,7 +150,7 @@ known_first_party = ["dynamo", "deploy"]
 # failure. To mitigate 1) one can install 3rd party lib so that isort is aware of it,
 # 2) hardcode 3rd party lib here, 3) add "# isort: skip_file" to problematic files
 # as the last resort.
-known_third_party = ["vllm", "tensorrt_llm", "sglang", "aiconfigurator"]
+known_third_party = ["vllm", "tensorrt_llm", "sglang", "tokenspeed", "aiconfigurator"]
 
 [tool.pytest.ini_options]
 minversion = "8.0"


### PR DESCRIPTION
Adds an initial TokenSpeed backend integration for Dynamo through the common LLMEngine path.

This introduces `python -m dynamo.tokenspeed`, TokenSpeed argument parsing, request/sampling conversion, streaming token output conversion, abort/cleanup handling, and focused unit coverage for sampling params, stop tokens, guided decoding validation, finish reason normalization, and unsupported multi-sample requests. 

The branch also updates CI filters so the new TokenSpeed files are covered under core until dedicated TokenSpeed Docker images and backend-specific CI jobs exist.

  Validated with:
  - Focused TokenSpeed unit tests
  - Direct engine/worker smoke tests
  - End-to-end dynamo.frontend -> dynamo.tokenspeed requests
  - Real Llama 3.2 3B checkpoint load with coherent chat/completion/streaming outputs
  - Published bring-up image: aphoh/not-dynamo-tokenspeed:v1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced TokenSpeed as a new backend option with a CLI entrypoint and configurable runtime arguments.
  * Added guided decoding support (JSON schema, grammar, structural tags), token filtering, streaming token generation, and lifecycle controls (start/abort/cleanup).
  * Improved sampling/parameter handling and usage reporting for TokenSpeed operations.

* **Tests**
  * Added comprehensive unit tests validating sampling parameters, guided decoding, single-choice rules, and output conversion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->