### PR TITLE
fix: enable encoder_only mode for sglang multimodal encode workers

### DIFF
--- a/components/src/dynamo/sglang/args.py
+++ b/components/src/dynamo/sglang/args.py
@@ -250,6 +250,11 @@ async def parse_args(args: list[str]) -> Config:
     if dynamo_config.embedding_worker:
         parsed_args.is_embedding = True
 
+    # Enable encoder_only mode for multimodal encode workers to load only vision encoder
+    # This significantly reduces memory usage by avoiding loading the full LLM weights
+    if dynamo_config.multimodal_encode_worker:
+        parsed_args.encoder_only = True
+
     endpoint = dynamo_config.endpoint
     if endpoint is None:
         if dynamo_config.embedding_worker:


### PR DESCRIPTION
#### Overview:

The SGLang multimodal encode worker was loading the **entire model** (including LLM weights), causing out-of-memory (OOM) errors on GPUs with limited memory.

#### Details:

This PR sets `parsed_args.encoder_only = True` in `args.py` when `dynamo_config.multimodal_encode_worker` is True, following the established pattern for `is_embedding`.

#### Where should the reviewer start?

`components/src/dynamo/sglang/args.py`

#### Related Issues:

- Fixes GitHub issue: #9291

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9292" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved configuration handling for multimodal encoder setup. The system now conditionally enables encoder-only mode when multimodal encoding workers are configured, with appropriate logging for monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->