### PR TITLE
test(parser): port over vLLM's tests (categories PARSER.batch.{2,4,5,6,7}.*), part 2

### DIFF
--- a/lib/parsers/PARSER_CASES.md
+++ b/lib/parsers/PARSER_CASES.md
@@ -133,6 +133,26 @@ Two or more calls in one response, in the same block or back-to-back.
   emit sequential top-level sentinels (JSON dialects). Either way,
   extract all.
 
+### Sub-cases
+
+vLLM's test corpus partitions multi-call coverage along call-structure
+axes — same-delta vs incremental, surrounding content, and ID/index
+distinctness. The bare bucket would collapse all of these into one
+parity cell; sub-cases preserve the distinction.
+
+- **`PARSER.batch.2.a`** Parallel calls (canonical batched). Two or
+  more calls present together in the same emission unit; harness
+  asserts each is extracted, and order matches input.
+- **`PARSER.batch.2.b`** Multi-invoke close-together. Calls arrive in
+  the same delta or in rapid sequential chunks; the parser's loop
+  must surface every closed invoke, not stop after the first.
+- **`PARSER.batch.2.c`** Multi-invoke with surrounding content. Normal
+  text wraps the call group (vs `batch.8`'s single-call interleaving);
+  asserts that the parser doesn't conflate text with subsequent calls.
+- **`PARSER.batch.2.d`** ID / index distinctness. Each emitted call
+  carries a unique `id` (or sequential index) — covers the surface
+  contract that downstream tool-result correlation depends on.
+
 ## `PARSER.batch.3` — No tool call
 
 Response is plain text, no tool-call grammar present.
@@ -155,6 +175,25 @@ arguments payload.
   parity tests should record divergences in their `KNOWN_DIVERGENCES`
   registry rather than asserting one truth.
 
+### Sub-cases
+
+The bare bucket lumped four distinct malformation classes together; vLLM's
+test corpus targets each separately and the recovery contract differs by
+class.
+
+- **`PARSER.batch.4.a`** Generic catch-all (no-crash). Random / arbitrary
+  garbage in the call body. Contract: parser must not panic; any output
+  shape is acceptable. This is the inherited common-suite shape.
+- **`PARSER.batch.4.b`** Invalid JSON syntax. Bad quote, extra/missing
+  comma, leaked delimiter chars inside an otherwise well-formed wrapper.
+  Tests the JSON-decoder fallback path (typically: surface as raw string).
+- **`PARSER.batch.4.c`** Missing structural keys. Wrapper is well-formed
+  but the body lacks `name` / `arguments` / `parameters`. Tests
+  field-validation surface (skip vs error vs partial extraction).
+- **`PARSER.batch.4.d`** Malformed wrapper / XML structure. Unclosed tags,
+  missing delimiters, mismatched fences. Tests the wrapper-parser layer
+  (vs the JSON-body layer in `.b`).
+
 ## `PARSER.batch.5` — Missing end-token recovery
 
 Model response is truncated before the closing fence arrives
@@ -170,6 +209,21 @@ or the model emitted EOS mid-generation.
   return an explicit error. Either way, pin the behavior with a test
   so a future change is intentional.
 
+### Sub-cases
+
+Three distinct truncation shapes with different recovery contracts:
+
+- **`PARSER.batch.5.a`** Missing closing tag. Open fence present,
+  matching close absent. The most common shape (model hit `max_tokens`
+  after emitting the call body but before the close fence).
+- **`PARSER.batch.5.b`** Missing opening tag. Close fence present
+  without a matching open — rare, but real (some grammars / streaming
+  edge cases). Most parsers no-op here; pin the behavior.
+- **`PARSER.batch.5.c`** Truncation / EOS mid-call. Stream ends
+  partway through the call body (mid-arguments, mid-name). The
+  recovery contract differs from `.a`/`.b`: the call body itself is
+  incomplete, not just the wrapper.
+
 ## `PARSER.batch.6` — Empty args
 
 Tool call with `arguments={}`, or a no-parameter invoke.
@@ -177,6 +231,22 @@ Tool call with `arguments={}`, or a no-parameter invoke.
 - Applies to every tool-call parser.
 - Must still return the call — empty args is a valid call, not a
   missing one.
+
+### Sub-cases
+
+vLLM's tests separate three empty-args shapes that look identical at
+the API but exercise different parser code paths.
+
+- **`PARSER.batch.6.a`** Canonical empty `{}`. Wrapper present,
+  arguments key with literal `{}` value. The inherited common-suite
+  baseline.
+- **`PARSER.batch.6.b`** Zero-arg formatting variants. Same call
+  shape as `.a` but with whitespace/newline variations (inline `{}`
+  vs newline `{\n}`, streaming-chunked emission). Tests parser
+  whitespace tolerance.
+- **`PARSER.batch.6.c`** No-args-key / parameterless. The
+  `arguments` key is absent entirely (vs explicit `{}`). Tests that
+  the parser treats missing-key as "no args" rather than "invalid".
 
 ## `PARSER.batch.7` — Complex argument types
 
@@ -189,6 +259,32 @@ values, and newlines inside argument values.
   type-coercion half lives under `PARSER.xml.2` instead — here just
   verify that complex values make it through without truncation or
   escape bugs.
+
+### Sub-cases
+
+vLLM's `batch.7` is the largest single bucket (58 rows) and naturally
+splits along four type-handling axes:
+
+- **`PARSER.batch.7.a`** Standard scalar / container types. Canonical
+  type matrix: int, float, bool, null, list, object. The inherited
+  common-suite shape — verifies the parser preserves JSON-typed values
+  (vs stringifying everything).
+- **`PARSER.batch.7.b`** Escaped / Unicode / special chars. String
+  escapes (`\n`, `\"`), Unicode preservation (no `\uXXXX` re-encoding),
+  HTML inside argument values. Tests the JSON-decoder boundary.
+- **`PARSER.batch.7.c`** Schema mismatch — string value where schema
+  declares a typed primitive. Input is `{"celsius": "20"}` while the
+  schema says `celsius: integer`. The contract pinned here is
+  *value-preservation*: most parsers surface the raw string `"20"`
+  as-is and leave coercion to a downstream layer; a few parsers
+  (e.g. vLLM's deepseek_v3_2) opt to coerce at the parser layer and
+  produce `20` (int) instead. The test asserts preservation
+  (Dynamo's behavior); schema-coercing impls show up as registered
+  divergences.
+- **`PARSER.batch.7.d`** Multi-arg / nested / quoted / split-across-chunks.
+  Multiple parameters in one call, deeply-nested arguments, quotes/
+  brackets inside string values, and primitives split across streaming
+  token boundaries. Tests the streaming-aware concatenation logic.
 
 ## `PARSER.batch.8` — Normal text interleaved with tool calls
 

--- a/tests/parity/README.md
+++ b/tests/parity/README.md
@@ -99,7 +99,7 @@ Both servers receive identical chat-completion requests with `structured_outputs
 | **Real tokenizer?** | yes | no | yes |
 | **Real chat template?** | yes | no | yes |
 | **Real HTTP?** | yes | no | yes |
-| **Cost** | (TBD) | ~3 s for 570 tests | ~60 s for 30 tests (server boot dominates) |
+| **Cost** | (TBD) | ~5 s for 1350 tests (693 pass / 545 skip / 112 xfail with sglang skipped locally) | ~60 s for 30 tests (server boot dominates) |
 | **GPU** | yes | none | yes (`--load-format dummy` still allocates ~2.5 GiB) |
 | **CI markers** | (TBD) | `unit, pre_merge, gpu_0` | `e2e, pre_merge, gpu_1` |
 
@@ -117,21 +117,15 @@ They're stacked diagnostics:
 
 ## Current parity status (M2, batch mode)
 
-Each row is a parser family; each column `bN` is
-[`PARSER.batch.N`](../../lib/parsers/PARSER_CASES.md):
-
-```
-b1   =  PARSER.batch.1   "single happy-path call"
-b2   =  PARSER.batch.2   "multiple calls"
-b3   =  PARSER.batch.3   "no tool call (plain text)"
-b4   =  PARSER.batch.4   "malformed JSON args"
-b5   =  PARSER.batch.5   "missing end-token recovery"
-b6   =  PARSER.batch.6   "empty args (no-arg call)"
-b7   =  PARSER.batch.7   "complex args (nested JSON / arrays)"
-b8   =  PARSER.batch.8   "interleaved normal text"
-b9   =  PARSER.batch.9   "empty input"
-b10  =  PARSER.batch.10  "duplicate calls (same name twice)"
-```
+Each row is one **parser** (one family of input wire format). Each row
+also names the **model(s)** that parser is wired up for — many parsers
+serve more than one model (e.g. `mistral` covers the Mistral series,
+`hermes` covers Hermes-3 + various Llama variants). Columns are the
+sub-case IDs from [`PARSER_CASES.md`](../../lib/parsers/PARSER_CASES.md):
+top-level buckets (`1`, `3`, `9`, `10`) have no sub-cases and use a
+single column; the other buckets (`2`, `4`, `5`, `6`, `7`, `8`) split
+into `.a`–`.d` sub-cases per the per-bucket axes documented in the
+PR description.
 
 Cell values show divergence from Dynamo (the oracle):
 
@@ -139,36 +133,38 @@ Cell values show divergence from Dynamo (the oracle):
 - `V` — vLLM diverges (xfailed via `KNOWN_DIVERGENCES`).
 - `S` — SGLang diverges.
 - `VS` — both diverge.
-- `n/a` — no peer parser registered for that family.
+- `n/a` — **not applicable**: no peer parser registered for that
+  family, OR the sub-case shape doesn't apply to this grammar (e.g.
+  attribute-encoded DSML families have no `4.b` because there's no
+  embedded JSON to malform).
 
-19 parser families total — split into the **Top-N models** we prioritize
-(rows tagged with the model name in parens) and **Others** that aren't
-top-N today but are wired into the harness for completeness. Both sections
-sorted alphabetically within themselves.
+19 parsers total — split into the **Top-N models** we prioritize and
+**Others** wired into the harness for completeness. Both sections sorted
+alphabetically within themselves.
 
-| family                          |  b1 |  b2 |  b3 |  b4 |  b5 |  b6 |  b7 |  b8 |  b9 | b10 |
-|---------------------------------|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-| **Top-N models**                |     |     |     |     |     |     |     |     |     |     |
-| deepseek_v4 § (DeepSeek V4)     | ✓   | ✓   | ✓   | ✓   | V   | ✓   | V   | ✓   | ✓   | ✓   |
-| gemma4 § (Gemma 4)              | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | V   | ✓   | ✓   |
-| glm47 (GLM 5.1)                 | ✓   | ✓   | ✓   | ✓   | VS  | ✓   | ✓   | V   | ✓   | ✓   |
-| harmony † (gpt-oss)             | S   | S   | ✓   | S   | S   | S   | S   | S   | ✓   | S   |
-| kimi_k2 (Kimi K2.6)             | ✓   | ✓   | ✓   | S   | ✓   | ✓   | ✓   | VS  | ✓   | ✓   |
-| minimax_m2 (MiniMax 2.7)        | ✓   | ✓   | ✓   | V   | VS  | ✓   | ✓   | ✓   | ✓   | ✓   |
-| nemotron_deci †§ (Nemotron)     | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a |
-| qwen3_coder (Qwen 3.5)          | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   |
-| **Others**                      |     |     |     |     |     |     |     |     |     |     |
-| deepseek_v3                     | ✓   | ✓   | ✓   | V   | VS  | ✓   | ✓   | S   | ✓   | ✓   |
-| deepseek_v3_1                   | ✓   | ✓   | ✓   | V   | VS  | ✓   | ✓   | S   | ✓   | ✓   |
-| deepseek_v3_2                   | ✓   | ✓   | ✓   | ✓   | V   | ✓   | V   | S   | ✓   | ✓   |
-| hermes                          | ✓   | ✓   | ✓   | VS  | ✓   | ✓   | ✓   | V   | ✓   | ✓   |
-| jamba §                         | ✓   | ✓   | ✓   | ✓   | V   | ✓   | ✓   | V   | ✓   | ✓   |
-| llama3_json §                   | ✓   | V   | ✓   | V   | V   | ✓   | ✓   | ✓   | ✓   | V   |
-| mistral                         | S   | S   | ✓   | VS  | S   | S   | S   | VS  | ✓   | S   |
-| nemotron_nano †§                | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a |
-| phi4 §                          | ✓   | ✓   | ✓   | ✓   | V   | ✓   | V   | V   | ✓   | ✓   |
-| pythonic                        | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | ✓   | VS  | ✓   | ✓   |
-| qwen25 †                        | S   | S   | ✓   | S   | S   | S   | S   | S   | ✓   | S   |
+| model | parser | 1 | 2.a | 2.b | 2.c | 2.d | 3 | 4.a | 4.b | 4.c | 4.d | 5.a | 5.b | 5.c | 6.a | 6.b | 6.c | 7.a | 7.b | 7.c | 7.d | 8.a | 8.b | 8.c | 8.d | 9 | 10 |
+|---|---|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
+| **Top-N models** |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
+| DeepSeek V4 | deepseek_v4 § | ✓ | ✓ | V | V | ✓ | ✓ | V | n/a | V | ✓ | V | ✓ | V | ✓ | ✓ | n/a | V | ✓ | n/a | n/a | ✓ | V | V | V | ✓ | ✓ |
+| Gemma 4 | gemma4 § | ✓ | ✓ | n/a | V | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | V | V | V | ✓ | ✓ |
+| GLM 5.1 | glm47 | ✓ | ✓ | n/a | V | ✓ | ✓ | VS | n/a | n/a | ✓ | VS | ✓ | VS | ✓ | S | n/a | ✓ | ✓ | n/a | n/a | V | V | V | V | ✓ | ✓ |
+| gpt-oss | harmony † | S | S | n/a | S | S | ✓ | S | S | ✓ | n/a | S | ✓ | S | S | S | ✓ | S | S | S | S | S | S | S | S | ✓ | S |
+| Kimi K2.6 | kimi_k2 | ✓ | ✓ | ✓ | VS | ✓ | ✓ | ✓ | S | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | VS | VS | VS | VS | ✓ | ✓ |
+| MiniMax 2.7 | minimax_m2 | ✓ | ✓ | S | S | ✓ | ✓ | V | n/a | V | V | VS | ✓ | VS | ✓ | ✓ | n/a | V | ✓ | n/a | n/a | ✓ | S | S | S | ✓ | ✓ |
+| Nemotron (DeciLM) | nemotron_deci †§ | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a |
+| Qwen 3 Coder | qwen3_coder | ✓ | ✓ | n/a | ✓ | ✓ | ✓ | V | n/a | n/a | ✓ | ✓ | V | ✓ | ✓ | ✓ | n/a | VS | ✓ | n/a | n/a | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| **Others** |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
+| DeepSeek V3 | deepseek_v3 | ✓ | ✓ | ✓ | S | ✓ | ✓ | VS | V | VS | VS | VS | ✓ | VS | ✓ | V | V | ✓ | ✓ | ✓ | ✓ | S | ✓ | S | S | ✓ | ✓ |
+| DeepSeek V3.1 | deepseek_v3_1 | ✓ | ✓ | ✓ | S | ✓ | ✓ | VS | V | VS | VS | VS | ✓ | VS | ✓ | ✓ | V | ✓ | ✓ | ✓ | ✓ | S | ✓ | S | S | ✓ | ✓ |
+| DeepSeek V3.2 | deepseek_v3_2 | ✓ | ✓ | VS | VS | ✓ | ✓ | V | n/a | V | ✓ | V | ✓ | V | ✓ | ✓ | n/a | V | ✓ | n/a | n/a | S | VS | VS | VS | ✓ | ✓ |
+| Hermes-3 / Llama variants | hermes | ✓ | ✓ | n/a | V | ✓ | ✓ | ✓ | VS | S | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | S | ✓ | ✓ | ✓ | ✓ | V | ✓ | V | V | ✓ | ✓ |
+| AI21 Jamba | jamba § | ✓ | ✓ | n/a | V | ✓ | ✓ | ✓ | ✓ | V | V | V | ✓ | ✓ | ✓ | ✓ | V | ✓ | ✓ | ✓ | ✓ | V | ✓ | V | V | ✓ | ✓ |
+| Llama 3 (JSON fmt) | llama3_json § | ✓ | V | n/a | V | V | ✓ | V | V | V | n/a | V | n/a | V | ✓ | ✓ | V | ✓ | ✓ | ✓ | ✓ | V | ✓ | V | V | ✓ | V |
+| Mistral series | mistral | S | S | n/a | VS | S | ✓ | VS | VS | V | S | S | ✓ | VS | S | S | V | S | S | S | S | VS | S | VS | V | ✓ | S |
+| Nemotron Nano | nemotron_nano †§ | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a |
+| Phi-4 | phi4 § | ✓ | ✓ | n/a | V | ✓ | ✓ | ✓ | ✓ | V | V | V | V | V | ✓ | ✓ | V | ✓ | ✓ | ✓ | V | V | ✓ | V | V | ✓ | ✓ |
+| Llama 4 (pythonic fmt) | pythonic | ✓ | ✓ | n/a | VS | ✓ | ✓ | ✓ | ✓ | n/a | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | n/a | ✓ | ✓ | ✓ | ✓ | VS | VS | VS | VS | ✓ | ✓ |
+| Qwen 2.5 | qwen25 † | S | S | n/a | S | S | ✓ | ✓ | S | ✓ | S | S | ✓ | ✓ | S | S | ✓ | S | S | S | S | S | S | S | S | ✓ | S |
 
 ### Footnotes
 
@@ -182,9 +178,6 @@ sorted alphabetically within themselves.
 upstream has a peer parser, so the rows are fully `n/a`. Listed here for
 completeness; Dynamo-only self-parity could be added in a follow-up but
 yields no cross-impl signal.
-
-Tally (excluding `dynamo` since it's the oracle): 380 cells against
-the YAML expected — 203 parity, 67 divergence (xfailed), 110 n/a.
 
 **Hot columns:**
 - `PARSER.batch.4` (malformed JSON) and `PARSER.batch.5` (missing
@@ -447,34 +440,25 @@ cases:
       normal_text: ''
   PARSER.batch.8.a:                    # sub-case keys also valid
     description: Narration before tool call only
-    ref: https://github.com/vllm-project/vllm/blob/<sha>/tests/tool_parsers/test_<family>_tool_parser.py#L<line>
+    ref: originated from https://github.com/vllm-project/vllm/blob/<sha>/tests/tool_parsers/test_<family>_tool_parser.py#L<line>
     model_text: |-
       ...
 ```
 
 The `ref` field is required on per-sub-case files
-(`PARSER.<mode>.<n>.yaml`) and takes one of three forms, distinguishing
-how strongly the fixture is tied to upstream:
+(`PARSER.<mode>.<n>.yaml`) and takes one of two forms:
 
-- **`ref: inspired-by <url>`** — there's an upstream test exercising
-  this same shape on this same family, but the fixture's `model_text`
-  is freshly authored (templated narration, consistent function/args
-  across families) rather than copied verbatim. The URL points back at
-  the upstream test for traceability. Most cases that have an upstream
-  analogue land here.
-- **`ref: ported-from <url>`** — the fixture's `model_text` is a
-  verbatim (or minimally-adapted) copy of the upstream test's input.
-  Rare; reserve for when the wire format is intricate enough that
-  byte-equivalence matters and we want the upstream link to be a
-  literal source-of-truth.
+- **`ref: originated from <url>`** — there's an upstream test exercising
+  this same shape on this same family. The fixture's `model_text` may
+  be freshly authored (templated narration, consistent function/args
+  across families) rather than copied verbatim, but the shape is
+  directly traceable to the linked upstream test. The URL names the
+  impl: `vllm-project/vllm` → vLLM, `sgl-project/sglang` → SGLang.
 - **`ref: dynamo`** — authored fresh in this repo, no upstream peer.
   Most sub-case taxonomy fillers (`.b` post-only, `.d` between-calls)
   land here because vLLM/SGLang don't test those shapes.
 
-The URL form (`inspired-by` / `ported-from`) names the impl in the URL
-itself: `vllm-project/vllm` → vLLM, `sgl-project/sglang` → SGLang.
-
-Every sub-case carries one of these three states; there's no "no
+Every sub-case carries one of these two states; there's no "no
 provenance" state. The legacy flat `PARSER.<mode>.yaml` (cases without
 sub-cases) does NOT carry `ref` — those entries predate the convention.
 
@@ -519,6 +503,26 @@ wire formats (XML-style families, harmony) read as the actual text
 the model would emit, not a `\n`-escaped one-liner. UTF-8 with
 `allow_unicode=True`, so DeepSeek special tokens (`｜` U+FF5C, `▁`
 U+2581) appear as literal characters rather than escape sequences.
+
+A side-effect of letting pyyaml choose the best block-scalar header
+for every value: `normal_text` occasionally emits as the
+unusual-looking `|2+`. Decoding this in three pieces:
+
+- `|` — literal block scalar (preserve newlines as written).
+- `2` — explicit indent indicator: "content is indented 2 spaces."
+  pyyaml normally auto-detects indent from the first content line;
+  it falls back to the explicit form when the body is blank-only
+  and there's nothing to detect from.
+- `+` — "keep" chomping: preserve all trailing newlines (`-` strips
+  them, no indicator clips to one).
+
+So `|2+` followed by one blank line decodes to `"\n"` — a single
+newline. It shows up where the divergence between Dynamo and an
+upstream impl is literally one inter-wrapper newline character (e.g.
+back-to-back `</tool_calls>` / `<tool_calls>` fence pairs where
+Dynamo treats the `\n` between them as `normal_text` and the impl
+treats it as part of the wrapper). pyyaml round-trips the value to
+its canonical form; the header looks cryptic but it's just `"\n"`.
 
 ## Why families' YAMLs look so similar (and why that's the point)
 

--- a/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.2.yaml
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: deepseek_v3
+mode: batch
+cases:
+  PARSER.batch.2.a:
+    description: Parallel calls in single fence pair
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L185
+    model_text: |-
+      <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+      ```json
+      {"location": "NYC"}
+      ```<｜tool▁call▁end｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_time
+      ```json
+      {"timezone": "EST"}
+      ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - &id002
+      name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
+  PARSER.batch.2.b:
+    description: Two back-to-back fence pairs
+    ref: dynamo
+    model_text: |-
+      <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+      ```json
+      {"location": "NYC"}
+      ```<｜tool▁call▁end｜><｜tool▁calls▁end｜><｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_time
+      ```json
+      {"timezone": "EST"}
+      ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    tools:
+    - *id001
+    - *id002
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
+  PARSER.batch.2.c:
+    description: With surrounding narration
+    ref: dynamo
+    model_text: |-
+      Both: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+      ```json
+      {"location": "NYC"}
+      ```<｜tool▁call▁end｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_time
+      ```json
+      {"timezone": "EST"}
+      ```<｜tool▁call▁end｜><｜tool▁calls▁end｜> Done.
+    tools:
+    - *id001
+    - *id002
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: 'Both: '
+  PARSER.batch.2.d:
+    description: Same-name twice
+    ref: dynamo
+    model_text: |-
+      <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+      ```json
+      {"location": "NYC"}
+      ```<｜tool▁call▁end｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+      ```json
+      {"location": "LA"}
+      ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    tools:
+    - *id001
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''

--- a/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.4.yaml
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: deepseek_v3
+mode: batch
+cases:
+  PARSER.batch.4.a:
+    description: Garbage between calls fences
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L322
+    model_text: <｜tool▁calls▁begin｜>nonsense<｜tool▁calls▁end｜>
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls: []
+      normal_text: <｜tool▁calls▁begin｜>nonsense<｜tool▁calls▁end｜>
+    # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
+    # vllm produces:
+    #   calls: []
+    #   normal_text: None
+  PARSER.batch.4.b:
+    description: Missing close brace inside fenced JSON
+    ref: dynamo
+    model_text: |-
+      <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+      ```json
+      {"location": "NYC"
+      ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: |-
+        <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+        ```json
+        {"location": "NYC"
+        ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
+    # vllm produces:
+    #   calls: [{'name': 'get_weather', 'arguments': '{"location": "NYC"'}]
+    #   normal_text: None
+  PARSER.batch.4.c:
+    description: Missing function name token
+    ref: dynamo
+    model_text: |-
+      <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>
+      ```json
+      {"location": "NYC"}
+      ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: |-
+        <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>
+        ```json
+        {"location": "NYC"}
+        ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
+    # vllm produces:
+    #   calls: [{'name': '', 'arguments': {'location': 'NYC'}}]
+    #   normal_text: None
+  PARSER.batch.4.d:
+    description: Missing fenced JSON block (no ```json)
+    ref: dynamo
+    model_text: |-
+      <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+      {"location": "NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+    # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
+    # vllm produces:
+    #   calls: []
+    #   normal_text: None

--- a/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.5.yaml
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: deepseek_v3
+mode: batch
+cases:
+  PARSER.batch.5.a:
+    description: Missing calls_end / call_end markers
+    ref: dynamo
+    model_text: |-
+      <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+      ```json
+      {"location": "NYC"}
+      ```
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls: []
+      normal_text: |-
+        <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+        ```json
+        {"location": "NYC"}
+        ```
+    # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
+    # vllm produces:
+    #   calls: []
+    #   normal_text: None
+  PARSER.batch.5.b:
+    description: Closing tool_calls_end without matching tool_calls_begin
+    ref: dynamo
+    model_text: |-
+      <｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+      ```json
+      {"location": "NYC"}
+      ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: |-
+        <｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+        ```json
+        {"location": "NYC"}
+        ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+  PARSER.batch.5.c:
+    description: Truncation mid-arguments JSON inside fenced block
+    ref: dynamo
+    model_text: |-
+      <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+      ```json
+      {"loc
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: |-
+        <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+        ```json
+        {"loc
+    # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
+    # vllm produces:
+    #   calls: []
+    #   normal_text: None

--- a/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.6.yaml
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: deepseek_v3
+mode: batch
+cases:
+  PARSER.batch.6.a:
+    description: Canonical empty {} in fenced code block
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L260
+    model_text: |-
+      <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_time
+      ```json
+      {}
+      ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    tools:
+    - &id001
+      name: get_time
+      parameters:
+        type: object
+        properties: {}
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.6.b:
+    description: Whitespace inside empty { } (newlines)
+    ref: dynamo
+    model_text: |-
+      <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_time
+      ```json
+      {
+      }
+      ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+    # TODO(research): vllm diverges — vLLM rejects whitespace inside empty {} when wrapped in fenced ```json``` block
+    # vllm produces:
+    #   calls: []
+    #   normal_text: None
+  PARSER.batch.6.c:
+    description: No fenced JSON block (function name only)
+    ref: dynamo
+    model_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_time<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_time<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    # TODO(research): vllm diverges — both return calls=[]; vLLM nullifies normal_text on this recovery path, Dynamo preserves the raw input as normal_text
+    # vllm produces:
+    #   calls: []
+    #   normal_text: None

--- a/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.7.yaml
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: deepseek_v3
+mode: batch
+cases:
+  PARSER.batch.7.a:
+    description: Standard scalar types
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L220
+    model_text: |-
+      <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>book_flight
+      ```json
+      {"destination": "Paris", "passengers": 2, "first_class": true}
+      ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    tools:
+    - name: book_flight
+      parameters:
+        type: object
+        properties:
+          destination:
+            type: string
+          passengers:
+            type: integer
+          first_class:
+            type: boolean
+    expected:
+      calls:
+      - name: book_flight
+        arguments:
+          destination: Paris
+          passengers: 2
+          first_class: true
+      normal_text: ''
+  PARSER.batch.7.b:
+    description: Unicode + escaped chars
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L302
+    model_text: |-
+      <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+      ```json
+      {"location": "Tōkyō \"central\""}
+      ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Tōkyō "central"
+      normal_text: ''
+  PARSER.batch.7.c:
+    description: Schema mismatch — string value where schema declares integer
+    ref: dynamo
+    model_text: |-
+      <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>set_temperature
+      ```json
+      {"celsius": "20"}
+      ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    tools:
+    - name: set_temperature
+      parameters:
+        type: object
+        properties:
+          celsius:
+            type: integer
+    expected:
+      calls:
+      - name: set_temperature
+        arguments:
+          celsius: '20'
+      normal_text: ''
+  PARSER.batch.7.d:
+    description: Nested object + array (existing)
+    ref: dynamo
+    model_text: |-
+      <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>process_data
+      ```json
+      {"items": [1, 2, 3], "config": {"nested": true}}
+      ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    tools:
+    - name: process_data
+      parameters:
+        type: object
+        properties:
+          items:
+            type: array
+          config:
+            type: object
+    expected:
+      calls:
+      - name: process_data
+        arguments:
+          items:
+          - 1
+          - 2
+          - 3
+          config:
+            nested: true
+      normal_text: ''

--- a/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.8.yaml
@@ -44,7 +44,7 @@ cases:
       normal_text: ''
   PARSER.batch.8.c:
     description: Narration both before and after (sandwich)
-    ref: inspired-by https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L282
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L282
     model_text: |-
       I will check the weather. <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
       ```json

--- a/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.yaml
@@ -25,33 +25,6 @@ cases:
         arguments:
           location: NYC
       normal_text: ''
-  PARSER.batch.2:
-    description: Multiple tool calls (parallel)
-    model_text: |-
-      <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
-      ```json
-      {"location": "NYC"}
-      ```<｜tool▁call▁end｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_time
-      ```json
-      {"timezone": "EST"}
-      ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
-    tools:
-    - *id001
-    - name: get_time
-      parameters:
-        type: object
-        properties:
-          timezone:
-            type: string
-    expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: ''
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
@@ -60,82 +33,6 @@ cases:
     expected:
       calls: []
       normal_text: Hello, how can I help you today?
-  PARSER.batch.4:
-    description: Malformed JSON args (missing close brace)
-    model_text: |-
-      <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
-      ```json
-      {"location": "NYC"
-      ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
-    tools:
-    - *id001
-    expected:
-      calls: []
-      normal_text: |-
-        <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
-        ```json
-        {"location": "NYC"
-        ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
-  PARSER.batch.5:
-    description: Missing calls_end / call_end markers
-    model_text: |-
-      <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
-      ```json
-      {"location": "NYC"}
-      ```
-    tools:
-    - *id001
-    expected:
-      calls: []
-      normal_text: |-
-        <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
-        ```json
-        {"location": "NYC"}
-        ```
-  PARSER.batch.6:
-    description: Empty args (no-arg call)
-    model_text: |-
-      <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_time
-      ```json
-      {}
-      ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
-    tools:
-    - name: get_time
-      parameters:
-        type: object
-        properties: {}
-    expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
-  PARSER.batch.7:
-    description: Complex args (nested object + array)
-    model_text: |-
-      <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>process_data
-      ```json
-      {"items": [1, 2, 3], "config": {"nested": true}}
-      ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
-    tools:
-    - name: process_data
-      parameters:
-        type: object
-        properties:
-          items:
-            type: array
-          config:
-            type: object
-    expected:
-      calls:
-      - name: process_data
-        arguments:
-          items:
-          - 1
-          - 2
-          - 3
-          config:
-            nested: true
-      normal_text: ''
   PARSER.batch.9:
     description: Empty input
     model_text: ''

--- a/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.2.yaml
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: deepseek_v3_1
+mode: batch
+cases:
+  PARSER.batch.2.a:
+    description: Parallel calls in single fence pair
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_deepseekv31_tool_parser.py#L39
+    model_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_time<｜tool▁sep｜>{"timezone":"EST"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - &id002
+      name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
+  PARSER.batch.2.b:
+    description: Two back-to-back fence pairs
+    ref: dynamo
+    model_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜><｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_time<｜tool▁sep｜>{"timezone":"EST"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    tools:
+    - *id001
+    - *id002
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
+  PARSER.batch.2.c:
+    description: Parallel with surrounding narration
+    ref: dynamo
+    model_text: 'Both: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_time<｜tool▁sep｜>{"timezone":"EST"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+      Results.'
+    tools:
+    - *id001
+    - *id002
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: 'Both: '
+  PARSER.batch.2.d:
+    description: Same-name twice (id distinctness)
+    ref: dynamo
+    model_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"LA"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    tools:
+    - *id001
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''

--- a/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.4.yaml
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: deepseek_v3_1
+mode: batch
+cases:
+  PARSER.batch.4.a:
+    description: Garbage between calls fences (no tool_sep / args)
+    ref: dynamo
+    model_text: <｜tool▁calls▁begin｜>nonsense<｜tool▁calls▁end｜>
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls: []
+      normal_text: <｜tool▁calls▁begin｜>nonsense<｜tool▁calls▁end｜>
+    # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
+    # vllm produces:
+    #   calls: []
+    #   normal_text: None
+  PARSER.batch.4.b:
+    description: Unterminated JSON string in args
+    ref: dynamo
+    model_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
+    # vllm produces:
+    #   calls: [{'name': 'get_weather', 'arguments': '{"location":"NYC'}]
+    #   normal_text: None
+  PARSER.batch.4.c:
+    description: Missing function name (no token before tool_sep)
+    ref: dynamo
+    model_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜><｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜><｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
+    # vllm produces:
+    #   calls: [{'name': '', 'arguments': {'location': 'NYC'}}]
+    #   normal_text: None
+  PARSER.batch.4.d:
+    description: Mismatched fences (calls_end without call_end)
+    ref: dynamo
+    model_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁calls▁end｜>
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁calls▁end｜>
+    # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
+    # vllm produces:
+    #   calls: []
+    #   normal_text: None

--- a/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.5.yaml
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: deepseek_v3_1
+mode: batch
+cases:
+  PARSER.batch.5.a:
+    description: Missing tool_calls_end (truncation)
+    ref: dynamo
+    model_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜>
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls: []
+      normal_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜>
+    # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
+    # vllm produces:
+    #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}]
+    #   normal_text: None
+  PARSER.batch.5.b:
+    description: Closing tool_calls_end without matching tool_calls_begin
+    ref: dynamo
+    model_text: <｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: <｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+  PARSER.batch.5.c:
+    description: Truncation mid-arguments JSON
+    ref: dynamo
+    model_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"loc
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"loc
+    # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
+    # vllm produces:
+    #   calls: []
+    #   normal_text: None

--- a/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.6.yaml
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: deepseek_v3_1
+mode: batch
+cases:
+  PARSER.batch.6.a:
+    description: Canonical empty {} after tool_sep
+    ref: dynamo
+    model_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_time<｜tool▁sep｜>{}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    tools:
+    - &id001
+      name: get_time
+      parameters:
+        type: object
+        properties: {}
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.6.b:
+    description: Whitespace inside empty { }
+    ref: dynamo
+    model_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_time<｜tool▁sep｜>{ }<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.6.c:
+    description: No tool_sep / args section
+    ref: dynamo
+    model_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_time<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_time<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    # TODO(research): vllm diverges — both return calls=[]; vLLM nullifies normal_text on this recovery path, Dynamo preserves the raw input as normal_text
+    # vllm produces:
+    #   calls: []
+    #   normal_text: None

--- a/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.7.yaml
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: deepseek_v3_1
+mode: batch
+cases:
+  PARSER.batch.7.a:
+    description: Standard scalar types
+    ref: dynamo
+    model_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>book_flight<｜tool▁sep｜>{"destination":"Paris","passengers":2,"first_class":true}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    tools:
+    - name: book_flight
+      parameters:
+        type: object
+        properties:
+          destination:
+            type: string
+          passengers:
+            type: integer
+          first_class:
+            type: boolean
+    expected:
+      calls:
+      - name: book_flight
+        arguments:
+          destination: Paris
+          passengers: 2
+          first_class: true
+      normal_text: ''
+  PARSER.batch.7.b:
+    description: Unicode + escaped chars
+    ref: dynamo
+    model_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"Tōkyō \"central\""}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Tōkyō "central"
+      normal_text: ''
+  PARSER.batch.7.c:
+    description: Schema mismatch — string value where schema declares integer
+    ref: dynamo
+    model_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>set_temperature<｜tool▁sep｜>{"celsius":"20"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    tools:
+    - name: set_temperature
+      parameters:
+        type: object
+        properties:
+          celsius:
+            type: integer
+    expected:
+      calls:
+      - name: set_temperature
+        arguments:
+          celsius: '20'
+      normal_text: ''
+  PARSER.batch.7.d:
+    description: Nested object + array (existing)
+    ref: dynamo
+    model_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>process_data<｜tool▁sep｜>{"items":[1,2,3],"config":{"nested":true}}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+    tools:
+    - name: process_data
+      parameters:
+        type: object
+        properties:
+          items:
+            type: array
+          config:
+            type: object
+    expected:
+      calls:
+      - name: process_data
+        arguments:
+          items:
+          - 1
+          - 2
+          - 3
+          config:
+            nested: true
+      normal_text: ''

--- a/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.yaml
@@ -21,26 +21,6 @@ cases:
         arguments:
           location: NYC
       normal_text: ''
-  PARSER.batch.2:
-    description: Multiple tool calls
-    model_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_time<｜tool▁sep｜>{"timezone":"EST"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
-    tools:
-    - *id001
-    - name: get_time
-      parameters:
-        type: object
-        properties:
-          timezone:
-            type: string
-    expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: ''
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
@@ -49,58 +29,6 @@ cases:
     expected:
       calls: []
       normal_text: Hello, how can I help you today?
-  PARSER.batch.4:
-    description: Malformed JSON inside call
-    model_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC<｜tool▁call▁end｜><｜tool▁calls▁end｜>
-    tools:
-    - *id001
-    expected:
-      calls: []
-      normal_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC<｜tool▁call▁end｜><｜tool▁calls▁end｜>
-  PARSER.batch.5:
-    description: Missing tool_calls_end (truncation)
-    model_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜>
-    tools:
-    - *id001
-    expected:
-      calls: []
-      normal_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜>
-  PARSER.batch.6:
-    description: Empty args (no-arg call)
-    model_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_time<｜tool▁sep｜>{}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
-    tools:
-    - name: get_time
-      parameters:
-        type: object
-        properties: {}
-    expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
-  PARSER.batch.7:
-    description: Complex args (nested object + array)
-    model_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>process_data<｜tool▁sep｜>{"items":[1,2,3],"config":{"nested":true}}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
-    tools:
-    - name: process_data
-      parameters:
-        type: object
-        properties:
-          items:
-            type: array
-          config:
-            type: object
-    expected:
-      calls:
-      - name: process_data
-        arguments:
-          items:
-          - 1
-          - 2
-          - 3
-          config:
-            nested: true
-      normal_text: ''
   PARSER.batch.9:
     description: Empty input
     model_text: ''

--- a/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.2.yaml
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# `|2+` simply means a single newline ("\n"); see tests/parity/README.md for the full decode.
+
+family: deepseek_v3_2
+mode: batch
+cases:
+  PARSER.batch.2.a:
+    description: Two invokes inside one function_calls wrapper
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_deepseekv32_tool_parser.py#L172
+    # `|-` = literal block scalar, strip trailing newline (multi-line text as-is)
+    model_text: |-
+      <｜DSML｜function_calls>
+      <｜DSML｜invoke name="get_weather">
+      <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+      </｜DSML｜invoke>
+      <｜DSML｜invoke name="get_time">
+      <｜DSML｜parameter name="timezone" string="true">EST</｜DSML｜parameter>
+      </｜DSML｜invoke>
+      </｜DSML｜function_calls>
+    tools:
+    # `&idN` defines an anchor; `*idN` below reuses the same tool def
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - &id002
+      name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
+  PARSER.batch.2.b:
+    description: Two back-to-back function_calls wrappers
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_deepseekv32_tool_parser.py#L327
+    model_text: |-
+      <｜DSML｜function_calls>
+      <｜DSML｜invoke name="get_weather">
+      <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+      </｜DSML｜invoke>
+      </｜DSML｜function_calls>
+      <｜DSML｜function_calls>
+      <｜DSML｜invoke name="get_time">
+      <｜DSML｜parameter name="timezone" string="true">EST</｜DSML｜parameter>
+      </｜DSML｜invoke>
+      </｜DSML｜function_calls>
+    tools:
+    - *id001
+    - *id002
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      # `|2+` below = "\n" (see file header)
+      normal_text: |2+
+
+    # TODO(research): vllm diverges — vLLM deepseek_v3_2 does not restart parsing on a second back-to-back fence pair
+    # vllm produces:
+    #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}, {'name': 'get_time', 'arguments': {'timezone': 'EST'}}]
+    #   normal_text: None
+  PARSER.batch.2.c:
+    description: With surrounding narration
+    ref: dynamo
+    model_text: |-
+      Both: <｜DSML｜function_calls>
+      <｜DSML｜invoke name="get_weather">
+      <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+      </｜DSML｜invoke>
+      <｜DSML｜invoke name="get_time">
+      <｜DSML｜parameter name="timezone" string="true">EST</｜DSML｜parameter>
+      </｜DSML｜invoke>
+      </｜DSML｜function_calls> Done.
+    tools:
+    - *id001
+    - *id002
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: 'Both:  Done.'
+    # TODO(research): vllm diverges — drops trailing normal_text after tool-call wrapper end
+    # vllm produces:
+    #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}, {'name': 'get_time', 'arguments': {'timezone': 'EST'}}]
+    #   normal_text: 'Both: '
+  PARSER.batch.2.d:
+    description: Same-name twice
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_deepseekv32_tool_parser.py#L370
+    model_text: |-
+      <｜DSML｜function_calls>
+      <｜DSML｜invoke name="get_weather">
+      <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+      </｜DSML｜invoke>
+      <｜DSML｜invoke name="get_weather">
+      <｜DSML｜parameter name="location" string="true">LA</｜DSML｜parameter>
+      </｜DSML｜invoke>
+      </｜DSML｜function_calls>
+    tools:
+    - *id001
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''

--- a/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.4.yaml
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: deepseek_v3_2
+mode: batch
+cases:
+  PARSER.batch.4.a:
+    description: Function_calls wrapper with garbage
+    ref: dynamo
+    model_text: |-
+      <｜DSML｜function_calls>
+      not a valid invoke
+      </｜DSML｜function_calls>
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls: []
+      normal_text: ''
+    # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
+    # vllm produces:
+    #   calls: []
+    #   normal_text: '<｜DSML｜function_calls>\nnot a valid invoke\n</｜DSML｜function_calls>'
+  # PARSER.batch.4.b (invalid JSON args) n/a: DSML uses attribute-encoded args, not JSON.
+  PARSER.batch.4.c:
+    description: Invoke without name attribute
+    ref: dynamo
+    model_text: |-
+      <｜DSML｜function_calls>
+      <｜DSML｜invoke>
+      <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+      </｜DSML｜invoke>
+      </｜DSML｜function_calls>
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''
+    # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
+    # vllm produces:
+    #   calls: []
+    #   normal_text: '<｜DSML｜function_calls>\n<｜DSML｜invoke>\n<｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜function_calls>'
+  PARSER.batch.4.d:
+    description: Missing </｜DSML｜parameter> end tag
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_deepseekv32_tool_parser.py#L499
+    model_text: |-
+      <｜DSML｜function_calls>
+      <｜DSML｜invoke name="get_weather">
+      <｜DSML｜parameter name="location" string="true">NYC
+      </｜DSML｜invoke>
+      </｜DSML｜function_calls>
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments: {}
+      normal_text: ''

--- a/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.5.yaml
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: deepseek_v3_2
+mode: batch
+cases:
+  PARSER.batch.5.a:
+    description: Missing </｜DSML｜function_calls> end marker
+    ref: dynamo
+    model_text: |-
+      <｜DSML｜function_calls>
+      <｜DSML｜invoke name="get_weather">
+      <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+      </｜DSML｜invoke>
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls: []
+      normal_text: ''
+    # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
+    # vllm produces:
+    #   calls: []
+    #   normal_text: '<｜DSML｜function_calls>\n<｜DSML｜invoke name="get_weather">\n<｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>\n</｜DSML｜invoke>'
+  PARSER.batch.5.b:
+    description: Closing </｜DSML｜function_calls> without matching open
+    ref: dynamo
+    model_text: |-
+      <｜DSML｜invoke name="get_weather">
+      <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+      </｜DSML｜invoke>
+      </｜DSML｜function_calls>
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: |-
+        <｜DSML｜invoke name="get_weather">
+        <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+        </｜DSML｜invoke>
+        </｜DSML｜function_calls>
+  PARSER.batch.5.c:
+    description: Truncation mid-parameter value
+    ref: dynamo
+    model_text: |-
+      <｜DSML｜function_calls>
+      <｜DSML｜invoke name="get_weather">
+      <｜DSML｜parameter name="location" string="true">NY
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''
+    # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
+    # vllm produces:
+    #   calls: []
+    #   normal_text: '<｜DSML｜function_calls>\n<｜DSML｜invoke name="get_weather">\n<｜DSML｜parameter name="location" string="true">NY'

--- a/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.6.yaml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: deepseek_v3_2
+mode: batch
+cases:
+  PARSER.batch.6.a:
+    description: Invoke with no <parameter>
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_deepseekv32_tool_parser.py#L363
+    model_text: |-
+      <｜DSML｜function_calls>
+      <｜DSML｜invoke name="get_time">
+      </｜DSML｜invoke>
+      </｜DSML｜function_calls>
+    tools:
+    - &id001
+      name: get_time
+      parameters:
+        type: object
+        properties: {}
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.6.b:
+    description: Invoke with extra newline
+    ref: dynamo
+    model_text: |-
+      <｜DSML｜function_calls>
+      <｜DSML｜invoke name="get_time">
+
+      </｜DSML｜invoke>
+      </｜DSML｜function_calls>
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''

--- a/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.7.yaml
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: deepseek_v3_2
+mode: batch
+cases:
+  PARSER.batch.7.a:
+    description: Multiple parameters
+    ref: dynamo
+    model_text: |-
+      <｜DSML｜function_calls>
+      <｜DSML｜invoke name="book_flight">
+      <｜DSML｜parameter name="destination" string="true">Paris</｜DSML｜parameter>
+      <｜DSML｜parameter name="passengers" string="false">2</｜DSML｜parameter>
+      <｜DSML｜parameter name="first_class" string="false">true</｜DSML｜parameter>
+      </｜DSML｜invoke>
+      </｜DSML｜function_calls>
+    tools:
+    - name: book_flight
+      parameters:
+        type: object
+        properties:
+          destination:
+            type: string
+          passengers:
+            type: integer
+          first_class:
+            type: boolean
+    expected:
+      calls:
+      - name: book_flight
+        arguments:
+          destination: Paris
+          passengers: 2
+          first_class: true
+      normal_text: ''
+    # TODO(research): vllm diverges — vLLM emits JSON-typed parameter values as raw strings; Dynamo coerces nested object/array types
+    # vllm produces:
+    #   calls: [{'name': 'book_flight', 'arguments': {'destination': 'Paris', 'passengers': '2', 'first_class': 'true'}}]
+    #   normal_text: None
+  PARSER.batch.7.b:
+    description: Unicode in parameter
+    ref: dynamo
+    model_text: |-
+      <｜DSML｜function_calls>
+      <｜DSML｜invoke name="get_weather">
+      <｜DSML｜parameter name="location" string="true">Tōkyō central</｜DSML｜parameter>
+      </｜DSML｜invoke>
+      </｜DSML｜function_calls>
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Tōkyō central
+      normal_text: ''

--- a/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.8.yaml
@@ -6,7 +6,7 @@ mode: batch
 cases:
   PARSER.batch.8.a:
     description: Narration before tool call only
-    ref: inspired-by https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_deepseekv32_tool_parser.py#L158
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_deepseekv32_tool_parser.py#L158
     model_text: |-
       I will check the weather. <｜DSML｜function_calls>
       <｜DSML｜invoke name="get_weather">

--- a/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.yaml
@@ -26,34 +26,6 @@ cases:
         arguments:
           location: NYC
       normal_text: ''
-  PARSER.batch.2:
-    description: Multiple tool calls (parallel)
-    model_text: |-
-      <｜DSML｜function_calls>
-      <｜DSML｜invoke name="get_weather">
-      <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
-      </｜DSML｜invoke>
-      <｜DSML｜invoke name="get_time">
-      <｜DSML｜parameter name="timezone" string="true">EST</｜DSML｜parameter>
-      </｜DSML｜invoke>
-      </｜DSML｜function_calls>
-    tools:
-    - *id001
-    - name: get_time
-      parameters:
-        type: object
-        properties:
-          timezone:
-            type: string
-    expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: ''
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
@@ -62,79 +34,6 @@ cases:
     expected:
       calls: []
       normal_text: Hello, how can I help you today?
-  PARSER.batch.4:
-    description: Malformed (missing </｜DSML｜parameter> end tag)
-    model_text: |-
-      <｜DSML｜function_calls>
-      <｜DSML｜invoke name="get_weather">
-      <｜DSML｜parameter name="location" string="true">NYC
-      </｜DSML｜invoke>
-      </｜DSML｜function_calls>
-    tools:
-    - *id001
-    expected:
-      calls:
-      - name: get_weather
-        arguments: {}
-      normal_text: ''
-  PARSER.batch.5:
-    description: Missing </｜DSML｜function_calls> end marker
-    model_text: |-
-      <｜DSML｜function_calls>
-      <｜DSML｜invoke name="get_weather">
-      <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
-      </｜DSML｜invoke>
-    tools:
-    - *id001
-    expected:
-      calls: []
-      normal_text: ''
-  PARSER.batch.6:
-    description: Empty args (no-arg call)
-    model_text: |-
-      <｜DSML｜function_calls>
-      <｜DSML｜invoke name="get_time">
-      </｜DSML｜invoke>
-      </｜DSML｜function_calls>
-    tools:
-    - name: get_time
-      parameters:
-        type: object
-        properties: {}
-    expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
-  PARSER.batch.7:
-    description: Complex args (nested object + array, JSON-typed)
-    model_text: |-
-      <｜DSML｜function_calls>
-      <｜DSML｜invoke name="process_data">
-      <｜DSML｜parameter name="items" string="false">[1, 2, 3]</｜DSML｜parameter>
-      <｜DSML｜parameter name="config" string="false">{"nested": true}</｜DSML｜parameter>
-      </｜DSML｜invoke>
-      </｜DSML｜function_calls>
-    tools:
-    - name: process_data
-      parameters:
-        type: object
-        properties:
-          items:
-            type: array
-          config:
-            type: object
-    expected:
-      calls:
-      - name: process_data
-        arguments:
-          items:
-          - 1
-          - 2
-          - 3
-          config:
-            nested: true
-      normal_text: ''
   PARSER.batch.9:
     description: Empty input
     model_text: ''

--- a/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.2.yaml
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# `|2+` simply means a single newline ("\n"); see tests/parity/README.md for the full decode.
+
+family: deepseek_v4
+mode: batch
+cases:
+  PARSER.batch.2.a:
+    description: Two invokes inside one tool_calls wrapper
+    ref: dynamo
+    # `|-` = literal block scalar, strip trailing newline (multi-line text as-is)
+    model_text: |-
+      <｜DSML｜tool_calls>
+      <｜DSML｜invoke name="get_weather">
+      <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+      </｜DSML｜invoke>
+      <｜DSML｜invoke name="get_time">
+      <｜DSML｜parameter name="timezone" string="true">EST</｜DSML｜parameter>
+      </｜DSML｜invoke>
+      </｜DSML｜tool_calls>
+    tools:
+    # `&idN` defines an anchor; `*idN` below reuses the same tool def
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - &id002
+      name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
+  PARSER.batch.2.b:
+    description: Two back-to-back tool_calls wrappers
+    ref: dynamo
+    model_text: |-
+      <｜DSML｜tool_calls>
+      <｜DSML｜invoke name="get_weather">
+      <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+      </｜DSML｜invoke>
+      </｜DSML｜tool_calls>
+      <｜DSML｜tool_calls>
+      <｜DSML｜invoke name="get_time">
+      <｜DSML｜parameter name="timezone" string="true">EST</｜DSML｜parameter>
+      </｜DSML｜invoke>
+      </｜DSML｜tool_calls>
+    tools:
+    - *id001
+    - *id002
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      # `|2+` below = "\n" (see file header)
+      normal_text: |2+
+
+    # TODO(research): vllm diverges — vLLM deepseek_v4 does not restart parsing on a second back-to-back fence pair
+    # vllm produces:
+    #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}, {'name': 'get_time', 'arguments': {'timezone': 'EST'}}]
+    #   normal_text: None
+  PARSER.batch.2.c:
+    description: Parallel with surrounding narration
+    ref: dynamo
+    model_text: |-
+      Both: <｜DSML｜tool_calls>
+      <｜DSML｜invoke name="get_weather">
+      <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+      </｜DSML｜invoke>
+      <｜DSML｜invoke name="get_time">
+      <｜DSML｜parameter name="timezone" string="true">EST</｜DSML｜parameter>
+      </｜DSML｜invoke>
+      </｜DSML｜tool_calls> Done.
+    tools:
+    - *id001
+    - *id002
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: 'Both:  Done.'
+    # TODO(research): vllm diverges — drops trailing normal_text after tool-call wrapper end
+    # vllm produces:
+    #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}, {'name': 'get_time', 'arguments': {'timezone': 'EST'}}]
+    #   normal_text: 'Both: '
+  PARSER.batch.2.d:
+    description: Same-name twice
+    ref: dynamo
+    model_text: |-
+      <｜DSML｜tool_calls>
+      <｜DSML｜invoke name="get_weather">
+      <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+      </｜DSML｜invoke>
+      <｜DSML｜invoke name="get_weather">
+      <｜DSML｜parameter name="location" string="true">LA</｜DSML｜parameter>
+      </｜DSML｜invoke>
+      </｜DSML｜tool_calls>
+    tools:
+    - *id001
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''

--- a/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.4.yaml
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: deepseek_v4
+mode: batch
+cases:
+  PARSER.batch.4.a:
+    description: Tool_calls wrapper with garbage
+    ref: dynamo
+    model_text: |-
+      <｜DSML｜tool_calls>
+      not a valid invoke
+      </｜DSML｜tool_calls>
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls: []
+      normal_text: ''
+    # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
+    # vllm produces:
+    #   calls: []
+    #   normal_text: '<｜DSML｜tool_calls>\nnot a valid invoke\n</｜DSML｜tool_calls>'
+  # PARSER.batch.4.b (invalid JSON args) n/a: DSML uses attribute-encoded args, not JSON.
+  PARSER.batch.4.c:
+    description: Invoke without name attribute
+    ref: dynamo
+    model_text: |-
+      <｜DSML｜tool_calls>
+      <｜DSML｜invoke>
+      <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+      </｜DSML｜invoke>
+      </｜DSML｜tool_calls>
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''
+    # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
+    # vllm produces:
+    #   calls: []
+    #   normal_text: '<｜DSML｜tool_calls>\n<｜DSML｜invoke>\n<｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>'
+  PARSER.batch.4.d:
+    description: Missing </｜DSML｜parameter> end tag
+    ref: dynamo
+    model_text: |-
+      <｜DSML｜tool_calls>
+      <｜DSML｜invoke name="get_weather">
+      <｜DSML｜parameter name="location" string="true">NYC
+      </｜DSML｜invoke>
+      </｜DSML｜tool_calls>
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments: {}
+      normal_text: ''

--- a/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.5.yaml
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: deepseek_v4
+mode: batch
+cases:
+  PARSER.batch.5.a:
+    description: Missing </｜DSML｜tool_calls> end marker
+    ref: dynamo
+    model_text: |-
+      <｜DSML｜tool_calls>
+      <｜DSML｜invoke name="get_weather">
+      <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+      </｜DSML｜invoke>
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls: []
+      normal_text: ''
+    # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
+    # vllm produces:
+    #   calls: []
+    #   normal_text: '<｜DSML｜tool_calls>\n<｜DSML｜invoke name="get_weather">\n<｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>\n</｜DSML｜invoke>'
+  PARSER.batch.5.b:
+    description: Closing </｜DSML｜tool_calls> without matching open
+    ref: dynamo
+    model_text: |-
+      <｜DSML｜invoke name="get_weather">
+      <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+      </｜DSML｜invoke>
+      </｜DSML｜tool_calls>
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: |-
+        <｜DSML｜invoke name="get_weather">
+        <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+        </｜DSML｜invoke>
+        </｜DSML｜tool_calls>
+  PARSER.batch.5.c:
+    description: Truncation mid-parameter value
+    ref: dynamo
+    model_text: |-
+      <｜DSML｜tool_calls>
+      <｜DSML｜invoke name="get_weather">
+      <｜DSML｜parameter name="location" string="true">NY
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''
+    # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
+    # vllm produces:
+    #   calls: []
+    #   normal_text: '<｜DSML｜tool_calls>\n<｜DSML｜invoke name="get_weather">\n<｜DSML｜parameter name="location" string="true">NY'

--- a/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.6.yaml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: deepseek_v4
+mode: batch
+cases:
+  PARSER.batch.6.a:
+    description: Invoke with no <parameter>
+    ref: dynamo
+    model_text: |-
+      <｜DSML｜tool_calls>
+      <｜DSML｜invoke name="get_time">
+      </｜DSML｜invoke>
+      </｜DSML｜tool_calls>
+    tools:
+    - &id001
+      name: get_time
+      parameters:
+        type: object
+        properties: {}
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.6.b:
+    description: Invoke with extra newline
+    ref: dynamo
+    model_text: |-
+      <｜DSML｜tool_calls>
+      <｜DSML｜invoke name="get_time">
+
+      </｜DSML｜invoke>
+      </｜DSML｜tool_calls>
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''

--- a/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.7.yaml
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: deepseek_v4
+mode: batch
+cases:
+  PARSER.batch.7.a:
+    description: Multiple parameters
+    ref: dynamo
+    model_text: |-
+      <｜DSML｜tool_calls>
+      <｜DSML｜invoke name="book_flight">
+      <｜DSML｜parameter name="destination" string="true">Paris</｜DSML｜parameter>
+      <｜DSML｜parameter name="passengers" string="false">2</｜DSML｜parameter>
+      <｜DSML｜parameter name="first_class" string="false">true</｜DSML｜parameter>
+      </｜DSML｜invoke>
+      </｜DSML｜tool_calls>
+    tools:
+    - name: book_flight
+      parameters:
+        type: object
+        properties:
+          destination:
+            type: string
+          passengers:
+            type: integer
+          first_class:
+            type: boolean
+    expected:
+      calls:
+      - name: book_flight
+        arguments:
+          destination: Paris
+          passengers: 2
+          first_class: true
+      normal_text: ''
+    # TODO(research): vllm diverges — vLLM emits JSON-typed parameter values as raw strings; Dynamo coerces nested object/array types
+    # vllm produces:
+    #   calls: [{'name': 'book_flight', 'arguments': {'destination': 'Paris', 'passengers': '2', 'first_class': 'true'}}]
+    #   normal_text: None
+  PARSER.batch.7.b:
+    description: Unicode in parameter
+    ref: dynamo
+    model_text: |-
+      <｜DSML｜tool_calls>
+      <｜DSML｜invoke name="get_weather">
+      <｜DSML｜parameter name="location" string="true">Tōkyō central</｜DSML｜parameter>
+      </｜DSML｜invoke>
+      </｜DSML｜tool_calls>
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Tōkyō central
+      normal_text: ''

--- a/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.yaml
@@ -26,34 +26,6 @@ cases:
         arguments:
           location: NYC
       normal_text: ''
-  PARSER.batch.2:
-    description: Multiple tool calls (parallel)
-    model_text: |-
-      <｜DSML｜tool_calls>
-      <｜DSML｜invoke name="get_weather">
-      <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
-      </｜DSML｜invoke>
-      <｜DSML｜invoke name="get_time">
-      <｜DSML｜parameter name="timezone" string="true">EST</｜DSML｜parameter>
-      </｜DSML｜invoke>
-      </｜DSML｜tool_calls>
-    tools:
-    - *id001
-    - name: get_time
-      parameters:
-        type: object
-        properties:
-          timezone:
-            type: string
-    expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: ''
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
@@ -62,79 +34,6 @@ cases:
     expected:
       calls: []
       normal_text: Hello, how can I help you today?
-  PARSER.batch.4:
-    description: Malformed (missing </｜DSML｜parameter> end tag)
-    model_text: |-
-      <｜DSML｜tool_calls>
-      <｜DSML｜invoke name="get_weather">
-      <｜DSML｜parameter name="location" string="true">NYC
-      </｜DSML｜invoke>
-      </｜DSML｜tool_calls>
-    tools:
-    - *id001
-    expected:
-      calls:
-      - name: get_weather
-        arguments: {}
-      normal_text: ''
-  PARSER.batch.5:
-    description: Missing </｜DSML｜tool_calls> end marker
-    model_text: |-
-      <｜DSML｜tool_calls>
-      <｜DSML｜invoke name="get_weather">
-      <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
-      </｜DSML｜invoke>
-    tools:
-    - *id001
-    expected:
-      calls: []
-      normal_text: ''
-  PARSER.batch.6:
-    description: Empty args (no-arg call)
-    model_text: |-
-      <｜DSML｜tool_calls>
-      <｜DSML｜invoke name="get_time">
-      </｜DSML｜invoke>
-      </｜DSML｜tool_calls>
-    tools:
-    - name: get_time
-      parameters:
-        type: object
-        properties: {}
-    expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
-  PARSER.batch.7:
-    description: Complex args (nested object + array, JSON-typed)
-    model_text: |-
-      <｜DSML｜tool_calls>
-      <｜DSML｜invoke name="process_data">
-      <｜DSML｜parameter name="items" string="false">[1, 2, 3]</｜DSML｜parameter>
-      <｜DSML｜parameter name="config" string="false">{"nested": true}</｜DSML｜parameter>
-      </｜DSML｜invoke>
-      </｜DSML｜tool_calls>
-    tools:
-    - name: process_data
-      parameters:
-        type: object
-        properties:
-          items:
-            type: array
-          config:
-            type: object
-    expected:
-      calls:
-      - name: process_data
-        arguments:
-          items:
-          - 1
-          - 2
-          - 3
-          config:
-            nested: true
-      normal_text: ''
   PARSER.batch.9:
     description: Empty input
     model_text: ''

--- a/tests/parity/parser/fixtures/gemma4/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/gemma4/PARSER.batch.2.yaml
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: gemma4
+mode: batch
+cases:
+  PARSER.batch.2.a:
+    description: Parallel calls (back-to-back sentinels)
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_gemma4_tool_parser.py#L207
+    model_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}<tool_call|><|tool_call>call:get_time{timezone:<|"|>EST<|"|>}<tool_call|>
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - &id002
+      name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
+  PARSER.batch.2.c:
+    description: With surrounding narration
+    ref: dynamo
+    model_text: 'Both: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}<tool_call|><|tool_call>call:get_time{timezone:<|"|>EST<|"|>}<tool_call|>
+      Done.'
+    tools:
+    - *id001
+    - *id002
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: 'Both:  Done.'
+    # TODO(research): vllm diverges — drops trailing normal_text after tool-call wrapper end
+    # vllm produces:
+    #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}, {'name': 'get_time', 'arguments': {'timezone': 'EST'}}]
+    #   normal_text: 'Both:'
+  PARSER.batch.2.d:
+    description: Same-name twice
+    ref: dynamo
+    model_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}<tool_call|><|tool_call>call:get_weather{location:<|"|>LA<|"|>}<tool_call|>
+    tools:
+    - *id001
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''

--- a/tests/parity/parser/fixtures/gemma4/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/gemma4/PARSER.batch.4.yaml
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: gemma4
+mode: batch
+cases:
+  PARSER.batch.4.a:
+    description: Sentinel pair with garbage
+    ref: dynamo
+    model_text: <|tool_call>nonsense<tool_call|>
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls: []
+      normal_text: <|tool_call>nonsense<tool_call|>
+  PARSER.batch.4.b:
+    description: Missing close brace in body
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_gemma4_tool_parser.py#L572
+    model_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|><tool_call|>
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|><tool_call|>
+  PARSER.batch.4.c:
+    description: No call:name prefix
+    ref: dynamo
+    model_text: <|tool_call>{location:<|"|>NYC<|"|>}<tool_call|>
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: <|tool_call>{location:<|"|>NYC<|"|>}<tool_call|>
+  PARSER.batch.4.d:
+    description: Mismatched sentinels
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_gemma4_tool_parser.py#L252
+    model_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}

--- a/tests/parity/parser/fixtures/gemma4/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/gemma4/PARSER.batch.5.yaml
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: gemma4
+mode: batch
+cases:
+  PARSER.batch.5.a:
+    description: Missing <tool_call|> end marker
+    ref: dynamo
+    model_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls: []
+      normal_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}
+  PARSER.batch.5.b:
+    description: Closing <tool_call|> without matching <|tool_call> open
+    ref: dynamo
+    model_text: call:get_weather{location:<|"|>NYC<|"|>}<tool_call|>
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: call:get_weather{location:<|"|>NYC<|"|>}<tool_call|>
+  PARSER.batch.5.c:
+    description: Truncation mid-argument value
+    ref: dynamo
+    model_text: <|tool_call>call:get_weather{location:<|"|>N
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: <|tool_call>call:get_weather{location:<|"|>N

--- a/tests/parity/parser/fixtures/gemma4/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/gemma4/PARSER.batch.6.yaml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: gemma4
+mode: batch
+cases:
+  PARSER.batch.6.a:
+    description: Canonical empty {} body
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_gemma4_tool_parser.py#L560
+    model_text: <|tool_call>call:get_time{}<tool_call|>
+    tools:
+    - &id001
+      name: get_time
+      parameters:
+        type: object
+        properties: {}
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.6.b:
+    description: Whitespace inside empty {}
+    ref: dynamo
+    model_text: <|tool_call>call:get_time{ }<tool_call|>
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.6.c:
+    description: No body (just call:name)
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_gemma4_tool_parser.py#L280
+    model_text: <|tool_call>call:get_time<tool_call|>
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: <|tool_call>call:get_time<tool_call|>

--- a/tests/parity/parser/fixtures/gemma4/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/gemma4/PARSER.batch.7.yaml
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: gemma4
+mode: batch
+cases:
+  PARSER.batch.7.a:
+    description: Standard scalar types
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_gemma4_tool_parser.py#L236
+    model_text: <|tool_call>call:book_flight{destination:<|"|>Paris<|"|>,passengers:2,first_class:true}<tool_call|>
+    tools:
+    - name: book_flight
+      parameters:
+        type: object
+        properties:
+          destination:
+            type: string
+          passengers:
+            type: integer
+          first_class:
+            type: boolean
+    expected:
+      calls:
+      - name: book_flight
+        arguments:
+          destination: Paris
+          passengers: 2
+          first_class: true
+      normal_text: ''
+  PARSER.batch.7.b:
+    description: Unicode in value
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_gemma4_tool_parser.py#L630
+    model_text: <|tool_call>call:get_weather{location:<|"|>Tōkyō central<|"|>}<tool_call|>
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Tōkyō central
+      normal_text: ''
+  PARSER.batch.7.c:
+    description: Schema mismatch — string value where schema declares integer
+    ref: dynamo
+    model_text: <|tool_call>call:set_temperature{celsius:<|"|>20<|"|>}<tool_call|>
+    tools:
+    - name: set_temperature
+      parameters:
+        type: object
+        properties:
+          celsius:
+            type: integer
+    expected:
+      calls:
+      - name: set_temperature
+        arguments:
+          celsius: '20'
+      normal_text: ''
+  PARSER.batch.7.d:
+    description: Nested object + array (existing)
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_gemma4_tool_parser.py#L179
+    model_text: <|tool_call>call:process_data{items:[1,2,3],config:{nested:true}}<tool_call|>
+    tools:
+    - name: process_data
+      parameters:
+        type: object
+        properties:
+          items:
+            type: array
+          config:
+            type: object
+    expected:
+      calls:
+      - name: process_data
+        arguments:
+          items:
+          - 1
+          - 2
+          - 3
+          config:
+            nested: true
+      normal_text: ''

--- a/tests/parity/parser/fixtures/gemma4/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/gemma4/PARSER.batch.8.yaml
@@ -6,7 +6,7 @@ mode: batch
 cases:
   PARSER.batch.8.a:
     description: Narration before tool call only
-    ref: inspired-by https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_gemma4_tool_parser.py#L194
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_gemma4_tool_parser.py#L194
     model_text: I will check the weather. <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}<tool_call|>
     tools:
     - &id001

--- a/tests/parity/parser/fixtures/gemma4/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/gemma4/PARSER.batch.yaml
@@ -21,26 +21,6 @@ cases:
         arguments:
           location: NYC
       normal_text: ''
-  PARSER.batch.2:
-    description: Multiple tool calls (parallel)
-    model_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}<tool_call|><|tool_call>call:get_time{timezone:<|"|>EST<|"|>}<tool_call|>
-    tools:
-    - *id001
-    - name: get_time
-      parameters:
-        type: object
-        properties:
-          timezone:
-            type: string
-    expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: ''
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
@@ -49,58 +29,6 @@ cases:
     expected:
       calls: []
       normal_text: Hello, how can I help you today?
-  PARSER.batch.4:
-    description: Malformed (missing close brace)
-    model_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|><tool_call|>
-    tools:
-    - *id001
-    expected:
-      calls: []
-      normal_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|><tool_call|>
-  PARSER.batch.5:
-    description: Missing <tool_call|> end marker
-    model_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}
-    tools:
-    - *id001
-    expected:
-      calls: []
-      normal_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}
-  PARSER.batch.6:
-    description: Empty args (no-arg call)
-    model_text: <|tool_call>call:get_time{}<tool_call|>
-    tools:
-    - name: get_time
-      parameters:
-        type: object
-        properties: {}
-    expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
-  PARSER.batch.7:
-    description: Complex args (nested object + array)
-    model_text: <|tool_call>call:process_data{items:[1,2,3],config:{nested:true}}<tool_call|>
-    tools:
-    - name: process_data
-      parameters:
-        type: object
-        properties:
-          items:
-            type: array
-          config:
-            type: object
-    expected:
-      calls:
-      - name: process_data
-        arguments:
-          items:
-          - 1
-          - 2
-          - 3
-          config:
-            nested: true
-      normal_text: ''
   PARSER.batch.9:
     description: Empty input
     model_text: ''

--- a/tests/parity/parser/fixtures/glm47/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/glm47/PARSER.batch.2.yaml
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: glm47
+mode: batch
+cases:
+  PARSER.batch.2.a:
+    description: Parallel calls (different names)
+    ref: dynamo
+    model_text: <tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call><tool_call>get_time<arg_key>timezone</arg_key><arg_value>EST</arg_value></tool_call>
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - &id002
+      name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
+  PARSER.batch.2.c:
+    description: Parallel calls with surrounding narration
+    ref: dynamo
+    model_text: 'Checking: <tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call><tool_call>get_time<arg_key>timezone</arg_key><arg_value>EST</arg_value></tool_call>
+      Done.'
+    tools:
+    - *id001
+    - *id002
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: 'Checking:  Done.'
+    # TODO(research): vllm diverges — drops trailing normal_text after tool-call wrapper end
+    # vllm produces:
+    #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}, {'name': 'get_time', 'arguments': {'timezone': 'EST'}}]
+    #   normal_text: 'Checking: '
+  PARSER.batch.2.d:
+    description: Same-name twice (id distinctness)
+    ref: dynamo
+    model_text: <tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call><tool_call>get_weather<arg_key>location</arg_key><arg_value>LA</arg_value></tool_call>
+    tools:
+    - *id001
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''

--- a/tests/parity/parser/fixtures/glm47/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/glm47/PARSER.batch.4.yaml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: glm47
+mode: batch
+cases:
+  PARSER.batch.4.a:
+    description: Tool_call wrapper with no function name
+    ref: dynamo
+    model_text: <tool_call><arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls: []
+      normal_text: <tool_call><arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>
+    # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
+    # vllm produces:
+    #   calls: [{'name': '<arg_key>location</arg_key><arg_value>NYC</arg_value>', 'arguments': {}}]
+    #   normal_text: None
+  PARSER.batch.4.d:
+    description: Missing </arg_value> end tag
+    ref: dynamo
+    model_text: <tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</tool_call>
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments: {}
+      normal_text: ''

--- a/tests/parity/parser/fixtures/glm47/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/glm47/PARSER.batch.5.yaml
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: glm47
+mode: batch
+cases:
+  PARSER.batch.5.a:
+    description: Missing </tool_call> end marker
+    ref: dynamo
+    model_text: <tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value>
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+    # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
+    # vllm produces:
+    #   calls: []
+    #   normal_text: '<tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value>'
+  PARSER.batch.5.b:
+    description: Closing </tool_call> without matching <tool_call> open
+    ref: dynamo
+    model_text: get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>
+  PARSER.batch.5.c:
+    description: Truncation mid-arg_value
+    ref: dynamo
+    model_text: <tool_call>get_weather<arg_key>location</arg_key><arg_value>N
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments: {}
+      normal_text: ''
+    # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
+    # vllm produces:
+    #   calls: []
+    #   normal_text: '<tool_call>get_weather<arg_key>location</arg_key><arg_value>N'

--- a/tests/parity/parser/fixtures/glm47/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/glm47/PARSER.batch.6.yaml
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: glm47
+mode: batch
+cases:
+  PARSER.batch.6.a:
+    description: Function-only call (no arg keys)
+    ref: dynamo
+    model_text: <tool_call>get_time</tool_call>
+    tools:
+    - &id001
+      name: get_time
+      parameters:
+        type: object
+        properties: {}
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.6.b:
+    description: Function-only with whitespace
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_glm47_moe_tool_parser.py#L68
+    model_text: <tool_call>get_time </tool_call>
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''

--- a/tests/parity/parser/fixtures/glm47/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/glm47/PARSER.batch.7.yaml
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: glm47
+mode: batch
+cases:
+  PARSER.batch.7.a:
+    description: Multiple parameters (existing multi-arg shape)
+    ref: dynamo
+    model_text: <tool_call>book_flight<arg_key>destination</arg_key><arg_value>Paris</arg_value><arg_key>passengers</arg_key><arg_value>2</arg_value><arg_key>first_class</arg_key><arg_value>true</arg_value></tool_call>
+    tools:
+    - name: book_flight
+      parameters:
+        type: object
+        properties:
+          destination:
+            type: string
+          passengers:
+            type: integer
+          first_class:
+            type: boolean
+    expected:
+      calls:
+      - name: book_flight
+        arguments:
+          first_class: true
+          passengers: 2
+          destination: Paris
+      normal_text: ''
+  PARSER.batch.7.b:
+    description: Unicode in arg value
+    ref: dynamo
+    model_text: <tool_call>get_weather<arg_key>location</arg_key><arg_value>Tōkyō central</arg_value></tool_call>
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Tōkyō central
+      normal_text: ''

--- a/tests/parity/parser/fixtures/glm47/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/glm47/PARSER.batch.8.yaml
@@ -6,7 +6,7 @@ mode: batch
 cases:
   PARSER.batch.8.a:
     description: Narration before tool call only
-    ref: inspired-by https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_glm47_moe_tool_parser.py#L94
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_glm47_moe_tool_parser.py#L94
     model_text: I will check the weather. <tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>
     tools:
     - &id001

--- a/tests/parity/parser/fixtures/glm47/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/glm47/PARSER.batch.yaml
@@ -21,26 +21,6 @@ cases:
         arguments:
           location: NYC
       normal_text: ''
-  PARSER.batch.2:
-    description: Multiple tool calls
-    model_text: <tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call><tool_call>get_time<arg_key>timezone</arg_key><arg_value>EST</arg_value></tool_call>
-    tools:
-    - *id001
-    - name: get_time
-      parameters:
-        type: object
-        properties:
-          timezone:
-            type: string
-    expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: ''
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
@@ -49,59 +29,6 @@ cases:
     expected:
       calls: []
       normal_text: Hello, how can I help you today?
-  PARSER.batch.4:
-    description: Malformed (missing arg_value end tag)
-    model_text: <tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</tool_call>
-    tools:
-    - *id001
-    expected:
-      calls:
-      - name: get_weather
-        arguments: {}
-      normal_text: ''
-  PARSER.batch.5:
-    description: Missing </tool_call> end marker
-    model_text: <tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value>
-    tools:
-    - *id001
-    expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
-  PARSER.batch.6:
-    description: Empty args (no-arg call)
-    model_text: <tool_call>get_time</tool_call>
-    tools:
-    - name: get_time
-      parameters:
-        type: object
-        properties: {}
-    expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
-  PARSER.batch.7:
-    description: Complex args (multi-parameter)
-    model_text: <tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value><arg_key>unit</arg_key><arg_value>fahrenheit</arg_value></tool_call>
-    tools:
-    - name: get_weather
-      parameters:
-        type: object
-        properties:
-          location:
-            type: string
-          unit:
-            type: string
-    expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-          unit: fahrenheit
-      normal_text: ''
   PARSER.batch.9:
     description: Empty input
     model_text: ''

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.2.yaml
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: harmony
+mode: batch
+cases:
+  PARSER.batch.2.a:
+    description: Two back-to-back commentary envelopes
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_openai_tool_parser.py#L130
+    model_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|><|start|>assistant<|channel|>commentary
+      to=functions.get_time <|constrain|>json<|message|>{"timezone":"EST"}<|call|>
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - &id002
+      name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      calls: []
+      normal_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|><|start|>assistant<|channel|>commentary
+        to=functions.get_time <|constrain|>json<|message|>{"timezone":"EST"}<|call|>
+  PARSER.batch.2.c:
+    description: With surrounding narration
+    ref: dynamo
+    model_text: I need both. <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|><|start|>assistant<|channel|>commentary
+      to=functions.get_time <|constrain|>json<|message|>{"timezone":"EST"}<|call|> Done.
+    tools:
+    - *id001
+    - *id002
+    expected:
+      calls: []
+      normal_text: I need both. <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|><|start|>assistant<|channel|>commentary
+        to=functions.get_time <|constrain|>json<|message|>{"timezone":"EST"}<|call|> Done.
+  PARSER.batch.2.d:
+    description: Same-name twice
+    ref: dynamo
+    model_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|><|start|>assistant<|channel|>commentary
+      to=functions.get_weather <|constrain|>json<|message|>{"location":"LA"}<|call|>
+    tools:
+    - *id001
+    - *id001
+    expected:
+      calls: []
+      normal_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|><|start|>assistant<|channel|>commentary
+        to=functions.get_weather <|constrain|>json<|message|>{"location":"LA"}<|call|>

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.4.yaml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: harmony
+mode: batch
+cases:
+  PARSER.batch.4.a:
+    description: Channel envelope with garbage body
+    ref: dynamo
+    model_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>not json at all<|call|>
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls: []
+      normal_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>not json at
+        all<|call|>
+  PARSER.batch.4.b:
+    description: Unterminated JSON in message body
+    ref: dynamo
+    model_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC<|call|>
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC<|call|>
+  PARSER.batch.4.c:
+    description: No to=functions.X recipient
+    ref: dynamo
+    model_text: <|start|>assistant<|channel|>commentary <|constrain|>json<|message|>{"location":"NYC"}<|call|>
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.5.yaml
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: harmony
+mode: batch
+cases:
+  PARSER.batch.5.a:
+    description: Missing <|call|> end marker (bare envelope)
+    ref: dynamo
+    model_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls: []
+      normal_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}
+  PARSER.batch.5.b:
+    description: Bare <|call|> without preceding channel envelope
+    ref: dynamo
+    model_text: <|call|>
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: <|call|>
+  PARSER.batch.5.c:
+    description: Truncation mid-message JSON
+    ref: dynamo
+    model_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"loc
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"loc

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.6.yaml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: harmony
+mode: batch
+cases:
+  PARSER.batch.6.a:
+    description: Canonical empty {} message body
+    ref: dynamo
+    model_text: <|channel|>commentary to=functions.get_time <|constrain|>json<|message|>{}
+    tools:
+    - &id001
+      name: get_time
+      parameters:
+        type: object
+        properties: {}
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.6.b:
+    description: Whitespace inside empty {}
+    ref: dynamo
+    model_text: <|channel|>commentary to=functions.get_time <|constrain|>json<|message|>{ }
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.6.c:
+    description: No <|message|> body
+    ref: dynamo
+    model_text: <|channel|>commentary to=functions.get_time <|constrain|>json
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: <|channel|>commentary to=functions.get_time <|constrain|>json

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.7.yaml
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: harmony
+mode: batch
+cases:
+  PARSER.batch.7.a:
+    description: Standard scalar types
+    ref: dynamo
+    model_text: <|channel|>commentary to=functions.book_flight <|constrain|>json<|message|>{"destination":"Paris","passengers":2,"first_class":true}<|call|>
+    tools:
+    - name: book_flight
+      parameters:
+        type: object
+        properties:
+          destination:
+            type: string
+          passengers:
+            type: integer
+          first_class:
+            type: boolean
+    expected:
+      calls:
+      - name: book_flight
+        arguments:
+          destination: Paris
+          passengers: 2
+          first_class: true
+      normal_text: ''
+  PARSER.batch.7.b:
+    description: Unicode + escaped chars
+    ref: dynamo
+    model_text: <|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"Tōkyō \"central\""}<|call|>
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Tōkyō "central"
+      normal_text: ''
+  PARSER.batch.7.c:
+    description: Schema mismatch — string value where schema declares integer
+    ref: dynamo
+    model_text: <|channel|>commentary to=functions.set_temperature <|constrain|>json<|message|>{"celsius":"20"}<|call|>
+    tools:
+    - name: set_temperature
+      parameters:
+        type: object
+        properties:
+          celsius:
+            type: integer
+    expected:
+      calls:
+      - name: set_temperature
+        arguments:
+          celsius: '20'
+      normal_text: ''
+  PARSER.batch.7.d:
+    description: Nested object + array
+    ref: dynamo
+    model_text: <|channel|>commentary to=functions.process_data <|constrain|>json<|message|>{"items":[1,2,3],"config":{"nested":true}}<|call|>
+    tools:
+    - name: process_data
+      parameters:
+        type: object
+        properties:
+          items:
+            type: array
+          config:
+            type: object
+    expected:
+      calls:
+      - name: process_data
+        arguments:
+          items:
+          - 1
+          - 2
+          - 3
+          config:
+            nested: true
+      normal_text: ''

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.8.yaml
@@ -34,7 +34,7 @@ cases:
         to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|> Let me know if you need more.
   PARSER.batch.8.c:
     description: Narration both before and after (sandwich)
-    ref: inspired-by https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_openai_tool_parser.py#L220
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_openai_tool_parser.py#L220
     model_text: I will check the weather. <|channel|>analysis<|message|>Need to use function get_weather.<|end|><|start|>assistant<|channel|>commentary
       to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|> Let me know if you need more.
     tools:

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.yaml
@@ -21,22 +21,6 @@ cases:
         arguments:
           location: NYC
       normal_text: ''
-  PARSER.batch.2:
-    description: Multiple tool calls (back-to-back commentary blocks)
-    model_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|><|start|>assistant<|channel|>commentary
-      to=functions.get_time <|constrain|>json<|message|>{"timezone":"EST"}<|call|>
-    tools:
-    - *id001
-    - name: get_time
-      parameters:
-        type: object
-        properties:
-          timezone:
-            type: string
-    expected:
-      calls: []
-      normal_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|><|start|>assistant<|channel|>commentary
-        to=functions.get_time <|constrain|>json<|message|>{"timezone":"EST"}<|call|>
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
@@ -45,55 +29,6 @@ cases:
     expected:
       calls: []
       normal_text: Hello, how can I help you today?
-  PARSER.batch.4:
-    description: Malformed (truncated JSON args)
-    model_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC<|call|>
-    tools:
-    - *id001
-    expected:
-      calls: []
-      normal_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC<|call|>
-  PARSER.batch.5:
-    description: Missing <|call|> end marker (bare envelope)
-    model_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}
-    tools:
-    - *id001
-    expected:
-      calls: []
-      normal_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}
-  PARSER.batch.6:
-    description: Empty args (no-arg call)
-    model_text: <|channel|>commentary to=functions.get_time <|constrain|>json<|message|>{}
-    tools:
-    - name: get_time
-      parameters:
-        type: object
-        properties: {}
-    expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
-  PARSER.batch.7:
-    description: Complex args (multi-parameter)
-    model_text: <|channel|>analysis<|message|>Need to use function get_weather.<|end|><|start|>assistant<|channel|>commentary
-      to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC","unit":"fahrenheit"}<|call|>
-    tools:
-    - name: get_weather
-      parameters:
-        type: object
-        properties:
-          location:
-            type: string
-          unit:
-            type: string
-    expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-          unit: fahrenheit
-      normal_text: Need to use function get_weather.
   PARSER.batch.9:
     description: Empty input
     model_text: ''

--- a/tests/parity/parser/fixtures/hermes/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/hermes/PARSER.batch.2.yaml
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: hermes
+mode: batch
+cases:
+  PARSER.batch.2.a:
+    description: Parallel calls (back-to-back tool_call wrappers)
+    ref: dynamo
+    model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name": "get_time",
+      "arguments": {"timezone": "EST"}}</tool_call>'
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - &id002
+      name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
+  PARSER.batch.2.c:
+    description: With surrounding narration
+    ref: dynamo
+    model_text: 'Both: <tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name":
+      "get_time", "arguments": {"timezone": "EST"}}</tool_call> Done.'
+    tools:
+    - *id001
+    - *id002
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: 'Both:'
+    # TODO(research): vllm diverges — drops trailing normal_text after tool-call wrapper end
+    # vllm produces:
+    #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}, {'name': 'get_time', 'arguments': {'timezone': 'EST'}}]
+    #   normal_text: 'Both: '
+  PARSER.batch.2.d:
+    description: Same-name twice
+    ref: dynamo
+    model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name": "get_weather",
+      "arguments": {"location": "LA"}}</tool_call>'
+    tools:
+    - *id001
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''

--- a/tests/parity/parser/fixtures/hermes/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/hermes/PARSER.batch.4.yaml
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: hermes
+mode: batch
+cases:
+  PARSER.batch.4.a:
+    description: Tool_call wrapper with non-JSON garbage
+    ref: dynamo
+    model_text: <tool_call>not even json</tool_call>
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls: []
+      normal_text: <tool_call>not even json</tool_call>
+  PARSER.batch.4.b:
+    description: Missing close brace in JSON body
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_hermes_tool_parser.py#L376
+    model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"</tool_call>'
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+    # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
+    # vllm produces:
+    #   calls: []
+    #   normal_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"</tool_call>'
+  PARSER.batch.4.c:
+    description: Missing name key
+    ref: dynamo
+    model_text: '<tool_call>{"arguments": {"location": "NYC"}}</tool_call>'
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: '<tool_call>{"arguments": {"location": "NYC"}}</tool_call>'
+  PARSER.batch.4.d:
+    description: Missing </tool_call> close
+    ref: dynamo
+    model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}'
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''

--- a/tests/parity/parser/fixtures/hermes/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/hermes/PARSER.batch.5.yaml
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: hermes
+mode: batch
+cases:
+  PARSER.batch.5.a:
+    description: Missing </tool_call> end marker
+    ref: dynamo
+    model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}'
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+  PARSER.batch.5.b:
+    description: Closing </tool_call> without matching <tool_call> open
+    ref: dynamo
+    model_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>'
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>'
+  PARSER.batch.5.c:
+    description: Truncation mid-arguments JSON
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_hermes_tool_parser.py#L356
+    model_text: '<tool_call>{"name": "get_weather", "arguments": {"loc'
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: '<tool_call>{"name": "get_weather", "arguments": {"loc'

--- a/tests/parity/parser/fixtures/hermes/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/hermes/PARSER.batch.6.yaml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: hermes
+mode: batch
+cases:
+  PARSER.batch.6.a:
+    description: 'Canonical "arguments": {}'
+    ref: dynamo
+    model_text: '<tool_call>{"name": "get_time", "arguments": {}}</tool_call>'
+    tools:
+    - &id001
+      name: get_time
+      parameters:
+        type: object
+        properties: {}
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.6.b:
+    description: Whitespace inside arguments {}
+    ref: dynamo
+    model_text: '<tool_call>{"name": "get_time", "arguments": { }}</tool_call>'
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.6.c:
+    description: No arguments key
+    ref: dynamo
+    model_text: '<tool_call>{"name": "get_time"}</tool_call>'
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: '<tool_call>{"name": "get_time"}</tool_call>'

--- a/tests/parity/parser/fixtures/hermes/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/hermes/PARSER.batch.7.yaml
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: hermes
+mode: batch
+cases:
+  PARSER.batch.7.a:
+    description: Standard scalar types
+    ref: dynamo
+    model_text: '<tool_call>{"name": "book_flight", "arguments": {"destination": "Paris", "passengers": 2, "first_class":
+      true}}</tool_call>'
+    tools:
+    - name: book_flight
+      parameters:
+        type: object
+        properties:
+          destination:
+            type: string
+          passengers:
+            type: integer
+          first_class:
+            type: boolean
+    expected:
+      calls:
+      - name: book_flight
+        arguments:
+          first_class: true
+          passengers: 2
+          destination: Paris
+      normal_text: ''
+  PARSER.batch.7.b:
+    description: Unicode + escaped chars
+    ref: dynamo
+    model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "Tōkyō \"central\""}}</tool_call>'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Tōkyō "central"
+      normal_text: ''
+  PARSER.batch.7.c:
+    description: Schema mismatch — string value where schema declares integer
+    ref: dynamo
+    model_text: '<tool_call>{"name": "set_temperature", "arguments": {"celsius": "20"}}</tool_call>'
+    tools:
+    - name: set_temperature
+      parameters:
+        type: object
+        properties:
+          celsius:
+            type: integer
+    expected:
+      calls:
+      - name: set_temperature
+        arguments:
+          celsius: '20'
+      normal_text: ''
+  PARSER.batch.7.d:
+    description: Nested object + array
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_hermes_tool_parser.py#L284
+    model_text: '<tool_call>{"name": "process_data", "arguments": {"items": [1,2,3], "config": {"nested": true}}}</tool_call>'
+    tools:
+    - name: process_data
+      parameters:
+        type: object
+        properties:
+          items:
+            type: array
+          config:
+            type: object
+    expected:
+      calls:
+      - name: process_data
+        arguments:
+          items:
+          - 1
+          - 2
+          - 3
+          config:
+            nested: true
+      normal_text: ''

--- a/tests/parity/parser/fixtures/hermes/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/hermes/PARSER.batch.8.yaml
@@ -6,7 +6,7 @@ mode: batch
 cases:
   PARSER.batch.8.a:
     description: Narration before tool call only
-    ref: inspired-by https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_hermes_tool_parser.py#L221
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_hermes_tool_parser.py#L221
     model_text: 'I will check the weather. <tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>'
     tools:
     - &id001

--- a/tests/parity/parser/fixtures/hermes/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/hermes/PARSER.batch.yaml
@@ -21,27 +21,6 @@ cases:
         arguments:
           location: NYC
       normal_text: ''
-  PARSER.batch.2:
-    description: Multiple tool calls (parallel)
-    model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name": "get_time",
-      "arguments": {"timezone": "EST"}}</tool_call>'
-    tools:
-    - *id001
-    - name: get_time
-      parameters:
-        type: object
-        properties:
-          timezone:
-            type: string
-    expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: ''
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
@@ -50,64 +29,6 @@ cases:
     expected:
       calls: []
       normal_text: Hello, how can I help you today?
-  PARSER.batch.4:
-    description: Malformed JSON args (missing close brace)
-    model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"</tool_call>'
-    tools:
-    - *id001
-    expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
-  PARSER.batch.5:
-    description: Missing </tool_call> end marker
-    model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}'
-    tools:
-    - *id001
-    expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
-  PARSER.batch.6:
-    description: Empty args (no-arg call)
-    model_text: '<tool_call>{"name": "get_time", "arguments": {}}</tool_call>'
-    tools:
-    - name: get_time
-      parameters:
-        type: object
-        properties: {}
-    expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
-  PARSER.batch.7:
-    description: Complex args (nested object + array)
-    model_text: '<tool_call>{"name": "process_data", "arguments": {"items": [1, 2, 3], "config": {"nested": true}}}</tool_call>'
-    tools:
-    - name: process_data
-      parameters:
-        type: object
-        properties:
-          items:
-            type: array
-          config:
-            type: object
-    expected:
-      calls:
-      - name: process_data
-        arguments:
-          config:
-            nested: true
-          items:
-          - 1
-          - 2
-          - 3
-      normal_text: ''
   PARSER.batch.9:
     description: Empty input
     model_text: ''

--- a/tests/parity/parser/fixtures/jamba/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/jamba/PARSER.batch.2.yaml
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: jamba
+mode: batch
+cases:
+  PARSER.batch.2.a:
+    description: Parallel calls in JSON array
+    ref: dynamo
+    model_text: '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_time", "arguments":
+      {"timezone": "EST"}}]</tool_calls>'
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - &id002
+      name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
+  PARSER.batch.2.c:
+    description: With surrounding narration
+    ref: dynamo
+    model_text: 'Both: <tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_time", "arguments":
+      {"timezone": "EST"}}]</tool_calls> Done.'
+    tools:
+    - *id001
+    - *id002
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: 'Both:'
+    # TODO(research): vllm diverges — drops trailing normal_text after tool-call wrapper end
+    # vllm produces:
+    #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}, {'name': 'get_time', 'arguments': {'timezone': 'EST'}}]
+    #   normal_text: 'Both: '
+  PARSER.batch.2.d:
+    description: Same-name twice
+    ref: dynamo
+    model_text: '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_weather", "arguments":
+      {"location": "LA"}}]</tool_calls>'
+    tools:
+    - *id001
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''

--- a/tests/parity/parser/fixtures/jamba/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/jamba/PARSER.batch.4.yaml
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: jamba
+mode: batch
+cases:
+  PARSER.batch.4.a:
+    description: Tool_calls wrapper with garbage
+    ref: dynamo
+    model_text: <tool_calls>not a json array</tool_calls>
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls: []
+      normal_text: <tool_calls>not a json array</tool_calls>
+  PARSER.batch.4.b:
+    description: Missing close brace in JSON
+    ref: dynamo
+    model_text: '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"]</tool_calls>'
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"]</tool_calls>'
+  PARSER.batch.4.c:
+    description: Missing name key
+    ref: dynamo
+    model_text: '<tool_calls>[{"arguments": {"location": "NYC"}}]</tool_calls>'
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''
+    # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
+    # vllm produces:
+    #   calls: []
+    #   normal_text: '<tool_calls>[{"arguments": {"location": "NYC"}}]</tool_calls>'
+  PARSER.batch.4.d:
+    description: Missing </tool_calls> close
+    ref: dynamo
+    model_text: '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}]'
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+    # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
+    # vllm produces:
+    #   calls: []
+    #   normal_text: '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}]'

--- a/tests/parity/parser/fixtures/jamba/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/jamba/PARSER.batch.5.yaml
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: jamba
+mode: batch
+cases:
+  PARSER.batch.5.a:
+    description: Missing </tool_calls> end marker
+    ref: dynamo
+    model_text: '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}]'
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+    # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
+    # vllm produces:
+    #   calls: []
+    #   normal_text: '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}]'
+  PARSER.batch.5.b:
+    description: Closing </tool_calls> without matching <tool_calls> open
+    ref: dynamo
+    model_text: '[{"name": "get_weather", "arguments": {"location": "NYC"}}]</tool_calls>'
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: '[{"name": "get_weather", "arguments": {"location": "NYC"}}]</tool_calls>'
+  PARSER.batch.5.c:
+    description: Truncation mid-arguments JSON
+    ref: dynamo
+    model_text: '<tool_calls>[{"name": "get_weather", "arguments": {"loc'
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: '<tool_calls>[{"name": "get_weather", "arguments": {"loc'

--- a/tests/parity/parser/fixtures/jamba/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/jamba/PARSER.batch.6.yaml
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: jamba
+mode: batch
+cases:
+  PARSER.batch.6.a:
+    description: 'Canonical "arguments": {}'
+    ref: dynamo
+    model_text: '<tool_calls>[{"name": "get_time", "arguments": {}}]</tool_calls>'
+    tools:
+    - &id001
+      name: get_time
+      parameters:
+        type: object
+        properties: {}
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.6.b:
+    description: Whitespace inside arguments {}
+    ref: dynamo
+    model_text: '<tool_calls>[{"name": "get_time", "arguments": { }}]</tool_calls>'
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.6.c:
+    description: No arguments key
+    ref: dynamo
+    model_text: '<tool_calls>[{"name": "get_time"}]</tool_calls>'
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''
+    # TODO(research): vllm diverges — both return calls=[]; vLLM preserves raw input as normal_text on this recovery path, Dynamo emits empty
+    # vllm produces:
+    #   calls: []
+    #   normal_text: '<tool_calls>[{"name": "get_time"}]</tool_calls>'

--- a/tests/parity/parser/fixtures/jamba/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/jamba/PARSER.batch.7.yaml
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: jamba
+mode: batch
+cases:
+  PARSER.batch.7.a:
+    description: Standard scalar types
+    ref: dynamo
+    model_text: '<tool_calls>[{"name": "book_flight", "arguments": {"destination": "Paris", "passengers": 2, "first_class":
+      true}}]</tool_calls>'
+    tools:
+    - name: book_flight
+      parameters:
+        type: object
+        properties:
+          destination:
+            type: string
+          passengers:
+            type: integer
+          first_class:
+            type: boolean
+    expected:
+      calls:
+      - name: book_flight
+        arguments:
+          first_class: true
+          destination: Paris
+          passengers: 2
+      normal_text: ''
+  PARSER.batch.7.b:
+    description: Unicode + escaped chars
+    ref: dynamo
+    model_text: '<tool_calls>[{"name": "get_weather", "arguments": {"location": "Tōkyō \"central\""}}]</tool_calls>'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Tōkyō "central"
+      normal_text: ''
+  PARSER.batch.7.c:
+    description: Schema mismatch — string value where schema declares integer
+    ref: dynamo
+    model_text: '<tool_calls>[{"name": "set_temperature", "arguments": {"celsius": "20"}}]</tool_calls>'
+    tools:
+    - name: set_temperature
+      parameters:
+        type: object
+        properties:
+          celsius:
+            type: integer
+    expected:
+      calls:
+      - name: set_temperature
+        arguments:
+          celsius: '20'
+      normal_text: ''
+  PARSER.batch.7.d:
+    description: Nested object + array
+    ref: dynamo
+    model_text: '<tool_calls>[{"name": "process_data", "arguments": {"items": [1,2,3], "config": {"nested": true}}}]</tool_calls>'
+    tools:
+    - name: process_data
+      parameters:
+        type: object
+        properties:
+          items:
+            type: array
+          config:
+            type: object
+    expected:
+      calls:
+      - name: process_data
+        arguments:
+          items:
+          - 1
+          - 2
+          - 3
+          config:
+            nested: true
+      normal_text: ''

--- a/tests/parity/parser/fixtures/jamba/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/jamba/PARSER.batch.yaml
@@ -21,27 +21,6 @@ cases:
         arguments:
           location: NYC
       normal_text: ''
-  PARSER.batch.2:
-    description: Multiple tool calls (parallel)
-    model_text: '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_time", "arguments":
-      {"timezone": "EST"}}]</tool_calls>'
-    tools:
-    - *id001
-    - name: get_time
-      parameters:
-        type: object
-        properties:
-          timezone:
-            type: string
-    expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: ''
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
@@ -50,61 +29,6 @@ cases:
     expected:
       calls: []
       normal_text: Hello, how can I help you today?
-  PARSER.batch.4:
-    description: Malformed JSON args (missing close brace)
-    model_text: '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"]</tool_calls>'
-    tools:
-    - *id001
-    expected:
-      calls: []
-      normal_text: '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"]</tool_calls>'
-  PARSER.batch.5:
-    description: Missing </tool_calls> end marker
-    model_text: '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}]'
-    tools:
-    - *id001
-    expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
-  PARSER.batch.6:
-    description: Empty args (no-arg call)
-    model_text: '<tool_calls>[{"name": "get_time", "arguments": {}}]</tool_calls>'
-    tools:
-    - name: get_time
-      parameters:
-        type: object
-        properties: {}
-    expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
-  PARSER.batch.7:
-    description: Complex args (nested object + array)
-    model_text: '<tool_calls>[{"name": "process_data", "arguments": {"items": [1, 2, 3], "config": {"nested": true}}}]</tool_calls>'
-    tools:
-    - name: process_data
-      parameters:
-        type: object
-        properties:
-          items:
-            type: array
-          config:
-            type: object
-    expected:
-      calls:
-      - name: process_data
-        arguments:
-          items:
-          - 1
-          - 2
-          - 3
-          config:
-            nested: true
-      normal_text: ''
   PARSER.batch.9:
     description: Empty input
     model_text: ''

--- a/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.2.yaml
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: kimi_k2
+mode: batch
+cases:
+  PARSER.batch.2.a:
+    description: Parallel calls in single section
+    ref: dynamo
+    model_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_call_begin|>functions.get_time:1<|tool_call_argument_begin|>{"timezone":"EST"}<|tool_call_end|><|tool_calls_section_end|>
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - &id002
+      name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
+  PARSER.batch.2.b:
+    description: Two back-to-back sections (each with one call)
+    ref: dynamo
+    model_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|><|tool_calls_section_begin|><|tool_call_begin|>functions.get_time:1<|tool_call_argument_begin|>{"timezone":"EST"}<|tool_call_end|><|tool_calls_section_end|>
+    tools:
+    - *id001
+    - *id002
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
+  PARSER.batch.2.c:
+    description: Parallel calls with surrounding narration
+    ref: dynamo
+    model_text: I will check both. <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_call_begin|>functions.get_time:1<|tool_call_argument_begin|>{"timezone":"EST"}<|tool_call_end|><|tool_calls_section_end|>
+      Done.
+    tools:
+    - *id001
+    - *id002
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: I will check both.  Done.
+    # TODO(research): vllm diverges — drops trailing normal_text after tool-call wrapper end
+    # vllm produces:
+    #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}, {'name': 'get_time', 'arguments': {'timezone': 'EST'}}]
+    #   normal_text: 'I will check both. '
+  PARSER.batch.2.d:
+    description: Same-name twice (id distinctness)
+    ref: dynamo
+    model_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_call_begin|>functions.get_weather:1<|tool_call_argument_begin|>{"location":"LA"}<|tool_call_end|><|tool_calls_section_end|>
+    tools:
+    - *id001
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''

--- a/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.4.yaml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: kimi_k2
+mode: batch
+cases:
+  PARSER.batch.4.a:
+    description: Garbage between section fences (no call_begin)
+    ref: dynamo
+    model_text: <|tool_calls_section_begin|>nonsense<|tool_calls_section_end|>
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls: []
+      normal_text: ''
+  PARSER.batch.4.b:
+    description: Invalid JSON args (missing close brace)
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_kimi_k2_tool_parser.py#L151
+    model_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"<|tool_call_end|><|tool_calls_section_end|>
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments: '{"location":"NYC"'
+      normal_text: ''
+  PARSER.batch.4.c:
+    description: Missing function name (call_begin without functions.X:N)
+    ref: dynamo
+    model_text: <|tool_calls_section_begin|><|tool_call_begin|><|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''
+  PARSER.batch.4.d:
+    description: Mismatched fences (call_end before call_begin closes)
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_kimi_k2_tool_parser.py#L165
+    model_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_calls_section_end|>
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''

--- a/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.5.yaml
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: kimi_k2
+mode: batch
+cases:
+  PARSER.batch.5.a:
+    description: 'Missing section_end (max_tokens truncation, PR #8208)'
+    ref: dynamo
+    model_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|>
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+  PARSER.batch.5.b:
+    description: Closing section_end without matching section_begin
+    ref: dynamo
+    model_text: <|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: <|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>
+  PARSER.batch.5.c:
+    description: Truncation mid-arguments (incomplete JSON body)
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_kimi_k2_tool_parser.py#L413
+    model_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"loc
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''

--- a/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.6.yaml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: kimi_k2
+mode: batch
+cases:
+  PARSER.batch.6.a:
+    description: Canonical empty {} arguments
+    ref: dynamo
+    model_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.get_time:0<|tool_call_argument_begin|>{}<|tool_call_end|><|tool_calls_section_end|>
+    tools:
+    - &id001
+      name: get_time
+      parameters:
+        type: object
+        properties: {}
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.6.b:
+    description: Whitespace inside empty {}
+    ref: dynamo
+    model_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.get_time:0<|tool_call_argument_begin|>{ }<|tool_call_end|><|tool_calls_section_end|>
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.6.c:
+    description: No argument body (skip argument_begin → end)
+    ref: dynamo
+    model_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.get_time:0<|tool_call_end|><|tool_calls_section_end|>
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''

--- a/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.7.yaml
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: kimi_k2
+mode: batch
+cases:
+  PARSER.batch.7.a:
+    description: Standard scalar types (string + int + bool)
+    ref: dynamo
+    model_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.book_flight:0<|tool_call_argument_begin|>{"destination":"Paris","passengers":2,"first_class":true}<|tool_call_end|><|tool_calls_section_end|>
+    tools:
+    - name: book_flight
+      parameters:
+        type: object
+        properties:
+          destination:
+            type: string
+          passengers:
+            type: integer
+          first_class:
+            type: boolean
+    expected:
+      calls:
+      - name: book_flight
+        arguments:
+          destination: Paris
+          passengers: 2
+          first_class: true
+      normal_text: ''
+  PARSER.batch.7.b:
+    description: Unicode + escaped chars in string value
+    ref: dynamo
+    model_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"Tōkyō
+      \"central\""}<|tool_call_end|><|tool_calls_section_end|>
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Tōkyō "central"
+      normal_text: ''
+  PARSER.batch.7.c:
+    description: Schema mismatch — string value where schema declares integer
+    ref: dynamo
+    model_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.set_temperature:0<|tool_call_argument_begin|>{"celsius":"20"}<|tool_call_end|><|tool_calls_section_end|>
+    tools:
+    - name: set_temperature
+      parameters:
+        type: object
+        properties:
+          celsius:
+            type: integer
+    expected:
+      calls:
+      - name: set_temperature
+        arguments:
+          celsius: '20'
+      normal_text: ''
+  PARSER.batch.7.d:
+    description: Nested object + array (existing shape)
+    ref: dynamo
+    model_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.process_data:0<|tool_call_argument_begin|>{"items":[1,2,3],"config":{"nested":true}}<|tool_call_end|><|tool_calls_section_end|>
+    tools:
+    - name: process_data
+      parameters:
+        type: object
+        properties:
+          items:
+            type: array
+          config:
+            type: object
+    expected:
+      calls:
+      - name: process_data
+        arguments:
+          items:
+          - 1
+          - 2
+          - 3
+          config:
+            nested: true
+      normal_text: ''

--- a/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.8.yaml
@@ -6,7 +6,7 @@ mode: batch
 cases:
   PARSER.batch.8.a:
     description: Narration before tool call only
-    ref: inspired-by https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_kimi_k2_tool_parser.py#L272
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_kimi_k2_tool_parser.py#L272
     model_text: I'll check the weather. <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"Dallas"}<|tool_call_end|><|tool_calls_section_end|>
     tools:
     - &id001
@@ -28,7 +28,7 @@ cases:
     #   normal_text: "I'll check the weather. "
   PARSER.batch.8.b:
     description: Narration after tool call only
-    ref: inspired-by https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_kimi_k2_tool_parser.py#L435
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_kimi_k2_tool_parser.py#L435
     model_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"Dallas"}<|tool_call_end|><|tool_calls_section_end|>
       Let me know if you need more.
     tools:

--- a/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.yaml
@@ -21,26 +21,6 @@ cases:
         arguments:
           location: NYC
       normal_text: ''
-  PARSER.batch.2:
-    description: Multiple tool calls
-    model_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_call_begin|>functions.get_time:1<|tool_call_argument_begin|>{"timezone":"EST"}<|tool_call_end|><|tool_calls_section_end|>
-    tools:
-    - *id001
-    - name: get_time
-      parameters:
-        type: object
-        properties:
-          timezone:
-            type: string
-    expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: ''
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
@@ -49,63 +29,6 @@ cases:
     expected:
       calls: []
       normal_text: Hello, how can I help you today?
-  PARSER.batch.4:
-    description: Malformed JSON args (missing close brace)
-    model_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"<|tool_call_end|><|tool_calls_section_end|>
-    tools:
-    - *id001
-    expected:
-      calls:
-      - name: get_weather
-        arguments: '{"location":"NYC"'
-      normal_text: ''
-  PARSER.batch.5:
-    description: 'Missing section_end (max_tokens truncation, PR #8208)'
-    model_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|>
-    tools:
-    - *id001
-    expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
-  PARSER.batch.6:
-    description: Empty args (no-arg call)
-    model_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.get_time:0<|tool_call_argument_begin|>{}<|tool_call_end|><|tool_calls_section_end|>
-    tools:
-    - name: get_time
-      parameters:
-        type: object
-        properties: {}
-    expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
-  PARSER.batch.7:
-    description: Complex args (nested object + array)
-    model_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.process_data:0<|tool_call_argument_begin|>{"items":[1,2,3],"config":{"nested":true}}<|tool_call_end|><|tool_calls_section_end|>
-    tools:
-    - name: process_data
-      parameters:
-        type: object
-        properties:
-          items:
-            type: array
-          config:
-            type: object
-    expected:
-      calls:
-      - name: process_data
-        arguments:
-          items:
-          - 1
-          - 2
-          - 3
-          config:
-            nested: true
-      normal_text: ''
   PARSER.batch.9:
     description: Empty input
     model_text: ''

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.batch.2.yaml
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: llama3_json
+mode: batch
+cases:
+  PARSER.batch.2.a:
+    description: Parallel calls (semicolon-separated)
+    ref: dynamo
+    model_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}};{"name": "get_time", "arguments":
+      {"timezone": "EST"}}'
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - &id002
+      name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      calls: []
+      normal_text: ''
+    # TODO(research): vllm diverges — vLLM llama3_json does not parse semicolon-separated calls the same way Dynamo does
+    # vllm produces:
+    #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}, {'name': 'get_time', 'arguments': {'timezone': 'EST'}}]
+    #   normal_text: None
+  PARSER.batch.2.c:
+    description: With surrounding narration
+    ref: dynamo
+    model_text: 'Both: <|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}};{"name": "get_time", "arguments":
+      {"timezone": "EST"}} Done.'
+    tools:
+    - *id001
+    - *id002
+    expected:
+      calls: []
+      normal_text: ''
+    # TODO(research): vllm diverges — vLLM llama3_json does not parse semicolon-separated calls the same way Dynamo does
+    # vllm produces:
+    #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}, {'name': 'get_time', 'arguments': {'timezone': 'EST'}}]
+    #   normal_text: None
+  PARSER.batch.2.d:
+    description: Same-name twice (semicolon-separated)
+    ref: dynamo
+    model_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}};{"name": "get_weather", "arguments":
+      {"location": "LA"}}'
+    tools:
+    - *id001
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''
+    # TODO(research): vllm diverges — vLLM llama3_json does not parse semicolon-separated calls the same way Dynamo does
+    # vllm produces:
+    #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}, {'name': 'get_weather', 'arguments': {'location': 'LA'}}]
+    #   normal_text: None

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.batch.4.yaml
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: llama3_json
+mode: batch
+cases:
+  PARSER.batch.4.a:
+    description: Python_tag prefix with non-JSON garbage
+    ref: dynamo
+    model_text: <|python_tag|>not even json
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls: []
+      normal_text: ''
+    # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
+    # vllm produces:
+    #   calls: []
+    #   normal_text: '<|python_tag|>not even json'
+  PARSER.batch.4.b:
+    description: Missing close brace
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_llama3_json_tool_parser.py#L66
+    model_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"'
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''
+    # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
+    # vllm produces:
+    #   calls: []
+    #   normal_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"'
+  PARSER.batch.4.c:
+    description: Missing name key
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_llama3_json_tool_parser.py#L234
+    model_text: '<|python_tag|>{"arguments": {"location": "NYC"}}'
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''
+    # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
+    # vllm produces:
+    #   calls: []
+    #   normal_text: '<|python_tag|>{"arguments": {"location": "NYC"}}'

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.batch.5.yaml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: llama3_json
+mode: batch
+cases:
+  PARSER.batch.5.a:
+    description: No explicit end (truncation)
+    ref: dynamo
+    model_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}'
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls: []
+      normal_text: ''
+    # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
+    # vllm produces:
+    #   calls: []
+    #   normal_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}'
+  PARSER.batch.5.c:
+    description: Truncation deeper inside arguments JSON (vs .a which truncates at the closing brace)
+    ref: dynamo
+    model_text: '<|python_tag|>{"name": "get_weather", "arguments": {"loc'
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''
+    # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
+    # vllm produces:
+    #   calls: []
+    #   normal_text: '<|python_tag|>{"name": "get_weather", "arguments": {"loc'

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.batch.6.yaml
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: llama3_json
+mode: batch
+cases:
+  PARSER.batch.6.a:
+    description: 'Canonical "arguments": {}'
+    ref: dynamo
+    model_text: '<|python_tag|>{"name": "get_time", "arguments": {}}'
+    tools:
+    - &id001
+      name: get_time
+      parameters:
+        type: object
+        properties: {}
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.6.b:
+    description: Whitespace inside arguments {}
+    ref: dynamo
+    model_text: '<|python_tag|>{"name": "get_time", "arguments": { }}'
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.6.c:
+    description: No arguments key
+    ref: dynamo
+    model_text: '<|python_tag|>{"name": "get_time"}'
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''
+    # TODO(research): vllm diverges — both return calls=[]; vLLM preserves raw input as normal_text on this recovery path, Dynamo emits empty
+    # vllm produces:
+    #   calls: []
+    #   normal_text: '<|python_tag|>{"name": "get_time"}'

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.batch.7.yaml
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: llama3_json
+mode: batch
+cases:
+  PARSER.batch.7.a:
+    description: Standard scalar types
+    ref: dynamo
+    model_text: '<|python_tag|>{"name": "book_flight", "arguments": {"destination": "Paris", "passengers": 2, "first_class":
+      true}}'
+    tools:
+    - name: book_flight
+      parameters:
+        type: object
+        properties:
+          destination:
+            type: string
+          passengers:
+            type: integer
+          first_class:
+            type: boolean
+    expected:
+      calls:
+      - name: book_flight
+        arguments:
+          destination: Paris
+          first_class: true
+          passengers: 2
+      normal_text: ''
+  PARSER.batch.7.b:
+    description: Unicode + escaped chars
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_llama3_json_tool_parser.py#L217
+    model_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location": "Tōkyō \"central\""}}'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Tōkyō "central"
+      normal_text: ''
+  PARSER.batch.7.c:
+    description: Schema mismatch — string value where schema declares integer
+    ref: dynamo
+    model_text: '<|python_tag|>{"name": "set_temperature", "arguments": {"celsius": "20"}}'
+    tools:
+    - name: set_temperature
+      parameters:
+        type: object
+        properties:
+          celsius:
+            type: integer
+    expected:
+      calls:
+      - name: set_temperature
+        arguments:
+          celsius: '20'
+      normal_text: ''
+  PARSER.batch.7.d:
+    description: Nested object + array
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_llama3_json_tool_parser.py#L146
+    model_text: '<|python_tag|>{"name": "process_data", "arguments": {"items": [1,2,3], "config": {"nested": true}}}'
+    tools:
+    - name: process_data
+      parameters:
+        type: object
+        properties:
+          items:
+            type: array
+          config:
+            type: object
+    expected:
+      calls:
+      - name: process_data
+        arguments:
+          config:
+            nested: true
+          items:
+          - 1
+          - 2
+          - 3
+      normal_text: ''

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.batch.8.yaml
@@ -40,7 +40,7 @@ cases:
       normal_text: ''
   PARSER.batch.8.c:
     description: Narration both before and after (sandwich)
-    ref: inspired-by https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_llama3_json_tool_parser.py#L128
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_llama3_json_tool_parser.py#L128
     model_text: 'I will check the weather. <|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}} Let me
       know if you need more.'
     tools:

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.batch.yaml
@@ -21,21 +21,6 @@ cases:
         arguments:
           location: NYC
       normal_text: ''
-  PARSER.batch.2:
-    description: Multiple tool calls (parallel)
-    model_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}};{"name": "get_time", "arguments":
-      {"timezone": "EST"}}'
-    tools:
-    - *id001
-    - name: get_time
-      parameters:
-        type: object
-        properties:
-          timezone:
-            type: string
-    expected:
-      calls: []
-      normal_text: ''
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
@@ -44,58 +29,6 @@ cases:
     expected:
       calls: []
       normal_text: Hello, how can I help you today?
-  PARSER.batch.4:
-    description: Malformed JSON args (missing close brace)
-    model_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"'
-    tools:
-    - *id001
-    expected:
-      calls: []
-      normal_text: ''
-  PARSER.batch.5:
-    description: No explicit end (truncation)
-    model_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}'
-    tools:
-    - *id001
-    expected:
-      calls: []
-      normal_text: ''
-  PARSER.batch.6:
-    description: Empty args (no-arg call)
-    model_text: '<|python_tag|>{"name": "get_time", "arguments": {}}'
-    tools:
-    - name: get_time
-      parameters:
-        type: object
-        properties: {}
-    expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
-  PARSER.batch.7:
-    description: Complex args (nested object + array)
-    model_text: '<|python_tag|>{"name": "process_data", "arguments": {"items": [1, 2, 3], "config": {"nested": true}}}'
-    tools:
-    - name: process_data
-      parameters:
-        type: object
-        properties:
-          items:
-            type: array
-          config:
-            type: object
-    expected:
-      calls:
-      - name: process_data
-        arguments:
-          items:
-          - 1
-          - 2
-          - 3
-          config:
-            nested: true
-      normal_text: ''
   PARSER.batch.9:
     description: Empty input
     model_text: ''

--- a/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.2.yaml
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: minimax_m2
+mode: batch
+cases:
+  PARSER.batch.2.a:
+    description: Two invokes inside one tool_call wrapper
+    ref: dynamo
+    model_text: |-
+      <minimax:tool_call>
+      <invoke name="get_weather">
+      <parameter name="location">NYC</parameter>
+      </invoke>
+      <invoke name="get_time">
+      <parameter name="timezone">EST</parameter>
+      </invoke>
+      </minimax:tool_call>
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - &id002
+      name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
+  PARSER.batch.2.b:
+    description: Two back-to-back tool_call wrappers
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_minimax_m2_tool_parser.py#L207
+    model_text: |-
+      <minimax:tool_call>
+      <invoke name="get_weather">
+      <parameter name="location">NYC</parameter>
+      </invoke>
+      </minimax:tool_call>
+      <minimax:tool_call>
+      <invoke name="get_time">
+      <parameter name="timezone">EST</parameter>
+      </invoke>
+      </minimax:tool_call>
+    tools:
+    - *id001
+    - *id002
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
+  PARSER.batch.2.c:
+    description: Parallel with surrounding narration
+    ref: dynamo
+    model_text: |-
+      Both: <minimax:tool_call>
+      <invoke name="get_weather">
+      <parameter name="location">NYC</parameter>
+      </invoke>
+      <invoke name="get_time">
+      <parameter name="timezone">EST</parameter>
+      </invoke>
+      </minimax:tool_call> Done.
+    tools:
+    - *id001
+    - *id002
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: 'Both: '
+  PARSER.batch.2.d:
+    description: Same-name twice
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_minimax_m2_tool_parser.py#L331
+    model_text: |-
+      <minimax:tool_call>
+      <invoke name="get_weather">
+      <parameter name="location">NYC</parameter>
+      </invoke>
+      <invoke name="get_weather">
+      <parameter name="location">LA</parameter>
+      </invoke>
+      </minimax:tool_call>
+    tools:
+    - *id001
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''

--- a/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.4.yaml
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: minimax_m2
+mode: batch
+cases:
+  PARSER.batch.4.a:
+    description: Tool_call wrapper with garbage body
+    ref: dynamo
+    model_text: |-
+      <minimax:tool_call>
+      not a valid invoke
+      </minimax:tool_call>
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls: []
+      normal_text: ''
+    # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
+    # vllm produces:
+    #   calls: []
+    #   normal_text: '<minimax:tool_call>\nnot a valid invoke\n</minimax:tool_call>'
+  # PARSER.batch.4.b (invalid JSON args) n/a: minimax_m2 uses attribute-encoded args, not JSON.
+  PARSER.batch.4.c:
+    description: Invoke without name attribute
+    ref: dynamo
+    model_text: |-
+      <minimax:tool_call>
+      <invoke>
+      <parameter name="location">NYC</parameter>
+      </invoke>
+      </minimax:tool_call>
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''
+    # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
+    # vllm produces:
+    #   calls: []
+    #   normal_text: '<minimax:tool_call>\n<invoke>\n<parameter name="location">NYC</parameter>\n</invoke>\n</minimax:tool_call>'
+  PARSER.batch.4.d:
+    description: Missing closing </invoke>
+    ref: dynamo
+    model_text: |-
+      <minimax:tool_call>
+      <invoke name="get_weather">
+      <parameter name="location">NYC</parameter>
+      </minimax:tool_call>
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+    # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
+    # vllm produces:
+    #   calls: []
+    #   normal_text: '<minimax:tool_call>\n<invoke name="get_weather">\n<parameter name="location">NYC</parameter>\n</minimax:tool_call>'

--- a/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.5.yaml
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: minimax_m2
+mode: batch
+cases:
+  PARSER.batch.5.a:
+    description: Missing </minimax:tool_call> end marker
+    ref: dynamo
+    model_text: |-
+      <minimax:tool_call>
+      <invoke name="get_weather">
+      <parameter name="location">NYC</parameter>
+      </invoke>
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+    # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
+    # vllm produces:
+    #   calls: []
+    #   normal_text: '<minimax:tool_call>\n<invoke name="get_weather">\n<parameter name="location">NYC</parameter>\n</invoke>'
+  PARSER.batch.5.b:
+    description: Closing </minimax:tool_call> without matching open
+    ref: dynamo
+    model_text: |-
+      <invoke name="get_weather">
+      <parameter name="location">NYC</parameter>
+      </invoke>
+      </minimax:tool_call>
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: |-
+        <invoke name="get_weather">
+        <parameter name="location">NYC</parameter>
+        </invoke>
+        </minimax:tool_call>
+  PARSER.batch.5.c:
+    description: Truncation mid-parameter value
+    ref: dynamo
+    model_text: |-
+      <minimax:tool_call>
+      <invoke name="get_weather">
+      <parameter name="location">NY
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NY
+      normal_text: ''
+    # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
+    # vllm produces:
+    #   calls: []
+    #   normal_text: '<minimax:tool_call>\n<invoke name="get_weather">\n<parameter name="location">NY'

--- a/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.6.yaml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: minimax_m2
+mode: batch
+cases:
+  PARSER.batch.6.a:
+    description: Invoke with no <parameter>
+    ref: dynamo
+    model_text: |-
+      <minimax:tool_call>
+      <invoke name="get_time">
+      </invoke>
+      </minimax:tool_call>
+    tools:
+    - &id001
+      name: get_time
+      parameters:
+        type: object
+        properties: {}
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.6.b:
+    description: Invoke with extra newline
+    ref: dynamo
+    model_text: |-
+      <minimax:tool_call>
+      <invoke name="get_time">
+
+      </invoke>
+      </minimax:tool_call>
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''

--- a/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.7.yaml
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: minimax_m2
+mode: batch
+cases:
+  PARSER.batch.7.a:
+    description: Multiple parameters
+    ref: dynamo
+    model_text: |-
+      <minimax:tool_call>
+      <invoke name="book_flight">
+      <parameter name="destination">Paris</parameter>
+      <parameter name="passengers">2</parameter>
+      <parameter name="first_class">true</parameter>
+      </invoke>
+      </minimax:tool_call>
+    tools:
+    - name: book_flight
+      parameters:
+        type: object
+        properties:
+          destination:
+            type: string
+          passengers:
+            type: integer
+          first_class:
+            type: boolean
+    expected:
+      calls:
+      - name: book_flight
+        arguments:
+          destination: Paris
+          first_class: true
+          passengers: 2
+      normal_text: ''
+    # TODO(research): vllm diverges — vLLM emits JSON-typed parameter values as raw strings; Dynamo coerces nested object/array types
+    # vllm produces:
+    #   calls: [{'name': 'book_flight', 'arguments': {'destination': 'Paris', 'passengers': '2', 'first_class': 'true'}}]
+    #   normal_text: None
+  PARSER.batch.7.b:
+    description: Unicode in parameter
+    ref: dynamo
+    model_text: |-
+      <minimax:tool_call>
+      <invoke name="get_weather">
+      <parameter name="location">Tōkyō central</parameter>
+      </invoke>
+      </minimax:tool_call>
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Tōkyō central
+      normal_text: ''

--- a/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.8.yaml
@@ -6,7 +6,7 @@ mode: batch
 cases:
   PARSER.batch.8.a:
     description: Narration before tool call only
-    ref: inspired-by https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_minimax_m2_tool_parser.py#L126
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_minimax_m2_tool_parser.py#L126
     model_text: |-
       I will check the weather. <minimax:tool_call>
       <invoke name="get_weather">

--- a/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.yaml
@@ -26,34 +26,6 @@ cases:
         arguments:
           location: NYC
       normal_text: ''
-  PARSER.batch.2:
-    description: Multiple tool calls
-    model_text: |-
-      <minimax:tool_call>
-      <invoke name="get_weather">
-      <parameter name="location">NYC</parameter>
-      </invoke>
-      <invoke name="get_time">
-      <parameter name="timezone">EST</parameter>
-      </invoke>
-      </minimax:tool_call>
-    tools:
-    - *id001
-    - name: get_time
-      parameters:
-        type: object
-        properties:
-          timezone:
-            type: string
-    expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: ''
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
@@ -62,78 +34,6 @@ cases:
     expected:
       calls: []
       normal_text: Hello, how can I help you today?
-  PARSER.batch.4:
-    description: Malformed (missing closing invoke tag)
-    model_text: |-
-      <minimax:tool_call>
-      <invoke name="get_weather">
-      <parameter name="location">NYC</parameter>
-      </minimax:tool_call>
-    tools:
-    - *id001
-    expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
-  PARSER.batch.5:
-    description: Missing </minimax:tool_call> end marker
-    model_text: |-
-      <minimax:tool_call>
-      <invoke name="get_weather">
-      <parameter name="location">NYC</parameter>
-      </invoke>
-    tools:
-    - *id001
-    expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
-  PARSER.batch.6:
-    description: Empty args (no-arg call)
-    model_text: |-
-      <minimax:tool_call>
-      <invoke name="get_time">
-      </invoke>
-      </minimax:tool_call>
-    tools:
-    - name: get_time
-      parameters:
-        type: object
-        properties: {}
-    expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
-  PARSER.batch.7:
-    description: Complex args (multi-parameter)
-    model_text: |-
-      <minimax:tool_call>
-      <invoke name="get_weather">
-      <parameter name="location">NYC</parameter>
-      <parameter name="unit">fahrenheit</parameter>
-      </invoke>
-      </minimax:tool_call>
-    tools:
-    - name: get_weather
-      parameters:
-        type: object
-        properties:
-          location:
-            type: string
-          unit:
-            type: string
-    expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-          unit: fahrenheit
-      normal_text: ''
   PARSER.batch.9:
     description: Empty input
     model_text: ''

--- a/tests/parity/parser/fixtures/mistral/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/mistral/PARSER.batch.2.yaml
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: mistral
+mode: batch
+cases:
+  PARSER.batch.2.a:
+    description: Parallel calls in JSON array
+    ref: dynamo
+    model_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_time", "arguments":
+      {"timezone": "EST"}}][/TOOL_CALLS]'
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - &id002
+      name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
+  PARSER.batch.2.c:
+    description: With surrounding narration
+    ref: dynamo
+    model_text: 'Both: [TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_time", "arguments":
+      {"timezone": "EST"}}][/TOOL_CALLS] Done.'
+    tools:
+    - *id001
+    - *id002
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: 'Both:'
+    # TODO(research): vllm diverges — drops trailing normal_text after tool-call wrapper end
+    # vllm produces:
+    #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}, {'name': 'get_time', 'arguments': {'timezone': 'EST'}}]
+    #   normal_text: 'Both: '
+  PARSER.batch.2.d:
+    description: Same-name twice
+    ref: dynamo
+    model_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_weather", "arguments":
+      {"location": "LA"}}][/TOOL_CALLS]'
+    tools:
+    - *id001
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''

--- a/tests/parity/parser/fixtures/mistral/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/mistral/PARSER.batch.4.yaml
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: mistral
+mode: batch
+cases:
+  PARSER.batch.4.a:
+    description: TOOL_CALLS wrapper with garbage
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_mistral_tool_parser.py#L405
+    model_text: '[TOOL_CALLS]not a json array[/TOOL_CALLS]'
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls: []
+      normal_text: '[TOOL_CALLS]not a json array[/TOOL_CALLS]'
+    # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
+    # vllm produces:
+    #   calls: []
+    #   normal_text: 'not a json array[/TOOL_CALLS]'
+  PARSER.batch.4.b:
+    description: Missing close brace in JSON
+    ref: dynamo
+    model_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"][/TOOL_CALLS]'
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"][/TOOL_CALLS]'
+    # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
+    # vllm produces:
+    #   calls: []
+    #   normal_text: '[{"name": "get_weather", "arguments": {"location": "NYC"][/TOOL_CALLS]'
+  PARSER.batch.4.c:
+    description: Missing name key
+    ref: dynamo
+    model_text: '[TOOL_CALLS][{"arguments": {"location": "NYC"}}][/TOOL_CALLS]'
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''
+    # TODO(research): vllm diverges — EXPECTS_ERROR(KeyError): vLLM mistral_tool_parser raises KeyError when 'name' key is missing
+    # vllm produces:
+    #   error: KeyError: 'name'
+  PARSER.batch.4.d:
+    description: Missing [/TOOL_CALLS] close
+    ref: dynamo
+    model_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}]'
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''

--- a/tests/parity/parser/fixtures/mistral/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/mistral/PARSER.batch.5.yaml
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: mistral
+mode: batch
+cases:
+  PARSER.batch.5.a:
+    description: Missing [/TOOL_CALLS] end marker
+    ref: dynamo
+    model_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}]'
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+  PARSER.batch.5.b:
+    description: Closing [/TOOL_CALLS] without matching [TOOL_CALLS] open
+    ref: dynamo
+    model_text: '[{"name": "get_weather", "arguments": {"location": "NYC"}}][/TOOL_CALLS]'
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: '[{"name": "get_weather", "arguments": {"location": "NYC"}}][/TOOL_CALLS]'
+  PARSER.batch.5.c:
+    description: Truncation mid-arguments JSON
+    ref: dynamo
+    model_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"loc'
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"loc'
+    # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
+    # vllm produces:
+    #   calls: []
+    #   normal_text: '[{"name": "get_weather", "arguments": {"loc'

--- a/tests/parity/parser/fixtures/mistral/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/mistral/PARSER.batch.6.yaml
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: mistral
+mode: batch
+cases:
+  PARSER.batch.6.a:
+    description: 'Canonical "arguments": {}'
+    ref: dynamo
+    model_text: '[TOOL_CALLS][{"name": "get_time", "arguments": {}}][/TOOL_CALLS]'
+    tools:
+    - &id001
+      name: get_time
+      parameters:
+        type: object
+        properties: {}
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.6.b:
+    description: Whitespace inside arguments {}
+    ref: dynamo
+    model_text: '[TOOL_CALLS][{"name": "get_time", "arguments": { }}][/TOOL_CALLS]'
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.6.c:
+    description: No arguments key
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_mistral_tool_parser.py#L514
+    model_text: '[TOOL_CALLS][{"name": "get_time"}][/TOOL_CALLS]'
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''
+    # TODO(research): vllm diverges — vLLM accepts call with missing arguments key as having empty args; Dynamo returns calls=[]
+    # vllm produces:
+    #   calls: [{'name': 'get_time', 'arguments': {}}]
+    #   normal_text: None

--- a/tests/parity/parser/fixtures/mistral/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/mistral/PARSER.batch.7.yaml
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: mistral
+mode: batch
+cases:
+  PARSER.batch.7.a:
+    description: Standard scalar types
+    ref: dynamo
+    model_text: '[TOOL_CALLS][{"name": "book_flight", "arguments": {"destination": "Paris", "passengers": 2, "first_class":
+      true}}][/TOOL_CALLS]'
+    tools:
+    - name: book_flight
+      parameters:
+        type: object
+        properties:
+          destination:
+            type: string
+          passengers:
+            type: integer
+          first_class:
+            type: boolean
+    expected:
+      calls:
+      - name: book_flight
+        arguments:
+          destination: Paris
+          first_class: true
+          passengers: 2
+      normal_text: ''
+  PARSER.batch.7.b:
+    description: Unicode + escaped chars
+    ref: dynamo
+    model_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "Tōkyō \"central\""}}][/TOOL_CALLS]'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Tōkyō "central"
+      normal_text: ''
+  PARSER.batch.7.c:
+    description: Schema mismatch — string value where schema declares integer
+    ref: dynamo
+    model_text: '[TOOL_CALLS][{"name": "set_temperature", "arguments": {"celsius": "20"}}][/TOOL_CALLS]'
+    tools:
+    - name: set_temperature
+      parameters:
+        type: object
+        properties:
+          celsius:
+            type: integer
+    expected:
+      calls:
+      - name: set_temperature
+        arguments:
+          celsius: '20'
+      normal_text: ''
+  PARSER.batch.7.d:
+    description: Nested object + array
+    ref: dynamo
+    model_text: '[TOOL_CALLS][{"name": "process_data", "arguments": {"items": [1,2,3], "config": {"nested": true}}}][/TOOL_CALLS]'
+    tools:
+    - name: process_data
+      parameters:
+        type: object
+        properties:
+          items:
+            type: array
+          config:
+            type: object
+    expected:
+      calls:
+      - name: process_data
+        arguments:
+          items:
+          - 1
+          - 2
+          - 3
+          config:
+            nested: true
+      normal_text: ''

--- a/tests/parity/parser/fixtures/mistral/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/mistral/PARSER.batch.8.yaml
@@ -41,7 +41,7 @@ cases:
       normal_text: ''
   PARSER.batch.8.c:
     description: Narration both before and after (sandwich)
-    ref: inspired-by https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_mistral_tool_parser.py#L1858
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_mistral_tool_parser.py#L1858
     model_text: 'I will check the weather. [TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}][/TOOL_CALLS]
       Let me know if you need more.'
     tools:

--- a/tests/parity/parser/fixtures/mistral/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/mistral/PARSER.batch.yaml
@@ -21,27 +21,6 @@ cases:
         arguments:
           location: NYC
       normal_text: ''
-  PARSER.batch.2:
-    description: Multiple tool calls (parallel)
-    model_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_time", "arguments":
-      {"timezone": "EST"}}][/TOOL_CALLS]'
-    tools:
-    - *id001
-    - name: get_time
-      parameters:
-        type: object
-        properties:
-          timezone:
-            type: string
-    expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: ''
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
@@ -50,61 +29,6 @@ cases:
     expected:
       calls: []
       normal_text: Hello, how can I help you today?
-  PARSER.batch.4:
-    description: Malformed JSON args (missing close brace)
-    model_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"][/TOOL_CALLS]'
-    tools:
-    - *id001
-    expected:
-      calls: []
-      normal_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"][/TOOL_CALLS]'
-  PARSER.batch.5:
-    description: Missing [/TOOL_CALLS] end marker
-    model_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}]'
-    tools:
-    - *id001
-    expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
-  PARSER.batch.6:
-    description: Empty args (no-arg call)
-    model_text: '[TOOL_CALLS][{"name": "get_time", "arguments": {}}][/TOOL_CALLS]'
-    tools:
-    - name: get_time
-      parameters:
-        type: object
-        properties: {}
-    expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
-  PARSER.batch.7:
-    description: Complex args (nested object + array)
-    model_text: '[TOOL_CALLS][{"name": "process_data", "arguments": {"items": [1, 2, 3], "config": {"nested": true}}}][/TOOL_CALLS]'
-    tools:
-    - name: process_data
-      parameters:
-        type: object
-        properties:
-          items:
-            type: array
-          config:
-            type: object
-    expected:
-      calls:
-      - name: process_data
-        arguments:
-          items:
-          - 1
-          - 2
-          - 3
-          config:
-            nested: true
-      normal_text: ''
   PARSER.batch.9:
     description: Empty input
     model_text: ''

--- a/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.2.yaml
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: nemotron_deci
+mode: batch
+cases:
+  PARSER.batch.2.a:
+    description: Parallel calls in JSON array
+    ref: dynamo
+    model_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_time", "arguments": {"timezone":
+      "EST"}}]</TOOLCALL>'
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - &id002
+      name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
+  PARSER.batch.2.b:
+    description: Two back-to-back TOOLCALL wrappers
+    ref: dynamo
+    model_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}]</TOOLCALL><TOOLCALL>[{"name": "get_time",
+      "arguments": {"timezone": "EST"}}]</TOOLCALL>'
+    tools:
+    - *id001
+    - *id002
+    expected:
+      calls: []
+      normal_text: ''
+    # NOTE: Dynamo's nemotron_deci parser does not restart on back-to-back
+    # <TOOLCALL>...</TOOLCALL> wrappers (handles multi-call within ONE wrapper
+    # — see 2.a — but not multiple wrappers). Known parser limitation; the
+    # fixture pins actual oracle output, not desired behavior. nemotron_deci
+    # has no vLLM/SGLang peer (n/a row in parity matrix) so this is
+    # Dynamo-self-check only.
+  PARSER.batch.2.c:
+    description: With surrounding narration
+    ref: dynamo
+    model_text: 'Both: <TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_time", "arguments":
+      {"timezone": "EST"}}]</TOOLCALL> Done.'
+    tools:
+    - *id001
+    - *id002
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: 'Both:'
+  PARSER.batch.2.d:
+    description: Same-name twice
+    ref: dynamo
+    model_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_weather", "arguments":
+      {"location": "LA"}}]</TOOLCALL>'
+    tools:
+    - *id001
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''

--- a/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.4.yaml
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: nemotron_deci
+mode: batch
+cases:
+  PARSER.batch.4.a:
+    description: TOOLCALL wrapper with garbage
+    ref: dynamo
+    model_text: <TOOLCALL>not a json array</TOOLCALL>
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls: []
+      normal_text: <TOOLCALL>not a json array</TOOLCALL>
+  PARSER.batch.4.b:
+    description: Unterminated JSON string in args
+    ref: dynamo
+    model_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC</TOOLCALL>'
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+  PARSER.batch.4.c:
+    description: Missing name key in JSON
+    ref: dynamo
+    model_text: '<TOOLCALL>[{"arguments": {"location": "NYC"}}]</TOOLCALL>'
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''
+  PARSER.batch.4.d:
+    description: Mismatched JSON brackets
+    ref: dynamo
+    model_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}</TOOLCALL>'
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''

--- a/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.5.yaml
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: nemotron_deci
+mode: batch
+cases:
+  PARSER.batch.5.a:
+    description: Missing </TOOLCALL> end marker
+    ref: dynamo
+    model_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}]'
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+  PARSER.batch.5.b:
+    description: Closing </TOOLCALL> without matching <TOOLCALL> open
+    ref: dynamo
+    model_text: '[{"name": "get_weather", "arguments": {"location": "NYC"}}]</TOOLCALL>'
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: '[{"name": "get_weather", "arguments": {"location": "NYC"}}]</TOOLCALL>'
+  PARSER.batch.5.c:
+    description: Truncation mid-arguments JSON
+    ref: dynamo
+    model_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"loc'
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"loc'

--- a/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.6.yaml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: nemotron_deci
+mode: batch
+cases:
+  PARSER.batch.6.a:
+    description: 'Canonical "arguments": {}'
+    ref: dynamo
+    model_text: '<TOOLCALL>[{"name": "get_time", "arguments": {}}]</TOOLCALL>'
+    tools:
+    - &id001
+      name: get_time
+      parameters:
+        type: object
+        properties: {}
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.6.b:
+    description: Whitespace inside arguments {}
+    ref: dynamo
+    model_text: '<TOOLCALL>[{"name": "get_time", "arguments": { }}]</TOOLCALL>'
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.6.c:
+    description: No arguments key
+    ref: dynamo
+    model_text: '<TOOLCALL>[{"name": "get_time"}]</TOOLCALL>'
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''

--- a/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.7.yaml
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: nemotron_deci
+mode: batch
+cases:
+  PARSER.batch.7.a:
+    description: Standard scalar types
+    ref: dynamo
+    model_text: '<TOOLCALL>[{"name": "book_flight", "arguments": {"destination": "Paris", "passengers": 2, "first_class":
+      true}}]</TOOLCALL>'
+    tools:
+    - name: book_flight
+      parameters:
+        type: object
+        properties:
+          destination:
+            type: string
+          passengers:
+            type: integer
+          first_class:
+            type: boolean
+    expected:
+      calls:
+      - name: book_flight
+        arguments:
+          first_class: true
+          destination: Paris
+          passengers: 2
+      normal_text: ''
+  PARSER.batch.7.b:
+    description: Unicode + escaped chars
+    ref: dynamo
+    model_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "Tōkyō \"central\""}}]</TOOLCALL>'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Tōkyō "central"
+      normal_text: ''
+  PARSER.batch.7.c:
+    description: Schema mismatch — string value where schema declares integer
+    ref: dynamo
+    model_text: '<TOOLCALL>[{"name": "set_temperature", "arguments": {"celsius": "20"}}]</TOOLCALL>'
+    tools:
+    - name: set_temperature
+      parameters:
+        type: object
+        properties:
+          celsius:
+            type: integer
+    expected:
+      calls:
+      - name: set_temperature
+        arguments:
+          celsius: '20'
+      normal_text: ''
+  PARSER.batch.7.d:
+    description: Nested object + array (existing)
+    ref: dynamo
+    model_text: '<TOOLCALL>[{"name": "process_data", "arguments": {"items": [1,2,3], "config": {"nested": true}}}]</TOOLCALL>'
+    tools:
+    - name: process_data
+      parameters:
+        type: object
+        properties:
+          items:
+            type: array
+          config:
+            type: object
+    expected:
+      calls:
+      - name: process_data
+        arguments:
+          items:
+          - 1
+          - 2
+          - 3
+          config:
+            nested: true
+      normal_text: ''

--- a/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.yaml
@@ -21,27 +21,6 @@ cases:
         arguments:
           location: NYC
       normal_text: ''
-  PARSER.batch.2:
-    description: Multiple tool calls
-    model_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_time", "arguments": {"timezone":
-      "EST"}}]</TOOLCALL>'
-    tools:
-    - *id001
-    - name: get_time
-      parameters:
-        type: object
-        properties:
-          timezone:
-            type: string
-    expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: ''
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
@@ -50,64 +29,6 @@ cases:
     expected:
       calls: []
       normal_text: Hello, how can I help you today?
-  PARSER.batch.4:
-    description: Malformed (truncated JSON inside TOOLCALL)
-    model_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC</TOOLCALL>'
-    tools:
-    - *id001
-    expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
-  PARSER.batch.5:
-    description: Missing </TOOLCALL> end marker
-    model_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}]'
-    tools:
-    - *id001
-    expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
-  PARSER.batch.6:
-    description: Empty args (no-arg call)
-    model_text: '<TOOLCALL>[{"name": "get_time", "arguments": {}}]</TOOLCALL>'
-    tools:
-    - name: get_time
-      parameters:
-        type: object
-        properties: {}
-    expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
-  PARSER.batch.7:
-    description: Complex args (nested object + array)
-    model_text: '<TOOLCALL>[{"name": "process_data", "arguments": {"items": [1,2,3], "config": {"nested": true}}}]</TOOLCALL>'
-    tools:
-    - name: process_data
-      parameters:
-        type: object
-        properties:
-          items:
-            type: array
-          config:
-            type: object
-    expected:
-      calls:
-      - name: process_data
-        arguments:
-          config:
-            nested: true
-          items:
-          - 1
-          - 2
-          - 3
-      normal_text: ''
   PARSER.batch.9:
     description: Empty input
     model_text: ''

--- a/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.2.yaml
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: nemotron_nano
+mode: batch
+cases:
+  PARSER.batch.2.a:
+    description: Parallel calls (back-to-back tool_call wrappers)
+    ref: dynamo
+    model_text: |-
+      <tool_call>
+      <function=get_weather>
+      <parameter=location>
+      NYC
+      </parameter>
+      </function>
+      </tool_call>
+      <tool_call>
+      <function=get_time>
+      <parameter=timezone>
+      EST
+      </parameter>
+      </function>
+      </tool_call>
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - &id002
+      name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
+  PARSER.batch.2.c:
+    description: With surrounding narration
+    ref: dynamo
+    model_text: |-
+      Both: <tool_call>
+      <function=get_weather>
+      <parameter=location>
+      NYC
+      </parameter>
+      </function>
+      </tool_call>
+      <tool_call>
+      <function=get_time>
+      <parameter=timezone>
+      EST
+      </parameter>
+      </function>
+      </tool_call> Done.
+    tools:
+    - *id001
+    - *id002
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: 'Both: '
+  PARSER.batch.2.d:
+    description: Same-name twice
+    ref: dynamo
+    model_text: |-
+      <tool_call>
+      <function=get_weather>
+      <parameter=location>
+      NYC
+      </parameter>
+      </function>
+      </tool_call>
+      <tool_call>
+      <function=get_weather>
+      <parameter=location>
+      LA
+      </parameter>
+      </function>
+      </tool_call>
+    tools:
+    - *id001
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''

--- a/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.4.yaml
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: nemotron_nano
+mode: batch
+cases:
+  PARSER.batch.4.a:
+    description: Tool_call wrapper with no <function> body
+    ref: dynamo
+    model_text: |-
+      <tool_call>
+      random text
+      </tool_call>
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls: []
+      normal_text: ''
+  PARSER.batch.4.d:
+    description: Missing </parameter> closing tag
+    ref: dynamo
+    model_text: |-
+      <tool_call>
+      <function=get_weather>
+      <parameter=location>
+      NYC
+      </function>
+      </tool_call>
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''

--- a/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.5.yaml
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: nemotron_nano
+mode: batch
+cases:
+  PARSER.batch.5.a:
+    description: Missing </tool_call> end marker
+    ref: dynamo
+    model_text: |-
+      <tool_call>
+      <function=get_weather>
+      <parameter=location>
+      NYC
+      </parameter>
+      </function>
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+  PARSER.batch.5.b:
+    description: Closing </tool_call> without matching <tool_call> open
+    ref: dynamo
+    model_text: |-
+      <function=get_weather>
+      <parameter=location>
+      NYC
+      </parameter>
+      </function>
+      </tool_call>
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: |-
+        <function=get_weather>
+        <parameter=location>
+        NYC
+        </parameter>
+        </function>
+        </tool_call>
+  PARSER.batch.5.c:
+    description: Truncation mid-parameter value
+    ref: dynamo
+    model_text: |-
+      <tool_call>
+      <function=get_weather>
+      <parameter=location>
+      NY
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NY
+      normal_text: ''

--- a/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.6.yaml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: nemotron_nano
+mode: batch
+cases:
+  PARSER.batch.6.a:
+    description: Function block with no <parameter>
+    ref: dynamo
+    model_text: |-
+      <tool_call>
+      <function=get_time>
+      </function>
+      </tool_call>
+    tools:
+    - &id001
+      name: get_time
+      parameters:
+        type: object
+        properties: {}
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.6.b:
+    description: Function block with extra whitespace inside
+    ref: dynamo
+    model_text: |-
+      <tool_call>
+      <function=get_time>
+
+      </function>
+      </tool_call>
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''

--- a/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.7.yaml
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: nemotron_nano
+mode: batch
+cases:
+  PARSER.batch.7.a:
+    description: Multiple parameters
+    ref: dynamo
+    model_text: |-
+      <tool_call>
+      <function=book_flight>
+      <parameter=destination>
+      Paris
+      </parameter>
+      <parameter=passengers>
+      2
+      </parameter>
+      <parameter=first_class>
+      true
+      </parameter>
+      </function>
+      </tool_call>
+    tools:
+    - name: book_flight
+      parameters:
+        type: object
+        properties:
+          destination:
+            type: string
+          passengers:
+            type: integer
+          first_class:
+            type: boolean
+    expected:
+      calls:
+      - name: book_flight
+        arguments:
+          destination: Paris
+          passengers: 2
+          first_class: true
+      normal_text: ''
+  PARSER.batch.7.b:
+    description: Unicode in parameter
+    ref: dynamo
+    model_text: |-
+      <tool_call>
+      <function=get_weather>
+      <parameter=location>
+      Tōkyō central
+      </parameter>
+      </function>
+      </tool_call>
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Tōkyō central
+      normal_text: ''

--- a/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.yaml
@@ -28,40 +28,6 @@ cases:
         arguments:
           location: NYC
       normal_text: ''
-  PARSER.batch.2:
-    description: Multiple tool calls (parallel)
-    model_text: |-
-      <tool_call>
-      <function=get_weather>
-      <parameter=location>
-      NYC
-      </parameter>
-      </function>
-      </tool_call>
-      <tool_call>
-      <function=get_time>
-      <parameter=timezone>
-      EST
-      </parameter>
-      </function>
-      </tool_call>
-    tools:
-    - *id001
-    - name: get_time
-      parameters:
-        type: object
-        properties:
-          timezone:
-            type: string
-    expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: ''
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
@@ -70,86 +36,6 @@ cases:
     expected:
       calls: []
       normal_text: Hello, how can I help you today?
-  PARSER.batch.4:
-    description: Malformed (missing </parameter> closing tag)
-    model_text: |-
-      <tool_call>
-      <function=get_weather>
-      <parameter=location>
-      NYC
-      </function>
-      </tool_call>
-    tools:
-    - *id001
-    expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
-  PARSER.batch.5:
-    description: Missing </tool_call> end marker
-    model_text: |-
-      <tool_call>
-      <function=get_weather>
-      <parameter=location>
-      NYC
-      </parameter>
-      </function>
-    tools:
-    - *id001
-    expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
-  PARSER.batch.6:
-    description: Empty args (no-arg call)
-    model_text: |-
-      <tool_call>
-      <function=get_time>
-      </function>
-      </tool_call>
-    tools:
-    - name: get_time
-      parameters:
-        type: object
-        properties: {}
-    expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
-  PARSER.batch.7:
-    description: Complex args (multi-parameter)
-    model_text: |-
-      <tool_call>
-      <function=get_weather>
-      <parameter=location>
-      NYC
-      </parameter>
-      <parameter=unit>
-      fahrenheit
-      </parameter>
-      </function>
-      </tool_call>
-    tools:
-    - name: get_weather
-      parameters:
-        type: object
-        properties:
-          location:
-            type: string
-          unit:
-            type: string
-    expected:
-      calls:
-      - name: get_weather
-        arguments:
-          unit: fahrenheit
-          location: NYC
-      normal_text: ''
   PARSER.batch.9:
     description: Empty input
     model_text: ''

--- a/tests/parity/parser/fixtures/phi4/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/phi4/PARSER.batch.2.yaml
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: phi4
+mode: batch
+cases:
+  PARSER.batch.2.a:
+    description: Parallel calls in JSON array
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L185
+    model_text: 'functools[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_time", "arguments": {"timezone":
+      "EST"}}]'
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - &id002
+      name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
+  PARSER.batch.2.c:
+    description: With surrounding narration
+    ref: dynamo
+    model_text: 'Both: functools[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_time", "arguments":
+      {"timezone": "EST"}}] Done.'
+    tools:
+    - *id001
+    - *id002
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: 'Both:'
+    # TODO(research): vllm diverges — drops trailing normal_text after tool-call wrapper end
+    # vllm produces:
+    #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}, {'name': 'get_time', 'arguments': {'timezone': 'EST'}}]
+    #   normal_text: None
+  PARSER.batch.2.d:
+    description: Same-name twice
+    ref: dynamo
+    model_text: 'functools[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_weather", "arguments":
+      {"location": "LA"}}]'
+    tools:
+    - *id001
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''

--- a/tests/parity/parser/fixtures/phi4/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/phi4/PARSER.batch.4.yaml
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: phi4
+mode: batch
+cases:
+  PARSER.batch.4.a:
+    description: functools[ wrapper with garbage
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L322
+    model_text: functools[not a json array]
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls: []
+      normal_text: ''
+  PARSER.batch.4.b:
+    description: Missing close brace
+    ref: dynamo
+    model_text: 'functools[{"name": "get_weather", "arguments": {"location": "NYC"]'
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''
+  PARSER.batch.4.c:
+    description: Missing name key
+    ref: dynamo
+    model_text: 'functools[{"arguments": {"location": "NYC"}}]'
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''
+    # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
+    # vllm produces:
+    #   calls: []
+    #   normal_text: 'functools[{"arguments": {"location": "NYC"}}]'
+  PARSER.batch.4.d:
+    description: Missing closing ]
+    ref: dynamo
+    model_text: 'functools[{"name": "get_weather", "arguments": {"location": "NYC"}}'
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''
+    # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
+    # vllm produces:
+    #   calls: []
+    #   normal_text: 'functools[{"name": "get_weather", "arguments": {"location": "NYC"}}'

--- a/tests/parity/parser/fixtures/phi4/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/phi4/PARSER.batch.5.yaml
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: phi4
+mode: batch
+cases:
+  PARSER.batch.5.a:
+    description: No explicit end (truncation)
+    ref: dynamo
+    model_text: 'functools[{"name": "get_weather", "arguments": {"location": "NYC"}}'
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls: []
+      normal_text: ''
+    # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
+    # vllm produces:
+    #   calls: []
+    #   normal_text: 'functools[{"name": "get_weather", "arguments": {"location": "NYC"}}'
+  PARSER.batch.5.b:
+    description: Closing `]` without matching `functools[` open
+    ref: dynamo
+    model_text: 'functools{"name": "get_weather", "arguments": {"location": "NYC"}}]'
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+    # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
+    # vllm produces:
+    #   calls: []
+    #   normal_text: 'functools{"name": "get_weather", "arguments": {"location": "NYC"}}]'
+  PARSER.batch.5.c:
+    description: Truncation mid-arguments JSON
+    ref: dynamo
+    model_text: 'functools[{"name": "get_weather", "arguments": {"loc'
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''
+    # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
+    # vllm produces:
+    #   calls: []
+    #   normal_text: 'functools[{"name": "get_weather", "arguments": {"loc'

--- a/tests/parity/parser/fixtures/phi4/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/phi4/PARSER.batch.6.yaml
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: phi4
+mode: batch
+cases:
+  PARSER.batch.6.a:
+    description: 'Canonical "arguments": {}'
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L260
+    model_text: 'functools[{"name": "get_time", "arguments": {}}]'
+    tools:
+    - &id001
+      name: get_time
+      parameters:
+        type: object
+        properties: {}
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.6.b:
+    description: Whitespace inside arguments {}
+    ref: dynamo
+    model_text: 'functools[{"name": "get_time", "arguments": { }}]'
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.6.c:
+    description: No arguments key
+    ref: dynamo
+    model_text: 'functools[{"name": "get_time"}]'
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: ''
+    # TODO(research): vllm diverges — both return calls=[]; vLLM preserves raw input as normal_text on this recovery path, Dynamo emits empty
+    # vllm produces:
+    #   calls: []
+    #   normal_text: 'functools[{"name": "get_time"}]'

--- a/tests/parity/parser/fixtures/phi4/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/phi4/PARSER.batch.7.yaml
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: phi4
+mode: batch
+cases:
+  PARSER.batch.7.a:
+    description: Standard scalar types
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L220
+    model_text: 'functools[{"name": "book_flight", "arguments": {"destination": "Paris", "passengers": 2, "first_class": true}}]'
+    tools:
+    - name: book_flight
+      parameters:
+        type: object
+        properties:
+          destination:
+            type: string
+          passengers:
+            type: integer
+          first_class:
+            type: boolean
+    expected:
+      calls:
+      - name: book_flight
+        arguments:
+          destination: Paris
+          passengers: 2
+          first_class: true
+      normal_text: ''
+  PARSER.batch.7.b:
+    description: Unicode + escaped chars
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L302
+    model_text: 'functools[{"name": "get_weather", "arguments": {"location": "Tōkyō \"central\""}}]'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Tōkyō "central"
+      normal_text: ''
+  PARSER.batch.7.c:
+    description: Schema mismatch — string value where schema declares integer
+    ref: dynamo
+    model_text: 'functools[{"name": "set_temperature", "arguments": {"celsius": "20"}}]'
+    tools:
+    - name: set_temperature
+      parameters:
+        type: object
+        properties:
+          celsius:
+            type: integer
+    expected:
+      calls:
+      - name: set_temperature
+        arguments:
+          celsius: '20'
+      normal_text: ''
+  PARSER.batch.7.d:
+    description: Nested object + array
+    ref: dynamo
+    model_text: 'functools[{"name": "process_data", "arguments": {"items": [1,2,3], "config": {"nested": true}}}]'
+    tools:
+    - name: process_data
+      parameters:
+        type: object
+        properties:
+          items:
+            type: array
+          config:
+            type: object
+    expected:
+      calls:
+      - name: process_data
+        arguments:
+          config:
+            nested: true
+          items:
+          - 1
+          - 2
+          - 3
+      normal_text: ''
+    # TODO(research): vllm diverges — vLLM emits JSON-typed parameter values as raw strings; Dynamo coerces nested object/array types
+    # vllm produces:
+    #   calls: []
+    #   normal_text: None

--- a/tests/parity/parser/fixtures/phi4/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/phi4/PARSER.batch.8.yaml
@@ -40,7 +40,7 @@ cases:
       normal_text: ''
   PARSER.batch.8.c:
     description: Narration both before and after (sandwich)
-    ref: inspired-by https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L282
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L282
     model_text: 'I will check the weather. functools[{"name": "get_weather", "arguments": {"location": "NYC"}}] Let me know
       if you need more.'
     tools:

--- a/tests/parity/parser/fixtures/phi4/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/phi4/PARSER.batch.yaml
@@ -21,27 +21,6 @@ cases:
         arguments:
           location: NYC
       normal_text: ''
-  PARSER.batch.2:
-    description: Multiple tool calls (parallel)
-    model_text: 'functools[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_time", "arguments": {"timezone":
-      "EST"}}]'
-    tools:
-    - *id001
-    - name: get_time
-      parameters:
-        type: object
-        properties:
-          timezone:
-            type: string
-    expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: ''
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
@@ -50,58 +29,6 @@ cases:
     expected:
       calls: []
       normal_text: Hello, how can I help you today?
-  PARSER.batch.4:
-    description: Malformed JSON args (missing close brace)
-    model_text: 'functools[{"name": "get_weather", "arguments": {"location": "NYC"]'
-    tools:
-    - *id001
-    expected:
-      calls: []
-      normal_text: ''
-  PARSER.batch.5:
-    description: No explicit end (truncation)
-    model_text: 'functools[{"name": "get_weather", "arguments": {"location": "NYC"}}'
-    tools:
-    - *id001
-    expected:
-      calls: []
-      normal_text: ''
-  PARSER.batch.6:
-    description: Empty args (no-arg call)
-    model_text: 'functools[{"name": "get_time", "arguments": {}}]'
-    tools:
-    - name: get_time
-      parameters:
-        type: object
-        properties: {}
-    expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
-  PARSER.batch.7:
-    description: Complex args (nested object + array)
-    model_text: 'functools[{"name": "process_data", "arguments": {"items": [1, 2, 3], "config": {"nested": true}}}]'
-    tools:
-    - name: process_data
-      parameters:
-        type: object
-        properties:
-          items:
-            type: array
-          config:
-            type: object
-    expected:
-      calls:
-      - name: process_data
-        arguments:
-          items:
-          - 1
-          - 2
-          - 3
-          config:
-            nested: true
-      normal_text: ''
   PARSER.batch.9:
     description: Empty input
     model_text: ''

--- a/tests/parity/parser/fixtures/pythonic/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/pythonic/PARSER.batch.2.yaml
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: pythonic
+mode: batch
+cases:
+  PARSER.batch.2.a:
+    description: Parallel calls in single bracket
+    ref: dynamo
+    model_text: '[get_weather(location="NYC"), get_time(timezone="EST")]'
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - &id002
+      name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
+  PARSER.batch.2.c:
+    description: With surrounding narration
+    ref: dynamo
+    model_text: 'Both: [get_weather(location="NYC"), get_time(timezone="EST")] Done.'
+    tools:
+    - *id001
+    - *id002
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: 'Both:'
+    # TODO(research): vllm diverges — vLLM rejects bracket-call form when surrounded by interleaved text; Dynamo extracts the calls
+    # vllm produces:
+    #   calls: []
+    #   normal_text: 'Both: [get_weather(location="NYC"), get_time(timezone="EST")] Done.'
+  PARSER.batch.2.d:
+    description: Same-name twice
+    ref: dynamo
+    model_text: '[get_weather(location="NYC"), get_weather(location="LA")]'
+    tools:
+    - *id001
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''

--- a/tests/parity/parser/fixtures/pythonic/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/pythonic/PARSER.batch.4.yaml
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: pythonic
+mode: batch
+cases:
+  PARSER.batch.4.a:
+    description: Bracket form with garbage call
+    ref: dynamo
+    model_text: '[not a valid python call]'
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls: []
+      normal_text: '[not a valid python call]'
+  PARSER.batch.4.b:
+    description: Missing closing bracket
+    ref: dynamo
+    model_text: '[get_weather(location="NYC"'
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: '[get_weather(location="NYC"'
+  PARSER.batch.4.d:
+    description: Mismatched paren / bracket
+    ref: dynamo
+    model_text: '[get_weather(location="NYC"]'
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: '[get_weather(location="NYC"]'

--- a/tests/parity/parser/fixtures/pythonic/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/pythonic/PARSER.batch.5.yaml
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: pythonic
+mode: batch
+cases:
+  PARSER.batch.5.a:
+    description: Missing closing `]` end marker
+    ref: dynamo
+    model_text: '[get_weather(location="NYC")'
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls: []
+      normal_text: '[get_weather(location="NYC")'
+  PARSER.batch.5.b:
+    description: Closing `]` without matching `[` open
+    ref: dynamo
+    model_text: get_weather(location="NYC")]
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: get_weather(location="NYC")]
+  PARSER.batch.5.c:
+    description: Truncation mid-argument value
+    ref: dynamo
+    model_text: '[get_weather(location="N'
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: '[get_weather(location="N'

--- a/tests/parity/parser/fixtures/pythonic/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/pythonic/PARSER.batch.6.yaml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: pythonic
+mode: batch
+cases:
+  PARSER.batch.6.a:
+    description: Empty parens (no args)
+    ref: dynamo
+    model_text: '[get_time()]'
+    tools:
+    - &id001
+      name: get_time
+      parameters:
+        type: object
+        properties: {}
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.6.b:
+    description: Whitespace inside parens
+    ref: dynamo
+    model_text: '[get_time( )]'
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: '[get_time( )]'

--- a/tests/parity/parser/fixtures/pythonic/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/pythonic/PARSER.batch.7.yaml
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: pythonic
+mode: batch
+cases:
+  PARSER.batch.7.a:
+    description: Standard scalar types
+    ref: dynamo
+    model_text: '[book_flight(destination="Paris", passengers=2, first_class=True)]'
+    tools:
+    - name: book_flight
+      parameters:
+        type: object
+        properties:
+          destination:
+            type: string
+          passengers:
+            type: integer
+          first_class:
+            type: boolean
+    expected:
+      calls:
+      - name: book_flight
+        arguments:
+          destination: Paris
+          passengers: 2
+          first_class: true
+      normal_text: ''
+  PARSER.batch.7.b:
+    description: Unicode + escaped chars
+    ref: dynamo
+    model_text: '[get_weather(location="Tōkyō \"central\"")]'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Tōkyō "central"
+      normal_text: ''
+  PARSER.batch.7.c:
+    description: Schema mismatch — string value where schema declares integer
+    ref: dynamo
+    model_text: '[set_temperature(celsius="20")]'
+    tools:
+    - name: set_temperature
+      parameters:
+        type: object
+        properties:
+          celsius:
+            type: integer
+    expected:
+      calls:
+      - name: set_temperature
+        arguments:
+          celsius: '20'
+      normal_text: ''
+  PARSER.batch.7.d:
+    description: Nested dict + array (existing)
+    ref: dynamo
+    model_text: '[process_data(items=[1, 2, 3], config={"nested": True})]'
+    tools:
+    - name: process_data
+      parameters:
+        type: object
+        properties:
+          items:
+            type: array
+          config:
+            type: object
+    expected:
+      calls:
+      - name: process_data
+        arguments:
+          items:
+          - 1
+          - 2
+          - 3
+          config:
+            nested: true
+      normal_text: ''

--- a/tests/parity/parser/fixtures/pythonic/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/pythonic/PARSER.batch.yaml
@@ -21,26 +21,6 @@ cases:
         arguments:
           location: NYC
       normal_text: ''
-  PARSER.batch.2:
-    description: Multiple tool calls (parallel)
-    model_text: '[get_weather(location="NYC"), get_time(timezone="EST")]'
-    tools:
-    - *id001
-    - name: get_time
-      parameters:
-        type: object
-        properties:
-          timezone:
-            type: string
-    expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: ''
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
@@ -49,58 +29,6 @@ cases:
     expected:
       calls: []
       normal_text: Hello, how can I help you today?
-  PARSER.batch.4:
-    description: Malformed (missing closing bracket)
-    model_text: '[get_weather(location="NYC"'
-    tools:
-    - *id001
-    expected:
-      calls: []
-      normal_text: '[get_weather(location="NYC"'
-  PARSER.batch.5:
-    description: Missing closing `]` end marker
-    model_text: '[get_weather(location="NYC")'
-    tools:
-    - *id001
-    expected:
-      calls: []
-      normal_text: '[get_weather(location="NYC")'
-  PARSER.batch.6:
-    description: Empty args (no-arg call)
-    model_text: '[get_time()]'
-    tools:
-    - name: get_time
-      parameters:
-        type: object
-        properties: {}
-    expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
-  PARSER.batch.7:
-    description: Complex args (nested dict + array)
-    model_text: '[process_data(items=[1, 2, 3], config={"nested": True})]'
-    tools:
-    - name: process_data
-      parameters:
-        type: object
-        properties:
-          items:
-            type: array
-          config:
-            type: object
-    expected:
-      calls:
-      - name: process_data
-        arguments:
-          items:
-          - 1
-          - 2
-          - 3
-          config:
-            nested: true
-      normal_text: ''
   PARSER.batch.9:
     description: Empty input
     model_text: ''

--- a/tests/parity/parser/fixtures/qwen25/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/qwen25/PARSER.batch.2.yaml
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: qwen25
+mode: batch
+cases:
+  PARSER.batch.2.a:
+    description: Parallel calls (back-to-back tool_call wrappers)
+    ref: dynamo
+    model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name": "get_time",
+      "arguments": {"timezone": "EST"}}</tool_call>'
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - &id002
+      name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
+  PARSER.batch.2.c:
+    description: With surrounding narration
+    ref: dynamo
+    model_text: 'Both: <tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name":
+      "get_time", "arguments": {"timezone": "EST"}}</tool_call> Done.'
+    tools:
+    - *id001
+    - *id002
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: 'Both:'
+  PARSER.batch.2.d:
+    description: Same-name twice
+    ref: dynamo
+    model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name": "get_weather",
+      "arguments": {"location": "LA"}}</tool_call>'
+    tools:
+    - *id001
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''

--- a/tests/parity/parser/fixtures/qwen25/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/qwen25/PARSER.batch.4.yaml
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: qwen25
+mode: batch
+cases:
+  PARSER.batch.4.a:
+    description: Tool_call wrapper with non-JSON garbage
+    ref: dynamo
+    model_text: <tool_call>not even json</tool_call>
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls: []
+      normal_text: <tool_call>not even json</tool_call>
+  PARSER.batch.4.b:
+    description: Missing close brace in JSON body
+    ref: dynamo
+    model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"</tool_call>'
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+  PARSER.batch.4.c:
+    description: Missing name key
+    ref: dynamo
+    model_text: '<tool_call>{"arguments": {"location": "NYC"}}</tool_call>'
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: '<tool_call>{"arguments": {"location": "NYC"}}</tool_call>'
+  PARSER.batch.4.d:
+    description: Missing </tool_call> close
+    ref: dynamo
+    model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}'
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''

--- a/tests/parity/parser/fixtures/qwen25/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/qwen25/PARSER.batch.5.yaml
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: qwen25
+mode: batch
+cases:
+  PARSER.batch.5.a:
+    description: Missing </tool_call> end marker
+    ref: dynamo
+    model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}'
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+  PARSER.batch.5.b:
+    description: Closing </tool_call> without matching <tool_call> open
+    ref: dynamo
+    model_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>'
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>'
+  PARSER.batch.5.c:
+    description: Truncation mid-arguments JSON
+    ref: dynamo
+    model_text: '<tool_call>{"name": "get_weather", "arguments": {"loc'
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: '<tool_call>{"name": "get_weather", "arguments": {"loc'

--- a/tests/parity/parser/fixtures/qwen25/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/qwen25/PARSER.batch.6.yaml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: qwen25
+mode: batch
+cases:
+  PARSER.batch.6.a:
+    description: 'Canonical "arguments": {}'
+    ref: dynamo
+    model_text: '<tool_call>{"name": "get_time", "arguments": {}}</tool_call>'
+    tools:
+    - &id001
+      name: get_time
+      parameters:
+        type: object
+        properties: {}
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.6.b:
+    description: Whitespace inside arguments {}
+    ref: dynamo
+    model_text: '<tool_call>{"name": "get_time", "arguments": { }}</tool_call>'
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.6.c:
+    description: No arguments key
+    ref: dynamo
+    model_text: '<tool_call>{"name": "get_time"}</tool_call>'
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: '<tool_call>{"name": "get_time"}</tool_call>'

--- a/tests/parity/parser/fixtures/qwen25/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/qwen25/PARSER.batch.7.yaml
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: qwen25
+mode: batch
+cases:
+  PARSER.batch.7.a:
+    description: Standard scalar types
+    ref: dynamo
+    model_text: '<tool_call>{"name": "book_flight", "arguments": {"destination": "Paris", "passengers": 2, "first_class":
+      true}}</tool_call>'
+    tools:
+    - name: book_flight
+      parameters:
+        type: object
+        properties:
+          destination:
+            type: string
+          passengers:
+            type: integer
+          first_class:
+            type: boolean
+    expected:
+      calls:
+      - name: book_flight
+        arguments:
+          destination: Paris
+          passengers: 2
+          first_class: true
+      normal_text: ''
+  PARSER.batch.7.b:
+    description: Unicode + escaped chars
+    ref: dynamo
+    model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "Tōkyō \"central\""}}</tool_call>'
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Tōkyō "central"
+      normal_text: ''
+  PARSER.batch.7.c:
+    description: Schema mismatch — string value where schema declares integer
+    ref: dynamo
+    model_text: '<tool_call>{"name": "set_temperature", "arguments": {"celsius": "20"}}</tool_call>'
+    tools:
+    - name: set_temperature
+      parameters:
+        type: object
+        properties:
+          celsius:
+            type: integer
+    expected:
+      calls:
+      - name: set_temperature
+        arguments:
+          celsius: '20'
+      normal_text: ''
+  PARSER.batch.7.d:
+    description: Nested object + array
+    ref: dynamo
+    model_text: '<tool_call>{"name": "process_data", "arguments": {"items": [1,2,3], "config": {"nested": true}}}</tool_call>'
+    tools:
+    - name: process_data
+      parameters:
+        type: object
+        properties:
+          items:
+            type: array
+          config:
+            type: object
+    expected:
+      calls:
+      - name: process_data
+        arguments:
+          items:
+          - 1
+          - 2
+          - 3
+          config:
+            nested: true
+      normal_text: ''

--- a/tests/parity/parser/fixtures/qwen25/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/qwen25/PARSER.batch.yaml
@@ -21,27 +21,6 @@ cases:
         arguments:
           location: NYC
       normal_text: ''
-  PARSER.batch.2:
-    description: Multiple tool calls (parallel)
-    model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name": "get_time",
-      "arguments": {"timezone": "EST"}}</tool_call>'
-    tools:
-    - *id001
-    - name: get_time
-      parameters:
-        type: object
-        properties:
-          timezone:
-            type: string
-    expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: ''
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
@@ -50,64 +29,6 @@ cases:
     expected:
       calls: []
       normal_text: Hello, how can I help you today?
-  PARSER.batch.4:
-    description: Malformed JSON args (missing close brace)
-    model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"</tool_call>'
-    tools:
-    - *id001
-    expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
-  PARSER.batch.5:
-    description: Missing </tool_call> end marker
-    model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}'
-    tools:
-    - *id001
-    expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
-  PARSER.batch.6:
-    description: Empty args (no-arg call)
-    model_text: '<tool_call>{"name": "get_time", "arguments": {}}</tool_call>'
-    tools:
-    - name: get_time
-      parameters:
-        type: object
-        properties: {}
-    expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
-  PARSER.batch.7:
-    description: Complex args (nested object + array)
-    model_text: '<tool_call>{"name": "process_data", "arguments": {"items": [1, 2, 3], "config": {"nested": true}}}</tool_call>'
-    tools:
-    - name: process_data
-      parameters:
-        type: object
-        properties:
-          items:
-            type: array
-          config:
-            type: object
-    expected:
-      calls:
-      - name: process_data
-        arguments:
-          items:
-          - 1
-          - 2
-          - 3
-          config:
-            nested: true
-      normal_text: ''
   PARSER.batch.9:
     description: Empty input
     model_text: ''

--- a/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.2.yaml
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: qwen3_coder
+mode: batch
+cases:
+  PARSER.batch.2.a:
+    description: Parallel calls (different names)
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L185
+    model_text: |-
+      <tool_call>
+      <function=get_weather>
+      <parameter=location>
+      NYC
+      </parameter>
+      </function>
+      </tool_call>
+      <tool_call>
+      <function=get_time>
+      <parameter=timezone>
+      EST
+      </parameter>
+      </function>
+      </tool_call>
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    - &id002
+      name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: ''
+  PARSER.batch.2.c:
+    description: Parallel calls with surrounding narration
+    ref: dynamo
+    model_text: |-
+      Both queries: <tool_call>
+      <function=get_weather>
+      <parameter=location>
+      NYC
+      </parameter>
+      </function>
+      </tool_call>
+      <tool_call>
+      <function=get_time>
+      <parameter=timezone>
+      EST
+      </parameter>
+      </function>
+      </tool_call> Results above.
+    tools:
+    - *id001
+    - *id002
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_time
+        arguments:
+          timezone: EST
+      normal_text: 'Both queries: '
+  PARSER.batch.2.d:
+    description: Same-name twice (id distinctness)
+    ref: dynamo
+    model_text: |-
+      <tool_call>
+      <function=get_weather>
+      <parameter=location>
+      NYC
+      </parameter>
+      </function>
+      </tool_call>
+      <tool_call>
+      <function=get_weather>
+      <parameter=location>
+      LA
+      </parameter>
+      </function>
+      </tool_call>
+    tools:
+    - *id001
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      - name: get_weather
+        arguments:
+          location: LA
+      normal_text: ''

--- a/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.4.yaml
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: qwen3_coder
+mode: batch
+cases:
+  PARSER.batch.4.a:
+    description: Tool_call wrapper with no <function> body
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L322
+    model_text: |-
+      <tool_call>
+      random text without function tag
+      </tool_call>
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls: []
+      normal_text: ''
+    # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
+    # vllm produces:
+    #   calls: []
+    #   normal_text: '<tool_call>\nrandom text without function tag\n</tool_call>'
+  PARSER.batch.4.d:
+    description: Missing </parameter> closing tag
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_qwen3coder_tool_parser.py#L729
+    model_text: |-
+      <tool_call>
+      <function=get_weather>
+      <parameter=location>
+      NYC
+      </function>
+      </tool_call>
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''

--- a/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.5.yaml
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: qwen3_coder
+mode: batch
+cases:
+  PARSER.batch.5.a:
+    description: Missing </tool_call> end marker
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_qwen3coder_tool_parser.py#L401
+    model_text: |-
+      <tool_call>
+      <function=get_weather>
+      <parameter=location>
+      NYC
+      </parameter>
+      </function>
+    tools:
+    - &id001
+      name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+  PARSER.batch.5.b:
+    description: Closing </tool_call> without matching <tool_call> open
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_qwen3coder_tool_parser.py#L943
+    model_text: |-
+      <function=get_weather>
+      <parameter=location>
+      NYC
+      </parameter>
+      </function>
+      </tool_call>
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: |-
+        <function=get_weather>
+        <parameter=location>
+        NYC
+        </parameter>
+        </function>
+        </tool_call>
+    # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
+    # vllm produces:
+    #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}]
+    #   normal_text: None
+  PARSER.batch.5.c:
+    description: Truncation mid-parameter value
+    ref: dynamo
+    model_text: |-
+      <tool_call>
+      <function=get_weather>
+      <parameter=location>
+      NY
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NY
+      normal_text: ''

--- a/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.6.yaml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: qwen3_coder
+mode: batch
+cases:
+  PARSER.batch.6.a:
+    description: Function block with no <parameter>
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L260
+    model_text: |-
+      <tool_call>
+      <function=get_time>
+      </function>
+      </tool_call>
+    tools:
+    - &id001
+      name: get_time
+      parameters:
+        type: object
+        properties: {}
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''
+  PARSER.batch.6.b:
+    description: Function block with extra whitespace inside
+    ref: dynamo
+    model_text: |-
+      <tool_call>
+      <function=get_time>
+
+      </function>
+      </tool_call>
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_time
+        arguments: {}
+      normal_text: ''

--- a/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.7.yaml
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+family: qwen3_coder
+mode: batch
+cases:
+  PARSER.batch.7.a:
+    description: Multiple parameters (existing multi-arg shape)
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L220
+    model_text: |-
+      <tool_call>
+      <function=book_flight>
+      <parameter=destination>
+      Paris
+      </parameter>
+      <parameter=passengers>
+      2
+      </parameter>
+      <parameter=first_class>
+      true
+      </parameter>
+      </function>
+      </tool_call>
+    tools:
+    - name: book_flight
+      parameters:
+        type: object
+        properties:
+          destination:
+            type: string
+          passengers:
+            type: integer
+          first_class:
+            type: boolean
+    expected:
+      calls:
+      - name: book_flight
+        arguments:
+          destination: Paris
+          first_class: true
+          passengers: 2
+      normal_text: ''
+    # TODO(research): vllm diverges — vLLM emits JSON-typed parameter values as raw strings; Dynamo coerces nested object/array types
+    # vllm produces:
+    #   calls: [{'name': 'book_flight', 'arguments': {'destination': 'Paris', 'passengers': '2', 'first_class': 'true'}}]
+    #   normal_text: None
+  PARSER.batch.7.b:
+    description: Unicode in parameter value
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L302
+    model_text: |-
+      <tool_call>
+      <function=get_weather>
+      <parameter=location>
+      Tōkyō central
+      </parameter>
+      </function>
+      </tool_call>
+    tools:
+    - name: get_weather
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Tōkyō central
+      normal_text: ''

--- a/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.8.yaml
@@ -50,7 +50,7 @@ cases:
       normal_text: ''
   PARSER.batch.8.c:
     description: Narration both before and after (sandwich)
-    ref: dynamo
+    ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L282
     model_text: |-
       I will check the weather. <tool_call>
       <function=get_weather>

--- a/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.yaml
@@ -28,40 +28,6 @@ cases:
         arguments:
           location: NYC
       normal_text: ''
-  PARSER.batch.2:
-    description: Multiple tool calls
-    model_text: |-
-      <tool_call>
-      <function=get_weather>
-      <parameter=location>
-      NYC
-      </parameter>
-      </function>
-      </tool_call>
-      <tool_call>
-      <function=get_time>
-      <parameter=timezone>
-      EST
-      </parameter>
-      </function>
-      </tool_call>
-    tools:
-    - *id001
-    - name: get_time
-      parameters:
-        type: object
-        properties:
-          timezone:
-            type: string
-    expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: ''
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
@@ -70,86 +36,6 @@ cases:
     expected:
       calls: []
       normal_text: Hello, how can I help you today?
-  PARSER.batch.4:
-    description: Malformed (missing </parameter> closing tag)
-    model_text: |-
-      <tool_call>
-      <function=get_weather>
-      <parameter=location>
-      NYC
-      </function>
-      </tool_call>
-    tools:
-    - *id001
-    expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
-  PARSER.batch.5:
-    description: Missing </tool_call> end marker
-    model_text: |-
-      <tool_call>
-      <function=get_weather>
-      <parameter=location>
-      NYC
-      </parameter>
-      </function>
-    tools:
-    - *id001
-    expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
-  PARSER.batch.6:
-    description: Empty args (no-arg call)
-    model_text: |-
-      <tool_call>
-      <function=get_time>
-      </function>
-      </tool_call>
-    tools:
-    - name: get_time
-      parameters:
-        type: object
-        properties: {}
-    expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
-  PARSER.batch.7:
-    description: Complex args (multi-parameter)
-    model_text: |-
-      <tool_call>
-      <function=get_weather>
-      <parameter=location>
-      NYC
-      </parameter>
-      <parameter=unit>
-      fahrenheit
-      </parameter>
-      </function>
-      </tool_call>
-    tools:
-    - name: get_weather
-      parameters:
-        type: object
-        properties:
-          location:
-            type: string
-          unit:
-            type: string
-    expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-          unit: fahrenheit
-      normal_text: ''
   PARSER.batch.9:
     description: Empty input
     model_text: ''

--- a/tests/parity/parser/regenerate_fixtures.py
+++ b/tests/parity/parser/regenerate_fixtures.py
@@ -81,6 +81,28 @@ _PROCESS_DATA_NESTED = {
         },
     },
 }
+# Multi-type tool for batch.7.a (standard scalar/container types).
+_BOOK_FLIGHT_MIXED = {
+    "name": "book_flight",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "destination": {"type": "string"},
+            "passengers": {"type": "integer"},
+            "first_class": {"type": "boolean"},
+        },
+    },
+}
+# Type-coercion tool for batch.7.c — numeric param schema.
+_SET_TEMP_NUMERIC = {
+    "name": "set_temperature",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "celsius": {"type": "integer"},
+        },
+    },
+}
 
 # (family, case_id) -> {"text": str, "tools": list[dict] | None, "description": str}
 # Cases marked with text=None are intentionally skipped (N/A or not yet
@@ -92,33 +114,101 @@ INPUTS: dict[tuple[str, str], dict[str, Any] | None] = {
         "text": '<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>',
         "tools": [_GET_WEATHER_LOC],
     },
-    ("kimi_k2", "PARSER.batch.2"): {
-        "description": "Multiple tool calls",
+    ("kimi_k2", "PARSER.batch.2.a"): {
+        "description": "Parallel calls in single section",
         "text": '<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_call_begin|>functions.get_time:1<|tool_call_argument_begin|>{"timezone":"EST"}<|tool_call_end|><|tool_calls_section_end|>',
         "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("kimi_k2", "PARSER.batch.2.b"): {
+        "description": "Two back-to-back sections (each with one call)",
+        "text": '<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|><|tool_calls_section_begin|><|tool_call_begin|>functions.get_time:1<|tool_call_argument_begin|>{"timezone":"EST"}<|tool_call_end|><|tool_calls_section_end|>',
+        "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("kimi_k2", "PARSER.batch.2.c"): {
+        "description": "Parallel calls with surrounding narration",
+        "text": 'I will check both. <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_call_begin|>functions.get_time:1<|tool_call_argument_begin|>{"timezone":"EST"}<|tool_call_end|><|tool_calls_section_end|> Done.',
+        "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("kimi_k2", "PARSER.batch.2.d"): {
+        "description": "Same-name twice (id distinctness)",
+        "text": '<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_call_begin|>functions.get_weather:1<|tool_call_argument_begin|>{"location":"LA"}<|tool_call_end|><|tool_calls_section_end|>',
+        "tools": [_GET_WEATHER_LOC, _GET_WEATHER_LOC],
     },
     ("kimi_k2", "PARSER.batch.3"): {
         "description": "No tool call (plain text)",
         "text": "Hello, how can I help you today?",
         "tools": [_GET_WEATHER_LOC],
     },
-    ("kimi_k2", "PARSER.batch.4"): {
-        "description": "Malformed JSON args (missing close brace)",
+    ("kimi_k2", "PARSER.batch.4.a"): {
+        "description": "Garbage between section fences (no call_begin)",
+        "text": "<|tool_calls_section_begin|>nonsense<|tool_calls_section_end|>",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("kimi_k2", "PARSER.batch.4.b"): {
+        "description": "Invalid JSON args (missing close brace)",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_kimi_k2_tool_parser.py#L151",
         "text": '<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"<|tool_call_end|><|tool_calls_section_end|>',
         "tools": [_GET_WEATHER_LOC],
     },
-    ("kimi_k2", "PARSER.batch.5"): {
+    ("kimi_k2", "PARSER.batch.4.c"): {
+        "description": "Missing function name (call_begin without functions.X:N)",
+        "text": '<|tool_calls_section_begin|><|tool_call_begin|><|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("kimi_k2", "PARSER.batch.4.d"): {
+        "description": "Mismatched fences (call_end before call_begin closes)",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_kimi_k2_tool_parser.py#L165",
+        "text": '<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_calls_section_end|>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("kimi_k2", "PARSER.batch.5.a"): {
         "description": "Missing section_end (max_tokens truncation, PR #8208)",
         "text": '<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|>',
         "tools": [_GET_WEATHER_LOC],
     },
-    ("kimi_k2", "PARSER.batch.6"): {
-        "description": "Empty args (no-arg call)",
+    ("kimi_k2", "PARSER.batch.5.b"): {
+        "description": "Closing section_end without matching section_begin",
+        "text": '<|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("kimi_k2", "PARSER.batch.5.c"): {
+        "description": "Truncation mid-arguments (incomplete JSON body)",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_kimi_k2_tool_parser.py#L413",
+        "text": '<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"loc',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("kimi_k2", "PARSER.batch.6.a"): {
+        "description": "Canonical empty {} arguments",
         "text": "<|tool_calls_section_begin|><|tool_call_begin|>functions.get_time:0<|tool_call_argument_begin|>{}<|tool_call_end|><|tool_calls_section_end|>",
         "tools": [_GET_TIME_NOARG],
     },
-    ("kimi_k2", "PARSER.batch.7"): {
-        "description": "Complex args (nested object + array)",
+    ("kimi_k2", "PARSER.batch.6.b"): {
+        "description": "Whitespace inside empty {}",
+        "text": "<|tool_calls_section_begin|><|tool_call_begin|>functions.get_time:0<|tool_call_argument_begin|>{ }<|tool_call_end|><|tool_calls_section_end|>",
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("kimi_k2", "PARSER.batch.6.c"): {
+        "description": "No argument body (skip argument_begin → end)",
+        "text": "<|tool_calls_section_begin|><|tool_call_begin|>functions.get_time:0<|tool_call_end|><|tool_calls_section_end|>",
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("kimi_k2", "PARSER.batch.7.a"): {
+        "description": "Standard scalar types (string + int + bool)",
+        "text": '<|tool_calls_section_begin|><|tool_call_begin|>functions.book_flight:0<|tool_call_argument_begin|>{"destination":"Paris","passengers":2,"first_class":true}<|tool_call_end|><|tool_calls_section_end|>',
+        "tools": [_BOOK_FLIGHT_MIXED],
+    },
+    ("kimi_k2", "PARSER.batch.7.b"): {
+        "description": "Unicode + escaped chars in string value",
+        "text": '<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"Tōkyō \\"central\\""}<|tool_call_end|><|tool_calls_section_end|>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("kimi_k2", "PARSER.batch.7.c"): {
+        "description": "Schema mismatch — string value where schema declares integer",
+        "text": '<|tool_calls_section_begin|><|tool_call_begin|>functions.set_temperature:0<|tool_call_argument_begin|>{"celsius":"20"}<|tool_call_end|><|tool_calls_section_end|>',
+        "tools": [_SET_TEMP_NUMERIC],
+    },
+    ("kimi_k2", "PARSER.batch.7.d"): {
+        "description": "Nested object + array (existing shape)",
         "text": '<|tool_calls_section_begin|><|tool_call_begin|>functions.process_data:0<|tool_call_argument_begin|>{"items":[1,2,3],"config":{"nested":true}}<|tool_call_end|><|tool_calls_section_end|>',
         "tools": [_PROCESS_DATA_NESTED],
     },
@@ -128,13 +218,13 @@ INPUTS: dict[tuple[str, str], dict[str, Any] | None] = {
     # kimi_k2/PARSER.batch.yaml after the regenerator runs.
     ("kimi_k2", "PARSER.batch.8.a"): {
         "description": "Narration before tool call only",
-        "ref": "inspired-by https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_kimi_k2_tool_parser.py#L272",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_kimi_k2_tool_parser.py#L272",
         "text": 'I\'ll check the weather. <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"Dallas"}<|tool_call_end|><|tool_calls_section_end|>',
         "tools": [_GET_WEATHER_LOC],
     },
     ("kimi_k2", "PARSER.batch.8.b"): {
         "description": "Narration after tool call only",
-        "ref": "inspired-by https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_kimi_k2_tool_parser.py#L435",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_kimi_k2_tool_parser.py#L435",
         "text": '<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"Dallas"}<|tool_call_end|><|tool_calls_section_end|> Let me know if you need more.',
         "tools": [_GET_WEATHER_LOC],
     },
@@ -164,35 +254,78 @@ INPUTS: dict[tuple[str, str], dict[str, Any] | None] = {
         "text": "<tool_call>\n<function=get_weather>\n<parameter=location>\nNYC\n</parameter>\n</function>\n</tool_call>",
         "tools": [_GET_WEATHER_LOC],
     },
-    ("qwen3_coder", "PARSER.batch.2"): {
-        "description": "Multiple tool calls",
+    ("qwen3_coder", "PARSER.batch.2.a"): {
+        "description": "Parallel calls (different names)",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L185",
         "text": "<tool_call>\n<function=get_weather>\n<parameter=location>\nNYC\n</parameter>\n</function>\n</tool_call>\n<tool_call>\n<function=get_time>\n<parameter=timezone>\nEST\n</parameter>\n</function>\n</tool_call>",
         "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("qwen3_coder", "PARSER.batch.2.c"): {
+        "description": "Parallel calls with surrounding narration",
+        "text": "Both queries: <tool_call>\n<function=get_weather>\n<parameter=location>\nNYC\n</parameter>\n</function>\n</tool_call>\n<tool_call>\n<function=get_time>\n<parameter=timezone>\nEST\n</parameter>\n</function>\n</tool_call> Results above.",
+        "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("qwen3_coder", "PARSER.batch.2.d"): {
+        "description": "Same-name twice (id distinctness)",
+        "text": "<tool_call>\n<function=get_weather>\n<parameter=location>\nNYC\n</parameter>\n</function>\n</tool_call>\n<tool_call>\n<function=get_weather>\n<parameter=location>\nLA\n</parameter>\n</function>\n</tool_call>",
+        "tools": [_GET_WEATHER_LOC, _GET_WEATHER_LOC],
     },
     ("qwen3_coder", "PARSER.batch.3"): {
         "description": "No tool call (plain text)",
         "text": "Hello, how can I help you today?",
         "tools": [_GET_WEATHER_LOC],
     },
-    ("qwen3_coder", "PARSER.batch.4"): {
-        "description": "Malformed (missing </parameter> closing tag)",
+    ("qwen3_coder", "PARSER.batch.4.a"): {
+        "description": "Tool_call wrapper with no <function> body",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L322",
+        "text": "<tool_call>\nrandom text without function tag\n</tool_call>",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("qwen3_coder", "PARSER.batch.4.d"): {
+        "description": "Missing </parameter> closing tag",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_qwen3coder_tool_parser.py#L729",
         "text": "<tool_call>\n<function=get_weather>\n<parameter=location>\nNYC\n</function>\n</tool_call>",
         "tools": [_GET_WEATHER_LOC],
     },
-    ("qwen3_coder", "PARSER.batch.5"): {
+    ("qwen3_coder", "PARSER.batch.5.a"): {
         "description": "Missing </tool_call> end marker",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_qwen3coder_tool_parser.py#L401",
         "text": "<tool_call>\n<function=get_weather>\n<parameter=location>\nNYC\n</parameter>\n</function>",
         "tools": [_GET_WEATHER_LOC],
     },
-    ("qwen3_coder", "PARSER.batch.6"): {
-        "description": "Empty args (no-arg call)",
+    ("qwen3_coder", "PARSER.batch.5.b"): {
+        "description": "Closing </tool_call> without matching <tool_call> open",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_qwen3coder_tool_parser.py#L943",
+        "text": "<function=get_weather>\n<parameter=location>\nNYC\n</parameter>\n</function>\n</tool_call>",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("qwen3_coder", "PARSER.batch.5.c"): {
+        "description": "Truncation mid-parameter value",
+        "text": "<tool_call>\n<function=get_weather>\n<parameter=location>\nNY",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("qwen3_coder", "PARSER.batch.6.a"): {
+        "description": "Function block with no <parameter>",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L260",
         "text": "<tool_call>\n<function=get_time>\n</function>\n</tool_call>",
         "tools": [_GET_TIME_NOARG],
     },
-    ("qwen3_coder", "PARSER.batch.7"): {
-        "description": "Complex args (multi-parameter)",
-        "text": "<tool_call>\n<function=get_weather>\n<parameter=location>\nNYC\n</parameter>\n<parameter=unit>\nfahrenheit\n</parameter>\n</function>\n</tool_call>",
-        "tools": [_GET_WEATHER_LOC_UNIT],
+    ("qwen3_coder", "PARSER.batch.6.b"): {
+        "description": "Function block with extra whitespace inside",
+        "text": "<tool_call>\n<function=get_time>\n\n</function>\n</tool_call>",
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("qwen3_coder", "PARSER.batch.7.a"): {
+        "description": "Multiple parameters (existing multi-arg shape)",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L220",
+        "text": "<tool_call>\n<function=book_flight>\n<parameter=destination>\nParis\n</parameter>\n<parameter=passengers>\n2\n</parameter>\n<parameter=first_class>\ntrue\n</parameter>\n</function>\n</tool_call>",
+        "tools": [_BOOK_FLIGHT_MIXED],
+    },
+    ("qwen3_coder", "PARSER.batch.7.b"): {
+        "description": "Unicode in parameter value",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L302",
+        "text": "<tool_call>\n<function=get_weather>\n<parameter=location>\nTōkyō central\n</parameter>\n</function>\n</tool_call>",
+        "tools": [_GET_WEATHER_LOC],
     },
     ("qwen3_coder", "PARSER.batch.8.a"): {
         "description": "Narration before tool call only",
@@ -206,6 +339,7 @@ INPUTS: dict[tuple[str, str], dict[str, Any] | None] = {
     },
     ("qwen3_coder", "PARSER.batch.8.c"): {
         "description": "Narration both before and after (sandwich)",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L282",
         "text": "I will check the weather. <tool_call>\n<function=get_weather>\n<parameter=location>\nNYC\n</parameter>\n</function>\n</tool_call> Let me know if you need more.",
         "tools": [_GET_WEATHER_LOC],
     },
@@ -230,39 +364,75 @@ INPUTS: dict[tuple[str, str], dict[str, Any] | None] = {
         "text": "<tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>",
         "tools": [_GET_WEATHER_LOC],
     },
-    ("glm47", "PARSER.batch.2"): {
-        "description": "Multiple tool calls",
+    ("glm47", "PARSER.batch.2.a"): {
+        "description": "Parallel calls (different names)",
         "text": "<tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call><tool_call>get_time<arg_key>timezone</arg_key><arg_value>EST</arg_value></tool_call>",
         "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("glm47", "PARSER.batch.2.c"): {
+        "description": "Parallel calls with surrounding narration",
+        "text": "Checking: <tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call><tool_call>get_time<arg_key>timezone</arg_key><arg_value>EST</arg_value></tool_call> Done.",
+        "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("glm47", "PARSER.batch.2.d"): {
+        "description": "Same-name twice (id distinctness)",
+        "text": "<tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call><tool_call>get_weather<arg_key>location</arg_key><arg_value>LA</arg_value></tool_call>",
+        "tools": [_GET_WEATHER_LOC, _GET_WEATHER_LOC],
     },
     ("glm47", "PARSER.batch.3"): {
         "description": "No tool call (plain text)",
         "text": "Hello, how can I help you today?",
         "tools": [_GET_WEATHER_LOC],
     },
-    ("glm47", "PARSER.batch.4"): {
-        "description": "Malformed (missing arg_value end tag)",
+    ("glm47", "PARSER.batch.4.a"): {
+        "description": "Tool_call wrapper with no function name",
+        "text": "<tool_call><arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("glm47", "PARSER.batch.4.d"): {
+        "description": "Missing </arg_value> end tag",
         "text": "<tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</tool_call>",
         "tools": [_GET_WEATHER_LOC],
     },
-    ("glm47", "PARSER.batch.5"): {
+    ("glm47", "PARSER.batch.5.a"): {
         "description": "Missing </tool_call> end marker",
         "text": "<tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value>",
         "tools": [_GET_WEATHER_LOC],
     },
-    ("glm47", "PARSER.batch.6"): {
-        "description": "Empty args (no-arg call)",
+    ("glm47", "PARSER.batch.5.b"): {
+        "description": "Closing </tool_call> without matching <tool_call> open",
+        "text": "get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("glm47", "PARSER.batch.5.c"): {
+        "description": "Truncation mid-arg_value",
+        "text": "<tool_call>get_weather<arg_key>location</arg_key><arg_value>N",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("glm47", "PARSER.batch.6.a"): {
+        "description": "Function-only call (no arg keys)",
         "text": "<tool_call>get_time</tool_call>",
         "tools": [_GET_TIME_NOARG],
     },
-    ("glm47", "PARSER.batch.7"): {
-        "description": "Complex args (multi-parameter)",
-        "text": "<tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value><arg_key>unit</arg_key><arg_value>fahrenheit</arg_value></tool_call>",
-        "tools": [_GET_WEATHER_LOC_UNIT],
+    ("glm47", "PARSER.batch.6.b"): {
+        "description": "Function-only with whitespace",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_glm47_moe_tool_parser.py#L68",
+        "text": "<tool_call>get_time </tool_call>",
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("glm47", "PARSER.batch.7.a"): {
+        "description": "Multiple parameters (existing multi-arg shape)",
+        "text": "<tool_call>book_flight<arg_key>destination</arg_key><arg_value>Paris</arg_value><arg_key>passengers</arg_key><arg_value>2</arg_value><arg_key>first_class</arg_key><arg_value>true</arg_value></tool_call>",
+        "tools": [_BOOK_FLIGHT_MIXED],
+    },
+    ("glm47", "PARSER.batch.7.b"): {
+        "description": "Unicode in arg value",
+        "text": "<tool_call>get_weather<arg_key>location</arg_key><arg_value>Tōkyō central</arg_value></tool_call>",
+        "tools": [_GET_WEATHER_LOC],
     },
     ("glm47", "PARSER.batch.8.a"): {
         "description": "Narration before tool call only",
-        "ref": "inspired-by https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_glm47_moe_tool_parser.py#L94",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_glm47_moe_tool_parser.py#L94",
         "text": "I will check the weather. <tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>",
         "tools": [_GET_WEATHER_LOC],
     },
@@ -297,33 +467,99 @@ INPUTS: dict[tuple[str, str], dict[str, Any] | None] = {
         "text": '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
         "tools": [_GET_WEATHER_LOC],
     },
-    ("deepseek_v3_1", "PARSER.batch.2"): {
-        "description": "Multiple tool calls",
+    ("deepseek_v3_1", "PARSER.batch.2.a"): {
+        "description": "Parallel calls in single fence pair",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_deepseekv31_tool_parser.py#L39",
         "text": '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_time<｜tool▁sep｜>{"timezone":"EST"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
         "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("deepseek_v3_1", "PARSER.batch.2.b"): {
+        "description": "Two back-to-back fence pairs",
+        "text": '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜><｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_time<｜tool▁sep｜>{"timezone":"EST"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
+        "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("deepseek_v3_1", "PARSER.batch.2.c"): {
+        "description": "Parallel with surrounding narration",
+        "text": 'Both: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_time<｜tool▁sep｜>{"timezone":"EST"}<｜tool▁call▁end｜><｜tool▁calls▁end｜> Results.',
+        "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("deepseek_v3_1", "PARSER.batch.2.d"): {
+        "description": "Same-name twice (id distinctness)",
+        "text": '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"LA"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
+        "tools": [_GET_WEATHER_LOC, _GET_WEATHER_LOC],
     },
     ("deepseek_v3_1", "PARSER.batch.3"): {
         "description": "No tool call (plain text)",
         "text": "Hello, how can I help you today?",
         "tools": [_GET_WEATHER_LOC],
     },
-    ("deepseek_v3_1", "PARSER.batch.4"): {
-        "description": "Malformed JSON inside call",
+    ("deepseek_v3_1", "PARSER.batch.4.a"): {
+        "description": "Garbage between calls fences (no tool_sep / args)",
+        "text": "<｜tool▁calls▁begin｜>nonsense<｜tool▁calls▁end｜>",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("deepseek_v3_1", "PARSER.batch.4.b"): {
+        "description": "Unterminated JSON string in args",
         "text": '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
         "tools": [_GET_WEATHER_LOC],
     },
-    ("deepseek_v3_1", "PARSER.batch.5"): {
+    ("deepseek_v3_1", "PARSER.batch.4.c"): {
+        "description": "Missing function name (no token before tool_sep)",
+        "text": '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜><｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("deepseek_v3_1", "PARSER.batch.4.d"): {
+        "description": "Mismatched fences (calls_end without call_end)",
+        "text": '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁calls▁end｜>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("deepseek_v3_1", "PARSER.batch.5.a"): {
         "description": "Missing tool_calls_end (truncation)",
         "text": '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜>',
         "tools": [_GET_WEATHER_LOC],
     },
-    ("deepseek_v3_1", "PARSER.batch.6"): {
-        "description": "Empty args (no-arg call)",
+    ("deepseek_v3_1", "PARSER.batch.5.b"): {
+        "description": "Closing tool_calls_end without matching tool_calls_begin",
+        "text": '<｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("deepseek_v3_1", "PARSER.batch.5.c"): {
+        "description": "Truncation mid-arguments JSON",
+        "text": '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"loc',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("deepseek_v3_1", "PARSER.batch.6.a"): {
+        "description": "Canonical empty {} after tool_sep",
         "text": "<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_time<｜tool▁sep｜>{}<｜tool▁call▁end｜><｜tool▁calls▁end｜>",
         "tools": [_GET_TIME_NOARG],
     },
-    ("deepseek_v3_1", "PARSER.batch.7"): {
-        "description": "Complex args (nested object + array)",
+    ("deepseek_v3_1", "PARSER.batch.6.b"): {
+        "description": "Whitespace inside empty { }",
+        "text": "<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_time<｜tool▁sep｜>{ }<｜tool▁call▁end｜><｜tool▁calls▁end｜>",
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("deepseek_v3_1", "PARSER.batch.6.c"): {
+        "description": "No tool_sep / args section",
+        "text": "<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_time<｜tool▁call▁end｜><｜tool▁calls▁end｜>",
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("deepseek_v3_1", "PARSER.batch.7.a"): {
+        "description": "Standard scalar types",
+        "text": '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>book_flight<｜tool▁sep｜>{"destination":"Paris","passengers":2,"first_class":true}<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
+        "tools": [_BOOK_FLIGHT_MIXED],
+    },
+    ("deepseek_v3_1", "PARSER.batch.7.b"): {
+        "description": "Unicode + escaped chars",
+        "text": '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"Tōkyō \\"central\\""}<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("deepseek_v3_1", "PARSER.batch.7.c"): {
+        "description": "Schema mismatch — string value where schema declares integer",
+        "text": '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>set_temperature<｜tool▁sep｜>{"celsius":"20"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
+        "tools": [_SET_TEMP_NUMERIC],
+    },
+    ("deepseek_v3_1", "PARSER.batch.7.d"): {
+        "description": "Nested object + array (existing)",
         "text": '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>process_data<｜tool▁sep｜>{"items":[1,2,3],"config":{"nested":true}}<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
         "tools": [_PROCESS_DATA_NESTED],
     },
@@ -363,35 +599,91 @@ INPUTS: dict[tuple[str, str], dict[str, Any] | None] = {
         "text": '<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}',
         "tools": [_GET_WEATHER_LOC],
     },
-    ("harmony", "PARSER.batch.2"): {
-        "description": "Multiple tool calls (back-to-back commentary blocks)",
+    ("harmony", "PARSER.batch.2.a"): {
+        "description": "Two back-to-back commentary envelopes",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_openai_tool_parser.py#L130",
         "text": '<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|><|start|>assistant<|channel|>commentary to=functions.get_time <|constrain|>json<|message|>{"timezone":"EST"}<|call|>',
         "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("harmony", "PARSER.batch.2.c"): {
+        "description": "With surrounding narration",
+        "text": 'I need both. <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|><|start|>assistant<|channel|>commentary to=functions.get_time <|constrain|>json<|message|>{"timezone":"EST"}<|call|> Done.',
+        "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("harmony", "PARSER.batch.2.d"): {
+        "description": "Same-name twice",
+        "text": '<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|><|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"LA"}<|call|>',
+        "tools": [_GET_WEATHER_LOC, _GET_WEATHER_LOC],
     },
     ("harmony", "PARSER.batch.3"): {
         "description": "No tool call (plain text)",
         "text": "Hello, how can I help you today?",
         "tools": [_GET_WEATHER_LOC],
     },
-    ("harmony", "PARSER.batch.4"): {
-        "description": "Malformed (truncated JSON args)",
+    ("harmony", "PARSER.batch.4.a"): {
+        "description": "Channel envelope with garbage body",
+        "text": "<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>not json at all<|call|>",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("harmony", "PARSER.batch.4.b"): {
+        "description": "Unterminated JSON in message body",
         "text": '<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC<|call|>',
         "tools": [_GET_WEATHER_LOC],
     },
-    ("harmony", "PARSER.batch.5"): {
+    ("harmony", "PARSER.batch.4.c"): {
+        "description": "No to=functions.X recipient",
+        "text": '<|start|>assistant<|channel|>commentary <|constrain|>json<|message|>{"location":"NYC"}<|call|>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("harmony", "PARSER.batch.5.a"): {
         "description": "Missing <|call|> end marker (bare envelope)",
         "text": '<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}',
         "tools": [_GET_WEATHER_LOC],
     },
-    ("harmony", "PARSER.batch.6"): {
-        "description": "Empty args (no-arg call)",
+    ("harmony", "PARSER.batch.5.b"): {
+        "description": "Bare <|call|> without preceding channel envelope",
+        "text": "<|call|>",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("harmony", "PARSER.batch.5.c"): {
+        "description": "Truncation mid-message JSON",
+        "text": '<|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"loc',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("harmony", "PARSER.batch.6.a"): {
+        "description": "Canonical empty {} message body",
         "text": "<|channel|>commentary to=functions.get_time <|constrain|>json<|message|>{}",
         "tools": [_GET_TIME_NOARG],
     },
-    ("harmony", "PARSER.batch.7"): {
-        "description": "Complex args (multi-parameter)",
-        "text": '<|channel|>analysis<|message|>Need to use function get_weather.<|end|><|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC","unit":"fahrenheit"}<|call|>',
-        "tools": [_GET_WEATHER_LOC_UNIT],
+    ("harmony", "PARSER.batch.6.b"): {
+        "description": "Whitespace inside empty {}",
+        "text": "<|channel|>commentary to=functions.get_time <|constrain|>json<|message|>{ }",
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("harmony", "PARSER.batch.6.c"): {
+        "description": "No <|message|> body",
+        "text": "<|channel|>commentary to=functions.get_time <|constrain|>json",
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("harmony", "PARSER.batch.7.a"): {
+        "description": "Standard scalar types",
+        "text": '<|channel|>commentary to=functions.book_flight <|constrain|>json<|message|>{"destination":"Paris","passengers":2,"first_class":true}<|call|>',
+        "tools": [_BOOK_FLIGHT_MIXED],
+    },
+    ("harmony", "PARSER.batch.7.b"): {
+        "description": "Unicode + escaped chars",
+        "text": '<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"Tōkyō \\"central\\""}<|call|>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("harmony", "PARSER.batch.7.c"): {
+        "description": "Schema mismatch — string value where schema declares integer",
+        "text": '<|channel|>commentary to=functions.set_temperature <|constrain|>json<|message|>{"celsius":"20"}<|call|>',
+        "tools": [_SET_TEMP_NUMERIC],
+    },
+    ("harmony", "PARSER.batch.7.d"): {
+        "description": "Nested object + array",
+        "text": '<|channel|>commentary to=functions.process_data <|constrain|>json<|message|>{"items":[1,2,3],"config":{"nested":true}}<|call|>',
+        "tools": [_PROCESS_DATA_NESTED],
     },
     ("harmony", "PARSER.batch.8.a"): {
         "description": "Narration before tool call only",
@@ -405,7 +697,7 @@ INPUTS: dict[tuple[str, str], dict[str, Any] | None] = {
     },
     ("harmony", "PARSER.batch.8.c"): {
         "description": "Narration both before and after (sandwich)",
-        "ref": "inspired-by https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_openai_tool_parser.py#L220",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_openai_tool_parser.py#L220",
         "text": 'I will check the weather. <|channel|>analysis<|message|>Need to use function get_weather.<|end|><|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|> Let me know if you need more.',
         "tools": [_GET_WEATHER_LOC],
     },
@@ -430,39 +722,86 @@ INPUTS: dict[tuple[str, str], dict[str, Any] | None] = {
         "text": '<minimax:tool_call>\n<invoke name="get_weather">\n<parameter name="location">NYC</parameter>\n</invoke>\n</minimax:tool_call>',
         "tools": [_GET_WEATHER_LOC],
     },
-    ("minimax_m2", "PARSER.batch.2"): {
-        "description": "Multiple tool calls",
+    ("minimax_m2", "PARSER.batch.2.a"): {
+        "description": "Two invokes inside one tool_call wrapper",
         "text": '<minimax:tool_call>\n<invoke name="get_weather">\n<parameter name="location">NYC</parameter>\n</invoke>\n<invoke name="get_time">\n<parameter name="timezone">EST</parameter>\n</invoke>\n</minimax:tool_call>',
         "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("minimax_m2", "PARSER.batch.2.b"): {
+        "description": "Two back-to-back tool_call wrappers",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_minimax_m2_tool_parser.py#L207",
+        "text": '<minimax:tool_call>\n<invoke name="get_weather">\n<parameter name="location">NYC</parameter>\n</invoke>\n</minimax:tool_call>\n<minimax:tool_call>\n<invoke name="get_time">\n<parameter name="timezone">EST</parameter>\n</invoke>\n</minimax:tool_call>',
+        "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("minimax_m2", "PARSER.batch.2.c"): {
+        "description": "Parallel with surrounding narration",
+        "text": 'Both: <minimax:tool_call>\n<invoke name="get_weather">\n<parameter name="location">NYC</parameter>\n</invoke>\n<invoke name="get_time">\n<parameter name="timezone">EST</parameter>\n</invoke>\n</minimax:tool_call> Done.',
+        "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("minimax_m2", "PARSER.batch.2.d"): {
+        "description": "Same-name twice",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_minimax_m2_tool_parser.py#L331",
+        "text": '<minimax:tool_call>\n<invoke name="get_weather">\n<parameter name="location">NYC</parameter>\n</invoke>\n<invoke name="get_weather">\n<parameter name="location">LA</parameter>\n</invoke>\n</minimax:tool_call>',
+        "tools": [_GET_WEATHER_LOC, _GET_WEATHER_LOC],
     },
     ("minimax_m2", "PARSER.batch.3"): {
         "description": "No tool call (plain text)",
         "text": "Hello, how can I help you today?",
         "tools": [_GET_WEATHER_LOC],
     },
-    ("minimax_m2", "PARSER.batch.4"): {
-        "description": "Malformed (missing closing invoke tag)",
+    ("minimax_m2", "PARSER.batch.4.a"): {
+        "description": "Tool_call wrapper with garbage body",
+        "text": "<minimax:tool_call>\nnot a valid invoke\n</minimax:tool_call>",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("minimax_m2", "PARSER.batch.4.c"): {
+        "description": "Invoke without name attribute",
+        "text": '<minimax:tool_call>\n<invoke>\n<parameter name="location">NYC</parameter>\n</invoke>\n</minimax:tool_call>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("minimax_m2", "PARSER.batch.4.d"): {
+        "description": "Missing closing </invoke>",
         "text": '<minimax:tool_call>\n<invoke name="get_weather">\n<parameter name="location">NYC</parameter>\n</minimax:tool_call>',
         "tools": [_GET_WEATHER_LOC],
     },
-    ("minimax_m2", "PARSER.batch.5"): {
+    ("minimax_m2", "PARSER.batch.5.a"): {
         "description": "Missing </minimax:tool_call> end marker",
         "text": '<minimax:tool_call>\n<invoke name="get_weather">\n<parameter name="location">NYC</parameter>\n</invoke>',
         "tools": [_GET_WEATHER_LOC],
     },
-    ("minimax_m2", "PARSER.batch.6"): {
-        "description": "Empty args (no-arg call)",
+    ("minimax_m2", "PARSER.batch.5.b"): {
+        "description": "Closing </minimax:tool_call> without matching open",
+        "text": '<invoke name="get_weather">\n<parameter name="location">NYC</parameter>\n</invoke>\n</minimax:tool_call>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("minimax_m2", "PARSER.batch.5.c"): {
+        "description": "Truncation mid-parameter value",
+        "text": '<minimax:tool_call>\n<invoke name="get_weather">\n<parameter name="location">NY',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("minimax_m2", "PARSER.batch.6.a"): {
+        "description": "Invoke with no <parameter>",
         "text": '<minimax:tool_call>\n<invoke name="get_time">\n</invoke>\n</minimax:tool_call>',
         "tools": [_GET_TIME_NOARG],
     },
-    ("minimax_m2", "PARSER.batch.7"): {
-        "description": "Complex args (multi-parameter)",
-        "text": '<minimax:tool_call>\n<invoke name="get_weather">\n<parameter name="location">NYC</parameter>\n<parameter name="unit">fahrenheit</parameter>\n</invoke>\n</minimax:tool_call>',
-        "tools": [_GET_WEATHER_LOC_UNIT],
+    ("minimax_m2", "PARSER.batch.6.b"): {
+        "description": "Invoke with extra newline",
+        "text": '<minimax:tool_call>\n<invoke name="get_time">\n\n</invoke>\n</minimax:tool_call>',
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("minimax_m2", "PARSER.batch.7.a"): {
+        "description": "Multiple parameters",
+        "text": '<minimax:tool_call>\n<invoke name="book_flight">\n<parameter name="destination">Paris</parameter>\n<parameter name="passengers">2</parameter>\n<parameter name="first_class">true</parameter>\n</invoke>\n</minimax:tool_call>',
+        "tools": [_BOOK_FLIGHT_MIXED],
+    },
+    ("minimax_m2", "PARSER.batch.7.b"): {
+        "description": "Unicode in parameter",
+        "text": '<minimax:tool_call>\n<invoke name="get_weather">\n<parameter name="location">Tōkyō central</parameter>\n</invoke>\n</minimax:tool_call>',
+        "tools": [_GET_WEATHER_LOC],
     },
     ("minimax_m2", "PARSER.batch.8.a"): {
         "description": "Narration before tool call only",
-        "ref": "inspired-by https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_minimax_m2_tool_parser.py#L126",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_minimax_m2_tool_parser.py#L126",
         "text": 'I will check the weather. <minimax:tool_call>\n<invoke name="get_weather">\n<parameter name="location">NYC</parameter>\n</invoke>\n</minimax:tool_call>',
         "tools": [_GET_WEATHER_LOC],
     },
@@ -497,33 +836,98 @@ INPUTS: dict[tuple[str, str], dict[str, Any] | None] = {
         "text": '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}]</TOOLCALL>',
         "tools": [_GET_WEATHER_LOC],
     },
-    ("nemotron_deci", "PARSER.batch.2"): {
-        "description": "Multiple tool calls",
+    ("nemotron_deci", "PARSER.batch.2.a"): {
+        "description": "Parallel calls in JSON array",
         "text": '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_time", "arguments": {"timezone": "EST"}}]</TOOLCALL>',
         "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("nemotron_deci", "PARSER.batch.2.b"): {
+        "description": "Two back-to-back TOOLCALL wrappers",
+        "text": '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}]</TOOLCALL><TOOLCALL>[{"name": "get_time", "arguments": {"timezone": "EST"}}]</TOOLCALL>',
+        "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("nemotron_deci", "PARSER.batch.2.c"): {
+        "description": "With surrounding narration",
+        "text": 'Both: <TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_time", "arguments": {"timezone": "EST"}}]</TOOLCALL> Done.',
+        "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("nemotron_deci", "PARSER.batch.2.d"): {
+        "description": "Same-name twice",
+        "text": '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_weather", "arguments": {"location": "LA"}}]</TOOLCALL>',
+        "tools": [_GET_WEATHER_LOC, _GET_WEATHER_LOC],
     },
     ("nemotron_deci", "PARSER.batch.3"): {
         "description": "No tool call (plain text)",
         "text": "Hello, how can I help you today?",
         "tools": [_GET_WEATHER_LOC],
     },
-    ("nemotron_deci", "PARSER.batch.4"): {
-        "description": "Malformed (truncated JSON inside TOOLCALL)",
+    ("nemotron_deci", "PARSER.batch.4.a"): {
+        "description": "TOOLCALL wrapper with garbage",
+        "text": "<TOOLCALL>not a json array</TOOLCALL>",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("nemotron_deci", "PARSER.batch.4.b"): {
+        "description": "Unterminated JSON string in args",
         "text": '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC</TOOLCALL>',
         "tools": [_GET_WEATHER_LOC],
     },
-    ("nemotron_deci", "PARSER.batch.5"): {
+    ("nemotron_deci", "PARSER.batch.4.c"): {
+        "description": "Missing name key in JSON",
+        "text": '<TOOLCALL>[{"arguments": {"location": "NYC"}}]</TOOLCALL>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("nemotron_deci", "PARSER.batch.4.d"): {
+        "description": "Mismatched JSON brackets",
+        "text": '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}</TOOLCALL>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("nemotron_deci", "PARSER.batch.5.a"): {
         "description": "Missing </TOOLCALL> end marker",
         "text": '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}]',
         "tools": [_GET_WEATHER_LOC],
     },
-    ("nemotron_deci", "PARSER.batch.6"): {
-        "description": "Empty args (no-arg call)",
+    ("nemotron_deci", "PARSER.batch.5.b"): {
+        "description": "Closing </TOOLCALL> without matching <TOOLCALL> open",
+        "text": '[{"name": "get_weather", "arguments": {"location": "NYC"}}]</TOOLCALL>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("nemotron_deci", "PARSER.batch.5.c"): {
+        "description": "Truncation mid-arguments JSON",
+        "text": '<TOOLCALL>[{"name": "get_weather", "arguments": {"loc',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("nemotron_deci", "PARSER.batch.6.a"): {
+        "description": 'Canonical "arguments": {}',
         "text": '<TOOLCALL>[{"name": "get_time", "arguments": {}}]</TOOLCALL>',
         "tools": [_GET_TIME_NOARG],
     },
-    ("nemotron_deci", "PARSER.batch.7"): {
-        "description": "Complex args (nested object + array)",
+    ("nemotron_deci", "PARSER.batch.6.b"): {
+        "description": "Whitespace inside arguments {}",
+        "text": '<TOOLCALL>[{"name": "get_time", "arguments": { }}]</TOOLCALL>',
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("nemotron_deci", "PARSER.batch.6.c"): {
+        "description": "No arguments key",
+        "text": '<TOOLCALL>[{"name": "get_time"}]</TOOLCALL>',
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("nemotron_deci", "PARSER.batch.7.a"): {
+        "description": "Standard scalar types",
+        "text": '<TOOLCALL>[{"name": "book_flight", "arguments": {"destination": "Paris", "passengers": 2, "first_class": true}}]</TOOLCALL>',
+        "tools": [_BOOK_FLIGHT_MIXED],
+    },
+    ("nemotron_deci", "PARSER.batch.7.b"): {
+        "description": "Unicode + escaped chars",
+        "text": '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "Tōkyō \\"central\\""}}]</TOOLCALL>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("nemotron_deci", "PARSER.batch.7.c"): {
+        "description": "Schema mismatch — string value where schema declares integer",
+        "text": '<TOOLCALL>[{"name": "set_temperature", "arguments": {"celsius": "20"}}]</TOOLCALL>',
+        "tools": [_SET_TEMP_NUMERIC],
+    },
+    ("nemotron_deci", "PARSER.batch.7.d"): {
+        "description": "Nested object + array (existing)",
         "text": '<TOOLCALL>[{"name": "process_data", "arguments": {"items": [1,2,3], "config": {"nested": true}}}]</TOOLCALL>',
         "tools": [_PROCESS_DATA_NESTED],
     },
@@ -565,33 +969,83 @@ INPUTS: dict[tuple[str, str], dict[str, Any] | None] = {
         "text": '[get_weather(location="NYC")]',
         "tools": [_GET_WEATHER_LOC],
     },
-    ("pythonic", "PARSER.batch.2"): {
-        "description": "Multiple tool calls (parallel)",
+    ("pythonic", "PARSER.batch.2.a"): {
+        "description": "Parallel calls in single bracket",
         "text": '[get_weather(location="NYC"), get_time(timezone="EST")]',
         "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("pythonic", "PARSER.batch.2.c"): {
+        "description": "With surrounding narration",
+        "text": 'Both: [get_weather(location="NYC"), get_time(timezone="EST")] Done.',
+        "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("pythonic", "PARSER.batch.2.d"): {
+        "description": "Same-name twice",
+        "text": '[get_weather(location="NYC"), get_weather(location="LA")]',
+        "tools": [_GET_WEATHER_LOC, _GET_WEATHER_LOC],
     },
     ("pythonic", "PARSER.batch.3"): {
         "description": "No tool call (plain text)",
         "text": "Hello, how can I help you today?",
         "tools": [_GET_WEATHER_LOC],
     },
-    ("pythonic", "PARSER.batch.4"): {
-        "description": "Malformed (missing closing bracket)",
+    ("pythonic", "PARSER.batch.4.a"): {
+        "description": "Bracket form with garbage call",
+        "text": "[not a valid python call]",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("pythonic", "PARSER.batch.4.b"): {
+        "description": "Missing closing bracket",
         "text": '[get_weather(location="NYC"',
         "tools": [_GET_WEATHER_LOC],
     },
-    ("pythonic", "PARSER.batch.5"): {
+    ("pythonic", "PARSER.batch.4.d"): {
+        "description": "Mismatched paren / bracket",
+        "text": '[get_weather(location="NYC"]',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("pythonic", "PARSER.batch.5.a"): {
         "description": "Missing closing `]` end marker",
         "text": '[get_weather(location="NYC")',
         "tools": [_GET_WEATHER_LOC],
     },
-    ("pythonic", "PARSER.batch.6"): {
-        "description": "Empty args (no-arg call)",
+    ("pythonic", "PARSER.batch.5.b"): {
+        "description": "Closing `]` without matching `[` open",
+        "text": 'get_weather(location="NYC")]',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("pythonic", "PARSER.batch.5.c"): {
+        "description": "Truncation mid-argument value",
+        "text": '[get_weather(location="N',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("pythonic", "PARSER.batch.6.a"): {
+        "description": "Empty parens (no args)",
         "text": "[get_time()]",
         "tools": [_GET_TIME_NOARG],
     },
-    ("pythonic", "PARSER.batch.7"): {
-        "description": "Complex args (nested dict + array)",
+    ("pythonic", "PARSER.batch.6.b"): {
+        "description": "Whitespace inside parens",
+        "text": "[get_time( )]",
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("pythonic", "PARSER.batch.7.a"): {
+        "description": "Standard scalar types",
+        "text": '[book_flight(destination="Paris", passengers=2, first_class=True)]',
+        "tools": [_BOOK_FLIGHT_MIXED],
+    },
+    ("pythonic", "PARSER.batch.7.b"): {
+        "description": "Unicode + escaped chars",
+        "text": '[get_weather(location="Tōkyō \\"central\\"")]',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("pythonic", "PARSER.batch.7.c"): {
+        "description": "Schema mismatch — string value where schema declares integer",
+        "text": '[set_temperature(celsius="20")]',
+        "tools": [_SET_TEMP_NUMERIC],
+    },
+    ("pythonic", "PARSER.batch.7.d"): {
+        "description": "Nested dict + array (existing)",
         "text": '[process_data(items=[1, 2, 3], config={"nested": True})]',
         "tools": [_PROCESS_DATA_NESTED],
     },
@@ -633,39 +1087,107 @@ INPUTS: dict[tuple[str, str], dict[str, Any] | None] = {
         "text": '<|tool_call>call:get_weather{location:<|"|>NYC<|"|>}<tool_call|>',
         "tools": [_GET_WEATHER_LOC],
     },
-    ("gemma4", "PARSER.batch.2"): {
-        "description": "Multiple tool calls (parallel)",
+    ("gemma4", "PARSER.batch.2.a"): {
+        "description": "Parallel calls (back-to-back sentinels)",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_gemma4_tool_parser.py#L207",
         "text": '<|tool_call>call:get_weather{location:<|"|>NYC<|"|>}<tool_call|><|tool_call>call:get_time{timezone:<|"|>EST<|"|>}<tool_call|>',
         "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("gemma4", "PARSER.batch.2.c"): {
+        "description": "With surrounding narration",
+        "text": 'Both: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}<tool_call|><|tool_call>call:get_time{timezone:<|"|>EST<|"|>}<tool_call|> Done.',
+        "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("gemma4", "PARSER.batch.2.d"): {
+        "description": "Same-name twice",
+        "text": '<|tool_call>call:get_weather{location:<|"|>NYC<|"|>}<tool_call|><|tool_call>call:get_weather{location:<|"|>LA<|"|>}<tool_call|>',
+        "tools": [_GET_WEATHER_LOC, _GET_WEATHER_LOC],
     },
     ("gemma4", "PARSER.batch.3"): {
         "description": "No tool call (plain text)",
         "text": "Hello, how can I help you today?",
         "tools": [_GET_WEATHER_LOC],
     },
-    ("gemma4", "PARSER.batch.4"): {
-        "description": "Malformed (missing close brace)",
+    ("gemma4", "PARSER.batch.4.a"): {
+        "description": "Sentinel pair with garbage",
+        "text": "<|tool_call>nonsense<tool_call|>",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("gemma4", "PARSER.batch.4.b"): {
+        "description": "Missing close brace in body",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_gemma4_tool_parser.py#L572",
         "text": '<|tool_call>call:get_weather{location:<|"|>NYC<|"|><tool_call|>',
         "tools": [_GET_WEATHER_LOC],
     },
-    ("gemma4", "PARSER.batch.5"): {
+    ("gemma4", "PARSER.batch.4.c"): {
+        "description": "No call:name prefix",
+        "text": '<|tool_call>{location:<|"|>NYC<|"|>}<tool_call|>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("gemma4", "PARSER.batch.4.d"): {
+        "description": "Mismatched sentinels",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_gemma4_tool_parser.py#L252",
+        "text": '<|tool_call>call:get_weather{location:<|"|>NYC<|"|>}',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("gemma4", "PARSER.batch.5.a"): {
         "description": "Missing <tool_call|> end marker",
         "text": '<|tool_call>call:get_weather{location:<|"|>NYC<|"|>}',
         "tools": [_GET_WEATHER_LOC],
     },
-    ("gemma4", "PARSER.batch.6"): {
-        "description": "Empty args (no-arg call)",
+    ("gemma4", "PARSER.batch.5.b"): {
+        "description": "Closing <tool_call|> without matching <|tool_call> open",
+        "text": 'call:get_weather{location:<|"|>NYC<|"|>}<tool_call|>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("gemma4", "PARSER.batch.5.c"): {
+        "description": "Truncation mid-argument value",
+        "text": '<|tool_call>call:get_weather{location:<|"|>N',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("gemma4", "PARSER.batch.6.a"): {
+        "description": "Canonical empty {} body",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_gemma4_tool_parser.py#L560",
         "text": "<|tool_call>call:get_time{}<tool_call|>",
         "tools": [_GET_TIME_NOARG],
     },
-    ("gemma4", "PARSER.batch.7"): {
-        "description": "Complex args (nested object + array)",
+    ("gemma4", "PARSER.batch.6.b"): {
+        "description": "Whitespace inside empty {}",
+        "text": "<|tool_call>call:get_time{ }<tool_call|>",
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("gemma4", "PARSER.batch.6.c"): {
+        "description": "No body (just call:name)",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_gemma4_tool_parser.py#L280",
+        "text": "<|tool_call>call:get_time<tool_call|>",
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("gemma4", "PARSER.batch.7.a"): {
+        "description": "Standard scalar types",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_gemma4_tool_parser.py#L236",
+        "text": '<|tool_call>call:book_flight{destination:<|"|>Paris<|"|>,passengers:2,first_class:true}<tool_call|>',
+        "tools": [_BOOK_FLIGHT_MIXED],
+    },
+    ("gemma4", "PARSER.batch.7.b"): {
+        "description": "Unicode in value",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_gemma4_tool_parser.py#L630",
+        "text": '<|tool_call>call:get_weather{location:<|"|>Tōkyō central<|"|>}<tool_call|>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("gemma4", "PARSER.batch.7.c"): {
+        "description": "Schema mismatch — string value where schema declares integer",
+        "text": '<|tool_call>call:set_temperature{celsius:<|"|>20<|"|>}<tool_call|>',
+        "tools": [_SET_TEMP_NUMERIC],
+    },
+    ("gemma4", "PARSER.batch.7.d"): {
+        "description": "Nested object + array (existing)",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_gemma4_tool_parser.py#L179",
         "text": "<|tool_call>call:process_data{items:[1,2,3],config:{nested:true}}<tool_call|>",
         "tools": [_PROCESS_DATA_NESTED],
     },
     ("gemma4", "PARSER.batch.8.a"): {
         "description": "Narration before tool call only",
-        "ref": "inspired-by https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_gemma4_tool_parser.py#L194",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_gemma4_tool_parser.py#L194",
         "text": 'I will check the weather. <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}<tool_call|>',
         "tools": [_GET_WEATHER_LOC],
     },
@@ -703,33 +1225,103 @@ INPUTS: dict[tuple[str, str], dict[str, Any] | None] = {
         "text": '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather\n```json\n{"location": "NYC"}\n```<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
         "tools": [_GET_WEATHER_LOC],
     },
-    ("deepseek_v3", "PARSER.batch.2"): {
-        "description": "Multiple tool calls (parallel)",
+    ("deepseek_v3", "PARSER.batch.2.a"): {
+        "description": "Parallel calls in single fence pair",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L185",
         "text": '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather\n```json\n{"location": "NYC"}\n```<｜tool▁call▁end｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_time\n```json\n{"timezone": "EST"}\n```<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
         "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("deepseek_v3", "PARSER.batch.2.b"): {
+        "description": "Two back-to-back fence pairs",
+        "text": '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather\n```json\n{"location": "NYC"}\n```<｜tool▁call▁end｜><｜tool▁calls▁end｜><｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_time\n```json\n{"timezone": "EST"}\n```<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
+        "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("deepseek_v3", "PARSER.batch.2.c"): {
+        "description": "With surrounding narration",
+        "text": 'Both: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather\n```json\n{"location": "NYC"}\n```<｜tool▁call▁end｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_time\n```json\n{"timezone": "EST"}\n```<｜tool▁call▁end｜><｜tool▁calls▁end｜> Done.',
+        "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("deepseek_v3", "PARSER.batch.2.d"): {
+        "description": "Same-name twice",
+        "text": '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather\n```json\n{"location": "NYC"}\n```<｜tool▁call▁end｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather\n```json\n{"location": "LA"}\n```<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
+        "tools": [_GET_WEATHER_LOC, _GET_WEATHER_LOC],
     },
     ("deepseek_v3", "PARSER.batch.3"): {
         "description": "No tool call (plain text)",
         "text": "Hello, how can I help you today?",
         "tools": [_GET_WEATHER_LOC],
     },
-    ("deepseek_v3", "PARSER.batch.4"): {
-        "description": "Malformed JSON args (missing close brace)",
+    ("deepseek_v3", "PARSER.batch.4.a"): {
+        "description": "Garbage between calls fences",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L322",
+        "text": "<｜tool▁calls▁begin｜>nonsense<｜tool▁calls▁end｜>",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("deepseek_v3", "PARSER.batch.4.b"): {
+        "description": "Missing close brace inside fenced JSON",
         "text": '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather\n```json\n{"location": "NYC"\n```<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
         "tools": [_GET_WEATHER_LOC],
     },
-    ("deepseek_v3", "PARSER.batch.5"): {
+    ("deepseek_v3", "PARSER.batch.4.c"): {
+        "description": "Missing function name token",
+        "text": '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>\n```json\n{"location": "NYC"}\n```<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("deepseek_v3", "PARSER.batch.4.d"): {
+        "description": "Missing fenced JSON block (no ```json)",
+        "text": '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather\n{"location": "NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("deepseek_v3", "PARSER.batch.5.a"): {
         "description": "Missing calls_end / call_end markers",
         "text": '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather\n```json\n{"location": "NYC"}\n```',
         "tools": [_GET_WEATHER_LOC],
     },
-    ("deepseek_v3", "PARSER.batch.6"): {
-        "description": "Empty args (no-arg call)",
+    ("deepseek_v3", "PARSER.batch.5.b"): {
+        "description": "Closing tool_calls_end without matching tool_calls_begin",
+        "text": '<｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather\n```json\n{"location": "NYC"}\n```<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("deepseek_v3", "PARSER.batch.5.c"): {
+        "description": "Truncation mid-arguments JSON inside fenced block",
+        "text": '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather\n```json\n{"loc',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("deepseek_v3", "PARSER.batch.6.a"): {
+        "description": "Canonical empty {} in fenced code block",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L260",
         "text": "<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_time\n```json\n{}\n```<｜tool▁call▁end｜><｜tool▁calls▁end｜>",
         "tools": [_GET_TIME_NOARG],
     },
-    ("deepseek_v3", "PARSER.batch.7"): {
-        "description": "Complex args (nested object + array)",
+    ("deepseek_v3", "PARSER.batch.6.b"): {
+        "description": "Whitespace inside empty { } (newlines)",
+        "text": "<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_time\n```json\n{\n}\n```<｜tool▁call▁end｜><｜tool▁calls▁end｜>",
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("deepseek_v3", "PARSER.batch.6.c"): {
+        "description": "No fenced JSON block (function name only)",
+        "text": "<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_time<｜tool▁call▁end｜><｜tool▁calls▁end｜>",
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("deepseek_v3", "PARSER.batch.7.a"): {
+        "description": "Standard scalar types",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L220",
+        "text": '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>book_flight\n```json\n{"destination": "Paris", "passengers": 2, "first_class": true}\n```<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
+        "tools": [_BOOK_FLIGHT_MIXED],
+    },
+    ("deepseek_v3", "PARSER.batch.7.b"): {
+        "description": "Unicode + escaped chars",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L302",
+        "text": '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather\n```json\n{"location": "Tōkyō \\"central\\""}\n```<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("deepseek_v3", "PARSER.batch.7.c"): {
+        "description": "Schema mismatch — string value where schema declares integer",
+        "text": '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>set_temperature\n```json\n{"celsius": "20"}\n```<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
+        "tools": [_SET_TEMP_NUMERIC],
+    },
+    ("deepseek_v3", "PARSER.batch.7.d"): {
+        "description": "Nested object + array (existing)",
         "text": '<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>process_data\n```json\n{"items": [1, 2, 3], "config": {"nested": true}}\n```<｜tool▁call▁end｜><｜tool▁calls▁end｜>',
         "tools": [_PROCESS_DATA_NESTED],
     },
@@ -745,7 +1337,7 @@ INPUTS: dict[tuple[str, str], dict[str, Any] | None] = {
     },
     ("deepseek_v3", "PARSER.batch.8.c"): {
         "description": "Narration both before and after (sandwich)",
-        "ref": "inspired-by https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L282",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L282",
         "text": 'I will check the weather. <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather\n```json\n{"location": "NYC"}\n```<｜tool▁call▁end｜><｜tool▁calls▁end｜> Let me know if you need more.',
         "tools": [_GET_WEATHER_LOC],
     },
@@ -778,35 +1370,80 @@ INPUTS: dict[tuple[str, str], dict[str, Any] | None] = {
         "text": '<｜DSML｜tool_calls>\n<｜DSML｜invoke name="get_weather">\n<｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>',
         "tools": [_GET_WEATHER_LOC],
     },
-    ("deepseek_v4", "PARSER.batch.2"): {
-        "description": "Multiple tool calls (parallel)",
+    ("deepseek_v4", "PARSER.batch.2.a"): {
+        "description": "Two invokes inside one tool_calls wrapper",
         "text": '<｜DSML｜tool_calls>\n<｜DSML｜invoke name="get_weather">\n<｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>\n</｜DSML｜invoke>\n<｜DSML｜invoke name="get_time">\n<｜DSML｜parameter name="timezone" string="true">EST</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>',
         "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("deepseek_v4", "PARSER.batch.2.b"): {
+        "description": "Two back-to-back tool_calls wrappers",
+        "text": '<｜DSML｜tool_calls>\n<｜DSML｜invoke name="get_weather">\n<｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>\n<｜DSML｜tool_calls>\n<｜DSML｜invoke name="get_time">\n<｜DSML｜parameter name="timezone" string="true">EST</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>',
+        "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("deepseek_v4", "PARSER.batch.2.c"): {
+        "description": "Parallel with surrounding narration",
+        "text": 'Both: <｜DSML｜tool_calls>\n<｜DSML｜invoke name="get_weather">\n<｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>\n</｜DSML｜invoke>\n<｜DSML｜invoke name="get_time">\n<｜DSML｜parameter name="timezone" string="true">EST</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls> Done.',
+        "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("deepseek_v4", "PARSER.batch.2.d"): {
+        "description": "Same-name twice",
+        "text": '<｜DSML｜tool_calls>\n<｜DSML｜invoke name="get_weather">\n<｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>\n</｜DSML｜invoke>\n<｜DSML｜invoke name="get_weather">\n<｜DSML｜parameter name="location" string="true">LA</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>',
+        "tools": [_GET_WEATHER_LOC, _GET_WEATHER_LOC],
     },
     ("deepseek_v4", "PARSER.batch.3"): {
         "description": "No tool call (plain text)",
         "text": "Hello, how can I help you today?",
         "tools": [_GET_WEATHER_LOC],
     },
-    ("deepseek_v4", "PARSER.batch.4"): {
-        "description": "Malformed (missing </｜DSML｜parameter> end tag)",
+    ("deepseek_v4", "PARSER.batch.4.a"): {
+        "description": "Tool_calls wrapper with garbage",
+        "text": "<｜DSML｜tool_calls>\nnot a valid invoke\n</｜DSML｜tool_calls>",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("deepseek_v4", "PARSER.batch.4.c"): {
+        "description": "Invoke without name attribute",
+        "text": '<｜DSML｜tool_calls>\n<｜DSML｜invoke>\n<｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("deepseek_v4", "PARSER.batch.4.d"): {
+        "description": "Missing </｜DSML｜parameter> end tag",
         "text": '<｜DSML｜tool_calls>\n<｜DSML｜invoke name="get_weather">\n<｜DSML｜parameter name="location" string="true">NYC\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>',
         "tools": [_GET_WEATHER_LOC],
     },
-    ("deepseek_v4", "PARSER.batch.5"): {
+    ("deepseek_v4", "PARSER.batch.5.a"): {
         "description": "Missing </｜DSML｜tool_calls> end marker",
         "text": '<｜DSML｜tool_calls>\n<｜DSML｜invoke name="get_weather">\n<｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>\n</｜DSML｜invoke>',
         "tools": [_GET_WEATHER_LOC],
     },
-    ("deepseek_v4", "PARSER.batch.6"): {
-        "description": "Empty args (no-arg call)",
+    ("deepseek_v4", "PARSER.batch.5.b"): {
+        "description": "Closing </｜DSML｜tool_calls> without matching open",
+        "text": '<｜DSML｜invoke name="get_weather">\n<｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("deepseek_v4", "PARSER.batch.5.c"): {
+        "description": "Truncation mid-parameter value",
+        "text": '<｜DSML｜tool_calls>\n<｜DSML｜invoke name="get_weather">\n<｜DSML｜parameter name="location" string="true">NY',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("deepseek_v4", "PARSER.batch.6.a"): {
+        "description": "Invoke with no <parameter>",
         "text": '<｜DSML｜tool_calls>\n<｜DSML｜invoke name="get_time">\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>',
         "tools": [_GET_TIME_NOARG],
     },
-    ("deepseek_v4", "PARSER.batch.7"): {
-        "description": "Complex args (nested object + array, JSON-typed)",
-        "text": '<｜DSML｜tool_calls>\n<｜DSML｜invoke name="process_data">\n<｜DSML｜parameter name="items" string="false">[1, 2, 3]</｜DSML｜parameter>\n<｜DSML｜parameter name="config" string="false">{"nested": true}</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>',
-        "tools": [_PROCESS_DATA_NESTED],
+    ("deepseek_v4", "PARSER.batch.6.b"): {
+        "description": "Invoke with extra newline",
+        "text": '<｜DSML｜tool_calls>\n<｜DSML｜invoke name="get_time">\n\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>',
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("deepseek_v4", "PARSER.batch.7.a"): {
+        "description": "Multiple parameters",
+        "text": '<｜DSML｜tool_calls>\n<｜DSML｜invoke name="book_flight">\n<｜DSML｜parameter name="destination" string="true">Paris</｜DSML｜parameter>\n<｜DSML｜parameter name="passengers" string="false">2</｜DSML｜parameter>\n<｜DSML｜parameter name="first_class" string="false">true</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>',
+        "tools": [_BOOK_FLIGHT_MIXED],
+    },
+    ("deepseek_v4", "PARSER.batch.7.b"): {
+        "description": "Unicode in parameter",
+        "text": '<｜DSML｜tool_calls>\n<｜DSML｜invoke name="get_weather">\n<｜DSML｜parameter name="location" string="true">Tōkyō central</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>',
+        "tools": [_GET_WEATHER_LOC],
     },
     ("deepseek_v4", "PARSER.batch.8.a"): {
         "description": "Narration before tool call only",
@@ -844,39 +1481,102 @@ INPUTS: dict[tuple[str, str], dict[str, Any] | None] = {
         "text": '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>',
         "tools": [_GET_WEATHER_LOC],
     },
-    ("hermes", "PARSER.batch.2"): {
-        "description": "Multiple tool calls (parallel)",
+    ("hermes", "PARSER.batch.2.a"): {
+        "description": "Parallel calls (back-to-back tool_call wrappers)",
         "text": '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name": "get_time", "arguments": {"timezone": "EST"}}</tool_call>',
         "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("hermes", "PARSER.batch.2.c"): {
+        "description": "With surrounding narration",
+        "text": 'Both: <tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name": "get_time", "arguments": {"timezone": "EST"}}</tool_call> Done.',
+        "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("hermes", "PARSER.batch.2.d"): {
+        "description": "Same-name twice",
+        "text": '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name": "get_weather", "arguments": {"location": "LA"}}</tool_call>',
+        "tools": [_GET_WEATHER_LOC, _GET_WEATHER_LOC],
     },
     ("hermes", "PARSER.batch.3"): {
         "description": "No tool call (plain text)",
         "text": "Hello, how can I help you today?",
         "tools": [_GET_WEATHER_LOC],
     },
-    ("hermes", "PARSER.batch.4"): {
-        "description": "Malformed JSON args (missing close brace)",
+    ("hermes", "PARSER.batch.4.a"): {
+        "description": "Tool_call wrapper with non-JSON garbage",
+        "text": "<tool_call>not even json</tool_call>",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("hermes", "PARSER.batch.4.b"): {
+        "description": "Missing close brace in JSON body",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_hermes_tool_parser.py#L376",
         "text": '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"</tool_call>',
         "tools": [_GET_WEATHER_LOC],
     },
-    ("hermes", "PARSER.batch.5"): {
+    ("hermes", "PARSER.batch.4.c"): {
+        "description": "Missing name key",
+        "text": '<tool_call>{"arguments": {"location": "NYC"}}</tool_call>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("hermes", "PARSER.batch.4.d"): {
+        "description": "Missing </tool_call> close",
+        "text": '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("hermes", "PARSER.batch.5.a"): {
         "description": "Missing </tool_call> end marker",
         "text": '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}',
         "tools": [_GET_WEATHER_LOC],
     },
-    ("hermes", "PARSER.batch.6"): {
-        "description": "Empty args (no-arg call)",
+    ("hermes", "PARSER.batch.5.b"): {
+        "description": "Closing </tool_call> without matching <tool_call> open",
+        "text": '{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("hermes", "PARSER.batch.5.c"): {
+        "description": "Truncation mid-arguments JSON",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_hermes_tool_parser.py#L356",
+        "text": '<tool_call>{"name": "get_weather", "arguments": {"loc',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("hermes", "PARSER.batch.6.a"): {
+        "description": 'Canonical "arguments": {}',
         "text": '<tool_call>{"name": "get_time", "arguments": {}}</tool_call>',
         "tools": [_GET_TIME_NOARG],
     },
-    ("hermes", "PARSER.batch.7"): {
-        "description": "Complex args (nested object + array)",
-        "text": '<tool_call>{"name": "process_data", "arguments": {"items": [1, 2, 3], "config": {"nested": true}}}</tool_call>',
+    ("hermes", "PARSER.batch.6.b"): {
+        "description": "Whitespace inside arguments {}",
+        "text": '<tool_call>{"name": "get_time", "arguments": { }}</tool_call>',
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("hermes", "PARSER.batch.6.c"): {
+        "description": "No arguments key",
+        "text": '<tool_call>{"name": "get_time"}</tool_call>',
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("hermes", "PARSER.batch.7.a"): {
+        "description": "Standard scalar types",
+        "text": '<tool_call>{"name": "book_flight", "arguments": {"destination": "Paris", "passengers": 2, "first_class": true}}</tool_call>',
+        "tools": [_BOOK_FLIGHT_MIXED],
+    },
+    ("hermes", "PARSER.batch.7.b"): {
+        "description": "Unicode + escaped chars",
+        "text": '<tool_call>{"name": "get_weather", "arguments": {"location": "Tōkyō \\"central\\""}}</tool_call>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("hermes", "PARSER.batch.7.c"): {
+        "description": "Schema mismatch — string value where schema declares integer",
+        "text": '<tool_call>{"name": "set_temperature", "arguments": {"celsius": "20"}}</tool_call>',
+        "tools": [_SET_TEMP_NUMERIC],
+    },
+    ("hermes", "PARSER.batch.7.d"): {
+        "description": "Nested object + array",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_hermes_tool_parser.py#L284",
+        "text": '<tool_call>{"name": "process_data", "arguments": {"items": [1,2,3], "config": {"nested": true}}}</tool_call>',
         "tools": [_PROCESS_DATA_NESTED],
     },
     ("hermes", "PARSER.batch.8.a"): {
         "description": "Narration before tool call only",
-        "ref": "inspired-by https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_hermes_tool_parser.py#L221",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_hermes_tool_parser.py#L221",
         "text": 'I will check the weather. <tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>',
         "tools": [_GET_WEATHER_LOC],
     },
@@ -911,34 +1611,94 @@ INPUTS: dict[tuple[str, str], dict[str, Any] | None] = {
         "text": '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>',
         "tools": [_GET_WEATHER_LOC],
     },
-    ("qwen25", "PARSER.batch.2"): {
-        "description": "Multiple tool calls (parallel)",
+    ("qwen25", "PARSER.batch.2.a"): {
+        "description": "Parallel calls (back-to-back tool_call wrappers)",
         "text": '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name": "get_time", "arguments": {"timezone": "EST"}}</tool_call>',
         "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("qwen25", "PARSER.batch.2.c"): {
+        "description": "With surrounding narration",
+        "text": 'Both: <tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name": "get_time", "arguments": {"timezone": "EST"}}</tool_call> Done.',
+        "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("qwen25", "PARSER.batch.2.d"): {
+        "description": "Same-name twice",
+        "text": '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name": "get_weather", "arguments": {"location": "LA"}}</tool_call>',
+        "tools": [_GET_WEATHER_LOC, _GET_WEATHER_LOC],
     },
     ("qwen25", "PARSER.batch.3"): {
         "description": "No tool call (plain text)",
         "text": "Hello, how can I help you today?",
         "tools": [_GET_WEATHER_LOC],
     },
-    ("qwen25", "PARSER.batch.4"): {
-        "description": "Malformed JSON args (missing close brace)",
+    ("qwen25", "PARSER.batch.4.a"): {
+        "description": "Tool_call wrapper with non-JSON garbage",
+        "text": "<tool_call>not even json</tool_call>",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("qwen25", "PARSER.batch.4.b"): {
+        "description": "Missing close brace in JSON body",
         "text": '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"</tool_call>',
         "tools": [_GET_WEATHER_LOC],
     },
-    ("qwen25", "PARSER.batch.5"): {
+    ("qwen25", "PARSER.batch.4.c"): {
+        "description": "Missing name key",
+        "text": '<tool_call>{"arguments": {"location": "NYC"}}</tool_call>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("qwen25", "PARSER.batch.4.d"): {
+        "description": "Missing </tool_call> close",
+        "text": '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("qwen25", "PARSER.batch.5.a"): {
         "description": "Missing </tool_call> end marker",
         "text": '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}',
         "tools": [_GET_WEATHER_LOC],
     },
-    ("qwen25", "PARSER.batch.6"): {
-        "description": "Empty args (no-arg call)",
+    ("qwen25", "PARSER.batch.5.b"): {
+        "description": "Closing </tool_call> without matching <tool_call> open",
+        "text": '{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("qwen25", "PARSER.batch.5.c"): {
+        "description": "Truncation mid-arguments JSON",
+        "text": '<tool_call>{"name": "get_weather", "arguments": {"loc',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("qwen25", "PARSER.batch.6.a"): {
+        "description": 'Canonical "arguments": {}',
         "text": '<tool_call>{"name": "get_time", "arguments": {}}</tool_call>',
         "tools": [_GET_TIME_NOARG],
     },
-    ("qwen25", "PARSER.batch.7"): {
-        "description": "Complex args (nested object + array)",
-        "text": '<tool_call>{"name": "process_data", "arguments": {"items": [1, 2, 3], "config": {"nested": true}}}</tool_call>',
+    ("qwen25", "PARSER.batch.6.b"): {
+        "description": "Whitespace inside arguments {}",
+        "text": '<tool_call>{"name": "get_time", "arguments": { }}</tool_call>',
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("qwen25", "PARSER.batch.6.c"): {
+        "description": "No arguments key",
+        "text": '<tool_call>{"name": "get_time"}</tool_call>',
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("qwen25", "PARSER.batch.7.a"): {
+        "description": "Standard scalar types",
+        "text": '<tool_call>{"name": "book_flight", "arguments": {"destination": "Paris", "passengers": 2, "first_class": true}}</tool_call>',
+        "tools": [_BOOK_FLIGHT_MIXED],
+    },
+    ("qwen25", "PARSER.batch.7.b"): {
+        "description": "Unicode + escaped chars",
+        "text": '<tool_call>{"name": "get_weather", "arguments": {"location": "Tōkyō \\"central\\""}}</tool_call>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("qwen25", "PARSER.batch.7.c"): {
+        "description": "Schema mismatch — string value where schema declares integer",
+        "text": '<tool_call>{"name": "set_temperature", "arguments": {"celsius": "20"}}</tool_call>',
+        "tools": [_SET_TEMP_NUMERIC],
+    },
+    ("qwen25", "PARSER.batch.7.d"): {
+        "description": "Nested object + array",
+        "text": '<tool_call>{"name": "process_data", "arguments": {"items": [1,2,3], "config": {"nested": true}}}</tool_call>',
         "tools": [_PROCESS_DATA_NESTED],
     },
     ("qwen25", "PARSER.batch.8.a"): {
@@ -977,34 +1737,96 @@ INPUTS: dict[tuple[str, str], dict[str, Any] | None] = {
         "text": '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}][/TOOL_CALLS]',
         "tools": [_GET_WEATHER_LOC],
     },
-    ("mistral", "PARSER.batch.2"): {
-        "description": "Multiple tool calls (parallel)",
+    ("mistral", "PARSER.batch.2.a"): {
+        "description": "Parallel calls in JSON array",
         "text": '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_time", "arguments": {"timezone": "EST"}}][/TOOL_CALLS]',
         "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("mistral", "PARSER.batch.2.c"): {
+        "description": "With surrounding narration",
+        "text": 'Both: [TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_time", "arguments": {"timezone": "EST"}}][/TOOL_CALLS] Done.',
+        "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("mistral", "PARSER.batch.2.d"): {
+        "description": "Same-name twice",
+        "text": '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_weather", "arguments": {"location": "LA"}}][/TOOL_CALLS]',
+        "tools": [_GET_WEATHER_LOC, _GET_WEATHER_LOC],
     },
     ("mistral", "PARSER.batch.3"): {
         "description": "No tool call (plain text)",
         "text": "Hello, how can I help you today?",
         "tools": [_GET_WEATHER_LOC],
     },
-    ("mistral", "PARSER.batch.4"): {
-        "description": "Malformed JSON args (missing close brace)",
+    ("mistral", "PARSER.batch.4.a"): {
+        "description": "TOOL_CALLS wrapper with garbage",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_mistral_tool_parser.py#L405",
+        "text": "[TOOL_CALLS]not a json array[/TOOL_CALLS]",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("mistral", "PARSER.batch.4.b"): {
+        "description": "Missing close brace in JSON",
         "text": '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"][/TOOL_CALLS]',
         "tools": [_GET_WEATHER_LOC],
     },
-    ("mistral", "PARSER.batch.5"): {
+    ("mistral", "PARSER.batch.4.c"): {
+        "description": "Missing name key",
+        "text": '[TOOL_CALLS][{"arguments": {"location": "NYC"}}][/TOOL_CALLS]',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("mistral", "PARSER.batch.4.d"): {
+        "description": "Missing [/TOOL_CALLS] close",
+        "text": '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}]',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("mistral", "PARSER.batch.5.a"): {
         "description": "Missing [/TOOL_CALLS] end marker",
         "text": '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}]',
         "tools": [_GET_WEATHER_LOC],
     },
-    ("mistral", "PARSER.batch.6"): {
-        "description": "Empty args (no-arg call)",
+    ("mistral", "PARSER.batch.5.b"): {
+        "description": "Closing [/TOOL_CALLS] without matching [TOOL_CALLS] open",
+        "text": '[{"name": "get_weather", "arguments": {"location": "NYC"}}][/TOOL_CALLS]',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("mistral", "PARSER.batch.5.c"): {
+        "description": "Truncation mid-arguments JSON",
+        "text": '[TOOL_CALLS][{"name": "get_weather", "arguments": {"loc',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("mistral", "PARSER.batch.6.a"): {
+        "description": 'Canonical "arguments": {}',
         "text": '[TOOL_CALLS][{"name": "get_time", "arguments": {}}][/TOOL_CALLS]',
         "tools": [_GET_TIME_NOARG],
     },
-    ("mistral", "PARSER.batch.7"): {
-        "description": "Complex args (nested object + array)",
-        "text": '[TOOL_CALLS][{"name": "process_data", "arguments": {"items": [1, 2, 3], "config": {"nested": true}}}][/TOOL_CALLS]',
+    ("mistral", "PARSER.batch.6.b"): {
+        "description": "Whitespace inside arguments {}",
+        "text": '[TOOL_CALLS][{"name": "get_time", "arguments": { }}][/TOOL_CALLS]',
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("mistral", "PARSER.batch.6.c"): {
+        "description": "No arguments key",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_mistral_tool_parser.py#L514",
+        "text": '[TOOL_CALLS][{"name": "get_time"}][/TOOL_CALLS]',
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("mistral", "PARSER.batch.7.a"): {
+        "description": "Standard scalar types",
+        "text": '[TOOL_CALLS][{"name": "book_flight", "arguments": {"destination": "Paris", "passengers": 2, "first_class": true}}][/TOOL_CALLS]',
+        "tools": [_BOOK_FLIGHT_MIXED],
+    },
+    ("mistral", "PARSER.batch.7.b"): {
+        "description": "Unicode + escaped chars",
+        "text": '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "Tōkyō \\"central\\""}}][/TOOL_CALLS]',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("mistral", "PARSER.batch.7.c"): {
+        "description": "Schema mismatch — string value where schema declares integer",
+        "text": '[TOOL_CALLS][{"name": "set_temperature", "arguments": {"celsius": "20"}}][/TOOL_CALLS]',
+        "tools": [_SET_TEMP_NUMERIC],
+    },
+    ("mistral", "PARSER.batch.7.d"): {
+        "description": "Nested object + array",
+        "text": '[TOOL_CALLS][{"name": "process_data", "arguments": {"items": [1,2,3], "config": {"nested": true}}}][/TOOL_CALLS]',
         "tools": [_PROCESS_DATA_NESTED],
     },
     ("mistral", "PARSER.batch.8.a"): {
@@ -1019,7 +1841,7 @@ INPUTS: dict[tuple[str, str], dict[str, Any] | None] = {
     },
     ("mistral", "PARSER.batch.8.c"): {
         "description": "Narration both before and after (sandwich)",
-        "ref": "inspired-by https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_mistral_tool_parser.py#L1858",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_mistral_tool_parser.py#L1858",
         "text": 'I will check the weather. [TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}][/TOOL_CALLS] Let me know if you need more.',
         "tools": [_GET_WEATHER_LOC],
     },
@@ -1044,34 +1866,94 @@ INPUTS: dict[tuple[str, str], dict[str, Any] | None] = {
         "text": '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}]</tool_calls>',
         "tools": [_GET_WEATHER_LOC],
     },
-    ("jamba", "PARSER.batch.2"): {
-        "description": "Multiple tool calls (parallel)",
+    ("jamba", "PARSER.batch.2.a"): {
+        "description": "Parallel calls in JSON array",
         "text": '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_time", "arguments": {"timezone": "EST"}}]</tool_calls>',
         "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("jamba", "PARSER.batch.2.c"): {
+        "description": "With surrounding narration",
+        "text": 'Both: <tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_time", "arguments": {"timezone": "EST"}}]</tool_calls> Done.',
+        "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("jamba", "PARSER.batch.2.d"): {
+        "description": "Same-name twice",
+        "text": '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_weather", "arguments": {"location": "LA"}}]</tool_calls>',
+        "tools": [_GET_WEATHER_LOC, _GET_WEATHER_LOC],
     },
     ("jamba", "PARSER.batch.3"): {
         "description": "No tool call (plain text)",
         "text": "Hello, how can I help you today?",
         "tools": [_GET_WEATHER_LOC],
     },
-    ("jamba", "PARSER.batch.4"): {
-        "description": "Malformed JSON args (missing close brace)",
+    ("jamba", "PARSER.batch.4.a"): {
+        "description": "Tool_calls wrapper with garbage",
+        "text": "<tool_calls>not a json array</tool_calls>",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("jamba", "PARSER.batch.4.b"): {
+        "description": "Missing close brace in JSON",
         "text": '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"]</tool_calls>',
         "tools": [_GET_WEATHER_LOC],
     },
-    ("jamba", "PARSER.batch.5"): {
+    ("jamba", "PARSER.batch.4.c"): {
+        "description": "Missing name key",
+        "text": '<tool_calls>[{"arguments": {"location": "NYC"}}]</tool_calls>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("jamba", "PARSER.batch.4.d"): {
+        "description": "Missing </tool_calls> close",
+        "text": '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}]',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("jamba", "PARSER.batch.5.a"): {
         "description": "Missing </tool_calls> end marker",
         "text": '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}]',
         "tools": [_GET_WEATHER_LOC],
     },
-    ("jamba", "PARSER.batch.6"): {
-        "description": "Empty args (no-arg call)",
+    ("jamba", "PARSER.batch.5.b"): {
+        "description": "Closing </tool_calls> without matching <tool_calls> open",
+        "text": '[{"name": "get_weather", "arguments": {"location": "NYC"}}]</tool_calls>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("jamba", "PARSER.batch.5.c"): {
+        "description": "Truncation mid-arguments JSON",
+        "text": '<tool_calls>[{"name": "get_weather", "arguments": {"loc',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("jamba", "PARSER.batch.6.a"): {
+        "description": 'Canonical "arguments": {}',
         "text": '<tool_calls>[{"name": "get_time", "arguments": {}}]</tool_calls>',
         "tools": [_GET_TIME_NOARG],
     },
-    ("jamba", "PARSER.batch.7"): {
-        "description": "Complex args (nested object + array)",
-        "text": '<tool_calls>[{"name": "process_data", "arguments": {"items": [1, 2, 3], "config": {"nested": true}}}]</tool_calls>',
+    ("jamba", "PARSER.batch.6.b"): {
+        "description": "Whitespace inside arguments {}",
+        "text": '<tool_calls>[{"name": "get_time", "arguments": { }}]</tool_calls>',
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("jamba", "PARSER.batch.6.c"): {
+        "description": "No arguments key",
+        "text": '<tool_calls>[{"name": "get_time"}]</tool_calls>',
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("jamba", "PARSER.batch.7.a"): {
+        "description": "Standard scalar types",
+        "text": '<tool_calls>[{"name": "book_flight", "arguments": {"destination": "Paris", "passengers": 2, "first_class": true}}]</tool_calls>',
+        "tools": [_BOOK_FLIGHT_MIXED],
+    },
+    ("jamba", "PARSER.batch.7.b"): {
+        "description": "Unicode + escaped chars",
+        "text": '<tool_calls>[{"name": "get_weather", "arguments": {"location": "Tōkyō \\"central\\""}}]</tool_calls>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("jamba", "PARSER.batch.7.c"): {
+        "description": "Schema mismatch — string value where schema declares integer",
+        "text": '<tool_calls>[{"name": "set_temperature", "arguments": {"celsius": "20"}}]</tool_calls>',
+        "tools": [_SET_TEMP_NUMERIC],
+    },
+    ("jamba", "PARSER.batch.7.d"): {
+        "description": "Nested object + array",
+        "text": '<tool_calls>[{"name": "process_data", "arguments": {"items": [1,2,3], "config": {"nested": true}}}]</tool_calls>',
         "tools": [_PROCESS_DATA_NESTED],
     },
     ("jamba", "PARSER.batch.8.a"): {
@@ -1110,34 +1992,88 @@ INPUTS: dict[tuple[str, str], dict[str, Any] | None] = {
         "text": '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}}',
         "tools": [_GET_WEATHER_LOC],
     },
-    ("llama3_json", "PARSER.batch.2"): {
-        "description": "Multiple tool calls (parallel)",
+    ("llama3_json", "PARSER.batch.2.a"): {
+        "description": "Parallel calls (semicolon-separated)",
         "text": '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}};{"name": "get_time", "arguments": {"timezone": "EST"}}',
         "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("llama3_json", "PARSER.batch.2.c"): {
+        "description": "With surrounding narration",
+        "text": 'Both: <|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}};{"name": "get_time", "arguments": {"timezone": "EST"}} Done.',
+        "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("llama3_json", "PARSER.batch.2.d"): {
+        "description": "Same-name twice (semicolon-separated)",
+        "text": '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}};{"name": "get_weather", "arguments": {"location": "LA"}}',
+        "tools": [_GET_WEATHER_LOC, _GET_WEATHER_LOC],
     },
     ("llama3_json", "PARSER.batch.3"): {
         "description": "No tool call (plain text)",
         "text": "Hello, how can I help you today?",
         "tools": [_GET_WEATHER_LOC],
     },
-    ("llama3_json", "PARSER.batch.4"): {
-        "description": "Malformed JSON args (missing close brace)",
+    ("llama3_json", "PARSER.batch.4.a"): {
+        "description": "Python_tag prefix with non-JSON garbage",
+        "text": "<|python_tag|>not even json",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("llama3_json", "PARSER.batch.4.b"): {
+        "description": "Missing close brace",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_llama3_json_tool_parser.py#L66",
         "text": '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"',
         "tools": [_GET_WEATHER_LOC],
     },
-    ("llama3_json", "PARSER.batch.5"): {
+    ("llama3_json", "PARSER.batch.4.c"): {
+        "description": "Missing name key",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_llama3_json_tool_parser.py#L234",
+        "text": '<|python_tag|>{"arguments": {"location": "NYC"}}',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("llama3_json", "PARSER.batch.5.a"): {
         "description": "No explicit end (truncation)",
         "text": '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}',
         "tools": [_GET_WEATHER_LOC],
     },
-    ("llama3_json", "PARSER.batch.6"): {
-        "description": "Empty args (no-arg call)",
+    ("llama3_json", "PARSER.batch.5.c"): {
+        "description": "Truncation deeper inside arguments JSON (vs .a which truncates at the closing brace)",
+        "text": '<|python_tag|>{"name": "get_weather", "arguments": {"loc',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("llama3_json", "PARSER.batch.6.a"): {
+        "description": 'Canonical "arguments": {}',
         "text": '<|python_tag|>{"name": "get_time", "arguments": {}}',
         "tools": [_GET_TIME_NOARG],
     },
-    ("llama3_json", "PARSER.batch.7"): {
-        "description": "Complex args (nested object + array)",
-        "text": '<|python_tag|>{"name": "process_data", "arguments": {"items": [1, 2, 3], "config": {"nested": true}}}',
+    ("llama3_json", "PARSER.batch.6.b"): {
+        "description": "Whitespace inside arguments {}",
+        "text": '<|python_tag|>{"name": "get_time", "arguments": { }}',
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("llama3_json", "PARSER.batch.6.c"): {
+        "description": "No arguments key",
+        "text": '<|python_tag|>{"name": "get_time"}',
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("llama3_json", "PARSER.batch.7.a"): {
+        "description": "Standard scalar types",
+        "text": '<|python_tag|>{"name": "book_flight", "arguments": {"destination": "Paris", "passengers": 2, "first_class": true}}',
+        "tools": [_BOOK_FLIGHT_MIXED],
+    },
+    ("llama3_json", "PARSER.batch.7.b"): {
+        "description": "Unicode + escaped chars",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_llama3_json_tool_parser.py#L217",
+        "text": '<|python_tag|>{"name": "get_weather", "arguments": {"location": "Tōkyō \\"central\\""}}',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("llama3_json", "PARSER.batch.7.c"): {
+        "description": "Schema mismatch — string value where schema declares integer",
+        "text": '<|python_tag|>{"name": "set_temperature", "arguments": {"celsius": "20"}}',
+        "tools": [_SET_TEMP_NUMERIC],
+    },
+    ("llama3_json", "PARSER.batch.7.d"): {
+        "description": "Nested object + array",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_llama3_json_tool_parser.py#L146",
+        "text": '<|python_tag|>{"name": "process_data", "arguments": {"items": [1,2,3], "config": {"nested": true}}}',
         "tools": [_PROCESS_DATA_NESTED],
     },
     ("llama3_json", "PARSER.batch.8.a"): {
@@ -1152,7 +2088,7 @@ INPUTS: dict[tuple[str, str], dict[str, Any] | None] = {
     },
     ("llama3_json", "PARSER.batch.8.c"): {
         "description": "Narration both before and after (sandwich)",
-        "ref": "inspired-by https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_llama3_json_tool_parser.py#L128",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_llama3_json_tool_parser.py#L128",
         "text": 'I will check the weather. <|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}} Let me know if you need more.',
         "tools": [_GET_WEATHER_LOC],
     },
@@ -1177,34 +2113,99 @@ INPUTS: dict[tuple[str, str], dict[str, Any] | None] = {
         "text": 'functools[{"name": "get_weather", "arguments": {"location": "NYC"}}]',
         "tools": [_GET_WEATHER_LOC],
     },
-    ("phi4", "PARSER.batch.2"): {
-        "description": "Multiple tool calls (parallel)",
+    ("phi4", "PARSER.batch.2.a"): {
+        "description": "Parallel calls in JSON array",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L185",
         "text": 'functools[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_time", "arguments": {"timezone": "EST"}}]',
         "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("phi4", "PARSER.batch.2.c"): {
+        "description": "With surrounding narration",
+        "text": 'Both: functools[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_time", "arguments": {"timezone": "EST"}}] Done.',
+        "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("phi4", "PARSER.batch.2.d"): {
+        "description": "Same-name twice",
+        "text": 'functools[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_weather", "arguments": {"location": "LA"}}]',
+        "tools": [_GET_WEATHER_LOC, _GET_WEATHER_LOC],
     },
     ("phi4", "PARSER.batch.3"): {
         "description": "No tool call (plain text)",
         "text": "Hello, how can I help you today?",
         "tools": [_GET_WEATHER_LOC],
     },
-    ("phi4", "PARSER.batch.4"): {
-        "description": "Malformed JSON args (missing close brace)",
+    ("phi4", "PARSER.batch.4.a"): {
+        "description": "functools[ wrapper with garbage",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L322",
+        "text": "functools[not a json array]",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("phi4", "PARSER.batch.4.b"): {
+        "description": "Missing close brace",
         "text": 'functools[{"name": "get_weather", "arguments": {"location": "NYC"]',
         "tools": [_GET_WEATHER_LOC],
     },
-    ("phi4", "PARSER.batch.5"): {
+    ("phi4", "PARSER.batch.4.c"): {
+        "description": "Missing name key",
+        "text": 'functools[{"arguments": {"location": "NYC"}}]',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("phi4", "PARSER.batch.4.d"): {
+        "description": "Missing closing ]",
+        "text": 'functools[{"name": "get_weather", "arguments": {"location": "NYC"}}',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("phi4", "PARSER.batch.5.a"): {
         "description": "No explicit end (truncation)",
         "text": 'functools[{"name": "get_weather", "arguments": {"location": "NYC"}}',
         "tools": [_GET_WEATHER_LOC],
     },
-    ("phi4", "PARSER.batch.6"): {
-        "description": "Empty args (no-arg call)",
+    ("phi4", "PARSER.batch.5.b"): {
+        "description": "Closing `]` without matching `functools[` open",
+        "text": 'functools{"name": "get_weather", "arguments": {"location": "NYC"}}]',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("phi4", "PARSER.batch.5.c"): {
+        "description": "Truncation mid-arguments JSON",
+        "text": 'functools[{"name": "get_weather", "arguments": {"loc',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("phi4", "PARSER.batch.6.a"): {
+        "description": 'Canonical "arguments": {}',
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L260",
         "text": 'functools[{"name": "get_time", "arguments": {}}]',
         "tools": [_GET_TIME_NOARG],
     },
-    ("phi4", "PARSER.batch.7"): {
-        "description": "Complex args (nested object + array)",
-        "text": 'functools[{"name": "process_data", "arguments": {"items": [1, 2, 3], "config": {"nested": true}}}]',
+    ("phi4", "PARSER.batch.6.b"): {
+        "description": "Whitespace inside arguments {}",
+        "text": 'functools[{"name": "get_time", "arguments": { }}]',
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("phi4", "PARSER.batch.6.c"): {
+        "description": "No arguments key",
+        "text": 'functools[{"name": "get_time"}]',
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("phi4", "PARSER.batch.7.a"): {
+        "description": "Standard scalar types",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L220",
+        "text": 'functools[{"name": "book_flight", "arguments": {"destination": "Paris", "passengers": 2, "first_class": true}}]',
+        "tools": [_BOOK_FLIGHT_MIXED],
+    },
+    ("phi4", "PARSER.batch.7.b"): {
+        "description": "Unicode + escaped chars",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L302",
+        "text": 'functools[{"name": "get_weather", "arguments": {"location": "Tōkyō \\"central\\""}}]',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("phi4", "PARSER.batch.7.c"): {
+        "description": "Schema mismatch — string value where schema declares integer",
+        "text": 'functools[{"name": "set_temperature", "arguments": {"celsius": "20"}}]',
+        "tools": [_SET_TEMP_NUMERIC],
+    },
+    ("phi4", "PARSER.batch.7.d"): {
+        "description": "Nested object + array",
+        "text": 'functools[{"name": "process_data", "arguments": {"items": [1,2,3], "config": {"nested": true}}}]',
         "tools": [_PROCESS_DATA_NESTED],
     },
     ("phi4", "PARSER.batch.8.a"): {
@@ -1219,7 +2220,7 @@ INPUTS: dict[tuple[str, str], dict[str, Any] | None] = {
     },
     ("phi4", "PARSER.batch.8.c"): {
         "description": "Narration both before and after (sandwich)",
-        "ref": "inspired-by https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L282",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L282",
         "text": 'I will check the weather. functools[{"name": "get_weather", "arguments": {"location": "NYC"}}] Let me know if you need more.',
         "tools": [_GET_WEATHER_LOC],
     },
@@ -1244,35 +2245,70 @@ INPUTS: dict[tuple[str, str], dict[str, Any] | None] = {
         "text": "<tool_call>\n<function=get_weather>\n<parameter=location>\nNYC\n</parameter>\n</function>\n</tool_call>",
         "tools": [_GET_WEATHER_LOC],
     },
-    ("nemotron_nano", "PARSER.batch.2"): {
-        "description": "Multiple tool calls (parallel)",
+    ("nemotron_nano", "PARSER.batch.2.a"): {
+        "description": "Parallel calls (back-to-back tool_call wrappers)",
         "text": "<tool_call>\n<function=get_weather>\n<parameter=location>\nNYC\n</parameter>\n</function>\n</tool_call>\n<tool_call>\n<function=get_time>\n<parameter=timezone>\nEST\n</parameter>\n</function>\n</tool_call>",
         "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("nemotron_nano", "PARSER.batch.2.c"): {
+        "description": "With surrounding narration",
+        "text": "Both: <tool_call>\n<function=get_weather>\n<parameter=location>\nNYC\n</parameter>\n</function>\n</tool_call>\n<tool_call>\n<function=get_time>\n<parameter=timezone>\nEST\n</parameter>\n</function>\n</tool_call> Done.",
+        "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("nemotron_nano", "PARSER.batch.2.d"): {
+        "description": "Same-name twice",
+        "text": "<tool_call>\n<function=get_weather>\n<parameter=location>\nNYC\n</parameter>\n</function>\n</tool_call>\n<tool_call>\n<function=get_weather>\n<parameter=location>\nLA\n</parameter>\n</function>\n</tool_call>",
+        "tools": [_GET_WEATHER_LOC, _GET_WEATHER_LOC],
     },
     ("nemotron_nano", "PARSER.batch.3"): {
         "description": "No tool call (plain text)",
         "text": "Hello, how can I help you today?",
         "tools": [_GET_WEATHER_LOC],
     },
-    ("nemotron_nano", "PARSER.batch.4"): {
-        "description": "Malformed (missing </parameter> closing tag)",
+    ("nemotron_nano", "PARSER.batch.4.a"): {
+        "description": "Tool_call wrapper with no <function> body",
+        "text": "<tool_call>\nrandom text\n</tool_call>",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("nemotron_nano", "PARSER.batch.4.d"): {
+        "description": "Missing </parameter> closing tag",
         "text": "<tool_call>\n<function=get_weather>\n<parameter=location>\nNYC\n</function>\n</tool_call>",
         "tools": [_GET_WEATHER_LOC],
     },
-    ("nemotron_nano", "PARSER.batch.5"): {
+    ("nemotron_nano", "PARSER.batch.5.a"): {
         "description": "Missing </tool_call> end marker",
         "text": "<tool_call>\n<function=get_weather>\n<parameter=location>\nNYC\n</parameter>\n</function>",
         "tools": [_GET_WEATHER_LOC],
     },
-    ("nemotron_nano", "PARSER.batch.6"): {
-        "description": "Empty args (no-arg call)",
+    ("nemotron_nano", "PARSER.batch.5.b"): {
+        "description": "Closing </tool_call> without matching <tool_call> open",
+        "text": "<function=get_weather>\n<parameter=location>\nNYC\n</parameter>\n</function>\n</tool_call>",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("nemotron_nano", "PARSER.batch.5.c"): {
+        "description": "Truncation mid-parameter value",
+        "text": "<tool_call>\n<function=get_weather>\n<parameter=location>\nNY",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("nemotron_nano", "PARSER.batch.6.a"): {
+        "description": "Function block with no <parameter>",
         "text": "<tool_call>\n<function=get_time>\n</function>\n</tool_call>",
         "tools": [_GET_TIME_NOARG],
     },
-    ("nemotron_nano", "PARSER.batch.7"): {
-        "description": "Complex args (multi-parameter)",
-        "text": "<tool_call>\n<function=get_weather>\n<parameter=location>\nNYC\n</parameter>\n<parameter=unit>\nfahrenheit\n</parameter>\n</function>\n</tool_call>",
-        "tools": [_GET_WEATHER_LOC_UNIT],
+    ("nemotron_nano", "PARSER.batch.6.b"): {
+        "description": "Function block with extra whitespace inside",
+        "text": "<tool_call>\n<function=get_time>\n\n</function>\n</tool_call>",
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("nemotron_nano", "PARSER.batch.7.a"): {
+        "description": "Multiple parameters",
+        "text": "<tool_call>\n<function=book_flight>\n<parameter=destination>\nParis\n</parameter>\n<parameter=passengers>\n2\n</parameter>\n<parameter=first_class>\ntrue\n</parameter>\n</function>\n</tool_call>",
+        "tools": [_BOOK_FLIGHT_MIXED],
+    },
+    ("nemotron_nano", "PARSER.batch.7.b"): {
+        "description": "Unicode in parameter",
+        "text": "<tool_call>\n<function=get_weather>\n<parameter=location>\nTōkyō central\n</parameter>\n</function>\n</tool_call>",
+        "tools": [_GET_WEATHER_LOC],
     },
     ("nemotron_nano", "PARSER.batch.8.a"): {
         "description": "Narration before tool call only",
@@ -1310,39 +2346,89 @@ INPUTS: dict[tuple[str, str], dict[str, Any] | None] = {
         "text": '<｜DSML｜function_calls>\n<｜DSML｜invoke name="get_weather">\n<｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜function_calls>',
         "tools": [_GET_WEATHER_LOC],
     },
-    ("deepseek_v3_2", "PARSER.batch.2"): {
-        "description": "Multiple tool calls (parallel)",
+    ("deepseek_v3_2", "PARSER.batch.2.a"): {
+        "description": "Two invokes inside one function_calls wrapper",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_deepseekv32_tool_parser.py#L172",
         "text": '<｜DSML｜function_calls>\n<｜DSML｜invoke name="get_weather">\n<｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>\n</｜DSML｜invoke>\n<｜DSML｜invoke name="get_time">\n<｜DSML｜parameter name="timezone" string="true">EST</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜function_calls>',
         "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("deepseek_v3_2", "PARSER.batch.2.b"): {
+        "description": "Two back-to-back function_calls wrappers",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_deepseekv32_tool_parser.py#L327",
+        "text": '<｜DSML｜function_calls>\n<｜DSML｜invoke name="get_weather">\n<｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜function_calls>\n<｜DSML｜function_calls>\n<｜DSML｜invoke name="get_time">\n<｜DSML｜parameter name="timezone" string="true">EST</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜function_calls>',
+        "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("deepseek_v3_2", "PARSER.batch.2.c"): {
+        "description": "With surrounding narration",
+        "text": 'Both: <｜DSML｜function_calls>\n<｜DSML｜invoke name="get_weather">\n<｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>\n</｜DSML｜invoke>\n<｜DSML｜invoke name="get_time">\n<｜DSML｜parameter name="timezone" string="true">EST</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜function_calls> Done.',
+        "tools": [_GET_WEATHER_LOC, _GET_TIME_TZ],
+    },
+    ("deepseek_v3_2", "PARSER.batch.2.d"): {
+        "description": "Same-name twice",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_deepseekv32_tool_parser.py#L370",
+        "text": '<｜DSML｜function_calls>\n<｜DSML｜invoke name="get_weather">\n<｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>\n</｜DSML｜invoke>\n<｜DSML｜invoke name="get_weather">\n<｜DSML｜parameter name="location" string="true">LA</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜function_calls>',
+        "tools": [_GET_WEATHER_LOC, _GET_WEATHER_LOC],
     },
     ("deepseek_v3_2", "PARSER.batch.3"): {
         "description": "No tool call (plain text)",
         "text": "Hello, how can I help you today?",
         "tools": [_GET_WEATHER_LOC],
     },
-    ("deepseek_v3_2", "PARSER.batch.4"): {
-        "description": "Malformed (missing </｜DSML｜parameter> end tag)",
+    ("deepseek_v3_2", "PARSER.batch.4.a"): {
+        "description": "Function_calls wrapper with garbage",
+        "text": "<｜DSML｜function_calls>\nnot a valid invoke\n</｜DSML｜function_calls>",
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("deepseek_v3_2", "PARSER.batch.4.c"): {
+        "description": "Invoke without name attribute",
+        "text": '<｜DSML｜function_calls>\n<｜DSML｜invoke>\n<｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜function_calls>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("deepseek_v3_2", "PARSER.batch.4.d"): {
+        "description": "Missing </｜DSML｜parameter> end tag",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_deepseekv32_tool_parser.py#L499",
         "text": '<｜DSML｜function_calls>\n<｜DSML｜invoke name="get_weather">\n<｜DSML｜parameter name="location" string="true">NYC\n</｜DSML｜invoke>\n</｜DSML｜function_calls>',
         "tools": [_GET_WEATHER_LOC],
     },
-    ("deepseek_v3_2", "PARSER.batch.5"): {
+    ("deepseek_v3_2", "PARSER.batch.5.a"): {
         "description": "Missing </｜DSML｜function_calls> end marker",
         "text": '<｜DSML｜function_calls>\n<｜DSML｜invoke name="get_weather">\n<｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>\n</｜DSML｜invoke>',
         "tools": [_GET_WEATHER_LOC],
     },
-    ("deepseek_v3_2", "PARSER.batch.6"): {
-        "description": "Empty args (no-arg call)",
+    ("deepseek_v3_2", "PARSER.batch.5.b"): {
+        "description": "Closing </｜DSML｜function_calls> without matching open",
+        "text": '<｜DSML｜invoke name="get_weather">\n<｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜function_calls>',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("deepseek_v3_2", "PARSER.batch.5.c"): {
+        "description": "Truncation mid-parameter value",
+        "text": '<｜DSML｜function_calls>\n<｜DSML｜invoke name="get_weather">\n<｜DSML｜parameter name="location" string="true">NY',
+        "tools": [_GET_WEATHER_LOC],
+    },
+    ("deepseek_v3_2", "PARSER.batch.6.a"): {
+        "description": "Invoke with no <parameter>",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_deepseekv32_tool_parser.py#L363",
         "text": '<｜DSML｜function_calls>\n<｜DSML｜invoke name="get_time">\n</｜DSML｜invoke>\n</｜DSML｜function_calls>',
         "tools": [_GET_TIME_NOARG],
     },
-    ("deepseek_v3_2", "PARSER.batch.7"): {
-        "description": "Complex args (nested object + array, JSON-typed)",
-        "text": '<｜DSML｜function_calls>\n<｜DSML｜invoke name="process_data">\n<｜DSML｜parameter name="items" string="false">[1, 2, 3]</｜DSML｜parameter>\n<｜DSML｜parameter name="config" string="false">{"nested": true}</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜function_calls>',
-        "tools": [_PROCESS_DATA_NESTED],
+    ("deepseek_v3_2", "PARSER.batch.6.b"): {
+        "description": "Invoke with extra newline",
+        "text": '<｜DSML｜function_calls>\n<｜DSML｜invoke name="get_time">\n\n</｜DSML｜invoke>\n</｜DSML｜function_calls>',
+        "tools": [_GET_TIME_NOARG],
+    },
+    ("deepseek_v3_2", "PARSER.batch.7.a"): {
+        "description": "Multiple parameters",
+        "text": '<｜DSML｜function_calls>\n<｜DSML｜invoke name="book_flight">\n<｜DSML｜parameter name="destination" string="true">Paris</｜DSML｜parameter>\n<｜DSML｜parameter name="passengers" string="false">2</｜DSML｜parameter>\n<｜DSML｜parameter name="first_class" string="false">true</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜function_calls>',
+        "tools": [_BOOK_FLIGHT_MIXED],
+    },
+    ("deepseek_v3_2", "PARSER.batch.7.b"): {
+        "description": "Unicode in parameter",
+        "text": '<｜DSML｜function_calls>\n<｜DSML｜invoke name="get_weather">\n<｜DSML｜parameter name="location" string="true">Tōkyō central</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜function_calls>',
+        "tools": [_GET_WEATHER_LOC],
     },
     ("deepseek_v3_2", "PARSER.batch.8.a"): {
         "description": "Narration before tool call only",
-        "ref": "inspired-by https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_deepseekv32_tool_parser.py#L158",
+        "ref": "originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_deepseekv32_tool_parser.py#L158",
         "text": 'I will check the weather. <｜DSML｜function_calls>\n<｜DSML｜invoke name="get_weather">\n<｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜function_calls>',
         "tools": [_GET_WEATHER_LOC],
     },
@@ -1437,13 +2523,19 @@ def _write_family_fixtures(
     family_dir.mkdir(parents=True, exist_ok=True)
     ordered = {cid: cases[cid] for cid in sorted(cases, key=_case_sort_key)}
     out = {"family": family, "mode": mode, "cases": ordered}
+    body = yaml.dump(out, sort_keys=False, allow_unicode=True, width=120)
     header = (
         "# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.\n"
-        "# SPDX-License-Identifier: Apache-2.0\n\n"
+        "# SPDX-License-Identifier: Apache-2.0\n"
     )
+    if "|2+" in body:
+        header += (
+            "#\n"
+            '# `|2+` simply means a single newline ("\\n"); '
+            "see tests/parity/README.md for the full decode.\n"
+        )
     (family_dir / f"{file_stem}.yaml").write_text(
-        header + yaml.dump(out, sort_keys=False, allow_unicode=True, width=120),
-        encoding="utf-8",
+        header + "\n" + body, encoding="utf-8"
     )
 
 

--- a/tests/parity/parser/test_parity_parser.py
+++ b/tests/parity/parser/test_parity_parser.py
@@ -85,28 +85,19 @@ KNOWN_DIVERGENCES: dict[tuple[str, str, str], str] = {
     # bot_token; bare '<|channel|>commentary' variants (PARSER.batch.1, .6, .13)
     # are not detected at all.
     ("sglang", "harmony", "PARSER.batch.1"): _HARMONY_REQUIRES_ASSISTANT_PREFIX,
-    ("sglang", "harmony", "PARSER.batch.6"): _HARMONY_REQUIRES_ASSISTANT_PREFIX,
+    ("sglang", "harmony", "PARSER.batch.6.a"): _HARMONY_REQUIRES_ASSISTANT_PREFIX,
+    ("sglang", "harmony", "PARSER.batch.6.b"): _HARMONY_REQUIRES_ASSISTANT_PREFIX,
     ("sglang", "harmony", "PARSER.batch.8.a"): _HARMONY_REQUIRES_ASSISTANT_PREFIX,
     ("sglang", "harmony", "PARSER.batch.8.b"): _HARMONY_REQUIRES_ASSISTANT_PREFIX,
     ("sglang", "harmony", "PARSER.batch.8.c"): _HARMONY_REQUIRES_ASSISTANT_PREFIX,
     ("sglang", "harmony", "PARSER.batch.8.d"): _HARMONY_REQUIRES_ASSISTANT_PREFIX,
     # SGLang's GptOssDetector drops the analysis-channel preamble entirely;
     # Dynamo surfaces it as normal_text.
-    (
-        "sglang",
-        "harmony",
-        "PARSER.batch.7",
-    ): "drops analysis-channel content from normal_text",
     # Inverse of the bare-envelope finding: when the input *does* have the
     # assistant prefix and contains back-to-back commentary blocks, SGLang
     # extracts both calls — Dynamo's harmony parser drops them and treats the
     # raw input as normal_text. Dynamo bug class; see harmony_parser.rs comment
     # block above test_parse_harmony_multiple_calls_recovers.
-    (
-        "sglang",
-        "harmony",
-        "PARSER.batch.2",
-    ): "Dynamo drops back-to-back commentary blocks; SGLang extracts them",
     (
         "sglang",
         "harmony",
@@ -166,21 +157,6 @@ KNOWN_DIVERGENCES: dict[tuple[str, str, str], str] = {
         "minimax_m2",
         "PARSER.batch.8.d",
     ): "sglang preserves trailing normal_text after wrapper end; Dynamo trims it (post-#9350)",
-    (
-        "sglang",
-        "deepseek_v3",
-        "PARSER.batch.5",
-    ): _RECOVERY_CONTRACT,
-    (
-        "vllm",
-        "deepseek_v3",
-        "PARSER.batch.4",
-    ): _RECOVERY_CONTRACT,
-    (
-        "vllm",
-        "deepseek_v3",
-        "PARSER.batch.5",
-    ): _RECOVERY_CONTRACT,
     ("vllm", "gemma4", "PARSER.batch.8.b"): _TRAILING_NORMAL_TEXT_DROP,
     ("vllm", "gemma4", "PARSER.batch.8.c"): _TRAILING_NORMAL_TEXT_DROP,
     ("vllm", "gemma4", "PARSER.batch.8.d"): _TRAILING_NORMAL_TEXT_DROP,
@@ -209,73 +185,485 @@ KNOWN_DIVERGENCES: dict[tuple[str, str, str], str] = {
         "pythonic",
         "PARSER.batch.8.d",
     ): "vLLM rejects bracket-call form when surrounded by interleaved text; Dynamo extracts the call",
-    (
-        "vllm",
-        "deepseek_v4",
-        "PARSER.batch.5",
-    ): _RECOVERY_CONTRACT,
-    (
-        "vllm",
-        "deepseek_v4",
-        "PARSER.batch.7",
-    ): "vLLM emits JSON-typed parameter values as raw strings; Dynamo coerces nested object/array types",
     # PARSER.batch.4 (malformed) — impl-defined recovery contract.
-    ("vllm", "deepseek_v3_1", "PARSER.batch.4"): _RECOVERY_CONTRACT,
-    ("vllm", "minimax_m2", "PARSER.batch.4"): _RECOVERY_CONTRACT,
-    ("sglang", "kimi_k2", "PARSER.batch.4"): _RECOVERY_CONTRACT,
-    ("sglang", "harmony", "PARSER.batch.4"): _RECOVERY_CONTRACT,
     # PARSER.batch.5 (missing end-token recovery) — impl-defined. Dynamo's
     # PyO3 batch binding now uses `detect_and_parse_tool_call_with_recovery`
     # so the registered `expected` reflects the recovered call; impls that
     # still drop on the missing end-token diverge here.
     # vllm/sglang qwen3_coder.batch.5 both recover to the same call as
     # Dynamo and match the new expected — intentionally NOT registered.
-    ("vllm", "glm47", "PARSER.batch.5"): _RECOVERY_CONTRACT,
-    ("vllm", "minimax_m2", "PARSER.batch.5"): _RECOVERY_CONTRACT,
-    ("vllm", "deepseek_v3_1", "PARSER.batch.5"): _RECOVERY_CONTRACT,
-    ("sglang", "glm47", "PARSER.batch.5"): _RECOVERY_CONTRACT,
-    ("sglang", "minimax_m2", "PARSER.batch.5"): _RECOVERY_CONTRACT,
-    ("sglang", "deepseek_v3_1", "PARSER.batch.5"): _RECOVERY_CONTRACT,
-    ("sglang", "harmony", "PARSER.batch.5"): _RECOVERY_CONTRACT,
-    # ----- new families: hermes / qwen25 / mistral / jamba / llama3_json / phi4 / nemotron_nano / deepseek_v3_2 -----
-    ("vllm", "deepseek_v3_2", "PARSER.batch.5"): _RECOVERY_CONTRACT,
+    # PARSER.batch.5 sub-cases — recovery contract (impl-defined; see PARSER_CASES.md).
+    # vllm divergences from harness; sglang .a inherited from prior bare-key registry,
+    # additional sglang .b/.c entries to be added as CI surfaces them.
+    ("vllm", "deepseek_v3", "PARSER.batch.5.a"): _RECOVERY_CONTRACT,
+    ("vllm", "deepseek_v3", "PARSER.batch.5.c"): _RECOVERY_CONTRACT,
+    ("vllm", "deepseek_v3_1", "PARSER.batch.5.a"): _RECOVERY_CONTRACT,
+    ("vllm", "deepseek_v3_1", "PARSER.batch.5.c"): _RECOVERY_CONTRACT,
+    ("vllm", "deepseek_v3_2", "PARSER.batch.5.a"): _RECOVERY_CONTRACT,
+    ("vllm", "deepseek_v3_2", "PARSER.batch.5.c"): _RECOVERY_CONTRACT,
+    ("vllm", "deepseek_v4", "PARSER.batch.5.a"): _RECOVERY_CONTRACT,
+    ("vllm", "deepseek_v4", "PARSER.batch.5.c"): _RECOVERY_CONTRACT,
+    ("vllm", "glm47", "PARSER.batch.5.a"): _RECOVERY_CONTRACT,
+    ("vllm", "glm47", "PARSER.batch.5.c"): _RECOVERY_CONTRACT,
+    ("vllm", "jamba", "PARSER.batch.5.a"): _RECOVERY_CONTRACT,
+    ("vllm", "llama3_json", "PARSER.batch.5.a"): _RECOVERY_CONTRACT,
+    ("vllm", "llama3_json", "PARSER.batch.5.c"): _RECOVERY_CONTRACT,
+    ("vllm", "minimax_m2", "PARSER.batch.5.a"): _RECOVERY_CONTRACT,
+    ("vllm", "minimax_m2", "PARSER.batch.5.c"): _RECOVERY_CONTRACT,
+    ("vllm", "mistral", "PARSER.batch.5.c"): _RECOVERY_CONTRACT,
+    ("vllm", "phi4", "PARSER.batch.5.a"): _RECOVERY_CONTRACT,
+    ("vllm", "phi4", "PARSER.batch.5.b"): _RECOVERY_CONTRACT,
+    ("vllm", "phi4", "PARSER.batch.5.c"): _RECOVERY_CONTRACT,
+    ("vllm", "qwen3_coder", "PARSER.batch.5.b"): _RECOVERY_CONTRACT,
+    ("sglang", "deepseek_v3", "PARSER.batch.5.a"): _RECOVERY_CONTRACT,
+    ("sglang", "deepseek_v3_1", "PARSER.batch.5.a"): _RECOVERY_CONTRACT,
+    ("sglang", "glm47", "PARSER.batch.5.a"): _RECOVERY_CONTRACT,
+    ("sglang", "harmony", "PARSER.batch.5.a"): _RECOVERY_CONTRACT,
+    ("sglang", "minimax_m2", "PARSER.batch.5.a"): _RECOVERY_CONTRACT,
+    ("sglang", "mistral", "PARSER.batch.5.a"): _RECOVERY_CONTRACT,
+    ("sglang", "qwen25", "PARSER.batch.5.a"): _RECOVERY_CONTRACT,
+    # PARSER.batch.4 sub-cases — malformed/partial JSON args; recovery contract impl-defined.
+    # vllm divergences from harness; sglang provisional .a entries inherited from prior bare-key set.
+    ("vllm", "deepseek_v3", "PARSER.batch.4.a"): _RECOVERY_CONTRACT,
+    ("vllm", "deepseek_v3", "PARSER.batch.4.b"): _RECOVERY_CONTRACT,
+    ("vllm", "deepseek_v3", "PARSER.batch.4.c"): _RECOVERY_CONTRACT,
+    ("vllm", "deepseek_v3", "PARSER.batch.4.d"): _RECOVERY_CONTRACT,
+    ("vllm", "deepseek_v3_1", "PARSER.batch.4.a"): _RECOVERY_CONTRACT,
+    ("vllm", "deepseek_v3_1", "PARSER.batch.4.b"): _RECOVERY_CONTRACT,
+    ("vllm", "deepseek_v3_1", "PARSER.batch.4.c"): _RECOVERY_CONTRACT,
+    ("vllm", "deepseek_v3_1", "PARSER.batch.4.d"): _RECOVERY_CONTRACT,
+    ("vllm", "deepseek_v3_2", "PARSER.batch.4.a"): _RECOVERY_CONTRACT,
+    ("vllm", "deepseek_v3_2", "PARSER.batch.4.c"): _RECOVERY_CONTRACT,
+    ("vllm", "deepseek_v4", "PARSER.batch.4.a"): _RECOVERY_CONTRACT,
+    ("vllm", "deepseek_v4", "PARSER.batch.4.c"): _RECOVERY_CONTRACT,
+    ("vllm", "glm47", "PARSER.batch.4.a"): _RECOVERY_CONTRACT,
+    ("vllm", "hermes", "PARSER.batch.4.b"): _RECOVERY_CONTRACT,
+    ("vllm", "jamba", "PARSER.batch.4.c"): _RECOVERY_CONTRACT,
+    ("vllm", "jamba", "PARSER.batch.4.d"): _RECOVERY_CONTRACT,
+    ("vllm", "llama3_json", "PARSER.batch.4.a"): _RECOVERY_CONTRACT,
+    ("vllm", "llama3_json", "PARSER.batch.4.b"): _RECOVERY_CONTRACT,
+    ("vllm", "llama3_json", "PARSER.batch.4.c"): _RECOVERY_CONTRACT,
+    ("vllm", "minimax_m2", "PARSER.batch.4.a"): _RECOVERY_CONTRACT,
+    ("vllm", "minimax_m2", "PARSER.batch.4.c"): _RECOVERY_CONTRACT,
+    ("vllm", "minimax_m2", "PARSER.batch.4.d"): _RECOVERY_CONTRACT,
+    ("vllm", "mistral", "PARSER.batch.4.a"): _RECOVERY_CONTRACT,
+    ("vllm", "mistral", "PARSER.batch.4.b"): _RECOVERY_CONTRACT,
+    (
+        "vllm",
+        "mistral",
+        "PARSER.batch.4.c",
+    ): "EXPECTS_ERROR(KeyError): vLLM mistral_tool_parser raises KeyError when 'name' key is missing",
+    ("vllm", "phi4", "PARSER.batch.4.c"): _RECOVERY_CONTRACT,
+    ("vllm", "phi4", "PARSER.batch.4.d"): _RECOVERY_CONTRACT,
+    ("vllm", "qwen3_coder", "PARSER.batch.4.a"): _RECOVERY_CONTRACT,
+    ("sglang", "harmony", "PARSER.batch.4.a"): _RECOVERY_CONTRACT,
+    # PARSER.batch.2 sub-cases — multi-call shape variations.
+    # .c (with surrounding narration): same trailing-space-vs-trim divergence
+    # as batch.8.c on most XML/JSON families. .b (multi-section back-to-back):
+    # vLLM's deepseek_v3_2/v4 parsers don't restart on second tool_calls fence.
+    # llama3_json across .a/.c/.d: semicolon-separated parsing differs.
     (
         "vllm",
         "deepseek_v3_2",
-        "PARSER.batch.7",
-    ): "emits JSON-typed parameter values as raw strings; Dynamo coerces nested object/array types",
-    ("vllm", "hermes", "PARSER.batch.4"): _RECOVERY_CONTRACT,
+        "PARSER.batch.2.b",
+    ): "vLLM deepseek_v3_2 does not restart parsing on a second back-to-back fence pair",
+    ("vllm", "deepseek_v3_2", "PARSER.batch.2.c"): _TRAILING_NORMAL_TEXT_DROP,
+    (
+        "vllm",
+        "deepseek_v4",
+        "PARSER.batch.2.b",
+    ): "vLLM deepseek_v4 does not restart parsing on a second back-to-back fence pair",
+    ("vllm", "deepseek_v4", "PARSER.batch.2.c"): _TRAILING_NORMAL_TEXT_DROP,
+    ("vllm", "gemma4", "PARSER.batch.2.c"): _TRAILING_NORMAL_TEXT_DROP,
+    ("vllm", "glm47", "PARSER.batch.2.c"): _TRAILING_NORMAL_TEXT_DROP,
+    ("vllm", "hermes", "PARSER.batch.2.c"): _TRAILING_NORMAL_TEXT_DROP,
+    ("vllm", "jamba", "PARSER.batch.2.c"): _TRAILING_NORMAL_TEXT_DROP,
+    ("vllm", "kimi_k2", "PARSER.batch.2.c"): _TRAILING_NORMAL_TEXT_DROP,
+    (
+        "vllm",
+        "llama3_json",
+        "PARSER.batch.2.a",
+    ): "vLLM llama3_json does not parse semicolon-separated calls the same way Dynamo does",
+    (
+        "vllm",
+        "llama3_json",
+        "PARSER.batch.2.c",
+    ): "vLLM llama3_json does not parse semicolon-separated calls the same way Dynamo does",
+    (
+        "vllm",
+        "llama3_json",
+        "PARSER.batch.2.d",
+    ): "vLLM llama3_json does not parse semicolon-separated calls the same way Dynamo does",
+    ("vllm", "mistral", "PARSER.batch.2.c"): _TRAILING_NORMAL_TEXT_DROP,
+    ("vllm", "phi4", "PARSER.batch.2.c"): _TRAILING_NORMAL_TEXT_DROP,
+    (
+        "vllm",
+        "pythonic",
+        "PARSER.batch.2.c",
+    ): "vLLM rejects bracket-call form when surrounded by interleaved text; Dynamo extracts the calls",
+    # sglang provisional sub-case entries (carried over from prior bare-key registry).
+    # CI will surface .b/.c/.d if they diverge separately.
+    (
+        "sglang",
+        "harmony",
+        "PARSER.batch.2.a",
+    ): "Dynamo drops back-to-back commentary blocks; SGLang extracts them",
+    (
+        "sglang",
+        "mistral",
+        "PARSER.batch.2.a",
+    ): "SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits",
+    (
+        "sglang",
+        "qwen25",
+        "PARSER.batch.2.a",
+    ): "SGLang Qwen25Detector returns calls=[] on the hermes-style <tool_call>...</tool_call> format Dynamo emits",
+    # PARSER.batch.7 sub-cases — complex argument types.
+    # .a (multi-arg standard types): vLLM's XML-grammar parsers (deepseek_v3_2/v4,
+    # minimax_m2, qwen3_coder) emit JSON-typed values as raw strings while Dynamo
+    # coerces per the schema. Same pattern as old bare-key entries, now scoped to .a/.d.
+    (
+        "vllm",
+        "deepseek_v3_2",
+        "PARSER.batch.7.a",
+    ): "vLLM emits JSON-typed parameter values as raw strings; Dynamo coerces nested object/array types",
+    (
+        "vllm",
+        "deepseek_v4",
+        "PARSER.batch.7.a",
+    ): "vLLM emits JSON-typed parameter values as raw strings; Dynamo coerces nested object/array types",
+    (
+        "vllm",
+        "minimax_m2",
+        "PARSER.batch.7.a",
+    ): "vLLM emits JSON-typed parameter values as raw strings; Dynamo coerces nested object/array types",
+    (
+        "vllm",
+        "qwen3_coder",
+        "PARSER.batch.7.a",
+    ): "vLLM emits JSON-typed parameter values as raw strings; Dynamo coerces nested object/array types",
+    (
+        "vllm",
+        "phi4",
+        "PARSER.batch.7.d",
+    ): "vLLM emits JSON-typed parameter values as raw strings; Dynamo coerces nested object/array types",
+    # sglang provisional .a entries (carried over from prior bare-key registry).
+    (
+        "sglang",
+        "harmony",
+        "PARSER.batch.7.a",
+    ): "drops analysis-channel content from normal_text",
+    (
+        "sglang",
+        "mistral",
+        "PARSER.batch.7.a",
+    ): "SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits",
+    (
+        "sglang",
+        "qwen25",
+        "PARSER.batch.7.a",
+    ): "SGLang Qwen25Detector returns calls=[] on the hermes-style <tool_call>...</tool_call> format Dynamo emits",
+    # Bulk-registered sglang sub-case divergences surfaced by CI on PR #9363.
+    # Patterns: TRIM = sglang trims trailing space from preceding normal_text;
+    # NULL = sglang nullifies normal_text on malformed/recovery shapes where Dynamo preserves input;
+    # OTHER = misc sglang-specific divergences (see CI log for per-case diff).
+    (
+        "sglang",
+        "deepseek_v3",
+        "PARSER.batch.2.c",
+    ): "trims trailing space from preceding normal_text",
+    (
+        "sglang",
+        "deepseek_v3",
+        "PARSER.batch.4.a",
+    ): "sglang nullifies normal_text on malformed/recovery shapes where Dynamo preserves input",
+    (
+        "sglang",
+        "deepseek_v3",
+        "PARSER.batch.4.c",
+    ): "sglang nullifies normal_text on malformed/recovery shapes where Dynamo preserves input",
+    (
+        "sglang",
+        "deepseek_v3",
+        "PARSER.batch.4.d",
+    ): "sglang nullifies normal_text on malformed/recovery shapes where Dynamo preserves input",
+    (
+        "sglang",
+        "deepseek_v3",
+        "PARSER.batch.5.c",
+    ): "sglang nullifies normal_text on malformed/recovery shapes where Dynamo preserves input",
+    (
+        "sglang",
+        "deepseek_v3_1",
+        "PARSER.batch.2.c",
+    ): "trims trailing space from preceding normal_text",
+    (
+        "sglang",
+        "deepseek_v3_1",
+        "PARSER.batch.4.a",
+    ): "sglang nullifies normal_text on malformed/recovery shapes where Dynamo preserves input",
+    (
+        "sglang",
+        "deepseek_v3_1",
+        "PARSER.batch.4.c",
+    ): "sglang nullifies normal_text on malformed/recovery shapes where Dynamo preserves input",
+    (
+        "sglang",
+        "deepseek_v3_1",
+        "PARSER.batch.4.d",
+    ): "sglang nullifies normal_text on malformed/recovery shapes where Dynamo preserves input",
+    (
+        "sglang",
+        "deepseek_v3_1",
+        "PARSER.batch.5.c",
+    ): "sglang nullifies normal_text on malformed/recovery shapes where Dynamo preserves input",
+    (
+        "sglang",
+        "deepseek_v3_2",
+        "PARSER.batch.2.b",
+    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
+    (
+        "sglang",
+        "deepseek_v3_2",
+        "PARSER.batch.2.c",
+    ): "trims trailing space from preceding normal_text",
+    (
+        "sglang",
+        "glm47",
+        "PARSER.batch.4.a",
+    ): "sglang nullifies normal_text on malformed/recovery shapes where Dynamo preserves input",
+    (
+        "sglang",
+        "glm47",
+        "PARSER.batch.5.c",
+    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
+    (
+        "sglang",
+        "glm47",
+        "PARSER.batch.6.b",
+    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
+    (
+        "sglang",
+        "harmony",
+        "PARSER.batch.2.c",
+    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
+    (
+        "sglang",
+        "harmony",
+        "PARSER.batch.2.d",
+    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
+    (
+        "sglang",
+        "harmony",
+        "PARSER.batch.4.b",
+    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
+    (
+        "sglang",
+        "harmony",
+        "PARSER.batch.5.c",
+    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
+    (
+        "sglang",
+        "harmony",
+        "PARSER.batch.7.b",
+    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
+    (
+        "sglang",
+        "harmony",
+        "PARSER.batch.7.c",
+    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
+    (
+        "sglang",
+        "harmony",
+        "PARSER.batch.7.d",
+    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
+    (
+        "sglang",
+        "hermes",
+        "PARSER.batch.4.b",
+    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
+    (
+        "sglang",
+        "hermes",
+        "PARSER.batch.4.c",
+    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
+    (
+        "sglang",
+        "hermes",
+        "PARSER.batch.6.c",
+    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
+    (
+        "sglang",
+        "kimi_k2",
+        "PARSER.batch.2.c",
+    ): "trims trailing space from preceding normal_text",
+    (
+        "sglang",
+        "kimi_k2",
+        "PARSER.batch.4.b",
+    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
+    (
+        "sglang",
+        "minimax_m2",
+        "PARSER.batch.2.b",
+    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
+    (
+        "sglang",
+        "minimax_m2",
+        "PARSER.batch.2.c",
+    ): "trims trailing space from preceding normal_text",
+    (
+        "sglang",
+        "minimax_m2",
+        "PARSER.batch.5.c",
+    ): "sglang nullifies normal_text on malformed/recovery shapes where Dynamo preserves input",
+    (
+        "sglang",
+        "mistral",
+        "PARSER.batch.2.c",
+    ): "trims trailing space from preceding normal_text",
+    (
+        "sglang",
+        "mistral",
+        "PARSER.batch.2.d",
+    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
+    (
+        "sglang",
+        "mistral",
+        "PARSER.batch.4.a",
+    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
+    (
+        "sglang",
+        "mistral",
+        "PARSER.batch.4.b",
+    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
+    (
+        "sglang",
+        "mistral",
+        "PARSER.batch.4.d",
+    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
+    (
+        "sglang",
+        "mistral",
+        "PARSER.batch.5.c",
+    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
+    (
+        "sglang",
+        "mistral",
+        "PARSER.batch.7.b",
+    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
+    (
+        "sglang",
+        "mistral",
+        "PARSER.batch.7.c",
+    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
+    (
+        "sglang",
+        "mistral",
+        "PARSER.batch.7.d",
+    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
+    (
+        "sglang",
+        "pythonic",
+        "PARSER.batch.2.c",
+    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
+    (
+        "sglang",
+        "qwen25",
+        "PARSER.batch.2.c",
+    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
+    (
+        "sglang",
+        "qwen25",
+        "PARSER.batch.2.d",
+    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
+    (
+        "sglang",
+        "qwen25",
+        "PARSER.batch.4.b",
+    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
+    (
+        "sglang",
+        "qwen25",
+        "PARSER.batch.4.d",
+    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
+    (
+        "sglang",
+        "qwen25",
+        "PARSER.batch.7.b",
+    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
+    (
+        "sglang",
+        "qwen25",
+        "PARSER.batch.7.c",
+    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
+    (
+        "sglang",
+        "qwen25",
+        "PARSER.batch.7.d",
+    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
+    (
+        "sglang",
+        "qwen3_coder",
+        "PARSER.batch.7.a",
+    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
+    # PARSER.batch.6 sub-cases — empty-args edge cases.
+    # .c (no arguments key) flips on impl: most parsers treat missing-key as
+    # malformed, vLLM accepts as empty {}. .b (whitespace inside {}) only
+    # flips for deepseek_v3 because the fenced ```json ... ``` body is
+    # whitespace-sensitive. Other families' .a/.b match across impls.
+    (
+        "vllm",
+        "jamba",
+        "PARSER.batch.6.c",
+    ): "both return calls=[]; vLLM preserves raw input as normal_text on this recovery path, Dynamo emits empty",
+    (
+        "vllm",
+        "llama3_json",
+        "PARSER.batch.6.c",
+    ): "both return calls=[]; vLLM preserves raw input as normal_text on this recovery path, Dynamo emits empty",
+    (
+        "vllm",
+        "mistral",
+        "PARSER.batch.6.c",
+    ): "vLLM accepts call with missing arguments key as having empty args; Dynamo returns calls=[]",
+    (
+        "vllm",
+        "phi4",
+        "PARSER.batch.6.c",
+    ): "both return calls=[]; vLLM preserves raw input as normal_text on this recovery path, Dynamo emits empty",
+    (
+        "vllm",
+        "deepseek_v3",
+        "PARSER.batch.6.c",
+    ): "both return calls=[]; vLLM nullifies normal_text on this recovery path, Dynamo preserves the raw input as normal_text",
+    (
+        "vllm",
+        "deepseek_v3_1",
+        "PARSER.batch.6.c",
+    ): "both return calls=[]; vLLM nullifies normal_text on this recovery path, Dynamo preserves the raw input as normal_text",
+    (
+        "vllm",
+        "deepseek_v3",
+        "PARSER.batch.6.b",
+    ): "vLLM rejects whitespace inside empty {} when wrapped in fenced ```json``` block",
+    # ----- new families: hermes / qwen25 / mistral / jamba / llama3_json / phi4 / nemotron_nano / deepseek_v3_2 -----
     ("vllm", "hermes", "PARSER.batch.8.a"): _TRAILING_NORMAL_TEXT_DROP,
     ("vllm", "hermes", "PARSER.batch.8.c"): _TRAILING_NORMAL_TEXT_DROP,
     ("vllm", "hermes", "PARSER.batch.8.d"): _TRAILING_NORMAL_TEXT_DROP,
-    ("vllm", "jamba", "PARSER.batch.5"): _RECOVERY_CONTRACT,
     ("vllm", "jamba", "PARSER.batch.8.a"): _TRAILING_NORMAL_TEXT_DROP,
     ("vllm", "jamba", "PARSER.batch.8.c"): _TRAILING_NORMAL_TEXT_DROP,
     ("vllm", "jamba", "PARSER.batch.8.d"): _TRAILING_NORMAL_TEXT_DROP,
     (
         "vllm",
         "llama3_json",
-        "PARSER.batch.2",
-    ): "vLLM llama3_json does not parse semicolon-separated calls the same way Dynamo does",
-    ("vllm", "llama3_json", "PARSER.batch.4"): _RECOVERY_CONTRACT,
-    ("vllm", "llama3_json", "PARSER.batch.5"): _RECOVERY_CONTRACT,
-    (
-        "vllm",
-        "llama3_json",
         "PARSER.batch.10",
     ): "vLLM llama3_json does not parse semicolon-separated calls the same way Dynamo does",
-    ("vllm", "mistral", "PARSER.batch.4"): _RECOVERY_CONTRACT,
     ("vllm", "mistral", "PARSER.batch.8.a"): _TRAILING_NORMAL_TEXT_DROP,
     ("vllm", "mistral", "PARSER.batch.8.c"): _TRAILING_NORMAL_TEXT_DROP,
     # `("vllm", "mistral", "PARSER.batch.8.d")` lives in the TODO(research) block below
     # — vLLM raises ValueError on two `[TOOL_CALLS]` envelopes; classified differently
     # than .a/.c.
-    ("vllm", "phi4", "PARSER.batch.5"): _RECOVERY_CONTRACT,
-    (
-        "vllm",
-        "phi4",
-        "PARSER.batch.7",
-    ): "emits JSON-typed parameter values as raw strings; Dynamo coerces nested object/array types",
     ("vllm", "phi4", "PARSER.batch.8.a"): _TRAILING_NORMAL_TEXT_DROP,
     ("vllm", "phi4", "PARSER.batch.8.c"): _TRAILING_NORMAL_TEXT_DROP,
     ("vllm", "phi4", "PARSER.batch.8.d"): _TRAILING_NORMAL_TEXT_DROP,
@@ -283,7 +671,6 @@ KNOWN_DIVERGENCES: dict[tuple[str, str, str], str] = {
     ("sglang", "deepseek_v3_2", "PARSER.batch.8.b"): _TRAILING_NORMAL_TEXT_DROP,
     ("sglang", "deepseek_v3_2", "PARSER.batch.8.c"): _TRAILING_NORMAL_TEXT_DROP,
     ("sglang", "deepseek_v3_2", "PARSER.batch.8.d"): _TRAILING_NORMAL_TEXT_DROP,
-    ("sglang", "hermes", "PARSER.batch.4"): _RECOVERY_CONTRACT,
     # SGLang's MistralDetector and Qwen25Detector both return empty `calls`
     # on the bare wire formats Dynamo emits — format-detection failure rather
     # than a recovery-contract divergence. The exact reason (different start
@@ -298,19 +685,12 @@ KNOWN_DIVERGENCES: dict[tuple[str, str, str], str] = {
     (
         "sglang",
         "mistral",
-        "PARSER.batch.2",
-    ): "SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits",
-    ("sglang", "mistral", "PARSER.batch.4"): _RECOVERY_CONTRACT,
-    ("sglang", "mistral", "PARSER.batch.5"): _RECOVERY_CONTRACT,
-    (
-        "sglang",
-        "mistral",
-        "PARSER.batch.6",
+        "PARSER.batch.6.a",
     ): "SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits",
     (
         "sglang",
         "mistral",
-        "PARSER.batch.7",
+        "PARSER.batch.6.b",
     ): "SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits",
     ("sglang", "mistral", "PARSER.batch.8.a"): _TRAILING_NORMAL_TEXT_DROP,
     ("sglang", "mistral", "PARSER.batch.8.b"): _TRAILING_NORMAL_TEXT_DROP,
@@ -328,19 +708,12 @@ KNOWN_DIVERGENCES: dict[tuple[str, str, str], str] = {
     (
         "sglang",
         "qwen25",
-        "PARSER.batch.2",
-    ): "SGLang Qwen25Detector returns calls=[] on the hermes-style <tool_call>...</tool_call> format Dynamo emits",
-    ("sglang", "qwen25", "PARSER.batch.4"): _RECOVERY_CONTRACT,
-    ("sglang", "qwen25", "PARSER.batch.5"): _RECOVERY_CONTRACT,
-    (
-        "sglang",
-        "qwen25",
-        "PARSER.batch.6",
+        "PARSER.batch.6.a",
     ): "SGLang Qwen25Detector returns calls=[] on the hermes-style <tool_call>...</tool_call> format Dynamo emits",
     (
         "sglang",
         "qwen25",
-        "PARSER.batch.7",
+        "PARSER.batch.6.b",
     ): "SGLang Qwen25Detector returns calls=[] on the hermes-style <tool_call>...</tool_call> format Dynamo emits",
     ("sglang", "qwen25", "PARSER.batch.8.a"): _TRAILING_NORMAL_TEXT_DROP,
     ("sglang", "qwen25", "PARSER.batch.8.b"): _TRAILING_NORMAL_TEXT_DROP,


### PR DESCRIPTION
#### Overview:

Follows PR #9338 (the batch.8 pilot, merged 2026-05-11). Extends the per-top-level-case sub-case rollout to the five remaining buckets where vLLM's test corpus organically partitions on a meaningful shape axis — `batch.2` (multi-call), `batch.4` (malformed), `batch.5` (missing end-token), `batch.6` (empty args), `batch.7` (complex types).

#### Details:

- **What lands here?** 293 new sub-case fixtures across 19 families × 5 buckets. Per-top-level-case file convention (`<family>/PARSER.batch.<n>.yaml`) extended bucket-by-bucket; legacy bare-key entries retired via orphan-rule.
- **Why these 5 buckets?** Audited in `~/dynamo/notes/VLLM_TEST_AUDIT.md` (private). Each carries genuine shape variation in vLLM's tests, not just parser-distribution. `batch.1`/`.3`/`.9`/`.10` were skipped — their row counts come from inherited common-suite repeating across N parsers, splitting would yield mostly-empty cells.
- **Per-bucket axes** (full taxonomy in `lib/parsers/PARSER_CASES.md`):
  - `batch.2`: `.a` parallel · `.b` multi-section back-to-back · `.c` surrounded with content · `.d` same-name twice (id distinctness)
  - `batch.4`: `.a` catch-all garbage · `.b` invalid JSON syntax · `.c` missing structural keys · `.d` malformed wrapper / mismatched tags
  - `batch.5`: `.a` missing closing tag · `.b` missing opening tag · `.c` truncation mid-call body
  - `batch.6`: `.a` canonical empty `{}` · `.b` zero-arg formatting · `.c` no-args-key
  - `batch.7`: `.a` standard scalar/container types · `.b` escaped/Unicode · `.c` type coercion · `.d` multi-arg/nested
- **Coverage gaps documented as skips:** pure-XML grammars (qwen3_coder, glm47, minimax_m2, deepseek_v4, deepseek_v3_2, nemotron_nano) skip sub-cases that need JSON arg structure (`batch.4.b`, `batch.6.c`, `batch.7.c/.d`). llama3_json skips `batch.5.b` (no paired close fence). harmony skips `batch.4.d` (no paired begin/end). These show as `n/a` in the matrix, not failures.
- **`KNOWN_DIVERGENCES` registry** restructured: 30+ stale bare-key entries dropped; ~80 sub-case entries added (vllm divergences from local pytest, sglang provisional `.a` entries inherited from prior bare-key set). One `EXPECTS_ERROR(KeyError):` prefix on `mistral.4.c` (vLLM's `mistral_tool_parser` raises on missing name key). Sglang `.b/.c/.d` divergences will surface when CI runs with sglang installed.
- **Tooling:** 2 new tool variants in `regenerate_fixtures.py` — `_BOOK_FLIGHT_MIXED` (string + int + bool for `batch.7.a`) and `_SET_TEMP_NUMERIC` (integer schema for `batch.7.c` coercion test).

#### Coverage matrix (mirrors `tests/parity/README.md`)

Each row is one parser (one wire-format family); the **Model(s)** column lists what model(s) that parser serves (many parsers cover multiple models — `mistral` covers the Mistral series, `hermes` covers Hermes-3 + various Llama variants, etc.). Columns are sub-case IDs from `PARSER_CASES.md`: top-level buckets (1, 3, 9, 10) have no sub-cases; the rest split into `.a`-`.d`.

Cell legend: `✓` = both vLLM and SGLang match Dynamo; `V` = vLLM diverges (xfailed); `S` = SGLang diverges; `VS` = both diverge; `n/a` = **not applicable** — no peer parser, OR the sub-case shape doesn't apply to this grammar (e.g. DSML families have no `4.b` because there's no embedded JSON to malform). Row-suffix `†` = no vLLM peer; `§` = no SGLang peer.

| model | parser | 1 | 2.a | 2.b | 2.c | 2.d | 3 | 4.a | 4.b | 4.c | 4.d | 5.a | 5.b | 5.c | 6.a | 6.b | 6.c | 7.a | 7.b | 7.c | 7.d | 8.a | 8.b | 8.c | 8.d | 9 | 10 |
|---|---|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
| **Top-N models** |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
| DeepSeek V4 | deepseek_v4 § | ✓ | ✓ | V | V | ✓ | ✓ | V | n/a | V | ✓ | V | ✓ | V | ✓ | ✓ | n/a | V | ✓ | n/a | n/a | ✓ | V | V | V | ✓ | ✓ |
| Gemma 4 | gemma4 § | ✓ | ✓ | n/a | V | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | V | V | V | ✓ | ✓ |
| GLM 5.1 | glm47 | ✓ | ✓ | n/a | V | ✓ | ✓ | VS | n/a | n/a | ✓ | VS | ✓ | VS | ✓ | S | n/a | ✓ | ✓ | n/a | n/a | V | V | V | V | ✓ | ✓ |
| gpt-oss | harmony † | S | S | n/a | S | S | ✓ | S | S | ✓ | n/a | S | ✓ | S | S | S | ✓ | S | S | S | S | S | S | S | S | ✓ | S |
| Kimi K2.6 | kimi_k2 | ✓ | ✓ | ✓ | VS | ✓ | ✓ | ✓ | S | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | VS | VS | VS | VS | ✓ | ✓ |
| MiniMax 2.7 | minimax_m2 | ✓ | ✓ | S | S | ✓ | ✓ | V | n/a | V | V | VS | ✓ | VS | ✓ | ✓ | n/a | V | ✓ | n/a | n/a | ✓ | S | S | S | ✓ | ✓ |
| Nemotron (DeciLM) | nemotron_deci †§ | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a |
| Qwen 3 Coder | qwen3_coder | ✓ | ✓ | n/a | ✓ | ✓ | ✓ | V | n/a | n/a | ✓ | ✓ | V | ✓ | ✓ | ✓ | n/a | VS | ✓ | n/a | n/a | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
| **Others** |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
| DeepSeek V3 | deepseek_v3 | ✓ | ✓ | ✓ | S | ✓ | ✓ | VS | V | VS | VS | VS | ✓ | VS | ✓ | V | V | ✓ | ✓ | ✓ | ✓ | S | ✓ | S | S | ✓ | ✓ |
| DeepSeek V3.1 | deepseek_v3_1 | ✓ | ✓ | ✓ | S | ✓ | ✓ | VS | V | VS | VS | VS | ✓ | VS | ✓ | ✓ | V | ✓ | ✓ | ✓ | ✓ | S | ✓ | S | S | ✓ | ✓ |
| DeepSeek V3.2 | deepseek_v3_2 | ✓ | ✓ | VS | VS | ✓ | ✓ | V | n/a | V | ✓ | V | ✓ | V | ✓ | ✓ | n/a | V | ✓ | n/a | n/a | S | VS | VS | VS | ✓ | ✓ |
| Hermes-3 / Llama variants | hermes | ✓ | ✓ | n/a | V | ✓ | ✓ | ✓ | VS | S | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | S | ✓ | ✓ | ✓ | ✓ | V | ✓ | V | V | ✓ | ✓ |
| AI21 Jamba | jamba § | ✓ | ✓ | n/a | V | ✓ | ✓ | ✓ | ✓ | V | V | V | ✓ | ✓ | ✓ | ✓ | V | ✓ | ✓ | ✓ | ✓ | V | ✓ | V | V | ✓ | ✓ |
| Llama 3 (JSON fmt) | llama3_json § | ✓ | V | n/a | V | V | ✓ | V | V | V | n/a | V | n/a | V | ✓ | ✓ | V | ✓ | ✓ | ✓ | ✓ | V | ✓ | V | V | ✓ | V |
| Mistral series | mistral | S | S | n/a | VS | S | ✓ | VS | VS | V | S | S | ✓ | VS | S | S | V | S | S | S | S | VS | S | VS | V | ✓ | S |
| Nemotron Nano | nemotron_nano †§ | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a |
| Phi-4 | phi4 § | ✓ | ✓ | n/a | V | ✓ | ✓ | ✓ | ✓ | V | V | V | V | V | ✓ | ✓ | V | ✓ | ✓ | ✓ | V | V | ✓ | V | V | ✓ | ✓ |
| Llama 4 (pythonic fmt) | pythonic | ✓ | ✓ | n/a | VS | ✓ | ✓ | ✓ | ✓ | n/a | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | n/a | ✓ | ✓ | ✓ | ✓ | VS | VS | VS | VS | ✓ | ✓ |
| Qwen 2.5 | qwen25 † | S | S | n/a | S | S | ✓ | ✓ | S | ✓ | S | S | ✓ | ✓ | S | S | ✓ | S | S | S | S | S | S | S | S | ✓ | S |

Each non-`✓` / non-`n/a` cell corresponds to an entry in `KNOWN_DIVERGENCES` at [`tests/parity/parser/test_parity_parser.py`](https://github.com/ai-dynamo/dynamo/blob/keivenchang/DIS-1936__parser-fixture-per-case-part-2/tests/parity/parser/test_parity_parser.py).

#### Verification:

693 passed (+307 vs pre-rollout baseline) / 545 skipped / 112 xfailed / 0 failed in local pytest with sglang skipped (not installed). All failures land as registered divergences via `KNOWN_DIVERGENCES`.

#### Where should the reviewer start?

`lib/parsers/PARSER_CASES.md` (the new sub-case taxonomy section under each top-level case), then `tests/parity/parser/regenerate_fixtures.py` INPUTS dict for the per-family shapes, then any one fixture file (e.g. `tests/parity/parser/fixtures/kimi_k2/PARSER.batch.4.yaml`) to see the embedded `TODO(research)` divergence comments inline. Divergence registry: `KNOWN_DIVERGENCES` in `tests/parity/parser/test_parity_parser.py`.

#### Related Issues:

Relates to [DIS-1936](https://linear.app/nvidia/issue/DIS-1936)
Builds on #9338 (merged 2026-05-11).

/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded parser testing taxonomy with detailed sub-case breakdowns across batch-mode categories.
  * Updated parity harness documentation with refreshed test matrix layout and fixture provenance guidelines.

* **Tests**
  * Reorganized batch parser test fixtures across multiple parser implementations.
  * Added comprehensive test coverage for malformed inputs, edge cases, and argument parsing scenarios.
  * Updated divergence registry for cross-implementation parity assertions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9363)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->