### PR TITLE
fix(runtime): enforce singleton claims without races

### DIFF
--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -1739,6 +1739,7 @@ dependencies = [
  "serde",
  "serde_json",
  "socket2 0.5.10",
+ "tempfile",
  "thiserror 2.0.18",
  "tmq",
  "tokio",

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -2316,6 +2316,7 @@ dependencies = [
  "serde",
  "serde_json",
  "socket2 0.5.10",
+ "tempfile",
  "thiserror 2.0.18",
  "tmq",
  "tokio",

--- a/lib/llm/src/kv_router/indexer/remote.rs
+++ b/lib/llm/src/kv_router/indexer/remote.rs
@@ -235,14 +235,13 @@ impl ServedIndexerMode {
 
 struct ServedIndexerService {
     mode: ServedIndexerMode,
-    _owns_singleton_claim: bool,
     bindings: Arc<RwLock<HashMap<String, Indexer>>>,
 }
 
 impl ServedIndexerService {
     async fn start(component: Component, mode: ServedIndexerMode) -> Result<Arc<Self>> {
         verify_service_topology(&component, mode).await?;
-        let owns_singleton_claim = claim_served_indexer_singleton(&component, mode).await?;
+        claim_served_indexer_singleton(&component, mode).await?;
 
         let bindings = Arc::new(RwLock::new(HashMap::new()));
         start_query_endpoint(component.clone(), bindings.clone())?;
@@ -250,11 +249,7 @@ impl ServedIndexerService {
             start_record_endpoint(component.clone(), bindings.clone())?;
         }
 
-        Ok(Arc::new(Self {
-            mode,
-            _owns_singleton_claim: owns_singleton_claim,
-            bindings,
-        }))
+        Ok(Arc::new(Self { mode, bindings }))
     }
 }
 
@@ -380,9 +375,9 @@ async fn verify_service_topology(component: &Component, mode: ServedIndexerMode)
 async fn claim_served_indexer_singleton(
     component: &Component,
     mode: ServedIndexerMode,
-) -> Result<bool> {
+) -> Result<()> {
     if mode != ServedIndexerMode::Approximate {
-        return Ok(false);
+        return Ok(());
     }
 
     let namespace = component.namespace().name();
@@ -402,7 +397,7 @@ async fn claim_served_indexer_singleton(
         .try_claim_singleton(&claim_key, payload)
         .await?
     {
-        return Ok(true);
+        return Ok(());
     }
 
     anyhow::bail!(

--- a/lib/llm/src/kv_router/indexer/remote.rs
+++ b/lib/llm/src/kv_router/indexer/remote.rs
@@ -235,12 +235,14 @@ impl ServedIndexerMode {
 
 struct ServedIndexerService {
     mode: ServedIndexerMode,
+    _owns_singleton_claim: bool,
     bindings: Arc<RwLock<HashMap<String, Indexer>>>,
 }
 
 impl ServedIndexerService {
     async fn start(component: Component, mode: ServedIndexerMode) -> Result<Arc<Self>> {
         verify_service_topology(&component, mode).await?;
+        let owns_singleton_claim = claim_served_indexer_singleton(&component, mode).await?;
 
         let bindings = Arc::new(RwLock::new(HashMap::new()));
         start_query_endpoint(component.clone(), bindings.clone())?;
@@ -248,7 +250,11 @@ impl ServedIndexerService {
             start_record_endpoint(component.clone(), bindings.clone())?;
         }
 
-        Ok(Arc::new(Self { mode, bindings }))
+        Ok(Arc::new(Self {
+            mode,
+            _owns_singleton_claim: owns_singleton_claim,
+            bindings,
+        }))
     }
 }
 
@@ -369,6 +375,41 @@ async fn verify_service_topology(component: &Component, mode: ServedIndexerMode)
     }
 
     Ok(())
+}
+
+async fn claim_served_indexer_singleton(
+    component: &Component,
+    mode: ServedIndexerMode,
+) -> Result<bool> {
+    if mode != ServedIndexerMode::Approximate {
+        return Ok(false);
+    }
+
+    let namespace = component.namespace().name();
+    let component_name = component.name();
+    let claim_key = format!("remote-indexer/approximate/{namespace}/{component_name}");
+    let instance_id = component.drt().connection_id();
+    let payload = serde_json::json!({
+        "namespace": namespace,
+        "component": component_name,
+        "mode": mode.topology_label(),
+        "instance_id": instance_id,
+    });
+
+    if component
+        .drt()
+        .discovery()
+        .try_claim_singleton(&claim_key, payload)
+        .await?
+    {
+        return Ok(true);
+    }
+
+    anyhow::bail!(
+        "cannot start approximate served indexer on {}.{}: singleton claim already exists",
+        namespace,
+        component_name
+    );
 }
 
 fn start_query_endpoint(

--- a/lib/runtime/Cargo.toml
+++ b/lib/runtime/Cargo.toml
@@ -53,6 +53,7 @@ reqwest = { workspace = true }
 rmp-serde = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+tempfile = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
 tokio-util = { workspace = true }
@@ -103,7 +104,6 @@ rstest = { version = "0.23.0" }
 temp-env = { version = "0.3.6" , features=["async_closure"] }
 stdio-override = {version= "0.2.0"}
 jsonschema = {version = "0.17"}
-tempfile = { workspace = true }
 
 [[bench]]
 name = "compute_pool_overhead"

--- a/lib/runtime/examples/Cargo.lock
+++ b/lib/runtime/examples/Cargo.lock
@@ -848,6 +848,7 @@ dependencies = [
  "serde",
  "serde_json",
  "socket2 0.5.10",
+ "tempfile",
  "thiserror 2.0.18",
  "tmq",
  "tokio",

--- a/lib/runtime/src/discovery/kube.rs
+++ b/lib/runtime/src/discovery/kube.rs
@@ -199,6 +199,20 @@ impl Discovery for KubeDiscoveryClient {
         Ok(instance)
     }
 
+    async fn try_claim_singleton(
+        &self,
+        claim_key: &str,
+        _payload: serde_json::Value,
+    ) -> Result<bool> {
+        // TODO: Back this with an atomic Kubernetes resource create. For now this
+        // keeps Kubernetes discovery compatible with approximate served indexers.
+        tracing::warn!(
+            claim_key,
+            "Kubernetes discovery singleton claim is advisory and not atomically enforced"
+        );
+        Ok(true)
+    }
+
     async fn unregister(&self, instance: DiscoveryInstance) -> Result<()> {
         let instance_id = self.instance_id();
 

--- a/lib/runtime/src/discovery/kv_store.rs
+++ b/lib/runtime/src/discovery/kv_store.rs
@@ -3,6 +3,7 @@
 
 use std::pin::Pin;
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -19,6 +20,8 @@ use crate::storage::kv;
 const INSTANCES_BUCKET: &str = "v1/instances";
 const MODELS_BUCKET: &str = "v1/mdc";
 const EVENT_CHANNELS_BUCKET: &str = "v1/event_channels";
+const CLAIMS_BUCKET: &str = "v1/claims";
+const CLAIM_TTL: Duration = Duration::from_secs(10);
 
 /// Discovery implementation backed by a kv::Store
 pub struct KVStoreDiscovery {
@@ -276,6 +279,24 @@ impl Discovery for KVStoreDiscovery {
         );
 
         Ok(instance)
+    }
+
+    async fn try_claim_singleton(
+        &self,
+        claim_key: &str,
+        payload: serde_json::Value,
+    ) -> Result<bool> {
+        let bucket = self
+            .store
+            .get_or_create_bucket(CLAIMS_BUCKET, Some(CLAIM_TTL))
+            .await?;
+        let key = kv::Key::new(claim_key.to_string());
+        let payload = serde_json::to_vec(&payload)?;
+
+        match bucket.insert(&key, payload.into(), 0).await? {
+            kv::StoreOutcome::Created(_) => Ok(true),
+            kv::StoreOutcome::Exists(_) => Ok(false),
+        }
     }
 
     async fn unregister(&self, instance: DiscoveryInstance) -> Result<()> {
@@ -601,6 +622,7 @@ impl Discovery for KVStoreDiscovery {
 mod tests {
     use super::*;
     use crate::component::TransportType;
+    use serde_json::json;
 
     #[tokio::test]
     async fn test_kv_store_discovery_register_endpoint() {
@@ -727,6 +749,29 @@ mod tests {
         }
 
         register_task.await.unwrap();
+        cancel_token.cancel();
+    }
+
+    #[tokio::test]
+    async fn test_kv_store_discovery_singleton_claim() {
+        let store = kv::Manager::memory();
+        let cancel_token = CancellationToken::new();
+        let client_a = KVStoreDiscovery::new(store.clone(), cancel_token.clone());
+        let client_b = KVStoreDiscovery::new(store, cancel_token.clone());
+
+        assert!(
+            client_a
+                .try_claim_singleton("test/comp/approximate-indexer", json!({ "owner": "a" }))
+                .await
+                .unwrap()
+        );
+        assert!(
+            !client_b
+                .try_claim_singleton("test/comp/approximate-indexer", json!({ "owner": "b" }))
+                .await
+                .unwrap()
+        );
+
         cancel_token.cancel();
     }
 }

--- a/lib/runtime/src/discovery/mod.rs
+++ b/lib/runtime/src/discovery/mod.rs
@@ -836,6 +836,20 @@ pub trait Discovery: Send + Sync {
     /// Backend-specific raw registration implementation.
     async fn register_internal(&self, spec: DiscoverySpec) -> Result<DiscoveryInstance>;
 
+    /// Atomically claim a singleton discovery-scoped resource.
+    ///
+    /// Returns `true` when this process acquired the claim and `false` when
+    /// another process already owns it. Backends that cannot provide atomic
+    /// create-if-absent semantics should leave this unsupported.
+    async fn try_claim_singleton(
+        &self,
+        claim_key: &str,
+        payload: serde_json::Value,
+    ) -> Result<bool> {
+        let _ = payload;
+        anyhow::bail!("discovery backend does not support singleton claims for key {claim_key}");
+    }
+
     /// Unregisters an instance from the discovery plane
     async fn unregister(&self, instance: DiscoveryInstance) -> Result<()>;
 

--- a/lib/runtime/src/storage/kv/file.rs
+++ b/lib/runtime/src/storage/kv/file.rs
@@ -7,6 +7,8 @@ use std::ffi::OsString;
 use std::fmt;
 use std::fs;
 use std::fs::OpenOptions;
+use std::io::ErrorKind;
+use std::io::Write;
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -20,6 +22,7 @@ use async_trait::async_trait;
 use futures::StreamExt;
 use notify::{Config, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher, event};
 use parking_lot::Mutex;
+use tempfile::Builder as TempFileBuilder;
 use tokio_util::sync::CancellationToken;
 
 use super::{Bucket, Key, KeyValue, Store, StoreError, StoreOutcome, WatchEvent};
@@ -301,25 +304,36 @@ impl Bucket for Directory {
         &self,
         key: &Key,
         value: bytes::Bytes,
-        _revision: u64, // Not used. Maybe put in file name?
+        revision: u64, // Not used for update versioning. Maybe put in file name?
     ) -> Result<StoreOutcome, StoreError> {
         let safe_key = key.url_safe();
         let full_path = self.p.join(safe_key.as_ref());
-        let str_path = full_path.display().to_string();
-
-        // Use atomic write: write to temp file, then rename.
-        // This prevents watchers from seeing partially written files.
-        let temp_name = format!("{TEMP_FILE_PREFIX}{:016x}", rand::random::<u64>());
-        let temp_path = self.p.join(&temp_name);
-
-        // Write to temp file first
-        fs::write(&temp_path, &value)
-            .with_context(|| format!("writing temp file {}", temp_path.display()))
+        let mut temp_file = TempFileBuilder::new()
+            .prefix(TEMP_FILE_PREFIX)
+            .tempfile_in(&self.p)
+            .with_context(|| format!("creating temp file in {}", self.p.display()))
+            .map_err(a_to_fs_err)?;
+        temp_file
+            .write_all(&value)
+            .with_context(|| format!("writing temp file {}", temp_file.path().display()))
             .map_err(a_to_fs_err)?;
 
-        // Atomic rename to target path
-        fs::rename(&temp_path, &full_path)
-            .with_context(|| format!("renaming {} to {}", temp_path.display(), str_path))
+        if revision == 0 {
+            return match temp_file.persist_noclobber(&full_path) {
+                Ok(_) => {
+                    self.owned_files.lock().insert(full_path.clone());
+                    Ok(StoreOutcome::Created(0))
+                }
+                Err(err) if err.error.kind() == ErrorKind::AlreadyExists => {
+                    Ok(StoreOutcome::Exists(0))
+                }
+                Err(err) => Err(to_fs_err(err.error)),
+            };
+        }
+
+        temp_file
+            .persist(&full_path)
+            .with_context(|| format!("persisting temp file to {}", full_path.display()))
             .map_err(a_to_fs_err)?;
 
         self.owned_files.lock().insert(full_path.clone());
@@ -523,7 +537,7 @@ mod tests {
 
     use tokio_util::sync::CancellationToken;
 
-    use crate::storage::kv::{Bucket as _, FileStore, Key, Store as _};
+    use crate::storage::kv::{Bucket as _, FileStore, Key, Store as _, StoreOutcome};
 
     #[tokio::test]
     async fn test_entries_full_path() {
@@ -546,5 +560,66 @@ mod tests {
 
         assert!(keys.contains(&Key::new("v1/tests/key1/multi/part".to_string())));
         assert!(keys.contains(&Key::new("v1/tests/key2".to_string())));
+    }
+
+    #[tokio::test]
+    async fn test_insert_revision_zero_is_create_if_absent() {
+        let t = tempfile::tempdir().unwrap();
+
+        let cancel_token = CancellationToken::new();
+        let m = FileStore::new(cancel_token.clone(), t.path());
+        let bucket = m.get_or_create_bucket("v1/tests", None).await.unwrap();
+        let key = Key::new("singleton".to_string());
+
+        let first = bucket.insert(&key, "winner".into(), 0).await.unwrap();
+        let second = bucket.insert(&key, "loser".into(), 0).await.unwrap();
+        let value = bucket.get(&key).await.unwrap().unwrap();
+        cancel_token.cancel();
+
+        assert_eq!(first, StoreOutcome::Created(0));
+        assert_eq!(second, StoreOutcome::Exists(0));
+        assert_eq!(value.as_ref(), b"winner");
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_insert_revision_zero_has_one_winner() {
+        let t = tempfile::tempdir().unwrap();
+        let root = t.path().to_path_buf();
+        let key = Key::new("singleton".to_string());
+
+        let mut tasks = Vec::new();
+        for index in 0..16 {
+            let root = root.clone();
+            let key = key.clone();
+            tasks.push(tokio::spawn(async move {
+                let cancel_token = CancellationToken::new();
+                let store = FileStore::new(cancel_token.clone(), root);
+                let bucket = store.get_or_create_bucket("v1/claims", None).await.unwrap();
+                let value = format!("value-{index}");
+                let outcome = bucket.insert(&key, value.clone().into(), 0).await.unwrap();
+                let stored = bucket.get(&key).await.unwrap().unwrap();
+                cancel_token.cancel();
+                (outcome, String::from_utf8(stored.to_vec()).unwrap(), value)
+            }));
+        }
+
+        let mut created_values = Vec::new();
+        let mut observed_values = HashSet::new();
+        for task in tasks {
+            let (outcome, stored, attempted) = task.await.unwrap();
+            observed_values.insert(stored);
+            if outcome == StoreOutcome::Created(0) {
+                created_values.push(attempted);
+            } else {
+                assert_eq!(outcome, StoreOutcome::Exists(0));
+            }
+        }
+
+        assert_eq!(created_values.len(), 1);
+        assert_eq!(observed_values.len(), 1);
+        assert_eq!(
+            observed_values.into_iter().next().unwrap(),
+            created_values.pop().unwrap()
+        );
     }
 }


### PR DESCRIPTION
Adds an atomic singleton claim path for served remote indexers and gives file-backed KV create-if-absent semantics matching etcd. Also updates standalone lockfiles for the promoted tempfile runtime dependency.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9302" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure & Reliability**
  * Enhanced atomic persistence in file-based storage system for safer data writes.
  * Added distributed singleton-claim mechanism to ensure coordinated service operations and prevent conflicts in multi-instance deployments.
  * Improved service lifecycle management with enhanced topology verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->