### PR TITLE
docs: fix broken Tool Calling link in feature matrix

### DIFF
--- a/docs/reference/feature-matrix.md
+++ b/docs/reference/feature-matrix.md
@@ -119,7 +119,7 @@ TensorRT-LLM delivers maximum inference performance and optimization, with full 
 [planner]: ../components/planner
 [kvbm]: ../components/kvbm
 [migration]: ../user-guides/fault-tolerance/request-migration
-[tools]: ../user-guides/tool-calling
+[tools]: ../user-guides/agents/tool-calling
 
 {/* Multimodal */}
 [mm]: ../user-guides/multimodal


### PR DESCRIPTION
## Summary
- The `[tools]` reference in `docs/reference/feature-matrix.md` pointed to `../user-guides/tool-calling`, which 404s.
- Tool Calling lives under User Guides → Agents in `docs/index.yml`, so the correct slug is `../user-guides/agents/tool-calling`.
- Follow-up to #9378 (same kind of broken-link fix for Multimodal).

## Test plan
- [ ] Verify the rendered Fern docs link from the feature-matrix page resolves to the Tool Calling guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9380" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation reference links for tool-calling features to ensure all feature tables properly resolve to the correct documentation location.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9380)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->