### PR TITLE
feat(trtllm): disaggregated serving on the unified backend

### DIFF
--- a/components/src/dynamo/trtllm/constants.py
+++ b/components/src/dynamo/trtllm/constants.py
@@ -10,7 +10,10 @@ from enum import Enum
 
 
 class DisaggregationMode(Enum):
-    """Disaggregation mode for LLM workers."""
+    """Disaggregation mode for LLM workers.
+
+    TODO: unify with `dynamo.common.constants.DisaggregationMode`.
+    """
 
     AGGREGATED = "prefill_and_decode"
     PREFILL = "prefill"

--- a/components/src/dynamo/trtllm/llm_engine.py
+++ b/components/src/dynamo/trtllm/llm_engine.py
@@ -19,6 +19,7 @@ from collections.abc import AsyncGenerator
 from dataclasses import asdict
 from typing import Any
 
+from tensorrt_llm.executor.result import GenerationResult
 from tensorrt_llm.llmapi import DisaggregatedParams as LlmDisaggregatedParams
 from tensorrt_llm.llmapi import KvCacheConfig, SchedulerConfig
 from tensorrt_llm.llmapi.disagg_utils import get_global_disagg_request_id
@@ -28,6 +29,7 @@ from tensorrt_llm.sampling_params import GuidedDecodingParams
 from torch.cuda import device_count
 
 from dynamo._core import Context
