### PR TITLE
Fix KVBM data transfer and runtime NIXL wheel resolution

### DIFF
--- a/components/src/dynamo/vllm/tests/test_vllm_renderer_api.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_renderer_api.py
@@ -421,8 +421,7 @@ class TestVllmRendererApi:
             "events",
             "kv_transfer_params",
             "trace_headers",
-            "num_cached_tokens",
-            "num_external_computed_tokens",
+            "prefill_stats",
             "routed_experts",
             "num_nans_in_logits",
         )

--- a/container/templates/dynamo_runtime.Dockerfile
+++ b/container/templates/dynamo_runtime.Dockerfile
@@ -100,6 +100,7 @@ ENV VIRTUAL_ENV=/opt/dynamo/venv \
 ARG ENABLE_KVBM
 RUN --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sharing=shared \
     export UV_CACHE_DIR=/home/dynamo/.cache/uv && \
+    uv pip uninstall -y nixl nixl-cu12 nixl-cu13 nixl-cpu nixl-xpu || true && \
     uv pip install \
     /opt/dynamo/wheelhouse/ai_dynamo_runtime*.whl \
     /opt/dynamo/wheelhouse/ai_dynamo*any.whl \
@@ -110,13 +111,14 @@ RUN --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sh
             echo "ERROR: ENABLE_KVBM is true but no KVBM wheel found in wheelhouse" >&2; \
             exit 1; \
         fi; \
-        uv pip install "$KVBM_WHEEL"; \
+        uv pip install --no-deps "$KVBM_WHEEL"; \
     fi
 {% else %}
 # Dev/local-dev: skip dynamo wheel install (users build from source via cargo build + maturin develop).
 # Install NIXL wheel only (pre-built C++ binary, not buildable from source).
 RUN --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sharing=shared \
     export UV_CACHE_DIR=/home/dynamo/.cache/uv && \
+    uv pip uninstall -y nixl nixl-cu12 nixl-cu13 nixl-cpu nixl-xpu || true && \
     uv pip install /opt/dynamo/wheelhouse/nixl/nixl*.whl
 {% endif %}
 

--- a/container/templates/frontend.Dockerfile
+++ b/container/templates/frontend.Dockerfile
@@ -88,6 +88,7 @@ ARG ENABLE_GPU_MEMORY_SERVICE
 # In an ideal world, we'd use a mirror of PyPI for much more reliable downloads.
 RUN --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sharing=shared \
     export UV_CACHE_DIR=/home/dynamo/.cache/uv && \
+    uv pip uninstall -y nixl nixl-cu12 nixl-cu13 nixl-cpu nixl-xpu || true && \
     uv pip install \
     /opt/dynamo/wheelhouse/ai_dynamo_runtime*.whl \
     /opt/dynamo/wheelhouse/ai_dynamo*any.whl \
@@ -106,7 +107,7 @@ RUN --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sh
             echo "ERROR: ENABLE_KVBM is true but no KVBM wheel found in wheelhouse" >&2; \
             exit 1; \
         fi; \
-        uv pip install "$KVBM_WHEEL"; \
+        uv pip install --no-deps "$KVBM_WHEEL"; \
     fi && \
     cd /workspace/benchmarks && \
     export UV_GIT_LFS=1 UV_HTTP_TIMEOUT=300 UV_HTTP_RETRIES=5 && \

