### PR TITLE
fix(vllm-tests): skip omni test collection when vllm_omni is missing

### DIFF
--- a/components/src/dynamo/vllm/tests/conftest.py
+++ b/components/src/dynamo/vllm/tests/conftest.py
@@ -20,6 +20,15 @@ def pytest_ignore_collect(collection_path, config):
     if filename.startswith("test_vllm_"):
         if importlib.util.find_spec("vllm") is None:
             return True  # vllm not available, skip this file
+    # Omni tests import dynamo.vllm.omni.* which transitively imports
+    # vllm_omni at module load — that import raises on platforms vllm_omni
+    # doesn't support (e.g. CPU-only sample-runtime runners), and the
+    # exception type isn't always ImportError so each file's local
+    # try/except guard isn't enough.
+    parts = collection_path.parts
+    if "omni" in parts and filename.startswith("test_"):
+        if importlib.util.find_spec("vllm_omni") is None:
+            return True
     return None
 
 


### PR DESCRIPTION
## Summary

- The `sample-runtime / Unified Test cuda12.9, amd64` CI job (`.github/workflows/pr.yaml:479`) has been failing on every PR that touches `lib/**` or other paths that trigger `changed-files.outputs.core`. The job runs `pytest -m "pre_merge and gpu_0 and unified"` on a CPU-only runner with no test-path filter, so pytest walks the whole repo and *imports* every `test_*.py` it finds before filtering by marker.
- `components/src/dynamo/vllm/tests/omni/test_*.py` files transitively import `vllm_omni` at module-load time. `vllm_omni` isn't installed in the sample-runtime image (and on CPU-only platforms the import can raise something other than `ImportError`), so the per-file `try/except ImportError: pytest.skip(...)` guard inside each test file doesn't always catch it.
- The repo already has a `pytest_ignore_collect` guard in `components/src/dynamo/vllm/tests/conftest.py` that skips `test_vllm_*.py` files when `vllm` isn't importable. This PR extends that same hook to also skip any file under an `omni/` directory when `vllm_omni` isn't importable.

## Test plan

- [ ] CI `sample-runtime / Unified Test cuda12.9, amd64` job passes on this PR (it has been failing on PRs that touch `core`-changed files)
- [ ] No change in behavior on runners that DO have `vllm_omni` installed — omni tests still get collected and run

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9406" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test collection logic to conditionally skip optional component tests when required dependencies are unavailable.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9406)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->