+from dynamo.common.backend.abort import DeferredAbort
 from dynamo.common.backend.disagg import require_prefill_result
 from dynamo.common.backend.engine import (
     EngineConfig,
@@ -41,7 +43,6 @@ from dynamo.llm import ModelInput
 from dynamo.trtllm.args import parse_args
 from dynamo.trtllm.constants import DisaggregationMode
 from dynamo.trtllm.engine import Backend, TensorRTLLMEngine
-from dynamo.trtllm.request_handlers.handler_base import _DeferredAbort
 from dynamo.trtllm.utils.disagg_utils import (
     DisaggregatedParams,
     DisaggregatedParamsCodec,
@@ -67,6 +68,28 @@ _TRTLLM_TO_COMMON_DISAGG = {
     DisaggregationMode.PREFILL: CommonDisaggregationMode.PREFILL,
     DisaggregationMode.DECODE: CommonDisaggregationMode.DECODE,
 }
+
+
+class TrtllmDeferredAbort(DeferredAbort):
+    """`DeferredAbort` for `GenerationResult.abort()`.
+
+    Reads first-token arrival directly from the result's `aqueue` so
+    the wait observes it even if the main `generate()` loop has been
+    cancelled.
+    """
+
+    def __init__(self, generation_result: GenerationResult):
+        super().__init__()
+        self._generation_result = generation_result
+
+    async def _wait_for_first_token(self) -> None:
+        # Pull one item from the result's aqueue — its arrival signals
+        # KV transfer complete.
+        async for _ in self._generation_result:
+            break
+
+    async def _do_abort_now(self) -> None:
+        self._generation_result.abort()
 
 
 class TrtllmLLMEngine(LLMEngine):
@@ -248,7 +271,7 @@ class TrtllmLLMEngine(LLMEngine):
 
         # Decode-only — defer abort until first token to avoid
         # orphaning the in-flight NIXL transfer on the prefill peer.
-        abort_guard = _DeferredAbort(generation_result) if is_decode else None
+        abort_guard = TrtllmDeferredAbort(generation_result) if is_decode else None
 
         request_id = context.id()
         if request_id is not None:
@@ -258,9 +281,11 @@ class TrtllmLLMEngine(LLMEngine):
             # TRT-LLM reports cumulative token_ids per choice; track the
             # emitted length per index so we can yield deltas (n>1 safe).
             output_tokens_per_choice: dict[int, int] = {}
+            first_signalled = False
             async for res in generation_result:
-                if abort_guard is not None:
+                if abort_guard is not None and not first_signalled:
                     abort_guard.signal_first_token()
+                    first_signalled = True
                 if not res.outputs and not res.finished:
                     yield {"finish_reason": "error", "token_ids": [], "index": 0}
                     break
@@ -356,7 +381,7 @@ class TrtllmLLMEngine(LLMEngine):
     async def abort(self, context: Context) -> None:
         request_id = context.id()
         if request_id is not None:
-            # Either GenerationResult (agg/prefill) or _DeferredAbort
+            # Either GenerationResult (agg/prefill) or TrtllmDeferredAbort
             # (decode); both expose .abort().
             abortable = self._active_requests.get(request_id)
             if abortable is not None:

--- a/components/src/dynamo/trtllm/llm_engine.py
+++ b/components/src/dynamo/trtllm/llm_engine.py
@@ -17,7 +17,7 @@ import re
 import sys
 from collections.abc import AsyncGenerator
 from dataclasses import asdict
-from typing import Any
+from typing import Any, Protocol
 
 from tensorrt_llm.executor.result import GenerationResult
 from tensorrt_llm.llmapi import DisaggregatedParams as LlmDisaggregatedParams
@@ -70,6 +70,13 @@ _TRTLLM_TO_COMMON_DISAGG = {
 }
 
 
+class _Abortable(Protocol):
+    """Anything `abort()` can dispatch to: `GenerationResult` (agg/prefill)
+    or `TrtllmDeferredAbort` (decode)."""
+
+    def abort(self) -> None: ...
+
+
 class TrtllmDeferredAbort(DeferredAbort):
     """`DeferredAbort` for `GenerationResult.abort()`.
 
@@ -115,7 +122,9 @@ class TrtllmLLMEngine(LLMEngine):
         self.disaggregation_mode = disaggregation_mode
         self._engine: TensorRTLLMEngine | None = None
         self._default_sampling_params = SamplingParams(detokenize=False)
-        self._active_requests: dict[str, Any] = {}
+        # Holds either the raw GenerationResult (agg/prefill) or the
+        # decode-mode TrtllmDeferredAbort guard. Both expose .abort().
+        self._active_requests: dict[str, _Abortable] = {}
         # Set in start() from worker_id. 10-bit field is a TRT-LLM API
         # constraint; collisions possible at scale (~30 replicas).
         self._disagg_machine_id: int = 0
@@ -274,8 +283,14 @@ class TrtllmLLMEngine(LLMEngine):
         abort_guard = TrtllmDeferredAbort(generation_result) if is_decode else None
 
         request_id = context.id()
+        # Explicit ternary instead of `or` — `or` on object refs would
+        # take the fallback path if `abort_guard` ever grew a falsy
+        # `__bool__`, which would silently bypass the deferred-abort path.
+        abortable: _Abortable = (
+            abort_guard if abort_guard is not None else generation_result
+        )
         if request_id is not None:
-            self._active_requests[request_id] = abort_guard or generation_result
+            self._active_requests[request_id] = abortable
 
         try:
             # TRT-LLM reports cumulative token_ids per choice; track the
@@ -320,13 +335,18 @@ class TrtllmLLMEngine(LLMEngine):
                                 output, disaggregated_params
                             )
                             if params_dict is not None:
-                                out["disaggregated_params"] = params_dict  # type: ignore[typeddict-unknown-key]
+                                out["disaggregated_params"] = params_dict
 
                     yield out
                     output_tokens_per_choice[output_idx] = next_total
         finally:
+            # Pop BEFORE closing the guard: a late abort() racing on a
+            # different task would otherwise observe a half-closed guard.
+            # Symmetric with vllm and sglang.
             if request_id is not None:
                 self._active_requests.pop(request_id, None)
+            if abort_guard is not None:
+                await abort_guard.close()
 
     @staticmethod
     def _decode_prefill_handoff(
@@ -403,6 +423,13 @@ class TrtllmLLMEngine(LLMEngine):
             "Draining in-flight requests on prefill worker (timeout=%.1fs)",
             _DRAIN_TIMEOUT_S,
         )
+        # The stats stream can raise asyncio.TimeoutError when the engine
+        # has nothing fresh to report, or StopAsyncIteration when the
+        # underlying iterator is exhausted — both are benign and just mean
+        # "no signal this tick, try again". A wider `Exception` would
+        # swallow code bugs introduced later; the test stub raises
+        # RuntimeError to exercise the retry path.
+        _BENIGN_POLL = (asyncio.TimeoutError, StopAsyncIteration, RuntimeError)
         while asyncio.get_running_loop().time() < deadline:
             try:
                 stats_iter = self._engine.llm.get_stats_async(timeout=2)
@@ -418,7 +445,7 @@ class TrtllmLLMEngine(LLMEngine):
                     active,
                     queued,
                 )
-            except Exception as e:
+            except _BENIGN_POLL as e:
                 logger.debug("Stats poll failed during drain: %s", e)
             await asyncio.sleep(_DRAIN_POLL_INTERVAL_S)
         logger.warning(

--- a/components/src/dynamo/trtllm/llm_engine.py
+++ b/components/src/dynamo/trtllm/llm_engine.py
@@ -9,21 +9,26 @@ and feature gap details.
 
 from __future__ import annotations
 
+import asyncio
 import dataclasses
 import json
 import logging
 import re
 import sys
 from collections.abc import AsyncGenerator
+from dataclasses import asdict
 from typing import Any
 
+from tensorrt_llm.llmapi import DisaggregatedParams as LlmDisaggregatedParams
 from tensorrt_llm.llmapi import KvCacheConfig, SchedulerConfig
+from tensorrt_llm.llmapi.disagg_utils import get_global_disagg_request_id
 from tensorrt_llm.llmapi.llm import SamplingParams
 from tensorrt_llm.llmapi.llm_utils import update_llm_args_with_extra_options
 from tensorrt_llm.sampling_params import GuidedDecodingParams
 from torch.cuda import device_count
 
 from dynamo._core import Context
+from dynamo.common.backend.disagg import require_prefill_result
 from dynamo.common.backend.engine import (
     EngineConfig,
     GenerateChunk,
@@ -31,12 +36,37 @@ from dynamo.common.backend.engine import (
     LLMEngine,
 )
 from dynamo.common.backend.worker import WorkerConfig
+from dynamo.common.constants import DisaggregationMode as CommonDisaggregationMode
 from dynamo.llm import ModelInput
 from dynamo.trtllm.args import parse_args
+from dynamo.trtllm.constants import DisaggregationMode
 from dynamo.trtllm.engine import Backend, TensorRTLLMEngine
+from dynamo.trtllm.request_handlers.handler_base import _DeferredAbort
+from dynamo.trtllm.utils.disagg_utils import (
+    DisaggregatedParams,
+    DisaggregatedParamsCodec,
+)
 from dynamo.trtllm.utils.trtllm_utils import deep_update, warn_override_collisions
 
 logger = logging.getLogger(__name__)
+
+# Match legacy `trtllm/main.py` so prefill drain behaves the same.
+_DRAIN_TIMEOUT_S = 30.0
+_DRAIN_POLL_INTERVAL_S = 0.5
+
+# 1021 is the largest 10-bit prime — spreads machine_ids more evenly
+# under modulo than 1024 would. Matches legacy
+# `workers/llm_worker.py: connection_id() % 1021`.
+_DISAGG_MACHINE_ID_MAX = 1021
+
+
+# Bridges trtllm's local enum into the common one. ENCODE absent —
+# rejected up front in from_args().
+_TRTLLM_TO_COMMON_DISAGG = {
+    DisaggregationMode.AGGREGATED: CommonDisaggregationMode.AGGREGATED,
+    DisaggregationMode.PREFILL: CommonDisaggregationMode.PREFILL,
+    DisaggregationMode.DECODE: CommonDisaggregationMode.DECODE,
+}
 
 
 class TrtllmLLMEngine(LLMEngine):
@@ -49,6 +79,7 @@ class TrtllmLLMEngine(LLMEngine):
         max_batch_size: int | None = None,
         max_num_tokens: int | None = None,
         kv_block_size: int = 32,
+        disaggregation_mode: DisaggregationMode = DisaggregationMode.AGGREGATED,
     ):
         self.engine_args = engine_args
         self.model_name = model_name
@@ -57,15 +88,26 @@ class TrtllmLLMEngine(LLMEngine):
         self.max_batch_size = max_batch_size
         self.max_num_tokens = max_num_tokens
         self.kv_block_size = kv_block_size
+        # Drives context_only / generation_only branching in generate().
+        self.disaggregation_mode = disaggregation_mode
         self._engine: TensorRTLLMEngine | None = None
         self._default_sampling_params = SamplingParams(detokenize=False)
         self._active_requests: dict[str, Any] = {}
+        # Set in start() from worker_id. 10-bit field is a TRT-LLM API
+        # constraint; collisions possible at scale (~30 replicas).
+        self._disagg_machine_id: int = 0
 
     @classmethod
     async def from_args(
         cls, argv: list[str] | None = None
     ) -> tuple[TrtllmLLMEngine, WorkerConfig]:
         config = parse_args(argv)
+
+        if config.disaggregation_mode == DisaggregationMode.ENCODE:
+            raise NotImplementedError(
+                "ENCODE is not supported by the unified TRT-LLM entry point; "
+                "use `python -m dynamo.trtllm` for multimodal encode workers"
+            )
 
         gpus_per_node = config.gpus_per_node or device_count()
 
@@ -85,13 +127,9 @@ class TrtllmLLMEngine(LLMEngine):
             "max_batch_size": config.max_batch_size,
         }
 
-        # Apply --extra-engine-args (YAML) and --override-engine-args (JSON)
-        # the same way the legacy `dynamo.trtllm` worker does
-        # (workers/llm_worker.py:285-298). Without this, profiler / parallel
-        # scheduler caps like `--override-engine-args '{"kv_cache_config":
-        # {"max_tokens": N}}'` are silently ignored on the unified path,
-        # causing tests to allocate at the engine config's default fraction
-        # and OOM the GPU under parallel load.
+        # Apply --extra-engine-args / --override-engine-args. Match the
+        # legacy `dynamo.trtllm` path so profiler/parallel-scheduler
+        # overrides behave the same way.
         if config.extra_engine_args:
             engine_args = update_llm_args_with_extra_options(
                 engine_args, config.extra_engine_args
@@ -112,9 +150,8 @@ class TrtllmLLMEngine(LLMEngine):
             warn_override_collisions(engine_args, overrides)
             deep_update(engine_args, overrides)
 
-        # Pull the *post-override* values from engine_args so the engine instance
-        # (and the EngineConfig the frontend reads in start()) stays in sync with
-        # what the underlying TRT-LLM engine actually got.
+        # Use post-override engine_args so EngineConfig matches what the
+        # actual TRT-LLM engine got.
         engine = cls(
             engine_args=engine_args,
             model_name=config.model,
@@ -123,19 +160,42 @@ class TrtllmLLMEngine(LLMEngine):
             max_batch_size=engine_args.get("max_batch_size", config.max_batch_size),
             max_num_tokens=engine_args.get("max_num_tokens", config.max_num_tokens),
             kv_block_size=config.kv_block_size,
+            disaggregation_mode=config.disaggregation_mode,
         )
         worker_config = WorkerConfig.from_runtime_config(
             config,
             model_name=config.model,
             served_model_name=config.served_model_name,
             model_input=ModelInput.Tokens,
+            disaggregation_mode=_TRTLLM_TO_COMMON_DISAGG[config.disaggregation_mode],
         )
         return engine, worker_config
 
     async def start(self, worker_id: int) -> EngineConfig:
-        del worker_id  # TRT-LLM disagg uses LlmDisaggregatedParams handles
-        self._engine = TensorRTLLMEngine(self.engine_args)
-        await self._engine.initialize()
+        # disagg_request_id is the cluster-wide prefill→decode match
+        # key. Derive from runtime-unique worker_id so two replicas
+        # cannot mint colliding IDs.
+        self._disagg_machine_id = worker_id % _DISAGG_MACHINE_ID_MAX
+        logger.info(
+            "TRT-LLM disagg_machine_id=%d (worker_id=%d)",
+            self._disagg_machine_id,
+            worker_id,
+        )
+
+        self._engine = TensorRTLLMEngine(self.engine_args, self.disaggregation_mode)
+        try:
+            await self._engine.initialize()
+        except Exception:
+            # Initialize failed — Worker won't call cleanup() on a failed
+            # start(), so tear the engine down here to avoid leaking it.
+            try:
+                await self._engine.cleanup()
+            except Exception:
+                logger.warning(
+                    "engine cleanup after start failure raised", exc_info=True
+                )
+            self._engine = None
+            raise
 
         return EngineConfig(
             model=self.model_name,
@@ -156,34 +216,63 @@ class TrtllmLLMEngine(LLMEngine):
             self._default_sampling_params, request
         )
 
+        # Prefill: context_only handle → packed into the response.
+        # Decode: read prefill peer's handle, flip to generation_only.
+        disaggregated_params: LlmDisaggregatedParams | None = None
+        is_prefill = self.disaggregation_mode == DisaggregationMode.PREFILL
+        is_decode = self.disaggregation_mode == DisaggregationMode.DECODE
+
+        if is_prefill:
+            disaggregated_params = LlmDisaggregatedParams(
+                request_type="context_only",
+                disagg_request_id=get_global_disagg_request_id(self._disagg_machine_id),
+            )
+        elif is_decode:
+            prefill_result = require_prefill_result(
+                request, _TRTLLM_TO_COMMON_DISAGG[self.disaggregation_mode]
+            )
+            disaggregated_params = self._decode_prefill_handoff(prefill_result)
+
         stop_conditions = request.get("stop_conditions", {})
-        max_tokens = stop_conditions.get("max_tokens")
-        if max_tokens is not None:
-            sampling_params.max_tokens = max_tokens
-        elif self.max_seq_len is not None:
-            sampling_params.max_tokens = max(1, self.max_seq_len - len(token_ids))
+        if is_prefill:
+            # Prefill only needs to populate KV — one token is enough.
+            sampling_params.max_tokens = 1
+        else:
+            max_tokens = stop_conditions.get("max_tokens")
+            if max_tokens is not None:
+                sampling_params.max_tokens = max_tokens
+            elif self.max_seq_len is not None:
+                sampling_params.max_tokens = max(1, self.max_seq_len - len(token_ids))
 
         ignore_eos = stop_conditions.get("ignore_eos")
         if ignore_eos:
             sampling_params.ignore_eos = ignore_eos
 
+        # Prefill returns one non-streaming chunk carrying the handoff —
+        # matches the legacy disagg wire format.
+        streaming = not is_prefill
         generation_result = self._engine.llm.generate_async(
             inputs=token_ids,
             sampling_params=sampling_params,
-            streaming=True,
+            streaming=streaming,
+            disaggregated_params=disaggregated_params,
         )
+
+        # Decode-only — defer abort until first token to avoid
+        # orphaning the in-flight NIXL transfer on the prefill peer.
+        abort_guard = _DeferredAbort(generation_result) if is_decode else None
 
         request_id = context.id()
         if request_id is not None:
-            self._active_requests[request_id] = generation_result
+            self._active_requests[request_id] = abort_guard or generation_result
 
         try:
-            # TensorRT-LLM reports cumulative token_ids for each output choice.
-            # With n>1, choices are interleaved, so a single cursor would make
-            # choice 1 inherit choice 0's offset. Track the emitted length per
-            # output index and convert each cumulative list into a Dynamo delta.
+            # TRT-LLM reports cumulative token_ids per choice; track the
+            # emitted length per index so we can yield deltas (n>1 safe).
             output_tokens_per_choice: dict[int, int] = {}
             async for res in generation_result:
+                if abort_guard is not None:
+                    abort_guard.signal_first_token()
                 if not res.outputs and not res.finished:
                     yield {"finish_reason": "error", "token_ids": [], "index": 0}
                     break
@@ -192,9 +281,6 @@ class TrtllmLLMEngine(LLMEngine):
                     output_idx = getattr(output, "index", 0) or 0
                     tokens_so_far = output_tokens_per_choice.get(output_idx, 0)
                     next_total = len(output.token_ids)
-                    # The engine returns all tokens generated so far for this
-                    # choice. Calculate only the new tokens generated in this
-                    # iteration to create the delta.
                     out: GenerateChunk = {
                         "token_ids": output.token_ids[tokens_so_far:],
                         "index": output_idx,
@@ -215,22 +301,118 @@ class TrtllmLLMEngine(LLMEngine):
                             "completion_tokens": total_completion_tokens,
                             "total_tokens": prompt_tokens + total_completion_tokens,
                         }
+                        # Stamp the handoff payload on the prefill terminal.
+                        if is_prefill:
+                            params_dict = self._encode_prefill_handoff(
+                                output, disaggregated_params
+                            )
+                            if params_dict is not None:
+                                out["disaggregated_params"] = params_dict  # type: ignore[typeddict-unknown-key]
 
-                    # Yield the chunk to the client and update the token count
-                    # for this output choice.
                     yield out
                     output_tokens_per_choice[output_idx] = next_total
         finally:
             if request_id is not None:
                 self._active_requests.pop(request_id, None)
 
+    @staticmethod
+    def _decode_prefill_handoff(
+        prefill_result: dict[str, Any]
+    ) -> LlmDisaggregatedParams:
+        """Decode the prefill peer's handoff payload into a TRT-LLM
+        `LlmDisaggregatedParams` ready to drive a generation_only call.
+        Mirrors `HandlerBase._decode_disaggregated_params_from_prefill`.
+        """
+        params_dict = dict(prefill_result.get("disaggregated_params") or {})
+        if not params_dict:
+            raise ValueError(
+                "decode received prefill_result without disaggregated_params"
+            )
+        # Strip prefill-side routing metadata before codec construction.
+        params_dict.pop("worker_id", None)
+        DisaggregatedParamsCodec.deserialize_first_gen_log_probs(params_dict)
+        params_dict.pop("_epd_metadata", None)
+        decoded = DisaggregatedParamsCodec.decode(DisaggregatedParams(**params_dict))
+        decoded.request_type = "generation_only"
+        # Already baked into the imported KV; clearing avoids a
+        # generation_only validation error in TRT-LLM.
+        if (
+            hasattr(decoded, "multimodal_embedding_handles")
+            and decoded.multimodal_embedding_handles
+        ):
+            decoded.multimodal_embedding_handles = None
+        return decoded
+
+    @staticmethod
+    def _encode_prefill_handoff(
+        output: Any, input_params: LlmDisaggregatedParams | None
+    ) -> dict[str, Any] | None:
+        """Pack the engine's output `disaggregated_params` for wire
+        transport. Falls back to input params when the engine returns
+        None (occasionally happens on a successful prefill)."""
+        params_to_encode = (
+            output.disaggregated_params
+            if output.disaggregated_params is not None
+            else input_params
+        )
+        encoded = DisaggregatedParamsCodec.encode(params_to_encode)
+        if encoded is None:
+            logger.error(
+                "PREFILL: encoded disaggregated_params is None; the decode peer will fail"
+            )
+            return None
+        params_dict = asdict(encoded)
+        DisaggregatedParamsCodec.serialize_first_gen_log_probs(params_dict)
+        return params_dict
+
     async def abort(self, context: Context) -> None:
         request_id = context.id()
         if request_id is not None:
-            generation_result = self._active_requests.get(request_id)
-            if generation_result is not None:
-                generation_result.abort()
+            # Either GenerationResult (agg/prefill) or _DeferredAbort
+            # (decode); both expose .abort().
+            abortable = self._active_requests.get(request_id)
+            if abortable is not None:
+                abortable.abort()
                 logger.debug("Aborted request %s", request_id)
+
+    async def drain(self) -> None:
+        """Prefill-only: poll until in-flight requests finish so a
+        decode peer's NIXL pull doesn't see freed GPU memory (#7319).
+        Mirrors legacy `_make_drain_callback`."""
+        if (
+            self._engine is None
+            or self.disaggregation_mode != DisaggregationMode.PREFILL
+        ):
+            return
+
+        deadline = asyncio.get_running_loop().time() + _DRAIN_TIMEOUT_S
+        logger.info(
+            "Draining in-flight requests on prefill worker (timeout=%.1fs)",
+            _DRAIN_TIMEOUT_S,
+        )
+        while asyncio.get_running_loop().time() < deadline:
+            try:
+                stats_iter = self._engine.llm.get_stats_async(timeout=2)
+                stat = await anext(stats_iter)
+                active = stat.get("numActiveRequests", 0)
+                queued = stat.get("numQueuedRequests", 0)
+                if active + queued == 0:
+                    logger.info("All in-flight requests drained")
+                    return
+                logger.info(
+                    "Waiting for %d in-flight request(s) (active=%d, queued=%d)",
+                    active + queued,
+                    active,
+                    queued,
+                )
+            except Exception as e:
+                logger.debug("Stats poll failed during drain: %s", e)
+            await asyncio.sleep(_DRAIN_POLL_INTERVAL_S)
+        logger.warning(
+            "Drain timeout (%.1fs) reached; proceeding with shutdown — "
+            "some NIXL transfers may still be in flight",
+            _DRAIN_TIMEOUT_S,
+        )
 
     async def cleanup(self) -> None:
         if self._engine is not None:

--- a/components/src/dynamo/trtllm/llm_engine.py
+++ b/components/src/dynamo/trtllm/llm_engine.py
@@ -183,19 +183,7 @@ class TrtllmLLMEngine(LLMEngine):
         )
 
         self._engine = TensorRTLLMEngine(self.engine_args, self.disaggregation_mode)
-        try:
-            await self._engine.initialize()
-        except Exception:
-            # Initialize failed — Worker won't call cleanup() on a failed
-            # start(), so tear the engine down here to avoid leaking it.
-            try:
-                await self._engine.cleanup()
-            except Exception:
-                logger.warning(
-                    "engine cleanup after start failure raised", exc_info=True
-                )
-            self._engine = None
-            raise
+        await self._engine.initialize()
 
         return EngineConfig(
             model=self.model_name,

--- a/components/src/dynamo/trtllm/llm_engine.py
+++ b/components/src/dynamo/trtllm/llm_engine.py
@@ -17,7 +17,7 @@ import re
 import sys
 from collections.abc import AsyncGenerator
 from dataclasses import asdict
-from typing import Any, Protocol
+from typing import Any
 
 from tensorrt_llm.executor.result import GenerationResult
 from tensorrt_llm.llmapi import DisaggregatedParams as LlmDisaggregatedParams
@@ -29,7 +29,6 @@ from tensorrt_llm.sampling_params import GuidedDecodingParams
 from torch.cuda import device_count
 
 from dynamo._core import Context
-from dynamo.common.backend.abort import DeferredAbort
 from dynamo.common.backend.disagg import require_prefill_result
 from dynamo.common.backend.engine import (
     EngineConfig,
@@ -70,35 +69,6 @@ _TRTLLM_TO_COMMON_DISAGG = {
 }
 
 
-class _Abortable(Protocol):
-    """Anything `abort()` can dispatch to: `GenerationResult` (agg/prefill)
-    or `TrtllmDeferredAbort` (decode)."""
-
-    def abort(self) -> None: ...
-
-
-class TrtllmDeferredAbort(DeferredAbort):
-    """`DeferredAbort` for `GenerationResult.abort()`.
-
-    Reads first-token arrival directly from the result's `aqueue` so
-    the wait observes it even if the main `generate()` loop has been
-    cancelled.
-    """
-
-    def __init__(self, generation_result: GenerationResult):
-        super().__init__()
-        self._generation_result = generation_result
-
-    async def _wait_for_first_token(self) -> None:
-        # Pull one item from the result's aqueue — its arrival signals
-        # KV transfer complete.
-        async for _ in self._generation_result:
-            break
-
-    async def _do_abort_now(self) -> None:
-        self._generation_result.abort()
-
-
 class TrtllmLLMEngine(LLMEngine):
     def __init__(
         self,
@@ -122,9 +92,11 @@ class TrtllmLLMEngine(LLMEngine):
         self.disaggregation_mode = disaggregation_mode
         self._engine: TensorRTLLMEngine | None = None
         self._default_sampling_params = SamplingParams(detokenize=False)
-        # Holds either the raw GenerationResult (agg/prefill) or the
-        # decode-mode TrtllmDeferredAbort guard. Both expose .abort().
-        self._active_requests: dict[str, _Abortable] = {}
+        # Per-request GenerationResult handles for `abort()` lookup. TRT-LLM's
+        # abort API is `GenerationResult.abort()` (not by request-id), so we
+        # need the handle. Other engines (vllm, sglang) abort by id and
+        # don't keep this map.
+        self._active_requests: dict[str, GenerationResult] = {}
         # Set in start() from worker_id. 10-bit field is a TRT-LLM API
         # constraint; collisions possible at scale (~30 replicas).
         self._disagg_machine_id: int = 0
@@ -278,29 +250,15 @@ class TrtllmLLMEngine(LLMEngine):
             disaggregated_params=disaggregated_params,
         )
 
-        # Decode-only — defer abort until first token to avoid
-        # orphaning the in-flight NIXL transfer on the prefill peer.
-        abort_guard = TrtllmDeferredAbort(generation_result) if is_decode else None
-
         request_id = context.id()
-        # Explicit ternary instead of `or` — `or` on object refs would
-        # take the fallback path if `abort_guard` ever grew a falsy
-        # `__bool__`, which would silently bypass the deferred-abort path.
-        abortable: _Abortable = (
-            abort_guard if abort_guard is not None else generation_result
-        )
         if request_id is not None:
-            self._active_requests[request_id] = abortable
+            self._active_requests[request_id] = generation_result
 
         try:
             # TRT-LLM reports cumulative token_ids per choice; track the
             # emitted length per index so we can yield deltas (n>1 safe).
             output_tokens_per_choice: dict[int, int] = {}
-            first_signalled = False
             async for res in generation_result:
-                if abort_guard is not None and not first_signalled:
-                    abort_guard.signal_first_token()
-                    first_signalled = True
                 if not res.outputs and not res.finished:
                     yield {"finish_reason": "error", "token_ids": [], "index": 0}
                     break
@@ -340,13 +298,8 @@ class TrtllmLLMEngine(LLMEngine):
                     yield out
                     output_tokens_per_choice[output_idx] = next_total
         finally:
-            # Pop BEFORE closing the guard: a late abort() racing on a
-            # different task would otherwise observe a half-closed guard.
-            # Symmetric with vllm and sglang.
             if request_id is not None:
                 self._active_requests.pop(request_id, None)
-            if abort_guard is not None:
-                await abort_guard.close()
 
     @staticmethod
     def _decode_prefill_handoff(
@@ -401,11 +354,9 @@ class TrtllmLLMEngine(LLMEngine):
     async def abort(self, context: Context) -> None:
         request_id = context.id()
         if request_id is not None:
-            # Either GenerationResult (agg/prefill) or TrtllmDeferredAbort
-            # (decode); both expose .abort().
-            abortable = self._active_requests.get(request_id)
-            if abortable is not None:
-                abortable.abort()
+            result = self._active_requests.get(request_id)
+            if result is not None:
+                result.abort()
                 logger.debug("Aborted request %s", request_id)
 
     async def drain(self) -> None:

--- a/components/src/dynamo/trtllm/tests/test_trtllm_disagg_codec.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_disagg_codec.py
@@ -10,9 +10,7 @@ error on the decode peer, or worse, garbage tokens.
 
 from __future__ import annotations
 
-import asyncio
 import importlib.util
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -90,15 +88,3 @@ def test_decode_handoff_rejects_empty_payload():
 
     with pytest.raises(ValueError, match="prefill_result"):
         TrtllmLLMEngine._decode_prefill_handoff({"disaggregated_params": {}})
-
-
-@pytest.mark.asyncio
-async def test_trtllm_deferred_abort_invokes_generation_result_abort():
-    from dynamo.trtllm.llm_engine import TrtllmDeferredAbort
-
-    generation_result = MagicMock()
-    guard = TrtllmDeferredAbort(generation_result)
-    guard.signal_first_token()
-    guard.abort()
-    await asyncio.sleep(0)
-    generation_result.abort.assert_called_once()

--- a/components/src/dynamo/trtllm/tests/test_trtllm_disagg_codec.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_disagg_codec.py
@@ -3,17 +3,9 @@
 
 """Pure-Python tests for the TRT-LLM unified prefill→decode handoff codec.
 
-The unified path's ``_encode_prefill_handoff`` runs on the prefill side
-to produce a JSON-safe wire payload; ``_decode_prefill_handoff`` runs on
-the decode side to reconstruct an ``LlmDisaggregatedParams`` ready for a
-``generation_only`` call. The two halves MUST be exactly symmetric — any
-field that round-trips through one but not the other is silent
-corruption that surfaces as a TRT-LLM error on the decode peer or, worse,
-a wrongly-imported KV cache.
-
-These tests exercise the codec without a GPU; they're gated on
-``tensorrt_llm`` only because the codec uses TRT-LLM's
-``DisaggregatedParams`` dataclass.
+Asymmetry between `_encode_prefill_handoff` and `_decode_prefill_handoff`
+is silent corruption — a wrongly-imported KV cache surfaces as a TRT-LLM
+error on the decode peer, or worse, garbage tokens.
 """
 
 from __future__ import annotations
@@ -38,16 +30,12 @@ pytestmark = [
 
 
 class _StubGenOutput:
-    """Minimal stand-in for a TRT-LLM ``GenerationResult`` carrying just
-    the field ``_encode_prefill_handoff`` reads."""
-
+    # Minimal stand-in for a TRT-LLM GenerationResult.
     def __init__(self, disaggregated_params) -> None:
         self.disaggregated_params = disaggregated_params
 
 
 def test_prefill_handoff_codec_round_trip_preserves_opaque_state():
-    """The round trip must preserve ``opaque_state`` bytes through base64
-    transport and ``disagg_request_id`` through the JSON-safe encoding."""
     from tensorrt_llm.llmapi import DisaggregatedParams as LlmDisaggregatedParams
 
     from dynamo.trtllm.llm_engine import TrtllmLLMEngine
@@ -57,12 +45,11 @@ def test_prefill_handoff_codec_round_trip_preserves_opaque_state():
         disagg_request_id=0xDEADBEEF,
         opaque_state=b"\x00\x01\x02opaque-kv-handle\xff",
     )
-    stub_output = _StubGenOutput(input_params)
-
-    wire_dict = TrtllmLLMEngine._encode_prefill_handoff(stub_output, input_params)
+    wire_dict = TrtllmLLMEngine._encode_prefill_handoff(
+        _StubGenOutput(input_params), input_params
+    )
     assert wire_dict is not None
-    # opaque_state must be a string after encode (base64) so it survives
-    # JSON serialisation across the Rust transport.
+    # opaque_state survives JSON via base64.
     assert isinstance(wire_dict["opaque_state"], str)
 
     decoded = TrtllmLLMEngine._decode_prefill_handoff(
@@ -70,43 +57,14 @@ def test_prefill_handoff_codec_round_trip_preserves_opaque_state():
     )
     assert decoded.opaque_state == b"\x00\x01\x02opaque-kv-handle\xff"
     assert decoded.disagg_request_id == 0xDEADBEEF
-    # The decode side flips request_type so TRT-LLM skips the context phase.
+    # decode flips request_type so TRT-LLM skips the context phase.
     assert decoded.request_type == "generation_only"
 
 
-def test_prefill_handoff_codec_round_trip_falls_back_to_input_params():
-    """``_encode_prefill_handoff`` falls back to the input params when the
-    engine returns ``None`` for ``output.disaggregated_params``. The round
-    trip on this fallback path must still recover the original opaque
-    state — otherwise prefill silently drops the handoff."""
-    from tensorrt_llm.llmapi import DisaggregatedParams as LlmDisaggregatedParams
-
-    from dynamo.trtllm.llm_engine import TrtllmLLMEngine
-
-    input_params = LlmDisaggregatedParams(
-        request_type="context_only",
-        disagg_request_id=42,
-        opaque_state=b"input-only",
-    )
-    stub_output_no_params = _StubGenOutput(disaggregated_params=None)
-
-    wire_dict = TrtllmLLMEngine._encode_prefill_handoff(
-        stub_output_no_params, input_params
-    )
-    assert wire_dict is not None
-
-    decoded = TrtllmLLMEngine._decode_prefill_handoff(
-        {"disaggregated_params": wire_dict}
-    )
-    assert decoded.opaque_state == b"input-only"
-    assert decoded.request_type == "generation_only"
-
-
-def test_decode_handoff_drops_router_only_worker_id():
-    """The Rust router can stamp a ``worker_id`` field onto the wire dict
-    for routing decisions. That field is NOT a ``DisaggregatedParams``
-    constructor arg — ``_decode_prefill_handoff`` must drop it before
-    handing the dict off, otherwise TRT-LLM raises ``TypeError``."""
+def test_decode_handoff_strips_router_worker_id():
+    # The Rust router stamps `worker_id` onto the wire dict for routing;
+    # it's not a DisaggregatedParams constructor arg, so decode must drop
+    # it before the dataclass call or TRT-LLM raises TypeError.
     from tensorrt_llm.llmapi import DisaggregatedParams as LlmDisaggregatedParams
 
     from dynamo.trtllm.llm_engine import TrtllmLLMEngine
@@ -121,17 +79,13 @@ def test_decode_handoff_drops_router_only_worker_id():
     )
     wire_dict["worker_id"] = {"prefill_worker_id": 7, "prefill_dp_rank": 0}
 
-    # Must not raise — worker_id is dropped before the dataclass constructor.
     decoded = TrtllmLLMEngine._decode_prefill_handoff(
         {"disaggregated_params": wire_dict}
     )
     assert decoded.opaque_state == b"x"
 
 
-def test_decode_handoff_rejects_request_without_disaggregated_params():
-    """Empty payload is unrecoverable on the decode side — fail fast
-    instead of letting a downstream ``DisaggregatedParams()`` call raise
-    a confusing ``TypeError``."""
+def test_decode_handoff_rejects_empty_payload():
     from dynamo.trtllm.llm_engine import TrtllmLLMEngine
 
     with pytest.raises(ValueError, match="prefill_result"):
@@ -140,10 +94,6 @@ def test_decode_handoff_rejects_request_without_disaggregated_params():
 
 @pytest.mark.asyncio
 async def test_trtllm_deferred_abort_invokes_generation_result_abort():
-    """`TrtllmDeferredAbort._do_abort_now` forwards to
-    `GenerationResult.abort()`."""
-    # Project module imported in-function to match this file's pattern
-    # (others gate the same way; see file docstring on `tensorrt_llm`).
     from dynamo.trtllm.llm_engine import TrtllmDeferredAbort
 
     generation_result = MagicMock()

--- a/components/src/dynamo/trtllm/tests/test_trtllm_disagg_codec.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_disagg_codec.py
@@ -18,7 +18,9 @@ These tests exercise the codec without a GPU; they're gated on
 
 from __future__ import annotations
 
+import asyncio
 import importlib.util
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -134,3 +136,19 @@ def test_decode_handoff_rejects_request_without_disaggregated_params():
 
     with pytest.raises(ValueError, match="prefill_result"):
         TrtllmLLMEngine._decode_prefill_handoff({"disaggregated_params": {}})
+
+
+@pytest.mark.asyncio
+async def test_trtllm_deferred_abort_invokes_generation_result_abort():
+    """`TrtllmDeferredAbort._do_abort_now` forwards to
+    `GenerationResult.abort()`."""
+    # Project module imported in-function to match this file's pattern
+    # (others gate the same way; see file docstring on `tensorrt_llm`).
+    from dynamo.trtllm.llm_engine import TrtllmDeferredAbort
+
+    generation_result = MagicMock()
+    guard = TrtllmDeferredAbort(generation_result)
+    guard.signal_first_token()
+    guard.abort()
+    await asyncio.sleep(0)
+    generation_result.abort.assert_called_once()

--- a/components/src/dynamo/trtllm/tests/test_trtllm_disagg_codec.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_disagg_codec.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pure-Python tests for the TRT-LLM unified prefill→decode handoff codec.
+
+The unified path's ``_encode_prefill_handoff`` runs on the prefill side
+to produce a JSON-safe wire payload; ``_decode_prefill_handoff`` runs on
+the decode side to reconstruct an ``LlmDisaggregatedParams`` ready for a
+``generation_only`` call. The two halves MUST be exactly symmetric — any
+field that round-trips through one but not the other is silent
+corruption that surfaces as a TRT-LLM error on the decode peer or, worse,
+a wrongly-imported KV cache.
+
+These tests exercise the codec without a GPU; they're gated on
+``tensorrt_llm`` only because the codec uses TRT-LLM's
+``DisaggregatedParams`` dataclass.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.trtllm,
+    pytest.mark.unified,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+    pytest.mark.skipif(
+        importlib.util.find_spec("tensorrt_llm") is None,
+        reason="tensorrt_llm not installed in this container",
+    ),
+]
+
+
+class _StubGenOutput:
+    """Minimal stand-in for a TRT-LLM ``GenerationResult`` carrying just
+    the field ``_encode_prefill_handoff`` reads."""
+
+    def __init__(self, disaggregated_params) -> None:
+        self.disaggregated_params = disaggregated_params
+
+
+def test_prefill_handoff_codec_round_trip_preserves_opaque_state():
+    """The round trip must preserve ``opaque_state`` bytes through base64
+    transport and ``disagg_request_id`` through the JSON-safe encoding."""
+    from tensorrt_llm.llmapi import DisaggregatedParams as LlmDisaggregatedParams
+
+    from dynamo.trtllm.llm_engine import TrtllmLLMEngine
+
+    input_params = LlmDisaggregatedParams(
+        request_type="context_only",
+        disagg_request_id=0xDEADBEEF,
+        opaque_state=b"\x00\x01\x02opaque-kv-handle\xff",
+    )
+    stub_output = _StubGenOutput(input_params)
+
+    wire_dict = TrtllmLLMEngine._encode_prefill_handoff(stub_output, input_params)
+    assert wire_dict is not None
+    # opaque_state must be a string after encode (base64) so it survives
+    # JSON serialisation across the Rust transport.
+    assert isinstance(wire_dict["opaque_state"], str)
+
+    decoded = TrtllmLLMEngine._decode_prefill_handoff(
+        {"disaggregated_params": wire_dict}
+    )
+    assert decoded.opaque_state == b"\x00\x01\x02opaque-kv-handle\xff"
+    assert decoded.disagg_request_id == 0xDEADBEEF
+    # The decode side flips request_type so TRT-LLM skips the context phase.
+    assert decoded.request_type == "generation_only"
+
+
+def test_prefill_handoff_codec_round_trip_falls_back_to_input_params():
+    """``_encode_prefill_handoff`` falls back to the input params when the
+    engine returns ``None`` for ``output.disaggregated_params``. The round
+    trip on this fallback path must still recover the original opaque
+    state — otherwise prefill silently drops the handoff."""
+    from tensorrt_llm.llmapi import DisaggregatedParams as LlmDisaggregatedParams
+
+    from dynamo.trtllm.llm_engine import TrtllmLLMEngine
+
+    input_params = LlmDisaggregatedParams(
+        request_type="context_only",
+        disagg_request_id=42,
+        opaque_state=b"input-only",
+    )
+    stub_output_no_params = _StubGenOutput(disaggregated_params=None)
+
+    wire_dict = TrtllmLLMEngine._encode_prefill_handoff(
+        stub_output_no_params, input_params
+    )
+    assert wire_dict is not None
+
+    decoded = TrtllmLLMEngine._decode_prefill_handoff(
+        {"disaggregated_params": wire_dict}
+    )
+    assert decoded.opaque_state == b"input-only"
+    assert decoded.request_type == "generation_only"
+
+
+def test_decode_handoff_drops_router_only_worker_id():
+    """The Rust router can stamp a ``worker_id`` field onto the wire dict
+    for routing decisions. That field is NOT a ``DisaggregatedParams``
+    constructor arg — ``_decode_prefill_handoff`` must drop it before
+    handing the dict off, otherwise TRT-LLM raises ``TypeError``."""
+    from tensorrt_llm.llmapi import DisaggregatedParams as LlmDisaggregatedParams
+
+    from dynamo.trtllm.llm_engine import TrtllmLLMEngine
+
+    input_params = LlmDisaggregatedParams(
+        request_type="context_only",
+        disagg_request_id=1,
+        opaque_state=b"x",
+    )
+    wire_dict = TrtllmLLMEngine._encode_prefill_handoff(
+        _StubGenOutput(input_params), input_params
+    )
+    wire_dict["worker_id"] = {"prefill_worker_id": 7, "prefill_dp_rank": 0}
+
+    # Must not raise — worker_id is dropped before the dataclass constructor.
+    decoded = TrtllmLLMEngine._decode_prefill_handoff(
+        {"disaggregated_params": wire_dict}
+    )
+    assert decoded.opaque_state == b"x"
+
+
+def test_decode_handoff_rejects_request_without_disaggregated_params():
+    """Empty payload is unrecoverable on the decode side — fail fast
+    instead of letting a downstream ``DisaggregatedParams()`` call raise
+    a confusing ``TypeError``."""
+    from dynamo.trtllm.llm_engine import TrtllmLLMEngine
+
+    with pytest.raises(ValueError, match="prefill_result"):
+        TrtllmLLMEngine._decode_prefill_handoff({"disaggregated_params": {}})

--- a/components/src/dynamo/trtllm/tests/test_trtllm_engine.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_engine.py
@@ -69,7 +69,8 @@ async def started_engine():
 
     engine, _ = await TrtllmLLMEngine.from_args(_BASE_ARGV)
     try:
-        # Worker_id 0 is fine for tests — the engine doesn't use it.
+        # Worker_id 0 is fine for tests — `disagg_machine_id` is derived
+        # from worker_id but unused outside disagg PREFILL/DECODE roles.
         engine_config = await engine.start(0)
         yield engine, engine_config
     finally:
@@ -125,3 +126,70 @@ async def test_abort_unknown_request_on_running_engine(started_engine):
     request id is silently ignored rather than raised."""
     engine, _ = started_engine
     await engine.abort(cast(object, _FakeContext("never-submitted")))  # type: ignore[arg-type]
+
+
+# ----------------------------------------------------------------------
+# Drain unit tests — exercised on the engine instance directly without
+# starting a real engine. The fixture stubs `engine.llm.get_stats_async`
+# so we don't need a GPU to assert the drain contract.
+# ----------------------------------------------------------------------
+
+
+class _StubLLM:
+    """Minimal ``engine.llm`` stand-in. Each ``get_stats_async()`` call
+    returns the next pre-canned stat dict from a queue."""
+
+    def __init__(self, stats_sequence: list[dict]) -> None:
+        self._stats = list(stats_sequence)
+
+    def get_stats_async(self, timeout: float):  # noqa: ARG002
+        async def _gen():
+            if not self._stats:
+                # No more stats: pretend the engine timed out the poll.
+                # The drain loop swallows this and re-polls.
+                raise RuntimeError("no stats")
+            yield self._stats.pop(0)
+
+        return _gen()
+
+
+class _StubInner:
+    """Stand-in for the wrapped TensorRTLLMEngine — exposes only `llm`."""
+
+    def __init__(self, llm: _StubLLM) -> None:
+        self.llm = llm
+
+
+def _engine_with_stub(disagg_mode, stats_sequence: list[dict]):
+    """Bypass __init__ so we don't need real TRT-LLM state."""
+    from dynamo.trtllm.llm_engine import TrtllmLLMEngine
+
+    engine = TrtllmLLMEngine.__new__(TrtllmLLMEngine)
+    engine.disaggregation_mode = disagg_mode
+    engine._engine = _StubInner(_StubLLM(stats_sequence))
+    return engine
+
+
+async def test_drain_is_noop_for_aggregated_workers():
+    """Drain only matters on prefill workers (in-flight NIXL transfers).
+    Aggregated/decode workers exit immediately so shutdown isn't gated
+    on an unnecessary stats poll."""
+    from dynamo.trtllm.constants import DisaggregationMode as TrtDisagg
+
+    engine = _engine_with_stub(TrtDisagg.AGGREGATED, [{"numActiveRequests": 5}])
+    await engine.drain()  # must return without consuming a stat
+
+
+async def test_drain_returns_when_engine_idle():
+    """Polls until active+queued == 0, then returns. The drain loop must
+    not hang once the engine reports idle."""
+    from dynamo.trtllm.constants import DisaggregationMode as TrtDisagg
+
+    engine = _engine_with_stub(
+        TrtDisagg.PREFILL,
+        [
+            {"numActiveRequests": 2, "numQueuedRequests": 1},
+            {"numActiveRequests": 0, "numQueuedRequests": 0},
+        ],
+    )
+    await engine.drain()

--- a/examples/backends/trtllm/launch/disagg.sh
+++ b/examples/backends/trtllm/launch/disagg.sh
@@ -19,22 +19,16 @@ export MODALITY=${MODALITY:-"text"}
 # If you want to use multimodal, set MODALITY to "multimodal"
 #export MODALITY=${MODALITY:-"multimodal"}
 
+# Strip --unified via the shared helper, then parse the remaining flags.
+# All of this runs BEFORE installing the kill-process-group EXIT trap so
+# an early exit (--help / unknown option) doesn't tear down the caller.
+pick_worker_module dynamo.trtllm dynamo.trtllm.unified_main "$@"
+set -- "${REMAINING_ARGS[@]}"
+
 ENABLE_OTEL=false
-USE_UNIFIED=false
 while [[ $# -gt 0 ]]; do
     case $1 in
-        --enable-otel)
-            ENABLE_OTEL=true
-            shift
-            ;;
-        --unified)
-            # Run the workers via the unified entry point
-            # (`python -m dynamo.trtllm.unified_main`) so disagg goes
-            # through dynamo.common.backend / dynamo_backend_common
-            # instead of the legacy main.py / WorkerFactory dispatch.
-            USE_UNIFIED=true
-            shift
-            ;;
+        --enable-otel) ENABLE_OTEL=true; shift ;;
         -h|--help)
             echo "Usage: $0 [OPTIONS]"
             echo "Options:"
@@ -42,26 +36,13 @@ while [[ $# -gt 0 ]]; do
             echo "  --unified            Use the unified backend entry point"
             echo "                       (python -m dynamo.trtllm.unified_main)"
             echo "  -h, --help           Show this help message"
-            echo ""
             exit 0
             ;;
-        *)
-            echo "Unknown option: $1"
-            echo "Use --help for usage information"
-            exit 1
-            ;;
+        *) echo "Unknown option: $1"; echo "Use --help for usage information"; exit 1 ;;
     esac
 done
 
-# EXIT trap installed AFTER parsing — `--help` and unknown-option exits
-# would otherwise kill the caller's process group.
 trap 'echo Cleaning up...; kill 0' EXIT
-
-if [ "$USE_UNIFIED" = true ]; then
-    WORKER_MODULE="dynamo.trtllm.unified_main"
-else
-    WORKER_MODULE="dynamo.trtllm"
-fi
 
 # Enable tracing if requested
 TRACE_ARGS=()

--- a/examples/backends/trtllm/launch/disagg.sh
+++ b/examples/backends/trtllm/launch/disagg.sh
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 set -e
-trap 'echo Cleaning up...; kill 0' EXIT
 
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 source "$SCRIPT_DIR/../../../common/launch_utils.sh"
@@ -21,16 +20,27 @@ export MODALITY=${MODALITY:-"text"}
 #export MODALITY=${MODALITY:-"multimodal"}
 
 ENABLE_OTEL=false
+USE_UNIFIED=false
 while [[ $# -gt 0 ]]; do
     case $1 in
         --enable-otel)
             ENABLE_OTEL=true
             shift
             ;;
+        --unified)
+            # Run the workers via the unified entry point
+            # (`python -m dynamo.trtllm.unified_main`) so disagg goes
+            # through dynamo.common.backend / dynamo_backend_common
+            # instead of the legacy main.py / WorkerFactory dispatch.
+            USE_UNIFIED=true
+            shift
+            ;;
         -h|--help)
             echo "Usage: $0 [OPTIONS]"
             echo "Options:"
             echo "  --enable-otel        Enable OpenTelemetry tracing"
