### PR TITLE
fix(helm): consolidate NATS config to single global.nats.install flag

### DIFF
--- a/deploy/helm/charts/platform/Chart.yaml
+++ b/deploy/helm/charts/platform/Chart.yaml
@@ -29,7 +29,7 @@ dependencies:
   - name: nats
     version: 1.3.2
     repository: https://nats-io.github.io/k8s/helm/charts/
-    condition: nats.enabled
+    condition: global.nats.install
   - name: etcd
     version: 12.0.18
     repository: "https://charts.bitnami.com/bitnami"

--- a/deploy/helm/charts/platform/README.md
+++ b/deploy/helm/charts/platform/README.md
@@ -108,6 +108,7 @@ The chart includes built-in validation to prevent all operator conflicts:
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | global.etcd.install | bool | `false` | Whether this chart should install the bundled etcd subchart. When true, deploys etcd and auto-configures the operator with its address. When false, etcd is not deployed. Use dynamo-operator.etcdAddr to point at an external instance if you are bringing your own etcd. |
+| global.nats.install | bool | `true` | Whether this chart should install the bundled NATS subchart. When true, deploys NATS and auto-configures the operator with its address. When false, NATS is not deployed. Use dynamo-operator.natsAddr to point at an external instance if you are bringing your own NATS. |
 | global.kai-scheduler.install | bool | `false` | Whether this chart should install the bundled kai-scheduler subchart. When true, deploys kai-scheduler and its CRDs. Integration is automatically enabled. NOTE: For production environments, it is recommended to install kai-scheduler separately. |
 | global.kai-scheduler.enabled | bool | `false` | Whether to enable Kai Scheduler integration (queue creation, schedulerName injection). Set to true when kai-scheduler is available in the cluster (installed externally). Automatically enabled when install=true. The operator uses this to decide whether to inject schedulerName and queue labels into pod templates. |
 | global.grove.install | bool | `false` | Whether this chart should install the bundled Grove subchart. When true, deploys the Grove operator cluster-wide. Integration is automatically enabled. NOTE: For production environments, it is recommended to install Grove separately. |
@@ -116,7 +117,6 @@ The chart includes built-in validation to prevent all operator conflicts:
 | dynamo-operator.upgradeCRD | bool | `true` | Whether to manage CRDs via a pre-install/pre-upgrade hook Job. The Job runs the operator image with the crd-apply tool to apply CRDs via server-side apply. |
 | dynamo-operator.natsAddr | string | `""` | NATS server address for operator communication (leave empty to use the bundled NATS chart). Format: "nats://hostname:port" |
 | dynamo-operator.etcdAddr | string | `""` | etcd server address for an external etcd instance. Only needed when using external etcd without the bundled subchart. Format: "http://hostname:port" or "https://hostname:port" |
-| dynamo-operator.nats.enabled | bool | `true` | Whether the NATS is enabled |
 | dynamo-operator.modelExpressURL | string | `""` | URL for the Model Express server if not deployed by this helm chart. This is ignored if Model Express server is installed by this helm chart (global.model-express.enabled is true). |
 | dynamo-operator.namespaceRestriction | object | `{"enabled":false,"lease":{"duration":"30s","renewInterval":"10s"},"targetNamespace":null}` | DEPRECATED: Namespace-restricted mode is deprecated and will be removed in a future release. Use cluster-wide mode (the default) instead. Do not enable this for new deployments. |
 | dynamo-operator.namespaceRestriction.enabled | bool | `false` | DEPRECATED: Do not enable for new deployments. Namespace-restricted mode is deprecated. |
@@ -174,7 +174,6 @@ The chart includes built-in validation to prevent all operator conflicts:
 | kai-scheduler.global.tolerations | list | `[]` | Node tolerations for kai-scheduler pods |
 | kai-scheduler.global.affinity | object | `{}` | Affinity for kai-scheduler pods |
 | etcd.image.repository | string | `"bitnamilegacy/etcd"` | following bitnami announcement for brownout - https://github.com/bitnami/charts/tree/main/bitnami/etcd#%EF%B8%8F-important-notice-upcoming-changes-to-the-bitnami-catalog, we need to use the legacy repository until we migrate to the new "secure" repository |
-| nats.enabled | bool | `true` | Whether to enable NATS deployment, disable if you want to use an external NATS instance. For complete configuration options, see: https://github.com/nats-io/k8s/tree/main/helm/charts/nats , all nats settings should be prefixed with "nats." |
 
 ### NATS Configuration
 

