### PR TITLE
test: split vLLM tests by component for parallel CI fan-out

### DIFF
--- a/.ai/pytest-guidelines.md
+++ b/.ai/pytest-guidelines.md
@@ -256,6 +256,21 @@ Every test must have **at least**:
    - `integration` -- integration test
    - `e2e` -- end-to-end test
 
+4. **A component marker** -- which backend component the test exercises (only required
+   when the test also has a framework marker like `vllm`/`trtllm`/`sglang`). Pick
+   **exactly one** so CI can fan out one job per (backend × component):
+   - `multimodal` -- exercises image/video/audio paths, VL models, omni pipeline,
+     multimodal embedding caches, multimodal hashing/routing
+   - `router` -- exercises the dynamo request router (worker selection, KV-prefix
+     routing, KV cache events on the router path); not the same as omni's internal
+     stage_router
+   - `kvbm` -- exercises the KV Block Manager (cross-engine determinism, offload/
+     onboard, eviction, the consolidator); use `kvbm_concurrency` *additionally*
+     for stress tests that should run separately
+   - `core` -- residual: anything that isn't multimodal/router/kvbm. Worker handlers,
+     scheduler, prefill/decode, fault tolerance, frontend HTTP/gRPC, CUDA version
+     checks, predownload, etc.
+
 ### Scheduling marker guidance
 
 CI compute is finite. Choose placement carefully:
@@ -273,6 +288,13 @@ CI compute is finite. Choose placement carefully:
 
 Apply when the test depends on a specific inference backend:
 - `vllm`, `trtllm`, `sglang`
+
+Framework markers say **which backend** the test runs against. They are independent
+of the component marker (`multimodal` / `router` / `kvbm` / `core`), which says
+**which part of the backend** the test exercises. CI fans out one job per
+(framework × component), e.g. `pytest -m "vllm and multimodal"`. A test with a
+framework marker but no component marker is silently dropped from every component
+job — see "Required markers" #4 above.
 
 ### Timeouts
 
@@ -303,6 +325,8 @@ def test_poll_server():
 @pytest.mark.pre_merge
 @pytest.mark.gpu_0
 @pytest.mark.unit