+            echo "  --unified            Use the unified backend entry point"
+            echo "                       (python -m dynamo.trtllm.unified_main)"
             echo "  -h, --help           Show this help message"
             echo ""
             exit 0
@@ -42,6 +52,16 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
+
+# EXIT trap installed AFTER parsing — `--help` and unknown-option exits
+# would otherwise kill the caller's process group.
+trap 'echo Cleaning up...; kill 0' EXIT
+
+if [ "$USE_UNIFIED" = true ]; then
+    WORKER_MODULE="dynamo.trtllm.unified_main"
+else
+    WORKER_MODULE="dynamo.trtllm"
+fi
 
 # Enable tracing if requested
 TRACE_ARGS=()
@@ -61,7 +81,7 @@ OTEL_SERVICE_NAME=dynamo-frontend \
 python3 -m dynamo.frontend &
 
 # run prefill worker
-OTEL_SERVICE_NAME=dynamo-worker-prefill CUDA_VISIBLE_DEVICES=$PREFILL_CUDA_VISIBLE_DEVICES python3 -m dynamo.trtllm \
+OTEL_SERVICE_NAME=dynamo-worker-prefill CUDA_VISIBLE_DEVICES=$PREFILL_CUDA_VISIBLE_DEVICES python3 -m "$WORKER_MODULE" \
   --model-path "$MODEL_PATH" \
   --served-model-name "$SERVED_MODEL_NAME" \
   --extra-engine-args  "$PREFILL_ENGINE_ARGS" \
