### PR TITLE
fix(ci): PYTEST_TIMEOUT_OPT assigned but never used

### DIFF
--- a/.github/actions/pytest/action.yml
+++ b/.github/actions/pytest/action.yml
@@ -274,7 +274,7 @@ runs:
             DIST_OPTS="--dist=loadscope"
           fi
 
-          PYTEST_CMD="pytest ${PARALLEL_OPTS} ${VRAM_OPTS} ${DIST_OPTS} --continue-on-collection-errors -v --tb=short --basetemp=/tmp/pytest_temp -o cache_dir=/tmp/.pytest_cache --junitxml=/workspace/test-results/${{ env.PYTEST_XML_FILE }} --alluredir=/workspace/test-results/allure-results --durations=10 -m \"${{ inputs.pytest_marks }}\""
+          PYTEST_CMD="pytest ${PARALLEL_OPTS} ${VRAM_OPTS} ${DIST_OPTS} ${PYTEST_TIMEOUT_OPT} --continue-on-collection-errors -v --tb=short --basetemp=/tmp/pytest_temp -o cache_dir=/tmp/.pytest_cache --junitxml=/workspace/test-results/${{ env.PYTEST_XML_FILE }} --alluredir=/workspace/test-results/allure-results --durations=10 -m \"${{ inputs.pytest_marks }}\""
         fi
 
         # Get absolute path for test-results directory and ensure it has proper permissions


### PR DESCRIPTION
#### Overview:

Any XPU CI pytest job (inputs.device == "xpu") that hits a hanging test — GPU deadlock, driver hang, infinite loop, etc.
The pytest process hangs indefinitely with no timeout. The CI job is only killed by GitHub Actions' 6-hour global timeout. The
  blocked job also stalls downstream cleanup-xpu jobs in xpu-ci.yaml. No diagnostic traceback is produced, making root-cause analysis harder.
After 600 seconds (10 minutes), pytest-timeout should kill the hung test, dump a traceback, and continue to the next test.

Root Cause: 
PYTEST_TIMEOUT_OPT is assigned --timeout=600 on the PR  https://github.com/ai-dynamo/dynamo/pull/7980 but never interpolated into the PYTEST_CMD string — an assignment  left unused.


#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)


<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9412" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test execution configuration in the continuous integration pipeline to improve reliability of automated testing processes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9412)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->