--- a/deploy/helm/charts/platform/components/operator/templates/operator-config.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/operator-config.yaml
@@ -65,7 +65,7 @@ data:
     {{- $natsAddr := "" }}
     {{- if .Values.natsAddr }}
       {{- $natsAddr = .Values.natsAddr }}
-    {{- else if and .Values.nats .Values.nats.enabled }}
+    {{- else if and .Values.global .Values.global.nats .Values.global.nats.install }}
       {{- $natsAddr = printf "nats://%s-nats.%s.svc.cluster.local:4222" .Release.Name .Release.Namespace }}
     {{- end }}
     {{- $etcdAddr := "" }}

--- a/deploy/helm/charts/platform/components/operator/templates/validate-values.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/validate-values.yaml
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{/*
+  Validate that removed/renamed dynamo-operator values are not present.
+  These values are set via 'dynamo-operator.<key>' in the parent chart.
+  Each check detects an old value path and fails with a migration message.
+*/}}
+
+{{/* ---- NATS toggle (moved to global.nats.install) ---- */}}
+
+{{- if and (hasKey .Values "nats") (hasKey .Values.nats "enabled") }}
+  {{- fail `
+BREAKING CHANGE: 'dynamo-operator.nats.enabled' has been removed.
+Use 'global.nats.install' instead.
+
+Before:
+  dynamo-operator:
+    nats:
+      enabled: false
+
+After:
+  global:
+    nats:
+      install: false
+` }}
+{{- end }}
+
+{{/* ---- Webhook enabled toggle (removed, webhooks are always enabled) ---- */}}
+
+{{- if and (hasKey .Values "webhook") (hasKey .Values.webhook "enabled") }}
+  {{- fail `
+BREAKING CHANGE: 'dynamo-operator.webhook.enabled' has been removed.
+Webhooks are now always enabled and cannot be disabled.
+Remove the 'dynamo-operator.webhook.enabled' field from your values.yaml.
+` }}
+{{- end }}
+
+{{/* ---- Webhook certificate generator (removed, replaced by built-in cert-controller) ---- */}}
+
+{{- if and (hasKey .Values "webhook") (hasKey .Values.webhook "certGenerator") }}
+  {{- fail `
+BREAKING CHANGE: 'dynamo-operator.webhook.certGenerator' has been removed.
+The operator now has a built-in cert-controller that generates and rotates
+webhook certificates automatically. Remove 'dynamo-operator.webhook.certGenerator'
+from your values.yaml.
+
+For external certificate management, use:
+  dynamo-operator:
+    webhook:
+      certificateSecret:
+        external: true
+` }}
+{{- end }}
+
+{{- if and (hasKey .Values "webhook") (hasKey .Values.webhook "certificateValidity") }}
+  {{- fail `
+BREAKING CHANGE: 'dynamo-operator.webhook.certificateValidity' has been removed.
+The operator's built-in cert-controller manages certificate lifecycle automatically.
+Remove 'dynamo-operator.webhook.certificateValidity' from your values.yaml.
+` }}
+{{- end }}
+
+{{/* ---- MPI SSH keygen toggle (removed, now handled by operator reconciliation) ---- */}}
+
+{{- if and (hasKey .Values "dynamo") (hasKey .Values.dynamo "mpiRun") (hasKey .Values.dynamo.mpiRun "sshKeygen") }}
+  {{- fail `
+BREAKING CHANGE: 'dynamo-operator.dynamo.mpiRun.sshKeygen' has been removed.
+SSH key generation is now handled automatically by the operator during reconciliation.
+Remove 'dynamo-operator.dynamo.mpiRun.sshKeygen' from your values.yaml.
+The 'dynamo-operator.dynamo.mpiRun.secretName' field is still supported.
+` }}
+{{- end }}
+
+{{/* ---- Checkpoint storage config (removed, moved to snapshot chart) ---- */}}
+
+{{- if and (hasKey .Values "checkpoint") (hasKey .Values.checkpoint "storage") }}
+  {{- fail `
+BREAKING CHANGE: 'dynamo-operator.checkpoint.storage' has been removed.
+Checkpoint storage is now configured via the snapshot Helm chart, not the operator.
+Remove 'dynamo-operator.checkpoint.storage' from your values.yaml.
+` }}
+{{- end }}
+
+{{- if and (hasKey .Values "checkpoint") (hasKey .Values.checkpoint "readyForCheckpointFilePath") }}
+  {{- fail `
+BREAKING CHANGE: 'dynamo-operator.checkpoint.readyForCheckpointFilePath' has been removed.
+Checkpoint lifecycle is now managed via file-based sentinels in DYN_SNAPSHOT_CONTROL_DIR.
+Remove 'dynamo-operator.checkpoint.readyForCheckpointFilePath' from your values.yaml.
+` }}
+{{- end }}
+
+{{/* ---- Debug/internal images (removed) ---- */}}
+
+{{- if and (hasKey .Values "dynamo") (hasKey .Values.dynamo "internalImages") }}
+  {{- fail `
+BREAKING CHANGE: 'dynamo-operator.dynamo.internalImages' has been removed.
+Remove 'dynamo-operator.dynamo.internalImages' from your values.yaml.
+` }}
+{{- end }}
+
+{{- if and (hasKey .Values "dynamo") (hasKey .Values.dynamo "enableRestrictedSecurityContext") }}
+  {{- fail `
+BREAKING CHANGE: 'dynamo-operator.dynamo.enableRestrictedSecurityContext' has been removed.
+Remove 'dynamo-operator.dynamo.enableRestrictedSecurityContext' from your values.yaml.
+` }}
+{{- end }}

