### PR TITLE
test: move vLLM LLAVA E_PD to nightly

### DIFF
--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -250,7 +250,7 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                 ],
             ),
             "e_pd": TopologyConfig(
-                marks=[pytest.mark.pre_merge],
+                marks=[pytest.mark.nightly],
                 timeout_s=600,
                 gpu_marker="gpu_2",
                 # Profiled with `tests/utils/profile_pytest.py --gpus 0,1` on


### PR DESCRIPTION
failure mode --

```
The test asked:
What colors are in the following image? Respond only with the colors.

Expected at least one of:
green, white, black, purple, red, pink, yellow, blue, orange

Actual response on all 5 attempts:
No.
```
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9336" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test scheduling configuration for the LLaVA multimodal profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->