### PR TITLE
chore: update branch-sharded benchmark docs

### DIFF
--- a/lib/bench/README.md
+++ b/lib/bench/README.md
@@ -124,5 +124,4 @@ knob while keeping the same internal polynomial model.
 
 See [kv_router/INDEXER_BENCH.md](kv_router/INDEXER_BENCH.md) for trace
 acquisition, benchmark commands, and results for the `mooncake_bench` suite:
-`concurrent-radix-tree-compressed`, `branch-sharded-crtc`, and
-`anchor-aware-branch-sharded-crtc`.
+`concurrent-radix-tree-compressed` and `branch-sharded-crtc`.

--- a/lib/bench/kv_router/INDEXER_BENCH.md
+++ b/lib/bench/kv_router/INDEXER_BENCH.md
@@ -92,20 +92,12 @@ cargo bench --package dynamo-bench --bench mooncake_bench -- \
   branch-sharded-crtc --num-shards 2 --num-event-workers-per-shard 4 --prefix-depth 2
 ```
 
-**Branch-sharded depth=4 (2 shards × 4 workers):**
+**Optional branch-sharded depth=4 (2 shards × 4 workers):**
 ```bash
 cargo bench --package dynamo-bench --bench mooncake_bench -- \
   $(git rev-parse --show-toplevel)/lib/kv-router/traces/mooncake_trace.jsonl \
   --trace-simulation-duration-ms 10000 --benchmark-duration-ms 30000 -d 7 \
   branch-sharded-crtc --num-shards 2 --num-event-workers-per-shard 4 --prefix-depth 4
-```
-
-**Anchor-aware branch-sharded depth=2 (2 shards × 4 workers):**
-```bash
-cargo bench --package dynamo-bench --bench mooncake_bench -- \
-  $(git rev-parse --show-toplevel)/lib/kv-router/traces/mooncake_trace.jsonl \
-  --trace-simulation-duration-ms 10000 --benchmark-duration-ms 30000 -d 7 \
-  anchor-aware-branch-sharded-crtc --num-shards 2 --num-event-workers-per-shard 4 --prefix-depth 2
 ```
 
 ### Peak throughput sweep
@@ -126,15 +118,6 @@ cargo bench --package dynamo-bench --bench mooncake_bench -- \
   --trace-simulation-duration-ms 10000 -d 7 \
   --sweep --sweep-min-ms 1000 --sweep-max-ms 30000 --sweep-steps 8 \
   branch-sharded-crtc --num-shards 2 --num-event-workers-per-shard 4 --prefix-depth 2
-```
-
-**Anchor-aware branch-sharded depth=2 — sweep:**
-```bash
-cargo bench --package dynamo-bench --bench mooncake_bench -- \
-  $(git rev-parse --show-toplevel)/lib/kv-router/traces/mooncake_trace.jsonl \
-  --trace-simulation-duration-ms 10000 -d 7 \
-  --sweep --sweep-min-ms 1000 --sweep-max-ms 30000 --sweep-steps 8 \
-  anchor-aware-branch-sharded-crtc --num-shards 2 --num-event-workers-per-shard 4 --prefix-depth 2
 ```
 
 ### Worker scaling