--- a/deploy/helm/charts/platform/components/operator/values.yaml
+++ b/deploy/helm/charts/platform/components/operator/values.yaml
@@ -126,10 +126,6 @@ metricsService:
 natsAddr: ""
 etcdAddr: ""
 
-nats:
-  # Whether the NATS is enabled
-  enabled: true
-
 modelExpressURL: ""
 
 # Checkpoint configuration for fast pod restore

--- a/deploy/helm/charts/platform/templates/validate-values.yaml
+++ b/deploy/helm/charts/platform/templates/validate-values.yaml
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{/*
+  Validate that removed/renamed values are not present in the user's values.yaml.
+  Each check detects an old value path and fails with a migration message.
+*/}}
+
+{{/* ---- Subchart toggle migrations (moved to global.*) ---- */}}
+
+{{- if and (hasKey .Values "nats") (hasKey .Values.nats "enabled") }}
+  {{- fail `
+BREAKING CHANGE: 'nats.enabled' has been removed.
+Use 'global.nats.install' instead to control NATS subchart installation.
+
+Before:
+  nats:
+    enabled: false
+
+After:
+  global:
+    nats:
+      install: false
+` }}
+{{- end }}
+
+{{- if and (hasKey .Values "etcd") (hasKey .Values.etcd "enabled") }}
+  {{- fail `
+BREAKING CHANGE: 'etcd.enabled' has been removed.
+Use 'global.etcd.install' instead to control etcd subchart installation.
+
+Before:
+  etcd:
+    enabled: false
+
+After:
+  global:
+    etcd:
+      install: false
+` }}
+{{- end }}
+
+{{- if and (hasKey .Values "grove") (hasKey .Values.grove "enabled") }}
+  {{- fail `
+BREAKING CHANGE: 'grove.enabled' has been removed.
+Use 'global.grove.install' to control Grove subchart installation
+and 'global.grove.enabled' to enable Grove integration.
+
+Before:
+  grove:
+    enabled: true
+
+After:
+  global:
+    grove:
+      install: true   # deploys the Grove operator
+      enabled: true   # enables integration (auto-set when install=true)
+` }}
+{{- end }}
+
+{{- if and (hasKey .Values "kai-scheduler") (hasKey (index .Values "kai-scheduler") "enabled") }}
+  {{- fail `
+BREAKING CHANGE: 'kai-scheduler.enabled' has been removed.
+Use 'global.kai-scheduler.install' to control kai-scheduler subchart installation
+and 'global.kai-scheduler.enabled' to enable kai-scheduler integration.
+
+Before:
+  kai-scheduler:
+    enabled: true
+
+After:
+  global:
+    kai-scheduler:
+      install: true   # deploys kai-scheduler
+      enabled: true   # enables integration (auto-set when install=true)
+` }}
+{{- end }}
+
+{{/*
+  NOTE: dynamo-operator subchart values (e.g. dynamo-operator.nats.enabled,
+  dynamo-operator.webhook.enabled) are validated in the operator subchart's
+  own validate-values.yaml. They cannot be reliably checked here because
+  the parent chart sees merged values (subchart defaults + user overrides),
+  making it impossible to distinguish user-set values from subchart defaults.
+*/}}

