### PR TITLE
fix(operator): require Kubernetes 1.34+ DRA v1 for GMS ResourceClaimTemplates

### DIFF
--- a/deploy/operator/api/config/v1alpha1/types.go
+++ b/deploy/operator/api/config/v1alpha1/types.go
@@ -201,10 +201,10 @@ type KaiSchedulerConfiguration struct {
 	Enabled *bool `json:"enabled,omitempty"`
 }
 
-// DRAConfiguration holds Dynamic Resource Allocation (resource.k8s.io) settings.
+// DRAConfiguration holds Dynamic Resource Allocation (resource.k8s.io/v1) settings.
 //
-// NOTE: auto-detection here only verifies that the resource.k8s.io API group is
-// registered on the apiserver (Kubernetes 1.32+). It does NOT verify that a
+// NOTE: auto-detection here only verifies that the resource.k8s.io/v1 API is
+// registered on the apiserver (Kubernetes 1.34+). It does NOT verify that a
 // GPU-specific DRA resource driver (e.g. nvidia/k8s-dra-driver-gpu) is
 // installed, that its DeviceClass exists, or that node-level GPU drivers are
 // compatible. An admin can use `enabled: false` to force-off DRA integration
@@ -213,7 +213,7 @@ type KaiSchedulerConfiguration struct {
 // with a clear error instead of letting pods Pend with a confusing
 // "resourceclaim not found" at schedule time.
 type DRAConfiguration struct {
-	// Enabled overrides auto-detection of the resource.k8s.io API group.
+	// Enabled overrides auto-detection of the resource.k8s.io/v1 API.
 	// nil = auto-detect. Setting true requires detection to also succeed (the
 	// operator will exit at startup otherwise).
 	Enabled *bool `json:"enabled,omitempty"`

--- a/deploy/operator/cmd/main.go
+++ b/deploy/operator/cmd/main.go
@@ -453,8 +453,8 @@ func main() {
 	case *operatorCfg.DRA.Enabled:
 		if !draDetected {
 			setupLog.Error(nil,
-				"DRA is explicitly enabled in config but the resource.k8s.io API group"+
-					" was not detected in the cluster (requires Kubernetes 1.32+)",
+				"DRA is explicitly enabled in config but the resource.k8s.io/v1 API"+
+					" was not detected in the cluster (requires Kubernetes 1.34+)",
 			)
 			os.Exit(1)
 		}

--- a/deploy/operator/internal/controller/dynamocheckpoint_controller.go
+++ b/deploy/operator/internal/controller/dynamocheckpoint_controller.go
@@ -219,7 +219,7 @@ func (r *CheckpointReconciler) handlePending(ctx context.Context, ckpt *nvidiaco
 	if ckpt.Spec.GPUMemoryService != nil && ckpt.Spec.GPUMemoryService.Enabled {
 		if !r.RuntimeConfig.DRAEnabled {
 			return ctrl.Result{}, fmt.Errorf(
-				"GMS requires DRA (Dynamic Resource Allocation), but the resource.k8s.io API group is not available")
+				"GMS requires DRA (Dynamic Resource Allocation), but the resource.k8s.io/v1 API is not available")
 		}
 		if len(ckpt.Spec.Job.PodTemplateSpec.Spec.Containers) == 0 {
 			return ctrl.Result{}, fmt.Errorf("checkpoint job requires at least one container for GMS")

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
@@ -29,7 +29,6 @@ import (
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
-	resourcev1 "k8s.io/api/resource/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"emperror.dev/errors"
@@ -39,7 +38,6 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/common"
 	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	commonController "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dra"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/observability"
 	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
@@ -184,10 +182,6 @@ func (r *DynamoComponentDeploymentReconciler) Reconcile(ctx context.Context, req
 		}
 	}
 
-	if err := r.reconcileGMSResourceClaimTemplate(ctx, dynamoComponentDeployment); err != nil {
-		return ctrl.Result{}, err
-	}
-
 	// Create the appropriate workload resource based on deployment type
 	var componentReconcileResult ComponentReconcileResult
 	if r.RuntimeConfig.LWSEnabled && dynamoComponentDeployment.IsMultinode() {
@@ -249,37 +243,6 @@ func (r *DynamoComponentDeploymentReconciler) Reconcile(ctx context.Context, req
 	}
 
 	return
-}
-
-func (r *DynamoComponentDeploymentReconciler) reconcileGMSResourceClaimTemplate(ctx context.Context, dynamoComponentDeployment *nvidiacomv1beta1.DynamoComponentDeployment) error {
-	spec := &dynamoComponentDeployment.Spec.DynamoComponentDeploymentSharedSpec
-	gmsSpec := dynamo.GetGPUMemoryService(spec)
-	if !r.RuntimeConfig.DRAEnabled {
-		if gmsSpec == nil {
-			return nil
-		}
-		return fmt.Errorf(
-			"gpuMemoryService requires DRA (Dynamic Resource Allocation), but the resource.k8s.io/v1 API " +
-				"is not available on this cluster (requires Kubernetes 1.34+)")
-	}
-
-	componentName := dynamo.GetDCDComponentName(dynamoComponentDeployment)
-	gpuCount, deviceClassName, err := dra.ExtractGPUParamsFromResourceRequirements(gmsSpec, dynamo.GetMainContainerResources(spec))
-	if err != nil {
-		return fmt.Errorf("invalid GPU resource requirements for GMS ResourceClaimTemplate: %w", err)
-	}
-	parentName := dynamoComponentDeployment.GetParentGraphDeploymentName()
-	if parentName == "" {
-		parentName = dynamoComponentDeployment.Name
-	}
-	claimTemplateName := dra.ResourceClaimTemplateName(parentName, componentName)
-	_, _, err = commonController.SyncResource(ctx, r, dynamoComponentDeployment, func(ctx context.Context) (*resourcev1.ResourceClaimTemplate, bool, error) {
-		return dra.GenerateResourceClaimTemplate(ctx, r.Client, claimTemplateName, dynamoComponentDeployment.Namespace, gpuCount, deviceClassName)
-	})
-	if err != nil {
-		return fmt.Errorf("failed to sync GMS ResourceClaimTemplate: %w", err)
-	}
-	return nil
 }
 
 type ComponentReconcileResult struct {

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
@@ -184,27 +184,8 @@ func (r *DynamoComponentDeploymentReconciler) Reconcile(ctx context.Context, req
 		}
 	}
 
-	// Sync GMS ResourceClaimTemplate before creating workload resources
-	if r.RuntimeConfig.DRAEnabled {
-		componentName := dynamo.GetDCDComponentName(dynamoComponentDeployment)
-		spec := &dynamoComponentDeployment.Spec.DynamoComponentDeploymentSharedSpec
-		gpuCount, deviceClassName, err := dra.ExtractGPUParamsFromResourceRequirements(dynamo.GetGPUMemoryService(spec), dynamo.GetMainContainerResources(spec))
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("invalid GPU resource requirements for GMS ResourceClaimTemplate: %w", err)
-		}
-		parentName := dynamoComponentDeployment.GetParentGraphDeploymentName()
-		if parentName == "" {
-			parentName = dynamoComponentDeployment.Name
-		}
-		claimTemplateName := dra.ResourceClaimTemplateName(parentName, componentName)
-		_, _, err = commonController.SyncResource(ctx, r, dynamoComponentDeployment, func(ctx context.Context) (*resourcev1.ResourceClaimTemplate, bool, error) {
-			return dra.GenerateResourceClaimTemplate(ctx, r.Client, claimTemplateName, dynamoComponentDeployment.Namespace, gpuCount, deviceClassName)
-		})
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to sync GMS ResourceClaimTemplate: %w", err)
-		}
-	} else if dynamo.GetGPUMemoryService(&dynamoComponentDeployment.Spec.DynamoComponentDeploymentSharedSpec) != nil {
-		return ctrl.Result{}, fmt.Errorf("gpuMemoryService requires DRA (Dynamic Resource Allocation), but the resource.k8s.io API group is not available on this cluster (requires Kubernetes 1.32+)")
+	if err := r.reconcileGMSResourceClaimTemplate(ctx, dynamoComponentDeployment); err != nil {
+		return ctrl.Result{}, err
 	}
 
 	// Create the appropriate workload resource based on deployment type
@@ -268,6 +249,37 @@ func (r *DynamoComponentDeploymentReconciler) Reconcile(ctx context.Context, req
 	}
 
 	return
+}
+
+func (r *DynamoComponentDeploymentReconciler) reconcileGMSResourceClaimTemplate(ctx context.Context, dynamoComponentDeployment *nvidiacomv1beta1.DynamoComponentDeployment) error {
+	spec := &dynamoComponentDeployment.Spec.DynamoComponentDeploymentSharedSpec
+	gmsSpec := dynamo.GetGPUMemoryService(spec)
+	if !r.RuntimeConfig.DRAEnabled {
+		if gmsSpec == nil {
+			return nil
+		}
+		return fmt.Errorf(
+			"gpuMemoryService requires DRA (Dynamic Resource Allocation), but the resource.k8s.io/v1 API " +
+				"is not available on this cluster (requires Kubernetes 1.34+)")
+	}
+
+	componentName := dynamo.GetDCDComponentName(dynamoComponentDeployment)
+	gpuCount, deviceClassName, err := dra.ExtractGPUParamsFromResourceRequirements(gmsSpec, dynamo.GetMainContainerResources(spec))
+	if err != nil {
+		return fmt.Errorf("invalid GPU resource requirements for GMS ResourceClaimTemplate: %w", err)
+	}
+	parentName := dynamoComponentDeployment.GetParentGraphDeploymentName()
+	if parentName == "" {
+		parentName = dynamoComponentDeployment.Name
+	}
+	claimTemplateName := dra.ResourceClaimTemplateName(parentName, componentName)
+	_, _, err = commonController.SyncResource(ctx, r, dynamoComponentDeployment, func(ctx context.Context) (*resourcev1.ResourceClaimTemplate, bool, error) {
+		return dra.GenerateResourceClaimTemplate(ctx, r.Client, claimTemplateName, dynamoComponentDeployment.Namespace, gpuCount, deviceClassName)
+	})
+	if err != nil {
+		return fmt.Errorf("failed to sync GMS ResourceClaimTemplate: %w", err)
+	}
+	return nil
 }
 
 type ComponentReconcileResult struct {

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -42,8 +42,11 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	resourcev1 "k8s.io/api/resource/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
@@ -217,6 +220,89 @@ func TestIsDeploymentReady(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := IsDeploymentReady(tt.args.deployment); got != tt.want {
 				t.Errorf("IsDeploymentReady() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDynamoComponentDeploymentReconciler_reconcileGMSResourceClaimTemplate_GuardsDRA(t *testing.T) {
+	ctx := context.Background()
+	tests := []struct {
+		name             string
+		runtime          *controller_common.RuntimeConfig
+		spec             v1beta1.DynamoComponentDeploymentSharedSpec
+		existingTemplate bool
+		wantDeleted      bool
+		wantError        string
+	}{
+		{
+			name:    "no gpu memory service skips ResourceClaimTemplate sync when DRA unavailable",
+			runtime: &controller_common.RuntimeConfig{DRAEnabled: false},
+			spec: v1beta1.DynamoComponentDeploymentSharedSpec{
+				ComponentName: "decode",
+			},
+		},
+		{
+			name:    "no gpu memory service cleans up stale ResourceClaimTemplate when DRA available",
+			runtime: &controller_common.RuntimeConfig{DRAEnabled: true},
+			spec: v1beta1.DynamoComponentDeploymentSharedSpec{
+				ComponentName: "decode",
+			},
+			existingTemplate: true,
+			wantDeleted:      true,
+		},
+		{
+			name:    "gpu memory service requires DRA v1",
+			runtime: &controller_common.RuntimeConfig{DRAEnabled: false},
+			spec: v1beta1.DynamoComponentDeploymentSharedSpec{
+				ComponentName: "decode",
+				Experimental: &v1beta1.ExperimentalSpec{
+					GPUMemoryService: &v1beta1.GPUMemoryServiceSpec{},
+				},
+			},
+			wantError: "resource.k8s.io/v1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := runtime.NewScheme()
+			require.NoError(t, v1beta1.AddToScheme(s))
+			require.NoError(t, resourcev1.AddToScheme(s))
+			dcd := &v1beta1.DynamoComponentDeployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-dcd", Namespace: "default"},
+				Spec: v1beta1.DynamoComponentDeploymentSpec{
+					DynamoComponentDeploymentSharedSpec: tt.spec,
+				},
+			}
+			templateName := "test-dcd-decode-gpu"
+			objects := []client.Object{dcd}
+			if tt.existingTemplate {
+				objects = append(objects, &resourcev1.ResourceClaimTemplate{
+					ObjectMeta: metav1.ObjectMeta{Name: templateName, Namespace: "default"},
+				})
+			}
+			cl := fake.NewClientBuilder().
+				WithScheme(s).
+				WithObjects(objects...).
+				Build()
+			r := &DynamoComponentDeploymentReconciler{
+				Client:        cl,
+				Recorder:      record.NewFakeRecorder(100),
+				RuntimeConfig: tt.runtime,
+			}
+
+			err := r.reconcileGMSResourceClaimTemplate(ctx, dcd)
+			if tt.wantError != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.wantError)
+				return
+			}
+			require.NoError(t, err)
+			if tt.wantDeleted {
+				got := &resourcev1.ResourceClaimTemplate{}
+				err = cl.Get(ctx, client.ObjectKey{Name: templateName, Namespace: "default"}, got)
+				require.True(t, apierrors.IsNotFound(err), "expected stale ResourceClaimTemplate to be deleted, got %v", err)
 			}
 		})
 	}

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -42,11 +42,8 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
-	resourcev1 "k8s.io/api/resource/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
@@ -220,89 +217,6 @@ func TestIsDeploymentReady(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := IsDeploymentReady(tt.args.deployment); got != tt.want {
 				t.Errorf("IsDeploymentReady() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestDynamoComponentDeploymentReconciler_reconcileGMSResourceClaimTemplate_GuardsDRA(t *testing.T) {
-	ctx := context.Background()
-	tests := []struct {
-		name             string
-		runtime          *controller_common.RuntimeConfig
-		spec             v1beta1.DynamoComponentDeploymentSharedSpec
-		existingTemplate bool
-		wantDeleted      bool
-		wantError        string
-	}{
-		{
-			name:    "no gpu memory service skips ResourceClaimTemplate sync when DRA unavailable",
-			runtime: &controller_common.RuntimeConfig{DRAEnabled: false},
-			spec: v1beta1.DynamoComponentDeploymentSharedSpec{
-				ComponentName: "decode",
-			},
-		},
-		{
-			name:    "no gpu memory service cleans up stale ResourceClaimTemplate when DRA available",
-			runtime: &controller_common.RuntimeConfig{DRAEnabled: true},
-			spec: v1beta1.DynamoComponentDeploymentSharedSpec{
-				ComponentName: "decode",
-			},
-			existingTemplate: true,
-			wantDeleted:      true,
-		},
-		{
-			name:    "gpu memory service requires DRA v1",
-			runtime: &controller_common.RuntimeConfig{DRAEnabled: false},
-			spec: v1beta1.DynamoComponentDeploymentSharedSpec{
-				ComponentName: "decode",
-				Experimental: &v1beta1.ExperimentalSpec{
-					GPUMemoryService: &v1beta1.GPUMemoryServiceSpec{},
-				},
-			},
-			wantError: "resource.k8s.io/v1",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			s := runtime.NewScheme()
-			require.NoError(t, v1beta1.AddToScheme(s))
-			require.NoError(t, resourcev1.AddToScheme(s))
-			dcd := &v1beta1.DynamoComponentDeployment{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-dcd", Namespace: "default"},
-				Spec: v1beta1.DynamoComponentDeploymentSpec{
-					DynamoComponentDeploymentSharedSpec: tt.spec,
-				},
-			}
-			templateName := "test-dcd-decode-gpu"
-			objects := []client.Object{dcd}
-			if tt.existingTemplate {
-				objects = append(objects, &resourcev1.ResourceClaimTemplate{
-					ObjectMeta: metav1.ObjectMeta{Name: templateName, Namespace: "default"},
-				})
-			}
-			cl := fake.NewClientBuilder().
-				WithScheme(s).
-				WithObjects(objects...).
-				Build()
-			r := &DynamoComponentDeploymentReconciler{
-				Client:        cl,
-				Recorder:      record.NewFakeRecorder(100),
-				RuntimeConfig: tt.runtime,
-			}
-
-			err := r.reconcileGMSResourceClaimTemplate(ctx, dcd)
-			if tt.wantError != "" {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), tt.wantError)
-				return
-			}
-			require.NoError(t, err)
-			if tt.wantDeleted {
-				got := &resourcev1.ResourceClaimTemplate{}
-				err = cl.Get(ctx, client.ObjectKey{Name: templateName, Namespace: "default"}, got)
-				require.True(t, apierrors.IsNotFound(err), "expected stale ResourceClaimTemplate to be deleted, got %v", err)
 			}
 		})
 	}

--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -421,6 +421,10 @@ func (r *DynamoGraphDeploymentReconciler) reconcileResources(ctx context.Context
 	restartStatus := r.computeRestartStatus(ctx, dynamoDeployment)
 	restartState := dynamo.DetermineRestartState(dynamoDeployment, restartStatus)
 
+	if err := r.reconcileGMSResourceClaimTemplates(ctx, dynamoDeployment); err != nil {
+		return ReconcileResult{}, err
+	}
+
 	var result ReconcileResult
 	if r.isGrovePathway(dynamoDeployment) {
 		logger.Info("Reconciling Grove resources", "hasMultinode", hasMultinode, "lwsEnabled", r.RuntimeConfig.LWSEnabled)
@@ -901,10 +905,6 @@ func (r *DynamoGraphDeploymentReconciler) reconcileGMSResourceClaimTemplates(ctx
 
 func (r *DynamoGraphDeploymentReconciler) reconcileGroveResources(ctx context.Context, dynamoDeployment *nvidiacomv1beta1.DynamoGraphDeployment, restartState *dynamo.RestartState, checkpointInfos map[string]*checkpoint.CheckpointInfo) (ReconcileResult, error) {
 	logger := log.FromContext(ctx)
-
-	if err := r.reconcileGMSResourceClaimTemplates(ctx, dynamoDeployment); err != nil {
-		return ReconcileResult{}, err
-	}
 
 	renderDeployment, existingPodCliqueSet, err := r.prepareGroveRenderDeployment(ctx, dynamoDeployment)
 	if err != nil {

--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -852,9 +852,10 @@ func (r *DynamoGraphDeploymentReconciler) reconcileGroveScaling(ctx context.Cont
 	return nil
 }
 
-// reconcileGMSResourceClaimTemplates syncs one ResourceClaimTemplate per
-// component when DRA is available, and otherwise fails fast if any component
-// needs DRA-backed GPU allocation.
+// reconcileGMSResourceClaimTemplates syncs ResourceClaimTemplates when DRA is
+// available, including deleting stale templates for components that no longer
+// use GMS. When DRA is unavailable, it fails fast if any component needs
+// DRA-backed GPU allocation.
 //
 // Both the GMS sidecar and inter-pod GMS
 // failover (failover.mode=interPod) allocate GPUs via DRA ResourceClaims.
@@ -869,7 +870,10 @@ func (r *DynamoGraphDeploymentReconciler) reconcileGMSResourceClaimTemplates(ctx
 		for i := range dynamoDeployment.Spec.Components {
 			component := &dynamoDeployment.Spec.Components[i]
 			if dynamo.GetGPUMemoryService(component) != nil || component.IsInterPodFailoverEnabled() {
-				return fmt.Errorf("gpuMemoryService / inter-pod GMS failover requires DRA (Dynamic Resource Allocation), but DRA is not available (either the resource.k8s.io API group is not registered on this cluster, which requires Kubernetes 1.32+, or DRA has been explicitly disabled in the operator configuration)")
+				return fmt.Errorf(
+					"gpuMemoryService / inter-pod GMS failover requires DRA (Dynamic Resource Allocation), " +
+						"but DRA is not available (either the resource.k8s.io/v1 API is not registered on this cluster, " +
+						"which requires Kubernetes 1.34+, or DRA has been explicitly disabled in the operator configuration)")
 			}
 		}
 		return nil
@@ -877,8 +881,9 @@ func (r *DynamoGraphDeploymentReconciler) reconcileGMSResourceClaimTemplates(ctx
 
 	for i := range dynamoDeployment.Spec.Components {
 		component := &dynamoDeployment.Spec.Components[i]
+		gmsSpec := dynamo.GetGPUMemoryService(component)
 		componentName := component.ComponentName
-		gpuCount, deviceClassName, err := dra.ExtractGPUParamsFromResourceRequirements(dynamo.GetGPUMemoryService(component), dynamo.GetMainContainerResources(component))
+		gpuCount, deviceClassName, err := dra.ExtractGPUParamsFromResourceRequirements(gmsSpec, dynamo.GetMainContainerResources(component))
 		if err != nil {
 			return fmt.Errorf("invalid GPU resource requirements for GMS ResourceClaimTemplate for %s: %w", componentName, err)
 		}

--- a/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
@@ -546,6 +546,43 @@ func TestDynamoGraphDeploymentReconciler_reconcileGMSResourceClaimTemplates_DRAV
 	}
 }
 
+func TestDynamoGraphDeploymentReconciler_reconcileResources_ValidatesGMSResourceClaimTemplatesBeforePathway(t *testing.T) {
+	ctx := context.Background()
+	g := gomega.NewGomegaWithT(t)
+	s := newDynamoGraphDeploymentControllerTestScheme(t)
+	dgd := &v1beta1.DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-dgd", Namespace: "default"},
+		Spec: v1beta1.DynamoGraphDeploymentSpec{
+			BackendFramework: "vllm",
+			Components: []v1beta1.DynamoComponentDeploymentSharedSpec{
+				{
+					ComponentName: "decode",
+					ComponentType: v1beta1.ComponentTypeDecode,
+					Experimental: &v1beta1.ExperimentalSpec{
+						GPUMemoryService: &v1beta1.GPUMemoryServiceSpec{},
+					},
+				},
+			},
+		},
+	}
+	reconciler := &DynamoGraphDeploymentReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(s).
+			WithObjects(dgd).
+			Build(),
+		Recorder: record.NewFakeRecorder(100),
+		Config: &configv1alpha1.OperatorConfiguration{
+			Namespace: configv1alpha1.NamespaceConfiguration{Restricted: "default"},
+		},
+		RuntimeConfig: &controller_common.RuntimeConfig{DRAEnabled: false},
+	}
+
+	_, err := reconciler.reconcileResources(ctx, dgd)
+	g.Expect(err).To(gomega.HaveOccurred())
+	g.Expect(err.Error()).To(gomega.ContainSubstring("requires DRA"))
+	g.Expect(err.Error()).To(gomega.ContainSubstring("explicitly disabled"))
+}
+
 func TestDynamoGraphDeploymentReconciler_reconcileGMSResourceClaimTemplates_ToleratesNonGMSComponents(t *testing.T) {
 	ctx := context.Background()
 	s := newDynamoGraphDeploymentControllerTestScheme(t)
@@ -1384,25 +1421,6 @@ func Test_reconcileGroveResources(t *testing.T) {
 					},
 				},
 			},
-		},
-		{
-			name: "inter-pod GMS failover requires DRA - returns clear error when DRA is disabled",
-			dgdSpec: v1alpha1.DynamoGraphDeploymentSpec{
-				BackendFramework: "vllm",
-				Services: map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{
-					"decode": {
-						ComponentType: string(commonconsts.ComponentTypeDecode),
-						Replicas:      ptr.To(int32(1)),
-						Failover: &v1alpha1.FailoverSpec{
-							Enabled:    true,
-							Mode:       v1alpha1.GMSModeInterPod,
-							NumShadows: 1,
-						},
-					},
-				},
-			},
-			draEnabled:       false,
-			wantErrSubstring: "requires DRA",
 		},
 	}
 

--- a/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
@@ -34,6 +34,8 @@ import (
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	resourcev1 "k8s.io/api/resource/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -54,6 +56,7 @@ func newDynamoGraphDeploymentControllerTestScheme(t testing.TB) *runtime.Scheme 
 		corev1.AddToScheme,
 		autoscalingv1.AddToScheme,
 		networkingv1.AddToScheme,
+		resourcev1.AddToScheme,
 		v1alpha1.AddToScheme,
 		v1beta1.AddToScheme,
 		grovev1alpha1.AddToScheme,
@@ -540,6 +543,76 @@ func TestDynamoGraphDeploymentReconciler_reconcileGMSResourceClaimTemplates_DRAV
 			}
 			g.Expect(err).NotTo(gomega.HaveOccurred())
 		})
+	}
+}
+
+func TestDynamoGraphDeploymentReconciler_reconcileGMSResourceClaimTemplates_ToleratesNonGMSComponents(t *testing.T) {
+	ctx := context.Background()
+	s := newDynamoGraphDeploymentControllerTestScheme(t)
+	dgd := &v1beta1.DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-dgd", Namespace: "default"},
+		Spec: v1beta1.DynamoGraphDeploymentSpec{
+			Components: []v1beta1.DynamoComponentDeploymentSharedSpec{
+				{
+					ComponentName: "frontend",
+					ComponentType: v1beta1.ComponentTypeFrontend,
+				},
+				{
+					ComponentName: "decode",
+					ComponentType: v1beta1.ComponentTypeDecode,
+				},
+			},
+		},
+	}
+	r := &DynamoGraphDeploymentReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(s).
+			WithObjects(dgd).
+			Build(),
+		Recorder:      record.NewFakeRecorder(100),
+		RuntimeConfig: &controller_common.RuntimeConfig{DRAEnabled: true},
+	}
+
+	if err := r.reconcileGMSResourceClaimTemplates(ctx, dgd); err != nil {
+		t.Fatalf("reconcileGMSResourceClaimTemplates() returned error for non-GMS components: %v", err)
+	}
+}
+
+func TestDynamoGraphDeploymentReconciler_reconcileGMSResourceClaimTemplates_CleansStaleNonGMSResourceClaimTemplate(t *testing.T) {
+	ctx := context.Background()
+	s := newDynamoGraphDeploymentControllerTestScheme(t)
+	dgd := &v1beta1.DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-dgd", Namespace: "default"},
+		Spec: v1beta1.DynamoGraphDeploymentSpec{
+			Components: []v1beta1.DynamoComponentDeploymentSharedSpec{
+				{
+					ComponentName: "decode",
+					ComponentType: v1beta1.ComponentTypeDecode,
+				},
+			},
+		},
+	}
+	templateName := "test-dgd-decode-gpu"
+	rct := &resourcev1.ResourceClaimTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: templateName, Namespace: "default"},
+	}
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(dgd, rct).
+		Build()
+	r := &DynamoGraphDeploymentReconciler{
+		Client:        cl,
+		Recorder:      record.NewFakeRecorder(100),
+		RuntimeConfig: &controller_common.RuntimeConfig{DRAEnabled: true},
+	}
+
+	if err := r.reconcileGMSResourceClaimTemplates(ctx, dgd); err != nil {
+		t.Fatalf("reconcileGMSResourceClaimTemplates() returned error: %v", err)
+	}
+	got := &resourcev1.ResourceClaimTemplate{}
+	err := cl.Get(ctx, client.ObjectKey{Name: templateName, Namespace: "default"}, got)
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("expected stale ResourceClaimTemplate to be deleted, got %v", err)
 	}
 }
 

