### PR TITLE
feat(kv-router): add ZMQ KV relay metrics

### DIFF
--- a/lib/bindings/python/src/dynamo/prometheus_names.py
+++ b/lib/bindings/python/src/dynamo/prometheus_names.py
@@ -161,6 +161,12 @@ class kv_publisher:
 
     # Total number of raw events dropped by engines before reaching publisher (detected via event_id gaps)
     ENGINES_DROPPED_EVENTS_TOTAL = "kv_publisher_engines_dropped_events_total"
+    # Total number of ZMQ KV events seen by the relay, labeled by stage and event type
+    ZMQ_EVENTS_TOTAL = "kv_publisher_zmq_events_total"
+    # Total number of ZMQ KV events filtered before conversion, labeled by event type and reason
+    ZMQ_FILTERED_EVENTS_TOTAL = "kv_publisher_zmq_filtered_events_total"
+    # Total number of ZMQ KV events with conversion issues, labeled by event type and reason
+    ZMQ_CONVERSION_ISSUES_TOTAL = "kv_publisher_zmq_conversion_issues_total"
 
 
 class kvbm:

--- a/lib/bindings/python/src/dynamo/prometheus_names.py
+++ b/lib/bindings/python/src/dynamo/prometheus_names.py
@@ -165,8 +165,10 @@ class kv_publisher:
     ZMQ_EVENTS_TOTAL = "kv_publisher_zmq_events_total"
     # Total number of ZMQ KV events filtered before conversion, labeled by event type and reason
     ZMQ_FILTERED_EVENTS_TOTAL = "kv_publisher_zmq_filtered_events_total"
-    # Total number of ZMQ KV events with conversion issues, labeled by event type and reason
+    # Total number of ZMQ KV events dropped due to conversion issues, labeled by event type and reason
     ZMQ_CONVERSION_ISSUES_TOTAL = "kv_publisher_zmq_conversion_issues_total"
+    # Total number of suspicious-but-forwarded ZMQ KV events, labeled by event type and reason
+    ZMQ_SUSPICIOUS_EVENTS_TOTAL = "kv_publisher_zmq_suspicious_events_total"
 
 
 class kvbm:

