### PR TITLE
feat(sglang): respect SGLANG_TRACE_LEVEL env var when tracing is enabled

### DIFF
--- a/components/src/dynamo/sglang/backend_args.py
+++ b/components/src/dynamo/sglang/backend_args.py
@@ -116,6 +116,17 @@ class DynamoSGLangArgGroup(ArgGroup):
         # EPD multimodal flags happens in DynamoSGLangConfig.validate() below.
         add_frontend_decoding_arg(g, env_prefix="SGL")
 
+        add_argument(
+            g,
+            flag_name="--sglang-trace-level",
+            env_var="SGLANG_TRACE_LEVEL",
+            default=2,
+            arg_type=int,
+            choices=[1, 2, 3, 4],
+            help="SGLang global trace level when --enable-trace is set "
+            "(1=minimal, 2=per-request [default], 3=+decode_loop, 4=full).",
+        )
+
 
 class DynamoSGLangConfig(ConfigBase):
     """Configuration for Dynamo SGLang wrapper (SGLang-specific only)."""
@@ -133,6 +144,7 @@ class DynamoSGLangConfig(ConfigBase):
     video_generation_worker: bool
     enable_rl: bool
     frontend_decoding: bool = False
+    sglang_trace_level: int
 
     def validate(self) -> None:
         if not isinstance(self.embedding_transfer_mode, EmbeddingTransferMode):

