### PR TITLE
fix(test): mm_e_pd_llava-1.5-7b: retry on "all content fields empty"

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -487,8 +487,10 @@ All commands shown in the "Local equivalent" columns above are also documented i
 
 Tests must be deterministic. A flaky test -- one that sometimes passes and sometimes fails without code changes -- wastes CI time and erodes developer trust in the test suite. If you encounter or introduce a flaky test:
 
-1. **Fix it first.** Remove sources of non-determinism: set a fixed random seed, eliminate race conditions, mock network calls, avoid relying on execution order. For LLM-output assertions, pass `temperature=0` and `seed=0` to the request so the model picks the same tokens each call.
-2. **If determinism truly isn't reachable** (model genuinely non-deterministic, an upstream library has races we don't own, etc.), retry. There are two mechanisms; pick based on what the test does.
+1. **Fix it first.** Remove sources of non-determinism: set a fixed random seed, eliminate race conditions, mock network calls, avoid relying on execution order.
+
+   **Special case — LLM-output assertions.** Pass `temperature=0` and `seed=0` so sampling picks the same logits, but treat that as **necessary, not sufficient**: GPU-served LLM inference remains non-deterministic in practice from FP non-associativity in tensor-parallel reductions, batch-size-dependent kernel selection (cuBLAS / flash-attn), prefix-cache state across calls, and non-deterministic attention kernels. For any test asserting on served-model response content, configure retry (step 2b below) — treat it as required, not a fallback.
+2. **If determinism truly isn't reachable** (LLM-output content as above, model genuinely non-deterministic, an upstream library has races we don't own, etc.), retry. There are two mechanisms; pick based on what the test does.
 
    **2a. Whole-test retry — `@pytest.mark.flaky`** (use for unit tests, parser tests, tool-calling tests, anything that doesn't launch a server)
 

--- a/tests/utils/payloads.py
+++ b/tests/utils/payloads.py
@@ -170,7 +170,7 @@ class ChatPayload(BasePayload):
             if field_content:
                 return field_content
 
-        raise ValueError(
+        raise AssertionError(
             "All possible content fields are empty in message. "
             f"Checked: content={repr(content)}, reasoning_content={repr(reasoning_content)}, "
             f"refusal={repr(refusal)}, tool_calls={tool_calls}"


### PR DESCRIPTION
#### Overview:

`test_serve_deployment[mm_e_pd_llava-1.5-7b]` flakes with `All possible content fields are empty in message`, but `payloads.py:173` raises `ValueError` which bypasses the `ResponseValidationError` retry from #9036. Change to `raise AssertionError` so `engine_process.py:126` routes it through the retry path; also update `tests/README.md` to flag that retry is required (not a fallback) for any LLM-output content assertion.

#### Details:

- `tests/utils/payloads.py:173`: `raise ValueError(...)` → `raise AssertionError(...)` — one-line change, `tests/utils/` only
- `tests/README.md` §Flaky Tests: rewrite step 1 to call out that `temperature=0` + `seed=0` is necessary but not sufficient on GPU-served LLMs (FP non-associativity in TP reductions, batch-size-dependent kernel selection, prefix-cache state, non-deterministic attention kernels), and that retry is required for LLM content assertions
- Verified in dev container: empty-content response now raises `AssertionError` → wrapped as `ResponseValidationError` → caught by `common.py:210` retry loop

#### Where should the reviewer start?

`tests/utils/payloads.py`, then `tests/utils/engine_process.py:122-128`, then `tests/README.md` §Flaky Tests

#### Related Issues:

Relates to [OPS-4520](https://linear.app/nvidia/issue/OPS-4520), [OPS-4521](https://linear.app/nvidia/issue/OPS-4521); follow-up to #9036 (added the retry but couldn't fire on this exception path).

/coderabbit profile chill