### PR TITLE
fix(trtllm): escalate poisoned KV-cache-transfer to worker shutdown

### DIFF
--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -195,6 +195,48 @@ class _DeferredAbort:
         logging.debug("Deferred abort: background task completed, abort fired")
 
 
+# Fatal CUDA error patterns from PR #8342 — unrecoverable hardware/driver
+# state that should restart the worker rather than being swallowed as a
+# per-request WARN. cudaErrorMemoryAllocation (OOM) is intentionally NOT
+# listed: TRT-LLM aborts the offending request and frees KV, so the engine
+# stays healthy.
+FATAL_CUDA_ERROR_PATTERNS = re.compile(
+    "|".join(
+        [
+            r"cudaErrorNvlinkUncorrectable",
+            r"cudaErrorNoDevice",
+            r"cudaErrorECCUncorrectable",
+            r"cudaErrorIllegalAddress",
+            r"cudaErrorAssert",
+            r"cudaErrorUnknown",
+            r"cudaErrorLaunchTimeout",
+            r"cudaErrorMisalignedAddress",
+            r"cudaErrorHardwareStackError",
+        ]
+    ),
+    re.IGNORECASE,
+)
+
+# Fatal KV-cache-transfer error patterns. When TRT-LLM's NIXL/UCX cache
+# transfer buffer is poisoned by a mid-transfer prefill failure, every
+# subsequent buffer allocation raises this RequestError. Per TRT-LLM
+# source (cpp/tensorrt_llm/batch_manager/baseTransBuffer.cpp), the only
+# safe recovery is a process restart — so escalate it the same way as a
+# fatal CUDA error: cleanup + os._exit(1), let k8s/docker restart the
+# container.
+FATAL_KV_TRANSFER_ERROR_PATTERNS = re.compile(
+    "|".join(
+        [
+            r"Cannot assign cache transfer buffer.*poisoned",
+            r"previous transfer left the buffer pool poisoned",
+            r"Poisoned .* cache transfer buffer",
+            r"process must restart before these memory ranges",
+        ]
+    ),
+    re.IGNORECASE,
+)
+
+
 @dataclass
 class RequestHandlerConfig:
     """
@@ -898,6 +940,41 @@ class HandlerBase(BaseGenerativeHandler):
             logging.critical("Forcing process exit for restart")
             os._exit(1)
 
+    async def _handle_per_request_error(
+        self, error: "RequestError", request_id: str
+    ) -> "AsyncGenerator[dict, None]":
+        """Emit the error chunk for a TRT-LLM RequestError, escalating to
+        worker shutdown if the message matches FATAL_CUDA_ERROR_PATTERNS or
+        FATAL_KV_TRANSFER_ERROR_PATTERNS.
+
+        Modeled on ai-dynamo/dynamo PR #8342. Extended here to also escalate
+        TRT-LLM poisoned-cache-transfer-buffer errors, which TRT-LLM itself
+        documents as requiring a process restart.
+        """
+        error_msg = str(error)
+        fatal_cuda = FATAL_CUDA_ERROR_PATTERNS.search(error_msg) is not None
+        fatal_kv = FATAL_KV_TRANSFER_ERROR_PATTERNS.search(error_msg) is not None
+        if fatal_cuda or fatal_kv:
+            kind = "CUDA" if fatal_cuda else "KV cache transfer"
+            logging.error(
+                f"Fatal {kind} error in request {request_id} "
+                f"(caught as RequestError): {error_msg}",
+                exc_info=True,
+            )
+        else:
+            logging.warning(f"Request {request_id} error: {error_msg}")
+        try:
+            yield {"finish_reason": {"error": error_msg}, "token_ids": []}
+        except Exception as emit_err:  # noqa: BLE001
+            logging.debug(
+                "Failed to emit error chunk for request %s: %s",
+                request_id,
+                emit_err,
+            )
+        if fatal_cuda or fatal_kv:
+            await self._initiate_shutdown(error)
+
+
     async def generate_locally(
         self,
         request: dict,
@@ -1289,13 +1366,12 @@ class HandlerBase(BaseGenerativeHandler):
             return  # Just stop, no error response
 
         # 2. Per-request errors - send to client, don't shutdown
+        #    UNLESS the error indicates fatal/unrecoverable state
+        #    (CUDA hardware/driver fault or poisoned KV-cache transfer
+        #    buffer), in which case escalate to graceful shutdown.
         except RequestError as e:
-            error_msg = str(e)
-            logging.warning(f"Request {request_id} error: {error_msg}")
-            yield {
-                "finish_reason": {"error": error_msg},
-                "token_ids": [],
-            }
+            async for chunk in self._handle_per_request_error(e, request_id):
+                yield chunk
 
         # 3. EngineShutdown - let it propagate to the Rust bridge
         except EngineShutdown:

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -227,10 +227,20 @@ FATAL_CUDA_ERROR_PATTERNS = re.compile(
 FATAL_KV_TRANSFER_ERROR_PATTERNS = re.compile(
     "|".join(
         [
+            # C++ error strings (these typically appear in TRT-LLM logs but
+            # are masked by the Python wrapper below; included so we still
+            # match if a future TRT-LLM release surfaces them through to
+            # the Python RequestError):
             r"Cannot assign cache transfer buffer.*poisoned",
             r"previous transfer left the buffer pool poisoned",
             r"Poisoned .* cache transfer buffer",
             r"process must restart before these memory ranges",
+            # Python wrapper string that TRT-LLM's _check_disagg_*_status
+            # actually raises to dynamo as a RequestError. In disaggregated
+            # mode, any "Error in kv cache transfer" (context or generation)
+            # is the practical signal that the worker is in an unrecoverable
+            # state — restart it.
+            r"Error in kv cache transfer for (context|generation) requests",
         ]
     ),
     re.IGNORECASE,
@@ -973,7 +983,6 @@ class HandlerBase(BaseGenerativeHandler):
             )
         if fatal_cuda or fatal_kv:
             await self._initiate_shutdown(error)
-
 
     async def generate_locally(
         self,


### PR DESCRIPTION
#### Overview

When a prefill worker is deleted mid-KV-transfer in a disaggregated setup, TRT-LLM's cache-transfer buffer pool gets poisoned. The decode worker logs `Poisoned ... cache transfer buffer kind=kv`, every subsequent request fails the `Cannot assign cache transfer buffer kind=kv because a previous transfer left the buffer pool poisoned. The process must restart before these memory ranges can be safely reused.` assertion in `cpp/tensorrt_llm/batch_manager/baseTransBuffer.cpp`, and TRT-LLM raises the wrapped Python `RequestError("Error in kv cache transfer for {context|generation} requests")` (`tensorrt_llm/_torch/pyexecutor/py_executor.py`).

Despite the explicit `The process must restart` directive in the TRT-LLM error, the dynamo handler's current `except RequestError` branch just logs a WARN and yields an error chunk — the worker keeps running and `/live`/`/health` stay green. End users see HTTP 500 indefinitely until an operator manually rolls the worker.

This PR adds a dynamo-side escalation modeled directly on #8342 (which does the same for fatal CUDA errors). The new `_handle_per_request_error` helper matches the error message against two regex groups:

1. `FATAL_CUDA_ERROR_PATTERNS` — same list as #8342, kept here so we don't conflict with that PR.
2. `FATAL_KV_TRANSFER_ERROR_PATTERNS` — new, matches both the TRT-LLM C++ error strings (kept for forward-compat) AND the actual Python wrapper `Error in kv cache transfer for (context|generation) requests` that is what reaches dynamo today.

On a match, the helper awaits the existing `_initiate_shutdown()` → `engine.cleanup()` → `os._exit(1)` path, so kubelet (or `docker --restart=on-failure`) replaces the container.

#### Why two commits

Kept as two commits so reviewers can see the design progression — the second commit (regex-widening) was driven by an actual e2e finding: my first attempt matched only the C++ strings, but those never reach the Python `RequestError.__str__()`. The wrapper string is what we actually need to match in production today. Both commits are individually testable.

#### Where should the reviewer start?

- `components/src/dynamo/trtllm/request_handlers/handler_base.py`
  - `FATAL_CUDA_ERROR_PATTERNS` and `FATAL_KV_TRANSFER_ERROR_PATTERNS` near the top
  - `HandlerBase._handle_per_request_error` right after `_initiate_shutdown`
  - The `except RequestError` branch in `_generate_locally_impl` (now delegates to the helper)

#### Testing

Verified end-to-end on 2× GB200 (1P1D, TP=4 + TP=4, Qwen3-Coder-480B-A35B-Instruct_nvfp4), same setup as the production reproducer in `dynamo-gb200-test/docs/disagg-pr13713-v8-poison-buffer-no-intervention-soak-reproducer-2026-05-11.md`. Two matched 15-min soak runs:

| metric (15 min post-kill soak, 90 probes) | **without patch (head-pr13713-dynamomain-v8)** | **with patch (head-pr13713-dynamomain-v9-poison-restart)** |
|---|---|---|
| `Poisoned recv cache transfer buffer kind=kv` in decode log | ✓ (460 lines) | ✓ (4 lines, before restart) |
| Dynamo handler escalates to `_initiate_shutdown` / `Forcing process exit for restart` | ✗ (0 occurrences) | ✓ (6 occurrences) |
| Decode `RestartCount` at end of soak | **0** | **1** |
| Soak HTTP probes: 200 / 500 / other | **0 / 77 / 0** (wedged) | **57 / 2 / 18** (recovers ~5 min after kill) |
| Operator intervention required to recover | yes | no |

Recovery timeline from the with-patch run: `os._exit(1)` fires ~62s after prefill kill; docker increments RestartCount immediately; new decode container loads weights + captures graphs (~3 min); registers endpoint; prefill router reactivates; first post-recovery probe returns 200 at +296s. Sustained 200s through end of soak.

Full comparison doc + raw logs + verdict line are saved at `claude-local-orchestrator/docs/disagg-pr13713-v9-poison-restart-2026-05-12.md` (also captures a couple of operational gotchas — `docker kill` doesn't fire `--restart=on-failure` policy; the dlcluster decode-side NIC routes NFS over 1 Gbps and bottlenecks the 256 GB model copy).

#### Related issues

- Builds on #8342 (fatal CUDA errors → worker shutdown). Same pattern, different error class.
- Resolves the wedge described in `dynamo-gb200-test/docs/disagg-pr13713-v8-poison-buffer-no-intervention-soak-2026-05-09.md` and the production reproducer linked above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