@@ -183,21 +166,6 @@ cargo bench --package dynamo-bench --bench mooncake_bench -- \
   --prefix-depth 2
 ```
 
-**Anchor-aware branch-sharded depth=2 with the same total event-worker count (2 shards × 4 workers):**
-```bash
-cargo bench --package dynamo-bench --bench mooncake_bench -- \
-  $(git rev-parse --show-toplevel)/lib/kv-router/traces/mooncake_trace.jsonl \
-  --num-unique-inference-workers 128 \
-  --trace-duplication-factor 20 \
-  --trace-length-factor 4 \
-  --benchmark-duration-ms 750 \
-  --benchmark-runs 20 \
-  anchor-aware-branch-sharded-crtc \
-  --num-shards 2 \
-  --num-event-workers-per-shard 4 \
-  --prefix-depth 2
-```
-
 For a larger branch-sharded worker pool, use `--num-event-workers-per-shard 8` (16 total event workers with 2 shards).
 
 ---
@@ -216,9 +184,9 @@ For a larger branch-sharded worker pool, use `--num-event-workers-per-shard 8` (
 
 | Field | Meaning |
 |-------|---------|
-| Dispatched | Queries routed to one shard for lookup |
-| Early-exit % | Queries with no registered prefix alias, resolved without shard dispatch |
-| Avg routing | Prefix-key routing-table lookup time |
+| Dispatched | Queries routed to one shard for anchored suffix lookup |
+| Shallow | Queries answered by router-owned TRIE state without shard dispatch |
+| Avg routing | Routing-TRIE traversal time |
 | Avg shard | CRTC traversal time on the dispatched shard |
 
 ---
@@ -239,7 +207,7 @@ For a larger branch-sharded worker pool, use `--num-event-workers-per-shard 8` (
 | `--sweep-min-ms` | 1000 | Shortest benchmark window in sweep |
 | `--sweep-max-ms` | 50000 | Longest benchmark window in sweep |
 | `--sweep-steps` | 10 | Number of steps in sweep |
-| `--shard-metrics-csv FILE` | — | Sample shard block/node counts over time → CSV + SVG |
+| `--shard-metrics-csv FILE` | — | Sample shard block/node counts over time → CSV |
 
 ### `branch-sharded-crtc` flags
 
@@ -247,17 +215,9 @@ For a larger branch-sharded worker pool, use `--num-event-workers-per-shard 8` (
 |------|---------|-------------|
 | `--num-shards` | 2 | Number of independent CRTC shards |
 | `--num-event-workers-per-shard` | 4 | OS threads per shard for KV event processing |
-| `--prefix-depth` | 2 | Blocks hashed to compute the branch routing key |
-
-### `anchor-aware-branch-sharded-crtc` flags
-
-| Flag | Default | What it does |
-|------|---------|-------------|
-| `--num-shards` | 2 | Number of independent CRTC shards |
-| `--num-event-workers-per-shard` | 4 | OS threads per shard for KV event processing |
 | `--prefix-depth` | 2 | Maximum routing-trie depth before dispatching to one shard |
 
-Note: `anchor-aware-branch-sharded-crtc` does not support approximate pruning. It provides a stronger routing-correctness guarantee for out-of-order events, at the cost of higher routing latency and a hot-branch shard collapse risk on dominant-prefix workloads (see Known Issues).
+Note: `branch-sharded-crtc` uses trie/anchor routing and does not support approximate pruning. It provides a stronger routing-correctness model for out-of-order events, at the cost of higher routing latency and a hot-branch shard collapse risk on dominant-prefix workloads (see Known Issues).
 
 ---
 
@@ -270,30 +230,24 @@ Trace: `mooncake_trace.jsonl` (Mooncake FAST25 arxiv trace). Config: 2 shards ×
 | Indexer | Achieved ops/s | p99 | Routing outcome | Avg routing | Avg shard |
 |---------|---------------|-----|-----------------|-------------|-----------|
 | CRTC baseline (8w) | 17,201 | 1,093 µs | — | — | — |
-| Branch-sharded depth=2 (2×4w) | 17,182 | **933 µs** | 0.0% miss | 762 ns | 238 µs |
-| Branch-sharded depth=4 (2×4w) | 17,221 | **841 µs** | 0.0% miss | 717 ns | 237 µs |
-| Anchor-aware BSI depth=2 (2×4w) | 17,064 | 1,510 µs | 91.3% dispatched / 8.7% shallow | 388 µs | 161 µs |
+| Branch-sharded depth=2 (2×4w) | 17,064 | 1,510 µs | 91.3% dispatched / 8.7% shallow | 388 µs | 161 µs |
+| Branch-sharded depth=4 (2×4w) | 16,939 | 5,263 µs | 86.1% dispatched / 13.9% shallow | 678 µs | 244 µs |
 
-All indexers keep up with the offered trace rate. On this arxiv trace, branch-sharded depth=2 is about **15% lower p99** than CRTC, and depth=4 is about **23% lower p99**. This is a modest latency win, not the large win seen on the smaller `conversation_trace.jsonl` workload; do not compare those results directly.
+All listed configs keep up with the offered trace rate. On this hot-prefix arxiv trace, branch-sharded routing is slower than CRTC in steady-state p99 because the routing TRIE does materially more work before dispatch and the stored block load collapses almost entirely onto one shard.
 
 The true-miss rate remains effectively zero in these runs.
 
-Anchor-aware BSI is slower than both CRTC and branch-sharded in this steady-state run. Its routing TRIE provides a stronger structural routing model, but on this hot-prefix trace the routing work is materially higher and the shard load collapses almost entirely onto one shard.
+The routing TRIE provides a structural routing model that keeps shallow router state and shard anchors consistent, but it does not yet solve hot-branch load collapse. These numbers are useful for correctness and hot-prefix performance, but they do not show ideal multi-shard scaling.
 
-> **Shard imbalance warning (this trace):** `mooncake_trace.jsonl` contains two dominant depth-2 prefixes: `[46,47]` appears 9,203 times and `[74,75]` appears 3,449 times. Branch-sharded routing therefore remains skewed even though it does not collapse to a single shard. These numbers are useful for correctness and hot-prefix performance, but they do not show ideal multi-shard scaling.
+> **Shard imbalance warning (this trace):** `mooncake_trace.jsonl` contains two dominant depth-2 prefixes: `[46,47]` appears 9,203 times and `[74,75]` appears 3,449 times. Branch-sharded routing can therefore collapse most stored blocks onto one shard until adaptive hot-branch splitting is implemented.
 
 Shard block distribution:
 ```text
