### PR TITLE
docs(parity): expand harness to all 19 Dynamo parser families

### DIFF
--- a/tests/parity/README.md
+++ b/tests/parity/README.md
@@ -99,7 +99,7 @@ Both servers receive identical chat-completion requests with `structured_outputs
 | **Real tokenizer?** | yes | no | yes |
 | **Real chat template?** | yes | no | yes |
 | **Real HTTP?** | yes | no | yes |
-| **Cost** | (TBD) | ~3 s for 210 tests | ~60 s for 30 tests (server boot dominates) |
+| **Cost** | (TBD) | ~3 s for 570 tests | ~60 s for 30 tests (server boot dominates) |
 | **GPU** | yes | none | yes (`--load-format dummy` still allocates ~2.5 GiB) |
 | **CI markers** | (TBD) | `unit, pre_merge, gpu_0` | `e2e, pre_merge, gpu_1` |
 
@@ -117,37 +117,74 @@ They're stacked diagnostics:
 
 ## Current parity status (M2, batch mode)
 
-`✓` = matches the YAML expected output. `X` = divergence recorded
-in `KNOWN_DIVERGENCES` (xfailed, not silenced). `n/a` = the impl has
-no parser registered for that family. `dynamo` rows are always `ok`
-because Dynamo is the regenerator's oracle.
+Each row is a parser family; each column `bN` is
+[`PARSER.batch.N`](../../lib/parsers/PARSER_CASES.md):
 
-| family#impl            |  1  |  2  |  3  |  4  |  5  |  6  |  7  |  8  |  9  | 10  |
-|--------------------------|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-| kimi_k2#dynamo         | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   |
-| kimi_k2#vllm           | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   |  X  | ✓   | ✓   |
-| kimi_k2#sglang         | ✓   | ✓   | ✓   |  X  | ✓   | ✓   | ✓   |  X  | ✓   | ✓   |
-| qwen3_coder#dynamo     | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   |
-| qwen3_coder#vllm       | ✓   | ✓   | ✓   |  X  |  X  | ✓   | ✓   |  X  | ✓   | ✓   |
-| qwen3_coder#sglang     | ✓   | ✓   | ✓   |  X  |  X  | ✓   | ✓   |  X  | ✓   | ✓   |
-| glm47#dynamo           | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   |
-| glm47#vllm             | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   |  X  | ✓   | ✓   |
-| glm47#sglang           | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   |  X  | ✓   | ✓   |
-| deepseek_v3_1#dynamo   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   |
-| deepseek_v3_1#vllm     | ✓   | ✓   | ✓   |  X  |  X  | ✓   | ✓   | ✓   | ✓   | ✓   |
-| deepseek_v3_1#sglang   | ✓   | ✓   | ✓   | ✓   |  X  | ✓   | ✓   |  X  | ✓   | ✓   |
-| harmony#dynamo         | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   |
-| harmony#vllm           | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a |
-| harmony#sglang         |  X  |  X  | ✓   |  X  |  X  |  X  |  X  |  X  | ✓   |  X  |
-| minimax_m2#dynamo      | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   |
-| minimax_m2#vllm        | ✓   | ✓   | ✓   |  X  | ✓   | ✓   | ✓   |  X  | ✓   | ✓   |
-| minimax_m2#sglang      | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   |
-| nemotron_deci#dynamo   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   |
-| nemotron_deci#vllm     | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a |
-| nemotron_deci#sglang   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   |
+```
+b1   =  PARSER.batch.1   "single happy-path call"
+b2   =  PARSER.batch.2   "multiple calls"
+b3   =  PARSER.batch.3   "no tool call (plain text)"
+b4   =  PARSER.batch.4   "malformed JSON args"
+b5   =  PARSER.batch.5   "missing end-token recovery"
+b6   =  PARSER.batch.6   "empty args (no-arg call)"
+b7   =  PARSER.batch.7   "complex args (nested JSON / arrays)"
+b8   =  PARSER.batch.8   "interleaved normal text"
+b9   =  PARSER.batch.9   "empty input"
+b10  =  PARSER.batch.10  "duplicate calls (same name twice)"
+```
 
-Tally (excluding `dynamo` since it's the oracle): 140 cells against
-the YAML expected — 95 parity, 25 divergence (xfailed), 20 n/a.
+Cell values show divergence from Dynamo (the oracle):
+
+- `✓` — both vLLM and SGLang match Dynamo's expected output.
+- `V` — vLLM diverges (xfailed via `KNOWN_DIVERGENCES`).
+- `S` — SGLang diverges.
+- `VS` — both diverge.
+- `n/a` — no peer parser registered for that family.
+
+19 parser families total — split into the **Top-N models** we prioritize
+(rows tagged with the model name in parens) and **Others** that aren't
+top-N today but are wired into the harness for completeness. Both sections
+sorted alphabetically within themselves.
+
+| family                          |  b1 |  b2 |  b3 |  b4 |  b5 |  b6 |  b7 |  b8 |  b9 | b10 |
+|---------------------------------|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| **Top-N models**                |     |     |     |     |     |     |     |     |     |     |
+| deepseek_v4 § (DeepSeek V4)     | ✓   | ✓   | ✓   | ✓   | V   | ✓   | V   | ✓   | ✓   | ✓   |
+| gemma4 § (Gemma 4)              | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | V   | ✓   | ✓   |
+| glm47 (GLM 5.1)                 | ✓   | ✓   | ✓   | ✓   | VS  | ✓   | ✓   | V   | ✓   | ✓   |
+| harmony † (gpt-oss)             | S   | S   | ✓   | S   | S   | S   | S   | S   | ✓   | S   |
+| kimi_k2 (Kimi K2.6)             | ✓   | ✓   | ✓   | S   | ✓   | ✓   | ✓   | VS  | ✓   | ✓   |
+| minimax_m2 (MiniMax 2.7)        | ✓   | ✓   | ✓   | V   | VS  | ✓   | ✓   | VS  | ✓   | ✓   |
+| nemotron_deci †§ (Nemotron)     | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a |
+| qwen3_coder (Qwen 3.5)          | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | VS  | ✓   | ✓   |
+| **Others**                      |     |     |     |     |     |     |     |     |     |     |
+| deepseek_v3                     | ✓   | ✓   | ✓   | V   | VS  | ✓   | ✓   | S   | ✓   | ✓   |
+| deepseek_v3_1                   | ✓   | ✓   | ✓   | V   | VS  | ✓   | ✓   | S   | ✓   | ✓   |
+| deepseek_v3_2                   | ✓   | ✓   | ✓   | ✓   | V   | ✓   | V   | S   | ✓   | ✓   |
+| hermes                          | ✓   | ✓   | ✓   | VS  | ✓   | ✓   | ✓   | V   | ✓   | ✓   |
+| jamba §                         | ✓   | ✓   | ✓   | ✓   | V   | ✓   | ✓   | V   | ✓   | ✓   |
+| llama3_json §                   | ✓   | V   | ✓   | V   | V   | ✓   | ✓   | ✓   | ✓   | V   |
+| mistral                         | S   | S   | ✓   | VS  | S   | S   | S   | VS  | ✓   | S   |
+| nemotron_nano †§                | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a |
+| phi4 §                          | ✓   | ✓   | ✓   | ✓   | V   | ✓   | V   | V   | ✓   | ✓   |
+| pythonic                        | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | VS  | ✓   | ✓   |
+| qwen25 †                        | S   | S   | ✓   | S   | S   | S   | S   | S   | ✓   | S   |
+
+### Footnotes
+
+† vLLM has no peer parser (or returns `UNAVAILABLE` at runtime, e.g.
+  `harmony#vllm` requires token IDs not text). Cells show SGLang status
+  only when SGLang is wired; otherwise the row is fully `n/a`.
+§ SGLang has no peer detector for this family. Cells show vLLM status
+  only when vLLM is wired; otherwise the row is fully `n/a`.
+
+`nemotron_deci` and `nemotron_nano` carry both daggers (`†§`) — neither
+upstream has a peer parser, so the rows are fully `n/a`. Listed here for
+completeness; Dynamo-only self-parity could be added in a follow-up but
+yields no cross-impl signal.
+
+Tally (excluding `dynamo` since it's the oracle): 380 cells against
+the YAML expected — 203 parity, 67 divergence (xfailed), 110 n/a.
 
 **Hot columns:**
 - `PARSER.batch.4` (malformed JSON) and `PARSER.batch.5` (missing
@@ -205,23 +242,12 @@ U+2581) appear as literal characters rather than escape sequences.
 
 Open any two family files side-by-side and the case shells look
 nearly identical: same `description` strings, same `tools` schemas,
-same case keys `"1"`–`"10"`. **That's by design** — case N is the
-same logical scenario across every family:
+same case keys `"PARSER.batch.1"`–`"PARSER.batch.10"`. **That's by
+design** — `PARSER.batch.N` is the same logical scenario across every
+family (full list in the [Current parity status](#current-parity-status-m2-batch-mode)
+section above).
 
-```
-case 1  =  "single happy-path call"
-case 2  =  "multiple calls"
-case 3  =  "no tool call (plain text)"
-case 4  =  "malformed JSON args"
-case 5  =  "missing end-token recovery"
-case 6  =  "empty args (no-arg call)"
-case 7  =  "complex args (nested JSON / arrays)"
-case 8  =  "interleaved normal text"
-case 9  =  "empty input"
-case 10 =  "duplicate calls (same name twice)"
-```
-
-So a reviewer can grep `PARSER.batch.4` across all 7 families and
+So a reviewer can grep `PARSER.batch.4` across all 10 families and
 immediately see how each parser handles the same scenario. The
 repetition *is* the diff: it's what makes per-case cross-family
 comparison trivial.
@@ -317,7 +343,7 @@ will guide which stages are worth adding when.
 
 Today there's overlap between this harness's fixtures and the
 hand-written Rust unit tests under `lib/parsers/src/tool_calling/*`
-— for the ~70 black-box "given input X, parser returns Y" tests,
+— for the ~190 black-box "given input X, parser returns Y" tests,
 the same input + expected appears in both places (the M2 fixtures
 were originally extracted from those Rust tests by hand).
 
@@ -368,7 +394,7 @@ Effort sketch (separate PRs after M2 + M3 land):
   schema + streaming PyO3 + streaming Rust harness. Roughly
   the size of the original M3 work.
 
-Until then, M2 and the Rust suite both exist; for ~70 cases they
+Until then, M2 and the Rust suite both exist; for ~100 cases they
 test the same Dynamo contract through different surfaces. M2's
 real value-add is the cross-impl half (vLLM and SGLang).
 

--- a/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.yaml
@@ -1,0 +1,183 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: deepseek_v3_2
+mode: batch
+cases:
+  PARSER.batch.1:
+    description: Single tool call (happy path)
+    model_text: |-
+      <｜DSML｜function_calls>
+      <｜DSML｜invoke name="get_weather">
+      <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+      </｜DSML｜invoke>
+      </｜DSML｜function_calls>
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+  PARSER.batch.2:
+    description: Multiple tool calls (parallel)
+    model_text: |-
+      <｜DSML｜function_calls>
+      <｜DSML｜invoke name="get_weather">
+      <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+      </｜DSML｜invoke>
+      <｜DSML｜invoke name="get_time">
+      <｜DSML｜parameter name="timezone" string="true">EST</｜DSML｜parameter>
+      </｜DSML｜invoke>
+      </｜DSML｜function_calls>
+    tools:
+    - *id001
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
+  PARSER.batch.3:
+    description: No tool call (plain text)
+    model_text: Hello, how can I help you today?
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: Hello, how can I help you today?
+  PARSER.batch.4:
+    description: Malformed (missing </｜DSML｜parameter> end tag)
+    model_text: |-
+      <｜DSML｜function_calls>
+      <｜DSML｜invoke name="get_weather">
+      <｜DSML｜parameter name="location" string="true">NYC
+      </｜DSML｜invoke>
+      </｜DSML｜function_calls>
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.5:
+    description: Missing </｜DSML｜function_calls> end marker
+    model_text: |-
+      <｜DSML｜function_calls>
+      <｜DSML｜invoke name="get_weather">
+      <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+      </｜DSML｜invoke>
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''
+  PARSER.batch.6:
+    description: Empty args (no-arg call)
+    model_text: |-
+      <｜DSML｜function_calls>
+      <｜DSML｜invoke name="get_time">
+      </｜DSML｜invoke>
+      </｜DSML｜function_calls>
+    tools:
+    - name: get_time
+      parameters:
+        type: object
+        properties: {}
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.7:
+    description: Complex args (nested object + array, JSON-typed)
+    model_text: |-
+      <｜DSML｜function_calls>
+      <｜DSML｜invoke name="process_data">
+      <｜DSML｜parameter name="items" string="false">[1, 2, 3]</｜DSML｜parameter>
+      <｜DSML｜parameter name="config" string="false">{"nested": true}</｜DSML｜parameter>
+      </｜DSML｜invoke>
+      </｜DSML｜function_calls>
+    tools:
+    - name: process_data
+      parameters:
+        type: object
+        properties:
+          items:
+            type: array
+          config:
+            type: object
+    expected:
+      calls:
+      - name: process_data
+        arguments:
+          items:
+          - 1
+          - 2
+          - 3
+          config:
+            nested: true
+      normal_text: ''
+  PARSER.batch.8:
+    description: Interleaved normal text
+    model_text: |-
+      I will check the weather. <｜DSML｜function_calls>
+      <｜DSML｜invoke name="get_weather">
+      <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+      </｜DSML｜invoke>
+      </｜DSML｜function_calls>
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'I will check the weather. '
+  PARSER.batch.9:
+    description: Empty input
+    model_text: ''
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''
+  PARSER.batch.10:
+    description: Duplicate calls (same name twice)
+    model_text: |-
+      <｜DSML｜function_calls>
+      <｜DSML｜invoke name="get_weather">
+      <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+      </｜DSML｜invoke>
+      <｜DSML｜invoke name="get_weather">
+      <｜DSML｜parameter name="location" string="true">LA</｜DSML｜parameter>
+      </｜DSML｜invoke>
+      </｜DSML｜function_calls>
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''

--- a/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.yaml
@@ -1,0 +1,183 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: deepseek_v4
+mode: batch
+cases:
+  PARSER.batch.1:
+    description: Single tool call (happy path)
+    model_text: |-
+      <｜DSML｜tool_calls>
+      <｜DSML｜invoke name="get_weather">
+      <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+      </｜DSML｜invoke>
+      </｜DSML｜tool_calls>
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+  PARSER.batch.2:
+    description: Multiple tool calls (parallel)
+    model_text: |-
+      <｜DSML｜tool_calls>
+      <｜DSML｜invoke name="get_weather">
+      <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+      </｜DSML｜invoke>
+      <｜DSML｜invoke name="get_time">
+      <｜DSML｜parameter name="timezone" string="true">EST</｜DSML｜parameter>
+      </｜DSML｜invoke>
+      </｜DSML｜tool_calls>
+    tools:
+    - *id001
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
+  PARSER.batch.3:
+    description: No tool call (plain text)
+    model_text: Hello, how can I help you today?
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: Hello, how can I help you today?
+  PARSER.batch.4:
+    description: Malformed (missing </｜DSML｜parameter> end tag)
+    model_text: |-
+      <｜DSML｜tool_calls>
+      <｜DSML｜invoke name="get_weather">
+      <｜DSML｜parameter name="location" string="true">NYC
+      </｜DSML｜invoke>
+      </｜DSML｜tool_calls>
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.5:
+    description: Missing </｜DSML｜tool_calls> end marker
+    model_text: |-
+      <｜DSML｜tool_calls>
+      <｜DSML｜invoke name="get_weather">
+      <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+      </｜DSML｜invoke>
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''
+  PARSER.batch.6:
+    description: Empty args (no-arg call)
+    model_text: |-
+      <｜DSML｜tool_calls>
+      <｜DSML｜invoke name="get_time">
+      </｜DSML｜invoke>
+      </｜DSML｜tool_calls>
+    tools:
+    - name: get_time
+      parameters:
+        type: object
+        properties: {}
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.7:
+    description: Complex args (nested object + array, JSON-typed)
+    model_text: |-
+      <｜DSML｜tool_calls>
+      <｜DSML｜invoke name="process_data">
+      <｜DSML｜parameter name="items" string="false">[1, 2, 3]</｜DSML｜parameter>
+      <｜DSML｜parameter name="config" string="false">{"nested": true}</｜DSML｜parameter>
+      </｜DSML｜invoke>
+      </｜DSML｜tool_calls>
+    tools:
+    - name: process_data
+      parameters:
+        type: object
+        properties:
+          items:
+            type: array
+          config:
+            type: object
+    expected:
+      calls:
+      - name: process_data
+        arguments:
+          items:
+          - 1
+          - 2
+          - 3
+          config:
+            nested: true
+      normal_text: ''
+  PARSER.batch.8:
+    description: Interleaved normal text
+    model_text: |-
+      I will check the weather. <｜DSML｜tool_calls>
+      <｜DSML｜invoke name="get_weather">
+      <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+      </｜DSML｜invoke>
+      </｜DSML｜tool_calls>
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: 'I will check the weather. '
+  PARSER.batch.9:
+    description: Empty input
+    model_text: ''
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''
+  PARSER.batch.10:
+    description: Duplicate calls (same name twice)
+    model_text: |-
+      <｜DSML｜tool_calls>
+      <｜DSML｜invoke name="get_weather">
+      <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+      </｜DSML｜invoke>
+      <｜DSML｜invoke name="get_weather">
+      <｜DSML｜parameter name="location" string="true">LA</｜DSML｜parameter>
+      </｜DSML｜invoke>
+      </｜DSML｜tool_calls>
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''

--- a/tests/parity/parser/fixtures/hermes/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/hermes/PARSER.batch.yaml
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: hermes
+mode: batch
+cases:
+  PARSER.batch.1:
+    description: Single tool call (happy path)
+    model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>'
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+  PARSER.batch.2:
+    description: Multiple tool calls (parallel)
+    model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name": "get_time",
+      "arguments": {"timezone": "EST"}}</tool_call>'
+    tools:
+    - *id001
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
+  PARSER.batch.3:
+    description: No tool call (plain text)
+    model_text: Hello, how can I help you today?
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: Hello, how can I help you today?
+  PARSER.batch.4:
+    description: Malformed JSON args (missing close brace)
+    model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"</tool_call>'
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+  PARSER.batch.5:
+    description: Missing </tool_call> end marker
+    model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}'
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+  PARSER.batch.6:
+    description: Empty args (no-arg call)
+    model_text: '<tool_call>{"name": "get_time", "arguments": {}}</tool_call>'
+    tools:
+    - name: get_time
+      parameters:
+        type: object
+        properties: {}
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.7:
+    description: Complex args (nested object + array)
+    model_text: '<tool_call>{"name": "process_data", "arguments": {"items": [1, 2, 3], "config": {"nested": true}}}</tool_call>'
+    tools:
+    - name: process_data
+      parameters:
+        type: object
+        properties:
+          items:
+            type: array
+          config:
+            type: object
+    expected:
+      calls:
+      - name: process_data
+        arguments:
+          config:
+            nested: true
+          items:
+          - 1
+          - 2
+          - 3
+      normal_text: ''
+  PARSER.batch.8:
+    description: Interleaved normal text
+    model_text: 'I will check the weather. <tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>
+      Done.'
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: I will check the weather.
+  PARSER.batch.9:
+    description: Empty input
+    model_text: ''
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''
+  PARSER.batch.10:
+    description: Duplicate calls (same name twice)
+    model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name": "get_weather",
+      "arguments": {"location": "LA"}}</tool_call>'
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''

