### PR TITLE
fix(container): fix vllm_runtime.Dockerfile for XPU builds (cupy + nixl conflicts)

### DIFF
--- a/container/templates/vllm_runtime.Dockerfile
+++ b/container/templates/vllm_runtime.Dockerfile
@@ -306,7 +306,7 @@ RUN --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sh
     # LMCache >=0.4.4 depends on nixl>=1.1.0 which pulls in both nixl-cu12 and
     # nixl-cu13; their coexistence breaks `import nixl` at runtime.
     CUDA_MAJOR="${CUDA_VERSION%%.*}" && \
-    (uv pip freeze 2>/dev/null | awk -F= '/^nixl-cu/{print $1}' | grep -v "^nixl-cu${CUDA_MAJOR}$" | xargs -r uv pip uninstall -y 2>/dev/null || true) && \
+    (uv pip freeze 2>/dev/null | awk -F= '/^nixl-cu/{print $1}' | grep -v "^nixl-cu${CUDA_MAJOR}" | xargs -r uv pip uninstall -y 2>/dev/null || true) && \
 {% endif %}
     if [ "${ENABLE_KVBM}" = "true" ]; then \
         KVBM_WHEEL=$(ls /opt/dynamo/wheelhouse/kvbm*.whl 2>/dev/null | head -1); \

--- a/container/templates/vllm_runtime.Dockerfile
+++ b/container/templates/vllm_runtime.Dockerfile
@@ -298,9 +298,16 @@ RUN --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sh
       /opt/dynamo/wheelhouse/ai_dynamo_runtime*.whl \
       /opt/dynamo/wheelhouse/ai_dynamo*any.whl \
       /opt/dynamo/wheelhouse/nixl/nixl*.whl && \
-    if [ "${CUDA_VERSION%%.*}" = "13" ]; then \
-        uv pip uninstall -y nixl-cu12 || true; \
-    fi && \
+{% if device == "xpu" %}
+    # XPU: remove all CUDA nixl variants that LMCache or other deps may pull in
+    (uv pip freeze 2>/dev/null | awk -F= '/^nixl-cu/{print $1}' | xargs -r uv pip uninstall -y 2>/dev/null || true) && \
+{% elif device == "cuda" %}
+    # Remove nixl-cu* variants that do NOT match the build CUDA major version.
+    # LMCache >=0.4.4 depends on nixl>=1.1.0 which pulls in both nixl-cu12 and
+    # nixl-cu13; their coexistence breaks `import nixl` at runtime.
+    CUDA_MAJOR="${CUDA_VERSION%%.*}" && \
+    (uv pip freeze 2>/dev/null | awk -F= '/^nixl-cu/{print $1}' | grep -v "^nixl-cu${CUDA_MAJOR}$" | xargs -r uv pip uninstall -y 2>/dev/null || true) && \
+{% endif %}
     if [ "${ENABLE_KVBM}" = "true" ]; then \
         KVBM_WHEEL=$(ls /opt/dynamo/wheelhouse/kvbm*.whl 2>/dev/null | head -1); \
         if [ -z "$KVBM_WHEEL" ]; then \
@@ -350,20 +357,25 @@ RUN --mount=type=bind,source=./container/deps/requirements.common.txt,target=/tm
     --mount=type=bind,source=./container/deps/requirements.benchmark.txt,target=/tmp/requirements.benchmark.txt \
     --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sharing=shared \
     export UV_CACHE_DIR=/home/dynamo/.cache/uv UV_GIT_LFS=1 UV_HTTP_TIMEOUT=300 UV_HTTP_RETRIES=5 && \
-    CUDA_VERSION_MAJOR=${CUDA_VERSION%%.*} && \
-    # Remove any cupy variant that may already be in the inherited venv
-    # (the framework base may install cupy-cuda12x, pyproject.toml also pins
-    # cupy-cuda12x). cupy's `_detect_duplicate_installation` ERRORS at import
-    # if both cu12 and cu13 variants are present, so we install exactly one
-    # variant matching the build target's CUDA major version. Discover the
-    # installed variants instead of hardcoding so future cupy versions
-    # (cupy-cuda14x, etc.) are covered without further edits.
-    (uv pip freeze 2>/dev/null | awk -F= '/^cupy-/{print $1}' | xargs -r uv pip uninstall 2>/dev/null || true) && \
     uv pip install \
         --requirement /tmp/requirements.common.txt \
         --requirement /tmp/requirements.vllm.txt \
-        --requirement /tmp/requirements.benchmark.txt \
-        cupy-cuda${CUDA_VERSION_MAJOR}x
+        --requirement /tmp/requirements.benchmark.txt
+
+{% if device == "cuda" %}
+# Install cupy matching the CUDA major version; remove any pre-existing variant
+# (the framework base may install cupy-cuda12x, pyproject.toml also pins
+# cupy-cuda12x). cupy's `_detect_duplicate_installation` ERRORS at import
+# if both cu12 and cu13 variants are present, so we install exactly one
+# variant matching the build target's CUDA major version. Discover the
+# installed variants instead of hardcoding so future cupy versions
+# (cupy-cuda14x, etc.) are covered without further edits.
+RUN --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sharing=shared \
+    export UV_CACHE_DIR=/home/dynamo/.cache/uv && \
+    CUDA_VERSION_MAJOR=${CUDA_VERSION%%.*} && \
+    (uv pip freeze 2>/dev/null | awk -F= '/^cupy-/{print $1}' | xargs -r uv pip uninstall 2>/dev/null || true) && \
+    uv pip install cupy-cuda${CUDA_VERSION_MAJOR}x
+{% endif %}
 
 # Copy tests, deploy, lib, and the vllm/common/mocker component subtrees for CI.
 # Pattern: COPY --chmod=775 <path>; chmod g+w <path> done later as root because COPY --chmod only affects <path>/*, not <path>


### PR DESCRIPTION
## Problem

PR #9379 (`fix(container): match cupy CUDA version to build target`) introduced cupy-cuda installation inline in the requirements RUN block. This works for CUDA builds but **breaks XPU builds** because:

1. **cupy-cuda issue**: `CUDA_VERSION` is empty for XPU, so `cupy-cuda${CUDA_VERSION_MAJOR}x` resolves to `cupy-cudax` (non-existent package), causing `uv pip install` to fail.

2. **nixl-cu13 conflict**: LMCache 0.4.4 depends on `nixl>=1.1.0`, which pulls in both `nixl-cu12` and `nixl-cu13`. The dynamo wheel install step replaces `nixl` and `nixl-cu12` with XPU versions, but `nixl-cu13` is left behind. The coexistence of `nixl-cu12` (replaced by `nixl-xpu`) and `nixl-cu13` causes `dynamo.nixl_connect` to fail at import time.

## Fix

1. **cupy**: Move cupy install out of the shared requirements RUN into a separate RUN block guarded by `{% if device == "cuda" %}`. XPU/CPU builds skip cupy entirely.

2. **nixl**: Add a `{% if device == "xpu" %}` block after nixl wheel installation to remove all `nixl-cu*` variants that LMCache or other deps may have pulled in.

## Introduced by
- #9379 (cupy inline install without device guard)
- nixl 1.1.0 release (pulls both cu12+cu13 backends as dependencies)

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9419" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced container runtime dependency installation with improved device-specific package handling. Restructured Python dependency installation for better layer efficiency. Separated conditional dependencies into discrete build steps for improved maintainability and consistency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9419)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->