### PR TITLE
fix(vllm): use main attention KV event block size

### DIFF
--- a/components/src/dynamo/vllm/cache_info.py
+++ b/components/src/dynamo/vllm/cache_info.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+from typing import Any
+
+from vllm.config import VllmConfig
+from vllm.v1.engine.async_llm import AsyncLLM
+
+logger = logging.getLogger(__name__)
+
+DYNAMO_KV_EVENT_BLOCK_SIZE_KEY = "dynamo_kv_event_block_size"
+MAIN_ATTENTION_KV_CACHE_KINDS = {
+    "full_attention",
+    "mla_attention",
+    "sink_full_attention",
+}
+
+
+def get_configured_kv_event_block_size(vllm_config: VllmConfig) -> int:
+    additional_config = vllm_config.additional_config or {}
+    return additional_config.get(
+        DYNAMO_KV_EVENT_BLOCK_SIZE_KEY,
+        vllm_config.cache_config.block_size,
+    )
+
+
+def select_main_attention_block_size(
+    group_metadata: list[dict[str, Any]],
+    fallback_block_size: int,
+) -> int:
+    if not group_metadata:
+        return fallback_block_size
+
+    fallback = group_metadata[0].get("block_size", fallback_block_size)
+    for group in group_metadata:
+        if group.get("kind") in MAIN_ATTENTION_KV_CACHE_KINDS:
+            return group.get("block_size", fallback_block_size)
+
+    return fallback
+
+
+async def configure_kv_event_block_size(
+    engine: AsyncLLM,
+    vllm_config: VllmConfig,
+) -> int:
+    fallback_block_size = vllm_config.cache_config.block_size
+    try:
+        group_metadata = await engine.engine_core.call_utility_async(
+            "get_kv_cache_group_metadata"
+        )
+        kv_event_block_size = select_main_attention_block_size(
+            group_metadata,
+            fallback_block_size,
+        )
+    except Exception:
+        logger.exception(
+            "Failed to resolve main-attention KV event block size; "
+            "falling back to vLLM cache_config.block_size"
+        )
+        kv_event_block_size = fallback_block_size
+
+    vllm_config.additional_config[DYNAMO_KV_EVENT_BLOCK_SIZE_KEY] = kv_event_block_size
+    logger.info(
+        "Resolved Dynamo KV event block size: scheduler_block_size=%s, "
+        "kv_event_block_size=%s",
+        fallback_block_size,
+        kv_event_block_size,
+    )
+    return kv_event_block_size

