### PR TITLE
fix(recipes): dsv4 vllm — disable flashinfer autotune

### DIFF
--- a/recipes/deepseek-v4/deepseek-v4-flash/README.md
+++ b/recipes/deepseek-v4/deepseek-v4-flash/README.md
@@ -130,6 +130,7 @@ curl http://localhost:8000/v1/chat/completions \
 | `--kv-cache-dtype fp8` + `--block-size 256` | FP8 KV cache; block size matches the upstream recipe |
 | `--tensor-parallel-size 1 --data-parallel-size 4 --enable-expert-parallel` | DP=4 + EP across the 4 GPUs (TP=1) |
 | `--compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["all"]}'` | Single-node DEP compilation config from the upstream recipe |
+| `--no-enable-flashinfer-autotune` | Skip per-shape FlashInfer autotuning at startup; required on dsv4 for correct accuracy |
 | `--max-num-seqs 256` | Concurrency cap |
 
 ### vLLM GB200 (`vllm/agg_gb200/deploy.yaml`)
@@ -140,6 +141,7 @@ Same OpenAI-renderer wiring as the B200 variant; differences below come from the
 |---|---|
 | `--tensor-parallel-size 4 --enable-expert-parallel` | **TP=4 + EP** across the 4 GPUs of the NVL4 tray (DP dropped — the GB200 tray's intra-tray NVLink makes TP attractive for this size class) |
 | `--moe-backend deep_gemm_mega_moe` | DeepGEMM "mega MoE" kernel — the optimized FP8 MoE path for V4 expert routing on Blackwell |
+| `--no-enable-flashinfer-autotune` | Skip per-shape FlashInfer autotuning at startup; required on dsv4 for correct accuracy |
 | `NCCL_NVLS_ENABLE=1`, `NCCL_P2P_LEVEL=NVL`, `VLLM_USE_NCCL_SYMM_MEM=1` | Enable NVLink Sharp (NVLS) multicast for one-shot all-reduce on the tray |
 
 ### SGLang B200 (`sglang/agg/deploy.yaml`)
@@ -246,6 +248,7 @@ If `tool_calls` is missing and raw tool-call markers appear in `content`, confir
 - **Prebuilt images.** Both `vllm/agg_b200/deploy.yaml` and `vllm/agg_gb200/deploy.yaml` reference `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0-deepseek-v4-cuda13-dev.2` (multi-arch). To rebuild from source (custom Dynamo branch, different vLLM base, etc.), see [`<repo_root>/container/README.md`](../../../container/README.md).
 - **Engine-ready timeout.** `VLLM_ENGINE_READY_TIMEOUT_S=3600` matches the startup probe budget on both variants.
 - **DP stability (B200 only).** `VLLM_RANDOMIZE_DP_DUMMY_INPUTS=1` and `VLLM_SKIP_P2P_CHECK=1` mirror the DeepSeek-R1 vLLM recipe and stabilize DP dummy inputs. The GB200 variant uses TP (no DP), so `VLLM_RANDOMIZE_DP_DUMMY_INPUTS` is not set.
+- **FlashInfer autotune.** `--no-enable-flashinfer-autotune` skips per-shape FlashInfer autotuning at startup and is set on both vLLM variants. Required on dsv4: the autotuner currently produces tunings that regress GSM8k accuracy. Skipping it also shortens first-launch warmup.
 - **FlashInfer TRT-LLM allreduce on GB200.** You may see a non-fatal startup warning `Failed to initialize FlashInfer Allreduce norm fusion workspace ... Flashinfer allreduce-norm fusion will be disabled`. vLLM falls back to a non-fused allreduce + RMSNorm; correctness is unaffected. To enable the fused kernel, set the compilation pass: `--compilation-config '{"mode":3,"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["all"],"pass_config":{"fuse_allreduce_rms":true}}'`.
 
 ### SGLang-specific

--- a/recipes/deepseek-v4/deepseek-v4-flash/vllm/agg_b200/deploy.yaml
+++ b/recipes/deepseek-v4/deepseek-v4-flash/vllm/agg_b200/deploy.yaml
@@ -98,6 +98,7 @@ spec:
                 --dyn-tool-call-parser deepseek_v4 \
                 --attention-config '{"use_fp4_indexer_cache":true}' \
                 --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["all"]}' \
+                --no-enable-flashinfer-autotune \
                 --max-num-seqs 256
       replicas: 1
       resources:

--- a/recipes/deepseek-v4/deepseek-v4-flash/vllm/agg_gb200/deploy.yaml
+++ b/recipes/deepseek-v4/deepseek-v4-flash/vllm/agg_gb200/deploy.yaml
@@ -106,6 +106,7 @@ spec:
                 --attention-config '{"use_fp4_indexer_cache":true}' \
                 --moe-backend deep_gemm_mega_moe \
                 --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["all"]}' \
+                --no-enable-flashinfer-autotune \
                 --max-num-seqs 256
       replicas: 1
       resources:

