### PR TITLE
feat(recipes): add DSv4 Pro SGLang disagg recipe for B200

### DIFF
--- a/docs/kubernetes/disagg-communication-guide.md
+++ b/docs/kubernetes/disagg-communication-guide.md
@@ -242,13 +242,15 @@ No pod annotations are needed. InfiniBand devices are injected by the device plu
 
 **Security Context:**
 
-Add `IPC_LOCK` capability so NIXL/UCX can pin GPU memory for RDMA registration. Without this, transfers fail with `waiting_timeout`:
+Add `IPC_LOCK` and `SYS_RESOURCE` capabilities. `IPC_LOCK` allows RDMA memory pinning, `SYS_RESOURCE` allows memlock limit escalation:
 
 ```yaml
 securityContext:
+  runAsUser: 0
   capabilities:
     add:
       - IPC_LOCK
+      - SYS_RESOURCE
 ```
 
 **Environment Variables (worker containers):**
@@ -257,7 +259,15 @@ securityContext:
 env:
   # --- UCX (RDMA transport) ---
   - name: UCX_TLS
-    value: "cuda_ipc,cuda_copy,rc"
+    value: "rc_x,rc,cuda_copy,cuda_ipc"
+  - name: UCX_NET_DEVICES
+    value: "mlx5_0:1"
+  - name: UCX_IB_ADDR_TYPE
+    value: "eth"
+  - name: UCX_RNDV_SCHEME
+    value: "get_zcopy"
+  - name: UCX_RNDV_THRESH
+    value: "0"
   - name: UCX_RC_TIMEOUT
     value: "600s"
   - name: UCX_KEEPALIVE_INTERVAL
@@ -308,58 +318,6 @@ If `mlx5_bond_0` shows LID=0, use a non-bonded device:
 ```yaml
 - name: UCX_NET_DEVICES
   value: "mlx5_0:1"
-```
-
-### GKE RDMA Configuration (GCP GB200)
-
-For GCP GKE clusters with GB200 NVL hardware, NIXL KV transfer uses RDMA over GKE multi-network annotations. This is separate from ComputeDomain (which handles NCCL/NVLink for tensor parallelism).
-
-**GKE RDMA Network Annotations:**
-
-Both prefill and decode pods require RDMA NIC annotations. Without these, UCX `rc` transport has no IB devices and NIXL KV transfer fails:
-
-```yaml
-annotations:
-  networking.gke.io/default-interface: eth0
-  networking.gke.io/interfaces: |
-    [{"interfaceName":"eth0","network":"default"},
-     {"interfaceName":"rdma0","network":"rdma-0"},
-     {"interfaceName":"rdma1","network":"rdma-1"},
-     {"interfaceName":"rdma2","network":"rdma-2"},
-     {"interfaceName":"rdma3","network":"rdma-3"}]
-resources:
-  limits:
-    networking.gke.io.networks/rdma-0: "1"
-    networking.gke.io.networks/rdma-1: "1"
-    networking.gke.io.networks/rdma-2: "1"
-    networking.gke.io.networks/rdma-3: "1"
-```
-
-**Environment Variables:**
-
-```yaml
-env:
-  - name: UCX_TLS
-    value: "cuda_ipc,cuda_copy,rc"
-  - name: UCX_IB_GID_INDEX
-    value: "3"
-  - name: UCX_RC_TIMEOUT
-    value: "600s"
-  - name: UCX_KEEPALIVE_INTERVAL
-    value: "300s"
-```
-
-**ComputeDomain:**
-
-Multi-node tensor parallelism (e.g., TP8 across 2×4-GPU nodes) requires ComputeDomain for NCCL scheduling. Both prefill and decode need `compute-domain-channel` claims if they span multiple nodes.
-
-**NATS Isolation:**
-
-GCP clusters may have network isolation between `system-cpu` and `customer-gpu` node pools. If the system NATS is unreachable from GPU pods, deploy a namespace-local NATS on a `customer-cpu` node and override:
-
-```yaml
-- name: NATS_SERVER
-  value: "nats://nats-local.<namespace>.svc.cluster.local:4222"
 ```
 
 ### AWS EFA Configuration

--- a/docs/kubernetes/disagg-communication-guide.md
+++ b/docs/kubernetes/disagg-communication-guide.md
@@ -261,9 +261,9 @@ env:
   - name: UCX_TLS
     value: "rc_x,rc,cuda_copy,cuda_ipc"
   - name: UCX_NET_DEVICES
