### PR TITLE
fix(agents): isolate trace bus tests to prevent cross-test contamination

### DIFF
--- a/lib/llm/src/agents/trace/record.rs
+++ b/lib/llm/src/agents/trace/record.rs
@@ -127,7 +127,12 @@ mod tests {
             },
         );
 
-        let record = rx.recv().await.expect("trace record should publish");
+        let record = loop {
+            let r = rx.recv().await.expect("trace record should publish");
+            if r.event_type == TraceEventType::RequestEnd {
+                break r;
+            }
+        };
         assert_eq!(record.event_time_unix_ms, 1000);
         let request = record.request.expect("request metrics should be present");
         assert_eq!(request.prefill_wait_time_ms, None);
@@ -170,7 +175,12 @@ mod tests {
             }),
         });
 
-        let record = rx.recv().await.expect("tool record should publish");
+        let record = loop {
+            let r = rx.recv().await.expect("tool record should publish");
+            if r.event_type == TraceEventType::ToolEnd {
+                break r;
+            }
+        };
         assert_eq!(record.schema, TraceSchema::V1);
         assert_eq!(record.event_type, TraceEventType::ToolEnd);
         assert_eq!(record.event_source, TraceEventSource::Harness);


### PR DESCRIPTION
#### Overview:

Two agent trace unit tests share a global `BUS` broadcast channel and race when run in parallel, `rx.recv()` in one test can pick up the event published by the other. This caused a flaky `assert_eq!(event_time, 1000)` failure when the receiver dequeued the other test's record (`event_time = 2000`).

Race Condition flow (generated with Claude):
```
Test runner (parallel by default)
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

Thread A (test ①)     Thread B (test ②)
─────────────────     ─────────────────
BUS.init(16)          BUS.init(16)
  └─ creates chan       └─ no-op (OnceLock)
rx = subscribe()      rx = subscribe()
  └─ Receiver A         └─ Receiver B

                      publish(tool_rec)
                        event_time = 2000
                        → Receiver A gets it
                        → Receiver B gets it

emit_request_end(…)
  event_time = 1000
  → Receiver A gets it
  → Receiver B gets it

rx.recv()  ← gets 2000 (tool_rec)
assert_eq!(…, 1000)  💥 FAIL
```

**Repro:**
```
cargo test -p dynamo-llm agents::trace::record::tests --lib 2>&1 | grep FAILED
```
**Before:** intermittent failure:
```
  assertion `left == right` failed
    left: 2000
   right: 1000
  test agents::trace::record::tests::test_emit_request_end_sanitizes_non_finite_metrics ... FAILED
```
#### Details:
Both `test_emit_request_end_sanitizes_non_finite_metrics` and `test_publish_tool_record_accepts_valid_tool_record` subscribe to the same static `TelemetryBus<AgentTraceRecord>`. Since `tokio::broadcast` fans out every event to every receiver, a subscriber in one test can dequeue the other test's record first.

Fix: each test now loops on `rx.recv()` and filters by `event_type` (`RequestEnd` for the sanitization test, `ToolEnd` for the tool-record test) so each only asserts on its own event.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Failed CI Run: http://github.com/ai-dynamo/dynamo/actions/runs/25526018498/job/74926784730?pr=9286#step:6:3707

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of floating-point metrics in trace records to prevent invalid values
  * Enhanced validation of trace records with stricter schema enforcement
  * Invalid records now handled gracefully with appropriate warnings

* **Tests**
  * Updated trace record filtering for more reliable event type identification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->