### PR TITLE
fix(ci): address remaining nightly runtime failures

### DIFF
--- a/tests/fault_tolerance/cancellation/utils.py
+++ b/tests/fault_tolerance/cancellation/utils.py
@@ -484,7 +484,7 @@ def poll_for_pattern(
     process: ManagedProcess,
     pattern: str,
     log_offset: int = 0,
-    max_wait_ms: int = 500,
+    max_wait_ms: int = 5000,
     poll_interval_ms: int = 5,
     match_type: str = "endswith",  # "contains" or "endswith"
 ) -> tuple[str, int]:

--- a/tests/fault_tolerance/test_canary_rank_pause.py
+++ b/tests/fault_tolerance/test_canary_rank_pause.py
@@ -27,6 +27,11 @@ from tests.serve.test_trtllm import trtllm_configs
 from tests.serve.test_vllm import vllm_configs
 from tests.utils.engine_process import EngineProcess
 
+
+def _is_cuda13() -> bool:
+    v = os.environ.get("CUDA_VERSION", "")
+    return v.startswith("13")
+
 logger = logging.getLogger(__name__)
 
 PAUSE_DETECT_BUDGET_S = 45
@@ -56,6 +61,20 @@ class RankPauseScenario:
 
 def _scenarios_for(backend: str) -> list:
     mark = getattr(pytest.mark, backend)
+
+    # sglang disagg workers use torch-memory-saver which preloads a .so that
+    # links libcudart.so.12.  That library doesn't exist in CUDA 13 images, so
+    # the scheduler subprocess dies with exit-code 127.  Skip these scenarios
+    # on CUDA 13 to match the skip already present in test_sglang.py configs.
+    disagg_marks: list = [mark]
+    if backend == "sglang":
+        disagg_marks.append(
+            pytest.mark.skipif(
+                _is_cuda13(),
+                reason="torch-memory-saver preload .so links libcudart.so.12, missing in cuda13 images",
+            )
+        )
+
     return [
         pytest.param(
             RankPauseScenario(f"{backend}-agg", backend, "aggregated", 0),
@@ -66,14 +85,14 @@ def _scenarios_for(backend: str) -> list:
             RankPauseScenario(
                 f"{backend}-disagg-prefill", backend, "disaggregated_same_gpu", 0
             ),
-            marks=mark,
+            marks=disagg_marks,
             id=f"{backend}-disagg-prefill",
         ),
         pytest.param(
             RankPauseScenario(
                 f"{backend}-disagg-decode", backend, "disaggregated_same_gpu", 1
             ),
-            marks=mark,
+            marks=disagg_marks,
             id=f"{backend}-disagg-decode",
         ),
     ]


### PR DESCRIPTION
## Summary

Fix two classes of nightly CI failures from run [25486043542](https://github.com/ai-dynamo/dynamo/actions/runs/25486043542), excluding the already-addressed hf-xet issues (PR #9287).

## Changes

### 1. sglang disagg canary skip on CUDA 13 (`tests/fault_tolerance/test_canary_rank_pause.py`)

**Failed tests:** `test_canary_detects_rank_pause[2-sglang-disagg-prefill]`, `[2-sglang-disagg-decode]`
**Root cause:** The sglang disaggregated scheduler uses `torch-memory-saver` which preloads a shared library that links `libcudart.so.12`. In CUDA 13 container images only `libcudart.so.13` exists, so the subprocess dies immediately (exit code 127).

**Fix:** Add `pytest.mark.skipif(_is_cuda13(), ...)` to sglang disagg parametrized scenarios in the canary test. This matches the existing skip already present in `tests/serve/test_sglang.py` for the `disaggregated_same_gpu` config.

### 2. Widen cancellation test polling window (`tests/fault_tolerance/cancellation/utils.py`)

**Failed tests:** `test_request_cancellation_vllm_decode_cancel[nats]`, `test_request_cancellation_vllm_prefill_cancel[nats]`, `test_request_cancellation_vllm_prefill_cancel[tcp]`
**Root cause:** `poll_for_pattern()` had a default `max_wait_ms=500` (0.5 s). In CI, disaggregated vLLM workers under load can take longer than 500 ms to emit log patterns after a cancellation event. The assertion fires after 100 iterations (500 ms), well before the test-level timeout of 150 s.

**Fix:** Increase the default `max_wait_ms` from 500 to 5000 ms (5 s). This is still far below individual test timeouts and does not change the fast-path — patterns found immediately still return immediately. The single negative-test call site (`max_wait_ms=10`) that verifies absence is unaffected.

## Not addressed (follow-up needed)

### 3. trtllm-runtime KVBM CUDA graph tests on CUDA 13.1

**Failed tests:** `tests/kvbm_integration/test_cuda_graph.py::test_kvbm_without_cuda_graph_enabled`, `::test_kvbm_with_cuda_graph_enabled`
**Error:** `RuntimeError: Executor worker returned error` from `tensorrt_llm/executor/proxy.py:279` during TinyLlama KVBM model build. Also warns about torchao incompatibility with torch 2.11.0a0+...nv26.02.

**Assessment:** This appears to be an upstream TRT-LLM / torchao / container toolchain incompatibility specific to CUDA 13.1. No safe code/config fix is apparent without upstream coordination. A speculative test skip would mask a real regression.

**Recommended follow-up:** File an upstream issue or coordinate with the TRT-LLM container team to resolve the toolchain mismatch in the CUDA 13.1 image. Once resolved, confirm the tests pass in that image.

## Validation

- Confirmed the `_is_cuda13()` logic matches the existing pattern used in `tests/serve/test_sglang.py:43` and `tests/serve/test_vllm.py:41`.
- Confirmed the single explicit `max_wait_ms=10` negative-test call site (line 476 in `test_vllm.py`) is unaffected by the default change.
- Verified no other callers of `poll_for_pattern` rely on the 500 ms default being tight.
- GPG-signed and DCO signed-off commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased polling timeout duration for cancellation test reliability.
  * Added conditional skipping of disaggregated test scenarios on CUDA 13 to address compatibility issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->