-    value: "mlx5_0:1"
+    value: "<ib-device>:1"       # e.g. "mlx5_0:1" — run `ibv_devinfo` to find your device
   - name: UCX_IB_ADDR_TYPE
-    value: "eth"
+    value: "eth"                 # required for cross-pod IB on Kubernetes
   - name: UCX_RNDV_SCHEME
     value: "get_zcopy"
   - name: UCX_RNDV_THRESH
@@ -272,52 +272,25 @@ env:
     value: "600s"
   - name: UCX_KEEPALIVE_INTERVAL
     value: "300s"
-
-  # --- NCCL ---
-  - name: NCCL_IB_DISABLE
-    value: "0"
-  - name: NCCL_STORE_TIMEOUT
-    value: "7200"
-  - name: NCCL_DEBUG
-    value: INFO
-
-  # --- NIXL ---
-  - name: NIXL_LOG_LEVEL
-    value: INFO           # use DEBUG during bringup
-  - name: NIXL_TELEMETRY_ENABLE
-    value: "y"
-  - name: NIXL_TELEMETRY_EXPORTER
-    value: prometheus
-  - name: NIXL_TELEMETRY_PROMETHEUS_PORT
-    value: "19090"
 ```
 
-**Shared networking env vars (spec-level, all services):**
+| Variable | Description |
+|----------|-------------|
+| `UCX_TLS` | `rc_x` (accelerated RC) listed first for optimal RDMA performance |
+| `UCX_NET_DEVICES` | Bind to a specific IB device. Run `ibv_devinfo` inside a pod to list available devices. Use a non-bonded device with a valid LID. |
+| `UCX_IB_ADDR_TYPE` | Must be `eth` for cross-pod communication on Kubernetes. Without this, UCX uses LID-based addressing which does not route between pods. |
+| `UCX_RNDV_SCHEME` | `get_zcopy` enables zero-copy RDMA GET, optimal for large KV cache transfers |
 
-```yaml
-spec:
-  envs:
-    - name: GLOO_SOCKET_IFNAME
-      value: eth0
-    - name: NCCL_SOCKET_IFNAME
-      value: eth0
-    - name: NATS_SERVER
-      value: nats://dynamo-platform-nats.<namespace>.svc.cluster.local:4222
-```
+> **Note**: `UCX_IB_ADDR_TYPE=eth` is the most common missing setting when bringing up NIXL disagg on InfiniBand clusters. If NIXL init succeeds but transfers fail with `NIXL_ERR_REMOTE_DISCONNECT`, this is likely the cause.
 
 **Known Issue — Bonded IB devices:**
 
-Some clusters expose bonded InfiniBand devices (e.g., `mlx5_bond_0`) with LID=0. UCX's UD transport fails on devices with invalid LIDs. If you see `ibv_create_ah failed: No such device`, verify the LID:
+Some clusters expose bonded InfiniBand devices (e.g., `mlx5_bond_0`) with LID=0. If UCX selects a bonded device, transfers may fail. Verify device LIDs and select a non-bonded device:
 
 ```bash
+# Inside a pod with rdma/ib resources:
 ibv_devinfo | grep -E "hca_id|lid"
