### PR TITLE
docs: reorganize tool calling and reasoning into top-level sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ If you're running a single model on a single GPU, your inference engine alone is
 | [**SLA-Based Planner**](https://docs.nvidia.com/dynamo/components/planner/planner-guide) | ✅ | ✅ | ✅ |
 | [**KVBM**](https://docs.nvidia.com/dynamo/components/kvbm) | 🚧 | ✅ | ✅ |
 | [**Multimodal**](https://docs.nvidia.com/dynamo/user-guides/multimodal) | ✅ | ✅ | ✅ |
-| [**Tool Calling**](https://docs.nvidia.com/dynamo/user-guides/agents/tool-calling) | ✅ | ✅ | ✅ |
+| [**Tool Calling**](https://docs.nvidia.com/dynamo/user-guides/tool-calling) | ✅ | ✅ | ✅ |
 
 > **[Full Feature Matrix →](https://docs.nvidia.com/dynamo/resources/feature-matrix)** — LoRA, request migration, speculative decoding, and feature interactions.
 
@@ -267,4 +267,4 @@ To quickly setup both: `docker compose -f deploy/docker-compose.yml up -d`
 [kvbm]: docs/components/kvbm/README.md
 [migration]: docs/fault-tolerance/request-migration.md
 [lora]: examples/backends/vllm/deploy/lora/README.md
-[tools]: docs/agents/tool-calling.md
+[tools]: docs/tool-calling/README.md

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ If you're running a single model on a single GPU, your inference engine alone is
 | [**SLA-Based Planner**](https://docs.nvidia.com/dynamo/components/planner/planner-guide) | ✅ | ✅ | ✅ |
 | [**KVBM**](https://docs.nvidia.com/dynamo/components/kvbm) | 🚧 | ✅ | ✅ |
 | [**Multimodal**](https://docs.nvidia.com/dynamo/user-guides/multimodal) | ✅ | ✅ | ✅ |
-| [**Tool Calling**](https://docs.nvidia.com/dynamo/user-guides/tool-calling) | ✅ | ✅ | ✅ |
+| [**Tool Calling**](docs/tool-calling/README.md) | ✅ | ✅ | ✅ |
 
 > **[Full Feature Matrix →](https://docs.nvidia.com/dynamo/resources/feature-matrix)** — LoRA, request migration, speculative decoding, and feature interactions.
 

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -16,9 +16,8 @@ telemetry, routing hints, and backend-specific cache behavior.
 |---------|---------|
 | [Agent Tracing](agent-tracing.md) | Passive `session_id`/`trajectory_id` metadata plus Dynamo-owned request timing, token, cache, worker-placement, and harness tool-event traces. |
 | [Agent Hints](agent-hints.md) | Optional per-request hints such as priority, expected output length, and speculative prefill. |
-| [Tool Calling](tool-calling.md) | Supported tool-call parsers and parser names. |
-| [Reasoning](reasoning.md) | Supported reasoning parsers for chain-of-thought models. |
-| [Chat Processors](chat-processor-options.md) | Dynamo, vLLM, and SGLang preprocessing options. |
+| [Tool Calling](../tool-calling/README.md) | Supported tool-call parsers and parser names, plus engine-fallback configurations. |
+| [Reasoning](../reasoning/README.md) | Supported reasoning parsers for chain-of-thought models, plus engine-fallback configurations. |
 
 ## Backend-Specific Guides
 

--- a/docs/backends/sglang/sglang-chat-processor.md
+++ b/docs/backends/sglang/sglang-chat-processor.md
@@ -149,6 +149,6 @@ Key differences:
 
 ## See Also
 
-- **[Tool Calling](../../agents/tool-calling.md)**: General tool calling guide
+- **[Tool Calling](../../tool-calling/README.md)**: General tool calling guide
 - **[Reference Guide](sglang-reference-guide.md)**: Full SGLang backend reference
 - **[Agentic Workloads](agents.md)**: Priority scheduling and cache pinning for agents

--- a/docs/backends/sglang/sglang-reference-guide.md
+++ b/docs/backends/sglang/sglang-reference-guide.md
@@ -35,8 +35,8 @@ These arguments are added by Dynamo on top of SGLang's native arguments.
 |----------|---------|---------|-------------|
 | `--endpoint` | `DYN_ENDPOINT` | Auto-generated | Dynamo endpoint in `dyn://namespace.component.endpoint` format |
 | `--use-sglang-tokenizer` | `DYN_SGL_USE_TOKENIZER` | `false` | **[Deprecated]** Use `--dyn-chat-processor sglang` on the frontend instead. See [SGLang Chat Processor](sglang-chat-processor.md). |
-| `--dyn-tool-call-parser` | `DYN_TOOL_CALL_PARSER` | `None` | [Tool call](../../agents/tool-calling.md#supported-tool-call-parsers) parser (overrides SGLang's `--tool-call-parser`) |
-| `--dyn-reasoning-parser` | `DYN_REASONING_PARSER` | `None` | [Reasoning](../../agents/reasoning.md#supported-reasoning-parsers) parser for chain-of-thought models |
+| `--dyn-tool-call-parser` | `DYN_TOOL_CALL_PARSER` | `None` | [Tool call](../../tool-calling/dynamo.md#supported-tool-call-parsers) parser (overrides SGLang's `--tool-call-parser`) |
+| `--dyn-reasoning-parser` | `DYN_REASONING_PARSER` | `None` | [Reasoning](../../reasoning/dynamo.md#supported-reasoning-parsers) parser for chain-of-thought models |
 | `--custom-jinja-template` | `DYN_CUSTOM_JINJA_TEMPLATE` | `None` | Custom chat template path (incompatible with `--use-sglang-tokenizer`) |
 | `--embedding-worker` | `DYN_SGL_EMBEDDING_WORKER` | `false` | Run as embedding worker (also sets SGLang's `--is-embedding`) |
 | `--multimodal-encode-worker` | `DYN_SGL_MULTIMODAL_ENCODE_WORKER` | `false` | Run as [multimodal](../../features/multimodal/multimodal-sglang.md) encode worker (frontend-facing) |
@@ -50,7 +50,7 @@ These arguments are added by Dynamo on top of SGLang's native arguments.
 `--disagg-config` and `--disagg-config-key` must be provided together. The selected section is written to a temp YAML file and passed to SGLang's `--config` flag.
 </Note>
 
-The current supported parser names for both flags are documented in [Tool Calling](../../agents/tool-calling.md#supported-tool-call-parsers) and [Reasoning](../../agents/reasoning.md#supported-reasoning-parsers).
+The current supported parser names for both flags are documented in [Tool Call Parsing (Dynamo)](../../tool-calling/dynamo.md#supported-tool-call-parsers) and [Reasoning Parsing (Dynamo)](../../reasoning/dynamo.md#supported-reasoning-parsers).
 
 ## Tokenizer Behavior
 

--- a/docs/backends/vllm/vllm-chat-processor.md
+++ b/docs/backends/vllm/vllm-chat-processor.md
@@ -1,0 +1,132 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: vLLM Chat Processor
+subtitle: vLLM-native preprocessing and postprocessing for chat completions
+---
+
+The vLLM chat processor enables vLLM-native preprocessing and postprocessing in the Dynamo frontend. It uses vLLM's tokenizer, chat templates, tool call parser, and reasoning parser directly -- bypassing the default Rust preprocessor for `v1/chat/completions` requests.
+
+## When to Use
+
+Use `--dyn-chat-processor vllm` when Dynamo's built-in Rust preprocessor does not yet support a tool call parser or reasoning parser you need. The vLLM processor delegates to vLLM's Python implementations, so any parser vLLM supports works immediately.
+
+Common cases:
+
+- A **tool call format** not yet in the Rust `tool_calling` library
+- A **reasoning parser** not yet supported natively
+- A **chat template** that the Rust preprocessor doesn't handle correctly
+
+If the parser you need is missing from the Rust preprocessor, consider [opening an issue or PR](https://github.com/ai-dynamo/dynamo/issues) to add native support -- native parsers avoid the Python GIL overhead entirely.
+
+## Quick Start
+
+```bash
+# Frontend with vLLM processor, tool calling, and reasoning
+python -m dynamo.frontend \
+  --router-mode kv \
+  --dyn-chat-processor vllm \
+  --enable-auto-tool-choice \
+  --tool-call-parser hermes \
+  --reasoning-parser qwen3
+
+# Workers (unchanged)
+CUDA_VISIBLE_DEVICES=0 python -m dynamo.vllm \
+  --model Qwen/Qwen3-14B-FP8 \
+  --served-model-name Qwen/Qwen3-14B-FP8 \
+  --tensor-parallel-size 1 --trust-remote-code
+```
+
+## Frontend Arguments
+
+These arguments are passed to the **frontend** (not the worker) when using `--dyn-chat-processor vllm`. The frontend forwards unknown arguments to vLLM's own CLI parser (`AsyncEngineArgs` and `FrontendArgs`), so any vLLM frontend or engine flag is accepted.
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `--dyn-chat-processor vllm` | (none) | Enable the vLLM chat processor |
+| `--tool-call-parser` | `None` | Tool call parser name (any vLLM-supported parser) |
+| `--reasoning-parser` | `None` | Reasoning parser name (any vLLM-supported parser) |
+| `--enable-auto-tool-choice` | `False` | Allow the model to emit tool calls without an explicit `tool_choice` in the request |
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DYN_VLLM_STREAM_INTERVAL` | `20` | Number of tokens to accumulate before detokenizing. Higher values improve throughput. The first chunk always emits immediately (interval=1) to minimize time-to-first-token. |
+
+## Tool Calling
+
+The processor supports all vLLM tool call formats. Pass `--tool-call-parser` (and typically `--enable-auto-tool-choice`) on the frontend:
+
+```bash
+python -m dynamo.frontend \
+  --dyn-chat-processor vllm \
+  --enable-auto-tool-choice \
+  --tool-call-parser hermes
+```
+
+Any parser supported by vLLM can be used. See the [vLLM documentation](https://docs.vllm.ai/) for the full list of available tool call parsers.
+
+### Example: Tool Call Request
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen/Qwen3-14B-FP8",
+    "messages": [{"role": "user", "content": "What is the weather in Paris?"}],
+    "tools": [{
+      "type": "function",
+      "function": {
+        "name": "get_weather",
+        "description": "Get weather for a city",
+        "parameters": {
+          "type": "object",
+          "properties": {"city": {"type": "string"}},
+          "required": ["city"]
+        }
+      }
+    }],
+    "tool_choice": "auto"
+  }'
+```
+
+Response:
+
+```json
+{
+  "choices": [{
+    "message": {
+      "role": "assistant",
+      "tool_calls": [{
+        "id": "call_8cd24396f3671048",
+        "type": "function",
+        "function": {
+          "name": "get_weather",
+          "arguments": "{\"city\": \"Paris\"}"
+        }
+      }],
+      "reasoning_content": "The user wants weather info for Paris..."
+    },
+    "finish_reason": "tool_calls"
+  }]
+}
+```
+
+## Reasoning Parsing
+
+For models that produce chain-of-thought reasoning (e.g., Qwen3, DeepSeek-R1), pass `--reasoning-parser`:
+
+```bash
+python -m dynamo.frontend \
+  --dyn-chat-processor vllm \
+  --reasoning-parser qwen3
+```
+
+The parser separates think tag content into the `reasoning_content` field and regular content into the `content` field.
+
+## See Also
+
+- **[Tool Calling](../../tool-calling/README.md)**: General tool calling guide
+- **[Reference Guide](vllm-reference-guide.md)**: Full vLLM backend reference
+- **[Examples](vllm-examples.md)**: vLLM deployment examples

--- a/docs/backends/vllm/vllm-reference-guide.md
+++ b/docs/backends/vllm/vllm-reference-guide.md
@@ -29,7 +29,7 @@ The `--help` output is organized into the following groups:
 
 ### Tool and Reasoning Parsers
 
-Use `--dyn-tool-call-parser` and `--dyn-reasoning-parser` to match the model's output format when the model emits tool calls and/or reasoning content. The current supported values are documented in [Tool Calling](../../agents/tool-calling.md#supported-tool-call-parsers) and [Reasoning](../../agents/reasoning.md#supported-reasoning-parsers).
+Use `--dyn-tool-call-parser` and `--dyn-reasoning-parser` to match the model's output format when the model emits tool calls and/or reasoning content. The current supported values are documented in [Tool Call Parsing (Dynamo)](../../tool-calling/dynamo.md#supported-tool-call-parsers) and [Reasoning Parsing (Dynamo)](../../reasoning/dynamo.md#supported-reasoning-parsers).
 
 ### Prompt Embeddings
 

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -251,7 +251,7 @@ navigation:
         contents:
           - page: Reference Guide
             path: backends/sglang/sglang-reference-guide.md
-          - page: Chat Processor
+          - page: Frontend Processor Fallback
             path: backends/sglang/sglang-chat-processor.md
           - page: Examples
             path: backends/sglang/sglang-examples.md
@@ -281,6 +281,8 @@ navigation:
         contents:
           - page: Reference Guide
             path: backends/vllm/vllm-reference-guide.md
+          - page: Frontend Processor Fallback
+            path: backends/vllm/vllm-chat-processor.md
           - page: Examples
             path: backends/vllm/vllm-examples.md
           - page: KV Cache Offloading

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -186,14 +186,24 @@ navigation:
             path: agents/agent-tracing.md
           - page: Agent Hints
             path: agents/agent-hints.md
-          - page: Chat Processors
-            path: agents/chat-processor-options.md
-          - page: Tool Calling
-            path: agents/tool-calling.md
-          - page: Reasoning
-            path: agents/reasoning.md
           - page: SGLang for Agentic Workloads
             path: backends/sglang/agents.md
+      - section: Tool Calling
+        slug: tool-calling
+        path: tool-calling/README.md
+        contents:
+          - page: Tool Call Parsing (Dynamo)
+            path: tool-calling/dynamo.md
+          - page: Tool Call Parsing (Engine Fallback)
+            path: tool-calling/engine-fallback.md
+      - section: Reasoning
+        slug: reasoning
+        path: reasoning/README.md
+        contents:
+          - page: Reasoning Parsing (Dynamo)
+            path: reasoning/dynamo.md
+          - page: Reasoning Parsing (Engine Fallback)
+            path: reasoning/engine-fallback.md
       - section: Observability (Local)
         path: observability/README.md
         contents:

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -154,6 +154,22 @@ navigation:
         path: components/router/router-guide.md
       - page: KV Cache Offloading
         path: components/kvbm/kvbm-guide.md
+      - section: Tool Calling
+        slug: tool-calling
+        path: tool-calling/README.md
+        contents:
+          - page: Tool Call Parsing (Dynamo)
+            path: tool-calling/dynamo.md
+          - page: Tool Call Parsing (Engine Fallback)
+            path: tool-calling/engine-fallback.md
+      - section: Reasoning
+        slug: reasoning
+        path: reasoning/README.md
+        contents:
+          - page: Reasoning Parsing (Dynamo)
+            path: reasoning/dynamo.md
+          - page: Reasoning Parsing (Engine Fallback)
+            path: reasoning/engine-fallback.md
       - section: Multimodal
         path: features/multimodal/README.md
         contents:
@@ -188,22 +204,6 @@ navigation:
             path: agents/agent-hints.md
           - page: SGLang for Agentic Workloads
             path: backends/sglang/agents.md
-      - section: Tool Calling
-        slug: tool-calling
-        path: tool-calling/README.md
-        contents:
-          - page: Tool Call Parsing (Dynamo)
-            path: tool-calling/dynamo.md
-          - page: Tool Call Parsing (Engine Fallback)
-            path: tool-calling/engine-fallback.md
-      - section: Reasoning
-        slug: reasoning
-        path: reasoning/README.md
-        contents:
-          - page: Reasoning Parsing (Dynamo)
-            path: reasoning/dynamo.md
-          - page: Reasoning Parsing (Engine Fallback)
-            path: reasoning/engine-fallback.md
       - section: Observability (Local)
         path: observability/README.md
         contents:
@@ -298,6 +298,8 @@ navigation:
         contents:
           - page: Frontend Guide
             path: components/frontend/frontend-guide.md
+          - page: Configuration Reference
+            path: components/frontend/configuration.md
           - page: Tokenizer
             path: components/frontend/Tokenizer.md
       - section: Router

--- a/docs/reasoning/README.md
+++ b/docs/reasoning/README.md
@@ -1,0 +1,30 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: Reasoning
+subtitle: Separate reasoning content from assistant output for chain-of-thought models
+---
+
+Some models emit reasoning or thinking content separately from their final
+response. Dynamo can split that output into `reasoning_content` and normal
+assistant content by configuring a reasoning parser. As with tool calling,
+there are two ways to do this depending on whether the parser lives in
+Dynamo's own registry or in the upstream engine (vLLM, SGLang).
+
+## Choose a parsing path
+
+| Path | When to use | Page |
+|------|-------------|------|
+| **Dynamo** | Dynamo ships a Rust parser for the model's reasoning format. Lowest latency, KV-routable, the default path. | [Reasoning Parsing (Dynamo)](dynamo.md) |
+| **Engine Fallback** | Dynamo does not have a parser, but the upstream engine (vLLM or SGLang) does. Tokenization stays on the frontend, parsing delegates to the engine's Python preprocessor. | [Reasoning Parsing (Engine Fallback)](engine-fallback.md) |
+
+Start with the Dynamo path. Fall back to the engine path only when Dynamo's
+registry does not list a parser for your model.
+
+## See Also
+
+- [Tool Calling](../tool-calling/README.md) -- parse tool calls out of model
+  output. Several models need both a reasoning parser and a tool-call parser
+  configured together.
+- [Frontend Configuration Reference](../components/frontend/configuration.md) --
+  full CLI flag reference.

--- a/docs/reasoning/dynamo.md
+++ b/docs/reasoning/dynamo.md
@@ -40,21 +40,21 @@ require the opening tag to be present in the model output.
 
 | Parser Name | Models | Upstream name | Force-reasoning | Notes |
 |---|---|---|---|---|
+| `kimi_k25` | Kimi K2.5 | Dynamo-only | Yes | `<think>...</think>` with force-reasoning |
+| `qwen3` | Qwen3.5, QwQ-32B, Qwen3-Think, Qwen3-Coder | | No | `<think>...</think>` |
+| `deepseek_v4` | DeepSeek V4 Pro / Flash | vLLM: `deepseek_v4`; SGLang: `deepseek-v4` | No | `<think>...</think>`. Aliases: `deepseek-v4`, `deepseekv4` |
 | `basic` | Generic CoT models | Dynamo-only | No | Plain `<think>...</think>` |
 | `deepseek_r1` | DeepSeek R1, DeepSeek V3.1, DeepSeek V3.2 | | Yes | Pass explicitly for V3.1/V3.2 (no alias) |
-| `deepseek_v4` | DeepSeek V4 Pro / Flash | vLLM: `deepseek_v4`; SGLang: `deepseek-v4` | No | `<think>...</think>`. Aliases: `deepseek-v4`, `deepseekv4` |
 | `gemma4` | Google Gemma 4 (thinking models) | vLLM: `gemma4` | No | `<\|channel>thought\n...<channel\|>` with `thought\n` role label stripped. Aliases: `gemma-4` |
 | `glm45` | GLM-4.5, GLM-4.7 | Dynamo-only | No | Alias for `nemotron_deci`. `<think>...</think>` |
 | `gpt_oss` | gpt-oss-20b / -120b | Dynamo-only | No | Harmony channel reasoning format |
 | `granite` | Granite 3.x | | No | `Here's my thought process:` / `Here's my response:` |
 | `kimi` | Kimi K2 Instruct / Thinking | Dynamo-only | No | `◁think▷...◁/think▷` |
-| `kimi_k25` | Kimi K2.5 | Dynamo-only | Yes | `<think>...</think>` with force-reasoning |
 | `minimax_append_think` | MiniMax M2 / M2.1 | Dynamo-only | No | Implicit opening `<think>` prepended |
 | `mistral` | Magistral | | Yes | `[THINK]...[/THINK]` |
 | `nemotron3` | Nemotron-3 / Mini | vLLM: `nemotron_v3` | Yes | Alias for `deepseek_r1`. Also accepts `nemotron_v3` |
 | `nemotron_deci` | Nemotron-Super / -Ultra / -Deci, Llama-Nemotron | Dynamo-only | No | `<think>...</think>` |
 | `nemotron_nano` | Nemotron-Nano | Dynamo-only | Yes | Alias for `deepseek_r1` |
-| `qwen3` | QwQ-32B, Qwen3-Think, Qwen3-Coder, Qwen3.5 | | No | `<think>...</think>` |
 | `step3` | Step-3 / Step-3-Reasoning | Dynamo-only | Yes | `<think>...</think>` |
 
 ## Common Parser Pairings

--- a/docs/reasoning/dynamo.md
+++ b/docs/reasoning/dynamo.md
@@ -1,17 +1,15 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-title: Reasoning
-subtitle: Configure reasoning parsers for models that emit thinking content
+title: Reasoning Parsing (Dynamo)
+subtitle: Configure Dynamo's built-in reasoning parsers for models that emit thinking content
 ---
 
 Some models emit reasoning or thinking content separately from their final response. Dynamo can split that output into `reasoning_content` and normal assistant content by configuring `--dyn-reasoning-parser` on the backend worker.
 
-> [!TIP]
-> This page covers parser names for the default Dynamo-native path. For a
-> comparison of all preprocessing options (including vLLM/SGLang chat-processor
-> swap and tokenizer delegation) and routing
-> compatibility, see [Chat Processor Options](chat-processor-options.md).
+This page covers parser names for the default Dynamo-native path. If Dynamo
+does not list a parser for your model, see
+[Reasoning Parsing (Engine Fallback)](engine-fallback.md).
 
 ## Prerequisites
 
@@ -25,14 +23,14 @@ python -m dynamo.<backend> --help
 ```
 
 > [!TIP]
-> Some models need both a reasoning parser and a tool call parser. For supported tool call parser names, see [Tool Calling](tool-calling.md).
+> Some models need both a reasoning parser and a tool call parser. For supported tool call parser names, see [Tool Call Parsing (Dynamo)](../tool-calling/dynamo.md).
 
 ## Supported Reasoning Parsers
 
 The table below lists the currently supported reasoning parsers in Dynamo's registry. The
 **Upstream name** column shows where the vLLM or SGLang parser name differs
 from Dynamo's -- relevant when using `--dyn-chat-processor vllm` or `sglang`
-(see [Chat Processor Options](chat-processor-options.md)). A blank upstream
+(see [Reasoning Parsing (Engine Fallback)](engine-fallback.md)). A blank upstream
 column means the same name works everywhere. `Dynamo-only` means no upstream
 parser exists for this format.
 

--- a/docs/reasoning/engine-fallback.md
+++ b/docs/reasoning/engine-fallback.md
@@ -5,185 +5,65 @@ title: Reasoning Parsing (Engine Fallback)
 subtitle: Use upstream vLLM or SGLang reasoning parsers when Dynamo does not ship one
 ---
 
-When Dynamo's registry does not list a reasoning parser for your model, you
-can fall back to the upstream engine's parser by switching the **chat
-processor** on the frontend, or by handing tokenization to the engine
-entirely. This page describes the available preprocessing configurations for
-reasoning parsing and how they interact with KV cache routing.
+When Dynamo's registry does not list a reasoning parser for your model, fall
+back to the upstream engine's parser. Two paths are available: **chat-processor
+swap** (keeps frontend tokenization and KV routing) and **tokenizer
+delegation** (engine owns tokenization, no KV routing).
 
-For the list of Dynamo-native parser names, see
-[Reasoning Parsing (Dynamo)](dynamo.md). For the equivalent tool-call parser
-fallback, see [Tool Call Parsing (Engine Fallback)](../tool-calling/engine-fallback.md).
+For Dynamo-native parsers, see [Reasoning Parsing (Dynamo)](dynamo.md). For
+the equivalent tool-call fallback, see
+[Tool Call Parsing (Engine Fallback)](../tool-calling/engine-fallback.md).
 
 > [!WARNING]
-> **Known Issue:** Engine-fallback reasoning parsing (options B/C/D/E below)
-> does not currently work with [disaggregated serving](../features/disaggregated-serving/README.md).
-> Use the [Dynamo-native reasoning parser](dynamo.md) (option A) for
-> disaggregated deployments.
+> **Known Issue:** Engine-fallback reasoning parsing does not currently work
+> with [disaggregated serving](../features/disaggregated-serving/README.md).
+> Use the [Dynamo-native reasoning parser](dynamo.md) for disaggregated
+> deployments.
 
 ## Configurations
 
-There are five supported configurations. Each is set at startup -- Dynamo does
-not switch between them per request.
-
 | | Frontend flags | Worker flags | KV routing | Notes |
 |---|---|---|---|---|
-| **A** Dynamo-native (default) | `--dyn-chat-processor dynamo` | `--dyn-reasoning-parser <name>` | Yes | Rust preprocessor. Lowest latency. See [Reasoning Parsing (Dynamo)](dynamo.md). |
-| **B** vLLM chat processor | `--dyn-chat-processor vllm` `--reasoning-parser <name>` | *(none)* | Yes | Delegates reasoning parsing to vLLM's Python preprocessor. |
-| **C** SGLang chat processor | `--dyn-chat-processor sglang` `--reasoning-parser <name>` | *(none)* | Yes | Delegates reasoning parsing to SGLang's Python preprocessor. See [SGLang Chat Processor](../backends/sglang/sglang-chat-processor.md). |
-| **D** vLLM tokenizer delegation | `--router-mode round-robin` | `--use-vllm-tokenizer` | No | Engine-side tokenization. Day-0 model fallback. |
-| **E** SGLang tokenizer delegation | `--router-mode round-robin` | `--use-sglang-tokenizer` | No | **Deprecated** -- use option C instead. |
+| **vLLM chat processor** | `--dyn-chat-processor vllm --reasoning-parser <name>` | *(none)* | Yes | Parsing runs in vLLM's Python preprocessor. |
+| **SGLang chat processor** | `--dyn-chat-processor sglang --reasoning-parser <name>` | *(none)* | Yes | Parsing runs in SGLang's Python preprocessor. See [SGLang Chat Processor](../backends/sglang/sglang-chat-processor.md). |
+| **vLLM tokenizer delegation** | `--router-mode round-robin` | `--use-vllm-tokenizer` | No | Engine owns tokenization. Day-0 model fallback. |
+| **SGLang tokenizer delegation** | `--router-mode round-robin` | `--use-sglang-tokenizer` | No | **Deprecated.** Use SGLang chat processor instead. |
 
-> [!NOTE]
-> Although `dynamo` is the default for `--dyn-chat-processor`, specifying it
-> explicitly in launch scripts makes the choice visible in logs and support
-> diagnostics.
+Upstream parser names come from the engine's registry and may differ from
+Dynamo's name for the same model (e.g., vLLM's `nemotron_v3` vs Dynamo's
+`nemotron3`). They are pinned to the engine version shipped in the Dynamo
+container.
 
-## Flag reference
+## Pitfalls
 
-### `--dyn-chat-processor {dynamo | vllm | sglang}`
+- **Tokenizer delegation + `--router-mode kv`** -- silent cache misses from
+  prefix-hash mismatches. Pair tokenizer delegation with `round-robin` or
+  `random`.
+- **`--use-vllm-tokenizer` on an SGLang worker** (or vice versa) -- rejected
+  at startup. The flag must match the engine.
+- **`--use-sglang-tokenizer` is deprecated** -- migrate to
+  `--dyn-chat-processor sglang`. See
+  [Migration from --use-sglang-tokenizer](../backends/sglang/sglang-chat-processor.md#migration-from---use-sglang-tokenizer).
 
-Frontend flag (default `dynamo`). Selects the chat processor that renders
-templates, tokenizes, and dispatches parsing.
-
-- `dynamo` -- Rust preprocessor. Reasoning parser names come from Dynamo's
-  registry (see [Reasoning Parsing (Dynamo)](dynamo.md)).
-- `vllm` -- vLLM's Python preprocessor. Reasoning parser names come from
-  vLLM's registry, which may differ from Dynamo's.
-- `sglang` -- SGLang's Python preprocessor. Reasoning parser names come from
-  SGLang's registry. See [SGLang Chat Processor](../backends/sglang/sglang-chat-processor.md).
-
-### `--dyn-reasoning-parser <name>`
-
-Worker flag. Names from Dynamo's parser registry. Only effective under
-`--dyn-chat-processor dynamo` (option A); silently ignored under other chat
-processors.
-
-The flag is declared on the worker CLI, but the parser runs on the frontend --
-the name propagates via model metadata. For supported names, see
-[Reasoning Parsing (Dynamo)](dynamo.md).
-
-### `--reasoning-parser <name>`
-
-Frontend flag (no `--dyn-` prefix). Names from the upstream engine's registry.
-Only accepted when paired with the matching chat processor:
-
-- Under `--dyn-chat-processor vllm`: accepted. Use vLLM reasoning parser names.
-- Under `--dyn-chat-processor sglang`: accepted. Use SGLang reasoning parser names.
-- Under `--dyn-chat-processor dynamo`: **rejected at startup** with
-  `Unknown arguments specified: ...`. Use the `--dyn-reasoning-parser` worker
-  flag instead.
-
-Upstream parser names are pinned to the engine version shipped in the Dynamo
-container. They may differ from Dynamo's names for the same model (e.g.,
-vLLM uses `nemotron_v3` where Dynamo uses `nemotron3`).
-
-### `--use-vllm-tokenizer` / `--use-sglang-tokenizer`
-
-Worker flags (boolean). Hand tokenization to the engine instead of the
-frontend. The flag must match the engine on the worker.
-
-`--use-sglang-tokenizer` is deprecated. New SGLang deployments should use
-`--dyn-chat-processor sglang` (option C) instead. See
-[Migration from --use-sglang-tokenizer](../backends/sglang/sglang-chat-processor.md#migration-from---use-sglang-tokenizer).
-
-## Which option should I pick?
-
-1. **Does Dynamo have a reasoning parser for your model?** Check the table in
-   [Reasoning Parsing (Dynamo)](dynamo.md). If yes, use **option A**. This is
-   the default path: Rust parsing on the frontend, KV-routable, lowest latency.
-
-2. **Does the upstream engine have a parser but Dynamo doesn't?** Use
-   **option B** (vLLM) or **option C** (SGLang). Still KV-routable.
-
-3. **Is the tokenizer itself the problem** (day-0 model, custom special tokens,
-   rope variants)? Use **option D**. KV routing is off; pair with
-   `--router-mode round-robin`.
-
-4. **SGLang + day-0 model?** Use **option C** with the appropriate upstream
-   parser name. Do not use option E (deprecated).
-
-## Invalid and silently broken combinations
-
-### Rejected at startup
-
-- **`--dyn-chat-processor dynamo` with `--reasoning-parser <name>`**. The
-  un-prefixed flag is not recognized under the Dynamo chat processor. Use
-  `--dyn-reasoning-parser` on the worker instead.
-
-- **`--use-vllm-tokenizer` on an SGLang worker** (and vice versa). The flag
-  must match the engine.
-
-### Silently broken (no startup error, wrong results)
-
-- **Tokenizer delegation + `--router-mode kv`** -- Options D/E with `kv`
-  routing produces prefix-hash mismatches and silent cache misses.
-
-- **`--dyn-reasoning-parser` + `--use-vllm-tokenizer`** on the same vLLM
-  worker. The worker bypasses Dynamo's preprocessor while the frontend-side
-  parser is still wired up, producing mismatched token streams. No
-  mutual-exclusivity check exists today.
-
-## Routing compatibility
-
-`--router-mode kv` needs frontend tokenization to compute prefix-hash routing
-keys. Options A, B, and C keep the tokenizer on the frontend and are
-KV-routable. Options D and E move tokenization to the worker and are **not**
-KV-routable -- pair them with `round-robin` or `random`.
-
-| Option | `kv` routing | `round-robin` / `random` |
-|--------|:---:|:---:|
-| A (Dynamo-native) | Yes | Yes |
-| B (vLLM processor) | Yes | Yes |
-| C (SGLang processor) | Yes | Yes |
-| D (vLLM tokenizer delegation) | **No** | Yes |
-| E (SGLang tokenizer delegation) | **No** | Yes |
-
-## Why each flag exists
-
-- **Frontend tokenization** is required for KV cache routing. The frontend
-  needs token IDs to compute prefix-hash routing keys before the request
-  reaches a worker. Parser flags on the Rust-native path (option A) co-locate
-  with tokenization on the frontend for this reason.
-
-- **Backend tokenization** is a fallback for when frontend tokenization can't
-  or shouldn't run: unsupported model, day-0 support, tokenizer edge cases
-  (custom special tokens, rope variants). The engine owns the tokenizer in
-  this mode, so KV routing drops out.
-
-- **Chat-processor swap** (options B/C) is the middle ground: tokenization
-  stays on the frontend (KV-routable), but parsing delegates to the upstream
-  engine's Python implementation. This covers models where Dynamo's Rust
-  parser hasn't been written yet.
-
-## Canonical launch examples
+## Examples
 
 ```bash
-# A -- Dynamo-native (default).
-python -m dynamo.vllm \
-  --dyn-reasoning-parser kimi_k25
-python -m dynamo.frontend --dyn-chat-processor dynamo
-
-# B -- vLLM chat-processor (upstream parser names on the frontend).
+# vLLM chat processor
 python -m dynamo.vllm ...
-python -m dynamo.frontend \
-  --dyn-chat-processor vllm \
-  --reasoning-parser deepseek_r1
+python -m dynamo.frontend --dyn-chat-processor vllm --reasoning-parser deepseek_r1
 
-# C -- SGLang chat-processor.
+# SGLang chat processor
 python -m dynamo.sglang ...
-python -m dynamo.frontend \
-  --dyn-chat-processor sglang \
-  --reasoning-parser kimi_k25
+python -m dynamo.frontend --dyn-chat-processor sglang --reasoning-parser kimi_k25
 
-# D -- vLLM tokenizer delegation (no KV routing).
+# vLLM tokenizer delegation (no KV routing)
 python -m dynamo.vllm --use-vllm-tokenizer ...
 python -m dynamo.frontend --router-mode round-robin
 ```
 
 ## See Also
 
-- [Reasoning Parsing (Dynamo)](dynamo.md) -- Supported Dynamo parser names and pairings
-- [Tool Call Parsing (Engine Fallback)](../tool-calling/engine-fallback.md) -- Equivalent fallback configuration for tool-call parsers
-- [SGLang Chat Processor](../backends/sglang/sglang-chat-processor.md) -- Option C details
+- [Reasoning Parsing (Dynamo)](dynamo.md) -- Dynamo-native parsers and common pairings
+- [Tool Call Parsing (Engine Fallback)](../tool-calling/engine-fallback.md) -- Equivalent fallback for tool-call parsers
+- [SGLang Chat Processor](../backends/sglang/sglang-chat-processor.md) -- SGLang chat-processor details
 - [Frontend Configuration Reference](../components/frontend/configuration.md) -- Full CLI flag reference

--- a/docs/reasoning/engine-fallback.md
+++ b/docs/reasoning/engine-fallback.md
@@ -34,11 +34,11 @@ container.
 ## Examples
 
 ```bash
-# vLLM chat processor (supports KV Routing)
+# vLLM chat processor
 python -m dynamo.vllm ...
 python -m dynamo.frontend --dyn-chat-processor vllm --reasoning-parser deepseek_r1
 
-# SGLang chat processor (supports KV Routing)
+# SGLang chat processor
 python -m dynamo.sglang ...
 python -m dynamo.frontend --dyn-chat-processor sglang --reasoning-parser kimi_k25
 ```

--- a/docs/reasoning/engine-fallback.md
+++ b/docs/reasoning/engine-fallback.md
@@ -1,0 +1,183 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: Reasoning Parsing (Engine Fallback)
+subtitle: Use upstream vLLM or SGLang reasoning parsers when Dynamo does not ship one
+---
+
+When Dynamo's registry does not list a reasoning parser for your model, you
+can fall back to the upstream engine's parser by switching the **chat
+processor** on the frontend, or by handing tokenization to the engine
+entirely. This page describes the available preprocessing configurations for
+reasoning parsing and how they interact with KV cache routing.
+
+For the list of Dynamo-native parser names, see
+[Reasoning Parsing (Dynamo)](dynamo.md). For the equivalent tool-call parser
+fallback, see [Tool Call Parsing (Engine Fallback)](../tool-calling/engine-fallback.md).
+
+## Configurations
+
+There are five supported configurations. Each is set at startup -- Dynamo does
+not switch between them per request.
+
+| | Frontend flags | Worker flags | KV routing | Notes |
+|---|---|---|---|---|
+| **A** Dynamo-native (default) | `--dyn-chat-processor dynamo` | `--dyn-reasoning-parser <name>` | Yes | Rust preprocessor. Lowest latency. See [Reasoning Parsing (Dynamo)](dynamo.md). |
+| **B** vLLM chat processor | `--dyn-chat-processor vllm` `--reasoning-parser <name>` | *(none)* | Yes | Delegates reasoning parsing to vLLM's Python preprocessor. |
+| **C** SGLang chat processor | `--dyn-chat-processor sglang` `--reasoning-parser <name>` | *(none)* | Yes | Delegates reasoning parsing to SGLang's Python preprocessor. See [SGLang Chat Processor](../backends/sglang/sglang-chat-processor.md). |
+| **D** vLLM tokenizer delegation | `--router-mode round-robin` | `--use-vllm-tokenizer` | No | Engine-side tokenization. Day-0 model fallback. |
+| **E** SGLang tokenizer delegation | `--router-mode round-robin` | `--use-sglang-tokenizer` | No | **Deprecated** -- use option C instead. |
+
+> [!NOTE]
+> Although `dynamo` is the default for `--dyn-chat-processor`, specifying it
+> explicitly in launch scripts makes the choice visible in logs and support
+> diagnostics.
+
+## Flag reference
+
+### `--dyn-chat-processor {dynamo | vllm | sglang}`
+
+Frontend flag (default `dynamo`). Selects the chat processor that renders
+templates, tokenizes, and dispatches parsing.
+
+- `dynamo` -- Rust preprocessor. Reasoning parser names come from Dynamo's
+  registry (see [Reasoning Parsing (Dynamo)](dynamo.md)).
+- `vllm` -- vLLM's Python preprocessor. Reasoning parser names come from
+  vLLM's registry, which may differ from Dynamo's.
+- `sglang` -- SGLang's Python preprocessor. Reasoning parser names come from
+  SGLang's registry. See [SGLang Chat Processor](../backends/sglang/sglang-chat-processor.md).
+
+### `--dyn-reasoning-parser <name>`
+
+Worker flag. Names from Dynamo's parser registry. Only effective under
+`--dyn-chat-processor dynamo` (option A); silently ignored under other chat
+processors.
+
+The flag is declared on the worker CLI, but the parser runs on the frontend --
+the name propagates via model metadata. For supported names, see
+[Reasoning Parsing (Dynamo)](dynamo.md).
+
+### `--reasoning-parser <name>`
+
+Frontend flag (no `--dyn-` prefix). Names from the upstream engine's registry.
+Only accepted when paired with the matching chat processor:
+
+- Under `--dyn-chat-processor vllm`: accepted. Use vLLM reasoning parser names.
+- Under `--dyn-chat-processor sglang`: accepted. Use SGLang reasoning parser names.
+- Under `--dyn-chat-processor dynamo`: **rejected at startup** with
+  `Unknown arguments specified: ...`. Use the `--dyn-reasoning-parser` worker
+  flag instead.
+
+Upstream parser names are pinned to the engine version shipped in the Dynamo
+container. They may differ from Dynamo's names for the same model (e.g.,
+vLLM uses `nemotron_v3` where Dynamo uses `nemotron3`).
+
+### `--use-vllm-tokenizer` / `--use-sglang-tokenizer`
+
+Worker flags (boolean). Hand tokenization to the engine instead of the
+frontend. The flag must match the engine on the worker.
+
+`--use-sglang-tokenizer` is deprecated. New SGLang deployments should use
+`--dyn-chat-processor sglang` (option C) instead. See
+[Migration from --use-sglang-tokenizer](../backends/sglang/sglang-chat-processor.md#migration-from---use-sglang-tokenizer).
+
+## Which option should I pick?
+
+1. **Does Dynamo have a reasoning parser for your model?** Check the table in
+   [Reasoning Parsing (Dynamo)](dynamo.md). If yes, use **option A**. This is
+   the default path: Rust parsing on the frontend, KV-routable, lowest latency.
+
+2. **Does the upstream engine have a parser but Dynamo doesn't?** Use
+   **option B** (vLLM) or **option C** (SGLang). Still KV-routable.
+
+3. **Is the tokenizer itself the problem** (day-0 model, custom special tokens,
+   rope variants)? Use **option D**. KV routing is off; pair with
+   `--router-mode round-robin`.
+
+4. **SGLang + day-0 model?** Use **option C** with the appropriate upstream
+   parser name. Do not use option E (deprecated).
+
+## Invalid and silently broken combinations
+
+### Rejected at startup
+
+- **`--dyn-chat-processor dynamo` with `--reasoning-parser <name>`**. The
+  un-prefixed flag is not recognized under the Dynamo chat processor. Use
+  `--dyn-reasoning-parser` on the worker instead.
+
+- **`--use-vllm-tokenizer` on an SGLang worker** (and vice versa). The flag
+  must match the engine.
+
+### Silently broken (no startup error, wrong results)
+
+- **Tokenizer delegation + `--router-mode kv`** -- Options D/E with `kv`
+  routing produces prefix-hash mismatches and silent cache misses.
+
+- **`--dyn-reasoning-parser` + `--use-vllm-tokenizer`** on the same vLLM
+  worker. The worker bypasses Dynamo's preprocessor while the frontend-side
+  parser is still wired up, producing mismatched token streams. No
+  mutual-exclusivity check exists today.
+
+## Routing compatibility
+
+`--router-mode kv` needs frontend tokenization to compute prefix-hash routing
+keys. Options A, B, and C keep the tokenizer on the frontend and are
+KV-routable. Options D and E move tokenization to the worker and are **not**
+KV-routable -- pair them with `round-robin` or `random`.
+
+| Option | `kv` routing | `round-robin` / `random` |
+|--------|:---:|:---:|
+| A (Dynamo-native) | Yes | Yes |
+| B (vLLM processor) | Yes | Yes |
+| C (SGLang processor) | Yes | Yes |
+| D (vLLM tokenizer delegation) | **No** | Yes |
+| E (SGLang tokenizer delegation) | **No** | Yes |
+
+## Why each flag exists
+
+- **Frontend tokenization** is required for KV cache routing. The frontend
+  needs token IDs to compute prefix-hash routing keys before the request
+  reaches a worker. Parser flags on the Rust-native path (option A) co-locate
+  with tokenization on the frontend for this reason.
+
+- **Backend tokenization** is a fallback for when frontend tokenization can't
+  or shouldn't run: unsupported model, day-0 support, tokenizer edge cases
+  (custom special tokens, rope variants). The engine owns the tokenizer in
+  this mode, so KV routing drops out.
+
+- **Chat-processor swap** (options B/C) is the middle ground: tokenization
+  stays on the frontend (KV-routable), but parsing delegates to the upstream
+  engine's Python implementation. This covers models where Dynamo's Rust
+  parser hasn't been written yet.
+
+## Canonical launch examples
+
+```bash
+# A -- Dynamo-native (default).
+python -m dynamo.vllm \
+  --dyn-reasoning-parser kimi_k25
+python -m dynamo.frontend --dyn-chat-processor dynamo
+
+# B -- vLLM chat-processor (upstream parser names on the frontend).
+python -m dynamo.vllm ...
+python -m dynamo.frontend \
+  --dyn-chat-processor vllm \
+  --reasoning-parser deepseek_r1
+
+# C -- SGLang chat-processor.
+python -m dynamo.sglang ...
+python -m dynamo.frontend \
+  --dyn-chat-processor sglang \
+  --reasoning-parser kimi_k25
+
+# D -- vLLM tokenizer delegation (no KV routing).
+python -m dynamo.vllm --use-vllm-tokenizer ...
+python -m dynamo.frontend --router-mode round-robin
+```
+
+## See Also
+
+- [Reasoning Parsing (Dynamo)](dynamo.md) -- Supported Dynamo parser names and pairings
+- [Tool Call Parsing (Engine Fallback)](../tool-calling/engine-fallback.md) -- Equivalent fallback configuration for tool-call parsers
+- [SGLang Chat Processor](../backends/sglang/sglang-chat-processor.md) -- Option C details
+- [Frontend Configuration Reference](../components/frontend/configuration.md) -- Full CLI flag reference

--- a/docs/reasoning/engine-fallback.md
+++ b/docs/reasoning/engine-fallback.md
@@ -6,9 +6,8 @@ subtitle: Use upstream vLLM or SGLang reasoning parsers when Dynamo does not shi
 ---
 
 When Dynamo's registry does not list a reasoning parser for your model, fall
-back to the upstream engine's parser. Two paths are available: **chat-processor
-swap** (keeps frontend tokenization and KV routing) and **tokenizer
-delegation** (engine owns tokenization, no KV routing).
+back to the upstream engine's parser via a **chat-processor swap**, which
+keeps frontend tokenization and KV routing.
 
 For Dynamo-native parsers, see [Reasoning Parsing (Dynamo)](dynamo.md). For
 the equivalent tool-call fallback, see
@@ -24,46 +23,30 @@ the equivalent tool-call fallback, see
 
 | | Frontend flags | Worker flags | KV routing | Notes |
 |---|---|---|---|---|
-| **vLLM chat processor** | `--dyn-chat-processor vllm --reasoning-parser <name>` | *(none)* | Yes | Parsing runs in vLLM's Python preprocessor. |
+| **vLLM chat processor** | `--dyn-chat-processor vllm --reasoning-parser <name>` | *(none)* | Yes | Parsing runs in vLLM's Python preprocessor. See [vLLM Chat Processor](../backends/vllm/vllm-chat-processor.md). |
 | **SGLang chat processor** | `--dyn-chat-processor sglang --reasoning-parser <name>` | *(none)* | Yes | Parsing runs in SGLang's Python preprocessor. See [SGLang Chat Processor](../backends/sglang/sglang-chat-processor.md). |
-| **vLLM tokenizer delegation** | `--router-mode round-robin` | `--use-vllm-tokenizer` | No | Engine owns tokenization. Day-0 model fallback. |
-| **SGLang tokenizer delegation** | `--router-mode round-robin` | `--use-sglang-tokenizer` | No | **Deprecated.** Use SGLang chat processor instead. |
 
 Upstream parser names come from the engine's registry and may differ from
 Dynamo's name for the same model (e.g., vLLM's `nemotron_v3` vs Dynamo's
 `nemotron3`). They are pinned to the engine version shipped in the Dynamo
 container.
 
-## Pitfalls
-
-- **Tokenizer delegation + `--router-mode kv`** -- silent cache misses from
-  prefix-hash mismatches. Pair tokenizer delegation with `round-robin` or
-  `random`.
-- **`--use-vllm-tokenizer` on an SGLang worker** (or vice versa) -- rejected
-  at startup. The flag must match the engine.
-- **`--use-sglang-tokenizer` is deprecated** -- migrate to
-  `--dyn-chat-processor sglang`. See
-  [Migration from --use-sglang-tokenizer](../backends/sglang/sglang-chat-processor.md#migration-from---use-sglang-tokenizer).
-
 ## Examples
 
 ```bash
-# vLLM chat processor
+# vLLM chat processor (supports KV Routing)
 python -m dynamo.vllm ...
 python -m dynamo.frontend --dyn-chat-processor vllm --reasoning-parser deepseek_r1
 
-# SGLang chat processor
+# SGLang chat processor (supports KV Routing)
 python -m dynamo.sglang ...
 python -m dynamo.frontend --dyn-chat-processor sglang --reasoning-parser kimi_k25
-
-# vLLM tokenizer delegation (no KV routing)
-python -m dynamo.vllm --use-vllm-tokenizer ...
-python -m dynamo.frontend --router-mode round-robin
 ```
 
 ## See Also
 
 - [Reasoning Parsing (Dynamo)](dynamo.md) -- Dynamo-native parsers and common pairings
 - [Tool Call Parsing (Engine Fallback)](../tool-calling/engine-fallback.md) -- Equivalent fallback for tool-call parsers
+- [vLLM Chat Processor](../backends/vllm/vllm-chat-processor.md) -- vLLM chat-processor details
 - [SGLang Chat Processor](../backends/sglang/sglang-chat-processor.md) -- SGLang chat-processor details
 - [Frontend Configuration Reference](../components/frontend/configuration.md) -- Full CLI flag reference

--- a/docs/reasoning/engine-fallback.md
+++ b/docs/reasoning/engine-fallback.md
@@ -15,6 +15,12 @@ For the list of Dynamo-native parser names, see
 [Reasoning Parsing (Dynamo)](dynamo.md). For the equivalent tool-call parser
 fallback, see [Tool Call Parsing (Engine Fallback)](../tool-calling/engine-fallback.md).
 
+> [!WARNING]
+> **Known Issue:** Engine-fallback reasoning parsing (options B/C/D/E below)
+> does not currently work with [disaggregated serving](../features/disaggregated-serving/README.md).
+> Use the [Dynamo-native reasoning parser](dynamo.md) (option A) for
+> disaggregated deployments.
+
 ## Configurations
 
 There are five supported configurations. Each is set at startup -- Dynamo does

--- a/docs/reference/feature-matrix.md
+++ b/docs/reference/feature-matrix.md
@@ -119,7 +119,7 @@ TensorRT-LLM delivers maximum inference performance and optimization, with full 
 [planner]: ../components/planner
 [kvbm]: ../components/kvbm
 [migration]: ../user-guides/fault-tolerance/request-migration
-[tools]: ../user-guides/agents/tool-calling
+[tools]: ../user-guides/tool-calling
 
 {/* Multimodal */}
 [mm]: ../user-guides/multimodal

--- a/docs/tool-calling/README.md
+++ b/docs/tool-calling/README.md
@@ -1,0 +1,32 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: Tool Calling
+subtitle: Parse tool calls from model output and surface them as OpenAI-compatible tool_calls
+---
+
+Dynamo can connect models to external tools and services by parsing tool-call
+syntax out of raw model output and surfacing it as OpenAI-compatible
+`tool_calls` on the response. Tool calling is controlled by the `tool_choice`
+and `tools` request parameters on the chat completions API.
+
+There are two ways to parse tool calls in Dynamo, depending on whether the
+parser lives in Dynamo's own registry or in the upstream engine (vLLM, SGLang).
+
+## Choose a parsing path
+
+| Path | When to use | Page |
+|------|-------------|------|
+| **Dynamo** | Dynamo ships a Rust parser for the model's tool-call format. Lowest latency, KV-routable, the default path. | [Tool Call Parsing (Dynamo)](dynamo.md) |
+| **Engine Fallback** | Dynamo does not have a parser, but the upstream engine (vLLM or SGLang) does. Tokenization stays on the frontend, parsing delegates to the engine's Python preprocessor. | [Tool Call Parsing (Engine Fallback)](engine-fallback.md) |
+
+Start with the Dynamo path. Fall back to the engine path only when Dynamo's
+registry does not list a parser for your model.
+
+## See Also
+
+- [Reasoning](../reasoning/README.md) -- separate `reasoning_content` from
+  assistant content for chain-of-thought models. Several models need both a
+  tool-call parser and a reasoning parser configured together.
+- [Frontend Configuration Reference](../components/frontend/configuration.md) --
+  full CLI flag reference.

--- a/docs/tool-calling/dynamo.md
+++ b/docs/tool-calling/dynamo.md
@@ -1,20 +1,21 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-title: Tool Calling
-subtitle: Connect Dynamo to external tools and services using function calling
+title: Tool Call Parsing (Dynamo)
+subtitle: Connect Dynamo to external tools and services using Dynamo's built-in tool call parsers
 ---
 
-You can connect Dynamo to external tools and services using function calling (also known as tool calling). By providing a list of available functions, Dynamo can choose
-to output function arguments for the relevant function(s) which you can execute to augment the prompt with relevant external information.
+You can connect Dynamo to external tools and services using tool calling. By
+providing a list of available functions, Dynamo can choose to output function
+arguments for the relevant function(s) which you can execute to augment the
+prompt with relevant external information.
 
-Tool calling (AKA function calling) is controlled using the `tool_choice` and `tools` request parameters.
+Tool calling is controlled using the `tool_choice` and `tools` request
+parameters.
 
-> [!TIP]
-> This page covers parser names for the default Dynamo-native path. For a
-> comparison of all preprocessing options (including vLLM/SGLang chat-processor
-> swap and tokenizer delegation) and routing
-> compatibility, see [Chat Processor Options](chat-processor-options.md).
+This page covers parser names for the default Dynamo-native path. If Dynamo
+does not list a parser for your model, see
+[Tool Call Parsing (Engine Fallback)](engine-fallback.md).
 
 ## Prerequisites
 
@@ -35,14 +36,14 @@ python -m dynamo.<backend> --help
 > with `python -m dynamo.<backend> --custom-jinja-template </path/to/template.jinja>`.
 
 > [!TIP]
-> If your model also emits reasoning content that should be separated from normal output, see [Reasoning](reasoning.md) for the supported `--dyn-reasoning-parser` values.
+> If your model also emits reasoning content that should be separated from normal output, see [Reasoning Parsing (Dynamo)](../reasoning/dynamo.md) for the supported `--dyn-reasoning-parser` values.
 
 ## Supported Tool Call Parsers
 
 The table below lists the currently supported tool call parsers in Dynamo's registry. The
 **Upstream name** column shows where the vLLM or SGLang parser name differs
 from Dynamo's -- relevant when using `--dyn-chat-processor vllm` or `sglang`
-(see [Chat Processor Options](chat-processor-options.md)). A blank upstream
+(see [Tool Call Parsing (Engine Fallback)](engine-fallback.md)). A blank upstream
 column means the same name works everywhere. `Dynamo-only` means no upstream
 parser exists for this format.
 
@@ -70,7 +71,7 @@ parser exists for this format.
 
 > [!TIP]
 > For Kimi K2.5 thinking models, pair `--dyn-tool-call-parser kimi_k2` with
-> `--dyn-reasoning-parser kimi_k25` from [Reasoning](reasoning.md) so that both `<think>` blocks and tool calls
+> `--dyn-reasoning-parser kimi_k25` from [Reasoning Parsing (Dynamo)](../reasoning/dynamo.md) so that both `<think>` blocks and tool calls
 > are parsed correctly from the same response.
 
 ## Examples

--- a/docs/tool-calling/dynamo.md
+++ b/docs/tool-calling/dynamo.md
@@ -49,17 +49,18 @@ parser exists for this format.
 
 | Parser Name | Models | Upstream name | Notes |
 |---|---|---|---|
+| `kimi_k2` | Kimi K2 Instruct/Thinking, Kimi K2.5 | | Pair with `--dyn-reasoning-parser kimi` or `kimi_k25` |
+| `qwen3_coder` | Qwen3.5, Qwen3-Coder | | XML `<tool_call><function=...>` |
+| `deepseek_v4` | DeepSeek V4 Pro / Flash | vLLM: `deepseek_v4`; SGLang: `deepseekv4` | DSML tags (`<｜DSML｜tool_calls>...`). Aliases: `deepseek-v4`, `deepseekv4` |
 | `deepseek_v3` | DeepSeek V3, DeepSeek R1-0528+ | SGLang: `deepseekv3` | Special Unicode markers |
 | `deepseek_v3_1` | DeepSeek V3.1 | Dynamo-only | JSON separators |
 | `deepseek_v3_2` | DeepSeek V3.2+ | Dynamo-only | DSML tags (`<｜DSML｜function_calls>...`) |
-| `deepseek_v4` | DeepSeek V4 Pro / Flash | vLLM: `deepseek_v4`; SGLang: `deepseekv4` | DSML tags (`<｜DSML｜tool_calls>...`). Aliases: `deepseek-v4`, `deepseekv4` |
 | `default` | *(fallback)* | Dynamo-only | Empty JSON config (no start/end tokens). Prefer a model-specific parser for production use. |
 | `gemma4` | Google Gemma 4 (thinking models) | vLLM: `gemma4` | Custom non-JSON grammar with `<\|"\|>` string delimiters and `<\|tool_call>...<tool_call\|>` markers. Aliases: `gemma-4`. Pair with `--dyn-reasoning-parser gemma4` and `--custom-jinja-template examples/chat_templates/gemma4_tool.jinja` |
 | `glm47` | GLM-4.5, GLM-4.7 | Dynamo-only | XML `<arg_key>/<arg_value>` |
 | `harmony` | gpt-oss-20b / -120b | Dynamo-only | Harmony channel format |
 | `hermes` | Qwen2.5-\*, QwQ-32B, Qwen3-Instruct, Qwen3-Think, NousHermes-2/3 | vLLM: `qwen2_5`; SGLang: `qwen25` (for Qwen models) | `<tool_call>` JSON |
 | `jamba` | Jamba 1.5 / 1.6 / 1.7 | Dynamo-only | `<tool_calls>` JSON |
-| `kimi_k2` | Kimi K2 Instruct/Thinking, Kimi K2.5 | | Pair with `--dyn-reasoning-parser kimi` or `kimi_k25` |
 | `llama3_json` | Llama 3 / 3.1 / 3.2 / 3.3 Instruct | | `<\|python_tag\|>` tool syntax |
 | `minimax_m2` | MiniMax M2 / M2.1 | vLLM: `minimax` | XML `<minimax:tool_call>` |
 | `mistral` | Mistral / Mixtral / Mistral-Nemo, Magistral | | `[TOOL_CALLS]...[/TOOL_CALLS]` |
@@ -67,7 +68,6 @@ parser exists for this format.
 | `nemotron_nano` | Nemotron-Nano | Dynamo-only | Alias for `qwen3_coder` |
 | `phi4` | Phi-4, Phi-4-mini, Phi-4-mini-reasoning | vLLM: `phi4_mini_json` | `functools[...]` JSON |
 | `pythonic` | Llama 4 (Scout / Maverick) | | Python-list tool syntax |
-| `qwen3_coder` | Qwen3-Coder, Qwen3.5 | | XML `<tool_call><function=...>` |
 
 > [!TIP]
 > For Kimi K2.5 thinking models, pair `--dyn-tool-call-parser kimi_k2` with

--- a/docs/tool-calling/dynamo.md
+++ b/docs/tool-calling/dynamo.md
@@ -86,9 +86,8 @@ python -m dynamo.vllm --model openai/gpt-oss-20b --dyn-tool-call-parser harmony
 python -m dynamo.frontend
 ```
 
-### Tool Calling Request Examples
+### Tool Calling Request Example
 
-- Example 1
 ```python
 from openai import OpenAI
 import json
@@ -122,95 +121,8 @@ response = client.chat.completions.create(
     tool_choice="auto",
     max_tokens=10000
 )
-print(f"{response}")
 tool_call = response.choices[0].message.tool_calls[0].function
 print(f"Function called: {tool_call.name}")
 print(f"Arguments: {tool_call.arguments}")
 print(f"Result: {tool_functions[tool_call.name](**json.loads(tool_call.arguments))}")
-```
-
-- Example 2
-```python
-
-# Use tools defined in example 1
-
-time_tool = {
-    "type": "function",
-    "function": {
-        "name": "get_current_time_nyc",
-        "description": "Get the current time in NYC.",
-        "parameters": {}
-    }
-}
-
-
-tools.append(time_tool)
-
-messages = [
-    {"role": "user", "content": "What's the current time in New York?"}
-]
-
-
-response = client.chat.completions.create(
-    model="openai/gpt-oss-20b", #client.models.list().data[1].id,
-    messages=messages,
-    tools=tools,
-    tool_choice="auto",
-    max_tokens=100,
-)
-print(f"{response}")
-tool_call = response.choices[0].message.tool_calls[0].function
-print(f"Function called: {tool_call.name}")
-print(f"Arguments: {tool_call.arguments}")
-```
-
-- Example 3
-
-
-```python
-
-tools = [
-    {
-        "type": "function",
-        "function": {
-            "name": "get_tourist_attractions",
-            "description": "Get a list of top tourist attractions for a given city.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "city": {
-                        "type": "string",
-                        "description": "The name of the city to find attractions for.",
-                    }
-                },
-                "required": ["city"],
-            },
-        },
-    },
-]
-
-def get_messages():
-    return [
-        {
-            "role": "user",
-            "content": (
-                "I'm planning a trip to Tokyo next week. what are some top tourist attractions in Tokyo? "
-            ),
-        },
-    ]
-
-
-messages = get_messages()
-
-response = client.chat.completions.create(
-    model="openai/gpt-oss-20b",
-    messages=messages,
-    tools=tools,
-    tool_choice="auto",
-    max_tokens=100,
-)
-print(f"{response}")
-tool_call = response.choices[0].message.tool_calls[0].function
-print(f"Function called: {tool_call.name}")
-print(f"Arguments: {tool_call.arguments}")
 ```

--- a/docs/tool-calling/engine-fallback.md
+++ b/docs/tool-calling/engine-fallback.md
@@ -1,19 +1,19 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-title: Chat Processor Options
-subtitle: Choose the right preprocessing pipeline for tool calling, reasoning, and tokenization
+title: Tool Call Parsing (Engine Fallback)
+subtitle: Use upstream vLLM or SGLang tool-call parsers when Dynamo does not ship one
 ---
 
-Dynamo splits work between a **frontend** process (HTTP server, tokenization,
-routing, parsing) and one or more **worker** processes (the engine running the
-model). Several CLI flags control which code path handles chat template
-rendering, tool-call parsing, and reasoning-content separation. This page
-explains the available configurations, when to use each, and how they interact
-with KV cache routing.
+When Dynamo's registry does not list a tool-call parser for your model, you can
+fall back to the upstream engine's parser by switching the **chat processor**
+on the frontend, or by handing tokenization to the engine entirely. This page
+describes the available preprocessing configurations for tool calling and how
+they interact with KV cache routing.
 
-For the list of individual parser names, see
-[Tool Calling](tool-calling.md) and [Reasoning](reasoning.md).
+For the list of Dynamo-native parser names, see
+[Tool Call Parsing (Dynamo)](dynamo.md). For the equivalent reasoning-parser
+fallback, see [Reasoning Parsing (Engine Fallback)](../reasoning/engine-fallback.md).
 
 ## Configurations
 
@@ -22,9 +22,9 @@ not switch between them per request.
 
 | | Frontend flags | Worker flags | KV routing | Notes |
 |---|---|---|---|---|
-| **A** Dynamo-native (default) | `--dyn-chat-processor dynamo` | `--dyn-tool-call-parser <name>` `--dyn-reasoning-parser <name>` | Yes | Rust preprocessor. Lowest latency. |
-| **B** vLLM chat processor | `--dyn-chat-processor vllm` `--tool-call-parser <name>` `--reasoning-parser <name>` | *(none)* | Yes | Delegates to vLLM's Python preprocessor. |
-| **C** SGLang chat processor | `--dyn-chat-processor sglang` `--tool-call-parser <name>` `--reasoning-parser <name>` | *(none)* | Yes | Delegates to SGLang's Python preprocessor. See [SGLang Chat Processor](../backends/sglang/sglang-chat-processor.md). |
+| **A** Dynamo-native (default) | `--dyn-chat-processor dynamo` | `--dyn-tool-call-parser <name>` | Yes | Rust preprocessor. Lowest latency. See [Tool Call Parsing (Dynamo)](dynamo.md). |
+| **B** vLLM chat processor | `--dyn-chat-processor vllm` `--tool-call-parser <name>` | *(none)* | Yes | Delegates tool-call parsing to vLLM's Python preprocessor. |
+| **C** SGLang chat processor | `--dyn-chat-processor sglang` `--tool-call-parser <name>` | *(none)* | Yes | Delegates tool-call parsing to SGLang's Python preprocessor. See [SGLang Chat Processor](../backends/sglang/sglang-chat-processor.md). |
 | **D** vLLM tokenizer delegation | `--router-mode round-robin` | `--use-vllm-tokenizer` | No | Engine-side tokenization. Day-0 model fallback. |
 | **E** SGLang tokenizer delegation | `--router-mode round-robin` | `--use-sglang-tokenizer` | No | **Deprecated** -- use option C instead. |
 
@@ -40,32 +40,33 @@ not switch between them per request.
 Frontend flag (default `dynamo`). Selects the chat processor that renders
 templates, tokenizes, and dispatches parsing.
 
-- `dynamo` -- Rust preprocessor. Parser names come from Dynamo's registry
-  (see [Tool Calling](tool-calling.md) and [Reasoning](reasoning.md)).
-- `vllm` -- vLLM's Python preprocessor. Parser names come from vLLM's
-  registry, which may differ from Dynamo's.
-- `sglang` -- SGLang's Python preprocessor. Parser names come from SGLang's
-  registry. See [SGLang Chat Processor](../backends/sglang/sglang-chat-processor.md).
+- `dynamo` -- Rust preprocessor. Tool-call parser names come from Dynamo's
+  registry (see [Tool Call Parsing (Dynamo)](dynamo.md)).
+- `vllm` -- vLLM's Python preprocessor. Tool-call parser names come from
+  vLLM's registry, which may differ from Dynamo's.
+- `sglang` -- SGLang's Python preprocessor. Tool-call parser names come from
+  SGLang's registry. See [SGLang Chat Processor](../backends/sglang/sglang-chat-processor.md).
 
-### `--dyn-tool-call-parser <name>` / `--dyn-reasoning-parser <name>`
+### `--dyn-tool-call-parser <name>`
 
-Worker flags. Names from Dynamo's parser registry. Only effective under
+Worker flag. Names from Dynamo's parser registry. Only effective under
 `--dyn-chat-processor dynamo` (option A); silently ignored under other chat
 processors.
 
-The flags are declared on the worker CLI, but the parser runs on the frontend --
+The flag is declared on the worker CLI, but the parser runs on the frontend --
 the name propagates via model metadata. For supported names, see
-[Tool Calling](tool-calling.md) and [Reasoning](reasoning.md).
+[Tool Call Parsing (Dynamo)](dynamo.md).
 
-### `--tool-call-parser <name>` / `--reasoning-parser <name>`
+### `--tool-call-parser <name>`
 
-Frontend flags (no `--dyn-` prefix). Names from the upstream engine's registry.
+Frontend flag (no `--dyn-` prefix). Names from the upstream engine's registry.
 Only accepted when paired with the matching chat processor:
 
-- Under `--dyn-chat-processor vllm`: accepted. Use vLLM parser names.
-- Under `--dyn-chat-processor sglang`: accepted. Use SGLang parser names.
+- Under `--dyn-chat-processor vllm`: accepted. Use vLLM tool-call parser names.
+- Under `--dyn-chat-processor sglang`: accepted. Use SGLang tool-call parser names.
 - Under `--dyn-chat-processor dynamo`: **rejected at startup** with
-  `Unknown arguments specified: ...`. Use the `--dyn-*` worker flags instead.
+  `Unknown arguments specified: ...`. Use the `--dyn-tool-call-parser` worker
+  flag instead.
 
 Upstream parser names are pinned to the engine version shipped in the Dynamo
 container. They may differ from Dynamo's names for the same model (e.g.,
@@ -82,10 +83,9 @@ frontend. The flag must match the engine on the worker.
 
 ## Which option should I pick?
 
-1. **Does Dynamo have a parser for your model?** Check the per-model tables in
-   [Tool Calling](tool-calling.md) and [Reasoning](reasoning.md). If yes, use
-   **option A**. This is the default path: Rust parsing on the frontend,
-   KV-routable, lowest latency.
+1. **Does Dynamo have a tool-call parser for your model?** Check the table in
+   [Tool Call Parsing (Dynamo)](dynamo.md). If yes, use **option A**. This is
+   the default path: Rust parsing on the frontend, KV-routable, lowest latency.
 
 2. **Does the upstream engine have a parser but Dynamo doesn't?** Use
    **option B** (vLLM) or **option C** (SGLang). Still KV-routable.
@@ -101,9 +101,9 @@ frontend. The flag must match the engine on the worker.
 
 ### Rejected at startup
 
-- **`--dyn-chat-processor dynamo` with `--tool-call-parser <name>`** (or
-  `--reasoning-parser`). The un-prefixed flags are not recognized under the
-  Dynamo chat processor. Use `--dyn-tool-call-parser` on the worker instead.
+- **`--dyn-chat-processor dynamo` with `--tool-call-parser <name>`**. The
+  un-prefixed flag is not recognized under the Dynamo chat processor. Use
+  `--dyn-tool-call-parser` on the worker instead.
 
 - **`--tool-call-parser` and `--dyn-tool-call-parser` together** on the same
   SGLang worker. SGLang rejects this: `Cannot use both --tool-call-parser and
@@ -154,38 +154,25 @@ KV-routable -- pair them with `round-robin` or `random`.
   engine's Python implementation. This covers models where Dynamo's Rust
   parser hasn't been written yet.
 
-## Parser names by model
-
-For the full list of supported parser names, which models they cover, and
-upstream name divergences (relevant for options B and C):
-
-- [Tool Calling](tool-calling.md) -- supported tool call parsers with model
-  mappings and upstream name differences
-- [Reasoning](reasoning.md) -- supported reasoning parsers with model mappings
-  and force-reasoning behavior
-
 ## Canonical launch examples
 
 ```bash
 # A -- Dynamo-native (default).
 python -m dynamo.vllm \
-  --dyn-tool-call-parser kimi_k2 \
-  --dyn-reasoning-parser kimi_k25
+  --dyn-tool-call-parser kimi_k2
 python -m dynamo.frontend --dyn-chat-processor dynamo
 
 # B -- vLLM chat-processor (upstream parser names on the frontend).
 python -m dynamo.vllm ...
 python -m dynamo.frontend \
   --dyn-chat-processor vllm \
-  --tool-call-parser hermes \
-  --reasoning-parser deepseek_r1
+  --tool-call-parser hermes
 
 # C -- SGLang chat-processor.
 python -m dynamo.sglang ...
 python -m dynamo.frontend \
   --dyn-chat-processor sglang \
-  --tool-call-parser kimi_k2 \
-  --reasoning-parser kimi_k25
+  --tool-call-parser kimi_k2
 
 # D -- vLLM tokenizer delegation (no KV routing).
 python -m dynamo.vllm --use-vllm-tokenizer ...
@@ -194,7 +181,7 @@ python -m dynamo.frontend --router-mode round-robin
 
 ## See Also
 
-- [Tool Calling](tool-calling.md) -- Supported tool call parser names, request examples
-- [Reasoning](reasoning.md) -- Supported reasoning parser names, common pairings
+- [Tool Call Parsing (Dynamo)](dynamo.md) -- Supported Dynamo parser names and request examples
+- [Reasoning Parsing (Engine Fallback)](../reasoning/engine-fallback.md) -- Equivalent fallback configuration for reasoning parsers
 - [SGLang Chat Processor](../backends/sglang/sglang-chat-processor.md) -- Option C details
 - [Frontend Configuration Reference](../components/frontend/configuration.md) -- Full CLI flag reference

--- a/docs/tool-calling/engine-fallback.md
+++ b/docs/tool-calling/engine-fallback.md
@@ -5,189 +5,65 @@ title: Tool Call Parsing (Engine Fallback)
 subtitle: Use upstream vLLM or SGLang tool-call parsers when Dynamo does not ship one
 ---
 
-When Dynamo's registry does not list a tool-call parser for your model, you can
-fall back to the upstream engine's parser by switching the **chat processor**
-on the frontend, or by handing tokenization to the engine entirely. This page
-describes the available preprocessing configurations for tool calling and how
-they interact with KV cache routing.
+When Dynamo's registry does not list a tool-call parser for your model, fall
+back to the upstream engine's parser. Two paths are available: **chat-processor
+swap** (keeps frontend tokenization and KV routing) and **tokenizer
+delegation** (engine owns tokenization, no KV routing).
 
-For the list of Dynamo-native parser names, see
-[Tool Call Parsing (Dynamo)](dynamo.md). For the equivalent reasoning-parser
-fallback, see [Reasoning Parsing (Engine Fallback)](../reasoning/engine-fallback.md).
+For Dynamo-native parsers, see [Tool Call Parsing (Dynamo)](dynamo.md). For
+the equivalent reasoning fallback, see
+[Reasoning Parsing (Engine Fallback)](../reasoning/engine-fallback.md).
 
 > [!WARNING]
-> **Known Issue:** Engine-fallback tool call parsing (options B/C/D/E below)
-> does not currently work with [disaggregated serving](../features/disaggregated-serving/README.md).
-> Use the [Dynamo-native tool call parser](dynamo.md) (option A) for
-> disaggregated deployments.
+> **Known Issue:** Engine-fallback tool call parsing does not currently work
+> with [disaggregated serving](../features/disaggregated-serving/README.md).
+> Use the [Dynamo-native tool call parser](dynamo.md) for disaggregated
+> deployments.
 
 ## Configurations
 
-There are five supported configurations. Each is set at startup -- Dynamo does
-not switch between them per request.
-
 | | Frontend flags | Worker flags | KV routing | Notes |
 |---|---|---|---|---|
-| **A** Dynamo-native (default) | `--dyn-chat-processor dynamo` | `--dyn-tool-call-parser <name>` | Yes | Rust preprocessor. Lowest latency. See [Tool Call Parsing (Dynamo)](dynamo.md). |
-| **B** vLLM chat processor | `--dyn-chat-processor vllm` `--tool-call-parser <name>` | *(none)* | Yes | Delegates tool-call parsing to vLLM's Python preprocessor. |
-| **C** SGLang chat processor | `--dyn-chat-processor sglang` `--tool-call-parser <name>` | *(none)* | Yes | Delegates tool-call parsing to SGLang's Python preprocessor. See [SGLang Chat Processor](../backends/sglang/sglang-chat-processor.md). |
-| **D** vLLM tokenizer delegation | `--router-mode round-robin` | `--use-vllm-tokenizer` | No | Engine-side tokenization. Day-0 model fallback. |
-| **E** SGLang tokenizer delegation | `--router-mode round-robin` | `--use-sglang-tokenizer` | No | **Deprecated** -- use option C instead. |
+| **vLLM chat processor** | `--dyn-chat-processor vllm --tool-call-parser <name>` | *(none)* | Yes | Parsing runs in vLLM's Python preprocessor. |
+| **SGLang chat processor** | `--dyn-chat-processor sglang --tool-call-parser <name>` | *(none)* | Yes | Parsing runs in SGLang's Python preprocessor. See [SGLang Chat Processor](../backends/sglang/sglang-chat-processor.md). |
+| **vLLM tokenizer delegation** | `--router-mode round-robin` | `--use-vllm-tokenizer` | No | Engine owns tokenization. Day-0 model fallback. |
+| **SGLang tokenizer delegation** | `--router-mode round-robin` | `--use-sglang-tokenizer` | No | **Deprecated.** Use SGLang chat processor instead. |
 
-> [!NOTE]
-> Although `dynamo` is the default for `--dyn-chat-processor`, specifying it
-> explicitly in launch scripts makes the choice visible in logs and support
-> diagnostics.
+Upstream parser names come from the engine's registry and may differ from
+Dynamo's name for the same model (e.g., SGLang's `deepseekv3` vs Dynamo's
+`deepseek_v3`). They are pinned to the engine version shipped in the Dynamo
+container.
 
-## Flag reference
+## Pitfalls
 
-### `--dyn-chat-processor {dynamo | vllm | sglang}`
+- **Tokenizer delegation + `--router-mode kv`** -- silent cache misses from
+  prefix-hash mismatches. Pair tokenizer delegation with `round-robin` or
+  `random`.
+- **`--use-vllm-tokenizer` on an SGLang worker** (or vice versa) -- rejected
+  at startup. The flag must match the engine.
+- **`--use-sglang-tokenizer` is deprecated** -- migrate to
+  `--dyn-chat-processor sglang`. See
+  [Migration from --use-sglang-tokenizer](../backends/sglang/sglang-chat-processor.md#migration-from---use-sglang-tokenizer).
 
-Frontend flag (default `dynamo`). Selects the chat processor that renders
-templates, tokenizes, and dispatches parsing.
-
-- `dynamo` -- Rust preprocessor. Tool-call parser names come from Dynamo's
-  registry (see [Tool Call Parsing (Dynamo)](dynamo.md)).
-- `vllm` -- vLLM's Python preprocessor. Tool-call parser names come from
-  vLLM's registry, which may differ from Dynamo's.
-- `sglang` -- SGLang's Python preprocessor. Tool-call parser names come from
-  SGLang's registry. See [SGLang Chat Processor](../backends/sglang/sglang-chat-processor.md).
-
-### `--dyn-tool-call-parser <name>`
-
-Worker flag. Names from Dynamo's parser registry. Only effective under
-`--dyn-chat-processor dynamo` (option A); silently ignored under other chat
-processors.
-
-The flag is declared on the worker CLI, but the parser runs on the frontend --
-the name propagates via model metadata. For supported names, see
-[Tool Call Parsing (Dynamo)](dynamo.md).
-
-### `--tool-call-parser <name>`
-
-Frontend flag (no `--dyn-` prefix). Names from the upstream engine's registry.
-Only accepted when paired with the matching chat processor:
-
-- Under `--dyn-chat-processor vllm`: accepted. Use vLLM tool-call parser names.
-- Under `--dyn-chat-processor sglang`: accepted. Use SGLang tool-call parser names.
-- Under `--dyn-chat-processor dynamo`: **rejected at startup** with
-  `Unknown arguments specified: ...`. Use the `--dyn-tool-call-parser` worker
-  flag instead.
-
-Upstream parser names are pinned to the engine version shipped in the Dynamo
-container. They may differ from Dynamo's names for the same model (e.g.,
-SGLang uses `deepseekv3` where Dynamo uses `deepseek_v3`).
-
-### `--use-vllm-tokenizer` / `--use-sglang-tokenizer`
-
-Worker flags (boolean). Hand tokenization to the engine instead of the
-frontend. The flag must match the engine on the worker.
-
-`--use-sglang-tokenizer` is deprecated. New SGLang deployments should use
-`--dyn-chat-processor sglang` (option C) instead. See
-[Migration from --use-sglang-tokenizer](../backends/sglang/sglang-chat-processor.md#migration-from---use-sglang-tokenizer).
-
-## Which option should I pick?
-
-1. **Does Dynamo have a tool-call parser for your model?** Check the table in
-   [Tool Call Parsing (Dynamo)](dynamo.md). If yes, use **option A**. This is
-   the default path: Rust parsing on the frontend, KV-routable, lowest latency.
-
-2. **Does the upstream engine have a parser but Dynamo doesn't?** Use
-   **option B** (vLLM) or **option C** (SGLang). Still KV-routable.
-
-3. **Is the tokenizer itself the problem** (day-0 model, custom special tokens,
-   rope variants)? Use **option D**. KV routing is off; pair with
-   `--router-mode round-robin`.
-
-4. **SGLang + day-0 model?** Use **option C** with the appropriate upstream
-   parser name. Do not use option E (deprecated).
-
-## Invalid and silently broken combinations
-
-### Rejected at startup
-
-- **`--dyn-chat-processor dynamo` with `--tool-call-parser <name>`**. The
-  un-prefixed flag is not recognized under the Dynamo chat processor. Use
-  `--dyn-tool-call-parser` on the worker instead.
-
-- **`--tool-call-parser` and `--dyn-tool-call-parser` together** on the same
-  SGLang worker. SGLang rejects this: `Cannot use both --tool-call-parser and
-  --dyn-tool-call-parser`. Pick one namespace.
-
-- **`--use-vllm-tokenizer` on an SGLang worker** (and vice versa). The flag
-  must match the engine.
-
-### Silently broken (no startup error, wrong results)
-
-- **Tokenizer delegation + `--router-mode kv`** -- Options D/E with `kv`
-  routing produces prefix-hash mismatches and silent cache misses.
-
-- **`--dyn-tool-call-parser` + `--use-vllm-tokenizer`** on the same vLLM
-  worker. The worker bypasses Dynamo's preprocessor while the frontend-side
-  parser is still wired up, producing mismatched token streams. No
-  mutual-exclusivity check exists today.
-
-## Routing compatibility
-
-`--router-mode kv` needs frontend tokenization to compute prefix-hash routing
-keys. Options A, B, and C keep the tokenizer on the frontend and are
-KV-routable. Options D and E move tokenization to the worker and are **not**
-KV-routable -- pair them with `round-robin` or `random`.
-
-| Option | `kv` routing | `round-robin` / `random` |
-|--------|:---:|:---:|
-| A (Dynamo-native) | Yes | Yes |
-| B (vLLM processor) | Yes | Yes |
-| C (SGLang processor) | Yes | Yes |
-| D (vLLM tokenizer delegation) | **No** | Yes |
-| E (SGLang tokenizer delegation) | **No** | Yes |
-
-## Why each flag exists
-
-- **Frontend tokenization** is required for KV cache routing. The frontend
-  needs token IDs to compute prefix-hash routing keys before the request
-  reaches a worker. Parser flags on the Rust-native path (option A) co-locate
-  with tokenization on the frontend for this reason.
-
-- **Backend tokenization** is a fallback for when frontend tokenization can't
-  or shouldn't run: unsupported model, day-0 support, tokenizer edge cases
-  (custom special tokens, rope variants). The engine owns the tokenizer in
-  this mode, so KV routing drops out.
-
-- **Chat-processor swap** (options B/C) is the middle ground: tokenization
-  stays on the frontend (KV-routable), but parsing delegates to the upstream
-  engine's Python implementation. This covers models where Dynamo's Rust
-  parser hasn't been written yet.
-
-## Canonical launch examples
+## Examples
 
 ```bash
-# A -- Dynamo-native (default).
-python -m dynamo.vllm \
-  --dyn-tool-call-parser kimi_k2
-python -m dynamo.frontend --dyn-chat-processor dynamo
-
-# B -- vLLM chat-processor (upstream parser names on the frontend).
+# vLLM chat processor
 python -m dynamo.vllm ...
-python -m dynamo.frontend \
-  --dyn-chat-processor vllm \
-  --tool-call-parser hermes
+python -m dynamo.frontend --dyn-chat-processor vllm --tool-call-parser hermes
 
-# C -- SGLang chat-processor.
+# SGLang chat processor
 python -m dynamo.sglang ...
-python -m dynamo.frontend \
-  --dyn-chat-processor sglang \
-  --tool-call-parser kimi_k2
+python -m dynamo.frontend --dyn-chat-processor sglang --tool-call-parser kimi_k2
 
-# D -- vLLM tokenizer delegation (no KV routing).
+# vLLM tokenizer delegation (no KV routing)
 python -m dynamo.vllm --use-vllm-tokenizer ...
 python -m dynamo.frontend --router-mode round-robin
 ```
 
 ## See Also
 
-- [Tool Call Parsing (Dynamo)](dynamo.md) -- Supported Dynamo parser names and request examples
-- [Reasoning Parsing (Engine Fallback)](../reasoning/engine-fallback.md) -- Equivalent fallback configuration for reasoning parsers
-- [SGLang Chat Processor](../backends/sglang/sglang-chat-processor.md) -- Option C details
+- [Tool Call Parsing (Dynamo)](dynamo.md) -- Dynamo-native parsers and request examples
+- [Reasoning Parsing (Engine Fallback)](../reasoning/engine-fallback.md) -- Equivalent fallback for reasoning
+- [SGLang Chat Processor](../backends/sglang/sglang-chat-processor.md) -- SGLang chat-processor details
 - [Frontend Configuration Reference](../components/frontend/configuration.md) -- Full CLI flag reference

--- a/docs/tool-calling/engine-fallback.md
+++ b/docs/tool-calling/engine-fallback.md
@@ -15,6 +15,12 @@ For the list of Dynamo-native parser names, see
 [Tool Call Parsing (Dynamo)](dynamo.md). For the equivalent reasoning-parser
 fallback, see [Reasoning Parsing (Engine Fallback)](../reasoning/engine-fallback.md).
 
+> [!WARNING]
+> **Known Issue:** Engine-fallback tool call parsing (options B/C/D/E below)
+> does not currently work with [disaggregated serving](../features/disaggregated-serving/README.md).
+> Use the [Dynamo-native tool call parser](dynamo.md) (option A) for
+> disaggregated deployments.
+
 ## Configurations
 
 There are five supported configurations. Each is set at startup -- Dynamo does

--- a/docs/tool-calling/engine-fallback.md
+++ b/docs/tool-calling/engine-fallback.md
@@ -34,11 +34,11 @@ container.
 ## Examples
 
 ```bash
-# vLLM chat processor (supports KV Routing)
+# vLLM chat processor
 python -m dynamo.vllm ...
 python -m dynamo.frontend --dyn-chat-processor vllm --tool-call-parser hermes
 
-# SGLang chat processor (supports KV Routing)
+# SGLang chat processor
 python -m dynamo.sglang ...
 python -m dynamo.frontend --dyn-chat-processor sglang --tool-call-parser kimi_k2
 ```

--- a/docs/tool-calling/engine-fallback.md
+++ b/docs/tool-calling/engine-fallback.md
@@ -6,9 +6,8 @@ subtitle: Use upstream vLLM or SGLang tool-call parsers when Dynamo does not shi
 ---
 
 When Dynamo's registry does not list a tool-call parser for your model, fall
-back to the upstream engine's parser. Two paths are available: **chat-processor
-swap** (keeps frontend tokenization and KV routing) and **tokenizer
-delegation** (engine owns tokenization, no KV routing).
+back to the upstream engine's parser via a **chat-processor swap**, which
+keeps frontend tokenization and KV routing.
 
 For Dynamo-native parsers, see [Tool Call Parsing (Dynamo)](dynamo.md). For
 the equivalent reasoning fallback, see
@@ -24,46 +23,30 @@ the equivalent reasoning fallback, see
 
 | | Frontend flags | Worker flags | KV routing | Notes |
 |---|---|---|---|---|
-| **vLLM chat processor** | `--dyn-chat-processor vllm --tool-call-parser <name>` | *(none)* | Yes | Parsing runs in vLLM's Python preprocessor. |
+| **vLLM chat processor** | `--dyn-chat-processor vllm --tool-call-parser <name>` | *(none)* | Yes | Parsing runs in vLLM's Python preprocessor. See [vLLM Chat Processor](../backends/vllm/vllm-chat-processor.md). |
 | **SGLang chat processor** | `--dyn-chat-processor sglang --tool-call-parser <name>` | *(none)* | Yes | Parsing runs in SGLang's Python preprocessor. See [SGLang Chat Processor](../backends/sglang/sglang-chat-processor.md). |
-| **vLLM tokenizer delegation** | `--router-mode round-robin` | `--use-vllm-tokenizer` | No | Engine owns tokenization. Day-0 model fallback. |
-| **SGLang tokenizer delegation** | `--router-mode round-robin` | `--use-sglang-tokenizer` | No | **Deprecated.** Use SGLang chat processor instead. |
 
 Upstream parser names come from the engine's registry and may differ from
 Dynamo's name for the same model (e.g., SGLang's `deepseekv3` vs Dynamo's
 `deepseek_v3`). They are pinned to the engine version shipped in the Dynamo
 container.
 
-## Pitfalls
-
-- **Tokenizer delegation + `--router-mode kv`** -- silent cache misses from
-  prefix-hash mismatches. Pair tokenizer delegation with `round-robin` or
-  `random`.
-- **`--use-vllm-tokenizer` on an SGLang worker** (or vice versa) -- rejected
-  at startup. The flag must match the engine.
-- **`--use-sglang-tokenizer` is deprecated** -- migrate to
-  `--dyn-chat-processor sglang`. See
-  [Migration from --use-sglang-tokenizer](../backends/sglang/sglang-chat-processor.md#migration-from---use-sglang-tokenizer).
-
 ## Examples
 
 ```bash
-# vLLM chat processor
+# vLLM chat processor (supports KV Routing)
 python -m dynamo.vllm ...
 python -m dynamo.frontend --dyn-chat-processor vllm --tool-call-parser hermes
 
-# SGLang chat processor
+# SGLang chat processor (supports KV Routing)
 python -m dynamo.sglang ...
 python -m dynamo.frontend --dyn-chat-processor sglang --tool-call-parser kimi_k2
-
-# vLLM tokenizer delegation (no KV routing)
-python -m dynamo.vllm --use-vllm-tokenizer ...
-python -m dynamo.frontend --router-mode round-robin
 ```
 
 ## See Also
 
 - [Tool Call Parsing (Dynamo)](dynamo.md) -- Dynamo-native parsers and request examples
 - [Reasoning Parsing (Engine Fallback)](../reasoning/engine-fallback.md) -- Equivalent fallback for reasoning
+- [vLLM Chat Processor](../backends/vllm/vllm-chat-processor.md) -- vLLM chat-processor details
 - [SGLang Chat Processor](../backends/sglang/sglang-chat-processor.md) -- SGLang chat-processor details
 - [Frontend Configuration Reference](../components/frontend/configuration.md) -- Full CLI flag reference


### PR DESCRIPTION
## Summary

- Split tool calling and reasoning parser docs into Dynamo-native and engine-fallback paths. Each is now a top-level **User Guides** section (`docs/tool-calling/`, `docs/reasoning/`) with a README landing page plus dedicated `dynamo.md` and `engine-fallback.md` subpages.
- The previous `docs/agents/chat-processor-options.md` covered both tool calling and reasoning together; its content is now split between the two `engine-fallback.md` pages so each section is self-contained.
- Removed "AKA function calling" / "also known as tool calling" phrasing — the docs consistently use "tool calling" now.
- Removed the `Tool Calling`, `Reasoning`, and `Chat Processors` entries from the Agents subsection in `docs/index.yml`; updated `docs/agents/README.md` accordingly.
- Updated all cross-references in `README.md`, `docs/reference/feature-matrix.md`, and the SGLang/vLLM backend reference guides.

## Test plan

- [ ] Fern docs build succeeds with new navigation in `docs/index.yml`
- [ ] Spot-check rendered URLs under `user-guides/tool-calling/...` and `user-guides/reasoning/...`
- [ ] Verify no remaining broken inbound links to old `agents/tool-calling`, `agents/reasoning`, `agents/chat-processor-options` paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9400" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Reorganized tool calling and reasoning documentation into dedicated sections for improved clarity and discoverability
  * Added comprehensive guides covering tool-call parsing and reasoning support with Dynamo
  * Introduced fallback configuration documentation for upstream engine integration
  * Updated documentation navigation and cross-references throughout

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9400)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->