### PR TITLE
feat(sglang): add opt-in decode warmup

### DIFF
--- a/components/src/dynamo/sglang/backend_args.py
+++ b/components/src/dynamo/sglang/backend_args.py
@@ -111,6 +111,12 @@ class DynamoSGLangArgGroup(ArgGroup):
             default=False,
             help="Enable RL training support. Registers the call_tokenizer_manager engine route for generic tokenizer_manager passthrough.",
         )
+        g.add_argument(
+            "--warmup-decode-engine",
+            action=argparse.BooleanOptionalAction,
+            default=False,
+            help="Run a small Engine API generation before registering a decode worker ready. Useful for moving lazy kernel compilation into startup.",
+        )
 
         # Topology constraint: rejecting --frontend-decoding combined with the
         # EPD multimodal flags happens in DynamoSGLangConfig.validate() below.
@@ -143,6 +149,7 @@ class DynamoSGLangConfig(ConfigBase):
 
     video_generation_worker: bool
     enable_rl: bool
+    warmup_decode_engine: bool
     frontend_decoding: bool = False
     sglang_trace_level: int
 

--- a/components/src/dynamo/sglang/init_llm.py
+++ b/components/src/dynamo/sglang/init_llm.py
@@ -27,6 +27,7 @@ from dynamo.sglang.publisher import (
 )
 from dynamo.sglang.register import register_model_with_readiness_gate
 from dynamo.sglang.request_handlers import DecodeWorkerHandler, PrefillWorkerHandler
+from dynamo.sglang.warmup import warmup_decode_handler, warmup_runtime_endpoint
 
 
 async def _warmup_prefill_engine(engine: sgl.Engine, server_args) -> None:
@@ -111,6 +112,21 @@ async def init_decode(
         shutdown_event,
         enable_frontend_decoding=dynamo_args.frontend_decoding,
     )
+
+    if dynamo_args.warmup_decode_engine:
+        try:
+            await warmup_decode_handler(handler, server_args)
+        except asyncio.TimeoutError as e:
+            logging.error(
+                "Decode warmup timed out after 1800s; aborting worker startup"
+            )
+            raise RuntimeError(
+                "Decode warmup timed out; worker cannot serve requests"
+            ) from e
+        except Exception as e:
+            logging.error("Decode warmup failed: %s; aborting worker startup", e)
+            raise RuntimeError(f"Decode warmup failed: {e}") from e
+
     handler.register_engine_routes(runtime)
 
     if config.serving_mode == DisaggregationMode.DECODE:
@@ -122,7 +138,7 @@ async def init_decode(
             engine, use_text_input=dynamo_args.use_sglang_tokenizer
         ).to_dict()
 