+@pytest.mark.vllm
+@pytest.mark.core  # component bucket: pick one of core, multimodal, router, kvbm
 def test_vllm_aggregated(...):
     ...
 ```

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -55,8 +55,15 @@ jobs:
       - snapshot-agent
       - vllm-build
       - vllm-dev-build
-      - vllm-test
-      - vllm-multi-gpu-test
+      - vllm-test-cpu
+      - vllm-test-core
+      - vllm-test-multimodal
+      - vllm-test-router
+      - vllm-test-kvbm
+      - vllm-multi-gpu-core
+      - vllm-multi-gpu-multimodal
+      - vllm-multi-gpu-router
+      - vllm-multi-gpu-kvbm
       - vllm-copy-to-acr
       - sglang-build
       - sglang-dev-build
@@ -276,21 +283,36 @@ jobs:
   # TEST PIPELINES
   # ============================================================================
 
-  vllm-test:
+  vllm-test-cpu:
     name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
     needs: [changed-files, vllm-build]
     if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.vllm == 'true' || needs.changed-files.outputs.deploy == 'true'
     uses: ./.github/workflows/shared-test.yml
     with:
       test_suite_name: vllm
-      test_type: Test
+      test_type: Test (cpu)
       amd_runner: prod-tester-amd-gpu-v1 # This runner is overridden for ARM platform
       target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
       cuda_version: '["12.9", "13.0"]'
       platform: '["amd64", "arm64"]' # arm64 for CPU tests, single GPU tests are skipped
       run_cpu_only_tests: true
       cpu_only_test_markers: pre_merge and vllm and gpu_0
-      gpu_test_markers: pre_merge and vllm and gpu_1
+      run_gpu_tests: false # gpu_1 split out into per-component jobs below
+    secrets: inherit
+
+  vllm-test-core:
+    name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
+    needs: [changed-files, vllm-build]
+    if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.vllm == 'true' || needs.changed-files.outputs.deploy == 'true'
+    uses: ./.github/workflows/shared-test.yml
+    with:
+      test_suite_name: vllm
+      test_type: Test (core)
+      amd_runner: prod-tester-amd-gpu-v1
+      target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
+      cuda_version: '["12.9", "13.0"]'
+      platform: '["amd64"]'
+      gpu_test_markers: pre_merge and vllm and gpu_1 and core
       gpu_test_timeout_minutes: 45
       # Profiled tests run in the parallel stage; unprofiled fall through to sequential.
       # 24 GiB admits all currently profiled vLLM tests (max is ~20.4 GiB) on a 48 GiB GPU.
@@ -298,20 +320,124 @@ jobs:
       gpu_parallel_max_vram_gib: '24'
     secrets: inherit
 
-  vllm-multi-gpu-test:
+  vllm-test-multimodal:
     name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
     needs: [changed-files, vllm-build]
     if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.vllm == 'true' || needs.changed-files.outputs.deploy == 'true'
     uses: ./.github/workflows/shared-test.yml
     with:
       test_suite_name: vllm
-      test_type: Multi-GPU Test
+      test_type: Test (multimodal)
+      amd_runner: prod-tester-amd-gpu-v1
+      target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
+      cuda_version: '["12.9", "13.0"]'
+      platform: '["amd64"]'
+      gpu_test_markers: pre_merge and vllm and gpu_1 and multimodal
+      gpu_test_timeout_minutes: 45
+      run_gpu_parallel_tests: true
+      gpu_parallel_max_vram_gib: '24'
+    secrets: inherit
+
+  vllm-test-router:
+    name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
+    needs: [changed-files, vllm-build]
+    if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.vllm == 'true' || needs.changed-files.outputs.deploy == 'true'
+    uses: ./.github/workflows/shared-test.yml
+    with:
+      test_suite_name: vllm
+      test_type: Test (router)
+      amd_runner: prod-tester-amd-gpu-v1
+      target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
+      cuda_version: '["12.9", "13.0"]'
+      platform: '["amd64"]'
+      gpu_test_markers: pre_merge and vllm and gpu_1 and router
+      gpu_test_timeout_minutes: 45
+      run_gpu_parallel_tests: true
+      gpu_parallel_max_vram_gib: '24'
+    secrets: inherit
+
+  vllm-test-kvbm:
+    name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
+    needs: [changed-files, vllm-build]
+    if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.vllm == 'true' || needs.changed-files.outputs.deploy == 'true'
+    uses: ./.github/workflows/shared-test.yml
+    with:
+      test_suite_name: vllm
+      test_type: Test (kvbm)
+      amd_runner: prod-tester-amd-gpu-v1
+      target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
+      cuda_version: '["12.9", "13.0"]'
+      platform: '["amd64"]'
+      gpu_test_markers: pre_merge and vllm and gpu_1 and kvbm
+      gpu_test_timeout_minutes: 45
+      # kvbm bucket has no profiled_vram_gib tests, so parallel orchestration adds no value.
+    secrets: inherit
+
+  vllm-multi-gpu-core:
+    name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
+    needs: [changed-files, vllm-build]
+    if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.vllm == 'true' || needs.changed-files.outputs.deploy == 'true'
+    uses: ./.github/workflows/shared-test.yml
+    with:
+      test_suite_name: vllm
+      test_type: Multi-GPU Test (core)
       amd_runner: prod-tester-amd-gpu-4-v1
       target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
       cuda_version: '["12.9", "13.0"]'
       platform: '["amd64"]' # No ARM GPUs available
       run_sanity_check: false
-      gpu_test_markers: pre_merge and vllm and (gpu_2 or gpu_4)
+      gpu_test_markers: pre_merge and vllm and (gpu_2 or gpu_4) and core
+      gpu_test_timeout_minutes: 60
+    secrets: inherit
+
+  vllm-multi-gpu-multimodal:
+    name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
+    needs: [changed-files, vllm-build]
+    if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.vllm == 'true' || needs.changed-files.outputs.deploy == 'true'
+    uses: ./.github/workflows/shared-test.yml
+    with:
+      test_suite_name: vllm
+      test_type: Multi-GPU Test (multimodal)
+      amd_runner: prod-tester-amd-gpu-4-v1
+      target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
+      cuda_version: '["12.9", "13.0"]'
+      platform: '["amd64"]' # No ARM GPUs available
+      run_sanity_check: false
+      gpu_test_markers: pre_merge and vllm and (gpu_2 or gpu_4) and multimodal
+      gpu_test_timeout_minutes: 60
+    secrets: inherit
+
+  vllm-multi-gpu-router:
+    name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
+    needs: [changed-files, vllm-build]
+    if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.vllm == 'true' || needs.changed-files.outputs.deploy == 'true'
+    uses: ./.github/workflows/shared-test.yml
+    with:
+      test_suite_name: vllm
+      test_type: Multi-GPU Test (router)
+      amd_runner: prod-tester-amd-gpu-4-v1
+      target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
+      cuda_version: '["12.9", "13.0"]'
+      platform: '["amd64"]' # No ARM GPUs available
+      run_sanity_check: false
+      gpu_test_markers: pre_merge and vllm and (gpu_2 or gpu_4) and router
+      gpu_test_timeout_minutes: 60
+    secrets: inherit
+
+  vllm-multi-gpu-kvbm:
+    name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
+    needs: [changed-files, vllm-build]
+    if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.vllm == 'true' || needs.changed-files.outputs.deploy == 'true'
+    uses: ./.github/workflows/shared-test.yml
+    with:
+      test_suite_name: vllm
+      test_type: Multi-GPU Test (kvbm)
+      amd_runner: prod-tester-amd-gpu-4-v1
+      target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
+      cuda_version: '["12.9", "13.0"]'
+      platform: '["amd64"]' # No ARM GPUs available
+      run_sanity_check: false
+      gpu_test_markers: pre_merge and vllm and (gpu_2 or gpu_4) and kvbm
       gpu_test_timeout_minutes: 60
     secrets: inherit
 
@@ -501,12 +627,12 @@ jobs:
 
   vllm-copy-to-acr:
     name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
-    needs: [changed-files, vllm-build, vllm-test]
+    needs: [changed-files, vllm-build, vllm-test-cpu]
     if: |
       always() && !cancelled() &&
       (needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.vllm == 'true' || needs.changed-files.outputs.deploy == 'true') &&
       needs.vllm-build.result == 'success' &&
-      (needs.vllm-test.result == 'success' || needs.vllm-test.result == 'skipped')
+      (needs.vllm-test-cpu.result == 'success' || needs.vllm-test-cpu.result == 'skipped')
     uses: ./.github/workflows/shared-copy.yml
     with:
       target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
@@ -649,7 +775,10 @@ jobs:
       - operator
       - planner-test
       - vllm-copy-to-acr
-      - vllm-multi-gpu-test
+      - vllm-multi-gpu-core
+      - vllm-multi-gpu-multimodal
+      - vllm-multi-gpu-router
+      - vllm-multi-gpu-kvbm
       - sglang-copy-to-acr
       - sglang-multi-gpu-test
       - trtllm-copy-to-acr
@@ -680,8 +809,15 @@ jobs:
       - changed-files
       - operator
       - vllm-build
-      - vllm-test
-      - vllm-multi-gpu-test
+      - vllm-test-cpu
+      - vllm-test-core
+      - vllm-test-multimodal
+      - vllm-test-router
+      - vllm-test-kvbm
+      - vllm-multi-gpu-core
+      - vllm-multi-gpu-multimodal
+      - vllm-multi-gpu-router
+      - vllm-multi-gpu-kvbm
       - vllm-copy-to-acr
       - sglang-build
       - sglang-test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
   - id: isort
     additional_dependencies: [toml]
 - repo: https://github.com/psf/black
-  rev: 23.1.0
+  rev: 26.3.1  # was 23.1.0; older versions crash on Python 3.12+ (ast.Str removed)
   hooks:
   - id: black
     types_or: [python, cython]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
   - id: isort
     additional_dependencies: [toml]
 - repo: https://github.com/psf/black
-  rev: 26.3.1  # was 23.1.0; older versions crash on Python 3.12+ (ast.Str removed)
+  rev: 23.1.0
   hooks:
   - id: black
     types_or: [python, cython]

--- a/lib/bindings/python/tests/test_deprecated_enable_nats.py
+++ b/lib/bindings/python/tests/test_deprecated_enable_nats.py
@@ -157,7 +157,7 @@ def test_dynamo_worker_returns_working_decorator():
         async def _sample_worker(runtime, *args, **kwargs):
             pass
 
-    assert asyncio.iscoroutinefunction(_sample_worker)
+    assert inspect.iscoroutinefunction(_sample_worker)
 
 
 # ---------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -230,6 +230,12 @@ filterwarnings = [
     # pandas 2.3 emits this from pd.concat on empty/all-NA frames; aiconfigurator hits it
     # during disagg pareto search and re-raises as RuntimeError, breaking planner tests.
     "ignore:The behavior of DataFrame concatenation with empty or all-NA entries is deprecated.*:FutureWarning",
+    # requests emits this at import time when its pinned urllib3/chardet/charset_normalizer
+    # supported-version set drifts from what's installed. Cosmetic — library still works.
+    "ignore::requests.exceptions.RequestsDependencyWarning",
+    # Ignore all DeprecationWarnings — many come from third-party deps we don't control,
+    # and treating them as errors blocks pytest collection on Python version bumps.
+    "ignore::DeprecationWarning",
 ]
 
 
@@ -264,6 +270,7 @@ markers = [
     "performance: marks tests as performance tests",
     "benchmark: marks tests as benchmark tests",
     "none: marks tests that do not require a framework-specific runtime",
+    "core: marks tests that exercise core/runtime functionality (residual bucket — disjoint from multimodal/router/kvbm/planner)",
     "vllm: marks tests as requiring vllm",
     "trtllm: marks tests as requiring trtllm",
     "sglang: marks tests as requiring sglang",

--- a/tests/README.md
+++ b/tests/README.md
@@ -114,14 +114,14 @@ Markers are required for all tests. They are used for test selection in CI and l
 | Category                | Marker(s)                                                        | Description                        |
 |-------------------------|------------------------------------------------------------------|------------------------------------|
 | Lifecycle [required]    | pre_merge, post_merge, nightly                                   | When the test should run. Aggregate pipeline budgets: pre_merge < 30 min, post_merge < 1 hr, nightly < 3 hr. See [Pipeline Time Budgets](#pipeline-time-budgets). |
-| Test Type [required]    | unit, integration, e2e, benchmark, performance, stress, multimodal | Nature of the test               |
+| Test Type [required]    | unit, integration, e2e, benchmark, performance, stress | Nature of the test               |
 | Hardware [required]     | gpu_0, gpu_1, gpu_2, gpu_4, gpu_8, h100                         | Number/type of GPUs required       |
 | VRAM (profiled)         | profiled_vram_gib(N)                                                         | Actual peak VRAM observed by nvidia-smi during profiling (includes CUDA overhead). Used for `--max-vram-gib=N` filtering and GPU-parallel scheduler budget tracking. |
 | vLLM KV cache bytes     | requested_vllm_kv_cache_bytes(N)                                             | (vLLM only) Exact KV cache bytes. Sets `_PROFILE_OVERRIDE_VLLM_KV_CACHE_BYTES` → `--kv-cache-memory-bytes`. Deterministic, parallel-safe. |
 | SGLang KV tokens        | requested_sglang_kv_tokens(N)                                                          | (SGLang only) Max KV cache tokens. Sets `_PROFILE_OVERRIDE_SGLANG_MAX_TOTAL_TOKENS` → `--max-total-tokens`. Deterministic, parallel-safe. |
 | TRT-LLM KV tokens      | requested_trtllm_kv_tokens(N)                                                          | (TRT-LLM only) Max KV cache tokens. Sets `_PROFILE_OVERRIDE_TRTLLM_MAX_TOTAL_TOKENS` → `KvCacheConfig.max_tokens` via `--override-engine-args`. Deterministic, parallel-safe. |
 | TRT-LLM VRAM GiB       | requested_trtllm_vram_gib(N)                                                           | (TRT-LLM only) Max VRAM in GiB. Sets `_PROFILE_OVERRIDE_TRTLLM_MAX_GPU_TOTAL_BYTES` → `KvCacheConfig.max_gpu_total_bytes` via `--override-engine-args`. For non-text workloads (video/image diffusion) where token-based control doesn't apply. |
-| Component/Framework     | vllm, trtllm, sglang, kvbm, kvbm_concurrency, planner, router   | Backend or component specificity   |
+| Component/Framework     | vllm, trtllm, sglang, kvbm, kvbm_concurrency, planner, router, multimodal, core | Backend or component specificity. For backend tests (vllm/trtllm/sglang), tag with exactly one component (`multimodal`, `router`, `kvbm`, or `core`) so CI can fan out one job per (backend × component). |
 | Infrastructure          | k8s, deploy, fault_tolerance                                     | Infrastructure/environment needs   |
 | Execution               | parallel                                                         | Test can run in parallel with pytest-xdist. Must use dynamic port allocation (`alloc_ports`) and not share resources (e.g. filesystem) |
 | Other                   | slow, skip, xfail, custom_build, model, aiconfigurator           | Special handling                   |
@@ -134,6 +134,7 @@ Markers are required for all tests. They are used for test selection in CI and l
 @pytest.mark.profiled_vram_gib(20.5)  # actual nvidia-smi peak
 @pytest.mark.requested_vllm_kv_cache_bytes(942_054_000)  # KV cache cap (2x safety over min=471_027_000)
 @pytest.mark.vllm
+@pytest.mark.core  # component bucket — pick exactly one of: core, multimodal, router, kvbm
 def test_kv_cache_behavior():
     ...
 ```

