### PR TITLE
test(sglang): re-profile disagg_same_gpu, drop memory-saver (cu13 still skipped pending #9283)

### DIFF
--- a/examples/backends/sglang/launch/disagg_same_gpu.sh
+++ b/examples/backends/sglang/launch/disagg_same_gpu.sh
@@ -64,7 +64,6 @@ python3 -m dynamo.sglang \
   --context-length "$CONTEXT_LENGTH" \
   --chunked-prefill-size "$CONTEXT_LENGTH" \
   --max-prefill-tokens "$CONTEXT_LENGTH" \
-  --enable-memory-saver \
   --delete-ckpt-after-loading \
   --max-running-requests "$MAX_RUNNING_REQUESTS" \
   --enable-metrics &
@@ -93,7 +92,6 @@ python3 -m dynamo.sglang \
   --context-length "$CONTEXT_LENGTH" \
   --chunked-prefill-size "$CONTEXT_LENGTH" \
   --max-prefill-tokens "$CONTEXT_LENGTH" \
-  --enable-memory-saver \
   --delete-ckpt-after-loading \
   --max-running-requests "$MAX_RUNNING_REQUESTS" \
   --enable-metrics &

--- a/tests/README.md
+++ b/tests/README.md
@@ -188,7 +188,7 @@ Markers differ by engine:
 
 **SGLang** uses token-based control:
 - **`profiled_vram_gib(N)`** — actual peak from nvidia-smi at the recommended token count. Used for `--max-vram-gib` filtering and scheduler budget.
-- **`requested_sglang_kv_tokens(N)`** — max KV cache tokens. Sets `_PROFILE_OVERRIDE_SGLANG_MAX_TOTAL_TOKENS` → `--max-total-tokens`. SGLang's default `--mem-fraction-static` is never overridden; the token cap is the sole allocation control. Deterministic and parallel-safe (see `examples/common/gpu_utils.md`).
+- **`requested_sglang_kv_tokens(N)`** — max KV cache tokens. Sets `_PROFILE_OVERRIDE_SGLANG_MAX_TOTAL_TOKENS` → `--max-total-tokens N --mem-fraction-static 0.9`. The token cap controls actual KV allocation; `--mem-fraction-static 0.9` is also emitted to keep SGLang's pool-creation gate open on small GPUs (see PR #9238). Deterministic and parallel-safe (see `examples/common/gpu_utils.md`).
 
 **TRT-LLM** uses token-based control (text models) or byte-based control (diffusion models):
 - **`profiled_vram_gib(N)`** — actual peak from nvidia-smi. Used for `--max-vram-gib` filtering and scheduler budget.
@@ -634,7 +634,7 @@ The profiler automatically detects the engine type and uses the appropriate bina
 
 **Requirement (vLLM):** The launch script must honor `_PROFILE_OVERRIDE_VLLM_KV_CACHE_BYTES`. This is handled by `build_vllm_gpu_mem_args` in `gpu_utils.sh` (returns `--kv-cache-memory-bytes N`).
 
-**Requirement (SGLang):** The launch script must honor `_PROFILE_OVERRIDE_SGLANG_MAX_TOTAL_TOKENS`. This is handled by `build_sglang_gpu_mem_args` in `gpu_utils.sh` (returns `--max-total-tokens N`).
+**Requirement (SGLang):** The launch script must honor `_PROFILE_OVERRIDE_SGLANG_MAX_TOTAL_TOKENS`. This is handled by `build_sglang_gpu_mem_args` in `gpu_utils.sh` (returns `--max-total-tokens N --mem-fraction-static 0.9`).
 
 **Requirement (TRT-LLM):** The launch script must honor `_PROFILE_OVERRIDE_TRTLLM_MAX_TOTAL_TOKENS` (and optionally `_PROFILE_OVERRIDE_TRTLLM_MAX_GPU_TOTAL_BYTES`). This is handled by `build_trtllm_override_args_with_mem` in `gpu_utils.sh` (returns JSON for `--override-engine-args`). Note: this is a separate function from `build_vllm_gpu_mem_args` / `build_sglang_gpu_mem_args` because TRT-LLM requires JSON merging.
 

--- a/tests/serve/test_sglang.py
+++ b/tests/serve/test_sglang.py
@@ -40,11 +40,6 @@ from tests.utils.payloads import (
 logger = logging.getLogger(__name__)
 
 
-def _is_cuda13() -> bool:
-    v = os.environ.get("CUDA_VERSION", "")
-    return v.startswith("13")
-
-
 @dataclass
 class SGLangConfig(EngineConfig):
     """Configuration for SGLang test scenarios"""
@@ -149,18 +144,16 @@ sglang_configs = {
         script_name="disagg_same_gpu.sh",
         marks=[
             pytest.mark.gpu_1,
-            pytest.mark.profiled_vram_gib(9.9),  # actual profiled peak with kv-tokens
+            pytest.mark.profiled_vram_gib(
+                5.5
+            ),  # actual profiled peak (re-profiled 2026-05-07 after dropping --enable-memory-saver)
             pytest.mark.requested_sglang_kv_tokens(
-                37472
-            ),  # KV cache cap (2x safety over min=18736)
+                1184
+            ),  # KV cache cap (2x safety over min=592)
             # Local repro took ~289s wall time with worker readiness reaching
             # "ready" at ~176s on a warm-cache RTX 6000 Ada.
             pytest.mark.timeout(420),
             pytest.mark.pre_merge,
-            pytest.mark.skipif(
-                _is_cuda13(),
-                reason="torch-memory-saver preload .so links libcudart.so.12, missing in cuda13 images",
-            ),
         ],
         model="Qwen/Qwen3-0.6B",
         delayed_start=10,
@@ -234,7 +227,8 @@ sglang_configs = {
         ],
     ),
     # NOTE: Pack all workers on 1 GPU for lower CI resource requirements.
-    # KV size is set by requested_sglang_kv_tokens; no fraction overrides.
+    # KV size is set by requested_sglang_kv_tokens; build_sglang_gpu_mem_args
+    # also emits --mem-fraction-static 0.9 (see PR #9238).
     "multimodal_e_pd_qwen": SGLangConfig(
         # E/P/D architecture: Encode, Prefill, Decode workers all on GPU 0
         name="multimodal_e_pd_qwen",


### PR DESCRIPTION
#### Overview:

Follow-up to #9238: drop `--enable-memory-saver` from `disagg_same_gpu.sh` so the test no longer carries the torch-memory-saver dependency, re-profile the now-leaner workload, and **keep** the existing cu13 skipif — but retarget its reason to track #9283 (sglang NIXL ABI fix) instead of the libcudart.so.12 issue, since the broader sglang cu13 stack still hits runtime failures without #9283.

#### Details:

- `examples/backends/sglang/launch/disagg_same_gpu.sh`: remove `--enable-memory-saver` from both prefill and decode worker invocations. With PR #9238's `--mem-fraction-static 0.9` keeping the SGLang pool gate open, both workers fit fine on the profiled token cap.
- `tests/serve/test_sglang.py`: re-profiled markers via `tests/utils/profile_pytest.py` on RTX 6000 Ada — `profiled_vram_gib` 9.9 → 5.5, `requested_sglang_kv_tokens` 37472 → 1184 (2× safety over min=592). `timeout(420)` kept as-is. `_is_cuda13()` helper kept; skipif retargeted from "torch-memory-saver libcudart.so.12" to "sglang cu13 NIXL ABI mismatch (#9283)".
- `tests/README.md`: SGLang marker docs updated to reflect that `build_sglang_gpu_mem_args` now emits `--max-total-tokens N --mem-fraction-static 0.9` (post-#9238).
- Verified end-to-end on cu12.9: gpu_1 + pre_merge SGLang suite under `-n auto --max-vram-gib=48` on a single GPU passes 7/7 runnable tests in 79.87s (3.8× sequential), including `disaggregated_same_gpu` at 61s.

#### Where should the reviewer start?

`tests/serve/test_sglang.py`, then `examples/backends/sglang/launch/disagg_same_gpu.sh`, then `tests/README.md`.

#### Related Issues:

- Follow-up to #9238 (KV markers + `--mem-fraction-static 0.9`).
- cu13 skip kept until #9283 (sglang NIXL ABI fix) lands; once it does, the skipif and `_is_cuda13()` helper can be removed.

/coderabbit profile chill
