### PR TITLE
chore: SGLang base image refresh for DeepSeek v4 images (#9002)

### DIFF
--- a/recipes/deepseek-v4/container/sglang/Dockerfile.dsv4.sglang.b200
+++ b/recipes/deepseek-v4/container/sglang/Dockerfile.dsv4.sglang.b200
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG DYNAMO_SRC_IMAGE=dynamo:latest-sglang-runtime
-ARG DSV4_BASE_IMAGE=lmsysorg/sglang:deepseek-v4-blackwell@sha256:6b0c68ff8880730a010b0c8ca05009597c0482f0884ca7159037e656fb6b3f3e
+# based on https://github.com/sgl-project/sglang/pull/23600/changes/6d0858d2a82e18b657c8140c329a336ab3673ff8
+ARG DSV4_BASE_IMAGE=lmsysorg/sglang:deepseek-v4-blackwell@sha256:940f7652dd16b04e82ecc57c4dcb6a3ae7d7283bc38db1ce3c4aa6ae3685c4aa
 
 FROM ${DYNAMO_SRC_IMAGE} AS dynamo_src
 

--- a/recipes/deepseek-v4/container/sglang/Dockerfile.dsv4.sglang.gb200
+++ b/recipes/deepseek-v4/container/sglang/Dockerfile.dsv4.sglang.gb200
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG DYNAMO_SRC_IMAGE=dynamo:latest-sglang-runtime
-ARG DSV4_BASE_IMAGE=lmsysorg/sglang:deepseek-v4-grace-blackwell@sha256:7fee20a945cbb6ae26e8544a9e3dc2d50a2adbed851d8c2b02bac9e9e5c734a0
+# based on https://github.com/sgl-project/sglang/pull/23600/changes/1b497c7a0c5a2951ae86f21f4cfebe4678bbc7e4
+ARG DSV4_BASE_IMAGE=lmsysorg/sglang:deepseek-v4-grace-blackwell@sha256:e0a0ebb70572a70d2a90759de96482e7f482d501283c48c3393b1e62198051ef
 
 FROM ${DYNAMO_SRC_IMAGE} AS dynamo_src
 


### PR DESCRIPTION
#### Overview:

CP #9002

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9218" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container base images to latest versions for improved stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->