### PR TITLE
feat(vllm): disaggregated serving on the unified backend

### DIFF
--- a/components/src/dynamo/vllm/llm_engine.py
+++ b/components/src/dynamo/vllm/llm_engine.py
@@ -154,39 +154,26 @@ class VllmLLMEngine(LLMEngine):
         )
         self._vllm_config = vllm_config
 
-        # Wrap AsyncLLM creation + post-init in try/except. Worker won't
-        # call cleanup() on a failed start(); without this any failure
-        # after AsyncLLM allocates leaves an orphan vLLM EngineCore.
         self.engine_client = AsyncLLM.from_vllm_config(
             vllm_config=vllm_config,
             usage_context=UsageContext.OPENAI_API_SERVER,
         )
-        try:
-            self._model_max_len = getattr(
-                getattr(vllm_config, "model_config", None), "max_model_len", None
-            )
+        self._model_max_len = getattr(
+            getattr(vllm_config, "model_config", None), "max_model_len", None
+        )
 
-            num_gpu_blocks = vllm_config.cache_config.num_gpu_blocks or 0
-            block_size = vllm_config.cache_config.block_size
+        num_gpu_blocks = vllm_config.cache_config.num_gpu_blocks or 0
+        block_size = vllm_config.cache_config.block_size
 
-            return EngineConfig(
-                model=self.engine_args.model,
-                served_model_name=self.engine_args.served_model_name,
-                context_length=self._model_max_len,
-                kv_cache_block_size=block_size,
-                total_kv_blocks=num_gpu_blocks,
-                max_num_seqs=vllm_config.scheduler_config.max_num_seqs,
-                max_num_batched_tokens=vllm_config.scheduler_config.max_num_batched_tokens,
-            )
-        except Exception:
-            try:
-                self.engine_client.shutdown()
-            except Exception:
-                logger.warning(
-                    "engine shutdown after start failure raised", exc_info=True
-                )
-            self.engine_client = None
-            raise
+        return EngineConfig(
+            model=self.engine_args.model,
+            served_model_name=self.engine_args.served_model_name,
+            context_length=self._model_max_len,
+            kv_cache_block_size=block_size,
+            total_kv_blocks=num_gpu_blocks,
+            max_num_seqs=vllm_config.scheduler_config.max_num_seqs,
+            max_num_batched_tokens=vllm_config.scheduler_config.max_num_batched_tokens,
+        )
 
     async def generate(
         self, request: GenerateRequest, context: Context

--- a/components/src/dynamo/vllm/llm_engine.py
+++ b/components/src/dynamo/vllm/llm_engine.py
@@ -9,16 +9,19 @@ and feature gap details.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import tempfile
 from collections.abc import AsyncGenerator
+from typing import Any
 
 from vllm.inputs import TokensPrompt
 from vllm.usage.usage_lib import UsageContext
 from vllm.v1.engine.async_llm import AsyncLLM
 
 from dynamo._core import Context
+from dynamo.common.backend.disagg import require_prefill_result
 from dynamo.common.backend.engine import (
     EngineConfig,
     GenerateChunk,
@@ -26,6 +29,7 @@ from dynamo.common.backend.engine import (
     LLMEngine,
 )
 from dynamo.common.backend.worker import WorkerConfig
+from dynamo.common.constants import DisaggregationMode
 from dynamo.llm import ModelInput
 from dynamo.vllm.args import parse_args
 
@@ -34,14 +38,71 @@ from .handlers import build_sampling_params
 logger = logging.getLogger(__name__)
 
 
+class _DeferredAbort:
+    """Holds ``engine_client.abort()`` on decode workers until first
+    engine output. Aborting mid-NIXL-transfer orphans the prefill peer.
+    Mirrors the legacy ``vllm/handlers.py:_DeferredAbort``."""
+
+    def __init__(self, engine_client: Any, request_id: str):
+        self._engine_client = engine_client
+        self._request_id = request_id
+        self._first_token_received = False
+        self._first_token_event = asyncio.Event()
+        # Strong reference so the task isn't GC'd while parked on the event.
+        self._abort_task: asyncio.Task | None = None
+
+    def signal_first_token(self) -> None:
+        if not self._first_token_received:
+            self._first_token_received = True
+            self._first_token_event.set()
+
+    def schedule_abort(self) -> None:
+        if self._abort_task is not None:
+            return
+        if self._first_token_received:
+            self._abort_task = asyncio.create_task(self._run_abort())
+        else:
+            self._abort_task = asyncio.create_task(self._wait_and_abort())
+
+    async def _wait_and_abort(self) -> None:
+        # Re-raise CancelledError so close() can cancel without firing abort.
+        await self._first_token_event.wait()
+        await self._run_abort()
+
+    async def _run_abort(self) -> None:
+        try:
+            await self._engine_client.abort(self._request_id)
+        except Exception as e:
+            logger.warning("deferred abort raised for %s: %s", self._request_id, e)
+
+    async def close(self) -> None:
+        """Called from generate's finally. Cancels a parked wait task
+        when first token never arrived; safe with no scheduled abort."""
+        if self._abort_task is None or self._abort_task.done():
+            return
+        if not self._first_token_received:
+            self._abort_task.cancel()
+        try:
+            await self._abort_task
+        except asyncio.CancelledError:
+            pass
+        except Exception as e:
+            logger.warning(
+                "deferred abort cleanup error for %s: %s", self._request_id, e
+            )
+
+
 class VllmLLMEngine(LLMEngine):
-    def __init__(self, engine_args):
+    def __init__(self, engine_args, disaggregation_mode: DisaggregationMode):
         self.engine_args = engine_args
-        self.engine_client = None
-        self._vllm_config = None
-        self._default_sampling_params = None
-        self._prometheus_temp_dir = None
-        self._model_max_len = None
+        self.disaggregation_mode = disaggregation_mode
+        self.engine_client: AsyncLLM | None = None
+        self._vllm_config: Any = None
+        self._default_sampling_params: Any = None
+        self._prometheus_temp_dir: tempfile.TemporaryDirectory[str] | None = None
+        self._model_max_len: int | None = None
+        # Populated only in decode mode.
+        self._active_aborts: dict[str, _DeferredAbort] = {}
 
     @classmethod
     async def from_args(
@@ -49,12 +110,22 @@ class VllmLLMEngine(LLMEngine):
     ) -> tuple[VllmLLMEngine, WorkerConfig]:
         config = parse_args(argv)
 
+        if config.disaggregation_mode == DisaggregationMode.ENCODE:
+            raise NotImplementedError(
+                "ENCODE is not supported by the unified vLLM entry point; "
+                "use `python -m dynamo.vllm` for multimodal encode workers"
+            )
+
         if not config.served_model_name:
             config.served_model_name = (
                 config.engine_args.served_model_name
             ) = config.model
 
-        engine = cls(config.engine_args)
+        # _resolve_disaggregation_mode() in DynamoVllmConfig has already
+        # promoted the field to a DisaggregationMode enum; the field type
+        # is still the input union, so narrow it here for mypy.
+        assert isinstance(config.disaggregation_mode, DisaggregationMode)
+        engine = cls(config.engine_args, config.disaggregation_mode)
         worker_config = WorkerConfig.from_runtime_config(
             config,
             model_name=config.model,
@@ -83,27 +154,39 @@ class VllmLLMEngine(LLMEngine):
         )
         self._vllm_config = vllm_config
 
+        # Wrap AsyncLLM creation + post-init in try/except. Worker won't
+        # call cleanup() on a failed start(); without this any failure
+        # after AsyncLLM allocates leaves an orphan vLLM EngineCore.
         self.engine_client = AsyncLLM.from_vllm_config(
             vllm_config=vllm_config,
             usage_context=UsageContext.OPENAI_API_SERVER,
         )
+        try:
+            self._model_max_len = getattr(
+                getattr(vllm_config, "model_config", None), "max_model_len", None
+            )
 
-        self._model_max_len = getattr(
-            getattr(vllm_config, "model_config", None), "max_model_len", None
-        )
+            num_gpu_blocks = vllm_config.cache_config.num_gpu_blocks or 0
+            block_size = vllm_config.cache_config.block_size
 
-        num_gpu_blocks = vllm_config.cache_config.num_gpu_blocks or 0
-        block_size = vllm_config.cache_config.block_size
-
-        return EngineConfig(
-            model=self.engine_args.model,
-            served_model_name=self.engine_args.served_model_name,
-            context_length=self._model_max_len,
-            kv_cache_block_size=block_size,
-            total_kv_blocks=num_gpu_blocks,
-            max_num_seqs=vllm_config.scheduler_config.max_num_seqs,
-            max_num_batched_tokens=vllm_config.scheduler_config.max_num_batched_tokens,
-        )
+            return EngineConfig(
+                model=self.engine_args.model,
+                served_model_name=self.engine_args.served_model_name,
+                context_length=self._model_max_len,
+                kv_cache_block_size=block_size,
+                total_kv_blocks=num_gpu_blocks,
+                max_num_seqs=vllm_config.scheduler_config.max_num_seqs,
+                max_num_batched_tokens=vllm_config.scheduler_config.max_num_batched_tokens,
+            )
+        except Exception:
+            try:
+                self.engine_client.shutdown()
+            except Exception:
+                logger.warning(
+                    "engine shutdown after start failure raised", exc_info=True
+                )
+            self.engine_client = None
+            raise
 
     async def generate(
         self, request: GenerateRequest, context: Context
@@ -121,49 +204,119 @@ class VllmLLMEngine(LLMEngine):
             dict(request), self._default_sampling_params, self._model_max_len
         )
 
+        # vLLM's KV transfer is internal to NixlConnector
+        # (--kv-transfer-config). Dispatch only sets connector hints and
+        # forwards the prefill→decode handoff payload.
+        if self.disaggregation_mode == DisaggregationMode.PREFILL:
+            if sampling_params.extra_args is None:
+                sampling_params.extra_args = {}
+            # `do_remote_decode` must be owned by prefill; setdefault the
+            # rest so a caller-supplied value wins.
+            kv_params = sampling_params.extra_args.setdefault("kv_transfer_params", {})
+            kv_params["do_remote_decode"] = True
+            for key, value in (
+                ("do_remote_prefill", False),
+                ("remote_engine_id", None),
+                ("remote_block_ids", None),
+                ("remote_host", None),
+                ("remote_port", None),
+            ):
+                kv_params.setdefault(key, value)
+            sampling_params.max_tokens = 1
+            sampling_params.min_tokens = 1
+        elif self.disaggregation_mode == DisaggregationMode.DECODE:
+            prefill_result = require_prefill_result(request, self.disaggregation_mode)
+            kv_params = prefill_result.get("disaggregated_params", {}).get(
+                "kv_transfer_params"
+            )
+            if kv_params is None:
+                raise ValueError(
+                    "decode worker received prefill_result without "
+                    "kv_transfer_params; the prefill peer must populate "
+                    "this for vLLM's NixlConnector to pull KV blocks"
+                )
+            if sampling_params.extra_args is None:
+                sampling_params.extra_args = {}
+            sampling_params.extra_args["kv_transfer_params"] = kv_params
+
         gen = self.engine_client.generate(prompt, sampling_params, request_id)
 
-        num_output_tokens_so_far: dict[int, int] = {}
-        async for res in gen:
-            if not res.outputs:
-                yield {
-                    "finish_reason": "error: No outputs from vLLM engine",
-                    "index": 0,
-                    "token_ids": [],
-                }
-                break
+        is_prefill = self.disaggregation_mode == DisaggregationMode.PREFILL
+        is_decode = self.disaggregation_mode == DisaggregationMode.DECODE
+        # Decode-only — only decode has an in-flight NIXL pull to protect.
+        # Skip the guard when the runtime didn't assign a request_id
+        # (no abort routing is possible without one).
+        abort_guard: _DeferredAbort | None = None
+        if is_decode and request_id is not None:
+            abort_guard = _DeferredAbort(self.engine_client, request_id)
+            self._active_aborts[request_id] = abort_guard
 
-            for output in res.outputs:
-                output_idx = getattr(output, "index", 0) or 0
-                previous_total = num_output_tokens_so_far.get(output_idx, 0)
-                next_total = len(output.token_ids)
-                out: GenerateChunk = {
-                    "index": output_idx,
-                    "token_ids": output.token_ids[previous_total:],
-                }
+        try:
+            num_output_tokens_so_far: dict[int, int] = {}
+            async for res in gen:
+                if abort_guard is not None:
+                    abort_guard.signal_first_token()
+                if not res.outputs:
+                    yield {
+                        "finish_reason": "error: No outputs from vLLM engine",
+                        "index": 0,
+                        "token_ids": [],
+                    }
+                    break
 
-                if output.finish_reason:
-                    out["finish_reason"] = str(output.finish_reason)
-                    prompt_tokens = (
-                        len(res.prompt_token_ids) if res.prompt_token_ids else 0
-                    )
-                    completion_tokens = sum(
-                        len(choice.token_ids) for choice in res.outputs
-                    )
-                    out["completion_usage"] = {
-                        "prompt_tokens": prompt_tokens,
-                        "completion_tokens": completion_tokens,
-                        "total_tokens": prompt_tokens + completion_tokens,
+                for output in res.outputs:
+                    output_idx = getattr(output, "index", 0) or 0
+                    previous_total = num_output_tokens_so_far.get(output_idx, 0)
+                    next_total = len(output.token_ids)
+                    out: GenerateChunk = {
+                        "index": output_idx,
+                        "token_ids": output.token_ids[previous_total:],
                     }
 
-                yield out
-                num_output_tokens_so_far[output_idx] = next_total
+                    if output.finish_reason:
+                        out["finish_reason"] = str(output.finish_reason)
+                        prompt_tokens = (
+                            len(res.prompt_token_ids) if res.prompt_token_ids else 0
+                        )
+                        completion_tokens = sum(
+                            len(choice.token_ids) for choice in res.outputs
+                        )
+                        out["completion_usage"] = {
+                            "prompt_tokens": prompt_tokens,
+                            "completion_tokens": completion_tokens,
+                            "total_tokens": prompt_tokens + completion_tokens,
+                        }
+                        # Stamp the connector's transfer handle on the
+                        # prefill terminal so PrefillRouter can forward it.
+                        if is_prefill:
+                            kv_transfer_params = getattr(
+                                res, "kv_transfer_params", None
+                            )
+                            if kv_transfer_params is not None:
+                                out["disaggregated_params"] = {  # type: ignore[typeddict-unknown-key]
+                                    "kv_transfer_params": kv_transfer_params,
+                                }
+
+                    yield out
+                    num_output_tokens_so_far[output_idx] = next_total
+        finally:
+            # Pop first so a late abort() falls through to direct
+            # engine.abort(); then close() cancels any parked wait task.
+            if abort_guard is not None and request_id is not None:
+                self._active_aborts.pop(request_id, None)
+                await abort_guard.close()
 
     async def abort(self, context: Context) -> None:
         request_id = context.id()
-        if self.engine_client is not None and request_id is not None:
+        if self.engine_client is None or request_id is None:
+            return
+        guard = self._active_aborts.get(request_id)
+        if guard is not None:
+            # Non-blocking; defers the real abort until first output.
+            guard.schedule_abort()
+        else:
             await self.engine_client.abort(request_id)
-            logger.debug("Aborted request %s", request_id)
+        logger.debug("Aborted request %s", request_id)
 
     async def cleanup(self) -> None:
         try:

--- a/components/src/dynamo/vllm/llm_engine.py
+++ b/components/src/dynamo/vllm/llm_engine.py
@@ -20,7 +20,6 @@ from vllm.usage.usage_lib import UsageContext
 from vllm.v1.engine.async_llm import AsyncLLM
 
 from dynamo._core import Context
-from dynamo.common.backend.abort import DeferredAbort
 from dynamo.common.backend.disagg import require_prefill_result
 from dynamo.common.backend.engine import (
     EngineConfig,
@@ -38,18 +37,6 @@ from .handlers import build_sampling_params
 logger = logging.getLogger(__name__)
 
 
-class VllmDeferredAbort(DeferredAbort):
-    """`DeferredAbort` for `AsyncLLM.abort(request_id)`."""
-
-    def __init__(self, engine_client: AsyncLLM, request_id: str):
-        super().__init__()
-        self._engine_client = engine_client
-        self._request_id = request_id
-
-    async def _do_abort_now(self) -> None:
-        await self._engine_client.abort(self._request_id)
-
-
 class VllmLLMEngine(LLMEngine):
     def __init__(self, engine_args, disaggregation_mode: DisaggregationMode):
         self.engine_args = engine_args
@@ -59,8 +46,6 @@ class VllmLLMEngine(LLMEngine):
         self._default_sampling_params: Any = None
         self._prometheus_temp_dir: tempfile.TemporaryDirectory[str] | None = None
         self._model_max_len: int | None = None
-        # Populated only in decode mode.
-        self._active_aborts: dict[str, VllmDeferredAbort] = {}
 
     @classmethod
     async def from_args(
@@ -191,82 +176,56 @@ class VllmLLMEngine(LLMEngine):
         gen = self.engine_client.generate(prompt, sampling_params, request_id)
 
         is_prefill = self.disaggregation_mode == DisaggregationMode.PREFILL
-        is_decode = self.disaggregation_mode == DisaggregationMode.DECODE
-        # Only decode has an in-flight NIXL pull to protect.
-        abort_guard: VllmDeferredAbort | None = None
-        if is_decode and request_id is not None:
-            abort_guard = VllmDeferredAbort(self.engine_client, request_id)
-            self._active_aborts[request_id] = abort_guard
 
-        try:
-            num_output_tokens_so_far: dict[int, int] = {}
-            first_signalled = False
-            async for res in gen:
-                if abort_guard is not None and not first_signalled:
-                    abort_guard.signal_first_token()
-                    first_signalled = True
-                if not res.outputs:
-                    yield {
-                        "finish_reason": "error: No outputs from vLLM engine",
-                        "index": 0,
-                        "token_ids": [],
+        num_output_tokens_so_far: dict[int, int] = {}
+        async for res in gen:
+            if not res.outputs:
+                yield {
+                    "finish_reason": "error: No outputs from vLLM engine",
+                    "index": 0,
+                    "token_ids": [],
+                }
+                break
+
+            for output in res.outputs:
+                output_idx = getattr(output, "index", 0) or 0
+                previous_total = num_output_tokens_so_far.get(output_idx, 0)
+                next_total = len(output.token_ids)
+                out: GenerateChunk = {
+                    "index": output_idx,
+                    "token_ids": output.token_ids[previous_total:],
+                }
+
+                if output.finish_reason:
+                    out["finish_reason"] = str(output.finish_reason)
+                    prompt_tokens = (
+                        len(res.prompt_token_ids) if res.prompt_token_ids else 0
+                    )
+                    completion_tokens = sum(
+                        len(choice.token_ids) for choice in res.outputs
+                    )
+                    out["completion_usage"] = {
+                        "prompt_tokens": prompt_tokens,
+                        "completion_tokens": completion_tokens,
+                        "total_tokens": prompt_tokens + completion_tokens,
                     }
-                    break
+                    # Stamp the connector's transfer handle on the
+                    # prefill terminal so PrefillRouter can forward it.
+                    if is_prefill:
+                        kv_transfer_params = getattr(res, "kv_transfer_params", None)
+                        if kv_transfer_params is not None:
+                            out["disaggregated_params"] = {
+                                "kv_transfer_params": kv_transfer_params,
+                            }
 
-                for output in res.outputs:
-                    output_idx = getattr(output, "index", 0) or 0
-                    previous_total = num_output_tokens_so_far.get(output_idx, 0)
-                    next_total = len(output.token_ids)
-                    out: GenerateChunk = {
-                        "index": output_idx,
-                        "token_ids": output.token_ids[previous_total:],
-                    }
-
-                    if output.finish_reason:
-                        out["finish_reason"] = str(output.finish_reason)
-                        prompt_tokens = (
-                            len(res.prompt_token_ids) if res.prompt_token_ids else 0
-                        )
-                        completion_tokens = sum(
-                            len(choice.token_ids) for choice in res.outputs
-                        )
-                        out["completion_usage"] = {
-                            "prompt_tokens": prompt_tokens,
-                            "completion_tokens": completion_tokens,
-                            "total_tokens": prompt_tokens + completion_tokens,
-                        }
-                        # Stamp the connector's transfer handle on the
-                        # prefill terminal so PrefillRouter can forward it.
-                        if is_prefill:
-                            kv_transfer_params = getattr(
-                                res, "kv_transfer_params", None
-                            )
-                            if kv_transfer_params is not None:
-                                out["disaggregated_params"] = {
-                                    "kv_transfer_params": kv_transfer_params,
-                                }
-
-                    yield out
-                    num_output_tokens_so_far[output_idx] = next_total
-        finally:
-            # Pop the guard from the lookup map BEFORE closing it. A late
-            # abort() racing on a different task would otherwise observe a
-            # half-closed guard; popping first sends that abort() down the
-            # engine-direct path instead.
-            if abort_guard is not None and request_id is not None:
-                self._active_aborts.pop(request_id, None)
-                await abort_guard.close()
+                yield out
+                num_output_tokens_so_far[output_idx] = next_total
 
     async def abort(self, context: Context) -> None:
         request_id = context.id()
-        if self.engine_client is None or request_id is None:
-            return
-        guard = self._active_aborts.get(request_id)
-        if guard is not None:
-            guard.abort()
-        else:
+        if self.engine_client is not None and request_id is not None:
             await self.engine_client.abort(request_id)
-        logger.debug("abort requested for %s", request_id)
+            logger.debug("Aborted request %s", request_id)
 
     async def cleanup(self) -> None:
         try:

--- a/components/src/dynamo/vllm/llm_engine.py
+++ b/components/src/dynamo/vllm/llm_engine.py
@@ -9,12 +9,11 @@ and feature gap details.
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import os
 import tempfile
 from collections.abc import AsyncGenerator
-from typing import Any
+from typing import Any, cast
 
 from vllm.inputs import TokensPrompt
 from vllm.usage.usage_lib import UsageContext
@@ -82,9 +81,10 @@ class VllmLLMEngine(LLMEngine):
 
         # _resolve_disaggregation_mode() in DynamoVllmConfig has already
         # promoted the field to a DisaggregationMode enum; the field type
-        # is still the input union, so narrow it here for mypy.
-        assert isinstance(config.disaggregation_mode, DisaggregationMode)
-        engine = cls(config.engine_args, config.disaggregation_mode)
+        # is still the input union, so narrow it here for mypy (cast
+        # rather than assert so `-O` builds don't drop the narrowing).
+        mode = cast(DisaggregationMode, config.disaggregation_mode)
+        engine = cls(config.engine_args, mode)
         worker_config = WorkerConfig.from_runtime_config(
             config,
             model_name=config.model,
@@ -156,18 +156,21 @@ class VllmLLMEngine(LLMEngine):
         if self.disaggregation_mode == DisaggregationMode.PREFILL:
             if sampling_params.extra_args is None:
                 sampling_params.extra_args = {}
-            # `do_remote_decode` must be owned by prefill; setdefault the
-            # rest so a caller-supplied value wins.
-            kv_params = sampling_params.extra_args.setdefault("kv_transfer_params", {})
-            kv_params["do_remote_decode"] = True
-            for key, value in (
-                ("do_remote_prefill", False),
-                ("remote_engine_id", None),
-                ("remote_block_ids", None),
-                ("remote_host", None),
-                ("remote_port", None),
-            ):
-                kv_params.setdefault(key, value)
+            # `do_remote_decode` is prefill's to own; merge caller-supplied
+            # values on top of the defaults so explicit overrides win.
+            kv_defaults = {
+                "do_remote_prefill": False,
+                "remote_engine_id": None,
+                "remote_block_ids": None,
+                "remote_host": None,
+                "remote_port": None,
+            }
+            caller_kv = sampling_params.extra_args.get("kv_transfer_params", {})
+            sampling_params.extra_args["kv_transfer_params"] = {
+                **kv_defaults,
+                **caller_kv,
+                "do_remote_decode": True,
+            }
             sampling_params.max_tokens = 1
             sampling_params.min_tokens = 1
         elif self.disaggregation_mode == DisaggregationMode.DECODE:
@@ -239,14 +242,17 @@ class VllmLLMEngine(LLMEngine):
                                 res, "kv_transfer_params", None
                             )
                             if kv_transfer_params is not None:
-                                out["disaggregated_params"] = {  # type: ignore[typeddict-unknown-key]
+                                out["disaggregated_params"] = {
                                     "kv_transfer_params": kv_transfer_params,
                                 }
 
                     yield out
                     num_output_tokens_so_far[output_idx] = next_total
         finally:
-            # pop before close(); ordering matters for late abort()
+            # Pop the guard from the lookup map BEFORE closing it. A late
+            # abort() racing on a different task would otherwise observe a
+            # half-closed guard; popping first sends that abort() down the
+            # engine-direct path instead.
             if abort_guard is not None and request_id is not None:
                 self._active_aborts.pop(request_id, None)
                 await abort_guard.close()

--- a/components/src/dynamo/vllm/llm_engine.py
+++ b/components/src/dynamo/vllm/llm_engine.py
@@ -21,6 +21,7 @@ from vllm.usage.usage_lib import UsageContext
 from vllm.v1.engine.async_llm import AsyncLLM
 
 from dynamo._core import Context
+from dynamo.common.backend.abort import DeferredAbort
 from dynamo.common.backend.disagg import require_prefill_result
 from dynamo.common.backend.engine import (
     EngineConfig,
@@ -38,58 +39,16 @@ from .handlers import build_sampling_params
 logger = logging.getLogger(__name__)
 
 
-class _DeferredAbort:
-    """Holds ``engine_client.abort()`` on decode workers until first
-    engine output. Aborting mid-NIXL-transfer orphans the prefill peer.
-    Mirrors the legacy ``vllm/handlers.py:_DeferredAbort``."""
+class VllmDeferredAbort(DeferredAbort):
+    """`DeferredAbort` for `AsyncLLM.abort(request_id)`."""
 
-    def __init__(self, engine_client: Any, request_id: str):
+    def __init__(self, engine_client: AsyncLLM, request_id: str):
+        super().__init__()
         self._engine_client = engine_client
         self._request_id = request_id
-        self._first_token_received = False
-        self._first_token_event = asyncio.Event()
-        # Strong reference so the task isn't GC'd while parked on the event.
-        self._abort_task: asyncio.Task | None = None
 
-    def signal_first_token(self) -> None:
-        if not self._first_token_received:
-            self._first_token_received = True
-            self._first_token_event.set()
-
-    def schedule_abort(self) -> None:
-        if self._abort_task is not None:
-            return
-        if self._first_token_received:
-            self._abort_task = asyncio.create_task(self._run_abort())
-        else:
-            self._abort_task = asyncio.create_task(self._wait_and_abort())
-
-    async def _wait_and_abort(self) -> None:
-        # Re-raise CancelledError so close() can cancel without firing abort.
-        await self._first_token_event.wait()
-        await self._run_abort()
-
-    async def _run_abort(self) -> None:
-        try:
-            await self._engine_client.abort(self._request_id)
-        except Exception as e:
-            logger.warning("deferred abort raised for %s: %s", self._request_id, e)
-
-    async def close(self) -> None:
-        """Called from generate's finally. Cancels a parked wait task
-        when first token never arrived; safe with no scheduled abort."""
-        if self._abort_task is None or self._abort_task.done():
-            return
-        if not self._first_token_received:
-            self._abort_task.cancel()
-        try:
-            await self._abort_task
-        except asyncio.CancelledError:
-            pass
-        except Exception as e:
-            logger.warning(
-                "deferred abort cleanup error for %s: %s", self._request_id, e
-            )
+    async def _do_abort_now(self) -> None:
+        await self._engine_client.abort(self._request_id)
 
 
 class VllmLLMEngine(LLMEngine):
@@ -102,7 +61,7 @@ class VllmLLMEngine(LLMEngine):
         self._prometheus_temp_dir: tempfile.TemporaryDirectory[str] | None = None
         self._model_max_len: int | None = None
         # Populated only in decode mode.
-        self._active_aborts: dict[str, _DeferredAbort] = {}
+        self._active_aborts: dict[str, VllmDeferredAbort] = {}
 
     @classmethod
     async def from_args(
@@ -230,19 +189,19 @@ class VllmLLMEngine(LLMEngine):
 
         is_prefill = self.disaggregation_mode == DisaggregationMode.PREFILL
         is_decode = self.disaggregation_mode == DisaggregationMode.DECODE
-        # Decode-only — only decode has an in-flight NIXL pull to protect.
-        # Skip the guard when the runtime didn't assign a request_id
-        # (no abort routing is possible without one).
-        abort_guard: _DeferredAbort | None = None
+        # Only decode has an in-flight NIXL pull to protect.
+        abort_guard: VllmDeferredAbort | None = None
         if is_decode and request_id is not None:
-            abort_guard = _DeferredAbort(self.engine_client, request_id)
+            abort_guard = VllmDeferredAbort(self.engine_client, request_id)
             self._active_aborts[request_id] = abort_guard
 
         try:
             num_output_tokens_so_far: dict[int, int] = {}
+            first_signalled = False
             async for res in gen:
-                if abort_guard is not None:
+                if abort_guard is not None and not first_signalled:
                     abort_guard.signal_first_token()
+                    first_signalled = True
                 if not res.outputs:
                     yield {
                         "finish_reason": "error: No outputs from vLLM engine",
@@ -287,8 +246,7 @@ class VllmLLMEngine(LLMEngine):
                     yield out
                     num_output_tokens_so_far[output_idx] = next_total
         finally:
-            # Pop first so a late abort() falls through to direct
-            # engine.abort(); then close() cancels any parked wait task.
+            # pop before close(); ordering matters for late abort()
             if abort_guard is not None and request_id is not None:
                 self._active_aborts.pop(request_id, None)
                 await abort_guard.close()
@@ -299,11 +257,10 @@ class VllmLLMEngine(LLMEngine):
             return
         guard = self._active_aborts.get(request_id)
         if guard is not None:
-            # Non-blocking; defers the real abort until first output.
-            guard.schedule_abort()
+            guard.abort()
         else:
             await self.engine_client.abort(request_id)
-        logger.debug("Aborted request %s", request_id)
+        logger.debug("abort requested for %s", request_id)
 
     async def cleanup(self) -> None:
         try:

--- a/components/src/dynamo/vllm/tests/test_vllm_engine.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_engine.py
@@ -141,3 +141,41 @@ async def test_abort_unknown_request_on_running_engine(started_engine):
     id the engine has never seen must not raise."""
     engine, _ = started_engine
     await engine.abort(cast(object, _FakeContext("never-submitted")))  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "mode_arg, expected",
+    [
+        ("agg", "AGGREGATED"),
+        ("prefill", "PREFILL"),
+        ("decode", "DECODE"),
+    ],
+)
+async def test_from_args_propagates_disaggregation_mode_to_worker_config(
+    mode_arg, expected
+):
+    """``--disaggregation-mode`` must flow from CLI through to the
+    ``WorkerConfig`` the unified Worker sees, and onto the engine instance
+    so ``generate()`` can branch on it. Without this hookup the prefill
+    role would silently degrade to aggregated."""
+    from dynamo.common.constants import DisaggregationMode
+    from dynamo.vllm.llm_engine import VllmLLMEngine
+
+    extra_args: list[str] = []
+    # vLLM rejects --disaggregation-mode prefill without an explicit
+    # --kv-transfer-config; supply NixlConnector to satisfy the validator.
+    if mode_arg == "prefill":
+        extra_args = [
+            "--kv-transfer-config",
+            '{"kv_connector":"NixlConnector","kv_role":"kv_both"}',
+        ]
+
+    engine, worker_config = await VllmLLMEngine.from_args(
+        [*_BASE_ARGV, "--disaggregation-mode", mode_arg, *extra_args]
+    )
+    try:
+        expected_mode = getattr(DisaggregationMode, expected)
+        assert engine.disaggregation_mode is expected_mode
+        assert worker_config.disaggregation_mode is expected_mode
+    finally:
+        await engine.cleanup()

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -3,6 +3,7 @@
 
 """Unit tests for vLLM backend components."""
 
+import asyncio
 import json
 import re
 import socket
@@ -10,7 +11,7 @@ import sys
 import warnings
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -24,6 +25,7 @@ from dynamo.vllm.args import (
     parse_args,
 )
 from dynamo.vllm.constants import DisaggregationMode
+from dynamo.vllm.llm_engine import VllmDeferredAbort
 from dynamo.vllm.tests.conftest import make_cli_args_fixture
 
 # Get path relative to this test file
@@ -723,3 +725,14 @@ class TestBenchmarkGrid:
         total_kv = 100 * 16
         for ctx_len, bs in points:
             assert ctx_len <= total_kv
+
+
+@pytest.mark.asyncio
+async def test_vllm_deferred_abort_invokes_engine_abort():
+    """`VllmDeferredAbort._do_abort_now` forwards to `AsyncLLM.abort(rid)`."""
+    engine_client = AsyncMock()
+    guard = VllmDeferredAbort(engine_client, "req-abc")
+    guard.signal_first_token()
+    guard.abort()
+    await asyncio.sleep(0)
+    engine_client.abort.assert_awaited_once_with("req-abc")

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -3,7 +3,6 @@
 
 """Unit tests for vLLM backend components."""
 
-import asyncio
 import json
 import re
 import socket
@@ -11,7 +10,7 @@ import sys
 import warnings
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -25,7 +24,6 @@ from dynamo.vllm.args import (
     parse_args,
 )
 from dynamo.vllm.constants import DisaggregationMode
-from dynamo.vllm.llm_engine import VllmDeferredAbort
 from dynamo.vllm.tests.conftest import make_cli_args_fixture
 
 # Get path relative to this test file
@@ -725,14 +723,3 @@ class TestBenchmarkGrid:
         total_kv = 100 * 16
         for ctx_len, bs in points:
             assert ctx_len <= total_kv
-
-
-@pytest.mark.asyncio
-async def test_vllm_deferred_abort_invokes_engine_abort():
-    """`VllmDeferredAbort._do_abort_now` forwards to `AsyncLLM.abort(rid)`."""
-    engine_client = AsyncMock()
-    guard = VllmDeferredAbort(engine_client, "req-abc")
-    guard.signal_first_token()
-    guard.abort()
-    await asyncio.sleep(0)
-    engine_client.abort.assert_awaited_once_with("req-abc")

--- a/examples/backends/vllm/launch/disagg.sh
+++ b/examples/backends/vllm/launch/disagg.sh
@@ -9,43 +9,23 @@ MODEL="Qwen/Qwen3-0.6B"
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 source "$SCRIPT_DIR/../../../common/launch_utils.sh"
 
-# Parse command line arguments BEFORE installing the kill-process-group
-# EXIT trap — `--help` and unknown-option early exits would otherwise
-# kill the caller's process group before any worker is even launched.
-USE_UNIFIED=false
-while [[ $# -gt 0 ]]; do
-    case $1 in
-        --unified)
-            # Run the workers via the unified entry point
-            # (`python -m dynamo.vllm.unified_main`) so disagg goes through
-            # the new dynamo.common.backend / dynamo_backend_common path
-            # instead of the legacy main.py / WorkerFactory dispatch.
-            USE_UNIFIED=true
-            shift
-            ;;
-        -h|--help)
-            echo "Usage: $0 [OPTIONS]"
-            echo "Options:"
-            echo "  --unified            Use the unified backend entry point"
-            echo "                       (python -m dynamo.vllm.unified_main)"
-            echo "  -h, --help           Show this help message"
-            exit 0
-            ;;
-        *)
-            echo "Unknown option: $1"
-            echo "Use --help for usage information"
-            exit 1
-            ;;
-    esac
-done
+# Consume --unified and handle --help BEFORE installing the
+# kill-process-group EXIT trap; an early exit would otherwise tear down
+# the caller's process group.
+pick_worker_module dynamo.vllm dynamo.vllm.unified_main "$@"
+set -- "${REMAINING_ARGS[@]}"
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    echo "Usage: $0 [--unified]"
+    echo "  --unified  Use the unified backend entry point (python -m dynamo.vllm.unified_main)"
+    exit 0
+fi
+if [[ $# -gt 0 ]]; then
+    echo "Unknown option: $1"
+    exit 1
+fi
 
 trap 'echo Cleaning up...; kill 0' EXIT
-
-if [ "$USE_UNIFIED" = true ]; then
-    WORKER_MODULE="dynamo.vllm.unified_main"
-else
-    WORKER_MODULE="dynamo.vllm"
-fi
 
 HTTP_PORT="${DYN_HTTP_PORT:-8000}"
 print_launch_banner "Launching Disaggregated Serving (2 GPUs)" "$MODEL" "$HTTP_PORT"

--- a/examples/backends/vllm/launch/disagg.sh
+++ b/examples/backends/vllm/launch/disagg.sh
@@ -2,13 +2,50 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 set -e
-trap 'echo Cleaning up...; kill 0' EXIT
 
 # Common configuration
 MODEL="Qwen/Qwen3-0.6B"
 
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 source "$SCRIPT_DIR/../../../common/launch_utils.sh"
+
+# Parse command line arguments BEFORE installing the kill-process-group
+# EXIT trap — `--help` and unknown-option early exits would otherwise
+# kill the caller's process group before any worker is even launched.
+USE_UNIFIED=false
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --unified)
+            # Run the workers via the unified entry point
+            # (`python -m dynamo.vllm.unified_main`) so disagg goes through
+            # the new dynamo.common.backend / dynamo_backend_common path
+            # instead of the legacy main.py / WorkerFactory dispatch.
+            USE_UNIFIED=true
+            shift
+            ;;
+        -h|--help)
+            echo "Usage: $0 [OPTIONS]"
+            echo "Options:"
+            echo "  --unified            Use the unified backend entry point"
+            echo "                       (python -m dynamo.vllm.unified_main)"
+            echo "  -h, --help           Show this help message"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Use --help for usage information"
+            exit 1
+            ;;
+    esac
+done
+
+trap 'echo Cleaning up...; kill 0' EXIT
+
+if [ "$USE_UNIFIED" = true ]; then
+    WORKER_MODULE="dynamo.vllm.unified_main"
+else
+    WORKER_MODULE="dynamo.vllm"
+fi
 
 HTTP_PORT="${DYN_HTTP_PORT:-8000}"
 print_launch_banner "Launching Disaggregated Serving (2 GPUs)" "$MODEL" "$HTTP_PORT"
@@ -20,7 +57,7 @@ python -m dynamo.frontend &
 # --enforce-eager is added for quick deployment. for production use, need to remove this flag
 # TODO: use build_vllm_gpu_mem_args to measure VRAM instead of relying on vLLM defaults
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT1:-8081} \
-CUDA_VISIBLE_DEVICES=0 python3 -m dynamo.vllm \
+CUDA_VISIBLE_DEVICES=0 python3 -m "$WORKER_MODULE" \
     --model "$MODEL" \
     --enforce-eager \
     --disaggregation-mode decode \
@@ -28,7 +65,7 @@ CUDA_VISIBLE_DEVICES=0 python3 -m dynamo.vllm \
 
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT2:-8082} \
 VLLM_NIXL_SIDE_CHANNEL_PORT=20097 \
-CUDA_VISIBLE_DEVICES=1 python3 -m dynamo.vllm \
+CUDA_VISIBLE_DEVICES=1 python3 -m "$WORKER_MODULE" \
     --model "$MODEL" \
     --enforce-eager \
     --disaggregation-mode prefill \


### PR DESCRIPTION
## PR stack

- #9249 — backend abstraction (base: `main`)
- **#9347 (this PR)** — vLLM engine
- #9348 — SGLang engine
- #9349 — TRT-LLM engine

Each engine PR is stacked on #9249. The three engine PRs are independent of each other and can be reviewed in parallel.

## Summary

Wires `VllmLLMEngine` into the unified disagg framework introduced
in #9249. vLLM's KV transfer happens transparently inside the engine
via NixlConnector (configured via `--kv-transfer-config`); the
Dynamo layer's job is per-mode dispatch and connecting the prefill
response handoff to the frontend's PrefillRouter.

## Per-mode behavior

- **PREFILL** — tag `kv_transfer_params` with `do_remote_decode`,
  cap `max_tokens=min_tokens=1`, stamp the connector's transfer
  handle on the terminal chunk's `disaggregated_params`.
- **DECODE** — pull `kv_transfer_params` from
  `request.prefill_result.disaggregated_params`, pass through to
  the engine. Wrap abort in `_DeferredAbort` so cancels arriving
  before first output don't orphan an in-flight NIXL transfer.
- **AGGREGATED** — existing path, no branching.
- **ENCODE** — rejected at parse time with a pointer to the legacy
  entry point.

`_DeferredAbort` mirrors `vllm/handlers.py:_DeferredAbort` —
spawns a wait-and-fire task, with a `close()` hook in generate's
finally that cancels the parked task without firing abort if the
request errored before producing output.

Launch: `examples/backends/vllm/launch/disagg.sh --unified` runs
through `python -m dynamo.vllm.unified_main`.

## Test plan

### Unit tests

- [x] Parametrised `test_vllm_engine.py` covers all three disaggregation modes through `from_args` + start-config plumbing.
- [x] `_DeferredAbort` lifecycle smoke (4 cases):
  - first-token → schedule_abort → fires immediately
  - schedule_abort → first-token → fires after first token
  - schedule_abort → close (no token) → cancels wait, abort NOT fired
  - close with no abort scheduled → no-op

### End-to-end: `disagg.sh --unified`

Launched two workers on a single RTX 5880 Ada (48GB) via the `test-unified-disagg` skill harness — `MODEL_NAME=Qwen/Qwen3-0.6B`, `gpu_memory_utilization=0.30` per worker, distinct `VLLM_NIXL_SIDE_CHANNEL_PORT` per worker:

```bash
docker exec dynamo-vllm-cancel bash -c '
  curl -sS -X POST http://localhost:8000/v1/chat/completions \
    -H "Content-Type: application/json" \
    -d "{\"model\":\"Qwen/Qwen3-0.6B\",
         \"messages\":[{\"role\":\"user\",\"content\":\"Reply with the single word: ping\"}],
         \"max_tokens\":10,\"stream\":false}"'
```

Response: 200 OK, valid `chat.completion` body (`prompt_tokens=15, completion_tokens=10`).

Prefill→decode handoff confirmed in logs:

```
prefill.log: request received  rid=4782dc29-... component=prefill   instance_id=7587894708860467211
prefill.log: request completed rid=4782dc29-... component=prefill
decode.log:  request received  rid=4782dc29-... component=backend   instance_id=...
decode.log:  request completed rid=4782dc29-...
```

Same `request_id` flows from prefill (component=`prefill`) to decode (component=`backend`), confirming the frontend's `PrefillRouter` extracted the prefill peer's `kv_transfer_params` and forwarded them under `prefill_result.disaggregated_params`.

### Mid-stream cancel (validates `_DeferredAbort.close()`)

5 concurrent `timeout 0.05 curl ...` requests with `max_tokens=512, stream=true` — all 5 land on the decode worker, all 5 log `Failed to publish response for stream` (consumer disconnect) followed immediately by `request completed` (~70ms each). Subsequent SIGTERM produces a clean shutdown sequence:

```
Received shutdown signal; running graceful orchestration
Endpoint unregistered from discovery
Engine cleanup complete
Phase 3: All endpoints ended gracefully
```

No wedged abort tasks. Pre-existing post-Worker.run() interpreter hang is tracked separately in #9343.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9347" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

