### PR TITLE
feat(kv-router): default approximate routing to CRTC

### DIFF
--- a/components/src/dynamo/common/configuration/groups/kv_router_args.py
+++ b/components/src/dynamo/common/configuration/groups/kv_router_args.py
@@ -252,8 +252,8 @@ class KvRouterArgGroup(ArgGroup):
             env_var="DYN_ROUTER_EVENT_THREADS",
             default=4,
             help=(
-                "KV Router: Number of event processing threads. When > 1, uses a concurrent "
-                "radix tree with a thread pool for higher throughput. Also applies to "
+                "KV Router: Number of KV indexer worker threads. When > 1, uses a concurrent "
+                "radix tree with a thread pool for higher throughput, including "
                 "approximate routing when --no-router-kv-events is set."
             ),
             arg_type=int,

--- a/components/src/dynamo/common/configuration/groups/kv_router_args.py
+++ b/components/src/dynamo/common/configuration/groups/kv_router_args.py
@@ -253,8 +253,8 @@ class KvRouterArgGroup(ArgGroup):
             default=4,
             help=(
                 "KV Router: Number of event processing threads. When > 1, uses a concurrent "
-                "radix tree with a thread pool for higher throughput. Ignored when "
-                "--no-router-kv-events is set."
+                "radix tree with a thread pool for higher throughput. Also applies to "
+                "approximate routing when --no-router-kv-events is set."
             ),
             arg_type=int,
         )

--- a/components/src/dynamo/router/backend_args.py
+++ b/components/src/dynamo/router/backend_args.py
@@ -177,6 +177,6 @@ class DynamoRouterArgGroup(ArgGroup):
             flag_name="--router-event-threads",
             env_var="DYN_ROUTER_EVENT_THREADS",
             default=4,
-            help="KV Router: Number of event processing threads. >1 uses concurrent radix tree and thread pool for higher throughput. Ignored when --no-router-kv-events is set (approximate mode uses TTL expiration).",
+            help="KV Router: Number of KV indexer worker threads. >1 uses concurrent radix tree and thread pool for higher throughput, including approximate routing with --no-router-kv-events.",
             arg_type=int,
         )

