### PR TITLE
chore: Unify TCP request wire parsing

### DIFF
--- a/lib/runtime/src/pipeline/network/codec.rs
+++ b/lib/runtime/src/pipeline/network/codec.rs
@@ -20,6 +20,193 @@ pub mod zero_copy_decoder;
 pub use two_part::{TwoPartCodec, TwoPartMessage, TwoPartMessageType};
 pub use zero_copy_decoder::{TcpRequestMessageZeroCopy, ZeroCopyTcpDecoder};
 
+const TCP_REQUEST_ENDPOINT_LEN_WIDTH: usize = 2;
+const TCP_REQUEST_HEADERS_LEN_WIDTH: usize = 2;
+const TCP_REQUEST_PAYLOAD_LEN_WIDTH: usize = 4;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct TcpRequestWireHeader {
+    endpoint_len: usize,
+    headers_len: usize,
+    payload_len: usize,
+    header_size: usize,
+    total_len: usize,
+}
+
+impl TcpRequestWireHeader {
+    fn endpoint_start(&self) -> usize {
+        TCP_REQUEST_ENDPOINT_LEN_WIDTH
+    }
+
+    fn endpoint_end(&self) -> usize {
+        self.endpoint_start() + self.endpoint_len
+    }
+
+    fn headers_start(&self) -> usize {
+        self.endpoint_end() + TCP_REQUEST_HEADERS_LEN_WIDTH
+    }
+
+    fn headers_end(&self) -> usize {
+        self.headers_start() + self.headers_len
+    }
+
+    fn payload_start(&self) -> usize {
+        self.header_size
+    }
+}
+
+fn tcp_request_header_size(endpoint_len: usize, headers_len: usize) -> usize {
+    TCP_REQUEST_ENDPOINT_LEN_WIDTH
+        + endpoint_len
+        + TCP_REQUEST_HEADERS_LEN_WIDTH
+        + headers_len
+        + TCP_REQUEST_PAYLOAD_LEN_WIDTH
+}
+
+fn tcp_request_total_len(
+    endpoint_len: usize,
+    headers_len: usize,
+    payload_len: usize,
+) -> Result<TcpRequestWireHeader, std::io::Error> {
+    let header_size = tcp_request_header_size(endpoint_len, headers_len);
+    let total_len = header_size.checked_add(payload_len).ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "TCP request message length overflow",
+        )
+    })?;
+
+    Ok(TcpRequestWireHeader {
+        endpoint_len,
+        headers_len,
+        payload_len,
+        header_size,
+        total_len,
+    })
+}
+
+fn validate_tcp_request_encode_lengths(
+    endpoint_len: usize,
+    headers_len: usize,
+    payload_len: usize,
+) -> Result<TcpRequestWireHeader, std::io::Error> {
+    if endpoint_len > u16::MAX as usize {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("Endpoint path too long: {} bytes", endpoint_len),
+        ));
+    }
+
+    if headers_len > u16::MAX as usize {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("Headers too large: {} bytes", headers_len),
+        ));
+    }
+
+    if payload_len > u32::MAX as usize {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("Payload too large: {} bytes", payload_len),
+        ));
+    }
+
+    tcp_request_total_len(endpoint_len, headers_len, payload_len)
+}
+
+fn tcp_request_endpoint_len(bytes: &[u8]) -> Result<usize, std::io::Error> {
+    if bytes.len() < TCP_REQUEST_ENDPOINT_LEN_WIDTH {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::UnexpectedEof,
+            "Not enough bytes for endpoint path length",
+        ));
+    }
+
+    Ok(u16::from_be_bytes([bytes[0], bytes[1]]) as usize)
+}
+
+fn tcp_request_headers_len(bytes: &[u8], endpoint_len: usize) -> Result<usize, std::io::Error> {
+    let endpoint_end = TCP_REQUEST_ENDPOINT_LEN_WIDTH + endpoint_len;
+    if bytes.len() < endpoint_end {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::UnexpectedEof,
+            "Not enough bytes for endpoint path",
+        ));
+    }
+
+    if bytes.len() < endpoint_end + TCP_REQUEST_HEADERS_LEN_WIDTH {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::UnexpectedEof,
+            "Not enough bytes for headers length",
+        ));
+    }
+
+    Ok(u16::from_be_bytes([bytes[endpoint_end], bytes[endpoint_end + 1]]) as usize)
+}
+
+fn parse_tcp_request_frame_header(bytes: &[u8]) -> Result<TcpRequestWireHeader, std::io::Error> {
+    let endpoint_len = tcp_request_endpoint_len(bytes)?;
+    let headers_len = tcp_request_headers_len(bytes, endpoint_len)?;
+
+    let headers_end =
+        TCP_REQUEST_ENDPOINT_LEN_WIDTH + endpoint_len + TCP_REQUEST_HEADERS_LEN_WIDTH + headers_len;
+    if bytes.len() < headers_end {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::UnexpectedEof,
+            "Not enough bytes for headers",
+        ));
+    }
+
+    if bytes.len() < headers_end + TCP_REQUEST_PAYLOAD_LEN_WIDTH {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::UnexpectedEof,
+            "Not enough bytes for payload length",
+        ));
+    }
+
+    let payload_len = u32::from_be_bytes([
+        bytes[headers_end],
+        bytes[headers_end + 1],
+        bytes[headers_end + 2],
+        bytes[headers_end + 3],
+    ]) as usize;
+
+    tcp_request_total_len(endpoint_len, headers_len, payload_len)
+}
+
+fn parse_tcp_request_frame(bytes: &[u8]) -> Result<TcpRequestWireHeader, std::io::Error> {
+    let parsed = parse_tcp_request_frame_header(bytes)?;
+    if bytes.len() < parsed.total_len {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::UnexpectedEof,
+            format!(
+                "Not enough bytes for payload: expected {}, got {}",
+                parsed.payload_len,
+                bytes.len().saturating_sub(parsed.payload_start())
+            ),
+        ));
+    }
+
+    Ok(parsed)
+}
+
+fn check_tcp_request_max_message_size(
+    total_len: usize,
+    max_message_size: usize,
+) -> Result<(), std::io::Error> {
+    if total_len > max_message_size {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "message too large: {} bytes (max: {} bytes)",
+                total_len, max_message_size
+            ),
+        ));
+    }
+
+    Ok(())
+}
+
 /// TCP request plane protocol message with endpoint routing and trace headers
 ///
 /// Wire format:
