### PR TITLE
fix(docs): update OpenAI API reference URLs in backend-guide

### DIFF
--- a/docs/development/backend-guide.md
+++ b/docs/development/backend-guide.md
@@ -67,8 +67,8 @@ The `model_input` can be:
 - ModelInput.Text. Your engine expects raw text input and handles its own tokenization and pre-processing.
 
 The `model_type` can be:
-- ModelType.Chat. Your `generate` method receives a `request` and must return a response dict of type [OpenAI Chat Completion](https://platform.openai.com/docs/api-reference/chat).
-- ModelType.Completions. Your `generate` method receives a `request` and must return a response dict of the older [Completions](https://platform.openai.com/docs/api-reference/completions/create).
+- ModelType.Chat. Your `generate` method receives a `request` and must return a response dict of type [OpenAI Chat Completion](https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create).
+- ModelType.Completions. Your `generate` method receives a `request` and must return a response dict of the older [Completions](https://developers.openai.com/api/reference/resources/completions/methods/create).
 
 `register_model` can also take the following kwargs:
 - `model_name`: The name to call the model. Your incoming HTTP requests model name must match this. Defaults to the hugging face repo name or the folder name.


### PR DESCRIPTION
## Summary

The lychee link checker reports 404 on the two `platform.openai.com` URLs in `docs/development/backend-guide.md`. OpenAI moved their API reference to `developers.openai.com` with a deeper `resources/.../methods/create` structure. Point at the new canonical pages.

| Old (404) | New |
|---|---|
| `https://platform.openai.com/docs/api-reference/chat` | `https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create` |
| `https://platform.openai.com/docs/api-reference/completions/create` | `https://developers.openai.com/api/reference/resources/completions/methods/create` |

The new URLs land on the request/response schema pages — same intent as the originals (telling implementers what response dict to return).

## Out of scope

The same broken URLs also appear in two source-code comments (`lib/llm/src/protocols/openai/completions/delta.rs:25`, `lib/bindings/python/examples/hello_world/server_sglang_tok.py:61`). Those aren't link-checked, so leaving them alone here to keep the PR small. Happy to do a follow-up if wanted.

## Test plan

- [ ] CI lychee job (`Docs link check` workflow) passes — the only change is the two URLs in `backend-guide.md`
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9270" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated backend development guide sections for Chat and Completions model types with clearer references to OpenAI's official documentation.
  * Enhanced external links throughout the guide to point directly to OpenAI Developers documentation, providing better access to current API specifications and response format information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->