### PR TITLE
fix(recipe): add DYN_MM_ALLOW_INTERNAL to allow http coco image urls

### DIFF
--- a/recipes/qwen3-vl-30b/vllm/agg-embedding-cache/deploy.yaml
+++ b/recipes/qwen3-vl-30b/vllm/agg-embedding-cache/deploy.yaml
@@ -62,6 +62,9 @@ spec:
               value: nixl-write
             - name: DYN_MULTIMODAL_EMBEDDING_CACHE_GB
               value: "10"
+            # Permit the COCO http:// image URLs in the multimodal benchmark dataset.
+            - name: DYN_MM_ALLOW_INTERNAL
+              value: "1"
           workingDir: /workspace
       replicas: 1
       resources:


### PR DESCRIPTION
#### Overview:                                       
                                                                                                     
Adds `DYN_MM_ALLOW_INTERNAL=1` to the Qwen3-VL-30B vLLM agg-embedding-cache worker so the recipe can
 keep working against current `main` builds. Without it, every multimodal benchmark request now     
fails because the dataset generator emits `http://images.cocodataset.org/...` URLs that the new     
default-deny URL validator (added in #8646, 2025-05-05) rejects.                                    
                                                                                                    
#### Details:                                                                                       

- `recipes/qwen3-vl-30b/vllm/agg-embedding-cache/deploy.yaml`: one new env var on the `VllmWorker`  
container.                                                                                        
- No change to the dataset generator, the recipe args, or any other recipe.                         
- Safe on releases that don't carry the validator (`v1.1.0`, `v1.1.1-rc0` and earlier do not include
 `components/src/dynamo/common/http/url_validator.py`); the env var is simply a no-op there.        


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to support internal image URL handling in multimodal benchmark testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->