### PR TITLE
fix(container): copy NIXL C++ SDK into sglang dev stage

### DIFF
--- a/container/context.yaml
+++ b/container/context.yaml
@@ -85,16 +85,10 @@ sglang:
     runtime_image: lmsysorg/sglang
     base_image_tag: 25.11-cuda13.0-devel-ubuntu24.04
     runtime_image_tag: v0.5.10.post1-cu130-runtime
-  # Setting nixl_ref enables the wheel_builder stage to build NIXL from source
-  # (C++ SDK at /opt/nvidia/nvda_nixl + nixl-cu*.whl). The dev stage COPIES the
-  # SDK from wheel_builder so `cargo build` can link nixl-sys (-lnixl,
-  # -lnixl_build, -lnixl_common); see templates/dev.Dockerfile.
-  #
-  # The runtime stage stays unchanged: it does NOT copy the SDK and does NOT
-  # install the NIXL wheel. SGLang at runtime continues to use the NIXL Python
-  # stack from the upstream lmsysorg/sglang image, unmodified. The runtime
-  # template's wheel COPY is narrowed to `ai_dynamo*.whl` so the nixl wheel
-  # produced by wheel_builder doesn't bloat the runtime image either.
+  # Builds the NIXL C++ SDK in wheel_builder so the dev stage can link nixl-sys
+  # (see templates/dev.Dockerfile). Runtime stays on the upstream lmsysorg/sglang
+  # NIXL Python stack — its wheel COPY is narrowed to ai_dynamo*.whl so the SDK
+  # build doesn't leak into the runtime image.
   nixl_ref: 0.10.1
   enable_media_ffmpeg: "true"
   enable_gpu_memory_service: "true"

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -85,9 +85,17 @@ sglang:
     runtime_image: lmsysorg/sglang
     base_image_tag: 25.11-cuda13.0-devel-ubuntu24.04
     runtime_image_tag: v0.5.10.post1-cu130-runtime
-  # SGLang uses the NIXL stack from the upstream lmsysorg/sglang runtime image.
-  # Do not add nixl_ref here: Dynamo does not build or install its NIXL wheel
-  # for SGLang, and SGLang does not use Dynamo KVBM/block-manager at runtime.
+  # Setting nixl_ref enables the wheel_builder stage to build NIXL from source
+  # (C++ SDK at /opt/nvidia/nvda_nixl + nixl-cu*.whl). The dev stage COPIES the
+  # SDK from wheel_builder so `cargo build` can link nixl-sys (-lnixl,
+  # -lnixl_build, -lnixl_common); see templates/dev.Dockerfile.
+  #
+  # The runtime stage stays unchanged: it does NOT copy the SDK and does NOT
+  # install the NIXL wheel. SGLang at runtime continues to use the NIXL Python
+  # stack from the upstream lmsysorg/sglang image, unmodified. The runtime
+  # template's wheel COPY is narrowed to `ai_dynamo*.whl` so the nixl wheel
+  # produced by wheel_builder doesn't bloat the runtime image either.
+  nixl_ref: 0.10.1
   enable_media_ffmpeg: "true"
   enable_gpu_memory_service: "true"
   enable_kvbm: "false"

--- a/container/templates/dev.Dockerfile
+++ b/container/templates/dev.Dockerfile
@@ -187,14 +187,9 @@ RUN if [ ! -e /usr/bin/python3 ]; then \
         fi; \
     fi
 
-# Copy the NIXL C++ SDK (headers + libs) from wheel_builder so `cargo build`
-# can link nixl-sys (-lnixl, -lnixl_build, -lnixl_common). The runtime stage
-# doesn't need this — it uses the prebuilt Python wheel — but the dev stage
-# builds from source via maturin develop.
-# - SGLang: upstream lmsysorg/sglang runtime ships only the NIXL Python wheel,
-#   not the C++ SDK; copy it from wheel_builder here.
-# - vllm/trtllm/none: NIXL is already at /opt/nvidia/nvda_nixl in runtime; the
-#   COPY below is idempotent (overwrites with same content from wheel_builder).
+# NIXL C++ SDK (+ ucx, libfabric, gdrcopy) for cargo to link nixl-sys.
+# - sglang: upstream runtime ships only the Python wheel; SDK comes from here.
+# - vllm/trtllm/none: SDK already in runtime; this COPY is a no-op overwrite.
 {% if device == "cuda" %}
 RUN --mount=from=wheel_builder,target=/wheel_builder \
     if [ -d /wheel_builder/opt/nvidia/nvda_nixl ]; then \
@@ -221,9 +216,6 @@ ENV NIXL_LIB_DIR=/opt/intel/intel_nixl/lib/x86_64-linux-gnu  \
     NIXL_PLUGIN_DIR=/opt/intel/intel_nixl/lib/x86_64-linux-gnu/plugins \
     NIXL_PREFIX=/opt/intel/intel_nixl
 {% else %}
