### PR TITLE
operator/worker-hash: cover unsupported v2 migration

### DIFF
--- a/deploy/operator/internal/controller/dynamographdeployment_rollingupdate_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_rollingupdate_test.go
@@ -454,11 +454,12 @@ func TestLegacyAlphaHashCompatibility_V2OnlyChangeUsesNewV2Generation(t *testing
 	require.Equal(t, newV2Hash, dgd.Annotations[consts.AnnotationCurrentWorkerHashV2])
 }
 
-func TestUnsupportedPathwayV2OnlyChangeKeepsV2OnlyGeneration(t *testing.T) {
+func TestUnsupportedPathwayMigratesV1OnlyAndKeepsV2OnlyGeneration(t *testing.T) {
 	dgd := createTestDGD("test-dgd", map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
 		"worker": {
 			ComponentType: consts.ComponentTypeWorker,
 			Envs:          []corev1.EnvVar{{Name: "FOO", Value: "bar"}},
+			Multinode:     &nvidiacomv1alpha1.MultinodeSpec{NodeCount: 2},
 		},
 	})
 	dgd.Spec.BackendFramework = "vllm"
@@ -466,11 +467,20 @@ func TestUnsupportedPathwayV2OnlyChangeKeepsV2OnlyGeneration(t *testing.T) {
 	require.NoError(t, err)
 	v2Hash := betaDGDWorkersSpecHash(t, dgd)
 	dgd.Annotations = map[string]string{
-		consts.AnnotationCurrentWorkerHash:   legacyHash,
-		consts.AnnotationCurrentWorkerHashV2: v2Hash,
+		consts.AnnotationCurrentWorkerHash: legacyHash,
 	}
 
 	r := createTestReconcilerWithStatus(dgd)
+	require.False(t, r.supportsManagedRollingUpdate(dgd))
+
+	require.NoError(t, r.migrateCurrentWorkerHashIfNeeded(context.Background(), dgd))
+	require.Equal(t, legacyHash, dgd.Annotations[consts.AnnotationCurrentWorkerHash])
+	require.Equal(t, v2Hash, dgd.Annotations[consts.AnnotationCurrentWorkerHashV2])
+
+	trigger, err := r.shouldTriggerRollingUpdate(dgd)
+	require.NoError(t, err)
+	require.False(t, trigger)
+
 	dgd.Spec.BackendFramework = "sglang"
 
 	newLegacyHash, err := dynamo.ComputeLegacyAlphaDGDWorkersSpecHash(dgd)


### PR DESCRIPTION
Summary:
- extend the unsupported-path worker-hash test to start from v1-only upgrade state
- verify unsupported multinode reconciles record v2 without triggering and keep v2-only changes v2-only

Tests:
- KUBEBUILDER_ASSETS="$(/Users/sschimanski/src/ai-dynamo/dynamo/.codex/worktrees/sttts-legacy-hash/deploy/operator/bin/setup-envtest-release-0.19 use 1.29.0 --bin-dir /Users/sschimanski/src/ai-dynamo/dynamo/.codex/worktrees/sttts-legacy-hash/deploy/operator/bin -p path)" go test ./internal/controller -run TestUnsupportedPathwayMigratesV1OnlyAndKeepsV2OnlyGeneration -count=1
- KUBEBUILDER_ASSETS="$(/Users/sschimanski/src/ai-dynamo/dynamo/.codex/worktrees/sttts-legacy-hash/deploy/operator/bin/setup-envtest-release-0.19 use 1.29.0 --bin-dir /Users/sschimanski/src/ai-dynamo/dynamo/.codex/worktrees/sttts-legacy-hash/deploy/operator/bin -p path)" go test ./internal/controller -count=1
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9425" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->