### PR TITLE
fix(container): pin SGLang nixl_ref to v1.0.0 to match upstream wheel ABI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5331,9 +5331,9 @@ dependencies = [
 
 [[package]]
 name = "nixl-sys"
-version = "0.10.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64cc4aaa4b0e9e49b677db3a58e24c91d1293952d3ef6430da235704740b3a6d"
+checksum = "e4f28c4892e39d6f5d8bcd551e7001c03a04b16e5669a9a7d67b23f9720ecaae"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -89,7 +89,10 @@ sglang:
   # (see templates/dev.Dockerfile). Runtime stays on the upstream lmsysorg/sglang
   # NIXL Python stack — its wheel COPY is narrowed to ai_dynamo*.whl so the SDK
   # build doesn't leak into the runtime image.
-  nixl_ref: 0.10.1
+  # Pin to v1.0.0 to match the nixl-cu13==1.0.0 wheel preinstalled in the
+  # upstream lmsysorg/sglang:v0.5.10.post1* runtime — keeps SDK and runtime
+  # ABIs aligned. Sglang-only; vllm/trtllm stay on 0.10.1.
+  nixl_ref: v1.0.0
   enable_media_ffmpeg: "true"
   enable_gpu_memory_service: "true"
   enable_kvbm: "false"

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -79,19 +79,21 @@ sglang:
     base_image: nvcr.io/nvidia/cuda-dl-base
     runtime_image: lmsysorg/sglang
     base_image_tag: 25.06-cuda12.9-devel-ubuntu24.04
+    # NOTE: when bumping the SGLang tag, also re-check `nixl_ref` below — it
+    # must match the `nixl-cu12` wheel version preinstalled in the upstream image.
     runtime_image_tag: v0.5.10.post1-runtime
   cuda13.0:
     base_image: nvcr.io/nvidia/cuda-dl-base
     runtime_image: lmsysorg/sglang
     base_image_tag: 25.11-cuda13.0-devel-ubuntu24.04
+    # NOTE: when bumping the SGLang tag, also re-check `nixl_ref` below — it
+    # must match the `nixl-cu13` wheel version preinstalled in the upstream image.
     runtime_image_tag: v0.5.10.post1-cu130-runtime
-  # Builds the NIXL C++ SDK in wheel_builder so the dev stage can link nixl-sys
-  # (see templates/dev.Dockerfile). Runtime stays on the upstream lmsysorg/sglang
-  # NIXL Python stack — its wheel COPY is narrowed to ai_dynamo*.whl so the SDK
-  # build doesn't leak into the runtime image.
-  # Pin to v1.0.0 to match the nixl-cu13==1.0.0 wheel preinstalled in the
-  # upstream lmsysorg/sglang:v0.5.10.post1* runtime — keeps SDK and runtime
-  # ABIs aligned. Sglang-only; vllm/trtllm stay on 0.10.1.
+  # Builds the NIXL C++ SDK in wheel_builder so the dev stage can link nixl-sys.
+  # Must match the nixl-cu1{2,3} wheel preinstalled in the upstream sglang
+  # runtime image (see runtime_image_tag above) to keep SDK/runtime ABIs aligned.
+  # Verify upstream version: docker run --rm <runtime_image>:<tag> pip show nixl-cu13
+  # Note that this is for Sglang-only; vllm/trtllm to stay on 0.10.1.
   nixl_ref: v1.0.0
   enable_media_ffmpeg: "true"
   enable_gpu_memory_service: "true"

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -4720,9 +4720,9 @@ dependencies = [
 
 [[package]]
 name = "nixl-sys"
-version = "0.10.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64cc4aaa4b0e9e49b677db3a58e24c91d1293952d3ef6430da235704740b3a6d"
+checksum = "e4f28c4892e39d6f5d8bcd551e7001c03a04b16e5669a9a7d67b23f9720ecaae"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",

--- a/lib/llm/Cargo.toml
+++ b/lib/llm/Cargo.toml
@@ -120,7 +120,7 @@ dialoguer = { version = "0.11", default-features = false, features = [
 
 # block_manager
 aligned-vec = { version = "0.6.4", optional = true }
-nixl-sys = { version = "=0.10.1", optional = true }
+nixl-sys = { version = "=1.0.0", optional = true }
 cudarc = { workspace = true, optional = true }
 nix = { version = "0.26", optional = true }
 

--- a/lib/memory/Cargo.toml
+++ b/lib/memory/Cargo.toml
@@ -25,7 +25,7 @@ testing-all = ["testing-cuda", "testing-nixl"]
 [dependencies]
 anyhow = { workspace = true }
 cudarc = { workspace = true }
-nixl-sys = { version = "=0.10.1" }
+nixl-sys = { version = "=1.0.0" }
 serde = { workspace = true}
 thiserror = { workspace = true }
 tracing = { workspace = true }


### PR DESCRIPTION
#### Overview:

#9216 added the NIXL C++ SDK to the sglang dev stage so `cargo build` could link `nixl-sys`, pinning `nixl_ref: 0.10.1`. But wheel_builder also builds `ai_dynamo*.whl` (Rust bindings) against that SDK, and the runtime image installs the wheel on top of `lmsysorg/sglang`, which preinstalls `nixl-cu1{2,3}==1.0.0`. ABI mismatch → nixl symbol load failures at runtime.

This PR pins all three NIXL surfaces to the same version (1.0.0) so the SDK `ai_dynamo` is built against matches the NIXL the runtime already ships:

- `sglang.nixl_ref: v1.0.0` — wheel_builder builds the C++ SDK at v1.0.0
- `nixl-sys = "=1.0.0"` (Cargo) — Rust bindings linked against v1.0.0 headers
- `nixl-cu1{2,3}==1.0.0` (already preinstalled by upstream sglang runtime) — runtime Python wheel

Sglang-only; vllm/trtllm stay at `0.10.1`.

#### Details:

- **Why both the SDK and the crate need bumping together:** Between NIXL 0.10.x and 1.0.0, `nixlDescList<T>::operator[]` flipped from `unsigned int` to `size_t` (and dropped `virtual`). The `nixl-sys` crate's vendored `wrapper.cpp` is generated against a specific NIXL commit's headers, so crate version and SDK version must match. `nixl-sys 1.0.0` is published on crates.io, lockstep with NIXL v1.0.0.
- **Why this doesn't change runtime image contents:** `sglang_runtime.Dockerfile` narrows the wheel COPY from wheel_builder to `ai_dynamo*.whl` and excludes `nixl-cu*.whl`, so the wheel_builder NIXL stack does not enter the runtime image. Runtime keeps using upstream `lmsysorg/sglang`'s preinstalled NIXL Python stack — only the ABI `ai_dynamo` is built against changes.
- **Public Rust API of `nixl-sys` is identical between 0.10.1 and 1.0.x** (only `wrapper.cpp` changed, plus internal `nixlAgentConfig` field-by-field construction). Zero dynamo Rust source changes needed.
- Cross-reference comments tying `runtime_image_tag` ↔ `nixl_ref` so future SGLang base-image bumps re-verify the upstream NIXL version (`pip show nixl-cu13` recipe included).

Verified locally on cu12.9 and cu13.0 (sglang local-dev images built from this branch):

- `compile.sh --dev` (full workspace cargo + maturin) PASSED on both — no `rust-lld: undefined symbol` from the prior 0.10.1 nixl-sys × v1.0.0 SDK mismatch.
- GPU tests on **cu13.0**: aggregated-2, video_agg_qwen-2, embedding_agg-2 — **3/3 PASSED** in 3:22.
- GPU tests on **cu12.9**: aggregated-2, disaggregated-2, video_agg_qwen-2, embedding_agg-2 — **4/4 PASSED** in 3:47.

#### Where should the reviewer start?

`lib/memory/Cargo.toml` and `lib/llm/Cargo.toml` for the crate bump; `container/context.yaml` for the SDK pin and the cross-reference comments.

#### Related Issues:

Linear: [DIS-9265](https://linear.app/nvidia/issue/DIS-9265)

Relates to #6671

/coderabbit profile chill

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9283" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded SGLang dependency to v1.0.0
  * Updated runtime image configurations for CUDA 12.9 and CUDA 13.0 compatibility
  * Added documentation notes clarifying version compatibility requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