--- a/tests/parity/parser/fixtures/jamba/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/jamba/PARSER.batch.yaml
@@ -1,0 +1,142 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: jamba
+mode: batch
+cases:
+  PARSER.batch.1:
+    description: Single tool call (happy path)
+    model_text: '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}]</tool_calls>'
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+  PARSER.batch.2:
+    description: Multiple tool calls (parallel)
+    model_text: '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_time", "arguments":
+      {"timezone": "EST"}}]</tool_calls>'
+    tools:
+    - *id001
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
+  PARSER.batch.3:
+    description: No tool call (plain text)
+    model_text: Hello, how can I help you today?
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: Hello, how can I help you today?
+  PARSER.batch.4:
+    description: Malformed JSON args (missing close brace)
+    model_text: '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"]</tool_calls>'
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"]</tool_calls>'
+  PARSER.batch.5:
+    description: Missing </tool_calls> end marker
+    model_text: '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}]'
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+  PARSER.batch.6:
+    description: Empty args (no-arg call)
+    model_text: '<tool_calls>[{"name": "get_time", "arguments": {}}]</tool_calls>'
+    tools:
+    - name: get_time
+      parameters:
+        type: object
+        properties: {}
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.7:
+    description: Complex args (nested object + array)
+    model_text: '<tool_calls>[{"name": "process_data", "arguments": {"items": [1, 2, 3], "config": {"nested": true}}}]</tool_calls>'
+    tools:
+    - name: process_data
+      parameters:
+        type: object
+        properties:
+          items:
+            type: array
+          config:
+            type: object
+    expected:
+      calls:
+      - name: process_data
+        arguments:
+          items:
+          - 1
+          - 2
+          - 3
+          config:
+            nested: true
+      normal_text: ''
+  PARSER.batch.8:
+    description: Interleaved normal text
+    model_text: 'I will check the weather. <tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}]</tool_calls>
+      Done.'
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: I will check the weather.
+  PARSER.batch.9:
+    description: Empty input
+    model_text: ''
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''
+  PARSER.batch.10:
+    description: Duplicate calls (same name twice)
+    model_text: '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_weather", "arguments":
+      {"location": "LA"}}]</tool_calls>'
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.batch.yaml
@@ -1,0 +1,126 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: llama3_json
+mode: batch
+cases:
+  PARSER.batch.1:
+    description: Single tool call (happy path)
+    model_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}}'
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+  PARSER.batch.2:
+    description: Multiple tool calls (parallel)
+    model_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}};{"name": "get_time", "arguments":
+      {"timezone": "EST"}}'
+    tools:
+    - *id001
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      calls: []
+      normal_text: ''
+  PARSER.batch.3:
+    description: No tool call (plain text)
+    model_text: Hello, how can I help you today?
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: Hello, how can I help you today?
+  PARSER.batch.4:
+    description: Malformed JSON args (missing close brace)
+    model_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"'
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''
+  PARSER.batch.5:
+    description: No explicit end (truncation)
+    model_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}'
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''
+  PARSER.batch.6:
+    description: Empty args (no-arg call)
+    model_text: '<|python_tag|>{"name": "get_time", "arguments": {}}'
+    tools:
+    - name: get_time
+      parameters:
+        type: object
+        properties: {}
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.7:
+    description: Complex args (nested object + array)
+    model_text: '<|python_tag|>{"name": "process_data", "arguments": {"items": [1, 2, 3], "config": {"nested": true}}}'
+    tools:
+    - name: process_data
+      parameters:
+        type: object
+        properties:
+          items:
+            type: array
+          config:
+            type: object
+    expected:
+      calls:
+      - name: process_data
+        arguments:
+          items:
+          - 1
+          - 2
+          - 3
+          config:
+            nested: true
+      normal_text: ''
+  PARSER.batch.8:
+    description: Interleaved normal text (text after wrapper)
+    model_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}} Done.'
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+  PARSER.batch.9:
+    description: Empty input
+    model_text: ''
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''
+  PARSER.batch.10:
+    description: Duplicate calls (same name twice)
+    model_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}};{"name": "get_weather", "arguments":
+      {"location": "LA"}}'
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''

