### PR TITLE
fix(preprocessor): drop dead choice.stop_reason assignment

### DIFF
--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -1578,7 +1578,6 @@ impl OpenAIPreprocessor {
                             choice.delta.refusal = None;
                             choice.delta.reasoning_content = None;
                             choice.finish_reason = None;
-                            choice.stop_reason = None;
                             choice.logprobs = None;
                             true
                         } else {


### PR DESCRIPTION
## Summary

Main HEAD currently fails to compile:

\`\`\`
error[E0609]: no field \`stop_reason\` on type \`&mut dynamo_protocols::types::ChatChoiceStream\`
  --> lib/llm/src/preprocessor.rs:1581
1581 |   choice.stop_reason = None;
     |          ^^^^^^^^^^^ unknown field
     = note: available fields are: \`index\`, \`delta\`, \`finish_reason\`, \`logprobs\`
\`\`\`

Cause: two PRs landed today in a way that left the tree internally inconsistent —

- #9058 (\`f6117b82ec\`) added \`choice.stop_reason = None;\` in the eof-flushed-buffers fallback path
- #8119 (\`74e3e0ef15\`) removed \`stop_reason\` from \`ChatChoiceStream\` as part of the sglang logprobs refactor

The next commit on main (#9230 \`8cee1e50e1\`, \"sglang 0.5.11 bump\") only touched sglang/Dockerfile files, so the Pre Merge workflow's path filter skipped \`rust-clippy\`/\`rust-tests\` entirely. The broken combination landed silently and is now exposed on every downstream PR that triggers a fresh build (e.g. #9352).

## Fix

Drop the orphaned assignment. The surrounding code already resets every remaining field on the struct.

## Test plan

- [x] \`cargo check -p dynamo-llm\` — passes
- [x] preprocessor.rs grep \`stop_reason\` returns no matches
- [ ] CI rust-clippy / rust-tests passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9403" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stream cleanup logic to ensure reasoning content is properly cleared without leaving fragments in processed output.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9403)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->