### PR TITLE
ci(operator): run lint and unit tests in pre-merge

### DIFF
--- a/.github/FILTERS.md
+++ b/.github/FILTERS.md
@@ -10,6 +10,7 @@ When you open a PR, CI checks which files changed and runs only relevant jobs:
 |--------|----------|
 | `core` | Main test suite (vLLM, SGLang, TRT-LLM containers) |
 | `operator` | Kubernetes operator tests |
+| `snapshot` | Snapshot Agent tests |
 | `deploy` | Deploy-specific tests |
 | `vllm` / `sglang` / `trtllm` | Backend-specific tests |
 | `benchmarks` | Dynamo runtime pipeline (runs `tests/benchmarks/**` pytest suite) |
@@ -65,4 +66,3 @@ changed-files action so the coverage check knows about it:
      "Check for uncovered files" step.
 
 If you skip this step, CI will fail with "uncovered files" even though your filter exists.
-

--- a/.github/actions/build-deploy-component/action.yml
+++ b/.github/actions/build-deploy-component/action.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: 'Build Deploy Component'
-description: 'Lint, test, and build/push a deploy component container (operator or snapshot)'
+description: 'Build and push a deploy component container (operator or snapshot)'
 
 inputs:
   component:
@@ -54,10 +54,8 @@ runs:
       shell: bash
       run: |
         if [[ "${{ inputs.component }}" == "operator" ]]; then
-          echo "lint_platform=linux/arm64" >> $GITHUB_OUTPUT
           echo "build_platforms=linux/amd64,linux/arm64" >> $GITHUB_OUTPUT
         else
-          echo "lint_platform=linux/amd64" >> $GITHUB_OUTPUT
           echo "build_platforms=linux/amd64" >> $GITHUB_OUTPUT
         fi
 
@@ -77,49 +75,6 @@ runs:
         azure_acr_user: ${{ inputs.azure_acr_user }}
         azure_acr_password: ${{ inputs.azure_acr_password }}
         ngc_ci_access_token: ${{ inputs.ngc_ci_access_token }}