--- a/tests/parity/parser/fixtures/mistral/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/mistral/PARSER.batch.yaml
@@ -1,0 +1,142 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: mistral
+mode: batch
+cases:
+  PARSER.batch.1:
+    description: Single tool call (happy path)
+    model_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}][/TOOL_CALLS]'
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+  PARSER.batch.2:
+    description: Multiple tool calls (parallel)
+    model_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_time", "arguments":
+      {"timezone": "EST"}}][/TOOL_CALLS]'
+    tools:
+    - *id001
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
+  PARSER.batch.3:
+    description: No tool call (plain text)
+    model_text: Hello, how can I help you today?
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: Hello, how can I help you today?
+  PARSER.batch.4:
+    description: Malformed JSON args (missing close brace)
+    model_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"][/TOOL_CALLS]'
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"][/TOOL_CALLS]'
+  PARSER.batch.5:
+    description: Missing [/TOOL_CALLS] end marker
+    model_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}]'
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+  PARSER.batch.6:
+    description: Empty args (no-arg call)
+    model_text: '[TOOL_CALLS][{"name": "get_time", "arguments": {}}][/TOOL_CALLS]'
+    tools:
+    - name: get_time
+      parameters:
+        type: object
+        properties: {}
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.7:
+    description: Complex args (nested object + array)
+    model_text: '[TOOL_CALLS][{"name": "process_data", "arguments": {"items": [1, 2, 3], "config": {"nested": true}}}][/TOOL_CALLS]'
+    tools:
+    - name: process_data
+      parameters:
+        type: object
+        properties:
+          items:
+            type: array
+          config:
+            type: object
+    expected:
+      calls:
+      - name: process_data
+        arguments:
+          items:
+          - 1
+          - 2
+          - 3
+          config:
+            nested: true
+      normal_text: ''
+  PARSER.batch.8:
+    description: Interleaved normal text
+    model_text: 'I will check the weather. [TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}][/TOOL_CALLS]
+      Done.'
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: I will check the weather.
+  PARSER.batch.9:
+    description: Empty input
+    model_text: ''
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''
+  PARSER.batch.10:
+    description: Duplicate calls (same name twice)
+    model_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_weather", "arguments":
+      {"location": "LA"}}][/TOOL_CALLS]'
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''

