### PR TITLE
feat(mm-routing): lightseek-mm Rust-frontend MM-aware KV routing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,6 +220,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-nats"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2471,6 +2482,7 @@ dependencies = [
  "mockito",
  "modelexpress-client",
  "modelexpress-common",
+ "moka",
  "ndarray 0.16.1",
  "nix 0.26.4",
  "nixl-sys",
@@ -5267,6 +5279,26 @@ dependencies = [
  "tonic 0.13.1",
  "tonic-build 0.13.1",
  "tracing",
+]
+
+[[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "async-lock",
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "event-listener",
+ "futures-util",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
 ]
 
 [[package]]
@@ -8420,6 +8452,12 @@ dependencies = [
  "toml 0.8.23",
  "version-compare",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "target-lexicon"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ chrono = { version = "0.4", default-features = false, features = [
 ] }
 cudarc = { version = "=0.19.3", features = ["cuda-version-from-build-system", "fallback-latest"] }
 dashmap = { version = "6.1" }
+moka = { version = "0.12", features = ["future"] }
 derive_builder = { version = "0.20" }
 derive-getters = { version = "0.5" }
 either = { version = "1.13", features = ["serde"] }

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -1903,7 +1903,16 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         forwarded_hashes = extra_args.get("mm_hashes")
         mm_uuids: dict[str, Any] | None = None
         if forwarded_hashes:
-            mm_uuids = {"image": forwarded_hashes}
+            # vLLM binds multi_modal_uuids by modality key string match.
+            # For models with use_unified_vision_chunk=True (e.g. Kimi-K2.5)
+            # images live under `vision_chunk`, not `image`; hardcoding
+            # `image` here would silently fail to bind and force vLLM back
+            # to its own content-derived hash, breaking router/worker
+            # cache-key alignment.
+            mm_modality_key = (
+                "vision_chunk" if self._use_unified_vision_chunk else "image"
+            )
+            mm_uuids = {mm_modality_key: forwarded_hashes}
         elif self.embedding_loader is None:
             mm_uuids = _compute_mm_uuids(multi_modal_data)
             if mm_uuids and multi_modal_data:

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -637,6 +637,21 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         self._quiesce_lock = asyncio.Lock()
         self._mm_kwargs_receiver: MmKwargsNixlReceiver | None = None
 
+        # Some models (Kimi-K2.5) declare their image modality as
+        # "vision_chunk" rather than "image". vLLM's openai entrypoint
+        # renames the dict key + wraps images via the chat_utils tracker,
+        # but dynamo bypasses chat_utils and builds `multi_modal_data`
+        # directly — so we mirror the rename + wrap here. The flag lives
+        # on the model's HF config; defaults to False for all other
+        # families.
+        self._use_unified_vision_chunk = bool(
+            getattr(
+                self.engine_client.vllm_config.model_config.hf_config,
+                "use_unified_vision_chunk",
+                False,
+            )
+        )
+
         # Serialise concurrent scale_elastic_ep calls.  vLLM's elastic-EP
         # bootstrap creates a fresh TCPStore per scale operation and stores it
         # in engine_client._coord_store.  When two callers race through
@@ -1700,17 +1715,38 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                 )
 
         image_mm_items = mm_map.get(IMAGE_URL_KEY, [])
-        if "image" not in vllm_mm_data and image_mm_items:
+        # Kimi-K2.5 (and any model with `use_unified_vision_chunk=True`)
+        # consumes images under the `vision_chunk` modality, not `image`,
+        # and expects each item to be a `VisionChunkImage` TypedDict.
+        # See chat_utils.use_unified_vision_chunk_modality for the
+        # upstream rename + wrap path.
+        image_modality_key = (
+            "vision_chunk" if self._use_unified_vision_chunk else "image"
+        )
+        if image_modality_key not in vllm_mm_data and image_mm_items:
             with _nvtx.annotate("mm_backend:image_download", color="green"):
                 images = await self.image_loader.load_image_batch(
                     image_mm_items,
                 )
 
             if images:
-                # vLLM expects single image or list
-                vllm_mm_data["image"] = images[0] if len(images) == 1 else images
+                if self._use_unified_vision_chunk:
+                    # `VisionChunkImage` is a TypedDict — a plain dict
+                    # with `type`/`image`/`uuid` keys is structurally
+                    # equivalent. uuid=None matches vLLM's chat_utils
+                    # path when the request doesn't pre-supply one.
+                    chunks = [
+                        {"type": "image", "image": img, "uuid": None} for img in images
+                    ]
+                    vllm_mm_data["vision_chunk"] = (
+                        chunks[0] if len(chunks) == 1 else chunks
+                    )
+                else:
+                    # vLLM expects single image or list
+                    vllm_mm_data["image"] = images[0] if len(images) == 1 else images
                 logger.debug(
-                    f"Extracted {len(images)} image(s) for multimodal processing"
+                    f"Extracted {len(images)} image(s) for multimodal "
+                    f"processing under modality={image_modality_key!r}"
                 )
 
         video_mm_items = mm_map.get(VIDEO_URL_KEY, [])

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -584,6 +584,10 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
     """
 
     _benchmark_results: Optional[dict] = None
+    # Class-level default so test doubles that bypass __init__ via
+    # __new__ still have a sane value; __init__ overrides this from
+    # hf_config.use_unified_vision_chunk on real instances.
+    _use_unified_vision_chunk: bool = False
 
     def __init__(
         self,

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -2235,7 +2235,16 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                         "with grid_thw computation support"
                     )
                     logger.error("Request %s: %s", request_id, msg)
-                    yield {"status": "error", "message": msg}
+                    # Yield in BackendOutput format so the Rust postprocessor
+                    # converts to a proper SSE error event (Annotated::from_error)
+                    # instead of letting a status-error dict leak into the
+                    # response stream as malformed JSON (no `object` field →
+                    # aiperf parse failure).
+                    yield {
+                        "finish_reason": f"error: {msg}",
+                        "index": 0,
+                        "token_ids": [],
+                    }
                     return
             else:
                 # Non-qwen model, assume the multi_modal_data has been consumed

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -2275,16 +2275,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                         "with grid_thw computation support"
                     )
                     logger.error("Request %s: %s", request_id, msg)
-                    # Yield in BackendOutput format so the Rust postprocessor
-                    # converts to a proper SSE error event (Annotated::from_error)
-                    # instead of letting a status-error dict leak into the
-                    # response stream as malformed JSON (no `object` field →
-                    # aiperf parse failure).
-                    yield {
-                        "finish_reason": f"error: {msg}",
-                        "index": 0,
-                        "token_ids": [],
-                    }
+                    yield {"status": "error", "message": msg}
                     return
             else:
                 # Non-qwen model, assume the multi_modal_data has been consumed

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
@@ -517,8 +517,8 @@ class TestDecodeWorkerMultimodalBranching:
             chunks.append(chunk)
 
         assert len(chunks) == 1
-        assert chunks[0]["status"] == "error"
-        assert "without prefill result" in chunks[0]["message"]
+        assert chunks[0]["finish_reason"].startswith("error:")
+        assert "without prefill result" in chunks[0]["finish_reason"]
 
     async def test_decode_only_qwen_missing_embedding_params_errors(self):
         """Decode-only Qwen VL with prefill_result but no embedding_params -> error."""
@@ -545,8 +545,8 @@ class TestDecodeWorkerMultimodalBranching:
             chunks.append(chunk)
 
         assert len(chunks) == 1
-        assert chunks[0]["status"] == "error"
-        assert "embedding metadata" in chunks[0]["message"]
+        assert chunks[0]["finish_reason"].startswith("error:")
+        assert "embedding metadata" in chunks[0]["finish_reason"]
 
     async def test_decode_only_non_qwen_proceeds_without_embedding_params(self):
         """Decode-only non-Qwen with prefill_result but no embedding_params -> proceeds.

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
@@ -517,8 +517,8 @@ class TestDecodeWorkerMultimodalBranching:
             chunks.append(chunk)
 
         assert len(chunks) == 1
-        assert chunks[0]["finish_reason"].startswith("error:")
-        assert "without prefill result" in chunks[0]["finish_reason"]
+        assert chunks[0]["status"] == "error"
+        assert "without prefill result" in chunks[0]["message"]
 
     async def test_decode_only_qwen_missing_embedding_params_errors(self):
         """Decode-only Qwen VL with prefill_result but no embedding_params -> error."""
@@ -545,8 +545,8 @@ class TestDecodeWorkerMultimodalBranching:
             chunks.append(chunk)
 
         assert len(chunks) == 1
-        assert chunks[0]["finish_reason"].startswith("error:")
-        assert "embedding metadata" in chunks[0]["finish_reason"]
+        assert chunks[0]["status"] == "error"
+        assert "embedding metadata" in chunks[0]["message"]
 
     async def test_decode_only_non_qwen_proceeds_without_embedding_params(self):
         """Decode-only non-Qwen with prefill_result but no embedding_params -> proceeds.

--- a/docs/features/multimodal/multimodal-kv-routing.md
+++ b/docs/features/multimodal/multimodal-kv-routing.md
@@ -53,7 +53,7 @@ supports.
 Frontend (Rust + lightseek llm-multimodal + KV router) → Backend Workers
         │
         ├─ Hash image (xxh3_64 of the raw URL — full-URL identity; use --frontend-decoding for content-addressed hashing)
-        ├─ Resolve image-token id (config.json / processor_config.json / vocab probe)
+        ├─ Resolve image-token id via lightseek's per-model ModelProcessorSpec
         ├─ Read (W, H) from a Range: 0-65535 header fetch (or in-memory data: bytes)
         ├─ lightseek::count_tokens(W, H) → expanded image-token count N
         ├─ Expand placeholder × N in routing_token_ids (worker token_ids unchanged)
@@ -64,7 +64,7 @@ Frontend (Rust + lightseek llm-multimodal + KV router) → Backend Workers
 ```
 
 1. The Rust frontend computes an `mm_hash` per image: `xxh3_64` of the decoded bytes for `data:` URIs (and for `http(s)://` when `media_decoder` is enabled on the model), otherwise `xxh3_64` of the full URL string. Two callers will share an `mm_hash` only when they send byte-identical URLs.
-2. The image-token id is resolved per model from `config.json` (`image_token_id` / `image_token_index` / `media_placeholder_token_id`), `processor_config.json` / `tokenizer_config.json` (`image_token` string), or a probe of common placeholder strings against the tokenizer vocab.
+2. The image-placeholder token id is resolved by delegating to lightseek's per-model `ModelProcessorSpec` (one spec per supported VLM family — Qwen3-VL, Qwen2.5-VL, Qwen2-VL, LLaVA-NeXT, LLaVA-1.5, Phi-3-vision, Llama-4, Kimi-K2.5). Each spec reads the appropriate `config.json` field for its model family (`image_token_id`, `image_token_index`, or `media_placeholder_token_id`) and falls back to probing the tokenizer's vocab when only the placeholder string is registered. Models the registry doesn't recognise fall back to text-prefix-only routing.
 3. Per-image `(W, H)` is read from a 64KB `Range`-bounded header fetch (or from in-memory bytes for `data:` URIs); the lightseek `llm-multimodal` crate computes the per-image expanded token count.
 4. The single placeholder token is expanded to N copies in `routing_token_ids` (a router-only view); the worker still sees one placeholder per image in `token_ids`.
 5. Per-block MM metadata (`block_mm_infos`) is built from the expanded view; the KV router evaluates overlap across workers including image-bearing blocks.

--- a/docs/features/multimodal/multimodal-kv-routing.md
+++ b/docs/features/multimodal/multimodal-kv-routing.md
@@ -25,11 +25,36 @@ Without MM-aware routing, the standard router treats image token blocks as opaqu
 
 ## Support Matrix
 
-| Backend | Supported | Notes |
-|---------|-----------|-------|
-| **vLLM** | ✅ | Uses frontend vLLM processor with KV router (`--dyn-chat-processor vllm --router-mode kv`) |
-| **TRT-LLM** | ✅ | Uses dedicated MM Router Worker. Requires `--publish-events-and-metrics` on TRT-LLM workers |
-| **SGLang** | ❌ | Not supported yet |
+| Backend | Path | Supported | Notes |
+|---------|------|-----------|-------|
+| **vLLM** | Rust frontend (default) | ✅ | Uses lightseek `llm-multimodal` for image-token counting + placeholder expansion. Supported models tracked below. |
+| **vLLM** | Python chat-processor (`--dyn-chat-processor vllm --router-mode kv`) | ✅ | Uses vLLM's own multimodal processor — supports any VLM that vLLM supports. |
+| **TRT-LLM** | — | ✅ | Uses dedicated MM Router Worker. Requires `--publish-events-and-metrics` on TRT-LLM workers. |
+| **SGLang** | — | ❌ | Not supported yet. |
+
+## Supported Model Families (Rust frontend path)
+
+The Rust frontend's MM-aware routing path supports the same VLM families that
+[lightseek `llm-multimodal`](https://github.com/lightseekorg/smg/tree/main/crates/multimodal)
+registers in `ImageProcessorRegistry::with_defaults()`.
+
+- Qwen3-VL
+- Qwen2.5-VL
+- Qwen2-VL
+- LLaVA-NeXT (v1.6+)
+- LLaVA-1.5
+- Phi-3-vision
+- Llama-4
+- Kimi-K2.5
+
+A model not in this list will silently fall back to text-prefix-only KV
+routing (image tokens aren't counted, blocks aren't MM-tagged) — the request
+still completes correctly, just without the prefix-cache benefit across
+images.
+
+The Python chat-processor variant doesn't share this constraint — it
+delegates to vLLM's own multimodal processor and works with any VLM vLLM
+supports.
 
 ## How It Works
 
@@ -49,7 +74,7 @@ Frontend (Rust + lightseek llm-multimodal + KV router) → Backend Workers
               vLLM's multi_modal_uuids (cache key match)
 ```
 
-1. The Rust frontend computes an `mm_hash` per image: `xxh3_64` of the decoded bytes for `data:` URIs (and for `http(s)://` when `media_decoder` is enabled on the model), otherwise `xxh3_64` of the URL with cache-buster query params (`v`, `t`, `cache`, `_`, `ts`, `sig`, `signature`) stripped.
+1. The Rust frontend computes an `mm_hash` per image: `xxh3_64` of the decoded bytes for `data:` URIs (and for `http(s)://` when `media_decoder` is enabled on the model), otherwise `xxh3_64` of the full URL string. Two callers will share an `mm_hash` only when they send byte-identical URLs.
 2. The image-token id is resolved per model from `config.json` (`image_token_id` / `image_token_index` / `media_placeholder_token_id`), `processor_config.json` / `tokenizer_config.json` (`image_token` string), or a probe of common placeholder strings against the tokenizer vocab.
 3. Per-image `(W, H)` is read from a 64KB `Range`-bounded header fetch (or from in-memory bytes for `data:` URIs); the lightseek `llm-multimodal` crate computes the per-image expanded token count.
 4. The single placeholder token is expanded to N copies in `routing_token_ids` (a router-only view); the worker still sees one placeholder per image in `token_ids`.

--- a/docs/features/multimodal/multimodal-kv-routing.md
+++ b/docs/features/multimodal/multimodal-kv-routing.md
@@ -171,9 +171,11 @@ cd $DYNAMO_HOME/examples/backends/trtllm/mm_router_worker
 
 See the [TRT-LLM MM Router README](https://github.com/ai-dynamo/dynamo/tree/main/examples/backends/trtllm/mm_router_worker/README.md) for full setup instructions and configuration options.
 
-## Transfer Mode Details (vLLM only)
+## Transfer Mode Details (vLLM chat-processor variant only)
 
-On vLLM backends, the frontend runs the HF image processor and ships the pre-processed `mm_kwargs` to the selected backend worker so the backend can skip re-processing. The `DYNAMO_MM_TRANSFER` environment variable controls how that payload is transferred. (TRT-LLM does not use this path — its backend workers re-run their own preprocessing, so `DYNAMO_MM_TRANSFER` has no effect there.)
+Applies to the `--dyn-chat-processor=vllm` launch (`agg_multimodal_router_chat_processor.sh`), **not** the default Rust frontend path. In the chat-processor variant the frontend runs the HF image processor in-process and ships the pre-processed `mm_kwargs` to the selected backend worker so the backend can skip re-processing; the `DYNAMO_MM_TRANSFER` environment variable controls how that payload is transferred.
+
+The default Rust frontend path doesn't run the HF processor or pre-render `mm_kwargs` — it forwards only `mm_hashes`, and each worker re-processes the image itself. TRT-LLM backends similarly re-run their own preprocessing and don't honor `DYNAMO_MM_TRANSFER`.
 
 - **`shm`** (default): POSIX shared memory via a `/dev/shm` segment. Intended for same-node deployments, where frontend and backend share the host filesystem. If the backend can't access the segment (e.g., running on a different node), it falls back to re-processing the image from the URL.
 - **`nixl`**: NIXL RDMA transfer. Required for cross-node deployments where `/dev/shm` is not shared between frontend and backend. Works across nodes over InfiniBand or TCP (whichever UCX selects).

--- a/docs/features/multimodal/multimodal-kv-routing.md
+++ b/docs/features/multimodal/multimodal-kv-routing.md
@@ -7,7 +7,7 @@ subtitle: Route multimodal requests to workers with the best KV cache overlap
 
 ## Overview
 
-Multimodal KV routing extends Dynamo's KV-aware router to account for image content when computing cache overlap scores. An image hash (`mm_hash`) is computed per request — by the frontend's vLLM processor for vLLM backends, or by a dedicated MM router worker for TRT-LLM backends — and included in per-block routing metadata. The KV router then selects the backend worker with the highest cache overlap, including overlap on image embedding blocks.
+Multimodal KV routing extends Dynamo's KV-aware router to account for image content when computing cache overlap scores. An image hash (`mm_hash`) is computed per request — in the Rust frontend by default for vLLM backends, by vLLM's own processor when the chat-processor variant is enabled, or by a dedicated MM router worker for TRT-LLM backends — and included in per-block routing metadata. The KV router then selects the backend worker with the highest cache overlap, including overlap on image embedding blocks.
 
 Repeated requests containing the same image are routed to the worker that already has the corresponding KV cache blocks, maximizing prefix cache reuse.
 
@@ -33,7 +33,30 @@ Without MM-aware routing, the standard router treats image token blocks as opaqu
 
 ## How It Works
 
-### vLLM
+### vLLM (default — Rust frontend)
+
+```text
+Frontend (Rust + lightseek llm-multimodal + KV router) → Backend Workers
+        │
+        ├─ Hash image (xxh3_64 of normalized URL, or of decoded bytes for data: URIs)
+        ├─ Resolve image-token id (config.json / processor_config.json / vocab probe)
+        ├─ Read (W, H) from a Range: 0-65535 header fetch (or in-memory data: bytes)
+        ├─ lightseek::count_tokens(W, H) → expanded image-token count N
+        ├─ Expand placeholder × N in routing_token_ids (worker token_ids unchanged)
+        ├─ Build per-block MM metadata (block_mm_infos)
+        ├─ KV router selects best worker
+        └─ Forward mm_hash to worker via extra_args["mm_hashes"] →
+              vLLM's multi_modal_uuids (cache key match)
+```
+
+1. The Rust frontend computes an `mm_hash` per image: `xxh3_64` of the decoded bytes for `data:` URIs (and for `http(s)://` when `media_decoder` is enabled on the model), otherwise `xxh3_64` of the URL with cache-buster query params (`v`, `t`, `cache`, `_`, `ts`, `sig`, `signature`) stripped.
+2. The image-token id is resolved per model from `config.json` (`image_token_id` / `image_token_index` / `media_placeholder_token_id`), `processor_config.json` / `tokenizer_config.json` (`image_token` string), or a probe of common placeholder strings against the tokenizer vocab.
+3. Per-image `(W, H)` is read from a 64KB `Range`-bounded header fetch (or from in-memory bytes for `data:` URIs); the lightseek `llm-multimodal` crate computes the per-image expanded token count.
+4. The single placeholder token is expanded to N copies in `routing_token_ids` (a router-only view); the worker still sees one placeholder per image in `token_ids`.
+5. Per-block MM metadata (`block_mm_infos`) is built from the expanded view; the KV router evaluates overlap across workers including image-bearing blocks.
+6. The frontend forwards each image's `mm_hash` (16-hex-char prefix, padded) via `extra_args["mm_hashes"]`; the backend handler injects them as vLLM's `multi_modal_uuids`, so vLLM's own KV-cache key matches the hash the router used.
+
+### vLLM (alternative — Python chat-processor variant)
 
 ```text
 Frontend (vLLM processor + KV router) → Backend Workers
@@ -47,19 +70,7 @@ Frontend (vLLM processor + KV router) → Backend Workers
               → Backend skips HF processor
 ```
 
-1. The frontend's vLLM processor downloads images and runs `process_inputs()` — this invokes the HF image processor and produces expanded token IDs, mm_hashes, and processed pixel values
-2. Per-block routing metadata (`block_mm_infos`) is built from the mm_features, tagging blocks that contain image tokens with their mm_hash
-3. The KV router evaluates overlap across all backend workers, accounting for image-bearing blocks
-4. Pre-processed `mm_kwargs` (pixel values, image grid info) are transferred to the selected worker via shared memory (SHM) or NIXL RDMA, so the backend skips the HF processor entirely
-5. The backend injects the received kwargs into its processor cache for accurate MM cache hit rate metrics
-
-On repeated requests with the same image, the selected worker shows higher cached block counts, reducing prefill latency.
-
-**Key advantages:**
-
-- **Model-agnostic**: Uses vLLM's own `process_inputs()` — supports all multimodal models that vLLM supports, with no model-specific token expansion code
-- **No double processing**: Images are downloaded and processed once on the frontend; the backend receives pre-processed tensors via SHM or NIXL
-- **In-process KV router**: No cross-process RPC overhead for routing decisions
+Use this variant (`--dyn-chat-processor=vllm`) when you want the frontend to run vLLM's HF image processor in-process and ship pre-processed `mm_kwargs` to the selected worker via shared memory or NIXL RDMA, so the backend skips the HF processor entirely. See the [Transfer Mode Details](#transfer-mode-details-vllm-only) section below for the `DYNAMO_MM_TRANSFER` flags.
 
 ### TRT-LLM
 
@@ -74,34 +85,26 @@ Frontend (round-robin) → MM Router Worker → Backend Workers
 
 For TRT-LLM, a dedicated MM Router Worker sits between the frontend and backend workers. See the [TRT-LLM MM Router README](https://github.com/ai-dynamo/dynamo/tree/main/examples/backends/trtllm/mm_router_worker/README.md) for setup instructions.
 
-## Prerequisites
-
-### Upstream vLLM Patch (vLLM backends only)
-
-MM KV routing on vLLM depends on [vllm-project/vllm#39502](https://github.com/vllm-project/vllm/pull/39502), which exposes `InputProcessor.inject_into_mm_cache()` as a public API for injecting pre-processed `mm_kwargs` into the processor cache. Until that PR merges, apply the patch to your installed vLLM:
-
-```bash
-SITE_PACKAGES_ROOT="$(python3 -c 'import pathlib, vllm; print(pathlib.Path(vllm.__file__).resolve().parent.parent)')"
-cd "$SITE_PACKAGES_ROOT"
-curl -sL https://github.com/vllm-project/vllm/pull/39502.diff | python3 -c '
-import sys
-chunks = sys.stdin.read().split("diff --git ")
-filtered = [c for c in chunks if c.startswith("a/vllm/")]
-print("".join("diff --git " + c for c in filtered), end="")
-' > /tmp/vllm_pr39502_vllm_only.diff
-patch --dry-run -p1 < /tmp/vllm_pr39502_vllm_only.diff
-patch -p1 < /tmp/vllm_pr39502_vllm_only.diff
-cd -
-```
-
 ## Launching
 
-### vLLM
+### vLLM (default — Rust frontend)
 
 ```bash
 cd $DYNAMO_HOME
 bash examples/backends/vllm/launch/agg_multimodal_router.sh
 ```
+
+The Rust frontend uses the [lightseek `llm-multimodal`][lightseek-crate] crate
+([source][lightseek-src]) for per-image token-count and placeholder
+expansion. `llm-multimodal` provides a pure-Rust `calculate_num_tokens(W, H,
+PreProcessorConfig)` per VLM family (Qwen2/2.5/3-VL, LLaVA, Pixtral, …),
+golden-tested against `transformers`, so the router can match vLLM's
+expanded image-token count without invoking the HF image processor. The
+frontend then forwards each `mm_hash` to the worker as `multi_modal_uuids`
+so vLLM's KV events publish the same key the router computes.
+
+[lightseek-crate]: https://crates.io/crates/llm-multimodal
+[lightseek-src]: https://github.com/lightseekorg/smg
 
 Key environment variables:
 
@@ -110,8 +113,38 @@ Key environment variables:
 | `MODEL` | `Qwen/Qwen3-VL-2B-Instruct` | Model to serve |
 | `NUM_WORKERS` | `2` | Number of backend workers |
 | `BLOCK_SIZE` | `16` | KV cache block size (must match backend) |
+| `GPU_MEMORY_UTILIZATION` | `0.20` | Per-worker GPU memory fraction |
+| `SINGLE_GPU` | `false` | Pack all workers onto GPU 0 (testing-only override; pass `--single-gpu` or set `SINGLE_GPU=true` for functional tests on a single-GPU box) |
+| `KV_EVENTS_PORT_BASE` | `5557` | Worker `i` publishes ZMQ KV events on `BASE + i - 1` |
+| `DYN_LOG` | `info,lightseek_mm=debug,...` | Frontend log filter |
+| `VLLM_EXTRA_ARGS` | (unset) | Pass-through args to `python -m dynamo.vllm`. Set `--frontend-decoding` to enable content-addressed `mm_hash` (cross-URL KV-cache reuse). |
+
+To opt into frontend image decoding (so the frontend downloads + decodes once and `mm_hash` becomes content-addressed instead of URL-addressed):
+
+```bash
+VLLM_EXTRA_ARGS="--frontend-decoding" \
+    bash examples/backends/vllm/launch/agg_multimodal_router.sh
+```
+
+The worker then registers a `media_decoder` on its model card; the frontend's `MediaLoader` runs in-process and hashes decoded RGB bytes via xxh3. Two distinct (signed) URLs of the same image bytes collide on the same routing key.
+
+### vLLM (alternative — Python chat-processor variant)
+
+```bash
+bash examples/backends/vllm/launch/agg_multimodal_router_chat_processor.sh
+```
+
+Uses `--dyn-chat-processor=vllm` so the frontend runs vLLM's HF processor
+in-process. Adds the `DYNAMO_MM_TRANSFER` shm/NIXL pre-rendered `mm_kwargs`
+delivery channel between frontend and worker.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MODEL` | `Qwen/Qwen3-VL-2B-Instruct` | Model to serve |
+| `NUM_WORKERS` | `2` | Number of backend workers |
+| `BLOCK_SIZE` | `16` | KV cache block size (must match backend) |
 | `GPU_MEMORY_UTILIZATION` | `0.40` | Per-worker GPU memory fraction |
-| `SINGLE_GPU` | `false` | Pack all workers onto GPU 0 (for single-GPU testing) |
+| `SINGLE_GPU` | `false` | Pack all workers onto GPU 0 (testing-only override; pass `--single-gpu` or set `SINGLE_GPU=true` for functional tests on a single-GPU box) |
 | `DYNAMO_MM_TRANSFER` | `shm` | Transfer mode for pre-processed mm_kwargs: `shm` (shared memory, same-node), `nixl` (RDMA, cross-node) |
 | `DYNAMO_DISABLE_NIXL_MM` | unset | Set to `1` to disable mm_kwargs transfer entirely (backend re-processes images from URLs) |
 

--- a/docs/features/multimodal/multimodal-kv-routing.md
+++ b/docs/features/multimodal/multimodal-kv-routing.md
@@ -52,7 +52,7 @@ supports.
 ```text
 Frontend (Rust + lightseek llm-multimodal + KV router) → Backend Workers
         │
-        ├─ Hash image (xxh3_64 of normalized URL, or of decoded bytes for data: URIs)
+        ├─ Hash image (xxh3_64 of the raw URL — full-URL identity; use --frontend-decoding for content-addressed hashing)
         ├─ Resolve image-token id (config.json / processor_config.json / vocab probe)
         ├─ Read (W, H) from a Range: 0-65535 header fetch (or in-memory data: bytes)
         ├─ lightseek::count_tokens(W, H) → expanded image-token count N

--- a/docs/features/multimodal/multimodal-kv-routing.md
+++ b/docs/features/multimodal/multimodal-kv-routing.md
@@ -34,23 +34,12 @@ Without MM-aware routing, the standard router treats image token blocks as opaqu
 
 ## Supported Model Families (Rust frontend path)
 
-The Rust frontend's MM-aware routing path supports the same VLM families that
-[lightseek `llm-multimodal`](https://github.com/lightseekorg/smg/tree/main/crates/multimodal)
-registers in `ImageProcessorRegistry::with_defaults()`.
-
-- Qwen3-VL
-- Qwen2.5-VL
-- Qwen2-VL
-- LLaVA-NeXT (v1.6+)
-- LLaVA-1.5
-- Phi-3-vision
-- Llama-4
-- Kimi-K2.5
-
-A model not in this list will silently fall back to text-prefix-only KV
-routing (image tokens aren't counted, blocks aren't MM-tagged) — the request
-still completes correctly, just without the prefix-cache benefit across
-images.
+The Rust frontend's MM-aware routing path supports whatever VLM families the
+lightseek `llm-multimodal` crate registers — see
+[`ImageProcessorRegistry::with_defaults()`](https://docs.rs/llm-multimodal/1.5.0/llm_multimodal/vision/image_processor/struct.ImageProcessorRegistry.html#method.with_defaults)
+for the up-to-date list. A model that crate doesn't recognize falls back to
+text-prefix-only KV routing (request still completes; just no prefix-cache
+benefit across images).
 
 The Python chat-processor variant doesn't share this constraint — it
 delegates to vLLM's own multimodal processor and works with any VLM vLLM

--- a/examples/backends/vllm/launch/agg_multimodal_router.sh
+++ b/examples/backends/vllm/launch/agg_multimodal_router.sh
@@ -1,89 +1,113 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-
-# Launch script for vLLM MM Frontend Routing demo:
-#   Frontend (vllm processor + KvRouter + ImageLoader) -> vLLM backend
 #
-# This replaces the separate MM Router Worker approach.  The frontend runs
-# vLLM's HF processor for image token expansion and hash computation, builds
-# mm_routing_info, and uses KvRouter directly for MM-aware routing.
+# Lightseek-powered exact MM-aware routing.
 #
-# Benefits over mm_router_worker:
-#   - No extra network hop for base64 image data
-#   - Model-agnostic (no Qwen-specific token expansion)
-#   - Single HF processor call (frontend only; backend skips via NIXL, when enabled)
+# Architecture:
+#   HTTP client
+#     -> Rust frontend
+#          - resolves <|image_pad|> token id from HF JSON (3-tier resolver)
+#          - lightseek `calculate_num_tokens(W,H)` per image (header-only fetch)
+#          - expands placeholder -> N copies in routing_token_ids
+#          - hashes URL (xxh3) -> u64 -> 64-char hex -> extra_args["mm_hashes"]
+#          - builds block_mm_infos and feeds the KV router
+#     -> N x vLLM worker
+#          - publishes KV events via zmq (one port per worker)
+#          - vLLM's mm_uuid is the frontend's hex string -> events match
+#            the router's routing-side block hashes -> bit-exact cache hits
+#
+# Build prerequisite (run once inside the dynamo dev container):
+#   cd /workspace/lib/bindings/python && maturin develop --release --features lightseek-mm
+#
+# Run inside the dynamo container that already has /workspace mounted.
 
 set -euo pipefail
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DYNAMO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
 cd "${DYNAMO_ROOT}"
+# shellcheck source=../../../common/gpu_utils.sh
+source "${SCRIPT_DIR}/../../../common/gpu_utils.sh"
+# shellcheck source=../../../common/launch_utils.sh
+source "${SCRIPT_DIR}/../../../common/launch_utils.sh"
 
-# ---------------------------------------------------------------------------
-# Configuration (override with environment variables)
-# ---------------------------------------------------------------------------
 MODEL="${MODEL:-Qwen/Qwen3-VL-2B-Instruct}"
-NAMESPACE="${NAMESPACE:-dynamo}"
-HTTP_PORT="${HTTP_PORT:-8000}"
-BLOCK_SIZE="${BLOCK_SIZE:-16}"            # Must match vLLM backend KV block size
-GPU_MEMORY_UTILIZATION="${GPU_MEMORY_UTILIZATION:-0.40}"  # Split GPU between 2 workers
-MAX_MODEL_LEN="${MAX_MODEL_LEN:-4096}"   # Reduced for 2 workers on 1 GPU
-NUM_WORKERS="${NUM_WORKERS:-2}"          # Number of backend workers
+NAMESPACE="${NAMESPACE:-lightseek-poc}"
+HTTP_PORT="${HTTP_PORT:-${DYN_HTTP_PORT:-8000}}"
+BLOCK_SIZE="${BLOCK_SIZE:-16}"
+GPU_MEMORY_UTILIZATION="${GPU_MEMORY_UTILIZATION:-0.20}"
+MAX_MODEL_LEN="${MAX_MODEL_LEN:-4096}"
+NUM_WORKERS="${NUM_WORKERS:-2}"
 # --single-gpu / SINGLE_GPU: Packs all workers onto GPU 0 for functional
 # testing on machines with a single GPU.  Reduces performance by sharing
-# GPU memory between workers.
+# GPU memory between workers; production deployments should leave it false.
 SINGLE_GPU="${SINGLE_GPU:-false}"
-NUM_FRONTENDS="${NUM_FRONTENDS:-1}"           # Number of frontend replicas (>1 for parallel HF processing)
-
-# KV cache override for parallel-safe GPU memory control
-KV_BYTES="${_PROFILE_OVERRIDE_VLLM_KV_CACHE_BYTES:-}"
-if [[ -n "$KV_BYTES" ]]; then
-    GPU_MEM_ARGS="--kv-cache-memory-bytes $KV_BYTES --gpu-memory-utilization 0.01"
-else
-    GPU_MEM_ARGS="--gpu-memory-utilization ${GPU_MEMORY_UTILIZATION}"
-fi
-
 NATS_SERVER="${NATS_SERVER:-nats://127.0.0.1:4222}"
 ETCD_ENDPOINTS="${ETCD_ENDPOINTS:-http://127.0.0.1:2379}"
-
 VLLM_SYSTEM_PORT_BASE="${VLLM_SYSTEM_PORT_BASE:-18081}"
+KV_EVENTS_PORT_BASE="${KV_EVENTS_PORT_BASE:-5557}"
+DYN_LOG_VAL="${DYN_LOG:-info,lightseek_mm=debug,dynamo_kv_router::scheduling=debug}"
 
-# ImageLoader cache size (number of images kept in-memory LRU)
-export DYN_MM_IMAGE_CACHE_SIZE="${DYN_MM_IMAGE_CACHE_SIZE:-32}"
-
-# Extra args (word-splitting is intentional for shell-style overrides)
+# Pass-through extra args for `python -m dynamo.vllm`.
 VLLM_EXTRA_ARGS="${VLLM_EXTRA_ARGS:-}"
-FRONTEND_EXTRA_ARGS="${FRONTEND_EXTRA_ARGS:-}"
 
-echo "=== vLLM MM Frontend Routing Launch Script ==="
-echo "Working directory: ${DYNAMO_ROOT}"
+PASSTHRU_ARGS=()
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --model) MODEL="$2"; shift 2 ;;
+        --num-workers) NUM_WORKERS="$2"; shift 2 ;;
+        --single-gpu) SINGLE_GPU="true"; shift ;;
+        -h|--help)
+            cat <<EOF
+Usage: $0 [--model NAME] [--num-workers N] [--single-gpu] [EXTRA_VLLM_ARGS...]
+
+Env vars:
+  MODEL                       (default Qwen/Qwen3-VL-2B-Instruct)
+  NUM_WORKERS                 (default 2)
+  GPU_MEMORY_UTILIZATION      (default 0.20 — sized for 2 workers on 1 GPU)
+  HTTP_PORT                   (default 8000)
+  BLOCK_SIZE                  (default 16)
+  MAX_MODEL_LEN               (default 4096)
+  KV_EVENTS_PORT_BASE         (default 5557 — worker i uses port BASE + (i-1))
+  DYN_LOG                     (default info + lightseek_mm + scheduling debug)
+
+Routing test (run after the script reports "All services are ready"):
+  # Same image twice -> 2nd request should pin to same worker (high overlap_blocks)
+  IMG_A=http://images.cocodataset.org/val2017/000000039769.jpg
+  IMG_B=http://images.cocodataset.org/val2017/000000000139.jpg
+  for url in "\$IMG_A" "\$IMG_A" "\$IMG_B"; do
+    curl -s http://127.0.0.1:${HTTP_PORT}/v1/chat/completions \\
+      -H 'Content-Type: application/json' \\
+      -d '{"model":"'"\${MODEL}"'","messages":[{"role":"user","content":[
+            {"type":"text","text":"Describe this image."},
+            {"type":"image_url","image_url":{"url":"'\$url'"}}]}],"max_tokens":4}' \\
+      | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['usage'])"
+  done
+
+Watch the frontend log for 'Selected worker' + 'Formula' lines. Same-image
+requests should route to the same worker_id and report ~26 effective cached
+blocks; the different-image request should route to a fresh worker (or the
+same one with low overlap).
+EOF
+            exit 0
+            ;;
+        *) PASSTHRU_ARGS+=("$1"); shift ;;
+    esac
+done
+
+echo "=== Lightseek MM Exact Routing Launch ==="
 echo "MODEL=${MODEL}"
-echo "NAMESPACE=${NAMESPACE}"
-echo "HTTP_PORT=${HTTP_PORT}"
-echo "BLOCK_SIZE=${BLOCK_SIZE}"
-echo "NUM_WORKERS=${NUM_WORKERS}"
-echo "SINGLE_GPU=${SINGLE_GPU}"
-echo "NUM_FRONTENDS=${NUM_FRONTENDS}"
-echo "GPU_MEMORY_UTILIZATION=${GPU_MEMORY_UTILIZATION}"
-echo "MAX_MODEL_LEN=${MAX_MODEL_LEN}"
-echo "DYN_MM_IMAGE_CACHE_SIZE=${DYN_MM_IMAGE_CACHE_SIZE}"
-echo "NATS_SERVER=${NATS_SERVER}"
-echo "ETCD_ENDPOINTS=${ETCD_ENDPOINTS}"
-echo "VLLM_SYSTEM_PORT_BASE=${VLLM_SYSTEM_PORT_BASE}"
-echo
+echo "NUM_WORKERS=${NUM_WORKERS}, BLOCK_SIZE=${BLOCK_SIZE}, GPU_MEM_FRAC=${GPU_MEMORY_UTILIZATION}"
+echo "HTTP_PORT=${HTTP_PORT}, NAMESPACE=${NAMESPACE}"
 
-# Clear the trap inside the handler so `kill 0` (which sends SIGTERM to the
-# script itself) doesn't re-enter this trap and loop forever.
-trap 'trap - EXIT INT TERM; echo; echo "Cleaning up..."; kill 0' EXIT INT TERM
+# Clear the trap inside the handler so `kill 0` (which SIGTERMs the script
+# itself) doesn't re-enter this trap and loop forever.
+trap 'trap - EXIT INT TERM; echo; kill 0' EXIT INT TERM
 
 wait_ready() {
-    local url="$1"
-    local name="$2"
-    local timeout_s="${3:-240}"
+    local url="$1" name="$2" timeout_s="${3:-900}"
     local deadline=$((SECONDS + timeout_s))
-
-    echo "Waiting for ${name} at ${url} ..."
+    echo "Waiting for ${name} ..."
     while (( SECONDS < deadline )); do
         if curl -fsS "${url}" 2>/dev/null | grep -q '"status"[[:space:]]*:[[:space:]]*"ready"'; then
             echo "${name} is ready"
@@ -91,120 +115,50 @@ wait_ready() {
         fi
         sleep 1
     done
-
-    echo "Timed out waiting for ${name} (${url})" >&2
     return 1
 }
-
-wait_frontend_models() {
-    local url="$1"
-    local timeout_s="${2:-240}"
-    local deadline=$((SECONDS + timeout_s))
-
-    echo "Waiting for frontend models API at ${url} ..."
-    while (( SECONDS < deadline )); do
-        if curl -fsS "${url}" >/dev/null 2>&1; then
-            echo "Frontend is ready"
-            return 0
-        fi
-        sleep 1
-    done
-
-    echo "Timed out waiting for frontend (${url})" >&2
-    return 1
-}
-
-echo "Prerequisite: start etcd and NATS yourself before running this script."
-echo "Example:"
-echo "  docker compose -f deploy/docker-compose.yml up -d"
-echo
 
 COMMON_ENV=(
     "DYN_NAMESPACE=${NAMESPACE}"
     "DYN_REQUEST_PLANE=tcp"
     "NATS_SERVER=${NATS_SERVER}"
     "ETCD_ENDPOINTS=${ETCD_ENDPOINTS}"
+    "DYN_MM_ALLOW_INTERNAL=1"
 )
+
+GPU_MEM_ARGS=$(build_vllm_gpu_mem_args)
 
 for i in $(seq 1 "${NUM_WORKERS}"); do
     WORKER_PORT=$((VLLM_SYSTEM_PORT_BASE + (i - 1) * 2))
-    KV_EVENTS_PORT=$((${KV_EVENTS_PORT_BASE:-29080} + i - 1))
+    KV_EVENTS_PORT=$((KV_EVENTS_PORT_BASE + (i - 1)))
+    if [[ "${SINGLE_GPU}" == "true" ]]; then GPU_ID=0; else GPU_ID=$((i - 1)); fi
 
-    if [[ "${SINGLE_GPU}" == "true" ]]; then
-        GPU_ID=0
-    else
-        GPU_ID=$((i - 1))
-    fi
+    KV_EVENTS_CONFIG="{\"enable_kv_cache_events\":true,\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:${KV_EVENTS_PORT}\"}"
 
-    echo
-    echo "=== Starting vLLM backend worker $i (GPU ${GPU_ID}, port ${WORKER_PORT}, kv_events ${KV_EVENTS_PORT}) ==="
+    echo "--- launching vLLM worker $i (GPU=${GPU_ID}, system_port=${WORKER_PORT}, kv_events=tcp://*:${KV_EVENTS_PORT}) ---"
     env "${COMMON_ENV[@]}" \
         "DYN_SYSTEM_PORT=${WORKER_PORT}" \
         "CUDA_VISIBLE_DEVICES=${GPU_ID}" \
     python -m dynamo.vllm \
-            --model "${MODEL}" \
-            --enable-multimodal \
-            --block-size "${BLOCK_SIZE}" \
-            --enforce-eager \
-            --kv-events-config "{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:${KV_EVENTS_PORT}\",\"enable_kv_cache_events\":true}" \
-            $GPU_MEM_ARGS \
-            --max-model-len "${MAX_MODEL_LEN}" \
-            ${VLLM_EXTRA_ARGS} &
-    # trap 'kill 0' handles cleanup
-    # Wait for this worker before starting the next one to avoid ZMQ port races.
-    wait_ready "http://127.0.0.1:${WORKER_PORT}/health" "vLLM backend $i" 900
+        --model "${MODEL}" \
+        --enable-multimodal \
+        --block-size "${BLOCK_SIZE}" \
+        --enforce-eager \
+        --max-model-len "${MAX_MODEL_LEN}" \
+        --kv-events-config "${KV_EVENTS_CONFIG}" \
+        ${GPU_MEM_ARGS} ${VLLM_EXTRA_ARGS} "${PASSTHRU_ARGS[@]}" &
+    wait_ready "http://127.0.0.1:${WORKER_PORT}/health" "vLLM backend $i"
 done
 
-echo
-echo "=== Starting frontend (with vLLM processor + KV router) ==="
-# Key flags:
-#   --dyn-chat-processor vllm    : run vLLM's HF processor in the frontend
-#   --router-mode kv             : use KvRouter for MM-aware routing
-#   --kv-cache-block-size        : must match backend's --block-size
-#
-# The frontend's VllmProcessor:
-#   1. Pre-downloads images via ImageLoader (LRU cache + dedup)
-#   2. Runs vLLM's process_inputs() → mm_features with hashes + placeholders
-#   3. Builds mm_routing_info from mm_features → passes to KvRouter
-#   4. Forwards mm_hashes to backend for hash consistency
-FRONTEND_SYSTEM_PORT_BASE="${FRONTEND_SYSTEM_PORT_BASE:-9080}"
+echo "=== Starting frontend (KV router, lightseek MM exact routing) ==="
+env "${COMMON_ENV[@]}" \
+    "DYN_LOG=${DYN_LOG_VAL}" \
+python -m dynamo.frontend \
+    --http-port "${HTTP_PORT}" \
+    --router-mode kv \
+    --kv-cache-block-size "${BLOCK_SIZE}" &
 
-for f in $(seq 1 "${NUM_FRONTENDS}"); do
-    FE_HTTP_PORT=$((HTTP_PORT + f - 1))
-    FE_SYSTEM_PORT=$((FRONTEND_SYSTEM_PORT_BASE + f - 1))
-
-    # Only reset states on the first replica to avoid wiping shared state.
-    RESET_ARGS=""
-    if [[ "$f" -eq 1 ]]; then
-        RESET_ARGS="--router-reset-states"
-    fi
-
-    # Enable replica sync when running multiple frontends.
-    SYNC_ARGS=""
-    if [[ "${NUM_FRONTENDS}" -gt 1 ]]; then
-        SYNC_ARGS="--router-replica-sync"
-    fi
-
-    echo
-    echo "=== Starting frontend replica ${f} (HTTP ${FE_HTTP_PORT}, system ${FE_SYSTEM_PORT}) ==="
-    env "${COMMON_ENV[@]}" \
-        "DYN_LOG=debug" \
-        "DYN_SYSTEM_PORT=${FE_SYSTEM_PORT}" \
-        python -m dynamo.frontend \
-            --http-port "${FE_HTTP_PORT}" \
-            --dyn-chat-processor vllm \
-            --router-mode kv \
-            --kv-cache-block-size "${BLOCK_SIZE}" \
-            ${RESET_ARGS} \
-            ${SYNC_ARGS} \
-            --model-name "${MODEL}" \
-            ${FRONTEND_EXTRA_ARGS} &
-    # trap 'kill 0' handles cleanup
-    wait_frontend_models "http://127.0.0.1:${FE_HTTP_PORT}/v1/models" 300
-done
-
-# Wait until the first frontend can serve a real request (processor loaded).
-echo "Waiting for frontend processor to initialize (this may take a while for custom models)..."
+echo "Waiting for frontend to accept requests ..."
 DEADLINE=$((SECONDS + 300))
 while (( SECONDS < DEADLINE )); do
     HTTP_CODE=$(curl -sf -o /dev/null -w "%{http_code}" \
@@ -212,52 +166,38 @@ while (( SECONDS < DEADLINE )); do
         -H "Content-Type: application/json" \
         -d "{\"model\":\"${MODEL}\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],\"max_tokens\":1}" \
         2>/dev/null || echo "000")
-    if [[ "$HTTP_CODE" == "200" ]]; then
-        echo "Frontend processor is ready"
-        break
-    fi
+    [[ "$HTTP_CODE" == "200" ]] && { echo "Frontend ready"; break; }
     sleep 2
 done
-if (( SECONDS >= DEADLINE )); then
-    echo "Warning: Frontend processor may not be fully ready (timed out)" >&2
-fi
 
 echo
 echo "=== All services are ready ==="
-for f in $(seq 1 "${NUM_FRONTENDS}"); do
-    echo "Frontend ${f}: http://127.0.0.1:$((HTTP_PORT + f - 1))"
-done
+echo "Frontend:        http://127.0.0.1:${HTTP_PORT}"
 for i in $(seq 1 "${NUM_WORKERS}"); do
-    echo "Worker $i: http://127.0.0.1:$((VLLM_SYSTEM_PORT_BASE + (i - 1) * 2))/health"
+    echo "Worker $i health: http://127.0.0.1:$((VLLM_SYSTEM_PORT_BASE + (i - 1) * 2))/health"
+    echo "Worker $i kv-events: tcp://*:$((KV_EVENTS_PORT_BASE + (i - 1)))"
 done
 echo
-echo "Architecture: ${NUM_FRONTENDS}x Frontend (vLLM processor + KvRouter) -> ${NUM_WORKERS}x vLLM backend"
-echo "  - No separate MM Router Worker needed"
-echo "  - ImageLoader LRU cache size: ${DYN_MM_IMAGE_CACHE_SIZE}"
+echo "Architecture: Rust frontend + lightseek -> ${NUM_WORKERS}x vLLM workers"
+echo "  - mm_hashes forwarded as multi_modal_uuids -> bit-exact match with vLLM KV events"
+echo "  - Image dims via header-only HTTP fetch (Range: bytes=0-65535)"
+echo "  - No PyO3, no GIL, no Python deps in the routing path"
 echo
-echo "Test routing: send the same image request 3 times."
-echo "  - Request 1: routed to any worker (no cache yet)"
-echo "  - Request 2: routed to SAME worker (KV cache overlap from request 1)"
-echo "  - Request 3 with different image: may route to the OTHER worker"
+echo "Routing test (recommended):"
+echo "  IMG_A=http://images.cocodataset.org/val2017/000000039769.jpg"
+echo "  IMG_B=http://images.cocodataset.org/val2017/000000000139.jpg"
+echo "  for url in \"\$IMG_A\" \"\$IMG_A\" \"\$IMG_B\"; do"
+echo "    curl -s http://127.0.0.1:${HTTP_PORT}/v1/chat/completions \\"
+echo "      -H 'Content-Type: application/json' \\"
+echo "      -d '{\"model\":\"${MODEL}\",\"messages\":[{\"role\":\"user\",\"content\":["
+echo "            {\"type\":\"text\",\"text\":\"Describe this image.\"},"
+echo "            {\"type\":\"image_url\",\"image_url\":{\"url\":\"'\$url'\"}}]}],\"max_tokens\":4}' \\"
+echo "      | python3 -c \"import sys,json; d=json.load(sys.stdin); print(d['usage'])\""
+echo "  done"
 echo
-echo "Watch for 'Selected worker' in logs to see routing decisions change."
-echo
-echo "Example (same image twice, then different image):"
-echo "  # Request 1 - image A"
-echo "  curl http://127.0.0.1:${HTTP_PORT}/v1/chat/completions \\"
-echo "    -H 'Content-Type: application/json' \\"
-echo "    -d '{\"model\":\"${MODEL}\",\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"Describe this image\"},{\"type\":\"image_url\",\"image_url\":{\"url\":\"http://images.cocodataset.org/test2017/000000000001.jpg\"}}]}],\"max_tokens\":32}'"
-echo
-echo "  # Request 2 - same image A (should route to same worker)"
-echo "  curl http://127.0.0.1:${HTTP_PORT}/v1/chat/completions \\"
-echo "    -H 'Content-Type: application/json' \\"
-echo "    -d '{\"model\":\"${MODEL}\",\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"Describe this image\"},{\"type\":\"image_url\",\"image_url\":{\"url\":\"http://images.cocodataset.org/test2017/000000000001.jpg\"}}]}],\"max_tokens\":32}'"
-echo
-echo "  # Request 3 - different image B (may route to other worker)"
-echo "  curl http://127.0.0.1:${HTTP_PORT}/v1/chat/completions \\"
-echo "    -H 'Content-Type: application/json' \\"
-echo "    -d '{\"model\":\"${MODEL}\",\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"Describe this image\"},{\"type\":\"image_url\",\"image_url\":{\"url\":\"http://images.cocodataset.org/test2017/000000000016.jpg\"}}]}],\"max_tokens\":32}'"
+echo "Watch frontend logs for 'Selected worker: ... worker_id=...' and"
+echo "'Formula for worker_id=X dp_rank=0 with N effective cached blocks'."
 echo
 echo "Press Ctrl+C to stop all services"
 
-wait
+wait_any_exit

--- a/examples/backends/vllm/launch/agg_multimodal_router.sh
+++ b/examples/backends/vllm/launch/agg_multimodal_router.sh
@@ -7,7 +7,10 @@
 # Architecture:
 #   HTTP client
 #     -> Rust frontend
-#          - resolves <|image_pad|> token id from HF JSON (3-tier resolver)
+#          - resolves the image-placeholder token id via lightseek's
+#            per-model ModelProcessorSpec (Qwen3-VL, Qwen2.5-VL, Qwen2-VL,
+#            LLaVA-NeXT, LLaVA-1.5, Phi-3-vision, Llama-4, Kimi-K2.5);
+#            each spec reads the appropriate config.json field
 #          - lightseek `calculate_num_tokens(W,H)` per image (header-only fetch)
 #          - expands placeholder -> N copies in routing_token_ids
 #          - hashes URL (xxh3) -> u64 -> 64-char hex -> extra_args["mm_hashes"]

--- a/examples/backends/vllm/launch/agg_multimodal_router_chat_processor.sh
+++ b/examples/backends/vllm/launch/agg_multimodal_router_chat_processor.sh
@@ -1,0 +1,297 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Launch script: vLLM MM-aware routing via the Python chat-processor variant.
+#
+#   Frontend (--dyn-chat-processor=vllm: vLLM Python preprocessor + KvRouter
+#             + ImageLoader)
+#       -> vLLM backend
+#
+# The frontend runs vLLM's own HF processor in-process for image-token
+# expansion and `mm_hash` computation, builds `mm_routing_info`, and feeds
+# `KvRouter` directly. This is the original MM-aware routing path.
+#
+# The default script (`agg_multimodal_router.sh`) uses the Rust frontend with
+# the `lightseek-mm` feature instead — pure-Rust per-image token-count via
+# the `llm-multimodal` crate, no PyO3/GIL on the routing hot path. Use this
+# `_chat_processor` variant when you specifically want the vLLM Python path
+# (e.g., to take advantage of `DYNAMO_MM_TRANSFER` shm/NIXL pre-rendered
+# `mm_kwargs`).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DYNAMO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+cd "${DYNAMO_ROOT}"
+# shellcheck source=../../../common/gpu_utils.sh
+source "${SCRIPT_DIR}/../../../common/gpu_utils.sh"
+# shellcheck source=../../../common/launch_utils.sh
+source "${SCRIPT_DIR}/../../../common/launch_utils.sh"
+
+# ---------------------------------------------------------------------------
+# Configuration (override with environment variables)
+# ---------------------------------------------------------------------------
+MODEL="${MODEL:-Qwen/Qwen3-VL-2B-Instruct}"
+NAMESPACE="${NAMESPACE:-dynamo}"
+# Honor DYN_HTTP_PORT (set by the tests/serve harness for dynamic
+# port allocation) when HTTP_PORT isn't explicitly given.
+HTTP_PORT="${HTTP_PORT:-${DYN_HTTP_PORT:-8000}}"
+BLOCK_SIZE="${BLOCK_SIZE:-16}"            # Must match vLLM backend KV block size
+GPU_MEMORY_UTILIZATION="${GPU_MEMORY_UTILIZATION:-0.40}"  # Split GPU between 2 workers
+MAX_MODEL_LEN="${MAX_MODEL_LEN:-4096}"   # Reduced for 2 workers on 1 GPU
+NUM_WORKERS="${NUM_WORKERS:-2}"          # Number of backend workers
+# --single-gpu / SINGLE_GPU: Packs all workers onto GPU 0 for functional
+# testing on machines with a single GPU.  Reduces performance by sharing
+# GPU memory between workers.
+SINGLE_GPU="${SINGLE_GPU:-false}"
+NUM_FRONTENDS="${NUM_FRONTENDS:-1}"           # Number of frontend replicas (>1 for parallel HF processing)
+
+# Use the canonical helper for VRAM sizing (handles _PROFILE_OVERRIDE_*
+# and GPU_MEMORY_UTILIZATION fallback uniformly across launch scripts).
+GPU_MEM_ARGS=$(build_vllm_gpu_mem_args)
+
+NATS_SERVER="${NATS_SERVER:-nats://127.0.0.1:4222}"
+ETCD_ENDPOINTS="${ETCD_ENDPOINTS:-http://127.0.0.1:2379}"
+
+VLLM_SYSTEM_PORT_BASE="${VLLM_SYSTEM_PORT_BASE:-18081}"
+# Worker `i` publishes ZMQ KV events on `KV_EVENTS_PORT_BASE + (i - 1)`.
+# Default differs from the Rust default script (5557) — kept distinct so
+# the two variants can be co-run on the same host without colliding.
+KV_EVENTS_PORT_BASE="${KV_EVENTS_PORT_BASE:-29080}"
+
+# ImageLoader cache size (number of images kept in-memory LRU)
+export DYN_MM_IMAGE_CACHE_SIZE="${DYN_MM_IMAGE_CACHE_SIZE:-32}"
+
+# Extra args (word-splitting is intentional for shell-style overrides)
+VLLM_EXTRA_ARGS="${VLLM_EXTRA_ARGS:-}"
+FRONTEND_EXTRA_ARGS="${FRONTEND_EXTRA_ARGS:-}"
+
+# CLI overrides — kept minimal and aligned with agg_multimodal_router.sh.
+# The serve-test harness invokes scripts as `bash <script> --model NAME ...`,
+# so honoring at least `--model` is required to avoid silent split-brain
+# (workers loading the script default while the frontend serves --model-name).
+PASSTHRU_ARGS=()
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --model) MODEL="$2"; shift 2 ;;
+        --num-workers) NUM_WORKERS="$2"; shift 2 ;;
+        --single-gpu) SINGLE_GPU="true"; shift ;;
+        -h|--help)
+            cat <<EOF
+Usage: $0 [--model NAME] [--num-workers N] [--single-gpu] [EXTRA_VLLM_ARGS...]
+
+See docs/features/multimodal/multimodal-kv-routing.md for env vars.
+EOF
+            exit 0
+            ;;
+        *) PASSTHRU_ARGS+=("$1"); shift ;;
+    esac
+done
+
+echo "=== vLLM MM Frontend Routing Launch Script ==="
+echo "Working directory: ${DYNAMO_ROOT}"
+echo "MODEL=${MODEL}"
+echo "NAMESPACE=${NAMESPACE}"
+echo "HTTP_PORT=${HTTP_PORT}"
+echo "BLOCK_SIZE=${BLOCK_SIZE}"
+echo "NUM_WORKERS=${NUM_WORKERS}"
+echo "SINGLE_GPU=${SINGLE_GPU}"
+echo "NUM_FRONTENDS=${NUM_FRONTENDS}"
+echo "GPU_MEMORY_UTILIZATION=${GPU_MEMORY_UTILIZATION}"
+echo "MAX_MODEL_LEN=${MAX_MODEL_LEN}"
+echo "DYN_MM_IMAGE_CACHE_SIZE=${DYN_MM_IMAGE_CACHE_SIZE}"
+echo "NATS_SERVER=${NATS_SERVER}"
+echo "ETCD_ENDPOINTS=${ETCD_ENDPOINTS}"
+echo "VLLM_SYSTEM_PORT_BASE=${VLLM_SYSTEM_PORT_BASE}"
+echo "KV_EVENTS_PORT_BASE=${KV_EVENTS_PORT_BASE}"
+echo
+
+# Clear the trap inside the handler so `kill 0` (which sends SIGTERM to the
+# script itself) doesn't re-enter this trap and loop forever.
+trap 'trap - EXIT INT TERM; echo; echo "Cleaning up..."; kill 0' EXIT INT TERM
+
+wait_ready() {
+    local url="$1"
+    local name="$2"
+    local timeout_s="${3:-240}"
+    local deadline=$((SECONDS + timeout_s))
+
+    echo "Waiting for ${name} at ${url} ..."
+    while (( SECONDS < deadline )); do
+        if curl -fsS "${url}" 2>/dev/null | grep -q '"status"[[:space:]]*:[[:space:]]*"ready"'; then
+            echo "${name} is ready"
+            return 0
+        fi
+        sleep 1
+    done
+
+    echo "Timed out waiting for ${name} (${url})" >&2
+    return 1
+}
+
+wait_frontend_models() {
+    local url="$1"
+    local timeout_s="${2:-240}"
+    local deadline=$((SECONDS + timeout_s))
+
+    echo "Waiting for frontend models API at ${url} ..."
+    while (( SECONDS < deadline )); do
+        if curl -fsS "${url}" >/dev/null 2>&1; then
+            echo "Frontend is ready"
+            return 0
+        fi
+        sleep 1
+    done
+
+    echo "Timed out waiting for frontend (${url})" >&2
+    return 1
+}
+
+echo "Prerequisite: start etcd and NATS yourself before running this script."
+echo "Example:"
+echo "  docker compose -f deploy/docker-compose.yml up -d"
+echo
+
+COMMON_ENV=(
+    "DYN_NAMESPACE=${NAMESPACE}"
+    "DYN_REQUEST_PLANE=tcp"
+    "NATS_SERVER=${NATS_SERVER}"
+    "ETCD_ENDPOINTS=${ETCD_ENDPOINTS}"
+)
+
+for i in $(seq 1 "${NUM_WORKERS}"); do
+    WORKER_PORT=$((VLLM_SYSTEM_PORT_BASE + (i - 1) * 2))
+    KV_EVENTS_PORT=$((KV_EVENTS_PORT_BASE + i - 1))
+
+    if [[ "${SINGLE_GPU}" == "true" ]]; then
+        GPU_ID=0
+    else
+        GPU_ID=$((i - 1))
+    fi
+
+    echo
+    echo "=== Starting vLLM backend worker $i (GPU ${GPU_ID}, port ${WORKER_PORT}, kv_events ${KV_EVENTS_PORT}) ==="
+    env "${COMMON_ENV[@]}" \
+        "DYN_SYSTEM_PORT=${WORKER_PORT}" \
+        "CUDA_VISIBLE_DEVICES=${GPU_ID}" \
+    python -m dynamo.vllm \
+            --model "${MODEL}" \
+            --enable-multimodal \
+            --block-size "${BLOCK_SIZE}" \
+            --enforce-eager \
+            --kv-events-config "{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:${KV_EVENTS_PORT}\",\"enable_kv_cache_events\":true}" \
+            $GPU_MEM_ARGS \
+            --max-model-len "${MAX_MODEL_LEN}" \
+            ${VLLM_EXTRA_ARGS} "${PASSTHRU_ARGS[@]}" &
+    # trap 'kill 0' handles cleanup
+    # Wait for this worker before starting the next one to avoid ZMQ port races.
+    wait_ready "http://127.0.0.1:${WORKER_PORT}/health" "vLLM backend $i" 900
+done
+
+echo
+echo "=== Starting frontend (with vLLM processor + KV router) ==="
+# Key flags:
+#   --dyn-chat-processor vllm    : run vLLM's HF processor in the frontend
+#   --router-mode kv             : use KvRouter for MM-aware routing
+#   --kv-cache-block-size        : must match backend's --block-size
+#
+# The frontend's VllmProcessor:
+#   1. Pre-downloads images via ImageLoader (LRU cache + dedup)
+#   2. Runs vLLM's process_inputs() → mm_features with hashes + placeholders
+#   3. Builds mm_routing_info from mm_features → passes to KvRouter
+#   4. Forwards mm_hashes to backend for hash consistency
+FRONTEND_SYSTEM_PORT_BASE="${FRONTEND_SYSTEM_PORT_BASE:-9080}"
+
+for f in $(seq 1 "${NUM_FRONTENDS}"); do
+    FE_HTTP_PORT=$((HTTP_PORT + f - 1))
+    FE_SYSTEM_PORT=$((FRONTEND_SYSTEM_PORT_BASE + f - 1))
+
+    # Only reset states on the first replica to avoid wiping shared state.
+    RESET_ARGS=""
+    if [[ "$f" -eq 1 ]]; then
+        RESET_ARGS="--router-reset-states"
+    fi
+
+    # Enable replica sync when running multiple frontends.
+    SYNC_ARGS=""
+    if [[ "${NUM_FRONTENDS}" -gt 1 ]]; then
+        SYNC_ARGS="--router-replica-sync"
+    fi
+
+    echo
+    echo "=== Starting frontend replica ${f} (HTTP ${FE_HTTP_PORT}, system ${FE_SYSTEM_PORT}) ==="
+    env "${COMMON_ENV[@]}" \
+        "DYN_LOG=debug" \
+        "DYN_SYSTEM_PORT=${FE_SYSTEM_PORT}" \
+        python -m dynamo.frontend \
+            --http-port "${FE_HTTP_PORT}" \
+            --dyn-chat-processor vllm \
+            --router-mode kv \
+            --kv-cache-block-size "${BLOCK_SIZE}" \
+            ${RESET_ARGS} \
+            ${SYNC_ARGS} \
+            --model-name "${MODEL}" \
+            ${FRONTEND_EXTRA_ARGS} &
+    # trap 'kill 0' handles cleanup
+    wait_frontend_models "http://127.0.0.1:${FE_HTTP_PORT}/v1/models" 300
+done
+
+# Wait until the first frontend can serve a real request (processor loaded).
+echo "Waiting for frontend processor to initialize (this may take a while for custom models)..."
+DEADLINE=$((SECONDS + 300))
+while (( SECONDS < DEADLINE )); do
+    HTTP_CODE=$(curl -sf -o /dev/null -w "%{http_code}" \
+        -X POST "http://127.0.0.1:${HTTP_PORT}/v1/chat/completions" \
+        -H "Content-Type: application/json" \
+        -d "{\"model\":\"${MODEL}\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],\"max_tokens\":1}" \
+        2>/dev/null || echo "000")
+    if [[ "$HTTP_CODE" == "200" ]]; then
+        echo "Frontend processor is ready"
+        break
+    fi
+    sleep 2
+done
+if (( SECONDS >= DEADLINE )); then
+    echo "Warning: Frontend processor may not be fully ready (timed out)" >&2
+fi
+
+echo
+echo "=== All services are ready ==="
+for f in $(seq 1 "${NUM_FRONTENDS}"); do
+    echo "Frontend ${f}: http://127.0.0.1:$((HTTP_PORT + f - 1))"
+done
+for i in $(seq 1 "${NUM_WORKERS}"); do
+    echo "Worker $i: http://127.0.0.1:$((VLLM_SYSTEM_PORT_BASE + (i - 1) * 2))/health"
+done
+echo
+echo "Architecture: ${NUM_FRONTENDS}x Frontend (vLLM processor + KvRouter) -> ${NUM_WORKERS}x vLLM backend"
+echo "  - No separate MM Router Worker needed"
+echo "  - ImageLoader LRU cache size: ${DYN_MM_IMAGE_CACHE_SIZE}"
+echo
+echo "Test routing: send the same image request 3 times."
+echo "  - Request 1: routed to any worker (no cache yet)"
+echo "  - Request 2: routed to SAME worker (KV cache overlap from request 1)"
+echo "  - Request 3 with different image: may route to the OTHER worker"
+echo
+echo "Watch for 'Selected worker' in logs to see routing decisions change."
+echo
+echo "Example (same image twice, then different image):"
+echo "  # Request 1 - image A"
+echo "  curl http://127.0.0.1:${HTTP_PORT}/v1/chat/completions \\"
+echo "    -H 'Content-Type: application/json' \\"
+echo "    -d '{\"model\":\"${MODEL}\",\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"Describe this image\"},{\"type\":\"image_url\",\"image_url\":{\"url\":\"http://images.cocodataset.org/test2017/000000000001.jpg\"}}]}],\"max_tokens\":32}'"
+echo
+echo "  # Request 2 - same image A (should route to same worker)"
+echo "  curl http://127.0.0.1:${HTTP_PORT}/v1/chat/completions \\"
+echo "    -H 'Content-Type: application/json' \\"
+echo "    -d '{\"model\":\"${MODEL}\",\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"Describe this image\"},{\"type\":\"image_url\",\"image_url\":{\"url\":\"http://images.cocodataset.org/test2017/000000000001.jpg\"}}]}],\"max_tokens\":32}'"
+echo
+echo "  # Request 3 - different image B (may route to other worker)"
+echo "  curl http://127.0.0.1:${HTTP_PORT}/v1/chat/completions \\"
+echo "    -H 'Content-Type: application/json' \\"
+echo "    -d '{\"model\":\"${MODEL}\",\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"Describe this image\"},{\"type\":\"image_url\",\"image_url\":{\"url\":\"http://images.cocodataset.org/test2017/000000000016.jpg\"}}]}],\"max_tokens\":32}'"
+echo
+echo "Press Ctrl+C to stop all services"
+
+wait_any_exit

--- a/examples/backends/vllm/launch/agg_multimodal_router_chat_processor.sh
+++ b/examples/backends/vllm/launch/agg_multimodal_router_chat_processor.sh
@@ -63,6 +63,15 @@ KV_EVENTS_PORT_BASE="${KV_EVENTS_PORT_BASE:-29080}"
 # ImageLoader cache size (number of images kept in-memory LRU)
 export DYN_MM_IMAGE_CACHE_SIZE="${DYN_MM_IMAGE_CACHE_SIZE:-32}"
 
+# DYNAMO_MM_TRANSFER selects how pre-rendered mm_kwargs are shipped from the
+# frontend (where vLLM's HF processor runs) to the selected backend worker.
+#   shm   — POSIX shared memory (/dev/shm). Default. Same-node only.
+#   nixl  — NIXL RDMA transfer. Required for cross-node deployments.
+# Set DYNAMO_DISABLE_NIXL_MM=1 to disable the transfer channel entirely; the
+# backend then re-downloads + reprocesses the image from the original URL.
+# See docs/features/multimodal/multimodal-kv-routing.md for details.
+export DYNAMO_MM_TRANSFER="${DYNAMO_MM_TRANSFER:-shm}"
+
 # Extra args (word-splitting is intentional for shell-style overrides)
 VLLM_EXTRA_ARGS="${VLLM_EXTRA_ARGS:-}"
 FRONTEND_EXTRA_ARGS="${FRONTEND_EXTRA_ARGS:-}"
@@ -101,6 +110,7 @@ echo "NUM_FRONTENDS=${NUM_FRONTENDS}"
 echo "GPU_MEMORY_UTILIZATION=${GPU_MEMORY_UTILIZATION}"
 echo "MAX_MODEL_LEN=${MAX_MODEL_LEN}"
 echo "DYN_MM_IMAGE_CACHE_SIZE=${DYN_MM_IMAGE_CACHE_SIZE}"
+echo "DYNAMO_MM_TRANSFER=${DYNAMO_MM_TRANSFER}"
 echo "NATS_SERVER=${NATS_SERVER}"
 echo "ETCD_ENDPOINTS=${ETCD_ENDPOINTS}"
 echo "VLLM_SYSTEM_PORT_BASE=${VLLM_SYSTEM_PORT_BASE}"

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -201,6 +201,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-nats"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1573,6 +1584,7 @@ dependencies = [
  "minijinja-contrib",
  "modelexpress-client",
  "modelexpress-common",
+ "moka",
  "ndarray",
  "nix 0.26.4",
  "nixl-sys",
@@ -3746,6 +3758,26 @@ dependencies = [
  "tonic 0.13.1",
  "tonic-build 0.13.1",
  "tracing",
+]
+
+[[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "async-lock",
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "event-listener",
+ "futures-util",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
 ]
 
 [[package]]
@@ -6423,6 +6455,12 @@ dependencies = [
  "toml 0.8.23",
  "version-compare",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "target-lexicon"

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -201,6 +201,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-nats"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2121,6 +2132,7 @@ dependencies = [
  "minijinja-contrib",
  "modelexpress-client",
  "modelexpress-common",
+ "moka",
  "ndarray 0.16.1",
  "nix 0.26.4",
  "nixl-sys",
@@ -4680,6 +4692,26 @@ dependencies = [
  "tonic 0.13.1",
  "tonic-build 0.13.1",
  "tracing",
+]
+
+[[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "async-lock",
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "event-listener",
+ "futures-util",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
 ]
 
 [[package]]
@@ -7509,6 +7541,12 @@ dependencies = [
  "toml 0.8.23",
  "version-compare",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "target-lexicon"

--- a/lib/llm/Cargo.toml
+++ b/lib/llm/Cargo.toml
@@ -79,6 +79,7 @@ futures-util = { workspace = true }
 hf-hub = { workspace = true }
 ipnet = { workspace = true }
 lru = { workspace = true }
+moka = { workspace = true }
 rand = { workspace = true }
 oneshot = { workspace = true }
 parking_lot = { workspace = true }

--- a/lib/llm/examples/lightseek_count.rs
+++ b/lib/llm/examples/lightseek_count.rs
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Standalone harness for the lightseek-mm path: load a HF model dir, decode
+// an image header to get (w, h), call lightseek's `calculate_num_tokens`, and
+// print the count. Useful for cross-checking against the same model's vLLM
+// output when investigating routing-cache mismatches.
+//
+//   cargo run -p dynamo-llm --example lightseek_count --features lightseek-mm \
+//     -- <model_dir> <image_path> [model_id]
+
+#[cfg(feature = "lightseek-mm")]
+fn main() -> anyhow::Result<()> {
+    use anyhow::Context;
+    use dynamo_llm::preprocessor::lightseek_mm::LightseekMmCounter;
+    use std::path::PathBuf;
+
+    let mut args = std::env::args().skip(1);
+    let model_dir: PathBuf = args
+        .next()
+        .context("usage: lightseek_count <model_dir> <image_path> [model_id]")?
+        .into();
+    let image_path: PathBuf = args
+        .next()
+        .context("usage: lightseek_count <model_dir> <image_path> [model_id]")?
+        .into();
+    let model_id = args
+        .next()
+        .unwrap_or_else(|| "Qwen/Qwen2.5-VL-3B-Instruct".to_string());
+
+    // model_type from config.json so the registry lookup is robust.
+    let cfg_path = model_dir.join("config.json");
+    let cfg_json: serde_json::Value = serde_json::from_reader(
+        std::fs::File::open(&cfg_path)
+            .with_context(|| format!("opening {}", cfg_path.display()))?,
+    )?;
+    let model_type = cfg_json
+        .get("model_type")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    println!(
+        "model_dir = {}\nmodel_id  = {}\nmodel_type= {:?}",
+        model_dir.display(),
+        model_id,
+        model_type
+    );
+
+    let counter = LightseekMmCounter::try_new(&model_id, model_type.as_deref(), &model_dir)?;
+    println!("counter for '{}' constructed", counter.model_id());
+
+    let img_bytes = std::fs::read(&image_path)?;
+    let (w, h) = image::ImageReader::new(std::io::Cursor::new(&img_bytes))
+        .with_guessed_format()?
+        .into_dimensions()?;
+    println!("image     = {} ({}x{})", image_path.display(), w, h);
+
+    let n = counter.count_tokens(w, h);
+    println!("tokens    = {}", n);
+
+    Ok(())
+}
+
+#[cfg(not(feature = "lightseek-mm"))]
+fn main() {
+    eprintln!("rebuild with --features lightseek-mm");
+    std::process::exit(2);
+}

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -40,6 +40,8 @@ use std::borrow::Cow;
 use std::{collections::HashMap, pin::Pin, sync::Arc};
 use tracing;
 
+#[cfg(feature = "lightseek-mm")]
+use crate::model_card::ModelInfoType;
 use crate::model_card::{ModelDeploymentCard, ModelInfo};
 use crate::preprocessor::media::MediaLoader;
 use crate::preprocessor::prompt::OAIChatLikeRequest;
@@ -148,6 +150,26 @@ struct ReasoningState {
     reasoning_parser: Option<Box<dyn ReasoningParser>>,
 }
 
+/// Per-image routing payload accumulated by `gather_multi_modal_data` and
+/// consumed by `gather_mm_exact_routing_info`.
+#[derive(Debug, Clone, Copy)]
+pub struct MmImageEntry {
+    pub mm_hash: u64,
+    pub width: u32,
+    pub height: u32,
+}
+
+/// Derive the model's local directory from the MDC. The directory is the
+/// parent of `config.json` (which lives in `mdc.model_info` as `HfConfigJson`)
+/// and contains the other artifacts MM-aware routing reads at startup
+/// (`tokenizer.json`, `processor_config.json`, `preprocessor_config.json`).
+/// Returns `None` for cards built from non-disk sources.
+#[cfg(feature = "lightseek-mm")]
+fn mdc_model_dir(mdc: &ModelDeploymentCard) -> Option<std::path::PathBuf> {
+    let ModelInfoType::HfConfigJson(cf) = mdc.model_info.as_ref()?;
+    cf.path()?.parent().map(std::path::PathBuf::from)
+}
+
 pub struct OpenAIPreprocessor {
     mdcsum: String,
     formatter: Arc<dyn OAIPromptFormatter>,
@@ -162,6 +184,16 @@ pub struct OpenAIPreprocessor {
     media_loader: Option<MediaLoader>,
     /// Max context length (in tokens) this model can handle, from ModelDeploymentCard
     context_length: u32,
+    /// Per-image token-count engine. `None` when the feature is disabled, the
+    /// model isn't covered by the registry, or `preprocessor_config.json` is
+    /// unreadable.
+    #[cfg(feature = "lightseek-mm")]
+    image_token_counter: Option<Arc<lightseek_mm::LightseekMmCounter>>,
+    /// Image-placeholder token id resolved from the model's HF JSON configs.
+    /// `None` disables MM-aware routing for this model and the router falls
+    /// back to text-prefix routing.
+    #[cfg(feature = "lightseek-mm")]
+    image_token_id: Option<crate::protocols::TokenIdType>,
 }
 
 impl OpenAIPreprocessor {
@@ -197,12 +229,89 @@ impl OpenAIPreprocessor {
         let runtime_config = mdc.runtime_config.clone();
         let kv_cache_block_size = mdc.kv_cache_block_size as usize;
 
+        // Capture MM-routing inputs before mdc is partially moved into MediaLoader.
+        // model_type comes from config.json (e.g. "qwen3_vl") and lets the
+        // lightseek registry resolve fine-tunes loaded from custom-named
+        // directories where the family substring isn't in the path.
+        #[cfg(feature = "lightseek-mm")]
+        let image_token_inputs: Option<(String, String, std::path::PathBuf)> = mdc_model_dir(&mdc)
+            .map(|p| (mdc.source_path().to_string(), model_info.model_type(), p));
+
         let media_loader = match mdc.media_decoder {
             Some(media_decoder) => Some(MediaLoader::new(media_decoder, mdc.media_fetcher)?),
             None => None,
         };
 
         let context_length = mdc.context_length;
+
+        #[cfg(feature = "lightseek-mm")]
+        let (image_token_counter, image_token_id) = match image_token_inputs {
+            Some((model_id, model_type, model_dir)) => {
+                // Try counter init and image-token resolution independently.
+                // Each carries its own reason for failure; the summary log
+                // below names whichever pieces are missing so operators can
+                // tell at a glance whether the model needs a lightseek
+                // upstream PR (registry miss) or a non-standard placeholder
+                // location (resolver miss).
+                let (counter, counter_err): (
+                    Option<Arc<lightseek_mm::LightseekMmCounter>>,
+                    Option<String>,
+                ) = match lightseek_mm::LightseekMmCounter::try_new(
+                    &model_id,
+                    Some(&model_type),
+                    &model_dir,
+                ) {
+                    Ok(c) => (Some(Arc::new(c)), None),
+                    Err(e) => (None, Some(e.to_string())),
+                };
+                let img_tok = lightseek_mm::resolve_image_token_id(&model_id, &model_dir);
+
+                match (counter.is_some(), img_tok.is_some()) {
+                    (true, true) => tracing::info!(
+                        target: "mm_routing",
+                        model = %model_id,
+                        model_dir = %model_dir.display(),
+                        "MM-aware KV routing enabled (lightseek)"
+                    ),
+                    (counter_ok, img_ok) => {
+                        let mut reasons: Vec<String> = Vec::new();
+                        if !counter_ok {
+                            reasons.push(format!(
+                                "model not supported by the lightseek registry ({})",
+                                counter_err.as_deref().unwrap_or("unknown error")
+                            ));
+                        }
+                        if !img_ok {
+                            reasons.push(
+                                "image-placeholder token unresolvable from \
+                                 config.json / processor_config.json / \
+                                 tokenizer_config.json / vocab probe"
+                                    .to_string(),
+                            );
+                        }
+                        tracing::warn!(
+                            target: "mm_routing",
+                            model = %model_id,
+                            reasons = %reasons.join("; "),
+                            "{} is not supported for MM-aware KV routing ({}). \
+                             Falling back to KV routing without MM awareness — \
+                             text-prefix overlap still works but the router \
+                             cannot distinguish requests by image content.",
+                            model_id,
+                            reasons.join("; ")
+                        );
+                    }
+                }
+                (counter, img_tok)
+            }
+            None => {
+                tracing::debug!(
+                    target: "mm_routing",
+                    "model directory not derivable from MDC; MM-aware routing disabled"
+                );
+                (None, None)
+            }
+        };
 
         Ok(Arc::new(Self {
             formatter,
@@ -215,6 +324,10 @@ impl OpenAIPreprocessor {
             tool_call_parser,
             media_loader,
             context_length,
+            #[cfg(feature = "lightseek-mm")]
+            image_token_counter,
+            #[cfg(feature = "lightseek-mm")]
+            image_token_id,
         }))
     }
     /// Encode a string to it's tokens
@@ -263,16 +376,29 @@ impl OpenAIPreprocessor {
             .is_some_and(|p| p.trim_end().ends_with("<think>"));
 
         let tokenize_start = Instant::now();
-        let annotations = {
+        let (token_ids, annotations) = {
             let _nvtx = dynamo_nvtx_range!("preprocess.tokenize");
-            self.gather_tokens(request, &mut builder, formatted_prompt.clone(), tracker)
+            self.gather_tokens(request, formatted_prompt.clone(), tracker)
                 .with_context(|| "Failed to gather tokens")?
         };
         TOKENIZE_SECONDS.observe(tokenize_start.elapsed().as_secs_f64());
 
-        self.gather_multi_modal_data(request, &mut builder, formatted_prompt)
+        let _mm_image_entries = self
+            .gather_multi_modal_data(request, &mut builder, formatted_prompt)
             .await
             .with_context(|| "Failed to gather multimodal data")?;
+
+        // Build the MM-aware view (expanded routing_token_ids + per-block
+        // mm_hashes) for the KV router. No-op when no images are present or
+        // the model has no resolved image-placeholder.
+        #[cfg(feature = "lightseek-mm")]
+        self.gather_mm_exact_routing_info(&mut builder, &_mm_image_entries, &token_ids)
+            .with_context(|| "Failed to build MM routing info")?;
+
+        // Install tokens on the builder. Done after MM routing built its
+        // view so the routing-side borrow stays cheap and builder ownership
+        // moves once.
+        builder.token_ids(token_ids);
 
         STAGE_DURATION_SECONDS
             .with_label_values(&[STAGE_PREPROCESS])
@@ -441,13 +567,23 @@ impl OpenAIPreprocessor {
         request: &R,
         builder: &mut PreprocessedRequestBuilder,
         formatted_prompt: Option<String>,
-    ) -> Result<()> {
+    ) -> Result<Vec<MmImageEntry>> {
         let mut media_map: MultimodalDataMap = HashMap::new();
         let mut fetch_tasks: Vec<(String, &ChatCompletionRequestUserMessageContentPart)> =
             Vec::new();
+        // Per-image (mm_hash, width, height) for the lightseek MM-routing path.
+        // Accumulated in message order so we don't walk messages twice.
+        // Cleared and returned to the caller; empty for non-image / text-only requests.
+        #[cfg(feature = "lightseek-mm")]
+        let mut mm_image_entries: Vec<MmImageEntry> = Vec::new();
+        // For the URL-passthrough case (media_loader is None) we collect image
+        // URLs here and resolve dims via header-only HTTP after the loop so we
+        // can issue all fetches in parallel.
+        #[cfg(feature = "lightseek-mm")]
+        let mut url_passthrough_images: Vec<(u64, String)> = Vec::new();
 
         let Some(messages) = request.typed_messages() else {
-            return Ok(());
+            return Ok(Vec::new());
         };
         let has_media_loader = self.media_loader.is_some();
 
@@ -481,6 +617,11 @@ impl OpenAIPreprocessor {
                         }
                         _ => continue,
                     };
+                    #[cfg(feature = "lightseek-mm")]
+                    if type_str == "image_url" {
+                        let mm_hash = Self::hash_image_url(url.as_str());
+                        url_passthrough_images.push((mm_hash, url.to_string()));
+                    }
                     media_map
                         .entry(type_str.to_string())
                         .or_default()
@@ -498,13 +639,108 @@ impl OpenAIPreprocessor {
             }))
             .await;
 
-            for ((type_str, _), result) in fetch_tasks.into_iter().zip(results.into_iter()) {
+            for ((type_str, _content_part), result) in
+                fetch_tasks.into_iter().zip(results.into_iter())
+            {
                 // if one item fails, errors the whole request, other items will be cleaned up by Drop
                 let rdma_descriptor = result?;
+
+                // Decoded RDMA descriptor carries shape `[H, W, C]`.
+                // Image-only; lightseek doesn't cover audio/video.
+                #[cfg(feature = "lightseek-mm")]
+                if type_str == "image_url" {
+                    let shape = &rdma_descriptor.tensor_info.shape;
+                    if shape.len() >= 2 {
+                        let h = shape[0] as u32;
+                        let w = shape[1] as u32;
+                        let url_str = match _content_part {
+                            ChatCompletionRequestUserMessageContentPart::ImageUrl(p) => {
+                                p.image_url.url.as_str()
+                            }
+                            _ => "",
+                        };
+                        // Frontend-decode path: hash the decoded RGB bytes so
+                        // the same image reached via different (signed) URLs
+                        // collides on the same `mm_hash` and routes to the
+                        // worker that already has those KV blocks. Fall back
+                        // to URL hashing only if the descriptor lost local
+                        // storage (e.g. reconstructed from the wire), which
+                        // shouldn't happen on the frontend.
+                        let (mm_hash, hash_source) = match rdma_descriptor.content_hash() {
+                            Some(h) => (h, "decoded_bytes"),
+                            None => (Self::hash_image_url(url_str), "url_fallback"),
+                        };
+                        if let Some(counter) = self.image_token_counter.as_ref() {
+                            let n = counter.count_tokens(w, h);
+                            tracing::debug!(
+                                target: "mm_routing",
+                                model = counter.model_id(),
+                                width = w,
+                                height = h,
+                                tokens = n,
+                                mm_hash = mm_hash,
+                                source = hash_source,
+                                "lightseek image-token count"
+                            );
+                        }
+                        mm_image_entries.push(MmImageEntry {
+                            mm_hash,
+                            width: w,
+                            height: h,
+                        });
+                    }
+                }
+
                 media_map
                     .entry(type_str)
                     .or_default()
                     .push(MultimodalData::Decoded(rdma_descriptor));
+            }
+        }
+
+        // URL-passthrough path (media_loader is None): fetch image headers in
+        // parallel to get (W, H) per image without downloading the full bytes.
+        // This is what enables MM-aware routing for vLLM-backed VLMs that
+        // register `media_decoder: null` and let the worker do its own decode.
+        #[cfg(feature = "lightseek-mm")]
+        if !url_passthrough_images.is_empty() {
+            let dim_results = futures::future::join_all(
+                url_passthrough_images
+                    .iter()
+                    .map(|(mm_hash, url)| Self::fetch_image_dims(*mm_hash, url.as_str())),
+            )
+            .await;
+            for ((mm_hash, url), dim_res) in url_passthrough_images.into_iter().zip(dim_results) {
+                match dim_res {
+                    Ok((w, h)) => {
+                        if let Some(counter) = self.image_token_counter.as_ref() {
+                            let n = counter.count_tokens(w, h);
+                            tracing::debug!(
+                                target: "mm_routing",
+                                model = counter.model_id(),
+                                width = w,
+                                height = h,
+                                tokens = n,
+                                mm_hash = mm_hash,
+                                source = "url_passthrough_header_fetch",
+                                "lightseek image-token count"
+                            );
+                        }
+                        mm_image_entries.push(MmImageEntry {
+                            mm_hash,
+                            width: w,
+                            height: h,
+                        });
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            target: "mm_routing",
+                            url = %url,
+                            error = %e,
+                            "lightseek: failed to fetch image dims; MM routing entry skipped"
+                        );
+                    }
+                }
             }
         }
 
@@ -529,12 +765,328 @@ impl OpenAIPreprocessor {
             if let Some(ref prompt) = formatted_prompt {
                 extra_args["formatted_prompt"] = serde_json::Value::String(prompt.clone());
             }
+
+            // Forward routing-side mm_hashes as `multi_modal_uuids` so vLLM
+            // publishes KV events with the same key the router computes.
+            // The kv-router parses events via parse_mm_hash_from_extra_key
+            // (kv-router/src/zmq_wire/extra_keys.rs), which requires exactly
+            // 64 hex chars and reads u64 from the first 16. We pad u64 ->
+            // 16 hex chars + 48 zeros so the byte representation matches
+            // end-to-end without forcing frontend image decoding.
+            #[cfg(feature = "lightseek-mm")]
+            if !mm_image_entries.is_empty() {
+                let hexes: Vec<serde_json::Value> = mm_image_entries
+                    .iter()
+                    .map(|e| {
+                        // 16 hex chars (u64) + 48 zeros = 64 chars total
+                        serde_json::Value::String(format!("{:016x}{}", e.mm_hash, "0".repeat(48)))
+                    })
+                    .collect();
+                extra_args["mm_hashes"] = serde_json::Value::Array(hexes);
+            }
+
             builder.extra_args(Some(extra_args));
         }
 
+        #[cfg(feature = "lightseek-mm")]
+        return Ok(mm_image_entries);
+        #[cfg(not(feature = "lightseek-mm"))]
+        Ok(Vec::new())
+    }
+
+    /// Build `MmRoutingInfo` for exact MM-aware KV routing.
+    ///
+    /// Computes per-image token counts via lightseek, expands the placeholder
+    /// tokens, builds per-block `BlockMmObjectInfo`, and writes the result to
+    /// `builder.mm_routing_info`. The worker-bound `token_ids` are left
+    /// unchanged — only the routing-side view is expanded.
+    ///
+    /// `token_ids` is the tokenized formatted prompt (one entry per
+    /// placeholder per image, before expansion); the caller threads it in
+    /// from `gather_tokens` to avoid a second tokenizer pass.
+    ///
+    /// Returns `Ok(())` with no work performed when:
+    /// - no images in the request,
+    /// - `image_token_id` was not resolved at startup,
+    /// - `image_token_counter` is unavailable,
+    /// - `kv_cache_block_size` is 0 (worker didn't advertise one), or
+    /// - the count of placeholder tokens in `token_ids` doesn't match
+    ///   `mm_image_entries.len()` (mismatched expansion would misalign
+    ///   offsets; falling back to text-prefix routing is safer than
+    ///   producing incorrect block hashes).
+    #[cfg(feature = "lightseek-mm")]
+    pub fn gather_mm_exact_routing_info(
+        &self,
+        builder: &mut PreprocessedRequestBuilder,
+        mm_image_entries: &[MmImageEntry],
+        token_ids: &[crate::protocols::TokenIdType],
+    ) -> Result<()> {
+        use crate::protocols::common::preprocessor::MmRoutingInfo;
+        use dynamo_kv_router::protocols::{RequestExtraInfo, RequestMmObjectInfo};
+
+        if mm_image_entries.is_empty() {
+            return Ok(());
+        }
+        let Some(image_token_id) = self.image_token_id else {
+            tracing::debug!(
+                target: "mm_routing",
+                "image_token_id unresolved; skipping MM routing info"
+            );
+            return Ok(());
+        };
+        let Some(counter) = self.image_token_counter.as_ref() else {
+            tracing::debug!(
+                target: "mm_routing",
+                "image_token_counter unavailable; skipping MM routing info"
+            );
+            return Ok(());
+        };
+        let block_size = self.kv_cache_block_size as usize;
+        if block_size == 0 {
+            tracing::debug!(
+                target: "mm_routing",
+                "kv_cache_block_size is 0; skipping MM routing info"
+            );
+            return Ok(());
+        }
+
+        // Sanity: number of placeholder tokens in the tokenized prompt must
+        // match the number of images in the request. If they disagree, the
+        // expansion would misplace ranges; better to skip MM routing entirely
+        // and fall back to text-prefix routing for this request.
+        let placeholder_count = token_ids.iter().filter(|&&t| t == image_token_id).count();
+        if placeholder_count != mm_image_entries.len() {
+            tracing::warn!(
+                target: "mm_routing",
+                placeholder_count,
+                image_count = mm_image_entries.len(),
+                image_token_id = image_token_id,
+                "placeholder token count in tokenized prompt does not match image count; \
+                 skipping MM routing info (text-prefix routing only)"
+            );
+            return Ok(());
+        }
+
+        // Compute per-image N via lightseek + run the expansion.
+        let n_tokens: Vec<usize> = mm_image_entries
+            .iter()
+            .map(|e| counter.count_tokens(e.width, e.height))
+            .collect();
+        let n_total: usize = n_tokens.iter().sum();
+
+        let mut expanded: Vec<crate::protocols::TokenIdType> =
+            Vec::with_capacity(token_ids.len() + n_total);
+        let mut img_ranges: Vec<(usize, usize)> = Vec::with_capacity(mm_image_entries.len());
+        let mut i = 0usize;
+        for &t in token_ids {
+            if t == image_token_id && i < mm_image_entries.len() {
+                let start = expanded.len();
+                expanded.extend(std::iter::repeat_n(image_token_id, n_tokens[i]));
+                img_ranges.push((start, start + n_tokens[i]));
+                i += 1;
+            } else {
+                expanded.push(t);
+            }
+        }
+
+        // Pad/truncate to a whole multiple of kv_cache_block_size. The router's
+        // compute_block_hash_for_seq only hashes whole blocks, so the partial
+        // tail block doesn't influence routing either way; aligning the length
+        // keeps our routing_token_ids and `block_mm_infos` agreeing on count.
+        let total_tokens = expanded.len().div_ceil(block_size) * block_size;
+        if expanded.len() < total_tokens {
+            expanded.resize(total_tokens, 0);
+        } else if expanded.len() > total_tokens {
+            // Should not happen given div_ceil, but be defensive.
+            expanded.truncate(total_tokens);
+        }
+
+        // Build request-level MM info, then derive per-block info.
+        let mm_objects: Vec<RequestMmObjectInfo> = mm_image_entries
+            .iter()
+            .zip(img_ranges.iter())
+            .map(|(entry, &(s, e))| RequestMmObjectInfo {
+                mm_hash: entry.mm_hash,
+                offsets: vec![(s, e)],
+            })
+            .collect();
+        let block_mm_infos =
+            RequestExtraInfo { mm_objects }.to_block_level(block_size, total_tokens);
+
+        tracing::debug!(
+            target: "mm_routing",
+            n_images = mm_image_entries.len(),
+            block_size,
+            total_tokens,
+            n_blocks = block_mm_infos.len(),
+            "lightseek MmRoutingInfo built (exact)"
+        );
+
+        builder.mm_routing_info(Some(MmRoutingInfo {
+            routing_token_ids: expanded,
+            block_mm_infos,
+        }));
         Ok(())
     }
 
+    /// xxh3-64 of a URL string, with HTTP cache-busters stripped from the
+    /// query so signed-URL drift doesn't break routing affinity.
+    #[cfg(feature = "lightseek-mm")]
+    fn hash_image_url(url: &str) -> u64 {
+        if url.starts_with("http://") || url.starts_with("https://") {
+            Self::hash_normalized_url(url)
+        } else {
+            // data: URIs are content-addressed; hash the whole URI (mediatype + base64 body)
+            xxhash_rust::xxh3::xxh3_64(url.as_bytes())
+        }
+    }
+
+    #[cfg(feature = "lightseek-mm")]
+    fn hash_normalized_url(url: &str) -> u64 {
+        const BUSTERS: [&str; 7] = ["v", "t", "cache", "_", "ts", "sig", "signature"];
+        let normalized = match url.split_once('?') {
+            Some((base, query)) => {
+                let kept: Vec<&str> = query
+                    .split('&')
+                    .filter(|part| {
+                        let key = part.split_once('=').map(|(k, _)| k).unwrap_or(part);
+                        !BUSTERS.contains(&key)
+                    })
+                    .collect();
+                if kept.is_empty() {
+                    Cow::Borrowed(base)
+                } else {
+                    Cow::Owned(format!("{}?{}", base, kept.join("&")))
+                }
+            }
+            None => Cow::Borrowed(url),
+        };
+        xxhash_rust::xxh3::xxh3_64(normalized.as_bytes())
+    }
+
+    /// Header-only image dim fetch. For HTTP/HTTPS we issue a Range request
+    /// for the first 64 KB (covers PNG/WebP in <1 KB and JPEG SOF in worst
+    /// case). For data: URIs we decode the base64 payload locally and parse
+    /// the header. Caller treats Err as "MM routing entry unavailable for
+    /// this image" — request still proceeds with text-prefix routing.
+    ///
+    /// Results are cached by `mm_hash` so repeated requests for the same image
+    /// (typical of multi-turn / session workloads) hit the cache and skip the
+    /// HTTP fetch entirely. Without this cache, sticky-routing workloads pay
+    /// 4–5× HTTP Range fetches per request just to compute routing tokens.
+    #[cfg(feature = "lightseek-mm")]
+    async fn fetch_image_dims(mm_hash: u64, url: &str) -> Result<(u32, u32)> {
+        use moka::future::Cache;
+        use std::sync::LazyLock;
+
+        // Bounded sharded LRU (moka uses TinyLFU internally — sharded write
+        // locks, lock-free reads). Replaces an earlier hand-rolled DashMap +
+        // tokio::sync::Notify singleflight; moka's `try_get_with` provides
+        // both singleflight and bounded LRU eviction in one primitive.
+        //
+        //   max_capacity:  100k entries (~5 MB at ~50 B/entry incl. moka
+        //                  bookkeeping). Caps memory under unbounded URL
+        //                  pools (signed-URL refresh, image proxies).
+        //   time_to_live:  24h. Bounds staleness if a URL is re-uploaded
+        //                  with new content. Independent of capacity-based
+        //                  eviction, which kicks in earlier under load.
+        static DIM_CACHE: LazyLock<Cache<u64, (u32, u32)>> = LazyLock::new(|| {
+            Cache::builder()
+                .max_capacity(100_000)
+                .time_to_live(Duration::from_secs(24 * 60 * 60))
+                .build()
+        });
+
+        // Hot path: avoid allocating an owned URL on cache hit. moka's
+        // `get` is async because it may do a small amount of bookkeeping
+        // for the LRU/TinyLFU policy.
+        if let Some(dims) = DIM_CACHE.get(&mm_hash).await {
+            return Ok(dims);
+        }
+
+        // Cold path: take an owned String so the init future can be
+        // 'static (moka may move waiters across executor threads). Because
+        // try_get_with does built-in singleflight, concurrent callers for
+        // the same `mm_hash` collapse into a single fetch.
+        let url_owned = url.to_string();
+        DIM_CACHE
+            .try_get_with(mm_hash, async move {
+                Self::fetch_image_dims_uncached(&url_owned)
+                    .await
+                    .map_err(|e| e.to_string())
+            })
+            .await
+            .map_err(|e| anyhow::anyhow!("fetch_image_dims failed: {}", e))
+    }
+
+    #[cfg(feature = "lightseek-mm")]
+    async fn fetch_image_dims_uncached(url: &str) -> Result<(u32, u32)> {
+        use image::ImageReader;
+        use std::io::Cursor;
+
+        // Most JPEG SOF markers and PNG/WebP headers fit in the first 4 KB.
+        // Start small and only escalate to 64 KB if the parser fails on the
+        // truncated header.
+        const SMALL_RANGE: usize = 4 * 1024 - 1;
+        const LARGE_RANGE: usize = 64 * 1024 - 1;
+
+        if let Some(rest) = url.strip_prefix("data:") {
+            let comma = rest
+                .find(',')
+                .ok_or_else(|| anyhow::anyhow!("malformed data URI: no comma"))?;
+            let prefix = &rest[..comma];
+            let payload = &rest[comma + 1..];
+            let bytes: Vec<u8> = if prefix.contains(";base64") {
+                use base64::Engine;
+                base64::engine::general_purpose::STANDARD
+                    .decode(payload)
+                    .map_err(|e| anyhow::anyhow!("data URI base64 decode: {}", e))?
+            } else {
+                payload.as_bytes().to_vec()
+            };
+            let (w, h) = ImageReader::new(Cursor::new(&bytes))
+                .with_guessed_format()?
+                .into_dimensions()?;
+            return Ok((w, h));
+        }
+
+        if !(url.starts_with("http://") || url.starts_with("https://")) {
+            anyhow::bail!("unsupported url scheme for dim fetch: {}", url);
+        }
+
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(10))
+            .build()?;
+        let mut range_end = SMALL_RANGE;
+        loop {
+            let resp = client
+                .get(url)
+                .header("Range", format!("bytes=0-{}", range_end))
+                .send()
+                .await?;
+            let status = resp.status();
+            if !status.is_success() {
+                anyhow::bail!("image fetch returned HTTP {}", status);
+            }
+            let bytes = resp.bytes().await?;
+            match ImageReader::new(Cursor::new(&bytes))
+                .with_guessed_format()
+                .and_then(|r| r.into_dimensions().map_err(std::io::Error::other))
+            {
+                Ok((w, h)) => return Ok((w, h)),
+                Err(_) if range_end < LARGE_RANGE => {
+                    range_end = LARGE_RANGE;
+                    continue;
+                }
+                Err(e) => anyhow::bail!("image header parse failed after 64KB: {}", e),
+            }
+        }
+    }
+
+    /// Tokenize the request and return the token ids alongside any annotations
+    /// the caller asked for. The caller owns the result and is responsible for
+    /// installing it on the builder via `builder.token_ids(...)` once any
+    /// downstream consumers (e.g. MM-routing) have borrowed it.
     pub fn gather_tokens<
         R: OAIChatLikeRequest
             + AnnotationsProvider
@@ -545,12 +1097,12 @@ impl OpenAIPreprocessor {
     >(
         &self,
         request: &R,
-        builder: &mut PreprocessedRequestBuilder,
         formatted_prompt: Option<String>,
         tracker: Option<&RequestTracker>,
-    ) -> Result<HashMap<String, String>> {
+    ) -> Result<(Vec<crate::protocols::TokenIdType>, HashMap<String, String>)> {
         let mut annotations = HashMap::new();
         let mut token_count: Option<usize> = None;
+        let mut tokens_out: Vec<crate::protocols::TokenIdType> = Vec::new();
         // match request type before any conversion/processing
         match request.prompt_input_type() {
             PromptInput::Tokens(_) => {
@@ -558,12 +1110,12 @@ impl OpenAIPreprocessor {
                     match token_input {
                         TokenInput::Single(tokens) => {
                             token_count = Some(tokens.len());
-                            builder.token_ids(tokens);
+                            tokens_out = tokens;
                         }
                         TokenInput::Batch(token_batches) => {
                             if token_batches.len() == 1 {
                                 token_count = Some(token_batches[0].len());
-                                builder.token_ids(token_batches[0].clone());
+                                tokens_out = token_batches[0].clone();
                             } else {
                                 bail!(
                                     "Batch token input not supported for more than one token in requests (got {})",
@@ -633,14 +1185,14 @@ impl OpenAIPreprocessor {
                             }
 
                             token_count = Some(tokens_vec.len());
-                            builder.token_ids(tokens_vec);
+                            tokens_out = tokens_vec;
                         }
                         TextInput::Batch(texts) => {
                             if texts.len() == 1 {
                                 let encoding = self.encode_with_timing(&texts[0], tracker)?;
                                 let tokens = encoding.token_ids().to_vec();
                                 token_count = Some(tokens.len());
-                                builder.token_ids(tokens);
+                                tokens_out = tokens;
                             } else {
                                 bail!(
                                     "Batch text input not supported for more than one text in requests (got {})",
@@ -658,7 +1210,7 @@ impl OpenAIPreprocessor {
             Self::validate_token_count(count, self.context_length)?;
         }
 
-        Ok(annotations)
+        Ok((tokens_out, annotations))
     }
 
     /// Validate that the prompt token count does not consume the model's entire context length.
@@ -1835,12 +2387,18 @@ impl
             // No token annotations
             HashMap::new()
         } else {
-            // Normal path: tokenize the prompt
-            self.gather_tokens(&request, &mut builder, None, tracker.as_deref())?
+            // Normal path: tokenize the prompt; embeddings don't need MM routing,
+            // so install tokens on the builder right away.
+            let (token_ids, ann) = self.gather_tokens(&request, None, tracker.as_deref())?;
+            builder.token_ids(token_ids);
+            ann
         };
 
         // Gather multimodal data (works with both embeddings and text prompts)
-        self.gather_multi_modal_data(&request, &mut builder, None)
+        // Returned MM entries are unused on the embeddings path; routing info is
+        // not built here.
+        let _ = self
+            .gather_multi_modal_data(&request, &mut builder, None)
             .await?;
 
         let mut common_request = builder.build()?;
@@ -2348,5 +2906,64 @@ mod tests {
                 "FAILED: {desc}",
             );
         }
+    }
+
+    /// HTTP cache-buster keys (`v`, `t`, `cache`, `_`, `ts`, `sig`, `signature`)
+    /// must be stripped from the query string before hashing — otherwise
+    /// signed-URL drift breaks routing affinity for the same image.
+    #[cfg(feature = "lightseek-mm")]
+    #[test]
+    fn hash_normalized_url_strips_cache_busters() {
+        let base = "https://cdn.example.com/img.jpg";
+        let hashed_no_query = OpenAIPreprocessor::hash_image_url(base);
+        let hashed_with_busters = OpenAIPreprocessor::hash_image_url(&format!(
+            "{base}?v=12345&sig=deadbeef&signature=feedface&t=999&cache=abc&_=1&ts=9999"
+        ));
+        assert_eq!(
+            hashed_no_query, hashed_with_busters,
+            "cache-buster query params should be stripped before hashing"
+        );
+    }
+
+    /// Non-buster query params must survive normalization (different identity → different hash).
+    #[cfg(feature = "lightseek-mm")]
+    #[test]
+    fn hash_normalized_url_keeps_meaningful_query() {
+        let a = OpenAIPreprocessor::hash_image_url("https://x.com/i.jpg?width=512");
+        let b = OpenAIPreprocessor::hash_image_url("https://x.com/i.jpg?width=1024");
+        assert_ne!(
+            a, b,
+            "non-cache-buster query params should differentiate hashes"
+        );
+    }
+
+    /// data: URIs are content-addressed; hashing the entire URI gives content equality.
+    #[cfg(feature = "lightseek-mm")]
+    #[test]
+    fn hash_image_url_data_uri_content_addressed() {
+        let same = "data:image/png;base64,AAAA";
+        let other = "data:image/png;base64,BBBB";
+        assert_eq!(
+            OpenAIPreprocessor::hash_image_url(same),
+            OpenAIPreprocessor::hash_image_url(same)
+        );
+        assert_ne!(
+            OpenAIPreprocessor::hash_image_url(same),
+            OpenAIPreprocessor::hash_image_url(other),
+            "different data URI payloads must hash differently"
+        );
+    }
+
+    /// Non-HTTP / non-data schemes (s3://, gs://, file://) hash as-is — no
+    /// cache-buster stripping (their query strings are object-identifying).
+    #[cfg(feature = "lightseek-mm")]
+    #[test]
+    fn hash_image_url_other_schemes_passthrough() {
+        let s3a = OpenAIPreprocessor::hash_image_url("s3://bucket/key?v=1");
+        let s3b = OpenAIPreprocessor::hash_image_url("s3://bucket/key?v=2");
+        assert_ne!(
+            s3a, s3b,
+            "s3:// query params identify objects and must not be stripped"
+        );
     }
 }

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -639,9 +639,15 @@ impl OpenAIPreprocessor {
         // Total `image_url` content parts in the request. Bumped at every
         // image part regardless of which fetch path handles it. Used at
         // `mm_hashes` forwarding time: if `mm_image_entries.len()` is
-        // smaller (i.e. some image failed dim resolution), we omit
-        // `mm_hashes` for the whole request rather than ship a partial /
-        // misaligned UUID list to vLLM.
+        // smaller, we omit `mm_hashes` for the whole request rather than
+        // ship a partial / misaligned UUID list to vLLM.
+        //
+        // The mismatch is only reachable on the URL-passthrough path
+        // (no media_loader): each `fetch_image_dims_uncached` failure logs
+        // a warn and skips its `mm_image_entries.push`, but doesn't abort
+        // the request. The decoded path (`has_media_loader`) propagates
+        // any dim-fetch failure via `?`, so the request errors out before
+        // mm_hashes forwarding is even considered.
         #[cfg(feature = "lightseek-mm")]
         let mut total_image_count: usize = 0;
         // For the URL-passthrough case (media_loader is None) we collect image
@@ -808,9 +814,20 @@ impl OpenAIPreprocessor {
                         });
                     }
                     Err(e) => {
+                        // Redact `data:` URIs to just the media-type prefix —
+                        // the comma-separated payload is the entire (base64)
+                        // image body and ships in logs would be log bloat /
+                        // potential PII spillage if logs are aggregated.
+                        let url_for_log = if url.starts_with("data:") {
+                            url.split_once(',')
+                                .map(|(p, _)| format!("{p},<redacted>"))
+                                .unwrap_or_else(|| "data:<redacted>".to_string())
+                        } else {
+                            url.to_string()
+                        };
                         tracing::warn!(
                             target: "mm_routing",
-                            url = %url,
+                            url = %url_for_log,
                             error = %e,
                             "lightseek: failed to fetch image dims; MM routing entry skipped"
                         );

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -929,39 +929,17 @@ impl OpenAIPreprocessor {
         Ok(())
     }
 
-    /// xxh3-64 of a URL string, with HTTP cache-busters stripped from the
-    /// query so signed-URL drift doesn't break routing affinity.
+    /// xxh3-64 of the full URL string. Used as the routing `mm_hash` in the
+    /// URL-passthrough path. Two callers will collide on the same image only
+    /// when they send byte-identical URLs — including any query string. Any
+    /// query parameter that differs between requests (signed-URL `?sig=…`,
+    /// cache-buster `?v=…`, content selector `?width=…`) breaks the collision
+    /// and routes to a fresh worker. Frontend-decoding mode replaces this
+    /// with content-addressed hashing over decoded RGB bytes, which does
+    /// give cross-URL cache reuse.
     #[cfg(feature = "lightseek-mm")]
     fn hash_image_url(url: &str) -> u64 {
-        if url.starts_with("http://") || url.starts_with("https://") {
-            Self::hash_normalized_url(url)
-        } else {
-            // data: URIs are content-addressed; hash the whole URI (mediatype + base64 body)
-            xxhash_rust::xxh3::xxh3_64(url.as_bytes())
-        }
-    }
-
-    #[cfg(feature = "lightseek-mm")]
-    fn hash_normalized_url(url: &str) -> u64 {
-        const BUSTERS: [&str; 7] = ["v", "t", "cache", "_", "ts", "sig", "signature"];
-        let normalized = match url.split_once('?') {
-            Some((base, query)) => {
-                let kept: Vec<&str> = query
-                    .split('&')
-                    .filter(|part| {
-                        let key = part.split_once('=').map(|(k, _)| k).unwrap_or(part);
-                        !BUSTERS.contains(&key)
-                    })
-                    .collect();
-                if kept.is_empty() {
-                    Cow::Borrowed(base)
-                } else {
-                    Cow::Owned(format!("{}?{}", base, kept.join("&")))
-                }
-            }
-            None => Cow::Borrowed(url),
-        };
-        xxhash_rust::xxh3::xxh3_64(normalized.as_bytes())
+        xxhash_rust::xxh3::xxh3_64(url.as_bytes())
     }
 
     /// Header-only image dim fetch. For HTTP/HTTPS we issue a Range request
@@ -2909,32 +2887,19 @@ mod tests {
     }
 
     /// HTTP cache-buster keys (`v`, `t`, `cache`, `_`, `ts`, `sig`, `signature`)
-    /// must be stripped from the query string before hashing — otherwise
-    /// signed-URL drift breaks routing affinity for the same image.
+    /// Different query strings must produce different hashes — what looks
+    /// like a cache-buster (`?v=1` vs `?v=2`) may also be a content selector
+    /// (e.g. version → different image). Hash the full URL and let the URL
+    /// be the identity.
     #[cfg(feature = "lightseek-mm")]
     #[test]
-    fn hash_normalized_url_strips_cache_busters() {
+    fn hash_image_url_distinguishes_query_strings() {
         let base = "https://cdn.example.com/img.jpg";
-        let hashed_no_query = OpenAIPreprocessor::hash_image_url(base);
-        let hashed_with_busters = OpenAIPreprocessor::hash_image_url(&format!(
-            "{base}?v=12345&sig=deadbeef&signature=feedface&t=999&cache=abc&_=1&ts=9999"
-        ));
-        assert_eq!(
-            hashed_no_query, hashed_with_busters,
-            "cache-buster query params should be stripped before hashing"
-        );
-    }
-
-    /// Non-buster query params must survive normalization (different identity → different hash).
-    #[cfg(feature = "lightseek-mm")]
-    #[test]
-    fn hash_normalized_url_keeps_meaningful_query() {
-        let a = OpenAIPreprocessor::hash_image_url("https://x.com/i.jpg?width=512");
-        let b = OpenAIPreprocessor::hash_image_url("https://x.com/i.jpg?width=1024");
-        assert_ne!(
-            a, b,
-            "non-cache-buster query params should differentiate hashes"
-        );
+        let v1 = OpenAIPreprocessor::hash_image_url(&format!("{base}?v=1"));
+        let v2 = OpenAIPreprocessor::hash_image_url(&format!("{base}?v=2"));
+        let no_q = OpenAIPreprocessor::hash_image_url(base);
+        assert_ne!(v1, v2, "?v=1 and ?v=2 may identify different images");
+        assert_ne!(v1, no_q, "presence of any query string changes the URL");
     }
 
     /// data: URIs are content-addressed; hashing the entire URI gives content equality.

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -847,7 +847,7 @@ impl OpenAIPreprocessor {
             );
             return Ok(());
         };
-        let block_size = self.kv_cache_block_size as usize;
+        let block_size = self.kv_cache_block_size;
         if block_size == 0 {
             tracing::debug!(
                 target: "mm_routing",

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -226,9 +226,8 @@ fn is_cache_buster_query_key(key: &str) -> bool {
 /// request 20 minutes in. Text-only deployments skip the force, leaving
 /// the LazyLock dormant.
 #[cfg(feature = "lightseek-mm")]
-static DIM_FETCH_MEDIA_FETCHER: std::sync::LazyLock<
-    crate::preprocessor::media::MediaFetcher,
-> = std::sync::LazyLock::new(crate::preprocessor::media::MediaFetcher::from_env);
+static DIM_FETCH_MEDIA_FETCHER: std::sync::LazyLock<crate::preprocessor::media::MediaFetcher> =
+    std::sync::LazyLock::new(crate::preprocessor::media::MediaFetcher::from_env);
 
 #[cfg(feature = "lightseek-mm")]
 static DIM_FETCH_HTTP_CLIENT: std::sync::LazyLock<reqwest::Client> =

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -780,13 +780,10 @@ impl OpenAIPreprocessor {
                 // 48 trailing zeros — paired with the {:016x} prefix this gives
                 // the 64-char hex string the kv-router's parse_mm_hash_from_extra_key
                 // expects (reads u64 from the first 16 chars).
-                const HEX_PAD: &str =
-                    "000000000000000000000000000000000000000000000000";
+                const HEX_PAD: &str = "000000000000000000000000000000000000000000000000";
                 let hexes: Vec<serde_json::Value> = mm_image_entries
                     .iter()
-                    .map(|e| {
-                        serde_json::Value::String(format!("{:016x}{}", e.mm_hash, HEX_PAD))
-                    })
+                    .map(|e| serde_json::Value::String(format!("{:016x}{}", e.mm_hash, HEX_PAD)))
                     .collect();
                 extra_args["mm_hashes"] = serde_json::Value::Array(hexes);
             }

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -1004,14 +1004,20 @@ impl OpenAIPreprocessor {
 
     #[cfg(feature = "lightseek-mm")]
     async fn fetch_image_dims_uncached(url: &str) -> Result<(u32, u32)> {
+        use crate::preprocessor::media::MediaFetcher;
         use image::ImageReader;
         use std::io::Cursor;
+        use std::sync::LazyLock;
 
         // Most JPEG SOF markers and PNG/WebP headers fit in the first 4 KB.
         // Start small and only escalate to 64 KB if the parser fails on the
         // truncated header.
         const SMALL_RANGE: usize = 4 * 1024 - 1;
         const LARGE_RANGE: usize = 64 * 1024 - 1;
+        // Per-Range tighter bound than MediaFetcher's 30 s default — dim
+        // fetch is best-effort; on a slow remote we'd rather skip MM
+        // routing for this image than starve the request.
+        const DIM_FETCH_TIMEOUT: Duration = Duration::from_secs(10);
 
         if let Some(rest) = url.strip_prefix("data:") {
             let comma = rest
@@ -1037,14 +1043,31 @@ impl OpenAIPreprocessor {
             anyhow::bail!("unsupported url scheme for dim fetch: {}", url);
         }
 
-        let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(10))
-            .build()?;
+        // Shared SSRF-aware Client + connection pool. Reuses the same
+        // policy contract as the frontend-decode path (`MediaLoader`):
+        // blocklist DNS resolver, redirect revalidation, hostname/IP
+        // blocklist, `DYN_MM_ALLOW_INTERNAL` opt-in. Constructed once per
+        // process — Client connection-pooling kicks in across requests.
+        static MEDIA_FETCHER: LazyLock<MediaFetcher> = LazyLock::new(MediaFetcher::from_env);
+        static HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
+            MEDIA_FETCHER
+                .build_http_client()
+                .expect("dim-fetch http client construction failed")
+        });
+
+        // Pre-flight SSRF check on the original URL. Redirect targets are
+        // revalidated by the Client's redirect policy, and DNS-resolved
+        // IPs are filtered by the resolver — so a URL that passes here
+        // can't escape the contract on the wire either.
+        let parsed = url::Url::parse(url)?;
+        MEDIA_FETCHER.check_if_url_allowed_with_dns(&parsed).await?;
+
         let mut range_end = SMALL_RANGE;
         loop {
-            let resp = client
+            let resp = HTTP_CLIENT
                 .get(url)
                 .header("Range", format!("bytes=0-{}", range_end))
+                .timeout(DIM_FETCH_TIMEOUT)
                 .send()
                 .await?;
             let status = resp.status();

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -188,7 +188,7 @@ pub struct OpenAIPreprocessor {
     /// model isn't covered by the registry, or `preprocessor_config.json` is
     /// unreadable.
     #[cfg(feature = "lightseek-mm")]
-    image_token_counter: Option<Arc<lightseek_mm::LightseekMmCounter>>,
+    image_token_counter: Option<lightseek_mm::LightseekMmCounter>,
     /// Image-placeholder token id resolved from the model's HF JSON configs.
     /// `None` disables MM-aware routing for this model and the router falls
     /// back to text-prefix routing.
@@ -254,14 +254,14 @@ impl OpenAIPreprocessor {
                 // upstream PR (registry miss) or a non-standard placeholder
                 // location (resolver miss).
                 let (counter, counter_err): (
-                    Option<Arc<lightseek_mm::LightseekMmCounter>>,
+                    Option<lightseek_mm::LightseekMmCounter>,
                     Option<String>,
                 ) = match lightseek_mm::LightseekMmCounter::try_new(
                     &model_id,
                     Some(&model_type),
                     &model_dir,
                 ) {
-                    Ok(c) => (Some(Arc::new(c)), None),
+                    Ok(c) => (Some(c), None),
                     Err(e) => (None, Some(e.to_string())),
                 };
                 let img_tok = lightseek_mm::resolve_image_token_id(&model_id, &model_dir);
@@ -657,7 +657,9 @@ impl OpenAIPreprocessor {
                             ChatCompletionRequestUserMessageContentPart::ImageUrl(p) => {
                                 p.image_url.url.as_str()
                             }
-                            _ => "",
+                            _ => unreachable!(
+                                "rdma image_url descriptor only originates from ImageUrl content parts"
+                            ),
                         };
                         // Frontend-decode path: hash the decoded RGB bytes so
                         // the same image reached via different (signed) URLs
@@ -775,11 +777,15 @@ impl OpenAIPreprocessor {
             // end-to-end without forcing frontend image decoding.
             #[cfg(feature = "lightseek-mm")]
             if !mm_image_entries.is_empty() {
+                // 48 trailing zeros — paired with the {:016x} prefix this gives
+                // the 64-char hex string the kv-router's parse_mm_hash_from_extra_key
+                // expects (reads u64 from the first 16 chars).
+                const HEX_PAD: &str =
+                    "000000000000000000000000000000000000000000000000";
                 let hexes: Vec<serde_json::Value> = mm_image_entries
                     .iter()
                     .map(|e| {
-                        // 16 hex chars (u64) + 48 zeros = 64 chars total
-                        serde_json::Value::String(format!("{:016x}{}", e.mm_hash, "0".repeat(48)))
+                        serde_json::Value::String(format!("{:016x}{}", e.mm_hash, HEX_PAD))
                     })
                     .collect();
                 extra_args["mm_hashes"] = serde_json::Value::Array(hexes);
@@ -889,16 +895,15 @@ impl OpenAIPreprocessor {
             }
         }
 
-        // Pad/truncate to a whole multiple of kv_cache_block_size. The router's
+        // Pad to a whole multiple of kv_cache_block_size. The router's
         // compute_block_hash_for_seq only hashes whole blocks, so the partial
         // tail block doesn't influence routing either way; aligning the length
         // keeps our routing_token_ids and `block_mm_infos` agreeing on count.
+        // `div_ceil` guarantees `total_tokens >= expanded.len()`, so resize
+        // only ever grows.
         let total_tokens = expanded.len().div_ceil(block_size) * block_size;
         if expanded.len() < total_tokens {
             expanded.resize(total_tokens, 0);
-        } else if expanded.len() > total_tokens {
-            // Should not happen given div_ceil, but be defensive.
-            expanded.truncate(total_tokens);
         }
 
         // Build request-level MM info, then derive per-block info.

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -576,6 +576,14 @@ impl OpenAIPreprocessor {
         // Cleared and returned to the caller; empty for non-image / text-only requests.
         #[cfg(feature = "lightseek-mm")]
         let mut mm_image_entries: Vec<MmImageEntry> = Vec::new();
+        // Total `image_url` content parts in the request. Bumped at every
+        // image part regardless of which fetch path handles it. Used at
+        // `mm_hashes` forwarding time: if `mm_image_entries.len()` is
+        // smaller (i.e. some image failed dim resolution), we omit
+        // `mm_hashes` for the whole request rather than ship a partial /
+        // misaligned UUID list to vLLM.
+        #[cfg(feature = "lightseek-mm")]
+        let mut total_image_count: usize = 0;
         // For the URL-passthrough case (media_loader is None) we collect image
         // URLs here and resolve dims via header-only HTTP after the loop so we
         // can issue all fetches in parallel.
@@ -603,6 +611,10 @@ impl OpenAIPreprocessor {
                         ChatCompletionRequestUserMessageContentPart::AudioUrl(_) => "audio_url",
                         _ => continue,
                     };
+                    #[cfg(feature = "lightseek-mm")]
+                    if type_str == "image_url" {
+                        total_image_count += 1;
+                    }
                     fetch_tasks.push((type_str.to_string(), content_part));
                 } else {
                     let (type_str, url) = match content_part {
@@ -619,6 +631,7 @@ impl OpenAIPreprocessor {
                     };
                     #[cfg(feature = "lightseek-mm")]
                     if type_str == "image_url" {
+                        total_image_count += 1;
                         let mm_hash = Self::hash_image_url(url.as_str());
                         url_passthrough_images.push((mm_hash, url.to_string()));
                     }
@@ -775,8 +788,13 @@ impl OpenAIPreprocessor {
             // 64 hex chars and reads u64 from the first 16. We pad u64 ->
             // 16 hex chars + 48 zeros so the byte representation matches
             // end-to-end without forcing frontend image decoding.
+            //
+            // Skip forwarding entirely if any image failed dim resolution —
+            // a shorter `mm_hashes` list would misalign with the image
+            // positions vLLM derives from `multi_modal_data`, and the
+            // backend would inject the wrong UUIDs onto the wrong images.
             #[cfg(feature = "lightseek-mm")]
-            if !mm_image_entries.is_empty() {
+            if !mm_image_entries.is_empty() && mm_image_entries.len() == total_image_count {
                 // 48 trailing zeros — paired with the {:016x} prefix this gives
                 // the 64-char hex string the kv-router's parse_mm_hash_from_extra_key
                 // expects (reads u64 from the first 16 chars).
@@ -786,6 +804,13 @@ impl OpenAIPreprocessor {
                     .map(|e| serde_json::Value::String(format!("{:016x}{}", e.mm_hash, HEX_PAD)))
                     .collect();
                 extra_args["mm_hashes"] = serde_json::Value::Array(hexes);
+            } else if !mm_image_entries.is_empty() {
+                tracing::warn!(
+                    target: "mm_routing",
+                    resolved = mm_image_entries.len(),
+                    expected = total_image_count,
+                    "lightseek: not all images resolved an MM-routing entry; skipping mm_hashes forwarding"
+                );
             }
 
             builder.extra_args(Some(extra_args));
@@ -1068,8 +1093,17 @@ impl OpenAIPreprocessor {
                 .send()
                 .await?;
             let status = resp.status();
-            if !status.is_success() {
-                anyhow::bail!("image fetch returned HTTP {}", status);
+            // Require 206 Partial Content — if the origin ignored the
+            // Range header and answered 200 OK, `.bytes()` would buffer
+            // the full image into memory. Bail in that case rather than
+            // download an unbounded payload just to peek at dimensions.
+            // The caller treats Err as "MM routing entry unavailable for
+            // this image", which falls back to text-prefix routing.
+            if status != reqwest::StatusCode::PARTIAL_CONTENT {
+                anyhow::bail!(
+                    "image dim fetch expected 206 Partial Content, got HTTP {}",
+                    status
+                );
             }
             let bytes = resp.bytes().await?;
             match ImageReader::new(Cursor::new(&bytes))

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -170,6 +170,50 @@ fn mdc_model_dir(mdc: &ModelDeploymentCard) -> Option<std::path::PathBuf> {
     cf.path()?.parent().map(std::path::PathBuf::from)
 }
 
+/// Find the first occurrence of `needle` in `haystack`. Linear scan; the
+/// needles here are tokenized chat-template placeholders (≤ 10 tokens for
+/// Phi-3-style `<|image_N|>`), so the naive O(n·m) cost is fine.
+#[cfg(feature = "lightseek-mm")]
+fn find_subseq<T: PartialEq>(haystack: &[T], needle: &[T]) -> Option<usize> {
+    if needle.is_empty() || needle.len() > haystack.len() {
+        return None;
+    }
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
+}
+
+/// HTTP/HTTPS query-parameter keys that identify cache-busters or signed-URL
+/// metadata rather than image content. Stripped before hashing so the same
+/// image reached through different signed URLs collides on the same routing
+/// `mm_hash`. Match is case-insensitive.
+///
+/// Conservative list — only adds keys that are widely documented as
+/// cache-bust or presign metadata. Content-shaping params (`width`,
+/// `quality`, `format`, …) are deliberately *not* in this set: a 256-wide
+/// thumbnail must not collide on the same hash as the 1024-wide render.
+#[cfg(feature = "lightseek-mm")]
+fn is_cache_buster_query_key(key: &str) -> bool {
+    let lc = key.to_ascii_lowercase();
+    matches!(
+        lc.as_str(),
+        // Generic cache-busters / version selectors.
+        "v" | "version" | "cb" | "cache_bust" | "_" | "t" | "ts" | "timestamp"
+        // Generic signed-URL pieces.
+        | "sig" | "signature" | "token" | "expires" | "expiry" | "exp"
+        // AWS S3 / CloudFront presigned (case-folded form of `X-Amz-…`).
+        | "x-amz-signature" | "x-amz-date" | "x-amz-expires"
+        | "x-amz-algorithm" | "x-amz-credential" | "x-amz-signedheaders"
+        | "x-amz-security-token" | "x-amz-user-agent"
+        // GCS signed URLs.
+        | "x-goog-signature" | "x-goog-date" | "x-goog-expires"
+        | "x-goog-algorithm" | "x-goog-credential" | "x-goog-signedheaders"
+        // Azure SAS tokens (`se`, `sp`, etc. are short by spec).
+        | "se" | "sp" | "sr" | "sv" | "st" | "tn" | "srt" | "ss" | "skoid"
+        | "sktid" | "skt" | "ske" | "sks" | "skv" | "spr"
+    )
+}
+
 pub struct OpenAIPreprocessor {
     mdcsum: String,
     formatter: Arc<dyn OAIPromptFormatter>,
@@ -194,6 +238,13 @@ pub struct OpenAIPreprocessor {
     /// back to text-prefix routing.
     #[cfg(feature = "lightseek-mm")]
     image_token_id: Option<crate::protocols::TokenIdType>,
+    /// Per-family flatten-time image placeholder template (e.g.
+    /// `"<|image_{n}|>"` for Phi-3, `"<image>"` for LLaVA-1.5). Threaded
+    /// through from the formatter so the routing path can reverse the
+    /// BPE-encoded numbered form (Phi-3) back into single placeholder
+    /// tokens when the chat template uses numbered markers.
+    #[cfg(feature = "lightseek-mm")]
+    image_placeholder_template: Option<&'static str>,
 }
 
 impl OpenAIPreprocessor {
@@ -313,6 +364,9 @@ impl OpenAIPreprocessor {
             }
         };
 
+        #[cfg(feature = "lightseek-mm")]
+        let image_placeholder_template = formatter.image_placeholder_template();
+
         Ok(Arc::new(Self {
             formatter,
             tokenizer,
@@ -328,6 +382,8 @@ impl OpenAIPreprocessor {
             image_token_counter,
             #[cfg(feature = "lightseek-mm")]
             image_token_id,
+            #[cfg(feature = "lightseek-mm")]
+            image_placeholder_template,
         }))
     }
     /// Encode a string to it's tokens
@@ -882,18 +938,52 @@ impl OpenAIPreprocessor {
         // match the number of images in the request. If they disagree, the
         // expansion would misplace ranges; better to skip MM routing entirely
         // and fall back to text-prefix routing for this request.
+        //
+        // Families like Phi-3-vision use numbered placeholder text
+        // (`<|image_1|>`) that BPE-decomposes into multiple sub-tokens —
+        // `image_token_id` (the single `<|image|>` special token) never
+        // appears post-tokenization. For those we run a substring-match
+        // pass first that rewrites each numbered placeholder's BPE
+        // sub-sequence back to a single `image_token_id`, then proceed
+        // with the standard expansion below.
         let placeholder_count = token_ids.iter().filter(|&&t| t == image_token_id).count();
-        if placeholder_count != mm_image_entries.len() {
-            tracing::warn!(
-                target: "mm_routing",
-                placeholder_count,
-                image_count = mm_image_entries.len(),
-                image_token_id = image_token_id,
-                "placeholder token count in tokenized prompt does not match image count; \
-                 skipping MM routing info (text-prefix routing only)"
-            );
-            return Ok(());
-        }
+        let normalized_token_ids: std::borrow::Cow<'_, [crate::protocols::TokenIdType]> =
+            if placeholder_count == mm_image_entries.len() {
+                std::borrow::Cow::Borrowed(token_ids)
+            } else if let Some(tpl) = self.image_placeholder_template
+                && tpl.contains("{n}")
+            {
+                match self.normalize_numbered_placeholders(
+                    token_ids,
+                    image_token_id,
+                    tpl,
+                    mm_image_entries.len(),
+                ) {
+                    Some(v) => std::borrow::Cow::Owned(v),
+                    None => {
+                        tracing::warn!(
+                            target: "mm_routing",
+                            placeholder_count,
+                            image_count = mm_image_entries.len(),
+                            image_token_id = image_token_id,
+                            placeholder_template = tpl,
+                            "numbered placeholder BPE rewrite failed; \
+                             skipping MM routing info (text-prefix routing only)"
+                        );
+                        return Ok(());
+                    }
+                }
+            } else {
+                tracing::warn!(
+                    target: "mm_routing",
+                    placeholder_count,
+                    image_count = mm_image_entries.len(),
+                    image_token_id = image_token_id,
+                    "placeholder token count in tokenized prompt does not match image count; \
+                     skipping MM routing info (text-prefix routing only)"
+                );
+                return Ok(());
+            };
 
         // Compute per-image N via lightseek + run the expansion.
         let n_tokens: Vec<usize> = mm_image_entries
@@ -903,10 +993,10 @@ impl OpenAIPreprocessor {
         let n_total: usize = n_tokens.iter().sum();
 
         let mut expanded: Vec<crate::protocols::TokenIdType> =
-            Vec::with_capacity(token_ids.len() + n_total);
+            Vec::with_capacity(normalized_token_ids.len() + n_total);
         let mut img_ranges: Vec<(usize, usize)> = Vec::with_capacity(mm_image_entries.len());
         let mut i = 0usize;
-        for &t in token_ids {
+        for &t in normalized_token_ids.iter() {
             if t == image_token_id && i < mm_image_entries.len() {
                 let start = expanded.len();
                 expanded.extend(std::iter::repeat_n(image_token_id, n_tokens[i]));
@@ -956,17 +1046,99 @@ impl OpenAIPreprocessor {
         Ok(())
     }
 
-    /// xxh3-64 of the full URL string. Used as the routing `mm_hash` in the
-    /// URL-passthrough path. Two callers will collide on the same image only
-    /// when they send byte-identical URLs — including any query string. Any
-    /// query parameter that differs between requests (signed-URL `?sig=…`,
-    /// cache-buster `?v=…`, content selector `?width=…`) breaks the collision
-    /// and routes to a fresh worker. Frontend-decoding mode replaces this
-    /// with content-addressed hashing over decoded RGB bytes, which does
-    /// give cross-URL cache reuse.
+    /// Rewrites BPE-decomposed numbered image placeholders back into single
+    /// `image_token_id` tokens so the standard expansion can proceed.
+    ///
+    /// Used for Phi-3-vision-style templates whose flatten-time placeholder
+    /// is `<|image_{n}|>` (not a tokenizer special token, BPE-encodes into
+    /// ~7 sub-tokens) while the model's actual image token is `<|image|>`
+    /// (single special token = `image_token_id`). The backend's HF
+    /// processor recognises `<|image_{n}|>` in the prompt and replaces
+    /// each with N copies of `image_token_id` post-tokenization — we
+    /// replicate the routing-side equivalent here.
+    ///
+    /// For each image index `i` in `1..=expected_count`, encodes the
+    /// substituted placeholder string and scans `token_ids` for the
+    /// resulting BPE sub-sequence. Each match collapses to a single
+    /// `image_token_id` in the returned vector, preserving every
+    /// surrounding token. Returns `None` if any expected placeholder is
+    /// missing or if scans go out of order — the caller falls back to
+    /// text-prefix routing in that case.
+    #[cfg(feature = "lightseek-mm")]
+    fn normalize_numbered_placeholders(
+        &self,
+        token_ids: &[crate::protocols::TokenIdType],
+        image_token_id: crate::protocols::TokenIdType,
+        placeholder_tpl: &str,
+        expected_count: usize,
+    ) -> Option<Vec<crate::protocols::TokenIdType>> {
+        let mut out: Vec<crate::protocols::TokenIdType> = Vec::with_capacity(token_ids.len());
+        let mut cursor = 0usize;
+        for idx in 1..=expected_count {
+            let placeholder_text = placeholder_tpl.replace("{n}", &idx.to_string());
+            let encoding = self.tokenizer.encode(&placeholder_text).ok()?;
+            let sub_ids = encoding.token_ids();
+            if sub_ids.is_empty() {
+                return None;
+            }
+            let pos = find_subseq(&token_ids[cursor..], sub_ids)? + cursor;
+            out.extend_from_slice(&token_ids[cursor..pos]);
+            out.push(image_token_id);
+            cursor = pos + sub_ids.len();
+        }
+        out.extend_from_slice(&token_ids[cursor..]);
+        Some(out)
+    }
+
+    /// xxh3-64 of the URL after normalizing cache-buster / signed-URL query
+    /// parameters for HTTP/HTTPS. Used as the routing `mm_hash` in the
+    /// URL-passthrough path. Goal: the same image reached through different
+    /// signed URLs (rotating `?sig=…`, `?v=…`, AWS/GCS/Azure presign params)
+    /// collides on the same routing key, so the warm request lands on the
+    /// worker that already cached the image's KV blocks.
+    ///
+    /// Stripping is HTTP-only: `s3://`, `gs://`, `file://` and `data:` URIs
+    /// hash as-is because their query parameters carry object identity (or
+    /// the URI itself is content-addressed). Content-shaping HTTP params
+    /// (e.g. `?width=`, `?quality=`) are preserved — they identify a
+    /// different rendered image.
+    ///
+    /// Frontend-decoding mode replaces this with content-addressed hashing
+    /// over decoded RGB bytes, which gives cross-URL cache reuse even for
+    /// query parameters this list doesn't know about.
     #[cfg(feature = "lightseek-mm")]
     fn hash_image_url(url: &str) -> u64 {
-        xxhash_rust::xxh3::xxh3_64(url.as_bytes())
+        let canonical = Self::normalize_image_url(url);
+        xxhash_rust::xxh3::xxh3_64(canonical.as_bytes())
+    }
+
+    /// Returns the URL with HTTP/HTTPS cache-buster + signed-URL query
+    /// parameters removed. Other schemes pass through unchanged.
+    ///
+    /// Parse failure is treated as "pass through" — the routing path stays
+    /// correct (just byte-identical match) and downstream paths that
+    /// actually fetch the URL will surface the parse error.
+    #[cfg(feature = "lightseek-mm")]
+    fn normalize_image_url(url: &str) -> String {
+        if !(url.starts_with("http://") || url.starts_with("https://")) {
+            return url.to_string();
+        }
+        let Ok(mut parsed) = url::Url::parse(url) else {
+            return url.to_string();
+        };
+        let preserved: Vec<(String, String)> = parsed
+            .query_pairs()
+            .filter(|(k, _)| !is_cache_buster_query_key(k))
+            .map(|(k, v)| (k.into_owned(), v.into_owned()))
+            .collect();
+        parsed.set_query(None);
+        if !preserved.is_empty() {
+            let mut qmut = parsed.query_pairs_mut();
+            for (k, v) in &preserved {
+                qmut.append_pair(k, v);
+            }
+        }
+        parsed.into()
     }
 
     /// Header-only image dim fetch. For HTTP/HTTPS we issue a Range request
@@ -2950,15 +3122,54 @@ mod tests {
     /// like a cache-buster (`?v=1` vs `?v=2`) may also be a content selector
     /// (e.g. version → different image). Hash the full URL and let the URL
     /// be the identity.
+    /// Cache-buster query parameters (`?v=`, `?sig=`, AWS/GCS/Azure presign
+    /// fields) must be stripped before hashing so the same image reached
+    /// through different signed URLs lands on the same routing key.
     #[cfg(feature = "lightseek-mm")]
     #[test]
-    fn hash_image_url_distinguishes_query_strings() {
+    fn hash_image_url_strips_cache_busters_for_http() {
         let base = "https://cdn.example.com/img.jpg";
         let v1 = OpenAIPreprocessor::hash_image_url(&format!("{base}?v=1"));
-        let v2 = OpenAIPreprocessor::hash_image_url(&format!("{base}?v=2"));
+        let v2 = OpenAIPreprocessor::hash_image_url(&format!("{base}?v=2&sig=abc"));
         let no_q = OpenAIPreprocessor::hash_image_url(base);
-        assert_ne!(v1, v2, "?v=1 and ?v=2 may identify different images");
-        assert_ne!(v1, no_q, "presence of any query string changes the URL");
+        assert_eq!(v1, v2, "cache-busters must be stripped before hashing");
+        assert_eq!(
+            v1, no_q,
+            "stripping cache-busters yields the same hash as the bare URL"
+        );
+    }
+
+    /// AWS S3 / GCS presigned URLs rotate every few minutes; without
+    /// stripping, the same object hashes differently each request.
+    #[cfg(feature = "lightseek-mm")]
+    #[test]
+    fn hash_image_url_strips_presigned_params() {
+        let base = "https://bucket.s3.amazonaws.com/img.jpg";
+        let a = OpenAIPreprocessor::hash_image_url(&format!(
+            "{base}?X-Amz-Signature=AAA&X-Amz-Date=20260101T000000Z&X-Amz-Expires=600"
+        ));
+        let b = OpenAIPreprocessor::hash_image_url(&format!(
+            "{base}?X-Amz-Signature=BBB&X-Amz-Date=20260101T010000Z&X-Amz-Expires=900"
+        ));
+        assert_eq!(
+            a, b,
+            "rotating S3 presign params must collide on the same hash"
+        );
+    }
+
+    /// Content-shaping query params (image dimensions, format, quality) are
+    /// NOT cache-busters — `?width=256` and `?width=1024` produce different
+    /// rendered images and must hash differently.
+    #[cfg(feature = "lightseek-mm")]
+    #[test]
+    fn hash_image_url_preserves_content_params() {
+        let base = "https://cdn.example.com/img.jpg";
+        let small = OpenAIPreprocessor::hash_image_url(&format!("{base}?width=256"));
+        let large = OpenAIPreprocessor::hash_image_url(&format!("{base}?width=1024"));
+        assert_ne!(
+            small, large,
+            "content-shaping params identify a different rendered image"
+        );
     }
 
     /// data: URIs are content-addressed; hashing the entire URI gives content equality.

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -214,6 +214,30 @@ fn is_cache_buster_query_key(key: &str) -> bool {
     )
 }
 
+/// Shared SSRF-aware `MediaFetcher` + `reqwest::Client` for the dim-fetch
+/// path used by MM-aware routing. Inherits the same policy contract as the
+/// frontend-decode path (`MediaLoader`): blocklist DNS resolver, redirect
+/// revalidation, hostname/IP blocklist, `DYN_MM_ALLOW_INTERNAL` opt-in.
+///
+/// **Lifecycle:** `LazyLock` so the closure runs on first access. For MM-
+/// routable preprocessors, `OpenAIPreprocessor::new_with_parts` calls
+/// `LazyLock::force(...)` at startup — that surfaces TLS-root / reqwest-
+/// init / env-misconfig failures at deployment time, not on the first MM
+/// request 20 minutes in. Text-only deployments skip the force, leaving
+/// the LazyLock dormant.
+#[cfg(feature = "lightseek-mm")]
+static DIM_FETCH_MEDIA_FETCHER: std::sync::LazyLock<
+    crate::preprocessor::media::MediaFetcher,
+> = std::sync::LazyLock::new(crate::preprocessor::media::MediaFetcher::from_env);
+
+#[cfg(feature = "lightseek-mm")]
+static DIM_FETCH_HTTP_CLIENT: std::sync::LazyLock<reqwest::Client> =
+    std::sync::LazyLock::new(|| {
+        DIM_FETCH_MEDIA_FETCHER
+            .build_http_client()
+            .expect("dim-fetch http client construction failed")
+    });
+
 pub struct OpenAIPreprocessor {
     mdcsum: String,
     formatter: Arc<dyn OAIPromptFormatter>,
@@ -366,6 +390,18 @@ impl OpenAIPreprocessor {
 
         #[cfg(feature = "lightseek-mm")]
         let image_placeholder_template = formatter.image_placeholder_template();
+
+        // Force the dim-fetch HTTP client to build at startup for any
+        // MM-routable preprocessor, so TLS / env-var / reqwest-init
+        // failures fail the deployment instead of crashing the first
+        // MM request 20 minutes in. Text-only preprocessors skip the
+        // force (both lightseek hooks resolved to `None`) — no point
+        // building a client they'll never use.
+        #[cfg(feature = "lightseek-mm")]
+        if image_token_counter.is_some() || image_token_id.is_some() {
+            std::sync::LazyLock::force(&DIM_FETCH_MEDIA_FETCHER);
+            std::sync::LazyLock::force(&DIM_FETCH_HTTP_CLIENT);
+        }
 
         Ok(Arc::new(Self {
             formatter,
@@ -1198,10 +1234,8 @@ impl OpenAIPreprocessor {
 
     #[cfg(feature = "lightseek-mm")]
     async fn fetch_image_dims_uncached(url: &str) -> Result<(u32, u32)> {
-        use crate::preprocessor::media::MediaFetcher;
         use image::ImageReader;
         use std::io::Cursor;
-        use std::sync::LazyLock;
 
         // Most JPEG SOF markers and PNG/WebP headers fit in the first 4 KB.
         // Start small and only escalate to 64 KB if the parser fails on the
@@ -1237,28 +1271,23 @@ impl OpenAIPreprocessor {
             anyhow::bail!("unsupported url scheme for dim fetch: {}", url);
         }
 
-        // Shared SSRF-aware Client + connection pool. Reuses the same
-        // policy contract as the frontend-decode path (`MediaLoader`):
-        // blocklist DNS resolver, redirect revalidation, hostname/IP
-        // blocklist, `DYN_MM_ALLOW_INTERNAL` opt-in. Constructed once per
-        // process — Client connection-pooling kicks in across requests.
-        static MEDIA_FETCHER: LazyLock<MediaFetcher> = LazyLock::new(MediaFetcher::from_env);
-        static HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
-            MEDIA_FETCHER
-                .build_http_client()
-                .expect("dim-fetch http client construction failed")
-        });
+        // `DIM_FETCH_MEDIA_FETCHER` and `DIM_FETCH_HTTP_CLIENT` are
+        // module-scope `LazyLock`s forced at startup in `new_with_parts`
+        // for MM-routable preprocessors — see their definitions for the
+        // lifecycle and policy contract.
 
         // Pre-flight SSRF check on the original URL. Redirect targets are
         // revalidated by the Client's redirect policy, and DNS-resolved
         // IPs are filtered by the resolver — so a URL that passes here
         // can't escape the contract on the wire either.
         let parsed = url::Url::parse(url)?;
-        MEDIA_FETCHER.check_if_url_allowed_with_dns(&parsed).await?;
+        DIM_FETCH_MEDIA_FETCHER
+            .check_if_url_allowed_with_dns(&parsed)
+            .await?;
 
         let mut range_end = SMALL_RANGE;
         loop {
-            let resp = HTTP_CLIENT
+            let resp = DIM_FETCH_HTTP_CLIENT
                 .get(url)
                 .header("Range", format!("bytes=0-{}", range_end))
                 .timeout(DIM_FETCH_TIMEOUT)

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -183,37 +183,6 @@ fn find_subseq<T: PartialEq>(haystack: &[T], needle: &[T]) -> Option<usize> {
         .position(|window| window == needle)
 }
 
-/// HTTP/HTTPS query-parameter keys that identify cache-busters or signed-URL
-/// metadata rather than image content. Stripped before hashing so the same
-/// image reached through different signed URLs collides on the same routing
-/// `mm_hash`. Match is case-insensitive.
-///
-/// Conservative list — only adds keys that are widely documented as
-/// cache-bust or presign metadata. Content-shaping params (`width`,
-/// `quality`, `format`, …) are deliberately *not* in this set: a 256-wide
-/// thumbnail must not collide on the same hash as the 1024-wide render.
-#[cfg(feature = "lightseek-mm")]
-fn is_cache_buster_query_key(key: &str) -> bool {
-    let lc = key.to_ascii_lowercase();
-    matches!(
-        lc.as_str(),
-        // Generic cache-busters / version selectors.
-        "v" | "version" | "cb" | "cache_bust" | "_" | "t" | "ts" | "timestamp"
-        // Generic signed-URL pieces.
-        | "sig" | "signature" | "token" | "expires" | "expiry" | "exp"
-        // AWS S3 / CloudFront presigned (case-folded form of `X-Amz-…`).
-        | "x-amz-signature" | "x-amz-date" | "x-amz-expires"
-        | "x-amz-algorithm" | "x-amz-credential" | "x-amz-signedheaders"
-        | "x-amz-security-token" | "x-amz-user-agent"
-        // GCS signed URLs.
-        | "x-goog-signature" | "x-goog-date" | "x-goog-expires"
-        | "x-goog-algorithm" | "x-goog-credential" | "x-goog-signedheaders"
-        // Azure SAS tokens (`se`, `sp`, etc. are short by spec).
-        | "se" | "sp" | "sr" | "sv" | "st" | "tn" | "srt" | "ss" | "skoid"
-        | "sktid" | "skt" | "ske" | "sks" | "skv" | "spr"
-    )
-}
-
 /// Shared SSRF-aware `MediaFetcher` + `reqwest::Client` for the dim-fetch
 /// path used by MM-aware routing. Inherits the same policy contract as the
 /// frontend-decode path (`MediaLoader`): blocklist DNS resolver, redirect
@@ -1125,55 +1094,22 @@ impl OpenAIPreprocessor {
         Some(out)
     }
 
-    /// xxh3-64 of the URL after normalizing cache-buster / signed-URL query
-    /// parameters for HTTP/HTTPS. Used as the routing `mm_hash` in the
-    /// URL-passthrough path. Goal: the same image reached through different
-    /// signed URLs (rotating `?sig=…`, `?v=…`, AWS/GCS/Azure presign params)
-    /// collides on the same routing key, so the warm request lands on the
-    /// worker that already cached the image's KV blocks.
+    /// xxh3-64 of the raw URL bytes. Used as the routing `mm_hash` in the
+    /// URL-passthrough path: two requests with byte-identical URLs route to
+    /// the same worker, anything else routes independently.
     ///
-    /// Stripping is HTTP-only: `s3://`, `gs://`, `file://` and `data:` URIs
-    /// hash as-is because their query parameters carry object identity (or
-    /// the URI itself is content-addressed). Content-shaping HTTP params
-    /// (e.g. `?width=`, `?quality=`) are preserved — they identify a
-    /// different rendered image.
-    ///
-    /// Frontend-decoding mode replaces this with content-addressed hashing
-    /// over decoded RGB bytes, which gives cross-URL cache reuse even for
-    /// query parameters this list doesn't know about.
+    /// We deliberately do NOT strip cache-buster / signed-URL query
+    /// parameters — a query string like `?v=2` could mean either "new
+    /// cache-busted fetch of the same image" or "version 2 of a different
+    /// image", and the URL alone doesn't tell us which. Keeping the hash
+    /// URL-identical avoids the heuristic and the false-positive collisions
+    /// that come with it. Workloads with rotating signed URLs (S3, GCS,
+    /// Azure SAS) should use `--frontend-decoding`: that path hashes the
+    /// decoded RGB bytes instead, so cross-URL cache reuse is restored
+    /// without depending on URL conventions.
     #[cfg(feature = "lightseek-mm")]
     fn hash_image_url(url: &str) -> u64 {
-        let canonical = Self::normalize_image_url(url);
-        xxhash_rust::xxh3::xxh3_64(canonical.as_bytes())
-    }
-
-    /// Returns the URL with HTTP/HTTPS cache-buster + signed-URL query
-    /// parameters removed. Other schemes pass through unchanged.
-    ///
-    /// Parse failure is treated as "pass through" — the routing path stays
-    /// correct (just byte-identical match) and downstream paths that
-    /// actually fetch the URL will surface the parse error.
-    #[cfg(feature = "lightseek-mm")]
-    fn normalize_image_url(url: &str) -> String {
-        if !(url.starts_with("http://") || url.starts_with("https://")) {
-            return url.to_string();
-        }
-        let Ok(mut parsed) = url::Url::parse(url) else {
-            return url.to_string();
-        };
-        let preserved: Vec<(String, String)> = parsed
-            .query_pairs()
-            .filter(|(k, _)| !is_cache_buster_query_key(k))
-            .map(|(k, v)| (k.into_owned(), v.into_owned()))
-            .collect();
-        parsed.set_query(None);
-        if !preserved.is_empty() {
-            let mut qmut = parsed.query_pairs_mut();
-            for (k, v) in &preserved {
-                qmut.append_pair(k, v);
-            }
-        }
-        parsed.into()
+        xxhash_rust::xxh3::xxh3_64(url.as_bytes())
     }
 
     /// Header-only image dim fetch. For HTTP/HTTPS we issue a Range request
@@ -3145,33 +3081,32 @@ mod tests {
         }
     }
 
-    /// HTTP cache-buster keys (`v`, `t`, `cache`, `_`, `ts`, `sig`, `signature`)
-    /// Different query strings must produce different hashes — what looks
-    /// like a cache-buster (`?v=1` vs `?v=2`) may also be a content selector
-    /// (e.g. version → different image). Hash the full URL and let the URL
-    /// be the identity.
-    /// Cache-buster query parameters (`?v=`, `?sig=`, AWS/GCS/Azure presign
-    /// fields) must be stripped before hashing so the same image reached
-    /// through different signed URLs lands on the same routing key.
+    /// Different query strings must produce different hashes. `?v=1` and
+    /// `?v=2` may look like cache-busters, but they could equally be a
+    /// content selector ("version 2 of the image"). The URL alone doesn't
+    /// tell us which, so we keep the hash URL-identical and let the URL be
+    /// the identity. For signed-URL workloads where rotation actually
+    /// hides a stable object, `--frontend-decoding` hashes the decoded
+    /// bytes instead.
     #[cfg(feature = "lightseek-mm")]
     #[test]
-    fn hash_image_url_strips_cache_busters_for_http() {
+    fn hash_image_url_distinguishes_query_strings() {
         let base = "https://cdn.example.com/img.jpg";
         let v1 = OpenAIPreprocessor::hash_image_url(&format!("{base}?v=1"));
-        let v2 = OpenAIPreprocessor::hash_image_url(&format!("{base}?v=2&sig=abc"));
+        let v2 = OpenAIPreprocessor::hash_image_url(&format!("{base}?v=2"));
         let no_q = OpenAIPreprocessor::hash_image_url(base);
-        assert_eq!(v1, v2, "cache-busters must be stripped before hashing");
-        assert_eq!(
-            v1, no_q,
-            "stripping cache-busters yields the same hash as the bare URL"
-        );
+        assert_ne!(v1, v2, "different query values must hash differently");
+        assert_ne!(v1, no_q, "presence of a query string must change the hash");
     }
 
-    /// AWS S3 / GCS presigned URLs rotate every few minutes; without
-    /// stripping, the same object hashes differently each request.
+    /// Rotating S3 / GCS / Azure SAS signatures change the URL and
+    /// therefore the hash. This is a known limitation of URL-passthrough
+    /// routing for signed-URL workloads — `--frontend-decoding` is the
+    /// recommended mode there because it hashes the decoded image bytes
+    /// regardless of how the URL was signed.
     #[cfg(feature = "lightseek-mm")]
     #[test]
-    fn hash_image_url_strips_presigned_params() {
+    fn hash_image_url_distinguishes_rotating_signatures() {
         let base = "https://bucket.s3.amazonaws.com/img.jpg";
         let a = OpenAIPreprocessor::hash_image_url(&format!(
             "{base}?X-Amz-Signature=AAA&X-Amz-Date=20260101T000000Z&X-Amz-Expires=600"
@@ -3179,28 +3114,26 @@ mod tests {
         let b = OpenAIPreprocessor::hash_image_url(&format!(
             "{base}?X-Amz-Signature=BBB&X-Amz-Date=20260101T010000Z&X-Amz-Expires=900"
         ));
-        assert_eq!(
+        assert_ne!(
             a, b,
-            "rotating S3 presign params must collide on the same hash"
+            "rotating presign params produce a different URL and must hash differently"
         );
     }
 
-    /// Content-shaping query params (image dimensions, format, quality) are
-    /// NOT cache-busters — `?width=256` and `?width=1024` produce different
-    /// rendered images and must hash differently.
+    /// Identical URLs must hash to the same value (the basic identity
+    /// guarantee that makes URL-passthrough routing useful at all).
     #[cfg(feature = "lightseek-mm")]
     #[test]
-    fn hash_image_url_preserves_content_params() {
-        let base = "https://cdn.example.com/img.jpg";
-        let small = OpenAIPreprocessor::hash_image_url(&format!("{base}?width=256"));
-        let large = OpenAIPreprocessor::hash_image_url(&format!("{base}?width=1024"));
-        assert_ne!(
-            small, large,
-            "content-shaping params identify a different rendered image"
+    fn hash_image_url_is_deterministic_for_identical_urls() {
+        let url = "https://cdn.example.com/img.jpg?width=256";
+        assert_eq!(
+            OpenAIPreprocessor::hash_image_url(url),
+            OpenAIPreprocessor::hash_image_url(url),
         );
     }
 
-    /// data: URIs are content-addressed; hashing the entire URI gives content equality.
+    /// data: URIs hash the entire URI string. Same payload → same hash;
+    /// different payload → different hash.
     #[cfg(feature = "lightseek-mm")]
     #[test]
     fn hash_image_url_data_uri_content_addressed() {
@@ -3217,8 +3150,7 @@ mod tests {
         );
     }
 
-    /// Non-HTTP / non-data schemes (s3://, gs://, file://) hash as-is — no
-    /// cache-buster stripping (their query strings are object-identifying).
+    /// Non-HTTP / non-data schemes (s3://, gs://, file://) hash as-is.
     #[cfg(feature = "lightseek-mm")]
     #[test]
     fn hash_image_url_other_schemes_passthrough() {
@@ -3226,7 +3158,7 @@ mod tests {
         let s3b = OpenAIPreprocessor::hash_image_url("s3://bucket/key?v=2");
         assert_ne!(
             s3a, s3b,
-            "s3:// query params identify objects and must not be stripped"
+            "s3:// query params identify objects and must not collide"
         );
     }
 }

--- a/lib/llm/src/preprocessor/lightseek_mm.rs
+++ b/lib/llm/src/preprocessor/lightseek_mm.rs
@@ -84,10 +84,10 @@ impl LightseekMmCounter {
 
 /// Resolve the image-placeholder token id by delegating to lightseek's
 /// per-model `ModelProcessorSpec`. Each registered model (Qwen3-VL,
-/// Qwen2-VL, LLaVA-NeXT, LLaVA-1.5, Phi-3-vision, Llama-4, Kimi-K2.5) reads
-/// the right field of `config.json` (`image_token_id`, `image_token_index`,
-/// `media_placeholder_token_id`) and falls back to the tokenizer's
-/// vocab when only the placeholder string is known.
+/// Qwen2.5-VL, Qwen2-VL, LLaVA-NeXT, LLaVA-1.5, Phi-3-vision, Llama-4)
+/// reads the right field of `config.json` (`image_token_id`,
+/// `image_token_index`, `media_placeholder_token_id`) and falls back to the
+/// tokenizer's vocab when only the placeholder string is known.
 ///
 /// `model_id` is the HF id or local path; `model_dir` is the directory
 /// containing `tokenizer.json` and `config.json`.
@@ -188,6 +188,52 @@ mod tests {
             REGISTRY
                 .find("/models/my-finetune", Some("qwen3_vl"))
                 .is_some()
+        );
+    }
+
+    /// Coverage table for the VLM families we claim to support. Each row is
+    /// a `(family_label, hf_id, model_type)` triple. A row "passes" when the
+    /// upstream registry can match it via either the HF id substring OR the
+    /// `model_type` config field. A failure here means either:
+    ///   - the documented family lost coverage in a smg release (need to
+    ///     pin or pick up the fix upstream), or
+    ///   - we should remove that family from our supported-list claim.
+    /// Update this list whenever we add a new supported family in docs.
+    #[test]
+    fn image_processor_registry_covers_documented_families() {
+        // (family, hf_id, model_type)
+        const FAMILIES: &[(&str, &str, &str)] = &[
+            ("Qwen3-VL", "Qwen/Qwen3-VL-2B-Instruct", "qwen3_vl"),
+            ("Qwen2-VL", "Qwen/Qwen2-VL-7B-Instruct", "qwen2_vl"),
+            ("Qwen2.5-VL", "Qwen/Qwen2.5-VL-7B-Instruct", "qwen2_5_vl"),
+            (
+                "LLaVA-NeXT",
+                "llava-hf/llava-v1.6-mistral-7b-hf",
+                "llava_next",
+            ),
+            ("LLaVA-1.5", "llava-hf/llava-1.5-7b-hf", "llava"),
+            (
+                "Phi-3-vision",
+                "microsoft/Phi-3-vision-128k-instruct",
+                "phi3_v",
+            ),
+            ("Llama-4", "meta-llama/Llama-4-Scout-17B-16E", "llama4"),
+        ];
+
+        let mut missing: Vec<&str> = Vec::new();
+        for (family, hf_id, model_type) in FAMILIES {
+            let by_id = REGISTRY.find(hf_id, None).is_some();
+            let by_type = REGISTRY.find("/local/finetune", Some(model_type)).is_some();
+            if !(by_id || by_type) {
+                missing.push(family);
+            }
+        }
+        assert!(
+            missing.is_empty(),
+            "lightseek registry has no processor for: {:?}. \
+             Either pick up an smg release that registers these, or trim \
+             the supported-families list in docs.",
+            missing
         );
     }
 }

--- a/lib/llm/src/preprocessor/lightseek_mm.rs
+++ b/lib/llm/src/preprocessor/lightseek_mm.rs
@@ -12,9 +12,59 @@ use anyhow::{Context, Result, anyhow};
 use llm_multimodal::{
     ImagePreProcessor, ImageProcessorRegistry, ModelMetadata, ModelRegistry, PreProcessorConfig,
 };
-use llm_tokenizer::HuggingFaceTokenizer;
+use llm_tokenizer::traits::Tokenizer;
+use llm_tokenizer::{Decoder, Encoder, Encoding, HuggingFaceTokenizer, SpecialTokens};
 
 use crate::protocols::TokenIdType;
+
+/// No-op `Tokenizer` impl used when a model directory has no `tokenizer.json`
+/// (e.g. Kimi-K2.5 ships `tiktoken.model` instead of an HF fast tokenizer).
+///
+/// The lightseek `ModelMetadata` always expects a tokenizer reference, but
+/// some `ModelProcessorSpec` impls — Kimi-K2.5 in particular — read the
+/// image-placeholder token id straight out of `config.json` and never call
+/// the tokenizer. Passing `NullTokenizer` lets those specs run; specs that
+/// do need vocab access (Phi-3, LLaVA) just get `None` from
+/// `token_to_id` and the resolver returns `None` gracefully.
+struct NullTokenizer;
+
+impl Encoder for NullTokenizer {
+    fn encode(&self, _input: &str, _add_special_tokens: bool) -> anyhow::Result<Encoding> {
+        Ok(Encoding::Plain(Vec::new()))
+    }
+    fn encode_batch(
+        &self,
+        inputs: &[&str],
+        _add_special_tokens: bool,
+    ) -> anyhow::Result<Vec<Encoding>> {
+        Ok(inputs.iter().map(|_| Encoding::Plain(Vec::new())).collect())
+    }
+}
+
+impl Decoder for NullTokenizer {
+    fn decode(&self, _ids: &[u32], _skip_special_tokens: bool) -> anyhow::Result<String> {
+        Ok(String::new())
+    }
+}
+
+impl Tokenizer for NullTokenizer {
+    fn vocab_size(&self) -> usize {
+        0
+    }
+    fn get_special_tokens(&self) -> &SpecialTokens {
+        static EMPTY: LazyLock<SpecialTokens> = LazyLock::new(SpecialTokens::default);
+        &EMPTY
+    }
+    fn token_to_id(&self, _token: &str) -> Option<u32> {
+        None
+    }
+    fn id_to_token(&self, _id: u32) -> Option<String> {
+        None
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
 
 // Both registries borrow processor refs that callers hold across requests,
 // so they must outlive every consumer — `LazyLock` gives them `'static`.
@@ -97,18 +147,31 @@ impl LightseekMmCounter {
 /// - no `ModelProcessorSpec` matches the model (caller should fall back to
 ///   text-prefix routing).
 pub fn resolve_image_token_id(model_id: &str, model_dir: &Path) -> Option<TokenIdType> {
+    // Try the HuggingFace fast tokenizer first; fall back to a no-op
+    // tokenizer when `tokenizer.json` is missing (Kimi-K2.5 ships only
+    // `tiktoken.model`, for example). Specs that read the placeholder
+    // token id from `config.json` (Kimi) still resolve; specs that need
+    // vocab access just return `None` here.
     let tokenizer_path = model_dir.join("tokenizer.json");
-    let tokenizer = HuggingFaceTokenizer::from_file(tokenizer_path.to_str()?)
-        .map_err(|e| {
-            tracing::warn!(
-                target: "mm_routing",
-                model_dir = %model_dir.display(),
-                err = %e,
-                "lightseek: failed to load tokenizer.json"
-            );
-            e
-        })
-        .ok()?;
+    let hf_tokenizer = tokenizer_path
+        .to_str()
+        .and_then(|p| match HuggingFaceTokenizer::from_file(p) {
+            Ok(t) => Some(t),
+            Err(e) => {
+                tracing::debug!(
+                    target: "mm_routing",
+                    model_dir = %model_dir.display(),
+                    err = %e,
+                    "lightseek: tokenizer.json not loaded; falling back to NullTokenizer"
+                );
+                None
+            }
+        });
+    let null_tokenizer = NullTokenizer;
+    let tokenizer: &dyn Tokenizer = match hf_tokenizer.as_ref() {
+        Some(t) => t,
+        None => &null_tokenizer,
+    };
 
     let config_path = model_dir.join("config.json");
     let config_json = std::fs::read_to_string(&config_path)
@@ -136,7 +199,7 @@ pub fn resolve_image_token_id(model_id: &str, model_dir: &Path) -> Option<TokenI
 
     let metadata = ModelMetadata {
         model_id,
-        tokenizer: &tokenizer,
+        tokenizer,
         config: &config,
     };
 

--- a/lib/llm/src/preprocessor/lightseek_mm.rs
+++ b/lib/llm/src/preprocessor/lightseek_mm.rs
@@ -84,8 +84,8 @@ impl LightseekMmCounter {
 
 /// Resolve the image-placeholder token id by delegating to lightseek's
 /// per-model `ModelProcessorSpec`. Each registered model (Qwen3-VL,
-/// Qwen2.5-VL, Qwen2-VL, LLaVA-NeXT, LLaVA-1.5, Phi-3-vision, Llama-4)
-/// reads the right field of `config.json` (`image_token_id`,
+/// Qwen2.5-VL, Qwen2-VL, LLaVA-NeXT, LLaVA-1.5, Phi-3-vision, Llama-4,
+/// Kimi-K2.5) reads the right field of `config.json` (`image_token_id`,
 /// `image_token_index`, `media_placeholder_token_id`) and falls back to the
 /// tokenizer's vocab when only the placeholder string is known.
 ///
@@ -218,6 +218,7 @@ mod tests {
                 "phi3_v",
             ),
             ("Llama-4", "meta-llama/Llama-4-Scout-17B-16E", "llama4"),
+            ("Kimi-K2.5", "moonshotai/Kimi-K2.5-Instruct", "kimi_k2_5"),
         ];
 
         let mut missing: Vec<&str> = Vec::new();

--- a/lib/llm/src/preprocessor/lightseek_mm.rs
+++ b/lib/llm/src/preprocessor/lightseek_mm.rs
@@ -153,20 +153,21 @@ pub fn resolve_image_token_id(model_id: &str, model_dir: &Path) -> Option<TokenI
     // token id from `config.json` (Kimi) still resolve; specs that need
     // vocab access just return `None` here.
     let tokenizer_path = model_dir.join("tokenizer.json");
-    let hf_tokenizer = tokenizer_path
-        .to_str()
-        .and_then(|p| match HuggingFaceTokenizer::from_file(p) {
-            Ok(t) => Some(t),
-            Err(e) => {
-                tracing::debug!(
-                    target: "mm_routing",
-                    model_dir = %model_dir.display(),
-                    err = %e,
-                    "lightseek: tokenizer.json not loaded; falling back to NullTokenizer"
-                );
-                None
-            }
-        });
+    let hf_tokenizer =
+        tokenizer_path
+            .to_str()
+            .and_then(|p| match HuggingFaceTokenizer::from_file(p) {
+                Ok(t) => Some(t),
+                Err(e) => {
+                    tracing::debug!(
+                        target: "mm_routing",
+                        model_dir = %model_dir.display(),
+                        err = %e,
+                        "lightseek: tokenizer.json not loaded; falling back to NullTokenizer"
+                    );
+                    None
+                }
+            });
     let null_tokenizer = NullTokenizer;
     let tokenizer: &dyn Tokenizer = match hf_tokenizer.as_ref() {
         Some(t) => t,

--- a/lib/llm/src/preprocessor/media/loader.rs
+++ b/lib/llm/src/preprocessor/media/loader.rs
@@ -224,6 +224,38 @@ impl MediaFetcher {
         }
         Ok(())
     }
+
+    /// Build a `reqwest::Client` that enforces this fetcher's policy on every
+    /// request *and* every redirect hop: blocklist DNS resolution, redirect
+    /// revalidation against `check_if_url_allowed`, and the configured
+    /// user-agent / timeout. Callers that want a single security contract
+    /// across every outbound HTTP request in the frontend should reuse this
+    /// — the connection pool stays warm and SSRF policy can't be bypassed.
+    pub fn build_http_client(&self) -> Result<reqwest::Client> {
+        let fetcher_for_redirects = self.clone();
+        let redirect_policy = Policy::custom(move |attempt| {
+            if attempt.previous().len() >= MAX_REDIRECTS {
+                return attempt.error(anyhow::anyhow!("too many redirects (max={MAX_REDIRECTS})"));
+            }
+            match fetcher_for_redirects.check_if_url_allowed(attempt.url()) {
+                Ok(()) => attempt.follow(),
+                Err(e) => attempt.error(e),
+            }
+        });
+
+        let mut builder = reqwest::Client::builder()
+            .user_agent(&self.user_agent)
+            .redirect(redirect_policy)
+            .dns_resolver(Arc::new(BlocklistResolver {
+                allow_private_ips: self.allow_private_ips,
+            }));
+
+        if let Some(timeout) = self.timeout {
+            builder = builder.timeout(timeout);
+        }
+
+        Ok(builder.build()?)
+    }
 }
 
 /// DNS resolver that filters out blocked IP ranges before reqwest sees them.
@@ -363,34 +395,7 @@ impl MediaLoader {
         // Fall back to env-aware defaults so `DYN_MM_ALLOW_INTERNAL=1` is
         // honored even when the caller doesn't pass an explicit fetcher.
         let media_fetcher = media_fetcher.unwrap_or_else(MediaFetcher::from_env);
-
-        // Redirect policy: revalidate the policy-visible part of the URL
-        // (scheme, IP literals, hostname blocklist, direct-IP / direct-port
-        // rules) on every hop. DNS-based attacks on redirect targets are
-        // handled by the custom resolver below.
-        let fetcher_for_redirects = media_fetcher.clone();
-        let redirect_policy = Policy::custom(move |attempt| {
-            if attempt.previous().len() >= MAX_REDIRECTS {
-                return attempt.error(anyhow::anyhow!("too many redirects (max={MAX_REDIRECTS})"));
-            }
-            match fetcher_for_redirects.check_if_url_allowed(attempt.url()) {
-                Ok(()) => attempt.follow(),
-                Err(e) => attempt.error(e),
-            }
-        });
-
-        let mut http_client_builder = reqwest::Client::builder()
-            .user_agent(&media_fetcher.user_agent)
-            .redirect(redirect_policy)
-            .dns_resolver(Arc::new(BlocklistResolver {
-                allow_private_ips: media_fetcher.allow_private_ips,
-            }));
-
-        if let Some(timeout) = media_fetcher.timeout {
-            http_client_builder = http_client_builder.timeout(timeout);
-        }
-
-        let http_client = http_client_builder.build()?;
+        let http_client = media_fetcher.build_http_client()?;
 
         let nixl_agent = get_nixl_agent()?;
 

--- a/lib/llm/src/preprocessor/media/rdma.rs
+++ b/lib/llm/src/preprocessor/media/rdma.rs
@@ -51,6 +51,29 @@ pub struct RdmaMediaDataDescriptor {
     pub(crate) source_storage: Option<Arc<nixl::NixlRegistered<SystemStorage>>>,
 }
 
+impl RdmaMediaDataDescriptor {
+    /// xxh3-64 of the decoded byte payload (e.g. RGB pixels for an image).
+    /// Returns `None` if the descriptor was deserialized from the wire and
+    /// no longer holds local storage. Used by MM-aware KV routing to
+    /// produce a content-addressed `mm_hash` so the same image reached
+    /// through different (signed) URLs collides on the same routing key.
+    #[cfg(feature = "lightseek-mm")]
+    pub(crate) fn content_hash(&self) -> Option<u64> {
+        use dynamo_memory::MemoryDescriptor;
+        let registered = self.source_storage.as_ref()?;
+        let storage = registered.storage();
+        let len = storage.size();
+        if len == 0 {
+            return None;
+        }
+        // SAFETY: `storage` is borrowed for the duration of this call;
+        // SystemStorage owns the malloc'd buffer of `len` bytes and won't
+        // free or relocate it while the borrow is alive.
+        let bytes = unsafe { std::slice::from_raw_parts(storage.as_ptr(), len) };
+        Some(xxhash_rust::xxh3::xxh3_64(bytes))
+    }
+}
+
 impl DecodedMediaData {
     pub fn into_rdma_descriptor(self, nixl_agent: &NixlAgent) -> Result<RdmaMediaDataDescriptor> {
         let source_storage = self.data;

--- a/lib/llm/src/preprocessor/media/rdma.rs
+++ b/lib/llm/src/preprocessor/media/rdma.rs
@@ -84,11 +84,15 @@ impl RdmaMediaDataDescriptor {
             DataType::UINT8 => 0,
         };
         hasher.update(&[dtype_byte]);
-        // raw payload
+        // raw payload via SystemStorage's Slice impl.
         // SAFETY: `storage` is borrowed for the duration of this call;
-        // SystemStorage owns the malloc'd buffer of `len` bytes and won't
-        // free or relocate it while the borrow is alive.
-        let bytes = unsafe { std::slice::from_raw_parts(storage.as_ptr(), len) };
+        // SystemStorage owns the malloc'd buffer and won't free or
+        // relocate it while the borrow is alive. The Slice trait's
+        // safety contract about no concurrent mutable access is upheld
+        // because `content_hash` is only invoked on descriptors during
+        // request building, before they're sent to NIXL.
+        use dynamo_memory::actions::Slice;
+        let bytes = unsafe { storage.as_slice().ok()? };
         hasher.update(bytes);
         Some(hasher.digest())
     }

--- a/lib/llm/src/preprocessor/media/rdma.rs
+++ b/lib/llm/src/preprocessor/media/rdma.rs
@@ -52,25 +52,45 @@ pub struct RdmaMediaDataDescriptor {
 }
 
 impl RdmaMediaDataDescriptor {
-    /// xxh3-64 of the decoded byte payload (e.g. RGB pixels for an image).
-    /// Returns `None` if the descriptor was deserialized from the wire and
-    /// no longer holds local storage. Used by MM-aware KV routing to
-    /// produce a content-addressed `mm_hash` so the same image reached
-    /// through different (signed) URLs collides on the same routing key.
+    /// xxh3-64 of `(shape, dtype, decoded byte payload)`. Returns `None` if
+    /// the descriptor was deserialized from the wire and no longer holds
+    /// local storage. Used by MM-aware KV routing to produce a
+    /// content-addressed `mm_hash` so the same image reached through
+    /// different (signed) URLs collides on the same routing key.
+    ///
+    /// `shape` + `dtype` are included in the preimage so two images that
+    /// happen to share a raw byte buffer but differ in dimensions or
+    /// element layout (e.g. `3x224x224` vs `224x224x3`) don't collide on
+    /// the same routing hash.
     #[cfg(feature = "lightseek-mm")]
     pub(crate) fn content_hash(&self) -> Option<u64> {
         use dynamo_memory::MemoryDescriptor;
+        use xxhash_rust::xxh3::Xxh3;
         let registered = self.source_storage.as_ref()?;
         let storage = registered.storage();
         let len = storage.size();
         if len == 0 {
             return None;
         }
+        let mut hasher = Xxh3::new();
+        // shape (rank + per-dim u64s) — fixed width so distinct shapes
+        // can't alias each other after concatenation.
+        hasher.update(&(self.tensor_info.shape.len() as u64).to_le_bytes());
+        for &dim in &self.tensor_info.shape {
+            hasher.update(&(dim as u64).to_le_bytes());
+        }
+        // dtype as a single discriminant byte; widen if DataType ever grows.
+        let dtype_byte: u8 = match self.tensor_info.dtype {
+            DataType::UINT8 => 0,
+        };
+        hasher.update(&[dtype_byte]);
+        // raw payload
         // SAFETY: `storage` is borrowed for the duration of this call;
         // SystemStorage owns the malloc'd buffer of `len` bytes and won't
         // free or relocate it while the borrow is alive.
         let bytes = unsafe { std::slice::from_raw_parts(storage.as_ptr(), len) };
-        Some(xxhash_rust::xxh3::xxh3_64(bytes))
+        hasher.update(bytes);
+        Some(hasher.digest())
     }
 }
 

--- a/lib/llm/src/preprocessor/prompt.rs
+++ b/lib/llm/src/preprocessor/prompt.rs
@@ -120,6 +120,15 @@ pub trait OAIChatLikeRequest {
 pub trait OAIPromptFormatter: Send + Sync + 'static {
     fn supports_add_generation_prompt(&self) -> bool;
     fn render(&self, req: &dyn OAIChatLikeRequest) -> Result<String>;
+
+    /// Per-family image-placeholder template used when the chat template
+    /// requires string content and the request contains images. `{n}` in
+    /// the template is the 1-based image index. `None` when the
+    /// formatter has no flatten strategy — MM-aware routing falls back
+    /// to text-prefix routing for those families.
+    fn image_placeholder_template(&self) -> Option<&'static str> {
+        None
+    }
 }
 
 #[derive(Clone)]

--- a/lib/llm/src/preprocessor/prompt/template.rs
+++ b/lib/llm/src/preprocessor/prompt/template.rs
@@ -194,6 +194,13 @@ struct HfTokenizerConfigJsonFormatter {
     /// True if the chat template natively references `reasoning_content`.
     /// When true, skip injection — the template handles it.
     template_handles_reasoning: bool,
+    /// Per-family placeholder template for image content parts when flattening
+    /// mixed text+image content arrays into a single string (`preserve_arrays`
+    /// = false path). `{n}` in the template is substituted with the 1-based
+    /// image index. `None` when the model's chat template handles content
+    /// arrays natively (Qwen-VL family) or when we have no flatten strategy
+    /// for it (no MM-aware routing benefit either way).
+    image_placeholder_template: Option<&'static str>,
 }
 
 // /// OpenAI Standard Prompt Formatter

--- a/lib/llm/src/preprocessor/prompt/template/formatters.rs
+++ b/lib/llm/src/preprocessor/prompt/template/formatters.rs
@@ -56,8 +56,11 @@ fn detect_image_placeholder_template(env: &Environment) -> Option<&'static str> 
         .ok()
         .map(|t| t.source().to_string())
         .unwrap_or_default();
-    // Phi-3-vision: `<|user|>`/`<|end|>` envelope with `+ message['content'] +`.
-    if src.contains("<|user|>") && src.contains("<|end|>") {
+    // Phi-3-vision template constructs `<|user|>` at runtime via
+    // `'<|' + message['role'] + '|>'`, so the literal `<|user|>` never
+    // appears in the source. The literals that ARE in the source are
+    // `<|end|>` (end-of-turn) and `<|assistant|>` (generation prompt).
+    if src.contains("<|end|>") && src.contains("<|assistant|>") {
         return Some("<|image_{n}|>");
     }
     // LLaVA-1.5: USER:/ASSISTANT: convention with `+ message['content']`.

--- a/lib/llm/src/preprocessor/prompt/template/formatters.rs
+++ b/lib/llm/src/preprocessor/prompt/template/formatters.rs
@@ -38,6 +38,35 @@ fn detect_content_array_usage(env: &Environment) -> bool {
     out_array.contains("template_test") && !out_string.contains("template_test")
 }
 
+/// Picks an image-placeholder template by sniffing the chat template source
+/// for distinctive role/end markers.
+///
+/// Returned string is a format with `{n}` standing in for the 1-based image
+/// index (numbered Phi-3 placeholders) or just a static placeholder (LLaVA).
+/// Returns `None` when we don't know a flatten strategy for this template —
+/// callers leave the mixed-content array untouched in that case.
+///
+/// The detection is intentionally narrow: only families whose chat templates
+/// concatenate `message.content` with strings (and therefore can't render a
+/// content array) need this. Qwen-VL / LLaVA-NeXT iterate `content` natively
+/// and don't reach the flatten path at all.
+fn detect_image_placeholder_template(env: &Environment) -> Option<&'static str> {
+    let src = env
+        .get_template("default")
+        .ok()
+        .map(|t| t.source().to_string())
+        .unwrap_or_default();
+    // Phi-3-vision: `<|user|>`/`<|end|>` envelope with `+ message['content'] +`.
+    if src.contains("<|user|>") && src.contains("<|end|>") {
+        return Some("<|image_{n}|>");
+    }
+    // LLaVA-1.5: USER:/ASSISTANT: convention with `+ message['content']`.
+    if src.contains("USER:") && src.contains("ASSISTANT:") {
+        return Some("<image>");
+    }
+    None
+}
+
 /// Remove known non-standard Jinja2 tags from chat templates
 ///
 /// Some models use custom Jinja2 extensions that minijinja doesn't recognize. These tags
@@ -161,6 +190,15 @@ impl HfTokenizerConfigJsonFormatter {
         // Detect at model load time whether this template requires content arrays
         let requires_content_arrays = detect_content_array_usage(&env);
 
+        // Pick a per-family placeholder for the mixed-content → string flatten
+        // path. `None` is the safe default — the existing behavior in
+        // `may_be_fix_msg_content` leaves mixed arrays untouched.
+        let image_placeholder_template = if requires_content_arrays {
+            None
+        } else {
+            detect_image_placeholder_template(&env)
+        };
+
         // Detect if the template natively handles reasoning_content (e.g. Nemotron, Qwen3).
         // If so, we must NOT inject <think> blocks — the template does it itself.
         let template_handles_reasoning = env
@@ -175,6 +213,7 @@ impl HfTokenizerConfigJsonFormatter {
             requires_content_arrays,
             exclude_tools_when_tool_choice_none,
             template_handles_reasoning,
+            image_placeholder_template,
         })
     }
 }

--- a/lib/llm/src/preprocessor/prompt/template/oai.rs
+++ b/lib/llm/src/preprocessor/prompt/template/oai.rs
@@ -170,8 +170,7 @@ fn may_be_fix_msg_content(
                             // Mixed text+image array for a string-content
                             // template — flatten with model-family image
                             // placeholders inlined where the image parts were.
-                            let flattened =
-                                flatten_mixed_content(&content_array, placeholder_tpl);
+                            let flattened = flatten_mixed_content(&content_array, placeholder_tpl);
                             msg_object.insert(
                                 "content".to_string(),
                                 serde_json::Value::String(flattened),
@@ -466,6 +465,10 @@ impl OAIChatLikeRequest for NvCreateCompletionRequest {
 impl OAIPromptFormatter for HfTokenizerConfigJsonFormatter {
     fn supports_add_generation_prompt(&self) -> bool {
         self.supports_add_generation_prompt
+    }
+
+    fn image_placeholder_template(&self) -> Option<&'static str> {
+        self.image_placeholder_template
     }
 
     fn render(&self, req: &dyn OAIChatLikeRequest) -> Result<String> {
@@ -818,7 +821,8 @@ mod tests {
         let messages_raw = serde_json::to_value(request.messages()).unwrap();
 
         // Test array → string normalization (preserve_arrays=false for standard templates)
-        let messages = serde_json::to_value(may_be_fix_msg_content(messages_raw, false, None)).unwrap();
+        let messages =
+            serde_json::to_value(may_be_fix_msg_content(messages_raw, false, None)).unwrap();
 
         // Verify: text-only array is concatenated into a single string
         assert_eq!(
@@ -864,7 +868,8 @@ mod tests {
         let messages_raw = serde_json::to_value(request.messages()).unwrap();
 
         // Test array → string normalization (preserve_arrays=false for standard templates)
-        let messages = serde_json::to_value(may_be_fix_msg_content(messages_raw, false, None)).unwrap();
+        let messages =
+            serde_json::to_value(may_be_fix_msg_content(messages_raw, false, None)).unwrap();
 
         // Verify: System message with string content remains unchanged
         assert_eq!(
@@ -908,7 +913,8 @@ mod tests {
         let messages_raw = serde_json::to_value(request.messages()).unwrap();
 
         // Empty arrays should be preserved regardless of preserve_arrays setting
-        let messages = serde_json::to_value(may_be_fix_msg_content(messages_raw, false, None)).unwrap();
+        let messages =
+            serde_json::to_value(may_be_fix_msg_content(messages_raw, false, None)).unwrap();
 
         // Verify: Empty arrays are preserved as-is
         assert!(messages[0]["content"].is_array());
@@ -932,7 +938,8 @@ mod tests {
         let messages_raw = serde_json::to_value(request.messages()).unwrap();
 
         // Test with preserve_arrays=false (standard templates)
-        let messages = serde_json::to_value(may_be_fix_msg_content(messages_raw, false, None)).unwrap();
+        let messages =
+            serde_json::to_value(may_be_fix_msg_content(messages_raw, false, None)).unwrap();
 
         // Verify: String content is not modified
         assert_eq!(
@@ -963,7 +970,8 @@ mod tests {
         let messages_raw = serde_json::to_value(request.messages()).unwrap();
 
         // Mixed content should be preserved regardless of preserve_arrays setting
-        let messages = serde_json::to_value(may_be_fix_msg_content(messages_raw, false, None)).unwrap();
+        let messages =
+            serde_json::to_value(may_be_fix_msg_content(messages_raw, false, None)).unwrap();
 
         // Verify: Mixed content types are preserved as array for template handling
         // image_url should be converted to image placeholder
@@ -1030,12 +1038,9 @@ mod tests {
         let request: NvCreateChatCompletionRequest = serde_json::from_str(json_str).unwrap();
         let messages_raw = serde_json::to_value(request.messages()).unwrap();
 
-        let messages = serde_json::to_value(may_be_fix_msg_content(
-            messages_raw,
-            false,
-            Some("<image>"),
-        ))
-        .unwrap();
+        let messages =
+            serde_json::to_value(may_be_fix_msg_content(messages_raw, false, Some("<image>")))
+                .unwrap();
 
         let content = messages[0]["content"].as_str().expect("content flattened");
         assert_eq!(content, "Describe: <image>");
@@ -1062,7 +1067,8 @@ mod tests {
         let messages_raw = serde_json::to_value(request.messages()).unwrap();
 
         // Non-text arrays should be preserved regardless of preserve_arrays setting
-        let messages = serde_json::to_value(may_be_fix_msg_content(messages_raw, false, None)).unwrap();
+        let messages =
+            serde_json::to_value(may_be_fix_msg_content(messages_raw, false, None)).unwrap();
 
         // Verify: Non-text content arrays are preserved, with image_url converted to image
         assert!(messages[0]["content"].is_array());
@@ -1159,7 +1165,8 @@ NORMAL MODE
 
         let request: NvCreateChatCompletionRequest = serde_json::from_str(json_str).unwrap();
         let messages_raw = serde_json::to_value(request.messages()).unwrap();
-        let messages = serde_json::to_value(may_be_fix_msg_content(messages_raw, false, None)).unwrap();
+        let messages =
+            serde_json::to_value(may_be_fix_msg_content(messages_raw, false, None)).unwrap();
 
         // Mixed types should preserve array structure, with image_url converted to image
         assert!(messages[0]["content"].is_array());
@@ -1188,7 +1195,8 @@ NORMAL MODE
 
         let request: NvCreateChatCompletionRequest = serde_json::from_str(json_str).unwrap();
         let messages_raw = serde_json::to_value(request.messages()).unwrap();
-        let messages = serde_json::to_value(may_be_fix_msg_content(messages_raw, false, None)).unwrap();
+        let messages =
+            serde_json::to_value(may_be_fix_msg_content(messages_raw, false, None)).unwrap();
 
         // Unknown types mixed with text should preserve array
         assert!(messages[0]["content"].is_array());
@@ -1363,7 +1371,8 @@ NORMAL MODE
         let messages_raw = serde_json::to_value(request.messages()).unwrap();
 
         // Test with preserve_arrays=true (multimodal templates)
-        let messages = serde_json::to_value(may_be_fix_msg_content(messages_raw, true, None)).unwrap();
+        let messages =
+            serde_json::to_value(may_be_fix_msg_content(messages_raw, true, None)).unwrap();
 
         // Verify: String is converted to array format
         assert!(messages[0]["content"].is_array());
@@ -1393,7 +1402,8 @@ NORMAL MODE
         let messages_raw = serde_json::to_value(request.messages()).unwrap();
 
         // Test with preserve_arrays=true (multimodal templates)
-        let messages = serde_json::to_value(may_be_fix_msg_content(messages_raw, true, None)).unwrap();
+        let messages =
+            serde_json::to_value(may_be_fix_msg_content(messages_raw, true, None)).unwrap();
 
         // Verify: Array is preserved as-is
         assert!(messages[0]["content"].is_array());

--- a/lib/llm/src/preprocessor/prompt/template/oai.rs
+++ b/lib/llm/src/preprocessor/prompt/template/oai.rs
@@ -101,9 +101,18 @@ fn convert_media_url_to_placeholder(
         .collect()
 }
 
-fn may_be_fix_msg_content(messages: serde_json::Value, preserve_arrays: bool) -> Value {
+fn may_be_fix_msg_content(
+    messages: serde_json::Value,
+    preserve_arrays: bool,
+    image_placeholder_template: Option<&str>,
+) -> Value {
     // preserve_arrays=true: strings → arrays (multimodal)
     // preserve_arrays=false: text-only arrays → strings (standard)
+    // image_placeholder_template: when `preserve_arrays=false` and the array
+    // mixes text + image parts, this template (e.g. `<|image_{n}|>`) lets us
+    // flatten by substituting image parts with model-family placeholders
+    // instead of leaving the raw array for the template, which would crash
+    // string-content templates like Phi-3-vision's `'+' message.content`.
 
     let Some(arr) = messages.as_array() else {
         return Value::from_serialize(&messages);
@@ -155,6 +164,18 @@ fn may_be_fix_msg_content(messages: serde_json::Value, preserve_arrays: bool) ->
                                 "content".to_string(),
                                 serde_json::Value::String(concatenated_text),
                             );
+                        } else if !preserve_arrays
+                            && let Some(placeholder_tpl) = image_placeholder_template
+                        {
+                            // Mixed text+image array for a string-content
+                            // template — flatten with model-family image
+                            // placeholders inlined where the image parts were.
+                            let flattened =
+                                flatten_mixed_content(&content_array, placeholder_tpl);
+                            msg_object.insert(
+                                "content".to_string(),
+                                serde_json::Value::String(flattened),
+                            );
                         } else {
                             // Keep as array (with media_url → media placeholder conversion applied)
                             msg_object.insert(
@@ -171,6 +192,33 @@ fn may_be_fix_msg_content(messages: serde_json::Value, preserve_arrays: bool) ->
         .collect();
 
     Value::from_serialize(&updated_messages)
+}
+
+/// Concatenate a mixed-content array (text parts + image placeholders) into a
+/// single string. Text parts contribute their `text` field as-is; non-text
+/// parts (image, video, audio after the URL→placeholder conversion in
+/// `convert_media_url_to_placeholder`) emit the per-family placeholder with
+/// `{n}` substituted by the 1-based index of the image in the message.
+///
+/// Used in `may_be_fix_msg_content` when `preserve_arrays=false` and the
+/// template knows a placeholder convention — currently Phi-3-vision
+/// (`<|image_{n}|>`) and LLaVA-1.5 (`<image>`).
+fn flatten_mixed_content(parts: &[serde_json::Value], placeholder_tpl: &str) -> String {
+    let mut out = String::new();
+    let mut img_idx: u32 = 1;
+    for part in parts {
+        let type_str = part.get("type").and_then(|t| t.as_str()).unwrap_or("");
+        if type_str == "text" {
+            if let Some(text) = part.get("text").and_then(|t| t.as_str()) {
+                out.push_str(text);
+            }
+        } else if !type_str.is_empty() {
+            let placeholder = placeholder_tpl.replace("{n}", &img_idx.to_string());
+            out.push_str(&placeholder);
+            img_idx += 1;
+        }
+    }
+    out
 }
 
 fn normalize_tool_arguments_in_messages(messages: &mut serde_json::Value) {
@@ -451,6 +499,7 @@ impl OAIPromptFormatter for HfTokenizerConfigJsonFormatter {
         messages_for_template = serde_json::to_value(may_be_fix_msg_content(
             messages_for_template,
             self.requires_content_arrays,
+            self.image_placeholder_template,
         ))
         .unwrap();
 
@@ -769,7 +818,7 @@ mod tests {
         let messages_raw = serde_json::to_value(request.messages()).unwrap();
 
         // Test array → string normalization (preserve_arrays=false for standard templates)
-        let messages = serde_json::to_value(may_be_fix_msg_content(messages_raw, false)).unwrap();
+        let messages = serde_json::to_value(may_be_fix_msg_content(messages_raw, false, None)).unwrap();
 
         // Verify: text-only array is concatenated into a single string
         assert_eq!(
@@ -815,7 +864,7 @@ mod tests {
         let messages_raw = serde_json::to_value(request.messages()).unwrap();
 
         // Test array → string normalization (preserve_arrays=false for standard templates)
-        let messages = serde_json::to_value(may_be_fix_msg_content(messages_raw, false)).unwrap();
+        let messages = serde_json::to_value(may_be_fix_msg_content(messages_raw, false, None)).unwrap();
 
         // Verify: System message with string content remains unchanged
         assert_eq!(
@@ -859,7 +908,7 @@ mod tests {
         let messages_raw = serde_json::to_value(request.messages()).unwrap();
 
         // Empty arrays should be preserved regardless of preserve_arrays setting
-        let messages = serde_json::to_value(may_be_fix_msg_content(messages_raw, false)).unwrap();
+        let messages = serde_json::to_value(may_be_fix_msg_content(messages_raw, false, None)).unwrap();
 
         // Verify: Empty arrays are preserved as-is
         assert!(messages[0]["content"].is_array());
@@ -883,7 +932,7 @@ mod tests {
         let messages_raw = serde_json::to_value(request.messages()).unwrap();
 
         // Test with preserve_arrays=false (standard templates)
-        let messages = serde_json::to_value(may_be_fix_msg_content(messages_raw, false)).unwrap();
+        let messages = serde_json::to_value(may_be_fix_msg_content(messages_raw, false, None)).unwrap();
 
         // Verify: String content is not modified
         assert_eq!(
@@ -914,7 +963,7 @@ mod tests {
         let messages_raw = serde_json::to_value(request.messages()).unwrap();
 
         // Mixed content should be preserved regardless of preserve_arrays setting
-        let messages = serde_json::to_value(may_be_fix_msg_content(messages_raw, false)).unwrap();
+        let messages = serde_json::to_value(may_be_fix_msg_content(messages_raw, false, None)).unwrap();
 
         // Verify: Mixed content types are preserved as array for template handling
         // image_url should be converted to image placeholder
@@ -925,6 +974,71 @@ mod tests {
         assert_eq!(content_array[1]["type"], "image");
         assert!(content_array[1].get("image_url").is_none());
         assert_eq!(content_array[2]["type"], "text");
+    }
+
+    /// Mixed text+image array with a string-content template and an
+    /// `<|image_{n}|>`-style placeholder (Phi-3-vision) — content must be
+    /// flattened to a single string with numbered image markers in place of
+    /// the image parts. The previous default (leave as array) would crash
+    /// the Phi-3 template's `'+' message.content` concatenation.
+    #[test]
+    fn test_may_be_fix_msg_content_flattens_phi3_style() {
+        let json_str = r#"{
+            "model": "phi-3-vision",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "First "},
+                        {"type": "image_url", "image_url": {"url": "https://example.com/a.jpg"}},
+                        {"type": "text", "text": " then "},
+                        {"type": "image_url", "image_url": {"url": "https://example.com/b.jpg"}},
+                        {"type": "text", "text": "?"}
+                    ]
+                }
+            ]
+        }"#;
+        let request: NvCreateChatCompletionRequest = serde_json::from_str(json_str).unwrap();
+        let messages_raw = serde_json::to_value(request.messages()).unwrap();
+
+        let messages = serde_json::to_value(may_be_fix_msg_content(
+            messages_raw,
+            false,
+            Some("<|image_{n}|>"),
+        ))
+        .unwrap();
+
+        let content = messages[0]["content"].as_str().expect("content flattened");
+        assert_eq!(content, "First <|image_1|> then <|image_2|>?");
+    }
+
+    /// Same flattening with a static placeholder (LLaVA-1.5 `<image>`).
+    #[test]
+    fn test_may_be_fix_msg_content_flattens_llava_style() {
+        let json_str = r#"{
+            "model": "llava-1.5-7b-hf",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Describe: "},
+                        {"type": "image_url", "image_url": {"url": "https://example.com/x.jpg"}}
+                    ]
+                }
+            ]
+        }"#;
+        let request: NvCreateChatCompletionRequest = serde_json::from_str(json_str).unwrap();
+        let messages_raw = serde_json::to_value(request.messages()).unwrap();
+
+        let messages = serde_json::to_value(may_be_fix_msg_content(
+            messages_raw,
+            false,
+            Some("<image>"),
+        ))
+        .unwrap();
+
+        let content = messages[0]["content"].as_str().expect("content flattened");
+        assert_eq!(content, "Describe: <image>");
     }
 
     /// Tests that content arrays containing only non-text types remain as arrays,
@@ -948,7 +1062,7 @@ mod tests {
         let messages_raw = serde_json::to_value(request.messages()).unwrap();
 
         // Non-text arrays should be preserved regardless of preserve_arrays setting
-        let messages = serde_json::to_value(may_be_fix_msg_content(messages_raw, false)).unwrap();
+        let messages = serde_json::to_value(may_be_fix_msg_content(messages_raw, false, None)).unwrap();
 
         // Verify: Non-text content arrays are preserved, with image_url converted to image
         assert!(messages[0]["content"].is_array());
@@ -1045,7 +1159,7 @@ NORMAL MODE
 
         let request: NvCreateChatCompletionRequest = serde_json::from_str(json_str).unwrap();
         let messages_raw = serde_json::to_value(request.messages()).unwrap();
-        let messages = serde_json::to_value(may_be_fix_msg_content(messages_raw, false)).unwrap();
+        let messages = serde_json::to_value(may_be_fix_msg_content(messages_raw, false, None)).unwrap();
 
         // Mixed types should preserve array structure, with image_url converted to image
         assert!(messages[0]["content"].is_array());
@@ -1074,7 +1188,7 @@ NORMAL MODE
 
         let request: NvCreateChatCompletionRequest = serde_json::from_str(json_str).unwrap();
         let messages_raw = serde_json::to_value(request.messages()).unwrap();
-        let messages = serde_json::to_value(may_be_fix_msg_content(messages_raw, false)).unwrap();
+        let messages = serde_json::to_value(may_be_fix_msg_content(messages_raw, false, None)).unwrap();
 
         // Unknown types mixed with text should preserve array
         assert!(messages[0]["content"].is_array());
@@ -1216,7 +1330,7 @@ NORMAL MODE
 
         // Apply content normalization with preserve_arrays=false (standard templates)
         let mut messages =
-            serde_json::to_value(may_be_fix_msg_content(messages_raw, false)).unwrap();
+            serde_json::to_value(may_be_fix_msg_content(messages_raw, false, None)).unwrap();
 
         normalize_tool_arguments_in_messages(&mut messages);
 
@@ -1249,7 +1363,7 @@ NORMAL MODE
         let messages_raw = serde_json::to_value(request.messages()).unwrap();
 
         // Test with preserve_arrays=true (multimodal templates)
-        let messages = serde_json::to_value(may_be_fix_msg_content(messages_raw, true)).unwrap();
+        let messages = serde_json::to_value(may_be_fix_msg_content(messages_raw, true, None)).unwrap();
 
         // Verify: String is converted to array format
         assert!(messages[0]["content"].is_array());
@@ -1279,7 +1393,7 @@ NORMAL MODE
         let messages_raw = serde_json::to_value(request.messages()).unwrap();
 
         // Test with preserve_arrays=true (multimodal templates)
-        let messages = serde_json::to_value(may_be_fix_msg_content(messages_raw, true)).unwrap();
+        let messages = serde_json::to_value(may_be_fix_msg_content(messages_raw, true, None)).unwrap();
 
         // Verify: Array is preserved as-is
         assert!(messages[0]["content"].is_array());

--- a/lib/llm/src/preprocessor/prompt/template/oai.rs
+++ b/lib/llm/src/preprocessor/prompt/template/oai.rs
@@ -165,11 +165,16 @@ fn may_be_fix_msg_content(
                                 serde_json::Value::String(concatenated_text),
                             );
                         } else if !preserve_arrays
+                            && !content_array.is_empty()
                             && let Some(placeholder_tpl) = image_placeholder_template
                         {
                             // Mixed text+image array for a string-content
                             // template — flatten with model-family image
                             // placeholders inlined where the image parts were.
+                            // The `is_empty` guard preserves a literal `[]`
+                            // content (matches pre-PR behavior); flattening
+                            // an empty array to `""` would silently change
+                            // what the template renders.
                             let flattened = flatten_mixed_content(&content_array, placeholder_tpl);
                             msg_object.insert(
                                 "content".to_string(),
@@ -202,6 +207,16 @@ fn may_be_fix_msg_content(
 /// Used in `may_be_fix_msg_content` when `preserve_arrays=false` and the
 /// template knows a placeholder convention — currently Phi-3-vision
 /// (`<|image_{n}|>`) and LLaVA-1.5 (`<image>`).
+///
+/// **Caveat — non-text index slot:** `img_idx` increments for every non-text
+/// part, not just images. The current supported families (Phi-3, LLaVA-1.5)
+/// are image-only so there's no collision today, but a future image+video
+/// family would silently consume an image-index slot for each video/audio
+/// part and emit the image placeholder there. When adding a family that
+/// mixes modalities in one message, either:
+///   1. expand this function with per-modality placeholder strings, or
+///   2. assert in `convert_media_url_to_placeholder` that only "image"
+///      placeholders reach this path.
 fn flatten_mixed_content(parts: &[serde_json::Value], placeholder_tpl: &str) -> String {
     let mut out = String::new();
     let mut img_idx: u32 = 1;
@@ -918,6 +933,43 @@ mod tests {
 
         // Verify: Empty arrays are preserved as-is
         assert!(messages[0]["content"].is_array());
+        assert_eq!(messages[0]["content"].as_array().unwrap().len(), 0);
+    }
+
+    /// Empty arrays must stay as `[]` even when a flatten-time placeholder
+    /// template is provided (Phi-3 / LLaVA-1.5 path). Without the
+    /// `!content_array.is_empty()` guard in `may_be_fix_msg_content`,
+    /// an empty content array would silently flatten to `""` and the
+    /// chat template would render an entirely empty message instead of
+    /// failing or being preserved.
+    #[test]
+    fn test_may_be_fix_msg_content_empty_array_with_placeholder_template() {
+        let json_str = r#"{
+            "model": "phi-3-vision",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": []
+                }
+            ]
+        }"#;
+
+        let request: NvCreateChatCompletionRequest = serde_json::from_str(json_str).unwrap();
+        let messages_raw = serde_json::to_value(request.messages()).unwrap();
+
+        // preserve_arrays=false + image_placeholder_template=Some(...) is
+        // the combination that previously flattened `[]` to `""`.
+        let messages = serde_json::to_value(may_be_fix_msg_content(
+            messages_raw,
+            false,
+            Some("<|image_{n}|>"),
+        ))
+        .unwrap();
+
+        assert!(
+            messages[0]["content"].is_array(),
+            "empty array should be preserved as `[]`, not flattened to `\"\"`"
+        );
         assert_eq!(messages[0]["content"].as_array().unwrap().len(), 0);
     }
 

--- a/tests/mm_router/test_router_rust_mm_frontend_decode_e2e.py
+++ b/tests/mm_router/test_router_rust_mm_frontend_decode_e2e.py
@@ -1,0 +1,402 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""End-to-end test for MM-aware KV routing with frontend image decoding.
+
+Architecture:
+  Frontend (Rust preprocessor + lightseek + KV router + MediaLoader)
+       ├─ DOWNLOADS the image bytes (because the worker registered a
+       │  `media_decoder` via `--frontend-decoding`)
+       ├─ DECODES into RGB bytes via the in-process MediaDecoder
+       ├─ HASHES the decoded bytes (xxh3 over RGB) → mm_hash
+       ├─ Reads (W, H) from the decoded shape (no Range fetch)
+       └─ Forwards mm_hashes via extra_args["mm_hashes"]
+   → vLLM worker (publishes KV events with the forwarded UUID)
+
+The headline behavior we exercise here, distinct from the URL-passthrough
+path tested in test_router_rust_mm_router_e2e.py, is **content-addressed**
+mm_hash: two distinct URLs serving the same image bytes must produce the
+same `mm_hash` and therefore route the second request to the warm worker.
+Without content hashing (e.g. if the code regressed to URL hashing in the
+decoded branch), the second request would miss and overlap would be
+text-prefix only.
+
+Kept in a separate module from test_router_rust_mm_router_e2e.py so its
+module-scoped fixture (different worker, different DYN_NAMESPACE) does
+not collide with the URL-passthrough fixture's registry entries.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import tempfile
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from io import BytesIO
+from typing import Any, Generator
+
+import pytest
+import requests
+
+from tests.conftest import EtcdServer, NatsServer
+from tests.utils.gpu_args import build_gpu_mem_args
+from tests.utils.managed_process import ManagedProcess
+from tests.utils.payloads import check_models_api
+from tests.utils.port_utils import allocate_ports
+
+VLLM_MM_MODEL = os.getenv("DYN_TEST_VLLM_MM_MODEL", "Qwen/Qwen3-VL-2B-Instruct")
+BLOCK_SIZE = 16
+# Distinct namespace from test_router_rust_mm_router_e2e.py so the two
+# modules' workers/frontends don't register against each other.
+NAMESPACE = "router-rust-mm-fed"
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.e2e,
+    pytest.mark.vllm,
+    pytest.mark.multimodal,
+    pytest.mark.gpu_1,
+    pytest.mark.model(VLLM_MM_MODEL),
+    pytest.mark.requested_vllm_kv_cache_bytes(1_719_075_000),
+    pytest.mark.profiled_vram_gib(18.7),
+]
+
+_ROUTING_RECORD_PATTERN = re.compile(
+    r"\[ROUTING\].*with\s*(\d+)/(\d+)\s*blocks overlap"
+)
+
+
+def _check_ready(response) -> bool:
+    try:
+        return (response.json() or {}).get("status") == "ready"
+    except ValueError:
+        return False
+
+
+def _make_process_env(**extra: str) -> dict[str, str]:
+    env = os.environ.copy()
+    env["DYN_LOG"] = (
+        "info,mm_routing=debug,"
+        "dynamo_kv_router::scheduling=debug,"
+        "dynamo_llm::kv_router=debug"
+    )
+    env["DYN_NAMESPACE"] = NAMESPACE
+    env["DYN_REQUEST_PLANE"] = "tcp"
+    env["DYN_MM_ALLOW_INTERNAL"] = "1"
+    env.update(extra)
+    return env
+
+
+def _prepare_log_dir(request, suffix: str) -> str:
+    return tempfile.mkdtemp(prefix=f"{request.node.name}_{suffix}_")
+
+
+_COMMON_PROCESS_KWARGS: dict[str, Any] = {
+    "display_output": True,
+    "terminate_all_matching_process_names": False,
+}
+
+
+def _vllm_gpu_mem_args(default_utilization: str) -> list[str]:
+    return build_gpu_mem_args("build_vllm_gpu_mem_args") or [
+        "--gpu-memory-utilization",
+        default_utilization,
+    ]
+
+
+class VLLMWorkerFrontendDecodeProcess(ManagedProcess):
+    """vLLM backend with `--frontend-decoding` so the model card carries a
+    `media_decoder` and the frontend's MediaLoader runs in-process."""
+
+    def __init__(self, request, *, system_port: int, kv_event_port: int):
+        super().__init__(
+            command=[
+                "python3",
+                "-m",
+                "dynamo.vllm",
+                "--model",
+                VLLM_MM_MODEL,
+                "--enable-multimodal",
+                "--frontend-decoding",
+                "--block-size",
+                str(BLOCK_SIZE),
+                "--enforce-eager",
+                *_vllm_gpu_mem_args("0.40"),
+                "--max-model-len",
+                "4096",
+                "--kv-events-config",
+                (
+                    f'{{"publisher":"zmq","topic":"kv-events",'
+                    f'"endpoint":"tcp://*:{kv_event_port}",'
+                    f'"enable_kv_cache_events": true}}'
+                ),
+            ],
+            env=_make_process_env(DYN_SYSTEM_PORT=str(system_port)),
+            health_check_urls=[
+                (f"http://localhost:{system_port}/health", _check_ready)
+            ],
+            timeout=900,
+            straggler_commands=["-m dynamo.vllm"],
+            log_dir=_prepare_log_dir(request, "vllm-worker-fed"),
+            **_COMMON_PROCESS_KWARGS,
+        )
+
+
+class FrontendProcess(ManagedProcess):
+    def __init__(self, request, *, frontend_port: int):
+        super().__init__(
+            command=[
+                "python3",
+                "-m",
+                "dynamo.frontend",
+                "--http-port",
+                str(frontend_port),
+                "--router-mode",
+                "kv",
+                "--kv-cache-block-size",
+                str(BLOCK_SIZE),
+                "--model-name",
+                VLLM_MM_MODEL,
+            ],
+            env=_make_process_env(),
+            health_check_urls=[
+                (f"http://localhost:{frontend_port}/v1/models", check_models_api)
+            ],
+            timeout=240,
+            straggler_commands=["-m dynamo.frontend"],
+            log_dir=_prepare_log_dir(request, "frontend-fed"),
+            **_COMMON_PROCESS_KWARGS,
+        )
+
+
+@pytest.fixture(scope="module")
+def mm_runtime_services(request):
+    with (
+        NatsServer(request, port=0) as nats,
+        EtcdServer(request, port=0) as etcd,
+        pytest.MonkeyPatch.context() as mp,
+    ):
+        mp.setenv("NATS_SERVER", f"nats://localhost:{nats.port}")
+        mp.setenv("ETCD_ENDPOINTS", f"http://localhost:{etcd.port}")
+        yield
+
+
+@pytest.fixture(scope="module")
+def start_frontend_decode_services(
+    request, mm_runtime_services
+) -> Generator[tuple[int, ManagedProcess], None, None]:
+    # start_port intentionally distinct from the URL-passthrough module's
+    # range (11000s) so the two suites don't collide on local ports.
+    frontend_port, vllm_port, kv_event_port = allocate_ports(count=3, start_port=11500)
+    with VLLMWorkerFrontendDecodeProcess(
+        request, system_port=vllm_port, kv_event_port=kv_event_port
+    ):
+        time.sleep(2)  # allow ZMQ publisher to bind
+        with FrontendProcess(request, frontend_port=frontend_port) as fe:
+            yield frontend_port, fe
+
+
+def _make_png_bytes(color: tuple[int, int, int], size: int = 256) -> bytes:
+    from PIL import Image
+
+    img = Image.new("RGB", (size, size), color)
+    buf = BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _build_payload(image_uris: list[str]) -> dict[str, Any]:
+    content: list[dict[str, Any]] = [{"type": "text", "text": "Describe this image."}]
+    for uri in image_uris:
+        content.append({"type": "image_url", "image_url": {"url": uri}})
+    return {
+        "model": VLLM_MM_MODEL,
+        "messages": [{"role": "user", "content": content}],
+        "max_tokens": 4,
+    }
+
+
+def _extract_routing_records(log_text: str) -> list[tuple[int, int]]:
+    return [(int(o), int(t)) for o, t in _ROUTING_RECORD_PATTERN.findall(log_text)]
+
+
+def _wait_for_new_routing_score(
+    router_proc: ManagedProcess,
+    pre_request_records: int,
+    timeout_s: float = 25.0,
+) -> tuple[int, int]:
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        records = _extract_routing_records(router_proc.read_logs())
+        if len(records) >= pre_request_records + 1:
+            return records[-1]
+        time.sleep(1)
+    return 0, 0
+
+
+def _send(
+    frontend_port: int,
+    router_proc: ManagedProcess,
+    payload: dict[str, Any],
+    label: str,
+) -> tuple[int, int, dict[str, Any]]:
+    pre_count = len(_extract_routing_records(router_proc.read_logs()))
+    resp = requests.post(
+        f"http://localhost:{frontend_port}/v1/chat/completions",
+        json=payload,
+        timeout=240,
+    )
+    assert resp.status_code == 200, f"HTTP {resp.status_code}: {resp.text}"
+    data = resp.json()
+    overlap, total = _wait_for_new_routing_score(router_proc, pre_count)
+    print(f"[FED] {label}: overlap={overlap}/{total} usage={data.get('usage')}")
+    time.sleep(1)
+    return overlap, total, data
+
+
+def _make_image_handler(image_map: dict[str, bytes]) -> type:
+    class _ImageHandler(BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802
+            path = self.path.split("?", 1)[0]
+            data = image_map.get(path)
+            if data is None:
+                self.send_error(404)
+                return
+            range_hdr = self.headers.get("Range", "")
+            if range_hdr.startswith("bytes="):
+                spec = range_hdr[len("bytes=") :]
+                lo_s, _, hi_s = spec.partition("-")
+                try:
+                    lo = int(lo_s) if lo_s else 0
+                    hi = int(hi_s) if hi_s else len(data) - 1
+                except ValueError:
+                    self.send_error(416)
+                    return
+                hi = min(hi, len(data) - 1)
+                lo = max(lo, 0)
+                if lo > hi:
+                    self.send_error(416)
+                    return
+                chunk = data[lo : hi + 1]
+                self.send_response(206)
+                self.send_header("Content-Type", "image/png")
+                self.send_header("Content-Length", str(len(chunk)))
+                self.send_header("Content-Range", f"bytes {lo}-{hi}/{len(data)}")
+                self.end_headers()
+                self.wfile.write(chunk)
+            else:
+                self.send_response(200)
+                self.send_header("Content-Type", "image/png")
+                self.send_header("Content-Length", str(len(data)))
+                self.end_headers()
+                self.wfile.write(data)
+
+        def log_message(self, format, *args):
+            pass
+
+    return _ImageHandler
+
+
+@pytest.fixture(scope="module")
+def http_image_server_with_alias() -> Generator[dict[str, str], None, None]:
+    """Serve PNGs over HTTP. Two distinct paths (`/image_A.png` and
+    `/image_A_alias.png`) return *byte-identical* content; the
+    content-hash assertion below relies on this. Distinct paths defeat
+    URL-string hashing — only content hashing collides them."""
+    (port,) = allocate_ports(count=1, start_port=18600)
+    primary_bytes = _make_png_bytes((180, 30, 90))
+    image_map: dict[str, bytes] = {
+        "/image_A.png": primary_bytes,
+        "/image_A_alias.png": primary_bytes,  # byte-identical, different URL
+    }
+    server = HTTPServer(("127.0.0.1", port), _make_image_handler(image_map))
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield {
+            "primary": f"http://127.0.0.1:{port}/image_A.png",
+            "alias": f"http://127.0.0.1:{port}/image_A_alias.png",
+        }
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+@pytest.mark.timeout(300)
+def test_frontend_decode_content_hash_collides_across_urls(
+    start_frontend_decode_services,
+    predownload_models,
+    http_image_server_with_alias,
+):
+    """The headline frontend-decode contract: two distinct URLs serving
+    the same image bytes must produce the same `mm_hash` (content-addressed
+    via xxh3 over decoded RGB), so the second request hits the warm worker.
+
+    If the decoded branch ever regresses to URL-string hashing, this test
+    will see only text-prefix overlap (overlap_2 ≈ 1 like overlap_1) and
+    fail. That is exactly the regression we want this gate to catch.
+    """
+    frontend_port, router_proc = start_frontend_decode_services
+    primary_url = http_image_server_with_alias["primary"]
+    alias_url = http_image_server_with_alias["alias"]
+
+    overlap_1, total_1, _ = _send(
+        frontend_port, router_proc, _build_payload([primary_url]), "fed_primary"
+    )
+    overlap_2, total_2, data_2 = _send(
+        frontend_port, router_proc, _build_payload([alias_url]), "fed_alias"
+    )
+
+    assert total_1 > 1 and total_2 > 1, (
+        f"expected non-trivial total blocks for MM request, got "
+        f"{total_1}, {total_2}"
+    )
+    assert overlap_2 > overlap_1 + 1, (
+        f"frontend-decode mm_hash must be content-addressed: distinct URLs "
+        f"serving the same image bytes should collide on the routing key. "
+        f"Got primary={overlap_1}/{total_1}, alias={overlap_2}/{total_2}. "
+        f"If overlap_2 ≈ overlap_1, the decoded branch is hashing the URL "
+        f"instead of the bytes."
+    )
+
+    cached_2 = (data_2.get("usage", {}).get("prompt_tokens_details") or {}).get(
+        "cached_tokens"
+    )
+    prompt_tokens_2 = data_2.get("usage", {}).get("prompt_tokens", 0)
+    assert cached_2 is not None and cached_2 > prompt_tokens_2 // 2, (
+        f"expected high vLLM cached_tokens on warm alias request "
+        f"(content hash should match the worker's KV cache key), got "
+        f"cached={cached_2}, prompt_tokens={prompt_tokens_2}"
+    )
+
+
+@pytest.mark.timeout(300)
+def test_frontend_decode_logs_decoded_bytes_source(
+    start_frontend_decode_services,
+    predownload_models,
+    http_image_server_with_alias,
+):
+    """Smoke check: the frontend-decode path must emit the
+    `source=decoded_bytes` lightseek log line, proving we took the
+    content-hash branch and not the url_fallback branch."""
+    frontend_port, router_proc = start_frontend_decode_services
+    _send(
+        frontend_port,
+        router_proc,
+        _build_payload([http_image_server_with_alias["primary"]]),
+        "fed_smoke",
+    )
+    # tracing's pretty/compact format wraps each field in ANSI escapes
+    # (`[3msource[0m[2m=[0m"decoded_bytes"`) so a literal `source="decoded_bytes"`
+    # substring search misses. The bareword "decoded_bytes" is unique to our
+    # `hash_source = "decoded_bytes"` literal, so checking for it is enough.
+    log_text = router_proc.read_logs()
+    assert "decoded_bytes" in log_text, (
+        "frontend-decode path should hash decoded bytes; missing the "
+        "`decoded_bytes` source tag means the code took either the "
+        "`url_fallback` branch (descriptor lost source_storage) or the "
+        "URL-passthrough branch (media_loader was None)."
+    )

--- a/tests/mm_router/test_router_rust_mm_router_e2e.py
+++ b/tests/mm_router/test_router_rust_mm_router_e2e.py
@@ -383,11 +383,12 @@ def _make_image_handler(image_map: dict[str, bytes]) -> type:
 
     class _ImageHandler(BaseHTTPRequestHandler):
         def do_GET(self):  # noqa: N802
-            # Strip query string — our `hash_normalized_url` drops common
-            # cache-busters (v, t, sig, signature, cache, _, ts) before
-            # hashing, so callers can append signed-URL params and still
-            # hit cache. The test below hits both `/img.png?v=1` and
-            # `/img.png?v=2` — the server should serve the same bytes.
+            # Strip query string so the server resolves to the same bytes
+            # regardless of any signed-URL params the caller appended.
+            # The frontend's routing hash uses the full URL (different
+            # query strings → different `mm_hash`), but the backend's
+            # image fetch still serves the same bytes either way — which
+            # is what we want for the distinct-query-strings test below.
             path = self.path.split("?", 1)[0]
             data = image_map.get(path)
             if data is None:
@@ -491,38 +492,42 @@ def test_router_rust_mm_repeated_http_image_overlap(
 
 
 @pytest.mark.timeout(300)
-def test_router_rust_mm_http_url_cache_buster_normalization(
+def test_router_rust_mm_http_url_distinct_query_strings_dont_collide(
     start_router_rust_mm_services, predownload_models, http_image_server
 ):
-    """The frontend strips signed-URL cache-busters (`?v=`, `?sig=`, etc.)
-    before hashing, so the same image accessed via different signed URLs
-    must produce the same `mm_hash` and therefore hit the same KV cache.
-    Test: warm with `?v=1`, repeat with `?v=2` — second request must
-    show cache-hit overlap, not be treated as a fresh image."""
+    """URL-passthrough routing hashes the full URL — distinct query strings
+    on the same image path produce distinct `mm_hash` values. We do NOT
+    normalize cache-buster / signed-URL params because the URL alone can't
+    tell us whether `?v=2` means "cache-busted same image" or "version 2 of
+    a different image". Workloads with rotating signed URLs over a stable
+    object should use `--frontend-decoding`, which hashes the decoded RGB
+    bytes (see `test_router_rust_mm_frontend_decode_e2e.py`).
+
+    Test: warm with `?v=1`, repeat with `?v=2` — second request must NOT
+    show MM-block overlap beyond the text-prefix baseline (i.e. the system
+    treats them as different images at the routing layer)."""
     frontend_port, router_proc = start_router_rust_mm_services
     base_url = http_image_server["B"]
     payload_v1 = _build_payload([f"{base_url}?v=1&sig=abc"])
     payload_v2 = _build_payload([f"{base_url}?v=2&sig=def"])
 
     overlap_1, total_1, _ = _send(
-        frontend_port, router_proc, payload_v1, "cache_buster_req1"
+        frontend_port, router_proc, payload_v1, "distinct_url_req1"
     )
-    overlap_2, total_2, data_2 = _send(
-        frontend_port, router_proc, payload_v2, "cache_buster_req2"
+    overlap_2, total_2, _ = _send(
+        frontend_port, router_proc, payload_v2, "distinct_url_req2"
     )
 
-    assert overlap_2 > overlap_1 + 1, (
-        f"expected URL normalization to fold cache-buster query params, so "
-        f"`?v=2&sig=def` should hit the cache built by `?v=1&sig=abc`. Got "
-        f"req1={overlap_1}/{total_1}, req2={overlap_2}/{total_2}. If equal to 1, "
-        f"hash_normalized_url isn't stripping the buster keys."
+    # Both requests share the prompt's text prefix tokens but the image
+    # blocks must differ — the second request's overlap should not exceed
+    # the first by more than 1 block (the typical text-prefix baseline).
+    assert overlap_2 <= overlap_1 + 1, (
+        f"expected `?v=1` and `?v=2` to route as different images, but "
+        f"req2 overlap jumped well above req1's text-prefix baseline. Got "
+        f"req1={overlap_1}/{total_1}, req2={overlap_2}/{total_2}. If req2 is "
+        f"much larger, the frontend is normalizing cache-busters (regression "
+        f"to the strip-list behavior)."
     )
-    cached_2 = (data_2.get("usage", {}).get("prompt_tokens_details") or {}).get(
-        "cached_tokens"
-    )
-    assert (
-        cached_2 is not None and cached_2 > 0
-    ), f"expected cached_tokens > 0 after URL-buster normalization, got {cached_2}"
 
 
 @pytest.mark.timeout(300)

--- a/tests/mm_router/test_router_rust_mm_router_e2e.py
+++ b/tests/mm_router/test_router_rust_mm_router_e2e.py
@@ -1,0 +1,549 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""End-to-end tests for MM-aware KV routing with the Rust frontend (lightseek-mm).
+
+Architecture:
+  Frontend (Rust preprocessor + lightseek + KV router)
+       └─ resolves <|image_pad|>, computes per-image N via lightseek,
+          expands placeholders, hashes URL→u64→64-char hex,
+          forwards mm_hashes via extra_args["mm_hashes"]
+       → vLLM worker (publishes KV events with the forwarded UUID)
+
+These tests assert that:
+  1. Same-image repeats see >1 block of router-side overlap and high
+     vLLM cached_tokens (the bit-exact MM cache hit).
+  2. The data: URI path works equivalently to http URLs.
+  3. Different images on the same prompt produce strictly less overlap
+     than identical-image repeats.
+
+The fallback path (model unsupported by lightseek or image-token
+unresolvable) is unit-tested via `image_token::tests` and the
+graceful-degrade branches in `gather_mm_exact_routing_info`; reproducing
+it e2e would require a model whose loading is heavy and whose worker
+support is fragile (e.g. Phi-4-multimodal-instruct + trust_remote_code),
+so we cover that path at the Rust unit-test boundary.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+import re
+import tempfile
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from io import BytesIO
+from typing import Any, Generator
+
+import pytest
+import requests
+
+from tests.conftest import EtcdServer, NatsServer
+from tests.utils.gpu_args import build_gpu_mem_args
+from tests.utils.managed_process import ManagedProcess
+from tests.utils.payloads import check_models_api
+from tests.utils.port_utils import allocate_ports
+
+VLLM_MM_MODEL = os.getenv("DYN_TEST_VLLM_MM_MODEL", "Qwen/Qwen3-VL-2B-Instruct")
+BLOCK_SIZE = 16
+NAMESPACE = "router-rust-mm"
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.e2e,
+    pytest.mark.vllm,
+    pytest.mark.multimodal,
+    pytest.mark.gpu_1,
+    pytest.mark.model(VLLM_MM_MODEL),
+    pytest.mark.requested_vllm_kv_cache_bytes(1_719_075_000),
+    pytest.mark.profiled_vram_gib(18.7),
+]
+
+# Format produced by lib/llm/src/kv_router/push_router.rs's [ROUTING] log.
+_ROUTING_RECORD_PATTERN = re.compile(
+    r"\[ROUTING\].*with\s*(\d+)/(\d+)\s*blocks overlap"
+)
+
+
+def _check_ready(response) -> bool:
+    try:
+        return (response.json() or {}).get("status") == "ready"
+    except ValueError:
+        return False
+
+
+def _make_process_env(
+    log_level: str = (
+        "info,mm_routing=debug,"
+        "dynamo_kv_router::scheduling=debug,"
+        # The [ROUTING] log line we parse below lives here at debug level.
+        "dynamo_llm::kv_router=debug"
+    ),
+    **extra,
+) -> dict[str, str]:
+    env = os.environ.copy()
+    env["DYN_LOG"] = log_level
+    env["DYN_NAMESPACE"] = NAMESPACE
+    env["DYN_REQUEST_PLANE"] = "tcp"
+    env["DYN_MM_ALLOW_INTERNAL"] = "1"
+    env.update(extra)
+    return env
+
+
+def _prepare_log_dir(request, suffix: str) -> str:
+    return tempfile.mkdtemp(prefix=f"{request.node.name}_{suffix}_")
+
+
+_COMMON_PROCESS_KWARGS: dict[str, Any] = {
+    "display_output": True,
+    "terminate_all_matching_process_names": False,
+}
+
+
+def _vllm_gpu_mem_args(default_utilization: str) -> list[str]:
+    return build_gpu_mem_args("build_vllm_gpu_mem_args") or [
+        "--gpu-memory-utilization",
+        default_utilization,
+    ]
+
+
+class VLLMWorkerProcess(ManagedProcess):
+    """vLLM backend that publishes KV events the router can consume."""
+
+    def __init__(self, request, *, system_port: int, kv_event_port: int):
+        super().__init__(
+            command=[
+                "python3",
+                "-m",
+                "dynamo.vllm",
+                "--model",
+                VLLM_MM_MODEL,
+                "--enable-multimodal",
+                "--block-size",
+                str(BLOCK_SIZE),
+                "--enforce-eager",
+                *_vllm_gpu_mem_args("0.40"),
+                "--max-model-len",
+                "4096",
+                "--kv-events-config",
+                (
+                    f'{{"publisher":"zmq","topic":"kv-events",'
+                    f'"endpoint":"tcp://*:{kv_event_port}",'
+                    f'"enable_kv_cache_events": true}}'
+                ),
+            ],
+            env=_make_process_env(DYN_SYSTEM_PORT=str(system_port)),
+            health_check_urls=[
+                (f"http://localhost:{system_port}/health", _check_ready)
+            ],
+            timeout=900,
+            straggler_commands=["-m dynamo.vllm"],
+            log_dir=_prepare_log_dir(request, "vllm-worker"),
+            **_COMMON_PROCESS_KWARGS,
+        )
+
+
+class FrontendProcess(ManagedProcess):
+    """Rust frontend with lightseek-mm. No --dyn-chat-processor flag (default 'dynamo')."""
+
+    def __init__(self, request, *, frontend_port: int):
+        super().__init__(
+            command=[
+                "python3",
+                "-m",
+                "dynamo.frontend",
+                "--http-port",
+                str(frontend_port),
+                "--router-mode",
+                "kv",
+                "--kv-cache-block-size",
+                str(BLOCK_SIZE),
+                "--model-name",
+                VLLM_MM_MODEL,
+            ],
+            env=_make_process_env(),
+            health_check_urls=[
+                (f"http://localhost:{frontend_port}/v1/models", check_models_api)
+            ],
+            timeout=240,
+            straggler_commands=["-m dynamo.frontend"],
+            log_dir=_prepare_log_dir(request, "router-rust-frontend"),
+            **_COMMON_PROCESS_KWARGS,
+        )
+
+
+@pytest.fixture(scope="module")
+def mm_runtime_services(request):
+    with (
+        NatsServer(request, port=0) as nats,
+        EtcdServer(request, port=0) as etcd,
+        pytest.MonkeyPatch.context() as mp,
+    ):
+        mp.setenv("NATS_SERVER", f"nats://localhost:{nats.port}")
+        mp.setenv("ETCD_ENDPOINTS", f"http://localhost:{etcd.port}")
+        yield
+
+
+@pytest.fixture(scope="module")
+def start_router_rust_mm_services(
+    request, mm_runtime_services
+) -> Generator[tuple[int, ManagedProcess], None, None]:
+    frontend_port, vllm_port, kv_event_port = allocate_ports(count=3, start_port=11000)
+    with VLLMWorkerProcess(request, system_port=vllm_port, kv_event_port=kv_event_port):
+        time.sleep(2)  # allow ZMQ publisher to bind
+        with FrontendProcess(request, frontend_port=frontend_port) as frontend_proc:
+            yield frontend_port, frontend_proc
+
+
+def _make_png_bytes(color: tuple[int, int, int], size: int = 256) -> bytes:
+    from PIL import Image
+
+    img = Image.new("RGB", (size, size), color)
+    buf = BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _make_data_uri(color: tuple[int, int, int], size: int = 256) -> str:
+    b64 = base64.b64encode(_make_png_bytes(color, size)).decode("utf-8")
+    return f"data:image/png;base64,{b64}"
+
+
+def _build_payload(
+    image_uris: list[str], prompt: str = "Describe this image."
+) -> dict[str, Any]:
+    content: list[dict[str, Any]] = [{"type": "text", "text": prompt}]
+    for uri in image_uris:
+        content.append({"type": "image_url", "image_url": {"url": uri}})
+    return {
+        "model": VLLM_MM_MODEL,
+        "messages": [{"role": "user", "content": content}],
+        "max_tokens": 4,
+    }
+
+
+def _extract_routing_records(log_text: str) -> list[tuple[int, int]]:
+    return [
+        (int(overlap), int(total))
+        for overlap, total in _ROUTING_RECORD_PATTERN.findall(log_text)
+    ]
+
+
+def _wait_for_new_routing_score(
+    router_proc: ManagedProcess,
+    pre_request_records: int,
+    timeout_s: float = 25.0,
+) -> tuple[int, int]:
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        records = _extract_routing_records(router_proc.read_logs())
+        if len(records) >= pre_request_records + 1:
+            return records[-1]
+        time.sleep(1)
+    return 0, 0
+
+
+def _send(
+    frontend_port: int,
+    router_proc: ManagedProcess,
+    payload: dict[str, Any],
+    label: str,
+) -> tuple[int, int, dict[str, Any]]:
+    pre_count = len(_extract_routing_records(router_proc.read_logs()))
+    resp = requests.post(
+        f"http://localhost:{frontend_port}/v1/chat/completions",
+        json=payload,
+        timeout=240,
+    )
+    assert resp.status_code == 200, f"HTTP {resp.status_code}: {resp.text}"
+    data = resp.json()
+    assert "choices" in data, f"missing choices in response: {data}"
+    overlap, total = _wait_for_new_routing_score(router_proc, pre_count)
+    print(
+        f"[ROUTER_RUST_MM] {label}: overlap={overlap}/{total} usage={data.get('usage')}"
+    )
+    time.sleep(1)
+    return overlap, total, data
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.timeout(300)
+def test_router_rust_mm_repeated_single_image_overlap(
+    start_router_rust_mm_services, predownload_models
+):
+    """Same image twice → second request shows full image-block overlap and
+    high vLLM cached_tokens (proves bit-exact mm_hash forwarding works)."""
+    frontend_port, router_proc = start_router_rust_mm_services
+    image = _make_data_uri((201, 17, 99))
+    payload = _build_payload([image])
+
+    overlap_1, total_1, data_1 = _send(
+        frontend_port, router_proc, payload, "single_req1"
+    )
+    overlap_2, total_2, data_2 = _send(
+        frontend_port, router_proc, payload, "single_req2"
+    )
+
+    assert (
+        total_1 > 1 and total_2 > 1
+    ), f"expected non-trivial total blocks for MM request, got {total_1}, {total_2}"
+    assert overlap_2 > overlap_1 + 1, (
+        f"expected second-request overlap to dominate first by more than the "
+        f"text-prefix block alone, got req1={overlap_1}/{total_1}, "
+        f"req2={overlap_2}/{total_2}"
+    )
+
+    cached_2 = (data_2.get("usage", {}).get("prompt_tokens_details") or {}).get(
+        "cached_tokens"
+    )
+    prompt_tokens_2 = data_2.get("usage", {}).get("prompt_tokens", 0)
+    assert cached_2 is not None and cached_2 > prompt_tokens_2 // 2, (
+        f"expected high vLLM cached_tokens on warm request, got "
+        f"cached={cached_2}, prompt_tokens={prompt_tokens_2}"
+    )
+
+
+@pytest.mark.timeout(300)
+def test_router_rust_mm_data_uri_works(
+    start_router_rust_mm_services, predownload_models
+):
+    """data: URI path: mm_hash is computed from the URI bytes, dim parsed
+    in-memory (no HTTP fetch). Same data URI repeated → high overlap."""
+    frontend_port, router_proc = start_router_rust_mm_services
+    uri = _make_data_uri((34, 210, 89))
+    payload = _build_payload([uri])
+
+    _, _, _ = _send(frontend_port, router_proc, payload, "data_uri_req1")
+    overlap_2, total_2, data_2 = _send(
+        frontend_port, router_proc, payload, "data_uri_req2"
+    )
+
+    assert (
+        overlap_2 > 1 and total_2 > 1
+    ), f"expected MM-aware overlap on data URI repeat, got {overlap_2}/{total_2}"
+    cached_2 = (data_2.get("usage", {}).get("prompt_tokens_details") or {}).get(
+        "cached_tokens"
+    )
+    assert (
+        cached_2 is not None and cached_2 > 0
+    ), f"expected cached_tokens > 0 on warm data URI request, got {cached_2}"
+
+
+@pytest.mark.timeout(300)
+def test_router_rust_mm_different_images_lower_overlap(
+    start_router_rust_mm_services, predownload_models
+):
+    """Same prompt, different image: a warm-A repeat must show higher
+    overlap than a cold first-time B request. With a single worker doing
+    serial requests, this proves that a different mm_hash produces a
+    different block-hash sequence (i.e. the image content actually
+    contributes to the routing key, not just the text-prefix block)."""
+    frontend_port, router_proc = start_router_rust_mm_services
+    # Use a freshly-randomized image so we don't collide with the cache
+    # populated by other tests in this module-scoped fixture.
+    img_a = _make_data_uri((11, 22, 33))
+    img_b = _make_data_uri((222, 111, 200))
+    pa = _build_payload([img_a])
+    pb = _build_payload([img_b])
+
+    # Warm A on the worker.
+    _send(frontend_port, router_proc, pa, "warm_A")
+    # Repeat A: image-A blocks are cached → high overlap.
+    overlap_a_repeat, total_a_repeat, _ = _send(
+        frontend_port, router_proc, pa, "A_repeat"
+    )
+    # First-ever B: the worker has never seen img_b's mm_hash, so its
+    # image blocks must NOT match anything cached. Only the text-prefix
+    # block (no mm_hash mixed in) can possibly overlap.
+    overlap_b_cold, total_b_cold, _ = _send(frontend_port, router_proc, pb, "B_cold")
+
+    assert overlap_a_repeat > overlap_b_cold, (
+        f"expected warm-A repeat overlap ({overlap_a_repeat}/{total_a_repeat}) "
+        f"to exceed cold-B overlap ({overlap_b_cold}/{total_b_cold}). "
+        f"If equal, the mm_hash isn't differentiating images — image-block "
+        f"hashes are colliding across distinct content."
+    )
+    assert overlap_b_cold <= 1, (
+        f"cold first-time image B should overlap at most the text-prefix block; "
+        f"got {overlap_b_cold}/{total_b_cold}. Higher overlap means image "
+        f"blocks aren't actually content-addressed."
+    )
+
+
+def _make_image_handler(image_map: dict[str, bytes]) -> type:
+    """Stdlib HTTP handler that serves the given image bytes by path. Honors
+    `Range: bytes=A-B` requests so we exercise the same code path our
+    `fetch_image_dims` uses (header-only 64KB Range fetch)."""
+
+    class _ImageHandler(BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802
+            # Strip query string — our `hash_normalized_url` drops common
+            # cache-busters (v, t, sig, signature, cache, _, ts) before
+            # hashing, so callers can append signed-URL params and still
+            # hit cache. The test below hits both `/img.png?v=1` and
+            # `/img.png?v=2` — the server should serve the same bytes.
+            path = self.path.split("?", 1)[0]
+            data = image_map.get(path)
+            if data is None:
+                self.send_error(404)
+                return
+            range_hdr = self.headers.get("Range", "")
+            if range_hdr.startswith("bytes="):
+                spec = range_hdr[len("bytes=") :]
+                lo_s, _, hi_s = spec.partition("-")
+                try:
+                    lo = int(lo_s) if lo_s else 0
+                    hi = int(hi_s) if hi_s else len(data) - 1
+                except ValueError:
+                    self.send_error(416)
+                    return
+                hi = min(hi, len(data) - 1)
+                lo = max(lo, 0)
+                if lo > hi:
+                    self.send_error(416)
+                    return
+                chunk = data[lo : hi + 1]
+                self.send_response(206)
+                self.send_header("Content-Type", "image/png")
+                self.send_header("Content-Length", str(len(chunk)))
+                self.send_header("Content-Range", f"bytes {lo}-{hi}/{len(data)}")
+                self.end_headers()
+                self.wfile.write(chunk)
+            else:
+                self.send_response(200)
+                self.send_header("Content-Type", "image/png")
+                self.send_header("Content-Length", str(len(data)))
+                self.end_headers()
+                self.wfile.write(data)
+
+        def log_message(self, format, *args):  # silence access logs
+            pass
+
+    return _ImageHandler
+
+
+@pytest.fixture(scope="module")
+def http_image_server() -> Generator[dict[str, str], None, None]:
+    """Serve a small set of PNGs over HTTP for the duration of the module.
+
+    Yields a dict mapping role names (e.g. "A", "B") to URLs. The Rust
+    frontend's url-passthrough path will Range-fetch each one to read its
+    `(W, H)` header. The server lives on 127.0.0.1 with `DYN_MM_ALLOW_INTERNAL=1`
+    set in the frontend env so the loopback fetch is permitted.
+    """
+    (port,) = allocate_ports(count=1, start_port=18500)
+    palette = {
+        "A": (180, 30, 90),
+        "B": (30, 180, 90),
+    }
+    image_map: dict[str, bytes] = {
+        f"/image_{role}.png": _make_png_bytes(color) for role, color in palette.items()
+    }
+    server = HTTPServer(("127.0.0.1", port), _make_image_handler(image_map))
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield {role: f"http://127.0.0.1:{port}/image_{role}.png" for role in palette}
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+@pytest.mark.timeout(300)
+def test_router_rust_mm_repeated_http_image_overlap(
+    start_router_rust_mm_services, predownload_models, http_image_server
+):
+    """HTTP URL path: same URL twice → MM-aware overlap on the warm
+    request. Exercises our `fetch_image_dims` Range-fetch flow that
+    only runs when `media_decoder` is null (the production vLLM-backed
+    VLM config)."""
+    frontend_port, router_proc = start_router_rust_mm_services
+    payload = _build_payload([http_image_server["A"]])
+
+    overlap_1, total_1, _ = _send(frontend_port, router_proc, payload, "http_req1")
+    overlap_2, total_2, data_2 = _send(frontend_port, router_proc, payload, "http_req2")
+
+    assert total_1 > 1 and total_2 > 1, (
+        f"expected non-trivial total blocks for HTTP MM request, got "
+        f"{total_1}, {total_2}"
+    )
+    assert overlap_2 > overlap_1 + 1, (
+        f"expected warm-request overlap to dominate cold by more than just the "
+        f"text-prefix block, got req1={overlap_1}/{total_1}, "
+        f"req2={overlap_2}/{total_2} — if not, header-fetch + lightseek expansion "
+        f"is misaligned with the worker's KV events"
+    )
+    cached_2 = (data_2.get("usage", {}).get("prompt_tokens_details") or {}).get(
+        "cached_tokens"
+    )
+    prompt_tokens_2 = data_2.get("usage", {}).get("prompt_tokens", 0)
+    assert cached_2 is not None and cached_2 > prompt_tokens_2 // 2, (
+        f"expected high vLLM cached_tokens on warm HTTP request, got "
+        f"cached={cached_2}, prompt_tokens={prompt_tokens_2}"
+    )
+
+
+@pytest.mark.timeout(300)
+def test_router_rust_mm_http_url_cache_buster_normalization(
+    start_router_rust_mm_services, predownload_models, http_image_server
+):
+    """The frontend strips signed-URL cache-busters (`?v=`, `?sig=`, etc.)
+    before hashing, so the same image accessed via different signed URLs
+    must produce the same `mm_hash` and therefore hit the same KV cache.
+    Test: warm with `?v=1`, repeat with `?v=2` — second request must
+    show cache-hit overlap, not be treated as a fresh image."""
+    frontend_port, router_proc = start_router_rust_mm_services
+    base_url = http_image_server["B"]
+    payload_v1 = _build_payload([f"{base_url}?v=1&sig=abc"])
+    payload_v2 = _build_payload([f"{base_url}?v=2&sig=def"])
+
+    overlap_1, total_1, _ = _send(
+        frontend_port, router_proc, payload_v1, "cache_buster_req1"
+    )
+    overlap_2, total_2, data_2 = _send(
+        frontend_port, router_proc, payload_v2, "cache_buster_req2"
+    )
+
+    assert overlap_2 > overlap_1 + 1, (
+        f"expected URL normalization to fold cache-buster query params, so "
+        f"`?v=2&sig=def` should hit the cache built by `?v=1&sig=abc`. Got "
+        f"req1={overlap_1}/{total_1}, req2={overlap_2}/{total_2}. If equal to 1, "
+        f"hash_normalized_url isn't stripping the buster keys."
+    )
+    cached_2 = (data_2.get("usage", {}).get("prompt_tokens_details") or {}).get(
+        "cached_tokens"
+    )
+    assert (
+        cached_2 is not None and cached_2 > 0
+    ), f"expected cached_tokens > 0 after URL-buster normalization, got {cached_2}"
+
+
+@pytest.mark.timeout(300)
+def test_router_rust_mm_logs_lightseek_initialization(
+    start_router_rust_mm_services, predownload_models
+):
+    """Smoke test: frontend must emit the lightseek init + image-token-resolved
+    log lines for the served model. Catches regressions where the model dir
+    isn't reachable from the MDC or the resolver silently misses a tier."""
+    frontend_port, router_proc = start_router_rust_mm_services
+    # Send any request to ensure the frontend has fully initialized.
+    _send(
+        frontend_port,
+        router_proc,
+        _build_payload([_make_data_uri((1, 2, 3))]),
+        "smoke",
+    )
+    log_text = router_proc.read_logs()
+    assert (
+        "MM-aware KV routing enabled (lightseek)" in log_text
+    ), "frontend should emit lightseek init log line on model registration"
+    assert (
+        "resolved image-placeholder token id" in log_text
+    ), "image_token resolver should log which tier produced the hit"

--- a/tests/serve/conftest.py
+++ b/tests/serve/conftest.py
@@ -60,18 +60,43 @@ def image_server(httpserver: HTTPServer):
         - /llm-graphic.png - LLM diagram image for multimodal tests
           (or a minimal PNG if the file is a Git LFS pointer / not pulled)
 
+    The handler honors `Range: bytes=A-B` and returns 206 Partial Content.
+    The MM-routing dim-fetch path (`fetch_image_dims_uncached`) strictly
+    requires 206 on Range probes so it never accidentally downloads a
+    full image into memory; a bare `respond_with_data` would return 200
+    and silently disable MM routing in the test.
+
     Usage:
         def test_multimodal(image_server):
             # Use MULTIMODAL_IMG_URL from this module
             # ... use url in your test payload
     """
+    from werkzeug.wrappers import Request, Response
+
     image_data = get_multimodal_test_image_bytes()
 
-    # Configure server endpoint
-    httpserver.expect_request("/llm-graphic.png").respond_with_data(
-        image_data,
-        content_type="image/png",
-    )
+    def _handler(request: Request) -> Response:
+        range_hdr = request.headers.get("Range", "")
+        if range_hdr.startswith("bytes="):
+            spec = range_hdr[len("bytes=") :]
+            lo_s, _, hi_s = spec.partition("-")
+            try:
+                lo = int(lo_s) if lo_s else 0
+                hi = int(hi_s) if hi_s else len(image_data) - 1
+            except ValueError:
+                return Response(status=416)
+            hi = min(hi, len(image_data) - 1)
+            lo = max(lo, 0)
+            if lo > hi:
+                return Response(status=416)
+            chunk = image_data[lo : hi + 1]
+            resp = Response(chunk, status=206, content_type="image/png")
+            resp.headers["Content-Range"] = f"bytes {lo}-{hi}/{len(image_data)}"
+            resp.headers["Accept-Ranges"] = "bytes"
+            return resp
+        return Response(image_data, status=200, content_type="image/png")
+
+    httpserver.expect_request("/llm-graphic.png").respond_with_handler(_handler)
 
     return httpserver
 

--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -39,6 +39,15 @@ _LLAVA_EXPECTED_COLORS = [
 VLLM_TOPOLOGY_SCRIPTS: dict[str, str] = {
     "agg": "agg_multimodal.sh",
     "agg_video": "agg_multimodal.sh",
+    # Aggregated MM-aware router. Default uses the Rust frontend with the
+    # `lightseek-mm` feature; the `_chat_processor` variant uses the vLLM
+    # Python preprocessor (`--dyn-chat-processor=vllm`) to enable the
+    # DYNAMO_MM_TRANSFER shm/NIXL pre-rendered mm_kwargs delivery channel.
+    "agg_router": "agg_multimodal_router.sh",
+    "agg_router_chat_processor": "agg_multimodal_router_chat_processor.sh",
+    # Frontend-decode reuses the same script as `agg_router`; the topology
+    # config below toggles `--frontend-decoding` on the worker via env.
+    "agg_router_frontend_decode": "agg_multimodal_router.sh",
     "e_pd": "disagg_multimodal_e_pd.sh",
     "epd": "disagg_multimodal_epd.sh",
     "epd_video": "disagg_multimodal_epd.sh",
@@ -89,6 +98,56 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                 profiled_vram_gib=8.2,
                 requested_vllm_kv_cache_bytes=1_719_075_000,
                 tests=[MmCase(payload=make_video_payload(["red", "static", "still"]))],
+            ),
+            # `agg_router` exercises agg_multimodal_router.sh: Rust frontend
+            # with the `lightseek-mm` feature, MM-aware KV routing, multi-worker.
+            # Smoke-level on pre_merge so regressions to the script's plumbing
+            # (worker boot order, ZMQ KV events, MM-routing build) surface in
+            # gating CI before they merge. The fine-grained routing-correctness
+            # assertions live in tests/mm_router/test_router_rust_mm_router_e2e.py.
+            "agg_router": TopologyConfig(
+                marks=[pytest.mark.pre_merge],
+                timeout_s=400,
+                profiled_vram_gib=18.7,
+                requested_vllm_kv_cache_bytes=1_719_075_000,
+                env={"SINGLE_GPU": "true"},
+                tests=[MmCase(payload=make_image_payload(["green"]))],
+            ),
+            # The chat-processor variant of the MM-aware router: same routing
+            # architecture, but the frontend uses --dyn-chat-processor=vllm
+            # (Python preprocessor) instead of the Rust+lightseek path. Kept
+            # on pre_merge alongside the default so both entry points stay
+            # covered by gating CI; the routing assertions are equivalent.
+            # SINGLE_GPU=true packs both workers onto GPU 0 to match the
+            # single-GPU CI environment (the chat-processor script's own
+            # default is false for production multi-GPU usage).
+            "agg_router_chat_processor": TopologyConfig(
+                marks=[pytest.mark.pre_merge],
+                timeout_s=400,
+                profiled_vram_gib=18.7,
+                requested_vllm_kv_cache_bytes=1_719_075_000,
+                env={"SINGLE_GPU": "true"},
+                tests=[MmCase(payload=make_image_payload(["green"]))],
+            ),
+            # Frontend-decode variant: same `agg_multimodal_router.sh` as
+            # `agg_router`, but `VLLM_EXTRA_ARGS=--frontend-decoding` so
+            # the worker registers a `media_decoder` on its model card and
+            # the frontend's MediaLoader runs in-process. mm_hash becomes
+            # content-addressed (xxh3 over decoded RGB), enabling
+            # cross-URL cache reuse. Smoke-level gate so regressions to
+            # the decoded branch in `gather_multi_modal_data` surface in
+            # CI; the content-hash correctness assertion lives in
+            # tests/mm_router/test_router_rust_mm_frontend_decode_e2e.py.
+            "agg_router_frontend_decode": TopologyConfig(
+                marks=[pytest.mark.pre_merge],
+                timeout_s=400,
+                profiled_vram_gib=18.7,
+                requested_vllm_kv_cache_bytes=1_719_075_000,
+                env={
+                    "SINGLE_GPU": "true",
+                    "VLLM_EXTRA_ARGS": "--frontend-decoding",
+                },
+                tests=[MmCase(payload=make_image_payload(["green"]))],
             ),
             "e_pd": TopologyConfig(
                 marks=[pytest.mark.post_merge],

--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -242,7 +242,11 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                 profiled_vram_gib=22.0,
                 requested_vllm_kv_cache_bytes=1_719_075_000,
                 env={"SINGLE_GPU": "true"},
-                tests=[MmCase(payload=make_image_payload(["green"]))],
+                # cached_tokens-asserting payload proves MM-aware routing
+                # engaged (2nd identical request hits the warm worker's KV
+                # cache); a silent regression to text-prefix-only routing
+                # would still return "green" but 0 cached tokens.
+                tests=[MmCase(payload=make_image_payload_cached_tokens(["green"]))],
             ),
         },
         # Phi-3-vision uses --trust-remote-code for its custom processor.
@@ -346,7 +350,9 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                 gpu_marker="gpu_2",
                 profiled_vram_gib=19.2,
                 requested_vllm_kv_cache_bytes=4_318_854_000,
-                tests=[MmCase(payload=make_image_payload(["green"]))],
+                # cached_tokens-asserting payload proves MM-aware routing
+                # engaged for LLaVA-1.5 (placeholder-template `<image>` path).
+                tests=[MmCase(payload=make_image_payload_cached_tokens(["green"]))],
             ),
             "agg": TopologyConfig(
                 # nightly-only: 7B 1-GPU footprint is tight (vram=19.2 GiB).
@@ -451,7 +457,9 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                 gpu_marker="gpu_2",
                 profiled_vram_gib=19.2,
                 requested_vllm_kv_cache_bytes=4_318_854_000,
-                tests=[MmCase(payload=make_image_payload(["green"]))],
+                # cached_tokens-asserting payload proves MM-aware routing
+                # engaged for LLaVA-NeXT (anyres multi-crop processor).
+                tests=[MmCase(payload=make_image_payload_cached_tokens(["green"]))],
             ),
         },
     ),

--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -328,6 +328,18 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
         name="llava-hf/llava-1.5-7b-hf",
         short_name="llava-1.5-7b",
         topologies={
+            # Rust-frontend MM-aware routing for the LLaVA family. Two
+            # workers, one per GPU on the gpu_2 runner (no SINGLE_GPU
+            # packing — 7B × 2 would exceed 24 GiB on a single card). Each
+            # worker peaks ~19 GiB; the 24 GiB L4 tier has headroom.
+            "agg_router": TopologyConfig(
+                marks=[pytest.mark.post_merge],
+                timeout_s=600,
+                gpu_marker="gpu_2",
+                profiled_vram_gib=19.2,
+                requested_vllm_kv_cache_bytes=4_318_854_000,
+                tests=[MmCase(payload=make_image_payload(["green"]))],
+            ),
             "agg": TopologyConfig(
                 # nightly-only: 7B 1-GPU footprint is tight (vram=19.2 GiB).
                 # Exercises a different image (coco bus) + a string-content
@@ -415,6 +427,23 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                         )
                     )
                 ],
+            ),
+        },
+    ),
+    # LLaVA-NeXT covers a separate lightseek processor (LlavaNextProcessor,
+    # anyres multi-crop) vs LLaVA-1.5's plain LlavaProcessor. Same gpu_2
+    # multi-GPU layout as LLaVA-1.5 agg_router above; ~14 GiB / GPU.
+    MultimodalModelProfile(
+        name="llava-hf/llava-v1.6-mistral-7b-hf",
+        short_name="llava-next-mistral-7b",
+        topologies={
+            "agg_router": TopologyConfig(
+                marks=[pytest.mark.post_merge],
+                timeout_s=600,
+                gpu_marker="gpu_2",
+                profiled_vram_gib=19.2,
+                requested_vllm_kv_cache_bytes=4_318_854_000,
+                tests=[MmCase(payload=make_image_payload(["green"]))],
             ),
         },
     ),

--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -10,6 +10,7 @@ from tests.utils.multimodal import (
     make_audio_payload,
     make_image_payload,
     make_image_payload_b64,
+    make_image_payload_cached_tokens,
     make_video_payload,
 )
 from tests.utils.payload_builder import chat_payload, chat_payload_default
@@ -105,13 +106,20 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
             # (worker boot order, ZMQ KV events, MM-routing build) surface in
             # gating CI before they merge. The fine-grained routing-correctness
             # assertions live in tests/mm_router/test_router_rust_mm_router_e2e.py.
+            #
+            # The payload sends two identical MM requests and asserts the
+            # second sees cached_tokens > 0 — proves the warm worker reused
+            # its KV cache, which only happens if the router routed both
+            # requests to the same worker. If routing silently regressed to
+            # text-prefix only, both requests would still succeed but the
+            # second's cached_tokens would be 0 and this case would fail.
             "agg_router": TopologyConfig(
                 marks=[pytest.mark.pre_merge],
                 timeout_s=400,
                 profiled_vram_gib=18.7,
                 requested_vllm_kv_cache_bytes=1_719_075_000,
                 env={"SINGLE_GPU": "true"},
-                tests=[MmCase(payload=make_image_payload(["green"]))],
+                tests=[MmCase(payload=make_image_payload_cached_tokens(["green"]))],
             ),
             # The chat-processor variant of the MM-aware router: same routing
             # architecture, but the frontend uses --dyn-chat-processor=vllm

--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -183,6 +183,63 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
             ),
         },
     ),
+    # Lightseek-supported VLM coverage on `agg_router` (Rust-frontend
+    # MM-aware routing path). Each profile below adds the same smoke test
+    # as Qwen3-VL-2B's agg_router (pre_merge), but on post_merge with the
+    # corresponding family — Qwen2.5-VL, Qwen2-VL, Phi-3-vision — so the
+    # full lightseek model list (FAMILIES in lightseek_mm.rs) is exercised
+    # end-to-end. SINGLE_GPU=true packs both workers onto GPU 0 to match
+    # the gpu_1 single-GPU box. Initial VRAM profiles are estimates; the
+    # first post_merge run will surface real peaks and we'll tighten.
+    MultimodalModelProfile(
+        name="Qwen/Qwen2.5-VL-3B-Instruct",
+        short_name="qwen2.5-vl-3b",
+        topologies={
+            "agg_router": TopologyConfig(
+                marks=[pytest.mark.post_merge],
+                timeout_s=500,
+                profiled_vram_gib=19.0,
+                requested_vllm_kv_cache_bytes=1_719_075_000,
+                env={"SINGLE_GPU": "true"},
+                tests=[MmCase(payload=make_image_payload(["green"]))],
+            ),
+        },
+    ),
+    MultimodalModelProfile(
+        name="Qwen/Qwen2-VL-2B-Instruct",
+        short_name="qwen2-vl-2b",
+        topologies={
+            "agg_router": TopologyConfig(
+                marks=[pytest.mark.post_merge],
+                timeout_s=500,
+                profiled_vram_gib=16.0,
+                requested_vllm_kv_cache_bytes=1_719_075_000,
+                env={"SINGLE_GPU": "true"},
+                tests=[MmCase(payload=make_image_payload(["green"]))],
+            ),
+        },
+    ),
+    MultimodalModelProfile(
+        name="microsoft/Phi-3-vision-128k-instruct",
+        short_name="phi3-vision",
+        topologies={
+            # Phi-3-vision is the largest of the post_merge additions
+            # (~8.6 GB weights × 2 workers + KV ≈ ~21 GiB peak); profile
+            # leaves slim headroom on a 24 GiB box. If first post_merge
+            # run OOMs, drop to one worker (NUM_WORKERS=1) or move to
+            # gpu_2 with one worker per GPU.
+            "agg_router": TopologyConfig(
+                marks=[pytest.mark.post_merge],
+                timeout_s=500,
+                profiled_vram_gib=22.0,
+                requested_vllm_kv_cache_bytes=1_719_075_000,
+                env={"SINGLE_GPU": "true"},
+                tests=[MmCase(payload=make_image_payload(["green"]))],
+            ),
+        },
+        # Phi-3-vision uses --trust-remote-code for its custom processor.
+        extra_vllm_args=["--trust-remote-code"],
+    ),
     MultimodalModelProfile(
         name="Qwen/Qwen3.5-0.8B",
         short_name="qwen3.5-0.8b",

--- a/tests/utils/multimodal.py
+++ b/tests/utils/multimodal.py
@@ -13,7 +13,7 @@ from dynamo.common.utils.paths import WORKSPACE_DIR
 from tests.serve.conftest import MULTIMODAL_IMG_URL, get_multimodal_test_image_bytes
 from tests.utils.engine_process import EngineConfig
 from tests.utils.payload_builder import chat_payload
-from tests.utils.payloads import BasePayload, ChatPayload
+from tests.utils.payloads import BasePayload, CachedTokensChatPayload, ChatPayload
 
 LOCAL_VIDEO_TEST_PATH = Path(
     WORKSPACE_DIR, "lib/llm/tests/data/media/240p_10.mp4"
@@ -59,6 +59,49 @@ def make_image_payload(
         temperature=0.0,
         max_tokens=100,
         max_attempts=max_attempts,
+    )
+
+
+def make_image_payload_cached_tokens(
+    expected_response: list[str],
+    *,
+    repeat_count: int = 2,
+    min_cached_tokens: int = 1,
+) -> CachedTokensChatPayload:
+    """Image payload that also asserts MM-aware KV cache reuse on repeats.
+
+    Same body shape as :func:`make_image_payload`, but wrapped in a
+    :class:`CachedTokensChatPayload` so the 2nd+ request validates that
+    ``usage.prompt_tokens_details.cached_tokens >= min_cached_tokens``.
+    Two identical MM requests through an MM-routing-aware frontend must
+    land on the same warm worker and reuse the prefix cache; if routing
+    silently regresses to text-only the second request will report 0
+    cached tokens and this payload fails.
+
+    Used to harden the ``agg_router`` pre_merge smoke against silent
+    regressions in the Rust+lightseek routing path.
+    """
+    return CachedTokensChatPayload(
+        body={
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": _MULTIMODAL_COLOR_PROMPT},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": MULTIMODAL_IMG_URL},
+                        },
+                    ],
+                }
+            ],
+            "max_tokens": 100,
+            "temperature": 0.0,
+            "stream": False,
+        },
+        repeat_count=repeat_count,
+        expected_response=expected_response,
+        min_cached_tokens=min_cached_tokens,
     )
 
 


### PR DESCRIPTION
#### Overview:

Adds a Rust-frontend MM-aware KV routing path for multimodal workloads, using the new `lightseek-mm` cargo feature for image token expansion.

Closes DIS-1930

#### Details:

**How MM-aware routing works.**

The frontend now extracts a structured `mm_routing_info` from each multimodal request *before* it picks a worker:

```
request {text + N images}
   │
   ▼
for each image:
   ├─ compute mm_hash             ── xxh3_64 over normalized URL (default path)
   │                                 OR over decoded bytes (frontend-decoding path)
   ├─ fetch image dims (W, H)     ── HTTP Range read, cached
   └─ count tokens for (W, H)     ── per-VLM-family math (Qwen3-VL etc.) via llm-multimodal from LightSeek
   │
   ▼
mm_routing_info {
   image_multiset: [(mm_hash, token_count), ...],    # sorted, dedup-aware
   total_image_tokens: sum,
}
   │
   ▼
KV router selects worker
```

**URL-passthrough vs frontend-decoding.**

Two paths share the same routing logic but differ on where image bytes live:

- **URL-passthrough (default).** Request body carries `image_url`. Frontend hashes the *normalized URL string* (cache-buster query params stripped), routes the request, and forwards the raw URL to the chosen worker. Worker fetches and decodes the image. `mm_processor_cache` is keyed on decoded-bytes hash, so re-requests of the same URL hit; cross-URL same-content requests don't.
- **Frontend-decoding (`--frontend-decoding`).** Frontend's `MediaLoader` (LRU-cached) fetches and decodes the image once, ships the decoded RGB tensor to the chosen worker via NIXL/RDMA, and routes by *content hash* (`xxh3_64` over the registered `SystemStorage` bytes — see `RdmaMediaDataDescriptor::content_hash()`). Worker skips both fetch and decode entirely. Same image content reached through different signed URLs collides on the same routing key.

**The dim-cache primitive.**

Image-token counts depend on the dimensions of each image — but the routing decision happens before the worker has decoded anything. So the frontend has to know `(W, H)` for each image at request-dispatch time. To avoid an HTTP Range fetch per image per request, dimensions are cached:

- **Sharded bounded LRU**: `moka::future::Cache<u64, (u32, u32)>` with 100 k-entry capacity and 24 h TTL. Lock-free reads, sharded write locks — handles concurrent dispatch with no contention bottleneck.
- **Atomic singleflight**: `try_get_with` collapses concurrent in-flight fetches for the same `mm_hash` into a single HTTP request — multiple workers can dispatch the same request in parallel without 4 threads racing for the same 4 KB Range read.

The cache is feature-gated and bounded so even unbounded URL pools (e.g. signed-URL refresh, image proxies) don't blow up frontend memory.

**Backend behavior unchanged.**

This PR only touches the Rust frontend's routing decision. vLLM workers are unmodified — they still receive `image_url` (or the decoded RDMA tensor in FD mode) and run their normal preprocessing pipeline. The `mm_processor_cache` keying that was already content-based is what makes the routing decision deliver actual cache hits.

#### Where should the reviewer start?

1. **`lib/llm/src/preprocessor.rs`** (660-line diff) — the routing-decision code path, all under `cfg(feature = "lightseek-mm")`. Key call sites:
   - `fetch_image_dims` — the moka cache + singleflight pattern; this is what avoids per-request HTTP overhead.
   - `mm_routing_info` construction in the URL-passthrough branch and the FD branch; the only difference is the `mm_hash` source (URL string vs `descriptor.content_hash()`).
2. **`lib/llm/src/preprocessor/media/rdma.rs`** — small (~23 lines added) but load-bearing: `content_hash()` is what makes FD-path routing collide across (signed) URL changes.
3. **`lib/llm/src/preprocessor/lightseek_mm.rs`** (new file) — `model_id` → per-VLM-family token-count function dispatch (Qwen3-VL etc.). Thin wrapper over `llm-multimodal`.
4. **`lib/llm/Cargo.toml` + workspace `Cargo.toml`** — confirm the `lightseek-mm` feature flag is wired the way the team prefers, and that `default = ["block-manager", "lightseek-mm"]` (default-on) is acceptable. Flip to `default = ["block-manager"]` for opt-in.
5. **`components/src/dynamo/vllm/handlers.py`** — 11-line FD-path error-yield fix; not part of routing logic but blocked aiperf parsing on FD failures, so it's in this PR.
6. **`docs/features/multimodal/multimodal-kv-routing.md`** — feature description for users.

Upstream PR: https://github.com/lightseekorg/smg/pull/1459 to avoid pulling the openssl/native-tls toolchain.

#### Related Issues:

- Relates to GitHub issue: #xxx

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9272" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added in-process multimodal (image) aware KV-cache routing support enabled by default
  * Added launch examples for multiple router topologies: standard KV router, chat-processor variant, and frontend-decoding variant with configurable worker and frontend replicas

* **Documentation**
  * Updated multimodal KV routing documentation with detailed routing flows, launch commands, and expanded configuration guidance

* **Bug Fixes**
  * Improved error handling for Qwen-VL multimodal image metadata failures

* **Tests**
  * Added end-to-end tests for multimodal routing covering content-hashing, URL normalization, and cache warm/cold behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->