-branch depth=2:  shard 0: 1,919,603 blocks (87.0%), 7,000 workers  shard 1: 286,468 blocks (13.0%), 7,000 workers
-                 branches: shard[0]=819, shard[1]=3
-
-branch depth=4:  shard 0: 1,919,603 blocks (87.0%), 7,000 workers  shard 1: 286,468 blocks (13.0%), 7,000 workers
-                 branches: shard[0]=960, shard[1]=17
-
-anchor-aware:    shard 0: 574 blocks (0.0%), 14 workers  shard 1: 2,094,155 blocks (100.0%), 7,000 workers
+branch depth=2:  shard 0: 574 blocks (0.0%), 14 workers  shard 1: 2,094,155 blocks (100.0%), 7,000 workers
+branch depth=4:  shard 0: 80,570 blocks (4.0%), 3,983 workers  shard 1: 1,922,501 blocks (96.0%), 7,000 workers
 ```
 
-Increasing `prefix_depth` from 2 to 4 creates more branch aliases, but the stored block split is unchanged because the hottest branch lifetime still dominates the trace. See Known Issues below.
+See Known Issues below for the current hot-branch collapse behavior.
 
 ### Peak throughput sweep — `mooncake_trace.jsonl`
 
@@ -302,10 +256,9 @@ Clean peak is defined as the highest achieved ops/s where the benchmark keeps up
 | Indexer | Clean peak achieved ops/s | p99 at clean peak | Notes |
 |---------|--------------------------:|-------------------|-------|
 | CRTC baseline (8w) | **118,157** | 1,087 µs | Best clean throughput on this hot-prefix trace |
-| Branch-sharded depth=2 (2×4w) | 73,304 | 1,337 µs | Clean peak is lower than CRTC because traffic is skewed to one shard |
-| Anchor-aware BSI depth=2 (2×4w) | 16,699 | 12,332 µs | Sweep degrades heavily after overload; use steady-state run for normal p99 |
+| Branch-sharded depth=2 (2×4w) | 16,699 | 12,332 µs | Sweep degrades heavily after overload; use steady-state run for normal p99 |
 
-On this arxiv trace, CRTC has the highest clean throughput in the sweep. That is not a contradiction with the steady-state table: branch-sharded still has lower trace-rate p99, but the hot-prefix distribution limits shard parallelism and therefore caps clean peak throughput. This is the main reason the arxiv trace is a better primary benchmark: it exposes the accuracy fix under a less favorable and more realistic hot-prefix workload.
+On this arxiv trace, CRTC has the highest clean throughput in the sweep. The hot-prefix distribution limits branch-sharded shard parallelism and caps clean peak throughput. This is the main reason the arxiv trace is a useful primary benchmark: it exposes the routing model under a less favorable and more realistic hot-prefix workload.
 
 Full sweep data:
 
@@ -326,19 +279,6 @@ Full sweep data:
 
 | Benchmark window | Offered ops/s | Achieved ops/s | p99 |
 |-----------------|--------------|----------------|-----|
-| 30,000 ms ⚠ | 17,268 | 13,732 | 17,772 µs |
-| 18,455 ms | 28,071 | 27,967 | 1,967 µs |
-| 11,352 ms | 45,635 | 45,089 | 814 µs |
-| 6,983 ms | 74,187 | 73,304 | 1,337 µs |
-| 4,296 ms ⚠ | 120,589 | 73,655 | 6,186 µs |
-| 2,643 ms ⚠ | 196,008 | 113,628 | 2,663 µs |
-| 1,626 ms ⚠ | 318,603 | 156,775 | 1,383 µs |
-| 1,000 ms ⚠ | 518,049 | 117,445 | 2,390 µs |
-
-**Anchor-aware BSI depth=2:**
-
-| Benchmark window | Offered ops/s | Achieved ops/s | p99 |
-|-----------------|--------------|----------------|-----|
 | 30,000 ms | 17,268 | 16,699 | 12,332 µs |
 | 18,455 ms ⚠ | 28,071 | 19,965 | 16,423 µs |
 | 11,352 ms ⚠ | 45,635 | 23,088 | 14,922 µs |
@@ -352,26 +292,20 @@ Full sweep data:
 
 ### Worker scaling — branch-sharded depth=2
 
-Tests how p99 and shard balance change as trace volume grows. Config: 2 shards × 4 workers per shard, `--num-unique-inference-workers 1000`, `-d 7` (7 replicas × 1,000 workers = 7,000 worker identities), `--benchmark-duration-ms 30000`.
+Config: 2 shards × 4 workers per shard, `--num-unique-inference-workers 1000`, `-d 7`, `--benchmark-duration-ms 30000`. `--trace-duplication-factor` duplicates request/hash spaces while keeping the worker identity count fixed; it increases branch diversity and event volume, but it does not multiply the number of worker identities.
 
-Note: `--trace-duplication-factor` duplicates request/hash spaces while keeping the worker identity count fixed at 7,000. It increases branch diversity and event volume; it does not multiply the number of worker identities.
+| Trace duplication | Achieved / offered ops/s | p99 | Avg routing | Avg shard | Anchor installs / reuses | Block split |
+|------------------:|--------------------------:|----:|------------:|----------:|-------------------------:|-------------|
+| 1× | 17,015 / 17,268 | 3,034 µs | 455 µs | 203 µs | 88,228 / 0 | 0.0% / 100.0% |
+| 2× | 33,554 / 34,536 | 6,383 µs | 515 µs | 297 µs | 176,386 / 14 | 91.9% / 8.1% |
+| 4× ⚠ | 42,596 / 69,073 | 4,916 µs | 451 µs | 258 µs | 352,842 / 28 | 89.7% / 10.3% |
+| 8× ⚠ | 40,695 / 138,147 | 5,489 µs | 473 µs | 280 µs | 705,593 / 98 | 76.6% / 23.4% |
+| 16× ⚠ | 42,607 / 276,295 | 4,630 µs | 454 µs | 259 µs | 1,410,983 / 182 | 82.0% / 18.0% |
+| 32× ⚠ | 35,018 / 552,590 | 5,928 µs | 529 µs | 319 µs | 2,822,050 / 343 | 84.8% / 15.2% |
 
-| Trace duplication | Branches | Offered ops/s | Achieved ops/s | Avg routing | Avg shard | p99 | Block split |
-|------------------:|---------:|--------------:|---------------:|-------------|-----------|-----|-------------|
-| 1× | 822 | 17,268 | 16,942 | 4.3 µs | 419 µs | 9,069 µs | 87.1% / 12.9% |
-| 2× | 1,640 | 34,536 | 33,623 | 4.3 µs | 531 µs | 9,989 µs | 45.5% / 54.5% |
-| 4× ⚠ | 3,306 | 69,073 | 56,049 | 5.2 µs | 488 µs | 8,403 µs | 54.2% / 45.8% |
-| 8× ⚠ | 6,587 | 138,147 | 61,306 | 4.8 µs | 439 µs | 6,563 µs | 29.4% / 70.6% |
-| 16× ⚠ | 13,162 | 276,295 | 106,127 | 2.0 µs | 262 µs | 2,859 µs | 44.3% / 55.7% |
-| 32× ⚠ | 26,328 | 552,590 | 99,795 | 4.9 µs | 263 µs | 2,549 µs | 55.4% / 44.6% |
+1× and 2× keep up with the offered load. 4× and higher are overloaded with this 30s window and should be treated as stress-shape data rather than clean capacity.
 
-**1× and 2× keep up but p99 is noisy in this long stress sequence.** Use the standalone steady-state runs for normal trace-rate latency comparisons.
-
-**Duplication improves branch diversity.** The block split is much closer to balanced at 2×, 4×, 16×, and 32× than in the single-copy arxiv run. The 8× run still skews because branch lifetimes are uneven even when branch counts grow.
-
-**4× and higher are overloaded with this 30s window on this machine.** Those rows are useful as stress shape, not as clean throughput limits. The benchmark driver emits warnings once achieved block throughput falls behind offered block throughput.
-
-**Practical implication:** for this arxiv trace and a 2-shard config, branch diversity alone does not guarantee clean scaling. The hot-prefix distribution and lifetime skew still matter, and higher-pressure runs need either more shards, longer benchmark windows, or lower trace volume to separate indexer limits from benchmark-driver pressure.
+Duplication increases branch diversity, but it does not reliably balance stored blocks because the hot routing path and branch lifetime skew still dominate. Achieved throughput saturates around 35-43k ops/s in the overloaded rows, and anchor installs scale roughly with event volume.
 
 ### Repeated overload benchmark
 
@@ -380,48 +314,37 @@ Config: `--num-unique-inference-workers 128`, `--trace-duplication-factor 20`, `
 | Indexer | Event workers | Offered ops/s | Achieved ops/s p50 | Achieved ops/s p90 | Achieved ops/s p99 | Achieved ops/s mean |
 |---------|--------------:|--------------:|------------------:|------------------:|------------------:|-------------------:|
 | CRTC baseline | 8 | 3,514,213 | 1,897,506 | 2,712,728 | 2,773,248 | 1,897,265 |
