### PR TITLE
refactor(operator): structure DCD and DGD converters

### DIFF
--- a/deploy/operator/api/CONVERSION.md
+++ b/deploy/operator/api/CONVERSION.md
@@ -64,100 +64,59 @@ return preserved if annotation exists
 
 ## Structural Helpers
 
-Conversion policy belongs in the API conversion package. Do not put conversion
-logic in controllers, internal helper packages, or compatibility wrappers. If a
-controller temporarily needs converted data while versions are being reconciled,
-it should call the same conversion function that the real conversion path uses.
-Read-only getters are acceptable outside the API package; conversion helpers
-are not.
+Conversion policy belongs in API conversion code. Controllers, reconcilers, and
+internal packages must not implement or wrap conversion. Temporary callers that
+need converted data must call the same exported structural converters used by
+the real conversion path. Read-only getters may live elsewhere; converters may
+not.
 
-Exported conversion helpers in the `v1alpha1` package use the spoke type name:
-
-```go
-func ConvertTo<TypeName>(src *v1beta1.HubType, dst *TypeName)
-func ConvertFrom<TypeName>(src *TypeName, dst *v1beta1.HubType)
-```
-
-Do not include `V1alpha1` in these names; the package already says that. Do not
-add wrapper functions with alternative names. Callers that need this behavior
-should call the structural helper directly.
-
-The paired `ConvertTo<TypeName>` and `ConvertFrom<TypeName>` functions must use
-the same structural signature: source pointer first, destination pointer second,
-and an optional typed context argument only at the end. The destination must be
-non-nil and owned by the caller. The conversion function writes into `dst`; it
-does not allocate `dst`, does not accept `**T`, and does not encode absence by
-assigning nil. Callers perform nil, disabled, zero, or absence checks before
-calling the helper and allocate destination subobjects explicitly.
-
-Conversion helpers must mirror the API type structure. If a converted type has
-a nested sub-struct that needs conversion, add the corresponding structural
-`ConvertTo<SubStruct>` and `ConvertFrom<SubStruct>` pair as well. Do not skip a
-sub-struct and inline its conversion somewhere else because it currently looks
-small. The point is to make every conversion edge systematic, discoverable, and
-usable by both generated-style conversion flow and temporary controller code.
-
-Conversion helpers should generally follow a `src`, `dst`, `restored`, `save`,
-`ctx` shape:
+Converters for API structs are exported from the `v1alpha1` package and are
+named after the v1alpha1 type:
 
 ```go
-func convertFooFromHub(
-	src *v1beta1.Foo,
-	dst *Foo,
-	restored *Foo,
-	save *v1beta1.Foo,
-	ctx fooConversionContext,
-) error {
-	// Convert representable fields from src to dst.
-
-	// Restore target-only fields that src cannot represent.
-
-	// Save source-only fields that dst cannot represent.
-
-	return nil
-}
+func ConvertFrom<TypeName>(src *TypeName, dst *v1beta1.HubType, ...)
+func ConvertTo<TypeName>(src *v1beta1.HubType, dst *TypeName, ...)
 ```
 
-The parameters have fixed meaning:
+Do not include `V1alpha1` in the name, and do not add wrapper functions with
+alternate names.
 
-- `src`: live source object. It is authoritative for every field representable
-  by the source version, including nil, empty, and zero values.
-- `dst`: converted target object.
-- `restored`: typed target-version data decoded from preservation annotations.
-  It may restore only target fields that `src` cannot represent.
-- `save`: typed source-version data that will be encoded into preservation
-  annotations. It may contain only source fields that `dst` cannot represent,
-  plus matching keys needed to locate those fields later.
-- `ctx`: typed high-level context needed by lower-level helpers.
+The parameter order is fixed:
 
-This mirrors conversion-gen's parameter discipline, not its generated function
-names. Because these conversions are handwritten, context should be typed
-instead of `any`. Avoid one global context type; prefer small family-specific
-contexts such as `dgdConversionContext`, `dcdConversionContext`,
-and `sharedSpecConversionContext`. Context should carry only cross-cutting
-information that leaves cannot derive from their local `src/restored/save`
-arguments.
+- `src`: live source object; authoritative for every representable field,
+  including nil, empty, and zero values.
+- `dst`: caller-owned, non-nil destination object.
+- `restored`: optional target-version data decoded from preservation
+  annotations; use it only for target-only fields.
+- `save`: optional source-version data to encode into preservation annotations;
+  write only source-only fields and keys needed to find them later.
+- `ctx`: optional typed context, always last.
 
-## Helper Naming
+`restored`, `save`, and `ctx` are included only when the converter needs them.
+Return `error` only when conversion can fail.
 
-Conversion helper names should be consistent and reveal the helper's role:
+Exported conversion-only helper types, such as typed contexts needed by
+exported converter signatures, must opt out of Kubernetes object generation and
+API reference docs.
 
-- `convert<Scope><Subject>ToHub` / `convert<Scope><Subject>FromHub`: convert
-  live representable fields and call local restore/save sections.
-- `restore<Scope><TargetOnly|HubOnly|AlphaOnly><Subject>`: copy only fields
-  the source version cannot represent from `restored` into `dst`.
-- `save<Scope><SourceOnly|HubOnly|AlphaOnly><Subject>`: copy only fields the
-  target version cannot represent from `src` into `save`.
-- `ensure<Scope>Save<Subject>...`: allocate nested objects inside the sparse
-  `save` payload and return the location the caller should fill.
-- `<scope><Subject><Predicate>`: answer a side-effect-free question used by
-  restore/save code, such as whether a live object still matches a preserved
-  key.
+Callers perform nil, disabled, zero, or absence checks before calling a
+converter and allocate nested `dst` objects explicitly. Converters do not accept
+`**T` and do not encode absence by setting `dst` to nil.
 
-Use the same `Scope` words that appear in the converted type or shared helper
-family, such as `DGD`, `DCD`, `DGDSA`, and `Shared`. Avoid ambiguous verbs such
-as `preserve` for conversion policy: use `restore` when reading `restored`, and
-`save` when writing `save`.
+Converters must mirror API type structure. A converter handles the fields of
+its own type and delegates each converted nested API struct to that nested
+struct's `ConvertFrom<SubStruct>` or `ConvertTo<SubStruct>` function. Do not
+convert multiple nested API layers at once in a parent converter.
+
+Local helpers are allowed only for conversion-private implementation details
+that are not API-struct converters: `restore*` readers, `save*` writers,
+`ensure*` allocators for sparse save payloads, side-effect-free predicates, and
+field-group projections such as podTemplate composition/decomposition. Use
+`restore` when reading `restored` and `save` when writing `save`.
+
+Converters may share data between `src` and `dst`, but they must never mutate
+`src`. Deep-copy only when the converter will mutate the copy or when separate
+ownership is required.
 
 ## Preservation Annotations
 
@@ -168,8 +127,9 @@ Preservation annotations are private to conversion code. Only API conversion
 code and its conversion tests may know their keys or payload shape. Controllers,
 reconcilers, webhooks, internal helper packages, and general API helpers must
 not read, write, delete, filter, decode, encode, branch on, or expose them.
-Do not define shared constants, prefixes, string literals, getters, predicates,
-or wrapper helpers for conversion annotations outside the conversion package.
+Keep annotation key constants unexported and local to conversion files. Do not
+define shared constants, prefixes, string literals, getters, predicates, or
+wrapper helpers for conversion annotations outside conversion code.
 
 Non-conversion code may copy Kubernetes metadata opaquely as part of normal
 object handling, but it must not identify or interpret individual conversion

--- a/deploy/operator/api/v1alpha1/dynamocomponentdeployment_conversion.go
+++ b/deploy/operator/api/v1alpha1/dynamocomponentdeployment_conversion.go
@@ -39,9 +39,12 @@ const (
 	preservedDCDEmptyServiceNamePath = "serviceName"
 )
 
