### PR TITLE
fix: enable DGDSA for planner-managed DGDR workers

### DIFF
--- a/components/src/dynamo/profiler/tests/integration/test_profile_sla_dgdr.py
+++ b/components/src/dynamo/profiler/tests/integration/test_profile_sla_dgdr.py
@@ -169,9 +169,9 @@ class TestRapidSupported:
         }
         assert worker_services, "Planner DGD should include worker services"
         for name, service in worker_services.items():
-            assert service.get("scalingAdapter", {}).get("enabled") is True, (
-                f"Planner worker {name} should enable DGDSA"
-            )
+            assert (
+                service.get("scalingAdapter", {}).get("enabled") is True
+            ), f"Planner worker {name} should enable DGDSA"
         assert "scalingAdapter" not in services["Planner"]
 
 

--- a/components/src/dynamo/profiler/tests/integration/test_profile_sla_dgdr.py
+++ b/components/src/dynamo/profiler/tests/integration/test_profile_sla_dgdr.py
@@ -161,6 +161,18 @@ class TestRapidSupported:
         assert "Planner" in dgd.get("spec", {}).get(
             "services", {}
         ), "Planner service should be added"
+        services = dgd.get("spec", {}).get("services", {})
+        worker_services = {
+            name: svc
+            for name, svc in services.items()
+            if svc.get("componentType") == "worker"
+        }
+        assert worker_services, "Planner DGD should include worker services"
+        for name, service in worker_services.items():
+            assert service.get("scalingAdapter", {}).get("enabled") is True, (
+                f"Planner worker {name} should enable DGDSA"
+            )
+        assert "scalingAdapter" not in services["Planner"]
 
 
 class TestRapidUnsupported:

--- a/components/src/dynamo/profiler/tests/unit/test_helpers_profile_sla.py
+++ b/components/src/dynamo/profiler/tests/unit/test_helpers_profile_sla.py
@@ -541,9 +541,7 @@ class TestAssembleFinalConfig:
             }
         }
 
