### PR TITLE
fix(helm): update Tiltfile and docs for global.nats.install migration

### DIFF
--- a/deploy/helm/charts/platform/README.md
+++ b/deploy/helm/charts/platform/README.md
@@ -108,7 +108,7 @@ The chart includes built-in validation to prevent all operator conflicts:
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | global.etcd.install | bool | `false` | Whether this chart should install the bundled etcd subchart. When true, deploys etcd and auto-configures the operator with its address. When false, etcd is not deployed. Use dynamo-operator.etcdAddr to point at an external instance if you are bringing your own etcd. |
-| global.nats.install | bool | `true` | Whether this chart should install the bundled NATS subchart. When true, deploys NATS and auto-configures the operator with its address. When false, NATS is not deployed. Use dynamo-operator.natsAddr to point at an external instance if you are bringing your own NATS. |
+| global.nats.install | bool | `true` | Whether this chart should install the bundled NATS subchart. When true, deploys NATS and auto-configures the operator with its address. When false, NATS is not deployed. Use dynamo-operator.natsAddr to point at an external instance if you are bringing your own NATS. Defaults to true (since release 1.1.0) because the Dynamo runtime's event plane (DYN_EVENT_PLANE) defaults to NATS for distributed backends (etcd/kubernetes). |
 | global.kai-scheduler.install | bool | `false` | Whether this chart should install the bundled kai-scheduler subchart. When true, deploys kai-scheduler and its CRDs. Integration is automatically enabled. NOTE: For production environments, it is recommended to install kai-scheduler separately. |
 | global.kai-scheduler.enabled | bool | `false` | Whether to enable Kai Scheduler integration (queue creation, schedulerName injection). Set to true when kai-scheduler is available in the cluster (installed externally). Automatically enabled when install=true. The operator uses this to decide whether to inject schedulerName and queue labels into pod templates. |
 | global.grove.install | bool | `false` | Whether this chart should install the bundled Grove subchart. When true, deploys the Grove operator cluster-wide. Integration is automatically enabled. NOTE: For production environments, it is recommended to install Grove separately. |
@@ -177,7 +177,7 @@ The chart includes built-in validation to prevent all operator conflicts:
 
 ### NATS Configuration
 
-For detailed NATS configuration options beyond `nats.enabled`, please refer to the official NATS Helm chart documentation:
+For detailed NATS configuration options beyond `global.nats.install`, please refer to the official NATS Helm chart documentation:
 **[NATS Helm Chart Documentation](https://github.com/nats-io/k8s/tree/main/helm/charts/nats)**
 
 ### etcd Configuration

--- a/deploy/helm/charts/platform/README.md.gotmpl
+++ b/deploy/helm/charts/platform/README.md.gotmpl
@@ -99,7 +99,7 @@ The chart includes built-in validation to prevent all operator conflicts:
 
 ### NATS Configuration
 
-For detailed NATS configuration options beyond `nats.enabled`, please refer to the official NATS Helm chart documentation:
+For detailed NATS configuration options beyond `global.nats.install`, please refer to the official NATS Helm chart documentation:
 **[NATS Helm Chart Documentation](https://github.com/nats-io/k8s/tree/main/helm/charts/nats)**
 
 ### etcd Configuration

--- a/deploy/helm/charts/platform/values.yaml
+++ b/deploy/helm/charts/platform/values.yaml
@@ -25,6 +25,7 @@ global:
     # -- Whether this chart should install the bundled NATS subchart.
     # When true, deploys NATS and auto-configures the operator with its address.
     # When false, NATS is not deployed. Use dynamo-operator.natsAddr to point at an external instance if you are bringing your own NATS.
+    # Defaults to true (since release 1.1.0) because the Dynamo runtime's event plane (DYN_EVENT_PLANE) defaults to NATS for distributed backends (etcd/kubernetes).
     install: true
 
   kai-scheduler:

--- a/deploy/operator/Tiltfile
+++ b/deploy/operator/Tiltfile
@@ -201,8 +201,7 @@ def render_helm():
         '--namespace', NAMESPACE,
         '--set', 'dynamo-operator.enabled=true',
         # Subcharts — NATS is on by default (workers need it)
-        '--set', 'nats.enabled=%s' % str(ENABLE_NATS).lower(),
-        '--set', 'dynamo-operator.nats.enabled=%s' % str(ENABLE_NATS).lower(),
+        '--set', 'global.nats.install=%s' % str(ENABLE_NATS).lower(),
         '--set', 'global.etcd.install=%s' % str(ENABLE_ETCD).lower(),
         '--set', 'global.kai-scheduler.install=%s' % str(ENABLE_KAI_SCHEDULER).lower(),
         '--set', 'global.grove.install=%s' % str(ENABLE_GROVE).lower(),


### PR DESCRIPTION
#### Overview:

Follow-up to #9232. Fixes stale references to the removed `nats.enabled` and `dynamo-operator.nats.enabled` values that were missed in the original PR.

#### Details:

- `deploy/operator/Tiltfile` — **Blocker fix**: replaced the two old `--set` flags (`nats.enabled` + `dynamo-operator.nats.enabled`) with a single `--set global.nats.install`, matching the etcd/grove/kai-scheduler pattern on adjacent lines. Without this, `tilt up` fails at `helm template` time due to the validation guards.
- `deploy/helm/charts/platform/README.md.gotmpl` — Updated stale `nats.enabled` reference to `global.nats.install`.
- `deploy/helm/charts/platform/values.yaml` — Added comment explaining why `global.nats.install` defaults to `true` (NATS is required for DGD/DGDR workloads) while `global.etcd.install` defaults to `false`.
- `deploy/helm/charts/platform/README.md` — Regenerated via `make generate-helm-docs`.

#### Where should the reviewer start?

`deploy/operator/Tiltfile` — the blocker fix.

#### Related Issues:

- Fixes review comments on #9232

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified NATS configuration guidance in Helm chart documentation.

* **Chores**
  * Cleaned up and corrected NATS-related configuration values and internal deployment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->