### PR TITLE
docs(tests): align SGLang marker docs with --mem-fraction-static 0.9 (post-#9238)

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -208,7 +208,7 @@ GPU tests run concurrently via a custom VRAM-aware scheduler (`tests/utils/pytes
 2. **Profiling race**: engines snapshot free memory during init; concurrent startups corrupt each other. The scheduler staggers launches (VRAM stability check) and retries transient failures.
 3. **Engine-specific allocation**: each test gets a constrained allocation so it uses only its budgeted share. xdist has no mechanism for this.
    - **vLLM**: `_PROFILE_OVERRIDE_VLLM_KV_CACHE_BYTES = N` → `--kv-cache-memory-bytes` (from `requested_vllm_kv_cache_bytes` marker). Byte-based cap is deterministic and doesn't depend on current free memory, making it inherently parallel-safe. Uses `build_vllm_gpu_mem_args` in `gpu_utils.sh`.
-   - **SGLang**: `_PROFILE_OVERRIDE_SGLANG_MAX_TOTAL_TOKENS = N` → `--max-total-tokens` (from `requested_sglang_kv_tokens` marker). Token-based cap is deterministic and doesn't depend on current free memory, making it inherently parallel-safe. Non-text workloads may use `requested_sglang_vram_gib` for scheduler admission only.
+   - **SGLang**: `_PROFILE_OVERRIDE_SGLANG_MAX_TOTAL_TOKENS = N` → `--max-total-tokens N --mem-fraction-static 0.9` (from `requested_sglang_kv_tokens` marker). Token-based cap is deterministic and doesn't depend on current free memory, making it inherently parallel-safe; `--mem-fraction-static 0.9` is also emitted to keep SGLang's pool-creation gate open on small GPUs (see PR #9238). Non-text workloads may use `requested_sglang_vram_gib` for scheduler admission only.
    - **TRT-LLM**: `_PROFILE_OVERRIDE_TRTLLM_MAX_TOTAL_TOKENS = N` → `KvCacheConfig.max_tokens` via `--override-engine-args` JSON (from `requested_trtllm_kv_tokens` marker). Token-based cap is deterministic and parallel-safe. Uses `build_trtllm_override_args_with_mem` in `gpu_utils.sh` (separate function because TRT-LLM requires JSON merging).
 
 ```bash
@@ -676,9 +676,9 @@ Env vars control engine allocation during profiling and parallel test execution:
 
 **`_PROFILE_OVERRIDE_SGLANG_MAX_TOTAL_TOKENS`** (integer) — SGLang only:
 
-| Engine  | Returned CLI flag                | Notes |
-|---------|----------------------------------|-------|
-| SGLang  | `--max-total-tokens N`           | Token-based KV cache cap |
+| Engine  | Returned CLI flag                                  | Notes |
+|---------|----------------------------------------------------|-------|
+| SGLang  | `--max-total-tokens N --mem-fraction-static 0.9`   | Token-based KV cache cap; `--mem-fraction-static 0.9` keeps the pool-creation gate open on small GPUs (see PR #9238) |
 
 **`_PROFILE_OVERRIDE_TRTLLM_MAX_TOTAL_TOKENS`** (integer) — TRT-LLM text models:
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -189,7 +189,7 @@ Markers differ by engine:
 
 **SGLang** uses token-based control:
 - **`profiled_vram_gib(N)`** — actual peak from nvidia-smi at the recommended token count. Used for `--max-vram-gib` filtering and scheduler budget.
-- **`requested_sglang_kv_tokens(N)`** — max KV cache tokens. Sets `_PROFILE_OVERRIDE_SGLANG_MAX_TOTAL_TOKENS` → `--max-total-tokens`. SGLang's default `--mem-fraction-static` is never overridden; the token cap is the sole allocation control. Deterministic and parallel-safe (see `examples/common/gpu_utils.md`).
+- **`requested_sglang_kv_tokens(N)`** — max KV cache tokens. Sets `_PROFILE_OVERRIDE_SGLANG_MAX_TOTAL_TOKENS` → `--max-total-tokens N --mem-fraction-static 0.9`. The token cap controls actual KV allocation; `--mem-fraction-static 0.9` is also emitted to keep SGLang's pool-creation gate open on small GPUs (see PR #9238). Deterministic and parallel-safe (see `examples/common/gpu_utils.md`).
 - **`requested_sglang_vram_gib(N)`** — max VRAM in GiB for non-text workloads (video/image diffusion), where token-based control doesn't apply. Used for scheduler admission and display only.
 
 **TRT-LLM** uses token-based control (text models) or byte-based control (diffusion models):
@@ -636,7 +636,7 @@ The profiler automatically detects the engine type and uses the appropriate bina
 
 **Requirement (vLLM):** The launch script must honor `_PROFILE_OVERRIDE_VLLM_KV_CACHE_BYTES`. This is handled by `build_vllm_gpu_mem_args` in `gpu_utils.sh` (returns `--kv-cache-memory-bytes N`).
 
-**Requirement (SGLang):** The launch script must honor `_PROFILE_OVERRIDE_SGLANG_MAX_TOTAL_TOKENS`. This is handled by `build_sglang_gpu_mem_args` in `gpu_utils.sh` (returns `--max-total-tokens N`).
+**Requirement (SGLang):** The launch script must honor `_PROFILE_OVERRIDE_SGLANG_MAX_TOTAL_TOKENS`. This is handled by `build_sglang_gpu_mem_args` in `gpu_utils.sh` (returns `--max-total-tokens N --mem-fraction-static 0.9`).
 
 **Requirement (TRT-LLM):** The launch script must honor `_PROFILE_OVERRIDE_TRTLLM_MAX_TOTAL_TOKENS` (and optionally `_PROFILE_OVERRIDE_TRTLLM_MAX_GPU_TOTAL_BYTES`). This is handled by `build_trtllm_override_args_with_mem` in `gpu_utils.sh` (returns JSON for `--override-engine-args`). Note: this is a separate function from `build_vllm_gpu_mem_args` / `build_sglang_gpu_mem_args` because TRT-LLM requires JSON merging.
 


### PR DESCRIPTION
#### Overview:

Doc-only follow-up to #9238: align `tests/README.md` SGLang marker docs with the post-#9238 reality that `build_sglang_gpu_mem_args` now emits both `--max-total-tokens N` and `--mem-fraction-static 0.9` (not just the token cap).

No code changes. The associated cu13 unblock + memory-saver cleanup that was scoped here originally turned out unnecessary — the broader sglang cu13 stack still needs more work upstream before that test can run on cu13, and on cu12 the `--enable-memory-saver` flag is harmless.

#### Details:

- `tests/README.md` line 192: `requested_sglang_kv_tokens(N)` description now says it sets `--max-total-tokens N --mem-fraction-static 0.9` (was: just `--max-total-tokens`, with a now-stale note that fraction is never overridden).
- `tests/README.md` line 639: SGLang launch-script requirement updated to reflect the same two-flag emission from `build_sglang_gpu_mem_args`.

#### Where should the reviewer start?

`tests/README.md` (2-line diff).

#### Related Issues:

Follow-up to #9238 (KV markers + `--mem-fraction-static 0.9`). Doc-only — no test or launch-script behavior change.

/coderabbit profile chill
