### PR TITLE
chore(kv-router): add replay recovery warnings

### DIFF
--- a/lib/kv-router/src/standalone_indexer/listener.rs
+++ b/lib/kv-router/src/standalone_indexer/listener.rs
@@ -28,6 +28,122 @@ fn cursor_from_watermark(watermark: u64) -> CursorState {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ReplayRecoveryFailureReason {
+    Empty,
+    StartedAfterRequested,
+    NonContiguous,
+    EndedBeforeTarget,
+}
+
+impl ReplayRecoveryFailureReason {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Empty => "empty",
+            Self::StartedAfterRequested => "started_after_requested",
+            Self::NonContiguous => "non_contiguous",
+            Self::EndedBeforeTarget => "ended_before_target",
+        }
+    }
+}
+
+struct ReplayRecoveryProgress {
+    start_seq: u64,
+    end_seq: u64,
+    first_replayed: Option<u64>,
+    last_replayed: Option<u64>,
+    expected_next: u64,
+    replayed: u64,
+    non_contiguous: bool,
+}
+
+impl ReplayRecoveryProgress {
+    fn new(start_seq: u64, end_seq: u64) -> Self {
+        Self {
+            start_seq,
+            end_seq,
+            first_replayed: None,
+            last_replayed: None,
+            expected_next: start_seq,
+            replayed: 0,
+            non_contiguous: false,
+        }
+    }
+
+    fn record_batch(&mut self, seq: u64) {
+        if self.first_replayed.is_none() {
+            self.first_replayed = Some(seq);
+        }
+        if seq != self.expected_next {
+            self.non_contiguous = true;
+        }
+        self.expected_next = seq.saturating_add(1);
+        self.last_replayed = Some(seq);
+        self.replayed += 1;
+    }
+
+    fn failure_reason(&self) -> Option<ReplayRecoveryFailureReason> {
+        if self.start_seq >= self.end_seq {
+            return None;
+        }
+        if self.replayed == 0 {
+            return Some(ReplayRecoveryFailureReason::Empty);
+        }
+        if self
+            .first_replayed
+            .is_some_and(|first| first > self.start_seq)
+        {
+            return Some(ReplayRecoveryFailureReason::StartedAfterRequested);
+        }
+        if self.non_contiguous {
+            return Some(ReplayRecoveryFailureReason::NonContiguous);
+        }
+        if self
+            .last_replayed
+            .is_some_and(|last| last < self.end_seq - 1)
+        {
+            return Some(ReplayRecoveryFailureReason::EndedBeforeTarget);
+        }
+        None
+    }
+
+    fn replayed(&self) -> u64 {
+        self.replayed
+    }
+
+    fn warn_if_incomplete(&self, worker_id: WorkerId, dp_rank: u32) {
+        let Some(reason) = self.failure_reason() else {
+            return;
+        };
+
+        let reason = reason.as_str();
+        let start_seq = self.start_seq;
+        let end_seq = self.end_seq;
+        let replayed = self.replayed;
+        let first_replayed_display = self
+            .first_replayed
+            .map(|seq| seq.to_string())
+            .unwrap_or_else(|| "none".to_string());
+        let last_replayed_display = self
+            .last_replayed
+            .map(|seq| seq.to_string())
+            .unwrap_or_else(|| "none".to_string());
+        tracing::warn!(
+            worker_id,
+            dp_rank,
+            requested_start = start_seq,
+            requested_end = end_seq,
+            first_replayed = ?self.first_replayed,
+            last_replayed = ?self.last_replayed,
+            replayed,
+            reason,
+            "Replay incomplete: requested=[{start_seq},{end_seq}), first={}, last={}, replayed={replayed}, reason={reason}",
+            first_replayed_display,
+            last_replayed_display,
+        );
+    }
+}
+
 struct ListenerLoop {
     worker_id: WorkerId,
     dp_rank: u32,
@@ -99,7 +215,7 @@ impl ListenerLoop {
             return 0;
         }
 
-        let mut replayed = 0u64;
+        let mut replay_progress = ReplayRecoveryProgress::new(start_seq, end_seq);
         loop {
             let msg = tokio::select! {
                 _ = self.cancel.cancelled() => break,
@@ -162,9 +278,12 @@ impl ListenerLoop {
                 indexer.apply_event_routed(router_event).await;
             }
             watermark.store(seq, Ordering::Release);
-            replayed += 1;
+            replay_progress.record_batch(seq);
         }
 
+        replay_progress.warn_if_incomplete(worker_id, dp_rank);
+
+        let replayed = replay_progress.replayed();
         tracing::info!(worker_id, dp_rank, replayed, "Replay complete");
         replayed
     }

--- a/lib/llm/src/mocker.rs
+++ b/lib/llm/src/mocker.rs
@@ -174,6 +174,31 @@ impl ZmqKvEventSink {
 
                         tracing::debug!(dp_rank, start_seq, buffer_len = ring_buffer.len(), "Replay request received");
 
+                        let buffer_first = ring_buffer.front().map(|(seq, _)| *seq);
+                        let buffer_last = ring_buffer.back().map(|(seq, _)| *seq);
+                        let outside_buffer = match (buffer_first, buffer_last) {
+                            (Some(first), Some(last)) => start_seq < first || start_seq > last,
+                            _ => true,
+                        };
+                        if outside_buffer {
+                            let buffer_first_display = buffer_first
+                                .map(|seq| seq.to_string())
+                                .unwrap_or_else(|| "empty".to_string());
+                            let buffer_last_display = buffer_last
+                                .map(|seq| seq.to_string())
+                                .unwrap_or_else(|| "empty".to_string());
+                            tracing::warn!(
+                                dp_rank,
+                                start_seq,
+                                buffer_first = ?buffer_first,
+                                buffer_last = ?buffer_last,
+                                buffer_len = ring_buffer.len(),
+                                "Replay request outside buffer: start_seq={start_seq}, buffer=[{},{}]",
+                                buffer_first_display,
+                                buffer_last_display,
+                            );
+                        }
+
                         // Compute start index directly — sequences are monotonic.
                         let start_idx = ring_buffer.front()
                             .map(|(first_seq, _)| start_seq.saturating_sub(*first_seq) as usize)


### PR DESCRIPTION
Adds standalone indexer replay coverage diagnostics and mocker replay buffer-bound warnings to make indexer-sync gaps visible in CI logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved replay recovery mechanism with comprehensive progress tracking, sequence advancement monitoring, and structured failure classification to better identify replay issues.
  * Enhanced detection of out-of-range replay requests with detailed diagnostic logging of boundary conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->