### PR TITLE
fix(test): wire SGLang/TRT-LLM KV markers and fix pool OOM

### DIFF
--- a/examples/common/gpu_utils.sh
+++ b/examples/common/gpu_utils.sh
@@ -57,7 +57,13 @@ build_vllm_gpu_mem_args() {
 # ---------------------------------------------------------------------------
 build_sglang_gpu_mem_args() {
     if [[ -n "${_PROFILE_OVERRIDE_SGLANG_MAX_TOTAL_TOKENS:-}" ]]; then
-        echo "--max-total-tokens ${_PROFILE_OVERRIDE_SGLANG_MAX_TOTAL_TOKENS}"
+        # --mem-fraction-static 0.9: SGLang sizes the KV cache pool using this
+        # fraction of pre-model-load memory BEFORE applying --max-total-tokens.
+        # The default (~0.65) can request more pool memory than is available on
+        # smaller GPUs (e.g. L4 24 GiB) even when the token cap would fit.
+        # Setting 0.9 maximises the pool headroom; the token cap controls the
+        # actual allocation.
+        echo "--max-total-tokens ${_PROFILE_OVERRIDE_SGLANG_MAX_TOTAL_TOKENS} --mem-fraction-static 0.9"
         return 0
     fi
 

--- a/examples/common/gpu_utils.sh
+++ b/examples/common/gpu_utils.sh
@@ -183,7 +183,7 @@ _gpu_utils_self_test() {
     echo "=== sglang: token cap env ==="
     result=$(_PROFILE_OVERRIDE_SGLANG_MAX_TOTAL_TOKENS=1024 \
         build_sglang_gpu_mem_args)
-    _assert "token cap" "--max-total-tokens 1024" "$result"
+    _assert "token cap" "--max-total-tokens 1024 --mem-fraction-static 0.9" "$result"
 
     echo ""
     echo "=== sglang: no override = empty ==="

--- a/tests/serve/common.py
+++ b/tests/serve/common.py
@@ -67,6 +67,31 @@ def run_serve_deployment(
                 "_PROFILE_OVERRIDE_VLLM_KV_CACHE_BYTES", str(int(kv_mark.args[0]))
             )
 
+    if "_PROFILE_OVERRIDE_SGLANG_MAX_TOTAL_TOKENS" not in os.environ:
+        sglang_kv_mark = request.node.get_closest_marker("requested_sglang_kv_tokens")
+        if sglang_kv_mark:
+            merged_env.setdefault(
+                "_PROFILE_OVERRIDE_SGLANG_MAX_TOTAL_TOKENS",
+                str(int(sglang_kv_mark.args[0])),
+            )
+
+    if "_PROFILE_OVERRIDE_TRTLLM_MAX_TOTAL_TOKENS" not in os.environ:
+        trtllm_kv_mark = request.node.get_closest_marker("requested_trtllm_kv_tokens")
+        if trtllm_kv_mark:
+            merged_env.setdefault(
+                "_PROFILE_OVERRIDE_TRTLLM_MAX_TOTAL_TOKENS",
+                str(int(trtllm_kv_mark.args[0])),
+            )
+
+    if "_PROFILE_OVERRIDE_TRTLLM_MAX_GPU_TOTAL_BYTES" not in os.environ:
+        trtllm_vram_mark = request.node.get_closest_marker("requested_trtllm_vram_gib")
+        if trtllm_vram_mark:
+            gib_to_bytes = int(trtllm_vram_mark.args[0] * 1024**3)
+            merged_env.setdefault(
+                "_PROFILE_OVERRIDE_TRTLLM_MAX_GPU_TOTAL_BYTES",
+                str(gib_to_bytes),
+            )
+
     # Stagger engine startup under xdist to avoid vLLM profiling race
     # (vLLM bug #10643: concurrent profilers miscount each other's memory).
     worker_id = os.environ.get("PYTEST_XDIST_WORKER", "")


### PR DESCRIPTION
#### Overview:

SGLang tests with `@pytest.mark.requested_sglang_kv_tokens(N)` OOM on L4 (24 GiB) CI runners despite being correctly profiled, because:
1. The marker was never translated to the `_PROFILE_OVERRIDE_SGLANG_MAX_TOTAL_TOKENS` env var
2. Even when the env var IS set, SGLang's default `--mem-fraction-static` (~0.65) causes the KV pool allocation to fail before the token cap is applied

**How `--mem-fraction-static` and `--max-total-tokens` interact in SGLang:**

SGLang allocates KV cache in two stages. `--mem-fraction-static` is a gate (pass/fail), not a reservation. `--max-total-tokens` controls actual allocation.

GPU memory layout (L4 24 GiB, `Qwen2-VL-7B`):
```
|<──────────── 24 GiB ──────────────────>|
| ctx | Model Weights 16G | FREE  7.4G   |

Stage 1 — Pool gate (mem_fraction_static):
  budget = fraction × free_before_model
         - model_weights
  If budget ≤ 0 → OOM (stage 2 never runs)

Stage 2 — Actual KV alloc (max_total_tokens):
  tokens = min(budget / cell_size,
               max_total_tokens)
  KV tensors allocated for exactly 'tokens' entries — nothing more
```

The fraction is a formula input, not a reservation. Setting it to 0.9 does not hold 90% of VRAM, it tells SGLang "budget up to 90% for weights+KV" so the pool-creation math succeeds. Then `--max-total-tokens` keeps actual allocation at the profiled level. Unused budget is genuinely free for other processes.
```
default fraction 0.636, no token cap:
  budget = 0.636 × 23.4 - 16 = -1.1 GiB
  → gate CLOSED, OOM 💥

fraction 0.9 + max_total_tokens=8736:
  budget = 0.9 × 23.4 - 16 = 5.1 GiB
  → gate OPEN ✅
  actual alloc = 8736 tokens ≈ 1 GiB
  free for other work = 6.4 GiB
```

**Repro** (simulated L4 on 48 GiB RTX 6000 Ada — 25 GiB background tensor, ~22 GiB free):
```
pytest  tests/serve/test_sglang.py\
  ::test_sglang_deployment[video_agg_qwen-2] -xvs
```


**Before (unfixed):** mem_fraction_static=0.65436
```
max_total_tokens=None          ← marker not wired
RuntimeError: Not enough memory
EXIT_CODE=1 FAILED
```



**After (fixed):** mem_fraction_static=0.9        ← pool creation succeeds
```
max_total_tokens=8736          ← marker wired through
Got total KV blocks: 546 (max_total_tokens=8736)
PASSED
EXIT_CODE=0
```

#### Details:

- In `tests/serve/common.py`, `run_serve_deployment()` already translated the vLLM KV marker into its env var but was missing SGLang and TRT-LLM. Added three blocks matching the existing vLLM pattern:
  - `requested_sglang_kv_tokens` → `_PROFILE_OVERRIDE_SGLANG_MAX_TOTAL_TOKENS`
  - `requested_trtllm_kv_tokens` → `_PROFILE_OVERRIDE_TRTLLM_MAX_TOTAL_TOKENS`
  - `requested_trtllm_vram_gib` → `_PROFILE_OVERRIDE_TRTLLM_MAX_GPU_TOTAL_BYTES`
- `examples/common/gpu_utils.sh` — `build_sglang_gpu_mem_args()` now emits `--mem-fraction-static 0.9` alongside `--max-total-tokens N`. This ensures the pool gate opens on small GPUs. The fraction is safe because it doesn't reserve memory, only `--max-total-tokens` controls actual allocation.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues
- Fixes post-merge CI: test_sglang_deployment[video_agg_qwen-2] OOM
- CI run: https://github.com/ai-dynamo/dynamo/actions/runs/25444234919/job/74644085737
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9238" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced GPU memory tuning for SGLang deployments with improved static memory fraction configuration.

* **Chores**
  * Extended environment variable override support for KV token and VRAM memory configuration across SGLang and TensorRT-LLM backends.
  * Improved memory parameter handling in model deployment configurations for better resource allocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->