### PR TITLE
fix: support ModelExpress non-shared-storage mode

### DIFF
--- a/docs/getting-started/local-installation.md
+++ b/docs/getting-started/local-installation.md
@@ -154,7 +154,12 @@ python3 -m dynamo.trtllm --model-path Qwen/Qwen3-0.6B --discovery-backend file
 ```
 
 The warning `Cannot connect to ModelExpress server/transport error. Using direct download.`
-is expected in local deployments and can be safely ignored.
+is expected in this local single-machine setup (no ModelExpress server running) and can
+be safely ignored. In a Kubernetes deployment where `MODEL_EXPRESS_URL` is configured,
+this warning -- or the related `Failed to resolve local model path after server download`
+-- indicates that ModelExpress is configured but is not actually serving cached models;
+see [Model Caching in Kubernetes](../kubernetes/model-caching.md#option-2-modelexpress-p2p-distribution)
+for the correct configuration.
 
 **vLLM**
 

--- a/docs/kubernetes/model-caching.md
+++ b/docs/kubernetes/model-caching.md
@@ -158,7 +158,7 @@ Use this path when startup time or fleet-wide model rollout time matters more th
 1. A ModelExpress server runs in the cluster and stores metadata for available sources.
 2. vLLM workers use the ModelExpress loader (`--load-format mx` on newer ModelExpress images, or `mx-source` / `mx-target` on older split-loader images).
 3. If a compatible source is already serving the model, a new worker pulls model tensors from that source over NIXL/RDMA.
-4. If no source is available, the worker falls back to storage. When `MX_MODEL_URI` is set, ModelStreamer can stream safetensors from S3, GCS, Azure Blob Storage, or a local path.
+4. If no source is available, the worker falls back to storage. With a shared filesystem (RWX PVC, NFS, hostPath), the worker reads directly from the server's cache. Without a shared filesystem, set `MODEL_EXPRESS_NO_SHARED_STORAGE=1` so the client streams files from the server over gRPC; see [Streaming Without Shared Storage](#streaming-without-shared-storage) below. When `MX_MODEL_URI` is set, ModelStreamer can stream safetensors from S3, GCS, Azure Blob Storage, or a local path.
 5. The Kubernetes operator can inject `MODEL_EXPRESS_URL` into all Dynamo pods from the platform `modelExpressURL` setting.
 
 ### What To Configure
@@ -207,6 +207,41 @@ When `MODEL_EXPRESS_URL` is configured in the operator, it is automatically inje
 <Note>
 Use the load format supported by your runtime image. ModelExpress v0.3 and newer document the unified `mx` loader. Some Dynamo images still expose the older split `mx-source` and `mx-target` loader names; those require the same server URL but separate source and target roles.
 </Note>
+
+### Streaming Without Shared Storage
+
+If the ModelExpress server's cache is on a non-shared volume (e.g. a `ReadWriteOnce` PVC, a cross-namespace deployment, or any topology where worker pods cannot mount the same filesystem as the server), the default shared-storage mode fails: the server reports the model as downloaded and returns its own local path, the worker cannot read that path from inside its own pod, and the load silently falls back to a direct HuggingFace download -- defeating the point of running ModelExpress.
+
+Set `MODEL_EXPRESS_NO_SHARED_STORAGE=1` on every worker pod to switch the ModelExpress client into gRPC streaming mode. The server then sends model files to the client over the existing gRPC channel and the worker writes them to its own local cache.
+
+```yaml
+services:
+  VllmWorker:
+    extraPodSpec:
+      mainContainer:
+        image: <vllm-runtime-image-with-modelexpress>
+        command: ["python3", "-m", "dynamo.vllm"]
+        args:
+          - --model
+          - meta-llama/Llama-3.1-70B-Instruct
+          - --load-format
+          - mx
+        env:
+          - name: VLLM_PLUGINS
+            value: modelexpress
+          - name: MODEL_EXPRESS_NO_SHARED_STORAGE
+            value: "1"
+```
+
+`MODEL_EXPRESS_URL` is injected automatically by the operator (`dynamo-operator.modelExpressURL`); you do not need to set it explicitly here. No volume mount for the ModelExpress cache is required on worker pods in this mode.
+
+Use this path when:
+
+- The server runs with an RWO PVC, or in a different namespace from the workers.
+- The cluster has no RDMA / InfiniBand fabric available, so P2P over NIXL is not an option.
+- You want ModelExpress to act as a centralized download-and-cache server (one HuggingFace pull, fan out over gRPC to many workers) without standing up object storage and `MX_MODEL_URI`.
+
+Shared-filesystem mode is still faster when available, so prefer an RWX PVC mounted on both the server and the workers when the storage class supports it. See the [ModelExpress storage access modes documentation](https://github.com/ai-dynamo/modelexpress/blob/main/docs/DEPLOYMENT.md#storage-access-modes) for the full trade-off and tuning knobs (chunk size, etc.).
 
 ### ModelStreamer From Object Storage
 
@@ -261,6 +296,7 @@ Use Shadow Engine Failover only when you specifically need an active/shadow reco
 | Models already on shared storage (NFS) | PVC |
 | Models in S3, GCS, Azure Blob Storage, or local safetensors paths | ModelExpress + ModelStreamer |
 | Frequent model updates across fleet | ModelExpress P2P, optionally seeded by ModelStreamer |
+| ModelExpress server with non-shared storage (RWO PVC, cross-namespace) | ModelExpress with `MODEL_EXPRESS_NO_SHARED_STORAGE=1` |
 
 ## See Also
 

--- a/lib/llm/src/hub.rs
+++ b/lib/llm/src/hub.rs
@@ -70,6 +70,17 @@ fn is_offline_mode() -> bool {
         .unwrap_or(false)
 }
 
+/// Check if shared-storage mode is disabled via MODEL_EXPRESS_NO_SHARED_STORAGE.
+/// When true, the Model Express client streams files from the server over gRPC
+/// instead of relying on a shared filesystem path. This is required when the
+/// server and worker pods do not share a filesystem (e.g. RWO PVCs, cross-namespace
+/// deployments).
+fn is_no_shared_storage() -> bool {
+    env::var(env_model::model_express::MODEL_EXPRESS_NO_SHARED_STORAGE)
+        .map(|v| v == "1" || v.to_lowercase() == "true")
+        .unwrap_or(false)
+}
+
 /// Download a model using ModelExpress client. The client first requests for the model
 /// from the server and fallbacks to direct download in case of server failure.
 /// If ignore_weights is true, model weight files will be skipped
@@ -97,6 +108,9 @@ pub async fn from_hf(name: impl AsRef<Path>, ignore_weights: bool) -> anyhow::Re
     let mut config: MxClientConfig = MxClientConfig::default();
     if let Ok(endpoint) = env::var(env_model::model_express::MODEL_EXPRESS_URL) {
         config = config.with_endpoint(endpoint);
+    }
+    if is_no_shared_storage() {
+        config.cache.shared_storage = false;
     }
 
     let result = match MxClient::new(config).await {

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -663,6 +663,7 @@ mod tests {
             // Model
             model::model_express::MODEL_EXPRESS_URL,
             model::model_express::MODEL_EXPRESS_CACHE_PATH,
+            model::model_express::MODEL_EXPRESS_NO_SHARED_STORAGE,
             model::huggingface::HF_TOKEN,
             model::huggingface::HF_HUB_CACHE,
             model::huggingface::HF_HOME,

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -424,6 +424,13 @@ pub mod model {
 
         /// Model Express cache path
         pub const MODEL_EXPRESS_CACHE_PATH: &str = "MODEL_EXPRESS_CACHE_PATH";
+
+        /// Disable shared-storage mode for the Model Express client. When set,
+        /// the client streams model files from the server over gRPC instead of
+        /// relying on a shared filesystem path. Required when the Model Express
+        /// server and worker pods do not share a filesystem (e.g. RWO PVCs,
+        /// cross-namespace deployments). Set to "1" or "true" to enable.
+        pub const MODEL_EXPRESS_NO_SHARED_STORAGE: &str = "MODEL_EXPRESS_NO_SHARED_STORAGE";
     }
 
     /// Hugging Face configuration


### PR DESCRIPTION
When MODEL_EXPRESS_URL is configured for a deployment whose ModelExpress
server runs on a non-shared filesystem, such as an RWO PVC or a cross-
namespace deployment, the dynamo client receives the server's absolute
filesystem path from get_model_path, fails to resolve it inside its own
pod, and silently falls back to direct HuggingFace downloads. ModelExpress
provides zero caching benefit in this topology.

ModelExpress 0.3.0 and later already implement the gRPC streaming path
when its client config has shared_storage=false, but dynamo's hub.rs
constructs MxClientConfig with defaults and never reads the corresponding
MX env var. Operators have no way to opt into streaming mode through
dynamo's surface today.

Changes:
- Add MODEL_EXPRESS_NO_SHARED_STORAGE to dynamo_runtime's environment_names
  module alongside MODEL_EXPRESS_URL, matching the existing convention.
- Read the env var in hub.rs and flip config.cache.shared_storage=false on
  the MX client when set. Parsing mirrors the existing is_offline_mode
  helper and accepts "1" or "true" case-insensitively.
- Add a Streaming Without Shared Storage section to docs/kubernetes/model-
  caching.md as a peer of the existing PVC, P2P, and ModelStreamer paths,
  with a working DGD example and a decision-table entry.
- Update step 4 of How It Works to be explicit about the shared-filesystem
  versus streaming choice and the silent-fallback failure mode without the
  env var.
- Scope the misleading "Cannot connect to ModelExpress server warning is
  expected" line in docs/getting-started/local-installation.md to the
  local single-machine case only, with a pointer to the Kubernetes guide
  for the production failure mode.

Fixes #8835.

Signed-off-by: Nicolas 'Pixel' Noble <nicolas@nobis-crew.org>

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9456" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced local installation guide with detailed explanation of ModelExpress connection messages in single-machine and Kubernetes setups.
  * Expanded model caching documentation with clarification on shared vs. non-shared storage behavior and a new guide for streaming without shared storage in Kubernetes.

* **New Features**
  * Added environment variable to disable Model Express shared-storage mode, enabling model file streaming via gRPC in non-shared storage configurations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9456)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->