### PR TITLE
fix(profile): merge pytest stderr into stdout for KV-token extraction

### DIFF
--- a/tests/utils/profile_pytest.py
+++ b/tests/utils/profile_pytest.py
@@ -766,10 +766,15 @@ def _run_once(
     timed_out = False
     captured_stdout = ""
     try:
+        # Merge stderr into stdout so engine markers (e.g. SGLang's
+        # 'max_total_tokens=N', 'KV Cache is allocated. #tokens: N') reach the
+        # extractor — gpu_parallel writes them to stderr by design so pytest
+        # capture won't swallow them, but we still need to grep them.
         result = subprocess.run(
             pytest_cmd,
             env=env,
-            capture_output=capture,
+            stdout=subprocess.PIPE if capture else None,
+            stderr=subprocess.STDOUT if capture else None,
             text=capture or None,
             timeout=timeout,
         )
@@ -788,8 +793,6 @@ def _run_once(
         prefix = f"[{run_label}] "
         for line in captured_stdout.splitlines():
             print(f"{prefix}{line}")
-        for line in (result.stderr or "").splitlines():
-            print(f"{prefix}{line}", file=sys.stderr)
     sys.stdout.flush()
     wall_secs = time.monotonic() - t_start
     test_end = time.monotonic() - sampler._t0


### PR DESCRIPTION
#### Overview:

`profile_pytest.py` binary-search mode aborts with `[ERROR] Could not extract max_total_tokens` for any test that runs under the `gpu_parallel` plugin (`-n N`). The plugin writes worker output to stderr; `_run_once` only returned stdout. Switch to `stderr=STDOUT` so the OS merges them.

#### Details:

- `tests/utils/profile_pytest.py:769-792`: `capture_output=True` → explicit `stdout=PIPE, stderr=STDOUT`; drop the now-redundant `result.stderr` print loop.
- Verified on RTX 6000 Ada (cu13.0): full bisection of `disaggregated_same_gpu` completes in 313s with recommended markers; without the fix the same run aborts at probe 1.

#### Where should the reviewer start?

`tests/utils/profile_pytest.py` (6-line diff).

#### Related Issues:

Surfaced while sanity-checking markers in #9276; not blocking that PR.

/coderabbit profile chill


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved subprocess output capture in profiling tests to ensure engine startup logs and memory allocation diagnostics are properly recorded and available for analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->