### PR TITLE
docs: add TokenSpeed Digest date

### DIFF
--- a/docs/digest/tokenspeed/tokenspeed-day-0.md
+++ b/docs/digest/tokenspeed/tokenspeed-day-0.md
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: "Dynamo Day 0 support for TokenSpeed"
-subtitle: "A short launch note for running TokenSpeed with Dynamo"
+subtitle: "A short launch note for running TokenSpeed with Dynamo — May 2026"
 description: "Dynamo adds day-0 TokenSpeed support with the Dynamo frontend for Kimi K2.5."
 keywords: TokenSpeed, Dynamo, LightSeek, Kimi K2.5, disaggregated serving, KV cache routing, LLM inference
 last-updated: May 6, 2026


### PR DESCRIPTION
## Summary
- adds `May 2026` to the TokenSpeed Day 0 Digest subtitle so it matches the other Digest posts

## Validation
- `git diff --check`
- commit hooks via `SKIP=pytest-marker-report git commit`

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9243" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated TokenSpeed Day 0 launch documentation with date clarification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->