### PR TITLE
feat: Add kv events support in tokenspeed

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -60,6 +60,7 @@ target/
 *.swo
 .vscode/
 .build/
+.worktrees/
 
 # Tests & Linters
 .pytest_cache/

--- a/components/src/dynamo/common/backend/engine.py
+++ b/components/src/dynamo/common/backend/engine.py
@@ -11,6 +11,8 @@ from typing import TYPE_CHECKING, Any, Optional, Required, TypedDict
 from dynamo._core import Context
 
 if TYPE_CHECKING:
+    from dynamo.runtime import Endpoint
+
     from .worker import WorkerConfig
 
 
@@ -115,6 +117,17 @@ class LLMEngine(ABC):
         """
         ...
         yield  # type: ignore[misc]
+
+    async def start_kv_events(
+        self, endpoint: "Endpoint", engine_config: EngineConfig
+    ) -> None:
+        """Start optional backend-specific KV event relays.
+
+        Backends that publish native KV cache events over a side channel can
+        override this hook once the Dynamo endpoint exists. The default keeps
+        unified backends that do not support KV events unchanged.
+        """
+        return None
 
     async def abort(self, context: Context) -> None:
         """Abort an in-flight request (optional, default no-op).

--- a/components/src/dynamo/tokenspeed/args.py
+++ b/components/src/dynamo/tokenspeed/args.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import argparse
 import dataclasses
 import importlib
+import json
 import os
 import sys
 from typing import Any, Dict, Optional, Sequence
@@ -33,7 +34,9 @@ class Config(DynamoRuntimeConfig):
 
     def validate(self) -> None:
         DynamoRuntimeConfig.validate(self)
-        self.use_kv_events = False
+        self.use_kv_events = kv_events_enabled(
+            getattr(getattr(self, "server_args", None), "kv_events_config", None)
+        )
 
 
 @register_encoder(Config)
@@ -112,3 +115,27 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> Config:
 def _server_args_cls():
     module = importlib.import_module("tokenspeed.runtime.utils.server_args")
     return module.ServerArgs
+
+
+def kv_events_config_dict(kv_events_config: Any) -> dict[str, Any]:
+    if not kv_events_config:
+        return {}
+    if isinstance(kv_events_config, str):
+        return json.loads(kv_events_config)
+    if isinstance(kv_events_config, dict):
+        return dict(kv_events_config)
+    if hasattr(kv_events_config, "model_dump"):
+        return kv_events_config.model_dump()
+    return dict(kv_events_config)
+
+
+def kv_events_enabled(kv_events_config: Any) -> bool:
+    config = kv_events_config_dict(kv_events_config)
+    if not config:
+        return False
+
+    enabled = bool(config.get("enable_kv_cache_events", False))
+    publisher = config.get("publisher")
+    if publisher is None:
+        publisher = "zmq" if enabled else "null"
+    return enabled and publisher != "null"

--- a/components/src/dynamo/tokenspeed/llm_engine.py
+++ b/components/src/dynamo/tokenspeed/llm_engine.py
@@ -23,11 +23,7 @@ from dynamo.common.backend.worker import WorkerConfig
 from dynamo.common.utils.engine_response import normalize_finish_reason
 from dynamo.llm import ModelInput
 from dynamo.llm.exceptions import InvalidArgument
-from dynamo.tokenspeed.args import (
-    kv_events_config_dict,
-    kv_events_enabled,
-    parse_args,
-)
+from dynamo.tokenspeed.args import kv_events_config_dict, kv_events_enabled, parse_args
 
 logger = logging.getLogger(__name__)
 

--- a/components/src/dynamo/tokenspeed/llm_engine.py
+++ b/components/src/dynamo/tokenspeed/llm_engine.py
@@ -23,24 +23,30 @@ from dynamo.common.backend.worker import WorkerConfig
 from dynamo.common.utils.engine_response import normalize_finish_reason
 from dynamo.llm import ModelInput
 from dynamo.llm.exceptions import InvalidArgument
-from dynamo.tokenspeed.args import parse_args
+from dynamo.tokenspeed.args import (
+    kv_events_config_dict,
+    kv_events_enabled,
+    parse_args,
+)
 
 logger = logging.getLogger(__name__)
 
 
 class TokenspeedLLMEngine(LLMEngine):
-    def __init__(self, server_args: Any):
+    def __init__(self, server_args: Any, dynamo_config: Any | None = None):
         self.server_args = server_args
