### PR TITLE
feat: add trtllm snapshot entrypoint and update backend support docs

### DIFF
--- a/components/src/dynamo/trtllm/snapshot.py
+++ b/components/src/dynamo/trtllm/snapshot.py
@@ -45,6 +45,12 @@ async def prepare_snapshot_engine(
         Exits the process with status 0 if checkpointing completed
         successfully (checkpoint path, not restore path).
     """
+    if config.tensor_parallel_size > 1 or config.pipeline_parallel_size > 1:
+        raise ValueError(
+            "Multi-rank snapshot is not supported yet. "
+            "Please use a single-rank deployment for now."
+        )
+
     checkpoint_config = CheckpointConfig.from_env()
     if checkpoint_config is None:
         return None

--- a/components/src/dynamo/trtllm/snapshot.py
+++ b/components/src/dynamo/trtllm/snapshot.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Dynamo Snapshot integration for TRT-LLM workers."""
+
+import gc
+import logging
+import time
+from collections.abc import Callable
+
+from dynamo.common.utils.snapshot import CheckpointConfig, EngineSnapshotController
+
+from .args import Config
+from .engine import TensorRTLLMEngine
+from .request_handlers.handler_base import TRTLLMEngineQuiesceController
+
+logger = logging.getLogger(__name__)
+
+
+async def prepare_snapshot_engine(
+    config: Config,
+    setup_trtllm_engine: Callable[[Config], TensorRTLLMEngine],
+) -> EngineSnapshotController[TensorRTLLMEngine] | None:
+    """Single entry point for Dynamo Snapshot integration with TRT-LLM.
+
+    Must be called BEFORE runtime creation so the engine can be checkpointed
+    without active NATS/etcd connections.
+
+    Weight quiesce (GMS) is intentionally excluded from the snapshot scope.
+    Snapshot mode only quiesces KV cache via TRT-LLM's _collective_rpc.
+
+    Args:
+        config: Parsed TRT-LLM worker configuration.
+        setup_trtllm_engine: Callable that constructs and returns a
+            TensorRTLLMEngine from config, without registering it with the
+            Dynamo runtime. Provided by the refactored worker init (see
+            components/src/dynamo/trtllm/workers/llm_worker.py).
+
+    Returns:
+        None when not in checkpoint mode (DYN_SNAPSHOT_CONTROL_DIR unset).
+        An EngineSnapshotController wrapping the restored engine when restore
+        completed and the caller should proceed with normal worker startup
+        using the pre-built engine.
+
+        Exits the process with status 0 if checkpointing completed
+        successfully (checkpoint path, not restore path).
+    """
+    checkpoint_config = CheckpointConfig.from_env()
+    if checkpoint_config is None:
+        return None
+
+    logger.info("Checkpoint mode enabled (watcher-driven signals)")
+
+    start_time = time.time()
+    engine = setup_trtllm_engine(config)
+    logger.info(
+        "TRT-LLM engine loaded in %.2fs (checkpoint mode)",
+        time.time() - start_time,
+    )
+
+    gc.collect()
+
+    snapshot_controller = EngineSnapshotController(
+        engine=engine,
+        quiesce_controller=TRTLLMEngineQuiesceController(engine),
+        checkpoint_config=checkpoint_config,
+        # Snapshot scope: KV cache only. Weight quiesce requires GMS and is
+        # tracked separately. Passing ["kv_cache"] skips _release_gms_weights
+        # in TRTLLMEngineQuiesceController.quiesce().
+        quiesce_args=(["kv_cache"],),
+    )
+    if not await snapshot_controller.wait_for_restore():
+        raise SystemExit(0)
+
+    return snapshot_controller

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -273,10 +273,17 @@ async def init_llm_worker(
 
     arg_map["load_format"] = engine_load_format
 
-    # Enable sleep_config when GMS manages weights — required for GMS
-    # unmap/remap. Conditional because SleepConfig contains unpicklable
-    # lambdas that break MPI-based multi-rank distribution.
-    if config.load_format == "gms":
+    # Enable sleep_config when GMS manages weights, or when snapshot mode is
+    # active on a single-rank deployment. Multi-rank snapshot requires the
+    # SleepConfig MPI pickle fix upstream in TRT-LLM first. Conditional because
+    # SleepConfig contains unpicklable lambdas that break MPI-based multi-rank
+    # distribution.
+    _snapshot_single_rank = (
+        os.environ.get("DYN_SNAPSHOT_CONTROL_DIR")
+        and config.tensor_parallel_size <= 1
+        and config.pipeline_parallel_size <= 1
+    )
+    if config.load_format == "gms" or _snapshot_single_rank:
         from tensorrt_llm.llmapi.llm_args import SleepConfig
 
         arg_map["sleep_config"] = SleepConfig()

--- a/docs/kubernetes/snapshot.md
+++ b/docs/kubernetes/snapshot.md
@@ -23,7 +23,7 @@ title: Snapshot
 
 - x86_64 (`amd64`) GPU nodes
 - NVIDIA driver 580.xx or newer on the target GPU nodes (590.xx or newer if testing multi-GPU snapshots)
-- vLLM backend today, with limited preview support
+- vLLM and SGLang backends, with limited preview support; TensorRT-LLM support in progress
 - `ReadWriteMany` storage for cross-node restore
 - **CRI-O / OpenShift:** set `runtime.type=crio` on the snapshot chart (and `openshift.enabled=true` on OpenShift). Defaults are for containerd; see the chart README for sockets and Helm flags.
 
@@ -401,7 +401,7 @@ status:
 
 ## Limitations
 
-- **Backend support is limited**: checkpoint/restore currently supports vLLM workers only, and that support is still a limited preview.
+- **Backend support is limited**: checkpoint/restore currently supports vLLM and SGLang workers, both still in limited preview. TensorRT-LLM support is in progress.
 - **Worker coverage is narrow**: specialized workers such as multimodal, embedding, and diffusion are not supported.
 - **Multi-GPU remains preview**: vLLM tensor-parallel configurations have limited validation and are not yet a broadly supported path across clusters.
 - **GMS restore is not yet available**: Snapshot plus GPU Memory Service is blocked by admission.
@@ -454,7 +454,7 @@ If the manifest already carries snapshot target metadata, it must agree with the
 ## Planned Features
 
 - Stabilize multi-GPU support
-- Additional backend support
+- TensorRT-LLM backend support
 - Alternative storage backends
 
 ## Related Documentation

--- a/docs/reference/feature-matrix.md
+++ b/docs/reference/feature-matrix.md
@@ -28,7 +28,7 @@ This document provides a comprehensive compatibility matrix for key Dynamo featu
 | **LoRA** | | | ✅ | [K8s Guide][lora] |
 | **Tool Calling** | ✅ | ✅ | ✅ | [Tool Calling Doc][tools] |
 | **Speculative Decoding** | 🚧 | ✅ | ✅ | Backend READMEs |
-| **Dynamo Snapshot** | ✅ | | ✅ | [Snapshot Docs][snapshot] |
+| **Dynamo Snapshot** | ✅ | 🚧 | ✅ | [Snapshot Docs][snapshot] |
 
 ## 1. vLLM Backend
 


### PR DESCRIPTION
#### Overview:

Prepare for TRTLLM Snapshot support with placeholder snapshot file. 

#### Details:

- Adds components/src/dynamo/trtllm/snapshot.py with prepare_snapshot_engine(), mirroring the vLLM/SGLang pattern. Quiesces KV cache only (no GMS/weights). The `setup_trtllm_engine` callable is a placeholder for the engine-creation refactor (functionality doesn't exist yet)
- Updated docs to reflect SGLang snapshot support and TRT-LLM as in-progress

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TensorRT-LLM backend support for Dynamo Snapshot checkpoint and restore capabilities.

* **Documentation**
  * Updated Kubernetes snapshot documentation to include TensorRT-LLM backend support status.
  * Updated feature matrix to reflect TensorRT-LLM snapshot functionality availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->