### PR TITLE
ci(docs): guard against cross-tree links in docs/

### DIFF
--- a/.github/workflows/check_cross_tree_links.py
+++ b/.github/workflows/check_cross_tree_links.py
@@ -20,7 +20,28 @@ import sys
 from pathlib import Path
 
 LINK_RE = re.compile(r"\[[^\]]+\]\(([^)#?]+)(?:[#?][^)]*)?\)")
+REF_DEF_RE = re.compile(r"^\s{0,3}\[[^\]]+\]:\s*<?([^>\s#?]+)(?:[#?][^>\s]*)?>?")
 SKIP_PREFIXES = ("http://", "https://", "mailto:", "tel:", "#", "/")
+
+
+def _check_target(
+    target: str, md: Path, docs: Path, lineno: int, failures: list[str]
+) -> None:
+    """Append a CI annotation to ``failures`` if ``target`` resolves outside ``docs/``."""
+    if target.startswith(SKIP_PREFIXES):
+        return
+    resolved = (md.parent / target).resolve()
+    try:
+        resolved.relative_to(docs)
+    except ValueError:
+        rel = md.relative_to(docs.parent)
+        failures.append(
+            f"::error file={rel},line={lineno}::"
+            f"Link target outside docs/: {target!r}. "
+            f"The docs-website branch ships only fern/, so this URL 404s on "
+            f"docs.nvidia.com. Use a full GitHub URL instead: "
+            f"https://github.com/ai-dynamo/dynamo/blob/main/<repo-path>"
+        )
 
 
 def main() -> int:
@@ -43,20 +64,10 @@ def main() -> int:
             if in_fence:
                 continue
             for target in LINK_RE.findall(line):
-                if target.startswith(SKIP_PREFIXES):
-                    continue
-                resolved = (md.parent / target).resolve()
-                try:
-                    resolved.relative_to(docs)
-                except ValueError:
-                    rel = md.relative_to(docs.parent)
-                    failures.append(
-                        f"::error file={rel},line={lineno}::"
-                        f"Link target outside docs/: {target!r}. "
-                        f"The docs-website branch ships only fern/, so this URL 404s on "
-                        f"docs.nvidia.com. Use a full GitHub URL instead: "
-                        f"https://github.com/ai-dynamo/dynamo/blob/main/<repo-path>"
-                    )
+                _check_target(target, md, docs, lineno, failures)
+            ref_match = REF_DEF_RE.match(line)
+            if ref_match:
+                _check_target(ref_match.group(1), md, docs, lineno, failures)
 
     if failures:
         print("\n".join(failures))