-    logging.info(f"Registering model with endpoint types: {dynamo_args.endpoint_types}")
+    logging.info(f"Configured model endpoint types: {dynamo_args.endpoint_types}")
     if dynamo_args.custom_jinja_template and "chat" not in dynamo_args.endpoint_types:
         logging.warning(
             "Custom Jinja template provided (--custom-jinja-template) but 'chat' not in --dyn-endpoint-types. "
@@ -137,6 +153,41 @@ async def init_decode(
         shutdown_endpoints.append(session_control_endpoint)
 
     try:
+
+        async def register_model_after_endpoint_warmup() -> None:
+            if dynamo_args.warmup_decode_engine:
+                try:
+                    await warmup_runtime_endpoint(
+                        generate_endpoint, engine, server_args
+                    )
+                except asyncio.TimeoutError as e:
+                    logging.error(
+                        "Decode runtime endpoint warmup timed out after 1800s; "
+                        "aborting worker startup"
+                    )
+                    raise RuntimeError(
+                        "Decode runtime endpoint warmup timed out; "
+                        "worker cannot serve requests"
+                    ) from e
+                except Exception as e:
+                    logging.error(
+                        "Decode runtime endpoint warmup failed: %s; "
+                        "aborting worker startup",
+                        e,
+                    )
+                    raise RuntimeError(
+                        f"Decode runtime endpoint warmup failed: {e}"
+                    ) from e
+
+            await register_model_with_readiness_gate(
+                engine,
+                generate_endpoint,
+                server_args,
+                dynamo_args,
+                output_type=parse_endpoint_types(dynamo_args.endpoint_types),
+                readiness_gate=ready_event,
+            )
+
         gather_tasks = [
             generate_endpoint.serve_endpoint(
                 handler.generate,
@@ -156,14 +207,7 @@ async def init_decode(
                 handler.list_loras,
                 metrics_labels=metrics_labels,
             ),
-            register_model_with_readiness_gate(
-                engine,
-                generate_endpoint,
-                server_args,
-                dynamo_args,
-                output_type=parse_endpoint_types(dynamo_args.endpoint_types),
-                readiness_gate=ready_event,
-            ),
+            register_model_after_endpoint_warmup(),
         ]
         if getattr(server_args, "enable_streaming_session", False):
             gather_tasks.append(

--- a/components/src/dynamo/sglang/main.py
+++ b/components/src/dynamo/sglang/main.py
@@ -41,7 +41,10 @@ async def worker():
         config.server_args.load_format = setup_gms(config.server_args)
 
     # Checkpoint mode: engine must be created BEFORE runtime (no NATS/etcd during CRIU)
-    snapshot_controller = await prepare_snapshot_engine(config.server_args)
+    snapshot_controller = await prepare_snapshot_engine(
+        config.server_args,
+        warmup_decode_engine=config.dynamo_args.warmup_decode_engine,
+    )
 
     dynamo_args = config.dynamo_args
     snapshot_engine = None

--- a/components/src/dynamo/sglang/snapshot.py
+++ b/components/src/dynamo/sglang/snapshot.py
@@ -13,12 +13,15 @@ import sglang as sgl
 from dynamo.common.utils.snapshot import CheckpointConfig, EngineSnapshotController
 
 from .request_handlers.handler_base import SGLangEngineQuiesceController
+from .warmup import warmup_generation_engine
 
 logger = logging.getLogger(__name__)
 
 
 async def prepare_snapshot_engine(
     server_args,
+    *,
+    warmup_decode_engine: bool = False,
 ) -> EngineSnapshotController[sgl.Engine] | None:
     """Single entry point for Dynamo Snapshot integration.
 
@@ -57,6 +60,13 @@ async def prepare_snapshot_engine(
     logger.info(
         f"SGLang engine loaded in {time.time() - start_time:.2f}s (checkpoint mode)"
     )
+
+    if warmup_decode_engine:
+        await warmup_generation_engine(
+            engine,
+            server_args,
+            label="checkpoint decode",
+        )
 
     gc.collect()
 

--- a/components/src/dynamo/sglang/tests/test_sglang_unit.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_unit.py
@@ -3,6 +3,8 @@
 
 """Unit tests for SGLang backend components."""
 
+import argparse
+import asyncio
 import re
 import sys
 from pathlib import Path
@@ -18,12 +20,18 @@ from dynamo.sglang._compat import (
     filter_supported_async_generate_kwargs,
 )
 from dynamo.sglang.args import parse_args
+from dynamo.sglang.backend_args import DynamoSGLangArgGroup, DynamoSGLangConfig
 from dynamo.sglang.health_check import (
     SglangDisaggHealthCheckPayload,
     SglangPrefillHealthCheckPayload,
 )
 from dynamo.sglang.request_handlers.llm.decode_handler import DecodeWorkerHandler
 from dynamo.sglang.tests.conftest import make_cli_args_fixture
+from dynamo.sglang.warmup import (
+    warmup_decode_handler,
+    warmup_generation_engine,
+    warmup_runtime_endpoint,
+)
 
 # Get path relative to this test file
 REPO_ROOT = Path(__file__).resolve().parents[5]
@@ -40,6 +48,42 @@ pytestmark = [
     pytest.mark.profiled_vram_gib(0),  # These unit tests do not actually use GPU VRAM
     pytest.mark.pre_merge,
 ]
+
+
+def _expected_decode_warmup_request():
+    return {
+        "token_ids": list(range(18)),
+        "stop_conditions": {
+            "max_tokens": 8,
+            "stop": [],
+            "stop_token_ids": [],
+            "min_tokens": 0,
+            "ignore_eos": False,
+        },
+        "sampling_options": {
+            "n": 1,
+            "presence_penalty": 0.0,
+            "frequency_penalty": 0.0,
+            "repetition_penalty": 1.0,
+            "temperature": 0.0,
+            "top_p": 1.0,
+            "top_k": -1,
+            "min_p": 0.0,
+            "seed": None,
+            "guided_decoding": None,
+        },
+        "output_options": {
+            "logprobs": None,
+            "prompt_logprobs": None,
+            "skip_special_tokens": True,
+            "return_tokens_as_token_ids": None,
+        },
+        "eos_token_ids": [],
+        "annotations": [],
+        "routing": None,
+    }
+
+
 # Create SGLang-specific CLI args fixture
 # This will use monkeypatch to write to argv
 mock_sglang_cli = make_cli_args_fixture("dynamo.sglang")
@@ -328,6 +372,224 @@ async def test_obsolete_dyn_endpoint_types_flag_is_supported(mock_sglang_cli):
 
     config = await parse_args(sys.argv[1:])
     assert config.dynamo_args.endpoint_types == "completions"
+
+
+def test_warmup_decode_engine_flag():
+    parser = argparse.ArgumentParser()
+    DynamoSGLangArgGroup().add_arguments(parser)
+
+    config = DynamoSGLangConfig.from_cli_args(
+        parser.parse_args(["--warmup-decode-engine"])
+    )
+
+    assert config.warmup_decode_engine is True
+
+
+def test_generation_warmup_drains_engine_stream():
+    class FakeEngine:
+        def __init__(self):
+            self.calls = []
+            self.freeze_gc_calls = 0
+            self.tokenizer_manager = self
+
+        async def async_generate(self, **kwargs):
+            self.calls.append(kwargs)
+
+            async def stream():
+                yield {"text": "warm"}
+                yield {"text": "done"}
+
+            return stream()
+
+        async def freeze_gc(self):
+            self.freeze_gc_calls += 1
+
+    engine = FakeEngine()
+
+    asyncio.run(
+        warmup_generation_engine(
+            engine,
+            SimpleNamespace(disaggregation_mode="null"),
+            timeout=1,
+        )
+    )
+
+    assert engine.calls == [
+        {
+            "input_ids": list(range(18)),
+            "sampling_params": {
+                "temperature": 0.0,
+                "max_new_tokens": 8,
+                "ignore_eos": True,
+            },
+            "stream": True,
+        }
+    ]
+    assert engine.freeze_gc_calls == 1
+
+
+def test_generation_warmup_skips_disaggregated_decode():
+    class FakeEngine:
+        async def async_generate(self, **kwargs):
+            raise AssertionError("warmup should not run")
+
+    asyncio.run(
+        warmup_generation_engine(
+            FakeEngine(),
+            SimpleNamespace(disaggregation_mode="decode"),
+            timeout=1,
+        )
+    )
+
+
+def test_handler_warmup_drains_decode_handler_stream():
+    class FakeHandler:
+        def __init__(self):
+            self.calls = []
+            self.engine = SimpleNamespace(tokenizer_manager=FakeTokenizerManager())
+
+        async def generate(self, request, context):
+            self.calls.append(
+                {
+                    "request": request,
+                    "context_id": context.id(),
+                    "trace_id": context.trace_id,
+                    "span_id": context.span_id,
+                    "is_stopped": context.is_stopped(),
+                    "cancel_future_done": context.async_killed_or_stopped().done(),
+                }
+            )
+            yield {"token_ids": [1]}
+            yield {"finish_reason": "length", "token_ids": []}
+
+    handler = FakeHandler()
+
+    asyncio.run(
+        warmup_decode_handler(
+            handler,
+            SimpleNamespace(disaggregation_mode="null"),
+            timeout=1,
+        )
+    )
+
+    assert handler.calls == [
+        {
+            "request": _expected_decode_warmup_request(),
+            "context_id": "dynamo-sglang-warmup",
+            "trace_id": "dynamo-sglang-warmup",
+            "span_id": None,
+            "is_stopped": False,
+            "cancel_future_done": False,
+        }
+    ]
+    assert handler.engine.tokenizer_manager.freeze_gc_calls == 1
+
+
+class FakeTokenizerManager:
+    def __init__(self):
+        self.freeze_gc_calls = 0
+
+    async def freeze_gc(self):
+        self.freeze_gc_calls += 1
+
+
+def test_runtime_endpoint_warmup_calls_own_instance():
+    class FakeStream:
+        def __init__(self):
+            self.items = iter([{"token_ids": [1]}, {"token_ids": [2]}])
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            try:
+                return next(self.items)
+            except StopIteration as e:
+                raise StopAsyncIteration from e
+
+    class FakeClient:
+        def __init__(self):
+            self.wait_calls = 0
+            self.direct_calls = []
+            self.instances = [1234]
+
+        async def wait_for_instances(self):
+            self.wait_calls += 1
+            return self.instances
+
+        def instance_ids(self):
+            return self.instances
+
+        async def direct(self, request, instance_id, annotated=True):
+            self.direct_calls.append(
+                {
+                    "request": request,
+                    "instance_id": instance_id,
+                    "annotated": annotated,
+                }
+            )
+            return FakeStream()
+
+    class FakeEndpoint:
+        def __init__(self):
+            self.fake_client = FakeClient()
+
+        async def client(self):
+            return self.fake_client
+
+        def connection_id(self):
+            return 1234
+
+    endpoint = FakeEndpoint()
+    engine = SimpleNamespace(tokenizer_manager=FakeTokenizerManager())
+
+    asyncio.run(
+        warmup_runtime_endpoint(
+            endpoint,
+            engine,
+            SimpleNamespace(disaggregation_mode="null"),
+            timeout=1,
+        )
+    )
+
+    assert endpoint.fake_client.wait_calls == 1
+    assert endpoint.fake_client.direct_calls == [
+        {
+            "request": _expected_decode_warmup_request(),
+            "instance_id": 1234,
+            "annotated": False,
+        }
+    ]
+    assert engine.tokenizer_manager.freeze_gc_calls == 1
+
+
+def test_runtime_endpoint_warmup_skips_disaggregated_decode():
+    class FakeEndpoint:
+        async def client(self):
+            raise AssertionError("runtime endpoint warmup should not run")
+
+    asyncio.run(
+        warmup_runtime_endpoint(
+            FakeEndpoint(),
+            SimpleNamespace(tokenizer_manager=FakeTokenizerManager()),
+            SimpleNamespace(disaggregation_mode="decode"),
+            timeout=1,
+        )
+    )
+
+
+def test_handler_warmup_skips_disaggregated_decode():
+    class FakeHandler:
+        async def generate(self, request, context):
+            raise AssertionError("handler warmup should not run")
+
+    asyncio.run(
+        warmup_decode_handler(
+            FakeHandler(),
+            SimpleNamespace(disaggregation_mode="decode"),
+            timeout=1,
+        )
+    )
 
 
 @pytest.mark.asyncio

--- a/components/src/dynamo/sglang/warmup.py
+++ b/components/src/dynamo/sglang/warmup.py
@@ -1,0 +1,188 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""SGLang Engine warmup helpers used by Dynamo workers."""
+
+import asyncio
+import inspect
+import logging
+from typing import Any
+
+import sglang as sgl
+
+logger = logging.getLogger(__name__)
+
+
+class _WarmupContext:
+    trace_id = "dynamo-sglang-warmup"
+    span_id = None
+
+    def id(self) -> str:
+        return self.trace_id
+
+    def is_stopped(self) -> bool:
+        return False
+
+    def async_killed_or_stopped(self) -> asyncio.Future:
+        return asyncio.get_running_loop().create_future()
+
+
+async def _freeze_gc_after_warmup(engine: Any, *, label: str) -> None:
+    tokenizer_manager = getattr(engine, "tokenizer_manager", None)
+    freeze_gc = getattr(tokenizer_manager, "freeze_gc", None)
+    if freeze_gc is None:
+        freeze_gc = getattr(engine, "freeze_gc", None)
+    if freeze_gc is None:
+        logger.info("Skipping %s GC freeze: freeze_gc is unavailable", label)
+        return
+
+    logger.info("Freezing %s GC after warmup", label)
+    result = freeze_gc()
+    if inspect.isawaitable(result):
+        await result
+    logger.info("%s GC freeze completed", label)
+
+
+_DECODE_WARMUP_TOKEN_IDS = list(range(18))
+
+
+def _decode_warmup_request() -> dict[str, Any]:
+    return {
+        "token_ids": list(_DECODE_WARMUP_TOKEN_IDS),
+        "stop_conditions": {
+            "max_tokens": 8,
+            "stop": [],
+            "stop_token_ids": [],
+            "min_tokens": 0,
+            "ignore_eos": False,
+        },
+        "sampling_options": {
+            "n": 1,
+            "presence_penalty": 0.0,
+            "frequency_penalty": 0.0,
+            "repetition_penalty": 1.0,
+            "temperature": 0.0,
+            "top_p": 1.0,
+            "top_k": -1,
+            "min_p": 0.0,
+            "seed": None,
+            "guided_decoding": None,
+        },
+        "output_options": {
+            "logprobs": None,
+            "prompt_logprobs": None,
+            "skip_special_tokens": True,
+            "return_tokens_as_token_ids": None,
+        },
+        "eos_token_ids": [],
+        "annotations": [],
+        "routing": None,
+    }
+
+
+async def warmup_generation_engine(
+    engine: sgl.Engine,
+    server_args,
+    *,
+    timeout: float = 1800,
+    label: str = "decode",
+) -> None:
+    if server_args.disaggregation_mode != "null":
+        logging.info(
+            "Skipping %s warmup for disaggregation_mode=%s",
+            label,
+            server_args.disaggregation_mode,
+        )
+        return
+
+    logging.info("Starting %s warmup request", label)
+    sampling_params = {
+        "temperature": 0.0,
+        "max_new_tokens": 8,
+        "ignore_eos": True,
+    }
+
+    async def _do_warmup():
+        results = await engine.async_generate(
+            input_ids=_DECODE_WARMUP_TOKEN_IDS,
+            sampling_params=sampling_params,
+            stream=True,
+        )
+        async for _ in results:
+            pass
+
+    await asyncio.wait_for(_do_warmup(), timeout=timeout)
+    await asyncio.wait_for(
+        _freeze_gc_after_warmup(engine, label=label), timeout=timeout
+    )
+    logging.info("%s warmup completed", label)
+
+
+async def warmup_runtime_endpoint(
+    endpoint: Any,
+    engine: Any,
+    server_args,
+    *,
+    timeout: float = 1800,
+    label: str = "decode runtime endpoint",
+) -> None:
+    if server_args.disaggregation_mode != "null":
+        logging.info(
+            "Skipping %s warmup for disaggregation_mode=%s",
+            label,
+            server_args.disaggregation_mode,
+        )
+        return
+
+    logging.info("Starting %s warmup request", label)
+
+    async def _do_warmup():
+        client = await endpoint.client()
+        instance_id = endpoint.connection_id()
+        await client.wait_for_instances()
+
+        while instance_id not in client.instance_ids():
+            await asyncio.sleep(0.05)
+
+        stream = await client.direct(
+            _decode_warmup_request(),
+            instance_id,
+            annotated=False,
+        )
+        async for _ in stream:
+            pass
+
+    await asyncio.wait_for(_do_warmup(), timeout=timeout)
+    await asyncio.wait_for(
+        _freeze_gc_after_warmup(engine, label=label), timeout=timeout
+    )
+    logging.info("%s warmup completed", label)
+
+
+async def warmup_decode_handler(
+    handler: Any,
+    server_args,
+    *,
+    timeout: float = 1800,
+    label: str = "decode handler",
+) -> None:
+    if server_args.disaggregation_mode != "null":
+        logging.info(
+            "Skipping %s warmup for disaggregation_mode=%s",
+            label,
+            server_args.disaggregation_mode,
+        )
+        return
+
+    logging.info("Starting %s warmup request", label)
+
+    async def _do_warmup():
+        async for _ in handler.generate(_decode_warmup_request(), _WarmupContext()):
+            pass
+
+    await asyncio.wait_for(_do_warmup(), timeout=timeout)
+    await asyncio.wait_for(
+        _freeze_gc_after_warmup(handler.engine, label=label),
+        timeout=timeout,
+    )
+    logging.info("%s warmup completed", label)

--- a/lib/gpu_memory_service/integrations/sglang/model_loader.py
+++ b/lib/gpu_memory_service/integrations/sglang/model_loader.py
@@ -27,6 +27,7 @@ from gpu_memory_service.integrations.sglang.memory_saver import (
     get_gms_memory_saver_impl,
 )
 from gpu_memory_service.integrations.sglang.patches import (
+    patch_idle_runtime_checks_for_gms,
     patch_model_runner,
     patch_static_state_for_gms,
     patch_torch_memory_saver,
@@ -43,6 +44,7 @@ patch_empty_cache()
 patch_torch_memory_saver()
 patch_model_runner()
 patch_static_state_for_gms()
+patch_idle_runtime_checks_for_gms()
 logger.info("[GMS] Applied patches")
 
 

--- a/lib/gpu_memory_service/integrations/sglang/patches.py
+++ b/lib/gpu_memory_service/integrations/sglang/patches.py
@@ -6,6 +6,8 @@
 - patch_torch_memory_saver: Routes weights and kv_cache to GMS
 - patch_model_runner: Fixes memory accounting with pre-loaded weights
 - patch_static_state_for_gms: No-ops named-buffer export/import (GMS preserves them)
+- patch_idle_runtime_checks_for_gms: Honors SGLang's idle mem-check env as
+  an actual check gate, avoiding idle-loop work on restore smoke paths
 """
 
 from __future__ import annotations
@@ -27,6 +29,7 @@ logger = logging.getLogger(__name__)
 _torch_memory_saver_patched = False
 _model_runner_patched = False
 _static_state_patched = False
+_idle_runtime_checks_patched = False
 
 
 def patch_torch_memory_saver() -> None:
@@ -262,3 +265,51 @@ def patch_static_state_for_gms() -> None:
             "[GMS] Could not patch scheduler_update_weights_mixin: ",
             exc_info=True,
         )
+
+
+def patch_idle_runtime_checks_for_gms() -> None:
+    """Skip SGLang idle memory checks when its strict idle check env is false.
+
+    Upstream still walks the request/KV pools on every idle loop and only uses
+    SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_IDLE to decide whether a detected leak
+    should warn or raise. For snapshot+GMS restore probes this can keep a
+    restored worker doing idle housekeeping after warmup and before the first
+    real request. Preserve metrics/event/timer idle hooks, but bypass the
+    expensive validation checks when the existing upstream env is disabled.
+    """
+    global _idle_runtime_checks_patched
+    if _idle_runtime_checks_patched:
+        return
+
+    try:
+        from sglang.srt.environ import envs
+        from sglang.srt.managers.scheduler_runtime_checker_mixin import (
+            SchedulerRuntimeCheckerMixin,
+        )
+    except Exception:
+        logger.warning("[GMS] Could not import SGLang idle checker", exc_info=True)
+        return
+
+    if hasattr(SchedulerRuntimeCheckerMixin, "_gms_idle_runtime_checks_patched"):
+        _idle_runtime_checks_patched = True
+        return
+
+    original_on_idle = SchedulerRuntimeCheckerMixin.on_idle
+
+    def patched_on_idle(self):
+        if envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_IDLE.get():
+            return original_on_idle(self)
+
+        if not self.is_fully_idle():
+            return
+
+        self._maybe_log_idle_metrics()
+        self._publish_kv_events()
+        self.new_token_ratio = self.init_new_token_ratio
+        self.reset_device_timer_window()
+        self.maybe_sleep_on_idle()
+
+    SchedulerRuntimeCheckerMixin.on_idle = patched_on_idle
+    SchedulerRuntimeCheckerMixin._gms_idle_runtime_checks_patched = True
+    _idle_runtime_checks_patched = True
+    logger.info("[GMS] Patched SGLang idle runtime checks")


### PR DESCRIPTION
## Summary

Adds an opt-in Dynamo SGLang decode warmup path stacked on #9062.

- Adds `--warmup-decode-engine` for Dynamo SGLang workers.
- Warms the direct decode handler before route registration.
- Starts the worker runtime endpoint, calls the worker's own `generate` endpoint, drains the stream, and only then registers the model card/readiness.
- Uses a frontend-shaped backend request for warmup: 18 prompt tokens, `max_tokens=8`, normal OpenAI sampling/output/stop fields, empty annotations, and no routing.
- Freezes SGLang GC after direct and endpoint warmups.
- Makes the SGLang GMS integration honor `SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_IDLE=false` as a real idle memory-check gate.
- Keeps the default SGLang startup path unchanged unless the flag is set.

## Why

During the #8900 snapshot+GMS validation, restored SGLang workers registered successfully and then paid a large first-request cost before the first prefill completed:

- Qwen3-0.6B inter-pod: first request around `33.9s` TTFT.
- Qwen2.5-72B intra-pod/default-PVC: first request around `28.8s` TTFT.

The worker logs showed the request was already inside SGLang before the delay. The runs had `--disable-cuda-graph`, `--disable-piecewise-cuda-graph`, and `enable_torch_compile=False`, but the first request emitted a one-time `CUTE_DSL` / `cutlass.cute.experimental` warning. That points at lazy kernel/import setup inside SGLang or its kernel stack, not intentional CUDA graph capture.

Upstream SGLang has an HTTP-server warmup path behind `--skip-server-warmup`, but Dynamo constructs `sgl.Engine(...)` directly, so that HTTP server warmup does not run. This PR adds the Dynamo-side hook and keeps the model invisible to the frontend until the worker endpoint has served its own warmup request.

## Validation

Pushed head: `42f4cccb5e6f`.

Fast checks after final amend:

- `python3 -m py_compile components/src/dynamo/sglang/init_llm.py components/src/dynamo/sglang/warmup.py components/src/dynamo/sglang/tests/test_sglang_unit.py`
- `git diff --check`
- Container pytest with mounted worktree: `python3 -m pytest -q -c /dev/null components/src/dynamo/sglang/tests/test_sglang_unit.py -k "warmup or warmup_decode_engine" -o cache_dir=/tmp/pytest-cache-sglang-warmup-final-postformat`
  - Result: `7 passed, 30 deselected`

Live Qwen3-0.6B SGLang snapshot+intra-pod GMS validation on DRA node `l9nsv` used these behavior-equivalent overlay images:

- Runtime: `nvcr.io/nvidian/dynamo-dev/schwinns:sglang-runtime-fc16a9d5fec8-pr9435realwarmup-overlay-20260512T205822Z`
- Placeholder: `nvcr.io/nvidian/dynamo-dev/schwinns:dynamo-sglang-placeholder-fc16a9d5fec8-pr9435realwarmup-overlay-20260512T205822Z`

The placeholder image was built through the requested CRIU chain:

- `CRIU_REPO=https://github.com/dfeigin-nv/criu.git`
- `CRIU_REF=add-aio-and-parallel-memfd`

Results:

- DCKPT `pr9435-sgq3-realwarm-ckpt` reached `Ready` with checkpoint hash `203995cf95c55f69`.
- DGD `pr9435-sgq3-realwarm` restored successfully.
- Source checkpoint warmup paid the lazy CUTE/CUTLASS setup before checkpoint readiness.
- Restore-side GMS loader restored `60` allocations / `255` metadata keys in about `3s`.
- Handler warmup paid an input-len-18 decode with `forward_duration=90.37ms`.
- Runtime endpoint self-call paid an input-len-18 decode with `forward_duration=91.44ms`.
- Model card registration happened only after runtime endpoint warmup.

TTFT after restore:

- Immediate external burst: first request `41.48ms`, then `21.76-22.95ms`.
- After a 75s idle gap: first request `28.75ms`, then `21.43-22.71ms`.

Request-time stats interpretation:

- A trace run before the realistic request shape showed one large first external request at `155.75ms` TTFT, but SGLang `queue_duration` was only `0.60ms`; the worker's request-received-to-prefill gap was `151.821ms`.
- With the realistic warmup, the remaining first-request spike is much smaller, and SGLang queue time stays sub-millisecond.
- Current read: the 29-34s first-inference delay was lazy SGLang compile and is now paid during checkpoint-source warmup. The remaining 28-41ms first-after-restore/first-after-idle cost is mostly before SGLang queue accounting, likely Dynamo runtime ingress / handler / Python wake-up work rather than model compilation.

## Notes

- The final pushed commit changes log wording and copies the warmup token list defensively after the live validation image was built; those do not change the measured warmup behavior.
- For the live restore manifests, `runAsGroup: 1000` was needed because the restored CRIU process did not retain supplemental group `1000`, while the projected service-account token is `0640 root:1000`.



## 2026-05-12 Prior RO-Timeout Stack Rebuild

Before the decoupling update, rebased and pushed head `f5c920d1166b` on top of the refreshed #9062/#9045/#8900/#8833 stack. Rebuilt and pushed the full validation image line:

- vLLM runtime: `nvcr.io/nvidian/dynamo-dev/schwinns:vllm-runtime-f5c920d1166b-pr9435rotimeout-20260512T220833Z`
- vLLM placeholder: `nvcr.io/nvidian/dynamo-dev/schwinns:dynamo-vllm-placeholder-f5c920d1166b-pr9435rotimeout-20260512T220833Z`
- SGLang runtime: `nvcr.io/nvidian/dynamo-dev/schwinns:sglang-runtime-f5c920d1166b-pr9435rotimeout-20260512T220833Z`
- SGLang placeholder: `nvcr.io/nvidian/dynamo-dev/schwinns:dynamo-sglang-placeholder-f5c920d1166b-pr9435rotimeout-20260512T220833Z`
- operator: `nvcr.io/nvidian/dynamo-dev/schwinns:kubernetes-operator-f5c920d1166b-pr9435rotimeout-20260512T220833Z`
- snapshot-agent: `nvcr.io/nvidian/dynamo-dev/schwinns:snapshot-agent-f5c920d1166b-pr9435rotimeout-20260512T220833Z`

Validation with the rebuilt images:

- vLLM `Qwen/Qwen3-0.6B` snapshot+GMS checkpoint/restore passed with `gms_ro_connect_timeout_ms=300000`; `/v1/models` and `/no_think` chat passed.
- SGLang `Qwen/Qwen3-0.6B` snapshot+GMS checkpoint/restore passed with `gms_ro_connect_timeout_ms=300000`; `/v1/models` and `/no_think` chat passed.
- The SGLang warmup path still removed the earlier 29-34s first-inference compile delay; the remaining post-restore first request was tens of milliseconds rather than seconds.


## 2026-05-13 Decoupled Stack Validation

Rebased and pushed current top head `42f4cccb5e6f` on top of the refreshed #9062/#9045/#8900/#8833 stack. Rebuilt and rolled out the decoupled operator and snapshot-agent images plus vLLM/SGLang runtime and placeholder images. Placeholder and snapshot-agent builds used `CRIU_REPO=https://github.com/dfeigin-nv/criu.git` and `CRIU_REF=add-aio-and-parallel-memfd`.

Primary validation images:

- vLLM runtime: `nvcr.io/nvidian/dynamo-dev/schwinns:vllm-runtime-42f4cccb5e6f-decouple-20260513T015813Z`
- vLLM placeholder: `nvcr.io/nvidian/dynamo-dev/schwinns:dynamo-vllm-placeholder-42f4cccb5e6f-decouple-20260513T015813Z`
- SGLang runtime: `nvcr.io/nvidian/dynamo-dev/schwinns:sglang-runtime-42f4cccb5e6f-decouple-20260513T015813Z`
- SGLang placeholder used for final validation: `nvcr.io/nvidian/dynamo-dev/schwinns:dynamo-sglang-placeholder-42f4cccb5e6f-decouplecfg-20260513T022259Z`
- operator: `nvcr.io/nvidian/dynamo-dev/schwinns:kubernetes-operator-42f4cccb5e6f-decouple-20260513T015813Z`
- snapshot-agent: `nvcr.io/nvidian/dynamo-dev/schwinns:snapshot-agent-42f4cccb5e6f-decouple-20260513T015813Z`

Validation results in namespace `schwinns`:

- vLLM `Qwen/Qwen3-0.6B` snapshot+intra-pod GMS checkpoint/restore passed with no explicit `gms_ro_connect_timeout_ms`; `/v1/models` and `/no_think` chat passed with `VLLM_DECOUPLE_OK`.
- SGLang `Qwen/Qwen3-0.6B` snapshot+intra-pod GMS checkpoint/restore passed with no explicit `gms_ro_connect_timeout_ms`; `/v1/models` and `/no_think` chat passed with `SGLANG_DECOUPLE_OK`.
- Snapshot-agent logs had no GMS sentinel wait path.
- SGLang warmup still ran after restore; the earlier multi-second lazy-compile delay remained absent in this smoke.

Validation issue fixed outside product code: the first SGLang placeholder overlay missed `dynamo.common.configuration.groups.frontend_decoding_args`, which is imported by the rebased SGLang backend args. The final placeholder tag above includes that shared config file. The SGLang runtime base is at Docker layer-depth limit, so the frontend runtime tag remains the decoupled runtime image and only the worker/checkpoint placeholder needed the config overlay.
