### PR TITLE
fix(parsers): align qwen3_coder + minimax_m2 XML parsers with official spec

### DIFF
--- a/lib/parsers/src/tool_calling/config.rs
+++ b/lib/parsers/src/tool_calling/config.rs
@@ -77,6 +77,34 @@ pub struct XmlParserConfig {
     /// leave this `false`.
     #[serde(default)]
     pub allow_eof_recovery: bool,
+
+    /// When true, the function- and parameter-regex omit the `|$` end-of-block
+    /// fallback (so missing `</function>` / `</parameter>` causes the match to
+    /// fail rather than being silently recovered), AND `detect_and_parse_tool_
+    /// call_with_recovery` does not flip `allow_eof_recovery=true` for this
+    /// config. Used by families whose official reference parser is
+    /// strict-match (e.g. MiniMax-M2 — see
+    /// https://huggingface.co/MiniMaxAI/MiniMax-M2/blob/main/docs/tool_calling_guide.md).
+    #[serde(default)]
+    pub strict_match: bool,
+
+    /// When true, if `function_start_token` is absent anywhere in the input,
+    /// short-circuit `try_tool_call_parse_xml` and return
+    /// `(calls=[], normal_text=<input>)`. Matches the early-return passthrough
+    /// in Qwen3-Coder's official reference parser
+    /// (https://huggingface.co/Qwen/Qwen3-Coder-480B-A35B-Instruct/blob/main/qwen3coder_tool_parser.py).
+    #[serde(default)]
+    pub passthrough_when_no_function: bool,
+
+    /// When true, if `tool_call_start_token` is absent but `function_start_
+    /// token` is present, parse the entire input as a single tool-call block
+    /// (back-off strategy). Matches the `if len(raw_tool_calls) == 0:
+    /// raw_tool_calls = [model_output]` back-off in Qwen3-Coder's reference
+    /// parser. Independent of `passthrough_when_no_function` (different
+    /// trigger: this one fires when function tags exist but the outer wrapper
+    /// does not).
+    #[serde(default)]
+    pub backoff_when_no_wrapper: bool,
 }
 
 impl Default for XmlParserConfig {
@@ -89,7 +117,24 @@ impl Default for XmlParserConfig {
             parameter_start_token: "<parameter=".to_string(),
             parameter_end_token: "</parameter>".to_string(),
             allow_eof_recovery: false,
+            strict_match: false,
+            passthrough_when_no_function: false,
+            backoff_when_no_wrapper: false,
         }
+    }
+}
+
+impl XmlParserConfig {
+    /// Returns true when the chunk lacks the outer `<tool_call>` wrapper but
+    /// contains `<function=...>`, and the family opts into back-off parsing
+    /// (qwen3_coder, nemotron_nano). In this mode the function-level tokens
+    /// act as the tool-call boundary for both start detection and end-position
+    /// search, mirroring the wrapped path's behavior so streaming and batch
+    /// agree on what counts as a tool call.
+    pub fn is_bare_function_mode(&self, chunk: &str) -> bool {
+        self.backoff_when_no_wrapper
+            && !chunk.contains(self.tool_call_start_token.as_str())
+            && chunk.contains(self.function_start_token.as_str())
     }
 }
 
