### PR TITLE
fix(container): align Dynamo NIXL with upstream sglang wheel; bump nixl-sys to v1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5326,9 +5326,9 @@ dependencies = [
 
 [[package]]
 name = "nixl-sys"
-version = "0.10.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64cc4aaa4b0e9e49b677db3a58e24c91d1293952d3ef6430da235704740b3a6d"
+checksum = "e4f28c4892e39d6f5d8bcd551e7001c03a04b16e5669a9a7d67b23f9720ecaae"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -85,11 +85,13 @@ sglang:
     runtime_image: lmsysorg/sglang
     base_image_tag: 25.11-cuda13.0-devel-ubuntu24.04
     runtime_image_tag: v0.5.10.post1-cu130-runtime
-  # Builds the NIXL C++ SDK in wheel_builder so the dev stage can link nixl-sys
-  # (see templates/dev.Dockerfile). Runtime stays on the upstream lmsysorg/sglang
-  # NIXL Python stack — its wheel COPY is narrowed to ai_dynamo*.whl so the SDK
-  # build doesn't leak into the runtime image.
-  nixl_ref: 0.10.1
+  # Do not add nixl_ref here: Dynamo does not build NIXL in wheel_builder for
+  # sglang — the upstream lmsysorg/sglang runtime image already ships nixl-cu1X
+  # with its own bundled libnixl. BUT we still need the NIXL SDK in the dev
+  # image because cargo's nixl-sys crate needs the C++ headers (to compile
+  # wrapper.cpp) and libnixl/libnixl_build/libnixl_common symbols (to link).
+  # THEREFORE the dev stage gets the SDK dynamically. See templates/dev.Dockerfile
+  # ("nixl-cu detect").
   enable_media_ffmpeg: "true"
   enable_gpu_memory_service: "true"
   enable_kvbm: "false"

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -27,7 +27,7 @@ dynamo:
   nats_version: v2.10.28
   etcd_version: v3.5.21
 
-  nixl_ref: 0.10.1
+  nixl_ref: v1.0.0
   nixl_ucx_ref: v1.20.x
   nixl_gdrcopy_ref: v2.5.1
   nixl_ucx_efa_ref: 9d2b88a1f67faf9876f267658bd077b379b8bb76
@@ -66,7 +66,7 @@ vllm:
   flashinf_ref: v0.6.8.post1
   lmcache_ref: 0.4.4
   vllm_omni_ref: "release/v0.19.0rc1"
-  nixl_ref: 0.10.1
+  nixl_ref: v1.0.0
   max_jobs: "10"
   enable_media_ffmpeg: "false"
   enable_gpu_memory_service: "true"
@@ -102,7 +102,7 @@ trtllm:
     runtime_image: nvcr.io/nvidia/cuda-dl-base
     base_image_tag: 26.02-py3
     runtime_image_tag: 26.02-cuda13.1-runtime-ubuntu24.04
-  nixl_ref: 0.10.1
+  nixl_ref: v1.0.0
   enable_media_ffmpeg: "false"
   enable_gpu_memory_service: "true"
   enable_kvbm: "true"

--- a/container/templates/dev.Dockerfile
+++ b/container/templates/dev.Dockerfile
@@ -167,6 +167,7 @@ USER root
 
 # Redeclare build args for use in this stage
 ARG PYTHON_VERSION
+ARG CUDA_MAJOR
 
 # Ensure the runtime stage always has /usr/bin/python3.
 # - vLLM/TRTLLM runtime images may only have Python in /opt/dynamo/venv/bin/{python,python3}
@@ -188,8 +189,12 @@ RUN if [ ! -e /usr/bin/python3 ]; then \
     fi
 
 # NIXL C++ SDK (+ ucx, libfabric, gdrcopy) for cargo to link nixl-sys.
-# - sglang: upstream runtime ships only the Python wheel; SDK comes from here.
-# - vllm/trtllm/none: SDK already in runtime; this COPY is a no-op overwrite.
+# - vllm/trtllm/none: wheel_builder built NIXL (nixl_ref set in context.yaml),
+#   so /wheel_builder/opt/nvidia/nvda_nixl exists — copy it in.
+# - sglang: nixl_ref is intentionally unset (we don't rebuild NIXL), so
+#   /wheel_builder/opt/nvidia/nvda_nixl does NOT exist and this COPY is a
+#   no-op. The SDK is constructed below from the upstream wheel after the
+#   venv is set up (see "nixl-cu detect").
 {% if device == "cuda" %}
 RUN --mount=from=wheel_builder,target=/wheel_builder \
     if [ -d /wheel_builder/opt/nvidia/nvda_nixl ]; then \
@@ -209,6 +214,7 @@ RUN --mount=from=wheel_builder,target=/wheel_builder \
             echo "/usr/lib64" > /etc/ld.so.conf.d/gdrcopy.conf; \
         fi; \
     fi
+
 {% endif %}
 
 {% if device == "xpu" %}
@@ -362,6 +368,32 @@ RUN if command -v uv >/dev/null 2>&1; then \
     else \
         python3 -m pip install maturin[patchelf] ; \
     fi
+
+# nixl-cu detect: on sglang the upstream runtime image ships a pre-installed
+# nixl-cu${CUDA_MAJOR} Python wheel but no C++ SDK, so this builds /opt/nvidia/
+# nvda_nixl/ from the wheel's bundled libs + headers fetched from GitHub at
+# the wheel's exact version. No-op on vllm/trtllm/none (SDK already present).
+{% if device == "cuda" %}
+RUN if [ ! -d /opt/nvidia/nvda_nixl/include ] && \
+       /opt/dynamo/venv/bin/python3 -c "import importlib.metadata; importlib.metadata.version('nixl-cu${CUDA_MAJOR}')" 2>/dev/null; then \
+        NIXL_VER=$(/opt/dynamo/venv/bin/python3 -c "import importlib.metadata; print(importlib.metadata.version('nixl-cu${CUDA_MAJOR}'))") && \
+        echo "Auto-detected nixl-cu${CUDA_MAJOR} version: ${NIXL_VER} — fetching matching SDK headers" && \
+        mkdir -p /opt/nvidia/nvda_nixl/include /opt/nvidia/nvda_nixl/lib64 /etc/ld.so.conf.d && \
+        cd /tmp && \
+        curl -fsSL "https://github.com/ai-dynamo/nixl/archive/refs/tags/v${NIXL_VER}.tar.gz" -o nixl-src.tar.gz && \
+        mkdir -p nixl-extract && cd nixl-extract && \
+        tar -xzf /tmp/nixl-src.tar.gz && \
+        cp -r "nixl-${NIXL_VER}/src/api/cpp/." /opt/nvidia/nvda_nixl/include/ && \
+        cp -r "nixl-${NIXL_VER}/src/utils" /opt/nvidia/nvda_nixl/include/utils && \
+        cd /tmp && rm -rf nixl-src.tar.gz nixl-extract && \
+        WHEEL_LIBS="/opt/dynamo/venv/lib/python${PYTHON_VERSION}/site-packages/.nixl_cu${CUDA_MAJOR}.mesonpy.libs" && \
+        for f in libnixl libnixl_build libnixl_capi libnixl_common libnixl_test_utils libserdes libstream libfile_utils libobj_utils; do \
+            [ -f "${WHEEL_LIBS}/${f}.so" ] && ln -sf "${WHEEL_LIBS}/${f}.so" "/opt/nvidia/nvda_nixl/lib64/${f}.so"; \
+        done && \
+        echo "/opt/dynamo/venv/lib/python${PYTHON_VERSION}/site-packages/nixl_cu${CUDA_MAJOR}.libs" > /etc/ld.so.conf.d/nixl_cu_deps.conf && \
+        ldconfig; \
+    fi
+{% endif %}
 
 # Set commit SHA for tests (passed via docker build as --build-arg)
 ARG DYNAMO_COMMIT_SHA

--- a/container/templates/dev.Dockerfile
+++ b/container/templates/dev.Dockerfile
@@ -378,9 +378,10 @@ RUN if [ ! -d /opt/nvidia/nvda_nixl/include ] && \
        /opt/dynamo/venv/bin/python3 -c "import importlib.metadata; importlib.metadata.version('nixl-cu${CUDA_MAJOR}')" 2>/dev/null; then \
         NIXL_VER=$(/opt/dynamo/venv/bin/python3 -c "import importlib.metadata; print(importlib.metadata.version('nixl-cu${CUDA_MAJOR}'))") && \
         echo "Auto-detected nixl-cu${CUDA_MAJOR} version: ${NIXL_VER} — fetching matching SDK headers" && \
-        mkdir -p /opt/nvidia/nvda_nixl/include /opt/nvidia/nvda_nixl/lib64 /etc/ld.so.conf.d && \
+        mkdir -p /opt/nvidia/nvda_nixl/include /opt/nvidia/nvda_nixl/lib64/plugins /etc/ld.so.conf.d && \
         cd /tmp && \
-        curl -fsSL "https://github.com/ai-dynamo/nixl/archive/refs/tags/v${NIXL_VER}.tar.gz" -o nixl-src.tar.gz && \
+        curl -fsSL --retry 5 --retry-delay 3 --max-time 90 \
+            "https://github.com/ai-dynamo/nixl/archive/refs/tags/v${NIXL_VER}.tar.gz" -o nixl-src.tar.gz && \
         mkdir -p nixl-extract && cd nixl-extract && \
         tar -xzf /tmp/nixl-src.tar.gz && \
         cp -r "nixl-${NIXL_VER}/src/api/cpp/." /opt/nvidia/nvda_nixl/include/ && \
@@ -388,8 +389,15 @@ RUN if [ ! -d /opt/nvidia/nvda_nixl/include ] && \
         cd /tmp && rm -rf nixl-src.tar.gz nixl-extract && \
         WHEEL_LIBS="/opt/dynamo/venv/lib/python${PYTHON_VERSION}/site-packages/.nixl_cu${CUDA_MAJOR}.mesonpy.libs" && \
         for f in libnixl libnixl_build libnixl_capi libnixl_common libnixl_test_utils libserdes libstream libfile_utils libobj_utils; do \
-            [ -f "${WHEEL_LIBS}/${f}.so" ] && ln -sf "${WHEEL_LIBS}/${f}.so" "/opt/nvidia/nvda_nixl/lib64/${f}.so"; \
-        done && \
+            if [ -f "${WHEEL_LIBS}/${f}.so" ]; then \
+                ln -sf "${WHEEL_LIBS}/${f}.so" "/opt/nvidia/nvda_nixl/lib64/${f}.so"; \
+            fi; \
+        done; \
+        for plugin in "${WHEEL_LIBS}/plugins/"*.so; do \
+            if [ -f "${plugin}" ]; then \
+                ln -sf "${plugin}" "/opt/nvidia/nvda_nixl/lib64/plugins/$(basename "${plugin}")"; \
+            fi; \
+        done; \
         echo "/opt/dynamo/venv/lib/python${PYTHON_VERSION}/site-packages/nixl_cu${CUDA_MAJOR}.libs" > /etc/ld.so.conf.d/nixl_cu_deps.conf && \
         ldconfig; \
     fi

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -3885,9 +3885,9 @@ dependencies = [
 
 [[package]]
 name = "nixl-sys"
-version = "0.10.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64cc4aaa4b0e9e49b677db3a58e24c91d1293952d3ef6430da235704740b3a6d"
+checksum = "e4f28c4892e39d6f5d8bcd551e7001c03a04b16e5669a9a7d67b23f9720ecaae"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -4698,9 +4698,9 @@ dependencies = [
 
 [[package]]
 name = "nixl-sys"
-version = "0.10.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64cc4aaa4b0e9e49b677db3a58e24c91d1293952d3ef6430da235704740b3a6d"
+checksum = "e4f28c4892e39d6f5d8bcd551e7001c03a04b16e5669a9a7d67b23f9720ecaae"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",

--- a/lib/llm/Cargo.toml
+++ b/lib/llm/Cargo.toml
@@ -120,7 +120,7 @@ dialoguer = { version = "0.11", default-features = false, features = [
 
 # block_manager
 aligned-vec = { version = "0.6.4", optional = true }
-nixl-sys = { version = "=0.10.1", optional = true }
+nixl-sys = { version = "=1.0.0", optional = true }
 cudarc = { workspace = true, optional = true }
 nix = { version = "0.26", optional = true }
 

--- a/lib/memory/Cargo.toml
+++ b/lib/memory/Cargo.toml
@@ -25,7 +25,7 @@ testing-all = ["testing-cuda", "testing-nixl"]
 [dependencies]
 anyhow = { workspace = true }
 cudarc = { workspace = true }
-nixl-sys = { version = "=0.10.1" }
+nixl-sys = { version = "=1.0.0" }
 serde = { workspace = true}
 thiserror = { workspace = true }
 tracing = { workspace = true }


### PR DESCRIPTION
#### Overview:

#9216 tried to fix the sglang cargo `nixl-sys` link error by building NIXL at `nixl_ref: 0.10.1`, but didn't fix the runtime NIXL ABI mismatch with the `nixl-cu1X==1.0.0` wheel that the upstream `lmsysorg/sglang` base already ships.

#### Details:

- **How is this fixed?** Drop `sglang.nixl_ref` in `container/context.yaml` so wheel_builder no longer builds NIXL for sglang (Jinja gate). New "nixl-cu detect" RUN in `container/templates/dev.Dockerfile`: read version from the upstream wheel via `importlib.metadata`, curl matching headers from the GitHub release tarball, symlink wheel libs (including `plugins/*.so`) into `/opt/nvidia/nvda_nixl/lib64/`, ldconfig the wheel's auditwheel-mangled deps dir.
- Rust `nixl-sys` pin `=0.10.1` → `=1.0.0` to match the wheel's libnixl ABI (`lib/{llm,memory}/Cargo.toml`, root + `lib/bindings/python` + `lib/bindings/kvbm` Cargo.locks)
- Bump vllm/trtllm/dynamo `nixl_ref` 0.10.1 → v1.0.0 in `container/context.yaml` so their wheel_builder builds NIXL v1.0.0 to match the new `nixl-sys=1.0.0` pin (their bases don't ship a nixl wheel, so they still build it themselves)
- Concrete failure mode: `ImportError: nixl_cu13/_bindings.so: undefined symbol: _ZNK9nixlAgent13prepXferDlistERK12nixlDescListI13nixlBasicDescERP10nixlDlistHPK21nixlAgentOptionalArgs` (2-arg `prepXferDlist` overload added in NIXL v1.0.0; not in 0.10.1)

#### Verification:

cu12.9 and cu13.0 sglang dev images rebuilt clean; build + sglang `aggregated-2` pass on both (60.61s / 63.06s).

#### Where should the reviewer start?

\`container/templates/dev.Dockerfile\` (the new \"nixl-cu detect\" RUN), then \`container/context.yaml\` (sglang section + the v1.0.0 bumps for the other frameworks)

/coderabbit profile chill