--- a/container/templates/trtllm_runtime.Dockerfile
+++ b/container/templates/trtllm_runtime.Dockerfile
@@ -237,6 +237,7 @@ COPY --chmod=775 --chown=dynamo:0 --from=wheel_builder /opt/dynamo/dist/*.whl /o
 ARG ENABLE_KVBM
 RUN --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sharing=shared \
     export UV_CACHE_DIR=/home/dynamo/.cache/uv && \
+    uv pip uninstall -y nixl nixl-cu12 nixl-cu13 nixl-cpu nixl-xpu || true && \
     uv pip install \
       pip \
       /opt/dynamo/wheelhouse/ai_dynamo_runtime*.whl \
@@ -248,7 +249,7 @@ RUN --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sh
             echo "ERROR: ENABLE_KVBM is true but no KVBM wheel found in wheelhouse" >&2; \
             exit 1; \
         fi; \
-        uv pip install "$KVBM_WHEEL"; \
+        uv pip install --no-deps "$KVBM_WHEEL"; \
     fi && \
     cd /workspace/benchmarks && \
     UV_GIT_LFS=1 uv pip install --no-cache . && \
@@ -261,6 +262,7 @@ RUN --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sh
 # JIT compilation on sm_100a, where cubins are not pre-compiled).
 RUN --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sharing=shared \
     export UV_CACHE_DIR=/home/dynamo/.cache/uv && \
+    uv pip uninstall -y nixl nixl-cu12 nixl-cu13 nixl-cpu nixl-xpu || true && \
     uv pip install pip /opt/dynamo/wheelhouse/nixl/nixl*.whl
 {% endif %}
 

--- a/container/templates/vllm_runtime.Dockerfile
+++ b/container/templates/vllm_runtime.Dockerfile
@@ -294,6 +294,7 @@ COPY --chmod=775 --chown=dynamo:0 --from=wheel_builder /opt/dynamo/dist/*.whl /o
 ARG ENABLE_KVBM
 RUN --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sharing=shared \
     export UV_CACHE_DIR=/home/dynamo/.cache/uv && \
+    uv pip uninstall -y nixl nixl-cu12 nixl-cu13 nixl-cpu nixl-xpu || true && \
     uv pip install \
       /opt/dynamo/wheelhouse/ai_dynamo_runtime*.whl \
       /opt/dynamo/wheelhouse/ai_dynamo*any.whl \
@@ -314,7 +315,7 @@ RUN --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sh
             echo "ERROR: ENABLE_KVBM is true but no KVBM wheel found in wheelhouse" >&2; \
             exit 1; \
         fi; \
-        uv pip install "$KVBM_WHEEL"; \
+        uv pip install --no-deps "$KVBM_WHEEL"; \
     fi && \
     cd /workspace/benchmarks && \
     export UV_GIT_LFS=1 UV_HTTP_TIMEOUT=300 UV_HTTP_RETRIES=5 && \
@@ -325,6 +326,7 @@ RUN --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sh
 # Install NIXL wheel only (pre-built C++ binary, not buildable from source).
 RUN --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sharing=shared \
     export UV_CACHE_DIR=/home/dynamo/.cache/uv && \
+    uv pip uninstall -y nixl nixl-cu12 nixl-cu13 nixl-cpu nixl-xpu || true && \
     uv pip install /opt/dynamo/wheelhouse/nixl/nixl*.whl && \
     if [ "${CUDA_VERSION%%.*}" = "13" ]; then \
         uv pip uninstall -y nixl-cu12 || true; \

--- a/lib/bindings/kvbm/python/kvbm/v2/vllm/schedulers/worker.py
+++ b/lib/bindings/kvbm/python/kvbm/v2/vllm/schedulers/worker.py
@@ -23,6 +23,7 @@ bind happens later, when the leader's `initialize_workers()` RPC drives
 from __future__ import annotations
 
 from dataclasses import dataclass
+import math
 from typing import TYPE_CHECKING, Optional
 
 import kvbm
@@ -39,32 +40,86 @@ class KvTensorLayout:
     """Semantic description of the KV cache tensor layout.
 
     Python derives this from VllmConfig (which has the model architecture)
-    so that Rust doesn't have to guess from raw tensor shapes.
+    so that Rust does not need to guess from raw tensor shapes.
 
-    For MLA models, outer_dim and inner_dim are set explicitly because Rust's
-    shape-based inference cannot distinguish the fused KV latent axis from the
-    block/page axis. For standard attention the fields are None, which tells
-    Rust to fall back to its own contiguity-based inference (already correct).
+    For both MLA and standard attention, dimensions are computed explicitly
+    from vLLM config and passed down to Rust. Tensor shape is only used for
+    sanity validation (e.g., block-axis presence / packed-tail checks).
 
     Mirrors the v1 helper in
     lib/bindings/kvbm/python/kvbm/vllm_integration/connector_worker.py.
     """
 
-    outer_dim: Optional[int]  # None = let Rust infer; 1 for MLA
-    inner_dim: Optional[int]  # None = let Rust infer; head_size for MLA
+    outer_dim: Optional[int]
+    inner_dim: Optional[int]
 
     @classmethod
     def from_vllm_config(
-        cls, shape: "torch.Size", use_mla: bool = False
+        cls,
+        vllm_config: "VllmConfig",
+        shape: "torch.Size",
+        num_device_blocks: int,
+        use_mla: bool = False,
     ) -> "KvTensorLayout":
         if use_mla:
             # MLA tensors are 3D: [num_blocks, page_size, head_size].
             # No outer_dim axis — K and V are fused into a single latent.
             return cls(outer_dim=1, inner_dim=int(shape[-1]))
-        # Standard attention: Rust already infers outer_dim/inner_dim correctly
-        # from tensor shape. Don't guess here — the block dimension can be at
-        # position 0 or 1 depending on the attention backend.
-        return cls(outer_dim=None, inner_dim=None)
+        # Standard attention:
+        # - outer_dim is K/V axis = 2
+        # - inner_dim is per-rank kv feature width
+        #
+        # vLLM API surfaces can differ by version/model family:
+        # `get_total_num_kv_heads()` may be global or already per-rank.
+        # Resolve this robustly by checking which config interpretation matches
+        # the observed packed tail in tensor shape.
+        total_kv_heads = int(vllm_config.model_config.get_total_num_kv_heads())
+        head_size = int(vllm_config.model_config.get_head_size())
+        tp_size = int(vllm_config.parallel_config.tensor_parallel_size)
+        if tp_size <= 0:
+            raise ValueError(f"Invalid tensor_parallel_size={tp_size}")
+        outer_dim = 2
+        if head_size <= 0 or total_kv_heads <= 0:
+            raise ValueError(
+                "Invalid standard attention inner_dim derived from config: "
+                f"total_num_kv_heads={total_kv_heads}, head_size={head_size}"
+            )
+
+        # Sanity checks against actual tensor shape so we fail loudly if vLLM
+        # changes layout semantics.
+        if len(shape) < 4:
+            raise ValueError(
+                "Standard attention KV tensor must have >=4 dims; "
+                f"got shape={tuple(shape)}"
+            )
+        if int(shape[0]) < num_device_blocks and int(shape[1]) < num_device_blocks:
+            raise ValueError(
+                "Cannot locate num_device_blocks in standard KV tensor shape; "
+                f"shape[:2]={tuple(shape[:2])}, num_device_blocks={num_device_blocks}"
+            )
+
+        inferred_inner_from_shape = int(math.prod(shape[3:]))
+        config_inner_candidates = [total_kv_heads * head_size]
+        if total_kv_heads % tp_size == 0:
+            config_inner_candidates.append((total_kv_heads // tp_size) * head_size)
+
+        matched_inner = None
+        for candidate in config_inner_candidates:
+            if candidate == inferred_inner_from_shape:
+                matched_inner = candidate
+                break
+
+        if matched_inner is None:
+            raise ValueError(
+                "KV layout mismatch between vLLM config and tensor shape: "
+                f"config_inner_candidates={config_inner_candidates}, "
+                f"shape_inner_dim={inferred_inner_from_shape}, "
+                f"shape={tuple(shape)}, total_num_kv_heads={total_kv_heads}, "
+                f"head_size={head_size}, tp_size={tp_size}"
+            )
+        inner_dim = matched_inner
+
+        return cls(outer_dim=outer_dim, inner_dim=inner_dim)
 
 
 # Import KvbmRuntime and ConnectorWorker from Rust bindings (requires v2 feature)
@@ -212,26 +267,64 @@ class SchedulerConnectorWorker:
                 "Hybrid models with different KV cache shapes are not supported yet."
             )
 
-        # Derive layout semantics from the vLLM model config so Rust doesn't
-        # have to guess the outer_dim/inner_dim from potentially-ambiguous
-        # tensor shapes (MLA caches are 3D without a K/V axis).
-        use_mla = getattr(self.vllm_config.model_config, "use_mla", False)
-        layout = KvTensorLayout.from_vllm_config(shape, use_mla)
-
         # Extract parameters.
-        # Standard attention: [2 (K/V), num_blocks, ...] or [num_blocks, 2, ...]
-        #   — block dim is whichever of shape[0]/shape[1] is larger.
-        # MLA: [num_blocks, page_size, head_size] — block dim is always axis 0.
-        num_device_blocks = shape[0] if use_mla else max(shape[0], shape[1])
+        # Prefer vLLM config's GPU block count; fall back to tensor-derived only
+        # when config is unavailable (older bring-up edge cases).
+        use_mla = getattr(self.vllm_config.model_config, "use_mla", False)
+        config_gpu_blocks = self.vllm_config.cache_config.num_gpu_blocks
+        if config_gpu_blocks is None or config_gpu_blocks <= 0:
+            num_device_blocks = int(shape[0] if use_mla else max(shape[0], shape[1]))
+            print(
+                "Warning: cache_config.num_gpu_blocks unavailable; "
+                f"falling back to tensor-derived num_device_blocks={num_device_blocks}"
+            )
+        else:
+            num_device_blocks = int(config_gpu_blocks)
+
+        # Derive explicit layout semantics from vLLM model config + tensor shape.
+        layout = KvTensorLayout.from_vllm_config(
+            self.vllm_config, shape, num_device_blocks, use_mla
+        )
+
         page_size = self.vllm_config.cache_config.block_size
         dtype_width_bytes = self.kvbm_config.cache_dtype_bytes()
+        if num_device_blocks <= 0:
+            raise ValueError(f"Invalid num_device_blocks={num_device_blocks}")
+        if page_size <= 0:
+            raise ValueError(f"Invalid page_size={page_size}")
+        if dtype_width_bytes <= 0:
+            raise ValueError(f"Invalid dtype_width_bytes={dtype_width_bytes}")
 
-        config_gpu_blocks = self.vllm_config.cache_config.num_gpu_blocks
-        if num_device_blocks != config_gpu_blocks:
-            print(
-                f"Warning: num_device_blocks from tensor ({num_device_blocks}) "
-                f"!= config.num_gpu_blocks ({config_gpu_blocks}). "
-                f"Using tensor-derived value."
+        if shape[0] < num_device_blocks and shape[1] < num_device_blocks:
+            raise ValueError(
+                "Cannot locate num_device_blocks in KV tensor shape; "
+                f"shape[:2]={tuple(shape[:2])}, num_gpu_blocks={num_device_blocks}"
+            )
+
+        # Strong startup contract:
+        # bytes_per_block from layout math must equal bytes_per_block implied by the
+        # concrete tensor storage. This catches subtle TP/layout drift early.
+        layer_total_bytes_from_shape = int(math.prod(shape)) * dtype_width_bytes
+        if layer_total_bytes_from_shape % num_device_blocks != 0:
+            raise ValueError(
+                "KV tensor total bytes is not divisible by num_device_blocks: "
+                f"shape={tuple(shape)}, dtype_width_bytes={dtype_width_bytes}, "
+                f"layer_total_bytes={layer_total_bytes_from_shape}, "
+                f"num_device_blocks={num_device_blocks}"
+            )
+        bytes_per_block_from_shape = layer_total_bytes_from_shape // num_device_blocks
+        bytes_per_block_from_layout = (
+            int(layout.outer_dim) * page_size * int(layout.inner_dim) * dtype_width_bytes
+        )
+        if bytes_per_block_from_shape != bytes_per_block_from_layout:
+            raise ValueError(
+                "KV bytes_per_block mismatch between tensor shape and derived layout: "
+                f"shape={tuple(shape)}, "
+                f"bytes_per_block_from_shape={bytes_per_block_from_shape}, "
+                f"bytes_per_block_from_layout={bytes_per_block_from_layout}, "
+                f"outer_dim={layout.outer_dim}, inner_dim={layout.inner_dim}, "
+                f"page_size={page_size}, dtype_width_bytes={dtype_width_bytes}, "
+                f"num_device_blocks={num_device_blocks}"
             )
 
         # Phase 2A: Register KV caches with NIXL via Rust binding

--- a/lib/bindings/kvbm/python/kvbm/vllm_integration/connector/pd_connector.py
+++ b/lib/bindings/kvbm/python/kvbm/vllm_integration/connector/pd_connector.py
@@ -1,0 +1,188 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional, Type
+
+from kvbm.vllm_integration.connector.dynamo_connector import DynamoConnector
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    KVConnectorHandshakeMetadata,
+    KVConnectorRole,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.multi_connector import (
+    MultiConnector,
+    MultiKVConnectorMetadata,
+)
+
+try:
+    from vllm.distributed.kv_transfer.kv_connector.v1.nixl_connector import (
+        NixlConnector,
+        NixlHandshakePayload,
+    )
+except ModuleNotFoundError as exc:
+    if exc.name != "vllm.distributed.kv_transfer.kv_connector.v1.nixl_connector":
+        raise
+    from vllm.distributed.kv_transfer.kv_connector.v1.nixl import (
+        NixlConnector,
+        NixlHandshakePayload,
+    )
+
+from vllm.v1.core.sched.output import SchedulerOutput
+
+# Optional import for LMCache support
+_LMCacheConnectorV1: Optional[Type] = None
+try:
+    from vllm.distributed.kv_transfer.kv_connector.v1.lmcache_connector import (
+        LMCacheConnectorV1,
+    )
+
+    _LMCacheConnectorV1 = LMCacheConnectorV1
+except ImportError:
+    pass
+
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
+    from vllm.distributed.kv_transfer.kv_connector.v1.lmcache_connector import (
+        LMCacheConnectorV1,
+    )
+    from vllm.v1.core.kv_cache_manager import KVCacheBlocks
+    from vllm.v1.kv_cache_interface import KVCacheConfig
+    from vllm.v1.request import Request
+
+
+@dataclass
+class PdConnectorMetadata(MultiKVConnectorMetadata):
+    pass
+
+
+class PdConnector(MultiConnector):
+    """
+    A wrapper for using KV offloading Connectors (e.g. KVBM or LMCache) and NIXL Connector for PD disaggregated serving.
+
+    The current logic is:
+    - The first connector must be KVBM or LMCache and would be used by prefill worker to offload and onboard KV blocks.
+    - The second connector must be NIXL and will be used by decode worker to get KV blocks from prefill worker.
+    """
+
+    def __init__(
+        self,
+        vllm_config: "VllmConfig",
+        role: KVConnectorRole,
+        kv_cache_config: "KVCacheConfig",
+    ):
+        super().__init__(
+            vllm_config=vllm_config, role=role, kv_cache_config=kv_cache_config
+        )
+        if len(self._connectors) != 2:
+            raise ValueError(
+                f"PdConnector requires exactly two connectors (got {len(self._connectors)})"
+            )
+
+        # Build allowed types for first connector
+        allowed_first_types: list[Type] = [DynamoConnector]
+        if _LMCacheConnectorV1 is not None:
+            allowed_first_types.append(_LMCacheConnectorV1)
+
+        if not isinstance(self._connectors[0], tuple(allowed_first_types)):
+            allowed_names = ["DynamoConnector"]
+            if _LMCacheConnectorV1 is not None:
+                allowed_names.append("LMCacheConnectorV1")
+            raise TypeError(
+                f"Expected first connector to be {' or '.join(allowed_names)}, "
+                f"got {type(self._connectors[0]).__name__}"
+            )
+        if not isinstance(self._connectors[1], NixlConnector):
+            raise TypeError(
+                f"Expected second connector to be NixlConnector, "
+                f"got {type(self._connectors[1]).__name__}"
+            )
+
+    # ==============================
+    # Worker-side methods
+    # ==============================
+
+    def set_xfer_handshake_metadata(
+        self, metadata: dict[int, KVConnectorHandshakeMetadata]
+    ) -> None:
+        """
+        Propagate handshake metadata to child connectors.
+
+        This is required for NIXL connector to start its handshake listener
+        which decode workers connect to for KV transfer coordination.
+        """
+        for c in self._connectors:
+            c.set_xfer_handshake_metadata(metadata)
+
+    def get_handshake_metadata(self) -> KVConnectorHandshakeMetadata | None:
+        """
+        Get the KVConnector handshake metadata from the NIXL connector.
+
+        This metadata is used for out-of-band connector handshake between
+        P/D workers. The NIXL connector (second connector) provides this
+        metadata so decode workers can connect for KV transfer coordination.
+
+        Returns:
+            NixlHandshakePayload from the NIXL connector, or None if not available.
+        """
+        # Get handshake metadata from the NIXL connector (second connector)
+        nixl_connector = self._connectors[1]
+        metadata = nixl_connector.get_handshake_metadata()
+        if metadata is not None and not isinstance(metadata, NixlHandshakePayload):
+            raise TypeError(
+                f"Expected NixlHandshakePayload from NIXL connector, "
+                f"got {type(metadata).__name__}"
+            )
+        return metadata
+
+    def bind_connector_metadata(self, connector_metadata: PdConnectorMetadata) -> None:
+        # Must call super() to set _connector_metadata so has_connector_metadata() returns True
+        # This is required for save_kv_layer to be called during the forward pass
+        super().bind_connector_metadata(connector_metadata)
+        assert isinstance(connector_metadata, PdConnectorMetadata)
+        if connector_metadata.extra_async_saves:
+            self._extra_async_saves.update(connector_metadata.extra_async_saves)
+        for c, cm in zip(self._connectors, connector_metadata.metadata):
+            c.bind_connector_metadata(cm)
+
+    # ==============================
+    # Scheduler-side methods
+    # ==============================
+
+    def get_num_new_matched_tokens(
+        self,
+        request: "Request",
+        num_computed_tokens: int,
+    ) -> tuple[int, bool]:
+        """
+        Get the number of matched tokens for the request using Dynamo Connector (KVBM).
+        """
+        return self._connectors[0].get_num_new_matched_tokens(
+            request, num_computed_tokens
+        )
+
+    def update_state_after_alloc(
+        self, request: "Request", blocks: "KVCacheBlocks", num_external_tokens: int
+    ):
+        """
+        Update the state after allocation using Dynamo Connector (KVBM) and Nixl Connector.
+        """
+        empty_blocks = blocks.new_empty()
+        # allocate blocks for KV offloading connector to onboard KV blocks
+        self._connectors[0].update_state_after_alloc(
+            request, blocks, num_external_tokens
+        )
+        # no need to allocate any blocks for NIXL connector since this is in prefill worker side
+        # and it only needs to wait for decode worker to pull its data.
+        self._connectors[1].update_state_after_alloc(request, empty_blocks, 0)
+
+    def build_connector_meta(
+        self, scheduler_output: SchedulerOutput
+    ) -> PdConnectorMetadata:
+        metadata = PdConnectorMetadata(
+            metadata=tuple(
+                c.build_connector_meta(scheduler_output) for c in self._connectors
+            )
+        )
+        if self._extra_async_saves:
+            metadata.extra_async_saves = self._extra_async_saves
+            self._extra_async_saves = {}
+        return metadata

--- a/lib/kvbm-connector/src/connector/leader/onboard.rs
+++ b/lib/kvbm-connector/src/connector/leader/onboard.rs
@@ -95,6 +95,26 @@ fn select_onboard_block_ids(
 ) -> Vec<BlockId> {
     let num_computed_blocks = num_computed_tokens / block_size;
     let num_external_blocks = num_external_tokens / block_size;
+    let floor_loss_tokens = num_external_tokens % block_size;
+    let num_external_blocks_ceil =
+        num_external_blocks + if floor_loss_tokens > 0 { 1 } else { 0 };
+
+    // Diagnostic: surface floor-division loss so we can tell whether
+    // num_external_tokens is a multiple of block_size for this workload.
+    // floor_loss_tokens > 0 means the trailing remainder is silently dropped
+    // and the actual byte count moved by the onboard transfer is smaller
+    // than (num_external_tokens * per_token_kv_bytes) suggests.
+    tracing::info!(
+        num_computed_tokens,
+        num_external_tokens,
+        block_size,
+        num_computed_blocks,
+        num_external_blocks,
+        num_external_blocks_ceil,
+        floor_loss_tokens,
+        "select_onboard_block_ids"
+    );
+
     block_ids[num_computed_blocks..num_computed_blocks + num_external_blocks].to_vec()
 }
 
@@ -435,9 +455,9 @@ async fn execute_onboarding(
 
     tracing::info!(
         blocks = num_blocks,
-        staging_ms = staging_complete.duration_since(start).as_millis() as u64,
-        xfer_ms = end_xfer.duration_since(start_xfer).as_millis() as u64,
-        total_ms = end_xfer.duration_since(start).as_millis() as u64,
+        staging_us = staging_complete.duration_since(start).as_micros() as u64,
+        xfer_us = end_xfer.duration_since(start_xfer).as_micros() as u64,
+        total_us = end_xfer.duration_since(start).as_micros() as u64,
         src = if bypass_host {
             "kvbm_engine::G3"
         } else {

--- a/lib/kvbm-connector/src/vllm/layout.rs
+++ b/lib/kvbm-connector/src/vllm/layout.rs
@@ -75,15 +75,30 @@ pub fn determine_kv_layout(
     }
 
     // Locate the blocks dimension from shape (independent of explicit dims).
-    let block_dim = if shape[0] >= num_device_blocks {
-        BlockDimension::BlockIsFirstDim
-    } else if shape[1] >= num_device_blocks {
-        BlockDimension::BlockIsSecondDim
-    } else {
-        bail!(
-            "Unexpected tensor shape: {:?}; expected num_device_blocks: {num_device_blocks} to be present in the first or second dimension",
-            shape
-        );
+    //
+    // Be strict on ambiguity: if both leading dimensions could be interpreted as
+    // the blocks axis we fail instead of silently picking axis 0. Silent fallback
+    // here can corrupt layout math (outer_dim/inner_dim) and under-transfer bytes.
+    let dim0_matches = shape[0] >= num_device_blocks;
+    let dim1_matches = shape[1] >= num_device_blocks;
+    let block_dim = match (dim0_matches, dim1_matches) {
+        (true, false) => BlockDimension::BlockIsFirstDim,
+        (false, true) => BlockDimension::BlockIsSecondDim,
+        (false, false) => {
+            bail!(
+                "Unexpected tensor shape: {:?}; expected num_device_blocks ({}) to be present in one of the first two dimensions",
+                shape,
+                num_device_blocks
+            );
+        }
+        (true, true) => {
+            bail!(
+                "Ambiguous tensor shape for block-dimension detection: shape[:2]={:?}, num_device_blocks={}. \
+                 Both leading dims satisfy >= num_device_blocks; cannot safely infer block axis.",
+                &shape[..2],
+                num_device_blocks
+            );
+        }
     };
 
     // Resolve outer_dim / inner_dim.

--- a/lib/kvbm-engine/src/offload/pipeline.rs
+++ b/lib/kvbm-engine/src/offload/pipeline.rs
@@ -1474,31 +1474,31 @@ impl<Src: BlockMetadata, Dst: BlockMetadata> BlockTransferExecutor<Src, Dst> {
             let unique_transfer_ids: std::collections::HashSet<_> =
                 resolved.iter().map(|b| b.transfer_id).collect();
 
-            let policy_ms = batch
+            let policy_us = batch
                 .timing
                 .policy_duration()
-                .map(|d| d.as_millis() as u64)
+                .map(|d| d.as_micros() as u64)
                 .unwrap_or(0);
-            let precondition_ms = batch
+            let precondition_us = batch
                 .timing
                 .precondition_duration()
-                .map(|d| d.as_millis() as u64)
+                .map(|d| d.as_micros() as u64)
                 .unwrap_or(0);
-            let total_ms = batch
+            let total_us = batch
                 .timing
                 .total_duration()
-                .map(|d| d.as_millis() as u64)
+                .map(|d| d.as_micros() as u64)
                 .unwrap_or(0);
 
             tracing::info!(
                 blocks = resolved.len(),
                 containers = unique_transfer_ids.len(),
-                policy_ms,
-                precondition_ms,
-                xfer_ms = end_xfer.duration_since(start_xfer).as_millis() as u64,
-                registration_ms =
-                    registration_timepoint.duration_since(end_xfer).as_millis() as u64,
-                total_ms,
+                policy_us,
+                precondition_us,
+                xfer_us = end_xfer.duration_since(start_xfer).as_micros() as u64,
+                registration_us =
+                    registration_timepoint.duration_since(end_xfer).as_micros() as u64,
+                total_us,
                 src = std::any::type_name::<Src>(),
                 dst = std::any::type_name::<Dst>(),
                 "Batch transfer complete"
@@ -1842,34 +1842,34 @@ impl<Src: BlockMetadata> ObjectTransferExecutor<Src> {
         let unique_transfer_ids: std::collections::HashSet<_> =
             resolved.iter().map(|b| b.transfer_id).collect();
 
-        let policy_ms = batch
+        let policy_us = batch
             .timing
             .policy_duration()
-            .map(|d| d.as_millis() as u64)
+            .map(|d| d.as_micros() as u64)
             .unwrap_or(0);
-        let precondition_ms = batch
+        let precondition_us = batch
             .timing
             .precondition_duration()
-            .map(|d| d.as_millis() as u64)
+            .map(|d| d.as_micros() as u64)
             .unwrap_or(0);
-        let transfer_ms = batch
+        let transfer_us = batch
             .timing
             .transfer_duration()
-            .map(|d| d.as_millis() as u64)
+            .map(|d| d.as_micros() as u64)
             .unwrap_or(0);
-        let total_ms = batch
+        let total_us = batch
             .timing
             .total_duration()
-            .map(|d| d.as_millis() as u64)
+            .map(|d| d.as_micros() as u64)
             .unwrap_or(0);
 
         tracing::info!(
             blocks = resolved.len(),
             containers = unique_transfer_ids.len(),
-            policy_ms,
-            precondition_ms,
-            transfer_ms,
-            total_ms,
+            policy_us,
+            precondition_us,
+            transfer_us,
+            total_us,
             src = std::any::type_name::<Src>(),
             dst = "G4-object",
             "Object batch transfer complete"

--- a/lib/kvbm-physical/src/transfer/executor/cuda.rs
+++ b/lib/kvbm-physical/src/transfer/executor/cuda.rs
@@ -97,6 +97,43 @@ pub fn execute_cuda_transfer(
         _ => "Unknown",
     };
 
+    // Diagnostic: bytes about to move + path selection. Cross-correlate
+    // with the connector's "Onboard transfer complete" xfer_us field to
+    // get effective bandwidth for the actual byte count this kernel
+    // moves (which is not necessarily what the caller assumes).
+    let log_num_blocks = src_block_ids.len();
+    let log_num_layers = layers.len();
+    let log_outer_dim = src_layout.outer_dim();
+    let log_page_size = src_layout.page_size();
+    let log_inner_dim = src_layout.inner_dim();
+    let log_dtype_width = src_layout.dtype_width_bytes();
+    let log_fc_lw_num_pairs = log_num_blocks * log_num_layers * log_outer_dim;
+    let log_fc_lw_chunk_bytes = log_page_size * log_inner_dim * log_dtype_width;
+    let log_fc_lw_bytes_from_pairs = log_fc_lw_num_pairs * log_fc_lw_chunk_bytes;
+    let log_expected_bytes = log_num_blocks
+        * log_num_layers
+        * log_outer_dim
+        * log_page_size
+        * log_inner_dim
+        * log_dtype_width;
+    tracing::info!(
+        strategy = strategy_name,
+        selected_path = if use_whole_block { "whole_block" } else { "fc_lw" },
+        num_blocks = log_num_blocks,
+        num_layers = log_num_layers,
+        outer_dim = log_outer_dim,
+        page_size = log_page_size,
+        inner_dim = log_inner_dim,
+        dtype_width = log_dtype_width,
+        fc_lw_num_pairs = log_fc_lw_num_pairs,
+        fc_lw_chunk_bytes = log_fc_lw_chunk_bytes,
+        fc_lw_bytes_from_pairs = log_fc_lw_bytes_from_pairs,
+        expected_bytes = log_expected_bytes,
+        src_is_fully_contiguous = src_layout.is_fully_contiguous(),
+        dst_is_fully_contiguous = dst_layout.is_fully_contiguous(),
+        "Transfer prepared"
+    );
+
     match strategy {
         TransferStrategy::CudaAsyncH2D
         | TransferStrategy::CudaAsyncD2H

--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -488,4 +488,39 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
             ),
         },
     ),
+    # [gluo NOTE] LLaVA 1.5 7B is big model and require at least 3 GPUs to run.
+    # We may use less GPUs by squeezing the model onto 2 GPUs.
+    MultimodalModelProfile(
+        name="llava-hf/llava-1.5-7b-hf",
+        short_name="llava-1.5-7b",
+        topologies={
+            "e_pd": TopologyConfig(
+                marks=[pytest.mark.pre_merge],
+                timeout_s=340,
+                gpu_marker="gpu_4",
+            ),
+            "epd": TopologyConfig(
+                marks=[pytest.mark.pre_merge],
+                timeout_s=300,
+                gpu_marker="gpu_4",
+            ),
+        },
+        # LLaVA 1.5 color naming varies across CUDA backends under vLLM 0.20;
+        # keep this as a multimodal serving smoke check, not a color oracle.
+        request_payloads=[
+            make_image_payload(
+                [
+                    "green",
+                    "white",
+                    "black",
+                    "purple",
+                    "red",
+                    "pink",
+                    "yellow",
+                    "blue",
+                    "orange",
+                ]
+            )
+        ],
+    ),
 ]


### PR DESCRIPTION
## Summary

- Retarget this PR to `ryan/kvbm-connector-merge`.
- Keep the base branch vLLM `0.20.1` stack; this PR no longer attempts to apply the older vLLM `0.20.0` version pins.
- Carry forward the remaining KVBM/vLLM data-transfer fixes: stricter KV tensor layout/block validation, onboarding/transfer diagnostics, scheduler API compatibility, and the PD connector wrapper.
- Fix runtime image NIXL/KVBM wheel resolution by uninstalling pre-existing NIXL variants before installing the wheelhouse NIXL wheel and installing KVBM with `--no-deps`.

## Branch Notes

- Base: `ryan/kvbm-connector-merge`
- Head: `aniket/kvbm-vllm-020-transfer-fix`
- Rebuilt the head branch on top of `origin/ryan/kvbm-connector-merge` and force-pushed it.
- During conflict resolution, kept the base branch side for vLLM/container dependency/version/support-matrix conflicts, including vLLM `0.20.1`.

## Testing

- `git diff --check origin/ryan/kvbm-connector-merge...HEAD`
- `git merge-base --is-ancestor origin/ryan/kvbm-connector-merge HEAD`

Not run locally: full Python/Rust test suites are not available in this environment.
