### PR TITLE
docs: bump DeepSeek-V4 doc references to v1.2.0-deepseek-v4-dev.3

### DIFF
--- a/docs/reference/release-artifacts.md
+++ b/docs/reference/release-artifacts.md
@@ -17,7 +17,7 @@ Release history in this document begins at v0.6.0.
 - **Docs:** [v1.1.1](https://docs.dynamo.nvidia.com/dynamo)
 - **NGC Collection:** [ai-dynamo](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/collections/ai-dynamo)
 
-> **Experimental:** [v1.2.0-deepseek-v4-dev.2](#v120-deepseek-v4-dev2) *(DeepSeek-V4-Flash / V4-Pro on Blackwell, vLLM + SGLang containers only)* is available as an experimental preview. Tagged **Pre-Releases** and experimental builds are listed under [Pre-Release Artifacts](#pre-release-artifacts).
+> **Experimental:** [v1.2.0-deepseek-v4-dev.3](#v120-deepseek-v4-dev3) *(DeepSeek-V4-Flash / V4-Pro on Blackwell, vLLM + SGLang containers only)* is available as an experimental preview. Tagged **Pre-Releases** and experimental builds are listed under [Pre-Release Artifacts](#pre-release-artifacts).
 
 ### Container Images
 
@@ -196,7 +196,7 @@ For backend version pins, see the version-pins table above and the [GitHub Relea
 
 **Pre-Release and Experimental Git Tags**
 
-- **v1.2.0-deepseek-v4-dev.2**: **Images:** `vllm-runtime:*-deepseek-v4-cuda13-dev.2`, `sglang-runtime:*-deepseek-v4-cuda12-dev.2`, `sglang-runtime:*-deepseek-v4-cuda13-dev.2`. **Helm / PyPI:** Not published for this tag (see [Pre-Release Artifacts](#v120-deepseek-v4-dev2)).
+- **v1.2.0-deepseek-v4-dev.3**: **Images:** `vllm-runtime:*-deepseek-v4-cuda13-dev.3`, `sglang-runtime:*-deepseek-v4-cuda12-dev.3`, `sglang-runtime:*-deepseek-v4-cuda13-dev.3`. **Helm / PyPI:** Not published for this tag (see [Pre-Release Artifacts](#v120-deepseek-v4-dev3)).
 - **v1.1.0-dev.3**: **Images:** `tensorrtllm-runtime:1.1.0-dev.3`. **Wheels:** `ai-dynamo`, `ai-dynamo-runtime` on [pypi.nvidia.com](https://pypi.nvidia.com/) (see [below](#v110-dev3)).
 - **v1.1.0-dev.2**: **Images:** `sglang-runtime:1.1.0-dev.2`, `tensorrtllm-runtime:1.1.0-dev.2`. **Wheels:** `ai-dynamo`, `ai-dynamo-runtime` on [pypi.nvidia.com](https://pypi.nvidia.com/) (see [below](#v110-dev2)).
 - **v1.1.0-dev.1**: **Images:** vLLM, SGLang, TRT-LLM runtime matrix (CUDA 12 / 13 and EFA variants as listed), `dynamo-frontend`, `kubernetes-operator`, `snapshot-agent`. **Wheels:** `ai-dynamo`, `ai-dynamo-runtime` on [pypi.nvidia.com](https://pypi.nvidia.com/). **Helm:** `dynamo-platform`, `snapshot` at `1.1.0-dev.1` (see [below](#v110-dev1)).
@@ -234,6 +234,7 @@ These crates use repository `https://github.com/ai-dynamo/dynamo.git`. The table
 
 | Version | Release Date | GitHub | Docs | Notes |
 |---------|--------------|--------|------|-------|
+| `v1.2.0-deepseek-v4-dev.3` | May 9, 2026 | [Tag](https://github.com/ai-dynamo/dynamo/releases/tag/v1.2.0-deepseek-v4-dev.3) | — | Experimental (DeepSeek-V4-Flash / V4-Pro Blackwell preview; vLLM + SGLang containers only) |
 | `v1.2.0-deepseek-v4-dev.2` | May 1, 2026 | [Tag](https://github.com/ai-dynamo/dynamo/releases/tag/v1.2.0-deepseek-v4-dev.2) | — | Experimental (DeepSeek-V4-Flash / V4-Pro Blackwell preview; vLLM + SGLang containers only) |
 | `v1.1.1` | May 5, 2026 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v1.1.1) | [Docs](https://docs.dynamo.nvidia.com/dynamo) | |
 | `v1.1.0` | May 1, 2026 | [Release](https://github.com/ai-dynamo/dynamo/releases/tag/v1.1.0) | [Docs](https://docs.dynamo.nvidia.com/dynamo) | |
@@ -699,6 +700,33 @@ pip install --pre --extra-index-url https://pypi.nvidia.com ai-dynamo==1.1.0.dev
 ```
 
 A GitHub or container tag `v1.1.0-dev.N` maps to a wheel version `1.1.0.devN` (for example `v1.1.0-dev.2` → `==1.1.0.dev2`). Optional extras such as `ai-dynamo[vllm]` use the same flags; pin the version you want from the sections below.
+
+### v1.2.0-deepseek-v4-dev.3
+
+- **Branch:** [release/1.2.0-deepseek-v4-dev.3](https://github.com/ai-dynamo/dynamo/tree/release/1.2.0-deepseek-v4-dev.3)
+- **GitHub Tag:** [v1.2.0-deepseek-v4-dev.3](https://github.com/ai-dynamo/dynamo/releases/tag/v1.2.0-deepseek-v4-dev.3)
+- **Backends:** vLLM `v0.20.1` (DSv4 stabilization patch over `v0.20.0` native DSv4 support) | SGLang upstream `lmsysorg/sglang:deepseek-v4-blackwell` preview (refreshed for dev.3) | NIXL `v0.10.1`
+- **Coverage:** Partial -- DeepSeek-V4-Flash and V4-Pro only. vLLM and SGLang containers are published for Blackwell (B200 plus GB200); no TensorRT-LLM container, no other component containers, no Helm charts, no wheels. Snapshot dev build for early-access V4 model support; not QA-gated.
+
+#### Container Images
+
+| Image:Tag | Backend | CUDA | Arch |
+|-----------|---------|------|------|
+| `vllm-runtime:1.2.0-deepseek-v4-cuda13-dev.3` | vLLM `v0.20.1` | `v13.0` | AMD64/ARM64 |
+| `sglang-runtime:1.2.0-deepseek-v4-cuda12-dev.3` | SGLang upstream DSv4 preview | `v12.9` | AMD64 |
+| `sglang-runtime:1.2.0-deepseek-v4-cuda13-dev.3` | SGLang upstream DSv4 preview | `v13.0` | ARM64 |
+
+#### Python Wheels
+
+Not published for this dev release. Use the `v1.1.1` wheels or `v1.1.0-dev.3` from [pypi.nvidia.com](https://pypi.nvidia.com/).
+
+#### Helm Charts
+
+Not published for this dev release. Use `v1.1.1` charts for platform install.
+
+#### Rust Crates
+
+Not shipped for pre-release versions.
 
 ### v1.2.0-deepseek-v4-dev.2
 

--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -11,7 +11,7 @@ subtitle: Hardware, software, and build compatibility for Dynamo
 
 **Latest stable release:** [v1.1.1](https://github.com/ai-dynamo/dynamo/releases/tag/v1.1.1) -- SGLang `0.5.10.post1` (NIXL `1.0.1`) | TensorRT-LLM `1.3.0rc11` (NIXL `0.10.1`) | vLLM `0.19.0` (NIXL `0.10.1`)
 
-**Experimental release:** [v1.2.0-deepseek-v4-dev.2](https://github.com/ai-dynamo/dynamo/releases/tag/v1.2.0-deepseek-v4-dev.2) *(DeepSeek-V4-Flash / V4-Pro on Blackwell, vLLM + SGLang containers only)* -- vLLM `0.20.0` | SGLang upstream `deepseek-v4-blackwell` preview | NIXL `0.10.1`
+**Experimental release:** [v1.2.0-deepseek-v4-dev.3](https://github.com/ai-dynamo/dynamo/releases/tag/v1.2.0-deepseek-v4-dev.3) *(DeepSeek-V4-Flash / V4-Pro on Blackwell, vLLM + SGLang containers only)* -- vLLM `0.20.1` | SGLang upstream `deepseek-v4-blackwell` preview | NIXL `0.10.1`
 
 | Requirement | Supported |
 | :--- | :--- |
@@ -32,6 +32,7 @@ The following table shows the backend framework versions included with each Dyna
 | **Dynamo** | **SGLang** | **TensorRT-LLM** | **vLLM** | **NIXL** |
 | :--- | :--- | :--- | :--- | :--- |
 | **main (ToT)** | `0.5.10.post1` | `1.3.0rc14` | `0.20.1` | `0.10.1` (TRT-LLM, vLLM); `1.0.1` (SGLang) |
+| **v1.2.0-deepseek-v4-dev.3** *(experimental, partial)* | upstream DSv4 preview | — | `0.20.1` | `0.10.1` |
 | **v1.2.0-deepseek-v4-dev.2** *(experimental, partial)* | upstream DSv4 preview | — | `0.20.0` | `0.10.1` |
 | **v1.1.1** | `0.5.10.post1` | `1.3.0rc11` | `0.19.0` | `0.10.1` (TRT-LLM, vLLM); `1.0.1` (SGLang) |
 | **v1.1.0** | `0.5.10.post1` | `1.3.0rc11` | `0.19.0` | `0.10.1` (TRT-LLM, vLLM); `1.0.1` (SGLang) |
@@ -55,7 +56,7 @@ The following table shows the backend framework versions included with each Dyna
 | **v0.6.1** | `0.5.3.post2` | `1.1.0rc5` | `0.11.0` | `0.6.0` |
 | **v0.6.0** | `0.5.3.post2` | `1.1.0rc5` | `0.11.0` | `0.6.0` |
 
-For **v1.1.0-dev.2**, **v1.1.0-dev.3**, and **v1.2.0-deepseek-v4-dev.2**, the cells above match `container/context.yaml` on the corresponding release branch (pins used to build images). Those lines are **partial releases**: not every backend has a published Dynamo runtime container for that tag. See [Pre-Release Artifacts](release-artifacts.md#pre-release-artifacts) for what actually shipped. The `v1.2.0-deepseek-v4-dev.2` SGLang container is built on the upstream `lmsysorg/sglang:deepseek-v4-blackwell` preview image rather than a tagged SGLang release; TensorRT-LLM is not part of that dev release.
+For **v1.1.0-dev.2**, **v1.1.0-dev.3**, **v1.2.0-deepseek-v4-dev.2**, and **v1.2.0-deepseek-v4-dev.3**, the cells above match `container/context.yaml` on the corresponding release branch (pins used to build images). Those lines are **partial releases**: not every backend has a published Dynamo runtime container for that tag. See [Pre-Release Artifacts](release-artifacts.md#pre-release-artifacts) for what actually shipped. The `v1.2.0-deepseek-v4-dev.2` and `v1.2.0-deepseek-v4-dev.3` SGLang containers are built on the upstream `lmsysorg/sglang:deepseek-v4-blackwell` preview image rather than a tagged SGLang release; TensorRT-LLM is not part of those dev releases.
 
 ### Version Labels
 
@@ -124,7 +125,7 @@ Dynamo container images include CUDA toolkit libraries. The host machine must ha
 
 Patch versions (e.g., v0.8.1.post1, v0.7.0.post1) have the same CUDA support as their base version.
 
-Experimental `v1.1.0-dev.*` images follow the same CUDA matrix as `v1.0.2`. The `v1.2.0-deepseek-v4-dev.2` vLLM container is CUDA 13.0 multi-arch; the SGLang containers split by arch (CUDA 12.9 on `amd64`, CUDA 13.0 on `arm64`).
+Experimental `v1.1.0-dev.*` images follow the same CUDA matrix as `v1.0.2`. The `v1.2.0-deepseek-v4-dev.3` vLLM container is CUDA 13.0 multi-arch; the SGLang containers split by arch (CUDA 12.9 on `amd64`, CUDA 13.0 on `arm64`).
 
 Experimental CUDA 13 images are not published for all versions. Check [Release Artifacts](release-artifacts.md) for availability.
 


### PR DESCRIPTION
## Overview

Mirrors #9356 (`recipes/deepseek-v4` dev.2 → dev.3 image refs) into the docs surface so `support-matrix` and `release-artifacts` reflect the current experimental DSv4 release.

## Details

The DSv4 dev.3 release (Snapshot dev build, May 9, 2026) ships:

- vLLM `0.20.1` (DSv4 stabilization patch over `0.20.0` native DSv4 support)
- SGLang upstream `lmsysorg/sglang:deepseek-v4-blackwell` (base refreshed for dev.3)
- NIXL `0.10.1` (unchanged)
- Containers: `vllm-runtime:1.2.0-deepseek-v4-cuda13-dev.3`, `sglang-runtime:1.2.0-deepseek-v4-{cuda12,cuda13}-dev.3`
- Recipes: GB200 vLLM agg/disagg for V4-Flash and V4-Pro, plus SGLang agg/disagg GB200 for V4-Pro
- No TensorRT-LLM container, no other component containers, no Helm charts, no wheels (consistent with dev.2 partial-release pattern)

CUDA matrix is unchanged from dev.2.

## Changes

### `docs/reference/support-matrix.md`

- **At-a-Glance experimental callout** (line 14) → dev.3, vLLM 0.20.1
- **Backend Dependencies table** (line 36) → new dev.3 row inserted above dev.2 (dev.2 retained as history)
- **Partial-releases note** (line 59) → dev.3 added to the partial-tag list and SGLang upstream caveat
- **CUDA matrix note** (line 128) → dev.2 → dev.3 reference; \`v1.0.2\` baseline left unchanged

### \`docs/reference/release-artifacts.md\`

- **Top-of-page Experimental banner** (line 20) → dev.3 link + anchor
- **Pre-Release Highlights bullet** (line 200) → dev.2 → dev.3 image list
- **GitHub Releases table** (line 237) → new dev.3 row inserted above dev.2 (dev.2 retained as history)
- **Pre-Release Artifacts section** (line 705) → new \`### v1.2.0-deepseek-v4-dev.3\` block inserted above the existing dev.2 section, mirroring its structure with dev.3 backends, containers, and unpublished-artifacts notes

History rows for dev.2 (Backend Dependencies table, GitHub Releases table, Pre-Release Artifacts section) are intentionally retained.

## Verification

- \`fern check\` → 0 errors
- \`detect_broken_links.py docs/reference/support-matrix.md docs/reference/release-artifacts.md\` → 0 broken links
- \`git diff --stat\` → 2 files changed, 34 insertions(+), 5 deletions(-) — exactly matches planned 4 inserts + 4 replacements per file
- \`rg\` audit → all remaining \`v1.2.0-deepseek-v4-dev.2\` references are in history rows (Backend Dependencies row, GitHub Releases row, Pre-Release Artifacts section, partial-releases note)

## Related

- ai-dynamo/dynamo#9356 (recipes dev.2 → dev.3)
- Release notes (TPM-internal): \`releases/deepseekv4/release_notes_v1.2.0-deepseek-v4-dev.3.md\`

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9358" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added experimental v1.2.0-deepseek-v4-dev.3 release documentation
  * Container images available (vLLM and SGLang with CUDA support)
  * Updated release artifacts and support matrix information
  * Note: No wheels, Helm charts, or Rust crates for this release

<!-- end of auto-generated comment: release notes by coderabbit.ai -->