### PR TITLE
feat(operator): keep shared-spec conversion logic in API conversions

### DIFF
--- a/deploy/operator/api/CONVERSION.md
+++ b/deploy/operator/api/CONVERSION.md
@@ -164,6 +164,19 @@ as `preserve` for conversion policy: use `restore` when reading `restored`, and
 Preservation annotations exist only to make unrepresentable data survive a
 round trip through a version that cannot express it natively.
 
+Preservation annotations are private to conversion code. Only API conversion
+code and its conversion tests may know their keys or payload shape. Controllers,
+reconcilers, webhooks, internal helper packages, and general API helpers must
+not read, write, delete, filter, decode, encode, branch on, or expose them.
+Do not define shared constants, prefixes, string literals, getters, predicates,
+or wrapper helpers for conversion annotations outside the conversion package.
+
+Non-conversion code may copy Kubernetes metadata opaquely as part of normal
+object handling, but it must not identify or interpret individual conversion
+annotations. If non-conversion code needs data that currently appears only in a
+preservation annotation, add or call a real conversion helper instead of
+decoding the annotation.
+
 It is acceptable for the annotation payload to include representable fields as
 context. Restore code must explicitly ignore those fields unless they are needed
 only to locate the unrepresentable data.
@@ -325,6 +338,8 @@ For each helper:
 - Are named-list fields matched by their list-map key, never by index?
 - Is the save payload sparse?
 - Are origin annotations used only as hints, not as shortcuts?
+- Are conversion annotations private to conversion code and absent from
+  controllers/internal helpers?
 - Are nil and empty shapes preserved where round-trip tests require them?
 
 ## Mutability

--- a/deploy/operator/api/CONVERSION.md
+++ b/deploy/operator/api/CONVERSION.md
@@ -64,6 +64,39 @@ return preserved if annotation exists
 
 ## Structural Helpers
 
+Conversion policy belongs in the API conversion package. Do not put conversion
+logic in controllers, internal helper packages, or compatibility wrappers. If a
+controller temporarily needs converted data while versions are being reconciled,
+it should call the same conversion function that the real conversion path uses.
+Read-only getters are acceptable outside the API package; conversion helpers
+are not.
+
+Exported conversion helpers in the `v1alpha1` package use the spoke type name:
+
+```go
+func ConvertTo<TypeName>(src *v1beta1.HubType, dst *TypeName)
+func ConvertFrom<TypeName>(src *TypeName, dst *v1beta1.HubType)
+```
+
+Do not include `V1alpha1` in these names; the package already says that. Do not
+add wrapper functions with alternative names. Callers that need this behavior
+should call the structural helper directly.
+
+The paired `ConvertTo<TypeName>` and `ConvertFrom<TypeName>` functions must use
+the same structural signature: source pointer first, destination pointer second,
+and an optional typed context argument only at the end. The destination must be
+non-nil and owned by the caller. The conversion function writes into `dst`; it
+does not allocate `dst`, does not accept `**T`, and does not encode absence by
+assigning nil. Callers perform nil, disabled, zero, or absence checks before
+calling the helper and allocate destination subobjects explicitly.
+
+Conversion helpers must mirror the API type structure. If a converted type has
+a nested sub-struct that needs conversion, add the corresponding structural
+`ConvertTo<SubStruct>` and `ConvertFrom<SubStruct>` pair as well. Do not skip a
+sub-struct and inline its conversion somewhere else because it currently looks
+small. The point is to make every conversion edge systematic, discoverable, and
+usable by both generated-style conversion flow and temporary controller code.
+
 Conversion helpers should generally follow a `src`, `dst`, `restored`, `save`,
 `ctx` shape:
 
@@ -297,6 +330,17 @@ For each helper:
 ## Mutability
 
 Conversion functions must not mutate their input object.
+
+`src` and `dst` may share backing data when the converted value can be assigned
+as-is. Do not add `DeepCopy` calls only because a field came from `src`.
+Aliasing is acceptable when the conversion code treats the shared value as
+read-only after assignment.
+
+Use `DeepCopy` only when the conversion needs an independently mutable value:
+for example, before editing, appending to, sorting, normalizing, clearing,
+merging into, or otherwise mutating a value that came from `src`. This applies
+equally to direct mutation through `src` and indirect mutation through a `dst`
+field that aliases `src`; both violate the "do not mutate input" invariant.
 
 The round-trip fuzz tests snapshot inputs through YAML before conversion because
 marshalling observes the actual in-memory shape, including aliasing bugs that a

--- a/deploy/operator/api/v1alpha1/shared_spec_conversion.go
+++ b/deploy/operator/api/v1alpha1/shared_spec_conversion.go
@@ -792,46 +792,50 @@ func sharedHubSpecSaveIsZero(save *v1beta1.DynamoComponentDeploymentSharedSpec) 
 // Shared-memory
 // ---------------------------------------------------------------------------
 
