### PR TITLE
test(mm-router): move new MM-router tests to post_merge

### DIFF
--- a/tests/mm_router/test_router_rust_mm_frontend_decode_e2e.py
+++ b/tests/mm_router/test_router_rust_mm_frontend_decode_e2e.py
@@ -53,7 +53,7 @@ BLOCK_SIZE = 16
 NAMESPACE = "router-rust-mm-fed"
 
 pytestmark = [
-    pytest.mark.pre_merge,
+    pytest.mark.post_merge,
     pytest.mark.e2e,
     pytest.mark.vllm,
     pytest.mark.multimodal,

--- a/tests/mm_router/test_router_rust_mm_router_e2e.py
+++ b/tests/mm_router/test_router_rust_mm_router_e2e.py
@@ -51,7 +51,7 @@ BLOCK_SIZE = 16
 NAMESPACE = "router-rust-mm"
 
 pytestmark = [
-    pytest.mark.pre_merge,
+    pytest.mark.post_merge,
     pytest.mark.e2e,
     pytest.mark.vllm,
     pytest.mark.multimodal,

--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -102,10 +102,10 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
             ),
             # `agg_router` exercises agg_multimodal_router.sh: Rust frontend
             # with the `lightseek-mm` feature, MM-aware KV routing, multi-worker.
-            # Smoke-level on pre_merge so regressions to the script's plumbing
+            # Smoke-level on post_merge so regressions to the script's plumbing
             # (worker boot order, ZMQ KV events, MM-routing build) surface in
-            # gating CI before they merge. The fine-grained routing-correctness
-            # assertions live in tests/mm_router/test_router_rust_mm_router_e2e.py.
+            # CI. The fine-grained routing-correctness assertions live in
+            # tests/mm_router/test_router_rust_mm_router_e2e.py.
             #
             # The payload sends two identical MM requests and asserts the
             # second sees cached_tokens > 0 — proves the warm worker reused
@@ -114,7 +114,7 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
             # text-prefix only, both requests would still succeed but the
             # second's cached_tokens would be 0 and this case would fail.
             "agg_router": TopologyConfig(
-                marks=[pytest.mark.pre_merge],
+                marks=[pytest.mark.post_merge],
                 timeout_s=400,
                 profiled_vram_gib=18.7,
                 requested_vllm_kv_cache_bytes=1_719_075_000,
@@ -124,13 +124,13 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
             # The chat-processor variant of the MM-aware router: same routing
             # architecture, but the frontend uses --dyn-chat-processor=vllm
             # (Python preprocessor) instead of the Rust+lightseek path. Kept
-            # on pre_merge alongside the default so both entry points stay
-            # covered by gating CI; the routing assertions are equivalent.
+            # on post_merge alongside the default so both entry points stay
+            # covered by CI; the routing assertions are equivalent.
             # SINGLE_GPU=true packs both workers onto GPU 0 to match the
             # single-GPU CI environment (the chat-processor script's own
             # default is false for production multi-GPU usage).
             "agg_router_chat_processor": TopologyConfig(
-                marks=[pytest.mark.pre_merge],
+                marks=[pytest.mark.post_merge],
                 timeout_s=400,
                 profiled_vram_gib=18.7,
                 requested_vllm_kv_cache_bytes=1_719_075_000,
@@ -147,7 +147,7 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
             # CI; the content-hash correctness assertion lives in
             # tests/mm_router/test_router_rust_mm_frontend_decode_e2e.py.
             "agg_router_frontend_decode": TopologyConfig(
-                marks=[pytest.mark.pre_merge],
+                marks=[pytest.mark.post_merge],
                 timeout_s=400,
                 profiled_vram_gib=18.7,
                 requested_vllm_kv_cache_bytes=1_719_075_000,


### PR DESCRIPTION
## Summary
- Move 3 new `agg_router*` qwen3-vl-2b topologies in `tests/serve/multimodal_profiles/vllm.py` from `pre_merge` to `post_merge`.
- Move module-level `pytestmark` in `tests/mm_router/test_router_rust_mm_router_e2e.py` and `tests/mm_router/test_router_rust_mm_frontend_decode_e2e.py` from `pre_merge` to `post_merge` (covers 8 tests).

## Why
Pre-merge wall-clock grew from ~6 min to ~28 min after these were added; pre_merge already has smoke coverage of the MM-router plumbing via the existing `agg_multimodal_*` topologies. The fine-grained routing-correctness assertions still run, just in post_merge.

## Test plan
- [ ] CI pre_merge wall-clock returns to pre-addition baseline
- [ ] post_merge picks up the moved tests
- [ ] No tests get silently dropped (collection report shows expected counts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)