### PR TITLE
fix(revert): complete revert of the erroneous #9216, which messed up nixl for sglang

### DIFF
--- a/container/context.yaml
+++ b/container/context.yaml
@@ -85,11 +85,9 @@ sglang:
     runtime_image: lmsysorg/sglang
     base_image_tag: 25.11-cuda13.0-devel-ubuntu24.04
     runtime_image_tag: v0.5.10.post1-cu130-runtime
-  # Builds the NIXL C++ SDK in wheel_builder so the dev stage can link nixl-sys
-  # (see templates/dev.Dockerfile). Runtime stays on the upstream lmsysorg/sglang
-  # NIXL Python stack — its wheel COPY is narrowed to ai_dynamo*.whl so the SDK
-  # build doesn't leak into the runtime image.
-  nixl_ref: 0.10.1
+  # SGLang uses the NIXL stack from the upstream lmsysorg/sglang runtime image.
+  # Do not add nixl_ref here: Dynamo does not build or install its NIXL wheel
+  # for SGLang, and SGLang does not use Dynamo KVBM/block-manager at runtime.
   enable_media_ffmpeg: "true"
   enable_gpu_memory_service: "true"
   enable_kvbm: "false"

--- a/container/templates/dev.Dockerfile
+++ b/container/templates/dev.Dockerfile
@@ -187,35 +187,13 @@ RUN if [ ! -e /usr/bin/python3 ]; then \
         fi; \
     fi
 
-# NIXL C++ SDK (+ ucx, libfabric, gdrcopy) for cargo to link nixl-sys.
-# - sglang: upstream runtime ships only the Python wheel; SDK comes from here.
-# - vllm/trtllm/none: SDK already in runtime; this COPY is a no-op overwrite.
-{% if device == "cuda" %}
-RUN --mount=from=wheel_builder,target=/wheel_builder \
-    if [ -d /wheel_builder/opt/nvidia/nvda_nixl ]; then \
-        mkdir -p /opt/nvidia /usr/include /usr/lib64 /etc/ld.so.conf.d; \
-        cp -rn /wheel_builder/opt/nvidia/nvda_nixl /opt/nvidia/; \
-        if [ -d /wheel_builder/usr/local/ucx ]; then \
-            cp -rn /wheel_builder/usr/local/ucx /usr/local/; \
-        fi; \
-        if [ -d /wheel_builder/usr/local/libfabric ]; then \
-            cp -rn /wheel_builder/usr/local/libfabric /usr/local/; \
-        fi; \
-        if [ -f /wheel_builder/usr/include/gdrapi.h ]; then \
-            cp -n /wheel_builder/usr/include/gdrapi.h /usr/include/; \
-        fi; \
-        if ls /wheel_builder/usr/lib64/libgdrapi.so* >/dev/null 2>&1; then \
-            cp -n /wheel_builder/usr/lib64/libgdrapi.so* /usr/lib64/; \
-            echo "/usr/lib64" > /etc/ld.so.conf.d/gdrcopy.conf; \
-        fi; \
-    fi
-{% endif %}
-
 {% if device == "xpu" %}
 ENV NIXL_LIB_DIR=/opt/intel/intel_nixl/lib/x86_64-linux-gnu  \
     NIXL_PLUGIN_DIR=/opt/intel/intel_nixl/lib/x86_64-linux-gnu/plugins \
     NIXL_PREFIX=/opt/intel/intel_nixl
-{% else %}
+{% elif framework != "sglang" %}
+# Non-SGLang runtimes use the Dynamo-built NIXL install from wheel_builder.
+# Reset the same values already set in runtime (no harm).
 ENV NIXL_PREFIX=/opt/nvidia/nvda_nixl \
     NIXL_LIB_DIR=/opt/nvidia/nvda_nixl/lib64 \
     NIXL_PLUGIN_DIR=/opt/nvidia/nvda_nixl/lib64/plugins
@@ -237,15 +215,17 @@ ENV CUDA_HOME=/usr/local/cuda \
     NVIDIA_DRIVER_CAPABILITIES=video,compute,utility
 {% endif %}
 
-# Base LD_LIBRARY_PATH for NIXL + UCX. Framework-specific paths are added in
-# /etc/profile.d/50-framework-paths.sh.
-{% if device == "cuda" %}
+{% if framework != "sglang" %}
+# Base LD_LIBRARY_PATH with universal paths (all frameworks have these)
+# Framework-specific paths are conditionally added in /etc/profile.d/50-framework-paths.sh
 ENV LD_LIBRARY_PATH=\
 ${NIXL_LIB_DIR}:\
 ${NIXL_PLUGIN_DIR}:\
 /usr/local/ucx/lib:\
 /usr/local/ucx/lib/ucx:\
 ${LD_LIBRARY_PATH}
+{% else %}
+# SGLang dev/local-dev inherit the upstream SGLang/NIXL runtime stack.
 {% endif %}
 
 # Copy shell profile script for framework-specific environment variables

--- a/container/templates/sglang_runtime.Dockerfile
+++ b/container/templates/sglang_runtime.Dockerfile
@@ -40,12 +40,11 @@ RUN --mount=type=bind,from=wheel_builder,source=/usr/local/,target=/tmp/usr/loca
 {% endif %}
 
 {% if target not in ("dev", "local-dev") %}
-# Runtime uses upstream lmsysorg/sglang's NIXL Python stack; --no-deps keeps
-# pip from replacing it. Dev/local-dev build from source after bind-mount.
-#
-# Glob is ai_dynamo*.whl (not *.whl): wheel_builder also produces nixl-cu*.whl
-# which is only needed by the dev stage's SDK COPY (see dev.Dockerfile).
-COPY --chmod=775 --chown=dynamo:0 --from=wheel_builder /opt/dynamo/dist/ai_dynamo*.whl /opt/dynamo/wheelhouse/
+# Runtime target installs only the prebuilt Dynamo wheels. SGLang and its NIXL
+# packages come from the upstream lmsysorg/sglang runtime image; --no-deps keeps
+# pip from replacing that stack. Dev/local-dev build from source later in the
+# shared dev stage after the workspace is bind-mounted.
+COPY --chmod=775 --chown=dynamo:0 --from=wheel_builder /opt/dynamo/dist/*.whl /opt/dynamo/wheelhouse/
 
 RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     export PIP_CACHE_DIR=/root/.cache/pip && \


### PR DESCRIPTION
#### Overview:

My erroneous #9216 copied a NIXL C++ SDK into the sglang dev image to fix a cargo `nixl-sys` link error, but sglang's runtime path through Dynamo doesn't actually invoke `nixl-sys` — the install is scaffolding for a non-existent runtime problem. Reverts #9216, restoring #8472's architectural carve-out.

#### Details:

Reverting #9216, back to #8472, which lets sglang work without Dynamo's NIXL stack.

#### Where should the reviewer start?

`container/context.yaml`, then `container/templates/dev.Dockerfile`

#### Related Issues:

- Reverts #9216, restores #8472
- Closes [DIS-9265](https://linear.app/nvidia/issue/DIS-9265)

/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
- Refactored SGLang container runtime to leverage upstream NIXL stack from runtime image, reducing build complexity and maintenance overhead
- Enhanced hardware device support, specifically for XPU, with explicit environment variable initialization
- Optimized prebuilt dependency management through improved wheel installation process in runtime containers
- Refined framework-specific dynamic library path configuration to properly support diverse runtime environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->