### PR TITLE
ci: fold unified-test jobs into framework test jobs

### DIFF
--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -209,49 +209,14 @@ jobs:
       platform: '["amd64", "arm64"]' # arm64 for CPU tests, single GPU tests are skipped
       enable_coverage: true
       run_cpu_only_tests: true
-      cpu_only_test_markers: vllm and gpu_0 and not unified
-      gpu_test_markers: vllm and gpu_1 and not unified
+      cpu_only_test_markers: vllm and gpu_0
+      gpu_test_markers: vllm and gpu_1
       gpu_test_timeout_minutes: 240
       # Profiled tests run in the parallel stage; unprofiled fall through to sequential.
       # 24 GiB admits all currently profiled vLLM tests (max is ~20.4 GiB) on a 48 GiB GPU.
       run_gpu_parallel_tests: true
       gpu_parallel_max_vram_gib: '24'
       source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
-    secrets: inherit
-
-  vllm-unified-test:
-    name: vllm-runtime # Share UI group with other vllm jobs
-    needs: [vllm-build]
-    uses: ./.github/workflows/shared-test.yml
-    with:
-      test_suite_name: vllm
-      test_type: Unified Test
-      amd_runner: prod-tester-amd-gpu-v2
-      target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
-      cuda_version: '["12.9", "13.0"]'
-      platform: '["amd64"]' # Unified tests are GPU-only
-      run_sanity_check: false
-      run_cpu_only_tests: false
-      gpu_test_markers: vllm and gpu_1 and unified
-      gpu_test_timeout_minutes: 60
-    secrets: inherit
-
-  sample-unified-test:
-    name: sample-runtime # New UI group for sample-backend jobs
-    needs: [vllm-build]
-    uses: ./.github/workflows/shared-test.yml
-    with:
-      test_suite_name: sample
-      test_type: Unified Test
-      amd_runner: prod-tester-amd-v2
-      target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
-      cuda_version: '["12.9"]' # Sample is image-agnostic; one entry is enough
-      platform: '["amd64"]'
-      run_sanity_check: false
-      run_cpu_only_tests: true
-      cpu_only_test_markers: gpu_0 and unified
-      cpu_only_test_timeout_minutes: 30
-      run_gpu_tests: false
     secrets: inherit
 
   vllm-multi-gpu-test:
@@ -268,7 +233,7 @@ jobs:
       platform: '["amd64"]' # No ARM GPUs available
       enable_coverage: true
       run_sanity_check: false
-      gpu_test_markers: vllm and (gpu_2 or gpu_4) and not unified
+      gpu_test_markers: vllm and (gpu_2 or gpu_4)
       gpu_test_timeout_minutes: 45
       source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
     secrets: inherit
@@ -287,8 +252,8 @@ jobs:
       platform: '["amd64", "arm64"]' # arm64 for CPU tests, single GPU tests are skipped
       enable_coverage: true
       run_cpu_only_tests: true
-      cpu_only_test_markers: sglang and gpu_0 and not unified
-      gpu_test_markers: sglang and gpu_1 and not unified
+      cpu_only_test_markers: sglang and gpu_0
+      gpu_test_markers: sglang and gpu_1
       gpu_test_timeout_minutes: 240
       # Profiled tests run in the VRAM-aware GPU stage; unprofiled fall through to sequential.
       # Current single-GPU runners are 24 GiB, so this cap admits the profiled SGLang pool
@@ -296,23 +261,6 @@ jobs:
       run_gpu_parallel_tests: true
       gpu_parallel_max_vram_gib: '24'
       source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
-    secrets: inherit
-
-  sglang-unified-test:
-    name: sglang-runtime # Share UI group with other sglang jobs
-    needs: [sglang-build]
-    uses: ./.github/workflows/shared-test.yml
-    with:
-      test_suite_name: sglang
-      test_type: Unified Test
-      amd_runner: prod-tester-amd-gpu-v2
-      target_tag_plain: ${{ needs.sglang-build.outputs.target_tag_plain }}
-      cuda_version: '["12.9", "13.0"]'
-      platform: '["amd64"]' # Unified tests are GPU-only
-      run_sanity_check: false
-      run_cpu_only_tests: false
-      gpu_test_markers: sglang and gpu_1 and unified
-      gpu_test_timeout_minutes: 60
     secrets: inherit
 
   sglang-multi-gpu-test:
