### PR TITLE
fix(kv-router): optimize clear recovery replay

### DIFF
--- a/lib/kv-router/src/indexer/local.rs
+++ b/lib/kv-router/src/indexer/local.rs
@@ -248,7 +248,7 @@ impl LocalKvIndexer {
         buffer.iter().cloned().collect()
     }
 
-    /// Query events by ID range, returning events in `[start_id, end_id]` (both inclusive).
+    /// Query events by ID range, returning a recovery-equivalent suffix for `[start_id, end_id]`.
     ///
     /// ### Arguments
     ///
@@ -259,8 +259,10 @@ impl LocalKvIndexer {
     ///
     /// ### Returns
     ///
-    /// - `Events`: Buffered events with original IDs from `start_id` through the
-    ///   current buffered tail, plus the buffered `last_event_id`
+    /// - `Events`: Buffered events with original IDs through the current buffered tail,
+    ///   plus the buffered `last_event_id`. If the buffered suffix contains one or more
+    ///   `Cleared` events, events before the last clear may be omitted because the clear
+    ///   is a worker-wide recovery barrier.
     /// - `TreeDump`: Full tree dump with synthetic IDs and the worker's latest real event ID (when range is too old or unspecified)
     /// - `TooNew`: Error when requested range is newer than available data
     /// - `InvalidRange`: Error when end_id < start_id
@@ -421,12 +423,21 @@ impl LocalKvIndexer {
             Ok(idx) => idx,
             Err(insertion_point) => insertion_point,
         };
-        let events = buffer.iter().skip(start_idx).cloned().collect();
+        let response_start_idx = Self::buffer_response_start_idx(&buffer, start_idx);
+        let events = buffer.iter().skip(response_start_idx).cloned().collect();
 
         DumpPlan::Immediate(WorkerKvQueryResponse::Events {
             events,
             last_event_id: last_buffered,
         })
+    }
+
+    fn buffer_response_start_idx(buffer: &VecDeque<RouterEvent>, start_idx: usize) -> usize {
+        buffer
+            .iter()
+            .skip(start_idx)
+            .rposition(|event| matches!(&event.event.data, KvCacheEventData::Cleared))
+            .map_or(start_idx, |idx| start_idx + idx)
     }
 
     async fn get_cached_or_fresh_dump(&self, fallback_last_event_id: u64) -> WorkerKvQueryResponse {

--- a/lib/kv-router/src/indexer/tests.rs
+++ b/lib/kv-router/src/indexer/tests.rs
@@ -2409,6 +2409,53 @@ mod local_indexer_tests {
     }
 
     #[tokio::test]
+    async fn test_local_indexer_buffer_response_starts_at_last_clear() {
+        let indexer = LocalKvIndexer::new(
+            CancellationToken::new(),
+            4,
+            Arc::new(KvIndexerMetrics::new_unregistered()),
+            16,
+        );
+
+        for event in [
+            make_local_store_event(10, 10),
+            make_local_clear_event(11),
+            make_local_store_event(12, 12),
+            make_local_store_event(13, 13),
+            make_local_clear_event(14),
+            make_local_store_event(15, 15),
+        ] {
+            indexer.apply_event_with_buffer(event).await.unwrap();
+        }
+        indexer.flush().await;
+
+        let event_ids = |response: WorkerKvQueryResponse| -> (Vec<u64>, u64) {
+            match response {
+                WorkerKvQueryResponse::Events {
+                    events,
+                    last_event_id,
+                } => (
+                    events.iter().map(|event| event.event.event_id).collect(),
+                    last_event_id,
+                ),
+                other => panic!("Expected Events, got: {other:?}"),
+            }
+        };
+
+        let (ids, last_event_id) = event_ids(indexer.get_events_in_id_range(Some(10), None).await);
+        assert_eq!(ids, vec![14, 15]);
+        assert_eq!(last_event_id, 15);
+
+        let (ids, last_event_id) = event_ids(indexer.get_events_in_id_range(Some(12), None).await);
+        assert_eq!(ids, vec![14, 15]);
+        assert_eq!(last_event_id, 15);
+
+        let (ids, last_event_id) = event_ids(indexer.get_events_in_id_range(Some(15), None).await);
+        assert_eq!(ids, vec![15]);
+        assert_eq!(last_event_id, 15);
+    }
+
+    #[tokio::test]
     async fn test_local_indexer_buffer_and_serialization() {
         let worker_id = 42u64;
         let token = CancellationToken::new();

--- a/lib/kv-router/src/indexer/types.rs
+++ b/lib/kv-router/src/indexer/types.rs
@@ -78,10 +78,13 @@ pub struct WorkerKvQueryRequest {
 /// Response from a worker's local KV indexer.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum WorkerKvQueryResponse {
-    /// Events served from the circular buffer (with original event IDs),
-    /// always covering the requested `start_event_id` through the current
-    /// buffered tail. `last_event_id` is taken from the same buffer snapshot
-    /// and should be used as the recovery watermark after applying the batch.
+    /// Events served from the circular buffer with original event IDs. The batch
+    /// is recovery-equivalent to replaying the requested `start_event_id` through
+    /// the current buffered tail. If the range contains one or more `Cleared`
+    /// barriers, the worker may omit events before the last clear while preserving
+    /// that clear event and all following events. `last_event_id` is taken from the
+    /// same buffer snapshot and should be used as the recovery watermark after
+    /// applying the batch.
     Events {
         events: Vec<RouterEvent>,
         last_event_id: u64,

--- a/lib/llm/src/kv_router/indexer/worker_query.rs
+++ b/lib/llm/src/kv_router/indexer/worker_query.rs
@@ -338,8 +338,11 @@ impl WorkerQueryClient {
 
         worker_state.epoch += 1;
         for rank_state in worker_state.ranks.values_mut() {
+            let post_clear_max_seen = rank_state
+                .max_seen_live_id
+                .filter(|max_seen| *max_seen > clear_event_id);
             rank_state.cursor = rank_state.cursor.invalidate_by_barrier();
-            rank_state.max_seen_live_id = None;
+            rank_state.max_seen_live_id = post_clear_max_seen;
             rank_state.recovery_inflight = false;
         }
 
@@ -504,7 +507,6 @@ impl WorkerQueryClient {
 
         let mut new_cursor = rank_state.cursor;
         let mut successful_response = false;
-        let mut saw_clear = false;
 
         match result {
             Ok(WorkerKvQueryResponse::Events {
@@ -523,7 +525,6 @@ impl WorkerQueryClient {
                         self.apply_worker_clear_locked(&mut worker_state, event)
                             .await;
                         new_cursor = new_cursor.apply_barrier(event_id);
-                        saw_clear = true;
                         continue;
                     }
                     self.indexer.apply_event(event).await;
@@ -595,7 +596,6 @@ impl WorkerQueryClient {
             rank_state.clear_max_seen_if_caught_up(last_applied_id);
 
             if successful_response
-                && !saw_clear
                 && rank_state
                     .max_seen_live_id
                     .is_some_and(|max_seen| max_seen > last_applied_id)
@@ -1586,5 +1586,66 @@ mod tests {
         kv_indexer.flush().await;
         let events = kv_indexer.dump_events().await.unwrap();
         assert_eq!(stored_block_hashes(&events), vec![13, 14, 30]);
+    }
+
+    #[tokio::test]
+    async fn test_recovered_cleared_follows_coalesced_live_tail() {
+        let (client, transport, kv_indexer) = make_test_client("recovered-cleared-live-tail").await;
+        let key = (1, 0);
+
+        {
+            let worker_state = client.get_or_create_worker_state(key.0);
+            let mut worker_state = worker_state.lock().await;
+            worker_state.ranks.entry(key.1).or_default().cursor = CursorState::Live(10);
+        }
+
+        let started = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+        transport.push_action(
+            key,
+            MockQueryAction {
+                started: Some(started.clone()),
+                release: Some(release.clone()),
+                response: Ok(WorkerKvQueryResponse::Events {
+                    events: vec![
+                        make_store_event(1, 0, 11),
+                        make_clear_event(1, 0, 12),
+                        make_store_event(1, 0, 13),
+                    ],
+                    last_event_id: 13,
+                }),
+            },
+        );
+        transport.push_action(
+            key,
+            MockQueryAction {
+                started: None,
+                release: None,
+                response: Ok(WorkerKvQueryResponse::Events {
+                    events: vec![make_store_event(1, 0, 14), make_store_event(1, 0, 15)],
+                    last_event_id: 15,
+                }),
+            },
+        );
+
+        client.handle_live_event(make_store_event(1, 0, 13)).await;
+        started.notified().await;
+        client.handle_live_event(make_store_event(1, 0, 15)).await;
+        release.notify_waiters();
+
+        wait_for(|| {
+            rank_state_matches(&client, key, |state| {
+                state.last_applied_id() == Some(15) && !state.recovery_inflight
+            })
+        })
+        .await;
+        assert_eq!(
+            transport.calls(),
+            vec![(key, Some(11), None), (key, Some(14), None)]
+        );
+
+        kv_indexer.flush().await;
+        let events = kv_indexer.dump_events().await.unwrap();
+        assert_eq!(stored_block_hashes(&events), vec![13, 14, 15]);
     }
 }


### PR DESCRIPTION
Fix router recovery after cleared batches and let worker buffer recovery responses start at the last clear barrier, avoiding replay of dead pre-clear events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of recovery barriers when querying KV events after clear operations; buffer queries now correctly skip entries prior to the most recent clear point.

* **Tests**
  * Added test coverage for KV event recovery behavior following clear operations.

* **Documentation**
  * Clarified KV event recovery semantics and how clear barriers affect event batch responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->