### PR TITLE
fix: align SGLang prefill bootstrap room with DP rank

### DIFF
--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -1095,6 +1095,27 @@ class BaseWorkerHandler(LoraMixin, RLMixin, BaseGenerativeHandler[RequestT, Resp
         """
         return random.randint(0, 2**63 - 1)
 
+    @classmethod
+    def _generate_bootstrap_room_for_dp(
+        cls, dp_rank: Optional[int], dp_size: Optional[int]
+    ) -> int:
+        """Generate a bootstrap room aligned to the selected prefill DP rank."""
+        if dp_rank is None or dp_size is None:
+            return cls._generate_bootstrap_room()
+
+        try:
+            rank = int(dp_rank)
+            size = int(dp_size)
+        except (TypeError, ValueError):
+            return cls._generate_bootstrap_room()
+
+        if rank < 0 or size <= 0 or rank >= size:
+            return cls._generate_bootstrap_room()
+
+        max_room = 2**63 - 1
+        max_q = (max_room - rank) // size
+        return random.randint(0, max_q) * size + rank
+
     @staticmethod
     def _get_bootstrap_info(engine: sgl.Engine) -> Tuple[str, int]:
         """Extract bootstrap host and port from SGLang engine.

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -1112,6 +1112,9 @@ class BaseWorkerHandler(LoraMixin, RLMixin, BaseGenerativeHandler[RequestT, Resp
         if rank < 0 or size <= 0 or rank >= size:
             return cls._generate_bootstrap_room()
 
+        # All valid rooms have the form q * size + rank.
+        # Bound q so the result never exceeds i64::MAX (2^63 - 1),
+        # which is the room ID contract on the SGLang side.
         max_room = 2**63 - 1
         max_q = (max_room - rank) // size
         return random.randint(0, max_q) * size + rank

--- a/components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py
@@ -102,6 +102,12 @@ class PrefillWorkerHandler(BaseWorkerHandler):
         bootstrap_host = self.bootstrap_host
         bootstrap_port = self.bootstrap_port
         bootstrap_room = None
+        routing = inner_request.get("routing") or {}
+        priority = routing.get("priority")
+        dp_rank = routing.get("dp_rank")
+
+        if dp_rank is not None and dp_rank == _DP_RANK_UNSET:
+            dp_rank = None
 
         bootstrap_info_from_req = inner_request.get("bootstrap_info")
         if isinstance(bootstrap_info_from_req, dict):
@@ -121,7 +127,8 @@ class PrefillWorkerHandler(BaseWorkerHandler):
                 logging.debug(f"Using router-provided bootstrap_room: {bootstrap_room}")
 
         if bootstrap_room is None:
-            bootstrap_room = self._generate_bootstrap_room()
+            dp_size = getattr(self.config.server_args, "dp_size", None)
+            bootstrap_room = self._generate_bootstrap_room_for_dp(dp_rank, dp_size)
             logging.debug(f"Generated bootstrap_room locally: {bootstrap_room}")
 
         bootstrap_info = {
@@ -131,12 +138,6 @@ class PrefillWorkerHandler(BaseWorkerHandler):
         }
 
         input_param = self._get_input_param(inner_request)
-        routing = inner_request.get("routing") or {}
-        priority = routing.get("priority")
-        dp_rank = routing.get("dp_rank")
-
-        if dp_rank is not None and dp_rank == _DP_RANK_UNSET:
-            dp_rank = None
 
         trace_header = build_trace_headers(context) if self.enable_trace else None
 

--- a/components/src/dynamo/sglang/tests/test_sglang_unit.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_unit.py
@@ -212,7 +212,9 @@ async def test_prefill_generated_bootstrap_room_matches_dp_rank(monkeypatch):
     handler._consume_tasks = set()
     handler._engine_supports_priority = False
     handler.lora_id_for_name = {}
-    monkeypatch.setattr(handler, "_get_input_param", lambda _request: {"input_ids": [1]})
+    monkeypatch.setattr(
+        handler, "_get_input_param", lambda _request: {"input_ids": [1]}
+    )
     monkeypatch.setattr(
         PrefillWorkerHandler, "_generate_bootstrap_room", staticmethod(lambda: 4)
     )

--- a/components/src/dynamo/sglang/tests/test_sglang_unit.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_unit.py
@@ -3,6 +3,7 @@
 
 """Unit tests for SGLang backend components."""
 
+import asyncio
 import re
 import sys
 from pathlib import Path
@@ -23,6 +24,7 @@ from dynamo.sglang.health_check import (
     SglangPrefillHealthCheckPayload,
 )
 from dynamo.sglang.request_handlers.llm.decode_handler import DecodeWorkerHandler
+from dynamo.sglang.request_handlers.llm.prefill_handler import PrefillWorkerHandler
 from dynamo.sglang.tests.conftest import make_cli_args_fixture
 
 # Get path relative to this test file
@@ -175,6 +177,61 @@ def test_routed_experts_kwarg_forwarded_when_flag_on_and_supported():
     assert DecodeWorkerHandler._resolve_routed_experts_kwargs(
         NewEngine(), server_args
     ) == {"return_routed_experts": True}
+
+
+@pytest.mark.asyncio
+async def test_prefill_generated_bootstrap_room_matches_dp_rank(monkeypatch):
+    captured_kwargs = {}
+
+    async def fake_results():
+        yield {"meta_info": {"id": "prefill-test"}}
+
+    class FakeEngine:
+        async def async_generate(self, **kwargs):
+            captured_kwargs.update(kwargs)
+            return fake_results()
+
+    class FakeContext:
+        trace_id = "trace-id"
+
+        def id(self):
+            return "context-id"
+
+        def async_killed_or_stopped(self):
+            return asyncio.Future()
+
+    handler = PrefillWorkerHandler.__new__(PrefillWorkerHandler)
+    handler.engine = FakeEngine()
+    handler.config = SimpleNamespace(
+        server_args=SimpleNamespace(dp_size=8, enable_streaming_session=False)
+    )
+    handler.bootstrap_host = "127.0.0.1"
+    handler.bootstrap_port = 30000
+    handler.enable_trace = False
+    handler.shutdown_event = None
+    handler._consume_tasks = set()
+    handler._engine_supports_priority = False
+    handler.lora_id_for_name = {}
+    monkeypatch.setattr(handler, "_get_input_param", lambda _request: {"input_ids": [1]})
+    monkeypatch.setattr(
+        PrefillWorkerHandler, "_generate_bootstrap_room", staticmethod(lambda: 4)
+    )
+
+    request = {
+        "token_ids": [1],
+        "sampling_options": {},
+        "stop_conditions": {"max_tokens": 1},
+        "routing": {"dp_rank": 3},
+    }
+
+    outputs = []
+    async for output in handler.generate(request, FakeContext()):
+        outputs.append(output)
+
+    bootstrap_room = captured_kwargs["bootstrap_room"]
+    assert captured_kwargs["data_parallel_rank"] == 3
+    assert bootstrap_room % 8 == 3
+    assert outputs[0]["disaggregated_params"]["bootstrap_room"] == bootstrap_room
 
 
 def test_compat_caches_async_generate_signature_inspection(monkeypatch):


### PR DESCRIPTION
#### Overview:

Fix DP-Rank Mismatch in SGLang Prefill Bootstrap Room Generation

#### Details:

Trigger scenario:
This happens in the SGLang disaggregated LLM prefill path when a request already carries routing.dp_rank, but does not provide  bootstrap_info.bootstrap_room. 

Prefill is launched with an explicit data_parallel_rank=dp_rank, but the fallback bootstrap_room was random. Since SGLang decodes the prefill rank from  bootstrap_room % dp_size, the two sides could disagree. That can lead to KV-transfer mismatch, failed coordination between prefill and decode, unstable  disaggregated requests, and uneven DP behavior.


Expected behavior:
  When dp_rank and dp_size are known, the generated room must satisfy:
  bootstrap_room % dp_size == dp_rank
  That keeps the prefill rank chosen by routing consistent with the rank recovered by decode/KV transfer.


Root cause
  The Python prefill handler already read routing.dp_rank, but it still used the generic random helper when bootstrap_room was missing. So the request had  two rank sources with different semantics: an explicit data_parallel_rank on the prefill side, and a random modulo-derived rank on the decode side.


Fix:
  I added a DP-aware bootstrap-room helper  to use it only when the request is missing bootstrap_info.bootstrap_room. If dp_rank or dp_size is  unavailable or invalid, it falls back to the original random behavior.


#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

similar issue fixed in https://github.com/ai-dynamo/dynamo/pull/9080

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced bootstrap room generation logic with improved support for data-parallel configurations in distributed prefilling scenarios.

* **Tests**
  * Added unit tests validating bootstrap room selection and routing interaction in prefilling workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->