+        self.dynamo_config = dynamo_config
         self.engine = None
         self._model_max_len: int | None = None
         self._active_rids_by_context: dict[str, list[str]] = {}
+        self._kv_publishers: list[Any] = []
 
     @classmethod
     async def from_args(
         cls, argv: list[str] | None = None
     ) -> tuple[TokenspeedLLMEngine, WorkerConfig]:
         config = parse_args(argv)
-        engine = cls(config.server_args)
+        engine = cls(config.server_args, config)
         worker_config = WorkerConfig.from_runtime_config(
             config,
             model_name=config.model,
@@ -93,6 +99,50 @@ class TokenspeedLLMEngine(LLMEngine):
             max_num_batched_tokens=max_num_batched_tokens,
         )
 
+    async def start_kv_events(self, endpoint: Any, engine_config: EngineConfig) -> None:
+        if not kv_events_enabled(getattr(self.server_args, "kv_events_config", None)):
+            return
+
+        if not getattr(self.server_args, "enable_prefix_caching", True):
+            logger.info(
+                "TokenSpeed KV event publishing skipped: prefix caching disabled"
+            )
+            return
+
+        _assert_tokenspeed_kv_events_supported()
+
+        kv_block_size = engine_config.kv_cache_block_size or _optional_int(
+            getattr(self.server_args, "block_size", None)
+        )
+        if not kv_block_size:
+            raise RuntimeError("TokenSpeed KV events require a non-zero block size")
+
+        config = kv_events_config_dict(self.server_args.kv_events_config)
+        base_zmq_endpoint = config.get("endpoint") or "tcp://*:5557"
+        publisher_cls = _kv_event_publisher_cls()
+
+        for dp_rank in _local_dp_rank_range(self.server_args):
+            zmq_endpoint = _format_zmq_connect_endpoint(
+                _offset_zmq_endpoint_port(base_zmq_endpoint, dp_rank)
+            )
+            logger.info(
+                "TokenSpeed KV event publisher for dp_rank=%s subscribing to %s",
+                dp_rank,
+                zmq_endpoint,
+            )
+            self._kv_publishers.append(
+                publisher_cls(
+                    endpoint=endpoint,
+                    kv_block_size=kv_block_size,
+                    zmq_endpoint=zmq_endpoint,
+                    zmq_topic="",
+                    enable_local_indexer=getattr(
+                        self.dynamo_config, "enable_local_indexer", False
+                    ),
+                    dp_rank=dp_rank,
+                )
+            )
+
     async def generate(
         self, request: GenerateRequest, context: Context
     ) -> AsyncGenerator[GenerateChunk, None]:
@@ -134,6 +184,14 @@ class TokenspeedLLMEngine(LLMEngine):
             logger.debug("Aborted TokenSpeed request %s", rid)
 
     async def cleanup(self) -> None:
+        for publisher in self._kv_publishers:
+            try:
+                publisher.shutdown()
+            except Exception:
+                logger.warning(
+                    "Failed to shut down TokenSpeed KV publisher", exc_info=True
+                )
+        self._kv_publishers.clear()
         if self.engine is not None:
             self.engine.shutdown()
             logger.info("TokenSpeed engine shutdown")
@@ -344,3 +402,73 @@ def _tokenspeed_engine_cls() -> Any:
 def _generate_req_input_cls() -> Any:
     module = importlib.import_module("tokenspeed.runtime.engine.io_struct")
     return module.GenerateReqInput