@@ -329,7 +277,7 @@ jobs:
       platform: '["amd64"]' # No ARM GPUs available
       enable_coverage: true
       run_sanity_check: false
-      gpu_test_markers: sglang and (gpu_2 or gpu_4) and not unified
+      gpu_test_markers: sglang and (gpu_2 or gpu_4)
       gpu_test_timeout_minutes: 45
       source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
     secrets: inherit
@@ -348,8 +296,8 @@ jobs:
       platform: '["amd64", "arm64"]' # arm64 for CPU tests, single GPU tests are skipped
       enable_coverage: true
       run_cpu_only_tests: true
-      cpu_only_test_markers: trtllm and gpu_0 and not unified
-      gpu_test_markers: trtllm and gpu_1 and not unified
+      cpu_only_test_markers: trtllm and gpu_0
+      gpu_test_markers: trtllm and gpu_1
       gpu_test_timeout_minutes: 240
       # Profiled tests run in the VRAM-aware GPU stage; unprofiled fall through to sequential.
       # Current single-GPU runners are 24 GiB, so this cap admits the profiled TRT-LLM pool
@@ -357,23 +305,6 @@ jobs:
       run_gpu_parallel_tests: true
       gpu_parallel_max_vram_gib: '24'
       source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
-    secrets: inherit
-
-  trtllm-unified-test:
-    name: trtllm-runtime # Share UI group with other trtllm jobs
-    needs: [trtllm-build]
-    uses: ./.github/workflows/shared-test.yml
-    with:
-      test_suite_name: trtllm
-      test_type: Unified Test
-      amd_runner: prod-tester-amd-gpu-v2
-      target_tag_plain: ${{ needs.trtllm-build.outputs.target_tag_plain }}
-      cuda_version: '["13.1"]'
-      platform: '["amd64"]' # Unified tests are GPU-only
-      run_sanity_check: false
-      run_cpu_only_tests: false
-      gpu_test_markers: trtllm and gpu_1 and unified
-      gpu_test_timeout_minutes: 60
     secrets: inherit
 
   trtllm-multi-gpu-test:
@@ -390,7 +321,7 @@ jobs:
       platform: '["amd64"]' # No ARM GPUs available
       enable_coverage: true
       run_sanity_check: false
-      gpu_test_markers: trtllm and (gpu_2 or gpu_4) and not unified
+      gpu_test_markers: trtllm and (gpu_2 or gpu_4)
       gpu_test_timeout_minutes: 45
       source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
     secrets: inherit
@@ -527,7 +458,7 @@ jobs:
   coverage-report:
     name: Generate Coverage Report
     runs-on: ubuntu-latest
-    needs: [vllm-test, vllm-unified-test, vllm-multi-gpu-test, sample-unified-test, sglang-test, sglang-unified-test, sglang-multi-gpu-test, trtllm-test, trtllm-unified-test, trtllm-multi-gpu-test, rust-tests]
+    needs: [vllm-test, vllm-multi-gpu-test, sglang-test, sglang-multi-gpu-test, trtllm-test, trtllm-multi-gpu-test, rust-tests]
     if: always()
     permissions:
       contents: read
@@ -751,7 +682,7 @@ jobs:
     name: Notify Slack
     runs-on: prod-default-v2
     if: always()
-    needs: [vllm-test, vllm-unified-test, vllm-multi-gpu-test, sample-unified-test, sglang-test, sglang-unified-test, sglang-multi-gpu-test, trtllm-test, trtllm-unified-test, trtllm-multi-gpu-test, rust-tests]
+    needs: [vllm-test, vllm-multi-gpu-test, sglang-test, sglang-multi-gpu-test, trtllm-test, trtllm-multi-gpu-test, rust-tests]
     permissions:
       contents: read
     steps:

