### PR TITLE
docs: add anchor-aware BSI benchmark results

### DIFF
--- a/lib/bench/README.md
+++ b/lib/bench/README.md
@@ -122,4 +122,4 @@ knob while keeping the same internal polynomial model.
 
 ## KV router / sharded indexer benchmarks
 
-See [lib/kv-router/src/indexer/INDEXER_BENCH.md](../kv-router/src/indexer/INDEXER_BENCH.md) for trace acquisition, benchmark commands, and results for the `mooncake_bench` suite (`concurrent-radix-tree-compressed` baseline vs `branch-sharded-crtc`).
+See [kv_router/INDEXER_BENCH.md](kv_router/INDEXER_BENCH.md) for trace acquisition, benchmark commands, and results for the `mooncake_bench` suite (`concurrent-radix-tree-compressed`, `branch-sharded-crtc`, and `anchor-aware-branch-sharded-crtc`).

--- a/lib/bench/README.md
+++ b/lib/bench/README.md
@@ -122,4 +122,7 @@ knob while keeping the same internal polynomial model.
 
 ## KV router / sharded indexer benchmarks
 
-See [kv_router/INDEXER_BENCH.md](kv_router/INDEXER_BENCH.md) for trace acquisition, benchmark commands, and results for the `mooncake_bench` suite (`concurrent-radix-tree-compressed`, `branch-sharded-crtc`, and `anchor-aware-branch-sharded-crtc`).
+See [kv_router/INDEXER_BENCH.md](kv_router/INDEXER_BENCH.md) for trace
+acquisition, benchmark commands, and results for the `mooncake_bench` suite:
+`concurrent-radix-tree-compressed`, `branch-sharded-crtc`, and
+`anchor-aware-branch-sharded-crtc`.

--- a/lib/bench/kv_router/INDEXER_BENCH.md
+++ b/lib/bench/kv_router/INDEXER_BENCH.md
@@ -150,8 +150,10 @@ done
 
 | Field | Meaning |
 |-------|---------|
-| Early-exit % | Queries resolved in ~300 ns with no shard dispatch (unknown branch key) |
-| Avg routing | Routing-table lookup time (branch key → shard index) |
+| Exact dispatch | Queries routed by the deepest requested prefix key |
+| Shallow-fallback % | Queries whose exact requested prefix key missed but a shorter registered prefix routed to a shard that can return the shallow overlap score |
+| Early-exit % | Queries with no registered prefix alias, resolved without shard dispatch |
+| Avg routing | Prefix-key routing-table lookup time (deepest registered prefix → shard index) |
 | Avg shard | CRTC traversal time on the dispatched shard |
 
 ---
@@ -200,29 +202,31 @@ Trace: `conversation_trace.jsonl` (Mooncake FAST25). Config: 2 shards × 4 worke
 
 ### Steady-state — p99 at real-world request rate (~11,860 ops/s offered)
 
-| Indexer | Achieved ops/s | p99 | Early-exit / TRIE-only | Avg routing | Avg shard |
-|---------|---------------|-----|------------------------|-------------|-----------|
+| Indexer | Achieved ops/s | p99 | Routing outcome | Avg routing | Avg shard |
+|---------|---------------|-----|-----------------|-------------|-----------|
 | CRTC baseline (8w) | 11,540 | 5,768 µs | — | — | — |
-| Branch-sharded depth=2 (2×4w) | 11,706 | **1,387 µs** | 85.4% | 433 ns | 521 µs |
-| Branch-sharded depth=4 (2×4w) | 11,775 | **727 µs** | 87.0% | 299 ns | 397 µs |
+| Branch-sharded depth=2 (2×4w) | 11,846 | **769 µs** | 14.6% exact / 85.4% shallow-fallback / 0.0% miss | 498 ns | 161 µs |
+| Branch-sharded depth=4 (2×4w) | 11,818 | **855 µs** | 13.0% exact / 87.0% shallow-fallback / 0.0% miss | 601 ns | 176 µs |
 | Anchor-aware BSI depth=2 (2×4w) | 11,740 | 1,006 µs | 18.5% TRIE-only | 394 µs | 8 µs |
 
-Branch-sharded depth=2 p99 is **4.2× lower** than CRTC; depth=4 is **7.9× lower**. The deeper key resolves more unique branches (1,038 vs 831), raising the early-exit rate slightly and reducing average shard traversal time.
+Branch-sharded depth=2 p99 is **7.5× lower** than CRTC; depth=4 is **6.7× lower**. Both branch-sharded runs effectively keep up with the offered trace rate. Routing remains sub-microsecond, while CRTC traversal on the selected shard dominates request latency.
 
-Anchor-aware BSI sits between CRTC and branch-sharded in p99 on this trace. Avg routing is 394 µs — the routing TRIE traversal is much heavier than old BSI's flat FNV lookup (433 ns). Avg shard is only 8 µs because most blocks are handled by the TRIE and never reach the CRTC. 18.5% of queries resolved entirely within the TRIE (no CRTC dispatch).
+The low true-miss rate is expected for this trace: most queries share a registered shallow prefix and are dispatched through shallow-fallback so the shard can return a shallow overlap score instead of an empty result. That keeps accuracy aligned with the unsharded CRTC baseline while preserving single-shard dispatch. In these runs, shallow-fallback accounts for **85.4%** of depth=2 lookups and **87.0%** of depth=4 lookups.
 
-> **Shard imbalance warning (this trace):** `conversation_trace.jsonl` has highly similar conversation prefixes (shared system prompts). Nearly all traffic fell on one shard — shard 0: 63 blocks (0.0%), shard 1: 2,036,902 blocks (100.0%). This is a known limitation of the static divergent-shard assignment in the routing TRIE when there is a single hot branch. See Known Issues.
+Anchor-aware BSI sits between CRTC and branch-sharded in p99 on this trace. Avg routing is 394 µs because the routing TRIE does more work before dispatch; avg shard time is only 8 µs because many blocks are represented by the routing TRIE and never reach the CRTC. Anchor-aware BSI provides a stronger routing-correctness guarantee for out-of-order events, but its routing overhead is materially higher on this workload.
+
+> **Shard imbalance warning (this trace):** `conversation_trace.jsonl` has highly similar conversation prefixes (shared system prompts). With `prefix_depth` 2 and 4, branch-sharded routing put all stored blocks on one shard for the single-copy trace. This does not prevent the trace-rate latency win above, but it means these numbers do not show the ideal multi-shard scaling case. See Known Issues.
 
 Shard block distribution:
 ```text
-depth=2:  shard 0: 1,061,550 blocks (91.1%), 3,556 workers  shard 1: 104,300 blocks  (8.9%), 3,444 workers
-          branches: shard[0]=415, shard[1]=416  ← balanced branch count, 10:1 block skew
+depth=2:  shard 0: 2,128,077 blocks (100.0%), 7,000 workers  shard 1: 0 blocks (0.0%), 0 workers
+          branches: shard[0]=831, shard[1]=0
 
-depth=4:  shard 0: 1,010,142 blocks (90.7%), 3,367 workers  shard 1: 103,222 blocks  (9.3%), 3,633 workers
-          branches: shard[0]=416, shard[1]=622  ← unbalanced branch count, similar 10:1 block skew
+depth=4:  shard 0: 2,128,077 blocks (100.0%), 7,000 workers  shard 1: 0 blocks (0.0%), 0 workers
+          branches: shard[0]=959, shard[1]=0
 ```
 
-The block skew (~10:1) persists at both depths despite different branch count distributions — confirming this is a lifetime skew problem (some branches inherently accumulate far more blocks), not an artifact of the assignment criterion. See Known Issues below.
+Increasing `prefix_depth` from 2 to 4 does not distribute blocks across shards on this trace, and this steady-state sample shows slightly higher p99 at depth=4. The common prefix is still too dominant for these depths. See Known Issues below.
 
 ### Peak throughput sweep — `conversation_trace.jsonl`
 
@@ -231,9 +235,9 @@ Peak is defined as the highest achieved ops/s before the bench warns it cannot k
 | Indexer | Peak achieved ops/s | p99 at peak | vs CRTC |
 |---------|--------------------:|-------------|---------|
 | CRTC baseline (8w) | 18,046 | 13,362 µs | — |
-| Branch-sharded depth=2 (2×4w) | **122,585** | **583 µs** | **+579%, 23× lower p99** |
+| Branch-sharded depth=2 (2×4w) | **130,096** | **655 µs** | **+621%, 20× lower p99** |
 
-CRTC saturates at ~18k ops/s with p99 exceeding 10,000 µs at all higher offered rates. Branch-sharded sustains 122k+ ops/s with p99 under 600 µs — the 85% early-exit rate means most queries never touch a shard at all, so it scales far better under load.
+CRTC saturates at ~18k ops/s with p99 exceeding 10,000 µs at all higher offered rates. Branch-sharded sustains ~130k ops/s before the first bench warning, with p99 under 700 µs at that point. The gain comes from cheap prefix routing plus one-shard CRTC traversal; it does not depend on early exits.
 
 Full sweep data:
 
@@ -254,14 +258,13 @@ Full sweep data:
 
 | Benchmark window | Offered ops/s | Achieved ops/s | p99 |
 |-----------------|--------------|----------------|-----|
-| 30,000 ms | 11,861 | 11,770 | 885 µs |
-| 18,455 ms | 19,281 | 19,052 | 794 µs |
-| 11,352 ms | 31,345 | 30,561 | 799 µs |
-| 6,983 ms | 50,956 | 49,033 | 746 µs |
-| 4,296 ms | 82,827 | 76,323 | 598 µs |
-| 2,643 ms | 134,629 | 122,585 | 583 µs |
-| 1,626 ms ⚠ | 218,834 | 182,005 | 569 µs |
-| 1,000 ms ⚠ | 355,824 | 255,190 | 573 µs |
+| 18,455 ms | 19,281 | 19,231 | 529 µs |
+| 11,352 ms | 31,345 | 31,250 | 591 µs |
+| 6,983 ms | 50,956 | 50,727 | 511 µs |
+| 4,296 ms | 82,827 | 82,224 | 531 µs |
+| 2,643 ms | 134,629 | 130,096 | 655 µs |
+| 1,626 ms ⚠ | 218,834 | 183,918 | 1,338 µs |
+| 1,000 ms ⚠ | 355,824 | 217,263 | 1,453 µs |
 
 **Anchor-aware BSI depth=2:**
 
