### PR TITLE
fix: reject glm47 EOF recovery when truncation produces empty args

### DIFF
--- a/lib/parsers/src/tool_calling/parsers.rs
+++ b/lib/parsers/src/tool_calling/parsers.rs
@@ -153,11 +153,8 @@ pub async fn detect_and_parse_tool_call_with_recovery(
             }
             ParserConfig::Xml(c)
         }
-        ParserConfig::Glm47(c) => {
-            let mut c = c.clone();
-            c.allow_eof_recovery = true;
-            ParserConfig::Glm47(c)
-        }
+        // GLM-4.7 intentionally omitted: match upstream vLLM/SGLang behavior
+        // (drop the call when </tool_call> is missing).
         // Other parsers don't have an EOF-recovery flag — pass through.
         other => other.clone(),
     };

--- a/lib/parsers/src/tool_calling/xml/glm47_parser.rs
+++ b/lib/parsers/src/tool_calling/xml/glm47_parser.rs
@@ -15,6 +15,29 @@ use super::super::ToolDefinition;
 use super::super::config::Glm47ParserConfig;
 use super::response::{CalledFunction, ToolCallResponse, ToolCallType};
 
+/// Render a tool_call block snippet for logs. Bounded so a huge truncated
+/// argument body doesn't blow up the log line; control chars are escaped
+/// because raw newlines/tabs make the warning unreadable in grep/jq.
+fn truncate_for_log(s: &str) -> String {
+    const MAX: usize = 200;
+    let mut out = String::with_capacity(MAX.min(s.len()) + 16);
+    let mut bytes = 0usize;
+    for ch in s.chars() {
+        if bytes >= MAX {
+            out.push('…');
+            break;
+        }
+        match ch {
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c => out.push(c),
+        }
+        bytes += ch.len_utf8();
+    }
+    out
+}
+
 /// Check if a chunk contains the start of a GLM-4.7 tool call.
 /// Format: <tool_call>function_name<arg_key>...</arg_key><arg_value>...</arg_value></tool_call>
 pub fn detect_tool_call_start_glm47(chunk: &str, config: &Glm47ParserConfig) -> bool {
@@ -115,13 +138,23 @@ fn extract_tool_calls(
                 let abs_end = abs_start + end_pos + end_token.len();
                 let block = &text[abs_start..abs_end];
 
-                // Parse this tool call block; preserve unparseable blocks as
-                // normal text so model output is never silently dropped.
+                // Parse this tool call block. Unparseable blocks (malformed
+                // <tool_call>...</tool_call> markup the parser can't extract)
+                // are dropped — emitting the raw markup as normal_text leaks
+                // wire tags downstream. vLLM and SGLang both drop on this
+                // path; aligning Dynamo to that contract.
                 match parse_tool_call_block(block, config, tools) {
                     Ok(parsed_call) => calls.push(parsed_call),
                     Err(e) => {
-                        warn!("Failed to parse GLM-4.7 tool call block: {e}");
-                        normal_parts.push(block);
+                        warn!(
+                            reason = %e,
+                            why = "block has open + close fence but content failed to parse \
+                                   as a GLM-4.7 tool call (e.g. empty function name, \
+                                   missing <arg_key>, malformed args); dropping to avoid \
+                                   leaking wire tags through normal_text",
+                            dropped_block = %truncate_for_log(block),
+                            "GLM-4.7 parser dropping unparseable tool_call block"
+                        );
                     }
                 }
 
@@ -142,11 +175,38 @@ fn extract_tool_calls(
                             continue;
                         }
                         Err(e) => {
-                            warn!("Failed to parse GLM-4.7 tool call block (no end token): {e}");
+                            warn!(
+                                reason = %e,
+                                why = "EOF recovery enabled and <arg_key> opener present, \
+                                       but parse_tool_call_block failed on the truncated \
+                                       tail; dropping to avoid leaking wire tags through \
+                                       normal_text",
+                                dropped_block = %truncate_for_log(block),
+                                "GLM-4.7 parser dropping truncated tool_call block (recovery attempt failed)"
+                            );
                         }
                     }
+                } else {
+                    // Either recovery disabled (production default for GLM-4.7)
+                    // or no <arg_key> in the tail (so this is plausibly not a
+                    // real tool call at all, just a stray <tool_call> token).
+                    let reason = if !config.allow_eof_recovery {
+                        "allow_eof_recovery=false (production default for GLM-4.7 to match \
+                         vLLM/SGLang on truncated tool calls)"
+                    } else {
+                        "no <arg_key> in the tail after the <tool_call> start fence, so the \
+                         block does not look like a structurally-real GLM-4.7 tool call"
+                    };
+                    warn!(
+                        why = %reason,
+                        dropped_block = %truncate_for_log(block),
+                        "GLM-4.7 parser dropping truncated tool_call block (no end fence)"
+                    );
                 }