--- a/deploy/operator/internal/controller_common/predicate.go
+++ b/deploy/operator/internal/controller_common/predicate.go
@@ -23,7 +23,9 @@ import (
 
 	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
 	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	resourcev1 "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/discovery"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -62,10 +64,9 @@ func DetectInferencePoolAvailability(ctx context.Context, mgr ctrl.Manager) bool
 	return detectAPIGroupAvailability(ctx, mgr, "inference.networking.k8s.io")
 }
 
-// DetectDRAAvailability checks if Dynamic Resource Allocation is available
-// by checking if the resource.k8s.io API group is registered (Kubernetes 1.32+)
+// DetectDRAAvailability checks if the DRA API version used by this operator is available.
 func DetectDRAAvailability(ctx context.Context, mgr ctrl.Manager) bool {
-	return detectAPIGroupAvailability(ctx, mgr, "resource.k8s.io")
+	return detectAPIGroupVersionAvailability(ctx, mgr, resourcev1.SchemeGroupVersion.Group, resourcev1.SchemeGroupVersion.Version)
 }
 
 // DetectIstioAvailability checks if Istio is available by checking if the
@@ -97,14 +98,64 @@ func detectAPIGroupAvailability(ctx context.Context, mgr ctrl.Manager, groupName
 		return false
 	}
 
