### PR TITLE
fix: align XML parser parity whitespace

### DIFF
--- a/lib/parsers/src/tool_calling/parsers.rs
+++ b/lib/parsers/src/tool_calling/parsers.rs
@@ -2898,10 +2898,7 @@ fahrenheit
             .unwrap();
         assert_eq!(
             content,
-            Some(
-                "I'll help you check the weather.  Let me get that information for you."
-                    .to_string()
-            )
+            Some("I'll help you check the weather. ".to_string())
         );
         assert_eq!(result.len(), 1);
         let (name, args) = extract_name_and_args(result[0].clone());

--- a/lib/parsers/src/tool_calling/xml/parser.rs
+++ b/lib/parsers/src/tool_calling/xml/parser.rs
@@ -123,8 +123,13 @@ fn extract_tool_calls(
         if let Some(start_pos) = text[cursor..].find(start_token.as_str()) {
             let abs_start = cursor + start_pos;
 
-            // Add text before tool call to normal parts.
-            normal_parts.push(&text[cursor..abs_start]);
+            // Qwen3-Coder-style templates allow natural language before the
+            // tool call, but text after the tool-call block is not response
+            // content. Keep scanning for additional calls, but only surface
+            // normal text that precedes the first parsed call.
+            if calls.is_empty() {
+                normal_parts.push(&text[cursor..abs_start]);
+            }
 
             // Find the corresponding end token.
             if let Some(end_pos) = text[abs_start..].find(end_token.as_str()) {
@@ -146,34 +151,34 @@ fn extract_tool_calls(
                 // `<tool_call>` is preserved verbatim.
                 let block = &text[abs_start..];
                 let function_start = &config.function_start_token;
-                let function_end = &config.function_end_token;
                 if config.allow_eof_recovery
                     && block.contains(function_start.as_str())
                     && let Ok(mut parsed_calls) = parse_tool_call_block(block, config, tools)
                     && !parsed_calls.is_empty()
                 {
                     calls.append(&mut parsed_calls);
-                    // Preserve any suffix after the last function close so
-                    // non-tool trailing content isn't dropped.
-                    if let Some(last_end) = block.rfind(function_end.as_str()) {
-                        let suffix_start = abs_start + last_end + function_end.len();
-                        if suffix_start < text.len() {
-                            normal_parts.push(&text[suffix_start..]);
-                        }
-                    }
                     break;
                 }
-                normal_parts.push(&text[abs_start..]);
+                if calls.is_empty() {
+                    normal_parts.push(&text[abs_start..]);
+                }
                 break;
             }
         } else {
             // No more tool calls.
-            normal_parts.push(&text[cursor..]);
+            if calls.is_empty() {
+                normal_parts.push(&text[cursor..]);
+            }
             break;
         }
     }
 
-    let normal_text = normal_parts.join("").trim().to_string();
+    let normal_text = normal_parts.join("");
+    let normal_text = if calls.is_empty() {
+        normal_text.trim().to_string()
+    } else {
+        normal_text
+    };
     Ok((normal_text, calls))
 }
 
@@ -768,10 +773,7 @@ Dallas
             try_tool_call_parse_xml(input, &XmlParserConfig::default(), None).unwrap();
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0].function.name, "get_weather");
-        assert_eq!(
-            normal,
-            Some("I'll help you with that.  Let me check that for you.".to_string())
-        );
+        assert_eq!(normal, Some("I'll help you with that. ".to_string()));
     }
 
     #[test] // PARSER.batch.2
@@ -951,11 +953,10 @@ NYC
         assert_eq!(args["city"], "NYC");
     }
 
-    // After EOF-recovery, any non-tool suffix following the last
-    // `</function>` close must surface as normal_text rather than being
-    // dropped along with the recovered call.
+    // Qwen3-Coder-style XML treats text after the first parsed tool call as
+    // non-content, including after EOF recovery.
     #[test]