--- a/deploy/helm/charts/platform/values.yaml
+++ b/deploy/helm/charts/platform/values.yaml
@@ -21,6 +21,12 @@ global:
     # When false, etcd is not deployed. Use dynamo-operator.etcdAddr to point at an external instance if you are bringing your own etcd.
     install: false
 
+  nats:
+    # -- Whether this chart should install the bundled NATS subchart.
+    # When true, deploys NATS and auto-configures the operator with its address.
+    # When false, NATS is not deployed. Use dynamo-operator.natsAddr to point at an external instance if you are bringing your own NATS.
+    install: true
+
   kai-scheduler:
     # -- Whether this chart should install the bundled kai-scheduler subchart.
     # When true, deploys kai-scheduler and its CRDs. Integration is automatically enabled.
@@ -62,10 +68,6 @@ dynamo-operator:
 
   # -- etcd server address for an external etcd instance. Only needed when using external etcd without the bundled subchart. Format: "http://hostname:port" or "https://hostname:port"
   etcdAddr: ""
-
-  nats:
-    # -- Whether the NATS is enabled
-    enabled: true
 
   # -- URL for the Model Express server if not deployed by this helm chart. This is ignored if Model Express server is installed by this helm chart (global.model-express.enabled is true).
   modelExpressURL: ""
@@ -316,10 +318,8 @@ etcd:
   affinity: {}
 
 # NATS configuration - messaging system for operator communication
+# Installation is controlled by global.nats.install above.
 nats:
-  # -- Whether to enable NATS deployment, disable if you want to use an external NATS instance. For complete configuration options, see: https://github.com/nats-io/k8s/tree/main/helm/charts/nats , all nats settings should be prefixed with "nats."
-  enabled: true
-
   # TLS Certificate Authority configuration for secure communication
   # Reference a common CA Certificate or Bundle in all nats config `tls` blocks and nats-box contexts
   # Note: `tls.verify` still must be set in the appropriate nats config `tls` blocks to require mTLS


### PR DESCRIPTION
#### Overview:

NATS subchart installation and operator config generation were controlled by two independent Helm values (`nats.enabled` and `dynamo-operator.nats.enabled`) that could silently get out of sync. Setting only one led to broken states: either NATS deployed but unused, or the operator injecting `NATS_SERVER` pointing at a non-existent service. This consolidates to a single `global.nats.install` flag, matching the pattern already used by etcd (`global.etcd.install`).

Also adds validation templates that detect stale values.yaml overrides from previous chart versions (not just NATS — covers all historically removed/renamed values) and fail with actionable migration messages at `helm install`/`helm template` time.

#### Details:

**NATS consolidation:**
- `deploy/helm/charts/platform/Chart.yaml` — Changed NATS subchart condition from `nats.enabled` to `global.nats.install`
- `deploy/helm/charts/platform/values.yaml` — Added `global.nats.install: true` with documentation matching the etcd pattern; removed the now-redundant `nats.enabled` from the top-level `nats:` block and `dynamo-operator.nats.enabled` passthrough
- `deploy/helm/charts/platform/components/operator/values.yaml` — Removed `nats.enabled` (no longer needed; the operator template now reads from `global`)
- `deploy/helm/charts/platform/components/operator/templates/operator-config.yaml` — Updated NATS address auto-generation to check `.Values.global.nats.install` instead of `.Values.nats.enabled`

**Validation templates (breaking change guards):**
- `deploy/helm/charts/platform/templates/validate-values.yaml` — Platform-level checks for removed subchart toggles: `nats.enabled`, `etcd.enabled`, `grove.enabled`, `kai-scheduler.enabled`
- `deploy/helm/charts/platform/components/operator/templates/validate-values.yaml` — Operator-level checks for removed values: `nats.enabled`, `webhook.enabled`, `webhook.certGenerator`, `webhook.certificateValidity`, `dynamo.mpiRun.sshKeygen`, `checkpoint.storage`, `checkpoint.readyForCheckpointFilePath`, `dynamo.internalImages`, `dynamo.enableRestrictedSecurityContext`

**Generated docs:**
- `deploy/helm/charts/platform/README.md` — Regenerated via `make generate-helm-docs` to reflect the values.yaml changes

#### Where should the reviewer start?

`deploy/helm/charts/platform/values.yaml` — shows the new `global.nats.install` flag and the removal of the two old independent values. Then `deploy/helm/charts/platform/templates/validate-values.yaml` for the breaking change guards.

#### Related Issues:

- Closes DEP-921
- Relates to https://github.com/ai-dynamo/dynamo/issues/9229