-| Branch-sharded depth=2 | 2×4 | 3,514,213 | 423,942 | 451,508 | 457,397 | 411,244 |
-| Anchor-aware BSI depth=2 | 2×4 | 3,514,213 | 594,934 | 664,920 | 703,730 | 593,921 |
+| Branch-sharded depth=2 | 2×4 | 3,514,213 | 594,934 | 664,920 | 703,730 | 593,921 |
 
 | Indexer | Offered block ops/s | Achieved block ops/s p50 | Achieved block ops/s p90 | Achieved block ops/s p99 | Achieved block ops/s mean |
 |---------|--------------------:|------------------------:|------------------------:|------------------------:|-------------------------:|
 | CRTC baseline | 73,600,216 | 39,740,576 | 56,814,248 | 58,081,760 | 39,735,535 |
-| Branch-sharded depth=2 | 73,600,216 | 8,878,863 | 9,456,199 | 9,579,526 | 8,612,927 |
-| Anchor-aware BSI depth=2 | 73,600,216 | 12,460,051 | 13,925,808 | 14,738,639 | 12,438,834 |
+| Branch-sharded depth=2 | 73,600,216 | 12,460,051 | 13,925,808 | 14,738,639 | 12,438,834 |
 
 | Indexer | p99 latency p50 | p99 latency p90 | p99 latency p99 | p99 latency mean |
 |---------|----------------:|----------------:|----------------:|-----------------:|
 | CRTC baseline | 138 µs | 312 µs | 380 µs | 158 µs |
-| Branch-sharded depth=2 | 137 µs | 161 µs | 198 µs | 137 µs |
-| Anchor-aware BSI depth=2 | 352 µs | 484 µs | 560 µs | 370 µs |
+| Branch-sharded depth=2 | 352 µs | 484 µs | 560 µs | 370 µs |
 
-Branch-sharded lookup latency remains comparable to CRTC in this overload run: routing averages roughly 1.2-2.6 µs, shard traversal averages roughly 9-16 µs, and block placement stays reasonably balanced across the two shards. The lower achieved ops/s is therefore not a lookup-latency regression. This command is dominated by event processing, especially `Removed` events; branch-sharded adds routing-table and block-to-shard bookkeeping on that path while CRTC applies events directly.
-
-Anchor-aware BSI lands between CRTC and branch-sharded on achieved ops/s in this overload run, but with higher p99 lookup latency. Routing averages roughly 18-27 µs, shard traversal roughly 12-19 µs, and stored blocks still collapse heavily onto one shard (usually about 93-100% on shard 1), so this is not a balanced-sharding result.
+Branch-sharded lands below CRTC on achieved ops/s in this overload run and has higher p99 lookup latency. Routing averages roughly 18-27 µs, shard traversal roughly 12-19 µs, and stored blocks still collapse heavily onto one shard (usually about 93-100% on shard 1), so this is not a balanced-sharding result. This command is dominated by event processing, especially `Removed` events; branch-sharded adds routing-TRIE and anchor bookkeeping on that path while CRTC applies events directly.
 
 ---
 
 ## Known Issues
 
