### PR TITLE
fix(backend): force-exit backstop after Worker.run for hung engines

### DIFF
--- a/components/src/dynamo/common/backend/run.py
+++ b/components/src/dynamo/common/backend/run.py
@@ -29,13 +29,21 @@ async def _start(engine_cls: type[LLMEngine], argv: list[str] | None = None):
     await w.run()
 
 
+def _shutdown_watchdog() -> None:
+    time.sleep(2)
+    # 911 mirrors the Rust orchestrator's deadline backstop in
+    # lib/backend-common/src/worker.rs so monitoring sees a forced
+    # termination rather than a clean exit.
+    os._exit(911)
+
+
 def run(engine_cls: type[LLMEngine], argv: list[str] | None = None):
     """Entry point for per-backend unified_main.py files."""
     uvloop.run(_start(engine_cls, argv))
     # Engines leak non-daemon threads that block exit after Worker.run
     # cleaned up; force-exit backstop. Issue #9343.
     threading.Thread(
-        target=lambda: (time.sleep(2), os._exit(0)),
+        target=_shutdown_watchdog,
         daemon=True,
         name="dynamo-backend-shutdown-watchdog",
     ).start()

--- a/components/src/dynamo/common/backend/run.py
+++ b/components/src/dynamo/common/backend/run.py
@@ -13,6 +13,10 @@ Each backend's ``unified_main.py`` calls :func:`run` with its
         run(VllmLLMEngine)
 """
 
+import os
+import threading
+import time
+
 import uvloop
 
 from .engine import LLMEngine
@@ -28,3 +32,10 @@ async def _start(engine_cls: type[LLMEngine], argv: list[str] | None = None):
 def run(engine_cls: type[LLMEngine], argv: list[str] | None = None):
     """Entry point for per-backend unified_main.py files."""
     uvloop.run(_start(engine_cls, argv))
+    # Engines leak non-daemon threads that block exit after Worker.run
+    # cleaned up; force-exit backstop. Issue #9343.
+    threading.Thread(
+        target=lambda: (time.sleep(2), os._exit(0)),
+        daemon=True,
+        name="dynamo-backend-shutdown-watchdog",
+    ).start()

--- a/components/src/dynamo/common/backend/run.py
+++ b/components/src/dynamo/common/backend/run.py
@@ -14,6 +14,7 @@ Each backend's ``unified_main.py`` calls :func:`run` with its
 """
 
 import os
+import sys
 import threading
 import time
 
@@ -29,21 +30,25 @@ async def _start(engine_cls: type[LLMEngine], argv: list[str] | None = None):
     await w.run()
 
 
-def _shutdown_watchdog() -> None:
+def _force_exit_after_delay() -> None:
     time.sleep(2)
-    # 911 mirrors the Rust orchestrator's deadline backstop in
-    # lib/backend-common/src/worker.rs so monitoring sees a forced
-    # termination rather than a clean exit.
+    # 911 matches the Rust force-exit code (lib/backend-common/src/worker.rs).
+    try:
+        sys.stderr.write("force-exit 911: leaked engine threads\n")
+        sys.stderr.flush()
+    except Exception:
+        pass
     os._exit(911)
 
 
 def run(engine_cls: type[LLMEngine], argv: list[str] | None = None):
     """Entry point for per-backend unified_main.py files."""
-    uvloop.run(_start(engine_cls, argv))
-    # Engines leak non-daemon threads that block exit after Worker.run
-    # cleaned up; force-exit backstop. Issue #9343.
-    threading.Thread(
-        target=_shutdown_watchdog,
-        daemon=True,
-        name="dynamo-backend-shutdown-watchdog",
-    ).start()
+    try:
+        uvloop.run(_start(engine_cls, argv))
+    finally:
+        # Backstop for engines that leak non-daemon threads.
+        threading.Thread(
+            target=_force_exit_after_delay,
+            daemon=True,
+            name="dynamo-backend-shutdown-watchdog",
+        ).start()


### PR DESCRIPTION
## Summary

- Heavyweight engines (vLLM AsyncLLM + EngineCore + ZMQ I/O threads, SGLang child schedulers, TRT-LLM workers, NIXL transports, multiprocessing trackers) leave non-daemon threads alive that block Python's interpreter shutdown — even after `Worker.run` has finished discovery unregister, drain, cleanup, and runtime shutdown.
- Adds a 2-second daemon-thread backstop in the common entry point (`dynamo.common.backend.run.run`) that `os._exit(0)`s if Python doesn't shut down on its own. The thread is killed before its sleep completes when the interpreter exits cleanly, so clean shutdowns are unaffected.
- Mirrors the Rust orchestrator's `std::process::exit(911)` deadline in `lib/backend-common/src/worker.rs` — same "bounded window, then force exit" pattern, on the Python side.

Fixes #9343.

## Test plan

- [ ] vLLM unified disagg: send a few cancelled streaming requests, then SIGTERM the decode worker. Process exits within ~2s of `Phase 3: All endpoints ended gracefully` instead of waiting on the 30s SIGKILL deadline.
- [ ] Aggregated vLLM unified worker: same SIGTERM behaviour.
- [ ] SGLang and TRT-LLM unified launches: confirm no regression on clean startup/shutdown.
- [ ] Verify a clean shutdown that completes in <2s is not delayed by the watchdog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced process termination reliability to ensure graceful shutdown in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->