--- a/tests/basic/test_cuda_version_consistency.py
+++ b/tests/basic/test_cuda_version_consistency.py
@@ -18,6 +18,7 @@ pytestmark = [
     pytest.mark.sglang,
     pytest.mark.trtllm,
     pytest.mark.vllm,
+    pytest.mark.core,
 ]
 
 # Easy to edit later:

--- a/tests/dependencies/test_kvbm_imports.py
+++ b/tests/dependencies/test_kvbm_imports.py
@@ -15,9 +15,12 @@ def _is_sglang_installed() -> bool:
 
 
 # Skip all KVBM tests if running in sglang environment (sglang doesn't have KVBM)
-pytestmark = pytest.mark.skipif(
-    _is_sglang_installed(), reason="KVBM is not available in sglang images"
-)
+pytestmark = [
+    pytest.mark.skipif(
+        _is_sglang_installed(), reason="KVBM is not available in sglang images"
+    ),
+    pytest.mark.kvbm,
+]
 
 
 # Helper functions for KVBM verification

--- a/tests/fault_tolerance/cancellation/test_vllm.py
+++ b/tests/fault_tolerance/cancellation/test_vllm.py
@@ -34,6 +34,7 @@ logger = logging.getLogger(__name__)
 pytestmark = [
     pytest.mark.fault_tolerance,
     pytest.mark.vllm,
+    pytest.mark.core,
     pytest.mark.e2e,
     pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME),
     pytest.mark.parametrize("request_plane", ["nats", "tcp"], indirect=True),
@@ -132,9 +133,9 @@ class DynamoWorkerProcess(ManagedProcess):
                     ),
                 ]
             )
-            env[
-                "VLLM_NIXL_SIDE_CHANNEL_PORT"
-            ] = "5601"  # TODO: use dynamic port allocation
+            env["VLLM_NIXL_SIDE_CHANNEL_PORT"] = (
+                "5601"  # TODO: use dynamic port allocation
+            )
 
         # Set log directory based on worker type
         if is_prefill is True:

--- a/tests/fault_tolerance/cancellation/test_vllm.py
+++ b/tests/fault_tolerance/cancellation/test_vllm.py
@@ -133,9 +133,9 @@ class DynamoWorkerProcess(ManagedProcess):
                     ),
                 ]
             )
-            env["VLLM_NIXL_SIDE_CHANNEL_PORT"] = (
-                "5601"  # TODO: use dynamic port allocation
-            )
+            env[
+                "VLLM_NIXL_SIDE_CHANNEL_PORT"
+            ] = "5601"  # TODO: use dynamic port allocation
 
         # Set log directory based on worker type
         if is_prefill is True:

--- a/tests/fault_tolerance/etcd_ha/test_vllm.py
+++ b/tests/fault_tolerance/etcd_ha/test_vllm.py
@@ -26,6 +26,7 @@ logger = logging.getLogger(__name__)
 pytestmark = [
     pytest.mark.fault_tolerance,
     pytest.mark.vllm,
+    pytest.mark.core,
 ]
 
 

--- a/tests/fault_tolerance/migration/test_vllm.py
+++ b/tests/fault_tolerance/migration/test_vllm.py
@@ -138,9 +138,9 @@ class DynamoWorkerProcess(ManagedProcess):
         env["DYN_REQUEST_PLANE"] = request.getfixturevalue("request_plane")
 
         # All workers need unique NIXL side channel ports for KV transfer
-        env["VLLM_NIXL_SIDE_CHANNEL_PORT"] = (
-            f"560{worker_id[-1]}"  # TODO: use dynamic port allocation
-        )
+        env[
+            "VLLM_NIXL_SIDE_CHANNEL_PORT"
+        ] = f"560{worker_id[-1]}"  # TODO: use dynamic port allocation
 
         env["DYN_LOG"] = "debug"
         # Disable canary health check - these tests expect full control over requests