+
+
+def _kv_event_publisher_cls() -> Any:
+    from dynamo.llm import KvEventPublisher
+
+    return KvEventPublisher
+
+
+def _assert_tokenspeed_kv_events_supported() -> None:
+    try:
+        module = importlib.import_module("tokenspeed.runtime.pd.kv_events")
+    except ImportError as exc:
+        raise RuntimeError(
+            "TokenSpeed KV events require tokenspeed.runtime.pd.kv_events"
+        ) from exc
+
+    factory = getattr(module, "EventPublisherFactory", None)
+    config_cls = getattr(module, "KVEventsConfig", None)
+    fields = getattr(config_cls, "model_fields", {}) if config_cls is not None else {}
+    if not hasattr(factory, "is_enabled") or "enable_kv_cache_events" not in fields:
+        raise RuntimeError(
+            "TokenSpeed KV events require a TokenSpeed build with "
+            "KVEventsConfig.enable_kv_cache_events and "
+            "EventPublisherFactory.is_enabled support"
+        )
+
+
+def _local_dp_rank_range(server_args: Any) -> range:
+    mapping = getattr(server_args, "mapping", None)
+    attn_mapping = getattr(mapping, "attn", None)
+    dp_size = (
+        _optional_int(getattr(attn_mapping, "dp_size", None))
+        or _optional_int(getattr(server_args, "data_parallel_size", None))
+        or 1
+    )
+    if dp_size <= 1:
+        return range(0, 1)
+
+    nnodes = _optional_int(getattr(mapping, "nnodes", None)) or _optional_int(
+        getattr(server_args, "nnodes", None)
+    )
+    nnodes = nnodes or 1
+    node_rank = _optional_int(getattr(server_args, "node_rank", None)) or 0
+
+    dp_ranks_per_node = dp_size // nnodes
+    start = node_rank * dp_ranks_per_node
+    end = min(dp_size, start + dp_ranks_per_node)
+    return range(start, end)
+
+
+def _offset_zmq_endpoint_port(endpoint: str | None, dp_rank: int) -> str | None:
+    if not endpoint or dp_rank == 0:
+        return endpoint
+
+    if "inproc" in endpoint:
+        return f"{endpoint}_dp{dp_rank}"
+    if "tcp" in endpoint:
+        last_colon_idx = endpoint.rfind(":")
+        if last_colon_idx < 0:
+            return endpoint
+        base_addr = endpoint[:last_colon_idx]
+        base_port = int(endpoint[last_colon_idx + 1 :])
+        return f"{base_addr}:{base_port + dp_rank}"
+    raise ValueError("Invalid endpoint: must contain 'inproc' or 'tcp'")
+
+
+def _format_zmq_connect_endpoint(endpoint: str | None) -> str:
+    if not endpoint:
+        raise ValueError("TokenSpeed kv_events_config is missing an endpoint")
+    return endpoint.replace("*", "127.0.0.1")

--- a/components/src/dynamo/tokenspeed/tests/test_tokenspeed_llm_engine.py
+++ b/components/src/dynamo/tokenspeed/tests/test_tokenspeed_llm_engine.py
@@ -220,9 +220,7 @@ def test_completion_delta_output_preserves_later_token_delta():
 
 def test_kv_events_enabled_requires_enabled_non_null_publisher():
     assert kv_events_enabled('{"enable_kv_cache_events": true}')
-    assert kv_events_enabled(
-        '{"publisher": "zmq", "enable_kv_cache_events": true}'
-    )
+    assert kv_events_enabled('{"publisher": "zmq", "enable_kv_cache_events": true}')
     assert not kv_events_enabled(
         '{"publisher": "null", "enable_kv_cache_events": true}'
     )
@@ -242,8 +240,7 @@ def test_offset_zmq_endpoint_port_matches_tokenspeed():
     assert _offset_zmq_endpoint_port("tcp://*:5557", 0) == "tcp://*:5557"
     assert _offset_zmq_endpoint_port("tcp://*:5557", 2) == "tcp://*:5559"
     assert (
-        _offset_zmq_endpoint_port("inproc://kv-events", 2)
-        == "inproc://kv-events_dp2"
+        _offset_zmq_endpoint_port("inproc://kv-events", 2) == "inproc://kv-events_dp2"
     )
 
 

--- a/components/src/dynamo/tokenspeed/tests/test_tokenspeed_llm_engine.py
+++ b/components/src/dynamo/tokenspeed/tests/test_tokenspeed_llm_engine.py
@@ -1,13 +1,20 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
 import json
+from types import SimpleNamespace
 
 import pytest
 
+from dynamo.common.backend.engine import EngineConfig
 from dynamo.llm.exceptions import InvalidArgument