@@ -276,7 +279,7 @@ Full sweep data:
 | 1,626 ms ⚠ | 218,834 | 114,587 | 2,042 µs |
 | 1,000 ms ⚠ | 355,824 | 106,663 | 2,427 µs |
 
-Anchor-aware BSI saturates at ~77k ops/s (no warning at 4,296 ms; first warning at 2,643 ms), comparable to branch-sharded. Best p99 is 1,228 µs at moderate load, vs 583 µs for branch-sharded. The TRIE routing overhead sets a floor: avg routing is ~394 µs regardless of throughput. The caveat on this trace (single hot shard) means these numbers do not represent ideal anchor-aware performance — on a trace with more diverse prefixes the shard load would distribute.
+Anchor-aware BSI saturates at ~77k ops/s (no warning at 4,296 ms; first warning at 2,643 ms). Best p99 is 1,228 µs at moderate load, vs 511-655 µs for branch-sharded in the same offered-rate range. The TRIE routing overhead sets a floor: avg routing is ~394 µs regardless of throughput. The caveat on this trace (single hot shard) means these numbers do not represent ideal anchor-aware performance — on a trace with more diverse prefixes the shard load would distribute.
 
 ⚠ = bench warned it could not keep up with the offered rate.
 
@@ -285,32 +288,37 @@ Anchor-aware BSI saturates at ~77k ops/s (no warning at 4,296 ms; first warning 
 Tests how p99 and shard balance change as the number of inference workers grows.
 Config: 2 shards × 4 workers per shard, `--num-unique-inference-workers 1000`, `-d 7` (7 replicas × 1,000 workers = 7,000 concurrent workers), `--benchmark-duration-ms 30000`.
 
-| Duplication factor | Effective workers | Branches | Offered ops/s | Early-exit | Avg routing | Avg shard | p99 | Block split |
-|-------------------|-----------------|----------|--------------|------------|-------------|-----------|-----|-------------|
-| 1× | 7,000 | 831 | 11,860 | 85.4% | 287 ns | 347 µs | 587 µs | 90.8% / 9.2% |
-| 2× | 14,000 | 1,650 | 23,721 | 86.3% | 282 ns | 289 µs | **458 µs** | 48.7% / 51.3% |
-| 4× | 28,000 | 3,330 | 47,443 | 86.4% | 249 ns | 293 µs | **446 µs** | 49.7% / 50.3% |
-| 8× | 56,000 | 6,647 | 94,886 | 86.7% | 302 ns | 381 µs | 623 µs | 57.9% / 42.1% |
-| 16× | 112,000 | 13,296 | 189,772 | 86.8% | 278 ns | 402 µs | 709 µs | 56.2% / 43.8% |
-| 32× | 224,000 | 26,617 | 379,543 | 86.5% | 344 ns | 364 µs | 713 µs | 49.3% / 50.7% |
+| Duplication factor | Effective workers | Branches | Offered ops/s | Achieved ops/s | Early-exit | Avg routing | Avg shard | p99 | Block split |
+|-------------------|------------------:|---------:|--------------:|---------------:|------------|-------------|-----------|-----|-------------|
+| 1× | 7,000 | 831 | 11,860 | 11,846 | 0.0% | 594 ns | 192 µs | 1,301 µs | 100.0% / 0.0% |
+| 2× | 14,000 | 1,650 | 23,721 | 23,670 | 0.0% | 472 ns | 176 µs | 505 µs | 50.0% / 50.0% |
+| 4× | 28,000 | 3,329 | 47,443 | 47,370 | 0.0% | 499 ns | 157 µs | **464 µs** | 50.0% / 50.0% |
+| 8× | 56,000 | 6,646 | 94,886 | 94,749 | 0.0% | 425 ns | 174 µs | 811 µs | 50.0% / 50.0% |
+| 16× | 112,000 | 13,296 | 189,772 | 184,034 | 0.0% | 432 ns | 185 µs | 1,363 µs | 37.5% / 62.5% |
+| 32× ⚠ | 224,000 | 26,617 | 379,543 | 160,396 | 0.0% | 550 ns | 227 µs | 2,121 µs | 50.0% / 50.0% |
 
-**1× is the only problematic case.** The 90.8%/9.2% block split at 7k workers is the lifetime skew issue — a few heavy branches landed on one shard and dominated it. At 2× the shards snap to balanced (48.7%/51.3%) due to the different hashes. and p99 drops to 458 µs.
+**1× is the most skewed case.** The single-copy trace lands entirely on one shard for `prefix_depth=2`, so p99 reflects one-shard CRTC traversal rather than multi-shard load distribution.
 
-**Sweet spot around 4×.** p99 is lowest at 4× (446 µs) where shards are balanced and per-shard tree depth is still moderate. Beyond that, p99 rises as each shard holds more blocks, but plateaus at ~700–750 µs between 16× and 32× even as workers double. This is sub-linear: block count grows 8× from 4× to 32×, but p99 grows only ~60%.
+**2× to 8× show the intended balanced case.** Once duplicated hash spaces introduce more distinct branch keys, block distribution is near 50/50 and p99 stays at or below 811 µs while offered throughput scales from 23.7k to 94.9k ops/s.
 
-**No worker-count or lookup ceiling.** Throughput scales linearly (11,860 → 379,543 ops/s, doubling each factor step) with no saturation up to 224,000 effective workers. There is no cliff. Similarly, avg routing ranges from 249–344 ns across 831 to 26,617 branches — DashMap lookup is not a bottleneck in this range.
+**16× remains usable but starts to show pressure.** It keeps up with the offered rate within a few percent, but p99 rises to 1,363 µs and block distribution skews to 37.5%/62.5%.
 
-**Practical implication:** If minimizing single-query latency matters, 14k–28k workers is the sweet spot for a 2-shard config; if maximizing throughput matters, the indexer keeps scaling.
+**32× is outside the clean measurement range for this command.** The bench warns that it cannot keep up and macOS reports allocation pressure, so the 160k achieved ops/s is not a reliable indexer ceiling. Avg routing is still sub-microsecond at 26,617 branches, which suggests the routing map is not the limiting factor.
+
+**Practical implication:** For this trace and a 2-shard config, the cleanest latency/throughput region is 14k-56k effective workers. Higher worker counts need either a longer benchmark window, more memory headroom, or more shards to separate indexer limits from benchmark-driver pressure.
 
 ---
 
 ## Known Issues
 
-### Lifetime block skew
+### Shared-prefix shard collapse and lifetime block skew
 
-`assign_shard` uses live block count as the primary load metric, so initial placement is good. The skew is a post-assignment problem: branches are placed permanently, and some branches accumulate far more blocks over their lifetime than others (e.g. long multi-turn conversations vs. one-shot queries). Shards diverge over time even though branch counts stay balanced.
+`assign_shard` uses live block count as the primary load metric, so branch placement adapts to observed load. Two skew modes remain:
 
-Observed on `conversation_trace.jsonl`: 415 vs 416 branches (balanced) but 1,061,550 vs 104,300 blocks (10:1). The hot shard's larger tree drives up its p99.
+1. **Shared-prefix collapse:** if many requests share the same first `prefix_depth` blocks, they share the same routing aliases and land on one shard. Observed on the single-copy `conversation_trace.jsonl` run: 831-959 branch aliases and 2,128,077 blocks all landed on shard 0.
+2. **Lifetime skew:** even when branch counts are distributed, branches are placed permanently and some conversations accumulate far more blocks than others. Over time, a few heavy branches can dominate one shard.
+
+The hot shard's larger tree drives up p99.
 
 **Future work — rebalancing:** periodically migrate heavy branches from the overloaded shard to lighter ones. This directly addresses lifetime skew when branches can be moved whole. It does not fully solve shared-prefix collapse (see `prefix_depth` section below), where the routing key itself is too coarse and a structural fix like node-depth routing is needed instead.
 

--- a/lib/bench/kv_router/INDEXER_BENCH.md
+++ b/lib/bench/kv_router/INDEXER_BENCH.md
@@ -14,10 +14,17 @@ Benchmarks use JSONL trace files. Each line is a JSON object with fields:
 
 ### Public traces (Mooncake FAST25)
 
-Three traces from the Mooncake FAST25 paper:
+Use the Mooncake FAST25 arxiv trace as the primary benchmark trace unless you are intentionally testing a secondary workload. This is the trace most likely to match external benchmark discussions:
 
 ```bash
 mkdir -p lib/kv-router/traces
+curl -L https://raw.githubusercontent.com/kvcache-ai/Mooncake/main/FAST25-release/arxiv-trace/mooncake_trace.jsonl \
+  -o lib/kv-router/traces/mooncake_trace.jsonl
+```
+
+Secondary traces:
+
+```bash
 curl -L https://raw.githubusercontent.com/kvcache-ai/Mooncake/main/FAST25-release/traces/conversation_trace.jsonl \
   -o lib/kv-router/traces/conversation_trace.jsonl
 curl -L https://raw.githubusercontent.com/kvcache-ai/Mooncake/main/FAST25-release/traces/synthetic_trace.jsonl \
@@ -28,9 +35,19 @@ curl -L https://raw.githubusercontent.com/kvcache-ai/Mooncake/main/FAST25-releas
 
 | File | Description |
 |------|-------------|
-| `conversation_trace.jsonl` | Conversational workload (diverse prefixes) |
-| `synthetic_trace.jsonl` | Synthetic workload |
-| `toolagent_trace.jsonl` | Agentic/tool-use workload |
+| `mooncake_trace.jsonl` | Primary arxiv workload: 23,608 requests over 1 hour, with two dominant hot prefixes |
+| `conversation_trace.jsonl` | Smaller conversational workload: 12,031 requests, different hash sequences from the arxiv trace |
+| `synthetic_trace.jsonl` | Synthetic workload: 3,993 requests, much smaller and structurally different |
+| `toolagent_trace.jsonl` | Agentic/tool-use workload: same request count and similar distribution to the arxiv trace, but different hash sequences |
+
+Trace shape summary from the current local copies:
+
+| File | Requests | Span | Avg blocks/request | Unique depth-2 prefixes | Top depth-2 prefixes |
+|------|---------:|------|-------------------:|------------------------:|----------------------|
+| `mooncake_trace.jsonl` | 23,608 | 3,600,000 ms | 17.3 | 6,557 | `[46,47]` × 9,203; `[74,75]` × 3,449 |
+| `conversation_trace.jsonl` | 12,031 | 3,536,999 ms | 24.0 | 7,373 | top prefix appears 43 times |
+| `synthetic_trace.jsonl` | 3,993 | 1,022,025 ms | 30.5 | 1,138 | top prefixes appear 24 times |
+| `toolagent_trace.jsonl` | 23,608 | 3,536,999 ms | 17.4 | 6,554 | `[46,47]` × 9,203; `[74,75]` × 3,449 |
 
 ---
 
@@ -62,7 +79,7 @@ cargo test --package dynamo-bench --test mooncake_trace
 **CRTC baseline (8 workers):**
 ```bash
 cargo bench --package dynamo-bench --bench mooncake_bench -- \
-  $(git rev-parse --show-toplevel)/lib/kv-router/traces/conversation_trace.jsonl \
+  $(git rev-parse --show-toplevel)/lib/kv-router/traces/mooncake_trace.jsonl \
   --trace-simulation-duration-ms 10000 --benchmark-duration-ms 30000 -d 7 \
   concurrent-radix-tree-compressed --num-event-workers 8
 ```
@@ -70,7 +87,7 @@ cargo bench --package dynamo-bench --bench mooncake_bench -- \
 **Branch-sharded depth=2 (2 shards × 4 workers):**
 ```bash
 cargo bench --package dynamo-bench --bench mooncake_bench -- \
-  $(git rev-parse --show-toplevel)/lib/kv-router/traces/conversation_trace.jsonl \
+  $(git rev-parse --show-toplevel)/lib/kv-router/traces/mooncake_trace.jsonl \
   --trace-simulation-duration-ms 10000 --benchmark-duration-ms 30000 -d 7 \
   branch-sharded-crtc --num-shards 2 --num-event-workers-per-shard 4 --prefix-depth 2
 ```
@@ -78,7 +95,7 @@ cargo bench --package dynamo-bench --bench mooncake_bench -- \
 **Branch-sharded depth=4 (2 shards × 4 workers):**
 ```bash
 cargo bench --package dynamo-bench --bench mooncake_bench -- \
-  $(git rev-parse --show-toplevel)/lib/kv-router/traces/conversation_trace.jsonl \
+  $(git rev-parse --show-toplevel)/lib/kv-router/traces/mooncake_trace.jsonl \
   --trace-simulation-duration-ms 10000 --benchmark-duration-ms 30000 -d 7 \
   branch-sharded-crtc --num-shards 2 --num-event-workers-per-shard 4 --prefix-depth 4
 ```
@@ -86,7 +103,7 @@ cargo bench --package dynamo-bench --bench mooncake_bench -- \
 **Anchor-aware branch-sharded depth=2 (2 shards × 4 workers):**
 ```bash
 cargo bench --package dynamo-bench --bench mooncake_bench -- \
-  $(git rev-parse --show-toplevel)/lib/kv-router/traces/conversation_trace.jsonl \
+  $(git rev-parse --show-toplevel)/lib/kv-router/traces/mooncake_trace.jsonl \
   --trace-simulation-duration-ms 10000 --benchmark-duration-ms 30000 -d 7 \
   anchor-aware-branch-sharded-crtc --num-shards 2 --num-event-workers-per-shard 4 --prefix-depth 2
 ```
@@ -96,7 +113,7 @@ cargo bench --package dynamo-bench --bench mooncake_bench -- \
 **CRTC baseline — sweep:**
 ```bash
 cargo bench --package dynamo-bench --bench mooncake_bench -- \
-  $(git rev-parse --show-toplevel)/lib/kv-router/traces/conversation_trace.jsonl \
+  $(git rev-parse --show-toplevel)/lib/kv-router/traces/mooncake_trace.jsonl \
   --trace-simulation-duration-ms 10000 -d 7 \
   --sweep --sweep-min-ms 1000 --sweep-max-ms 30000 --sweep-steps 8 \
   concurrent-radix-tree-compressed --num-event-workers 8
@@ -105,7 +122,7 @@ cargo bench --package dynamo-bench --bench mooncake_bench -- \
 **Branch-sharded depth=2 — sweep:**
 ```bash
 cargo bench --package dynamo-bench --bench mooncake_bench -- \
-  $(git rev-parse --show-toplevel)/lib/kv-router/traces/conversation_trace.jsonl \
+  $(git rev-parse --show-toplevel)/lib/kv-router/traces/mooncake_trace.jsonl \
   --trace-simulation-duration-ms 10000 -d 7 \
   --sweep --sweep-min-ms 1000 --sweep-max-ms 30000 --sweep-steps 8 \
   branch-sharded-crtc --num-shards 2 --num-event-workers-per-shard 4 --prefix-depth 2
@@ -114,7 +131,7 @@ cargo bench --package dynamo-bench --bench mooncake_bench -- \
 **Anchor-aware branch-sharded depth=2 — sweep:**
 ```bash
 cargo bench --package dynamo-bench --bench mooncake_bench -- \
-  $(git rev-parse --show-toplevel)/lib/kv-router/traces/conversation_trace.jsonl \
+  $(git rev-parse --show-toplevel)/lib/kv-router/traces/mooncake_trace.jsonl \
   --trace-simulation-duration-ms 10000 -d 7 \
   --sweep --sweep-min-ms 1000 --sweep-max-ms 30000 --sweep-steps 8 \
   anchor-aware-branch-sharded-crtc --num-shards 2 --num-event-workers-per-shard 4 --prefix-depth 2
@@ -125,7 +142,7 @@ cargo bench --package dynamo-bench --bench mooncake_bench -- \
 ```bash
 for factor in 1 2 4 8 16 32; do
   cargo bench --package dynamo-bench --bench mooncake_bench -- \
-    $(git rev-parse --show-toplevel)/lib/kv-router/traces/conversation_trace.jsonl \
+    $(git rev-parse --show-toplevel)/lib/kv-router/traces/mooncake_trace.jsonl \
     --trace-simulation-duration-ms 10000 --benchmark-duration-ms 30000 \
     --num-unique-inference-workers 1000 \
     --trace-duplication-factor $factor \
@@ -133,6 +150,55 @@ for factor in 1 2 4 8 16 32; do
     branch-sharded-crtc --num-shards 2 --num-event-workers-per-shard 4 --prefix-depth 2
 done
 ```
+
+### Repeated overload benchmark
+
+This short-window benchmark intentionally drives offered load into the millions of request/event ops per second. The run is useful for stress-shape comparisons, but warnings are expected and the achieved values should not be interpreted as clean steady-state capacity.
+
+**CRTC baseline (8 workers):**
+```bash
+cargo bench --package dynamo-bench --bench mooncake_bench -- \
+  $(git rev-parse --show-toplevel)/lib/kv-router/traces/mooncake_trace.jsonl \
+  --num-unique-inference-workers 128 \
+  --trace-duplication-factor 20 \
+  --trace-length-factor 4 \
+  --benchmark-duration-ms 750 \
+  --benchmark-runs 20 \
+  concurrent-radix-tree-compressed \
+  --num-event-workers 8
+```
+
+**Branch-sharded depth=2 with the same total event-worker count (2 shards × 4 workers):**
+```bash
+cargo bench --package dynamo-bench --bench mooncake_bench -- \
+  $(git rev-parse --show-toplevel)/lib/kv-router/traces/mooncake_trace.jsonl \
+  --num-unique-inference-workers 128 \
+  --trace-duplication-factor 20 \
+  --trace-length-factor 4 \
+  --benchmark-duration-ms 750 \
+  --benchmark-runs 20 \
+  branch-sharded-crtc \
+  --num-shards 2 \
+  --num-event-workers-per-shard 4 \
+  --prefix-depth 2
+```
+
+**Anchor-aware branch-sharded depth=2 with the same total event-worker count (2 shards × 4 workers):**
+```bash
+cargo bench --package dynamo-bench --bench mooncake_bench -- \
+  $(git rev-parse --show-toplevel)/lib/kv-router/traces/mooncake_trace.jsonl \
+  --num-unique-inference-workers 128 \
+  --trace-duplication-factor 20 \
+  --trace-length-factor 4 \
+  --benchmark-duration-ms 750 \
+  --benchmark-runs 20 \
+  anchor-aware-branch-sharded-crtc \
+  --num-shards 2 \
+  --num-event-workers-per-shard 4 \
+  --prefix-depth 2
+```
+
+For a larger branch-sharded worker pool, use `--num-event-workers-per-shard 8` (16 total event workers with 2 shards).
 
 ---
 
@@ -198,46 +264,49 @@ Note: `anchor-aware-branch-sharded-crtc` does not support approximate pruning. I
 
 ## Results
 
-Trace: `conversation_trace.jsonl` (Mooncake FAST25). Config: 2 shards × 4 workers for branch-sharded, 8 workers for CRTC baseline, `-d 7`.
+Trace: `mooncake_trace.jsonl` (Mooncake FAST25 arxiv trace). Config: 2 shards × 4 workers for branch-sharded, 8 workers for CRTC baseline, `--trace-simulation-duration-ms 10000`, `--benchmark-duration-ms 30000`, `-d 7`.
 
-### Steady-state — p99 at real-world request rate (~11,860 ops/s offered)
+### Steady-state — p99 at trace request rate (~17,268 ops/s offered)
 
 | Indexer | Achieved ops/s | p99 | Routing outcome | Avg routing | Avg shard |
 |---------|---------------|-----|-----------------|-------------|-----------|
-| CRTC baseline (8w) | 11,540 | 5,768 µs | — | — | — |
-| Branch-sharded depth=2 (2×4w) | 11,846 | **769 µs** | 14.6% exact / 85.4% shallow-fallback / 0.0% miss | 498 ns | 161 µs |
-| Branch-sharded depth=4 (2×4w) | 11,818 | **855 µs** | 13.0% exact / 87.0% shallow-fallback / 0.0% miss | 601 ns | 176 µs |
-| Anchor-aware BSI depth=2 (2×4w) | 11,740 | 1,006 µs | 18.5% TRIE-only | 394 µs | 8 µs |
+| CRTC baseline (8w) | 17,201 | 1,093 µs | — | — | — |
+| Branch-sharded depth=2 (2×4w) | 17,182 | **933 µs** | 60.5% exact / 39.5% shallow-fallback / 0.0% miss | 762 ns | 238 µs |
+| Branch-sharded depth=4 (2×4w) | 17,221 | **841 µs** | 59.9% exact / 40.1% shallow-fallback / 0.0% miss | 717 ns | 237 µs |
+| Anchor-aware BSI depth=2 (2×4w) | 17,064 | 1,510 µs | 91.3% dispatched / 8.7% shallow | 388 µs | 161 µs |
 
-Branch-sharded depth=2 p99 is **7.5× lower** than CRTC; depth=4 is **6.7× lower**. Both branch-sharded runs effectively keep up with the offered trace rate. Routing remains sub-microsecond, while CRTC traversal on the selected shard dominates request latency.
+All indexers keep up with the offered trace rate. On this arxiv trace, branch-sharded depth=2 is about **15% lower p99** than CRTC, and depth=4 is about **23% lower p99**. This is a modest latency win, not the large win seen on the smaller `conversation_trace.jsonl` workload; do not compare those results directly.
 
-The low true-miss rate is expected for this trace: most queries share a registered shallow prefix and are dispatched through shallow-fallback so the shard can return a shallow overlap score instead of an empty result. That keeps accuracy aligned with the unsharded CRTC baseline while preserving single-shard dispatch. In these runs, shallow-fallback accounts for **85.4%** of depth=2 lookups and **87.0%** of depth=4 lookups.
+The true-miss rate remains effectively zero. Shallow fallback accounts for about **40%** of branch-sharded lookups, which means those lookups did not find the exact requested prefix alias but did find a shorter registered prefix and could still return the shallow overlap score from one shard. That is the accuracy-preserving behavior this branch is meant to protect.
 
-Anchor-aware BSI sits between CRTC and branch-sharded in p99 on this trace. Avg routing is 394 µs because the routing TRIE does more work before dispatch; avg shard time is only 8 µs because many blocks are represented by the routing TRIE and never reach the CRTC. Anchor-aware BSI provides a stronger routing-correctness guarantee for out-of-order events, but its routing overhead is materially higher on this workload.
+Anchor-aware BSI is slower than both CRTC and branch-sharded in this steady-state run. Its routing TRIE provides a stronger structural routing model, but on this hot-prefix trace the routing work is materially higher and the shard load collapses almost entirely onto one shard.
 
-> **Shard imbalance warning (this trace):** `conversation_trace.jsonl` has highly similar conversation prefixes (shared system prompts). With `prefix_depth` 2 and 4, branch-sharded routing put all stored blocks on one shard for the single-copy trace. This does not prevent the trace-rate latency win above, but it means these numbers do not show the ideal multi-shard scaling case. See Known Issues.
+> **Shard imbalance warning (this trace):** `mooncake_trace.jsonl` contains two dominant depth-2 prefixes: `[46,47]` appears 9,203 times and `[74,75]` appears 3,449 times. Branch-sharded routing therefore remains skewed even though it does not collapse to a single shard. These numbers are useful for correctness and hot-prefix performance, but they do not show ideal multi-shard scaling.
 
 Shard block distribution:
 ```text
-depth=2:  shard 0: 2,128,077 blocks (100.0%), 7,000 workers  shard 1: 0 blocks (0.0%), 0 workers
-          branches: shard[0]=831, shard[1]=0
+branch depth=2:  shard 0: 1,919,603 blocks (87.0%), 7,000 workers  shard 1: 286,468 blocks (13.0%), 7,000 workers
+                 branches: shard[0]=819, shard[1]=3
 
-depth=4:  shard 0: 2,128,077 blocks (100.0%), 7,000 workers  shard 1: 0 blocks (0.0%), 0 workers
-          branches: shard[0]=959, shard[1]=0
+branch depth=4:  shard 0: 1,919,603 blocks (87.0%), 7,000 workers  shard 1: 286,468 blocks (13.0%), 7,000 workers
+                 branches: shard[0]=960, shard[1]=17
+
+anchor-aware:    shard 0: 574 blocks (0.0%), 14 workers  shard 1: 2,094,155 blocks (100.0%), 7,000 workers
 ```
 
-Increasing `prefix_depth` from 2 to 4 does not distribute blocks across shards on this trace, and this steady-state sample shows slightly higher p99 at depth=4. The common prefix is still too dominant for these depths. See Known Issues below.
+Increasing `prefix_depth` from 2 to 4 creates more branch aliases, but the stored block split is unchanged because the hottest branch lifetime still dominates the trace. See Known Issues below.
 
-### Peak throughput sweep — `conversation_trace.jsonl`
+### Peak throughput sweep — `mooncake_trace.jsonl`
 
-Peak is defined as the highest achieved ops/s before the bench warns it cannot keep up with the offered rate.
+Clean peak is defined as the highest achieved ops/s where the benchmark keeps up with the offered block throughput. Rows marked ⚠ were overloaded and should not be treated as clean throughput ceilings. The sweep runs shortest windows first for multithreaded indexers, so use the standalone steady-state run above for trace-rate p99.
 
-| Indexer | Peak achieved ops/s | p99 at peak | vs CRTC |
-|---------|--------------------:|-------------|---------|
-| CRTC baseline (8w) | 18,046 | 13,362 µs | — |
-| Branch-sharded depth=2 (2×4w) | **130,096** | **655 µs** | **+621%, 20× lower p99** |
+| Indexer | Clean peak achieved ops/s | p99 at clean peak | Notes |
+|---------|--------------------------:|-------------------|-------|
+| CRTC baseline (8w) | **118,157** | 1,087 µs | Best clean throughput on this hot-prefix trace |
+| Branch-sharded depth=2 (2×4w) | 73,304 | 1,337 µs | Clean peak is lower than CRTC because traffic is skewed to one shard |
+| Anchor-aware BSI depth=2 (2×4w) | 16,699 | 12,332 µs | Sweep degrades heavily after overload; use steady-state run for normal p99 |
 
-CRTC saturates at ~18k ops/s with p99 exceeding 10,000 µs at all higher offered rates. Branch-sharded sustains ~130k ops/s before the first bench warning, with p99 under 700 µs at that point. The gain comes from cheap prefix routing plus one-shard CRTC traversal; it does not depend on early exits.
+On this arxiv trace, CRTC has the highest clean throughput in the sweep. That is not a contradiction with the steady-state table: branch-sharded still has lower trace-rate p99, but the hot-prefix distribution limits shard parallelism and therefore caps clean peak throughput. This is the main reason the arxiv trace is a better primary benchmark: it exposes the accuracy fix under a less favorable and more realistic hot-prefix workload.
 
 Full sweep data:
 
@@ -245,67 +314,91 @@ Full sweep data:
 
 | Benchmark window | Offered ops/s | Achieved ops/s | p99 |
 |-----------------|--------------|----------------|-----|
-| 30,000 ms | 11,861 | 11,532 | 7,536 µs |
-| 18,455 ms | 19,281 | 18,046 | 13,362 µs |
-| 11,352 ms ⚠ | 31,345 | 25,240 | 11,076 µs |
-| 6,983 ms ⚠ | 50,956 | 30,547 | 10,529 µs |
-| 4,296 ms ⚠ | 82,827 | 25,050 | 11,607 µs |
-| 2,643 ms ⚠ | 134,629 | 23,684 | 10,233 µs |
-| 1,626 ms ⚠ | 218,834 | 27,543 | 11,143 µs |
-| 1,000 ms ⚠ | 355,824 | 25,249 | 12,388 µs |
+| 30,000 ms | 17,268 | 17,219 | 1,027 µs |
+| 18,455 ms | 28,071 | 27,955 | 741 µs |
+| 11,352 ms | 45,635 | 45,309 | 771 µs |
+| 6,983 ms | 74,187 | 73,298 | 683 µs |
+| 4,296 ms | 120,589 | 118,157 | 1,087 µs |
+| 2,643 ms ⚠ | 196,008 | 160,615 | 1,281 µs |
+| 1,626 ms ⚠ | 318,603 | 178,812 | 1,236 µs |
+| 1,000 ms ⚠ | 518,049 | 164,820 | 1,511 µs |
 
 **Branch-sharded depth=2:**
 
 | Benchmark window | Offered ops/s | Achieved ops/s | p99 |
 |-----------------|--------------|----------------|-----|
-| 18,455 ms | 19,281 | 19,231 | 529 µs |
-| 11,352 ms | 31,345 | 31,250 | 591 µs |
-| 6,983 ms | 50,956 | 50,727 | 511 µs |
-| 4,296 ms | 82,827 | 82,224 | 531 µs |
-| 2,643 ms | 134,629 | 130,096 | 655 µs |
-| 1,626 ms ⚠ | 218,834 | 183,918 | 1,338 µs |
-| 1,000 ms ⚠ | 355,824 | 217,263 | 1,453 µs |
+| 30,000 ms ⚠ | 17,268 | 13,732 | 17,772 µs |
+| 18,455 ms | 28,071 | 27,967 | 1,967 µs |
+| 11,352 ms | 45,635 | 45,089 | 814 µs |
+| 6,983 ms | 74,187 | 73,304 | 1,337 µs |
+| 4,296 ms ⚠ | 120,589 | 73,655 | 6,186 µs |
+| 2,643 ms ⚠ | 196,008 | 113,628 | 2,663 µs |
+| 1,626 ms ⚠ | 318,603 | 156,775 | 1,383 µs |
+| 1,000 ms ⚠ | 518,049 | 117,445 | 2,390 µs |
 
 **Anchor-aware BSI depth=2:**
 
 | Benchmark window | Offered ops/s | Achieved ops/s | p99 |
 |-----------------|--------------|----------------|-----|
-| 30,000 ms | 11,861 | 11,797 | 2,069 µs |
-| 18,455 ms | 19,281 | 18,777 | 1,454 µs |
-| 11,352 ms | 31,345 | 30,778 | 1,376 µs |
-| 6,983 ms | 50,956 | 47,684 | **1,228 µs** |
-| 4,296 ms | 82,827 | 77,039 | 1,496 µs |
-| 2,643 ms ⚠ | 134,629 | 114,488 | 1,984 µs |
-| 1,626 ms ⚠ | 218,834 | 114,587 | 2,042 µs |
-| 1,000 ms ⚠ | 355,824 | 106,663 | 2,427 µs |
-
-Anchor-aware BSI saturates at ~77k ops/s (no warning at 4,296 ms; first warning at 2,643 ms). Best p99 is 1,228 µs at moderate load, vs 511-655 µs for branch-sharded in the same offered-rate range. The TRIE routing overhead sets a floor: avg routing is ~394 µs regardless of throughput. The caveat on this trace (single hot shard) means these numbers do not represent ideal anchor-aware performance — on a trace with more diverse prefixes the shard load would distribute.
+| 30,000 ms | 17,268 | 16,699 | 12,332 µs |
+| 18,455 ms ⚠ | 28,071 | 19,965 | 16,423 µs |
+| 11,352 ms ⚠ | 45,635 | 23,088 | 14,922 µs |
+| 6,983 ms ⚠ | 74,187 | 25,232 | 13,322 µs |
+| 4,296 ms ⚠ | 120,589 | 26,185 | 11,384 µs |
+| 2,643 ms ⚠ | 196,008 | 29,912 | 9,832 µs |
+| 1,626 ms ⚠ | 318,603 | 35,720 | 6,970 µs |
+| 1,000 ms ⚠ | 518,049 | 37,076 | 6,743 µs |
 
 ⚠ = bench warned it could not keep up with the offered rate.
 
 ### Worker scaling — branch-sharded depth=2
 
-Tests how p99 and shard balance change as the number of inference workers grows.
-Config: 2 shards × 4 workers per shard, `--num-unique-inference-workers 1000`, `-d 7` (7 replicas × 1,000 workers = 7,000 concurrent workers), `--benchmark-duration-ms 30000`.
+Tests how p99 and shard balance change as trace volume grows. Config: 2 shards × 4 workers per shard, `--num-unique-inference-workers 1000`, `-d 7` (7 replicas × 1,000 workers = 7,000 worker identities), `--benchmark-duration-ms 30000`.
 
-| Duplication factor | Effective workers | Branches | Offered ops/s | Achieved ops/s | Early-exit | Avg routing | Avg shard | p99 | Block split |
-|-------------------|------------------:|---------:|--------------:|---------------:|------------|-------------|-----------|-----|-------------|
-| 1× | 7,000 | 831 | 11,860 | 11,846 | 0.0% | 594 ns | 192 µs | 1,301 µs | 100.0% / 0.0% |
-| 2× | 14,000 | 1,650 | 23,721 | 23,670 | 0.0% | 472 ns | 176 µs | 505 µs | 50.0% / 50.0% |
-| 4× | 28,000 | 3,329 | 47,443 | 47,370 | 0.0% | 499 ns | 157 µs | **464 µs** | 50.0% / 50.0% |
-| 8× | 56,000 | 6,646 | 94,886 | 94,749 | 0.0% | 425 ns | 174 µs | 811 µs | 50.0% / 50.0% |
-| 16× | 112,000 | 13,296 | 189,772 | 184,034 | 0.0% | 432 ns | 185 µs | 1,363 µs | 37.5% / 62.5% |
-| 32× ⚠ | 224,000 | 26,617 | 379,543 | 160,396 | 0.0% | 550 ns | 227 µs | 2,121 µs | 50.0% / 50.0% |
+Note: `--trace-duplication-factor` duplicates request/hash spaces while keeping the worker identity count fixed at 7,000. It increases branch diversity and event volume; it does not multiply the number of worker identities.
 
-**1× is the most skewed case.** The single-copy trace lands entirely on one shard for `prefix_depth=2`, so p99 reflects one-shard CRTC traversal rather than multi-shard load distribution.
+| Trace duplication | Branches | Offered ops/s | Achieved ops/s | Shallow fallback | Avg routing | Avg shard | p99 | Block split |
+|------------------:|---------:|--------------:|---------------:|-----------------|-------------|-----------|-----|-------------|
+| 1× | 822 | 17,268 | 16,942 | 39.5% | 4.3 µs | 419 µs | 9,069 µs | 87.1% / 12.9% |
+| 2× | 1,640 | 34,536 | 33,623 | 39.7% | 4.3 µs | 531 µs | 9,989 µs | 45.5% / 54.5% |
+| 4× ⚠ | 3,306 | 69,073 | 56,049 | 39.3% | 5.2 µs | 488 µs | 8,403 µs | 54.2% / 45.8% |
+| 8× ⚠ | 6,587 | 138,147 | 61,306 | 39.4% | 4.8 µs | 439 µs | 6,563 µs | 29.4% / 70.6% |
+| 16× ⚠ | 13,162 | 276,295 | 106,127 | 39.3% | 2.0 µs | 262 µs | 2,859 µs | 44.3% / 55.7% |
+| 32× ⚠ | 26,328 | 552,590 | 99,795 | 39.2% | 4.9 µs | 263 µs | 2,549 µs | 55.4% / 44.6% |
 
-**2× to 8× show the intended balanced case.** Once duplicated hash spaces introduce more distinct branch keys, block distribution is near 50/50 and p99 stays at or below 811 µs while offered throughput scales from 23.7k to 94.9k ops/s.
+**1× and 2× keep up but p99 is noisy in this long stress sequence.** Use the standalone steady-state runs for normal trace-rate latency comparisons.
 
-**16× remains usable but starts to show pressure.** It keeps up with the offered rate within a few percent, but p99 rises to 1,363 µs and block distribution skews to 37.5%/62.5%.
+**Duplication improves branch diversity.** The block split is much closer to balanced at 2×, 4×, 16×, and 32× than in the single-copy arxiv run. The 8× run still skews because branch lifetimes are uneven even when branch counts grow.
 
-**32× is outside the clean measurement range for this command.** The bench warns that it cannot keep up and macOS reports allocation pressure, so the 160k achieved ops/s is not a reliable indexer ceiling. Avg routing is still sub-microsecond at 26,617 branches, which suggests the routing map is not the limiting factor.
+**4× and higher are overloaded with this 30s window on this machine.** Those rows are useful as stress shape, not as clean throughput limits. The benchmark driver emits warnings once achieved block throughput falls behind offered block throughput.
 
-**Practical implication:** For this trace and a 2-shard config, the cleanest latency/throughput region is 14k-56k effective workers. Higher worker counts need either a longer benchmark window, more memory headroom, or more shards to separate indexer limits from benchmark-driver pressure.
+**Practical implication:** for this arxiv trace and a 2-shard config, branch diversity alone does not guarantee clean scaling. The hot-prefix distribution and lifetime skew still matter, and higher-pressure runs need either more shards, longer benchmark windows, or lower trace volume to separate indexer limits from benchmark-driver pressure.
+
+### Repeated overload benchmark
+
+Config: `--num-unique-inference-workers 128`, `--trace-duplication-factor 20`, `--trace-length-factor 4`, `--benchmark-duration-ms 750`, `--benchmark-runs 20`. These runs generated 2,163,500 events: 1,007,958 `Stored` and 1,155,542 `Removed`. Every run warned that the benchmarker could not keep up, and macOS emitted malloc range-group warnings during event generation. Treat this as saturated stress data, not clean capacity.
+
+| Indexer | Event workers | Offered ops/s | Achieved ops/s p50 | Achieved ops/s p90 | Achieved ops/s p99 | Achieved ops/s mean |
+|---------|--------------:|--------------:|------------------:|------------------:|------------------:|-------------------:|
+| CRTC baseline | 8 | 3,514,213 | 1,897,506 | 2,712,728 | 2,773,248 | 1,897,265 |
+| Branch-sharded depth=2 | 2×4 | 3,514,213 | 423,942 | 451,508 | 457,397 | 411,244 |
+| Anchor-aware BSI depth=2 | 2×4 | 3,514,213 | 594,934 | 664,920 | 703,730 | 593,921 |
+
+| Indexer | Offered block ops/s | Achieved block ops/s p50 | Achieved block ops/s p90 | Achieved block ops/s p99 | Achieved block ops/s mean |
+|---------|--------------------:|------------------------:|------------------------:|------------------------:|-------------------------:|
+| CRTC baseline | 73,600,216 | 39,740,576 | 56,814,248 | 58,081,760 | 39,735,535 |
+| Branch-sharded depth=2 | 73,600,216 | 8,878,863 | 9,456,199 | 9,579,526 | 8,612,927 |
+| Anchor-aware BSI depth=2 | 73,600,216 | 12,460,051 | 13,925,808 | 14,738,639 | 12,438,834 |
+
+| Indexer | p99 latency p50 | p99 latency p90 | p99 latency p99 | p99 latency mean |
+|---------|----------------:|----------------:|----------------:|-----------------:|
+| CRTC baseline | 138 µs | 312 µs | 380 µs | 158 µs |
+| Branch-sharded depth=2 | 137 µs | 161 µs | 198 µs | 137 µs |
+| Anchor-aware BSI depth=2 | 352 µs | 484 µs | 560 µs | 370 µs |
+
+Branch-sharded lookup latency remains comparable to CRTC in this overload run: routing averages roughly 1.2-2.6 µs, shard traversal averages roughly 9-16 µs, and block placement stays reasonably balanced across the two shards. The lower achieved ops/s is therefore not a lookup-latency regression. This command is dominated by event processing, especially `Removed` events; branch-sharded adds routing-table and block-to-shard bookkeeping on that path while CRTC applies events directly.
+
+Anchor-aware BSI lands between CRTC and branch-sharded on achieved ops/s in this overload run, but with higher p99 lookup latency. Routing averages roughly 18-27 µs, shard traversal roughly 12-19 µs, and stored blocks still collapse heavily onto one shard (usually about 93-100% on shard 1), so this is not a balanced-sharding result.
 
 ---
 
@@ -315,7 +408,7 @@ Config: 2 shards × 4 workers per shard, `--num-unique-inference-workers 1000`, 
 
 `assign_shard` uses live block count as the primary load metric, so branch placement adapts to observed load. Two skew modes remain:
 
-1. **Shared-prefix collapse:** if many requests share the same first `prefix_depth` blocks, they share the same routing aliases and land on one shard. Observed on the single-copy `conversation_trace.jsonl` run: 831-959 branch aliases and 2,128,077 blocks all landed on shard 0.
+1. **Shared-prefix collapse:** if many requests share the same first `prefix_depth` blocks, they share the same routing aliases and land on one shard. On `mooncake_trace.jsonl`, the two hottest depth-2 prefixes account for 12,652 of 23,608 requests, and branch-sharded depth=2/depth=4 store 87% of blocks on one shard.
 2. **Lifetime skew:** even when branch counts are distributed, branches are placed permanently and some conversations accumulate far more blocks than others. Over time, a few heavy branches can dominate one shard.
 
 The hot shard's larger tree drives up p99.
@@ -324,12 +417,12 @@ The hot shard's larger tree drives up p99.
 
 ### `prefix_depth` must be tuned per workload
 
-If most requests share a long system prompt, all conversations may hash to the same first `prefix_depth` blocks → single branch key → one shard gets all traffic. Set `prefix_depth` to span the shared prefix plus at least 1–2 unique blocks.
+If most requests share a long prompt prefix, all conversations may hash to the same first `prefix_depth` blocks → single branch key → one shard gets most traffic. Set `prefix_depth` to span the shared prefix plus at least 1–2 unique blocks.
 
 Note: `anchor-aware-branch-sharded-crtc` avoids FNV routing-key collisions (different conversations with the same prefix still get distinct TRIE paths) but has its own hot-branch collapse issue on dominant-prefix workloads (see below). Neither variant is unconditionally better here — tune `prefix_depth` regardless of which you use.
 
 ### Anchor-aware BSI: hot-branch shard collapse
 
-`AnchorAwareBranchShardedIndexer` uses static divergent-shard assignment: the first conversation under a new parent node stays on the parent's shard; only subsequent divergent siblings are hashed to a different shard. On workloads with a dominant shared prefix (e.g. one system prompt used by >99% of conversations), nearly all traffic ends up as the "first child" of the same TRIE node and routes to one shard. Observed on `conversation_trace.jsonl`: 100% of blocks on shard 1.
+`AnchorAwareBranchShardedIndexer` uses static divergent-shard assignment: the first conversation under a new parent node stays on the parent's shard; only subsequent divergent siblings are hashed to a different shard. On workloads with a dominant shared prefix, nearly all traffic can end up as the "first child" of the same TRIE node and route to one shard. Observed on `mooncake_trace.jsonl`: effectively 100% of stored blocks on shard 1 in the steady-state run.
 
 The code has an open TODO for adaptive hot-branch splitting. Until that is resolved, `branch-sharded-crtc` (with sticky routing) is the safer choice for traces with narrow prefix diversity.

--- a/lib/bench/kv_router/INDEXER_BENCH.md
+++ b/lib/bench/kv_router/INDEXER_BENCH.md
@@ -277,7 +277,7 @@ Trace: `mooncake_trace.jsonl` (Mooncake FAST25 arxiv trace). Config: 2 shards ×
 
 All indexers keep up with the offered trace rate. On this arxiv trace, branch-sharded depth=2 is about **15% lower p99** than CRTC, and depth=4 is about **23% lower p99**. This is a modest latency win, not the large win seen on the smaller `conversation_trace.jsonl` workload; do not compare those results directly.
 
-The true-miss rate remains effectively zero. Shallow fallback accounts for about **40%** of branch-sharded lookups, which means those lookups did not find the exact requested prefix alias but did find a shorter registered prefix and could still return the shallow overlap score from one shard. That is the accuracy-preserving behavior this branch is meant to protect.
+The true-miss rate remains effectively zero. Shallow fallback accounts for about **40%** of branch-sharded lookups, which means those lookups did not find the exact requested prefix alias but did find a shorter registered prefix and could still return the shallow overlap score from one shard. That is the accuracy-preserving behavior this benchmark is meant to track.
 
 Anchor-aware BSI is slower than both CRTC and branch-sharded in this steady-state run. Its routing TRIE provides a stronger structural routing model, but on this hot-prefix trace the routing work is materially higher and the shard load collapses almost entirely onto one shard.
 

--- a/lib/bench/kv_router/INDEXER_BENCH.md
+++ b/lib/bench/kv_router/INDEXER_BENCH.md
@@ -216,10 +216,9 @@ For a larger branch-sharded worker pool, use `--num-event-workers-per-shard 8` (
 
 | Field | Meaning |
 |-------|---------|
-| Exact dispatch | Queries routed by the deepest requested prefix key |
-| Shallow-fallback % | Queries whose exact requested prefix key missed but a shorter registered prefix routed to a shard that can return the shallow overlap score |
+| Dispatched | Queries routed to one shard for lookup |
 | Early-exit % | Queries with no registered prefix alias, resolved without shard dispatch |
-| Avg routing | Prefix-key routing-table lookup time (deepest registered prefix → shard index) |
+| Avg routing | Prefix-key routing-table lookup time |
 | Avg shard | CRTC traversal time on the dispatched shard |
 
 ---
@@ -271,13 +270,13 @@ Trace: `mooncake_trace.jsonl` (Mooncake FAST25 arxiv trace). Config: 2 shards ×
 | Indexer | Achieved ops/s | p99 | Routing outcome | Avg routing | Avg shard |
 |---------|---------------|-----|-----------------|-------------|-----------|
 | CRTC baseline (8w) | 17,201 | 1,093 µs | — | — | — |
-| Branch-sharded depth=2 (2×4w) | 17,182 | **933 µs** | 60.5% exact / 39.5% shallow-fallback / 0.0% miss | 762 ns | 238 µs |
-| Branch-sharded depth=4 (2×4w) | 17,221 | **841 µs** | 59.9% exact / 40.1% shallow-fallback / 0.0% miss | 717 ns | 237 µs |
+| Branch-sharded depth=2 (2×4w) | 17,182 | **933 µs** | 0.0% miss | 762 ns | 238 µs |
+| Branch-sharded depth=4 (2×4w) | 17,221 | **841 µs** | 0.0% miss | 717 ns | 237 µs |
 | Anchor-aware BSI depth=2 (2×4w) | 17,064 | 1,510 µs | 91.3% dispatched / 8.7% shallow | 388 µs | 161 µs |
 
 All indexers keep up with the offered trace rate. On this arxiv trace, branch-sharded depth=2 is about **15% lower p99** than CRTC, and depth=4 is about **23% lower p99**. This is a modest latency win, not the large win seen on the smaller `conversation_trace.jsonl` workload; do not compare those results directly.
 
-The true-miss rate remains effectively zero. Shallow fallback accounts for about **40%** of branch-sharded lookups, which means those lookups did not find the exact requested prefix alias but did find a shorter registered prefix and could still return the shallow overlap score from one shard. That is the accuracy-preserving behavior this benchmark is meant to track.
+The true-miss rate remains effectively zero in these runs.
 
 Anchor-aware BSI is slower than both CRTC and branch-sharded in this steady-state run. Its routing TRIE provides a stronger structural routing model, but on this hot-prefix trace the routing work is materially higher and the shard load collapses almost entirely onto one shard.
 
@@ -357,14 +356,14 @@ Tests how p99 and shard balance change as trace volume grows. Config: 2 shards �
 
 Note: `--trace-duplication-factor` duplicates request/hash spaces while keeping the worker identity count fixed at 7,000. It increases branch diversity and event volume; it does not multiply the number of worker identities.
 
-| Trace duplication | Branches | Offered ops/s | Achieved ops/s | Shallow fallback | Avg routing | Avg shard | p99 | Block split |
-|------------------:|---------:|--------------:|---------------:|-----------------|-------------|-----------|-----|-------------|
-| 1× | 822 | 17,268 | 16,942 | 39.5% | 4.3 µs | 419 µs | 9,069 µs | 87.1% / 12.9% |
-| 2× | 1,640 | 34,536 | 33,623 | 39.7% | 4.3 µs | 531 µs | 9,989 µs | 45.5% / 54.5% |
-| 4× ⚠ | 3,306 | 69,073 | 56,049 | 39.3% | 5.2 µs | 488 µs | 8,403 µs | 54.2% / 45.8% |
-| 8× ⚠ | 6,587 | 138,147 | 61,306 | 39.4% | 4.8 µs | 439 µs | 6,563 µs | 29.4% / 70.6% |
-| 16× ⚠ | 13,162 | 276,295 | 106,127 | 39.3% | 2.0 µs | 262 µs | 2,859 µs | 44.3% / 55.7% |
-| 32× ⚠ | 26,328 | 552,590 | 99,795 | 39.2% | 4.9 µs | 263 µs | 2,549 µs | 55.4% / 44.6% |
+| Trace duplication | Branches | Offered ops/s | Achieved ops/s | Avg routing | Avg shard | p99 | Block split |
+|------------------:|---------:|--------------:|---------------:|-------------|-----------|-----|-------------|
+| 1× | 822 | 17,268 | 16,942 | 4.3 µs | 419 µs | 9,069 µs | 87.1% / 12.9% |
+| 2× | 1,640 | 34,536 | 33,623 | 4.3 µs | 531 µs | 9,989 µs | 45.5% / 54.5% |
+| 4× ⚠ | 3,306 | 69,073 | 56,049 | 5.2 µs | 488 µs | 8,403 µs | 54.2% / 45.8% |
+| 8× ⚠ | 6,587 | 138,147 | 61,306 | 4.8 µs | 439 µs | 6,563 µs | 29.4% / 70.6% |
+| 16× ⚠ | 13,162 | 276,295 | 106,127 | 2.0 µs | 262 µs | 2,859 µs | 44.3% / 55.7% |
+| 32× ⚠ | 26,328 | 552,590 | 99,795 | 4.9 µs | 263 µs | 2,549 µs | 55.4% / 44.6% |
 
 **1× and 2× keep up but p99 is noisy in this long stress sequence.** Use the standalone steady-state runs for normal trace-rate latency comparisons.
 
@@ -425,4 +424,4 @@ Note: `anchor-aware-branch-sharded-crtc` avoids FNV routing-key collisions (diff
 
 `AnchorAwareBranchShardedIndexer` uses static divergent-shard assignment: the first conversation under a new parent node stays on the parent's shard; only subsequent divergent siblings are hashed to a different shard. On workloads with a dominant shared prefix, nearly all traffic can end up as the "first child" of the same TRIE node and route to one shard. Observed on `mooncake_trace.jsonl`: effectively 100% of stored blocks on shard 1 in the steady-state run.
 
-The code has an open TODO for adaptive hot-branch splitting. Until that is resolved, `branch-sharded-crtc` (with sticky routing) is the safer choice for traces with narrow prefix diversity.
+The code has an open TODO for adaptive hot-branch splitting. Until that is resolved, compare both branch-sharded variants on traces with narrow prefix diversity before choosing one for production.

--- a/lib/kv-router/README.md
+++ b/lib/kv-router/README.md
@@ -47,5 +47,5 @@ types re-exported from the crate root.
 - Router guide: <https://docs.nvidia.com/dynamo/components/router>
 - Indexer internals:
   <https://github.com/ai-dynamo/dynamo/blob/main/lib/kv-router/src/indexer/README.md>
-- Benchmarking the sharded KV router: [INDEXER_BENCH.md](src/indexer/INDEXER_BENCH.md)
+- Benchmarking the sharded KV indexer: [INDEXER_BENCH.md](../bench/kv_router/INDEXER_BENCH.md)
 - Dynamo repository: <https://github.com/ai-dynamo/dynamo>

--- a/lib/kv-router/src/indexer/INDEXER_BENCH.md
+++ b/lib/kv-router/src/indexer/INDEXER_BENCH.md
@@ -83,6 +83,14 @@ cargo bench --package dynamo-bench --bench mooncake_bench -- \
   branch-sharded-crtc --num-shards 2 --num-event-workers-per-shard 4 --prefix-depth 4
 ```
 
+**Anchor-aware branch-sharded depth=2 (2 shards × 4 workers):**
+```bash
+cargo bench --package dynamo-bench --bench mooncake_bench -- \
+  $(git rev-parse --show-toplevel)/lib/kv-router/traces/conversation_trace.jsonl \
+  --trace-simulation-duration-ms 10000 --benchmark-duration-ms 30000 -d 7 \
+  anchor-aware-branch-sharded-crtc --num-shards 2 --num-event-workers-per-shard 4 --prefix-depth 2
+```
+
 ### Peak throughput sweep
 
 **CRTC baseline — sweep:**
@@ -101,6 +109,15 @@ cargo bench --package dynamo-bench --bench mooncake_bench -- \
   --trace-simulation-duration-ms 10000 -d 7 \
   --sweep --sweep-min-ms 1000 --sweep-max-ms 30000 --sweep-steps 8 \
   branch-sharded-crtc --num-shards 2 --num-event-workers-per-shard 4 --prefix-depth 2
+```
+
+**Anchor-aware branch-sharded depth=2 — sweep:**
+```bash
+cargo bench --package dynamo-bench --bench mooncake_bench -- \
+  $(git rev-parse --show-toplevel)/lib/kv-router/traces/conversation_trace.jsonl \
+  --trace-simulation-duration-ms 10000 -d 7 \
+  --sweep --sweep-min-ms 1000 --sweep-max-ms 30000 --sweep-steps 8 \
+  anchor-aware-branch-sharded-crtc --num-shards 2 --num-event-workers-per-shard 4 --prefix-depth 2
 ```
 
 ### Worker scaling
@@ -165,6 +182,16 @@ done
 | `--num-event-workers-per-shard` | 4 | OS threads per shard for KV event processing |
 | `--prefix-depth` | 2 | Blocks hashed to compute the branch routing key |
 
+### `anchor-aware-branch-sharded-crtc` flags
+
+| Flag | Default | What it does |
+|------|---------|-------------|
+| `--num-shards` | 2 | Number of independent CRTC shards |
+| `--num-event-workers-per-shard` | 4 | OS threads per shard for KV event processing |
+| `--prefix-depth` | 2 | Maximum routing-trie depth before dispatching to one shard |
+
+Note: `anchor-aware-branch-sharded-crtc` does not support approximate pruning. It provides a stronger routing-correctness guarantee for out-of-order events, at the cost of higher routing latency and a hot-branch shard collapse risk on dominant-prefix workloads (see Known Issues).
+
 ---
 
 ## Results
@@ -173,13 +200,18 @@ Trace: `conversation_trace.jsonl` (Mooncake FAST25). Config: 2 shards × 4 worke
 
 ### Steady-state — p99 at real-world request rate (~11,860 ops/s offered)
 
-| Indexer | Achieved ops/s | p99 | Early-exit | Avg routing | Avg shard |
-|---------|---------------|-----|------------|-------------|-----------|
+| Indexer | Achieved ops/s | p99 | Early-exit / TRIE-only | Avg routing | Avg shard |
+|---------|---------------|-----|------------------------|-------------|-----------|
 | CRTC baseline (8w) | 11,540 | 5,768 µs | — | — | — |
 | Branch-sharded depth=2 (2×4w) | 11,706 | **1,387 µs** | 85.4% | 433 ns | 521 µs |
 | Branch-sharded depth=4 (2×4w) | 11,775 | **727 µs** | 87.0% | 299 ns | 397 µs |
+| Anchor-aware BSI depth=2 (2×4w) | 11,740 | 1,006 µs | 18.5% TRIE-only | 394 µs | 8 µs |
 
 Branch-sharded depth=2 p99 is **4.2× lower** than CRTC; depth=4 is **7.9× lower**. The deeper key resolves more unique branches (1,038 vs 831), raising the early-exit rate slightly and reducing average shard traversal time.
+
+Anchor-aware BSI sits between CRTC and branch-sharded in p99 on this trace. Avg routing is 394 µs — the routing TRIE traversal is much heavier than old BSI's flat FNV lookup (433 ns). Avg shard is only 8 µs because most blocks are handled by the TRIE and never reach the CRTC. 18.5% of queries resolved entirely within the TRIE (no CRTC dispatch).
+
+> **Shard imbalance warning (this trace):** `conversation_trace.jsonl` has highly similar conversation prefixes (shared system prompts). Nearly all traffic fell on one shard — shard 0: 63 blocks (0.0%), shard 1: 2,036,902 blocks (100.0%). This is a known limitation of the static divergent-shard assignment in the routing TRIE when there is a single hot branch. See Known Issues.
 
 Shard block distribution:
 ```text
@@ -231,6 +263,21 @@ Full sweep data:
 | 1,626 ms ⚠ | 218,834 | 182,005 | 569 µs |
 | 1,000 ms ⚠ | 355,824 | 255,190 | 573 µs |
 
+**Anchor-aware BSI depth=2:**
+
+| Benchmark window | Offered ops/s | Achieved ops/s | p99 |
+|-----------------|--------------|----------------|-----|
+| 30,000 ms | 11,861 | 11,797 | 2,069 µs |
+| 18,455 ms | 19,281 | 18,777 | 1,454 µs |
+| 11,352 ms | 31,345 | 30,778 | 1,376 µs |
+| 6,983 ms | 50,956 | 47,684 | **1,228 µs** |
+| 4,296 ms | 82,827 | 77,039 | 1,496 µs |
+| 2,643 ms ⚠ | 134,629 | 114,488 | 1,984 µs |
+| 1,626 ms ⚠ | 218,834 | 114,587 | 2,042 µs |
+| 1,000 ms ⚠ | 355,824 | 106,663 | 2,427 µs |
+
+Anchor-aware BSI saturates at ~77k ops/s (no warning at 4,296 ms; first warning at 2,643 ms), comparable to branch-sharded. Best p99 is 1,228 µs at moderate load, vs 583 µs for branch-sharded. The TRIE routing overhead sets a floor: avg routing is ~394 µs regardless of throughput. The caveat on this trace (single hot shard) means these numbers do not represent ideal anchor-aware performance — on a trace with more diverse prefixes the shard load would distribute.
+
 ⚠ = bench warned it could not keep up with the offered rate.
 
 ### Worker scaling — branch-sharded depth=2
@@ -270,3 +317,11 @@ Observed on `conversation_trace.jsonl`: 415 vs 416 branches (balanced) but 1,061
 ### `prefix_depth` must be tuned per workload
 
 If most requests share a long system prompt, all conversations may hash to the same first `prefix_depth` blocks → single branch key → one shard gets all traffic. Set `prefix_depth` to span the shared prefix plus at least 1–2 unique blocks.
+
+Note: `anchor-aware-branch-sharded-crtc` avoids FNV routing-key collisions (different conversations with the same prefix still get distinct TRIE paths) but has its own hot-branch collapse issue on dominant-prefix workloads (see below). Neither variant is unconditionally better here — tune `prefix_depth` regardless of which you use.
+
+### Anchor-aware BSI: hot-branch shard collapse
+
+`AnchorAwareBranchShardedIndexer` uses static divergent-shard assignment: the first conversation under a new parent node stays on the parent's shard; only subsequent divergent siblings are hashed to a different shard. On workloads with a dominant shared prefix (e.g. one system prompt used by >99% of conversations), nearly all traffic ends up as the "first child" of the same TRIE node and routes to one shard. Observed on `conversation_trace.jsonl`: 100% of blocks on shard 1.
+
+The code has an open TODO for adaptive hot-branch splitting. Until that is resolved, `branch-sharded-crtc` (with sticky routing) is the safer choice for traces with narrow prefix diversity.

--- a/lib/kv-router/src/indexer/README.md
+++ b/lib/kv-router/src/indexer/README.md
@@ -342,3 +342,69 @@ let workers_at_64 = index.get(&(64, local_hashes[64]));  // O(1) lookup
 let workers_at_128 = index.get(&(128, local_hashes[128]));  // O(1) lookup
 // Skip positions 1-63, 65-127 entirely!
 ```
+
+---
+
+## Indexer Selection Guide
+
+There are five production indexer variants. This section maps deployment scenarios to the right choice.
+
+### Variant Summary
+
+| Variant | Struct | Concurrency | Routing | When to use |
+|---------|--------|-------------|---------|-------------|
+| `RadixTree` | `RadixTree` | Single-threaded | N/A (local) | Worker-side `LocalKvIndexer`, unit tests |
+| `ConcurrentRadixTree` (CRT) | `ConcurrentRadixTree` | Thread-safe reads | N/A (local) | Single-node, moderate traffic |
+| `ThreadPoolIndexer<CRT>` (CRTC) | `ThreadPoolIndexer<ConcurrentRadixTree>` | N write threads + inline reads | Full-mesh, all workers | Default for most deployments |
+| `BranchShardedIndexer<CRTC>` (BSI) | `BranchShardedIndexer<ThreadPoolIndexer<CRT>>` | Sharded write pools | FNV prefix hash | High worker counts, approximate pruning needed |
+| `AnchorAwareBranchShardedIndexer<CRTC>` | `AnchorAwareBranchShardedIndexer<ThreadPoolIndexer<CRT>>` | Sharded write pools | Prefix-TRIE routing | High worker counts, correctness-first (no approximate pruning) |
+
+### When to use each
+
+**`RadixTree` (non-concurrent)**
+- Never use on the router/scheduler side.
+- Correct choice inside `LocalKvIndexer` — worker-side, single-tokio-task access, no lock needed.
+- Also useful in unit tests where you want a simple, deterministic index.
+
+**`ConcurrentRadixTree` alone (not inside a ThreadPoolIndexer)**
+- Only if you have a single dedicated writer with many concurrent readers and prefer simpler code over maximum throughput.
+- In practice, `ThreadPoolIndexer<CRT>` dominates: it gives you both safe concurrent writes *and* higher throughput.
+
+**`ThreadPoolIndexer<ConcurrentRadixTree>` (CRTC)**
+- The default. Start here.
+- One global index, all workers. Read path (`find_matches`) is always O(depth × workers).
+- Works well up to ~1 000 workers. Above that, `find_matches` p99 climbs because every query scans all workers.
+- Does not shard; a single hot branch can become a write bottleneck at extreme scale.
+
+**`BranchShardedIndexer<CRTC>` (BSI)**
+- Routes each conversation to one shard via a fixed-depth FNV prefix hash. Read path only scans one shard.
+- Enables *approximate pruning*: a shard can evict its least-recently-used entries independently without coordinating with others.
+- Use when: worker count > ~1 000, you need per-shard approximate pruning, and you accept a small risk of shard crossing for very short conversations (< `prefix_depth` blocks in the root segment).
+- **Shard-crossing**: short chains (root shorter than `prefix_depth` blocks) use *sticky routing* — continuations inherit the root's shard from `block_to_fnv_state`, so the full chain always lands on one shard.
+- Not the right choice if you need a guarantee that every conversation stays on one shard even under out-of-order events (use anchor-aware BSI for that).
+
+**`AnchorAwareBranchShardedIndexer<CRTC>` (anchor-aware BSI)**
+- Uses a routing TRIE instead of a flat hash map. Before dispatching a continuation, it pre-installs *anchor* nodes on the target shard so the CRTC already has the parent chain at lookup time.
+- Architecturally prevents shard crossing: the routing decision is made before the event is dispatched, not after.
+- Trade-off: does **not** support approximate pruning (anchor nodes are shared state; pruning one shard would corrupt the TRIE).
+- Use when: correctness of routing is the top priority and you can live without approximate pruning.
+
+### Quick decision tree
+
+```
+Start
+  │
+  ├─ Single worker or worker-side local index?
+  │      └─ RadixTree
+  │
+  ├─ < ~1 000 workers, no sharding needed?
+  │      └─ CRTC (ThreadPoolIndexer<ConcurrentRadixTree>)
+  │
+  └─ ≥ ~1 000 workers (or want per-shard pruning)?
+         │
+         ├─ Need approximate pruning / full BSI feature set?
+         │      └─ BranchShardedIndexer<CRTC>  (sticky routing)
+         │
+         └─ Need routing-correctness guarantee, no pruning needed?
+                └─ AnchorAwareBranchShardedIndexer<CRTC>
+```

--- a/lib/kv-router/src/indexer/README.md
+++ b/lib/kv-router/src/indexer/README.md
@@ -391,7 +391,7 @@ There are five production indexer variants. This section maps deployment scenari
 
 ### Quick decision tree
 
-```
+```text
 Start
   │
   ├─ Single worker or worker-side local index?

--- a/lib/kv-router/src/indexer/README.md
+++ b/lib/kv-router/src/indexer/README.md
@@ -377,10 +377,10 @@ There are five production indexer variants. This section maps deployment scenari
 - Does not shard; a single hot branch can become a write bottleneck at extreme scale.
 
 **`BranchShardedIndexer<CRTC>` (BSI)**
-- Routes each conversation to one shard via a fixed-depth FNV prefix hash. Read path normally scans one shard, using the deepest registered prefix alias when a query diverges before `prefix_depth`.
+- Routes each conversation to one shard via a fixed-depth FNV prefix hash. Read path scans one shard for the routed prefix key.
 - Enables *approximate pruning*: a shard can evict its least-recently-used entries independently without coordinating with others.
-- Use when: worker count > ~1 000, you need per-shard approximate pruning, and you can tolerate the residual shard-crossing risk from out-of-order events (rare in practice).
-- **Shard-crossing**: short chains (root shorter than `prefix_depth` blocks) use *sticky routing* in `branch_sharded.rs`: continuations inherit the root `shard_idx` from `block_to_fnv_state`, and root batches register prefix aliases up to `prefix_depth`, so short-root continuations do not cross shards. The remaining caveat is out-of-order delivery where a continuation arrives before its parent is known.
+- Use when: worker count > ~1 000, you need per-shard approximate pruning, and you can tolerate the flat-map router's shallow-chain and out-of-order limitations.
+- **Shard-crossing**: `branch_sharded.rs` stores `block_to_fnv_state` for shallow roots and registers prefix aliases for short queries, but the flat map does not provide the stronger anchor/replay model needed to guarantee every shallow continuation stays with its parent shard. Out-of-order delivery remains a caveat when a continuation arrives before its parent is known.
 - Not the right choice if you need a guarantee that every conversation stays on one shard even under out-of-order events (use anchor-aware BSI for that).
 
 **`AnchorAwareBranchShardedIndexer<CRTC>` (anchor-aware BSI)**
@@ -403,7 +403,7 @@ Start
   └─ ≥ ~1 000 workers (or want per-shard pruning)?
          │
          ├─ Need approximate pruning / full BSI feature set?
-         │      └─ BranchShardedIndexer<CRTC>  (sticky routing)
+         │      └─ BranchShardedIndexer<CRTC>  (flat-map routing)
          │
          └─ Need routing-correctness guarantee, no pruning needed?
                 └─ AnchorAwareBranchShardedIndexer<CRTC>

--- a/lib/kv-router/src/indexer/README.md
+++ b/lib/kv-router/src/indexer/README.md
@@ -377,10 +377,10 @@ There are five production indexer variants. This section maps deployment scenari
 - Does not shard; a single hot branch can become a write bottleneck at extreme scale.
 
 **`BranchShardedIndexer<CRTC>` (BSI)**
-- Routes each conversation to one shard via a fixed-depth FNV prefix hash. Read path only scans one shard.
+- Routes each conversation to one shard via a fixed-depth FNV prefix hash. Read path normally scans one shard, using the deepest registered prefix alias when a query diverges before `prefix_depth`.
 - Enables *approximate pruning*: a shard can evict its least-recently-used entries independently without coordinating with others.
-- Use when: worker count > ~1 000, you need per-shard approximate pruning, and you accept a small risk of shard crossing for very short conversations (< `prefix_depth` blocks in the root segment).
-- **Shard-crossing**: short chains (root shorter than `prefix_depth` blocks) use *sticky routing* — continuations inherit the root's shard from `block_to_fnv_state`, so the full chain always lands on one shard.
+- Use when: worker count > ~1 000, you need per-shard approximate pruning, and you can tolerate the residual shard-crossing risk from out-of-order events (rare in practice).
+- **Shard-crossing**: short chains (root shorter than `prefix_depth` blocks) use *sticky routing* in `branch_sharded.rs`: continuations inherit the root `shard_idx` from `block_to_fnv_state`, and root batches register prefix aliases up to `prefix_depth`, so short-root continuations do not cross shards. The remaining caveat is out-of-order delivery where a continuation arrives before its parent is known.
 - Not the right choice if you need a guarantee that every conversation stays on one shard even under out-of-order events (use anchor-aware BSI for that).
 
 **`AnchorAwareBranchShardedIndexer<CRTC>` (anchor-aware BSI)**


### PR DESCRIPTION
#### Overview

Updates the KV router indexer benchmark docs with anchor-aware BSI benchmark coverage and moves the benchmark notes under `lib/bench/kv_router`, where the `mooncake_bench` benchmark sources live.

#### Details

- Moves `INDEXER_BENCH.md` to `lib/bench/kv_router/INDEXER_BENCH.md` and updates README links.
- Documents the Mooncake FAST25 arxiv trace as the primary benchmark trace.
- Adds anchor-aware BSI benchmark commands and results for steady-state, sweep, and repeated overload runs.
- Captures the observed AABSI tradeoffs: stronger routing structure, higher routing cost, and hot-branch collapse on dominant-prefix workloads.
- Leaves routing/indexer behavior unchanged in this MR.

### Validation

- `git diff --check`
- Benchmarks documented in `lib/bench/kv_router/INDEXER_BENCH.md` were run manually.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #9087 

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9275" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized benchmark documentation to a dedicated location with enhanced structure and accessibility.
  * Added comprehensive benchmarking guide including trace schemas, benchmark modes, command templates, performance results, and known issues for indexer configurations.
  * Added indexer selection guide to help users choose the appropriate indexer variant based on deployment requirements and worker count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->