### PR TITLE
fix(prompt): preserve verbatim tool_call arguments for `is string` templates

### DIFF
--- a/lib/llm/src/preprocessor/prompt/template.rs
+++ b/lib/llm/src/preprocessor/prompt/template.rs
@@ -201,6 +201,13 @@ struct HfTokenizerConfigJsonFormatter {
     /// arrays natively (Qwen-VL family) or when we have no flatten strategy
     /// for it (no MM-aware routing benefit either way).
     image_placeholder_template: Option<&'static str>,
+    /// True if the chat template branches on `tool_call.arguments is string`
+    /// (Qwen3, Hermes, etc.). When true, skip pre-parsing the JSON-string
+    /// arguments into an object — the template wants the raw string verbatim.
+    /// Pre-parsing forces the `tojson`-with-object branch and re-emits with
+    /// minijinja's compact separators, which breaks append-only prefix matching
+    /// across multi-step tool-use turns.
+    template_handles_arguments_string: bool,
 }
 
 // /// OpenAI Standard Prompt Formatter

--- a/lib/llm/src/preprocessor/prompt/template.rs
+++ b/lib/llm/src/preprocessor/prompt/template.rs
@@ -201,13 +201,21 @@ struct HfTokenizerConfigJsonFormatter {
     /// arrays natively (Qwen-VL family) or when we have no flatten strategy
     /// for it (no MM-aware routing benefit either way).
     image_placeholder_template: Option<&'static str>,
-    /// True if the chat template branches on `tool_call.arguments is string`
-    /// (Qwen3, Hermes, etc.). When true, skip pre-parsing the JSON-string
-    /// arguments into an object — the template wants the raw string verbatim.
-    /// Pre-parsing forces the `tojson`-with-object branch and re-emits with
-    /// minijinja's compact separators, which breaks append-only prefix matching
-    /// across multi-step tool-use turns.
-    template_handles_arguments_string: bool,
+    /// True if the `default` template branches on `tool_call.arguments is string`
+    /// (Qwen3, Hermes, etc.). When true and rendering through `default`, skip
+    /// pre-parsing the JSON-string `tool_calls[].function.arguments` into an
+    /// object — the template wants the raw string verbatim. Pre-parsing forces
+    /// the `tojson`-with-object branch and re-emits with minijinja's compact
+    /// separators, which breaks append-only prefix matching across multi-step
+    /// tool-use turns. Tracked separately for `default` and `tool_use` because
+    /// HF configs may register different sources for each, and because
+    /// `arguments is string` is tool_calls-specific — legacy
+    /// `function_call.arguments` lives outside that branch and is still
+    /// normalized unconditionally.
+    default_template_handles_tool_calls_arguments_string: bool,
+    /// True if the `tool_use` template branches on `tool_call.arguments is string`.
+    /// See `default_template_handles_tool_calls_arguments_string` for rationale.
+    tool_use_template_handles_tool_calls_arguments_string: bool,
 }
 
 // /// OpenAI Standard Prompt Formatter

--- a/lib/llm/src/preprocessor/prompt/template/formatters.rs
+++ b/lib/llm/src/preprocessor/prompt/template/formatters.rs
@@ -208,6 +208,14 @@ impl HfTokenizerConfigJsonFormatter {
             .templates()
             .any(|(_, tmpl)| tmpl.source().contains("reasoning_content"));
 
+        // Detect if the template branches on `tool_call.arguments is string` (Qwen3, Hermes).
+        // Such templates render a JSON-string `arguments` field verbatim; if we pre-parse
+        // it into an object, the `tojson` branch fires instead and emits compact JSON,
+        // breaking byte-level append-only across multi-step tool-use turns.
+        let template_handles_arguments_string = env
+            .templates()
+            .any(|(_, tmpl)| tmpl.source().contains("arguments is string"));
+
         Ok(HfTokenizerConfigJsonFormatter {
             env,
             config,
@@ -217,6 +225,7 @@ impl HfTokenizerConfigJsonFormatter {
             exclude_tools_when_tool_choice_none,
             template_handles_reasoning,
             image_placeholder_template,
+            template_handles_arguments_string,
         })
     }
 }

--- a/lib/llm/src/preprocessor/prompt/template/formatters.rs
+++ b/lib/llm/src/preprocessor/prompt/template/formatters.rs
@@ -208,13 +208,25 @@ impl HfTokenizerConfigJsonFormatter {
             .templates()
             .any(|(_, tmpl)| tmpl.source().contains("reasoning_content"));
 
-        // Detect if the template branches on `tool_call.arguments is string` (Qwen3, Hermes).
+        // Detect if a given template branches on `tool_call.arguments is string` (Qwen3, Hermes).
         // Such templates render a JSON-string `arguments` field verbatim; if we pre-parse
         // it into an object, the `tojson` branch fires instead and emits compact JSON,
-        // breaking byte-level append-only across multi-step tool-use turns.
-        let template_handles_arguments_string = env
-            .templates()
-            .any(|(_, tmpl)| tmpl.source().contains("arguments is string"));
+        // breaking byte-level append-only across multi-step tool-use turns. The check is
+        // per-template (default vs tool_use) because in HF configs they can differ — and
+        // because `arguments is string` only appears inside tool-call iteration, the flag
+        // is naturally tied to the `tool_use` template in practice. It is also
+        // tool_calls-specific: legacy `function_call.arguments` lives outside this branch
+        // and must still be normalized.
+        let template_handles_args_string = |name: &str| -> bool {
+            env.templates()
+                .find(|(n, _)| *n == name)
+                .map(|(_, tmpl)| tmpl.source().contains("arguments is string"))
+                .unwrap_or(false)
+        };
+        let default_template_handles_tool_calls_arguments_string =
+            template_handles_args_string("default");
+        let tool_use_template_handles_tool_calls_arguments_string =
+            template_handles_args_string("tool_use");
 
         Ok(HfTokenizerConfigJsonFormatter {
             env,
@@ -225,7 +237,8 @@ impl HfTokenizerConfigJsonFormatter {
             exclude_tools_when_tool_choice_none,
             template_handles_reasoning,
             image_placeholder_template,
-            template_handles_arguments_string,
+            default_template_handles_tool_calls_arguments_string,
+            tool_use_template_handles_tool_calls_arguments_string,
         })
     }
 }

