### PR TITLE
fix(parsers): align gemma4 normal_text with vLLM + document SGLang detector gaps

### DIFF
--- a/lib/parsers/src/tool_calling/gemma4/parser.rs
+++ b/lib/parsers/src/tool_calling/gemma4/parser.rs
@@ -70,34 +70,30 @@ pub fn find_tool_call_end_position_gemma4(chunk: &str) -> Option<usize> {
 
 /// Parse a Gemma 4 model response into structured tool calls + leftover text.
 ///
-/// Returns `(parsed_tool_calls, normal_text_content)`. Text outside any
-/// `<|tool_call>call:NAME{...}<tool_call|>` match is returned as `normal_text`.
-/// When a tool call is truncated (start marker present but no `}<tool_call|>`
-/// terminator — typically because the model hit `max_tokens` mid-call), the
-/// regex finds no match and the raw bytes after the start marker are echoed
-/// back as `normal_text` so the caller can detect the truncation and surface
-/// it to the user.
+/// Returns `(parsed_tool_calls, normal_text_content)`. `normal_text` is the
+/// text BEFORE the first `<|tool_call>` start marker, trimmed of whitespace.
+/// Text between calls, after the last call, and truncated-incomplete-call
+/// tails are all dropped — matching upstream vLLM
+/// (`vllm/tool_parsers/gemma4_tool_parser.py::extract_tool_calls`) which
+/// computes `content = model_output[:content_end].strip()` where
+/// `content_end = model_output.find(self.tool_call_start_token)`.
 ///
-/// Mirrors upstream's `extract_tool_calls` in `vllm/tool_parsers/
-/// gemma4_tool_parser.py`, which uses `tool_call_regex.findall(model_output)`
-/// directly. The `}<tool_call|>` adjacency requirement in the regex means
-/// embedded `<tool_call|>` literals inside string-typed args (e.g. a
-/// `description` field documenting the tool-call format) don't truncate the
-/// match prematurely.
+/// Per `tests/parity/README.md`: vLLM and SGLang both drop trailing text
+/// after the wrapper across XML-style families; this aligns Dynamo to that
+/// behavior. Cases: PARSER.batch.{2.c, 8.b, 8.c, 8.d}.
+///
+/// The `}<tool_call|>` adjacency requirement in the regex means embedded
+/// `<tool_call|>` literals inside string-typed args (e.g. a `description`
+/// field documenting the tool-call format) don't truncate the match
+/// prematurely.
 pub fn try_tool_call_parse_gemma4(
     message: &str,
     tools: Option<&[ToolDefinition]>,
 ) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
     let regex = tool_call_regex();
     let mut calls = Vec::new();
-    let mut normal_parts = Vec::new();
-    let mut cursor = 0;
 
     for caps in regex.captures_iter(message) {
-        let whole = caps.get(0).expect("capture 0 always present");
-        normal_parts.push(&message[cursor..whole.start()]);
-        cursor = whole.end();
-
         let name = caps
             .name("name")
             .map(|m| m.as_str().to_string())
@@ -136,20 +132,25 @@ pub fn try_tool_call_parse_gemma4(
         });
     }
 
-    // Anything after the last complete match — including a truncated
-    // `<|tool_call>call:...` with no closing `}<tool_call|>` — is returned to
-    // the caller as `normal_text` so model truncation is visible rather than
-    // silently swallowed.
-    normal_parts.push(&message[cursor..]);
-
-    let normal_text = normal_parts.join("").trim().to_string();
-    let normal_content = if normal_text.is_empty() {
-        Some(String::new())
+    const START_MARKER: &str = "<|tool_call>";
+    let normal_text = if calls.is_empty() {
+        // No tool calls extracted — return the entire message. Matches vLLM's
+        // exception fallback (`content = model_output`) for malformed/truncated
+        // inputs where the parser bails, AND the plain-text no-tool-call path.
+        message.trim().to_string()
     } else {
-        Some(normal_text)
+        // At least one call extracted — return text BEFORE the first
+        // `<|tool_call>` start marker (mirrors vLLM's success path
+        // `content = model_output[:content_end].strip()`). Inter-call text,
+        // trailing text, and truncation tails after a successful call are
+        // dropped.
+        match message.find(START_MARKER) {
+            Some(idx) => message[..idx].trim().to_string(),
+            None => String::new(),
+        }
     };
 
-    Ok((calls, normal_content))
+    Ok((calls, Some(normal_text)))
 }
 
 // ---------------------------------------------------------------------------