--- a/.github/workflows/post-merge-ci.yml
+++ b/.github/workflows/post-merge-ci.yml
@@ -326,49 +326,14 @@ jobs:
       cuda_version: '["12.9", "13.0"]'
       platform: '["amd64", "arm64"]' # arm64 for CPU tests, single GPU tests are skipped
       run_cpu_only_tests: true
-      cpu_only_test_markers: '(pre_merge or post_merge) and vllm and gpu_0 and not unified'
-      gpu_test_markers: '(pre_merge or post_merge) and vllm and gpu_1 and not unified'
+      cpu_only_test_markers: '(pre_merge or post_merge) and vllm and gpu_0'
+      gpu_test_markers: '(pre_merge or post_merge) and vllm and gpu_1'
       gpu_test_timeout_minutes: 120
       # Profiled tests (those carrying @pytest.mark.profiled_vram_gib(N)) run concurrently in
       # the parallel stage; the rest fall through to the sequential stage. 24 GiB admits all
       # currently profiled vLLM tests (max is ~20.4 GiB) on a 48 GiB GPU.
       run_gpu_parallel_tests: true
       gpu_parallel_max_vram_gib: '24'
-    secrets: inherit
-
-  vllm-unified-test:
-    name: vllm-runtime # Share UI group with other vllm jobs
-    needs: [vllm-build]
-    uses: ./.github/workflows/shared-test.yml
-    with:
-      test_suite_name: vllm
-      test_type: Unified Test
-      amd_runner: prod-tester-amd-gpu-v2
-      target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
-      cuda_version: '["12.9", "13.0"]'
-      platform: '["amd64"]' # Unified tests are GPU-only
-      run_sanity_check: false
-      run_cpu_only_tests: false
-      gpu_test_markers: '(pre_merge or post_merge) and vllm and gpu_1 and unified'
-      gpu_test_timeout_minutes: 45
-    secrets: inherit
-
-  sample-unified-test:
-    name: sample-runtime # New UI group for sample-backend jobs
-    needs: [vllm-build]
-    uses: ./.github/workflows/shared-test.yml
-    with:
-      test_suite_name: sample
-      test_type: Unified Test
-      amd_runner: prod-tester-amd-v2
-      target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
-      cuda_version: '["12.9"]' # Sample is image-agnostic; one entry is enough
-      platform: '["amd64"]'
-      run_sanity_check: false
-      run_cpu_only_tests: true
-      cpu_only_test_markers: '(pre_merge or post_merge) and gpu_0 and unified'
-      cpu_only_test_timeout_minutes: 30
-      run_gpu_tests: false
     secrets: inherit
 
   vllm-multi-gpu-test:
@@ -383,7 +348,7 @@ jobs:
       cuda_version: '["12.9", "13.0"]'
       platform: '["amd64"]' # No ARM GPUs available
       run_sanity_check: false
-      gpu_test_markers: '(pre_merge or post_merge) and vllm and (gpu_2 or gpu_4) and not unified'
+      gpu_test_markers: '(pre_merge or post_merge) and vllm and (gpu_2 or gpu_4)'
       gpu_test_timeout_minutes: 60
     secrets: inherit
 
@@ -415,31 +380,14 @@ jobs:
       cuda_version: '["12.9", "13.0"]'
       platform: '["amd64", "arm64"]' # arm64 for CPU tests, single GPU tests are skipped
       run_cpu_only_tests: true
-      cpu_only_test_markers: '(pre_merge or post_merge) and sglang and gpu_0 and not unified'
-      gpu_test_markers: '(pre_merge or post_merge) and sglang and gpu_1 and not unified'
+      cpu_only_test_markers: '(pre_merge or post_merge) and sglang and gpu_0'
+      gpu_test_markers: '(pre_merge or post_merge) and sglang and gpu_1'
       gpu_test_timeout_minutes: 120
       # Profiled tests run in the VRAM-aware GPU stage; unprofiled fall through to sequential.
       # Current single-GPU runners are 24 GiB, so this cap admits the profiled SGLang pool
       # while yielding one auto slot today. Larger runners will get more slots from the same markers.
       run_gpu_parallel_tests: true
       gpu_parallel_max_vram_gib: '24'
