### PR TITLE
Closed: merging oandreeva-kvbm-v2-latest to ryan/kvbm-connector

### DIFF
--- a/components/src/dynamo/vllm/instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/instrumented_scheduler.py
@@ -269,7 +269,7 @@ class InstrumentedScheduler(AsyncScheduler):
             **kwargs,
         )
 
-        dp_rank = getattr(vllm_config.parallel_config, "data_parallel_rank", 0) or 0
+        dp_rank = self._resolve_dp_rank(vllm_config.parallel_config)
         self._fpm_worker_id = vllm_config.additional_config.get("fpm_worker_id", "")
         self._fpm_dp_rank = dp_rank
 
@@ -296,6 +296,21 @@ class InstrumentedScheduler(AsyncScheduler):
         )
 
         self._bench_init(vllm_config)
+
+    @staticmethod
+    def _resolve_dp_rank(parallel_config) -> int:
+        # ``data_parallel_index`` always holds the true global DP rank of the
+        # engine process. For dense (non-MoE) models in external DP mode,
+        # vLLM resets ``data_parallel_rank`` to 0 in every child process but
+        # preserves ``data_parallel_index`` (see ``vllm/v1/engine/core.py``:
+        # ``parallel_config.data_parallel_index = dp_rank`` then
+        # ``parallel_config.data_parallel_rank = 0``). Reading the rank field
+        # would make every DP child compute ``base_port + 0`` and the second
+        # ``bind()`` would fail with "Address already in use".
+        dp_rank = getattr(parallel_config, "data_parallel_index", None)
+        if dp_rank is None:
+            dp_rank = getattr(parallel_config, "data_parallel_rank", 0) or 0
+        return dp_rank
 
     # ------------------------------------------------------------------
     # Overrides
@@ -451,7 +466,38 @@ class InstrumentedScheduler(AsyncScheduler):
         )
 
     def _compute_queued(self) -> QueuedRequestMetrics:
-        """Single-pass aggregation over self.waiting -- no intermediate list."""
+        """Single-pass aggregation over ``self.waiting`` and ``self.skipped_waiting``.
+
+        vLLM's scheduler parks requests in two queues:
+
+        * ``self.waiting`` holds requests in ``WAITING`` (new, never scheduled)
+          and ``PREEMPTED`` (were decoding, evicted back for memory) states.
+        * ``self.skipped_waiting`` holds "blocked-waiting" requests awaiting an
+          async precondition — see ``Scheduler._is_blocked_waiting_status`` /
+          ``Scheduler._enqueue_waiting_request``:
+
+              WAITING_FOR_STRUCTURED_OUTPUT_GRAMMAR
+                                          -- grammar/structured-output compile
+                                          -- WAITING_FOR_FSM on older vLLM
+              WAITING_FOR_REMOTE_KVS      -- disagg decode-engine KV transfer
+              WAITING_FOR_STREAMING_REQ   -- streaming request handshake
+
+        A ``WAITING_FOR_REMOTE_KVS`` request is a **decode** request: the
+        prefill engine has already computed its KV and is transferring it; once
+        finished the request goes straight to decode without a local prefill
+        step. ``num_computed_tokens`` is pre-set to the transferred KV length
+        (see ``Scheduler.schedule`` at the ``load_kv_async`` branch), so it is
+        the correct decode-KV-context value for FPM purposes.
+
+        ``WAITING_FOR_STRUCTURED_OUTPUT_GRAMMAR`` /
+        ``WAITING_FOR_STREAMING_REQ`` have no KV computed yet — they are queued
+        prefill requests blocked on a precondition.
+
+        Only iterating ``self.waiting`` (the previous behaviour) silently
+        misses every ``WAITING_FOR_REMOTE_KVS`` request on the decode engine
+        in disaggregated serving, and misclassifies it as queued prefill if it
+        ever transiently appears in ``self.waiting``.
+        """
         prefill = WelfordAccumulator()
         decode_kv = WelfordAccumulator()
 
@@ -459,6 +505,18 @@ class InstrumentedScheduler(AsyncScheduler):
             if request.status == RequestStatus.PREEMPTED:
                 decode_kv.add(request.num_computed_tokens)
             else:
