### PR TITLE
fix(config): honor callable arg_type for env var conversion

### DIFF
--- a/components/src/dynamo/common/configuration/utils.py
+++ b/components/src/dynamo/common/configuration/utils.py
@@ -81,9 +81,7 @@ def add_argument(
         arg_type: Type for the argument (default: str)
     """
     arg_dest = _get_dest_name(flag_name, kwargs.get("dest"))
-    value_type_for_env: Optional[Union[type, Callable[..., Any]]] = None
-    if arg_type is not None and isinstance(arg_type, type):
-        value_type_for_env = arg_type
+    value_type_for_env: Optional[Union[type, Callable[..., Any]]] = arg_type
     if isinstance(default, list) and (arg_type is None or arg_type is str):
         value_type_for_env = None
     default_with_env = env_or_default(env_var, default, value_type=value_type_for_env)

--- a/components/src/dynamo/common/tests/configuration/test_utils.py
+++ b/components/src/dynamo/common/tests/configuration/test_utils.py
@@ -149,7 +149,7 @@ class TestAddArgument:
         assert args.model_name is None
 
     def test_callable_type_with_invalid_env_value_fails_parse(self, monkeypatch):
-        """Test invalid env value still fails validation via argparse type callable."""
+        """Test invalid env value is rejected by the callable validator at registration."""
         monkeypatch.setenv("TEST_MODEL_NAME", "   ")
         parser = argparse.ArgumentParser()
 
@@ -158,17 +158,42 @@ class TestAddArgument:
                 raise argparse.ArgumentTypeError("model-name must be non-empty")
             return value.strip()
 
+        with pytest.raises((SystemExit, argparse.ArgumentTypeError)):
+            add_argument(
+                parser,
+                flag_name="--model-name",
+                env_var="TEST_MODEL_NAME",
+                default=None,
+                help="Model name",
+                arg_type=validate_model_name,
+            )
+            parser.parse_args([])
+
+    def test_nullable_callable_type_with_typed_default_uses_env(self, monkeypatch):
+        """Callable arg_type must convert env values even when default is non-None.
+
+        Regression: previously the env path fell back to type(default) (e.g. float)
+        because callables are not types, so env var "None" raised ValueError on float("None").
+        """
+        monkeypatch.setenv("TEST_THRESHOLD", "None")
+        parser = argparse.ArgumentParser()
+
+        def nullable_float(value):
+            if value is None or value == "None":
+                return None
+            return float(value)
+
         add_argument(
             parser,
-            flag_name="--model-name",
-            env_var="TEST_MODEL_NAME",
-            default=None,
-            help="Model name",
-            arg_type=validate_model_name,
+            flag_name="--threshold",
+            env_var="TEST_THRESHOLD",
+            default=1.0,
+            help="Threshold",
+            arg_type=nullable_float,
         )
 
-        with pytest.raises(SystemExit):
-            parser.parse_args([])
+        args = parser.parse_args([])
+        assert args.threshold is None
 
 
 class TestAddNegatableBool:


### PR DESCRIPTION
## Summary

Fix `add_argument` so env vars are converted through custom callable validators (e.g. `_nullable_float`, `_nullable_int`).

`env_or_default` only received `arg_type` when it was a class (`str`/`int`/`float`), because `add_argument` guarded with `isinstance(arg_type, type)`. Custom validator callables fell through, so `env_or_default` used `type(default)` as the converter and crashed on env values the callable was specifically written to accept.

### Repro (against `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.0`)

The frontend [configuration docs](https://github.com/ai-dynamo/dynamo/blob/main/docs/components/frontend/configuration.md) state that `--active-decode-blocks-threshold` and `--active-prefill-tokens-threshold` accept `None` via either CLI or env var to disable the busy check. CLI works; env var crashes at startup:

```
$ docker run --rm -e DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD=None \
    nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.1.0 -m dynamo.frontend
...
  File ".../dynamo/common/configuration/utils.py", line 49, in env_or_default
    return float(value)
ValueError: could not convert string to float: 'None'
```

After this fix the env var path matches the CLI path:

```
$ curl -s http://127.0.0.1:8000/busy_threshold
{"thresholds":[{"model":"Qwen/Qwen3-0.6B",
  "active_decode_blocks_threshold":null,
  "active_prefill_tokens_threshold":null,
  "active_prefill_tokens_threshold_frac":10.0}]}
```

### Behavior change

The existing test `test_callable_type_with_invalid_env_value_fails_parse` previously passed for the wrong reason: with the bug, env values flowed through as raw strings to argparse, and `type=` ran at parse-time, raising `SystemExit`. With the fix, the validator fires at registration time (when `env_or_default` runs). The test now accepts either `SystemExit` or `argparse.ArgumentTypeError` — both reflect the same intent: invalid env values are rejected.

## Test plan

- [x] Unit tests pass (20/20 in `test_utils.py`), including new regression `test_nullable_callable_type_with_typed_default_uses_env`
- [x] CLI path still works: `--active-decode-blocks-threshold None --active-prefill-tokens-threshold None` → `/busy_threshold` returns `null` for both fields
- [x] Env var path now works: `DYN_ACTIVE_DECODE_BLOCKS_THRESHOLD=None DYN_ACTIVE_PREFILL_TOKENS_THRESHOLD=None` → frontend starts cleanly
- [x] End-to-end chat completion against Qwen3-0.6B (vllm-runtime:1.1.0) returns valid response with thresholds disabled