-	for _, group := range apiGroups.Groups {
-		if group.Name == groupName {
-			logger.Info("API group is available", "group", groupName)
-			return true
-		}
+	if apiGroupServesVersion(apiGroups, groupName, "") {
+		logger.Info("API group is available", "group", groupName)
+		return true
 	}
 
 	logger.Info("API group not available", "group", groupName)
+	return false
+}
+
+// detectAPIGroupVersionAvailability checks if a specific API group/version is registered in the cluster.
+func detectAPIGroupVersionAvailability(ctx context.Context, mgr ctrl.Manager, groupName, version string) bool {
+	logger := log.FromContext(ctx)
+
+	cfg := mgr.GetConfig()
+	if cfg == nil {
+		logger.Info("detection failed, no discovery client available", "group", groupName, "version", version)
+		return false
+	}
+
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(cfg)
+	if err != nil {
+		logger.Error(err, "detection failed, could not create discovery client", "group", groupName, "version", version)
+		return false
+	}
+
+	apiGroups, err := discoveryClient.ServerGroups()
+	if err != nil {
+		logger.Error(err, "detection failed, could not list server groups", "group", groupName, "version", version)
+		return false
+	}
+
+	if apiGroupServesVersion(apiGroups, groupName, version) {
+		logger.Info("API group version is available", "group", groupName, "version", version)
+		return true
+	}
+
+	logger.Info("API group version not available", "group", groupName, "version", version)
+	return false
+}
+
+func apiGroupServesVersion(apiGroups *metav1.APIGroupList, groupName, version string) bool {
+	if apiGroups == nil {
+		return false
+	}
+	for _, group := range apiGroups.Groups {
+		if group.Name != groupName {
+			continue
+		}
+		if version == "" {
+			return true
+		}
+		for _, served := range group.Versions {
+			if served.Version == version {
+				return true
+			}
+		}
+		return false
+	}
 	return false
 }
 

