### PR TITLE
test: skip flaky sglang graceful tcp case

### DIFF
--- a/tests/fault_tolerance/migration/test_sglang.py
+++ b/tests/fault_tolerance/migration/test_sglang.py
@@ -251,12 +251,15 @@ def test_request_migration_sglang_aggregated(
 
     # OPS-4446: first-token delay routinely exceeds the 6s threshold in
     # utils.validate_response for this parameter combination. Originally only
-    # the NATS variant tripped; once the NATS skip landed, the TCP variant
-    # started failing the same way (now bears the cold-start cost first).
+    # the worker-failure variants tripped; once the NATS graceful-shutdown skip
+    # landed, the TCP graceful-shutdown variant started failing the same way.
     if (
         migration_limit == 3
         and migration_max_seq_len is None
-        and immediate_kill is True
+        and (
+            immediate_kill is True
+            or (immediate_kill is False and request_plane == "tcp")
+        )
         and request_api == "chat"
         and stream is True
     ):


### PR DESCRIPTION
#### Overview:

Skip the SGLang aggregated migration parameter set that is now failing post-merge after #9332 shifted the first active max-seq-len-disabled graceful-shutdown case to TCP.

#### Details:

- Extend the existing OPS-4446 skip condition to include graceful-shutdown TCP for migration_enabled + max_seq_len_disabled + chat streaming.
- Keep the max_seq_len_not_exceeded and max_seq_len_exceeded SGLang migration coverage active for TCP/NATS.

#### Where should the reviewer start?

tests/fault_tolerance/migration/test_sglang.py

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to OPS-4446
- Relates to OPS-4472
- CI failure: https://github.com/ai-dynamo/dynamo/actions/runs/25580017875/job/75096994557

#### Validation:

- python3 -m py_compile tests/fault_tolerance/migration/test_sglang.py
- git diff --check
- python3 -m pytest --collect-only -q tests/fault_tolerance/migration/test_sglang.py -m "post_merge and sglang and gpu_1" (blocked locally: pytest is not installed in this shell)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test stability for fault tolerance migration scenarios with updated skip conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->