### PR TITLE
feat(api): implement structural DGDR conversion

### DIFF
--- a/deploy/operator/api/CONVERSION.md
+++ b/deploy/operator/api/CONVERSION.md
@@ -6,18 +6,44 @@ explicitly document why conversion is unaffected.
 
 ## Structure
 
-Top-level `ConvertTo` / `ConvertFrom` methods:
+Top-level API objects implement `sigs.k8s.io/controller-runtime/pkg/conversion.Convertible`:
+
+```go
+type Convertible interface {
+	runtime.Object
+	ConvertTo(dst Hub) error
+	ConvertFrom(src Hub) error
+}
+```
+
+Top-level methods have only the `Convertible` parameters:
+
+```go
+func (src *DynamoWidget) ConvertTo(dstRaw conversion.Hub) error
+func (dst *DynamoWidget) ConvertFrom(srcRaw conversion.Hub) error
+```
+
+Their call stack is:
 
 1. Copy Kubernetes metadata from `src` to `dst`.
 2. Decode sparse spec/status payloads into typed `restored` values.
 3. Scrub private conversion annotations from `dst`.
-4. Convert live spec/status fields from `src` to `dst`.
+4. Call typed conversion functions for spec/status.
 5. Restore destination-only fields from `restored`.
 6. Collect source-only fields in typed `save` values.
 7. Encode non-empty `save` values into sparse spec/status payloads on `dst`.
 
-Conversion functions follow the same semantic order even when their local
-control flow differs.
+Example:
+
+```text
+(*DynamoWidget).ConvertTo(dstRaw)
+  ConvertFromDynamoWidgetSpec(&src.Spec, &dst.Spec, restored.Spec, &save.Spec, ctx)
+    ConvertFromDynamoWidgetNestedSpec(&src.Spec.Nested, &dst.Spec.Nested, restoredNested, saveNested, ctx)
+  ConvertFromDynamoWidgetStatus(&src.Status, &dst.Status, restored.Status, &save.Status)
+  saveDynamoWidgetAnnotations(save, dst)
+```
+
+The conversion algorithm follows the API Go types inductively:
 
 - Export conversion functions from `v1alpha1`.
 - Name conversion functions after the v1alpha1 type:
