### PR TITLE
fix(parsers): glm47 streaming jail captures all parallel tool calls

### DIFF
--- a/lib/llm/tests/test_jail.rs
+++ b/lib/llm/tests/test_jail.rs
@@ -2668,6 +2668,53 @@ mod parallel_jail_tests {
         validate_parallel_streaming_tool_calls(&results, &expected_calls);
     }
 
+    /// GLM-4.7 parallel tool calls in a single chunk. GLM uses a distinct
+    /// `<tool_call>func<arg_key>k</arg_key><arg_value>v</arg_value></tool_call>`
+    /// wire format with its own `find_tool_call_end_position_glm47`.
+    /// Regression test: the old single-find end-position function exited after the
+    /// first `</tool_call>`, leaking subsequent calls as raw XML into content.
+    #[tokio::test]
+    async fn test_parallel_tool_calls_single_chunk_glm47() {
+        let jail = JailedStream::builder().tool_call_parser("glm47").build();
+
+        let input_chunks = vec![test_utils::create_mock_response_chunk(
+            "<tool_call>get_weather\
+<arg_key>location</arg_key><arg_value>Boston</arg_value>\
+</tool_call>\
+<tool_call>get_weather\
+<arg_key>location</arg_key><arg_value>New York</arg_value>\
+</tool_call>"
+                .to_string(),
+            0,
+        )];
+
+        let input_stream = stream::iter(input_chunks);
+        let results: Vec<_> = jail.apply_with_finish_reason(input_stream).collect().await;
+
+        assert!(!results.is_empty(), "Should have results");
+
+        let expected_calls = [
+            ("get_weather", json!({"location": "Boston"})),
+            ("get_weather", json!({"location": "New York"})),
+        ];
+
+        validate_parallel_streaming_tool_calls(&results, &expected_calls);
+
+        for result in &results {
+            if let Some(ref data) = result.data {
+                for choice in &data.inner.choices {
+                    if let Some(ref content) = choice.delta.content {
+                        let text = test_utils::extract_text(content);
+                        assert!(
+                            !text.contains("<tool_call>"),
+                            "Raw XML must not leak as text content, got: {text:?}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
     // =============================================================================
     // 2. PARALLEL TOOL CALLS ACROSS MULTIPLE CHUNKS (STREAMING)
     // =============================================================================

--- a/lib/parsers/src/tool_calling/xml/glm47_parser.rs
+++ b/lib/parsers/src/tool_calling/xml/glm47_parser.rs
@@ -35,16 +35,39 @@ pub fn detect_tool_call_start_glm47(chunk: &str, config: &Glm47ParserConfig) -> 
     false
 }
 
-/// Find the end position of a GLM-4.7 tool call.
-/// Returns the position after </tool_call> or the length of the chunk if not found.
+/// Find the end position of all consecutive GLM-4.7 tool calls.
+/// When a model emits multiple parallel tool calls in one chunk
+/// (e.g. `<tool_call>A</tool_call><tool_call>B</tool_call>`), this
+/// function advances past every consecutive start→end pair so the
+/// entire group is captured as a single jailed region.  Returns the
+/// position after the last `</tool_call>` found, or the length of the
+/// chunk when no end token is present.
 pub fn find_tool_call_end_position_glm47(chunk: &str, config: &Glm47ParserConfig) -> usize {
+    let start_token = &config.tool_call_start;
     let end_token = &config.tool_call_end;
 
-    if let Some(pos) = chunk.find(end_token.as_str()) {
-        pos + end_token.len()
-    } else {
-        chunk.len()
+    let Some(first_end) = chunk.find(end_token.as_str()) else {
+        return chunk.len();
+    };
+
+    let mut cursor = first_end + end_token.len();
+
+    loop {
+        let rest = &chunk[cursor..];
+        let trimmed = rest.trim_start();
+        if !trimmed.starts_with(start_token.as_str()) {
+            break;
+        }
+        let trim_offset = rest.len() - trimmed.len();
+        let search_from = cursor + trim_offset + start_token.len();
+        if let Some(end_pos) = chunk[search_from..].find(end_token.as_str()) {
+            cursor = search_from + end_pos + end_token.len();
+        } else {
+            break;
+        }
     }
+
+    cursor
 }
 
 /// Try to parse GLM-4.7 formatted tool calls from a message.
@@ -432,6 +455,73 @@ mod tests {
         assert_eq!(
             &chunk[..end_pos],
             "<tool_call>func<arg_key>k</arg_key><arg_value>v</arg_value></tool_call>"
+        );
+    }
+
+    #[test] // helper — parallel calls: end position must advance past ALL blocks
+    fn test_find_tool_call_end_position_parallel() {
+        let config = get_test_config();
+        let chunk = "<tool_call>get_weather<arg_key>location</arg_key><arg_value>SF</arg_value></tool_call><tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>trailing";
+
+        let end_pos = find_tool_call_end_position_glm47(chunk, &config);
+        assert_eq!(
+            &chunk[..end_pos],
+            "<tool_call>get_weather<arg_key>location</arg_key><arg_value>SF</arg_value></tool_call><tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>",
+            "Must advance past ALL consecutive tool call blocks"
+        );
+    }
+
+    #[test] // helper — parallel calls with whitespace between blocks
+    fn test_find_tool_call_end_position_parallel_with_whitespace() {
+        let config = get_test_config();
+        let chunk = "<tool_call>a<arg_key>k</arg_key><arg_value>1</arg_value></tool_call>\n<tool_call>b<arg_key>k</arg_key><arg_value>2</arg_value></tool_call>";
+
+        let end_pos = find_tool_call_end_position_glm47(chunk, &config);
+        assert_eq!(
+            end_pos,
+            chunk.len(),
+            "Must handle whitespace/newlines between consecutive blocks"
+        );
+    }
+
+    #[test] // helper — parallel calls: second block incomplete (streaming)
+    fn test_find_tool_call_end_position_parallel_second_incomplete() {
+        let config = get_test_config();
+        let chunk = "<tool_call>a<arg_key>k</arg_key><arg_value>1</arg_value></tool_call><tool_call>b<arg_key>k</arg_key><arg_value>2</arg_value>";
+
+        let end_pos = find_tool_call_end_position_glm47(chunk, &config);
+        assert_eq!(
+            &chunk[..end_pos],
+            "<tool_call>a<arg_key>k</arg_key><arg_value>1</arg_value></tool_call>",
+            "Must stop at first complete block when second is incomplete"
+        );
+    }
+
+    #[test] // PARSER.batch.2 + PARSER.batch.8 — bug report repro: text + parallel calls
+    fn test_parse_text_then_parallel_calls() {
+        let config = get_test_config();
+        let message = "I'll check the weather for both cities at the same time!<tool_call>get_weather<arg_key>location</arg_key><arg_value>San Francisco</arg_value></tool_call><tool_call>get_weather<arg_key>location</arg_key><arg_value>New York</arg_value></tool_call>";
+
+        let (calls, normal_text) = try_tool_call_parse_glm47(message, &config, None).unwrap();
+
+        assert_eq!(calls.len(), 2, "Both parallel calls must be extracted");
+        assert_eq!(calls[0].function.name, "get_weather");
+        assert_eq!(calls[1].function.name, "get_weather");
+
+        let args0: HashMap<String, Value> =
+            serde_json::from_str(&calls[0].function.arguments).unwrap();
+        let args1: HashMap<String, Value> =
+            serde_json::from_str(&calls[1].function.arguments).unwrap();
+        assert_eq!(
+            args0.get("location").unwrap().as_str().unwrap(),
+            "San Francisco"
+        );
+        assert_eq!(args1.get("location").unwrap().as_str().unwrap(), "New York");
+
+        let text = normal_text.unwrap();
+        assert_eq!(
+            text,
+            "I'll check the weather for both cities at the same time!"
         );
     }
 

--- a/tests/parity/parser/vllm.py
+++ b/tests/parity/parser/vllm.py
@@ -78,6 +78,29 @@ _FAMILY_TO_VLLM_KEY = {
 }
 
 
+def _tools_as_namespace(
+    tools: list[dict[str, Any]] | None,
+) -> list[SimpleNamespace] | None:
+    """Wrap tool dicts so vLLM parsers can use attribute access
+    (``tool.function.name``) while keeping ``parameters`` as a plain
+    dict (vLLM also calls ``.get()`` on it)."""
+    if not tools:
+        return None
+    out = []
+    for t in tools:
+        fn = t.get("function", t)
+        out.append(
+            SimpleNamespace(
+                type=t.get("type", "function"),
+                function=SimpleNamespace(
+                    name=fn["name"],
+                    parameters=fn.get("parameters") or {},
+                ),
+            )
+        )
+    return out
+
+
 def parse(
     parser_family: str,
     raw_text: str,
@@ -99,15 +122,19 @@ def parse(
         if tools
         else None
     )
+    # Some vLLM parsers (e.g. glm4_moe) access request.tools[i].function.name
+    # via attribute, not dict subscript. Convert to SimpleNamespace so both
+    # access styles work.
+    ns_tools = _tools_as_namespace(wrapped_tools)
     try:
         parser_cls = ToolParserManager.get_tool_parser(key)
         # vLLM's ToolParser constructor checks `if not self.model_tokenizer:` and raises
         # if falsy. None of the parsers we test actually call tokenizer methods inside
         # extract_tool_calls(), so a truthy stub satisfies the check.
-        parser: ToolParser = parser_cls(tokenizer=_StubTokenizer(), tools=wrapped_tools)
+        parser: ToolParser = parser_cls(tokenizer=_StubTokenizer(), tools=ns_tools)
         # vLLM's extract_tool_calls signature: (model_output, request) → ExtractedToolCallInformation.
         # We construct a minimal request shape with only the tools field, since most parsers ignore the rest.
-        request = SimpleNamespace(tools=wrapped_tools)
+        request = SimpleNamespace(tools=ns_tools)
         info = parser.extract_tool_calls(raw_text, request)
     except NotImplementedError as e:
         # Known unsupported combinations (e.g., vLLM's harmony parser requires


### PR DESCRIPTION
#### Overview:

`find_tool_call_end_position_glm47` only found the first `</tool_call>` in a chunk, so the streaming jail exited after one call. Subsequent parallel calls leaked as raw XML into the content field.

**Repro:**
```bash
cargo test -p dynamo-parsers --lib \
  -- test_parse_text_then_parallel_calls
```
**Before:**
```json
{
  "tool_calls": [
    {"function": {"name": "get_weather",
     "arguments": "{\"location\":\"SF\"}"}}
  ],
  "content": "I'll check!<tool_call>get_weather
    <arg_key>location</arg_key>
    <arg_value>NYC</arg_value></tool_call>"
}
```

**After:**
```json
{
  "tool_calls": [
    {"function": {"name": "get_weather",
     "arguments": "{\"location\":\"SF\"}"}},
    {"function": {"name": "get_weather",
     "arguments": "{\"location\":\"NYC\"}"}}
  ],
  "content": "I'll check!"
}
```

#### Details:

`find_tool_call_end_position_glm47()` replaced with a loop that advances past all consecutive `<tool_call>...</tool_call>` blocks. Matches the existing `find_tool_call_end_position_xml` pattern used by `kimi_k2`, `qwen3_coder`, `hermes`, and `minimax_m2`. The batch parser was already correct (its while loop iterates all blocks). 4 new unit tests cover back-to-back blocks, whitespace between blocks, incomplete second block (streaming boundary), and the full bug repro.

Two new parity fixtures added: `PARSER.batch.2.e` (second call truncated at `</tool_call>`, args complete) and PARSER.batch.2.f (second call truncated mid-arg-value). These exercise the intersection of parallel calls and truncation.

`_tools_as_namespace()` added to `vllm.py` to fix `AttributeError` in vLLM's glm47 parser, which accesses `tool.function.name` via attribute. The wrapper previously passed plain dicts.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9438" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of parallel and consecutive tool calls to correctly process multiple calls within the same chunk instead of stopping at the first one.
  * Enhanced truncation detection to properly handle incomplete tool calls and preserve preceding content.
  * Extended test coverage for edge cases including parallel calls with whitespace separation and mid-stream truncation scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9438)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->