### PR TITLE
feat(operator/worker-hash): preserve downgrade-compatible hashes

### DIFF
--- a/deploy/operator/api/CONVERSION.md
+++ b/deploy/operator/api/CONVERSION.md
@@ -104,6 +104,10 @@ Allowed local helpers:
 - `save` data contains only source fields that `dst` cannot represent.
 - Preserve unrepresentable data only through the type's private sparse spec and
   status payloads.
+- Conversion is stateless: do not infer origin, age, creation version, upgrade
+  path, or controller state from the fact that conversion runs.
+- If origin matters, admission can stamp explicit metadata on create;
+  conversion may only preserve it opaquely.
 - New conversion style allows at most two private conversion annotations per
   type: one spec payload annotation and one status payload annotation.
 - Do not add per-field, per-list, per-subobject, or other conversion

--- a/deploy/operator/api/v1alpha1/dynamographdeployment_conversion.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeployment_conversion.go
@@ -75,18 +75,6 @@ func (src *DynamoGraphDeployment) ConvertTo(dstRaw conversion.Hub) error {
 	}
 	hubOrigin := restoredHubSpec != nil
 	scrubDGDInternalAnnotations(&dst.ObjectMeta)
-	// Preserve the alpha-era desired worker hash when a v1alpha1 object already
-	// carries active worker-hash state. The v1beta1 controller keeps the public
-	// current-worker-hash annotation in the v1 meaning and adds a separate v2
-	// annotation, so this conversion-only value is only a recomputed legacy
-	// reference for v2 controller initialization.
-	if hash, ok := getAnnFromObj(&src.ObjectMeta, annCurrentWorkerHash); ok && hash != "" {
-		legacyHash, err := ComputeDGDWorkersSpecHash(src)
-		if err != nil {
-			return fmt.Errorf("compute v1alpha1 DGD worker hash: %w", err)
-		}
-		setAnnOnObj(&dst.ObjectMeta, AnnotationDGDLegacyWorkerHash, legacyHash)
-	}
 
 	ctx := DynamoGraphDeploymentConversionContext{
 		IncludeOriginSplits: !hubOrigin,
@@ -524,7 +512,6 @@ func scrubDGDInternalAnnotations(obj metav1.Object) {
 	for _, key := range []string{
 		annDGDSpec,
 		annDGDStatus,
-		AnnotationDGDLegacyWorkerHash,
 	} {
 		delAnnFromObj(obj, key)
 	}

--- a/deploy/operator/api/v1alpha1/dynamographdeployment_conversion.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeployment_conversion.go
@@ -75,13 +75,12 @@ func (src *DynamoGraphDeployment) ConvertTo(dstRaw conversion.Hub) error {
 	}
 	hubOrigin := restoredHubSpec != nil
 	scrubDGDInternalAnnotations(&dst.ObjectMeta)
-	currentHashVersion := src.ObjectMeta.Annotations[annCurrentWorkerHashVersion]
-	// Preserve the alpha-era worker hash only while the object is still in
-	// legacy hash state. Once the controller has stamped the v2 hash version,
-	// conversion must stop recomputing the alpha hash so the compatibility path
-	// remains a bounded one-time bridge.
-	if hash, ok := getAnnFromObj(&src.ObjectMeta, annCurrentWorkerHash); ok && hash != "" &&
-		currentHashVersion != currentWorkerHashVersionV2 {
+	// Preserve the alpha-era desired worker hash when a v1alpha1 object already
+	// carries active worker-hash state. The v1beta1 controller keeps the public
+	// current-worker-hash annotation in the v1 meaning and adds a separate v2
+	// annotation, so this conversion-only value is only a recomputed legacy
+	// reference for v2 controller initialization.
+	if hash, ok := getAnnFromObj(&src.ObjectMeta, annCurrentWorkerHash); ok && hash != "" {
 		legacyHash, err := ComputeDGDWorkersSpecHash(src)
 		if err != nil {
 			return fmt.Errorf("compute v1alpha1 DGD worker hash: %w", err)

--- a/deploy/operator/api/v1alpha1/legacy_worker_hash.go
+++ b/deploy/operator/api/v1alpha1/legacy_worker_hash.go
@@ -18,8 +18,6 @@ import (
 const (
 	AnnotationDGDLegacyWorkerHash = "nvidia.com/dgd-legacy-worker-hash"
 	annCurrentWorkerHash          = "nvidia.com/current-worker-hash"
-	annCurrentWorkerHashVersion   = "nvidia.com/current-worker-hash-version"
-	currentWorkerHashVersionV2    = "v2"
 )
 
 // GetDGDLegacyWorkerHash returns the preserved v1alpha1 worker hash carried on

--- a/deploy/operator/api/v1alpha1/legacy_worker_hash.go
+++ b/deploy/operator/api/v1alpha1/legacy_worker_hash.go
@@ -11,36 +11,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
-
-const (
-	AnnotationDGDLegacyWorkerHash = "nvidia.com/dgd-legacy-worker-hash"
-	annCurrentWorkerHash          = "nvidia.com/current-worker-hash"
-)
-
-// GetDGDLegacyWorkerHash returns the preserved v1alpha1 worker hash carried on
-// converted v1beta1 DGD objects.
-func GetDGDLegacyWorkerHash(obj metav1.Object) string {
-	return obj.GetAnnotations()[AnnotationDGDLegacyWorkerHash]
-}
-
-// ClearDGDLegacyWorkerHash removes the preserved v1alpha1 worker hash from a
-// DGD object after the v1beta1 controller has consumed it.
-func ClearDGDLegacyWorkerHash(obj metav1.Object) {
-	annotations := obj.GetAnnotations()
-	delete(annotations, AnnotationDGDLegacyWorkerHash)
-	obj.SetAnnotations(annotations)
-}
 
 // ComputeDGDWorkersSpecHash computes the worker hash used by the
-// v1alpha1 DGD controller before v1beta1 conversion. ConvertTo stores this
-// value on the v1beta1 hub object so the v1beta1 controller can migrate
-// existing v1alpha1 hashes without rolling workers.
+// v1alpha1 DGD controller. Controller reconciliation may use this to compare
+// v1/v2 worker generations, but API conversion must not derive controller
+// rollout state from it.
 //
-// Keep this in the api/v1alpha1 package so conversion can call it without an
-// api/v1alpha1 -> internal/dynamo -> api/v1alpha1 import cycle.
+// Keep this in the api/v1alpha1 package so internal controller helpers can
+// reproduce the legacy hash without duplicating the old algorithm.
 func ComputeDGDWorkersSpecHash(dgd *DynamoGraphDeployment) (string, error) {
 	if dgd == nil {
 		return "", fmt.Errorf("nil DynamoGraphDeployment")

--- a/deploy/operator/api/v1alpha1/legacy_worker_hash_test.go
+++ b/deploy/operator/api/v1alpha1/legacy_worker_hash_test.go
@@ -7,53 +7,21 @@ package v1alpha1
 
 import (
 	"testing"
+	"unicode/utf8"
 
 	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 )
 
 const currentWorkerHashAnnotation = "nvidia.com/current-worker-hash"
 
 func TestComputeDGDWorkersSpecHashGolden(t *testing.T) {
-	tests := []struct {
-		name string
-		dgd  *DynamoGraphDeployment
-		want string
-	}{
-		{
-			name: "worker",
-			dgd:  legacyWorkerHashDGD(),
-			want: "9b66accc",
-		},
-		{
-			name: "resource metadata and non-workers ignored",
-			dgd:  legacyWorkerHashDGDWithResourceMetadataAndNonWorkerChanges(),
-			want: "9b66accc",
-		},
-		{
-			name: "pod metadata included",
-			dgd:  legacyWorkerHashDGDWithPodMetadataChanges(),
-			want: "af8a6c60",
-		},
-		{
-			name: "all worker component types",
-			dgd: &DynamoGraphDeployment{
-				Spec: DynamoGraphDeploymentSpec{
-					Services: map[string]*DynamoComponentDeploymentSharedSpec{
-						"decode":  {ComponentType: commonconsts.ComponentTypeDecode, Envs: []corev1.EnvVar{{Name: "ROLE", Value: "decode"}}},
-						"prefill": {ComponentType: commonconsts.ComponentTypePrefill, Envs: []corev1.EnvVar{{Name: "ROLE", Value: "prefill"}}},
-						"worker":  {ComponentType: commonconsts.ComponentTypeWorker, Envs: []corev1.EnvVar{{Name: "ROLE", Value: "worker"}}},
-					},
-				},
-			},
-			want: "b175ee30",
-		},
-	}
-
-	for _, tt := range tests {
+	for _, tt := range legacyWorkerHashGoldenCases() {
 		t.Run(tt.name, func(t *testing.T) {
 			got1, err := ComputeDGDWorkersSpecHash(tt.dgd)
 			if err != nil {
@@ -73,123 +41,421 @@ func TestComputeDGDWorkersSpecHashGolden(t *testing.T) {
 	}
 }
 
+type legacyWorkerHashGoldenCase struct {
+	name string
+	dgd  *DynamoGraphDeployment
+	want string
+}
+
+// legacyWorkerHashGoldenCases are golden values from the v1.1.x worker-hash
+// algorithm in deploy/operator/internal/dynamo/hash.go. Changing any value here
+// is a rollout-compatibility change and needs an explicit migration plan.
+func legacyWorkerHashGoldenCases() []legacyWorkerHashGoldenCase {
+	return []legacyWorkerHashGoldenCase{
+		{
+			name: "worker",
+			dgd:  legacyWorkerHashDGD(),
+			want: "9b66accc",
+		},
+		{
+			name: "resource metadata and non-workers ignored",
+			dgd:  legacyWorkerHashDGDWithResourceMetadataAndNonWorkerChanges(),
+			want: "9b66accc",
+		},
+		{
+			name: "pod metadata included",
+			dgd:  legacyWorkerHashDGDWithPodMetadataChanges(),
+			want: "af8a6c60",
+		},
+		{
+			name: "no workers",
+			dgd: legacyWorkerHashDGDFromServices(map[string]*DynamoComponentDeploymentSharedSpec{
+				"frontend": {ComponentType: commonconsts.ComponentTypeFrontend},
+			}),
+			want: "44136fa3",
+		},
+		{
+			name: "nil services",
+			dgd:  legacyWorkerHashDGDFromServices(nil),
+			want: "44136fa3",
+		},
+		{
+			name: "worker ordering",
+			dgd: legacyWorkerHashDGDFromServices(map[string]*DynamoComponentDeploymentSharedSpec{
+				"z-worker": {ComponentType: commonconsts.ComponentTypeWorker, Envs: []corev1.EnvVar{{Name: "Z", Value: "1"}}},
+				"a-worker": {ComponentType: commonconsts.ComponentTypeWorker, Envs: []corev1.EnvVar{{Name: "A", Value: "1"}}},
+			}),
+			want: "59cae8b3",
+		},
+		{
+			name: "all worker component types",
+			dgd: legacyWorkerHashDGDFromServices(map[string]*DynamoComponentDeploymentSharedSpec{
+				"decode":  {ComponentType: commonconsts.ComponentTypeDecode, Envs: []corev1.EnvVar{{Name: "ROLE", Value: "decode"}}},
+				"prefill": {ComponentType: commonconsts.ComponentTypePrefill, Envs: []corev1.EnvVar{{Name: "ROLE", Value: "prefill"}}},
+				"worker":  {ComponentType: commonconsts.ComponentTypeWorker, Envs: []corev1.EnvVar{{Name: "ROLE", Value: "worker"}}},
+			}),
+			want: "b175ee30",
+		},
+		{
+			name: "main container name only",
+			dgd: legacyWorkerHashDGDFromServices(map[string]*DynamoComponentDeploymentSharedSpec{
+				"worker": {
+					ComponentType: commonconsts.ComponentTypeWorker,
+					ExtraPodSpec: &ExtraPodSpec{
+						MainContainer: &corev1.Container{Name: commonconsts.MainContainerName},
+					},
+				},
+			}),
+			want: "0c322ce0",
+		},
+		{
+			name: "main container rich",
+			dgd: legacyWorkerHashDGDFromServices(map[string]*DynamoComponentDeploymentSharedSpec{
+				"worker": {
+					ComponentType: commonconsts.ComponentTypeWorker,
+					ExtraPodSpec: &ExtraPodSpec{
+						MainContainer: &corev1.Container{
+							Name:    commonconsts.MainContainerName,
+							Image:   "worker:1",
+							Command: []string{"python", "-m", "server"},
+							Args:    []string{"--model", "qwen"},
+							Env:     []corev1.EnvVar{{Name: "EXTRA", Value: "true"}},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")},
+							},
+						},
+					},
+				},
+			}),
+			want: "9e64367a",
+		},
+		{
+			name: "pod spec rich",
+			dgd: legacyWorkerHashDGDFromServices(map[string]*DynamoComponentDeploymentSharedSpec{
+				"worker": {
+					ComponentType: commonconsts.ComponentTypeWorker,
+					ExtraPodSpec: &ExtraPodSpec{
+						PodSpec: &corev1.PodSpec{
+							NodeSelector: map[string]string{"gpu": "true"},
+							Tolerations: []corev1.Toleration{{
+								Key:      "nvidia.com/gpu",
+								Operator: corev1.TolerationOpExists,
+							}},
+							Volumes: []corev1.Volume{{
+								Name: "cache",
+								VolumeSource: corev1.VolumeSource{
+									EmptyDir: &corev1.EmptyDirVolumeSource{},
+								},
+							}},
+						},
+					},
+				},
+			}),
+			want: "1fcd5d7c",
+		},
+		{
+			name: "resources requests limits claims",
+			dgd: legacyWorkerHashDGDFromServices(map[string]*DynamoComponentDeploymentSharedSpec{
+				"worker": {
+					ComponentType: commonconsts.ComponentTypeWorker,
+					Resources: &Resources{
+						Requests: &ResourceItem{CPU: "1", Memory: "4Gi", GPU: "1", GPUType: "nvidia.com/gpu"},
+						Limits:   &ResourceItem{CPU: "2", Memory: "8Gi", GPU: "1"},
+						Claims:   []corev1.ResourceClaim{{Name: "gpu-claim"}},
+					},
+				},
+			}),
+			want: "a4172e4e",
+		},
+		{
+			name: "envs volume mounts secret",
+			dgd: legacyWorkerHashDGDFromServices(map[string]*DynamoComponentDeploymentSharedSpec{
+				"worker": {
+					ComponentType:  commonconsts.ComponentTypeWorker,
+					Envs:           []corev1.EnvVar{{Name: "MODEL", Value: "llama"}},
+					EnvFromSecret:  ptr.To("worker-secret"),
+					VolumeMounts:   []VolumeMount{{Name: "models", MountPoint: "/models", UseAsCompilationCache: true}},
+					SharedMemory:   &SharedMemorySpec{Size: resource.MustParse("2Gi")},
+					LivenessProbe:  &corev1.Probe{InitialDelaySeconds: 5},
+					ReadinessProbe: &corev1.Probe{TimeoutSeconds: 3},
+				},
+			}),
+			want: "a0ceefd2",
+		},
+		{
+			name: "ignored scaling ingress model",
+			dgd: legacyWorkerHashDGDFromServices(map[string]*DynamoComponentDeploymentSharedSpec{
+				"worker": {
+					ComponentType:  commonconsts.ComponentTypeWorker,
+					Annotations:    map[string]string{"ignored": "true"},
+					Labels:         map[string]string{"ignored": "true"},
+					Replicas:       ptr.To(int32(3)),
+					Autoscaling:    &Autoscaling{Enabled: true, MinReplicas: 1, MaxReplicas: 10},
+					Ingress:        &IngressSpec{Enabled: true, Host: "example.com"},
+					ModelRef:       &ModelReference{Name: "model"},
+					ScalingAdapter: &ScalingAdapter{Enabled: true},
+				},
+			}),
+			want: "769fa7c7",
+		},
+		{
+			name: "multinode sidecar checkpoint",
+			dgd: legacyWorkerHashDGDFromServices(map[string]*DynamoComponentDeploymentSharedSpec{
+				"worker": {
+					ComponentType: commonconsts.ComponentTypeWorker,
+					Multinode:     &MultinodeSpec{NodeCount: 2},
+					FrontendSidecar: &FrontendSidecarSpec{
+						Image: "frontend:1",
+						Args:  []string{"--router-mode", "direct"},
+					},
+					Checkpoint: &ServiceCheckpointConfig{Enabled: true},
+				},
+			}),
+			want: "bf66a8e3",
+		},
+		{
+			name: "probe handler",
+			dgd: legacyWorkerHashDGDFromServices(map[string]*DynamoComponentDeploymentSharedSpec{
+				"worker": {
+					ComponentType: commonconsts.ComponentTypeWorker,
+					ReadinessProbe: &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path: "/health",
+								Port: intstr.FromString("http"),
+							},
+						},
+					},
+				},
+			}),
+			want: "8ddbbadc",
+		},
+	}
+}
+
 func TestComputeDGDWorkersSpecHashNil(t *testing.T) {
 	if _, err := ComputeDGDWorkersSpecHash(nil); err == nil {
 		t.Fatal("ComputeDGDWorkersSpecHash(nil) error = nil, want error")
 	}
 }
 
-func TestDGDConvertToPreservesLegacyWorkerHashCompatibleWithControllerHash(t *testing.T) {
+func TestDGDConvertToPreservesWorkerHashAnnotationOpaquely(t *testing.T) {
 	src := legacyWorkerHashDGD()
 	src.Annotations = map[string]string{
-		currentWorkerHashAnnotation: "stale-controller-hash",
+		currentWorkerHashAnnotation: "controller-owned-hash",
+		"user":                      "kept",
 	}
 
-	expected, err := ComputeDGDWorkersSpecHash(src)
-	if err != nil {
-		t.Fatalf("ComputeDGDWorkersSpecHash: %v", err)
-	}
 	hub := &v1beta1.DynamoGraphDeployment{}
 	if err := src.ConvertTo(hub); err != nil {
 		t.Fatalf("ConvertTo: %v", err)
 	}
 
-	got := hub.Annotations[AnnotationDGDLegacyWorkerHash]
-	if got != expected {
-		t.Fatalf("%s = %q, want legacy hash %q", AnnotationDGDLegacyWorkerHash, got, expected)
+	if got := hub.Annotations[currentWorkerHashAnnotation]; got != "controller-owned-hash" {
+		t.Fatalf("%s = %q, want controller-owned-hash", currentWorkerHashAnnotation, got)
 	}
-	if got == src.Annotations[currentWorkerHashAnnotation] {
-		t.Fatalf("%s copied stale %s value instead of recomputing from spec", AnnotationDGDLegacyWorkerHash, currentWorkerHashAnnotation)
-	}
-}
-
-func TestDGDConvertToSkipsLegacyWorkerHashWithoutCurrentWorkerHash(t *testing.T) {
-	src := legacyWorkerHashDGD()
-
-	hub := &v1beta1.DynamoGraphDeployment{}
-	if err := src.ConvertTo(hub); err != nil {
-		t.Fatalf("ConvertTo: %v", err)
-	}
-	if _, ok := hub.Annotations[AnnotationDGDLegacyWorkerHash]; ok {
-		t.Fatalf("unexpected %s annotation without %s trigger: %v", AnnotationDGDLegacyWorkerHash, currentWorkerHashAnnotation, hub.Annotations)
-	}
-}
-
-func TestDGDLegacyWorkerHashTracksPodMetadata(t *testing.T) {
-	baseHash := preservedLegacyWorkerHash(t, legacyWorkerHashDGD())
-
-	mutated := legacyWorkerHashDGDWithPodMetadataChanges()
-
-	if got := preservedLegacyWorkerHash(t, mutated); got == baseHash {
-		t.Fatalf("pod metadata change did not change preserved legacy worker hash: %q", got)
-	}
-}
-
-func TestDGDLegacyWorkerHashIgnoresResourceMetadataAndNonWorkers(t *testing.T) {
-	baseHash := preservedLegacyWorkerHash(t, legacyWorkerHashDGD())
-
-	mutated := legacyWorkerHashDGDWithResourceMetadataAndNonWorkerChanges()
-
-	if got := preservedLegacyWorkerHash(t, mutated); got != baseHash {
-		t.Fatalf("non-pod-template metadata/non-worker changes changed preserved legacy worker hash: got %q, want %q", got, baseHash)
-	}
-}
-
-func TestDGDConvertFromDropsLegacyWorkerHash(t *testing.T) {
-	hub := &v1beta1.DynamoGraphDeployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "legacy-worker-hash",
-			Namespace: "ns",
-			Annotations: map[string]string{
-				AnnotationDGDLegacyWorkerHash: "deadbeef",
-				"user":                        "kept",
-			},
-		},
-		Spec: v1beta1.DynamoGraphDeploymentSpec{
-			Components: []v1beta1.DynamoComponentDeploymentSharedSpec{
-				{
-					ComponentName: "worker",
-					ComponentType: v1beta1.ComponentTypeWorker,
-				},
-			},
-		},
-	}
-
-	spoke := &DynamoGraphDeployment{}
-	if err := spoke.ConvertFrom(hub); err != nil {
-		t.Fatalf("ConvertFrom: %v", err)
-	}
-	if _, ok := spoke.Annotations[AnnotationDGDLegacyWorkerHash]; ok {
-		t.Fatalf("%s leaked back to v1alpha1 annotations: %v", AnnotationDGDLegacyWorkerHash, spoke.Annotations)
-	}
-	if got := spoke.Annotations["user"]; got != "kept" {
+	if got := hub.Annotations["user"]; got != "kept" {
 		t.Fatalf("user annotation = %q, want kept", got)
 	}
 }
 
-func preservedLegacyWorkerHash(t *testing.T, src *DynamoGraphDeployment) string {
-	t.Helper()
-	if src.Annotations == nil {
-		src.Annotations = map[string]string{}
-	}
-	src.Annotations[currentWorkerHashAnnotation] = "existing-controller-hash"
+func TestComputeDGDWorkersSpecHashConversionRoundTripExact(t *testing.T) {
+	alpha := legacyWorkerHashDGDFromServices(map[string]*DynamoComponentDeploymentSharedSpec{
+		"worker": {
+			ComponentType: commonconsts.ComponentTypeWorker,
+			ExtraPodSpec: &ExtraPodSpec{
+				MainContainer: &corev1.Container{Name: commonconsts.MainContainerName},
+			},
+		},
+	})
 
-	expected, err := ComputeDGDWorkersSpecHash(src)
+	directHash, err := ComputeDGDWorkersSpecHash(alpha)
+	if err != nil {
+		t.Fatalf("ComputeDGDWorkersSpecHash(alpha): %v", err)
+	}
+	roundTripHash, err := legacyWorkerHashAfterBetaRoundTrip(alpha)
+	if err != nil {
+		t.Fatalf("legacyWorkerHashAfterBetaRoundTrip: %v", err)
+	}
+
+	if directHash != "0c322ce0" {
+		t.Fatalf("direct alpha hash = %q, want 0c322ce0", directHash)
+	}
+	if roundTripHash != directHash {
+		t.Fatalf("round-tripped alpha hash = %q, want direct alpha hash %q", roundTripHash, directHash)
+	}
+}
+
+func TestComputeDGDWorkersSpecHashConversionRoundTripStableSubset(t *testing.T) {
+	for _, tt := range legacyWorkerHashGoldenCases() {
+		t.Run(tt.name, func(t *testing.T) {
+			roundTripHash, err := legacyWorkerHashAfterBetaRoundTrip(tt.dgd)
+			if err != nil {
+				t.Fatalf("legacyWorkerHashAfterBetaRoundTrip: %v", err)
+			}
+			if roundTripHash != tt.want {
+				t.Fatalf("round-tripped alpha hash = %q, want direct golden %q", roundTripHash, tt.want)
+			}
+		})
+	}
+}
+
+func TestComputeDGDWorkersSpecHashTracksPodMetadata(t *testing.T) {
+	baseHash, err := ComputeDGDWorkersSpecHash(legacyWorkerHashDGD())
 	if err != nil {
 		t.Fatalf("ComputeDGDWorkersSpecHash: %v", err)
 	}
+
+	mutated := legacyWorkerHashDGDWithPodMetadataChanges()
+
+	got, err := ComputeDGDWorkersSpecHash(mutated)
+	if err != nil {
+		t.Fatalf("ComputeDGDWorkersSpecHash: %v", err)
+	}
+	if got == baseHash {
+		t.Fatalf("pod metadata change did not change preserved legacy worker hash: %q", got)
+	}
+}
+
+func TestComputeDGDWorkersSpecHashIgnoresResourceMetadataAndNonWorkers(t *testing.T) {
+	baseHash, err := ComputeDGDWorkersSpecHash(legacyWorkerHashDGD())
+	if err != nil {
+		t.Fatalf("ComputeDGDWorkersSpecHash: %v", err)
+	}
+
+	mutated := legacyWorkerHashDGDWithResourceMetadataAndNonWorkerChanges()
+
+	got, err := ComputeDGDWorkersSpecHash(mutated)
+	if err != nil {
+		t.Fatalf("ComputeDGDWorkersSpecHash: %v", err)
+	}
+	if got != baseHash {
+		t.Fatalf("non-pod-template metadata/non-worker changes changed preserved legacy worker hash: got %q, want %q", got, baseHash)
+	}
+}
+
+func FuzzComputeDGDWorkersSpecHashDeterministic(f *testing.F) {
+	f.Add("worker", "MODEL", "llama", "checksum/config", "base", false)
+	f.Add("prefill", "ROLE", "prefill", "rollout", "v1", true)
+	f.Add("decode", "", "", "", "", false)
+
+	f.Fuzz(func(t *testing.T, componentType, envName, envValue, metadataKey, metadataValue string, includeMainContainer bool) {
+		switch componentType {
+		case commonconsts.ComponentTypeWorker, commonconsts.ComponentTypePrefill, commonconsts.ComponentTypeDecode:
+		default:
+			componentType = commonconsts.ComponentTypeWorker
+		}
+
+		spec := &DynamoComponentDeploymentSharedSpec{
+			ComponentType: componentType,
+			Envs:          []corev1.EnvVar{{Name: envName, Value: envValue}},
+			ExtraPodMetadata: &ExtraPodMetadata{
+				Labels: map[string]string{metadataKey: metadataValue},
+			},
+		}
+		if includeMainContainer {
+			spec.ExtraPodSpec = &ExtraPodSpec{
+				MainContainer: &corev1.Container{Name: commonconsts.MainContainerName, Image: envValue},
+			}
+		}
+
+		dgd := legacyWorkerHashDGDFromServices(map[string]*DynamoComponentDeploymentSharedSpec{
+			"worker": spec,
+		})
+		got1, err := ComputeDGDWorkersSpecHash(dgd)
+		if err != nil {
+			t.Fatalf("ComputeDGDWorkersSpecHash: %v", err)
+		}
+		got2, err := ComputeDGDWorkersSpecHash(dgd)
+		if err != nil {
+			t.Fatalf("second ComputeDGDWorkersSpecHash: %v", err)
+		}
+		if got1 != got2 {
+			t.Fatalf("hash is not deterministic: first %q, second %q", got1, got2)
+		}
+		if len(got1) != 8 {
+			t.Fatalf("hash length = %d, want 8: %q", len(got1), got1)
+		}
+	})
+}
+
+func FuzzComputeDGDWorkersSpecHashConversionRoundTripStableSubset(f *testing.F) {
+	f.Add("worker", "MODEL", "llama", "rollout", "base", "1", "4Gi")
+	f.Add("prefill", "ROLE", "prefill", "checksum", "v1", "", "")
+	f.Add("decode", "", "", "", "", "250m", "1Gi")
+
+	f.Fuzz(func(t *testing.T, componentType, envName, envValue, metadataKey, metadataValue, cpu, memory string) {
+		for _, value := range []string{componentType, envName, envValue, metadataKey, metadataValue, cpu, memory} {
+			if !utf8.ValidString(value) {
+				t.Skip("Kubernetes JSON strings are valid UTF-8")
+			}
+		}
+		if cpu != "" {
+			if _, err := resource.ParseQuantity(cpu); err != nil {
+				t.Skip("invalid CPU quantity")
+			}
+		}
+		if memory != "" {
+			if _, err := resource.ParseQuantity(memory); err != nil {
+				t.Skip("invalid memory quantity")
+			}
+		}
+		switch componentType {
+		case commonconsts.ComponentTypeWorker, commonconsts.ComponentTypePrefill, commonconsts.ComponentTypeDecode:
+		default:
+			componentType = commonconsts.ComponentTypeWorker
+		}
+
+		alpha := legacyWorkerHashDGDFromServices(map[string]*DynamoComponentDeploymentSharedSpec{
+			"worker": {
+				ComponentType: componentType,
+				Envs:          []corev1.EnvVar{{Name: envName, Value: envValue}},
+				ExtraPodMetadata: &ExtraPodMetadata{
+					Labels: map[string]string{metadataKey: metadataValue},
+				},
+				Resources: &Resources{
+					Requests: &ResourceItem{CPU: cpu, Memory: memory},
+				},
+			},
+		})
+
+		directHash, err := ComputeDGDWorkersSpecHash(alpha)
+		if err != nil {
+			t.Fatalf("ComputeDGDWorkersSpecHash(alpha): %v", err)
+		}
+		roundTripHash, err := legacyWorkerHashAfterBetaRoundTrip(alpha)
+		if err != nil {
+			t.Fatalf("legacyWorkerHashAfterBetaRoundTrip: %v", err)
+		}
+		if directHash != roundTripHash {
+			t.Fatalf("round-trip changed stable-subset hash: direct %q, round-trip %q", directHash, roundTripHash)
+		}
+	})
+}
+
+func legacyWorkerHashAfterBetaRoundTrip(src *DynamoGraphDeployment) (string, error) {
 	hub := &v1beta1.DynamoGraphDeployment{}
 	if err := src.ConvertTo(hub); err != nil {
-		t.Fatalf("ConvertTo: %v", err)
+		return "", err
 	}
-	got := hub.Annotations[AnnotationDGDLegacyWorkerHash]
-	if got == "" {
-		t.Fatalf("missing %s annotation in hub annotations: %v", AnnotationDGDLegacyWorkerHash, hub.Annotations)
+
+	roundTripped := &DynamoGraphDeployment{}
+	if err := roundTripped.ConvertFrom(hub); err != nil {
+		return "", err
 	}
-	if got != expected {
-		t.Fatalf("%s = %q, want legacy hash %q", AnnotationDGDLegacyWorkerHash, got, expected)
+	return ComputeDGDWorkersSpecHash(roundTripped)
+}
+
+func legacyWorkerHashDGDFromServices(services map[string]*DynamoComponentDeploymentSharedSpec) *DynamoGraphDeployment {
+	return &DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "legacy-worker-hash",
+			Namespace: "ns",
+		},
+		Spec: DynamoGraphDeploymentSpec{
+			Services: services,
+		},
 	}
-	return got
 }
 
 func legacyWorkerHashDGD() *DynamoGraphDeployment {

--- a/deploy/operator/api/v1alpha1/legacy_worker_hash_test.go
+++ b/deploy/operator/api/v1alpha1/legacy_worker_hash_test.go
@@ -183,6 +183,19 @@ func legacyWorkerHashGoldenCases() []legacyWorkerHashGoldenCase {
 			want: "a0ceefd2",
 		},
 		{
+			name: "multiple compilation cache volume mounts",
+			dgd: legacyWorkerHashDGDFromServices(map[string]*DynamoComponentDeploymentSharedSpec{
+				"worker": {
+					ComponentType: commonconsts.ComponentTypeWorker,
+					VolumeMounts: []VolumeMount{
+						{Name: "model-cache", MountPoint: "/models", UseAsCompilationCache: true},
+						{Name: "compile-cache", MountPoint: "/compile", UseAsCompilationCache: true},
+					},
+				},
+			}),
+			want: "5a3c0f65",
+		},
+		{
 			name: "ignored scaling ingress model",
 			dgd: legacyWorkerHashDGDFromServices(map[string]*DynamoComponentDeploymentSharedSpec{
 				"worker": {

--- a/deploy/operator/api/v1alpha1/shared_spec_conversion.go
+++ b/deploy/operator/api/v1alpha1/shared_spec_conversion.go
@@ -1963,7 +1963,8 @@ func pruneEmptyExtraPodSpec(dst, restored *DynamoComponentDeploymentSharedSpec) 
 	if dst == nil || dst.ExtraPodSpec == nil {
 		return
 	}
-	if containerIsEmpty(dst.ExtraPodSpec.MainContainer) {
+	if containerIsEmpty(dst.ExtraPodSpec.MainContainer) &&
+		!extraPodSpecOnlyPreservesMainContainerName(restoredExtraPodSpec(restored)) {
 		dst.ExtraPodSpec.MainContainer = nil
 	}
 	if extraPodSpecIsZero(dst.ExtraPodSpec) {
@@ -1972,6 +1973,13 @@ func pruneEmptyExtraPodSpec(dst, restored *DynamoComponentDeploymentSharedSpec) 
 		}
 		dst.ExtraPodSpec = nil
 	}
+}
+
+func restoredExtraPodSpec(restored *DynamoComponentDeploymentSharedSpec) *ExtraPodSpec {
+	if restored == nil {
+		return nil
+	}
+	return restored.ExtraPodSpec
 }
 
 func restoreMainContainerFieldOrigins(dst, preserved *DynamoComponentDeploymentSharedSpec, mainContainerPresent bool) {

--- a/deploy/operator/api/v1alpha1/shared_spec_conversion.go
+++ b/deploy/operator/api/v1alpha1/shared_spec_conversion.go
@@ -548,6 +548,7 @@ func ConvertToDynamoComponentDeploymentSharedSpec(src *v1beta1.DynamoComponentDe
 	}
 
 	fillSharedAlphaOnlyFromPreserved(dst, restored, sharedHasMainContainer(src))
+	restoreSharedPreservedFlatVolumeMounts(dst, restored, src)
 	pruneEmptyExtraPodSpec(dst, restored)
 	if save != nil {
 		if err := saveSharedHubOnlySpec(src, dst, save); err != nil {
@@ -912,6 +913,66 @@ func convertVolumeMountsFromHub(src *v1beta1.DynamoComponentDeploymentSharedSpec
 		MountPoint:            src.CompilationCache.MountPath,
 		UseAsCompilationCache: true,
 	}}
+}
+
+// Restore alpha-only cache flags only when live beta still matches their lossy projection.
+func restoreSharedPreservedFlatVolumeMounts(dst, preserved *DynamoComponentDeploymentSharedSpec, src *v1beta1.DynamoComponentDeploymentSharedSpec) {
+	if dst == nil || preserved == nil || src == nil || volumeMountsRoundTripThroughHub(preserved.VolumeMounts) {
+		return
+	}
+	if !firstPreservedCompilationCacheMatches(src.CompilationCache, preserved.VolumeMounts) {
+		return
+	}
+	if !volumeMountsEqual(dst.VolumeMounts, visiblePreservedVolumeMountProjection(src, preserved.VolumeMounts)) {
+		return
+	}
+	dst.VolumeMounts = slices.Clone(preserved.VolumeMounts)
+}
+
+func firstPreservedCompilationCacheMatches(compilationCache *v1beta1.CompilationCacheConfig, mounts []VolumeMount) bool {
+	for _, mount := range mounts {
+		if !mount.UseAsCompilationCache {
+			continue
+		}
+		return compilationCache != nil &&
+			compilationCache.PVCName == mount.Name &&
+			compilationCache.MountPath == mount.MountPoint
+	}
+	return compilationCache == nil
+}
+
+func visiblePreservedVolumeMountProjection(src *v1beta1.DynamoComponentDeploymentSharedSpec, mounts []VolumeMount) []VolumeMount {
+	projected := make([]VolumeMount, 0, len(mounts))
+	firstCompilationCacheSeen := false
+	for _, mount := range mounts {
+		if !mount.UseAsCompilationCache {
+			continue
+		}
+		if firstCompilationCacheSeen {
+			continue
+		}
+		projected = append(projected, mount)
+		firstCompilationCacheSeen = true
+	}
+	if main, ok := sharedMainContainer(src); ok && len(main.VolumeMounts) > 0 {
+		projected = appendMissingVolumeMounts(projected, volumeMountsFromNative(main.VolumeMounts))
+	}
+	return projected
+}
+
+func sharedMainContainer(src *v1beta1.DynamoComponentDeploymentSharedSpec) (corev1.Container, bool) {
+	if src == nil || src.PodTemplate == nil {
+		return corev1.Container{}, false
+	}
+	return findContainerByName(src.PodTemplate.Spec.Containers, mainContainerName)
+}
+
+func volumeMountsEqual(a, b []VolumeMount) bool {
+	return slices.EqualFunc(a, b, func(left, right VolumeMount) bool {
+		return left.Name == right.Name &&
+			left.MountPoint == right.MountPoint &&
+			left.UseAsCompilationCache == right.UseAsCompilationCache
+	})
 }
 
 // ---------------------------------------------------------------------------

--- a/deploy/operator/api/v1alpha1/shared_spec_conversion_bugs_test.go
+++ b/deploy/operator/api/v1alpha1/shared_spec_conversion_bugs_test.go
@@ -193,6 +193,92 @@ func TestBugDGD_SpokeMainContainerNameOnlyRoundTrips(t *testing.T) {
 	}
 }
 
+func TestBugDGD_SpokeMultipleCompilationCacheVolumeMountsRoundTrip(t *testing.T) {
+	in := &DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "multi-cache", Namespace: "ns"},
+		Spec: DynamoGraphDeploymentSpec{
+			Services: map[string]*DynamoComponentDeploymentSharedSpec{
+				"worker": {
+					ComponentType: "worker",
+					VolumeMounts: []VolumeMount{
+						{Name: "model-cache", MountPoint: "/models", UseAsCompilationCache: true},
+						{Name: "compile-cache", MountPoint: "/compile", UseAsCompilationCache: true},
+					},
+				},
+			},
+		},
+	}
+	wantHash, err := ComputeDGDWorkersSpecHash(in)
+	if err != nil {
+		t.Fatalf("ComputeDGDWorkersSpecHash(in) error = %v", err)
+	}
+
+	hub := &v1beta1.DynamoGraphDeployment{}
+	if err := in.ConvertTo(hub); err != nil {
+		t.Fatalf("ConvertTo() error = %v", err)
+	}
+	if len(hub.Spec.Components) != 1 {
+		t.Fatalf("expected one hub component, got %#v", hub.Spec.Components)
+	}
+	if got := hub.Spec.Components[0].CompilationCache; got == nil || got.PVCName != "model-cache" || got.MountPath != "/models" {
+		t.Fatalf("expected first compilation cache to be visible in hub, got %#v", got)
+	}
+	preserved := mustRestoreDGDSpokeServiceSave(t, hub, "worker")
+	if diff := cmp.Diff(in.Spec.Services["worker"].VolumeMounts, preserved.VolumeMounts); diff != "" {
+		t.Fatalf("expected sparse save to preserve alpha volume mounts (-want +got):\n%s", diff)
+	}
+
+	out := &DynamoGraphDeployment{}
+	if err := out.ConvertFrom(hub); err != nil {
+		t.Fatalf("ConvertFrom() error = %v", err)
+	}
+	if diff := cmp.Diff(in.Spec.Services["worker"].VolumeMounts, out.Spec.Services["worker"].VolumeMounts); diff != "" {
+		t.Fatalf("volume mounts changed after round-trip (-want +got):\n%s", diff)
+	}
+	gotHash, err := ComputeDGDWorkersSpecHash(out)
+	if err != nil {
+		t.Fatalf("ComputeDGDWorkersSpecHash(out) error = %v", err)
+	}
+	if gotHash != wantHash {
+		t.Fatalf("round-trip worker hash = %q, want %q", gotHash, wantHash)
+	}
+}
+
+func TestBugDGD_ChangedCompilationCacheDoesNotRestoreStaleVolumeMounts(t *testing.T) {
+	in := &DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "multi-cache-edited", Namespace: "ns"},
+		Spec: DynamoGraphDeploymentSpec{
+			Services: map[string]*DynamoComponentDeploymentSharedSpec{
+				"worker": {
+					ComponentType: "worker",
+					VolumeMounts: []VolumeMount{
+						{Name: "model-cache", MountPoint: "/models", UseAsCompilationCache: true},
+						{Name: "compile-cache", MountPoint: "/compile", UseAsCompilationCache: true},
+					},
+				},
+			},
+		},
+	}
+
+	hub := &v1beta1.DynamoGraphDeployment{}
+	if err := in.ConvertTo(hub); err != nil {
+		t.Fatalf("ConvertTo() error = %v", err)
+	}
+	hub.Spec.Components[0].CompilationCache = &v1beta1.CompilationCacheConfig{
+		PVCName:   "new-cache",
+		MountPath: "/new-cache",
+	}
+
+	out := &DynamoGraphDeployment{}
+	if err := out.ConvertFrom(hub); err != nil {
+		t.Fatalf("ConvertFrom() error = %v", err)
+	}
+	want := []VolumeMount{{Name: "new-cache", MountPoint: "/new-cache", UseAsCompilationCache: true}}
+	if diff := cmp.Diff(want, out.Spec.Services["worker"].VolumeMounts); diff != "" {
+		t.Fatalf("stale preserved volume mounts were restored (-want +got):\n%s", diff)
+	}
+}
+
 func TestBugDGD_HubOriginSpokeMainContainerEnvSplitRoundTrips(t *testing.T) {
 	hub := &v1beta1.DynamoGraphDeployment{
 		ObjectMeta: metav1.ObjectMeta{Name: "main-container-env-split", Namespace: "ns"},

--- a/deploy/operator/api/v1alpha1/shared_spec_conversion_bugs_test.go
+++ b/deploy/operator/api/v1alpha1/shared_spec_conversion_bugs_test.go
@@ -149,6 +149,50 @@ func TestBugDGD_HubEmptyPodTemplateRoundTrips(t *testing.T) {
 	}
 }
 
+func TestBugDGD_SpokeMainContainerNameOnlyRoundTrips(t *testing.T) {
+	in := &DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "main-container-name-only", Namespace: "ns"},
+		Spec: DynamoGraphDeploymentSpec{
+			Services: map[string]*DynamoComponentDeploymentSharedSpec{
+				"worker": {
+					ComponentType: "worker",
+					ExtraPodSpec: &ExtraPodSpec{
+						MainContainer: &corev1.Container{Name: mainContainerName},
+					},
+				},
+			},
+		},
+	}
+	wantHash, err := ComputeDGDWorkersSpecHash(in)
+	if err != nil {
+		t.Fatalf("ComputeDGDWorkersSpecHash(in) error = %v", err)
+	}
+
+	hub := &v1beta1.DynamoGraphDeployment{}
+	if err := in.ConvertTo(hub); err != nil {
+		t.Fatalf("ConvertTo() error = %v", err)
+	}
+	out := &DynamoGraphDeployment{}
+	if err := out.ConvertFrom(hub); err != nil {
+		t.Fatalf("ConvertFrom() error = %v", err)
+	}
+
+	got := out.Spec.Services["worker"]
+	if got == nil || got.ExtraPodSpec == nil || got.ExtraPodSpec.MainContainer == nil {
+		t.Fatalf("mainContainer was lost after round-trip: %#v", got)
+	}
+	if got.ExtraPodSpec.MainContainer.Name != mainContainerName {
+		t.Fatalf("mainContainer.name = %q, want %q", got.ExtraPodSpec.MainContainer.Name, mainContainerName)
+	}
+	gotHash, err := ComputeDGDWorkersSpecHash(out)
+	if err != nil {
+		t.Fatalf("ComputeDGDWorkersSpecHash(out) error = %v", err)
+	}
+	if gotHash != wantHash {
+		t.Fatalf("round-trip worker hash = %q, want %q", gotHash, wantHash)
+	}
+}
+
 func TestBugDGD_HubOriginSpokeMainContainerEnvSplitRoundTrips(t *testing.T) {
 	hub := &v1beta1.DynamoGraphDeployment{
 		ObjectMeta: metav1.ObjectMeta{Name: "main-container-env-split", Namespace: "ns"},

--- a/deploy/operator/internal/consts/consts.go
+++ b/deploy/operator/internal/consts/consts.go
@@ -56,7 +56,12 @@ const (
 	KubeAnnotationDynamoBaseModel      = "nvidia.com/dynamo-base-model"
 	KubeLabelDynamoDiscoveryBackend    = "nvidia.com/dynamo-discovery-backend"
 	KubeLabelDynamoDiscoveryEnabled    = "nvidia.com/dynamo-discovery-enabled"
-	KubeLabelDynamoWorkerHash          = "nvidia.com/dynamo-worker-hash"
+	// KubeLabelDynamoWorkerHash is the worker generation label on worker DCDs
+	// and worker pods. During v1/v2 hash compatibility the label key remains
+	// stable and the value may be either the active v1 hash or the active v2 hash
+	// recorded on the parent DGD. Older operators understand only the v1 value,
+	// so v1-compatible releases continue to generate new DCDs with the v1 value.
+	KubeLabelDynamoWorkerHash = "nvidia.com/dynamo-worker-hash"
 
 	KubeLabelValueFalse = "false"
 	KubeLabelValueTrue  = "true"
@@ -172,39 +177,30 @@ const (
 	PodInfoFileDynParentDGDNamespace    = "dyn_parent_dgd_k8s_namespace"
 
 	// Worker hash rolling-update annotations are controller-owned annotations on
-	// DynamoGraphDeployment. They record the active worker generation used by
-	// generated worker DynamoComponentDeployments and must not be treated as
-	// user-configurable inputs. During a managed rolling update, the current hash
-	// remains the previously serving worker generation until the new generation is
-	// fully ready and the old generation has been drained.
+	// DynamoGraphDeployment. They record the active worker generation and must not
+	// be treated as user-configurable inputs. During a managed rolling update,
+	// these annotations remain on the previously serving worker generation until
+	// the new generation is fully ready and old workers have drained.
+	//
+	// The compatibility contract is intentionally additive: existing annotation
+	// and label keys keep their old meaning. AnnotationCurrentWorkerHash stores
+	// the v1alpha1-compatible worker hash so a downgrade can still understand the
+	// active generation. AnnotationCurrentWorkerHashV2 stores the v2 worker hash
+	// for the same active generation. A worker DCD whose
+	// KubeLabelDynamoWorkerHash value matches either annotation is current. While
+	// v1 compatibility is required, generated worker DCDs use the v1 hash as the
+	// label value. If a worker change is visible only to v2, the controller
+	// removes the v1 annotation and rolls to a v2-labeled DCD because the v1 hash
+	// can no longer prove pod-template compatibility. A future v2-only release
+	// can start using the v2 value with the same label key and keep accepting the
+	// v1 annotation until the next v2 generation change drains old workers.
 
-	// AnnotationCurrentWorkerHash stores the active worker generation hash. On
-	// first reconcile it is initialized from the desired worker spec. During a
-	// rolling update it remains the previous active hash and is only moved to the
-	// new hash when the rolling update completes.
+	// AnnotationCurrentWorkerHash stores the active v1alpha1-compatible worker
+	// generation hash.
 	AnnotationCurrentWorkerHash = "nvidia.com/current-worker-hash"
 
-	// AnnotationCurrentWorkerHashVersion identifies the algorithm used to produce
-	// AnnotationCurrentWorkerHash. Missing or unknown versions are legacy state
-	// that must be migrated before the controller can rely on v2-only rollout
-	// comparisons.
-	AnnotationCurrentWorkerHashVersion = "nvidia.com/current-worker-hash-version"
-
-	// AnnotationCurrentWorkerHashEquivalentV1 stores the one-time legacy
-	// v1alpha1 hash equivalent for AnnotationCurrentWorkerHash after the active
-	// hash has been migrated to v2. While present, it is an alias for already
-	// running worker DCDs named/labeled with the old hash, so a v1alpha1 ->
-	// v1beta1 no-op upgrade can reuse those resources. The controller clears it
-	// as soon as the desired v2 hash changes or a rolling update completes.
-	AnnotationCurrentWorkerHashEquivalentV1 = "nvidia.com/current-worker-hash-equivalent-v1"
-
-	// CurrentWorkerHashVersionV1Alpha1 marks an active worker hash computed with
-	// the legacy v1alpha1-compatible worker spec hash algorithm.
-	CurrentWorkerHashVersionV1Alpha1 = "v1alpha1"
-
-	// CurrentWorkerHashVersionV2 marks an active worker hash computed with the
-	// current v1beta1 worker spec hash algorithm.
-	CurrentWorkerHashVersionV2 = "v2"
+	// AnnotationCurrentWorkerHashV2 stores the active v2 worker generation hash.
+	AnnotationCurrentWorkerHashV2 = "nvidia.com/current-worker-hash-v2"
 
 	// LegacyWorkerHash is a sentinel value used during migration from pre-rolling-update
 	// operator versions. Legacy worker DCDs (those without a worker hash label) are tagged

--- a/deploy/operator/internal/consts/consts.go
+++ b/deploy/operator/internal/consts/consts.go
@@ -49,13 +49,20 @@ const (
 	KubeLabelDynamoGraphDeploymentName = "nvidia.com/dynamo-graph-deployment-name"
 	KubeLabelDynamoComponent           = "nvidia.com/dynamo-component"
 	KubeLabelDynamoNamespace           = "nvidia.com/dynamo-namespace"
-	KubeLabelDynamoComponentType       = "nvidia.com/dynamo-component-type"
-	KubeLabelDynamoSubComponentType    = "nvidia.com/dynamo-sub-component-type"
-	KubeLabelDynamoBaseModel           = "nvidia.com/dynamo-base-model"
-	KubeLabelDynamoBaseModelHash       = "nvidia.com/dynamo-base-model-hash"
-	KubeAnnotationDynamoBaseModel      = "nvidia.com/dynamo-base-model"
-	KubeLabelDynamoDiscoveryBackend    = "nvidia.com/dynamo-discovery-backend"
-	KubeLabelDynamoDiscoveryEnabled    = "nvidia.com/dynamo-discovery-enabled"
+	// KubeLabelDynamoComponentType is the workload selector contract stamped on
+	// DCDs and rendered onto pods/services. Native v1beta1 prefill/decode worker
+	// DCDs use "prefill" or "decode". A DCD generation that is already serving
+	// alpha-era selectors uses "worker" and pairs it with
+	// KubeLabelDynamoSubComponentType so a no-op upgrade keeps matching existing
+	// pods. This selector contract is separate from worker-hash currentness:
+	// matching current-worker-hash does not imply legacy selectors.
+	KubeLabelDynamoComponentType    = "nvidia.com/dynamo-component-type"
+	KubeLabelDynamoSubComponentType = "nvidia.com/dynamo-sub-component-type"
+	KubeLabelDynamoBaseModel        = "nvidia.com/dynamo-base-model"
+	KubeLabelDynamoBaseModelHash    = "nvidia.com/dynamo-base-model-hash"
+	KubeAnnotationDynamoBaseModel   = "nvidia.com/dynamo-base-model"
+	KubeLabelDynamoDiscoveryBackend = "nvidia.com/dynamo-discovery-backend"
+	KubeLabelDynamoDiscoveryEnabled = "nvidia.com/dynamo-discovery-enabled"
 	// KubeLabelDynamoWorkerHash is the worker generation label on worker DCDs
 	// and worker pods. During v1/v2 hash compatibility the label key remains
 	// stable and the value may be either the active v1 hash or the active v2 hash

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
@@ -1134,72 +1134,68 @@ func (r *DynamoComponentDeploymentReconciler) getDCDWorkloadComponentType(
 		return componentType, nil
 	}
 
-	// Decode/prefill are the current v1beta1 workload-facing worker types. When
-	// their DCD hash is still aliased to a legacy-compatible generation, keep
-	// rendering pod labels/env and service selectors as "worker" so a no-op
-	// upgrade keeps matching the already-running v1alpha1 worker pods.
+	// Decode/prefill are the current v1beta1 workload-facing worker types. If
+	// this DCD generation is already serving with legacy v1alpha1 worker
+	// selectors, keep rendering pod labels/env and service selectors as
+	// "worker" so a no-op upgrade keeps matching already-running pods.
 	labels := dcd.GetLabels()
 	workerHash := labels[commonconsts.KubeLabelDynamoWorkerHash]
 	if workerHash == "" {
 		return componentType, nil
 	}
-	if labels[commonconsts.KubeLabelDynamoSubComponentType] != componentType {
-		return componentType, nil
+	if hasLegacyWorkerSelector(labels, componentType) {
+		return commonconsts.ComponentTypeWorker, nil
 	}
 
-	parentDGD, ok, err := r.getParentDGD(ctx, dcd)
+	legacy, err := r.hasExistingLegacyWorkerSelector(ctx, dcd, componentType)
 	if err != nil {
 		return "", err
 	}
-	if !ok {
-		return componentType, nil
-	}
-
-	if dgdHasLegacyCompatibleWorkerHash(parentDGD, workerHash) {
+	if legacy {
 		return commonconsts.ComponentTypeWorker, nil
 	}
 
 	return componentType, nil
 }
 
-func (r *DynamoComponentDeploymentReconciler) getParentDGD(
+func (r *DynamoComponentDeploymentReconciler) hasExistingLegacyWorkerSelector(
 	ctx context.Context,
 	dcd *nvidiacomv1beta1.DynamoComponentDeployment,
-) (*nvidiacomv1beta1.DynamoGraphDeployment, bool, error) {
+	componentType string,
+) (bool, error) {
 	if dcd == nil || r == nil || r.Client == nil {
-		return nil, false, nil
-	}
-	labels := dcd.GetLabels()
-	parentDGDName := dcd.GetParentGraphDeploymentName()
-	if parentDGDName == "" {
-		parentDGDName = labels[commonconsts.KubeLabelDynamoGraphDeploymentName]
-	}
-	if parentDGDName == "" {
-		return nil, false, nil
+		return false, nil
 	}
 
-	parentDGD := &nvidiacomv1beta1.DynamoGraphDeployment{}
-	if err := r.Get(ctx, types.NamespacedName{Name: parentDGDName, Namespace: dcd.Namespace}, parentDGD); err != nil {
-		if k8serrors.IsNotFound(err) {
-			return nil, false, nil
+	deployment := &appsv1.Deployment{}
+	if err := r.Get(ctx, types.NamespacedName{Name: dcd.Name, Namespace: dcd.Namespace}, deployment); err == nil {
+		if hasLegacyWorkerSelector(deployment.Spec.Template.Labels, componentType) {
+			return true, nil
 		}
-		return nil, false, fmt.Errorf("failed to get parent DynamoGraphDeployment %s/%s: %w", dcd.Namespace, parentDGDName, err)
+	} else if !k8serrors.IsNotFound(err) {
+		return false, fmt.Errorf("failed to get deployment %s/%s: %w", dcd.Namespace, dcd.Name, err)
 	}
-	return parentDGD, true, nil
+
+	serviceName := dynamo.NormalizeKubeResourceName(dcd.Name)
+	service := &corev1.Service{}
+	if err := r.Get(ctx, types.NamespacedName{Name: serviceName, Namespace: dcd.Namespace}, service); err == nil {
+		return hasLegacyWorkerSelector(service.Spec.Selector, componentType), nil
+	} else if !k8serrors.IsNotFound(err) {
+		return false, fmt.Errorf("failed to get service %s/%s: %w", dcd.Namespace, serviceName, err)
+	}
+
+	return false, nil
 }
 
-// dgdHasLegacyCompatibleWorkerHash reports whether workerHash is an old
-// v1alpha1 worker generation that is still recorded by the parent DGD.
-// This lets DCD rendering preserve legacy workload selectors without patching
-// existing DCDs to v2 labels in place.
-func dgdHasLegacyCompatibleWorkerHash(
-	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
-	workerHash string,
-) bool {
-	if dgd == nil || workerHash == "" || dgd.Annotations == nil {
+func hasLegacyWorkerSelector(labels map[string]string, componentType string) bool {
+	if labels[commonconsts.KubeLabelDynamoComponentType] != commonconsts.ComponentTypeWorker {
 		return false
 	}
-	return dgd.Annotations[commonconsts.AnnotationCurrentWorkerHash] == workerHash
+	if componentType != commonconsts.ComponentTypePrefill && componentType != commonconsts.ComponentTypeDecode {
+		return false
+	}
+	subComponentType := labels[commonconsts.KubeLabelDynamoSubComponentType]
+	return subComponentType == "" || subComponentType == componentType
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
@@ -1143,6 +1143,9 @@ func (r *DynamoComponentDeploymentReconciler) getDCDWorkloadComponentType(
 	if workerHash == "" {
 		return componentType, nil
 	}
+	if labels[commonconsts.KubeLabelDynamoSubComponentType] != componentType {
+		return componentType, nil
+	}
 
 	parentDGD, ok, err := r.getParentDGD(ctx, dcd)
 	if err != nil {
@@ -1186,7 +1189,7 @@ func (r *DynamoComponentDeploymentReconciler) getParentDGD(
 }
 
 // dgdHasLegacyCompatibleWorkerHash reports whether workerHash is an old
-// v1alpha1 worker generation that is still explicitly aliased by the parent DGD.
+// v1alpha1 worker generation that is still recorded by the parent DGD.
 // This lets DCD rendering preserve legacy workload selectors without patching
 // existing DCDs to v2 labels in place.
 func dgdHasLegacyCompatibleWorkerHash(
@@ -1196,25 +1199,7 @@ func dgdHasLegacyCompatibleWorkerHash(
 	if dgd == nil || workerHash == "" || dgd.Annotations == nil {
 		return false
 	}
-
-	if dgd.Annotations[commonconsts.AnnotationCurrentWorkerHashVersion] == commonconsts.CurrentWorkerHashVersionV2 {
-		// In migrated state the DGD's active hash is v2. The only old-hash DCDs
-		// that should keep legacy "worker" selectors are those explicitly named
-		// by current-worker-hash-equivalent-v1.
-		return dgd.Annotations[commonconsts.AnnotationCurrentWorkerHashEquivalentV1] == workerHash
-	}
-
-	if dgd.Annotations[commonconsts.AnnotationCurrentWorkerHash] != workerHash {
-		return false
-	}
-	if dynamo.GetPreservedLegacyAlphaDGDWorkersSpecHash(dgd) == workerHash {
-		// Pre-migration window: conversion preserved the old alpha hash but the
-		// DGD has not yet been updated to v2 bookkeeping. Honor the old DCD
-		// selector shape until migrateCurrentWorkerHashIfNeeded records the alias.
-		return true
-	}
-
-	return false
+	return dgd.Annotations[commonconsts.AnnotationCurrentWorkerHash] == workerHash
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -605,6 +605,7 @@ func TestDynamoComponentDeploymentReconciler_generateService_DottedDeleteStub(t 
 func TestDynamoComponentDeploymentReconciler_LegacyAlphaWorkloadComponentType(t *testing.T) {
 	s := scheme.Scheme
 	require.NoError(t, v1alpha1.AddToScheme(s))
+	require.NoError(t, appsv1.AddToScheme(s))
 	require.NoError(t, corev1.AddToScheme(s))
 
 	dcd := betaDCD(t, &v1alpha1.DynamoComponentDeployment{
@@ -615,7 +616,6 @@ func TestDynamoComponentDeploymentReconciler_LegacyAlphaWorkloadComponentType(t 
 				commonconsts.KubeLabelDynamoGraphDeploymentName: "qwen",
 				commonconsts.KubeLabelDynamoWorkerHash:          "db6b6891",
 				commonconsts.KubeLabelDynamoComponentType:       commonconsts.ComponentTypeDecode,
-				commonconsts.KubeLabelDynamoSubComponentType:    commonconsts.ComponentTypeDecode,
 			},
 		},
 		Spec: v1alpha1.DynamoComponentDeploymentSpec{
@@ -636,13 +636,19 @@ func TestDynamoComponentDeploymentReconciler_LegacyAlphaWorkloadComponentType(t 
 	})
 	require.Equal(t, v1beta1.ComponentTypeDecode, dcd.Spec.ComponentType)
 
-	parentDGD := &v1beta1.DynamoGraphDeployment{
+	existingDeployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "qwen",
+			Name:      "qwen-vllmdecodeworker-db6b6891",
 			Namespace: "default",
-			Annotations: map[string]string{
-				commonconsts.AnnotationCurrentWorkerHash:   "db6b6891",
-				commonconsts.AnnotationCurrentWorkerHashV2: "ea91a23f",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						commonconsts.KubeLabelDynamoComponentType:    commonconsts.ComponentTypeWorker,
+						commonconsts.KubeLabelDynamoSubComponentType: commonconsts.ComponentTypeDecode,
+					},
+				},
 			},
 		},
 	}
@@ -650,7 +656,7 @@ func TestDynamoComponentDeploymentReconciler_LegacyAlphaWorkloadComponentType(t 
 	r := &DynamoComponentDeploymentReconciler{
 		Client: fake.NewClientBuilder().
 			WithScheme(s).
-			WithObjects(dcd, parentDGD).
+			WithObjects(dcd, existingDeployment).
 			Build(),
 		Config: &configv1alpha1.OperatorConfiguration{
 			Discovery: configv1alpha1.DiscoveryConfiguration{Backend: configv1alpha1.DiscoveryBackendKubernetes},

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -641,9 +641,8 @@ func TestDynamoComponentDeploymentReconciler_LegacyAlphaWorkloadComponentType(t 
 			Name:      "qwen",
 			Namespace: "default",
 			Annotations: map[string]string{
-				commonconsts.AnnotationCurrentWorkerHash:             "ea91a23f",
-				commonconsts.AnnotationCurrentWorkerHashVersion:      commonconsts.CurrentWorkerHashVersionV2,
-				commonconsts.AnnotationCurrentWorkerHashEquivalentV1: "db6b6891",
+				commonconsts.AnnotationCurrentWorkerHash:   "db6b6891",
+				commonconsts.AnnotationCurrentWorkerHashV2: "ea91a23f",
 			},
 		},
 	}
@@ -683,6 +682,77 @@ func TestDynamoComponentDeploymentReconciler_LegacyAlphaWorkloadComponentType(t 
 	require.NoError(t, err)
 	require.False(t, toDelete)
 	require.Equal(t, commonconsts.ComponentTypeWorker, service.Spec.Selector[commonconsts.KubeLabelDynamoComponentType])
+}
+
+func TestDynamoComponentDeploymentReconciler_BetaPrefillWorkloadComponentType(t *testing.T) {
+	s := scheme.Scheme
+	require.NoError(t, v1beta1.AddToScheme(s))
+	require.NoError(t, corev1.AddToScheme(s))
+
+	dcd := &v1beta1.DynamoComponentDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "qwen-prefill-db6b6891",
+			Namespace: "default",
+			Labels: map[string]string{
+				commonconsts.KubeLabelDynamoGraphDeploymentName: "qwen",
+				commonconsts.KubeLabelDynamoWorkerHash:          "db6b6891",
+				commonconsts.KubeLabelDynamoComponentType:       commonconsts.ComponentTypePrefill,
+			},
+		},
+		Spec: v1beta1.DynamoComponentDeploymentSpec{
+			BackendFramework: string(dynamo.BackendFrameworkVLLM),
+			DynamoComponentDeploymentSharedSpec: v1beta1.DynamoComponentDeploymentSharedSpec{
+				ComponentName: "prefill",
+				ComponentType: v1beta1.ComponentTypePrefill,
+				PodTemplate:   &corev1.PodTemplateSpec{},
+			},
+		},
+	}
+
+	parentDGD := &v1beta1.DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "qwen",
+			Namespace: "default",
+			Annotations: map[string]string{
+				commonconsts.AnnotationCurrentWorkerHash:   "db6b6891",
+				commonconsts.AnnotationCurrentWorkerHashV2: "ea91a23f",
+			},
+		},
+	}
+
+	r := &DynamoComponentDeploymentReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(s).
+			WithObjects(dcd, parentDGD).
+			Build(),
+		Config: &configv1alpha1.OperatorConfiguration{
+			Discovery: configv1alpha1.DiscoveryConfiguration{Backend: configv1alpha1.DiscoveryBackendKubernetes},
+		},
+		DockerSecretRetriever: &mockDockerSecretRetriever{
+			GetSecretsFunc: func(namespace, imageName string) ([]string, error) {
+				return nil, nil
+			},
+		},
+	}
+
+	podTemplate, err := r.generatePodTemplateSpec(
+		context.Background(),
+		generateResourceOption{dynamoComponentDeployment: dcd},
+		dynamo.RoleMain,
+	)
+	require.NoError(t, err)
+	require.Equal(t, commonconsts.ComponentTypePrefill, podTemplate.Labels[commonconsts.KubeLabelDynamoComponentType])
+
+	env := map[string]string{}
+	for _, item := range podTemplate.Spec.Containers[0].Env {
+		env[item.Name] = item.Value
+	}
+	require.Equal(t, commonconsts.ComponentTypePrefill, env[commonconsts.DynamoComponentEnvVar])
+
+	service, toDelete, err := r.generateService(context.Background(), generateResourceOption{dynamoComponentDeployment: dcd})
+	require.NoError(t, err)
+	require.False(t, toDelete)
+	require.Equal(t, commonconsts.ComponentTypePrefill, service.Spec.Selector[commonconsts.KubeLabelDynamoComponentType])
 }
 
 func TestDynamoComponentDeploymentReconciler_getKubeAnnotations_DropsOperatorOriginVersion(t *testing.T) {

--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -222,15 +222,15 @@ func (r *DynamoGraphDeploymentReconciler) Reconcile(ctx context.Context, req ctr
 			}
 		}
 	} else {
-		if r.getCurrentWorkerHash(dynamoDeployment) == "" {
-			hash, err := nvidiacomv1beta1.ComputeDGDWorkersSpecHash(dynamoDeployment)
+		if r.currentWorkerHashes(dynamoDeployment).empty() {
+			hashes, err := r.desiredWorkerHashes(dynamoDeployment)
 			if err != nil {
 				logger.Error(err, "Failed to compute worker hash for unsupported pathway")
 				reason = reasonFailedToInitializeWorkerHash
 				message = Message(err.Error())
 				return ctrl.Result{}, err
 			}
-			r.setCurrentWorkerHash(dynamoDeployment, hash)
+			r.setCurrentWorkerHashes(dynamoDeployment, hashes)
 			if updateErr := r.Update(ctx, dynamoDeployment); updateErr != nil {
 				logger.Error(updateErr, "Failed to initialize worker hash for unsupported pathway")
 				reason = reasonFailedToInitializeWorkerHash
@@ -256,7 +256,7 @@ func (r *DynamoGraphDeploymentReconciler) Reconcile(ctx context.Context, req ctr
 				"Worker spec changed but custom rolling updates are not supported for Grove/multinode deployments")
 
 			// Update the hash to prevent repeated warnings
-			hash, err := nvidiacomv1beta1.ComputeDGDWorkersSpecHash(dynamoDeployment)
+			hashes, err := r.desiredWorkerHashes(dynamoDeployment)
 			if err != nil {
 				logger.Error(err, "Failed to compute worker hash for unsupported pathway")
 				state = nvidiacomv1beta1.DGDStateFailed
@@ -264,7 +264,7 @@ func (r *DynamoGraphDeploymentReconciler) Reconcile(ctx context.Context, req ctr
 				message = Message(err.Error())
 				return ctrl.Result{}, err
 			}
-			r.setCurrentWorkerHash(dynamoDeployment, hash)
+			r.setCurrentWorkerHashes(dynamoDeployment, hashes)
 			if updateErr := r.Update(ctx, dynamoDeployment); updateErr != nil {
 				logger.Error(updateErr, "Failed to update worker hash for unsupported pathway")
 			}
@@ -1103,8 +1103,26 @@ func (r *DynamoGraphDeploymentReconciler) computeRestartStatus(ctx context.Conte
 
 // checkComponentFullyUpdated checks if a DynamoComponentDeployment is fully updated.
 func (r *DynamoGraphDeploymentReconciler) checkComponentFullyUpdated(ctx context.Context, dgd *nvidiacomv1beta1.DynamoGraphDeployment, componentName string) (bool, string) {
-	resourceName := dynamo.GetDCDResourceName(dgd, componentName, r.getCurrentWorkerHash(dgd))
-	return checkDCDReady(ctx, r.Client, resourceName, dgd.Namespace)
+	if r.currentWorkerHashes(dgd).empty() {
+		resourceName := dynamo.GetDCDResourceName(dgd, componentName, "")
+		return checkDCDReady(ctx, r.Client, resourceName, dgd.Namespace)
+	}
+
+	hashes, err := r.desiredWorkerHashes(dgd)
+	if err != nil {
+		return false, err.Error()
+	}
+
+	var lastReason string
+	for _, hash := range r.activeWorkerHashCandidates(dgd, hashes) {
+		resourceName := dynamo.GetDCDResourceName(dgd, componentName, hash)
+		ready, reason := checkDCDReady(ctx, r.Client, resourceName, dgd.Namespace)
+		if ready || reason != "resource not found" {
+			return ready, reason
+		}
+		lastReason = reason
+	}
+	return false, lastReason
 }
 
 // checkDCDReady checks if a DynamoComponentDeployment has completed its restart.
@@ -1285,24 +1303,29 @@ func (r *DynamoGraphDeploymentReconciler) reconcileDynamoComponentsDeployments(c
 func (r *DynamoGraphDeploymentReconciler) getExistingRestartAnnotationsDCD(ctx context.Context, dgd *nvidiacomv1beta1.DynamoGraphDeployment) (map[string]string, error) {
 	logger := log.FromContext(ctx)
 
-	computedHash, err := nvidiacomv1beta1.ComputeDGDWorkersSpecHash(dgd)
+	hashes, err := r.desiredWorkerHashes(dgd)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compute worker hash: %w", err)
+		return nil, err
 	}
-	workerHash := r.activeWorkerHashForDCDGeneration(dgd, computedHash)
+	workerHashes := r.activeWorkerHashCandidates(dgd, hashes)
 
 	restartAnnotations := make(map[string]string)
 	for i := range dgd.Spec.Components {
 		componentName := dgd.Spec.Components[i].ComponentName
-		dcdName := dynamo.GetDCDResourceName(dgd, componentName, workerHash)
 		existingDCD := &nvidiacomv1beta1.DynamoComponentDeployment{}
-		err := r.Get(ctx, types.NamespacedName{Name: dcdName, Namespace: dgd.Namespace}, existingDCD)
+		for _, workerHash := range workerHashes {
+			dcdName := dynamo.GetDCDResourceName(dgd, componentName, workerHash)
+			err := r.Get(ctx, types.NamespacedName{Name: dcdName, Namespace: dgd.Namespace}, existingDCD)
 
-		if err != nil && !errors.IsNotFound(err) {
-			return nil, fmt.Errorf("failed to get DynamoComponentDeployment: %w", err)
-		}
-		if errors.IsNotFound(err) {
+			if err == nil {
+				break
+			}
+			if !errors.IsNotFound(err) {
+				return nil, fmt.Errorf("failed to get DynamoComponentDeployment: %w", err)
+			}
 			logger.Info("DynamoComponentDeployment not found", "dcdName", dcdName)
+		}
+		if existingDCD.Name == "" {
 			continue
 		}
 		if restartAt := dynamo.GetPodTemplateAnnotations(&existingDCD.Spec.DynamoComponentDeploymentSharedSpec)[consts.RestartAnnotation]; restartAt != "" {

--- a/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
@@ -2326,7 +2326,7 @@ func Test_reconcileDynamoComponentsDeployments(t *testing.T) {
 				}),
 				betaDCD(t, &v1alpha1.DynamoComponentDeployment{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-dgd-decode-e7884bce",
+						Name:      "test-dgd-decode-e1f2a6fe",
 						Namespace: "default",
 					},
 					Spec: v1alpha1.DynamoComponentDeploymentSpec{
@@ -2345,7 +2345,7 @@ func Test_reconcileDynamoComponentsDeployments(t *testing.T) {
 						},
 						Service: &v1alpha1.ServiceReplicaStatus{
 							ComponentKind:     v1alpha1.ComponentKindDeployment,
-							ComponentNames:    []string{"test-dgd-decode-e7884bce-deployment"},
+							ComponentNames:    []string{"test-dgd-decode-e1f2a6fe-deployment"},
 							Replicas:          2,
 							UpdatedReplicas:   2,
 							ReadyReplicas:     ptr.To(int32(2)),
@@ -2355,7 +2355,7 @@ func Test_reconcileDynamoComponentsDeployments(t *testing.T) {
 				}),
 				betaDCD(t, &v1alpha1.DynamoComponentDeployment{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-dgd-prefill-e7884bce",
+						Name:      "test-dgd-prefill-e1f2a6fe",
 						Namespace: "default",
 					},
 					Spec: v1alpha1.DynamoComponentDeploymentSpec{
@@ -2374,7 +2374,7 @@ func Test_reconcileDynamoComponentsDeployments(t *testing.T) {
 						},
 						Service: &v1alpha1.ServiceReplicaStatus{
 							ComponentKind:     v1alpha1.ComponentKindDeployment,
-							ComponentNames:    []string{"test-dgd-prefill-e7884bce-deployment"},
+							ComponentNames:    []string{"test-dgd-prefill-e1f2a6fe-deployment"},
 							Replicas:          3,
 							UpdatedReplicas:   3,
 							ReadyReplicas:     ptr.To(int32(3)),
@@ -2398,7 +2398,7 @@ func Test_reconcileDynamoComponentsDeployments(t *testing.T) {
 					},
 					"decode": {
 						ComponentKind:     v1beta1.ComponentKindDeployment,
-						ComponentNames:    []string{"test-dgd-decode-e7884bce-deployment"},
+						ComponentNames:    []string{"test-dgd-decode-e1f2a6fe-deployment"},
 						Replicas:          2,
 						UpdatedReplicas:   2,
 						ReadyReplicas:     ptr.To(int32(2)),
@@ -2406,7 +2406,7 @@ func Test_reconcileDynamoComponentsDeployments(t *testing.T) {
 					},
 					"prefill": {
 						ComponentKind:     v1beta1.ComponentKindDeployment,
-						ComponentNames:    []string{"test-dgd-prefill-e7884bce-deployment"},
+						ComponentNames:    []string{"test-dgd-prefill-e1f2a6fe-deployment"},
 						Replicas:          3,
 						UpdatedReplicas:   3,
 						ReadyReplicas:     ptr.To(int32(3)),
@@ -2472,7 +2472,7 @@ func Test_reconcileDynamoComponentsDeployments(t *testing.T) {
 				}),
 				betaDCD(t, &v1alpha1.DynamoComponentDeployment{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-dgd-decode-e7884bce",
+						Name:      "test-dgd-decode-e1f2a6fe",
 						Namespace: "default",
 					},
 					Spec: v1alpha1.DynamoComponentDeploymentSpec{
@@ -2491,7 +2491,7 @@ func Test_reconcileDynamoComponentsDeployments(t *testing.T) {
 						},
 						Service: &v1alpha1.ServiceReplicaStatus{
 							ComponentKind:     v1alpha1.ComponentKindDeployment,
-							ComponentNames:    []string{"test-dgd-decode-e7884bce-deployment"},
+							ComponentNames:    []string{"test-dgd-decode-e1f2a6fe-deployment"},
 							Replicas:          2,
 							UpdatedReplicas:   1,
 							ReadyReplicas:     ptr.To(int32(1)),
@@ -2501,7 +2501,7 @@ func Test_reconcileDynamoComponentsDeployments(t *testing.T) {
 				}),
 				betaDCD(t, &v1alpha1.DynamoComponentDeployment{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-dgd-prefill-e7884bce",
+						Name:      "test-dgd-prefill-e1f2a6fe",
 						Namespace: "default",
 					},
 					Spec: v1alpha1.DynamoComponentDeploymentSpec{
@@ -2520,7 +2520,7 @@ func Test_reconcileDynamoComponentsDeployments(t *testing.T) {
 						},
 						Service: &v1alpha1.ServiceReplicaStatus{
 							ComponentKind:     v1alpha1.ComponentKindDeployment,
-							ComponentNames:    []string{"test-dgd-prefill-e7884bce-deployment"},
+							ComponentNames:    []string{"test-dgd-prefill-e1f2a6fe-deployment"},
 							Replicas:          3,
 							UpdatedReplicas:   3,
 							ReadyReplicas:     ptr.To(int32(3)),
@@ -2532,7 +2532,7 @@ func Test_reconcileDynamoComponentsDeployments(t *testing.T) {
 			wantReconcileResult: ReconcileResult{
 				State:   v1beta1.DGDStatePending,
 				Reason:  "some_resources_are_not_ready",
-				Message: "Resources not ready: test-dgd-decode-e7884bce: Component deployment not ready - Available condition not true",
+				Message: "Resources not ready: test-dgd-decode-e1f2a6fe: Component deployment not ready - Available condition not true",
 				ComponentStatus: map[string]v1beta1.ComponentReplicaStatus{
 					"frontend": {
 						ComponentKind:     v1beta1.ComponentKindDeployment,
@@ -2544,7 +2544,7 @@ func Test_reconcileDynamoComponentsDeployments(t *testing.T) {
 					},
 					"decode": {
 						ComponentKind:     v1beta1.ComponentKindDeployment,
-						ComponentNames:    []string{"test-dgd-decode-e7884bce-deployment"},
+						ComponentNames:    []string{"test-dgd-decode-e1f2a6fe-deployment"},
 						Replicas:          2,
 						UpdatedReplicas:   1,
 						ReadyReplicas:     ptr.To(int32(1)),
@@ -2552,7 +2552,7 @@ func Test_reconcileDynamoComponentsDeployments(t *testing.T) {
 					},
 					"prefill": {
 						ComponentKind:     v1beta1.ComponentKindDeployment,
-						ComponentNames:    []string{"test-dgd-prefill-e7884bce-deployment"},
+						ComponentNames:    []string{"test-dgd-prefill-e1f2a6fe-deployment"},
 						Replicas:          3,
 						UpdatedReplicas:   3,
 						ReadyReplicas:     ptr.To(int32(3)),
@@ -2612,7 +2612,7 @@ func Test_reconcileDynamoComponentsDeployments(t *testing.T) {
 				}),
 				betaDCD(t, &v1alpha1.DynamoComponentDeployment{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-dgd-decode-0c79b015",
+						Name:      "test-dgd-decode-5f3d46ba",
 						Namespace: "default",
 					},
 					Spec: v1alpha1.DynamoComponentDeploymentSpec{
@@ -2631,7 +2631,7 @@ func Test_reconcileDynamoComponentsDeployments(t *testing.T) {
 						},
 						Service: &v1alpha1.ServiceReplicaStatus{
 							ComponentKind:     v1alpha1.ComponentKindDeployment,
-							ComponentNames:    []string{"test-dgd-decode-0c79b015-deployment"},
+							ComponentNames:    []string{"test-dgd-decode-5f3d46ba-deployment"},
 							Replicas:          2,
 							UpdatedReplicas:   1,
 							ReadyReplicas:     ptr.To(int32(1)),
@@ -2643,7 +2643,7 @@ func Test_reconcileDynamoComponentsDeployments(t *testing.T) {
 			wantReconcileResult: ReconcileResult{
 				State:   v1beta1.DGDStatePending,
 				Reason:  "some_resources_are_not_ready",
-				Message: "Resources not ready: test-dgd-decode-0c79b015: Component deployment not ready - Available condition not true; test-dgd-frontend: Component deployment not ready - Available condition not true",
+				Message: "Resources not ready: test-dgd-decode-5f3d46ba: Component deployment not ready - Available condition not true; test-dgd-frontend: Component deployment not ready - Available condition not true",
 				ComponentStatus: map[string]v1beta1.ComponentReplicaStatus{
 					"frontend": {
 						ComponentKind:     v1beta1.ComponentKindDeployment,
@@ -2655,7 +2655,7 @@ func Test_reconcileDynamoComponentsDeployments(t *testing.T) {
 					},
 					"decode": {
 						ComponentKind:     v1beta1.ComponentKindDeployment,
-						ComponentNames:    []string{"test-dgd-decode-0c79b015-deployment"},
+						ComponentNames:    []string{"test-dgd-decode-5f3d46ba-deployment"},
 						Replicas:          2,
 						UpdatedReplicas:   1,
 						ReadyReplicas:     ptr.To(int32(1)),

--- a/deploy/operator/internal/controller/dynamographdeployment_rollingupdate.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_rollingupdate.go
@@ -36,59 +36,114 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
 )
 
-// shouldTriggerRollingUpdate compares the desired v2 worker hash with the
-// active worker generation recorded on the DGD.
+type workerGenerationHashes struct {
+	v1 string
+	v2 string
+}
+
+func (h workerGenerationHashes) empty() bool {
+	return h.v1 == "" && h.v2 == ""
+}
+
+func (h workerGenerationHashes) contains(hash string) bool {
+	if hash == "" {
+		return false
+	}
+	return hash == h.v1 || hash == h.v2
+}
+
+func (r *DynamoGraphDeploymentReconciler) desiredWorkerHashes(
+	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+) (workerGenerationHashes, error) {
+	v1Hash, err := dynamo.ComputeLegacyAlphaDGDWorkersSpecHash(dgd)
+	if err != nil {
+		return workerGenerationHashes{}, fmt.Errorf("failed to compute v1 worker hash: %w", err)
+	}
+
+	v2Hash, err := nvidiacomv1beta1.ComputeDGDWorkersSpecHash(dgd)
+	if err != nil {
+		return workerGenerationHashes{}, fmt.Errorf("failed to compute v2 worker hash: %w", err)
+	}
+
+	return workerGenerationHashes{v1: v1Hash, v2: v2Hash}, nil
+}
+
+func (r *DynamoGraphDeploymentReconciler) currentWorkerHashes(
+	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+) workerGenerationHashes {
+	return workerGenerationHashes{
+		v1: r.getCurrentWorkerHash(dgd),
+		v2: r.getCurrentWorkerHashV2(dgd),
+	}
+}
+
+func currentWorkerHashesMatchDesired(current, desired workerGenerationHashes) bool {
+	if current.empty() {
+		return true
+	}
+	if current.v1 != "" {
+		if current.v1 != desired.v1 {
+			return false
+		}
+		return current.v2 == "" || current.v2 == desired.v2
+	}
+	return current.v2 == desired.v2
+}
+
+func workerHashForDCDGeneration(current, desired workerGenerationHashes) string {
+	if current.v1 != "" {
+		if current.v1 == desired.v1 {
+			if current.v2 == "" || current.v2 == desired.v2 {
+				return desired.v1
+			}
+			return desired.v2
+		}
+		return desired.v1
+	}
+	if current.v2 != "" {
+		return desired.v2
+	}
+	return desired.v1
+}
+
+func workerHashesForCompletedGeneration(newWorkerHash string, desired workerGenerationHashes) workerGenerationHashes {
+	if newWorkerHash == desired.v2 && desired.v2 != desired.v1 {
+		return workerGenerationHashes{v2: desired.v2}
+	}
+	return desired
+}
+
+// shouldTriggerRollingUpdate compares desired worker hashes with the active
+// generation recorded on the DGD.
 //
-// Normal state is v2-only: current-worker-hash stores the v2 hash and a
-// mismatch means the worker pod template changed. During the first reconcile of
-// an upgraded v1alpha1 object, current-worker-hash may still contain the old
-// alpha hash. In that narrow pre-migration window, the conversion webhook's
-// preserved alpha hash is the proof that the old hash still represents the
-// current worker spec, so the controller can migrate bookkeeping without
-// starting a rollout.
+// During v1/v2 compatibility a worker DCD is current if its worker-hash label
+// matches either current-worker-hash (v1) or current-worker-hash-v2. This keeps
+// the existing annotation/label meaning downgrade-safe while allowing the
+// controller to record the v2 hash that will become primary later.
 func (r *DynamoGraphDeploymentReconciler) shouldTriggerRollingUpdate(
 	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
 ) (bool, error) {
-	computedHash, err := nvidiacomv1beta1.ComputeDGDWorkersSpecHash(dgd)
+	desired, err := r.desiredWorkerHashes(dgd)
 	if err != nil {
-		return false, fmt.Errorf("failed to compute worker hash: %w", err)
+		return false, err
 	}
 
-	currentHash := r.getCurrentWorkerHash(dgd)
-
-	// If no current hash exists (new deployment), no rolling update needed
-	if currentHash == "" {
-		return false, nil
-	}
-
-	if currentHash == computedHash {
-		return false, nil
-	}
-
-	if r.getCurrentWorkerHashVersion(dgd) != consts.CurrentWorkerHashVersionV2 {
-		// Upgrade path before migration has persisted the v2 hash: only suppress
-		// rollout when conversion preserved the one-time legacy hash proving the
-		// active hash still represents the current spec.
-		if currentHash == dynamo.GetPreservedLegacyAlphaDGDWorkersSpecHash(dgd) {
-			return false, nil
-		}
-	}
-
-	return computedHash != currentHash, nil
+	current := r.currentWorkerHashes(dgd)
+	return !currentWorkerHashesMatchDesired(current, desired), nil
 }
 
 // initializeWorkerHashIfNeeded establishes the DGD's active worker generation.
-// New DGDs store the current v2 worker hash immediately. DGDs created before
+// New DGDs store the current v1 and v2 worker hashes immediately. DGDs created before
 // managed rolling updates may already have worker DCDs without a hash label; in
 // that case we label those DCDs with the legacy sentinel and let the normal
-// rolling update path migrate from that sentinel to the desired v2 hash.
+// rolling update path migrate from that sentinel to the desired compatibility hash.
 func (r *DynamoGraphDeploymentReconciler) initializeWorkerHashIfNeeded(
 	ctx context.Context,
 	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
 ) error {
 	logger := log.FromContext(ctx)
 
-	if r.getCurrentWorkerHash(dgd) != "" {
+	if !r.currentWorkerHashes(dgd).empty() {
 		return r.migrateCurrentWorkerHashIfNeeded(ctx, dgd)
 	}
 
@@ -128,154 +183,102 @@ func (r *DynamoGraphDeploymentReconciler) initializeWorkerHashIfNeeded(
 		return nil
 	}
 
-	// Normal first deploy — set the actual computed hash
-	hash, err := nvidiacomv1beta1.ComputeDGDWorkersSpecHash(dgd)
+	// Normal first deploy — set the actual computed compatibility hashes
+	hashes, err := r.desiredWorkerHashes(dgd)
 	if err != nil {
-		return fmt.Errorf("failed to compute worker hash: %w", err)
+		return err
 	}
-	r.setCurrentWorkerHash(dgd, hash)
+	r.setCurrentWorkerHashes(dgd, hashes)
 
 	if err := r.Update(ctx, dgd); err != nil {
 		return fmt.Errorf("failed to initialize worker hash: %w", err)
 	}
 
-	logger.Info("Initialized current worker hash", "hash", hash)
+	logger.Info("Initialized current worker hashes", "v1Hash", hashes.v1, "v2Hash", hashes.v2)
 
 	return nil
 }
 
-// migrateCurrentWorkerHashIfNeeded moves a DGD from legacy hash bookkeeping to
-// the v2 rollout contract.
-//
-// The migration has three relevant states:
-//
-//  1. New/current DGD:
-//     current-worker-hash=<v2>, current-worker-hash-version=v2.
-//
-//  2. v1alpha1 -> v1beta1 no-op upgrade:
-//     current-worker-hash=<v2>, current-worker-hash-version=v2,
-//     current-worker-hash-equivalent-v1=<old-alpha>.
-//     The v1 alias is history only. It is used to keep generating the same old
-//     DCD names/labels so existing DCDs are not patched or rolled just because
-//     the hash algorithm changed.
-//
-//  3. Real worker spec change after state 2:
-//     the desired v2 hash differs from current-worker-hash, so the controller
-//     clears current-worker-hash-equivalent-v1 before the normal rolling update
-//     path creates a new v2 generation.
-//
-// The alpha hash is computed by conversion while entering state 2. Once state 2
-// is recorded, the controller treats the v1 hash as stored history and does not
-// recompute it for that DGD.
+// migrateCurrentWorkerHashIfNeeded fills in additive v2 worker-hash state while
+// the v1 hash still represents the active worker generation. If v2 changes
+// without a v1 change, v1 compatibility no longer proves current pod contents,
+// so the v1 annotation is removed before rolling to a v2-labeled DCD.
 func (r *DynamoGraphDeploymentReconciler) migrateCurrentWorkerHashIfNeeded(
 	ctx context.Context,
 	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
 ) error {
 	logger := log.FromContext(ctx)
 
-	currentHash := r.getCurrentWorkerHash(dgd)
-	if currentHash == "" {
+	current := r.currentWorkerHashes(dgd)
+	if current.empty() {
 		return nil
 	}
-	if currentHash == consts.LegacyWorkerHash {
+	if current.v1 == consts.LegacyWorkerHash {
 		return nil
 	}
 
-	computedHash, err := nvidiacomv1beta1.ComputeDGDWorkersSpecHash(dgd)
+	desired, err := r.desiredWorkerHashes(dgd)
 	if err != nil {
-		return fmt.Errorf("failed to compute worker hash: %w", err)
+		return err
 	}
 
-	if r.getCurrentWorkerHashVersion(dgd) == consts.CurrentWorkerHashVersionV2 {
-		if r.getCurrentWorkerHashEquivalentV1(dgd) == "" || currentHash == computedHash {
-			return nil
-		}
-		// A v1 alias is valid only while it describes the same worker spec as the
-		// active v2 hash. Once the desired v2 hash changes, wipe the alias before
-		// rolling so old alpha DCDs are treated as previous generations.
-		r.clearCurrentWorkerHashEquivalentV1(dgd)
-		dynamo.ClearLegacyAlphaDGDWorkersSpecHash(dgd)
-		if err := r.Update(ctx, dgd); err != nil {
-			return fmt.Errorf("failed to clear worker hash compatibility history: %w", err)
-		}
-		logger.Info("Cleared legacy worker hash compatibility after v2 worker spec changed",
-			"currentHash", currentHash,
-			"desiredHash", computedHash)
+	var next workerGenerationHashes
+	var eventMessage string
+	switch {
+	case current.v1 == desired.v1 && current.v2 == "":
+		next = current
+		next.v2 = desired.v2
+		eventMessage = "Recorded compatible v1 and v2 worker hash annotations without rolling workers"
+	case current.v1 == desired.v1 && current.v2 != desired.v2:
+		next = workerGenerationHashes{v2: current.v2}
+		eventMessage = "Removed v1 worker hash annotation before rolling a v2-only worker change"
+	default:
 		return nil
 	}
 
-	if currentHash == computedHash {
-		// The stored hash already matches the current algorithm. Stamp the v2
-		// version so future reconciles can avoid legacy compatibility checks.
-		r.setCurrentWorkerHash(dgd, computedHash)
-		dynamo.ClearLegacyAlphaDGDWorkersSpecHash(dgd)
-		if err := r.Update(ctx, dgd); err != nil {
-			return fmt.Errorf("failed to migrate worker hash annotation: %w", err)
-		}
-
-		logger.Info("Migrated worker hash annotation to current version",
-			"previousHash", currentHash,
-			"currentHash", computedHash,
-			"version", consts.CurrentWorkerHashVersionV2)
-		r.Recorder.Event(dgd, corev1.EventTypeNormal, "WorkerHashMigrated",
-			"Migrated worker hash annotation to the current hash version without rolling workers")
+	if next == current {
 		return nil
 	}
-
-	legacyHash := dynamo.GetPreservedLegacyAlphaDGDWorkersSpecHash(dgd)
-	if currentHash != legacyHash {
-		return nil
-	}
-
-	// The converted object still carries the alpha hash that was active before
-	// upgrade, and it matches current-worker-hash. Promote the active hash to v2
-	// now, but remember the alpha value as an alias for the existing DCDs.
-	r.setCurrentWorkerHashWithEquivalentV1(dgd, computedHash, currentHash)
+	r.setCurrentWorkerHashes(dgd, next)
 	dynamo.ClearLegacyAlphaDGDWorkersSpecHash(dgd)
 	if err := r.Update(ctx, dgd); err != nil {
-		return fmt.Errorf("failed to record legacy worker hash compatibility: %w", err)
+		return fmt.Errorf("failed to migrate worker hash annotations: %w", err)
 	}
-	logger.Info("Recorded legacy worker hash compatibility",
-		"currentHash", computedHash,
-		"equivalentV1Hash", currentHash)
-	r.Recorder.Event(dgd, corev1.EventTypeNormal, "WorkerHashCompatibilityRecorded",
-		"Recorded legacy worker hash compatibility without rolling workers")
+	logger.Info("Migrated worker hash annotations",
+		"v1Hash", next.v1,
+		"v2Hash", next.v2)
+	r.Recorder.Event(dgd, corev1.EventTypeNormal, "WorkerHashMigrated", eventMessage)
 
 	return nil
 }
 
 // activeWorkerHashForDCDGeneration returns the hash used for generated worker
-// DCD names and labels in this reconcile.
-//
-// This is usually the desired v2 hash. The exception is state 2 from
-// migrateCurrentWorkerHashIfNeeded: the DGD's active hash has already been
-// migrated to v2, but existing DCDs are still named/labeled with the old alpha
-// hash. While the v1 alias is present and the v2 hash is unchanged, keep
-// generating the old value so graph reconciliation does not patch those DCDs.
+// DCD names and worker-hash labels in this reconcile. While v1 compatibility is
+// required, new DCDs continue to use the v1 hash. If the active generation is
+// already v2-labeled, preserve that value so future v2-only transitions do not
+// create a v1-labeled replacement.
 func (r *DynamoGraphDeploymentReconciler) activeWorkerHashForDCDGeneration(
 	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
-	computedHash string,
+	desired workerGenerationHashes,
 ) string {
-	currentHash := r.getCurrentWorkerHash(dgd)
-	if currentHash == "" || currentHash == consts.LegacyWorkerHash {
-		return computedHash
+	return r.activeWorkerHashCandidates(dgd, desired)[0]
+}
+
+func (r *DynamoGraphDeploymentReconciler) activeWorkerHashCandidates(
+	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+	desired workerGenerationHashes,
+) []string {
+	current := r.currentWorkerHashes(dgd)
+	candidates := make([]string, 0, 2)
+	generated := workerHashForDCDGeneration(current, desired)
+	candidates = append(candidates, generated)
+	if current.v1 == desired.v1 && (current.v2 == "" || current.v2 == desired.v2) && desired.v1 != generated {
+		candidates = append(candidates, desired.v1)
 	}
-	if currentHash == computedHash {
-		if equivalentV1Hash := r.getCurrentWorkerHashEquivalentV1(dgd); equivalentV1Hash != "" {
-			// No semantic worker-spec change after an alpha-to-v2 migration:
-			// keep generating DCD names and labels from the active legacy alias
-			// so existing DCDs are not patched to the v2 value in place.
-			return equivalentV1Hash
-		}
-		return computedHash
+	if current.contains(desired.v2) && desired.v2 != generated && desired.v2 != desired.v1 {
+		candidates = append(candidates, desired.v2)
 	}
-	if r.getCurrentWorkerHashVersion(dgd) == consts.CurrentWorkerHashVersionV2 {
-		return computedHash
-	}
-	if currentHash == dynamo.GetPreservedLegacyAlphaDGDWorkersSpecHash(dgd) {
-		return currentHash
-	}
-	return computedHash
+	return candidates
 }
 
 // findLegacyWorkerDCDs returns worker DCDs owned by this DGD that lack the worker hash label.
@@ -333,63 +336,35 @@ func (r *DynamoGraphDeploymentReconciler) getCurrentWorkerHash(
 	return dgd.Annotations[consts.AnnotationCurrentWorkerHash]
 }
 
-func (r *DynamoGraphDeploymentReconciler) getCurrentWorkerHashVersion(
+func (r *DynamoGraphDeploymentReconciler) getCurrentWorkerHashV2(
 	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
 ) string {
 	if dgd.Annotations == nil {
 		return ""
 	}
-	return dgd.Annotations[consts.AnnotationCurrentWorkerHashVersion]
+	return dgd.Annotations[consts.AnnotationCurrentWorkerHashV2]
 }
 
-// getCurrentWorkerHashEquivalentV1 returns the legacy v1alpha1 hash alias for a
-// migrated v2 active worker hash, if one has already been recorded.
-func (r *DynamoGraphDeploymentReconciler) getCurrentWorkerHashEquivalentV1(
+// setCurrentWorkerHashes stores the active worker hashes for one generation.
+// Empty fields are deleted, which is how v2-only generations intentionally drop
+// the downgrade-compatible v1 annotation.
+func (r *DynamoGraphDeploymentReconciler) setCurrentWorkerHashes(
 	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
-) string {
-	if dgd.Annotations == nil {
-		return ""
-	}
-	return dgd.Annotations[consts.AnnotationCurrentWorkerHashEquivalentV1]
-}
-
-// setCurrentWorkerHash stores a current-algorithm worker hash as the active
-// generation and clears any legacy equivalence state.
-func (r *DynamoGraphDeploymentReconciler) setCurrentWorkerHash(
-	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
-	hash string,
+	hashes workerGenerationHashes,
 ) {
 	if dgd.Annotations == nil {
 		dgd.Annotations = make(map[string]string)
 	}
-	dgd.Annotations[consts.AnnotationCurrentWorkerHash] = hash
-	dgd.Annotations[consts.AnnotationCurrentWorkerHashVersion] = consts.CurrentWorkerHashVersionV2
-	delete(dgd.Annotations, consts.AnnotationCurrentWorkerHashEquivalentV1)
-}
-
-// setCurrentWorkerHashWithEquivalentV1 records currentHash as the v2 active
-// generation while keeping equivalentV1Hash as an alias for existing worker DCDs
-// already named/labeled with the old v1alpha1 hash.
-func (r *DynamoGraphDeploymentReconciler) setCurrentWorkerHashWithEquivalentV1(
-	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
-	currentHash string,
-	equivalentV1Hash string,
-) {
-	if dgd.Annotations == nil {
-		dgd.Annotations = make(map[string]string)
+	if hashes.v1 != "" {
+		dgd.Annotations[consts.AnnotationCurrentWorkerHash] = hashes.v1
+	} else {
+		delete(dgd.Annotations, consts.AnnotationCurrentWorkerHash)
 	}
-	dgd.Annotations[consts.AnnotationCurrentWorkerHash] = currentHash
-	dgd.Annotations[consts.AnnotationCurrentWorkerHashVersion] = consts.CurrentWorkerHashVersionV2
-	dgd.Annotations[consts.AnnotationCurrentWorkerHashEquivalentV1] = equivalentV1Hash
-}
-
-func (r *DynamoGraphDeploymentReconciler) clearCurrentWorkerHashEquivalentV1(
-	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
-) {
-	if dgd.Annotations == nil {
-		return
+	if hashes.v2 != "" {
+		dgd.Annotations[consts.AnnotationCurrentWorkerHashV2] = hashes.v2
+	} else {
+		delete(dgd.Annotations, consts.AnnotationCurrentWorkerHashV2)
 	}
-	delete(dgd.Annotations, consts.AnnotationCurrentWorkerHashEquivalentV1)
 }
 
 // setLegacyWorkerHash marks pre-rolling-update worker DCDs as the active
@@ -402,8 +377,7 @@ func (r *DynamoGraphDeploymentReconciler) setLegacyWorkerHash(
 		dgd.Annotations = make(map[string]string)
 	}
 	dgd.Annotations[consts.AnnotationCurrentWorkerHash] = consts.LegacyWorkerHash
-	delete(dgd.Annotations, consts.AnnotationCurrentWorkerHashVersion)
-	delete(dgd.Annotations, consts.AnnotationCurrentWorkerHashEquivalentV1)
+	delete(dgd.Annotations, consts.AnnotationCurrentWorkerHashV2)
 }
 
 // getOrCreateRollingUpdateStatus returns the existing rolling update status or creates a new one.
@@ -439,30 +413,38 @@ func (r *DynamoGraphDeploymentReconciler) reconcileRollingUpdate(
 
 	rollingUpdateStatus := r.getOrCreateRollingUpdateStatus(dgd)
 
-	newWorkerHash, err := nvidiacomv1beta1.ComputeDGDWorkersSpecHash(dgd)
+	desired, err := r.desiredWorkerHashes(dgd)
 	if err != nil {
-		return fmt.Errorf("failed to compute worker hash: %w", err)
+		return err
 	}
-	prevWorkerHash := r.getCurrentWorkerHash(dgd)
+	newWorkerHash := r.activeWorkerHashForDCDGeneration(dgd, desired)
+	current := r.currentWorkerHashes(dgd)
 
 	logger.Info("Reconciling rolling update",
 		"phase", rollingUpdateStatus.Phase,
-		"prevWorkerHash", prevWorkerHash,
-		"newWorkerHash", newWorkerHash)
+		"currentV1WorkerHash", current.v1,
+		"currentV2WorkerHash", current.v2,
+		"newWorkerHash", newWorkerHash,
+		"desiredV1WorkerHash", desired.v1,
+		"desiredV2WorkerHash", desired.v2)
 
-	if (rollingUpdateStatus.Phase == nvidiacomv1beta1.RollingUpdatePhaseCompleted) && prevWorkerHash != newWorkerHash {
+	if rollingUpdateStatus.Phase == nvidiacomv1beta1.RollingUpdatePhaseCompleted && !current.contains(newWorkerHash) {
 		// Check if DCDs with the new hash already exist and are serving.
 		// If so, this is just a stale annotation — update it without starting a new rollout.
 		newInfo, err := r.getWorkerInfoForWorkerHash(ctx, dgd, newWorkerHash)
 		if err == nil && newInfo.TotalReadyWorkers() > 0 {
 			logger.Info("Updating stale worker hash annotation",
-				"prevWorkerHash", prevWorkerHash, "newHash", newWorkerHash)
-			r.setCurrentWorkerHash(dgd, newWorkerHash)
+				"currentV1WorkerHash", current.v1,
+				"currentV2WorkerHash", current.v2,
+				"newHash", newWorkerHash)
+			r.setCurrentWorkerHashes(dgd, workerHashesForCompletedGeneration(newWorkerHash, desired))
 			return r.Update(ctx, dgd)
 		}
 		// New spec change: reset to start a proper rolling update cycle with surge/drain.
 		logger.Info("New worker spec change detected, starting new rolling update cycle",
-			"prevWorkerHash", prevWorkerHash, "newHash", newWorkerHash,
+			"currentV1WorkerHash", current.v1,
+			"currentV2WorkerHash", current.v2,
+			"newHash", newWorkerHash,
 			"previousPhase", rollingUpdateStatus.Phase)
 		rollingUpdateStatus.Phase = nvidiacomv1beta1.RollingUpdatePhaseNone
 		rollingUpdateStatus.StartTime = nil
@@ -470,7 +452,7 @@ func (r *DynamoGraphDeploymentReconciler) reconcileRollingUpdate(
 		rollingUpdateStatus.UpdatedComponents = nil
 	}
 
-	if prevWorkerHash == newWorkerHash &&
+	if current.contains(newWorkerHash) &&
 		rollingUpdateStatus.Phase == nvidiacomv1beta1.RollingUpdatePhaseInProgress {
 		logger.Info("Detected stuck rolling update: hashes match but phase is InProgress",
 			"hash", newWorkerHash,
@@ -505,10 +487,11 @@ func (r *DynamoGraphDeploymentReconciler) startRollingUpdate(
 ) error {
 	logger := log.FromContext(ctx)
 
-	prevWorkerHash := r.getCurrentWorkerHash(dgd)
+	current := r.currentWorkerHashes(dgd)
 
 	logger.Info("Starting rolling update",
-		"prevHash", prevWorkerHash,
+		"currentV1Hash", current.v1,
+		"currentV2Hash", current.v2,
 		"newHash", newWorkerHash)
 
 	now := metav1.Now()
@@ -518,7 +501,7 @@ func (r *DynamoGraphDeploymentReconciler) startRollingUpdate(
 	rollingUpdateStatus.UpdatedComponents = nil
 
 	r.Recorder.Eventf(dgd, corev1.EventTypeNormal, "RollingUpdateStarted",
-		"Starting rolling update from worker hash %s to %s", prevWorkerHash, newWorkerHash)
+		"Starting rolling update to worker hash %s", newWorkerHash)
 
 	return nil // deferred function in Reconcile() persists status
 }
@@ -605,12 +588,17 @@ func (r *DynamoGraphDeploymentReconciler) completeRollingUpdate(
 ) error {
 	logger := log.FromContext(ctx)
 
+	desired, err := r.desiredWorkerHashes(dgd)
+	if err != nil {
+		return err
+	}
+
 	// Delete all non-current worker DCDs (any number of old generations)
 	if err := r.deleteOldWorkerDCDs(ctx, dgd, newWorkerHash); err != nil {
 		return fmt.Errorf("failed to delete old worker DCDs: %w", err)
 	}
 
-	r.setCurrentWorkerHash(dgd, newWorkerHash)
+	r.setCurrentWorkerHashes(dgd, workerHashesForCompletedGeneration(newWorkerHash, desired))
 	if err := r.Update(ctx, dgd); err != nil {
 		return fmt.Errorf("failed to update current worker hash: %w", err)
 	}
@@ -1037,22 +1025,14 @@ func (r *DynamoGraphDeploymentReconciler) buildRollingUpdateContext(
 ) (dynamo.RollingUpdateContext, error) {
 	logger := log.FromContext(ctx)
 
-	computedHash, err := nvidiacomv1beta1.ComputeDGDWorkersSpecHash(dgd)
+	desiredHashes, err := r.desiredWorkerHashes(dgd)
 	if err != nil {
-		return dynamo.RollingUpdateContext{}, fmt.Errorf("failed to compute worker hash: %w", err)
+		return dynamo.RollingUpdateContext{}, err
 	}
-	newWorkerHash := r.activeWorkerHashForDCDGeneration(dgd, computedHash)
-	prevWorkerHash := r.getCurrentWorkerHash(dgd)
-	if prevWorkerHash == computedHash {
-		if equivalentV1Hash := r.getCurrentWorkerHashEquivalentV1(dgd); equivalentV1Hash != "" {
-			// Treat the alias as the previous generation for context building;
-			// otherwise the no-op-upgrade state would look like prev==new and the
-			// existing alpha-labeled DCDs would disappear from rollout accounting.
-			prevWorkerHash = equivalentV1Hash
-		}
-	}
+	newWorkerHash := r.activeWorkerHashForDCDGeneration(dgd, desiredHashes)
+	currentHashes := r.currentWorkerHashes(dgd)
 
-	if prevWorkerHash == newWorkerHash {
+	if currentHashes.contains(newWorkerHash) {
 		return dynamo.RollingUpdateContext{
 			NewWorkerHash:     newWorkerHash,
 			OldWorkerReplicas: make(map[string]int32),

--- a/deploy/operator/internal/controller/dynamographdeployment_rollingupdate.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_rollingupdate.go
@@ -240,7 +240,6 @@ func (r *DynamoGraphDeploymentReconciler) migrateCurrentWorkerHashIfNeeded(
 		return nil
 	}
 	r.setCurrentWorkerHashes(dgd, next)
-	dynamo.ClearLegacyAlphaDGDWorkersSpecHash(dgd)
 	if err := r.Update(ctx, dgd); err != nil {
 		return fmt.Errorf("failed to migrate worker hash annotations: %w", err)
 	}

--- a/deploy/operator/internal/controller/dynamographdeployment_rollingupdate_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_rollingupdate_test.go
@@ -181,8 +181,11 @@ func TestShouldTriggerRollingUpdate(t *testing.T) {
 			dgd := createTestDGD("test-dgd", tt.services)
 
 			if tt.existingHash == "compute" {
-				hash := betaDGDWorkersSpecHash(t, dgd)
-				dgd.Annotations = map[string]string{consts.AnnotationCurrentWorkerHash: hash}
+				hash := legacyDGDWorkersSpecHash(t, dgd)
+				dgd.Annotations = map[string]string{
+					consts.AnnotationCurrentWorkerHash:   hash,
+					consts.AnnotationCurrentWorkerHashV2: betaDGDWorkersSpecHash(t, dgd),
+				}
 			} else if tt.existingHash == "legacy-compute" {
 				hash, err := dynamo.ComputeLegacyAlphaDGDWorkersSpecHash(dgd)
 				require.NoError(t, err)
@@ -227,10 +230,12 @@ func TestInitializeWorkerHashIfNeeded_FirstDeploy(t *testing.T) {
 	hash := r.getCurrentWorkerHash(dgd)
 	assert.NotEmpty(t, hash, "Hash should be set after initialization")
 
-	// Verify the hash is correct
-	expectedHash := betaDGDWorkersSpecHash(t, dgd)
-	assert.Equal(t, expectedHash, hash, "Hash should match computed value")
-	assert.Equal(t, consts.CurrentWorkerHashVersionV2, dgd.Annotations[consts.AnnotationCurrentWorkerHashVersion])
+	// Verify both compatibility hashes are correct.
+	expectedV1Hash, err := dynamo.ComputeLegacyAlphaDGDWorkersSpecHash(dgd)
+	require.NoError(t, err)
+	expectedV2Hash := betaDGDWorkersSpecHash(t, dgd)
+	assert.Equal(t, expectedV1Hash, hash, "v1 hash should remain the downgrade-compatible current hash")
+	assert.Equal(t, expectedV2Hash, dgd.Annotations[consts.AnnotationCurrentWorkerHashV2])
 }
 
 func TestInitializeWorkerHashIfNeeded_AlreadyInitialized(t *testing.T) {
@@ -297,9 +302,8 @@ func TestInitializeWorkerHashIfNeeded_PreservesLegacyAlphaHash(t *testing.T) {
 	err = r.initializeWorkerHashIfNeeded(context.Background(), dgd)
 	require.NoError(t, err)
 
-	assert.Equal(t, v2Hash, r.getCurrentWorkerHash(dgd))
-	assert.Equal(t, consts.CurrentWorkerHashVersionV2, dgd.Annotations[consts.AnnotationCurrentWorkerHashVersion])
-	assert.Equal(t, legacyHash, dgd.Annotations[consts.AnnotationCurrentWorkerHashEquivalentV1])
+	assert.Equal(t, legacyHash, r.getCurrentWorkerHash(dgd))
+	assert.Equal(t, v2Hash, dgd.Annotations[consts.AnnotationCurrentWorkerHashV2])
 	trigger, err := r.shouldTriggerRollingUpdate(dgd)
 	require.NoError(t, err)
 	assert.False(t, trigger)
@@ -364,7 +368,7 @@ func TestLegacyAlphaHashCompatibility_NoOpUpgradeUsesExistingWorkerGeneration(t 
 	require.NotEqual(t, "qwen-vllmdecodeworker-"+v2Hash, dcds["VllmDecodeWorker"].Name)
 }
 
-func TestLegacyAlphaHashCompatibility_WorkerSpecChangeUsesNewV2Generation(t *testing.T) {
+func TestLegacyAlphaHashCompatibility_WorkerSpecChangeUsesNewV1Generation(t *testing.T) {
 	dgd := createTestDGD("test-dgd", map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
 		"worker": {
 			ComponentType: consts.ComponentTypeWorker,
@@ -386,19 +390,59 @@ func TestLegacyAlphaHashCompatibility_WorkerSpecChangeUsesNewV2Generation(t *tes
 
 	r := createTestReconcilerWithStatus(dgd)
 	require.NoError(t, r.initializeWorkerHashIfNeeded(context.Background(), dgd))
-	require.Equal(t, consts.CurrentWorkerHashVersionV2, dgd.Annotations[consts.AnnotationCurrentWorkerHashVersion])
-	require.Equal(t, v2Hash, dgd.Annotations[consts.AnnotationCurrentWorkerHash])
-	require.Equal(t, legacyHash, dgd.Annotations[consts.AnnotationCurrentWorkerHashEquivalentV1])
+	require.Equal(t, legacyHash, dgd.Annotations[consts.AnnotationCurrentWorkerHash])
+	require.Equal(t, v2Hash, dgd.Annotations[consts.AnnotationCurrentWorkerHashV2])
 
 	dgd.Spec.Components[0].PodTemplate.Spec.Containers[0].Env = append(
 		dgd.Spec.Components[0].PodTemplate.Spec.Containers[0].Env,
 		corev1.EnvVar{Name: "NEW_WORKER_SETTING", Value: "true"},
 	)
 	newV2Hash := betaDGDWorkersSpecHash(t, dgd)
+	newLegacyHash, err := dynamo.ComputeLegacyAlphaDGDWorkersSpecHash(dgd)
+	require.NoError(t, err)
+	require.NotEqual(t, v2Hash, newV2Hash)
+	require.NotEqual(t, legacyHash, newLegacyHash)
+
+	require.NoError(t, r.migrateCurrentWorkerHashIfNeeded(context.Background(), dgd))
+
+	trigger, err := r.shouldTriggerRollingUpdate(dgd)
+	require.NoError(t, err)
+	require.True(t, trigger)
+
+	rollingCtx, err := r.buildRollingUpdateContext(context.Background(), dgd)
+	require.NoError(t, err)
+	require.Equal(t, newLegacyHash, rollingCtx.NewWorkerHash)
+	require.NotEqual(t, newV2Hash, rollingCtx.NewWorkerHash)
+}
+
+func TestLegacyAlphaHashCompatibility_V2OnlyChangeUsesNewV2Generation(t *testing.T) {
+	dgd := createTestDGD("test-dgd", map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+		"worker": {
+			ComponentType: consts.ComponentTypeWorker,
+			Envs:          []corev1.EnvVar{{Name: "FOO", Value: "bar"}},
+		},
+	})
+	dgd.Spec.BackendFramework = "vllm"
+	legacyHash, err := dynamo.ComputeLegacyAlphaDGDWorkersSpecHash(dgd)
+	require.NoError(t, err)
+	v2Hash := betaDGDWorkersSpecHash(t, dgd)
+	dgd.Annotations = map[string]string{
+		consts.AnnotationCurrentWorkerHash:   legacyHash,
+		consts.AnnotationCurrentWorkerHashV2: v2Hash,
+	}
+
+	r := createTestReconcilerWithStatus(dgd)
+	dgd.Spec.BackendFramework = "sglang"
+
+	newLegacyHash, err := dynamo.ComputeLegacyAlphaDGDWorkersSpecHash(dgd)
+	require.NoError(t, err)
+	newV2Hash := betaDGDWorkersSpecHash(t, dgd)
+	require.Equal(t, legacyHash, newLegacyHash)
 	require.NotEqual(t, v2Hash, newV2Hash)
 
 	require.NoError(t, r.migrateCurrentWorkerHashIfNeeded(context.Background(), dgd))
-	require.Empty(t, dgd.Annotations[consts.AnnotationCurrentWorkerHashEquivalentV1])
+	require.Empty(t, dgd.Annotations[consts.AnnotationCurrentWorkerHash])
+	require.Equal(t, v2Hash, dgd.Annotations[consts.AnnotationCurrentWorkerHashV2])
 
 	trigger, err := r.shouldTriggerRollingUpdate(dgd)
 	require.NoError(t, err)
@@ -407,6 +451,11 @@ func TestLegacyAlphaHashCompatibility_WorkerSpecChangeUsesNewV2Generation(t *tes
 	rollingCtx, err := r.buildRollingUpdateContext(context.Background(), dgd)
 	require.NoError(t, err)
 	require.Equal(t, newV2Hash, rollingCtx.NewWorkerHash)
+	require.NotEqual(t, newLegacyHash, rollingCtx.NewWorkerHash)
+
+	require.NoError(t, r.completeRollingUpdate(context.Background(), dgd, newV2Hash))
+	require.Empty(t, dgd.Annotations[consts.AnnotationCurrentWorkerHash])
+	require.Equal(t, newV2Hash, dgd.Annotations[consts.AnnotationCurrentWorkerHashV2])
 }
 
 func TestSupportsManagedRollingUpdate(t *testing.T) {
@@ -1377,8 +1426,8 @@ func TestGetExistingRestartAnnotationsDCD(t *testing.T) {
 				ComponentType: consts.ComponentTypeWorker,
 			},
 		})
-		// Annotation hash can differ from computed hash — function uses computed hash
-		computedHash := betaDGDWorkersSpecHash(t, dgd)
+		// Annotation hash can differ from computed hash — function uses active compatibility hash.
+		computedHash := legacyDGDWorkersSpecHash(t, dgd)
 		dgd.Annotations = map[string]string{
 			consts.AnnotationCurrentWorkerHash: "oldhash",
 		}
@@ -1418,6 +1467,42 @@ func TestGetExistingRestartAnnotationsDCD(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, "2025-01-01T00:00:00Z", annotations["frontend"])
+		assert.Equal(t, "2025-01-01T00:00:00Z", annotations["worker"])
+	})
+
+	t.Run("worker DCD with v2 hash suffix - finds annotation", func(t *testing.T) {
+		dgd := createTestDGD("test-dgd", map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+			"worker": {
+				ComponentType: consts.ComponentTypeWorker,
+			},
+		})
+		legacyHash := legacyDGDWorkersSpecHash(t, dgd)
+		v2Hash := betaDGDWorkersSpecHash(t, dgd)
+		dgd.Annotations = map[string]string{
+			consts.AnnotationCurrentWorkerHash:   legacyHash,
+			consts.AnnotationCurrentWorkerHashV2: v2Hash,
+		}
+
+		workerDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-dgd-worker-" + v2Hash,
+				Namespace: "default",
+			},
+			Spec: nvidiacomv1alpha1.DynamoComponentDeploymentSpec{
+				DynamoComponentDeploymentSharedSpec: nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+					Annotations: map[string]string{
+						consts.RestartAnnotation: "2025-01-01T00:00:00Z",
+					},
+				},
+			},
+		})
+
+		r := createTestReconcilerWithStatus(dgd, withObjects(workerDCD))
+		ctx := context.Background()
+
+		annotations, err := r.getExistingRestartAnnotationsDCD(ctx, dgd)
+		require.NoError(t, err)
+
 		assert.Equal(t, "2025-01-01T00:00:00Z", annotations["worker"])
 	})
 
@@ -1495,19 +1580,57 @@ func TestGetExistingRestartAnnotationsDCD(t *testing.T) {
 
 func TestCheckComponentFullyUpdated(t *testing.T) {
 	t.Run("worker with hash suffix - finds DCD", func(t *testing.T) {
-		workerHash := "abc12345"
 		dgd := createTestDGD("test-dgd", map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
 			"worker": {
 				ComponentType: consts.ComponentTypeWorker,
 			},
 		})
+		workerHash := legacyDGDWorkersSpecHash(t, dgd)
 		dgd.Annotations = map[string]string{
-			consts.AnnotationCurrentWorkerHash: workerHash + "fullhashextra",
+			consts.AnnotationCurrentWorkerHash: workerHash,
 		}
 
 		workerDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:       "test-dgd-worker-" + workerHash + "fullhashextra",
+				Name:       "test-dgd-worker-" + workerHash,
+				Namespace:  "default",
+				Generation: 1,
+			},
+			Status: nvidiacomv1alpha1.DynamoComponentDeploymentStatus{
+				ObservedGeneration: 1,
+				Conditions: []metav1.Condition{
+					{
+						Type:   nvidiacomv1alpha1.DynamoGraphDeploymentConditionTypeAvailable,
+						Status: metav1.ConditionTrue,
+					},
+				},
+			},
+		})
+
+		r := createTestReconcilerWithStatus(dgd, withObjects(workerDCD))
+		ctx := context.Background()
+
+		isReady, reason := r.checkComponentFullyUpdated(ctx, dgd, "worker")
+		assert.True(t, isReady, "worker DCD should be ready")
+		assert.Empty(t, reason)
+	})
+
+	t.Run("worker with v2 hash suffix - finds DCD", func(t *testing.T) {
+		dgd := createTestDGD("test-dgd", map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+			"worker": {
+				ComponentType: consts.ComponentTypeWorker,
+			},
+		})
+		legacyHash := legacyDGDWorkersSpecHash(t, dgd)
+		v2Hash := betaDGDWorkersSpecHash(t, dgd)
+		dgd.Annotations = map[string]string{
+			consts.AnnotationCurrentWorkerHash:   legacyHash,
+			consts.AnnotationCurrentWorkerHashV2: v2Hash,
+		}
+
+		workerDCD := betaDCD(t, &nvidiacomv1alpha1.DynamoComponentDeployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "test-dgd-worker-" + v2Hash,
 				Namespace:  "default",
 				Generation: 1,
 			},
@@ -2734,8 +2857,12 @@ func TestReconcileRollingUpdate_NoChange(t *testing.T) {
 	dgd := createTestDGD("test-dgd", map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
 		"worker": {ComponentType: consts.ComponentTypeWorker},
 	})
-	hash := betaDGDWorkersSpecHash(t, dgd)
-	dgd.Annotations = map[string]string{consts.AnnotationCurrentWorkerHash: hash}
+	hash := legacyDGDWorkersSpecHash(t, dgd)
+	v2Hash := betaDGDWorkersSpecHash(t, dgd)
+	dgd.Annotations = map[string]string{
+		consts.AnnotationCurrentWorkerHash:   hash,
+		consts.AnnotationCurrentWorkerHashV2: v2Hash,
+	}
 	dgd.Status.RollingUpdate = &nvidiacomv1beta1.RollingUpdateStatus{
 		Phase: nvidiacomv1beta1.RollingUpdatePhaseCompleted,
 	}
@@ -2783,9 +2910,12 @@ func TestReconcileRollingUpdate_StuckDetection(t *testing.T) {
 	dgd := createTestDGD("test-dgd", map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
 		"worker": {ComponentType: consts.ComponentTypeWorker},
 	})
-	hash := betaDGDWorkersSpecHash(t, dgd)
+	hash := legacyDGDWorkersSpecHash(t, dgd)
 	// Hash matches current but phase is InProgress — stuck
-	dgd.Annotations = map[string]string{consts.AnnotationCurrentWorkerHash: hash}
+	dgd.Annotations = map[string]string{
+		consts.AnnotationCurrentWorkerHash:   hash,
+		consts.AnnotationCurrentWorkerHashV2: betaDGDWorkersSpecHash(t, dgd),
+	}
 	dgd.Status.RollingUpdate = &nvidiacomv1beta1.RollingUpdateStatus{
 		Phase: nvidiacomv1beta1.RollingUpdatePhaseInProgress,
 	}
@@ -2864,8 +2994,12 @@ func TestReconcileRollingUpdate_StuckDetection_CompletesViaCompleteRollingUpdate
 		"prefill": {ComponentType: consts.ComponentTypePrefill},
 		"decode":  {ComponentType: consts.ComponentTypeDecode},
 	})
-	hash := betaDGDWorkersSpecHash(t, dgd)
-	dgd.Annotations = map[string]string{consts.AnnotationCurrentWorkerHash: hash}
+	legacyHash := legacyDGDWorkersSpecHash(t, dgd)
+	v2Hash := betaDGDWorkersSpecHash(t, dgd)
+	dgd.Annotations = map[string]string{
+		consts.AnnotationCurrentWorkerHash:   legacyHash,
+		consts.AnnotationCurrentWorkerHashV2: v2Hash,
+	}
 	dgd.Status.RollingUpdate = &nvidiacomv1beta1.RollingUpdateStatus{
 		Phase: nvidiacomv1beta1.RollingUpdatePhaseInProgress,
 	}
@@ -2881,8 +3015,9 @@ func TestReconcileRollingUpdate_StuckDetection_CompletesViaCompleteRollingUpdate
 	// UpdatedComponents should contain all worker services
 	assert.Contains(t, dgd.Status.RollingUpdate.UpdatedComponents, "prefill")
 	assert.Contains(t, dgd.Status.RollingUpdate.UpdatedComponents, "decode")
-	// Annotation should still have the correct hash
-	assert.Equal(t, hash, dgd.Annotations[consts.AnnotationCurrentWorkerHash])
+	// Completion records both active compatibility hashes.
+	assert.Equal(t, legacyHash, dgd.Annotations[consts.AnnotationCurrentWorkerHash])
+	assert.Equal(t, v2Hash, dgd.Annotations[consts.AnnotationCurrentWorkerHashV2])
 }
 
 func TestBuildRollingUpdateContext(t *testing.T) {
@@ -3152,8 +3287,8 @@ func TestBuildRollingUpdateContext(t *testing.T) {
 				consts.AnnotationCurrentWorkerHash: testOldWorkerHash,
 			}
 
-			// Compute the actual new hash from the DGD spec (same as buildRollingUpdateContext does)
-			newHash := betaDGDWorkersSpecHash(t, dgd)
+			// Compute the actual new DCD label hash from the DGD spec.
+			newHash := legacyDGDWorkersSpecHash(t, dgd)
 			require.NotEqual(t, testOldWorkerHash, newHash, "test setup: computed hash must differ from old hash")
 
 			// Collect all mock objects
@@ -3219,7 +3354,7 @@ func TestBuildRollingUpdateContext_NoNewDCDExists(t *testing.T) {
 		},
 	})
 
-	newHash := betaDGDWorkersSpecHash(t, dgd)
+	newHash := legacyDGDWorkersSpecHash(t, dgd)
 	assert.NotEqual(t, testOldWorkerHash, newHash, "test setup: computed hash must differ from old hash")
 
 	r := createTestReconcilerWithStatus(dgd, withObjects(oldDCD))
@@ -3245,7 +3380,7 @@ func TestBuildRollingUpdateContext_ListOldDCDsError(t *testing.T) {
 		consts.AnnotationCurrentWorkerHash: testOldWorkerHash,
 	}
 
-	assert.NotEqual(t, testOldWorkerHash, betaDGDWorkersSpecHash(t, dgd),
+	assert.NotEqual(t, testOldWorkerHash, legacyDGDWorkersSpecHash(t, dgd),
 		"test setup: computed hash must differ so we proceed past the early-return")
 
 	injectedErr := errors.New("simulated apiserver list failure")
@@ -3276,7 +3411,7 @@ func TestBuildRollingUpdateContext_GetNewDCDError(t *testing.T) {
 		consts.AnnotationCurrentWorkerHash: testOldWorkerHash,
 	}
 
-	require.NotEqual(t, testOldWorkerHash, betaDGDWorkersSpecHash(t, dgd),
+	require.NotEqual(t, testOldWorkerHash, legacyDGDWorkersSpecHash(t, dgd),
 		"test setup: computed hash must differ so we proceed past the early-return")
 
 	injectedErr := errors.New("simulated apiserver get failure")

--- a/deploy/operator/internal/controller/dynamographdeployment_rollingupdate_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_rollingupdate_test.go
@@ -190,8 +190,7 @@ func TestShouldTriggerRollingUpdate(t *testing.T) {
 				hash, err := dynamo.ComputeLegacyAlphaDGDWorkersSpecHash(dgd)
 				require.NoError(t, err)
 				dgd.Annotations = map[string]string{
-					consts.AnnotationCurrentWorkerHash:              hash,
-					nvidiacomv1alpha1.AnnotationDGDLegacyWorkerHash: hash,
+					consts.AnnotationCurrentWorkerHash: hash,
 				}
 			} else if tt.existingHash != "" {
 				dgd.Annotations = map[string]string{consts.AnnotationCurrentWorkerHash: tt.existingHash}
@@ -296,7 +295,6 @@ func TestInitializeWorkerHashIfNeeded_PreservesLegacyAlphaHash(t *testing.T) {
 		dgd.Annotations = map[string]string{}
 	}
 	dgd.Annotations[consts.AnnotationCurrentWorkerHash] = legacyHash
-	dgd.Annotations[nvidiacomv1alpha1.AnnotationDGDLegacyWorkerHash] = legacyHash
 
 	r := createTestReconcilerWithStatus(dgd)
 	err = r.initializeWorkerHashIfNeeded(context.Background(), dgd)
@@ -348,7 +346,6 @@ func TestLegacyAlphaHashCompatibility_NoOpUpgradeUsesExistingWorkerGeneration(t 
 		dgd.Annotations = map[string]string{}
 	}
 	dgd.Annotations[consts.AnnotationCurrentWorkerHash] = legacyHash
-	dgd.Annotations[nvidiacomv1alpha1.AnnotationDGDLegacyWorkerHash] = legacyHash
 
 	r := createTestReconcilerWithStatus(dgd)
 	require.NoError(t, r.initializeWorkerHashIfNeeded(context.Background(), dgd))
@@ -386,7 +383,6 @@ func TestLegacyAlphaHashCompatibility_WorkerSpecChangeUsesNewV1Generation(t *tes
 		dgd.Annotations = map[string]string{}
 	}
 	dgd.Annotations[consts.AnnotationCurrentWorkerHash] = legacyHash
-	dgd.Annotations[nvidiacomv1alpha1.AnnotationDGDLegacyWorkerHash] = legacyHash
 
 	r := createTestReconcilerWithStatus(dgd)
 	require.NoError(t, r.initializeWorkerHashIfNeeded(context.Background(), dgd))

--- a/deploy/operator/internal/controller/test_beta_helpers_test.go
+++ b/deploy/operator/internal/controller/test_beta_helpers_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -81,6 +82,15 @@ func betaDGDWorkersSpecHash(t testing.TB, dgd *v1beta1.DynamoGraphDeployment) st
 	hash, err := v1beta1.ComputeDGDWorkersSpecHash(dgd)
 	if err != nil {
 		t.Fatalf("compute v1beta1 DGD worker hash: %v", err)
+	}
+	return hash
+}
+
+func legacyDGDWorkersSpecHash(t testing.TB, dgd *v1beta1.DynamoGraphDeployment) string {
+	t.Helper()
+	hash, err := dynamo.ComputeLegacyAlphaDGDWorkersSpecHash(dgd)
+	if err != nil {
+		t.Fatalf("compute v1alpha1-compatible DGD worker hash: %v", err)
 	}
 	return hash
 }

--- a/deploy/operator/internal/dynamo/hash.go
+++ b/deploy/operator/internal/dynamo/hash.go
@@ -22,32 +22,13 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 )
 
-// ComputeLegacyAlphaDGDWorkersSpecHash returns the v1alpha1 worker hash used by
-// pre-v1beta1 controllers. Converted v1alpha1 DGDs carry the exact old hash in
-// an annotation; the ConvertFrom fallback is only for synthetic beta objects.
+// ComputeLegacyAlphaDGDWorkersSpecHash returns the v1alpha1 worker hash that a
+// pre-v1beta1 controller would compute for the DGD's current spec. Conversion
+// must preserve every v1alpha1 hash input shape this depends on.
 func ComputeLegacyAlphaDGDWorkersSpecHash(dgd *v1beta1.DynamoGraphDeployment) (string, error) {
-	if hash := v1alpha1.GetDGDLegacyWorkerHash(dgd); hash != "" {
-		return hash, nil
-	}
 	alpha := &v1alpha1.DynamoGraphDeployment{}
 	if err := alpha.ConvertFrom(dgd); err != nil {
 		return "", err
 	}
 	return v1alpha1.ComputeDGDWorkersSpecHash(alpha)
-}
-
-// GetPreservedLegacyAlphaDGDWorkersSpecHash returns only the alpha hash value
-// that conversion already preserved on the v1beta1 object. Unlike
-// ComputeLegacyAlphaDGDWorkersSpecHash, it never converts back to v1alpha1 and
-// never recomputes the old algorithm. Use this in controller migration logic
-// when the alpha hash should be treated as immutable history.
-func GetPreservedLegacyAlphaDGDWorkersSpecHash(dgd *v1beta1.DynamoGraphDeployment) string {
-	return v1alpha1.GetDGDLegacyWorkerHash(dgd)
-}
-
-// ClearLegacyAlphaDGDWorkersSpecHash removes the transient conversion-only
-// alpha hash after the controller has either recorded the v1 alias or decided
-// not to use legacy compatibility for this DGD.
-func ClearLegacyAlphaDGDWorkersSpecHash(dgd *v1beta1.DynamoGraphDeployment) {
-	v1alpha1.ClearDGDLegacyWorkerHash(dgd)
 }

--- a/deploy/operator/internal/dynamo/hash_test.go
+++ b/deploy/operator/internal/dynamo/hash_test.go
@@ -90,6 +90,27 @@ func TestComputeLegacyAlphaDGDWorkersSpecHash_MatchesV1Alpha1Hash(t *testing.T) 
 	assert.NotEqual(t, mustComputeBetaDGDWorkersSpecHash(t, beta), legacyHash)
 }
 
+func TestComputeLegacyAlphaDGDWorkersSpecHash_RecoversNameOnlyMainContainerHash(t *testing.T) {
+	alpha := baseDGD(map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{
+		"worker": {
+			ComponentType: commonconsts.ComponentTypeWorker,
+			ExtraPodSpec: &v1alpha1.ExtraPodSpec{
+				MainContainer: &corev1.Container{Name: commonconsts.MainContainerName},
+			},
+		},
+	})
+	directAlphaHash, err := v1alpha1.ComputeDGDWorkersSpecHash(alpha)
+	assert.NoError(t, err)
+	assert.Equal(t, "0c322ce0", directAlphaHash)
+
+	beta := &v1beta1.DynamoGraphDeployment{}
+	assert.NoError(t, alpha.ConvertTo(beta))
+	recomputedHash, err := ComputeLegacyAlphaDGDWorkersSpecHash(beta)
+	assert.NoError(t, err)
+
+	assert.Equal(t, directAlphaHash, recomputedHash)
+}
+
 func TestComputeBetaDGDWorkersSpecHash_IgnoresNonWorkers(t *testing.T) {
 	withFrontend := baseDGD(map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{
 		"worker":   {ComponentType: commonconsts.ComponentTypeWorker},

--- a/deploy/operator/internal/dynamo/hash_test.go
+++ b/deploy/operator/internal/dynamo/hash_test.go
@@ -111,6 +111,27 @@ func TestComputeLegacyAlphaDGDWorkersSpecHash_RecoversNameOnlyMainContainerHash(
 	assert.Equal(t, directAlphaHash, recomputedHash)
 }
 
+func TestComputeLegacyAlphaDGDWorkersSpecHash_RecoversMultipleCompilationCacheVolumeMounts(t *testing.T) {
+	alpha := baseDGD(map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{
+		"worker": {
+			ComponentType: commonconsts.ComponentTypeWorker,
+			VolumeMounts: []v1alpha1.VolumeMount{
+				{Name: "model-cache", MountPoint: "/models", UseAsCompilationCache: true},
+				{Name: "compile-cache", MountPoint: "/compile", UseAsCompilationCache: true},
+			},
+		},
+	})
+	directAlphaHash, err := v1alpha1.ComputeDGDWorkersSpecHash(alpha)
+	assert.NoError(t, err)
+
+	beta := &v1beta1.DynamoGraphDeployment{}
+	assert.NoError(t, alpha.ConvertTo(beta))
+	recomputedHash, err := ComputeLegacyAlphaDGDWorkersSpecHash(beta)
+	assert.NoError(t, err)
+
+	assert.Equal(t, directAlphaHash, recomputedHash)
+}
+
 func TestComputeBetaDGDWorkersSpecHash_IgnoresNonWorkers(t *testing.T) {
 	withFrontend := baseDGD(map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{
 		"worker":   {ComponentType: commonconsts.ComponentTypeWorker},


### PR DESCRIPTION
## Summary

- keep `current-worker-hash` as the downgrade-compatible v1 worker hash while writing `current-worker-hash-v2`
- preserve v1 DCD labels until a v1-incompatible v2-only change requires rollout
- harden legacy alpha hash compatibility with golden tests, fuzz smoke coverage, and a stateless conversion rule
- preserve legacy worker selectors only from existing workload selectors, not from hash currentness

## Tests

- `KUBEBUILDER_ASSETS="$(./bin/setup-envtest-release-0.19 use 1.29.0 --bin-dir $(pwd)/bin -p path)" go test ./api/v1alpha1 ./api/v1beta1 ./internal/dynamo ./internal/controller -count=1`
- `go test ./api/v1alpha1 -run "^$" -fuzz "^FuzzComputeDGDWorkersSpecHashDeterministic$" -fuzztime=2s`
- `go test ./api/v1alpha1 -run "^$" -fuzz "^FuzzComputeDGDWorkersSpecHashConversionRoundTripStableSubset$" -fuzztime=2s`