-### Shared-prefix shard collapse and lifetime block skew
+### Hot-branch shard collapse and lifetime block skew
 
-`assign_shard` uses live block count as the primary load metric, so branch placement adapts to observed load. Two skew modes remain:
+`BranchShardedIndexer` uses a routing TRIE with static divergent-child shard assignment: the first child under a routing node stays with the parent shard, and later divergent siblings may split to other shards. Two skew modes remain:
 
-1. **Shared-prefix collapse:** if many requests share the same first `prefix_depth` blocks, they share the same routing aliases and land on one shard. On `mooncake_trace.jsonl`, the two hottest depth-2 prefixes account for 12,652 of 23,608 requests, and branch-sharded depth=2/depth=4 store 87% of blocks on one shard.
+1. **Shared-prefix collapse:** if many requests share the same first `prefix_depth` blocks, they share the same routing path and land on one shard. On `mooncake_trace.jsonl`, the two hottest depth-2 prefixes account for 12,652 of 23,608 requests, and the branch-sharded depth=2 steady-state run above stores effectively all blocks on one shard.
 2. **Lifetime skew:** even when branch counts are distributed, branches are placed permanently and some conversations accumulate far more blocks than others. Over time, a few heavy branches can dominate one shard.
 
 The hot shard's larger tree drives up p99.
 
-**Future work — rebalancing:** periodically migrate heavy branches from the overloaded shard to lighter ones. This directly addresses lifetime skew when branches can be moved whole. It does not fully solve shared-prefix collapse (see `prefix_depth` section below), where the routing key itself is too coarse and a structural fix like node-depth routing is needed instead.
+**Future work — hot-branch splitting/rebalancing:** detect prefixes whose request or pending-prefill-token load would overload a shard, then split or migrate that hot branch across a small candidate shard set. This directly addresses the current collapse mode while preserving single-shard routing for cold branches.
 
 ### `prefix_depth` must be tuned per workload
 
-If most requests share a long prompt prefix, all conversations may hash to the same first `prefix_depth` blocks → single branch key → one shard gets most traffic. Set `prefix_depth` to span the shared prefix plus at least 1–2 unique blocks.
+If most requests share a long prompt prefix, all conversations may follow the same routing-TRIE path until the first divergent block. Set `prefix_depth` to span the shared prefix plus at least 1-2 unique blocks when you want the configured depth to expose more branch diversity.
 
-Note: `anchor-aware-branch-sharded-crtc` avoids FNV routing-key collisions (different conversations with the same prefix still get distinct TRIE paths) but has its own hot-branch collapse issue on dominant-prefix workloads (see below). Neither variant is unconditionally better here — tune `prefix_depth` regardless of which you use.
-
-### Anchor-aware BSI: hot-branch shard collapse
-
-`AnchorAwareBranchShardedIndexer` uses static divergent-shard assignment: the first conversation under a new parent node stays on the parent's shard; only subsequent divergent siblings are hashed to a different shard. On workloads with a dominant shared prefix, nearly all traffic can end up as the "first child" of the same TRIE node and route to one shard. Observed on `mooncake_trace.jsonl`: effectively 100% of stored blocks on shard 1 in the steady-state run.
-
-The code has an open TODO for adaptive hot-branch splitting. Until that is resolved, compare both branch-sharded variants on traces with narrow prefix diversity before choosing one for production.
+The routing TRIE avoids prefix-key collisions, but `prefix_depth` tuning alone does not solve a genuinely dominant hot branch. The code has an open TODO for adaptive hot-branch splitting. Until that is resolved, compare branch-sharded results on traces with narrow prefix diversity before choosing it for production.

--- a/lib/bench/kv_router/mooncake_bench.rs
+++ b/lib/bench/kv_router/mooncake_bench.rs
@@ -53,10 +53,9 @@ enum IndexerArgs {
         num_event_workers: usize,
     },
 
-    /// Branch-sharded CRTC: N independent CRTC shards assigned via an explicit routing
-    /// table keyed on the first K block hashes. New branches are assigned to the
-    /// least-loaded shard. find_matches touches exactly ONE shard (no scatter-gather).
-    /// Unknown branch keys return empty scores immediately without any dispatch.
+    /// Branch-sharded CRTC: N independent CRTC shards routed by a bounded
+    /// prefix trie with structural anchors for depth-boundary suffixes.
+    /// find_matches touches at most one shard (no scatter-gather).
     BranchShardedCrtc {
         /// Number of independent CRTC shards.
         #[clap(long, default_value = "2")]
@@ -66,26 +65,9 @@ enum IndexerArgs {
         #[clap(long, default_value = "4")]
         num_event_workers_per_shard: usize,
 
-        /// Number of prefix blocks hashed to identify a branch. K=2 is the
-        /// recommended default: depth=1 often produces too few distinct branch
-        /// keys, while depth=2 gives a much larger set of distinguishable branches.
-        #[clap(long, default_value = "2")]
-        prefix_depth: usize,
-    },
-
-    /// Anchor-aware branch-sharded CRTC: bounded routing trie with structural
-    /// anchors for depth-boundary suffixes. Exact KV-event replay only;
-    /// approximate pruning is unsupported.
-    AnchorAwareBranchShardedCrtc {
-        /// Number of independent CRTC shards.
-        #[clap(long, default_value = "2")]
-        num_shards: usize,
-
-        /// Number of OS event-worker threads per shard.
-        #[clap(long, default_value = "4")]
-        num_event_workers_per_shard: usize,
-
-        /// Maximum routing-trie depth before dispatching to one shard.
+        /// Maximum routing-trie depth before dispatching suffixes to one shard.
+        /// K=2 is the recommended default: depth=1 often produces too few
+        /// distinct branches, while depth=2 exposes more branch diversity.
         #[clap(long, default_value = "2")]
         prefix_depth: usize,
     },
@@ -114,15 +96,6 @@ impl IndexerArgs {
                 *num_event_workers_per_shard,
                 *prefix_depth,
             ),
-            IndexerArgs::AnchorAwareBranchShardedCrtc {
-                num_shards,
-                num_event_workers_per_shard,
-                prefix_depth,
-            } => MooncakeIndexerConfig::anchor_aware_branch_sharded_crtc(
-                *num_shards,
-                *num_event_workers_per_shard,
-                *prefix_depth,
-            ),
         }
     }
 }
