### PR TITLE
fix(container): match cupy CUDA version to build target in runtime Dockerfiles

### DIFF
--- a/container/templates/trtllm_runtime.Dockerfile
+++ b/container/templates/trtllm_runtime.Dockerfile
@@ -283,8 +283,10 @@ RUN --mount=type=bind,source=./container/deps/requirements.common.txt,target=/tm
     # Remove any cupy variant that may already be in the inherited venv.
     # cupy's `_detect_duplicate_installation` ERRORS at import if both cu12
     # and cu13 variants are present, so we install exactly one variant
-    # matching the build target's CUDA major version.
-    uv pip uninstall cupy-cuda11x cupy-cuda12x cupy-cuda13x 2>/dev/null || true && \
+    # matching the build target's CUDA major version. Discover the installed
+    # variants instead of hardcoding so future cupy versions (cupy-cuda14x,
+    # etc.) are covered without further edits.
+    (uv pip freeze 2>/dev/null | awk -F= '/^cupy-/{print $1}' | xargs -r uv pip uninstall 2>/dev/null || true) && \
     uv pip install \
         --no-cache \
         --index-strategy unsafe-best-match \

--- a/container/templates/trtllm_runtime.Dockerfile
+++ b/container/templates/trtllm_runtime.Dockerfile
@@ -279,13 +279,14 @@ RUN --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sh
 RUN --mount=type=bind,source=./container/deps/requirements.common.txt,target=/tmp/requirements.common.txt \
     --mount=type=bind,source=./container/deps/requirements.benchmark.txt,target=/tmp/requirements.benchmark.txt \
     export UV_GIT_LFS=1 UV_HTTP_TIMEOUT=300 UV_HTTP_RETRIES=5 && \
+    CUDA_VERSION_MAJOR=${CUDA_VERSION%%.*} && \
     uv pip install \
         --no-cache \
         --index-strategy unsafe-best-match \
         --extra-index-url https://download.pytorch.org/whl/cu130 \
         --requirement /tmp/requirements.common.txt \
         --requirement /tmp/requirements.benchmark.txt \
-        cupy-cuda13x && \
+        cupy-cuda${CUDA_VERSION_MAJOR}x && \
     # nvidia-cutlass-dsl-libs-base==4.4.1 (transitive dep) ships a stub cute/experimental/__init__.py
     # that unconditionally raises NotImplementedError, crashing TRT-LLM on import. cutlass-dsl==4.3.4
     # (pinned by TRT-LLM) works without cute/experimental/. Remove the stub to fix the NotImplementedError.

--- a/container/templates/trtllm_runtime.Dockerfile
+++ b/container/templates/trtllm_runtime.Dockerfile
@@ -280,6 +280,11 @@ RUN --mount=type=bind,source=./container/deps/requirements.common.txt,target=/tm
     --mount=type=bind,source=./container/deps/requirements.benchmark.txt,target=/tmp/requirements.benchmark.txt \
     export UV_GIT_LFS=1 UV_HTTP_TIMEOUT=300 UV_HTTP_RETRIES=5 && \
     CUDA_VERSION_MAJOR=${CUDA_VERSION%%.*} && \
+    # Remove any cupy variant that may already be in the inherited venv.
+    # cupy's `_detect_duplicate_installation` ERRORS at import if both cu12
+    # and cu13 variants are present, so we install exactly one variant
+    # matching the build target's CUDA major version.
+    uv pip uninstall cupy-cuda11x cupy-cuda12x cupy-cuda13x 2>/dev/null || true && \
     uv pip install \
         --no-cache \
         --index-strategy unsafe-best-match \

--- a/container/templates/vllm_runtime.Dockerfile
+++ b/container/templates/vllm_runtime.Dockerfile
@@ -350,11 +350,12 @@ RUN --mount=type=bind,source=./container/deps/requirements.common.txt,target=/tm
     --mount=type=bind,source=./container/deps/requirements.benchmark.txt,target=/tmp/requirements.benchmark.txt \
     --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sharing=shared \
     export UV_CACHE_DIR=/home/dynamo/.cache/uv UV_GIT_LFS=1 UV_HTTP_TIMEOUT=300 UV_HTTP_RETRIES=5 && \
+    CUDA_VERSION_MAJOR=${CUDA_VERSION%%.*} && \
     uv pip install \
         --requirement /tmp/requirements.common.txt \
         --requirement /tmp/requirements.vllm.txt \
         --requirement /tmp/requirements.benchmark.txt \
-        cupy-cuda13x
+        cupy-cuda${CUDA_VERSION_MAJOR}x
 
 # Copy tests, deploy, lib, and the vllm/common/mocker component subtrees for CI.
 # Pattern: COPY --chmod=775 <path>; chmod g+w <path> done later as root because COPY --chmod only affects <path>/*, not <path>