--- a/lib/llm/src/preprocessor/prompt/template/oai.rs
+++ b/lib/llm/src/preprocessor/prompt/template/oai.rs
@@ -521,7 +521,15 @@ impl OAIPromptFormatter for HfTokenizerConfigJsonFormatter {
         ))
         .unwrap();
 
-        normalize_tool_arguments_in_messages(&mut messages_for_template);
+        // Pre-parse JSON-string `arguments` into objects — but only for templates
+        // that unconditionally `| tojson` them. Templates that branch on
+        // `tool_call.arguments is string` (Qwen3, Hermes) want the raw string
+        // verbatim so the rendered bytes match what the model emitted on the
+        // prior turn. Re-serializing through minijinja's compact `tojson` here
+        // breaks append-only prefix matching across multi-step tool use.
+        if !self.template_handles_arguments_string {
+            normalize_tool_arguments_in_messages(&mut messages_for_template);
+        }
 
         // Inject reasoning_content as <think> blocks into content — but only if
         // the template doesn't handle it natively. Templates like Nemotron and
@@ -1905,6 +1913,237 @@ NORMAL_MODE
             think_count, 1,
             "must have exactly one <think> block (from template), got {} in: {}",
             think_count, rendered
+        );
+    }
+
+    /// Real Qwen3-4B-Thinking-2507 chat template (verbatim from
+    /// `Qwen/Qwen3-4B-Thinking-2507/tokenizer_config.json`). Used to
+    /// regression-test append-only rendering across multi-step tool use.
+    const QWEN3_THINKING_TEMPLATE: &str = r##"{%- if tools %}
+    {{- '<|im_start|>system\n' }}
+    {%- if messages[0].role == 'system' %}
+        {{- messages[0].content + '\n\n' }}
+    {%- endif %}
+    {{- "# Tools\n\nYou may call one or more functions to assist with the user query.\n\nYou are provided with function signatures within <tools></tools> XML tags:\n<tools>" }}
+    {%- for tool in tools %}
+        {{- "\n" }}
+        {{- tool | tojson }}
+    {%- endfor %}
+    {{- "\n</tools>\n\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call><|im_end|>\n" }}
+{%- else %}
+    {%- if messages[0].role == 'system' %}
+        {{- '<|im_start|>system\n' + messages[0].content + '<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}
+{%- for message in messages[::-1] %}
+    {%- set index = (messages|length - 1) - loop.index0 %}
+    {%- if ns.multi_step_tool and message.role == "user" and message.content is string and not(message.content.startswith('<tool_response>') and message.content.endswith('</tool_response>')) %}
+        {%- set ns.multi_step_tool = false %}
+        {%- set ns.last_query_index = index %}
+    {%- endif %}
+{%- endfor %}
+{%- for message in messages %}
+    {%- if message.content is string %}
+        {%- set content = message.content %}
+    {%- else %}
+        {%- set content = '' %}
+    {%- endif %}
+    {%- if (message.role == "user") or (message.role == "system" and not loop.first) %}
+        {{- '<|im_start|>' + message.role + '\n' + content + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "assistant" %}
+        {%- set reasoning_content = '' %}
+        {%- if message.reasoning_content is string %}
+            {%- set reasoning_content = message.reasoning_content %}
+        {%- else %}
+            {%- if '</think>' in content %}
+                {%- set reasoning_content = content.split('</think>')[0].rstrip('\n').split('<think>')[-1].lstrip('\n') %}
+                {%- set content = content.split('</think>')[-1].lstrip('\n') %}
+            {%- endif %}
+        {%- endif %}
+        {%- if loop.index0 > ns.last_query_index %}
+            {%- if loop.last or (not loop.last and reasoning_content) %}
+                {{- '<|im_start|>' + message.role + '\n<think>\n' + reasoning_content.strip('\n') + '\n</think>\n\n' + content.lstrip('\n') }}
+            {%- else %}
+                {{- '<|im_start|>' + message.role + '\n' + content }}
+            {%- endif %}
+        {%- else %}
+            {{- '<|im_start|>' + message.role + '\n' + content }}
+        {%- endif %}
+        {%- if message.tool_calls %}
+            {%- for tool_call in message.tool_calls %}
+                {%- if (loop.first and content) or (not loop.first) %}
+                    {{- '\n' }}
+                {%- endif %}
+                {%- if tool_call.function %}
+                    {%- set tool_call = tool_call.function %}
+                {%- endif %}
+                {{- '<tool_call>\n{"name": "' }}
+                {{- tool_call.name }}
+                {{- '", "arguments": ' }}
+                {%- if tool_call.arguments is string %}
+                    {{- tool_call.arguments }}
+                {%- else %}
+                    {{- tool_call.arguments | tojson }}
+                {%- endif %}
+                {{- '}\n</tool_call>' }}
+            {%- endfor %}
+        {%- endif %}
+        {{- '<|im_end|>\n' }}
+    {%- elif message.role == "tool" %}
+        {%- if loop.first or (messages[loop.index0 - 1].role != "tool") %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {{- '\n<tool_response>\n' }}
+        {{- content }}
+        {{- '\n</tool_response>' }}
+        {%- if loop.last or (messages[loop.index0 + 1].role != "tool") %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n<think>\n' }}
+{%- endif %}"##;
+
+    fn qwen3_thinking_formatter() -> HfTokenizerConfigJsonFormatter {
+        let chat_template: ChatTemplate = serde_json::from_value(serde_json::json!({
+            "chat_template": QWEN3_THINKING_TEMPLATE,
+        }))
+        .unwrap();
+        HfTokenizerConfigJsonFormatter::new(chat_template, ContextMixins::new(&[])).unwrap()
+    }
+
+    #[test]
+    fn test_qwen3_thinking_template_flags_detected() {
+        let formatter = qwen3_thinking_formatter();
+        assert!(
+            formatter.template_handles_reasoning,
+            "template references reasoning_content directly"
+        );
+        assert!(
+            formatter.template_handles_arguments_string,
+            "template branches on `arguments is string` and must opt out of arg pre-parsing"
+        );
+    }
+
+    /// Across a multi-step tool-use turn, the rendered prompt for turn N+1
+    /// must be a strict prefix-extension of [turn-N prompt + bytes the model
+    /// emitted on turn N]. Otherwise KV-cache prefix matching falls off a
+    /// cliff every time a tool result comes back.
+    ///
+    /// The Qwen3-Thinking template's `is string` branch (template lines 63-67)
+    /// renders `tool_call.arguments` verbatim from the OpenAI-canonical JSON
+    /// string. Pre-parsing that string into an object forces the `else` branch
+    /// and re-emits with minijinja's compact `tojson`, breaking append-only.
+    #[test]
+    fn test_qwen3_thinking_append_only_across_tool_use_turn() {
+        let formatter = qwen3_thinking_formatter();
+
+        let tools = serde_json::json!([{
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get the current weather for a location",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "location": {"type": "string"},
+                        "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}
+                    },
+                    "required": ["location"]
+                }
+            }
+        }]);
+
+        // Turn 1: server is asked to produce the first assistant turn.
+        let turn1_request: NvCreateChatCompletionRequest =
+            serde_json::from_value(serde_json::json!({
+                "model": "qwen3-thinking",
+                "messages": [
+                    {"role": "system", "content": "You are a helpful assistant."},
+                    {"role": "user", "content": "What's the weather in San Francisco?"},
+                ],
+                "tools": tools,
+            }))
+            .unwrap();
+        let p1 = formatter.render(&turn1_request).unwrap();
+
+        // Bytes the model emits next. Spacing matches the Qwen3 training
+        // distribution (Python jinja2 / json.dumps defaults: `, ` and `: `).
+        // Empty content + reasoning + a tool call.
+        let model_emitted = "I'll call get_weather for SF.\n\
+            </think>\n\n\
+            <tool_call>\n\
+            {\"name\": \"get_weather\", \"arguments\": {\"location\": \"San Francisco\", \"unit\": \"celsius\"}}\n\
+            </tool_call><|im_end|>\n";
+        let wire_after_t1 = format!("{p1}{model_emitted}");
+
+        // Turn 2: client sends the prior assistant turn back in OpenAI canonical
+        // form (arguments as a JSON STRING with spaces) plus the tool result.
+        let turn2_request: NvCreateChatCompletionRequest =
+            serde_json::from_value(serde_json::json!({
+                "model": "qwen3-thinking",
+                "messages": [
+                    {"role": "system", "content": "You are a helpful assistant."},
+                    {"role": "user", "content": "What's the weather in San Francisco?"},
+                    {
+                        "role": "assistant",
+                        "content": "",
+                        "reasoning_content": "I'll call get_weather for SF.",
+                        "tool_calls": [{
+                            "id": "call_sf",
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": "{\"location\": \"San Francisco\", \"unit\": \"celsius\"}"
+                            }
+                        }]
+                    },
+                    {
+                        "role": "tool",
+                        "tool_call_id": "call_sf",
+                        "content": "{\"temp\": 18, \"conditions\": \"Foggy\"}"
+                    }
+                ],
+                "tools": tools,
+            }))
+            .unwrap();
+        let p2 = formatter.render(&turn2_request).unwrap();
+
+        if !p2.starts_with(&wire_after_t1) {
+            // Find first divergence and report it for easy debugging.
+            let div = wire_after_t1
+                .as_bytes()
+                .iter()
+                .zip(p2.as_bytes())
+                .position(|(a, b)| a != b)
+                .unwrap_or_else(|| wire_after_t1.len().min(p2.len()));
+            let lo = div.saturating_sub(40);
+            panic!(
+                "turn-2 prompt is NOT a prefix-extension of [turn-1 + model bytes]\n  \
+                 diverges at byte {div}\n  \
+                 wire ends: ...{}|{}\n  \
+                 t2 has:    ...{}|{}",
+                String::from_utf8_lossy(&wire_after_t1.as_bytes()[lo..div]),
+                String::from_utf8_lossy(
+                    &wire_after_t1.as_bytes()[div..(div + 60).min(wire_after_t1.len())]
+                ),
+                String::from_utf8_lossy(&p2.as_bytes()[lo..div]),
+                String::from_utf8_lossy(&p2.as_bytes()[div..(div + 60).min(p2.len())]),
+            );
+        }
+
+        // The only new bytes in P2 should be the tool response and the next
+        // generation prompt — nothing in the prior conversation should change.
+        let suffix = &p2[wire_after_t1.len()..];
+        assert!(
+            suffix.contains("<tool_response>"),
+            "appended bytes must include the tool response, got: {suffix}"
+        );
+        assert!(
+            suffix.ends_with("<|im_start|>assistant\n<think>\n"),
+            "appended bytes must end with the next generation prompt, got: {suffix}"
         );
     }
 }

--- a/lib/llm/src/preprocessor/prompt/template/oai.rs
+++ b/lib/llm/src/preprocessor/prompt/template/oai.rs
@@ -235,9 +235,11 @@ fn flatten_mixed_content(parts: &[serde_json::Value], placeholder_tpl: &str) -> 
     out
 }
 