@@ -140,15 +113,13 @@ struct Args {
     /// Comma-separated list of indexer names to benchmark and compare on the
     /// same plot. Overrides the subcommand indexer when present. Valid names:
     /// radix-tree, nested-map, concurrent-radix-tree,
-    /// concurrent-radix-tree-compressed, branch-sharded-crtc,
-    /// anchor-aware-branch-sharded-crtc.
+    /// concurrent-radix-tree-compressed, branch-sharded-crtc.
     #[clap(long, value_delimiter = ',')]
     compare: Vec<String>,
 
     /// Number of OS threads for event processing in compare mode. Applies to
     /// indexers that use a thread pool (nested-map, concurrent-radix-tree,
-    /// concurrent-radix-tree-compressed, branch-sharded-crtc,
-    /// anchor-aware-branch-sharded-crtc).
+    /// concurrent-radix-tree-compressed, branch-sharded-crtc).
     /// Ignored by radix-tree.
     #[clap(long, default_value = "16")]
     num_event_workers: usize,

--- a/lib/bench/kv_router/mooncake_shared.rs
+++ b/lib/bench/kv_router/mooncake_shared.rs
@@ -32,7 +32,6 @@ pub enum MooncakeIndexerKind {
     ConcurrentRadixTree,
     ConcurrentRadixTreeCompressed,
     BranchShardedCrtc,
-    AnchorAwareBranchShardedCrtc,
 }
 
 #[derive(Clone, Debug)]
@@ -97,20 +96,6 @@ impl MooncakeIndexerConfig {
         }
     }
 
-    pub fn anchor_aware_branch_sharded_crtc(
-        num_shards: usize,
-        num_event_workers_per_shard: usize,
-        prefix_depth: usize,
-    ) -> Self {
-        Self {
-            kind: MooncakeIndexerKind::AnchorAwareBranchShardedCrtc,
-            num_shards,
-            num_event_workers_per_shard,
-            prefix_depth,
-            ..Self::radix_tree()
-        }
-    }
-
     pub fn short_name(&self) -> &'static str {
         match self.kind {
             MooncakeIndexerKind::RadixTree => "radix-tree",
@@ -120,7 +105,6 @@ impl MooncakeIndexerConfig {
                 "concurrent-radix-tree-compressed"
             }
             MooncakeIndexerKind::BranchShardedCrtc => "branch-sharded-crtc",
-            MooncakeIndexerKind::AnchorAwareBranchShardedCrtc => "anchor-aware-branch-sharded-crtc",
         }
     }
 
@@ -131,7 +115,6 @@ impl MooncakeIndexerConfig {
                 | MooncakeIndexerKind::ConcurrentRadixTree
                 | MooncakeIndexerKind::ConcurrentRadixTreeCompressed
                 | MooncakeIndexerKind::BranchShardedCrtc
-                | MooncakeIndexerKind::AnchorAwareBranchShardedCrtc
         )
     }
 
@@ -140,11 +123,7 @@ impl MooncakeIndexerConfig {
     }
 
     pub fn supports_approximate(&self) -> bool {
-        !matches!(
-            self.kind,
-            MooncakeIndexerKind::BranchShardedCrtc
-                | MooncakeIndexerKind::AnchorAwareBranchShardedCrtc
-        )
+        !matches!(self.kind, MooncakeIndexerKind::BranchShardedCrtc)
     }
 
     pub fn from_short_name(name: &str, num_event_workers: usize) -> anyhow::Result<Self> {
@@ -156,11 +135,8 @@ impl MooncakeIndexerConfig {
                 Self::concurrent_radix_tree_compressed(num_event_workers)
             }
             "branch-sharded-crtc" => Self::branch_sharded_crtc(2, num_event_workers, 2),
-            "anchor-aware-branch-sharded-crtc" => {
-                Self::anchor_aware_branch_sharded_crtc(2, num_event_workers, 2)
-            }
             _ => anyhow::bail!(
-                "Unknown indexer '{}'. Valid names: radix-tree, nested-map, concurrent-radix-tree, concurrent-radix-tree-compressed, branch-sharded-crtc, anchor-aware-branch-sharded-crtc",
+                "Unknown indexer '{}'. Valid names: radix-tree, nested-map, concurrent-radix-tree, concurrent-radix-tree-compressed, branch-sharded-crtc",
                 name
             ),
         };
