### PR TITLE
test(parsers): glm47 batch.5 sub-case parity fixtures (5.c-5.i)

### DIFF
--- a/lib/parsers/src/tool_calling/xml/glm47_parser.rs
+++ b/lib/parsers/src/tool_calling/xml/glm47_parser.rs
@@ -114,9 +114,25 @@ fn extract_tool_calls(
                 if config.allow_eof_recovery && block.contains(arg_key_start.as_str()) {
                     match parse_tool_call_block(block, config, tools) {
                         Ok(parsed_call) => {
-                            calls.push(parsed_call);
-                            cursor = text.len();
-                            continue;
+                            // Guard: if the block contained arg tags but the
+                            // regex extracted zero pairs, truncation hit
+                            // mid-arg and the parse is incomplete. Reject
+                            // rather than returning empty-args (silent wrong
+                            // invocation).
+                            let args: serde_json::Value =
+                                serde_json::from_str(&parsed_call.function.arguments)
+                                    .unwrap_or(serde_json::Value::Null);
+                            let has_args = args.as_object().is_some_and(|m| !m.is_empty());
+                            if has_args {
+                                calls.push(parsed_call);
+                                cursor = text.len();
+                                continue;
+                            }
+                            warn!(
+                                "GLM-4.7 EOF recovery: block has arg tags but \
+                                 parsed zero complete pairs — truncation \
+                                 mid-arg; rejecting call"
+                            );
                         }
                         Err(e) => {
                             warn!("Failed to parse GLM-4.7 tool call block (no end token): {e}");
@@ -502,6 +518,106 @@ mod tests {
         assert_eq!(calls.len(), 2);
         assert_eq!(calls[0].function.name, "get_weather");
         assert_eq!(calls[1].function.name, "get_time");
+    }
+
+    // --- b5 multi-position truncation tests ---
+    // Verify that EOF recovery rejects incomplete arg pairs rather than
+    // returning a call with silently-empty arguments.
+
+    #[test] // PARSER.batch.5
+    fn test_eof_recovery_rejects_truncation_mid_arg_value() {
+        let config = Glm47ParserConfig {
+            allow_eof_recovery: true,
+            ..get_test_config()
+        };
+        // Truncated inside <arg_value> content — no closing </arg_value>.
+        let message = "<tool_call>get_weather<arg_key>location</arg_key><arg_value>NY";
+        let (calls, normal_text) = try_tool_call_parse_glm47(message, &config, None).unwrap();
+        assert_eq!(
+            calls.len(),
+            0,
+            "Truncation mid-arg-value must NOT produce a call with empty args"
+        );
+        let text = normal_text.unwrap();
+        assert!(
+            text.contains("get_weather"),
+            "Rejected block must be preserved as normal_text"
+        );
+    }
+
+    #[test] // PARSER.batch.5
+    fn test_eof_recovery_rejects_truncation_mid_arg_key() {
+        let config = Glm47ParserConfig {
+            allow_eof_recovery: true,
+            ..get_test_config()
+        };
+        // Truncated inside <arg_key> tag content.
+        let message = "<tool_call>get_weather<arg_key>loc";
+        let (calls, normal_text) = try_tool_call_parse_glm47(message, &config, None).unwrap();
+        assert_eq!(
+            calls.len(),
+            0,
+            "Truncation mid-arg-key must NOT produce a call with empty args"
+        );
+        let text = normal_text.unwrap();
+        assert!(text.contains("get_weather"));
+    }
+
+    #[test] // PARSER.batch.5
+    fn test_eof_recovery_rejects_truncation_mid_arg_value_tag() {
+        let config = Glm47ParserConfig {
+            allow_eof_recovery: true,
+            ..get_test_config()
+        };
+        // Truncated inside the <arg_value> opening tag itself.
+        let message = "<tool_call>get_weather<arg_key>location</arg_key><arg_val";
+        let (calls, normal_text) = try_tool_call_parse_glm47(message, &config, None).unwrap();
+        assert_eq!(
+            calls.len(),
+            0,
+            "Truncation mid-tag must NOT produce a call"
+        );
+        let text = normal_text.unwrap();
+        assert!(text.contains("get_weather"));
+    }
+
+    #[test] // PARSER.batch.5
+    fn test_eof_recovery_partial_second_arg_keeps_first() {
+        let config = Glm47ParserConfig {
+            allow_eof_recovery: true,
+            ..get_test_config()
+        };
+        // First arg pair complete, second truncated mid-value.
+        // Should recover the first arg; second is silently lost but at
+        // least we have partial-correct data rather than empty.
+        let message = "<tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value><arg_key>unit</arg_key><arg_value>fah";
+        let (calls, _) = try_tool_call_parse_glm47(message, &config, None).unwrap();
+        assert_eq!(calls.len(), 1, "First complete pair should allow recovery");
+        let args: serde_json::Value =
+            serde_json::from_str(&calls[0].function.arguments).unwrap();
+        assert_eq!(args["location"], "NYC");
+        assert!(
+            args.get("unit").is_none(),
+            "Truncated second arg should not appear"
+        );
+    }
+
+    #[test] // PARSER.batch.5
+    fn test_eof_recovery_rejects_truncation_inside_xml_entity() {
+        let config = Glm47ParserConfig {
+            allow_eof_recovery: true,
+            ..get_test_config()
+        };
+        // Truncated inside an XML entity within arg_value.
+        let message = "<tool_call>get_weather<arg_key>query</arg_key><arg_value>x &lt";
+        let (calls, normal_text) = try_tool_call_parse_glm47(message, &config, None).unwrap();
+        assert_eq!(
+            calls.len(),
+            0,
+            "Truncation inside XML entity must NOT produce a call"
+        );
+        let text = normal_text.unwrap();
+        assert!(text.contains("get_weather"));
     }
 
     #[test] // PARSER.batch.4, PARSER.batch.8

--- a/lib/parsers/src/tool_calling/xml/glm47_parser.rs
+++ b/lib/parsers/src/tool_calling/xml/glm47_parser.rs
@@ -572,11 +572,7 @@ mod tests {
         // Truncated inside the <arg_value> opening tag itself.
         let message = "<tool_call>get_weather<arg_key>location</arg_key><arg_val";
         let (calls, normal_text) = try_tool_call_parse_glm47(message, &config, None).unwrap();
-        assert_eq!(
-            calls.len(),
-            0,
-            "Truncation mid-tag must NOT produce a call"
-        );
+        assert_eq!(calls.len(), 0, "Truncation mid-tag must NOT produce a call");
         let text = normal_text.unwrap();
         assert!(text.contains("get_weather"));
     }
@@ -593,8 +589,7 @@ mod tests {
         let message = "<tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value><arg_key>unit</arg_key><arg_value>fah";
         let (calls, _) = try_tool_call_parse_glm47(message, &config, None).unwrap();
         assert_eq!(calls.len(), 1, "First complete pair should allow recovery");
-        let args: serde_json::Value =
-            serde_json::from_str(&calls[0].function.arguments).unwrap();
+        let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
         assert_eq!(args["location"], "NYC");
         assert!(
             args.get("unit").is_none(),

--- a/tests/parity/parser/fixtures/glm47/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/glm47/PARSER.batch.yaml
@@ -70,6 +70,185 @@ cases:
         arguments:
           location: NYC
       normal_text: null
+  # =====================================================================
+  # PARSER.batch.5 missing-end-token recovery — sub-cases.
+  #
+  # SPEC STATUS — there isn't one. The cited "spec" is the GLM-4.7 chat template
+  # https://huggingface.co/zai-org/GLM-4.7/blob/main/chat_template.jinja which
+  # specifies only:
+  #   (a) the system-prompt instruction telling the model what well-formed tool
+  #       calls look like: `<tool_call>{name}<arg_key>{k}</arg_key><arg_value>{v}</arg_value>...</tool_call>`
+  #   (b) the forward serialization (how prior tool_calls get rendered back into
+  #       context for the next turn).
+  # It does NOT specify what a parser should do with truncated / malformed model
+  # output. There is no upstream "correct answer" for any of the 5.* sub-cases
+  # below — each runtime (Dynamo, vLLM, SGLang) picks its own recovery contract.
+  #
+  # The spec is ambiguous on truncation. Therefore the behavior pinned in each
+  # `expected:` block below is a deliberate Dynamo-side choice — not "the right
+  # answer," just "what Dynamo does today." When vLLM or SGLang produce a different
+  # output, that's documented via KNOWN_DIVERGENCES in test_parity_parser.py rather
+  # than treated as a bug. If the GLM team publishes a recovery contract later, the
+  # `expected:` blocks here are the units of change. Until then: pin, document, and
+  # treat parity divergences as informational (so customers comparing engines see
+  # an explicit map, not a surprise).
+  #
+  # References:
+  #   - GLM-4.7 chat template (forward direction only):
+  #     https://huggingface.co/zai-org/GLM-4.7/blob/main/chat_template.jinja
+  #   - Dynamo parser source: lib/parsers/src/tool_calling/xml/glm47_parser.rs
+  #   - vLLM tool parser:     vllm/tool_parsers/glm4_moe_tool_parser.py (in vllm package)
+  #   - SGLang detector:      sglang.srt.function_call.function_call_parser:Glm47MoeDetector
+  #   - PR #9355: the has_args guard that flips 5.c/5.e/5.f/5.g/5.h Dynamo behavior
+  #     from "emit empty-args wrong call" to "reject, raw markup → normal_text"
+  #   - PR #9438: parallel-tool-calls streaming-jail fix (same author; not part of
+  #     this PR, but addresses the user-visible content leak in Ajay's report)
+  #   - GLM-5.1 prod leak report: Ajay Rajan in #nv-inference Slack, 2026-05-11
+  #     (curl request and verbatim response captured below under 5.e)
+  #
+  # Sub-letters parallel the canonical taxonomy that lands with #9363 (future).
+  # The bare `PARSER.batch.5` above is the 5.a-equivalent (single-call shallow,
+  # body complete, only </tool_call> missing); the entries below add the deeper
+  # truncation positions and the multi-call shapes.
+  #
+  # Each fixture pins **post-#9355 Dynamo behavior** (this branch carries the fix).
+  # Pre-#9355 outputs are documented in each comment block as a reference for what
+  # changed (and why the existing 5.* KNOWN_DIVERGENCES on bare `5` may need
+  # revisiting after #9355 lands on main).
+  #
+  # 5.d / 5.e correspond directly to Ajay Rajan's GLM-5.1 prod leak repro
+  # (#nv-inference, 2026-05-11). Request:
+  #
+  #   curl -s "https://inference-api.nvidia.com/v1/chat/completions" \
+  #     -H "Authorization: Bearer $API_KEY" -H "Content-Type: application/json" \
+  #     -d '{"model":"nvidia/zai-org/glm-5.1","messages":[
+  #       {"role":"system","content":"You are a helpful assistant. Use tools when appropriate. You must use the provided tools to answer questions."},
+  #       {"role":"user","content":"Search for the weather in Boston and New York, then send the forecast to admin@example.com"}],
+  #       "tools":[{"type":"function","function":{"name":"get_weather","description":"Get weather for a location",
+  #         "parameters":{"type":"object","properties":{"location":{"type":"string"}},"required":["location"]}}},
+  #         {"type":"function","function":{"name":"send_email","description":"Send an email",
+  #         "parameters":{"type":"object","properties":{"to":{"type":"string"},"subject":{"type":"string"},"body":{"type":"string"}},"required":["to","subject","body"]}}}],
+  #       "max_tokens":512,"stream":false}'
+  #
+  # Pre-#9355 response (the leak):
+  #   {"finish_reason":"tool_calls","index":0,"message":{
+  #     "content":"I'll start by fetching the weather for both Boston and New York at the same time!get_weatherlocationNew York",
+  #     "role":"assistant",
+  #     "tool_calls":[{"function":{"arguments":"{\"location\":\"Boston\"}","name":"get_weather"},
+  #                    "id":"0b19bf30-aefa-4273-a33d-4b69fd82ba46","type":"function"}]}}
+  #
+  # The "get_weatherlocationNew York" tail is the second tool_call's XML markup
+  # after downstream tag-stripping. #9355 stops the parser from generating a
+  # silent empty-args call but the raw markup still lands in normal_text →
+  # message.content unless the downstream pipeline is changed too.
+  # =====================================================================
+  PARSER.batch.5.c:
+    description: Truncation mid-arg_value (single call, body incomplete)
+    model_text: <tool_call>get_weather<arg_key>location</arg_key><arg_value>N
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: <tool_call>get_weather<arg_key>location</arg_key><arg_value>N
+    # Verified 2026-05-12:
+    #   dynamo PRE-#9355:  calls=[{name: get_weather, args: {}}], normal_text=""   ← the silent empty-args wrong call
+    #   dynamo POST-#9355: calls=[], normal_text="<tool_call>get_weather<arg_key>location</arg_key><arg_value>N"   (pinned above)
+    #   vllm   (glm4_moe):         calls=[], normal_text="<tool_call>get_weather<arg_key>location</arg_key><arg_value>N"   (matches post-#9355)
+    #   sglang (Glm47MoeDetector): calls=[], normal_text="<tool_call>get_weather<arg_key>location</arg_key><arg_value>N"   (matches post-#9355)
+  PARSER.batch.5.d:
+    description: Multi-call, last call missing only </tool_call> end marker (body complete). Shallow-truncation flavor of Ajay's GLM-5.1 prod repro.
+    model_text: I'll start by fetching the weather for both Boston and New York at the same time!<tool_call>get_weather<arg_key>location</arg_key><arg_value>Boston</arg_value></tool_call><tool_call>get_weather<arg_key>location</arg_key><arg_value>New York</arg_value>
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Boston
+      - name: get_weather
+        arguments:
+          location: New York
+      normal_text: I'll start by fetching the weather for both Boston and New York at the same time!
+    # Verified 2026-05-12 (unaffected by #9355 — has_args=true on second block):
+    #   dynamo PRE-#9355:  calls=[Boston, New York], normal_text="I'll start by fetching the weather for both Boston and New York at the same time!"   (same)
+    #   dynamo POST-#9355: calls=[Boston, New York], normal_text="I'll start by fetching the weather for both Boston and New York at the same time!"   (pinned above)
+    #   vllm:              calls=[Boston],           normal_text="I'll start by fetching the weather for both Boston and New York at the same time!"   (drops 2nd call AND its raw text)
+    #   sglang:            calls=[Boston],           normal_text="I'll start by fetching the weather for both Boston and New York at the same time!<tool_call>get_weather<arg_key>location</arg_key><arg_value>New York</arg_value>"   (drops 2nd call, preserves raw markup)
+  PARSER.batch.5.e:
+    description: Multi-call, last call truncated mid-arg-value. Direct shape of Ajay's GLM-5.1 prod leak.
+    model_text: I'll start by fetching the weather for both Boston and New York at the same time!<tool_call>get_weather<arg_key>location</arg_key><arg_value>Boston</arg_value></tool_call><tool_call>get_weather<arg_key>location</arg_key><arg_value>New York
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: Boston
+      normal_text: I'll start by fetching the weather for both Boston and New York at the same time!<tool_call>get_weather<arg_key>location</arg_key><arg_value>New York
+    # Verified 2026-05-12:
+    #   dynamo PRE-#9355:  calls=[Boston, {args:{}}], normal_text="I'll start by fetching the weather for both Boston and New York at the same time!"   ← silent empty-args wrong call for 2nd
+    #   dynamo POST-#9355: calls=[Boston],            normal_text="I'll start by fetching the weather for both Boston and New York at the same time!<tool_call>get_weather<arg_key>location</arg_key><arg_value>New York"   (pinned above — 2nd rejected, raw preserved)
+    #   vllm:              calls=[Boston],            normal_text="I'll start by fetching the weather for both Boston and New York at the same time!"   (drops raw 2nd block too)
+    #   sglang:            calls=[Boston],            normal_text="I'll start by fetching the weather for both Boston and New York at the same time!<tool_call>get_weather<arg_key>location</arg_key><arg_value>New York"   (matches post-#9355 dynamo)
+    # In Ajay's prod response the downstream chat-pipeline tag-stripper turns the trailing
+    # `<tool_call>get_weather<arg_key>location</arg_key><arg_value>New York` in normal_text into
+    # `get_weatherlocationNew York` in message.content. The parser-level fix (#9355) is necessary
+    # but not sufficient — downstream still needs to handle the raw markup.
+  PARSER.batch.5.f:
+    description: Truncation mid-arg-key (single call, no </arg_key>)
+    model_text: <tool_call>get_weather<arg_key>loc
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: <tool_call>get_weather<arg_key>loc
+    # Verified 2026-05-12:
+    #   dynamo PRE-#9355:  calls=[{args:{}}], normal_text=""
+    #   dynamo POST-#9355: calls=[], normal_text="<tool_call>get_weather<arg_key>loc"   (pinned above)
+    #   vllm:              calls=[], normal_text="<tool_call>get_weather<arg_key>loc"   (matches post-#9355)
+    #   sglang:            calls=[], normal_text="<tool_call>get_weather<arg_key>loc"   (matches post-#9355)
+  PARSER.batch.5.g:
+    description: Truncation inside opening tag (single call, `<arg_val` instead of `<arg_value>`)
+    model_text: <tool_call>get_weather<arg_key>location</arg_key><arg_val
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: <tool_call>get_weather<arg_key>location</arg_key><arg_val
+    # Verified 2026-05-12:
+    #   dynamo PRE-#9355:  calls=[{args:{}}], normal_text=""
+    #   dynamo POST-#9355: calls=[], normal_text="<tool_call>get_weather<arg_key>location</arg_key><arg_val"   (pinned above)
+    #   vllm:              calls=[], normal_text="<tool_call>get_weather<arg_key>location</arg_key><arg_val"   (matches post-#9355)
+    #   sglang:            calls=[], normal_text="<tool_call>get_weather<arg_key>location</arg_key><arg_val"   (matches post-#9355)
+  PARSER.batch.5.h:
+    description: Truncation inside XML entity (single call, mid `&lt;` encoding)
+    model_text: <tool_call>get_weather<arg_key>query</arg_key><arg_value>x &lt
+    tools:
+    - *id001
+    expected:
+      calls: []
+      normal_text: <tool_call>get_weather<arg_key>query</arg_key><arg_value>x &lt
+    # Verified 2026-05-12:
+    #   dynamo PRE-#9355:  calls=[{args:{}}], normal_text=""
+    #   dynamo POST-#9355: calls=[], normal_text="<tool_call>get_weather<arg_key>query</arg_key><arg_value>x &lt"   (pinned above)
+    #   vllm:              calls=[], normal_text="<tool_call>get_weather<arg_key>query</arg_key><arg_value>x &lt"   (matches post-#9355)
+    #   sglang:            calls=[], normal_text="<tool_call>get_weather<arg_key>query</arg_key><arg_value>x &lt"   (matches post-#9355)
+  PARSER.batch.5.i:
+    description: Intra-block partial recovery — single tool_call with TWO arg pairs, second truncated mid-value. Tests that completed inner pairs survive when subsequent ones are truncated.
+    model_text: <tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value><arg_key>unit</arg_key><arg_value>fah
+    tools:
+    - *id001
+    expected:
+      calls:
+      - name: get_weather
+        arguments:
+          location: NYC
+      normal_text: ''
+    # Verified 2026-05-12 (unaffected by #9355 — first pair's has_args=true survives):
+    #   dynamo PRE-#9355:  calls=[{location: NYC}], normal_text=""   (same)
+    #   dynamo POST-#9355: calls=[{location: NYC}], normal_text=""   (pinned above)
+    #   vllm:              calls=[], normal_text="<tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value><arg_key>unit</arg_key><arg_value>fah"   (no intra-block recovery)
+    #   sglang:            calls=[], normal_text="<tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value><arg_key>unit</arg_key><arg_value>fah"   (no intra-block recovery)
   PARSER.batch.6:
     description: Empty args (no-arg call)
     model_text: <tool_call>get_time</tool_call>

--- a/tests/parity/parser/test_parity_parser.py
+++ b/tests/parity/parser/test_parity_parser.py
@@ -173,7 +173,35 @@ KNOWN_DIVERGENCES: dict[tuple[str, str, str], str] = {
     ("sglang", "minimax_m2", "PARSER.batch.5"): _RECOVERY_CONTRACT,
     ("sglang", "deepseek_v3_1", "PARSER.batch.5"): _RECOVERY_CONTRACT,
     ("sglang", "harmony", "PARSER.batch.5"): _RECOVERY_CONTRACT,
+    # PARSER.batch.5 glm47 sub-cases — pin POST-#9355 Dynamo behavior. The fixture
+    # expected blocks match Dynamo on this branch; entries below capture where
+    # vllm/sglang still diverge after the fix.
+    # 5.c / 5.f / 5.g / 5.h: vllm + sglang already match post-#9355 Dynamo (calls=[],
+    # raw preserved) — NO divergence entries needed.
+    # 5.d (multi-call shallow): both peers drop the second call.
+    ("vllm", "glm47", "PARSER.batch.5.d"): _RECOVERY_CONTRACT,
+    ("sglang", "glm47", "PARSER.batch.5.d"): _RECOVERY_CONTRACT,
+    # 5.e (multi-call mid-value): sglang matches post-#9355 Dynamo bit-for-bit;
+    # vllm diverges by dropping the raw 2nd block from normal_text.
+    ("vllm", "glm47", "PARSER.batch.5.e"): _RECOVERY_CONTRACT,
+    # 5.i (intra-block partial): only Dynamo recovers the first complete pair;
+    # vllm and sglang both return calls=[] and raw text.
+    ("vllm", "glm47", "PARSER.batch.5.i"): _RECOVERY_CONTRACT,
+    ("sglang", "glm47", "PARSER.batch.5.i"): _RECOVERY_CONTRACT,
 }
+
+
+def _case_sort_key(case_id: str) -> tuple[int, str]:
+    """Sort key for case IDs that may carry a sub-letter.
+
+    `PARSER.batch.5`   → (5, "")
+    `PARSER.batch.5.c` → (5, "c")
+    `PARSER.batch.5.i` → (5, "i")
+    """
+    parts = case_id.split(".")
+    top = int(parts[2])
+    sub = parts[3] if len(parts) > 3 else ""
+    return (top, sub)
 
 
 def _load_fixtures() -> list[tuple[str, str, dict[str, Any]]]:
@@ -181,15 +209,16 @@ def _load_fixtures() -> list[tuple[str, str, dict[str, Any]]]:
 
     Schema: <family>/PARSER.<mode>.yaml holds
         {family: "...", mode: "batch", cases: {PARSER.batch.1: {...}, ...}}
-    Case keys are the full PARSER_CASES.md ID (e.g. `PARSER.batch.1`)
-    so they match KNOWN_DIVERGENCES keys and parametrize IDs directly.
+    Case keys are the full PARSER_CASES.md ID (e.g. `PARSER.batch.1` or
+    `PARSER.batch.5.c`) so they match KNOWN_DIVERGENCES keys and parametrize
+    IDs directly.
     """
     out = []
     for fp in sorted(FIXTURES_ROOT.glob("*/PARSER.*.yaml")):
         doc = yaml.safe_load(fp.read_text())
         for case_id, case in doc["cases"].items():
             out.append((doc["family"], case_id, case))
-    out.sort(key=lambda t: (t[0], int(t[1].rsplit(".", 1)[1])))
+    out.sort(key=lambda t: (t[0], *_case_sort_key(t[1])))
     return out
 
 

--- a/tests/parity/parser/vllm.py
+++ b/tests/parity/parser/vllm.py
@@ -71,6 +71,29 @@ _FAMILY_TO_VLLM_KEY = {
 }
 
 
+def _tools_as_namespace(
+    tools: list[dict[str, Any]] | None,
+) -> list[SimpleNamespace] | None:
+    """Wrap tool dicts so vLLM parsers can use attribute access
+    (``tool.function.name``) while keeping ``parameters`` as a plain
+    dict (vLLM also calls ``.get()`` on it)."""
+    if not tools:
+        return None
+    out = []
+    for t in tools:
+        fn = t.get("function", t)
+        out.append(
+            SimpleNamespace(
+                type=t.get("type", "function"),
+                function=SimpleNamespace(
+                    name=fn["name"],
+                    parameters=fn.get("parameters") or {},
+                ),
+            )
+        )
+    return out
+
+
 def parse(
     parser_family: str,
     raw_text: str,
@@ -92,15 +115,14 @@ def parse(
         if tools
         else None
     )
+    # Some vLLM parsers (e.g. glm4_moe) access request.tools[i].function.name
+    # via attribute, not dict subscript. Convert to SimpleNamespace so both
+    # access styles work.
+    ns_tools = _tools_as_namespace(wrapped_tools)
     try:
         parser_cls = ToolParserManager.get_tool_parser(key)
-        # vLLM's ToolParser constructor checks `if not self.model_tokenizer:` and raises
-        # if falsy. None of the parsers we test actually call tokenizer methods inside
-        # extract_tool_calls(), so a truthy stub satisfies the check.
-        parser: ToolParser = parser_cls(tokenizer=_StubTokenizer(), tools=wrapped_tools)
-        # vLLM's extract_tool_calls signature: (model_output, request) → ExtractedToolCallInformation.
-        # We construct a minimal request shape with only the tools field, since most parsers ignore the rest.
-        request = SimpleNamespace(tools=wrapped_tools)
+        parser: ToolParser = parser_cls(tokenizer=_StubTokenizer(), tools=ns_tools)
+        request = SimpleNamespace(tools=ns_tools)
         info = parser.extract_tool_calls(raw_text, request)
     except NotImplementedError as e:
         # Known unsupported combinations (e.g., vLLM's harmony parser requires


### PR DESCRIPTION
#### Overview:

Adds parity-fixture coverage for the GLM-4.7 missing-end-token recovery sub-cases that #9355 introduces inline Rust tests for, plus two multi-call variants that match the GLM-5.1 prod leak shape from Ajay Rajan's nv-inference report (2026-05-11). **Stacked on #9355** — expected blocks pin post-#9355 Dynamo behavior.

#### Details:

- **How is this fixed?** Adds 7 fixtures `PARSER.batch.5.{c,d,e,f,g,h,i}` to `tests/parity/parser/fixtures/glm47/PARSER.batch.yaml`, each pinning post-#9355 Dynamo behavior with verified pre/post-#9355 and vLLM/SGLang outputs documented inline. Ports `_case_sort_key` helper from #9363 to `tests/parity/parser/test_parity_parser.py` so the loader handles sub-letter case IDs. Adds 5 KNOWN_DIVERGENCES entries for cells where vLLM/SGLang diverge from post-#9355 Dynamo.
- 5.c / 5.f / 5.g / 5.h — single-call deep truncation (mid-arg-value / mid-arg-key / mid-tag-name / mid-XML-entity); all three impls converge on `calls=[], normal_text=<raw>` post-#9355 (no divergence entries needed)
- 5.d / 5.e — multi-call truncation (shallow / mid-arg-value). 5.e is the direct shape of Ajay's GLM-5.1 prod leak; the comment block on 5.e contains the verbatim curl request and pre-#9355 response showing the `get_weatherlocationNew York` content leak
- 5.i — intra-block partial recovery (one tool_call block, two arg pairs, second truncated); only Dynamo recovers the first complete pair, vLLM and SGLang drop everything
- Section header includes a SPEC STATUS note: GLM-4.7's chat_template.jinja defines only the forward direction (well-formed output and round-trip serialization); it doesn't specify a recovery contract for truncated input. The pinned expected blocks are deliberate Dynamo-side choices, not "the right answer."

#### Verification:

Probed all 7 fixtures on 2026-05-12 against:
- Dynamo (Rust parser via PyO3) on both pre-#9355 base and post-#9355 head
- vLLM 0.20.1 `glm4_moe` tool parser
- SGLang 0.5.10.post1 `Glm47MoeDetector`

Each fixture's comment block captures the verbatim `(calls, normal_text)` tuple from all three impls.

#### Where should the reviewer start?

`tests/parity/parser/fixtures/glm47/PARSER.batch.yaml` (the new 5.c–5.i section with inline pre/post-#9355 + vllm + sglang outputs), then `tests/parity/parser/test_parity_parser.py` (`_case_sort_key` helper at top of `_load_fixtures`, plus the 5 new KNOWN_DIVERGENCES entries).

#### Related Issues:

- Stacks on #9355 (has_args guard) — required for expected blocks to match Dynamo
- Adjacent to #9438 (parallel-tool-calls streaming-jail fix, same author) — that PR addresses the user-visible content leak from a different code path; if it lands first, my 5.d/5.e may overlap with its 2.e/2.f and should be reconciled
- Relates to [DIS-1906](https://linear.app/nvidia/issue/DIS-1906) (cross-impl parser-parity harness)

/coderabbit profile chill
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9442" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced GLM-4.7 parser robustness: truncated tool invocation blocks with incomplete arguments are now correctly rejected and treated as normal text instead of generating invalid tool calls.

* **Tests**
  * Expanded test coverage for tool invocation truncation scenarios and parser recovery behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9442)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->