### PR TITLE
ci: use services for NATS and etcd in tests

### DIFF
--- a/.github/actions/pytest-local/action.yml
+++ b/.github/actions/pytest-local/action.yml
@@ -91,6 +91,59 @@ runs:
           fi
           sleep 1
         done
+    - name: Verify runtime services
+      shell: python
+      run: |
+        import os
+        import socket
+        import time
+        import urllib.parse
+        import urllib.request
+
+        def wait_tcp(name: str, endpoint: str, default_port: int, timeout: int = 60) -> None:
+            parsed = urllib.parse.urlparse(endpoint)
+            host = parsed.hostname or "localhost"
+            port = parsed.port or default_port
+            deadline = time.monotonic() + timeout
+            last_error = None
+            while time.monotonic() < deadline:
+                try:
+                    with socket.create_connection((host, port), timeout=2):
+                        print(f"{name} is ready at {host}:{port}")
+                        return
+                except OSError as exc:
+                    last_error = exc
+                    time.sleep(1)
+            raise SystemExit(f"{name} was not reachable at {host}:{port}: {last_error}")
+
+        def wait_http_health(name: str, endpoint: str, timeout: int = 60) -> None:
+            first_endpoint = endpoint.split(",", 1)[0].rstrip("/")
+            health_url = f"{first_endpoint}/health"
+            deadline = time.monotonic() + timeout
+            last_error = None
+            while time.monotonic() < deadline:
+                try:
+                    with urllib.request.urlopen(health_url, timeout=2) as response:
+                        if response.status < 500:
+                            print(f"{name} is ready at {first_endpoint}")
+                            return
+                except Exception as exc:
+                    last_error = exc
+                    time.sleep(1)
+            raise SystemExit(f"{name} was not healthy at {health_url}: {last_error}")
+
+        nats_server = os.environ.get("NATS_SERVER")
+        etcd_endpoints = os.environ.get("ETCD_ENDPOINTS")
+
+        if nats_server:
+            wait_tcp("NATS", nats_server, 4222)
+        else:
+            print("NATS_SERVER is unset; pytest fixtures may start local NATS if needed")
+
+        if etcd_endpoints:
+            wait_http_health("etcd", etcd_endpoints)
+        else:
+            print("ETCD_ENDPOINTS is unset; pytest fixtures may start local etcd if needed")
     - name: Verify GPU visibility
       if: inputs.gpu_tests == 'true'
       shell: python

--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -121,9 +121,17 @@ jobs:
         #   * torch._inductor calling getpass.getuser() -> pwd.getpwuid(1001) -> KeyError
         HOME: /__w/dynamo/dynamo
         USER: dynamo
+        NATS_SERVER: nats://localhost:4222
+        ETCD_ENDPOINTS: http://localhost:2379
     permissions:
       contents: read
     services:
+      nats:
+        image: ${{ vars.RUNNERS_REGISTRY }}/dockerhub/library/nats:2.11.4
+      etcd:
+        image: ${{ vars.RUNNERS_REGISTRY }}/quay/coreos/etcd:v3.5.18
+        env:
+          ETCD_DATA_DIR: /tmp/etcd-data
       minio:
         image: ${{ vars.RUNNERS_REGISTRY }}/quay/minio/minio:latest
         env:
@@ -131,9 +139,6 @@ jobs:
           MINIO_ROOT_PASSWORD: minioadmin
           MINIO_VOLUMES: /tmp/minio-data
           MINIO_CONSOLE_ADDRESS: ':9001'
-        ports:
-          - 9000:9000
-          - 9001:9001
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,8 +6,10 @@ import logging
 import os
 import shutil
 import tempfile
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Generator, Optional
+from urllib.parse import urlparse
 
 import pytest
 from filelock import FileLock
@@ -646,18 +648,24 @@ def pytest_collection_modifyitems(config, items):
 
 class EtcdServer(ManagedProcess):
     def __init__(self, request, port=2379, timeout=300):