--- a/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.yaml
@@ -1,0 +1,206 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: nemotron_nano
+mode: batch
+cases:
+  PARSER.batch.1:
+    description: Single tool call (happy path)
+    model_text: |-
+      <tool_call>
+      <function=get_weather>
+      <parameter=location>
+      NYC
+      </parameter>
+      </function>
+      </tool_call>
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+  PARSER.batch.2:
+    description: Multiple tool calls (parallel)
+    model_text: |-
+      <tool_call>
+      <function=get_weather>
+      <parameter=location>
+      NYC
+      </parameter>
+      </function>
+      </tool_call>
+      <tool_call>
+      <function=get_time>
+      <parameter=timezone>
+      EST
+      </parameter>
+      </function>
+      </tool_call>
+    tools:
+    - *id001
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
+  PARSER.batch.3:
+    description: No tool call (plain text)
+    model_text: Hello, how can I help you today?
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: Hello, how can I help you today?
+  PARSER.batch.4:
+    description: Malformed (missing </parameter> closing tag)
+    model_text: |-
+      <tool_call>
+      <function=get_weather>
+      <parameter=location>
+      NYC
+      </function>
+      </tool_call>
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+  PARSER.batch.5:
+    description: Missing </tool_call> end marker
+    model_text: |-
+      <tool_call>
+      <function=get_weather>
+      <parameter=location>
+      NYC
+      </parameter>
+      </function>
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+  PARSER.batch.6:
+    description: Empty args (no-arg call)
+    model_text: |-
+      <tool_call>
+      <function=get_time>
+      </function>
+      </tool_call>
+    tools:
+    - name: get_time
+      parameters:
+        type: object
+        properties: {}
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.7:
+    description: Complex args (multi-parameter)
+    model_text: |-
+      <tool_call>
+      <function=get_weather>
+      <parameter=location>
+      NYC
+      </parameter>
+      <parameter=unit>
+      fahrenheit
+      </parameter>
+      </function>
+      </tool_call>
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+          unit:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+          unit: fahrenheit
+      normal_text: ''
+  PARSER.batch.8:
+    description: Interleaved normal text
+    model_text: |-
+      I'll help you check the weather. <tool_call>
+      <function=get_weather>
+      <parameter=location>
+      NYC
+      </parameter>
+      </function>
+      </tool_call> Let me get that information for you.
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: I'll help you check the weather.  Let me get that information for you.
+  PARSER.batch.9:
+    description: Empty input
+    model_text: ''
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''
+  PARSER.batch.10:
+    description: Duplicate calls (same name twice)
+    model_text: |-
+      <tool_call>
+      <function=get_weather>
+      <parameter=location>
+      NYC
+      </parameter>
+      </function>
+      </tool_call>
+      <tool_call>
+      <function=get_weather>
+      <parameter=location>
+      LA
+      </parameter>
+      </function>
+      </tool_call>
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''

--- a/tests/parity/parser/fixtures/phi4/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/phi4/PARSER.batch.yaml
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: phi4
+mode: batch
+cases:
+  PARSER.batch.1:
+    description: Single tool call (happy path)
+    model_text: 'functools[{"name": "get_weather", "arguments": {"location": "NYC"}}]'
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+  PARSER.batch.2:
+    description: Multiple tool calls (parallel)
+    model_text: 'functools[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_time", "arguments": {"timezone":
+      "EST"}}]'
+    tools:
+    - *id001
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
+  PARSER.batch.3:
+    description: No tool call (plain text)
+    model_text: Hello, how can I help you today?
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: Hello, how can I help you today?
+  PARSER.batch.4:
+    description: Malformed JSON args (missing close brace)
+    model_text: 'functools[{"name": "get_weather", "arguments": {"location": "NYC"]'
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''
+  PARSER.batch.5:
+    description: No explicit end (truncation)
+    model_text: 'functools[{"name": "get_weather", "arguments": {"location": "NYC"}}'
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''
+  PARSER.batch.6:
+    description: Empty args (no-arg call)
+    model_text: 'functools[{"name": "get_time", "arguments": {}}]'
+    tools:
+    - name: get_time
+      parameters:
+        type: object
+        properties: {}
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.7:
+    description: Complex args (nested object + array)
+    model_text: 'functools[{"name": "process_data", "arguments": {"items": [1, 2, 3], "config": {"nested": true}}}]'
+    tools:
+    - name: process_data
+      parameters:
+        type: object
+        properties:
+          items:
+            type: array
+          config:
+            type: object
+    expected:
+      calls:
+      - name: process_data
+        arguments:
+          config:
+            nested: true
+          items:
+          - 1
+          - 2
+          - 3
+      normal_text: ''
+  PARSER.batch.8:
+    description: Interleaved normal text
+    model_text: 'I will check the weather. functools[{"name": "get_weather", "arguments": {"location": "NYC"}}] Done.'
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: I will check the weather.
+  PARSER.batch.9:
+    description: Empty input
+    model_text: ''
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''
+  PARSER.batch.10:
+    description: Duplicate calls (same name twice)
+    model_text: 'functools[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_weather", "arguments":
+      {"location": "LA"}}]'
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''

--- a/tests/parity/parser/fixtures/qwen25/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/qwen25/PARSER.batch.yaml
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: qwen25
+mode: batch
+cases:
+  PARSER.batch.1:
+    description: Single tool call (happy path)
+    model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>'
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+  PARSER.batch.2:
+    description: Multiple tool calls (parallel)
+    model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name": "get_time",
+      "arguments": {"timezone": "EST"}}</tool_call>'
+    tools:
+    - *id001
+    - name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
+  PARSER.batch.3:
+    description: No tool call (plain text)
+    model_text: Hello, how can I help you today?
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: Hello, how can I help you today?
+  PARSER.batch.4:
+    description: Malformed JSON args (missing close brace)
+    model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"</tool_call>'
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+  PARSER.batch.5:
+    description: Missing </tool_call> end marker
+    model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}'
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+  PARSER.batch.6:
+    description: Empty args (no-arg call)
+    model_text: '<tool_call>{"name": "get_time", "arguments": {}}</tool_call>'
+    tools:
+    - name: get_time
+      parameters:
+        type: object
+        properties: {}
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.7:
+    description: Complex args (nested object + array)
+    model_text: '<tool_call>{"name": "process_data", "arguments": {"items": [1, 2, 3], "config": {"nested": true}}}</tool_call>'
+    tools:
+    - name: process_data
+      parameters:
+        type: object
+        properties:
+          items:
+            type: array
+          config:
+            type: object
+    expected:
+      calls:
+      - name: process_data
+        arguments:
+          items:
+          - 1
+          - 2
+          - 3
+          config:
+            nested: true
+      normal_text: ''
+  PARSER.batch.8:
+    description: Interleaved normal text
+    model_text: 'I will check the weather. <tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>
+      Done.'
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: I will check the weather.
+  PARSER.batch.9:
+    description: Empty input
+    model_text: ''
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''
+  PARSER.batch.10:
+    description: Duplicate calls (same name twice)
+    model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name": "get_weather",
+      "arguments": {"location": "LA"}}</tool_call>'
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''

--- a/tests/parity/parser/regenerate_fixtures.py
+++ b/tests/parity/parser/regenerate_fixtures.py
@@ -603,6 +603,473 @@ INPUTS: dict[tuple[str, str], dict[str, Any] | None] = {
         "text": '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather\n```json\n{"location": "NYC"}\n```<｜tool▁call▁end｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather\n```json\n{"location": "LA"}\n```<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
         "tools": [_GET_WEATHER_LOC],
     },
