### PR TITLE
docs: improve global planner guide

### DIFF
--- a/docs/components/planner/README.md
+++ b/docs/components/planner/README.md
@@ -208,10 +208,26 @@ When `PLANNER_PROMETHEUS_PORT` is set, the planner serves its own metrics endpoi
 - TTFT and ITL distributions
 - Input/output sequence lengths
 
+Planner can read these traffic signals from either the public `Frontend` or a pool-local `LocalRouter`. Use `throughput_metrics_source: "frontend"` for a single-DGD deployment. Use `throughput_metrics_source: "router"` for GlobalPlanner / multi-pool deployments so each pool Planner reads its own router traffic instead of the shared public endpoint.
+
+| Planner input | Frontend source | Router source |
+|---|---|---|
+| Request count | `dynamo_frontend_requests_total` | `dynamo_component_router_requests_total` |
+| TTFT | `dynamo_frontend_time_to_first_token_seconds` | `dynamo_component_router_time_to_first_token_seconds` |
+| ITL | `dynamo_frontend_inter_token_latency_seconds` | `dynamo_component_router_inter_token_latency_seconds` |
+| Request duration | `dynamo_frontend_request_duration_seconds` | `dynamo_component_request_duration_seconds` until router-specific duration metrics are available |
+| Input sequence length / ISL | `dynamo_frontend_input_sequence_tokens` | `dynamo_component_router_input_sequence_tokens` |
+| Output sequence length / OSL | `dynamo_frontend_output_sequence_tokens` | `dynamo_component_router_output_sequence_tokens` |
+| KV hit rate | Not available from frontend source | `dynamo_component_router_kv_hit_rate` |
+
+The throughput planner uses request count, ISL, OSL, and optional KV hit rate as the core traffic forecast inputs. TTFT, ITL, and request duration are also scraped and exported as observed diagnostics.
+
 **Load-based scaling** uses ForwardPassMetrics (FPM) from the Dynamo event plane:
 - Per-iteration wall time, scheduled prefill/decode tokens, and queued request status
 - Delivered via `FpmEventSubscriber` with automatic engine discovery and lifecycle tracking
 - No router `/metrics` scraping required
+
+FPM observes engine-side scheduled and queued work. It does not include requests still queued in the `LocalRouter` before engine assignment.
 
 Core gauges on the planner port include replica counts (`dynamo_planner_num_prefill_replicas`, `dynamo_planner_num_decode_replicas`), observed traffic (`dynamo_planner_observed_*`), replica decisions (`dynamo_planner_predicted_num_prefill_replicas`, `dynamo_planner_predicted_num_decode_replicas`), and cumulative `dynamo_planner_gpu_hours`.
 

--- a/docs/components/planner/global-planner.md
+++ b/docs/components/planner/global-planner.md
@@ -88,31 +88,54 @@ In the current implementation, the single-endpoint pattern is composed from mult
 
 ## Architecture
 
-```text
-Client
-  |
-  v
-Frontend (single public endpoint)
-  |
-  v
-GlobalRouter
-  |
-  +--> Prefill pool 0 Dynamo namespace --> LocalRouter --> Prefill workers --> Pool Planner
-  +--> Prefill pool 1 Dynamo namespace --> LocalRouter --> Prefill workers --> Pool Planner
-  |
-  +--> Decode pool 0 Dynamo namespace  --> LocalRouter --> Decode workers  --> Pool Planner
-  +--> Decode pool 1 Dynamo namespace  --> LocalRouter --> Decode workers  --> Pool Planner
+```mermaid
+flowchart LR
+    client["Client"]
+    prometheus["Prometheus<br/>per-pool router metrics"]
+    operator["Kubernetes operator<br/>DGD replica updates"]
 
-Pool Planners
-  |
-  v
-GlobalPlanner
-  |
-  v
-Kubernetes scaling updates on the target DGDs
+    subgraph control["Control DGD"]
+        frontend["Frontend<br/>single public endpoint"]
+        global_router["GlobalRouter<br/>selects a pool"]
+        global_planner["GlobalPlanner<br/>policy, budget, scale execution"]
+    end
+
+    subgraph prefill0["Prefill pool DGD: short prompts"]
+        prefill_router0["LocalRouter"] --> prefill_workers0["Prefill workers"]
+        prefill_planner0["Pool Planner"]
+    end
+
+    subgraph prefill1["Prefill pool DGD: long prompts"]
+        prefill_router1["LocalRouter"] --> prefill_workers1["Prefill workers"]
+        prefill_planner1["Pool Planner"]
+    end
+
+    subgraph decode0["Decode pool DGD"]
+        decode_router0["LocalRouter"] --> decode_workers0["Decode workers"]
+        decode_planner0["Pool Planner"]
+    end
+
+    prometheus -.-> prefill_planner0
+    prometheus -.-> prefill_planner1
+    prometheus -.-> decode_planner0
+
+    client --> frontend
+    frontend --> global_router
+    global_router --> prefill_router0
+    global_router --> prefill_router1
+    global_router --> decode_router0
+
+    prefill_planner0 -- scale request --> global_planner
+    prefill_planner1 -- scale request --> global_planner
+    decode_planner0 -- scale request --> global_planner
+
+    global_planner --> operator
+    operator --> prefill_workers0
+    operator --> prefill_workers1
+    operator --> decode_workers0
 ```
 
-The `Frontend` exposes a single model endpoint. `GlobalRouter` selects the best pool for each request. Each pool-local `Planner` decides how much capacity its own pool needs. `GlobalPlanner` receives those scale requests and applies the Kubernetes replica changes centrally.
+Read the diagram left to right for request traffic: clients call the control `Frontend`, `GlobalRouter` selects a private pool, and each pool's `LocalRouter` sends the request to workers. Read the dotted and lower paths for scaling: each pool-local `Planner` reads that pool's router metrics, sends a scale request to `GlobalPlanner`, and `GlobalPlanner` applies the Kubernetes replica changes centrally.
 
 ## Prerequisites
 
@@ -244,6 +267,8 @@ The planner inside each pool must be configured for `global-planner` mode so it 
 ```
 
 `global_planner_namespace` must point to the control stack's **Dynamo namespace**. In the reference manifests, that is the namespace string passed to the control `Frontend` and `GlobalRouter`.
