### PR TITLE
fix(ci): pin hf-xet below 1.5.0 for nightly tests

### DIFF
--- a/container/deps/requirements.test.txt
+++ b/container/deps/requirements.test.txt
@@ -17,7 +17,10 @@ coverage[toml]==7.13.1
 datasets==4.4.1
 filelock==3.25.1
 # For faster model downloads
-hf-xet
+# Pin below 1.5.0: xet-core 1.5.0 (2026-05-06) deprecated hf_xet.download_files()
+# which huggingface_hub's snapshot_download() still uses internally.
+# Remove pin once huggingface_hub is updated to use the new XetSession API.
+hf-xet>=1.0.0,<1.5.0
 # For Kubernetes operations in deploy tests
 kr8s==0.20.13
 kubernetes_asyncio==32.0.0


### PR DESCRIPTION
## Summary

Pin `hf-xet` below 1.5.0 in test requirements (`container/deps/requirements.test.txt`).

## Evidence

Nightly CI run [25486043542](https://github.com/ai-dynamo/dynamo/actions/runs/25486043542) failed after the xet-core 1.5.0 release on 2026-05-06. The new version deprecated `hf_xet.download_files()`, which `huggingface_hub`'s `snapshot_download()` still calls internally, causing test failures in any test that downloads model weights.

## Change

```
hf-xet>=1.0.0,<1.5.0
```

The version specifier is PEP 440 compliant and restricts to the working range while the upstream `huggingface_hub` library is updated to use the new XetSession API.

## Validation

- **Static validation**: the PEP 440 specifier `>=1.0.0,<1.5.0` is syntactically valid.
- **Scope**: the change is test-only (`requirements.test.txt`); no runtime or production dependencies are affected.
- **GPU/nightly validation**: was NOT run in this PR-creation task. The fix will be validated by the next nightly CI run after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependency versioning with pinned constraints to ensure compatibility with evolving upstream packages. Added documentation notes regarding compatibility constraints with upstream services effective May 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->