### PR TITLE
fix(ci): unblock main build (stop_reason refs + omni-test CPU collection)

### DIFF
--- a/components/src/dynamo/vllm/tests/conftest.py
+++ b/components/src/dynamo/vllm/tests/conftest.py
@@ -6,10 +6,34 @@ Handles conditional test collection to prevent import errors when the vllm
 framework is not installed in the current container.
 """
 
+import importlib
 import importlib.util
 import sys
 
 import pytest
+
+# Cached result of attempting to import the omni handler module.
+# `None` = not yet attempted, `True` = succeeded, `False` = raised.
+_omni_importable: bool | None = None
+
+
+def _can_import_omni() -> bool:
+    """Try to import dynamo.vllm.omni.base_handler once and cache the result.
+
+    Catches any exception, not just ImportError — vllm_omni's import chain
+    can raise NotImplementedError (and other types) when vllm._C / libcuda
+    aren't available on a CPU-only runner. importlib.util.find_spec is
+    insufficient because it only resolves the top-level package, not the
+    transitive imports that actually fail.
+    """
+    global _omni_importable
+    if _omni_importable is None:
+        try:
+            importlib.import_module("dynamo.vllm.omni.base_handler")
+            _omni_importable = True
+        except Exception:
+            _omni_importable = False
+    return _omni_importable
 
 
 def pytest_ignore_collect(collection_path, config):
@@ -21,13 +45,14 @@ def pytest_ignore_collect(collection_path, config):
         if importlib.util.find_spec("vllm") is None:
             return True  # vllm not available, skip this file
     # Omni tests import dynamo.vllm.omni.* which transitively imports
-    # vllm_omni at module load — that import raises on platforms vllm_omni
-    # doesn't support (e.g. CPU-only sample-runtime runners), and the
-    # exception type isn't always ImportError so each file's local
-    # try/except guard isn't enough.
+    # vllm_omni at module load. On CPU-only sample-runtime runners the
+    # import chain reaches vllm._C and raises (NotImplementedError when
+    # libcuda.so.1 is missing). Each file's local try/except ImportError
+    # doesn't catch this, so skip collection up-front if the canonical
+    # omni module isn't importable.
     parts = collection_path.parts
     if "omni" in parts and filename.startswith("test_"):
-        if importlib.util.find_spec("vllm_omni") is None:
+        if not _can_import_omni():
             return True
     return None
 

--- a/components/src/dynamo/vllm/tests/conftest.py
+++ b/components/src/dynamo/vllm/tests/conftest.py
@@ -20,6 +20,15 @@ def pytest_ignore_collect(collection_path, config):
     if filename.startswith("test_vllm_"):
         if importlib.util.find_spec("vllm") is None:
             return True  # vllm not available, skip this file
+    # Omni tests import dynamo.vllm.omni.* which transitively imports
+    # vllm_omni at module load — that import raises on platforms vllm_omni
+    # doesn't support (e.g. CPU-only sample-runtime runners), and the
+    # exception type isn't always ImportError so each file's local
+    # try/except guard isn't enough.
+    parts = collection_path.parts
+    if "omni" in parts and filename.startswith("test_"):
+        if importlib.util.find_spec("vllm_omni") is None:
+            return True
     return None
 
 

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -1578,7 +1578,6 @@ impl OpenAIPreprocessor {
                             choice.delta.refusal = None;
                             choice.delta.reasoning_content = None;
                             choice.finish_reason = None;
-                            choice.stop_reason = None;
                             choice.logprobs = None;
                             true
                         } else {

--- a/lib/llm/tests/postprocessor_parsing_stream.rs
+++ b/lib/llm/tests/postprocessor_parsing_stream.rs
@@ -329,7 +329,6 @@ fn mock_multi_choice_content_chunk(
                 reasoning_content: None,
             },
             finish_reason: None,
-            stop_reason: None,
             logprobs: None,
         })
         .collect();

--- a/tests/serve/test_vllm_omni.py
+++ b/tests/serve/test_vllm_omni.py
@@ -10,7 +10,10 @@ import pytest
 
 try:
     from dynamo.vllm.omni.args import OmniConfig  # noqa: F401
-except ImportError:
+except Exception:
+    # vllm_omni's import chain can raise NotImplementedError (and other
+    # non-ImportError types) on platforms it doesn't support — e.g. a
+    # CPU-only runner where vllm._C can't load libcuda.so.1.
     pytest.skip("vLLM omni dependencies not available", allow_module_level=True)
 
 from tests.serve.common import (


### PR DESCRIPTION
## Summary

### 1. Drop dead `stop_reason` refs (`f804b56255`)

Main is currently failing the dynamo-llm build with `error[E0609]: no field stop_reason on type &mut ChatChoiceStream` at `lib/llm/src/preprocessor.rs:1581`. `ChatChoiceStream` (`lib/protocols/src/types/chat.rs:813`) only has `index`, `delta`, `finish_reason`, `logprobs` — no `stop_reason`.

PR #9058 (`f6117b82ec`, landed earlier today) introduced two dead assignments to a field that was already removed in PR #8119.

### 2. Skip omni test collection on runners without `vllm_omni` (`9e086c21c0`)

`sample-runtime / Unified Test cuda12.9, amd64` runs `pytest -m "pre_merge and gpu_0 and unified"` on a CPU-only runner with no path filter, so pytest walks the whole repo and imports every `test_*.py` before applying marker filters. `components/src/dynamo/vllm/tests/omni/test_*.py` transitively imports `vllm_omni` at module-load time; on platforms vllm_omni doesn't support, that raises something other than `ImportError`, so the per-file `try/except ImportError: pytest.skip(...)` doesn't catch it.

Extends the existing `pytest_ignore_collect` hook in `components/src/dynamo/vllm/tests/conftest.py` (which already skips `test_vllm_*.py` when `vllm` is unavailable) to also skip files under an `omni/` directory when `vllm_omni` is unavailable.

## Test plan

- [ ] `vllm-runtime / Build multi-arch cuda12.9` and `dynamo-runtime / image / Build multi-arch cuda12.9` go green
- [ ] `sample-runtime / Unified Test cuda12.9, amd64` goes green
- [ ] No change in behavior on runners that DO have `vllm_omni` installed — omni tests still get collected and run

🤖 Generated with [Claude Code](https://claude.com/claude-code)