+    # ----- deepseek_v4 (DSML) -----
+    # Format: <｜DSML｜tool_calls>
+    #          <｜DSML｜invoke name="NAME">
+    #          <｜DSML｜parameter name="K" string="true|false">V</｜DSML｜parameter>
+    #          ...
+    #          </｜DSML｜invoke>
+    #          </｜DSML｜tool_calls>
+    # `string="true"` means the parameter value is a literal string;
+    # `string="false"` means the value is a JSON literal (bool/int/array/etc).
+    ("deepseek_v4", "PARSER.batch.1"): {
+        "description": "Single tool call (happy path)",
+        "text": '<｜DSML｜tool_calls>\n<｜DSML｜invoke name="get_weather">\n<｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("deepseek_v4", "PARSER.batch.2"): {
+        "description": "Multiple tool calls (parallel)",
+        "text": '<｜DSML｜tool_calls>\n<｜DSML｜invoke name="get_weather">\n<｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>\n</｜DSML｜invoke>\n<｜DSML｜invoke name="get_time">\n<｜DSML｜parameter name="timezone" string="true">EST</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>',
+        "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("deepseek_v4", "PARSER.batch.3"): {
+        "description": "No tool call (plain text)",
+        "text": "Hello, how can I help you today?",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("deepseek_v4", "PARSER.batch.4"): {
+        "description": "Malformed (missing </｜DSML｜parameter> end tag)",
+        "text": '<｜DSML｜tool_calls>\n<｜DSML｜invoke name="get_weather">\n<｜DSML｜parameter name="location" string="true">NYC\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("deepseek_v4", "PARSER.batch.5"): {
+        "description": "Missing </｜DSML｜tool_calls> end marker",
+        "text": '<｜DSML｜tool_calls>\n<｜DSML｜invoke name="get_weather">\n<｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>\n</｜DSML｜invoke>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("deepseek_v4", "PARSER.batch.6"): {
+        "description": "Empty args (no-arg call)",
+        "text": '<｜DSML｜tool_calls>\n<｜DSML｜invoke name="get_time">\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>',
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("deepseek_v4", "PARSER.batch.7"): {
+        "description": "Complex args (nested object + array, JSON-typed)",
+        "text": '<｜DSML｜tool_calls>\n<｜DSML｜invoke name="process_data">\n<｜DSML｜parameter name="items" string="false">[1, 2, 3]</｜DSML｜parameter>\n<｜DSML｜parameter name="config" string="false">{"nested": true}</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>',
+        "tools": [_PROCESS_DATA_NESTED],
+    },
+    ("deepseek_v4", "PARSER.batch.8"): {
+        "description": "Interleaved normal text",
+        "text": 'I will check the weather. <｜DSML｜tool_calls>\n<｜DSML｜invoke name="get_weather">\n<｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("deepseek_v4", "PARSER.batch.9"): {
+        "description": "Empty input",
+        "text": "",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("deepseek_v4", "PARSER.batch.10"): {
+        "description": "Duplicate calls (same name twice)",
+        "text": '<｜DSML｜tool_calls>\n<｜DSML｜invoke name="get_weather">\n<｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>\n</｜DSML｜invoke>\n<｜DSML｜invoke name="get_weather">\n<｜DSML｜parameter name="location" string="true">LA</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    # ----- hermes -----
+    ("hermes", "PARSER.batch.1"): {
+        "description": "Single tool call (happy path)",
+        "text": '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("hermes", "PARSER.batch.2"): {
+        "description": "Multiple tool calls (parallel)",
+        "text": '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name": "get_time", "arguments": {"timezone": "EST"}}</tool_call>',
+        "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("hermes", "PARSER.batch.3"): {
+        "description": "No tool call (plain text)",
+        "text": "Hello, how can I help you today?",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("hermes", "PARSER.batch.4"): {
+        "description": "Malformed JSON args (missing close brace)",
+        "text": '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"</tool_call>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("hermes", "PARSER.batch.5"): {
+        "description": "Missing </tool_call> end marker",
+        "text": '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("hermes", "PARSER.batch.6"): {
+        "description": "Empty args (no-arg call)",
+        "text": '<tool_call>{"name": "get_time", "arguments": {}}</tool_call>',
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("hermes", "PARSER.batch.7"): {
+        "description": "Complex args (nested object + array)",
+        "text": '<tool_call>{"name": "process_data", "arguments": {"items": [1, 2, 3], "config": {"nested": true}}}</tool_call>',
+        "tools": [_PROCESS_DATA_NESTED],
+    },
+    ("hermes", "PARSER.batch.8"): {
+        "description": "Interleaved normal text",
+        "text": 'I will check the weather. <tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call> Done.',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("hermes", "PARSER.batch.9"): {
+        "description": "Empty input",
+        "text": "",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("hermes", "PARSER.batch.10"): {
+        "description": "Duplicate calls (same name twice)",
+        "text": '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name": "get_weather", "arguments": {"location": "LA"}}</tool_call>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    # ----- qwen25 -----
+    ("qwen25", "PARSER.batch.1"): {
+        "description": "Single tool call (happy path)",
+        "text": '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("qwen25", "PARSER.batch.2"): {
+        "description": "Multiple tool calls (parallel)",
+        "text": '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name": "get_time", "arguments": {"timezone": "EST"}}</tool_call>',
+        "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("qwen25", "PARSER.batch.3"): {
+        "description": "No tool call (plain text)",
+        "text": "Hello, how can I help you today?",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("qwen25", "PARSER.batch.4"): {
+        "description": "Malformed JSON args (missing close brace)",
+        "text": '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"</tool_call>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("qwen25", "PARSER.batch.5"): {
+        "description": "Missing </tool_call> end marker",
+        "text": '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("qwen25", "PARSER.batch.6"): {
+        "description": "Empty args (no-arg call)",
+        "text": '<tool_call>{"name": "get_time", "arguments": {}}</tool_call>',
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("qwen25", "PARSER.batch.7"): {
+        "description": "Complex args (nested object + array)",
+        "text": '<tool_call>{"name": "process_data", "arguments": {"items": [1, 2, 3], "config": {"nested": true}}}</tool_call>',
+        "tools": [_PROCESS_DATA_NESTED],
+    },
+    ("qwen25", "PARSER.batch.8"): {
+        "description": "Interleaved normal text",
+        "text": 'I will check the weather. <tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call> Done.',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("qwen25", "PARSER.batch.9"): {
+        "description": "Empty input",
+        "text": "",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("qwen25", "PARSER.batch.10"): {
+        "description": "Duplicate calls (same name twice)",
+        "text": '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name": "get_weather", "arguments": {"location": "LA"}}</tool_call>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    # ----- mistral -----
+    ("mistral", "PARSER.batch.1"): {
+        "description": "Single tool call (happy path)",
+        "text": '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}][/TOOL_CALLS]',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("mistral", "PARSER.batch.2"): {
+        "description": "Multiple tool calls (parallel)",
+        "text": '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_time", "arguments": {"timezone": "EST"}}][/TOOL_CALLS]',
+        "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("mistral", "PARSER.batch.3"): {
+        "description": "No tool call (plain text)",
+        "text": "Hello, how can I help you today?",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("mistral", "PARSER.batch.4"): {
+        "description": "Malformed JSON args (missing close brace)",
+        "text": '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"][/TOOL_CALLS]',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("mistral", "PARSER.batch.5"): {
+        "description": "Missing [/TOOL_CALLS] end marker",
+        "text": '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}]',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("mistral", "PARSER.batch.6"): {
+        "description": "Empty args (no-arg call)",
+        "text": '[TOOL_CALLS][{"name": "get_time", "arguments": {}}][/TOOL_CALLS]',
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("mistral", "PARSER.batch.7"): {
+        "description": "Complex args (nested object + array)",
+        "text": '[TOOL_CALLS][{"name": "process_data", "arguments": {"items": [1, 2, 3], "config": {"nested": true}}}][/TOOL_CALLS]',
+        "tools": [_PROCESS_DATA_NESTED],
+    },
+    ("mistral", "PARSER.batch.8"): {
+        "description": "Interleaved normal text",
+        "text": 'I will check the weather. [TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}][/TOOL_CALLS] Done.',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("mistral", "PARSER.batch.9"): {
+        "description": "Empty input",
+        "text": "",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("mistral", "PARSER.batch.10"): {
+        "description": "Duplicate calls (same name twice)",
+        "text": '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_weather", "arguments": {"location": "LA"}}][/TOOL_CALLS]',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    # ----- jamba -----
+    ("jamba", "PARSER.batch.1"): {
+        "description": "Single tool call (happy path)",
+        "text": '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}]</tool_calls>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("jamba", "PARSER.batch.2"): {
+        "description": "Multiple tool calls (parallel)",
+        "text": '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_time", "arguments": {"timezone": "EST"}}]</tool_calls>',
+        "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("jamba", "PARSER.batch.3"): {
+        "description": "No tool call (plain text)",
+        "text": "Hello, how can I help you today?",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("jamba", "PARSER.batch.4"): {
+        "description": "Malformed JSON args (missing close brace)",
+        "text": '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"]</tool_calls>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("jamba", "PARSER.batch.5"): {
+        "description": "Missing </tool_calls> end marker",
+        "text": '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}]',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("jamba", "PARSER.batch.6"): {
+        "description": "Empty args (no-arg call)",
+        "text": '<tool_calls>[{"name": "get_time", "arguments": {}}]</tool_calls>',
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("jamba", "PARSER.batch.7"): {
+        "description": "Complex args (nested object + array)",
+        "text": '<tool_calls>[{"name": "process_data", "arguments": {"items": [1, 2, 3], "config": {"nested": true}}}]</tool_calls>',
+        "tools": [_PROCESS_DATA_NESTED],
+    },
+    ("jamba", "PARSER.batch.8"): {
+        "description": "Interleaved normal text",
+        "text": 'I will check the weather. <tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}]</tool_calls> Done.',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("jamba", "PARSER.batch.9"): {
+        "description": "Empty input",
+        "text": "",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("jamba", "PARSER.batch.10"): {
+        "description": "Duplicate calls (same name twice)",
+        "text": '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_weather", "arguments": {"location": "LA"}}]</tool_calls>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    # ----- llama3_json -----
+    ("llama3_json", "PARSER.batch.1"): {
+        "description": "Single tool call (happy path)",
+        "text": '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}}',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("llama3_json", "PARSER.batch.2"): {
+        "description": "Multiple tool calls (parallel)",
+        "text": '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}};{"name": "get_time", "arguments": {"timezone": "EST"}}',
+        "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("llama3_json", "PARSER.batch.3"): {
+        "description": "No tool call (plain text)",
+        "text": "Hello, how can I help you today?",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("llama3_json", "PARSER.batch.4"): {
+        "description": "Malformed JSON args (missing close brace)",
+        "text": '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("llama3_json", "PARSER.batch.5"): {
+        "description": "No explicit end (truncation)",
+        "text": '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("llama3_json", "PARSER.batch.6"): {
+        "description": "Empty args (no-arg call)",
+        "text": '<|python_tag|>{"name": "get_time", "arguments": {}}',
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("llama3_json", "PARSER.batch.7"): {
+        "description": "Complex args (nested object + array)",
+        "text": '<|python_tag|>{"name": "process_data", "arguments": {"items": [1, 2, 3], "config": {"nested": true}}}',
+        "tools": [_PROCESS_DATA_NESTED],
+    },
+    ("llama3_json", "PARSER.batch.8"): {
+        "description": "Interleaved normal text (text after wrapper)",
+        "text": '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}} Done.',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("llama3_json", "PARSER.batch.9"): {
+        "description": "Empty input",
+        "text": "",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("llama3_json", "PARSER.batch.10"): {
+        "description": "Duplicate calls (same name twice)",
+        "text": '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}};{"name": "get_weather", "arguments": {"location": "LA"}}',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    # ----- phi4 -----
+    ("phi4", "PARSER.batch.1"): {
+        "description": "Single tool call (happy path)",
+        "text": 'functools[{"name": "get_weather", "arguments": {"location": "NYC"}}]',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("phi4", "PARSER.batch.2"): {
+        "description": "Multiple tool calls (parallel)",
+        "text": 'functools[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_time", "arguments": {"timezone": "EST"}}]',
+        "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("phi4", "PARSER.batch.3"): {
+        "description": "No tool call (plain text)",
+        "text": "Hello, how can I help you today?",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("phi4", "PARSER.batch.4"): {
+        "description": "Malformed JSON args (missing close brace)",
+        "text": 'functools[{"name": "get_weather", "arguments": {"location": "NYC"]',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("phi4", "PARSER.batch.5"): {
+        "description": "No explicit end (truncation)",
+        "text": 'functools[{"name": "get_weather", "arguments": {"location": "NYC"}}',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("phi4", "PARSER.batch.6"): {
+        "description": "Empty args (no-arg call)",
+        "text": 'functools[{"name": "get_time", "arguments": {}}]',
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("phi4", "PARSER.batch.7"): {
+        "description": "Complex args (nested object + array)",
+        "text": 'functools[{"name": "process_data", "arguments": {"items": [1, 2, 3], "config": {"nested": true}}}]',
+        "tools": [_PROCESS_DATA_NESTED],
+    },
+    ("phi4", "PARSER.batch.8"): {
+        "description": "Interleaved normal text",
+        "text": 'I will check the weather. functools[{"name": "get_weather", "arguments": {"location": "NYC"}}] Done.',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("phi4", "PARSER.batch.9"): {
+        "description": "Empty input",
+        "text": "",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("phi4", "PARSER.batch.10"): {
+        "description": "Duplicate calls (same name twice)",
+        "text": 'functools[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_weather", "arguments": {"location": "LA"}}]',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    # ----- nemotron_nano -----
+    ("nemotron_nano", "PARSER.batch.1"): {
+        "description": "Single tool call (happy path)",
+        "text": "<tool_call>\n<function=get_weather>\n<parameter=location>\nNYC\n</parameter>\n</function>\n</tool_call>",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("nemotron_nano", "PARSER.batch.2"): {
+        "description": "Multiple tool calls (parallel)",
+        "text": "<tool_call>\n<function=get_weather>\n<parameter=location>\nNYC\n</parameter>\n</function>\n</tool_call>\n<tool_call>\n<function=get_time>\n<parameter=timezone>\nEST\n</parameter>\n</function>\n</tool_call>",
+        "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("nemotron_nano", "PARSER.batch.3"): {
+        "description": "No tool call (plain text)",
+        "text": "Hello, how can I help you today?",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("nemotron_nano", "PARSER.batch.4"): {
+        "description": "Malformed (missing </parameter> closing tag)",
+        "text": "<tool_call>\n<function=get_weather>\n<parameter=location>\nNYC\n</function>\n</tool_call>",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("nemotron_nano", "PARSER.batch.5"): {
+        "description": "Missing </tool_call> end marker",
+        "text": "<tool_call>\n<function=get_weather>\n<parameter=location>\nNYC\n</parameter>\n</function>",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("nemotron_nano", "PARSER.batch.6"): {
+        "description": "Empty args (no-arg call)",
+        "text": "<tool_call>\n<function=get_time>\n</function>\n</tool_call>",
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("nemotron_nano", "PARSER.batch.7"): {
+        "description": "Complex args (multi-parameter)",
+        "text": "<tool_call>\n<function=get_weather>\n<parameter=location>\nNYC\n</parameter>\n<parameter=unit>\nfahrenheit\n</parameter>\n</function>\n</tool_call>",
+        "tools": [_GET_WEATHER_LOC_UNIT],
+    },
+    ("nemotron_nano", "PARSER.batch.8"): {
+        "description": "Interleaved normal text",
+        "text": "I'll help you check the weather. <tool_call>\n<function=get_weather>\n<parameter=location>\nNYC\n</parameter>\n</function>\n</tool_call> Let me get that information for you.",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("nemotron_nano", "PARSER.batch.9"): {
+        "description": "Empty input",
+        "text": "",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("nemotron_nano", "PARSER.batch.10"): {
+        "description": "Duplicate calls (same name twice)",
+        "text": "<tool_call>\n<function=get_weather>\n<parameter=location>\nNYC\n</parameter>\n</function>\n</tool_call>\n<tool_call>\n<function=get_weather>\n<parameter=location>\nLA\n</parameter>\n</function>\n</tool_call>",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    # ----- deepseek_v3_2 -----
+    ("deepseek_v3_2", "PARSER.batch.1"): {
+        "description": "Single tool call (happy path)",
+        "text": '<｜DSML｜function_calls>\n<｜DSML｜invoke name="get_weather">\n<｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜function_calls>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("deepseek_v3_2", "PARSER.batch.2"): {
+        "description": "Multiple tool calls (parallel)",
+        "text": '<｜DSML｜function_calls>\n<｜DSML｜invoke name="get_weather">\n<｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>\n</｜DSML｜invoke>\n<｜DSML｜invoke name="get_time">\n<｜DSML｜parameter name="timezone" string="true">EST</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜function_calls>',
+        "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("deepseek_v3_2", "PARSER.batch.3"): {
+        "description": "No tool call (plain text)",
+        "text": "Hello, how can I help you today?",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("deepseek_v3_2", "PARSER.batch.4"): {
+        "description": "Malformed (missing </｜DSML｜parameter> end tag)",
+        "text": '<｜DSML｜function_calls>\n<｜DSML｜invoke name="get_weather">\n<｜DSML｜parameter name="location" string="true">NYC\n</｜DSML｜invoke>\n</｜DSML｜function_calls>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("deepseek_v3_2", "PARSER.batch.5"): {
+        "description": "Missing </｜DSML｜function_calls> end marker",
+        "text": '<｜DSML｜function_calls>\n<｜DSML｜invoke name="get_weather">\n<｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>\n</｜DSML｜invoke>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("deepseek_v3_2", "PARSER.batch.6"): {
+        "description": "Empty args (no-arg call)",
+        "text": '<｜DSML｜function_calls>\n<｜DSML｜invoke name="get_time">\n</｜DSML｜invoke>\n</｜DSML｜function_calls>',
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("deepseek_v3_2", "PARSER.batch.7"): {
+        "description": "Complex args (nested object + array, JSON-typed)",
+        "text": '<｜DSML｜function_calls>\n<｜DSML｜invoke name="process_data">\n<｜DSML｜parameter name="items" string="false">[1, 2, 3]</｜DSML｜parameter>\n<｜DSML｜parameter name="config" string="false">{"nested": true}</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜function_calls>',
+        "tools": [_PROCESS_DATA_NESTED],
+    },
+    ("deepseek_v3_2", "PARSER.batch.8"): {
+        "description": "Interleaved normal text",
+        "text": 'I will check the weather. <｜DSML｜function_calls>\n<｜DSML｜invoke name="get_weather">\n<｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜function_calls>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("deepseek_v3_2", "PARSER.batch.9"): {
+        "description": "Empty input",
+        "text": "",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("deepseek_v3_2", "PARSER.batch.10"): {
+        "description": "Duplicate calls (same name twice)",
+        "text": '<｜DSML｜function_calls>\n<｜DSML｜invoke name="get_weather">\n<｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>\n</｜DSML｜invoke>\n<｜DSML｜invoke name="get_weather">\n<｜DSML｜parameter name="location" string="true">LA</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜function_calls>',
+        "tools": [_GET_WEATHER_LOC],
+    },
 }
 
 

--- a/tests/parity/parser/sglang.py
+++ b/tests/parity/parser/sglang.py
@@ -11,6 +11,9 @@ from typing import Any
 from sglang.srt.function_call.deepseekv3_detector import (
     DeepSeekV3Detector,  # type: ignore[import-untyped]
 )
+from sglang.srt.function_call.deepseekv32_detector import (
+    DeepSeekV32Detector,  # type: ignore[import-untyped]
+)
 
 # SGLang re-exports detectors through `function_call_parser`; we go through
 # that umbrella so the import is stable across per-module renames.
@@ -21,17 +24,26 @@ from sglang.srt.function_call.function_call_parser import (  # type: ignore[impo
 from sglang.srt.function_call.gpt_oss_detector import (
     GptOssDetector,  # type: ignore[import-untyped]
 )
+from sglang.srt.function_call.hermes_detector import (
+    HermesDetector,  # type: ignore[import-untyped]
+)
 from sglang.srt.function_call.kimik2_detector import (
     KimiK2Detector,  # type: ignore[import-untyped]
 )
 from sglang.srt.function_call.minimax_m2 import (
     MinimaxM2Detector,  # type: ignore[import-untyped]
 )
+from sglang.srt.function_call.mistral_detector import (
+    MistralDetector,  # type: ignore[import-untyped]
+)
 from sglang.srt.function_call.pythonic_detector import (
     PythonicDetector,  # type: ignore[import-untyped]
 )
 from sglang.srt.function_call.qwen3_coder_detector import (  # type: ignore[import-untyped]
     Qwen3CoderDetector,
+)
+from sglang.srt.function_call.qwen25_detector import (
+    Qwen25Detector,  # type: ignore[import-untyped]
 )
 
 from tests.parity.common import ParseResult, decode_arguments
@@ -41,15 +53,20 @@ from tests.parity.common import ParseResult, decode_arguments
 _FAMILY_TO_SGLANG_DETECTOR = {
     "kimi_k2": KimiK2Detector,
     "qwen3_coder": Qwen3CoderDetector,
+    "qwen25": Qwen25Detector,
     "glm47": Glm47MoeDetector,
     "deepseek_v3_1": DeepSeekV31Detector,
+    "deepseek_v3_2": DeepSeekV32Detector,
     "deepseek_v3": DeepSeekV3Detector,
     "harmony": GptOssDetector,
     "minimax_m2": MinimaxM2Detector,
     "pythonic": PythonicDetector,
+    "hermes": HermesDetector,
+    "mistral": MistralDetector,
 }
 
-# Families with no SGLang detector today: nemotron_deci, gemma4.
+# Families with no SGLang detector today: nemotron_deci, nemotron_nano,
+# gemma4, deepseek_v4, jamba, llama3_json, phi4.
 
 
 def parse(

--- a/tests/parity/parser/test_parity_parser.py
+++ b/tests/parity/parser/test_parity_parser.py
@@ -147,6 +147,16 @@ KNOWN_DIVERGENCES: dict[tuple[str, str, str], str] = {
     ): "vLLM rejects bracket-call form when surrounded by interleaved text; Dynamo extracts the call",
     (
         "vllm",
+        "deepseek_v4",
+        "PARSER.batch.5",
+    ): _RECOVERY_CONTRACT,
+    (
+        "vllm",
+        "deepseek_v4",
+        "PARSER.batch.7",
+    ): "vLLM emits JSON-typed parameter values as raw strings; Dynamo coerces nested object/array types",
+    (
+        "vllm",
         "minimax_m2",
         "PARSER.batch.8",
     ): "preserves trailing space; Dynamo trims it",
@@ -173,6 +183,102 @@ KNOWN_DIVERGENCES: dict[tuple[str, str, str], str] = {
     ("sglang", "minimax_m2", "PARSER.batch.5"): _RECOVERY_CONTRACT,
     ("sglang", "deepseek_v3_1", "PARSER.batch.5"): _RECOVERY_CONTRACT,
     ("sglang", "harmony", "PARSER.batch.5"): _RECOVERY_CONTRACT,
+    # ----- new families: hermes / qwen25 / mistral / jamba / llama3_json / phi4 / nemotron_nano / deepseek_v3_2 -----
+    ("vllm", "deepseek_v3_2", "PARSER.batch.5"): _RECOVERY_CONTRACT,
+    (
+        "vllm",
+        "deepseek_v3_2",
+        "PARSER.batch.7",
+    ): "emits JSON-typed parameter values as raw strings; Dynamo coerces nested object/array types",
+    ("vllm", "hermes", "PARSER.batch.4"): _RECOVERY_CONTRACT,
+    ("vllm", "hermes", "PARSER.batch.8"): _TRAILING_NORMAL_TEXT_DROP,
+    ("vllm", "jamba", "PARSER.batch.5"): _RECOVERY_CONTRACT,
+    ("vllm", "jamba", "PARSER.batch.8"): _TRAILING_NORMAL_TEXT_DROP,
+    (
+        "vllm",
+        "llama3_json",
+        "PARSER.batch.2",
+    ): "vLLM llama3_json does not parse semicolon-separated calls the same way Dynamo does",
+    ("vllm", "llama3_json", "PARSER.batch.4"): _RECOVERY_CONTRACT,
+    ("vllm", "llama3_json", "PARSER.batch.5"): _RECOVERY_CONTRACT,
+    (
+        "vllm",
+        "llama3_json",
+        "PARSER.batch.10",
+    ): "vLLM llama3_json does not parse semicolon-separated calls the same way Dynamo does",
+    ("vllm", "mistral", "PARSER.batch.4"): _RECOVERY_CONTRACT,
+    ("vllm", "mistral", "PARSER.batch.8"): _TRAILING_NORMAL_TEXT_DROP,
+    ("vllm", "phi4", "PARSER.batch.5"): _RECOVERY_CONTRACT,
+    (
+        "vllm",
+        "phi4",
+        "PARSER.batch.7",
+    ): "emits JSON-typed parameter values as raw strings; Dynamo coerces nested object/array types",
+    ("vllm", "phi4", "PARSER.batch.8"): _TRAILING_NORMAL_TEXT_DROP,
+    ("sglang", "deepseek_v3_2", "PARSER.batch.8"): _TRAILING_NORMAL_TEXT_DROP,
+    ("sglang", "hermes", "PARSER.batch.4"): _RECOVERY_CONTRACT,
+    # SGLang's MistralDetector and Qwen25Detector both return empty `calls`
+    # on the bare wire formats Dynamo emits — format-detection failure rather
+    # than a recovery-contract divergence. The exact reason (different start
+    # token, schema-shape mismatch, missing chat-format envelope) is not
+    # investigated here; the cells are recorded as `X` so the matrix reflects
+    # the observed behavior.
+    (
+        "sglang",
+        "mistral",
+        "PARSER.batch.1",
+    ): "SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits",
+    (
+        "sglang",
+        "mistral",
+        "PARSER.batch.2",
+    ): "SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits",
+    ("sglang", "mistral", "PARSER.batch.4"): _RECOVERY_CONTRACT,
+    ("sglang", "mistral", "PARSER.batch.5"): _RECOVERY_CONTRACT,
+    (
+        "sglang",
+        "mistral",
+        "PARSER.batch.6",
+    ): "SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits",
+    (
+        "sglang",
+        "mistral",
+        "PARSER.batch.7",
+    ): "SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits",
+    ("sglang", "mistral", "PARSER.batch.8"): _TRAILING_NORMAL_TEXT_DROP,
+    (
+        "sglang",
+        "mistral",
+        "PARSER.batch.10",
+    ): "SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits",
+    (
+        "sglang",
+        "qwen25",
+        "PARSER.batch.1",
+    ): "SGLang Qwen25Detector returns calls=[] on the hermes-style <tool_call>...</tool_call> format Dynamo emits",
+    (
+        "sglang",
+        "qwen25",
+        "PARSER.batch.2",
+    ): "SGLang Qwen25Detector returns calls=[] on the hermes-style <tool_call>...</tool_call> format Dynamo emits",
+    ("sglang", "qwen25", "PARSER.batch.4"): _RECOVERY_CONTRACT,
+    ("sglang", "qwen25", "PARSER.batch.5"): _RECOVERY_CONTRACT,
+    (
+        "sglang",
+        "qwen25",
+        "PARSER.batch.6",
+    ): "SGLang Qwen25Detector returns calls=[] on the hermes-style <tool_call>...</tool_call> format Dynamo emits",
+    (
+        "sglang",
+        "qwen25",
+        "PARSER.batch.7",
+    ): "SGLang Qwen25Detector returns calls=[] on the hermes-style <tool_call>...</tool_call> format Dynamo emits",
+    ("sglang", "qwen25", "PARSER.batch.8"): _TRAILING_NORMAL_TEXT_DROP,
+    (
+        "sglang",
+        "qwen25",
+        "PARSER.batch.10",
+    ): "SGLang Qwen25Detector returns calls=[] on the hermes-style <tool_call>...</tool_call> format Dynamo emits",
 }
 
 

--- a/tests/parity/parser/vllm.py
+++ b/tests/parity/parser/vllm.py
@@ -65,6 +65,13 @@ _FAMILY_TO_VLLM_KEY = {
     "glm47": "glm47",
     "deepseek_v3_1": "deepseek_v31",
     "deepseek_v3": "deepseek_v3",
+    "deepseek_v3_2": "deepseek_v32",
+    "deepseek_v4": "deepseek_v4",
+    "hermes": "hermes",
+    "mistral": "mistral",
+    "jamba": "jamba",
+    "llama3_json": "llama3_json",
+    "phi4": "phi4_mini_json",
     "harmony": "openai",  # gpt-oss / harmony parser registered as "openai"
     "pythonic": "pythonic",
     "gemma4": "gemma4",


### PR DESCRIPTION
#### Overview:

[#9186](https://github.com/ai-dynamo/dynamo/pull/9186) shipped the M2 cross-impl parity harness with 7 parser families; this PR adds the 12 remaining families Dynamo registers that have at least one upstream peer, bringing the matrix to full registry coverage.

#### Details:

- **How is this fixed?** New fixtures for `pythonic`, `gemma4`, `deepseek_v3` (legacy), `deepseek_v4`, `deepseek_v3_2`, `hermes`, `qwen25`, `mistral`, `jamba`, `llama3_json`, `phi4`, and `nemotron_nano`; matching vLLM keys and SGLang detectors wired through `tests/parity/parser/{vllm,sglang}.py`; fixtures regenerated via the live Dynamo binding; cross-impl divergences recorded as `KNOWN_DIVERGENCES` xfails.
- Divergence categories surfaced: impl-defined recovery contracts on `PARSER.batch.4`/`.5` (malformed args / missing end-token), trailing-text drops on `PARSER.batch.8` (XML-style families), and format-detection failures on `sglang/mistral/*` and `sglang/qwen25/*` (root cause not investigated here; cells recorded as `X` so the matrix reflects observed behavior).
- No parser-side code change — `lib/parsers/` untouched. Doc + harness wiring only.

#### Coverage matrix (as in `tests/parity/README.md`)

Cell legend: `✓` = both vLLM and SGLang match Dynamo; `V` = vLLM diverges (xfailed); `S` = SGLang diverges; `VS` = both diverge; `n/a` = no peer parser. Column legend: `bN` = `PARSER.batch.N` (1 happy-path, 2 multiple, 3 no-tool, 4 malformed, 5 missing-end-token, 6 empty-args, 7 complex-args, 8 interleaved-text, 9 empty, 10 duplicate).

| family                          |  b1 |  b2 |  b3 |  b4 |  b5 |  b6 |  b7 |  b8 |  b9 | b10 |
|---------------------------------|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
| **Top-N models**                |     |     |     |     |     |     |     |     |     |     |
| deepseek_v4 § (DeepSeek V4)     | ✓   | ✓   | ✓   | ✓   | V   | ✓   | V   | ✓   | ✓   | ✓   |
| gemma4 § (Gemma 4)              | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | V   | ✓   | ✓   |
| glm47 (GLM 5.1)                 | ✓   | ✓   | ✓   | ✓   | VS  | ✓   | ✓   | V   | ✓   | ✓   |
| harmony † (gpt-oss)             | S   | S   | ✓   | S   | S   | S   | S   | S   | ✓   | S   |
| kimi_k2 (Kimi K2.6)             | ✓   | ✓   | ✓   | S   | ✓   | ✓   | ✓   | VS  | ✓   | ✓   |
| minimax_m2 (MiniMax 2.7)        | ✓   | ✓   | ✓   | V   | VS  | ✓   | ✓   | VS  | ✓   | ✓   |
| nemotron_deci †§ (Nemotron)     | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a |
| qwen3_coder (Qwen 3.5)          | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | VS  | ✓   | ✓   |
| **Others**                      |     |     |     |     |     |     |     |     |     |     |
| deepseek_v3                     | ✓   | ✓   | ✓   | V   | VS  | ✓   | ✓   | S   | ✓   | ✓   |
| deepseek_v3_1                   | ✓   | ✓   | ✓   | V   | VS  | ✓   | ✓   | S   | ✓   | ✓   |
| deepseek_v3_2                   | ✓   | ✓   | ✓   | ✓   | V   | ✓   | V   | S   | ✓   | ✓   |
| hermes                          | ✓   | ✓   | ✓   | VS  | ✓   | ✓   | ✓   | V   | ✓   | ✓   |
| jamba §                         | ✓   | ✓   | ✓   | ✓   | V   | ✓   | ✓   | V   | ✓   | ✓   |
| llama3_json §                   | ✓   | V   | ✓   | V   | V   | ✓   | ✓   | ✓   | ✓   | V   |
| mistral                         | S   | S   | ✓   | VS  | S   | S   | S   | VS  | ✓   | S   |
| nemotron_nano †§                | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a |
| phi4 §                          | ✓   | ✓   | ✓   | ✓   | V   | ✓   | V   | V   | ✓   | ✓   |
| pythonic                        | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | VS  | ✓   | ✓   |
| qwen25 †                        | S   | S   | ✓   | S   | S   | S   | S   | S   | ✓   | S   |

`†` = no vLLM peer (or vLLM returns `UNAVAILABLE` at runtime — harmony needs token IDs); `§` = no SGLang peer.

#### Verification:

Smoke against pinned containers — vllm 120/30/40, sglang 83/37/70, dynamo 190/190 (passed/xfailed/skipped); skips are families without a peer on that side.

#### Where should the reviewer start?

`tests/parity/README.md` (matrix), then `tests/parity/parser/test_parity_parser.py` (`KNOWN_DIVERGENCES` block).

#### Related Issues:

Relates to [DIS-1906](https://linear.app/nvidia/issue/DIS-1906)

/coderabbit profile chill