--- a/components/src/dynamo/sglang/init_llm.py
+++ b/components/src/dynamo/sglang/init_llm.py
@@ -93,6 +93,11 @@ async def init_decode(
         engine = sgl.Engine(server_args=server_args)
         load_time = time.time() - start_time
 
+    if getattr(server_args, "enable_trace", False):
+        from sglang.srt.observability.trace import set_global_trace_level
+
+        set_global_trace_level(int(os.environ.get("SGLANG_TRACE_LEVEL", "2")))
+
     load_lora_endpoint = runtime.endpoint(
         f"{dynamo_args.namespace}.{dynamo_args.component}.load_lora"
     )
@@ -234,6 +239,11 @@ async def init_prefill(
         start_time = time.time()
         engine = sgl.Engine(server_args=server_args)
         load_time = time.time() - start_time
+
+    if getattr(server_args, "enable_trace", False):
+        from sglang.srt.observability.trace import set_global_trace_level
+
+        set_global_trace_level(int(os.environ.get("SGLANG_TRACE_LEVEL", "2")))
 
     load_lora_endpoint = runtime.endpoint(
         f"{dynamo_args.namespace}.{dynamo_args.component}.load_lora"

--- a/components/src/dynamo/sglang/init_llm.py
+++ b/components/src/dynamo/sglang/init_llm.py
@@ -8,6 +8,7 @@ import time
 from typing import Awaitable, Callable, Optional
 
 import sglang as sgl
+from sglang.srt.observability.trace import set_global_trace_level
 
 from dynamo.common.constants import DisaggregationMode
 from dynamo.common.utils.endpoint_types import parse_endpoint_types
@@ -93,10 +94,8 @@ async def init_decode(
         engine = sgl.Engine(server_args=server_args)
         load_time = time.time() - start_time
 
-    if getattr(server_args, "enable_trace", False):
-        from sglang.srt.observability.trace import set_global_trace_level
-
-        set_global_trace_level(int(os.environ.get("SGLANG_TRACE_LEVEL", "2")))
+    if server_args.enable_trace:
+        set_global_trace_level(dynamo_args.sglang_trace_level)
 
     load_lora_endpoint = runtime.endpoint(
         f"{dynamo_args.namespace}.{dynamo_args.component}.load_lora"
@@ -240,10 +239,8 @@ async def init_prefill(
         engine = sgl.Engine(server_args=server_args)
         load_time = time.time() - start_time
 
-    if getattr(server_args, "enable_trace", False):
-        from sglang.srt.observability.trace import set_global_trace_level
-
-        set_global_trace_level(int(os.environ.get("SGLANG_TRACE_LEVEL", "2")))
+    if server_args.enable_trace:
+        set_global_trace_level(dynamo_args.sglang_trace_level)
 
     load_lora_endpoint = runtime.endpoint(
         f"{dynamo_args.namespace}.{dynamo_args.component}.load_lora"

--- a/docs/backends/sglang/sglang-observability.md
+++ b/docs/backends/sglang/sglang-observability.md
@@ -258,6 +258,31 @@ Key implementation files:
 
 Both flags are required for end-to-end tracing through the SGLang engine. Without `--enable-trace`, the Dynamo handler still creates spans, but SGLang's internal engine spans will not be linked.
 
+### Controlling SGLang Trace Verbosity
+
+When `--enable-trace` is set, SGLang emits spans at four verbosity levels. Dynamo defaults to level 2, which keeps all useful per-request spans while suppressing high-volume scheduler noise:
+
+| Level | Spans included | Volume |
+|-------|---------------|--------|
+| 1 | `tokenize`, `prefill_forward`, `decode_forward` | Low |
+| 2 | Level 1 + `request_process`, `api_server_dispatch` | Low |
+| 3 (SGLang default) | Level 2 + `decode_loop`, `chunked_prefill`, `fake_output` | Very high (~1.6M spans/hr per model) |
+| 4 | Level 3 + `run_batch_cpu` | Extremely high |
+
+Use the `SGLANG_TRACE_LEVEL` environment variable to override the default:
+
+| Variable | Description | Default | Example |
+|----------|-------------|---------|---------|
+| `SGLANG_TRACE_LEVEL` | SGLang internal span verbosity level (1–4); only active when `--enable-trace` is set | `2` | `1` |
+
+```bash
+# Keep only the most essential per-request spans
+SGLANG_TRACE_LEVEL=1 python -m dynamo.sglang --model Qwen/Qwen3-0.6B --enable-trace --otlp-traces-endpoint localhost:4317
+
+# Restore SGLang's default level (includes decode_loop — high volume)
+SGLANG_TRACE_LEVEL=3 python -m dynamo.sglang --model Qwen/Qwen3-0.6B --enable-trace --otlp-traces-endpoint localhost:4317
+```
+
 ### Launch with Tracing
 
 The disaggregated launch script supports `--enable-otel` to enable tracing across all components:


### PR DESCRIPTION
## Summary

When `--enable-trace` is set, SGLang's `global_trace_level` defaults to 3,
which includes `decode_loop` spans emitted once per scheduler iteration across
all TP ranks. At typical throughput these dominate trace volume with little
per-request debugging value.

- After `sgl.Engine` is ready in both `init_decode` and `init_prefill`, call
  `set_global_trace_level()` directly in-process (no HTTP round-trip needed
  since the engine runs in the same Python process as the Dynamo worker)
- Default to level 2, which keeps all useful per-request spans (`tokenize`,
  `prefill_forward`, `decode_forward`, `request_process`, `api_server_dispatch`)
  while suppressing high-volume scheduler noise (`decode_loop`, `chunked_prefill`,
  `fake_output`)
- Overridable via `SGLANG_TRACE_LEVEL` env var (e.g. `SGLANG_TRACE_LEVEL=3`
  restores SGLang's default)
- Documents the new env var and span level reference table in
  `docs/backends/sglang/sglang-observability.md`

## SGLang span levels reference

| Level | Spans | Volume |
|-------|-------|--------|
| 1 | `tokenize`, `prefill_forward`, `decode_forward` | Low |
| 2 (new default) | Level 1 + `request_process`, `api_server_dispatch` | Low |
| 3 (SGLang default) | Level 2 + `decode_loop`, `chunked_prefill`, `fake_output` | Very high |
| 4 | Level 3 + `run_batch_cpu` | Extremely high |

## Test plan

- [ ] Launch SGLang worker with `--enable-trace --otlp-traces-endpoint localhost:4317`
      and verify `decode_loop` spans are absent in Tempo at default level
- [ ] Set `SGLANG_TRACE_LEVEL=3` and verify `decode_loop` spans reappear
- [ ] Set `SGLANG_TRACE_LEVEL=1` and verify only `tokenize`/`prefill_forward`/
      `decode_forward` spans appear
- [ ] Verify behaviour is identical for disaggregated prefill workers (`init_prefill` path)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9327" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enabled SGLang tracing with configurable verbosity levels to improve observability and debugging capabilities during inference operations

* **Documentation**
  * New section on controlling SGLang trace verbosity, including environment variable configuration instructions and practical example commands demonstrating how to run deployments with different trace levels

<!-- end of auto-generated comment: release notes by coderabbit.ai -->