@@ -394,8 +439,17 @@ impl ToolCallConfig {
 
     pub fn qwen3_coder() -> Self {
         // <tool_call><function=name><parameter=key>value</parameter></function></tool_call>
+        // Behavior aligned with Qwen3-Coder's official reference parser
+        // (huggingface.co/Qwen/Qwen3-Coder-480B-A35B-Instruct/.../qwen3coder_tool_parser.py):
+        //  - passthrough: when no `<function=` in input, return raw input as content
+        //  - back-off: when `<function=` present but no `<tool_call>` wrapper,
+        //              parse the entire input as a tool block
         Self {
-            parser_config: ParserConfig::Xml(XmlParserConfig::default()),
+            parser_config: ParserConfig::Xml(XmlParserConfig {
+                passthrough_when_no_function: true,
+                backoff_when_no_wrapper: true,
+                ..XmlParserConfig::default()
+            }),
         }
     }
 
@@ -447,6 +501,13 @@ impl ToolCallConfig {
         // </invoke>
         // </minimax:tool_call>
         // Reference: https://huggingface.co/MiniMaxAI/MiniMax-M2.1/blob/main/docs/tool_calling_guide.md
+        //
+        // MiniMax's official reference parser is strict-match — its three
+        // regexes (outer/invoke/parameter) all require paired fences and
+        // return [] on any mismatch. `strict_match=true` enforces that:
+        // it drops the `|$` end-of-block fallback from the function- and
+        // parameter-regex AND prevents the PyO3 `with_recovery` shim from
+        // flipping `allow_eof_recovery=true`.
         Self {
             parser_config: ParserConfig::Xml(XmlParserConfig {
                 tool_call_start_token: "<minimax:tool_call>".to_string(),
@@ -456,6 +517,9 @@ impl ToolCallConfig {
                 parameter_start_token: "<parameter name=".to_string(),
                 parameter_end_token: "</parameter>".to_string(),
                 allow_eof_recovery: false,
+                strict_match: true,
+                passthrough_when_no_function: false,
+                backoff_when_no_wrapper: false,
             }),
         }
     }

--- a/lib/parsers/src/tool_calling/parsers.rs
+++ b/lib/parsers/src/tool_calling/parsers.rs
@@ -146,7 +146,11 @@ pub async fn detect_and_parse_tool_call_with_recovery(
         }
         ParserConfig::Xml(c) => {
             let mut c = c.clone();
-            c.allow_eof_recovery = true;
+            // Strict-match families opt out — flipping recovery here would
+            // contradict their per-spec strictness.
+            if !c.strict_match {
+                c.allow_eof_recovery = true;
+            }
             ParserConfig::Xml(c)
         }
         ParserConfig::Glm47(c) => {

--- a/lib/parsers/src/tool_calling/xml/parser.rs
+++ b/lib/parsers/src/tool_calling/xml/parser.rs
@@ -14,6 +14,20 @@ use super::super::ToolDefinition;
 use super::super::config::XmlParserConfig;
 use super::response::{CalledFunction, ToolCallResponse, ToolCallType};
 
+/// Build a `<start>name>(body)<end>` regex pattern. When `strict` is false,
+/// missing `<end>` falls back to end-of-block so truncated input still parses
+/// best-effort. Strict mode requires both fences and returns no match without
+/// the close tag.
+fn build_block_pattern(start: &str, end: &str, strict: bool) -> String {
+    let start = regex::escape(start);
+    let end = regex::escape(end);
+    if strict {
+        format!(r"(?s){}([^>]+)>(.*?){}", start, end)
+    } else {
+        format!(r"(?s){}([^>]+)>(.*?)(?:{}|$)", start, end)
+    }
+}
+
 /// Strip surrounding quotes from a string if present
 fn strip_quotes(s: &str) -> &str {
     let trimmed = s.trim();
@@ -29,11 +43,12 @@ fn strip_quotes(s: &str) -> &str {
 /// Check if a chunk contains the start of a xml-style tool call.
 /// Format: `<tool_call><function=name><parameter=foo>...</parameter></function></tool_call>`
 pub fn detect_tool_call_start_xml(chunk: &str, config: &XmlParserConfig) -> bool {
-    // Check for complete or partial start token.
     let start_token = &config.tool_call_start_token;
 
-    // Check if we have the complete start token.
-    if chunk.contains(start_token.as_str()) {
+    // Complete start token, or bare `<function=...>` in back-off mode (the
+    // batch path treats both as tool-call starts; the streaming jail must
+    // agree — see XmlParserConfig::is_bare_function_mode).
+    if chunk.contains(start_token.as_str()) || config.is_bare_function_mode(chunk) {
         return true;
     }
 
@@ -53,9 +68,17 @@ pub fn detect_tool_call_start_xml(chunk: &str, config: &XmlParserConfig) -> bool
 /// advances past every consecutive start→end pair so the entire group is captured
 /// as a single jailed region.  Returns the position after the last `</tool_call>`
 /// found, or the length of the chunk when no end token is present.
+///
+/// In back-off mode (see XmlParserConfig::is_bare_function_mode) the
+/// function-level tokens act as the boundary so the jail releases at
+/// `</function>` instead of buffering to EOS waiting for a missing
+/// `</tool_call>`.
 pub fn find_tool_call_end_position_xml(chunk: &str, config: &XmlParserConfig) -> usize {
-    let start_token = &config.tool_call_start_token;
-    let end_token = &config.tool_call_end_token;
+    let (start_token, end_token) = if config.is_bare_function_mode(chunk) {
+        (&config.function_start_token, &config.function_end_token)
+    } else {
+        (&config.tool_call_start_token, &config.tool_call_end_token)
+    };
 
     // Find the first end token — if there isn't one, the call is incomplete.
     let Some(first_end) = chunk.find(end_token.as_str()) else {
@@ -94,6 +117,41 @@ pub fn try_tool_call_parse_xml(
     config: &XmlParserConfig,
     tools: Option<&[ToolDefinition]>,
 ) -> anyhow::Result<(Vec<ToolCallResponse>, Option<String>)> {
+    // Qwen3-Coder-style passthrough: if the function-start token is absent
+    // anywhere in the input, the reference parser returns the raw input as
+    // content with no tool calls. Gated so it only fires for parsers that
+    // opt in (e.g. qwen3_coder, nemotron_nano); other XML-style families
+    // (minimax_m2, kimi_k2 alias paths) keep their stricter behavior.
+    if config.passthrough_when_no_function
+        && !message.contains(config.function_start_token.as_str())
+    {
+        return Ok((vec![], Some(message.to_string())));
+    }
+
+    // Qwen3-Coder-style back-off: outer wrapper missing but `<function=...>`
+    // tags are present — parse the whole input as a single tool-call block
+    // (mirrors `qwen3coder_tool_parser._get_function_calls`'s fallback).
+    //
+    // Gated on `function_end_token` being present OR `allow_eof_recovery` set,
+    // mirroring the wrapped path's recovery gate in `extract_tool_calls`. The
+    // lenient inner regex has a `|$` fallback that would otherwise match a
+    // partial `<function=...>` block mid-stream and cause `should_exit_jail_
+    // early` to release the jail before the closing tag arrives.
+    if config.is_bare_function_mode(message)
+        && (message.contains(config.function_end_token.as_str()) || config.allow_eof_recovery)
+    {
+        let calls = parse_tool_call_block(message, config, tools).unwrap_or_default();
+        if !calls.is_empty() {
+            // Preserve narration before the first `<function=...>` tag so
+            // streaming output isn't dropped on the back-off path.
+            let prefix = message
+                .split_once(config.function_start_token.as_str())
+                .map(|(p, _)| p.to_string())
+                .unwrap_or_default();
+            return Ok((calls, Some(prefix)));
+        }
+    }
+
     let (normal_text, tool_calls) = extract_tool_calls(message, config, tools)?;
 
     let normal_content = if normal_text.is_empty() {
@@ -152,6 +210,7 @@ fn extract_tool_calls(
                 let block = &text[abs_start..];
                 let function_start = &config.function_start_token;
                 if config.allow_eof_recovery
+                    && !config.strict_match
                     && block.contains(function_start.as_str())
                     && let Ok(mut parsed_calls) = parse_tool_call_block(block, config, tools)
                     && !parsed_calls.is_empty()
@@ -189,20 +248,18 @@ fn parse_tool_call_block(
     config: &XmlParserConfig,
     tools: Option<&[ToolDefinition]>,
 ) -> anyhow::Result<Vec<ToolCallResponse>> {
-    // Build regex patterns based on config
-    let function_start = regex::escape(&config.function_start_token);
-    let function_end = regex::escape(&config.function_end_token);
-    let parameter_start = regex::escape(&config.parameter_start_token);
-    let parameter_end = regex::escape(&config.parameter_end_token);
-
-    let function_pattern = format!(r"(?s){}([^>]+)>(.*?)(?:{}|$)", function_start, function_end);
-    let parameter_pattern = format!(
-        r"(?s){}([^>]+)>(.*?)(?:{}|$)",
-        parameter_start, parameter_end
-    );
-
-    let function_regex = Regex::new(&function_pattern)?;
-    let parameter_regex = Regex::new(&parameter_pattern)?;
+    // Strict-match families (e.g. minimax_m2) require paired fences; lenient
+    // families fall back to end-of-block when the close tag is missing.
+    let function_regex = Regex::new(&build_block_pattern(
+        &config.function_start_token,
+        &config.function_end_token,
+        config.strict_match,
+    ))?;
+    let parameter_regex = Regex::new(&build_block_pattern(
+        &config.parameter_start_token,
+        &config.parameter_end_token,
+        config.strict_match,
+    ))?;
 
     let mut results = Vec::new();
 
@@ -953,6 +1010,56 @@ NYC
         assert_eq!(args["city"], "NYC");
     }
 
+    // Streaming-jail symmetry: when `<function=...>` is partial (no
+    // `</function>` yet) and recovery is OFF, back-off must NOT fire — the
+    // lenient `|$` regex would otherwise match the truncated content and
+    // cause `should_exit_jail_early` to release the jail before the closing
+    // tag arrives, leaking the rest of the call as text. Recovery ON
+    // (finalize path) is still allowed to recover the truncated call.
+    #[test]
+    fn test_parse_qwen3_bare_function_partial_no_recovery_returns_no_calls() {
+        let input = "<function=get_weather>\n<parameter=city>\nNY";
+        let config = XmlParserConfig {
+            backoff_when_no_wrapper: true,
+            // allow_eof_recovery=false (streaming jail path)
+            ..XmlParserConfig::default()
+        };
+        let (calls, _) = try_tool_call_parse_xml(input, &config, None).unwrap();
+        assert!(
+            calls.is_empty(),
+            "back-off must not fire on partial input without recovery (streaming jail leak)",
+        );
+    }
+
+    #[test]
+    fn test_parse_qwen3_bare_function_complete_streaming_recovers() {
+        // Same scenario but `</function>` has arrived — back-off should fire
+        // even with recovery off (streaming-complete path).
+        let input = "<function=get_weather>\n<parameter=city>\nNYC\n</parameter>\n</function>";
+        let config = XmlParserConfig {
+            backoff_when_no_wrapper: true,
+            ..XmlParserConfig::default()
+        };
+        let (calls, _) = try_tool_call_parse_xml(input, &config, None).unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].function.name, "get_weather");
+    }
+
+    #[test]
+    fn test_parse_qwen3_bare_function_partial_with_recovery_recovers() {
+        // Finalize path: recovery ON allows truncated function block to
+        // surface a (potentially incomplete) call rather than being dropped.
+        let input = "<function=get_weather>\n<parameter=city>\nNY";
+        let config = XmlParserConfig {
+            backoff_when_no_wrapper: true,
+            allow_eof_recovery: true,
+            ..XmlParserConfig::default()
+        };
+        let (calls, _) = try_tool_call_parse_xml(input, &config, None).unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].function.name, "get_weather");
+    }
+
     // Qwen3-Coder-style XML treats text after the first parsed tool call as
     // non-content, including after EOF recovery.
     #[test]
@@ -968,8 +1075,14 @@ NYC
         assert_eq!(normal, Some("".to_string()));
     }
 
-    #[test] // PARSER.batch.5 — minimax_m2
-    fn test_parse_minimax_m2_no_outer_close_recovers() {
+    #[test] // PARSER.batch.5.a — minimax_m2 spec-strict
+    fn test_parse_minimax_m2_no_outer_close_drops_call() {
+        // MiniMax-M2's reference parser (huggingface.co/MiniMaxAI/MiniMax-M2)
+        // requires both outer fences — missing `</minimax:tool_call>` means
+        // the regex does not match and zero calls are recovered. Strict-match
+        // mode opts into that behavior even when `allow_eof_recovery=true`
+        // would otherwise apply (and the binding-layer override is also
+        // suppressed for strict configs).
         let config = XmlParserConfig {
             tool_call_start_token: "<minimax:tool_call>".to_string(),
             tool_call_end_token: "</minimax:tool_call>".to_string(),
@@ -978,14 +1091,17 @@ NYC
             parameter_start_token: "<parameter name=".to_string(),
             parameter_end_token: "</parameter>".to_string(),
             allow_eof_recovery: true,
+            strict_match: true,
+            passthrough_when_no_function: false,
+            backoff_when_no_wrapper: false,
         };
         let input = r#"<minimax:tool_call><invoke name="get_weather"><parameter name="city">NYC</parameter></invoke>"#;
 
         let (calls, _) = try_tool_call_parse_xml(input, &config, None).unwrap();
-        assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].function.name, "get_weather");
-        let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
-        assert_eq!(args["city"], "NYC");
+        assert!(
+            calls.is_empty(),
+            "strict_match config must not recover when outer </minimax:tool_call> is absent"
+        );
     }
 
     #[test] // helper
@@ -1171,10 +1287,8 @@ NYC
     }
 
     /// Helper for the new corner-case tests below (PARSER.batch.6 / PIPELINE.finish_reason / PARSER.batch.9
-    /// / PARSER.batch.10) — `allow_eof_recovery: false` because none of these tests
-    /// rely on EOF recovery. The inline config in
-    /// `test_parse_minimax_m2_no_outer_close_recovers` keeps that flag `true`
-    /// because that test specifically exercises the recovery path.
+    /// / PARSER.batch.10) — matches the production `ToolCallConfig::minimax_m2()`
+    /// factory: strict-match per MiniMax's reference parser.
     fn minimax_m2_config() -> XmlParserConfig {
         XmlParserConfig {
             tool_call_start_token: "<minimax:tool_call>".to_string(),
@@ -1184,6 +1298,9 @@ NYC
             parameter_start_token: "<parameter name=".to_string(),
             parameter_end_token: "</parameter>".to_string(),
             allow_eof_recovery: false,
+            strict_match: true,
+            passthrough_when_no_function: false,
+            backoff_when_no_wrapper: false,
         }
     }
 

--- a/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.4.yaml
@@ -70,6 +70,14 @@ cases:
       dynamo:
         calls: []
         normal_text: ''
+        reason: |-
+          Strict per MiniMax-M2 reference parser
+          (https://huggingface.co/MiniMaxAI/MiniMax-M2/blob/main/docs/tool_calling_guide.md):
+          the published `<invoke name=(.*?)</invoke>` regex requires both
+          fences, so missing `</invoke>` yields no match and no recovered
+          call. Wrapper markup is intentionally dropped (not echoed to
+          normal_text) so tool-call protocol markers don't leak to
+          user-facing content.
       vllm:
         calls: []
         normal_text: |-
@@ -84,3 +92,9 @@ cases:
           arguments:
             location: NYC
         normal_text: ''
+        reason: |-
+          SGLang's MinimaxM2Detector regex
+          (`r"<invoke name=\"(.*?)</invoke>|<invoke name=\"(.*)$"`) has an
+          `|$` end-of-input alternation that lets a missing `</invoke>`
+          still produce a call — contradicts MiniMax-M2 reference parser.
+          Should be filed against sgl-project/sglang.

--- a/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.4.yaml
@@ -12,7 +12,7 @@ cases:
       not a valid invoke
       </minimax:tool_call>
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
@@ -20,19 +20,17 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_4_a
+      dynamo: &id001
         calls: []
         normal_text: ''
       vllm:
         calls: []
-        normal_text: '<minimax:tool_call>
-
+        normal_text: |-
+          <minimax:tool_call>
           not a valid invoke
-
-          </minimax:tool_call>'
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
-      sglang: *d_4_a
-  # PARSER.batch.4.b (invalid JSON args) n/a: minimax_m2 uses attribute-encoded args, not JSON.
+          </minimax:tool_call>
+        reason: impl-defined recovery contract (see PARSER_CASES.md)
+      sglang: *id001
   PARSER.batch.4.c:
     description: Invoke without name attribute
     ref: dynamo
@@ -43,24 +41,21 @@ cases:
       </invoke>
       </minimax:tool_call>
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_4_c
+      dynamo: &id003
         calls: []
         normal_text: ''
       vllm:
         calls: []
-        normal_text: '<minimax:tool_call>
-
+        normal_text: |-
+          <minimax:tool_call>
           <invoke>
-
           <parameter name="location">NYC</parameter>
-
           </invoke>
-
-          </minimax:tool_call>'
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
-      sglang: *d_4_c
+          </minimax:tool_call>
+        reason: impl-defined recovery contract (see PARSER_CASES.md)
+      sglang: *id003
   PARSER.batch.4.d:
     description: Missing closing </invoke>
     ref: dynamo
@@ -70,22 +65,22 @@ cases:
       <parameter name="location">NYC</parameter>
       </minimax:tool_call>
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_4_d
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
+        calls: []
+        normal_text: |-
+          <minimax:tool_call>
+          <invoke name="get_weather">
+          <parameter name="location">NYC</parameter>
+          </minimax:tool_call>
+        reason: impl-defined recovery contract (see PARSER_CASES.md)
+      sglang:
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm:
-        calls: []
-        normal_text: '<minimax:tool_call>
-
-          <invoke name="get_weather">
-
-          <parameter name="location">NYC</parameter>
-
-          </minimax:tool_call>'
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
-      sglang: *d_4_d

--- a/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.5.yaml
@@ -22,31 +22,28 @@ cases:
             type: string
     expected:
       dynamo:
-        calls:
-        - name: get_weather
-          arguments:
-            location: NYC
-        normal_text: ''
+        calls: []
+        normal_text: |-
+          <minimax:tool_call>
+          <invoke name="get_weather">
+          <parameter name="location">NYC</parameter>
+          </invoke>
       vllm:
         calls: []
-        normal_text: '<minimax:tool_call>
-
+        normal_text: |-
+          <minimax:tool_call>
           <invoke name="get_weather">
-
           <parameter name="location">NYC</parameter>
-
-          </invoke>'
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
+          </invoke>
+        reason: impl-defined recovery contract (see PARSER_CASES.md)
       sglang:
         calls: []
-        normal_text: '<minimax:tool_call>
-
+        normal_text: |-
+          <minimax:tool_call>
           <invoke name="get_weather">
-
           <parameter name="location">NYC</parameter>
-
-          </invoke>'
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
+          </invoke>
+        reason: impl-defined recovery contract (see PARSER_CASES.md)
   PARSER.batch.5.b:
     description: Closing </minimax:tool_call> without matching open
     ref: dynamo
@@ -58,15 +55,15 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &d_5_b
+      dynamo: &id002
         calls: []
         normal_text: |-
           <invoke name="get_weather">
           <parameter name="location">NYC</parameter>
           </invoke>
           </minimax:tool_call>
-      vllm: *d_5_b
-      sglang: *d_5_b
+      vllm: *id002
+      sglang: *id002
   PARSER.batch.5.c:
     description: Truncation mid-parameter value
     ref: dynamo
@@ -78,24 +75,22 @@ cases:
     - *id001
     expected:
       dynamo:
-        calls:
-        - name: get_weather
-          arguments:
-            location: NY
-        normal_text: ''
+        calls: []
+        normal_text: |-
+          <minimax:tool_call>
+          <invoke name="get_weather">
+          <parameter name="location">NY
       vllm:
         calls: []
-        normal_text: '<minimax:tool_call>
-
+        normal_text: |-
+          <minimax:tool_call>
           <invoke name="get_weather">
-
-          <parameter name="location">NY'
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
+          <parameter name="location">NY
+        reason: impl-defined recovery contract (see PARSER_CASES.md)
       sglang:
         calls: []
-        normal_text: '<minimax:tool_call>
-
+        normal_text: |-
+          <minimax:tool_call>
           <invoke name="get_weather">
-
-          <parameter name="location">NY'
-        reason: "sglang nullifies normal_text on malformed/recovery shapes where Dynamo preserves input"
+          <parameter name="location">NY
+        reason: sglang nullifies normal_text on malformed/recovery shapes where Dynamo preserves input

--- a/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.4.yaml
@@ -22,7 +22,10 @@ cases:
     expected:
       dynamo:
         calls: []
-        normal_text: ''
+        normal_text: |-
+          <tool_call>
+          random text
+          </tool_call>
       vllm:
         unavailable: vLLM has no parser for family='nemotron_nano'
       sglang:

--- a/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.5.yaml
@@ -47,14 +47,11 @@ cases:
     - *id001
     expected:
       dynamo:
-        calls: []
-        normal_text: |-
-          <function=get_weather>
-          <parameter=location>
-          NYC
-          </parameter>
-          </function>
-          </tool_call>
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
       vllm:
         unavailable: vLLM has no parser for family='nemotron_nano'
       sglang:

--- a/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.4.yaml
@@ -20,18 +20,22 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_4_a
+      dynamo:
         calls: []
-        normal_text: ''
+        normal_text: |-
+          <tool_call>
+          random text without function tag
+          </tool_call>
       vllm:
         calls: []
-        normal_text: '<tool_call>
-
+        normal_text: |-
+          <tool_call>
           random text without function tag
-
-          </tool_call>'
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
-      sglang: *d_4_a
+          </tool_call>
+        reason: impl-defined recovery contract (see PARSER_CASES.md)
+      sglang:
+        calls: []
+        normal_text: ''
   PARSER.batch.4.d:
     description: Missing </parameter> closing tag
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_qwen3coder_tool_parser.py#L729
@@ -45,11 +49,11 @@ cases:
     tools:
     - *id001
     expected:
-      dynamo: &d_4_d
+      dynamo: &id002
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *d_4_d
-      sglang: *d_4_d
+      vllm: *id002
+      sglang: *id002

--- a/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.5.yaml
@@ -15,7 +15,7 @@ cases:
       </parameter>
       </function>
     tools:
-    - &id001
+    - &id002
       name: get_weather
       parameters:
         type: object
@@ -23,14 +23,14 @@ cases:
           location:
             type: string
     expected:
-      dynamo: &d_5_a
+      dynamo: &id001
         calls:
         - name: get_weather
           arguments:
             location: NYC
         normal_text: ''
-      vllm: *d_5_a
-      sglang: *d_5_a
+      vllm: *id001
+      sglang: *id001
   PARSER.batch.5.b:
     description: Closing </tool_call> without matching <tool_call> open
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_qwen3coder_tool_parser.py#L943
@@ -42,9 +42,22 @@ cases:
       </function>
       </tool_call>
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_5_b
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm:
+        calls:
+        - arguments:
+            location: NYC
+          name: get_weather
+        normal_text: ''
+        reason: impl-defined recovery contract (see PARSER_CASES.md)
+      sglang:
         calls: []
         normal_text: |-
           <function=get_weather>
@@ -53,14 +66,6 @@ cases:
           </parameter>
           </function>
           </tool_call>
-      vllm:
-        calls:
-        - arguments:
-            location: NYC
-          name: get_weather
-        normal_text: ''
-        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
-      sglang: *d_5_b
   PARSER.batch.5.c:
     description: Truncation mid-parameter value
     ref: dynamo
@@ -70,13 +75,13 @@ cases:
       <parameter=location>
       NY
     tools:
-    - *id001
+    - *id002
     expected:
-      dynamo: &d_5_c
+      dynamo: &id003
         calls:
         - name: get_weather
           arguments:
             location: NY
         normal_text: ''
-      vllm: *d_5_c
-      sglang: *d_5_c
+      vllm: *id003
+      sglang: *id003


### PR DESCRIPTION
#### Overview:

`qwen3_coder` and `minimax_m2` shared Dynamo's XML parser, but the two families' upstream reference parsers (published on Hugging Face by Qwen and MiniMax) have **opposite recovery contracts** — Qwen is lenient (passthrough + back-off), MiniMax is strict (require all paired fences). Dynamo's XML parser implemented an unconditional middle ground that matched neither, surfaced as ambiguous `_RECOVERY_CONTRACT` xfails in the parity matrix.

This PR introduces three per-family flags on `XmlParserConfig` so each family's behavior matches its model authors' reference parser.

#### Details:

**New `XmlParserConfig` flags:**

- `passthrough_when_no_function: bool` — when `function_start_token` is absent in input, return `(calls=[], normal_text=<raw input>)`. Mirrors [Qwen3-Coder's reference parser early return](https://huggingface.co/Qwen/Qwen3-Coder-480B-A35B-Instruct/blob/main/qwen3coder_tool_parser.py):
  ```python
  if self.tool_call_prefix not in model_output:
      return ExtractedToolCallInformation(..., content=model_output)
  ```

- `backoff_when_no_wrapper: bool` — when `tool_call_start_token` is absent but `function_start_token` is present, treat the whole input as a tool-call block. Mirrors Qwen's `_get_function_calls` back-off:
  ```python
  if len(raw_tool_calls) == 0:
      raw_tool_calls = [model_output]
  ```

- `strict_match: bool` — drop the `|$` end-of-block fallback from the function- and parameter-regex AND suppress the PyO3 `with_recovery` shim from flipping `allow_eof_recovery=true`. Mirrors [MiniMax-M2's reference parser](https://huggingface.co/MiniMaxAI/MiniMax-M2/blob/main/docs/tool_calling_guide.md), whose three regexes (outer/invoke/parameter) all require paired fences.

**Factory wiring** (`tool_calling/config.rs`):
- `qwen3_coder()` opts into `passthrough_when_no_function + backoff_when_no_wrapper`
- `minimax_m2()` opts into `strict_match`
- All other XML-style families (`kimi_k2`, `glm47`, etc.) keep historical defaults

**Fixture regen** (Dynamo is the oracle, so `expected` blocks rewrite automatically):
- `minimax_m2/PARSER.batch.{4,5}`: Dynamo no longer recovers missing inner/outer fences; `expected.calls` flips to `[]`
- `qwen3_coder/PARSER.batch.7`: YAML key-order shuffle only (semantic unchanged on `main`)
- Other family `batch.8.yaml` files: TODO(research) divergence comments rewritten by `embed_divergence_comments.py`

**`KNOWN_DIVERGENCES` (cumulative)**:
- ✅ Drop `(vllm, minimax_m2, PARSER.batch.5)` — Dynamo now matches vLLM (both return `[]`)
- ✅ Drop `(sglang, minimax_m2, PARSER.batch.5)` — same
- ➕ Add `(sglang, minimax_m2, PARSER.batch.4)` — SGLang's `MinimaxM2Detector` regex retains a `|$` lenient fallback that contradicts MiniMax's spec; needs an upstream issue against `sgl-project/sglang`
- ⏸️ Keep `(vllm, minimax_m2, PARSER.batch.4)` — vLLM matches Dynamo on `calls=[]` but echoes the raw wrapper as `normal_text`; MiniMax spec is silent on normal_text handling for garbage input

#### Verification:

Stacked baseline (PR #9459 head, before this PR):

| | vLLM | SGLang |
|---|---|---|
| passed | 119 | (~96) |
| failed | 34 | 0 |
| xfailed | 42 | 58 |

After this PR:

| | vLLM | SGLang |
|---|---|---|
| passed | **120** (+1) | **97** (+1) |
| failed | 34 (=) | 0 (=) |
| xfailed | 41 (-1) | 59 (+1, new sglang/4) |

**Net: 0 regressions, +2 cells flip to ✓.** Plus Rust unit tests: 500/500 pass.

#### What happens when PR #9363 merges:

PR #9363 introduces the per-bucket sub-case fixtures (`PARSER.batch.{4,5,7}.<sub>`). Once it merges, this spec-align change additionally flips the following cells to ✓ without further code changes:
- `qwen3_coder/PARSER.batch.4.a × vllm` — `passthrough_when_no_function` produces matching content
- `qwen3_coder/PARSER.batch.5.b × vllm` — `backoff_when_no_wrapper` recovers the call
- `qwen3_coder/PARSER.batch.7.a × vllm` and × sglang — already covered by PR #9459 wrapper fix (these were XPASS-strict pending registry cleanup on #9363)
- `minimax_m2/PARSER.batch.4.d, 5.a, 5.c × vllm` — `strict_match` correctly returns `[]`

#### Where should the reviewer start?

1. `lib/parsers/src/tool_calling/config.rs` — three new flags + their per-family wiring
2. `lib/parsers/src/tool_calling/xml/parser.rs` — flag honoring at four sites (passthrough, back-off, strict regex, outer-recovery suppression)
3. `lib/parsers/src/tool_calling/parsers.rs` — `with_recovery` respects `strict_match`
4. `tests/parity/parser/test_parity_parser.py` — `KNOWN_DIVERGENCES` deltas with inline rationale

Reference parsers cited:
- [Qwen/Qwen3-Coder-480B-A35B-Instruct: qwen3coder_tool_parser.py](https://huggingface.co/Qwen/Qwen3-Coder-480B-A35B-Instruct/blob/main/qwen3coder_tool_parser.py)
- [MiniMaxAI/MiniMax-M2: docs/tool_calling_guide.md](https://huggingface.co/MiniMaxAI/MiniMax-M2/blob/main/docs/tool_calling_guide.md)

#### Related Issues:

Stacks on #9459 (parity wrapper fix). Relates to DIS-1936.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9462" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three new configuration modes for XML tool-call parsing: strict matching (disallow recovery), passthrough mode (return raw input when function tags missing), and backoff mode (parse single tool-call block when outer wrapper missing).

* **Bug Fixes**
  * Updated Qwen3-Coder parsing to enable passthrough and backoff recovery modes.
  * Updated Minimax-M2 parsing to enforce strict matching, preventing incomplete tool calls from being recovered.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9462)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->