### PR TITLE
feat(sglang): disaggregated serving on the unified backend

### DIFF
--- a/components/src/dynamo/sglang/_disagg.py
+++ b/components/src/dynamo/sglang/_disagg.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Disaggregation helpers shared by the legacy (`init_llm.py`,
+`register.py`) and unified (`llm_engine.py`) entry points.
+
+Two helpers:
+
+* :func:`compute_bootstrap_address` — resolve the `(host, port)` triple a
+  prefill worker advertises to decode peers from a live `sgl.Engine`.
+  Returns `(None, None)` on any failure so legacy callers can keep their
+  graceful-degradation behaviour; the unified path treats `None` as a
+  fatal configuration error and raises.
+
+* :func:`warmup_prefill_engine` — drive one request through the disagg
+  path with SGLang's `FAKE_BOOTSTRAP_HOST` so the first real request
+  doesn't pay the JIT/CUDA-graph compile cost.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Optional
+
+import sglang as sgl
+
+from dynamo.sglang._compat import NetworkAddress, get_local_ip_auto
+
+# Matches the prior in-tree value. Long enough for the slowest cold-start
+# we've seen (TP8 70B with FlashInfer JIT).
+_PREFILL_WARMUP_TIMEOUT_S = 1800.0
+
+
+def compute_bootstrap_address(
+    engine: sgl.Engine,
+) -> tuple[Optional[str], Optional[int]]:
+    """Return `(host, port)` for this prefill worker's bootstrap address.
+
+    Returns `(None, None)` when the engine doesn't advertise a
+    `disaggregation_bootstrap_port` or when address resolution raises.
+    Caller decides whether `None` is fatal — legacy `register.py` treats
+    it as soft-skip; the unified path treats it as a fatal misconfig.
+    """
+    try:
+        inner_tm = engine.tokenizer_manager
+        bootstrap_port = getattr(
+            inner_tm.server_args, "disaggregation_bootstrap_port", None
+        )
+        if bootstrap_port is None:
+            return None, None
+
+        if inner_tm.server_args.dist_init_addr:
+            dist_init = NetworkAddress.parse(inner_tm.server_args.dist_init_addr)
+            resolved = dist_init.resolved()
+            bootstrap_host = (
+                NetworkAddress(resolved.host, bootstrap_port)
+                .to_host_port_str()
+                .rsplit(":", 1)[0]
+            )
+            logging.info(
+                "Resolved bootstrap host '%s' -> '%s' (%s)",
+                dist_init.host,
+                resolved.host,
+                "IPv6" if resolved.is_ipv6 else "IPv4",
+            )
+        else:
+            # SGLANG_HOST_IP overrides auto-detection (use bracketed [addr]
+            # for IPv6); falls back to a v4-then-v6 probe.
+            local_ip = get_local_ip_auto()
+            local_addr = NetworkAddress(local_ip, bootstrap_port)
+            bootstrap_host = local_addr.to_host_port_str().rsplit(":", 1)[0]
+            logging.info(
+                "Using auto-detected local IP: %s (%s)",
+                local_ip,
+                "IPv6" if local_addr.is_ipv6 else "IPv4",
+            )
+        return bootstrap_host, bootstrap_port
+    except Exception as e:
+        logging.warning("Failed to compute bootstrap address: %s", e)
+        return None, None
+
+
+async def warmup_prefill_engine(engine: sgl.Engine, bootstrap_port: int) -> None:
+    """Drive one request through the prefill disagg path with SGLang's
+    `FAKE_BOOTSTRAP_HOST` so JIT/CUDA-graph compile happens before the
+    first real request. Raises on timeout/failure — an unwarmed prefill
+    silently drops production requests."""
+    from sglang.srt.disaggregation.utils import FAKE_BOOTSTRAP_HOST
+
+    sampling_params = {
+        "temperature": 0.0,
+        "max_new_tokens": 8,
+        "ignore_eos": True,
+    }
+
+    async def _do_warmup() -> None:
+        results = await engine.async_generate(
+            input_ids=[0, 1, 2, 3],
+            sampling_params=sampling_params,
+            stream=True,
+            bootstrap_host=FAKE_BOOTSTRAP_HOST,
+            bootstrap_port=bootstrap_port,
+            bootstrap_room=999999,
+        )
+        async for _ in results:
+            pass
+
+    logging.info("SGLang prefill warmup starting...")
+    await asyncio.wait_for(_do_warmup(), timeout=_PREFILL_WARMUP_TIMEOUT_S)
+    logging.info("SGLang prefill warmup complete")

--- a/components/src/dynamo/sglang/init_llm.py
+++ b/components/src/dynamo/sglang/init_llm.py
@@ -28,31 +28,12 @@ async def _warmup_prefill_engine(engine: sgl.Engine, server_args) -> None:
     """Perform warmup request for prefill engine to reduce initial TTFT.
 
     Raises on failure so the caller can prevent the worker from registering
-    with a broken engine (silent request drops).
+    with a broken engine (silent request drops). Shared with the unified
+    backend (`dynamo.sglang.llm_engine`) via `_disagg.warmup_prefill_engine`.
     """
-    logging.info("Start of prefill disaggregation warmup ...")
-    from sglang.srt.disaggregation.utils import FAKE_BOOTSTRAP_HOST
+    from dynamo.sglang._disagg import warmup_prefill_engine
 