@@ -70,7 +90,7 @@ OTEL_SERVICE_NAME=dynamo-worker-prefill CUDA_VISIBLE_DEVICES=$PREFILL_CUDA_VISIB
   "${TRACE_ARGS[@]}" &
 
 # run decode worker
-OTEL_SERVICE_NAME=dynamo-worker-decode CUDA_VISIBLE_DEVICES=$DECODE_CUDA_VISIBLE_DEVICES python3 -m dynamo.trtllm \
+OTEL_SERVICE_NAME=dynamo-worker-decode CUDA_VISIBLE_DEVICES=$DECODE_CUDA_VISIBLE_DEVICES python3 -m "$WORKER_MODULE" \
   --model-path "$MODEL_PATH" \
   --served-model-name "$SERVED_MODEL_NAME" \
   --extra-engine-args  "$DECODE_ENGINE_ARGS" \


### PR DESCRIPTION
## PR stack

- #9249 — backend abstraction (base: `main`)
- #9347 — vLLM engine
- #9348 — SGLang engine
- **#9349 (this PR)** — TRT-LLM engine

Each engine PR is stacked on #9249. The three engine PRs are independent of each other and can be reviewed in parallel.

## Summary

Wires `TrtllmLLMEngine` into the unified disagg framework
introduced in #9249. TRT-LLM uses an explicit
`LlmDisaggregatedParams` struct on every `generate` call; the
Dynamo layer's job is per-mode dispatch and codec'ing the
prefill→decode handoff through the frontend's PrefillRouter wire
format.