@@ -55,7 +81,7 @@ func ConvertToDynamoWidgetSpec(
 - Converters do not accept `**T`.
 - Converters do not encode absence by assigning `dst` to nil.
 - Converters perform only their own API struct's conversion.
-- Every nested API struct that needs conversion gets its own
+- Every nested API struct gets its own systematic
   `ConvertFrom<SubStruct>` / `ConvertTo<SubStruct>` conversion function pair.
 - Parent converters call those nested converters instead of inlining nested
   struct conversion.
@@ -184,22 +210,6 @@ listed v1beta1 roots:
   or otherwise mutating data that came from `src`.
 - Mutating through `dst` after assigning shared data from `src` still violates
   this rule.
-
-## Generics
-
-Allowed generic helpers:
-
-- Decode/encode typed spec/status payloads.
-- Test typed save payload emptiness.
-- Convert list-maps to keyed maps.
-- Convert keyed maps to deterministic sorted lists.
-- Match restored/save child objects by key.
-
-Do not use generics for:
-
-- representability policy;
-- sparse save/restore policy;
-- pod template or main-container decomposition policy.
 
 ## Tests
 

--- a/deploy/operator/api/CONVERSION.md
+++ b/deploy/operator/api/CONVERSION.md
@@ -1,420 +1,253 @@
-# Conversion Invariants and Implementation Guide
+# Conversion Rules
 
-This document defines the invariants expected from conversions between the
-spoke API versions and the hub API version. The fuzz round-trip tests in this
-directory should enforce these rules.
+These rules apply to API conversion code and tests under `deploy/operator/api`.
+Every API type change in any version must update conversion code/tests, or
+explicitly document why conversion is unaffected.
 
-## Goals
+## Invariants
 
-- Make live source fields visibly authoritative.
-- Restore only fields that the source API version cannot represent.
-- Save only fields that the target API version cannot represent.
-- Keep preservation annotations sparse, so stale snapshots cannot quietly
-  override later live edits.
-- Keep representability decisions explicit and reviewable in typed conversion
-  helpers.
-- Use generics only for mechanical plumbing, not for conversion policy.
+- `src` live fields are always the source of truth.
+- A represented field always comes from `src`, including nil, empty, false, and
+  zero values.
+- `restored` data is used only for destination fields that `src` cannot
+  represent.
+- `save` data contains only source fields that `dst` cannot represent.
+- Preserve unrepresentable data only through the type's private sparse spec and
+  status payloads.
+- New conversion style allows at most two private conversion annotations per
+  type: one spec payload annotation and one status payload annotation.
+- Do not add per-field, per-list, per-subobject, or other conversion
+  annotations.
+- Do not overlay preserved data onto converted live fields.
+- Do not use preserved data as a fallback for represented fields.
+- Do not mutate `src`.
 
-## Source of Truth
+## Flow
 
-Live object fields are the source of truth.
+Top-level `ConvertTo` / `ConvertFrom` methods:
 
-Preservation annotations should store sparse typed payloads. Some legacy
-annotations may still contain coarse snapshots, including full spec/status
-payloads, but restore logic must use them only as old-value caches. Annotations
-must not overlay, underlay, or otherwise override fields that are representable
-by the API version being converted from.
+1. Copy Kubernetes metadata from `src` to `dst`.
+2. Decode sparse spec/status payloads into typed `restored` values.
+3. Scrub private conversion annotations from `dst`.
+4. Convert live spec/status fields from `src` to `dst`.
+5. Restore destination-only fields from `restored`.
+6. Collect source-only fields in typed `save` values.
+7. Encode non-empty `save` values into sparse spec/status payloads on `dst`.
 
-This is about representability in the version's schema, not whether a specific
-object currently represents the field with a non-zero value. If a field can be
-expressed natively by the source version, the source-version field is
-authoritative, including its zero, nil, or empty value.
+Structural helpers follow the same semantic order even when their local control
+flow differs.
 
-The conversion shape should be:
+## Helper Shape
 
-```text
-semantic = convert(live fields)
-preserved = decode annotation, if present
-
-for each known unrepresentable field:
-  find the matching live subobject
-  copy only that unrepresentable field from preserved into semantic
-
-return semantic
-```
-
-This is a semantic description, not a required top-level control flow.
-Recursive helpers may express the same invariant directly, for example:
-
-```text
-convertFooFrom(&src.Foo, &dst.Foo, &preserved.Foo)
-```
-
-Such helpers must still treat `src.Foo` as authoritative for every field
-representable by the source version, and use `preserved.Foo` only for fields
-that the source version cannot represent.
-
-The conversion shape must not be:
-
-```text
-return overlay(preserved, semantic)
-return overlay(semantic, preserved)
-return preserved if annotation exists
-```
-
-## Structural Helpers
-
-Conversion policy belongs in API conversion code. Controllers, reconcilers, and
-internal packages must not implement or wrap conversion. Temporary callers that
-need converted data must call the same exported structural converters used by
-the real conversion path. Read-only getters may live elsewhere; converters may
-not.
-
-Converters for API structs are exported from the `v1alpha1` package and are
-named after the v1alpha1 type:
+- Export conversion helpers from `v1alpha1`.
+- Name helpers after the v1alpha1 type:
 
 ```go
-func ConvertFrom<TypeName>(src *TypeName, dst *v1beta1.HubType, ...)
-func ConvertTo<TypeName>(src *v1beta1.HubType, dst *TypeName, ...)
+func ConvertFromDynamoWidgetSpec(
+	src *DynamoWidgetSpec,
+	dst *v1beta1.DynamoWidgetSpec,
+	restored *v1beta1.DynamoWidgetSpec,
+	save *DynamoWidgetSpec,
+	ctx DynamoWidgetSpecConversionContext,
+) error
+
+func ConvertToDynamoWidgetSpec(
+	src *v1beta1.DynamoWidgetSpec,
+	dst *DynamoWidgetSpec,
+	restored *DynamoWidgetSpec,
+	save *v1beta1.DynamoWidgetSpec,
+	ctx DynamoWidgetSpecConversionContext,
+) error
 ```
 
-Do not include `V1alpha1` in the name, and do not add wrapper functions with
-alternate names.
+- `ConvertFrom` means v1alpha1 -> hub.
+- `ConvertTo` means hub -> v1alpha1.
+- Do not include `V1alpha1` in helper names.
+- Do not add wrapper helpers with alternate names.
+- Parameter order is fixed: `src`, `dst`, `restored`, `save`, `ctx`.
+- Include `restored`, `save`, `ctx`, and `error` only when needed.
+- Put `ctx` last.
+- Return no value for infallible conversions.
+- Return `error` when the helper parses JSON, validates preserved payloads, or
+  otherwise can reject input.
+- `dst` is caller-owned and non-nil.
+- Callers allocate nested `dst` objects explicitly.
+- Converters do not accept `**T`.
+- Converters do not encode absence by assigning `dst` to nil.
+- Converters perform only their own API struct's conversion.
+- Every nested API struct that needs conversion gets its own
+  `ConvertFrom<SubStruct>` / `ConvertTo<SubStruct>` helper pair.
+- Parent converters call those nested helpers instead of inlining nested struct
+  conversion.
 
-The parameter order is fixed:
+Allowed local helpers:
 
-- `src`: live source object; authoritative for every representable field,
-  including nil, empty, and zero values.
-- `dst`: caller-owned, non-nil destination object.
-- `restored`: optional target-version data decoded from preservation
-  annotations; use it only for target-only fields.
-- `save`: optional source-version data to encode into preservation annotations;
-  write only source-only fields and keys needed to find them later.
-- `ctx`: optional typed context, always last.
+- `restore*` readers for decoded sparse payloads.
+- `save*` writers for sparse payloads.
+- `ensure*` allocators for sparse save payloads.
+- Side-effect-free predicates.
+- Field-group projections, such as pod template composition/decomposition.
 
-`restored`, `save`, and `ctx` are included only when the converter needs them.
-Return `error` only when conversion can fail.
+## Sparse Payloads
 
-Exported conversion-only helper types, such as typed contexts needed by
-exported converter signatures, must opt out of Kubernetes object generation and
-API reference docs.
+- Payloads are typed API structs from the source version.
+- Payloads must be sparse by construction.
+- Save only source fields the target version cannot represent.
+- Save only the minimal context needed to match preserved fields back to live
+  source structure.
+- Skip empty save objects.
+- Keep payload annotation constants unexported and local to conversion files.
+- Only API conversion code and conversion tests may know payload annotations or
+  payload shapes.
+- Controllers, reconcilers, webhooks, internal helpers, and general API helpers
+  must not read, write, delete, filter, decode, encode, branch on, or expose
+  payload annotations or payloads.
+- Non-conversion code may copy Kubernetes metadata opaquely, but must not
+  identify conversion annotations.
+- If non-conversion code needs data from a sparse payload, add or call a real
+  conversion helper instead.
+- Restore code may read represented fields from a sparse payload only as
+  matching context.
+- Restore code must not restore represented fields from a sparse payload.
 
-Callers perform nil, disabled, zero, or absence checks before calling a
-converter and allocate nested `dst` objects explicitly. Converters do not accept
-`**T` and do not encode absence by setting `dst` to nil.
+## Compound Values
 
-Converters must mirror API type structure. A converter handles the fields of
-its own type and delegates each converted nested API struct to that nested
-struct's `ConvertFrom<SubStruct>` or `ConvertTo<SubStruct>` function. Do not
-convert multiple nested API layers at once in a parent converter.
-
-Local helpers are allowed only for conversion-private implementation details
-that are not API-struct converters: `restore*` readers, `save*` writers,
-`ensure*` allocators for sparse save payloads, side-effect-free predicates, and
-field-group projections such as podTemplate composition/decomposition. Use
-`restore` when reading `restored` and `save` when writing `save`.
-
-Converters may share data between `src` and `dst`, but they must never mutate
-`src`. Deep-copy only when the converter will mutate the copy or when separate
-ownership is required.
-
-## Preservation Annotations
-
-Preservation annotations exist only to make unrepresentable data survive a
-round trip through a version that cannot express it natively.
-
-Preservation annotations are private to conversion code. Only API conversion
-code and its conversion tests may know their keys or payload shape. Controllers,
-reconcilers, webhooks, internal helper packages, and general API helpers must
-not read, write, delete, filter, decode, encode, branch on, or expose them.
-Keep annotation key constants unexported and local to conversion files. Do not
-define shared constants, prefixes, string literals, getters, predicates, or
-wrapper helpers for conversion annotations outside conversion code.
-
-Non-conversion code may copy Kubernetes metadata opaquely as part of normal
-object handling, but it must not identify or interpret individual conversion
-annotations. If non-conversion code needs data that currently appears only in a
-preservation annotation, add or call a real conversion helper instead of
-decoding the annotation.
-
-It is acceptable for the annotation payload to include representable fields as
-context. Restore code must explicitly ignore those fields unless they are needed
-only to locate the unrepresentable data.
-
-For compound objects with mixed representability, such as pod templates or job
-specs, restore code must copy individual unrepresentable leaves. It must not
-restore the whole compound object and then patch represented fields over it.
-
-Save payloads should be sparse by construction. A helper should write only the
-source-version fields that the target version cannot represent:
-
-```go
-// Save source-only fields that dst cannot represent.
-save.FrontendSidecar = src.FrontendSidecar
-save.PodTemplate = sparseHubOnlyPodTemplateRemainder(src.PodTemplate, projected)
-if experimentalIsHubOnlyShape(src.Experimental) {
-	save.Experimental = src.Experimental
-}
-```
-
-After helper execution, callers should skip empty save objects:
-
-```go
-if !dcdHubSpecSaveIsZero(&save) {
-	encodeDCDSaveAnnotation(dst, &save)
-}
-```
-
-Typed zero checks are preferred over broad reflection when they keep the
-preserved shape clearer. `apiequality.Semantic.DeepEqual` is appropriate for
-Kubernetes API structs when nil/empty semantic equality is intended.
+- Restore compound values leaf-by-leaf.
+- Do not restore a whole pod template, container, job, resource requirements,
+  or similar compound object and then patch represented fields over it.
+- For projected fields, compare the live target object with the projected
+  object and save only the unrepresentable remainder.
+- Keep sparse matching/decomposition context inside the spec/status payload.
+- Sparse context is not a source of truth.
 
 ## Named Lists
 
-For list-map fields, preserved data must be matched by the declared list-map
-key, not by slice index.
+- Match preserved list-map entries by the declared list-map key, not by slice
+  index.
+- Ignore preserved entries whose key is no longer present in live `src`.
+- New live entries get no preserved data unless the sparse payload has the same
+  key.
+- Saved entries for named lists must include the list-map key, such as
+  `ComponentName` for DGD components.
 
-For example, `v1beta1.spec.components[]` data is matched by `name`. If the live
-object no longer contains that name, the preserved subobject is stale and must
-be ignored. If a live object introduces a new name, it gets no preserved data
-unless the annotation has a matching key.
+## Legacy DGDR Exception
 
-Saved entries for named lists must include the list-map key. For example, a
-saved DGD component needs `ComponentName` so the preserved fields can be
-matched back to the live component later.
+- Do not add new legacy formats.
+- Existing legacy DGDR annotations are temporary downgrade shims only.
+- Keep legacy keys named `legacyAnn*`.
+- Keep their `TODO(sttts)` removal comments.
+- Isolate legacy reads/writes in legacy helpers.
+- Decode legacy data into the same typed `restored` model used by structural
+  conversion.
+- Legacy data is an old-value cache only.
+- Legacy data must not override fields representable by live `src`.
+- Keep the old converter as a test oracle while downgrade compatibility is
+  required.
+- Legacy-vs-structural fuzz tests may normalize inputs to the old converter's
+  representable behavior.
+- Main round-trip fuzz tests must not keep workarounds for fixed structural
+  conversion bugs.
 
-## Origin Hints
+## API Changes
 
-Some annotations record that a field was generated by conversion from another
-version. These annotations are hints for lossless no-op round trips, not sources
-of truth.
+For every added, removed, renamed, or semantically changed API field, choose one
+explicit conversion policy:
 
-If a later edit changes source-version-representable semantics, the converted
-source-version object must change visibly.
+- Native mapping: convert from live `src`.
+- Source-only preservation: save into the source-version sparse payload on
+  `dst`.
+- Target-only restore: restore from `restored` after live fields are converted.
+- Derived or lossy mapping: document the mapping and add focused tests.
+- Intentional drop: document why it is outside the conversion contract and add
+  a focused test when observable.
 
-If a later edit changes only target-version-only semantics, the converted
-source-version object may look unchanged, but its preservation annotation must
-change so converting back restores the edited target-version-only data.
+If the other version later grows a native field for the same concept:
 
-If a later edit changes both, the converted source-version object must change
-visibly for the representable part, and the annotation must preserve the
-target-version-only remainder.
+- live `src` wins over stale sparse payload data;
+- the sparse payload stops preserving that now-representable value.
 
-The bug class to avoid is letting a stale origin annotation restore the old
-generated value after a live edit changed source-version-representable
-semantics.
+`TestV1Beta1ConversionFieldSetIsAcknowledged` is a schema-change tripwire for
+listed v1beta1 roots:
 
-Example: v1alpha1 can represent the frontend sidecar image, but cannot
-represent every field of the generated v1beta1 sidecar container.
-
-```yaml
-# v1alpha1 input
-spec:
-  services:
-    epp:
-      frontendSidecar:
-        image: frontend:v1
-```
-
-Converting to v1beta1 generates a sidecar container and records an origin hint:
-
-```yaml
-metadata:
-  annotations:
-    nvidia.com/dgd-comp-epp-frontend-sidecar-origin: '{"image":"frontend:v1"}'
-spec:
-  components:
-  - name: epp
-    frontendSidecar: sidecar-frontend
-    podTemplate:
-      spec:
-        containers:
-        - name: main
-        - name: sidecar-frontend
-          image: frontend:v1
-```
-
-If v1beta1 edits the image, v1alpha1 must change visibly:
-
-```yaml
-# edited v1beta1
-containers:
-- name: sidecar-frontend
-  image: frontend:v2
-
-# converted v1alpha1
-frontendSidecar:
-  image: frontend:v2
-```
-
-If v1beta1 edits only a container field that v1alpha1 cannot represent, the
-visible v1alpha1 field may stay the same, but preservation must carry the
-v1beta1-only data:
-
-```yaml
-# edited v1beta1
-containers:
-- name: sidecar-frontend
-  image: frontend:v1
-  securityContext:
-    runAsNonRoot: true
-
-# converted v1alpha1
-frontendSidecar:
-  image: frontend:v1
-metadata:
-  annotations:
-    nvidia.com/dgd-spec: '{... "securityContext":{"runAsNonRoot":true} ...}'
-```
-
-## Generics
-
-Use generics for boring mechanics only.
-
-Good candidates:
-
-- Decode/encode typed annotation payloads.
-- Test whether a typed save payload is empty.
-- Convert a list-map into a keyed map.
-- Convert a keyed map into a deterministic sorted list.
-- Match restored/save child objects by key.
-
-Bad candidates:
-
-- Deciding which fields are representable.
-- PodTemplate/main-container semantic origin logic.
-
-Generic helpers should reduce repeated mechanics without obscuring conversion
-policy.
-
-## Review Checklist
-
-For each helper:
-
-- Does every represented field come from `src`?
-- Does every restored field come only from `restored` and only when the source
-  version cannot represent it?
-- Does every saved field represent data that `dst` cannot express?
-- Are named-list fields matched by their list-map key, never by index?
-- Is the save payload sparse?
-- Are origin annotations used only as hints, not as shortcuts?
-- Are conversion annotations private to conversion code and absent from
-  controllers/internal helpers?
-- Are nil and empty shapes preserved where round-trip tests require them?
+- Do not update `knownV1Beta1ConversionFieldSet` first.
+- Implement the conversion decision.
+- Add or update focused tests.
+- Then refresh the snapshot from the failing test diff.
 
 ## Mutability
 
-Conversion functions must not mutate their input object.
+- Conversion must not mutate `src`.
+- Sharing backing data between `src` and `dst` is allowed when treated as
+  read-only after assignment.
+- Do not deep-copy solely because a value came from `src`.
+- Deep-copy before editing, appending, sorting, normalizing, clearing, merging,
+  or otherwise mutating data that came from `src`.
+- Mutating through `dst` after assigning shared data from `src` still violates
+  this rule.
 
-`src` and `dst` may share backing data when the converted value can be assigned
-as-is. Do not add `DeepCopy` calls only because a field came from `src`.
-Aliasing is acceptable when the conversion code treats the shared value as
-read-only after assignment.
+## Generics
 
-Use `DeepCopy` only when the conversion needs an independently mutable value:
-for example, before editing, appending to, sorting, normalizing, clearing,
-merging into, or otherwise mutating a value that came from `src`. This applies
-equally to direct mutation through `src` and indirect mutation through a `dst`
-field that aliases `src`; both violate the "do not mutate input" invariant.
+Allowed generic helpers:
 
-The round-trip fuzz tests snapshot inputs through YAML before conversion because
-marshalling observes the actual in-memory shape, including aliasing bugs that a
-plain structural comparison may miss.
+- Decode/encode typed spec/status payloads.
+- Test typed save payload emptiness.
+- Convert list-maps to keyed maps.
+- Convert keyed maps to deterministic sorted lists.
+- Match restored/save child objects by key.
 
-## Fuzz Test Expectations
+Do not use generics for:
 
-The regular round-trip tests verify unchanged objects:
+- representability policy;
+- sparse save/restore policy;
+- pod template or main-container decomposition policy.
+
+## Tests
+
+Required coverage for conversion changes:
+
+- Focused tests for each new or changed conversion policy.
+- Found conversion regressions get focused tests in the relevant
+  `*_bugs_test.go` files.
+- Regular round-trip fuzz:
 
 ```text
 hub -> spoke -> hub
 spoke -> hub -> spoke
 ```
 
-The mutability round-trip test verifies stale annotation behavior:
+- Mutability fuzz for stale sparse payload behavior:
 
 ```text
 fuzz in
 convert to other
-mutate other without deleting preservation annotations
+mutate other without deleting private spec/status annotations
 convert other -> in -> other2
-compare other and other2, ignoring only preservation annotations
+compare other and other2, ignoring only private spec/status annotations
 ```
 
-The mutation step must update nested existing objects, including elements inside
-arrays and slices. This is what exposes stale annotation overlays on deep
-fields.
+- Mutation must touch nested existing objects, arrays, and slices.
 
-## Adding v1beta1 Fields
+## Review Checklist
 
-In Kubernetes conversion, `v1beta1` is the hub version and `v1alpha1` is the
-spoke version. Objects may be converted in either direction:
-
-```text
-v1beta1 hub -> v1alpha1 spoke
-v1alpha1 spoke -> v1beta1 hub
-```
-
-The conversion helpers use these names:
-
-- `src`: the live object we are converting from now. It is the source of truth.
-- `dst`: the object we are building.
-- `restored`: older `dst`-version data decoded from preservation annotations.
-- `save`: `src`-version data that `dst` cannot represent directly and that
-  will be written into `dst.metadata.annotations` for a future conversion.
-- `ctx`: extra typed context passed to nested helpers.
-
-`TestV1Beta1ConversionFieldSetIsAcknowledged` is a schema-change tripwire. It
-reflects over the v1beta1 spec/status structs covered by this conversion
-cleanup and compares their JSON field paths to a checked-in field-set snapshot.
-It currently covers DGD, DCD, and DGDSA. DGDR already shipped with conversion
-annotations, so changes to its annotation/storage contract should be handled in
-a separate compatibility-focused PR.
-
-When a v1beta1 field is added, this test should fail before the field can be
-silently dropped by conversion. Treat that failure as a prompt to make an
-explicit conversion decision:
-
-- Native mapping: add the field to the relevant `convert*ToHub` /
-  `convert*FromHub` helper, sourced from the live `src` value.
-- Source-only preservation: if the target version cannot represent the field,
-  add it to the sparse `save` payload. The payload is serialized into an
-  annotation on `dst`. On a later conversion back, restore that field from
-  `restored` only if the then-current `src` version still cannot represent it.
-- Derived or lossy mapping: document the semantic mapping and add a targeted
-  regression test for the lossy shape.
-- Intentional drop: document why the field is not part of the conversion
-  contract and add a targeted test if the omission is observable.
-
-For example, if a new v1beta1 field has no v1alpha1 field, then on
-`v1beta1 -> v1alpha1` the converter should copy it into `save` and encode that
-save payload into a v1alpha1 annotation. On `v1alpha1 -> v1beta1`, the
-converter may restore that field from `restored`. If v1alpha1 later grows a
-native field for the same concept, the live `src` field must win over any stale
-annotation.
-
-Then add or update a focused conversion test for the new field. Fuzz is a broad
-backstop; the field-set test tells reviewers that the schema changed, while the
-focused test proves the chosen conversion policy.
-
-After the conversion code and tests are updated, refresh the
-`knownV1Beta1ConversionFieldSet` snapshot in
-`conversion_field_coverage_test.go` by applying the diff from the failing test
-output. Do not update the snapshot before the conversion decision is
-implemented.
-
-The field-set snapshot walks v1beta1 API structs and v1beta1-owned nested
-types. Kubernetes/library structs such as `corev1.PodTemplateSpec` are treated
-as leaves; additions inside those upstream types are covered by the existing
-pod-template/job conversion tests rather than by this schema tripwire.
+- Every represented field comes from live `src`.
+- Every restored field is unrepresentable by live `src`.
+- Every saved field is unrepresentable by `dst`.
+- Save payloads are sparse.
+- Sparse context stays inside spec/status payloads.
+- Sparse context is used only for matching.
+- Named lists are matched by list-map key.
+- Compound values are restored leaf-by-leaf.
+- Nil and empty shapes are preserved where tests require them.
+- `src` is not mutated.
+- No new conversion annotations were added beyond spec/status.
+- Non-conversion code does not interpret sparse payloads.
 
 ## Verification
 
-Each conversion change should run:
+Run for conversion changes:
 
 ```sh
 GOCACHE=/tmp/dynamo-go-cache go test ./api/v1alpha1 -count=1
 GOCACHE=/tmp/dynamo-go-cache go test ./api/... -count=1
 GOCACHE=/tmp/dynamo-go-cache go test ./api -run TestFuzzRoundTrip -roundtrip-fuzz-iters=3000 -count=1 -v
-git diff --check
-docker buildx build --platform linux/arm64 --target linter --progress=plain --build-context snapshot=../snapshot .
 ```

--- a/deploy/operator/api/CONVERSION.md
+++ b/deploy/operator/api/CONVERSION.md
@@ -4,25 +4,7 @@ These rules apply to API conversion code and tests under `deploy/operator/api`.
 Every API type change in any version must update conversion code/tests, or
 explicitly document why conversion is unaffected.
 
-## Invariants
-
-- `src` live fields are always the source of truth.
-- A represented field always comes from `src`, including nil, empty, false, and
-  zero values.
-- `restored` data is used only for destination fields that `src` cannot
-  represent.
-- `save` data contains only source fields that `dst` cannot represent.
-- Preserve unrepresentable data only through the type's private sparse spec and
-  status payloads.
-- New conversion style allows at most two private conversion annotations per
-  type: one spec payload annotation and one status payload annotation.
-- Do not add per-field, per-list, per-subobject, or other conversion
-  annotations.
-- Do not overlay preserved data onto converted live fields.
-- Do not use preserved data as a fallback for represented fields.
-- Do not mutate `src`.
-
-## Flow
+## Structure
 
 Top-level `ConvertTo` / `ConvertFrom` methods:
 
@@ -34,13 +16,11 @@ Top-level `ConvertTo` / `ConvertFrom` methods:
 6. Collect source-only fields in typed `save` values.
 7. Encode non-empty `save` values into sparse spec/status payloads on `dst`.
 
-Structural helpers follow the same semantic order even when their local control
-flow differs.
+Conversion functions follow the same semantic order even when their local
+control flow differs.
 
-## Helper Shape
-
-- Export conversion helpers from `v1alpha1`.
-- Name helpers after the v1alpha1 type:
+- Export conversion functions from `v1alpha1`.
+- Name conversion functions after the v1alpha1 type:
 
 ```go
 func ConvertFromDynamoWidgetSpec(
@@ -62,13 +42,13 @@ func ConvertToDynamoWidgetSpec(
 
 - `ConvertFrom` means v1alpha1 -> hub.
 - `ConvertTo` means hub -> v1alpha1.
-- Do not include `V1alpha1` in helper names.
-- Do not add wrapper helpers with alternate names.
+- Do not include `V1alpha1` in conversion function names.
+- Do not add wrapper conversion functions with alternate names.
 - Parameter order is fixed: `src`, `dst`, `restored`, `save`, `ctx`.
 - Include `restored`, `save`, `ctx`, and `error` only when needed.
 - Put `ctx` last.
 - Return no value for infallible conversions.
-- Return `error` when the helper parses JSON, validates preserved payloads, or
+- Return `error` when the converter parses JSON, validates preserved payloads, or
   otherwise can reject input.
 - `dst` is caller-owned and non-nil.
 - Callers allocate nested `dst` objects explicitly.
@@ -76,9 +56,9 @@ func ConvertToDynamoWidgetSpec(
 - Converters do not encode absence by assigning `dst` to nil.
 - Converters perform only their own API struct's conversion.
 - Every nested API struct that needs conversion gets its own
-  `ConvertFrom<SubStruct>` / `ConvertTo<SubStruct>` helper pair.
-- Parent converters call those nested helpers instead of inlining nested struct
-  conversion.
+  `ConvertFrom<SubStruct>` / `ConvertTo<SubStruct>` conversion function pair.
+- Parent converters call those nested converters instead of inlining nested
+  struct conversion.
 
 Allowed local helpers:
 
@@ -88,6 +68,24 @@ Allowed local helpers:
 - Side-effect-free predicates.
 - Field-group projections, such as pod template composition/decomposition.
 
+## Invariants
+
+- `src` live fields are always the source of truth.
+- A represented field always comes from `src`, including nil, empty, false, and
+  zero values.
+- `restored` data is used only for destination fields that `src` cannot
+  represent.
+- `save` data contains only source fields that `dst` cannot represent.
+- Preserve unrepresentable data only through the type's private sparse spec and
+  status payloads.
+- New conversion style allows at most two private conversion annotations per
+  type: one spec payload annotation and one status payload annotation.
+- Do not add per-field, per-list, per-subobject, or other conversion
+  annotations.
+- Do not overlay preserved data onto converted live fields.
+- Do not use preserved data as a fallback for represented fields.
+- Do not mutate `src`.
+
 ## Sparse Payloads
 
 - Payloads are typed API structs from the source version.
@@ -96,6 +94,8 @@ Allowed local helpers:
 - Save only the minimal context needed to match preserved fields back to live
   source structure.
 - Skip empty save objects.
+- Do not allocate nested save structs unless they contain at least one saved
+  field.
 - Keep payload annotation constants unexported and local to conversion files.
 - Only API conversion code and conversion tests may know payload annotations or
   payload shapes.

--- a/deploy/operator/api/roundtrip_fuzz_test.go
+++ b/deploy/operator/api/roundtrip_fuzz_test.go
@@ -322,6 +322,12 @@ func fuzzBetaDGDRStatus(s *v1beta1.DynamoGraphDeploymentRequestStatus, c randfil
 
 	s.Phase = oneOf(c, v1beta1.DGDRPhasePending, v1beta1.DGDRPhaseProfiling, v1beta1.DGDRPhaseReady, v1beta1.DGDRPhaseDeploying, v1beta1.DGDRPhaseDeployed, v1beta1.DGDRPhaseFailed)
 
+	// Profiling substatus is only valid while the request is profiling.
+	if s.Phase != v1beta1.DGDRPhaseProfiling {
+		s.ProfilingPhase = ""
+		s.ProfilingJobName = ""
+	}
+
 	if s.ProfilingResults != nil {
 		// Empty ProfilingResults is not reconstructed without SelectedConfig or Pareto.
 		if s.ProfilingResults.SelectedConfig == nil && len(s.ProfilingResults.Pareto) == 0 {

--- a/deploy/operator/api/roundtrip_fuzz_test.go
+++ b/deploy/operator/api/roundtrip_fuzz_test.go
@@ -100,16 +100,11 @@ func scrubReservedAnnotations(m map[string]string) map[string]string {
 	return m
 }
 
-// TODO: fix this conversion bug: DGDR conversion re-emits internal annotations during direct round-trips.
-// Example:
-//
-//	spec:
-//	  sla:
-//	    ttft: 2000
-//
-// round-trips with metadata.annotations["nvidia.com/dgdr-profiling-config"].
-var ignoreDGDRInternalAnnotationTODO = cmpopts.AcyclicTransformer(
-	"ignoreDGDRInternalAnnotationTODO",
+// DGDR still writes legacy nvidia.com/dgdr-* annotations for downgrade
+// compatibility with Dynamo 1.1. Direct round-trip fuzzing compares live API
+// fields and ignores those intentionally re-emitted compatibility annotations.
+var ignoreDGDRCompatibilityAnnotations = cmpopts.AcyclicTransformer(
+	"ignoreDGDRCompatibilityAnnotations",
 	func(m metav1.ObjectMeta) metav1.ObjectMeta {
 		if len(m.Annotations) == 0 {
 			return m
@@ -234,18 +229,10 @@ func fuzzAlphaDGDRSpec(s *v1alpha1.DynamoGraphDeploymentRequestSpec, c randfill.
 	// Empty resources do not survive the alpha resources to beta profiling job projection.
 	if s.ProfilingConfig.Resources != nil &&
 		len(s.ProfilingConfig.Resources.Requests) == 0 &&
-		len(s.ProfilingConfig.Resources.Limits) == 0 {
+		len(s.ProfilingConfig.Resources.Limits) == 0 &&
+		len(s.ProfilingConfig.Resources.Claims) == 0 {
 		s.ProfilingConfig.Resources = nil
 	}
-
-	// TODO: fix this conversion bug: NodeSelector is not mapped into the v1beta1 profiling job override.
-	// Example:
-	//   spec:
-	//     profilingConfig:
-	//       nodeSelector:
-	//         accelerator: h100
-	// round-trips without nodeSelector.
-	s.ProfilingConfig.NodeSelector = nil
 
 	// Only true EnableGPUDiscovery is annotation-preserved; false is dropped.
 	if s.EnableGPUDiscovery != nil {
@@ -269,14 +256,15 @@ func fuzzAlphaDGDRSpec(s *v1alpha1.DynamoGraphDeploymentRequestSpec, c randfill.
 func fuzzAlphaDGDRStatus(s *v1alpha1.DynamoGraphDeploymentRequestStatus, c randfill.Continue) {
 	c.FillNoCustom(s)
 
-	// TODO: fix this conversion bug: Initializing and DeploymentDeleted are lossy through the v1beta1 phase enum.
-	// Example:
-	//   status:
-	//     state: DeploymentDeleted
-	//     deployment:
-	//       created: true
-	// round-trips as Ready with created=false.
-	s.State = oneOf(c, v1alpha1.DGDRStatePending, v1alpha1.DGDRStateProfiling, v1alpha1.DGDRStateReady, v1alpha1.DGDRStateDeploying, v1alpha1.DGDRStateFailed)
+	s.State = oneOf(c,
+		v1alpha1.DGDRStateInitializing,
+		v1alpha1.DGDRStatePending,
+		v1alpha1.DGDRStateProfiling,
+		v1alpha1.DGDRStateReady,
+		v1alpha1.DGDRStateDeploying,
+		v1alpha1.DGDRStateDeploymentDeleted,
+		v1alpha1.DGDRStateFailed,
+	)
 }
 
 func fuzzBetaDGDRSpec(s *v1beta1.DynamoGraphDeploymentRequestSpec, c randfill.Continue) {
@@ -284,32 +272,10 @@ func fuzzBetaDGDRSpec(s *v1beta1.DynamoGraphDeploymentRequestSpec, c randfill.Co
 
 	s.Backend = oneOf(c, v1beta1.BackendTypeAuto, v1beta1.BackendTypeVllm, v1beta1.BackendTypeSglang, v1beta1.BackendTypeTrtllm)
 
-	// TODO: fix this conversion bug: Hardware is not annotation-preserved through v1alpha1.
-	// Example:
-	//   spec:
-	//     hardware:
-	//       gpuSku: h100_sxm
-	//       totalGpus: 8
-	// round-trips without hardware.
-	s.Hardware = nil
-
-	// Concurrency and RequestRate have no v1alpha1 DGDR fields.
-	if s.Workload != nil {
-		s.Workload.Concurrency = nil
-		s.Workload.RequestRate = nil
-
-		// Empty Workload is not reconstructed from the alpha profiling config blob.
-		if s.Workload.ISL == nil && s.Workload.OSL == nil {
-			s.Workload = nil
-		} else if s.SLA == nil {
-			// Workload-only blob reconstruction creates an empty SLA shell.
-			s.SLA = &v1beta1.SLASpec{}
-		}
-	}
-
-	// E2ELatency has no v1alpha1 DGDR field.
-	if s.SLA != nil {
-		s.SLA.E2ELatency = nil
+	if s.Workload != nil && s.SLA == nil && (s.Workload.ISL != nil || s.Workload.OSL != nil) {
+		// ISL/OSL live under the alpha profiling config's "sla" object, whose
+		// reconstruction creates an empty v1beta1 SLA shell.
+		s.SLA = &v1beta1.SLASpec{}
 	}
 
 	// Empty ModelCache is not reconstructed from the alpha profiling config blob.
@@ -320,33 +286,12 @@ func fuzzBetaDGDRSpec(s *v1beta1.DynamoGraphDeploymentRequestSpec, c randfill.Co
 		s.ModelCache = nil
 	}
 
-	// TODO: fix this conversion bug: Overrides beyond alpha resources/tolerations are not annotation-preserved.
-	// Example:
-	//   spec:
-	//     overrides:
-	//       profilingJob:
-	//         activeDeadlineSeconds: 3600
-	// round-trips without overrides.profilingJob.
-	s.Overrides = nil
-
 	if s.Features != nil {
-		// False Mocker is not reconstructed because alpha only records enabled mocker.
-		if s.Features.Mocker != nil {
-			s.Features.Mocker.Enabled = true
-		}
-
-		// Empty Features is not reconstructed without Planner or enabled Mocker.
+		// Empty Features is not reconstructed without Planner or Mocker.
 		if s.Features.Planner == nil && s.Features.Mocker == nil {
 			s.Features = nil
 		}
 	}
-
-	// TODO: fix this conversion bug: SearchStrategy is not annotation-preserved through v1alpha1.
-	// Example:
-	//   spec:
-	//     searchStrategy: thorough
-	// round-trips without searchStrategy.
-	s.SearchStrategy = ""
 
 	// Nil AutoApply round-trips as the v1beta1 default true.
 	if s.AutoApply == nil {
@@ -358,46 +303,14 @@ func fuzzBetaDGDRSpec(s *v1beta1.DynamoGraphDeploymentRequestSpec, c randfill.Co
 func fuzzBetaDGDRStatus(s *v1beta1.DynamoGraphDeploymentRequestStatus, c randfill.Continue) {
 	c.FillNoCustom(s)
 
-	// TODO: fix this conversion bug: Deployed is not preserved through the alpha deployment state.
-	// Example:
-	//   status:
-	//     phase: Deployed
-	// round-trips as Ready.
-	s.Phase = oneOf(c, v1beta1.DGDRPhasePending, v1beta1.DGDRPhaseProfiling, v1beta1.DGDRPhaseReady, v1beta1.DGDRPhaseDeploying, v1beta1.DGDRPhaseFailed)
-
-	// TODO: fix this conversion bug: ProfilingPhase is not annotation-preserved through v1alpha1.
-	// Example:
-	//   status:
-	//     phase: Profiling
-	//     profilingPhase: SweepingDecode
-	// round-trips without profilingPhase.
-	s.ProfilingPhase = ""
+	s.Phase = oneOf(c, v1beta1.DGDRPhasePending, v1beta1.DGDRPhaseProfiling, v1beta1.DGDRPhaseReady, v1beta1.DGDRPhaseDeploying, v1beta1.DGDRPhaseDeployed, v1beta1.DGDRPhaseFailed)
 
 	if s.ProfilingResults != nil {
-		// TODO: fix this conversion bug: Pareto is not annotation-preserved through v1alpha1.
-		// Example:
-		//   status:
-		//     profilingResults:
-		//       pareto:
-		//       - config:
-		//           spec: {}
-		// round-trips without pareto.
-		s.ProfilingResults.Pareto = nil
-
-		// Empty ProfilingResults is not reconstructed without SelectedConfig.
-		if s.ProfilingResults.SelectedConfig == nil {
+		// Empty ProfilingResults is not reconstructed without SelectedConfig or Pareto.
+		if s.ProfilingResults.SelectedConfig == nil && len(s.ProfilingResults.Pareto) == 0 {
 			s.ProfilingResults = nil
 		}
 	}
-
-	// TODO: fix this conversion bug: DeploymentInfo is not annotation-preserved through v1alpha1.
-	// Example:
-	//   status:
-	//     deploymentInfo:
-	//       replicas: 2
-	//       availableReplicas: 1
-	// round-trips without deploymentInfo.
-	s.DeploymentInfo = nil
 }
 
 func newRoundTripFiller(seed int64) *randfill.Filler {
@@ -579,14 +492,14 @@ func TestFuzzRoundTrip_DCD_SpokeHubSpoke(t *testing.T) {
 func TestFuzzRoundTrip_DGDR_HubSpokeHub(t *testing.T) {
 	fuzzHubSpokeHub[*v1beta1.DynamoGraphDeploymentRequest, v1alpha1.DynamoGraphDeploymentRequest](t, "DGDR",
 		func() *v1beta1.DynamoGraphDeploymentRequest { return &v1beta1.DynamoGraphDeploymentRequest{} },
-		ignoreDGDRInternalAnnotationTODO,
+		ignoreDGDRCompatibilityAnnotations,
 	)
 }
 
 func TestFuzzRoundTrip_DGDR_SpokeHubSpoke(t *testing.T) {
 	fuzzSpokeHubSpoke[*v1beta1.DynamoGraphDeploymentRequest, v1alpha1.DynamoGraphDeploymentRequest](t, "DGDR",
 		func() *v1beta1.DynamoGraphDeploymentRequest { return &v1beta1.DynamoGraphDeploymentRequest{} },
-		ignoreDGDRInternalAnnotationTODO,
+		ignoreDGDRCompatibilityAnnotations,
 	)
 }
 

--- a/deploy/operator/api/roundtrip_fuzz_test.go
+++ b/deploy/operator/api/roundtrip_fuzz_test.go
@@ -103,6 +103,18 @@ func scrubReservedAnnotations(m map[string]string) map[string]string {
 // DGDR still writes legacy nvidia.com/dgdr-* annotations for downgrade
 // compatibility with Dynamo 1.1. Direct round-trip fuzzing compares live API
 // fields and ignores those intentionally re-emitted compatibility annotations.
+var legacyDGDRCompatibilityAnnotations = []string{
+	"nvidia.com/dgdr-config-map-ref",
+	"nvidia.com/dgdr-output-pvc",
+	"nvidia.com/dgdr-enable-gpu-discovery",
+	"nvidia.com/dgdr-deployment-overrides",
+	"nvidia.com/dgdr-profiling-config",
+	"nvidia.com/dgdr-status-backend",
+	"nvidia.com/dgdr-profiling-results",
+	"nvidia.com/dgdr-deployment-status",
+	"nvidia.com/dgdr-profiling-job-name",
+}
+
 var ignoreDGDRCompatibilityAnnotations = cmpopts.AcyclicTransformer(
 	"ignoreDGDRCompatibilityAnnotations",
 	func(m metav1.ObjectMeta) metav1.ObjectMeta {
@@ -113,10 +125,8 @@ var ignoreDGDRCompatibilityAnnotations = cmpopts.AcyclicTransformer(
 		for k, v := range m.Annotations {
 			annotations[k] = v
 		}
-		for k := range annotations {
-			if strings.HasPrefix(k, "nvidia.com/dgdr-") {
-				delete(annotations, k)
-			}
+		for _, k := range legacyDGDRCompatibilityAnnotations {
+			delete(annotations, k)
 		}
 		if len(annotations) == 0 {
 			m.Annotations = nil
@@ -276,6 +286,13 @@ func fuzzBetaDGDRSpec(s *v1beta1.DynamoGraphDeploymentRequestSpec, c randfill.Co
 		// ISL/OSL live under the alpha profiling config's "sla" object, whose
 		// reconstruction creates an empty v1beta1 SLA shell.
 		s.SLA = &v1beta1.SLASpec{}
+	}
+	if s.Workload != nil &&
+		s.Workload.ISL == nil &&
+		s.Workload.OSL == nil &&
+		s.Workload.Concurrency == nil &&
+		s.Workload.RequestRate == nil {
+		s.Workload = nil
 	}
 
 	// Empty ModelCache is not reconstructed from the alpha profiling config blob.

--- a/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion.go
@@ -119,10 +119,7 @@ func (dst *DynamoGraphDeploymentRequest) ConvertFrom(srcRaw conversion.Hub) erro
 
 	dst.ObjectMeta = *src.ObjectMeta.DeepCopy()
 
-	restoredSpokeSpec, restoredSpokeStatus, err := restoreDGDRSpokeAnnotations(&dst.ObjectMeta)
-	if err != nil {
-		return err
-	}
+	restoredSpokeSpec, restoredSpokeStatus := restoreDGDRSpokeAnnotations(&dst.ObjectMeta)
 	scrubDGDRInternalAnnotations(&dst.ObjectMeta)
 
 	var hubSpecSave v1beta1.DynamoGraphDeploymentRequestSpec
@@ -167,7 +164,7 @@ func restoreDGDRHubAnnotations(obj metav1.Object) (*v1beta1.DynamoGraphDeploymen
 	return restoredSpec, restoredStatus
 }
 
-func restoreDGDRSpokeAnnotations(obj metav1.Object) (*DynamoGraphDeploymentRequestSpec, *DynamoGraphDeploymentRequestStatus, error) {
+func restoreDGDRSpokeAnnotations(obj metav1.Object) (*DynamoGraphDeploymentRequestSpec, *DynamoGraphDeploymentRequestStatus) {
 	var restoredSpec *DynamoGraphDeploymentRequestSpec
 	var restoredStatus *DynamoGraphDeploymentRequestStatus
 	if raw, ok := getAnnFromObj(obj, annDGDRSpec); ok && raw != "" {
@@ -186,15 +183,12 @@ func restoreDGDRSpokeAnnotations(obj metav1.Object) (*DynamoGraphDeploymentReque
 		}
 	}
 	if restoredStatus == nil {
-		status, err := restoreDGDRLegacySpokeStatus(obj)
-		if err != nil {
-			return nil, nil, err
-		}
+		status := restoreDGDRLegacySpokeStatus(obj)
 		if !dgdrAlphaStatusSaveIsZero(status) {
 			restoredStatus = status
 		}
 	}
-	return restoredSpec, restoredStatus, nil
+	return restoredSpec, restoredStatus
 }
 
 func scrubDGDRInternalAnnotations(obj metav1.Object) {
@@ -551,7 +545,7 @@ func projectProfilingConfigToProfilingJob(src *ProfilingConfigSpec, dst *v1beta1
 func saveDGDRLegacySpokeAnnotations(srcSpec *DynamoGraphDeploymentRequestSpec, srcStatus *DynamoGraphDeploymentRequestStatus, dst *v1beta1.DynamoGraphDeploymentRequest) {
 	if srcSpec != nil {
 		if srcSpec.EnableGPUDiscovery != nil && *srcSpec.EnableGPUDiscovery {
-			setAnnotation(dst, legacyAnnDGDREnableGPUDisc, "true")
+			setAnnotation(dst, legacyAnnDGDREnableGPUDisc, annotationTrue)
 		}
 		if srcSpec.ProfilingConfig.Config != nil && srcSpec.ProfilingConfig.Config.Raw != nil {
 			setAnnotation(dst, legacyAnnDGDRProfilingConfig, string(srcSpec.ProfilingConfig.Config.Raw))
@@ -981,7 +975,7 @@ func restoreDGDRLegacySpokeSpec(obj metav1.Object) *DynamoGraphDeploymentRequest
 			}
 		}
 	}
-	if raw, ok := getAnnFromObj(obj, legacyAnnDGDREnableGPUDisc); ok && raw == "true" {
+	if raw, ok := getAnnFromObj(obj, legacyAnnDGDREnableGPUDisc); ok && raw == annotationTrue {
 		v := true
 		restored.EnableGPUDiscovery = &v
 	}
@@ -1013,7 +1007,7 @@ func restoreDGDRLegacySpokeSpec(obj metav1.Object) *DynamoGraphDeploymentRequest
 	return restored
 }
 
-func restoreDGDRLegacySpokeStatus(obj metav1.Object) (*DynamoGraphDeploymentRequestStatus, error) {
+func restoreDGDRLegacySpokeStatus(obj metav1.Object) *DynamoGraphDeploymentRequestStatus {
 	restored := &DynamoGraphDeploymentRequestStatus{}
 	if v, ok := getAnnFromObj(obj, legacyAnnDGDRStatusBackend); ok {
 		restored.Backend = v
@@ -1028,7 +1022,7 @@ func restoreDGDRLegacySpokeStatus(obj metav1.Object) (*DynamoGraphDeploymentRequ
 			restored.State = state
 		}
 	}
-	return restored, nil
+	return restored
 }
 
 func restoreDGDRLegacyDeploymentStatus(raw string) (DeploymentStatus, DGDRState, bool) {
@@ -1122,7 +1116,7 @@ func saveDGDRAlphaOnlyStatus(src *DynamoGraphDeploymentRequestStatus, save *Dyna
 	}
 	save.Backend = src.Backend
 	save.ProfilingResults = src.ProfilingResults
-	if !dgdrAlphaStateHasHubPhase(src.State, src.Deployment) {
+	if !dgdrAlphaStateHasHubPhase(src.State) {
 		save.State = src.State
 	}
 	if dgdrAlphaDeploymentNeedsSave(src.State, src.Deployment) {
@@ -1138,7 +1132,7 @@ func dgdrAlphaDeploymentNeedsSave(state DGDRState, deployment *DeploymentStatus)
 	if deployment.Namespace != "" || deployment.State != "" || deployment.Created {
 		return true
 	}
-	return !dgdrAlphaStateHasHubPhase(state, deployment)
+	return !dgdrAlphaStateHasHubPhase(state)
 }
 
 func restoreDGDRAlphaOnlyStatus(restored *DynamoGraphDeploymentRequestStatus, dst *DynamoGraphDeploymentRequestStatus, src *v1beta1.DynamoGraphDeploymentRequestStatus) {
@@ -1205,7 +1199,7 @@ func restoreDGDRHubOnlyStatus(restored *v1beta1.DynamoGraphDeploymentRequestStat
 	}
 }
 
-func dgdrAlphaStateHasHubPhase(state DGDRState, deployment *DeploymentStatus) bool {
+func dgdrAlphaStateHasHubPhase(state DGDRState) bool {
 	return state == "" ||
 		state == DGDRStatePending ||
 		state == DGDRStateProfiling ||

--- a/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion.go
@@ -377,15 +377,16 @@ func saveDGDRAlphaOnlySpec(src *DynamoGraphDeploymentRequestSpec, save *DynamoGr
 }
 
 func saveDGDRAlphaOnlyProfilingConfig(blob dgdrProfilingConfigBlob, save *DynamoGraphDeploymentRequestSpec) {
-	if save == nil || len(blob) == 0 {
-		if save != nil && blob != nil {
-			save.ProfilingConfig.Config = &apiextensionsv1.JSON{Raw: []byte(`{}`)}
-		}
+	if save == nil || blob == nil {
+		return
+	}
+	if len(blob) == 0 {
+		save.ProfilingConfig.Config = &apiextensionsv1.JSON{Raw: []byte(`{}`)}
 		return
 	}
 	remainder := stripDGDRTypedProfilingConfig(blob)
 	if len(remainder) == 0 {
-		remainder = dgdrProfilingConfigBlob{}
+		return
 	}
 	data, err := json.Marshal(remainder)
 	if err != nil {
@@ -633,22 +634,31 @@ func ConvertToDynamoGraphDeploymentRequestSpec(src *v1beta1.DynamoGraphDeploymen
 		blob = stripDGDRTypedProfilingConfig(blob)
 	}
 	if src.SLA != nil || src.Workload != nil {
-		if blob == nil {
-			blob = make(dgdrProfilingConfigBlob)
+		next := blob
+		if next == nil {
+			next = make(dgdrProfilingConfigBlob)
 		}
-		projectSLAAndWorkloadToProfilingConfigBlob(src, blob)
+		if projectSLAAndWorkloadToProfilingConfigBlob(src, next) {
+			blob = next
+		}
 	}
 	if src.ModelCache != nil {
-		if blob == nil {
-			blob = make(dgdrProfilingConfigBlob)
+		next := blob
+		if next == nil {
+			next = make(dgdrProfilingConfigBlob)
 		}
-		projectModelCacheToProfilingConfigBlob(src.ModelCache, blob)
+		if projectModelCacheToProfilingConfigBlob(src.ModelCache, next) {
+			blob = next
+		}
 	}
 	if src.Features != nil && src.Features.Planner != nil {
-		if blob == nil {
-			blob = make(dgdrProfilingConfigBlob)
+		next := blob
+		if next == nil {
+			next = make(dgdrProfilingConfigBlob)
 		}
-		projectPlannerToProfilingConfigBlob(src.Features.Planner, blob)
+		if projectPlannerToProfilingConfigBlob(src.Features.Planner, next) {
+			blob = next
+		}
 	}
 	if blob != nil {
 		if data, err := json.Marshal(blob); err == nil {
@@ -699,23 +709,21 @@ func saveDGDRHubOnlySpec(src *v1beta1.DynamoGraphDeploymentRequestSpec, save *v1
 	if src.Hardware != nil {
 		save.Hardware = src.Hardware.DeepCopy()
 	}
-	if src.Workload != nil {
-		save.Workload = &v1beta1.WorkloadSpec{}
+	if src.Workload != nil && (src.Workload.Concurrency != nil || src.Workload.RequestRate != nil) {
+		workload := &v1beta1.WorkloadSpec{}
 		if src.Workload.Concurrency != nil {
 			v := *src.Workload.Concurrency
-			save.Workload.Concurrency = &v
+			workload.Concurrency = &v
 		}
 		if src.Workload.RequestRate != nil {
 			v := *src.Workload.RequestRate
-			save.Workload.RequestRate = &v
+			workload.RequestRate = &v
 		}
+		save.Workload = workload
 	}
-	if src.SLA != nil {
-		save.SLA = &v1beta1.SLASpec{}
-		if src.SLA.E2ELatency != nil {
-			v := *src.SLA.E2ELatency
-			save.SLA.E2ELatency = &v
-		}
+	if src.SLA != nil && src.SLA.E2ELatency != nil {
+		v := *src.SLA.E2ELatency
+		save.SLA = &v1beta1.SLASpec{E2ELatency: &v}
 	}
 	if src.Overrides != nil {
 		saveDGDRHubOnlyOverrides(src.Overrides, save)
@@ -864,9 +872,9 @@ func dgdrFirstContainerResources(job *batchv1.JobSpec) (corev1.ResourceRequireme
 	return res, !apiequality.Semantic.DeepEqual(res, corev1.ResourceRequirements{})
 }
 
-// projectSLAAndWorkloadToProfilingConfigBlob writes SLA and Workload structured fields back into the JSON blob,
-// overwriting any existing values for those keys.
-func projectSLAAndWorkloadToProfilingConfigBlob(src *v1beta1.DynamoGraphDeploymentRequestSpec, blob map[string]interface{}) {
+// projectSLAAndWorkloadToProfilingConfigBlob writes SLA and Workload structured fields back into the JSON blob.
+// It overwrites existing typed values for those keys and reports whether it wrote or retained SLA data.
+func projectSLAAndWorkloadToProfilingConfigBlob(src *v1beta1.DynamoGraphDeploymentRequestSpec, blob map[string]interface{}) bool {
 	slaMap, hadSLA := blob["sla"].(map[string]interface{})
 	if slaMap == nil {
 		slaMap = make(map[string]interface{})
@@ -899,10 +907,11 @@ func projectSLAAndWorkloadToProfilingConfigBlob(src *v1beta1.DynamoGraphDeployme
 	if wroteSLA || hadSLA {
 		blob["sla"] = slaMap
 	}
+	return wroteSLA || hadSLA
 }
 
 // projectModelCacheToProfilingConfigBlob writes ModelCache structured fields back into blob["deployment"]["modelCache"].
-func projectModelCacheToProfilingConfigBlob(mc *v1beta1.ModelCacheSpec, blob map[string]interface{}) {
+func projectModelCacheToProfilingConfigBlob(mc *v1beta1.ModelCacheSpec, blob map[string]interface{}) bool {
 	deployMap, _ := blob["deployment"].(map[string]interface{})
 	if deployMap == nil {
 		deployMap = make(map[string]interface{})
@@ -920,20 +929,23 @@ func projectModelCacheToProfilingConfigBlob(mc *v1beta1.ModelCacheSpec, blob map
 	if len(mcMap) > 0 {
 		deployMap["modelCache"] = mcMap
 		blob["deployment"] = deployMap
+		return true
 	}
+	return false
 }
 
 // projectPlannerToProfilingConfigBlob writes the planner RawExtension into blob["planner"].
 // The RawExtension is the full PlannerConfig JSON blob (opaque to Go).
-func projectPlannerToProfilingConfigBlob(planner *runtime.RawExtension, blob map[string]interface{}) {
+func projectPlannerToProfilingConfigBlob(planner *runtime.RawExtension, blob map[string]interface{}) bool {
 	if planner == nil || planner.Raw == nil {
-		return
+		return false
 	}
 	var plannerMap map[string]interface{}
 	if err := json.Unmarshal(planner.Raw, &plannerMap); err != nil || len(plannerMap) == 0 {
-		return
+		return false
 	}
 	blob["planner"] = plannerMap
+	return true
 }
 
 // projectPlannerFromProfilingConfigBlob extracts blob["planner"] and populates v1beta1 Features.Planner.
@@ -1078,7 +1090,7 @@ func ConvertFromDynamoGraphDeploymentRequestStatus(src *DynamoGraphDeploymentReq
 	}
 
 	saveDGDRAlphaOnlyStatus(src, save)
-	restoreDGDRHubOnlyStatus(restored, dst)
+	restoreDGDRHubOnlyStatus(restored, dst, src)
 }
 
 // ConvertToDynamoGraphDeploymentRequestStatus converts the DGDR status from
@@ -1101,7 +1113,7 @@ func ConvertToDynamoGraphDeploymentRequestStatus(src *v1beta1.DynamoGraphDeploym
 		}
 	}
 	restoreDGDRAlphaOnlyStatus(restored, dst, src)
-	saveDGDRHubOnlyStatus(src, save)
+	saveDGDRHubOnlyStatus(src, dst, save)
 }
 
 func saveDGDRAlphaOnlyStatus(src *DynamoGraphDeploymentRequestStatus, save *DynamoGraphDeploymentRequestStatus) {
@@ -1113,10 +1125,20 @@ func saveDGDRAlphaOnlyStatus(src *DynamoGraphDeploymentRequestStatus, save *Dyna
 	if !dgdrAlphaStateHasHubPhase(src.State, src.Deployment) {
 		save.State = src.State
 	}
-	if src.Deployment != nil {
+	if dgdrAlphaDeploymentNeedsSave(src.State, src.Deployment) {
 		save.State = src.State
 		save.Deployment = src.Deployment.DeepCopy()
 	}
+}
+
+func dgdrAlphaDeploymentNeedsSave(state DGDRState, deployment *DeploymentStatus) bool {
+	if deployment == nil {
+		return false
+	}
+	if deployment.Namespace != "" || deployment.State != "" || deployment.Created {
+		return true
+	}
+	return !dgdrAlphaStateHasHubPhase(state, deployment)
 }
 
 func restoreDGDRAlphaOnlyStatus(restored *DynamoGraphDeploymentRequestStatus, dst *DynamoGraphDeploymentRequestStatus, src *v1beta1.DynamoGraphDeploymentRequestStatus) {
@@ -1135,11 +1157,11 @@ func restoreDGDRAlphaOnlyStatus(restored *DynamoGraphDeploymentRequestStatus, ds
 	}
 }
 
-func saveDGDRHubOnlyStatus(src *v1beta1.DynamoGraphDeploymentRequestStatus, save *v1beta1.DynamoGraphDeploymentRequestStatus) {
+func saveDGDRHubOnlyStatus(src *v1beta1.DynamoGraphDeploymentRequestStatus, dst *DynamoGraphDeploymentRequestStatus, save *v1beta1.DynamoGraphDeploymentRequestStatus) {
 	if src == nil || save == nil {
 		return
 	}
-	if src.Phase == v1beta1.DGDRPhaseDeployed {
+	if src.Phase == v1beta1.DGDRPhaseDeployed && dgdrStateToPhase(string(dst.State), dst.Deployment) != src.Phase {
 		save.Phase = src.Phase
 	}
 	save.ProfilingPhase = src.ProfilingPhase
@@ -1153,11 +1175,14 @@ func saveDGDRHubOnlyStatus(src *v1beta1.DynamoGraphDeploymentRequestStatus, save
 	}
 }
 
-func restoreDGDRHubOnlyStatus(restored *v1beta1.DynamoGraphDeploymentRequestStatus, dst *v1beta1.DynamoGraphDeploymentRequestStatus) {
+func restoreDGDRHubOnlyStatus(restored *v1beta1.DynamoGraphDeploymentRequestStatus, dst *v1beta1.DynamoGraphDeploymentRequestStatus, src *DynamoGraphDeploymentRequestStatus) {
 	if restored == nil || dst == nil {
 		return
 	}
-	if restored.Phase == v1beta1.DGDRPhaseDeployed && dst.Phase == v1beta1.DGDRPhaseReady {
+	if restored.Phase == v1beta1.DGDRPhaseDeployed &&
+		dst.Phase == v1beta1.DGDRPhaseReady &&
+		src != nil &&
+		dgdrAlphaStatusMatchesHubPhase(src.State, src.Deployment, restored.Phase) {
 		dst.Phase = v1beta1.DGDRPhaseDeployed
 	}
 	dst.ProfilingPhase = restored.ProfilingPhase
@@ -1184,7 +1209,10 @@ func dgdrAlphaStateHasHubPhase(state DGDRState, deployment *DeploymentStatus) bo
 
 func dgdrAlphaStatusMatchesHubPhase(state DGDRState, deployment *DeploymentStatus, phase v1beta1.DGDRPhase) bool {
 	alphaPhase := dgdrStateToPhase(string(state), deployment)
-	return alphaPhase == phase || phase == v1beta1.DGDRPhaseDeployed && alphaPhase == v1beta1.DGDRPhaseReady
+	if alphaPhase == phase {
+		return true
+	}
+	return phase == v1beta1.DGDRPhaseDeployed && state == DGDRStateReady
 }
 
 // restoreDGDRDeploymentStatus ignores stale deployment-status overlays after hub-side status edits.

--- a/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion.go
@@ -17,156 +17,63 @@
 
 // Conversion between v1alpha1 and v1beta1 DynamoGraphDeploymentRequest (DGDR).
 //
-// The two API versions have fundamentally different shapes: v1alpha1 stores SLA,
-// workload, and model-cache configuration inside an opaque JSON blob
-// (ProfilingConfig.Config), while v1beta1 breaks these out into typed structs.
-// This file bridges the two representations.
+// v1beta1 is the hub. DGDR conversion predates the structural DGD/DCD cleanup,
+// so this file reads legacy Dynamo 1.0/1.1 annotations and still writes them for
+// downgrade compatibility. New preservation uses sparse nvidia.com/dgdr-spec and
+// nvidia.com/dgdr-status annotations.
 //
-// # Spec field mapping
+// Live source fields are authoritative. Preservation annotations are old-value
+// caches only for fields the live source version cannot represent.
 //
-// 1:1 simple mappings (value copied, path or wrapper type differs):
+// The main spec projections are:
 //
-//	v1alpha1                                   v1beta1
-//	──────────────────────────────────────────  ──────────────────────────────────────
-//	Spec.Model              (string)           Spec.Model                    (string)
-//	Spec.Backend            (string)           Spec.Backend              (BackendType)
-//	Spec.AutoApply          (bool)             Spec.AutoApply                 (*bool)
-//	Spec.UseMocker          (bool)             Spec.Features.Mocker.Enabled    (bool)
-//	Spec.ProfilingConfig.ProfilerImage         Spec.Image                    (string)
-//	Spec.DeploymentOverrides.WorkersImage      (no v1beta1 equivalent yet — TODO: overrides.dgd)
+//   - v1alpha1 ProfilingConfig.Config JSON keys under sla, deployment.modelCache,
+//     and planner map to v1beta1 SLA, Workload, ModelCache, and Features.Planner.
+//   - v1alpha1 ProfilingConfig.Resources, Tolerations, and NodeSelector map to
+//     v1beta1 Overrides.ProfilingJob pod fields.
+//   - v1alpha1-only spec fields are saved sparsely in annDGDRSpec and, for
+//     downgrade compatibility, in legacyAnnDGDR* annotations.
+//   - v1beta1-only spec fields such as Hardware, Workload Concurrency/RequestRate,
+//     SLA E2ELatency, Overrides.DGD, hub-only ProfilingJob leaves, disabled Mocker,
+//     and SearchStrategy are saved sparsely in annDGDRSpec.
 //
-// JSON blob → structured fields (parsed/reconstructed on each trip):
-//
-//	Blob key path                              v1beta1 field
-//	──────────────────────────────────────────  ──────────────────────────────────────
-//	sla.ttft                                   Spec.SLA.TTFT             (*float64)
-//	sla.itl                                    Spec.SLA.ITL              (*float64)
-//	sla.isl                                    Spec.Workload.ISL           (*int32)
-//	sla.osl                                    Spec.Workload.OSL           (*int32)
-//	deployment.modelCache.pvcName              Spec.ModelCache.PVCName       (string)
-//	deployment.modelCache.modelPathInPvc       Spec.ModelCache.PVCModelPath  (string)
-//	deployment.modelCache.pvcMountPath         Spec.ModelCache.PVCMountPath  (string)
-//
-// The full JSON blob is also preserved as the annotation
-// nvidia.com/dgdr-profiling-config so that unknown keys survive the round-trip.
-// On ConvertFrom the blob is loaded from the annotation first, then the
-// structured v1beta1 fields are written on top (structured fields win).
-//
-// Structural reshaping (same data, different container type):
-//
-//	v1alpha1                                   v1beta1
-//	──────────────────────────────────────────  ──────────────────────────────────────
-//	ProfilingConfig.Resources                  Overrides.ProfilingJob.Template.
-//	  (*corev1.ResourceRequirements)             Spec.Containers[0].Resources
-//	ProfilingConfig.Tolerations                Overrides.ProfilingJob.Template.
-//	  ([]corev1.Toleration)                      Spec.Tolerations
-//
-// Annotation-only (no v1beta1 equivalent; round-tripped via ObjectMeta annotations):
-//
-//	v1alpha1 field                             Annotation key
-//	──────────────────────────────────────────  ──────────────────────────────────────
-//	Spec.EnableGPUDiscovery                    nvidia.com/dgdr-enable-gpu-discovery
-//	Spec.ProfilingConfig.ConfigMapRef          nvidia.com/dgdr-config-map-ref
-//	Spec.ProfilingConfig.OutputPVC             nvidia.com/dgdr-output-pvc
-//	Spec.ProfilingConfig.Config (full blob)    nvidia.com/dgdr-profiling-config
-//	Spec.DeploymentOverrides.{Name,            nvidia.com/dgdr-deployment-overrides
-//	  Namespace,Labels,Annotations}
-//
-// Planner config (opaque blob stored verbatim under blob["planner"]):
-//
-//	v1beta1                                    blob key
-//	──────────────────────────────────────────  ──────────────────────────────────────
-//	Features.Planner (*runtime.RawExtension)   planner.*  (JSON fields written directly)
-//
-// v1beta1-only fields with no v1alpha1 equivalent (omitted / TODO):
-//
-//	Hardware.*, Workload.{Concurrency,RequestRate}, SLA.{E2ELatency},
-//	Features.{KVRouter}, SearchStrategy
-//
-// # Status field mapping
-//
-// 1:1 simple mappings:
-//
-//	v1alpha1                                   v1beta1
-//	──────────────────────────────────────────  ──────────────────────────────────────
-//	Status.ObservedGeneration                  Status.ObservedGeneration
-//	Status.Conditions                          Status.Conditions
-//	Status.GeneratedDeployment                 Status.ProfilingResults.SelectedConfig
-//	Status.Deployment.Name                     Status.DGDName
-//
-// State ↔ Phase (many-to-one, context-dependent):
-//
-//	v1alpha1 State         → v1beta1 Phase     Notes
-//	───────────────────────  ─────────────────  ─────────────────────────────────
-//	"" / "Pending"           Pending
-//	"Profiling"              Profiling
-//	"Ready"                  Ready or Deployed  Deployed if Deployment.Created
-//	"Deploying"              Deploying
-//	"DeploymentDeleted"      Ready              lossy
-//	"Failed"                 Failed
-//
-//	v1beta1 Phase          → v1alpha1 State
-//	───────────────────────  ─────────────────
-//	Pending                  "Pending"
-//	Profiling                "Profiling"
-//	Ready                    "Ready"
-//	Deploying                "Deploying"
-//	Deployed                 "Ready"            lossy
-//	Failed                   "Failed"
-//
-// Annotation-only status fields (no v1beta1 equivalent):
-//
-//	v1alpha1 field                             Annotation key
-//	──────────────────────────────────────────  ──────────────────────────────────────
-//	Status.Backend                             nvidia.com/dgdr-status-backend
-//	Status.ProfilingResults (string ref,       nvidia.com/dgdr-profiling-results
-//	  e.g. "configmap/<name>")                   (not the v1beta1 struct — see below)
-//	Status.Deployment.{Namespace,State,        nvidia.com/dgdr-deployment-status
-//	  Created}                                   (JSON-encoded; Name maps to DGDName)
-//
-// Note on ProfilingResults naming collision: the two versions both have a field
-// called "ProfilingResults" but with entirely different types. v1alpha1 has a
-// plain string (a configmap reference). v1beta1 has a struct with Pareto and
-// SelectedConfig. The string is annotation-preserved; the struct's
-// SelectedConfig maps from v1alpha1 GeneratedDeployment (see 1:1 table above).
-//
-// Note: v1alpha1 DeploymentStatus{Name,Namespace,State,Created} and v1beta1
-// DeploymentInfoStatus{Replicas,AvailableReplicas} share no common fields —
-// they track different aspects of the DGD. Only Deployment.Name ↔ DGDName
-// overlaps. The rest of DeploymentStatus is round-tripped via annotation;
-// DeploymentInfoStatus has no v1alpha1 source and is left empty.
-//
-// v1beta1-only status fields with no v1alpha1 equivalent (omitted / TODO):
-//
-//	Status.DeploymentInfo.{Replicas,AvailableReplicas},
-//	Status.ProfilingPhase, Status.ProfilingJobName,
-//	Status.ProfilingResults.Pareto
+// Status follows the same rules: common fields are converted from live source,
+// alpha-only status is saved in annDGDRStatus and legacy annotations, and
+// hub-only status such as ProfilingPhase, ProfilingJobName, Pareto results,
+// DeploymentInfo, and the Deployed phase is saved in annDGDRStatus.
 
 package v1alpha1
 
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
+	"slices"
 
 	v1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 )
 
-// Annotation keys used to round-trip v1alpha1 fields that have no v1beta1 equivalent.
 const (
-	annDGDRConfigMapRef     = "nvidia.com/dgdr-config-map-ref"
-	annDGDROutputPVC        = "nvidia.com/dgdr-output-pvc"
-	annDGDREnableGPUDisc    = "nvidia.com/dgdr-enable-gpu-discovery"
-	annDGDRDeployOverrides  = "nvidia.com/dgdr-deployment-overrides"
-	annDGDRProfilingConfig  = "nvidia.com/dgdr-profiling-config"
-	annDGDRStatusBackend    = "nvidia.com/dgdr-status-backend"
-	annDGDRProfilingResults = "nvidia.com/dgdr-profiling-results"
-	annDGDRDeploymentStatus = "nvidia.com/dgdr-deployment-status"
-	annDGDRProfilingJobName = "nvidia.com/dgdr-profiling-job-name"
+	annDGDRSpec   = "nvidia.com/dgdr-spec"
+	annDGDRStatus = "nvidia.com/dgdr-status"
+
+	// TODO(sttts): remove after 1.2 when downgrade does not matter anymore.
+	legacyAnnDGDRConfigMapRef     = "nvidia.com/dgdr-config-map-ref"
+	legacyAnnDGDROutputPVC        = "nvidia.com/dgdr-output-pvc"
+	legacyAnnDGDREnableGPUDisc    = "nvidia.com/dgdr-enable-gpu-discovery"
+	legacyAnnDGDRDeployOverrides  = "nvidia.com/dgdr-deployment-overrides"
+	legacyAnnDGDRProfilingConfig  = "nvidia.com/dgdr-profiling-config"
+	legacyAnnDGDRStatusBackend    = "nvidia.com/dgdr-status-backend"
+	legacyAnnDGDRProfilingResults = "nvidia.com/dgdr-profiling-results"
+	legacyAnnDGDRDeploymentStatus = "nvidia.com/dgdr-deployment-status"
+	legacyAnnDGDRProfilingJobName = "nvidia.com/dgdr-profiling-job-name"
 )
 
 // dgdrDeploymentStatusAnnotation preserves alpha deployment status with its source request state.
@@ -174,6 +81,8 @@ type dgdrDeploymentStatusAnnotation struct {
 	DeploymentStatus
 	RequestState DGDRState `json:"requestState,omitempty"`
 }
+
+type dgdrProfilingConfigBlob = map[string]any
 
 // ConvertTo converts this DynamoGraphDeploymentRequest (v1alpha1) to the Hub version (v1beta1).
 func (src *DynamoGraphDeploymentRequest) ConvertTo(dstRaw conversion.Hub) error {
@@ -184,11 +93,19 @@ func (src *DynamoGraphDeploymentRequest) ConvertTo(dstRaw conversion.Hub) error 
 
 	dst.ObjectMeta = *src.ObjectMeta.DeepCopy()
 
-	if err := convertDGDRSpecTo(&src.Spec, &dst.Spec, dst); err != nil {
+	restoredHubSpec, restoredHubStatus := restoreDGDRHubAnnotations(&dst.ObjectMeta)
+	scrubDGDRInternalAnnotations(&dst.ObjectMeta)
+
+	var spokeSpecSave DynamoGraphDeploymentRequestSpec
+	if err := ConvertFromDynamoGraphDeploymentRequestSpec(&src.Spec, &dst.Spec, restoredHubSpec, &spokeSpecSave); err != nil {
 		return err
 	}
 
-	convertDGDRStatusTo(&src.Status, &dst.Status, dst)
+	var spokeStatusSave DynamoGraphDeploymentRequestStatus
+	ConvertFromDynamoGraphDeploymentRequestStatus(&src.Status, &dst.Status, restoredHubStatus, &spokeStatusSave)
+	if err := saveDGDRSpokeAnnotations(&src.Spec, &spokeSpecSave, &src.Status, &spokeStatusSave, dst); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -202,16 +119,19 @@ func (dst *DynamoGraphDeploymentRequest) ConvertFrom(srcRaw conversion.Hub) erro
 
 	dst.ObjectMeta = *src.ObjectMeta.DeepCopy()
 
-	convertDGDRSpecFrom(&src.Spec, &dst.Spec, src)
-	convertDGDRStatusFrom(&src.Status, &dst.Status, src)
-	delAnnFromObj(&dst.ObjectMeta, annDGDRDeploymentStatus)
+	restoredSpokeSpec, restoredSpokeStatus, err := restoreDGDRSpokeAnnotations(&dst.ObjectMeta)
+	if err != nil {
+		return err
+	}
+	scrubDGDRInternalAnnotations(&dst.ObjectMeta)
 
-	// ProfilingJobName — no v1alpha1 status field; store as annotation for round-trip
-	if src.Status.ProfilingJobName != "" {
-		if dst.Annotations == nil {
-			dst.Annotations = make(map[string]string)
-		}
-		dst.Annotations[annDGDRProfilingJobName] = src.Status.ProfilingJobName
+	var hubSpecSave v1beta1.DynamoGraphDeploymentRequestSpec
+	ConvertToDynamoGraphDeploymentRequestSpec(&src.Spec, &dst.Spec, restoredSpokeSpec, &hubSpecSave)
+
+	var hubStatusSave v1beta1.DynamoGraphDeploymentRequestStatus
+	ConvertToDynamoGraphDeploymentRequestStatus(&src.Status, &dst.Status, restoredSpokeStatus, &hubStatusSave)
+	if err := saveDGDRHubAnnotations(&hubSpecSave, &src.Status, &hubStatusSave, dst); err != nil {
+		return err
 	}
 
 	return nil
@@ -225,10 +145,172 @@ func setAnnotation(obj *v1beta1.DynamoGraphDeploymentRequest, key, value string)
 	obj.Annotations[key] = value
 }
 
-// convertDGDRSpecTo converts the v1alpha1 Spec into the v1beta1 Spec.
-func convertDGDRSpecTo(src *DynamoGraphDeploymentRequestSpec, dst *v1beta1.DynamoGraphDeploymentRequestSpec, dstObj *v1beta1.DynamoGraphDeploymentRequest) error {
+func restoreDGDRHubAnnotations(obj metav1.Object) (*v1beta1.DynamoGraphDeploymentRequestSpec, *v1beta1.DynamoGraphDeploymentRequestStatus) {
+	var restoredSpec *v1beta1.DynamoGraphDeploymentRequestSpec
+	var restoredStatus *v1beta1.DynamoGraphDeploymentRequestStatus
+	if raw, ok := getAnnFromObj(obj, annDGDRSpec); ok && raw != "" {
+		if spec, ok := restoreDGDRHubSpec(raw); ok {
+			restoredSpec = &spec
+		}
+	}
+	if raw, ok := getAnnFromObj(obj, annDGDRStatus); ok && raw != "" {
+		if status, ok := restoreDGDRHubStatus(raw); ok {
+			restoredStatus = &status
+		}
+	}
+	if raw, ok := getAnnFromObj(obj, legacyAnnDGDRProfilingJobName); ok && raw != "" {
+		if restoredStatus == nil {
+			restoredStatus = &v1beta1.DynamoGraphDeploymentRequestStatus{}
+		}
+		restoredStatus.ProfilingJobName = raw
+	}
+	return restoredSpec, restoredStatus
+}
+
+func restoreDGDRSpokeAnnotations(obj metav1.Object) (*DynamoGraphDeploymentRequestSpec, *DynamoGraphDeploymentRequestStatus, error) {
+	var restoredSpec *DynamoGraphDeploymentRequestSpec
+	var restoredStatus *DynamoGraphDeploymentRequestStatus
+	if raw, ok := getAnnFromObj(obj, annDGDRSpec); ok && raw != "" {
+		if spec, ok := restoreDGDRSpokeSpec(raw); ok {
+			restoredSpec = &spec
+		}
+	}
+	if restoredSpec == nil {
+		if spec := restoreDGDRLegacySpokeSpec(obj); !dgdrAlphaSpecSaveIsZero(spec) {
+			restoredSpec = spec
+		}
+	}
+	if raw, ok := getAnnFromObj(obj, annDGDRStatus); ok && raw != "" {
+		if status, ok := restoreDGDRSpokeStatus(raw); ok {
+			restoredStatus = &status
+		}
+	}
+	if restoredStatus == nil {
+		status, err := restoreDGDRLegacySpokeStatus(obj)
+		if err != nil {
+			return nil, nil, err
+		}
+		if !dgdrAlphaStatusSaveIsZero(status) {
+			restoredStatus = status
+		}
+	}
+	return restoredSpec, restoredStatus, nil
+}
+
+func scrubDGDRInternalAnnotations(obj metav1.Object) {
+	for _, key := range []string{
+		annDGDRSpec,
+		annDGDRStatus,
+		legacyAnnDGDRConfigMapRef,
+		legacyAnnDGDROutputPVC,
+		legacyAnnDGDREnableGPUDisc,
+		legacyAnnDGDRDeployOverrides,
+		legacyAnnDGDRProfilingConfig,
+		legacyAnnDGDRStatusBackend,
+		legacyAnnDGDRProfilingResults,
+		legacyAnnDGDRDeploymentStatus,
+		legacyAnnDGDRProfilingJobName,
+	} {
+		delAnnFromObj(obj, key)
+	}
+}
+
+func saveDGDRSpokeAnnotations(srcSpec *DynamoGraphDeploymentRequestSpec, specSave *DynamoGraphDeploymentRequestSpec, srcStatus *DynamoGraphDeploymentRequestStatus, statusSave *DynamoGraphDeploymentRequestStatus, dst *v1beta1.DynamoGraphDeploymentRequest) error {
+	if !dgdrAlphaSpecSaveIsZero(specSave) {
+		data, err := marshalDGDRSpokeSpec(specSave)
+		if err != nil {
+			return fmt.Errorf("preserve DGDR spoke spec: %w", err)
+		}
+		setAnnOnObj(&dst.ObjectMeta, annDGDRSpec, string(data))
+	}
+	if !dgdrAlphaStatusSaveIsZero(statusSave) {
+		if err := setJSONAnnOnObj(&dst.ObjectMeta, annDGDRStatus, statusSave); err != nil {
+			return err
+		}
+	}
+	saveDGDRLegacySpokeAnnotations(srcSpec, srcStatus, dst)
+	return nil
+}
+
+func saveDGDRHubAnnotations(specSave *v1beta1.DynamoGraphDeploymentRequestSpec, srcStatus *v1beta1.DynamoGraphDeploymentRequestStatus, statusSave *v1beta1.DynamoGraphDeploymentRequestStatus, dst *DynamoGraphDeploymentRequest) error {
+	if !dgdrHubSpecSaveIsZero(specSave) {
+		data, err := marshalDGDRHubSpec(specSave)
+		if err != nil {
+			return fmt.Errorf("preserve DGDR hub spec: %w", err)
+		}
+		setAnnOnObj(&dst.ObjectMeta, annDGDRSpec, string(data))
+	}
+	if !dgdrHubStatusSaveIsZero(statusSave) {
+		if err := setJSONAnnOnObj(&dst.ObjectMeta, annDGDRStatus, statusSave); err != nil {
+			return err
+		}
+	}
+	if srcStatus != nil && srcStatus.ProfilingJobName != "" {
+		setAnnOnObj(&dst.ObjectMeta, legacyAnnDGDRProfilingJobName, srcStatus.ProfilingJobName)
+	}
+	return nil
+}
+
+func dgdrAlphaSpecSaveIsZero(save *DynamoGraphDeploymentRequestSpec) bool {
+	if save == nil {
+		return true
+	}
+	if save.ProfilingConfig.Config != nil {
+		return false
+	}
+	return apiequality.Semantic.DeepEqual(*save, DynamoGraphDeploymentRequestSpec{})
+}
+
+func dgdrAlphaStatusSaveIsZero(save *DynamoGraphDeploymentRequestStatus) bool {
+	return save == nil || apiequality.Semantic.DeepEqual(*save, DynamoGraphDeploymentRequestStatus{})
+}
+
+func dgdrHubSpecSaveIsZero(save *v1beta1.DynamoGraphDeploymentRequestSpec) bool {
+	return save == nil || apiequality.Semantic.DeepEqual(*save, v1beta1.DynamoGraphDeploymentRequestSpec{})
+}
+
+func dgdrHubStatusSaveIsZero(save *v1beta1.DynamoGraphDeploymentRequestStatus) bool {
+	return save == nil || apiequality.Semantic.DeepEqual(*save, v1beta1.DynamoGraphDeploymentRequestStatus{})
+}
+
+func marshalDGDRHubSpec(src *v1beta1.DynamoGraphDeploymentRequestSpec) ([]byte, error) {
+	return marshalPreservedSpec(*src.DeepCopy(), nil)
+}
+
+func restoreDGDRHubSpec(raw string) (v1beta1.DynamoGraphDeploymentRequestSpec, bool) {
+	return restorePreservedSpec[v1beta1.DynamoGraphDeploymentRequestSpec](raw, nil)
+}
+
+func marshalDGDRSpokeSpec(src *DynamoGraphDeploymentRequestSpec) ([]byte, error) {
+	return marshalPreservedSpec(*src.DeepCopy(), nil)
+}
+
+func restoreDGDRSpokeSpec(raw string) (DynamoGraphDeploymentRequestSpec, bool) {
+	return restorePreservedSpec[DynamoGraphDeploymentRequestSpec](raw, nil)
+}
+
+func restoreDGDRHubStatus(raw string) (v1beta1.DynamoGraphDeploymentRequestStatus, bool) {
+	var status v1beta1.DynamoGraphDeploymentRequestStatus
+	if err := json.Unmarshal([]byte(raw), &status); err != nil {
+		return v1beta1.DynamoGraphDeploymentRequestStatus{}, false
+	}
+	return status, true
+}
+
+func restoreDGDRSpokeStatus(raw string) (DynamoGraphDeploymentRequestStatus, bool) {
+	var status DynamoGraphDeploymentRequestStatus
+	if err := json.Unmarshal([]byte(raw), &status); err != nil {
+		return DynamoGraphDeploymentRequestStatus{}, false
+	}
+	return status, true
+}
+
+// ConvertFromDynamoGraphDeploymentRequestSpec converts the DGDR spec from
+// v1alpha1 to v1beta1.
+func ConvertFromDynamoGraphDeploymentRequestSpec(src *DynamoGraphDeploymentRequestSpec, dst *v1beta1.DynamoGraphDeploymentRequestSpec, restored *v1beta1.DynamoGraphDeploymentRequestSpec, save *DynamoGraphDeploymentRequestSpec) error {
 	dst.Model = src.Model
-	dst.AutoApply = &src.AutoApply
+	autoApply := src.AutoApply
+	dst.AutoApply = &autoApply
 
 	if src.Backend != "" {
 		dst.Backend = v1beta1.BackendType(src.Backend)
@@ -242,19 +324,16 @@ func convertDGDRSpecTo(src *DynamoGraphDeploymentRequestSpec, dst *v1beta1.Dynam
 		}
 		dst.Features.Mocker = &v1beta1.MockerSpec{Enabled: true}
 	}
-	if src.EnableGPUDiscovery != nil && *src.EnableGPUDiscovery {
-		setAnnotation(dstObj, annDGDREnableGPUDisc, "true")
-	}
 
 	if src.ProfilingConfig.Config != nil && src.ProfilingConfig.Config.Raw != nil {
-		var blob map[string]interface{}
+		var blob dgdrProfilingConfigBlob
 		if err := json.Unmarshal(src.ProfilingConfig.Config.Raw, &blob); err != nil {
 			return fmt.Errorf("failed to parse ProfilingConfig.Config: %w", err)
 		}
-		applySLAAndWorkloadFromBlob(blob, dst)
-		applyModelCacheFromBlob(blob, dst)
-		applyPlannerFromBlob(blob, dst)
-		setAnnotation(dstObj, annDGDRProfilingConfig, string(src.ProfilingConfig.Config.Raw))
+		projectSLAAndWorkloadFromProfilingConfigBlob(blob, dst)
+		projectModelCacheFromProfilingConfigBlob(blob, dst)
+		projectPlannerFromProfilingConfigBlob(blob, dst)
+		saveDGDRAlphaOnlyProfilingConfig(blob, save)
 	}
 
 	// ProfilerImage → Image (the profiler runs in the frontend image)
@@ -262,24 +341,107 @@ func convertDGDRSpecTo(src *DynamoGraphDeploymentRequestSpec, dst *v1beta1.Dynam
 	if src.ProfilingConfig.ProfilerImage != "" {
 		dst.Image = src.ProfilingConfig.ProfilerImage
 	}
-	if src.ProfilingConfig.ConfigMapRef != nil {
-		if data, err := json.Marshal(src.ProfilingConfig.ConfigMapRef); err == nil {
-			setAnnotation(dstObj, annDGDRConfigMapRef, string(data))
-		}
-	}
-	if src.ProfilingConfig.OutputPVC != "" {
-		setAnnotation(dstObj, annDGDROutputPVC, src.ProfilingConfig.OutputPVC)
-	}
 
-	convertProfilingResourcesToOverrides(&src.ProfilingConfig, dst)
-	convertDeploymentOverridesToAnnotation(src.DeploymentOverrides, dstObj)
+	projectProfilingConfigToProfilingJob(&src.ProfilingConfig, dst)
+	saveDGDRAlphaOnlySpec(src, save)
+	restoreDGDRHubOnlySpec(restored, dst)
 
 	return nil
 }
 
-// applySLAAndWorkloadFromBlob extracts SLA and Workload fields from the v1alpha1 JSON blob.
+func saveDGDRAlphaOnlySpec(src *DynamoGraphDeploymentRequestSpec, save *DynamoGraphDeploymentRequestSpec) {
+	if src == nil || save == nil {
+		return
+	}
+	if src.EnableGPUDiscovery != nil {
+		v := *src.EnableGPUDiscovery
+		save.EnableGPUDiscovery = &v
+	}
+	if src.ProfilingConfig.ConfigMapRef != nil {
+		ref := *src.ProfilingConfig.ConfigMapRef
+		save.ProfilingConfig.ConfigMapRef = &ref
+	}
+	save.ProfilingConfig.OutputPVC = src.ProfilingConfig.OutputPVC
+	if src.DeploymentOverrides != nil {
+		overrides := &DeploymentOverridesSpec{
+			Name:         src.DeploymentOverrides.Name,
+			Namespace:    src.DeploymentOverrides.Namespace,
+			Labels:       maps.Clone(src.DeploymentOverrides.Labels),
+			Annotations:  maps.Clone(src.DeploymentOverrides.Annotations),
+			WorkersImage: src.DeploymentOverrides.WorkersImage,
+		}
+		if !apiequality.Semantic.DeepEqual(*overrides, DeploymentOverridesSpec{}) {
+			save.DeploymentOverrides = overrides
+		}
+	}
+}
+
+func saveDGDRAlphaOnlyProfilingConfig(blob dgdrProfilingConfigBlob, save *DynamoGraphDeploymentRequestSpec) {
+	if save == nil || len(blob) == 0 {
+		if save != nil && blob != nil {
+			save.ProfilingConfig.Config = &apiextensionsv1.JSON{Raw: []byte(`{}`)}
+		}
+		return
+	}
+	remainder := stripDGDRTypedProfilingConfig(blob)
+	if len(remainder) == 0 {
+		remainder = dgdrProfilingConfigBlob{}
+	}
+	data, err := json.Marshal(remainder)
+	if err != nil {
+		return
+	}
+	save.ProfilingConfig.Config = &apiextensionsv1.JSON{Raw: data}
+}
+
+func restoreDGDRHubOnlySpec(restored *v1beta1.DynamoGraphDeploymentRequestSpec, dst *v1beta1.DynamoGraphDeploymentRequestSpec) {
+	if restored == nil || dst == nil {
+		return
+	}
+	if restored.Hardware != nil {
+		dst.Hardware = restored.Hardware.DeepCopy()
+	}
+	if restored.Workload != nil {
+		if dst.Workload == nil {
+			dst.Workload = &v1beta1.WorkloadSpec{}
+		}
+		if restored.Workload.Concurrency != nil {
+			v := *restored.Workload.Concurrency
+			dst.Workload.Concurrency = &v
+		}
+		if restored.Workload.RequestRate != nil {
+			v := *restored.Workload.RequestRate
+			dst.Workload.RequestRate = &v
+		}
+	}
+	if restored.SLA != nil {
+		if dst.SLA == nil {
+			dst.SLA = &v1beta1.SLASpec{}
+		}
+		if restored.SLA.E2ELatency != nil {
+			v := *restored.SLA.E2ELatency
+			dst.SLA.E2ELatency = &v
+		}
+	}
+	if restored.Overrides != nil {
+		restoreDGDRHubOnlyOverrides(restored.Overrides, dst)
+	}
+	if restored.Features != nil && restored.Features.Mocker != nil && !restored.Features.Mocker.Enabled {
+		if dst.Features == nil {
+			dst.Features = &v1beta1.FeaturesSpec{}
+		}
+		if dst.Features.Mocker == nil {
+			dst.Features.Mocker = &v1beta1.MockerSpec{Enabled: false}
+		}
+	}
+	if restored.SearchStrategy != "" {
+		dst.SearchStrategy = restored.SearchStrategy
+	}
+}
+
+// projectSLAAndWorkloadFromProfilingConfigBlob extracts SLA and Workload fields from the v1alpha1 JSON blob.
 // Both are nested under blob["sla"] in the v1alpha1 schema.
-func applySLAAndWorkloadFromBlob(blob map[string]interface{}, dst *v1beta1.DynamoGraphDeploymentRequestSpec) {
+func projectSLAAndWorkloadFromProfilingConfigBlob(blob map[string]interface{}, dst *v1beta1.DynamoGraphDeploymentRequestSpec) {
 	slaRaw, ok := blob["sla"]
 	if !ok {
 		return
@@ -321,8 +483,8 @@ func applySLAAndWorkloadFromBlob(blob map[string]interface{}, dst *v1beta1.Dynam
 	}
 }
 
-// applyModelCacheFromBlob extracts ModelCache from blob["deployment"]["modelCache"].
-func applyModelCacheFromBlob(blob map[string]interface{}, dst *v1beta1.DynamoGraphDeploymentRequestSpec) {
+// projectModelCacheFromProfilingConfigBlob extracts ModelCache from blob["deployment"]["modelCache"].
+func projectModelCacheFromProfilingConfigBlob(blob map[string]interface{}, dst *v1beta1.DynamoGraphDeploymentRequestSpec) {
 	deployRaw, ok := blob["deployment"]
 	if !ok {
 		return
@@ -353,10 +515,10 @@ func applyModelCacheFromBlob(blob map[string]interface{}, dst *v1beta1.DynamoGra
 	dst.ModelCache = mc
 }
 
-// convertProfilingResourcesToOverrides maps ProfilingConfig Resources and Tolerations
-// into the v1beta1 Overrides.ProfilingJob pod spec.
-func convertProfilingResourcesToOverrides(src *ProfilingConfigSpec, dst *v1beta1.DynamoGraphDeploymentRequestSpec) {
-	if src.Resources == nil && len(src.Tolerations) == 0 {
+// projectProfilingConfigToProfilingJob maps ProfilingConfig pod-level fields into
+// the v1beta1 Overrides.ProfilingJob pod spec.
+func projectProfilingConfigToProfilingJob(src *ProfilingConfigSpec, dst *v1beta1.DynamoGraphDeploymentRequestSpec) {
+	if src.Resources == nil && len(src.Tolerations) == 0 && len(src.NodeSelector) == 0 {
 		return
 	}
 	if dst.Overrides == nil {
@@ -380,12 +542,49 @@ func convertProfilingResourcesToOverrides(src *ProfilingConfigSpec, dst *v1beta1
 	if len(src.Tolerations) > 0 {
 		podSpec.Tolerations = src.Tolerations
 	}
+	if len(src.NodeSelector) > 0 {
+		podSpec.NodeSelector = maps.Clone(src.NodeSelector)
+	}
 }
 
-// convertDeploymentOverridesToAnnotation serialises the DeploymentOverrides metadata fields
-// (Name, Namespace, Labels, Annotations) into an annotation for round-trip.
-// WorkersImage is handled separately via dst.Image.
-func convertDeploymentOverridesToAnnotation(src *DeploymentOverridesSpec, dstObj *v1beta1.DynamoGraphDeploymentRequest) {
+func saveDGDRLegacySpokeAnnotations(srcSpec *DynamoGraphDeploymentRequestSpec, srcStatus *DynamoGraphDeploymentRequestStatus, dst *v1beta1.DynamoGraphDeploymentRequest) {
+	if srcSpec != nil {
+		if srcSpec.EnableGPUDiscovery != nil && *srcSpec.EnableGPUDiscovery {
+			setAnnotation(dst, legacyAnnDGDREnableGPUDisc, "true")
+		}
+		if srcSpec.ProfilingConfig.Config != nil && srcSpec.ProfilingConfig.Config.Raw != nil {
+			setAnnotation(dst, legacyAnnDGDRProfilingConfig, string(srcSpec.ProfilingConfig.Config.Raw))
+		}
+		if srcSpec.ProfilingConfig.ConfigMapRef != nil {
+			if data, err := json.Marshal(srcSpec.ProfilingConfig.ConfigMapRef); err == nil {
+				setAnnotation(dst, legacyAnnDGDRConfigMapRef, string(data))
+			}
+		}
+		if srcSpec.ProfilingConfig.OutputPVC != "" {
+			setAnnotation(dst, legacyAnnDGDROutputPVC, srcSpec.ProfilingConfig.OutputPVC)
+		}
+		saveDGDRLegacyDeploymentOverridesAnnotation(srcSpec.DeploymentOverrides, dst)
+	}
+	if srcStatus != nil {
+		if srcStatus.Backend != "" {
+			setAnnotation(dst, legacyAnnDGDRStatusBackend, srcStatus.Backend)
+		}
+		if srcStatus.ProfilingResults != "" {
+			setAnnotation(dst, legacyAnnDGDRProfilingResults, srcStatus.ProfilingResults)
+		}
+		if srcStatus.Deployment != nil {
+			payload := dgdrDeploymentStatusAnnotation{
+				DeploymentStatus: *srcStatus.Deployment.DeepCopy(),
+				RequestState:     srcStatus.State,
+			}
+			if data, err := json.Marshal(payload); err == nil {
+				setAnnotation(dst, legacyAnnDGDRDeploymentStatus, string(data))
+			}
+		}
+	}
+}
+
+func saveDGDRLegacyDeploymentOverridesAnnotation(src *DeploymentOverridesSpec, dstObj *v1beta1.DynamoGraphDeploymentRequest) {
 	if src == nil {
 		return
 	}
@@ -404,12 +603,13 @@ func convertDeploymentOverridesToAnnotation(src *DeploymentOverridesSpec, dstObj
 		return
 	}
 	if data, err := json.Marshal(overrides); err == nil {
-		setAnnotation(dstObj, annDGDRDeployOverrides, string(data))
+		setAnnotation(dstObj, legacyAnnDGDRDeployOverrides, string(data))
 	}
 }
 
-// convertDGDRSpecFrom converts the v1beta1 Spec back into the v1alpha1 Spec.
-func convertDGDRSpecFrom(src *v1beta1.DynamoGraphDeploymentRequestSpec, dst *DynamoGraphDeploymentRequestSpec, srcObj *v1beta1.DynamoGraphDeploymentRequest) {
+// ConvertToDynamoGraphDeploymentRequestSpec converts the DGDR spec from
+// v1beta1 to v1alpha1.
+func ConvertToDynamoGraphDeploymentRequestSpec(src *v1beta1.DynamoGraphDeploymentRequestSpec, dst *DynamoGraphDeploymentRequestSpec, restored *DynamoGraphDeploymentRequestSpec, save *v1beta1.DynamoGraphDeploymentRequestSpec) {
 	dst.Model = src.Model
 	if src.AutoApply != nil {
 		dst.AutoApply = *src.AutoApply
@@ -424,38 +624,31 @@ func convertDGDRSpecFrom(src *v1beta1.DynamoGraphDeploymentRequestSpec, dst *Dyn
 		dst.UseMocker = src.Features.Mocker.Enabled
 	}
 
-	if srcObj.Annotations != nil {
-		if v, ok := srcObj.Annotations[annDGDREnableGPUDisc]; ok && v == "true" {
-			trueVal := true
-			dst.EnableGPUDiscovery = &trueVal
-		}
-	}
-
-	// Reconstruct the JSON blob: start from the round-trip annotation (preserves unknown
-	// keys), then overwrite with structured v1beta1 fields (structured fields win).
-	var blob map[string]interface{}
-	if srcObj.Annotations != nil {
-		if rawBlob, ok := srcObj.Annotations[annDGDRProfilingConfig]; ok && rawBlob != "" {
-			_ = json.Unmarshal([]byte(rawBlob), &blob) // best-effort
-		}
+	// Reconstruct the JSON blob from alpha-only saved remainder, then write
+	// live v1beta1 structured fields on top. The saved remainder has typed
+	// paths stripped, so stale annotations cannot resurrect old live values.
+	var blob dgdrProfilingConfigBlob
+	if restored != nil && restored.ProfilingConfig.Config != nil && restored.ProfilingConfig.Config.Raw != nil {
+		_ = json.Unmarshal(restored.ProfilingConfig.Config.Raw, &blob)
+		blob = stripDGDRTypedProfilingConfig(blob)
 	}
 	if src.SLA != nil || src.Workload != nil {
 		if blob == nil {
-			blob = make(map[string]interface{})
+			blob = make(dgdrProfilingConfigBlob)
 		}
-		mergeSLAWorkloadIntoBlob(src, blob)
+		projectSLAAndWorkloadToProfilingConfigBlob(src, blob)
 	}
 	if src.ModelCache != nil {
 		if blob == nil {
-			blob = make(map[string]interface{})
+			blob = make(dgdrProfilingConfigBlob)
 		}
-		mergeModelCacheIntoBlob(src.ModelCache, blob)
+		projectModelCacheToProfilingConfigBlob(src.ModelCache, blob)
 	}
 	if src.Features != nil && src.Features.Planner != nil {
 		if blob == nil {
-			blob = make(map[string]interface{})
+			blob = make(dgdrProfilingConfigBlob)
 		}
-		mergePlannerIntoBlob(src.Features.Planner, blob)
+		projectPlannerToProfilingConfigBlob(src.Features.Planner, blob)
 	}
 	if blob != nil {
 		if data, err := json.Marshal(blob); err == nil {
@@ -470,41 +663,246 @@ func convertDGDRSpecFrom(src *v1beta1.DynamoGraphDeploymentRequestSpec, dst *Dyn
 		dst.ProfilingConfig.ProfilerImage = src.Image
 	}
 
-	restoreAnnotationFields(srcObj, dst)
-	restoreProfilingJobResources(src, dst)
+	restoreDGDRAlphaOnlySpec(restored, dst)
+	projectProfilingJobToProfilingConfig(src, dst)
+	saveDGDRHubOnlySpec(src, save)
 }
 
-// mergeSLAWorkloadIntoBlob writes SLA and Workload structured fields back into the JSON blob,
+func restoreDGDRAlphaOnlySpec(restored *DynamoGraphDeploymentRequestSpec, dst *DynamoGraphDeploymentRequestSpec) {
+	if restored == nil || dst == nil {
+		return
+	}
+	if restored.EnableGPUDiscovery != nil {
+		v := *restored.EnableGPUDiscovery
+		dst.EnableGPUDiscovery = &v
+	}
+	if restored.ProfilingConfig.ConfigMapRef != nil {
+		ref := *restored.ProfilingConfig.ConfigMapRef
+		dst.ProfilingConfig.ConfigMapRef = &ref
+	}
+	dst.ProfilingConfig.OutputPVC = restored.ProfilingConfig.OutputPVC
+	if restored.DeploymentOverrides != nil {
+		dst.DeploymentOverrides = &DeploymentOverridesSpec{
+			Name:         restored.DeploymentOverrides.Name,
+			Namespace:    restored.DeploymentOverrides.Namespace,
+			Labels:       maps.Clone(restored.DeploymentOverrides.Labels),
+			Annotations:  maps.Clone(restored.DeploymentOverrides.Annotations),
+			WorkersImage: restored.DeploymentOverrides.WorkersImage,
+		}
+	}
+}
+
+func saveDGDRHubOnlySpec(src *v1beta1.DynamoGraphDeploymentRequestSpec, save *v1beta1.DynamoGraphDeploymentRequestSpec) {
+	if src == nil || save == nil {
+		return
+	}
+	if src.Hardware != nil {
+		save.Hardware = src.Hardware.DeepCopy()
+	}
+	if src.Workload != nil {
+		save.Workload = &v1beta1.WorkloadSpec{}
+		if src.Workload.Concurrency != nil {
+			v := *src.Workload.Concurrency
+			save.Workload.Concurrency = &v
+		}
+		if src.Workload.RequestRate != nil {
+			v := *src.Workload.RequestRate
+			save.Workload.RequestRate = &v
+		}
+	}
+	if src.SLA != nil {
+		save.SLA = &v1beta1.SLASpec{}
+		if src.SLA.E2ELatency != nil {
+			v := *src.SLA.E2ELatency
+			save.SLA.E2ELatency = &v
+		}
+	}
+	if src.Overrides != nil {
+		saveDGDRHubOnlyOverrides(src.Overrides, save)
+	}
+	if src.Features != nil && src.Features.Mocker != nil && !src.Features.Mocker.Enabled {
+		save.Features = &v1beta1.FeaturesSpec{Mocker: &v1beta1.MockerSpec{Enabled: false}}
+	}
+	save.SearchStrategy = src.SearchStrategy
+}
+
+func stripDGDRTypedProfilingConfig(blob dgdrProfilingConfigBlob) dgdrProfilingConfigBlob {
+	if blob == nil {
+		return nil
+	}
+	out := maps.Clone(blob)
+	if len(out) == 0 {
+		return out
+	}
+	if slaMap, ok := cloneStringAnyMap(out["sla"]); ok {
+		for _, key := range []string{"ttft", "itl", "optimizationType", "isl", "osl"} {
+			delete(slaMap, key)
+		}
+		if len(slaMap) == 0 {
+			delete(out, "sla")
+		} else {
+			out["sla"] = slaMap
+		}
+	}
+	if deploymentMap, ok := cloneStringAnyMap(out["deployment"]); ok {
+		if modelCacheMap, ok := cloneStringAnyMap(deploymentMap["modelCache"]); ok {
+			for _, key := range []string{"pvcName", "modelPathInPvc", "pvcMountPath"} {
+				delete(modelCacheMap, key)
+			}
+			if len(modelCacheMap) == 0 {
+				delete(deploymentMap, "modelCache")
+			} else {
+				deploymentMap["modelCache"] = modelCacheMap
+			}
+		}
+		if len(deploymentMap) == 0 {
+			delete(out, "deployment")
+		} else {
+			out["deployment"] = deploymentMap
+		}
+	}
+	delete(out, "planner")
+	if len(out) == 0 {
+		return dgdrProfilingConfigBlob{}
+	}
+	return out
+}
+
+func cloneStringAnyMap(v any) (map[string]any, bool) {
+	m, ok := v.(map[string]any)
+	if !ok {
+		return nil, false
+	}
+	return maps.Clone(m), true
+}
+
+func saveDGDRHubOnlyOverrides(src *v1beta1.OverridesSpec, save *v1beta1.DynamoGraphDeploymentRequestSpec) {
+	if src == nil || save == nil {
+		return
+	}
+	var overrides v1beta1.OverridesSpec
+	if src.DGD != nil {
+		overrides.DGD = src.DGD.DeepCopy()
+	}
+	if profilingJob := dgdrHubOnlyProfilingJob(src.ProfilingJob); profilingJob != nil {
+		overrides.ProfilingJob = profilingJob
+	}
+	if !apiequality.Semantic.DeepEqual(overrides, v1beta1.OverridesSpec{}) {
+		save.Overrides = &overrides
+	}
+}
+
+func restoreDGDRHubOnlyOverrides(restored *v1beta1.OverridesSpec, dst *v1beta1.DynamoGraphDeploymentRequestSpec) {
+	if restored == nil || dst == nil {
+		return
+	}
+	if dst.Overrides == nil {
+		dst.Overrides = &v1beta1.OverridesSpec{}
+	}
+	if restored.DGD != nil {
+		dst.Overrides.DGD = restored.DGD.DeepCopy()
+	}
+	if restored.ProfilingJob != nil {
+		if dst.Overrides.ProfilingJob == nil {
+			dst.Overrides.ProfilingJob = restored.ProfilingJob.DeepCopy()
+		} else {
+			mergeDGDRHubOnlyProfilingJob(dst.Overrides.ProfilingJob, restored.ProfilingJob)
+		}
+	}
+	if apiequality.Semantic.DeepEqual(*dst.Overrides, v1beta1.OverridesSpec{}) {
+		dst.Overrides = nil
+	}
+}
+
+func dgdrHubOnlyProfilingJob(src *batchv1.JobSpec) *batchv1.JobSpec {
+	if src == nil {
+		return nil
+	}
+	save := src.DeepCopy()
+	if len(save.Template.Spec.Containers) > 0 {
+		save.Template.Spec.Containers[0].Resources = corev1.ResourceRequirements{}
+		if len(save.Template.Spec.Containers) == 1 && apiequality.Semantic.DeepEqual(save.Template.Spec.Containers[0], corev1.Container{}) {
+			save.Template.Spec.Containers = slices.Delete(save.Template.Spec.Containers, 0, 1)
+		}
+	}
+	save.Template.Spec.Tolerations = nil
+	save.Template.Spec.NodeSelector = nil
+	if apiequality.Semantic.DeepEqual(*save, batchv1.JobSpec{}) {
+		return nil
+	}
+	return save
+}
+
+func mergeDGDRHubOnlyProfilingJob(dst *batchv1.JobSpec, restored *batchv1.JobSpec) {
+	if dst == nil || restored == nil {
+		return
+	}
+	resources, hasResources := dgdrFirstContainerResources(dst)
+	tolerations := slices.Clone(dst.Template.Spec.Tolerations)
+	nodeSelector := maps.Clone(dst.Template.Spec.NodeSelector)
+
+	*dst = *restored.DeepCopy()
+	if hasResources {
+		if len(dst.Template.Spec.Containers) == 0 {
+			dst.Template.Spec.Containers = []corev1.Container{{}}
+		}
+		dst.Template.Spec.Containers[0].Resources = resources
+	}
+	if len(tolerations) > 0 {
+		dst.Template.Spec.Tolerations = tolerations
+	}
+	if len(nodeSelector) > 0 {
+		dst.Template.Spec.NodeSelector = nodeSelector
+	}
+}
+
+func dgdrFirstContainerResources(job *batchv1.JobSpec) (corev1.ResourceRequirements, bool) {
+	if job == nil || len(job.Template.Spec.Containers) == 0 {
+		return corev1.ResourceRequirements{}, false
+	}
+	res := job.Template.Spec.Containers[0].Resources
+	return res, !apiequality.Semantic.DeepEqual(res, corev1.ResourceRequirements{})
+}
+
+// projectSLAAndWorkloadToProfilingConfigBlob writes SLA and Workload structured fields back into the JSON blob,
 // overwriting any existing values for those keys.
-func mergeSLAWorkloadIntoBlob(src *v1beta1.DynamoGraphDeploymentRequestSpec, blob map[string]interface{}) {
-	slaMap, _ := blob["sla"].(map[string]interface{})
+func projectSLAAndWorkloadToProfilingConfigBlob(src *v1beta1.DynamoGraphDeploymentRequestSpec, blob map[string]interface{}) {
+	slaMap, hadSLA := blob["sla"].(map[string]interface{})
 	if slaMap == nil {
 		slaMap = make(map[string]interface{})
 	}
+	wroteSLA := false
 	if src.SLA != nil {
 		if src.SLA.TTFT != nil {
 			slaMap["ttft"] = *src.SLA.TTFT
+			wroteSLA = true
 		}
 		if src.SLA.ITL != nil {
 			slaMap["itl"] = *src.SLA.ITL
+			wroteSLA = true
 		}
 		if src.SLA.OptimizationType != nil {
 			slaMap["optimizationType"] = string(*src.SLA.OptimizationType)
+			wroteSLA = true
 		}
 	}
 	if src.Workload != nil {
 		if src.Workload.ISL != nil {
 			slaMap["isl"] = float64(*src.Workload.ISL)
+			wroteSLA = true
 		}
 		if src.Workload.OSL != nil {
 			slaMap["osl"] = float64(*src.Workload.OSL)
+			wroteSLA = true
 		}
 	}
-	blob["sla"] = slaMap
+	if wroteSLA || hadSLA {
+		blob["sla"] = slaMap
+	}
 }
 
-// mergeModelCacheIntoBlob writes ModelCache structured fields back into blob["deployment"]["modelCache"].
-func mergeModelCacheIntoBlob(mc *v1beta1.ModelCacheSpec, blob map[string]interface{}) {
+// projectModelCacheToProfilingConfigBlob writes ModelCache structured fields back into blob["deployment"]["modelCache"].
+func projectModelCacheToProfilingConfigBlob(mc *v1beta1.ModelCacheSpec, blob map[string]interface{}) {
 	deployMap, _ := blob["deployment"].(map[string]interface{})
 	if deployMap == nil {
 		deployMap = make(map[string]interface{})
@@ -525,9 +923,9 @@ func mergeModelCacheIntoBlob(mc *v1beta1.ModelCacheSpec, blob map[string]interfa
 	}
 }
 
-// mergePlannerIntoBlob writes the planner RawExtension into blob["planner"].
+// projectPlannerToProfilingConfigBlob writes the planner RawExtension into blob["planner"].
 // The RawExtension is the full PlannerConfig JSON blob (opaque to Go).
-func mergePlannerIntoBlob(planner *runtime.RawExtension, blob map[string]interface{}) {
+func projectPlannerToProfilingConfigBlob(planner *runtime.RawExtension, blob map[string]interface{}) {
 	if planner == nil || planner.Raw == nil {
 		return
 	}
@@ -538,8 +936,8 @@ func mergePlannerIntoBlob(planner *runtime.RawExtension, blob map[string]interfa
 	blob["planner"] = plannerMap
 }
 
-// applyPlannerFromBlob extracts blob["planner"] and populates v1beta1 Features.Planner.
-func applyPlannerFromBlob(blob map[string]interface{}, dst *v1beta1.DynamoGraphDeploymentRequestSpec) {
+// projectPlannerFromProfilingConfigBlob extracts blob["planner"] and populates v1beta1 Features.Planner.
+func projectPlannerFromProfilingConfigBlob(blob map[string]interface{}, dst *v1beta1.DynamoGraphDeploymentRequestSpec) {
 	plannerRaw, ok := blob["planner"]
 	if !ok {
 		return
@@ -558,22 +956,33 @@ func applyPlannerFromBlob(blob map[string]interface{}, dst *v1beta1.DynamoGraphD
 	dst.Features.Planner = &runtime.RawExtension{Raw: raw}
 }
 
-// restoreAnnotationFields restores v1alpha1 spec fields that were annotation-preserved
-// during ConvertTo: ConfigMapRef, OutputPVC, and DeploymentOverrides.
-func restoreAnnotationFields(srcObj *v1beta1.DynamoGraphDeploymentRequest, dst *DynamoGraphDeploymentRequestSpec) {
-	if srcObj.Annotations == nil {
-		return
-	}
-	if v, ok := srcObj.Annotations[annDGDRConfigMapRef]; ok && v != "" {
-		var ref ConfigMapKeySelector
-		if err := json.Unmarshal([]byte(v), &ref); err == nil {
-			dst.ProfilingConfig.ConfigMapRef = &ref
+func restoreDGDRLegacySpokeSpec(obj metav1.Object) *DynamoGraphDeploymentRequestSpec {
+	restored := &DynamoGraphDeploymentRequestSpec{}
+	if raw, ok := getAnnFromObj(obj, legacyAnnDGDRProfilingConfig); ok && raw != "" {
+		var blob dgdrProfilingConfigBlob
+		if err := json.Unmarshal([]byte(raw), &blob); err == nil {
+			blob = stripDGDRTypedProfilingConfig(blob)
+			if blob != nil {
+				if data, err := json.Marshal(blob); err == nil {
+					restored.ProfilingConfig.Config = &apiextensionsv1.JSON{Raw: data}
+				}
+			}
 		}
 	}
-	if v, ok := srcObj.Annotations[annDGDROutputPVC]; ok {
-		dst.ProfilingConfig.OutputPVC = v
+	if raw, ok := getAnnFromObj(obj, legacyAnnDGDREnableGPUDisc); ok && raw == "true" {
+		v := true
+		restored.EnableGPUDiscovery = &v
 	}
-	if v, ok := srcObj.Annotations[annDGDRDeployOverrides]; ok && v != "" {
+	if v, ok := getAnnFromObj(obj, legacyAnnDGDRConfigMapRef); ok && v != "" {
+		var ref ConfigMapKeySelector
+		if err := json.Unmarshal([]byte(v), &ref); err == nil {
+			restored.ProfilingConfig.ConfigMapRef = &ref
+		}
+	}
+	if v, ok := getAnnFromObj(obj, legacyAnnDGDROutputPVC); ok {
+		restored.ProfilingConfig.OutputPVC = v
+	}
+	if v, ok := getAnnFromObj(obj, legacyAnnDGDRDeployOverrides); ok && v != "" {
 		var overrides struct {
 			Name        string            `json:"name,omitempty"`
 			Namespace   string            `json:"namespace,omitempty"`
@@ -581,99 +990,108 @@ func restoreAnnotationFields(srcObj *v1beta1.DynamoGraphDeploymentRequest, dst *
 			Annotations map[string]string `json:"annotations,omitempty"`
 		}
 		if err := json.Unmarshal([]byte(v), &overrides); err == nil {
-			if dst.DeploymentOverrides == nil {
-				dst.DeploymentOverrides = &DeploymentOverridesSpec{}
+			restored.DeploymentOverrides = &DeploymentOverridesSpec{
+				Name:        overrides.Name,
+				Namespace:   overrides.Namespace,
+				Labels:      overrides.Labels,
+				Annotations: overrides.Annotations,
 			}
-			dst.DeploymentOverrides.Name = overrides.Name
-			dst.DeploymentOverrides.Namespace = overrides.Namespace
-			dst.DeploymentOverrides.Labels = overrides.Labels
-			dst.DeploymentOverrides.Annotations = overrides.Annotations
 		}
 	}
+	return restored
 }
 
-// restoreProfilingJobResources restores Resources and Tolerations from
-// v1beta1 Overrides.ProfilingJob back into v1alpha1 ProfilingConfig.
-func restoreProfilingJobResources(src *v1beta1.DynamoGraphDeploymentRequestSpec, dst *DynamoGraphDeploymentRequestSpec) {
+func restoreDGDRLegacySpokeStatus(obj metav1.Object) (*DynamoGraphDeploymentRequestStatus, error) {
+	restored := &DynamoGraphDeploymentRequestStatus{}
+	if v, ok := getAnnFromObj(obj, legacyAnnDGDRStatusBackend); ok {
+		restored.Backend = v
+	}
+	if v, ok := getAnnFromObj(obj, legacyAnnDGDRProfilingResults); ok {
+		restored.ProfilingResults = v
+	}
+	if raw, ok := getAnnFromObj(obj, legacyAnnDGDRDeploymentStatus); ok && raw != "" {
+		deployment, state, ok := restoreDGDRLegacyDeploymentStatus(raw)
+		if ok {
+			restored.Deployment = &deployment
+			restored.State = state
+		}
+	}
+	return restored, nil
+}
+
+func restoreDGDRLegacyDeploymentStatus(raw string) (DeploymentStatus, DGDRState, bool) {
+	var payload dgdrDeploymentStatusAnnotation
+	if err := json.Unmarshal([]byte(raw), &payload); err == nil && payload.Name != "" {
+		if payload.RequestState == "" || isValidDGDRRequestState(payload.RequestState) {
+			return payload.DeploymentStatus, payload.RequestState, true
+		}
+		return DeploymentStatus{}, "", false
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(raw), &obj); err == nil {
+		if _, hasRequestState := obj["requestState"]; hasRequestState {
+			return DeploymentStatus{}, "", false
+		}
+	}
+	var legacy DeploymentStatus
+	if err := json.Unmarshal([]byte(raw), &legacy); err != nil || legacy.Name == "" {
+		return DeploymentStatus{}, "", false
+	}
+	return legacy, "", true
+}
+
+// projectProfilingJobToProfilingConfig maps alpha-representable profiling pod
+// fields from v1beta1 Overrides.ProfilingJob back into v1alpha1 ProfilingConfig.
+func projectProfilingJobToProfilingConfig(src *v1beta1.DynamoGraphDeploymentRequestSpec, dst *DynamoGraphDeploymentRequestSpec) {
 	if src.Overrides == nil || src.Overrides.ProfilingJob == nil {
 		return
 	}
 	podSpec := &src.Overrides.ProfilingJob.Template.Spec
 	if len(podSpec.Containers) > 0 {
 		res := podSpec.Containers[0].Resources
-		if len(res.Requests) > 0 || len(res.Limits) > 0 {
+		if !apiequality.Semantic.DeepEqual(res, corev1.ResourceRequirements{}) {
 			dst.ProfilingConfig.Resources = &res
 		}
 	}
 	if len(podSpec.Tolerations) > 0 {
 		dst.ProfilingConfig.Tolerations = podSpec.Tolerations
 	}
+	if len(podSpec.NodeSelector) > 0 {
+		dst.ProfilingConfig.NodeSelector = maps.Clone(podSpec.NodeSelector)
+	}
 }
 
-// convertDGDRStatusTo converts the v1alpha1 Status into the v1beta1 Status.
-func convertDGDRStatusTo(src *DynamoGraphDeploymentRequestStatus, dst *v1beta1.DynamoGraphDeploymentRequestStatus, dstObj *v1beta1.DynamoGraphDeploymentRequest) {
+// ConvertFromDynamoGraphDeploymentRequestStatus converts the DGDR status from
+// v1alpha1 to v1beta1.
+func ConvertFromDynamoGraphDeploymentRequestStatus(src *DynamoGraphDeploymentRequestStatus, dst *v1beta1.DynamoGraphDeploymentRequestStatus, restored *v1beta1.DynamoGraphDeploymentRequestStatus, save *DynamoGraphDeploymentRequestStatus) {
 	dst.Phase = dgdrStateToPhase(string(src.State), src.Deployment)
 	dst.ObservedGeneration = src.ObservedGeneration
-	dst.Conditions = src.Conditions
-
-	if src.Backend != "" {
-		setAnnotation(dstObj, annDGDRStatusBackend, src.Backend)
-	}
-	if src.ProfilingResults != "" {
-		setAnnotation(dstObj, annDGDRProfilingResults, src.ProfilingResults)
-	}
+	dst.Conditions = slices.Clone(src.Conditions)
 	if src.GeneratedDeployment != nil {
 		if dst.ProfilingResults == nil {
 			dst.ProfilingResults = &v1beta1.ProfilingResultsStatus{}
 		}
-		dst.ProfilingResults.SelectedConfig = src.GeneratedDeployment
+		dst.ProfilingResults.SelectedConfig = src.GeneratedDeployment.DeepCopy()
 	}
 	if src.Deployment != nil {
 		dst.DGDName = src.Deployment.Name
-		payload := dgdrDeploymentStatusAnnotation{
-			DeploymentStatus: *src.Deployment,
-			RequestState:     src.State,
-		}
-		if data, err := json.Marshal(payload); err == nil {
-			setAnnotation(dstObj, annDGDRDeploymentStatus, string(data))
-		}
 	}
 
-	// ProfilingJobName — read from annotation (stored during ConvertFrom for round-trip)
-	if ann, ok := dstObj.Annotations[annDGDRProfilingJobName]; ok && ann != "" {
-		dst.ProfilingJobName = ann
-	}
+	saveDGDRAlphaOnlyStatus(src, save)
+	restoreDGDRHubOnlyStatus(restored, dst)
 }
 
-// convertDGDRStatusFrom converts the v1beta1 Status back into the v1alpha1 Status.
-func convertDGDRStatusFrom(src *v1beta1.DynamoGraphDeploymentRequestStatus, dst *DynamoGraphDeploymentRequestStatus, srcObj *v1beta1.DynamoGraphDeploymentRequest) {
+// ConvertToDynamoGraphDeploymentRequestStatus converts the DGDR status from
+// v1beta1 to v1alpha1.
+func ConvertToDynamoGraphDeploymentRequestStatus(src *v1beta1.DynamoGraphDeploymentRequestStatus, dst *DynamoGraphDeploymentRequestStatus, restored *DynamoGraphDeploymentRequestStatus, save *v1beta1.DynamoGraphDeploymentRequestStatus) {
 	dst.State = DGDRState(dgdrPhaseToState(src.Phase))
 	dst.ObservedGeneration = src.ObservedGeneration
-	dst.Conditions = src.Conditions
-
-	if srcObj.Annotations != nil {
-		if v, ok := srcObj.Annotations[annDGDRStatusBackend]; ok {
-			dst.Backend = v
-		}
-		if v, ok := srcObj.Annotations[annDGDRProfilingResults]; ok {
-			dst.ProfilingResults = v
-		}
-	}
+	dst.Conditions = slices.Clone(src.Conditions)
 
 	if src.ProfilingResults != nil && src.ProfilingResults.SelectedConfig != nil {
-		dst.GeneratedDeployment = src.ProfilingResults.SelectedConfig
+		dst.GeneratedDeployment = src.ProfilingResults.SelectedConfig.DeepCopy()
 	}
 
-	if srcObj.Annotations != nil {
-		if v, ok := srcObj.Annotations[annDGDRDeploymentStatus]; ok && v != "" {
-			if depStatus, requestState, ok := restoreDGDRDeploymentStatus(v, src); ok {
-				dst.Deployment = &depStatus
-				if requestState != "" {
-					dst.State = requestState
-				}
-			}
-		}
-	}
 	// If no annotation but we have DGDName, create a minimal deployment status.
 	// Created is left false so the v1alpha1 controller does not skip re-creating the DGD.
 	if dst.Deployment == nil && src.DGDName != "" {
@@ -682,6 +1100,91 @@ func convertDGDRStatusFrom(src *v1beta1.DynamoGraphDeploymentRequestStatus, dst 
 			Created: false,
 		}
 	}
+	restoreDGDRAlphaOnlyStatus(restored, dst, src)
+	saveDGDRHubOnlyStatus(src, save)
+}
+
+func saveDGDRAlphaOnlyStatus(src *DynamoGraphDeploymentRequestStatus, save *DynamoGraphDeploymentRequestStatus) {
+	if src == nil || save == nil {
+		return
+	}
+	save.Backend = src.Backend
+	save.ProfilingResults = src.ProfilingResults
+	if !dgdrAlphaStateHasHubPhase(src.State, src.Deployment) {
+		save.State = src.State
+	}
+	if src.Deployment != nil {
+		save.State = src.State
+		save.Deployment = src.Deployment.DeepCopy()
+	}
+}
+
+func restoreDGDRAlphaOnlyStatus(restored *DynamoGraphDeploymentRequestStatus, dst *DynamoGraphDeploymentRequestStatus, src *v1beta1.DynamoGraphDeploymentRequestStatus) {
+	if restored == nil || dst == nil {
+		return
+	}
+	dst.Backend = restored.Backend
+	dst.ProfilingResults = restored.ProfilingResults
+	if restored.State != "" && dgdrAlphaStatusMatchesHubPhase(restored.State, restored.Deployment, src.Phase) {
+		dst.State = restored.State
+	}
+	if restored.Deployment != nil &&
+		restored.Deployment.Name == src.DGDName &&
+		(restored.State == "" || dgdrAlphaStatusMatchesHubPhase(restored.State, restored.Deployment, src.Phase)) {
+		dst.Deployment = restored.Deployment.DeepCopy()
+	}
+}
+
+func saveDGDRHubOnlyStatus(src *v1beta1.DynamoGraphDeploymentRequestStatus, save *v1beta1.DynamoGraphDeploymentRequestStatus) {
+	if src == nil || save == nil {
+		return
+	}
+	if src.Phase == v1beta1.DGDRPhaseDeployed {
+		save.Phase = src.Phase
+	}
+	save.ProfilingPhase = src.ProfilingPhase
+	save.ProfilingJobName = src.ProfilingJobName
+	if src.ProfilingResults != nil && len(src.ProfilingResults.Pareto) > 0 {
+		save.ProfilingResults = src.ProfilingResults.DeepCopy()
+		save.ProfilingResults.SelectedConfig = nil
+	}
+	if src.DeploymentInfo != nil {
+		save.DeploymentInfo = src.DeploymentInfo.DeepCopy()
+	}
+}
+
+func restoreDGDRHubOnlyStatus(restored *v1beta1.DynamoGraphDeploymentRequestStatus, dst *v1beta1.DynamoGraphDeploymentRequestStatus) {
+	if restored == nil || dst == nil {
+		return
+	}
+	if restored.Phase == v1beta1.DGDRPhaseDeployed && dst.Phase == v1beta1.DGDRPhaseReady {
+		dst.Phase = v1beta1.DGDRPhaseDeployed
+	}
+	dst.ProfilingPhase = restored.ProfilingPhase
+	dst.ProfilingJobName = restored.ProfilingJobName
+	if restored.ProfilingResults != nil && len(restored.ProfilingResults.Pareto) > 0 {
+		if dst.ProfilingResults == nil {
+			dst.ProfilingResults = &v1beta1.ProfilingResultsStatus{}
+		}
+		dst.ProfilingResults.Pareto = restored.ProfilingResults.DeepCopy().Pareto
+	}
+	if restored.DeploymentInfo != nil {
+		dst.DeploymentInfo = restored.DeploymentInfo.DeepCopy()
+	}
+}
+
+func dgdrAlphaStateHasHubPhase(state DGDRState, deployment *DeploymentStatus) bool {
+	return state == "" ||
+		state == DGDRStatePending ||
+		state == DGDRStateProfiling ||
+		state == DGDRStateReady ||
+		state == DGDRStateDeploying ||
+		state == DGDRStateFailed
+}
+
+func dgdrAlphaStatusMatchesHubPhase(state DGDRState, deployment *DeploymentStatus, phase v1beta1.DGDRPhase) bool {
+	alphaPhase := dgdrStateToPhase(string(state), deployment)
+	return alphaPhase == phase || phase == v1beta1.DGDRPhaseDeployed && alphaPhase == v1beta1.DGDRPhaseReady
 }
 
 // restoreDGDRDeploymentStatus ignores stale deployment-status overlays after hub-side status edits.
@@ -696,7 +1199,7 @@ func restoreDGDRDeploymentStatus(raw string, src *v1beta1.DynamoGraphDeploymentR
 	if payload.Name != src.DGDName {
 		return DeploymentStatus{}, "", false
 	}
-	if dgdrStateToPhase(string(payload.RequestState), &payload.DeploymentStatus) != src.Phase {
+	if !dgdrAlphaStatusMatchesHubPhase(payload.RequestState, &payload.DeploymentStatus, src.Phase) {
 		return DeploymentStatus{}, "", false
 	}
 	return payload.DeploymentStatus, payload.RequestState, true

--- a/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion.go
@@ -736,38 +736,77 @@ func stripDGDRTypedProfilingConfig(blob dgdrProfilingConfigBlob) dgdrProfilingCo
 	if len(out) == 0 {
 		return out
 	}
+
+	// The profiling config blob is opaque except for leaves that conversion can
+	// project into v1beta1 typed fields. Keep unprojectable values in the sparse
+	// remainder so an alpha->hub->alpha round trip does not drop user JSON.
 	if slaMap, ok := cloneStringAnyMap(out["sla"]); ok {
-		for _, key := range []string{"ttft", "itl", "optimizationType", "isl", "osl"} {
-			delete(slaMap, key)
-		}
-		if len(slaMap) == 0 {
+		stripped := stripDGDRProjectedSLAKeys(slaMap)
+		if stripped && len(slaMap) == 0 {
 			delete(out, "sla")
 		} else {
 			out["sla"] = slaMap
 		}
 	}
 	if deploymentMap, ok := cloneStringAnyMap(out["deployment"]); ok {
+		stripped := false
 		if modelCacheMap, ok := cloneStringAnyMap(deploymentMap["modelCache"]); ok {
-			for _, key := range []string{"pvcName", "modelPathInPvc", "pvcMountPath"} {
-				delete(modelCacheMap, key)
-			}
-			if len(modelCacheMap) == 0 {
+			stripped = stripDGDRProjectedModelCacheKeys(modelCacheMap)
+			if stripped && len(modelCacheMap) == 0 {
 				delete(deploymentMap, "modelCache")
 			} else {
 				deploymentMap["modelCache"] = modelCacheMap
 			}
 		}
-		if len(deploymentMap) == 0 {
+		if stripped && len(deploymentMap) == 0 {
 			delete(out, "deployment")
 		} else {
 			out["deployment"] = deploymentMap
 		}
 	}
-	delete(out, "planner")
+	if dgdrPlannerBlobProjects(out["planner"]) {
+		delete(out, "planner")
+	}
 	if len(out) == 0 {
 		return dgdrProfilingConfigBlob{}
 	}
 	return out
+}
+
+func stripDGDRProjectedSLAKeys(slaMap map[string]any) bool {
+	stripped := false
+	for _, key := range []string{"ttft", "itl", "isl", "osl"} {
+		if _, ok := slaMap[key].(float64); ok {
+			delete(slaMap, key)
+			stripped = true
+		}
+	}
+	if v, ok := slaMap["optimizationType"].(string); ok {
+		ot := v1beta1.OptimizationType(v)
+		if ot == v1beta1.OptimizationTypeLatency || ot == v1beta1.OptimizationTypeThroughput {
+			delete(slaMap, "optimizationType")
+			stripped = true
+		}
+	}
+	return stripped
+}
+
+func stripDGDRProjectedModelCacheKeys(modelCacheMap map[string]any) bool {
+	stripped := false
+	for _, key := range []string{"pvcName", "modelPathInPvc", "pvcMountPath"} {
+		// Empty strings are not reconstructed by projectModelCacheToProfilingConfigBlob,
+		// so they must remain in the opaque blob remainder.
+		if v, ok := modelCacheMap[key].(string); ok && v != "" {
+			delete(modelCacheMap, key)
+			stripped = true
+		}
+	}
+	return stripped
+}
+
+func dgdrPlannerBlobProjects(v any) bool {
+	plannerMap, ok := v.(map[string]any)
+	return ok && len(plannerMap) > 0
 }
 
 func cloneStringAnyMap(v any) (map[string]any, bool) {

--- a/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion.go
@@ -1141,7 +1141,9 @@ func restoreDGDRAlphaOnlyStatus(restored *DynamoGraphDeploymentRequestStatus, ds
 	}
 	dst.Backend = restored.Backend
 	dst.ProfilingResults = restored.ProfilingResults
-	if restored.State != "" && dgdrAlphaStatusMatchesHubPhase(restored.State, restored.Deployment, src.Phase) {
+	if restored.State != "" &&
+		dgdrAlphaStatusMatchesHubPhase(restored.State, restored.Deployment, src.Phase) &&
+		dgdrAlphaRestoredStateMatchesLiveDGD(restored.State, restored.Deployment, src.DGDName) {
 		dst.State = restored.State
 	}
 	if restored.Deployment != nil &&
@@ -1214,6 +1216,19 @@ func dgdrAlphaStatusMatchesHubPhase(state DGDRState, deployment *DeploymentStatu
 		return true
 	}
 	return phase == v1beta1.DGDRPhaseDeployed && state == DGDRStateReady
+}
+
+func dgdrAlphaRestoredStateMatchesLiveDGD(state DGDRState, deployment *DeploymentStatus, dgdName string) bool {
+	if state != DGDRStateDeploymentDeleted {
+		return true
+	}
+
+	// DeploymentDeleted is an alpha-only state for the specific DGD recorded in status.deployment.
+	// If the live hub status now points at another DGD, the preserved state is stale.
+	if deployment == nil {
+		return dgdName == ""
+	}
+	return deployment.Name == dgdName
 }
 
 // restoreDGDRDeploymentStatus ignores stale deployment-status overlays after hub-side status edits.

--- a/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion.go
@@ -1163,14 +1163,18 @@ func saveDGDRHubOnlyStatus(src *v1beta1.DynamoGraphDeploymentRequestStatus, dst 
 	}
 	if src.Phase == v1beta1.DGDRPhaseDeployed && dgdrStateToPhase(string(dst.State), dst.Deployment) != src.Phase {
 		save.Phase = src.Phase
+		save.DGDName = src.DGDName
 	}
-	save.ProfilingPhase = src.ProfilingPhase
-	save.ProfilingJobName = src.ProfilingJobName
+	if src.Phase == v1beta1.DGDRPhaseProfiling {
+		save.ProfilingPhase = src.ProfilingPhase
+		save.ProfilingJobName = src.ProfilingJobName
+	}
 	if src.ProfilingResults != nil && len(src.ProfilingResults.Pareto) > 0 {
 		save.ProfilingResults = src.ProfilingResults.DeepCopy()
 		save.ProfilingResults.SelectedConfig = nil
 	}
 	if src.DeploymentInfo != nil {
+		save.DGDName = src.DGDName
 		save.DeploymentInfo = src.DeploymentInfo.DeepCopy()
 	}
 }
@@ -1182,18 +1186,21 @@ func restoreDGDRHubOnlyStatus(restored *v1beta1.DynamoGraphDeploymentRequestStat
 	if restored.Phase == v1beta1.DGDRPhaseDeployed &&
 		dst.Phase == v1beta1.DGDRPhaseReady &&
 		src != nil &&
-		dgdrAlphaStatusMatchesHubPhase(src.State, src.Deployment, restored.Phase) {
+		dgdrAlphaStatusMatchesHubPhase(src.State, src.Deployment, restored.Phase) &&
+		restored.DGDName == dst.DGDName {
 		dst.Phase = v1beta1.DGDRPhaseDeployed
 	}
-	dst.ProfilingPhase = restored.ProfilingPhase
-	dst.ProfilingJobName = restored.ProfilingJobName
+	if dst.Phase == v1beta1.DGDRPhaseProfiling {
+		dst.ProfilingPhase = restored.ProfilingPhase
+		dst.ProfilingJobName = restored.ProfilingJobName
+	}
 	if restored.ProfilingResults != nil && len(restored.ProfilingResults.Pareto) > 0 {
 		if dst.ProfilingResults == nil {
 			dst.ProfilingResults = &v1beta1.ProfilingResultsStatus{}
 		}
 		dst.ProfilingResults.Pareto = restored.ProfilingResults.DeepCopy().Pareto
 	}
-	if restored.DeploymentInfo != nil {
+	if restored.DeploymentInfo != nil && restored.DGDName == dst.DGDName {
 		dst.DeploymentInfo = restored.DeploymentInfo.DeepCopy()
 	}
 }

--- a/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion_bugs_test.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion_bugs_test.go
@@ -1,0 +1,133 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v1alpha1
+
+import (
+	"encoding/json"
+	"testing"
+
+	v1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestBugDGDRStaleHubDeployedPhaseRequiresDGDNameMatch(t *testing.T) {
+	src := &DynamoGraphDeploymentRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				annDGDRStatus: mustDGDRHubStatusAnnotation(t, v1beta1.DynamoGraphDeploymentRequestStatus{
+					Phase:   v1beta1.DGDRPhaseDeployed,
+					DGDName: "old-dgd",
+				}),
+			},
+		},
+		Status: DynamoGraphDeploymentRequestStatus{
+			State: DGDRStateReady,
+			Deployment: &DeploymentStatus{
+				Name: "new-dgd",
+			},
+		},
+	}
+
+	dst := &v1beta1.DynamoGraphDeploymentRequest{}
+	if err := src.ConvertTo(dst); err != nil {
+		t.Fatalf("ConvertTo() error = %v", err)
+	}
+
+	if dst.Status.Phase != v1beta1.DGDRPhaseReady {
+		t.Fatalf("phase = %q, want %q", dst.Status.Phase, v1beta1.DGDRPhaseReady)
+	}
+	if dst.Status.DGDName != "new-dgd" {
+		t.Fatalf("dgdName = %q, want %q", dst.Status.DGDName, "new-dgd")
+	}
+}
+
+func TestBugDGDRStaleHubProfilingSubstatusRequiresProfilingPhase(t *testing.T) {
+	src := &DynamoGraphDeploymentRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				annDGDRStatus: mustDGDRHubStatusAnnotation(t, v1beta1.DynamoGraphDeploymentRequestStatus{
+					ProfilingPhase:   v1beta1.ProfilingPhaseSweepingDecode,
+					ProfilingJobName: "old-profiling-job",
+				}),
+			},
+		},
+		Status: DynamoGraphDeploymentRequestStatus{
+			State: DGDRStateReady,
+		},
+	}
+
+	dst := &v1beta1.DynamoGraphDeploymentRequest{}
+	if err := src.ConvertTo(dst); err != nil {
+		t.Fatalf("ConvertTo() error = %v", err)
+	}
+
+	if dst.Status.Phase != v1beta1.DGDRPhaseReady {
+		t.Fatalf("phase = %q, want %q", dst.Status.Phase, v1beta1.DGDRPhaseReady)
+	}
+	if dst.Status.ProfilingPhase != "" {
+		t.Fatalf("profilingPhase = %q, want empty", dst.Status.ProfilingPhase)
+	}
+	if dst.Status.ProfilingJobName != "" {
+		t.Fatalf("profilingJobName = %q, want empty", dst.Status.ProfilingJobName)
+	}
+}
+
+func TestBugDGDRStaleHubDeploymentInfoRequiresDGDNameMatch(t *testing.T) {
+	replicas := int32(3)
+	availableReplicas := int32(2)
+	src := &DynamoGraphDeploymentRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				annDGDRStatus: mustDGDRHubStatusAnnotation(t, v1beta1.DynamoGraphDeploymentRequestStatus{
+					DGDName: "old-dgd",
+					DeploymentInfo: &v1beta1.DeploymentInfoStatus{
+						Replicas:          &replicas,
+						AvailableReplicas: &availableReplicas,
+					},
+				}),
+			},
+		},
+		Status: DynamoGraphDeploymentRequestStatus{
+			State: DGDRStateReady,
+			Deployment: &DeploymentStatus{
+				Name: "new-dgd",
+			},
+		},
+	}
+
+	dst := &v1beta1.DynamoGraphDeploymentRequest{}
+	if err := src.ConvertTo(dst); err != nil {
+		t.Fatalf("ConvertTo() error = %v", err)
+	}
+
+	if dst.Status.DGDName != "new-dgd" {
+		t.Fatalf("dgdName = %q, want %q", dst.Status.DGDName, "new-dgd")
+	}
+	if dst.Status.DeploymentInfo != nil {
+		t.Fatalf("deploymentInfo = %#v, want nil", dst.Status.DeploymentInfo)
+	}
+}
+
+func mustDGDRHubStatusAnnotation(t *testing.T, status v1beta1.DynamoGraphDeploymentRequestStatus) string {
+	t.Helper()
+	data, err := json.Marshal(status)
+	if err != nil {
+		t.Fatalf("marshal DGDR hub status annotation: %v", err)
+	}
+	return string(data)
+}

--- a/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion_bugs_test.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion_bugs_test.go
@@ -123,11 +123,58 @@ func TestBugDGDRStaleHubDeploymentInfoRequiresDGDNameMatch(t *testing.T) {
 	}
 }
 
+func TestBugDGDRStaleAlphaDeploymentDeletedRequiresDGDNameMatch(t *testing.T) {
+	src := &v1beta1.DynamoGraphDeploymentRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				annDGDRStatus: mustDGDRAlphaStatusAnnotation(t, DynamoGraphDeploymentRequestStatus{
+					State: DGDRStateDeploymentDeleted,
+					Deployment: &DeploymentStatus{
+						Name:    "old-dgd",
+						Created: true,
+					},
+				}),
+			},
+		},
+		Status: v1beta1.DynamoGraphDeploymentRequestStatus{
+			Phase:   v1beta1.DGDRPhaseReady,
+			DGDName: "new-dgd",
+		},
+	}
+
+	dst := &DynamoGraphDeploymentRequest{}
+	if err := dst.ConvertFrom(src); err != nil {
+		t.Fatalf("ConvertFrom() error = %v", err)
+	}
+
+	if dst.Status.State != DGDRStateReady {
+		t.Fatalf("state = %q, want %q", dst.Status.State, DGDRStateReady)
+	}
+	if dst.Status.Deployment == nil {
+		t.Fatal("deployment = nil, want minimal live deployment")
+	}
+	if dst.Status.Deployment.Name != "new-dgd" {
+		t.Fatalf("deployment.name = %q, want %q", dst.Status.Deployment.Name, "new-dgd")
+	}
+	if dst.Status.Deployment.Created {
+		t.Fatal("deployment.created = true, want false")
+	}
+}
+
 func mustDGDRHubStatusAnnotation(t *testing.T, status v1beta1.DynamoGraphDeploymentRequestStatus) string {
 	t.Helper()
 	data, err := json.Marshal(status)
 	if err != nil {
 		t.Fatalf("marshal DGDR hub status annotation: %v", err)
+	}
+	return string(data)
+}
+
+func mustDGDRAlphaStatusAnnotation(t *testing.T, status DynamoGraphDeploymentRequestStatus) string {
+	t.Helper()
+	data, err := json.Marshal(status)
+	if err != nil {
+		t.Fatalf("marshal DGDR alpha status annotation: %v", err)
 	}
 	return string(data)
 }

--- a/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion_bugs_test.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion_bugs_test.go
@@ -26,6 +26,8 @@ import (
 )
 
 func TestBugDGDRStaleHubDeployedPhaseRequiresDGDNameMatch(t *testing.T) {
+	const newDGDName = "new-deployed-dgd"
+
 	src := &DynamoGraphDeploymentRequest{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
@@ -38,7 +40,7 @@ func TestBugDGDRStaleHubDeployedPhaseRequiresDGDNameMatch(t *testing.T) {
 		Status: DynamoGraphDeploymentRequestStatus{
 			State: DGDRStateReady,
 			Deployment: &DeploymentStatus{
-				Name: "new-dgd",
+				Name: newDGDName,
 			},
 		},
 	}
@@ -51,8 +53,8 @@ func TestBugDGDRStaleHubDeployedPhaseRequiresDGDNameMatch(t *testing.T) {
 	if dst.Status.Phase != v1beta1.DGDRPhaseReady {
 		t.Fatalf("phase = %q, want %q", dst.Status.Phase, v1beta1.DGDRPhaseReady)
 	}
-	if dst.Status.DGDName != "new-dgd" {
-		t.Fatalf("dgdName = %q, want %q", dst.Status.DGDName, "new-dgd")
+	if dst.Status.DGDName != newDGDName {
+		t.Fatalf("dgdName = %q, want %q", dst.Status.DGDName, newDGDName)
 	}
 }
 
@@ -88,6 +90,8 @@ func TestBugDGDRStaleHubProfilingSubstatusRequiresProfilingPhase(t *testing.T) {
 }
 
 func TestBugDGDRStaleHubDeploymentInfoRequiresDGDNameMatch(t *testing.T) {
+	const newDGDName = "new-info-dgd"
+
 	replicas := int32(3)
 	availableReplicas := int32(2)
 	src := &DynamoGraphDeploymentRequest{
@@ -105,7 +109,7 @@ func TestBugDGDRStaleHubDeploymentInfoRequiresDGDNameMatch(t *testing.T) {
 		Status: DynamoGraphDeploymentRequestStatus{
 			State: DGDRStateReady,
 			Deployment: &DeploymentStatus{
-				Name: "new-dgd",
+				Name: newDGDName,
 			},
 		},
 	}
@@ -115,8 +119,8 @@ func TestBugDGDRStaleHubDeploymentInfoRequiresDGDNameMatch(t *testing.T) {
 		t.Fatalf("ConvertTo() error = %v", err)
 	}
 
-	if dst.Status.DGDName != "new-dgd" {
-		t.Fatalf("dgdName = %q, want %q", dst.Status.DGDName, "new-dgd")
+	if dst.Status.DGDName != newDGDName {
+		t.Fatalf("dgdName = %q, want %q", dst.Status.DGDName, newDGDName)
 	}
 	if dst.Status.DeploymentInfo != nil {
 		t.Fatalf("deploymentInfo = %#v, want nil", dst.Status.DeploymentInfo)
@@ -124,6 +128,8 @@ func TestBugDGDRStaleHubDeploymentInfoRequiresDGDNameMatch(t *testing.T) {
 }
 
 func TestBugDGDRStaleAlphaDeploymentDeletedRequiresDGDNameMatch(t *testing.T) {
+	const newDGDName = "new-deleted-dgd"
+
 	src := &v1beta1.DynamoGraphDeploymentRequest{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
@@ -138,7 +144,7 @@ func TestBugDGDRStaleAlphaDeploymentDeletedRequiresDGDNameMatch(t *testing.T) {
 		},
 		Status: v1beta1.DynamoGraphDeploymentRequestStatus{
 			Phase:   v1beta1.DGDRPhaseReady,
-			DGDName: "new-dgd",
+			DGDName: newDGDName,
 		},
 	}
 
@@ -153,8 +159,8 @@ func TestBugDGDRStaleAlphaDeploymentDeletedRequiresDGDNameMatch(t *testing.T) {
 	if dst.Status.Deployment == nil {
 		t.Fatal("deployment = nil, want minimal live deployment")
 	}
-	if dst.Status.Deployment.Name != "new-dgd" {
-		t.Fatalf("deployment.name = %q, want %q", dst.Status.Deployment.Name, "new-dgd")
+	if dst.Status.Deployment.Name != newDGDName {
+		t.Fatalf("deployment.name = %q, want %q", dst.Status.Deployment.Name, newDGDName)
 	}
 	if dst.Status.Deployment.Created {
 		t.Fatal("deployment.created = true, want false")

--- a/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion_bugs_test.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion_bugs_test.go
@@ -19,9 +19,11 @@ package v1alpha1
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 
 	v1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -167,6 +169,48 @@ func TestBugDGDRStaleAlphaDeploymentDeletedRequiresDGDNameMatch(t *testing.T) {
 	}
 }
 
+func TestBugDGDRProfilingConfigPreservesUnprojectableTypedKeys(t *testing.T) {
+	config := []byte(`{
+		"sla": {
+			"ttft": "not-a-number",
+			"itl": false,
+			"optimizationType": "priority",
+			"isl": "1024",
+			"osl": null
+		},
+		"deployment": {
+			"modelCache": {
+				"pvcName": 123,
+				"modelPathInPvc": "",
+				"pvcMountPath": false
+			}
+		},
+		"planner": []
+	}`)
+	src := &DynamoGraphDeploymentRequest{
+		Spec: DynamoGraphDeploymentRequestSpec{
+			ProfilingConfig: ProfilingConfigSpec{
+				Config: &apiextensionsv1.JSON{Raw: config},
+			},
+		},
+	}
+
+	hub := &v1beta1.DynamoGraphDeploymentRequest{}
+	if err := src.ConvertTo(hub); err != nil {
+		t.Fatalf("ConvertTo() error = %v", err)
+	}
+
+	restored := &DynamoGraphDeploymentRequest{}
+	if err := restored.ConvertFrom(hub); err != nil {
+		t.Fatalf("ConvertFrom() error = %v", err)
+	}
+
+	if restored.Spec.ProfilingConfig.Config == nil {
+		t.Fatal("profilingConfig.config = nil, want preserved opaque JSON")
+	}
+	assertDGDRJSONEqual(t, config, restored.Spec.ProfilingConfig.Config.Raw)
+}
+
 func mustDGDRHubStatusAnnotation(t *testing.T, status v1beta1.DynamoGraphDeploymentRequestStatus) string {
 	t.Helper()
 	data, err := json.Marshal(status)
@@ -174,6 +218,23 @@ func mustDGDRHubStatusAnnotation(t *testing.T, status v1beta1.DynamoGraphDeploym
 		t.Fatalf("marshal DGDR hub status annotation: %v", err)
 	}
 	return string(data)
+}
+
+func assertDGDRJSONEqual(t *testing.T, wantRaw, gotRaw []byte) {
+	t.Helper()
+	var want, got any
+	if err := json.Unmarshal(wantRaw, &want); err != nil {
+		t.Fatalf("unmarshal wanted JSON: %v", err)
+	}
+	if err := json.Unmarshal(gotRaw, &got); err != nil {
+		t.Fatalf("unmarshal got JSON: %v", err)
+	}
+	if reflect.DeepEqual(want, got) {
+		return
+	}
+	wantJSON, _ := json.Marshal(want)
+	gotJSON, _ := json.Marshal(got)
+	t.Fatalf("JSON mismatch:\nwant: %s\n got: %s", wantJSON, gotJSON)
 }
 
 func mustDGDRAlphaStatusAnnotation(t *testing.T, status DynamoGraphDeploymentRequestStatus) string {

--- a/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion_test.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion_test.go
@@ -217,18 +217,18 @@ func TestConvertTo_SpecFields(t *testing.T) {
 	}
 
 	// EnableGPUDiscovery → annotation
-	if dst.Annotations[annDGDREnableGPUDisc] != "true" {
-		t.Errorf("annDGDREnableGPUDisc annotation: got %q, want %q", dst.Annotations[annDGDREnableGPUDisc], "true")
+	if dst.Annotations[legacyAnnDGDREnableGPUDisc] != "true" {
+		t.Errorf("legacyAnnDGDREnableGPUDisc annotation: got %q, want %q", dst.Annotations[legacyAnnDGDREnableGPUDisc], "true")
 	}
 
 	// OutputPVC → annotation
-	if dst.Annotations[annDGDROutputPVC] != "output-pvc" {
-		t.Errorf("annDGDROutputPVC annotation: got %q, want %q", dst.Annotations[annDGDROutputPVC], "output-pvc")
+	if dst.Annotations[legacyAnnDGDROutputPVC] != "output-pvc" {
+		t.Errorf("legacyAnnDGDROutputPVC annotation: got %q, want %q", dst.Annotations[legacyAnnDGDROutputPVC], "output-pvc")
 	}
 
 	// DeploymentOverrides → annotation
-	if dst.Annotations[annDGDRDeployOverrides] == "" {
-		t.Error("annDGDRDeployOverrides annotation is empty")
+	if dst.Annotations[legacyAnnDGDRDeployOverrides] == "" {
+		t.Error("legacyAnnDGDRDeployOverrides annotation is empty")
 	}
 }
 
@@ -255,13 +255,13 @@ func TestConvertTo_StatusFields(t *testing.T) {
 	}
 
 	// Backend → annotation
-	if dst.Annotations[annDGDRStatusBackend] != "vllm" {
-		t.Errorf("annDGDRStatusBackend annotation: got %q, want %q", dst.Annotations[annDGDRStatusBackend], "vllm")
+	if dst.Annotations[legacyAnnDGDRStatusBackend] != "vllm" {
+		t.Errorf("legacyAnnDGDRStatusBackend annotation: got %q, want %q", dst.Annotations[legacyAnnDGDRStatusBackend], "vllm")
 	}
 
 	// ProfilingResults → annotation
-	if dst.Annotations[annDGDRProfilingResults] != "configmap/profiling-cm" {
-		t.Errorf("annDGDRProfilingResults annotation: got %q, want %q", dst.Annotations[annDGDRProfilingResults], "configmap/profiling-cm")
+	if dst.Annotations[legacyAnnDGDRProfilingResults] != "configmap/profiling-cm" {
+		t.Errorf("legacyAnnDGDRProfilingResults annotation: got %q, want %q", dst.Annotations[legacyAnnDGDRProfilingResults], "configmap/profiling-cm")
 	}
 }
 
@@ -309,7 +309,7 @@ func TestAlpha1RoundTrip(t *testing.T) {
 	if blob["extra_key"] != "preserved" {
 		t.Errorf("extra_key: got %v, want %q", blob["extra_key"], "preserved")
 	}
-	// Planner round-trip via applyPlannerFromBlob / mergePlannerIntoBlob
+	// Planner round-trip via profiling-config projection helpers.
 	plannerMap, _ := blob["planner"].(map[string]interface{})
 	if plannerMap == nil {
 		t.Fatal("planner key missing in restored JSON blob")
@@ -346,11 +346,7 @@ func TestHubRoundTrip(t *testing.T) {
 	}
 
 	// --- Status checks ---
-	// Phase is intentionally lossy: DGDRPhaseDeployed → Ready → Ready
-	if restored.Status.Phase != v1beta1.DGDRPhaseReady {
-		t.Errorf("Status.Phase: got %q, want %q (Deployed→Ready is lossy)", restored.Status.Phase, v1beta1.DGDRPhaseReady)
-	}
-	if diff := cmp.Diff(original.Status, restored.Status, cmpopts.IgnoreFields(v1beta1.DynamoGraphDeploymentRequestStatus{}, "Phase")); diff != "" {
+	if diff := cmp.Diff(original.Status, restored.Status); diff != "" {
 		t.Errorf("Status mismatch after round-trip (-want +got):\n%s", diff)
 	}
 	// GeneratedDeployment round-trip via ProfilingResults.SelectedConfig
@@ -369,6 +365,49 @@ func TestConvertTo_InvalidProfilingConfigJSON(t *testing.T) {
 	err := src.ConvertTo(dst)
 	if err == nil {
 		t.Fatal("ConvertTo() expected error for invalid JSON, got nil")
+	}
+}
+
+func TestDGDRHubOnlyFieldsRoundTripThroughSparseAnnotations(t *testing.T) {
+	original := newV1beta1DGDR()
+	concurrency := float64(8)
+	requestRate := float64(2.5)
+	e2eLatency := float64(900)
+	totalGPUs := int32(8)
+	replicas := int32(3)
+	availableReplicas := int32(2)
+	original.Spec.Workload.Concurrency = &concurrency
+	original.Spec.Workload.RequestRate = &requestRate
+	original.Spec.SLA.E2ELatency = &e2eLatency
+	original.Spec.Hardware = &v1beta1.HardwareSpec{
+		GPUSKU:    v1beta1.GPUSKUTypeH100SXM,
+		TotalGPUs: &totalGPUs,
+	}
+	original.Spec.SearchStrategy = v1beta1.SearchStrategyThorough
+	original.Status.Phase = v1beta1.DGDRPhaseDeployed
+	original.Status.ProfilingPhase = v1beta1.ProfilingPhaseSweepingDecode
+	original.Status.DeploymentInfo = &v1beta1.DeploymentInfoStatus{
+		Replicas:          &replicas,
+		AvailableReplicas: &availableReplicas,
+	}
+	original.Status.ProfilingResults.Pareto = []v1beta1.ParetoConfig{
+		{Config: runtime.RawExtension{Raw: []byte(`{"candidate":"a"}`)}},
+	}
+
+	spoke := &DynamoGraphDeploymentRequest{}
+	if err := spoke.ConvertFrom(original); err != nil {
+		t.Fatalf("ConvertFrom() error = %v", err)
+	}
+	restored := &v1beta1.DynamoGraphDeploymentRequest{}
+	if err := spoke.ConvertTo(restored); err != nil {
+		t.Fatalf("ConvertTo() error = %v", err)
+	}
+
+	if diff := cmp.Diff(original.Spec, restored.Spec); diff != "" {
+		t.Fatalf("spec mismatch after sparse hub-only round-trip (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(original.Status, restored.Status); diff != "" {
+		t.Fatalf("status mismatch after sparse hub-only round-trip (-want +got):\n%s", diff)
 	}
 }
 

--- a/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion_test.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion_test.go
@@ -368,6 +368,120 @@ func TestConvertTo_InvalidProfilingConfigJSON(t *testing.T) {
 	}
 }
 
+func TestDGDRReadsLegacyAnnotationsWrittenByOldConverter(t *testing.T) {
+	original := newV1alpha1DGDR()
+	hub, err := legacyDGDRConvertToHubForTest(original)
+	if err != nil {
+		t.Fatalf("legacy convert to hub: %v", err)
+	}
+
+	restored := &DynamoGraphDeploymentRequest{}
+	if err := restored.ConvertFrom(hub); err != nil {
+		t.Fatalf("ConvertFrom() error = %v", err)
+	}
+
+	if diff := cmp.Diff(original.Spec, restored.Spec, cmpopts.IgnoreFields(ProfilingConfigSpec{}, "Config")); diff != "" {
+		t.Fatalf("spec mismatch after legacy read (-want +got):\n%s", diff)
+	}
+	assertProfilingConfigBlobHas(t, restored.Spec.ProfilingConfig.Config, map[string]any{
+		"extra_key": "preserved",
+	})
+	if diff := cmp.Diff(original.Status, restored.Status); diff != "" {
+		t.Fatalf("status mismatch after legacy read (-want +got):\n%s", diff)
+	}
+}
+
+func TestDGDRWritesLegacyAnnotationsReadableByOldConverter(t *testing.T) {
+	original := newV1alpha1DGDR()
+	hub := &v1beta1.DynamoGraphDeploymentRequest{}
+	if err := original.ConvertTo(hub); err != nil {
+		t.Fatalf("ConvertTo() error = %v", err)
+	}
+
+	for _, key := range []string{
+		legacyAnnDGDREnableGPUDisc,
+		legacyAnnDGDRProfilingConfig,
+		legacyAnnDGDRConfigMapRef,
+		legacyAnnDGDROutputPVC,
+		legacyAnnDGDRDeployOverrides,
+		legacyAnnDGDRStatusBackend,
+		legacyAnnDGDRProfilingResults,
+		legacyAnnDGDRDeploymentStatus,
+	} {
+		if hub.Annotations[key] == "" {
+			t.Fatalf("legacy annotation %q was not written", key)
+		}
+	}
+
+	legacyRestored := legacyDGDRConvertFromHubForTest(hub)
+	if diff := cmp.Diff(original.Spec, legacyRestored.Spec, cmpopts.IgnoreFields(ProfilingConfigSpec{}, "Config")); diff != "" {
+		t.Fatalf("legacy restored spec mismatch (-want +got):\n%s", diff)
+	}
+	assertProfilingConfigBlobHas(t, legacyRestored.Spec.ProfilingConfig.Config, map[string]any{
+		"extra_key": "preserved",
+	})
+	if diff := cmp.Diff(original.Status, legacyRestored.Status); diff != "" {
+		t.Fatalf("legacy restored status mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestDGDRLegacyProfilingConfigDoesNotOverrideLiveHubFields(t *testing.T) {
+	legacyBlob, err := json.Marshal(map[string]any{
+		"sla": map[string]any{
+			"ttft": 100,
+			"itl":  10,
+			"isl":  200,
+			"osl":  20,
+		},
+		"deployment": map[string]any{
+			"modelCache": map[string]any{
+				"pvcName": "stale-pvc",
+			},
+		},
+		"planner":   map[string]any{"stale": true},
+		"extra_key": "keep",
+	})
+	if err != nil {
+		t.Fatalf("marshal legacy blob: %v", err)
+	}
+	hub := &v1beta1.DynamoGraphDeploymentRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "edited",
+			Annotations: map[string]string{
+				legacyAnnDGDRProfilingConfig: string(legacyBlob),
+			},
+		},
+		Spec: v1beta1.DynamoGraphDeploymentRequestSpec{
+			Model: "model",
+		},
+	}
+
+	spoke := &DynamoGraphDeploymentRequest{}
+	if err := spoke.ConvertFrom(hub); err != nil {
+		t.Fatalf("ConvertFrom() error = %v", err)
+	}
+	restored := &v1beta1.DynamoGraphDeploymentRequest{}
+	if err := spoke.ConvertTo(restored); err != nil {
+		t.Fatalf("ConvertTo() error = %v", err)
+	}
+
+	if restored.Spec.SLA != nil {
+		t.Fatalf("stale legacy SLA restored into live hub spec: %#v", restored.Spec.SLA)
+	}
+	if restored.Spec.Workload != nil {
+		t.Fatalf("stale legacy workload restored into live hub spec: %#v", restored.Spec.Workload)
+	}
+	if restored.Spec.ModelCache != nil {
+		t.Fatalf("stale legacy model cache restored into live hub spec: %#v", restored.Spec.ModelCache)
+	}
+	if restored.Spec.Features != nil && restored.Spec.Features.Planner != nil {
+		t.Fatalf("stale legacy planner restored into live hub spec: %#v", restored.Spec.Features.Planner)
+	}
+	assertProfilingConfigBlobHas(t, spoke.Spec.ProfilingConfig.Config, map[string]any{
+		"extra_key": "keep",
+	})
+}
+
 func TestDGDRHubOnlyFieldsRoundTripThroughSparseAnnotations(t *testing.T) {
 	original := newV1beta1DGDR()
 	concurrency := float64(8)
@@ -408,6 +522,22 @@ func TestDGDRHubOnlyFieldsRoundTripThroughSparseAnnotations(t *testing.T) {
 	}
 	if diff := cmp.Diff(original.Status, restored.Status); diff != "" {
 		t.Fatalf("status mismatch after sparse hub-only round-trip (-want +got):\n%s", diff)
+	}
+}
+
+func assertProfilingConfigBlobHas(t *testing.T, raw *apiextensionsv1.JSON, want map[string]any) {
+	t.Helper()
+	if raw == nil {
+		t.Fatal("profiling config is nil")
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw.Raw, &got); err != nil {
+		t.Fatalf("unmarshal profiling config: %v", err)
+	}
+	for key, wantValue := range want {
+		if diff := cmp.Diff(wantValue, got[key]); diff != "" {
+			t.Fatalf("profiling config %q mismatch (-want +got):\n%s", key, diff)
+		}
 	}
 }
 

--- a/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion_test.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion_test.go
@@ -133,9 +133,10 @@ func newV1beta1DGDR() *v1beta1.DynamoGraphDeploymentRequest {
 			},
 		},
 		Status: v1beta1.DynamoGraphDeploymentRequestStatus{
-			Phase:              v1beta1.DGDRPhaseDeployed,
+			Phase:              v1beta1.DGDRPhaseProfiling,
 			ObservedGeneration: 2,
 			DGDName:            "hub-dgd",
+			ProfilingPhase:     v1beta1.ProfilingPhaseSweepingDecode,
 			ProfilingJobName:   "profiling-job-1",
 			ProfilingResults: &v1beta1.ProfilingResultsStatus{
 				SelectedConfig: &runtime.RawExtension{Raw: rawDGD},
@@ -499,7 +500,8 @@ func TestDGDRHubOnlyFieldsRoundTripThroughSparseAnnotations(t *testing.T) {
 	}
 	original.Spec.SearchStrategy = v1beta1.SearchStrategyThorough
 	original.Status.Phase = v1beta1.DGDRPhaseDeployed
-	original.Status.ProfilingPhase = v1beta1.ProfilingPhaseSweepingDecode
+	original.Status.ProfilingPhase = ""
+	original.Status.ProfilingJobName = ""
 	original.Status.DeploymentInfo = &v1beta1.DeploymentInfoStatus{
 		Replicas:          &replicas,
 		AvailableReplicas: &availableReplicas,

--- a/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion_test.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion_test.go
@@ -527,6 +527,151 @@ func TestDGDRHubOnlyFieldsRoundTripThroughSparseAnnotations(t *testing.T) {
 	}
 }
 
+func TestStripDGDRTypedProfilingConfig(t *testing.T) {
+	const (
+		customKey         = "custom"
+		deployKey         = "deployment"
+		islKey            = "isl"
+		itlKey            = "itl"
+		keepValue         = "keep"
+		modelCache        = "modelCache"
+		modelPathInPvcKey = "modelPathInPvc"
+		optimizationType  = "optimizationType"
+		oslKey            = "osl"
+		plannerKey        = "planner"
+		pvcMountPathKey   = "pvcMountPath"
+		pvcNameKey        = "pvcName"
+		slaKey            = "sla"
+		ttftKey           = "ttft"
+		unrelatedKey      = "unrelated"
+	)
+	tests := []struct {
+		name string
+		in   dgdrProfilingConfigBlob
+		want dgdrProfilingConfigBlob
+	}{
+		{
+			name: "strips projected leaves and keeps opaque siblings",
+			in: dgdrProfilingConfigBlob{
+				slaKey: map[string]any{
+					ttftKey:          float64(10),
+					itlKey:           float64(20),
+					optimizationType: string(v1beta1.OptimizationTypeLatency),
+					islKey:           float64(30),
+					oslKey:           float64(40),
+					customKey:        keepValue,
+				},
+				deployKey: map[string]any{
+					modelCache: map[string]any{
+						pvcNameKey:        "cache-pvc",
+						modelPathInPvcKey: "/models",
+						pvcMountPathKey:   "/cache",
+						customKey:         keepValue,
+					},
+					unrelatedKey: keepValue,
+				},
+				plannerKey: map[string]any{"enabled": true},
+				"top":      keepValue,
+			},
+			want: dgdrProfilingConfigBlob{
+				slaKey: map[string]any{
+					customKey: keepValue,
+				},
+				deployKey: map[string]any{
+					modelCache: map[string]any{
+						customKey: keepValue,
+					},
+					unrelatedKey: keepValue,
+				},
+				"top": keepValue,
+			},
+		},
+		{
+			name: "preserves typed-looking values that projection skips",
+			in: dgdrProfilingConfigBlob{
+				slaKey: map[string]any{
+					ttftKey:          "not-a-number",
+					itlKey:           false,
+					optimizationType: "priority",
+					islKey:           "1024",
+					oslKey:           nil,
+				},
+				deployKey: map[string]any{
+					modelCache: map[string]any{
+						pvcNameKey:        float64(123),
+						modelPathInPvcKey: "",
+						pvcMountPathKey:   false,
+					},
+				},
+				plannerKey: []any{},
+			},
+			want: dgdrProfilingConfigBlob{
+				slaKey: map[string]any{
+					ttftKey:          "not-a-number",
+					itlKey:           false,
+					optimizationType: "priority",
+					islKey:           "1024",
+					oslKey:           nil,
+				},
+				deployKey: map[string]any{
+					modelCache: map[string]any{
+						pvcNameKey:        float64(123),
+						modelPathInPvcKey: "",
+						pvcMountPathKey:   false,
+					},
+				},
+				plannerKey: []any{},
+			},
+		},
+		{
+			name: "removes empty containers only when projected leaves were stripped",
+			in: dgdrProfilingConfigBlob{
+				slaKey: map[string]any{
+					ttftKey: float64(10),
+				},
+				deployKey: map[string]any{
+					modelCache: map[string]any{
+						pvcNameKey: "cache-pvc",
+					},
+				},
+				plannerKey: map[string]any{"enabled": true},
+			},
+			want: dgdrProfilingConfigBlob{},
+		},
+		{
+			name: "preserves explicit empty maps that were not projected",
+			in: dgdrProfilingConfigBlob{
+				slaKey: map[string]any{},
+				deployKey: map[string]any{
+					modelCache: map[string]any{},
+				},
+				plannerKey: map[string]any{},
+			},
+			want: dgdrProfilingConfigBlob{
+				slaKey: map[string]any{},
+				deployKey: map[string]any{
+					modelCache: map[string]any{},
+				},
+				plannerKey: map[string]any{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			before := mustDGDRJSON(t, tt.in)
+			got := stripDGDRTypedProfilingConfig(tt.in)
+
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Fatalf("stripped config mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(string(before), string(mustDGDRJSON(t, tt.in))); diff != "" {
+				t.Fatalf("input was mutated (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func assertProfilingConfigBlobHas(t *testing.T, raw *apiextensionsv1.JSON, want map[string]any) {
 	t.Helper()
 	if raw == nil {
@@ -541,6 +686,15 @@ func assertProfilingConfigBlobHas(t *testing.T, raw *apiextensionsv1.JSON, want 
 			t.Fatalf("profiling config %q mismatch (-want +got):\n%s", key, diff)
 		}
 	}
+}
+
+func mustDGDRJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal JSON: %v", err)
+	}
+	return data
 }
 
 func TestRestoreDGDRDeploymentStatusValidatesRequestState(t *testing.T) {

--- a/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_legacy_conversion_test.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_legacy_conversion_test.go
@@ -24,6 +24,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -48,7 +49,7 @@ func legacyDGDRConvertToHubForTest(src *DynamoGraphDeploymentRequest) (*v1beta1.
 		dst.Spec.Features.Mocker = &v1beta1.MockerSpec{Enabled: true}
 	}
 	if src.Spec.EnableGPUDiscovery != nil && *src.Spec.EnableGPUDiscovery {
-		setAnnotation(dst, legacyAnnDGDREnableGPUDisc, "true")
+		setAnnotation(dst, legacyAnnDGDREnableGPUDisc, annotationTrue)
 	}
 	if src.Spec.ProfilingConfig.Config != nil && src.Spec.ProfilingConfig.Config.Raw != nil {
 		var blob map[string]any
@@ -108,21 +109,27 @@ func legacyDGDRConvertFromHubForTest(src *v1beta1.DynamoGraphDeploymentRequest) 
 	dst := &DynamoGraphDeploymentRequest{}
 	dst.ObjectMeta = *src.ObjectMeta.DeepCopy()
 
-	dst.Spec.Model = src.Spec.Model
+	legacyDGDRConvertHubSpecForTest(src, &dst.Spec)
+	legacyDGDRConvertHubStatusForTest(src, &dst.Status, &dst.ObjectMeta)
+	return dst
+}
+
+func legacyDGDRConvertHubSpecForTest(src *v1beta1.DynamoGraphDeploymentRequest, dst *DynamoGraphDeploymentRequestSpec) {
+	dst.Model = src.Spec.Model
 	if src.Spec.AutoApply != nil {
-		dst.Spec.AutoApply = *src.Spec.AutoApply
+		dst.AutoApply = *src.Spec.AutoApply
 	} else {
-		dst.Spec.AutoApply = true
+		dst.AutoApply = true
 	}
 	if src.Spec.Backend != "" {
-		dst.Spec.Backend = string(src.Spec.Backend)
+		dst.Backend = string(src.Spec.Backend)
 	}
 	if src.Spec.Features != nil && src.Spec.Features.Mocker != nil {
-		dst.Spec.UseMocker = src.Spec.Features.Mocker.Enabled
+		dst.UseMocker = src.Spec.Features.Mocker.Enabled
 	}
-	if raw, ok := getAnnFromObj(&src.ObjectMeta, legacyAnnDGDREnableGPUDisc); ok && raw == "true" {
+	if raw, ok := getAnnFromObj(&src.ObjectMeta, legacyAnnDGDREnableGPUDisc); ok && raw == annotationTrue {
 		v := true
-		dst.Spec.EnableGPUDiscovery = &v
+		dst.EnableGPUDiscovery = &v
 	}
 
 	var blob map[string]any
@@ -149,42 +156,43 @@ func legacyDGDRConvertFromHubForTest(src *v1beta1.DynamoGraphDeploymentRequest) 
 	}
 	if blob != nil {
 		if data, err := json.Marshal(blob); err == nil {
-			dst.Spec.ProfilingConfig.Config = &apiextensionsv1.JSON{Raw: data}
+			dst.ProfilingConfig.Config = &apiextensionsv1.JSON{Raw: data}
 		}
 	}
 	if src.Spec.Image != "" {
-		dst.Spec.ProfilingConfig.ProfilerImage = src.Spec.Image
+		dst.ProfilingConfig.ProfilerImage = src.Spec.Image
 	}
-	legacyDGDRRestoreAnnotationFields(src, &dst.Spec)
-	legacyDGDRRestoreProfilingJobResources(&src.Spec, &dst.Spec)
+	legacyDGDRRestoreAnnotationFields(src, dst)
+	legacyDGDRRestoreProfilingJobResources(&src.Spec, dst)
+}
 
-	dst.Status.State = DGDRState(dgdrPhaseToState(src.Status.Phase))
-	dst.Status.ObservedGeneration = src.Status.ObservedGeneration
-	dst.Status.Conditions = src.Status.Conditions
+func legacyDGDRConvertHubStatusForTest(src *v1beta1.DynamoGraphDeploymentRequest, dst *DynamoGraphDeploymentRequestStatus, metadata *metav1.ObjectMeta) {
+	dst.State = DGDRState(dgdrPhaseToState(src.Status.Phase))
+	dst.ObservedGeneration = src.Status.ObservedGeneration
+	dst.Conditions = src.Status.Conditions
 	if v, ok := getAnnFromObj(&src.ObjectMeta, legacyAnnDGDRStatusBackend); ok {
-		dst.Status.Backend = v
+		dst.Backend = v
 	}
 	if v, ok := getAnnFromObj(&src.ObjectMeta, legacyAnnDGDRProfilingResults); ok {
-		dst.Status.ProfilingResults = v
+		dst.ProfilingResults = v
 	}
 	if src.Status.ProfilingResults != nil && src.Status.ProfilingResults.SelectedConfig != nil {
-		dst.Status.GeneratedDeployment = src.Status.ProfilingResults.SelectedConfig
+		dst.GeneratedDeployment = src.Status.ProfilingResults.SelectedConfig
 	}
 	if raw, ok := getAnnFromObj(&src.ObjectMeta, legacyAnnDGDRDeploymentStatus); ok && raw != "" {
 		if depStatus, requestState, ok := restoreDGDRDeploymentStatus(raw, &src.Status); ok {
-			dst.Status.Deployment = &depStatus
+			dst.Deployment = &depStatus
 			if requestState != "" {
-				dst.Status.State = requestState
+				dst.State = requestState
 			}
 		}
 	}
-	if dst.Status.Deployment == nil && src.Status.DGDName != "" {
-		dst.Status.Deployment = &DeploymentStatus{Name: src.Status.DGDName}
+	if dst.Deployment == nil && src.Status.DGDName != "" {
+		dst.Deployment = &DeploymentStatus{Name: src.Status.DGDName}
 	}
 	if src.Status.ProfilingJobName != "" {
-		setAnnOnObj(&dst.ObjectMeta, legacyAnnDGDRProfilingJobName, src.Status.ProfilingJobName)
+		setAnnOnObj(metadata, legacyAnnDGDRProfilingJobName, src.Status.ProfilingJobName)
 	}
-	return dst
 }
 
 func legacyDGDRConvertProfilingResourcesToOverrides(src *ProfilingConfigSpec, dst *v1beta1.DynamoGraphDeploymentRequestSpec) {

--- a/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_legacy_conversion_test.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_legacy_conversion_test.go
@@ -1,0 +1,405 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v1alpha1
+
+import (
+	"encoding/json"
+
+	v1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// legacyDGDRConvertToHubForTest is the pre-structural DGDR converter kept as a
+// compatibility oracle while we still write legacy annotations for downgrade.
+func legacyDGDRConvertToHubForTest(src *DynamoGraphDeploymentRequest) (*v1beta1.DynamoGraphDeploymentRequest, error) {
+	dst := &v1beta1.DynamoGraphDeploymentRequest{}
+	dst.ObjectMeta = *src.ObjectMeta.DeepCopy()
+
+	dst.Spec.Model = src.Spec.Model
+	dst.Spec.AutoApply = &src.Spec.AutoApply
+	if src.Spec.Backend != "" {
+		dst.Spec.Backend = v1beta1.BackendType(src.Spec.Backend)
+	}
+	if src.Spec.DeploymentOverrides != nil && src.Spec.DeploymentOverrides.WorkersImage != "" {
+		dst.Spec.Image = src.Spec.DeploymentOverrides.WorkersImage
+	}
+	if src.Spec.UseMocker {
+		if dst.Spec.Features == nil {
+			dst.Spec.Features = &v1beta1.FeaturesSpec{}
+		}
+		dst.Spec.Features.Mocker = &v1beta1.MockerSpec{Enabled: true}
+	}
+	if src.Spec.EnableGPUDiscovery != nil && *src.Spec.EnableGPUDiscovery {
+		setAnnotation(dst, legacyAnnDGDREnableGPUDisc, "true")
+	}
+	if src.Spec.ProfilingConfig.Config != nil && src.Spec.ProfilingConfig.Config.Raw != nil {
+		var blob map[string]any
+		if err := json.Unmarshal(src.Spec.ProfilingConfig.Config.Raw, &blob); err != nil {
+			return nil, err
+		}
+		legacyDGDRApplySLAAndWorkloadFromBlob(blob, &dst.Spec)
+		legacyDGDRApplyModelCacheFromBlob(blob, &dst.Spec)
+		legacyDGDRApplyPlannerFromBlob(blob, &dst.Spec)
+		setAnnotation(dst, legacyAnnDGDRProfilingConfig, string(src.Spec.ProfilingConfig.Config.Raw))
+	}
+	if src.Spec.ProfilingConfig.ProfilerImage != "" {
+		dst.Spec.Image = src.Spec.ProfilingConfig.ProfilerImage
+	}
+	if src.Spec.ProfilingConfig.ConfigMapRef != nil {
+		if data, err := json.Marshal(src.Spec.ProfilingConfig.ConfigMapRef); err == nil {
+			setAnnotation(dst, legacyAnnDGDRConfigMapRef, string(data))
+		}
+	}
+	if src.Spec.ProfilingConfig.OutputPVC != "" {
+		setAnnotation(dst, legacyAnnDGDROutputPVC, src.Spec.ProfilingConfig.OutputPVC)
+	}
+	legacyDGDRConvertProfilingResourcesToOverrides(&src.Spec.ProfilingConfig, &dst.Spec)
+	saveDGDRLegacyDeploymentOverridesAnnotation(src.Spec.DeploymentOverrides, dst)
+
+	dst.Status.Phase = dgdrStateToPhase(string(src.Status.State), src.Status.Deployment)
+	dst.Status.ObservedGeneration = src.Status.ObservedGeneration
+	dst.Status.Conditions = src.Status.Conditions
+	if src.Status.Backend != "" {
+		setAnnotation(dst, legacyAnnDGDRStatusBackend, src.Status.Backend)
+	}
+	if src.Status.ProfilingResults != "" {
+		setAnnotation(dst, legacyAnnDGDRProfilingResults, src.Status.ProfilingResults)
+	}
+	if src.Status.GeneratedDeployment != nil {
+		dst.Status.ProfilingResults = &v1beta1.ProfilingResultsStatus{SelectedConfig: src.Status.GeneratedDeployment}
+	}
+	if src.Status.Deployment != nil {
+		dst.Status.DGDName = src.Status.Deployment.Name
+		payload := dgdrDeploymentStatusAnnotation{
+			DeploymentStatus: *src.Status.Deployment,
+			RequestState:     src.Status.State,
+		}
+		if data, err := json.Marshal(payload); err == nil {
+			setAnnotation(dst, legacyAnnDGDRDeploymentStatus, string(data))
+		}
+	}
+	if ann, ok := dst.Annotations[legacyAnnDGDRProfilingJobName]; ok && ann != "" {
+		dst.Status.ProfilingJobName = ann
+	}
+	return dst, nil
+}
+
+// legacyDGDRConvertFromHubForTest is the pre-structural hub-to-spoke converter
+// kept as a downgrade-read oracle for objects written by the new converter.
+func legacyDGDRConvertFromHubForTest(src *v1beta1.DynamoGraphDeploymentRequest) *DynamoGraphDeploymentRequest {
+	dst := &DynamoGraphDeploymentRequest{}
+	dst.ObjectMeta = *src.ObjectMeta.DeepCopy()
+
+	dst.Spec.Model = src.Spec.Model
+	if src.Spec.AutoApply != nil {
+		dst.Spec.AutoApply = *src.Spec.AutoApply
+	} else {
+		dst.Spec.AutoApply = true
+	}
+	if src.Spec.Backend != "" {
+		dst.Spec.Backend = string(src.Spec.Backend)
+	}
+	if src.Spec.Features != nil && src.Spec.Features.Mocker != nil {
+		dst.Spec.UseMocker = src.Spec.Features.Mocker.Enabled
+	}
+	if raw, ok := getAnnFromObj(&src.ObjectMeta, legacyAnnDGDREnableGPUDisc); ok && raw == "true" {
+		v := true
+		dst.Spec.EnableGPUDiscovery = &v
+	}
+
+	var blob map[string]any
+	if raw, ok := getAnnFromObj(&src.ObjectMeta, legacyAnnDGDRProfilingConfig); ok && raw != "" {
+		_ = json.Unmarshal([]byte(raw), &blob)
+	}
+	if src.Spec.SLA != nil || src.Spec.Workload != nil {
+		if blob == nil {
+			blob = map[string]any{}
+		}
+		legacyDGDRMergeSLAWorkloadIntoBlob(&src.Spec, blob)
+	}
+	if src.Spec.ModelCache != nil {
+		if blob == nil {
+			blob = map[string]any{}
+		}
+		legacyDGDRMergeModelCacheIntoBlob(src.Spec.ModelCache, blob)
+	}
+	if src.Spec.Features != nil && src.Spec.Features.Planner != nil {
+		if blob == nil {
+			blob = map[string]any{}
+		}
+		legacyDGDRMergePlannerIntoBlob(src.Spec.Features.Planner, blob)
+	}
+	if blob != nil {
+		if data, err := json.Marshal(blob); err == nil {
+			dst.Spec.ProfilingConfig.Config = &apiextensionsv1.JSON{Raw: data}
+		}
+	}
+	if src.Spec.Image != "" {
+		dst.Spec.ProfilingConfig.ProfilerImage = src.Spec.Image
+	}
+	legacyDGDRRestoreAnnotationFields(src, &dst.Spec)
+	legacyDGDRRestoreProfilingJobResources(&src.Spec, &dst.Spec)
+
+	dst.Status.State = DGDRState(dgdrPhaseToState(src.Status.Phase))
+	dst.Status.ObservedGeneration = src.Status.ObservedGeneration
+	dst.Status.Conditions = src.Status.Conditions
+	if v, ok := getAnnFromObj(&src.ObjectMeta, legacyAnnDGDRStatusBackend); ok {
+		dst.Status.Backend = v
+	}
+	if v, ok := getAnnFromObj(&src.ObjectMeta, legacyAnnDGDRProfilingResults); ok {
+		dst.Status.ProfilingResults = v
+	}
+	if src.Status.ProfilingResults != nil && src.Status.ProfilingResults.SelectedConfig != nil {
+		dst.Status.GeneratedDeployment = src.Status.ProfilingResults.SelectedConfig
+	}
+	if raw, ok := getAnnFromObj(&src.ObjectMeta, legacyAnnDGDRDeploymentStatus); ok && raw != "" {
+		if depStatus, requestState, ok := restoreDGDRDeploymentStatus(raw, &src.Status); ok {
+			dst.Status.Deployment = &depStatus
+			if requestState != "" {
+				dst.Status.State = requestState
+			}
+		}
+	}
+	if dst.Status.Deployment == nil && src.Status.DGDName != "" {
+		dst.Status.Deployment = &DeploymentStatus{Name: src.Status.DGDName}
+	}
+	if src.Status.ProfilingJobName != "" {
+		setAnnOnObj(&dst.ObjectMeta, legacyAnnDGDRProfilingJobName, src.Status.ProfilingJobName)
+	}
+	return dst
+}
+
+func legacyDGDRConvertProfilingResourcesToOverrides(src *ProfilingConfigSpec, dst *v1beta1.DynamoGraphDeploymentRequestSpec) {
+	if src.Resources == nil && len(src.Tolerations) == 0 {
+		return
+	}
+	if dst.Overrides == nil {
+		dst.Overrides = &v1beta1.OverridesSpec{}
+	}
+	if dst.Overrides.ProfilingJob == nil {
+		dst.Overrides.ProfilingJob = &batchv1.JobSpec{Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{}}}
+	}
+	podSpec := &dst.Overrides.ProfilingJob.Template.Spec
+	if src.Resources != nil {
+		if len(podSpec.Containers) == 0 {
+			podSpec.Containers = []corev1.Container{{}}
+		}
+		podSpec.Containers[0].Resources = *src.Resources
+	}
+	if len(src.Tolerations) > 0 {
+		podSpec.Tolerations = src.Tolerations
+	}
+}
+
+func legacyDGDRRestoreAnnotationFields(src *v1beta1.DynamoGraphDeploymentRequest, dst *DynamoGraphDeploymentRequestSpec) {
+	if raw, ok := getAnnFromObj(&src.ObjectMeta, legacyAnnDGDRConfigMapRef); ok && raw != "" {
+		var ref ConfigMapKeySelector
+		if err := json.Unmarshal([]byte(raw), &ref); err == nil {
+			dst.ProfilingConfig.ConfigMapRef = &ref
+		}
+	}
+	if raw, ok := getAnnFromObj(&src.ObjectMeta, legacyAnnDGDROutputPVC); ok {
+		dst.ProfilingConfig.OutputPVC = raw
+	}
+	if raw, ok := getAnnFromObj(&src.ObjectMeta, legacyAnnDGDRDeployOverrides); ok && raw != "" {
+		var overrides struct {
+			Name        string            `json:"name,omitempty"`
+			Namespace   string            `json:"namespace,omitempty"`
+			Labels      map[string]string `json:"labels,omitempty"`
+			Annotations map[string]string `json:"annotations,omitempty"`
+		}
+		if err := json.Unmarshal([]byte(raw), &overrides); err == nil {
+			dst.DeploymentOverrides = &DeploymentOverridesSpec{
+				Name:        overrides.Name,
+				Namespace:   overrides.Namespace,
+				Labels:      overrides.Labels,
+				Annotations: overrides.Annotations,
+			}
+		}
+	}
+}
+
+func legacyDGDRRestoreProfilingJobResources(src *v1beta1.DynamoGraphDeploymentRequestSpec, dst *DynamoGraphDeploymentRequestSpec) {
+	if src.Overrides == nil || src.Overrides.ProfilingJob == nil {
+		return
+	}
+	podSpec := &src.Overrides.ProfilingJob.Template.Spec
+	if len(podSpec.Containers) > 0 {
+		res := podSpec.Containers[0].Resources
+		if len(res.Requests) > 0 || len(res.Limits) > 0 {
+			dst.ProfilingConfig.Resources = &res
+		}
+	}
+	if len(podSpec.Tolerations) > 0 {
+		dst.ProfilingConfig.Tolerations = podSpec.Tolerations
+	}
+}
+
+func legacyDGDRApplySLAAndWorkloadFromBlob(blob map[string]any, dst *v1beta1.DynamoGraphDeploymentRequestSpec) {
+	slaRaw, ok := blob["sla"]
+	if !ok {
+		return
+	}
+	slaMap, ok := slaRaw.(map[string]any)
+	if !ok {
+		return
+	}
+
+	if dst.SLA == nil {
+		dst.SLA = &v1beta1.SLASpec{}
+	}
+	if v, ok := slaMap["ttft"].(float64); ok {
+		dst.SLA.TTFT = &v
+	}
+	if v, ok := slaMap["itl"].(float64); ok {
+		dst.SLA.ITL = &v
+	}
+	if v, ok := slaMap["optimizationType"].(string); ok {
+		ot := v1beta1.OptimizationType(v)
+		if ot == v1beta1.OptimizationTypeLatency || ot == v1beta1.OptimizationTypeThroughput {
+			dst.SLA.OptimizationType = &ot
+		}
+	}
+
+	if v, ok := slaMap["isl"].(float64); ok {
+		if dst.Workload == nil {
+			dst.Workload = &v1beta1.WorkloadSpec{}
+		}
+		isl := int32(v)
+		dst.Workload.ISL = &isl
+	}
+	if v, ok := slaMap["osl"].(float64); ok {
+		if dst.Workload == nil {
+			dst.Workload = &v1beta1.WorkloadSpec{}
+		}
+		osl := int32(v)
+		dst.Workload.OSL = &osl
+	}
+}
+
+func legacyDGDRApplyModelCacheFromBlob(blob map[string]any, dst *v1beta1.DynamoGraphDeploymentRequestSpec) {
+	deployRaw, ok := blob["deployment"]
+	if !ok {
+		return
+	}
+	deployMap, ok := deployRaw.(map[string]any)
+	if !ok {
+		return
+	}
+	mcRaw, ok := deployMap["modelCache"]
+	if !ok {
+		return
+	}
+	mcMap, ok := mcRaw.(map[string]any)
+	if !ok {
+		return
+	}
+
+	mc := &v1beta1.ModelCacheSpec{}
+	if v, ok := mcMap["pvcName"].(string); ok {
+		mc.PVCName = v
+	}
+	if v, ok := mcMap["modelPathInPvc"].(string); ok {
+		mc.PVCModelPath = v
+	}
+	if v, ok := mcMap["pvcMountPath"].(string); ok {
+		mc.PVCMountPath = v
+	}
+	dst.ModelCache = mc
+}
+
+func legacyDGDRApplyPlannerFromBlob(blob map[string]any, dst *v1beta1.DynamoGraphDeploymentRequestSpec) {
+	plannerRaw, ok := blob["planner"]
+	if !ok {
+		return
+	}
+	plannerMap, ok := plannerRaw.(map[string]any)
+	if !ok || len(plannerMap) == 0 {
+		return
+	}
+	raw, err := json.Marshal(plannerMap)
+	if err != nil {
+		return
+	}
+	if dst.Features == nil {
+		dst.Features = &v1beta1.FeaturesSpec{}
+	}
+	dst.Features.Planner = &runtime.RawExtension{Raw: raw}
+}
+
+func legacyDGDRMergeSLAWorkloadIntoBlob(src *v1beta1.DynamoGraphDeploymentRequestSpec, blob map[string]any) {
+	slaMap, _ := blob["sla"].(map[string]any)
+	if slaMap == nil {
+		slaMap = make(map[string]any)
+	}
+	if src.SLA != nil {
+		if src.SLA.TTFT != nil {
+			slaMap["ttft"] = *src.SLA.TTFT
+		}
+		if src.SLA.ITL != nil {
+			slaMap["itl"] = *src.SLA.ITL
+		}
+		if src.SLA.OptimizationType != nil {
+			slaMap["optimizationType"] = string(*src.SLA.OptimizationType)
+		}
+	}
+	if src.Workload != nil {
+		if src.Workload.ISL != nil {
+			slaMap["isl"] = float64(*src.Workload.ISL)
+		}
+		if src.Workload.OSL != nil {
+			slaMap["osl"] = float64(*src.Workload.OSL)
+		}
+	}
+	blob["sla"] = slaMap
+}
+
+func legacyDGDRMergeModelCacheIntoBlob(mc *v1beta1.ModelCacheSpec, blob map[string]any) {
+	deployMap, _ := blob["deployment"].(map[string]any)
+	if deployMap == nil {
+		deployMap = make(map[string]any)
+	}
+	mcMap := make(map[string]any)
+	if mc.PVCName != "" {
+		mcMap["pvcName"] = mc.PVCName
+	}
+	if mc.PVCModelPath != "" {
+		mcMap["modelPathInPvc"] = mc.PVCModelPath
+	}
+	if mc.PVCMountPath != "" {
+		mcMap["pvcMountPath"] = mc.PVCMountPath
+	}
+	if len(mcMap) > 0 {
+		deployMap["modelCache"] = mcMap
+		blob["deployment"] = deployMap
+	}
+}
+
+func legacyDGDRMergePlannerIntoBlob(planner *runtime.RawExtension, blob map[string]any) {
+	if planner == nil || planner.Raw == nil {
+		return
+	}
+	var plannerMap map[string]any
+	if err := json.Unmarshal(planner.Raw, &plannerMap); err != nil || len(plannerMap) == 0 {
+		return
+	}
+	blob["planner"] = plannerMap
+}

--- a/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_legacy_fuzz_test.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_legacy_fuzz_test.go
@@ -244,6 +244,7 @@ func normalizeAlphaDGDRForLegacyComparison(obj *DynamoGraphDeploymentRequest) {
 func normalizeHubDGDRForLegacyComparison(obj *v1beta1.DynamoGraphDeploymentRequest) {
 	obj.Annotations = scrubDGDRConversionAnnotations(obj.Annotations)
 	spec := &obj.Spec
+	status := &obj.Status
 
 	if spec.Workload != nil {
 		spec.Workload.Concurrency = nil
@@ -270,6 +271,12 @@ func normalizeHubDGDRForLegacyComparison(obj *v1beta1.DynamoGraphDeploymentReque
 		if len(podSpec.Containers) > 0 {
 			podSpec.Containers[0].Resources.Claims = nil
 		}
+	}
+
+	// Profiling substatus is only valid while the request is profiling.
+	if status.Phase != v1beta1.DGDRPhaseProfiling {
+		status.ProfilingPhase = ""
+		status.ProfilingJobName = ""
 	}
 }
 

--- a/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_legacy_fuzz_test.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_legacy_fuzz_test.go
@@ -1,0 +1,280 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v1alpha1
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"math/rand"
+	"strconv"
+	"strings"
+	"testing"
+
+	v1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apitestingfuzzer "k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metafuzzer "k8s.io/apimachinery/pkg/apis/meta/fuzzer"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/randfill"
+)
+
+var (
+	dgdrLegacyFuzzIters = flag.Int("dgdr-legacy-fuzz-iters", 1000, "iterations per direction for DGDR legacy/structural conversion equivalence tests")
+	dgdrLegacyFuzzSeed  = flag.Int64("dgdr-legacy-fuzz-seed", 1, "rand seed for DGDR legacy/structural conversion equivalence tests")
+)
+
+func TestDGDRFuzzLegacyAndStructuralConvertToHubEquivalent(t *testing.T) {
+	f := newDGDRLegacyComparisonFiller(*dgdrLegacyFuzzSeed)
+	for i := 0; i < *dgdrLegacyFuzzIters; i++ {
+		src := &DynamoGraphDeploymentRequest{}
+		f.Fill(src)
+		normalizeAlphaDGDRForLegacyComparison(src)
+
+		legacy, err := legacyDGDRConvertToHubForTest(src)
+		if err != nil {
+			t.Fatalf("iter %d legacy convert to hub: %v\ninput=%s", i, err, mustDGDRLegacyJSON(src))
+		}
+		structural := &v1beta1.DynamoGraphDeploymentRequest{}
+		if err := src.ConvertTo(structural); err != nil {
+			t.Fatalf("iter %d structural ConvertTo: %v\ninput=%s", i, err, mustDGDRLegacyJSON(src))
+		}
+		stripDGDRSparseAnnotationsForLegacyComparison(&structural.ObjectMeta)
+
+		if diff := cmp.Diff(legacy, structural, cmpopts.EquateEmpty()); diff != "" {
+			t.Fatalf("iter %d legacy/structural alpha->hub mismatch (-legacy +structural):\n%s\ninput=%s", i, diff, mustDGDRLegacyJSON(src))
+		}
+	}
+}
+
+func TestDGDRFuzzLegacyAndStructuralConvertFromHubEquivalent(t *testing.T) {
+	f := newDGDRLegacyComparisonFiller(*dgdrLegacyFuzzSeed)
+	for i := 0; i < *dgdrLegacyFuzzIters; i++ {
+		src := &v1beta1.DynamoGraphDeploymentRequest{}
+		f.Fill(src)
+		normalizeHubDGDRForLegacyComparison(src)
+
+		legacy := legacyDGDRConvertFromHubForTest(src)
+		structural := &DynamoGraphDeploymentRequest{}
+		if err := structural.ConvertFrom(src); err != nil {
+			t.Fatalf("iter %d structural ConvertFrom: %v\ninput=%s", i, err, mustDGDRLegacyJSON(src))
+		}
+		stripDGDRSparseAnnotationsForLegacyComparison(&structural.ObjectMeta)
+
+		if diff := cmp.Diff(legacy, structural, cmpopts.EquateEmpty()); diff != "" {
+			t.Fatalf("iter %d legacy/structural hub->alpha mismatch (-legacy +structural):\n%s\ninput=%s", i, diff, mustDGDRLegacyJSON(src))
+		}
+	}
+}
+
+func newDGDRLegacyComparisonFiller(seed int64) *randfill.Filler {
+	dgdrLegacyFuzzerFuncs := func(_ runtimeserializer.CodecFactory) []interface{} {
+		return []interface{}{
+			func(m *metav1.ObjectMeta, c randfill.Continue) {
+				c.FillNoCustom(m)
+				m.Annotations = scrubDGDRConversionAnnotations(m.Annotations)
+				m.ManagedFields = nil
+			},
+			func(r *runtime.RawExtension, c randfill.Continue) {
+				obj := map[string]string{
+					fmt.Sprintf("k%d", c.Uint32()%32): fmt.Sprintf("v%d", c.Uint32()%32),
+				}
+				raw, err := json.Marshal(obj)
+				if err != nil {
+					panic(err)
+				}
+				r.Raw = raw
+				r.Object = nil
+				apitestingfuzzer.NormalizeJSONRawExtension(r)
+			},
+			func(raw *json.RawMessage, c randfill.Continue) {
+				if c.Bool() {
+					*raw = nil
+					return
+				}
+				data, err := json.Marshal(fuzzDGDRLegacyJSONValue(c, 0))
+				if err != nil {
+					panic(err)
+				}
+				*raw = append((*raw)[:0], data...)
+			},
+			func(v *apiextensionsv1.JSON, c randfill.Continue) {
+				data, err := json.Marshal(fuzzDGDRLegacyJSONObject(c, 0))
+				if err != nil {
+					panic(err)
+				}
+				v.Raw = append(v.Raw[:0], data...)
+			},
+			func(q *resource.Quantity, c randfill.Continue) {
+				n := c.Int63() % 65536
+				*q = resource.MustParse(strconv.FormatInt(n, 10) + "Mi")
+			},
+			func(v *intstr.IntOrString, c randfill.Continue) {
+				if c.Bool() {
+					*v = intstr.FromInt32(c.Int31() % 65535)
+				} else {
+					*v = intstr.FromString(fmt.Sprintf("p%d", c.Uint32()%65535))
+				}
+			},
+			func(v *v1beta1.OptimizationType, c randfill.Continue) {
+				*v = oneOfDGDRLegacy(c, v1beta1.OptimizationTypeLatency, v1beta1.OptimizationTypeThroughput)
+			},
+			func(s *DynamoGraphDeploymentRequestSpec, c randfill.Continue) {
+				c.FillNoCustom(s)
+				s.Backend = oneOfDGDRLegacy(c, "auto", "vllm", "sglang", "trtllm")
+			},
+			func(s *v1beta1.DynamoGraphDeploymentRequestSpec, c randfill.Continue) {
+				c.FillNoCustom(s)
+				s.Backend = oneOfDGDRLegacy(c, v1beta1.BackendTypeAuto, v1beta1.BackendTypeVllm, v1beta1.BackendTypeSglang, v1beta1.BackendTypeTrtllm)
+			},
+			func(s *v1beta1.DynamoGraphDeploymentRequestStatus, c randfill.Continue) {
+				c.FillNoCustom(s)
+				s.Phase = oneOfDGDRLegacy(c, v1beta1.DGDRPhasePending, v1beta1.DGDRPhaseProfiling, v1beta1.DGDRPhaseReady, v1beta1.DGDRPhaseDeploying, v1beta1.DGDRPhaseDeployed, v1beta1.DGDRPhaseFailed)
+			},
+		}
+	}
+	funcs := apitestingfuzzer.MergeFuzzerFuncs(metafuzzer.Funcs, dgdrLegacyFuzzerFuncs)
+	return apitestingfuzzer.FuzzerFor(funcs, rand.NewSource(seed), runtimeserializer.NewCodecFactory(runtime.NewScheme()))
+}
+
+func normalizeAlphaDGDRForLegacyComparison(obj *DynamoGraphDeploymentRequest) {
+	obj.Annotations = scrubDGDRConversionAnnotations(obj.Annotations)
+
+	// NodeSelector is one of the fixed conversion bugs. The regular DGDR
+	// round-trip fuzz tests keep it enabled; the legacy equivalence fuzz keeps
+	// the visible legacy-compatible shape and compares the extra sparse payload
+	// separately by stripping annDGDRSpec/annDGDRStatus from the structural result.
+	obj.Spec.ProfilingConfig.NodeSelector = nil
+}
+
+func normalizeHubDGDRForLegacyComparison(obj *v1beta1.DynamoGraphDeploymentRequest) {
+	obj.Annotations = scrubDGDRConversionAnnotations(obj.Annotations)
+	spec := &obj.Spec
+
+	if spec.Workload != nil {
+		spec.Workload.Concurrency = nil
+		spec.Workload.RequestRate = nil
+		if spec.Workload.ISL == nil && spec.Workload.OSL == nil {
+			spec.Workload = nil
+		}
+	}
+	if spec.SLA != nil {
+		spec.SLA.E2ELatency = nil
+		if spec.SLA.TTFT == nil && spec.SLA.ITL == nil && spec.SLA.OptimizationType == nil {
+			spec.SLA = nil
+		}
+	}
+	if spec.ModelCache != nil &&
+		spec.ModelCache.PVCName == "" &&
+		spec.ModelCache.PVCModelPath == "" &&
+		spec.ModelCache.PVCMountPath == "" {
+		spec.ModelCache = nil
+	}
+	if spec.Overrides != nil && spec.Overrides.ProfilingJob != nil {
+		podSpec := &spec.Overrides.ProfilingJob.Template.Spec
+		podSpec.NodeSelector = nil
+		if len(podSpec.Containers) > 0 {
+			podSpec.Containers[0].Resources.Claims = nil
+		}
+	}
+}
+
+func stripDGDRSparseAnnotationsForLegacyComparison(obj metav1.Object) {
+	delAnnFromObj(obj, annDGDRSpec)
+	delAnnFromObj(obj, annDGDRStatus)
+}
+
+func scrubDGDRConversionAnnotations(annotations map[string]string) map[string]string {
+	if len(annotations) == 0 {
+		return annotations
+	}
+	for k := range annotations {
+		if strings.HasPrefix(k, "nvidia.com/dgdr-") {
+			delete(annotations, k)
+		}
+	}
+	if len(annotations) == 0 {
+		return nil
+	}
+	return annotations
+}
+
+func fuzzDGDRLegacyJSONValue(c randfill.Continue, depth int) any {
+	if depth >= 2 {
+		switch c.Uint32() % 5 {
+		case 0:
+			return nil
+		case 1:
+			return c.Bool()
+		case 2:
+			return c.Int63() % 1024
+		case 3:
+			return fmt.Sprintf("s%d", c.Uint32()%1024)
+		default:
+			return float64(c.Uint32()%1000) / 10
+		}
+	}
+
+	switch c.Uint32() % 7 {
+	case 0:
+		return nil
+	case 1:
+		return c.Bool()
+	case 2:
+		return c.Int63() % 1024
+	case 3:
+		return fmt.Sprintf("s%d", c.Uint32()%1024)
+	case 4:
+		out := make([]any, int(c.Uint32()%3))
+		for i := range out {
+			out[i] = fuzzDGDRLegacyJSONValue(c, depth+1)
+		}
+		return out
+	case 5:
+		return fuzzDGDRLegacyJSONObject(c, depth+1)
+	default:
+		return float64(c.Uint32()%1000) / 10
+	}
+}
+
+func fuzzDGDRLegacyJSONObject(c randfill.Continue, depth int) map[string]any {
+	n := int(c.Uint32() % 3)
+	out := make(map[string]any, n)
+	for i := 0; i < n; i++ {
+		out[fmt.Sprintf("k%d", i)] = fuzzDGDRLegacyJSONValue(c, depth+1)
+	}
+	return out
+}
+
+func oneOfDGDRLegacy[T any](c randfill.Continue, values ...T) T {
+	return values[c.Intn(len(values))]
+}
+
+func mustDGDRLegacyJSON(v any) string {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return fmt.Sprintf("(marshal err: %v)", err)
+	}
+	return string(data)
+}

--- a/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_legacy_fuzz_test.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_legacy_fuzz_test.go
@@ -88,6 +88,57 @@ func TestDGDRFuzzLegacyAndStructuralConvertFromHubEquivalent(t *testing.T) {
 	}
 }
 
+func TestDGDRFuzzLegacyHubStorageRoundTripsThroughStructural(t *testing.T) {
+	f := newDGDRLegacyComparisonFiller(*dgdrLegacyFuzzSeed)
+	for i := 0; i < *dgdrLegacyFuzzIters; i++ {
+		src := &DynamoGraphDeploymentRequest{}
+		f.Fill(src)
+		normalizeAlphaDGDRForLegacyComparison(src)
+
+		oldStored, err := legacyDGDRConvertToHubForTest(src)
+		if err != nil {
+			t.Fatalf("iter %d legacy convert to hub: %v\ninput=%s", i, err, mustDGDRLegacyJSON(src))
+		}
+		spoke := &DynamoGraphDeploymentRequest{}
+		if err := spoke.ConvertFrom(oldStored); err != nil {
+			t.Fatalf("iter %d structural ConvertFrom old hub: %v\ninput=%s", i, err, mustDGDRLegacyJSON(oldStored))
+		}
+		got := &v1beta1.DynamoGraphDeploymentRequest{}
+		if err := spoke.ConvertTo(got); err != nil {
+			t.Fatalf("iter %d structural ConvertTo old hub roundtrip: %v\ninput=%s", i, err, mustDGDRLegacyJSON(oldStored))
+		}
+		stripDGDRSparseAnnotationsForLegacyComparison(&got.ObjectMeta)
+
+		if diff := cmp.Diff(oldStored, got, cmpopts.EquateEmpty()); diff != "" {
+			t.Fatalf("iter %d legacy hub storage roundtrip mismatch (-old +got):\n%s\ninput=%s", i, diff, mustDGDRLegacyJSON(oldStored))
+		}
+	}
+}
+
+func TestDGDRFuzzLegacySpokeStorageRoundTripsThroughStructural(t *testing.T) {
+	f := newDGDRLegacyComparisonFiller(*dgdrLegacyFuzzSeed)
+	for i := 0; i < *dgdrLegacyFuzzIters; i++ {
+		src := &v1beta1.DynamoGraphDeploymentRequest{}
+		f.Fill(src)
+		normalizeHubDGDRForLegacyComparison(src)
+
+		oldStored := legacyDGDRConvertFromHubForTest(src)
+		hub := &v1beta1.DynamoGraphDeploymentRequest{}
+		if err := oldStored.ConvertTo(hub); err != nil {
+			t.Fatalf("iter %d structural ConvertTo old spoke: %v\ninput=%s", i, err, mustDGDRLegacyJSON(oldStored))
+		}
+		got := &DynamoGraphDeploymentRequest{}
+		if err := got.ConvertFrom(hub); err != nil {
+			t.Fatalf("iter %d structural ConvertFrom old spoke roundtrip: %v\ninput=%s", i, err, mustDGDRLegacyJSON(oldStored))
+		}
+		stripDGDRSparseAnnotationsForLegacyComparison(&got.ObjectMeta)
+
+		if diff := cmp.Diff(oldStored, got, cmpopts.EquateEmpty()); diff != "" {
+			t.Fatalf("iter %d legacy spoke storage roundtrip mismatch (-old +got):\n%s\ninput=%s", i, diff, mustDGDRLegacyJSON(oldStored))
+		}
+	}
+}
+
 func newDGDRLegacyComparisonFiller(seed int64) *randfill.Filler {
 	dgdrLegacyFuzzerFuncs := func(_ runtimeserializer.CodecFactory) []interface{} {
 		return []interface{}{
@@ -144,6 +195,18 @@ func newDGDRLegacyComparisonFiller(seed int64) *randfill.Filler {
 				c.FillNoCustom(s)
 				s.Backend = oneOfDGDRLegacy(c, "auto", "vllm", "sglang", "trtllm")
 			},
+			func(s *DynamoGraphDeploymentRequestStatus, c randfill.Continue) {
+				c.FillNoCustom(s)
+				s.State = oneOfDGDRLegacy(c,
+					DGDRStateInitializing,
+					DGDRStatePending,
+					DGDRStateProfiling,
+					DGDRStateReady,
+					DGDRStateDeploying,
+					DGDRStateDeploymentDeleted,
+					DGDRStateFailed,
+				)
+			},
 			func(s *v1beta1.DynamoGraphDeploymentRequestSpec, c randfill.Continue) {
 				c.FillNoCustom(s)
 				s.Backend = oneOfDGDRLegacy(c, v1beta1.BackendTypeAuto, v1beta1.BackendTypeVllm, v1beta1.BackendTypeSglang, v1beta1.BackendTypeTrtllm)
@@ -166,6 +229,16 @@ func normalizeAlphaDGDRForLegacyComparison(obj *DynamoGraphDeploymentRequest) {
 	// the visible legacy-compatible shape and compares the extra sparse payload
 	// separately by stripping annDGDRSpec/annDGDRStatus from the structural result.
 	obj.Spec.ProfilingConfig.NodeSelector = nil
+	if obj.Spec.ProfilingConfig.Resources != nil {
+		obj.Spec.ProfilingConfig.Resources.Claims = nil
+		if len(obj.Spec.ProfilingConfig.Resources.Requests) == 0 &&
+			len(obj.Spec.ProfilingConfig.Resources.Limits) == 0 {
+			obj.Spec.ProfilingConfig.Resources = nil
+		}
+	}
+	if obj.Status.Deployment != nil && obj.Status.Deployment.Name == "" {
+		obj.Status.Deployment = nil
+	}
 }
 
 func normalizeHubDGDRForLegacyComparison(obj *v1beta1.DynamoGraphDeploymentRequest) {


### PR DESCRIPTION
## Summary
This PR aligns DGDR conversion with the structural DGD/DCD conversion rules from `api/CONVERSION.md` after #9257. DGDR conversion has been used since Dynamo 1.0, so the change preserves compatible reads and continues writing legacy downgrade annotations while 1.2 -> 1.1 downgrade must remain supported.

- Implement structural DGDR conversion with live source fields authoritative.
- Preserve source-version-only values sparsely through `nvidia.com/dgdr-spec` and `nvidia.com/dgdr-status`.
- Read old legacy DGDR annotations and new sparse annotations in parallel.
- Continue writing old legacy DGDR annotations for downgrade compatibility.
- Keep the pre-structural DGDR converter in tests as a legacy compatibility oracle.
- Tighten sparse-save behavior so empty structural payloads are not emitted.
- Update `api/CONVERSION.md` to document the current structural conversion style.

## Compatibility and Fuzz Scope
- Main DGDR roundtrip fuzz tests have the fixed-field TODO workarounds disabled, so the newly fixed fields are exercised directly.
- Legacy-vs-structural fuzz tests intentionally normalize inputs to the old converter's representable behavior, then compare legacy and structural conversion modulo only the new sparse annotations.
- Legacy storage fuzz covers old-style hub and spoke storage objects round-tripping through the new structural converter and back to legacy-compatible state.
- Direct roundtrip fuzz ignores only legacy DGDR compatibility annotations, so new sparse `dgdr-spec` / `dgdr-status` annotations remain visible to the sparse-save invariant.

## Fixed Bugs
- Preserve v1alpha1 `spec.profilingConfig.nodeSelector` through `v1beta1.spec.overrides.profilingJob.template.spec.nodeSelector`.
- Preserve v1alpha1 status `state=Initializing` and `state=DeploymentDeleted` through v1beta1 using sparse annotations.
- Preserve v1beta1 `spec.hardware` through v1alpha1 using sparse annotations.
- Preserve v1beta1 `spec.workload.concurrency` and `spec.workload.requestRate` through v1alpha1 using sparse annotations.
- Preserve v1beta1 `spec.sla.e2eLatency` through v1alpha1 using sparse annotations.
- Preserve v1beta1 `spec.overrides.dgd` and hub-only `spec.overrides.profilingJob` leaves through v1alpha1 using sparse annotations.
- Preserve v1beta1 `spec.searchStrategy` through v1alpha1 using sparse annotations.
- Preserve explicit disabled `spec.features.mocker.enabled=false` through v1alpha1 without overriding live `useMocker=true`.
- Preserve v1beta1 status `phase=Deployed` through v1alpha1 status conversion.
- Avoid stale `phase=Deployed` restoration when the live v1alpha1 state maps lossily to `Ready`, such as `DeploymentDeleted`.
- Preserve v1beta1 `status.profilingPhase` through v1alpha1 using sparse annotations.
- Preserve v1beta1 `status.profilingResults.pareto` through v1alpha1 using sparse annotations.
- Preserve v1beta1 `status.deploymentInfo` through v1alpha1 using sparse annotations.
- Stop stale legacy profiling config annotations from restoring old live hub fields such as SLA, Workload, ModelCache, and Planner.
- Stop writing empty structural DGDR annotations when only representable or generated fields are present.

## Documentation
- Condense `api/CONVERSION.md` into rules for the current structural conversion style.
- Document the top-level `controller-runtime` `conversion.Convertible` interface and its limited `ConvertTo` / `ConvertFrom` method signatures.
- Document the call stack from top-level object conversion into typed spec/status conversion functions.
- Make explicit that every nested API Go struct gets a systematic `ConvertFrom*` / `ConvertTo*` conversion function pair.

## Prompt History Trace
- Base the DGDR work on the DGD/DCD structural conversion cleanup from PR #9257 and follow `api/CONVERSION.md`.
- Preserve existing DGDR v1alpha1/v1beta1 read behavior because DGDR conversion has been in use since Dynamo 1.0.
- Continue writing legacy DGDR annotations until 1.2 downgrade compatibility no longer matters.
- Keep the old DGDR converter around in tests so fuzzing and compatibility tests can compare against legacy behavior.
- Rename legacy annotation constants to `legacyAnn*` and mark them with `TODO(sttts)` for removal after 1.2.
- Use `CONVERSION.md` naming for structural converters, including `ConvertFromDynamoGraphDeploymentRequest*` and `ConvertToDynamoGraphDeploymentRequest*`.
- Keep main DGDR roundtrip fuzz tests unmasked for fixed fields; keep legacy-vs-structural fuzz tests normalized to the old converter's representable behavior.
- Add legacy storage roundtrip fuzz for old-style hub and spoke objects.
- Keep sparse structural annotations visible in main roundtrip fuzz comparisons while ignoring only legacy downgrade annotations.
- Update PR title and description to satisfy conventional PR checks and document the follow-up fixes.

## Testing
- `GOCACHE=/tmp/dynamo-go-cache go test ./api/v1alpha1 -count=1`
- `GOCACHE=/tmp/dynamo-go-cache go test ./api -run 'TestFuzzRoundTrip_DGDR|TestFuzzRoundTripMutability/DGDR' -roundtrip-fuzz-iters=3000 -count=1 -v`
- `GOCACHE=/tmp/dynamo-go-cache go test ./api/v1alpha1 -run TestDGDRFuzzLegacyAndStructural -dgdr-legacy-fuzz-iters=3000 -count=1 -v`
- `GOCACHE=/tmp/dynamo-go-cache go test ./api/... -count=1`
- `git diff --check`