+from dynamo.tokenspeed.args import kv_events_enabled
 from dynamo.tokenspeed.llm_engine import (
+    TokenspeedLLMEngine,
     _completion_delta_output,
+    _local_dp_rank_range,
+    _offset_zmq_endpoint_port,
     _validate_single_choice_sampling,
     build_sampling_params,
     convert_output_to_chunk,
@@ -209,3 +216,83 @@ def test_completion_delta_output_preserves_later_token_delta():
 
     assert emitted == 2
     assert delta_out["output_ids"] == [100]
+
+
+def test_kv_events_enabled_requires_enabled_non_null_publisher():
+    assert kv_events_enabled('{"enable_kv_cache_events": true}')
+    assert kv_events_enabled(
+        '{"publisher": "zmq", "enable_kv_cache_events": true}'
+    )
+    assert not kv_events_enabled(
+        '{"publisher": "null", "enable_kv_cache_events": true}'
+    )
+    assert not kv_events_enabled('{"enable_kv_cache_events": false}')
+
+
+def test_local_dp_rank_range_matches_tokenspeed_node_partitioning():
+    server_args = SimpleNamespace(
+        mapping=SimpleNamespace(attn=SimpleNamespace(dp_size=4), nnodes=2),
+        node_rank=1,
+    )
+
+    assert list(_local_dp_rank_range(server_args)) == [2, 3]
+
+
+def test_offset_zmq_endpoint_port_matches_tokenspeed():
+    assert _offset_zmq_endpoint_port("tcp://*:5557", 0) == "tcp://*:5557"
+    assert _offset_zmq_endpoint_port("tcp://*:5557", 2) == "tcp://*:5559"
+    assert (
+        _offset_zmq_endpoint_port("inproc://kv-events", 2)
+        == "inproc://kv-events_dp2"
+    )
+
+
+def test_start_kv_events_subscribes_to_tokenspeed_zmq_ports(monkeypatch):
+    created = []
+
+    class FakeKvEventPublisher:
+        def __init__(self, **kwargs):
+            created.append(kwargs)
+
+        def shutdown(self):
+            pass
+
+    monkeypatch.setattr(
+        "dynamo.tokenspeed.llm_engine._kv_event_publisher_cls",
+        lambda: FakeKvEventPublisher,
+    )
+    monkeypatch.setattr(
+        "dynamo.tokenspeed.llm_engine._assert_tokenspeed_kv_events_supported",
+        lambda: None,
+    )
+
+    server_args = SimpleNamespace(
+        kv_events_config=(
+            '{"publisher":"zmq","endpoint":"tcp://*:5557",'
+            '"enable_kv_cache_events":true}'
+        ),
+        block_size=64,
+        enable_prefix_caching=True,
+        mapping=SimpleNamespace(attn=SimpleNamespace(dp_size=2), nnodes=1),
+        node_rank=0,
+    )
+    engine = TokenspeedLLMEngine(
+        server_args,
+        dynamo_config=SimpleNamespace(enable_local_indexer=True),
+    )
+
+    asyncio.run(
+        engine.start_kv_events(
+            endpoint="generate-endpoint",
+            engine_config=EngineConfig(model="m", kv_cache_block_size=64),
+        )
+    )
+
+    assert [item["dp_rank"] for item in created] == [0, 1]
+    assert [item["zmq_endpoint"] for item in created] == [
+        "tcp://127.0.0.1:5557",
+        "tcp://127.0.0.1:5558",
+    ]
+    assert all(item["endpoint"] == "generate-endpoint" for item in created)
+    assert all(item["kv_block_size"] == 64 for item in created)
+    assert all(item["enable_local_indexer"] is True for item in created)

--- a/lib/backend-common/src/engine.rs
+++ b/lib/backend-common/src/engine.rs
@@ -77,6 +77,21 @@ pub trait LLMEngine: Send + Sync + 'static {
     /// endpoint serving.
     async fn start(&self) -> Result<EngineConfig, DynamoError>;
 
+    /// Start optional backend-specific KV event relays.
+    ///
+    /// Called after [`LLMEngine::start`] returns and after the Dynamo endpoint
+    /// has been constructed, but before the model is registered and request
+    /// serving begins. Backends that receive native KV cache events over a
+    /// side channel can override this hook to attach a relay to the worker's
+    /// endpoint. The default is a no-op for engines without KV event support.
+    async fn start_kv_events(
+        &self,
+        _endpoint: dynamo_runtime::component::Endpoint,
+        _engine_config: &EngineConfig,
+    ) -> Result<(), DynamoError> {
+        Ok(())
+    }
+
     /// Yield streaming response chunks for a single request.
     ///
     /// Called concurrently for multiple in-flight requests. The returned

--- a/lib/backend-common/src/worker.rs
+++ b/lib/backend-common/src/worker.rs
@@ -352,6 +352,22 @@ impl Worker {
             return Ok(());
         }
 
+        self.engine
+            .start_kv_events(endpoint.clone(), &engine_config)
+            .await?;
+        tracing::debug!("engine.start_kv_events() complete");
+
+        // Mid-KV-event setup signal: the engine and optional KV relays are
+        // initialized, so use the orchestrator path to drain and clean up
+        // while the distributed runtime is still alive.
+        if shutdown.is_cancelled() {
+            tracing::info!(
+                "Shutdown signal observed during engine.start_kv_events(); running orchestrator"
+            );
+            self.orchestrator_steps(&endpoint).await;
+            return Ok(());
+        }
+
         self.serve_with_orchestrator(&engine_config, endpoint, shutdown.clone())
             .await
     }