-        enable_planner_worker_scaling_adapters(
-            dgd_config, _make_planner(mode="decode")
-        )
+        enable_planner_worker_scaling_adapters(dgd_config, _make_planner(mode="decode"))
 
         assert dgd_config["spec"]["services"]["decode"]["scalingAdapter"] == {
             "enabled": True,

--- a/components/src/dynamo/profiler/tests/unit/test_helpers_profile_sla.py
+++ b/components/src/dynamo/profiler/tests/unit/test_helpers_profile_sla.py
@@ -38,6 +38,7 @@ try:
     from dynamo.profiler.utils.dgd_generation import (
         add_profile_data_to_config,
         assemble_final_config,
+        enable_planner_worker_scaling_adapters,
     )
     from dynamo.profiler.utils.dgdr_v1beta1_types import (
         DynamoGraphDeploymentRequestSpec,
@@ -479,6 +480,178 @@ class TestAssembleFinalConfig:
         )
 
         assert result is None
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_planner_enables_scaling_adapter_on_worker_services(self, tmp_path):
+        """Planner-generated workers should be scaled through DGDSA."""
+        dgdr = _make_dgdr(features=FeaturesSpec(planner=_make_planner()))
+        ops = _make_ops(tmp_path)
+        os.makedirs(ops.output_dir, exist_ok=True)
+        dgd_config = {
+            "kind": "DGD",
+            "spec": {
+                "services": {
+                    "Frontend": {"componentType": "frontend", "replicas": 1},
+                    "decode": {
+                        "componentType": "worker",
+                        "subComponentType": "decode",
+                        "replicas": 1,
+                    },
+                    "prefill": {
+                        "componentType": "worker",
+                        "subComponentType": "prefill",
+                        "replicas": 1,
+                    },
+                }
+            },
+        }
+        planner_cm = {"kind": "ConfigMap", "metadata": {"name": "planner-cm"}}
+
+        with patch(
+            f"{_DGD_GEN}.add_planner_to_config",
+            return_value=planner_cm,
+        ):
+            result = assemble_final_config(
+                dgdr,
+                ops,
+                dgd_config,
+                PickedParallelConfig(tp=1),
+                PickedParallelConfig(tp=1),
+            )
+
+        assert result == [planner_cm, dgd_config]
+        services = dgd_config["spec"]["services"]
+        assert services["decode"]["scalingAdapter"] == {"enabled": True}
+        assert services["prefill"]["scalingAdapter"] == {"enabled": True}
+        assert "scalingAdapter" not in services["Frontend"]
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_enable_planner_worker_scaling_adapters_updates_existing_config(self):
+        dgd_config = {
+            "spec": {
+                "services": {
+                    "decode": {
+                        "componentType": "worker",
+                        "scalingAdapter": {"enabled": False},
+                    },
+                    "Planner": {"componentType": "planner"},
+                }
+            }
+        }
+
+        enable_planner_worker_scaling_adapters(
+            dgd_config, _make_planner(mode="decode")
+        )
+
+        assert dgd_config["spec"]["services"]["decode"]["scalingAdapter"] == {
+            "enabled": True,
+        }
+        assert "scalingAdapter" not in dgd_config["spec"]["services"]["Planner"]
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    @pytest.mark.parametrize(
+        ("mode", "enabled_services", "disabled_services"),
+        [
+            ("disagg", {"prefill", "decode"}, set()),
+            ("prefill", {"prefill"}, {"decode"}),
+            ("decode", {"decode"}, {"prefill"}),
+            ("agg", {"decode"}, {"prefill"}),
+        ],
+    )
+    def test_enable_planner_worker_scaling_adapters_honors_planner_mode(
+        self, mode, enabled_services, disabled_services
+    ):
+        dgd_config = {
+            "spec": {
+                "services": {
+                    "Frontend": {"componentType": "frontend"},
+                    "prefill": {
+                        "componentType": "worker",
+                        "subComponentType": "prefill",
+                    },
+                    "decode": {
+                        "componentType": "worker",
+                        "subComponentType": "decode",
+                    },
+                }
+            }
+        }
+
+        enable_planner_worker_scaling_adapters(dgd_config, _make_planner(mode=mode))
+
+        services = dgd_config["spec"]["services"]
+        for service_name in enabled_services:
+            assert services[service_name]["scalingAdapter"] == {"enabled": True}
+        for service_name in disabled_services:
+            assert "scalingAdapter" not in services[service_name]
+        assert "scalingAdapter" not in services["Frontend"]
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_enable_planner_worker_scaling_adapters_uses_service_name_fallback(self):
+        dgd_config = {
+            "spec": {
+                "services": {
+                    "VllmPrefillWorker": {"componentType": "worker"},
+                    "VllmDecodeWorker": {"componentType": "worker"},
+                }
+            }
+        }
+
+        enable_planner_worker_scaling_adapters(
+            dgd_config, _make_planner(mode="prefill")
+        )
+
+        services = dgd_config["spec"]["services"]
+        assert services["VllmPrefillWorker"]["scalingAdapter"] == {"enabled": True}
+        assert "scalingAdapter" not in services["VllmDecodeWorker"]
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_enable_planner_worker_scaling_adapters_handles_agg_worker(self):
+        dgd_config = {
+            "spec": {
+                "services": {
+                    "Frontend": {"componentType": "frontend"},
+                    "TRTLLMWorker": {"componentType": "worker"},
+                }
+            }
+        }
+
+        enable_planner_worker_scaling_adapters(dgd_config, _make_planner(mode="agg"))
+
+        assert dgd_config["spec"]["services"]["TRTLLMWorker"]["scalingAdapter"] == {
+            "enabled": True,
+        }
+        assert "scalingAdapter" not in dgd_config["spec"]["services"]["Frontend"]
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_enable_planner_worker_scaling_adapters_skips_advisory_mode(self):
+        dgd_config = {
+            "spec": {
+                "services": {
+                    "prefill": {
+                        "componentType": "worker",
+                        "subComponentType": "prefill",
+                    },
+                    "decode": {
+                        "componentType": "worker",
+                        "subComponentType": "decode",
+                    },
+                }
+            }
+        }
+
+        enable_planner_worker_scaling_adapters(
+            dgd_config, _make_planner(mode="disagg", advisory=True)
+        )
+
+        assert "scalingAdapter" not in dgd_config["spec"]["services"]["prefill"]
+        assert "scalingAdapter" not in dgd_config["spec"]["services"]["decode"]
 
     @pytest.mark.pre_merge
     @pytest.mark.gpu_0

--- a/components/src/dynamo/profiler/tests/unit/test_helpers_profile_sla.py
+++ b/components/src/dynamo/profiler/tests/unit/test_helpers_profile_sla.py
@@ -605,7 +605,9 @@ class TestAssembleFinalConfig:
 
         services = dgd_config["spec"]["services"]
         assert services["VllmPrefillWorker"]["scalingAdapter"] == {"enabled": True}
+        assert services["VllmPrefillWorker"]["subComponentType"] == "prefill"
         assert "scalingAdapter" not in services["VllmDecodeWorker"]
+        assert "subComponentType" not in services["VllmDecodeWorker"]
 
     @pytest.mark.pre_merge
     @pytest.mark.gpu_0

--- a/components/src/dynamo/profiler/tests/unit/test_helpers_profile_sla.py
+++ b/components/src/dynamo/profiler/tests/unit/test_helpers_profile_sla.py
@@ -624,6 +624,10 @@ class TestAssembleFinalConfig:
         assert dgd_config["spec"]["services"]["TRTLLMWorker"]["scalingAdapter"] == {
             "enabled": True,
         }
+        assert (
+            dgd_config["spec"]["services"]["TRTLLMWorker"]["subComponentType"]
+            == "decode"
+        )
         assert "scalingAdapter" not in dgd_config["spec"]["services"]["Frontend"]
 
     @pytest.mark.pre_merge

--- a/components/src/dynamo/profiler/utils/dgd_generation.py
+++ b/components/src/dynamo/profiler/utils/dgd_generation.py
@@ -128,6 +128,9 @@ def assemble_final_config(
     config_maps: list[dict] = []
 
     if planner:
+        planner_cfg = dgdr.features.planner if dgdr.features else None
+        if planner_cfg is not None:
+            enable_planner_worker_scaling_adapters(base, planner_cfg)
         planner_cm = add_planner_to_config(
             dgdr,
             base,
@@ -244,6 +247,86 @@ def generate_mocker_config(
             main_container["args"] = args_list
 
     return mocker_config
+
+
+def enable_planner_worker_scaling_adapters(
+    config_dict: dict, planner_config: PlannerConfig
+) -> None:
+    """Opt worker services into DGDSA when non-advisory Planner manages replicas."""
+    if planner_config.advisory:
+        return
+
+    services = config_dict.get("spec", {}).get("services", {})
+    if not isinstance(services, dict):
+        return
+
+    target_subcomponents = _planner_scaling_subcomponents(planner_config.mode)
+    untyped_worker_count = sum(
+        1
+        for service_name, service_config in services.items()
+        if isinstance(service_config, dict)
+        and service_config.get("componentType") == "worker"
+        and not service_config.get("subComponentType")
+        and _infer_subcomponent_from_service_name(service_name) is None
+    )
+
+    for service_name, service_config in services.items():
+        if not isinstance(service_config, dict):
+            continue
+        if not _is_planner_scalable_worker_service(
+            service_name,
+            service_config,
+            target_subcomponents,
+            planner_config.mode,
+            untyped_worker_count,
+        ):
+            continue
+        scaling_adapter = service_config.setdefault("scalingAdapter", {})
+        if not isinstance(scaling_adapter, dict):
+            service_config["scalingAdapter"] = {"enabled": True}
+            continue
+        scaling_adapter["enabled"] = True
+
+
+def _is_planner_scalable_worker_service(
+    service_name: str,
+    service_config: dict,
+    target_subcomponents: set[str],
+    planner_mode: str,
+    untyped_worker_count: int,
+) -> bool:
+    if service_config.get("componentType") != "worker":
+        return False
+
+    sub_component_type = service_config.get("subComponentType")
+    if sub_component_type:
+        return sub_component_type in target_subcomponents
+
+    inferred_type = _infer_subcomponent_from_service_name(service_name)
+    if inferred_type is not None:
+        return inferred_type in target_subcomponents
+
+    # Some agg templates have one generic worker name and no subComponentType.
+    return planner_mode == "agg" and untyped_worker_count == 1
+
+
+def _planner_scaling_subcomponents(planner_mode: str) -> set[str]:
+    if planner_mode == "prefill":
+        return {"prefill"}
+    if planner_mode in {"decode", "agg"}:
+        return {"decode"}
+    if planner_mode == "disagg":
+        return {"prefill", "decode"}
+    return set()
+
+
+def _infer_subcomponent_from_service_name(service_name: str) -> Optional[str]:
+    normalized = service_name.lower()
+    if "prefill" in normalized:
+        return "prefill"
+    if "decode" in normalized:
+        return "decode"
+    return None
 
 
 def _mocker_aic_worker_picks(

--- a/components/src/dynamo/profiler/utils/dgd_generation.py
+++ b/components/src/dynamo/profiler/utils/dgd_generation.py
@@ -307,7 +307,12 @@ def _is_planner_scalable_worker_service(
         return inferred_type in target_subcomponents
 
     # Some agg templates have one generic worker name and no subComponentType.
-    return planner_mode == "agg" and untyped_worker_count == 1
+    # Mark it as decode so the Kubernetes planner can rediscover the target.
+    if planner_mode == "agg" and untyped_worker_count == 1:
+        service_config["subComponentType"] = "decode"
+        return True
+
+    return False
 
 
 def _planner_scaling_subcomponents(planner_mode: str) -> set[str]:

--- a/components/src/dynamo/profiler/utils/dgd_generation.py
+++ b/components/src/dynamo/profiler/utils/dgd_generation.py
@@ -304,7 +304,10 @@ def _is_planner_scalable_worker_service(
 
     inferred_type = _infer_subcomponent_from_service_name(service_name)
     if inferred_type is not None:
-        return inferred_type in target_subcomponents
+        if inferred_type in target_subcomponents:
+            service_config["subComponentType"] = inferred_type
+            return True
+        return False
 
     # Some agg templates have one generic worker name and no subComponentType.
     # Mark it as decode so the Kubernetes planner can rediscover the target.


### PR DESCRIPTION
## Summary
- Fixes DGDR-generated Planner deployments missing worker `scalingAdapter.enabled`.
- Scopes DGDSA creation to the workers the non-advisory Planner actually manages by mode.
- Adds coverage for disagg/prefill/decode/agg, advisory mode, existing config, and service-name fallback.

Fixes #6491
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9450" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Worker services now automatically enable scaling support when using the planner feature (except in advisory mode).

* **Tests**
  * Added comprehensive test coverage for worker scaling adapter configuration across different planner modes and scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9450)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->