-fn normalize_tool_arguments_in_messages(messages: &mut serde_json::Value) {
-    // Deserialize tool call arguments from JSON strings to objects/arrays before template rendering
-    // avoids double encoding and enables iteration
+fn normalize_tool_calls_arguments_in_messages(messages: &mut serde_json::Value) {
+    // Deserialize `tool_calls[].function.arguments` from JSON strings to
+    // objects/arrays before template rendering — avoids double encoding
+    // and enables iteration. Skipped for templates whose own `is string`
+    // branch wants the raw string verbatim (see render()).
     let Some(msgs) = messages.as_array_mut() else {
         return;
     };
@@ -254,7 +256,19 @@ fn normalize_tool_arguments_in_messages(messages: &mut serde_json::Value) {
                 }
             }
         }
+    }
+}
 
+fn normalize_function_call_arguments_in_messages(messages: &mut serde_json::Value) {
+    // Legacy (deprecated) OpenAI `function_call.arguments` path. Kept separate
+    // from `tool_calls` normalization so the per-template `arguments is string`
+    // opt-out — which only refers to `tool_call.arguments` inside the
+    // tool_calls loop — does not accidentally suppress this path.
+    let Some(msgs) = messages.as_array_mut() else {
+        return;
+    };
+
+    for msg in msgs.iter_mut() {
         if let Some(function_call) = msg.get_mut("function_call").and_then(|v| v.as_object_mut())
             && let Some(args) = function_call.get_mut("arguments")
             && let Some(s) = args.as_str()
@@ -521,15 +535,37 @@ impl OAIPromptFormatter for HfTokenizerConfigJsonFormatter {
         ))
         .unwrap();
 
+        // Pick the concrete template first so the normalization opt-out can be
+        // template- and field-specific: only the chosen template's
+        // `tool_call.arguments is string` flag should suppress normalization,
+        // and only for the `tool_calls[].function.arguments` field. Legacy
+        // `function_call.arguments` lives outside that branch and is always
+        // normalized.
+        let (template_name, template_handles_tool_calls_args_string) = if has_tools {
+            (
+                "tool_use",
+                self.tool_use_template_handles_tool_calls_arguments_string,
+            )
+        } else {
+            (
+                "default",
+                self.default_template_handles_tool_calls_arguments_string,
+            )
+        };
+
         // Pre-parse JSON-string `arguments` into objects — but only for templates
         // that unconditionally `| tojson` them. Templates that branch on
         // `tool_call.arguments is string` (Qwen3, Hermes) want the raw string
         // verbatim so the rendered bytes match what the model emitted on the
         // prior turn. Re-serializing through minijinja's compact `tojson` here
         // breaks append-only prefix matching across multi-step tool use.
-        if !self.template_handles_arguments_string {
-            normalize_tool_arguments_in_messages(&mut messages_for_template);
+        if !template_handles_tool_calls_args_string {
+            normalize_tool_calls_arguments_in_messages(&mut messages_for_template);
         }
+        // Legacy `function_call.arguments` is always normalized — the
+        // `arguments is string` opt-out only covers the modern `tool_calls`
+        // branch.
+        normalize_function_call_arguments_in_messages(&mut messages_for_template);
 
         // Inject reasoning_content as <think> blocks into content — but only if
         // the template doesn't handle it natively. Templates like Nemotron and
@@ -557,11 +593,7 @@ impl OAIPromptFormatter for HfTokenizerConfigJsonFormatter {
             ctx
         };
 
-        let tmpl: minijinja::Template<'_, '_> = if has_tools {
-            self.env.get_template("tool_use")?
-        } else {
-            self.env.get_template("default")?
-        };
+        let tmpl: minijinja::Template<'_, '_> = self.env.get_template(template_name)?;
         Ok(tmpl.render(&ctx)?)
     }
 }