@@ -62,13 +249,6 @@ impl TcpRequestMessage {
         let endpoint_bytes = self.endpoint_path.as_bytes();
         let endpoint_len = endpoint_bytes.len();
 
-        if endpoint_len > u16::MAX as usize {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                format!("Endpoint path too long: {} bytes", endpoint_len),
-            ));
-        }
-
         // Encode headers as JSON
         let headers_json = serde_json::to_vec(&self.headers).map_err(|e| {
             std::io::Error::new(
@@ -78,23 +258,11 @@ impl TcpRequestMessage {
         })?;
         let headers_len = headers_json.len();
 
-        if headers_len > u16::MAX as usize {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                format!("Headers too large: {} bytes", headers_len),
-            ));
-        }
-
-        if self.payload.len() > u32::MAX as usize {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                format!("Payload too large: {} bytes", self.payload.len()),
-            ));
-        }
+        let parsed =
+            validate_tcp_request_encode_lengths(endpoint_len, headers_len, self.payload.len())?;
 
         // Use BytesMut for efficient buffer building
-        let mut buf =
-            BytesMut::with_capacity(2 + endpoint_len + 2 + headers_len + 4 + self.payload.len());
+        let mut buf = BytesMut::with_capacity(parsed.total_len);
 
         // Write endpoint path length (2 bytes)
         buf.put_u16(endpoint_len as u16);
@@ -120,284 +288,37 @@ impl TcpRequestMessage {
 
     /// Decode message from bytes (for backward compatibility, zero-copy when possible)
     pub fn decode(bytes: &Bytes) -> Result<Self, std::io::Error> {
-        if bytes.len() < 2 {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::UnexpectedEof,
-                "Not enough bytes for endpoint path length",
-            ));
-        }
-
-        // Read endpoint path length (2 bytes)
-        let endpoint_len = u16::from_be_bytes([bytes[0], bytes[1]]) as usize;
-        let mut offset = 2;
-
-        if bytes.len() < offset + endpoint_len {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::UnexpectedEof,
-                "Not enough bytes for endpoint path",
-            ));
-        }
+        let parsed = parse_tcp_request_frame(bytes)?;
 
         // Read endpoint path (requires copy for UTF-8 validation)