-        # Allocate free ports if port is 0
-        use_random_port = port == 0
-        if use_random_port:
-            # Need two ports: client port and peer port for parallel execution
-            # Start from 2380 (etcd default 2379 + 1)
+        self._allocated_ports: list[int] = []
+        # Allocate free ports if port is 0. Etcd needs a separate peer port;
+        # configuring it explicitly avoids the default 2380 peer listener when
+        # the client port itself is dynamic.
+        if port == 0:
+            # Need two ports: client port and peer port for parallel execution.
+            # Start from 2380 (etcd default 2379 + 1).
             port, peer_port = allocate_ports(2, 2380)
+            self._allocated_ports.extend([port, peer_port])
+        elif port != 2379:
+            peer_port = allocate_port(2380)
+            self._allocated_ports.append(peer_port)
         else:
             peer_port = None
 
         self.port = port
         self.peer_port = peer_port  # Store for cleanup
-        self.use_random_port = use_random_port  # Track if we allocated the port
+        self.use_random_port = bool(self._allocated_ports)
         port_string = str(port)
         etcd_env = os.environ.copy()
         etcd_env["ALLOW_NONE_AUTHENTICATION"] = "yes"
@@ -696,7 +704,8 @@ class EtcdServer(ManagedProcess):
             command=command,
             timeout=timeout,
             display_output=False,
-            terminate_all_matching_process_names=not use_random_port,  # For distributed tests, do not terminate all matching processes
+            terminate_all_matching_process_names=port
+            == 2379,  # For distributed tests, do not terminate all matching processes
             health_check_ports=[port],
             data_dir=data_dir,
             log_dir=request.node.name,
@@ -705,12 +714,10 @@ class EtcdServer(ManagedProcess):
     def __exit__(self, exc_type, exc_val, exc_tb):
         """Release allocated ports when server exits."""
         try:
-            # Only deallocate ports that were dynamically allocated (not default ports)
-            if self.use_random_port:
-                ports_to_release = [self.port]
-                if self.peer_port is not None:
-                    ports_to_release.append(self.peer_port)
-                deallocate_ports(ports_to_release)
+            # Only deallocate ports this object allocated itself.
+            if self._allocated_ports:
+                deallocate_ports(self._allocated_ports)
+                self._allocated_ports = []
         except Exception as e:
             logging.warning(f"Failed to release EtcdServer port: {e}")
 
@@ -962,6 +969,55 @@ class SharedNatsServer(SharedManagedProcess):
         return server
 
 
+class ExternalRuntimeService:
+    """Reference to a runtime service provided outside pytest."""
+
+    def __init__(self, endpoint: str, default_port: int):
+        parsed = urlparse(endpoint)
+        self.endpoint = endpoint
+        self.host = parsed.hostname or "localhost"
+        self.port = parsed.port or default_port
+
+
+def _configured_runtime_services(discovery_backend: str, request_plane: str):
+    """Return externally configured runtime services, if all required endpoints exist."""
+    needs_nats = request_plane == "nats"
+    needs_etcd = discovery_backend == "etcd"
+
+    nats_endpoint = os.environ.get("NATS_SERVER")
+    etcd_endpoint = os.environ.get("ETCD_ENDPOINTS")
+
+    if (needs_nats and not nats_endpoint) or (needs_etcd and not etcd_endpoint):
+        return None
+
+    nats = ExternalRuntimeService(nats_endpoint, 4222) if needs_nats else None
+    etcd = ExternalRuntimeService(etcd_endpoint, 2379) if needs_etcd else None
+    return nats, etcd
+
+
+@contextmanager
+def _runtime_service_env(nats_process=None, etcd_process=None):
+    """Expose dynamically-started runtime service endpoints to child processes."""
+    orig_nats = os.environ.get("NATS_SERVER")
+    orig_etcd = os.environ.get("ETCD_ENDPOINTS")
+
+    try:
+        if nats_process is not None:
+            os.environ["NATS_SERVER"] = f"nats://localhost:{nats_process.port}"
+        if etcd_process is not None:
+            os.environ["ETCD_ENDPOINTS"] = f"http://localhost:{etcd_process.port}"
+        yield
+    finally:
+        if orig_nats is not None:
+            os.environ["NATS_SERVER"] = orig_nats
+        else:
+            os.environ.pop("NATS_SERVER", None)
+        if orig_etcd is not None:
+            os.environ["ETCD_ENDPOINTS"] = orig_etcd
+        else:
+            os.environ.pop("ETCD_ENDPOINTS", None)
+
+
 @pytest.fixture
 def discovery_backend(request):
     """
@@ -1016,20 +1072,29 @@ def runtime_services(request, discovery_backend, request_plane):
 
     - If discovery_backend != "etcd", etcd is not started (returns None)
     - If request_plane != "nats", NATS is not started (returns None)
+    - If NATS_SERVER/ETCD_ENDPOINTS are already set, those external services are reused.
 
     Returns a tuple of (nats_process, etcd_process) where each has a .port attribute.
     """