--- a/lib/kv-router/src/zmq_wire/mod.rs
+++ b/lib/kv-router/src/zmq_wire/mod.rs
@@ -47,6 +47,27 @@ struct KvCacheGroupMetadata {
     sliding_window: Option<u32>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ZmqEventFilterReason {
+    IgnoredEvent,
+    NonMainAttentionKind,
+    UnknownKind,
+    NonMainAttentionGroup,
+    UnlearnedGroupIdx,
+}
+
+impl ZmqEventFilterReason {
+    pub fn as_label(self) -> &'static str {
+        match self {
+            Self::IgnoredEvent => "ignored_event",
+            Self::NonMainAttentionKind => "non_main_attention_kind",
+            Self::UnknownKind => "unknown_kind",
+            Self::NonMainAttentionGroup => "non_main_attention_group",
+            Self::UnlearnedGroupIdx => "unlearned_group_idx",
+        }
+    }
+}
+
 impl ZmqEventNormalizer {
     pub fn new(kv_block_size: u32) -> Self {
         Self {
@@ -65,15 +86,26 @@ impl ZmqEventNormalizer {
     }
 
     pub fn preprocess(&mut self, raw: RawKvEvent, worker: WorkerWithDpRank) -> Option<RawKvEvent> {
+        self.preprocess_with_reason(raw, worker).ok()
+    }
+
+    pub fn preprocess_with_reason(
+        &mut self,
+        raw: RawKvEvent,
+        worker: WorkerWithDpRank,
+    ) -> Result<RawKvEvent, ZmqEventFilterReason> {
         if raw.is_ignored() {
-            return None;
+            return Err(ZmqEventFilterReason::IgnoredEvent);
         }
 
         let metadata = raw.metadata();
         if matches!(raw, RawKvEvent::BlockStored { .. }) {
             self.learn_metadata(metadata, worker.dp_rank);
         }
-        self.should_accept(metadata, worker.dp_rank).then_some(raw)
+        if let Some(reason) = self.filter_reason(metadata, worker.dp_rank) {
+            return Err(reason);
+        }
+        Ok(raw)
     }
 
     pub fn normalize_preprocessed(
@@ -116,20 +148,38 @@ impl ZmqEventNormalizer {
         );
     }
 
-    fn should_accept(&self, metadata: KvCacheEventMetadata, dp_rank: DpRank) -> bool {
+    fn filter_reason(
+        &self,
+        metadata: KvCacheEventMetadata,
+        dp_rank: DpRank,
+    ) -> Option<ZmqEventFilterReason> {
         if let Some(kind) = metadata.kv_cache_spec_kind {
-            return kind.is_main_attention();
+            if kind.is_main_attention() {
+                return None;
+            }
+            if kind == KvCacheSpecKind::Unknown {
+                return Some(ZmqEventFilterReason::UnknownKind);
+            }
+            return Some(ZmqEventFilterReason::NonMainAttentionKind);
         }
 
-        let Some(group_idx) = metadata.group_idx else {
-            return true;
-        };
+        let group_idx = metadata.group_idx?;
 
         if let Some(metadata) = self.group_metadata.get(&(dp_rank, group_idx)) {
             let _sliding_window = metadata.sliding_window;
-            return metadata.kind.is_main_attention();
+            if metadata.kind.is_main_attention() {
+                return None;
+            }
+            if metadata.kind == KvCacheSpecKind::Unknown {
+                return Some(ZmqEventFilterReason::UnknownKind);
+            }
+            return Some(ZmqEventFilterReason::NonMainAttentionGroup);
         }
 
-        group_idx == 0
+        if group_idx == 0 {
+            None
+        } else {
+            Some(ZmqEventFilterReason::UnlearnedGroupIdx)
+        }
     }
 }

--- a/lib/kv-router/src/zmq_wire/tests.rs
+++ b/lib/kv-router/src/zmq_wire/tests.rs
@@ -337,10 +337,11 @@ fn test_normalizer_ignores_non_main_group_idx_without_metadata() {
         from_slice(&block_removed_sequence(Some(1), None)).expect("valid raw event");
     let mut normalizer = ZmqEventNormalizer::new(2);
 
-    assert!(
+    assert_eq!(
         normalizer
-            .preprocess(raw_event, WorkerWithDpRank::new(3, 0))
-            .is_none()
+            .preprocess_with_reason(raw_event, WorkerWithDpRank::new(3, 0))
+            .unwrap_err(),
+        ZmqEventFilterReason::UnlearnedGroupIdx
     );
 }
 
@@ -374,10 +375,11 @@ fn test_normalizer_ignores_map_serialized_non_main_attention_kind() {
     let mut normalizer = ZmqEventNormalizer::new(2);
 
     assert_event_metadata(&decoded, Some(1), Some(KvCacheSpecKind::Mamba), None);
-    assert!(
+    assert_eq!(
         normalizer
-            .preprocess(decoded, WorkerWithDpRank::new(3, 0))
-            .is_none()
+            .preprocess_with_reason(decoded, WorkerWithDpRank::new(3, 0))
+            .unwrap_err(),
+        ZmqEventFilterReason::NonMainAttentionKind
     );
 }
 

--- a/lib/kv-router/src/zmq_wire/types.rs
+++ b/lib/kv-router/src/zmq_wire/types.rs
@@ -97,6 +97,15 @@ pub enum RawKvEvent {
 }
 
 impl RawKvEvent {
+    pub fn event_type_label(&self) -> &'static str {
+        match self {
+            Self::BlockStored { .. } => "stored",
+            Self::BlockRemoved { .. } => "removed",
+            Self::AllBlocksCleared => "cleared",
+            Self::Ignored => "ignored",
+        }
+    }
+
     pub fn is_ignored(&self) -> bool {
         matches!(self, Self::Ignored)
     }

--- a/lib/llm/src/kv_router/metrics.rs
+++ b/lib/llm/src/kv_router/metrics.rs
@@ -153,51 +153,6 @@ impl KvPublisherMetrics {
             .clone()
     }
 
-    /// Creates unregistered metrics for use when registration fails.
-    /// Increments still work in-process but are not exposed on `/metrics`.
-    #[cfg(test)]
-    pub fn new_unregistered() -> Self {
-        Self {
-            engines_dropped_events_total: IntCounter::with_opts(Opts::new(
-                kv_publisher::ENGINES_DROPPED_EVENTS_TOTAL,
-                "Total number of raw events dropped by engines before reaching publisher (detected via event_id gaps)",
-            ))
-            .expect("failed to create engines_dropped_events_total counter"),
-            zmq_events_total: IntCounterVec::new(
-                Opts::new(
-                    kv_publisher::ZMQ_EVENTS_TOTAL,
-                    "Total number of ZMQ KV events seen by the relay",
-                ),
-                &["stage", "event_type"],
-            )
-            .expect("failed to create zmq_events_total counter"),
-            zmq_filtered_events_total: IntCounterVec::new(
-                Opts::new(
-                    kv_publisher::ZMQ_FILTERED_EVENTS_TOTAL,
-                    "Total number of ZMQ KV events filtered before conversion",
-                ),
-                &["event_type", "reason"],
-            )
-            .expect("failed to create zmq_filtered_events_total counter"),
-            zmq_conversion_issues_total: IntCounterVec::new(
-                Opts::new(
-                    kv_publisher::ZMQ_CONVERSION_ISSUES_TOTAL,
-                    "Total number of ZMQ KV events dropped due to conversion issues",
-                ),
-                &["event_type", "reason"],
-            )
-            .expect("failed to create zmq_conversion_issues_total counter"),
-            zmq_suspicious_events_total: IntCounterVec::new(
-                Opts::new(
-                    kv_publisher::ZMQ_SUSPICIOUS_EVENTS_TOTAL,
-                    "Total number of suspicious-but-forwarded ZMQ KV events",
-                ),
-                &["event_type", "reason"],
-            )
-            .expect("failed to create zmq_suspicious_events_total counter"),
-        }
-    }
-
     /// Increment the engines dropped events counter by the given amount.
     pub fn increment_engines_dropped_events(&self, count: u64) {
         self.engines_dropped_events_total.inc_by(count);

--- a/lib/llm/src/kv_router/metrics.rs
+++ b/lib/llm/src/kv_router/metrics.rs
@@ -30,6 +30,11 @@
 //!   - Standalone router (`python -m dynamo.router`): available on `DYN_SYSTEM_PORT`
 //!     when set (default is `-1`, disabled), populated per-request
 //!
+//! - [`KvPublisherMetrics`]: Worker-local KV event publisher and ZMQ relay counters.
+//!   Registered on the DRT `MetricsRegistry` hierarchy via `Component::metrics()`.
+//!   Populated by `KvEventPublisher` and the ZMQ listener when engines publish KV
+//!   events.
+//!
 //! The standalone router does not create `WorkerLoadMetrics` or
 //! `RoutingOverheadMetrics` (those are frontend-only). It only exposes
 //! `RouterRequestMetrics` and standard DRT transport metrics
@@ -44,7 +49,7 @@ use std::time::Duration;
 use dynamo_runtime::component::Component;
 use dynamo_runtime::metrics::MetricsHierarchy;
 use dynamo_runtime::metrics::prometheus_names::{
-    frontend_service, labels, name_prefix, router, router_request, routing_overhead,
+    frontend_service, kv_publisher, labels, name_prefix, router, router_request, routing_overhead,
 };
 
 /// Build a router metric name: `"router_" + frontend_service_suffix`.
@@ -52,7 +57,7 @@ fn router_metric(suffix: &str) -> String {
     format!("{}{}", router_request::METRIC_PREFIX, suffix)
 }
 use dynamo_runtime::traits::DistributedRuntimeProvider;
-use prometheus::{HistogramOpts, IntGaugeVec, Opts};
+use prometheus::{HistogramOpts, IntCounter, IntCounterVec, IntGaugeVec, Opts};
 
 use crate::http::service::metrics::generate_log_buckets;
 
@@ -64,6 +69,150 @@ fn compute_overhead_buckets() -> Vec<f64> {
 /// Buckets for async phases (indexer find_matches, scheduling, total).
 fn async_overhead_buckets() -> Vec<f64> {
     prometheus::exponential_buckets(0.01, 3.0, 17).unwrap()
+}
+
+// ---------------------------------------------------------------------------
+// KV publisher metrics
+// ---------------------------------------------------------------------------
+
+/// Metrics for the KV publisher, created via the MetricsHierarchy API.
+/// This provides automatic `dynamo_namespace`, `dynamo_component`, and other
+/// hierarchy labels for free.
+pub(crate) struct KvPublisherMetrics {
+    /// Total number of raw events dropped by engines before reaching publisher.
+    pub engines_dropped_events_total: IntCounter,
+    /// Total number of decoded ZMQ KV events by relay stage and event type.
+    pub zmq_events_total: IntCounterVec,
+    /// Total number of ZMQ KV events filtered before conversion.
+    pub zmq_filtered_events_total: IntCounterVec,
+    /// Total number of ZMQ KV events that produced suspicious conversion output.
+    pub zmq_conversion_issues_total: IntCounterVec,
+}
+
+static KV_PUBLISHER_METRICS: OnceLock<Arc<KvPublisherMetrics>> = OnceLock::new();
+
+impl KvPublisherMetrics {
+    /// Create from a Component, memoized in a static OnceLock.
+    /// Uses the MetricsHierarchy API which auto-prepends `dynamo_component_`,
+    /// injects hierarchy labels (including `worker_id`), and registers with the
+    /// DRT `MetricsRegistry`.
+    pub fn from_component(component: &Component) -> Arc<Self> {
+        KV_PUBLISHER_METRICS
+            .get_or_init(|| {
+                let metrics = component.metrics();
+                match (
+                    metrics.create_intcounter(
+                        kv_publisher::ENGINES_DROPPED_EVENTS_TOTAL,
+                        "Total number of raw events dropped by engines before reaching publisher (detected via event_id gaps)",
+                        &[],
+                    ),
+                    metrics.create_intcountervec(
+                        kv_publisher::ZMQ_EVENTS_TOTAL,
+                        "Total number of ZMQ KV events seen by the relay",
+                        &["stage", "event_type"],
+                        &[],
+                    ),
+                    metrics.create_intcountervec(
+                        kv_publisher::ZMQ_FILTERED_EVENTS_TOTAL,
+                        "Total number of ZMQ KV events filtered before conversion",
+                        &["event_type", "reason"],
+                        &[],
+                    ),
+                    metrics.create_intcountervec(
+                        kv_publisher::ZMQ_CONVERSION_ISSUES_TOTAL,
+                        "Total number of ZMQ KV events with conversion issues",
+                        &["event_type", "reason"],
+                        &[],
+                    ),
+                ) {
+                    (
+                        Ok(engines_dropped_events_total),
+                        Ok(zmq_events_total),
+                        Ok(zmq_filtered_events_total),
+                        Ok(zmq_conversion_issues_total),
+                    ) => Arc::new(Self {
+                        engines_dropped_events_total,
+                        zmq_events_total,
+                        zmq_filtered_events_total,
+                        zmq_conversion_issues_total,
+                    }),
+                    (Err(e), _, _, _)
+                    | (_, Err(e), _, _)
+                    | (_, _, Err(e), _)
+                    | (_, _, _, Err(e)) => {
+                        tracing::warn!(
+                            "Failed to create kv_publisher metrics from component: {}. Using unregistered metrics as fallback.",
+                            e
+                        );
+                        Arc::new(Self::new_unregistered())
+                    }
+                }
+            })
+            .clone()
+    }
+
+    /// Creates unregistered metrics for use when registration fails.
+    /// Increments still work in-process but are not exposed on `/metrics`.
+    pub fn new_unregistered() -> Self {
+        Self {
+            engines_dropped_events_total: IntCounter::with_opts(Opts::new(
+                kv_publisher::ENGINES_DROPPED_EVENTS_TOTAL,
+                "Total number of raw events dropped by engines before reaching publisher (detected via event_id gaps)",
+            ))
+            .expect("failed to create engines_dropped_events_total counter"),
+            zmq_events_total: IntCounterVec::new(
+                Opts::new(
+                    kv_publisher::ZMQ_EVENTS_TOTAL,
+                    "Total number of ZMQ KV events seen by the relay",
+                ),
+                &["stage", "event_type"],
+            )
+            .expect("failed to create zmq_events_total counter"),
+            zmq_filtered_events_total: IntCounterVec::new(
+                Opts::new(
+                    kv_publisher::ZMQ_FILTERED_EVENTS_TOTAL,
+                    "Total number of ZMQ KV events filtered before conversion",
+                ),
+                &["event_type", "reason"],
+            )
+            .expect("failed to create zmq_filtered_events_total counter"),
+            zmq_conversion_issues_total: IntCounterVec::new(
+                Opts::new(
+                    kv_publisher::ZMQ_CONVERSION_ISSUES_TOTAL,
+                    "Total number of ZMQ KV events with conversion issues",
+                ),
+                &["event_type", "reason"],
+            )
+            .expect("failed to create zmq_conversion_issues_total counter"),
+        }
+    }
+
+    /// Increment the engines dropped events counter by the given amount.
+    pub fn increment_engines_dropped_events(&self, count: u64) {
+        self.engines_dropped_events_total.inc_by(count);
+    }
+
+    pub fn increment_zmq_event(&self, stage: &'static str, event_type: &'static str) {
+        self.zmq_events_total
+            .with_label_values(&[stage, event_type])
+            .inc();
+    }
+
+    pub fn increment_zmq_filtered_event(&self, event_type: &'static str, reason: &'static str) {
+        self.zmq_filtered_events_total
+            .with_label_values(&[event_type, reason])
+            .inc();
+    }
+
+    pub fn increment_zmq_conversion_issue(&self, event_type: &'static str, reason: &'static str) {
+        self.zmq_conversion_issues_total
+            .with_label_values(&[event_type, reason])
+            .inc();
+    }
+}
+
+pub(crate) fn kv_publisher_metrics() -> Option<Arc<KvPublisherMetrics>> {
+    KV_PUBLISHER_METRICS.get().cloned()
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/llm/src/kv_router/metrics.rs
+++ b/lib/llm/src/kv_router/metrics.rs
@@ -85,8 +85,10 @@ pub(crate) struct KvPublisherMetrics {
     pub zmq_events_total: IntCounterVec,
     /// Total number of ZMQ KV events filtered before conversion.
     pub zmq_filtered_events_total: IntCounterVec,
-    /// Total number of ZMQ KV events that produced suspicious conversion output.
+    /// Total number of ZMQ KV events dropped due to conversion issues.
     pub zmq_conversion_issues_total: IntCounterVec,
+    /// Total number of suspicious-but-forwarded ZMQ KV events.
+    pub zmq_suspicious_events_total: IntCounterVec,
 }
 
 static KV_PUBLISHER_METRICS: OnceLock<Arc<KvPublisherMetrics>> = OnceLock::new();
@@ -100,59 +102,60 @@ impl KvPublisherMetrics {
         KV_PUBLISHER_METRICS
             .get_or_init(|| {
                 let metrics = component.metrics();
-                match (
-                    metrics.create_intcounter(
+                let engines_dropped_events_total = metrics
+                    .create_intcounter(
                         kv_publisher::ENGINES_DROPPED_EVENTS_TOTAL,
                         "Total number of raw events dropped by engines before reaching publisher (detected via event_id gaps)",
                         &[],
-                    ),
-                    metrics.create_intcountervec(
+                    )
+                    .expect("failed to create kv_publisher_engines_dropped_events_total");
+                let zmq_events_total = metrics
+                    .create_intcountervec(
                         kv_publisher::ZMQ_EVENTS_TOTAL,
                         "Total number of ZMQ KV events seen by the relay",
                         &["stage", "event_type"],
                         &[],
-                    ),
-                    metrics.create_intcountervec(
+                    )
+                    .expect("failed to create kv_publisher_zmq_events_total");
+                let zmq_filtered_events_total = metrics
+                    .create_intcountervec(
                         kv_publisher::ZMQ_FILTERED_EVENTS_TOTAL,
                         "Total number of ZMQ KV events filtered before conversion",
                         &["event_type", "reason"],
                         &[],
-                    ),
-                    metrics.create_intcountervec(
+                    )
+                    .expect("failed to create kv_publisher_zmq_filtered_events_total");
+                let zmq_conversion_issues_total = metrics
+                    .create_intcountervec(
                         kv_publisher::ZMQ_CONVERSION_ISSUES_TOTAL,
-                        "Total number of ZMQ KV events with conversion issues",
+                        "Total number of ZMQ KV events dropped due to conversion issues",
                         &["event_type", "reason"],
                         &[],
-                    ),
-                ) {
-                    (
-                        Ok(engines_dropped_events_total),
-                        Ok(zmq_events_total),
-                        Ok(zmq_filtered_events_total),
-                        Ok(zmq_conversion_issues_total),
-                    ) => Arc::new(Self {
-                        engines_dropped_events_total,
-                        zmq_events_total,
-                        zmq_filtered_events_total,
-                        zmq_conversion_issues_total,
-                    }),
-                    (Err(e), _, _, _)
-                    | (_, Err(e), _, _)
-                    | (_, _, Err(e), _)
-                    | (_, _, _, Err(e)) => {
-                        tracing::warn!(
-                            "Failed to create kv_publisher metrics from component: {}. Using unregistered metrics as fallback.",
-                            e
-                        );
-                        Arc::new(Self::new_unregistered())
-                    }
-                }
+                    )
+                    .expect("failed to create kv_publisher_zmq_conversion_issues_total");
+                let zmq_suspicious_events_total = metrics
+                    .create_intcountervec(
+                        kv_publisher::ZMQ_SUSPICIOUS_EVENTS_TOTAL,
+                        "Total number of suspicious-but-forwarded ZMQ KV events",
+                        &["event_type", "reason"],
+                        &[],
+                    )
+                    .expect("failed to create kv_publisher_zmq_suspicious_events_total");
+
+                Arc::new(Self {
+                    engines_dropped_events_total,
+                    zmq_events_total,
+                    zmq_filtered_events_total,
+                    zmq_conversion_issues_total,
+                    zmq_suspicious_events_total,
+                })
             })
             .clone()
     }
 
     /// Creates unregistered metrics for use when registration fails.
     /// Increments still work in-process but are not exposed on `/metrics`.
+    #[cfg(test)]
     pub fn new_unregistered() -> Self {
         Self {
             engines_dropped_events_total: IntCounter::with_opts(Opts::new(
@@ -179,11 +182,19 @@ impl KvPublisherMetrics {
             zmq_conversion_issues_total: IntCounterVec::new(
                 Opts::new(
                     kv_publisher::ZMQ_CONVERSION_ISSUES_TOTAL,
-                    "Total number of ZMQ KV events with conversion issues",
+                    "Total number of ZMQ KV events dropped due to conversion issues",
                 ),
                 &["event_type", "reason"],
             )
             .expect("failed to create zmq_conversion_issues_total counter"),
+            zmq_suspicious_events_total: IntCounterVec::new(
+                Opts::new(
+                    kv_publisher::ZMQ_SUSPICIOUS_EVENTS_TOTAL,
+                    "Total number of suspicious-but-forwarded ZMQ KV events",
+                ),
+                &["event_type", "reason"],
+            )
+            .expect("failed to create zmq_suspicious_events_total counter"),
         }
     }
 
@@ -206,6 +217,12 @@ impl KvPublisherMetrics {
 
     pub fn increment_zmq_conversion_issue(&self, event_type: &'static str, reason: &'static str) {
         self.zmq_conversion_issues_total
+            .with_label_values(&[event_type, reason])
+            .inc();
+    }
+
+    pub fn increment_zmq_suspicious_event(&self, event_type: &'static str, reason: &'static str) {
+        self.zmq_suspicious_events_total
             .with_label_values(&[event_type, reason])
             .inc();
     }

--- a/lib/llm/src/kv_router/publisher/event_processor.rs
+++ b/lib/llm/src/kv_router/publisher/event_processor.rs
@@ -12,10 +12,12 @@ use dynamo_kv_router::indexer::LocalKvIndexer;
 use dynamo_kv_router::protocols::*;
 use dynamo_runtime::transports::nats::NatsQueue;
 
+use crate::kv_router::metrics::kv_publisher_metrics;
+
+use super::DEFAULT_MAX_BATCH_BLOCKS;
 use super::batching::BatchingState;
 use super::dedup::EventDedupFilter;
 use super::sinks::{JetStreamPublisher, emit};
-use super::{DEFAULT_MAX_BATCH_BLOCKS, kv_publisher_metrics};
 
 pub(super) async fn run_event_processor_loop<P: RouterEventSink + Send + Sync + 'static>(
     publisher: P,

--- a/lib/llm/src/kv_router/publisher/mod.rs
+++ b/lib/llm/src/kv_router/publisher/mod.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::sync::Arc;
-use std::sync::OnceLock;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use anyhow::Result;
@@ -15,8 +14,6 @@ pub use dynamo_kv_router::zmq_wire::create_stored_blocks;
 #[cfg(test)]
 use dynamo_kv_router::zmq_wire::*;
 use dynamo_runtime::config::environment_names::nats as env_nats;
-use dynamo_runtime::metrics::MetricsHierarchy;
-use dynamo_runtime::metrics::prometheus_names::kv_publisher;
 use dynamo_runtime::traits::DistributedRuntimeProvider;
 use dynamo_runtime::{
     component::Component,
@@ -25,6 +22,7 @@ use dynamo_runtime::{
 
 use crate::kv_router::{
     KV_EVENT_SUBJECT, WORKER_KV_INDEXER_BUFFER_SIZE, indexer::start_worker_kv_query_endpoint,
+    metrics::KvPublisherMetrics,
 };
 
 mod batching;
@@ -64,66 +62,6 @@ fn create_kv_stream_name(component: &Component, subject: &str) -> String {
     ))
     .to_string()
     .replace("_", "-")
-}
-
-/// Metrics for the KV publisher, created via the MetricsHierarchy API.
-/// This provides automatic `dynamo_namespace`, `dynamo_component`, and other
-/// hierarchy labels for free.
-pub(super) struct KvPublisherMetrics {
-    /// Total number of raw events dropped by engines before reaching publisher
-    pub engines_dropped_events_total: prometheus::IntCounter,
-}
-
-static KV_PUBLISHER_METRICS: OnceLock<Arc<KvPublisherMetrics>> = OnceLock::new();
-
-impl KvPublisherMetrics {
-    /// Create from a Component, memoized in a static OnceLock.
-    /// Uses the MetricsHierarchy API which auto-prepends `dynamo_component_`,
-    /// injects hierarchy labels (including `worker_id`), and registers with the
-    /// DRT `MetricsRegistry`.
-    pub fn from_component(component: &Component) -> Arc<Self> {
-        KV_PUBLISHER_METRICS
-            .get_or_init(|| {
-                let metrics = component.metrics();
-                match metrics.create_intcounter(
-                    kv_publisher::ENGINES_DROPPED_EVENTS_TOTAL,
-                    "Total number of raw events dropped by engines before reaching publisher (detected via event_id gaps)",
-                    &[],
-                ) {
-                    Ok(engines_dropped_events_total) => {
-                        Arc::new(Self { engines_dropped_events_total })
-                    }
-                    Err(e) => {
-                        tracing::warn!("Failed to create kv_publisher metrics from component: {}. Using unregistered metrics as fallback.", e);
-                        Arc::new(Self::new_unregistered())
-                    }
-                }
-            })
-            .clone()
-    }
-
-    /// Creates unregistered metrics for use when registration fails.
-    /// Increments still work in-process but are not exposed on `/metrics`.
-    pub fn new_unregistered() -> Self {
-        Self {
-            engines_dropped_events_total: prometheus::IntCounter::with_opts(
-                prometheus::Opts::new(
-                    kv_publisher::ENGINES_DROPPED_EVENTS_TOTAL,
-                    "Total number of raw events dropped by engines before reaching publisher (detected via event_id gaps)",
-                ),
-            )
-            .expect("failed to create engines_dropped_events_total counter"),
-        }
-    }
-
-    /// Increment the engines dropped events counter by the given amount.
-    pub fn increment_engines_dropped_events(&self, count: u64) {
-        self.engines_dropped_events_total.inc_by(count);
-    }
-}
-
-fn kv_publisher_metrics() -> Option<Arc<KvPublisherMetrics>> {
-    KV_PUBLISHER_METRICS.get().cloned()
 }
 
 /// Configure the source of KV events.
@@ -236,7 +174,7 @@ impl KvEventPublisher {
         let (tx, rx) = mpsc::unbounded_channel::<PlacementEvent>();
         let worker_id = component.drt().connection_id();
 
-        KvPublisherMetrics::from_component(&component);
+        let _ = KvPublisherMetrics::from_component(&component);
 
         let component_name = component.name();
         tracing::info!(

--- a/lib/llm/src/kv_router/publisher/zmq_listener.rs
+++ b/lib/llm/src/kv_router/publisher/zmq_listener.rs
@@ -11,6 +11,7 @@ use tokio_util::sync::CancellationToken;
 use dynamo_kv_router::protocols::*;
 use dynamo_kv_router::zmq_wire::*;
 
+use crate::kv_router::metrics::kv_publisher_metrics;
 use crate::utils::zmq::{connect_sub_socket, multipart_message};
 
 pub(super) async fn start_zmq_listener(
@@ -37,6 +38,7 @@ pub(super) async fn start_zmq_listener(
         }
     };
     let mut socket = socket;
+    let metrics = kv_publisher_metrics();
 
     if cancellation_token.is_cancelled() {
         return;
@@ -102,16 +104,37 @@ pub(super) async fn start_zmq_listener(
 
                 let dp_rank = batch.data_parallel_rank.unwrap_or(0).cast_unsigned();
                 for raw_event in batch.events {
+                    let event_type = raw_event.event_type_label();
+                    if let Some(metrics) = &metrics {
+                        metrics.increment_zmq_event("received", event_type);
+                    }
                     let worker = WorkerWithDpRank::new(worker_id, dp_rank);
-                    let Some(raw_event) = normalizer.preprocess(raw_event, worker) else {
-                        continue;
+                    let raw_event = match normalizer.preprocess_with_reason(raw_event, worker) {
+                        Ok(raw_event) => raw_event,
+                        Err(reason) => {
+                            if let Some(metrics) = &metrics {
+                                metrics.increment_zmq_filtered_event(event_type, reason.as_label());
+                            }
+                            continue;
+                        }
                     };
+                    if let Some(metrics) = &metrics {
+                        metrics.increment_zmq_event("accepted", event_type);
+                    }
                     let event_id = next_event_id.fetch_add(1, Ordering::SeqCst);
                     let Some(event) =
                         normalizer.normalize_preprocessed(raw_event, event_id, worker)
                     else {
+                        if let Some(metrics) = &metrics {
+                            metrics.increment_zmq_conversion_issue(event_type, "conversion_none");
+                        }
                         continue;
                     };
+                    if matches!(event.event.data, KvCacheEventData::Stored(ref data) if data.blocks.is_empty())
+                        && let Some(metrics) = &metrics
+                    {
+                        metrics.increment_zmq_conversion_issue(event_type, "empty_store_blocks");
+                    }
                     if tx.send(event).is_err() {
                         tracing::warn!("Failed to send message to channel - receiver dropped");
                         break 'main String::from("channel receiver dropped");

--- a/lib/llm/src/kv_router/publisher/zmq_listener.rs
+++ b/lib/llm/src/kv_router/publisher/zmq_listener.rs
@@ -133,7 +133,7 @@ pub(super) async fn start_zmq_listener(
                     if matches!(event.event.data, KvCacheEventData::Stored(ref data) if data.blocks.is_empty())
                         && let Some(metrics) = &metrics
                     {
-                        metrics.increment_zmq_conversion_issue(event_type, "empty_store_blocks");
+                        metrics.increment_zmq_suspicious_event(event_type, "empty_store_blocks");
                     }
                     if tx.send(event).is_err() {
                         tracing::warn!("Failed to send message to channel - receiver dropped");

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -681,6 +681,15 @@ pub mod kvrouter {
 pub mod kv_publisher {
     /// Total number of raw events dropped by engines before reaching publisher (detected via event_id gaps)
     pub const ENGINES_DROPPED_EVENTS_TOTAL: &str = "kv_publisher_engines_dropped_events_total";
+
+    /// Total number of ZMQ KV events seen by the relay, labeled by stage and event type
+    pub const ZMQ_EVENTS_TOTAL: &str = "kv_publisher_zmq_events_total";
+
+    /// Total number of ZMQ KV events filtered before conversion, labeled by event type and reason
+    pub const ZMQ_FILTERED_EVENTS_TOTAL: &str = "kv_publisher_zmq_filtered_events_total";
+
+    /// Total number of ZMQ KV events with conversion issues, labeled by event type and reason
+    pub const ZMQ_CONVERSION_ISSUES_TOTAL: &str = "kv_publisher_zmq_conversion_issues_total";
 }
 
 /// Additional TRT-LLM worker metrics beyond what the engine natively provides.

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -688,8 +688,11 @@ pub mod kv_publisher {
     /// Total number of ZMQ KV events filtered before conversion, labeled by event type and reason
     pub const ZMQ_FILTERED_EVENTS_TOTAL: &str = "kv_publisher_zmq_filtered_events_total";
 
-    /// Total number of ZMQ KV events with conversion issues, labeled by event type and reason
+    /// Total number of ZMQ KV events dropped due to conversion issues, labeled by event type and reason
     pub const ZMQ_CONVERSION_ISSUES_TOTAL: &str = "kv_publisher_zmq_conversion_issues_total";
+
+    /// Total number of suspicious-but-forwarded ZMQ KV events, labeled by event type and reason
+    pub const ZMQ_SUSPICIOUS_EVENTS_TOTAL: &str = "kv_publisher_zmq_suspicious_events_total";
 }
 
 /// Additional TRT-LLM worker metrics beyond what the engine natively provides.


### PR DESCRIPTION
## Summary
- add worker-side ZMQ KV relay counters for received/accepted events, filtered events, and conversion issues
- expose ZMQ normalizer filter reasons so relay filtering is observable without noisy logs
- move KV publisher metrics into the existing KV router metrics module

## Tests
- cargo fmt --all
- git diff --check
- cargo test -p dynamo-kv-router zmq_wire --no-default-features
- cargo test -p dynamo-llm --lib kv_router::publisher --no-default-features (local macOS link failure: ld: library 'stdc++' not found; compile reached final link)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9233" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive KV event publisher metrics for ZMQ event tracking, including counters for events seen, filtered, and conversion issues, enabling better system observability and monitoring.

* **Chores**
  * Refactored event filtering to provide detailed rejection reasons for improved troubleshooting and diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->