--- a/.github/workflows/check_cross_tree_links.py
+++ b/.github/workflows/check_cross_tree_links.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fail CI if any docs link points outside docs/.
+
+The published docs-website branch contains only fern/. Any link like
+``[x](../../lib/foo.rs)`` becomes a 404 at docs.nvidia.com because the
+referenced file does not exist on docs-website. Use a full GitHub URL
+(https://github.com/ai-dynamo/dynamo/blob/main/...) instead.
+
+Run from the repo root::
+
+    python3 .github/workflows/check_cross_tree_links.py
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+LINK_RE = re.compile(r"\[[^\]]+\]\(([^)#?]+)(?:[#?][^)]*)?\)")
+SKIP_PREFIXES = ("http://", "https://", "mailto:", "tel:", "#", "/")
+
+
+def main() -> int:
+    docs = Path("docs").resolve()
+    if not docs.is_dir():
+        print(f"::error::docs/ not found at {docs}", file=sys.stderr)
+        return 2
+
+    failures: list[str] = []
+    for md in sorted(docs.rglob("*.md")):
+        try:
+            text = md.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        in_fence = False
+        for lineno, line in enumerate(text.splitlines(), 1):
+            if line.lstrip().startswith("```"):
+                in_fence = not in_fence
+                continue
+            if in_fence:
+                continue
+            for target in LINK_RE.findall(line):
+                if target.startswith(SKIP_PREFIXES):
+                    continue
+                resolved = (md.parent / target).resolve()
+                try:
+                    resolved.relative_to(docs)
+                except ValueError:
+                    rel = md.relative_to(docs.parent)
+                    failures.append(
+                        f"::error file={rel},line={lineno}::"
+                        f"Link target outside docs/: {target!r}. "
+                        f"The docs-website branch ships only fern/, so this URL 404s on "
+                        f"docs.nvidia.com. Use a full GitHub URL instead: "
+                        f"https://github.com/ai-dynamo/dynamo/blob/main/<repo-path>"
+                    )
+
+    if failures:
+        print("\n".join(failures))
+        print(
+            f"\nFound {len(failures)} cross-tree link(s) in docs/. "
+            f"Fix by replacing the relative path with a full GitHub URL.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("No cross-tree docs links found.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -264,3 +264,30 @@ jobs:
             echo "   - A clickable GitHub URL to jump directly to the problem line"
             exit 1
           fi
+
+  cross-tree-link-check:
+    name: Check for cross-tree docs links
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Detect docs/ changes
+        id: filter
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36  # v3.0.2
+        with:
+          filters: |
+            docs:
+              - 'docs/**'
+              - '.github/workflows/check_cross_tree_links.py'
+              - '.github/workflows/docs-link-check.yml'
+
+      - name: Set up Python
+        if: steps.filter.outputs.docs == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Check for cross-tree links
+        if: steps.filter.outputs.docs == 'true'
+        run: python3 .github/workflows/check_cross_tree_links.py

--- a/docs/api/nixl-connect/README.md
+++ b/docs/api/nixl-connect/README.md
@@ -90,7 +90,7 @@ flowchart LR
 
 ### Multimodal Example
 
-In the case of the [Dynamo Multimodal Disaggregated Example](../../features/multimodal/multimodal-vllm.md):
+In the case of the [Dynamo Multimodal Disaggregated Example](https://github.com/ai-dynamo/dynamo/blob/main/docs/features/multimodal/multimodal-vllm.md):
 
  1. The HTTP frontend accepts a text prompt and a URL to an image.
 

--- a/docs/backends/mocker_backend/README.md
+++ b/docs/backends/mocker_backend/README.md
@@ -8,7 +8,7 @@ title: Mocker Backend (Rust)
 
 Reference Rust backend for Dynamo. Wraps the `dynamo-mocker` scheduler
 in the `LLMEngine` contract from
-[`dynamo-backend-common`](../../../lib/backend-common/), giving a
+[`dynamo-backend-common`](https://github.com/ai-dynamo/dynamo/tree/main/lib/backend-common), giving a
 full-fidelity mocked engine — one shared forward-pass loop paces all
 in-flight requests (continuous batching), not independent per-request
 timers. Use it as a template for writing your own Rust backend, a
@@ -17,7 +17,7 @@ forcing function that keeps the mocker scheduler tied to the
 `LLMEngine` contract.
 
 See the `LLMEngine` trait's doc comments in
-[`engine.rs`](../../../lib/backend-common/src/engine.rs) for the
+[`engine.rs`](https://github.com/ai-dynamo/dynamo/blob/main/lib/backend-common/src/engine.rs) for the
 authoritative contract.
 
 ## Quick demo (docker compose)
@@ -73,7 +73,7 @@ reachable via `NATS_SERVER` / `ETCD_ENDPOINTS` env vars.
 
 1. New crate depending on `dynamo-backend-common`; place under `lib/`.
 2. Implement
-   [`LLMEngine`](../../../lib/backend-common/src/engine.rs)
+   [`LLMEngine`](https://github.com/ai-dynamo/dynamo/blob/main/lib/backend-common/src/engine.rs)
    plus an inherent
    `from_args(argv) -> Result<(Self, WorkerConfig), DynamoError>`.
 3. Mirror the mocker example's three-line `main.rs`.
@@ -109,6 +109,6 @@ lib/backend-common/examples/mocker/
 
 ## References
 
-- Crate: [`lib/backend-common/`](../../../lib/backend-common/)
-- Example source: [`lib/backend-common/examples/mocker/`](../../../lib/backend-common/examples/mocker/)
-- Conformance kit: [`lib/backend-common/src/testing.rs`](../../../lib/backend-common/src/testing.rs)
+- Crate: [`lib/backend-common/`](https://github.com/ai-dynamo/dynamo/tree/main/lib/backend-common)
+- Example source: [`lib/backend-common/examples/mocker/`](https://github.com/ai-dynamo/dynamo/tree/main/lib/backend-common/examples/mocker)
+- Conformance kit: [`lib/backend-common/src/testing.rs`](https://github.com/ai-dynamo/dynamo/blob/main/lib/backend-common/src/testing.rs)

--- a/docs/backends/sglang/README.md
+++ b/docs/backends/sglang/README.md
@@ -73,7 +73,7 @@ docker run \
 | [**Disaggregated Serving**](../../design-docs/disagg-serving.md) | ✅ | Prefill/decode separation with NIXL KV transfer |
 | [**KV-Aware Routing**](../../components/router/README.md) | ✅ | |
 | [**SLA-Based Planner**](../../components/planner/planner-guide.md) | ✅ | |
-| [**Multimodal Support**](../../features/multimodal/multimodal-sglang.md) | ✅ | Image via EPD, E/PD, E/P/D patterns |
+| [**Multimodal Support**](https://github.com/ai-dynamo/dynamo/blob/main/docs/features/multimodal/multimodal-sglang.md) | ✅ | Image via EPD, E/PD, E/P/D patterns |
 | [**Diffusion Models**](sglang-diffusion.md) | ✅ | LLM diffusion, image, and video generation |
 | [**Request Cancellation**](../../fault-tolerance/request-cancellation.md) | ✅ | Aggregated full; disaggregated decode-only |
 | [**Graceful Shutdown**](../../fault-tolerance/graceful-shutdown.md) | ✅ | Discovery unregister + grace period |

--- a/docs/backends/sglang/sglang-examples.md
+++ b/docs/backends/sglang/sglang-examples.md
@@ -102,7 +102,7 @@ curl http://localhost:8000/v1/chat/completions \
 
 ### Multimodal with Disaggregated Components
 
-For advanced multimodal deployments with separate encoder, prefill, and decode workers (E/PD and E/P/D patterns), see the dedicated [SGLang Multimodal](../../features/multimodal/multimodal-sglang.md) documentation.
+For advanced multimodal deployments with separate encoder, prefill, and decode workers (E/PD and E/P/D patterns), see the dedicated [SGLang Multimodal](https://github.com/ai-dynamo/dynamo/blob/main/docs/features/multimodal/multimodal-sglang.md) documentation.
 
 | Pattern | Script                          | Description                                   |
 | ------- | ------------------------------- | --------------------------------------------- |
@@ -187,7 +187,7 @@ Ensure both prefill and decode workers can reach each other over TCP. The bootst
 
 - **[SGLang README](README.md)**: Quick start and feature overview
 - **[Reference Guide](sglang-reference-guide.md)**: Architecture, configuration, and operational details
-- **[SGLang Multimodal](../../features/multimodal/multimodal-sglang.md)**: Vision model deployment patterns
+- **[SGLang Multimodal](https://github.com/ai-dynamo/dynamo/blob/main/docs/features/multimodal/multimodal-sglang.md)**: Vision model deployment patterns
 - **[SGLang HiCache](../../integrations/sglang-hicache.md)**: Hierarchical cache integration
 - **[Benchmarking](../../benchmarks/benchmarking.md)**: Performance benchmarking tools
 - **[Tuning Disaggregated Performance](../../performance/tuning.md)**: P/D tuning guide

--- a/docs/backends/sglang/sglang-reference-guide.md
+++ b/docs/backends/sglang/sglang-reference-guide.md
@@ -39,7 +39,7 @@ These arguments are added by Dynamo on top of SGLang's native arguments.
 | `--dyn-reasoning-parser` | `DYN_REASONING_PARSER` | `None` | [Reasoning](../../agents/reasoning.md#supported-reasoning-parsers) parser for chain-of-thought models |
 | `--custom-jinja-template` | `DYN_CUSTOM_JINJA_TEMPLATE` | `None` | Custom chat template path (incompatible with `--use-sglang-tokenizer`) |
 | `--embedding-worker` | `DYN_SGL_EMBEDDING_WORKER` | `false` | Run as embedding worker (also sets SGLang's `--is-embedding`) |
-| `--multimodal-encode-worker` | `DYN_SGL_MULTIMODAL_ENCODE_WORKER` | `false` | Run as [multimodal](../../features/multimodal/multimodal-sglang.md) encode worker (frontend-facing) |
+| `--multimodal-encode-worker` | `DYN_SGL_MULTIMODAL_ENCODE_WORKER` | `false` | Run as [multimodal](https://github.com/ai-dynamo/dynamo/blob/main/docs/features/multimodal/multimodal-sglang.md) encode worker (frontend-facing) |
 | `--multimodal-worker` | `DYN_SGL_MULTIMODAL_WORKER` | `false` | Run as multimodal LLM worker |
 | `--image-diffusion-worker` | `DYN_SGL_IMAGE_DIFFUSION_WORKER` | `false` | Run as [image diffusion](sglang-diffusion.md#image-diffusion) worker |
 | `--video-generation-worker` | `DYN_SGL_VIDEO_GENERATION_WORKER` | `false` | Run as [video generation](sglang-diffusion.md#video-generation) worker |

--- a/docs/backends/trtllm/multinode/trtllm-multinode-examples.md
+++ b/docs/backends/trtllm/multinode/trtllm-multinode-examples.md
@@ -10,29 +10,29 @@ For general TensorRT-LLM features and engine configuration, see the
 ## Recommended Path
 
 For multinode TensorRT-LLM deployments, start from the checked-in Kubernetes
-recipes under [`recipes/`](../../../../recipes/README.md). Those manifests are
+recipes under [`recipes/`](https://github.com/ai-dynamo/dynamo/blob/main/recipes/README.md). Those manifests are
 the supported entrypoints for launching multi-node workers, frontend services,
 and related routing components.
 
 The main TRT-LLM recipe entrypoints are:
 
-- [DeepSeek-R1 WideEP on GB200](../../../../recipes/deepseek-r1/trtllm/disagg/wide_ep/gb200/deploy.yaml)
-- [Qwen3-235B-A22B-FP8 aggregated](../../../../recipes/qwen3-235b-a22b-fp8/trtllm/agg/deploy.yaml)
-- [Qwen3-235B-A22B-FP8 disaggregated](../../../../recipes/qwen3-235b-a22b-fp8/trtllm/disagg/deploy.yaml)
-- [Qwen3-32B-FP8 aggregated](../../../../recipes/qwen3-32b-fp8/trtllm/agg/deploy.yaml)
-- [Qwen3-32B-FP8 disaggregated](../../../../recipes/qwen3-32b-fp8/trtllm/disagg/deploy.yaml)
-- [GPT-OSS-120B aggregated](../../../../recipes/gpt-oss-120b/trtllm/agg/deploy.yaml)
-- [GPT-OSS-120B disaggregated](../../../../recipes/gpt-oss-120b/trtllm/disagg/deploy.yaml)
-- [Nemotron-3-Super-FP8 disaggregated](../../../../recipes/nemotron-3-super-fp8/trtllm/disagg/deploy.yaml)
+- [DeepSeek-R1 WideEP on GB200](https://github.com/ai-dynamo/dynamo/blob/main/recipes/deepseek-r1/trtllm/disagg/wide_ep/gb200/deploy.yaml)
+- [Qwen3-235B-A22B-FP8 aggregated](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-235b-a22b-fp8/trtllm/agg/deploy.yaml)
+- [Qwen3-235B-A22B-FP8 disaggregated](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-235b-a22b-fp8/trtllm/disagg/deploy.yaml)
+- [Qwen3-32B-FP8 aggregated](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-32b-fp8/trtllm/agg/deploy.yaml)
+- [Qwen3-32B-FP8 disaggregated](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-32b-fp8/trtllm/disagg/deploy.yaml)
+- [GPT-OSS-120B aggregated](https://github.com/ai-dynamo/dynamo/blob/main/recipes/gpt-oss-120b/trtllm/agg/deploy.yaml)
+- [GPT-OSS-120B disaggregated](https://github.com/ai-dynamo/dynamo/blob/main/recipes/gpt-oss-120b/trtllm/disagg/deploy.yaml)
+- [Nemotron-3-Super-FP8 disaggregated](https://github.com/ai-dynamo/dynamo/blob/main/recipes/nemotron-3-super-fp8/trtllm/disagg/deploy.yaml)
 
 For model-level setup, prerequisites, and hardware notes, use the recipe
 README files:
 
-- [DeepSeek-R1 recipes](../../../../recipes/deepseek-r1/README.md)
-- [Qwen3-235B-A22B-FP8 recipes](../../../../recipes/qwen3-235b-a22b-fp8/README.md)
-- [Qwen3-32B-FP8 recipes](../../../../recipes/qwen3-32b-fp8/README.md)
-- [GPT-OSS-120B recipes](../../../../recipes/gpt-oss-120b/README.md)
-- [Kimi-K2.5 recipes](../../../../recipes/kimi-k2.5/README.md)
+- [DeepSeek-R1 recipes](https://github.com/ai-dynamo/dynamo/blob/main/recipes/deepseek-r1/README.md)
+- [Qwen3-235B-A22B-FP8 recipes](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-235b-a22b-fp8/README.md)
+- [Qwen3-32B-FP8 recipes](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-32b-fp8/README.md)
+- [GPT-OSS-120B recipes](https://github.com/ai-dynamo/dynamo/blob/main/recipes/gpt-oss-120b/README.md)
+- [Kimi-K2.5 recipes](https://github.com/ai-dynamo/dynamo/blob/main/recipes/kimi-k2.5/README.md)
 
 ## Quick Start
 
@@ -76,7 +76,7 @@ curl http://localhost:8000/v1/models
 ## Notes
 
 - The TRT-LLM engine config files used by launch and deploy flows live under
-  [`examples/backends/trtllm/engine_configs/`](../../../../examples/backends/trtllm/engine_configs/README.md).
+  [`examples/backends/trtllm/engine_configs/`](https://github.com/ai-dynamo/dynamo/blob/main/examples/backends/trtllm/engine_configs/README.md).
 - If you need to customize model parallelism, replica counts, or routing mode,
   edit the recipe-local manifest rather than introducing a separate scheduler-specific guide.
-- For the current catalog of supported recipes, see [recipes/README.md](../../../../recipes/README.md).
+- For the current catalog of supported recipes, see [recipes/README.md](https://github.com/ai-dynamo/dynamo/blob/main/recipes/README.md).

--- a/docs/backends/trtllm/trtllm-reference-guide.md
+++ b/docs/backends/trtllm/trtllm-reference-guide.md
@@ -46,7 +46,7 @@ TensorRT-LLM documents `n`/`best_of` behavior and validates this guard as greedy
 
 ## Multimodal Support
 
-Dynamo with the TensorRT-LLM backend supports multimodal models, enabling you to process both text and images (or pre-computed embeddings) in a single request. For detailed setup instructions, example requests, and best practices, see the [TensorRT-LLM Multimodal Guide](../../features/multimodal/multimodal-trtllm.md).
+Dynamo with the TensorRT-LLM backend supports multimodal models, enabling you to process both text and images (or pre-computed embeddings) in a single request. For detailed setup instructions, example requests, and best practices, see the [TensorRT-LLM Multimodal Guide](https://github.com/ai-dynamo/dynamo/blob/main/docs/features/multimodal/multimodal-trtllm.md).
 
 ## Diffusion Support (Experimental)
 

--- a/docs/benchmarks/mocker-trace-replay.md
+++ b/docs/benchmarks/mocker-trace-replay.md
@@ -63,7 +63,7 @@ flowchart TD
     MES --> P
 ```
 
-See [`lib/mocker/src/replay/offline/README.md`](../../lib/mocker/src/replay/offline/README.md) for offline-harness internals (logical clock, event queue, worker model) and [`docs/mocker/mocker.md`](../mocker/mocker.md) for engine-core details (scheduler, KV block manager).
+See the [Offline Replay README](https://github.com/ai-dynamo/dynamo/blob/main/lib/mocker/src/replay/offline/README.md) for offline-harness internals (logical clock, event queue, worker model) and the [Dynamo Mocker](../mocker/mocker.md) for engine-core details (scheduler, KV block manager).
 
 ## Quick Start
 

--- a/docs/components/router/router-testing.md
+++ b/docs/components/router/router-testing.md
@@ -41,9 +41,9 @@ Use the fixture-backed tests in `lib/bench/tests` when you want a realistic repl
 
 Current coverage uses the checked-in 1000-line Mooncake trace fixture:
 
-- [active_sequences_trace.rs](../../../lib/bench/tests/active_sequences_trace.rs)
-- [mooncake_trace.rs](../../../lib/bench/tests/mooncake_trace.rs)
-- [mooncake_trace_1000.jsonl](../../../lib/bench/testdata/mooncake_trace_1000.jsonl)
+- [active_sequences_trace.rs](https://github.com/ai-dynamo/dynamo/blob/main/lib/bench/tests/active_sequences_trace.rs)
+- [mooncake_trace.rs](https://github.com/ai-dynamo/dynamo/blob/main/lib/bench/tests/mooncake_trace.rs)
+- [mooncake_trace_1000.jsonl](https://github.com/ai-dynamo/dynamo/blob/main/lib/bench/testdata/mooncake_trace_1000.jsonl)
 
 These tests are useful for catching regressions such as:
 
@@ -66,10 +66,10 @@ Use the Python tests in `tests/router` when you need the full request plane and 
 
 Current entry points include:
 
-- [test_router_e2e_with_mockers.py](../../../tests/router/test_router_e2e_with_mockers.py)
-- [test_router_e2e_with_vllm.py](../../../tests/router/test_router_e2e_with_vllm.py)
-- [test_router_e2e_with_trtllm.py](../../../tests/router/test_router_e2e_with_trtllm.py)
-- [test_router_e2e_with_sglang.py](../../../tests/router/test_router_e2e_with_sglang.py)
+- [test_router_e2e_with_mockers.py](https://github.com/ai-dynamo/dynamo/blob/main/tests/router/test_router_e2e_with_mockers.py)
+- [test_router_e2e_with_vllm.py](https://github.com/ai-dynamo/dynamo/blob/main/tests/router/test_router_e2e_with_vllm.py)
+- [test_router_e2e_with_trtllm.py](https://github.com/ai-dynamo/dynamo/blob/main/tests/router/test_router_e2e_with_trtllm.py)
+- [test_router_e2e_with_sglang.py](https://github.com/ai-dynamo/dynamo/blob/main/tests/router/test_router_e2e_with_sglang.py)
 
 Use this layer for changes involving:
 

--- a/docs/components/router/standalone-indexer.md
+++ b/docs/components/router/standalone-indexer.md
@@ -14,7 +14,7 @@ The standalone KV indexer (`python -m dynamo.indexer`) is a lightweight service 
 - It preserves P2P recovery and gap detection/replay for the standalone ZMQ path.
 - It indexes device, host-pinned, and disk tier blocks and reports per-tier matches in `/query` responses.
 
-This is distinct from the [Standalone Router](../../../components/src/dynamo/router/README.md), which is a full routing service. The standalone indexer provides only the indexing and query layer without routing logic.
+This is distinct from the [Standalone Router](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/router/README.md), which is a full routing service. The standalone indexer provides only the indexing and query layer without routing logic.
 
 For Dynamo-native remote indexing, use `--serve-indexer` on `dynamo.frontend` or `dynamo.router` and `--use-remote-indexer` on consumers instead. That request-plane service reuses the router's existing event ingestion and recovery machinery; it is not implemented by `dynamo.indexer`.
 
@@ -483,4 +483,4 @@ sequenceDiagram
 - **[Mooncake KV Indexer RFC](https://github.com/kvcache-ai/Mooncake/issues/1403)**: Community API standardization for KV cache indexers
 - **[Configuration and Tuning](router-configuration.md)**: Full KV router configuration and tuning
 - **[Router Design](../../design-docs/router-design.md)**: Architecture and event transport modes
-- **[Standalone Router](../../../components/src/dynamo/router/README.md)**: Full routing service (routes requests to workers)
+- **[Standalone Router](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/router/README.md)**: Full routing service (routes requests to workers)

--- a/docs/digest/agentic-inference/agentic-inference.md
+++ b/docs/digest/agentic-inference/agentic-inference.md
@@ -86,7 +86,7 @@ The `agent_hints` fields:
 - **`osl`** (output sequence length) is the harness's estimate of how many tokens this request will generate. The router uses this to gauge how long a worker will be occupied, which improves load balancing. A harness can learn this over time by tracking average output lengths per tool call type.
 - **`speculative_prefill`** signals the orchestrator to begin caching this request's prefix on a likely worker before the full request is ready. This is useful when the harness knows a tool call is about to return and wants to warm the cache ahead of time.
 
-The `cache_control` field will look familiar to anyone who has used Anthropic's prompt caching API. It tells the orchestrator to pin the computed prefix on the worker for the specified TTL, protecting it from eviction during tool call gaps. Currently `ephemeral` is the only supported type (to match Anthropic's API). We discuss how this works in the cache retention section below. You can find complete documentation on agent hints [here](../../components/frontend/nvext.md#cache-control).
+The `cache_control` field will look familiar to anyone who has used Anthropic's prompt caching API. It tells the orchestrator to pin the computed prefix on the worker for the specified TTL, protecting it from eviction during tool call gaps. Currently `ephemeral` is the only supported type (to match Anthropic's API). We discuss how this works in the cache retention section below. You can find complete documentation on [Agent Hints](../../agents/agent-hints.md) and [NVIDIA Request Extensions](../../components/frontend/nvext.md).
 
 ## Layer 2: The Router
 

--- a/docs/kubernetes/disagg-communication-guide.md
+++ b/docs/kubernetes/disagg-communication-guide.md
@@ -820,5 +820,5 @@ resources:
 
 - [Disaggregated Serving Architecture](../design-docs/disagg-serving.md)
 - [AIConfigurator Deployment Guide](../features/disaggregated-serving/README.md)
-- [NIXL Benchmark Deployment](../../deploy/pre-deployment/nixl/README.md)
+- [NIXL Benchmark Deployment](https://github.com/ai-dynamo/dynamo/blob/main/deploy/pre-deployment/nixl/README.md)
 - [KV Cache Transfer Methods](../backends/trtllm/trtllm-kv-cache-transfer.md)

--- a/docs/kubernetes/snapshot.md
+++ b/docs/kubernetes/snapshot.md
@@ -293,7 +293,7 @@ Failover restore is not yet available. The current Snapshot flow does not suppor
 
 It is possible to checkpoint and restore pods without the Dynamo operator via the lower-level `snapshotctl` utility. However, the snapshot helm chart must be installed, with a running `snapshot-agent` DaemonSet in the namespace with the checkpoint PVC mounted.
 
-`snapshotctl` is intended for lower-level debugging and validation workflows, not as the primary user-facing checkpoint interface. For command details and manifest requirements, see [deploy/snapshot/cmd/snapshotctl/README.md](../../deploy/snapshot/cmd/snapshotctl/README.md).
+`snapshotctl` is intended for lower-level debugging and validation workflows, not as the primary user-facing checkpoint interface. For command details and manifest requirements, see the [snapshotctl README](https://github.com/ai-dynamo/dynamo/blob/main/deploy/snapshot/cmd/snapshotctl/README.md).
 
 ### Checkpoint from a worker pod manifest
 

--- a/docs/mocker/mocker.md
+++ b/docs/mocker/mocker.md
@@ -366,7 +366,7 @@ kubectl apply -f examples/backends/mocker/deploy/disagg.yaml
 
 ## Architecture
 
-The mocker is organized into several cooperating components that mirror the internal architecture of production LLM inference engines. The scheduler (vLLM-style and SGLang-style variants) and KV block manager live inside the engine core. Multi-engine behavior — KV transfer/offloading simulation, KV router simulation, planner simulation — is added by the replay harness on top of multiple engine cores; see [Mocker Trace Replay](../benchmarks/mocker-trace-replay.md) for the component-level diagram and for offline replay internals under [`lib/mocker/src/replay/offline/`](../../lib/mocker/src/replay/offline/README.md).
+The mocker is organized into several cooperating components that mirror the internal architecture of production LLM inference engines. The scheduler (vLLM-style and SGLang-style variants) and KV block manager live inside the engine core. Multi-engine behavior — KV transfer/offloading simulation, KV router simulation, planner simulation — is added by the replay harness on top of multiple engine cores; see [Mocker Trace Replay](../benchmarks/mocker-trace-replay.md) for the component-level diagram and the [Offline Replay README](https://github.com/ai-dynamo/dynamo/blob/main/lib/mocker/src/replay/offline/README.md) for offline replay internals.
 
 ### Scheduler
 
@@ -388,7 +388,7 @@ When resources become constrained, the mocker simulates the engine's real recove
 
 ### KV Block Manager
 
-The mocker's KV block manager is now built on [`kvbm-logical::BlockManager<G1>`](../../lib/kvbm-logical/), the same logical block manager the real Dynamo runtime uses. The mocker wraps it in [`lib/mocker/src/kv_manager/kvbm_backend.rs`](../../lib/mocker/src/kv_manager/kvbm_backend.rs) and translates its own `MoveBlock` protocol onto kvbm-logical's RAII lifecycle (`allocate → stage → register → drop`).
+The mocker's KV block manager is now built on [KV Block Manager](https://github.com/ai-dynamo/dynamo/tree/main/lib/kvbm-logical) (the `kvbm-logical::BlockManager<G1>` crate), the same logical block manager the real Dynamo runtime uses. The [Dynamo Mocker](https://github.com/ai-dynamo/dynamo/blob/main/lib/mocker/src/kv_manager/kvbm_backend.rs) wraps it and translates its own `MoveBlock` protocol onto kvbm-logical's RAII lifecycle (`allocate → stage → register → drop`).
 
 Blocks still conceptually live in one of two pools:
 
@@ -417,7 +417,7 @@ Three `Use` outcomes are tracked for KV-event emission: `ActiveHit` (bump refcou
 
 ### Eviction Backends
 
-The kvbm-logical inactive pool selects eviction victims via one of three backends, exposed as `MockerEvictionBackend` in [`lib/mocker/src/common/protocols.rs`](../../lib/mocker/src/common/protocols.rs):
+The kvbm-logical inactive pool selects eviction victims via one of three backends, exposed as `MockerEvictionBackend` in the [Dynamo Mocker](https://github.com/ai-dynamo/dynamo/blob/main/lib/mocker/src/common/protocols.rs):
 
 - **`Lineage`** (default) — parent-chain aware: evicts leaf blocks first, preserving shared prefix chains. Subsumes the preemption-priority behavior the old hand-rolled `LRUEvictor::push_front` used to provide.
 - **`Lru`** — plain recency-based LRU.
@@ -493,9 +493,9 @@ The mocker is particularly useful for:
 | Document | Description |
 |----------|-------------|
 | [Benchmarking Dynamo Deployments](../benchmarks/benchmarking.md) | Run AIPerf against a mocker-backed deployment to measure latency, TTFT, throughput, and scaling behavior |
-| [Aggregated Mocker Deployment Example](../../examples/backends/mocker/deploy/agg.yaml) | Deploy a mocker-backed aggregated DynamoGraphDeployment on Kubernetes |
-| [Disaggregated Mocker Deployment Example](../../examples/backends/mocker/deploy/disagg.yaml) | Deploy separate prefill and decode mocker workers for disaggregated-serving benchmarks |
-| [Global Planner Mocker Example](../../examples/global_planner/global-planner-mocker-test.yaml) | Advanced multi-pool mocker setup for planner and global-router experiments |
+| [Aggregated Mocker Deployment Example](https://github.com/ai-dynamo/dynamo/blob/main/examples/backends/mocker/deploy/agg.yaml) | Deploy a mocker-backed aggregated DynamoGraphDeployment on Kubernetes |
+| [Disaggregated Mocker Deployment Example](https://github.com/ai-dynamo/dynamo/blob/main/examples/backends/mocker/deploy/disagg.yaml) | Deploy separate prefill and decode mocker workers for disaggregated-serving benchmarks |
+| [Global Planner Mocker Example](https://github.com/ai-dynamo/dynamo/blob/main/examples/global_planner/global-planner-mocker-test.yaml) | Advanced multi-pool mocker setup for planner and global-router experiments |
 
 ## Feature Gaps (WIP)
 

--- a/docs/templates/README.md
+++ b/docs/templates/README.md
@@ -175,4 +175,4 @@ After adding new documentation:
 1. **Sphinx (current):** Update `docs/index.rst` or the appropriate `_sections/*.rst` file to include your new docs in the navigation
 2. **Fern (future):** Update `fern/docs.yml` with your new pages
 
-See [docs/README.md](../../README.md) for documentation build instructions.
+See the [Dynamo Docs Guide](../README.md) for documentation build instructions.


### PR DESCRIPTION
## Overview

Adds a small CI check that fails if any markdown link in `docs/` resolves to a path outside `docs/`. Catches the class of issue that broke 50 links on the published site and that `fern check` / `lychee` cannot see.

Layered on top of #9384 (which fixes the existing offenders). Merge that first, this second.

## Why

The published `docs-website` branch ships only `fern/`. Links like `[x](../../lib/foo.rs)` or `[x](../../../README.md)` 404 on docs.nvidia.com even though the target file exists in the repo. `fern check` cannot see this because Fern operates on the `docs-website` branch (where `lib/`, `examples/`, etc. don't exist). `lychee` only validates HTTP URLs.

## What changed

**New script** `.github/workflows/check_cross_tree_links.py` (~50 lines):
- Walks `docs/**/*.md`
- Resolves every relative link target
- Emits a GitHub annotation when the resolved path leaves `docs/`
- Skips fenced code blocks, anchor-only links (`#section`), external URLs, and root-absolute Fern slugs (`/components/...`)

**New CI job** `cross-tree-link-check` in `.github/workflows/docs-link-check.yml`:
- Path-filtered to PRs touching `docs/**` (via `dorny/paths-filter@v3`)
- Existing `lychee` and `broken-links-check` jobs unchanged

**One straggler fix** that the v1 scan missed:
- `docs/templates/README.md` linked to `../../README.md` (repo root) when the intent was the docs README at `../README.md`.

## Validation

```bash
$ python3 .github/workflows/check_cross_tree_links.py
No cross-tree docs links found.

# Add a bad link, re-run:
$ python3 .github/workflows/check_cross_tree_links.py
::error file=docs/README.md,line=534::Link target outside docs/: '../../lib/foo.rs'. ...
Found 1 cross-tree link(s) in docs/.
```

## Suggested merge order

1. #9384 (fixes the existing 50 broken links)
2. This PR (prevents regressions)

If this merges first, #9384's CI will start failing on the existing offenders — but those are exactly what #9384 fixes, so the next push to #9384 will go green.

## Test plan

- [ ] CI runs `cross-tree-link-check` and passes on this PR
- [ ] Existing `lychee` + `broken-links-check` jobs still run and pass
- [ ] Manually add a bad link, push to a test branch, confirm annotation fires

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9389" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added automated documentation link validation to CI/CD pipeline to continuously check for broken or invalid cross-references

* **Documentation**
  * Standardized internal documentation links across backend guides, component documentation, deployment guides, and feature documentation to ensure consistent reference patterns and improve cross-document navigation reliability

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9389)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->