--- a/docs/components/frontend/configuration.md
+++ b/docs/components/frontend/configuration.md
@@ -42,7 +42,7 @@ The Rust HTTP server also reads these environment variables (not exposed as CLI 
 | `--router-track-output-blocks` / `--no-router-track-output-blocks` | `DYN_ROUTER_TRACK_OUTPUT_BLOCKS` | `false` | Track output blocks with fractional decay during generation |
 | `--router-track-prefill-tokens` / `--no-router-track-prefill-tokens` | `DYN_ROUTER_TRACK_PREFILL_TOKENS` | `true` | Track prompt-side prefill load in worker load accounting |
 | `--router-prefill-load-model` | `DYN_ROUTER_PREFILL_LOAD_MODEL` | `none` | Prompt-side load model: `none` for static load, `aic` for oldest-prefill decay using an AIC prediction |
-| `--router-event-threads` | `DYN_ROUTER_EVENT_THREADS` | `4` | Event processing threads. >1 enables concurrent radix tree |
+| `--router-event-threads` | `DYN_ROUTER_EVENT_THREADS` | `4` | KV indexer worker threads. >1 enables the concurrent radix tree, including with `--no-router-kv-events` |
 | `--router-queue-threshold` | `DYN_ROUTER_QUEUE_THRESHOLD` | `4.0` | Queue threshold fraction of prefill capacity. Enables priority scheduling |
 | `--router-queue-policy` | `DYN_ROUTER_QUEUE_POLICY` | `fcfs` | Queue scheduling policy: `fcfs` (tail TTFT), `wspt` (avg TTFT), or `lcfs` (comparison-only reverse ordering) |
 | `--decode-fallback` / `--no-decode-fallback` | `DYN_DECODE_FALLBACK` | `false` | Fall back to aggregated mode when prefill workers unavailable |

--- a/docs/components/router/router-configuration.md
+++ b/docs/components/router/router-configuration.md
@@ -40,7 +40,7 @@ For `--router-mode device-aware-weighted`, set `DYN_ENCODER_CUDA_TO_CPU_RATIO` t
 ## KV Indexer / Approx KV Indexer
 
 - `--router-ttl-secs`: Time-to-live in seconds for blocks in the router's local cache predictions. Defaults to 120.0 seconds when `--no-router-kv-events` is used.
-- `--router-event-threads`: Number of event processing threads for the KV indexer (default: 4). With KV events enabled, values greater than 1 use the concurrent radix tree; approximate mode always uses a single-threaded indexer.
+- `--router-event-threads`: Number of KV indexer worker threads (default: 4). Values greater than 1 use the concurrent radix tree for both event-driven routing and approximate routing with `--no-router-kv-events`; set this to 1 to force the single-threaded indexer.
 
 To implement KV event publishing for custom inference engines, see [KV Event Publishing for Custom Engines](../../integrations/kv-events-custom-engines.md).
 For details on per-request agent hints (`priority`, `osl`, `speculative_prefill`), see [NVIDIA Request Extensions (`nvext`)](../frontend/nvext.md#agent-hints).

--- a/docs/design-docs/distributed-runtime.md
+++ b/docs/design-docs/distributed-runtime.md
@@ -53,7 +53,7 @@ When using Kubernetes discovery, the KV store backend automatically switches to 
 - `DistributedRuntime`: When a `DistributedRuntime` object is created, it establishes connections based on the discovery backend:
     - **Kubernetes mode**: Uses K8s API for service registration via DynamoWorkerMetadata CRD. No external dependencies required.
     - **KV Store mode**: Connects to etcd for service discovery. Creates a primary lease with a background keep-alive task. All objects registered under this `DistributedRuntime` use this lease_id to maintain their lifecycle.
-    - **NATS** (optional): Used for KV event messaging when using KV-aware routing. Can be disabled via `--no-kv-events` flag, which enables prediction-based routing without event persistence.
+    - **NATS** (optional): Used for KV event messaging when using KV-aware routing. Can be disabled via `--no-router-kv-events`, which enables prediction-based routing without event persistence.
     - **Request Plane**: TCP by default. Can be configured to use HTTP or NATS via `DYN_REQUEST_PLANE` environment variable.
 - `Namespace`: `Namespace`s are primarily a logical grouping mechanism. They provide the root path for all components under this `Namespace`.
 - `Component`: When a `Component` object is created, it registers a service in the internal registry of the `DistributedRuntime`, which tracks all services and endpoints.
@@ -88,5 +88,4 @@ We provide native rust and python (through binding) examples for basic usage of 
 
 - Rust: `/lib/runtime/examples/`
 - Python: We also provide complete examples of using `DistributedRuntime`. Please refer to the engines in `components/src/dynamo` for full implementation details.
-
 

--- a/docs/design-docs/dynamo-flow.md
+++ b/docs/design-docs/dynamo-flow.md
@@ -43,7 +43,7 @@ Coordination and messaging support:
 - **HTTP/NATS**: Alternative transports configurable via `DYN_REQUEST_PLANE`.
 
 ### NATS Connections (Optional, for KV routing)
-- **KV Events**: Cache state events for KV-aware routing (can be disabled with `--no-kv-events`)
+- **KV Events**: Cache state events for KV-aware routing (can be disabled with `--no-router-kv-events`)
 
 ### Planning Connections (Gold, dotted)
 - **Frontend → Planner**: Metrics collection for auto-scaling decisions

--- a/docs/design-docs/router-design.md
+++ b/docs/design-docs/router-design.md
@@ -131,9 +131,9 @@ The KVIndexer has a method `find_matches_for_request`, which takes in tokens and
 
 The KVIndexer supports two backend implementations, selected via `--router-event-threads`:
 
-- **Single-threaded RadixTree** (`--router-event-threads 1`): Events are processed in a dedicated single-threaded tokio runtime via channel-based dispatch. Supports TTL-based expiration for `--no-kv-events` approximate mode.
+- **Single-threaded RadixTree** (`--router-event-threads 1`): Events are processed in a dedicated single-threaded tokio runtime via channel-based dispatch. Also supports TTL-based expiration for `--no-router-kv-events` approximate mode.
 
-- **ConcurrentRadixTree** (default, `--router-event-threads N` where N > 1): A thread-safe radix tree with a pool of N worker threads for event processing (default: 4). Uses sticky worker routing (events for the same worker always go to the same thread) to ensure per-worker event serialization. Read operations (`find_matches`) execute concurrently with writes.
+- **ConcurrentRadixTree** (default, `--router-event-threads N` where N > 1): A thread-safe radix tree with a pool of N worker threads for event processing and approximate routing-decision writes (default: 4). Uses sticky worker routing (events or synthetic approximate writes for the same worker always go to the same thread) to ensure per-worker serialization. Read operations (`find_matches`) execute concurrently with writes.
 
 ### Inter-Router Communication
 

--- a/docs/development/runtime-guide.md
+++ b/docs/development/runtime-guide.md
@@ -60,7 +60,7 @@ be operating within your distributed runtime.
 
 The current examples use a hard-coded `namespace`. We will address the `namespace` collisions later.
 
-Most examples require `etcd` for service discovery. `nats.io` is required for KV-aware routing with event tracking; for approximate mode (`--no-kv-events`), NATS is optional.
+Most examples require `etcd` for service discovery. `nats.io` is required for KV-aware routing with event tracking; for approximate mode (`--no-router-kv-events`), NATS is optional.
 
 #### Rust `hello_world`
 

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -1296,8 +1296,9 @@ class KvRouterConfig:
                 Requests are queued if all workers exceed this fraction of max_num_batched_tokens.
                 Enables priority scheduling via request priority hints.
                 Set to None to disable queueing (all requests go directly to the scheduler).
-            router_event_threads: Number of event processing threads (default: 4).
-                When > 1, uses a concurrent radix tree with a thread pool.
+            router_event_threads: Number of KV indexer worker threads (default: 4).
+                When > 1, uses a concurrent radix tree with a thread pool,
+                including for approximate routing when KV events are disabled.
             router_queue_policy: Scheduling policy for the router queue (default: "fcfs").
                 "fcfs": first-come first-served with priority bumps — optimizes tail TTFT.
                 "lcfs": last-come first-served with priority bumps — intentionally worsens tail behavior for policy comparisons.

--- a/lib/kv-router/src/indexer/tests.rs
+++ b/lib/kv-router/src/indexer/tests.rs
@@ -820,6 +820,30 @@ mod interface_tests {
     }
 
     #[tokio::test]
+    async fn test_concurrent_compressed_approx_records_precomputed_hashes() {
+        let index = ThreadPoolIndexer::new_with_pruning(
+            ConcurrentRadixTreeCompressed::new(),
+            4,
+            4,
+            PruneConfig {
+                ttl: Duration::from_secs(60),
+            },
+        );
+        let tokens = vec![1, 2, 3, 4];
+        let worker = WorkerWithDpRank::new(7, 0);
+        let block_hashes = compute_block_hash_for_seq(&tokens, 4, BlockHashOptions::default());
+        let sequence_hashes = compute_seq_hash_for_block(&block_hashes);
+
+        index
+            .process_routing_decision_with_hashes(worker, block_hashes, sequence_hashes)
+            .await
+            .unwrap();
+        flush_and_settle(&index).await;
+
+        assert_request_score(&index, &tokens, worker, 1).await;
+    }
+
+    #[tokio::test]
     #[apply(approx_indexer_template)]
     async fn test_approx_ttl_expiry_removes_match(variant: &str) {
         let ttl = Duration::from_millis(25);

--- a/lib/kv-router/src/indexer/thread_pool.rs
+++ b/lib/kv-router/src/indexer/thread_pool.rs
@@ -434,6 +434,55 @@ impl<T: SyncIndexer> ThreadPoolIndexer<T> {
             );
         }
     }
+
+    async fn record_routing_decision_hashes(
+        &self,
+        worker: WorkerWithDpRank,
+        local_hashes: &[LocalBlockHash],
+        sequence_hashes: &[SequenceHash],
+    ) -> Result<(), KvRouterError> {
+        let Some(prune_manager) = &self.prune_manager else {
+            // Approximate routing decisions are only recorded when explicitly enabled.
+            return Ok(());
+        };
+
+        let event_id = Self::next_synthetic_event_id(&self.synthetic_event_id);
+        let event = Self::stored_event_for_hashes(worker, local_hashes, sequence_hashes, event_id);
+        let prune_entries = Self::block_entries_for_hashes(worker, sequence_hashes);
+        let thread_idx = Self::get_or_assign_thread_idx(
+            &self.worker_assignments,
+            &self.worker_assignment_count,
+            worker.worker_id,
+            self.num_workers,
+        );
+
+        let (resp_tx, resp_rx) = oneshot::channel();
+        self.worker_event_channels[thread_idx]
+            .send(WorkerTask::EventWithAck {
+                event,
+                resp: resp_tx,
+            })
+            .map_err(|_| KvRouterError::IndexerOffline)?;
+
+        let applied = resp_rx
+            .await
+            .map_err(|_| KvRouterError::IndexerDroppedRequest)?;
+        if applied {
+            prune_manager.insert_worker_block_entries(worker, prune_entries);
+        }
+
+        Ok(())
+    }
+
+    pub async fn process_routing_decision_with_hashes(
+        &self,
+        worker: WorkerWithDpRank,
+        local_hashes: Vec<LocalBlockHash>,
+        sequence_hashes: Vec<SequenceHash>,
+    ) -> Result<(), KvRouterError> {
+        self.record_routing_decision_hashes(worker, &local_hashes, &sequence_hashes)
+            .await
+    }
 }
 
 impl<T: SyncIndexer> Drop for ThreadPoolIndexer<T> {
@@ -639,11 +688,6 @@ impl<T: SyncIndexer> KvIndexerInterface for ThreadPoolIndexer<T> {
         tokens_with_hashes: &mut TokensWithHashes,
         worker: WorkerWithDpRank,
     ) -> Result<(), KvRouterError> {
-        let Some(prune_manager) = &self.prune_manager else {
-            // Approximate routing decisions are only recorded when explicitly enabled.
-            return Ok(());
-        };
-
         tokens_with_hashes.get_or_compute_seq_hashes();
         let local_hashes = tokens_with_hashes
             .block_hashes()
@@ -651,32 +695,8 @@ impl<T: SyncIndexer> KvIndexerInterface for ThreadPoolIndexer<T> {
         let sequence_hashes = tokens_with_hashes
             .seq_hashes()
             .expect("sequence hashes missing after computing sequence hashes");
-        let event_id = Self::next_synthetic_event_id(&self.synthetic_event_id);
-        let event = Self::stored_event_for_hashes(worker, local_hashes, sequence_hashes, event_id);
-        let prune_entries = Self::block_entries_for_hashes(worker, sequence_hashes);
-        let thread_idx = Self::get_or_assign_thread_idx(
-            &self.worker_assignments,
-            &self.worker_assignment_count,
-            worker.worker_id,
-            self.num_workers,
-        );
-
-        let (resp_tx, resp_rx) = oneshot::channel();
-        self.worker_event_channels[thread_idx]
-            .send(WorkerTask::EventWithAck {
-                event,
-                resp: resp_tx,
-            })
-            .map_err(|_| KvRouterError::IndexerOffline)?;
-
-        let applied = resp_rx
+        self.record_routing_decision_hashes(worker, local_hashes, sequence_hashes)
             .await
-            .map_err(|_| KvRouterError::IndexerDroppedRequest)?;
-        if applied {
-            prune_manager.insert_worker_block_entries(worker, prune_entries);
-        }
-
-        Ok(())
     }
 
     async fn flush(&self) -> usize {

--- a/lib/kv-router/src/scheduling/config.rs
+++ b/lib/kv-router/src/scheduling/config.rs
@@ -238,9 +238,9 @@ pub struct KvRouterConfig {
     #[validate(range(min = 0.0))]
     pub router_queue_threshold: Option<f64>,
 
-    /// Number of event processing threads for the KV indexer.
-    /// When > 1, uses ConcurrentRadixTree with a thread pool instead of the
-    /// single-threaded RadixTree. Default: 4.
+    /// Number of KV indexer worker threads.
+    /// When > 1, uses ConcurrentRadixTree with a thread pool for event-driven
+    /// and approximate routing writes. Default: 4.
     #[validate(range(min = 1))]
     pub router_event_threads: u32,
 

--- a/lib/llm/src/kv_router/indexer/mod.rs
+++ b/lib/llm/src/kv_router/indexer/mod.rs
@@ -81,10 +81,26 @@ impl Indexer {
 
         if !kv_router_config.use_kv_events {
             let kv_indexer_metrics = KvIndexerMetrics::from_component(component);
-            let cancellation_token = component.drt().primary_token();
             let prune_config = Some(PruneConfig {
                 ttl: Duration::from_secs_f64(kv_router_config.router_ttl_secs),
             });
+            if kv_router_config.router_event_threads > 1 {
+                return Ok(Self::Concurrent {
+                    primary: Arc::new(ThreadPoolIndexer::new_with_metrics_and_pruning(
+                        ConcurrentRadixTreeCompressed::new(),
+                        kv_router_config.router_event_threads as usize,
+                        block_size,
+                        Some(kv_indexer_metrics),
+                        prune_config,
+                    )),
+                    lower_tier: LowerTierIndexers::new(
+                        kv_router_config.router_event_threads as usize,
+                        block_size,
+                    ),
+                });
+            }
+
+            let cancellation_token = component.drt().primary_token();
             return Ok(Self::KvIndexer {
                 primary: KvIndexer::new_with_frequency(
                     cancellation_token,
@@ -201,11 +217,10 @@ impl Indexer {
                     .process_routing_decision_with_hashes(worker, local_hashes, sequence_hashes)
                     .await
             }
-            Self::Concurrent { .. } => {
-                tracing::warn!(
-                    "Hashed routing-decision recording is unsupported for concurrent indexers"
-                );
-                Err(KvRouterError::IndexerDroppedRequest)
+            Self::Concurrent { primary, .. } => {
+                primary
+                    .process_routing_decision_with_hashes(worker, local_hashes, sequence_hashes)
+                    .await
             }
             Self::Remote(remote) => remote
                 .record_hashed_routing_decision(worker, local_hashes, sequence_hashes)
@@ -432,6 +447,7 @@ pub(super) mod test_util {
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
+    use std::time::Duration;
 
     use tokio_util::sync::CancellationToken;
 
@@ -439,8 +455,12 @@ mod tests {
     use super::{Indexer, LowerTierIndexers};
     use dynamo_kv_router::{
         ConcurrentRadixTreeCompressed, ThreadPoolIndexer,
+        approx::PruneConfig,
         indexer::{KvIndexer, KvIndexerInterface, KvIndexerMetrics},
-        protocols::{LocalBlockHash, StorageTier, WorkerWithDpRank},
+        protocols::{
+            BlockHashOptions, LocalBlockHash, StorageTier, WorkerWithDpRank,
+            compute_block_hash_for_seq, compute_seq_hash_for_block,
+        },
     };
 
     fn make_test_indexer() -> Indexer {
@@ -460,6 +480,20 @@ mod tests {
                 ConcurrentRadixTreeCompressed::new(),
                 2,
                 4,
+            )),
+            lower_tier: LowerTierIndexers::new(2, 4),
+        }
+    }
+
+    fn make_test_concurrent_approx_indexer() -> Indexer {
+        Indexer::Concurrent {
+            primary: Arc::new(ThreadPoolIndexer::new_with_pruning(
+                ConcurrentRadixTreeCompressed::new(),
+                2,
+                4,
+                PruneConfig {
+                    ttl: Duration::from_secs(60),
+                },
             )),
             lower_tier: LowerTierIndexers::new(2, 4),
         }
@@ -675,6 +709,24 @@ mod tests {
                 .and_then(|tier| tier.hits.get(&worker)),
             Some(&1)
         );
+    }
+
+    #[tokio::test]
+    async fn concurrent_records_hashed_routing_decision() {
+        let indexer = make_test_concurrent_approx_indexer();
+        let worker = WorkerWithDpRank::new(7, 0);
+        let tokens = vec![1, 2, 3, 4];
+        let block_hashes = compute_block_hash_for_seq(&tokens, 4, BlockHashOptions::default());
+        let sequence_hashes = compute_seq_hash_for_block(&block_hashes);
+
+        indexer
+            .record_hashed_routing_decision(worker, block_hashes.clone(), sequence_hashes)
+            .await
+            .unwrap();
+        flush_indexer(&indexer).await;
+
+        let matches = indexer.find_matches_by_tier(block_hashes).await.unwrap();
+        assert_eq!(matches.device.overlap_scores.scores.get(&worker), Some(&1));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- default approximate routing to the concurrent radix tree when router event threads > 1
- allow concurrent approximate indexers to record precomputed routing-decision hashes
- update CLI help and add focused coverage for the concurrent approx path

## Validation
- cargo clippy --no-deps --all-targets -- -D warnings in lib/kv-router
- cargo clippy --no-default-features -- -D warnings in lib/llm
- cargo fmt in lib/kv-router and lib/llm
- cargo test test_concurrent_compressed_approx_records_precomputed_hashes in lib/kv-router
- attempted cargo test --no-default-features concurrent_records_hashed_routing_decision in lib/llm, but local linking failed with ld: library 'stdc++' not found
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9219" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated help text for router event threads configuration to clarify behavior with approximate routing.

* **Improvements**
  * Enhanced multi-threaded KV indexer to support pruning with hashed routing decisions.

* **Tests**
  * Added test coverage for concurrent approximate routing with precomputed hashes and pruning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->