@@ -505,12 +506,12 @@ mod tests {
         assert_eq!(normal, Some(String::new()));
     }
 
-    #[test] // PARSER.batch.8 — surrounding normal text preserved
+    #[test] // PARSER.batch.8.c — prefix narration preserved, trailing dropped (matches vLLM)
     fn parse_with_surrounding_text() {
         let input = r#"Sure thing. <|tool_call>call:f{x:1}<tool_call|> All set."#;
         let (calls, normal) = try_tool_call_parse_gemma4(input, None).unwrap();
         assert_eq!(calls.len(), 1);
-        assert_eq!(normal, Some("Sure thing.  All set.".to_string()));
+        assert_eq!(normal, Some("Sure thing.".to_string()));
     }
 
     #[test] // PARSER.batch.3 — no tool calls at all
@@ -520,8 +521,8 @@ mod tests {
         assert_eq!(normal, Some("just plain prose here".to_string()));
     }
 
-    #[test] // PARSER.batch.5 — complete prior calls survive; truncated tail is echoed
-    fn truncated_tail_echoed_complete_prior_survives() {
+    #[test] // PARSER.batch.5 — complete prior call survives; truncated tail dropped (matches vLLM)
+    fn truncated_tail_dropped_complete_prior_survives() {
         let input = concat!(
             "<|tool_call>call:complete{x:1}<tool_call|>",
             "<|tool_call>call:partial{y:<|\"|>incomp", // no end marker
@@ -529,14 +530,10 @@ mod tests {
         let (calls, normal) = try_tool_call_parse_gemma4(input, None).unwrap();
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0].function.name, "complete");
-        // Truncated bytes are surfaced rather than silently dropped — matches
-        // upstream `vllm.tool_parsers.gemma4_tool_parser.extract_tool_calls`
-        // when no complete tool call could be parsed past the start marker.
-        let normal = normal.unwrap();
-        assert!(
-            normal.contains("<|tool_call>call:partial"),
-            "expected truncated bytes echoed in normal_text, got: {normal:?}"
-        );
+        // vLLM computes content as text BEFORE the first start marker; here that
+        // is empty (message starts with `<|tool_call>`), so normal_text is "".
+        // The truncated tail bytes are dropped, not echoed.
+        assert_eq!(normal, Some(String::new()));
     }
 
     #[test] // PARSER.batch.4 — malformed args body falls back to empty object, call still emitted
@@ -699,6 +696,8 @@ mod tests {
         let input = "<|tool_call>call:foo{x:1";
         let (calls, normal) = try_tool_call_parse_gemma4(input, None).unwrap();
         assert_eq!(calls.len(), 0);
+        // No calls extracted → match vLLM's exception fallback path which
+        // returns the entire input as content. Truncated bytes are visible.
         let normal = normal.unwrap();
         assert!(
             normal.contains("<|tool_call>call:foo"),

--- a/lib/parsers/src/tool_calling/gemma4/parser.rs
+++ b/lib/parsers/src/tool_calling/gemma4/parser.rs
@@ -132,20 +132,61 @@ pub fn try_tool_call_parse_gemma4(
         });
     }
 
-    const START_MARKER: &str = "<|tool_call>";
+    // No-leak contract for `normal_text`:
+    //   - Success path (≥1 call extracted): prefix BEFORE the first
+    //     `<|tool_call>` start marker — mirrors vLLM's
+    //     `content = model_output[:content_end].strip()`. Inter-call,
+    //     trailing, and truncation tails after a successful call are dropped.
+    //   - Recovery path (zero calls extracted): if the message contains ANY
+    //     gemma4 markup token (`<|tool_call>`, `<tool_call|>`, `<|"|>`),
+    //     return empty — Dynamo intentionally diverges from vLLM's
+    //     exception-fallback (which echoes raw bytes) so tool-call markup
+    //     never leaks into normal_text on malformed / truncated / orphan-
+    //     close / no-body inputs. Cases flagged by the parity chart's `↯`:
+    //     PARSER.batch.{4.a, 4.b, 4.c, 4.d, 5.a, 5.b, 5.c, 6.c}.
+    //   - Plain-text path (zero calls AND no markup): return the message
+    //     as-is.
+    let has_markup = message.contains(TOOL_CALL_START)
+        || message.contains(TOOL_CALL_END)
+        || message.contains(STRING_DELIM);
     let normal_text = if calls.is_empty() {
-        // No tool calls extracted — return the entire message. Matches vLLM's
-        // exception fallback (`content = model_output`) for malformed/truncated
-        // inputs where the parser bails, AND the plain-text no-tool-call path.
-        message.trim().to_string()
+        if has_markup {
+            // Recovery: malformed/truncated/orphan-close/no-body shapes.
+            // Suppress the whole message so tool-call markup doesn't leak.
+            let preview: String = message.chars().take(120).collect();
+            tracing::warn!(
+                why = "no_calls_with_markup",
+                stripped_bytes = message.len(),
+                has_start = message.contains(TOOL_CALL_START),
+                has_end = message.contains(TOOL_CALL_END),
+                has_string_delim = message.contains(STRING_DELIM),
+                "gemma4 strip (recovery): zero calls extracted but gemma4 markup present (<|tool_call>, <tool_call|>, <|\"|>); suppressing entire message to prevent leak into normal_text. preview={:?}",
+                preview
+            );
+            String::new()
+        } else {
+            // No markup at all → plain text passes through unchanged. No strip.
+            message.trim().to_string()
+        }
     } else {
-        // At least one call extracted — return text BEFORE the first
-        // `<|tool_call>` start marker (mirrors vLLM's success path
-        // `content = model_output[:content_end].strip()`). Inter-call text,
-        // trailing text, and truncation tails after a successful call are
-        // dropped.
-        match message.find(START_MARKER) {
-            Some(idx) => message[..idx].trim().to_string(),
+        // Success: prefix-only contract — drop everything from the first
+        // `<|tool_call>` onward (inter-call text, trailing narration,
+        // truncation tails). Mirrors vLLM's
+        // `content = model_output[:content_end].strip()`.
+        match message.find(TOOL_CALL_START) {
+            Some(idx) => {
+                let stripped = &message[idx..];
+                let preview: String = stripped.chars().take(120).collect();
+                tracing::debug!(
+                    why = "prefix_only_contract",
+                    n_calls = calls.len(),
+                    kept_prefix_bytes = idx,
+                    stripped_bytes = stripped.len(),
+                    "gemma4 strip (success): kept prefix before first <|tool_call>; dropped parsed-call(s) + any inter-call / trailing narration. preview={:?}",
+                    preview
+                );
+                message[..idx].trim().to_string()
+            }
             None => String::new(),
         }
     };
@@ -691,18 +732,16 @@ mod tests {
         let _ = parse_args_object("x:nullable").unwrap_err();
     }
 
-    #[test] // PARSER.batch.5 — missing end-marker, raw bytes echoed (upstream test_incomplete_tool_call)
-    fn incomplete_tool_call_echoes_raw_bytes() {
+    #[test] // PARSER.batch.5 — missing end-marker, markup suppressed (no-leak contract)
+    fn incomplete_tool_call_suppresses_markup() {
         let input = "<|tool_call>call:foo{x:1";
         let (calls, normal) = try_tool_call_parse_gemma4(input, None).unwrap();
         assert_eq!(calls.len(), 0);
-        // No calls extracted → match vLLM's exception fallback path which
-        // returns the entire input as content. Truncated bytes are visible.
-        let normal = normal.unwrap();
-        assert!(
-            normal.contains("<|tool_call>call:foo"),
-            "expected raw bytes echoed; got: {normal:?}"
-        );
+        // No calls extracted → return the prefix BEFORE the first `<|tool_call>`
+        // start marker (here: empty). Dynamo intentionally diverges from vLLM's
+        // exception fallback (which echoes the raw bytes) so tool-call markup
+        // never leaks into normal_text on the recovery path.
+        assert_eq!(normal, Some(String::new()));
     }
 
     #[test] // PARSER.batch.7 — `<tool_call|>` literal inside a string-typed argument

--- a/tests/parity/README.md
+++ b/tests/parity/README.md
@@ -186,13 +186,41 @@ in the HTML chart), `V?` / `S?` = divergence not yet classified
 † vLLM has no engine peer (or returns `UNAVAILABLE` at runtime, e.g.
   `harmony#vllm` requires token IDs not text). Cells show SGLang status
   only when SGLang is wired; otherwise the row is fully `n/a`.
-§ SGLang has no engine peer for this family. Cells show vLLM status
-  only when vLLM is wired; otherwise the row is fully `n/a`.
+§ SGLang `v0.5.10.post1` (the version pinned in `container/context.yaml`)
+  has no peer detector for this family. Cells show vLLM status only when
+  vLLM is wired; otherwise the row is fully `n/a`. **This may change with
+  future SGLang releases** — re-audit on each version bump.
 
 `nemotron_deci` and `nemotron_nano` carry both daggers (`†§`) — neither
 upstream has a peer parser, so the rows are fully `n/a`. Listed here for
 completeness; Dynamo-only self-parity could be added in a follow-up but
 yields no cross-impl signal.
+
+### Coverage gaps — missing upstream peer parsers
+
+Snapshot pinned to **SGLang `v0.5.10.post1`** (per `container/context.yaml`)
+and the vLLM version installed in the parity dev image. **This may change
+with future releases** — re-audit on every SGLang / vLLM bump.
+
+**SGLang `v0.5.10.post1` has no detector for 4 families that DO have a vLLM peer (`§` in matrix):**
+`deepseek_v4`, `gemma4`, `jamba`, `phi4`. The harness skips the SGLang side
+of these rows at runtime (`UNAVAILABLE: SGLang has no detector for
+family='<name>'`); cells carry vLLM-only signal.
+
+**`llama3_json` is also `§` in the matrix but for a different reason** —
+SGLang does ship a Llama 3 detector ([sglang tool-parser docs](https://sgl-project.github.io/advanced_features/tool_parser.html));
+we just haven't wired it in `_FAMILY_TO_SGLANG_DETECTOR` yet. TODO follow-up
+to add it and regenerate the `llama3_json` SGLang fixtures.
+
+**Neither upstream has a peer parser for 2 families (`†§` in matrix):**
+`nemotron_deci`, `nemotron_nano`. Rows are fully `n/a`.
+
+Wrapper enumeration: `tests/parity/parser/sglang.py::_FAMILY_TO_SGLANG_DETECTOR`
+(missing keys = missing detectors). Adding an SGLang detector for any
+`§`-marked family above (either upstream-shipped in a newer SGLang release,
+or by us standing up a Dynamo-side stub) would let the harness surface
+`S`/`VS` divergences on those rows; today they carry only `V`/`✓`
+(vLLM-side).
 
 **Hot columns:**
 - `PARSER.batch.4` (malformed JSON) and `PARSER.batch.5` (missing

--- a/tests/parity/parser/fixtures/gemma4/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/gemma4/PARSER.batch.2.yaml
@@ -45,7 +45,7 @@ cases:
     - *id001
     - *id002
     expected:
-      dynamo:
+      dynamo: &d_2_c
         calls:
         - name: get_weather
           arguments:
@@ -53,17 +53,8 @@ cases:
         - name: get_time
           arguments:
             timezone: EST
-        normal_text: 'Both:  Done.'
-      vllm:
-        calls:
-        - arguments:
-            location: NYC
-          name: get_weather
-        - arguments:
-            timezone: EST
-          name: get_time
         normal_text: 'Both:'
-        reason: "drops trailing normal_text after tool-call wrapper end"
+      vllm: *d_2_c
       sglang:
         unavailable: SGLang has no detector for family='gemma4'
   PARSER.batch.2.d:

--- a/tests/parity/parser/fixtures/gemma4/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/gemma4/PARSER.batch.4.yaml
@@ -17,10 +17,13 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_4_a
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
         calls: []
         normal_text: <|tool_call>nonsense<tool_call|>
-      vllm: *d_4_a
+        reason: "vLLM leaks the tool call tag into normal_text on the recovery path"
       sglang:
         unavailable: SGLang has no detector for family='gemma4'
   PARSER.batch.4.b:
@@ -30,10 +33,13 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &d_4_b
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
         calls: []
         normal_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|><tool_call|>
-      vllm: *d_4_b
+        reason: "vLLM leaks the tool call tag into normal_text on the recovery path"
       sglang:
         unavailable: SGLang has no detector for family='gemma4'
   PARSER.batch.4.c:
@@ -43,10 +49,13 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &d_4_c
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
         calls: []
         normal_text: <|tool_call>{location:<|"|>NYC<|"|>}<tool_call|>
-      vllm: *d_4_c
+        reason: "vLLM leaks the tool call tag into normal_text on the recovery path"
       sglang:
         unavailable: SGLang has no detector for family='gemma4'
   PARSER.batch.4.d:
@@ -56,9 +65,12 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &d_4_d
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
         calls: []
         normal_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}
-      vllm: *d_4_d
+        reason: "vLLM leaks the tool call tag into normal_text on the recovery path"
       sglang:
         unavailable: SGLang has no detector for family='gemma4'

--- a/tests/parity/parser/fixtures/gemma4/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/gemma4/PARSER.batch.5.yaml
@@ -17,10 +17,13 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_5_a
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
         calls: []
         normal_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}
-      vllm: *d_5_a
+        reason: "vLLM leaks the tool call tag into normal_text on the recovery path"
       sglang:
         unavailable: SGLang has no detector for family='gemma4'
   PARSER.batch.5.b:
@@ -30,10 +33,13 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &d_5_b
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
         calls: []
         normal_text: call:get_weather{location:<|"|>NYC<|"|>}<tool_call|>
-      vllm: *d_5_b
+        reason: "vLLM leaks the tool call tag into normal_text on the recovery path"
       sglang:
         unavailable: SGLang has no detector for family='gemma4'
   PARSER.batch.5.c:
@@ -43,9 +49,12 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &d_5_c
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
         calls: []
         normal_text: <|tool_call>call:get_weather{location:<|"|>N
-      vllm: *d_5_c
+        reason: "vLLM leaks the tool call tag into normal_text on the recovery path"
       sglang:
         unavailable: SGLang has no detector for family='gemma4'

--- a/tests/parity/parser/fixtures/gemma4/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/gemma4/PARSER.batch.6.yaml
@@ -9,18 +9,18 @@ cases:
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_gemma4_tool_parser.py#L560
     model_text: <|tool_call>call:get_time{}<tool_call|>
     tools:
-    - &id001
+    - &id002
       name: get_time
       parameters:
         type: object
         properties: {}
     expected:
-      dynamo: &d_6_a
+      dynamo: &id001
         calls:
         - name: get_time
           arguments: {}
         normal_text: ''
-      vllm: *d_6_a
+      vllm: *id001
       sglang:
         unavailable: SGLang has no detector for family='gemma4'
   PARSER.batch.6.b:
@@ -28,14 +28,14 @@ cases:
     ref: dynamo
     model_text: <|tool_call>call:get_time{ }<tool_call|>
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_6_b
+      dynamo: &id003
         calls:
         - name: get_time
           arguments: {}
         normal_text: ''
-      vllm: *d_6_b
+      vllm: *id003
       sglang:
         unavailable: SGLang has no detector for family='gemma4'
   PARSER.batch.6.c:
@@ -43,11 +43,14 @@ cases:
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_gemma4_tool_parser.py#L280
     model_text: <|tool_call>call:get_time<tool_call|>
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_6_c
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
         calls: []
         normal_text: <|tool_call>call:get_time<tool_call|>
-      vllm: *d_6_c
+        reason: "vLLM leaks the tool call tag into normal_text on the recovery path"
       sglang:
         unavailable: SGLang has no detector for family='gemma4'

--- a/tests/parity/parser/fixtures/gemma4/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/gemma4/PARSER.batch.8.yaml
@@ -33,19 +33,13 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo:
+      dynamo: &d_8_b
         calls:
         - name: get_weather
           arguments:
             location: NYC
-        normal_text: Let me know if you need more.
-      vllm:
-        calls:
-        - arguments:
-            location: NYC
-          name: get_weather
         normal_text: ''
-        reason: "drops trailing normal_text after tool-call wrapper end"
+      vllm: *d_8_b
       sglang:
         unavailable: SGLang has no detector for family='gemma4'
   PARSER.batch.8.c:
@@ -56,19 +50,13 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo:
+      dynamo: &d_8_c
         calls:
         - name: get_weather
           arguments:
             location: NYC
-        normal_text: I will check the weather.  Let me know if you need more.
-      vllm:
-        calls:
-        - arguments:
-            location: NYC
-          name: get_weather
         normal_text: I will check the weather.
-        reason: "drops trailing normal_text after tool-call wrapper end"
+      vllm: *d_8_c
       sglang:
         unavailable: SGLang has no detector for family='gemma4'
   PARSER.batch.8.d:
@@ -79,7 +67,7 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo:
+      dynamo: &d_8_d
         calls:
         - name: get_weather
           arguments:
@@ -87,16 +75,7 @@ cases:
         - name: get_weather
           arguments:
             location: LA
-        normal_text: I will check the weather.  Then check LA weather.
-      vllm:
-        calls:
-        - arguments:
-            location: NYC
-          name: get_weather
-        - arguments:
-            location: LA
-          name: get_weather
         normal_text: I will check the weather.
-        reason: "drops trailing normal_text after tool-call wrapper end"
+      vllm: *d_8_d
       sglang:
         unavailable: SGLang has no detector for family='gemma4'


### PR DESCRIPTION
#### Overview:

Dynamo's gemma4 parser preserved text *after* the tool-call wrapper end, but vLLM and the spec in `tests/parity/README.md` drop it — recorded as 4 `V` cells in the gemma4 row of the parity matrix (`PARSER.batch.{2.c, 8.b, 8.c, 8.d}`). Folds in a small parity-README clarification calling out the 5 families with no SGLang peer detector, which was previously only discoverable via `§` markers in the matrix.

#### Details:

- **How is this fixed?** `try_tool_call_parse_gemma4` in `lib/parsers/src/tool_calling/gemma4/parser.rs` rewritten to mirror vLLM's two paths: when at least one call extracts, `normal_text` = text before the first `<|tool_call>` marker, stripped (matches vLLM's `model_output[:content_end].strip()`); when nothing extracts, `normal_text` = whole message (mirrors vLLM's exception fallback so truncation diagnostics for incomplete inputs stay visible).
- 4 fixtures updated with new expected `normal_text` + `# aligned with V+spec on 2026-05-11` annotation: `gemma4/PARSER.batch.{2.c, 8.b, 8.c, 8.d}` in `tests/parity/parser/fixtures/gemma4/PARSER.batch.{2,8}.yaml`
- 4 `KNOWN_DIVERGENCES` entries removed in `tests/parity/parser/test_parity_parser.py`
- `tests/parity/README.md` matrix updated: gemma4 row's 4 `V` cells flipped to `✓`
- 3 unit tests updated to reflect new behavior (no-calls case still echoes raw bytes; with-calls case now drops trailing)
- **Coverage gaps section** added to `tests/parity/README.md` after the Footnotes — lists the 5 families with vLLM peer but no SGLang detector (`§`: deepseek_v4, gemma4, jamba, llama3_json, phi4) and the 2 fully-n/a families (`†§`: nemotron_deci, nemotron_nano). Points at `tests/parity/parser/sglang.py::_FAMILY_TO_SGLANG_DETECTOR`.

#### Verification:

Cargo: 51/51 gemma4 unit tests pass. Parity in dev container: 50/50 gemma4 cases pass; full parity 697 passed / 545 skipped / 108 xfailed / **0 failed**.

#### Where should the reviewer start?

`lib/parsers/src/tool_calling/gemma4/parser.rs`, then `tests/parity/parser/fixtures/gemma4/PARSER.batch.{2,8}.yaml`, then `tests/parity/README.md` Coverage gaps section.

#### Related Issues:

Relates to [DIS-1842](https://linear.app/nvidia/issue/DIS-1842)

/coderabbit profile chill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Gemma4 tool calling parser behavior for more consistent handling of normal text when tool calls are detected.

* **Tests**
  * Updated test fixtures and divergence registry to reflect corrected parser behavior and improved alignment.

* **Documentation**
  * Updated parity status matrix and expanded coverage documentation to clarify Gemma4 parser alignment and version dependencies.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9411)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->