-        let endpoint_path = String::from_utf8(bytes[offset..offset + endpoint_len].to_vec())
-            .map_err(|e| {
-                std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    format!("Invalid UTF-8 in endpoint path: {}", e),
-                )
-            })?;
-        offset += endpoint_len;
-
-        if bytes.len() < offset + 2 {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::UnexpectedEof,
-                "Not enough bytes for headers length",
-            ));
-        }
-
-        // Read headers length (2 bytes)
-        let headers_len = u16::from_be_bytes([bytes[offset], bytes[offset + 1]]) as usize;
-        offset += 2;
-
-        if bytes.len() < offset + headers_len {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::UnexpectedEof,
-                "Not enough bytes for headers",
-            ));
-        }
+        let endpoint_path =
+            String::from_utf8(bytes[parsed.endpoint_start()..parsed.endpoint_end()].to_vec())
+                .map_err(|e| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!("Invalid UTF-8 in endpoint path: {}", e),
+                    )
+                })?;
 
         // Read and parse headers
-        let headers: std::collections::HashMap<String, String> =
-            serde_json::from_slice(&bytes[offset..offset + headers_len]).map_err(|e| {
-                std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    format!("Invalid JSON in headers: {}", e),
-                )
-            })?;
-        offset += headers_len;
-
-        if bytes.len() < offset + 4 {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::UnexpectedEof,
-                "Not enough bytes for payload length",
-            ));
-        }
-
-        // Read payload length (4 bytes)
-        let payload_len = u32::from_be_bytes([
-            bytes[offset],
-            bytes[offset + 1],
-            bytes[offset + 2],
-            bytes[offset + 3],
-        ]) as usize;
-        offset += 4;
-
-        if bytes.len() < offset + payload_len {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::UnexpectedEof,
-                format!(
-                    "Not enough bytes for payload: expected {}, got {}",
-                    payload_len,
-                    bytes.len() - offset
-                ),
-            ));
-        }
+        let headers: std::collections::HashMap<String, String> = serde_json::from_slice(
+            &bytes[parsed.headers_start()..parsed.headers_end()],
+        )
+        .map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("Invalid JSON in headers: {}", e),
+            )
+        })?;
 
         // Read payload (zero-copy slice)
-        let payload = bytes.slice(offset..offset + payload_len);
+        let payload = bytes.slice(parsed.payload_start()..parsed.total_len);
 
         Ok(Self {
             endpoint_path,
             headers,
             payload,
         })
