### PR TITLE
docs: protocols, tokenizers, parsers - tighten descriptions and clean up doc framing

### DIFF
--- a/lib/parsers/Cargo.toml
+++ b/lib/parsers/Cargo.toml
@@ -16,13 +16,12 @@
 [package]
 name = "dynamo-parsers"
 description = "Reasoning and tool-calling parsers for OpenAI-compatible inference output."
-# Canonical home for this crate is ai-dynamo/frontend-crates.
-homepage = "https://github.com/ai-dynamo/frontend-crates"
-repository = "https://github.com/ai-dynamo/frontend-crates.git"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
+homepage.workspace = true
+repository.workspace = true
 keywords.workspace = true
 
 [dependencies]

--- a/lib/parsers/Cargo.toml
+++ b/lib/parsers/Cargo.toml
@@ -1,22 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 [package]
 name = "dynamo-parsers"
-description = "Reasoning and tool-calling parsers for OpenAI-compatible inference output."
 readme = "README.md"
+description = "Reasoning and tool-calling parsers for OpenAI-compatible inference output."
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/lib/parsers/Cargo.toml
+++ b/lib/parsers/Cargo.toml
@@ -15,13 +15,14 @@
 
 [package]
 name = "dynamo-parsers"
+description = "Reasoning and tool-calling parsers for OpenAI-compatible inference output."
+# Canonical home for this crate is ai-dynamo/frontend-crates.
+homepage = "https://github.com/ai-dynamo/frontend-crates"
+repository = "https://github.com/ai-dynamo/frontend-crates.git"
 version.workspace = true
 edition.workspace = true
-description = "Dynamo Parser Library for Tool Calling and Reasoning"
 authors.workspace = true
 license.workspace = true
-homepage.workspace = true
-repository.workspace = true
 keywords.workspace = true
 
 [dependencies]

--- a/lib/parsers/Cargo.toml
+++ b/lib/parsers/Cargo.toml
@@ -16,6 +16,7 @@
 [package]
 name = "dynamo-parsers"
 description = "Reasoning and tool-calling parsers for OpenAI-compatible inference output."
+readme = "README.md"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/lib/parsers/README.md
+++ b/lib/parsers/README.md
@@ -1,37 +1,34 @@
 # dynamo-parsers
 