-    secrets: inherit
-
-  sglang-unified-test:
-    name: sglang-runtime # Share UI group with other sglang jobs
-    needs: [sglang-build]
-    uses: ./.github/workflows/shared-test.yml
-    with:
-      test_suite_name: sglang
-      test_type: Unified Test
-      amd_runner: prod-tester-amd-gpu-v2
-      target_tag_plain: ${{ needs.sglang-build.outputs.target_tag_plain }}
-      cuda_version: '["12.9", "13.0"]'
-      platform: '["amd64"]' # Unified tests are GPU-only
-      run_sanity_check: false
-      run_cpu_only_tests: false
-      gpu_test_markers: '(pre_merge or post_merge) and sglang and gpu_1 and unified'
-      gpu_test_timeout_minutes: 45
     secrets: inherit
 
   sglang-multi-gpu-test:
@@ -454,7 +402,7 @@ jobs:
       cuda_version: '["12.9", "13.0"]'
       platform: '["amd64"]' # No ARM GPUs available
       run_sanity_check: false
-      gpu_test_markers: '(pre_merge or post_merge) and sglang and (gpu_2 or gpu_4) and not unified'
+      gpu_test_markers: '(pre_merge or post_merge) and sglang and (gpu_2 or gpu_4)'
       gpu_test_timeout_minutes: 60
     secrets: inherit
 
@@ -470,31 +418,14 @@ jobs:
       cuda_version: '["13.1"]'
       platform: '["amd64", "arm64"]' # arm64 for CPU tests, single GPU tests are skipped
       run_cpu_only_tests: true
-      cpu_only_test_markers: '(pre_merge or post_merge) and trtllm and gpu_0 and not unified'
-      gpu_test_markers: '(pre_merge or post_merge) and trtllm and gpu_1 and not unified'
+      cpu_only_test_markers: '(pre_merge or post_merge) and trtllm and gpu_0'
+      gpu_test_markers: '(pre_merge or post_merge) and trtllm and gpu_1'
       gpu_test_timeout_minutes: 120
       # Profiled tests run in the VRAM-aware GPU stage; unprofiled fall through to sequential.
       # Current single-GPU runners are 24 GiB, so this cap admits the profiled TRT-LLM pool
       # while yielding one auto slot today. Larger runners will get more slots from the same markers.
       run_gpu_parallel_tests: true
       gpu_parallel_max_vram_gib: '24'
-    secrets: inherit
-
-  trtllm-unified-test:
-    name: trtllm-runtime # Share UI group with other trtllm jobs
-    needs: [trtllm-build]
-    uses: ./.github/workflows/shared-test.yml
-    with:
-      test_suite_name: trtllm
-      test_type: Unified Test
-      amd_runner: prod-tester-amd-gpu-v2
-      target_tag_plain: ${{ needs.trtllm-build.outputs.target_tag_plain }}
-      cuda_version: '["13.1"]'
-      platform: '["amd64"]' # Unified tests are GPU-only
-      run_sanity_check: false
-      run_cpu_only_tests: false
-      gpu_test_markers: '(pre_merge or post_merge) and trtllm and gpu_1 and unified'
-      gpu_test_timeout_minutes: 45
     secrets: inherit
 
   trtllm-multi-gpu-test:
@@ -509,7 +440,7 @@ jobs:
       cuda_version: '["13.1"]'
       platform: '["amd64"]' # No ARM GPUs available
       run_sanity_check: false
-      gpu_test_markers: '(pre_merge or post_merge) and trtllm and (gpu_2 or gpu_4) and not unified'
+      gpu_test_markers: '(pre_merge or post_merge) and trtllm and (gpu_2 or gpu_4)'
       gpu_test_timeout_minutes: 60
     secrets: inherit
 
@@ -618,12 +549,11 @@ jobs:
 
   vllm-copy-to-acr:
     name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
-    needs: [vllm-build, vllm-test, vllm-unified-test]
+    needs: [vllm-build, vllm-test]
     if: |
       always() &&
       needs.vllm-build.result == 'success' &&
-      (needs.vllm-test.result == 'success' || needs.vllm-test.result == 'skipped') &&
-      (needs.vllm-unified-test.result == 'success' || needs.vllm-unified-test.result == 'skipped')
+      (needs.vllm-test.result == 'success' || needs.vllm-test.result == 'skipped')
     uses: ./.github/workflows/shared-copy.yml
     with:
       target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
