### PR TITLE
refactor(llm): consolidate simple OpenAI DeltaAggregators

### DIFF
--- a/lib/llm/src/protocols/openai.rs
+++ b/lib/llm/src/protocols/openai.rs
@@ -20,6 +20,7 @@ pub mod images;
 pub mod models;
 pub mod nvext;
 pub mod responses;
+pub mod stream_aggregator;
 pub mod tools;
 pub mod validate;
 pub mod videos;

--- a/lib/llm/src/protocols/openai/audios.rs
+++ b/lib/llm/src/protocols/openai/audios.rs
@@ -8,7 +8,6 @@ use validator::Validate;
 mod aggregator;
 mod nvext;
 
-pub use aggregator::DeltaAggregator;
 pub use nvext::{NvExt, NvExtProvider};
 
 /// Request for audio speech generation (/v1/audio/speech endpoint).

--- a/lib/llm/src/protocols/openai/audios/aggregator.rs
+++ b/lib/llm/src/protocols/openai/audios/aggregator.rs
@@ -1,70 +1,20 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use futures::{Stream, StreamExt};
+use futures::Stream;
 
+use crate::protocols::openai::stream_aggregator::{StreamAggregable, aggregate_stream};
 use crate::types::Annotated;
 
 use super::NvAudioSpeechResponse;
 
