### PR TITLE
test: skip failing sglang nats migration case

### DIFF
--- a/tests/fault_tolerance/migration/test_sglang.py
+++ b/tests/fault_tolerance/migration/test_sglang.py
@@ -235,6 +235,20 @@ def test_request_migration_sglang_aggregated(
         stream: True for streaming, False for non-streaming
     """
 
+    request_plane = request.getfixturevalue("request_plane")
+
+    # OPS-4472: graceful-shutdown migration with NATS is flaky for the
+    # chat streaming aggregated SGLang case.
+    if (
+        migration_limit == 3
+        and migration_max_seq_len is None
+        and immediate_kill is False
+        and request_api == "chat"
+        and stream is True
+        and request_plane == "nats"
+    ):
+        pytest.skip("Flaky: graceful-shutdown migration fails with NATS. OPS-4472")
+
     # OPS-4446: first-token delay routinely exceeds the 6s threshold in
     # utils.validate_response for this parameter combination. Originally only
     # the NATS variant tripped; once the NATS skip landed, the TCP variant


### PR DESCRIPTION
Skip only the aggregated SGLang migration parameter set that fails for graceful-shutdown chat streaming over NATS. The skip is tracked by OPS-4472 and leaves the surrounding TCP and worker-failure coverage intact.

ref: OPS-4472

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9332" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by adding conditional skip logic in the fault tolerance migration test suite to handle a flaky scenario under specific configuration conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->