@@ -1279,7 +1311,7 @@ NORMAL MODE
             }]
         })]);
 
-        normalize_tool_arguments_in_messages(&mut messages);
+        normalize_tool_calls_arguments_in_messages(&mut messages);
 
         let mut env = Environment::new();
         env.add_filter("tojson", super::super::tokcfg::tojson);
@@ -1312,7 +1344,7 @@ NORMAL MODE
             }]
         })]);
 
-        normalize_tool_arguments_in_messages(&mut messages);
+        normalize_tool_calls_arguments_in_messages(&mut messages);
 
         let mut env = Environment::new();
         env.add_template("t", tmpl).unwrap();
@@ -1336,7 +1368,7 @@ NORMAL MODE
             }
         })]);
 
-        normalize_tool_arguments_in_messages(&mut messages);
+        normalize_function_call_arguments_in_messages(&mut messages);
 
         assert_eq!(
             messages[0]["function_call"]["arguments"],
@@ -1358,7 +1390,7 @@ NORMAL MODE
             }]
         })]);
 
-        normalize_tool_arguments_in_messages(&mut messages);
+        normalize_tool_calls_arguments_in_messages(&mut messages);
 
         assert_eq!(
             messages[0]["tool_calls"][0]["function"]["arguments"],
@@ -1400,7 +1432,7 @@ NORMAL MODE
         let mut messages =
             serde_json::to_value(may_be_fix_msg_content(messages_raw, false, None)).unwrap();
 
-        normalize_tool_arguments_in_messages(&mut messages);
+        normalize_tool_calls_arguments_in_messages(&mut messages);
 
         // Multimodal content preserved as array (mixed types not flattened)
         assert!(messages[0]["content"].is_array());
@@ -2021,9 +2053,15 @@ NORMAL_MODE
             formatter.template_handles_reasoning,
             "template references reasoning_content directly"
         );
