### PR TITLE
fix(kvbm-logical): remove unreachable partial.commit() in create_test_token_block

### DIFF
--- a/lib/kvbm-logical/src/testing/token_blocks.rs
+++ b/lib/kvbm-logical/src/testing/token_blocks.rs
@@ -9,16 +9,14 @@ use super::TEST_SALT;
 
 /// Create a token block from a slice of tokens with standard test salt.
 ///
-/// If the token count matches block_size, returns a complete block.
-/// Otherwise attempts to commit a partial block.
+/// The slice must contain at least one complete block.
 pub fn create_test_token_block(tokens: &[u32], block_size: u32) -> TokenBlock {
     let sequence = TokenBlockSequence::from_slice(tokens, block_size, Some(TEST_SALT));
-    if let Some(block) = sequence.blocks().first() {
-        block.clone()
-    } else {
-        let mut partial = sequence.into_parts().1;
-        partial.commit().expect("Should be able to commit")
-    }
+    sequence
+        .blocks()
+        .first()
+        .cloned()
+        .expect("create_test_token_block requires tokens.len() >= block_size")
 }
 
 /// Create a token block with sequential tokens starting from `start`.


### PR DESCRIPTION
#### Overview:

create_test_token_block previously fell back to committing the trailing PartialTokenBlock when TokenBlockSequence::from_slice produced no complete blocks. That fallback can never succeed:                                    
                  
  - TokenBlockSequence::from_slice already consumes every full                
  block_size-sized chunk into sequence.blocks(), leaving only the leftover tokens (< block_size) in the partial block.                                 
  - PartialTokenBlock::commit returns TokenBlockError::Incomplete unless the partial holds exactly block_size tokens (lib/tokens/src/lib.rs:683-687).    
   
  So whenever the else branch was reached, the partial was guaranteed to be incomplete and partial.commit().expect("Should be able to commit") would panic. The branch was effectively dead code that masked the real precondition with a misleading error message.

#### Details:

  - lib/kvbm-logical/src/testing/token_blocks.rs: drop the unreachable partial.commit() fallback. Return the first complete block from the sequence, or panic with a clear message stating that the caller must supply at least one full block (tokens.len() >= block_size).
  - Update the doc comment to reflect the actual contract.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9251" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Test helper for token blocks now enforces stricter validation, requiring complete block input and failing fast if requirements are not met.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->