-    }
-}
-
-/// Codec for encoding/decoding TcpRequestMessage
-/// Supports max_message_size enforcement
-#[derive(Clone, Default)]
-pub struct TcpRequestCodec {
-    max_message_size: Option<usize>,
-}
-
-impl TcpRequestCodec {
-    pub fn new(max_message_size: Option<usize>) -> Self {
-        Self { max_message_size }
-    }
-}
-
-impl Decoder for TcpRequestCodec {
-    type Item = TcpRequestMessage;
-    type Error = std::io::Error;
-
-    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
-        // Need at least 2 bytes for endpoint_path_len
-        if src.len() < 2 {
-            return Ok(None);
-        }
-
-        // Peek at endpoint path length without consuming
-        let endpoint_len = u16::from_be_bytes([src[0], src[1]]) as usize;
-
-        // Need path + headers_len
-        if src.len() < 2 + endpoint_len + 2 {
-            return Ok(None);
-        }
-
-        // Peek at headers length
-        let headers_len_offset = 2 + endpoint_len;
-        let headers_len =
-            u16::from_be_bytes([src[headers_len_offset], src[headers_len_offset + 1]]) as usize;
-
-        // Need path + headers + payload_len
-        let header_size = 2 + endpoint_len + 2 + headers_len + 4;
-        if src.len() < header_size {
-            return Ok(None);
-        }
-
-        // Peek at payload length
-        let payload_len_offset = 2 + endpoint_len + 2 + headers_len;
-        let payload_len = u32::from_be_bytes([
-            src[payload_len_offset],
-            src[payload_len_offset + 1],
-            src[payload_len_offset + 2],
-            src[payload_len_offset + 3],
-        ]) as usize;
-
-        let total_len = header_size + payload_len;
-
-        // Check max message size
-        if let Some(max_size) = self.max_message_size
-            && total_len > max_size
-        {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!(
-                    "Request too large: {} bytes (max: {} bytes)",
-                    total_len, max_size
-                ),
-            ));
-        }
-
-        // Check if we have the full message
-        if src.len() < total_len {
-            return Ok(None);
-        }
-
-        // We have a complete message, advance past endpoint path length prefix
-        src.advance(2);
-
-        // Read endpoint path
-        let endpoint_bytes = src.split_to(endpoint_len);
-        let endpoint_path = String::from_utf8(endpoint_bytes.to_vec()).map_err(|e| {
-            std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!("Invalid UTF-8 in endpoint path: {}", e),
-            )
-        })?;
-
-        // Advance past headers length
-        src.advance(2);
-
-        // Read and parse headers
-        let headers_bytes = src.split_to(headers_len);
-        let headers: std::collections::HashMap<String, String> =
-            serde_json::from_slice(&headers_bytes).map_err(|e| {
-                std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    format!("Invalid JSON in headers: {}", e),
-                )
-            })?;
-
-        // Advance past payload length
-        src.advance(4);
-
-        // Read payload
-        let payload = src.split_to(payload_len).freeze();
-
-        Ok(Some(TcpRequestMessage {
-            endpoint_path,
-            headers,
-            payload,
-        }))
-    }
-}
-
-impl Encoder<TcpRequestMessage> for TcpRequestCodec {
-    type Error = std::io::Error;
-
-    fn encode(&mut self, item: TcpRequestMessage, dst: &mut BytesMut) -> Result<(), Self::Error> {
-        let endpoint_bytes = item.endpoint_path.as_bytes();
-        let endpoint_len = endpoint_bytes.len();
-
-        if endpoint_len > u16::MAX as usize {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                format!("Endpoint path too long: {} bytes", endpoint_len),
-            ));
-        }
-
-        // Encode headers as JSON
-        let headers_json = serde_json::to_vec(&item.headers).map_err(|e| {
-            std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                format!("Failed to encode headers: {}", e),
-            )
-        })?;
-        let headers_len = headers_json.len();
-
-        if headers_len > u16::MAX as usize {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                format!("Headers too large: {} bytes", headers_len),
-            ));
-        }
-
-        if item.payload.len() > u32::MAX as usize {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                format!("Payload too large: {} bytes", item.payload.len()),
-            ));
-        }
-
-        let total_len = 2 + endpoint_len + 2 + headers_len + 4 + item.payload.len();
-
-        // Check max message size
-        if let Some(max_size) = self.max_message_size
-            && total_len > max_size
-        {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                format!(
-                    "Request too large: {} bytes (max: {} bytes)",
-                    total_len, max_size
-                ),
-            ));
-        }
-
-        // Reserve space
-        dst.reserve(total_len);
-
-        // Write endpoint path length
-        dst.put_u16(endpoint_len as u16);
-
-        // Write endpoint path
-        dst.put_slice(endpoint_bytes);
-
-        // Write headers length
-        dst.put_u16(headers_len as u16);
-
-        // Write headers
-        dst.put_slice(&headers_json);
-
-        // Write payload length
-        dst.put_u32(item.payload.len() as u32);
-
-        // Write payload
-        dst.put_slice(&item.payload);
-
-        Ok(())
     }
 }
 
@@ -617,6 +538,50 @@ mod tests {
     }
 
     #[test]