@@ -648,12 +578,11 @@ jobs:
 
   sglang-copy-to-acr:
     name: sglang-runtime # This name overlaps with other sglang jobs to group them in the UI
-    needs: [sglang-build, sglang-test, sglang-unified-test]
+    needs: [sglang-build, sglang-test]
     if: |
       always() &&
       needs.sglang-build.result == 'success' &&
-      (needs.sglang-test.result == 'success' || needs.sglang-test.result == 'skipped') &&
-      (needs.sglang-unified-test.result == 'success' || needs.sglang-unified-test.result == 'skipped')
+      (needs.sglang-test.result == 'success' || needs.sglang-test.result == 'skipped')
     uses: ./.github/workflows/shared-copy.yml
     with:
       target_tag_plain: ${{ needs.sglang-build.outputs.target_tag_plain }}
@@ -678,12 +607,11 @@ jobs:
 
   trtllm-copy-to-acr:
     name: trtllm-runtime # This name overlaps with other trtllm jobs to group them in the UI
-    needs: [trtllm-build, trtllm-test, trtllm-unified-test]
+    needs: [trtllm-build, trtllm-test]
     if: |
       always() &&
       needs.trtllm-build.result == 'success' &&
-      (needs.trtllm-test.result == 'success' || needs.trtllm-test.result == 'skipped') &&
-      (needs.trtllm-unified-test.result == 'success' || needs.trtllm-unified-test.result == 'skipped')
+      (needs.trtllm-test.result == 'success' || needs.trtllm-test.result == 'skipped')
     uses: ./.github/workflows/shared-copy.yml
     with:
       target_tag_plain: ${{ needs.trtllm-build.outputs.target_tag_plain }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -58,22 +58,18 @@ jobs:
       - vllm-build
       - vllm-dev-build
       - vllm-test
-      - vllm-unified-test
       - vllm-multi-gpu-test
       - vllm-copy-to-acr
       - sglang-build
       - sglang-dev-build
       - sglang-test
-      - sglang-unified-test
       - sglang-multi-gpu-test
       - sglang-copy-to-acr
       - trtllm-build
       - trtllm-dev-build
       - trtllm-test
-      - trtllm-unified-test
       - trtllm-multi-gpu-test
       - trtllm-copy-to-acr
-      - sample-unified-test
       - planner-build
       - planner-test
       - frontend-build
@@ -185,7 +181,7 @@ jobs:
   vllm-build:
     name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
     needs: [changed-files]
-    # `sample` is here because sample-unified-test piggybacks on this image.
+    # `sample` is here because sample tests piggyback on this image and run as part of vllm-test.
     if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.vllm == 'true' || needs.changed-files.outputs.deploy == 'true' || needs.changed-files.outputs.sample == 'true'
     uses: ./.github/workflows/shared-build-image.yml
     with:
@@ -305,7 +301,7 @@ jobs:
   vllm-test:
     name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
     needs: [changed-files, vllm-build]
-    if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.vllm == 'true' || needs.changed-files.outputs.deploy == 'true'
+    if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.vllm == 'true' || needs.changed-files.outputs.deploy == 'true' || needs.changed-files.outputs.sample == 'true'
     uses: ./.github/workflows/shared-test.yml
     with:
       test_suite_name: vllm
@@ -315,31 +311,13 @@ jobs:
       cuda_version: '["12.9", "13.0"]'
       platform: '["amd64", "arm64"]' # arm64 for CPU tests, single GPU tests are skipped
       run_cpu_only_tests: true
-      cpu_only_test_markers: pre_merge and vllm and gpu_0 and not unified
-      gpu_test_markers: pre_merge and vllm and gpu_1 and not unified
+      cpu_only_test_markers: pre_merge and vllm and gpu_0
+      gpu_test_markers: pre_merge and vllm and gpu_1
       gpu_test_timeout_minutes: 45
       # Profiled tests run in the parallel stage; unprofiled fall through to sequential.
       # 24 GiB admits all currently profiled vLLM tests (max is ~20.4 GiB) on a 48 GiB GPU.
       run_gpu_parallel_tests: true
       gpu_parallel_max_vram_gib: '24'
-    secrets: inherit
-
-  vllm-unified-test:
-    name: vllm-runtime # Share UI group with other vllm jobs
-    needs: [changed-files, vllm-build]
-    if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.vllm == 'true' || needs.changed-files.outputs.deploy == 'true'
-    uses: ./.github/workflows/shared-test.yml
-    with:
-      test_suite_name: vllm
-      test_type: Unified Test
-      amd_runner: prod-tester-amd-gpu-v2
-      target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
-      cuda_version: '["12.9", "13.0"]'
-      platform: '["amd64"]' # Unified tests are GPU-only
-      run_sanity_check: false
-      run_cpu_only_tests: false
-      gpu_test_markers: pre_merge and vllm and gpu_1 and unified
-      gpu_test_timeout_minutes: 30
     secrets: inherit
 
   vllm-multi-gpu-test:
@@ -355,7 +333,7 @@ jobs:
       cuda_version: '["12.9", "13.0"]'
       platform: '["amd64"]' # No ARM GPUs available
       run_sanity_check: false
-      gpu_test_markers: pre_merge and vllm and (gpu_2 or gpu_4) and not unified
+      gpu_test_markers: pre_merge and vllm and (gpu_2 or gpu_4)
       gpu_test_timeout_minutes: 60
     secrets: inherit
 
@@ -372,31 +350,13 @@ jobs:
       cuda_version: '["12.9", "13.0"]'
       platform: '["amd64", "arm64"]' # arm64 for CPU tests, single GPU tests are skipped
       run_cpu_only_tests: true
-      cpu_only_test_markers: pre_merge and sglang and gpu_0 and not unified
-      gpu_test_markers: pre_merge and sglang and gpu_1 and not unified
+      cpu_only_test_markers: pre_merge and sglang and gpu_0
+      gpu_test_markers: pre_merge and sglang and gpu_1
       # Profiled tests run in the VRAM-aware GPU stage; unprofiled fall through to sequential.
       # Current single-GPU runners are 24 GiB, so this cap admits the profiled SGLang pool
       # while yielding one auto slot today. Larger runners will get more slots from the same markers.
       run_gpu_parallel_tests: true
       gpu_parallel_max_vram_gib: '24'
-    secrets: inherit
-
-  sglang-unified-test:
-    name: sglang-runtime # Share UI group with other sglang jobs
-    needs: [changed-files, sglang-build]
-    if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.sglang == 'true' || needs.changed-files.outputs.deploy == 'true'
-    uses: ./.github/workflows/shared-test.yml
-    with:
-      test_suite_name: sglang
-      test_type: Unified Test
-      amd_runner: prod-tester-amd-gpu-v2
-      target_tag_plain: ${{ needs.sglang-build.outputs.target_tag_plain }}
-      cuda_version: '["12.9", "13.0"]'
-      platform: '["amd64"]' # Unified tests are GPU-only
-      run_sanity_check: false
-      run_cpu_only_tests: false
-      gpu_test_markers: pre_merge and sglang and gpu_1 and unified
-      gpu_test_timeout_minutes: 30
     secrets: inherit
 
   sglang-multi-gpu-test:
@@ -412,7 +372,7 @@ jobs:
       cuda_version: '["12.9", "13.0"]'
       platform: '["amd64"]' # No ARM GPUs available
       run_sanity_check: false
-      gpu_test_markers: pre_merge and sglang and (gpu_2 or gpu_4) and not unified
+      gpu_test_markers: pre_merge and sglang and (gpu_2 or gpu_4)
       gpu_test_timeout_minutes: 60
     secrets: inherit
 
@@ -429,31 +389,13 @@ jobs:
       cuda_version: '["13.1"]'
       platform: '["amd64", "arm64"]' # arm64 for CPU tests, single GPU tests are skipped
       run_cpu_only_tests: true
-      cpu_only_test_markers: pre_merge and trtllm and gpu_0 and not unified
-      gpu_test_markers: pre_merge and trtllm and gpu_1 and not unified
+      cpu_only_test_markers: pre_merge and trtllm and gpu_0
+      gpu_test_markers: pre_merge and trtllm and gpu_1
       # Profiled tests run in the VRAM-aware GPU stage; unprofiled fall through to sequential.
       # Current single-GPU runners are 24 GiB, so this cap admits the profiled TRT-LLM pool
       # while yielding one auto slot today. Larger runners will get more slots from the same markers.
       run_gpu_parallel_tests: true
       gpu_parallel_max_vram_gib: '24'
-    secrets: inherit
-
-  trtllm-unified-test:
-    name: trtllm-runtime # Share UI group with other trtllm jobs
-    needs: [changed-files, trtllm-build]
-    if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.trtllm == 'true' || needs.changed-files.outputs.deploy == 'true'
-    uses: ./.github/workflows/shared-test.yml
-    with:
-      test_suite_name: trtllm
-      test_type: Unified Test
-      amd_runner: prod-tester-amd-gpu-v2
-      target_tag_plain: ${{ needs.trtllm-build.outputs.target_tag_plain }}
-      cuda_version: '["13.1"]'
-      platform: '["amd64"]' # Unified tests are GPU-only
-      run_sanity_check: false
-      run_cpu_only_tests: false
-      gpu_test_markers: pre_merge and trtllm and gpu_1 and unified
-      gpu_test_timeout_minutes: 30
     secrets: inherit
 
   trtllm-multi-gpu-test:
@@ -469,30 +411,8 @@ jobs:
       cuda_version: '["13.1"]'
       platform: '["amd64"]' # No ARM GPUs available
       run_sanity_check: false
-      gpu_test_markers: pre_merge and trtllm and (gpu_2 or gpu_4) and not unified
+      gpu_test_markers: pre_merge and trtllm and (gpu_2 or gpu_4)
       gpu_test_timeout_minutes: 60
-    secrets: inherit
-
-  # Sample backend is framework-agnostic CPU-only; piggybacks on the vllm image
-  # (which has the dynamo runtime it needs). Runs the unified-backend sample test
-  # in its own job so it doesn't share a slot with GPU tests.
-  sample-unified-test:
-    name: sample-runtime # New UI group for sample-backend jobs
-    needs: [changed-files, vllm-build]
-    if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.vllm == 'true' || needs.changed-files.outputs.deploy == 'true' || needs.changed-files.outputs.sample == 'true'
-    uses: ./.github/workflows/shared-test.yml
-    with:
-      test_suite_name: sample
-      test_type: Unified Test
-      amd_runner: prod-tester-amd-v2
-      target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
-      cuda_version: '["12.9"]' # Sample is image-agnostic; one entry is enough
-      platform: '["amd64"]'
-      run_sanity_check: false
-      run_cpu_only_tests: true
-      cpu_only_test_markers: pre_merge and gpu_0 and unified
-      cpu_only_test_timeout_minutes: 15
-      run_gpu_tests: false
     secrets: inherit
 
   planner-test:
@@ -613,13 +533,12 @@ jobs:
 
   vllm-copy-to-acr:
     name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
-    needs: [changed-files, vllm-build, vllm-test, vllm-unified-test]
+    needs: [changed-files, vllm-build, vllm-test]
     if: |
       always() && !cancelled() &&
       (needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.vllm == 'true' || needs.changed-files.outputs.deploy == 'true') &&
       needs.vllm-build.result == 'success' &&
-      (needs.vllm-test.result == 'success' || needs.vllm-test.result == 'skipped') &&
-      (needs.vllm-unified-test.result == 'success' || needs.vllm-unified-test.result == 'skipped')
+      (needs.vllm-test.result == 'success' || needs.vllm-test.result == 'skipped')
     uses: ./.github/workflows/shared-copy.yml
     with:
       target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
@@ -630,13 +549,12 @@ jobs:
 
   sglang-copy-to-acr:
     name: sglang-runtime # This name overlaps with other sglang jobs to group them in the UI
-    needs: [changed-files, sglang-build, sglang-test, sglang-unified-test]
+    needs: [changed-files, sglang-build, sglang-test]
     if: |
       always() && !cancelled() &&
       (needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.sglang == 'true' || needs.changed-files.outputs.deploy == 'true') &&
       needs.sglang-build.result == 'success' &&
-      (needs.sglang-test.result == 'success' || needs.sglang-test.result == 'skipped') &&
-      (needs.sglang-unified-test.result == 'success' || needs.sglang-unified-test.result == 'skipped')
+      (needs.sglang-test.result == 'success' || needs.sglang-test.result == 'skipped')
     uses: ./.github/workflows/shared-copy.yml
     with:
       target_tag_plain: ${{ needs.sglang-build.outputs.target_tag_plain }}
@@ -647,13 +565,12 @@ jobs:
 
   trtllm-copy-to-acr:
     name: trtllm-runtime # This name overlaps with other trtllm jobs to group them in the UI
-    needs: [changed-files, trtllm-build, trtllm-test, trtllm-unified-test]
+    needs: [changed-files, trtllm-build, trtllm-test]
     if: |
       always() && !cancelled() &&
       (needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.trtllm == 'true' || needs.changed-files.outputs.deploy == 'true') &&
       needs.trtllm-build.result == 'success' &&
-      (needs.trtllm-test.result == 'success' || needs.trtllm-test.result == 'skipped') &&
-      (needs.trtllm-unified-test.result == 'success' || needs.trtllm-unified-test.result == 'skipped')
+      (needs.trtllm-test.result == 'success' || needs.trtllm-test.result == 'skipped')
     uses: ./.github/workflows/shared-copy.yml
     with:
       target_tag_plain: ${{ needs.trtllm-build.outputs.target_tag_plain }}
@@ -764,16 +681,12 @@ jobs:
       - operator
       - planner-test
       - vllm-copy-to-acr
-      - vllm-unified-test
       - vllm-multi-gpu-test
       - sglang-copy-to-acr
-      - sglang-unified-test
       - sglang-multi-gpu-test
       - trtllm-copy-to-acr
-      - trtllm-unified-test
       - trtllm-multi-gpu-test
       - dynamo-pipeline
-      - sample-unified-test
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -800,20 +713,16 @@ jobs:
       - operator
       - vllm-build
       - vllm-test
-      - vllm-unified-test
       - vllm-multi-gpu-test
       - vllm-copy-to-acr
       - sglang-build
       - sglang-test
-      - sglang-unified-test
       - sglang-multi-gpu-test
       - sglang-copy-to-acr
       - trtllm-build
       - trtllm-test
-      - trtllm-unified-test
       - trtllm-multi-gpu-test
       - trtllm-copy-to-acr
-      - sample-unified-test
       - deploy-test-vllm
       - deploy-test-sglang
       - deploy-test-trtllm

--- a/tests/serve/test_sample.py
+++ b/tests/serve/test_sample.py
@@ -31,6 +31,7 @@ sample_configs = {
             pytest.mark.timeout(300),
             pytest.mark.pre_merge,
             pytest.mark.unified,
+            pytest.mark.vllm,
         ],
         model="Qwen/Qwen3-0.6B",
         frontend_port=DefaultPort.FRONTEND.value,


### PR DESCRIPTION
The dedicated vllm/sglang/trtllm/sample-unified-test jobs in pr.yaml, post-merge-ci.yml, and nightly-ci.yml duplicated their *-test siblings: same image, same runners, same suite — only the marker expression flipped between `and unified` and `and not unified`.

Remove the four *-unified-test jobs in each workflow and drop the `and not unified` exclusion from the surviving framework + multi-gpu jobs so unified-marked tests run as part of the existing test passes.

Tag tests/serve/test_sample.py with pytest.mark.vllm so the sample suite is picked up by vllm-test's CPU stage (it already piggybacks on the vllm image). Extend vllm-test's if: to include the sample changed-files output so sample-only PRs still exercise it.

Prune the now-stale references from backend-status-check, the *-copy-to-acr needs/if blocks, clean-k8s-builder, allure-report, and the nightly aggregation lists.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/testing infrastructure by removing unified test job variants and simplifying marker-based test filtering across nightly, post-merge, and PR workflows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9451)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->