-
-    - name: Linter
-      shell: bash
-      working-directory: ./deploy/${{ inputs.component }}
-      env:
-        ECR_HOSTNAME: ${{ inputs.aws_account_id }}.dkr.ecr.${{ inputs.aws_default_region }}.amazonaws.com
-      run: |
-        docker buildx build --platform ${{ steps.settings.outputs.lint_platform }} --target linter --progress=plain --build-arg DOCKER_PROXY=${ECR_HOSTNAME}/dockerhub/ --build-context snapshot=../snapshot .
-
-    - name: Tester
-      shell: bash
-      working-directory: ./deploy/${{ inputs.component }}
-      env:
-        ECR_HOSTNAME: ${{ inputs.aws_account_id }}.dkr.ecr.${{ inputs.aws_default_region }}.amazonaws.com
-      run: |
-        docker buildx build --platform ${{ steps.settings.outputs.lint_platform }} --target tester --progress=plain --build-arg DOCKER_PROXY=${ECR_HOSTNAME}/dockerhub/ --build-context snapshot=../snapshot .
-
-    - name: Set up Go
-      if: ${{ inputs.component == 'operator' }}
-      uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
-      with:
-        go-version: '1.25'
-
-    - name: Set up Python
-      if: ${{ inputs.component == 'operator' }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.11"
-
-    - name: Install Python dependencies for operator codegen
-      if: ${{ inputs.component == 'operator' }}
-      shell: bash
-      working-directory: ./deploy/operator
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install "pydantic>=2,<3" "black==23.1.0" "pyyaml>=6.0"
-
-    - name: Check for uncommitted changes
-      if: ${{ inputs.component == 'operator' }}
-      shell: bash
-      working-directory: ./deploy/operator
-      run: |
-        make check
 
     - name: Build and push Container
       shell: bash

--- a/.github/actions/changed-files/action.yml
+++ b/.github/actions/changed-files/action.yml
@@ -13,6 +13,9 @@ outputs:
   operator:
     description: 'Whether operator files changed'
     value: ${{ steps.filter.outputs.operator_any_modified }}
+  snapshot:
+    description: 'Whether snapshot-agent files changed'
+    value: ${{ steps.filter.outputs.snapshot_any_modified }}
   deploy:
     description: 'Whether deploy files changed'
     value: ${{ steps.filter.outputs.deploy_any_modified }}
@@ -114,6 +117,7 @@ runs:
         echo "ci: ${{ steps.filter.outputs.ci_any_modified }}"
         echo "core: ${{ steps.filter.outputs.core_any_modified }}"
         echo "operator: ${{ steps.filter.outputs.operator_any_modified }}"
+        echo "snapshot: ${{ steps.filter.outputs.snapshot_any_modified }}"
         echo "deploy: ${{ steps.filter.outputs.deploy_any_modified }}"
         echo "planner: ${{ steps.filter.outputs.planner_any_modified }}"
         echo "vllm: ${{ steps.filter.outputs.vllm_any_modified }}"
@@ -129,6 +133,7 @@ runs:
         echo "ci: ${{ steps.filter.outputs.ci_all_modified_files }}"
         echo "core: ${{ steps.filter.outputs.core_all_modified_files }}"
         echo "operator: ${{ steps.filter.outputs.operator_all_modified_files }}"
+        echo "snapshot: ${{ steps.filter.outputs.snapshot_all_modified_files }}"
         echo "deploy: ${{ steps.filter.outputs.deploy_all_modified_files }}"
         echo "planner: ${{ steps.filter.outputs.planner_all_modified_files }}"
         echo "vllm: ${{ steps.filter.outputs.vllm_all_modified_files }}"
@@ -143,7 +148,7 @@ runs:
       shell: bash
       run: |
         # Combine all filter-specific files into one list
-        COVERED_FILES=$(echo "${{ steps.filter.outputs.docs_all_modified_files }} ${{ steps.filter.outputs.examples_all_modified_files }} ${{ steps.filter.outputs.ignore_all_modified_files }} ${{ steps.filter.outputs.ci_all_modified_files }} ${{ steps.filter.outputs.core_all_modified_files }} ${{ steps.filter.outputs.operator_all_modified_files }} ${{ steps.filter.outputs.deploy_all_modified_files }} ${{ steps.filter.outputs.planner_all_modified_files }} ${{ steps.filter.outputs.vllm_all_modified_files }} ${{ steps.filter.outputs.sglang_all_modified_files }} ${{ steps.filter.outputs.trtllm_all_modified_files }} ${{ steps.filter.outputs.sample_all_modified_files }} ${{ steps.filter.outputs.frontend_all_modified_files }} ${{ steps.filter.outputs.benchmarks_all_modified_files }} ${{ steps.filter.outputs.rust_all_modified_files }}" | tr ' ' '\n' | grep -v '^$' | sort -u)
+        COVERED_FILES=$(echo "${{ steps.filter.outputs.docs_all_modified_files }} ${{ steps.filter.outputs.examples_all_modified_files }} ${{ steps.filter.outputs.ignore_all_modified_files }} ${{ steps.filter.outputs.ci_all_modified_files }} ${{ steps.filter.outputs.core_all_modified_files }} ${{ steps.filter.outputs.operator_all_modified_files }} ${{ steps.filter.outputs.snapshot_all_modified_files }} ${{ steps.filter.outputs.deploy_all_modified_files }} ${{ steps.filter.outputs.planner_all_modified_files }} ${{ steps.filter.outputs.vllm_all_modified_files }} ${{ steps.filter.outputs.sglang_all_modified_files }} ${{ steps.filter.outputs.trtllm_all_modified_files }} ${{ steps.filter.outputs.sample_all_modified_files }} ${{ steps.filter.outputs.frontend_all_modified_files }} ${{ steps.filter.outputs.benchmarks_all_modified_files }} ${{ steps.filter.outputs.rust_all_modified_files }}" | tr ' ' '\n' | grep -v '^$' | sort -u)
 
         # Get all modified files
         ALL_FILES=$(echo "${{ steps.filter.outputs.all_all_modified_files }}" | tr ' ' '\n' | grep -v '^$' | sort -u)
@@ -160,4 +165,3 @@ runs:
           exit 1
         fi
         echo "All modified files are covered by CI filters."
-

--- a/.github/actions/check-deploy-component/action.yml
+++ b/.github/actions/check-deploy-component/action.yml
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: 'Check Deploy Component'
+description: 'Run validation checks for a deploy component'
+
+inputs:
+  component:
+    description: 'Component to check: operator or snapshot'
+    required: true
+  platform:
+    description: 'Docker platform used for linter and tester targets'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Linter
+      shell: bash
+      working-directory: ./deploy/${{ inputs.component }}
+      run: |
+        docker buildx build \
+          --platform ${{ inputs.platform }} \
+          --target linter \
+          --progress=plain \
+          --build-context snapshot=../snapshot \
+          .
+
+    - name: Tester
+      shell: bash
+      working-directory: ./deploy/${{ inputs.component }}
+      run: |
+        docker buildx build \
+          --platform ${{ inputs.platform }} \
+          --target tester \
+          --progress=plain \
+          --build-context snapshot=../snapshot \
+          .
+
+    - name: Set up Go
+      if: ${{ inputs.component == 'operator' }}
+      uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+      with:
+        go-version: '1.25'
+
+    - name: Set up Python
+      if: ${{ inputs.component == 'operator' }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+
+    - name: Install Python dependencies for operator codegen
+      if: ${{ inputs.component == 'operator' }}
+      shell: bash
+      working-directory: ./deploy/operator
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install "pydantic>=2,<3" "black==23.1.0" "pyyaml>=6.0"
+
+    - name: Check operator generated files
+      if: ${{ inputs.component == 'operator' }}
+      shell: bash
+      working-directory: ./deploy/operator
+      run: |
+        make check

--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -3,6 +3,7 @@
 # Filters that trigger CI jobs:
 #   core     -> dynamo build-test, all backend builds (vllm/sglang/trtllm)
 #   operator -> operator build and test
+#   snapshot -> snapshot-agent build and test
 #   deploy   -> deploy tests
 #   planner  -> dynamo build-test
 #   vllm     -> vllm build and test
@@ -111,9 +112,16 @@ operator:
   - *ci
   - 'deploy/operator/**'
   - 'deploy/operator/.*'
+  # Operator imports the local snapshot module.
+  - 'deploy/snapshot/**'
   - 'docs/kubernetes/api-reference.md'
   - 'deploy/helm/charts/platform/**'
   - 'components/src/dynamo/profiler/utils/dgdr_*'
+
+snapshot:
+  - *ci
+  - 'deploy/snapshot/**'
+  - 'deploy/snapshot/.*'
 
 deploy:
   - *ci

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -26,6 +26,7 @@ jobs:
       core: ${{ steps.changes.outputs.core }}
       planner: ${{ steps.changes.outputs.planner }}
       operator: ${{ steps.changes.outputs.operator }}
+      snapshot: ${{ steps.changes.outputs.snapshot }}
       deploy: ${{ steps.changes.outputs.deploy }}
       vllm: ${{ steps.changes.outputs.vllm }}
       sglang: ${{ steps.changes.outputs.sglang }}
@@ -155,7 +156,7 @@ jobs:
 
   snapshot-agent:
     needs: changed-files
-    if: needs.changed-files.outputs.deploy == 'true'
+    if: needs.changed-files.outputs.snapshot == 'true'
     name: Snapshot Agent
     runs-on: prod-default-v2
     steps:

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -31,6 +31,8 @@ jobs:
   changed-files:
     runs-on: ubuntu-latest
     outputs:
+      operator: ${{ steps.changes.outputs.operator }}
+      snapshot: ${{ steps.changes.outputs.snapshot }}
       rust: ${{ steps.changes.outputs.rust }}
     steps:
       - name: Checkout code
@@ -44,7 +46,7 @@ jobs:
 
   pre-merge-status-check:
     runs-on: ubuntu-latest
-    needs: [changed-files, pre-commit, rust-tests, rust-clippy]
+    needs: [changed-files, pre-commit, operator, snapshot, rust-tests, rust-clippy]
     if: always()
     steps:
       - name: "Check all dependent jobs"
@@ -60,6 +62,36 @@ jobs:
     - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
     - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
       timeout-minutes: 3
+
+  operator:
+    needs: changed-files
+    if: needs.changed-files.outputs.operator == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+    - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 #v3.11.1
+    - name: Run operator checks
+      uses: ./.github/actions/check-deploy-component
+      with:
+        component: operator
+        platform: linux/amd64
+
+  snapshot:
+    needs: changed-files
+    if: needs.changed-files.outputs.snapshot == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+    - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 #v3.11.1
+    - name: Run snapshot agent checks
+      uses: ./.github/actions/check-deploy-component
+      with:
+        component: snapshot
+        platform: linux/amd64
 
   rust-tests:
     needs: changed-files


### PR DESCRIPTION
## Summary
- move deploy component validation into the public Pre Merge workflow for operator and snapshot
- add a shared `check-deploy-component` action for deploy component linter/tester Docker targets
- run operator generated-file validation (`make check`) from that check action and make `build-deploy-component` build/push only

## Testing
- `yq e '.' .github/filters.yaml .github/actions/changed-files/action.yml .github/actions/build-deploy-component/action.yml .github/actions/check-deploy-component/action.yml .github/workflows/pre-merge.yml .github/workflows/pr.yaml .github/workflows/post-merge-ci.yml >/dev/null`
- `git diff --check`
- local pre-commit hook via `git commit`

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9316" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