+    fn test_tcp_request_decode_invalid_endpoint_utf8() {
+        let mut encoded = BytesMut::new();
+        encoded.put_u16(2);
+        encoded.put_slice(&[0xff, 0xff]);
+        encoded.put_u16(2);
+        encoded.put_slice(b"{}");
+        encoded.put_u32(0);
+
+        let result = TcpRequestMessage::decode(&encoded.freeze());
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("Invalid UTF-8"));
+    }
+
+    #[test]
+    fn test_tcp_request_decode_invalid_headers_json() {
+        let mut encoded = BytesMut::new();
+        encoded.put_u16(4);
+        encoded.put_slice(b"test");
+        encoded.put_u16(1);
+        encoded.put_slice(b"{");
+        encoded.put_u32(0);
+
+        let result = TcpRequestMessage::decode(&encoded.freeze());
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("Invalid JSON"));
+    }
+
+    #[test]
+    fn test_tcp_request_empty_endpoint_path() {
+        let msg = TcpRequestMessage::new(String::new(), Bytes::from_static(b"payload"));
+
+        let encoded = msg.encode().unwrap();
+        let decoded = TcpRequestMessage::decode(&encoded).unwrap();
+
+        assert_eq!(decoded, msg);
+    }
+
+    #[test]
     fn test_tcp_response_encode_decode() {
         let msg = TcpResponseMessage::new(Bytes::from(vec![1, 2, 3, 4, 5]));
 
@@ -657,61 +622,6 @@ mod tests {
         let decoded = TcpRequestMessage::decode(&encoded).unwrap();
 
         assert_eq!(decoded, msg);
-    }
-
-    #[test]
-    fn test_tcp_request_codec() {
-        use tokio_util::codec::{Decoder, Encoder};
-
-        let msg = TcpRequestMessage::new(
-            "test.endpoint".to_string(),
-            Bytes::from(vec![1, 2, 3, 4, 5]),
-        );
-
-        let mut codec = TcpRequestCodec::new(None);
-        let mut buf = BytesMut::new();
-
-        // Encode
-        codec.encode(msg.clone(), &mut buf).unwrap();
-
-        // Decode
-        let decoded = codec.decode(&mut buf).unwrap().unwrap();
-        assert_eq!(decoded, msg);
-    }
-
-    #[test]
-    fn test_tcp_request_codec_partial() {
-        use tokio_util::codec::Decoder;
-
-        let msg = TcpRequestMessage::new(
-            "test.endpoint".to_string(),
-            Bytes::from(vec![1, 2, 3, 4, 5]),
-        );
-
-        let encoded = msg.encode().unwrap();
-        let mut codec = TcpRequestCodec::new(None);
-
-        // Feed partial data
-        let mut buf = BytesMut::from(&encoded[..5]);
-        assert!(codec.decode(&mut buf).unwrap().is_none());
-
-        // Feed rest of data
-        buf.extend_from_slice(&encoded[5..]);
-        let decoded = codec.decode(&mut buf).unwrap().unwrap();
-        assert_eq!(decoded, msg);
-    }
-
-    #[test]
-    fn test_tcp_request_codec_max_size() {
-        use tokio_util::codec::Encoder;
-
-        let msg = TcpRequestMessage::new("test".to_string(), Bytes::from(vec![1, 2, 3, 4, 5]));
-
-        let mut codec = TcpRequestCodec::new(Some(10)); // Too small
-        let mut buf = BytesMut::new();
-
-        let result = codec.encode(msg, &mut buf);
-        assert!(result.is_err());
     }
 
     #[test]
@@ -761,83 +671,5 @@ mod tests {
 
         let result = codec.encode(msg, &mut buf);
         assert!(result.is_err());
-    }
-
-    /// Demonstrates how framed codec enables testability without actual TCP connections
-    #[tokio::test]
-    async fn test_framed_codec_integration() {
-        use futures::{SinkExt, StreamExt};
-        use std::io::Cursor;
-        use tokio_util::codec::{FramedRead, FramedWrite};
-
-        // Simulate a duplex connection using in-memory buffer
-        let mut buffer = Vec::new();
-
-        // Writer side: encode requests
-        {
-            let cursor = Cursor::new(&mut buffer);
-            let mut writer = FramedWrite::new(cursor, TcpRequestCodec::new(None));
-
-            let msg1 = TcpRequestMessage::new("endpoint1".to_string(), Bytes::from("data1"));
-            let msg2 = TcpRequestMessage::new("endpoint2".to_string(), Bytes::from("data2"));
-
-            writer.send(msg1).await.unwrap();
-            writer.send(msg2).await.unwrap();
-        }
-
-        // Reader side: decode requests
-        {
-            let cursor = Cursor::new(&buffer[..]);
-            let mut reader = FramedRead::new(cursor, TcpRequestCodec::new(None));
-
-            let decoded1 = reader.next().await.unwrap().unwrap();
-            assert_eq!(decoded1.endpoint_path, "endpoint1");
-            assert_eq!(decoded1.payload, Bytes::from("data1"));
-
-            let decoded2 = reader.next().await.unwrap().unwrap();
-            assert_eq!(decoded2.endpoint_path, "endpoint2");
-            assert_eq!(decoded2.payload, Bytes::from("data2"));
-        }
-    }
-
-    /// Demonstrates testing partial message handling
-    #[tokio::test]
-    async fn test_framed_codec_partial_messages() {
-        use futures::StreamExt;
-        use std::io::Cursor;
-        use tokio_util::codec::FramedRead;
-
-        // Create a message and encode it
-        let msg = TcpRequestMessage::new("test".to_string(), Bytes::from("hello"));
-        let encoded = msg.encode().unwrap();
-
-        // Split the encoded message into chunks
-        let chunk1 = &encoded[..5];
-        let chunk2 = &encoded[5..];
-
-        // Create a buffer that simulates receiving data in chunks
-        let mut full_buffer = Vec::new();
-        full_buffer.extend_from_slice(chunk1);
-
-        // Reader can't decode yet (partial data)
-        {
-            let cursor = Cursor::new(&full_buffer[..]);
-            let _reader = FramedRead::new(cursor, TcpRequestCodec::new(None));
-            // In real async, this would return Ok(None) and wait for more data
-            // For Cursor, it returns None at EOF
-        }
-
-        // Add the rest of the data
-        full_buffer.extend_from_slice(chunk2);
-
-        // Now decoding succeeds
-        {
-            let cursor = Cursor::new(&full_buffer[..]);
-            let mut reader = FramedRead::new(cursor, TcpRequestCodec::new(None));
-
-            let decoded = reader.next().await.unwrap().unwrap();
-            assert_eq!(decoded.endpoint_path, "test");
-            assert_eq!(decoded.payload, Bytes::from("hello"));
-        }
     }
 }