-/// Aggregator for combining audio response deltas into a final response.
-#[derive(Debug)]
-pub struct DeltaAggregator {
-    response: Option<NvAudioSpeechResponse>,
-    error: Option<String>,
-}
-
-impl Default for DeltaAggregator {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl DeltaAggregator {
-    pub fn new() -> Self {
-        DeltaAggregator {
-            response: None,
-            error: None,
-        }
+impl StreamAggregable for NvAudioSpeechResponse {
+    fn empty() -> Self {
+        Self::empty()
     }
 
-    /// Aggregates a stream of annotated audio responses into a final response.
-    pub async fn apply(
-        stream: impl Stream<Item = Annotated<NvAudioSpeechResponse>>,
-    ) -> Result<NvAudioSpeechResponse, String> {
-        let aggregator = stream
-            .fold(DeltaAggregator::new(), |mut aggregator, delta| async move {
-                let delta = match delta.ok() {
-                    Ok(delta) => delta,
-                    Err(error) => {
-                        aggregator.error = Some(error);
-                        return aggregator;
-                    }
-                };
-
-                if aggregator.error.is_none()
-                    && let Some(response) = delta.data
-                {
-                    match &mut aggregator.response {
-                        Some(existing) => {
-                            existing.data.extend(response.data);
-                        }
-                        None => {
-                            aggregator.response = Some(response);
-                        }
-                    }
-                }
-                aggregator
-            })
-            .await;
-
-        if let Some(error) = aggregator.error {
-            return Err(error);
-        }
-
-        Ok(aggregator
-            .response
-            .unwrap_or_else(NvAudioSpeechResponse::empty))
+    fn merge(&mut self, next: Self) {
+        self.data.extend(next.data);
     }
 }
 
@@ -73,6 +23,6 @@ impl NvAudioSpeechResponse {
     pub async fn from_annotated_stream(
         stream: impl Stream<Item = Annotated<NvAudioSpeechResponse>>,
     ) -> Result<NvAudioSpeechResponse, String> {
-        DeltaAggregator::apply(stream).await
+        aggregate_stream(stream).await
     }
 }

--- a/lib/llm/src/protocols/openai/embeddings.rs
+++ b/lib/llm/src/protocols/openai/embeddings.rs
@@ -9,7 +9,6 @@ use validator::Validate;
 mod aggregator;
 mod nvext;
 
-pub use aggregator::DeltaAggregator;
 pub use nvext::{NvExt, NvExtProvider};
 
 #[derive(ToSchema, Serialize, Deserialize, Validate, Debug, Clone)]

--- a/lib/llm/src/protocols/openai/embeddings/aggregator.rs
+++ b/lib/llm/src/protocols/openai/embeddings/aggregator.rs
@@ -6,105 +6,26 @@ use crate::protocols::{
     Annotated,
     codec::{Message, SseCodecError},
     convert_sse_stream,
+    openai::stream_aggregator::{StreamAggregable, aggregate_stream},
 };
 
 use dynamo_runtime::engine::DataStream;
-use futures::{Stream, StreamExt};
+use futures::Stream;
 
-/// Aggregates a stream of [`NvCreateEmbeddingResponse`]s into a single
-/// [`NvCreateEmbeddingResponse`]. For embeddings, this is typically simpler
-/// than text generation as embeddings are usually returned as a complete response.
-pub struct DeltaAggregator {
-    /// The accumulated embeddings response.
-    response: Option<NvCreateEmbeddingResponse>,
-    /// Optional error message if an error occurs during aggregation.
-    error: Option<String>,
-}
-
-impl Default for DeltaAggregator {
-    /// Provides a default implementation for `DeltaAggregator` by calling [`DeltaAggregator::new`].
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl DeltaAggregator {
-    /// Creates a new, empty [`DeltaAggregator`] instance.
-    pub fn new() -> Self {
-        Self {
-            response: None,
-            error: None,
-        }
+impl StreamAggregable for NvCreateEmbeddingResponse {
+    fn empty() -> Self {
+        Self::empty()
     }
 
-    /// Aggregates a stream of [`NvCreateEmbeddingResponse`]s into a single
-    /// [`NvCreateEmbeddingResponse`].
-    ///
-    /// # Arguments
-    /// * `stream` - A stream of annotated embedding responses.
-    ///
-    /// # Returns
-    /// * `Ok(NvCreateEmbeddingResponse)` if aggregation is successful.
-    /// * `Err(String)` if an error occurs during processing.
-    pub async fn apply(
-        stream: impl Stream<Item = Annotated<NvCreateEmbeddingResponse>>,
-    ) -> Result<NvCreateEmbeddingResponse, String> {
-        let aggregator = stream
-            .fold(DeltaAggregator::new(), |mut aggregator, delta| async move {
-                // Attempt to unwrap the delta, capturing any errors.
-                let delta = match delta.ok() {
-                    Ok(delta) => delta,
-                    Err(error) => {
-                        aggregator.error = Some(error);
-                        return aggregator;
-                    }
-                };
-
-                if aggregator.error.is_none()
-                    && let Some(response) = delta.data
-                {
-                    // For embeddings, we typically expect a single complete response
-                    // or we accumulate data from multiple responses
-                    match &mut aggregator.response {
-                        Some(existing) => {
-                            // Merge embedding data if we have multiple responses
-                            existing.inner.data.extend(response.inner.data);
-
-                            // Update usage statistics
-                            existing.inner.usage.prompt_tokens +=
-                                response.inner.usage.prompt_tokens;
-                            existing.inner.usage.total_tokens += response.inner.usage.total_tokens;
-                        }
-                        None => {
-                            aggregator.response = Some(response);
-                        }
-                    }
-                }
-                aggregator
-            })
-            .await;
-
-        // Return early if an error was encountered.
-        if let Some(error) = aggregator.error {
-            return Err(error);
-        }
-
-        // Return the aggregated response or an empty response if none was found.
-        Ok(aggregator
-            .response
-            .unwrap_or_else(NvCreateEmbeddingResponse::empty))
+    fn merge(&mut self, next: Self) {
+        self.inner.data.extend(next.inner.data);
+        self.inner.usage.prompt_tokens += next.inner.usage.prompt_tokens;
+        self.inner.usage.total_tokens += next.inner.usage.total_tokens;
     }
 }
 
 impl NvCreateEmbeddingResponse {
     /// Converts an SSE stream into a [`NvCreateEmbeddingResponse`].
-    ///
-    /// # Arguments
-    /// * `stream` - A stream of SSE messages containing embedding responses.
-    ///
-    /// # Returns
-    /// * `Ok(NvCreateEmbeddingResponse)` if aggregation succeeds.
-    /// * `Err(String)` if an error occurs.
     pub async fn from_sse_stream(
         stream: DataStream<Result<Message, SseCodecError>>,
     ) -> Result<NvCreateEmbeddingResponse, String> {
@@ -113,17 +34,10 @@ impl NvCreateEmbeddingResponse {
     }
 
     /// Aggregates an annotated stream of embedding responses into a final response.
-    ///
-    /// # Arguments
-    /// * `stream` - A stream of annotated embedding responses.
-    ///
-    /// # Returns
-    /// * `Ok(NvCreateEmbeddingResponse)` if aggregation succeeds.
-    /// * `Err(String)` if an error occurs.
     pub async fn from_annotated_stream(
         stream: impl Stream<Item = Annotated<NvCreateEmbeddingResponse>>,
     ) -> Result<NvCreateEmbeddingResponse, String> {
-        DeltaAggregator::apply(stream).await
+        aggregate_stream(stream).await
     }
 }
 
@@ -155,7 +69,7 @@ mod tests {
     #[tokio::test]
     async fn test_empty_stream() {
         let stream = stream::empty();
-        let result = DeltaAggregator::apply(Box::pin(stream)).await;
+        let result = NvCreateEmbeddingResponse::from_annotated_stream(Box::pin(stream)).await;
 
         assert!(result.is_ok());
         let response = result.unwrap();
@@ -175,7 +89,7 @@ mod tests {
         let annotated = create_test_embedding_response(vec![embedding.clone()], 10, 10);
         let stream = stream::iter(vec![annotated]);
 
-        let result = DeltaAggregator::apply(Box::pin(stream)).await;
+        let result = NvCreateEmbeddingResponse::from_annotated_stream(Box::pin(stream)).await;
 
         assert!(result.is_ok());
         let response = result.unwrap();
@@ -204,15 +118,15 @@ mod tests {
         let annotated2 = create_test_embedding_response(vec![embedding2.clone()], 7, 7);
         let stream = stream::iter(vec![annotated1, annotated2]);
 
-        let result = DeltaAggregator::apply(Box::pin(stream)).await;
+        let result = NvCreateEmbeddingResponse::from_annotated_stream(Box::pin(stream)).await;
 
         assert!(result.is_ok());
         let response = result.unwrap();
         assert_eq!(response.inner.data.len(), 2);
         assert_eq!(response.inner.data[0].index, 0);
         assert_eq!(response.inner.data[1].index, 1);
-        assert_eq!(response.inner.usage.prompt_tokens, 12); // sum of 5 and 7
-        assert_eq!(response.inner.usage.total_tokens, 12); // sum of 5 and 7
+        assert_eq!(response.inner.usage.prompt_tokens, 12);
+        assert_eq!(response.inner.usage.total_tokens, 12);
     }
 
     #[tokio::test]
@@ -221,7 +135,7 @@ mod tests {
             Annotated::<NvCreateEmbeddingResponse>::from_error("Test error".to_string());
         let stream = stream::iter(vec![error_annotated]);
 
-        let result = DeltaAggregator::apply(Box::pin(stream)).await;
+        let result = NvCreateEmbeddingResponse::from_annotated_stream(Box::pin(stream)).await;
 
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("Test error"));

--- a/lib/llm/src/protocols/openai/images.rs
+++ b/lib/llm/src/protocols/openai/images.rs
@@ -8,7 +8,6 @@ use validator::Validate;
 mod aggregator;
 mod nvext;
 
-pub use aggregator::DeltaAggregator;
 pub use nvext::{NvExt, NvExtProvider};
 
 /// Image generation request with NVIDIA extensions.

--- a/lib/llm/src/protocols/openai/images/aggregator.rs
+++ b/lib/llm/src/protocols/openai/images/aggregator.rs
@@ -1,90 +1,28 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use futures::{Stream, StreamExt};
+use futures::Stream;
 
+use crate::protocols::openai::stream_aggregator::{StreamAggregable, aggregate_stream};
 use crate::types::Annotated;
 
 use super::NvImagesResponse;
 
-/// Aggregator for combining image response deltas into a final response.
-#[derive(Debug)]
-pub struct DeltaAggregator {
-    response: Option<NvImagesResponse>,
-    error: Option<String>,
-}
-
-impl Default for DeltaAggregator {
-    /// Provides a default implementation for `DeltaAggregator` by calling [`DeltaAggregator::new`].
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl DeltaAggregator {
-    pub fn new() -> Self {
-        DeltaAggregator {
-            response: None,
-            error: None,
-        }
+impl StreamAggregable for NvImagesResponse {
+    fn empty() -> Self {
+        Self::empty()
     }
 
-    /// Aggregates a stream of annotated image responses into a final response.
-    pub async fn apply(
-        stream: impl Stream<Item = Annotated<NvImagesResponse>>,
-    ) -> Result<NvImagesResponse, String> {
-        let aggregator = stream
-            .fold(DeltaAggregator::new(), |mut aggregator, delta| async move {
-                // Attempt to unwrap the delta, capturing any errors.
-                let delta = match delta.ok() {
-                    Ok(delta) => delta,
-                    Err(error) => {
-                        aggregator.error = Some(error);
-                        return aggregator;
-                    }
-                };
-
-                if aggregator.error.is_none()
-                    && let Some(response) = delta.data
-                {
-                    // For images, we typically expect a single complete response
-                    // or we accumulate data from multiple responses
-                    match &mut aggregator.response {
-                        Some(existing) => {
-                            // Merge image data if we have multiple responses
-                            existing.inner.data.extend(response.inner.data);
-                        }
-                        None => {
-                            aggregator.response = Some(response);
-                        }
-                    }
-                }
-                aggregator
-            })
-            .await;
-
-        // Return early if an error was encountered.
-        if let Some(error) = aggregator.error {
-            return Err(error);
-        }
-
-        // Return the aggregated response or an empty response if none was found.
-        Ok(aggregator.response.unwrap_or_else(NvImagesResponse::empty))
+    fn merge(&mut self, next: Self) {
+        self.inner.data.extend(next.inner.data);
     }
 }
 
 impl NvImagesResponse {
     /// Aggregates an annotated stream of image responses into a final response.
-    ///
-    /// # Arguments
-    /// * `stream` - A stream of annotated image responses.
-    ///
-    /// # Returns
-    /// * `Ok(NvImagesResponse)` if aggregation succeeds.
-    /// * `Err(String)` if an error occurs.
     pub async fn from_annotated_stream(
         stream: impl Stream<Item = Annotated<NvImagesResponse>>,
     ) -> Result<NvImagesResponse, String> {
-        DeltaAggregator::apply(stream).await
+        aggregate_stream(stream).await
     }
 }

--- a/lib/llm/src/protocols/openai/stream_aggregator.rs
+++ b/lib/llm/src/protocols/openai/stream_aggregator.rs
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use futures::{Stream, StreamExt};
+
+use crate::types::Annotated;
+
+/// Response types whose `Annotated<T>` streams can be folded into a single `T`
+/// using shared aggregation infrastructure.
+pub trait StreamAggregable: Sized {
+    /// Empty fallback when the stream yields no data items.
+    fn empty() -> Self;
+    /// Merge `next` into `self`. Implementors define type-specific
+    /// behavior (extending data, summing usage, etc.).
+    fn merge(&mut self, next: Self);
+}
+
+/// Aggregate a stream of [`Annotated<T>`] into a single `T`. The first error
+/// encountered short-circuits further merging and is returned; the remainder
+/// of the stream is dropped.
+pub async fn aggregate_stream<T, S>(stream: S) -> Result<T, String>
+where
+    T: StreamAggregable,
+    S: Stream<Item = Annotated<T>>,
+{
+    let mut stream = std::pin::pin!(stream);
+    let mut response: Option<T> = None;
+
+    while let Some(delta) = stream.next().await {
+        let delta = delta.ok()?;
+        if let Some(data) = delta.data {
+            match response.as_mut() {
+                Some(existing) => existing.merge(data),
+                None => response = Some(data),
+            }
+        }
+    }
+
+    Ok(response.unwrap_or_else(T::empty))
+}

--- a/lib/llm/src/protocols/openai/videos.rs
+++ b/lib/llm/src/protocols/openai/videos.rs
@@ -8,7 +8,6 @@ use validator::Validate;
 mod aggregator;
 mod nvext;
 
-pub use aggregator::DeltaAggregator;
 pub use nvext::{NvExt, NvExtProvider};
 
 /// Request for video generation (/v1/videos endpoint)

--- a/lib/llm/src/protocols/openai/videos/aggregator.rs
+++ b/lib/llm/src/protocols/openai/videos/aggregator.rs
@@ -1,90 +1,28 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use futures::{Stream, StreamExt};
+use futures::Stream;
 
+use crate::protocols::openai::stream_aggregator::{StreamAggregable, aggregate_stream};
 use crate::types::Annotated;
 
 use super::NvVideosResponse;
 
-/// Aggregator for combining video response deltas into a final response.
-#[derive(Debug)]
-pub struct DeltaAggregator {
-    response: Option<NvVideosResponse>,
-    error: Option<String>,
-}
-
-impl Default for DeltaAggregator {
-    /// Provides a default implementation for `DeltaAggregator` by calling [`DeltaAggregator::new`].
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl DeltaAggregator {
-    pub fn new() -> Self {
-        DeltaAggregator {
-            response: None,
-            error: None,
-        }
+impl StreamAggregable for NvVideosResponse {
+    fn empty() -> Self {
+        Self::empty()
     }
 
-    /// Aggregates a stream of annotated video responses into a final response.
-    pub async fn apply(
-        stream: impl Stream<Item = Annotated<NvVideosResponse>>,
-    ) -> Result<NvVideosResponse, String> {
-        let aggregator = stream
-            .fold(DeltaAggregator::new(), |mut aggregator, delta| async move {
-                // Attempt to unwrap the delta, capturing any errors.
-                let delta = match delta.ok() {
-                    Ok(delta) => delta,
-                    Err(error) => {
-                        aggregator.error = Some(error);
-                        return aggregator;
-                    }
-                };
-
-                if aggregator.error.is_none()
-                    && let Some(response) = delta.data
-                {
-                    // For videos, we typically expect a single complete response
-                    // or we accumulate data from multiple responses
-                    match &mut aggregator.response {
-                        Some(existing) => {
-                            // Merge video data if we have multiple responses
-                            existing.data.extend(response.data);
-                        }
-                        None => {
-                            aggregator.response = Some(response);
-                        }
-                    }
-                }
-                aggregator
-            })
-            .await;
-
-        // Return early if an error was encountered.
-        if let Some(error) = aggregator.error {
-            return Err(error);
-        }
-
-        // Return the aggregated response or an empty response if none was found.
-        Ok(aggregator.response.unwrap_or_else(NvVideosResponse::empty))
+    fn merge(&mut self, next: Self) {
+        self.data.extend(next.data);
     }
 }
 
 impl NvVideosResponse {
     /// Aggregates an annotated stream of video responses into a final response.
-    ///
-    /// # Arguments
-    /// * `stream` - A stream of annotated video responses.
-    ///
-    /// # Returns
-    /// * `Ok(NvVideosResponse)` if aggregation succeeds.
-    /// * `Err(String)` if an error occurs.
     pub async fn from_annotated_stream(
         stream: impl Stream<Item = Annotated<NvVideosResponse>>,
     ) -> Result<NvVideosResponse, String> {
-        DeltaAggregator::apply(stream).await
+        aggregate_stream(stream).await
     }
 }


### PR DESCRIPTION
Replace the four near-identical DeltaAggregator structs in audios, images, videos, and embeddings with a shared StreamAggregable trait and aggregate_stream<T> helper in protocols/openai/stream_aggregator.rs.

Each response type now provides only its per-type merge logic (~10 lines) instead of duplicating ~80 lines of fold/error plumbing.

aggregate_stream uses a while-let loop with early return on error, so a failing stream is dropped immediately rather than drained.

chat_completions and completions aggregators are out of scope — they take parsing_options and have richer merge semantics.

Detailed agent plan is in the linked issue.

Closes: #9222

Assisted-By: Claude Opus 4.7
Verified-By: Gemini 3.1 Pro

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9223" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated streaming data aggregation patterns across multiple service response types by implementing a single centralized, trait-based architecture. Removed duplicate aggregation logic previously scattered across modules, improving code maintainability, consistency, and reducing technical debt throughout the library. These internal structural improvements do not affect any external APIs, integrations, or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->