### PR TITLE
fix(preprocessor): preserve special tokens for kimi_k2 / kimi_k25 parsers

### DIFF
--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -1280,15 +1280,22 @@ impl OpenAIPreprocessor {
         tool_call_parser: Option<&str>,
         reasoning_parser: Option<&str>,
     ) -> bool {
-        // gpt-oss / harmony parsers consume `<|channel|>analysis<|message|>...<|end|>`
-        // markers; without them the parser silently produces empty
-        // reasoning_content. Same shape as gemma4's `<|think|>` markers.
+        // Parsers in this allow-list match against special tokens that the
+        // tokenizer would otherwise strip when `skip_special_tokens=true`
+        // (the OpenAI-API default). Without the tokens preserved through
+        // decode the parsers silently produce empty reasoning_content /
+        // tool_calls.
+        //
+        // - gemma4: `<|think|>` markers (reasoning + tool-call).
+        // - harmony / gpt_oss: `<|channel|>analysis<|message|>...<|end|>`.
+        // - kimi_k2: `<|tool_calls_section_begin|>` / `<|tool_calls_section_end|>`.
+        // - kimi_k25: `</think>` (special token id 163607).
         matches!(
             tool_call_parser,
-            Some("gemma4") | Some("gemma-4") | Some("harmony")
+            Some("gemma4") | Some("gemma-4") | Some("harmony") | Some("kimi_k2")
         ) || matches!(
             reasoning_parser,
-            Some("gemma4") | Some("gemma-4") | Some("gpt_oss")
+            Some("gemma4") | Some("gemma-4") | Some("gpt_oss") | Some("kimi_k25")
         )
     }
 
@@ -1889,8 +1896,24 @@ mod tests {
             (
                 Some("kimi_k2"),
                 Some("kimi_k25"),
-                false,
-                "kimi_k2 paired → not required",
+                true,
+                "kimi_k2 + kimi_k25 paired → required \
+                 (tool-call markers `<|tool_calls_section_*|>` and reasoning \
+                  marker `</think>` are special tokens that get stripped under \
+                  the default skip_special_tokens=true)",
+            ),
+            (
+                None,
+                Some("kimi_k25"),
+                true,
+                "kimi_k25 reasoning only → required (`</think>` is special token id 163607)",
+            ),
+            (
+                Some("kimi_k2"),
+                None,
+                true,
+                "kimi_k2 tool-call only → required \
+                 (`<|tool_calls_section_begin|>` / `<|tool_calls_section_end|>` are special)",
             ),
             (None, None, false, "no parsers → not required"),
         ];


### PR DESCRIPTION
#### Overview:

Add `kimi_k2` (tool-call) and `kimi_k25` (reasoning) to `parser_requires_special_tokens` so the tokenizer keeps the markers their text-based parsers depend on.

Empirically reported by William Arnold on Slack (2026-05-06): Kimi K2.5 chat completions return `content: null` and stuff the entire reply into `reasoning_content` because `</think>` (id 163607) is stripped by the default `skip_special_tokens=true`. Setting `skip_special_tokens: false` per request restores correct splitting; this PR makes that the default whenever the kimi parsers are configured.

#### Details:

- Add `kimi_k2` to the tool-call branch — `<|tool_calls_section_begin|>` / `<|tool_calls_section_end|>` survive decode
- Add `kimi_k25` to the reasoning branch — `</think>` (special token id 163607) survives decode
- Update the doc comment to enumerate every entry's marker (gemma4, harmony/gpt_oss, kimi_k2, kimi_k25)
- Flip the existing `(kimi_k2, kimi_k25)` row in `test_parser_requires_special_tokens` from `false` to `true` so the regression actually asserts the correct policy
- Add `(None, kimi_k25)` and `(kimi_k2, None)` rows to cover reasoning-only and tool-call-only configurations

The default value of `skip_special_tokens` is unchanged (still `true` globally); the allow-list flips the per-request default to `false` only when a kimi parser is configured. Caller-supplied values still win.

#### Reproduction:

Run a Kimi K2.5 frontend with `--dyn-reasoning-parser kimi_k25 --dyn-tool-call-parser kimi_k2`.

**What we did** — request with the API default `skip_special_tokens=true`:

```bash
curl -s -m 240 -X POST http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "kimi-k2.5",
    "messages": [{"role":"user","content":"hello"}],
    "max_tokens": 300,
    "chat_template_kwargs": {"thinking": true}
  }'
```

**What we expected:** `reasoning_content` populated with thinking, `content` populated with the visible reply.

**What we saw (bug):** `content: null`, the visible reply concatenated to the end of `reasoning_content`. `</think>` (id 163607) is stripped before the reasoning parser sees it, the parser stays in thinking mode, no boundary, no content.

**Confirmation** — same request with `skip_special_tokens: false` splits correctly. This PR removes the need for the per-request workaround.

#### Root cause + follow-up (this PR is a workaround):

The deeper bug is in `load_special_tokens` at `lib/tokenizers/src/tiktoken.rs:206-218` — it inserts every `added_tokens_decoder` entry into the tiktoken special-token set without checking the `"special": true/false` field. So tokens HF declared `special: false` (Kimi `</think>` id 163607) get stripped under `skip_special_tokens=true` anyway, despite the metadata. Empirical Rust repro confirms `decode([163607], skip_special=true) = ""` while the JSON declares `special: false`.

Proper fix is to gate the insertion on `token_def["special"] == true` so the wrapper honors the declared metadata. Not done in this PR — it changes runtime behavior for every model loaded via `TikTokenTokenizer` and needs per-model verification first. Tracked separately so the follow-up doesn't get lost behind this workaround.

#### Verification:

`cargo test -p dynamo-llm --lib test_parser_requires_special_tokens` — passes with this change.

#### Where should the reviewer start?

`lib/llm/src/preprocessor.rs`

#### Related Issues:

Closes [DIS-1935](https://linear.app/nvidia/issue/DIS-1935)

/coderabbit profile chill