--- a/lib/runtime/src/pipeline/network/codec/zero_copy_decoder.rs
+++ b/lib/runtime/src/pipeline/network/codec/zero_copy_decoder.rs
@@ -9,8 +9,12 @@
 //! 3. Splitting off exact message sizes (zero-copy via Bytes::split_to)
 //! 4. Returning Arc-counted Bytes that can be cloned cheaply
 
+use super::{
+    check_tcp_request_max_message_size, parse_tcp_request_frame_header, tcp_request_endpoint_len,
+    tcp_request_header_size, tcp_request_headers_len,
+};
 use crate::pipeline::network::get_tcp_max_message_size;
-use bytes::{Buf, Bytes, BytesMut};
+use bytes::{Bytes, BytesMut};
 use std::io;
 use std::sync::OnceLock;
 use tokio::io::{AsyncRead, AsyncReadExt};
@@ -109,12 +113,8 @@ impl ZeroCopyTcpDecoder {
         &mut self,
         reader: &mut R,
     ) -> io::Result<TcpRequestMessageZeroCopy> {
-        // Ensure we have at least enough bytes to start parsing
-        // Wire format: [path_len(2)][path][headers_len(2)][headers][payload_len(4)][payload]
-        const MIN_HEADER_SIZE: usize = 2;
-
         // Fill buffer if needed
-        while self.read_buffer.len() < MIN_HEADER_SIZE {
+        while self.read_buffer.len() < super::TCP_REQUEST_ENDPOINT_LEN_WIDTH {
             let n = reader.read_buf(&mut self.read_buffer).await?;
             if n == 0 {
                 if self.read_buffer.is_empty() {
@@ -132,18 +132,11 @@ impl ZeroCopyTcpDecoder {
         }
 
         // Parse endpoint path length (first 2 bytes) - NO COPY
-        let path_len = u16::from_be_bytes([self.read_buffer[0], self.read_buffer[1]]) as usize;
-
-        // Sanity check path length
-        if path_len == 0 || path_len > 1024 {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("invalid endpoint path length: {}", path_len),
-            ));
-        }
+        let path_len = tcp_request_endpoint_len(&self.read_buffer)?;
 
         // Ensure we have path + headers_len
-        let initial_header_size = 2 + path_len + 2; // path_len(2) + path + headers_len(2)
+        let initial_header_size =
+            super::TCP_REQUEST_ENDPOINT_LEN_WIDTH + path_len + super::TCP_REQUEST_HEADERS_LEN_WIDTH;
         while self.read_buffer.len() < initial_header_size {
             let n = reader.read_buf(&mut self.read_buffer).await?;
             if n == 0 {
@@ -155,14 +148,10 @@ impl ZeroCopyTcpDecoder {
         }
 
         // Parse headers length (2 bytes after path) - NO COPY
-        let headers_len_offset = 2 + path_len;
-        let headers_len = u16::from_be_bytes([
-            self.read_buffer[headers_len_offset],
-            self.read_buffer[headers_len_offset + 1],
-        ]) as usize;
+        let headers_len = tcp_request_headers_len(&self.read_buffer, path_len)?;
 
         // Ensure we have headers + payload length
-        let full_header_size = 2 + path_len + 2 + headers_len + 4; // path_len(2) + path + headers_len(2) + headers + payload_len(4)
+        let full_header_size = tcp_request_header_size(path_len, headers_len);
         while self.read_buffer.len() < full_header_size {
             let n = reader.read_buf(&mut self.read_buffer).await?;
             if n == 0 {
@@ -173,38 +162,20 @@ impl ZeroCopyTcpDecoder {
             }
         }
 
-        // Parse payload length (4 bytes after headers) - NO COPY
-        let payload_len_offset = 2 + path_len + 2 + headers_len;
-        let payload_len = u32::from_be_bytes([
-            self.read_buffer[payload_len_offset],
-            self.read_buffer[payload_len_offset + 1],
-            self.read_buffer[payload_len_offset + 2],
-            self.read_buffer[payload_len_offset + 3],
-        ]) as usize;
-
-        // Calculate total message size
-        let total_len = 2 + path_len + 2 + headers_len + 4 + payload_len;
+        let parsed = parse_tcp_request_frame_header(&self.read_buffer)?;
 
         // Sanity check total message length (including all overhead)
-        if total_len > self.max_message_size {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!(
-                    "message too large: {} bytes (max: {} bytes)",
-                    total_len, self.max_message_size
-                ),
-            ));
-        }
+        check_tcp_request_max_message_size(parsed.total_len, self.max_message_size)?;
 
         // Ensure entire message is buffered
-        while self.read_buffer.len() < total_len {
+        while self.read_buffer.len() < parsed.total_len {
             let n = reader.read_buf(&mut self.read_buffer).await?;
             if n == 0 {
                 return Err(io::Error::new(
                     io::ErrorKind::UnexpectedEof,
                     format!(
                         "incomplete message: expected {} bytes, got {}",
-                        total_len,
+                        parsed.total_len,
                         self.read_buffer.len()
                     ),
                 ));
@@ -213,7 +184,7 @@ impl ZeroCopyTcpDecoder {
 
         // Split off exactly what we need - ZERO COPY!
         // split_to() just advances the internal pointer, doesn't allocate or copy
-        let message_bytes = self.read_buffer.split_to(total_len).freeze();
+        let message_bytes = self.read_buffer.split_to(parsed.total_len).freeze();
 
         // Shrink buffer if it grew too large and is now empty, could be optimized with lock-free buffer pool in the future.
         if self.read_buffer.is_empty() && self.read_buffer.capacity() > self.shrink_threshold {
@@ -221,7 +192,7 @@ impl ZeroCopyTcpDecoder {
         }
 
         // Return zero-copy message wrapper
-        Ok(TcpRequestMessageZeroCopy::new(message_bytes))
+        Ok(TcpRequestMessageZeroCopy::new(message_bytes, parsed))
     }
 
     /// Get the current buffer capacity
@@ -250,48 +221,30 @@ pub struct TcpRequestMessageZeroCopy {
     /// Entire message as Arc-counted buffer
     /// Format: [path_len(2)][path(var)][headers_len(2)][headers(var)][payload_len(4)][payload(var)]
     raw: Bytes,
+    parsed: super::TcpRequestWireHeader,
 }
 
 impl TcpRequestMessageZeroCopy {
     /// Create a new zero-copy message from raw bytes
-    fn new(raw: Bytes) -> Self {
-        Self { raw }
-    }
-
-    /// Get the endpoint path length
-    #[inline]
-    fn path_len(&self) -> usize {
-        u16::from_be_bytes([self.raw[0], self.raw[1]]) as usize
+    fn new(raw: Bytes, parsed: super::TcpRequestWireHeader) -> Self {
+        Self { raw, parsed }
     }
 
     /// Get endpoint path as a string slice (zero-copy)
     ///
     /// This returns a reference into the message buffer, no allocation.
     pub fn endpoint_path(&self) -> Result<&str, std::str::Utf8Error> {
-        let path_len = self.path_len();
-        std::str::from_utf8(&self.raw[2..2 + path_len])
+        std::str::from_utf8(&self.raw[self.parsed.endpoint_start()..self.parsed.endpoint_end()])
     }
 
     /// Get endpoint path as bytes (zero-copy)
     pub fn endpoint_path_bytes(&self) -> &[u8] {
-        let path_len = self.path_len();
-        &self.raw[2..2 + path_len]
-    }
-
-    /// Get the headers length
-    #[inline]
-    fn headers_len(&self) -> usize {
-        let path_len = self.path_len();
-        let offset = 2 + path_len;
-        u16::from_be_bytes([self.raw[offset], self.raw[offset + 1]]) as usize
+        &self.raw[self.parsed.endpoint_start()..self.parsed.endpoint_end()]
     }
 
     /// Get headers as bytes (zero-copy)
     pub fn headers_bytes(&self) -> &[u8] {
-        let path_len = self.path_len();
-        let headers_len = self.headers_len();
-        let headers_start = 2 + path_len + 2;
-        &self.raw[headers_start..headers_start + headers_len]
+        &self.raw[self.parsed.headers_start()..self.parsed.headers_end()]
     }
 
     /// Get headers as a HashMap (requires parsing)
@@ -308,15 +261,7 @@ impl TcpRequestMessageZeroCopy {
     /// Get the payload length
     #[inline]
     fn payload_len(&self) -> usize {
-        let path_len = self.path_len();
-        let headers_len = self.headers_len();
-        let offset = 2 + path_len + 2 + headers_len;
-        u32::from_be_bytes([
-            self.raw[offset],
-            self.raw[offset + 1],
-            self.raw[offset + 2],
-            self.raw[offset + 3],
-        ]) as usize
+        self.parsed.payload_len
     }
 
     /// Get payload as zero-copy Bytes
@@ -324,10 +269,7 @@ impl TcpRequestMessageZeroCopy {
     /// This returns an Arc-counted slice of the message buffer.
     /// Cloning the returned Bytes is extremely cheap (just Arc clone).
     pub fn payload(&self) -> Bytes {
-        let path_len = self.path_len();
-        let headers_len = self.headers_len();
-        let payload_start = 2 + path_len + 2 + headers_len + 4;
-        self.raw.slice(payload_start..) // ZERO COPY! Just Arc clone + offset
+        self.raw.slice(self.parsed.payload_start()..) // ZERO COPY! Just Arc clone + offset
     }
 
     /// Get total message size in bytes
@@ -444,6 +386,27 @@ mod tests {
         assert_eq!(msg.payload().as_ref(), payload);
         assert_eq!(msg.total_size(), message.len());
         assert_eq!(msg.headers().len(), 0); // Empty headers
+    }
+
+    #[tokio::test]
+    async fn test_zero_copy_decoder_allows_empty_and_long_endpoint_paths() {
+        for endpoint in [String::new(), "x".repeat(2048)] {
+            let payload = b"payload";
+
+            let mut message = Vec::new();
+            message.extend_from_slice(&(endpoint.len() as u16).to_be_bytes());
+            message.extend_from_slice(endpoint.as_bytes());
+            message.extend_from_slice(&(0u16).to_be_bytes());
+            message.extend_from_slice(&(payload.len() as u32).to_be_bytes());
+            message.extend_from_slice(payload);
+
+            let mut reader = &message[..];
+            let mut decoder = ZeroCopyTcpDecoder::new();
+            let msg = decoder.read_message(&mut reader).await.unwrap();
+
+            assert_eq!(msg.endpoint_path().unwrap(), endpoint.as_str());
+            assert_eq!(msg.payload().as_ref(), payload);
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
Remove the unused framed request codec and route both the owned and zero-copy TCP request paths through shared wire-format length parsing. This keeps request encoding behavior unchanged while making ingress size validation consistent.

The full agent plan is on the attached issue.

Closes #9217

Assisted-By: Codex 5.5 high

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9220" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of network request data (endpoint paths and JSON headers) to catch invalid inputs.
  * Enhanced handling of edge cases in network communication.

* **Performance**
  * Optimized buffer allocation and payload handling for network requests.
  * Introduced dynamic buffer tuning for improved memory efficiency.

* **Tests**
  * Expanded test coverage for network codec validation and edge case scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->