### PR TITLE
docs(kv-router): document Mooncake RFC #1403 multi-tier indexer API

### DIFF
--- a/docs/components/router/standalone-indexer.md
+++ b/docs/components/router/standalone-indexer.md
@@ -12,6 +12,7 @@ The standalone KV indexer (`python -m dynamo.indexer`) is a lightweight service 
 - It subscribes to ZMQ KV event streams directly from workers.
 - It exposes an HTTP API for registration, inspection, and overlap queries.
 - It preserves P2P recovery and gap detection/replay for the standalone ZMQ path.
+- It indexes device, host-pinned, and disk tier blocks and reports per-tier matches in `/query` responses.
 
 This is distinct from the [Standalone Router](../../../components/src/dynamo/router/README.md), which is a full routing service. The standalone indexer provides only the indexing and query layer without routing logic.
 
@@ -34,6 +35,8 @@ The indexer maintains one radix tree per `(model_name, tenant_id)` pair. Workers
 ## Compatibility
 
 The standalone indexer works with any engine that publishes KV cache events over ZMQ in the expected msgpack format. This includes bare vLLM and SGLang engines, which emit ZMQ KV events natively — no Dynamo-specific wrapper is required.
+
+Events tagged with non-device storage tiers (host-pinned, disk, external) are routed into a lower-tier slot rather than dropped, and surface in `/query` responses as `cpu` / `disk` reach.
 
 ## Use Cases
 
@@ -196,6 +199,7 @@ curl -X POST http://localhost:8090/register \
 | `tenant_id` | no | `"default"` | Tenant identifier for isolation |
 | `dp_rank` | no | `0` | Data parallel rank |
 | `replay_endpoint` | no | — | ZMQ ROUTER address for gap replay (e.g. `tcp://host:5560`) |