-type dcdConversionContext struct {
-	objectName          string
-	includeOriginSplits bool
+// DynamoComponentDeploymentConversionContext carries DCD-level conversion
+// context that shared-spec converters cannot derive from their local inputs.
+// +kubebuilder:object:generate=false
+type DynamoComponentDeploymentConversionContext struct {
+	ObjectName          string
+	IncludeOriginSplits bool
 }
 
 // ConvertTo converts this DynamoComponentDeployment (v1alpha1) into the hub
@@ -63,12 +66,12 @@ func (src *DynamoComponentDeployment) ConvertTo(dstRaw conversion.Hub) error {
 	hubOrigin := preservedHubSpec != nil
 	scrubDCDInternalAnnotations(&dst.ObjectMeta)
 
-	ctx := dcdConversionContext{
-		objectName:          dst.ObjectMeta.Name,
-		includeOriginSplits: !hubOrigin,
+	ctx := DynamoComponentDeploymentConversionContext{
+		ObjectName:          dst.ObjectMeta.Name,
+		IncludeOriginSplits: !hubOrigin,
 	}
 	var spokeSave DynamoComponentDeploymentSpec
-	if err := convertDCDSpecToHub(&src.Spec, &dst.Spec, preservedHubSpec, &spokeSave, ctx); err != nil {
+	if err := ConvertFromDynamoComponentDeploymentSpec(&src.Spec, &dst.Spec, preservedHubSpec, &spokeSave, ctx); err != nil {
 		return err
 	}
 	var statusSave DynamoComponentDeploymentStatus
@@ -77,7 +80,7 @@ func (src *DynamoComponentDeployment) ConvertTo(dstRaw conversion.Hub) error {
 	generatedPodTemplateSave := !hubOrigin && dst.Spec.PodTemplate != nil
 	saveSpec := generatedPodTemplateSave || emptyServiceNameSave || !dcdAlphaSpecSaveIsZero(&spokeSave)
 
-	convertDCDStatusToHub(&src.Status, &dst.Status, nil, nil, ctx)
+	ConvertFromDynamoComponentDeploymentStatus(&src.Status, &dst.Status)
 	if saveSpec || !dcdAlphaStatusSaveIsZero(&statusSave) {
 		if err := saveDCDSpokeAnnotations(&spokeSave, saveSpec, emptyServiceNameSave, &statusSave, dst); err != nil {
 			return err
@@ -86,11 +89,9 @@ func (src *DynamoComponentDeployment) ConvertTo(dstRaw conversion.Hub) error {
 	return nil
 }
 
-func convertDCDSpecToHub(src *DynamoComponentDeploymentSpec, dst *v1beta1.DynamoComponentDeploymentSpec, restored *v1beta1.DynamoComponentDeploymentSpec, save *DynamoComponentDeploymentSpec, ctx dcdConversionContext) error {
-	if src == nil || dst == nil {
-		return nil
-	}
-
+// ConvertFromDynamoComponentDeploymentSpec converts the DCD spec from
+// v1alpha1 to v1beta1.
+func ConvertFromDynamoComponentDeploymentSpec(src *DynamoComponentDeploymentSpec, dst *v1beta1.DynamoComponentDeploymentSpec, restored *v1beta1.DynamoComponentDeploymentSpec, save *DynamoComponentDeploymentSpec, ctx DynamoComponentDeploymentConversionContext) error {
 	// Convert fields represented by both versions from the live source.
 	dst.BackendFramework = src.BackendFramework
 
@@ -102,11 +103,11 @@ func convertDCDSpecToHub(src *DynamoComponentDeploymentSpec, dst *v1beta1.Dynamo
 	if save != nil {
 		sharedSave = &save.DynamoComponentDeploymentSharedSpec
 	}
-	sharedCtx := sharedSpecConversionContext{
-		includeOriginSplits: ctx.includeOriginSplits,
-		podTemplateOrigin:   preservedShared != nil && preservedShared.PodTemplate != nil,
+	sharedCtx := DynamoComponentDeploymentSharedSpecConversionContext{
+		IncludeOriginSplits: ctx.IncludeOriginSplits,
+		PodTemplateOrigin:   preservedShared != nil && preservedShared.PodTemplate != nil,
 	}
-	if err := convertSharedSpecToHub(&src.DynamoComponentDeploymentSharedSpec, &dst.DynamoComponentDeploymentSharedSpec, preservedShared, sharedSave, sharedCtx); err != nil {
+	if err := ConvertFromDynamoComponentDeploymentSharedSpec(&src.DynamoComponentDeploymentSharedSpec, &dst.DynamoComponentDeploymentSharedSpec, preservedShared, sharedSave, sharedCtx); err != nil {
 		return err
 	}
 
@@ -114,11 +115,11 @@ func convertDCDSpecToHub(src *DynamoComponentDeploymentSpec, dst *v1beta1.Dynamo
 	// ServiceName, fall back to ObjectMeta.Name for schema validity. The
 	// sparse spoke save records whether the v1alpha1 field was truly empty.
 	if dst.ComponentName == "" {
-		dst.ComponentName = ctx.objectName
+		dst.ComponentName = ctx.ObjectName
 	}
 
 	// Restore target-only fields that the live source cannot represent.
-	if restored != nil && restored.ComponentName == "" && dst.ComponentName == ctx.objectName {
+	if restored != nil && restored.ComponentName == "" && dst.ComponentName == ctx.ObjectName {
 		dst.ComponentName = ""
 	}
 
@@ -214,15 +215,12 @@ func (dst *DynamoComponentDeployment) ConvertFrom(srcRaw conversion.Hub) error {
 		preservedSpokeStatus = &status
 	}
 
-	ctx := dcdConversionContext{
-		objectName: src.ObjectMeta.Name,
-	}
 	var hubSave v1beta1.DynamoComponentDeploymentSpec
-	if err := convertDCDSpecFromHub(&src.Spec, &dst.Spec, preservedSpokeSpec, &hubSave, ctx); err != nil {
+	if err := ConvertToDynamoComponentDeploymentSpec(&src.Spec, &dst.Spec, preservedSpokeSpec, &hubSave); err != nil {
 		return err
 	}
 
-	convertDCDStatusFromHub(&src.Status, &dst.Status, nil, nil, ctx)
+	ConvertToDynamoComponentDeploymentStatus(&src.Status, &dst.Status)
 	restoreDCDAlphaOnlySpecFromSaved(&dst.Spec, preservedSpokeEmptyServiceName, src.ObjectMeta.Name)
 	restoreDCDAlphaOnlyStatusFromSaved(&dst.Status, preservedSpokeStatus)
 	scrubDCDInternalAnnotations(&dst.ObjectMeta)
@@ -247,12 +245,9 @@ func dcdHubSpecNeedsSave(src *v1beta1.DynamoComponentDeployment, save *v1beta1.D
 					src.Spec.PodTemplate != nil)
 }
 
-//nolint:unparam // Keep the structural conversion signature aligned; this direction does not currently need ctx.
-func convertDCDSpecFromHub(src *v1beta1.DynamoComponentDeploymentSpec, dst *DynamoComponentDeploymentSpec, restored *DynamoComponentDeploymentSpec, save *v1beta1.DynamoComponentDeploymentSpec, ctx dcdConversionContext) error {
-	if src == nil || dst == nil {
-		return nil
-	}
-
+// ConvertToDynamoComponentDeploymentSpec converts the DCD spec from v1beta1 to
+// v1alpha1.
+func ConvertToDynamoComponentDeploymentSpec(src *v1beta1.DynamoComponentDeploymentSpec, dst *DynamoComponentDeploymentSpec, restored *DynamoComponentDeploymentSpec, save *v1beta1.DynamoComponentDeploymentSpec) error {
 	// Convert fields represented by both versions from the live source.
 	dst.BackendFramework = src.BackendFramework
 
@@ -264,8 +259,7 @@ func convertDCDSpecFromHub(src *v1beta1.DynamoComponentDeploymentSpec, dst *Dyna
 	if save != nil {
 		sharedSave = &save.DynamoComponentDeploymentSharedSpec
 	}
-	sharedCtx := sharedSpecConversionContext{}
-	if err := convertSharedSpecFromHub(&src.DynamoComponentDeploymentSharedSpec, &dst.DynamoComponentDeploymentSharedSpec, preservedShared, sharedSave, sharedCtx); err != nil {
+	if err := ConvertToDynamoComponentDeploymentSharedSpec(&src.DynamoComponentDeploymentSharedSpec, &dst.DynamoComponentDeploymentSharedSpec, preservedShared, sharedSave); err != nil {
 		return err
 	}
 
@@ -327,10 +321,9 @@ func hasDCDSpokeAnnotations(obj metav1.Object) bool {
 	return hasSpec || hasStatus
 }
 
-//nolint:unparam // Keep the structural conversion signature; this leaf has no preserved fields.
-func convertDCDStatusToHub(src *DynamoComponentDeploymentStatus, dst *v1beta1.DynamoComponentDeploymentStatus, restored *v1beta1.DynamoComponentDeploymentStatus, save *DynamoComponentDeploymentStatus, ctx dcdConversionContext) {
-	_, _, _ = restored, save, ctx
-
+// ConvertFromDynamoComponentDeploymentStatus converts the DCD status from
+// v1alpha1 to v1beta1.
+func ConvertFromDynamoComponentDeploymentStatus(src *DynamoComponentDeploymentStatus, dst *v1beta1.DynamoComponentDeploymentStatus) {
 	dst.ObservedGeneration = src.ObservedGeneration
 	if len(src.Conditions) > 0 {
 		dst.Conditions = make([]metav1.Condition, 0, len(src.Conditions))
@@ -340,17 +333,16 @@ func convertDCDStatusToHub(src *DynamoComponentDeploymentStatus, dst *v1beta1.Dy
 	}
 	if src.Service != nil {
 		dst.Component = &v1beta1.ComponentReplicaStatus{}
-		convertReplicaStatusToHub(src.Service, dst.Component, nil, nil, replicaStatusConversionContext{})
+		ConvertFromServiceReplicaStatus(src.Service, dst.Component)
 	}
 	// PodSelector is dropped in v1beta1 (the field was never populated by the
 	// controller). No annotation is needed: the round-trip invariant is on
 	// v1beta1 inputs, which do not carry PodSelector.
 }
 
-//nolint:unparam // Keep the structural conversion signature; this leaf has no preserved fields.
-func convertDCDStatusFromHub(src *v1beta1.DynamoComponentDeploymentStatus, dst *DynamoComponentDeploymentStatus, restored *DynamoComponentDeploymentStatus, save *v1beta1.DynamoComponentDeploymentStatus, ctx dcdConversionContext) {
-	_, _, _ = restored, save, ctx
-
+// ConvertToDynamoComponentDeploymentStatus converts the DCD status from
+// v1beta1 to v1alpha1.
+func ConvertToDynamoComponentDeploymentStatus(src *v1beta1.DynamoComponentDeploymentStatus, dst *DynamoComponentDeploymentStatus) {
 	dst.ObservedGeneration = src.ObservedGeneration
 	if len(src.Conditions) > 0 {
 		dst.Conditions = make([]metav1.Condition, 0, len(src.Conditions))
@@ -360,7 +352,7 @@ func convertDCDStatusFromHub(src *v1beta1.DynamoComponentDeploymentStatus, dst *
 	}
 	if src.Component != nil {
 		dst.Service = &ServiceReplicaStatus{}
-		convertReplicaStatusFromHub(src.Component, dst.Service, nil, nil, replicaStatusConversionContext{})
+		ConvertToServiceReplicaStatus(src.Component, dst.Service)
 	}
 }
 

--- a/deploy/operator/api/v1alpha1/dynamographdeployment_conversion.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeployment_conversion.go
@@ -50,9 +50,12 @@ const (
 	annDGDStatus = "nvidia.com/dgd-status"
 )
 
-type dgdConversionContext struct {
-	includeOriginSplits bool
-	saveHubOrigin       bool
+// DynamoGraphDeploymentConversionContext carries DGD-level conversion context
+// that component converters cannot derive from their local inputs.
+// +kubebuilder:object:generate=false
+type DynamoGraphDeploymentConversionContext struct {
+	IncludeOriginSplits bool
+	SaveHubOrigin       bool
 }
 
 // ConvertTo converts this DynamoGraphDeployment (v1alpha1) into the hub
@@ -80,17 +83,17 @@ func (src *DynamoGraphDeployment) ConvertTo(dstRaw conversion.Hub) error {
 		setAnnOnObj(&dst.ObjectMeta, AnnotationDGDLegacyWorkerHash, legacyHash)
 	}
 
-	ctx := dgdConversionContext{
-		includeOriginSplits: !hubOrigin,
+	ctx := DynamoGraphDeploymentConversionContext{
+		IncludeOriginSplits: !hubOrigin,
 	}
 	var spokeSave DynamoGraphDeploymentSpec
-	if err := convertDGDSpecToHub(&src.Spec, &dst.Spec, restoredHubSpec, &spokeSave, ctx); err != nil {
+	if err := ConvertFromDynamoGraphDeploymentSpec(&src.Spec, &dst.Spec, restoredHubSpec, &spokeSave, ctx); err != nil {
 		return err
 	}
 	var statusSave DynamoGraphDeploymentStatus
 	saveDGDAlphaOnlyStatus(&src.Status, &statusSave)
 
-	convertDGDStatusToHub(&src.Status, &dst.Status, nil, nil, ctx)
+	ConvertFromDynamoGraphDeploymentStatus(&src.Status, &dst.Status)
 	if !dgdAlphaSpecSaveIsZero(&spokeSave) || !dgdAlphaStatusSaveIsZero(&statusSave) {
 		if err := saveDGDSpokeAnnotations(&spokeSave, &statusSave, dst); err != nil {
 			return err
@@ -99,11 +102,9 @@ func (src *DynamoGraphDeployment) ConvertTo(dstRaw conversion.Hub) error {
 	return nil
 }
 
-func convertDGDSpecToHub(src *DynamoGraphDeploymentSpec, dst *v1beta1.DynamoGraphDeploymentSpec, restored *v1beta1.DynamoGraphDeploymentSpec, save *DynamoGraphDeploymentSpec, ctx dgdConversionContext) error {
-	if src == nil || dst == nil {
-		return nil
-	}
-
+// ConvertFromDynamoGraphDeploymentSpec converts the DGD spec from v1alpha1 to
+// v1beta1.
+func ConvertFromDynamoGraphDeploymentSpec(src *DynamoGraphDeploymentSpec, dst *v1beta1.DynamoGraphDeploymentSpec, restored *v1beta1.DynamoGraphDeploymentSpec, save *DynamoGraphDeploymentSpec, ctx DynamoGraphDeploymentConversionContext) error {
 	// Convert fields represented by both versions from the live source.
 	dst.Annotations = src.Annotations
 	dst.Labels = src.Labels
@@ -111,13 +112,11 @@ func convertDGDSpecToHub(src *DynamoGraphDeploymentSpec, dst *v1beta1.DynamoGrap
 
 	if src.Restart != nil {
 		dst.Restart = &v1beta1.Restart{}
-		convertRestartToHub(src.Restart, dst.Restart, nil, nil, ctx)
+		ConvertFromRestart(src.Restart, dst.Restart)
 	}
 	if src.TopologyConstraint != nil {
-		dst.TopologyConstraint = &v1beta1.SpecTopologyConstraint{
-			ClusterTopologyName: src.TopologyConstraint.TopologyProfile,
-			PackDomain:          v1beta1.TopologyDomain(src.TopologyConstraint.PackDomain),
-		}
+		dst.TopologyConstraint = &v1beta1.SpecTopologyConstraint{}
+		ConvertFromSpecTopologyConstraint(src.TopologyConstraint, dst.TopologyConstraint)
 	}
 	dst.Env = src.Envs
 	if save != nil && len(src.PVCs) > 0 {
@@ -150,11 +149,11 @@ func convertDGDSpecToHub(src *DynamoGraphDeploymentSpec, dst *v1beta1.DynamoGrap
 			if save != nil {
 				compSave = &DynamoComponentDeploymentSharedSpec{}
 			}
-			sharedCtx := sharedSpecConversionContext{
-				includeOriginSplits: ctx.includeOriginSplits,
-				podTemplateOrigin:   restoredShared != nil && restoredShared.PodTemplate != nil,
+			sharedCtx := DynamoComponentDeploymentSharedSpecConversionContext{
+				IncludeOriginSplits: ctx.IncludeOriginSplits,
+				PodTemplateOrigin:   restoredShared != nil && restoredShared.PodTemplate != nil,
 			}
-			if err := convertSharedSpecToHub(compSrc, &compDst, restoredShared, compSave, sharedCtx); err != nil {
+			if err := ConvertFromDynamoComponentDeploymentSharedSpec(compSrc, &compDst, restoredShared, compSave, sharedCtx); err != nil {
 				return fmt.Errorf("component %q: %w", name, err)
 			}
 			// In v1alpha1 DGD, the services-map key is the canonical name and
@@ -386,13 +385,13 @@ func (dst *DynamoGraphDeployment) ConvertFrom(srcRaw conversion.Hub) error {
 	}
 	scrubDGDInternalAnnotations(&dst.ObjectMeta)
 
-	ctx := dgdConversionContext{saveHubOrigin: !spokeOrigin}
+	ctx := DynamoGraphDeploymentConversionContext{SaveHubOrigin: !spokeOrigin}
 	var hubSave v1beta1.DynamoGraphDeploymentSpec
-	if err := convertDGDSpecFromHub(&src.Spec, &dst.Spec, restoredSpokeSpec, &hubSave, ctx); err != nil {
+	if err := ConvertToDynamoGraphDeploymentSpec(&src.Spec, &dst.Spec, restoredSpokeSpec, &hubSave, ctx); err != nil {
 		return err
 	}
 
-	convertDGDStatusFromHub(&src.Status, &dst.Status, nil, nil, ctx)
+	ConvertToDynamoGraphDeploymentStatus(&src.Status, &dst.Status)
 	restoreDGDAlphaOnlySpecFromSaved(&dst.Spec, restoredSpokeSpec)
 	restoreDGDAlphaOnlyStatusFromSaved(&dst.Status, restoredSpokeStatus)
 	if !dgdHubSpecSaveIsZero(&hubSave) {
@@ -405,11 +404,9 @@ func (dst *DynamoGraphDeployment) ConvertFrom(srcRaw conversion.Hub) error {
 	return nil
 }
 
-func convertDGDSpecFromHub(src *v1beta1.DynamoGraphDeploymentSpec, dst *DynamoGraphDeploymentSpec, restored *DynamoGraphDeploymentSpec, save *v1beta1.DynamoGraphDeploymentSpec, ctx dgdConversionContext) error {
-	if src == nil || dst == nil {
-		return nil
-	}
-
+// ConvertToDynamoGraphDeploymentSpec converts the DGD spec from v1beta1 to
+// v1alpha1.
+func ConvertToDynamoGraphDeploymentSpec(src *v1beta1.DynamoGraphDeploymentSpec, dst *DynamoGraphDeploymentSpec, restored *DynamoGraphDeploymentSpec, save *v1beta1.DynamoGraphDeploymentSpec, ctx DynamoGraphDeploymentConversionContext) error {
 	// Convert fields represented by both versions from the live source.
 	dst.Annotations = src.Annotations
 	dst.Labels = src.Labels
@@ -417,13 +414,11 @@ func convertDGDSpecFromHub(src *v1beta1.DynamoGraphDeploymentSpec, dst *DynamoGr
 
 	if src.Restart != nil {
 		dst.Restart = &Restart{}
-		convertRestartFromHub(src.Restart, dst.Restart, nil, nil, ctx)
+		ConvertToRestart(src.Restart, dst.Restart)
 	}
 	if src.TopologyConstraint != nil {
-		dst.TopologyConstraint = &SpecTopologyConstraint{
-			TopologyProfile: src.TopologyConstraint.ClusterTopologyName,
-			PackDomain:      TopologyDomain(src.TopologyConstraint.PackDomain),
-		}
+		dst.TopologyConstraint = &SpecTopologyConstraint{}
+		ConvertToSpecTopologyConstraint(src.TopologyConstraint, dst.TopologyConstraint)
 	}
 	dst.Envs = src.Env
 
@@ -452,8 +447,7 @@ func convertDGDSpecFromHub(src *v1beta1.DynamoGraphDeploymentSpec, dst *DynamoGr
 					ComponentName: compSrc.ComponentName,
 				}
 			}
-			sharedCtx := sharedSpecConversionContext{}
-			if err := convertSharedSpecFromHub(compSrc, compDst, preservedShared, compSave, sharedCtx); err != nil {
+			if err := ConvertToDynamoComponentDeploymentSharedSpec(compSrc, compDst, preservedShared, compSave); err != nil {
 				return fmt.Errorf("component %q: %w", compSrc.ComponentName, err)
 			}
 			// In v1alpha1 the services-map key is the canonical name; the
@@ -462,7 +456,7 @@ func convertDGDSpecFromHub(src *v1beta1.DynamoGraphDeploymentSpec, dst *DynamoGr
 			// spec conversion.
 			compDst.ServiceName = ""
 			dst.Services[compSrc.ComponentName] = compDst
-			if save != nil && (preserveComponentOrder || !dgdHubComponentSaveIsZero(compSave) || ctx.saveHubOrigin && dgdHubComponentOriginSaveNeeded(compSrc)) {
+			if save != nil && (preserveComponentOrder || !dgdHubComponentSaveIsZero(compSave) || ctx.SaveHubOrigin && dgdHubComponentOriginSaveNeeded(compSrc)) {
 				save.Components = append(save.Components, *compSave)
 			}
 		}
@@ -531,49 +525,63 @@ func scrubDGDInternalAnnotations(obj metav1.Object) {
 	}
 }
 
-// convertRestartToHub / convertRestartFromHub handle the Restart struct pair,
-// which is structurally identical across versions but uses version-specific types.
-//
-//nolint:unparam // Keep the structural conversion signature; this leaf has no preserved fields.
-func convertRestartToHub(src *Restart, dst *v1beta1.Restart, restored *v1beta1.Restart, save *Restart, ctx dgdConversionContext) {
-	_, _, _ = restored, save, ctx
-
-	if src == nil || dst == nil {
-		return
-	}
+// ConvertFromRestart converts the restart spec from v1alpha1 to v1beta1.
+func ConvertFromRestart(src *Restart, dst *v1beta1.Restart) {
 	*dst = v1beta1.Restart{ID: src.ID}
 	if src.Strategy != nil {
-		dst.Strategy = &v1beta1.RestartStrategy{
-			Type:  v1beta1.RestartStrategyType(src.Strategy.Type),
-			Order: slices.Clone(src.Strategy.Order),
-		}
+		dst.Strategy = &v1beta1.RestartStrategy{}
+		ConvertFromRestartStrategy(src.Strategy, dst.Strategy)
 	}
 }
 
-//nolint:unparam // Keep the structural conversion signature; this leaf has no preserved fields.
-func convertRestartFromHub(src *v1beta1.Restart, dst *Restart, restored *Restart, save *v1beta1.Restart, ctx dgdConversionContext) {
-	_, _, _ = restored, save, ctx
-
-	if src == nil || dst == nil {
-		return
-	}
+// ConvertToRestart converts the restart spec from v1beta1 to v1alpha1.
+func ConvertToRestart(src *v1beta1.Restart, dst *Restart) {
 	*dst = Restart{ID: src.ID}
 	if src.Strategy != nil {
-		dst.Strategy = &RestartStrategy{
-			Type:  RestartStrategyType(src.Strategy.Type),
-			Order: slices.Clone(src.Strategy.Order),
-		}
+		dst.Strategy = &RestartStrategy{}
+		ConvertToRestartStrategy(src.Strategy, dst.Strategy)
 	}
 }
 
-// convertDGDStatusToHub / convertDGDStatusFromHub copy the status sub-struct.
-// Status fields are structurally identical; version types differ so each field
-// is copied explicitly.
-//
-//nolint:unparam // Keep the structural conversion signature; this leaf has no preserved fields.
-func convertDGDStatusToHub(src *DynamoGraphDeploymentStatus, dst *v1beta1.DynamoGraphDeploymentStatus, restored *v1beta1.DynamoGraphDeploymentStatus, save *DynamoGraphDeploymentStatus, ctx dgdConversionContext) {
-	_, _, _ = restored, save, ctx
+// ConvertFromRestartStrategy converts the restart strategy from v1alpha1 to
+// v1beta1.
+func ConvertFromRestartStrategy(src *RestartStrategy, dst *v1beta1.RestartStrategy) {
+	*dst = v1beta1.RestartStrategy{
+		Type:  v1beta1.RestartStrategyType(src.Type),
+		Order: slices.Clone(src.Order),
+	}
+}
 
+// ConvertToRestartStrategy converts the restart strategy from v1beta1 to
+// v1alpha1.
+func ConvertToRestartStrategy(src *v1beta1.RestartStrategy, dst *RestartStrategy) {
+	*dst = RestartStrategy{
+		Type:  RestartStrategyType(src.Type),
+		Order: slices.Clone(src.Order),
+	}
+}
+
+// ConvertFromSpecTopologyConstraint converts deployment topology constraints
+// from v1alpha1 to v1beta1.
+func ConvertFromSpecTopologyConstraint(src *SpecTopologyConstraint, dst *v1beta1.SpecTopologyConstraint) {
+	*dst = v1beta1.SpecTopologyConstraint{
+		ClusterTopologyName: src.TopologyProfile,
+		PackDomain:          v1beta1.TopologyDomain(src.PackDomain),
+	}
+}
+
+// ConvertToSpecTopologyConstraint converts deployment topology constraints
+// from v1beta1 to v1alpha1.
+func ConvertToSpecTopologyConstraint(src *v1beta1.SpecTopologyConstraint, dst *SpecTopologyConstraint) {
+	*dst = SpecTopologyConstraint{
+		TopologyProfile: src.ClusterTopologyName,
+		PackDomain:      TopologyDomain(src.PackDomain),
+	}
+}
+
+// ConvertFromDynamoGraphDeploymentStatus converts the DGD status from
+// v1alpha1 to v1beta1.
+func ConvertFromDynamoGraphDeploymentStatus(src *DynamoGraphDeploymentStatus, dst *v1beta1.DynamoGraphDeploymentStatus) {
 	dst.ObservedGeneration = src.ObservedGeneration
 	dst.State = v1beta1.DGDState(src.State)
 	if len(src.Conditions) > 0 {
@@ -586,41 +594,31 @@ func convertDGDStatusToHub(src *DynamoGraphDeploymentStatus, dst *v1beta1.Dynamo
 		dst.Components = make(map[string]v1beta1.ComponentReplicaStatus, len(src.Services))
 		for k, v := range src.Services {
 			var component v1beta1.ComponentReplicaStatus
-			convertReplicaStatusToHub(&v, &component, nil, nil, replicaStatusConversionContext{})
+			ConvertFromServiceReplicaStatus(&v, &component)
 			dst.Components[k] = component
 		}
 	}
 	if src.Restart != nil {
-		dst.Restart = &v1beta1.RestartStatus{
-			ObservedID: src.Restart.ObservedID,
-			Phase:      v1beta1.RestartPhase(src.Restart.Phase),
-			InProgress: slices.Clone(src.Restart.InProgress),
-		}
+		dst.Restart = &v1beta1.RestartStatus{}
+		ConvertFromRestartStatus(src.Restart, dst.Restart)
 	}
 	if len(src.Checkpoints) > 0 {
 		dst.Checkpoints = make(map[string]v1beta1.ComponentCheckpointStatus, len(src.Checkpoints))
 		for k, v := range src.Checkpoints {
-			dst.Checkpoints[k] = v1beta1.ComponentCheckpointStatus{
-				CheckpointName: v.CheckpointName,
-				IdentityHash:   v.IdentityHash,
-				Ready:          v.Ready,
-			}
+			var checkpoint v1beta1.ComponentCheckpointStatus
+			ConvertFromServiceCheckpointStatus(&v, &checkpoint)
+			dst.Checkpoints[k] = checkpoint
 		}
 	}
 	if src.RollingUpdate != nil {
-		dst.RollingUpdate = &v1beta1.RollingUpdateStatus{
-			Phase:             v1beta1.RollingUpdatePhase(src.RollingUpdate.Phase),
-			StartTime:         src.RollingUpdate.StartTime.DeepCopy(),
-			EndTime:           src.RollingUpdate.EndTime.DeepCopy(),
-			UpdatedComponents: slices.Clone(src.RollingUpdate.UpdatedServices),
-		}
+		dst.RollingUpdate = &v1beta1.RollingUpdateStatus{}
+		ConvertFromRollingUpdateStatus(src.RollingUpdate, dst.RollingUpdate)
 	}
 }
 
-//nolint:unparam // Keep the structural conversion signature; this leaf has no preserved fields.
-func convertDGDStatusFromHub(src *v1beta1.DynamoGraphDeploymentStatus, dst *DynamoGraphDeploymentStatus, restored *DynamoGraphDeploymentStatus, save *v1beta1.DynamoGraphDeploymentStatus, ctx dgdConversionContext) {
-	_, _, _ = restored, save, ctx
-
+// ConvertToDynamoGraphDeploymentStatus converts the DGD status from v1beta1 to
+// v1alpha1.
+func ConvertToDynamoGraphDeploymentStatus(src *v1beta1.DynamoGraphDeploymentStatus, dst *DynamoGraphDeploymentStatus) {
 	dst.ObservedGeneration = src.ObservedGeneration
 	dst.State = DGDState(src.State)
 	if len(src.Conditions) > 0 {
@@ -633,46 +631,91 @@ func convertDGDStatusFromHub(src *v1beta1.DynamoGraphDeploymentStatus, dst *Dyna
 		dst.Services = make(map[string]ServiceReplicaStatus, len(src.Components))
 		for k, v := range src.Components {
 			var service ServiceReplicaStatus
-			convertReplicaStatusFromHub(&v, &service, nil, nil, replicaStatusConversionContext{})
+			ConvertToServiceReplicaStatus(&v, &service)
 			dst.Services[k] = service
 		}
 	}
 	if src.Restart != nil {
-		dst.Restart = &RestartStatus{
-			ObservedID: src.Restart.ObservedID,
-			Phase:      RestartPhase(src.Restart.Phase),
-			InProgress: slices.Clone(src.Restart.InProgress),
-		}
+		dst.Restart = &RestartStatus{}
+		ConvertToRestartStatus(src.Restart, dst.Restart)
 	}
 	if len(src.Checkpoints) > 0 {
 		dst.Checkpoints = make(map[string]ServiceCheckpointStatus, len(src.Checkpoints))
 		for k, v := range src.Checkpoints {
-			dst.Checkpoints[k] = ServiceCheckpointStatus{
-				CheckpointName: v.CheckpointName,
-				IdentityHash:   v.IdentityHash,
-				Ready:          v.Ready,
-			}
+			var checkpoint ServiceCheckpointStatus
+			ConvertToServiceCheckpointStatus(&v, &checkpoint)
+			dst.Checkpoints[k] = checkpoint
 		}
 	}
 	if src.RollingUpdate != nil {
-		dst.RollingUpdate = &RollingUpdateStatus{
-			Phase:           RollingUpdatePhase(src.RollingUpdate.Phase),
-			StartTime:       src.RollingUpdate.StartTime.DeepCopy(),
-			EndTime:         src.RollingUpdate.EndTime.DeepCopy(),
-			UpdatedServices: slices.Clone(src.RollingUpdate.UpdatedComponents),
-		}
+		dst.RollingUpdate = &RollingUpdateStatus{}
+		ConvertToRollingUpdateStatus(src.RollingUpdate, dst.RollingUpdate)
 	}
 }
 
-type replicaStatusConversionContext struct{}
-
-//nolint:unparam // Keep the structural conversion signature; this leaf has no preserved fields.
-func convertReplicaStatusToHub(src *ServiceReplicaStatus, dst *v1beta1.ComponentReplicaStatus, restored *v1beta1.ComponentReplicaStatus, save *ServiceReplicaStatus, ctx replicaStatusConversionContext) {
-	_, _, _ = restored, save, ctx
-
-	if src == nil || dst == nil {
-		return
+// ConvertFromRestartStatus converts restart status from v1alpha1 to v1beta1.
+func ConvertFromRestartStatus(src *RestartStatus, dst *v1beta1.RestartStatus) {
+	*dst = v1beta1.RestartStatus{
+		ObservedID: src.ObservedID,
+		Phase:      v1beta1.RestartPhase(src.Phase),
+		InProgress: slices.Clone(src.InProgress),
 	}
+}
+
+// ConvertToRestartStatus converts restart status from v1beta1 to v1alpha1.
+func ConvertToRestartStatus(src *v1beta1.RestartStatus, dst *RestartStatus) {
+	*dst = RestartStatus{
+		ObservedID: src.ObservedID,
+		Phase:      RestartPhase(src.Phase),
+		InProgress: slices.Clone(src.InProgress),
+	}
+}
+
+// ConvertFromServiceCheckpointStatus converts checkpoint status from v1alpha1
+// to v1beta1.
+func ConvertFromServiceCheckpointStatus(src *ServiceCheckpointStatus, dst *v1beta1.ComponentCheckpointStatus) {
+	*dst = v1beta1.ComponentCheckpointStatus{
+		CheckpointName: src.CheckpointName,
+		IdentityHash:   src.IdentityHash,
+		Ready:          src.Ready,
+	}
+}
+
+// ConvertToServiceCheckpointStatus converts checkpoint status from v1beta1 to
+// v1alpha1.
+func ConvertToServiceCheckpointStatus(src *v1beta1.ComponentCheckpointStatus, dst *ServiceCheckpointStatus) {
+	*dst = ServiceCheckpointStatus{
+		CheckpointName: src.CheckpointName,
+		IdentityHash:   src.IdentityHash,
+		Ready:          src.Ready,
+	}
+}
+
+// ConvertFromRollingUpdateStatus converts rolling-update status from v1alpha1
+// to v1beta1.
+func ConvertFromRollingUpdateStatus(src *RollingUpdateStatus, dst *v1beta1.RollingUpdateStatus) {
+	*dst = v1beta1.RollingUpdateStatus{
+		Phase:             v1beta1.RollingUpdatePhase(src.Phase),
+		StartTime:         src.StartTime.DeepCopy(),
+		EndTime:           src.EndTime.DeepCopy(),
+		UpdatedComponents: slices.Clone(src.UpdatedServices),
+	}
+}
+
+// ConvertToRollingUpdateStatus converts rolling-update status from v1beta1 to
+// v1alpha1.
+func ConvertToRollingUpdateStatus(src *v1beta1.RollingUpdateStatus, dst *RollingUpdateStatus) {
+	*dst = RollingUpdateStatus{
+		Phase:           RollingUpdatePhase(src.Phase),
+		StartTime:       src.StartTime.DeepCopy(),
+		EndTime:         src.EndTime.DeepCopy(),
+		UpdatedServices: slices.Clone(src.UpdatedComponents),
+	}
+}
+
+// ConvertFromServiceReplicaStatus converts replica status from v1alpha1 to
+// v1beta1.
+func ConvertFromServiceReplicaStatus(src *ServiceReplicaStatus, dst *v1beta1.ComponentReplicaStatus) {
 	*dst = v1beta1.ComponentReplicaStatus{
 		ComponentKind:   v1beta1.ComponentKind(src.ComponentKind),
 		ComponentNames:  componentNamesToHub(src),
@@ -687,13 +730,9 @@ func convertReplicaStatusToHub(src *ServiceReplicaStatus, dst *v1beta1.Component
 	}
 }
 
-//nolint:unparam // Keep the structural conversion signature; this leaf has no preserved fields.
-func convertReplicaStatusFromHub(src *v1beta1.ComponentReplicaStatus, dst *ServiceReplicaStatus, restored *ServiceReplicaStatus, save *v1beta1.ComponentReplicaStatus, ctx replicaStatusConversionContext) {
-	_, _, _ = restored, save, ctx
-
-	if src == nil || dst == nil {
-		return
-	}
+// ConvertToServiceReplicaStatus converts replica status from v1beta1 to
+// v1alpha1.
+func ConvertToServiceReplicaStatus(src *v1beta1.ComponentReplicaStatus, dst *ServiceReplicaStatus) {
 	componentNames := slices.Clone(src.ComponentNames)
 
 	*dst = ServiceReplicaStatus{

--- a/deploy/operator/api/v1alpha1/dynamographdeployment_conversion_test.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeployment_conversion_test.go
@@ -1585,7 +1585,7 @@ func TestDGD_FromV1alpha1_CheckpointEnabledFalseEmptyPayload(t *testing.T) {
 // an aggregated frontend+worker service pair where the frontend has no
 // explicit container resources (so `containers[*].resources` projects as an
 // empty object) and `sharedMemorySize="0"` (which exercises the Disabled=true
-// path in convertSharedMemoryFrom). It is shared by the idempotence tests
+// path in ConvertToSharedMemorySpec). It is shared by the idempotence tests
 // below so the linter does not flag the identical fixture builders as dupl.
 func newIdempotenceDGDFixture() *v1beta1.DynamoGraphDeployment {
 	replicas := int32(1)
@@ -1646,7 +1646,7 @@ func newIdempotenceDGDFixture() *v1beta1.DynamoGraphDeployment {
 // round-trip, so kubectl apply is idempotent for any v1beta1 input.
 func TestDGD_ApplyIdempotence_GenerationBump(t *testing.T) {
 	// sharedMemorySize=\"0\" is the critical trigger: it exercises the
-	// Disabled=true path in convertSharedMemoryFrom, which previously left
+	// Disabled=true path in ConvertToSharedMemorySpec, which previously left
 	// SharedMemorySpec.Size as a bare Quantity{}.
 	newSrc := newIdempotenceDGDFixture
 
@@ -1691,13 +1691,13 @@ func TestDGD_ApplyIdempotence_GenerationBump(t *testing.T) {
 // a non-pointer struct, so encoding/json's omitempty does not drop it); after
 // the etcd JSON round-trip the Size becomes a canonical zero Quantity that is
 // not reflect.DeepEqual to the Go zero value. Without the fix in
-// convertSharedMemoryFrom, every reapply of a v1beta1 object carrying the
+// ConvertToSharedMemorySpec, every reapply of a v1beta1 object carrying the
 // sparse save would bump .metadata.generation.
 func TestDGD_ApplyIdempotence_EmptySharedMemoryOrigin(t *testing.T) {
 	// Seed a v1alpha1 object whose only non-default bit is SharedMemory =
 	// &SharedMemorySpec{}, then run it through ConvertTo once so the
 	// produced v1beta1 carries the sparse save we need to exercise the empty
-	// branch of convertSharedMemoryFrom.
+	// branch of shared-memory restoration.
 	a1 := &DynamoGraphDeployment{
 		ObjectMeta: metav1.ObjectMeta{Name: "shm-empty", Namespace: "ns"},
 		Spec: DynamoGraphDeploymentSpec{

--- a/deploy/operator/api/v1alpha1/shared_spec_conversion.go
+++ b/deploy/operator/api/v1alpha1/shared_spec_conversion.go
@@ -174,7 +174,10 @@ func ConvertFromDynamoComponentDeploymentSharedSpec(src *DynamoComponentDeployme
 	}
 
 	// sharedMemory <-> sharedMemorySize (lossy struct flatten).
-	convertSharedMemoryToHub(src.SharedMemory, dst)
+	if src.SharedMemory != nil && (src.SharedMemory.Disabled || !src.SharedMemory.Size.IsZero()) {
+		dst.SharedMemorySize = &resource.Quantity{}
+		ConvertFromSharedMemorySpec(src.SharedMemory, dst.SharedMemorySize)
+	}
 
 	// volumeMounts + useAsCompilationCache -> compilationCache (the container
 	// volumeMounts themselves are emitted by buildPodTemplateToHub).
@@ -521,7 +524,10 @@ func ConvertToDynamoComponentDeploymentSharedSpec(src *v1beta1.DynamoComponentDe
 	dst.ServiceName = src.ComponentName
 
 	// sharedMemorySize -> SharedMemorySpec.
-	convertSharedMemoryFromHub(src.SharedMemorySize, dst)
+	if src.SharedMemorySize != nil {
+		dst.SharedMemory = &SharedMemorySpec{}
+		ConvertToSharedMemorySpec(src.SharedMemorySize, dst.SharedMemory)
+	}
 
 	// compilationCache + podTemplate volumeMounts -> VolumeMounts.
 	convertVolumeMountsFromHub(src, dst)
@@ -854,19 +860,12 @@ func ConvertFromSharedMemorySpec(src *SharedMemorySpec, dst *resource.Quantity) 
 	*dst = src.Size
 }
 
-func convertSharedMemoryToHub(src *SharedMemorySpec, dst *v1beta1.DynamoComponentDeploymentSharedSpec) {
-	if src != nil && (src.Disabled || !src.Size.IsZero()) {
-		dst.SharedMemorySize = &resource.Quantity{}
-		ConvertFromSharedMemorySpec(src, dst.SharedMemorySize)
-	}
-}
-
 // ConvertToSharedMemorySpec converts the v1beta1 shared-memory scalar
 // representation into the shared-memory struct.
 func ConvertToSharedMemorySpec(src *resource.Quantity, dst *SharedMemorySpec) {
 	if src.Sign() == 0 {
 		// Canonical v1beta1 "size=0" <-> v1alpha1 Disabled=true. See
-		// convertSharedMemoryToHub for the forward direction.
+		// ConvertFromSharedMemorySpec for the forward direction.
 		//
 		// Size carries the incoming canonical Quantity value (not the Go zero
 		// value) so that every apply produces a spec that is reflect.DeepEqual
@@ -880,13 +879,6 @@ func ConvertToSharedMemorySpec(src *resource.Quantity, dst *SharedMemorySpec) {
 		return
 	}
 	*dst = SharedMemorySpec{Size: *src}
-}
-
-func convertSharedMemoryFromHub(src *resource.Quantity, dst *DynamoComponentDeploymentSharedSpec) {
-	if src != nil {
-		dst.SharedMemory = &SharedMemorySpec{}
-		ConvertToSharedMemorySpec(src, dst.SharedMemory)
-	}
 }
 
 // ---------------------------------------------------------------------------

--- a/deploy/operator/api/v1alpha1/shared_spec_conversion.go
+++ b/deploy/operator/api/v1alpha1/shared_spec_conversion.go
@@ -127,19 +127,17 @@ func delAnnFromObj(obj metav1.Object, key string) {
 // Shared-spec conversion entry points
 // ---------------------------------------------------------------------------
 
-type sharedSpecConversionContext struct {
-	includeOriginSplits bool
-	podTemplateOrigin   bool
+// DynamoComponentDeploymentSharedSpecConversionContext carries shared-spec
+// conversion context that leaf converters cannot derive from local inputs.
+// +kubebuilder:object:generate=false
+type DynamoComponentDeploymentSharedSpecConversionContext struct {
+	IncludeOriginSplits bool
+	PodTemplateOrigin   bool
 }
 
-// convertSharedSpecToHub converts fields represented by both versions from src,
-// restores only v1beta1-only fields from restored, and writes v1alpha1-only
-// fields to save.
-func convertSharedSpecToHub(src *DynamoComponentDeploymentSharedSpec, dst *v1beta1.DynamoComponentDeploymentSharedSpec, restored *v1beta1.DynamoComponentDeploymentSharedSpec, save *DynamoComponentDeploymentSharedSpec, ctx sharedSpecConversionContext) error {
-	if src == nil || dst == nil {
-		return nil
-	}
-
+// ConvertFromDynamoComponentDeploymentSharedSpec converts the shared spec from
+// v1alpha1 to v1beta1.
+func ConvertFromDynamoComponentDeploymentSharedSpec(src *DynamoComponentDeploymentSharedSpec, dst *v1beta1.DynamoComponentDeploymentSharedSpec, restored *v1beta1.DynamoComponentDeploymentSharedSpec, save *DynamoComponentDeploymentSharedSpec, ctx DynamoComponentDeploymentSharedSpecConversionContext) error {
 	// ComponentType: v1beta1 promotes the legacy v1alpha1 worker subcomponent
 	// values to first-class component types.
 	dst.ComponentType = sharedComponentTypeToHub(src)
@@ -156,36 +154,30 @@ func convertSharedSpecToHub(src *DynamoComponentDeploymentSharedSpec, dst *v1bet
 	dst.Replicas = src.Replicas
 
 	if src.Multinode != nil {
-		dst.Multinode = &v1beta1.MultinodeSpec{NodeCount: src.Multinode.NodeCount}
+		dst.Multinode = &v1beta1.MultinodeSpec{}
+		ConvertFromMultinodeSpec(src.Multinode, dst.Multinode)
 	}
 
 	if src.ModelRef != nil {
-		dst.ModelRef = &v1beta1.ModelReference{
-			Name:     src.ModelRef.Name,
-			Revision: src.ModelRef.Revision,
-		}
+		dst.ModelRef = &v1beta1.ModelReference{}
+		ConvertFromModelReference(src.ModelRef, dst.ModelRef)
 	}
 
 	if src.TopologyConstraint != nil {
-		dst.TopologyConstraint = &v1beta1.TopologyConstraint{
-			PackDomain: v1beta1.TopologyDomain(src.TopologyConstraint.PackDomain),
-		}
+		dst.TopologyConstraint = &v1beta1.TopologyConstraint{}
+		ConvertFromTopologyConstraint(src.TopologyConstraint, dst.TopologyConstraint)
 	}
 
 	if src.EPPConfig != nil {
-		dst.EPPConfig = &v1beta1.EPPConfig{
-			ConfigMapRef: src.EPPConfig.ConfigMapRef.DeepCopy(),
-			Config:       src.EPPConfig.Config.DeepCopy(),
-		}
+		dst.EPPConfig = &v1beta1.EPPConfig{}
+		ConvertFromEPPConfig(src.EPPConfig, dst.EPPConfig)
 	}
 
 	// sharedMemory <-> sharedMemorySize (lossy struct flatten).
-	if err := convertSharedMemoryTo(src.SharedMemory, dst); err != nil {
-		return err
-	}
+	convertSharedMemoryToHub(src.SharedMemory, dst)
 
 	// volumeMounts + useAsCompilationCache -> compilationCache (the container
-	// volumeMounts themselves are emitted by buildPodTemplateTo).
+	// volumeMounts themselves are emitted by buildPodTemplateToHub).
 	for _, vm := range src.VolumeMounts {
 		if vm.UseAsCompilationCache {
 			dst.CompilationCache = &v1beta1.CompilationCacheConfig{
@@ -197,13 +189,16 @@ func convertSharedSpecToHub(src *DynamoComponentDeploymentSharedSpec, dst *v1bet
 	}
 
 	// scalingAdapter: drop Enabled bool, keep presence semantics.
-	convertScalingAdapterTo(src.ScalingAdapter, dst)
+	if src.ScalingAdapter != nil && src.ScalingAdapter.Enabled {
+		dst.ScalingAdapter = &v1beta1.ScalingAdapter{}
+		ConvertFromScalingAdapter(src.ScalingAdapter, dst.ScalingAdapter)
+	}
 
 	// experimental block: gpuMemoryService, failover, checkpoint.
-	convertExperimentalTo(src, dst)
+	convertExperimentalToHub(src, dst)
 
 	// Resources + envs + probes + mainContainer -> podTemplate.containers[main].
-	if err := buildPodTemplateTo(src, dst, ctx); err != nil {
+	if err := buildPodTemplateToHub(src, dst, ctx); err != nil {
 		return err
 	}
 
@@ -211,7 +206,7 @@ func convertSharedSpecToHub(src *DynamoComponentDeploymentSharedSpec, dst *v1bet
 		return err
 	}
 	if save != nil {
-		saveSharedAlphaOnlySpec(src, save, ctx.includeOriginSplits)
+		saveSharedAlphaOnlySpec(src, save, ctx.IncludeOriginSplits)
 	}
 	return nil
 }
@@ -499,58 +494,50 @@ func extraPodMetadataNeedsPreservation(src *ExtraPodMetadata) bool {
 	return src != nil && len(src.Annotations) == 0 && len(src.Labels) == 0
 }
 
-// convertSharedSpecFromHub converts fields represented by both versions from
-// src, restores only v1alpha1-only fields from restored, and writes v1beta1-only
-// fields to save.
-//
-//nolint:unparam // Keep the structural conversion signature aligned; this direction does not currently need ctx.
-func convertSharedSpecFromHub(src *v1beta1.DynamoComponentDeploymentSharedSpec, dst *DynamoComponentDeploymentSharedSpec, restored *DynamoComponentDeploymentSharedSpec, save *v1beta1.DynamoComponentDeploymentSharedSpec, ctx sharedSpecConversionContext) error {
-	if src == nil || dst == nil {
-		return nil
-	}
-
+// ConvertToDynamoComponentDeploymentSharedSpec converts the shared spec from
+// v1beta1 to v1alpha1.
+func ConvertToDynamoComponentDeploymentSharedSpec(src *v1beta1.DynamoComponentDeploymentSharedSpec, dst *DynamoComponentDeploymentSharedSpec, restored *DynamoComponentDeploymentSharedSpec, save *v1beta1.DynamoComponentDeploymentSharedSpec) error {
 	dst.ComponentType, dst.SubComponentType = sharedComponentTypeFromHub(src.ComponentType)
 	dst.GlobalDynamoNamespace = src.GlobalDynamoNamespace
 	dst.Replicas = src.Replicas
 
 	if src.Multinode != nil {
-		dst.Multinode = &MultinodeSpec{NodeCount: src.Multinode.NodeCount}
+		dst.Multinode = &MultinodeSpec{}
+		ConvertToMultinodeSpec(src.Multinode, dst.Multinode)
 	}
 	if src.ModelRef != nil {
-		dst.ModelRef = &ModelReference{
-			Name:     src.ModelRef.Name,
-			Revision: src.ModelRef.Revision,
-		}
+		dst.ModelRef = &ModelReference{}
+		ConvertToModelReference(src.ModelRef, dst.ModelRef)
 	}
 	if src.TopologyConstraint != nil {
-		dst.TopologyConstraint = &TopologyConstraint{
-			PackDomain: TopologyDomain(src.TopologyConstraint.PackDomain),
-		}
+		dst.TopologyConstraint = &TopologyConstraint{}
+		ConvertToTopologyConstraint(src.TopologyConstraint, dst.TopologyConstraint)
 	}
 	if src.EPPConfig != nil {
-		dst.EPPConfig = &EPPConfig{
-			ConfigMapRef: src.EPPConfig.ConfigMapRef.DeepCopy(),
-			Config:       src.EPPConfig.Config.DeepCopy(),
-		}
+		dst.EPPConfig = &EPPConfig{}
+		ConvertToEPPConfig(src.EPPConfig, dst.EPPConfig)
 	}
 
 	dst.ServiceName = src.ComponentName
 
 	// sharedMemorySize -> SharedMemorySpec.
-	convertSharedMemoryFrom(src.SharedMemorySize, dst)
+	convertSharedMemoryFromHub(src.SharedMemorySize, dst)
 
 	// compilationCache + podTemplate volumeMounts -> VolumeMounts.
-	convertVolumeMountsFrom(src, dst)
+	convertVolumeMountsFromHub(src, dst)
 
 	// experimental -> GPUMemoryService, Failover, Checkpoint.
-	convertExperimentalFrom(src, dst)
+	convertExperimentalFromHub(src, dst)
 
 	// scalingAdapter presence -> Enabled=true; annotation -> Enabled=false payload.
-	convertScalingAdapterFrom(src.ScalingAdapter, dst)
+	if src.ScalingAdapter != nil {
+		dst.ScalingAdapter = &ScalingAdapter{}
+		ConvertToScalingAdapter(src.ScalingAdapter, dst.ScalingAdapter)
+	}
 
 	// podTemplate -> mainContainer + extraPodSpec + extraPodMetadata +
 	// Resources + Envs + Probes (+ FrontendSidecar).
-	if err := decomposePodTemplate(src, dst, restored); err != nil {
+	if err := decomposePodTemplateFromHub(src, dst, restored); err != nil {
 		return err
 	}
 
@@ -789,6 +776,71 @@ func sharedHubSpecSaveIsZero(save *v1beta1.DynamoComponentDeploymentSharedSpec) 
 }
 
 // ---------------------------------------------------------------------------
+// Simple shared-spec structs
+// ---------------------------------------------------------------------------
+
+// ConvertFromMultinodeSpec converts multinode settings from v1alpha1 to
+// v1beta1.
+func ConvertFromMultinodeSpec(src *MultinodeSpec, dst *v1beta1.MultinodeSpec) {
+	*dst = v1beta1.MultinodeSpec{NodeCount: src.NodeCount}
+}
+
+// ConvertToMultinodeSpec converts multinode settings from v1beta1 to
+// v1alpha1.
+func ConvertToMultinodeSpec(src *v1beta1.MultinodeSpec, dst *MultinodeSpec) {
+	*dst = MultinodeSpec{NodeCount: src.NodeCount}
+}
+
+// ConvertFromModelReference converts model references from v1alpha1 to
+// v1beta1.
+func ConvertFromModelReference(src *ModelReference, dst *v1beta1.ModelReference) {
+	*dst = v1beta1.ModelReference{
+		Name:     src.Name,
+		Revision: src.Revision,
+	}
+}
+
+// ConvertToModelReference converts model references from v1beta1 to v1alpha1.
+func ConvertToModelReference(src *v1beta1.ModelReference, dst *ModelReference) {
+	*dst = ModelReference{
+		Name:     src.Name,
+		Revision: src.Revision,
+	}
+}
+
+// ConvertFromTopologyConstraint converts component topology constraints from
+// v1alpha1 to v1beta1.
+func ConvertFromTopologyConstraint(src *TopologyConstraint, dst *v1beta1.TopologyConstraint) {
+	*dst = v1beta1.TopologyConstraint{
+		PackDomain: v1beta1.TopologyDomain(src.PackDomain),
+	}
+}
+
+// ConvertToTopologyConstraint converts component topology constraints from
+// v1beta1 to v1alpha1.
+func ConvertToTopologyConstraint(src *v1beta1.TopologyConstraint, dst *TopologyConstraint) {
+	*dst = TopologyConstraint{
+		PackDomain: TopologyDomain(src.PackDomain),
+	}
+}
+
+// ConvertFromEPPConfig converts EPP config from v1alpha1 to v1beta1.
+func ConvertFromEPPConfig(src *EPPConfig, dst *v1beta1.EPPConfig) {
+	*dst = v1beta1.EPPConfig{
+		ConfigMapRef: src.ConfigMapRef.DeepCopy(),
+		Config:       src.Config.DeepCopy(),
+	}
+}
+
+// ConvertToEPPConfig converts EPP config from v1beta1 to v1alpha1.
+func ConvertToEPPConfig(src *v1beta1.EPPConfig, dst *EPPConfig) {
+	*dst = EPPConfig{
+		ConfigMapRef: src.ConfigMapRef.DeepCopy(),
+		Config:       src.Config.DeepCopy(),
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Shared-memory
 // ---------------------------------------------------------------------------
 
@@ -802,12 +854,11 @@ func ConvertFromSharedMemorySpec(src *SharedMemorySpec, dst *resource.Quantity) 
 	*dst = src.Size
 }
 
-func convertSharedMemoryTo(src *SharedMemorySpec, dst *v1beta1.DynamoComponentDeploymentSharedSpec) error {
+func convertSharedMemoryToHub(src *SharedMemorySpec, dst *v1beta1.DynamoComponentDeploymentSharedSpec) {
 	if src != nil && (src.Disabled || !src.Size.IsZero()) {
 		dst.SharedMemorySize = &resource.Quantity{}
 		ConvertFromSharedMemorySpec(src, dst.SharedMemorySize)
 	}
-	return nil
 }
 
 // ConvertToSharedMemorySpec converts the v1beta1 shared-memory scalar
@@ -815,7 +866,7 @@ func convertSharedMemoryTo(src *SharedMemorySpec, dst *v1beta1.DynamoComponentDe
 func ConvertToSharedMemorySpec(src *resource.Quantity, dst *SharedMemorySpec) {
 	if src.Sign() == 0 {
 		// Canonical v1beta1 "size=0" <-> v1alpha1 Disabled=true. See
-		// convertSharedMemoryTo for the forward direction.
+		// convertSharedMemoryToHub for the forward direction.
 		//
 		// Size carries the incoming canonical Quantity value (not the Go zero
 		// value) so that every apply produces a spec that is reflect.DeepEqual
@@ -831,7 +882,7 @@ func ConvertToSharedMemorySpec(src *resource.Quantity, dst *SharedMemorySpec) {
 	*dst = SharedMemorySpec{Size: *src}
 }
 
-func convertSharedMemoryFrom(src *resource.Quantity, dst *DynamoComponentDeploymentSharedSpec) {
+func convertSharedMemoryFromHub(src *resource.Quantity, dst *DynamoComponentDeploymentSharedSpec) {
 	if src != nil {
 		dst.SharedMemory = &SharedMemorySpec{}
 		ConvertToSharedMemorySpec(src, dst.SharedMemory)
@@ -855,12 +906,12 @@ func convertSharedMemoryFrom(src *resource.Quantity, dst *DynamoComponentDeploym
 //     extraPodSpec escape hatch anyway, so placing them there mirrors the
 //     v1alpha1 reconcile-merge behaviour in graph.go).
 
-// convertVolumeMountsFrom is the v1beta1 -> v1alpha1 inverse: it synthesises
+// convertVolumeMountsFromHub is the v1beta1 -> v1alpha1 inverse: it synthesises
 // a single flagged entry in dst.VolumeMounts when the v1beta1 side declares
 // a CompilationCacheConfig. Non-cache mounts on the main container are
-// preserved through decomposePodTemplate's ExtraPodSpec.MainContainer copy,
+// preserved through decomposePodTemplateFromHub's ExtraPodSpec.MainContainer copy,
 // not here.
-func convertVolumeMountsFrom(src *v1beta1.DynamoComponentDeploymentSharedSpec, dst *DynamoComponentDeploymentSharedSpec) {
+func convertVolumeMountsFromHub(src *v1beta1.DynamoComponentDeploymentSharedSpec, dst *DynamoComponentDeploymentSharedSpec) {
 	if src.CompilationCache == nil {
 		return
 	}
@@ -875,19 +926,16 @@ func convertVolumeMountsFrom(src *v1beta1.DynamoComponentDeploymentSharedSpec, d
 // Scaling adapter (Enabled flag removed in v1beta1)
 // ---------------------------------------------------------------------------
 
-func convertScalingAdapterTo(src *ScalingAdapter, dst *v1beta1.DynamoComponentDeploymentSharedSpec) {
-	if src == nil {
-		return
-	}
-	if src.Enabled {
-		dst.ScalingAdapter = &v1beta1.ScalingAdapter{}
-	}
+// ConvertFromScalingAdapter converts the v1alpha1 scaling adapter marker into
+// the v1beta1 marker. Callers skip disabled adapters before calling.
+func ConvertFromScalingAdapter(src *ScalingAdapter, dst *v1beta1.ScalingAdapter) {
+	*dst = v1beta1.ScalingAdapter{}
 }
 
-func convertScalingAdapterFrom(src *v1beta1.ScalingAdapter, dst *DynamoComponentDeploymentSharedSpec) {
-	if src != nil {
-		dst.ScalingAdapter = &ScalingAdapter{Enabled: true}
-	}
+// ConvertToScalingAdapter converts the v1beta1 scaling adapter marker into
+// the enabled v1alpha1 marker.
+func ConvertToScalingAdapter(src *v1beta1.ScalingAdapter, dst *ScalingAdapter) {
+	*dst = ScalingAdapter{Enabled: true}
 }
 
 // ---------------------------------------------------------------------------
@@ -1040,7 +1088,7 @@ func ConvertToDynamoCheckpointIdentity(src *v1beta1.DynamoCheckpointIdentity, ds
 	}
 }
 
-func convertExperimentalTo(src *DynamoComponentDeploymentSharedSpec, dst *v1beta1.DynamoComponentDeploymentSharedSpec) {
+func convertExperimentalToHub(src *DynamoComponentDeploymentSharedSpec, dst *v1beta1.DynamoComponentDeploymentSharedSpec) {
 	var exp *v1beta1.ExperimentalSpec
 	ensureExp := func() *v1beta1.ExperimentalSpec {
 		if exp == nil {
@@ -1067,7 +1115,7 @@ func convertExperimentalTo(src *DynamoComponentDeploymentSharedSpec, dst *v1beta
 	dst.Experimental = exp
 }
 
-func convertExperimentalFrom(src *v1beta1.DynamoComponentDeploymentSharedSpec, dst *DynamoComponentDeploymentSharedSpec) {
+func convertExperimentalFromHub(src *v1beta1.DynamoComponentDeploymentSharedSpec, dst *DynamoComponentDeploymentSharedSpec) {
 	if src.Experimental != nil && src.Experimental.GPUMemoryService != nil {
 		dst.GPUMemoryService = &GPUMemoryServiceSpec{}
 		ConvertToGPUMemoryServiceSpec(src.Experimental.GPUMemoryService, dst.GPUMemoryService)
@@ -1088,13 +1136,13 @@ func convertExperimentalFrom(src *v1beta1.DynamoComponentDeploymentSharedSpec, d
 // podTemplate (the big one)
 // ---------------------------------------------------------------------------
 
-// buildPodTemplateTo composes the v1beta1 podTemplate from v1alpha1's flat
+// buildPodTemplateToHub composes the v1beta1 podTemplate from v1alpha1's flat
 // fields (Resources, Envs, Probes, EnvFromSecret, ExtraPodSpec,
 // ExtraPodMetadata, FrontendSidecar) following the same merge precedence the
 // v1alpha1 controller uses at reconcile time: ExtraPodSpec.MainContainer wins
 // over dedicated fields, except for env which is additive.
-func buildPodTemplateTo(src *DynamoComponentDeploymentSharedSpec, dst *v1beta1.DynamoComponentDeploymentSharedSpec, ctx sharedSpecConversionContext) error {
-	podTpl, err := buildSharedPodTemplateFromAlpha(src, ctx.podTemplateOrigin, false)
+func buildPodTemplateToHub(src *DynamoComponentDeploymentSharedSpec, dst *v1beta1.DynamoComponentDeploymentSharedSpec, ctx DynamoComponentDeploymentSharedSpecConversionContext) error {
+	podTpl, err := buildSharedPodTemplateFromAlpha(src, ctx.PodTemplateOrigin, false)
 	if err != nil {
 		return err
 	}
@@ -1228,8 +1276,8 @@ func buildMainContainerFromDedicated(src *DynamoComponentDeploymentSharedSpec) c
 	return ctr
 }
 
-// decomposePodTemplate inverts buildPodTemplateTo.
-func decomposePodTemplate(src *v1beta1.DynamoComponentDeploymentSharedSpec, dst, restored *DynamoComponentDeploymentSharedSpec) error {
+// decomposePodTemplateFromHub inverts buildPodTemplateToHub.
+func decomposePodTemplateFromHub(src *v1beta1.DynamoComponentDeploymentSharedSpec, dst, restored *DynamoComponentDeploymentSharedSpec) error {
 	if src.PodTemplate == nil {
 		decomposeMissingPodTemplate(src, dst, restored)
 		return nil
@@ -1265,7 +1313,7 @@ func decomposePodTemplate(src *v1beta1.DynamoComponentDeploymentSharedSpec, dst,
 	// true escape-hatch remainder.
 	podSpecCopy := podTpl.Spec.DeepCopy()
 	podSpecCopy.Containers = other
-	// The forward path (buildPodTemplateTo) always emits a "main" container,
+	// The forward path (buildPodTemplateToHub) always emits a "main" container,
 	// even when v1alpha1 had no main-container fields set (e.g. only
 	// FrontendSidecar triggered hasAny). Skip recording it on the v1alpha1
 	// side when every field other than Name is zero-valued, so that
@@ -1750,8 +1798,8 @@ func restoreFlatVolumeMountsFromMain(main *corev1.Container, dst *DynamoComponen
 }
 
 // containerIsEmpty reports whether c has no user-visible fields set. Used by
-// decomposePodTemplate to drop the "main" container synthesized by
-// buildPodTemplateTo when v1alpha1 had no main-container fields of its own.
+// decomposePodTemplateFromHub to drop the "main" container synthesized by
+// buildPodTemplateToHub when v1alpha1 had no main-container fields of its own.
 // Name is expected to have been cleared by the caller.
 func containerIsEmpty(c *corev1.Container) bool {
 	if c == nil {

--- a/deploy/operator/api/v1alpha1/shared_spec_conversion_bugs_test.go
+++ b/deploy/operator/api/v1alpha1/shared_spec_conversion_bugs_test.go
@@ -56,17 +56,15 @@ func TestConvertFromSharedMemorySpec(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var got v1beta1.DynamoComponentDeploymentSharedSpec
-			if err := convertSharedMemoryTo(tt.src, &got); err != nil {
-				t.Fatalf("convertSharedMemoryTo() error = %v", err)
-			}
+			convertSharedMemoryToHub(tt.src, &got)
 			if tt.want == "" {
 				if got.SharedMemorySize != nil {
-					t.Fatalf("convertSharedMemoryTo().SharedMemorySize = %s, want nil", got.SharedMemorySize.String())
+					t.Fatalf("convertSharedMemoryToHub().SharedMemorySize = %s, want nil", got.SharedMemorySize.String())
 				}
 				return
 			}
 			if got.SharedMemorySize == nil || got.SharedMemorySize.String() != tt.want {
-				t.Fatalf("convertSharedMemoryTo().SharedMemorySize = %v, want %s", got.SharedMemorySize, tt.want)
+				t.Fatalf("convertSharedMemoryToHub().SharedMemorySize = %v, want %s", got.SharedMemorySize, tt.want)
 			}
 		})
 	}

--- a/deploy/operator/api/v1alpha1/shared_spec_conversion_bugs_test.go
+++ b/deploy/operator/api/v1alpha1/shared_spec_conversion_bugs_test.go
@@ -56,15 +56,17 @@ func TestConvertFromSharedMemorySpec(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var got v1beta1.DynamoComponentDeploymentSharedSpec
-			convertSharedMemoryToHub(tt.src, &got)
+			if err := ConvertFromDynamoComponentDeploymentSharedSpec(&DynamoComponentDeploymentSharedSpec{SharedMemory: tt.src}, &got, nil, nil, DynamoComponentDeploymentSharedSpecConversionContext{}); err != nil {
+				t.Fatalf("ConvertFromDynamoComponentDeploymentSharedSpec() error = %v", err)
+			}
 			if tt.want == "" {
 				if got.SharedMemorySize != nil {
-					t.Fatalf("convertSharedMemoryToHub().SharedMemorySize = %s, want nil", got.SharedMemorySize.String())
+					t.Fatalf("ConvertFromDynamoComponentDeploymentSharedSpec().SharedMemorySize = %s, want nil", got.SharedMemorySize.String())
 				}
 				return
 			}
 			if got.SharedMemorySize == nil || got.SharedMemorySize.String() != tt.want {
-				t.Fatalf("convertSharedMemoryToHub().SharedMemorySize = %v, want %s", got.SharedMemorySize, tt.want)
+				t.Fatalf("ConvertFromDynamoComponentDeploymentSharedSpec().SharedMemorySize = %v, want %s", got.SharedMemorySize, tt.want)
 			}
 		})
 	}

--- a/deploy/operator/docs/crd-ref-docs-config.yaml
+++ b/deploy/operator/docs/crd-ref-docs-config.yaml
@@ -34,6 +34,7 @@ processor:
     # Ignore only the override wrapper type to reduce repetition
     # Keep SharedSpec so embedded fields are documented once
     # - "DynamoComponentDeploymentOverridesSpec$"
+    - "ConversionContext$"
     - "DynamoComponentDeploymentStatus$"
     - "BaseStatus$"
     - "ExcludedNamespacesChecker"


### PR DESCRIPTION
This is the main-based version of the DCD/DGD structural conversion cleanup. It intentionally excludes the non-conversion changes from the previous stacked base; the PR diff is limited to API conversion docs, DCD/DGD/shared conversion code, and conversion tests.

Summary:
- Export structural ConvertFrom<Type>/ConvertTo<Type> helpers for DCD/DGD API structs.
- Keep src/dst/restored/save/ctx ordering with optional args only where needed.
- Remove wrapper-style conversion helpers and keep optional allocation at call sites.
- Document conversion rules in deploy/operator/api/CONVERSION.md, including annotation privacy, source immutability, and one-API-layer-at-a-time delegation.

Tests:
- go test ./api/... ./internal/dynamo -count=1
- go test ./api -run "TestFuzzRoundTrip|TestFuzzRoundTripMutability" -roundtrip-fuzz-iters=3000 -count=1 -v