-                normal_parts.push(&text[abs_start..]);
+                // Drop the truncated/unrecoverable tail. Emitting the raw
+                // <tool_call>...<arg_key>...<arg_value>... prefix as
+                // normal_text would leak wire tags into message.content; vLLM
+                // strips the same way on truncation.
                 break;
             }
         } else {
@@ -595,24 +655,33 @@ mod tests {
     }
 
     #[test] // PARSER.batch.4, PARSER.batch.8
-    fn test_unparseable_block_preserved_as_normal_text() {
+    fn test_unparseable_block_dropped_no_tag_leak() {
         let config = get_test_config();
         let tools = vec![ToolDefinition {
             name: "get_weather".to_string(),
             parameters: None,
         }];
 
-        // Tool call block references a function not in the tools list
+        // Tool call block references a function not in the tools list — the
+        // whole block (including <tool_call>...<arg_key>...<arg_value>... wire
+        // markup) must be dropped, not leaked through normal_text.
         let message = "Here is the result: <tool_call>unknown_func<arg_key>x</arg_key><arg_value>1</arg_value></tool_call> done";
         let (calls, normal_text) =
             try_tool_call_parse_glm47(message, &config, Some(&tools)).unwrap();
 
         assert_eq!(calls.len(), 0);
-        // The unparseable block should be preserved in normal text, not dropped
         let text = normal_text.unwrap();
         assert!(
-            text.contains("unknown_func"),
-            "Unparseable block should be in normal text, got: {text}"
+            !text.contains("unknown_func"),
+            "Unparseable block must be dropped to avoid tag leakage, got: {text}"
+        );
+        assert!(
+            !text.contains("<tool_call>") && !text.contains("<arg_key>"),
+            "Wire-format tags must not leak into normal_text, got: {text}"
+        );
+        assert!(
+            text.contains("Here is the result:") && text.contains("done"),
+            "Surrounding prose must be preserved, got: {text}"
         );
     }
 

--- a/lib/parsers/src/tool_calling/xml/glm47_parser.rs
+++ b/lib/parsers/src/tool_calling/xml/glm47_parser.rs
@@ -662,11 +662,7 @@ mod tests {
         // Truncated inside the <arg_value> opening tag itself.
         let message = "<tool_call>get_weather<arg_key>location</arg_key><arg_val";
         let (calls, normal_text) = try_tool_call_parse_glm47(message, &config, None).unwrap();
-        assert_eq!(
-            calls.len(),
-            0,
-            "Truncation mid-tag must NOT produce a call"
-        );
+        assert_eq!(calls.len(), 0, "Truncation mid-tag must NOT produce a call");
         let text = normal_text.unwrap();
         assert!(text.contains("get_weather"));
     }
@@ -683,8 +679,7 @@ mod tests {
         let message = "<tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value><arg_key>unit</arg_key><arg_value>fah";
         let (calls, _) = try_tool_call_parse_glm47(message, &config, None).unwrap();
         assert_eq!(calls.len(), 1, "First complete pair should allow recovery");
-        let args: serde_json::Value =
-            serde_json::from_str(&calls[0].function.arguments).unwrap();
+        let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
         assert_eq!(args["location"], "NYC");
         assert!(
             args.get("unit").is_none(),

--- a/lib/parsers/src/tool_calling/xml/glm47_parser.rs
+++ b/lib/parsers/src/tool_calling/xml/glm47_parser.rs
@@ -137,9 +137,25 @@ fn extract_tool_calls(
                 if config.allow_eof_recovery && block.contains(arg_key_start.as_str()) {
                     match parse_tool_call_block(block, config, tools) {
                         Ok(parsed_call) => {
-                            calls.push(parsed_call);
-                            cursor = text.len();
-                            continue;
+                            // Guard: if the block contained arg tags but the
+                            // regex extracted zero pairs, truncation hit
+                            // mid-arg and the parse is incomplete. Reject
+                            // rather than returning empty-args (silent wrong
+                            // invocation).
+                            let args: serde_json::Value =
+                                serde_json::from_str(&parsed_call.function.arguments)
+                                    .unwrap_or(serde_json::Value::Null);
+                            let has_args = args.as_object().is_some_and(|m| !m.is_empty());
+                            if has_args {
+                                calls.push(parsed_call);
+                                cursor = text.len();
+                                continue;
+                            }
+                            warn!(
+                                "GLM-4.7 EOF recovery: block has arg tags but \
+                                 parsed zero complete pairs — truncation \
+                                 mid-arg; rejecting call"
+                            );
                         }
                         Err(e) => {
                             warn!("Failed to parse GLM-4.7 tool call block (no end token): {e}");
@@ -592,6 +608,106 @@ mod tests {
         assert_eq!(calls.len(), 2);
         assert_eq!(calls[0].function.name, "get_weather");
         assert_eq!(calls[1].function.name, "get_time");
+    }
+
+    // --- b5 multi-position truncation tests ---
+    // Verify that EOF recovery rejects incomplete arg pairs rather than
+    // returning a call with silently-empty arguments.
+
+    #[test] // PARSER.batch.5
+    fn test_eof_recovery_rejects_truncation_mid_arg_value() {
+        let config = Glm47ParserConfig {
+            allow_eof_recovery: true,
+            ..get_test_config()
+        };
+        // Truncated inside <arg_value> content — no closing </arg_value>.
+        let message = "<tool_call>get_weather<arg_key>location</arg_key><arg_value>NY";
+        let (calls, normal_text) = try_tool_call_parse_glm47(message, &config, None).unwrap();
+        assert_eq!(
+            calls.len(),
+            0,
+            "Truncation mid-arg-value must NOT produce a call with empty args"
+        );
+        let text = normal_text.unwrap();
+        assert!(
+            text.contains("get_weather"),
+            "Rejected block must be preserved as normal_text"
+        );
+    }
+
+    #[test] // PARSER.batch.5
+    fn test_eof_recovery_rejects_truncation_mid_arg_key() {
+        let config = Glm47ParserConfig {
+            allow_eof_recovery: true,
+            ..get_test_config()
+        };
+        // Truncated inside <arg_key> tag content.
+        let message = "<tool_call>get_weather<arg_key>loc";
+        let (calls, normal_text) = try_tool_call_parse_glm47(message, &config, None).unwrap();
+        assert_eq!(
+            calls.len(),
+            0,
+            "Truncation mid-arg-key must NOT produce a call with empty args"
+        );
+        let text = normal_text.unwrap();
+        assert!(text.contains("get_weather"));
+    }
+
+    #[test] // PARSER.batch.5
+    fn test_eof_recovery_rejects_truncation_mid_arg_value_tag() {
+        let config = Glm47ParserConfig {
+            allow_eof_recovery: true,
+            ..get_test_config()
+        };
+        // Truncated inside the <arg_value> opening tag itself.
+        let message = "<tool_call>get_weather<arg_key>location</arg_key><arg_val";
+        let (calls, normal_text) = try_tool_call_parse_glm47(message, &config, None).unwrap();
+        assert_eq!(
+            calls.len(),
+            0,
+            "Truncation mid-tag must NOT produce a call"
+        );
+        let text = normal_text.unwrap();
+        assert!(text.contains("get_weather"));
+    }
+
+    #[test] // PARSER.batch.5
+    fn test_eof_recovery_partial_second_arg_keeps_first() {
+        let config = Glm47ParserConfig {
+            allow_eof_recovery: true,
+            ..get_test_config()
+        };
+        // First arg pair complete, second truncated mid-value.
+        // Should recover the first arg; second is silently lost but at
+        // least we have partial-correct data rather than empty.
+        let message = "<tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value><arg_key>unit</arg_key><arg_value>fah";
+        let (calls, _) = try_tool_call_parse_glm47(message, &config, None).unwrap();
+        assert_eq!(calls.len(), 1, "First complete pair should allow recovery");
+        let args: serde_json::Value =
+            serde_json::from_str(&calls[0].function.arguments).unwrap();
+        assert_eq!(args["location"], "NYC");
+        assert!(
+            args.get("unit").is_none(),
+            "Truncated second arg should not appear"
+        );
+    }
+
+    #[test] // PARSER.batch.5
+    fn test_eof_recovery_rejects_truncation_inside_xml_entity() {
+        let config = Glm47ParserConfig {
+            allow_eof_recovery: true,
+            ..get_test_config()
+        };
+        // Truncated inside an XML entity within arg_value.
+        let message = "<tool_call>get_weather<arg_key>query</arg_key><arg_value>x &lt";
+        let (calls, normal_text) = try_tool_call_parse_glm47(message, &config, None).unwrap();
+        assert_eq!(
+            calls.len(),
+            0,
+            "Truncation inside XML entity must NOT produce a call"
+        );
+        let text = normal_text.unwrap();
+        assert!(text.contains("get_weather"));
     }
 
     #[test] // PARSER.batch.4, PARSER.batch.8

--- a/lib/parsers/src/tool_calling/xml/glm47_parser.rs
+++ b/lib/parsers/src/tool_calling/xml/glm47_parser.rs
@@ -137,25 +137,9 @@ fn extract_tool_calls(
                 if config.allow_eof_recovery && block.contains(arg_key_start.as_str()) {
                     match parse_tool_call_block(block, config, tools) {
                         Ok(parsed_call) => {
-                            // Guard: if the block contained arg tags but the
-                            // regex extracted zero pairs, truncation hit
-                            // mid-arg and the parse is incomplete. Reject
-                            // rather than returning empty-args (silent wrong
-                            // invocation).
-                            let args: serde_json::Value =
-                                serde_json::from_str(&parsed_call.function.arguments)
-                                    .unwrap_or(serde_json::Value::Null);
-                            let has_args = args.as_object().is_some_and(|m| !m.is_empty());
-                            if has_args {
-                                calls.push(parsed_call);
-                                cursor = text.len();
-                                continue;
-                            }
-                            warn!(
-                                "GLM-4.7 EOF recovery: block has arg tags but \
-                                 parsed zero complete pairs — truncation \
-                                 mid-arg; rejecting call"
-                            );
+                            calls.push(parsed_call);
+                            cursor = text.len();
+                            continue;
                         }
                         Err(e) => {
                             warn!("Failed to parse GLM-4.7 tool call block (no end token): {e}");
@@ -608,101 +592,6 @@ mod tests {
         assert_eq!(calls.len(), 2);
         assert_eq!(calls[0].function.name, "get_weather");
         assert_eq!(calls[1].function.name, "get_time");
-    }
-
-    // --- b5 multi-position truncation tests ---
-    // Verify that EOF recovery rejects incomplete arg pairs rather than
-    // returning a call with silently-empty arguments.
-
-    #[test] // PARSER.batch.5
-    fn test_eof_recovery_rejects_truncation_mid_arg_value() {
-        let config = Glm47ParserConfig {
-            allow_eof_recovery: true,
-            ..get_test_config()
-        };
-        // Truncated inside <arg_value> content — no closing </arg_value>.
-        let message = "<tool_call>get_weather<arg_key>location</arg_key><arg_value>NY";
-        let (calls, normal_text) = try_tool_call_parse_glm47(message, &config, None).unwrap();
-        assert_eq!(
-            calls.len(),
-            0,
-            "Truncation mid-arg-value must NOT produce a call with empty args"
-        );
-        let text = normal_text.unwrap();
-        assert!(
-            text.contains("get_weather"),
-            "Rejected block must be preserved as normal_text"
-        );
-    }
-
-    #[test] // PARSER.batch.5
-    fn test_eof_recovery_rejects_truncation_mid_arg_key() {
-        let config = Glm47ParserConfig {
-            allow_eof_recovery: true,
-            ..get_test_config()
-        };
-        // Truncated inside <arg_key> tag content.
-        let message = "<tool_call>get_weather<arg_key>loc";
-        let (calls, normal_text) = try_tool_call_parse_glm47(message, &config, None).unwrap();
-        assert_eq!(
-            calls.len(),
-            0,
-            "Truncation mid-arg-key must NOT produce a call with empty args"
-        );
-        let text = normal_text.unwrap();
-        assert!(text.contains("get_weather"));
-    }
-
-    #[test] // PARSER.batch.5
-    fn test_eof_recovery_rejects_truncation_mid_arg_value_tag() {
-        let config = Glm47ParserConfig {
-            allow_eof_recovery: true,
-            ..get_test_config()
-        };
-        // Truncated inside the <arg_value> opening tag itself.
-        let message = "<tool_call>get_weather<arg_key>location</arg_key><arg_val";
-        let (calls, normal_text) = try_tool_call_parse_glm47(message, &config, None).unwrap();
-        assert_eq!(calls.len(), 0, "Truncation mid-tag must NOT produce a call");
-        let text = normal_text.unwrap();
-        assert!(text.contains("get_weather"));
-    }
-
-    #[test] // PARSER.batch.5
-    fn test_eof_recovery_partial_second_arg_keeps_first() {
-        let config = Glm47ParserConfig {
-            allow_eof_recovery: true,
-            ..get_test_config()
-        };
-        // First arg pair complete, second truncated mid-value.
-        // Should recover the first arg; second is silently lost but at
-        // least we have partial-correct data rather than empty.
-        let message = "<tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value><arg_key>unit</arg_key><arg_value>fah";
-        let (calls, _) = try_tool_call_parse_glm47(message, &config, None).unwrap();
-        assert_eq!(calls.len(), 1, "First complete pair should allow recovery");
-        let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
-        assert_eq!(args["location"], "NYC");
-        assert!(
-            args.get("unit").is_none(),
-            "Truncated second arg should not appear"
-        );
-    }
-
-    #[test] // PARSER.batch.5
-    fn test_eof_recovery_rejects_truncation_inside_xml_entity() {
-        let config = Glm47ParserConfig {
-            allow_eof_recovery: true,
-            ..get_test_config()
-        };
-        // Truncated inside an XML entity within arg_value.
-        let message = "<tool_call>get_weather<arg_key>query</arg_key><arg_value>x &lt";
-        let (calls, normal_text) = try_tool_call_parse_glm47(message, &config, None).unwrap();
-        assert_eq!(
-            calls.len(),
-            0,
-            "Truncation inside XML entity must NOT produce a call"
-        );
-        let text = normal_text.unwrap();
-        assert!(text.contains("get_weather"));
     }
 
     #[test] // PARSER.batch.4, PARSER.batch.8

--- a/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.2.yaml
@@ -16,14 +16,14 @@ cases:
       {"timezone": "EST"}
       ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
         properties:
           location:
             type: string
-    - &id002
+    - &id003
       name: get_time
       parameters:
         type: object
@@ -31,7 +31,7 @@ cases:
           timezone:
             type: string
     expected:
-      dynamo: &d_2_a
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
@@ -40,8 +40,8 @@ cases:
           arguments:
             timezone: EST
         normal_text: ''
-      vllm: *d_2_a
-      sglang: *d_2_a
+      vllm: *id001
+      sglang: *id001
   PARSER.batch.2.b:
     description: Two back-to-back fence pairs
     ref: dynamo
@@ -54,10 +54,10 @@ cases:
       {"timezone": "EST"}
       ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
     tools:
-    - *id001
     - *id002
+    - *id003
     expected:
-      dynamo: &d_2_b
+      dynamo: &id004
         calls:
         - name: get_weather
           arguments:
@@ -66,8 +66,8 @@ cases:
           arguments:
             timezone: EST
         normal_text: ''
-      vllm: *d_2_b
-      sglang: *d_2_b
+      vllm: *id004
+      sglang: *id004
   PARSER.batch.2.c:
     description: With surrounding narration
     ref: dynamo
@@ -80,10 +80,10 @@ cases:
       {"timezone": "EST"}
       ```<｜tool▁call▁end｜><｜tool▁calls▁end｜> Done.
     tools:
-    - *id001
     - *id002
+    - *id003
     expected:
-      dynamo: &d_2_c
+      dynamo: &id005
         calls:
         - name: get_weather
           arguments:
@@ -92,17 +92,16 @@ cases:
           arguments:
             timezone: EST
         normal_text: 'Both: '
-      vllm: *d_2_c
+      vllm: *id005
       sglang:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
-        - arguments:
+        - name: get_time
+          arguments:
             timezone: EST
-          name: get_time
         normal_text: 'Both:'
-        reason: "trims trailing space from preceding normal_text"
   PARSER.batch.2.d:
     description: Same-name twice
     ref: dynamo
@@ -115,10 +114,10 @@ cases:
       {"location": "LA"}
       ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
     tools:
-    - *id001
-    - *id001
+    - *id002
+    - *id002
     expected:
-      dynamo: &d_2_d
+      dynamo: &id006
         calls:
         - name: get_weather
           arguments:
@@ -127,5 +126,5 @@ cases:
           arguments:
             location: LA
         normal_text: ''
-      vllm: *d_2_d
-      sglang: *d_2_d
+      vllm: *id006
+      sglang: *id006

--- a/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.4.yaml
@@ -23,11 +23,9 @@ cases:
       vllm:
         calls: []
         normal_text: ''
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
       sglang:
         calls: []
         normal_text: ''
-        reason: "sglang nullifies normal_text on malformed/recovery shapes where Dynamo preserves input"
   PARSER.batch.4.b:
     description: Missing close brace inside fenced JSON
     ref: dynamo
@@ -39,7 +37,7 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &d_4_b
+      dynamo: &id002
         calls: []
         normal_text: |-
           <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
@@ -48,11 +46,10 @@ cases:
           ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
       vllm:
         calls:
-        - arguments: '{"location": "NYC"'
-          name: get_weather
+        - name: get_weather
+          arguments: '{"location": "NYC"'
         normal_text: ''
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
-      sglang: *d_4_b
+      sglang: *id002
   PARSER.batch.4.c:
     description: Missing function name token
     ref: dynamo
@@ -73,15 +70,13 @@ cases:
           ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
       vllm:
         calls:
-        - arguments:
+        - name: ''
+          arguments:
             location: NYC
-          name: ''
         normal_text: ''
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
       sglang:
         calls: []
         normal_text: ''
-        reason: "sglang nullifies normal_text on malformed/recovery shapes where Dynamo preserves input"
   PARSER.batch.4.d:
     description: Missing fenced JSON block (no ```json)
     ref: dynamo
@@ -100,10 +95,8 @@ cases:
       vllm:
         calls: []
         normal_text: ''
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
       sglang:
         calls: []
-        normal_text: '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
-
-          {"location": "NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>'
-        reason: "sglang nullifies normal_text on malformed/recovery shapes where Dynamo preserves input"
+        normal_text: |-
+          <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+          {"location": "NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>

--- a/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.5.yaml
@@ -31,11 +31,9 @@ cases:
       vllm:
         calls: []
         normal_text: ''
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
       sglang:
         calls: []
         normal_text: ''
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
   PARSER.batch.5.b:
     description: Closing tool_calls_end without matching tool_calls_begin
     ref: dynamo
@@ -47,15 +45,15 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &d_5_b
+      dynamo: &id002
         calls: []
         normal_text: |-
           <｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
           ```json
           {"location": "NYC"}
           ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
-      vllm: *d_5_b
-      sglang: *d_5_b
+      vllm: *id002
+      sglang: *id002
   PARSER.batch.5.c:
     description: Truncation mid-arguments JSON inside fenced block
     ref: dynamo
@@ -75,8 +73,82 @@ cases:
       vllm:
         calls: []
         normal_text: ''
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
       sglang:
         calls: []
         normal_text: ''
-        reason: "sglang nullifies normal_text on malformed/recovery shapes where Dynamo preserves input"
+  PARSER.batch.5.d:
+    description: Multi-call, last call missing only end marker (body complete)
+    ref: dynamo
+    model_text: |-
+      I'll start by fetching the weather for both Boston and New York at the same time!
+      <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+      ```json
+      {"location": "Boston"}
+      ```<｜tool▁call▁end｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+      ```json
+      {"location": "New York"}
+      ```
+    tools:
+    - *id001
+    expected:
+      dynamo:
+        calls: []
+        normal_text: |-
+          I'll start by fetching the weather for both Boston and New York at the same time!
+          <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+          ```json
+          {"location": "Boston"}
+          ```<｜tool▁call▁end｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+          ```json
+          {"location": "New York"}
+          ```
+      vllm:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: |
+          I'll start by fetching the weather for both Boston and New York at the same time!
+      sglang:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
+  PARSER.batch.5.e:
+    description: Multi-call, last call truncated mid-arg-value
+    ref: dynamo
+    model_text: |-
+      I'll start by fetching the weather for both Boston and New York at the same time!
+      <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+      ```json
+      {"location": "Boston"}
+      ```<｜tool▁call▁end｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+      ```json
+      {"location": "New York
+    tools:
+    - *id001
+    expected:
+      dynamo:
+        calls: []
+        normal_text: |-
+          I'll start by fetching the weather for both Boston and New York at the same time!
+          <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+          ```json
+          {"location": "Boston"}
+          ```<｜tool▁call▁end｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+          ```json
+          {"location": "New York
+      vllm:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: |
+          I'll start by fetching the weather for both Boston and New York at the same time!
+      sglang:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!

--- a/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.6.yaml
@@ -13,19 +13,19 @@ cases:
       {}
       ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
     tools:
-    - &id001
+    - &id002
       name: get_time
       parameters:
         type: object
         properties: {}
     expected:
-      dynamo: &d_6_a
+      dynamo: &id001
         calls:
         - name: get_time
           arguments: {}
         normal_text: ''
-      vllm: *d_6_a
-      sglang: *d_6_a
+      vllm: *id001
+      sglang: *id001
   PARSER.batch.6.b:
     description: Whitespace inside empty { } (newlines)
     ref: dynamo
@@ -36,9 +36,9 @@ cases:
       }
       ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_6_b
+      dynamo: &id003
         calls:
         - name: get_time
           arguments: {}
@@ -46,20 +46,18 @@ cases:
       vllm:
         calls: []
         normal_text: ''
-        reason: "vLLM rejects whitespace inside empty {} when wrapped in fenced ```json``` block"
-      sglang: *d_6_b
+      sglang: *id003
   PARSER.batch.6.c:
     description: No fenced JSON block (function name only)
     ref: dynamo
     model_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_time<｜tool▁call▁end｜><｜tool▁calls▁end｜>
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_6_c
+      dynamo: &id004
         calls: []
         normal_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_time<｜tool▁call▁end｜><｜tool▁calls▁end｜>
       vllm:
         calls: []
         normal_text: ''
-        reason: "both return calls=[]; vLLM nullifies normal_text on this recovery path, Dynamo preserves the raw input as normal_text"
-      sglang: *d_6_c
+      sglang: *id004

--- a/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.7.yaml
@@ -24,7 +24,7 @@ cases:
           first_class:
             type: boolean
     expected:
-      dynamo: &d_7_a
+      dynamo: &id001
         calls:
         - name: book_flight
           arguments:
@@ -32,8 +32,8 @@ cases:
             passengers: 2
             first_class: true
         normal_text: ''
-      vllm: *d_7_a
-      sglang: *d_7_a
+      vllm: *id001
+      sglang: *id001
   PARSER.batch.7.b:
     description: Unicode + escaped chars
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L302
@@ -50,14 +50,14 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_7_b
+      dynamo: &id002
         calls:
         - name: get_weather
           arguments:
             location: Tōkyō "central"
         normal_text: ''
-      vllm: *d_7_b
-      sglang: *d_7_b
+      vllm: *id002
+      sglang: *id002
   PARSER.batch.7.c:
     description: Schema mismatch — string value where schema declares integer
     ref: dynamo
@@ -74,14 +74,14 @@ cases:
           celsius:
             type: integer
     expected:
-      dynamo: &d_7_c
+      dynamo: &id003
         calls:
         - name: set_temperature
           arguments:
             celsius: '20'
         normal_text: ''
-      vllm: *d_7_c
-      sglang: *d_7_c
+      vllm: *id003
+      sglang: *id003
   PARSER.batch.7.d:
     description: Nested object + array (existing)
     ref: dynamo
@@ -100,7 +100,7 @@ cases:
           config:
             type: object
     expected:
-      dynamo: &d_7_d
+      dynamo: &id004
         calls:
         - name: process_data
           arguments:
@@ -111,5 +111,5 @@ cases:
             config:
               nested: true
         normal_text: ''
-      vllm: *d_7_d
-      sglang: *d_7_d
+      vllm: *id004
+      sglang: *id004

--- a/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.8.yaml
@@ -13,7 +13,7 @@ cases:
       {"location": "NYC"}
       ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
@@ -21,20 +21,19 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_8_a
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: 'I will check the weather. '
-      vllm: *d_8_a
+      vllm: *id001
       sglang:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
         normal_text: I will check the weather.
-        reason: "trims trailing space from preceding normal_text"
   PARSER.batch.8.b:
     description: Narration after tool call only
     ref: dynamo
@@ -44,16 +43,16 @@ cases:
       {"location": "NYC"}
       ```<｜tool▁call▁end｜><｜tool▁calls▁end｜> Let me know if you need more.
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_8_b
+      dynamo: &id003
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *d_8_b
-      sglang: *d_8_b
+      vllm: *id003
+      sglang: *id003
   PARSER.batch.8.c:
     description: Narration both before and after (sandwich)
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L282
@@ -63,22 +62,21 @@ cases:
       {"location": "NYC"}
       ```<｜tool▁call▁end｜><｜tool▁calls▁end｜> Let me know if you need more.
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_8_c
+      dynamo: &id004
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: 'I will check the weather. '
-      vllm: *d_8_c
+      vllm: *id004
       sglang:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
         normal_text: I will check the weather.
-        reason: "trims trailing space from preceding normal_text"
   PARSER.batch.8.d:
     description: Narration between multiple tool calls
     ref: dynamo
@@ -91,9 +89,9 @@ cases:
       {"location": "LA"}
       ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_8_d
+      dynamo: &id005
         calls:
         - name: get_weather
           arguments:
@@ -102,14 +100,13 @@ cases:
           arguments:
             location: LA
         normal_text: 'I will check the weather. '
-      vllm: *d_8_d
+      vllm: *id005
       sglang:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
-        - arguments:
+        - name: get_weather
+          arguments:
             location: LA
-          name: get_weather
         normal_text: I will check the weather.
-        reason: "trims trailing space from preceding normal_text"

--- a/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.yaml
@@ -13,7 +13,7 @@ cases:
       {"location": "NYC"}
       ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
@@ -21,36 +21,36 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_1
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *d_1
-      sglang: *d_1
+      vllm: *id001
+      sglang: *id001
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_3
+      dynamo: &id003
         calls: []
         normal_text: Hello, how can I help you today?
-      vllm: *d_3
-      sglang: *d_3
+      vllm: *id003
+      sglang: *id003
   PARSER.batch.9:
     description: Empty input
     model_text: ''
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_9
+      dynamo: &id004
         calls: []
         normal_text: ''
-      vllm: *d_9
-      sglang: *d_9
+      vllm: *id004
+      sglang: *id004
   PARSER.batch.10:
     description: Duplicate calls (same name twice)
     model_text: |-
@@ -62,9 +62,9 @@ cases:
       {"location": "LA"}
       ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_10
+      dynamo: &id005
         calls:
         - name: get_weather
           arguments:
@@ -73,5 +73,5 @@ cases:
           arguments:
             location: LA
         normal_text: ''
-      vllm: *d_10
-      sglang: *d_10
+      vllm: *id005
+      sglang: *id005

--- a/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.2.yaml
@@ -9,14 +9,14 @@ cases:
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_deepseekv31_tool_parser.py#L39
     model_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_time<｜tool▁sep｜>{"timezone":"EST"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
         properties:
           location:
             type: string
-    - &id002
+    - &id003
       name: get_time
       parameters:
         type: object
@@ -24,7 +24,7 @@ cases:
           timezone:
             type: string
     expected:
-      dynamo: &d_2_a
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
@@ -33,17 +33,17 @@ cases:
           arguments:
             timezone: EST
         normal_text: ''
-      vllm: *d_2_a
-      sglang: *d_2_a
+      vllm: *id001
+      sglang: *id001
   PARSER.batch.2.b:
     description: Two back-to-back fence pairs
     ref: dynamo
     model_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜><｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_time<｜tool▁sep｜>{"timezone":"EST"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
     tools:
-    - *id001
     - *id002
+    - *id003
     expected:
-      dynamo: &d_2_b
+      dynamo: &id004
         calls:
         - name: get_weather
           arguments:
@@ -52,18 +52,18 @@ cases:
           arguments:
             timezone: EST
         normal_text: ''
-      vllm: *d_2_b
-      sglang: *d_2_b
+      vllm: *id004
+      sglang: *id004
   PARSER.batch.2.c:
     description: Parallel with surrounding narration
     ref: dynamo
     model_text: 'Both: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_time<｜tool▁sep｜>{"timezone":"EST"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
       Results.'
     tools:
-    - *id001
     - *id002
+    - *id003
     expected:
-      dynamo: &d_2_c
+      dynamo: &id005
         calls:
         - name: get_weather
           arguments:
@@ -72,26 +72,25 @@ cases:
           arguments:
             timezone: EST
         normal_text: 'Both: '
-      vllm: *d_2_c
+      vllm: *id005
       sglang:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
-        - arguments:
+        - name: get_time
+          arguments:
             timezone: EST
-          name: get_time
         normal_text: 'Both:'
-        reason: "trims trailing space from preceding normal_text"
   PARSER.batch.2.d:
     description: Same-name twice (id distinctness)
     ref: dynamo
     model_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"LA"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
     tools:
-    - *id001
-    - *id001
+    - *id002
+    - *id002
     expected:
-      dynamo: &d_2_d
+      dynamo: &id006
         calls:
         - name: get_weather
           arguments:
@@ -100,5 +99,5 @@ cases:
           arguments:
             location: LA
         normal_text: ''
-      vllm: *d_2_d
-      sglang: *d_2_d
+      vllm: *id006
+      sglang: *id006

--- a/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.4.yaml
@@ -23,11 +23,9 @@ cases:
       vllm:
         calls: []
         normal_text: ''
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
       sglang:
         calls: []
         normal_text: ''
-        reason: "sglang nullifies normal_text on malformed/recovery shapes where Dynamo preserves input"
   PARSER.batch.4.b:
     description: Unterminated JSON string in args
     ref: dynamo
@@ -35,16 +33,15 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &d_4_b
+      dynamo: &id002
         calls: []
         normal_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC<｜tool▁call▁end｜><｜tool▁calls▁end｜>
       vllm:
         calls:
-        - arguments: '{"location":"NYC'
-          name: get_weather
+        - name: get_weather
+          arguments: '{"location":"NYC'
         normal_text: ''
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
-      sglang: *d_4_b
+      sglang: *id002
   PARSER.batch.4.c:
     description: Missing function name (no token before tool_sep)
     ref: dynamo
@@ -57,15 +54,13 @@ cases:
         normal_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜><｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
       vllm:
         calls:
-        - arguments:
+        - name: ''
+          arguments:
             location: NYC
-          name: ''
         normal_text: ''
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
       sglang:
         calls: []
         normal_text: ''
-        reason: "sglang nullifies normal_text on malformed/recovery shapes where Dynamo preserves input"
   PARSER.batch.4.d:
     description: Mismatched fences (calls_end without call_end)
     ref: dynamo
@@ -79,8 +74,6 @@ cases:
       vllm:
         calls: []
         normal_text: ''
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
       sglang:
         calls: []
         normal_text: ''
-        reason: "sglang nullifies normal_text on malformed/recovery shapes where Dynamo preserves input"

--- a/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.5.yaml
@@ -22,18 +22,16 @@ cases:
         normal_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜>
       vllm:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
         normal_text: ''
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
       sglang:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
         normal_text: ''
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
   PARSER.batch.5.b:
     description: Closing tool_calls_end without matching tool_calls_begin
     ref: dynamo
@@ -41,11 +39,11 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &d_5_b
+      dynamo: &id002
         calls: []
         normal_text: <｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
-      vllm: *d_5_b
-      sglang: *d_5_b
+      vllm: *id002
+      sglang: *id002
   PARSER.batch.5.c:
     description: Truncation mid-arguments JSON
     ref: dynamo
@@ -59,8 +57,54 @@ cases:
       vllm:
         calls: []
         normal_text: ''
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
       sglang:
         calls: []
         normal_text: ''
-        reason: "sglang nullifies normal_text on malformed/recovery shapes where Dynamo preserves input"
+  PARSER.batch.5.d:
+    description: Multi-call, last call missing only end marker (body complete)
+    ref: dynamo
+    model_text: I'll start by fetching the weather for both Boston and New York at the same time!<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"Boston"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"New
+      York"}
+    tools:
+    - *id001
+    expected:
+      dynamo:
+        calls: []
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"Boston"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"New
+          York"}
+      vllm:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
+      sglang:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
+  PARSER.batch.5.e:
+    description: Multi-call, last call truncated mid-arg-value
+    ref: dynamo
+    model_text: I'll start by fetching the weather for both Boston and New York at the same time!<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"Boston"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"New
+      York
+    tools:
+    - *id001
+    expected:
+      dynamo:
+        calls: []
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"Boston"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"New
+          York
+      vllm:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
+      sglang:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!

--- a/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.6.yaml
@@ -9,45 +9,44 @@ cases:
     ref: dynamo
     model_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_time<｜tool▁sep｜>{}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
     tools:
-    - &id001
+    - &id002
       name: get_time
       parameters:
         type: object
         properties: {}
     expected:
-      dynamo: &d_6_a
+      dynamo: &id001
         calls:
         - name: get_time
           arguments: {}
         normal_text: ''
-      vllm: *d_6_a
-      sglang: *d_6_a
+      vllm: *id001
+      sglang: *id001
   PARSER.batch.6.b:
     description: Whitespace inside empty { }
     ref: dynamo
     model_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_time<｜tool▁sep｜>{ }<｜tool▁call▁end｜><｜tool▁calls▁end｜>
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_6_b
+      dynamo: &id003
         calls:
         - name: get_time
           arguments: {}
         normal_text: ''
-      vllm: *d_6_b
-      sglang: *d_6_b
+      vllm: *id003
+      sglang: *id003
   PARSER.batch.6.c:
     description: No tool_sep / args section
     ref: dynamo
     model_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_time<｜tool▁call▁end｜><｜tool▁calls▁end｜>
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_6_c
+      dynamo: &id004
         calls: []
         normal_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_time<｜tool▁call▁end｜><｜tool▁calls▁end｜>
       vllm:
         calls: []
         normal_text: ''
-        reason: "both return calls=[]; vLLM nullifies normal_text on this recovery path, Dynamo preserves the raw input as normal_text"
-      sglang: *d_6_c
+      sglang: *id004

--- a/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.7.yaml
@@ -20,7 +20,7 @@ cases:
           first_class:
             type: boolean
     expected:
-      dynamo: &d_7_a
+      dynamo: &id001
         calls:
         - name: book_flight
           arguments:
@@ -28,8 +28,8 @@ cases:
             passengers: 2
             first_class: true
         normal_text: ''
-      vllm: *d_7_a
-      sglang: *d_7_a
+      vllm: *id001
+      sglang: *id001
   PARSER.batch.7.b:
     description: Unicode + escaped chars
     ref: dynamo
@@ -42,14 +42,14 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_7_b
+      dynamo: &id002
         calls:
         - name: get_weather
           arguments:
             location: Tōkyō "central"
         normal_text: ''
-      vllm: *d_7_b
-      sglang: *d_7_b
+      vllm: *id002
+      sglang: *id002
   PARSER.batch.7.c:
     description: Schema mismatch — string value where schema declares integer
     ref: dynamo
@@ -62,14 +62,14 @@ cases:
           celsius:
             type: integer
     expected:
-      dynamo: &d_7_c
+      dynamo: &id003
         calls:
         - name: set_temperature
           arguments:
             celsius: '20'
         normal_text: ''
-      vllm: *d_7_c
-      sglang: *d_7_c
+      vllm: *id003
+      sglang: *id003
   PARSER.batch.7.d:
     description: Nested object + array (existing)
     ref: dynamo
@@ -84,7 +84,7 @@ cases:
           config:
             type: object
     expected:
-      dynamo: &d_7_d
+      dynamo: &id004
         calls:
         - name: process_data
           arguments:
@@ -95,5 +95,5 @@ cases:
             config:
               nested: true
         normal_text: ''
-      vllm: *d_7_d
-      sglang: *d_7_d
+      vllm: *id004
+      sglang: *id004

--- a/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.8.yaml
@@ -9,7 +9,7 @@ cases:
     ref: dynamo
     model_text: I will check the weather. <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
@@ -17,67 +17,65 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_8_a
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: 'I will check the weather. '
-      vllm: *d_8_a
+      vllm: *id001
       sglang:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
         normal_text: I will check the weather.
-        reason: "trims trailing space from preceding normal_text"
   PARSER.batch.8.b:
     description: Narration after tool call only
     ref: dynamo
     model_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
       Let me know if you need more.
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_8_b
+      dynamo: &id003
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *d_8_b
-      sglang: *d_8_b
+      vllm: *id003
+      sglang: *id003
   PARSER.batch.8.c:
     description: Narration both before and after (sandwich)
     ref: dynamo
     model_text: I will check the weather. <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
       Let me know if you need more.
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_8_c
+      dynamo: &id004
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: 'I will check the weather. '
-      vllm: *d_8_c
+      vllm: *id004
       sglang:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
         normal_text: I will check the weather.
-        reason: "trims trailing space from preceding normal_text"
   PARSER.batch.8.d:
     description: Narration between multiple tool calls
     ref: dynamo
     model_text: I will check the weather. <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
       Then check LA weather. <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"LA"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_8_d
+      dynamo: &id005
         calls:
         - name: get_weather
           arguments:
@@ -86,14 +84,13 @@ cases:
           arguments:
             location: LA
         normal_text: 'I will check the weather. '
-      vllm: *d_8_d
+      vllm: *id005
       sglang:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
-        - arguments:
+        - name: get_weather
+          arguments:
             location: LA
-          name: get_weather
         normal_text: I will check the weather.
-        reason: "trims trailing space from preceding normal_text"

--- a/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.yaml
@@ -9,7 +9,7 @@ cases:
     description: Single tool call (happy path)
     model_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
@@ -17,43 +17,43 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_1
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *d_1
-      sglang: *d_1
+      vllm: *id001
+      sglang: *id001
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_3
+      dynamo: &id003
         calls: []
         normal_text: Hello, how can I help you today?
-      vllm: *d_3
-      sglang: *d_3
+      vllm: *id003
+      sglang: *id003
   PARSER.batch.9:
     description: Empty input
     model_text: ''
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_9
+      dynamo: &id004
         calls: []
         normal_text: ''
-      vllm: *d_9
-      sglang: *d_9
+      vllm: *id004
+      sglang: *id004
   PARSER.batch.10:
     description: Duplicate calls (same name twice)
     model_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"LA"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_10
+      dynamo: &id005
         calls:
         - name: get_weather
           arguments:
@@ -62,5 +62,5 @@ cases:
           arguments:
             location: LA
         normal_text: ''
-      vllm: *d_10
-      sglang: *d_10
+      vllm: *id005
+      sglang: *id005

--- a/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.5.yaml
@@ -77,3 +77,67 @@ cases:
           <｜DSML｜parameter name="location" string="true">NY'
         reason: "vLLM leaks the tool call tag into normal_text on the recovery path"
       sglang: *d_5_c
+  PARSER.batch.5.d:
+    description: Multi-call, last call missing only end marker (body complete)
+    ref: dynamo
+    model_text: |-
+      I'll start by fetching the weather for both Boston and New York at the same time!
+      <｜DSML｜function_calls>
+      <｜DSML｜invoke name="get_weather">
+      <｜DSML｜parameter name="location" string="true">Boston</｜DSML｜parameter>
+      </｜DSML｜invoke>
+      <｜DSML｜invoke name="get_weather">
+      <｜DSML｜parameter name="location" string="true">New York</｜DSML｜parameter>
+      </｜DSML｜invoke>
+    tools:
+    - *id001
+    expected:
+      dynamo:
+        calls: []
+        normal_text: |
+          I'll start by fetching the weather for both Boston and New York at the same time!
+      vllm:
+        calls: []
+        normal_text: |-
+          I'll start by fetching the weather for both Boston and New York at the same time!
+          <｜DSML｜function_calls>
+          <｜DSML｜invoke name="get_weather">
+          <｜DSML｜parameter name="location" string="true">Boston</｜DSML｜parameter>
+          </｜DSML｜invoke>
+          <｜DSML｜invoke name="get_weather">
+          <｜DSML｜parameter name="location" string="true">New York</｜DSML｜parameter>
+          </｜DSML｜invoke>
+      sglang:
+        calls: []
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
+  PARSER.batch.5.e:
+    description: Multi-call, last call truncated mid-arg-value
+    ref: dynamo
+    model_text: |-
+      I'll start by fetching the weather for both Boston and New York at the same time!
+      <｜DSML｜function_calls>
+      <｜DSML｜invoke name="get_weather">
+      <｜DSML｜parameter name="location" string="true">Boston</｜DSML｜parameter>
+      </｜DSML｜invoke>
+      <｜DSML｜invoke name="get_weather">
+      <｜DSML｜parameter name="location" string="true">New York
+    tools:
+    - *id001
+    expected:
+      dynamo:
+        calls: []
+        normal_text: |
+          I'll start by fetching the weather for both Boston and New York at the same time!
+      vllm:
+        calls: []
+        normal_text: |-
+          I'll start by fetching the weather for both Boston and New York at the same time!
+          <｜DSML｜function_calls>
+          <｜DSML｜invoke name="get_weather">
+          <｜DSML｜parameter name="location" string="true">Boston</｜DSML｜parameter>
+          </｜DSML｜invoke>
+          <｜DSML｜invoke name="get_weather">
+          <｜DSML｜parameter name="location" string="true">New York
+      sglang:
+        calls: []
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!

--- a/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.yaml
@@ -14,7 +14,7 @@ cases:
       </｜DSML｜invoke>
       </｜DSML｜function_calls>
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
@@ -22,36 +22,36 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_1
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *d_1
-      sglang: *d_1
+      vllm: *id001
+      sglang: *id001
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_3
+      dynamo: &id003
         calls: []
         normal_text: Hello, how can I help you today?
-      vllm: *d_3
-      sglang: *d_3
+      vllm: *id003
+      sglang: *id003
   PARSER.batch.9:
     description: Empty input
     model_text: ''
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_9
+      dynamo: &id004
         calls: []
         normal_text: ''
-      vllm: *d_9
-      sglang: *d_9
+      vllm: *id004
+      sglang: *id004
   PARSER.batch.10:
     description: Duplicate calls (same name twice)
     model_text: |-
@@ -64,9 +64,9 @@ cases:
       </｜DSML｜invoke>
       </｜DSML｜function_calls>
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_10
+      dynamo: &id005
         calls:
         - name: get_weather
           arguments:
@@ -75,5 +75,5 @@ cases:
           arguments:
             location: LA
         normal_text: ''
-      vllm: *d_10
-      sglang: *d_10
+      vllm: *id005
+      sglang: *id005

--- a/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.2.yaml
@@ -81,9 +81,8 @@ cases:
         - name: get_time
           arguments:
             timezone: EST
-        normal_text: |2+
-
-        reason: "preserves inter-fence newline between back-to-back tool_calls wrappers"
+        normal_text: ''
+        reason: "vLLM drops the inter-fence newline between back-to-back tool_calls wrappers"
       sglang:
         unavailable: SGLang has no detector for family='deepseek_v4'
   PARSER.batch.2.c:
@@ -113,14 +112,13 @@ cases:
         normal_text: 'Both: '
       vllm:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
-        - arguments:
+        - name: get_time
+          arguments:
             timezone: EST
-          name: get_time
         normal_text: 'Both: '
-        reason: drops trailing normal_text after tool-call wrapper end
       sglang:
         unavailable: SGLang has no detector for family='deepseek_v4'
   PARSER.batch.2.d:

--- a/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.4.yaml
@@ -25,11 +25,10 @@ cases:
         normal_text: ''
       vllm:
         calls: []
-        normal_text: '<｜DSML｜tool_calls>
-
+        normal_text: |-
+          <｜DSML｜tool_calls>
           not a valid invoke
-
-          </｜DSML｜tool_calls>'
+          </｜DSML｜tool_calls>
         reason: "vLLM leaks the tool call tag into normal_text on the recovery path"
       sglang:
         unavailable: SGLang has no detector for family='deepseek_v4'
@@ -51,15 +50,12 @@ cases:
         normal_text: ''
       vllm:
         calls: []
-        normal_text: '<｜DSML｜tool_calls>
-
+        normal_text: |-
+          <｜DSML｜tool_calls>
           <｜DSML｜invoke>
-
           <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
-
           </｜DSML｜invoke>
-
-          </｜DSML｜tool_calls>'
+          </｜DSML｜tool_calls>
         reason: "vLLM leaks the tool call tag into normal_text on the recovery path"
       sglang:
         unavailable: SGLang has no detector for family='deepseek_v4'

--- a/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.5.yaml
@@ -80,3 +80,47 @@ cases:
         reason: "vLLM leaks the tool call tag into normal_text on the recovery path"
       sglang:
         unavailable: SGLang has no detector for family='deepseek_v4'
+  PARSER.batch.5.d:
+    description: Multi-call, last call missing only end marker (body complete)
+    ref: dynamo
+    model_text: |-
+      I'll start by fetching the weather for both Boston and New York at the same time!
+      <｜DSML｜tool_calls>
+      <｜DSML｜invoke name="get_weather">
+      <｜DSML｜parameter name="location" string="true">Boston</｜DSML｜parameter>
+      </｜DSML｜invoke>
+      <｜DSML｜invoke name="get_weather">
+      <｜DSML｜parameter name="location" string="true">New York</｜DSML｜parameter>
+      </｜DSML｜invoke>
+    tools:
+    - *id001
+    expected:
+      dynamo:
+        calls: []
+        normal_text: |
+          I'll start by fetching the weather for both Boston and New York at the same time!
+      sglang:
+        unavailable: SGLang has no detector for family='deepseek_v4'
+      vllm: &vllm_deepseek_v4_missing
+        error: 'KeyError: deepseek_v4 parser not registered in this vLLM build'
+  PARSER.batch.5.e:
+    description: Multi-call, last call truncated mid-arg-value
+    ref: dynamo
+    model_text: |-
+      I'll start by fetching the weather for both Boston and New York at the same time!
+      <｜DSML｜tool_calls>
+      <｜DSML｜invoke name="get_weather">
+      <｜DSML｜parameter name="location" string="true">Boston</｜DSML｜parameter>
+      </｜DSML｜invoke>
+      <｜DSML｜invoke name="get_weather">
+      <｜DSML｜parameter name="location" string="true">New York
+    tools:
+    - *id001
+    expected:
+      dynamo:
+        calls: []
+        normal_text: |
+          I'll start by fetching the weather for both Boston and New York at the same time!
+      sglang:
+        unavailable: SGLang has no detector for family='deepseek_v4'
+      vllm: *vllm_deepseek_v4_missing

--- a/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.5.yaml
@@ -26,13 +26,11 @@ cases:
         normal_text: ''
       vllm:
         calls: []
-        normal_text: '<｜DSML｜tool_calls>
-
+        normal_text: |-
+          <｜DSML｜tool_calls>
           <｜DSML｜invoke name="get_weather">
-
           <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
-
-          </｜DSML｜invoke>'
+          </｜DSML｜invoke>
         reason: "vLLM leaks the tool call tag into normal_text on the recovery path"
       sglang:
         unavailable: SGLang has no detector for family='deepseek_v4'
@@ -72,11 +70,10 @@ cases:
         normal_text: ''
       vllm:
         calls: []
-        normal_text: '<｜DSML｜tool_calls>
-
+        normal_text: |-
+          <｜DSML｜tool_calls>
           <｜DSML｜invoke name="get_weather">
-
-          <｜DSML｜parameter name="location" string="true">NY'
+          <｜DSML｜parameter name="location" string="true">NY
         reason: "vLLM leaks the tool call tag into normal_text on the recovery path"
       sglang:
         unavailable: SGLang has no detector for family='deepseek_v4'
@@ -101,8 +98,18 @@ cases:
           I'll start by fetching the weather for both Boston and New York at the same time!
       sglang:
         unavailable: SGLang has no detector for family='deepseek_v4'
-      vllm: &vllm_deepseek_v4_missing
-        error: 'KeyError: deepseek_v4 parser not registered in this vLLM build'
+      vllm:
+        calls: []
+        normal_text: |-
+          I'll start by fetching the weather for both Boston and New York at the same time!
+          <｜DSML｜tool_calls>
+          <｜DSML｜invoke name="get_weather">
+          <｜DSML｜parameter name="location" string="true">Boston</｜DSML｜parameter>
+          </｜DSML｜invoke>
+          <｜DSML｜invoke name="get_weather">
+          <｜DSML｜parameter name="location" string="true">New York</｜DSML｜parameter>
+          </｜DSML｜invoke>
+        reason: "vLLM leaks the unterminated DSML block into normal_text on the recovery path"
   PARSER.batch.5.e:
     description: Multi-call, last call truncated mid-arg-value
     ref: dynamo
@@ -123,4 +130,14 @@ cases:
           I'll start by fetching the weather for both Boston and New York at the same time!
       sglang:
         unavailable: SGLang has no detector for family='deepseek_v4'
-      vllm: *vllm_deepseek_v4_missing
+      vllm:
+        calls: []
+        normal_text: |-
+          I'll start by fetching the weather for both Boston and New York at the same time!
+          <｜DSML｜tool_calls>
+          <｜DSML｜invoke name="get_weather">
+          <｜DSML｜parameter name="location" string="true">Boston</｜DSML｜parameter>
+          </｜DSML｜invoke>
+          <｜DSML｜invoke name="get_weather">
+          <｜DSML｜parameter name="location" string="true">New York
+        reason: "vLLM leaks the unterminated DSML block into normal_text on the recovery path"

--- a/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.6.yaml
@@ -13,18 +13,18 @@ cases:
       </｜DSML｜invoke>
       </｜DSML｜tool_calls>
     tools:
-    - &id001
+    - &id002
       name: get_time
       parameters:
         type: object
         properties: {}
     expected:
-      dynamo: &d_6_a
+      dynamo: &id001
         calls:
         - name: get_time
           arguments: {}
         normal_text: ''
-      vllm: *d_6_a
+      vllm: *id001
       sglang:
         unavailable: SGLang has no detector for family='deepseek_v4'
   PARSER.batch.6.b:
@@ -37,14 +37,14 @@ cases:
       </｜DSML｜invoke>
       </｜DSML｜tool_calls>
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_6_b
+      dynamo: &id003
         calls:
         - name: get_time
           arguments: {}
         normal_text: ''
-      vllm: *d_6_b
+      vllm: *id003
       sglang:
         unavailable: SGLang has no detector for family='deepseek_v4'
   # PARSER.batch.6.c (arguments-key absent) n/a: DSML has no 'arguments' key — params are <｜DSML｜parameter> children of <｜DSML｜invoke>. Zero-args is already case 6.a.

--- a/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.7.yaml
@@ -27,7 +27,7 @@ cases:
           first_class:
             type: boolean
     expected:
-      dynamo: &d_7_a
+      dynamo: &id001
         calls:
         - name: book_flight
           arguments:
@@ -35,7 +35,7 @@ cases:
             passengers: 2
             first_class: true
         normal_text: ''
-      vllm: *d_7_a
+      vllm: *id001
       sglang:
         unavailable: SGLang has no detector for family='deepseek_v4'
   PARSER.batch.7.b:
@@ -55,13 +55,13 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_7_b
+      dynamo: &id002
         calls:
         - name: get_weather
           arguments:
             location: Tōkyō central
         normal_text: ''
-      vllm: *d_7_b
+      vllm: *id002
       sglang:
         unavailable: SGLang has no detector for family='deepseek_v4'
   # PARSER.batch.7.c (schema mismatch on JSON value) n/a: DSML encodes typing explicitly via the string="true|false" parameter attribute, not via JSON. There's no JSON-typing/coercion path to mismatch with.

--- a/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.8.yaml
@@ -51,9 +51,9 @@ cases:
         normal_text: ''
       vllm:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
         normal_text: ''
       sglang:
         unavailable: SGLang has no detector for family='deepseek_v4'
@@ -77,9 +77,9 @@ cases:
         normal_text: 'I will check the weather. '
       vllm:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
         normal_text: 'I will check the weather. '
       sglang:
         unavailable: SGLang has no detector for family='deepseek_v4'
@@ -110,12 +110,12 @@ cases:
         normal_text: 'I will check the weather. '
       vllm:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
-        - arguments:
+        - name: get_weather
+          arguments:
             location: LA
-          name: get_weather
         normal_text: 'I will check the weather. '
       sglang:
         unavailable: SGLang has no detector for family='deepseek_v4'

--- a/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.yaml
@@ -14,7 +14,7 @@ cases:
       </｜DSML｜invoke>
       </｜DSML｜tool_calls>
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
@@ -22,37 +22,37 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_1
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *d_1
+      vllm: *id001
       sglang:
         unavailable: SGLang has no detector for family='deepseek_v4'
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_3
+      dynamo: &id003
         calls: []
         normal_text: Hello, how can I help you today?
-      vllm: *d_3
+      vllm: *id003
       sglang:
         unavailable: SGLang has no detector for family='deepseek_v4'
   PARSER.batch.9:
     description: Empty input
     model_text: ''
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_9
+      dynamo: &id004
         calls: []
         normal_text: ''
-      vllm: *d_9
+      vllm: *id004
       sglang:
         unavailable: SGLang has no detector for family='deepseek_v4'
   PARSER.batch.10:
@@ -67,9 +67,9 @@ cases:
       </｜DSML｜invoke>
       </｜DSML｜tool_calls>
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_10
+      dynamo: &id005
         calls:
         - name: get_weather
           arguments:
@@ -78,6 +78,6 @@ cases:
           arguments:
             location: LA
         normal_text: ''
-      vllm: *d_10
+      vllm: *id005
       sglang:
         unavailable: SGLang has no detector for family='deepseek_v4'

--- a/tests/parity/parser/fixtures/gemma4/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/gemma4/PARSER.batch.5.yaml
@@ -58,3 +58,37 @@ cases:
         reason: "vLLM leaks the tool call tag into normal_text on the recovery path"
       sglang:
         unavailable: SGLang has no detector for family='gemma4'
+  PARSER.batch.5.d:
+    description: Multi-call, last call missing only end marker (body complete)
+    ref: dynamo
+    model_text: I'll start by fetching the weather for both Boston and New York at the same time!<|tool_call>call:get_weather{location:<|"|>Boston<|"|>}<tool_call|><|tool_call>call:get_weather{location:<|"|>New
+      York<|"|>}
+    tools:
+    - *id001
+    expected:
+      dynamo: &d_5_d
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
+      vllm: *d_5_d
+      sglang:
+        unavailable: SGLang has no detector for family='gemma4'
+  PARSER.batch.5.e:
+    description: Multi-call, last call truncated mid-arg-value
+    ref: dynamo
+    model_text: I'll start by fetching the weather for both Boston and New York at the same time!<|tool_call>call:get_weather{location:<|"|>Boston<|"|>}<tool_call|><|tool_call>call:get_weather{location:<|"|>New
+      York
+    tools:
+    - *id001
+    expected:
+      dynamo: &d_5_e
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
+      vllm: *d_5_e
+      sglang:
+        unavailable: SGLang has no detector for family='gemma4'

--- a/tests/parity/parser/fixtures/gemma4/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/gemma4/PARSER.batch.7.yaml
@@ -20,7 +20,7 @@ cases:
           first_class:
             type: boolean
     expected:
-      dynamo: &d_7_a
+      dynamo: &id001
         calls:
         - name: book_flight
           arguments:
@@ -28,7 +28,7 @@ cases:
             passengers: 2
             first_class: true
         normal_text: ''
-      vllm: *d_7_a
+      vllm: *id001
       sglang:
         unavailable: SGLang has no detector for family='gemma4'
   PARSER.batch.7.b:
@@ -43,13 +43,13 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_7_b
+      dynamo: &id002
         calls:
         - name: get_weather
           arguments:
             location: Tōkyō central
         normal_text: ''
-      vllm: *d_7_b
+      vllm: *id002
       sglang:
         unavailable: SGLang has no detector for family='gemma4'
   PARSER.batch.7.c:
@@ -64,13 +64,13 @@ cases:
           celsius:
             type: integer
     expected:
-      dynamo: &d_7_c
+      dynamo: &id003
         calls:
         - name: set_temperature
           arguments:
             celsius: '20'
         normal_text: ''
-      vllm: *d_7_c
+      vllm: *id003
       sglang:
         unavailable: SGLang has no detector for family='gemma4'
   PARSER.batch.7.d:
@@ -87,7 +87,7 @@ cases:
           config:
             type: object
     expected:
-      dynamo: &d_7_d
+      dynamo: &id004
         calls:
         - name: process_data
           arguments:
@@ -98,6 +98,6 @@ cases:
             config:
               nested: true
         normal_text: ''
-      vllm: *d_7_d
+      vllm: *id004
       sglang:
         unavailable: SGLang has no detector for family='gemma4'

--- a/tests/parity/parser/fixtures/gemma4/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/gemma4/PARSER.batch.yaml
@@ -9,7 +9,7 @@ cases:
     description: Single tool call (happy path)
     model_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}<tool_call|>
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
@@ -17,46 +17,46 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_1
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *d_1
+      vllm: *id001
       sglang:
         unavailable: SGLang has no detector for family='gemma4'
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_3
+      dynamo: &id003
         calls: []
         normal_text: Hello, how can I help you today?
-      vllm: *d_3
+      vllm: *id003
       sglang:
         unavailable: SGLang has no detector for family='gemma4'
   PARSER.batch.9:
     description: Empty input
     model_text: ''
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_9
+      dynamo: &id004
         calls: []
         normal_text: ''
-      vllm: *d_9
+      vllm: *id004
       sglang:
         unavailable: SGLang has no detector for family='gemma4'
   PARSER.batch.10:
     description: Duplicate calls (same name twice)
     model_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}<tool_call|><|tool_call>call:get_weather{location:<|"|>LA<|"|>}<tool_call|>
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_10
+      dynamo: &id005
         calls:
         - name: get_weather
           arguments:
@@ -65,6 +65,6 @@ cases:
           arguments:
             location: LA
         normal_text: ''
-      vllm: *d_10
+      vllm: *id005
       sglang:
         unavailable: SGLang has no detector for family='gemma4'

--- a/tests/parity/parser/fixtures/glm47/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/glm47/PARSER.batch.2.yaml
@@ -62,6 +62,7 @@ cases:
           arguments:
             timezone: EST
         normal_text: 'Checking: '
+        reason: vLLM glm47 only emits the prefix before the first <tool_call> as normal_text — trailing prose after the last </tool_call> is dropped; Dynamo and SGLang preserve it
       sglang: *id004
   PARSER.batch.2.d:
     description: Same-name twice (id distinctness)

--- a/tests/parity/parser/fixtures/glm47/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/glm47/PARSER.batch.2.yaml
@@ -9,14 +9,14 @@ cases:
     ref: dynamo
     model_text: <tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call><tool_call>get_time<arg_key>timezone</arg_key><arg_value>EST</arg_value></tool_call>
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
         properties:
           location:
             type: string
-    - &id002
+    - &id003
       name: get_time
       parameters:
         type: object
@@ -24,7 +24,7 @@ cases:
           timezone:
             type: string
     expected:
-      dynamo: &d_2_a
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
@@ -33,18 +33,18 @@ cases:
           arguments:
             timezone: EST
         normal_text: ''
-      vllm: *d_2_a
-      sglang: *d_2_a
+      vllm: *id001
+      sglang: *id001
   PARSER.batch.2.c:
     description: Parallel calls with surrounding narration
     ref: dynamo
     model_text: 'Checking: <tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call><tool_call>get_time<arg_key>timezone</arg_key><arg_value>EST</arg_value></tool_call>
       Done.'
     tools:
-    - *id001
     - *id002
+    - *id003
     expected:
-      dynamo: &d_2_c
+      dynamo: &id004
         calls:
         - name: get_weather
           arguments:
@@ -55,24 +55,23 @@ cases:
         normal_text: 'Checking:  Done.'
       vllm:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
-        - arguments:
+        - name: get_time
+          arguments:
             timezone: EST
-          name: get_time
         normal_text: 'Checking: '
-        reason: "drops trailing normal_text after tool-call wrapper end"
-      sglang: *d_2_c
+      sglang: *id004
   PARSER.batch.2.d:
     description: Same-name twice (id distinctness)
     ref: dynamo
     model_text: <tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call><tool_call>get_weather<arg_key>location</arg_key><arg_value>LA</arg_value></tool_call>
     tools:
-    - *id001
-    - *id001
+    - *id002
+    - *id002
     expected:
-      dynamo: &d_2_d
+      dynamo: &id005
         calls:
         - name: get_weather
           arguments:
@@ -81,5 +80,5 @@ cases:
           arguments:
             location: LA
         normal_text: ''
-      vllm: *d_2_d
-      sglang: *d_2_d
+      vllm: *id005
+      sglang: *id005

--- a/tests/parity/parser/fixtures/glm47/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/glm47/PARSER.batch.4.yaml
@@ -22,14 +22,12 @@ cases:
         normal_text: <tool_call><arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>
       vllm:
         calls:
-        - arguments: {}
-          name: <arg_key>location</arg_key><arg_value>NYC</arg_value>
+        - name: <arg_key>location</arg_key><arg_value>NYC</arg_value>
+          arguments: {}
         normal_text: ''
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
       sglang:
         calls: []
         normal_text: ''
-        reason: "sglang nullifies normal_text on malformed/recovery shapes where Dynamo preserves input"
   PARSER.batch.4.d:
     description: Missing </arg_value> end tag
     ref: dynamo
@@ -37,10 +35,10 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &d_4_d
+      dynamo: &id002
         calls:
         - name: get_weather
           arguments: {}
         normal_text: ''
-      vllm: *d_4_d
-      sglang: *d_4_d
+      vllm: *id002
+      sglang: *id002

--- a/tests/parity/parser/fixtures/glm47/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/glm47/PARSER.batch.4.yaml
@@ -19,12 +19,13 @@ cases:
     expected:
       dynamo:
         calls: []
-        normal_text: <tool_call><arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>
+        normal_text: ''
       vllm:
         calls:
         - name: <arg_key>location</arg_key><arg_value>NYC</arg_value>
           arguments: {}
         normal_text: ''
+        reason: vLLM treats the leading <arg_key>...</arg_value> bytes as a function name when no name precedes the first arg_key; Dynamo and SGLang both drop the malformed call
       sglang:
         calls: []
         normal_text: ''

--- a/tests/parity/parser/fixtures/glm47/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/glm47/PARSER.batch.5.yaml
@@ -17,10 +17,13 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &id001
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm: &id001
         calls: []
         normal_text: <tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value>
-      vllm: *id001
+        reason: vLLM and SGLang preserve the truncated <tool_call>... markup as content on missing-end-token recovery; Dynamo drops to keep wire tags out of message.content
       sglang: *id001
   PARSER.batch.5.b:
     description: Closing </tool_call> without matching <tool_call> open
@@ -41,10 +44,13 @@ cases:
     tools:
     - *id002
     expected:
-      dynamo: &id004
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm: &id004
         calls: []
         normal_text: <tool_call>get_weather<arg_key>location</arg_key><arg_value>N
-      vllm: *id004
+        reason: vLLM and SGLang preserve the truncated <tool_call>... prefix as content on mid-arg-value truncation; Dynamo drops to keep wire tags out of message.content
       sglang: *id004
   PARSER.batch.5.d:
     description: Multi-call, last call missing only </tool_call> end marker (body complete)
@@ -54,20 +60,26 @@ cases:
     tools:
     - *id002
     expected:
-      dynamo: &id005
+      dynamo:
         calls:
         - name: get_weather
           arguments:
             location: Boston
-        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!<tool_call>get_weather<arg_key>location</arg_key><arg_value>New
-          York</arg_value>
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
       vllm:
         calls:
         - name: get_weather
           arguments:
             location: Boston
         normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
-      sglang: *id005
+      sglang:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!<tool_call>get_weather<arg_key>location</arg_key><arg_value>New
+          York</arg_value>
+        reason: SGLang preserves the trailing truncated <tool_call>... block as content; Dynamo and vLLM both drop it
   PARSER.batch.5.e:
     description: Multi-call, last call truncated mid-arg-value
     ref: dynamo
@@ -76,17 +88,23 @@ cases:
     tools:
     - *id002
     expected:
-      dynamo: &id006
+      dynamo:
         calls:
         - name: get_weather
           arguments:
             location: Boston
-        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!<tool_call>get_weather<arg_key>location</arg_key><arg_value>New
-          York
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
       vllm:
         calls:
         - name: get_weather
           arguments:
             location: Boston
         normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
-      sglang: *id006
+      sglang:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!<tool_call>get_weather<arg_key>location</arg_key><arg_value>New
+          York
+        reason: SGLang preserves the trailing truncated <tool_call>... block as content; Dynamo and vLLM both drop it

--- a/tests/parity/parser/fixtures/glm47/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/glm47/PARSER.batch.5.yaml
@@ -9,7 +9,7 @@ cases:
     ref: dynamo
     model_text: <tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value>
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
@@ -17,74 +17,76 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_5_a
+      dynamo: &id001
         calls: []
         normal_text: <tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value>
-      vllm: *d_5_a
-      sglang: *d_5_a
+      vllm: *id001
+      sglang: *id001
   PARSER.batch.5.b:
     description: Closing </tool_call> without matching <tool_call> open
     ref: dynamo
     model_text: get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_5_b
+      dynamo: &id003
         calls: []
         normal_text: get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>
-      vllm: *d_5_b
-      sglang: *d_5_b
+      vllm: *id003
+      sglang: *id003
   PARSER.batch.5.c:
     description: Truncation mid-arg_value
     ref: dynamo
     model_text: <tool_call>get_weather<arg_key>location</arg_key><arg_value>N
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_5_c
+      dynamo: &id004
         calls: []
         normal_text: <tool_call>get_weather<arg_key>location</arg_key><arg_value>N
-      vllm: *d_5_c
-      sglang: *d_5_c
+      vllm: *id004
+      sglang: *id004
   PARSER.batch.5.d:
     description: Multi-call, last call missing only </tool_call> end marker (body complete)
     ref: dynamo
-    model_text: I'll start by fetching the weather for both Boston and New York at the same time!<tool_call>get_weather<arg_key>location</arg_key><arg_value>Boston</arg_value></tool_call><tool_call>get_weather<arg_key>location</arg_key><arg_value>New York</arg_value>
+    model_text: I'll start by fetching the weather for both Boston and New York at the same time!<tool_call>get_weather<arg_key>location</arg_key><arg_value>Boston</arg_value></tool_call><tool_call>get_weather<arg_key>location</arg_key><arg_value>New
+      York</arg_value>
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_5_d
+      dynamo: &id005
         calls:
         - name: get_weather
           arguments:
             location: Boston
-        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!<tool_call>get_weather<arg_key>location</arg_key><arg_value>New York</arg_value>
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!<tool_call>get_weather<arg_key>location</arg_key><arg_value>New
+          York</arg_value>
       vllm:
         calls:
         - name: get_weather
           arguments:
             location: Boston
         normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
-        reason: vLLM preserves leading narration but drops the incomplete tool_call block
-      sglang: *d_5_d
+      sglang: *id005
   PARSER.batch.5.e:
     description: Multi-call, last call truncated mid-arg-value
     ref: dynamo
-    model_text: I'll start by fetching the weather for both Boston and New York at the same time!<tool_call>get_weather<arg_key>location</arg_key><arg_value>Boston</arg_value></tool_call><tool_call>get_weather<arg_key>location</arg_key><arg_value>New York
+    model_text: I'll start by fetching the weather for both Boston and New York at the same time!<tool_call>get_weather<arg_key>location</arg_key><arg_value>Boston</arg_value></tool_call><tool_call>get_weather<arg_key>location</arg_key><arg_value>New
+      York
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_5_e
+      dynamo: &id006
         calls:
         - name: get_weather
           arguments:
             location: Boston
-        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!<tool_call>get_weather<arg_key>location</arg_key><arg_value>New York
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!<tool_call>get_weather<arg_key>location</arg_key><arg_value>New
+          York
       vllm:
         calls:
         - name: get_weather
           arguments:
             location: Boston
         normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
-        reason: vLLM preserves leading narration but drops the incomplete tool_call block
-      sglang: *d_5_e
+      sglang: *id006

--- a/tests/parity/parser/fixtures/glm47/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/glm47/PARSER.batch.5.yaml
@@ -64,8 +64,8 @@ cases:
         - name: get_weather
           arguments:
             location: Boston
-        normal_text: ''
-        reason: vLLM drops the raw 2nd block from normal_text
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
+        reason: vLLM preserves leading narration but drops the incomplete tool_call block
       sglang: *d_5_d
   PARSER.batch.5.e:
     description: Multi-call, last call truncated mid-arg-value
@@ -85,6 +85,6 @@ cases:
         - name: get_weather
           arguments:
             location: Boston
-        normal_text: ''
-        reason: vLLM drops the raw 2nd block from normal_text
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
+        reason: vLLM preserves leading narration but drops the incomplete tool_call block
       sglang: *d_5_e

--- a/tests/parity/parser/fixtures/glm47/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/glm47/PARSER.batch.5.yaml
@@ -17,20 +17,11 @@ cases:
           location:
             type: string
     expected:
-      dynamo:
-        calls:
-        - name: get_weather
-          arguments:
-            location: NYC
-        normal_text: ''
-      vllm:
+      dynamo: &d_5_a
         calls: []
         normal_text: <tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value>
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
-      sglang:
-        calls: []
-        normal_text: <tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value>
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
+      vllm: *d_5_a
+      sglang: *d_5_a
   PARSER.batch.5.b:
     description: Closing </tool_call> without matching <tool_call> open
     ref: dynamo
@@ -50,15 +41,50 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo:
+      dynamo: &d_5_c
+        calls: []
+        normal_text: <tool_call>get_weather<arg_key>location</arg_key><arg_value>N
+      vllm: *d_5_c
+      sglang: *d_5_c
+  PARSER.batch.5.d:
+    description: Multi-call, last call missing only </tool_call> end marker (body complete)
+    ref: dynamo
+    model_text: I'll start by fetching the weather for both Boston and New York at the same time!<tool_call>get_weather<arg_key>location</arg_key><arg_value>Boston</arg_value></tool_call><tool_call>get_weather<arg_key>location</arg_key><arg_value>New York</arg_value>
+    tools:
+    - *id001
+    expected:
+      dynamo: &d_5_d
         calls:
         - name: get_weather
-          arguments: {}
-        normal_text: ''
+          arguments:
+            location: Boston
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!<tool_call>get_weather<arg_key>location</arg_key><arg_value>New York</arg_value>
       vllm:
-        calls: []
-        normal_text: <tool_call>get_weather<arg_key>location</arg_key><arg_value>N
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
-      sglang:
-        calls: []
-        normal_text: <tool_call>get_weather<arg_key>location</arg_key><arg_value>N
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: ''
+        reason: vLLM drops the raw 2nd block from normal_text
+      sglang: *d_5_d
+  PARSER.batch.5.e:
+    description: Multi-call, last call truncated mid-arg-value
+    ref: dynamo
+    model_text: I'll start by fetching the weather for both Boston and New York at the same time!<tool_call>get_weather<arg_key>location</arg_key><arg_value>Boston</arg_value></tool_call><tool_call>get_weather<arg_key>location</arg_key><arg_value>New York
+    tools:
+    - *id001
+    expected:
+      dynamo: &d_5_e
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!<tool_call>get_weather<arg_key>location</arg_key><arg_value>New York
+      vllm:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: ''
+        reason: vLLM drops the raw 2nd block from normal_text
+      sglang: *d_5_e

--- a/tests/parity/parser/fixtures/glm47/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/glm47/PARSER.batch.6.yaml
@@ -9,32 +9,32 @@ cases:
     ref: dynamo
     model_text: <tool_call>get_time</tool_call>
     tools:
-    - &id001
+    - &id002
       name: get_time
       parameters:
         type: object
         properties: {}
     expected:
-      dynamo: &d_6_a
+      dynamo: &id001
         calls:
         - name: get_time
           arguments: {}
         normal_text: ''
-      vllm: *d_6_a
-      sglang: *d_6_a
+      vllm: *id001
+      sglang: *id001
   PARSER.batch.6.b:
     description: Function-only with whitespace
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_glm47_moe_tool_parser.py#L68
     model_text: <tool_call>get_time </tool_call>
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_6_b
+      dynamo: &id003
         calls:
         - name: get_time
           arguments: {}
         normal_text: ''
-      vllm: *d_6_b
+      vllm: *id003
       sglang:
         calls: []
         normal_text: ''

--- a/tests/parity/parser/fixtures/glm47/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/glm47/PARSER.batch.6.yaml
@@ -38,3 +38,4 @@ cases:
       sglang:
         calls: []
         normal_text: ''
+        reason: SGLang glm47 rejects whitespace between the function name and </tool_call> (`get_time `), emitting no calls; Dynamo and vLLM both tolerate it and extract the empty-args call

--- a/tests/parity/parser/fixtures/glm47/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/glm47/PARSER.batch.7.yaml
@@ -20,7 +20,7 @@ cases:
           first_class:
             type: boolean
     expected:
-      dynamo: &d_7_a
+      dynamo: &id001
         calls:
         - name: book_flight
           arguments:
@@ -28,8 +28,8 @@ cases:
             passengers: 2
             destination: Paris
         normal_text: ''
-      vllm: *d_7_a
-      sglang: *d_7_a
+      vllm: *id001
+      sglang: *id001
   PARSER.batch.7.b:
     description: Unicode in arg value
     ref: dynamo
@@ -42,11 +42,11 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_7_b
+      dynamo: &id002
         calls:
         - name: get_weather
           arguments:
             location: Tōkyō central
         normal_text: ''
-      vllm: *d_7_b
-      sglang: *d_7_b
+      vllm: *id002
+      sglang: *id002

--- a/tests/parity/parser/fixtures/glm47/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/glm47/PARSER.batch.8.yaml
@@ -9,7 +9,7 @@ cases:
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_glm47_moe_tool_parser.py#L94
     model_text: I will check the weather. <tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
@@ -17,7 +17,7 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_8_a
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
@@ -25,21 +25,20 @@ cases:
         normal_text: I will check the weather.
       vllm:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
         normal_text: 'I will check the weather. '
-        reason: "drops trailing normal_text after tool-call wrapper end"
-      sglang: *d_8_a
+      sglang: *id001
   PARSER.batch.8.b:
     description: Narration after tool call only
     ref: dynamo
     model_text: <tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call> Let me know if you
       need more.
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_8_b
+      dynamo: &id003
         calls:
         - name: get_weather
           arguments:
@@ -47,21 +46,20 @@ cases:
         normal_text: Let me know if you need more.
       vllm:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
         normal_text: ''
-        reason: "drops trailing normal_text after tool-call wrapper end"
-      sglang: *d_8_b
+      sglang: *id003
   PARSER.batch.8.c:
     description: Narration both before and after (sandwich)
     ref: dynamo
     model_text: I will check the weather. <tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>
       Let me know if you need more.
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_8_c
+      dynamo: &id004
         calls:
         - name: get_weather
           arguments:
@@ -69,21 +67,20 @@ cases:
         normal_text: I will check the weather.  Let me know if you need more.
       vllm:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
         normal_text: 'I will check the weather. '
-        reason: "drops trailing normal_text after tool-call wrapper end"
-      sglang: *d_8_c
+      sglang: *id004
   PARSER.batch.8.d:
     description: Narration between multiple tool calls
     ref: dynamo
     model_text: I will check the weather. <tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>
       Then check LA weather. <tool_call>get_weather<arg_key>location</arg_key><arg_value>LA</arg_value></tool_call>
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_8_d
+      dynamo: &id005
         calls:
         - name: get_weather
           arguments:
@@ -94,12 +91,11 @@ cases:
         normal_text: I will check the weather.  Then check LA weather.
       vllm:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
-        - arguments:
+        - name: get_weather
+          arguments:
             location: LA
-          name: get_weather
         normal_text: 'I will check the weather. '
-        reason: "drops trailing normal_text after tool-call wrapper end"
-      sglang: *d_8_d
+      sglang: *id005

--- a/tests/parity/parser/fixtures/glm47/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/glm47/PARSER.batch.8.yaml
@@ -29,6 +29,7 @@ cases:
           arguments:
             location: NYC
         normal_text: 'I will check the weather. '
+        reason: vLLM glm47 keeps trailing whitespace before the first <tool_call>; Dynamo and SGLang both trim it
       sglang: *id001
   PARSER.batch.8.b:
     description: Narration after tool call only
@@ -50,6 +51,7 @@ cases:
           arguments:
             location: NYC
         normal_text: ''
+        reason: vLLM glm47 only emits the prefix before the first <tool_call> as normal_text — content after the last </tool_call> is dropped; Dynamo and SGLang both preserve it
       sglang: *id003
   PARSER.batch.8.c:
     description: Narration both before and after (sandwich)
@@ -71,6 +73,7 @@ cases:
           arguments:
             location: NYC
         normal_text: 'I will check the weather. '
+        reason: vLLM glm47 only emits the prefix before the first <tool_call> as normal_text — content after the </tool_call> is dropped; Dynamo and SGLang both concatenate the prefix and the trailing prose
       sglang: *id004
   PARSER.batch.8.d:
     description: Narration between multiple tool calls
@@ -98,4 +101,5 @@ cases:
           arguments:
             location: LA
         normal_text: 'I will check the weather. '
+        reason: vLLM glm47 only emits the prefix before the first <tool_call> as normal_text — prose between successive calls is dropped; Dynamo and SGLang concatenate all non-tool-call segments
       sglang: *id005

--- a/tests/parity/parser/fixtures/glm47/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/glm47/PARSER.batch.yaml
@@ -9,7 +9,7 @@ cases:
     description: Single tool call (happy path)
     model_text: <tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
@@ -17,43 +17,43 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_1
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *d_1
-      sglang: *d_1
+      vllm: *id001
+      sglang: *id001
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_3
+      dynamo: &id003
         calls: []
         normal_text: Hello, how can I help you today?
-      vllm: *d_3
-      sglang: *d_3
+      vllm: *id003
+      sglang: *id003
   PARSER.batch.9:
     description: Empty input
     model_text: ''
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_9
+      dynamo: &id004
         calls: []
         normal_text: ''
-      vllm: *d_9
-      sglang: *d_9
+      vllm: *id004
+      sglang: *id004
   PARSER.batch.10:
     description: Duplicate calls (same name twice)
     model_text: <tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call><tool_call>get_weather<arg_key>location</arg_key><arg_value>LA</arg_value></tool_call>
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_10
+      dynamo: &id005
         calls:
         - name: get_weather
           arguments:
@@ -62,5 +62,5 @@ cases:
           arguments:
             location: LA
         normal_text: ''
-      vllm: *d_10
-      sglang: *d_10
+      vllm: *id005
+      sglang: *id005

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.2.yaml
@@ -33,14 +33,13 @@ cases:
         unavailable: 'NotImplementedError: OpenAIToolParser requires token IDs and does not support text-based extraction.'
       sglang:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
-        - arguments:
+        - name: get_time
+          arguments:
             timezone: EST
-          name: get_time
         normal_text: ''
-        reason: "Dynamo drops back-to-back commentary blocks; SGLang extracts them"
   PARSER.batch.2.c:
     description: With surrounding narration
     ref: dynamo
@@ -58,12 +57,12 @@ cases:
         unavailable: 'NotImplementedError: OpenAIToolParser requires token IDs and does not support text-based extraction.'
       sglang:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
-        - arguments:
+        - name: get_time
+          arguments:
             timezone: EST
-          name: get_time
         normal_text: I need both.   Done.
   PARSER.batch.2.d:
     description: Same-name twice
@@ -82,10 +81,10 @@ cases:
         unavailable: 'NotImplementedError: OpenAIToolParser requires token IDs and does not support text-based extraction.'
       sglang:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
-        - arguments:
+        - name: get_weather
+          arguments:
             location: LA
-          name: get_weather
         normal_text: ''

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.4.yaml
@@ -19,14 +19,13 @@ cases:
     expected:
       dynamo:
         calls: []
-        normal_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>not json at
-          all<|call|>
+        normal_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>not json
+          at all<|call|>
       vllm:
         unavailable: 'NotImplementedError: OpenAIToolParser requires token IDs and does not support text-based extraction.'
       sglang:
         calls: []
         normal_text: ''
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
   PARSER.batch.4.b:
     description: Unterminated JSON in message body
     ref: dynamo
@@ -49,9 +48,9 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &d_4_c
+      dynamo: &id002
         calls: []
         normal_text: ''
       vllm:
         unavailable: 'NotImplementedError: OpenAIToolParser requires token IDs and does not support text-based extraction.'
-      sglang: *d_4_c
+      sglang: *id002

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.5.yaml
@@ -25,7 +25,6 @@ cases:
       sglang:
         calls: []
         normal_text: ''
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
   PARSER.batch.5.b:
     description: Bare <|call|> without preceding channel envelope
     ref: dynamo
@@ -33,12 +32,12 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &d_5_b
+      dynamo: &id002
         calls: []
         normal_text: <|call|>
       vllm:
         unavailable: 'NotImplementedError: OpenAIToolParser requires token IDs and does not support text-based extraction.'
-      sglang: *d_5_b
+      sglang: *id002
   PARSER.batch.5.c:
     description: Truncation mid-message JSON
     ref: dynamo
@@ -54,3 +53,47 @@ cases:
       sglang:
         calls: []
         normal_text: ''
+  PARSER.batch.5.d:
+    description: Multi-call, last call missing only end marker (body complete)
+    ref: dynamo
+    model_text: I'll start by fetching the weather for both Boston and New York at the same time!<|start|>assistant<|channel|>commentary
+      to=functions.get_weather <|constrain|>json<|message|>{"location":"Boston"}<|call|><|start|>assistant<|channel|>commentary
+      to=functions.get_weather <|constrain|>json<|message|>{"location":"New York"}
+    tools:
+    - *id001
+    expected:
+      dynamo:
+        calls: []
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!<|start|>assistant<|channel|>commentary
+          to=functions.get_weather <|constrain|>json<|message|>{"location":"Boston"}<|call|><|start|>assistant<|channel|>commentary
+          to=functions.get_weather <|constrain|>json<|message|>{"location":"New York"}
+      vllm:
+        unavailable: 'NotImplementedError: OpenAIToolParser requires token IDs and does not support text-based extraction.'
+      sglang:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
+  PARSER.batch.5.e:
+    description: Multi-call, last call truncated mid-arg-value
+    ref: dynamo
+    model_text: I'll start by fetching the weather for both Boston and New York at the same time!<|start|>assistant<|channel|>commentary
+      to=functions.get_weather <|constrain|>json<|message|>{"location":"Boston"}<|call|><|start|>assistant<|channel|>commentary
+      to=functions.get_weather <|constrain|>json<|message|>{"location":"New York
+    tools:
+    - *id001
+    expected:
+      dynamo:
+        calls: []
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!<|start|>assistant<|channel|>commentary
+          to=functions.get_weather <|constrain|>json<|message|>{"location":"Boston"}<|call|><|start|>assistant<|channel|>commentary
+          to=functions.get_weather <|constrain|>json<|message|>{"location":"New York
+      vllm:
+        unavailable: 'NotImplementedError: OpenAIToolParser requires token IDs and does not support text-based extraction.'
+      sglang:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.6.yaml
@@ -25,7 +25,6 @@ cases:
       sglang:
         calls: []
         normal_text: <|channel|>commentary to=functions.get_time <|constrain|>json<|message|>{}
-        reason: "SGLang's GptOssDetector bot_token requires '<|start|>assistant<|channel|>commentary' envelope; Dynamo accepts the bare '<|channel|>commentary' variant"
   PARSER.batch.6.b:
     description: Whitespace inside empty {}
     ref: dynamo
@@ -43,7 +42,6 @@ cases:
       sglang:
         calls: []
         normal_text: <|channel|>commentary to=functions.get_time <|constrain|>json<|message|>{ }
-        reason: "SGLang's GptOssDetector bot_token requires '<|start|>assistant<|channel|>commentary' envelope; Dynamo accepts the bare '<|channel|>commentary' variant"
   PARSER.batch.6.c:
     description: No <|message|> body
     ref: dynamo
@@ -51,9 +49,9 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &d_6_c
+      dynamo: &id002
         calls: []
         normal_text: <|channel|>commentary to=functions.get_time <|constrain|>json
       vllm:
         unavailable: 'NotImplementedError: OpenAIToolParser requires token IDs and does not support text-based extraction.'
-      sglang: *d_6_c
+      sglang: *id002

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.7.yaml
@@ -33,7 +33,6 @@ cases:
       sglang:
         calls: []
         normal_text: <|channel|>commentary to=functions.book_flight <|constrain|>json<|message|>{"destination":"Paris","passengers":2,"first_class":true}<|call|>
-        reason: "drops analysis-channel content from normal_text"
   PARSER.batch.7.b:
     description: Unicode + escaped chars
     ref: dynamo

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.8.yaml
@@ -26,11 +26,10 @@ cases:
         unavailable: 'NotImplementedError: OpenAIToolParser requires token IDs and does not support text-based extraction.'
       sglang:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
         normal_text: I will check the weather.
-        reason: "SGLang's GptOssDetector bot_token requires '<|start|>assistant<|channel|>commentary' envelope; Dynamo accepts the bare '<|channel|>commentary' variant"
   PARSER.batch.8.b:
     description: Narration after tool call only
     ref: dynamo
@@ -47,11 +46,10 @@ cases:
         unavailable: 'NotImplementedError: OpenAIToolParser requires token IDs and does not support text-based extraction.'
       sglang:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
         normal_text: Let me know if you need more.
-        reason: "SGLang's GptOssDetector bot_token requires '<|start|>assistant<|channel|>commentary' envelope; Dynamo accepts the bare '<|channel|>commentary' variant"
   PARSER.batch.8.c:
     description: Narration both before and after (sandwich)
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_openai_tool_parser.py#L220
@@ -68,11 +66,10 @@ cases:
         unavailable: 'NotImplementedError: OpenAIToolParser requires token IDs and does not support text-based extraction.'
       sglang:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
         normal_text: I will check the weather.   Let me know if you need more.
-        reason: "SGLang's GptOssDetector bot_token requires '<|start|>assistant<|channel|>commentary' envelope; Dynamo accepts the bare '<|channel|>commentary' variant"
   PARSER.batch.8.d:
     description: Narration between multiple tool calls
     ref: dynamo
@@ -91,11 +88,10 @@ cases:
         unavailable: 'NotImplementedError: OpenAIToolParser requires token IDs and does not support text-based extraction.'
       sglang:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
-        - arguments:
+        - name: get_weather
+          arguments:
             location: LA
-          name: get_weather
         normal_text: I will check the weather.   Then check LA weather.
-        reason: "SGLang's GptOssDetector bot_token requires '<|start|>assistant<|channel|>commentary' envelope; Dynamo accepts the bare '<|channel|>commentary' variant"

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.yaml
@@ -28,31 +28,30 @@ cases:
       sglang:
         calls: []
         normal_text: <|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}
-        reason: "SGLang's GptOssDetector bot_token requires '<|start|>assistant<|channel|>commentary' envelope; Dynamo accepts the bare '<|channel|>commentary' variant"
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
     tools:
     - *id001
     expected:
-      dynamo: &d_3
+      dynamo: &id002
         calls: []
         normal_text: Hello, how can I help you today?
       vllm:
         unavailable: 'NotImplementedError: OpenAIToolParser requires token IDs and does not support text-based extraction.'
-      sglang: *d_3
+      sglang: *id002
   PARSER.batch.9:
     description: Empty input
     model_text: ''
     tools:
     - *id001
     expected:
-      dynamo: &d_9
+      dynamo: &id003
         calls: []
         normal_text: ''
       vllm:
         unavailable: 'NotImplementedError: OpenAIToolParser requires token IDs and does not support text-based extraction.'
-      sglang: *d_9
+      sglang: *id003
   PARSER.batch.10:
     description: Duplicate calls (same name twice)
     model_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|><|start|>assistant<|channel|>commentary
@@ -68,11 +67,10 @@ cases:
         unavailable: 'NotImplementedError: OpenAIToolParser requires token IDs and does not support text-based extraction.'
       sglang:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
-        - arguments:
+        - name: get_weather
+          arguments:
             location: LA
-          name: get_weather
         normal_text: ''
-        reason: "Dynamo drops back-to-back commentary blocks; SGLang extracts them"

--- a/tests/parity/parser/fixtures/hermes/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/hermes/PARSER.batch.2.yaml
@@ -10,14 +10,14 @@ cases:
     model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name": "get_time",
       "arguments": {"timezone": "EST"}}</tool_call>'
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
         properties:
           location:
             type: string
-    - &id002
+    - &id003
       name: get_time
       parameters:
         type: object
@@ -25,7 +25,7 @@ cases:
           timezone:
             type: string
     expected:
-      dynamo: &d_2_a
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
@@ -34,18 +34,18 @@ cases:
           arguments:
             timezone: EST
         normal_text: ''
-      vllm: *d_2_a
-      sglang: *d_2_a
+      vllm: *id001
+      sglang: *id001
   PARSER.batch.2.c:
     description: With surrounding narration
     ref: dynamo
     model_text: 'Both: <tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name":
       "get_time", "arguments": {"timezone": "EST"}}</tool_call> Done.'
     tools:
-    - *id001
     - *id002
+    - *id003
     expected:
-      dynamo: &d_2_c
+      dynamo: &id004
         calls:
         - name: get_weather
           arguments:
@@ -56,25 +56,24 @@ cases:
         normal_text: 'Both:'
       vllm:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
-        - arguments:
+        - name: get_time
+          arguments:
             timezone: EST
-          name: get_time
         normal_text: 'Both: '
-        reason: "drops trailing normal_text after tool-call wrapper end"
-      sglang: *d_2_c
+      sglang: *id004
   PARSER.batch.2.d:
     description: Same-name twice
     ref: dynamo
     model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name": "get_weather",
       "arguments": {"location": "LA"}}</tool_call>'
     tools:
-    - *id001
-    - *id001
+    - *id002
+    - *id002
     expected:
-      dynamo: &d_2_d
+      dynamo: &id005
         calls:
         - name: get_weather
           arguments:
@@ -83,5 +82,5 @@ cases:
           arguments:
             location: LA
         normal_text: ''
-      vllm: *d_2_d
-      sglang: *d_2_d
+      vllm: *id005
+      sglang: *id005

--- a/tests/parity/parser/fixtures/hermes/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/hermes/PARSER.batch.4.yaml
@@ -9,7 +9,7 @@ cases:
     ref: dynamo
     model_text: <tool_call>not even json</tool_call>
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
@@ -17,17 +17,17 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_4_a
+      dynamo: &id001
         calls: []
         normal_text: <tool_call>not even json</tool_call>
-      vllm: *d_4_a
-      sglang: *d_4_a
+      vllm: *id001
+      sglang: *id001
   PARSER.batch.4.b:
     description: Missing close brace in JSON body
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_hermes_tool_parser.py#L376
     model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"</tool_call>'
     tools:
-    - *id001
+    - *id002
     expected:
       dynamo:
         calls:
@@ -38,7 +38,6 @@ cases:
       vllm:
         calls: []
         normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"</tool_call>'
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
       sglang:
         calls: []
         normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"</tool_call>'
@@ -47,12 +46,12 @@ cases:
     ref: dynamo
     model_text: '<tool_call>{"arguments": {"location": "NYC"}}</tool_call>'
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_4_c
+      dynamo: &id003
         calls: []
         normal_text: '<tool_call>{"arguments": {"location": "NYC"}}</tool_call>'
-      vllm: *d_4_c
+      vllm: *id003
       sglang:
         calls: []
         normal_text: ''
@@ -61,13 +60,13 @@ cases:
     ref: dynamo
     model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}'
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_4_d
+      dynamo: &id004
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *d_4_d
-      sglang: *d_4_d
+      vllm: *id004
+      sglang: *id004

--- a/tests/parity/parser/fixtures/hermes/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/hermes/PARSER.batch.5.yaml
@@ -9,7 +9,7 @@ cases:
     ref: dynamo
     model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}'
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
@@ -17,35 +17,91 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_5_a
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *d_5_a
-      sglang: *d_5_a
+      vllm: *id001
+      sglang: *id001
   PARSER.batch.5.b:
     description: Closing </tool_call> without matching <tool_call> open
     ref: dynamo
     model_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>'
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_5_b
+      dynamo: &id003
         calls: []
         normal_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>'
-      vllm: *d_5_b
-      sglang: *d_5_b
+      vllm: *id003
+      sglang: *id003
   PARSER.batch.5.c:
     description: Truncation mid-arguments JSON
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_hermes_tool_parser.py#L356
     model_text: '<tool_call>{"name": "get_weather", "arguments": {"loc'
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_5_c
+      dynamo: &id004
         calls: []
         normal_text: '<tool_call>{"name": "get_weather", "arguments": {"loc'
-      vllm: *d_5_c
-      sglang: *d_5_c
+      vllm: *id004
+      sglang: *id004
+  PARSER.batch.5.d:
+    description: Multi-call, last call missing only end marker (body complete)
+    ref: dynamo
+    model_text: 'I''ll start by fetching the weather for both Boston and New York at the same time!<tool_call>{"name": "get_weather",
+      "arguments": {"location": "Boston"}}</tool_call><tool_call>{"name": "get_weather", "arguments": {"location": "New York"}}'
+    tools:
+    - *id002
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
+      vllm:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        - name: get_weather
+          arguments:
+            location: New York
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
+      sglang:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        - name: get_weather
+          arguments:
+            location: New York
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
+  PARSER.batch.5.e:
+    description: Multi-call, last call truncated mid-arg-value
+    ref: dynamo
+    model_text: 'I''ll start by fetching the weather for both Boston and New York at the same time!<tool_call>{"name": "get_weather",
+      "arguments": {"location": "Boston"}}</tool_call><tool_call>{"name": "get_weather", "arguments": {"location": "New York'
+    tools:
+    - *id002
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
+      vllm:
+        calls: []
+        normal_text: 'I''ll start by fetching the weather for both Boston and New York at the same time!<tool_call>{"name":
+          "get_weather", "arguments": {"location": "Boston"}}</tool_call><tool_call>{"name": "get_weather", "arguments": {"location":
+          "New York'
+      sglang:
+        calls: []
+        normal_text: 'I''ll start by fetching the weather for both Boston and New York at the same time!<tool_call>{"name":
+          "get_weather", "arguments": {"location": "Boston"}}</tool_call><tool_call>{"name": "get_weather", "arguments": {"location":
+          "New York'

--- a/tests/parity/parser/fixtures/hermes/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/hermes/PARSER.batch.6.yaml
@@ -9,46 +9,46 @@ cases:
     ref: dynamo
     model_text: '<tool_call>{"name": "get_time", "arguments": {}}</tool_call>'
     tools:
-    - &id001
+    - &id002
       name: get_time
       parameters:
         type: object
         properties: {}
     expected:
-      dynamo: &d_6_a
+      dynamo: &id001
         calls:
         - name: get_time
           arguments: {}
         normal_text: ''
-      vllm: *d_6_a
-      sglang: *d_6_a
+      vllm: *id001
+      sglang: *id001
   PARSER.batch.6.b:
     description: Whitespace inside arguments {}
     ref: dynamo
     model_text: '<tool_call>{"name": "get_time", "arguments": { }}</tool_call>'
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_6_b
+      dynamo: &id003
         calls:
         - name: get_time
           arguments: {}
         normal_text: ''
-      vllm: *d_6_b
-      sglang: *d_6_b
+      vllm: *id003
+      sglang: *id003
   PARSER.batch.6.c:
     description: No arguments key
     ref: dynamo
     model_text: '<tool_call>{"name": "get_time"}</tool_call>'
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_6_c
+      dynamo: &id004
         calls: []
         normal_text: '<tool_call>{"name": "get_time"}</tool_call>'
-      vllm: *d_6_c
+      vllm: *id004
       sglang:
         calls:
-        - arguments: {}
-          name: get_time
+        - name: get_time
+          arguments: {}
         normal_text: ''

--- a/tests/parity/parser/fixtures/hermes/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/hermes/PARSER.batch.7.yaml
@@ -21,7 +21,7 @@ cases:
           first_class:
             type: boolean
     expected:
-      dynamo: &d_7_a
+      dynamo: &id001
         calls:
         - name: book_flight
           arguments:
@@ -29,8 +29,8 @@ cases:
             passengers: 2
             destination: Paris
         normal_text: ''
-      vllm: *d_7_a
-      sglang: *d_7_a
+      vllm: *id001
+      sglang: *id001
   PARSER.batch.7.b:
     description: Unicode + escaped chars
     ref: dynamo
@@ -43,14 +43,14 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_7_b
+      dynamo: &id002
         calls:
         - name: get_weather
           arguments:
             location: Tōkyō "central"
         normal_text: ''
-      vllm: *d_7_b
-      sglang: *d_7_b
+      vllm: *id002
+      sglang: *id002
   PARSER.batch.7.c:
     description: Schema mismatch — string value where schema declares integer
     ref: dynamo
@@ -63,14 +63,14 @@ cases:
           celsius:
             type: integer
     expected:
-      dynamo: &d_7_c
+      dynamo: &id003
         calls:
         - name: set_temperature
           arguments:
             celsius: '20'
         normal_text: ''
-      vllm: *d_7_c
-      sglang: *d_7_c
+      vllm: *id003
+      sglang: *id003
   PARSER.batch.7.d:
     description: Nested object + array
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_hermes_tool_parser.py#L284
@@ -85,7 +85,7 @@ cases:
           config:
             type: object
     expected:
-      dynamo: &d_7_d
+      dynamo: &id004
         calls:
         - name: process_data
           arguments:
@@ -96,5 +96,5 @@ cases:
             config:
               nested: true
         normal_text: ''
-      vllm: *d_7_d
-      sglang: *d_7_d
+      vllm: *id004
+      sglang: *id004

--- a/tests/parity/parser/fixtures/hermes/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/hermes/PARSER.batch.8.yaml
@@ -9,7 +9,7 @@ cases:
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_hermes_tool_parser.py#L221
     model_text: 'I will check the weather. <tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>'
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
@@ -17,7 +17,7 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_8_a
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
@@ -25,37 +25,36 @@ cases:
         normal_text: I will check the weather.
       vllm:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
         normal_text: 'I will check the weather. '
-        reason: "drops trailing normal_text after tool-call wrapper end"
-      sglang: *d_8_a
+      sglang: *id001
   PARSER.batch.8.b:
     description: Narration after tool call only
     ref: dynamo
     model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call> Let me know if you need
       more.'
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_8_b
+      dynamo: &id003
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *d_8_b
-      sglang: *d_8_b
+      vllm: *id003
+      sglang: *id003
   PARSER.batch.8.c:
     description: Narration both before and after (sandwich)
     ref: dynamo
     model_text: 'I will check the weather. <tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>
       Let me know if you need more.'
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_8_c
+      dynamo: &id004
         calls:
         - name: get_weather
           arguments:
@@ -63,21 +62,20 @@ cases:
         normal_text: I will check the weather.
       vllm:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
         normal_text: 'I will check the weather. '
-        reason: "drops trailing normal_text after tool-call wrapper end"
-      sglang: *d_8_c
+      sglang: *id004
   PARSER.batch.8.d:
     description: Narration between multiple tool calls
     ref: dynamo
     model_text: 'I will check the weather. <tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>
       Then check LA weather. <tool_call>{"name": "get_weather", "arguments": {"location": "LA"}}</tool_call>'
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_8_d
+      dynamo: &id005
         calls:
         - name: get_weather
           arguments:
@@ -88,12 +86,11 @@ cases:
         normal_text: I will check the weather.
       vllm:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
-        - arguments:
+        - name: get_weather
+          arguments:
             location: LA
-          name: get_weather
         normal_text: 'I will check the weather. '
-        reason: "drops trailing normal_text after tool-call wrapper end"
-      sglang: *d_8_d
+      sglang: *id005

--- a/tests/parity/parser/fixtures/hermes/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/hermes/PARSER.batch.yaml
@@ -9,7 +9,7 @@ cases:
     description: Single tool call (happy path)
     model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>'
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
@@ -17,44 +17,44 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_1
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *d_1
-      sglang: *d_1
+      vllm: *id001
+      sglang: *id001
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_3
+      dynamo: &id003
         calls: []
         normal_text: Hello, how can I help you today?
-      vllm: *d_3
-      sglang: *d_3
+      vllm: *id003
+      sglang: *id003
   PARSER.batch.9:
     description: Empty input
     model_text: ''
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_9
+      dynamo: &id004
         calls: []
         normal_text: ''
-      vllm: *d_9
-      sglang: *d_9
+      vllm: *id004
+      sglang: *id004
   PARSER.batch.10:
     description: Duplicate calls (same name twice)
     model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name": "get_weather",
       "arguments": {"location": "LA"}}</tool_call>'
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_10
+      dynamo: &id005
         calls:
         - name: get_weather
           arguments:
@@ -63,5 +63,5 @@ cases:
           arguments:
             location: LA
         normal_text: ''
-      vllm: *d_10
-      sglang: *d_10
+      vllm: *id005
+      sglang: *id005

--- a/tests/parity/parser/fixtures/jamba/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/jamba/PARSER.batch.2.yaml
@@ -10,14 +10,14 @@ cases:
     model_text: '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_time", "arguments":
       {"timezone": "EST"}}]</tool_calls>'
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
         properties:
           location:
             type: string
-    - &id002
+    - &id003
       name: get_time
       parameters:
         type: object
@@ -25,7 +25,7 @@ cases:
           timezone:
             type: string
     expected:
-      dynamo: &d_2_a
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
@@ -34,7 +34,7 @@ cases:
           arguments:
             timezone: EST
         normal_text: ''
-      vllm: *d_2_a
+      vllm: *id001
       sglang:
         unavailable: SGLang has no detector for family='jamba'
   PARSER.batch.2.c:
@@ -43,8 +43,8 @@ cases:
     model_text: 'Both: <tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_time", "arguments":
       {"timezone": "EST"}}]</tool_calls> Done.'
     tools:
-    - *id001
     - *id002
+    - *id003
     expected:
       dynamo:
         calls:
@@ -57,14 +57,13 @@ cases:
         normal_text: 'Both:'
       vllm:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
-        - arguments:
+        - name: get_time
+          arguments:
             timezone: EST
-          name: get_time
         normal_text: 'Both: '
-        reason: "drops trailing normal_text after tool-call wrapper end"
       sglang:
         unavailable: SGLang has no detector for family='jamba'
   PARSER.batch.2.d:
@@ -73,10 +72,10 @@ cases:
     model_text: '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_weather", "arguments":
       {"location": "LA"}}]</tool_calls>'
     tools:
-    - *id001
-    - *id001
+    - *id002
+    - *id002
     expected:
-      dynamo: &d_2_d
+      dynamo: &id004
         calls:
         - name: get_weather
           arguments:
@@ -85,6 +84,6 @@ cases:
           arguments:
             location: LA
         normal_text: ''
-      vllm: *d_2_d
+      vllm: *id004
       sglang:
         unavailable: SGLang has no detector for family='jamba'

--- a/tests/parity/parser/fixtures/jamba/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/jamba/PARSER.batch.4.yaml
@@ -9,7 +9,7 @@ cases:
     ref: dynamo
     model_text: <tool_calls>not a json array</tool_calls>
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
@@ -17,10 +17,10 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_4_a
+      dynamo: &id001
         calls: []
         normal_text: <tool_calls>not a json array</tool_calls>
-      vllm: *d_4_a
+      vllm: *id001
       sglang:
         unavailable: SGLang has no detector for family='jamba'
   PARSER.batch.4.b:
@@ -28,12 +28,12 @@ cases:
     ref: dynamo
     model_text: '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"]</tool_calls>'
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_4_b
+      dynamo: &id003
         calls: []
         normal_text: '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"]</tool_calls>'
-      vllm: *d_4_b
+      vllm: *id003
       sglang:
         unavailable: SGLang has no detector for family='jamba'
   PARSER.batch.4.c:
@@ -41,7 +41,7 @@ cases:
     ref: dynamo
     model_text: '<tool_calls>[{"arguments": {"location": "NYC"}}]</tool_calls>'
     tools:
-    - *id001
+    - *id002
     expected:
       dynamo:
         calls: []
@@ -49,7 +49,6 @@ cases:
       vllm:
         calls: []
         normal_text: '<tool_calls>[{"arguments": {"location": "NYC"}}]</tool_calls>'
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
       sglang:
         unavailable: SGLang has no detector for family='jamba'
   PARSER.batch.4.d:
@@ -57,7 +56,7 @@ cases:
     ref: dynamo
     model_text: '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}]'
     tools:
-    - *id001
+    - *id002
     expected:
       dynamo:
         calls:
@@ -68,6 +67,5 @@ cases:
       vllm:
         calls: []
         normal_text: '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}]'
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
       sglang:
         unavailable: SGLang has no detector for family='jamba'

--- a/tests/parity/parser/fixtures/jamba/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/jamba/PARSER.batch.5.yaml
@@ -26,7 +26,6 @@ cases:
       vllm:
         calls: []
         normal_text: '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}]'
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
       sglang:
         unavailable: SGLang has no detector for family='jamba'
   PARSER.batch.5.b:
@@ -36,10 +35,10 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &d_5_b
+      dynamo: &id002
         calls: []
         normal_text: '[{"name": "get_weather", "arguments": {"location": "NYC"}}]</tool_calls>'
-      vllm: *d_5_b
+      vllm: *id002
       sglang:
         unavailable: SGLang has no detector for family='jamba'
   PARSER.batch.5.c:
@@ -49,9 +48,55 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &d_5_c
+      dynamo: &id003
         calls: []
         normal_text: '<tool_calls>[{"name": "get_weather", "arguments": {"loc'
-      vllm: *d_5_c
+      vllm: *id003
+      sglang:
+        unavailable: SGLang has no detector for family='jamba'
+  PARSER.batch.5.d:
+    description: Multi-call, last call missing only end marker (body complete)
+    ref: dynamo
+    model_text: 'I''ll start by fetching the weather for both Boston and New York at the same time!<tool_calls>[{"name": "get_weather",
+      "arguments": {"location": "Boston"}}, {"name": "get_weather", "arguments": {"location": "New York"}}]'
+    tools:
+    - *id001
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        - name: get_weather
+          arguments:
+            location: New York
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
+      vllm:
+        calls: []
+        normal_text: 'I''ll start by fetching the weather for both Boston and New York at the same time!<tool_calls>[{"name":
+          "get_weather", "arguments": {"location": "Boston"}}, {"name": "get_weather", "arguments": {"location": "New York"}}]'
+      sglang:
+        unavailable: SGLang has no detector for family='jamba'
+  PARSER.batch.5.e:
+    description: Multi-call, last call truncated mid-arg-value
+    ref: dynamo
+    model_text: 'I''ll start by fetching the weather for both Boston and New York at the same time!<tool_calls>[{"name": "get_weather",
+      "arguments": {"location": "Boston"}}, {"name": "get_weather", "arguments": {"location": "New York'
+    tools:
+    - *id001
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        - name: get_weather
+          arguments:
+            location: New York
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
+      vllm:
+        calls: []
+        normal_text: 'I''ll start by fetching the weather for both Boston and New York at the same time!<tool_calls>[{"name":
+          "get_weather", "arguments": {"location": "Boston"}}, {"name": "get_weather", "arguments": {"location": "New York'
       sglang:
         unavailable: SGLang has no detector for family='jamba'

--- a/tests/parity/parser/fixtures/jamba/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/jamba/PARSER.batch.6.yaml
@@ -9,18 +9,18 @@ cases:
     ref: dynamo
     model_text: '<tool_calls>[{"name": "get_time", "arguments": {}}]</tool_calls>'
     tools:
-    - &id001
+    - &id002
       name: get_time
       parameters:
         type: object
         properties: {}
     expected:
-      dynamo: &d_6_a
+      dynamo: &id001
         calls:
         - name: get_time
           arguments: {}
         normal_text: ''
-      vllm: *d_6_a
+      vllm: *id001
       sglang:
         unavailable: SGLang has no detector for family='jamba'
   PARSER.batch.6.b:
@@ -28,14 +28,14 @@ cases:
     ref: dynamo
     model_text: '<tool_calls>[{"name": "get_time", "arguments": { }}]</tool_calls>'
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_6_b
+      dynamo: &id003
         calls:
         - name: get_time
           arguments: {}
         normal_text: ''
-      vllm: *d_6_b
+      vllm: *id003
       sglang:
         unavailable: SGLang has no detector for family='jamba'
   PARSER.batch.6.c:
@@ -43,7 +43,7 @@ cases:
     ref: dynamo
     model_text: '<tool_calls>[{"name": "get_time"}]</tool_calls>'
     tools:
-    - *id001
+    - *id002
     expected:
       dynamo:
         calls: []
@@ -51,6 +51,5 @@ cases:
       vllm:
         calls: []
         normal_text: '<tool_calls>[{"name": "get_time"}]</tool_calls>'
-        reason: "both return calls=[]; vLLM preserves raw input as normal_text on this recovery path, Dynamo emits empty"
       sglang:
         unavailable: SGLang has no detector for family='jamba'

--- a/tests/parity/parser/fixtures/jamba/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/jamba/PARSER.batch.7.yaml
@@ -21,7 +21,7 @@ cases:
           first_class:
             type: boolean
     expected:
-      dynamo: &d_7_a
+      dynamo: &id001
         calls:
         - name: book_flight
           arguments:
@@ -29,7 +29,7 @@ cases:
             destination: Paris
             passengers: 2
         normal_text: ''
-      vllm: *d_7_a
+      vllm: *id001
       sglang:
         unavailable: SGLang has no detector for family='jamba'
   PARSER.batch.7.b:
@@ -44,13 +44,13 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_7_b
+      dynamo: &id002
         calls:
         - name: get_weather
           arguments:
             location: Tōkyō "central"
         normal_text: ''
-      vllm: *d_7_b
+      vllm: *id002
       sglang:
         unavailable: SGLang has no detector for family='jamba'
   PARSER.batch.7.c:
@@ -65,13 +65,13 @@ cases:
           celsius:
             type: integer
     expected:
-      dynamo: &d_7_c
+      dynamo: &id003
         calls:
         - name: set_temperature
           arguments:
             celsius: '20'
         normal_text: ''
-      vllm: *d_7_c
+      vllm: *id003
       sglang:
         unavailable: SGLang has no detector for family='jamba'
   PARSER.batch.7.d:
@@ -88,7 +88,7 @@ cases:
           config:
             type: object
     expected:
-      dynamo: &d_7_d
+      dynamo: &id004
         calls:
         - name: process_data
           arguments:
@@ -99,6 +99,6 @@ cases:
             config:
               nested: true
         normal_text: ''
-      vllm: *d_7_d
+      vllm: *id004
       sglang:
         unavailable: SGLang has no detector for family='jamba'

--- a/tests/parity/parser/fixtures/jamba/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/jamba/PARSER.batch.8.yaml
@@ -25,11 +25,10 @@ cases:
         normal_text: I will check the weather.
       vllm:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
         normal_text: 'I will check the weather. '
-        reason: "drops trailing normal_text after tool-call wrapper end"
       sglang:
         unavailable: SGLang has no detector for family='jamba'
   PARSER.batch.8.b:
@@ -40,13 +39,13 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &d_8_b
+      dynamo: &id002
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *d_8_b
+      vllm: *id002
       sglang:
         unavailable: SGLang has no detector for family='jamba'
   PARSER.batch.8.c:
@@ -65,11 +64,10 @@ cases:
         normal_text: I will check the weather.
       vllm:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
         normal_text: 'I will check the weather. '
-        reason: "drops trailing normal_text after tool-call wrapper end"
       sglang:
         unavailable: SGLang has no detector for family='jamba'
   PARSER.batch.8.d:
@@ -85,10 +83,9 @@ cases:
         normal_text: I will check the weather.
       vllm:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
         normal_text: 'I will check the weather. '
-        reason: "drops trailing normal_text after tool-call wrapper end"
       sglang:
         unavailable: SGLang has no detector for family='jamba'

--- a/tests/parity/parser/fixtures/jamba/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/jamba/PARSER.batch.yaml
@@ -9,7 +9,7 @@ cases:
     description: Single tool call (happy path)
     model_text: '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}]</tool_calls>'
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
@@ -17,37 +17,37 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_1
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *d_1
+      vllm: *id001
       sglang:
         unavailable: SGLang has no detector for family='jamba'
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_3
+      dynamo: &id003
         calls: []
         normal_text: Hello, how can I help you today?
-      vllm: *d_3
+      vllm: *id003
       sglang:
         unavailable: SGLang has no detector for family='jamba'
   PARSER.batch.9:
     description: Empty input
     model_text: ''
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_9
+      dynamo: &id004
         calls: []
         normal_text: ''
-      vllm: *d_9
+      vllm: *id004
       sglang:
         unavailable: SGLang has no detector for family='jamba'
   PARSER.batch.10:
@@ -55,9 +55,9 @@ cases:
     model_text: '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_weather", "arguments":
       {"location": "LA"}}]</tool_calls>'
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_10
+      dynamo: &id005
         calls:
         - name: get_weather
           arguments:
@@ -66,6 +66,6 @@ cases:
           arguments:
             location: LA
         normal_text: ''
-      vllm: *d_10
+      vllm: *id005
       sglang:
         unavailable: SGLang has no detector for family='jamba'

--- a/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.2.yaml
@@ -9,14 +9,14 @@ cases:
     ref: dynamo
     model_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_call_begin|>functions.get_time:1<|tool_call_argument_begin|>{"timezone":"EST"}<|tool_call_end|><|tool_calls_section_end|>
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
         properties:
           location:
             type: string
-    - &id002
+    - &id003
       name: get_time
       parameters:
         type: object
@@ -24,7 +24,7 @@ cases:
           timezone:
             type: string
     expected:
-      dynamo: &d_2_a
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
@@ -33,17 +33,17 @@ cases:
           arguments:
             timezone: EST
         normal_text: ''
-      vllm: *d_2_a
-      sglang: *d_2_a
+      vllm: *id001
+      sglang: *id001
   PARSER.batch.2.b:
     description: Two back-to-back sections (each with one call)
     ref: dynamo
     model_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|><|tool_calls_section_begin|><|tool_call_begin|>functions.get_time:1<|tool_call_argument_begin|>{"timezone":"EST"}<|tool_call_end|><|tool_calls_section_end|>
     tools:
-    - *id001
     - *id002
+    - *id003
     expected:
-      dynamo: &d_2_b
+      dynamo: &id004
         calls:
         - name: get_weather
           arguments:
@@ -52,16 +52,16 @@ cases:
           arguments:
             timezone: EST
         normal_text: ''
-      vllm: *d_2_b
-      sglang: *d_2_b
+      vllm: *id004
+      sglang: *id004
   PARSER.batch.2.c:
     description: Parallel calls with surrounding narration
     ref: dynamo
     model_text: I will check both. <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_call_begin|>functions.get_time:1<|tool_call_argument_begin|>{"timezone":"EST"}<|tool_call_end|><|tool_calls_section_end|>
       Done.
     tools:
-    - *id001
     - *id002
+    - *id003
     expected:
       dynamo:
         calls:
@@ -74,33 +74,31 @@ cases:
         normal_text: I will check both.  Done.
       vllm:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
-        - arguments:
+        - name: get_time
+          arguments:
             timezone: EST
-          name: get_time
         normal_text: 'I will check both. '
-        reason: "drops trailing normal_text after tool-call wrapper end"
       sglang:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
-        - arguments:
+        - name: get_time
+          arguments:
             timezone: EST
-          name: get_time
         normal_text: 'I will check both. '
-        reason: "trims trailing space from preceding normal_text"
   PARSER.batch.2.d:
     description: Same-name twice (id distinctness)
     ref: dynamo
     model_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_call_begin|>functions.get_weather:1<|tool_call_argument_begin|>{"location":"LA"}<|tool_call_end|><|tool_calls_section_end|>
     tools:
-    - *id001
-    - *id001
+    - *id002
+    - *id002
     expected:
-      dynamo: &d_2_d
+      dynamo: &id005
         calls:
         - name: get_weather
           arguments:
@@ -109,5 +107,5 @@ cases:
           arguments:
             location: LA
         normal_text: ''
-      vllm: *d_2_d
-      sglang: *d_2_d
+      vllm: *id005
+      sglang: *id005

--- a/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.4.yaml
@@ -9,7 +9,7 @@ cases:
     ref: dynamo
     model_text: <|tool_calls_section_begin|>nonsense<|tool_calls_section_end|>
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
@@ -17,24 +17,24 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_4_a
+      dynamo: &id001
         calls: []
         normal_text: ''
-      vllm: *d_4_a
-      sglang: *d_4_a
+      vllm: *id001
+      sglang: *id001
   PARSER.batch.4.b:
     description: Invalid JSON args (missing close brace)
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_kimi_k2_tool_parser.py#L151
     model_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"<|tool_call_end|><|tool_calls_section_end|>
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_4_b
+      dynamo: &id003
         calls:
         - name: get_weather
           arguments: '{"location":"NYC"'
         normal_text: ''
-      vllm: *d_4_b
+      vllm: *id003
       sglang:
         calls: []
         normal_text: ''
@@ -43,22 +43,22 @@ cases:
     ref: dynamo
     model_text: <|tool_calls_section_begin|><|tool_call_begin|><|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_4_c
+      dynamo: &id004
         calls: []
         normal_text: ''
-      vllm: *d_4_c
-      sglang: *d_4_c
+      vllm: *id004
+      sglang: *id004
   PARSER.batch.4.d:
     description: Mismatched fences (call_end before call_begin closes)
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_kimi_k2_tool_parser.py#L165
     model_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_calls_section_end|>
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_4_d
+      dynamo: &id005
         calls: []
         normal_text: ''
-      vllm: *d_4_d
-      sglang: *d_4_d
+      vllm: *id005
+      sglang: *id005

--- a/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.5.yaml
@@ -9,7 +9,7 @@ cases:
     ref: dynamo
     model_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|>
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
@@ -17,35 +17,67 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_5_a
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *d_5_a
-      sglang: *d_5_a
+      vllm: *id001
+      sglang: *id001
   PARSER.batch.5.b:
     description: Closing section_end without matching section_begin
     ref: dynamo
     model_text: <|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_5_b
+      dynamo: &id003
         calls: []
         normal_text: <|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>
-      vllm: *d_5_b
-      sglang: *d_5_b
+      vllm: *id003
+      sglang: *id003
   PARSER.batch.5.c:
     description: Truncation mid-arguments (incomplete JSON body)
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_kimi_k2_tool_parser.py#L413
     model_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"loc
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_5_c
+      dynamo: &id004
         calls: []
         normal_text: ''
-      vllm: *d_5_c
-      sglang: *d_5_c
+      vllm: *id004
+      sglang: *id004
+  PARSER.batch.5.d:
+    description: Multi-call, last call missing only end marker (body complete)
+    ref: dynamo
+    model_text: I'll start by fetching the weather for both Boston and New York at the same time!<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"Boston"}<|tool_call_end|><|tool_call_begin|>functions.get_weather:1<|tool_call_argument_begin|>{"location":"New
+      York"}
+    tools:
+    - *id002
+    expected:
+      dynamo: &id005
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
+      vllm: *id005
+      sglang: *id005
+  PARSER.batch.5.e:
+    description: Multi-call, last call truncated mid-arg-value
+    ref: dynamo
+    model_text: I'll start by fetching the weather for both Boston and New York at the same time!<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"Boston"}<|tool_call_end|><|tool_call_begin|>functions.get_weather:1<|tool_call_argument_begin|>{"location":"New
+      York
+    tools:
+    - *id002
+    expected:
+      dynamo: &id006
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
+      vllm: *id006
+      sglang: *id006

--- a/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.6.yaml
@@ -9,42 +9,42 @@ cases:
     ref: dynamo
     model_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.get_time:0<|tool_call_argument_begin|>{}<|tool_call_end|><|tool_calls_section_end|>
     tools:
-    - &id001
+    - &id002
       name: get_time
       parameters:
         type: object
         properties: {}
     expected:
-      dynamo: &d_6_a
+      dynamo: &id001
         calls:
         - name: get_time
           arguments: {}
         normal_text: ''
-      vllm: *d_6_a
-      sglang: *d_6_a
+      vllm: *id001
+      sglang: *id001
   PARSER.batch.6.b:
     description: Whitespace inside empty {}
     ref: dynamo
     model_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.get_time:0<|tool_call_argument_begin|>{ }<|tool_call_end|><|tool_calls_section_end|>
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_6_b
+      dynamo: &id003
         calls:
         - name: get_time
           arguments: {}
         normal_text: ''
-      vllm: *d_6_b
-      sglang: *d_6_b
+      vllm: *id003
+      sglang: *id003
   PARSER.batch.6.c:
     description: No argument body (skip argument_begin → end)
     ref: dynamo
     model_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.get_time:0<|tool_call_end|><|tool_calls_section_end|>
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_6_c
+      dynamo: &id004
         calls: []
         normal_text: ''
-      vllm: *d_6_c
-      sglang: *d_6_c
+      vllm: *id004
+      sglang: *id004

--- a/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.7.yaml
@@ -20,7 +20,7 @@ cases:
           first_class:
             type: boolean
     expected:
-      dynamo: &d_7_a
+      dynamo: &id001
         calls:
         - name: book_flight
           arguments:
@@ -28,8 +28,8 @@ cases:
             passengers: 2
             first_class: true
         normal_text: ''
-      vllm: *d_7_a
-      sglang: *d_7_a
+      vllm: *id001
+      sglang: *id001
   PARSER.batch.7.b:
     description: Unicode + escaped chars in string value
     ref: dynamo
@@ -43,14 +43,14 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_7_b
+      dynamo: &id002
         calls:
         - name: get_weather
           arguments:
             location: Tōkyō "central"
         normal_text: ''
-      vllm: *d_7_b
-      sglang: *d_7_b
+      vllm: *id002
+      sglang: *id002
   PARSER.batch.7.c:
     description: Schema mismatch — string value where schema declares integer
     ref: dynamo
@@ -63,14 +63,14 @@ cases:
           celsius:
             type: integer
     expected:
-      dynamo: &d_7_c
+      dynamo: &id003
         calls:
         - name: set_temperature
           arguments:
             celsius: '20'
         normal_text: ''
-      vllm: *d_7_c
-      sglang: *d_7_c
+      vllm: *id003
+      sglang: *id003
   PARSER.batch.7.d:
     description: Nested object + array (existing shape)
     ref: dynamo
@@ -85,7 +85,7 @@ cases:
           config:
             type: object
     expected:
-      dynamo: &d_7_d
+      dynamo: &id004
         calls:
         - name: process_data
           arguments:
@@ -96,5 +96,5 @@ cases:
             config:
               nested: true
         normal_text: ''
-      vllm: *d_7_d
-      sglang: *d_7_d
+      vllm: *id004
+      sglang: *id004

--- a/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.8.yaml
@@ -25,16 +25,15 @@ cases:
         normal_text: I'll check the weather.
       vllm:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: Dallas
-          name: get_weather
         normal_text: 'I''ll check the weather. '
-        reason: "preserves trailing space; Dynamo trims it"
       sglang:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: Dallas
-          name: get_weather
         normal_text: 'I''ll check the weather. '
   PARSER.batch.8.b:
     description: Narration after tool call only
@@ -52,16 +51,15 @@ cases:
         normal_text: Let me know if you need more.
       vllm:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: Dallas
-          name: get_weather
         normal_text: ''
-        reason: "drops trailing normal_text after tool-call wrapper end"
       sglang:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: Dallas
-          name: get_weather
         normal_text: ''
   PARSER.batch.8.c:
     description: Narration both before and after (sandwich)
@@ -79,16 +77,15 @@ cases:
         normal_text: I'll check the weather.  Let me know if you need more.
       vllm:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: Dallas
-          name: get_weather
         normal_text: 'I''ll check the weather. '
-        reason: "drops trailing normal_text after tool-call wrapper end"
       sglang:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: Dallas
-          name: get_weather
         normal_text: 'I''ll check the weather. '
   PARSER.batch.8.d:
     description: Narration between multiple tool calls
@@ -109,20 +106,19 @@ cases:
         normal_text: First check Dallas.  Then check NYC.
       vllm:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: Dallas
-          name: get_weather
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
         normal_text: 'First check Dallas. '
-        reason: "drops trailing normal_text after tool-call wrapper end"
       sglang:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: Dallas
-          name: get_weather
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
         normal_text: 'First check Dallas. '

--- a/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.yaml
@@ -9,7 +9,7 @@ cases:
     description: Single tool call (happy path)
     model_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
@@ -17,43 +17,43 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_1
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *d_1
-      sglang: *d_1
+      vllm: *id001
+      sglang: *id001
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_3
+      dynamo: &id003
         calls: []
         normal_text: Hello, how can I help you today?
-      vllm: *d_3
-      sglang: *d_3
+      vllm: *id003
+      sglang: *id003
   PARSER.batch.9:
     description: Empty input
     model_text: ''
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_9
+      dynamo: &id004
         calls: []
         normal_text: ''
-      vllm: *d_9
-      sglang: *d_9
+      vllm: *id004
+      sglang: *id004
   PARSER.batch.10:
     description: Duplicate calls (same name twice)
     model_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_call_begin|>functions.get_weather:1<|tool_call_argument_begin|>{"location":"LA"}<|tool_call_end|><|tool_calls_section_end|>
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_10
+      dynamo: &id005
         calls:
         - name: get_weather
           arguments:
@@ -62,5 +62,5 @@ cases:
           arguments:
             location: LA
         normal_text: ''
-      vllm: *d_10
-      sglang: *d_10
+      vllm: *id005
+      sglang: *id005

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.batch.2.yaml
@@ -10,14 +10,14 @@ cases:
     model_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}};{"name": "get_time", "arguments":
       {"timezone": "EST"}}'
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
         properties:
           location:
             type: string
-    - &id002
+    - &id003
       name: get_time
       parameters:
         type: object
@@ -25,7 +25,7 @@ cases:
           timezone:
             type: string
     expected:
-      dynamo: &d_2a
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
@@ -34,7 +34,7 @@ cases:
           arguments:
             timezone: EST
         normal_text: ''
-      vllm: *d_2a
+      vllm: *id001
       sglang:
         unavailable: SGLang has no detector for family='llama3_json'
   PARSER.batch.2.c:
@@ -43,10 +43,10 @@ cases:
     model_text: 'Both: <|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}};{"name": "get_time", "arguments":
       {"timezone": "EST"}} Done.'
     tools:
-    - *id001
     - *id002
+    - *id003
     expected:
-      dynamo: &d_2c
+      dynamo:
         calls:
         - name: get_weather
           arguments:
@@ -64,7 +64,7 @@ cases:
           arguments:
             timezone: EST
         normal_text: ''
-        reason: "vLLM llama3_json drops leading normal_text before the python_tag token"
+        reason: vLLM llama3_json drops leading normal_text before the python_tag token
       sglang:
         unavailable: SGLang has no detector for family='llama3_json'
   PARSER.batch.2.d:
@@ -73,10 +73,10 @@ cases:
     model_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}};{"name": "get_weather", "arguments":
       {"location": "LA"}}'
     tools:
-    - *id001
-    - *id001
+    - *id002
+    - *id002
     expected:
-      dynamo: &d_2d
+      dynamo: &id004
         calls:
         - name: get_weather
           arguments:
@@ -85,6 +85,6 @@ cases:
           arguments:
             location: LA
         normal_text: ''
-      vllm: *d_2d
+      vllm: *id004
       sglang:
         unavailable: SGLang has no detector for family='llama3_json'

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.batch.4.yaml
@@ -23,7 +23,7 @@ cases:
       vllm:
         calls: []
         normal_text: <|python_tag|>not even json
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
+        reason: impl-defined recovery contract (see PARSER_CASES.md)
       sglang:
         unavailable: SGLang has no detector for family='llama3_json'
   PARSER.batch.4.b:
@@ -39,7 +39,7 @@ cases:
       vllm:
         calls: []
         normal_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"'
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
+        reason: impl-defined recovery contract (see PARSER_CASES.md)
       sglang:
         unavailable: SGLang has no detector for family='llama3_json'
   PARSER.batch.4.c:
@@ -55,6 +55,6 @@ cases:
       vllm:
         calls: []
         normal_text: '<|python_tag|>{"arguments": {"location": "NYC"}}'
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
+        reason: impl-defined recovery contract (see PARSER_CASES.md)
       sglang:
         unavailable: SGLang has no detector for family='llama3_json'

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.batch.4.yaml
@@ -23,7 +23,6 @@ cases:
       vllm:
         calls: []
         normal_text: <|python_tag|>not even json
-        reason: impl-defined recovery contract (see PARSER_CASES.md)
       sglang:
         unavailable: SGLang has no detector for family='llama3_json'
   PARSER.batch.4.b:
@@ -39,7 +38,6 @@ cases:
       vllm:
         calls: []
         normal_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"'
-        reason: impl-defined recovery contract (see PARSER_CASES.md)
       sglang:
         unavailable: SGLang has no detector for family='llama3_json'
   PARSER.batch.4.c:
@@ -55,6 +53,5 @@ cases:
       vllm:
         calls: []
         normal_text: '<|python_tag|>{"arguments": {"location": "NYC"}}'
-        reason: impl-defined recovery contract (see PARSER_CASES.md)
       sglang:
         unavailable: SGLang has no detector for family='llama3_json'

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.batch.5.yaml
@@ -23,7 +23,7 @@ cases:
       vllm:
         calls: []
         normal_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}'
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
+        reason: impl-defined recovery contract (see PARSER_CASES.md)
       sglang:
         unavailable: SGLang has no detector for family='llama3_json'
   PARSER.batch.5.c:
@@ -39,6 +39,38 @@ cases:
       vllm:
         calls: []
         normal_text: '<|python_tag|>{"name": "get_weather", "arguments": {"loc'
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
+        reason: impl-defined recovery contract (see PARSER_CASES.md)
       sglang:
         unavailable: SGLang has no detector for family='llama3_json'
+  PARSER.batch.5.d:
+    description: Multi-call, last call missing only end marker (body complete)
+    ref: dynamo
+    model_text: 'I''ll start by fetching the weather for both Boston and New York at the same time!<|python_tag|>{"name":
+      "get_weather", "arguments": {"location": "Boston"}};{"name": "get_weather", "arguments": {"location": "New York"}'
+    tools:
+    - *id001
+    expected:
+      dynamo:
+        calls: []
+        normal_text: ''
+      sglang:
+        unavailable: SGLang has no detector for family='llama3_json'
+      vllm: &id002
+        error: 'AttributeError: ''_StubTokenizer'' object has no attribute ''encode'''
+  PARSER.batch.5.e:
+    description: Multi-call, last call truncated mid-arg-value
+    ref: dynamo
+    model_text: 'I''ll start by fetching the weather for both Boston and New York at the same time!<|python_tag|>{"name":
+      "get_weather", "arguments": {"location": "Boston"}};{"name": "get_weather", "arguments": {"location": "New York'
+    tools:
+    - *id001
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
+      sglang:
+        unavailable: SGLang has no detector for family='llama3_json'
+      vllm: *id002

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.batch.5.yaml
@@ -23,7 +23,6 @@ cases:
       vllm:
         calls: []
         normal_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}'
-        reason: impl-defined recovery contract (see PARSER_CASES.md)
       sglang:
         unavailable: SGLang has no detector for family='llama3_json'
   PARSER.batch.5.c:
@@ -39,7 +38,6 @@ cases:
       vllm:
         calls: []
         normal_text: '<|python_tag|>{"name": "get_weather", "arguments": {"loc'
-        reason: impl-defined recovery contract (see PARSER_CASES.md)
       sglang:
         unavailable: SGLang has no detector for family='llama3_json'
   PARSER.batch.5.d:
@@ -55,8 +53,10 @@ cases:
         normal_text: ''
       sglang:
         unavailable: SGLang has no detector for family='llama3_json'
-      vllm: &id002
-        error: 'AttributeError: ''_StubTokenizer'' object has no attribute ''encode'''
+      vllm:
+        calls: []
+        normal_text: 'I''ll start by fetching the weather for both Boston and New York at the same time!<|python_tag|>{"name":
+          "get_weather", "arguments": {"location": "Boston"}};{"name": "get_weather", "arguments": {"location": "New York"}'
   PARSER.batch.5.e:
     description: Multi-call, last call truncated mid-arg-value
     ref: dynamo
@@ -73,4 +73,7 @@ cases:
         normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
       sglang:
         unavailable: SGLang has no detector for family='llama3_json'
-      vllm: *id002
+      vllm:
+        calls: []
+        normal_text: 'I''ll start by fetching the weather for both Boston and New York at the same time!<|python_tag|>{"name":
+          "get_weather", "arguments": {"location": "Boston"}};{"name": "get_weather", "arguments": {"location": "New York'

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.batch.5.yaml
@@ -49,8 +49,11 @@ cases:
     - *id001
     expected:
       dynamo:
-        calls: []
-        normal_text: ''
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
       sglang:
         unavailable: SGLang has no detector for family='llama3_json'
       vllm:

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.batch.6.yaml
@@ -9,18 +9,18 @@ cases:
     ref: dynamo
     model_text: '<|python_tag|>{"name": "get_time", "arguments": {}}'
     tools:
-    - &id001
+    - &id002
       name: get_time
       parameters:
         type: object
         properties: {}
     expected:
-      dynamo: &d_6_a
+      dynamo: &id001
         calls:
         - name: get_time
           arguments: {}
         normal_text: ''
-      vllm: *d_6_a
+      vllm: *id001
       sglang:
         unavailable: SGLang has no detector for family='llama3_json'
   PARSER.batch.6.b:
@@ -28,14 +28,14 @@ cases:
     ref: dynamo
     model_text: '<|python_tag|>{"name": "get_time", "arguments": { }}'
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_6_b
+      dynamo: &id003
         calls:
         - name: get_time
           arguments: {}
         normal_text: ''
-      vllm: *d_6_b
+      vllm: *id003
       sglang:
         unavailable: SGLang has no detector for family='llama3_json'
   PARSER.batch.6.c:
@@ -43,7 +43,7 @@ cases:
     ref: dynamo
     model_text: '<|python_tag|>{"name": "get_time"}'
     tools:
-    - *id001
+    - *id002
     expected:
       dynamo:
         calls: []
@@ -51,6 +51,6 @@ cases:
       vllm:
         calls: []
         normal_text: '<|python_tag|>{"name": "get_time"}'
-        reason: "both return calls=[]; vLLM preserves raw input as normal_text on this recovery path, Dynamo emits empty"
+        reason: both return calls=[]; vLLM preserves raw input as normal_text on this recovery path, Dynamo emits empty
       sglang:
         unavailable: SGLang has no detector for family='llama3_json'

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.batch.6.yaml
@@ -51,6 +51,5 @@ cases:
       vllm:
         calls: []
         normal_text: '<|python_tag|>{"name": "get_time"}'
-        reason: both return calls=[]; vLLM preserves raw input as normal_text on this recovery path, Dynamo emits empty
       sglang:
         unavailable: SGLang has no detector for family='llama3_json'

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.batch.7.yaml
@@ -21,7 +21,7 @@ cases:
           first_class:
             type: boolean
     expected:
-      dynamo: &d_7_a
+      dynamo: &id001
         calls:
         - name: book_flight
           arguments:
@@ -29,7 +29,7 @@ cases:
             first_class: true
             passengers: 2
         normal_text: ''
-      vllm: *d_7_a
+      vllm: *id001
       sglang:
         unavailable: SGLang has no detector for family='llama3_json'
   PARSER.batch.7.b:
@@ -44,13 +44,13 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_7_b
+      dynamo: &id002
         calls:
         - name: get_weather
           arguments:
             location: Tōkyō "central"
         normal_text: ''
-      vllm: *d_7_b
+      vllm: *id002
       sglang:
         unavailable: SGLang has no detector for family='llama3_json'
   PARSER.batch.7.c:
@@ -65,13 +65,13 @@ cases:
           celsius:
             type: integer
     expected:
-      dynamo: &d_7_c
+      dynamo: &id003
         calls:
         - name: set_temperature
           arguments:
             celsius: '20'
         normal_text: ''
-      vllm: *d_7_c
+      vllm: *id003
       sglang:
         unavailable: SGLang has no detector for family='llama3_json'
   PARSER.batch.7.d:
@@ -88,7 +88,7 @@ cases:
           config:
             type: object
     expected:
-      dynamo: &d_7_d
+      dynamo: &id004
         calls:
         - name: process_data
           arguments:
@@ -99,6 +99,6 @@ cases:
             - 2
             - 3
         normal_text: ''
-      vllm: *d_7_d
+      vllm: *id004
       sglang:
         unavailable: SGLang has no detector for family='llama3_json'

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.batch.8.yaml
@@ -38,13 +38,13 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &d_8_b
+      dynamo: &id002
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *d_8_b
+      vllm: *id002
       sglang:
         unavailable: SGLang has no detector for family='llama3_json'
   PARSER.batch.8.c:

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.batch.8.yaml
@@ -25,9 +25,9 @@ cases:
         normal_text: I will check the weather.
       vllm:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
         normal_text: ''
       sglang:
         unavailable: SGLang has no detector for family='llama3_json'
@@ -63,9 +63,9 @@ cases:
         normal_text: I will check the weather.
       vllm:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
         normal_text: ''
       sglang:
         unavailable: SGLang has no detector for family='llama3_json'
@@ -88,12 +88,12 @@ cases:
         normal_text: I will check the weather.
       vllm:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
-        - arguments:
+        - name: get_weather
+          arguments:
             location: LA
-          name: get_weather
         normal_text: ''
       sglang:
         unavailable: SGLang has no detector for family='llama3_json'

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.batch.yaml
@@ -9,7 +9,7 @@ cases:
     description: Single tool call (happy path)
     model_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}}'
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
@@ -17,13 +17,13 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_1
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *d_1
+      vllm: *id001
       sglang:
         unavailable: SGLang has no detector for family='llama3_json'
   PARSER.batch.2:
@@ -31,16 +31,15 @@ cases:
     model_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}};{"name": "get_time", "arguments":
       {"timezone": "EST"}}'
     tools:
-    - *id001
-    - &id002
-      name: get_time
+    - *id002
+    - name: get_time
       parameters:
         type: object
         properties:
           timezone:
             type: string
     expected:
-      dynamo: &d_2
+      dynamo: &id003
         calls:
         - name: get_weather
           arguments:
@@ -49,31 +48,31 @@ cases:
           arguments:
             timezone: EST
         normal_text: ''
-      vllm: *d_2
+      vllm: *id003
       sglang:
         unavailable: SGLang has no detector for family='llama3_json'
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_3
+      dynamo: &id004
         calls: []
         normal_text: Hello, how can I help you today?
-      vllm: *d_3
+      vllm: *id004
       sglang:
         unavailable: SGLang has no detector for family='llama3_json'
   PARSER.batch.9:
     description: Empty input
     model_text: ''
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_9
+      dynamo: &id005
         calls: []
         normal_text: ''
-      vllm: *d_9
+      vllm: *id005
       sglang:
         unavailable: SGLang has no detector for family='llama3_json'
   PARSER.batch.10:
@@ -81,9 +80,9 @@ cases:
     model_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}};{"name": "get_weather", "arguments":
       {"location": "LA"}}'
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_10
+      dynamo: &id006
         calls:
         - name: get_weather
           arguments:
@@ -92,7 +91,7 @@ cases:
           arguments:
             location: LA
         normal_text: ''
-      vllm: *d_10
+      vllm: *id006
       sglang:
         unavailable: SGLang has no detector for family='llama3_json'
   PARSER.batch.11:
@@ -106,18 +105,19 @@ cases:
           sql:
             type: string
     expected:
-      dynamo: &d_11
+      dynamo: &id007
         calls:
         - name: run_query
           arguments:
             sql: SELECT a; SELECT b
         normal_text: ''
-      vllm: *d_11
+      vllm: *id007
       sglang:
         unavailable: SGLang has no detector for family='llama3_json'
   PARSER.batch.12:
     description: Parallel calls where one argument contains a semicolon (streaming split safety)
-    model_text: '<|python_tag|>{"name": "run_query", "arguments": {"sql": "SELECT a; SELECT b"}};{"name": "get_time", "arguments": {"timezone": "EST"}}'
+    model_text: '<|python_tag|>{"name": "run_query", "arguments": {"sql": "SELECT a; SELECT b"}};{"name": "get_time", "arguments":
+      {"timezone": "EST"}}'
     tools:
     - name: run_query
       parameters:
@@ -125,15 +125,14 @@ cases:
         properties:
           sql:
             type: string
-    - &id_time
-      name: get_time
+    - name: get_time
       parameters:
         type: object
         properties:
           timezone:
             type: string
     expected:
-      dynamo: &d_12
+      dynamo: &id008
         calls:
         - name: run_query
           arguments:
@@ -142,6 +141,6 @@ cases:
           arguments:
             timezone: EST
         normal_text: ''
-      vllm: *d_12
+      vllm: *id008
       sglang:
         unavailable: SGLang has no detector for family='llama3_json'

--- a/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.2.yaml
@@ -1,5 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# `|2+` simply means a single newline ("\n"); see tests/parity/README.md for the full decode.
 
 family: minimax_m2
 mode: batch
@@ -17,14 +19,14 @@ cases:
       </invoke>
       </minimax:tool_call>
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
         properties:
           location:
             type: string
-    - &id002
+    - &id003
       name: get_time
       parameters:
         type: object
@@ -32,7 +34,7 @@ cases:
           timezone:
             type: string
     expected:
-      dynamo: &d_2_a
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
@@ -41,8 +43,8 @@ cases:
           arguments:
             timezone: EST
         normal_text: ''
-      vllm: *d_2_a
-      sglang: *d_2_a
+      vllm: *id001
+      sglang: *id001
   PARSER.batch.2.b:
     description: Two back-to-back tool_call wrappers
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_minimax_m2_tool_parser.py#L207
@@ -58,10 +60,10 @@ cases:
       </invoke>
       </minimax:tool_call>
     tools:
-    - *id001
     - *id002
+    - *id003
     expected:
-      dynamo: &d_2_b
+      dynamo: &id004
         calls:
         - name: get_weather
           arguments:
@@ -70,18 +72,17 @@ cases:
           arguments:
             timezone: EST
         normal_text: ''
-      vllm: *d_2_b
+      vllm: *id004
       sglang:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
-        - arguments:
+        - name: get_time
+          arguments:
             timezone: EST
-          name: get_time
-        normal_text: '
+        normal_text: |2+
 
-          '
   PARSER.batch.2.c:
     description: Parallel with surrounding narration
     ref: dynamo
@@ -95,10 +96,10 @@ cases:
       </invoke>
       </minimax:tool_call> Done.
     tools:
-    - *id001
     - *id002
+    - *id003
     expected:
-      dynamo: &d_2_c
+      dynamo: &id005
         calls:
         - name: get_weather
           arguments:
@@ -107,17 +108,16 @@ cases:
           arguments:
             timezone: EST
         normal_text: 'Both: '
-      vllm: *d_2_c
+      vllm: *id005
       sglang:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
-        - arguments:
+        - name: get_time
+          arguments:
             timezone: EST
-          name: get_time
         normal_text: 'Both:  Done.'
-        reason: "trims trailing space from preceding normal_text"
   PARSER.batch.2.d:
     description: Same-name twice
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_minimax_m2_tool_parser.py#L331
@@ -131,10 +131,10 @@ cases:
       </invoke>
       </minimax:tool_call>
     tools:
-    - *id001
-    - *id001
+    - *id002
+    - *id002
     expected:
-      dynamo: &d_2_d
+      dynamo: &id006
         calls:
         - name: get_weather
           arguments:
@@ -143,5 +143,5 @@ cases:
           arguments:
             location: LA
         normal_text: ''
-      vllm: *d_2_d
-      sglang: *d_2_d
+      vllm: *id006
+      sglang: *id006

--- a/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.5.yaml
@@ -94,3 +94,94 @@ cases:
           <invoke name="get_weather">
           <parameter name="location">NY
         reason: sglang nullifies normal_text on malformed/recovery shapes where Dynamo preserves input
+  PARSER.batch.5.d:
+    description: Multi-call, last call missing only end marker (body complete)
+    ref: dynamo
+    model_text: |-
+      I'll start by fetching the weather for both Boston and New York at the same time!
+      <minimax:tool_call>
+      <invoke name="get_weather">
+      <parameter name="location">Boston</parameter>
+      </invoke>
+      <invoke name="get_weather">
+      <parameter name="location">New York</parameter>
+      </invoke>
+    tools:
+    - *id001
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        - name: get_weather
+          arguments:
+            location: New York
+        normal_text: |
+          I'll start by fetching the weather for both Boston and New York at the same time!
+      vllm:
+        calls: []
+        normal_text: |-
+          I'll start by fetching the weather for both Boston and New York at the same time!
+          <minimax:tool_call>
+          <invoke name="get_weather">
+          <parameter name="location">Boston</parameter>
+          </invoke>
+          <invoke name="get_weather">
+          <parameter name="location">New York</parameter>
+          </invoke>
+      sglang:
+        calls: []
+        normal_text: |-
+          I'll start by fetching the weather for both Boston and New York at the same time!
+          <minimax:tool_call>
+          <invoke name="get_weather">
+          <parameter name="location">Boston</parameter>
+          </invoke>
+          <invoke name="get_weather">
+          <parameter name="location">New York</parameter>
+          </invoke>
+  PARSER.batch.5.e:
+    description: Multi-call, last call truncated mid-arg-value
+    ref: dynamo
+    model_text: |-
+      I'll start by fetching the weather for both Boston and New York at the same time!
+      <minimax:tool_call>
+      <invoke name="get_weather">
+      <parameter name="location">Boston</parameter>
+      </invoke>
+      <invoke name="get_weather">
+      <parameter name="location">New York
+    tools:
+    - *id001
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        - name: get_weather
+          arguments:
+            location: New York
+        normal_text: |
+          I'll start by fetching the weather for both Boston and New York at the same time!
+      vllm:
+        calls: []
+        normal_text: |-
+          I'll start by fetching the weather for both Boston and New York at the same time!
+          <minimax:tool_call>
+          <invoke name="get_weather">
+          <parameter name="location">Boston</parameter>
+          </invoke>
+          <invoke name="get_weather">
+          <parameter name="location">New York
+      sglang:
+        calls: []
+        normal_text: |-
+          I'll start by fetching the weather for both Boston and New York at the same time!
+          <minimax:tool_call>
+          <invoke name="get_weather">
+          <parameter name="location">Boston</parameter>
+          </invoke>
+          <invoke name="get_weather">
+          <parameter name="location">New York

--- a/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.5.yaml
@@ -110,15 +110,16 @@ cases:
     - *id001
     expected:
       dynamo:
-        calls:
-        - name: get_weather
-          arguments:
-            location: Boston
-        - name: get_weather
-          arguments:
-            location: New York
-        normal_text: |
+        calls: []
+        normal_text: |-
           I'll start by fetching the weather for both Boston and New York at the same time!
+          <minimax:tool_call>
+          <invoke name="get_weather">
+          <parameter name="location">Boston</parameter>
+          </invoke>
+          <invoke name="get_weather">
+          <parameter name="location">New York</parameter>
+          </invoke>
       vllm:
         calls: []
         normal_text: |-
@@ -156,15 +157,15 @@ cases:
     - *id001
     expected:
       dynamo:
-        calls:
-        - name: get_weather
-          arguments:
-            location: Boston
-        - name: get_weather
-          arguments:
-            location: New York
-        normal_text: |
+        calls: []
+        normal_text: |-
           I'll start by fetching the weather for both Boston and New York at the same time!
+          <minimax:tool_call>
+          <invoke name="get_weather">
+          <parameter name="location">Boston</parameter>
+          </invoke>
+          <invoke name="get_weather">
+          <parameter name="location">New York
       vllm:
         calls: []
         normal_text: |-

--- a/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.6.yaml
@@ -13,19 +13,19 @@ cases:
       </invoke>
       </minimax:tool_call>
     tools:
-    - &id001
+    - &id002
       name: get_time
       parameters:
         type: object
         properties: {}
     expected:
-      dynamo: &d_6_a
+      dynamo: &id001
         calls:
         - name: get_time
           arguments: {}
         normal_text: ''
-      vllm: *d_6_a
-      sglang: *d_6_a
+      vllm: *id001
+      sglang: *id001
   PARSER.batch.6.b:
     description: Invoke with extra newline
     ref: dynamo
@@ -36,12 +36,12 @@ cases:
       </invoke>
       </minimax:tool_call>
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_6_b
+      dynamo: &id003
         calls:
         - name: get_time
           arguments: {}
         normal_text: ''
-      vllm: *d_6_b
-      sglang: *d_6_b
+      vllm: *id003
+      sglang: *id003

--- a/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.7.yaml
@@ -27,7 +27,7 @@ cases:
           first_class:
             type: boolean
     expected:
-      dynamo: &d_7_a
+      dynamo: &id001
         calls:
         - name: book_flight
           arguments:
@@ -35,8 +35,8 @@ cases:
             first_class: true
             passengers: 2
         normal_text: ''
-      vllm: *d_7_a
-      sglang: *d_7_a
+      vllm: *id001
+      sglang: *id001
   PARSER.batch.7.b:
     description: Unicode in parameter
     ref: dynamo
@@ -54,11 +54,11 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_7_b
+      dynamo: &id002
         calls:
         - name: get_weather
           arguments:
             location: Tōkyō central
         normal_text: ''
-      vllm: *d_7_b
-      sglang: *d_7_b
+      vllm: *id002
+      sglang: *id002

--- a/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.8.yaml
@@ -14,7 +14,7 @@ cases:
       </invoke>
       </minimax:tool_call>
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
@@ -22,14 +22,14 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_8_a
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: 'I will check the weather. '
-      vllm: *d_8_a
-      sglang: *d_8_a
+      vllm: *id001
+      sglang: *id001
   PARSER.batch.8.b:
     description: Narration after tool call only
     ref: dynamo
@@ -40,22 +40,21 @@ cases:
       </invoke>
       </minimax:tool_call> Let me know if you need more.
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_8_b
+      dynamo: &id003
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *d_8_b
+      vllm: *id003
       sglang:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
         normal_text: ' Let me know if you need more.'
-        reason: "sglang preserves trailing normal_text after wrapper end; Dynamo trims it (post-#9350)"
   PARSER.batch.8.c:
     description: Narration both before and after (sandwich)
     ref: dynamo
@@ -66,22 +65,21 @@ cases:
       </invoke>
       </minimax:tool_call> Let me know if you need more.
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_8_c
+      dynamo: &id004
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: 'I will check the weather. '
-      vllm: *d_8_c
+      vllm: *id004
       sglang:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
         normal_text: I will check the weather.  Let me know if you need more.
-        reason: "sglang preserves trailing normal_text after wrapper end; Dynamo trims it (post-#9350)"
   PARSER.batch.8.d:
     description: Narration between multiple tool calls
     ref: dynamo
@@ -96,9 +94,9 @@ cases:
       </invoke>
       </minimax:tool_call>
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_8_d
+      dynamo: &id005
         calls:
         - name: get_weather
           arguments:
@@ -107,14 +105,13 @@ cases:
           arguments:
             location: LA
         normal_text: 'I will check the weather. '
-      vllm: *d_8_d
+      vllm: *id005
       sglang:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
-        - arguments:
+        - name: get_weather
+          arguments:
             location: LA
-          name: get_weather
         normal_text: 'I will check the weather.  Then check LA weather. '
-        reason: "sglang preserves trailing normal_text after wrapper end; Dynamo trims it (post-#9350)"

--- a/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.yaml
@@ -14,7 +14,7 @@ cases:
       </invoke>
       </minimax:tool_call>
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
@@ -22,36 +22,36 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_1
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *d_1
-      sglang: *d_1
+      vllm: *id001
+      sglang: *id001
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_3
+      dynamo: &id003
         calls: []
         normal_text: Hello, how can I help you today?
-      vllm: *d_3
-      sglang: *d_3
+      vllm: *id003
+      sglang: *id003
   PARSER.batch.9:
     description: Empty input
     model_text: ''
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_9
+      dynamo: &id004
         calls: []
         normal_text: ''
-      vllm: *d_9
-      sglang: *d_9
+      vllm: *id004
+      sglang: *id004
   PARSER.batch.10:
     description: Duplicate calls (same name twice)
     model_text: |-
@@ -64,9 +64,9 @@ cases:
       </invoke>
       </minimax:tool_call>
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_10
+      dynamo: &id005
         calls:
         - name: get_weather
           arguments:
@@ -75,5 +75,5 @@ cases:
           arguments:
             location: LA
         normal_text: ''
-      vllm: *d_10
-      sglang: *d_10
+      vllm: *id005
+      sglang: *id005

--- a/tests/parity/parser/fixtures/mistral/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/mistral/PARSER.batch.2.yaml
@@ -58,14 +58,13 @@ cases:
         normal_text: 'Both:'
       vllm:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
-        - arguments:
+        - name: get_time
+          arguments:
             timezone: EST
-          name: get_time
         normal_text: 'Both: '
-        reason: drops trailing normal_text after tool-call wrapper end
       sglang:
         calls: []
         normal_text: 'Both:'

--- a/tests/parity/parser/fixtures/mistral/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/mistral/PARSER.batch.2.yaml
@@ -10,14 +10,14 @@ cases:
     model_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_time", "arguments":
       {"timezone": "EST"}}][/TOOL_CALLS]'
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
         properties:
           location:
             type: string
-    - &id002
+    - &id003
       name: get_time
       parameters:
         type: object
@@ -25,7 +25,7 @@ cases:
           timezone:
             type: string
     expected:
-      dynamo: &d_2_a
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
@@ -34,19 +34,18 @@ cases:
           arguments:
             timezone: EST
         normal_text: ''
-      vllm: *d_2_a
+      vllm: *id001
       sglang:
         calls: []
         normal_text: ''
-        reason: "SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits"
   PARSER.batch.2.c:
     description: With surrounding narration
     ref: dynamo
     model_text: 'Both: [TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_time", "arguments":
       {"timezone": "EST"}}][/TOOL_CALLS] Done.'
     tools:
-    - *id001
     - *id002
+    - *id003
     expected:
       dynamo:
         calls:
@@ -66,21 +65,20 @@ cases:
             timezone: EST
           name: get_time
         normal_text: 'Both: '
-        reason: "drops trailing normal_text after tool-call wrapper end"
+        reason: drops trailing normal_text after tool-call wrapper end
       sglang:
         calls: []
         normal_text: 'Both:'
-        reason: "trims trailing space from preceding normal_text"
   PARSER.batch.2.d:
     description: Same-name twice
     ref: dynamo
     model_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_weather", "arguments":
       {"location": "LA"}}][/TOOL_CALLS]'
     tools:
-    - *id001
-    - *id001
+    - *id002
+    - *id002
     expected:
-      dynamo: &d_2_d
+      dynamo: &id004
         calls:
         - name: get_weather
           arguments:
@@ -89,7 +87,7 @@ cases:
           arguments:
             location: LA
         normal_text: ''
-      vllm: *d_2_d
+      vllm: *id004
       sglang:
         calls: []
         normal_text: ''

--- a/tests/parity/parser/fixtures/mistral/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/mistral/PARSER.batch.4.yaml
@@ -23,7 +23,6 @@ cases:
       vllm:
         calls: []
         normal_text: not a json array[/TOOL_CALLS]
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
       sglang:
         calls: []
         normal_text: ''
@@ -40,7 +39,6 @@ cases:
       vllm:
         calls: []
         normal_text: '[{"name": "get_weather", "arguments": {"location": "NYC"][/TOOL_CALLS]'
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
       sglang:
         calls: []
         normal_text: ''
@@ -51,13 +49,13 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &d_4_c
+      dynamo: &id002
         calls: []
         normal_text: ''
       vllm:
         error: 'KeyError: ''name'''
-        reason: "vLLM mistral_tool_parser raises KeyError when 'name' key is missing"
-      sglang: *d_4_c
+        reason: vLLM mistral_tool_parser raises KeyError when 'name' key is missing
+      sglang: *id002
   PARSER.batch.4.d:
     description: Missing [/TOOL_CALLS] close
     ref: dynamo
@@ -65,13 +63,13 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &d_4_d
+      dynamo: &id003
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *d_4_d
+      vllm: *id003
       sglang:
         calls: []
         normal_text: ''

--- a/tests/parity/parser/fixtures/mistral/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/mistral/PARSER.batch.5.yaml
@@ -9,7 +9,7 @@ cases:
     ref: dynamo
     model_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}]'
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
@@ -17,35 +17,34 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_5_a
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *d_5_a
+      vllm: *id001
       sglang:
         calls: []
         normal_text: ''
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
   PARSER.batch.5.b:
     description: Closing [/TOOL_CALLS] without matching [TOOL_CALLS] open
     ref: dynamo
     model_text: '[{"name": "get_weather", "arguments": {"location": "NYC"}}][/TOOL_CALLS]'
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_5_b
+      dynamo: &id003
         calls: []
         normal_text: '[{"name": "get_weather", "arguments": {"location": "NYC"}}][/TOOL_CALLS]'
-      vllm: *d_5_b
-      sglang: *d_5_b
+      vllm: *id003
+      sglang: *id003
   PARSER.batch.5.c:
     description: Truncation mid-arguments JSON
     ref: dynamo
     model_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"loc'
     tools:
-    - *id001
+    - *id002
     expected:
       dynamo:
         calls: []
@@ -53,7 +52,51 @@ cases:
       vllm:
         calls: []
         normal_text: '[{"name": "get_weather", "arguments": {"loc'
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
       sglang:
         calls: []
         normal_text: ''
+  PARSER.batch.5.d:
+    description: Multi-call, last call missing only end marker (body complete)
+    ref: dynamo
+    model_text: 'I''ll start by fetching the weather for both Boston and New York at the same time![TOOL_CALLS][{"name": "get_weather",
+      "arguments": {"location": "Boston"}}, {"name": "get_weather", "arguments": {"location": "New York"}}]'
+    tools:
+    - *id002
+    expected:
+      dynamo: &id004
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        - name: get_weather
+          arguments:
+            location: New York
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
+      vllm: *id004
+      sglang:
+        calls: []
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
+  PARSER.batch.5.e:
+    description: Multi-call, last call truncated mid-arg-value
+    ref: dynamo
+    model_text: 'I''ll start by fetching the weather for both Boston and New York at the same time![TOOL_CALLS][{"name": "get_weather",
+      "arguments": {"location": "Boston"}}, {"name": "get_weather", "arguments": {"location": "New York'
+    tools:
+    - *id002
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        - name: get_weather
+          arguments:
+            location: New York
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
+      vllm:
+        calls: []
+        normal_text: '[{"name": "get_weather", "arguments": {"location": "Boston"}}, {"name": "get_weather", "arguments":
+          {"location": "New York'
+      sglang:
+        calls: []
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!

--- a/tests/parity/parser/fixtures/mistral/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/mistral/PARSER.batch.6.yaml
@@ -52,8 +52,7 @@ cases:
         normal_text: ''
       vllm:
         calls:
-        - arguments: {}
-          name: get_time
+        - name: get_time
+          arguments: {}
         normal_text: ''
-        reason: vLLM accepts call with missing arguments key as having empty args; Dynamo returns calls=[]
       sglang: *id004

--- a/tests/parity/parser/fixtures/mistral/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/mistral/PARSER.batch.6.yaml
@@ -9,47 +9,45 @@ cases:
     ref: dynamo
     model_text: '[TOOL_CALLS][{"name": "get_time", "arguments": {}}][/TOOL_CALLS]'
     tools:
-    - &id001
+    - &id002
       name: get_time
       parameters:
         type: object
         properties: {}
     expected:
-      dynamo: &d_6_a
+      dynamo: &id001
         calls:
         - name: get_time
           arguments: {}
         normal_text: ''
-      vllm: *d_6_a
+      vllm: *id001
       sglang:
         calls: []
         normal_text: ''
-        reason: "SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits"
   PARSER.batch.6.b:
     description: Whitespace inside arguments {}
     ref: dynamo
     model_text: '[TOOL_CALLS][{"name": "get_time", "arguments": { }}][/TOOL_CALLS]'
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_6_b
+      dynamo: &id003
         calls:
         - name: get_time
           arguments: {}
         normal_text: ''
-      vllm: *d_6_b
+      vllm: *id003
       sglang:
         calls: []
         normal_text: ''
-        reason: "SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits"
   PARSER.batch.6.c:
     description: No arguments key
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_mistral_tool_parser.py#L514
     model_text: '[TOOL_CALLS][{"name": "get_time"}][/TOOL_CALLS]'
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_6_c
+      dynamo: &id004
         calls: []
         normal_text: ''
       vllm:
@@ -57,5 +55,5 @@ cases:
         - arguments: {}
           name: get_time
         normal_text: ''
-        reason: "vLLM accepts call with missing arguments key as having empty args; Dynamo returns calls=[]"
-      sglang: *d_6_c
+        reason: vLLM accepts call with missing arguments key as having empty args; Dynamo returns calls=[]
+      sglang: *id004

--- a/tests/parity/parser/fixtures/mistral/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/mistral/PARSER.batch.7.yaml
@@ -21,7 +21,7 @@ cases:
           first_class:
             type: boolean
     expected:
-      dynamo: &d_7_a
+      dynamo: &id001
         calls:
         - name: book_flight
           arguments:
@@ -29,11 +29,10 @@ cases:
             first_class: true
             passengers: 2
         normal_text: ''
-      vllm: *d_7_a
+      vllm: *id001
       sglang:
         calls: []
         normal_text: ''
-        reason: "SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits"
   PARSER.batch.7.b:
     description: Unicode + escaped chars
     ref: dynamo
@@ -46,13 +45,13 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_7_b
+      dynamo: &id002
         calls:
         - name: get_weather
           arguments:
             location: Tōkyō "central"
         normal_text: ''
-      vllm: *d_7_b
+      vllm: *id002
       sglang:
         calls: []
         normal_text: ''
@@ -68,13 +67,13 @@ cases:
           celsius:
             type: integer
     expected:
-      dynamo: &d_7_c
+      dynamo: &id003
         calls:
         - name: set_temperature
           arguments:
             celsius: '20'
         normal_text: ''
-      vllm: *d_7_c
+      vllm: *id003
       sglang:
         calls: []
         normal_text: ''
@@ -92,7 +91,7 @@ cases:
           config:
             type: object
     expected:
-      dynamo: &d_7_d
+      dynamo: &id004
         calls:
         - name: process_data
           arguments:
@@ -103,7 +102,7 @@ cases:
             config:
               nested: true
         normal_text: ''
-      vllm: *d_7_d
+      vllm: *id004
       sglang:
         calls: []
         normal_text: ''

--- a/tests/parity/parser/fixtures/mistral/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/mistral/PARSER.batch.8.yaml
@@ -25,11 +25,10 @@ cases:
         normal_text: I will check the weather.
       vllm:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
         normal_text: 'I will check the weather. '
-        reason: drops trailing normal_text after tool-call wrapper end
       sglang:
         calls: []
         normal_text: I will check the weather.
@@ -67,11 +66,10 @@ cases:
         normal_text: I will check the weather.
       vllm:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
         normal_text: 'I will check the weather. '
-        reason: drops trailing normal_text after tool-call wrapper end
       sglang:
         calls: []
         normal_text: I will check the weather.

--- a/tests/parity/parser/fixtures/mistral/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/mistral/PARSER.batch.8.yaml
@@ -29,11 +29,10 @@ cases:
             location: NYC
           name: get_weather
         normal_text: 'I will check the weather. '
-        reason: "drops trailing normal_text after tool-call wrapper end"
+        reason: drops trailing normal_text after tool-call wrapper end
       sglang:
         calls: []
         normal_text: I will check the weather.
-        reason: "drops trailing normal_text after tool-call wrapper end"
   PARSER.batch.8.b:
     description: Narration after tool call only
     ref: dynamo
@@ -42,17 +41,16 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &d_8_b
+      dynamo: &id002
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *d_8_b
+      vllm: *id002
       sglang:
         calls: []
         normal_text: ''
-        reason: "drops trailing normal_text after tool-call wrapper end"
   PARSER.batch.8.c:
     description: Narration both before and after (sandwich)
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_mistral_tool_parser.py#L1858
@@ -73,11 +71,10 @@ cases:
             location: NYC
           name: get_weather
         normal_text: 'I will check the weather. '
-        reason: "drops trailing normal_text after tool-call wrapper end"
+        reason: drops trailing normal_text after tool-call wrapper end
       sglang:
         calls: []
         normal_text: I will check the weather.
-        reason: "drops trailing normal_text after tool-call wrapper end"
   PARSER.batch.8.d:
     description: Narration between multiple tool calls
     ref: dynamo
@@ -86,10 +83,10 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &d_8_d
+      dynamo: &id003
         calls: []
         normal_text: I will check the weather.
       vllm:
         error: 'ValueError: Only one BOT token should have been outputted'
-        reason: "vLLM mistral_tool_parser raises ValueError on two consecutive [TOOL_CALLS] envelopes"
-      sglang: *d_8_d
+        reason: vLLM mistral_tool_parser raises ValueError on two consecutive [TOOL_CALLS] envelopes
+      sglang: *id003

--- a/tests/parity/parser/fixtures/mistral/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/mistral/PARSER.batch.yaml
@@ -9,7 +9,7 @@ cases:
     description: Single tool call (happy path)
     model_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}][/TOOL_CALLS]'
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
@@ -17,47 +17,46 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_1
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *d_1
+      vllm: *id001
       sglang:
         calls: []
         normal_text: ''
-        reason: "SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits"
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_3
+      dynamo: &id003
         calls: []
         normal_text: Hello, how can I help you today?
-      vllm: *d_3
-      sglang: *d_3
+      vllm: *id003
+      sglang: *id003
   PARSER.batch.9:
     description: Empty input
     model_text: ''
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_9
+      dynamo: &id004
         calls: []
         normal_text: ''
-      vllm: *d_9
-      sglang: *d_9
+      vllm: *id004
+      sglang: *id004
   PARSER.batch.10:
     description: Duplicate calls (same name twice)
     model_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_weather", "arguments":
       {"location": "LA"}}][/TOOL_CALLS]'
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_10
+      dynamo: &id005
         calls:
         - name: get_weather
           arguments:
@@ -66,8 +65,7 @@ cases:
           arguments:
             location: LA
         normal_text: ''
-      vllm: *d_10
+      vllm: *id005
       sglang:
         calls: []
         normal_text: ''
-        reason: "SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits"

--- a/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.2.yaml
@@ -54,12 +54,6 @@ cases:
         unavailable: vLLM has no parser for family='nemotron_deci'
       sglang:
         unavailable: SGLang has no detector for family='nemotron_deci'
-    # NOTE: Dynamo's nemotron_deci parser does not restart on back-to-back
-    # <TOOLCALL>...</TOOLCALL> wrappers (handles multi-call within ONE wrapper
-    # — see 2.a — but not multiple wrappers). Known parser limitation; the
-    # fixture pins actual oracle output, not desired behavior. nemotron_deci
-    # has no vLLM/SGLang peer (n/a row in parity matrix) so this is
-    # Dynamo-self-check only.
   PARSER.batch.2.c:
     description: With surrounding narration
     ref: dynamo

--- a/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.5.yaml
@@ -55,3 +55,45 @@ cases:
         unavailable: vLLM has no parser for family='nemotron_deci'
       sglang:
         unavailable: SGLang has no detector for family='nemotron_deci'
+  PARSER.batch.5.d:
+    description: Multi-call, last call missing only end marker (body complete)
+    ref: dynamo
+    model_text: 'I''ll start by fetching the weather for both Boston and New York at the same time!<TOOLCALL>[{"name": "get_weather",
+      "arguments": {"location": "Boston"}}, {"name": "get_weather", "arguments": {"location": "New York"}}]'
+    tools:
+    - *id001
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        - name: get_weather
+          arguments:
+            location: New York
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
+      vllm:
+        unavailable: vLLM has no parser for family='nemotron_deci'
+      sglang:
+        unavailable: SGLang has no detector for family='nemotron_deci'
+  PARSER.batch.5.e:
+    description: Multi-call, last call truncated mid-arg-value
+    ref: dynamo
+    model_text: 'I''ll start by fetching the weather for both Boston and New York at the same time!<TOOLCALL>[{"name": "get_weather",
+      "arguments": {"location": "Boston"}}, {"name": "get_weather", "arguments": {"location": "New York'
+    tools:
+    - *id001
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        - name: get_weather
+          arguments:
+            location: New York
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
+      vllm:
+        unavailable: vLLM has no parser for family='nemotron_deci'
+      sglang:
+        unavailable: SGLang has no detector for family='nemotron_deci'

--- a/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.5.yaml
@@ -77,3 +77,71 @@ cases:
         unavailable: vLLM has no parser for family='nemotron_nano'
       sglang:
         unavailable: SGLang has no detector for family='nemotron_nano'
+  PARSER.batch.5.d:
+    description: Multi-call, last call missing only end marker (body complete)
+    ref: dynamo
+    model_text: |-
+      I'll start by fetching the weather for both Boston and New York at the same time!
+      <tool_call>
+      <function=get_weather>
+      <parameter=location>
+      Boston
+      </parameter>
+      </function>
+      </tool_call>
+      <tool_call>
+      <function=get_weather>
+      <parameter=location>
+      New York
+      </parameter>
+      </function>
+    tools:
+    - *id001
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        - name: get_weather
+          arguments:
+            location: New York
+        normal_text: |
+          I'll start by fetching the weather for both Boston and New York at the same time!
+      vllm:
+        unavailable: vLLM has no parser for family='nemotron_nano'
+      sglang:
+        unavailable: SGLang has no detector for family='nemotron_nano'
+  PARSER.batch.5.e:
+    description: Multi-call, last call truncated mid-arg-value
+    ref: dynamo
+    model_text: |-
+      I'll start by fetching the weather for both Boston and New York at the same time!
+      <tool_call>
+      <function=get_weather>
+      <parameter=location>
+      Boston
+      </parameter>
+      </function>
+      </tool_call>
+      <tool_call>
+      <function=get_weather>
+      <parameter=location>
+      New York
+    tools:
+    - *id001
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        - name: get_weather
+          arguments:
+            location: New York
+        normal_text: |
+          I'll start by fetching the weather for both Boston and New York at the same time!
+      vllm:
+        unavailable: vLLM has no parser for family='nemotron_nano'
+      sglang:
+        unavailable: SGLang has no detector for family='nemotron_nano'

--- a/tests/parity/parser/fixtures/phi4/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/phi4/PARSER.batch.2.yaml
@@ -10,14 +10,14 @@ cases:
     model_text: 'functools[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_time", "arguments": {"timezone":
       "EST"}}]'
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
         properties:
           location:
             type: string
-    - &id002
+    - &id003
       name: get_time
       parameters:
         type: object
@@ -25,7 +25,7 @@ cases:
           timezone:
             type: string
     expected:
-      dynamo: &d_2_a
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
@@ -34,7 +34,7 @@ cases:
           arguments:
             timezone: EST
         normal_text: ''
-      vllm: *d_2_a
+      vllm: *id001
       sglang:
         unavailable: SGLang has no detector for family='phi4'
   PARSER.batch.2.c:
@@ -43,8 +43,8 @@ cases:
     model_text: 'Both: functools[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_time", "arguments":
       {"timezone": "EST"}}] Done.'
     tools:
-    - *id001
     - *id002
+    - *id003
     expected:
       dynamo:
         calls:
@@ -57,14 +57,13 @@ cases:
         normal_text: 'Both:'
       vllm:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
-        - arguments:
+        - name: get_time
+          arguments:
             timezone: EST
-          name: get_time
         normal_text: ''
-        reason: "drops trailing normal_text after tool-call wrapper end"
       sglang:
         unavailable: SGLang has no detector for family='phi4'
   PARSER.batch.2.d:
@@ -73,10 +72,10 @@ cases:
     model_text: 'functools[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_weather", "arguments":
       {"location": "LA"}}]'
     tools:
-    - *id001
-    - *id001
+    - *id002
+    - *id002
     expected:
-      dynamo: &d_2_d
+      dynamo: &id004
         calls:
         - name: get_weather
           arguments:
@@ -85,6 +84,6 @@ cases:
           arguments:
             location: LA
         normal_text: ''
-      vllm: *d_2_d
+      vllm: *id004
       sglang:
         unavailable: SGLang has no detector for family='phi4'

--- a/tests/parity/parser/fixtures/phi4/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/phi4/PARSER.batch.4.yaml
@@ -9,7 +9,7 @@ cases:
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L322
     model_text: functools[not a json array]
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
@@ -17,10 +17,10 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_4_a
+      dynamo: &id001
         calls: []
         normal_text: ''
-      vllm: *d_4_a
+      vllm: *id001
       sglang:
         unavailable: SGLang has no detector for family='phi4'
   PARSER.batch.4.b:
@@ -28,12 +28,12 @@ cases:
     ref: dynamo
     model_text: 'functools[{"name": "get_weather", "arguments": {"location": "NYC"]'
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_4_b
+      dynamo: &id003
         calls: []
         normal_text: ''
-      vllm: *d_4_b
+      vllm: *id003
       sglang:
         unavailable: SGLang has no detector for family='phi4'
   PARSER.batch.4.c:
@@ -41,7 +41,7 @@ cases:
     ref: dynamo
     model_text: 'functools[{"arguments": {"location": "NYC"}}]'
     tools:
-    - *id001
+    - *id002
     expected:
       dynamo:
         calls: []
@@ -49,7 +49,6 @@ cases:
       vllm:
         calls: []
         normal_text: 'functools[{"arguments": {"location": "NYC"}}]'
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
       sglang:
         unavailable: SGLang has no detector for family='phi4'
   PARSER.batch.4.d:
@@ -57,7 +56,7 @@ cases:
     ref: dynamo
     model_text: 'functools[{"name": "get_weather", "arguments": {"location": "NYC"}}'
     tools:
-    - *id001
+    - *id002
     expected:
       dynamo:
         calls: []
@@ -65,6 +64,5 @@ cases:
       vllm:
         calls: []
         normal_text: 'functools[{"name": "get_weather", "arguments": {"location": "NYC"}}'
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
       sglang:
         unavailable: SGLang has no detector for family='phi4'

--- a/tests/parity/parser/fixtures/phi4/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/phi4/PARSER.batch.5.yaml
@@ -23,7 +23,6 @@ cases:
       vllm:
         calls: []
         normal_text: 'functools[{"name": "get_weather", "arguments": {"location": "NYC"}}'
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
       sglang:
         unavailable: SGLang has no detector for family='phi4'
   PARSER.batch.5.b:
@@ -42,7 +41,6 @@ cases:
       vllm:
         calls: []
         normal_text: 'functools{"name": "get_weather", "arguments": {"location": "NYC"}}]'
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
       sglang:
         unavailable: SGLang has no detector for family='phi4'
   PARSER.batch.5.c:
@@ -58,6 +56,39 @@ cases:
       vllm:
         calls: []
         normal_text: 'functools[{"name": "get_weather", "arguments": {"loc'
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
+      sglang:
+        unavailable: SGLang has no detector for family='phi4'
+  PARSER.batch.5.d:
+    description: Multi-call, last call missing only end marker (body complete)
+    ref: dynamo
+    model_text: 'I''ll start by fetching the weather for both Boston and New York at the same time!functools[{"name": "get_weather",
+      "arguments": {"location": "Boston"}}, {"name": "get_weather", "arguments": {"location": "New York"}}'
+    tools:
+    - *id001
+    expected:
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
+        calls: []
+        normal_text: 'I''ll start by fetching the weather for both Boston and New York at the same time!functools[{"name":
+          "get_weather", "arguments": {"location": "Boston"}}, {"name": "get_weather", "arguments": {"location": "New York"}}'
+      sglang:
+        unavailable: SGLang has no detector for family='phi4'
+  PARSER.batch.5.e:
+    description: Multi-call, last call truncated mid-arg-value
+    ref: dynamo
+    model_text: 'I''ll start by fetching the weather for both Boston and New York at the same time!functools[{"name": "get_weather",
+      "arguments": {"location": "Boston"}}, {"name": "get_weather", "arguments": {"location": "New York'
+    tools:
+    - *id001
+    expected:
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
+        calls: []
+        normal_text: 'I''ll start by fetching the weather for both Boston and New York at the same time!functools[{"name":
+          "get_weather", "arguments": {"location": "Boston"}}, {"name": "get_weather", "arguments": {"location": "New York'
       sglang:
         unavailable: SGLang has no detector for family='phi4'

--- a/tests/parity/parser/fixtures/phi4/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/phi4/PARSER.batch.6.yaml
@@ -9,18 +9,18 @@ cases:
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L260
     model_text: 'functools[{"name": "get_time", "arguments": {}}]'
     tools:
-    - &id001
+    - &id002
       name: get_time
       parameters:
         type: object
         properties: {}
     expected:
-      dynamo: &d_6_a
+      dynamo: &id001
         calls:
         - name: get_time
           arguments: {}
         normal_text: ''
-      vllm: *d_6_a
+      vllm: *id001
       sglang:
         unavailable: SGLang has no detector for family='phi4'
   PARSER.batch.6.b:
@@ -28,14 +28,14 @@ cases:
     ref: dynamo
     model_text: 'functools[{"name": "get_time", "arguments": { }}]'
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_6_b
+      dynamo: &id003
         calls:
         - name: get_time
           arguments: {}
         normal_text: ''
-      vllm: *d_6_b
+      vllm: *id003
       sglang:
         unavailable: SGLang has no detector for family='phi4'
   PARSER.batch.6.c:
@@ -43,7 +43,7 @@ cases:
     ref: dynamo
     model_text: 'functools[{"name": "get_time"}]'
     tools:
-    - *id001
+    - *id002
     expected:
       dynamo:
         calls: []
@@ -51,6 +51,5 @@ cases:
       vllm:
         calls: []
         normal_text: 'functools[{"name": "get_time"}]'
-        reason: "both return calls=[]; vLLM preserves raw input as normal_text on this recovery path, Dynamo emits empty"
       sglang:
         unavailable: SGLang has no detector for family='phi4'

--- a/tests/parity/parser/fixtures/phi4/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/phi4/PARSER.batch.7.yaml
@@ -20,7 +20,7 @@ cases:
           first_class:
             type: boolean
     expected:
-      dynamo: &d_7_a
+      dynamo: &id001
         calls:
         - name: book_flight
           arguments:
@@ -28,7 +28,7 @@ cases:
             passengers: 2
             first_class: true
         normal_text: ''
-      vllm: *d_7_a
+      vllm: *id001
       sglang:
         unavailable: SGLang has no detector for family='phi4'
   PARSER.batch.7.b:
@@ -43,13 +43,13 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_7_b
+      dynamo: &id002
         calls:
         - name: get_weather
           arguments:
             location: Tōkyō "central"
         normal_text: ''
-      vllm: *d_7_b
+      vllm: *id002
       sglang:
         unavailable: SGLang has no detector for family='phi4'
   PARSER.batch.7.c:
@@ -64,13 +64,13 @@ cases:
           celsius:
             type: integer
     expected:
-      dynamo: &d_7_c
+      dynamo: &id003
         calls:
         - name: set_temperature
           arguments:
             celsius: '20'
         normal_text: ''
-      vllm: *d_7_c
+      vllm: *id003
       sglang:
         unavailable: SGLang has no detector for family='phi4'
   PARSER.batch.7.d:
@@ -101,6 +101,5 @@ cases:
       vllm:
         calls: []
         normal_text: ''
-        reason: "vLLM emits JSON-typed parameter values as raw strings; Dynamo coerces nested object/array types"
       sglang:
         unavailable: SGLang has no detector for family='phi4'

--- a/tests/parity/parser/fixtures/phi4/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/phi4/PARSER.batch.8.yaml
@@ -25,11 +25,10 @@ cases:
         normal_text: I will check the weather.
       vllm:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
         normal_text: ''
-        reason: "drops trailing normal_text after tool-call wrapper end"
       sglang:
         unavailable: SGLang has no detector for family='phi4'
   PARSER.batch.8.b:
@@ -39,13 +38,13 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &d_8_b
+      dynamo: &id002
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *d_8_b
+      vllm: *id002
       sglang:
         unavailable: SGLang has no detector for family='phi4'
   PARSER.batch.8.c:
@@ -64,11 +63,10 @@ cases:
         normal_text: I will check the weather.
       vllm:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
         normal_text: ''
-        reason: "drops trailing normal_text after tool-call wrapper end"
       sglang:
         unavailable: SGLang has no detector for family='phi4'
   PARSER.batch.8.d:
@@ -90,10 +88,9 @@ cases:
         normal_text: I will check the weather.
       vllm:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
         normal_text: ''
-        reason: "drops trailing normal_text after tool-call wrapper end"
       sglang:
         unavailable: SGLang has no detector for family='phi4'

--- a/tests/parity/parser/fixtures/phi4/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/phi4/PARSER.batch.yaml
@@ -9,7 +9,7 @@ cases:
     description: Single tool call (happy path)
     model_text: 'functools[{"name": "get_weather", "arguments": {"location": "NYC"}}]'
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
@@ -17,37 +17,37 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_1
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *d_1
+      vllm: *id001
       sglang:
         unavailable: SGLang has no detector for family='phi4'
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_3
+      dynamo: &id003
         calls: []
         normal_text: Hello, how can I help you today?
-      vllm: *d_3
+      vllm: *id003
       sglang:
         unavailable: SGLang has no detector for family='phi4'
   PARSER.batch.9:
     description: Empty input
     model_text: ''
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_9
+      dynamo: &id004
         calls: []
         normal_text: ''
-      vllm: *d_9
+      vllm: *id004
       sglang:
         unavailable: SGLang has no detector for family='phi4'
   PARSER.batch.10:
@@ -55,9 +55,9 @@ cases:
     model_text: 'functools[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_weather", "arguments":
       {"location": "LA"}}]'
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_10
+      dynamo: &id005
         calls:
         - name: get_weather
           arguments:
@@ -66,6 +66,6 @@ cases:
           arguments:
             location: LA
         normal_text: ''
-      vllm: *d_10
+      vllm: *id005
       sglang:
         unavailable: SGLang has no detector for family='phi4'

--- a/tests/parity/parser/fixtures/pythonic/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/pythonic/PARSER.batch.2.yaml
@@ -9,14 +9,14 @@ cases:
     ref: dynamo
     model_text: '[get_weather(location="NYC"), get_time(timezone="EST")]'
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
         properties:
           location:
             type: string
-    - &id002
+    - &id003
       name: get_time
       parameters:
         type: object
@@ -24,7 +24,7 @@ cases:
           timezone:
             type: string
     expected:
-      dynamo: &d_2_a
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
@@ -33,15 +33,15 @@ cases:
           arguments:
             timezone: EST
         normal_text: ''
-      vllm: *d_2_a
-      sglang: *d_2_a
+      vllm: *id001
+      sglang: *id001
   PARSER.batch.2.c:
     description: With surrounding narration
     ref: dynamo
     model_text: 'Both: [get_weather(location="NYC"), get_time(timezone="EST")] Done.'
     tools:
-    - *id001
     - *id002
+    - *id003
     expected:
       dynamo:
         calls:
@@ -55,25 +55,24 @@ cases:
       vllm:
         calls: []
         normal_text: 'Both: [get_weather(location="NYC"), get_time(timezone="EST")] Done.'
-        reason: "vLLM rejects bracket-call form when surrounded by interleaved text; Dynamo extracts the calls"
       sglang:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
-        - arguments:
+        - name: get_time
+          arguments:
             timezone: EST
-          name: get_time
         normal_text: 'Both:  Done.'
   PARSER.batch.2.d:
     description: Same-name twice
     ref: dynamo
     model_text: '[get_weather(location="NYC"), get_weather(location="LA")]'
     tools:
-    - *id001
-    - *id001
+    - *id002
+    - *id002
     expected:
-      dynamo: &d_2_d
+      dynamo: &id004
         calls:
         - name: get_weather
           arguments:
@@ -82,5 +81,5 @@ cases:
           arguments:
             location: LA
         normal_text: ''
-      vllm: *d_2_d
-      sglang: *d_2_d
+      vllm: *id004
+      sglang: *id004

--- a/tests/parity/parser/fixtures/pythonic/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/pythonic/PARSER.batch.4.yaml
@@ -9,7 +9,7 @@ cases:
     ref: dynamo
     model_text: '[not a valid python call]'
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
@@ -17,32 +17,32 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_4_a
+      dynamo: &id001
         calls: []
         normal_text: '[not a valid python call]'
-      vllm: *d_4_a
-      sglang: *d_4_a
+      vllm: *id001
+      sglang: *id001
   PARSER.batch.4.b:
     description: Missing closing bracket
     ref: dynamo
     model_text: '[get_weather(location="NYC"'
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_4_b
+      dynamo: &id003
         calls: []
         normal_text: '[get_weather(location="NYC"'
-      vllm: *d_4_b
-      sglang: *d_4_b
+      vllm: *id003
+      sglang: *id003
   PARSER.batch.4.d:
     description: Mismatched paren / bracket
     ref: dynamo
     model_text: '[get_weather(location="NYC"]'
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_4_d
+      dynamo: &id004
         calls: []
         normal_text: '[get_weather(location="NYC"]'
-      vllm: *d_4_d
-      sglang: *d_4_d
+      vllm: *id004
+      sglang: *id004

--- a/tests/parity/parser/fixtures/pythonic/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/pythonic/PARSER.batch.5.yaml
@@ -9,7 +9,7 @@ cases:
     ref: dynamo
     model_text: '[get_weather(location="NYC")'
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
@@ -17,32 +17,60 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_5_a
+      dynamo: &id001
         calls: []
         normal_text: '[get_weather(location="NYC")'
-      vllm: *d_5_a
-      sglang: *d_5_a
+      vllm: *id001
+      sglang: *id001
   PARSER.batch.5.b:
     description: Closing `]` without matching `[` open
     ref: dynamo
     model_text: get_weather(location="NYC")]
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_5_b
+      dynamo: &id003
         calls: []
         normal_text: get_weather(location="NYC")]
-      vllm: *d_5_b
-      sglang: *d_5_b
+      vllm: *id003
+      sglang: *id003
   PARSER.batch.5.c:
     description: Truncation mid-argument value
     ref: dynamo
     model_text: '[get_weather(location="N'
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_5_c
+      dynamo: &id004
         calls: []
         normal_text: '[get_weather(location="N'
-      vllm: *d_5_c
-      sglang: *d_5_c
+      vllm: *id004
+      sglang: *id004
+  PARSER.batch.5.d:
+    description: Multi-call, last call missing only end marker (body complete)
+    ref: dynamo
+    model_text: I'll start by fetching the weather for both Boston and New York at the same time![get_weather(location="Boston"),
+      get_weather(location="New York")
+    tools:
+    - *id002
+    expected:
+      dynamo: &id005
+        calls: []
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time![get_weather(location="Boston"),
+          get_weather(location="New York")
+      vllm: *id005
+      sglang: *id005
+  PARSER.batch.5.e:
+    description: Multi-call, last call truncated mid-arg-value
+    ref: dynamo
+    model_text: I'll start by fetching the weather for both Boston and New York at the same time![get_weather(location="Boston"),
+      get_weather(location="New York
+    tools:
+    - *id002
+    expected:
+      dynamo: &id006
+        calls: []
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time![get_weather(location="Boston"),
+          get_weather(location="New York
+      vllm: *id006
+      sglang: *id006

--- a/tests/parity/parser/fixtures/pythonic/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/pythonic/PARSER.batch.6.yaml
@@ -9,28 +9,28 @@ cases:
     ref: dynamo
     model_text: '[get_time()]'
     tools:
-    - &id001
+    - &id002
       name: get_time
       parameters:
         type: object
         properties: {}
     expected:
-      dynamo: &d_6_a
+      dynamo: &id001
         calls:
         - name: get_time
           arguments: {}
         normal_text: ''
-      vllm: *d_6_a
-      sglang: *d_6_a
+      vllm: *id001
+      sglang: *id001
   PARSER.batch.6.b:
     description: Whitespace inside parens
     ref: dynamo
     model_text: '[get_time( )]'
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_6_b
+      dynamo: &id003
         calls: []
         normal_text: '[get_time( )]'
-      vllm: *d_6_b
-      sglang: *d_6_b
+      vllm: *id003
+      sglang: *id003

--- a/tests/parity/parser/fixtures/pythonic/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/pythonic/PARSER.batch.7.yaml
@@ -20,7 +20,7 @@ cases:
           first_class:
             type: boolean
     expected:
-      dynamo: &d_7_a
+      dynamo: &id001
         calls:
         - name: book_flight
           arguments:
@@ -28,8 +28,8 @@ cases:
             passengers: 2
             first_class: true
         normal_text: ''
-      vllm: *d_7_a
-      sglang: *d_7_a
+      vllm: *id001
+      sglang: *id001
   PARSER.batch.7.b:
     description: Unicode + escaped chars
     ref: dynamo
@@ -42,14 +42,14 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_7_b
+      dynamo: &id002
         calls:
         - name: get_weather
           arguments:
             location: Tōkyō "central"
         normal_text: ''
-      vllm: *d_7_b
-      sglang: *d_7_b
+      vllm: *id002
+      sglang: *id002
   PARSER.batch.7.c:
     description: Schema mismatch — string value where schema declares integer
     ref: dynamo
@@ -62,14 +62,14 @@ cases:
           celsius:
             type: integer
     expected:
-      dynamo: &d_7_c
+      dynamo: &id003
         calls:
         - name: set_temperature
           arguments:
             celsius: '20'
         normal_text: ''
-      vllm: *d_7_c
-      sglang: *d_7_c
+      vllm: *id003
+      sglang: *id003
   PARSER.batch.7.d:
     description: Nested dict + array (existing)
     ref: dynamo
@@ -84,7 +84,7 @@ cases:
           config:
             type: object
     expected:
-      dynamo: &d_7_d
+      dynamo: &id004
         calls:
         - name: process_data
           arguments:
@@ -95,5 +95,5 @@ cases:
             config:
               nested: true
         normal_text: ''
-      vllm: *d_7_d
-      sglang: *d_7_d
+      vllm: *id004
+      sglang: *id004

--- a/tests/parity/parser/fixtures/pythonic/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/pythonic/PARSER.batch.8.yaml
@@ -26,14 +26,12 @@ cases:
       vllm:
         calls: []
         normal_text: I will check the weather. [get_weather(location="NYC")]
-        reason: "vLLM rejects bracket-call form when surrounded by interleaved text; Dynamo extracts the call"
       sglang:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
         normal_text: 'I will check the weather. '
-        reason: "drops trailing normal_text after tool-call wrapper end"
   PARSER.batch.8.b:
     description: Narration after tool call only
     ref: dynamo
@@ -50,14 +48,12 @@ cases:
       vllm:
         calls: []
         normal_text: '[get_weather(location="NYC")] Let me know if you need more.'
-        reason: "vLLM rejects bracket-call form when surrounded by interleaved text; Dynamo extracts the call"
       sglang:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
         normal_text: ' Let me know if you need more.'
-        reason: "drops trailing normal_text after tool-call wrapper end"
   PARSER.batch.8.c:
     description: Narration both before and after (sandwich)
     ref: dynamo
@@ -74,14 +70,12 @@ cases:
       vllm:
         calls: []
         normal_text: I will check the weather. [get_weather(location="NYC")] Let me know if you need more.
-        reason: "vLLM rejects bracket-call form when surrounded by interleaved text; Dynamo extracts the call"
       sglang:
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
         normal_text: I will check the weather.  Let me know if you need more.
-        reason: "drops trailing normal_text after tool-call wrapper end"
   PARSER.batch.8.d:
     description: Narration between multiple tool calls
     ref: dynamo
@@ -98,8 +92,6 @@ cases:
       vllm:
         calls: []
         normal_text: I will check the weather. [get_weather(location="NYC")] Then check LA weather. [get_weather(location="LA")]
-        reason: "vLLM rejects bracket-call form when surrounded by interleaved text; Dynamo extracts the call"
       sglang:
         calls: []
         normal_text: 'I will check the weather. '
-        reason: "drops trailing normal_text after tool-call wrapper end"

--- a/tests/parity/parser/fixtures/pythonic/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/pythonic/PARSER.batch.yaml
@@ -9,7 +9,7 @@ cases:
     description: Single tool call (happy path)
     model_text: '[get_weather(location="NYC")]'
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
@@ -17,43 +17,43 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_1
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *d_1
-      sglang: *d_1
+      vllm: *id001
+      sglang: *id001
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_3
+      dynamo: &id003
         calls: []
         normal_text: Hello, how can I help you today?
-      vllm: *d_3
-      sglang: *d_3
+      vllm: *id003
+      sglang: *id003
   PARSER.batch.9:
     description: Empty input
     model_text: ''
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_9
+      dynamo: &id004
         calls: []
         normal_text: ''
-      vllm: *d_9
-      sglang: *d_9
+      vllm: *id004
+      sglang: *id004
   PARSER.batch.10:
     description: Duplicate calls (same name twice)
     model_text: '[get_weather(location="NYC"), get_weather(location="LA")]'
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_10
+      dynamo: &id005
         calls:
         - name: get_weather
           arguments:
@@ -62,5 +62,5 @@ cases:
           arguments:
             location: LA
         normal_text: ''
-      vllm: *d_10
-      sglang: *d_10
+      vllm: *id005
+      sglang: *id005

--- a/tests/parity/parser/fixtures/qwen25/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/qwen25/PARSER.batch.2.yaml
@@ -38,9 +38,8 @@ cases:
         unavailable: vLLM has no parser for family='qwen25'
       sglang:
         calls: []
-        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name": "get_time",
-          "arguments": {"timezone": "EST"}}</tool_call>'
-        reason: "SGLang Qwen25Detector returns calls=[] on the hermes-style <tool_call>...</tool_call> format Dynamo emits"
+        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name":
+          "get_time", "arguments": {"timezone": "EST"}}</tool_call>'
   PARSER.batch.2.c:
     description: With surrounding narration
     ref: dynamo
@@ -63,8 +62,8 @@ cases:
         unavailable: vLLM has no parser for family='qwen25'
       sglang:
         calls: []
-        normal_text: 'Both: <tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name": "get_time",
-          "arguments": {"timezone": "EST"}}</tool_call> Done.'
+        normal_text: 'Both: <tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name":
+          "get_time", "arguments": {"timezone": "EST"}}</tool_call> Done.'
   PARSER.batch.2.d:
     description: Same-name twice
     ref: dynamo
@@ -87,5 +86,5 @@ cases:
         unavailable: vLLM has no parser for family='qwen25'
       sglang:
         calls: []
-        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name": "get_weather",
-          "arguments": {"location": "LA"}}</tool_call>'
+        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name":
+          "get_weather", "arguments": {"location": "LA"}}</tool_call>'

--- a/tests/parity/parser/fixtures/qwen25/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/qwen25/PARSER.batch.4.yaml
@@ -9,7 +9,7 @@ cases:
     ref: dynamo
     model_text: <tool_call>not even json</tool_call>
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
@@ -17,18 +17,18 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_4_a
+      dynamo: &id001
         calls: []
         normal_text: <tool_call>not even json</tool_call>
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang: *d_4_a
+      sglang: *id001
   PARSER.batch.4.b:
     description: Missing close brace in JSON body
     ref: dynamo
     model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"</tool_call>'
     tools:
-    - *id001
+    - *id002
     expected:
       dynamo:
         calls:
@@ -46,20 +46,20 @@ cases:
     ref: dynamo
     model_text: '<tool_call>{"arguments": {"location": "NYC"}}</tool_call>'
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_4_c
+      dynamo: &id003
         calls: []
         normal_text: '<tool_call>{"arguments": {"location": "NYC"}}</tool_call>'
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang: *d_4_c
+      sglang: *id003
   PARSER.batch.4.d:
     description: Missing </tool_call> close
     ref: dynamo
     model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}'
     tools:
-    - *id001
+    - *id002
     expected:
       dynamo:
         calls:

--- a/tests/parity/parser/fixtures/qwen25/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/qwen25/PARSER.batch.5.yaml
@@ -28,7 +28,6 @@ cases:
       sglang:
         calls: []
         normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}'
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
   PARSER.batch.5.b:
     description: Closing </tool_call> without matching <tool_call> open
     ref: dynamo
@@ -36,12 +35,12 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &d_5_b
+      dynamo: &id002
         calls: []
         normal_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>'
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang: *d_5_b
+      sglang: *id002
   PARSER.batch.5.c:
     description: Truncation mid-arguments JSON
     ref: dynamo
@@ -49,9 +48,51 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &d_5_c
+      dynamo: &id003
         calls: []
         normal_text: '<tool_call>{"name": "get_weather", "arguments": {"loc'
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang: *d_5_c
+      sglang: *id003
+  PARSER.batch.5.d:
+    description: Multi-call, last call missing only end marker (body complete)
+    ref: dynamo
+    model_text: 'I''ll start by fetching the weather for both Boston and New York at the same time!<tool_call>{"name": "get_weather",
+      "arguments": {"location": "Boston"}}</tool_call><tool_call>{"name": "get_weather", "arguments": {"location": "New York"}}'
+    tools:
+    - *id001
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
+      vllm:
+        unavailable: vLLM has no parser for family='qwen25'
+      sglang:
+        calls: []
+        normal_text: 'I''ll start by fetching the weather for both Boston and New York at the same time!<tool_call>{"name":
+          "get_weather", "arguments": {"location": "Boston"}}</tool_call><tool_call>{"name": "get_weather", "arguments": {"location":
+          "New York"}}'
+  PARSER.batch.5.e:
+    description: Multi-call, last call truncated mid-arg-value
+    ref: dynamo
+    model_text: 'I''ll start by fetching the weather for both Boston and New York at the same time!<tool_call>{"name": "get_weather",
+      "arguments": {"location": "Boston"}}</tool_call><tool_call>{"name": "get_weather", "arguments": {"location": "New York'
+    tools:
+    - *id001
+    expected:
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
+      vllm:
+        unavailable: vLLM has no parser for family='qwen25'
+      sglang:
+        calls: []
+        normal_text: 'I''ll start by fetching the weather for both Boston and New York at the same time!<tool_call>{"name":
+          "get_weather", "arguments": {"location": "Boston"}}</tool_call><tool_call>{"name": "get_weather", "arguments": {"location":
+          "New York'

--- a/tests/parity/parser/fixtures/qwen25/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/qwen25/PARSER.batch.6.yaml
@@ -25,7 +25,6 @@ cases:
       sglang:
         calls: []
         normal_text: '<tool_call>{"name": "get_time", "arguments": {}}</tool_call>'
-        reason: "SGLang Qwen25Detector returns calls=[] on the hermes-style <tool_call>...</tool_call> format Dynamo emits"
   PARSER.batch.6.b:
     description: Whitespace inside arguments {}
     ref: dynamo
@@ -43,7 +42,6 @@ cases:
       sglang:
         calls: []
         normal_text: '<tool_call>{"name": "get_time", "arguments": { }}</tool_call>'
-        reason: "SGLang Qwen25Detector returns calls=[] on the hermes-style <tool_call>...</tool_call> format Dynamo emits"
   PARSER.batch.6.c:
     description: No arguments key
     ref: dynamo
@@ -51,9 +49,9 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &d_6_c
+      dynamo: &id002
         calls: []
         normal_text: '<tool_call>{"name": "get_time"}</tool_call>'
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang: *d_6_c
+      sglang: *id002

--- a/tests/parity/parser/fixtures/qwen25/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/qwen25/PARSER.batch.7.yaml
@@ -33,8 +33,8 @@ cases:
         unavailable: vLLM has no parser for family='qwen25'
       sglang:
         calls: []
-        normal_text: '<tool_call>{"name": "book_flight", "arguments": {"destination": "Paris", "passengers": 2, "first_class": true}}</tool_call>'
-        reason: "SGLang Qwen25Detector returns calls=[] on the hermes-style <tool_call>...</tool_call> format Dynamo emits"
+        normal_text: '<tool_call>{"name": "book_flight", "arguments": {"destination": "Paris", "passengers": 2, "first_class":
+          true}}</tool_call>'
   PARSER.batch.7.b:
     description: Unicode + escaped chars
     ref: dynamo

--- a/tests/parity/parser/fixtures/qwen25/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/qwen25/PARSER.batch.8.yaml
@@ -28,7 +28,6 @@ cases:
       sglang:
         calls: []
         normal_text: 'I will check the weather. <tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>'
-        reason: "drops trailing normal_text after tool-call wrapper end"
   PARSER.batch.8.b:
     description: Narration after tool call only
     ref: dynamo
@@ -47,8 +46,8 @@ cases:
         unavailable: vLLM has no parser for family='qwen25'
       sglang:
         calls: []
-        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call> Let me know if you need more.'
-        reason: "drops trailing normal_text after tool-call wrapper end"
+        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call> Let me know if you
+          need more.'
   PARSER.batch.8.c:
     description: Narration both before and after (sandwich)
     ref: dynamo
@@ -67,9 +66,8 @@ cases:
         unavailable: vLLM has no parser for family='qwen25'
       sglang:
         calls: []
-        normal_text: 'I will check the weather. <tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call> Let
-          me know if you need more.'
-        reason: "drops trailing normal_text after tool-call wrapper end"
+        normal_text: 'I will check the weather. <tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>
+          Let me know if you need more.'
   PARSER.batch.8.d:
     description: Narration between multiple tool calls
     ref: dynamo
@@ -91,6 +89,5 @@ cases:
         unavailable: vLLM has no parser for family='qwen25'
       sglang:
         calls: []
-        normal_text: 'I will check the weather. <tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call> Then
-          check LA weather. <tool_call>{"name": "get_weather", "arguments": {"location": "LA"}}</tool_call>'
-        reason: "drops trailing normal_text after tool-call wrapper end"
+        normal_text: 'I will check the weather. <tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>
+          Then check LA weather. <tool_call>{"name": "get_weather", "arguments": {"location": "LA"}}</tool_call>'

--- a/tests/parity/parser/fixtures/qwen25/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/qwen25/PARSER.batch.yaml
@@ -28,31 +28,30 @@ cases:
       sglang:
         calls: []
         normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>'
-        reason: "SGLang Qwen25Detector returns calls=[] on the hermes-style <tool_call>...</tool_call> format Dynamo emits"
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
     tools:
     - *id001
     expected:
-      dynamo: &d_3
+      dynamo: &id002
         calls: []
         normal_text: Hello, how can I help you today?
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang: *d_3
+      sglang: *id002
   PARSER.batch.9:
     description: Empty input
     model_text: ''
     tools:
     - *id001
     expected:
-      dynamo: &d_9
+      dynamo: &id003
         calls: []
         normal_text: ''
       vllm:
         unavailable: vLLM has no parser for family='qwen25'
-      sglang: *d_9
+      sglang: *id003
   PARSER.batch.10:
     description: Duplicate calls (same name twice)
     model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name": "get_weather",
@@ -73,6 +72,5 @@ cases:
         unavailable: vLLM has no parser for family='qwen25'
       sglang:
         calls: []
-        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name": "get_weather",
-          "arguments": {"location": "LA"}}</tool_call>'
-        reason: "SGLang Qwen25Detector returns calls=[] on the hermes-style <tool_call>...</tool_call> format Dynamo emits"
+        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name":
+          "get_weather", "arguments": {"location": "LA"}}</tool_call>'

--- a/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.2.yaml
@@ -23,14 +23,14 @@ cases:
       </function>
       </tool_call>
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
         properties:
           location:
             type: string
-    - &id002
+    - &id003
       name: get_time
       parameters:
         type: object
@@ -38,7 +38,7 @@ cases:
           timezone:
             type: string
     expected:
-      dynamo: &d_2_a
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
@@ -47,8 +47,8 @@ cases:
           arguments:
             timezone: EST
         normal_text: ''
-      vllm: *d_2_a
-      sglang: *d_2_a
+      vllm: *id001
+      sglang: *id001
   PARSER.batch.2.c:
     description: Parallel calls with surrounding narration
     ref: dynamo
@@ -68,10 +68,10 @@ cases:
       </function>
       </tool_call> Results above.
     tools:
-    - *id001
     - *id002
+    - *id003
     expected:
-      dynamo: &d_2_c
+      dynamo: &id004
         calls:
         - name: get_weather
           arguments:
@@ -80,8 +80,8 @@ cases:
           arguments:
             timezone: EST
         normal_text: 'Both queries: '
-      vllm: *d_2_c
-      sglang: *d_2_c
+      vllm: *id004
+      sglang: *id004
   PARSER.batch.2.d:
     description: Same-name twice (id distinctness)
     ref: dynamo
@@ -101,10 +101,10 @@ cases:
       </function>
       </tool_call>
     tools:
-    - *id001
-    - *id001
+    - *id002
+    - *id002
     expected:
-      dynamo: &d_2_d
+      dynamo: &id005
         calls:
         - name: get_weather
           arguments:
@@ -113,5 +113,5 @@ cases:
           arguments:
             location: LA
         normal_text: ''
-      vllm: *d_2_d
-      sglang: *d_2_d
+      vllm: *id005
+      sglang: *id005

--- a/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.5.yaml
@@ -106,7 +106,7 @@ cases:
     tools:
     - *id002
     expected:
-      dynamo: &id005
+      dynamo: &id004
         calls:
         - name: get_weather
           arguments:
@@ -116,7 +116,7 @@ cases:
             location: New York
         normal_text: |
           I'll start by fetching the weather for both Boston and New York at the same time!
-      vllm: *id005
+      vllm: *id004
       sglang:
         calls:
         - name: get_weather
@@ -143,7 +143,7 @@ cases:
     tools:
     - *id002
     expected:
-      dynamo: &id006
+      dynamo: &id005
         calls:
         - name: get_weather
           arguments:
@@ -153,7 +153,7 @@ cases:
             location: New York
         normal_text: |
           I'll start by fetching the weather for both Boston and New York at the same time!
-      vllm: *id006
+      vllm: *id005
       sglang:
         calls:
         - name: get_weather

--- a/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.5.yaml
@@ -85,3 +85,79 @@ cases:
         normal_text: ''
       vllm: *id003
       sglang: *id003
+  PARSER.batch.5.d:
+    description: Multi-call, last call missing only end marker (body complete)
+    ref: dynamo
+    model_text: |-
+      I'll start by fetching the weather for both Boston and New York at the same time!
+      <tool_call>
+      <function=get_weather>
+      <parameter=location>
+      Boston
+      </parameter>
+      </function>
+      </tool_call>
+      <tool_call>
+      <function=get_weather>
+      <parameter=location>
+      New York
+      </parameter>
+      </function>
+    tools:
+    - *id002
+    expected:
+      dynamo: &id005
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        - name: get_weather
+          arguments:
+            location: New York
+        normal_text: |
+          I'll start by fetching the weather for both Boston and New York at the same time!
+      vllm: *id005
+      sglang:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: |
+          I'll start by fetching the weather for both Boston and New York at the same time!
+  PARSER.batch.5.e:
+    description: Multi-call, last call truncated mid-arg-value
+    ref: dynamo
+    model_text: |-
+      I'll start by fetching the weather for both Boston and New York at the same time!
+      <tool_call>
+      <function=get_weather>
+      <parameter=location>
+      Boston
+      </parameter>
+      </function>
+      </tool_call>
+      <tool_call>
+      <function=get_weather>
+      <parameter=location>
+      New York
+    tools:
+    - *id002
+    expected:
+      dynamo: &id006
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        - name: get_weather
+          arguments:
+            location: New York
+        normal_text: |
+          I'll start by fetching the weather for both Boston and New York at the same time!
+      vllm: *id006
+      sglang:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Boston
+        normal_text: |
+          I'll start by fetching the weather for both Boston and New York at the same time!

--- a/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.6.yaml
@@ -13,19 +13,19 @@ cases:
       </function>
       </tool_call>
     tools:
-    - &id001
+    - &id002
       name: get_time
       parameters:
         type: object
         properties: {}
     expected:
-      dynamo: &d_6_a
+      dynamo: &id001
         calls:
         - name: get_time
           arguments: {}
         normal_text: ''
-      vllm: *d_6_a
-      sglang: *d_6_a
+      vllm: *id001
+      sglang: *id001
   PARSER.batch.6.b:
     description: Function block with extra whitespace inside
     ref: dynamo
@@ -36,12 +36,12 @@ cases:
       </function>
       </tool_call>
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_6_b
+      dynamo: &id003
         calls:
         - name: get_time
           arguments: {}
         normal_text: ''
-      vllm: *d_6_b
-      sglang: *d_6_b
+      vllm: *id003
+      sglang: *id003

--- a/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.7.yaml
@@ -33,7 +33,7 @@ cases:
           first_class:
             type: boolean
     expected:
-      dynamo: &d_7_a
+      dynamo: &id001
         calls:
         - name: book_flight
           arguments:
@@ -41,16 +41,15 @@ cases:
             first_class: true
             passengers: 2
         normal_text: ''
-      vllm: *d_7_a
+      vllm: *id001
       sglang:
         calls:
-        - arguments:
+        - name: book_flight
+          arguments:
             destination: Paris
-            first_class: 'true'
             passengers: '2'
-          name: book_flight
+            first_class: 'true'
         normal_text: ''
-        reason: "SGLang's qwen3_coder parser does not coerce parameter values via the tool schema, so booleans / integers surface as raw strings; vLLM and Dynamo coerce."
   PARSER.batch.7.b:
     description: Unicode in parameter value
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L302
@@ -70,11 +69,11 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_7_b
+      dynamo: &id002
         calls:
         - name: get_weather
           arguments:
             location: Tōkyō central
         normal_text: ''
-      vllm: *d_7_b
-      sglang: *d_7_b
+      vllm: *id002
+      sglang: *id002

--- a/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.8.yaml
@@ -16,7 +16,7 @@ cases:
       </function>
       </tool_call>
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
@@ -24,14 +24,14 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_8_a
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: 'I will check the weather. '
-      vllm: *d_8_a
-      sglang: *d_8_a
+      vllm: *id001
+      sglang: *id001
   PARSER.batch.8.b:
     description: Narration after tool call only
     ref: dynamo
@@ -44,16 +44,16 @@ cases:
       </function>
       </tool_call> Let me know if you need more.
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_8_b
+      dynamo: &id003
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *d_8_b
-      sglang: *d_8_b
+      vllm: *id003
+      sglang: *id003
   PARSER.batch.8.c:
     description: Narration both before and after (sandwich)
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L282
@@ -66,16 +66,16 @@ cases:
       </function>
       </tool_call> Let me know if you need more.
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_8_c
+      dynamo: &id004
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: 'I will check the weather. '
-      vllm: *d_8_c
-      sglang: *d_8_c
+      vllm: *id004
+      sglang: *id004
   PARSER.batch.8.d:
     description: Narration between multiple tool calls
     ref: dynamo
@@ -94,9 +94,9 @@ cases:
       </function>
       </tool_call>
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_8_d
+      dynamo: &id005
         calls:
         - name: get_weather
           arguments:
@@ -105,5 +105,5 @@ cases:
           arguments:
             location: LA
         normal_text: 'I will check the weather. '
-      vllm: *d_8_d
-      sglang: *d_8_d
+      vllm: *id005
+      sglang: *id005

--- a/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.yaml
@@ -16,7 +16,7 @@ cases:
       </function>
       </tool_call>
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
@@ -24,36 +24,36 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_1
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *d_1
-      sglang: *d_1
+      vllm: *id001
+      sglang: *id001
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_3
+      dynamo: &id003
         calls: []
         normal_text: Hello, how can I help you today?
-      vllm: *d_3
-      sglang: *d_3
+      vllm: *id003
+      sglang: *id003
   PARSER.batch.9:
     description: Empty input
     model_text: ''
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_9
+      dynamo: &id004
         calls: []
         normal_text: ''
-      vllm: *d_9
-      sglang: *d_9
+      vllm: *id004
+      sglang: *id004
   PARSER.batch.10:
     description: Duplicate calls (same name twice)
     model_text: |-
@@ -72,9 +72,9 @@ cases:
       </function>
       </tool_call>
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_10
+      dynamo: &id005
         calls:
         - name: get_weather
           arguments:
@@ -83,5 +83,5 @@ cases:
           arguments:
             location: LA
         normal_text: ''
-      vllm: *d_10
-      sglang: *d_10
+      vllm: *id005
+      sglang: *id005

--- a/tests/parity/parser/test_parity_parser.py
+++ b/tests/parity/parser/test_parity_parser.py
@@ -64,8 +64,8 @@ def _case_sort_key(case_id: str) -> tuple[int, str]:
     """Sort key for case IDs that may carry a sub-letter.
 
     `PARSER.batch.5`   → (5, "")
+    `PARSER.batch.5.d` → (5, "d")
     `PARSER.batch.8.a` → (8, "a")
-    `PARSER.batch.8.b` → (8, "b")
     """
     parts = case_id.split(".")
     top = int(parts[2])

--- a/tests/parity/parser/test_parity_parser.py
+++ b/tests/parity/parser/test_parity_parser.py
@@ -59,6 +59,7 @@ _PACKAGE: dict[str, str] = {
 }
 
 
+
 def _case_sort_key(case_id: str) -> tuple[int, str]:
     """Sort key for case IDs that may carry a sub-letter.
 

--- a/tests/parity/parser/test_parity_parser.py
+++ b/tests/parity/parser/test_parity_parser.py
@@ -59,7 +59,6 @@ _PACKAGE: dict[str, str] = {
 }
 
 
-
 def _case_sort_key(case_id: str) -> tuple[int, str]:
     """Sort key for case IDs that may carry a sub-letter.
 

--- a/tests/parity/parser/vllm.py
+++ b/tests/parity/parser/vllm.py
@@ -80,6 +80,29 @@ _FAMILY_TO_VLLM_KEY = {
 }
 
 
+def _tools_as_namespace(
+    tools: list[dict[str, Any]] | None,
+) -> list[SimpleNamespace] | None:
+    """Wrap tool dicts so vLLM parsers can use attribute access
+    (``tool.function.name``) while keeping ``parameters`` as a plain
+    dict (vLLM also calls ``.get()`` on it)."""
+    if not tools:
+        return None
+    out = []
+    for t in tools:
+        fn = t.get("function", t)
+        out.append(
+            SimpleNamespace(
+                type=t.get("type", "function"),
+                function=SimpleNamespace(
+                    name=fn["name"],
+                    parameters=fn.get("parameters") or {},
+                ),
+            )
+        )
+    return out
+
+
 def parse(
     parser_family: str,
     raw_text: str,
@@ -105,15 +128,14 @@ def parse(
         if tools
         else None
     )
+    # Some vLLM parsers (e.g. glm4_moe) access request.tools[i].function.name
+    # via attribute, not dict subscript. Convert to SimpleNamespace so both
+    # access styles work.
+    ns_tools = _tools_as_namespace(wrapped_tools)
     try:
         parser_cls = ToolParserManager.get_tool_parser(key)
-        # vLLM's ToolParser constructor checks `if not self.model_tokenizer:` and raises
-        # if falsy. None of the parsers we test actually call tokenizer methods inside
-        # extract_tool_calls(), so a truthy stub satisfies the check.
-        parser: ToolParser = parser_cls(tokenizer=_StubTokenizer(), tools=wrapped_tools)
-        # vLLM's extract_tool_calls signature: (model_output, request) → ExtractedToolCallInformation.
-        # We construct a minimal request shape with only the tools field, since most parsers ignore the rest.
-        request = SimpleNamespace(tools=wrapped_tools)
+        parser: ToolParser = parser_cls(tokenizer=_StubTokenizer(), tools=ns_tools)
+        request = SimpleNamespace(tools=ns_tools)
         info = parser.extract_tool_calls(raw_text, request)
     except NotImplementedError as e:
         # Known unsupported combinations (e.g., vLLM's harmony parser requires

--- a/tests/parity/parser/vllm.py
+++ b/tests/parity/parser/vllm.py
@@ -80,29 +80,6 @@ _FAMILY_TO_VLLM_KEY = {
 }
 
 
-def _tools_as_namespace(
-    tools: list[dict[str, Any]] | None,
-) -> list[SimpleNamespace] | None:
-    """Wrap tool dicts so vLLM parsers can use attribute access
-    (``tool.function.name``) while keeping ``parameters`` as a plain
-    dict (vLLM also calls ``.get()`` on it)."""
-    if not tools:
-        return None
-    out = []
-    for t in tools:
-        fn = t.get("function", t)
-        out.append(
-            SimpleNamespace(
-                type=t.get("type", "function"),
-                function=SimpleNamespace(
-                    name=fn["name"],
-                    parameters=fn.get("parameters") or {},
-                ),
-            )
-        )
-    return out
-
-
 def parse(
     parser_family: str,
     raw_text: str,
@@ -128,14 +105,15 @@ def parse(
         if tools
         else None
     )
-    # Some vLLM parsers (e.g. glm4_moe) access request.tools[i].function.name
-    # via attribute, not dict subscript. Convert to SimpleNamespace so both
-    # access styles work.
-    ns_tools = _tools_as_namespace(wrapped_tools)
     try:
         parser_cls = ToolParserManager.get_tool_parser(key)
-        parser: ToolParser = parser_cls(tokenizer=_StubTokenizer(), tools=ns_tools)
-        request = SimpleNamespace(tools=ns_tools)
+        # vLLM's ToolParser constructor checks `if not self.model_tokenizer:` and raises
+        # if falsy. None of the parsers we test actually call tokenizer methods inside
+        # extract_tool_calls(), so a truthy stub satisfies the check.
+        parser: ToolParser = parser_cls(tokenizer=_StubTokenizer(), tools=wrapped_tools)
+        # vLLM's extract_tool_calls signature: (model_output, request) → ExtractedToolCallInformation.
+        # We construct a minimal request shape with only the tools field, since most parsers ignore the rest.
+        request = SimpleNamespace(tools=wrapped_tools)
         info = parser.extract_tool_calls(raw_text, request)
     except NotImplementedError as e:
         # Known unsupported combinations (e.g., vLLM's harmony parser requires


### PR DESCRIPTION
#### Overview:

- Disable EOF recovery for GLM-4.7 so truncated tool calls are dropped instead of returned with empty arguments
- Add PARSER.batch.5.d and 5.e (multi-call truncation) across all 19 parser families
- Re-capture expected values from CI-matching containers (vLLM 0.20.1, SGLang 0.5.11)

Example glm engine output:
```XML
  model output:
    <tool_call>get_weather
      <arg_key>location</arg_key>
      <arg_value>NY         <-- truncated
```

BEFORE:
```yaml
  Dynamo response:
    tool_calls: [{
      name: "get_weather",
      arguments: {}          <-- silent empty args
    }]
```


AFTER:
```yaml
  Dynamo response:
    tool_calls: []           <-- dropped
    content: "<tool_call>..." <-- raw preserved
```    
(matches vLLM + SGLang)


#### Details:

GLM-4.7's parser had `allow_eof_recovery = true` forced in `detect_and_parse_tool_call_with_recovery`. When truncation cut mid-argument, the recovery path returned a tool call with empty arguments instead of dropping it.
Downstream tag-stripping then leaked raw markup into `message.content`.

The fix removes the `ParserConfig::Glm47` arm from the recovery match block. Without the override, the parser's default behavior applies: drop the incomplete call and surface the raw text in `normal_text`. All three impls now converge on 5.a and 5.c for glm47.

Added `PARSER.batch.5.d` (multi-call, last call missing end marker) and `5.e` (multi-call, last call truncated
mid-arg-value) across all 19 parser families per the parity README contract. Expected values captured from
CI-matching containers.

Note: parser-level fix only. The content leak from `normal_text` through postprocessing is a separate issue.

#### Related Issues:

Relates to [DIS-1906](https://linear.app/nvidia/issue/DIS-1906)

/coderabbit profile chill


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved GLM-4.7 tool call parser robustness by validating recovered argument payloads, preventing invalid empty-argument tool invocations from truncated input.

* **Tests**
  * Added test coverage for tool call parser edge cases including various truncation scenarios and argument recovery validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