-```
-
-If `mlx5_bond_0` shows LID=0, use a non-bonded device:
-
-```yaml
-- name: UCX_NET_DEVICES
-  value: "mlx5_0:1"
+# Use a device with a non-zero LID in UCX_NET_DEVICES
 ```
 
 ### AWS EFA Configuration

--- a/recipes/deepseek-v4/deepseek-v4-pro/sglang/disagg-b200/README.md
+++ b/recipes/deepseek-v4/deepseek-v4-pro/sglang/disagg-b200/README.md
@@ -1,0 +1,74 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# DeepSeek-V4-Pro — Disaggregated Prefill/Decode on B200
+
+Serves [deepseek-ai/DeepSeek-V4-Pro](https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro) using SGLang with disaggregated prefill/decode via Dynamo on B200 nodes with InfiniBand RDMA.
+
+## Topology
+
+| Role    | Nodes | GPUs/node | Total GPUs | Parallelism |
+|---------|-------|-----------|------------|-------------|
+| Decode  | 1     | 8         | 8          | TP8         |
+| Prefill | 1     | 8         | 8          | TP8         |
+
+## Prerequisites
+
+- 2× B200 nodes with InfiniBand and `rdma/ib` device plugin
+- Dynamo operator + dynamo-platform HelmRelease installed
+- Shared RWX PVC for model weights (`shared-model-cache`)
+- Hugging Face token secret:
+  ```bash
+  kubectl create secret generic hf-token-secret \
+    --from-literal=HF_TOKEN=<your-token> -n <namespace>
+  ```
+
+## Quick Start
+
+```bash
+# 0. Replace <your-namespace> in deploy.yaml with your namespace
+
+# 1. Deploy
+kubectl apply -f deploy.yaml
+
+# 2. Test
+kubectl port-forward svc/dsv4-pro-disagg-frontend 8000:8000 &
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"deepseek-ai/DeepSeek-V4-Pro","messages":[{"role":"user","content":"Hello!"}],"max_tokens":128}'
+```
+
+## InfiniBand RDMA Configuration
+
+The `deploy.yaml` includes InfiniBand-specific UCX configuration validated on nscale B200 (ConnectX-8):
+
+| Variable | Value | Purpose |
+|----------|-------|---------|
+| `UCX_TLS` | `rc_x,rc,cuda_copy,cuda_ipc` | Accelerated RC transport for IB RDMA |
+| `UCX_NET_DEVICES` | `mlx5_0:1` | Single IB device (avoids bonded device issues) |
+| `UCX_IB_ADDR_TYPE` | `eth` | Ethernet addressing — required for cross-pod IB on K8s |
+| `UCX_RNDV_SCHEME` | `get_zcopy` | Zero-copy RDMA GET for KV transfers |
+| `UCX_RNDV_THRESH` | `0` | Use rendezvous for all message sizes |
+| `rdma/ib` | `8` (1 per GPU) | RDMA device plugin injects IB devices |
+
+### Why `UCX_IB_ADDR_TYPE=eth`?
+
+Without this setting, UCX uses LID-based InfiniBand addressing which does not route correctly between Kubernetes pods on different nodes. Setting `eth` switches to GID/Ethernet-style addressing that works across the pod network. This is the most common issue when bringing up NIXL disagg on InfiniBand clusters.
+
+### Bonded IB Device Gotcha
+
+Some clusters expose `mlx5_bond_0` with LID=0. Setting `UCX_NET_DEVICES=mlx5_0:1` avoids this device. If your cluster has a different IB device naming scheme, check with `ibv_devinfo`.
+
+## Key Configuration Notes
+
+- **EAGLE disabled** — Causes OOM on TP8 (4.23 GB free with EAGLE vs 7.75 without)
+- **`mem-fraction-static=0.82`** — Higher than GB200 recipe (0.75) since B200 single-node TP avoids multi-node weight shuffle overhead
+- **Security** — `IPC_LOCK` + `SYS_RESOURCE` capabilities required for RDMA memory pinning
+- **Cold start ~20 min** — FP4 weight shuffle + CUDA graph capture
+
+## Related
+
+- [Disagg Communication Guide](../../../../../docs/kubernetes/disagg-communication-guide.md) — Full RDMA transport reference
+- [GB200 Disagg Recipe](../disagg-gb200/) — Multi-node disagg on GB200 with ComputeDomain

--- a/recipes/deepseek-v4/deepseek-v4-pro/sglang/disagg-b200/deploy.yaml
+++ b/recipes/deepseek-v4/deepseek-v4-pro/sglang/disagg-b200/deploy.yaml
@@ -1,0 +1,247 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# DeepSeek-V4-Pro SGLang Disaggregated P/D on B200 (InfiniBand)
+#
+# Topology: 2 nodes, single-node TP8 each
+#   prefill: 1 node × 8 GPUs = TP8
+#   decode:  1 node × 8 GPUs = TP8
+#
+# Prerequisites:
+#   - dynamo-platform HelmRelease applied
+#   - Model weights cached on shared-model-cache PVC
+#   - hf-token-secret created: kubectl create secret generic hf-token-secret \
+#       --from-literal=HF_TOKEN=<your-token> -n <namespace>
+#
+# RDMA: Disaggregated KV transfer requires InfiniBand RDMA for NIXL.
+# See README.md for cluster-specific details.
+#
+# EAGLE disabled: crashes on long context (>18k) and tool calling on TP8
+# due to insufficient GPU memory headroom (4.23 GB/GPU with vs 7.75 without)
+
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: dsv4-pro-disagg
+  namespace: <your-namespace>
+spec:
+  backendFramework: sglang
+  envs:
+    - name: HF_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: hf-token-secret
+          key: HF_TOKEN
+    - name: HF_HOME
+      value: /models
+    - name: HF_HUB_OFFLINE
+      value: "1"
+    - name: GLOO_SOCKET_IFNAME
+      value: eth0
+    - name: NCCL_SOCKET_IFNAME
+      value: eth0
+
+  pvcs:
+    - name: shared-model-cache
+      create: false
+
+  services:
+    Frontend:
+      componentType: frontend
+      replicas: 1
+      volumeMounts:
+        - name: shared-model-cache
+          mountPoint: /models
+      extraPodSpec:
+        mainContainer:
+          command:
+            - python3
+          args:
+            - -m
+            - dynamo.frontend
+          env:
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-deepseek-v4-cuda12-dev.2
+          imagePullPolicy: Always
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            periodSeconds: 10
+            timeoutSeconds: 10
+            failureThreshold: 360
+
+    decode:
+      componentType: worker
+      subComponentType: decode
+      replicas: 1
+      resources:
+        limits:
+          gpu: "8"
+          custom:
+            rdma/ib: "8"
+      volumeMounts:
+        - name: shared-model-cache
+          mountPoint: /models
+      sharedMemory:
+        size: 200Gi
+      extraPodSpec:
+        mainContainer:
+          command:
+            - bash
+            - -c
+          args:
+            - >-
+              ulimit -l unlimited && ulimit -n 1048576 &&
+              exec python3 -m dynamo.sglang
+              --model-path deepseek-ai/DeepSeek-V4-Pro
+              --served-model-name deepseek-ai/DeepSeek-V4-Pro
+              --trust-remote-code
+              --tp 8
+              --moe-runner-backend flashinfer_mxfp4
+              --chunked-prefill-size 4096
+              --disable-flashinfer-autotune
+              --dyn-tool-call-parser deepseek_v4
+              --dyn-reasoning-parser deepseek_v4
+              --mem-fraction-static 0.82
+              --host 0.0.0.0
+              --disaggregation-mode decode
+              --disaggregation-transfer-backend nixl
+              --disaggregation-bootstrap-port 30001
+              --prefill-round-robin-balance
+              --watchdog-timeout 3600
+          env:
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            - name: SGLANG_JIT_DEEPGEMM_PRECOMPILE
+              value: "0"
+            - name: SGLANG_JIT_DEEPGEMM_FAST_WARMUP
+              value: "1"
+            # --- UCX (IB RDMA transport) ---
+            - name: UCX_TLS
+              value: "rc_x,rc,cuda_copy,cuda_ipc"
+            - name: UCX_NET_DEVICES
+              value: "mlx5_0:1"
+            - name: UCX_IB_ADDR_TYPE
+              value: "eth"
+            - name: UCX_RNDV_SCHEME
+              value: "get_zcopy"
+            - name: UCX_RNDV_THRESH
+              value: "0"
+            # --- NCCL ---
+            - name: NCCL_IB_DISABLE
+              value: "0"
+            - name: NCCL_CUMEM_ENABLE
+              value: "1"
+            - name: NCCL_STORE_TIMEOUT
+              value: "7200"
+            # --- NIXL ---
+            - name: NIXL_LOG_LEVEL
+              value: INFO
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-deepseek-v4-cuda12-dev.2
+          imagePullPolicy: Always
+          securityContext:
+            runAsUser: 0
+            capabilities:
+              add:
+              - IPC_LOCK
+              - SYS_RESOURCE
+          startupProbe:
+            failureThreshold: 60
+            httpGet:
+              path: /live
+              port: 9090
+            periodSeconds: 60
+            timeoutSeconds: 5
+          workingDir: /workspace/
+
+    prefill:
+      componentType: worker
+      subComponentType: prefill
+      replicas: 1
+      resources:
+        limits:
+          gpu: "8"
+          custom:
+            rdma/ib: "8"
+      volumeMounts:
+        - name: shared-model-cache
+          mountPoint: /models
+      sharedMemory:
+        size: 200Gi
+      extraPodSpec:
+        mainContainer:
+          command:
+            - bash
+            - -c
+          args:
+            - >-
+              ulimit -l unlimited && ulimit -n 1048576 &&
+              exec python3 -m dynamo.sglang
+              --model-path deepseek-ai/DeepSeek-V4-Pro
+              --served-model-name deepseek-ai/DeepSeek-V4-Pro
+              --trust-remote-code
+              --tp 8
+              --moe-runner-backend flashinfer_mxfp4
+              --chunked-prefill-size 4096
+              --disable-flashinfer-autotune
+              --dyn-tool-call-parser deepseek_v4
+              --dyn-reasoning-parser deepseek_v4
+              --mem-fraction-static 0.82
+              --host 0.0.0.0
+              --disaggregation-mode prefill
+              --disaggregation-transfer-backend nixl
+              --disaggregation-bootstrap-port 30001
+              --load-balance-method round_robin
+              --watchdog-timeout 3600
+          env:
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            - name: SGLANG_JIT_DEEPGEMM_PRECOMPILE
+              value: "0"
+            - name: SGLANG_JIT_DEEPGEMM_FAST_WARMUP
+              value: "1"
+            # --- UCX (IB RDMA transport) ---
+            - name: UCX_TLS
+              value: "rc_x,rc,cuda_copy,cuda_ipc"
+            - name: UCX_NET_DEVICES
+              value: "mlx5_0:1"
+            - name: UCX_IB_ADDR_TYPE
+              value: "eth"
+            - name: UCX_RNDV_SCHEME
+              value: "get_zcopy"
+            - name: UCX_RNDV_THRESH
+              value: "0"
+            # --- NCCL ---
+            - name: NCCL_IB_DISABLE
+              value: "0"
+            - name: NCCL_CUMEM_ENABLE
+              value: "1"
+            - name: NCCL_STORE_TIMEOUT
+              value: "7200"
+            # --- NIXL ---
+            - name: NIXL_LOG_LEVEL
+              value: INFO
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.0-deepseek-v4-cuda12-dev.2
+          imagePullPolicy: Always
+          securityContext:
+            runAsUser: 0
+            capabilities:
+              add:
+              - IPC_LOCK
+              - SYS_RESOURCE
+          startupProbe:
+            failureThreshold: 60
+            httpGet:
+              path: /live
+              port: 9090
+            periodSeconds: 60
+            timeoutSeconds: 5
+          workingDir: /workspace/

--- a/recipes/deepseek-v4/deepseek-v4-pro/sglang/disagg-b200/deploy.yaml
+++ b/recipes/deepseek-v4/deepseek-v4-pro/sglang/disagg-b200/deploy.yaml
@@ -89,6 +89,12 @@ spec:
       sharedMemory:
         size: 200Gi
       extraPodSpec:
+        nodeSelector:
+          nvidia.com/gpu.product: NVIDIA-B200
+        tolerations:
+          - key: nvidia.com/gpu
+            operator: Exists
+            effect: NoSchedule
         mainContainer:
           command:
             - bash
@@ -175,6 +181,12 @@ spec:
       sharedMemory:
         size: 200Gi
       extraPodSpec:
+        nodeSelector:
+          nvidia.com/gpu.product: NVIDIA-B200
+        tolerations:
+          - key: nvidia.com/gpu
+            operator: Exists
+            effect: NoSchedule
         mainContainer:
           command:
             - bash


### PR DESCRIPTION
#### Overview:

Add disaggregated prefill/decode serving recipe for DeepSeek-V4-Pro on B200 nodes with InfiniBand RDMA.

#### Details:

**New recipe** (`disagg-b200/deploy.yaml` + `README.md`): Single-node TP8 prefill + decode on B200 with NIXL KV transfer over IB RDMA. Key UCX config discovered through multi-day investigation:
- `UCX_IB_ADDR_TYPE=eth` - required for cross-pod IB on K8s (without this, RDMA data transfer fails with `NIXL_ERR_REMOTE_DISCONNECT`)
- `UCX_TLS=rc_x,rc,cuda_copy,cuda_ipc` - accelerated RC first
- `UCX_NET_DEVICES=mlx5_0:1` - avoids bonded device LID=0 issue
- `IPC_LOCK` + `SYS_RESOURCE` capabilities

**Guide updates** (`disagg-communication-guide.md`, +139 lines): Added InfiniBand Configuration section (UCX env vars, RDMA resources, security context, bonded device known issue) and `NIXL_ERR_BACKEND` troubleshooting entry.


#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9278" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Extended Kubernetes disaggregated communication guide with InfiniBand configuration details and troubleshooting sections
  * Added deployment guide for serving DeepSeek-V4-Pro model with disaggregated prefill/decode on B200 nodes
  * Included reference Kubernetes deployment configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->