+                prefill.add(request.num_tokens)
+
+        for request in self.skipped_waiting:
+            if request.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
+                # Disagg decode side: KV already computed on the prefill
+                # engine and being transferred. Next schedule() step will
+                # start generating -- count as queued decode.
+                decode_kv.add(request.num_computed_tokens)
+            else:
+                # Structured-output waits / WAITING_FOR_STREAMING_REQ:
+                # no KV yet, essentially a queued prefill awaiting a
+                # precondition.
                 prefill.add(request.num_tokens)
 
         return QueuedRequestMetrics(

--- a/components/src/dynamo/vllm/publisher.py
+++ b/components/src/dynamo/vllm/publisher.py
@@ -51,12 +51,16 @@ class DynamoStatLoggerPublisher(StatLoggerBase):
 
     def record(
         self,
-        scheduler_stats: SchedulerStats,
+        scheduler_stats: Optional[SchedulerStats],
         iteration_stats: Optional[IterationStats],
+        mm_cache_stats: object = None,
         engine_idx: int = 0,
         *args: object,
         **kwargs: object,
     ) -> None:
+        if scheduler_stats is None:
+            return
+
         active_decode_blocks = int(self.num_gpu_block * scheduler_stats.kv_cache_usage)
         self.inner.publish(self.dp_rank, kv_used_blocks=active_decode_blocks)
 

--- a/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
@@ -1,0 +1,316 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for ``InstrumentedScheduler._compute_queued`` classification.
+
+Focus: correct handling of ``self.skipped_waiting`` and disaggregated-serving
+request states. The production scheduler is heavy to construct (needs a real
+``VllmConfig`` + ``KVCacheConfig`` + ``StructuredOutputManager``), so these
+tests invoke ``_compute_queued`` as an unbound method against a minimal stub
+built with ``object.__new__`` — this exercises the real function body without
+spinning up vLLM engine internals.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from vllm.v1.request import RequestStatus  # noqa: E402
+
+# Module-level import: triggers real site-packages ``vllm`` to load before
+# pytest's rootpath insertion adds ``components/src/dynamo`` to ``sys.path``
+# (which shadows the real ``vllm`` with the ``dynamo.vllm`` submodule for any
+# later bare ``import vllm``). Mirrors the pattern in ``test_vllm_unit.py``,
+# which imports ``dynamo.vllm.args`` at module level for the same reason.
+# If this import is deferred to inside a test body, the real ``vllm`` will
+# not be resolvable and ``instrumented_scheduler`` will fail to load with
+# ``ModuleNotFoundError: No module named 'vllm.sampling_params'``.
+from dynamo.vllm.instrumented_scheduler import InstrumentedScheduler  # noqa: E402
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.vllm,
+    pytest.mark.pre_merge,
+]
+
+STRUCTURED_OUTPUT_WAITING_STATUS = getattr(
+    RequestStatus, "WAITING_FOR_STRUCTURED_OUTPUT_GRAMMAR", None
+) or getattr(RequestStatus, "WAITING_FOR_FSM")
+
+
+def _make_request(status, num_tokens: int, num_computed_tokens: int = 0):
+    """Build a minimal stand-in for ``vllm.v1.request.Request``.
+
+    Only the three attributes read by ``_compute_queued`` are populated.
+    """
+    return SimpleNamespace(
+        status=status,
+        num_tokens=num_tokens,
+        num_computed_tokens=num_computed_tokens,
+    )
+
+
+def _run_compute_queued(waiting, skipped_waiting):
+    """Invoke the real ``InstrumentedScheduler._compute_queued`` on a stub.
+
+    Bypasses ``__init__`` (which needs full vLLM config) and populates only
+    the two attributes the method reads.
+    """
+    stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
+    stub.waiting = waiting
+    stub.skipped_waiting = skipped_waiting
+    return InstrumentedScheduler._compute_queued(stub)
+
+
+# ---------------------------------------------------------------------------
+# self.waiting classification (existing behaviour — regression coverage)
+# ---------------------------------------------------------------------------
+
+
+def test_waiting_new_requests_count_as_queued_prefill():
+    q = _run_compute_queued(
+        waiting=[
+            _make_request(RequestStatus.WAITING, num_tokens=100),
+            _make_request(RequestStatus.WAITING, num_tokens=200),
+        ],
+        skipped_waiting=[],
+    )
+    assert q.num_prefill_requests == 2
+    assert q.sum_prefill_tokens == 300
+    assert q.num_decode_requests == 0
+    assert q.sum_decode_kv_tokens == 0
+
+
+def test_waiting_preempted_requests_count_as_queued_decode():
+    q = _run_compute_queued(
+        waiting=[
+            _make_request(
+                RequestStatus.PREEMPTED, num_tokens=512, num_computed_tokens=480
+            ),
+            _make_request(
+                RequestStatus.PREEMPTED, num_tokens=256, num_computed_tokens=240
+            ),
+        ],
+        skipped_waiting=[],
+    )
+    assert q.num_prefill_requests == 0
+    assert q.sum_prefill_tokens == 0
+    assert q.num_decode_requests == 2
+    # sum_decode_kv_tokens = sum of num_computed_tokens
+    assert q.sum_decode_kv_tokens == 720
+
+
+# ---------------------------------------------------------------------------
+# self.skipped_waiting classification (the fix)
+# ---------------------------------------------------------------------------
+
+
+def test_skipped_waiting_for_remote_kvs_counts_as_queued_decode():
+    """Disagg decode-engine: request has KV being transferred; should count
+    as queued decode, not queued prefill.
+    """
+
+    q = _run_compute_queued(
+        waiting=[],
+        skipped_waiting=[
+            _make_request(
+                RequestStatus.WAITING_FOR_REMOTE_KVS,
+                num_tokens=1000,
+                num_computed_tokens=1000,
+            ),
+            _make_request(
+                RequestStatus.WAITING_FOR_REMOTE_KVS,
+                num_tokens=500,
+                num_computed_tokens=500,
+            ),
+        ],
+    )
+    # Must NOT be classified as prefill.
+    assert q.num_prefill_requests == 0
+    assert q.sum_prefill_tokens == 0
+    # Classified as decode with KV = num_computed_tokens.
+    assert q.num_decode_requests == 2
+    assert q.sum_decode_kv_tokens == 1500
+
+
+def test_skipped_waiting_for_structured_output_counts_as_queued_prefill():
+    """Structured-output grammar compile wait has no KV computed yet; prefill."""
+
+    q = _run_compute_queued(
+        waiting=[],
+        skipped_waiting=[
+            _make_request(STRUCTURED_OUTPUT_WAITING_STATUS, num_tokens=128),
+        ],
+    )
+    assert q.num_prefill_requests == 1
+    assert q.sum_prefill_tokens == 128
+    assert q.num_decode_requests == 0
+    assert q.sum_decode_kv_tokens == 0
+
+
+def test_skipped_waiting_for_streaming_req_counts_as_queued_prefill():
+    q = _run_compute_queued(
+        waiting=[],
+        skipped_waiting=[
+            _make_request(RequestStatus.WAITING_FOR_STREAMING_REQ, num_tokens=64),
+        ],
+    )
+    assert q.num_prefill_requests == 1
+    assert q.sum_prefill_tokens == 64
+    assert q.num_decode_requests == 0
+
+
+# ---------------------------------------------------------------------------
+# Mixed scenarios -- the realistic disagg decode engine picture
+# ---------------------------------------------------------------------------
+
+
+def test_mixed_disagg_decode_engine_snapshot():
+    """Realistic decode-engine snapshot: some local preempts in ``self.waiting``
+    plus many ``WAITING_FOR_REMOTE_KVS`` in ``self.skipped_waiting``.
+    """
+
+    q = _run_compute_queued(
+        waiting=[
+            _make_request(
+                RequestStatus.PREEMPTED, num_tokens=800, num_computed_tokens=780
+            ),
+        ],
+        skipped_waiting=[
+            _make_request(
+                RequestStatus.WAITING_FOR_REMOTE_KVS,
+                num_tokens=1024,
+                num_computed_tokens=1024,
+            ),
+            _make_request(
+                RequestStatus.WAITING_FOR_REMOTE_KVS,
+                num_tokens=2048,
+                num_computed_tokens=2048,
+            ),
+            _make_request(
+                RequestStatus.WAITING_FOR_REMOTE_KVS,
+                num_tokens=512,
+                num_computed_tokens=512,
+            ),
+        ],
+    )
+    # 0 queued prefill on the decode engine under healthy disagg.
+    assert q.num_prefill_requests == 0
+    assert q.sum_prefill_tokens == 0
+    # 1 preempted (local decode evicted) + 3 remote-KV-waiting.
+    assert q.num_decode_requests == 4
+    assert q.sum_decode_kv_tokens == 780 + 1024 + 2048 + 512
+
+
+def test_mixed_prefill_engine_snapshot():
+    """Prefill engine side: all queued work is prefill across both queues."""
+
+    q = _run_compute_queued(
+        waiting=[
+            _make_request(RequestStatus.WAITING, num_tokens=100),
+            _make_request(RequestStatus.WAITING, num_tokens=200),
+        ],
+        skipped_waiting=[
+            _make_request(STRUCTURED_OUTPUT_WAITING_STATUS, num_tokens=300),
+        ],
+    )
+    assert q.num_prefill_requests == 3
+    assert q.sum_prefill_tokens == 600
+    assert q.num_decode_requests == 0
+
+
+def test_empty_queues():
+    q = _run_compute_queued(waiting=[], skipped_waiting=[])
+    assert q.num_prefill_requests == 0
+    assert q.sum_prefill_tokens == 0
+    assert q.num_decode_requests == 0
+    assert q.sum_decode_kv_tokens == 0
+    assert q.var_prefill_length == 0.0
+    assert q.var_decode_kv_tokens == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Variance correctness across both queues
+# ---------------------------------------------------------------------------
+
+
+def test_variance_spans_both_queues():
+    """Variance is computed over the union of both queues, not each in
+    isolation. Using lengths 100 and 300 → mean 200, var 10000 (population).
+    """
+
+    q = _run_compute_queued(
+        waiting=[
+            _make_request(RequestStatus.WAITING, num_tokens=100),
+        ],
+        skipped_waiting=[
+            _make_request(STRUCTURED_OUTPUT_WAITING_STATUS, num_tokens=300),
+        ],
+    )
+    assert q.num_prefill_requests == 2
+    assert q.sum_prefill_tokens == 400
+    # Population variance of [100, 300] = 10000.
+    assert q.var_prefill_length == pytest.approx(10000.0)
+
+
+def test_dp_rank_prefers_data_parallel_index():
+    """External DP + dense model: vLLM resets ``data_parallel_rank`` to 0 in
+    every child but keeps ``data_parallel_index`` as the true global rank.
+    The resolver must prefer the index so each DP child gets its own port.
+    """
+    pc = SimpleNamespace(data_parallel_index=1, data_parallel_rank=0)
+    assert InstrumentedScheduler._resolve_dp_rank(pc) == 1
+
+
+def test_dp_rank_falls_back_to_rank_when_index_absent():
+    pc = SimpleNamespace(data_parallel_rank=2)
+    assert InstrumentedScheduler._resolve_dp_rank(pc) == 2
+
+
+def test_dp_rank_handles_none_rank():
+    pc = SimpleNamespace(data_parallel_index=None, data_parallel_rank=None)
+    assert InstrumentedScheduler._resolve_dp_rank(pc) == 0
+
+
+def test_dp_rank_default_zero():
+    pc = SimpleNamespace()
+    assert InstrumentedScheduler._resolve_dp_rank(pc) == 0
+
+
+def test_dp_rank_multi_node_start_offset():
+    """Multi-node: node 2 runs DP ranks 8..15 with ``--data-parallel-start-rank 8``.
+    vLLM spawns each child engine with ``dp_rank = start_rank + local_index``
+    (``vllm/v1/engine/utils.py``: ``global_index = start_index + index``) and
+    sets ``parallel_config.data_parallel_index = dp_rank`` (``vllm/v1/engine/
+    core.py``). The resolver must return the global rank so each child's ZMQ
+    port offset matches the parent-side FPM relay subscription, which iterates
+    the same global range.
+    """
+    for global_rank in (8, 9, 15):
+        pc = SimpleNamespace(data_parallel_index=global_rank, data_parallel_rank=0)
+        assert InstrumentedScheduler._resolve_dp_rank(pc) == global_rank
+
+
+def test_decode_variance_spans_both_queues():
+    """Decode variance mixes local-preempted (``self.waiting``) and
+    remote-KV-waiting (``self.skipped_waiting``) into one accumulator.
+    KV lengths 500 and 1500 → mean 1000, population variance 250000.
+    """
+
+    q = _run_compute_queued(
+        waiting=[
+            _make_request(
+                RequestStatus.PREEMPTED, num_tokens=520, num_computed_tokens=500
+            ),
+        ],
+        skipped_waiting=[
+            _make_request(
+                RequestStatus.WAITING_FOR_REMOTE_KVS,
+                num_tokens=1500,
+                num_computed_tokens=1500,
+            ),
+        ],
+    )
+    assert q.num_decode_requests == 2
+    assert q.sum_decode_kv_tokens == 2000
+    assert q.var_decode_kv_tokens == pytest.approx(250000.0)

--- a/components/src/dynamo/vllm/tests/test_vllm_renderer_api.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_renderer_api.py
@@ -400,8 +400,7 @@ class TestVllmRendererApi:
             "events",
             "kv_transfer_params",
             "trace_headers",
-            "num_cached_tokens",
-            "num_external_computed_tokens",
+            "prefill_stats",
             "routed_experts",
             "num_nans_in_logits",
         )

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -16,7 +16,7 @@ dynamo:
   cuda13.0:
     base_image: nvcr.io/nvidia/cuda-dl-base
     base_image_tag: 25.11-cuda13.0-devel-ubuntu24.04
-  epp_image: us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/epp:v0.5.1
+  epp_image: us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-inference-extension/epp:v1.5.0-rc.2
   frontend_image: nvcr.io/nvidia/base/ubuntu:noble-20250619
   planner_build_image: python
   planner_build_image_tag: 3.12-slim
@@ -35,7 +35,7 @@ dynamo:
   enable_kvbm: "true"
   enable_media_ffmpeg: "false"
   enable_gpu_memory_service: "true"
-  ffmpeg_version: "7.1"
+  ffmpeg_version: "8.1"
   efa_version: 1.47.0
 
 vllm:
@@ -44,13 +44,13 @@ vllm:
     runtime_image: nvcr.io/nvidia/cuda
     base_image_tag: 25.06-cuda12.9-devel-ubuntu24.04
     runtime_image_tag: 12.9.1-runtime-ubuntu24.04
-    vllm_ref: v0.19.0
+    vllm_ref: v0.20.0
   cuda13.0:
     base_image: nvcr.io/nvidia/cuda-dl-base
     runtime_image: nvcr.io/nvidia/cuda
     base_image_tag: 25.11-cuda13.0-devel-ubuntu24.04
     runtime_image_tag: 13.0.2-runtime-ubuntu24.04
-    vllm_ref: v0.19.0
+    vllm_ref: v0.20.0
   xpu:
     base_image: intel/deep-learning-essentials
     runtime_image: intel/deep-learning-essentials
@@ -63,8 +63,8 @@ vllm:
     base_image_tag: 24.04
     runtime_image_tag: 24.04
     vllm_ref: v0.16.0