--- a/deploy/operator/internal/controller_common/predicate.go
+++ b/deploy/operator/internal/controller_common/predicate.go
@@ -40,101 +40,86 @@ type ExcludedNamespacesInterface interface {
 
 // DetectGroveAvailability checks if Grove is available by checking if the Grove API group is registered
 func DetectGroveAvailability(ctx context.Context, mgr ctrl.Manager) bool {
-	return detectAPIGroupAvailability(ctx, mgr, "grove.io")
+	return detectAPIGroupAvailability(ctx, mgr, "grove.io", nil)
 }
 
 // DetectLWSAvailability checks if LWS is available by checking if the LWS API group is registered
 func DetectLWSAvailability(ctx context.Context, mgr ctrl.Manager) bool {
-	return detectAPIGroupAvailability(ctx, mgr, "leaderworkerset.x-k8s.io")
+	return detectAPIGroupAvailability(ctx, mgr, "leaderworkerset.x-k8s.io", nil)
 }
 
 // DetectVolcanoAvailability checks if Volcano is available by checking if the Volcano API group is registered
 func DetectVolcanoAvailability(ctx context.Context, mgr ctrl.Manager) bool {
-	return detectAPIGroupAvailability(ctx, mgr, "scheduling.volcano.sh")
+	return detectAPIGroupAvailability(ctx, mgr, "scheduling.volcano.sh", nil)
 }
 
 // DetectKaiSchedulerAvailability checks if Kai-scheduler is available by checking if the scheduling.run.ai API group is registered
 func DetectKaiSchedulerAvailability(ctx context.Context, mgr ctrl.Manager) bool {
-	return detectAPIGroupAvailability(ctx, mgr, "scheduling.run.ai")
+	return detectAPIGroupAvailability(ctx, mgr, "scheduling.run.ai", nil)
 }
 
 // DetectInferencePoolAvailability checks if the Gateway API Inference Extension is available
 // by checking if the inference.networking.k8s.io API group is registered
 func DetectInferencePoolAvailability(ctx context.Context, mgr ctrl.Manager) bool {
-	return detectAPIGroupAvailability(ctx, mgr, "inference.networking.k8s.io")
+	return detectAPIGroupAvailability(ctx, mgr, "inference.networking.k8s.io", nil)
 }
 
 // DetectDRAAvailability checks if the DRA API version used by this operator is available.
 func DetectDRAAvailability(ctx context.Context, mgr ctrl.Manager) bool {
-	return detectAPIGroupVersionAvailability(ctx, mgr, resourcev1.SchemeGroupVersion.Group, resourcev1.SchemeGroupVersion.Version)
+	version := resourcev1.SchemeGroupVersion.Version
+	return detectAPIGroupAvailability(ctx, mgr, resourcev1.SchemeGroupVersion.Group, &version)
 }
 
 // DetectIstioAvailability checks if Istio is available by checking if the
 // networking.istio.io API group is registered. Used to guard DestinationRule
 // reconciliation so the operator doesn't error on clusters without Istio CRDs.
 func DetectIstioAvailability(ctx context.Context, mgr ctrl.Manager) bool {
-	return detectAPIGroupAvailability(ctx, mgr, "networking.istio.io")
+	return detectAPIGroupAvailability(ctx, mgr, "networking.istio.io", nil)
 }
 
-// detectAPIGroupAvailability checks if a specific API group is registered in the cluster
-func detectAPIGroupAvailability(ctx context.Context, mgr ctrl.Manager, groupName string) bool {
+// detectAPIGroupAvailability checks if a specific API group, and optionally a
+// specific version, is registered in the cluster.
+func detectAPIGroupAvailability(ctx context.Context, mgr ctrl.Manager, groupName string, version *string) bool {
 	logger := log.FromContext(ctx)
+	logValues := []any{"group", groupName}
+	versionValue := ""
+	if version != nil {
+		versionValue = *version
+		logValues = append(logValues, "version", versionValue)
+	}
 
 	cfg := mgr.GetConfig()
 	if cfg == nil {
-		logger.Info("detection failed, no discovery client available", "group", groupName)
+		logger.Info("detection failed, no discovery client available", logValues...)
 		return false
 	}
 
 	discoveryClient, err := discovery.NewDiscoveryClientForConfig(cfg)
 	if err != nil {
-		logger.Error(err, "detection failed, could not create discovery client", "group", groupName)
+		logger.Error(err, "detection failed, could not create discovery client", logValues...)
 		return false
 	}
 
 	apiGroups, err := discoveryClient.ServerGroups()
 	if err != nil {
-		logger.Error(err, "detection failed, could not list server groups", "group", groupName)
+		logger.Error(err, "detection failed, could not list server groups", logValues...)
 		return false
 	}
 
-	if apiGroupServesVersion(apiGroups, groupName, "") {
-		logger.Info("API group is available", "group", groupName)
+	if apiGroupServesVersion(apiGroups, groupName, versionValue) {
+		if version == nil {
+			logger.Info("API group is available", logValues...)
+		} else {
+			logger.Info("API group version is available", logValues...)
+		}
 		return true
 	}
 
-	logger.Info("API group not available", "group", groupName)
-	return false
-}
-
-// detectAPIGroupVersionAvailability checks if a specific API group/version is registered in the cluster.
-func detectAPIGroupVersionAvailability(ctx context.Context, mgr ctrl.Manager, groupName, version string) bool {
-	logger := log.FromContext(ctx)
-
-	cfg := mgr.GetConfig()
-	if cfg == nil {
-		logger.Info("detection failed, no discovery client available", "group", groupName, "version", version)
-		return false
+	if version == nil {
+		logger.Info("API group not available", logValues...)
+	} else {
+		logger.Info("API group version not available", logValues...)
 	}
-
-	discoveryClient, err := discovery.NewDiscoveryClientForConfig(cfg)
-	if err != nil {
-		logger.Error(err, "detection failed, could not create discovery client", "group", groupName, "version", version)
-		return false
-	}
-
-	apiGroups, err := discoveryClient.ServerGroups()
-	if err != nil {
-		logger.Error(err, "detection failed, could not list server groups", "group", groupName, "version", version)
-		return false
-	}
-
-	if apiGroupServesVersion(apiGroups, groupName, version) {
-		logger.Info("API group version is available", "group", groupName, "version", version)
-		return true
-	}
-
-	logger.Info("API group version not available", "group", groupName, "version", version)
 	return false
 }
 

--- a/deploy/operator/internal/controller_common/predicate_test.go
+++ b/deploy/operator/internal/controller_common/predicate_test.go
@@ -1,0 +1,65 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controller_common
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestAPIGroupServesVersion(t *testing.T) {
+	apiGroups := &metav1.APIGroupList{
+		Groups: []metav1.APIGroup{
+			{
+				Name: "resource.k8s.io",
+				Versions: []metav1.GroupVersionForDiscovery{
+					{GroupVersion: "resource.k8s.io/v1beta1", Version: "v1beta1"},
+					{GroupVersion: "resource.k8s.io/v1beta2", Version: "v1beta2"},
+				},
+			},
+			{
+				Name: "apps",
+				Versions: []metav1.GroupVersionForDiscovery{
+					{GroupVersion: "apps/v1", Version: "v1"},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name      string
+		groupName string
+		version   string
+		want      bool
+	}{
+		{name: "group exists when version omitted", groupName: "resource.k8s.io", want: true},
+		{name: "served beta version exists", groupName: "resource.k8s.io", version: "v1beta2", want: true},
+		{name: "unserved v1 version is unavailable", groupName: "resource.k8s.io", version: "v1", want: false},
+		{name: "different group with v1 exists", groupName: "apps", version: "v1", want: true},
+		{name: "missing group is unavailable", groupName: "missing.example.com", version: "v1", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := apiGroupServesVersion(apiGroups, tt.groupName, tt.version); got != tt.want {
+				t.Fatalf("apiGroupServesVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/deploy/operator/internal/controller_common/runtime.go
+++ b/deploy/operator/internal/controller_common/runtime.go
@@ -26,7 +26,7 @@ type RuntimeConfig struct {
 	LWSEnabled bool
 	// KaiSchedulerEnabled is the resolved Kai-scheduler availability (config override merged with auto-detection)
 	KaiSchedulerEnabled bool
-	// DRAEnabled indicates whether Dynamic Resource Allocation (resource.k8s.io) is available
+	// DRAEnabled indicates whether Dynamic Resource Allocation (resource.k8s.io/v1) is available
 	DRAEnabled bool
 	// IstioAvailable indicates whether the networking.istio.io CRDs are installed.
 	// When false the operator skips DestinationRule reconciliation to avoid errors

--- a/docs/kubernetes/api-reference.md
+++ b/docs/kubernetes/api-reference.md
@@ -2707,10 +2707,10 @@ _Appears in:_
 
 
 
-DRAConfiguration holds Dynamic Resource Allocation (resource.k8s.io) settings.
+DRAConfiguration holds Dynamic Resource Allocation (resource.k8s.io/v1) settings.
 
-NOTE: auto-detection here only verifies that the resource.k8s.io API group is
-registered on the apiserver (Kubernetes 1.32+). It does NOT verify that a
+NOTE: auto-detection here only verifies that the resource.k8s.io/v1 API is
+registered on the apiserver (Kubernetes 1.34+). It does NOT verify that a
 GPU-specific DRA resource driver (e.g. nvidia/k8s-dra-driver-gpu) is
 installed, that its DeviceClass exists, or that node-level GPU drivers are
 compatible. An admin can use `enabled: false` to force-off DRA integration
@@ -2726,7 +2726,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `enabled` _boolean_ | Enabled overrides auto-detection of the resource.k8s.io API group.<br />nil = auto-detect. Setting true requires detection to also succeed (the<br />operator will exit at startup otherwise). |  |  |
+| `enabled` _boolean_ | Enabled overrides auto-detection of the resource.k8s.io/v1 API.<br />nil = auto-detect. Setting true requires detection to also succeed (the<br />operator will exit at startup otherwise). |  |  |
 
 
 #### DiscoveryBackend

--- a/docs/kubernetes/shadow-engine-failover.md
+++ b/docs/kubernetes/shadow-engine-failover.md
@@ -98,7 +98,7 @@ active/passive failover; use the `failover` field for the shadow engine flow.
 
 ## Prerequisites
 
-- Kubernetes 1.32 or newer with DRA enabled.
+- Kubernetes 1.34 or newer with DRA v1 (`resource.k8s.io/v1`) enabled.
 - NVIDIA GPU DRA driver installed.
 - A matching DRA `DeviceClass`, defaulting to `gpu.nvidia.com`.
 - A supported backend image. The current failover examples are vLLM-focused.

--- a/examples/backends/sglang/deploy/agg_gms.yaml
+++ b/examples/backends/sglang/deploy/agg_gms.yaml
@@ -8,7 +8,7 @@
 # processes per GPU (weights + kv_cache) and communicates with the main container
 # over UDS sockets on a shared emptyDir volume.
 #
-# Requires Kubernetes 1.32+ with DRA enabled and the NVIDIA GPU DRA driver installed.
+# Requires Kubernetes 1.34+ with DRA v1 enabled and the NVIDIA GPU DRA driver installed.
 
 apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment

--- a/examples/backends/vllm/deploy/agg_failover.yaml
+++ b/examples/backends/vllm/deploy/agg_failover.yaml
@@ -10,7 +10,7 @@
 # Requires:
 #   - gpuMemoryService.enabled: true (GMS sidecar + DRA)
 #   - nvidia.com/dynamo-kube-discovery-mode: container (per-container K8s discovery)
-#   - Kubernetes 1.32+ with DRA enabled and the NVIDIA GPU DRA driver installed
+#   - Kubernetes 1.34+ with DRA v1 enabled and the NVIDIA GPU DRA driver installed
 
 apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment

--- a/examples/backends/vllm/deploy/agg_gms.yaml
+++ b/examples/backends/vllm/deploy/agg_gms.yaml
@@ -8,7 +8,7 @@
 # processes per GPU (weights + kv_cache) and communicates with the main container
 # over UDS sockets on a shared emptyDir volume.
 #
-# Requires Kubernetes 1.32+ with DRA enabled and the NVIDIA GPU DRA driver installed.
+# Requires Kubernetes 1.34+ with DRA v1 enabled and the NVIDIA GPU DRA driver installed.
 
 apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment


### PR DESCRIPTION
## Summary

Fix DRA handling for GMS ResourceClaimTemplates by requiring the `resource.k8s.io/v1` API before syncing v1 RCTs.

## Changes

- Detect `resource.k8s.io/v1` instead of only the `resource.k8s.io` API group.
- Skip GMS RCT sync when GMS is disabled and DRA v1 is unavailable.
- Return a clear error when GMS requires DRA but `resource.k8s.io/v1` is not available.
- Preserve stale RCT cleanup when DRA v1 is available.
- Update generated API docs and examples to call out Kubernetes 1.34+ DRA v1 support.

Fixes #9449 

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9454" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Kubernetes version requirements for Dynamic Resource Allocation support from 1.32+ to 1.34+.
  * Updated all example deployment configurations to reflect the new version requirement.

* **Bug Fixes**
  * Improved detection of Dynamic Resource Allocation API availability to specifically validate the v1 version is present on the cluster.

* **Tests**
  * Added comprehensive test coverage for Dynamic Resource Allocation functionality and version detection.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9454)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->