### PR TITLE
test: skip flaky migration aggregated tests, move llava mm_e_pd/mm_epd to post-merge

### DIFF
--- a/tests/fault_tolerance/migration/test_sglang.py
+++ b/tests/fault_tolerance/migration/test_sglang.py
@@ -213,6 +213,10 @@ class DynamoWorkerProcess(ManagedProcess):
 
 @pytest.mark.timeout(230)  # 3x average
 @pytest.mark.post_merge
+@pytest.mark.skip(
+    reason="Flaky: 0% post-merge pass rate across multiple parametrizations; "
+    "skipped wholesale until the underlying migration fault is owned and fixed."
+)
 def test_request_migration_sglang_aggregated(
     request,
     runtime_services_dynamic_ports,

--- a/tests/fault_tolerance/migration/test_vllm.py
+++ b/tests/fault_tolerance/migration/test_vllm.py
@@ -216,6 +216,10 @@ class DynamoWorkerProcess(ManagedProcess):
 
 @pytest.mark.timeout(290)  # 3x average
 @pytest.mark.post_merge
+@pytest.mark.skip(
+    reason="Flaky: 0% post-merge pass rate across multiple parametrizations; "
+    "skipped wholesale until the underlying migration fault is owned and fixed."
+)
 def test_request_migration_vllm_aggregated(
     request,
     runtime_services_dynamic_ports,

--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -269,7 +269,8 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                 ],
             ),
             "epd": TopologyConfig(
-                marks=[pytest.mark.pre_merge],
+                # Moved to post_merge: same LLaVA-1.5 flake as e_pd above.
+                marks=[pytest.mark.post_merge],
                 timeout_s=600,
                 gpu_marker="gpu_4",
                 # Default 3-GPU layout: encode → GPU 0, prefill → GPU 1,


### PR DESCRIPTION
#### Overview:

Two `*_aggregated` migration tests are 0% post-merge and the llava `mm_e_pd` / `mm_epd` configs are flaky in pre-merge — this PR triages both.

#### Details:

Skip both `*_aggregated` migration tests at the function level. Move `llava-1.5-7b` `e_pd` / `epd` topologies from `pre_merge` to `post_merge`.

#### Where should the reviewer start?

`tests/fault_tolerance/migration/test_sglang.py`, `tests/fault_tolerance/migration/test_vllm.py`, `tests/serve/multimodal_profiles/vllm.py`

#### Related Issues:

Refs [OPS-4472](https://linear.app/nvidia/issue/OPS-4472), [OPS-4386](https://linear.app/nvidia/issue/OPS-4386), [OPS-4520](https://linear.app/nvidia/issue/OPS-4520), [OPS-4521](https://linear.app/nvidia/issue/OPS-4521)

/coderabbit profile chill