### PR TITLE
fix(operator): only set CONTAINER_NAME when in container discovery mode

### DIFF
--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -631,7 +631,6 @@ func TestDynamoComponentDeploymentReconciler_generateLeaderWorkerSet(t *testing.
 										Command: []string{"/bin/sh", "-c"},
 										Args:    []string{"ray start --head --port=6379 && some dynamo command --tensor-parallel-size 4 --pipeline-parallel-size 1 --distributed-executor-backend ray"},
 										Env: []corev1.EnvVar{
-											{Name: "CONTAINER_NAME", Value: commonconsts.MainContainerName},
 											{Name: commonconsts.DynamoComponentEnvVar, Value: commonconsts.ComponentTypeWorker},
 											{Name: commonconsts.DynamoDiscoveryBackendEnvVar, Value: "kubernetes"},
 											{Name: "DYN_FORWARDPASS_METRIC_PORT", Value: "20380"},
@@ -772,7 +771,6 @@ func TestDynamoComponentDeploymentReconciler_generateLeaderWorkerSet(t *testing.
 										Command: []string{"/bin/sh", "-c"},
 										Args:    []string{"ray start --address=$(LWS_LEADER_ADDRESS):6379 --block"},
 										Env: []corev1.EnvVar{
-											{Name: "CONTAINER_NAME", Value: commonconsts.MainContainerName},
 											{Name: commonconsts.DynamoComponentEnvVar, Value: commonconsts.ComponentTypeWorker},
 											{Name: commonconsts.DynamoDiscoveryBackendEnvVar, Value: "kubernetes"},
 											{Name: "DYN_FORWARDPASS_METRIC_PORT", Value: "20380"},

--- a/deploy/operator/internal/dynamo/component_common.go
+++ b/deploy/operator/internal/dynamo/component_common.go
@@ -94,10 +94,6 @@ func (b *BaseComponentDefaults) getCommonContainer(context ComponentContext) cor
 	}
 	container.Env = []corev1.EnvVar{
 		{
-			Name:  "CONTAINER_NAME",
-			Value: commonconsts.MainContainerName,
-		},
-		{
 			Name:  commonconsts.DynamoNamespaceEnvVar,
 			Value: context.DynamoNamespace,
 		},
@@ -148,9 +144,10 @@ func (b *BaseComponentDefaults) getCommonContainer(context ComponentContext) cor
 	}
 
 	if context.Discovery.Mode == configv1alpha1.KubeDiscoveryModeContainer {
-		// CONTAINER_NAME is already injected unconditionally above with
-		// MainContainerName (which equals container.Name here); do not append
-		// it again or we end up with two env entries of the same name.
+		container.Env = append(container.Env, corev1.EnvVar{
+			Name:  "CONTAINER_NAME",
+			Value: commonconsts.MainContainerName,
+		})
 		container.Env = append(container.Env, corev1.EnvVar{
 			Name:  "DYN_KUBE_DISCOVERY_MODE",
 			Value: string(configv1alpha1.KubeDiscoveryModeContainer),

--- a/deploy/operator/internal/dynamo/component_planner_test.go
+++ b/deploy/operator/internal/dynamo/component_planner_test.go
@@ -82,7 +82,6 @@ func TestPlannerDefaults_GetBaseContainer(t *testing.T) {
 					FailureThreshold: 720,
 				},
 				Env: []corev1.EnvVar{
-					{Name: "CONTAINER_NAME", Value: commonconsts.MainContainerName},
 					{Name: commonconsts.DynamoNamespaceEnvVar, Value: "dynamo-namespace"},
 					{Name: commonconsts.DynamoComponentEnvVar, Value: commonconsts.ComponentTypePlanner},
 					{Name: "DYN_PARENT_DGD_K8S_NAME", Value: "name"},

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -1495,10 +1495,6 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 												},
 												Env: []corev1.EnvVar{
 													{
-														Name:  "CONTAINER_NAME",
-														Value: commonconsts.MainContainerName,
-													},
-													{
 														Name:  "DYN_HTTP_PORT",
 														Value: fmt.Sprintf("%d", commonconsts.DynamoServicePort),
 													},
@@ -1704,10 +1700,6 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 													FailureThreshold: 720,
 												},
 												Env: []corev1.EnvVar{
-													{
-														Name:  "CONTAINER_NAME",
-														Value: commonconsts.MainContainerName,
-													},
 													{
 														Name:  "DYNAMO_POD_GANG_SET_REPLICAS",
 														Value: "1",
@@ -2104,10 +2096,6 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 												},
 												Env: []corev1.EnvVar{
 													{
-														Name:  "CONTAINER_NAME",
-														Value: commonconsts.MainContainerName,
-													},
-													{
 														Name:  "DYNAMO_POD_GANG_SET_REPLICAS",
 														Value: "1",
 													},
@@ -2322,10 +2310,6 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 												},
 												Env: []corev1.EnvVar{
 													{
-														Name:  "CONTAINER_NAME",
-														Value: commonconsts.MainContainerName,
-													},
-													{
 														Name:  "DYNAMO_POD_GANG_SET_REPLICAS",
 														Value: "1",
 													},
@@ -2516,10 +2500,6 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 													},
 												},
 												Env: []corev1.EnvVar{
-													{
-														Name:  "CONTAINER_NAME",
-														Value: commonconsts.MainContainerName,
-													},
 													{
 														Name:  "DYN_HTTP_PORT",
 														Value: fmt.Sprintf("%d", commonconsts.DynamoServicePort),
@@ -2717,10 +2697,6 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 													FailureThreshold: 720,
 												},
 												Env: []corev1.EnvVar{
-													{
-														Name:  "CONTAINER_NAME",
-														Value: commonconsts.MainContainerName,
-													},
 													{
 														Name:  "DYNAMO_POD_GANG_SET_REPLICAS",
 														Value: "1",
@@ -3139,10 +3115,6 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 												},
 												Env: []corev1.EnvVar{
 													{
-														Name:  "CONTAINER_NAME",
-														Value: commonconsts.MainContainerName,
-													},
-													{
 														Name:  "DYNAMO_POD_GANG_SET_REPLICAS",
 														Value: "1",
 													},
@@ -3344,10 +3316,6 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 												},
 												Env: []corev1.EnvVar{
 													{
-														Name:  "CONTAINER_NAME",
-														Value: commonconsts.MainContainerName,
-													},
-													{
 														Name:  "DYNAMO_POD_GANG_SET_REPLICAS",
 														Value: "1",
 													},
@@ -3538,10 +3506,6 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 													},
 												},
 												Env: []corev1.EnvVar{
-													{
-														Name:  "CONTAINER_NAME",
-														Value: commonconsts.MainContainerName,
-													},
 													{
 														Name:  "DYN_HTTP_PORT",
 														Value: fmt.Sprintf("%d", commonconsts.DynamoServicePort),
@@ -3739,10 +3703,6 @@ func TestGenerateGrovePodCliqueSet(t *testing.T) {
 													FailureThreshold: 720,
 												},
 												Env: []corev1.EnvVar{
-													{
-														Name:  "CONTAINER_NAME",
-														Value: commonconsts.MainContainerName,
-													},
 													{
 														Name:  "DYNAMO_POD_GANG_SET_REPLICAS",
 														Value: "1",
@@ -5651,7 +5611,6 @@ func TestGenerateBasePodSpec_Worker(t *testing.T) {
 						Env: []corev1.EnvVar{
 							{Name: "ANOTHER_COMPONENTENV", Value: "true"},
 							{Name: "ANOTHER_CONTAINER_ENV", Value: "true"},
-							{Name: "CONTAINER_NAME", Value: commonconsts.MainContainerName},
 							{Name: commonconsts.DynamoComponentEnvVar, Value: "worker"},
 							{Name: commonconsts.DynamoDiscoveryBackendEnvVar, Value: "kubernetes"},
 							{Name: "DYN_FORWARDPASS_METRIC_PORT", Value: "20380"},
@@ -7747,6 +7706,44 @@ func TestFrontendDefaults_NamespacePrefixEnvVar(t *testing.T) {
 		}
 	}
 	assert.True(t, found, "DYN_NAMESPACE_PREFIX should be set on frontend")
+}
+
+func TestBaseComponentDefaults_ContainerNameOnlyInContainerDiscoveryMode(t *testing.T) {
+	w := NewWorkerDefaults()
+
+	podModeContainer, err := w.GetBaseContainer(ComponentContext{
+		DynamoNamespace: "ns-dgd",
+		ComponentType:   commonconsts.ComponentTypeWorker,
+		Discovery: DiscoveryContext{
+			Backend: configv1alpha1.DiscoveryBackendKubernetes,
+			Mode:    configv1alpha1.KubeDiscoveryModePod,
+		},
+	})
+	require.NoError(t, err)
+	podModeEnv := envVarsToMap(podModeContainer.Env)
+	assert.NotContains(t, podModeEnv, "CONTAINER_NAME")
+	assert.NotContains(t, podModeEnv, "DYN_KUBE_DISCOVERY_MODE")
+
+	containerModeContainer, err := w.GetBaseContainer(ComponentContext{
+		DynamoNamespace: "ns-dgd",
+		ComponentType:   commonconsts.ComponentTypeWorker,
+		Discovery: DiscoveryContext{
+			Backend: configv1alpha1.DiscoveryBackendKubernetes,
+			Mode:    configv1alpha1.KubeDiscoveryModeContainer,
+		},
+	})
+	require.NoError(t, err)
+	containerModeEnv := envVarsToMap(containerModeContainer.Env)
+	assert.Equal(t, commonconsts.MainContainerName, containerModeEnv["CONTAINER_NAME"])
+	assert.Equal(t, string(configv1alpha1.KubeDiscoveryModeContainer), containerModeEnv["DYN_KUBE_DISCOVERY_MODE"])
+}
+
+func envVarsToMap(envs []corev1.EnvVar) map[string]string {
+	out := make(map[string]string, len(envs))
+	for _, env := range envs {
+		out[env.Name] = env.Value
+	}
+	return out
 }
 
 func TestGenerateBasePodSpec_FrontendSidecar(t *testing.T) {


### PR DESCRIPTION
This change stops injecting CONTAINER_NAME=main into every generated component container unconditionally. CONTAINER_NAME is only required by the runtime when Kubernetes discovery is running in per-container mode, so the operator now adds it only when DYN_KUBE_DISCOVERY_MODE=container is also set.

Previously, the unconditional env var changed the rendered pod template for all workloads, including the default pod discovery mode where CONTAINER_NAME is unused. Because pod-template env changes affect the workload spec hash, this could trigger rolling updates even for deployments that were not using container discovery.

The fix keeps the required behavior for container discovery mode:

- pod discovery mode: no CONTAINER_NAME env var is injected
- container discovery mode: CONTAINER_NAME=main and DYN_KUBE_DISCOVERY_MODE=container are injected together
- intra-pod failover continues to set per-engine values such as CONTAINER_NAME=engine-0 / engine-1
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9366" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated container environment variable injection to be conditional based on discovery mode configuration, ensuring proper setup for different deployment scenarios.

* **Tests**
  * Updated test expectations and added new test coverage to validate environment variable injection behavior across discovery modes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9366)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->