-    fn test_parse_qwen3_no_outer_close_preserves_suffix() {
+    fn test_parse_qwen3_no_outer_close_drops_suffix() {
         let input = "<tool_call>\n<function=get_weather>\n<parameter=city>\nNYC\n</parameter>\n</function>\nTRAILING NOTE";
 
         let config = XmlParserConfig {
@@ -964,11 +965,7 @@ NYC
         };
         let (calls, normal) = try_tool_call_parse_xml(input, &config, None).unwrap();
         assert_eq!(calls.len(), 1);
-        let normal = normal.unwrap_or_default();
-        assert!(
-            normal.contains("TRAILING NOTE"),
-            "normal must keep suffix after </function>: {normal:?}"
-        );
+        assert_eq!(normal, Some("".to_string()));
     }
 
     #[test] // PARSER.batch.5 — minimax_m2

--- a/tests/parity/README.md
+++ b/tests/parity/README.md
@@ -154,7 +154,7 @@ sorted alphabetically within themselves.
 | glm47 (GLM 5.1)                 | ✓   | ✓   | ✓   | ✓   | VS  | ✓   | ✓   | V   | ✓   | ✓   |
 | harmony † (gpt-oss)             | S   | S   | ✓   | S   | S   | S   | S   | S   | ✓   | S   |
 | kimi_k2 (Kimi K2.6)             | ✓   | ✓   | ✓   | S   | ✓   | ✓   | ✓   | VS  | ✓   | ✓   |
-| minimax_m2 (MiniMax 2.7)        | ✓   | ✓   | ✓   | V   | VS  | ✓   | ✓   | VS  | ✓   | ✓   |
+| minimax_m2 (MiniMax 2.7)        | ✓   | ✓   | ✓   | V   | VS  | ✓   | ✓   | ✓   | ✓   | ✓   |
 | nemotron_deci †§ (Nemotron)     | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a |
 | qwen3_coder (Qwen 3.5)          | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   |
 | **Others**                      |     |     |     |     |     |     |     |     |     |     |

--- a/tests/parity/README.md
+++ b/tests/parity/README.md
@@ -156,7 +156,7 @@ sorted alphabetically within themselves.
 | kimi_k2 (Kimi K2.6)             | ✓   | ✓   | ✓   | S   | ✓   | ✓   | ✓   | VS  | ✓   | ✓   |
 | minimax_m2 (MiniMax 2.7)        | ✓   | ✓   | ✓   | V   | VS  | ✓   | ✓   | VS  | ✓   | ✓   |
 | nemotron_deci †§ (Nemotron)     | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a |
-| qwen3_coder (Qwen 3.5)          | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | VS  | ✓   | ✓   |
+| qwen3_coder (Qwen 3.5)          | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   |
 | **Others**                      |     |     |     |     |     |     |     |     |     |     |
 | deepseek_v3                     | ✓   | ✓   | ✓   | V   | VS  | ✓   | ✓   | S   | ✓   | ✓   |
 | deepseek_v3_1                   | ✓   | ✓   | ✓   | V   | VS  | ✓   | ✓   | S   | ✓   | ✓   |

--- a/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.yaml
@@ -149,7 +149,7 @@ cases:
       - name: get_weather
         arguments:
           location: Tokyo
-      normal_text: I'll help you check the weather.
+      normal_text: "I'll help you check the weather. "
   PARSER.batch.9:
     description: Empty input
     model_text: ''

--- a/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.yaml
@@ -167,7 +167,7 @@ cases:
       - name: get_weather
         arguments:
           location: NYC
-      normal_text: I'll help you check the weather.  Let me get that information for you.
+      normal_text: "I'll help you check the weather. "
   PARSER.batch.9:
     description: Empty input
     model_text: ''

--- a/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.yaml
@@ -167,7 +167,7 @@ cases:
       - name: get_weather
         arguments:
           location: NYC
-      normal_text: I'll help you check the weather.  Let me get that information for you.
+      normal_text: "I'll help you check the weather. "
   PARSER.batch.9:
     description: Empty input
     model_text: ''

--- a/tests/parity/parser/test_parity_parser.py
+++ b/tests/parity/parser/test_parity_parser.py
@@ -45,8 +45,8 @@ _PACKAGE: dict[str, str] = {
 # than fix. Promote to a tracked bug before removing.
 #
 # Pattern: vLLM and SGLang both truncate normal_text at the *end* of the
-# tool-call wrapper across all XML-style parsers (kimi_k2, qwen3_coder, glm47).
-# Only Dynamo preserves text that appears after the closing wrapper token.
+# tool-call wrapper for some parser families. Dynamo preserves text that
+# appears after the closing wrapper token for the families still listed below.
 _TRAILING_NORMAL_TEXT_DROP = "drops trailing normal_text after tool-call wrapper end"
 _HARMONY_REQUIRES_ASSISTANT_PREFIX = (
     "SGLang's GptOssDetector bot_token requires '<|start|>assistant<|channel|>commentary' "
@@ -61,13 +61,11 @@ _RECOVERY_CONTRACT = "impl-defined recovery contract (see PARSER_CASES.md)"
 
 KNOWN_DIVERGENCES: dict[tuple[str, str, str], str] = {
     # vLLM and SGLang both truncate normal_text at the *end* of the tool-call
-    # wrapper across all XML-style parsers. Only Dynamo preserves text after
+    # wrapper for these parser families. Only Dynamo preserves text after
     # the closing wrapper token.
     ("vllm", "kimi_k2", "PARSER.batch.8"): _TRAILING_NORMAL_TEXT_DROP,
-    ("vllm", "qwen3_coder", "PARSER.batch.8"): _TRAILING_NORMAL_TEXT_DROP,
     ("vllm", "glm47", "PARSER.batch.8"): _TRAILING_NORMAL_TEXT_DROP,
     ("sglang", "kimi_k2", "PARSER.batch.8"): _TRAILING_NORMAL_TEXT_DROP,
-    ("sglang", "qwen3_coder", "PARSER.batch.8"): _TRAILING_NORMAL_TEXT_DROP,
     # SGLang's GptOssDetector requires a strict '<|start|>assistant<|channel|>commentary'
     # bot_token; bare '<|channel|>commentary' variants (PARSER.batch.1, .6, .13)
     # are not detected at all.

--- a/tests/parity/parser/test_parity_parser.py
+++ b/tests/parity/parser/test_parity_parser.py
@@ -95,9 +95,7 @@ KNOWN_DIVERGENCES: dict[tuple[str, str, str], str] = {
         "PARSER.batch.10",
     ): "Dynamo drops back-to-back commentary blocks; SGLang extracts them",
     # Whitespace handling on text immediately preceding the bot_token:
-    # - SGLang on deepseek_v3_1: trims one trailing space; Dynamo keeps it
-    # - vLLM on minimax_m2: keeps trailing space; Dynamo trims it (opposite
-    #   direction from deepseek)
+    # - SGLang on DeepSeek variants trims one trailing space; Dynamo keeps it.
     (
         "sglang",
         "deepseek_v3_1",
@@ -153,16 +151,6 @@ KNOWN_DIVERGENCES: dict[tuple[str, str, str], str] = {
         "deepseek_v4",
         "PARSER.batch.7",
     ): "vLLM emits JSON-typed parameter values as raw strings; Dynamo coerces nested object/array types",
-    (
-        "vllm",
-        "minimax_m2",
-        "PARSER.batch.8",
-    ): "preserves trailing space; Dynamo trims it",
-    (
-        "sglang",
-        "minimax_m2",
-        "PARSER.batch.8",
-    ): "preserves trailing space; Dynamo trims it",
     # PARSER.batch.4 (malformed) — impl-defined recovery contract.
     ("vllm", "deepseek_v3_1", "PARSER.batch.4"): _RECOVERY_CONTRACT,
     ("vllm", "minimax_m2", "PARSER.batch.4"): _RECOVERY_CONTRACT,


### PR DESCRIPTION
## Summary
- Drop normal text after Qwen3-Coder XML tool-call blocks while preserving prefix separator whitespace.
- Align qwen3_coder, nemotron_nano, and minimax_m2 parity fixtures with the generic XML parser behavior.
- Remove stale qwen3_coder/minimax_m2 batch.8 divergences and refresh the parity README matrix.

## Root Cause
Dynamo's generic XML parser previously trimmed normal text before parsed calls and also surfaced suffix text after a tool call for Qwen3-Coder-style output. That differed from the upstream parser parity contract for XML-style families.

## Validation
- cargo test -p dynamo-parsers qwen3_coder --lib
- cargo test -p dynamo-parsers minimax_m2 --lib
- cargo fmt -- --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text parsing around tool calls to only capture content preceding the first tool call, with trailing text after tool calls now discarded for consistency.

* **Tests**
  * Updated test expectations across multiple model configurations to reflect refined text handling behavior.
  * Enhanced parser parity status improvements across implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->