### PR TITLE
docs: fix broken Multimodal links in feature matrix

### DIFF
--- a/docs/reference/feature-matrix.md
+++ b/docs/reference/feature-matrix.md
@@ -122,10 +122,10 @@ TensorRT-LLM delivers maximum inference performance and optimization, with full 
 [tools]: ../user-guides/tool-calling
 
 {/* Multimodal */}
-[mm]: ../features/multimodal/README.md
-[mm-vllm]: ../features/multimodal/multimodal-vllm.md
-[mm-trtllm]: ../features/multimodal/multimodal-trtllm.md
-[mm-sglang]: ../features/multimodal/multimodal-sglang.md
+[mm]: ../user-guides/multimodal
+[mm-vllm]: https://github.com/ai-dynamo/dynamo/blob/main/docs/features/multimodal/multimodal-vllm.md
+[mm-trtllm]: https://github.com/ai-dynamo/dynamo/blob/main/docs/features/multimodal/multimodal-trtllm.md
+[mm-sglang]: https://github.com/ai-dynamo/dynamo/blob/main/docs/features/multimodal/multimodal-sglang.md
 
 {/* Feature-specific */}
 [lora]: ../kubernetes-deployment/deployment-guide/managing-models-with-dynamo-model


### PR DESCRIPTION
## Summary
- `[mm]` pointed at `../features/multimodal/README.md`, which 404s on docs.nvidia.com — the Multimodal section is published under `/user-guides/multimodal` per `docs/index.yml`. Repointed to `../user-guides/multimodal`.
- `[mm-vllm]`, `[mm-trtllm]`, `[mm-sglang]` referenced `.md` files that aren't registered in `docs/index.yml`, so Fern never publishes them (the `.md` URLs return HTTP 200 but the body is literally "Page Not Found"). Switched to the GitHub source URLs already used by `docs/features/multimodal/README.md`, `embedding-cache.md`, and `encoder-disaggregation.md`.

## Test plan
- [x] `curl -L https://docs.nvidia.com/dynamo/latest/user-guides/multimodal` → HTTP 200
- [x] All three `github.com/ai-dynamo/dynamo/blob/main/docs/features/multimodal/multimodal-*.md` URLs → HTTP 200
- [ ] Verify on Fern preview that the four "Multimodal Doc" / source links in the feature matrix table render and resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9378" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->