### PR TITLE
docs: clarify KvRouter runtime warning

### DIFF
--- a/docs/components/router/router-examples.md
+++ b/docs/components/router/router-examples.md
@@ -11,7 +11,14 @@ For quick start instructions, see the [Router README](README.md). This document 
 Instead of launching the KV Router via command line, you can create a `KvRouter` object directly in Python. This allows per-request routing configuration overrides.
 
 >[!Warning]
-> **Multiple Routers in Same Process**: If you need to run multiple `KvRouter` instances for fault tolerance or load distribution, you must launch them in **separate processes** (e.g., using `python -m dynamo.frontend` with different ports). Creating multiple `KvRouter` objects in the same Python process is not supported - they share the same cancellation token from the component's primary lease, so dropping one router will cancel all routers in that process. For in-process routing, use a single `KvRouter` instance.
+> **Multiple Routers from the Same Runtime**: Do not create multiple independently managed `KvRouter` instances from the same `DistributedRuntime`. Routers created from endpoints owned by the same runtime share that runtime's primary cancellation token, so dropping one router can cancel background work used by the others. For one in-process frontend, use a single `KvRouter`; for independent router lifetimes, use separate frontend processes or create each router from a separate `DistributedRuntime`.
+
+With the event loop available as `loop`, independent in-process router lifetimes require separate runtimes:
+
+```python
+router_a = KvRouter(DistributedRuntime(loop, "etcd", "tcp").endpoint("dynamo.backend.generate"), 16, KvRouterConfig())
+router_b = KvRouter(DistributedRuntime(loop, "etcd", "tcp").endpoint("dynamo.backend.generate"), 16, KvRouterConfig())
+```
 
 ### Methods
 


### PR DESCRIPTION
## Summary
- Clarifies that multiple independently managed `KvRouter` instances are unsafe when created from the same `DistributedRuntime`, not merely the same Python process.
- Adds a compact example showing two independent in-process routers created from separate runtimes.

## Validation
- `git commit` pre-commit hooks: Markdown-relevant hooks passed (`codespell`, case conflicts, merge conflicts, line endings, trailing whitespace, etc.).
- `pytest-marker-report` was skipped on the final commit after failing during collection with an unrelated local `ImportError: cannot import name 'backend' from 'dynamo._core'`.
- `fern` was not available on PATH, so Fern docs checks were not run locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified KvRouter Python API guidance to explain proper usage of multiple routers in the same process using separate DistributedRuntime instances, with added code example demonstrating the recommended pattern.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9401)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->