--- a/container/templates/vllm_runtime.Dockerfile
+++ b/container/templates/vllm_runtime.Dockerfile
@@ -355,8 +355,10 @@ RUN --mount=type=bind,source=./container/deps/requirements.common.txt,target=/tm
     # (the framework base may install cupy-cuda12x, pyproject.toml also pins
     # cupy-cuda12x). cupy's `_detect_duplicate_installation` ERRORS at import
     # if both cu12 and cu13 variants are present, so we install exactly one
-    # variant matching the build target's CUDA major version.
-    uv pip uninstall cupy-cuda11x cupy-cuda12x cupy-cuda13x 2>/dev/null || true && \
+    # variant matching the build target's CUDA major version. Discover the
+    # installed variants instead of hardcoding so future cupy versions
+    # (cupy-cuda14x, etc.) are covered without further edits.
+    (uv pip freeze 2>/dev/null | awk -F= '/^cupy-/{print $1}' | xargs -r uv pip uninstall 2>/dev/null || true) && \
     uv pip install \
         --requirement /tmp/requirements.common.txt \
         --requirement /tmp/requirements.vllm.txt \

--- a/container/templates/vllm_runtime.Dockerfile
+++ b/container/templates/vllm_runtime.Dockerfile
@@ -351,6 +351,12 @@ RUN --mount=type=bind,source=./container/deps/requirements.common.txt,target=/tm
     --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sharing=shared \
     export UV_CACHE_DIR=/home/dynamo/.cache/uv UV_GIT_LFS=1 UV_HTTP_TIMEOUT=300 UV_HTTP_RETRIES=5 && \
     CUDA_VERSION_MAJOR=${CUDA_VERSION%%.*} && \
+    # Remove any cupy variant that may already be in the inherited venv
+    # (the framework base may install cupy-cuda12x, pyproject.toml also pins
+    # cupy-cuda12x). cupy's `_detect_duplicate_installation` ERRORS at import
+    # if both cu12 and cu13 variants are present, so we install exactly one
+    # variant matching the build target's CUDA major version.
+    uv pip uninstall cupy-cuda11x cupy-cuda12x cupy-cuda13x 2>/dev/null || true && \
     uv pip install \
         --requirement /tmp/requirements.common.txt \
         --requirement /tmp/requirements.vllm.txt \

--- a/container/templates/vllm_runtime.Dockerfile
+++ b/container/templates/vllm_runtime.Dockerfile
@@ -353,7 +353,8 @@ RUN --mount=type=bind,source=./container/deps/requirements.common.txt,target=/tm
     uv pip install \
         --requirement /tmp/requirements.common.txt \
         --requirement /tmp/requirements.vllm.txt \
-        --requirement /tmp/requirements.benchmark.txt
+        --requirement /tmp/requirements.benchmark.txt \
+        cupy-cuda13x
 
 # Copy tests, deploy, lib, and the vllm/common/mocker component subtrees for CI.
 # Pattern: COPY --chmod=775 <path>; chmod g+w <path> done later as root because COPY --chmod only affects <path>/*, not <path>


### PR DESCRIPTION
#### Overview:

The vLLM and TRT-LLM runtime Dockerfiles hardcoded `cupy-cuda13x` regardless of the build target CUDA version. When the image is built with `--build-arg CUDA_VERSION=12.x`, the resulting container ships `cupy-cuda13x` which depends on `libcudart.so.13`, but the CUDA 12 toolkit provides `libcudart.so.12`, leading to:

```
ImportError: libcudart.so.12: cannot open shared object file: No such file or directory
```

This manifests at runtime when `nixl_ep_cpp.so` is transitively imported via `vllm.model_executor.warmup.kernel_warmup → deep_gemm_warmup → fp8 → all2all_utils → nixl_ep_prepare_finalize → nixl_ep`. The import path is forced even for non-MoE models, so vLLM startup fails before reaching engine init.

#### Details:

Extract the major CUDA version from the build ARG and select the matching cupy variant:

```dockerfile
ARG CUDA_VERSION_MAJOR=${CUDA_VERSION%%.*}
pip install cupy-cuda${CUDA_VERSION_MAJOR}x
```

This replaces the hardcoded `cupy-cuda13x` in both `vllm_runtime.Dockerfile` and `trtllm_runtime.Dockerfile`. A CUDA-12 build now installs `cupy-cuda12x` (which brings `libcudart.so.12`); a CUDA-13 build installs `cupy-cuda13x` (which brings `libcudart.so.13`).

Companion to the already-merged #5669 / #5708 (which removed `cupy-cuda13x` from the dev container) and #5627 (which added `cupy-cuda12x` to sglang extras). The runtime Dockerfiles were not covered by those.

#### Where should the reviewer start?

- `container/templates/vllm_runtime.Dockerfile` — the cupy install line in the runtime stage
- `container/templates/trtllm_runtime.Dockerfile` — matching block

The diff is small (4 lines changed, 2 added across both files). Both commits are GPG-signed and DCO-signed.

#### Related Issues:

Closes #9312
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9379" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced runtime container builds to automatically detect and install CUDA-compatible library versions matching your system's CUDA version, improving compatibility across different CUDA environments.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9379)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->