+    configured_services = _configured_runtime_services(discovery_backend, request_plane)
+    if configured_services is not None:
+        yield configured_services
+        return
+
     # Port cleanup is now handled in NatsServer and EtcdServer __exit__ methods
     if request_plane == "nats" and discovery_backend == "etcd":
-        with NatsServer(request) as nats_process:
-            with EtcdServer(request) as etcd_process:
-                yield nats_process, etcd_process
+        with NatsServer(request, port=0) as nats_process:
+            with EtcdServer(request, port=0) as etcd_process:
+                with _runtime_service_env(nats_process, etcd_process):
+                    yield nats_process, etcd_process
     elif request_plane == "nats":
-        with NatsServer(request) as nats_process:
-            yield nats_process, None
+        with NatsServer(request, port=0) as nats_process:
+            with _runtime_service_env(nats_process, None):
+                yield nats_process, None
     elif discovery_backend == "etcd":
-        with EtcdServer(request) as etcd_process:
-            yield None, etcd_process
+        with EtcdServer(request, port=0) as etcd_process:
+            with _runtime_service_env(None, etcd_process):
+                yield None, etcd_process
     else:
         yield None, None
 
@@ -1056,8 +1121,6 @@ def runtime_services_dynamic_ports(
 
     Returns a tuple of (nats_process, etcd_process) where each has a .port attribute.
     """
-    import os
-
     # Port cleanup is now handled in NatsServer and EtcdServer __exit__ methods
     # Always start NATS when etcd is used - KV events require NATS regardless of request_plane
     # When durable_kv_events=False (default), disable JetStream for faster startup
@@ -1066,36 +1129,14 @@ def runtime_services_dynamic_ports(
             request, port=0, disable_jetstream=not durable_kv_events
         ) as nats_process:
             with EtcdServer(request, port=0) as etcd_process:
-                # Save original env vars (may be set by session-scoped fixture)
-                orig_nats = os.environ.get("NATS_SERVER")
-                orig_etcd = os.environ.get("ETCD_ENDPOINTS")
-
-                # Set environment variables for this test's dynamic ports
-                os.environ["NATS_SERVER"] = f"nats://localhost:{nats_process.port}"
-                os.environ["ETCD_ENDPOINTS"] = f"http://localhost:{etcd_process.port}"
-
-                yield nats_process, etcd_process
-
-                # Restore original env vars (or remove if they weren't set)
-                if orig_nats is not None:
-                    os.environ["NATS_SERVER"] = orig_nats
-                else:
-                    os.environ.pop("NATS_SERVER", None)
-                if orig_etcd is not None:
-                    os.environ["ETCD_ENDPOINTS"] = orig_etcd
-                else:
-                    os.environ.pop("ETCD_ENDPOINTS", None)
+                with _runtime_service_env(nats_process, etcd_process):
+                    yield nats_process, etcd_process
     elif request_plane == "nats":
         with NatsServer(
             request, port=0, disable_jetstream=not durable_kv_events
         ) as nats_process:
-            orig_nats = os.environ.get("NATS_SERVER")
-            os.environ["NATS_SERVER"] = f"nats://localhost:{nats_process.port}"
-            yield nats_process, None
-            if orig_nats is not None:
-                os.environ["NATS_SERVER"] = orig_nats
-            else:
-                os.environ.pop("NATS_SERVER", None)
+            with _runtime_service_env(nats_process, None):
+                yield nats_process, None
     else:
         yield None, None
 

--- a/tests/fault_tolerance/etcd_ha/test_sglang.py
+++ b/tests/fault_tolerance/etcd_ha/test_sglang.py
@@ -16,6 +16,7 @@ from tests.conftest import NatsServer
 from tests.fault_tolerance.etcd_ha.utils import (
     DynamoFrontendProcess,
     EtcdCluster,
+    nats_server_env,
     send_inference_request,
     wait_for_processes_to_terminate,
 )
@@ -175,7 +176,7 @@ def test_etcd_ha_failover_sglang_aggregated(request, predownload_models):
     - Frontend/worker disconnection from their connected ETCD replica
     """
     # Step 1: Start NATS server
-    with NatsServer(request):
+    with NatsServer(request, port=0) as nats, nats_server_env(nats):
         logger.info("NATS server started successfully")
 
         # Step 2: Start 3-node ETCD cluster
@@ -252,7 +253,7 @@ def test_etcd_ha_failover_sglang_disaggregated(
     Note: This test requires 2 GPUs to run decode and prefill workers on separate GPUs.
     """
     # Step 1: Start NATS server
-    with NatsServer(request):
+    with NatsServer(request, port=0) as nats, nats_server_env(nats):
         logger.info("NATS server started successfully")
 
         # Step 2: Start 3-node ETCD cluster
@@ -324,7 +325,7 @@ def test_etcd_non_ha_shutdown_sglang_aggregated(request, predownload_models):
     5. Verifies that frontend and worker shut down gracefully
     """
     # Step 1: Start NATS server
-    with NatsServer(request):
+    with NatsServer(request, port=0) as nats, nats_server_env(nats):
         logger.info("NATS server started successfully")
 
         # Step 2: Start single ETCD node using EtcdCluster with num_replicas=1
@@ -385,7 +386,7 @@ def test_etcd_non_ha_shutdown_sglang_disaggregated(
     Note: This test requires 2 GPUs to run decode and prefill workers on separate GPUs.
     """
     # Step 1: Start NATS server
-    with NatsServer(request):
+    with NatsServer(request, port=0) as nats, nats_server_env(nats):
         logger.info("NATS server started successfully")
 
         # Step 2: Start single ETCD node using EtcdCluster with num_replicas=1

--- a/tests/fault_tolerance/etcd_ha/test_trtllm.py
+++ b/tests/fault_tolerance/etcd_ha/test_trtllm.py
@@ -12,6 +12,7 @@ from tests.conftest import NatsServer
 from tests.fault_tolerance.etcd_ha.utils import (
     DynamoFrontendProcess,
     EtcdCluster,
+    nats_server_env,
     send_inference_request,
     wait_for_processes_to_terminate,
 )
@@ -152,7 +153,7 @@ def test_etcd_ha_failover_trtllm_aggregated(request, predownload_models):
     - Frontend/worker disconnection from their connected ETCD replica
     """
     # Step 1: Start NATS server
-    with NatsServer(request):
+    with NatsServer(request, port=0) as nats, nats_server_env(nats):
         logger.info("NATS server started successfully")
 
         # Step 2: Start 3-node ETCD cluster
@@ -227,7 +228,7 @@ def test_etcd_ha_failover_trtllm_disaggregated(
     - Frontend/worker disconnection from their connected ETCD replica
     """
     # Step 1: Start NATS server
-    with NatsServer(request):
+    with NatsServer(request, port=0) as nats, nats_server_env(nats):
         logger.info("NATS server started successfully")
 
         # Step 2: Start 3-node ETCD cluster
@@ -300,7 +301,7 @@ def test_etcd_non_ha_shutdown_trtllm_aggregated(request, predownload_models):
     5. Verifies that frontend and worker shut down gracefully
     """
     # Step 1: Start NATS server
-    with NatsServer(request):
+    with NatsServer(request, port=0) as nats, nats_server_env(nats):
         logger.info("NATS server started successfully")
 
         # Step 2: Start single ETCD node using EtcdCluster with num_replicas=1
@@ -362,7 +363,7 @@ def test_etcd_non_ha_shutdown_trtllm_disaggregated(
     5. Verifies that frontend and both workers shut down gracefully
     """
     # Step 1: Start NATS server
-    with NatsServer(request):
+    with NatsServer(request, port=0) as nats, nats_server_env(nats):
         logger.info("NATS server started successfully")
 
         # Step 2: Start single ETCD node using EtcdCluster with num_replicas=1

--- a/tests/fault_tolerance/etcd_ha/test_vllm.py
+++ b/tests/fault_tolerance/etcd_ha/test_vllm.py
@@ -13,6 +13,7 @@ from tests.conftest import NatsServer
 from tests.fault_tolerance.etcd_ha.utils import (
     DynamoFrontendProcess,
     EtcdCluster,
+    nats_server_env,
     send_inference_request,
     wait_for_processes_to_terminate,
 )
@@ -176,7 +177,7 @@ def test_etcd_ha_failover_vllm_aggregated(request, predownload_models):
     - Frontend/worker disconnection from their connected ETCD replica
     """
     # Step 1: Start NATS server
-    with NatsServer(request):
+    with NatsServer(request, port=0) as nats, nats_server_env(nats):
         logger.info("NATS server started successfully")
 
         # Step 2: Start 3-node ETCD cluster
@@ -249,7 +250,7 @@ def test_etcd_ha_failover_vllm_disaggregated(
     - Frontend/worker disconnection from their connected ETCD replica
     """
     # Step 1: Start NATS server
-    with NatsServer(request):
+    with NatsServer(request, port=0) as nats, nats_server_env(nats):
         logger.info("NATS server started successfully")
 
         # Step 2: Start 3-node ETCD cluster
@@ -323,7 +324,7 @@ def test_etcd_non_ha_shutdown_vllm_aggregated(request, predownload_models):
     5. Verifies that frontend and worker shut down gracefully
     """
     # Step 1: Start NATS server
-    with NatsServer(request):
+    with NatsServer(request, port=0) as nats, nats_server_env(nats):
         logger.info("NATS server started successfully")
 
         # Step 2: Start single ETCD node using EtcdCluster with num_replicas=1
@@ -380,7 +381,7 @@ def test_etcd_non_ha_shutdown_vllm_disaggregated(
     5. Verifies that frontend and both workers shut down gracefully
     """
     # Step 1: Start NATS server
-    with NatsServer(request):
+    with NatsServer(request, port=0) as nats, nats_server_env(nats):
         logger.info("NATS server started successfully")
 
         # Step 2: Start single ETCD node using EtcdCluster with num_replicas=1

--- a/tests/fault_tolerance/etcd_ha/utils.py
+++ b/tests/fault_tolerance/etcd_ha/utils.py
@@ -8,6 +8,7 @@ import shutil
 import subprocess
 import tempfile
 import time
+from contextlib import contextmanager
 from typing import List, Optional
 
 import pytest
@@ -19,9 +20,24 @@ from tests.utils.managed_process import (
     DynamoFrontendProcess as BaseDynamoFrontendProcess,
 )
 from tests.utils.managed_process import ManagedProcess
+from tests.utils.port_utils import allocate_ports, deallocate_ports
 from tests.utils.test_output import resolve_test_output_path
 
 logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def nats_server_env(nats):
+    """Point child Dynamo processes at the NATS server started by the test."""
+    orig_nats = os.environ.get("NATS_SERVER")
+    os.environ["NATS_SERVER"] = f"nats://localhost:{nats.port}"
+    try:
+        yield
+    finally:
+        if orig_nats is not None:
+            os.environ["NATS_SERVER"] = orig_nats
+        else:
+            os.environ.pop("NATS_SERVER", None)
 
 
 class DynamoFrontendProcess(BaseDynamoFrontendProcess):
@@ -137,11 +153,21 @@ class EtcdCluster:
         self,
         request,
         num_replicas: int = 3,
-        base_port: int = 2379,
+        base_port: Optional[int] = None,
     ):
         self.request = request
         self.num_replicas = num_replicas
         self.base_port = base_port
+        self._allocated_ports: list[int] = (
+            allocate_ports(num_replicas * 2, 2379)
+            if base_port is None or base_port == 0
+            else []
+        )
+        self._ports = (
+            self._allocated_ports
+            if self._allocated_ports
+            else [base_port + idx for idx in range(num_replicas * 2)]
+        )
         self.replicas: List[Optional[EtcdReplicaServer]] = []
         self.data_dirs: List[str] = []
         self.log_base_dir = resolve_test_output_path(
@@ -157,22 +183,26 @@ class EtcdCluster:
 
         os.makedirs(self.log_base_dir, exist_ok=True)
 
+    def _client_port(self, idx: int) -> int:
+        return self._ports[2 * idx]
+
+    def _peer_port(self, idx: int) -> int:
+        return self._ports[(2 * idx) + 1]
+
     def _get_initial_cluster(self) -> str:
         """Build the initial cluster configuration string"""
         initial_cluster_parts = []
         for i in range(self.num_replicas):
             name = f"etcd-{i}"
-            peer_port = self.base_port + (2 * i) + 1
+            peer_port = self._peer_port(i)
             initial_cluster_parts.append(f"{name}=http://127.0.0.1:{peer_port}")
         return ",".join(initial_cluster_parts)
 
     def _start_replica(self, idx: int, cluster_state: str = "new") -> EtcdReplicaServer:
         """Start a single ETCD replica"""
         name = f"etcd-{idx}"
-        # e.g. base_port = 2379 -> client_port = 2379, 2381, 2383
-        # e.g. base_port = 2379 -> peer_port = 2380, 2382, 2384
-        client_port = self.base_port + (2 * idx)
-        peer_port = self.base_port + (2 * idx) + 1
+        client_port = self._client_port(idx)
+        peer_port = self._peer_port(idx)
 
         # Create data dir for the node
         data_dir = tempfile.mkdtemp(prefix=f"etcd_{idx}_")
@@ -245,7 +275,7 @@ class EtcdCluster:
             raise RuntimeError("No healthy replica found to perform member operations")
 
         name = f"etcd-{idx}"
-        peer_port = self.base_port + (2 * idx) + 1
+        peer_port = self._peer_port(idx)
         peer_url = f"http://127.0.0.1:{peer_port}"
 
         # Set ETCDCTL_ENDPOINTS for etcdctl commands
@@ -339,8 +369,7 @@ class EtcdCluster:
         endpoints = []
         for i, replica in enumerate(self.replicas):
             if replica:  # Only include active replicas
-                client_port = self.base_port + (2 * i)
-                endpoints.append(f"http://127.0.0.1:{client_port}")
+                endpoints.append(f"http://127.0.0.1:{replica.client_port}")
         return endpoints
 
     def terminate_replica(self, idx: int):
@@ -398,6 +427,14 @@ class EtcdCluster:
             except Exception as e:
                 logger.warning(f"Error removing data directory {data_dir}: {e}")
         self.data_dirs = []
+
+        if self._allocated_ports:
+            try:
+                deallocate_ports(self._allocated_ports)
+            except Exception as e:
+                logger.warning(f"Error releasing ETCD cluster ports: {e}")
+            finally:
+                self._allocated_ports = []
 
     def __enter__(self):
         self.start()

--- a/tests/kvbm_integration/test_consolidator_router_e2e.py
+++ b/tests/kvbm_integration/test_consolidator_router_e2e.py
@@ -294,8 +294,6 @@ def frontend_server(test_directory, runtime_services):
     env.update(
         {
             "RUST_BACKTRACE": "1",
-            "NATS_SERVER": "nats://localhost:4222",
-            "ETCD_ENDPOINTS": "http://localhost:2379",
             "DYN_LOG": "debug",  # Enable debug logs for consolidator visibility
         }
     )
@@ -383,8 +381,6 @@ def llm_worker(frontend_server, test_directory, runtime_services, engine_type):
     env.update(
         {
             "RUST_BACKTRACE": "1",
-            "NATS_SERVER": "nats://localhost:4222",
-            "ETCD_ENDPOINTS": "http://localhost:2379",
             "DYN_KVBM_CPU_CACHE_GB": "5",
             "DYN_KVBM_DISK_CACHE_GB": "5",
             # Disable O_DIRECT on the KVBM G3 disk cache so the test runs on
@@ -740,8 +736,6 @@ class TestConsolidatorRouterE2E:
         frontend_env.update(
             {
                 "RUST_BACKTRACE": "1",
-                "NATS_SERVER": "nats://localhost:4222",
-                "ETCD_ENDPOINTS": "http://localhost:2379",
                 "DYN_LOG": "debug",
             }
         )
@@ -820,8 +814,6 @@ class TestConsolidatorRouterE2E:
             worker_env.update(
                 {
                     "RUST_BACKTRACE": "1",
-                    "NATS_SERVER": "nats://localhost:4222",
-                    "ETCD_ENDPOINTS": "http://localhost:2379",
                     "DYN_KVBM_CPU_CACHE_OVERRIDE_NUM_BLOCKS": str(g2_cpu_blocks),
                     "DYN_KVBM_DISK_CACHE_OVERRIDE_NUM_BLOCKS": str(g3_disk_blocks),
                     # Disable O_DIRECT on the KVBM G3 disk cache so the test runs

--- a/tests/kvbm_integration/test_determinism_agg.py
+++ b/tests/kvbm_integration/test_determinism_agg.py
@@ -169,9 +169,6 @@ class LLMServerManager:
         self.env.update(
             {
                 "RUST_BACKTRACE": "1",
-                # DynamoConnector connection settings
-                "NATS_SERVER": "nats://localhost:4222",
-                "ETCD_ENDPOINTS": "http://localhost:2379",
                 # Enable KVBM metrics for monitoring offload/onboard
                 "DYN_KVBM_METRICS": "true",
                 "DYN_KVBM_METRICS_PORT": str(self.metrics_port),

--- a/tests/kvbm_integration/test_determinism_disagg.py
+++ b/tests/kvbm_integration/test_determinism_disagg.py
@@ -107,9 +107,6 @@ class LLMServerManager:
         self.env.update(
             {
                 "RUST_BACKTRACE": "1",
-                # DynamoConnector connection settings
-                "NATS_SERVER": "nats://localhost:4222",
-                "ETCD_ENDPOINTS": "http://localhost:2379",
             }
         )
 


### PR DESCRIPTION
## Summary
- add job-scoped NATS and ETCD GitHub service containers alongside MinIO for shared test jobs
- make default pytest runtime services reuse NATS_SERVER/ETCD_ENDPOINTS when CI provides them, with local fallback for developer runs
- remove hardcoded localhost runtime service env overrides from KVBM tests so they inherit the fixture-provided endpoints

## Validation
- git diff --check
- python -m py_compile tests/conftest.py tests/fault_tolerance/etcd_ha/utils.py tests/fault_tolerance/etcd_ha/test_sglang.py tests/fault_tolerance/etcd_ha/test_trtllm.py tests/fault_tolerance/etcd_ha/test_vllm.py tests/kvbm_integration/test_consolidator_router_e2e.py tests/kvbm_integration/test_determinism_agg.py tests/kvbm_integration/test_determinism_disagg.py
- python YAML parse for .github/workflows/shared-test.yml and .github/actions/pytest-local/action.yml
- PYTHONPATH=components/src:lib/bindings/python/src python -m pytest --collect-only -q tests/basic/test_autodeploy_backend.py tests/kvbm_integration/test_determinism_agg.py tests/kvbm_integration/test_determinism_disagg.py tests/kvbm_integration/test_consolidator_router_e2e.py

Linear: OPS-3075
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9458" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test infrastructure to support external NATS and etcd service configuration with dynamic port allocation
  * Enhanced GitHub Actions workflow to provision NATS and etcd services for improved test reliability

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9458)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->