### PR TITLE
refactor(llm): Deduplicate DeepSeek prompt encoders v3.2 and v4

### DIFF
--- a/lib/llm/src/preprocessor/prompt.rs
+++ b/lib/llm/src/preprocessor/prompt.rs
@@ -25,6 +25,7 @@ use std::sync::Arc;
 
 use crate::preprocessor::media::MediaDecoder;
 
+pub mod deepseek_common;
 pub mod deepseek_v32;
 pub mod deepseek_v4;
 mod template;

--- a/lib/llm/src/preprocessor/prompt/deepseek_common.rs
+++ b/lib/llm/src/preprocessor/prompt/deepseek_common.rs
@@ -1,0 +1,513 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared DeepSeek native prompt-formatting helpers.
+
+use anyhow::{Context, Result};
+use serde_json::Value as JsonValue;
+
+/// Special tokens for DeepSeek prompt formatting.
+pub mod tokens {
+    pub const BOS: &str = "<｜begin▁of▁sentence｜>";
+    pub const EOS: &str = "<｜end▁of▁sentence｜>";
+    pub const THINKING_START: &str = "<think>";
+    pub const THINKING_END: &str = "</think>";
+    pub const DSML_TOKEN: &str = "｜DSML｜";
+    pub const USER_START: &str = "<｜User｜>";
+    pub const ASSISTANT_START: &str = "<｜Assistant｜>";
+    pub const LATEST_REMINDER: &str = "<｜latest_reminder｜>";
+
+    // Quick-instruction task tokens
+    pub const TASK_ACTION: &str = "<｜action｜>";
+    pub const TASK_QUERY: &str = "<｜query｜>";
+    pub const TASK_AUTHORITY: &str = "<｜authority｜>";
+    pub const TASK_DOMAIN: &str = "<｜domain｜>";
+    pub const TASK_TITLE: &str = "<｜title｜>";
+    pub const TASK_READ_URL: &str = "<｜read_url｜>";
+}
+
+pub(crate) const TOOL_CALLS_BLOCK_NAME: &str = "tool_calls";
+
+pub(crate) const RESPONSE_FORMAT_TEMPLATE: &str =
+    "## Response Format:\n\nYou MUST strictly adhere to the following schema to reply:\n{schema}";
+
+pub(crate) const TOOLS_TEMPLATE: &str = r#"## Tools
+
+You have access to a set of tools to help answer the user's question. You can invoke tools by writing a "<{dsml_token}tool_calls>" block like the following:
+
+<{dsml_token}tool_calls>
+<{dsml_token}invoke name="$TOOL_NAME">
+<{dsml_token}parameter name="$PARAMETER_NAME" string="true|false">$PARAMETER_VALUE</{dsml_token}parameter>
+...
+</{dsml_token}invoke>
+<{dsml_token}invoke name="$TOOL_NAME2">
+...
+</{dsml_token}invoke>
+</{dsml_token}tool_calls>
+
+String parameters should be specified as is and set `string="true"`. For all other types (numbers, booleans, arrays, objects), pass the value in JSON format and set `string="false"`.
+
+If thinking_mode is enabled (triggered by {thinking_start_token}), you MUST output your complete reasoning inside {thinking_start_token}...{thinking_end_token} BEFORE any tool calls or final response.
+
+Otherwise, output directly after {thinking_end_token} with tool calls or final response.
+
+### Available Tool Schemas
+
+{tool_schemas}
+
+You MUST strictly follow the above defined tool name and parameter schemas to invoke tool calls.
+"#;
+
+/// System message template for tools.
+pub(crate) const TOOLS_SYSTEM_TEMPLATE: &str = r#"## Tools
+
+You have access to a set of tools you can use to answer the user's question.
+You can invoke functions by writing a "<{dsml_token}function_calls>" block like the following as part of your reply to the user:
+<{dsml_token}function_calls>
+<{dsml_token}invoke name="$FUNCTION_NAME">
+<{dsml_token}parameter name="$PARAMETER_NAME" string="true|false">$PARAMETER_VALUE</{dsml_token}parameter>
+...
+</{dsml_token}invoke>
+<{dsml_token}invoke name="$FUNCTION_NAME2">
+...
+</{dsml_token}invoke>
+</{dsml_token}function_calls>
+
+String and scalar parameters should be specified as is without any escaping or quotes, while lists and objects should use JSON format. The "string" attribute should be set to "true" for string type parameters and "false" for other types (numbers, booleans, arrays, objects).
+
+If the thinking_mode is enabled, then after function results you should strongly consider outputting a thinking block. Here is an example:
+
+<{dsml_token}function_calls>
+...
+</{dsml_token}function_calls>
+
+<function_results>
+...
+</function_results>
+
+{thinking_start_token}...thinking about results{thinking_end_token}
+
+Here are the functions available in JSONSchema format:
+<functions>
+{tool_schemas}
+</functions>
+"#;
+
+pub(crate) const TOOL_CALL_TEMPLATE: &str =
+    "<{dsml_token}invoke name=\"{name}\">\n{arguments}\n</{dsml_token}invoke>";
+
+pub(crate) const TOOL_OUTPUT_TEMPLATE: &str = "\n<result>{content}</result>";
+
+pub(crate) const REASONING_EFFORT_MAX: &str = "Reasoning Effort: Absolute maximum with no shortcuts permitted.\nYou MUST be very thorough in your thinking and comprehensively decompose the problem to resolve the root cause, rigorously stress-testing your logic against all potential paths, edge cases, and adversarial scenarios.\nExplicitly write out your entire deliberation process, documenting every intermediate step, considered alternative, and rejected hypothesis to ensure absolutely no assumption is left unchecked.\n\n";
+
+/// Thinking mode for the model.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ThinkingMode {
+    Chat,
+    Thinking,
+}
+
+impl ThinkingMode {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ThinkingMode::Chat => "chat",
+            ThinkingMode::Thinking => "thinking",
+        }
+    }
+}
+
+/// Reasoning effort level. `None` conveyed as `Option<ReasoningEffort>`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReasoningEffort {
+    Max,
+    High,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum NormalizeNonText {
+    SerializeJson,
+    LeaveUntouched,
+}
+
+// Serialize a JSON value to match Python's `json.dumps(ensure_ascii=False)` spacing.
+// Python's default separators are `(', ', ': ')`; we use a custom `Formatter`
+// so escape sequences inside strings can't confuse state tracking.
+pub(crate) fn to_json(value: &JsonValue) -> String {
+    use serde::Serialize;
+    use serde_json::ser::Formatter;
+    use std::io;
+
+    struct PythonFormatter;
+
+    impl Formatter for PythonFormatter {
+        fn begin_array_value<W: ?Sized + io::Write>(
+            &mut self,
+            writer: &mut W,
+            first: bool,
+        ) -> io::Result<()> {
+            if first {
+                Ok(())
+            } else {
+                writer.write_all(b", ")
+            }
+        }
+
+        fn begin_object_key<W: ?Sized + io::Write>(
+            &mut self,
+            writer: &mut W,
+            first: bool,
+        ) -> io::Result<()> {
+            if first {
+                Ok(())
+            } else {
+                writer.write_all(b", ")
+            }
+        }
+
+        fn begin_object_value<W: ?Sized + io::Write>(&mut self, writer: &mut W) -> io::Result<()> {
+            writer.write_all(b": ")
+        }
+    }
+
+    // Serializing a JsonValue into Vec<u8> is infallible; the output is always UTF-8.
+    let mut buf = Vec::with_capacity(64);
+    let mut ser = serde_json::Serializer::with_formatter(&mut buf, PythonFormatter);
+    value
+        .serialize(&mut ser)
+        .expect("JsonValue serialization to Vec<u8> is infallible");
+    String::from_utf8(buf).expect("serde_json output is always valid UTF-8")
+}
+
+pub(crate) fn render_tools(template: &str, tools: &[JsonValue]) -> String {
+    let tools_json: Vec<String> = tools
+        .iter()
+        .filter_map(|tool| tool.get("function"))
+        .map(to_json)
+        .collect();
+
+    template
+        .replace("{tool_schemas}", &tools_json.join("\n"))
+        .replace("{dsml_token}", tokens::DSML_TOKEN)
+        .replace("{thinking_start_token}", tokens::THINKING_START)
+        .replace("{thinking_end_token}", tokens::THINKING_END)
+}
+
+pub(crate) fn find_last_user_index(messages: &[JsonValue]) -> Option<usize> {
+    messages
+        .iter()
+        .enumerate()
+        .rev()
+        .find(|(_, msg)| {
+            msg.get("role")
+                .and_then(|r| r.as_str())
+                .map(|r| r == "user" || r == "developer")
+                .unwrap_or(false)
+        })
+        .map(|(idx, _)| idx)
+}
+
+pub(crate) fn extract_visible_text(content: &JsonValue) -> String {
+    match content {
+        JsonValue::String(text) => text.clone(),
+        JsonValue::Array(items) => items
+            .iter()
+            .filter_map(|item| {
+                if let Some(text) = item.as_str() {
+                    return Some(text.to_string());
+                }
+                let item_type = item.get("type").and_then(|v| v.as_str());
+                if item_type == Some("text") {
+                    return item
+                        .get("text")
+                        .and_then(|v| v.as_str())
+                        .map(|text| text.to_string());
+                }
+                tracing::warn!(
+                    chunk_type = item_type.unwrap_or("unknown"),
+                    "DeepSeek formatter dropped non-text content chunk while normalizing message content",
+                );
+                None
+            })
+            .collect::<String>(),
+        _ => to_json(content),
+    }
+}
+
+pub(crate) fn normalize_message_contents(messages: &mut [JsonValue], non_text: NormalizeNonText) {
+    for msg in messages {
+        let Some(content) = msg.get("content") else {
+            continue;
+        };
+        if !content.is_string()
+            && !content.is_array()
+            && non_text == NormalizeNonText::LeaveUntouched
+        {
+            continue;
+        }
+        let normalized = extract_visible_text(content);
+        if let Some(obj) = msg.as_object_mut() {
+            obj.insert("content".to_string(), JsonValue::String(normalized));
+        }
+    }
+}
+
+pub(crate) fn encode_arguments_to_dsml(tool_call: &JsonValue) -> Result<String> {
+    let arguments_str = tool_call
+        .get("arguments")
+        .and_then(|a| a.as_str())
+        .context("Missing or invalid 'arguments' field")?;
+
+    // Python falls back to `{"arguments": raw_string}` on parse failure.
+    let arguments: JsonValue = match serde_json::from_str(arguments_str) {
+        Ok(v) => v,
+        Err(_) => serde_json::json!({ "arguments": arguments_str }),
+    };
+
+    let arguments_obj = arguments
+        .as_object()
+        .context("Arguments must be a JSON object")?;
+
+    let mut params = Vec::new();
+    for (key, value) in arguments_obj {
+        let value_str = if let Some(vs) = value.as_str() {
+            vs.to_string()
+        } else {
+            to_json(value)
+        };
+        params.push(format!(
+            "<{}parameter name=\"{}\" string=\"{}\">{}</{}parameter>",
+            tokens::DSML_TOKEN,
+            key,
+            if value.is_string() { "true" } else { "false" },
+            value_str,
+            tokens::DSML_TOKEN
+        ));
+    }
+
+    Ok(params.join("\n"))
+}
+
+pub(crate) fn task_token(task: &str) -> Option<&'static str> {
+    match task {
+        "action" => Some(tokens::TASK_ACTION),
+        "query" => Some(tokens::TASK_QUERY),
+        "authority" => Some(tokens::TASK_AUTHORITY),
+        "domain" => Some(tokens::TASK_DOMAIN),
+        "title" => Some(tokens::TASK_TITLE),
+        "read_url" => Some(tokens::TASK_READ_URL),
+        _ => None,
+    }
+}
+
+// Merge `tool` role messages into preceding user `content_blocks` and collapse
+// consecutive user turns, matching Python's `merge_tool_messages`.
+pub(crate) fn merge_tool_messages(messages: &[JsonValue]) -> Vec<JsonValue> {
+    let mut merged: Vec<JsonValue> = Vec::with_capacity(messages.len());
+
+    for msg in messages {
+        let role = msg.get("role").and_then(|r| r.as_str()).unwrap_or("");
+
+        if role == "tool" {
+            let tool_block = serde_json::json!({
+                "type": "tool_result",
+                "tool_use_id": msg.get("tool_call_id").cloned().unwrap_or_else(|| JsonValue::String(String::new())),
+                "content": msg.get("content").cloned().unwrap_or_else(|| JsonValue::String(String::new())),
+            });
+
+            let can_merge = merged
+                .last()
+                .map(|m| {
+                    m.get("role").and_then(|r| r.as_str()) == Some("user")
+                        && m.get("content_blocks").is_some()
+                })
+                .unwrap_or(false);
+
+            if can_merge {
+                let last = merged.last_mut().unwrap();
+                if let Some(blocks) = last
+                    .as_object_mut()
+                    .and_then(|o| o.get_mut("content_blocks"))
+                    .and_then(|v| v.as_array_mut())
+                {
+                    blocks.push(tool_block);
+                }
+            } else {
+                merged.push(serde_json::json!({
+                    "role": "user",
+                    "content_blocks": [tool_block],
+                }));
+            }
+        } else if role == "user" {
+            let text = msg
+                .get("content")
+                .and_then(|c| c.as_str())
+                .unwrap_or("")
+                .to_string();
+            let text_block = serde_json::json!({ "type": "text", "text": text });
+
+            let can_merge = merged
+                .last()
+                .map(|m| {
+                    m.get("role").and_then(|r| r.as_str()) == Some("user")
+                        && m.get("content_blocks").is_some()
+                        && m.get("task").map(|v| v.is_null()).unwrap_or(true)
+                })
+                .unwrap_or(false);
+
+            if can_merge {
+                let last = merged.last_mut().unwrap();
+                if let Some(blocks) = last
+                    .as_object_mut()
+                    .and_then(|o| o.get_mut("content_blocks"))
+                    .and_then(|v| v.as_array_mut())
+                {
+                    blocks.push(text_block);
+                }
+            } else {
+                let mut new_msg = serde_json::json!({
+                    "role": "user",
+                    "content": text,
+                    "content_blocks": [text_block],
+                });
+                // Preserve extra fields.
+                if let Some(obj) = new_msg.as_object_mut() {
+                    for key in ["task", "wo_eos", "mask"] {
+                        if let Some(v) = msg.get(key) {
+                            obj.insert(key.to_string(), v.clone());
+                        }
+                    }
+                }
+                merged.push(new_msg);
+            }
+        } else {
+            merged.push(msg.clone());
+        }
+    }
+
+    merged
+}
+
+// Sort `tool_result` blocks within user messages by the `tool_calls[].id` order
+// of the preceding assistant message.
+pub(crate) fn sort_tool_results_by_call_order(mut messages: Vec<JsonValue>) -> Vec<JsonValue> {
+    use std::collections::HashMap;
+    let mut last_order: HashMap<String, usize> = HashMap::new();
+
+    for msg in &mut messages {
+        let role = msg.get("role").and_then(|r| r.as_str()).unwrap_or("");
+        if role == "assistant" {
+            if let Some(tcs) = msg.get("tool_calls").and_then(|t| t.as_array()) {
+                last_order.clear();
+                for (idx, tc) in tcs.iter().enumerate() {
+                    let id = tc
+                        .get("id")
+                        .and_then(|v| v.as_str())
+                        .or_else(|| {
+                            tc.get("function")
+                                .and_then(|f| f.get("id"))
+                                .and_then(|v| v.as_str())
+                        })
+                        .unwrap_or("");
+                    if !id.is_empty() {
+                        last_order.insert(id.to_string(), idx);
+                    }
+                }
+            }
+        } else if role == "user" && !last_order.is_empty() {
+            let Some(blocks) = msg
+                .as_object_mut()
+                .and_then(|o| o.get_mut("content_blocks"))
+                .and_then(|v| v.as_array_mut())
+            else {
+                continue;
+            };
+
+            // Collect tool_result blocks with their positions.
+            let tool_positions: Vec<usize> = blocks
+                .iter()
+                .enumerate()
+                .filter(|(_, b)| b.get("type").and_then(|v| v.as_str()) == Some("tool_result"))
+                .map(|(i, _)| i)
+                .collect();
+
+            if tool_positions.len() > 1 {
+                let start = *tool_positions
+                    .first()
+                    .expect("tool_positions has length > 1");
+                let end = *tool_positions
+                    .last()
+                    .expect("tool_positions has length > 1");
+                let is_contiguous = end - start + 1 == tool_positions.len();
+
+                if is_contiguous {
+                    // Fast path: sort the contiguous slice in place
+                    blocks[start..=end].sort_by_key(|b| {
+                        let id = b.get("tool_use_id").and_then(|v| v.as_str()).unwrap_or("");
+                        *last_order.get(id).unwrap_or(&0)
+                    });
+                } else {
+                    // Fallback: extract, sort, and replace for non-contiguous blocks
+                    let mut tool_blocks: Vec<JsonValue> = tool_positions
+                        .iter()
+                        .map(|&i| std::mem::take(&mut blocks[i]))
+                        .collect();
+
+                    tool_blocks.sort_by_key(|b| {
+                        let id = b.get("tool_use_id").and_then(|v| v.as_str()).unwrap_or("");
+                        *last_order.get(id).unwrap_or(&0)
+                    });
+
+                    for (sorted_idx, &pos) in tool_positions.iter().enumerate() {
+                        blocks[pos] = std::mem::take(&mut tool_blocks[sorted_idx]);
+                    }
+                }
+            }
+        }
+    }
+
+    messages
+}
+
+// Drop reasoning and non-essential messages before the last user message.
+pub(crate) fn drop_thinking_messages(messages: Vec<JsonValue>) -> Vec<JsonValue> {
+    let last_user_idx = find_last_user_index(&messages);
+    let mut out = Vec::with_capacity(messages.len());
+    const KEEP: &[&str] = &[
+        "user",
+        "system",
+        "tool",
+        "latest_reminder",
+        "direct_search_results",
+    ];
+
+    for (idx, mut msg) in messages.into_iter().enumerate() {
+        let role = msg.get("role").and_then(|r| r.as_str()).unwrap_or("");
+        if KEEP.contains(&role) || last_user_idx.is_none_or(|u| idx >= u) {
+            out.push(msg);
+        } else if role == "assistant" {
+            if let Some(obj) = msg.as_object_mut() {
+                obj.remove("reasoning_content");
+            }
+            out.push(msg);
+        }
+        // developer and other roles before last_user_idx are dropped.
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_extract_visible_text_from_content_array() {
+        let content = json!([
+            {"type": "text", "text": "who "},
+            {"type": "text", "text": "are "},
+            {"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}},
+            {"type": "text", "text": "you?"}
+        ]);
+        assert_eq!(extract_visible_text(&content), "who are you?");
+    }
+}

--- a/lib/llm/src/preprocessor/prompt/deepseek_common.rs
+++ b/lib/llm/src/preprocessor/prompt/deepseek_common.rs
@@ -495,6 +495,80 @@ pub(crate) fn drop_thinking_messages(messages: Vec<JsonValue>) -> Vec<JsonValue>
     out
 }
 
+pub(crate) fn resolve_thinking_mode(
+    args: Option<&std::collections::HashMap<String, serde_json::Value>>,
+    default_mode: ThinkingMode,
+) -> ThinkingMode {
+    if let Some(enabled) = super::thinking_bool_from_args(args) {
+        return if enabled {
+            ThinkingMode::Thinking
+        } else {
+            ThinkingMode::Chat
+        };
+    }
+    if let Some(args) = args
+        && let Some(mode) = args.get("thinking_mode").and_then(|v| v.as_str())
+    {
+        match mode {
+            "chat" => return ThinkingMode::Chat,
+            "thinking" => return ThinkingMode::Thinking,
+            _ => {}
+        }
+    }
+    default_mode
+}
+
+pub(crate) fn inject_tools_and_response_format(
+    messages_array: &mut Vec<JsonValue>,
+    req: &dyn super::OAIChatLikeRequest,
+) -> Result<()> {
+    let tools_json = req
+        .tools()
+        .map(|t| serde_json::to_value(&t))
+        .transpose()
+        .context("Failed to convert tools to JSON")?;
+
+    let response_format_json = req
+        .response_format()
+        .map(|rf| serde_json::to_value(&rf))
+        .transpose()
+        .context("Failed to convert response_format to JSON")?;
+
+    if tools_json.is_some() || response_format_json.is_some() {
+        let system_idx = messages_array
+            .iter()
+            .position(|msg| msg.get("role").and_then(|r| r.as_str()) == Some("system"));
+
+        if let Some(idx) = system_idx {
+            if let Some(msg) = messages_array.get_mut(idx)
+                && let Some(obj) = msg.as_object_mut()
+            {
+                if let Some(tools) = tools_json {
+                    obj.insert("tools".to_string(), tools);
+                }
+                if let Some(rf) = response_format_json {
+                    obj.insert("response_format".to_string(), rf);
+                }
+            }
+        } else {
+            let mut system_msg = serde_json::json!({
+                "role": "system",
+                "content": ""
+            });
+            if let Some(obj) = system_msg.as_object_mut() {
+                if let Some(tools) = tools_json {
+                    obj.insert("tools".to_string(), tools);
+                }
+                if let Some(rf) = response_format_json {
+                    obj.insert("response_format".to_string(), rf);
+                }
+            }
+            messages_array.insert(0, system_msg);
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/lib/llm/src/preprocessor/prompt/deepseek_common.rs
+++ b/lib/llm/src/preprocessor/prompt/deepseek_common.rs
@@ -185,11 +185,13 @@ pub(crate) fn render_tools(template: &str, tools: &[JsonValue]) -> String {
         .map(to_json)
         .collect();
 
+    // Always do the tool_schemas last because they are user controlled.
+    // See test_render_tools_preserves_placeholder_text_inside_tool_schema.
     template
-        .replace("{tool_schemas}", &tools_json.join("\n"))
         .replace("{dsml_token}", tokens::DSML_TOKEN)
         .replace("{thinking_start_token}", tokens::THINKING_START)
         .replace("{thinking_end_token}", tokens::THINKING_END)
+        .replace("{tool_schemas}", &tools_json.join("\n"))
 }
 
 pub(crate) fn find_last_user_index(messages: &[JsonValue]) -> Option<usize> {
@@ -583,5 +585,31 @@ mod tests {
             {"type": "text", "text": "you?"}
         ]);
         assert_eq!(extract_visible_text(&content), "who are you?");
+    }
+
+    #[test]
+    fn test_render_tools_preserves_placeholder_text_inside_tool_schema() {
+        let tools = json!([{
+            "type": "function",
+            "function": {
+                "name": "placeholder_tool",
+                "description": "literal {dsml_token} {thinking_start_token} {thinking_end_token}",
+                "parameters": {"type": "object", "properties": {}}
+            }
+        }]);
+        let rendered = render_tools(
+            "static {dsml_token} {thinking_start_token} {thinking_end_token}\n{tool_schemas}",
+            tools.as_array().unwrap(),
+        );
+
+        assert!(rendered.starts_with(&format!(
+            "static {} {} {}\n",
+            tokens::DSML_TOKEN,
+            tokens::THINKING_START,
+            tokens::THINKING_END
+        )));
+        assert!(
+            rendered.contains("literal {dsml_token} {thinking_start_token} {thinking_end_token}")
+        );
     }
 }

--- a/lib/llm/src/preprocessor/prompt/deepseek_common.rs
+++ b/lib/llm/src/preprocessor/prompt/deepseek_common.rs
@@ -301,6 +301,18 @@ pub(crate) fn task_token(task: &str) -> Option<&'static str> {
     }
 }
 