--- a/recipes/deepseek-v4/deepseek-v4-pro/README.md
+++ b/recipes/deepseek-v4/deepseek-v4-pro/README.md
@@ -145,6 +145,7 @@ curl http://localhost:8000/v1/chat/completions \
 | `--kv-cache-dtype fp8` + `--block-size 256` | FP8 KV cache; block size matches the upstream recipe |
 | `--tensor-parallel-size 8 --enable-expert-parallel` | TP=8 across 8 GPUs of one node, with EP enabled for the MoE experts |
 | `--compilation-config '{"mode":0,"cudagraph_mode":"FULL_DECODE_ONLY"}'` | Conservative cudagraph mode appropriate for the larger Pro model (matches upstream V4-Pro example) |
+| `--no-enable-flashinfer-autotune` | Skip per-shape FlashInfer autotuning at startup; required on dsv4 for correct accuracy |
 | `--max-num-seqs 256` | Concurrency cap |
 
 ### vLLM GB200 agg (`vllm/agg/gb200/deploy.yaml`)
@@ -156,6 +157,7 @@ V4-Pro at ~865 GB on disk does not fit a single GB200 NVL4 tray (~768 GB HBM acr
 | `--tensor-parallel-size 8 --enable-expert-parallel` | TP=8 + EP across 2 nodes (4 GPUs/node × 2 nodes) — no DP. |
 | `--compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["all"],"pass_config":{"fuse_allreduce_rms":false}}'` | FULL_AND_PIECEWISE cudagraph + all custom ops; `fuse_allreduce_rms:false` avoids a non-fatal FlashInfer trtllm allreduce-norm workspace warning at startup. |
 | `--attention-config '{"use_fp4_indexer_cache":true}'` + `--moe-backend deep_gemm_mega_moe` | Blackwell FP4 indexer cache + DeepGEMM "mega MoE" kernel — same kernels as the B200 agg variant. |
+| `--no-enable-flashinfer-autotune` | Skip per-shape FlashInfer autotuning at startup; required on dsv4 for correct accuracy |
 | `NCCL_MNNVL_ENABLE=1`, `UCX_CUDA_IPC_ENABLE_MNNVL=y`, `UCX_TLS=cuda_copy,cuda_ipc,tcp`, `NCCL_NVLS_ENABLE=1`, `NCCL_P2P_LEVEL=NVL` | Enable cross-node NVLink72 / MNNVL fabric. Required because the TP=8 process group spans 2 nodes. |
 | `ComputeDomain` CR + `resourceClaimTemplate` (top of manifest) | DRA primitive that asks the scheduler to allocate an MNNVL channel on demand and co-locate the 2-pod set on the same NVLink72 clique. |
 | (no `--data-parallel-rpc-port`) | TP-only — torch.distributed master binds `MASTER_PORT` (29500) for the cross-node rendezvous, which also satisfies the operator's `wait-for-leader-mp` TCP probe. |
@@ -172,6 +174,7 @@ V4-Pro at ~865 GB on disk does not fit a single GB200 NVL4 tray (~768 GB HBM acr
 | `NCCL_MNNVL_ENABLE=1`, `UCX_CUDA_IPC_ENABLE_MNNVL=y`, `NCCL_NVLS_ENABLE=1`, `NCCL_P2P_LEVEL=NVL` | Enable cross-node NVLink72 / MNNVL fabric. Required because the prefill and decode workers each span 2 nodes. |
 | `ComputeDomain` CR + `resourceClaimTemplate` (top of manifest) | DRA primitive that asks the scheduler to allocate an MNNVL channel on demand and co-locate the 4-pod set on the same NVLink72 clique. Without it, NCCL bring-up across pods fails — TCP-only fallback is not viable for DP=8 cross-pod all-reduce. |
 | `--compilation-config '{"mode":0,"cudagraph_mode":"FULL_DECODE_ONLY"}'` (decode), `--enforce-eager` (prefill) | Conservative compile/graph config — matches the B200 agg variant's V4-Pro tuning. |
+| `--no-enable-flashinfer-autotune` (prefill + decode) | Skip per-shape FlashInfer autotuning at startup; required on dsv4 for correct accuracy |
 | `--max-model-len 9280`, `--max-num-seqs 16` (prefill) / `128` (decode) | Capped to the 8K-input / 1K-output benchmark shape. |
 
 ### SGLang (`sglang/agg/deploy.yaml`)
@@ -288,6 +291,7 @@ If `tool_calls` is missing and raw tool-call markers appear in `content`, confir
 
 - **Prebuilt images.** All three vLLM manifests (`vllm/agg/b200/`, `vllm/agg/gb200/`, `vllm/disagg/gb200/`) reference `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0-deepseek-v4-cuda13-dev.2` (multi-arch). To rebuild from source (custom Dynamo branch, different vLLM base, etc.), see [`<repo_root>/container/README.md`](../../../container/README.md).
 - **Engine-ready timeout.** `VLLM_ENGINE_READY_TIMEOUT_S=5400` is set to match the startup probe budget (`failureThreshold: 540` at `periodSeconds: 10`).
+- **FlashInfer autotune.** `--no-enable-flashinfer-autotune` skips per-shape FlashInfer autotuning at startup and is set on every vLLM worker (prefill and decode). Required on dsv4: the autotuner currently produces tunings that regress GSM8k accuracy. Skipping it also shortens first-launch warmup.
 - **GB200: agg vs. disagg.** Both spread V4-Pro across two GB200 NVL4 trays via MNNVL/ComputeDomain. The agg variant runs one TP=8 group across both nodes (lower-latency, simpler topology, 2 pods); the disagg variant runs separate prefill and decode DP=8 workers (higher steady-state throughput at high concurrency, 4 pods). Use the agg variant for general-purpose serving and the disagg variant when prefill/decode separation pays off for the workload.
 
 ### SGLang-specific

--- a/recipes/deepseek-v4/deepseek-v4-pro/vllm/agg/b200/deploy.yaml
+++ b/recipes/deepseek-v4/deepseek-v4-pro/vllm/agg/b200/deploy.yaml
@@ -102,6 +102,7 @@ spec:
                 --dyn-tool-call-parser deepseek_v4 \
                 --attention-config '{"use_fp4_indexer_cache":true}' \
                 --compilation-config '{"mode":0,"cudagraph_mode":"FULL_DECODE_ONLY"}' \
+                --no-enable-flashinfer-autotune \
                 --max-num-seqs 256
       replicas: 1
       resources:

--- a/recipes/deepseek-v4/deepseek-v4-pro/vllm/agg/gb200/deploy.yaml
+++ b/recipes/deepseek-v4/deepseek-v4-pro/vllm/agg/gb200/deploy.yaml
@@ -151,4 +151,5 @@ spec:
                 --dyn-tool-call-parser deepseek_v4 \
                 --attention-config '{"use_fp4_indexer_cache":true}' \
                 --moe-backend deep_gemm_mega_moe \
-                --compilation-config '{"mode":3,"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["all"],"pass_config":{"fuse_allreduce_rms":true}}'
+                --compilation-config '{"mode":3,"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["all"],"pass_config":{"fuse_allreduce_rms":true}}' \
+                --no-enable-flashinfer-autotune

--- a/recipes/deepseek-v4/deepseek-v4-pro/vllm/disagg/gb200/deploy.yaml
+++ b/recipes/deepseek-v4/deepseek-v4-pro/vllm/disagg/gb200/deploy.yaml
@@ -244,6 +244,7 @@ spec:
                 --max-cudagraph-capture-size 128 \
                 --max-num-batched-tokens 128 \
                 --no-enable-prefix-caching \
+                --no-enable-flashinfer-autotune \
                 --gpu-memory-utilization 0.9 \
                 --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY","mode":0}' \
                 --stream-interval 50 \


### PR DESCRIPTION
## Summary

- Pin `--no-enable-flashinfer-autotune` on every dsv4 vLLM worker (prefill + decode) across the dsv4-pro and dsv4-flash recipes. The FlashInfer autotuner currently produces tunings that regress GSM8k accuracy on DeepSeek-V4 (~0.85 vs ~0.94 expected).
- Mirrors the SGLang recipes which already pass `--disable-flashinfer-autotune`.
- Document the flag in the per-recipe flag tables and the vLLM-specific notes section of both READMEs.

## Files changed

- `recipes/deepseek-v4/deepseek-v4-pro/vllm/agg/b200/deploy.yaml`
- `recipes/deepseek-v4/deepseek-v4-pro/vllm/agg/gb200/deploy.yaml`
- `recipes/deepseek-v4/deepseek-v4-pro/vllm/disagg/gb200/deploy.yaml` (decode worker — prefill already had it)
- `recipes/deepseek-v4/deepseek-v4-flash/vllm/agg_b200/deploy.yaml`
- `recipes/deepseek-v4/deepseek-v4-flash/vllm/agg_gb200/deploy.yaml`
- `recipes/deepseek-v4/deepseek-v4-pro/README.md`
- `recipes/deepseek-v4/deepseek-v4-flash/README.md`

## Test plan

- [ ] Re-run the dsv4-pro vLLM disagg-gb200 GSM8k eval on the existing srt-slurm/InferenceX path; confirm exact_match ≥ 0.94
- [ ] Smoke each agg recipe (`vllm/agg/b200`, `vllm/agg/gb200`, `vllm-flash/agg_b200`, `vllm-flash/agg_gb200`) by deploying and hitting `/v1/chat/completions`
- [ ] Verify first-launch warmup time decreases (autotune skipped)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9268" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated vLLM deployment configurations across DeepSeek-V4 models (flash and pro) for both B200 and GB200 GPU variants to include necessary runtime settings.

* **Documentation**
  * Updated deployment guides to document required vLLM runtime configuration for DeepSeek-V4 models across all deployment modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->