+
+`throughput_metrics_source: "router"` is required for pool-local Planner in GlobalPlanner deployments. The pool Planner should forecast demand from its own `LocalRouter` `dynamo_component_router_*` Prometheus metrics, not from the shared public `Frontend`. See the [Planner overview](README.md#prometheus-metrics) for the exact frontend and router metric sources.
 
 Use:
 

--- a/docs/components/planner/planner-examples.md
+++ b/docs/components/planner/planner-examples.md
@@ -126,7 +126,7 @@ spec:
   searchStrategy: rapid
 ```
 
-### Mocker Deployment (Testing)
+### Simulation with Mocker
 
 Deploy a mocker backend that simulates GPU timing behavior without real GPUs. Useful for:
 - Large-scale experiments without GPU resources

--- a/docs/components/planner/planner-guide.md
+++ b/docs/components/planner/planner-guide.md
@@ -77,6 +77,7 @@ When throughput-based scaling is enabled, the planner needs engine performance d
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `throughput_adjustment_interval_seconds` | int | `180` | Seconds between throughput-based scaling decisions. |
+| `throughput_metrics_source` | string | `frontend` | Prometheus traffic source for throughput scaling: `frontend` reads `dynamo_frontend_*` metrics from the public Frontend; `router` reads `dynamo_component_router_*` metrics from a LocalRouter. Use `router` for pool-local Planner in GlobalPlanner deployments. |
 | `min_endpoint` | int | `1` | Minimum number of engine endpoints to maintain. |
 | `max_gpu_budget` | int | `8` | Maximum total GPUs the planner may allocate. |
 | `ttft_ms` | float | `500.0` | TTFT SLA target (ms) for scaling decisions. |

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -224,7 +224,7 @@ navigation:
             path: fault-tolerance/testing.md
       - page: Benchmarking
         path: benchmarks/benchmarking.md
-      - section: Mocker
+      - section: Simulation with Mocker
         contents:
           - page: Testing with Mocker
             path: mocker/mocker.md
@@ -314,6 +314,8 @@ navigation:
         contents:
           - page: Planner Guide
             path: components/planner/planner-guide.md
+          - page: Global Planner Guide
+            path: components/planner/global-planner.md
           - page: Planner Examples
             path: components/planner/planner-examples.md
       - section: Profiler
@@ -454,8 +456,8 @@ navigation:
       # -- Benchmarks --
       - page: KV Router A/B Testing
         path: benchmarks/kv-router-ab-testing.md
-      # -- Mocker --
-      - page: Mocker
+      # -- Simulation with Mocker --
+      - page: Simulation with Mocker
         path: mocker/mocker.md
       # -- Templates --
       - section: Templates

--- a/docs/mocker/mocker.md
+++ b/docs/mocker/mocker.md
@@ -1,10 +1,10 @@
 ---
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-title: Mocker
+title: Simulation with Mocker
 ---
 
-The Mocker is a lightweight, high-fidelity simulation of an LLM inference engine, implemented entirely in Rust. It replicates the core scheduling, memory management, and timing behaviors of production engines without requiring a GPU, making it invaluable for testing Dynamo's routing, KV cache events, disaggregated serving, and planner components.
+Mocker is Dynamo's lightweight, high-fidelity simulation of an LLM inference engine, implemented entirely in Rust. It replicates the core scheduling, memory management, and timing behaviors of production engines without requiring a GPU, making it invaluable for testing Dynamo's routing, KV cache events, disaggregated serving, and planner components.
 
 ## Overview
 


### PR DESCRIPTION
## Summary
- Replace the Global Planner ASCII diagram with a Mermaid diagram that separates request traffic, pool-local metrics, and centralized scale execution.
- Add the Global Planner Guide to the docs nav so it shows up on the public docs site.
- Rename the Mocker docs surface to “Simulation with Mocker” and update the planner example heading.
- Document `throughput_metrics_source`, including frontend vs router metric sources for GlobalPlanner pool planners.

## Validation
- `git diff --check`
- `python3 -c 'import yaml, pathlib; yaml.safe_load(pathlib.Path("docs/index.yml").read_text()); print("docs/index.yml: ok")'`\n\n## Notes\n- I inspected the in-flight metrics code path: `throughput_metrics_source` already supports `frontend` and `router`; the docs were missing the config row and the metric source mapping.\n- Targeted planner pytest was not completed locally: plain pytest was missing `pytest_benchmark`, and a `uv run --with pytest-benchmark` retry hit the repo extras dependency conflict between the vLLM and SGLang `nixl[cu12]` constraints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated throughput planner metrics source configuration documentation
  * Added Global Planner architecture guide with visual flow diagrams
  * Documented new `throughput_metrics_source` configuration option
  * Reorganized documentation navigation structure

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9418)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->