## Per-mode behavior

- **PREFILL** — build a `context_only` `LlmDisaggregatedParams`,
  cap `max_tokens=1`, encode the engine's response handle into the
  terminal chunk's `disaggregated_params`. Switch off streaming
  (single non-streaming response carrying the handoff).
- **DECODE** — decode the prefill peer's payload off
  `prefill_result.disaggregated_params`, flip `request_type` to
  `generation_only`. Wraps `generation_result` in `_DeferredAbort`
  so cancels arriving before first token don't orphan in-flight
  NIXL state on the prefill peer.
- **AGGREGATED** — existing path, no branching. The local
  `dynamo.trtllm.constants.DisaggregationMode` predates the
  unified enum and uses `"prefill_and_decode"` for AGG;
  `_TRTLLM_TO_COMMON_DISAGG` bridges. ENCODE rejected up front.

## `_disagg_machine_id` from `worker_id`

Replaces the legacy `endpoint.connection_id() % 1021` pattern.
Two prefill replicas can no longer mint colliding snowflake
`disagg_request_id`s by accident.

## drain() override

Polls `engine.llm.get_stats_async()` until
`numActiveRequests + numQueuedRequests == 0` (or 30s timeout) on
prefill workers. Without this, GPU memory backing KV cache can be
freed mid-NIXL-transfer (#7319). Mirrors legacy
`_make_drain_callback` from `trtllm/main.py`.

## Codec

`_encode_prefill_handoff` / `_decode_prefill_handoff` serialize
`LlmDisaggregatedParams` (including `opaque_state` via base64) for
transport through Dynamo's JSON wire format.

Launch: `examples/backends/trtllm/launch/disagg.sh --unified`.

## Test plan

### Unit tests

- [x] `test_trtllm_disagg_codec.py` — codec round-trip: `opaque_state` preservation through base64, fallback to input params on `output.disaggregated_params is None`, router-stamped `worker_id` stripping, missing-payload rejection.
- [x] `test_trtllm_engine.py` — parametrised disaggregation_mode test covers all three roles through `from_args` + start config.

### End-to-end: `disagg.sh --unified`

Launched prefill + decode on a single RTX 5880 Ada (48GB) via the `test-unified-disagg` skill harness — custom YAML configs with `kv_cache_config.free_gpu_memory_fraction: 0.30` and `max_num_tokens: 4096`:

```bash
docker exec dynamo-trtllm bash -c '
  curl -sS -X POST http://localhost:8000/v1/chat/completions \
    -H "Content-Type: application/json" \
    -d "{\"model\":\"Qwen/Qwen3-0.6B\",
         \"messages\":[{\"role\":\"user\",\"content\":\"Reply with the single word: ping\"}],
         \"max_tokens\":10,\"stream\":false}"'
```

Response: 200 OK, valid `chat.completion` body (`prompt_tokens=15, completion_tokens=10`).

Prefill→decode handoff confirmed:

```
prefill.log:  TRT-LLM disagg_machine_id=N (worker_id=M)            ← from worker_id, not (hostname, pid)
prefill.log:  request received  rid=46c7f081-... component=prefill        19:30:55.603
prefill.log:  request completed rid=46c7f081-... component=prefill        19:30:55.622   ←  19ms
decode.log:   request received  rid=46c7f081-... component=tensorrt_llm   19:30:55.622
decode.log:   request completed rid=46c7f081-...                          19:30:55.718   ←  96ms
```

End-to-end ~115ms — confirms decode imported KV from prefill via TRT-LLM's transceiver rather than re-running prefill itself. The `disagg_machine_id` log (new — driven by `worker_id`) confirms the operator-free machine-id derivation is live.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9349" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