-  flashinf_ref: v0.6.6
-  lmcache_ref: 0.4.2
+  flashinf_ref: v0.6.8.post1
+  lmcache_ref: 0.4.4
   vllm_omni_ref: "release/v0.19.0rc1"
   nixl_ref: 0.10.1
   max_jobs: "10"
@@ -72,7 +72,7 @@ vllm:
   enable_gpu_memory_service: "true"
   enable_kvbm: "true"
   enable_modelexpress_p2p: "false"
-  modelexpress_ref: "3d73992ce6c10e52ddc54f7f12af35d27e173f15"
+  modelexpress_ref: "76fc5d7f06c37121ee8789a29fac6f9b08c4743a"  # v0.3.0
 
 sglang:
   cuda12.9:
@@ -85,7 +85,9 @@ sglang:
     runtime_image: lmsysorg/sglang
     base_image_tag: 25.11-cuda13.0-devel-ubuntu24.04
     runtime_image_tag: v0.5.10.post1-cu130-runtime
-  nixl_ref: v1.0.1
+  # SGLang uses the NIXL stack from the upstream lmsysorg/sglang runtime image.
+  # Do not add nixl_ref here: Dynamo does not build or install its NIXL wheel
+  # for SGLang, and SGLang does not use Dynamo KVBM/block-manager at runtime.
   enable_media_ffmpeg: "true"
   enable_gpu_memory_service: "true"
   enable_kvbm: "false"

--- a/container/deps/requirements.test.txt
+++ b/container/deps/requirements.test.txt
@@ -10,6 +10,7 @@ allure-pytest==2.15.3
 # For MinIO/S3 operations in LoRA tests (replaces AWS CLI dependency)
 boto3==1.42.4
 boto3-stubs[s3]==1.42.9  # Type stubs for boto3 S3 client
+coverage[toml]==7.13.1
 # For IFEval dataset loading in kvbm tests
 datasets==4.4.1
 filelock==3.25.1
@@ -17,10 +18,11 @@ filelock==3.25.1
 kr8s==0.20.13
 kubernetes_asyncio==32.0.0
 matplotlib-stubs
-mistral-common>=1.10.0
+mistral-common>=1.11.0
 mypy==1.18.2
 # For NATS object store verification in router tests
 nats-py==2.12.0
+openai==2.32.0  # for Fault Tolerance migration tests
 psutil<=7.0.0  # System package, may vary by platform (was >=5.0.0)
 # Required by pyproject.toml warning filters (pydantic.warnings.PydanticDeprecatedSince20)
 pydantic>=2.11.4,<2.13

--- a/container/deps/requirements.vllm.txt
+++ b/container/deps/requirements.vllm.txt
@@ -5,5 +5,11 @@
 
 av==15.0.0
 ftfy==6.3.1
-nvtx==0.2.14
+# Pin transformers and onnxruntime: vLLM only sets a lower bound on
+# transformers, so resolver drift can change versions between builds
+# and shift LLaVA/vision preprocessing, making multimodal outputs
+# non-reproducible. Lock both here to keep the image deterministic.
+onnxruntime==1.24.4
+ray==2.55.0
 sentencepiece==0.2.1
+transformers==5.6.2

--- a/container/deps/vllm/install_vllm.sh
+++ b/container/deps/vllm/install_vllm.sh
@@ -4,15 +4,16 @@
 
 # This script installs vLLM and its dependencies from PyPI (release versions only).
 # Installation order:
-# 1. vLLM
-# 2. LMCache (built from source AFTER vLLM so c_ops.so is compiled against installed PyTorch)
-# 3. vLLM-Omni
-# 4. DeepGEMM
-# 5. EP kernels
+# 1. PyTorch for the requested CUDA backend
+# 2. vLLM-Omni
+# 3. vLLM
+# 4. LMCache (built from source AFTER vLLM so c_ops.so is compiled against installed PyTorch)
+# 5. DeepGEMM
+# 6. EP kernels
 
 set -euo pipefail
 
-VLLM_VER="0.19.0"
+VLLM_VER="0.20.0"
 VLLM_REF="v${VLLM_VER}"
 DEVICE="cuda"
 
@@ -25,9 +26,11 @@ INSTALLATION_DIR=/tmp
 TORCH_CUDA_ARCH_LIST="9.0;10.0" # For EP Kernels -- TODO: check if we need to add 12.0+PTX
 DEEPGEMM_REF=""
 CUDA_VERSION="12.9"
-FLASHINF_REF="v0.6.6"
-LMCACHE_REF="0.4.2"
-VLLM_OMNI_REF="v0.16.0"
+FLASHINF_REF="v0.6.8.post1"
+LMCACHE_REF="0.4.4"
+VLLM_OMNI_REF="release/v0.19.0rc1"
+TORCH_REF="2.11.0"
+TORCHVISION_REF="0.26.0"
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -106,23 +109,31 @@ elif [ "$ARCH" = "aarch64" ]; then
     ARCH="arm64"
 fi
 
-# Set alternative CPU architecture naming
-if [ "$ARCH" = "amd64" ]; then
-    ALT_ARCH="x86_64"
-elif [ "$ARCH" = "arm64" ]; then
-    ALT_ARCH="aarch64"
-fi
-
 export MAX_JOBS=$MAX_JOBS
+TORCH_UV_ARGS=""
+VLLM_UV_ARGS=""
 if [ "$DEVICE" = "cuda" ]; then
     export CUDA_HOME=/usr/local/cuda
 
     # Derive torch backend from CUDA version (e.g., "12.9" -> "cu129")
     TORCH_BACKEND="cu$(echo $CUDA_VERSION | tr -d '.')"
     CUDA_VERSION_MAJOR=${CUDA_VERSION%%.*}
+    CUDA_VERSION_MINOR=$(echo "${CUDA_VERSION#*.}" | cut -d. -f1)
+    if [[ "$TORCH_BACKEND" == "cu129" || "$TORCH_BACKEND" == "cu130" ]]; then
+        TORCH_UV_ARGS="--index-url https://pypi.org/simple --index-strategy=unsafe-best-match --torch-backend=${TORCH_BACKEND}"
+        VLLM_UV_ARGS="${TORCH_UV_ARGS} --extra-index-url https://wheels.vllm.ai/${VLLM_VER}/${TORCH_BACKEND}"
+    else
+        echo "❌ Unsupported CUDA version for vLLM installation: ${CUDA_VERSION}"
+        exit 1
+    fi
 
     echo "=== Installing prerequisites ==="
-    uv pip install pip cuda-python
+    uv pip install ${TORCH_UV_ARGS} pip cuda-python
+    echo "Installing PyTorch ${TORCH_REF} for ${TORCH_BACKEND}..."
+    uv pip install ${TORCH_UV_ARGS} \
+        "torch==${TORCH_REF}+${TORCH_BACKEND}" \
+        "torchaudio==${TORCH_REF}+${TORCH_BACKEND}" \
+        "torchvision==${TORCHVISION_REF}+${TORCH_BACKEND}"
 fi
 
 if [ "$DEVICE" = "cuda" ]; then
@@ -148,12 +159,12 @@ echo "\n=== Installing vLLM-Omni ==="
 # vLLM should remain the final owner of the runtime stack in this environment.
 if [ -n "$VLLM_OMNI_REF" ] && [ "$ARCH" = "amd64" ]; then
     # Try PyPI first, fall back to building from source
