### PR TITLE
feat(llm/realtime): wire /v1/realtime through ModelManager + bidirectional PushRouter

### DIFF
--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -604,6 +604,10 @@ impl ModelType {
     const Videos: Self = ModelType {
         inner: llm_rs::model_type::ModelType::Videos,
     };
+    #[classattr]
+    const Realtime: Self = ModelType {
+        inner: llm_rs::model_type::ModelType::Realtime,
+    };
 
     fn supports_chat(&self) -> bool {
         self.inner.supports_chat()

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -1347,7 +1347,7 @@ class ModelInput:
 
 
 class ModelType:
-    """What type of request this model needs: Chat, Completions, Embedding, Tensor, Images, Videos or Prefill"""
+    """What type of request this model needs: Chat, Completions, Embedding, Tensor, Images, Videos, Realtime or Prefill"""
     Chat: ModelType
     Completions: ModelType
     Embedding: ModelType
@@ -1356,6 +1356,7 @@ class ModelType:
     Images: ModelType
     Audios: ModelType
     Videos: ModelType
+    Realtime: ModelType
 
     def __or__(self, other: ModelType) -> ModelType:
         ...

--- a/lib/llm/src/discovery/model.rs
+++ b/lib/llm/src/discovery/model.rs
@@ -17,6 +17,7 @@ use super::{KvWorkerMonitor, ModelManagerError};
 use crate::protocols::openai::ParsingOptions;
 
 use crate::types::{
+    RealtimeBidirectionalEngine,
     generic::tensor::TensorStreamingEngine,
     openai::{
         audios::OpenAIAudiosStreamingEngine,
@@ -157,6 +158,13 @@ impl Model {
             .any(|entry| entry.value().has_audios_engine())
     }
 
+    /// Check if any WorkerSet has a realtime engine.
+    pub fn has_realtime_engine(&self) -> bool {
+        self.worker_sets
+            .iter()
+            .any(|entry| entry.value().has_realtime_engine())
+    }
+
     // -- Topology readiness --
     //
     // A *topology* is the set of WorkerSets in this Model that share the same
@@ -275,6 +283,7 @@ impl Model {
                 || ws.has_tensor_engine()
                 || ws.has_videos_engine()
                 || ws.has_audios_engine()
+                || ws.has_realtime_engine()
         };
 
         let has_any_serving_engine = self.worker_sets.iter().any(|entry| {
@@ -332,6 +341,11 @@ impl Model {
     pub fn get_tensor_engine(&self) -> Result<TensorStreamingEngine, ModelManagerError> {
         self.select_worker_set_with(|ws| ws.tensor_engine.clone())
             .ok_or_else(|| self.engine_error(self.has_tensor_engine()))
+    }
+
+    pub fn get_realtime_engine(&self) -> Result<RealtimeBidirectionalEngine, ModelManagerError> {
+        self.select_worker_set_with(|ws| ws.realtime_engine.clone())
+            .ok_or_else(|| self.engine_error(self.has_realtime_engine()))
     }
 
     // -- Combined engine + parsing options (atomically from one WorkerSet) --
@@ -627,6 +641,32 @@ mod tests {
         assert!(model.get_embeddings_engine().is_err());
         assert!(model.get_images_engine().is_err());
         assert!(model.get_tensor_engine().is_err());
+        assert!(model.get_realtime_engine().is_err());
+    }
+
+    fn make_realtime_worker_set(namespace: &str) -> Arc<WorkerSet> {
+        let mut ws = WorkerSet::new(
+            namespace.to_string(),
+            "abc".to_string(),
+            ModelDeploymentCard::default(),
+        );
+        ws.realtime_engine = Some(Arc::new(crate::engines::EchoBidirectionalEngine));
+        Arc::new(ws)
+    }
+
+    #[test]
+    fn test_realtime_engine_round_trip() {
+        let model = Model::new("realtime-mock".to_string());
+        model.add_worker_set("ns1".to_string(), make_realtime_worker_set("ns1"));
+        assert!(model.has_realtime_engine());
+        assert!(model.get_realtime_engine().is_ok());
+    }
+
+    #[test]
+    fn test_realtime_only_model_is_displayable() {
+        let model = Model::new("realtime-mock".to_string());
+        model.add_worker_set("ns1".to_string(), make_realtime_worker_set("ns1"));
+        assert!(model.is_displayable());
     }
 
     #[test]

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -25,6 +25,7 @@ use crate::{
     local_model::runtime_config::DisaggregatedEndpoint,
     model_card::ModelDeploymentCard,
     types::{
+        RealtimeBidirectionalEngine,
         generic::tensor::TensorStreamingEngine,
         openai::{
             audios::OpenAIAudiosStreamingEngine,
@@ -250,6 +251,14 @@ impl ModelManager {
             .collect()
     }
 
+    pub fn list_realtime_models(&self) -> Vec<String> {
+        self.models
+            .iter()
+            .filter(|entry| entry.value().has_realtime_engine())
+            .map(|entry| entry.key().clone())
+            .collect()
+    }
+
     pub fn list_prefill_models(&self) -> Vec<String> {
         self.models
             .iter()
@@ -326,6 +335,16 @@ impl ModelManager {
             .get(model)
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
             .get_audios_engine()
+    }
+
+    pub fn get_realtime_engine(
+        &self,
+        model: &str,
+    ) -> Result<RealtimeBidirectionalEngine, ModelManagerError> {
+        self.models
+            .get(model)
+            .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
+            .get_realtime_engine()
     }
 
     // -- Combined engine + parsing options (atomically from one WorkerSet) --
@@ -515,6 +534,27 @@ impl ModelManager {
         Ok(())
     }
 
+    pub fn add_realtime_model(
+        &self,
+        model: &str,
+        card_checksum: &str,
+        engine: RealtimeBidirectionalEngine,
+    ) -> Result<(), ModelManagerError> {
+        let model_entry = self.get_or_create_model(model);
+        if model_entry.has_realtime_engine() {
+            return Err(ModelManagerError::ModelAlreadyExists(model.to_string()));
+        }
+        let namespace = format!("__local_realtime_{}", model);
+        let mut ws = WorkerSet::new(
+            namespace.clone(),
+            card_checksum.to_string(),
+            ModelDeploymentCard::default(),
+        );
+        ws.realtime_engine = Some(engine);
+        model_entry.add_worker_set(namespace, Arc::new(ws));
+        Ok(())
+    }
+
     pub fn add_prefill_model(
         &self,
         model: &str,
@@ -582,6 +622,13 @@ impl ModelManager {
 
     pub fn remove_videos_model(&self, model: &str) -> Result<(), ModelManagerError> {
         let namespace = format!("__local_videos_{}", model);
+        self.remove_worker_set(model, &namespace)
+            .map(|_| ())
+            .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))
+    }
+
+    pub fn remove_realtime_model(&self, model: &str) -> Result<(), ModelManagerError> {
+        let namespace = format!("__local_realtime_{}", model);
         self.remove_worker_set(model, &namespace)
             .map(|_| ())
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))
@@ -1151,6 +1198,45 @@ mod tests {
     fn test_model_display_names_empty() {
         let mm = ModelManager::new();
         assert!(mm.model_display_names().is_empty());
+    }
+
+    #[test]
+    fn test_add_get_remove_realtime_model_round_trip() {
+        let mm = ModelManager::new();
+        let engine = std::sync::Arc::new(crate::engines::EchoBidirectionalEngine);
+
+        mm.add_realtime_model("rt-echo", "0", engine.clone())
+            .unwrap();
+        assert!(mm.list_realtime_models().contains(&"rt-echo".to_string()));
+        assert!(mm.get_realtime_engine("rt-echo").is_ok());
+
+        mm.remove_realtime_model("rt-echo").unwrap();
+        assert!(!mm.list_realtime_models().contains(&"rt-echo".to_string()));
+        assert!(matches!(
+            mm.get_realtime_engine("rt-echo"),
+            Err(ModelManagerError::ModelNotFound(_))
+        ));
+    }
+
+    #[test]
+    fn test_add_realtime_model_duplicate() {
+        let mm = ModelManager::new();
+        let engine = std::sync::Arc::new(crate::engines::EchoBidirectionalEngine);
+        mm.add_realtime_model("rt-echo", "0", engine.clone())
+            .unwrap();
+        assert!(matches!(
+            mm.add_realtime_model("rt-echo", "0", engine),
+            Err(ModelManagerError::ModelAlreadyExists(_))
+        ));
+    }
+
+    #[test]
+    fn test_get_realtime_engine_missing() {
+        let mm = ModelManager::new();
+        assert!(matches!(
+            mm.get_realtime_engine("does-not-exist"),
+            Err(ModelManagerError::ModelNotFound(_))
+        ));
     }
 
     #[test]

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -1068,16 +1068,8 @@ impl ModelWatcher {
             .await?;
             worker_set.tensor_engine = Some(Arc::new(push_router));
         } else if card.model_input == ModelInput::Text && card.model_type.supports_realtime() {
-            // Mirrors the Images / Videos / Audios shape: a single PushRouter
-            // typed end-to-end on the realtime event pair, no Backend /
-            // Migration composition. The `model_input == Text` guard matches
-            // the multimodal arm above — realtime carries JSON `Message::Text`
-            // frames over `/v1/realtime`. Note that PushRouter's bidirectional
-            // generate currently bails after sticky-instance selection
-            // pending #9361 (remote dispatch over AddressedPushRouter), so
-            // the engine slot is populated but unusable for discovered
-            // workers until that work lands. The local-engine path via
-            // ModelManager.add_realtime_model is unaffected.
+            // Case 7: Text + Realtime
+            // 'Text' is being overloaded here, it simply means the I/O will be passed through
             let realtime_router = PushRouter::<
                 RealtimeClientEvent,
                 Annotated<RealtimeServerEvent>,

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -1067,10 +1067,12 @@ impl ModelWatcher {
             )
             .await?;
             worker_set.tensor_engine = Some(Arc::new(push_router));
-        } else if card.model_type.supports_realtime() {
+        } else if card.model_input == ModelInput::Text && card.model_type.supports_realtime() {
             // Mirrors the Images / Videos / Audios shape: a single PushRouter
             // typed end-to-end on the realtime event pair, no Backend /
-            // Migration composition. Note that PushRouter's bidirectional
+            // Migration composition. The `model_input == Text` guard matches
+            // the multimodal arm above — realtime carries JSON `Message::Text`
+            // frames over `/v1/realtime`. Note that PushRouter's bidirectional
             // generate currently bails after sticky-instance selection
             // pending #9361 (remote dispatch over AddressedPushRouter), so
             // the engine slot is populated but unusable for discovered

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -49,6 +49,7 @@ use crate::{
         },
         tensor::{NvCreateTensorRequest, NvCreateTensorResponse},
     },
+    types::generic::realtime::{RealtimeClientEvent, RealtimeServerEvent},
 };
 
 use super::ModelManager;
@@ -1066,6 +1067,15 @@ impl ModelWatcher {
             )
             .await?;
             worker_set.tensor_engine = Some(Arc::new(push_router));
+        } else if card.model_type.supports_realtime() {
+            let realtime_router = PushRouter::<
+                RealtimeClientEvent,
+                Annotated<RealtimeServerEvent>,
+            >::from_client_with_monitor(
+                client, router_config.router_mode, None
+            )
+            .await?;
+            worker_set.realtime_engine = Some(Arc::new(realtime_router));
         } else if card.model_type.supports_prefill() {
             // Case 6: Prefill
             // Guardrail: Verify model_input is Tokens

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -104,6 +104,7 @@ const ALL_MODEL_TYPES: &[ModelType] = &[
     ModelType::Videos,
     ModelType::TensorBased,
     ModelType::Prefill,
+    ModelType::Realtime,
 ];
 
 /// Returns true if no models in the manager support the given model type.
@@ -124,6 +125,8 @@ fn is_model_type_list_empty(manager: &ModelManager, model_type: ModelType) -> bo
         manager.list_tensor_models().is_empty()
     } else if model_type == ModelType::Prefill {
         manager.list_prefill_models().is_empty()
+    } else if model_type == ModelType::Realtime {
+        manager.list_realtime_models().is_empty()
     } else {
         true
     }
@@ -1221,6 +1224,20 @@ mod tests {
         assert!(is_model_type_list_empty(&mm, ModelType::Videos));
         assert!(is_model_type_list_empty(&mm, ModelType::TensorBased));
         assert!(is_model_type_list_empty(&mm, ModelType::Prefill));
+        assert!(is_model_type_list_empty(&mm, ModelType::Realtime));
+    }
+
+    #[test]
+    fn test_is_model_type_list_empty_realtime_after_register() {
+        let mm = ModelManager::new();
+        let engine = std::sync::Arc::new(crate::engines::EchoBidirectionalEngine);
+        mm.add_realtime_model("rt-echo", "0", engine).unwrap();
+        assert!(!is_model_type_list_empty(&mm, ModelType::Realtime));
+    }
+
+    #[test]
+    fn test_realtime_in_all_model_types() {
+        assert!(ALL_MODEL_TYPES.contains(&ModelType::Realtime));
     }
 
     #[test]

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -1068,6 +1068,14 @@ impl ModelWatcher {
             .await?;
             worker_set.tensor_engine = Some(Arc::new(push_router));
         } else if card.model_type.supports_realtime() {
+            // Mirrors the Images / Videos / Audios shape: a single PushRouter
+            // typed end-to-end on the realtime event pair, no Backend /
+            // Migration composition. Note that PushRouter's bidirectional
+            // generate currently bails after sticky-instance selection
+            // pending #9361 (remote dispatch over AddressedPushRouter), so
+            // the engine slot is populated but unusable for discovered
+            // workers until that work lands. The local-engine path via
+            // ModelManager.add_realtime_model is unaffected.
             let realtime_router = PushRouter::<
                 RealtimeClientEvent,
                 Annotated<RealtimeServerEvent>,

--- a/lib/llm/src/discovery/worker_set.rs
+++ b/lib/llm/src/discovery/worker_set.rs
@@ -14,6 +14,7 @@ use crate::{
     kv_router::{KvRouter, PrefillRouter},
     model_card::ModelDeploymentCard,
     types::{
+        RealtimeBidirectionalEngine,
         generic::tensor::TensorStreamingEngine,
         openai::{
             audios::OpenAIAudiosStreamingEngine,
@@ -44,6 +45,7 @@ pub struct WorkerSet {
     pub(crate) videos_engine: Option<OpenAIVideosStreamingEngine>,
     pub(crate) audios_engine: Option<OpenAIAudiosStreamingEngine>,
     pub(crate) tensor_engine: Option<TensorStreamingEngine>,
+    pub(crate) realtime_engine: Option<RealtimeBidirectionalEngine>,
 
     /// KV router for this set's workers (if KV mode)
     pub(crate) kv_router: Option<Arc<KvRouter>>,
@@ -73,6 +75,7 @@ impl WorkerSet {
             videos_engine: None,
             audios_engine: None,
             tensor_engine: None,
+            realtime_engine: None,
             kv_router: None,
             worker_monitor: None,
             prefill_router: None,
@@ -120,6 +123,10 @@ impl WorkerSet {
         self.tensor_engine.is_some()
     }
 
+    pub fn has_realtime_engine(&self) -> bool {
+        self.realtime_engine.is_some()
+    }
+
     /// Whether this set has any decode engine (chat or completions)
     pub fn has_decode_engine(&self) -> bool {
         self.has_chat_engine() || self.has_completions_engine()
@@ -133,6 +140,7 @@ impl WorkerSet {
             && !self.has_videos_engine()
             && !self.has_audios_engine()
             && !self.has_tensor_engine()
+            && !self.has_realtime_engine()
     }
 
     /// Build ParsingOptions from this WorkerSet's card configuration.
@@ -197,8 +205,17 @@ mod tests {
         assert!(!ws.has_embeddings_engine());
         assert!(!ws.has_images_engine());
         assert!(!ws.has_tensor_engine());
+        assert!(!ws.has_realtime_engine());
         assert!(!ws.has_decode_engine());
         assert!(ws.is_prefill_set());
+    }
+
+    #[test]
+    fn test_realtime_only_set_is_not_prefill() {
+        let mut ws = make_worker_set("ns1", "abc123");
+        ws.realtime_engine = Some(Arc::new(crate::engines::EchoBidirectionalEngine));
+        assert!(ws.has_realtime_engine());
+        assert!(!ws.is_prefill_set());
     }
 
     #[test]

--- a/lib/llm/src/discovery/worker_set.rs
+++ b/lib/llm/src/discovery/worker_set.rs
@@ -181,6 +181,22 @@ impl WorkerSet {
 mod tests {
     use super::*;
     use crate::model_card::ModelDeploymentCard;
+    use crate::types::Annotated;
+    use crate::types::generic::tensor::{NvCreateTensorRequest, NvCreateTensorResponse};
+    use crate::types::openai::audios::{NvAudioSpeechResponse, NvCreateAudioSpeechRequest};
+    use crate::types::openai::chat_completions::{
+        NvCreateChatCompletionRequest, NvCreateChatCompletionStreamResponse,
+    };
+    use crate::types::openai::completions::{
+        NvCreateCompletionRequest, NvCreateCompletionResponse,
+    };
+    use crate::types::openai::embeddings::{NvCreateEmbeddingRequest, NvCreateEmbeddingResponse};
+    use crate::types::openai::images::{NvCreateImageRequest, NvImagesResponse};
+    use crate::types::openai::videos::{NvCreateVideoRequest, NvVideosResponse};
+    use async_trait::async_trait;
+    use dynamo_runtime::engine::AsyncEngine;
+    use dynamo_runtime::pipeline::{Error, ManyOut, SingleIn};
+    use std::marker::PhantomData;
 
     fn make_worker_set(namespace: &str, mdcsum: &str) -> WorkerSet {
         WorkerSet::new(
@@ -188,6 +204,30 @@ mod tests {
             mdcsum.to_string(),
             ModelDeploymentCard::default(),
         )
+    }
+
+    /// Generic stub satisfying any `ServerStreamingEngine<Req, Annotated<Resp>>` trait
+    /// object. `generate` is unreachable: the stub exists only to populate typed engine
+    /// slots on `WorkerSet` so `is_prefill_set`'s exclusion logic can be exercised per
+    /// field. `Req` / `Resp` are inferred from the assignment-site engine alias.
+    struct StubEngine<Req, Resp>(PhantomData<fn() -> (Req, Resp)>);
+
+    impl<Req, Resp> StubEngine<Req, Resp> {
+        fn new() -> Arc<Self> {
+            Arc::new(Self(PhantomData))
+        }
+    }
+
+    #[async_trait]
+    impl<Req, Resp> AsyncEngine<SingleIn<Req>, ManyOut<Annotated<Resp>>, Error>
+        for StubEngine<Req, Resp>
+    where
+        Req: dynamo_runtime::engine::Data,
+        Resp: dynamo_runtime::engine::Data,
+    {
+        async fn generate(&self, _req: SingleIn<Req>) -> Result<ManyOut<Annotated<Resp>>, Error> {
+            unimplemented!("stub for is_prefill_set classification tests only")
+        }
     }
 
     #[test]
@@ -204,18 +244,82 @@ mod tests {
         assert!(!ws.has_completions_engine());
         assert!(!ws.has_embeddings_engine());
         assert!(!ws.has_images_engine());
+        assert!(!ws.has_videos_engine());
+        assert!(!ws.has_audios_engine());
         assert!(!ws.has_tensor_engine());
         assert!(!ws.has_realtime_engine());
         assert!(!ws.has_decode_engine());
         assert!(ws.is_prefill_set());
     }
 
+    /// `is_prefill_set` must exclude every serving-engine field on `WorkerSet`. If a new
+    /// engine variant is added without updating `is_prefill_set`, a worker that registers
+    /// only that engine would be misclassified as prefill — silent and easy to miss in
+    /// integration tests. This walks each engine in isolation so the failing arm names
+    /// itself.
     #[test]
-    fn test_realtime_only_set_is_not_prefill() {
-        let mut ws = make_worker_set("ns1", "abc123");
-        ws.realtime_engine = Some(Arc::new(crate::engines::EchoBidirectionalEngine));
-        assert!(ws.has_realtime_engine());
-        assert!(!ws.is_prefill_set());
+    fn test_any_serving_engine_excludes_prefill() {
+        macro_rules! check {
+            ($field:ident, $has:ident, $engine:expr, $label:literal) => {{
+                let mut ws = make_worker_set("ns1", "abc123");
+                ws.$field = Some($engine);
+                assert!(ws.$has());
+                assert!(
+                    !ws.is_prefill_set(),
+                    concat!($label, "-only WorkerSet must not be classified as prefill")
+                );
+            }};
+        }
+
+        check!(
+            chat_engine,
+            has_chat_engine,
+            StubEngine::<NvCreateChatCompletionRequest, NvCreateChatCompletionStreamResponse>::new(
+            ),
+            "chat"
+        );
+        check!(
+            completions_engine,
+            has_completions_engine,
+            StubEngine::<NvCreateCompletionRequest, NvCreateCompletionResponse>::new(),
+            "completions"
+        );
+        check!(
+            embeddings_engine,
+            has_embeddings_engine,
+            StubEngine::<NvCreateEmbeddingRequest, NvCreateEmbeddingResponse>::new(),
+            "embeddings"
+        );
+        check!(
+            images_engine,
+            has_images_engine,
+            StubEngine::<NvCreateImageRequest, NvImagesResponse>::new(),
+            "images"
+        );
+        check!(
+            videos_engine,
+            has_videos_engine,
+            StubEngine::<NvCreateVideoRequest, NvVideosResponse>::new(),
+            "videos"
+        );
+        check!(
+            audios_engine,
+            has_audios_engine,
+            StubEngine::<NvCreateAudioSpeechRequest, NvAudioSpeechResponse>::new(),
+            "audios"
+        );
+        check!(
+            tensor_engine,
+            has_tensor_engine,
+            StubEngine::<NvCreateTensorRequest, NvCreateTensorResponse>::new(),
+            "tensor"
+        );
+        check!(
+            realtime_engine,
+            has_realtime_engine,
+            Arc::new(crate::engines::EchoBidirectionalEngine),
+            "realtime"
+        );
     }
 
     #[test]

--- a/lib/llm/src/endpoint_type.rs
+++ b/lib/llm/src/endpoint_type.rs
@@ -18,6 +18,8 @@ pub enum EndpointType {
     Audios,
     /// Videos API (video generation)
     Videos,
+    /// Realtime API (bidirectional streaming over WebSocket)
+    Realtime,
     /// Responses API
     Responses,
     /// Anthropic Messages API
@@ -33,6 +35,7 @@ impl EndpointType {
             Self::Images => "images",
             Self::Audios => "audios",
             Self::Videos => "videos",
+            Self::Realtime => "realtime",
             Self::Responses => "responses",
             Self::AnthropicMessages => "anthropic_messages",
         }
@@ -46,8 +49,24 @@ impl EndpointType {
             Self::Images,
             Self::Audios,
             Self::Videos,
+            Self::Realtime,
             Self::Responses,
             Self::AnthropicMessages,
         ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn realtime_as_str() {
+        assert_eq!(EndpointType::Realtime.as_str(), "realtime");
+    }
+
+    #[test]
+    fn realtime_in_all() {
+        assert!(EndpointType::all().contains(&EndpointType::Realtime));
     }
 }

--- a/lib/llm/src/http/service/realtime.rs
+++ b/lib/llm/src/http/service/realtime.rs
@@ -199,7 +199,6 @@ async fn handle_socket(socket: WebSocket, state: Arc<service_v2::State>) {
         // writer dropped at end of scope → spawned cleanup sends Close + drains.
     });
 
-    // Inbound loop: parse client frames into request stream items.
     while let Some(msg) = ws_rx.next().await {
         let msg = match msg {
             Ok(m) => m,
@@ -267,6 +266,16 @@ fn close_message(code: u16, reason: &str) -> Message {
 /// the sink: `writer.send(...).await`, `&mut *writer` for fns that take
 /// `&mut Sink<Message>`. There is no explicit close API — the close sequence
 /// is bound to the wrapper's lifecycle, including panic / early-return paths.
+///
+/// `Drop` is sync and the close sequence is async, so the cleanup runs on
+/// a spawned task that outlives the dropping scope. The task owns `ws_tx`
+/// exclusively, so the WebSocket's underlying TCP socket stays open until
+/// the cleanup writes the Close frame, drains the sink under
+/// `CLOSE_DRAIN_TIMEOUT`, and drops `ws_tx`. `handle_socket`'s
+/// `outbound.await` returns *before* the Close frame is on the wire, but
+/// the client still sees the in-band Close — the only scenario the cleanup
+/// can't complete is runtime shutdown racing connection teardown, which
+/// doesn't happen on axum's long-lived global runtime.
 struct ScopedWsWriter {
     ws_tx: Option<SplitSink<WebSocket, Message>>,
     close_reason: Arc<Mutex<Option<Message>>>,
@@ -289,7 +298,7 @@ impl std::ops::Deref for ScopedWsWriter {
     fn deref(&self) -> &Self::Target {
         self.ws_tx
             .as_ref()
-            .expect("ScopedWsWriter sink already taken")
+            .expect("ScopedWsWriter sink only taken by Drop; no other consumer should exist")
     }
 }
 
@@ -297,7 +306,7 @@ impl std::ops::DerefMut for ScopedWsWriter {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.ws_tx
             .as_mut()
-            .expect("ScopedWsWriter sink already taken")
+            .expect("ScopedWsWriter sink only taken by Drop; no other consumer should exist")
     }
 }
 
@@ -358,7 +367,9 @@ where
                 match serde_json::from_str::<RealtimeClientEvent>(text.as_str()) {
                     Ok(e) => e,
                     Err(err) => {
-                        tracing::warn!(%err, "/v1/realtime malformed JSON during engine selection");
+                        // Client-driven and repeatable; debug! so a misbehaving
+                        // peer can't amplify the log channel.
+                        tracing::debug!(%err, "/v1/realtime malformed JSON during engine selection");
                         send_error_event(ws_tx, "invalid_request", "malformed JSON frame", None)
                             .await;
                         continue;
@@ -366,7 +377,7 @@ where
                 }
             }
             Message::Binary(_) => {
-                tracing::warn!("/v1/realtime binary frame during engine selection");
+                tracing::debug!("/v1/realtime binary frame during engine selection");
                 send_error_event(
                     ws_tx,
                     "invalid_request",
@@ -382,7 +393,7 @@ where
         let session_update = match event {
             RealtimeClientEvent::SessionUpdate(req) => req,
             other => {
-                tracing::warn!(
+                tracing::debug!(
                     event = other.event_type(),
                     "/v1/realtime expected session.update before engine selection"
                 );

--- a/lib/llm/src/http/service/realtime.rs
+++ b/lib/llm/src/http/service/realtime.rs
@@ -41,7 +41,7 @@ use axum::{
 };
 use dynamo_runtime::engine::{AsyncEngineContextProvider, RequestStream};
 use dynamo_runtime::pipeline::Context;
-use futures::{SinkExt, StreamExt};
+use futures::{SinkExt, StreamExt, stream::SplitSink};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 
@@ -83,7 +83,14 @@ async fn realtime_ws_handler(
     upgrade.on_upgrade(move |socket| handle_socket(socket, state))
 }
 
-async fn handle_socket(mut socket: WebSocket, state: Arc<service_v2::State>) {
+async fn handle_socket(socket: WebSocket, state: Arc<service_v2::State>) {
+    // Inbound writes a non-NORMAL close message to `close_reason` on protocol errors
+    // before cancelling the engine; the ScopedWsWriter takes it on Drop.
+    // Empty slot ⇒ NORMAL completion.
+    let close_reason: Arc<Mutex<Option<Message>>> = Arc::new(Mutex::new(None));
+    let (ws_tx, mut ws_rx) = socket.split();
+    let mut writer = ScopedWsWriter::new(ws_tx, close_reason.clone());
+
     // OpenAI Realtime spec requires `session.created` to be the first server
     // frame on the wire, before any client event arrives. The handler synthesizes
     // it here so the connection handshake works regardless of which engine is
@@ -96,16 +103,14 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<service_v2::State>) {
         Ok(s) => s,
         Err(err) => {
             tracing::error!(%err, "/v1/realtime serializing session.created failed");
-            let _ = socket
-                .send(close_message(
-                    close_code::ERROR,
-                    "internal error preparing session.created",
-                ))
-                .await;
+            *close_reason.lock() = Some(close_message(
+                close_code::ERROR,
+                "internal error preparing session.created",
+            ));
             return;
         }
     };
-    if let Err(err) = socket
+    if let Err(err) = writer
         .send(Message::Text(Utf8Bytes::from(session_created_payload)))
         .await
     {
@@ -113,13 +118,10 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<service_v2::State>) {
         return;
     }
 
-    let (mut ws_tx, mut ws_rx) = socket.split();
-
     let Some((engine, session_update)) =
-        select_engine(&mut ws_rx, &mut ws_tx, state.as_ref()).await
+        select_engine(&mut ws_rx, &mut *writer, state.as_ref()).await
     else {
-        // Client disconnected before an engine was selected; no close frame
-        // to send (the peer is already gone or sent its own Close).
+        // Client disconnected before an engine was selected.
         return;
     };
 
@@ -141,21 +143,14 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<service_v2::State>) {
     let request_stream = Box::pin(ReceiverStream::new(req_rx));
     let input = RequestStream::new(request_stream, Context::new(()).context());
 
-    // Inbound writes a non-NORMAL close message here on protocol errors
-    // before cancelling the engine; outbound takes it after the response
-    // stream ends. Empty slot ⇒ NORMAL completion.
-    let close_reason: Arc<Mutex<Option<Message>>> = Arc::new(Mutex::new(None));
-
     let mut response_stream = match engine.generate(input).await {
         Ok(s) => s,
         Err(err) => {
             tracing::error!(%err, "/v1/realtime engine.generate() failed");
-            let _ = ws_tx
-                .send(close_message(
-                    close_code::ERROR,
-                    &format!("engine error: {err}"),
-                ))
-                .await;
+            *close_reason.lock() = Some(close_message(
+                close_code::ERROR,
+                &format!("engine error: {err}"),
+            ));
             return;
         }
     };
@@ -166,8 +161,8 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<service_v2::State>) {
     // `RealtimeServerEvent` frames as the OpenAI Realtime spec requires. Engine
     // errors surfaced via `Annotated::error` are mapped to a synthesized
     // `RealtimeServerEvent::Error` so they remain visible on the wire.
-    let outbound_close_reason = close_reason.clone();
     let outbound = tokio::spawn(async move {
+        let mut writer = writer;
         while let Some(annotated) = response_stream.next().await {
             let event = if let Some(event) = annotated.data {
                 event
@@ -192,7 +187,7 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<service_v2::State>) {
                     continue;
                 }
             };
-            if ws_tx
+            if writer
                 .send(Message::Text(Utf8Bytes::from(frame_payload)))
                 .await
                 .is_err()
@@ -201,19 +196,7 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<service_v2::State>) {
                 break;
             }
         }
-        // Pick the close message inbound left behind on protocol errors;
-        // otherwise the engine ended naturally (or via client cancellation)
-        // → NORMAL.
-        let msg = outbound_close_reason
-            .lock()
-            .take()
-            .unwrap_or_else(|| close_message(close_code::NORMAL, "stream complete"));
-        let _ = ws_tx.send(msg).await;
-        // Drive the sink to completion so the Close frame drains before the
-        // transport is dropped — otherwise axum can tear down the TCP socket
-        // mid-frame and the client sees EOF instead of an in-band Close. Bound
-        // the wait so a half-broken peer can't park this task indefinitely.
-        let _ = tokio::time::timeout(CLOSE_DRAIN_TIMEOUT, ws_tx.close()).await;
+        // writer dropped at end of scope → spawned cleanup sends Close + drains.
     });
 
     // Inbound loop: parse client frames into request stream items.
@@ -271,6 +254,72 @@ fn close_message(code: u16, reason: &str) -> Message {
         code,
         reason: Utf8Bytes::from(reason.to_string()),
     }))
+}
+
+/// RAII wrapper around the outbound side of the WebSocket. Owns the
+/// [`SplitSink`] plus the inbound-supplied close-reason slot, and on `Drop`
+/// spawns a detached cleanup that sends the Close frame (inbound-supplied
+/// reason, or `NORMAL`) and drives the sink to completion under
+/// [`CLOSE_DRAIN_TIMEOUT`]. Without that drain step axum can tear down the TCP
+/// socket mid-frame and the client sees EOF instead of an in-band Close.
+///
+/// The wrapper [`Deref`]s to its inner sink so callers use it as if it were
+/// the sink: `writer.send(...).await`, `&mut *writer` for fns that take
+/// `&mut Sink<Message>`. There is no explicit close API — the close sequence
+/// is bound to the wrapper's lifecycle, including panic / early-return paths.
+struct ScopedWsWriter {
+    ws_tx: Option<SplitSink<WebSocket, Message>>,
+    close_reason: Arc<Mutex<Option<Message>>>,
+}
+
+impl ScopedWsWriter {
+    fn new(
+        ws_tx: SplitSink<WebSocket, Message>,
+        close_reason: Arc<Mutex<Option<Message>>>,
+    ) -> Self {
+        Self {
+            ws_tx: Some(ws_tx),
+            close_reason,
+        }
+    }
+}
+
+impl std::ops::Deref for ScopedWsWriter {
+    type Target = SplitSink<WebSocket, Message>;
+    fn deref(&self) -> &Self::Target {
+        self.ws_tx
+            .as_ref()
+            .expect("ScopedWsWriter sink already taken")
+    }
+}
+
+impl std::ops::DerefMut for ScopedWsWriter {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.ws_tx
+            .as_mut()
+            .expect("ScopedWsWriter sink already taken")
+    }
+}
+
+impl Drop for ScopedWsWriter {
+    fn drop(&mut self) {
+        let Some(mut ws_tx) = self.ws_tx.take() else {
+            return;
+        };
+        let close_reason = self.close_reason.clone();
+        // Spawn detached because Drop is sync but the close sequence is
+        // async. Tokio's runtime outlives the per-connection task so the
+        // cleanup task gets a chance to run; if the runtime is shutting
+        // down we get a best-effort attempt.
+        tokio::spawn(async move {
+            let msg = close_reason
+                .lock()
+                .take()
+                .unwrap_or_else(|| close_message(close_code::NORMAL, "stream complete"));
+            let _ = ws_tx.send(msg).await;
+            let _ = tokio::time::timeout(CLOSE_DRAIN_TIMEOUT, ws_tx.close()).await;
+        });
+    }
 }
 
 /// Drive engine selection by looping over inbound client frames until either

--- a/lib/llm/src/http/service/realtime.rs
+++ b/lib/llm/src/http/service/realtime.rs
@@ -12,13 +12,17 @@
 //!
 //! On connect the handler synthesizes a `session.created` server event before any
 //! engine event flows — the spec requires it to be the first server event on the
-//! wire. The handler then waits for the first client frame; it must be a
-//! `session.update`, and its `session.model` field selects the engine via
-//! [`ModelManager::get_realtime_engine`]. The selected engine handles everything
-//! subsequent (including `session.updated` echoes, audio-buffer state, and
-//! response generation). The first `session.update` is forwarded onto the
-//! engine's input stream verbatim — the handler used it only to pick the
-//! engine, the rest of the carried session config is the engine's to apply.
+//! wire. The handler then loops over inbound client frames in
+//! [`select_engine`] until a `session.update` arrives with a usable
+//! `session.model` and [`ModelManager::get_realtime_engine`] returns Ok.
+//! Non-conforming frames (wrong event type, missing model, unknown / unavailable
+//! model, malformed JSON, binary frames) emit a spec-shaped
+//! `RealtimeServerEvent::Error` and the loop continues so a well-behaved client
+//! can recover. Terminal states are engine selected (success) or client
+//! disconnect (no error event to send). The first qualifying `session.update`
+//! is forwarded onto the engine's input stream verbatim — the handler used it
+//! only to pick the engine; the rest of the carried session config is the
+//! engine's to apply.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -53,9 +57,10 @@ const CLOSE_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
 
 use super::{RouteDoc, service_v2};
 use crate::discovery::ModelManagerError;
+use crate::types::RealtimeBidirectionalEngine;
 use dynamo_protocols::types::realtime::{
-    EventType, RealtimeAPIError, RealtimeClientEvent, RealtimeServerEvent,
-    RealtimeServerEventError, RealtimeServerEventSessionCreated, Session,
+    EventType, RealtimeAPIError, RealtimeClientEvent, RealtimeClientEventSessionUpdate,
+    RealtimeServerEvent, RealtimeServerEventError, RealtimeServerEventSessionCreated, Session,
 };
 use uuid::Uuid;
 
@@ -110,88 +115,12 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<service_v2::State>) {
 
     let (mut ws_tx, mut ws_rx) = socket.split();
 
-    let session_update = match expect_session_update(&mut ws_rx).await {
-        Ok(req) => req,
-        Err(close) => {
-            if let Some((code, reason)) = close {
-                send_error_event(
-                    &mut ws_tx,
-                    "invalid_request",
-                    &reason,
-                    Some("session.update"),
-                )
-                .await;
-                let _ = ws_tx.send(close_message(code, &reason)).await;
-                let _ = tokio::time::timeout(CLOSE_DRAIN_TIMEOUT, ws_tx.close()).await;
-            }
-            return;
-        }
-    };
-
-    let model = match &session_update.session {
-        Session::RealtimeSession(s) => s.model.as_deref().filter(|m| !m.is_empty()),
-        Session::RealtimeTranscriptionSession(_) => None,
-    };
-    let Some(model_name) = model else {
-        send_error_event(
-            &mut ws_tx,
-            "invalid_request",
-            "session.model required",
-            Some("session.model"),
-        )
-        .await;
-        let _ = ws_tx
-            .send(close_message(close_code::POLICY, "session.model required"))
-            .await;
-        let _ = tokio::time::timeout(CLOSE_DRAIN_TIMEOUT, ws_tx.close()).await;
+    let Some((engine, session_update)) =
+        select_engine(&mut ws_rx, &mut ws_tx, state.as_ref()).await
+    else {
+        // Client disconnected before an engine was selected; no close frame
+        // to send (the peer is already gone or sent its own Close).
         return;
-    };
-
-    let engine = match state.manager().get_realtime_engine(model_name) {
-        Ok(engine) => engine,
-        Err(ModelManagerError::ModelNotFound(_)) => {
-            send_error_event(
-                &mut ws_tx,
-                "model_not_found",
-                &format!("unknown model: {model_name}"),
-                Some("session.model"),
-            )
-            .await;
-            let _ = ws_tx
-                .send(close_message(close_code::POLICY, "unknown model"))
-                .await;
-            let _ = tokio::time::timeout(CLOSE_DRAIN_TIMEOUT, ws_tx.close()).await;
-            return;
-        }
-        Err(ModelManagerError::ModelUnavailable(_)) => {
-            send_error_event(
-                &mut ws_tx,
-                "model_unavailable",
-                &format!("model unavailable: {model_name}"),
-                Some("session.model"),
-            )
-            .await;
-            let _ = ws_tx
-                .send(close_message(close_code::AGAIN, "model unavailable"))
-                .await;
-            let _ = tokio::time::timeout(CLOSE_DRAIN_TIMEOUT, ws_tx.close()).await;
-            return;
-        }
-        Err(err) => {
-            tracing::error!(%err, "/v1/realtime engine lookup failed");
-            send_error_event(
-                &mut ws_tx,
-                "server_error",
-                &err.to_string(),
-                Some("session.model"),
-            )
-            .await;
-            let _ = ws_tx
-                .send(close_message(close_code::ERROR, "engine lookup failed"))
-                .await;
-            let _ = tokio::time::timeout(CLOSE_DRAIN_TIMEOUT, ws_tx.close()).await;
-            return;
-        }
     };
 
     let (req_tx, req_rx) = mpsc::channel::<RealtimeClientEvent>(REQUEST_CHANNEL_CAPACITY);
@@ -344,62 +273,130 @@ fn close_message(code: u16, reason: &str) -> Message {
     }))
 }
 
-/// Drain the inbound socket until a `session.update` arrives; that's the
-/// only event the handler accepts before engine selection. Returns
-/// `Err(Some((code, reason)))` for protocol violations the handler should
-/// signal back to the client, or `Err(None)` for a silent client-initiated
-/// close / EOF (no Close frame to send).
-async fn expect_session_update<S>(
+/// Drive engine selection by looping over inbound client frames until either
+/// a usable `session.update` lands and `ModelManager::get_realtime_engine`
+/// returns Ok — `Some((engine, session_update))` — or the client disconnects
+/// (Close frame, EOF, or transport error) — `None`.
+///
+/// Every other frame the loop sees (non-`session.update` event type, malformed
+/// JSON, binary frame, missing/empty `session.model`, model not found,
+/// model unavailable, other lookup errors) emits a spec-shaped
+/// `RealtimeServerEvent::Error` to the client and the loop continues — a
+/// well-behaved client can recover by sending another `session.update` with
+/// corrected fields.
+async fn select_engine<S, T>(
     ws_rx: &mut S,
-) -> Result<
-    dynamo_protocols::types::realtime::RealtimeClientEventSessionUpdate,
-    Option<(u16, String)>,
->
+    ws_tx: &mut T,
+    state: &service_v2::State,
+) -> Option<(
+    RealtimeBidirectionalEngine,
+    RealtimeClientEventSessionUpdate,
+)>
 where
     S: futures::Stream<Item = Result<Message, axum::Error>> + Unpin,
+    T: futures::Sink<Message, Error = axum::Error> + Unpin,
 {
     while let Some(msg) = ws_rx.next().await {
         let msg = match msg {
             Ok(m) => m,
             Err(err) => {
-                tracing::debug!(%err, "/v1/realtime inbound error before session.update");
-                return Err(None);
+                tracing::debug!(%err, "/v1/realtime inbound error during engine selection");
+                return None;
             }
         };
-        match msg {
-            Message::Text(text) => match serde_json::from_str::<RealtimeClientEvent>(text.as_str())
-            {
-                Ok(RealtimeClientEvent::SessionUpdate(req)) => return Ok(req),
-                Ok(other) => {
-                    tracing::warn!(
-                        event = other.event_type(),
-                        "/v1/realtime first frame must be session.update"
-                    );
-                    return Err(Some((
-                        close_code::INVALID,
-                        "expected session.update as first client event".to_string(),
-                    )));
+        let event = match msg {
+            Message::Text(text) => {
+                match serde_json::from_str::<RealtimeClientEvent>(text.as_str()) {
+                    Ok(e) => e,
+                    Err(err) => {
+                        tracing::warn!(%err, "/v1/realtime malformed JSON during engine selection");
+                        send_error_event(ws_tx, "invalid_request", "malformed JSON frame", None)
+                            .await;
+                        continue;
+                    }
                 }
-                Err(err) => {
-                    tracing::warn!(%err, "/v1/realtime malformed JSON before session.update");
-                    return Err(Some((
-                        close_code::INVALID,
-                        "malformed JSON frame".to_string(),
-                    )));
-                }
-            },
-            Message::Binary(_) => {
-                tracing::warn!("/v1/realtime binary frame before session.update; rejecting");
-                return Err(Some((
-                    close_code::UNSUPPORTED,
-                    "binary frames not supported".to_string(),
-                )));
             }
-            Message::Close(_) => return Err(None),
-            Message::Ping(_) | Message::Pong(_) => {}
+            Message::Binary(_) => {
+                tracing::warn!("/v1/realtime binary frame during engine selection");
+                send_error_event(
+                    ws_tx,
+                    "invalid_request",
+                    "binary frames not supported",
+                    None,
+                )
+                .await;
+                continue;
+            }
+            Message::Close(_) => return None,
+            Message::Ping(_) | Message::Pong(_) => continue, // axum handles ping replies
+        };
+        let session_update = match event {
+            RealtimeClientEvent::SessionUpdate(req) => req,
+            other => {
+                tracing::warn!(
+                    event = other.event_type(),
+                    "/v1/realtime expected session.update before engine selection"
+                );
+                send_error_event(
+                    ws_tx,
+                    "invalid_request",
+                    "expected session.update before engine is selected",
+                    Some("session.update"),
+                )
+                .await;
+                continue;
+            }
+        };
+        let model_name = match &session_update.session {
+            Session::RealtimeSession(s) => s.model.as_deref().filter(|m| !m.is_empty()),
+            Session::RealtimeTranscriptionSession(_) => None,
+        };
+        let Some(model_name) = model_name else {
+            send_error_event(
+                ws_tx,
+                "invalid_request",
+                "session.model required",
+                Some("session.model"),
+            )
+            .await;
+            continue;
+        };
+        match state.manager().get_realtime_engine(model_name) {
+            Ok(engine) => return Some((engine, session_update)),
+            Err(ModelManagerError::ModelNotFound(_)) => {
+                send_error_event(
+                    ws_tx,
+                    "model_not_found",
+                    &format!("unknown model: {model_name}"),
+                    Some("session.model"),
+                )
+                .await;
+                continue;
+            }
+            Err(ModelManagerError::ModelUnavailable(_)) => {
+                send_error_event(
+                    ws_tx,
+                    "model_unavailable",
+                    &format!("model unavailable: {model_name}"),
+                    Some("session.model"),
+                )
+                .await;
+                continue;
+            }
+            Err(err) => {
+                tracing::error!(%err, "/v1/realtime engine lookup failed");
+                send_error_event(
+                    ws_tx,
+                    "server_error",
+                    &err.to_string(),
+                    Some("session.model"),
+                )
+                .await;
+                continue;
+            }
         }
     }
-    Err(None)
+    None
 }
 
 async fn send_error_event<S>(ws_tx: &mut S, code: &str, message: &str, param: Option<&str>)

--- a/lib/llm/src/http/service/realtime.rs
+++ b/lib/llm/src/http/service/realtime.rs
@@ -398,7 +398,21 @@ where
         };
         let model_name = match &session_update.session {
             Session::RealtimeSession(s) => s.model.as_deref().filter(|m| !m.is_empty()),
-            Session::RealtimeTranscriptionSession(_) => None,
+            Session::RealtimeTranscriptionSession(_) => {
+                // Transcription sessions need their own engine wiring (audio →
+                // text via /audio/transcriptions) that this slice doesn't
+                // implement. Surface that directly instead of letting the
+                // empty `model` fall through to the generic "session.model
+                // required" error from the realtime path below.
+                send_error_event(
+                    ws_tx,
+                    "unsupported_session_type",
+                    "session.type 'transcription' is not yet supported (only 'realtime' is supported)",
+                    Some("session.type"),
+                )
+                .await;
+                continue;
+            }
         };
         let Some(model_name) = model_name else {
             send_error_event(

--- a/lib/llm/src/http/service/realtime.rs
+++ b/lib/llm/src/http/service/realtime.rs
@@ -12,18 +12,15 @@
 //!
 //! On connect the handler synthesizes a `session.created` server event before any
 //! engine event flows — the spec requires it to be the first server event on the
-//! wire. The handler then waits for the first client frame; if it's a
-//! `session.update`, the carried `session.model` field is the routing input for
-//! engine selection. The selected engine handles everything subsequent
-//! (including `session.updated` echoes, audio-buffer state, and response
-//! generation).
-//!
-//! For now the engine is a process-scoped mock ([`EchoBidirectionalEngine`]) held
-//! in a `OnceLock` and `select_engine` ignores the model field — there's only
-//! one engine to return. The architectural shape (model in, engine out) is in
-//! place for #9174 to swap the static for a `ModelManager`-keyed lookup.
+//! wire. The handler then waits for the first client frame; it must be a
+//! `session.update`, and its `session.model` field selects the engine via
+//! [`ModelManager::get_realtime_engine`]. The selected engine handles everything
+//! subsequent (including `session.updated` echoes, audio-buffer state, and
+//! response generation). The first `session.update` is forwarded onto the
+//! engine's input stream verbatim — the handler used it only to pick the
+//! engine, the rest of the carried session config is the engine's to apply.
 
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 use std::time::Duration;
 
 use parking_lot::Mutex;
@@ -38,7 +35,7 @@ use axum::{
     response::Response,
     routing::get,
 };
-use dynamo_runtime::engine::{AsyncEngine, AsyncEngineContextProvider, RequestStream};
+use dynamo_runtime::engine::{AsyncEngineContextProvider, RequestStream};
 use dynamo_runtime::pipeline::Context;
 use futures::{SinkExt, StreamExt};
 use tokio::sync::mpsc;
@@ -55,38 +52,12 @@ const REQUEST_CHANNEL_CAPACITY: usize = 64;
 const CLOSE_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
 
 use super::{RouteDoc, service_v2};
-use crate::engines::EchoBidirectionalEngine;
+use crate::discovery::ModelManagerError;
 use dynamo_protocols::types::realtime::{
     EventType, RealtimeAPIError, RealtimeClientEvent, RealtimeServerEvent,
     RealtimeServerEventError, RealtimeServerEventSessionCreated, Session,
 };
 use uuid::Uuid;
-
-/// Process-scoped registry for the bidirectional engine. Populated by tests and
-/// (in production) by whatever wires up the experimental endpoint. If unset when
-/// a connection arrives, the handler closes with `INTERNAL_ERROR`.
-///
-/// **Placeholder.** Tracked in #9174 (2/N). The proper registration path is
-/// through `ModelManager` keyed on `model_name`, parallel to chat / completions
-/// / embeddings engines, but no bidirectional accessor exists on `ModelManager`
-/// yet. When that lands, replace this static and the `install_*` helpers below
-/// with `state.manager().get_realtime_engine(model_name)` lookups in `handle_socket`,
-/// and remove the install-time API entirely.
-static BIDIRECTIONAL_ENGINE: OnceLock<EchoBidirectionalEngine> = OnceLock::new();
-
-/// Install the bidirectional engine to be used by `/v1/realtime`. Returns `Err` if an
-/// engine is already installed (the static can only be set once per process).
-/// See [`BIDIRECTIONAL_ENGINE`] for why this install-time API exists.
-pub fn install_engine(engine: EchoBidirectionalEngine) -> Result<(), &'static str> {
-    BIDIRECTIONAL_ENGINE
-        .set(engine)
-        .map_err(|_| "realtime bidirectional engine already installed")
-}
-
-/// Convenience installer for tests/dev: registers the echo mock engine.
-pub fn install_echo_engine() -> Result<(), &'static str> {
-    install_engine(EchoBidirectionalEngine)
-}
 
 pub fn realtime_router(
     state: Arc<service_v2::State>,
@@ -107,12 +78,11 @@ async fn realtime_ws_handler(
     upgrade.on_upgrade(move |socket| handle_socket(socket, state))
 }
 
-async fn handle_socket(mut socket: WebSocket, _state: Arc<service_v2::State>) {
+async fn handle_socket(mut socket: WebSocket, state: Arc<service_v2::State>) {
     // OpenAI Realtime spec requires `session.created` to be the first server
     // frame on the wire, before any client event arrives. The handler synthesizes
     // it here so the connection handshake works regardless of which engine is
-    // installed; engine selection happens once we observe the client's first
-    // frame (typically `session.update` carrying the desired model).
+    // selected later.
     let session_created = RealtimeServerEvent::SessionCreated(RealtimeServerEventSessionCreated {
         event_id: format!("event_{}", Uuid::new_v4()),
         session: Session::RealtimeSession(Box::default()),
@@ -140,36 +110,88 @@ async fn handle_socket(mut socket: WebSocket, _state: Arc<service_v2::State>) {
 
     let (mut ws_tx, mut ws_rx) = socket.split();
 
-    // Strict: the first client frame must be `session.update` so we can pick
-    // the engine by `session.model`. Any other event, malformed JSON, or
-    // binary frame closes the connection — there is no default-engine path.
     let session_update = match expect_session_update(&mut ws_rx).await {
         Ok(req) => req,
         Err(close) => {
             if let Some((code, reason)) = close {
+                send_error_event(
+                    &mut ws_tx,
+                    "invalid_request",
+                    &reason,
+                    Some("session.update"),
+                )
+                .await;
                 let _ = ws_tx.send(close_message(code, &reason)).await;
                 let _ = tokio::time::timeout(CLOSE_DRAIN_TIMEOUT, ws_tx.close()).await;
             }
             return;
         }
     };
+
     let model = match &session_update.session {
-        Session::RealtimeSession(s) => s.model.as_deref(),
+        Session::RealtimeSession(s) => s.model.as_deref().filter(|m| !m.is_empty()),
         Session::RealtimeTranscriptionSession(_) => None,
     };
-    let Some(engine) = select_engine(model) else {
-        tracing::error!(
-            ?model,
-            "/v1/realtime connection rejected: no engine available"
-        );
+    let Some(model_name) = model else {
+        send_error_event(
+            &mut ws_tx,
+            "invalid_request",
+            "session.model required",
+            Some("session.model"),
+        )
+        .await;
         let _ = ws_tx
-            .send(close_message(
-                close_code::ERROR,
-                "no realtime engine available",
-            ))
+            .send(close_message(close_code::POLICY, "session.model required"))
             .await;
         let _ = tokio::time::timeout(CLOSE_DRAIN_TIMEOUT, ws_tx.close()).await;
         return;
+    };
+
+    let engine = match state.manager().get_realtime_engine(model_name) {
+        Ok(engine) => engine,
+        Err(ModelManagerError::ModelNotFound(_)) => {
+            send_error_event(
+                &mut ws_tx,
+                "model_not_found",
+                &format!("unknown model: {model_name}"),
+                Some("session.model"),
+            )
+            .await;
+            let _ = ws_tx
+                .send(close_message(close_code::POLICY, "unknown model"))
+                .await;
+            let _ = tokio::time::timeout(CLOSE_DRAIN_TIMEOUT, ws_tx.close()).await;
+            return;
+        }
+        Err(ModelManagerError::ModelUnavailable(_)) => {
+            send_error_event(
+                &mut ws_tx,
+                "model_unavailable",
+                &format!("model unavailable: {model_name}"),
+                Some("session.model"),
+            )
+            .await;
+            let _ = ws_tx
+                .send(close_message(close_code::AGAIN, "model unavailable"))
+                .await;
+            let _ = tokio::time::timeout(CLOSE_DRAIN_TIMEOUT, ws_tx.close()).await;
+            return;
+        }
+        Err(err) => {
+            tracing::error!(%err, "/v1/realtime engine lookup failed");
+            send_error_event(
+                &mut ws_tx,
+                "server_error",
+                &err.to_string(),
+                Some("session.model"),
+            )
+            .await;
+            let _ = ws_tx
+                .send(close_message(close_code::ERROR, "engine lookup failed"))
+                .await;
+            let _ = tokio::time::timeout(CLOSE_DRAIN_TIMEOUT, ws_tx.close()).await;
+            return;
+        }
     };
 
     let (req_tx, req_rx) = mpsc::channel::<RealtimeClientEvent>(REQUEST_CHANNEL_CAPACITY);
@@ -380,15 +402,26 @@ where
     Err(None)
 }
 
-/// Pick the realtime engine for this connection.
-///
-/// Today the slot is a single `OnceLock<EchoBidirectionalEngine>` and the
-/// model is logged but not used for routing — there's only one engine to
-/// return. #9174 will replace this with a `ModelManager`-keyed lookup; the
-/// function signature is the architectural seam.
-fn select_engine(model: Option<&str>) -> Option<&'static EchoBidirectionalEngine> {
-    if let Some(m) = model {
-        tracing::debug!(model = m, "/v1/realtime engine selection by model");
-    }
-    BIDIRECTIONAL_ENGINE.get()
+async fn send_error_event<S>(ws_tx: &mut S, code: &str, message: &str, param: Option<&str>)
+where
+    S: futures::Sink<Message, Error = axum::Error> + Unpin,
+{
+    let event = RealtimeServerEvent::Error(RealtimeServerEventError {
+        event_id: format!("event_{}", Uuid::new_v4()),
+        error: RealtimeAPIError {
+            r#type: "invalid_request_error".to_string(),
+            code: Some(code.to_string()),
+            message: message.to_string(),
+            param: param.map(|s| s.to_string()),
+            event_id: None,
+        },
+    });
+    let payload = match serde_json::to_string(&event) {
+        Ok(s) => s,
+        Err(err) => {
+            tracing::warn!(%err, "/v1/realtime serializing error event failed");
+            return;
+        }
+    };
+    let _ = ws_tx.send(Message::Text(Utf8Bytes::from(payload))).await;
 }

--- a/lib/llm/src/http/service/realtime.rs
+++ b/lib/llm/src/http/service/realtime.rs
@@ -22,6 +22,7 @@
 //!   model, malformed JSON, binary frames) emit a spec-shaped
 //!   `RealtimeServerEvent::Error` while the loop continues so a well-behaved client
 //!   can recover.
+//!
 //! On selected engine:
 //! - The handler forwards all frames including `session.update` onto the engine's input stream.
 //! - The handler drains the engine's response stream onto the WebSocket.

--- a/lib/llm/src/http/service/realtime.rs
+++ b/lib/llm/src/http/service/realtime.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Experimental WebSocket endpoint at `/v1/realtime` for the OpenAI Realtime API.
+//! WebSocket endpoint at `/v1/realtime` for the OpenAI Realtime API.
 //!
 //! Wire shape: client sends a sequence of `Message::Text` frames each containing a
 //! JSON-encoded [`RealtimeClientEvent`]; server forwards each frame onto an
@@ -10,19 +10,22 @@
 //! inside the JSON envelope (`input_audio_buffer.append`); binary WebSocket frames
 //! are rejected.
 //!
-//! On connect the handler synthesizes a `session.created` server event before any
-//! engine event flows — the spec requires it to be the first server event on the
-//! wire. The handler then loops over inbound client frames in
-//! [`select_engine`] until a `session.update` arrives with a usable
-//! `session.model` and [`ModelManager::get_realtime_engine`] returns Ok.
-//! Non-conforming frames (wrong event type, missing model, unknown / unavailable
-//! model, malformed JSON, binary frames) emit a spec-shaped
-//! `RealtimeServerEvent::Error` and the loop continues so a well-behaved client
-//! can recover. Terminal states are engine selected (success) or client
-//! disconnect (no error event to send). The first qualifying `session.update`
-//! is forwarded onto the engine's input stream verbatim — the handler used it
-//! only to pick the engine; the rest of the carried session config is the
-//! engine's to apply.
+//! Workflow:
+//!
+//! On connect:
+//! - The handler sends a `session.created` server event before any
+//!   engine events flow.
+//! - The handler loops over inbound client frames in
+//!   [`select_engine`] until a `session.update` arrives with a usable
+//!   `session.model` and [`ModelManager::get_realtime_engine`] returns Ok.
+//! - Non-conforming frames (wrong event type, missing model, unknown / unavailable
+//!   model, malformed JSON, binary frames) emit a spec-shaped
+//!   `RealtimeServerEvent::Error` while the loop continues so a well-behaved client
+//!   can recover.
+//! On selected engine:
+//! - The handler forwards all frames including `session.update` onto the engine's input stream.
+//! - The handler drains the engine's response stream onto the WebSocket.
+//! - WebSocket stream close procedure is encapsulated in the `ScopedWsWriter` wrapper.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -355,6 +358,7 @@ where
     T: futures::Sink<Message, Error = axum::Error> + Unpin,
 {
     while let Some(msg) = ws_rx.next().await {
+        // Parse socket messages.
         let msg = match msg {
             Ok(m) => m,
             Err(err) => {
@@ -407,6 +411,8 @@ where
                 continue;
             }
         };
+
+        // Extract model name from session update.
         let model_name = match &session_update.session {
             Session::RealtimeSession(s) => s.model.as_deref().filter(|m| !m.is_empty()),
             Session::RealtimeTranscriptionSession(_) => {

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -608,13 +608,6 @@ impl HttpServiceConfigBuilder {
             inference_router = inference_router.merge(route);
             all_docs.extend(route_docs);
         }
-        // Experimental WebSocket endpoint (`/v1/realtime`) — see #9173 ("Streaming Request Support").
-        // Registered unconditionally; the underlying engine is opt-in via
-        // `crate::http::service::realtime::install_engine`. If no engine is installed when
-        // a connection arrives, the handler closes with an error frame.
-        let (realtime_docs, realtime_route) = super::realtime::realtime_router(state.clone(), None);
-        inference_router = inference_router.merge(realtime_route);
-        all_docs.extend(realtime_docs);
         inference_router = inference_router.layer(
             TraceLayer::new_for_http()
                 .make_span_with(make_inference_request_span)
@@ -673,6 +666,7 @@ impl HttpServiceConfigBuilder {
         let (images_docs, images_route) = super::openai::images_router(state.clone(), None);
         let (videos_docs, videos_route) = super::openai::videos_router(state.clone(), None);
         let (audios_docs, audios_route) = super::openai::audios_router(state.clone(), None);
+        let (realtime_docs, realtime_route) = super::realtime::realtime_router(state.clone(), None);
         let (responses_docs, responses_route) = super::openai::responses_router(
             state.clone(),
             request_template.clone(),
@@ -685,6 +679,7 @@ impl HttpServiceConfigBuilder {
         endpoint_routes.insert(EndpointType::Images, (images_docs, images_route));
         endpoint_routes.insert(EndpointType::Videos, (videos_docs, videos_route));
         endpoint_routes.insert(EndpointType::Audios, (audios_docs, audios_route));
+        endpoint_routes.insert(EndpointType::Realtime, (realtime_docs, realtime_route));
         endpoint_routes.insert(EndpointType::Responses, (responses_docs, responses_route));
 
         if env_is_truthy(env_llm::DYN_ENABLE_ANTHROPIC_API) {

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -70,6 +70,7 @@ struct StateFlags {
     images_endpoints_enabled: AtomicBool,
     videos_endpoints_enabled: AtomicBool,
     audios_endpoints_enabled: AtomicBool,
+    realtime_endpoints_enabled: AtomicBool,
     responses_endpoints_enabled: AtomicBool,
     anthropic_endpoints_enabled: AtomicBool,
 }
@@ -83,6 +84,7 @@ impl StateFlags {
             EndpointType::Images => self.images_endpoints_enabled.load(Ordering::Relaxed),
             EndpointType::Videos => self.videos_endpoints_enabled.load(Ordering::Relaxed),
             EndpointType::Audios => self.audios_endpoints_enabled.load(Ordering::Relaxed),
+            EndpointType::Realtime => self.realtime_endpoints_enabled.load(Ordering::Relaxed),
             EndpointType::Responses => self.responses_endpoints_enabled.load(Ordering::Relaxed),
             EndpointType::AnthropicMessages => {
                 self.anthropic_endpoints_enabled.load(Ordering::Relaxed)
@@ -109,6 +111,9 @@ impl StateFlags {
                 .store(enabled, Ordering::Relaxed),
             EndpointType::Audios => self
                 .audios_endpoints_enabled
+                .store(enabled, Ordering::Relaxed),
+            EndpointType::Realtime => self
+                .realtime_endpoints_enabled
                 .store(enabled, Ordering::Relaxed),
             EndpointType::Responses => self
                 .responses_endpoints_enabled
@@ -137,6 +142,7 @@ impl State {
                 images_endpoints_enabled: AtomicBool::new(false),
                 videos_endpoints_enabled: AtomicBool::new(false),
                 audios_endpoints_enabled: AtomicBool::new(false),
+                realtime_endpoints_enabled: AtomicBool::new(false),
                 responses_endpoints_enabled: AtomicBool::new(false),
                 anthropic_endpoints_enabled: AtomicBool::new(false),
             },

--- a/lib/llm/src/model_type.rs
+++ b/lib/llm/src/model_type.rs
@@ -29,9 +29,9 @@ bitflags! {
     ///
     /// Using bitflags avoids deep branching on a single enum variant,
     /// simplifies checks like `supports_chat()`, and enables efficient,
-    /// type-safe combinations of multiple endpoint types within a single byte.
+    /// type-safe combinations of multiple endpoint types.
     #[derive(Copy, Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq)]
-    pub struct ModelType: u8 {
+    pub struct ModelType: u16 {
         const Chat = 1 << 0;
         const Completions = 1 << 1;
         const Embedding = 1 << 2;
@@ -40,6 +40,7 @@ bitflags! {
         const Images = 1 << 5;
         const Audios = 1 << 6;
         const Videos = 1 << 7;
+        const Realtime = 1 << 8;
     }
 }
 
@@ -72,6 +73,9 @@ impl ModelType {
     pub fn supports_videos(&self) -> bool {
         self.contains(ModelType::Videos)
     }
+    pub fn supports_realtime(&self) -> bool {
+        self.contains(ModelType::Realtime)
+    }
 
     pub fn as_vec(&self) -> Vec<&'static str> {
         let mut result = Vec::new();
@@ -98,6 +102,9 @@ impl ModelType {
         }
         if self.supports_videos() {
             result.push("videos");
+        }
+        if self.supports_realtime() {
+            result.push("realtime");
         }
         result
     }
@@ -129,6 +136,9 @@ impl ModelType {
         }
         if self.supports_videos() {
             result.push(ModelType::Videos);
+        }
+        if self.supports_realtime() {
+            result.push(ModelType::Realtime);
         }
         result
     }
@@ -163,6 +173,9 @@ impl ModelType {
         if self.contains(Self::Videos) {
             endpoint_types.push(crate::endpoint_type::EndpointType::Videos);
         }
+        if self.contains(Self::Realtime) {
+            endpoint_types.push(crate::endpoint_type::EndpointType::Realtime);
+        }
         // [gluo NOTE] ModelType::Tensor doesn't map to any endpoint type,
         // current use of endpoint type is LLM specific and so does the HTTP
         // server that uses it.
@@ -194,5 +207,53 @@ impl ModelInput {
             Self::Tokens => "tokens",
             Self::Tensor => "tensor",
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::endpoint_type::EndpointType;
+
+    #[test]
+    fn realtime_bit_position() {
+        assert_eq!(ModelType::Realtime.bits(), 1 << 8);
+    }
+
+    #[test]
+    fn prefill_bit_position_unchanged() {
+        assert_eq!(ModelType::Prefill.bits(), 1 << 4);
+    }
+
+    #[test]
+    fn realtime_supports_realtime() {
+        assert!(ModelType::Realtime.supports_realtime());
+        assert!(!ModelType::Chat.supports_realtime());
+    }
+
+    #[test]
+    fn realtime_in_as_vec() {
+        assert_eq!(ModelType::Realtime.as_vec(), vec!["realtime"]);
+    }
+
+    #[test]
+    fn realtime_in_units() {
+        let combined = ModelType::Chat | ModelType::Realtime;
+        assert_eq!(combined.units(), vec![ModelType::Chat, ModelType::Realtime]);
+    }
+
+    #[test]
+    fn realtime_endpoint_mapping() {
+        assert_eq!(
+            ModelType::Realtime.as_endpoint_types(),
+            vec![EndpointType::Realtime]
+        );
+    }
+
+    #[test]
+    fn realtime_combines_with_other_endpoints() {
+        let endpoints = (ModelType::Chat | ModelType::Realtime).as_endpoint_types();
+        assert!(endpoints.contains(&EndpointType::Chat));
+        assert!(endpoints.contains(&EndpointType::Realtime));
     }
 }

--- a/lib/llm/src/types.rs
+++ b/lib/llm/src/types.rs
@@ -148,3 +148,5 @@ pub mod generic {
             BidirectionalStreamingEngine<RealtimeClientEvent, Annotated<RealtimeServerEvent>>;
     }
 }
+
+pub use generic::realtime::RealtimeBidirectionalEngine;

--- a/lib/llm/tests/http_websocket.rs
+++ b/lib/llm/tests/http_websocket.rs
@@ -11,6 +11,7 @@
 use std::time::Duration;
 
 use anyhow::Result;
+use dynamo_llm::endpoint_type::EndpointType;
 use dynamo_llm::http::service::{realtime, service_v2::HttpService};
 use dynamo_runtime::CancellationToken;
 use futures::{SinkExt, StreamExt};
@@ -56,10 +57,37 @@ async fn spawn_test_service() -> (u16, CancellationToken, JoinHandle<Result<()>>
     ensure_echo_engine_installed();
     let (listener, port) = bind_random_port().await;
     let service = HttpService::builder().port(port).build().unwrap();
+    service.enable_model_endpoint(EndpointType::Realtime, true);
     let token = CancellationToken::new();
     let handle = service.spawn_with_listener(token.clone(), listener).await;
     wait_for_health(port).await;
     (port, token, handle)
+}
+
+async fn spawn_test_service_realtime_disabled() -> (u16, CancellationToken, JoinHandle<Result<()>>)
+{
+    ensure_echo_engine_installed();
+    let port = get_random_port().await;
+    let service = HttpService::builder().port(port).build().unwrap();
+    let token = CancellationToken::new();
+    let handle = service.spawn(token.clone()).await;
+    wait_for_health(port).await;
+    (port, token, handle)
+}
+
+#[tokio::test]
+async fn realtime_websocket_route_gated_by_endpoint_flag() {
+    let (port, token, handle) = spawn_test_service_realtime_disabled().await;
+
+    let url = format!("ws://127.0.0.1:{port}/v1/realtime");
+    let result = tokio_tungstenite::connect_async(&url).await;
+    assert!(
+        result.is_err(),
+        "/v1/realtime upgrade must fail when EndpointType::Realtime is disabled"
+    );
+
+    token.cancel();
+    let _ = handle.await;
 }
 
 /// Read one Text frame off the socket and parse it as JSON, asserting the

--- a/lib/llm/tests/http_websocket.rs
+++ b/lib/llm/tests/http_websocket.rs
@@ -525,6 +525,63 @@ async fn realtime_websocket_session_update_missing_model_emits_error() {
     let _ = handle.await;
 }
 
+/// `session.update` with `session.type = "transcription"` is the OpenAI Realtime
+/// transcription mode, which this slice doesn't yet wire up to an engine.
+/// Surface a specific `unsupported_session_type` error instead of letting the
+/// `Session::RealtimeTranscriptionSession` arm fall through to the generic
+/// "session.model required" path (which would be misleading — the issue isn't
+/// a missing field, it's an unsupported session subtype). The connection stays
+/// open so the client can recover by sending a `realtime` session.
+#[tokio::test]
+async fn realtime_websocket_transcription_session_emits_unsupported_error() {
+    let (port, token, handle) = spawn_test_service(true, true).await;
+
+    let url = format!("ws://127.0.0.1:{port}/v1/realtime");
+    let (mut ws, _resp) = tokio_tungstenite::connect_async(&url)
+        .await
+        .expect("ws connect");
+
+    expect_text_event(&mut ws, "session.created").await;
+
+    // Minimum valid `RealtimeTranscriptionSession` JSON: requires
+    // `audio.input.format` (unit-variant `audio/pcmu` is shortest) and
+    // `audio.input.turn_detection`. `server_vad` carries three required
+    // numeric fields. The handler rejects the session subtype before any of
+    // these values matter — they exist only to get serde past
+    // deserialization.
+    let body = serde_json::json!({
+        "type": "session.update",
+        "session": {
+            "type": "transcription",
+            "audio": {
+                "input": {
+                    "format": { "type": "audio/pcmu" },
+                    "turn_detection": {
+                        "type": "server_vad",
+                        "prefix_padding_ms": 300,
+                        "silence_duration_ms": 500,
+                        "threshold": 0.5
+                    }
+                }
+            }
+        }
+    });
+    ws.send(Message::Text(body.to_string().into()))
+        .await
+        .expect("send");
+
+    let event = expect_error_event_no_close(&mut ws).await;
+    assert_eq!(
+        event.pointer("/error/code").and_then(|s| s.as_str()),
+        Some("unsupported_session_type"),
+        "error event should report unsupported_session_type for transcription: {event}"
+    );
+
+    let _ = ws.close(None).await;
+    token.cancel();
+    let _ = handle.await;
+}
+
 /// After an intermediate error during engine selection, the loop stays open
 /// and a follow-up `session.update` with a registered model selects the engine
 /// normally. Demonstrates the recovery property the lenient loop is designed

--- a/lib/llm/tests/http_websocket.rs
+++ b/lib/llm/tests/http_websocket.rs
@@ -53,33 +53,18 @@ fn register_echo(service: &HttpService) {
         .expect("register echo realtime engine");
 }
 
-async fn spawn_test_service() -> (u16, CancellationToken, JoinHandle<Result<()>>) {
+async fn spawn_test_service(
+    realtime_enabled: bool,
+    register_echo_engine: bool,
+) -> (u16, CancellationToken, JoinHandle<Result<()>>) {
     let (listener, port) = bind_random_port().await;
     let service = HttpService::builder().port(port).build().unwrap();
-    service.enable_model_endpoint(EndpointType::Realtime, true);
-    register_echo(&service);
-    let token = CancellationToken::new();
-    let handle = service.spawn_with_listener(token.clone(), listener).await;
-    wait_for_health(port).await;
-    (port, token, handle)
-}
-
-async fn spawn_test_service_realtime_disabled() -> (u16, CancellationToken, JoinHandle<Result<()>>)
-{
-    let (listener, port) = bind_random_port().await;
-    let service = HttpService::builder().port(port).build().unwrap();
-    register_echo(&service);
-    let token = CancellationToken::new();
-    let handle = service.spawn_with_listener(token.clone(), listener).await;
-    wait_for_health(port).await;
-    (port, token, handle)
-}
-
-async fn spawn_test_service_no_engine() -> (u16, CancellationToken, JoinHandle<Result<()>>) {
-    let (listener, port) = bind_random_port().await;
-    let service = HttpService::builder().port(port).build().unwrap();
-    service.enable_model_endpoint(EndpointType::Realtime, true);
-    // No engine registered — exercises the `model_not_found` error path.
+    if realtime_enabled {
+        service.enable_model_endpoint(EndpointType::Realtime, true);
+    }
+    if register_echo_engine {
+        register_echo(&service);
+    }
     let token = CancellationToken::new();
     let handle = service.spawn_with_listener(token.clone(), listener).await;
     wait_for_health(port).await;
@@ -88,7 +73,7 @@ async fn spawn_test_service_no_engine() -> (u16, CancellationToken, JoinHandle<R
 
 #[tokio::test]
 async fn realtime_websocket_route_gated_by_endpoint_flag() {
-    let (port, token, handle) = spawn_test_service_realtime_disabled().await;
+    let (port, token, handle) = spawn_test_service(false, true).await;
 
     let url = format!("ws://127.0.0.1:{port}/v1/realtime");
     let result = tokio_tungstenite::connect_async(&url).await;
@@ -131,7 +116,7 @@ async fn expect_text_event(
 /// per the OpenAI Realtime spec, before any client event arrives.
 #[tokio::test]
 async fn realtime_websocket_emits_session_created_on_connect() {
-    let (port, token, handle) = spawn_test_service().await;
+    let (port, token, handle) = spawn_test_service(true, true).await;
 
     let url = format!("ws://127.0.0.1:{port}/v1/realtime");
     let (mut ws, _resp) = tokio_tungstenite::connect_async(&url)
@@ -159,7 +144,7 @@ async fn realtime_websocket_emits_session_created_on_connect() {
 /// Demonstrates end-to-end realtime-event plumbing through the WebSocket.
 #[tokio::test]
 async fn realtime_websocket_session_update_echoes_session_updated() {
-    let (port, token, handle) = spawn_test_service().await;
+    let (port, token, handle) = spawn_test_service(true, true).await;
 
     let url = format!("ws://127.0.0.1:{port}/v1/realtime");
     let (mut ws, _resp) = tokio_tungstenite::connect_async(&url)
@@ -200,7 +185,7 @@ async fn realtime_websocket_session_update_echoes_session_updated() {
 /// in the right order with stable response_id across the turn.
 #[tokio::test]
 async fn realtime_websocket_audio_append_streams_response_envelope() {
-    let (port, token, handle) = spawn_test_service().await;
+    let (port, token, handle) = spawn_test_service(true, true).await;
 
     let url = format!("ws://127.0.0.1:{port}/v1/realtime");
     let (mut ws, _resp) = tokio_tungstenite::connect_async(&url)
@@ -339,7 +324,7 @@ async fn realtime_websocket_audio_append_streams_response_envelope() {
 /// (the echo test) or server-side rejection (the binary-frame test).
 #[tokio::test]
 async fn realtime_websocket_emits_close_after_client_close() {
-    let (port, token, handle) = spawn_test_service().await;
+    let (port, token, handle) = spawn_test_service(true, true).await;
 
     let url = format!("ws://127.0.0.1:{port}/v1/realtime");
     let (mut ws, _resp) = tokio_tungstenite::connect_async(&url)
@@ -421,7 +406,7 @@ async fn expect_error_event_no_close(
 
 #[tokio::test]
 async fn realtime_websocket_binary_frame_during_selection_emits_error() {
-    let (port, token, handle) = spawn_test_service().await;
+    let (port, token, handle) = spawn_test_service(true, true).await;
 
     let url = format!("ws://127.0.0.1:{port}/v1/realtime");
     let (mut ws, _resp) = tokio_tungstenite::connect_async(&url)
@@ -449,7 +434,7 @@ async fn realtime_websocket_binary_frame_during_selection_emits_error() {
 
 #[tokio::test]
 async fn realtime_websocket_unknown_model_emits_error() {
-    let (port, token, handle) = spawn_test_service_no_engine().await;
+    let (port, token, handle) = spawn_test_service(true, false).await;
 
     let url = format!("ws://127.0.0.1:{port}/v1/realtime");
     let (mut ws, _resp) = tokio_tungstenite::connect_async(&url)
@@ -480,7 +465,7 @@ async fn realtime_websocket_unknown_model_emits_error() {
 
 #[tokio::test]
 async fn realtime_websocket_non_session_update_first_frame_emits_error() {
-    let (port, token, handle) = spawn_test_service().await;
+    let (port, token, handle) = spawn_test_service(true, true).await;
 
     let url = format!("ws://127.0.0.1:{port}/v1/realtime");
     let (mut ws, _resp) = tokio_tungstenite::connect_async(&url)
@@ -511,7 +496,7 @@ async fn realtime_websocket_non_session_update_first_frame_emits_error() {
 
 #[tokio::test]
 async fn realtime_websocket_session_update_missing_model_emits_error() {
-    let (port, token, handle) = spawn_test_service().await;
+    let (port, token, handle) = spawn_test_service(true, true).await;
 
     let url = format!("ws://127.0.0.1:{port}/v1/realtime");
     let (mut ws, _resp) = tokio_tungstenite::connect_async(&url)
@@ -546,7 +531,7 @@ async fn realtime_websocket_session_update_missing_model_emits_error() {
 /// for.
 #[tokio::test]
 async fn realtime_websocket_recovers_after_unknown_model() {
-    let (port, token, handle) = spawn_test_service().await;
+    let (port, token, handle) = spawn_test_service(true, true).await;
 
     let url = format!("ws://127.0.0.1:{port}/v1/realtime");
     let (mut ws, _resp) = tokio_tungstenite::connect_async(&url)

--- a/lib/llm/tests/http_websocket.rs
+++ b/lib/llm/tests/http_websocket.rs
@@ -393,8 +393,34 @@ async fn realtime_websocket_emits_close_after_client_close() {
     );
 }
 
+/// Wait for an `error` event, then assert no `Close` frame arrives within a
+/// short bounded window. The lenient engine-selection loop emits error events
+/// for intermediate failures (wrong event type, missing model, unknown model,
+/// binary frames) without closing the connection so a well-behaved client can
+/// recover by sending another `session.update`.
+async fn expect_error_event_no_close(
+    ws: &mut tokio_tungstenite::WebSocketStream<
+        tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+    >,
+) -> Value {
+    let event = expect_text_event(ws, "error").await;
+    let probe = tokio::time::timeout(Duration::from_millis(500), ws.next()).await;
+    match probe {
+        Ok(Some(Ok(Message::Close(_)))) => {
+            panic!("server should not close on an intermediate error during engine selection")
+        }
+        Ok(None) => {
+            panic!(
+                "server should not end the stream on an intermediate error during engine selection"
+            )
+        }
+        _ => {} // timeout (no close) or non-close frame → connection kept open
+    }
+    event
+}
+
 #[tokio::test]
-async fn realtime_websocket_rejects_binary_frame() {
+async fn realtime_websocket_binary_frame_during_selection_emits_error() {
     let (port, token, handle) = spawn_test_service().await;
 
     let url = format!("ws://127.0.0.1:{port}/v1/realtime");
@@ -409,55 +435,20 @@ async fn realtime_websocket_rejects_binary_frame() {
         .await
         .expect("send binary");
 
-    let mut got_close = false;
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
-    while tokio::time::Instant::now() < deadline {
-        let frame = tokio::time::timeout(Duration::from_secs(2), ws.next()).await;
-        let Ok(maybe) = frame else { break };
-        match maybe {
-            Some(Ok(Message::Close(_))) => {
-                got_close = true;
-                break;
-            }
-            None => break,
-            _ => {}
-        }
-    }
+    let event = expect_error_event_no_close(&mut ws).await;
+    assert_eq!(
+        event.pointer("/error/code").and_then(|s| s.as_str()),
+        Some("invalid_request"),
+        "error event should report invalid_request for binary frame: {event}"
+    );
 
     let _ = ws.close(None).await;
     token.cancel();
     let _ = handle.await;
-
-    assert!(
-        got_close,
-        "server should close the connection on a binary frame"
-    );
-}
-
-/// Wait for an `error` event then drain frames until a `Close` arrives.
-async fn expect_error_event_then_close(
-    ws: &mut tokio_tungstenite::WebSocketStream<
-        tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
-    >,
-) -> Value {
-    let event = expect_text_event(ws, "error").await;
-    let mut got_close = false;
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
-    while !got_close && tokio::time::Instant::now() < deadline {
-        let frame = tokio::time::timeout(Duration::from_secs(2), ws.next()).await;
-        let Ok(maybe) = frame else { break };
-        match maybe {
-            Some(Ok(Message::Close(_))) => got_close = true,
-            None => break,
-            _ => {}
-        }
-    }
-    assert!(got_close, "server should send Close after error event");
-    event
 }
 
 #[tokio::test]
-async fn realtime_websocket_unknown_model_emits_error_and_closes() {
+async fn realtime_websocket_unknown_model_emits_error() {
     let (port, token, handle) = spawn_test_service_no_engine().await;
 
     let url = format!("ws://127.0.0.1:{port}/v1/realtime");
@@ -475,19 +466,20 @@ async fn realtime_websocket_unknown_model_emits_error_and_closes() {
         .await
         .expect("send");
 
-    let event = expect_error_event_then_close(&mut ws).await;
+    let event = expect_error_event_no_close(&mut ws).await;
     assert_eq!(
         event.pointer("/error/code").and_then(|s| s.as_str()),
         Some("model_not_found"),
         "error event should report model_not_found: {event}"
     );
 
+    let _ = ws.close(None).await;
     token.cancel();
     let _ = handle.await;
 }
 
 #[tokio::test]
-async fn realtime_websocket_first_frame_must_be_session_update() {
+async fn realtime_websocket_non_session_update_first_frame_emits_error() {
     let (port, token, handle) = spawn_test_service().await;
 
     let url = format!("ws://127.0.0.1:{port}/v1/realtime");
@@ -505,13 +497,14 @@ async fn realtime_websocket_first_frame_must_be_session_update() {
         .await
         .expect("send");
 
-    let event = expect_error_event_then_close(&mut ws).await;
+    let event = expect_error_event_no_close(&mut ws).await;
     assert_eq!(
         event.pointer("/error/code").and_then(|s| s.as_str()),
         Some("invalid_request"),
         "error event should report invalid_request: {event}"
     );
 
+    let _ = ws.close(None).await;
     token.cancel();
     let _ = handle.await;
 }
@@ -535,13 +528,59 @@ async fn realtime_websocket_session_update_missing_model_emits_error() {
         .await
         .expect("send");
 
-    let event = expect_error_event_then_close(&mut ws).await;
+    let event = expect_error_event_no_close(&mut ws).await;
     assert_eq!(
         event.pointer("/error/code").and_then(|s| s.as_str()),
         Some("invalid_request"),
         "error event should report invalid_request when model is absent: {event}"
     );
 
+    let _ = ws.close(None).await;
+    token.cancel();
+    let _ = handle.await;
+}
+
+/// After an intermediate error during engine selection, the loop stays open
+/// and a follow-up `session.update` with a registered model selects the engine
+/// normally. Demonstrates the recovery property the lenient loop is designed
+/// for.
+#[tokio::test]
+async fn realtime_websocket_recovers_after_unknown_model() {
+    let (port, token, handle) = spawn_test_service().await;
+
+    let url = format!("ws://127.0.0.1:{port}/v1/realtime");
+    let (mut ws, _resp) = tokio_tungstenite::connect_async(&url)
+        .await
+        .expect("ws connect");
+
+    expect_text_event(&mut ws, "session.created").await;
+
+    // First attempt: bogus model → error event, connection stays open.
+    let bad = serde_json::json!({
+        "type": "session.update",
+        "session": { "type": "realtime", "model": "does-not-exist" }
+    });
+    ws.send(Message::Text(bad.to_string().into()))
+        .await
+        .expect("send bad");
+    let err = expect_error_event_no_close(&mut ws).await;
+    assert_eq!(
+        err.pointer("/error/code").and_then(|s| s.as_str()),
+        Some("model_not_found")
+    );
+
+    // Recovery: valid session.update with the registered echo model. The
+    // engine round-trips it back as session.updated.
+    let good = serde_json::json!({
+        "type": "session.update",
+        "session": { "type": "realtime", "model": ECHO_MODEL }
+    });
+    ws.send(Message::Text(good.to_string().into()))
+        .await
+        .expect("send good");
+    expect_text_event(&mut ws, "session.updated").await;
+
+    let _ = ws.close(None).await;
     token.cancel();
     let _ = handle.await;
 }

--- a/lib/llm/tests/http_websocket.rs
+++ b/lib/llm/tests/http_websocket.rs
@@ -10,9 +10,12 @@
 
 use std::time::Duration;
 
+use std::sync::Arc;
+
 use anyhow::Result;
 use dynamo_llm::endpoint_type::EndpointType;
-use dynamo_llm::http::service::{realtime, service_v2::HttpService};
+use dynamo_llm::engines::EchoBidirectionalEngine;
+use dynamo_llm::http::service::service_v2::HttpService;
 use dynamo_runtime::CancellationToken;
 use futures::{SinkExt, StreamExt};
 use serde_json::Value;
@@ -23,17 +26,10 @@ use tokio_tungstenite::tungstenite::Message;
 mod ports;
 use ports::bind_random_port;
 
-/// Engine slot is process-global; ensure we install the echo mock at most once
-/// across all tests in this binary.
-///
-/// #9174 (2/N) will replace `OnceLock`-based engine registration with proper
-/// `ModelManager`-keyed lookups; this helper goes away then.
-fn ensure_echo_engine_installed() {
-    static INIT: std::sync::Once = std::sync::Once::new();
-    INIT.call_once(|| {
-        let _ = realtime::install_echo_engine();
-    });
-}
+/// Default model name used by tests; the fixture's first `session.update`
+/// frame must carry this in `session.model` so the handler's
+/// `get_realtime_engine` lookup hits the registered echo engine.
+const ECHO_MODEL: &str = "echo";
 
 async fn wait_for_health(port: u16) {
     let deadline = std::time::Instant::now() + Duration::from_secs(5);
@@ -50,14 +46,18 @@ async fn wait_for_health(port: u16) {
     panic!("frontend never became healthy on port {port}");
 }
 
-/// Spawn an `HttpService` on a free port with the echo engine installed and
-/// the `/health` endpoint live, returning the port plus a cancel-token /
-/// join-handle pair the caller cleans up at the end of the test.
+fn register_echo(service: &HttpService) {
+    service
+        .model_manager()
+        .add_realtime_model(ECHO_MODEL, "0", Arc::new(EchoBidirectionalEngine))
+        .expect("register echo realtime engine");
+}
+
 async fn spawn_test_service() -> (u16, CancellationToken, JoinHandle<Result<()>>) {
-    ensure_echo_engine_installed();
     let (listener, port) = bind_random_port().await;
     let service = HttpService::builder().port(port).build().unwrap();
     service.enable_model_endpoint(EndpointType::Realtime, true);
+    register_echo(&service);
     let token = CancellationToken::new();
     let handle = service.spawn_with_listener(token.clone(), listener).await;
     wait_for_health(port).await;
@@ -66,11 +66,22 @@ async fn spawn_test_service() -> (u16, CancellationToken, JoinHandle<Result<()>>
 
 async fn spawn_test_service_realtime_disabled() -> (u16, CancellationToken, JoinHandle<Result<()>>)
 {
-    ensure_echo_engine_installed();
-    let port = get_random_port().await;
+    let (listener, port) = bind_random_port().await;
     let service = HttpService::builder().port(port).build().unwrap();
+    register_echo(&service);
     let token = CancellationToken::new();
-    let handle = service.spawn(token.clone()).await;
+    let handle = service.spawn_with_listener(token.clone(), listener).await;
+    wait_for_health(port).await;
+    (port, token, handle)
+}
+
+async fn spawn_test_service_no_engine() -> (u16, CancellationToken, JoinHandle<Result<()>>) {
+    let (listener, port) = bind_random_port().await;
+    let service = HttpService::builder().port(port).build().unwrap();
+    service.enable_model_endpoint(EndpointType::Realtime, true);
+    // No engine registered — exercises the `model_not_found` error path.
+    let token = CancellationToken::new();
+    let handle = service.spawn_with_listener(token.clone(), listener).await;
     wait_for_health(port).await;
     (port, token, handle)
 }
@@ -160,7 +171,7 @@ async fn realtime_websocket_session_update_echoes_session_updated() {
 
     let body = serde_json::json!({
         "type": "session.update",
-        "session": { "type": "realtime", "model": "gpt-realtime" }
+        "session": { "type": "realtime", "model": ECHO_MODEL }
     });
     ws.send(Message::Text(body.to_string().into()))
         .await
@@ -173,7 +184,7 @@ async fn realtime_websocket_session_update_echoes_session_updated() {
     );
     assert_eq!(
         event.pointer("/session/model").and_then(|s| s.as_str()),
-        Some("gpt-realtime")
+        Some(ECHO_MODEL)
     );
 
     let _ = ws.close(None).await;
@@ -202,7 +213,7 @@ async fn realtime_websocket_audio_append_streams_response_envelope() {
     // session.update first to pick the engine.
     let session_update = serde_json::json!({
         "type": "session.update",
-        "session": { "type": "realtime", "model": "gpt-realtime" }
+        "session": { "type": "realtime", "model": ECHO_MODEL }
     });
     ws.send(Message::Text(session_update.to_string().into()))
         .await
@@ -340,7 +351,7 @@ async fn realtime_websocket_emits_close_after_client_close() {
 
     let body = serde_json::json!({
         "type": "session.update",
-        "session": { "type": "realtime" }
+        "session": { "type": "realtime", "model": ECHO_MODEL }
     });
     ws.send(Message::Text(body.to_string().into()))
         .await
@@ -421,4 +432,116 @@ async fn realtime_websocket_rejects_binary_frame() {
         got_close,
         "server should close the connection on a binary frame"
     );
+}
+
+/// Wait for an `error` event then drain frames until a `Close` arrives.
+async fn expect_error_event_then_close(
+    ws: &mut tokio_tungstenite::WebSocketStream<
+        tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+    >,
+) -> Value {
+    let event = expect_text_event(ws, "error").await;
+    let mut got_close = false;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
+    while !got_close && tokio::time::Instant::now() < deadline {
+        let frame = tokio::time::timeout(Duration::from_secs(2), ws.next()).await;
+        let Ok(maybe) = frame else { break };
+        match maybe {
+            Some(Ok(Message::Close(_))) => got_close = true,
+            None => break,
+            _ => {}
+        }
+    }
+    assert!(got_close, "server should send Close after error event");
+    event
+}
+
+#[tokio::test]
+async fn realtime_websocket_unknown_model_emits_error_and_closes() {
+    let (port, token, handle) = spawn_test_service_no_engine().await;
+
+    let url = format!("ws://127.0.0.1:{port}/v1/realtime");
+    let (mut ws, _resp) = tokio_tungstenite::connect_async(&url)
+        .await
+        .expect("ws connect");
+
+    expect_text_event(&mut ws, "session.created").await;
+
+    let body = serde_json::json!({
+        "type": "session.update",
+        "session": { "type": "realtime", "model": "does-not-exist" }
+    });
+    ws.send(Message::Text(body.to_string().into()))
+        .await
+        .expect("send");
+
+    let event = expect_error_event_then_close(&mut ws).await;
+    assert_eq!(
+        event.pointer("/error/code").and_then(|s| s.as_str()),
+        Some("model_not_found"),
+        "error event should report model_not_found: {event}"
+    );
+
+    token.cancel();
+    let _ = handle.await;
+}
+
+#[tokio::test]
+async fn realtime_websocket_first_frame_must_be_session_update() {
+    let (port, token, handle) = spawn_test_service().await;
+
+    let url = format!("ws://127.0.0.1:{port}/v1/realtime");
+    let (mut ws, _resp) = tokio_tungstenite::connect_async(&url)
+        .await
+        .expect("ws connect");
+
+    expect_text_event(&mut ws, "session.created").await;
+
+    let body = serde_json::json!({
+        "type": "input_audio_buffer.append",
+        "audio": "AAAA",
+    });
+    ws.send(Message::Text(body.to_string().into()))
+        .await
+        .expect("send");
+
+    let event = expect_error_event_then_close(&mut ws).await;
+    assert_eq!(
+        event.pointer("/error/code").and_then(|s| s.as_str()),
+        Some("invalid_request"),
+        "error event should report invalid_request: {event}"
+    );
+
+    token.cancel();
+    let _ = handle.await;
+}
+
+#[tokio::test]
+async fn realtime_websocket_session_update_missing_model_emits_error() {
+    let (port, token, handle) = spawn_test_service().await;
+
+    let url = format!("ws://127.0.0.1:{port}/v1/realtime");
+    let (mut ws, _resp) = tokio_tungstenite::connect_async(&url)
+        .await
+        .expect("ws connect");
+
+    expect_text_event(&mut ws, "session.created").await;
+
+    let body = serde_json::json!({
+        "type": "session.update",
+        "session": { "type": "realtime" }
+    });
+    ws.send(Message::Text(body.to_string().into()))
+        .await
+        .expect("send");
+
+    let event = expect_error_event_then_close(&mut ws).await;
+    assert_eq!(
+        event.pointer("/error/code").and_then(|s| s.as_str()),
+        Some("invalid_request"),
+        "error event should report invalid_request when model is absent: {event}"
+    );
+
+    token.cancel();
+    let _ = handle.await;
 }

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -1040,6 +1040,9 @@ where
             .select_next_worker()
             .ok_or_else(|| anyhow::anyhow!("no instances available for bidirectional routing"))?;
 
+        // Per-frame remote dispatch over AddressedPushRouter / PushWorkHandler
+        // is tracked in #9361. Until that lands, callers must register engines
+        // in-process via ModelManager rather than rely on discovered workers.
         anyhow::bail!(
             "bidirectional remote dispatch is not yet implemented (selected instance {instance_id})"
         )

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -13,7 +13,7 @@ use crate::{
     engine::{AsyncEngine, AsyncEngineContext, Data},
     metrics::frontend_perf::{STAGE_DURATION_SECONDS, STAGE_ROUTE},
     pipeline::{
-        AddressedPushRouter, AddressedRequest, Error, ManyOut, SingleIn,
+        AddressedPushRouter, AddressedRequest, Error, ManyIn, ManyOut, SingleIn,
         error::{PipelineError, PipelineErrorExt},
     },
     protocols::{EndpointId, maybe_error::MaybeError},
@@ -1002,6 +1002,50 @@ where
     }
 }
 
+/// Bidirectional `AsyncEngine` impl for streaming-input workloads (e.g. the
+/// OpenAI Realtime API). Selects a sticky instance on the first inbound frame
+/// and binds the whole input stream to that worker. Required so engines of
+/// shape `BidirectionalStreamingEngine<T, U>` can be stored as a `PushRouter`
+/// in `WorkerSet`.
+///
+/// Remote per-frame dispatch over `AddressedPushRouter` / `PushWorkHandler`
+/// is not yet implemented; this impl currently bails after selecting the
+/// worker. KV and Direct modes inherit the same `bail!` invariants as the
+/// unary impl.
+#[async_trait]
+impl<T, U> AsyncEngine<ManyIn<T>, ManyOut<U>, Error> for PushRouter<T, U>
+where
+    T: Data + Serialize,
+    U: Data + for<'de> Deserialize<'de> + MaybeError,
+{
+    async fn generate(&self, mut input: ManyIn<T>) -> Result<ManyOut<U>, Error> {
+        match self.router_mode {
+            RouterMode::KV => {
+                anyhow::bail!("KV routing should not call generate on PushRouter");
+            }
+            RouterMode::Direct => {
+                anyhow::bail!(
+                    "Direct routing should not call generate on PushRouter directly; use DirectRoutingRouter wrapper"
+                );
+            }
+            _ => {}
+        }
+
+        // Wait for the first frame so the sticky-instance pick reflects the
+        // session's actual start, not router construction time.
+        if input.next().await.is_none() {
+            anyhow::bail!("bidirectional input stream closed before first frame");
+        }
+        let instance_id = self
+            .select_next_worker()
+            .ok_or_else(|| anyhow::anyhow!("no instances available for bidirectional routing"))?;
+
+        anyhow::bail!(
+            "bidirectional remote dispatch is not yet implemented (selected instance {instance_id})"
+        )
+    }
+}
+
 struct OccupancyTrackedStream<U: Data> {
     inner: ManyOut<U>,
     state: Arc<RoutingOccupancyState>,
@@ -1199,6 +1243,95 @@ mod tests {
         assert_eq!(state.load(selected), 1);
         drop(permit);
         assert_eq!(state.load(selected), 0);
+    }
+
+    #[tokio::test]
+    async fn bidirectional_generate_bails_with_no_instances() {
+        let rt = Runtime::from_current().unwrap();
+        let drt = DistributedRuntime::new(rt.clone(), DistributedConfig::process_local())
+            .await
+            .unwrap();
+        let ns = drt.namespace("test_bidi_no_instances".to_string()).unwrap();
+        let component = ns.component("test_component".to_string()).unwrap();
+        let endpoint = component.endpoint("test_endpoint".to_string());
+        let client = endpoint.client().await.unwrap();
+
+        let router = PushRouter::<u64, TestResponse>::from_client(client, RouterMode::RoundRobin)
+            .await
+            .unwrap();
+
+        let ctx: Arc<dyn AsyncEngineContext> = Arc::new(Controller::default());
+        let input: ManyIn<u64> =
+            ResponseStream::new(Box::pin(tokio_stream::iter(vec![1u64, 2u64])), ctx);
+        let result = router.generate(input).await;
+        assert!(
+            result.is_err(),
+            "bidirectional generate must bail when no instances are registered"
+        );
+
+        rt.shutdown();
+    }
+
+    #[tokio::test]
+    async fn bidirectional_generate_bails_for_kv_router_mode() {
+        let rt = Runtime::from_current().unwrap();
+        let drt = DistributedRuntime::new(rt.clone(), DistributedConfig::process_local())
+            .await
+            .unwrap();
+        let ns = drt.namespace("test_bidi_kv_mode".to_string()).unwrap();
+        let component = ns.component("test_component".to_string()).unwrap();
+        let endpoint = component.endpoint("test_endpoint".to_string());
+        let client = endpoint.client().await.unwrap();
+
+        let router = PushRouter::<u64, TestResponse>::from_client(client, RouterMode::KV)
+            .await
+            .unwrap();
+
+        let ctx: Arc<dyn AsyncEngineContext> = Arc::new(Controller::default());
+        let input: ManyIn<u64> = ResponseStream::new(Box::pin(tokio_stream::iter(vec![1u64])), ctx);
+        let result = router.generate(input).await;
+        assert!(
+            result.is_err(),
+            "bidirectional generate must bail for RouterMode::KV"
+        );
+        let err_msg = format!("{:?}", result.unwrap_err());
+        assert!(
+            err_msg.contains("KV") || err_msg.contains("kv"),
+            "error should mention KV: got {err_msg}"
+        );
+
+        rt.shutdown();
+    }
+
+    #[tokio::test]
+    async fn bidirectional_generate_bails_for_direct_router_mode() {
+        let rt = Runtime::from_current().unwrap();
+        let drt = DistributedRuntime::new(rt.clone(), DistributedConfig::process_local())
+            .await
+            .unwrap();
+        let ns = drt.namespace("test_bidi_direct_mode".to_string()).unwrap();
+        let component = ns.component("test_component".to_string()).unwrap();
+        let endpoint = component.endpoint("test_endpoint".to_string());
+        let client = endpoint.client().await.unwrap();
+
+        let router = PushRouter::<u64, TestResponse>::from_client(client, RouterMode::Direct)
+            .await
+            .unwrap();
+
+        let ctx: Arc<dyn AsyncEngineContext> = Arc::new(Controller::default());
+        let input: ManyIn<u64> = ResponseStream::new(Box::pin(tokio_stream::iter(vec![1u64])), ctx);
+        let result = router.generate(input).await;
+        assert!(
+            result.is_err(),
+            "bidirectional generate must bail for RouterMode::Direct"
+        );
+        let err_msg = format!("{:?}", result.unwrap_err());
+        assert!(
+            err_msg.contains("Direct") || err_msg.contains("direct"),
+            "error should mention Direct: got {err_msg}"
+        );
+
+        rt.shutdown();
     }
 
     #[tokio::test]


### PR DESCRIPTION
#### Overview:

Slice 2/N of the bidirectional streaming-input feature. #9079 (1/N) shipped
the WebSocket frontend at `/v1/realtime` against a process-scoped
`OnceLock<EchoBidirectionalEngine>` placeholder. This PR wires the endpoint
to a real model registry and adds the bidirectional transport invariant the
engine-pipeline layer was missing:

- `ModelType::Realtime` is added as a first-class endpoint kind, mirroring
  `Images` / `Videos` / `Audios` and `as_endpoint_types` mapping it to a new
  `EndpointType::Realtime`. The temporary `bidirectional_streaming: bool`
  flag the design doc proposed is rejected in favor of single-dimension
  dispatch via `ModelType` — the same shape every other endpoint uses today.
- `ModelManager` gains `get_realtime_engine` / `add_realtime_model` /
  `remove_realtime_model` / `list_realtime_models`, parallel to chat /
  completions / embeddings / images / videos / audios. The registry is
  keyed on `model_name`; `WorkerSet.realtime_engine` joins the existing
  serving-engine slot list.
- `PushRouter` gains a bidirectional `AsyncEngine<ManyIn<T>, ManyOut<U>>`
  impl with stream-affinity (sticky instance after the first frame).
  `RouterMode::KV` and `RouterMode::Direct` inherit the unary impl's
  `bail!` guards (KV dispatches via `direct(req, instance_id)` from
  dynamo-llm's `KvRouter` and never calls `generate`; Direct requires
  `DirectRoutingRouter`). Per-frame remote dispatch is 3/N and tracked in
  DIS-1942.
- `/v1/realtime` is rewritten to read the engine name from the first
  `session.update` event's `session.model` field. Engine selection is
  lenient: non-conforming first frames (wrong event type, missing model,
  unknown / unavailable model, malformed JSON, binary frames) emit a
  spec-shaped `RealtimeServerEvent::Error` and the loop continues so a
  well-behaved client can recover by sending another `session.update`.
- The `OnceLock` registry and `install_engine` / `install_echo_engine`
  install-time API from #9079 are retired; the integration tests are
  retargeted onto `add_realtime_model`.

The four components the ticket originally listed ("incomplete list of
components: BackendEngine, MigrationEngine, Router, AsyncEngine") collapse
to just Router needing new bidirectional work. Inspection of
`lib/llm/src/discovery/watcher.rs:910–981` confirms Images / Videos /
Audios compose as a single `PushRouter<RequestType, Annotated<ResponseType>>`
with no `Backend` / `Migration` layers — those are LLM-pipeline-shape
concerns (preprocessing / detokenization / per-request retry over
`PreprocessedRequest` + `BackendOutput`) that don't apply to engine-emitted
modality responses. Realtime joins the multimodal pattern. Whether a
future LLM-shaped bidirectional path needs Backend / Migration variants is
tracked as DIS-1941.

#### Details:

**`ModelType` widening + `EndpointType::Realtime`:**
- `lib/llm/src/model_type.rs` — `ModelType` widened from `bitflags<u8>` to
  `bitflags<u16>`. Bit positions 0..7 unchanged so the Python
  `_MODEL_TYPE_PREFILL_BIT = 16` constant and `test_mdc.py` assertions
  remain valid. Adds `Realtime = 1<<8`, `supports_realtime`, and the
  `Realtime → EndpointType::Realtime` arm in `as_endpoint_types`.
- `lib/llm/src/endpoint_type.rs` — `EndpointType::Realtime` variant.
- `lib/bindings/python/rust/lib.rs` + `lib/bindings/python/src/dynamo/_core.pyi`
  — `Realtime` PyClass classattr.

**`ModelManager` accessor + watcher arm:**
- `lib/llm/src/discovery/worker_set.rs` — `realtime_engine` field;
  `has_realtime_engine`; `is_prefill_set` extension so a realtime-only
  WorkerSet isn't misclassified as prefill.
- `lib/llm/src/discovery/model.rs` — `has_realtime_engine` /
  `get_realtime_engine`; `is_displayable` extension.
- `lib/llm/src/discovery/model_manager.rs` —
  `add_realtime_model` / `get_realtime_engine` / `remove_realtime_model` /
  `list_realtime_models` mirroring `add_chat_completions_model` etc.
- `lib/llm/src/discovery/watcher.rs` — `Realtime` arm in
  `ALL_MODEL_TYPES`, `is_model_type_list_empty`, and
  `do_worker_set_registration` (single `PushRouter`, no Backend/Migration —
  same shape as the Images / Videos / Audios arm).

**Route gating:**
- `lib/llm/src/http/service/service_v2.rs` — `StateFlags::Realtime` flag;
  `/v1/realtime` moves out of the unconditional `inference_router.merge`
  into the keyed `endpoint_routes` map so it's gated by the same
  `state.flags.get(&endpoint_type)` middleware as chat / completions /
  embeddings.

**Bidirectional `PushRouter`:**
- `lib/runtime/src/pipeline/network/egress/push_router.rs` — new
  `AsyncEngine<ManyIn<T>, ManyOut<U>, Error>` impl with stream-affinity:
  the first inbound frame runs `select_next_worker`; subsequent frames go
  to the same instance. `RouterMode::KV` and `RouterMode::Direct` bail
  with the same `anyhow::bail!` messages as the unary impl.

**`/v1/realtime` rewrite:**
- `lib/llm/src/http/service/realtime.rs` — drops the `OnceLock` registry
  and the `install_engine` / `install_echo_engine` API. New
  `select_engine` loop reads the first inbound `RealtimeClientEvent`,
  requires `SessionUpdate`, extracts `session.model`, calls
  `state.manager().get_realtime_engine(model_name)`, and forwards that
  same event onto the engine input mpsc verbatim. Intermediate failures
  emit a spec-shaped `RealtimeServerEvent::Error` and the loop continues.
  The outbound side is wrapped in a `ScopedWsWriter` RAII guard whose
  `Drop` spawns a detached cleanup that sends the Close frame and drains
  the sink under `CLOSE_DRAIN_TIMEOUT` — covers panic / early-return
  paths so the client always sees an in-band Close instead of TCP EOF.

**Tests:**
- `lib/llm/tests/http_websocket.rs` — existing realtime tests retargeted
  onto `add_realtime_model("echo", ...)`; three new error-path tests
  (`unknown_model`, `non_session_update_first_frame`,
  `session_update_missing_model`) plus a `recovers_after_unknown_model`
  end-to-end recovery test. Single parameterized `spawn_test_service`
  fixture.
- `lib/runtime/src/pipeline/network/egress/push_router.rs` — three
  bidirectional `AsyncEngine` unit tests covering the bail paths
  (KV / Direct / no-instances).
- `lib/llm/src/discovery/worker_set.rs` — generalized
  `is_prefill_set` test covering all eight serving-engine fields via a
  generic `StubEngine<Req, Resp>`.

#### Where should the reviewer start?

Reading order, smallest mental model first:

1. `lib/llm/src/model_type.rs` — the foundation. Adding `Realtime` as a
   bitflag unit + `as_endpoint_types` mapping is the single dispatch
   dimension everything else hangs off.
2. `lib/llm/src/discovery/watcher.rs` (lines around the `Realtime` arm
   and the existing Images / Videos / Audios arms) — the multimodal
   precedent. The realtime arm mirrors that shape exactly.
3. `lib/llm/src/discovery/model_manager.rs` — the `realtime` accessor
   block. Compare against `add_chat_completions_model` etc. immediately
   above.
4. `lib/runtime/src/pipeline/network/egress/push_router.rs` —
   bidirectional impl. Read the stream-affinity flow and confirm KV /
   Direct still bail.
5. `lib/llm/src/http/service/realtime.rs` — the bridge. `select_engine`
   loop is the lenient engine-selection logic; `ScopedWsWriter` is the
   RAII close guard.
6. `lib/llm/tests/http_websocket.rs` — what does this PR enable end to
   end?

#### To verify locally:

```bash
cargo test -p dynamo-llm --lib
cargo test -p dynamo-llm --test http_websocket
cargo test -p dynamo-runtime --lib pipeline::network::egress::push_router
cargo check --workspace --all-targets
cargo clippy --no-deps --all-targets -- -D warnings
```

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Closes #9174 — `ModelManager` accessor for bidirectional engines
  (DGH-838).
- Built on #9205 (5/N) — base of this PR. Will retarget to `main` once
  #9205 squash-merges.
- Relates to #9079 (1/N) — frontend base; this PR retires the
  `OnceLock` registry it shipped.
- Relates to DIS-1941 — evaluate whether `Backend` / `Migration` need
  bidirectional variants for a future LLM-shaped streaming-input
  pipeline (filed during planning).
- Relates to DIS-1942 — evaluate `RouterMode::KV` and `RouterMode::Direct`
  bidirectional support, including the `DirectRoutingRouter`
  bidirectional impl 3/N will likely need.

Internal Linear tickets DIS-1859 and DGH-838 mirror the GitHub issues
above (cross-linked per `.ai/linear-ticket-refs.md`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Realtime model type support across the platform
  * Introduced realtime bidirectional engine with improved WebSocket session management
  * Enhanced model discovery with realtime-capable model listing and engine retrieval
  * Improved error handling and graceful recovery in realtime endpoints

* **Tests**
  * Extended integration test coverage for realtime endpoints and model operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9308?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->