--- a/lib/bindings/python/rust/backend.rs
+++ b/lib/bindings/python/rust/backend.rs
@@ -32,6 +32,7 @@ use pyo3::types::{PyDict, PyModule};
 use pyo3_async_runtimes::TaskLocals;
 use pythonize::{depythonize, pythonize};
 
+use crate::Endpoint;
 use crate::ModelInput;
 use crate::context::Context as PyContext;
 use crate::errors::py_exception_to_backend_error;
@@ -444,6 +445,48 @@ impl LLMEngine for PyLLMEngine {
             })
         })
         .map_err(py_err_to_dynamo)
+    }
+
+    async fn start_kv_events(
+        &self,
+        endpoint: dynamo_runtime::component::Endpoint,
+        engine_config: &RsEngineConfig,
+    ) -> Result<(), DynamoError> {
+        let engine = self.engine.clone();
+        let event_loop = self.event_loop.clone();
+        let engine_config = engine_config.clone();
+
+        let py_future = tokio::task::spawn_blocking(move || {
+            Python::with_gil(|py| -> PyResult<_> {
+                let py_endpoint = Py::new(
+                    py,
+                    Endpoint {
+                        inner: endpoint,
+                        event_loop: event_loop.as_ref().clone_ref(py),
+                    },
+                )?;
+                let py_engine_config = Py::new(
+                    py,
+                    EngineConfig {
+                        inner: engine_config,
+                    },
+                )?;
+                let bound = engine.bind(py);
+                let coroutine =
+                    bound.call_method1("start_kv_events", (py_endpoint, py_engine_config))?;
+                let locals = TaskLocals::new(event_loop.bind(py).clone());
+                pyo3_async_runtimes::into_future_with_locals(&locals, coroutine)
+            })
+        })
+        .await
+        .map_err(|e| {
+            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("offload error: {e}"))
+        })
+        .map_err(py_err_to_dynamo)?
+        .map_err(py_err_to_dynamo)?;
+
+        py_future.await.map_err(py_err_to_dynamo)?;
+        Ok(())
     }
 
     async fn generate(


### PR DESCRIPTION
#### Overview:

Adds KV event publishing support for TokenSpeed backends so Dynamo can pass KV event configuration through the common backend APIs and wire TokenSpeed workers into the event stream.

Depends on https://github.com/lightseekorg/tokenspeed/pull/8

#### Details:

- Adds common backend plumbing for KV event configuration and worker metadata.
- Extends the Python TokenSpeed argument/config handling to parse and enable KV cache events.
- Wires TokenSpeed LLM engine startup to configure event publishing endpoints, including per-data-parallel endpoint offsets.
- Updates Python/Rust backend bindings so KV event configuration can flow through backend initialization.
- Adds TokenSpeed unit coverage for KV event config parsing, enablement checks, and endpoint offset behavior.

#### Where should the reviewer start?

Start with `components/src/dynamo/tokenspeed/llm_engine.py` for the TokenSpeed integration path, then `components/src/dynamo/tokenspeed/args.py` for config parsing. The backend interface changes are in `lib/backend-common/src/engine.rs`, `lib/backend-common/src/worker.rs`, and `lib/bindings/python/rust/backend.rs`.

#### Validation:

- `uvx prek run --all-files`
- GitHub DCO and pre-commit are passing on the rebased, signed PR head.
- Full PR CI is running on the refreshed `pull-request/9234` validation branch.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to TokenSpeed KV event support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added KV (key-value) cache event support with configurable event publishers and flexible endpoint management
* Introduced optional backend lifecycle hooks for KV event initialization and relaying across all supported implementations
* Enhanced server configuration to conditionally enable KV cache events based on runtime settings and publisher configuration
* Integrated KV event publishing capabilities with the TokenSpeed backend

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9234)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->