+        // The Qwen3-Thinking template is registered as both `default` and
+        // `tool_use` (single-string HF chat template), so both flags must fire.
         assert!(
-            formatter.template_handles_arguments_string,
-            "template branches on `arguments is string` and must opt out of arg pre-parsing"
+            formatter.default_template_handles_tool_calls_arguments_string,
+            "default template branches on `arguments is string`"
+        );
+        assert!(
+            formatter.tool_use_template_handles_tool_calls_arguments_string,
+            "tool_use template branches on `arguments is string`"
         );
     }
 

--- a/lib/parsers/Cargo.toml
+++ b/lib/parsers/Cargo.toml
@@ -28,7 +28,7 @@ keywords.workspace = true
 anyhow = { workspace = true }
 dynamo-protocols = { workspace = true }
 serde = { workspace = true }
-serde_json = { workspace = true }
+serde_json = { workspace = true, features = ["raw_value"] }
 tokio = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }

--- a/lib/parsers/src/tool_calling/json/base_json_parser.rs
+++ b/lib/parsers/src/tool_calling/json/base_json_parser.rs
@@ -108,17 +108,16 @@ fn handle_single_token_tool_calls(input: &str, start_token: &str) -> Option<Stri
             // Handle array format (like phi4: functools[{...}])
             if let Some(pos) = s.rfind(']') {
                 let candidate = &s[..=pos].trim();
-                // Keep only valid JSON arrays
-                if serde_json::from_str::<serde_json::Value>(candidate).is_ok() {
-                    // For arrays, we need to extract the individual objects
-                    if let Ok(serde_json::Value::Array(arr)) =
-                        serde_json::from_str::<serde_json::Value>(candidate)
-                    {
-                        for item in arr {
-                            if let Ok(item_str) = serde_json::to_string(&item) {
-                                items.push(item_str);
-                            }
-                        }
+                // Parse as `Vec<Box<RawValue>>` so each element retains its
+                // original byte span. Going through `serde_json::Value` +
+                // `to_string` here would strip whitespace and reorder keys
+                // inside each tool call's `arguments`, breaking byte-level
+                // append-only across multi-step tool use for parsers that
+                // route through this single-token path (functools, [TOOL_CALLS],
+                // <|python_tag|>).
+                if let Ok(arr) = serde_json::from_str::<Vec<Box<RawValue>>>(candidate) {
+                    for item in arr {
+                        items.push(item.get().to_string());
                     }
                 }
             }

--- a/lib/parsers/src/tool_calling/json/base_json_parser.rs
+++ b/lib/parsers/src/tool_calling/json/base_json_parser.rs
@@ -1,28 +1,34 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
-
 use regex::RegexBuilder;
-use serde_json::Value;
+use serde_json::value::RawValue;
 use uuid::Uuid;
 
 use super::super::ToolDefinition;
 use super::config::JsonParserConfig;
 use super::response::{CalledFunction, ToolCallResponse, ToolCallType};
 
-// Same as CalledFunction with named parameters
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+// Same as CalledFunction with named parameters.
+//
+// `parameters` / `arguments` are deserialized as `Box<RawValue>` so the
+// original byte span — including key order, whitespace, and number
+// formatting — is preserved verbatim. Going through `HashMap<String, Value>`
+// here would normalize via `serde_json::to_string`, which strips spaces and
+// reorders keys based on HashMap iteration. That broke append-only KV-cache
+// prefix matching: when the model's emitted `arguments` were re-rendered
+// through this parser and round-tripped back into the next turn's prompt,
+// the bytes diverged from what the model originally emitted.
+#[derive(Debug, serde::Deserialize)]
 pub struct CalledFunctionParameters {
     pub name: String,
-    pub parameters: HashMap<String, Value>,
+    pub parameters: Box<RawValue>,
 }
 
-// Same as CalledFunction with named parameters
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 pub struct CalledFunctionArguments {
     pub name: String,
-    pub arguments: HashMap<String, Value>,
+    pub arguments: Box<RawValue>,
 }
 
 // Extract the contents between start and end tokens using regex parsing.
@@ -334,16 +340,19 @@ pub fn try_tool_call_parse_basic_json(
     }
     // Convert json (String) to &str
     let json = json.as_str();
-    // Anonymous function to attempt deserialization into a known representation
-    let parse = |name: String, args: HashMap<String, Value>| -> anyhow::Result<ToolCallResponse> {
-        // Preserve nested JSON strings intact; do not double-escape.
-        // serde_json::to_string on Value preserves required escapes only.
+    // Anonymous function to attempt deserialization into a known representation.
+    //
+    // We pass through the original byte span via `RawValue::get()` rather than
+    // re-serializing a parsed `HashMap` / `Value`. That keeps `arguments`
+    // byte-identical to what the model emitted, which is required for KV-cache
+    // append-only prefix matching across multi-step tool use.
+    let parse = |name: String, args: &RawValue| -> anyhow::Result<ToolCallResponse> {
         Ok(ToolCallResponse {
             id: format!("call-{}", Uuid::new_v4()),
             tp: ToolCallType::Function,
             function: CalledFunction {
                 name,
-                arguments: serde_json::to_string(&args)?,
+                arguments: args.get().to_string(),
             },
         })
     };
@@ -359,10 +368,9 @@ pub fn try_tool_call_parse_basic_json(
     // }
     if let Ok(single) = serde_json::from_str::<CalledFunctionParameters>(json) {
         return Ok((
-            vec![parse(single.name, single.parameters)?],
+            vec![parse(single.name, &single.parameters)?],
             Some(normal_text),
         ));
-        //parse(single.name, single.parameters).map(Some);
 
         // CalledFunctionArguments: Single { name, arguments }
         // Example:
@@ -375,7 +383,7 @@ pub fn try_tool_call_parse_basic_json(
         // }
     } else if let Ok(single) = serde_json::from_str::<CalledFunctionArguments>(json) {
         return Ok((
-            vec![parse(single.name, single.arguments)?],
+            vec![parse(single.name, &single.arguments)?],
             Some(normal_text),
         ));
 
@@ -385,17 +393,21 @@ pub fn try_tool_call_parse_basic_json(
     //   { "name": "lookup_user", "parameters": { "user_id": "123" } },
     //   { "name": "get_weather", "arguments": { "location": "SF", "units": "celsius" } }
     // ]
-    // Parse as generic array to handle both formats and malformed entries gracefully
-    // Note: Always return once we parse a valid array, even if empty or with malformed entries
-    } else if let Ok(array) = serde_json::from_str::<Vec<serde_json::Value>>(json) {
+    // Parse the array as `Vec<Box<RawValue>>` so each element retains its
+    // original byte span. Going through `Vec<serde_json::Value>` would
+    // already have mangled the inner `arguments` / `parameters` bytes by the
+    // time we tried to extract them.
+    } else if let Ok(array) = serde_json::from_str::<Vec<Box<RawValue>>>(json) {
         let mut results = Vec::new();
         for item in array {
+            let item_str = item.get();
             // Try both CalledFunctionArguments and CalledFunctionParameters formats
-            if let Ok(func_args) = serde_json::from_value::<CalledFunctionArguments>(item.clone()) {
-                results.push(parse(func_args.name, func_args.arguments)?);
-            } else if let Ok(func_params) = serde_json::from_value::<CalledFunctionParameters>(item)
+            if let Ok(func_args) = serde_json::from_str::<CalledFunctionArguments>(item_str) {
+                results.push(parse(func_args.name, &func_args.arguments)?);
+            } else if let Ok(func_params) =
+                serde_json::from_str::<CalledFunctionParameters>(item_str)
             {
-                results.push(parse(func_params.name, func_params.parameters)?);
+                results.push(parse(func_params.name, &func_params.parameters)?);
             }
             // Skip malformed entries silently
         }
@@ -413,25 +425,24 @@ pub fn try_tool_call_parse_basic_json(
         let repaired = repaired.as_str();
         if let Ok(single) = serde_json::from_str::<CalledFunctionParameters>(repaired) {
             return Ok((
-                vec![parse(single.name, single.parameters)?],
+                vec![parse(single.name, &single.parameters)?],
                 Some(normal_text),
             ));
         } else if let Ok(single) = serde_json::from_str::<CalledFunctionArguments>(repaired) {
             return Ok((
-                vec![parse(single.name, single.arguments)?],
+                vec![parse(single.name, &single.arguments)?],
                 Some(normal_text),
             ));
-        } else if let Ok(array) = serde_json::from_str::<Vec<serde_json::Value>>(repaired) {
+        } else if let Ok(array) = serde_json::from_str::<Vec<Box<RawValue>>>(repaired) {
             let mut results = Vec::new();
             for item in array {
-                if let Ok(func_args) =
-                    serde_json::from_value::<CalledFunctionArguments>(item.clone())
-                {
-                    results.push(parse(func_args.name, func_args.arguments)?);
+                let item_str = item.get();
+                if let Ok(func_args) = serde_json::from_str::<CalledFunctionArguments>(item_str) {
+                    results.push(parse(func_args.name, &func_args.arguments)?);
                 } else if let Ok(func_params) =
-                    serde_json::from_value::<CalledFunctionParameters>(item)
+                    serde_json::from_str::<CalledFunctionParameters>(item_str)
                 {
-                    results.push(parse(func_params.name, func_params.parameters)?);
+                    results.push(parse(func_params.name, &func_params.parameters)?);
                 }
             }
             if !results.is_empty() {

--- a/lib/parsers/src/tool_calling/parsers.rs
+++ b/lib/parsers/src/tool_calling/parsers.rs
@@ -620,6 +620,41 @@ Okay, the user is asking for the weather in San Francisco in Fahrenheit. Let me 
         assert_eq!(result[1].function.arguments, r#"{"k":"v2"}"#);
     }
 
+    /// Single-token-start parsers (`functools`, `[TOOL_CALLS]`,
+    /// `<|python_tag|>`) route arrays through
+    /// `handle_single_token_tool_calls`. That helper previously round-tripped
+    /// each element through `serde_json::Value` + `to_string`, which dropped
+    /// whitespace and reordered keys in `arguments` before the downstream
+    /// `Vec<Box<RawValue>>` parser ever saw them. The fix parses the array
+    /// directly as `Vec<Box<RawValue>>` so each element retains its original
+    /// byte span end-to-end.
+    #[tokio::test]
+    async fn single_token_array_preserves_argument_byte_span_phi4() {
+        let input = r#"functools[{"name":"f","arguments":{"z":1,"a":2,"unit":"celsius"}}]"#;
+        let (result, _) = detect_and_parse_tool_call(input, Some("phi4"), None)
+            .await
+            .unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result[0].function.arguments, r#"{"z":1,"a":2,"unit":"celsius"}"#,
+            "phi4/functools path must preserve key order and absent whitespace verbatim"
+        );
+    }
+
+    #[tokio::test]
+    async fn single_token_array_preserves_argument_byte_span_mistral() {
+        let input = r#"[TOOL_CALLS] [{"name":"f","arguments":{"z":1,"a":2}}, {"name":"g","arguments":{"b":3.0}}]"#;
+        let (result, _) = detect_and_parse_tool_call(input, Some("mistral"), None)
+            .await
+            .unwrap();
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].function.arguments, r#"{"z":1,"a":2}"#);
+        assert_eq!(
+            result[1].function.arguments, r#"{"b":3.0}"#,
+            "numeric formatting (3.0 vs 3) must be preserved"
+        );
+    }
+
     #[tokio::test]
     async fn test_nousresearch_hermes3_llama31_8b_simple() {
         let input = r#"<tool_call>

--- a/lib/parsers/src/tool_calling/parsers.rs
+++ b/lib/parsers/src/tool_calling/parsers.rs
@@ -562,6 +562,65 @@ Okay, the user is asking for the weather in San Francisco in Fahrenheit. Let me 
         assert_eq!(result.len(), 1);
     }
 
+    /// Hermes-style models emit `arguments` as compact JSON (no spaces) on the
+    /// wire. The parser must preserve those exact bytes so the next turn's
+    /// rendered prompt is byte-equivalent to [turn-N prompt + model output],
+    /// keeping KV-cache prefix matching intact across multi-step tool use.
+    /// See PR 9301 for the matching prompt-rendering fix.
+    #[tokio::test]
+    async fn parser_preserves_compact_arguments_byte_span() {
+        let input = r#"<tool_call>{"name": "get_weather", "arguments": {"location":"San Francisco, USA","unit":"celsius"}}</tool_call>"#;
+        let (result, _) = detect_and_parse_tool_call(input, Some("hermes"), None)
+            .await
+            .unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result[0].function.arguments,
+            r#"{"location":"San Francisco, USA","unit":"celsius"}"#,
+            "arguments must be preserved byte-for-byte (no `, ` or `: ` injected)"
+        );
+    }
+
+    /// HashMap iteration order is randomized; key order in the output of a
+    /// `HashMap` round-trip would not match what the model emitted. With
+    /// RawValue passthrough, the order survives.
+    #[tokio::test]
+    async fn parser_preserves_argument_key_order() {
+        let input = r#"<tool_call>{"name":"f","arguments":{"z":1,"a":2,"m":3}}</tool_call>"#;
+        let (result, _) = detect_and_parse_tool_call(input, Some("hermes"), None)
+            .await
+            .unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].function.arguments, r#"{"z":1,"a":2,"m":3}"#);
+    }
+
+    /// Numeric formatting (e.g. `1.0` vs `1`) must survive round-tripping;
+    /// `serde_json::Value` parses `1.0` as `Number::F64(1.0)` and may
+    /// serialize differently than what the model emitted.
+    #[tokio::test]
+    async fn parser_preserves_numeric_formatting() {
+        let input = r#"<tool_call>{"name":"f","arguments":{"x":1.0,"y":42}}</tool_call>"#;
+        let (result, _) = detect_and_parse_tool_call(input, Some("hermes"), None)
+            .await
+            .unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].function.arguments, r#"{"x":1.0,"y":42}"#);
+    }
+
+    /// Parallel tool_calls each go through the array-deserialization path
+    /// (`Vec<Box<RawValue>>`); each element's byte span must be independent.
+    #[tokio::test]
+    async fn parser_preserves_byte_span_for_parallel_calls() {
+        let input = r#"<tool_call>{"name":"a","arguments":{"k":"v1"}}</tool_call>
+<tool_call>{"name":"b","arguments":{"k":"v2"}}</tool_call>"#;
+        let (result, _) = detect_and_parse_tool_call(input, Some("hermes"), None)
+            .await
+            .unwrap();
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].function.arguments, r#"{"k":"v1"}"#);
+        assert_eq!(result[1].function.arguments, r#"{"k":"v2"}"#);
+    }
+
     #[tokio::test]
     async fn test_nousresearch_hermes3_llama31_8b_simple() {
         let input = r#"<tool_call>

--- a/lib/parsers/src/tool_calling/parsers.rs
+++ b/lib/parsers/src/tool_calling/parsers.rs
@@ -575,8 +575,7 @@ Okay, the user is asking for the weather in San Francisco in Fahrenheit. Let me 
             .unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(
-            result[0].function.arguments,
-            r#"{"location":"San Francisco, USA","unit":"celsius"}"#,
+            result[0].function.arguments, r#"{"location":"San Francisco, USA","unit":"celsius"}"#,
             "arguments must be preserved byte-for-byte (no `, ` or `: ` injected)"
         );
     }


### PR DESCRIPTION
## Summary

- Qwen3-Thinking, Hermes, and similar templates branch on `tool_call.arguments is string` and emit the OpenAI-canonical JSON string verbatim — preserving exactly the bytes the model produced on the prior turn.
- Dynamo's `normalize_tool_arguments_in_messages` pre-parses that string into an object, which forces the template's `else` branch to fire and re-emit via minijinja's compact `tojson` (no spaces). The result no longer matches what the model emitted, so turn `N+1`'s prompt is **not** a strict prefix-extension of turn `N`'s wire output. KV-cache prefix matching breaks on every multi-step tool-use round.
- Fix: detect templates that contain `arguments is string` at template-load time (mirrors the existing `template_handles_reasoning` flag) and skip normalization for them. Templates without the branch still get the pre-parsing behavior so unconditional `tojson` of arguments continues to work.

## Repro / observed divergence

Same conversation, rendered through the real `Qwen/Qwen3-4B-Thinking-2507` template:

```
wire (turn 1, what the model emitted): "arguments": {"location": "San Francisco", "unit": "celsius"}
dynamo turn-2 re-render (before fix):  "arguments": {"location":"San Francisco","unit":"celsius"}
                                                              ^ space dropped → bytes diverge
```

vLLM (Python jinja2) renders the prior assistant turn byte-identically to what was on the wire and remains append-only. Dynamo, before this fix, does not.

## What changes

- `template.rs`: new `template_handles_arguments_string: bool` field on `HfTokenizerConfigJsonFormatter`.
- `formatters.rs`: detect the flag at template-load time by scanning template source for the literal `arguments is string`.
- `oai.rs`: gate `normalize_tool_arguments_in_messages` on `!template_handles_arguments_string`.

## Tests

Two new tests in `lib/llm/src/preprocessor/prompt/template/oai.rs`, both against the real Qwen3-4B-Thinking-2507 chat template embedded verbatim:

- `test_qwen3_thinking_template_flags_detected` — sanity: both `template_handles_reasoning` and `template_handles_arguments_string` are detected.
- `test_qwen3_thinking_append_only_across_tool_use_turn` — renders turn 1 (system + user), constructs the bytes the model would emit (jinja2-default spacing), renders turn 2 (system + user + assistant_with_tool_call + tool_response), and asserts `turn2.starts_with(turn1 + model_emitted_bytes)`.

Verified that the new test fails when the gate is forced off (regression catches the exact byte-level divergence in the tool_call arguments). With the gate in place, all 47 `preprocessor::prompt::template` tests and the broader 93 `preprocessor` tests pass. Existing `test_normalize_tool_arguments_*` tests use minimal templates without the `is string` branch and continue to exercise the pre-parsing path.

## Test plan

- [x] `cargo test -p dynamo-llm --lib preprocessor::prompt::template` — 47 passed
- [x] `cargo test -p dynamo-llm --lib preprocessor` — 93 passed
- [x] Forced-regression check: temporarily disabling the gate (`|| true`) makes the new append-only test fail at the expected byte offset, confirming it catches the bug.
- [x] End-to-end: serve a Qwen3-Thinking model, run a multi-turn tool-use conversation, and confirm KV prefix-cache hit rate is restored across tool result turns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for templates that handle tool call arguments as raw JSON strings, improving compatibility with advanced language models.

* **Bug Fixes**
  * Fixed tool argument JSON formatting preservation across multi-turn conversations to ensure exact byte-level consistency.

* **Tests**
  * Added regression tests to verify tool call argument preservation and multi-turn tool use behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9301)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->