--- a/components/src/dynamo/vllm/cache_info.py
+++ b/components/src/dynamo/vllm/cache_info.py
@@ -18,6 +18,7 @@ MAIN_ATTENTION_KV_CACHE_KINDS = {
 
 
 def get_configured_kv_event_block_size(vllm_config: VllmConfig) -> int:
+    """Return the configured KV event block size, falling back to vLLM's cache block size."""
     additional_config = vllm_config.additional_config or {}
     return additional_config.get(
         DYNAMO_KV_EVENT_BLOCK_SIZE_KEY,
@@ -29,42 +30,40 @@ def select_main_attention_block_size(
     group_metadata: list[dict[str, Any]],
     fallback_block_size: int,
 ) -> int:
+    """Select the main-attention KV block size from engine cache-group metadata."""
     if not group_metadata:
         return fallback_block_size
 
-    fallback = group_metadata[0].get("block_size", fallback_block_size)
     for group in group_metadata:
         if group.get("kind") in MAIN_ATTENTION_KV_CACHE_KINDS:
             return group.get("block_size", fallback_block_size)
 
-    return fallback
+    return fallback_block_size
 
 
 async def configure_kv_event_block_size(
     engine: AsyncLLM,
     vllm_config: VllmConfig,
 ) -> int:
+    """Fetch engine cache-group metadata and cache the KV event block size on vLLM config."""
     fallback_block_size = vllm_config.cache_config.block_size
     try:
         group_metadata = await engine.engine_core.call_utility_async(
             "get_kv_cache_group_metadata"
         )
+    except Exception:
+        logger.exception(
+            "Failed to fetch KV cache group metadata; "
+            "falling back to vLLM cache_config.block_size"
+        )
+        kv_event_block_size = fallback_block_size
+    else:
         kv_event_block_size = select_main_attention_block_size(
             group_metadata,
             fallback_block_size,
         )
-    except Exception:
-        logger.exception(
-            "Failed to resolve main-attention KV event block size; "
-            "falling back to vLLM cache_config.block_size"
-        )
-        kv_event_block_size = fallback_block_size
 
+    if vllm_config.additional_config is None:
+        vllm_config.additional_config = {}
     vllm_config.additional_config[DYNAMO_KV_EVENT_BLOCK_SIZE_KEY] = kv_event_block_size
-    logger.info(
-        "Resolved Dynamo KV event block size: scheduler_block_size=%s, "
-        "kv_event_block_size=%s",
-        fallback_block_size,
-        kv_event_block_size,
-    )
     return kv_event_block_size

--- a/components/src/dynamo/vllm/cache_info.py
+++ b/components/src/dynamo/vllm/cache_info.py
@@ -51,10 +51,11 @@ async def configure_kv_event_block_size(
         group_metadata = await engine.engine_core.call_utility_async(
             "get_kv_cache_group_metadata"
         )
-    except Exception:
-        logger.exception(
-            "Failed to fetch KV cache group metadata; "
-            "falling back to vLLM cache_config.block_size"
+    except Exception as e:
+        logger.warning(
+            "Failed to fetch KV cache group metadata; falling back to "
+            "vLLM cache_config.block_size: %s",
+            e,
         )
         kv_event_block_size = fallback_block_size
     else:

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -703,7 +703,7 @@ async def register_vllm_model(
 
 
 def get_engine_cache_info(engine: AsyncLLM) -> dict[str, Any]:
-    """Retrieve cache configuration information from [`AsyncLLM`] engine."""
+    """Return vLLM cache and scheduler limits used for model registration."""
 
     try:
         # Get values directly from vllm_config instead of collective_rpc
@@ -719,8 +719,8 @@ def get_engine_cache_info(engine: AsyncLLM) -> dict[str, Any]:
             "max_num_batched_tokens": engine.vllm_config.scheduler_config.max_num_batched_tokens,
         }
 
-        logging.info(f"Cache config values: {cache_values}")
-        logging.info(f"Scheduler config values: {scheduler_values}")
+        logging.debug(f"Cache config values: {cache_values}")
+        logging.debug(f"Scheduler config values: {scheduler_values}")
         return {
             "num_gpu_blocks": cache_values["num_gpu_blocks"],
             "block_size": cache_values["block_size"],

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -41,6 +41,7 @@ from dynamo.vllm.worker_factory import WorkerFactory
 
 from . import envs
 from .args import Config, _uses_dynamo_connector, parse_args
+from .cache_info import get_configured_kv_event_block_size
 from .constants import DisaggregationMode
 from .handlers import get_dp_range_for_worker
 from .publisher import DYNAMO_COMPONENT_REGISTRY, StatLoggerFactory
@@ -333,6 +334,7 @@ def setup_kv_event_publisher(
     # all served workers should cover all ranks.
     dp_start, dp_size = get_dp_range_for_worker(vllm_config)
     kv_publishers = []
+    kv_event_block_size = get_configured_kv_event_block_size(vllm_config)
 
     for dp_rank in range(dp_start, dp_start + dp_size):
         if consolidator_enabled:
@@ -353,7 +355,7 @@ def setup_kv_event_publisher(
 
         kv_publisher = KvEventPublisher(
             endpoint=generate_endpoint,
-            kv_block_size=vllm_config.cache_config.block_size,
+            kv_block_size=kv_event_block_size,
             zmq_endpoint=zmq_endpoint,
             zmq_topic="",
             enable_local_indexer=config.enable_local_indexer,
@@ -692,7 +694,7 @@ async def register_vllm_model(
         config.model,
         config.served_model_name,
         context_length=vllm_config.model_config.max_model_len,
-        kv_cache_block_size=runtime_values["block_size"],
+        kv_cache_block_size=runtime_values["kv_event_block_size"],
         runtime_config=runtime_config,
         custom_template_path=config.custom_jinja_template,
         media_decoder=media_decoder,
@@ -705,9 +707,11 @@ def get_engine_cache_info(engine: AsyncLLM) -> dict[str, Any]:
 
     try:
         # Get values directly from vllm_config instead of collective_rpc
+        kv_event_block_size = get_configured_kv_event_block_size(engine.vllm_config)
         cache_values = {
             "num_gpu_blocks": engine.vllm_config.cache_config.num_gpu_blocks,
             "block_size": engine.vllm_config.cache_config.block_size,
+            "kv_event_block_size": kv_event_block_size,
         }
 
         scheduler_values = {
@@ -720,6 +724,7 @@ def get_engine_cache_info(engine: AsyncLLM) -> dict[str, Any]:
         return {
             "num_gpu_blocks": cache_values["num_gpu_blocks"],
             "block_size": cache_values["block_size"],
+            "kv_event_block_size": cache_values["kv_event_block_size"],
             "max_num_seqs": scheduler_values["max_num_seqs"],
             "max_num_batched_tokens": scheduler_values["max_num_batched_tokens"],
         }

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -25,6 +25,7 @@ from dynamo.llm import ModelInput, ModelType
 from dynamo.runtime import DistributedRuntime
 
 from .args import Config
+from .cache_info import configure_kv_event_block_size
 from .constants import DisaggregationMode
 from .handlers import (
     BaseWorkerHandler,
@@ -296,6 +297,7 @@ class WorkerFactory:
                 prometheus_temp_dir,
                 component_gauges,
             ) = self.setup_vllm_engine(config, factory, fpm_worker_id=fpm_worker_id)
+        await configure_kv_event_block_size(engine_client, vllm_config)
 
         # TODO Hack to get data, move this to registering in TBD
         factory.set_num_gpu_blocks_all(vllm_config.cache_config.num_gpu_blocks)
@@ -513,6 +515,7 @@ class WorkerFactory:
                 prometheus_temp_dir,
                 _component_gauges,
             ) = self.setup_vllm_engine(config, fpm_worker_id=fpm_worker_id)
+        await configure_kv_event_block_size(engine_client, vllm_config)
 
         encode_worker_client = await self._maybe_get_encode_worker_client(
             runtime, config

--- a/lib/kv-router/src/zmq_wire/mod.rs
+++ b/lib/kv-router/src/zmq_wire/mod.rs
@@ -73,26 +73,7 @@ impl ZmqEventNormalizer {
         if matches!(raw, RawKvEvent::BlockStored { .. }) {
             self.learn_metadata(metadata, worker.dp_rank);
         }
-        let event_type = match &raw {
-            RawKvEvent::BlockStored { .. } => "stored",
-            RawKvEvent::BlockRemoved { .. } => "removed",
-            RawKvEvent::AllBlocksCleared => "cleared",
-            RawKvEvent::Ignored => "ignored",
-        };
-
-        let accepted = self.should_accept(metadata, worker.dp_rank);
-        tracing::info!(
-            target: "kv_event_debug",
-            event_type,
-            worker_id = worker.worker_id,
-            dp_rank = worker.dp_rank,
-            group_idx = ?metadata.group_idx,
-            kind = ?metadata.kv_cache_spec_kind,
-            sliding_window = ?metadata.kv_cache_spec_sliding_window,
-            accepted,
-            "kv_event_preprocess"
-        );
-        accepted.then_some(raw)
+        self.should_accept(metadata, worker.dp_rank).then_some(raw)
     }
 
     pub fn normalize_preprocessed(

--- a/lib/kv-router/src/zmq_wire/mod.rs
+++ b/lib/kv-router/src/zmq_wire/mod.rs
@@ -73,7 +73,26 @@ impl ZmqEventNormalizer {
         if matches!(raw, RawKvEvent::BlockStored { .. }) {
             self.learn_metadata(metadata, worker.dp_rank);
         }
-        self.should_accept(metadata, worker.dp_rank).then_some(raw)
+        let event_type = match &raw {
+            RawKvEvent::BlockStored { .. } => "stored",
+            RawKvEvent::BlockRemoved { .. } => "removed",
+            RawKvEvent::AllBlocksCleared => "cleared",
+            RawKvEvent::Ignored => "ignored",
+        };
+
+        let accepted = self.should_accept(metadata, worker.dp_rank);
+        tracing::info!(
+            target: "kv_event_debug",
+            event_type,
+            worker_id = worker.worker_id,
+            dp_rank = worker.dp_rank,
+            group_idx = ?metadata.group_idx,
+            kind = ?metadata.kv_cache_spec_kind,
+            sliding_window = ?metadata.kv_cache_spec_sliding_window,
+            accepted,
+            "kv_event_preprocess"
+        );
+        accepted.then_some(raw)
     }
 
     pub fn normalize_preprocessed(


### PR DESCRIPTION
Resolve the Dynamo KV event block size from vLLM's main-attention KV cache group metadata, then use that value for KV event relay conversion and model registration. This keeps hybrid Nemotron-style events aligned with the router/indexer block size instead of falling back to cache_config.block_size.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable KV cache event block sizing for vLLM integration, enabling optimized cache event handling.

* **Chores**
  * Enhanced diagnostic logging for KV event processing to improve observability of cache operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->