-Rust crate for parsing **tool calls** and **reasoning content** out of raw LLM
-output. Wire-format-aware, streaming-first, model-family-aware.
+> Also available as a standalone crate at **[ai-dynamo/frontend-crates](https://github.com/ai-dynamo/frontend-crates)**. That repo is the canonical home for publishing to crates.io; this in-tree copy is kept in sync manually for workspace builds.
 
-This is the post-model side of Dynamo's chat-completions pipeline: given a
-token stream from vLLM or SGLang, extract structured `Vec<ToolCall>` +
-`reasoning_content` for the client. The pre-model side (prompt formatting)
-lives in `lib/llm/src/preprocessor/prompt/`.
+Rust crate for parsing **tool calls** and **reasoning content** out of raw LLM output. Wire-format-aware, streaming-first, model-family-aware.
+
+Given a token stream from any inference engine (vLLM, SGLang, etc.), extract structured `Vec<ToolCallResponse>` + `reasoning_content` ready to be returned to the client. Prompt formatting (the pre-model side) is out of scope.
 
 ## What's in the crate
 
 Two top-level modules, each with its own parser registry:
 
 ```
-lib/parsers/
-├── src/
-│   ├── tool_calling/        ← tool-call extraction (18 registered parsers)
-│   │   ├── parsers.rs         — registry + dispatch (detect_and_parse_tool_call)
-│   │   ├── config.rs          — per-parser ToolCallConfig
-│   │   ├── response.rs        — ToolCallResponse shape (wire type)
-│   │   ├── dsml/              — DeepSeek V3.2 / V4 DSML grammar
-│   │   ├── gemma4/            — Google Gemma 4 custom non-JSON grammar (`<|"|>`-delimited strings)
-│   │   ├── xml/               — hermes, glm47, kimi_k2, minimax_m2, qwen3_coder
-│   │   ├── json/              — deepseek_v3, deepseek_v3_1, nemotron_deci/nano, jamba, mistral, phi4, llama3_json
-│   │   ├── harmony/           — OpenAI gpt-oss (Harmony token stream, uses openai_harmony crate)
-│   │   └── pythonic/          — Python function-call syntax (some Llama variants)
-│   └── reasoning/           ← reasoning-content extraction (15 registered parsers)
-│       ├── mod.rs             — registry + dispatch
-│       ├── base_parser.rs     — BasicReasoningParser (<think> ... </think>)
-│       ├── gemma4_parser.rs   — Gemma 4 (`<|channel>thought\n...<channel|>`)
-│       ├── gpt_oss_parser.rs  — Harmony channel parsing
-│       ├── granite_parser.rs  — Granite-style
-│       └── minimax_append_think_parser.rs  — MiniMax inline-reasoning
+src/
+├── tool_calling/        ← tool-call extraction (18 registered parsers)
+│   ├── parsers.rs         — registry + dispatch (detect_and_parse_tool_call)
+│   ├── config.rs          — per-parser ToolCallConfig
+│   ├── response.rs        — ToolCallResponse shape (wire type)
+│   ├── dsml/              — DeepSeek V3.2 / V4 DSML grammar
+│   ├── gemma4/            — Google Gemma 4 custom non-JSON grammar (`<|"|>`-delimited strings)
+│   ├── xml/               — hermes, glm47, kimi_k2, minimax_m2, qwen3_coder
+│   ├── json/              — deepseek_v3, deepseek_v3_1, nemotron_deci/nano, jamba, mistral, phi4, llama3_json
+│   ├── harmony/           — OpenAI gpt-oss (Harmony token stream, uses openai_harmony crate)
+│   └── pythonic/          — Python function-call syntax (some Llama variants)
+└── reasoning/           ← reasoning-content extraction (15 registered parsers)
+    ├── mod.rs             — registry + dispatch
+    ├── base_parser.rs     — BasicReasoningParser (<think> ... </think>)
+    ├── gemma4_parser.rs   — Gemma 4 (`<|channel>thought\n...<channel|>`)
+    ├── gpt_oss_parser.rs  — Harmony channel parsing
+    ├── granite_parser.rs  — Granite-style
+    └── minimax_append_think_parser.rs  — MiniMax inline-reasoning
 ```
 
 ## How a request flows through the crate
@@ -90,45 +87,20 @@ Reasoning parsers:
 | **Append-think** | `<think>...</think>` left inline as text, with `<think>` prefix on first chunk | `reasoning/minimax_append_think_parser.rs` | MiniMax M2 |
 | **Harmony channel** | Hidden `analysis` channel | `reasoning/gpt_oss_parser.rs` (wraps external `openai_harmony`) | gpt-oss-20B / 120B |
 | **Granite** | Custom start/end tokens | `reasoning/granite_parser.rs` | IBM Granite |
-| **Gemma 4 channel** | `<\|channel>thought\n...<channel\|>` with role-label prefix stripped | `reasoning/gemma4_parser.rs` | Google Gemma 4 thinking models |
+| **Gemma 4 channel** | `<\|channel>thought\n...<channel|>` with role-label prefix stripped | `reasoning/gemma4_parser.rs` | Google Gemma 4 thinking models |
 
 ## Adding a new parser
 
-1. **Pick the family** from the cheat sheet above. If an existing config-driven
-   family fits, add a `ToolCallConfig::<your_model>()` constructor in
-   `tool_calling/config.rs`, register it in `tool_calling/parsers.rs`. Done —
-   you inherit all the shared parser and tests.
+1. **Pick the family** from the cheat sheet above. If an existing config-driven family fits, add a `ToolCallConfig::<your_model>()` constructor in `tool_calling/config.rs`, register it in `tool_calling/parsers.rs`. Done — you inherit all the shared parser and tests.
 
-2. **If the grammar is genuinely new**, add a module under `tool_calling/` and
-   add a `ParserConfig` variant in `config.rs`. Follow the existing parser
-   modules for layout.
+2. **If the grammar is genuinely new**, add a module under `tool_calling/` and add a `ParserConfig` variant in `config.rs`. Follow the existing parser modules for layout.
 
-3. **For reasoning**, prefer aliasing to `BasicReasoningParser` unless the
-   grammar truly diverges (append-think, Harmony channels). Most new models
-   use plain `<think>...</think>` and can share.
+3. **For reasoning**, prefer aliasing to `BasicReasoningParser` unless the grammar truly diverges (append-think, Harmony channels). Most new models use plain `<think>...</think>` and can share.
 
-4. **Write tests.** Minimum viable set is in [`PARSER_CASES.md`](./PARSER_CASES.md) (`PARSER.*`
-   taxonomy). At minimum: `PARSER.1`/`PARSER.2`/`PARSER.3` for correctness,
-   `PARSER.5` for truncation behavior, `PARSER.8`/`PARSER.9` for streaming
-   with reasoning, and `PARSER.13` for interleaved text. `N/A` categories
-   should be explicitly called out in a comment rather than silently skipped.
+4. **Write tests.** Minimum viable set is in [`PARSER_CASES.md`](./PARSER_CASES.md) (`PARSER.*` taxonomy). At minimum: `PARSER.1`/`PARSER.2`/`PARSER.3` for correctness, `PARSER.5` for truncation behavior, `PARSER.8`/`PARSER.9` for streaming with reasoning, and `PARSER.13` for interleaved text. `N/A` categories should be explicitly called out in a comment rather than silently skipped.
 
 ## Related docs
 
-- [`PARSER_CASES.md`](./PARSER_CASES.md) — corner-case taxonomy. What every
-  parser should be tested against, what's N/A per family, what's a universal
-  gap today.
-- `lib/llm/tests/data/` — captured streaming fixtures per (engine × model)
-  that feed `test_streaming_tool_parsers.rs`. The replay side of the testing
-  story.
-
-## Integration with the rest of Dynamo
-
-- `lib/llm/src/preprocessor/prompt/` — pre-model side. Writes the prompts
-  that (eventually) come back and get parsed here.
-- `lib/llm/src/preprocessor.rs` — top-level request/response pipeline.
-  Decides whether to run the reasoning parser based on
-  `is_reasoning_disabled_by_request`, then hands the reasoning-stripped
-  tail to the tool-call parser.
-- `components/src/dynamo/frontend/` — Python frontend that surfaces parsed
-  output as OpenAI-compatible SSE chunks to the client.
+- [`PARSER_CASES.md`](./PARSER_CASES.md) — corner-case taxonomy. What every parser should be tested against, what's N/A per family, what's a universal gap today.
+- [`REASONING_CASES.md`](./REASONING_CASES.md) — same idea for reasoning parsers.
+- [`PIPELINE_CASES.md`](./PIPELINE_CASES.md) — end-to-end (reasoning → tool-call) test scenarios.

--- a/lib/parsers/README.md
+++ b/lib/parsers/README.md
@@ -8,7 +8,7 @@ Given a token stream from any inference engine (vLLM, SGLang, etc.), extract str
 
 Two top-level modules, each with its own parser registry:
 
-```
+```text
 src/
 ├── tool_calling/        ← tool-call extraction (18 registered parsers)
 │   ├── parsers.rs         — registry + dispatch (detect_and_parse_tool_call)
@@ -31,7 +31,7 @@ src/
 
 ## How a request flows through the crate
 
-```
+```text
   token stream from engine
             │
             ▼
@@ -85,7 +85,7 @@ Reasoning parsers:
 | **Append-think** | `<think>...</think>` left inline as text, with `<think>` prefix on first chunk | `reasoning/minimax_append_think_parser.rs` | MiniMax M2 |
 | **Harmony channel** | Hidden `analysis` channel | `reasoning/gpt_oss_parser.rs` (wraps external `openai_harmony`) | gpt-oss-20B / 120B |
 | **Granite** | Custom start/end tokens | `reasoning/granite_parser.rs` | IBM Granite |
-| **Gemma 4 channel** | `<\|channel>thought\n...<channel|>` with role-label prefix stripped | `reasoning/gemma4_parser.rs` | Google Gemma 4 thinking models |
+| **Gemma 4 channel** | `<\|channel>thought\n...<channel\|>` with role-label prefix stripped | `reasoning/gemma4_parser.rs` | Google Gemma 4 thinking models |
 
 ## Adding a new parser
 

--- a/lib/parsers/README.md
+++ b/lib/parsers/README.md
@@ -1,7 +1,5 @@
 # dynamo-parsers
 
-> Also available as a standalone crate at **[ai-dynamo/frontend-crates](https://github.com/ai-dynamo/frontend-crates)**. That repo is the canonical home for publishing to crates.io; this in-tree copy is kept in sync manually for workspace builds.
-
 Rust crate for parsing **tool calls** and **reasoning content** out of raw LLM output. Wire-format-aware, streaming-first, model-family-aware.
 
 Given a token stream from any inference engine (vLLM, SGLang, etc.), extract structured `Vec<ToolCallResponse>` + `reasoning_content` ready to be returned to the client. Prompt formatting (the pre-model side) is out of scope.

--- a/lib/protocols/CLAUDE.md
+++ b/lib/protocols/CLAUDE.md
@@ -1,6 +1,8 @@
-# lib/protocols
+# dynamo-protocols
 
-OpenAI-compatible request/response types for Dynamo's HTTP surface. Built on top of the `async-openai` crate, with selective Dynamo-owned overrides where we need behaviors upstream won't accept or hasn't merged yet.
+> Also available as a standalone crate at **[ai-dynamo/frontend-crates](https://github.com/ai-dynamo/frontend-crates)**. That repo is the canonical home for publishing to crates.io; this in-tree copy is kept in sync manually for workspace builds.
+
+OpenAI-compatible request/response types for inference servers. Built on top of the `async-openai` crate, with selective crate-owned overrides where we need behaviors upstream won't accept or hasn't merged yet.
 
 If you're extending or debugging types here, read this whole file before editing. The central question every change hinges on is: **do we re-export this upstream, or do we own it?** This document exists so the answer is consistent.
 
@@ -8,14 +10,14 @@ If you're extending or debugging types here, read this whole file before editing
 
 `async-openai` is well-maintained but slow on input-laxity PRs. The maintainer generally wants changes to match the OpenAPI spec exactly, even when OpenAI's *hosted* API accepts more permissive shapes on input than the spec requires. See `64bit/async-openai#535` (optional `ReasoningItem.id`) and prior work on optional `OutputMessage.id`/`status` — both driven by real Agents-SDK / Codex traffic that the spec technically rejects.
 
-We can't block Dynamo on upstream merges. We also can't fork the whole crate — it's enormous and updates often. The rule we settled on is: **re-export upstream by default; own the narrowest type subtree that lets us fix the behavior we need.**
+We can't block on upstream merges. We also can't fork the whole crate — it's enormous and updates often. The rule we settled on is: **re-export upstream by default; own the narrowest type subtree that lets us fix the behavior we need.**
 
 ## The ownership rubric
 
 Default to upstream. Own a type only when at least one of these is true:
 
 1. **Upstream rejects a shape real clients send.** The driving case. Example: `OutputMessage.id`/`status`/`annotations` marked required upstream but routinely omitted by Codex / Agents SDK on input.
-2. **We need to extend the schema with a Dynamo-specific field** that doesn't belong upstream. Example: `CreateChatCompletionRequest.mm_processor_kwargs` (vLLM multimodal), `ChatCompletionRequestAssistantMessage.reasoning_content` (R1 / QwQ), `ChatCompletionStreamOptions.continuous_usage_stats`.
+2. **We need to extend the schema with an inference-serving field** that doesn't belong upstream. Example: `CreateChatCompletionRequest.mm_processor_kwargs` (vLLM multimodal), `ChatCompletionRequestAssistantMessage.reasoning_content` (R1 / QwQ), `ChatCompletionStreamOptions.continuous_usage_stats`.
 3. **Upstream's type forces a shape that breaks downstream backends.** Example: `FunctionCall.arguments` is `String` upstream; LangChain and similar send it as an object. We own `FunctionCall` to accept both via a custom deserializer and normalize to `String`.
 4. **Upstream has a known bug.** Example: `ChatCompletionMessageToolCall.type` wasn't always serialized; we own it with `#[serde(default = "default_function_type")]` to preserve wire compat.
 
@@ -27,13 +29,13 @@ Default to upstream. Own a type only when at least one of these is true:
 - `src/types/responses/mod.rs` — Responses API (Codex, Agents SDK). Input chain owned; output chain fully upstream.
 - `src/types/completion.rs` — Legacy completions. Mostly upstream.
 - `src/types/anthropic.rs` — Anthropic Messages API. Fully owned (no upstream equivalent in `async-openai`).
-- `src/types/embeddings`, `src/types/images` — full upstream re-export (no Dynamo extensions).
+- `src/types/embeddings`, `src/types/images` — full upstream re-export (no inference-serving extensions).
 
 ## Re-export conventions
 
 Use **explicit re-exports** (`pub use foo::{A, B, C}`), not globs, when you need to selectively shadow. Globs (`pub use foo::*`) are allowed at the top of a module — Rust lets a local `pub struct Foo` shadow a glob-imported `Foo` (the glob just emits `unused_imports` warnings). But explicit lists make the ownership split obvious to readers and catch mistakes at compile time when upstream renames or removes a type.
 
-`src/types/responses/mod.rs` uses glob re-export because the surface is huge (200+ types). `src/types/chat.rs` uses explicit lists because the surface is manageable and Dynamo owns more of it. Either pattern is acceptable; pick based on how many types you'd have to enumerate to exclude the ones you own.
+`src/types/responses/mod.rs` uses glob re-export because the surface is huge (200+ types). `src/types/chat.rs` uses explicit lists because the surface is manageable and we own more of it. Either pattern is acceptable; pick based on how many types you'd have to enumerate to exclude the ones you own.
 
 ## Naming: avoiding dual-side collisions
 
@@ -43,11 +45,11 @@ If we relax `OutputMessage` (make `id`/`status` optional) and shadow upstream's 
 
 The naive fix is to also own `OutputItem`. But that cascades into owning `Response`, streaming events, and a long tail of their sub-types. The right fix is smaller:
 
-**Rule.** If a type is reused by upstream on both input and output sides, give the Dynamo-owned input-side variant a *different name*. The output side keeps using upstream's name via the glob / explicit re-export.
+**Rule.** If a type is reused by upstream on both input and output sides, give the owned input-side variant a *different name*. The output side keeps using upstream's name via the glob / explicit re-export.
 
 Current naming in `responses/mod.rs`:
 
-- `InputOutputMessage` — Dynamo-owned, relaxed; used in `MessageItem::Output(...)` on the input side.
+- `InputOutputMessage` — owned, relaxed; used in `MessageItem::Output(...)` on the input side.
 - `OutputMessage` — upstream, unchanged; used in `OutputItem::Message(...)` on the output side.
 - Same pattern for `InputOutputMessageContent` (input) vs upstream `OutputMessageContent` (output), and `InputOutputTextContent` (input) vs upstream `OutputTextContent` (output).
 
@@ -85,7 +87,7 @@ If an upstream PR lands that makes a field optional (matching what we relaxed), 
 3. Update consumer sites (convert `Option<T>` to `T` if upstream still has the field but non-optional, etc.).
 4. Run the full test suite; the serialization-shape tests should catch any regressions.
 
-Don't leave redundant Dynamo-owned types in place "just in case." Dead ownership is tech debt.
+Don't leave redundant owned types in place "just in case." Dead ownership is tech debt.
 
 ## When upstream renames or restructures a type we re-export
 
@@ -93,21 +95,21 @@ Glob re-exports will silently pick up the rename. Explicit re-exports will fail 
 
 ## Testing patterns
 
-- Serialization-shape tests (`test_response_wire_format_shape` in `lib/llm`) validate that our serialized JSON matches the API spec. Lean on these when you change owned types.
+- Serialization-shape tests in `tests/` validate that our serialized JSON matches the API spec. Lean on these when you change owned types.
 - Deserialization tests for owned types should cover both the relaxed shape (the reason we own it) and the strict shape (to prove we didn't break spec-conformant clients).
-- When you add a new Dynamo field to an owned type, add a test that omits it and asserts the default behavior.
+- When you add a new owned field to a type, add a test that omits it and asserts the default behavior.
 
 ## Things that are explicitly *not* this crate's job
 
-- HTTP transport (request execution, retries, streaming frame parsing) — that's `lib/llm/src/http/`.
-- Semantic conversion between API types (Responses → Chat, Anthropic → Chat, etc.) — that lives in `lib/llm/src/protocols/` and uses the types defined here.
-- Model-specific tokenization or prompt templating.
+- HTTP transport (request execution, retries, streaming frame parsing) — pair this crate with `axum`, `reqwest`, or whatever your stack uses.
+- Semantic conversion between API types (Responses → Chat, Anthropic → Chat, etc.) — keep that in your server-side translation layer; this crate just defines the wire types.
+- Model-specific tokenization or prompt templating — see `dynamo-tokenizers` and `dynamo-parsers`.
 
 Keep this crate declarative: types, serde derives, builders, conversions-by-`From`. Business logic belongs downstream.
 
 ## Common mistakes
 
 - Owning a type because it's *nearby* a bug, not because of the bug itself. Narrow the fix.
-- Shadowing a dual-side type without checking output-side construction sites. `grep` the workspace for constructor calls before renaming.
+- Shadowing a dual-side type without checking output-side construction sites. `grep` for constructor calls before renaming.
 - Adding fields to upstream-re-exported types via `#[serde(default)]` on a local wrapper struct. Doesn't work — serde can't inject defaults into a foreign type unless you use `#[serde(remote)]`, which requires field-for-field mirroring and doesn't help with optional-vs-required mismatches.
 - Forgetting to update `From` impls when adding variants. The compiler catches exhaustive matches but not variant count on `From<Ours> for Upstream` when the enum is non-exhaustive.

--- a/lib/protocols/CLAUDE.md
+++ b/lib/protocols/CLAUDE.md
@@ -1,7 +1,5 @@
 # dynamo-protocols
 
-> Also available as a standalone crate at **[ai-dynamo/frontend-crates](https://github.com/ai-dynamo/frontend-crates)**. That repo is the canonical home for publishing to crates.io; this in-tree copy is kept in sync manually for workspace builds.
-
 OpenAI-compatible request/response types for inference servers. Built on top of the `async-openai` crate, with selective crate-owned overrides where we need behaviors upstream won't accept or hasn't merged yet.
 
 If you're extending or debugging types here, read this whole file before editing. The central question every change hinges on is: **do we re-export this upstream, or do we own it?** This document exists so the answer is consistent.

--- a/lib/protocols/Cargo.toml
+++ b/lib/protocols/Cargo.toml
@@ -12,12 +12,11 @@
 name = "dynamo-protocols"
 description = "Protocol types for OpenAI-compatible inference APIs with inference-serving extensions."
 license = "Apache-2.0 AND MIT"
-# Canonical home for this crate is ai-dynamo/frontend-crates.
-homepage = "https://github.com/ai-dynamo/frontend-crates"
-repository = "https://github.com/ai-dynamo/frontend-crates.git"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
 readme.workspace = true
 
 [dependencies]

--- a/lib/protocols/Cargo.toml
+++ b/lib/protocols/Cargo.toml
@@ -12,11 +12,12 @@
 name = "dynamo-protocols"
 description = "Protocol types for OpenAI-compatible inference APIs with inference-serving extensions."
 license = "Apache-2.0 AND MIT"
+# Canonical home for this crate is ai-dynamo/frontend-crates.
+homepage = "https://github.com/ai-dynamo/frontend-crates"
+repository = "https://github.com/ai-dynamo/frontend-crates.git"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true
-homepage.workspace = true
-repository.workspace = true
 readme.workspace = true
 
 [dependencies]

--- a/lib/protocols/Cargo.toml
+++ b/lib/protocols/Cargo.toml
@@ -10,9 +10,9 @@
 
 [package]
 name = "dynamo-protocols"
+readme = "README.md"
 description = "Protocol types for OpenAI-compatible inference APIs with inference-serving extensions."
 license = "Apache-2.0 AND MIT"
-readme = "README.md"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/lib/protocols/Cargo.toml
+++ b/lib/protocols/Cargo.toml
@@ -12,7 +12,7 @@
 name = "dynamo-protocols"
 description = "Protocol types for OpenAI-compatible inference APIs with inference-serving extensions."
 license = "Apache-2.0 AND MIT"
-readme = "CLAUDE.md"
+readme = "README.md"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/lib/protocols/Cargo.toml
+++ b/lib/protocols/Cargo.toml
@@ -12,12 +12,12 @@
 name = "dynamo-protocols"
 description = "Protocol types for OpenAI-compatible inference APIs with inference-serving extensions."
 license = "Apache-2.0 AND MIT"
+readme = "CLAUDE.md"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true
 homepage.workspace = true
 repository.workspace = true
-readme.workspace = true
 
 [dependencies]
 # Upstream OpenAI types (types-only, no HTTP client)

--- a/lib/protocols/README.md
+++ b/lib/protocols/README.md
@@ -1,0 +1,20 @@
+# dynamo-protocols
+
+Request/response types for OpenAI- and Anthropic-compatible inference servers. Built on [`async-openai`](https://crates.io/crates/async-openai) v0.34, with selective overrides where inference engines need behaviors upstream doesn't support.
+
+## What's included
+
+- **Chat Completions** — multimodal content, reasoning content (DeepSeek-R1 / QwQ), continuous usage stats, tool-calling.
+- **Responses API** — input chain owned (relaxed for Codex / Agents SDK); output chain re-exported from upstream.
+- **Completions** — re-exported.
+- **Anthropic Messages** — fully owned (no upstream equivalent).
+- **Embeddings**, **Images** — re-exported.
+
+## Locally-defined extensions
+
+A few fields extend the upstream `async-openai` schema:
+
+- `reasoning_content` on assistant messages
+- `mm_processor_kwargs` on chat-completion requests (vLLM multimodal)
+- `continuous_usage_stats` on chat stream options
+- `FunctionCall.arguments` accepts both string and object forms

--- a/lib/tokenizers/Cargo.toml
+++ b/lib/tokenizers/Cargo.toml
@@ -3,13 +3,14 @@
 
 [package]
 name = "dynamo-tokenizers"
+description = "Standalone tokenizer implementations (HuggingFace, tiktoken, FastTokenizers) for LLM inference serving."
+# Canonical home for this crate is ai-dynamo/frontend-crates.
+homepage = "https://github.com/ai-dynamo/frontend-crates"
+repository = "https://github.com/ai-dynamo/frontend-crates.git"
 version.workspace = true
 edition.workspace = true
-description = "Standalone tokenizer implementations for Dynamo"
 authors.workspace = true
 license.workspace = true
-homepage.workspace = true
-repository.workspace = true
 keywords.workspace = true
 
 [dependencies]

--- a/lib/tokenizers/Cargo.toml
+++ b/lib/tokenizers/Cargo.toml
@@ -3,8 +3,8 @@
 
 [package]
 name = "dynamo-tokenizers"
-description = "Standalone tokenizer implementations (HuggingFace, tiktoken, FastTokenizers) for LLM inference serving."
 readme = "README.md"
+description = "Standalone tokenizer implementations (HuggingFace, tiktoken, FastTokenizers) for LLM inference serving."
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/lib/tokenizers/Cargo.toml
+++ b/lib/tokenizers/Cargo.toml
@@ -4,13 +4,12 @@
 [package]
 name = "dynamo-tokenizers"
 description = "Standalone tokenizer implementations (HuggingFace, tiktoken, FastTokenizers) for LLM inference serving."
-# Canonical home for this crate is ai-dynamo/frontend-crates.
-homepage = "https://github.com/ai-dynamo/frontend-crates"
-repository = "https://github.com/ai-dynamo/frontend-crates.git"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
+homepage.workspace = true
+repository.workspace = true
 keywords.workspace = true
 
 [dependencies]

--- a/lib/tokenizers/Cargo.toml
+++ b/lib/tokenizers/Cargo.toml
@@ -4,6 +4,7 @@
 [package]
 name = "dynamo-tokenizers"
 description = "Standalone tokenizer implementations (HuggingFace, tiktoken, FastTokenizers) for LLM inference serving."
+readme = "README.md"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/lib/tokenizers/README.md
+++ b/lib/tokenizers/README.md
@@ -1,7 +1,5 @@
 # dynamo-tokenizers
 
-> Also available as a standalone crate at **[ai-dynamo/frontend-crates](https://github.com/ai-dynamo/frontend-crates)**. That repo is the canonical home for publishing to crates.io; this in-tree copy is kept in sync manually for workspace builds.
-
 Efficient, versatile tokenization for LLM inference. Wraps HuggingFace and TikToken tokenizers (plus a FastTokenizer hybrid mode) behind a small encode/decode/sequence API designed for streaming detokenization.
 
 ## Features

--- a/lib/tokenizers/README.md
+++ b/lib/tokenizers/README.md
@@ -1,53 +1,48 @@
-# Tokenizers
+# dynamo-tokenizers
 
-## Introduction
-`dynamo-tokenizers` provides efficient, versatile tokenization for NLP workloads. It supports HuggingFace and TikToken tokenizers (plus a FastTokenizer hybrid mode) through a streamlined encoding/decoding API.
+> Also available as a standalone crate at **[ai-dynamo/frontend-crates](https://github.com/ai-dynamo/frontend-crates)**. That repo is the canonical home for publishing to crates.io; this in-tree copy is kept in sync manually for workspace builds.
+
+Efficient, versatile tokenization for LLM inference. Wraps HuggingFace and TikToken tokenizers (plus a FastTokenizer hybrid mode) behind a small encode/decode/sequence API designed for streaming detokenization.
 
 ## Features
-- **Hash Verification**: Ensures tokenization consistency and accuracy across different models.
-- **Simple Encoding and Decoding**: Facilitates the conversion of text to token IDs and back.
-- **Sequence Management**: Manage sequences of tokens for complex NLP tasks effectively.
 
-## Quick Start
+- **Multiple backends.** HuggingFace `tokenizers`, OpenAI `tiktoken`, and a FastTokenizer hybrid behind one trait.
+- **Streaming-friendly.** `Sequence` tracks incremental token-id appends and emits text deltas without re-decoding the full prefix.
+- **Hash verification.** Detect tokenizer drift across model versions.
 
-#### HuggingFace Tokenizer
+## Quick start
+
 ```rust
 use dynamo_tokenizers::hf::HuggingFaceTokenizer;
+use dynamo_tokenizers::traits::{Encoder, Decoder};
 
-let hf_tokenizer = HuggingFaceTokenizer::from_file("tests/data/sample-models/TinyLlama_v1.1/tokenizer.json")
-    .expect("Failed to load HuggingFace tokenizer");
+// tokenizer.json downloaded from any HuggingFace model repo
+let tokenizer = HuggingFaceTokenizer::from_file("/path/to/tokenizer.json")
+    .expect("load tokenizer");
+
+let encoding = tokenizer.encode("Your sample text here")
+    .expect("encode");
+println!("{:?}", encoding);
+
+let decoded = tokenizer.decode(&encoding.token_ids, false)
+    .expect("decode");
+assert_eq!(decoded, "Your sample text here");
 ```
 
-### Encoding and Decoding Text
+## Streaming detokenization with `Sequence`
 
 ```rust
-use dynamo_tokenizers::{HuggingFaceTokenizer, traits::{Encoder, Decoder}};
-
-let tokenizer = HuggingFaceTokenizer::from_file("tests/data/sample-models/TinyLlama_v1.1/tokenizer.json")
-    .expect("Failed to load HuggingFace tokenizer");
-
-let text = "Your sample text here";
-let encoding = tokenizer.encode(text)
-    .expect("Failed to encode text");
-
-println!("Encoding: {:?}", encoding);
-
-let decoded_text = tokenizer.decode(&encoding.token_ids, false)
-    .expect("Failed to decode token IDs");
-
-assert_eq!(text, decoded_text);
-
-// Using the Sequence object for encoding and decoding
-
 use dynamo_tokenizers::{Sequence, Tokenizer};
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 let tokenizer = Tokenizer::from(Arc::new(tokenizer));
 let mut sequence = Sequence::new(tokenizer.clone());
 
 sequence.append_text("Your sample text here")
-    .expect("Failed to append text");
+    .expect("append text");
 
+// As each new token id is produced by the engine, append it
+// and get back just the incremental text delta:
 let delta = sequence.append_token_id(1337)
-    .expect("Failed to append token_id");
+    .expect("append token_id");
 ```


### PR DESCRIPTION
## Summary

Minor cleanups to the three crates' Cargo.toml descriptions and their docs. No code changes, no behavior changes.

## Changes

**Cargo.toml descriptions:**
- \`lib/tokenizers/Cargo.toml\` — \"Standalone tokenizer implementations for Dynamo\" → \"Standalone tokenizer implementations (HuggingFace, tiktoken, FastTokenizers) for LLM inference serving.\"
- \`lib/parsers/Cargo.toml\` — \"Dynamo Parser Library for Tool Calling and Reasoning\" → \"Reasoning and tool-calling parsers for OpenAI-compatible inference output.\"
- \`lib/protocols/Cargo.toml\` — no change.

**Docs:**
- \`lib/protocols/CLAUDE.md\` (+ symlinked \`AGENTS.md\`) — open with what the crate is rather than \"types for Dynamo's HTTP surface\"; trim a couple of cross-references to \`lib/llm/src/http/\` / \`lib/llm/src/protocols/\` in the \"Things that are explicitly *not* this crate's job\" list. Technical content (ownership rubric, dual-side naming, Responses input chain diagram, etc.) is unchanged.
- \`lib/parsers/README.md\` — drop the \`lib/parsers/\` path prefix from the layout tree (now just \`src/\`); drop the \"Integration with the rest of Dynamo\" section that referenced \`lib/llm/src/preprocessor/...\` and \`components/src/dynamo/frontend/\`; point Related Docs at the sibling \`*_CASES.md\` files instead of \`lib/llm/tests/data/\`.
- \`lib/tokenizers/README.md\` — fix the broken example path that pointed at \`tests/data/sample-models/TinyLlama_v1.1/tokenizer.json\` (doesn't exist in this crate); minor reframe of the intro.

## Test plan

- [x] \`cargo check -p dynamo-protocols -p dynamo-tokenizers -p dynamo-parsers\` passes against this branch.
- [ ] CI workspace build is green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated parser library documentation to clarify support for reasoning and tool-calling extraction from LLM output.
  * Expanded tokenizer documentation to explicitly highlight support for multiple backends (HuggingFace, tiktoken, and FastTokenizers).
  * Refined protocol guidance documentation for clearer OpenAI-compatible type handling and ownership rules.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9464)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->