+const USER_FIELDS_TO_PRESERVE: [&str; 3] = ["task", "wo_eos", "mask"];
+
+fn preserve_user_fields(target: &mut JsonValue, source: &JsonValue) {
+    if let Some(obj) = target.as_object_mut() {
+        for key in USER_FIELDS_TO_PRESERVE {
+            if let Some(v) = source.get(key) {
+                obj.insert(key.to_string(), v.clone());
+            }
+        }
+    }
+}
+
 // Merge `tool` role messages into preceding user `content_blocks` and collapse
 // consecutive user turns, matching Python's `merge_tool_messages`.
 pub(crate) fn merge_tool_messages(messages: &[JsonValue]) -> Vec<JsonValue> {
@@ -358,12 +370,16 @@ pub(crate) fn merge_tool_messages(messages: &[JsonValue]) -> Vec<JsonValue> {
 
             if can_merge {
                 let last = merged.last_mut().unwrap();
-                if let Some(blocks) = last
+                let appended = last
                     .as_object_mut()
                     .and_then(|o| o.get_mut("content_blocks"))
                     .and_then(|v| v.as_array_mut())
-                {
-                    blocks.push(text_block);
+                    .map(|blocks| {
+                        blocks.push(text_block);
+                    })
+                    .is_some();
+                if appended {
+                    preserve_user_fields(last, msg);
                 }
             } else {
                 let mut new_msg = serde_json::json!({
@@ -371,14 +387,7 @@ pub(crate) fn merge_tool_messages(messages: &[JsonValue]) -> Vec<JsonValue> {
                     "content": text,
                     "content_blocks": [text_block],
                 });
-                // Preserve extra fields.
-                if let Some(obj) = new_msg.as_object_mut() {
-                    for key in ["task", "wo_eos", "mask"] {
-                        if let Some(v) = msg.get(key) {
-                            obj.insert(key.to_string(), v.clone());
-                        }
-                    }
-                }
+                preserve_user_fields(&mut new_msg, msg);
                 merged.push(new_msg);
             }
         } else {

--- a/lib/llm/src/preprocessor/prompt/deepseek_v32.rs
+++ b/lib/llm/src/preprocessor/prompt/deepseek_v32.rs
@@ -286,33 +286,6 @@ impl DeepSeekV32Formatter {
     pub fn new_chat() -> Self {
         Self::new(ThinkingMode::Chat)
     }
-
-    /// Resolve thinking mode from per-request `chat_template_args`, falling back to the
-    /// formatter's default. Two conventions are supported:
-    ///   - `{"thinking": bool}` — common across models (e.g. Kimi K25)
-    ///   - `{"thinking_mode": "chat"|"thinking"}` — matches the DSV3.2 Jinja template parameter
-    fn resolve_thinking_mode(
-        &self,
-        args: Option<&std::collections::HashMap<String, serde_json::Value>>,
-    ) -> ThinkingMode {
-        if let Some(args) = args {
-            if let Some(thinking) = args.get("thinking").and_then(|v| v.as_bool()) {
-                return if thinking {
-                    ThinkingMode::Thinking
-                } else {
-                    ThinkingMode::Chat
-                };
-            }
-            if let Some(mode) = args.get("thinking_mode").and_then(|v| v.as_str()) {
-                match mode {
-                    "chat" => return ThinkingMode::Chat,
-                    "thinking" => return ThinkingMode::Thinking,
-                    _ => {}
-                }
-            }
-        }
-        self.thinking_mode
-    }
 }
 
 impl super::OAIPromptFormatter for DeepSeekV32Formatter {
@@ -321,7 +294,10 @@ impl super::OAIPromptFormatter for DeepSeekV32Formatter {
     }
 
     fn render(&self, req: &dyn super::OAIChatLikeRequest) -> Result<String> {
-        let thinking_mode = self.resolve_thinking_mode(req.chat_template_args());
+        let thinking_mode = super::deepseek_common::resolve_thinking_mode(
+            req.chat_template_args(),
+            self.thinking_mode,
+        );
 
         // Get messages from request
         let messages_value = req.messages();
@@ -341,53 +317,7 @@ impl super::OAIPromptFormatter for DeepSeekV32Formatter {
 
         // Inject tools and response_format from request into the first system message
         // DeepSeek V3.2 expects these to be part of the system message for prompt rendering
-        let tools_json = req
-            .tools()
-            .map(|t| serde_json::to_value(&t))
-            .transpose()
-            .context("Failed to convert tools to JSON")?;
-
-        let response_format_json = req
-            .response_format()
-            .map(|rf| serde_json::to_value(&rf))
-            .transpose()
-            .context("Failed to convert response_format to JSON")?;
-
-        if tools_json.is_some() || response_format_json.is_some() {
-            // Find or create system message
-            let system_idx = messages_array
-                .iter()
-                .position(|msg| msg.get("role").and_then(|r| r.as_str()) == Some("system"));
-
-            if let Some(idx) = system_idx {
-                // Add to existing system message
-                if let Some(msg) = messages_array.get_mut(idx)
-                    && let Some(obj) = msg.as_object_mut()
-                {
-                    if let Some(tools) = tools_json {
-                        obj.insert("tools".to_string(), tools);
-                    }
-                    if let Some(rf) = response_format_json {
-                        obj.insert("response_format".to_string(), rf);
-                    }
-                }
-            } else {
-                // Create a system message if none exists
-                let mut system_msg = serde_json::json!({
-                    "role": "system",
-                    "content": ""
-                });
-                if let Some(obj) = system_msg.as_object_mut() {
-                    if let Some(tools) = tools_json {
-                        obj.insert("tools".to_string(), tools);
-                    }
-                    if let Some(rf) = response_format_json {
-                        obj.insert("response_format".to_string(), rf);
-                    }
-                }
-                messages_array.insert(0, system_msg);
-            }
-        }
+        super::deepseek_common::inject_tools_and_response_format(&mut messages_array, req)?;
 
         // Encode with native implementation
         encode_messages(

--- a/lib/llm/src/preprocessor/prompt/deepseek_v32.rs
+++ b/lib/llm/src/preprocessor/prompt/deepseek_v32.rs
@@ -11,235 +11,13 @@
 use anyhow::{Context, Result};
 use serde_json::Value as JsonValue;
 
-/// Special tokens for DeepSeek V3.2
-pub mod tokens {
-    pub const BOS: &str = "<｜begin▁of▁sentence｜>";
-    pub const EOS: &str = "<｜end▁of▁sentence｜>";
-    pub const THINKING_START: &str = "<think>";
-    pub const THINKING_END: &str = "</think>";
-    pub const DSML_TOKEN: &str = "｜DSML｜";
-    pub const USER_START: &str = "<｜User｜>";
-    pub const ASSISTANT_START: &str = "<｜Assistant｜>";
-}
+use super::deepseek_common::{
+    NormalizeNonText, RESPONSE_FORMAT_TEMPLATE, TOOL_CALL_TEMPLATE, TOOL_OUTPUT_TEMPLATE,
+    TOOLS_SYSTEM_TEMPLATE, encode_arguments_to_dsml, find_last_user_index,
+    normalize_message_contents, render_tools, to_json,
+};
 
-/// System message template for tools
-const TOOLS_SYSTEM_TEMPLATE: &str = r#"## Tools
-
-You have access to a set of tools you can use to answer the user's question.
-You can invoke functions by writing a "<{dsml_token}function_calls>" block like the following as part of your reply to the user:
-<{dsml_token}function_calls>
-<{dsml_token}invoke name="$FUNCTION_NAME">
-<{dsml_token}parameter name="$PARAMETER_NAME" string="true|false">$PARAMETER_VALUE</{dsml_token}parameter>
-...
-</{dsml_token}invoke>
-<{dsml_token}invoke name="$FUNCTION_NAME2">
-...
-</{dsml_token}invoke>
-</{dsml_token}function_calls>
-
-String and scalar parameters should be specified as is without any escaping or quotes, while lists and objects should use JSON format. The "string" attribute should be set to "true" for string type parameters and "false" for other types (numbers, booleans, arrays, objects).
-
-If the thinking_mode is enabled, then after function results you should strongly consider outputting a thinking block. Here is an example:
-
-<{dsml_token}function_calls>
-...
-</{dsml_token}function_calls>
-
-<function_results>
-...
-</function_results>
-
-{thinking_start_token}...thinking about results{thinking_end_token}
-
-Here are the functions available in JSONSchema format:
-<functions>
-{tool_schemas}
-</functions>
-"#;
-
-const RESPONSE_FORMAT_TEMPLATE: &str =
-    "## Response Format:\n\nYou MUST strictly adhere to the following schema to reply:\n{schema}";
-
-const TOOL_CALL_TEMPLATE: &str =
-    "<{dsml_token}invoke name=\"{name}\">\n{arguments}\n</{dsml_token}invoke>";
-
-#[allow(dead_code)]
-const TOOL_CALLS_TEMPLATE: &str =
-    "<{dsml_token}function_calls>\n{tool_calls}\n</{dsml_token}function_calls>";
-
-const TOOL_OUTPUT_TEMPLATE: &str = "\n<result>{content}</result>";
-
-/// Thinking mode for the model
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ThinkingMode {
-    Chat,
-    Thinking,
-}
-
-impl ThinkingMode {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            ThinkingMode::Chat => "chat",
-            ThinkingMode::Thinking => "thinking",
-        }
-    }
-}
-
-/// Convert value to JSON string matching Python's json.dumps() format with spaces
-fn to_json(value: &JsonValue) -> String {
-    // Python's json.dumps() adds spaces after colons and commas
-    // {"name": "value", "key": "value2"}
-    // Rust's serde_json::to_string() produces:
-    // {"name":"value","key":"value2"}
-    // We need to match Python's format for test compatibility
-
-    let compact = serde_json::to_string(value).unwrap_or_else(|_| "{}".to_string());
-
-    // Add spaces after colons and commas (but not inside strings)
-    let mut result = String::with_capacity(compact.len() + compact.len() / 4);
-    let mut in_string = false;
-    let mut prev_char = '\0';
-
-    for ch in compact.chars() {
-        if ch == '"' && prev_char != '\\' {
-            in_string = !in_string;
-        }
-
-        result.push(ch);
-
-        // Add space after ':' or ',' if not inside a string
-        if !in_string && (ch == ':' || ch == ',') {
-            result.push(' ');
-        }
-
-        prev_char = ch;
-    }
-
-    result
-}
-
-/// Extract tools from OpenAI format
-fn tools_from_openai_format(tools: &[JsonValue]) -> Vec<JsonValue> {
-    tools
-        .iter()
-        .filter_map(|tool| tool.get("function").cloned())
-        .collect()
-}
-
-/// Render tools section for system prompt
-fn render_tools(tools: &[JsonValue]) -> String {
-    let tools_json: Vec<String> = tools_from_openai_format(tools)
-        .iter()
-        .map(to_json)
-        .collect();
-
-    TOOLS_SYSTEM_TEMPLATE
-        .replace("{tool_schemas}", &tools_json.join("\n"))
-        .replace("{dsml_token}", tokens::DSML_TOKEN)
-        .replace("{thinking_start_token}", tokens::THINKING_START)
-        .replace("{thinking_end_token}", tokens::THINKING_END)
-}
-
-/// Find the last user or developer message index
-fn find_last_user_index(messages: &[JsonValue]) -> Option<usize> {
-    messages
-        .iter()
-        .enumerate()
-        .rev()
-        .find(|(_, msg)| {
-            msg.get("role")
-                .and_then(|r| r.as_str())
-                .map(|r| r == "user" || r == "developer")
-                .unwrap_or(false)
-        })
-        .map(|(idx, _)| idx)
-}
-
-/// Extract visible text from OpenAI-style message content.
-///
-/// Matches common chat-template behavior:
-/// - string content: returned as-is
-/// - array content: concatenates `type=text` parts and raw string items
-/// - other JSON types: serialized to JSON string
-fn extract_visible_text(content: &JsonValue) -> String {
-    match content {
-        JsonValue::String(text) => text.clone(),
-        JsonValue::Array(items) => items
-            .iter()
-            .filter_map(|item| {
-                if let Some(text) = item.as_str() {
-                    return Some(text.to_string());
-                }
-
-                let item_type = item.get("type").and_then(|v| v.as_str());
-                if item_type == Some("text") {
-                    return item
-                        .get("text")
-                        .and_then(|v| v.as_str())
-                        .map(|text| text.to_string());
-                }
-
-                tracing::warn!(
-                    chunk_type = item_type.unwrap_or("unknown"),
-                    "DeepSeek V3.2 formatter dropped non-text content chunk while normalizing message content",
-                );
-
-                None
-            })
-            .collect::<String>(),
-        _ => to_json(content),
-    }
-}
-
-/// Normalize message `content` fields for text-only DeepSeek V3.2 rendering.
-fn normalize_message_contents(messages: &mut [JsonValue]) {
-    for msg in messages {
-        let Some(content) = msg.get("content") else {
-            continue;
-        };
-        let normalized = extract_visible_text(content);
-        if let Some(obj) = msg.as_object_mut() {
-            obj.insert("content".to_string(), JsonValue::String(normalized));
-        }
-    }
-}
-
-/// Encode arguments to DSML parameter format
-fn encode_arguments_to_dsml(tool_call: &JsonValue) -> Result<String> {
-    let arguments_str = tool_call
-        .get("arguments")
-        .and_then(|a| a.as_str())
-        .context("Missing or invalid 'arguments' field")?;
-
-    let arguments: JsonValue =
-        serde_json::from_str(arguments_str).context("Failed to parse arguments JSON")?;
-
-    let arguments_obj = arguments
-        .as_object()
-        .context("Arguments must be an object")?;
-
-    let mut params = Vec::new();
-    for (key, value) in arguments_obj {
-        let is_string = value.is_string();
-        let value_str = if is_string {
-            value.as_str().unwrap().to_string()
-        } else {
-            to_json(value)
-        };
-
-        let param = format!(
-            "<{}parameter name=\"{}\" string=\"{}\">{}</{}parameter>",
-            tokens::DSML_TOKEN,
-            key,
-            if is_string { "true" } else { "false" },
-            value_str,
-            tokens::DSML_TOKEN
-        );
-        params.push(param);
-    }
-
-    Ok(params.join("\n"))
-}
+pub use super::deepseek_common::{ThinkingMode, tokens};
 
 /// Render a single message
 fn render_message(
@@ -263,7 +41,7 @@ fn render_message(
 
             if let Some(tools) = msg.get("tools").and_then(|t| t.as_array()) {
                 prompt.push_str("\n\n");
-                prompt.push_str(&render_tools(tools));
+                prompt.push_str(&render_tools(TOOLS_SYSTEM_TEMPLATE, tools));
             }
 
             if let Some(response_format) = msg.get("response_format") {
@@ -297,7 +75,7 @@ fn render_message(
 
             if let Some(tools) = msg.get("tools").and_then(|t| t.as_array()) {
                 content_developer.push_str("\n\n");
-                content_developer.push_str(&render_tools(tools));
+                content_developer.push_str(&render_tools(TOOLS_SYSTEM_TEMPLATE, tools));
             }
 
             if let Some(response_format) = msg.get("response_format") {
@@ -559,7 +337,7 @@ impl super::OAIPromptFormatter for DeepSeekV32Formatter {
 
         // DeepSeek V3.2 native formatter expects text content in each message.
         // Normalize OpenAI content arrays (e.g. [{type: "text", text: "..."}]) to strings.
-        normalize_message_contents(&mut messages_array);
+        normalize_message_contents(&mut messages_array, NormalizeNonText::SerializeJson);
 
         // Inject tools and response_format from request into the first system message
         // DeepSeek V3.2 expects these to be part of the system message for prompt rendering
@@ -644,19 +422,6 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_visible_text_from_content_array() {
-        let content = json!([
-            {"type": "text", "text": "who "},
-            {"type": "text", "text": "are "},
-            {"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}},
-            {"type": "text", "text": "you?"}
-        ]);
-
-        let result = extract_visible_text(&content);
-        assert_eq!(result, "who are you?");
-    }
-
-    #[test]
     fn test_formatter_handles_user_content_array() {
         use super::super::OAIPromptFormatter;
 
@@ -672,6 +437,20 @@ mod tests {
         assert!(result.contains("who are you?"));
         assert!(result.contains(tokens::USER_START));
         assert!(result.contains(tokens::ASSISTANT_START));
+    }
+
+    #[test]
+    fn test_formatter_serializes_non_text_content() {
+        use super::super::OAIPromptFormatter;
+
+        let request = MockRequest::new(json!([
+            {"role": "user", "content": {"foo": "bar"}}
+        ]));
+
+        let formatter = DeepSeekV32Formatter::new_thinking();
+        let result = formatter.render(&request).unwrap();
+
+        assert!(result.contains(r#"{"foo": "bar"}"#));
     }
 
     #[test]

--- a/lib/llm/src/preprocessor/prompt/deepseek_v4.rs
+++ b/lib/llm/src/preprocessor/prompt/deepseek_v4.rs
@@ -378,29 +378,6 @@ impl DeepSeekV4Formatter {
         );
         true
     }
-
-    fn resolve_thinking_mode(
-        &self,
-        args: Option<&std::collections::HashMap<String, serde_json::Value>>,
-    ) -> ThinkingMode {
-        if let Some(enabled) = super::thinking_bool_from_args(args) {
-            return if enabled {
-                ThinkingMode::Thinking
-            } else {
-                ThinkingMode::Chat
-            };
-        }
-        if let Some(args) = args
-            && let Some(mode) = args.get("thinking_mode").and_then(|v| v.as_str())
-        {
-            match mode {
-                "chat" => return ThinkingMode::Chat,
-                "thinking" => return ThinkingMode::Thinking,
-                _ => {}
-            }
-        }
-        self.thinking_mode
-    }
 }
 
 impl super::OAIPromptFormatter for DeepSeekV4Formatter {
@@ -410,7 +387,7 @@ impl super::OAIPromptFormatter for DeepSeekV4Formatter {
 
     fn render(&self, req: &dyn super::OAIChatLikeRequest) -> Result<String> {
         let args = req.chat_template_args();
-        let thinking_mode = self.resolve_thinking_mode(args);
+        let thinking_mode = super::deepseek_common::resolve_thinking_mode(args, self.thinking_mode);
         let reasoning_effort = Self::resolve_reasoning_effort(args);
         let drop_thinking = Self::resolve_drop_thinking(args);
 
@@ -425,50 +402,7 @@ impl super::OAIPromptFormatter for DeepSeekV4Formatter {
 
         normalize_message_contents(&mut messages_array, NormalizeNonText::LeaveUntouched);
 
-        let tools_json = req
-            .tools()
-            .map(|t| serde_json::to_value(&t))
-            .transpose()
-            .context("Failed to convert tools to JSON")?;
-
-        let response_format_json = req
-            .response_format()
-            .map(|rf| serde_json::to_value(&rf))
-            .transpose()
-            .context("Failed to convert response_format to JSON")?;
-
-        if tools_json.is_some() || response_format_json.is_some() {
-            let system_idx = messages_array
-                .iter()
-                .position(|msg| msg.get("role").and_then(|r| r.as_str()) == Some("system"));
-
-            if let Some(idx) = system_idx {
-                if let Some(msg) = messages_array.get_mut(idx)
-                    && let Some(obj) = msg.as_object_mut()
-                {
-                    if let Some(tools) = tools_json {
-                        obj.insert("tools".to_string(), tools);
-                    }
-                    if let Some(rf) = response_format_json {
-                        obj.insert("response_format".to_string(), rf);
-                    }
-                }
-            } else {
-                let mut system_msg = serde_json::json!({
-                    "role": "system",
-                    "content": ""
-                });
-                if let Some(obj) = system_msg.as_object_mut() {
-                    if let Some(tools) = tools_json {
-                        obj.insert("tools".to_string(), tools);
-                    }
-                    if let Some(rf) = response_format_json {
-                        obj.insert("response_format".to_string(), rf);
-                    }
-                }
-                messages_array.insert(0, system_msg);
-            }
-        }
+        super::deepseek_common::inject_tools_and_response_format(&mut messages_array, req)?;
 
         encode_messages_with_options(
             &messages_array,
@@ -643,15 +577,26 @@ mod tests {
     #[test]
     fn test_resolve_thinking_mode_honors_enable_thinking() {
         use std::collections::HashMap;
-        let f = DeepSeekV4Formatter::new_thinking();
         let mut args = HashMap::new();
         args.insert(
             "enable_thinking".to_string(),
             serde_json::Value::Bool(false),
         );
-        assert_eq!(f.resolve_thinking_mode(Some(&args)), ThinkingMode::Chat);
+        assert_eq!(
+            super::super::deepseek_common::resolve_thinking_mode(
+                Some(&args),
+                ThinkingMode::Thinking
+            ),
+            ThinkingMode::Chat
+        );
         args.insert("enable_thinking".to_string(), serde_json::Value::Bool(true));
-        assert_eq!(f.resolve_thinking_mode(Some(&args)), ThinkingMode::Thinking);
+        assert_eq!(
+            super::super::deepseek_common::resolve_thinking_mode(
+                Some(&args),
+                ThinkingMode::Thinking
+            ),
+            ThinkingMode::Thinking
+        );
     }
 
     struct MockRequest {

--- a/lib/llm/src/preprocessor/prompt/deepseek_v4.rs
+++ b/lib/llm/src/preprocessor/prompt/deepseek_v4.rs
@@ -10,271 +10,13 @@
 use anyhow::{Context, Result};
 use serde_json::Value as JsonValue;
 
-/// Special tokens for DeepSeek V4
-pub mod tokens {
-    pub const BOS: &str = "<｜begin▁of▁sentence｜>";
-    pub const EOS: &str = "<｜end▁of▁sentence｜>";
-    pub const THINKING_START: &str = "<think>";
-    pub const THINKING_END: &str = "</think>";
-    pub const DSML_TOKEN: &str = "｜DSML｜";
-    pub const USER_START: &str = "<｜User｜>";
-    pub const ASSISTANT_START: &str = "<｜Assistant｜>";
-    pub const LATEST_REMINDER: &str = "<｜latest_reminder｜>";
-
-    // Quick-instruction task tokens
-    pub const TASK_ACTION: &str = "<｜action｜>";
-    pub const TASK_QUERY: &str = "<｜query｜>";
-    pub const TASK_AUTHORITY: &str = "<｜authority｜>";
-    pub const TASK_DOMAIN: &str = "<｜domain｜>";
-    pub const TASK_TITLE: &str = "<｜title｜>";
-    pub const TASK_READ_URL: &str = "<｜read_url｜>";
-}
-
-const TOOL_CALLS_BLOCK_NAME: &str = "tool_calls";
-
-const RESPONSE_FORMAT_TEMPLATE: &str =
-    "## Response Format:\n\nYou MUST strictly adhere to the following schema to reply:\n{schema}";
-
-const TOOLS_TEMPLATE: &str = r#"## Tools
-
-You have access to a set of tools to help answer the user's question. You can invoke tools by writing a "<{dsml_token}tool_calls>" block like the following:
-
-<{dsml_token}tool_calls>
-<{dsml_token}invoke name="$TOOL_NAME">
-<{dsml_token}parameter name="$PARAMETER_NAME" string="true|false">$PARAMETER_VALUE</{dsml_token}parameter>
-...
-</{dsml_token}invoke>
-<{dsml_token}invoke name="$TOOL_NAME2">
-...
-</{dsml_token}invoke>
-</{dsml_token}tool_calls>
-
-String parameters should be specified as is and set `string="true"`. For all other types (numbers, booleans, arrays, objects), pass the value in JSON format and set `string="false"`.
-
-If thinking_mode is enabled (triggered by {thinking_start_token}), you MUST output your complete reasoning inside {thinking_start_token}...{thinking_end_token} BEFORE any tool calls or final response.
-
-Otherwise, output directly after {thinking_end_token} with tool calls or final response.
-
-### Available Tool Schemas
-
-{tool_schemas}
-
-You MUST strictly follow the above defined tool name and parameter schemas to invoke tool calls.
-"#;
-
-const REASONING_EFFORT_MAX: &str = "Reasoning Effort: Absolute maximum with no shortcuts permitted.\nYou MUST be very thorough in your thinking and comprehensively decompose the problem to resolve the root cause, rigorously stress-testing your logic against all potential paths, edge cases, and adversarial scenarios.\nExplicitly write out your entire deliberation process, documenting every intermediate step, considered alternative, and rejected hypothesis to ensure absolutely no assumption is left unchecked.\n\n";
-
-/// Thinking mode for the model
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ThinkingMode {
-    Chat,
-    Thinking,
-}
-
-impl ThinkingMode {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            ThinkingMode::Chat => "chat",
-            ThinkingMode::Thinking => "thinking",
-        }
-    }
-}
-
-/// Reasoning effort level. `None` conveyed as `Option<ReasoningEffort>`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ReasoningEffort {
-    Max,
-    High,
-}
-
-/// Serialize a JSON value to match Python's `json.dumps(ensure_ascii=False)` spacing.
-/// Python's default separators are `(', ', ': ')`; we use a custom `Formatter`
-/// so escape sequences inside strings can't confuse state tracking.
-fn to_json(value: &JsonValue) -> String {
-    use serde::Serialize;
-    use serde_json::ser::Formatter;
-    use std::io;
-
-    struct PythonFormatter;
-
-    impl Formatter for PythonFormatter {
-        fn begin_array_value<W: ?Sized + io::Write>(
-            &mut self,
-            writer: &mut W,
-            first: bool,
-        ) -> io::Result<()> {
-            if first {
-                Ok(())
-            } else {
-                writer.write_all(b", ")
-            }
-        }
-
-        fn begin_object_key<W: ?Sized + io::Write>(
-            &mut self,
-            writer: &mut W,
-            first: bool,
-        ) -> io::Result<()> {
-            if first {
-                Ok(())
-            } else {
-                writer.write_all(b", ")
-            }
-        }
-
-        fn begin_object_value<W: ?Sized + io::Write>(&mut self, writer: &mut W) -> io::Result<()> {
-            writer.write_all(b": ")
-        }
-    }
-
-    let mut buf = Vec::with_capacity(64);
-    let mut ser = serde_json::Serializer::with_formatter(&mut buf, PythonFormatter);
-    if let Err(e) = value.serialize(&mut ser) {
-        tracing::warn!(error = %e, "to_json: serialize failed; falling back to empty object");
-        return "{}".to_string();
-    }
-    String::from_utf8(buf).unwrap_or_else(|e| {
-        tracing::warn!(error = %e, "to_json: serialized output not valid UTF-8; falling back to empty object");
-        "{}".to_string()
-    })
-}
-
-/// Extract function definitions from OpenAI-format tool list.
-fn tools_from_openai_format(tools: &[JsonValue]) -> Vec<JsonValue> {
-    tools
-        .iter()
-        .filter_map(|tool| tool.get("function").cloned())
-        .collect()
-}
-
-/// Render tool schemas into the system prompt format.
-fn render_tools(tools: &[JsonValue]) -> String {
-    let tools_json: Vec<String> = tools_from_openai_format(tools)
-        .iter()
-        .map(to_json)
-        .collect();
-
-    TOOLS_TEMPLATE
-        .replace("{tool_schemas}", &tools_json.join("\n"))
-        .replace("{dsml_token}", tokens::DSML_TOKEN)
-        .replace("{thinking_start_token}", tokens::THINKING_START)
-        .replace("{thinking_end_token}", tokens::THINKING_END)
-}
-
-/// Find the index of the last user/developer message.
-///
-/// Returns `None` when no such message exists. Callers should treat `None`
-/// as Python's `-1` sentinel: `idx >= -1` is always true in Python, so use
-/// `Option::is_none_or(|u| idx >= u)` (or `>`) to match the reference encoder.
-fn find_last_user_index(messages: &[JsonValue]) -> Option<usize> {
-    messages
-        .iter()
-        .enumerate()
-        .rev()
-        .find(|(_, msg)| {
-            msg.get("role")
-                .and_then(|r| r.as_str())
-                .map(|r| r == "user" || r == "developer")
-                .unwrap_or(false)
-        })
-        .map(|(idx, _)| idx)
-}
-
-/// Extract visible text from OpenAI-style message content.
-fn extract_visible_text(content: &JsonValue) -> String {
-    match content {
-        JsonValue::String(text) => text.clone(),
-        JsonValue::Array(items) => items
-            .iter()
-            .filter_map(|item| {
-                if let Some(text) = item.as_str() {
-                    return Some(text.to_string());
-                }
-                let item_type = item.get("type").and_then(|v| v.as_str());
-                if item_type == Some("text") {
-                    return item
-                        .get("text")
-                        .and_then(|v| v.as_str())
-                        .map(|text| text.to_string());
-                }
-                tracing::warn!(
-                    chunk_type = item_type.unwrap_or("unknown"),
-                    "DeepSeek V4 formatter dropped non-text content chunk while normalizing message content",
-                );
-                None
-            })
-            .collect::<String>(),
-        _ => to_json(content),
-    }
-}
-
-/// Normalize message `content` fields for text-only DeepSeek V4 rendering.
-fn normalize_message_contents(messages: &mut [JsonValue]) {
-    for msg in messages {
-        let Some(content) = msg.get("content") else {
-            continue;
-        };
-        // Leave non-string/non-array content untouched (null, etc.)
-        if !content.is_string() && !content.is_array() {
-            continue;
-        }
-        let normalized = extract_visible_text(content);
-        if let Some(obj) = msg.as_object_mut() {
-            obj.insert("content".to_string(), JsonValue::String(normalized));
-        }
-    }
-}
-
-/// Encode tool call arguments into DSML parameter format.
-fn encode_arguments_to_dsml(tool_call: &JsonValue) -> Result<String> {
-    let arguments_str = tool_call
-        .get("arguments")
-        .and_then(|a| a.as_str())
-        .context("Missing or invalid 'arguments' field")?;
-
-    // Python falls back to `{"arguments": raw_string}` on parse failure.
-    let arguments: JsonValue = match serde_json::from_str(arguments_str) {
-        Ok(v) => v,
-        Err(_) => serde_json::json!({ "arguments": arguments_str }),
-    };
-
-    let arguments_obj = arguments
-        .as_object()
-        .context("Arguments must be a JSON object")?;
-
-    let mut params = Vec::new();
-    for (key, value) in arguments_obj {
-        let is_string = value.is_string();
-        let value_str = if is_string {
-            value.as_str().unwrap().to_string()
-        } else {
-            to_json(value)
-        };
-        params.push(format!(
-            "<{}parameter name=\"{}\" string=\"{}\">{}</{}parameter>",
-            tokens::DSML_TOKEN,
-            key,
-            if is_string { "true" } else { "false" },
-            value_str,
-            tokens::DSML_TOKEN
-        ));
-    }
-
-    Ok(params.join("\n"))
-}
-
-/// Lookup the task token for a quick-instruction task.
-fn task_token(task: &str) -> Option<&'static str> {
-    match task {
-        "action" => Some(tokens::TASK_ACTION),
-        "query" => Some(tokens::TASK_QUERY),
-        "authority" => Some(tokens::TASK_AUTHORITY),
-        "domain" => Some(tokens::TASK_DOMAIN),
-        "title" => Some(tokens::TASK_TITLE),
-        "read_url" => Some(tokens::TASK_READ_URL),
-        _ => None,
-    }
-}
+use super::deepseek_common::{
+    NormalizeNonText, REASONING_EFFORT_MAX, RESPONSE_FORMAT_TEMPLATE, TOOL_CALLS_BLOCK_NAME,
+    TOOLS_TEMPLATE, drop_thinking_messages, encode_arguments_to_dsml, find_last_user_index,
+    merge_tool_messages, normalize_message_contents, render_tools, sort_tool_results_by_call_order,
+    task_token, to_json,
+};
+pub use super::deepseek_common::{ReasoningEffort, ThinkingMode, tokens};
 
 /// Render a single message at the given index.
 fn render_message(
@@ -308,7 +50,7 @@ fn render_message(
             prompt.push_str(content);
             if let Some(tools) = msg.get("tools").and_then(|t| t.as_array()) {
                 prompt.push_str("\n\n");
-                prompt.push_str(&render_tools(tools));
+                prompt.push_str(&render_tools(TOOLS_TEMPLATE, tools));
             }
             if let Some(response_format) = msg.get("response_format") {
                 prompt.push_str("\n\n");
@@ -330,7 +72,7 @@ fn render_message(
 
             if let Some(tools) = msg.get("tools").and_then(|t| t.as_array()) {
                 content_developer.push_str("\n\n");
-                content_developer.push_str(&render_tools(tools));
+                content_developer.push_str(&render_tools(TOOLS_TEMPLATE, tools));
             }
             if let Some(response_format) = msg.get("response_format") {
                 content_developer.push_str("\n\n");
@@ -515,182 +257,6 @@ fn render_tool_result_content(content: &JsonValue) -> String {
     }
 }
 
-/// Merge `tool` role messages into preceding user `content_blocks` and collapse
-/// consecutive user turns, matching Python's `merge_tool_messages`.
-pub fn merge_tool_messages(messages: &[JsonValue]) -> Vec<JsonValue> {
-    let mut merged: Vec<JsonValue> = Vec::with_capacity(messages.len());
-
-    for msg in messages {
-        let msg = msg.clone();
-        let role = msg.get("role").and_then(|r| r.as_str()).unwrap_or("");
-
-        if role == "tool" {
-            let tool_block = serde_json::json!({
-                "type": "tool_result",
-                "tool_use_id": msg.get("tool_call_id").cloned().unwrap_or(JsonValue::String(String::new())),
-                "content": msg.get("content").cloned().unwrap_or(JsonValue::String(String::new())),
-            });
-
-            let can_merge = merged
-                .last()
-                .map(|m| {
-                    m.get("role").and_then(|r| r.as_str()) == Some("user")
-                        && m.get("content_blocks").is_some()
-                })
-                .unwrap_or(false);
-
-            if can_merge {
-                let last = merged.last_mut().unwrap();
-                if let Some(blocks) = last
-                    .as_object_mut()
-                    .and_then(|o| o.get_mut("content_blocks"))
-                    .and_then(|v| v.as_array_mut())
-                {
-                    blocks.push(tool_block);
-                }
-            } else {
-                merged.push(serde_json::json!({
-                    "role": "user",
-                    "content_blocks": [tool_block],
-                }));
-            }
-        } else if role == "user" {
-            let text = msg
-                .get("content")
-                .and_then(|c| c.as_str())
-                .unwrap_or("")
-                .to_string();
-            let text_block = serde_json::json!({ "type": "text", "text": text });
-
-            let can_merge = merged
-                .last()
-                .map(|m| {
-                    m.get("role").and_then(|r| r.as_str()) == Some("user")
-                        && m.get("content_blocks").is_some()
-                        && m.get("task").map(|v| v.is_null()).unwrap_or(true)
-                })
-                .unwrap_or(false);
-
-            if can_merge {
-                let last = merged.last_mut().unwrap();
-                if let Some(blocks) = last
-                    .as_object_mut()
-                    .and_then(|o| o.get_mut("content_blocks"))
-                    .and_then(|v| v.as_array_mut())
-                {
-                    blocks.push(text_block);
-                }
-            } else {
-                let mut new_msg = serde_json::json!({
-                    "role": "user",
-                    "content": text,
-                    "content_blocks": [text_block],
-                });
-                // Preserve extra fields.
-                if let Some(obj) = new_msg.as_object_mut() {
-                    for key in ["task", "wo_eos", "mask"] {
-                        if let Some(v) = msg.get(key) {
-                            obj.insert(key.to_string(), v.clone());
-                        }
-                    }
-                }
-                merged.push(new_msg);
-            }
-        } else {
-            merged.push(msg);
-        }
-    }
-
-    merged
-}
-
-/// Sort `tool_result` blocks within user messages by the `tool_calls[].id` order
-/// of the preceding assistant message.
-pub fn sort_tool_results_by_call_order(mut messages: Vec<JsonValue>) -> Vec<JsonValue> {
-    use std::collections::HashMap;
-    let mut last_order: HashMap<String, usize> = HashMap::new();
-
-    for msg in &mut messages {
-        let role = msg.get("role").and_then(|r| r.as_str()).unwrap_or("");
-        if role == "assistant" {
-            if let Some(tcs) = msg.get("tool_calls").and_then(|t| t.as_array()) {
-                last_order.clear();
-                for (idx, tc) in tcs.iter().enumerate() {
-                    let id = tc
-                        .get("id")
-                        .and_then(|v| v.as_str())
-                        .or_else(|| {
-                            tc.get("function")
-                                .and_then(|f| f.get("id"))
-                                .and_then(|v| v.as_str())
-                        })
-                        .unwrap_or("");
-                    if !id.is_empty() {
-                        last_order.insert(id.to_string(), idx);
-                    }
-                }
-            }
-        } else if role == "user" && !last_order.is_empty() {
-            let Some(blocks) = msg
-                .as_object_mut()
-                .and_then(|o| o.get_mut("content_blocks"))
-                .and_then(|v| v.as_array_mut())
-            else {
-                continue;
-            };
-
-            // Collect tool_result blocks with their positions.
-            let tool_positions: Vec<usize> = blocks
-                .iter()
-                .enumerate()
-                .filter(|(_, b)| b.get("type").and_then(|v| v.as_str()) == Some("tool_result"))
-                .map(|(i, _)| i)
-                .collect();
-
-            if tool_positions.len() > 1 {
-                let mut tool_blocks: Vec<JsonValue> =
-                    tool_positions.iter().map(|&i| blocks[i].clone()).collect();
-                tool_blocks.sort_by_key(|b| {
-                    let id = b.get("tool_use_id").and_then(|v| v.as_str()).unwrap_or("");
-                    *last_order.get(id).unwrap_or(&0)
-                });
-                for (sorted_idx, &pos) in tool_positions.iter().enumerate() {
-                    blocks[pos] = tool_blocks[sorted_idx].clone();
-                }
-            }
-        }
-    }
-
-    messages
-}
-
-/// Drop reasoning and non-essential messages before the last user message.
-fn drop_thinking_messages(messages: Vec<JsonValue>) -> Vec<JsonValue> {
-    let last_user_idx = find_last_user_index(&messages);
-    let mut out = Vec::with_capacity(messages.len());
-    const KEEP: &[&str] = &[
-        "user",
-        "system",
-        "tool",
-        "latest_reminder",
-        "direct_search_results",
-    ];
-
-    for (idx, mut msg) in messages.into_iter().enumerate() {
-        let role = msg.get("role").and_then(|r| r.as_str()).unwrap_or("");
-        if KEEP.contains(&role) || last_user_idx.is_none_or(|u| idx >= u) {
-            out.push(msg);
-        } else if role == "assistant" {
-            if let Some(obj) = msg.as_object_mut() {
-                obj.remove("reasoning_content");
-            }
-            out.push(msg);
-        }
-        // developer and other roles before last_user_idx are dropped.
-    }
-    out
-}
-
 /// Encode messages to prompt string with default options.
 ///
 /// Equivalent to `encode_messages_with_options(.., drop_thinking=true, reasoning_effort=None)`.
@@ -857,7 +423,7 @@ impl super::OAIPromptFormatter for DeepSeekV4Formatter {
             .context("Messages is not an array")?
             .clone();
 
-        normalize_message_contents(&mut messages_array);
+        normalize_message_contents(&mut messages_array, NormalizeNonText::LeaveUntouched);
 
         let tools_json = req
             .tools()
@@ -1128,6 +694,29 @@ mod tests {
         ) -> Option<&std::collections::HashMap<String, serde_json::Value>> {
             self.chat_template_args.as_ref()
         }
+    }
+
+    #[test]
+    fn test_render_leaves_null_assistant_tool_content_empty() {
+        use super::super::OAIPromptFormatter;
+
+        let req = MockRequest::new(json!([
+            {"role": "user", "content": "call tool"},
+            {"role": "assistant", "content": null, "tool_calls": [{
+                "id": "c1", "type": "function",
+                "function": {"name": "f", "arguments": "{}"}
+            }]}
+        ]));
+
+        let formatter = DeepSeekV4Formatter::new_chat();
+        let out = formatter.render(&req).unwrap();
+
+        assert!(out.contains(&format!(
+            "<{}{}>",
+            tokens::DSML_TOKEN,
+            TOOL_CALLS_BLOCK_NAME
+        )));
+        assert!(!out.contains("null"));
     }
 
     #[test]

--- a/lib/llm/src/preprocessor/prompt/deepseek_v4.rs
+++ b/lib/llm/src/preprocessor/prompt/deepseek_v4.rs
@@ -495,6 +495,32 @@ mod tests {
     }
 
     #[test]
+    fn test_user_task_preserved_when_merged_after_tool_result() {
+        let messages = json!([
+            {"role": "assistant", "content": "", "tool_calls": [{
+                "id": "c1", "type": "function",
+                "function": {"name": "search", "arguments": "{}"}
+            }]},
+            {"role": "tool", "tool_call_id": "c1", "content": "RESULT"},
+            {"role": "user", "content": "Search", "task": "action"},
+            {"role": "assistant", "content": "OK"}
+        ]);
+
+        let out = encode_messages(messages.as_array().unwrap(), ThinkingMode::Chat, true).unwrap();
+        assert!(
+            out.contains(&format!(
+                "{}Search{}{}{}OK",
+                "<tool_result>RESULT</tool_result>\n\n",
+                tokens::ASSISTANT_START,
+                tokens::THINKING_END,
+                tokens::TASK_ACTION
+            )),
+            "expected merged user text to keep the action task transition, got:\n{}",
+            out
+        );
+    }
+
+    #[test]
     fn test_drop_thinking_auto_disable_when_tools_present() {
         let messages = json!([
             {"role": "system", "content": "s", "tools": [{


### PR DESCRIPTION
Make a deepseek_common module that is the superset of both versions. Everything that can live in the common module lives there, including items currently used by only one version. Only items that cannot be unified, maily the two public formatter structs and their version-specific render_message / encode_messages pipelines, stay in the per-version files.

This keeps the per-version files quite small. Most of the code ends up in _common, and most of that is shared.

Implements the plan from #9317. All the details are there.
Closes: #9317

The code saving is larger than the diff implies because of new tests.

Assisted-By: Claude Opus 4.7 (plan)
Assisted-By: Codex GPT 5.5 (implementation)
Assisted-By: Gemini 3.1 Pro (review and optimization)

Reviews please note the following not backwards compatible changes (users should not notice):
- DeepSeek v3.2 had a bug on backslash escape handling. That is fixed so [relevant XKCD](https://xkcd.com/1172/).
- DeepSeek v3.2 is now more lenient on tool call function `arguments` field that is not JSON. This matches both v4 and the upstream Python, so I believe it is more correct.
- DeepSeek v4 now has a security fix where the a tool definition cannot change prevent the thinking start/stop tokens from being included.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9322" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Consolidated DeepSeek prompt-handling logic to improve consistency across model versions.
  * Enhanced message content normalization and tool call argument processing for more reliable DeepSeek model support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->