-    if uv pip install vllm-omni==${VLLM_OMNI_REF#v} 2>&1; then
+    if uv pip install ${VLLM_UV_ARGS} vllm-omni==${VLLM_OMNI_REF#v} 2>&1; then
         echo "✓ vLLM-Omni ${VLLM_OMNI_REF} installed from PyPI"
     else
         echo "⚠ PyPI install failed, building from source..."
         git clone --depth 1 --branch ${VLLM_OMNI_REF} https://github.com/vllm-project/vllm-omni.git $INSTALLATION_DIR/vllm-omni
-        uv pip install $INSTALLATION_DIR/vllm-omni
+        uv pip install ${VLLM_UV_ARGS} $INSTALLATION_DIR/vllm-omni
         rm -rf $INSTALLATION_DIR/vllm-omni
         echo "✓ vLLM-Omni ${VLLM_OMNI_REF} installed from source"
     fi
@@ -170,43 +181,57 @@ fi
 if [ "$DEVICE" = "cuda" ]; then
     echo "\n=== Installing vLLM & FlashInfer ==="
 
-    # Build GitHub release wheel URL per CUDA version
-    # CUDA 12 wheels have no +cu suffix and use manylinux_2_31
-    # CUDA 13 wheels have +cu130 suffix and use manylinux_2_35
-    if [[ "$CUDA_VERSION_MAJOR" == "12" ]]; then
-        VLLM_GITHUB_WHEEL="vllm-${VLLM_VER}-cp38-abi3-manylinux_2_31_${ALT_ARCH}.whl"
-        EXTRA_PIP_ARGS=""
-    elif [[ "$CUDA_VERSION_MAJOR" == "13" ]]; then
-        VLLM_GITHUB_WHEEL="vllm-${VLLM_VER}+${TORCH_BACKEND}-cp38-abi3-manylinux_2_35_${ALT_ARCH}.whl"
-        EXTRA_PIP_ARGS="--index-strategy=unsafe-best-match --extra-index-url https://download.pytorch.org/whl/${TORCH_BACKEND}"
-    else
-        echo "❌ Unsupported CUDA version for vLLM installation: ${CUDA_VERSION}"
-        exit 1
-    fi
-    VLLM_GITHUB_URL="https://github.com/vllm-project/vllm/releases/download/v${VLLM_VER}/${VLLM_GITHUB_WHEEL}"
-
-    # Install vLLM wheel
-    # CUDA 12: Try PyPI first, fall back to GitHub release
-    # CUDA 13: Always use GitHub release (PyPI only has cu12 wheels, --torch-backend
-    #           does not prevent uv from resolving the cu12 variant)
+    # vLLM 0.20.0 switches the default PyPI CUDA wheel to CUDA 13.0.
+    # Use the release wheel variant index for CUDA-specific vLLM binaries,
+    # and ask uv for the matching torch backend for the PyTorch stack.
     echo "Installing vLLM $VLLM_VER (torch backend: $TORCH_BACKEND)..."
-    if [[ "$CUDA_VERSION_MAJOR" == "12" ]]; then
-        if uv pip install "vllm[flashinfer,runai,otel]==${VLLM_VER}" ${EXTRA_PIP_ARGS} --torch-backend=${TORCH_BACKEND} 2>&1; then
-            echo "✓ vLLM ${VLLM_VER} installed from PyPI"
-        else
-            echo "⚠ PyPI install failed, installing from GitHub release..."
-            uv pip install ${EXTRA_PIP_ARGS} \
-                "${VLLM_GITHUB_URL}[flashinfer,runai,otel]" \
-                --torch-backend=${TORCH_BACKEND}
-            echo "✓ vLLM ${VLLM_VER} installed from GitHub"
-        fi
-    else
-        echo "Installing vLLM from GitHub release (cu130 wheel not available on PyPI)..."
-        uv pip install ${EXTRA_PIP_ARGS} \
-            "${VLLM_GITHUB_URL}[flashinfer,runai,otel]" \
-            --torch-backend=${TORCH_BACKEND}
-        echo "✓ vLLM ${VLLM_VER} installed from GitHub"
-    fi
+    uv pip install ${VLLM_UV_ARGS} "vllm[flashinfer,runai,otel]==${VLLM_VER}"
+    echo "✓ vLLM ${VLLM_VER} installed from PyPI"
+    # Run outside /opt/vllm so Python inspects the installed wheel, not the cloned source tree.
+    (cd / && python3 - <<PY
+from importlib import metadata
+from pathlib import Path
+import subprocess
+
+import torch
+
+expected = "${CUDA_VERSION_MAJOR}.${CUDA_VERSION_MINOR}"
+if torch.version.cuda != expected:
+    raise RuntimeError(
+        f"PyTorch CUDA version {torch.version.cuda} does not match CUDA {expected}"
+    )
+print(f"✓ PyTorch CUDA version verified: {torch.version.cuda}")
+
+vllm_version = metadata.version("vllm")
+if "${TORCH_BACKEND}" == "cu129" and not vllm_version.endswith("+cu129"):
+    raise RuntimeError(f"Expected vLLM cu129 wheel, found vLLM {vllm_version}")
+
+dist = metadata.distribution("vllm")
+extension_paths = [
+    Path(dist.locate_file(file))
+    for file in (dist.files or [])
+    if str(file).startswith("vllm/_C") and str(file).endswith(".so")
+]
+if not extension_paths:
+    raise RuntimeError(f"Could not find vLLM extension libraries in vLLM {vllm_version}")
+
+ldd_output = "\n".join(
+    subprocess.check_output(["ldd", str(path)], text=True)
+    for path in extension_paths
+)
+missing_cudart = [
+    line.strip()
+    for line in ldd_output.splitlines()
+    if "libcudart.so" in line and "not found" in line
+]
+if missing_cudart:
+    raise RuntimeError(
+        "vLLM extension is linked against a missing CUDA runtime: "
+        + "; ".join(missing_cudart)
+    )
+print(f"✓ vLLM extension CUDA runtime linkage verified: {vllm_version}")
+PY
+    )
     uv pip install flashinfer-cubin==$FLASHINF_REF
     uv pip install flashinfer-jit-cache==$FLASHINF_REF --extra-index-url https://flashinfer.ai/whl/${TORCH_BACKEND}
 fi

--- a/container/templates/args.Dockerfile
+++ b/container/templates/args.Dockerfile
@@ -66,7 +66,9 @@ ARG SCCACHE_REGION=""
 
 # NIXL configuration
 ARG NIXL_UCX_REF={{ context.dynamo.nixl_ucx_ref }}
+{% if "nixl_ref" in context[framework] -%}
 ARG NIXL_REF={{ context[framework].nixl_ref }}
+{% endif -%}
 {% if device == "cuda" %}
 ARG NIXL_GDRCOPY_REF={{ context.dynamo.nixl_gdrcopy_ref }}
 ARG NIXL_LIBFABRIC_REF={{ context.dynamo.nixl_libfabric_ref }}
@@ -92,8 +94,8 @@ ARG PLANNER_RUNTIME_IMAGE_TAG={{ context.dynamo.planner_runtime_image_tag }}
 # Make sure to update the dependency version in pyproject.toml when updating this
 ARG VLLM_REF={{ context[framework][device_key].vllm_ref }}
 ARG MAX_JOBS={{ context.vllm.max_jobs }}
-# FlashInfer only respected when building vLLM from source, ie when VLLM_REF does not start with 'v' or for arm64 builds
 {% if device == "cuda" -%}
+# FlashInfer cubin/jit-cache version used by the vLLM installer.
 ARG FLASHINF_REF={{ context.vllm.flashinf_ref }}
 {% endif %}
 ARG LMCACHE_REF={{ context.vllm.lmcache_ref }}

--- a/container/templates/vllm_runtime.Dockerfile
+++ b/container/templates/vllm_runtime.Dockerfile
@@ -112,7 +112,9 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         curl \
         # Libraries required by UCX to find RDMA devices
         libibverbs1 rdma-core ibverbs-utils libibumad3 \
-        libnuma1 librdmacm1 ibverbs-providers \
+        libnuma1 libnuma-dev librdmacm1 ibverbs-providers \
+        # numactl CLI for NUMA binding at runtime
+        numactl \
         # JIT Kernel Compilation, flashinfer
         ninja-build \
         g++ \
@@ -296,6 +298,9 @@ RUN --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775 \
       /opt/dynamo/wheelhouse/ai_dynamo_runtime*.whl \
       /opt/dynamo/wheelhouse/ai_dynamo*any.whl \
       /opt/dynamo/wheelhouse/nixl/nixl*.whl && \
+    if [ "${CUDA_VERSION%%.*}" = "13" ]; then \
+        uv pip uninstall -y nixl-cu12 || true; \
+    fi && \
     if [ "${ENABLE_KVBM}" = "true" ]; then \
         KVBM_WHEEL=$(ls /opt/dynamo/wheelhouse/kvbm*.whl 2>/dev/null | head -1); \
         if [ -z "$KVBM_WHEEL" ]; then \
@@ -313,7 +318,10 @@ RUN --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775 \
 # Install NIXL wheel only (pre-built C++ binary, not buildable from source).
 RUN --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775 \
     export UV_CACHE_DIR=/home/dynamo/.cache/uv && \
-    uv pip install /opt/dynamo/wheelhouse/nixl/nixl*.whl
+    uv pip install /opt/dynamo/wheelhouse/nixl/nixl*.whl && \
+    if [ "${CUDA_VERSION%%.*}" = "13" ]; then \
+        uv pip uninstall -y nixl-cu12 || true; \
+    fi
 {% endif %}
 
 {% if device == "cuda" %}

--- a/container/templates/wheel_builder.Dockerfile
+++ b/container/templates/wheel_builder.Dockerfile
@@ -280,7 +280,6 @@ RUN --mount=type=secret,id=aws-web-identity-token,target=/run/secrets/aws-token 
         --disable-doc \
         --disable-static \
         --disable-x86asm \
-        --disable-postproc \
         --disable-network \
         --disable-encoders \
         --disable-muxers \

--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -9,9 +9,12 @@ subtitle: Hardware, software, and build compatibility for Dynamo
 
 ## At a Glance
 
-**Latest stable release:** [v1.0.1](https://github.com/ai-dynamo/dynamo/releases/tag/v1.0.1) -- SGLang `0.5.9` | TensorRT-LLM `1.3.0rc5.post1` | vLLM `0.16.0` | NIXL `0.10.1`
+**Latest stable release:** [v1.0.2](https://github.com/ai-dynamo/dynamo/releases/tag/v1.0.2) -- SGLang `0.5.9` | TensorRT-LLM `1.3.0rc5.post1` | vLLM `0.16.0` | NIXL `0.10.1`
 
-**Experimental release:** [v1.1.0-dev.1](https://github.com/ai-dynamo/dynamo/tree/release/1.1.0-dev.1) -- SGLang `0.5.9` | TensorRT-LLM `1.3.0rc5.post1` | vLLM `0.17.1` | NIXL `0.10.1`
+**Experimental releases:**
+- [v1.1.0-dev.3](https://github.com/ai-dynamo/dynamo/releases/tag/v1.1.0-dev.3) *(partial -- TensorRT-LLM container only)* -- TensorRT-LLM `1.3.0rc11` | branch ToT also pins SGLang `0.5.10.post1` | vLLM `0.19.0` | NIXL `0.10.1`
+- [v1.1.0-dev.2](https://github.com/ai-dynamo/dynamo/releases/tag/v1.1.0-dev.2) *(partial -- SGLang + TensorRT-LLM containers)* -- SGLang `0.5.9` | TensorRT-LLM `1.3.0rc9` | branch ToT also pins vLLM `0.19.0` | NIXL `0.10.1`
+- [v1.1.0-dev.1](https://github.com/ai-dynamo/dynamo/releases/tag/v1.1.0-dev.1) -- SGLang `0.5.9` | TensorRT-LLM `1.3.0rc5.post1` | vLLM `0.17.1` | NIXL `0.10.1`
 
 | Requirement | Supported |
 | :--- | :--- |
@@ -29,8 +32,11 @@ The following table shows the backend framework versions included with each Dyna
 
 | **Dynamo** | **SGLang** | **TensorRT-LLM** | **vLLM** | **NIXL** |
 | :--- | :--- | :--- | :--- | :--- |
-| **main (ToT)** | `0.5.10.post1` | `1.3.0rc11` | `0.19.0` | `0.10.1` |
+| **main (ToT)** | `0.5.10.post1` | `1.3.0rc11` | `0.20.0` | `0.10.1` |
+| **v1.1.0-dev.3** *(experimental, partial)* | `0.5.10.post1` | `1.3.0rc11` | `0.19.0` | `0.10.1` |
+| **v1.1.0-dev.2** *(experimental, partial)* | `0.5.9` | `1.3.0rc9` | `0.19.0` | `0.10.1` |
 | **v1.1.0-dev.1** *(experimental)* | `0.5.9` | `1.3.0rc5.post1` | `0.17.1` | `0.10.1` |
+| **v1.0.2** | `0.5.9` | `1.3.0rc5.post1` | `0.16.0` | `0.10.1` |
 | **v1.0.1** | `0.5.9` | `1.3.0rc5.post1` | `0.16.0` | `0.10.1` |
 | **v1.0.0** | `0.5.9` | `1.3.0rc5.post1` | `0.16.0` | `0.10.1` |
 | **v0.9.1** | `0.5.8` | `1.3.0rc3` | `0.14.1` | `0.9.0` |
@@ -47,9 +53,12 @@ The following table shows the backend framework versions included with each Dyna
 | **v0.6.1** | `0.5.3.post2` | `1.1.0rc5` | `0.11.0` | `0.6.0` |
 | **v0.6.0** | `0.5.3.post2` | `1.1.0rc5` | `0.11.0` | `0.6.0` |
 
+For **v1.1.0-dev.2** and **v1.1.0-dev.3**, the cells above match `container/context.yaml` on the corresponding release branch (pins used to build images). Those dev lines are **partial releases**: not every backend has a published Dynamo runtime container for that tag. See [Pre-Release Artifacts](release-artifacts.md#pre-release-artifacts) for what actually shipped.
+
 ### Version Labels
 
 - **main (ToT)** reflects the current development branch.
+- Releases marked *(experimental, partial)* are pre-releases: the table shows branch build pins, which may include backends with no NGC image for that dev tag yet.
 - Releases marked *(in progress)* or *(planned)* show target versions that may change before final release.
 
 ### Version Compatibility
@@ -63,6 +72,11 @@ Dynamo container images include CUDA toolkit libraries. The host machine must ha
 
 | Dynamo Version | Backend | CUDA Toolkit | Min Driver | Notes |
 | :--- | :--- | :--- | :--- | :--- |
+| **1.0.2** | **SGLang** | 12.9 | 575.xx+ | |
+| | | 13.0 | 580.xx+ | |
+| | **TensorRT-LLM** | 13.1 | 580.xx+ | |
+| | **vLLM** | 12.9 | 575.xx+ | |
+| | | 13.0 | 580.xx+ | |
 | **1.0.1** | **SGLang** | 12.9 | 575.xx+ | |
 | | | 13.0 | 580.xx+ | |
 | | **TensorRT-LLM** | 13.1 | 580.xx+ | |
@@ -97,6 +111,8 @@ Dynamo container images include CUDA toolkit libraries. The host machine must ha
 | | **vLLM** | 12.8 | 570.xx+ | |
 
 Patch versions (e.g., v0.8.1.post1, v0.7.0.post1) have the same CUDA support as their base version.
+
+Experimental `v1.1.0-dev.*` images follow the same CUDA matrix as `v1.0.2`.
 
 Experimental CUDA 13 images are not published for all versions. Check [Release Artifacts](release-artifacts.md) for availability.
 

--- a/lib/bindings/kvbm/python/kvbm/v2/vllm/schedulers/worker.py
+++ b/lib/bindings/kvbm/python/kvbm/v2/vllm/schedulers/worker.py
@@ -23,6 +23,7 @@ bind happens later, when the leader's `initialize_workers()` RPC drives
 from __future__ import annotations
 
 from dataclasses import dataclass
+import math
 from typing import TYPE_CHECKING, Optional
 
 import kvbm
@@ -39,32 +40,86 @@ class KvTensorLayout:
     """Semantic description of the KV cache tensor layout.
 
     Python derives this from VllmConfig (which has the model architecture)
-    so that Rust doesn't have to guess from raw tensor shapes.
+    so that Rust does not need to guess from raw tensor shapes.
 
-    For MLA models, outer_dim and inner_dim are set explicitly because Rust's
-    shape-based inference cannot distinguish the fused KV latent axis from the
-    block/page axis. For standard attention the fields are None, which tells
-    Rust to fall back to its own contiguity-based inference (already correct).
+    For both MLA and standard attention, dimensions are computed explicitly
+    from vLLM config and passed down to Rust. Tensor shape is only used for
+    sanity validation (e.g., block-axis presence / packed-tail checks).
 
     Mirrors the v1 helper in
     lib/bindings/kvbm/python/kvbm/vllm_integration/connector_worker.py.
     """
 
-    outer_dim: Optional[int]  # None = let Rust infer; 1 for MLA
-    inner_dim: Optional[int]  # None = let Rust infer; head_size for MLA
+    outer_dim: Optional[int]
+    inner_dim: Optional[int]
 
     @classmethod
     def from_vllm_config(
-        cls, shape: "torch.Size", use_mla: bool = False
+        cls,
+        vllm_config: "VllmConfig",
+        shape: "torch.Size",
+        num_device_blocks: int,
+        use_mla: bool = False,
     ) -> "KvTensorLayout":
         if use_mla:
             # MLA tensors are 3D: [num_blocks, page_size, head_size].
             # No outer_dim axis — K and V are fused into a single latent.
             return cls(outer_dim=1, inner_dim=int(shape[-1]))
-        # Standard attention: Rust already infers outer_dim/inner_dim correctly
-        # from tensor shape. Don't guess here — the block dimension can be at
-        # position 0 or 1 depending on the attention backend.
-        return cls(outer_dim=None, inner_dim=None)
+        # Standard attention:
+        # - outer_dim is K/V axis = 2
+        # - inner_dim is per-rank kv feature width
+        #
+        # vLLM API surfaces can differ by version/model family:
+        # `get_total_num_kv_heads()` may be global or already per-rank.
+        # Resolve this robustly by checking which config interpretation matches
+        # the observed packed tail in tensor shape.
+        total_kv_heads = int(vllm_config.model_config.get_total_num_kv_heads())
+        head_size = int(vllm_config.model_config.get_head_size())
+        tp_size = int(vllm_config.parallel_config.tensor_parallel_size)
+        if tp_size <= 0:
+            raise ValueError(f"Invalid tensor_parallel_size={tp_size}")
+        outer_dim = 2
+        if head_size <= 0 or total_kv_heads <= 0:
+            raise ValueError(
+                "Invalid standard attention inner_dim derived from config: "
+                f"total_num_kv_heads={total_kv_heads}, head_size={head_size}"
+            )
+
+        # Sanity checks against actual tensor shape so we fail loudly if vLLM
+        # changes layout semantics.
+        if len(shape) < 4:
+            raise ValueError(
+                "Standard attention KV tensor must have >=4 dims; "
+                f"got shape={tuple(shape)}"
+            )
+        if int(shape[0]) < num_device_blocks and int(shape[1]) < num_device_blocks:
+            raise ValueError(
+                "Cannot locate num_device_blocks in standard KV tensor shape; "
+                f"shape[:2]={tuple(shape[:2])}, num_device_blocks={num_device_blocks}"
+            )
+
+        inferred_inner_from_shape = int(math.prod(shape[3:]))
+        config_inner_candidates = [total_kv_heads * head_size]
+        if total_kv_heads % tp_size == 0:
+            config_inner_candidates.append((total_kv_heads // tp_size) * head_size)
+
+        matched_inner = None
+        for candidate in config_inner_candidates:
+            if candidate == inferred_inner_from_shape:
+                matched_inner = candidate
+                break
+
+        if matched_inner is None:
+            raise ValueError(
+                "KV layout mismatch between vLLM config and tensor shape: "
+                f"config_inner_candidates={config_inner_candidates}, "
+                f"shape_inner_dim={inferred_inner_from_shape}, "
+                f"shape={tuple(shape)}, total_num_kv_heads={total_kv_heads}, "
+                f"head_size={head_size}, tp_size={tp_size}"
+            )
+        inner_dim = matched_inner
+
+        return cls(outer_dim=outer_dim, inner_dim=inner_dim)
 
 
 # Import KvbmRuntime and ConnectorWorker from Rust bindings (requires v2 feature)
@@ -212,26 +267,64 @@ class SchedulerConnectorWorker:
                 "Hybrid models with different KV cache shapes are not supported yet."
             )
 
-        # Derive layout semantics from the vLLM model config so Rust doesn't
-        # have to guess the outer_dim/inner_dim from potentially-ambiguous
-        # tensor shapes (MLA caches are 3D without a K/V axis).
-        use_mla = getattr(self.vllm_config.model_config, "use_mla", False)
-        layout = KvTensorLayout.from_vllm_config(shape, use_mla)
-
         # Extract parameters.
-        # Standard attention: [2 (K/V), num_blocks, ...] or [num_blocks, 2, ...]
-        #   — block dim is whichever of shape[0]/shape[1] is larger.
-        # MLA: [num_blocks, page_size, head_size] — block dim is always axis 0.
-        num_device_blocks = shape[0] if use_mla else max(shape[0], shape[1])
+        # Prefer vLLM config's GPU block count; fall back to tensor-derived only
+        # when config is unavailable (older bring-up edge cases).
+        use_mla = getattr(self.vllm_config.model_config, "use_mla", False)
+        config_gpu_blocks = self.vllm_config.cache_config.num_gpu_blocks
+        if config_gpu_blocks is None or config_gpu_blocks <= 0:
+            num_device_blocks = int(shape[0] if use_mla else max(shape[0], shape[1]))
+            print(
+                "Warning: cache_config.num_gpu_blocks unavailable; "
+                f"falling back to tensor-derived num_device_blocks={num_device_blocks}"
+            )
+        else:
+            num_device_blocks = int(config_gpu_blocks)
+
+        # Derive explicit layout semantics from vLLM model config + tensor shape.
+        layout = KvTensorLayout.from_vllm_config(
+            self.vllm_config, shape, num_device_blocks, use_mla
+        )
+
         page_size = self.vllm_config.cache_config.block_size
         dtype_width_bytes = self.kvbm_config.cache_dtype_bytes()
+        if num_device_blocks <= 0:
+            raise ValueError(f"Invalid num_device_blocks={num_device_blocks}")
+        if page_size <= 0:
+            raise ValueError(f"Invalid page_size={page_size}")
+        if dtype_width_bytes <= 0:
+            raise ValueError(f"Invalid dtype_width_bytes={dtype_width_bytes}")
 
-        config_gpu_blocks = self.vllm_config.cache_config.num_gpu_blocks
-        if num_device_blocks != config_gpu_blocks:
-            print(
-                f"Warning: num_device_blocks from tensor ({num_device_blocks}) "
-                f"!= config.num_gpu_blocks ({config_gpu_blocks}). "
-                f"Using tensor-derived value."
+        if shape[0] < num_device_blocks and shape[1] < num_device_blocks:
+            raise ValueError(
+                "Cannot locate num_device_blocks in KV tensor shape; "
+                f"shape[:2]={tuple(shape[:2])}, num_gpu_blocks={num_device_blocks}"
+            )
+
+        # Strong startup contract:
+        # bytes_per_block from layout math must equal bytes_per_block implied by the
+        # concrete tensor storage. This catches subtle TP/layout drift early.
+        layer_total_bytes_from_shape = int(math.prod(shape)) * dtype_width_bytes
+        if layer_total_bytes_from_shape % num_device_blocks != 0:
+            raise ValueError(
+                "KV tensor total bytes is not divisible by num_device_blocks: "
+                f"shape={tuple(shape)}, dtype_width_bytes={dtype_width_bytes}, "
+                f"layer_total_bytes={layer_total_bytes_from_shape}, "
+                f"num_device_blocks={num_device_blocks}"
+            )
+        bytes_per_block_from_shape = layer_total_bytes_from_shape // num_device_blocks
+        bytes_per_block_from_layout = (
+            int(layout.outer_dim) * page_size * int(layout.inner_dim) * dtype_width_bytes
+        )
+        if bytes_per_block_from_shape != bytes_per_block_from_layout:
+            raise ValueError(
+                "KV bytes_per_block mismatch between tensor shape and derived layout: "
+                f"shape={tuple(shape)}, "
+                f"bytes_per_block_from_shape={bytes_per_block_from_shape}, "
+                f"bytes_per_block_from_layout={bytes_per_block_from_layout}, "
+                f"outer_dim={layout.outer_dim}, inner_dim={layout.inner_dim}, "
+                f"page_size={page_size}, dtype_width_bytes={dtype_width_bytes}, "
+                f"num_device_blocks={num_device_blocks}"
             )
 
         # Phase 2A: Register KV caches with NIXL via Rust binding

--- a/lib/bindings/kvbm/python/kvbm/vllm_integration/connector/pd_connector.py
+++ b/lib/bindings/kvbm/python/kvbm/vllm_integration/connector/pd_connector.py
@@ -1,0 +1,188 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional, Type
+
+from kvbm.vllm_integration.connector.dynamo_connector import DynamoConnector
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    KVConnectorHandshakeMetadata,
+    KVConnectorRole,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.multi_connector import (
+    MultiConnector,
+    MultiKVConnectorMetadata,
+)
+
+try:
+    from vllm.distributed.kv_transfer.kv_connector.v1.nixl_connector import (
+        NixlConnector,
+        NixlHandshakePayload,
+    )
+except ModuleNotFoundError as exc:
+    if exc.name != "vllm.distributed.kv_transfer.kv_connector.v1.nixl_connector":
+        raise
+    from vllm.distributed.kv_transfer.kv_connector.v1.nixl import (
+        NixlConnector,
+        NixlHandshakePayload,
+    )
+
+from vllm.v1.core.sched.output import SchedulerOutput
+
+# Optional import for LMCache support
+_LMCacheConnectorV1: Optional[Type] = None
+try:
+    from vllm.distributed.kv_transfer.kv_connector.v1.lmcache_connector import (
+        LMCacheConnectorV1,
+    )
+
+    _LMCacheConnectorV1 = LMCacheConnectorV1
+except ImportError:
+    pass
+
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
+    from vllm.distributed.kv_transfer.kv_connector.v1.lmcache_connector import (
+        LMCacheConnectorV1,
+    )
+    from vllm.v1.core.kv_cache_manager import KVCacheBlocks
+    from vllm.v1.kv_cache_interface import KVCacheConfig
+    from vllm.v1.request import Request
+
+
+@dataclass
+class PdConnectorMetadata(MultiKVConnectorMetadata):
+    pass
+
+
+class PdConnector(MultiConnector):
+    """
+    A wrapper for using KV offloading Connectors (e.g. KVBM or LMCache) and NIXL Connector for PD disaggregated serving.
+
+    The current logic is:
+    - The first connector must be KVBM or LMCache and would be used by prefill worker to offload and onboard KV blocks.
+    - The second connector must be NIXL and will be used by decode worker to get KV blocks from prefill worker.
+    """
+
+    def __init__(
+        self,
+        vllm_config: "VllmConfig",
+        role: KVConnectorRole,
+        kv_cache_config: "KVCacheConfig",
+    ):
+        super().__init__(
+            vllm_config=vllm_config, role=role, kv_cache_config=kv_cache_config
+        )
+        if len(self._connectors) != 2:
+            raise ValueError(
+                f"PdConnector requires exactly two connectors (got {len(self._connectors)})"
+            )
+
+        # Build allowed types for first connector
+        allowed_first_types: list[Type] = [DynamoConnector]
+        if _LMCacheConnectorV1 is not None:
+            allowed_first_types.append(_LMCacheConnectorV1)
+
+        if not isinstance(self._connectors[0], tuple(allowed_first_types)):
+            allowed_names = ["DynamoConnector"]
+            if _LMCacheConnectorV1 is not None:
+                allowed_names.append("LMCacheConnectorV1")
+            raise TypeError(
+                f"Expected first connector to be {' or '.join(allowed_names)}, "
+                f"got {type(self._connectors[0]).__name__}"
+            )
+        if not isinstance(self._connectors[1], NixlConnector):
+            raise TypeError(
+                f"Expected second connector to be NixlConnector, "
+                f"got {type(self._connectors[1]).__name__}"
+            )
+
+    # ==============================
+    # Worker-side methods
+    # ==============================
+
+    def set_xfer_handshake_metadata(
+        self, metadata: dict[int, KVConnectorHandshakeMetadata]
+    ) -> None:
+        """
+        Propagate handshake metadata to child connectors.
+
+        This is required for NIXL connector to start its handshake listener
+        which decode workers connect to for KV transfer coordination.
+        """
+        for c in self._connectors:
+            c.set_xfer_handshake_metadata(metadata)
+
+    def get_handshake_metadata(self) -> KVConnectorHandshakeMetadata | None:
+        """
+        Get the KVConnector handshake metadata from the NIXL connector.
+
+        This metadata is used for out-of-band connector handshake between
+        P/D workers. The NIXL connector (second connector) provides this
+        metadata so decode workers can connect for KV transfer coordination.
+
+        Returns:
+            NixlHandshakePayload from the NIXL connector, or None if not available.
+        """
+        # Get handshake metadata from the NIXL connector (second connector)
+        nixl_connector = self._connectors[1]
+        metadata = nixl_connector.get_handshake_metadata()
+        if metadata is not None and not isinstance(metadata, NixlHandshakePayload):
+            raise TypeError(
+                f"Expected NixlHandshakePayload from NIXL connector, "
+                f"got {type(metadata).__name__}"
+            )
+        return metadata
+
+    def bind_connector_metadata(self, connector_metadata: PdConnectorMetadata) -> None:
+        # Must call super() to set _connector_metadata so has_connector_metadata() returns True
+        # This is required for save_kv_layer to be called during the forward pass
+        super().bind_connector_metadata(connector_metadata)
+        assert isinstance(connector_metadata, PdConnectorMetadata)
+        if connector_metadata.extra_async_saves:
+            self._extra_async_saves.update(connector_metadata.extra_async_saves)
+        for c, cm in zip(self._connectors, connector_metadata.metadata):
+            c.bind_connector_metadata(cm)
+
+    # ==============================
+    # Scheduler-side methods
+    # ==============================
+
+    def get_num_new_matched_tokens(
+        self,
+        request: "Request",
+        num_computed_tokens: int,
+    ) -> tuple[int, bool]:
+        """
+        Get the number of matched tokens for the request using Dynamo Connector (KVBM).
+        """
+        return self._connectors[0].get_num_new_matched_tokens(
+            request, num_computed_tokens
+        )
+
+    def update_state_after_alloc(
+        self, request: "Request", blocks: "KVCacheBlocks", num_external_tokens: int
+    ):
+        """
+        Update the state after allocation using Dynamo Connector (KVBM) and Nixl Connector.
+        """
+        empty_blocks = blocks.new_empty()
+        # allocate blocks for KV offloading connector to onboard KV blocks
+        self._connectors[0].update_state_after_alloc(
+            request, blocks, num_external_tokens
+        )
+        # no need to allocate any blocks for NIXL connector since this is in prefill worker side
+        # and it only needs to wait for decode worker to pull its data.
+        self._connectors[1].update_state_after_alloc(request, empty_blocks, 0)
+
+    def build_connector_meta(
+        self, scheduler_output: SchedulerOutput
+    ) -> PdConnectorMetadata:
+        metadata = PdConnectorMetadata(
+            metadata=tuple(
+                c.build_connector_meta(scheduler_output) for c in self._connectors
+            )
+        )
+        if self._extra_async_saves:
+            metadata.extra_async_saves = self._extra_async_saves
+            self._extra_async_saves = {}
+        return metadata

--- a/lib/kvbm-connector/src/connector/leader/onboard.rs
+++ b/lib/kvbm-connector/src/connector/leader/onboard.rs
@@ -32,6 +32,26 @@ fn select_onboard_block_ids(
 ) -> Vec<BlockId> {
     let num_computed_blocks = num_computed_tokens / block_size;
     let num_external_blocks = num_external_tokens / block_size;
+    let floor_loss_tokens = num_external_tokens % block_size;
+    let num_external_blocks_ceil =
+        num_external_blocks + if floor_loss_tokens > 0 { 1 } else { 0 };
+
+    // Diagnostic: surface floor-division loss so we can tell whether
+    // num_external_tokens is a multiple of block_size for this workload.
+    // floor_loss_tokens > 0 means the trailing remainder is silently dropped
+    // and the actual byte count moved by the onboard transfer is smaller
+    // than (num_external_tokens * per_token_kv_bytes) suggests.
+    tracing::info!(
+        num_computed_tokens,
+        num_external_tokens,
+        block_size,
+        num_computed_blocks,
+        num_external_blocks,
+        num_external_blocks_ceil,
+        floor_loss_tokens,
+        "select_onboard_block_ids"
+    );
+
     block_ids[num_computed_blocks..num_computed_blocks + num_external_blocks].to_vec()
 }
 
@@ -257,9 +277,9 @@ async fn execute_onboarding(
 
     tracing::info!(
         blocks = num_blocks,
-        staging_ms = staging_complete.duration_since(start).as_millis() as u64,
-        xfer_ms = end_xfer.duration_since(start_xfer).as_millis() as u64,
-        total_ms = end_xfer.duration_since(start).as_millis() as u64,
+        staging_us = staging_complete.duration_since(start).as_micros() as u64,
+        xfer_us = end_xfer.duration_since(start_xfer).as_micros() as u64,
+        total_us = end_xfer.duration_since(start).as_micros() as u64,
         src = "kvbm_engine::G2",
         dst = "kvbm_engine::G1",
         "Onboard transfer complete"

--- a/lib/kvbm-connector/src/vllm/layout.rs
+++ b/lib/kvbm-connector/src/vllm/layout.rs
@@ -75,15 +75,30 @@ pub fn determine_kv_layout(
     }
 
     // Locate the blocks dimension from shape (independent of explicit dims).
-    let block_dim = if shape[0] >= num_device_blocks {
-        BlockDimension::BlockIsFirstDim
-    } else if shape[1] >= num_device_blocks {
-        BlockDimension::BlockIsSecondDim
-    } else {
-        bail!(
-            "Unexpected tensor shape: {:?}; expected num_device_blocks: {num_device_blocks} to be present in the first or second dimension",
-            shape
-        );
+    //
+    // Be strict on ambiguity: if both leading dimensions could be interpreted as
+    // the blocks axis we fail instead of silently picking axis 0. Silent fallback
+    // here can corrupt layout math (outer_dim/inner_dim) and under-transfer bytes.
+    let dim0_matches = shape[0] >= num_device_blocks;
+    let dim1_matches = shape[1] >= num_device_blocks;
+    let block_dim = match (dim0_matches, dim1_matches) {
+        (true, false) => BlockDimension::BlockIsFirstDim,
+        (false, true) => BlockDimension::BlockIsSecondDim,
+        (false, false) => {
+            bail!(
+                "Unexpected tensor shape: {:?}; expected num_device_blocks ({}) to be present in one of the first two dimensions",
+                shape,
+                num_device_blocks
+            );
+        }
+        (true, true) => {
+            bail!(
+                "Ambiguous tensor shape for block-dimension detection: shape[:2]={:?}, num_device_blocks={}. \
+                 Both leading dims satisfy >= num_device_blocks; cannot safely infer block axis.",
+                &shape[..2],
+                num_device_blocks
+            );
+        }
     };
 
     // Resolve outer_dim / inner_dim.

--- a/lib/kvbm-engine/src/offload/pipeline.rs
+++ b/lib/kvbm-engine/src/offload/pipeline.rs
@@ -1467,31 +1467,31 @@ impl<Src: BlockMetadata, Dst: BlockMetadata> BlockTransferExecutor<Src, Dst> {
             let unique_transfer_ids: std::collections::HashSet<_> =
                 resolved.iter().map(|b| b.transfer_id).collect();
 
-            let policy_ms = batch
+            let policy_us = batch
                 .timing
                 .policy_duration()
-                .map(|d| d.as_millis() as u64)
+                .map(|d| d.as_micros() as u64)
                 .unwrap_or(0);
-            let precondition_ms = batch
+            let precondition_us = batch
                 .timing
                 .precondition_duration()
-                .map(|d| d.as_millis() as u64)
+                .map(|d| d.as_micros() as u64)
                 .unwrap_or(0);
-            let total_ms = batch
+            let total_us = batch
                 .timing
                 .total_duration()
-                .map(|d| d.as_millis() as u64)
+                .map(|d| d.as_micros() as u64)
                 .unwrap_or(0);
 
             tracing::info!(
                 blocks = resolved.len(),
                 containers = unique_transfer_ids.len(),
-                policy_ms,
-                precondition_ms,
-                xfer_ms = end_xfer.duration_since(start_xfer).as_millis() as u64,
-                registration_ms =
-                    registration_timepoint.duration_since(end_xfer).as_millis() as u64,
-                total_ms,
+                policy_us,
+                precondition_us,
+                xfer_us = end_xfer.duration_since(start_xfer).as_micros() as u64,
+                registration_us =
+                    registration_timepoint.duration_since(end_xfer).as_micros() as u64,
+                total_us,
                 src = std::any::type_name::<Src>(),
                 dst = std::any::type_name::<Dst>(),
                 "Batch transfer complete"
@@ -1829,34 +1829,34 @@ impl<Src: BlockMetadata> ObjectTransferExecutor<Src> {
         let unique_transfer_ids: std::collections::HashSet<_> =
             resolved.iter().map(|b| b.transfer_id).collect();
 
-        let policy_ms = batch
+        let policy_us = batch
             .timing
             .policy_duration()
-            .map(|d| d.as_millis() as u64)
+            .map(|d| d.as_micros() as u64)
             .unwrap_or(0);
-        let precondition_ms = batch
+        let precondition_us = batch
             .timing
             .precondition_duration()
-            .map(|d| d.as_millis() as u64)
+            .map(|d| d.as_micros() as u64)
             .unwrap_or(0);
-        let transfer_ms = batch
+        let transfer_us = batch
             .timing
             .transfer_duration()
-            .map(|d| d.as_millis() as u64)
+            .map(|d| d.as_micros() as u64)
             .unwrap_or(0);
-        let total_ms = batch
+        let total_us = batch
             .timing
             .total_duration()
-            .map(|d| d.as_millis() as u64)
+            .map(|d| d.as_micros() as u64)
             .unwrap_or(0);
 
         tracing::info!(
             blocks = resolved.len(),
             containers = unique_transfer_ids.len(),
-            policy_ms,
-            precondition_ms,
-            transfer_ms,
-            total_ms,
+            policy_us,
+            precondition_us,
+            transfer_us,
+            total_us,
             src = std::any::type_name::<Src>(),
             dst = "G4-object",
             "Object batch transfer complete"

--- a/lib/kvbm-physical/src/transfer/executor/cuda.rs
+++ b/lib/kvbm-physical/src/transfer/executor/cuda.rs
@@ -97,6 +97,43 @@ pub fn execute_cuda_transfer(
         _ => "Unknown",
     };
 
+    // Diagnostic: bytes about to move + path selection. Cross-correlate
+    // with the connector's "Onboard transfer complete" xfer_us field to
+    // get effective bandwidth for the actual byte count this kernel
+    // moves (which is not necessarily what the caller assumes).
+    let log_num_blocks = src_block_ids.len();
+    let log_num_layers = layers.len();
+    let log_outer_dim = src_layout.outer_dim();
+    let log_page_size = src_layout.page_size();
+    let log_inner_dim = src_layout.inner_dim();
+    let log_dtype_width = src_layout.dtype_width_bytes();
+    let log_fc_lw_num_pairs = log_num_blocks * log_num_layers * log_outer_dim;
+    let log_fc_lw_chunk_bytes = log_page_size * log_inner_dim * log_dtype_width;
+    let log_fc_lw_bytes_from_pairs = log_fc_lw_num_pairs * log_fc_lw_chunk_bytes;
+    let log_expected_bytes = log_num_blocks
+        * log_num_layers
+        * log_outer_dim
+        * log_page_size
+        * log_inner_dim
+        * log_dtype_width;
+    tracing::info!(
+        strategy = strategy_name,
+        selected_path = if use_whole_block { "whole_block" } else { "fc_lw" },
+        num_blocks = log_num_blocks,
+        num_layers = log_num_layers,
+        outer_dim = log_outer_dim,
+        page_size = log_page_size,
+        inner_dim = log_inner_dim,
+        dtype_width = log_dtype_width,
+        fc_lw_num_pairs = log_fc_lw_num_pairs,
+        fc_lw_chunk_bytes = log_fc_lw_chunk_bytes,
+        fc_lw_bytes_from_pairs = log_fc_lw_bytes_from_pairs,
+        expected_bytes = log_expected_bytes,
+        src_is_fully_contiguous = src_layout.is_fully_contiguous(),
+        dst_is_fully_contiguous = dst_layout.is_fully_contiguous(),
+        "Transfer prepared"
+    );
+
     match strategy {
         TransferStrategy::CudaAsyncH2D
         | TransferStrategy::CudaAsyncD2H

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ trtllm =[
 vllm = [
     "uvloop",
     "nixl[cu12]<=0.10.1",
-    "vllm[flashinfer,runai,otel]==0.19.0",
+    "vllm[flashinfer,runai,otel]==0.20.0",
     # vllm-omni is installed separately in container builds (see
     # container/deps/vllm/install_vllm.sh). Do not add it to ai-dynamo[vllm]:
     # pip/uv dependency resolution for omni can override the vLLM torch stack.
@@ -58,6 +58,7 @@ vllm = [
     "blake3>=1.0.0,<2.0.0",
     "soundfile>=0.13.1",
     "librosa>=0.10.0",
+    "ray==2.55.0",
 ]
 
 sglang = [
@@ -232,6 +233,8 @@ markers = [
     "post_merge: marks tests to run after merge",
     "parallel: marks tests that can run in parallel with pytest-xdist",
     "nightly: marks tests to run nightly",
+    "skip_in_nightly: excludes a test from the nightly pipeline only (still runs in pre_merge/post_merge). Used via `not skip_in_nightly` in nightly-ci.yml marker filters",
+    "frontend_api_surface_compliance: marks tests that validate Dynamo's HTTP API surface (Responses/Anthropic wire shape, tool-call routing) against upstream compliance harnesses",
     "weekly: marks tests to run weekly",
     "release: marks tests to run on release pipelines",
     "gpu_0: marks tests that don't require GPU",

--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -85,6 +85,10 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
         topologies={
             "agg": TopologyConfig(
                 marks=[
+                    pytest.mark.skip(
+                        reason="vLLM engine core init fails on amd64 post-merge. "
+                        "OPS-4445"
+                    ),
                     pytest.mark.post_merge,
                 ],
                 timeout_s=600,
@@ -107,5 +111,40 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
         request_payloads=[make_image_payload(["green"])],
         extra_vllm_args=["--dtype", "bfloat16"],
         gated=True,
+    ),
+    # [gluo NOTE] LLaVA 1.5 7B is big model and require at least 3 GPUs to run.
+    # We may use less GPUs by squeezing the model onto 2 GPUs.
+    MultimodalModelProfile(
+        name="llava-hf/llava-1.5-7b-hf",
+        short_name="llava-1.5-7b",
+        topologies={
+            "e_pd": TopologyConfig(
+                marks=[pytest.mark.pre_merge],
+                timeout_s=340,
+                gpu_marker="gpu_4",
+            ),
+            "epd": TopologyConfig(
+                marks=[pytest.mark.pre_merge],
+                timeout_s=300,
+                gpu_marker="gpu_4",
+            ),
+        },
+        # LLaVA 1.5 color naming varies across CUDA backends under vLLM 0.20;
+        # keep this as a multimodal serving smoke check, not a color oracle.
+        request_payloads=[
+            make_image_payload(
+                [
+                    "green",
+                    "white",
+                    "black",
+                    "purple",
+                    "red",
+                    "pink",
+                    "yellow",
+                    "blue",
+                    "orange",
+                ]
+            )
+        ],
     ),
 ]

--- a/tests/serve/test_vllm_omni.py
+++ b/tests/serve/test_vllm_omni.py
@@ -1,13 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import base64
 import dataclasses
 import logging
 import os
 from dataclasses import dataclass, field
-from io import BytesIO
-from typing import Any
 
 import pytest
 
@@ -22,117 +19,19 @@ from tests.serve.common import (
     run_serve_deployment,
 )
 from tests.utils.engine_process import EngineConfig
-from tests.utils.payloads import BasePayload, ChatPayload
+from tests.utils.payloads import (
+    AudioSpeechPayload,
+    ChatPayload,
+    I2VPayload,
+    ImageGenerationPayload,
+    VideoGenerationPayload,
+)
 
 logger = logging.getLogger(__name__)
 
 vllm_dir = os.environ.get("VLLM_DIR") or os.path.join(
     WORKSPACE_DIR, "examples/backends/vllm"
 )
-
-
-@dataclass
-class ImageGenerationPayload(BasePayload):
-    """Payload for /v1/images/generations endpoint."""
-
-    endpoint: str = "/v1/images/generations"
-    timeout: int = 300
-
-    def response_handler(self, response: Any) -> str:
-        response.raise_for_status()
-        result = response.json()
-        assert (
-            "data" in result
-        ), f"Missing 'data' in response. Keys: {list(result.keys())}"
-        assert len(result["data"]) > 0, "Empty data in image response"
-        entry = result["data"][0]
-        if "url" in entry:
-            assert entry["url"], "Image response url is empty"
-            return entry["url"]
-        assert entry.get("b64_json"), "Image response b64_json is empty"
-        return "b64_image_returned"
-
-
-@dataclass
-class VideoGenerationPayload(BasePayload):
-    """Payload for /v1/videos endpoint."""
-
-    endpoint: str = "/v1/videos"
-    timeout: int = 600
-
-    def response_handler(self, response: Any) -> str:
-        response.raise_for_status()
-        result = response.json()
-        assert result.get("status") == "completed", (
-            f"Video generation not completed. Status: {result.get('status')}, "
-            f"Error: {result.get('error', 'none')}"
-        )
-        assert (
-            "data" in result
-        ), f"Missing 'data' in response. Keys: {list(result.keys())}"
-        assert len(result["data"]) > 0, "Empty data in video response"
-        entry = result["data"][0]
-        if "url" in entry:
-            assert entry["url"], "Video response url is empty"
-            return entry["url"]
-        assert entry.get("b64_json"), "Video response b64_json is empty"
-        return "b64_video_returned"
-
-    def validate(self, response: Any, content: str) -> None:
-        assert content, "Video response content is empty"
-        if self.expected_response and not any(
-            expected.lower() in content.lower() for expected in self.expected_response
-        ):
-            raise AssertionError(
-                f"Expected at least one of {self.expected_response} in {content!r}"
-            )
-
-
-@dataclass
-class I2VPayload(VideoGenerationPayload):
-    """Payload for image-to-video via /v1/videos with input_reference."""
-
-    def __post_init__(self):
-        from PIL import Image
-
-        image_buffer = BytesIO()
-        Image.new("RGB", (64, 64), color="red").save(image_buffer, format="PNG")
-        image_b64 = base64.b64encode(image_buffer.getvalue()).decode("ascii")
-        self.body["input_reference"] = f"data:image/png;base64,{image_b64}"
-
-
-@dataclass
-class AudioSpeechPayload(BasePayload):
-    """Payload for /v1/audio/speech endpoint."""
-
-    endpoint: str = "/v1/audio/speech"
-    timeout: int = 300
-
-    def response_handler(self, response: Any) -> str:
-        response.raise_for_status()
-        content_type = response.headers.get("content-type", "")
-        if "audio" in content_type:
-            # Binary audio response
-            audio_bytes = response.content
-            assert len(audio_bytes) > 100, (
-                f"Audio response too small ({len(audio_bytes)} bytes), "
-                f"likely not valid audio"
-            )
-            return f"binary_audio_{len(audio_bytes)}_bytes"
-        # JSON response (error or url format)
-        result = response.json()
-        assert (
-            result.get("status") != "failed"
-        ), f"Audio generation failed: {result.get('error', 'unknown')}"
-        assert (
-            "data" in result
-        ), f"Missing 'data' in response. Keys: {list(result.keys())}"
-        assert len(result["data"]) > 0, "Empty data in audio response"
-        entry = result["data"][0]
-        if "url" in entry and entry["url"]:
-            return entry["url"]
-        assert entry.get("b64_json"), "Audio response b64_json is empty"
-        return "b64_audio_returned"
 
 
 @dataclass
@@ -272,6 +171,10 @@ vllm_omni_configs = {
             pytest.mark.gpu_1,
             pytest.mark.pre_merge,
             pytest.mark.timeout(1200),
+            pytest.mark.skip(
+                reason="vLLM-Omni audio release/v0.19.0rc1 uses the pre-vLLM 0.20 "
+                "GPUModelRunner._bookkeeping_sync signature"
+            ),
         ],
         model="Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
         request_payloads=[


### PR DESCRIPTION
## Summary

- Upgrade the vLLM runtime stack to vLLM 0.20.0, including container/default pins for FlashInfer, LMCache, ModelExpress, PyTorch/vLLM wheel install flow, and support-matrix documentation.
- Adapt Dynamo's vLLM integration to vLLM 0.20 APIs: stat logger signature changes, `EngineCoreOutput.prefill_stats`, external-DP rank resolution, and queued FPM classification for `skipped_waiting` / `WAITING_FOR_REMOTE_KVS` requests.
- Add KVBM/vLLM connector fixes: a `PdConnector` wrapper for Dynamo/LMCache + NIXL P/D serving, stricter KV tensor layout and block-count validation, and improved onboarding/transfer timing and byte diagnostics.
- Update vLLM multimodal/Omni tests and payload reuse, add scheduler metric regression coverage, and skip known vLLM 0.20-incompatible cases with explicit reasons.

## Branch / Merge Notes

- Merged `origin/ryan/kvbm-connector` into this branch before opening the PR so the head contains the latest target commits.
- Resolved the only merge conflict in `lib/kvbm-connector/src/connector/leader/onboard.rs` by keeping the target branch's G2/G3 source selection and this branch's microsecond onboarding timing fields.

## Testing

- `git diff --check origin/ryan/kvbm-connector...HEAD`
- `git merge-base --is-ancestor origin/ryan/kvbm-connector HEAD`

Not run locally due environment gaps:

- `python -m pytest components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py -q` (`python` is not on PATH)
- `python3 -m pytest components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py -q` (repo pytest config requires missing `pytest_benchmark`)
- `PYTHONPATH=components/src python3 -m pytest -c /dev/null components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py -q` (installed local vLLM does not match this branch: missing `vllm.utils.hashing`)
- `cargo test -p kvbm-connector test_select_onboard_blocks --lib` (`cargo` is not on PATH)

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9447" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->