-// ConvertToV1beta1SharedMemorySize converts the v1alpha1 shared-memory struct
-// into the v1beta1 scalar representation.
-func ConvertToV1beta1SharedMemorySize(src *SharedMemorySpec) *resource.Quantity {
-	if src == nil {
-		return nil
-	}
+// ConvertFromSharedMemorySpec converts the shared-memory struct into the
+// v1beta1 scalar representation.
+func ConvertFromSharedMemorySpec(src *SharedMemorySpec, dst *resource.Quantity) {
 	if src.Disabled {
-		return ptr.To(resource.MustParse("0"))
+		*dst = resource.MustParse("0")
+		return
 	}
-	if src.Size.IsZero() {
-		return nil
-	}
-	return ptr.To(src.Size.DeepCopy())
+	*dst = src.Size
 }
 
 func convertSharedMemoryTo(src *SharedMemorySpec, dst *v1beta1.DynamoComponentDeploymentSharedSpec) error {
-	dst.SharedMemorySize = ConvertToV1beta1SharedMemorySize(src)
+	if src != nil && (src.Disabled || !src.Size.IsZero()) {
+		dst.SharedMemorySize = &resource.Quantity{}
+		ConvertFromSharedMemorySpec(src, dst.SharedMemorySize)
+	}
 	return nil
 }
 
-func convertSharedMemoryFrom(src *resource.Quantity, dst *DynamoComponentDeploymentSharedSpec) {
-	if src == nil {
-		return
-	}
+// ConvertToSharedMemorySpec converts the v1beta1 shared-memory scalar
+// representation into the shared-memory struct.
+func ConvertToSharedMemorySpec(src *resource.Quantity, dst *SharedMemorySpec) {
 	if src.Sign() == 0 {
 		// Canonical v1beta1 "size=0" <-> v1alpha1 Disabled=true. See
 		// convertSharedMemoryTo for the forward direction.
 		//
-		// Size is carried as the DeepCopy of the incoming canonical Quantity
-		// (not the Go zero value) so that every apply produces a spec that is
-		// reflect.DeepEqual to what's in etcd. A bare Quantity{} and a
-		// JSON-round-tripped Quantity serialize identically to "0" but differ
-		// in internal state (Format, cached string), and the API server's
-		// generation-bump check uses DeepEqual -- so emitting a bare
-		// Quantity{} here would cause every `kubectl apply` to bump
-		// `.metadata.generation` even though the spec is byte-identical.
-		dst.SharedMemory = &SharedMemorySpec{Disabled: true, Size: src.DeepCopy()}
+		// Size carries the incoming canonical Quantity value (not the Go zero
+		// value) so that every apply produces a spec that is reflect.DeepEqual
+		// to what's in etcd. A bare Quantity{} and a JSON-round-tripped
+		// Quantity serialize identically to "0" but differ in internal state
+		// (Format, cached string), and the API server's generation-bump check
+		// uses DeepEqual -- so emitting a bare Quantity{} here would cause
+		// every `kubectl apply` to bump `.metadata.generation` even though the
+		// spec is byte-identical.
+		*dst = SharedMemorySpec{Disabled: true, Size: *src}
 		return
 	}
-	dst.SharedMemory = &SharedMemorySpec{Size: src.DeepCopy()}
+	*dst = SharedMemorySpec{Size: *src}
+}
+
+func convertSharedMemoryFrom(src *resource.Quantity, dst *DynamoComponentDeploymentSharedSpec) {
+	if src != nil {
+		dst.SharedMemory = &SharedMemorySpec{}
+		ConvertToSharedMemorySpec(src, dst.SharedMemory)
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -934,99 +938,82 @@ func checkpointModeFromV1beta1(mode v1beta1.CheckpointMode) CheckpointMode {
 	}
 }
 
-// ConvertToV1beta1GPUMemoryService converts the v1alpha1 GMS config into the
-// v1beta1 experimental GMS config. Disabled v1alpha1 configs are represented
-// by absence in v1beta1.
-func ConvertToV1beta1GPUMemoryService(src *GPUMemoryServiceSpec) *v1beta1.GPUMemoryServiceSpec {
-	if src == nil || !src.Enabled {
-		return nil
-	}
-	return &v1beta1.GPUMemoryServiceSpec{
+// ConvertFromGPUMemoryServiceSpec converts an enabled GMS config into the
+// v1beta1 experimental GMS config. Disabled configs are represented by absence
+// in v1beta1 and are skipped by the caller.
+func ConvertFromGPUMemoryServiceSpec(src *GPUMemoryServiceSpec, dst *v1beta1.GPUMemoryServiceSpec) {
+	*dst = v1beta1.GPUMemoryServiceSpec{
 		Mode:            gmsModeToV1beta1(src.Mode),
 		DeviceClassName: src.DeviceClassName,
 	}
 }
 
-// ConvertToV1alpha1GPUMemoryService converts the v1beta1 experimental GMS
-// config into the v1alpha1 enabled config.
-func ConvertToV1alpha1GPUMemoryService(src *v1beta1.GPUMemoryServiceSpec) *GPUMemoryServiceSpec {
-	if src == nil {
-		return nil
-	}
-	return &GPUMemoryServiceSpec{
+// ConvertToGPUMemoryServiceSpec converts the v1beta1 experimental GMS config
+// into the GMS config.
+func ConvertToGPUMemoryServiceSpec(src *v1beta1.GPUMemoryServiceSpec, dst *GPUMemoryServiceSpec) {
+	*dst = GPUMemoryServiceSpec{
 		Enabled:         true,
 		Mode:            gmsModeFromV1beta1(src.Mode),
 		DeviceClassName: src.DeviceClassName,
 	}
 }
 
-// ConvertToV1beta1Failover converts the v1alpha1 failover config into the
-// v1beta1 experimental failover config. Disabled v1alpha1 configs are
-// represented by absence in v1beta1.
-func ConvertToV1beta1Failover(src *FailoverSpec) *v1beta1.FailoverSpec {
-	if src == nil || !src.Enabled {
-		return nil
-	}
-	return &v1beta1.FailoverSpec{
+// ConvertFromFailoverSpec converts an enabled failover config into the v1beta1
+// experimental failover config. Disabled configs are represented by absence in
+// v1beta1 and are skipped by the caller.
+func ConvertFromFailoverSpec(src *FailoverSpec, dst *v1beta1.FailoverSpec) {
+	*dst = v1beta1.FailoverSpec{
 		Mode:       gmsModeToV1beta1(src.Mode),
 		NumShadows: src.NumShadows,
 	}
 }
 
-// ConvertToV1alpha1Failover converts the v1beta1 experimental failover config
-// into the v1alpha1 enabled config.
-func ConvertToV1alpha1Failover(src *v1beta1.FailoverSpec) *FailoverSpec {
-	if src == nil {
-		return nil
-	}
-	return &FailoverSpec{
+// ConvertToFailoverSpec converts the v1beta1 experimental failover config into
+// the failover config.
+func ConvertToFailoverSpec(src *v1beta1.FailoverSpec, dst *FailoverSpec) {
+	*dst = FailoverSpec{
 		Enabled:    true,
 		Mode:       gmsModeFromV1beta1(src.Mode),
 		NumShadows: src.NumShadows,
 	}
 }
 
-// ConvertToV1beta1ComponentCheckpoint converts the v1alpha1 checkpoint config
-// into the v1beta1 experimental checkpoint config. Disabled v1alpha1 configs
-// are represented by absence in v1beta1.
-func ConvertToV1beta1ComponentCheckpoint(src *ServiceCheckpointConfig) *v1beta1.ComponentCheckpointConfig {
-	if src == nil || !src.Enabled {
-		return nil
-	}
-	dst := &v1beta1.ComponentCheckpointConfig{
-		Mode:     checkpointModeToV1beta1(src.Mode),
-		Identity: ConvertToV1beta1CheckpointIdentity(src.Identity),
+// ConvertFromServiceCheckpointConfig converts an enabled checkpoint config into
+// the v1beta1 experimental checkpoint config. Disabled configs are represented
+// by absence in v1beta1 and are skipped by the caller.
+func ConvertFromServiceCheckpointConfig(src *ServiceCheckpointConfig, dst *v1beta1.ComponentCheckpointConfig) {
+	*dst = v1beta1.ComponentCheckpointConfig{
+		Mode: checkpointModeToV1beta1(src.Mode),
 	}
 	if src.CheckpointRef != nil {
-		dst.CheckpointRef = ptr.To(*src.CheckpointRef)
+		dst.CheckpointRef = src.CheckpointRef
 	}
-	return dst
+	if src.Identity != nil {
+		dst.Identity = &v1beta1.DynamoCheckpointIdentity{}
+		ConvertFromDynamoCheckpointIdentity(src.Identity, dst.Identity)
+	}
 }
 
-// ConvertToV1alpha1ComponentCheckpoint converts the v1beta1 experimental
-// checkpoint config into the v1alpha1 enabled config.
-func ConvertToV1alpha1ComponentCheckpoint(src *v1beta1.ComponentCheckpointConfig) *ServiceCheckpointConfig {
-	if src == nil {
-		return nil
-	}
-	dst := &ServiceCheckpointConfig{
-		Enabled:  true,
-		Mode:     checkpointModeFromV1beta1(src.Mode),
-		Identity: ConvertToV1alpha1CheckpointIdentity(src.Identity),
+// ConvertToServiceCheckpointConfig converts the v1beta1 experimental checkpoint
+// config into the checkpoint config.
+func ConvertToServiceCheckpointConfig(src *v1beta1.ComponentCheckpointConfig, dst *ServiceCheckpointConfig) {
+	*dst = ServiceCheckpointConfig{
+		Enabled: true,
+		Mode:    checkpointModeFromV1beta1(src.Mode),
 	}
 	if src.CheckpointRef != nil {
-		dst.CheckpointRef = ptr.To(*src.CheckpointRef)
+		dst.CheckpointRef = src.CheckpointRef
 	}
-	return dst
+	if src.Identity != nil {
+		dst.Identity = &DynamoCheckpointIdentity{}
+		ConvertToDynamoCheckpointIdentity(src.Identity, dst.Identity)
+	}
 }
 
-// ConvertToV1beta1CheckpointIdentity converts checkpoint identity fields from
-// v1alpha1 to v1beta1.
-func ConvertToV1beta1CheckpointIdentity(src *DynamoCheckpointIdentity) *v1beta1.DynamoCheckpointIdentity {
-	if src == nil {
-		return nil
-	}
-	return &v1beta1.DynamoCheckpointIdentity{
+// ConvertFromDynamoCheckpointIdentity converts checkpoint identity fields to
+// v1beta1.
+func ConvertFromDynamoCheckpointIdentity(src *DynamoCheckpointIdentity, dst *v1beta1.DynamoCheckpointIdentity) {
+	*dst = v1beta1.DynamoCheckpointIdentity{
 		Model:                src.Model,
 		BackendFramework:     src.BackendFramework,
 		DynamoVersion:        src.DynamoVersion,
@@ -1038,13 +1025,10 @@ func ConvertToV1beta1CheckpointIdentity(src *DynamoCheckpointIdentity) *v1beta1.
 	}
 }
 
-// ConvertToV1alpha1CheckpointIdentity converts checkpoint identity fields from
-// v1beta1 to v1alpha1.
-func ConvertToV1alpha1CheckpointIdentity(src *v1beta1.DynamoCheckpointIdentity) *DynamoCheckpointIdentity {
-	if src == nil {
-		return nil
-	}
-	return &DynamoCheckpointIdentity{
+// ConvertToDynamoCheckpointIdentity converts checkpoint identity fields from
+// v1beta1.
+func ConvertToDynamoCheckpointIdentity(src *v1beta1.DynamoCheckpointIdentity, dst *DynamoCheckpointIdentity) {
+	*dst = DynamoCheckpointIdentity{
 		Model:                src.Model,
 		BackendFramework:     src.BackendFramework,
 		DynamoVersion:        src.DynamoVersion,
@@ -1065,16 +1049,19 @@ func convertExperimentalTo(src *DynamoComponentDeploymentSharedSpec, dst *v1beta
 		return exp
 	}
 
-	if gms := ConvertToV1beta1GPUMemoryService(src.GPUMemoryService); gms != nil {
-		ensureExp().GPUMemoryService = gms
+	if src.GPUMemoryService != nil && src.GPUMemoryService.Enabled {
+		ensureExp().GPUMemoryService = &v1beta1.GPUMemoryServiceSpec{}
+		ConvertFromGPUMemoryServiceSpec(src.GPUMemoryService, exp.GPUMemoryService)
 	}
 
-	if failover := ConvertToV1beta1Failover(src.Failover); failover != nil {
-		ensureExp().Failover = failover
+	if src.Failover != nil && src.Failover.Enabled {
+		ensureExp().Failover = &v1beta1.FailoverSpec{}
+		ConvertFromFailoverSpec(src.Failover, exp.Failover)
 	}
 
-	if checkpoint := ConvertToV1beta1ComponentCheckpoint(src.Checkpoint); checkpoint != nil {
-		ensureExp().Checkpoint = checkpoint
+	if src.Checkpoint != nil && src.Checkpoint.Enabled {
+		ensureExp().Checkpoint = &v1beta1.ComponentCheckpointConfig{}
+		ConvertFromServiceCheckpointConfig(src.Checkpoint, exp.Checkpoint)
 	}
 
 	dst.Experimental = exp
@@ -1082,15 +1069,18 @@ func convertExperimentalTo(src *DynamoComponentDeploymentSharedSpec, dst *v1beta
 
 func convertExperimentalFrom(src *v1beta1.DynamoComponentDeploymentSharedSpec, dst *DynamoComponentDeploymentSharedSpec) {
 	if src.Experimental != nil && src.Experimental.GPUMemoryService != nil {
-		dst.GPUMemoryService = ConvertToV1alpha1GPUMemoryService(src.Experimental.GPUMemoryService)
+		dst.GPUMemoryService = &GPUMemoryServiceSpec{}
+		ConvertToGPUMemoryServiceSpec(src.Experimental.GPUMemoryService, dst.GPUMemoryService)
 	}
 
 	if src.Experimental != nil && src.Experimental.Failover != nil {
-		dst.Failover = ConvertToV1alpha1Failover(src.Experimental.Failover)
+		dst.Failover = &FailoverSpec{}
+		ConvertToFailoverSpec(src.Experimental.Failover, dst.Failover)
 	}
 
 	if src.Experimental != nil && src.Experimental.Checkpoint != nil {
-		dst.Checkpoint = ConvertToV1alpha1ComponentCheckpoint(src.Experimental.Checkpoint)
+		dst.Checkpoint = &ServiceCheckpointConfig{}
+		ConvertToServiceCheckpointConfig(src.Experimental.Checkpoint, dst.Checkpoint)
 	}
 }
 

--- a/deploy/operator/api/v1alpha1/shared_spec_conversion_bugs_test.go
+++ b/deploy/operator/api/v1alpha1/shared_spec_conversion_bugs_test.go
@@ -22,11 +22,55 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
 	v1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 )
+
+func TestConvertToServiceCheckpointConfigSetsNilIdentity(t *testing.T) {
+	var got ServiceCheckpointConfig
+	ConvertToServiceCheckpointConfig(&v1beta1.ComponentCheckpointConfig{
+		Mode:          v1beta1.CheckpointMode("auto"),
+		CheckpointRef: ptr.To("checkpoint"),
+	}, &got)
+	if got.Identity != nil {
+		t.Fatalf("ConvertToServiceCheckpointConfig().Identity = %#v, want nil", got.Identity)
+	}
+}
+
+func TestConvertFromSharedMemorySpec(t *testing.T) {
+	size := resource.MustParse("2Gi")
+	tests := []struct {
+		name string
+		src  *SharedMemorySpec
+		want string
+	}{
+		{name: "nil"},
+		{name: "zero size", src: &SharedMemorySpec{}},
+		{name: "disabled", src: &SharedMemorySpec{Disabled: true}, want: "0"},
+		{name: "size", src: &SharedMemorySpec{Size: size}, want: "2Gi"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got v1beta1.DynamoComponentDeploymentSharedSpec
+			if err := convertSharedMemoryTo(tt.src, &got); err != nil {
+				t.Fatalf("convertSharedMemoryTo() error = %v", err)
+			}
+			if tt.want == "" {
+				if got.SharedMemorySize != nil {
+					t.Fatalf("convertSharedMemoryTo().SharedMemorySize = %s, want nil", got.SharedMemorySize.String())
+				}
+				return
+			}
+			if got.SharedMemorySize == nil || got.SharedMemorySize.String() != tt.want {
+				t.Fatalf("convertSharedMemoryTo().SharedMemorySize = %v, want %s", got.SharedMemorySize, tt.want)
+			}
+		})
+	}
+}
 
 func addGeneratedFrontendSidecarHubOnlySecurityContext(t *testing.T, podTemplate *corev1.PodTemplateSpec) {
 	t.Helper()

--- a/deploy/operator/internal/dynamo/v1beta1_helpers.go
+++ b/deploy/operator/internal/dynamo/v1beta1_helpers.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 const (
@@ -86,22 +85,6 @@ func GetCheckpoint(component *v1beta1.DynamoComponentDeploymentSharedSpec) *v1be
 		return nil
 	}
 	return component.Experimental.Checkpoint
-}
-
-func ToAlphaCheckpointConfig(src *v1beta1.ComponentCheckpointConfig) *v1alpha1.ServiceCheckpointConfig {
-	return v1alpha1.ConvertToV1alpha1ComponentCheckpoint(src)
-}
-
-func ToAlphaCheckpointIdentity(src *v1beta1.DynamoCheckpointIdentity) *v1alpha1.DynamoCheckpointIdentity {
-	return v1alpha1.ConvertToV1alpha1CheckpointIdentity(src)
-}
-
-func ToAlphaGPUMemoryService(src *v1beta1.GPUMemoryServiceSpec) *v1alpha1.GPUMemoryServiceSpec {
-	return v1alpha1.ConvertToV1alpha1GPUMemoryService(src)
-}
-
-func ToBetaSharedMemorySize(src *v1alpha1.SharedMemorySpec) *resource.Quantity {
-	return v1alpha1.ConvertToV1beta1SharedMemorySize(src)
 }
 
 func GetDCDComponentName(dcd *v1beta1.DynamoComponentDeployment) string {

--- a/deploy/operator/internal/dynamo/v1beta1_helpers.go
+++ b/deploy/operator/internal/dynamo/v1beta1_helpers.go
@@ -6,30 +6,10 @@
 package dynamo
 
 import (
-	"encoding/json"
-	"maps"
-	"strings"
-
-	v1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	corev1 "k8s.io/api/core/v1"
 )
-
-const (
-	preservedDCDAnnotationPrefix           = "nvidia.com/dcd-"
-	preservedDCDAlphaSpecAnnotation        = "nvidia.com/dcd-spec"
-	preservedDCDServiceNameAnnotation      = preservedDCDAnnotationPrefix + "service-name"
-	preservedDCDDynamoNamespaceAnnotation  = preservedDCDAnnotationPrefix + "dynamo-namespace"
-	preservedDCDSubComponentTypeAnnotation = preservedDCDAnnotationPrefix + "sub-component-type"
-	PreservedDCDAnnotationsAnnotation      = preservedDCDAnnotationPrefix + "annotations"
-	PreservedDCDLabelsAnnotation           = preservedDCDAnnotationPrefix + "labels"
-	PreservedDCDIngressAnnotation          = preservedDCDAnnotationPrefix + "ingress"
-)
-
-func IsPreservedDCDAnnotation(key string) bool {
-	return strings.HasPrefix(key, preservedDCDAnnotationPrefix)
-}
 
 func ComponentsByName(dgd *v1beta1.DynamoGraphDeployment) map[string]*v1beta1.DynamoComponentDeploymentSharedSpec {
 	components := make(map[string]*v1beta1.DynamoComponentDeploymentSharedSpec, len(dgd.Spec.Components))
@@ -99,22 +79,12 @@ func GetDCDComponentName(dcd *v1beta1.DynamoComponentDeployment) string {
 			return componentName
 		}
 	}
-	if serviceName := dcd.GetAnnotations()[preservedDCDServiceNameAnnotation]; serviceName != "" {
-		return serviceName
-	}
 	return dcd.Name
 }
 
 func GetDCDDynamoNamespace(dcd *v1beta1.DynamoComponentDeployment) string {
 	if dcd == nil {
 		return ""
-	}
-	if spec := getDCDPreservedAlphaSpec(dcd); spec != nil {
-		if spec.DynamoNamespace != nil {
-			return *spec.DynamoNamespace
-		}
-	} else if dynamoNamespace := dcd.GetAnnotations()[preservedDCDDynamoNamespaceAnnotation]; dynamoNamespace != "" {
-		return dynamoNamespace
 	}
 	if dcd.Labels != nil {
 		if dynamoNamespace := dcd.Labels[commonconsts.KubeLabelDynamoNamespace]; dynamoNamespace != "" {
@@ -126,105 +96,6 @@ func GetDCDDynamoNamespace(dcd *v1beta1.DynamoComponentDeployment) string {
 		parentName = dcd.Name
 	}
 	return v1beta1.ComputeDynamoNamespace(dcd.Spec.GlobalDynamoNamespace, dcd.GetNamespace(), parentName)
-}
-
-func GetDCDSubComponentType(dcd *v1beta1.DynamoComponentDeployment) string {
-	if dcd == nil {
-		return ""
-	}
-	if spec := getDCDPreservedAlphaSpec(dcd); spec != nil {
-		return spec.SubComponentType
-	}
-	if subComponentType := dcd.GetAnnotations()[preservedDCDSubComponentTypeAnnotation]; subComponentType != "" {
-		return subComponentType
-	}
-	return ""
-}
-
-func GetDCDPreservedAlphaAnnotations(dcd *v1beta1.DynamoComponentDeployment) map[string]string {
-	if spec := getDCDPreservedAlphaSpec(dcd); spec != nil {
-		return maps.Clone(spec.Annotations)
-	}
-	if values := getDCDPreservedStringMapAnnotation(dcd, PreservedDCDAnnotationsAnnotation); values != nil {
-		return values
-	}
-	return nil
-}
-
-func GetDCDPreservedAlphaLabels(dcd *v1beta1.DynamoComponentDeployment) map[string]string {
-	if spec := getDCDPreservedAlphaSpec(dcd); spec != nil {
-		return maps.Clone(spec.Labels)
-	}
-	if values := getDCDPreservedStringMapAnnotation(dcd, PreservedDCDLabelsAnnotation); values != nil {
-		return values
-	}
-	return nil
-}
-
-func GetDCDPreservedAlphaIngressSpec(dcd *v1beta1.DynamoComponentDeployment) (IngressSpec, bool, error) {
-	if dcd == nil {
-		return IngressSpec{}, false, nil
-	}
-	spec := getDCDPreservedAlphaSpec(dcd)
-	if spec != nil {
-		if spec.Ingress == nil {
-			return IngressSpec{}, false, nil
-		}
-		data, err := json.Marshal(spec.Ingress)
-		if err != nil {
-			return IngressSpec{}, false, err
-		}
-		var ingressSpec IngressSpec
-		if err := json.Unmarshal(data, &ingressSpec); err != nil {
-			return IngressSpec{}, false, err
-		}
-		return ingressSpec, true, nil
-	}
-	raw := dcd.GetAnnotations()[PreservedDCDIngressAnnotation]
-	if raw == "" {
-		return IngressSpec{}, false, nil
-	}
-	var ingressSpec IngressSpec
-	if err := json.Unmarshal([]byte(raw), &ingressSpec); err != nil {
-		return IngressSpec{}, false, err
-	}
-	return ingressSpec, true, nil
-}
-
-func getDCDPreservedStringMapAnnotation(dcd *v1beta1.DynamoComponentDeployment, key string) map[string]string {
-	if dcd == nil {
-		return nil
-	}
-	raw := dcd.GetAnnotations()[key]
-	if raw == "" {
-		return nil
-	}
-	var values map[string]string
-	if err := json.Unmarshal([]byte(raw), &values); err != nil {
-		return nil
-	}
-	return values
-}
-
-func getDCDPreservedAlphaSpec(dcd *v1beta1.DynamoComponentDeployment) *v1alpha1.DynamoComponentDeploymentSharedSpec {
-	if dcd == nil {
-		return nil
-	}
-	raw := dcd.GetAnnotations()[preservedDCDAlphaSpecAnnotation]
-	if raw == "" {
-		return nil
-	}
-	var envelope struct {
-		Spec *v1alpha1.DynamoComponentDeploymentSpec `json:"spec"`
-	}
-	if err := json.Unmarshal([]byte(raw), &envelope); err == nil && envelope.Spec != nil {
-		return &envelope.Spec.DynamoComponentDeploymentSharedSpec
-	}
-	var spec v1alpha1.DynamoComponentDeploymentSpec
-	if err := json.Unmarshal([]byte(raw), &spec); err != nil {
-		return nil
-	}
-	return &spec.DynamoComponentDeploymentSharedSpec
 }
 
 func mergeLowPriorityMetadata(dst, src map[string]string) map[string]string {

--- a/deploy/operator/internal/dynamo/v1beta1_helpers_test.go
+++ b/deploy/operator/internal/dynamo/v1beta1_helpers_test.go
@@ -1,15 +1,12 @@
 package dynamo
 
 import (
-	"encoding/json"
 	"maps"
 	"testing"
 
-	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 )
 
 func TestGetDCDComponentNamePrefersSpecOverLegacyMetadata(t *testing.T) {
@@ -18,9 +15,6 @@ func TestGetDCDComponentNamePrefersSpecOverLegacyMetadata(t *testing.T) {
 			Name: "metadata-name",
 			Labels: map[string]string{
 				commonconsts.KubeLabelDynamoComponent: "label-component",
-			},
-			Annotations: map[string]string{
-				preservedDCDServiceNameAnnotation: "annotation-component",
 			},
 		},
 		Spec: v1beta1.DynamoComponentDeploymentSpec{
@@ -53,24 +47,9 @@ func TestGetDCDComponentNameLegacyFallbacks(t *testing.T) {
 					Labels: map[string]string{
 						commonconsts.KubeLabelDynamoComponent: "label-component",
 					},
-					Annotations: map[string]string{
-						preservedDCDServiceNameAnnotation: "annotation-component",
-					},
 				},
 			},
 			want: "label-component",
-		},
-		{
-			name: "annotation",
-			dcd: &v1beta1.DynamoComponentDeployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "metadata-name",
-					Annotations: map[string]string{
-						preservedDCDServiceNameAnnotation: "annotation-component",
-					},
-				},
-			},
-			want: "annotation-component",
 		},
 		{
 			name: "metadata name",
@@ -90,125 +69,6 @@ func TestGetDCDComponentNameLegacyFallbacks(t *testing.T) {
 	}
 }
 
-func TestPreservedAlphaSpecTakesPrecedenceOverLegacyCarrierAnnotations(t *testing.T) {
-	dynamoNamespace := "canonical-namespace"
-	alphaSpec := v1alpha1.DynamoComponentDeploymentSpec{
-		DynamoComponentDeploymentSharedSpec: v1alpha1.DynamoComponentDeploymentSharedSpec{
-			Annotations:      map[string]string{"canonical-annotation": "kept"},
-			Labels:           map[string]string{"canonical-label": "kept"},
-			DynamoNamespace:  &dynamoNamespace,
-			SubComponentType: "canonical-sub",
-			Ingress: &v1alpha1.IngressSpec{
-				Enabled:                    true,
-				Host:                       "canonical.example.com",
-				IngressControllerClassName: ptr.To("nginx"),
-			},
-		},
-	}
-	dcd := dcdWithPreservedAlphaSpec(t, alphaSpec, true)
-	dcd.Labels = map[string]string{
-		commonconsts.KubeLabelDynamoNamespace: "label-namespace",
-	}
-	dcd.Annotations[preservedDCDDynamoNamespaceAnnotation] = "stale-namespace"
-	dcd.Annotations[preservedDCDSubComponentTypeAnnotation] = "stale-sub"
-	dcd.Annotations[PreservedDCDAnnotationsAnnotation] = mustJSON(t, map[string]string{"stale-annotation": "ignored"})
-	dcd.Annotations[PreservedDCDLabelsAnnotation] = mustJSON(t, map[string]string{"stale-label": "ignored"})
-	dcd.Annotations[PreservedDCDIngressAnnotation] = mustJSON(t, IngressSpec{Enabled: true, Host: "stale.example.com"})
-
-	if got := GetDCDDynamoNamespace(dcd); got != "canonical-namespace" {
-		t.Fatalf("GetDCDDynamoNamespace() = %q, want canonical-namespace", got)
-	}
-	if got := GetDCDSubComponentType(dcd); got != "canonical-sub" {
-		t.Fatalf("GetDCDSubComponentType() = %q, want canonical-sub", got)
-	}
-	if got, want := GetDCDPreservedAlphaAnnotations(dcd), alphaSpec.Annotations; !maps.Equal(got, want) {
-		t.Fatalf("GetDCDPreservedAlphaAnnotations() = %#v, want %#v", got, want)
-	}
-	if got, want := GetDCDPreservedAlphaLabels(dcd), alphaSpec.Labels; !maps.Equal(got, want) {
-		t.Fatalf("GetDCDPreservedAlphaLabels() = %#v, want %#v", got, want)
-	}
-	ingressSpec, ok, err := GetDCDPreservedAlphaIngressSpec(dcd)
-	if err != nil {
-		t.Fatalf("GetDCDPreservedAlphaIngressSpec() error = %v", err)
-	}
-	if !ok || !ingressSpec.Enabled || ingressSpec.Host != "canonical.example.com" || ingressSpec.IngressControllerClassName == nil || *ingressSpec.IngressControllerClassName != "nginx" {
-		t.Fatalf("GetDCDPreservedAlphaIngressSpec() = (%#v, %v), want canonical ingress", ingressSpec, ok)
-	}
-}
-
-func TestPreservedAlphaHelpersFallbackToLegacyCarrierAnnotations(t *testing.T) {
-	dcd := &v1beta1.DynamoComponentDeployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "dcd",
-			Namespace: "test-ns",
-			Annotations: map[string]string{
-				preservedDCDDynamoNamespaceAnnotation:  "legacy-namespace",
-				preservedDCDSubComponentTypeAnnotation: "legacy-sub",
-				PreservedDCDAnnotationsAnnotation:      mustJSON(t, map[string]string{"legacy-annotation": "kept"}),
-				PreservedDCDLabelsAnnotation:           mustJSON(t, map[string]string{"legacy-label": "kept"}),
-				PreservedDCDIngressAnnotation:          mustJSON(t, IngressSpec{Enabled: true, Host: "legacy.example.com"}),
-			},
-			Labels: map[string]string{
-				commonconsts.KubeLabelDynamoNamespace: "label-namespace",
-			},
-		},
-	}
-
-	if got := GetDCDDynamoNamespace(dcd); got != "legacy-namespace" {
-		t.Fatalf("GetDCDDynamoNamespace() = %q, want legacy-namespace", got)
-	}
-	if got := GetDCDSubComponentType(dcd); got != "legacy-sub" {
-		t.Fatalf("GetDCDSubComponentType() = %q, want legacy-sub", got)
-	}
-	if got, want := GetDCDPreservedAlphaAnnotations(dcd), map[string]string{"legacy-annotation": "kept"}; !maps.Equal(got, want) {
-		t.Fatalf("GetDCDPreservedAlphaAnnotations() = %#v, want %#v", got, want)
-	}
-	if got, want := GetDCDPreservedAlphaLabels(dcd), map[string]string{"legacy-label": "kept"}; !maps.Equal(got, want) {
-		t.Fatalf("GetDCDPreservedAlphaLabels() = %#v, want %#v", got, want)
-	}
-	ingressSpec, ok, err := GetDCDPreservedAlphaIngressSpec(dcd)
-	if err != nil {
-		t.Fatalf("GetDCDPreservedAlphaIngressSpec() error = %v", err)
-	}
-	if !ok || ingressSpec.Host != "legacy.example.com" {
-		t.Fatalf("GetDCDPreservedAlphaIngressSpec() = (%#v, %v), want legacy ingress", ingressSpec, ok)
-	}
-}
-
-func TestGetDCDPreservedAlphaSpecSupportsEnvelopeAndRawSpec(t *testing.T) {
-	dynamoNamespace := "raw-namespace"
-	alphaSpec := v1alpha1.DynamoComponentDeploymentSpec{
-		DynamoComponentDeploymentSharedSpec: v1alpha1.DynamoComponentDeploymentSharedSpec{
-			DynamoNamespace:  &dynamoNamespace,
-			SubComponentType: "raw-sub",
-		},
-	}
-
-	envelopeDCD := dcdWithPreservedAlphaSpec(t, alphaSpec, true)
-	if got := getDCDPreservedAlphaSpec(envelopeDCD); got == nil || got.SubComponentType != "raw-sub" {
-		t.Fatalf("envelope getDCDPreservedAlphaSpec() = %#v, want raw-sub", got)
-	}
-
-	rawDCD := dcdWithPreservedAlphaSpec(t, alphaSpec, false)
-	if got := getDCDPreservedAlphaSpec(rawDCD); got == nil || got.DynamoNamespace == nil || *got.DynamoNamespace != "raw-namespace" {
-		t.Fatalf("raw getDCDPreservedAlphaSpec() = %#v, want raw-namespace", got)
-	}
-}
-
-func TestGetDCDPreservedAlphaIngressSpecReturnsMalformedAnnotationError(t *testing.T) {
-	dcd := &v1beta1.DynamoComponentDeployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Annotations: map[string]string{
-				PreservedDCDIngressAnnotation: "{",
-			},
-		},
-	}
-
-	if _, _, err := GetDCDPreservedAlphaIngressSpec(dcd); err == nil {
-		t.Fatalf("GetDCDPreservedAlphaIngressSpec() error = nil, want malformed JSON error")
-	}
-}
-
 func TestMergeLowPriorityMetadata(t *testing.T) {
 	got := mergeLowPriorityMetadata(
 		map[string]string{"existing": "kept", "shared": "winner"},
@@ -218,33 +78,4 @@ func TestMergeLowPriorityMetadata(t *testing.T) {
 	if !maps.Equal(got, want) {
 		t.Fatalf("mergeLowPriorityMetadata() = %#v, want %#v", got, want)
 	}
-}
-
-func dcdWithPreservedAlphaSpec(t *testing.T, spec v1alpha1.DynamoComponentDeploymentSpec, envelope bool) *v1beta1.DynamoComponentDeployment {
-	t.Helper()
-
-	var value any = spec
-	if envelope {
-		value = struct {
-			Spec v1alpha1.DynamoComponentDeploymentSpec `json:"spec"`
-		}{Spec: spec}
-	}
-	return &v1beta1.DynamoComponentDeployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "dcd",
-			Annotations: map[string]string{
-				preservedDCDAlphaSpecAnnotation: mustJSON(t, value),
-			},
-		},
-	}
-}
-
-func mustJSON(t *testing.T, value any) string {
-	t.Helper()
-
-	data, err := json.Marshal(value)
-	if err != nil {
-		t.Fatalf("json.Marshal(%#v) error = %v", value, err)
-	}
-	return string(data)
 }

--- a/deploy/operator/internal/dynamo/v1beta1_helpers_test.go
+++ b/deploy/operator/internal/dynamo/v1beta1_helpers_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 )
@@ -207,48 +206,6 @@ func TestGetDCDPreservedAlphaIngressSpecReturnsMalformedAnnotationError(t *testi
 
 	if _, _, err := GetDCDPreservedAlphaIngressSpec(dcd); err == nil {
 		t.Fatalf("GetDCDPreservedAlphaIngressSpec() error = nil, want malformed JSON error")
-	}
-}
-
-func TestToAlphaCheckpointConfigSetsNilIdentityThroughConverter(t *testing.T) {
-	got := ToAlphaCheckpointConfig(&v1beta1.ComponentCheckpointConfig{
-		Mode:          v1beta1.CheckpointMode("auto"),
-		CheckpointRef: ptr.To("checkpoint"),
-	})
-	if got == nil {
-		t.Fatalf("ToAlphaCheckpointConfig() = nil")
-	}
-	if got.Identity != nil {
-		t.Fatalf("ToAlphaCheckpointConfig().Identity = %#v, want nil", got.Identity)
-	}
-}
-
-func TestToBetaSharedMemorySize(t *testing.T) {
-	size := resource.MustParse("2Gi")
-	tests := []struct {
-		name string
-		src  *v1alpha1.SharedMemorySpec
-		want string
-	}{
-		{name: "nil"},
-		{name: "zero size", src: &v1alpha1.SharedMemorySpec{}},
-		{name: "disabled", src: &v1alpha1.SharedMemorySpec{Disabled: true}, want: "0"},
-		{name: "size", src: &v1alpha1.SharedMemorySpec{Size: size}, want: "2Gi"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := ToBetaSharedMemorySize(tt.src)
-			if tt.want == "" {
-				if got != nil {
-					t.Fatalf("ToBetaSharedMemorySize() = %s, want nil", got.String())
-				}
-				return
-			}
-			if got == nil || got.String() != tt.want {
-				t.Fatalf("ToBetaSharedMemorySize() = %v, want %s", got, tt.want)
-			}
-		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- structure the touched v1alpha1 shared-spec converters with caller-owned destinations
- drop controller/helper conversion wrappers and conversion annotation readers
- document conversion rules, annotation privacy, and source mutability invariants

## Tests
- go test ./api/... ./internal/dynamo -count=1
- go test ./api -run 'TestFuzzRoundTrip|TestFuzzRoundTripMutability' -roundtrip-fuzz-iters=3000 -count=1 -v
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9256" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->