### PR TITLE
perf(vllm): NCCL stream-fence sync for shared multimodal EC arena

### DIFF
--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -558,6 +558,8 @@ def setup_vllm_engine(
         not config.route_to_encoder
         and config.multimodal_embedding_cache_capacity_gb > 0
     ):
+        import uuid
+
         from vllm.config import ECTransferConfig
 
         logger.info(
@@ -567,6 +569,10 @@ def setup_vllm_engine(
         )
         instance_id = 0
         engine_id = f"{config.namespace}.{config.component}.backend.{instance_id}"
+        # Nonce disambiguates the POSIX shm name across concurrent engines
+        # on the same host — generated once on the parent and threaded
+        # through extra_config so every TP worker sees the same value.
+        shared_arena_nonce = uuid.uuid4().hex
         engine_args.ec_transfer_config = ECTransferConfig(
             engine_id=engine_id,
             ec_role="ec_both",
@@ -574,9 +580,14 @@ def setup_vllm_engine(
             ec_connector_module_path="dynamo.vllm.multimodal_utils.multimodal_embedding_cache_connector",
             ec_connector_extra_config={
                 "multimodal_embedding_cache_capacity_gb": config.multimodal_embedding_cache_capacity_gb,
+                "shared_arena_nonce": shared_arena_nonce,
             },
         )
-        logger.info("Configured ec_both with engine_id=%s", engine_id)
+        logger.info(
+            "Configured ec_both with engine_id=%s shared_arena_nonce=%s",
+            engine_id,
+            shared_arena_nonce[:8],
+        )
 
     # Taken from build_async_engine_client_from_engine_args()
     usage_context = UsageContext.OPENAI_API_SERVER

--- a/components/src/dynamo/vllm/multimodal_utils/multimodal_embedding_cache_connector.py
+++ b/components/src/dynamo/vllm/multimodal_utils/multimodal_embedding_cache_connector.py
@@ -330,7 +330,12 @@ class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
         )
         mm_cfg = getattr(vllm_config.model_config, "multimodal_config", None)
         mm_encoder_only = bool(getattr(mm_cfg, "mm_encoder_only", False))
-        env_disabled = os.environ.get("DYN_EC_NCCL_FENCE", "1") == "0"
+        env_disabled = os.environ.get("DYN_EC_NCCL_FENCE", "1").strip().lower() in (
+            "0",
+            "false",
+            "no",
+            "off",
+        )
         self._nccl_fence_active: bool = (
             role == ECConnectorRole.WORKER
             and self._tp_world_size > 1
@@ -348,7 +353,7 @@ class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
         elif mm_encoder_only:
             self._fence_reason = "mm_encoder_only"
         elif env_disabled:
-            self._fence_reason = "DYN_EC_NCCL_FENCE=0"
+            self._fence_reason = "DYN_EC_NCCL_FENCE_disabled"
         elif arch not in KNOWN_TP_NCCL_FORWARD_MODELS:
             self._fence_reason = f"arch_not_allowlisted:{arch}"
         else:
@@ -418,8 +423,11 @@ class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
             return False
         # Lazy promotion: an entry is considered safely loaded once at least
         # one full scheduling step has elapsed since it was saved. By that
-        # point the worker has called `_on_step_begin` (post-save), which
-        # drained save_stream on every rank, and the bytes are visible.
+        # point the prior step's worker fence has run — under Plan B this
+        # is `clear_connector_metadata`'s wait_event chained into the LLM
+        # forward's TP NCCL all-reduce; under Plan A it is `_on_step_begin`'s
+        # CPU drain + `dist.barrier`. Either way the D2H is globally visible
+        # across ranks before any H2D in this step issues.
         if entry.state == "PENDING" and entry.save_step < self._scheduling_step:
             entry.state = "READY"
         if entry.state == "READY":

--- a/components/src/dynamo/vllm/multimodal_utils/multimodal_embedding_cache_connector.py
+++ b/components/src/dynamo/vllm/multimodal_utils/multimodal_embedding_cache_connector.py
@@ -314,10 +314,23 @@ class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
         self._worker_initialized: bool = False
         self._released: bool = False
 
-        # Plan B: latest save_done event recorded this step, drained at
-        # `clear_connector_metadata` against compute_stream so the LLM
-        # forward's TP NCCL all-reduce serves as the cross-rank fence.
-        self._latest_save_event: torch.cuda.Event | None = None
+        # Plan B: one CUDA event per step instead of one per save. The
+        # flag is set in `save_caches` whenever a D2H is enqueued on
+        # `_save_stream`; `clear_connector_metadata` then records a
+        # single event at the stream's tail and waits on it from
+        # compute_stream. Equivalent to per-save events because every
+        # D2H this step is enqueued serially on the same stream, but
+        # collapses N cudaEventCreate+Record down to 1.
+        self._save_pending_this_step: bool = False
+
+        # O(1) per-step `mm_hash -> _SaveCmd` lookup, populated in
+        # `bind_connector_metadata`. Replaces the per-call linear scan
+        # in `save_caches` (model_runner invokes save_caches once per
+        # produced encoder output → was O(N²) per step). Filtered to
+        # `writer_rank == _tp_rank` once `_setup_worker` has run; the
+        # `writer_rank != _tp_rank` early-return in `save_caches`
+        # remains the correctness boundary.
+        self._save_cmd_by_hash: dict[str, _SaveCmd] = {}
 
         # Plan B activation gate: the model's LLM forward must be known
         # to issue a same-stream TP NCCL all-reduce after _execute_mm_encoder.
@@ -534,6 +547,36 @@ class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
     # Worker-side
     # ==================================================================
 
+    def bind_connector_metadata(self, connector_metadata: ECConnectorMetadata) -> None:
+        """Build the per-step `mm_hash -> _SaveCmd` lookup so `save_caches`
+        runs in O(1). The model_runner invokes `save_caches` once per
+        produced encoder output, so the previous linear scan over
+        `metadata.saves` was O(N²) per step.
+
+        On the very first multimodal-active step `_setup_worker` has
+        not yet run, so `_tp_rank` is still its default 0 — build an
+        unfiltered dict in that case (slightly more dict entries on
+        non-writer ranks for one step). The `writer_rank != _tp_rank`
+        early-return in `save_caches` remains the correctness gate
+        regardless.
+        """
+        super().bind_connector_metadata(connector_metadata)
+        if not isinstance(
+            connector_metadata, MultimodalEmbeddingCacheConnectorMetadata
+        ):
+            self._save_cmd_by_hash = {}
+            return
+        if self._worker_initialized:
+            self._save_cmd_by_hash = {
+                cmd.mm_hash: cmd
+                for cmd in connector_metadata.saves
+                if cmd.writer_rank == self._tp_rank
+            }
+        else:
+            self._save_cmd_by_hash = {
+                cmd.mm_hash: cmd for cmd in connector_metadata.saves
+            }
+
     def _setup_worker(self) -> None:
         """Allocate shm, cudaHostRegister, build the arena view, and create
         save_stream. Invoked lazily on the first non-empty metadata cycle so
@@ -675,21 +718,49 @@ class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
         self._on_step_begin()
 
         compute = torch.cuda.current_stream()
-        for cmd in metadata.loads:
-            if cmd.mm_hash in encoder_cache:
-                continue
+        # Coalesce contiguous arena spans into one cudaMemcpyAsync each.
+        # For hit-heavy steps in big-model sweeps (e.g. 397B / conc=30 /
+        # 5 imgs), the alternative is many small H2Ds. Sort by offset,
+        # walk groups of contiguous cmds, issue one H2D per group, then
+        # expose per-cmd tensors as PyTorch views into the packed
+        # allocation. The packed Storage is ref-counted by the views,
+        # and `record_stream(compute)` on each view tags that shared
+        # Storage, so the packed buffer lives until every view's
+        # compute consumption completes. Degrades cleanly to per-load
+        # H2D when no spans are contiguous (no regression vs prior).
+        pending = [c for c in metadata.loads if c.mm_hash not in encoder_cache]
+        pending.sort(key=lambda c: c.offset)
+        i, n = 0, len(pending)
+        while i < n:
+            j = i + 1
+            while (
+                j < n
+                and pending[j - 1].offset + pending[j - 1].nbytes == pending[j].offset
+            ):
+                j += 1
+
             assert self._arena_uint8 is not None
-            # H2D as raw bytes, then reinterpret on the GPU side.
-            cpu_uint8 = self._arena_uint8.narrow(0, cmd.offset, cmd.nbytes)
-            gpu_uint8 = cpu_uint8.to(device=compute.device, non_blocking=True)
-            gpu_tensor = gpu_uint8.view(self._model_dtype).view(
-                cmd.num_embeds, self._feature_dim
-            )
-            # Tell the caching allocator the destination is consumed by
-            # compute; vLLM may pop encoder_cache[h] before compute drains.
-            gpu_tensor.record_stream(compute)
-            encoder_cache[cmd.mm_hash] = gpu_tensor
-            self._loads_issued += 1
+            group = pending[i:j]
+            group_start = group[0].offset
+            group_total = group[-1].offset + group[-1].nbytes - group_start
+            cpu_uint8 = self._arena_uint8.narrow(0, group_start, group_total)
+            packed = cpu_uint8.to(device=compute.device, non_blocking=True)
+
+            for cmd in group:
+                rel = cmd.offset - group_start
+                view = (
+                    packed.narrow(0, rel, cmd.nbytes)
+                    .view(self._model_dtype)
+                    .view(cmd.num_embeds, self._feature_dim)
+                )
+                # Tag the underlying packed Storage so the caching
+                # allocator keeps it alive until compute drains; vLLM
+                # may pop encoder_cache[h] before that point.
+                view.record_stream(compute)
+                encoder_cache[cmd.mm_hash] = view
+                self._loads_issued += 1
+
+            i = j
 
         # Evict commands carry no worker-side state to clean up — the
         # scheduler-side allocator owns slot lifetime.
@@ -702,11 +773,7 @@ class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
         metadata = self._get_connector_metadata()
         assert isinstance(metadata, MultimodalEmbeddingCacheConnectorMetadata)
 
-        save_cmd: _SaveCmd | None = None
-        for cmd in metadata.saves:
-            if cmd.mm_hash == mm_hash:
-                save_cmd = cmd
-                break
+        save_cmd = self._save_cmd_by_hash.get(mm_hash)
         if save_cmd is None:
             return
         if not self._worker_initialized:
@@ -755,25 +822,39 @@ class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
         self._saves_issued += 1
 
         if self._nccl_fence_active:
-            # Plan B: record the save_done event on save_stream and keep the
-            # most recent one for this step. clear_connector_metadata will
-            # drain it against compute_stream so the next LLM-forward NCCL
-            # all-reduce serves as the cross-rank fence.
-            done = torch.cuda.Event()
-            done.record(self._save_stream)
-            self._latest_save_event = done
+            # Plan B: just mark that a D2H was enqueued on save_stream
+            # this step. `clear_connector_metadata` records exactly one
+            # event at the stream's tail, which strictly happens-after
+            # every save enqueued serially on the same stream. One
+            # cudaEventCreate+Record per step instead of one per save.
+            self._save_pending_this_step = True
 
     def clear_connector_metadata(self) -> None:
-        """Plan B fence point. After every metadata-bearing step, drain
-        the latest save_done event against compute_stream. The next op on
-        compute_stream is the LLM forward's first TP all-reduce — that NCCL
-        collective is the cross-rank visibility point.
+        """Plan B fence point + per-step state reset.
 
-        Plan A path leaves _latest_save_event as None (we never record it
-        in save_caches when the fence is inactive), so this is a no-op."""
-        if self._latest_save_event is not None:
-            torch.cuda.current_stream().wait_event(self._latest_save_event)
-            self._latest_save_event = None
+        Plan B: if any D2H was enqueued on `_save_stream` this step,
+        record one CUDA event at the stream's tail and have
+        compute_stream wait on it. The next op on compute_stream is
+        the LLM forward's first TP all-reduce — that NCCL collective
+        is the cross-rank visibility point. Recording the event here
+        instead of inside `save_caches` collapses N events per step
+        down to 1; equivalent because every D2H this step is enqueued
+        serially on the same stream.
+
+        Plan A path leaves `_save_pending_this_step` False, so the
+        fence branch is a no-op.
+
+        Always reset the per-step `_save_cmd_by_hash` dict so we
+        don't pin _SaveCmd objects across non-multimodal steps where
+        `bind_connector_metadata` may not be re-called with our type.
+        """
+        if self._save_pending_this_step:
+            assert self._save_stream is not None
+            done = torch.cuda.Event()
+            done.record(self._save_stream)
+            torch.cuda.current_stream().wait_event(done)
+            self._save_pending_this_step = False
+        self._save_cmd_by_hash = {}
         super().clear_connector_metadata()
 
     # ==================================================================

--- a/components/src/dynamo/vllm/multimodal_utils/multimodal_embedding_cache_connector.py
+++ b/components/src/dynamo/vllm/multimodal_utils/multimodal_embedding_cache_connector.py
@@ -1,9 +1,13 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import logging
+import atexit
+import ctypes
+import hashlib
+import os
 from collections import OrderedDict
 from dataclasses import dataclass, field
+from multiprocessing import shared_memory
 from typing import TYPE_CHECKING
 
 import torch
@@ -14,6 +18,7 @@ from vllm.distributed.ec_transfer.ec_connector.base import (
     ECConnectorMetadata,
     ECConnectorRole,
 )
+from vllm.logger import init_logger
 from vllm.v1.core.sched.output import SchedulerOutput
 
 if TYPE_CHECKING:
@@ -22,28 +27,216 @@ if TYPE_CHECKING:
 
 MINIMUM_VLLM_VERSION = "0.17.0"
 
-logger = logging.getLogger(__name__)
+# Architectures whose LLM forward is verified to issue a same-stream TP
+# all-reduce after `_execute_mm_encoder` returns. The Plan-B fence relies
+# on that collective acting as the cross-rank visibility point: every
+# worker reaches the all-reduce on its compute_stream, and the all-reduce
+# can't complete on any rank until every rank's compute_stream is past
+# the prior `wait_event(latest_save_event)`. Add new families only after
+# tracing their forward path (or after a CI canary verifies it).
+KNOWN_TP_NCCL_FORWARD_MODELS: frozenset[str] = frozenset(
+    {
+        "Qwen2VLForConditionalGeneration",
+        "Qwen2_5_VLForConditionalGeneration",
+        "Qwen3VLForConditionalGeneration",
+        "Qwen3VLMoeForConditionalGeneration",
+    }
+)
+
+# Use vllm.* name so logs surface inside the EngineCore subprocess where
+# only the `vllm` logger has a handler attached (DEFAULT_LOGGING_CONFIG with
+# propagate=False). A bare logging.getLogger(__name__) lands in the
+# dynamo.* namespace and is silently dropped.
+logger = init_logger("vllm.dynamo_ec_connector")
+
+
+# ---------------------------------------------------------------------------
+# Wire-format commands. The scheduler embeds offset/nbytes/num_embeds in each
+# command so the worker can address its slot in the shared arena without
+# maintaining its own hash → slot map.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class _LoadCmd:
+    mm_hash: str
+    offset: int
+    nbytes: int
+    num_embeds: int
+
+
+@dataclass(slots=True)
+class _SaveCmd:
+    mm_hash: str
+    offset: int
+    nbytes: int
+    num_embeds: int
+    writer_rank: int
+
+
+@dataclass(slots=True)
+class _EvictCmd:
+    mm_hash: str
+    offset: int
+    nbytes: int
 
 
 @dataclass
 class MultimodalEmbeddingCacheConnectorMetadata(ECConnectorMetadata):
-    """Commands from scheduler to worker for CPU embedding cache management."""
+    """Commands from scheduler to worker for one step."""
 
-    loads: list[str] = field(default_factory=list)
-    saves: list[str] = field(default_factory=list)
-    evicts: list[str] = field(default_factory=list)
+    loads: list[_LoadCmd] = field(default_factory=list)
+    saves: list[_SaveCmd] = field(default_factory=list)
+    evicts: list[_EvictCmd] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Scheduler-side state
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class _SchedulerEntry:
+    offset: int
+    nbytes: int
+    num_embeds: int
+    writer_rank: int
+    save_step: int
+    retire_step: int | None = None
+    state: str = "PENDING"  # PENDING | READY | RETIRING
+
+
+def _writer_rank_for(mm_hash: str, world_size: int) -> int:
+    """Stable rank assignment so the same hash always lands in the same
+    partition across requests, regardless of insertion order."""
+    if world_size <= 1:
+        return 0
+    digest = hashlib.blake2b(mm_hash.encode(), digest_size=8).digest()
+    return int.from_bytes(digest, "little") % world_size
+
+
+class _PartitionAllocator:
+    """First-fit byte-granularity allocator over one rank's partition,
+    with lazy reclaim of RETIRING entries whose retire_step < scheduling_step.
+    """
+
+    def __init__(self, base_offset: int, capacity: int) -> None:
+        self._free_regions: list[tuple[int, int]] = (
+            [(base_offset, capacity)] if capacity > 0 else []
+        )
+        # (mm_hash, offset, nbytes, retire_step) — eligible for reclaim once
+        # retire_step < current scheduling_step.
+        self._retiring: list[tuple[str, int, int, int]] = []
+
+    def add_retiring(
+        self, mm_hash: str, offset: int, nbytes: int, retire_step: int
+    ) -> None:
+        self._retiring.append((mm_hash, offset, nbytes, retire_step))
+
+    def alloc(self, nbytes: int, scheduling_step: int) -> tuple[int | None, list[str]]:
+        """Try first-fit; if it fails, lazy-reclaim retiring entries with
+        retire_step < scheduling_step and retry. Returns (offset_or_None,
+        reclaimed_hashes)."""
+        offset = self._first_fit(nbytes)
+        if offset is not None:
+            return offset, []
+        reclaimed = self._reclaim(scheduling_step)
+        if not reclaimed:
+            return None, []
+        return self._first_fit(nbytes), reclaimed
+
+    def _first_fit(self, nbytes: int) -> int | None:
+        for i, (off, length) in enumerate(self._free_regions):
+            if length >= nbytes:
+                if length == nbytes:
+                    self._free_regions.pop(i)
+                else:
+                    self._free_regions[i] = (off + nbytes, length - nbytes)
+                return off
+        return None
+
+    def _reclaim(self, scheduling_step: int) -> list[str]:
+        reclaimed: list[str] = []
+        survivors: list[tuple[str, int, int, int]] = []
+        for h, off, nb, rs in self._retiring:
+            if rs < scheduling_step:
+                self._add_to_free_list(off, nb)
+                reclaimed.append(h)
+            else:
+                survivors.append((h, off, nb, rs))
+        self._retiring = survivors
+        return reclaimed
+
+    def _add_to_free_list(self, offset: int, nbytes: int) -> None:
+        lo, hi = 0, len(self._free_regions)
+        while lo < hi:
+            mid = (lo + hi) // 2
+            if self._free_regions[mid][0] < offset:
+                lo = mid + 1
+            else:
+                hi = mid
+        self._free_regions.insert(lo, (offset, nbytes))
+        # right merge
+        if lo + 1 < len(self._free_regions):
+            a_off, a_len = self._free_regions[lo]
+            b_off, b_len = self._free_regions[lo + 1]
+            if a_off + a_len == b_off:
+                self._free_regions[lo] = (a_off, a_len + b_len)
+                self._free_regions.pop(lo + 1)
+        # left merge
+        if lo > 0:
+            a_off, a_len = self._free_regions[lo - 1]
+            b_off, b_len = self._free_regions[lo]
+            if a_off + a_len == b_off:
+                self._free_regions[lo - 1] = (a_off, a_len + b_len)
+                self._free_regions.pop(lo)
+
+
+# ---------------------------------------------------------------------------
+# Connector
+# ---------------------------------------------------------------------------
 
 
 class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
-    """EC connector with scheduler-authoritative CPU embedding cache.
+    """Embedding-cache connector with one shared pinned arena per engine.
 
-    The scheduler maintains a logical LRU cache (OrderedDict) and issues
-    load/save/evict commands to the worker via ECConnectorMetadata. The
-    worker holds a plain dict[str, Tensor] on CPU and obeys commands
-    without independent caching decisions.
+    Per-rank partitioning replaces the prior per-rank private arena: each TP
+    rank owns one slice of the shared shm region (writer_rank assigned via
+    blake2b(mm_hash) % world_size). All ranks DMA-read every slot, so
+    capacity_bytes of host RAM is locked once per engine instead of once per
+    rank.
 
-    This mirrors vLLM's EncoderCacheManager pattern: the scheduler is the
-    single source of truth for cache state; the worker is a plain dict storage.
+    Two synchronization modes:
+
+    Plan B (NCCL fence — default for allowlisted models on TP>1): the worker
+    records each save's CUDA event on save_stream, tracks the latest one for
+    the step, and at the encoder context exit (`clear_connector_metadata`)
+    issues `compute_stream.wait_event(latest_save_event)`. The next op on
+    compute_stream is the LLM forward's first TP all-reduce — that NCCL
+    collective is the cross-rank fence: it cannot complete on any rank
+    until every rank's compute_stream has cleared `wait_event`, which
+    means every rank's prior-step D2H has retired. CPU never blocks.
+    Trade-off: D2H from the *last* save in the step is gated against
+    LLM-forward overlap (~100–200 µs), but stays overlapped with the
+    encoder forward.
+
+    Plan A (CPU sync — fallback): when the model isn't in the allowlist
+    or TP=1 or `mm_encoder_only=True`, the worker drains save_stream +
+    compute_stream and runs a TP barrier at the start of each multimodal-
+    active step (`_on_step_begin`). CPU-blocking but model-agnostic.
+
+    Scheduler-side authority:
+        - LRU OrderedDict of _SchedulerEntry, keyed by mm_hash.
+        - Per-rank _PartitionAllocator handles offsets and lazy reclaim.
+        - State machine (PENDING → READY → RETIRING) gates load issuance.
+          PENDING is promoted lazily inside `has_cache_item` once
+          save_step < scheduling_step (i.e. at least one full step elapsed
+          since the save was emitted, so `_on_step_begin` of *this* step
+          has already drained every rank's save_stream).
+
+    Worker-side has no per-hash state: every command in metadata carries
+    (offset, nbytes, num_embeds), and the arena is a shared memoryview
+    cudaHostRegister'd into each rank's CUDA context.
     """
 
     def __init__(self, vllm_config: "VllmConfig", role: ECConnectorRole) -> None:
@@ -59,170 +252,462 @@ class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
         transfer_config = vllm_config.ec_transfer_config
         if transfer_config is None:
             raise ValueError(
-                "ec_transfer_config must be set for DynamoMultimodalEmbeddingCacheConnector"
+                "ec_transfer_config must be set for "
+                "DynamoMultimodalEmbeddingCacheConnector"
             )
 
-        if "multimodal_embedding_cache_capacity_gb" not in (
-            transfer_config.ec_connector_extra_config or {}
-        ):
+        extra_config = transfer_config.ec_connector_extra_config or {}
+        if "multimodal_embedding_cache_capacity_gb" not in extra_config:
             raise ValueError(
                 "multimodal_embedding_cache_capacity_gb must be set in "
-                "ec_connector_extra_config for DynamoMultimodalEmbeddingCacheConnector"
+                "ec_connector_extra_config"
             )
-        capacity_gb: float = transfer_config.ec_connector_extra_config[
-            "multimodal_embedding_cache_capacity_gb"
+        capacity_gb: float = extra_config["multimodal_embedding_cache_capacity_gb"]
+
+        # Encoder cache stores tensors of shape (num_embeds, feature_dim).
+        # feature_dim is the *encoder output* width, which differs from the
+        # text hidden_size for models that concatenate deepstack features
+        # post-encoder (e.g. Qwen3-VL: out_hidden_size × (1 + len(deepstack))).
+        self._model_dtype: torch.dtype = vllm_config.model_config.dtype
+        dtype_bytes = torch.tensor([], dtype=self._model_dtype).element_size()
+        self._feature_dim: int = self._compute_feature_dim(vllm_config.model_config)
+        self._bytes_per_embed: int = self._feature_dim * dtype_bytes
+        self._capacity_bytes: int = int(capacity_gb * 1024**3)
+        # Round capacity down so the arena holds an integer number of
+        # bytes-per-embed; partitions further round to be a multiple of it.
+        self._capacity_bytes -= self._capacity_bytes % self._bytes_per_embed
+
+        # Discover TP shape early; used for partition layout on both
+        # scheduler and worker. The scheduler also needs world_size to
+        # compute writer_rank consistently with the worker. We read it from
+        # parallel_config because the scheduler runs in P1 EngineCore where
+        # the TP group isn't initialized.
+        self._tp_world_size: int = max(
+            int(getattr(vllm_config.parallel_config, "tensor_parallel_size", 1)), 1
+        )
+        self._partition_bytes: int = self._capacity_bytes // self._tp_world_size
+        self._partition_bytes -= self._partition_bytes % self._bytes_per_embed
+
+        # Scheduler-side state (only used when role == SCHEDULER).
+        self._entries: OrderedDict[str, _SchedulerEntry] = OrderedDict()
+        self._partitions: list[_PartitionAllocator] = [
+            _PartitionAllocator(
+                base_offset=r * self._partition_bytes,
+                capacity=self._partition_bytes,
+            )
+            for r in range(self._tp_world_size)
         ]
+        self._scheduling_step: int = 0
+        self._loads_this_step: list[_LoadCmd] = []
+        self._saves_this_step: list[_SaveCmd] = []
+        self._evicts_this_step: list[_EvictCmd] = []
 
-        # --- Scheduler-side: logical LRU for CPU embedding cache ---
-        # Mirrors EncoderCacheManager but for the CPU tier, tracking bytes.
-        hidden_size = vllm_config.model_config.get_hidden_size()
-        dtype_bytes = torch.tensor(
-            [], dtype=vllm_config.model_config.dtype
-        ).element_size()
-        self._bytes_per_embed = hidden_size * dtype_bytes
-        self._capacity_bytes = int(capacity_gb * 1024**3)
+        # Worker-side state (filled in by _setup_worker on first call).
+        self._engine_id: str = transfer_config.engine_id or ""
+        self._shared_arena_nonce: str = extra_config.get("shared_arena_nonce", "")
+        self._tp_rank: int = 0
+        self._shm: shared_memory.SharedMemory | None = None
+        self._shm_addr: int = 0
+        self._arena_uint8: torch.Tensor | None = None
+        self._save_stream: torch.cuda.Stream | None = None
+        self._device: torch.device | None = None
+        self._worker_initialized: bool = False
+        self._released: bool = False
 
-        self._cache_order: OrderedDict[str, int] = OrderedDict()  # hash → size_bytes
-        self._num_used_bytes: int = 0
+        # Plan B: latest save_done event recorded this step, drained at
+        # `clear_connector_metadata` against compute_stream so the LLM
+        # forward's TP NCCL all-reduce serves as the cross-rank fence.
+        self._latest_save_event: torch.cuda.Event | None = None
 
-        self._loads_this_step: set[str] = set()
-        self._saves_this_step: set[str] = set()
-        self._evicts_this_step: set[str] = set()
+        # Plan B activation gate: the model's LLM forward must be known
+        # to issue a same-stream TP NCCL all-reduce after _execute_mm_encoder.
+        # Disabled for TP=1 (no cross-rank concern), encoder-only configs
+        # (no LLM forward to fence on), and unrecognized architectures.
+        arch = (
+            (vllm_config.model_config.architectures or [None])[0]
+            if vllm_config.model_config is not None
+            else None
+        )
+        mm_cfg = getattr(vllm_config.model_config, "multimodal_config", None)
+        mm_encoder_only = bool(getattr(mm_cfg, "mm_encoder_only", False))
+        env_disabled = os.environ.get("DYN_EC_NCCL_FENCE", "1") == "0"
+        self._nccl_fence_active: bool = (
+            role == ECConnectorRole.WORKER
+            and self._tp_world_size > 1
+            and not mm_encoder_only
+            and not env_disabled
+            and arch in KNOWN_TP_NCCL_FORWARD_MODELS
+        )
+        # Reasoning trace for the init banner so an operator can tell at a
+        # glance which sync path took effect.
+        self._fence_reason: str
+        if role != ECConnectorRole.WORKER:
+            self._fence_reason = "scheduler-role"
+        elif self._tp_world_size <= 1:
+            self._fence_reason = "tp_world_size==1"
+        elif mm_encoder_only:
+            self._fence_reason = "mm_encoder_only"
+        elif env_disabled:
+            self._fence_reason = "DYN_EC_NCCL_FENCE=0"
+        elif arch not in KNOWN_TP_NCCL_FORWARD_MODELS:
+            self._fence_reason = f"arch_not_allowlisted:{arch}"
+        else:
+            self._fence_reason = "nccl_fence"
 
-        # --- Worker-side: dumb CPU tensor store ---
-        self._cpu_store: dict[str, torch.Tensor] = {}
+        # Per-rank counters for the periodic distribution log. Only the
+        # writer rank increments _saves_issued; every rank increments
+        # _loads_issued for the loads that targeted its compute stream.
+        self._saves_issued: int = 0
+        self._loads_issued: int = 0
+        # Step counter — bumped once per `start_load_caches` call where
+        # metadata was non-empty. Logging fires every _LOG_EVERY_N_STEPS.
+        self._mm_active_steps: int = 0
+
+        if role == ECConnectorRole.WORKER:
+            # Defer the actual SHM/cudaHostRegister setup to first metadata
+            # cycle: at __init__ time we may not know which CUDA device this
+            # worker owns yet, and we want all ranks to enter the setup at
+            # the same step (driven by metadata being non-empty on every
+            # rank). This is correct because metadata is built by a single
+            # scheduler and broadcast identically to every TP rank.
+            atexit.register(self._release_shm)
 
         logger.info(
             "DynamoMultimodalEmbeddingCacheConnector initialized: "
-            "capacity_gb=%.2f, capacity_bytes=%d, bytes_per_embed=%d",
+            "role=%s tp_world_size=%d capacity_gb=%.6f capacity_bytes=%d "
+            "partition_bytes=%d bytes_per_embed=%d sync_mode=%s (%s)",
+            role.name,
+            self._tp_world_size,
             capacity_gb,
             self._capacity_bytes,
+            self._partition_bytes,
             self._bytes_per_embed,
+            "PlanB" if self._nccl_fence_active else "PlanA",
+            self._fence_reason,
         )
 
-    # ==============================
-    # Scheduler-side methods
-    #
-    # vLLM scheduler call sequence per multimodal feature:
-    #
-    #   1. encoder_cache_manager.check_and_update_cache(request, i)
-    #      → if True (GPU hit): skip entirely, neither method below is called.
-    #
-    #   2. has_cache_item(identifier)
-    #      → if True (CPU hit):  item goes to external_load_encoder_input
-    #      → if False (CPU miss): item goes to encoder_inputs_to_schedule
-    #
-    #   3. update_state_after_alloc(request, i) is called for both paths.
-    #      The two paths are mutually exclusive per hash within a step:
-    #      - external_load_encoder_input → mm_hash IN _cache_order  → load path
-    #      - encoder_inputs_to_schedule  → mm_hash NOT in _cache_order → save path
-    # ==============================
+    @staticmethod
+    def _compute_feature_dim(model_config) -> int:
+        """Encoder-output width per visual token.
+
+        For Qwen3-VL: vision_config.out_hidden_size × (1 + len(deepstack)).
+        For models without deepstack: out_hidden_size or text hidden_size.
+        Falls back conservatively when neither is exposed."""
+        fallback = int(model_config.get_hidden_size())
+        hf = getattr(model_config, "hf_config", None)
+        if hf is None:
+            return fallback
+        vc = getattr(hf, "vision_config", None)
+        if vc is None:
+            return fallback
+        base = getattr(vc, "out_hidden_size", None) or fallback
+        deepstack = getattr(vc, "deepstack_visual_indexes", None) or []
+        try:
+            multiplier = 1 + len(deepstack)
+        except TypeError:
+            multiplier = 1
+        return int(base) * multiplier
+
+    # ==================================================================
+    # Scheduler-side
+    # ==================================================================
 
     def has_cache_item(self, identifier: str) -> bool:
-        """Check if an embedding is in the CPU cache, promoting it to MRU on hit.
-
-        Called by the scheduler only after the GPU encoder_cache_manager reports
-        a miss. A True return tells the scheduler to skip encoder compute and
-        load the embedding from the CPU store instead.
-        """
-        if identifier in self._cache_order:
-            self._cache_order.move_to_end(identifier)
+        entry = self._entries.get(identifier)
+        if entry is None:
+            return False
+        # Lazy promotion: an entry is considered safely loaded once at least
+        # one full scheduling step has elapsed since it was saved. By that
+        # point the worker has called `_on_step_begin` (post-save), which
+        # drained save_stream on every rank, and the bytes are visible.
+        if entry.state == "PENDING" and entry.save_step < self._scheduling_step:
+            entry.state = "READY"
+        if entry.state == "READY":
+            self._entries.move_to_end(identifier)
             return True
         return False
 
     def update_state_after_alloc(self, request: "Request", index: int) -> None:
-        """Record a load or save command for a multimodal feature.
-
-        Called by the scheduler after has_cache_item has already determined
-        the path. The _cache_order check here mirrors that decision:
-
-        CPU hit  (mm_hash in _cache_order):  mark for CPU→GPU load.
-        CPU miss (mm_hash not in _cache_order): evict LRU entries if needed,
-            then mark for GPU→CPU save so the worker persists the newly
-            computed embedding. Silently skips items larger than total capacity.
-        """
         mm_hash: str = request.mm_features[index].identifier
         num_embeds: int = request.get_num_encoder_embeds(index)
-        size_bytes: int = num_embeds * self._bytes_per_embed
+        nbytes: int = num_embeds * self._bytes_per_embed
 
-        if mm_hash in self._cache_order:
-            self._cache_order.move_to_end(mm_hash)
-            self._loads_this_step.add(mm_hash)
+        existing = self._entries.get(mm_hash)
+        if existing is not None and existing.state == "READY":
+            self._entries.move_to_end(mm_hash)
+            self._loads_this_step.append(
+                _LoadCmd(
+                    mm_hash=mm_hash,
+                    offset=existing.offset,
+                    nbytes=existing.nbytes,
+                    num_embeds=existing.num_embeds,
+                )
+            )
             return
 
-        if size_bytes > self._capacity_bytes:
+        # CPU miss: must have come through has_cache_item returning False,
+        # so existing is None or state is PENDING/RETIRING. Either way we
+        # do not double-insert.
+        if existing is not None:
+            return
+        if nbytes <= 0 or nbytes > self._partition_bytes:
+            # Doesn't fit in any partition; cache is best-effort, skip.
             return
 
-        self._saves_this_step.add(mm_hash)
+        writer_rank = _writer_rank_for(mm_hash, self._tp_world_size)
+        partition = self._partitions[writer_rank]
 
-        while (
-            self._num_used_bytes + size_bytes > self._capacity_bytes
-            and self._cache_order
-        ):
-            evicted_hash, evicted_bytes = self._cache_order.popitem(last=False)
-            self._num_used_bytes -= evicted_bytes
-            self._evicts_this_step.add(evicted_hash)
+        offset, reclaimed = partition.alloc(nbytes, self._scheduling_step)
+        for h in reclaimed:
+            self._entries.pop(h, None)
 
-        self._cache_order[mm_hash] = size_bytes
-        self._num_used_bytes += size_bytes
+        if offset is None:
+            # Mark the partition's LRU READY entry as RETIRING so it can be
+            # reclaimed *next* step. Same-step reclaim is intentionally not
+            # eligible (rs < scheduling_step gate prevents reuse-while-reads-
+            # may-still-be-in-flight). This save just gets skipped, which is
+            # fine — cache is best-effort.
+            self._evict_lru_in_partition(writer_rank)
+            return
+
+        entry = _SchedulerEntry(
+            offset=offset,
+            nbytes=nbytes,
+            num_embeds=num_embeds,
+            writer_rank=writer_rank,
+            save_step=self._scheduling_step,
+            state="PENDING",
+        )
+        self._entries[mm_hash] = entry
+        self._saves_this_step.append(
+            _SaveCmd(
+                mm_hash=mm_hash,
+                offset=offset,
+                nbytes=nbytes,
+                num_embeds=num_embeds,
+                writer_rank=writer_rank,
+            )
+        )
+
+    def _evict_lru_in_partition(self, writer_rank: int) -> bool:
+        """Mark the LRU READY entry from this partition as RETIRING."""
+        for h, entry in self._entries.items():
+            if entry.writer_rank != writer_rank or entry.state != "READY":
+                continue
+            entry.state = "RETIRING"
+            entry.retire_step = self._scheduling_step
+            self._partitions[writer_rank].add_retiring(
+                h, entry.offset, entry.nbytes, self._scheduling_step
+            )
+            self._evicts_this_step.append(
+                _EvictCmd(mm_hash=h, offset=entry.offset, nbytes=entry.nbytes)
+            )
+            return True
+        return False
 
     def build_connector_meta(
         self, scheduler_output: SchedulerOutput
     ) -> ECConnectorMetadata:
-        """Flush accumulated load/save/evict commands into metadata for the worker."""
         meta = MultimodalEmbeddingCacheConnectorMetadata(
-            loads=list(self._loads_this_step),
-            saves=list(self._saves_this_step),
-            evicts=list(self._evicts_this_step),
+            loads=self._loads_this_step,
+            saves=self._saves_this_step,
+            evicts=self._evicts_this_step,
         )
-
-        self._loads_this_step.clear()
-        self._saves_this_step.clear()
-        self._evicts_this_step.clear()
+        self._loads_this_step = []
+        self._saves_this_step = []
+        self._evicts_this_step = []
+        # _scheduling_step ticks at the end of metadata build so the
+        # *next* call to `has_cache_item` sees save_step < scheduling_step
+        # for entries written this step (lazy promotion gate).
+        self._scheduling_step += 1
         return meta
 
-    # ==============================
-    # Worker-side methods
-    #
-    # Called by the model runner each step with the metadata produced by
-    # build_connector_meta. The worker has no caching logic of its own;
-    # it simply obeys the scheduler's load/save/evict commands.
-    # ==============================
+    # ==================================================================
+    # Worker-side
+    # ==================================================================
+
+    def _setup_worker(self) -> None:
+        """Allocate shm, cudaHostRegister, build the arena view, and create
+        save_stream. Invoked lazily on the first non-empty metadata cycle so
+        every rank reaches it together (metadata is identical across ranks).
+
+        Lazy-setup correctness depends on `ec_role == ec_both`: every rank
+        runs both `start_load_caches` (gated by `is_consumer`) and
+        `save_caches` (gated by `is_producer`), and `MultiprocExecutor`
+        broadcasts metadata identically to all ranks, so all ranks call
+        `_setup_worker` on the same step. If this connector is ever wired
+        as `ec_producer`-only, the lazy setup must move to an unconditional
+        engine-startup hook to avoid rank divergence on save-free steps.
+        """
+        if self._worker_initialized:
+            return
+
+        if (
+            not torch.distributed.is_available()
+            or not torch.distributed.is_initialized()
+        ):
+            # TP=1 single-rank fallback.
+            self._tp_rank = 0
+            self._tp_world_size = 1
+        else:
+            try:
+                from vllm.distributed.parallel_state import get_tp_group
+
+                tp_group = get_tp_group()
+                self._tp_rank = tp_group.rank_in_group
+                self._tp_world_size = tp_group.world_size
+            except Exception:
+                self._tp_rank = torch.distributed.get_rank()
+                self._tp_world_size = torch.distributed.get_world_size()
+
+        if not self._shared_arena_nonce:
+            raise ValueError(
+                "shared_arena_nonce missing from ec_connector_extra_config; "
+                "main.py must populate it"
+            )
+        shm_name = f"dynamo-ec-{self._engine_id}-{self._shared_arena_nonce[:8]}"
+        # Trim down to a portable shm name (POSIX limits are usually ~31 chars
+        # on macOS, much higher on Linux; we expect Linux but truncate
+        # defensively).
+        shm_name = shm_name.replace(".", "_")[-200:]
+
+        if self._tp_rank == 0:
+            # Best-effort cleanup if a prior crashed engine left a stale shm.
+            try:
+                stale = shared_memory.SharedMemory(name=shm_name)
+                stale.close()
+                stale.unlink()
+            except FileNotFoundError:
+                pass
+            self._shm = shared_memory.SharedMemory(
+                name=shm_name, create=True, size=self._capacity_bytes
+            )
+
+        if self._tp_world_size > 1:
+            # TP-group barrier so non-zero ranks don't try to attach before
+            # rank 0 has created the shm. Using the TP group (not world)
+            # keeps DP siblings from blocking each other at startup.
+            from vllm.distributed.parallel_state import get_tp_group
+
+            get_tp_group().barrier()
+
+        if self._tp_rank != 0:
+            self._shm = shared_memory.SharedMemory(name=shm_name)
+
+        assert self._shm is not None
+        addr = ctypes.addressof(ctypes.c_char.from_buffer(self._shm.buf))
+        self._shm_addr = addr
+        # cudaHostRegisterPortable = 0x01.
+        err = torch.cuda.cudart().cudaHostRegister(addr, self._capacity_bytes, 1)
+        if err.value != 0:
+            raise RuntimeError(
+                f"cudaHostRegister failed (rank={self._tp_rank}): err={err}"
+            )
+
+        self._arena_uint8 = torch.frombuffer(self._shm.buf, dtype=torch.uint8)
+
+        device_idx = torch.cuda.current_device()
+        self._device = torch.device(f"cuda:{device_idx}")
+        self._save_stream = torch.cuda.Stream(device=self._device)
+
+        self._worker_initialized = True
+        logger.info(
+            "EC shared arena ready: rank=%d/%d shm=%s bytes=%d device=%s",
+            self._tp_rank,
+            self._tp_world_size,
+            shm_name,
+            self._capacity_bytes,
+            self._device,
+        )
+
+    def _on_step_begin(self) -> None:
+        """Plan A only: drain streams and TP-barrier so prior-step D2Hs are
+        globally visible before any H2D in this step. No-op when Plan B's
+        NCCL fence is active — the previous step's LLM forward already
+        served as the cross-rank fence."""
+        if self._nccl_fence_active:
+            return
+        assert self._save_stream is not None
+        self._save_stream.synchronize()
+        torch.cuda.current_stream().synchronize()
+        if self._tp_world_size > 1:
+            from vllm.distributed.parallel_state import get_tp_group
+
+            get_tp_group().barrier()
+
+    _LOG_EVERY_N_STEPS: int = 100
+
+    def _maybe_log_distribution(self) -> None:
+        """Periodic per-rank counter dump. Cheap (one int compare) on
+        every-other step; logs once per _LOG_EVERY_N_STEPS multimodal-
+        active steps. Lets an operator confirm saves spread across ranks."""
+        self._mm_active_steps += 1
+        if self._mm_active_steps % self._LOG_EVERY_N_STEPS != 0:
+            return
+        logger.info(
+            "ec_connector stats: rank=%d/%d step=%d saves_issued=%d loads_issued=%d sync_mode=%s",
+            self._tp_rank,
+            self._tp_world_size,
+            self._mm_active_steps,
+            self._saves_issued,
+            self._loads_issued,
+            "PlanB" if self._nccl_fence_active else "PlanA",
+        )
 
     def start_load_caches(
         self, encoder_cache: dict[str, torch.Tensor], **kwargs
     ) -> None:
-        """Copy cached embeddings from CPU store to GPU encoder_cache, and evict
-        entries the scheduler marked for removal.
-        """
         metadata = self._get_connector_metadata()
         assert isinstance(metadata, MultimodalEmbeddingCacheConnectorMetadata)
 
-        for mm_hash in metadata.loads:
-            if mm_hash in encoder_cache:
-                continue
-            if mm_hash in self._cpu_store:
-                encoder_cache[mm_hash] = self._cpu_store[mm_hash].to(
-                    "cuda", non_blocking=True
-                )
-            else:
-                logger.warning(
-                    "start_load_caches: hash %s not in cpu_store, skipping", mm_hash
-                )
+        if not (metadata.loads or metadata.saves or metadata.evicts):
+            return
 
-        for mm_hash in metadata.evicts:
-            self._cpu_store.pop(mm_hash, None)
+        self._setup_worker()
+        self._on_step_begin()
+
+        compute = torch.cuda.current_stream()
+        for cmd in metadata.loads:
+            if cmd.mm_hash in encoder_cache:
+                continue
+            assert self._arena_uint8 is not None
+            # H2D as raw bytes, then reinterpret on the GPU side.
+            cpu_uint8 = self._arena_uint8.narrow(0, cmd.offset, cmd.nbytes)
+            gpu_uint8 = cpu_uint8.to(device=compute.device, non_blocking=True)
+            gpu_tensor = gpu_uint8.view(self._model_dtype).view(
+                cmd.num_embeds, self._feature_dim
+            )
+            # Tell the caching allocator the destination is consumed by
+            # compute; vLLM may pop encoder_cache[h] before compute drains.
+            gpu_tensor.record_stream(compute)
+            encoder_cache[cmd.mm_hash] = gpu_tensor
+            self._loads_issued += 1
+
+        # Evict commands carry no worker-side state to clean up — the
+        # scheduler-side allocator owns slot lifetime.
+
+        self._maybe_log_distribution()
 
     def save_caches(
         self, encoder_cache: dict[str, torch.Tensor], mm_hash: str, **kwargs
     ) -> None:
-        """Copy a newly computed embedding from GPU encoder_cache to CPU store."""
         metadata = self._get_connector_metadata()
         assert isinstance(metadata, MultimodalEmbeddingCacheConnectorMetadata)
 
-        if mm_hash not in metadata.saves:
+        save_cmd: _SaveCmd | None = None
+        for cmd in metadata.saves:
+            if cmd.mm_hash == mm_hash:
+                save_cmd = cmd
+                break
+        if save_cmd is None:
             return
-        if mm_hash in self._cpu_store:
+        if not self._worker_initialized:
+            # start_load_caches normally runs first, but if the model runner
+            # ever flips the order on a save-only step, set up here too.
+            self._setup_worker()
+        if save_cmd.writer_rank != self._tp_rank:
+            # Other ranks rely on the cudaHostRegister'd shared mapping;
+            # only the assigned writer rank issues the D2H.
             return
         if mm_hash not in encoder_cache:
             logger.warning(
@@ -230,4 +715,79 @@ class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
                 mm_hash,
             )
             return
-        self._cpu_store[mm_hash] = encoder_cache[mm_hash].cpu()
+
+        src = encoder_cache[mm_hash]
+        if not src.is_contiguous():
+            src = src.contiguous()
+
+        actual = src.numel() * src.element_size()
+        if actual != save_cmd.nbytes:
+            raise RuntimeError(
+                f"EC save_caches size mismatch for {mm_hash}: "
+                f"src={actual} cmd={save_cmd.nbytes} "
+                f"(num_embeds={save_cmd.num_embeds} feature_dim={self._feature_dim})"
+            )
+
+        # Byte-level copy: reinterpret src as flat uint8 and copy into the
+        # arena slot. Shape-agnostic — works for any encoder output layout
+        # as long as numel() * element_size() matches the reserved nbytes.
+        assert self._arena_uint8 is not None
+        cpu_uint8 = self._arena_uint8.narrow(0, save_cmd.offset, save_cmd.nbytes)
+        src_uint8 = src.view(torch.uint8).reshape(-1)
+
+        compute = torch.cuda.current_stream(src.device)
+        assert self._save_stream is not None
+        self._save_stream.wait_stream(compute)
+        with torch.cuda.stream(self._save_stream):
+            cpu_uint8.copy_(src_uint8, non_blocking=True)
+            # vLLM may pop encoder_cache[h] before our async D2H finishes;
+            # protect the source storage with a record_stream on save_stream.
+            src.record_stream(self._save_stream)
+
+        self._saves_issued += 1
+
+        if self._nccl_fence_active:
+            # Plan B: record the save_done event on save_stream and keep the
+            # most recent one for this step. clear_connector_metadata will
+            # drain it against compute_stream so the next LLM-forward NCCL
+            # all-reduce serves as the cross-rank fence.
+            done = torch.cuda.Event()
+            done.record(self._save_stream)
+            self._latest_save_event = done
+
+    def clear_connector_metadata(self) -> None:
+        """Plan B fence point. After every metadata-bearing step, drain
+        the latest save_done event against compute_stream. The next op on
+        compute_stream is the LLM forward's first TP all-reduce — that NCCL
+        collective is the cross-rank visibility point.
+
+        Plan A path leaves _latest_save_event as None (we never record it
+        in save_caches when the fence is inactive), so this is a no-op."""
+        if self._latest_save_event is not None:
+            torch.cuda.current_stream().wait_event(self._latest_save_event)
+            self._latest_save_event = None
+        super().clear_connector_metadata()
+
+    # ==================================================================
+    # Cleanup
+    # ==================================================================
+
+    def _release_shm(self) -> None:
+        if self._released:
+            return
+        self._released = True
+        # Drop the torch view first so the underlying buffer reference goes
+        # away before we close/unlink the shm.
+        self._arena_uint8 = None
+        try:
+            if self._shm_addr != 0 and self._capacity_bytes > 0:
+                torch.cuda.cudart().cudaHostUnregister(self._shm_addr)
+        except Exception:  # noqa: BLE001 — atexit, never propagate
+            pass
+        try:
+            if self._shm is not None:
+                self._shm.close()
+                if self._tp_rank == 0:
+                    self._shm.unlink()
+        except Exception:  # noqa: BLE001 — atexit, never propagate
+            pass

--- a/components/src/dynamo/vllm/multimodal_utils/multimodal_embedding_cache_connector.py
+++ b/components/src/dynamo/vllm/multimodal_utils/multimodal_embedding_cache_connector.py
@@ -40,6 +40,9 @@ KNOWN_TP_NCCL_FORWARD_MODELS: frozenset[str] = frozenset(
         "Qwen2_5_VLForConditionalGeneration",
         "Qwen3VLForConditionalGeneration",
         "Qwen3VLMoeForConditionalGeneration",
+        # Qwen3.5 397B FP8 MoE shares the Qwen3 multimodal forward path,
+        # which issues the same post-encoder TP all-reduce — PlanB fence
+        # engages. Without this entry the 397B sweep falls back to PlanA.
         "Qwen3_5MoeForConditionalGeneration",
     }
 )
@@ -382,6 +385,15 @@ class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
         # metadata was non-empty. Logging fires every _LOG_EVERY_N_STEPS.
         self._mm_active_steps: int = 0
 
+        # Per-step workload visibility (reset at bind, accumulated through
+        # start_load_caches / save_caches, drained at clear_connector_metadata).
+        self._step_loads_planned: int = 0
+        self._step_loads_issued: int = 0
+        self._step_loads_bytes: int = 0
+        self._step_saves_planned: int = 0
+        self._step_saves_issued: int = 0
+        self._step_saves_bytes: int = 0
+
         if role == ECConnectorRole.WORKER:
             # Defer the actual SHM/cudaHostRegister setup to first metadata
             # cycle: at __init__ time we may not know which CUDA device this
@@ -562,6 +574,15 @@ class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
         regardless.
         """
         super().bind_connector_metadata(connector_metadata)
+        # Reset per-step counters — bind runs every step, so this also
+        # zeros out non-MM-active steps.
+        self._step_loads_planned = 0
+        self._step_loads_issued = 0
+        self._step_loads_bytes = 0
+        self._step_saves_planned = 0
+        self._step_saves_issued = 0
+        self._step_saves_bytes = 0
+
         if not isinstance(
             connector_metadata, MultimodalEmbeddingCacheConnectorMetadata
         ):
@@ -577,6 +598,8 @@ class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
             self._save_cmd_by_hash = {
                 cmd.mm_hash: cmd for cmd in connector_metadata.saves
             }
+        self._step_loads_planned = len(connector_metadata.loads)
+        self._step_saves_planned = len(self._save_cmd_by_hash)
 
     def _setup_worker(self) -> None:
         """Allocate shm, cudaHostRegister, build the arena view, and create
@@ -760,6 +783,8 @@ class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
                 view.record_stream(compute)
                 encoder_cache[cmd.mm_hash] = view
                 self._loads_issued += 1
+                self._step_loads_issued += 1
+                self._step_loads_bytes += cmd.nbytes
 
             i = j
 
@@ -821,6 +846,8 @@ class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
             src.record_stream(self._save_stream)
 
         self._saves_issued += 1
+        self._step_saves_issued += 1
+        self._step_saves_bytes += save_cmd.nbytes
 
         if self._nccl_fence_active:
             # Plan B: just mark that a D2H was enqueued on save_stream
@@ -855,6 +882,19 @@ class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
             done.record(self._save_stream)
             torch.cuda.current_stream().wait_event(done)
             self._save_pending_this_step = False
+        if self._step_loads_planned or self._step_saves_planned:
+            logger.info(
+                "ec_step rank=%d/%d step=%d loads=%d/%d (%d B) saves=%d/%d (%d B)",
+                self._tp_rank,
+                self._tp_world_size,
+                self._mm_active_steps,
+                self._step_loads_issued,
+                self._step_loads_planned,
+                self._step_loads_bytes,
+                self._step_saves_issued,
+                self._step_saves_planned,
+                self._step_saves_bytes,
+            )
         self._save_cmd_by_hash = {}
         super().clear_connector_metadata()
 

--- a/components/src/dynamo/vllm/multimodal_utils/multimodal_embedding_cache_connector.py
+++ b/components/src/dynamo/vllm/multimodal_utils/multimodal_embedding_cache_connector.py
@@ -40,6 +40,7 @@ KNOWN_TP_NCCL_FORWARD_MODELS: frozenset[str] = frozenset(
         "Qwen2_5_VLForConditionalGeneration",
         "Qwen3VLForConditionalGeneration",
         "Qwen3VLMoeForConditionalGeneration",
+        "Qwen3_5MoeForConditionalGeneration",
     }
 )
 

--- a/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_multimodal_embedding_cache_connector.py
+++ b/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_multimodal_embedding_cache_connector.py
@@ -142,3 +142,627 @@ class TestSchedulerSideLRU:
         assert meta.saves == []
         assert meta.loads == []
         assert "huge_hash" not in conn._cache_order
+
+
+# ---------------------------------------------------------------------------
+# Worker-side fixtures for start_load_caches / save_caches /
+# clear_connector_metadata tests. Avoid the real `_setup_worker` (cudaHostRegister
+# + shared_memory.SharedMemory) by pre-populating the worker state.
+# ---------------------------------------------------------------------------
+
+
+def _make_worker_connector(
+    *,
+    tp_rank: int = 0,
+    tp_world_size: int = 2,
+    feature_dim: int = 4,
+    arena_bytes: int = 4096,
+    fence_active: bool = True,
+) -> mod.DynamoMultimodalEmbeddingCacheConnector:
+    """Build a connector with worker-side state ready for load/save calls,
+    bypassing _setup_worker (which would touch shm + CUDA)."""
+    with patch.object(mod.ECConnectorBase, "__init__", return_value=None):
+        conn = mod.DynamoMultimodalEmbeddingCacheConnector(
+            vllm_config=_make_vllm_config(),
+            role=MagicMock(),
+        )
+    conn._tp_rank = tp_rank
+    conn._tp_world_size = tp_world_size
+    conn._worker_initialized = True
+    conn._nccl_fence_active = fence_active
+    conn._model_dtype = torch.float16
+    conn._feature_dim = feature_dim
+    conn._save_stream = MagicMock()
+
+    # Deterministic arena: byte at offset i is `i % 256`. Lets tests assert
+    # that views map to the right arena slice.
+    pattern = (torch.arange(arena_bytes, dtype=torch.long) % 256).to(torch.uint8)
+    conn._arena_uint8 = pattern.contiguous()
+    conn._connector_metadata = None
+    return conn
+
+
+class _LoadCallTracker:
+    """Captures every Tensor.to / Tensor.record_stream call during a
+    start_load_caches invocation. Class-method patching (not autospec) so
+    Python's descriptor protocol binds `self` for us."""
+
+    def __init__(self) -> None:
+        self.to_calls: list[tuple[torch.Tensor, tuple, dict]] = []
+        self.record_stream_calls: list[tuple[int, int]] = []  # (data_ptr, numel)
+
+
+def _patch_cuda_for_load(monkeypatch) -> _LoadCallTracker:
+    """Patch the three CUDA-only call sites used by start_load_caches so the
+    method runs end-to-end on CPU. Returns the tracker for assertions."""
+    tracker = _LoadCallTracker()
+    fake_stream = MagicMock()
+    fake_stream.device = torch.device("cpu")
+    monkeypatch.setattr(torch.cuda, "current_stream", lambda *a, **kw: fake_stream)
+
+    def fake_to(self, *args, **kwargs):
+        tracker.to_calls.append((self, args, kwargs))
+        # No-op transfer: stay on CPU and return self so the view chain is
+        # built off the arena buffer (lets test_view_content_* read bytes).
+        return self
+
+    def fake_record_stream(self, _stream):
+        tracker.record_stream_calls.append((self.data_ptr(), self.numel()))
+
+    monkeypatch.setattr(torch.Tensor, "to", fake_to, raising=False)
+    monkeypatch.setattr(
+        torch.Tensor, "record_stream", fake_record_stream, raising=False
+    )
+    return tracker
+
+
+def _start_load(monkeypatch, conn, metadata, encoder_cache) -> _LoadCallTracker:
+    """Drive start_load_caches with metadata bound and CUDA mocks active."""
+    tracker = _patch_cuda_for_load(monkeypatch)
+    conn.bind_connector_metadata(metadata)
+    conn.start_load_caches(encoder_cache=encoder_cache)
+    return tracker
+
+
+# 4 embeds * 4 features * 2 bytes (fp16) = 32 bytes per slot — keeps tests
+# concise.
+_NB = 32
+_NE = 4
+
+
+class TestStartLoadCachesCoalesce:
+    """Worker-side load path: H2D coalescing, skip-cached, sort, view shape,
+    record_stream, counter increments."""
+
+    def test_three_contiguous_loads_coalesce_to_single_h2d(self, monkeypatch):
+        conn = _make_worker_connector()
+        metadata = mod.MultimodalEmbeddingCacheConnectorMetadata(
+            loads=[
+                mod._LoadCmd(mm_hash="a", offset=0, nbytes=_NB, num_embeds=_NE),
+                mod._LoadCmd(mm_hash="b", offset=_NB, nbytes=_NB, num_embeds=_NE),
+                mod._LoadCmd(mm_hash="c", offset=2 * _NB, nbytes=_NB, num_embeds=_NE),
+            ]
+        )
+        cache: dict[str, torch.Tensor] = {}
+        tracker = _start_load(monkeypatch, conn, metadata, cache)
+
+        assert len(tracker.to_calls) == 1
+        assert set(cache) == {"a", "b", "c"}
+        assert conn._loads_issued == 3
+
+    def test_non_contiguous_loads_remain_separate(self, monkeypatch):
+        conn = _make_worker_connector()
+        # Gap between 32 and 128 → two groups.
+        metadata = mod.MultimodalEmbeddingCacheConnectorMetadata(
+            loads=[
+                mod._LoadCmd(mm_hash="a", offset=0, nbytes=_NB, num_embeds=_NE),
+                mod._LoadCmd(mm_hash="b", offset=128, nbytes=_NB, num_embeds=_NE),
+                mod._LoadCmd(mm_hash="c", offset=128 + _NB, nbytes=_NB, num_embeds=_NE),
+            ]
+        )
+        cache: dict[str, torch.Tensor] = {}
+        tracker = _start_load(monkeypatch, conn, metadata, cache)
+
+        assert len(tracker.to_calls) == 2
+        assert set(cache) == {"a", "b", "c"}
+        assert conn._loads_issued == 3
+
+    def test_unsorted_loads_sorted_before_grouping(self, monkeypatch):
+        # Cmds emitted in non-offset order should still coalesce.
+        conn = _make_worker_connector()
+        metadata = mod.MultimodalEmbeddingCacheConnectorMetadata(
+            loads=[
+                mod._LoadCmd(mm_hash="c", offset=2 * _NB, nbytes=_NB, num_embeds=_NE),
+                mod._LoadCmd(mm_hash="a", offset=0, nbytes=_NB, num_embeds=_NE),
+                mod._LoadCmd(mm_hash="b", offset=_NB, nbytes=_NB, num_embeds=_NE),
+            ]
+        )
+        cache: dict[str, torch.Tensor] = {}
+        tracker = _start_load(monkeypatch, conn, metadata, cache)
+
+        assert len(tracker.to_calls) == 1
+        assert set(cache) == {"a", "b", "c"}
+
+    def test_already_cached_loads_are_skipped(self, monkeypatch):
+        conn = _make_worker_connector()
+        # 'b' already in cache → only 'a' and 'c' fire H2Ds, and they're
+        # non-contiguous in the *pending* set so two groups.
+        metadata = mod.MultimodalEmbeddingCacheConnectorMetadata(
+            loads=[
+                mod._LoadCmd(mm_hash="a", offset=0, nbytes=_NB, num_embeds=_NE),
+                mod._LoadCmd(mm_hash="b", offset=_NB, nbytes=_NB, num_embeds=_NE),
+                mod._LoadCmd(mm_hash="c", offset=2 * _NB, nbytes=_NB, num_embeds=_NE),
+            ]
+        )
+        prior = torch.zeros((_NE, 4), dtype=torch.float16)
+        cache: dict[str, torch.Tensor] = {"b": prior}
+        tracker = _start_load(monkeypatch, conn, metadata, cache)
+
+        assert len(tracker.to_calls) == 2
+        assert cache["b"] is prior  # untouched
+        assert conn._loads_issued == 2  # only 'a' and 'c'
+        # record_stream fires once per pending view — 'b' was skipped.
+        assert len(tracker.record_stream_calls) == 2
+
+    def test_view_shape_dtype_match_metadata(self, monkeypatch):
+        conn = _make_worker_connector()
+        metadata = mod.MultimodalEmbeddingCacheConnectorMetadata(
+            loads=[
+                mod._LoadCmd(mm_hash="a", offset=0, nbytes=_NB, num_embeds=_NE),
+                mod._LoadCmd(mm_hash="b", offset=_NB, nbytes=_NB, num_embeds=_NE),
+            ]
+        )
+        cache: dict[str, torch.Tensor] = {}
+        _start_load(monkeypatch, conn, metadata, cache)
+
+        for h in ("a", "b"):
+            t = cache[h]
+            assert t.dtype == torch.float16
+            assert t.shape == (_NE, conn._feature_dim)
+
+    def test_view_content_reads_correct_arena_bytes(self, monkeypatch):
+        # With Tensor.to patched to be identity, the encoder_cache views
+        # observe the raw arena bytes — so we can check that each hash
+        # maps to the right slice of the deterministic arena pattern.
+        conn = _make_worker_connector()
+        metadata = mod.MultimodalEmbeddingCacheConnectorMetadata(
+            loads=[
+                mod._LoadCmd(mm_hash="a", offset=0, nbytes=_NB, num_embeds=_NE),
+                mod._LoadCmd(mm_hash="b", offset=_NB, nbytes=_NB, num_embeds=_NE),
+            ]
+        )
+        cache: dict[str, torch.Tensor] = {}
+        _start_load(monkeypatch, conn, metadata, cache)
+
+        for h, off in (("a", 0), ("b", _NB)):
+            view_bytes = cache[h].contiguous().view(torch.uint8).reshape(-1)
+            expected = conn._arena_uint8.narrow(0, off, _NB)
+            assert torch.equal(view_bytes, expected)
+
+    def test_record_stream_called_for_every_view(self, monkeypatch):
+        conn = _make_worker_connector()
+        metadata = mod.MultimodalEmbeddingCacheConnectorMetadata(
+            loads=[
+                mod._LoadCmd(mm_hash="a", offset=0, nbytes=_NB, num_embeds=_NE),
+                mod._LoadCmd(mm_hash="b", offset=_NB, nbytes=_NB, num_embeds=_NE),
+                mod._LoadCmd(mm_hash="c", offset=128, nbytes=_NB, num_embeds=_NE),
+            ]
+        )
+        cache: dict[str, torch.Tensor] = {}
+        tracker = _start_load(monkeypatch, conn, metadata, cache)
+        assert len(tracker.record_stream_calls) == 3
+
+    def test_empty_metadata_short_circuits(self, monkeypatch):
+        conn = _make_worker_connector()
+        metadata = mod.MultimodalEmbeddingCacheConnectorMetadata()
+        cache: dict[str, torch.Tensor] = {}
+        tracker = _start_load(monkeypatch, conn, metadata, cache)
+        assert len(tracker.to_calls) == 0
+        assert cache == {}
+        assert conn._loads_issued == 0
+
+    def test_single_load(self, monkeypatch):
+        conn = _make_worker_connector()
+        metadata = mod.MultimodalEmbeddingCacheConnectorMetadata(
+            loads=[
+                mod._LoadCmd(mm_hash="solo", offset=0, nbytes=_NB, num_embeds=_NE),
+            ]
+        )
+        cache: dict[str, torch.Tensor] = {}
+        tracker = _start_load(monkeypatch, conn, metadata, cache)
+        assert len(tracker.to_calls) == 1
+        assert len(tracker.record_stream_calls) == 1
+        assert cache["solo"].shape == (_NE, conn._feature_dim)
+
+    def test_all_loads_already_cached_zero_h2ds(self, monkeypatch):
+        conn = _make_worker_connector()
+        metadata = mod.MultimodalEmbeddingCacheConnectorMetadata(
+            loads=[
+                mod._LoadCmd(mm_hash="a", offset=0, nbytes=_NB, num_embeds=_NE),
+                mod._LoadCmd(mm_hash="b", offset=_NB, nbytes=_NB, num_embeds=_NE),
+            ]
+        )
+        prior_a = torch.zeros((_NE, 4), dtype=torch.float16)
+        prior_b = torch.ones((_NE, 4), dtype=torch.float16)
+        cache: dict[str, torch.Tensor] = {"a": prior_a, "b": prior_b}
+        tracker = _start_load(monkeypatch, conn, metadata, cache)
+        assert len(tracker.to_calls) == 0
+        assert cache["a"] is prior_a
+        assert cache["b"] is prior_b
+        assert conn._loads_issued == 0
+
+    def test_mixed_contiguous_and_gap_two_groups(self, monkeypatch):
+        # Two contiguous groups separated by a gap → 2 H2Ds, 5 views.
+        conn = _make_worker_connector()
+        metadata = mod.MultimodalEmbeddingCacheConnectorMetadata(
+            loads=[
+                mod._LoadCmd(
+                    mm_hash=f"g0_{i}", offset=i * _NB, nbytes=_NB, num_embeds=_NE
+                )
+                for i in range(3)
+            ]
+            + [
+                mod._LoadCmd(
+                    mm_hash=f"g1_{i}",
+                    offset=512 + i * _NB,
+                    nbytes=_NB,
+                    num_embeds=_NE,
+                )
+                for i in range(2)
+            ]
+        )
+        cache: dict[str, torch.Tensor] = {}
+        tracker = _start_load(monkeypatch, conn, metadata, cache)
+        assert len(tracker.to_calls) == 2
+        assert len(tracker.record_stream_calls) == 5
+        assert conn._loads_issued == 5
+
+    def test_skip_middle_breaks_contiguity(self, monkeypatch):
+        # 4 originally-contiguous offsets; 'b' (the second) is already cached.
+        # Pending = a, c, d. After sort: a [0..32], c [64..96], d [96..128].
+        # That's two groups: {a} and {c, d}. → 2 H2Ds.
+        conn = _make_worker_connector()
+        metadata = mod.MultimodalEmbeddingCacheConnectorMetadata(
+            loads=[
+                mod._LoadCmd(mm_hash="a", offset=0, nbytes=_NB, num_embeds=_NE),
+                mod._LoadCmd(mm_hash="b", offset=_NB, nbytes=_NB, num_embeds=_NE),
+                mod._LoadCmd(mm_hash="c", offset=2 * _NB, nbytes=_NB, num_embeds=_NE),
+                mod._LoadCmd(mm_hash="d", offset=3 * _NB, nbytes=_NB, num_embeds=_NE),
+            ]
+        )
+        prior = torch.zeros((_NE, 4), dtype=torch.float16)
+        cache: dict[str, torch.Tensor] = {"b": prior}
+        tracker = _start_load(monkeypatch, conn, metadata, cache)
+        assert len(tracker.to_calls) == 2
+        assert conn._loads_issued == 3
+
+    def test_views_in_same_group_share_storage(self, monkeypatch):
+        # All views from one coalesced H2D must share an underlying Storage —
+        # this is the lifetime contract that keeps the packed buffer alive
+        # while any view is still consumed by compute.
+        conn = _make_worker_connector()
+        metadata = mod.MultimodalEmbeddingCacheConnectorMetadata(
+            loads=[
+                mod._LoadCmd(mm_hash="a", offset=0, nbytes=_NB, num_embeds=_NE),
+                mod._LoadCmd(mm_hash="b", offset=_NB, nbytes=_NB, num_embeds=_NE),
+                mod._LoadCmd(mm_hash="c", offset=2 * _NB, nbytes=_NB, num_embeds=_NE),
+            ]
+        )
+        cache: dict[str, torch.Tensor] = {}
+        _start_load(monkeypatch, conn, metadata, cache)
+        ptrs = {h: cache[h].untyped_storage().data_ptr() for h in ("a", "b", "c")}
+        assert ptrs["a"] == ptrs["b"] == ptrs["c"]
+
+    def test_views_in_different_groups_have_distinct_storage(self, monkeypatch):
+        # Two groups separated by a gap → two distinct underlying Storages
+        # for the GPU side. (With Tensor.to patched to identity, the views
+        # actually share the arena's storage — so we instead verify the
+        # storage offset differs by exactly the gap, which is the same
+        # invariant in disguise.)
+        conn = _make_worker_connector()
+        metadata = mod.MultimodalEmbeddingCacheConnectorMetadata(
+            loads=[
+                mod._LoadCmd(mm_hash="a", offset=0, nbytes=_NB, num_embeds=_NE),
+                mod._LoadCmd(mm_hash="b", offset=128, nbytes=_NB, num_embeds=_NE),
+            ]
+        )
+        cache: dict[str, torch.Tensor] = {}
+        _start_load(monkeypatch, conn, metadata, cache)
+        # Each view's element address is its arena offset under identity .to().
+        offset_a = cache["a"].data_ptr() - conn._arena_uint8.data_ptr()
+        offset_b = cache["b"].data_ptr() - conn._arena_uint8.data_ptr()
+        assert offset_a == 0
+        assert offset_b == 128
+
+
+def _patch_save_path(monkeypatch) -> dict:
+    """Stub the CUDA-only side of save_caches so it can run on CPU. Returns a
+    dict with the captured stream / event mocks for assertions."""
+    captured: dict = {}
+    fake_save_event = MagicMock()
+    monkeypatch.setattr(torch.cuda, "current_stream", lambda *a, **kw: MagicMock())
+    monkeypatch.setattr(torch.cuda, "stream", lambda *a, **kw: MagicMock())
+    monkeypatch.setattr(torch.cuda, "Event", lambda: fake_save_event)
+    monkeypatch.setattr(
+        torch.Tensor, "record_stream", lambda self, _s: None, raising=False
+    )
+    captured["event"] = fake_save_event
+    return captured
+
+
+class TestSaveCachesEndToEnd:
+    """End-to-end save_caches behavior: writer-rank D2H, counter, fence flag,
+    error paths."""
+
+    def test_writer_rank_save_increments_counter_and_flag(self, monkeypatch):
+        conn = _make_worker_connector(tp_rank=0, fence_active=True)
+        metadata = mod.MultimodalEmbeddingCacheConnectorMetadata(
+            saves=[
+                mod._SaveCmd(
+                    mm_hash="a", offset=0, nbytes=_NB, num_embeds=_NE, writer_rank=0
+                ),
+            ]
+        )
+        conn.bind_connector_metadata(metadata)
+        encoder_cache = {
+            "a": torch.zeros((_NE, conn._feature_dim), dtype=torch.float16)
+        }
+        _patch_save_path(monkeypatch)
+
+        conn.save_caches(encoder_cache=encoder_cache, mm_hash="a")
+
+        assert conn._saves_issued == 1
+        assert conn._save_pending_this_step is True
+
+    def test_wrong_rank_save_is_no_op(self, monkeypatch):
+        # Owner is rank 1; we are rank 0. Even with the dict unfiltered,
+        # save_caches must early-return without touching state.
+        conn = _make_worker_connector(tp_rank=0)
+        conn._worker_initialized = False  # forces unfiltered dict
+        metadata = mod.MultimodalEmbeddingCacheConnectorMetadata(
+            saves=[
+                mod._SaveCmd(
+                    mm_hash="a", offset=0, nbytes=_NB, num_embeds=_NE, writer_rank=1
+                ),
+            ]
+        )
+        conn.bind_connector_metadata(metadata)
+        # Now flip _worker_initialized back so save_caches doesn't trigger
+        # _setup_worker (which would touch shm).
+        conn._worker_initialized = True
+        encoder_cache = {
+            "a": torch.zeros((_NE, conn._feature_dim), dtype=torch.float16)
+        }
+        _patch_save_path(monkeypatch)
+
+        conn.save_caches(encoder_cache=encoder_cache, mm_hash="a")
+
+        assert conn._saves_issued == 0
+        assert conn._save_pending_this_step is False
+
+    def test_size_mismatch_raises(self, monkeypatch):
+        conn = _make_worker_connector(tp_rank=0)
+        metadata = mod.MultimodalEmbeddingCacheConnectorMetadata(
+            saves=[
+                mod._SaveCmd(
+                    mm_hash="a", offset=0, nbytes=_NB, num_embeds=_NE, writer_rank=0
+                ),
+            ]
+        )
+        conn.bind_connector_metadata(metadata)
+        # Wrong shape — totals to 64 bytes (8 elements * 8 bytes for fp32),
+        # but cmd.nbytes is 32.
+        encoder_cache = {
+            "a": torch.zeros((_NE, conn._feature_dim), dtype=torch.float32),
+        }
+        _patch_save_path(monkeypatch)
+
+        with pytest.raises(RuntimeError, match="size mismatch"):
+            conn.save_caches(encoder_cache=encoder_cache, mm_hash="a")
+
+    def test_missing_from_encoder_cache_warns_and_returns(self, monkeypatch):
+        conn = _make_worker_connector(tp_rank=0)
+        metadata = mod.MultimodalEmbeddingCacheConnectorMetadata(
+            saves=[
+                mod._SaveCmd(
+                    mm_hash="a", offset=0, nbytes=_NB, num_embeds=_NE, writer_rank=0
+                ),
+            ]
+        )
+        conn.bind_connector_metadata(metadata)
+        _patch_save_path(monkeypatch)
+
+        with patch.object(mod.logger, "warning") as warn:
+            conn.save_caches(encoder_cache={}, mm_hash="a")
+
+        warn.assert_called_once()
+        assert conn._saves_issued == 0
+        assert conn._save_pending_this_step is False
+
+    def test_three_saves_one_event(self, monkeypatch):
+        # Plan B fence: even if save_caches fires N times, clear emits ONE
+        # event. _save_pending_this_step is the only flag mutated in
+        # save_caches; the event lives in clear.
+        conn = _make_worker_connector(tp_rank=0, fence_active=True)
+        metadata = mod.MultimodalEmbeddingCacheConnectorMetadata(
+            saves=[
+                mod._SaveCmd(
+                    mm_hash=h, offset=i * _NB, nbytes=_NB, num_embeds=_NE, writer_rank=0
+                )
+                for i, h in enumerate(("a", "b", "c"))
+            ]
+        )
+        conn.bind_connector_metadata(metadata)
+        encoder_cache = {
+            h: torch.zeros((_NE, conn._feature_dim), dtype=torch.float16)
+            for h in ("a", "b", "c")
+        }
+        captured = _patch_save_path(monkeypatch)
+
+        for h in ("a", "b", "c"):
+            conn.save_caches(encoder_cache=encoder_cache, mm_hash=h)
+
+        # No events created during save_caches itself.
+        captured["event"].record.assert_not_called()
+        assert conn._save_pending_this_step is True
+
+        # The single event is created in clear_connector_metadata.
+        with patch.object(mod.ECConnectorBase, "clear_connector_metadata"):
+            conn.clear_connector_metadata()
+        # Exactly one record on save_stream at clear time.
+        assert captured["event"].record.call_count == 1
+
+    def test_bind_clear_bind_cycle_resets_dict(self, monkeypatch):
+        conn = _make_worker_connector(tp_rank=0)
+        meta1 = mod.MultimodalEmbeddingCacheConnectorMetadata(
+            saves=[
+                mod._SaveCmd(
+                    mm_hash="a", offset=0, nbytes=_NB, num_embeds=_NE, writer_rank=0
+                ),
+            ]
+        )
+        meta2 = mod.MultimodalEmbeddingCacheConnectorMetadata(
+            saves=[
+                mod._SaveCmd(
+                    mm_hash="x", offset=0, nbytes=_NB, num_embeds=_NE, writer_rank=0
+                ),
+            ]
+        )
+        conn.bind_connector_metadata(meta1)
+        assert set(conn._save_cmd_by_hash) == {"a"}
+
+        with patch.object(mod.ECConnectorBase, "clear_connector_metadata"):
+            conn.clear_connector_metadata()
+        assert conn._save_cmd_by_hash == {}
+
+        conn.bind_connector_metadata(meta2)
+        assert set(conn._save_cmd_by_hash) == {"x"}
+
+
+class TestSaveCachesO1Lookup:
+    """save_caches uses the dict built in bind_connector_metadata."""
+
+    def test_dict_filtered_by_writer_rank_after_setup(self):
+        conn = _make_worker_connector(tp_rank=0)
+        metadata = mod.MultimodalEmbeddingCacheConnectorMetadata(
+            saves=[
+                mod._SaveCmd(
+                    mm_hash="a", offset=0, nbytes=_NB, num_embeds=_NE, writer_rank=0
+                ),
+                mod._SaveCmd(
+                    mm_hash="b", offset=_NB, nbytes=_NB, num_embeds=_NE, writer_rank=1
+                ),
+            ]
+        )
+        conn.bind_connector_metadata(metadata)
+        assert set(conn._save_cmd_by_hash) == {"a"}
+
+    def test_dict_unfiltered_before_setup(self):
+        conn = _make_worker_connector(tp_rank=0)
+        conn._worker_initialized = False  # simulate first-step path
+        metadata = mod.MultimodalEmbeddingCacheConnectorMetadata(
+            saves=[
+                mod._SaveCmd(
+                    mm_hash="a", offset=0, nbytes=_NB, num_embeds=_NE, writer_rank=0
+                ),
+                mod._SaveCmd(
+                    mm_hash="b", offset=_NB, nbytes=_NB, num_embeds=_NE, writer_rank=1
+                ),
+            ]
+        )
+        conn.bind_connector_metadata(metadata)
+        # Both present; writer_rank gate in save_caches still enforces correctness.
+        assert set(conn._save_cmd_by_hash) == {"a", "b"}
+
+    def test_non_our_metadata_type_resets_dict(self):
+        conn = _make_worker_connector()
+        conn._save_cmd_by_hash = {"stale": MagicMock()}  # type: ignore[dict-item]
+        conn.bind_connector_metadata(MagicMock())
+        assert conn._save_cmd_by_hash == {}
+
+    def test_save_caches_returns_silently_on_unknown_hash(self):
+        # Non-writer ranks see an empty dict; save_caches must early-return
+        # without touching state.
+        conn = _make_worker_connector(tp_rank=1)
+        metadata = mod.MultimodalEmbeddingCacheConnectorMetadata(
+            saves=[
+                mod._SaveCmd(
+                    mm_hash="a", offset=0, nbytes=_NB, num_embeds=_NE, writer_rank=0
+                ),
+            ]
+        )
+        conn.bind_connector_metadata(metadata)
+        assert conn._save_cmd_by_hash == {}  # filtered to rank 1, none match
+
+        # Calling save_caches for "a" should be a no-op — counters unchanged,
+        # no event flag set.
+        conn._saves_issued = 0
+        conn._save_pending_this_step = False
+        conn.save_caches(encoder_cache={}, mm_hash="a")
+        assert conn._saves_issued == 0
+        assert conn._save_pending_this_step is False
+
+
+class TestPlanBSingleEvent:
+    """Plan B fence: one event per step, recorded in clear_connector_metadata."""
+
+    def test_clear_records_event_when_save_pending(self):
+        conn = _make_worker_connector(fence_active=True)
+        conn._save_pending_this_step = True
+
+        fake_stream = MagicMock()
+        fake_event = MagicMock()
+        with (
+            patch.object(torch.cuda, "Event", return_value=fake_event),
+            patch.object(torch.cuda, "current_stream", return_value=fake_stream),
+            patch.object(mod.ECConnectorBase, "clear_connector_metadata"),
+        ):
+            conn.clear_connector_metadata()
+
+        fake_event.record.assert_called_once_with(conn._save_stream)
+        fake_stream.wait_event.assert_called_once_with(fake_event)
+        assert conn._save_pending_this_step is False
+        assert conn._save_cmd_by_hash == {}
+
+    def test_clear_no_op_when_no_save_pending(self):
+        conn = _make_worker_connector(fence_active=True)
+        conn._save_pending_this_step = False
+
+        fake_stream = MagicMock()
+        with (
+            patch.object(torch.cuda, "Event") as event_cls,
+            patch.object(torch.cuda, "current_stream", return_value=fake_stream),
+            patch.object(mod.ECConnectorBase, "clear_connector_metadata"),
+        ):
+            conn.clear_connector_metadata()
+
+        event_cls.assert_not_called()
+        fake_stream.wait_event.assert_not_called()
+
+    def test_plan_a_never_records_event(self, monkeypatch):
+        # With the fence inactive, save_caches must NOT set the pending flag,
+        # so clear_connector_metadata stays a no-op even if a save fired.
+        conn = _make_worker_connector(fence_active=False, tp_rank=0)
+        metadata = mod.MultimodalEmbeddingCacheConnectorMetadata(
+            saves=[
+                mod._SaveCmd(
+                    mm_hash="a", offset=0, nbytes=_NB, num_embeds=_NE, writer_rank=0
+                ),
+            ]
+        )
+        conn.bind_connector_metadata(metadata)
+        src = torch.zeros((_NE, conn._feature_dim), dtype=torch.float16)
+        encoder_cache = {"a": src}
+        # Bypass real CUDA: stub current_stream + stream + record_stream so
+        # the save path runs to completion on CPU.
+        monkeypatch.setattr(torch.cuda, "current_stream", lambda *a, **kw: MagicMock())
+        monkeypatch.setattr(torch.cuda, "stream", lambda *a, **kw: MagicMock())
+        monkeypatch.setattr(
+            torch.Tensor, "record_stream", lambda self, _s: None, raising=False
+        )
+
+        conn.save_caches(encoder_cache=encoder_cache, mm_hash="a")
+
+        assert conn._save_pending_this_step is False
+        # Plan A still must increment the per-rank save counter.
+        assert conn._saves_issued == 1

--- a/tests/report_pytest_markers.py
+++ b/tests/report_pytest_markers.py
@@ -223,6 +223,7 @@ STUB_MODULES = [
     "vllm.entrypoints.openai.engine",
     "vllm.entrypoints.openai.engine.protocol",
     "vllm.inputs",
+    "vllm.logger",
     "vllm.logprobs",
     "vllm.lora",
     "vllm.lora.request",


### PR DESCRIPTION
## Why

Sibling to #9289 (Plan A — CPU barrier). Same shared-shm arena substrate; replaces the per-step `dist.barrier` + `current_stream().synchronize()` with a GPU-side stream fence that piggybacks on the LLM forward's first TP NCCL all-reduce as the cross-rank visibility point. The fence is auto-gated: TP=1, encoder-only, and arches whose forward path we haven't traced fall back to Plan A. Init banner reports `sync_mode=PlanA|PlanB (<reason>)` so an operator can confirm which mode took effect.

On top of the fence, three perf passes the connector hot path was begging for: collapse N per-save CUDA events down to 1, replace the `O(N)` linear scan in `save_caches` with an `O(1)` dict built once per step in `bind_connector_metadata`, and coalesce hit-heavy H2D loads into a single `cudaMemcpyAsync` per contiguous arena span (per-cmd tensors are PyTorch views into the packed allocation, ref-counted via the storage).

## What Change

- Plan B NCCL stream-fence sync: `clear_connector_metadata` waits one save_done event on compute_stream; next op is the LLM forward's TP all-reduce.
- Architecture allowlist + env override (`DYN_EC_NCCL_FENCE`); auto-fallback to Plan A on TP=1 / encoder-only / unrecognized arch.
- Per-rank `saves_issued` / `loads_issued` counters logged every 100 multimodal-active steps via `vllm.dynamo_ec_connector` logger.
- O(1) save lookup, packed H2D, single-event fence — collapses per-save CUDA events and per-call linear scans.

## Test Plan

- Local TP=2 Qwen3-VL-2B-Instruct, two distinct base64 PNGs, miss-then-hit. `sync_mode=PlanB (nccl_fence)` on both ranks; both responses coherent.
- 35B FP8 sweep (fd vs fd-ec, 8K ISL / 1K OSL) — to follow.