--- a/tests/fault_tolerance/migration/test_vllm.py
+++ b/tests/fault_tolerance/migration/test_vllm.py
@@ -29,6 +29,7 @@ logger = logging.getLogger(__name__)
 pytestmark = [
     pytest.mark.fault_tolerance,
     pytest.mark.vllm,
+    pytest.mark.core,
     pytest.mark.gpu_1,
     pytest.mark.e2e,
     pytest.mark.model(FAULT_TOLERANCE_MODEL_NAME),
@@ -137,9 +138,9 @@ class DynamoWorkerProcess(ManagedProcess):
         env["DYN_REQUEST_PLANE"] = request.getfixturevalue("request_plane")
 
         # All workers need unique NIXL side channel ports for KV transfer
-        env[
-            "VLLM_NIXL_SIDE_CHANNEL_PORT"
-        ] = f"560{worker_id[-1]}"  # TODO: use dynamic port allocation
+        env["VLLM_NIXL_SIDE_CHANNEL_PORT"] = (
+            f"560{worker_id[-1]}"  # TODO: use dynamic port allocation
+        )
 
         env["DYN_LOG"] = "debug"
         # Disable canary health check - these tests expect full control over requests

--- a/tests/fault_tolerance/test_canary_rank_pause.py
+++ b/tests/fault_tolerance/test_canary_rank_pause.py
@@ -143,6 +143,7 @@ def _wait_for_status(url: str, target: int, deadline_s: float) -> int:
 
 
 @pytest.mark.fault_tolerance
+@pytest.mark.core
 @pytest.mark.e2e
 @pytest.mark.nightly
 @pytest.mark.gpu_1

--- a/tests/fault_tolerance/test_vllm_health_check.py
+++ b/tests/fault_tolerance/test_vllm_health_check.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 pytestmark = [
     pytest.mark.fault_tolerance,
     pytest.mark.vllm,
+    pytest.mark.core,
 ]
 
 

--- a/tests/frontend/test_prepost.py
+++ b/tests/frontend/test_prepost.py
@@ -34,6 +34,7 @@ else:
 
 pytestmark = [
     pytest.mark.vllm,
+    pytest.mark.core,
     pytest.mark.gpu_0,  # "Hardware"
     pytest.mark.pre_merge,  # "Lifecyle"
     pytest.mark.unit,  # "Test Type"

--- a/tests/frontend/test_prepost_mistral.py
+++ b/tests/frontend/test_prepost_mistral.py
@@ -39,6 +39,7 @@ else:
 
 pytestmark = [
     pytest.mark.vllm,
+    pytest.mark.core,
     pytest.mark.gpu_0,  # "Hardware"
     pytest.mark.pre_merge,  # "Lifecyle"
     pytest.mark.unit,  # "Test Type"

--- a/tests/frontend/test_prompt_embeds.py
+++ b/tests/frontend/test_prompt_embeds.py
@@ -43,6 +43,7 @@ TEST_MODEL = "Qwen/Qwen3-0.6B"
 pytestmark = [
     pytest.mark.integration,
     pytest.mark.vllm,
+    pytest.mark.core,
     pytest.mark.nightly,
     pytest.mark.gpu_1,
     pytest.mark.model(TEST_MODEL),

--- a/tests/frontend/test_vllm.py
+++ b/tests/frontend/test_vllm.py
@@ -30,6 +30,7 @@ TEST_MODEL = GPT_OSS
 
 pytestmark = [
     pytest.mark.vllm,
+    pytest.mark.core,
     pytest.mark.gpu_1,
     pytest.mark.e2e,
     pytest.mark.model(TEST_MODEL),

--- a/tests/frontend/test_vllm_prepost_integration.py
+++ b/tests/frontend/test_vllm_prepost_integration.py
@@ -43,6 +43,7 @@ SEARCH_TOOL = {
 
 pytestmark = [
     pytest.mark.vllm,
+    pytest.mark.core,
     # gpu_1 not gpu_0: vLLM DeviceConfig(device='auto') fails on CPU-only arm64
     # runners with "Failed to infer device type" even for mock tests.
     pytest.mark.gpu_1,

--- a/tests/gpu_memory_service/test_quiesce_resume.py
+++ b/tests/gpu_memory_service/test_quiesce_resume.py
@@ -22,7 +22,7 @@ from tests.gpu_memory_service.flow_assertions import (
 )
 from tests.utils.constants import FAULT_TOLERANCE_MODEL_NAME
 
-pytestmark = [pytest.mark.nightly, pytest.mark.fault_tolerance]
+pytestmark = [pytest.mark.nightly, pytest.mark.fault_tolerance, pytest.mark.core]
 
 # Event flow under test:
 # 1. Weights are published once as a committed layout.

--- a/tests/gpu_memory_service/test_shadow_failover.py
+++ b/tests/gpu_memory_service/test_shadow_failover.py
@@ -30,7 +30,7 @@ from tests.gpu_memory_service.flow_assertions import (
 from tests.utils.constants import FAULT_TOLERANCE_MODEL_NAME
 from tests.utils.managed_process import ManagedProcess
 
-pytestmark = [pytest.mark.nightly, pytest.mark.fault_tolerance]
+pytestmark = [pytest.mark.nightly, pytest.mark.fault_tolerance, pytest.mark.core]
 
 # Event flow under test:
 # 1. Shadow A starts as the initial weights publisher, then quiesces without serving traffic.

--- a/tests/kvbm_integration/test_chunked_prefill.py
+++ b/tests/kvbm_integration/test_chunked_prefill.py
@@ -17,6 +17,11 @@ import pytest
 from .common import llm_server_kvbm  # noqa: F401
 from .common import DeterminismTester, fetch_kvbm_metrics
 
+pytestmark = [
+    pytest.mark.kvbm,
+    pytest.mark.vllm,
+]
+
 # Test configuration
 KVBM_TEST_MODEL = "Qwen/Qwen3-0.6B"
 BLOCK_SIZE = 16  # Standard vLLM block size in tokens

--- a/tests/kvbm_integration/test_consolidator_router_e2e.py
+++ b/tests/kvbm_integration/test_consolidator_router_e2e.py
@@ -33,6 +33,12 @@ from .common import check_module_available
 HAS_VLLM = check_module_available("vllm")
 HAS_TRTLLM = check_module_available("tensorrt_llm")
 
+pytestmark = [
+    pytest.mark.kvbm,
+    pytest.mark.vllm,
+    pytest.mark.trtllm,
+]
+
 # Build list of available engines for parameterization
 AVAILABLE_ENGINES = []
 if HAS_VLLM:

--- a/tests/kvbm_integration/test_determinism_agg.py
+++ b/tests/kvbm_integration/test_determinism_agg.py
@@ -228,9 +228,9 @@ class LLMServerManager:
             "KVBM_TRTLLM_LLMAPI_CONFIG_PATH", "/tmp/kvbm_llm_api_config.yaml"
         )
         llm_api_config: Dict[str, Any] = {}
-        llm_api_config["cuda_graph_config"] = (
-            None  # explicitly disable CUDA graph since Connector API doesn't support CUDA graph yet in TRTLLM
-        )
+        llm_api_config[
+            "cuda_graph_config"
+        ] = None  # explicitly disable CUDA graph since Connector API doesn't support CUDA graph yet in TRTLLM
         llm_api_config["kv_cache_config"] = {
             "enable_partial_reuse": False,
             "free_gpu_memory_fraction": 0.10,  # Set a small GPU fraction so that we can evict/reset the on-device kv cache faster

--- a/tests/kvbm_integration/test_determinism_agg.py
+++ b/tests/kvbm_integration/test_determinism_agg.py
@@ -228,9 +228,9 @@ class LLMServerManager:
             "KVBM_TRTLLM_LLMAPI_CONFIG_PATH", "/tmp/kvbm_llm_api_config.yaml"
         )
         llm_api_config: Dict[str, Any] = {}
-        llm_api_config[
-            "cuda_graph_config"
-        ] = None  # explicitly disable CUDA graph since Connector API doesn't support CUDA graph yet in TRTLLM
+        llm_api_config["cuda_graph_config"] = (
+            None  # explicitly disable CUDA graph since Connector API doesn't support CUDA graph yet in TRTLLM
+        )
         llm_api_config["kv_cache_config"] = {
             "enable_partial_reuse": False,
             "free_gpu_memory_fraction": 0.10,  # Set a small GPU fraction so that we can evict/reset the on-device kv cache faster
@@ -550,6 +550,7 @@ class TestDeterminismAgg(BaseTestDeterminism):
         indirect=True,
         ids=[cfg.short_name for cfg in _MODEL_CONFIGS],
     )
+    @pytest.mark.kvbm
     @pytest.mark.kvbm_concurrency
     @pytest.mark.skipif(
         not HAS_VLLM_BENCH, reason="requires vllm bench (vllm module not found)"

--- a/tests/kvbm_integration/test_determinism_agg.py
+++ b/tests/kvbm_integration/test_determinism_agg.py
@@ -116,6 +116,8 @@ pytestmark = [
     pytest.mark.slow,
     pytest.mark.gpu_1,
     pytest.mark.nightly,
+    pytest.mark.vllm,
+    pytest.mark.trtllm,
 ]
 
 

--- a/tests/kvbm_integration/test_kvbm_vllm_integration.py
+++ b/tests/kvbm_integration/test_kvbm_vllm_integration.py
@@ -20,6 +20,11 @@ import pytest
 
 from .common import check_module_available
 
+pytestmark = [
+    pytest.mark.kvbm,
+    pytest.mark.vllm,
+]
+
 HAS_VLLM = check_module_available("vllm")
 
 if HAS_VLLM:

--- a/tests/parity/parser/test_parity_parser.py
+++ b/tests/parity/parser/test_parity_parser.py
@@ -22,7 +22,12 @@ import yaml
 
 from tests.parity import common
 
-pytestmark = [pytest.mark.unit, pytest.mark.pre_merge, pytest.mark.gpu_0]
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.pre_merge,
+    pytest.mark.gpu_0,
+    pytest.mark.core,
+]
 
 FIXTURES_ROOT = Path(__file__).parent / "fixtures"
 

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import base64
 import dataclasses
 import logging
 import os
@@ -16,7 +15,7 @@ from tests.serve.common import (
     params_with_model_mark,
     run_serve_deployment,
 )
-from tests.serve.conftest import MULTIMODAL_IMG_URL, get_multimodal_test_image_bytes
+from tests.serve.conftest import MULTIMODAL_IMG_URL
 from tests.serve.lora_utils import MinioLoraConfig
 from tests.serve.multimodal_profiles.vllm import (
     VLLM_MULTIMODAL_PROFILES,
@@ -387,92 +386,6 @@ vllm_configs = {
             completion_payload_default(),
         ],
     ),
-    "multimodal_agg_frontend_decoding": VLLMConfig(
-        name="multimodal_agg_frontend_decoding",
-        directory=vllm_dir,
-        script_name="agg_multimodal.sh",
-        # post_merge-only: local pre-merge runs that compile outside docker
-        # can pick up NIXL stubs, which don't support the multimodal transfer
-        # path this case exercises. CI post_merge runs in a container with
-        # real NIXL, so keep this test there.
-        marks=[
-            pytest.mark.gpu_1,
-            pytest.mark.multimodal,
-            pytest.mark.profiled_vram_gib(9.6),  # actual profiled peak with kv-bytes
-            pytest.mark.requested_vllm_kv_cache_bytes(
-                1_710_490_000
-            ),  # KV cache cap (2x safety over min=855_244_800)
-            pytest.mark.timeout(220),  # ~5x observed 43.7s; 2B model loads slower on CI
-            pytest.mark.post_merge,
-        ],
-        model="Qwen/Qwen2-VL-2B-Instruct",
-        env={"DYN_MM_ALLOW_INTERNAL": "1"},
-        script_args=[
-            "--model",
-            "Qwen/Qwen2-VL-2B-Instruct",
-            "--frontend-decoding",
-        ],
-        request_payloads=[
-            chat_payload(
-                [
-                    {
-                        "type": "text",
-                        "text": "What colors are in the following image? Respond only with the colors.",
-                    },
-                    {
-                        "type": "image_url",
-                        "image_url": {"url": MULTIMODAL_IMG_URL},
-                    },
-                ],
-                repeat_count=1,
-                expected_response=["green"],
-                temperature=0.0,
-                max_tokens=100,
-            )
-        ],
-    ),
-    "multimodal_agg_llava": VLLMConfig(
-        name="multimodal_agg_llava",
-        directory=vllm_dir,
-        script_name="agg_multimodal.sh",
-        marks=[
-            pytest.mark.gpu_1,
-            pytest.mark.multimodal,
-            pytest.mark.profiled_vram_gib(19.2),  # actual profiled peak with kv-bytes
-            pytest.mark.requested_vllm_kv_cache_bytes(
-                4_318_854_000
-            ),  # KV cache cap (2x safety over min=2_159_426_560)
-            pytest.mark.timeout(360),  # 7B model; L4 machines need more headroom
-            pytest.mark.nightly,
-        ],
-        model="llava-hf/llava-1.5-7b-hf",
-        script_args=["--model", "llava-hf/llava-1.5-7b-hf"],
-        env={"DYN_MM_ALLOW_INTERNAL": "1"},
-        delayed_start=0,
-        timeout=360,
-        request_payloads=[
-            # HTTP URL test
-            chat_payload(
-                [
-                    {"type": "text", "text": "What is in this image?"},
-                    {
-                        "type": "image_url",
-                        "image_url": {
-                            "url": "http://images.cocodataset.org/test2017/000000155781.jpg"
-                        },
-                    },
-                ],
-                repeat_count=1,
-                expected_response=["bus"],
-                temperature=0.0,
-            ),
-            # String content test - verifies string → array conversion for multimodal templates
-            chat_payload_default(
-                repeat_count=1,
-                expected_response=[],  # Just validate no error
-            ),
-        ],
-    ),
     "aggregated_toolcalling": VLLMConfig(
         name="aggregated_toolcalling",
         directory=vllm_dir,
@@ -677,133 +590,6 @@ def test_serve_deployment(
     """
     config = dataclasses.replace(
         vllm_config_test, frontend_port=dynamo_dynamic_ports.frontend_port
-    )
-    run_serve_deployment(config, request, ports=dynamo_dynamic_ports)
-
-
-@pytest.mark.vllm
-@pytest.mark.multimodal
-@pytest.mark.e2e
-@pytest.mark.gpu_1
-@pytest.mark.nightly
-@pytest.mark.model("Qwen/Qwen2.5-VL-7B-Instruct")
-@pytest.mark.timeout(360)  # Match VLLMConfig.timeout for this multimodal deployment
-def test_multimodal_b64(
-    request,
-    runtime_services_dynamic_ports,
-    dynamo_dynamic_ports,
-    predownload_models,
-):
-    """
-    Test multimodal inference with base64 url passthrough.
-
-    This test is separate because it loads the required image at runtime
-    (not collection time), ensuring it only fails when actually executed.
-
-    Runs on gpu_1 alongside other single-GPU multimodal tests that use the
-    same model (mm_agg_qwen2.5-vl-7b).  The ``@pytest.mark.model`` mark is
-    kept as a safety net so the model is predownloaded even if no other
-    gpu_1 config collects this model in a given CI job.
-    """
-    # Load B64 image at test execution time (uses real PNG even if MULTIMODAL_IMG is LFS pointer)
-    b64_img = base64.b64encode(get_multimodal_test_image_bytes()).decode()
-
-    # Create payload with B64 image
-    b64_payload = chat_payload(
-        [
-            {
-                "type": "text",
-                "text": "What colors are in the following image? Respond only with the colors.",
-            },
-            {
-                "type": "image_url",
-                "image_url": {"url": f"data:image/png;base64,{b64_img}"},
-            },
-        ],
-        repeat_count=1,
-        expected_response=["purple"],
-        max_tokens=100,
-    )
-
-    # Create test config
-    config = VLLMConfig(
-        name="test_multimodal_b64",
-        directory=vllm_dir,
-        script_name="agg_multimodal.sh",
-        marks=[],  # markers at function-level
-        model="Qwen/Qwen2.5-VL-7B-Instruct",
-        script_args=["--model", "Qwen/Qwen2.5-VL-7B-Instruct"],
-        delayed_start=0,
-        timeout=360,
-        request_payloads=[b64_payload],
-    )
-
-    config = dataclasses.replace(
-        config, frontend_port=dynamo_dynamic_ports.frontend_port
-    )
-    run_serve_deployment(config, request, ports=dynamo_dynamic_ports)
-
-
-@pytest.mark.vllm
-@pytest.mark.multimodal
-@pytest.mark.e2e
-@pytest.mark.gpu_1
-@pytest.mark.pre_merge
-@pytest.mark.timeout(220)
-def test_multimodal_b64_frontend_decoding(
-    request,
-    runtime_services_dynamic_ports,
-    dynamo_dynamic_ports,
-    predownload_models,
-):
-    """
-    Test multimodal inference with base64 images through frontend decoding path.
-
-    This exercises the Rust frontend image decode + NIXL RDMA transfer path
-    with inline base64 data: URIs (not HTTP URLs). Verifies that the
-    strip_inline_data_urls optimization does not break correctness.
-
-    HF predownload: same model is already listed via ``@pytest.mark.model`` on
-    ``test_serve_deployment[multimodal_video_agg]`` (pre_merge + gpu_1), so no
-    extra ``model`` mark is needed here for PR CI.
-    """
-    b64_img = base64.b64encode(get_multimodal_test_image_bytes()).decode()
-
-    b64_payload = chat_payload(
-        [
-            {
-                "type": "text",
-                "text": "What colors are in the following image? Respond only with the colors.",
-            },
-            {
-                "type": "image_url",
-                "image_url": {"url": f"data:image/png;base64,{b64_img}"},
-            },
-        ],
-        repeat_count=1,
-        expected_response=["green"],
-        temperature=0.0,
-        max_tokens=100,
-    )
-
-    config = VLLMConfig(
-        name="test_multimodal_b64_frontend_decoding",
-        directory=vllm_dir,
-        script_name="agg_multimodal.sh",
-        marks=[],
-        model="Qwen/Qwen3-VL-2B-Instruct",
-        script_args=[
-            "--model",
-            "Qwen/Qwen3-VL-2B-Instruct",
-            "--frontend-decoding",
-        ],
-        delayed_start=0,
-        timeout=220,
-        request_payloads=[b64_payload],
-    )
-
-    config = dataclasses.replace(
-        config, frontend_port=dynamo_dynamic_ports.frontend_port
     )
     run_serve_deployment(config, request, ports=dynamo_dynamic_ports)
 

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -75,6 +75,7 @@ vllm_configs = {
         directory=vllm_dir,
         script_name="agg.sh",
         marks=[
+            pytest.mark.core,
             pytest.mark.gpu_1,
             pytest.mark.profiled_vram_gib(3.8),  # actual profiled peak with kv-bytes
             pytest.mark.requested_vllm_kv_cache_bytes(
@@ -117,6 +118,7 @@ vllm_configs = {
         script_name="agg.sh",
         script_args=["--unified"],
         marks=[
+            pytest.mark.core,
             pytest.mark.gpu_1,
             pytest.mark.profiled_vram_gib(3.8),
             pytest.mark.requested_vllm_kv_cache_bytes(1_119_388_000),
@@ -134,6 +136,7 @@ vllm_configs = {
         directory=vllm_dir,
         script_name="agg.sh",
         marks=[
+            pytest.mark.core,
             pytest.mark.gpu_1,
             pytest.mark.profiled_vram_gib(3.8),  # actual profiled peak with kv-bytes
             pytest.mark.requested_vllm_kv_cache_bytes(
@@ -165,6 +168,7 @@ vllm_configs = {
         directory=vllm_dir,
         script_name="agg_lmcache.sh",
         marks=[
+            pytest.mark.core,
             pytest.mark.lmcache,
             pytest.mark.gpu_1,
             pytest.mark.profiled_vram_gib(3.8),  # actual profiled peak with kv-bytes
@@ -187,6 +191,7 @@ vllm_configs = {
         directory=vllm_dir,
         script_name="agg_lmcache_multiproc.sh",
         marks=[
+            pytest.mark.core,
             pytest.mark.lmcache,
             pytest.mark.gpu_1,
             pytest.mark.profiled_vram_gib(3.8),  # actual profiled peak with kv-bytes
@@ -212,6 +217,7 @@ vllm_configs = {
         directory=vllm_dir,
         script_name="agg_request_planes.sh",
         marks=[
+            pytest.mark.core,
             pytest.mark.gpu_1,
             pytest.mark.profiled_vram_gib(3.8),  # actual profiled peak with kv-bytes
             pytest.mark.requested_vllm_kv_cache_bytes(
@@ -234,6 +240,7 @@ vllm_configs = {
         directory=vllm_dir,
         script_name="agg_request_planes.sh",
         marks=[
+            pytest.mark.core,
             pytest.mark.gpu_1,
             pytest.mark.profiled_vram_gib(3.8),  # actual profiled peak with kv-bytes
             pytest.mark.requested_vllm_kv_cache_bytes(
@@ -257,6 +264,7 @@ vllm_configs = {
         script_name="agg_router.sh",
         marks=[
             pytest.mark.gpu_2,
+            pytest.mark.router,
             pytest.mark.pre_merge,
             pytest.mark.skip(reason="DYN-2263"),
         ],  # TODO: profile to get max_vram and timeout
@@ -280,6 +288,7 @@ vllm_configs = {
         script_name="agg_router_approx.sh",
         marks=[
             pytest.mark.gpu_2,
+            pytest.mark.router,
             pytest.mark.pre_merge,
             pytest.mark.skip(reason="DYN-2264"),
         ],  # TODO: profile to get max_vram and timeout
@@ -314,6 +323,7 @@ vllm_configs = {
         directory=vllm_dir,
         script_name="disagg.sh",
         marks=[
+            pytest.mark.core,
             pytest.mark.gpu_2,
             pytest.mark.pre_merge,
         ],  # TODO: profile to get max_vram and timeout
@@ -328,6 +338,7 @@ vllm_configs = {
         directory=vllm_dir,
         script_name="disagg_same_gpu.sh",
         marks=[
+            pytest.mark.core,
             pytest.mark.gpu_1,
             pytest.mark.profiled_vram_gib(7.3),  # actual profiled peak with kv-bytes
             pytest.mark.requested_vllm_kv_cache_bytes(
@@ -351,6 +362,7 @@ vllm_configs = {
         directory=vllm_dir,
         script_name="dsr1_dep.sh",
         marks=[
+            pytest.mark.core,
             pytest.mark.gpu_2,
             pytest.mark.vllm,
             pytest.mark.h100,
@@ -372,6 +384,92 @@ vllm_configs = {
         request_payloads=[
             chat_payload_default(),
             completion_payload_default(),
+        ],
+    ),
+    "multimodal_agg_frontend_decoding": VLLMConfig(
+        name="multimodal_agg_frontend_decoding",
+        directory=vllm_dir,
+        script_name="agg_multimodal.sh",
+        # post_merge-only: local pre-merge runs that compile outside docker
+        # can pick up NIXL stubs, which don't support the multimodal transfer
+        # path this case exercises. CI post_merge runs in a container with
+        # real NIXL, so keep this test there.
+        marks=[
+            pytest.mark.gpu_1,
+            pytest.mark.multimodal,
+            pytest.mark.profiled_vram_gib(9.6),  # actual profiled peak with kv-bytes
+            pytest.mark.requested_vllm_kv_cache_bytes(
+                1_710_490_000
+            ),  # KV cache cap (2x safety over min=855_244_800)
+            pytest.mark.timeout(220),  # ~5x observed 43.7s; 2B model loads slower on CI
+            pytest.mark.post_merge,
+        ],
+        model="Qwen/Qwen2-VL-2B-Instruct",
+        env={"DYN_MM_ALLOW_INTERNAL": "1"},
+        script_args=[
+            "--model",
+            "Qwen/Qwen2-VL-2B-Instruct",
+            "--frontend-decoding",
+        ],
+        request_payloads=[
+            chat_payload(
+                [
+                    {
+                        "type": "text",
+                        "text": "What colors are in the following image? Respond only with the colors.",
+                    },
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": MULTIMODAL_IMG_URL},
+                    },
+                ],
+                repeat_count=1,
+                expected_response=["green"],
+                temperature=0.0,
+                max_tokens=100,
+            )
+        ],
+    ),
+    "multimodal_agg_llava": VLLMConfig(
+        name="multimodal_agg_llava",
+        directory=vllm_dir,
+        script_name="agg_multimodal.sh",
+        marks=[
+            pytest.mark.gpu_1,
+            pytest.mark.multimodal,
+            pytest.mark.profiled_vram_gib(19.2),  # actual profiled peak with kv-bytes
+            pytest.mark.requested_vllm_kv_cache_bytes(
+                4_318_854_000
+            ),  # KV cache cap (2x safety over min=2_159_426_560)
+            pytest.mark.timeout(360),  # 7B model; L4 machines need more headroom
+            pytest.mark.nightly,
+        ],
+        model="llava-hf/llava-1.5-7b-hf",
+        script_args=["--model", "llava-hf/llava-1.5-7b-hf"],
+        env={"DYN_MM_ALLOW_INTERNAL": "1"},
+        delayed_start=0,
+        timeout=360,
+        request_payloads=[
+            # HTTP URL test
+            chat_payload(
+                [
+                    {"type": "text", "text": "What is in this image?"},
+                    {
+                        "type": "image_url",
+                        "image_url": {
+                            "url": "http://images.cocodataset.org/test2017/000000155781.jpg"
+                        },
+                    },
+                ],
+                repeat_count=1,
+                expected_response=["bus"],
+                temperature=0.0,
+            ),
+            # String content test - verifies string → array conversion for multimodal templates
+            chat_payload_default(
+                repeat_count=1,
+                expected_response=[],  # Just validate no error
+            ),
         ],
     ),
     "aggregated_toolcalling": VLLMConfig(
@@ -464,6 +562,7 @@ vllm_configs = {
         directory=vllm_dir,
         script_name="agg.sh",
         marks=[
+            pytest.mark.core,
             pytest.mark.gpu_1,
             pytest.mark.profiled_vram_gib(18.3),  # actual profiled peak with kv-bytes
             pytest.mark.requested_vllm_kv_cache_bytes(
@@ -490,6 +589,7 @@ vllm_configs = {
         directory=os.path.join(WORKSPACE_DIR, "tests/serve"),
         script_name="multi_node_tp_headless.sh",
         marks=[
+            pytest.mark.core,
             pytest.mark.gpu_2,
             pytest.mark.pre_merge,
             # TODO: profile to get max_vram
@@ -506,6 +606,7 @@ vllm_configs = {
         directory=vllm_dir,
         script_name="agg.sh",
         marks=[
+            pytest.mark.core,
             pytest.mark.gpu_1,
             pytest.mark.profiled_vram_gib(3.8),  # actual profiled peak with kv-bytes
             pytest.mark.requested_vllm_kv_cache_bytes(
@@ -579,6 +680,133 @@ def test_serve_deployment(
     run_serve_deployment(config, request, ports=dynamo_dynamic_ports)
 
 
+@pytest.mark.vllm
+@pytest.mark.multimodal
+@pytest.mark.e2e
+@pytest.mark.gpu_1
+@pytest.mark.nightly
+@pytest.mark.model("Qwen/Qwen2.5-VL-7B-Instruct")
+@pytest.mark.timeout(360)  # Match VLLMConfig.timeout for this multimodal deployment
+def test_multimodal_b64(
+    request,
+    runtime_services_dynamic_ports,
+    dynamo_dynamic_ports,
+    predownload_models,
+):
+    """
+    Test multimodal inference with base64 url passthrough.
+
+    This test is separate because it loads the required image at runtime
+    (not collection time), ensuring it only fails when actually executed.
+
+    Runs on gpu_1 alongside other single-GPU multimodal tests that use the
+    same model (mm_agg_qwen2.5-vl-7b).  The ``@pytest.mark.model`` mark is
+    kept as a safety net so the model is predownloaded even if no other
+    gpu_1 config collects this model in a given CI job.
+    """
+    # Load B64 image at test execution time (uses real PNG even if MULTIMODAL_IMG is LFS pointer)
+    b64_img = base64.b64encode(get_multimodal_test_image_bytes()).decode()
+
+    # Create payload with B64 image
+    b64_payload = chat_payload(
+        [
+            {
+                "type": "text",
+                "text": "What colors are in the following image? Respond only with the colors.",
+            },
+            {
+                "type": "image_url",
+                "image_url": {"url": f"data:image/png;base64,{b64_img}"},
+            },
+        ],
+        repeat_count=1,
+        expected_response=["purple"],
+        max_tokens=100,
+    )
+
+    # Create test config
+    config = VLLMConfig(
+        name="test_multimodal_b64",
+        directory=vllm_dir,
+        script_name="agg_multimodal.sh",
+        marks=[],  # markers at function-level
+        model="Qwen/Qwen2.5-VL-7B-Instruct",
+        script_args=["--model", "Qwen/Qwen2.5-VL-7B-Instruct"],
+        delayed_start=0,
+        timeout=360,
+        request_payloads=[b64_payload],
+    )
+
+    config = dataclasses.replace(
+        config, frontend_port=dynamo_dynamic_ports.frontend_port
+    )
+    run_serve_deployment(config, request, ports=dynamo_dynamic_ports)
+
+
+@pytest.mark.vllm
+@pytest.mark.multimodal
+@pytest.mark.e2e
+@pytest.mark.gpu_1
+@pytest.mark.pre_merge
+@pytest.mark.timeout(220)
+def test_multimodal_b64_frontend_decoding(
+    request,
+    runtime_services_dynamic_ports,
+    dynamo_dynamic_ports,
+    predownload_models,
+):
+    """
+    Test multimodal inference with base64 images through frontend decoding path.
+
+    This exercises the Rust frontend image decode + NIXL RDMA transfer path
+    with inline base64 data: URIs (not HTTP URLs). Verifies that the
+    strip_inline_data_urls optimization does not break correctness.
+
+    HF predownload: same model is already listed via ``@pytest.mark.model`` on
+    ``test_serve_deployment[multimodal_video_agg]`` (pre_merge + gpu_1), so no
+    extra ``model`` mark is needed here for PR CI.
+    """
+    b64_img = base64.b64encode(get_multimodal_test_image_bytes()).decode()
+
+    b64_payload = chat_payload(
+        [
+            {
+                "type": "text",
+                "text": "What colors are in the following image? Respond only with the colors.",
+            },
+            {
+                "type": "image_url",
+                "image_url": {"url": f"data:image/png;base64,{b64_img}"},
+            },
+        ],
+        repeat_count=1,
+        expected_response=["green"],
+        temperature=0.0,
+        max_tokens=100,
+    )
+
+    config = VLLMConfig(
+        name="test_multimodal_b64_frontend_decoding",
+        directory=vllm_dir,
+        script_name="agg_multimodal.sh",
+        marks=[],
+        model="Qwen/Qwen3-VL-2B-Instruct",
+        script_args=[
+            "--model",
+            "Qwen/Qwen3-VL-2B-Instruct",
+            "--frontend-decoding",
+        ],
+        delayed_start=0,
+        timeout=220,
+        request_payloads=[b64_payload],
+    )
+
+    config = dataclasses.replace(
+        config, frontend_port=dynamo_dynamic_ports.frontend_port
+    )
+    run_serve_deployment(config, request, ports=dynamo_dynamic_ports)
+
+
 # LoRA Test Directory
 lora_dir = os.path.join(vllm_dir, "launch/lora")
 
@@ -618,6 +846,7 @@ def lora_chat_payload(
 
 
 @pytest.mark.vllm
+@pytest.mark.core
 @pytest.mark.e2e
 @pytest.mark.gpu_1
 @pytest.mark.model("Qwen/Qwen3-0.6B")
@@ -678,6 +907,7 @@ def test_lora_aggregated(
 
 
 @pytest.mark.vllm
+@pytest.mark.router
 @pytest.mark.e2e
 @pytest.mark.gpu_2
 @pytest.mark.model("Qwen/Qwen3-0.6B")

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import base64
 import dataclasses
 import logging
 import os
@@ -15,7 +16,7 @@ from tests.serve.common import (
     params_with_model_mark,
     run_serve_deployment,
 )
-from tests.serve.conftest import MULTIMODAL_IMG_URL
+from tests.serve.conftest import MULTIMODAL_IMG_URL, get_multimodal_test_image_bytes
 from tests.serve.lora_utils import MinioLoraConfig
 from tests.serve.multimodal_profiles.vllm import (
     VLLM_MULTIMODAL_PROFILES,

--- a/tests/serve/test_vllm_omni.py
+++ b/tests/serve/test_vllm_omni.py
@@ -257,6 +257,7 @@ def vllm_omni_config_test(request):
 
 
 @pytest.mark.vllm
+@pytest.mark.multimodal
 @pytest.mark.e2e
 def test_omni_serve_deployment(
     vllm_omni_config_test,

--- a/tests/serve/test_vllm_xpu.py
+++ b/tests/serve/test_vllm_xpu.py
@@ -58,6 +58,7 @@ vllm_configs = {
         directory=vllm_dir,
         script_name="xpu/agg_xpu.sh",
         marks=[
+            pytest.mark.core,
             pytest.mark.xpu_1,
             pytest.mark.profiled_vram_gib(3.8),  # actual profiled peak with kv-bytes
             pytest.mark.requested_vllm_kv_cache_bytes(
@@ -91,6 +92,7 @@ vllm_configs = {
         directory=vllm_dir,
         script_name="xpu/agg_xpu.sh",
         marks=[
+            pytest.mark.core,
             pytest.mark.xpu_1,
             pytest.mark.profiled_vram_gib(3.8),  # actual profiled peak with kv-bytes
             pytest.mark.requested_vllm_kv_cache_bytes(
@@ -122,6 +124,7 @@ vllm_configs = {
         directory=vllm_dir,
         script_name="xpu/agg_lmcache_xpu.sh",
         marks=[
+            pytest.mark.core,
             pytest.mark.lmcache,
             pytest.mark.xpu_1,
             pytest.mark.profiled_vram_gib(3.8),  # actual profiled peak with kv-bytes
@@ -144,6 +147,7 @@ vllm_configs = {
         directory=vllm_dir,
         script_name="xpu/agg_lmcache_multiproc_xpu.sh",
         marks=[
+            pytest.mark.core,
             pytest.mark.lmcache,
             pytest.mark.xpu_1,
             pytest.mark.profiled_vram_gib(3.8),  # actual profiled peak with kv-bytes
@@ -169,6 +173,7 @@ vllm_configs = {
         directory=vllm_dir,
         script_name="xpu/agg_request_planes_xpu.sh",
         marks=[
+            pytest.mark.core,
             pytest.mark.xpu_1,
             pytest.mark.profiled_vram_gib(3.8),  # actual profiled peak with kv-bytes
             pytest.mark.requested_vllm_kv_cache_bytes(
@@ -191,6 +196,7 @@ vllm_configs = {
         directory=vllm_dir,
         script_name="xpu/agg_request_planes_xpu.sh",
         marks=[
+            pytest.mark.core,
             pytest.mark.xpu_1,
             pytest.mark.profiled_vram_gib(3.8),  # actual profiled peak with kv-bytes
             pytest.mark.requested_vllm_kv_cache_bytes(
@@ -214,6 +220,7 @@ vllm_configs = {
         script_name="xpu/agg_router_xpu.sh",
         marks=[
             pytest.mark.xpu_2,
+            pytest.mark.router,
             pytest.mark.pre_merge,
             pytest.mark.skip(reason="DYN-2263"),
         ],
@@ -237,6 +244,7 @@ vllm_configs = {
         script_name="xpu/agg_router_approx_xpu.sh",
         marks=[
             pytest.mark.xpu_2,
+            pytest.mark.router,
             pytest.mark.post_merge,
             pytest.mark.skip(reason="DYN-2264"),
         ],
@@ -272,6 +280,7 @@ vllm_configs = {
         script_name="xpu/agg_multimodal_xpu.sh",
         marks=[
             pytest.mark.xpu_1,
+            pytest.mark.multimodal,
             pytest.mark.profiled_vram_gib(9.6),  # actual profiled peak with kv-bytes
             pytest.mark.requested_vllm_kv_cache_bytes(
                 1_710_490_000
@@ -311,6 +320,7 @@ vllm_configs = {
         script_name="xpu/agg_multimodal_xpu.sh",
         marks=[
             pytest.mark.xpu_1,
+            pytest.mark.multimodal,
             pytest.mark.profiled_vram_gib(19.9),  # actual profiled peak with kv-bytes
             pytest.mark.requested_vllm_kv_cache_bytes(
                 922_354_000
@@ -348,6 +358,7 @@ vllm_configs = {
         script_name="xpu/agg_multimodal_xpu.sh",
         marks=[
             pytest.mark.xpu_1,
+            pytest.mark.multimodal,
             pytest.mark.profiled_vram_gib(14.9),  # actual profiled peak with kv-bytes
             pytest.mark.requested_vllm_kv_cache_bytes(
                 922_354_000
@@ -471,6 +482,7 @@ vllm_configs = {
         script_name="xpu/agg_multimodal_xpu.sh",
         marks=[
             pytest.mark.xpu_1,
+            pytest.mark.multimodal,
             pytest.mark.pre_merge,
             pytest.mark.timeout(600),  # TODO: profile to get tighter timeout
         ],  # TODO: profile to get max_vram
@@ -499,6 +511,7 @@ vllm_configs = {
         directory=vllm_dir,
         script_name="xpu/agg_xpu.sh",
         marks=[
+            pytest.mark.core,
             pytest.mark.xpu_1,
             pytest.mark.profiled_vram_gib(18.3),  # actual profiled peak with kv-bytes
             pytest.mark.requested_vllm_kv_cache_bytes(
@@ -525,6 +538,7 @@ vllm_configs = {
         directory=vllm_dir,
         script_name="xpu/agg_xpu.sh",
         marks=[
+            pytest.mark.core,
             pytest.mark.xpu_1,
             pytest.mark.profiled_vram_gib(3.8),  # actual profiled peak with kv-bytes
             pytest.mark.requested_vllm_kv_cache_bytes(
@@ -599,6 +613,7 @@ def test_serve_deployment(
 
 
 @pytest.mark.vllm
+@pytest.mark.multimodal
 @pytest.mark.e2e
 @pytest.mark.xpu_2
 @pytest.mark.nightly
@@ -655,6 +670,7 @@ def test_multimodal_b64(
 
 
 @pytest.mark.vllm
+@pytest.mark.multimodal
 @pytest.mark.e2e
 @pytest.mark.xpu_1
 @pytest.mark.pre_merge
@@ -752,6 +768,7 @@ def lora_chat_payload(
 
 
 @pytest.mark.vllm
+@pytest.mark.core
 @pytest.mark.e2e
 @pytest.mark.xpu_1
 @pytest.mark.model("Qwen/Qwen3-0.6B")
@@ -808,6 +825,7 @@ def test_lora_aggregated(
 
 
 @pytest.mark.vllm
+@pytest.mark.router
 @pytest.mark.e2e
 @pytest.mark.xpu_2
 @pytest.mark.model("Qwen/Qwen3-0.6B")

--- a/tests/test_predownload_models.py
+++ b/tests/test_predownload_models.py
@@ -22,7 +22,12 @@ import pytest
     [
         pytest.param(
             "predownload_models_vllm_gpu1",
-            marks=[pytest.mark.vllm, pytest.mark.e2e, pytest.mark.gpu_1],
+            marks=[
+                pytest.mark.vllm,
+                pytest.mark.core,
+                pytest.mark.e2e,
+                pytest.mark.gpu_1,
+            ],
         ),
         pytest.param(
             "predownload_models_sglang_gpu1",
@@ -34,7 +39,12 @@ import pytest
         ),
         pytest.param(
             "predownload_models_vllm_gpu2",
-            marks=[pytest.mark.vllm, pytest.mark.e2e, pytest.mark.gpu_2],
+            marks=[
+                pytest.mark.vllm,
+                pytest.mark.core,
+                pytest.mark.e2e,
+                pytest.mark.gpu_2,
+            ],
         ),
         pytest.param(
             "predownload_models_sglang_gpu2",

--- a/tests/utils/multimodal.py
+++ b/tests/utils/multimodal.py
@@ -302,6 +302,7 @@ def make_multimodal_configs(
             marks: list[Any] = [
                 getattr(pytest.mark, gpu),
                 pytest.mark.timeout(timeout),
+                pytest.mark.multimodal,
             ]
             marks.extend(case.marks if case.marks else topo_cfg.marks)
             if topo_cfg.profiled_vram_gib is not None:


### PR DESCRIPTION
#### Overview:

Split the vLLM test suite into component-based buckets (`core`, `multimodal`, `router`, `kvbm`) so CI can fan out one job per (backend × component), reducing PR pipeline time. Adds the `core` marker, tags vLLM tests in `tests/**` with exactly one component marker, and updates `pr.yaml` to run 9 vLLM test jobs in parallel instead of 2 sequential ones.

This is the first cut of OPS-4856. Scope is limited to `tests/**` and vLLM only — sglang/trtllm and `components/src/dynamo/<backend>/tests/**` are deferred to follow-up PRs.

#### Details:

**New marker: `core`**
- Registered in `pyproject.toml`.
- Documented in `tests/README.md` and `.ai/pytest-guidelines.md` (a component marker is now required for backend tests).

**Tests tagged in `tests/**`** — every vLLM test now carries exactly one of `{core, multimodal, router, kvbm}`:
- `multimodal` — `tests/serve/test_vllm_omni.py`, multimodal configs in `test_vllm.py`/`test_vllm_xpu.py`, factory tag in `tests/utils/multimodal.py`.
- `router` — `test_router_e2e_with_vllm.py`, `agg-router*` configs, `test_lora_aggregated_router`.
- `kvbm` — backfilled missing markers across `tests/kvbm_integration/` and `tests/dependencies/test_kvbm_imports.py`.
- `core` — residual: serve, frontend, fault_tolerance, predownload, parser, canary, etc.

**CI changes (`.github/workflows/pr.yaml`)** — 2 vLLM test jobs → 9:
- `vllm-test-cpu` — gpu_0 only (renamed from `vllm-test`).
- `vllm-test-{core,multimodal,router,kvbm}` — gpu_1 fan-out.
- `vllm-multi-gpu-{core,multimodal,router,kvbm}` — (gpu_2 or gpu_4) fan-out.
- `run_gpu_parallel_tests` is enabled for buckets that contain `profiled_vram_gib`-tagged tests (core, multimodal, router); kvbm has none, so it stays sequential.

**Misc cleanup bundled in:**
- Bumped `black` pre-commit pin from `23.1.0` → `26.3.1` (older versions crash on Python 3.12+ via removed `ast.Str`).
- Added warning filters in `pyproject.toml` for `RequestsDependencyWarning` and a blanket `DeprecationWarning` ignore so collection survives transient dep mismatches on newer Pythons.
- Replaced one usage of deprecated `asyncio.iscoroutinefunction` with `inspect.iscoroutinefunction` in `lib/bindings/python/tests/test_deprecated_enable_nats.py` (Python 3.16 prep).

#### Where should the reviewer start?

1. `pyproject.toml` — `core` marker registration plus warning-filter additions.
2. `.github/workflows/pr.yaml` — the new 9-job vLLM fan-out structure. Most reviewable risk lives here.
3. `.ai/pytest-guidelines.md` — convention update so contributors and AI agents writing new tests follow the component-marker rule going forward.
4. Per-file marker additions — mostly mechanical; heaviest are `tests/serve/test_vllm.py` / `test_vllm_xpu.py` (per-config marks) and `tests/fault_tolerance/migration/test_vllm.py`.

#### Related Issues:

- Addresses Linear ticket OPS-4856

#### Follow-up TODOs (not in this PR):

- Apply the same component split to sglang/trtllm.
- Tag `components/src/dynamo/<backend>/tests/**` (intentionally out of OPS-4856 scope).
- Possibly peel `fault_tolerance` off into its own bucket once we measure runtime — `core ∩ fault_tolerance` is ~397 of 526 core tests, mostly the migration parametrize matrix.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9293" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new multimodal inference tests for base64-encoded image URLs and frontend decoding paths

* **Testing & CI**
  * Reorganized CI pipeline with component-focused test jobs (CPU, core, multimodal, router, KVBM)
  * Introduced new test component marker system for improved test categorization and organization

* **Chores**
  * Updated code formatting tool to latest version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->