### PR TITLE
fix: gate frontend PR jobs on frontend changes

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -260,13 +260,15 @@ jobs:
 
   frontend-build:
     name: frontend
+    needs: [changed-files]
+    if: needs.changed-files.outputs.frontend == 'true'
     uses: ./.github/workflows/shared-build-image.yml
     with:
       framework: dynamo
       target: frontend
       cuda_version: '[""]'
       platform: 'linux/amd64,linux/arm64'
-      builder_name: b-${{ github.run_id }}-${{ github.run_attempt }}
+      builder_name: ${{ needs.changed-files.outputs.builder_name }}
       build_timeout_minutes: 45
     secrets: inherit
 
@@ -482,7 +484,8 @@ jobs:
 
   frontend-compliance:
     name: frontend # This name overlaps with other frontend jobs to group them in the UI
-    needs: [frontend-build]
+    needs: [changed-files, frontend-build]
+    if: needs.changed-files.outputs.frontend == 'true'
     uses: ./.github/workflows/shared-compliance.yml
     with:
       framework: dynamo


### PR DESCRIPTION
Gate the PR frontend image build and frontend compliance scan on the existing changed-files frontend output. This keeps frontend CI aligned with the other framework jobs and skips the frontend image path when no frontend-impacting files changed.

Also route frontend-build through the shared builder_name output from changed-files so it uses the same central builder naming source as the surrounding PR jobs.

ref: OPS-4984


<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9260" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved continuous integration workflow coordination between build and compliance verification jobs for more reliable automated checks and dependency handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->