+| `additional_salt` | no | — | Per-tenant salt (Mooncake RFC #1403 `additionalsalt`, alias accepted). Currently parsed for forward compatibility — engines apply their own salting today. |
 
 ### `POST /unregister` — Deregister an instance
 
@@ -279,11 +283,30 @@ Returns:
 ```json
 {
   "scores": {"1": {"0": 32}, "2": {"1": 0}},
-  "frequencies": [1, 1]
+  "frequencies": [1, 1],
+  "instances": {
+    "1": {
+      "longest_matched": 48,
+      "gpu": 32,
+      "dp": {"0": 32},
+      "cpu": 48,
+      "disk": 48
+    },
+    "2": {
+      "longest_matched": 0,
+      "gpu": 0,
+      "dp": {"1": 0},
+      "cpu": 0,
+      "disk": 0
+    }
+  }
 }
 ```
 
-Scores are in **matched tokens** (block overlap count × block size). Nested by `instance_id` then `dp_rank`.
+All counts are in **matched tokens** (block overlap count × block size).
+
+- `scores` / `frequencies`: legacy device-tier overlap. `scores` is nested by `instance_id` then `dp_rank`. Preserved for backward compatibility — existing callers do not need to change.
+- `instances`: per-instance, per-tier breakdown aligned with [Mooncake RFC #1403](https://github.com/kvcache-ai/Mooncake/issues/1403). See [Per-instance tier breakdown](#per-instance-tier-breakdown) below.
 
 | Field | Required | Default | Description |
 |-------|----------|---------|-------------|
@@ -291,6 +314,7 @@ Scores are in **matched tokens** (block overlap count × block size). Nested by 
 | `model_name` | yes | — | Model name (selects the indexer) |
 | `tenant_id` | no | `"default"` | Tenant identifier |
 | `lora_name` | no | — | LoRA adapter (overrides indexer-level lora_name for this query) |
+| `cache_salt` | no | — | Per-request cache salt (Mooncake RFC #1403). Currently parsed for forward compatibility — engines apply their own salting today. |
 
 ### `POST /query_by_hash` — Query overlap for pre-computed hashes
 
@@ -300,13 +324,30 @@ curl -X POST http://localhost:8090/query_by_hash \
   -d '{"block_hashes": [123456, 789012], "model_name": "llama-3-8b"}'
 ```
 
-Same response format as `/query`. Scores are in matched tokens.
+Same response format as `/query`, including the per-instance `instances` map. Scores are in matched tokens.
 
 | Field | Required | Default | Description |
 |-------|----------|---------|-------------|
 | `block_hashes` | yes | — | Pre-computed block hash array |
 | `model_name` | yes | — | Model name (selects the indexer) |
 | `tenant_id` | no | `"default"` | Tenant identifier |
+| `cache_salt` | no | — | Per-request cache salt (Mooncake RFC #1403). Currently parsed for forward compatibility — engines apply their own salting today. |
+
+### Per-instance tier breakdown
+
+Each entry in `instances` is keyed by `instance_id` (as a string) and reports prefix reach across the device, host-pinned, and disk storage tiers:
+
+| Field | Description |
+|-------|-------------|
+| `gpu` | Tokens matched on the device tier (the longest device-tier prefix for any `dp_rank` of this instance). |
+| `dp` | Per-`dp_rank` device-tier match count, as `{rank: tokens}`. |
+| `cpu` | Tokens matched through the host-pinned tier. **Cumulative** through the device tier — includes everything counted in `gpu` plus any host-pinned extension. |
+| `disk` | Tokens matched through the disk (or external) tier. **Cumulative** through the device → host-pinned walk. |
+| `longest_matched` | The maximum of `gpu`, `cpu`, and `disk` — a single "best prefix length" the gateway can sort on. |
+
+Tier counts are cumulative because the lower-tier walk reports each tier's *extension* on top of the previous one. Under a natural offload pipeline (device → host → disk), this guarantees `gpu ≤ cpu ≤ disk` for every instance — lower tiers extend the device-tier prefix rather than shrink it.
+
+Legacy callers that only consume `scores` keep working: those values are equal to each instance's per-`dp_rank` `gpu` count.
 
 ### `GET /dump` — Dump all radix tree events
 


### PR DESCRIPTION
## Summary

Follow-up to #8912 — that PR added Mooncake RFC #1403 alignment to the standalone HTTP indexer (per-instance tier breakdown plus `additional_salt`/`cache_salt`) but the user-facing docs in `docs/components/router/standalone-indexer.md` still showed only the legacy `scores`/`frequencies` response and didn't mention the new fields.

This PR brings the docs in line with what `python -m dynamo.indexer` actually returns today.

- Updates the `/query` example to include the `instances` map and explains the cumulative `gpu` ≤ `cpu` ≤ `disk` semantics.
- Notes that `/query_by_hash` returns the same per-instance shape.
- Adds `additional_salt` to the `/register` field table and `cache_salt` to both query field tables, with a short note that they're plumbed for forward compatibility.
- Adds a one-liner to the overview and to the Compatibility section pointing out that lower-tier (host-pinned / disk / external) events are now indexed instead of dropped.
- Cross-links the new "Per-instance tier breakdown" subsection with the existing Mooncake RFC #1403 reference.

No code changes — docs only.

## Test plan

- [ ] Render `docs/components/router/standalone-indexer.md` locally and check the new tables / JSON example.
- [ ] Spot-check that the example response matches what `build_score_response` in `lib/kv-router/src/standalone_indexer/server.rs` actually emits (legacy `scores`/`frequencies` plus the new `instances` map).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9247" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added optional `additional_salt` field to `/register` requests and optional `cache_salt` fields to `/query` and `/query_by_hash` requests in standalone KV indexer API documentation.
  * Enhanced `/query` response schema documentation with detailed per-instance tier breakdown (`gpu`, `dp`, `cpu`, `disk`, `longest_matched`) and clarified storage tier event handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->