### PR TITLE
docs: update kvbm python support

### DIFF
--- a/docs/reference/release-artifacts.md
+++ b/docs/reference/release-artifacts.md
@@ -43,7 +43,7 @@ We recommend using the TensorRT-LLM NGC container instead of the `ai-dynamo[trtl
 |---------|-------------|--------|----------|------|
 | `ai-dynamo==1.1.0` | Main package with backend integrations (vLLM, SGLang, TRT-LLM) | `3.10`–`3.12` | Linux (glibc `v2.28+`) | [link](https://pypi.org/project/ai-dynamo/1.1.0/) |
 | `ai-dynamo-runtime==1.1.0` | Core Python bindings for Dynamo runtime | `3.10`–`3.12` | Linux (glibc `v2.28+`) | [link](https://pypi.org/project/ai-dynamo-runtime/1.1.0/) |
-| `kvbm==1.1.0` | KV Block Manager for disaggregated KV cache | `3.12` | Linux (glibc `v2.28+`) | [link](https://pypi.org/project/kvbm/1.1.0/) |
+| `kvbm==1.1.0` | KV Block Manager for disaggregated KV cache | `3.10`–`3.12` | Linux (glibc `v2.28+`) | [link](https://pypi.org/project/kvbm/1.1.0/) |
 
 ### Helm Charts
 
@@ -111,7 +111,7 @@ pip install --pre --extra-index-url https://pypi.nvidia.com "ai-dynamo[trtllm]==
 # Install Dynamo core only
 uv pip install ai-dynamo==1.1.0
 
-# Install standalone KVBM (Python 3.12 only)
+# Install standalone KVBM
 uv pip install kvbm==1.1.0
 ```
 
@@ -385,16 +385,16 @@ For a complete list of known issues, refer to the release notes for each version
 
 | Package | Python | Platform | Notes |
 |---------|--------|----------|-------|
-| `kvbm==1.1.0` | `3.12` | Linux (glibc `v2.28+`) | |
-| `kvbm==1.0.2` | `3.12` | Linux (glibc `v2.28+`) | |
-| `kvbm==1.0.1` | `3.12` | Linux (glibc `v2.28+`) | |
-| `kvbm==1.0.0` | `3.12` | Linux (glibc `v2.28+`) | |
-| `kvbm==0.9.1` | `3.12` | Linux (glibc `v2.28+`) | |
-| `kvbm==0.9.0` | `3.12` | Linux (glibc `v2.28+`) | |
-| `kvbm==0.8.1` | `3.12` | Linux (glibc `v2.28+`) | |
-| `kvbm==0.8.0` | `3.12` | Linux (glibc `v2.28+`) | |
-| `kvbm==0.7.1` | `3.12` | Linux (glibc `v2.28+`) | |
-| `kvbm==0.7.0` | `3.12` | Linux (glibc `v2.28+`) | Initial |
+| `kvbm==1.1.0` | `3.10`–`3.12` | Linux (glibc `v2.28+`) | |
+| `kvbm==1.0.2` | `3.10`–`3.12` | Linux (glibc `v2.28+`) | |
+| `kvbm==1.0.1` | `3.10`–`3.12` | Linux (glibc `v2.28+`) | |
+| `kvbm==1.0.0` | `3.10`–`3.12` | Linux (glibc `v2.28+`) | |
+| `kvbm==0.9.1` | `3.10`–`3.12` | Linux (glibc `v2.28+`) | |
+| `kvbm==0.9.0` | `3.10`–`3.12` | Linux (glibc `v2.28+`) | |
+| `kvbm==0.8.1` | `3.10`–`3.12` | Linux (glibc `v2.28+`) | |
+| `kvbm==0.8.0` | `3.10`–`3.12` | Linux (glibc `v2.28+`) | |
+| `kvbm==0.7.1` | `3.10`–`3.12` | Linux (glibc `v2.28+`) | |
+| `kvbm==0.7.0` | `3.10`–`3.12` | Linux (glibc `v2.28+`) | Initial |
 
 ### Helm Charts
 

--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -169,9 +169,6 @@ If you are using a **GPU**, the following GPU models and architectures are suppo
 
 Wheels are built using a manylinux_2_28-compatible environment and validated on CentOS Stream 9 and Ubuntu (22.04, 24.04). Compatibility with other Linux distributions is expected but not officially verified.
 
-> [!Caution]
-> KV Block Manager is supported only with Python 3.12. Python 3.12 support is currently limited to Ubuntu 24.04.
-
 ## Cloud Service Provider Compatibility
 
 ### AWS


### PR DESCRIPTION
Update kvbm python version in docs. Supports python 3.10+

ref: OPS-4984

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9258" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to reflect expanded Python version support for kvbm==1.1.0 across Python 3.10–3.12 (previously documented as 3.12 only).
  * Revised quick install instructions for the standalone KVBM package.
  * Removed previously documented platform compatibility limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->