### PR TITLE
docs: fix Qwen3-235B-A22B-FP8 recipe links to hardware-specific manifests

### DIFF
--- a/docs/backends/trtllm/multinode/trtllm-multinode-examples.md
+++ b/docs/backends/trtllm/multinode/trtllm-multinode-examples.md
@@ -17,8 +17,10 @@ and related routing components.
 The main TRT-LLM recipe entrypoints are:
 
 - [DeepSeek-R1 WideEP on GB200](../../../../recipes/deepseek-r1/trtllm/disagg/wide_ep/gb200/deploy.yaml)
-- [Qwen3-235B-A22B-FP8 aggregated](../../../../recipes/qwen3-235b-a22b-fp8/trtllm/agg/deploy.yaml)
-- [Qwen3-235B-A22B-FP8 disaggregated](../../../../recipes/qwen3-235b-a22b-fp8/trtllm/disagg/deploy.yaml)
+- [Qwen3-235B-A22B-FP8 aggregated, Hopper](../../../../recipes/qwen3-235b-a22b-fp8/trtllm/agg/hopper/deploy.yaml)
+- [Qwen3-235B-A22B-FP8 aggregated, Blackwell](../../../../recipes/qwen3-235b-a22b-fp8/trtllm/agg/blackwell/deploy.yaml)
+- [Qwen3-235B-A22B-FP8 disaggregated, Hopper](../../../../recipes/qwen3-235b-a22b-fp8/trtllm/disagg/hopper/deploy.yaml)
+- [Qwen3-235B-A22B-FP8 disaggregated, Blackwell](../../../../recipes/qwen3-235b-a22b-fp8/trtllm/disagg/blackwell/deploy.yaml)
 - [Qwen3-32B-FP8 aggregated](../../../../recipes/qwen3-32b-fp8/trtllm/agg/deploy.yaml)
 - [Qwen3-32B-FP8 disaggregated](../../../../recipes/qwen3-32b-fp8/trtllm/disagg/deploy.yaml)
 - [GPT-OSS-120B aggregated](../../../../recipes/gpt-oss-120b/trtllm/agg/deploy.yaml)


### PR DESCRIPTION
## Overview

The Qwen3-235B-A22B-FP8 bullets in `docs/backends/trtllm/multinode/trtllm-multinode-examples.md` point at `agg/deploy.yaml` and `disagg/deploy.yaml`, but those flat files do not exist. The actual deploy manifests live in `hopper/` and `blackwell/` subdirectories.

## Details

Split each broken bullet into two hardware-specific bullets:

- `recipes/qwen3-235b-a22b-fp8/trtllm/agg/hopper/deploy.yaml`
- `recipes/qwen3-235b-a22b-fp8/trtllm/agg/blackwell/deploy.yaml`
- `recipes/qwen3-235b-a22b-fp8/trtllm/disagg/hopper/deploy.yaml`
- `recipes/qwen3-235b-a22b-fp8/trtllm/disagg/blackwell/deploy.yaml`

This matches the level of specificity already used for the DeepSeek-R1 GB200 entry in the same list, and gives readers the exact deploy.yaml their hardware needs.

## Why a separate PR

Two related PRs (#9384 and #9389) convert this list to absolute `github.com/.../blob/main/...` URLs. With the original flat paths, those URLs returned 404 in lychee. Landing this path correction independently keeps the URL-style sweep separate from the path-correction; #9384 can rebase on this and pick up the new bullets cleanly.

## Where Should the Reviewer Start

`docs/backends/trtllm/multinode/trtllm-multinode-examples.md` lines 20-23. Two lines deleted, four lines added.

## Related Issues

Unblocks lychee on #9384 (and transitively #9389).

## Summary by CodeRabbit

- **Documentation**
  - Replaced two broken Qwen3-235B-A22B-FP8 recipe links with four hardware-specific links covering Hopper and Blackwell variants for both aggregated and disaggregated configurations.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9429" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated TRT-LLM recipe examples with hardware-specific variants for Hopper and Blackwell architectures, providing clearer guidance for both aggregated and disaggregated deployment configurations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9429)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->