### PR TITLE
feat: add LMCache transfer signal collection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,6 +11,8 @@
 *.fatbin            binary
 *.mp4               binary
 
+container/deps/lmcache/*.patch -whitespace
+
 # Exclude test data files from linguist language detection
 lib/llm/tests/data/** linguist-vendored
 lib/llm/tests/snapshots/** linguist-vendored

--- a/components/src/dynamo/router/__main__.py
+++ b/components/src/dynamo/router/__main__.py
@@ -134,6 +134,7 @@ class StandaloneRouterHandler:
                 "disaggregated_params": worker_output.get("disaggregated_params"),  # type: ignore[attr-defined]
                 "extra_args": worker_output.get("extra_args"),  # type: ignore[attr-defined]
                 "completion_usage": worker_output.get("completion_usage"),  # type: ignore[attr-defined]
+                "engine_data": worker_output.get("engine_data"),  # type: ignore[attr-defined]
             }
             yield llm_engine_output
 

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -1850,6 +1850,40 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         }
 
     @staticmethod
+    def _build_engine_data_from_kv_transfer_params(
+        kv_transfer_params,
+    ) -> Dict[str, Any] | None:
+        if not isinstance(kv_transfer_params, dict):
+            return None
+
+        stats = kv_transfer_params.get("lmcache_transfer_stats")
+        if not isinstance(stats, dict):
+            return None
+
+        engine_data: Dict[str, Any] = {
+            "lmcache_transfer_stats": stats,
+        }
+
+        total = stats.get("total")
+        if isinstance(total, dict):
+            engine_data["kv_transfer_tokens"] = total.get("transferred_tokens", 0)
+            engine_data["kv_transfer_bytes"] = total.get("transferred_bytes", 0)
+            if not stats.get("estimated", False):
+                engine_data["kv_transfer_time_ms"] = total.get("time_ms", 0.0)
+                engine_data["kv_transfer_speed_gb_s"] = total.get("speed_gb_s", 0.0)
+
+        for key in (
+            "kv_transfer_tokens",
+            "kv_transfer_bytes",
+            "kv_transfer_time_ms",
+            "kv_transfer_speed_gb_s",
+        ):
+            if key in kv_transfer_params:
+                engine_data[key] = kv_transfer_params[key]
+
+        return engine_data
+
+    @staticmethod
     def _extract_logprobs(
         output, num_output_tokens_so_far: int, tokenizer=None
     ) -> tuple[list[float] | None, list[list[dict]] | None]:
@@ -2026,6 +2060,13 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                             request_output=res,
                             embedding_sequence_length=embedding_sequence_length,
                         )
+                        engine_data = (
+                            BaseWorkerHandler._build_engine_data_from_kv_transfer_params(
+                                getattr(res, "kv_transfer_params", None)
+                            )
+                        )
+                        if engine_data is not None:
+                            out["engine_data"] = engine_data
                         # Log completion with LoRA info (debug level to avoid log spam)
                         self._log_with_lora_context(
                             "Completed token generation for request {request_id}{lora_info}: "
@@ -2551,6 +2592,11 @@ class PrefillWorkerHandler(BaseWorkerHandler):
                         embedding_sequence_length=embedding_sequence_length,
                     ),
                 }
+                engine_data = BaseWorkerHandler._build_engine_data_from_kv_transfer_params(
+                    res.kv_transfer_params
+                )
+                if engine_data is not None:
+                    output["engine_data"] = engine_data
 
                 # Log prefill completion with LoRA info
                 self._log_with_lora_context(

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
@@ -35,6 +35,33 @@ pytestmark = [
 # ── Helpers ──────────────────────────────────────────────────────────
 
 
+def test_build_engine_data_from_lmcache_transfer_stats():
+    params = {
+        "lmcache_transfer_stats": {
+            "connector": "lmcache",
+            "estimated": False,
+            "total": {
+                "transferred_tokens": 128,
+                "transferred_bytes": 4096,
+                "time_ms": 12.5,
+                "speed_gb_s": 0.3,
+            },
+        },
+        "kv_transfer_bytes": 4096,
+    }
+
+    engine_data = mod.BaseWorkerHandler._build_engine_data_from_kv_transfer_params(
+        params
+    )
+
+    assert engine_data is not None
+    assert engine_data["kv_transfer_tokens"] == 128
+    assert engine_data["kv_transfer_bytes"] == 4096
+    assert engine_data["kv_transfer_time_ms"] == 12.5
+    assert engine_data["kv_transfer_speed_gb_s"] == 0.3
+    assert engine_data["lmcache_transfer_stats"]["connector"] == "lmcache"
+
+
 def _make_config(
     model: str = "test-model",
     is_prefill_worker: bool = False,

--- a/container/deps/lmcache/README.md
+++ b/container/deps/lmcache/README.md
@@ -1,0 +1,8 @@
+Place an optional LMCache patch at:
+
+    container/deps/lmcache/local.patch
+
+The vLLM container build applies this patch after cloning LMCache and before
+building/installing LMCache from source. Pass a changing `LMCACHE_PATCH_SHA`
+build arg when the patch changes so Docker does not reuse the cached framework
+install layer.

--- a/container/deps/lmcache/local.patch
+++ b/container/deps/lmcache/local.patch
@@ -1,0 +1,576 @@
+diff --git a/lmcache/integration/vllm/vllm_v1_adapter.py b/lmcache/integration/vllm/vllm_v1_adapter.py
+index ecb7af86..048bb656 100644
+--- a/lmcache/integration/vllm/vllm_v1_adapter.py
++++ b/lmcache/integration/vllm/vllm_v1_adapter.py
+@@ -31,6 +31,7 @@ from lmcache.integration.vllm.utils import (
+     ENGINE_NAME,
+     apply_mm_hashes_to_token_ids,
+     extract_mm_features,
++    get_size_bytes,
+     lmcache_get_or_create_config,
+ )
+ from lmcache.integration.vllm.vllm_service_factory import VllmServiceFactory
+@@ -140,6 +141,13 @@ class RequestTracker:
+     # The number of tokens that are cached in LMCache for this request
+     num_lmcache_cached_tokens: int = 0
+ 
++    # Request-level transfer accounting. These are scheduler-side estimates
++    # used when worker-side timing stats are not visible in this process.
++    num_lmcache_retrieved_tokens: int = 0
++    num_lmcache_retrieved_bytes: int = 0
++    num_lmcache_stored_tokens: int = 0
++    num_lmcache_stored_bytes: int = 0
++
+     @_lmcache_nvtx_annotate
+     @staticmethod
+     def from_new_request(
+@@ -698,6 +706,141 @@ class LMCacheConnectorV1Impl:
+         """
+         return VLLM_VERSION
+ 
++    def _estimate_kv_bytes(self, num_tokens: int) -> int:
++        """Estimate KV payload bytes for ``num_tokens`` across all layers."""
++        if num_tokens <= 0:
++            return 0
++
++        metadata = self.lmcache_engine_metadata
++        if metadata is None:
++            return 0
++
++        try:
++            return get_size_bytes(
++                metadata.get_shapes(num_tokens),
++                metadata.get_dtypes(),
++            )
++        except Exception:
++            logger.exception(
++                "Failed to estimate LMCache KV bytes for %d tokens", num_tokens
++            )
++            return 0
++
++    def _record_planned_transfer_stats(
++        self,
++        tracker: RequestTracker,
++        req_meta: ReqMeta,
++    ) -> None:
++        load_spec = req_meta.load_spec
++        if load_spec is not None and load_spec.can_load:
++            masked_token_count = (
++                load_spec.vllm_cached_tokens
++                // self._lmcache_chunk_size
++                * self._lmcache_chunk_size
++            )
++            retrieved_tokens = max(
++                load_spec.lmcache_cached_tokens - masked_token_count,
++                0,
++            )
++            tracker.num_lmcache_retrieved_tokens += retrieved_tokens
++            tracker.num_lmcache_retrieved_bytes += self._estimate_kv_bytes(
++                retrieved_tokens
++            )
++
++        save_spec = req_meta.save_spec
++        can_save = (
++            save_spec is not None and save_spec.can_save
++        ) or self.kv_role == "kv_producer"
++        if can_save:
++            skip_leading_tokens = 0
++            if self.kv_role != "kv_producer":
++                assert save_spec is not None
++                skip_leading_tokens = (
++                    save_spec.skip_leading_tokens
++                    // self._lmcache_chunk_size
++                    * self._lmcache_chunk_size
++                )
++            stored_tokens = max(len(req_meta.token_ids) - skip_leading_tokens, 0)
++            tracker.num_lmcache_stored_tokens += stored_tokens
++            tracker.num_lmcache_stored_bytes += self._estimate_kv_bytes(stored_tokens)
++
++    @staticmethod
++    def _empty_direction_transfer_stats() -> dict[str, Union[int, float]]:
++        return {
++            "requests": 0,
++            "requested_tokens": 0,
++            "transferred_tokens": 0,
++            "transferred_bytes": 0,
++            "time_ms": 0.0,
++            "speed_gb_s": 0.0,
++        }
++
++    def _estimated_transfer_stats_to_dict(
++        self,
++        tracker: RequestTracker,
++    ) -> Optional[dict[str, Any]]:
++        retrieve_tokens = tracker.num_lmcache_retrieved_tokens
++        store_tokens = tracker.num_lmcache_stored_tokens
++        retrieve_bytes = tracker.num_lmcache_retrieved_bytes
++        store_bytes = tracker.num_lmcache_stored_bytes
++
++        if retrieve_tokens == 0 and store_tokens == 0 and retrieve_bytes == 0:
++            return None
++
++        retrieve = self._empty_direction_transfer_stats()
++        retrieve.update(
++            {
++                "requests": 1 if retrieve_tokens > 0 else 0,
++                "requested_tokens": retrieve_tokens,
++                "transferred_tokens": retrieve_tokens,
++                "transferred_bytes": retrieve_bytes,
++            }
++        )
++
++        store = self._empty_direction_transfer_stats()
++        store.update(
++            {
++                "requests": 1 if store_tokens > 0 else 0,
++                "requested_tokens": store_tokens,
++                "transferred_tokens": store_tokens,
++                "transferred_bytes": store_bytes,
++            }
++        )
++
++        total = self._empty_direction_transfer_stats()
++        total.update(
++            {
++                "requests": int(retrieve["requests"]) + int(store["requests"]),
++                "requested_tokens": retrieve_tokens + store_tokens,
++                "transferred_tokens": retrieve_tokens + store_tokens,
++                "transferred_bytes": retrieve_bytes + store_bytes,
++            }
++        )
++
++        return {
++            "connector": "lmcache",
++            "estimated": True,
++            "retrieve": retrieve,
++            "store": store,
++            "total": total,
++        }
++
++    def _get_transfer_stats_for_response(
++        self,
++        request_id: str,
++        tracker: Optional[RequestTracker],
++    ) -> Optional[dict[str, Any]]:
++        actual_stats = self._stats_monitor.pop_request_transfer_stats(request_id)
++        if actual_stats is not None:
++            actual_stats["connector"] = "lmcache"
++            actual_stats["estimated"] = False
++            return actual_stats
++
++        if tracker is None:
++            return None
++
++        return self._estimated_transfer_stats_to_dict(tracker)
++
+     # TODO(chunxiaozheng): in the latest lmcache_connector, we use `register_kv_caches`
+     #  to init self.kv_caches, we keep it in order to be compatible with old versions
+     #  and will be removed in the future.
+@@ -1578,6 +1721,7 @@ class LMCacheConnectorV1Impl:
+                 save_decode_cache=self.config.save_decode_cache,
+             )
+             if req_meta is not None:
++                self._record_planned_transfer_stats(request_tracker, req_meta)
+                 meta.add_request(req_meta)
+ 
+         cached_reqs = scheduler_output.scheduled_cached_reqs
+@@ -1624,6 +1768,7 @@ class LMCacheConnectorV1Impl:
+                     save_decode_cache=self.config.save_decode_cache,
+                 )
+                 if req_meta is not None:
++                    self._record_planned_transfer_stats(request_tracker, req_meta)
+                     meta.add_request(req_meta)
+             return meta
+ 
+@@ -1747,6 +1892,7 @@ class LMCacheConnectorV1Impl:
+                 save_decode_cache=self.config.save_decode_cache,
+             )
+             if req_meta is not None:
++                self._record_planned_transfer_stats(request_tracker, req_meta)
+                 meta.add_request(req_meta)
+ 
+         return meta
+@@ -1786,10 +1932,35 @@ class LMCacheConnectorV1Impl:
+                 "first_tok": request._output_token_ids[0],
+             }
+ 
++        request_tracker = self._request_trackers.get(request.request_id)
++
++        transfer_stats = self._get_transfer_stats_for_response(
++            request.request_id,
++            request_tracker,
++        )
++        if transfer_stats is not None:
++            return_params = return_params or {}
++            return_params["lmcache_transfer_stats"] = transfer_stats
++
++            total_stats = transfer_stats.get("total", {})
++            if isinstance(total_stats, dict):
++                return_params["kv_transfer_tokens"] = total_stats.get(
++                    "transferred_tokens", 0
++                )
++                return_params["kv_transfer_bytes"] = total_stats.get(
++                    "transferred_bytes", 0
++                )
++                if not transfer_stats.get("estimated", False):
++                    return_params["kv_transfer_time_ms"] = total_stats.get(
++                        "time_ms", 0.0
++                    )
++                    return_params["kv_transfer_speed_gb_s"] = total_stats.get(
++                        "speed_gb_s", 0.0
++                    )
++
+         if self.config.get_extra_config_value(
+             "enable_cache_usage_details_in_response", False
+         ):
+-            request_tracker = self._request_trackers.get(request.request_id)
+             if request_tracker:
+                 return_params = return_params or {}
+                 return_params["num_lmcache_cached_tokens"] = (
+diff --git a/lmcache/observability.py b/lmcache/observability.py
+index 8a9a3a15..fd01809c 100644
+--- a/lmcache/observability.py
++++ b/lmcache/observability.py
+@@ -246,6 +246,100 @@ class P2PTransferRequestStats:
+         return self.num_tokens / self.time_to_transfer()
+ 
+ 
++@dataclass
++class RequestTransferStats:
++    retrieve_requests: int = 0
++    retrieve_requested_tokens: int = 0
++    retrieve_transferred_tokens: int = 0
++    retrieve_transferred_bytes: int = 0
++    retrieve_time_ms: float = 0.0
++    store_requests: int = 0
++    store_requested_tokens: int = 0
++    store_transferred_tokens: int = 0
++    store_transferred_bytes: int = 0
++    store_time_ms: float = 0.0
++
++    def add(
++        self,
++        direction: str,
++        requested_tokens: int,
++        transferred_tokens: int,
++        transferred_bytes: int,
++        transfer_time_s: float,
++    ) -> None:
++        requested_tokens = max(int(requested_tokens), 0)
++        transferred_tokens = max(int(transferred_tokens), 0)
++        transferred_bytes = max(int(transferred_bytes), 0)
++        transfer_time_ms = max(float(transfer_time_s), 0.0) * 1000.0
++
++        if direction == "retrieve":
++            self.retrieve_requests += 1
++            self.retrieve_requested_tokens += requested_tokens
++            self.retrieve_transferred_tokens += transferred_tokens
++            self.retrieve_transferred_bytes += transferred_bytes
++            self.retrieve_time_ms += transfer_time_ms
++        elif direction == "store":
++            self.store_requests += 1
++            self.store_requested_tokens += requested_tokens
++            self.store_transferred_tokens += transferred_tokens
++            self.store_transferred_bytes += transferred_bytes
++            self.store_time_ms += transfer_time_ms
++        else:
++            raise ValueError(f"Unsupported transfer direction: {direction}")
++
++    @staticmethod
++    def _speed_gb_s(num_bytes: int, time_ms: float) -> float:
++        if num_bytes <= 0 or time_ms <= 0:
++            return 0.0
++        return num_bytes / (time_ms / 1000.0) / 1024**3
++
++    def to_dict(self) -> Dict[str, Any]:
++        total_requests = self.retrieve_requests + self.store_requests
++        total_requested_tokens = (
++            self.retrieve_requested_tokens + self.store_requested_tokens
++        )
++        total_transferred_tokens = (
++            self.retrieve_transferred_tokens + self.store_transferred_tokens
++        )
++        total_transferred_bytes = (
++            self.retrieve_transferred_bytes + self.store_transferred_bytes
++        )
++        total_time_ms = self.retrieve_time_ms + self.store_time_ms
++
++        return {
++            "retrieve": {
++                "requests": self.retrieve_requests,
++                "requested_tokens": self.retrieve_requested_tokens,
++                "transferred_tokens": self.retrieve_transferred_tokens,
++                "transferred_bytes": self.retrieve_transferred_bytes,
++                "time_ms": self.retrieve_time_ms,
++                "speed_gb_s": self._speed_gb_s(
++                    self.retrieve_transferred_bytes, self.retrieve_time_ms
++                ),
++            },
++            "store": {
++                "requests": self.store_requests,
++                "requested_tokens": self.store_requested_tokens,
++                "transferred_tokens": self.store_transferred_tokens,
++                "transferred_bytes": self.store_transferred_bytes,
++                "time_ms": self.store_time_ms,
++                "speed_gb_s": self._speed_gb_s(
++                    self.store_transferred_bytes, self.store_time_ms
++                ),
++            },
++            "total": {
++                "requests": total_requests,
++                "requested_tokens": total_requested_tokens,
++                "transferred_tokens": total_transferred_tokens,
++                "transferred_bytes": total_transferred_bytes,
++                "time_ms": total_time_ms,
++                "speed_gb_s": self._speed_gb_s(
++                    total_transferred_bytes, total_time_ms
++                ),
++            },
++        }
++
++
+ class LMCStatsMonitor:
+     def __init__(self):
+         # Interval metrics that will be reset after each log
+@@ -305,6 +399,7 @@ class LMCStatsMonitor:
+         self.retrieve_requests: Dict[int, RetrieveRequestStats] = {}
+         self.store_requests: Dict[int, StoreRequestStats] = {}
+         self.lookup_requests: Dict[int, LookupRequestStats] = {}
++        self.request_transfer_stats: Dict[str, RequestTransferStats] = {}
+ 
+         self.retrieve_request_id = 0
+         self.store_request_id = 0
+@@ -506,6 +601,40 @@ class LMCStatsMonitor:
+         self.interval_p2p_transferred_tokens += p2p_stats.num_tokens
+         p2p_stats.end_time = curr_time
+ 
++    @thread_safe
++    def record_request_transfer_stats(
++        self,
++        req_id: Optional[str],
++        direction: str,
++        requested_tokens: int,
++        transferred_tokens: int,
++        transferred_bytes: int,
++        transfer_time_s: float,
++    ) -> None:
++        if req_id is None:
++            return
++
++        stats = self.request_transfer_stats.setdefault(
++            req_id, RequestTransferStats()
++        )
++        stats.add(
++            direction,
++            requested_tokens,
++            transferred_tokens,
++            transferred_bytes,
++            transfer_time_s,
++        )
++
++    @thread_safe
++    def pop_request_transfer_stats(
++        self,
++        req_id: str,
++    ) -> Optional[Dict[str, Any]]:
++        stats = self.request_transfer_stats.pop(req_id, None)
++        if stats is None:
++            return None
++        return stats.to_dict()
++
+     @thread_safe
+     def on_chunk_reuse(self, time_interval: float):
+         """
+diff --git a/lmcache/v1/cache_engine.py b/lmcache/v1/cache_engine.py
+index 6fb2733e..33aefb56 100644
+--- a/lmcache/v1/cache_engine.py
++++ b/lmcache/v1/cache_engine.py
+@@ -261,6 +261,45 @@ class LMCacheEngine:
+         """Extracts request ID from kwargs for logging."""
+         return kwargs.get("req_id", "unspecified")
+ 
++    def _log_connector_transfer_complete(
++        self,
++        direction: str,
++        transferred_tokens: int,
++        staging_time_s: float,
++        xfer_time_s: float,
++        total_time_s: float,
++    ) -> None:
++        if transferred_tokens <= 0:
++            return
++
++        blocks = (
++            transferred_tokens + self.config.chunk_size - 1
++        ) // self.config.chunk_size
++        staging_us = max(int(staging_time_s * 1_000_000), 0)
++        xfer_us = max(int(xfer_time_s * 1_000_000), 0)
++        total_us = max(int(total_time_s * 1_000_000), 0)
++
++        if xfer_us == 0 and total_us > staging_us:
++            xfer_us = total_us - staging_us
++
++        if direction == "store":
++            src = "lmcache::G2"
++            dst = "lmcache::G1"
++        else:
++            src = "lmcache::G1"
++            dst = "lmcache::G2"
++
++        logger.info(
++            'Onboard transfer complete blocks=%d staging_us=%d xfer_us=%d '
++            'total_us=%d src="%s" dst="%s"',
++            blocks,
++            staging_us,
++            xfer_us,
++            total_us,
++            src,
++            dst,
++        )
++
+     def mark_init_failed(self, reason: str = "") -> None:
+         """
+         Mark the engine as having failed initialization.
+@@ -548,6 +587,21 @@ class LMCacheEngine:
+             tot_token_num,
+         )
+         tot_time = store_stats.time_to_store()
++        self.stats_monitor.record_request_transfer_stats(
++            kwargs.get("req_id"),
++            "store",
++            num_to_store_tokens,
++            tot_token_num,
++            tot_kv_size,
++            tot_time,
++        )
++        self._log_connector_transfer_complete(
++            "store",
++            tot_token_num,
++            store_stats.process_tokens_time,
++            store_stats.from_gpu_time + store_stats.put_time,
++            tot_time,
++        )
+ 
+         logger.info(
+             "[req_id=%s] Stored %d out of total %d tokens. "
+@@ -740,6 +794,21 @@ class LMCacheEngine:
+                 tot_time * 1000,
+                 tot_kv_size / tot_time / 1024**3 if tot_time > 0 else 0,
+             )
++            self.stats_monitor.record_request_transfer_stats(
++                kwargs.get("req_id"),
++                "store",
++                num_to_store_tokens,
++                tot_token_num,
++                tot_kv_size,
++                tot_time,
++            )
++            self._log_connector_transfer_complete(
++                "store",
++                tot_token_num,
++                0.0,
++                tot_time,
++                tot_time,
++            )
+         else:
+             # If no cache are found, we still need to yield to avoid
+             # `StopIteration`
+@@ -870,6 +939,21 @@ class LMCacheEngine:
+             retrieved_tokens,
+         )
+         onload_time = retrieve_stats.time_to_retrieve()
++        self.stats_monitor.record_request_transfer_stats(
++            kwargs.get("req_id"),
++            "retrieve",
++            num_required_tokens,
++            int(retrieved_tokens.item()),
++            tot_kv_size,
++            onload_time,
++        )
++        self._log_connector_transfer_complete(
++            "retrieve",
++            int(retrieved_tokens.item()),
++            retrieve_stats.process_tokens_time,
++            retrieve_stats.broadcast_time + retrieve_stats.to_gpu_time,
++            onload_time,
++        )
+         # The retrieved may be larger than the need_to_load
+         # Example (page_size=16, chunk_size=256):
+         #
+@@ -1043,6 +1127,30 @@ class LMCacheEngine:
+ 
+         retrieved_tokens = torch.sum(ret_mask)
+         self.stats_monitor.on_retrieve_finished(monitor_req_id, retrieved_tokens)
++        retrieved_token_count = int(retrieved_tokens.item())
++        retrieved_bytes = sum(
++            shape.numel() * dtype.itemsize
++            for shape, dtype in zip(
++                self.metadata.get_shapes(retrieved_token_count),
++                self.metadata.get_dtypes(),
++                strict=True,
++            )
++        )
++        self.stats_monitor.record_request_transfer_stats(
++            kwargs.get("req_id"),
++            "retrieve",
++            num_required_tokens,
++            retrieved_token_count,
++            retrieved_bytes,
++            monitor_req_id.time_to_retrieve(),
++        )
++        self._log_connector_transfer_complete(
++            "retrieve",
++            retrieved_token_count,
++            0.0,
++            monitor_req_id.time_to_retrieve(),
++            monitor_req_id.time_to_retrieve(),
++        )
+         if not self._is_passive():
+             logger.info(
+                 "[req_id=%s] Retrieved %d out of %d out of total %d tokens",
+diff --git a/tests/test_observability.py b/tests/test_observability.py
+index 6f41ae88..889b91b4 100644
+--- a/tests/test_observability.py
++++ b/tests/test_observability.py
+@@ -118,6 +118,41 @@ def test_remote_time_metrics(stats_monitor):
+     assert stats.interval_remote_time_to_get_sync == [12.3]
+ 
+ 
++def test_request_transfer_stats(stats_monitor):
++    stats_monitor.record_request_transfer_stats(
++        req_id="req-1",
++        direction="retrieve",
++        requested_tokens=128,
++        transferred_tokens=96,
++        transferred_bytes=1024,
++        transfer_time_s=0.01,
++    )
++    stats_monitor.record_request_transfer_stats(
++        req_id="req-1",
++        direction="store",
++        requested_tokens=64,
++        transferred_tokens=64,
++        transferred_bytes=2048,
++        transfer_time_s=0.02,
++    )
++
++    stats = stats_monitor.pop_request_transfer_stats("req-1")
++    assert stats is not None
++    assert stats["retrieve"]["requested_tokens"] == 128
++    assert stats["retrieve"]["transferred_tokens"] == 96
++    assert stats["retrieve"]["transferred_bytes"] == 1024
++    assert stats["retrieve"]["time_ms"] == pytest.approx(10.0)
++    assert stats["store"]["requested_tokens"] == 64
++    assert stats["store"]["transferred_tokens"] == 64
++    assert stats["store"]["transferred_bytes"] == 2048
++    assert stats["store"]["time_ms"] == pytest.approx(20.0)
++    assert stats["total"]["requested_tokens"] == 192
++    assert stats["total"]["transferred_tokens"] == 160
++    assert stats["total"]["transferred_bytes"] == 3072
++    assert stats["total"]["time_ms"] == pytest.approx(30.0)
++    assert stats_monitor.pop_request_transfer_stats("req-1") is None
++
++
+ def test_remote_ping_metrics(stats_monitor):
+     # Test successful ping
+     stats_monitor.update_remote_ping_latency(latency=25.5)

--- a/container/deps/lmcache/local.patch
+++ b/container/deps/lmcache/local.patch
@@ -1,5 +1,5 @@
 diff --git a/lmcache/integration/vllm/vllm_v1_adapter.py b/lmcache/integration/vllm/vllm_v1_adapter.py
-index ecb7af86..048bb656 100644
+index 2e369a6..30aa7ba 100644
 --- a/lmcache/integration/vllm/vllm_v1_adapter.py
 +++ b/lmcache/integration/vllm/vllm_v1_adapter.py
 @@ -31,6 +31,7 @@ from lmcache.integration.vllm.utils import (
@@ -10,7 +10,7 @@ index ecb7af86..048bb656 100644
      lmcache_get_or_create_config,
  )
  from lmcache.integration.vllm.vllm_service_factory import VllmServiceFactory
-@@ -140,6 +141,13 @@ class RequestTracker:
+@@ -139,6 +140,13 @@ class RequestTracker:
      # The number of tokens that are cached in LMCache for this request
      num_lmcache_cached_tokens: int = 0
  
@@ -24,7 +24,7 @@ index ecb7af86..048bb656 100644
      @_lmcache_nvtx_annotate
      @staticmethod
      def from_new_request(
-@@ -698,6 +706,141 @@ class LMCacheConnectorV1Impl:
+@@ -697,6 +705,141 @@ class LMCacheConnectorV1Impl:
          """
          return VLLM_VERSION
  
@@ -163,10 +163,10 @@ index ecb7af86..048bb656 100644
 +
 +        return self._estimated_transfer_stats_to_dict(tracker)
 +
-     # TODO(chunxiaozheng): in the latest lmcache_connector, we use `register_kv_caches`
-     #  to init self.kv_caches, we keep it in order to be compatible with old versions
-     #  and will be removed in the future.
-@@ -1578,6 +1721,7 @@ class LMCacheConnectorV1Impl:
+     def _build_kv_layer_groups(self):
+         # Build KV layer groups structure if not already built
+         if self.lmcache_engine is not None:
+@@ -1486,6 +1629,7 @@ class LMCacheConnectorV1Impl:
                  save_decode_cache=self.config.save_decode_cache,
              )
              if req_meta is not None:
@@ -174,7 +174,7 @@ index ecb7af86..048bb656 100644
                  meta.add_request(req_meta)
  
          cached_reqs = scheduler_output.scheduled_cached_reqs
-@@ -1624,6 +1768,7 @@ class LMCacheConnectorV1Impl:
+@@ -1532,6 +1676,7 @@ class LMCacheConnectorV1Impl:
                      save_decode_cache=self.config.save_decode_cache,
                  )
                  if req_meta is not None:
@@ -182,7 +182,7 @@ index ecb7af86..048bb656 100644
                      meta.add_request(req_meta)
              return meta
  
-@@ -1747,6 +1892,7 @@ class LMCacheConnectorV1Impl:
+@@ -1655,6 +1800,7 @@ class LMCacheConnectorV1Impl:
                  save_decode_cache=self.config.save_decode_cache,
              )
              if req_meta is not None:
@@ -190,7 +190,7 @@ index ecb7af86..048bb656 100644
                  meta.add_request(req_meta)
  
          return meta
-@@ -1786,10 +1932,35 @@ class LMCacheConnectorV1Impl:
+@@ -1694,10 +1840,35 @@ class LMCacheConnectorV1Impl:
                  "first_tok": request._output_token_ids[0],
              }
  
@@ -228,7 +228,7 @@ index ecb7af86..048bb656 100644
                  return_params = return_params or {}
                  return_params["num_lmcache_cached_tokens"] = (
 diff --git a/lmcache/observability.py b/lmcache/observability.py
-index 8a9a3a15..fd01809c 100644
+index 8a9a3a1..fd01809 100644
 --- a/lmcache/observability.py
 +++ b/lmcache/observability.py
 @@ -246,6 +246,100 @@ class P2PTransferRequestStats:
@@ -382,7 +382,7 @@ index 8a9a3a15..fd01809c 100644
      def on_chunk_reuse(self, time_interval: float):
          """
 diff --git a/lmcache/v1/cache_engine.py b/lmcache/v1/cache_engine.py
-index 6fb2733e..33aefb56 100644
+index 6fb2733..33aefb5 100644
 --- a/lmcache/v1/cache_engine.py
 +++ b/lmcache/v1/cache_engine.py
 @@ -261,6 +261,45 @@ class LMCacheEngine:
@@ -529,7 +529,7 @@ index 6fb2733e..33aefb56 100644
              logger.info(
                  "[req_id=%s] Retrieved %d out of %d out of total %d tokens",
 diff --git a/tests/test_observability.py b/tests/test_observability.py
-index 6f41ae88..889b91b4 100644
+index 6f41ae8..889b91b 100644
 --- a/tests/test_observability.py
 +++ b/tests/test_observability.py
 @@ -118,6 +118,41 @@ def test_remote_time_metrics(stats_monitor):

--- a/container/deps/vllm/install_vllm.sh
+++ b/container/deps/vllm/install_vllm.sh
@@ -260,6 +260,12 @@ echo "\n=== Installing LMCache from source ==="
 if [ "$DEVICE" = "cuda" ]; then
     git clone --depth 1 --branch v${LMCACHE_REF} https://github.com/LMCache/LMCache.git ${INSTALLATION_DIR}/lmcache
     cd ${INSTALLATION_DIR}/lmcache
+    LMCACHE_PATCH="${LMCACHE_PATCH:-/tmp/deps/lmcache/local.patch}"
+    if [ -f "$LMCACHE_PATCH" ]; then
+        echo "Applying local LMCache patch: ${LMCACHE_PATCH}"
+        git apply --check "$LMCACHE_PATCH"
+        git apply "$LMCACHE_PATCH"
+    fi
     uv pip install -r requirements/build.txt
     # Get torch lib dir and embed it as RPATH so c_ops.so finds torch libs at runtime
     TORCH_LIB=$(python3 -c "import torch, os; print(os.path.dirname(torch.__file__) + '/lib')")

--- a/container/templates/args.Dockerfile
+++ b/container/templates/args.Dockerfile
@@ -99,6 +99,7 @@ ARG MAX_JOBS={{ context.vllm.max_jobs }}
 ARG FLASHINF_REF={{ context.vllm.flashinf_ref }}
 {% endif %}
 ARG LMCACHE_REF={{ context.vllm.lmcache_ref }}
+ARG LMCACHE_PATCH_SHA=""
 ARG VLLM_OMNI_REF={{ context.vllm.vllm_omni_ref }}
 
 {% if device == "cuda" -%}

--- a/container/templates/vllm_framework.Dockerfile
+++ b/container/templates/vllm_framework.Dockerfile
@@ -71,6 +71,7 @@ ARG TARGETARCH
 ARG VLLM_REF
 ARG VLLM_GIT_URL
 ARG LMCACHE_REF
+ARG LMCACHE_PATCH_SHA
 ARG VLLM_OMNI_REF
 
 {% if device == "cuda" %}
@@ -110,6 +111,7 @@ ARG VLLM_CPU_AMXBF16=true          # Support for building with AMXBF16 ISA
 RUN --mount=type=bind,source=./container/deps/,target=/tmp/deps \
     --mount=type=cache,target=/root/.cache/uv,sharing=locked \
     export UV_CACHE_DIR=/root/.cache/uv UV_HTTP_TIMEOUT=300 UV_HTTP_RETRIES=5 && \
+    echo "LMCACHE_PATCH_SHA=${LMCACHE_PATCH_SHA}" && \
     cp /tmp/deps/vllm/install_vllm.sh /tmp/install_vllm.sh && \
     chmod +x /tmp/install_vllm.sh && \
     if [ "$DEVICE" = "cpu" ] && [ "$TARGETARCH" = "amd64" ]; then \


### PR DESCRIPTION
## Summary                                                                                                                            
                                                                                                                                        
  Builds on `aniket/lmcache-transfer-reporting` with three small fixes so the                                                           
  LMCache transfer log lines slot directly into the existing kvcache_benchmarks                                                         
  dashboard pipeline (which already parses the KVBM v2 worker.log format).                                                              
                                                                                                                                        
  All three changes are inside `container/deps/lmcache/local.patch`. The original                                                       
  PR is otherwise untouched.                                                                                                            
                                                                                                                                        
  ## Changes                                                                                                                            
                                                                                                                                        
  ### 1. Distinct log verbs for store vs retrieve           
  `_log_connector_transfer_complete` now emits:
  - `Offload transfer complete …` for `direction == "store"`                                                                            
  - `Onboard transfer complete …` for `direction == "retrieve"`                                                                         
                                                                                                                                        
  **Why:** the dashboard regex (`site/generate.py:_parse_kvbm_worker_log`)                                                              
  matches every line containing `Onboard transfer complete`. With the original                                                          
  single-verb scheme, store and retrieve get conflated for any request that                                                             
  does both, double-counting transfer time. KVBM uses different verbs per                                                               
  direction; mirroring that keeps a single regex sufficient for both backends.                                                          
                                                                                                                                        
  ### 2. Flipped `src`/`dst` labels to match KVBM convention                                                                            
  KVBM treats `G1 = device`, `G2 = host`. After this fix:                                                                               
  - `store` (offload, GPU → host) → `src="lmcache::G1" dst="lmcache::G2"`                                                               
  - `retrieve` (onboard, host → GPU) → `src="lmcache::G2" dst="lmcache::G1"`                                                            
                                                                                                                                        
  **Why:** the original PR labeled both directions backwards relative to KVBM.                                                          
  The byte/time numbers were correct, but anything downstream that interprets                                                           
  `src`/`dst` (or filters by direction) would draw onboard ↔ offload upside-down.                                                       
                                                                                                                                        
  ### 3. `_speed_gb_s` uses base-10 GB/s, not GiB/s                                                                                     
  `RequestTransferStats._speed_gb_s` now divides by `1e9` instead of `1024**3`,                                                         
  with a comment explaining why.                                                                                                        
                                                                                                                                        
  **Why:** `single_prompt_tester.py`, `site/generate.py`, and vLLM's native                                                             
  offloading Prometheus metrics (`kv_offload_total_bytes / time`) all use
  decimal GB/s. The 1024³ form produced GiB/s and undershot every other                                                                 
  bandwidth number in our pipeline by ~7 %.                                                                                             
                                                                                                                                        
  ## Notes for the reviewer                                                                                                             
                                                                                                                                        
  - Hunk headers in `local.patch` were updated to reflect line-count drift                                                              
    (+5 lines in the `cache_engine.py` hunk for the verb branch + comments,
    +2 lines in the `observability.py` hunk for the `_speed_gb_s` comment).                                                             
    `git apply --check` is strict about these; verified clean apply against                                                             
    LMCache `v0.4.4` (the version pinned by `container/deps/vllm/install_vllm.sh`).                                                     
  - `tests/test_observability.py::test_request_transfer_stats` does not assert                                                          
    on `speed_gb_s`, so the unit change does not need a test update.                                                                    
  - `components/src/dynamo/vllm/handlers.py` and the new test there are                                                                 
    unchanged — the shorthand `kv_transfer_speed_gb_s` field they pass through                                                          
    is computed from the patched `_speed_gb_s` and inherits the fix.                                                                    
                                                                                                                                        
  ## Test plan                                                                                                                          
                                                                                                                                        
  - [ ] `git apply --check container/deps/lmcache/local.patch` against                                                                  
        LMCache v0.4.4
  - [ ] Container build with `LMCACHE_PATCH_SHA` bumped, then run                                                                       
        `benchmarks/single_prompt/run_vllm_lmcache_sweep.sh` and confirm                                                                
        `worker.log` contains both `Onboard transfer complete` (warm path)                                                              
        and `Offload transfer complete` (cold prefill) lines with                                                                       
        `src="lmcache::G2" dst="lmcache::G1"` and `src="lmcache::G1" dst="lmcache::G2"`                                                 
        respectively                                                                                                                    
  - [ ] Run the kvcache_benchmarks dashboard generator and verify                                                                       
        `transfer_data.json` reports a non-zero `xfer_ms_p50` and an                                                                    
        `onboard_bw_p50` within ~7 % of the value derived from                                                                          
        `kv_bytes_per_token × ISL / xfer_us`