-    sampling_params = {
-        "temperature": 0.0,
-        "max_new_tokens": 8,
-        "ignore_eos": True,
-    }
-
-    async def _do_warmup():
-        results = await engine.async_generate(
-            input_ids=[0, 1, 2, 3],
-            sampling_params=sampling_params,
-            stream=True,
-            bootstrap_host=FAKE_BOOTSTRAP_HOST,
-            bootstrap_port=server_args.disaggregation_bootstrap_port,
-            bootstrap_room=999999,
-        )
-        async for _ in results:
-            pass
-
-    await asyncio.wait_for(_do_warmup(), timeout=1800)
-    logging.info("Prefill warmup completed")
+    await warmup_prefill_engine(engine, server_args.disaggregation_bootstrap_port)
 
 
 async def init_decode(

--- a/components/src/dynamo/sglang/llm_engine.py
+++ b/components/src/dynamo/sglang/llm_engine.py
@@ -21,7 +21,6 @@ from typing import Any
 import sglang as sgl
 
 from dynamo._core import Context
-from dynamo.common.backend.abort import DeferredAbort
 from dynamo.common.backend.engine import (
     EngineConfig,
     GenerateChunk,
@@ -53,18 +52,6 @@ def _warmup_enabled() -> bool:
     return raw.strip().lower() not in ("1", "true", "yes", "on")
 
 
-class SglangDeferredAbort(DeferredAbort):
-    """`DeferredAbort` for `tokenizer_manager.abort_request(rid=...)`."""
-
-    def __init__(self, tokenizer_manager: Any, rid: str):
-        super().__init__()
-        self._tokenizer_manager = tokenizer_manager
-        self._rid = rid
-
-    async def _do_abort_now(self) -> None:
-        self._tokenizer_manager.abort_request(rid=self._rid, abort_all=False)
-
-
 class SglangLLMEngine(LLMEngine):
     def __init__(self, server_args, dynamo_args, serving_mode: DisaggregationMode):
         self.server_args = server_args
@@ -80,7 +67,6 @@ class SglangLLMEngine(LLMEngine):
         # Background drain tasks for prefill stream after the bootstrap
         # chunk yields (Completed path only). Cancelled in cleanup().
         self._prefill_consume_tasks: set[asyncio.Task[Any]] = set()
-        self._active_aborts: dict[str, SglangDeferredAbort] = {}
 
     @classmethod
     async def from_args(
@@ -205,62 +191,20 @@ class SglangLLMEngine(LLMEngine):
             task.add_done_callback(self._prefill_consume_tasks.discard)
             return
 
-        # Only decode has an in-flight NIXL pull to protect.
-        is_decode = self.serving_mode == DisaggregationMode.DECODE
-        rid = context.trace_id
-        tokenizer_manager = getattr(self.engine, "tokenizer_manager", None)
-        abort_guard: SglangDeferredAbort | None = None
-        if is_decode and rid is not None and tokenizer_manager is not None:
-            abort_guard = SglangDeferredAbort(tokenizer_manager, rid)
-            self._active_aborts[rid] = abort_guard
+        async for res in stream:
+            # SGLang sets index when n>1; default to 0 otherwise.
+            output_idx = res.get("index") or 0
+            out: GenerateChunk = {"token_ids": [], "index": output_idx}
+            meta_info = res["meta_info"]
+            finish_reason = meta_info["finish_reason"]
 
-        first_signalled = False
-        try:
-            async for res in stream:
-                if abort_guard is not None and not first_signalled:
-                    abort_guard.signal_first_token()
-                    first_signalled = True
-                # SGLang sets index when n>1; default to 0 otherwise.
-                output_idx = res.get("index") or 0
-                out: GenerateChunk = {"token_ids": [], "index": output_idx}
-                meta_info = res["meta_info"]
-                finish_reason = meta_info["finish_reason"]
-
-                output_ids = res.get("output_ids", [])
-                if not output_ids and not finish_reason:
-                    if context.is_stopped():
-                        prompt_tokens = meta_info.get("prompt_tokens", 0)
-                        completion_tokens = meta_info.get("completion_tokens", 0)
-                        yield {
-                            "token_ids": [],
-                            "index": output_idx,
-                            "finish_reason": "cancelled",
-                            "completion_usage": {
-                                "prompt_tokens": prompt_tokens,
-                                "completion_tokens": completion_tokens,
-                                "total_tokens": prompt_tokens + completion_tokens,
-                            },
-                        }
-                        break
-                    continue
-
-                out["token_ids"] = output_ids
-
-                if finish_reason:
-                    prompt_tokens = meta_info["prompt_tokens"]
-                    completion_tokens = meta_info["completion_tokens"]
-                    out["finish_reason"] = finish_reason["type"]
-                    out["completion_usage"] = {
-                        "prompt_tokens": prompt_tokens,
-                        "completion_tokens": completion_tokens,
-                        "total_tokens": prompt_tokens + completion_tokens,
-                    }
-
+            output_ids = res.get("output_ids", [])
+            if not output_ids and not finish_reason:
                 if context.is_stopped():
                     prompt_tokens = meta_info.get("prompt_tokens", 0)
                     completion_tokens = meta_info.get("completion_tokens", 0)
                     yield {
-                        "token_ids": output_ids,
+                        "token_ids": [],
                         "index": output_idx,
                         "finish_reason": "cancelled",
                         "completion_usage": {
@@ -270,30 +214,45 @@ class SglangLLMEngine(LLMEngine):
                         },
                     }
                     break
+                continue
 
-                yield out
-        finally:
-            # Pop the guard from the lookup map BEFORE closing it. A late
-            # abort() racing on a different task would otherwise observe a
-            # half-closed guard; popping first sends that abort() down the
-            # engine-direct path instead.
-            if abort_guard is not None and rid is not None:
-                self._active_aborts.pop(rid, None)
-                await abort_guard.close()
+            out["token_ids"] = output_ids
+
+            if finish_reason:
+                prompt_tokens = meta_info["prompt_tokens"]
+                completion_tokens = meta_info["completion_tokens"]
+                out["finish_reason"] = finish_reason["type"]
+                out["completion_usage"] = {
+                    "prompt_tokens": prompt_tokens,
+                    "completion_tokens": completion_tokens,
+                    "total_tokens": prompt_tokens + completion_tokens,
+                }
+
+            if context.is_stopped():
+                prompt_tokens = meta_info.get("prompt_tokens", 0)
+                completion_tokens = meta_info.get("completion_tokens", 0)
+                yield {
+                    "token_ids": output_ids,
+                    "index": output_idx,
+                    "finish_reason": "cancelled",
+                    "completion_usage": {
+                        "prompt_tokens": prompt_tokens,
+                        "completion_tokens": completion_tokens,
+                        "total_tokens": prompt_tokens + completion_tokens,
+                    },
+                }
+                break
+
+            yield out
 
     async def abort(self, context: Context) -> None:
         rid = context.trace_id
         if self.engine is None or rid is None:
             return
         tokenizer_manager = getattr(self.engine, "tokenizer_manager", None)
-        if tokenizer_manager is None:
-            return
-        guard = self._active_aborts.get(rid)
-        if guard is not None:
-            guard.abort()
-        else:
+        if tokenizer_manager is not None:
             tokenizer_manager.abort_request(rid=rid, abort_all=False)
-        logger.debug("abort requested for %s", rid)
+            logger.debug("Aborted request %s", rid)
 
     async def drain(self) -> None:
         """Await background prefill consume tasks before cleanup (#7319)."""

--- a/components/src/dynamo/sglang/llm_engine.py
+++ b/components/src/dynamo/sglang/llm_engine.py
@@ -32,16 +32,11 @@ from dynamo.common.backend.worker import WorkerConfig
 from dynamo.common.constants import DisaggregationMode
 from dynamo.common.utils.input_params import InputParamManager
 from dynamo.llm import ModelInput
-from dynamo.sglang._compat import NetworkAddress, get_local_ip_auto, get_scheduler_info
+from dynamo.sglang._compat import get_scheduler_info
+from dynamo.sglang._disagg import compute_bootstrap_address, warmup_prefill_engine
 from dynamo.sglang.args import parse_args
 
 logger = logging.getLogger(__name__)
-
-# Mirrors `_warmup_prefill_engine` in init_llm.py — must finish before the
-# prefill worker starts serving so the first real request doesn't pay the
-# JIT/CUDA-graph compile cost. SGLang's FAKE_BOOTSTRAP_HOST drives the
-# warmup through the disagg path without needing a real decode peer.
-_PREFILL_WARMUP_TIMEOUT_S = 1800.0
 
 # Bound on prefill drain during graceful shutdown. After this, force-cancel
 # any still-running consume tasks. Matches TRT-LLM's drain timeout.
@@ -121,14 +116,16 @@ class SglangLLMEngine(LLMEngine):
         self._input_param_manager = InputParamManager(tokenizer)
 
         if self.serving_mode == DisaggregationMode.PREFILL:
-            # Cache bootstrap host/port; warm the engine to avoid first-
-            # request JIT/cuda-graph compile latency.
-            (
-                self._bootstrap_host,
-                self._bootstrap_port,
-            ) = self._resolve_bootstrap_info()
+            self._bootstrap_host, self._bootstrap_port = compute_bootstrap_address(
+                self.engine
+            )
+            if self._bootstrap_host is None or self._bootstrap_port is None:
+                raise RuntimeError(
+                    "prefill worker could not resolve bootstrap host/port; "
+                    "SGLang server_args.disaggregation_bootstrap_port is unset"
+                )
             if _warmup_enabled():
-                await self._warmup_prefill()
+                await warmup_prefill_engine(self.engine, self._bootstrap_port)
             else:
                 logger.info(
                     "Skipping SGLang prefill warmup (%s set)",
@@ -192,7 +189,7 @@ class SglangLLMEngine(LLMEngine):
             yield {
                 "token_ids": [],
                 "index": 0,
-                "disaggregated_params": dict(bootstrap_kwargs),  # type: ignore[typeddict-unknown-key]
+                "disaggregated_params": dict(bootstrap_kwargs),
             }
             # Bootstrap path (router-populated bootstrap_info): drain
             # inline so cancellation propagates to engine.abort().
@@ -276,7 +273,10 @@ class SglangLLMEngine(LLMEngine):
 
                 yield out
         finally:
-            # pop before close(); ordering matters for late abort()
+            # Pop the guard from the lookup map BEFORE closing it. A late
+            # abort() racing on a different task would otherwise observe a
+            # half-closed guard; popping first sends that abort() down the
+            # engine-direct path instead.
             if abort_guard is not None and rid is not None:
                 self._active_aborts.pop(rid, None)
                 await abort_guard.close()
@@ -296,12 +296,7 @@ class SglangLLMEngine(LLMEngine):
         logger.debug("abort requested for %s", rid)
 
     async def drain(self) -> None:
-        """Await background prefill consume tasks before cleanup.
-
-        On the Completed path these tasks are still draining in-flight
-        NIXL KV transfers for already-routed decode requests; cancelling
-        them in cleanup() abandons the transfer mid-flight (#7319).
-        """
+        """Await background prefill consume tasks before cleanup (#7319)."""
         pending = [t for t in self._prefill_consume_tasks if not t.done()]
         if not pending:
             return
@@ -455,63 +450,6 @@ class SglangLLMEngine(LLMEngine):
                 rid,
                 exc_info=True,
             )
-
-    def _resolve_bootstrap_info(self) -> tuple[str, int]:
-        """Mirrors `BaseWorkerHandler._get_bootstrap_info` — returns the
-        `(host, port)` tuple this prefill worker advertises to decode
-        peers. Source of truth is the SGLang engine's ServerArgs.
-
-        TODO: dedup with `dynamo.sglang.register._get_bootstrap_info_for_config`.
-        """
-        assert self.engine is not None
-        inner_tm = self.engine.tokenizer_manager
-        bootstrap_port = inner_tm.server_args.disaggregation_bootstrap_port
-
-        if inner_tm.server_args.dist_init_addr:
-            dist_init = NetworkAddress.parse(inner_tm.server_args.dist_init_addr)
-            bootstrap_host = (
-                NetworkAddress(dist_init.resolved().host, bootstrap_port)
-                .to_host_port_str()
-                .rsplit(":", 1)[0]
-            )
-        else:
-            bootstrap_host = (
-                NetworkAddress(get_local_ip_auto(), bootstrap_port)
-                .to_host_port_str()
-                .rsplit(":", 1)[0]
-            )
-        return bootstrap_host, bootstrap_port
-
-    async def _warmup_prefill(self) -> None:
-        """Warm the engine through the disagg path so the first real
-        request doesn't pay JIT/CUDA-graph compile cost. Uses
-        FAKE_BOOTSTRAP_HOST so no decode peer is required. Startup
-        fails on warmup error — an unwarmed prefill silently drops
-        requests in production."""
-        assert self.engine is not None
-        from sglang.srt.disaggregation.utils import FAKE_BOOTSTRAP_HOST
-
-        sampling_params = {
-            "temperature": 0.0,
-            "max_new_tokens": 8,
-            "ignore_eos": True,
-        }
-
-        async def _do_warmup() -> None:
-            results = await self.engine.async_generate(
-                input_ids=[0, 1, 2, 3],
-                sampling_params=sampling_params,
-                stream=True,
-                bootstrap_host=FAKE_BOOTSTRAP_HOST,
-                bootstrap_port=self._bootstrap_port,
-                bootstrap_room=999999,
-            )
-            async for _ in results:
-                pass
-
-        logger.info("SGLang prefill warmup starting...")
-        await asyncio.wait_for(_do_warmup(), timeout=_PREFILL_WARMUP_TIMEOUT_S)
-        logger.info("SGLang prefill warmup complete")
 
     def _build_sampling_params(self, request: GenerateRequest) -> dict:
         if not self._use_sglang_tokenizer:

--- a/components/src/dynamo/sglang/llm_engine.py
+++ b/components/src/dynamo/sglang/llm_engine.py
@@ -106,32 +106,20 @@ class SglangLLMEngine(LLMEngine):
         )
         self._input_param_manager = InputParamManager(tokenizer)
 
-        # Wrap warmup in try/except so an early-fail leaves no orphan SGLang
-        # engine subprocess. Worker won't call cleanup() on a failed start().
-        try:
-            if self.serving_mode == DisaggregationMode.PREFILL:
-                # Cache bootstrap host/port; warm the engine to avoid first-
-                # request JIT/cuda-graph compile latency.
-                (
-                    self._bootstrap_host,
-                    self._bootstrap_port,
-                ) = self._resolve_bootstrap_info()
-                if _warmup_enabled():
-                    await self._warmup_prefill()
-                else:
-                    logger.info(
-                        "Skipping SGLang prefill warmup (%s set)",
-                        _DYN_SGLANG_SKIP_WARMUP_ENV,
-                    )
-        except Exception:
-            try:
-                self.engine.shutdown()
-            except Exception:
-                logger.warning(
-                    "engine shutdown after start failure raised", exc_info=True
+        if self.serving_mode == DisaggregationMode.PREFILL:
+            # Cache bootstrap host/port; warm the engine to avoid first-
+            # request JIT/cuda-graph compile latency.
+            (
+                self._bootstrap_host,
+                self._bootstrap_port,
+            ) = self._resolve_bootstrap_info()
+            if _warmup_enabled():
+                await self._warmup_prefill()
+            else:
+                logger.info(
+                    "Skipping SGLang prefill warmup (%s set)",
+                    _DYN_SGLANG_SKIP_WARMUP_ENV,
                 )
-            self.engine = None
-            raise
 
         # Capacity fields — match register.py in the legacy path.
         total_kv_blocks = None

--- a/components/src/dynamo/sglang/llm_engine.py
+++ b/components/src/dynamo/sglang/llm_engine.py
@@ -9,10 +9,14 @@ and feature gap details.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
+import os
+import random
 import sys
 from collections.abc import AsyncGenerator
+from typing import Any
 
 import sglang as sgl
 
@@ -24,22 +28,50 @@ from dynamo.common.backend.engine import (
     LLMEngine,
 )
 from dynamo.common.backend.worker import WorkerConfig
+from dynamo.common.constants import DisaggregationMode
 from dynamo.common.utils.input_params import InputParamManager
 from dynamo.llm import ModelInput
-from dynamo.sglang._compat import get_scheduler_info
+from dynamo.sglang._compat import NetworkAddress, get_local_ip_auto, get_scheduler_info
 from dynamo.sglang.args import parse_args
 
 logger = logging.getLogger(__name__)
 
+# Mirrors `_warmup_prefill_engine` in init_llm.py — must finish before the
+# prefill worker starts serving so the first real request doesn't pay the
+# JIT/CUDA-graph compile cost. SGLang's FAKE_BOOTSTRAP_HOST drives the
+# warmup through the disagg path without needing a real decode peer.
+_PREFILL_WARMUP_TIMEOUT_S = 1800.0
+
+# Bound on prefill drain during graceful shutdown. After this, force-cancel
+# any still-running consume tasks. Matches TRT-LLM's drain timeout.
+_PREFILL_DRAIN_TIMEOUT_S = 30.0
+
+# Operators can opt out of the prefill warmup for fast-iteration / smoke
+# environments where the warmup adds avoidable startup latency. The default
+# (`0`/unset) keeps warmup on; set to `1`/`true` to skip.
+_DYN_SGLANG_SKIP_WARMUP_ENV = "DYN_SGLANG_SKIP_PREFILL_WARMUP"
+
+
+def _warmup_enabled() -> bool:
+    raw = os.environ.get(_DYN_SGLANG_SKIP_WARMUP_ENV, "")
+    return raw.strip().lower() not in ("1", "true", "yes", "on")
+
 
 class SglangLLMEngine(LLMEngine):
-    def __init__(self, server_args, dynamo_args):
+    def __init__(self, server_args, dynamo_args, serving_mode: DisaggregationMode):
         self.server_args = server_args
         self.dynamo_args = dynamo_args
-        self.engine = None
-        self._input_param_manager = None
+        # SGLang's local name for disaggregation_mode. Same enum.
+        self.serving_mode = serving_mode
+        self.engine: Any = None
+        self._bootstrap_host: str | None = None
+        self._bootstrap_port: int | None = None
+        self._input_param_manager: InputParamManager | None = None
         self._skip_tokenizer_init = server_args.skip_tokenizer_init
         self._use_sglang_tokenizer = dynamo_args.use_sglang_tokenizer
+        # Background drain tasks for prefill stream after the bootstrap
+        # chunk yields (Completed path only). Cancelled in cleanup().
+        self._prefill_consume_tasks: set[asyncio.Task[Any]] = set()
 
     @classmethod
     async def from_args(
@@ -53,12 +85,13 @@ class SglangLLMEngine(LLMEngine):
             ModelInput.Text if dynamo_args.use_sglang_tokenizer else ModelInput.Tokens
         )
 
-        engine = cls(server_args, dynamo_args)
+        engine = cls(server_args, dynamo_args, config.serving_mode)
         worker_config = WorkerConfig.from_runtime_config(
             dynamo_args,
             model_name=server_args.model_path,
             served_model_name=server_args.served_model_name,
             model_input=model_input,
+            disaggregation_mode=config.serving_mode,
         )
         return engine, worker_config
 
@@ -73,8 +106,34 @@ class SglangLLMEngine(LLMEngine):
         )
         self._input_param_manager = InputParamManager(tokenizer)
 
-        # Capacity fields -- sourced the same way as register.py in the
-        # non-unified path so the Rust runtime gets consistent values.
+        # Wrap warmup in try/except so an early-fail leaves no orphan SGLang
+        # engine subprocess. Worker won't call cleanup() on a failed start().
+        try:
+            if self.serving_mode == DisaggregationMode.PREFILL:
+                # Cache bootstrap host/port; warm the engine to avoid first-
+                # request JIT/cuda-graph compile latency.
+                (
+                    self._bootstrap_host,
+                    self._bootstrap_port,
+                ) = self._resolve_bootstrap_info()
+                if _warmup_enabled():
+                    await self._warmup_prefill()
+                else:
+                    logger.info(
+                        "Skipping SGLang prefill warmup (%s set)",
+                        _DYN_SGLANG_SKIP_WARMUP_ENV,
+                    )
+        except Exception:
+            try:
+                self.engine.shutdown()
+            except Exception:
+                logger.warning(
+                    "engine shutdown after start failure raised", exc_info=True
+                )
+            self.engine = None
+            raise
+
+        # Capacity fields — match register.py in the legacy path.
         total_kv_blocks = None
         scheduler_info = get_scheduler_info(self.engine)
         max_total_tokens = scheduler_info.get("max_total_num_tokens")
@@ -82,8 +141,7 @@ class SglangLLMEngine(LLMEngine):
         if max_total_tokens and page_size:
             total_kv_blocks = (max_total_tokens + page_size - 1) // page_size
 
-        # Prefer explicit max_prefill_tokens; fall back to max_total_num_tokens
-        # from the scheduler so the planner always has a prefill load signal.
+        # Prefer max_prefill_tokens; fall back so planner has a signal.
         max_num_batched_tokens = (
             getattr(self.server_args, "max_prefill_tokens", None) or max_total_tokens
         )
@@ -96,6 +154,9 @@ class SglangLLMEngine(LLMEngine):
             total_kv_blocks=total_kv_blocks,
             max_num_seqs=getattr(self.server_args, "max_running_requests", None),
             max_num_batched_tokens=max_num_batched_tokens,
+            # Prefill-only — drives PrefillRouter's Bootstrap path.
+            bootstrap_host=self._bootstrap_host,
+            bootstrap_port=self._bootstrap_port,
         )
 
     async def generate(
@@ -106,17 +167,47 @@ class SglangLLMEngine(LLMEngine):
         sampling_params = self._build_sampling_params(request)
         input_param = self._get_input_param(request)
 
+        # SGLang disagg keys NIXL transport on a (host, port, room) triple
+        # exchanged between prefill and decode peers.
+        bootstrap_kwargs: dict[str, Any] = {}
+        if self.serving_mode == DisaggregationMode.PREFILL:
+            bootstrap_kwargs = self._resolve_prefill_bootstrap(request)
+        elif self.serving_mode == DisaggregationMode.DECODE:
+            bootstrap_kwargs = self._resolve_decode_bootstrap(request)
+
         stream = await self.engine.async_generate(
             **input_param,
             sampling_params=sampling_params,
             stream=True,
             rid=context.trace_id,
+            **bootstrap_kwargs,
         )
 
+        # ORDER MATTERS: async_generate must register the room (the await
+        # above) before we yield the bootstrap chunk — otherwise the
+        # decode peer can connect to a room that doesn't exist yet.
+        if self.serving_mode == DisaggregationMode.PREFILL:
+            yield {
+                "token_ids": [],
+                "index": 0,
+                "disaggregated_params": dict(bootstrap_kwargs),  # type: ignore[typeddict-unknown-key]
+            }
+            # Bootstrap path (router-populated bootstrap_info): drain
+            # inline so cancellation propagates to engine.abort().
+            # Completed path: router awaits our stream end before
+            # forwarding to decode — a sync drain deadlocks, so spawn.
+            if request.get("bootstrap_info"):
+                await self._consume_prefill_stream(stream, context, context.trace_id)
+                return
+            task = asyncio.create_task(
+                self._consume_prefill_stream(stream, context, context.trace_id)
+            )
+            self._prefill_consume_tasks.add(task)
+            task.add_done_callback(self._prefill_consume_tasks.discard)
+            return
+
         async for res in stream:
-            # SGLang includes an output index when n>1. Preserve it so the
-            # Rust/OpenAI response layer can keep choices separate; default to
-            # 0 for legacy/non-n chunks.
+            # SGLang sets index when n>1; default to 0 otherwise.
             output_idx = res.get("index") or 0
             out: GenerateChunk = {"token_ids": [], "index": output_idx}
             meta_info = res["meta_info"]
@@ -179,10 +270,223 @@ class SglangLLMEngine(LLMEngine):
                 self.engine.tokenizer_manager.abort_request(rid=rid, abort_all=False)
                 logger.debug("Aborted request %s", rid)
 
+    async def drain(self) -> None:
+        """Await background prefill consume tasks before cleanup.
+
+        On the Completed path these tasks are still draining in-flight
+        NIXL KV transfers for already-routed decode requests; cancelling
+        them in cleanup() abandons the transfer mid-flight (#7319).
+        """
+        pending = [t for t in self._prefill_consume_tasks if not t.done()]
+        if not pending:
+            return
+        logger.info(
+            "Draining %d background prefill consume task(s) (timeout=%.1fs)",
+            len(pending),
+            _PREFILL_DRAIN_TIMEOUT_S,
+        )
+        try:
+            await asyncio.wait_for(
+                asyncio.gather(*pending, return_exceptions=True),
+                timeout=_PREFILL_DRAIN_TIMEOUT_S,
+            )
+            logger.info("All prefill consume tasks drained")
+        except asyncio.TimeoutError:
+            logger.warning(
+                "Drain timeout (%.1fs) reached; cleanup() will cancel "
+                "remaining tasks — some NIXL transfers may not complete",
+                _PREFILL_DRAIN_TIMEOUT_S,
+            )
+
     async def cleanup(self) -> None:
+        # Anything still running here either timed out in drain() or was
+        # never drained (e.g. start failed). Force-cancel.
+        for task in self._prefill_consume_tasks:
+            if not task.done():
+                task.cancel()
+        self._prefill_consume_tasks.clear()
+
         if self.engine is not None:
             self.engine.shutdown()
             logger.info("SGLang engine shutdown")
+
+    def _resolve_prefill_bootstrap(self, request: GenerateRequest) -> dict[str, Any]:
+        """Pick the (host, port, room) triple this prefill request will use.
+
+        Bootstrap path: router pre-populates ``request.bootstrap_info``
+        and the same triple is on the decode side. Completed path: fall
+        back to engine defaults + a locally generated room; the router
+        forwards this triple via ``prefill_result.disaggregated_params``.
+
+        Partial ``bootstrap_info`` is a router contract violation; we
+        warn and fill the gaps so the request doesn't fail outright.
+        """
+        assert (
+            self._bootstrap_host is not None and self._bootstrap_port is not None
+        ), "prefill workers must resolve bootstrap host/port in start()"
+
+        bootstrap_info_from_req = request.get("bootstrap_info") or {}
+        if isinstance(bootstrap_info_from_req, dict) and bootstrap_info_from_req:
+            missing = [
+                k
+                for k in ("bootstrap_host", "bootstrap_port", "bootstrap_room")
+                if k not in bootstrap_info_from_req
+            ]
+            if missing:
+                logger.warning(
+                    "incomplete prefill bootstrap_info (missing %s); "
+                    "filling from engine defaults — decode peer may not "
+                    "find this room. PrefillRouter contract violation?",
+                    missing,
+                )
+            host = bootstrap_info_from_req.get("bootstrap_host", self._bootstrap_host)
+            port = bootstrap_info_from_req.get("bootstrap_port", self._bootstrap_port)
+            room = bootstrap_info_from_req.get("bootstrap_room")
+        else:
+            host, port, room = self._bootstrap_host, self._bootstrap_port, None
+
+        if room is None:
+            room = random.randint(0, 2**63 - 1)
+        return {
+            "bootstrap_host": host,
+            "bootstrap_port": port,
+            "bootstrap_room": room,
+        }
+
+    @staticmethod
+    def _resolve_decode_bootstrap(request: GenerateRequest) -> dict[str, Any]:
+        """Read the triple from ``bootstrap_info`` (Bootstrap path) or
+        ``prefill_result.disaggregated_params`` (Completed path)."""
+        bootstrap_info: Any = request.get("bootstrap_info")
+        if not bootstrap_info:
+            prefill_result: Any = request.get("prefill_result")
+            if prefill_result is not None:
+                bootstrap_info = prefill_result.get("disaggregated_params")
+
+        if not bootstrap_info:
+            raise ValueError(
+                "decode worker received request without bootstrap info "
+                "from PrefillRouter (bootstrap_info or prefill_result)"
+            )
+
+        try:
+            return {
+                "bootstrap_host": bootstrap_info["bootstrap_host"],
+                "bootstrap_port": bootstrap_info["bootstrap_port"],
+                "bootstrap_room": bootstrap_info["bootstrap_room"],
+            }
+        except KeyError as e:
+            raise ValueError(
+                "decode worker received bootstrap info missing required "
+                f"field: {e.args[0]} (need host/port/room)"
+            ) from e
+
+    async def _consume_prefill_stream(
+        self,
+        stream: AsyncGenerator[Any, None],
+        context: Context,
+        rid: str | None,
+    ) -> None:
+        """Drain a prefill engine stream after the bootstrap chunk has
+        been yielded. Awaited inline on the Bootstrap path, run as a
+        background task on the Completed path (see ``generate``).
+
+        On stream failure (NIXL transport error, engine crash) abort the
+        SGLang request so the decode peer's NIXL connect fails fast
+        instead of hanging on a KV transfer that will not arrive.
+        """
+        try:
+            async for _ in stream:
+                if context.is_stopped():
+                    break
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            # Abort releases the bootstrap room so the decode peer fails
+            # fast instead of waiting on KV that won't arrive.
+            logger.warning(
+                "prefill consume task ended with exception (rid=%s); "
+                "aborting to release the bootstrap room",
+                rid,
+                exc_info=True,
+            )
+            if rid is not None:
+                self._abort_sglang_request(rid)
+
+    def _abort_sglang_request(self, rid: str) -> None:
+        """Best-effort abort. Failures here are swallowed — SGLang is
+        already in a bad state and we want to surface the original
+        failure, not a follow-up abort error."""
+        if self.engine is None:
+            return
+        tokenizer_manager = getattr(self.engine, "tokenizer_manager", None)
+        if tokenizer_manager is None:
+            return
+        try:
+            tokenizer_manager.abort_request(rid=rid, abort_all=False)
+        except Exception:
+            logger.debug(
+                "abort_request failed while releasing bootstrap room (rid=%s)",
+                rid,
+                exc_info=True,
+            )
+
+    def _resolve_bootstrap_info(self) -> tuple[str, int]:
+        """Mirrors `BaseWorkerHandler._get_bootstrap_info` — returns the
+        `(host, port)` tuple this prefill worker advertises to decode
+        peers. Source of truth is the SGLang engine's ServerArgs.
+
+        TODO: dedup with `dynamo.sglang.register._get_bootstrap_info_for_config`.
+        """
+        assert self.engine is not None
+        inner_tm = self.engine.tokenizer_manager
+        bootstrap_port = inner_tm.server_args.disaggregation_bootstrap_port
+
+        if inner_tm.server_args.dist_init_addr:
+            dist_init = NetworkAddress.parse(inner_tm.server_args.dist_init_addr)
+            bootstrap_host = (
+                NetworkAddress(dist_init.resolved().host, bootstrap_port)
+                .to_host_port_str()
+                .rsplit(":", 1)[0]
+            )
+        else:
+            bootstrap_host = (
+                NetworkAddress(get_local_ip_auto(), bootstrap_port)
+                .to_host_port_str()
+                .rsplit(":", 1)[0]
+            )
+        return bootstrap_host, bootstrap_port
+
+    async def _warmup_prefill(self) -> None:
+        """Warm the engine through the disagg path so the first real
+        request doesn't pay JIT/CUDA-graph compile cost. Uses
+        FAKE_BOOTSTRAP_HOST so no decode peer is required. Startup
+        fails on warmup error — an unwarmed prefill silently drops
+        requests in production."""
+        assert self.engine is not None
+        from sglang.srt.disaggregation.utils import FAKE_BOOTSTRAP_HOST
+
+        sampling_params = {
+            "temperature": 0.0,
+            "max_new_tokens": 8,
+            "ignore_eos": True,
+        }
+
+        async def _do_warmup() -> None:
+            results = await self.engine.async_generate(
+                input_ids=[0, 1, 2, 3],
+                sampling_params=sampling_params,
+                stream=True,
+                bootstrap_host=FAKE_BOOTSTRAP_HOST,
+                bootstrap_port=self._bootstrap_port,
+                bootstrap_room=999999,
+            )
+            async for _ in results:
+                pass
+
+        logger.info("SGLang prefill warmup starting...")
+        await asyncio.wait_for(_do_warmup(), timeout=_PREFILL_WARMUP_TIMEOUT_S)
+        logger.info("SGLang prefill warmup complete")
 
     def _build_sampling_params(self, request: GenerateRequest) -> dict:
         if not self._use_sglang_tokenizer:
@@ -226,7 +530,7 @@ class SglangLLMEngine(LLMEngine):
     def _get_input_param(self, request: GenerateRequest) -> dict:
         assert self._input_param_manager is not None, "Engine not initialized"
         request_input = self._input_param_manager.get_input_param(
-            request, use_tokenizer=self._use_sglang_tokenizer
+            dict(request), use_tokenizer=self._use_sglang_tokenizer
         )
         return {
             "prompt" if isinstance(request_input, str) else "input_ids": request_input

--- a/components/src/dynamo/sglang/llm_engine.py
+++ b/components/src/dynamo/sglang/llm_engine.py
@@ -21,6 +21,7 @@ from typing import Any
 import sglang as sgl
 
 from dynamo._core import Context
+from dynamo.common.backend.abort import DeferredAbort
 from dynamo.common.backend.engine import (
     EngineConfig,
     GenerateChunk,
@@ -57,6 +58,18 @@ def _warmup_enabled() -> bool:
     return raw.strip().lower() not in ("1", "true", "yes", "on")
 
 
+class SglangDeferredAbort(DeferredAbort):
+    """`DeferredAbort` for `tokenizer_manager.abort_request(rid=...)`."""
+
+    def __init__(self, tokenizer_manager: Any, rid: str):
+        super().__init__()
+        self._tokenizer_manager = tokenizer_manager
+        self._rid = rid
+
+    async def _do_abort_now(self) -> None:
+        self._tokenizer_manager.abort_request(rid=self._rid, abort_all=False)
+
+
 class SglangLLMEngine(LLMEngine):
     def __init__(self, server_args, dynamo_args, serving_mode: DisaggregationMode):
         self.server_args = server_args
@@ -72,6 +85,7 @@ class SglangLLMEngine(LLMEngine):
         # Background drain tasks for prefill stream after the bootstrap
         # chunk yields (Completed path only). Cancelled in cleanup().
         self._prefill_consume_tasks: set[asyncio.Task[Any]] = set()
+        self._active_aborts: dict[str, SglangDeferredAbort] = {}
 
     @classmethod
     async def from_args(
@@ -194,20 +208,62 @@ class SglangLLMEngine(LLMEngine):
             task.add_done_callback(self._prefill_consume_tasks.discard)
             return
 
-        async for res in stream:
-            # SGLang sets index when n>1; default to 0 otherwise.
-            output_idx = res.get("index") or 0
-            out: GenerateChunk = {"token_ids": [], "index": output_idx}
-            meta_info = res["meta_info"]
-            finish_reason = meta_info["finish_reason"]
+        # Only decode has an in-flight NIXL pull to protect.
+        is_decode = self.serving_mode == DisaggregationMode.DECODE
+        rid = context.trace_id
+        tokenizer_manager = getattr(self.engine, "tokenizer_manager", None)
+        abort_guard: SglangDeferredAbort | None = None
+        if is_decode and rid is not None and tokenizer_manager is not None:
+            abort_guard = SglangDeferredAbort(tokenizer_manager, rid)
+            self._active_aborts[rid] = abort_guard
 
-            output_ids = res.get("output_ids", [])
-            if not output_ids and not finish_reason:
+        first_signalled = False
+        try:
+            async for res in stream:
+                if abort_guard is not None and not first_signalled:
+                    abort_guard.signal_first_token()
+                    first_signalled = True
+                # SGLang sets index when n>1; default to 0 otherwise.
+                output_idx = res.get("index") or 0
+                out: GenerateChunk = {"token_ids": [], "index": output_idx}
+                meta_info = res["meta_info"]
+                finish_reason = meta_info["finish_reason"]
+
+                output_ids = res.get("output_ids", [])
+                if not output_ids and not finish_reason:
+                    if context.is_stopped():
+                        prompt_tokens = meta_info.get("prompt_tokens", 0)
+                        completion_tokens = meta_info.get("completion_tokens", 0)
+                        yield {
+                            "token_ids": [],
+                            "index": output_idx,
+                            "finish_reason": "cancelled",
+                            "completion_usage": {
+                                "prompt_tokens": prompt_tokens,
+                                "completion_tokens": completion_tokens,
+                                "total_tokens": prompt_tokens + completion_tokens,
+                            },
+                        }
+                        break
+                    continue
+
+                out["token_ids"] = output_ids
+
+                if finish_reason:
+                    prompt_tokens = meta_info["prompt_tokens"]
+                    completion_tokens = meta_info["completion_tokens"]
+                    out["finish_reason"] = finish_reason["type"]
+                    out["completion_usage"] = {
+                        "prompt_tokens": prompt_tokens,
+                        "completion_tokens": completion_tokens,
+                        "total_tokens": prompt_tokens + completion_tokens,
+                    }
+
                 if context.is_stopped():
                     prompt_tokens = meta_info.get("prompt_tokens", 0)
                     completion_tokens = meta_info.get("completion_tokens", 0)
                     yield {
-                        "token_ids": [],
+                        "token_ids": output_ids,
                         "index": output_idx,
                         "finish_reason": "cancelled",
                         "completion_usage": {
@@ -217,46 +273,27 @@ class SglangLLMEngine(LLMEngine):
                         },
                     }
                     break
-                continue
 
-            out["token_ids"] = output_ids
-
-            if finish_reason:
-                prompt_tokens = meta_info["prompt_tokens"]
-                completion_tokens = meta_info["completion_tokens"]
-                out["finish_reason"] = finish_reason["type"]
-                out["completion_usage"] = {
-                    "prompt_tokens": prompt_tokens,
-                    "completion_tokens": completion_tokens,
-                    "total_tokens": prompt_tokens + completion_tokens,
-                }
-
-            if context.is_stopped():
-                prompt_tokens = meta_info.get("prompt_tokens", 0)
-                completion_tokens = meta_info.get("completion_tokens", 0)
-                yield {
-                    "token_ids": output_ids,
-                    "index": output_idx,
-                    "finish_reason": "cancelled",
-                    "completion_usage": {
-                        "prompt_tokens": prompt_tokens,
-                        "completion_tokens": completion_tokens,
-                        "total_tokens": prompt_tokens + completion_tokens,
-                    },
-                }
-                break
-
-            yield out
+                yield out
+        finally:
+            # pop before close(); ordering matters for late abort()
+            if abort_guard is not None and rid is not None:
+                self._active_aborts.pop(rid, None)
+                await abort_guard.close()
 
     async def abort(self, context: Context) -> None:
         rid = context.trace_id
-        if self.engine is not None and rid is not None:
-            if (
-                hasattr(self.engine, "tokenizer_manager")
-                and self.engine.tokenizer_manager
-            ):
-                self.engine.tokenizer_manager.abort_request(rid=rid, abort_all=False)
-                logger.debug("Aborted request %s", rid)
+        if self.engine is None or rid is None:
+            return
+        tokenizer_manager = getattr(self.engine, "tokenizer_manager", None)
+        if tokenizer_manager is None:
+            return
+        guard = self._active_aborts.get(rid)
+        if guard is not None:
+            guard.abort()
+        else:
+            tokenizer_manager.abort_request(rid=rid, abort_all=False)
+        logger.debug("abort requested for %s", rid)
 
     async def drain(self) -> None:
         """Await background prefill consume tasks before cleanup.

--- a/components/src/dynamo/sglang/register.py
+++ b/components/src/dynamo/sglang/register.py
@@ -14,7 +14,7 @@ from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 from dynamo._core import Endpoint
 from dynamo.common.utils.output_modalities import get_output_modalities
 from dynamo.llm import ModelInput, ModelRuntimeConfig, ModelType, register_model
-from dynamo.sglang._compat import NetworkAddress, get_local_ip_auto, get_scheduler_info
+from dynamo.sglang._compat import get_scheduler_info
 from dynamo.sglang.args import DynamoConfig
 
 SGLANG_HICACHE_MOONCAKE_RUNTIME_KEY = "sglang_hicache_mooncake"
@@ -74,49 +74,11 @@ async def _register_model_with_runtime_config(
 def _get_bootstrap_info_for_config(
     engine: sgl.Engine,
 ) -> tuple[Optional[str], Optional[int]]:
-    """Extract bootstrap host and port from SGLang engine for config registration.
+    """Thin wrapper for the shared `_disagg.compute_bootstrap_address`,
+    kept for source-compat with this module's callers."""
+    from dynamo.sglang._disagg import compute_bootstrap_address
 
-    Args:
-        engine: The SGLang engine instance.
-
-    Returns:
-        Tuple of (bootstrap_host, bootstrap_port), or (None, None) if not available.
-    """
-    try:
-        inner_tm = engine.tokenizer_manager
-        bootstrap_port = getattr(
-            inner_tm.server_args, "disaggregation_bootstrap_port", None
-        )
-
-        if bootstrap_port is None:
-            return None, None
-
-        if inner_tm.server_args.dist_init_addr:
-            dist_init = NetworkAddress.parse(inner_tm.server_args.dist_init_addr)
-            resolved = dist_init.resolved()
-            bootstrap_host = (
-                NetworkAddress(resolved.host, bootstrap_port)
-                .to_host_port_str()
-                .rsplit(":", 1)[0]
-            )
-            logging.info(
-                f"Resolved bootstrap host '{dist_init.host}' -> '{resolved.host}' "
-                f"({'IPv6' if resolved.is_ipv6 else 'IPv4'})"
-            )
-        else:
-            # get_local_ip_auto() tries IPv4 first, then IPv6. For explicit control,
-            # set SGLANG_HOST_IP env var (use bracketed format for IPv6: [addr])
-            local_ip = get_local_ip_auto()
-            local_addr = NetworkAddress(local_ip, bootstrap_port)
-            bootstrap_host = local_addr.to_host_port_str().rsplit(":", 1)[0]
-            logging.info(
-                f"Using auto-detected local IP: {local_ip} "
-                f"({'IPv6' if local_addr.is_ipv6 else 'IPv4'})"
-            )
-        return bootstrap_host, bootstrap_port
-    except Exception as e:
-        logging.warning(f"Failed to get bootstrap info: {e}")
-        return None, None
+    return compute_bootstrap_address(engine)
 
 
 def _parse_hicache_storage_extra_config(

--- a/components/src/dynamo/sglang/tests/test_sglang_disagg.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_disagg.py
@@ -5,18 +5,12 @@
 
 from __future__ import annotations
 
-import asyncio
-from unittest.mock import MagicMock
-
 import pytest
 
 pytest.importorskip("sglang", reason="sglang not installed in this container")
 
 from dynamo.common.constants import DisaggregationMode  # noqa: E402
-from dynamo.sglang.llm_engine import (  # noqa: E402
-    SglangDeferredAbort,
-    SglangLLMEngine,
-)
+from dynamo.sglang.llm_engine import SglangLLMEngine  # noqa: E402
 
 pytestmark = [
     pytest.mark.unit,
@@ -63,15 +57,3 @@ def test_decode_bootstrap_raises_when_router_left_no_info():
     # leave the decode worker waiting on a phantom KV transfer.
     with pytest.raises(ValueError, match="bootstrap"):
         SglangLLMEngine._resolve_decode_bootstrap({"token_ids": [1, 2, 3]})
-
-
-@pytest.mark.asyncio
-async def test_sglang_deferred_abort_invokes_tokenizer_abort_request():
-    tokenizer_manager = MagicMock()
-    guard = SglangDeferredAbort(tokenizer_manager, "req-xyz")
-    guard.signal_first_token()
-    guard.abort()
-    await asyncio.sleep(0)
-    tokenizer_manager.abort_request.assert_called_once_with(
-        rid="req-xyz", abort_all=False
-    )

--- a/components/src/dynamo/sglang/tests/test_sglang_disagg.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_disagg.py
@@ -11,6 +11,9 @@ at top level — gated with ``importorskip``.
 
 from __future__ import annotations
 
+import asyncio
+from unittest.mock import MagicMock
+
 import pytest
 
 pytest.importorskip(
@@ -19,7 +22,10 @@ pytest.importorskip(
 )
 
 from dynamo.common.constants import DisaggregationMode  # noqa: E402
-from dynamo.sglang.llm_engine import SglangLLMEngine  # noqa: E402
+from dynamo.sglang.llm_engine import (  # noqa: E402
+    SglangDeferredAbort,
+    SglangLLMEngine,
+)
 
 pytestmark = [
     pytest.mark.unit,
@@ -136,3 +142,17 @@ def test_decode_bootstrap_raises_when_required_field_missing():
                 "bootstrap_info": {"bootstrap_host": "h", "bootstrap_port": 1},
             }
         )
+
+
+@pytest.mark.asyncio
+async def test_sglang_deferred_abort_invokes_tokenizer_abort_request():
+    """`SglangDeferredAbort._do_abort_now` forwards to
+    `tokenizer_manager.abort_request(rid=..., abort_all=False)`."""
+    tokenizer_manager = MagicMock()
+    guard = SglangDeferredAbort(tokenizer_manager, "req-xyz")
+    guard.signal_first_token()
+    guard.abort()
+    await asyncio.sleep(0)
+    tokenizer_manager.abort_request.assert_called_once_with(
+        rid="req-xyz", abort_all=False
+    )

--- a/components/src/dynamo/sglang/tests/test_sglang_disagg.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_disagg.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the SGLang unified engine's disagg dispatch.
+
+Targets the pure-Python helpers that decide which (host, port, room)
+triple a request uses, so the tests don't need a running engine. They
+do require ``sglang`` to be importable because the module imports it
+at top level — gated with ``importorskip``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip(
+    "sglang",
+    reason="sglang not installed in this container",
+)
+
+from dynamo.common.constants import DisaggregationMode  # noqa: E402
+from dynamo.sglang.llm_engine import SglangLLMEngine  # noqa: E402
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.sglang,
+    pytest.mark.unified,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+def _engine_with_cached_bootstrap() -> SglangLLMEngine:
+    """Bypass ``__init__`` so we can exercise the bootstrap helpers
+    without spinning up a real ``sgl.Engine`` (which needs a GPU)."""
+    engine = SglangLLMEngine.__new__(SglangLLMEngine)
+    engine._bootstrap_host = "10.0.0.5"
+    engine._bootstrap_port = 12345
+    engine.serving_mode = DisaggregationMode.PREFILL
+    return engine
+
+
+def test_prefill_bootstrap_uses_router_provided_info_when_present():
+    # Bootstrap path: the Rust PrefillRouter resolved bootstrap upfront
+    # and writes (host, port, room) onto request.bootstrap_info before
+    # calling prefill. The engine MUST honour that exact triple so the
+    # decode peer (which the router writes the same triple onto) finds
+    # the matching room.
+    engine = _engine_with_cached_bootstrap()
+    request = {
+        "token_ids": [1, 2, 3],
+        "bootstrap_info": {
+            "bootstrap_host": "router.host",
+            "bootstrap_port": 9999,
+            "bootstrap_room": 42,
+        },
+    }
+    out = engine._resolve_prefill_bootstrap(request)
+    assert out == {
+        "bootstrap_host": "router.host",
+        "bootstrap_port": 9999,
+        "bootstrap_room": 42,
+    }
+
+
+def test_prefill_bootstrap_falls_back_to_engine_address_when_request_has_none():
+    # Completed path: the router didn't resolve bootstrap upfront, so
+    # the engine generates its own room and uses its own address. The
+    # router will pull this triple off the prefill response and forward
+    # it to decode.
+    engine = _engine_with_cached_bootstrap()
+    out = engine._resolve_prefill_bootstrap({"token_ids": [1, 2, 3]})
+    assert out["bootstrap_host"] == "10.0.0.5"
+    assert out["bootstrap_port"] == 12345
+    assert isinstance(out["bootstrap_room"], int)
+
+
+def test_decode_bootstrap_reads_bootstrap_info_first():
+    # Bootstrap path: router puts bootstrap info directly on the decode
+    # request. Decode workers must read it from there.
+    out = SglangLLMEngine._resolve_decode_bootstrap(
+        {
+            "token_ids": [1, 2, 3],
+            "bootstrap_info": {
+                "bootstrap_host": "h",
+                "bootstrap_port": 1,
+                "bootstrap_room": 2,
+            },
+        }
+    )
+    assert out == {
+        "bootstrap_host": "h",
+        "bootstrap_port": 1,
+        "bootstrap_room": 2,
+    }
+
+
+def test_decode_bootstrap_falls_back_to_prefill_result():
+    # Completed path: router waits for prefill, packs the prefill
+    # response's disaggregated_params into prefill_result. Decode
+    # workers must accept that fallback shape.
+    out = SglangLLMEngine._resolve_decode_bootstrap(
+        {
+            "token_ids": [1, 2, 3],
+            "prefill_result": {
+                "disaggregated_params": {
+                    "bootstrap_host": "h",
+                    "bootstrap_port": 1,
+                    "bootstrap_room": 2,
+                },
+            },
+        }
+    )
+    assert out == {
+        "bootstrap_host": "h",
+        "bootstrap_port": 1,
+        "bootstrap_room": 2,
+    }
+
+
+def test_decode_bootstrap_raises_when_neither_path_populated():
+    # Both router paths missing → loud failure. Silent zero-fill would
+    # leave the decode worker waiting on a phantom KV transfer.
+    with pytest.raises(ValueError, match="bootstrap"):
+        SglangLLMEngine._resolve_decode_bootstrap({"token_ids": [1, 2, 3]})
+
+
+def test_decode_bootstrap_raises_when_required_field_missing():
+    # Partial bootstrap info is a configuration bug — surface the
+    # specific missing field so operators don't have to debug from a
+    # generic NIXL connection error later.
+    with pytest.raises(ValueError, match="bootstrap_room"):
+        SglangLLMEngine._resolve_decode_bootstrap(
+            {
+                "token_ids": [1, 2, 3],
+                "bootstrap_info": {"bootstrap_host": "h", "bootstrap_port": 1},
+            }
+        )

--- a/components/src/dynamo/sglang/tests/test_sglang_disagg.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_disagg.py
@@ -1,13 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Unit tests for the SGLang unified engine's disagg dispatch.
-
-Targets the pure-Python helpers that decide which (host, port, room)
-triple a request uses, so the tests don't need a running engine. They
-do require ``sglang`` to be importable because the module imports it
-at top level — gated with ``importorskip``.
-"""
+"""Unit tests for the SGLang unified engine's disagg dispatch."""
 
 from __future__ import annotations
 
@@ -16,10 +10,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-pytest.importorskip(
-    "sglang",
-    reason="sglang not installed in this container",
-)
+pytest.importorskip("sglang", reason="sglang not installed in this container")
 
 from dynamo.common.constants import DisaggregationMode  # noqa: E402
 from dynamo.sglang.llm_engine import (  # noqa: E402
@@ -37,8 +28,7 @@ pytestmark = [
 
 
 def _engine_with_cached_bootstrap() -> SglangLLMEngine:
-    """Bypass ``__init__`` so we can exercise the bootstrap helpers
-    without spinning up a real ``sgl.Engine`` (which needs a GPU)."""
+    # __new__ bypasses real engine init; we only exercise pure-Python helpers.
     engine = SglangLLMEngine.__new__(SglangLLMEngine)
     engine._bootstrap_host = "10.0.0.5"
     engine._bootstrap_port = 12345
@@ -46,22 +36,21 @@ def _engine_with_cached_bootstrap() -> SglangLLMEngine:
     return engine
 
 
-def test_prefill_bootstrap_uses_router_provided_info_when_present():
-    # Bootstrap path: the Rust PrefillRouter resolved bootstrap upfront
-    # and writes (host, port, room) onto request.bootstrap_info before
-    # calling prefill. The engine MUST honour that exact triple so the
+def test_prefill_bootstrap_honours_router_provided_triple():
+    # Router-resolved triple must be passed through unchanged so the
     # decode peer (which the router writes the same triple onto) finds
     # the matching room.
     engine = _engine_with_cached_bootstrap()
-    request = {
-        "token_ids": [1, 2, 3],
-        "bootstrap_info": {
-            "bootstrap_host": "router.host",
-            "bootstrap_port": 9999,
-            "bootstrap_room": 42,
-        },
-    }
-    out = engine._resolve_prefill_bootstrap(request)
+    out = engine._resolve_prefill_bootstrap(
+        {
+            "token_ids": [1, 2, 3],
+            "bootstrap_info": {
+                "bootstrap_host": "router.host",
+                "bootstrap_port": 9999,
+                "bootstrap_room": 42,
+            },
+        }
+    )
     assert out == {
         "bootstrap_host": "router.host",
         "bootstrap_port": 9999,
@@ -69,85 +58,15 @@ def test_prefill_bootstrap_uses_router_provided_info_when_present():
     }
 
 
-def test_prefill_bootstrap_falls_back_to_engine_address_when_request_has_none():
-    # Completed path: the router didn't resolve bootstrap upfront, so
-    # the engine generates its own room and uses its own address. The
-    # router will pull this triple off the prefill response and forward
-    # it to decode.
-    engine = _engine_with_cached_bootstrap()
-    out = engine._resolve_prefill_bootstrap({"token_ids": [1, 2, 3]})
-    assert out["bootstrap_host"] == "10.0.0.5"
-    assert out["bootstrap_port"] == 12345
-    assert isinstance(out["bootstrap_room"], int)
-
-
-def test_decode_bootstrap_reads_bootstrap_info_first():
-    # Bootstrap path: router puts bootstrap info directly on the decode
-    # request. Decode workers must read it from there.
-    out = SglangLLMEngine._resolve_decode_bootstrap(
-        {
-            "token_ids": [1, 2, 3],
-            "bootstrap_info": {
-                "bootstrap_host": "h",
-                "bootstrap_port": 1,
-                "bootstrap_room": 2,
-            },
-        }
-    )
-    assert out == {
-        "bootstrap_host": "h",
-        "bootstrap_port": 1,
-        "bootstrap_room": 2,
-    }
-
-
-def test_decode_bootstrap_falls_back_to_prefill_result():
-    # Completed path: router waits for prefill, packs the prefill
-    # response's disaggregated_params into prefill_result. Decode
-    # workers must accept that fallback shape.
-    out = SglangLLMEngine._resolve_decode_bootstrap(
-        {
-            "token_ids": [1, 2, 3],
-            "prefill_result": {
-                "disaggregated_params": {
-                    "bootstrap_host": "h",
-                    "bootstrap_port": 1,
-                    "bootstrap_room": 2,
-                },
-            },
-        }
-    )
-    assert out == {
-        "bootstrap_host": "h",
-        "bootstrap_port": 1,
-        "bootstrap_room": 2,
-    }
-
-
-def test_decode_bootstrap_raises_when_neither_path_populated():
+def test_decode_bootstrap_raises_when_router_left_no_info():
     # Both router paths missing → loud failure. Silent zero-fill would
     # leave the decode worker waiting on a phantom KV transfer.
     with pytest.raises(ValueError, match="bootstrap"):
         SglangLLMEngine._resolve_decode_bootstrap({"token_ids": [1, 2, 3]})
 
 
-def test_decode_bootstrap_raises_when_required_field_missing():
-    # Partial bootstrap info is a configuration bug — surface the
-    # specific missing field so operators don't have to debug from a
-    # generic NIXL connection error later.
-    with pytest.raises(ValueError, match="bootstrap_room"):
-        SglangLLMEngine._resolve_decode_bootstrap(
-            {
-                "token_ids": [1, 2, 3],
-                "bootstrap_info": {"bootstrap_host": "h", "bootstrap_port": 1},
-            }
-        )
-
-
 @pytest.mark.asyncio
 async def test_sglang_deferred_abort_invokes_tokenizer_abort_request():
-    """`SglangDeferredAbort._do_abort_now` forwards to
-    `tokenizer_manager.abort_request(rid=..., abort_all=False)`."""
     tokenizer_manager = MagicMock()
     guard = SglangDeferredAbort(tokenizer_manager, "req-xyz")
     guard.signal_first_token()

--- a/examples/backends/sglang/launch/disagg.sh
+++ b/examples/backends/sglang/launch/disagg.sh
@@ -6,24 +6,37 @@
 # GPUs: 2
 
 set -e
-trap 'echo Cleaning up...; kill 0' EXIT
 
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 source "$SCRIPT_DIR/../../../common/gpu_utils.sh"   # build_sglang_gpu_mem_args
 source "$SCRIPT_DIR/../../../common/launch_utils.sh" # print_launch_banner, wait_any_exit
 
-# Parse command line arguments
+# Parse command line arguments BEFORE installing the kill-process-group
+# EXIT trap — `--help` and unknown-option early exits would otherwise
+# kill the caller's process group before any worker is even launched.
 ENABLE_OTEL=false
+USE_UNIFIED=false
 while [[ $# -gt 0 ]]; do
     case $1 in
         --enable-otel)
             ENABLE_OTEL=true
             shift
             ;;
+        --unified)
+            # Run the workers via the unified entry point
+            # (`python -m dynamo.sglang.unified_main`) so disagg goes
+            # through dynamo.common.backend / dynamo_backend_common
+            # instead of the legacy main.py / init_prefill init_decode
+            # dispatch.
+            USE_UNIFIED=true
+            shift
+            ;;
         -h|--help)
             echo "Usage: $0 [OPTIONS]"
             echo "Options:"
             echo "  --enable-otel        Enable OpenTelemetry tracing"
+            echo "  --unified            Use the unified backend entry point"
+            echo "                       (python -m dynamo.sglang.unified_main)"
             echo "  -h, --help           Show this help message"
             echo ""
             echo "Note: System metrics are enabled by default on ports 8081 (prefill), 8082 (decode)"
@@ -36,6 +49,14 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
+
+trap 'echo Cleaning up...; kill 0' EXIT
+
+if [ "$USE_UNIFIED" = true ]; then
+    WORKER_MODULE="dynamo.sglang.unified_main"
+else
+    WORKER_MODULE="dynamo.sglang"
+fi
 
 # Enable tracing if requested
 TRACE_ARGS=()
@@ -69,7 +90,7 @@ python3 -m dynamo.frontend &
 # Use DYN_SYSTEM_PORT1/2 instead of *_PREFILL/*_DECODE env names so test
 # harnesses can set one simple pair for disaggregated deployments.
 OTEL_SERVICE_NAME=dynamo-worker-prefill DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT1:-8081} \
-python3 -m dynamo.sglang \
+python3 -m "$WORKER_MODULE" \
   --model-path "$MODEL" \
   --served-model-name "$MODEL" \
   --page-size 16 \
@@ -87,7 +108,7 @@ python3 -m dynamo.sglang \
 
 # run decode worker
 OTEL_SERVICE_NAME=dynamo-worker-decode DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT2:-8082} \
-CUDA_VISIBLE_DEVICES=1 python3 -m dynamo.sglang \
+CUDA_VISIBLE_DEVICES=1 python3 -m "$WORKER_MODULE" \
   --model-path "$MODEL" \
   --served-model-name "$MODEL" \
   --page-size 16 \

--- a/examples/backends/sglang/launch/disagg.sh
+++ b/examples/backends/sglang/launch/disagg.sh
@@ -11,26 +11,16 @@ SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 source "$SCRIPT_DIR/../../../common/gpu_utils.sh"   # build_sglang_gpu_mem_args
 source "$SCRIPT_DIR/../../../common/launch_utils.sh" # print_launch_banner, wait_any_exit
 
-# Parse command line arguments BEFORE installing the kill-process-group
-# EXIT trap — `--help` and unknown-option early exits would otherwise
-# kill the caller's process group before any worker is even launched.
+# Strip --unified via the shared helper, then parse the remaining flags.
+# All of this runs BEFORE installing the kill-process-group EXIT trap so
+# an early exit (--help / unknown option) doesn't tear down the caller.
+pick_worker_module dynamo.sglang dynamo.sglang.unified_main "$@"
+set -- "${REMAINING_ARGS[@]}"
+
 ENABLE_OTEL=false
-USE_UNIFIED=false
 while [[ $# -gt 0 ]]; do
     case $1 in
-        --enable-otel)
-            ENABLE_OTEL=true
-            shift
-            ;;
-        --unified)
-            # Run the workers via the unified entry point
-            # (`python -m dynamo.sglang.unified_main`) so disagg goes
-            # through dynamo.common.backend / dynamo_backend_common
-            # instead of the legacy main.py / init_prefill init_decode
-            # dispatch.
-            USE_UNIFIED=true
-            shift
-            ;;
+        --enable-otel) ENABLE_OTEL=true; shift ;;
         -h|--help)
             echo "Usage: $0 [OPTIONS]"
             echo "Options:"
@@ -42,21 +32,11 @@ while [[ $# -gt 0 ]]; do
             echo "Note: System metrics are enabled by default on ports 8081 (prefill), 8082 (decode)"
             exit 0
             ;;
-        *)
-            echo "Unknown option: $1"
-            echo "Use --help for usage information"
-            exit 1
-            ;;
+        *) echo "Unknown option: $1"; echo "Use --help for usage information"; exit 1 ;;
     esac
 done
 
 trap 'echo Cleaning up...; kill 0' EXIT
-
-if [ "$USE_UNIFIED" = true ]; then
-    WORKER_MODULE="dynamo.sglang.unified_main"
-else
-    WORKER_MODULE="dynamo.sglang"
-fi
 
 # Enable tracing if requested
 TRACE_ARGS=()


### PR DESCRIPTION
## PR stack

- #9249 — backend abstraction (base: `main`)
- #9347 — vLLM engine
- **#9348 (this PR)** — SGLang engine
- #9349 — TRT-LLM engine

Each engine PR is stacked on #9249. The three engine PRs are independent of each other and can be reviewed in parallel.

## Summary

Wires `SglangLLMEngine` into the unified disagg framework
introduced in #9249. SGLang disagg works via a bootstrap handshake:
prefill and decode workers exchange `(host, port, room)` and
SGLang's NIXL transport pulls the KV cache from prefill to decode
keyed on that triple.

## Per-mode behavior

- **PREFILL** — resolve the bootstrap triple. If the Rust
  PrefillRouter pre-populated `request.bootstrap_info` (Bootstrap
  path), use that; else generate a local room (Completed path).
  Order matters: `engine.async_generate` must register the room
  BEFORE we yield the bootstrap chunk.
- **DECODE** — pull the triple from `bootstrap_info` (Bootstrap
  path) or `prefill_result.disaggregated_params` (Completed path).
- **AGGREGATED** — existing path, no branching.

## Two router paths surfaced via stream lifetime

- **Bootstrap path** — drain inline so the Rust adapter's
  cancellation monitor can propagate aborts to `engine.abort()`
  while prefill is in flight.
- **Completed path** — drain in a background task. The router
  awaits stream end before forwarding to decode, so a sync drain
  would deadlock.

`EngineConfig.bootstrap_host/port` is published from `start()` so
the frontend can take its optimised Bootstrap path. Prefill warmup
(skippable via `DYN_SGLANG_SKIP_PREFILL_WARMUP=1`) drives a
warmup request through the disagg path so the first real request
doesn't pay JIT/cuda-graph compile cost.

Launch: `examples/backends/sglang/launch/disagg.sh --unified` runs
through `python -m dynamo.sglang.unified_main`.

## Test plan

### Unit tests

- [x] `test_sglang_disagg.py` — bootstrap-resolve helpers cover Bootstrap-path (router-provided info), Completed-path fallback (prefill_result), missing-info raises, partial info raises with named missing field.

### End-to-end: `disagg.sh --unified`

Launched prefill + decode on a single RTX 5880 Ada (48GB) via the `test-unified-disagg` skill harness — `mem-fraction-static=0.40` each, **staggered start** (prefill registered before decode launches; concurrent start at 0.40 each loses the GPU memory race on a single card):

```bash
docker exec dynamo-sglang bash -c '
  curl -sS -X POST http://localhost:8000/v1/chat/completions \
    -H "Content-Type: application/json" \
    -d "{\"model\":\"Qwen/Qwen3-0.6B\",
         \"messages\":[{\"role\":\"user\",\"content\":\"Reply with the single word: ping\"}],
         \"max_tokens\":10,\"stream\":false}"'
```

Response: 200 OK, valid `chat.completion` body (`prompt_tokens=15, completion_tokens=10`).

Prefill→decode handoff via the **Bootstrap path** (router pre-resolves bootstrap, fires both workers concurrently) confirmed:

```
prefill.log:  Publishing disaggregated_endpoint for prefill worker bootstrap_host=10.110.41.163 bootstrap_port=12345
frontend.log: Prefill model registered and router activated successfully model_name="Qwen/Qwen3-0.6B"
prefill.log:  request received  rid=fef26bf3-... component=prefill  19:28:11.646
decode.log:   request received  rid=fef26bf3-... component=backend  19:28:11.647   ← 1ms later, Bootstrap path
prefill.log:  request completed rid=fef26bf3-...
decode.log:   request completed rid=fef26bf3-...
```

The 1ms gap between prefill and decode `request received` proves the Rust router took the Bootstrap path — both workers are fired in parallel rather than the router waiting for prefill to drain. This is the path the new conditional-drain fix in `_consume_prefill_stream` targets (drain inline so cancellation propagates to `engine.abort()`).

## Known follow-ups (not in this PR)

- #9345 — prefill drain() override (NIXL #7319 exposure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9348" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

