### PR TITLE
docs: add TokenSpeed day 0 launch note

### DIFF
--- a/docs/digest/index.mdx
+++ b/docs/digest/index.mdx
@@ -7,6 +7,14 @@ Technical deep dives, announcements, and updates from the Dynamo team.
 
 <CardGroup cols={2}>
   <Card
+    title="Dynamo Day 0 support for TokenSpeed"
+    icon="regular newspaper"
+    href="/dynamo/dev/digest/tokenspeed-day-0"
+  >
+    A short note on TokenSpeed's launch, its kernel and scheduler work, and
+    Dynamo's day-0 integration.
+  </Card>
+  <Card
     title="Streaming Tokens and Tools: Multi-Turn Agentic Harness Support in Dynamo"
     icon="regular code-branch"
     href="/dynamo/dev/digest/agentic-harnesses"

--- a/docs/digest/tokenspeed-day-0.md
+++ b/docs/digest/tokenspeed-day-0.md
@@ -14,4 +14,6 @@ Two pieces are worth calling out. First, TokenSpeed includes new MLA kernel work
 
 Dynamo now has day-0 support for running TokenSpeed as a Dynamo backend through `python -m dynamo.tokenspeed`. The Dynamo frontend remains the user-facing OpenAI-compatible API entrypoint and handles request routing, streaming responses, and cancellation.
 
+See the [Kimi K2.5 TokenSpeed recipe](https://github.com/ai-dynamo/dynamo/tree/main/recipes/kimi-k2.5/tokenspeed/agg/nvidia) for the current Dynamo launch recipe.
+
 Things are moving quickly. Upstream TokenSpeed calls out ongoing work on model coverage, P/D, EPLB, KV store, Mamba cache, VLM, metrics, Hopper optimization, and related runtime features.

--- a/docs/digest/tokenspeed-day-0.md
+++ b/docs/digest/tokenspeed-day-0.md
@@ -1,0 +1,17 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: "Dynamo Day 0 support for TokenSpeed"
+subtitle: "A short launch note for running TokenSpeed with Dynamo"
+description: "Dynamo adds day-0 TokenSpeed support with the Dynamo frontend for Kimi K2.5."
+keywords: TokenSpeed, Dynamo, LightSeek, Kimi K2.5, disaggregated serving, KV cache routing, LLM inference
+last-updated: May 6, 2026
+---
+
+[TokenSpeed](https://lightseek.org/blog/lightseek-tokenspeed.html) ([GitHub](https://github.com/lightseekorg/tokenspeed)) launched today as LightSeek's new inference engine for agentic workloads. The initial repo is a preview, with more model coverage and runtime features landing over the next few weeks.
+
+Two pieces are worth calling out. First, TokenSpeed includes new MLA kernel work for long-context Kimi-style workloads on Blackwell. Second, TokenSpeed has a native C++ scheduler in `tokenspeed-scheduler/` that models request flow and cache operations as explicit state machines, while Python remains the runtime and integration layer.
+
+Dynamo now has day-0 support for running TokenSpeed as a Dynamo backend through `python -m dynamo.tokenspeed`. The Dynamo frontend remains the user-facing OpenAI-compatible API entrypoint and handles request routing, streaming responses, and cancellation.
+
+Things are moving quickly. Upstream TokenSpeed calls out ongoing work on model coverage, P/D, EPLB, KV store, Mamba cache, VLM, metrics, Hopper optimization, and related runtime features.

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -52,6 +52,9 @@ navigation:
     path: digest/index.mdx
     slug: digest
     contents:
+      - page: "Dynamo Day 0 support for TokenSpeed"
+        path: digest/tokenspeed-day-0.md
+        slug: tokenspeed-day-0
       - page: "Multi-Turn Agentic Harnesses"
         path: digest/agentic-inference/agentic-harnesses.md
         slug: agentic-harnesses

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -127,6 +127,8 @@ navbar-links:
     links:
       - text: All Posts
         href: /dynamo/dev/digest
+      - text: "Dynamo Day 0 support for TokenSpeed"
+        href: /dynamo/dev/digest/tokenspeed-day-0
       - text: "Full-Stack Optimizations for Agentic Inference"
         href: /dynamo/dev/digest/agentic-inference
       - text: "Flash Indexer: Inter-Galactic KV Routing"


### PR DESCRIPTION
## Summary

Adds a short Day 0 launch note for running TokenSpeed with Dynamo.

The post now keeps the launch note concise:
- links to the LightSeek TokenSpeed launch
- calls out the new MLA kernel work and the C++ scheduler / Python runtime split
- states Dynamo day-0 backend support through `python -m dynamo.tokenspeed`
- points readers to the external TokenSpeed launch recipe placeholder
- notes that upstream TokenSpeed work is moving quickly

Also wires the post into the blog landing page, docs sidebar, and Fern navbar.

## Validation

- `git diff --check`
- parsed `docs/index.yml` and `fern/docs.yml` with PyYAML
- pre-commit hooks during commit: `codespell`, YAML check, whitespace, line endings, merge-conflict checks passed

Note: the repo-level `pytest-marker-report` pre-commit hook was skipped for the final commit after failing under Python 3.10 on imports that require newer typing symbols (`Self`, `Required`). This docs-only PR does not touch that code path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added new blog post covering Dynamo Day 0 support for TokenSpeed, including technical features and usage guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->