@@ -201,23 +177,6 @@ impl MooncakeIndexerConfig {
                 ))
             }
             MooncakeIndexerKind::BranchShardedCrtc => {
-                let shards = (0..self.num_shards)
-                    .map(|_| {
-                        ThreadPoolIndexer::new_with_metrics(
-                            ConcurrentRadixTreeCompressed::new(),
-                            self.num_event_workers_per_shard,
-                            block_size,
-                            Some(Arc::clone(&metrics)),
-                        )
-                    })
-                    .collect();
-                Arc::new(BranchShardedIndexer::new_with_options(
-                    shards,
-                    self.prefix_depth,
-                    block_size,
-                ))
-            }
-            MooncakeIndexerKind::AnchorAwareBranchShardedCrtc => {
                 let shards = (0..self.num_shards)
                     .map(|_| {
                         ThreadPoolIndexer::new_with_metrics(
@@ -288,11 +247,6 @@ impl MooncakeIndexerConfig {
             }
             MooncakeIndexerKind::BranchShardedCrtc => {
                 anyhow::bail!("branch-sharded-crtc does not support approximate pruning")
-            }
-            MooncakeIndexerKind::AnchorAwareBranchShardedCrtc => {
-                anyhow::bail!(
-                    "anchor-aware-branch-sharded-crtc does not support approximate pruning"
-                )
             }
         };
         Ok(indexer)

--- a/lib/bench/tests/mooncake_trace.rs
+++ b/lib/bench/tests/mooncake_trace.rs
@@ -388,6 +388,18 @@ fn process_mooncake_trace_expands_and_duplicates_hash_space() -> anyhow::Result<
     Ok(())
 }
 
+#[test]
+fn removed_legacy_branch_sharded_name_is_rejected() {
+    let removed_name = format!("{}-{}-branch-sharded-crtc", "anchor", "aware");
+    let error = MooncakeIndexerConfig::from_short_name(&removed_name, 4).unwrap_err();
+    let message = error.to_string();
+
+    assert!(message.contains("Unknown indexer"));
+    assert!(message.contains("branch-sharded-crtc"));
+    let valid_names = message.split("Valid names: ").nth(1).unwrap_or("");
+    assert!(!valid_names.contains(&removed_name));
+}
+
 #[tokio::test(flavor = "current_thread")]
 async fn generate_replay_artifacts_waits_for_completion_delay() -> anyhow::Result<()> {
     let trace = Trace {

--- a/lib/kv-router/src/indexer/README.md
+++ b/lib/kv-router/src/indexer/README.md
@@ -347,7 +347,7 @@ let workers_at_128 = index.get(&(128, local_hashes[128]));  // O(1) lookup
 
 ## Indexer Selection Guide
 
-There are five production indexer variants. This section maps deployment scenarios to the right choice.
+There are four main production indexer shapes. This section maps deployment scenarios to the right choice.
 
 ### Variant Summary
 
@@ -356,8 +356,7 @@ There are five production indexer variants. This section maps deployment scenari
 | `RadixTree` | `RadixTree` | Single-threaded | N/A (local) | Worker-side `LocalKvIndexer`, unit tests |
 | `ConcurrentRadixTree` (CRT) | `ConcurrentRadixTree` | Thread-safe reads | N/A (local) | Single-node, moderate traffic |
 | `ThreadPoolIndexer<CRT>` (CRTC) | `ThreadPoolIndexer<ConcurrentRadixTree>` | N write threads + inline reads | Full-mesh, all workers | Default for most deployments |
-| `BranchShardedIndexer<CRTC>` (BSI) | `BranchShardedIndexer<ThreadPoolIndexer<CRT>>` | Sharded write pools | FNV prefix hash | High worker counts, approximate pruning needed |
-| `AnchorAwareBranchShardedIndexer<CRTC>` | `AnchorAwareBranchShardedIndexer<ThreadPoolIndexer<CRT>>` | Sharded write pools | Prefix-TRIE routing | High worker counts, correctness-first (no approximate pruning) |
+| `BranchShardedIndexer<CRTC>` (BSI) | `BranchShardedIndexer<ThreadPoolIndexer<CRT>>` | Sharded write pools | Prefix TRIE + anchors | High worker counts, correctness-first sharding |
 
 ### When to use each
 
@@ -377,17 +376,12 @@ There are five production indexer variants. This section maps deployment scenari
 - Does not shard; a single hot branch can become a write bottleneck at extreme scale.
 
 **`BranchShardedIndexer<CRTC>` (BSI)**
-- Routes each conversation to one shard via a fixed-depth FNV prefix hash. Read path scans one shard for the routed prefix key.
-- Enables *approximate pruning*: a shard can evict its least-recently-used entries independently without coordinating with others.
-- Use when: worker count > ~1 000, you need per-shard approximate pruning, and you can tolerate the flat-map router's shallow-chain and out-of-order limitations.
-- **Shard-crossing**: `branch_sharded.rs` stores `block_to_fnv_state` for shallow roots and registers prefix aliases for short queries, but the flat map does not provide the stronger anchor/replay model needed to guarantee every shallow continuation stays with its parent shard. Out-of-order delivery remains a caveat when a continuation arrives before its parent is known.
-- Not the right choice if you need a guarantee that every conversation stays on one shard even under out-of-order events (use anchor-aware BSI for that).
-
-**`AnchorAwareBranchShardedIndexer<CRTC>` (anchor-aware BSI)**
-- Uses a routing TRIE instead of a flat hash map. Before dispatching a continuation, it pre-installs *anchor* nodes on the target shard so the CRTC already has the parent chain at lookup time.
-- Architecturally prevents shard crossing: the routing decision is made before the event is dispatched, not after.
-- Trade-off: does **not** support approximate pruning (anchor nodes are shared state; pruning one shard would corrupt the TRIE).
-- Use when: correctness of routing is the top priority and you can live without approximate pruning.
+- Uses a bounded routing TRIE. Router-owned nodes track live workers for shallow reads, and deeper suffixes are dispatched to one shard through explicit backend anchors.
+- Before dispatching a continuation across the routing-depth boundary, BSI pre-installs the parent anchor on the target shard so the CRTC already has the parent chain at lookup time.
+- This prevents the stale shallow-prefix failure mode where a continuation is written to one shard while lookups for the finalized prefix route to another.
+- Trade-off: BSI does **not** support approximate pruning. Router anchors and shard state must stay consistent, so a shard cannot independently prune its anchored subtree without coordinating with the routing TRIE.
+- Known issue: static divergent-child assignment can still collapse a dominant hot branch onto one shard. Adaptive hot-branch splitting/rebalancing is future work.
+- Use when: worker count is high enough that one global CRTC scan is too expensive, and routing correctness is more important than approximate pruning.
 
 ### Quick decision tree
 
@@ -400,11 +394,11 @@ Start
   ├─ < ~1 000 workers, no sharding needed?
   │      └─ CRTC (ThreadPoolIndexer<ConcurrentRadixTree>)
   │
-  └─ ≥ ~1 000 workers (or want per-shard pruning)?
+  └─ ≥ ~1 000 workers or need one-shard lookups?
          │
-         ├─ Need approximate pruning / full BSI feature set?
-         │      └─ BranchShardedIndexer<CRTC>  (flat-map routing)
+         ├─ Need approximate pruning?
+         │      └─ CRTC or a future coordinated-pruning design
          │
-         └─ Need routing-correctness guarantee, no pruning needed?
-                └─ AnchorAwareBranchShardedIndexer<CRTC>
+         └─ Need routing-correct sharding without approximate pruning?
+                └─ BranchShardedIndexer<CRTC>
 ```

--- a/lib/kv-router/src/indexer/branch_sharded.rs
+++ b/lib/kv-router/src/indexer/branch_sharded.rs
@@ -1,11 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Branch-sharded routing-trie sharding over `ThreadPoolIndexer<T>`.
+//! Branch-based prefix sharding over `ThreadPoolIndexer<T>`.
 //!
-//! This implementation owns a bounded routing prefix tree that can answer
+//! [`BranchShardedIndexer`] owns a bounded routing prefix tree. It can answer
 //! shallow drained reads and route depth-boundary suffixes through explicit
-//! backend anchors.
+//! backend anchors, while keeping the public branch-sharded indexer API.
 
 use std::{
     collections::VecDeque,
@@ -540,9 +540,11 @@ impl<T: AnchorCapableSyncIndexer> BranchShardedIndexer<T> {
                 continue;
             };
             let worker = WorkerWithDpRank::new(event.worker_id, event.event.dp_rank);
-            if let Some(parent_hash) = store_data.parent_hash
-                && !dumped_blocks.contains(&(worker, parent_hash))
-            {
+            let missing_parent = match store_data.parent_hash {
+                Some(parent_hash) => !dumped_blocks.contains(&(worker, parent_hash)),
+                None => false,
+            };
+            if missing_parent {
                 continue;
             }
             for block in &store_data.blocks {
@@ -563,9 +565,7 @@ impl<T: AnchorCapableSyncIndexer> BranchShardedIndexer<T> {
             return;
         }
 
-        if decision.rewrite_for_anchor
-            && let Some(anchor) = decision.anchor
-        {
+        if let (true, Some(anchor)) = (decision.rewrite_for_anchor, decision.anchor) {
             self.ensure_worker_anchor(decision.shard_idx, worker, anchor);
             if let Some(rewritten) = self.rewritten_store_event(event, &decision) {
                 self.shards[decision.shard_idx].apply_event(rewritten).await;

--- a/lib/kv-router/src/indexer/traits.rs
+++ b/lib/kv-router/src/indexer/traits.rs
@@ -178,7 +178,7 @@ pub trait SyncIndexer: Send + Sync + 'static {
 
     /// Install a shared structural anchor for branch-sharded suffix routing.
     ///
-    /// Backends that do not support anchor-aware routing keep the default
+    /// Backends that do not support anchored routing keep the default
     /// unsupported response. This is only called by the branch-sharded wrapper
     /// when a routed subtree starts on a different shard than its parent prefix.
     fn apply_anchor(
@@ -196,7 +196,7 @@ pub trait SyncIndexer: Send + Sync + 'static {
         _suffix: &[LocalBlockHash],
     ) -> Result<OverlapScores, KvRouterError> {
         Err(KvRouterError::Unsupported(
-            "backend does not support anchor-aware find_matches".to_string(),
+            "backend does not support anchored find_matches".to_string(),
         ))
     }
 


### PR DESCRIPTION
#### Overview:

Updates all sharded indexer documentation to use the anchor-aware BSI and removes references to the old BSI flat map structure

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9335" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated benchmark documentation with new test results and performance metrics.
  * Revised indexer selection guide to reflect current production options.

* **Refactor**
  * Removed the anchor-aware variant from the indexer configuration, consolidating to a simplified set of indexer options.
  * Internal code cleanup to reflect the removal of the legacy variant.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9335)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->