-# All CUDA frameworks resolve NIXL the same way (lib64 layout from wheel_builder).
-# For vllm/trtllm/none: resets values already set in runtime (no harm).
-# For sglang: sets them for the first time (required — upstream runtime omits SDK).
 ENV NIXL_PREFIX=/opt/nvidia/nvda_nixl \
     NIXL_LIB_DIR=/opt/nvidia/nvda_nixl/lib64 \
     NIXL_PLUGIN_DIR=/opt/nvidia/nvda_nixl/lib64/plugins
@@ -245,9 +237,8 @@ ENV CUDA_HOME=/usr/local/cuda \
     NVIDIA_DRIVER_CAPABILITIES=video,compute,utility
 {% endif %}
 
-# Base LD_LIBRARY_PATH with universal paths (all CUDA frameworks have these
-# now that sglang dev copies the NIXL SDK from wheel_builder).
-# Framework-specific paths are conditionally added in /etc/profile.d/50-framework-paths.sh
+# Base LD_LIBRARY_PATH for NIXL + UCX. Framework-specific paths are added in
+# /etc/profile.d/50-framework-paths.sh.
 {% if device == "cuda" %}
 ENV LD_LIBRARY_PATH=\
 ${NIXL_LIB_DIR}:\

--- a/container/templates/dev.Dockerfile
+++ b/container/templates/dev.Dockerfile
@@ -187,13 +187,43 @@ RUN if [ ! -e /usr/bin/python3 ]; then \
         fi; \
     fi
 
+# Copy the NIXL C++ SDK (headers + libs) from wheel_builder so `cargo build`
+# can link nixl-sys (-lnixl, -lnixl_build, -lnixl_common). The runtime stage
+# doesn't need this — it uses the prebuilt Python wheel — but the dev stage
+# builds from source via maturin develop.
+# - SGLang: upstream lmsysorg/sglang runtime ships only the NIXL Python wheel,
+#   not the C++ SDK; copy it from wheel_builder here.
+# - vllm/trtllm/none: NIXL is already at /opt/nvidia/nvda_nixl in runtime; the
+#   COPY below is idempotent (overwrites with same content from wheel_builder).
+{% if device == "cuda" %}
+RUN --mount=from=wheel_builder,target=/wheel_builder \
+    if [ -d /wheel_builder/opt/nvidia/nvda_nixl ]; then \
+        mkdir -p /opt/nvidia /usr/include /usr/lib64 /etc/ld.so.conf.d; \
+        cp -rn /wheel_builder/opt/nvidia/nvda_nixl /opt/nvidia/; \
+        if [ -d /wheel_builder/usr/local/ucx ]; then \
+            cp -rn /wheel_builder/usr/local/ucx /usr/local/; \
+        fi; \
+        if [ -d /wheel_builder/usr/local/libfabric ]; then \
+            cp -rn /wheel_builder/usr/local/libfabric /usr/local/; \
+        fi; \
+        if [ -f /wheel_builder/usr/include/gdrapi.h ]; then \
+            cp -n /wheel_builder/usr/include/gdrapi.h /usr/include/; \
+        fi; \
+        if ls /wheel_builder/usr/lib64/libgdrapi.so* >/dev/null 2>&1; then \
+            cp -n /wheel_builder/usr/lib64/libgdrapi.so* /usr/lib64/; \
+            echo "/usr/lib64" > /etc/ld.so.conf.d/gdrcopy.conf; \
+        fi; \
+    fi
+{% endif %}
+
 {% if device == "xpu" %}
 ENV NIXL_LIB_DIR=/opt/intel/intel_nixl/lib/x86_64-linux-gnu  \
     NIXL_PLUGIN_DIR=/opt/intel/intel_nixl/lib/x86_64-linux-gnu/plugins \
     NIXL_PREFIX=/opt/intel/intel_nixl
-{% elif framework != "sglang" %}
-# Non-SGLang runtimes use the Dynamo-built NIXL install from wheel_builder.
-# Reset the same values already set in runtime (no harm).
+{% else %}
+# All CUDA frameworks resolve NIXL the same way (lib64 layout from wheel_builder).
+# For vllm/trtllm/none: resets values already set in runtime (no harm).
+# For sglang: sets them for the first time (required — upstream runtime omits SDK).
 ENV NIXL_PREFIX=/opt/nvidia/nvda_nixl \
     NIXL_LIB_DIR=/opt/nvidia/nvda_nixl/lib64 \
     NIXL_PLUGIN_DIR=/opt/nvidia/nvda_nixl/lib64/plugins
@@ -215,17 +245,16 @@ ENV CUDA_HOME=/usr/local/cuda \
     NVIDIA_DRIVER_CAPABILITIES=video,compute,utility
 {% endif %}
 
-{% if framework != "sglang" %}
-# Base LD_LIBRARY_PATH with universal paths (all frameworks have these)
+# Base LD_LIBRARY_PATH with universal paths (all CUDA frameworks have these
+# now that sglang dev copies the NIXL SDK from wheel_builder).
 # Framework-specific paths are conditionally added in /etc/profile.d/50-framework-paths.sh
+{% if device == "cuda" %}
 ENV LD_LIBRARY_PATH=\
 ${NIXL_LIB_DIR}:\
 ${NIXL_PLUGIN_DIR}:\
 /usr/local/ucx/lib:\
 /usr/local/ucx/lib/ucx:\
 ${LD_LIBRARY_PATH}
