### PR TITLE
recipes(kimi-k2.5): add TokenSpeed aggregated recipe + local-build Dockerfile

### DIFF
--- a/recipes/kimi-k2.5/README.md
+++ b/recipes/kimi-k2.5/README.md
@@ -1,17 +1,17 @@
 # Kimi-K2.5 Recipes
 
-Deployment recipes for **Kimi-K2.5** using TensorRT-LLM with Dynamo's KV-aware routing.
+Deployment recipes for **Kimi-K2.5** using TensorRT-LLM or TokenSpeed with Dynamo's KV-aware routing.
 
 ## Available Configurations
 
-There are two model weight variants, each with its own model download and deploy manifests:
+| Variant | Model | Engine | Status | Modality | Deploy Configs | Notes |
+|---------|-------|--------|--------|----------|---------------|-------|
+| **baseten** | `baseten-admin/Kimi-2.5-text-nvfp4-v3` | TRT-LLM | Functional | Text only | [`deploy.yaml`](trtllm/agg/baseten/deploy.yaml) | Works with the stock image, not yet performance-optimized |
+| **nvidia** | `nvidia/Kimi-K2.5-NVFP4` | TRT-LLM | Experimental | Text only | [`deploy.yaml`](trtllm/agg/nvidia/deploy.yaml) and [`deploy-specdec.yaml`](trtllm/agg/nvidia/deploy-specdec.yaml) | All configs are compatible with a current top-of-tree Dynamo TRT-LLM image. Vision input is not yet functional |
+| **nvidia** | `nvidia/Kimi-K2.5-NVFP4` | TokenSpeed | Experimental | Text only | [`deploy.yaml`](tokenspeed/agg/nvidia/deploy.yaml) + [`Dockerfile`](tokenspeed/agg/nvidia/Dockerfile) | TP=4 + EP=4 on a single 4×B200 worker. **Requires local image build** (no public `tokenspeed-runtime` image yet) — the Dockerfile layers Dynamo on top of a public TokenSpeed base. See the [recipe README](tokenspeed/agg/nvidia/README.md) |
 
-| Variant | Model | Status | Modality | Deploy Configs | Notes |
-|---------|-------|--------|----------|---------------|-------|
-| **baseten** | `baseten-admin/Kimi-2.5-text-nvfp4-v3` | Functional | Text only | [`deploy.yaml`](trtllm/agg/baseten/deploy.yaml) | Works with the stock image, not yet performance-optimized |
-| **nvidia** | `nvidia/Kimi-K2.5-NVFP4` | Experimental | Text only | [`deploy.yaml`](trtllm/agg/nvidia/deploy.yaml) and [`deploy-specdec.yaml`](trtllm/agg/nvidia/deploy-specdec.yaml) | All configs are compatible with a current top-of-tree Dynamo TRT-LLM image. Vision input is not yet functional |
-
-All configurations use TP8, EP8, aggregated mode with KV-aware routing.
+The TRT-LLM configurations use TP=8 / EP=8; the TokenSpeed configuration uses TP=4 / EP=4. All
+use aggregated serving with KV-aware routing.
 
 ## Prerequisites
 
@@ -23,8 +23,9 @@ All configurations use TP8, EP8, aggregated mode with KV-aware routing.
 
 | Configuration | GPUs |
 |--------------|------|
-| Aggregated | 8x B200 |
-| Aggregated Speculative Decoding | 8x4 GB200 (4 workers, each worker spanning 2 nodes) |
+| Aggregated (TRT-LLM) | 8x B200 |
+| Aggregated (TokenSpeed) | 4x B200 |
+| Aggregated Speculative Decoding (TRT-LLM) | 8x4 GB200 (4 workers, each worker spanning 2 nodes) |
 
 ---
 

--- a/recipes/kimi-k2.5/README.md
+++ b/recipes/kimi-k2.5/README.md
@@ -1,17 +1,21 @@
 # Kimi-K2.5 Recipes
 
-Deployment recipes for **Kimi-K2.5** using TensorRT-LLM or TokenSpeed with Dynamo's KV-aware routing.
+Deployment recipes for **Kimi-K2.5** using TensorRT-LLM with Dynamo's KV-aware routing.
+
+A separate TokenSpeed-based aggregated recipe is available under
+[`tokenspeed/agg/nvidia/`](tokenspeed/agg/nvidia/README.md) (requires a local
+image build — no public Dynamo+TokenSpeed image yet).
 
 ## Available Configurations
 
-| Variant | Model | Engine | Status | Modality | Deploy Configs | Notes |
-|---------|-------|--------|--------|----------|---------------|-------|
-| **baseten** | `baseten-admin/Kimi-2.5-text-nvfp4-v3` | TRT-LLM | Functional | Text only | [`deploy.yaml`](trtllm/agg/baseten/deploy.yaml) | Works with the stock image, not yet performance-optimized |
-| **nvidia** | `nvidia/Kimi-K2.5-NVFP4` | TRT-LLM | Experimental | Text only | [`deploy.yaml`](trtllm/agg/nvidia/deploy.yaml) and [`deploy-specdec.yaml`](trtllm/agg/nvidia/deploy-specdec.yaml) | All configs are compatible with a current top-of-tree Dynamo TRT-LLM image. Vision input is not yet functional |
-| **nvidia** | `nvidia/Kimi-K2.5-NVFP4` | TokenSpeed | Experimental | Text only | [`deploy.yaml`](tokenspeed/agg/nvidia/deploy.yaml) + [`Dockerfile`](tokenspeed/agg/nvidia/Dockerfile) | TP=4 + EP=4 on a single 4×B200 worker. **Requires local image build** (no public `tokenspeed-runtime` image yet) — the Dockerfile layers Dynamo on top of a public TokenSpeed base. See the [recipe README](tokenspeed/agg/nvidia/README.md) |
+There are two model weight variants, each with its own model download and deploy manifests:
 
-The TRT-LLM configurations use TP=8 / EP=8; the TokenSpeed configuration uses TP=4 / EP=4. All
-use aggregated serving with KV-aware routing.
+| Variant | Model | Status | Modality | Deploy Configs | Notes |
+|---------|-------|--------|----------|---------------|-------|
+| **baseten** | `baseten-admin/Kimi-2.5-text-nvfp4-v3` | Functional | Text only | [`deploy.yaml`](trtllm/agg/baseten/deploy.yaml) | Works with the stock image, not yet performance-optimized |
+| **nvidia** | `nvidia/Kimi-K2.5-NVFP4` | Experimental | Text only | [`deploy.yaml`](trtllm/agg/nvidia/deploy.yaml) and [`deploy-specdec.yaml`](trtllm/agg/nvidia/deploy-specdec.yaml) | All configs are compatible with a current top-of-tree Dynamo TRT-LLM image. Vision input is not yet functional |
+
+All configurations use TP8, EP8, aggregated mode with KV-aware routing.
 
 ## Prerequisites
 
