### PR TITLE
docs(kubernetes/dgdr): add PCIe profiler callout and Known Issues section

### DIFF
--- a/docs/kubernetes/dgdr.md
+++ b/docs/kubernetes/dgdr.md
@@ -97,6 +97,14 @@ All supported values: `gb200_sxm`, `b200_sxm`, `h200_sxm`, `h100_sxm`,
 > Not all SKUs are supported by the AIC profiler for `rapid` mode. See
 > [AIC Support Matrix](model-deployment-guide.md#aic-support-matrix) for details.
 
+> [!IMPORTANT]
+> **PCIe variants not yet supported by profiler.** The CRD admits PCIe SKUs
+> (`h100_pcie`, `a100_pcie`, `v100_pcie`), but the profiler does not currently
+> ship training data for them. You can submit a DGDR with a PCIe value; the
+> operator will accept it but profiler-assisted sizing will fall back to
+> defaults. Profiler support for PCIe SKUs is tracked as an engineering
+> follow-up.
+
 ## Lifecycle
 
 When you create a DGDR, it progresses through these phases:
@@ -156,6 +164,14 @@ kubectl get dgdr my-model -n $NAMESPACE \
   `dgdr.nvidia.com/namespace`.
 - Additional resources (planner ConfigMaps) are created in the same namespace
   and labeled with `dgdr.nvidia.com/name`.
+
+## Known Issues
+
+- **`pareto_analysis.py` produces NaN for some configurations.** Tracked as an
+  engineering follow-up. Workaround: re-run with a narrower sweep; narrow
+  sweeps bypass the NaN path in practice.
+- **PCIe profiler data not yet available.** See the PCIe callout under
+  [SKU Format](#sku-format).
 
 ## Further Reading
 


### PR DESCRIPTION
#### Overview

Two small additions on top of the SKU Format work that already shipped to `main` via #9176 (A30 SKU) and #8777 (K8s docs refactor). Replaces the older, now-superseded #8390.

#### What's in this PR (16-line diff, single file)

- **PCIe callout** under the SKU Format `[!NOTE]`: the CRD admits `h100_pcie`, `a100_pcie`, `v100_pcie`, but the profiler does not ship training data for them. Operator accepts the value; profiler-assisted sizing falls back to defaults. Engineering follow-up tracked separately.
- **Known Issues section** near the bottom of `dgdr.md`: documents the `pareto_analysis.py` NaN-with-narrow-sweep workaround and back-references the PCIe callout.

#### Why rescope from #8390

When that branch was rebased on current `main`, the SKU table commit hit a conflict because `main` had grown an equivalent (and slightly newer — includes `a30`) section in its own K8s docs refactor. The unique content still worth shipping is the operator-vs-profiler gap callout and the user-facing pareto NaN workaround, which `main` does not yet document.

#### Tickets

- DYN-2793 and DYN-2794: closed as Done — shipped via #9176 + #8777.
- This PR is unblocked of any open VDR ticket; merging it is a docs-only improvement, not a blocker.

#### Reviewers

Single file, no code, no CI risk.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9428" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification on PCIe variant SKU support and expected fallback behavior when rapid profiling is unavailable
  * Introduced a new Known Issues section documenting known limitations with specific configurations and profiler data availability

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9428)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->