-{% else %}
-# SGLang dev/local-dev inherit the upstream SGLang/NIXL runtime stack.
 {% endif %}
 
 # Copy shell profile script for framework-specific environment variables

--- a/container/templates/sglang_runtime.Dockerfile
+++ b/container/templates/sglang_runtime.Dockerfile
@@ -40,16 +40,11 @@ RUN --mount=type=bind,from=wheel_builder,source=/usr/local/,target=/tmp/usr/loca
 {% endif %}
 
 {% if target not in ("dev", "local-dev") %}
-# Runtime target installs only the prebuilt Dynamo wheels. SGLang and its NIXL
-# packages come from the upstream lmsysorg/sglang runtime image; --no-deps keeps
-# pip from replacing that stack. Dev/local-dev build from source later in the
-# shared dev stage after the workspace is bind-mounted.
+# Runtime uses upstream lmsysorg/sglang's NIXL Python stack; --no-deps keeps
+# pip from replacing it. Dev/local-dev build from source after bind-mount.
 #
-# Glob is `ai_dynamo*.whl` (not `*.whl`) on purpose: the wheel_builder also
-# produces nixl-cu*.whl which is only needed by the dev stage's C++ SDK COPY
-# (see templates/dev.Dockerfile). Including it here would deposit ~tens of MB
-# of unused wheel into the runtime image, since `pip install --no-deps` below
-# only installs the ai_dynamo_runtime / ai_dynamo wheels.
+# Glob is ai_dynamo*.whl (not *.whl): wheel_builder also produces nixl-cu*.whl
+# which is only needed by the dev stage's SDK COPY (see dev.Dockerfile).
 COPY --chmod=775 --chown=dynamo:0 --from=wheel_builder /opt/dynamo/dist/ai_dynamo*.whl /opt/dynamo/wheelhouse/
 
 RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \

--- a/container/templates/sglang_runtime.Dockerfile
+++ b/container/templates/sglang_runtime.Dockerfile
@@ -44,7 +44,13 @@ RUN --mount=type=bind,from=wheel_builder,source=/usr/local/,target=/tmp/usr/loca
 # packages come from the upstream lmsysorg/sglang runtime image; --no-deps keeps
 # pip from replacing that stack. Dev/local-dev build from source later in the
 # shared dev stage after the workspace is bind-mounted.
-COPY --chmod=775 --chown=dynamo:0 --from=wheel_builder /opt/dynamo/dist/*.whl /opt/dynamo/wheelhouse/
+#
+# Glob is `ai_dynamo*.whl` (not `*.whl`) on purpose: the wheel_builder also
+# produces nixl-cu*.whl which is only needed by the dev stage's C++ SDK COPY
+# (see templates/dev.Dockerfile). Including it here would deposit ~tens of MB
+# of unused wheel into the runtime image, since `pip install --no-deps` below
+# only installs the ai_dynamo_runtime / ai_dynamo wheels.
+COPY --chmod=775 --chown=dynamo:0 --from=wheel_builder /opt/dynamo/dist/ai_dynamo*.whl /opt/dynamo/wheelhouse/
 
 RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     export PIP_CACHE_DIR=/root/.cache/pip && \


### PR DESCRIPTION
#### Overview:

The sglang dev image doesn't have the NIXL C++ SDK, so source compilation fails with `rust-lld: error: unable to find library -lnixl_common`. This PR fixes it by adding the SDK to the dev stage (dev only, others not affected).

#### Details:

- Add `nixl_ref: 0.10.1` for sglang in `container/context.yaml` so `wheel_builder` builds the NIXL C++ SDK
- In `templates/dev.Dockerfile`, add a `RUN --mount=from=wheel_builder` block that copies `/opt/nvidia/nvda_nixl`, `/usr/local/ucx`, `/usr/local/libfabric`, and `gdrapi.h` into the dev stage; make NIXL `ENV` vars and `LD_LIBRARY_PATH` unconditional for all CUDA frameworks
- In `templates/sglang_runtime.Dockerfile`, narrow the wheel COPY from `*.whl` → `ai_dynamo*.whl` so the new `nixl-cu*.whl` produced by wheel_builder doesn't bloat the runtime image

#### Verification:

Built `dynamo:sglang-dev-test` locally from the modified template (`docker buildx build --target dev -f container/sglang-dev-cuda13.0-amd64-rendered.Dockerfile .`) and confirmed:

- `/opt/nvidia/nvda_nixl/include/nixl.h` and `/opt/nvidia/nvda_nixl/lib64/libnixl_common.so` present
- `NIXL_PREFIX`, `NIXL_LIB_DIR` env vars set
- `cargo build --features dynamo-llm/block-manager --workspace` succeeds end-to-end:
  ```
  Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 19s
  Build completed successfully
  Rudimentary Python import test PASSED
  ```

#### Where should the reviewer start?

`container/context.yaml`, then `container/templates/dev.Dockerfile`, then `container/templates/sglang_runtime.Dockerfile`

/coderabbit profile chill