### PR TITLE
fix: prevent basetemp race in GPU-parallel pytest orchestrator

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -263,6 +263,23 @@ def pytest_runtestloop(session: pytest.Session) -> bool | None:
     if config.getoption("skip_service_restart", default=None):
         extra_args.append("--skip-service-restart")
 
+    # Forward -o cache_dir= so workers don't fall back to <cwd>/.pytest_cache.
+    # In CI cwd=/workspace is read-only for the runner uid, and pyproject's
+    # filterwarnings=["error"] escalates the resulting PytestCacheWarning into
+    # a test failure. Only forward cache_dir when absolute -- pytest's default
+    # ini value is the relative ".pytest_cache", and forwarding it would
+    # needlessly pin every worker to an explicit override outside our CI
+    # scenario.
+    cache_dir = config.getini("cache_dir")
+    if cache_dir and os.path.isabs(str(cache_dir)):
+        extra_args.extend(["-o", f"cache_dir={cache_dir}"])
+    # --basetemp is racy if forwarded directly: pytest rmtrees the given
+    # basetemp at session startup, so concurrent children sharing one root
+    # would wipe each other's temp trees. The orchestrator suffixes a unique
+    # per-test subdir before passing it to each child.
+    raw_basetemp = config.getoption("basetemp", default=None)
+    parent_basetemp = str(raw_basetemp) if raw_basetemp else None
+
     old_downloads_ready = os.environ.get(_GPU_PARALLEL_DOWNLOADS_READY_ENV)
     old_hf_offline = os.environ.get("HF_HUB_OFFLINE")
     downloads_ready = False
@@ -288,6 +305,7 @@ def pytest_runtestloop(session: pytest.Session) -> bool | None:
             gpu_indices=gpu_indices,
             extra_pytest_args=extra_args or None,
             stream=is_stream,
+            parent_basetemp=parent_basetemp,
         )
     finally:
         if downloads_ready:

--- a/tests/utils/pytest_parallel_gpu.py
+++ b/tests/utils/pytest_parallel_gpu.py
@@ -310,6 +310,7 @@ def run_parallel(
     gpu_indices: list[int] | None = None,
     extra_pytest_args: list[str] | None = None,
     stream: bool = False,
+    parent_basetemp: str | None = None,
 ) -> int:
     """Run tests in parallel with VRAM-aware scheduling across multiple GPUs.
 
@@ -545,6 +546,17 @@ def run_parallel(
         ]
         if extra_pytest_args:
             cmd.extend(extra_pytest_args)
+        # Give each child a unique --basetemp under the parent's root.
+        # pytest rmtrees the given basetemp at session startup, so a shared
+        # root would let siblings wipe each other's tmp_path trees mid-run.
+        # Prefix with w{w_id} because safe_name normalizes "/" and "::" and
+        # is not guaranteed collision-free across parametrized ids.
+        # Appended after extra_pytest_args so the orchestrator's per-child
+        # path wins over any --basetemp that a caller stuffs into
+        # extra_pytest_args (pytest uses argparse semantics: last value wins).
+        if parent_basetemp:
+            child_basetemp = os.path.join(parent_basetemp, f"w{test.w_id}-{safe_name}")
+            cmd.extend(["--basetemp", child_basetemp])
 
         proc = subprocess.Popen(
             cmd,


### PR DESCRIPTION
## Summary

Fix post-merge CI failure: sglang-runtime / Test (cuda12.9, amd64) and (cuda13.0, amd64) both FAILED in run 25566830406.

### Root Cause

When  was added to the sglang-test job in eb2f599a1e, the GPU-parallel orchestrator  spawns each test as its own subprocess. The  value (set by action.yml) was forwarded verbatim to each child:

1. Worker 1 starts → pytest rmtrees  and creates a subdir
2. Worker 2 starts concurrently → sees the replaced dir; tmp_path resolution fails
3. Worker 2 falls back to  (read-only in CI)
4. pytest emits  →  has 
5. Every warning becomes a test-failure exit code even though the test passed

### Fix

Instead of forwarding  verbatim, pass  to  and suffix a unique per-test subdirectory () for each child. This eliminates the race because every child works in its own isolated temp subdirectory.

### Files Changed

- : Added  forwarding (prevents PytestCacheWarning from cache fallback) + replaced verbatim  forward with  variable, passed to 
- : Added  parameter; before , each child receives 

### Testing

- Syntax verified via 
- Diff matches the fix from 
- Preserves  feature from eb2f599a1e (tester-v2 had removed it)

Closes: https://github.com/ai-dynamo/dynamo/actions/runs/25566830406/job/75053355908

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9330" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved parallel test execution configuration to prevent race conditions in temporary directory handling across worker subprocesses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->