@@ -23,9 +27,8 @@ use aggregated serving with KV-aware routing.
 
 | Configuration | GPUs |
 |--------------|------|
-| Aggregated (TRT-LLM) | 8x B200 |
-| Aggregated (TokenSpeed) | 4x B200 |
-| Aggregated Speculative Decoding (TRT-LLM) | 8x4 GB200 (4 workers, each worker spanning 2 nodes) |
+| Aggregated | 8x B200 |
+| Aggregated Speculative Decoding | 8x4 GB200 (4 workers, each worker spanning 2 nodes) |
 
 ---
 

--- a/recipes/kimi-k2.5/tokenspeed/agg/nvidia/Dockerfile
+++ b/recipes/kimi-k2.5/tokenspeed/agg/nvidia/Dockerfile
@@ -1,0 +1,106 @@
+# syntax=docker/dockerfile:1.10.0-labs
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# TokenSpeed bring-up image for iterating on the Dynamo common LLMEngine path.
+# Layers Dynamo (built from source via maturin) on top of a public TokenSpeed
+# runtime image, so you can ship a Dynamo+TokenSpeed worker before NVIDIA
+# publishes an `nvcr.io/nvidia/ai-dynamo/tokenspeed-runtime` image.
+#
+# Build context must be the Dynamo repo root (the source tree is COPY'd in).
+#
+# Examples:
+#   # 1. Dev image (keeps the Rust toolchain for in-pod rebuilds):
+#   docker build \
+#     -f recipes/kimi-k2.5/tokenspeed/agg/nvidia/Dockerfile \
+#     --build-arg BASE_IMAGE=<your-tokenspeed-image>:<tag> \
+#     --target dev \
+#     -t <your-registry>/dynamo-tokenspeed:dev \
+#     .
+#
+#   # 2. Slim runtime image (no compilers / no Rust toolchain):
+#   docker build \
+#     -f recipes/kimi-k2.5/tokenspeed/agg/nvidia/Dockerfile \
+#     --build-arg BASE_IMAGE=<your-tokenspeed-image>:<tag> \
+#     --target runtime \
+#     -t <your-registry>/dynamo-tokenspeed:runtime \
+#     .
+#
+# Use --build-arg ARCH=arm64 for arm64 base images.
+ARG BASE_IMAGE=tokenspeed:local
+ARG ARCH=amd64
+ARG CARGO_BUILD_JOBS=16
+
+FROM ${BASE_IMAGE} AS tokenspeed_base
+ARG ARCH
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
+USER root
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends ca-certificates curl; \
+    rm -rf /var/lib/apt/lists/*
+
+# Dynamo services used by local agg/backend smoke tests.
+RUN set -eux; \
+    curl -fsSL "https://github.com/etcd-io/etcd/releases/download/v3.6.7/etcd-v3.6.7-linux-${ARCH}.tar.gz" | \
+        tar xz -C /usr/bin --strip-components=1 \
+            "etcd-v3.6.7-linux-${ARCH}/etcd" \
+            "etcd-v3.6.7-linux-${ARCH}/etcdctl"; \
+    curl -fsSL "https://github.com/nats-io/nats-server/releases/download/v2.12.4/nats-server-v2.12.4-linux-${ARCH}.tar.gz" | \
+        tar xz -C /usr/bin --strip-components=1 \
+            "nats-server-v2.12.4-linux-${ARCH}/nats-server"
+
+FROM tokenspeed_base AS build_tools
+ARG CARGO_BUILD_JOBS
+ENV CARGO_BUILD_JOBS=${CARGO_BUILD_JOBS}
+ENV CARGO_HOME=/root/.cargo
+ENV RUSTUP_HOME=/root/.rustup
+ENV PATH="${CARGO_HOME}/bin:${PATH}"
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        git \
+        libclang-dev \
+        pkg-config \
+        protobuf-compiler; \
+    rm -rf /var/lib/apt/lists/*
+RUN --mount=type=cache,target=/root/.cargo/registry \
+    --mount=type=cache,target=/root/.cargo/git \
+    set -eux; \
+    if ! command -v cargo >/dev/null 2>&1; then \
+        curl -fsSL https://sh.rustup.rs | \
+            sh -s -- -y --profile minimal --default-toolchain stable; \
+    fi; \
+    cargo install maturin --locked
+
+FROM build_tools AS wheel_builder
+WORKDIR /workspace/dynamo
+COPY . /workspace/dynamo
+RUN --mount=type=cache,target=/root/.cargo/registry \
+    --mount=type=cache,target=/root/.cargo/git \
+    set -eux; \
+    cd /workspace/dynamo/lib/bindings/python; \
+    maturin build --release -o /tmp/dynamo-dist
+
+FROM tokenspeed_base AS runtime
+COPY --from=wheel_builder /workspace/dynamo /workspace/dynamo
+COPY --from=wheel_builder /tmp/dynamo-dist/*.whl /tmp/
+RUN set -eux; \
+    python3 -m pip install --no-cache-dir /tmp/*.whl; \
+    cd /workspace/dynamo; \
+    python3 -m pip install --no-cache-dir -e . --no-deps; \
+    rm -f /tmp/*.whl
+WORKDIR /workspace/dynamo
+
+FROM build_tools AS dev
+COPY --from=wheel_builder /workspace/dynamo /workspace/dynamo
+COPY --from=wheel_builder /tmp/dynamo-dist/*.whl /tmp/
+RUN set -eux; \
+    python3 -m pip install --no-cache-dir /tmp/*.whl; \
+    cd /workspace/dynamo; \
+    python3 -m pip install --no-cache-dir -e . --no-deps; \
+    rm -f /tmp/*.whl
+WORKDIR /workspace/dynamo

--- a/recipes/kimi-k2.5/tokenspeed/agg/nvidia/Dockerfile
+++ b/recipes/kimi-k2.5/tokenspeed/agg/nvidia/Dockerfile
@@ -30,19 +30,43 @@
 #   --build-arg BASE_IMAGE=docker.io/lightseekorg/tokenspeed-runner:cu129-torch-2.11.0
 # or for arm64 base images:
 #   --build-arg ARCH=arm64
+#
+# The runner image is the runtime base only; this Dockerfile installs the
+# TokenSpeed engine itself from github.com/lightseekorg/tokenspeed, following
+# the upstream guide at lightseek.org/tokenspeed/guides/getting-started. Pin
+# the TokenSpeed source ref via --build-arg TOKENSPEED_GIT_REF=<ref>.
 ARG BASE_IMAGE=docker.io/lightseekorg/tokenspeed-runner:cu130-torch-2.11.0
 ARG ARCH=amd64
 ARG CARGO_BUILD_JOBS=16
 
 FROM ${BASE_IMAGE} AS tokenspeed_base
 ARG ARCH
+ARG TOKENSPEED_GIT_REF=main
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
 USER root
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     set -eux; \
     apt-get update; \
-    apt-get install -y --no-install-recommends ca-certificates curl; \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        curl \
+        git; \
     rm -rf /var/lib/apt/lists/*
+
+# Install TokenSpeed from upstream source. The public lightseekorg/tokenspeed-runner
+# image ships only the runtime base (CUDA, PyTorch, mooncake); the engine itself
+# is not yet published on PyPI. Mirrors the upstream guide at
+# https://lightseek.org/tokenspeed/guides/getting-started.
+# Override the source ref (a branch / tag / commit SHA) with --build-arg TOKENSPEED_GIT_REF=<ref>.
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
+    set -eux; \
+    git clone https://github.com/lightseekorg/tokenspeed.git /opt/tokenspeed; \
+    cd /opt/tokenspeed; \
+    git checkout "${TOKENSPEED_GIT_REF}"; \
+    pip install -e "./python" --no-build-isolation; \
+    pip install -e tokenspeed-kernel/python/ --no-build-isolation; \
+    pip install -e tokenspeed-scheduler/
 
 # Dynamo services used by local agg/backend smoke tests.
 RUN set -eux; \
@@ -60,12 +84,12 @@ ENV CARGO_BUILD_JOBS=${CARGO_BUILD_JOBS}
 ENV CARGO_HOME=/root/.cargo
 ENV RUSTUP_HOME=/root/.rustup
 ENV PATH="${CARGO_HOME}/bin:${PATH}"
+# build-essential and git already installed in tokenspeed_base for the
+# TokenSpeed kernel build; this layer adds the remaining Rust/Dynamo tooling.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
-        build-essential \
-        git \
         libclang-dev \
         pkg-config \
         protobuf-compiler; \

--- a/recipes/kimi-k2.5/tokenspeed/agg/nvidia/Dockerfile
+++ b/recipes/kimi-k2.5/tokenspeed/agg/nvidia/Dockerfile
@@ -13,7 +13,6 @@
 #   # 1. Dev image (keeps the Rust toolchain for in-pod rebuilds):
 #   docker build \
 #     -f recipes/kimi-k2.5/tokenspeed/agg/nvidia/Dockerfile \
-#     --build-arg BASE_IMAGE=<your-tokenspeed-image>:<tag> \
 #     --target dev \
 #     -t <your-registry>/dynamo-tokenspeed:dev \
 #     .
@@ -21,13 +20,17 @@
 #   # 2. Slim runtime image (no compilers / no Rust toolchain):
 #   docker build \
 #     -f recipes/kimi-k2.5/tokenspeed/agg/nvidia/Dockerfile \
-#     --build-arg BASE_IMAGE=<your-tokenspeed-image>:<tag> \
 #     --target runtime \
 #     -t <your-registry>/dynamo-tokenspeed:runtime \
 #     .
 #
-# Use --build-arg ARCH=arm64 for arm64 base images.
-ARG BASE_IMAGE=tokenspeed:local
+# The default BASE_IMAGE pins lightseekorg/tokenspeed-runner at a CUDA-13
+# tag (matches B200's CUDA 13.x driver, ~4.66 GB). To target a different
+# TokenSpeed runtime build, override it:
+#   --build-arg BASE_IMAGE=docker.io/lightseekorg/tokenspeed-runner:cu129-torch-2.11.0
+# or for arm64 base images:
+#   --build-arg ARCH=arm64
+ARG BASE_IMAGE=docker.io/lightseekorg/tokenspeed-runner:cu130-torch-2.11.0
 ARG ARCH=amd64
 ARG CARGO_BUILD_JOBS=16
 

--- a/recipes/kimi-k2.5/tokenspeed/agg/nvidia/README.md
+++ b/recipes/kimi-k2.5/tokenspeed/agg/nvidia/README.md
@@ -18,8 +18,9 @@ Kimi K2.5 / K2.6.
 There is **no public `nvcr.io/nvidia/ai-dynamo/tokenspeed-runtime` image** at the time
 this recipe was written; TokenSpeed integration in Dynamo is still in flight. This
 directory ships a [`Dockerfile`](Dockerfile) that builds a Dynamo+TokenSpeed image
-on top of a public TokenSpeed runtime image. Run the build, push the result to a
-registry your cluster can pull from, then update the `image:` fields in
+on top of `docker.io/lightseekorg/tokenspeed-runner:cu130-torch-2.11.0` (the upstream
+TokenSpeed runtime, pinned by tag for reproducibility). Run the build, push the result
+to a registry your cluster can pull from, then update the `image:` fields in
 [`deploy.yaml`](deploy.yaml).
 
 ### 1. Build the Dynamo+TokenSpeed image
@@ -31,10 +32,23 @@ tree in to build the Dynamo Python wheel via `maturin`).
 # From the repo root.
 docker build \
   -f recipes/kimi-k2.5/tokenspeed/agg/nvidia/Dockerfile \
-  --build-arg BASE_IMAGE=<your-tokenspeed-image>:<tag> \
   --target dev \
   -t <your-registry>/dynamo-tokenspeed:dev \
   .
+```
+
+The Dockerfile defaults `BASE_IMAGE` to a pinned public TokenSpeed runtime tag:
+
+```
+docker.io/lightseekorg/tokenspeed-runner:cu130-torch-2.11.0
+```
+
+This tag is CUDA-13-based (matches B200's CUDA 13.x driver) and ships PyTorch 2.11.0.
+Sibling tags on the same repo: `cu130`, `cu129-torch-2.11.0`, `cu129`, `latest`. To
+target a different runtime, override the build arg:
+
+```bash
+--build-arg BASE_IMAGE=docker.io/lightseekorg/tokenspeed-runner:cu129-torch-2.11.0
 ```
 
 The Dockerfile has two reachable targets:

--- a/recipes/kimi-k2.5/tokenspeed/agg/nvidia/README.md
+++ b/recipes/kimi-k2.5/tokenspeed/agg/nvidia/README.md
@@ -13,6 +13,16 @@ Kimi K2.5 / K2.6.
 |-----------|----------|-------------|----------|
 | **Aggregated (TokenSpeed)** | [`deploy.yaml`](deploy.yaml) | Aggregated serving with KV-aware routing using the TokenSpeed engine | 1× 4×B200 (TP=4, EP=4) |
 
+> **Note: raw Kubernetes primitives, not `DynamoGraphDeployment`.** The Dynamo
+> Operator's CRD currently only validates `backendFramework` values `vllm`, `sglang`,
+> `trtllm` (see `deploy/operator/api/v1beta1/common.go`). Until `tokenspeed` is added
+> to that enum, this recipe wires the four processes the operator would otherwise
+> generate (etcd discovery + NATS event-plane + frontend HTTP router + worker engine)
+> as plain `Deployment`s and `Service`s. The frontend Service is named
+> `kimi-k25-tokenspeed-agg-frontend` to match the operator-generated naming so
+> port-forward instructions stay stable across the migration to `DynamoGraphDeployment`
+> once supported. The `deploy.yaml` carries an inline TODO marking the swap point.
+
 ## Image — local build required
 
 There is **no public `nvcr.io/nvidia/ai-dynamo/tokenspeed-runtime` image** at the time
@@ -81,9 +91,12 @@ the tag you just pushed.
 
 ## Prerequisites
 
-- A Kubernetes cluster with the [Dynamo Operator](https://docs.nvidia.com/dynamo/) installed
+- A Kubernetes cluster (the Dynamo Operator is **not** required for this recipe — see
+  the note above)
 - 4× B200 GPUs (or 8× B200 if you raise `--tensor-parallel-size` to 8)
 - A `hf-token-secret` Secret containing your Hugging Face token
+- An `nvcrimagepullsecret` Secret in the namespace, or update `imagePullSecrets` in
+  [`deploy.yaml`](deploy.yaml) to match your cluster's pull-secret naming
 - A pre-existing `model-cache` PVC with `nvidia/Kimi-K2.5-NVFP4` downloaded (see
   the [`model-cache/nvidia/`](../../../model-cache/nvidia/) sibling job)
 - A registry your cluster's nodes can pull from with the `dynamo-tokenspeed` image
@@ -103,13 +116,15 @@ kubectl wait --for=condition=Complete job/model-download -n ${NAMESPACE} --timeo
 kubectl apply -f deploy.yaml -n ${NAMESPACE}
 ```
 
-This creates a **DynamoGraphDeployment** (`kimi-k25-tokenspeed-agg`) with:
+This creates four Deployments + three Services:
 
-- A **Frontend** running `dynamo.frontend` in KV-router mode on port 8000.
-- A **TokenSpeedWorker** running `dynamo.tokenspeed` against `nvidia/Kimi-K2.5-NVFP4`,
-  TP=4 + expert parallel, NVFP4 weights, FP8 KV cache, MLA attention via
-  `trtllm_mla`, MoE via `flashinfer_trtllm`, and the `kimi_k25` / `kimi_k2`
-  Dynamo reasoning + tool-call parsers.
+| Resource | Purpose | Image |
+|---|---|---|
+| `kimi-k25-tokenspeed-etcd` (Deployment + Service) | Discovery backend | `gcr.io/etcd-development/etcd:v3.6.7` |
+| `kimi-k25-tokenspeed-nats` (Deployment + Service) | Event plane (JetStream) | `nats:2.12.4` |
+| `kimi-k25-tokenspeed-frontend` (Deployment) | `dynamo.frontend` in KV-router mode on port 8000 | your locally-built `dynamo-tokenspeed` |
+| `kimi-k25-tokenspeed-agg-frontend` (Service) | Stable name for port-forward; selects the frontend Deployment | — |
+| `kimi-k25-tokenspeed-worker` (Deployment) | `dynamo.tokenspeed` against `nvidia/Kimi-K2.5-NVFP4`, TP=4 + EP=4, NVFP4 weights, FP8 KV cache, MLA attention via `trtllm_mla`, MoE via `flashinfer_trtllm`, with `kimi_k25` reasoning + `kimi_k2` tool-call parsers | your locally-built `dynamo-tokenspeed` |
 
 ## Test the deployment
 
@@ -154,11 +169,23 @@ final answer in `content`. Send `max_tokens >= 200` to leave room for both phase
 
 ## What's different from the TRT-LLM sibling
 
-The [`../../trtllm/agg/nvidia/`](../../trtllm/agg/nvidia/) deployment uses TP=8 and
-a ConfigMap-based engine YAML. TokenSpeed accepts engine knobs directly as worker
-CLI flags, so this recipe inlines them in `deploy.yaml` (no ConfigMap), matching the
-[`recipes/llama-3-70b/vllm/agg/`](../../../../llama-3-70b/vllm/agg/) layout. The
-TRT-LLM recipe ships against the public
-`nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime` image; this recipe requires you to
-build and push your own Dynamo+TokenSpeed image (see the build steps above) until
-NVIDIA publishes one.
+The [`../../trtllm/agg/nvidia/`](../../trtllm/agg/nvidia/) deployment uses TP=8 and a
+ConfigMap-based engine YAML, and ships as a single `DynamoGraphDeployment` letting
+the Dynamo Operator generate the underlying `Deployment`s/`Service`s. This recipe
+differs on three axes:
+
+1. **Engine knobs are inline CLI flags, not a ConfigMap.** TokenSpeed accepts engine
+   knobs directly on the worker command line, similar to vLLM. Layout therefore
+   mirrors [`recipes/llama-3-70b/vllm/agg/`](../../../../llama-3-70b/vllm/agg/) rather
+   than the TRT-LLM ConfigMap pattern.
+2. **Raw `Deployment` + `Service` resources, not a `DynamoGraphDeployment`.** The
+   operator's `backendFramework` enum currently only validates `vllm`, `sglang`,
+   `trtllm` — `tokenspeed` is rejected by admission validation. Until the operator
+   adds `tokenspeed` support, this recipe lays out the four processes the operator
+   would otherwise generate as plain `Deployment`s. See the inline TODO in
+   `deploy.yaml` — once the operator backend lands, the deploy.yaml collapses to a
+   single `DynamoGraphDeployment` matching the TRT-LLM sibling's shape.
+3. **Local image build.** The TRT-LLM recipe ships against the public
+   `nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime` image; this recipe requires you
+   to build and push your own Dynamo+TokenSpeed image (see the build steps above)
+   until NVIDIA publishes one.

--- a/recipes/kimi-k2.5/tokenspeed/agg/nvidia/README.md
+++ b/recipes/kimi-k2.5/tokenspeed/agg/nvidia/README.md
@@ -1,0 +1,142 @@
+# Kimi-K2.5 nvidia/Kimi-K2.5-NVFP4 — TokenSpeed Aggregated Deployment on Kubernetes
+
+> **Text only:** the NVFP4 export of Kimi-K2.5 ships without vision-tower weights. The
+> TokenSpeed loader logs warnings for the missing `vision_tower.*` parameters and
+> continues with text-only forward paths. Image inputs will fail.
+
+This recipe runs `nvidia/Kimi-K2.5-NVFP4` on the **TokenSpeed** engine under Dynamo's
+KV-aware aggregated frontend. It mirrors the parameter set documented in the upstream
+[TokenSpeed model recipes](https://lightseek.org/tokenspeed/recipes/models) for
+Kimi K2.5 / K2.6.
+
+| Deployment | Manifest | Description | Hardware |
+|-----------|----------|-------------|----------|
+| **Aggregated (TokenSpeed)** | [`deploy.yaml`](deploy.yaml) | Aggregated serving with KV-aware routing using the TokenSpeed engine | 1× 4×B200 (TP=4, EP=4) |
+
+## Image — local build required
+
+There is **no public `nvcr.io/nvidia/ai-dynamo/tokenspeed-runtime` image** at the time
+this recipe was written; TokenSpeed integration in Dynamo is still in flight. This
+directory ships a [`Dockerfile`](Dockerfile) that builds a Dynamo+TokenSpeed image
+on top of a public TokenSpeed runtime image. Run the build, push the result to a
+registry your cluster can pull from, then update the `image:` fields in
+[`deploy.yaml`](deploy.yaml).
+
+### 1. Build the Dynamo+TokenSpeed image
+
+The build context must be the **Dynamo repo root** (the Dockerfile `COPY`s the source
+tree in to build the Dynamo Python wheel via `maturin`).
+
+```bash
+# From the repo root.
+docker build \
+  -f recipes/kimi-k2.5/tokenspeed/agg/nvidia/Dockerfile \
+  --build-arg BASE_IMAGE=<your-tokenspeed-image>:<tag> \
+  --target dev \
+  -t <your-registry>/dynamo-tokenspeed:dev \
+  .
+```
+
+The Dockerfile has two reachable targets:
+
+- `--target runtime`: slim image, no compilers. Use for production-leaning deploys.
+- `--target dev`: keeps `cargo`, `rustc`, `maturin`, build-essential, git, etc. Useful
+  when iterating on the Rust bindings inside the pod (`maturin develop` inline).
+
+For arm64 base images, add `--build-arg ARCH=arm64`.
+
+### 2. Push to a cluster-reachable registry
+
+```bash
+docker push <your-registry>/dynamo-tokenspeed:dev
+```
+
+### 3. Update both `image:` fields in `deploy.yaml`
+
+The `Frontend` and `TokenSpeedWorker` services in [`deploy.yaml`](deploy.yaml) both
+reference the placeholder `<your-registry>/dynamo-tokenspeed:dev`. Replace both with
+the tag you just pushed.
+
+## Prerequisites
+
+- A Kubernetes cluster with the [Dynamo Operator](https://docs.nvidia.com/dynamo/) installed
+- 4× B200 GPUs (or 8× B200 if you raise `--tensor-parallel-size` to 8)
+- A `hf-token-secret` Secret containing your Hugging Face token
+- A pre-existing `model-cache` PVC with `nvidia/Kimi-K2.5-NVFP4` downloaded (see
+  the [`model-cache/nvidia/`](../../../model-cache/nvidia/) sibling job)
+- A registry your cluster's nodes can pull from with the `dynamo-tokenspeed` image
+  pushed (see the build steps above)
+
+## Deploy
+
+```bash
+export NAMESPACE=dynamo-demo
+
+# Download model weights into the model-cache PVC
+kubectl apply -f ../../../model-cache/model-cache.yaml -n ${NAMESPACE}
+kubectl apply -f ../../../model-cache/nvidia/model-download.yaml -n ${NAMESPACE}
+kubectl wait --for=condition=Complete job/model-download -n ${NAMESPACE} --timeout=6000s
+
+# After updating both image: fields in deploy.yaml, apply.
+kubectl apply -f deploy.yaml -n ${NAMESPACE}
+```
+
+This creates a **DynamoGraphDeployment** (`kimi-k25-tokenspeed-agg`) with:
+
+- A **Frontend** running `dynamo.frontend` in KV-router mode on port 8000.
+- A **TokenSpeedWorker** running `dynamo.tokenspeed` against `nvidia/Kimi-K2.5-NVFP4`,
+  TP=4 + expert parallel, NVFP4 weights, FP8 KV cache, MLA attention via
+  `trtllm_mla`, MoE via `flashinfer_trtllm`, and the `kimi_k25` / `kimi_k2`
+  Dynamo reasoning + tool-call parsers.
+
+## Test the deployment
+
+```bash
+kubectl port-forward svc/kimi-k25-tokenspeed-agg-frontend 8000:8000 -n ${NAMESPACE}
+```
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "kimi-k2.5",
+    "messages": [{"role": "user", "content": "Hello!"}],
+    "max_tokens": 300
+  }'
+```
+
+Kimi K2.5 emits a `<think>...</think>` reasoning prefix; the `kimi_k25` reasoning
+parser splits it out into the response's `reasoning_content` field, leaving the
+final answer in `content`. Send `max_tokens >= 200` to leave room for both phases.
+
+## Notes on parameter choice
+
+- `--tensor-parallel-size 4 --enable-expert-parallel`: matches the upstream TokenSpeed
+  recipe; attention is sharded TP=4, MoE experts are sharded EP=4 across the same 4
+  ranks. Bump to 8 if you have an 8×B200 node and want lower latency at the cost of
+  higher per-GPU memory pressure.
+- `--quantization nvfp4 --attention-backend trtllm_mla --moe-backend flashinfer_trtllm`:
+  Blackwell-native fast paths. These three together are why the recipe targets B200.
+- `--kv-cache-dtype fp8`: paired with `--quantization nvfp4`, halves the KV cache
+  footprint vs BF16 KV at no measurable accuracy loss for chat workloads.
+- `--gpu-memory-utilization 0.80`: lower than TokenSpeed's 0.85 default. The Dynamo
+  worker layer (etcd discovery, NATS event plane, request-plane TCP) holds additional
+  memory beyond the engine, and the default headroom is too tight for K2.5's MoE
+  weight init. 0.75 is too low — the engine sizes the KV cache pool negative.
+- `--dyn-reasoning-parser kimi_k25 --dyn-tool-call-parser kimi_k2`: the upstream
+  TokenSpeed recipe uses `--reasoning-parser kimi_k2 --tool-call-parser kimi_k2`,
+  which apply at the engine level. Dynamo intercepts these at the worker layer
+  with the `--dyn-*` variants; `kimi_k25` is the K2.5/K2.6-specific parser.
+- `--max-model-len 262144`: K2.5 supports 256K context. The KV cache budget at this
+  length is large; reduce if your prompts are shorter to free GPU memory for batches.
+
+## What's different from the TRT-LLM sibling
+
+The [`../../trtllm/agg/nvidia/`](../../trtllm/agg/nvidia/) deployment uses TP=8 and
+a ConfigMap-based engine YAML. TokenSpeed accepts engine knobs directly as worker
+CLI flags, so this recipe inlines them in `deploy.yaml` (no ConfigMap), matching the
+[`recipes/llama-3-70b/vllm/agg/`](../../../../llama-3-70b/vllm/agg/) layout. The
+TRT-LLM recipe ships against the public
+`nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime` image; this recipe requires you to
+build and push your own Dynamo+TokenSpeed image (see the build steps above) until
+NVIDIA publishes one.

--- a/recipes/kimi-k2.5/tokenspeed/agg/nvidia/README.md
+++ b/recipes/kimi-k2.5/tokenspeed/agg/nvidia/README.md
@@ -19,9 +19,17 @@ There is **no public `nvcr.io/nvidia/ai-dynamo/tokenspeed-runtime` image** at th
 this recipe was written; TokenSpeed integration in Dynamo is still in flight. This
 directory ships a [`Dockerfile`](Dockerfile) that builds a Dynamo+TokenSpeed image
 on top of `docker.io/lightseekorg/tokenspeed-runner:cu130-torch-2.11.0` (the upstream
-TokenSpeed runtime, pinned by tag for reproducibility). Run the build, push the result
-to a registry your cluster can pull from, then update the `image:` fields in
-[`deploy.yaml`](deploy.yaml).
+TokenSpeed runtime base, pinned by tag for reproducibility).
+
+The lightseek runner image is the **runtime base only** — it ships CUDA 13, PyTorch
+2.11, and mooncake, but not the TokenSpeed engine itself (the engine is not yet
+published on PyPI; only a name-reservation placeholder exists). This Dockerfile
+installs TokenSpeed from upstream source per the official guide at
+[lightseek.org/tokenspeed/guides/getting-started](https://lightseek.org/tokenspeed/guides/getting-started),
+then layers Dynamo on top.
+
+Run the build, push the result to a registry your cluster can pull from, then
+update the `image:` fields in [`deploy.yaml`](deploy.yaml).
 
 ### 1. Build the Dynamo+TokenSpeed image
 

--- a/recipes/kimi-k2.5/tokenspeed/agg/nvidia/README.md
+++ b/recipes/kimi-k2.5/tokenspeed/agg/nvidia/README.md
@@ -138,13 +138,35 @@ curl http://localhost:8000/v1/chat/completions \
   -d '{
     "model": "kimi-k2.5",
     "messages": [{"role": "user", "content": "Hello!"}],
-    "max_tokens": 300
+    "max_tokens": 300,
+    "skip_special_tokens": false,
+    "chat_template_kwargs": {"thinking": true}
   }'
 ```
 
 Kimi K2.5 emits a `<think>...</think>` reasoning prefix; the `kimi_k25` reasoning
 parser splits it out into the response's `reasoning_content` field, leaving the
 final answer in `content`. Send `max_tokens >= 200` to leave room for both phases.
+
+Both extra request fields are required:
+
+- `chat_template_kwargs: {thinking: true}` tells the chat template to emit the
+  `<think>` opener that primes the model to produce a reasoning block before the
+  answer. Without it the template skips the think prefix and the model's first
+  decoded token changes. (`thinking` is not a top-level OpenAI field, so it must
+  go inside `chat_template_kwargs` — Dynamo's frontend rejects unknown top-level
+  fields with `400 Unsupported parameter(s): thinking`.)
+- `skip_special_tokens: false` keeps structural tokens (`<|im_end|>`, `</think>`)
+  in the streamed output so the `kimi_k25` reasoning parser can find the
+  reasoning/content boundary. With the default `true`, the parser sees stripped
+  output, can't split the segments, and returns `content: null` with a small
+  number of trailing-stop tokens.
+
+The two knobs together restore the engine-side contract that the upstream
+`tokenspeed serve` monolith gets implicitly because it owns both the chat
+template and the parser in the same process; Dynamo's split (frontend renders
+template, worker streams output, parser runs after) creates a seam that needs
+explicit user-side wiring.
 
 ## Notes on parameter choice
 

--- a/recipes/kimi-k2.5/tokenspeed/agg/nvidia/deploy.yaml
+++ b/recipes/kimi-k2.5/tokenspeed/agg/nvidia/deploy.yaml
@@ -8,67 +8,230 @@
 # from, since NVIDIA does not currently publish a
 # `nvcr.io/nvidia/ai-dynamo/tokenspeed-runtime` image. See ./README.md for
 # the build/push/deploy flow.
-apiVersion: nvidia.com/v1alpha1
-kind: DynamoGraphDeployment
+#
+# TODO: Change to DynamoGraphDeployment once supported. The Dynamo Operator
+# currently only accepts `backendFramework` values `vllm`, `sglang`, `trtllm`
+# (see deploy/operator/api/v1beta1/common.go). Until tokenspeed is added to
+# that enum, this recipe wires the four processes the operator would otherwise
+# generate (etcd discovery + nats event-plane + frontend HTTP router + worker
+# engine) as plain Deployments and Services. The Service names mirror the
+# operator-generated naming so port-forward instructions stay stable across
+# the migration.
+
+# ---------------------------------------------------------------------------
+# 1. etcd — discovery backend
+# ---------------------------------------------------------------------------
+apiVersion: apps/v1
+kind: Deployment
 metadata:
-  name: kimi-k25-tokenspeed-agg
+  name: kimi-k25-tokenspeed-etcd
+  labels:
+    app: kimi-k25-tokenspeed
+    component: etcd
 spec:
-  backendFramework: tokenspeed
-  pvcs:
-    - name: model-cache
-      create: false
-  services:
-    Frontend:
-      componentType: frontend
-      volumeMounts:
-        - name: model-cache
-          mountPoint: /opt/models
-      extraPodSpec:
-        mainContainer:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kimi-k25-tokenspeed
+      component: etcd
+  template:
+    metadata:
+      labels:
+        app: kimi-k25-tokenspeed
+        component: etcd
+    spec:
+      containers:
+        - name: etcd
+          image: gcr.io/etcd-development/etcd:v3.6.7
+          command:
+            - /usr/local/bin/etcd
+          args:
+            - --data-dir=/var/run/etcd/data
+            - --listen-client-urls=http://0.0.0.0:2379
+            - --advertise-client-urls=http://0.0.0.0:2379
+          ports:
+            - containerPort: 2379
+              name: client
+          volumeMounts:
+            - name: data
+              mountPath: /var/run/etcd
+      volumes:
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kimi-k25-tokenspeed-etcd
+spec:
+  selector:
+    app: kimi-k25-tokenspeed
+    component: etcd
+  ports:
+    - port: 2379
+      targetPort: 2379
+      name: client
+# ---------------------------------------------------------------------------
+# 2. nats — event-plane (with JetStream)
+# ---------------------------------------------------------------------------
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kimi-k25-tokenspeed-nats
+  labels:
+    app: kimi-k25-tokenspeed
+    component: nats
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kimi-k25-tokenspeed
+      component: nats
+  template:
+    metadata:
+      labels:
+        app: kimi-k25-tokenspeed
+        component: nats
+    spec:
+      containers:
+        - name: nats
+          image: nats:2.12.4
+          args:
+            - "-js"
+            - "-a"
+            - "0.0.0.0"
+            - "-p"
+            - "4222"
+          ports:
+            - containerPort: 4222
+              name: client
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kimi-k25-tokenspeed-nats
+spec:
+  selector:
+    app: kimi-k25-tokenspeed
+    component: nats
+  ports:
+    - port: 4222
+      targetPort: 4222
+      name: client
+# ---------------------------------------------------------------------------
+# 3. Frontend — HTTP router (KV-aware)
+# ---------------------------------------------------------------------------
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kimi-k25-tokenspeed-frontend
+  labels:
+    app: kimi-k25-tokenspeed
+    component: frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kimi-k25-tokenspeed
+      component: frontend
+  template:
+    metadata:
+      labels:
+        app: kimi-k25-tokenspeed
+        component: frontend
+    spec:
+      imagePullSecrets:
+        - name: nvcrimagepullsecret
+      containers:
+        - name: frontend
           # Replace with your locally-built dev/runtime image (see ./Dockerfile).
           image: <your-registry>/dynamo-tokenspeed:dev
           workingDir: /workspace/dynamo
-          args:
-            - python3 -m dynamo.frontend --router-mode kv --http-port 8000
           command:
             - /bin/sh
             - -c
-      envs:
-        - name: HF_HOME
-          value: /opt/models
-      replicas: 1
-    TokenSpeedWorker:
-      componentType: worker
-      envFromSecret: hf-token-secret
-      volumeMounts:
+          args:
+            - python3 -m dynamo.frontend --router-mode kv --http-port 8000
+          env:
+            - name: ETCD_ENDPOINTS
+              value: http://kimi-k25-tokenspeed-etcd:2379
+            - name: NATS_SERVER
+              value: nats://kimi-k25-tokenspeed-nats:4222
+            - name: HF_HOME
+              value: /opt/models
+          ports:
+            - containerPort: 8000
+              name: http
+          volumeMounts:
+            - name: model-cache
+              mountPath: /opt/models
+      volumes:
         - name: model-cache
-          mountPoint: /opt/models
-      sharedMemory:
-        size: 80Gi
-      extraPodSpec:
-        affinity:
-          nodeAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-              nodeSelectorTerms:
-                - matchExpressions:
-                    - key: nvidia.com/gpu.present
-                      operator: In
-                      values:
-                        - "true"
-        mainContainer:
+          persistentVolumeClaim:
+            claimName: model-cache
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kimi-k25-tokenspeed-agg-frontend
+spec:
+  selector:
+    app: kimi-k25-tokenspeed
+    component: frontend
+  ports:
+    - port: 8000
+      targetPort: 8000
+      name: http
+# ---------------------------------------------------------------------------
+# 4. Worker — TokenSpeed engine
+# ---------------------------------------------------------------------------
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kimi-k25-tokenspeed-worker
+  labels:
+    app: kimi-k25-tokenspeed
+    component: worker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kimi-k25-tokenspeed
+      component: worker
+  template:
+    metadata:
+      labels:
+        app: kimi-k25-tokenspeed
+        component: worker
+    spec:
+      imagePullSecrets:
+        - name: nvcrimagepullsecret
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: nvidia.com/gpu.present
+                    operator: In
+                    values:
+                      - "true"
+      containers:
+        - name: worker
           # Replace with your locally-built dev/runtime image (see ./Dockerfile).
           image: <your-registry>/dynamo-tokenspeed:dev
           workingDir: /workspace/dynamo
-          env:
-            - name: SERVED_MODEL_NAME
-              value: kimi-k2.5
-            - name: MODEL_PATH
-              value: nvidia/Kimi-K2.5-NVFP4
-            - name: HF_HOME
-              value: /opt/models
+          command:
+            - /bin/sh
+            - -c
           args:
             - |
               python3 -m dynamo.tokenspeed \
+                --discovery-backend etcd \
+                --request-plane tcp \
+                --event-plane nats \
                 --dyn-reasoning-parser kimi_k25 \
                 --dyn-tool-call-parser kimi_k2 \
                 --model "${MODEL_PATH}" \
@@ -84,12 +247,35 @@ spec:
                 --attention-backend trtllm_mla \
                 --moe-backend flashinfer_trtllm \
                 --gpu-memory-utilization 0.80
-          command:
-            - /bin/sh
-            - -c
-      replicas: 1
-      resources:
-        limits:
-          gpu: "4"
-        requests:
-          gpu: "4"
+          envFrom:
+            - secretRef:
+                name: hf-token-secret
+          env:
+            - name: ETCD_ENDPOINTS
+              value: http://kimi-k25-tokenspeed-etcd:2379
+            - name: NATS_SERVER
+              value: nats://kimi-k25-tokenspeed-nats:4222
+            - name: MODEL_PATH
+              value: nvidia/Kimi-K2.5-NVFP4
+            - name: SERVED_MODEL_NAME
+              value: kimi-k2.5
+            - name: HF_HOME
+              value: /opt/models
+          resources:
+            limits:
+              nvidia.com/gpu: "4"
+            requests:
+              nvidia.com/gpu: "4"
+          volumeMounts:
+            - name: model-cache
+              mountPath: /opt/models
+            - name: dshm
+              mountPath: /dev/shm
+      volumes:
+        - name: model-cache
+          persistentVolumeClaim:
+            claimName: model-cache
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 80Gi

--- a/recipes/kimi-k2.5/tokenspeed/agg/nvidia/deploy.yaml
+++ b/recipes/kimi-k2.5/tokenspeed/agg/nvidia/deploy.yaml
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Aggregated TokenSpeed serving for nvidia/Kimi-K2.5-NVFP4.
+#
+# Note: this recipe expects the Dynamo+TokenSpeed image to be built locally
+# from the sibling Dockerfile and pushed to a registry your cluster can pull
+# from, since NVIDIA does not currently publish a
+# `nvcr.io/nvidia/ai-dynamo/tokenspeed-runtime` image. See ./README.md for
+# the build/push/deploy flow.
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: kimi-k25-tokenspeed-agg
+spec:
+  backendFramework: tokenspeed
+  pvcs:
+    - name: model-cache
+      create: false
+  services:
+    Frontend:
+      componentType: frontend
+      volumeMounts:
+        - name: model-cache
+          mountPoint: /opt/models
+      extraPodSpec:
+        mainContainer:
+          # Replace with your locally-built dev/runtime image (see ./Dockerfile).
+          image: <your-registry>/dynamo-tokenspeed:dev
+          workingDir: /workspace/dynamo
+          args:
+            - python3 -m dynamo.frontend --router-mode kv --http-port 8000
+          command:
+            - /bin/sh
+            - -c
+      envs:
+        - name: HF_HOME
+          value: /opt/models
+      replicas: 1
+    TokenSpeedWorker:
+      componentType: worker
+      envFromSecret: hf-token-secret
+      volumeMounts:
+        - name: model-cache
+          mountPoint: /opt/models
+      sharedMemory:
+        size: 80Gi
+      extraPodSpec:
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: nvidia.com/gpu.present
+                      operator: In
+                      values:
+                        - "true"
+        mainContainer:
+          # Replace with your locally-built dev/runtime image (see ./Dockerfile).
+          image: <your-registry>/dynamo-tokenspeed:dev
+          workingDir: /workspace/dynamo
+          env:
+            - name: SERVED_MODEL_NAME
+              value: kimi-k2.5
+            - name: MODEL_PATH
+              value: nvidia/Kimi-K2.5-NVFP4
+            - name: HF_HOME
+              value: /opt/models
+          args:
+            - |
+              python3 -m dynamo.tokenspeed \
+                --dyn-reasoning-parser kimi_k25 \
+                --dyn-tool-call-parser kimi_k2 \
+                --model "${MODEL_PATH}" \
+                --served-model-name "${SERVED_MODEL_NAME}" \
+                --trust-remote-code \
+                --max-model-len 262144 \
+                --kv-cache-dtype fp8 \
+                --quantization nvfp4 \
+                --tensor-parallel-size 4 \
+                --enable-expert-parallel \
+                --chunked-prefill-size 8192 \
+                --max-num-seqs 256 \
+                --attention-backend trtllm_mla \
+                --moe-backend flashinfer_trtllm \
+                --gpu-memory-utilization 0.80
+          command:
+            - /bin/sh
+            - -c
+      replicas: 1
+      resources:
+        limits:
+          gpu: "4"
+        requests:
+          gpu: "4"


### PR DESCRIPTION
## Summary

- Adds `recipes/kimi-k2.5/tokenspeed/agg/nvidia/` for serving `nvidia/Kimi-K2.5-NVFP4` on the TokenSpeed engine under Dynamo's KV-aware aggregated frontend. TP=4, EP=4, NVFP4 weights, FP8 KV cache, MLA via `trtllm_mla`, MoE via `flashinfer_trtllm`.
- Mirrors the upstream TokenSpeed model recipe at https://lightseek.org/tokenspeed/recipes/models (Kimi K2.5 / K2.6 section) and the existing `recipes/llama-3-70b/vllm/agg/` layout (inline worker args, no ConfigMap), since TokenSpeed accepts engine knobs directly as worker CLI flags.
- Ships a `Dockerfile` alongside `deploy.yaml` because there is no public `nvcr.io/nvidia/ai-dynamo/tokenspeed-runtime` image yet. The Dockerfile layers Dynamo (built from this branch via `maturin`) on top of `lightseekorg/tokenspeed-runner:cu130-torch-2.11.0` plus the upstream TokenSpeed source clone (per the official guide at lightseek.org/tokenspeed/guides/getting-started). Two reachable targets: `runtime` (slim) and `dev` (keeps `cargo`/`rustc`/`maturin` for in-pod iteration).
- `deploy.yaml` is **raw `Deployment`s + `Service`s**, not a `DynamoGraphDeployment`. The Dynamo Operator's `backendFramework` CRD enum currently only validates `vllm`, `sglang`, `trtllm`, so a DGD with `backendFramework: tokenspeed` is rejected at admission. Until the operator adds tokenspeed support, this recipe wires the four processes the operator would otherwise generate (etcd discovery, NATS event-plane, frontend, worker) as plain Deployments + Services. The frontend Service name `kimi-k25-tokenspeed-agg-frontend` matches the operator-generated naming, so port-forward instructions stay stable across the migration. The deploy.yaml carries an inline TODO marking the swap point.
- Updates the parent `recipes/kimi-k2.5/README.md` with a single 3-line pointer to the new sub-recipe; all TokenSpeed-specific docs live in `tokenspeed/agg/nvidia/README.md`.

Stacked on top of #9212 (`warnold/tokenspeed-initial-impl`) — that PR adds `dynamo.tokenspeed` itself; this PR adds a real recipe that exercises it.

## Caveats

- TokenSpeed's K2.5 NVFP4 export ships without vision-tower weights → text-only inference (the loader logs warnings for missing `vision_tower.*` and continues).
- `--gpu-memory-utilization 0.80` (vs the upstream lightseek recipe's 0.85 default) leaves headroom for Dynamo's worker runtime (etcd watcher + NATS subscriber + TCP request-plane listener all hold CUDA contexts on the same process). 0.85 OOMs at MoE NVFP4 weight init; 0.75 has the engine size the KV cache pool negative.
- **Chat-completions request shape**: `/v1/chat/completions` requires two extra request fields for the `kimi_k25` reasoning parser to produce non-empty `content`:
  - `chat_template_kwargs: {thinking: true}` — primes the chat template to emit the `<think>` opener (must be nested; Dynamo's frontend rejects `thinking` as a top-level field with `400 Unsupported parameter(s): thinking`).
  - `skip_special_tokens: false` — keeps `<|im_end|>` and `</think>` in the streamed output so the parser can split reasoning_content from content.

  Without both fields, the response comes back with `content: null` and a few trailing stop tokens. Documented in the recipe README's smoke-test command. (Originally tracked as a Dynamo bug; turned out to be a request-shape requirement that the upstream `tokenspeed serve` monolith hides because it owns both the template and the parser in the same process.)

## Test plan

- [x] `python3 -c "import yaml; list(yaml.safe_load_all(open('recipes/kimi-k2.5/tokenspeed/agg/nvidia/deploy.yaml')))"` — parses 7 docs cleanly.
- [x] `docker build -f recipes/kimi-k2.5/tokenspeed/agg/nvidia/Dockerfile --target dev -t <registry>/dynamo-tokenspeed:dev .` — succeeds on Linux/amd64 (~36 GB image; tokenspeed kernel build is the long pole).
- [x] `docker push <registry>/dynamo-tokenspeed:dev` to nvcr.io/nvstaging.
- [x] On a B200 cluster, after applying `deploy.yaml`, all four Deployments reach Ready; worker loads weights + cudagraph captures within ~7 minutes.
- [x] `/v1/completions` with a raw prompt returns useful tokens (verified: 35-token continuation of "The capital of France is Paris...").
- [x] `/v1/chat/completions` with `chat_template_kwargs: {thinking: true}` + `skip_special_tokens: false` returns full reasoning + content (verified: 133-token response on "hello", byte-for-byte matching upstream `tokenspeed serve`).