### PR TITLE
fix(llm): use cached HF snapshot before issuing remote download

### DIFF
--- a/lib/llm/src/hub.rs
+++ b/lib/llm/src/hub.rs
@@ -81,25 +81,22 @@ fn is_no_shared_storage() -> bool {
         .unwrap_or(false)
 }
 
-/// Download a model using ModelExpress client. The client first requests for the model
-/// from the server and fallbacks to direct download in case of server failure.
-/// If ignore_weights is true, model weight files will be skipped
-/// Returns the path to the model files
-///
-/// If HF_HUB_OFFLINE=1 is set and the model is already cached, returns the cached
-/// path without making any API calls to HuggingFace.
+/// Download a model using ModelExpress client. Returns the cached path
+/// immediately if the model is already in the HF cache; otherwise requests it
+/// from the server and falls back to direct download on server failure.
+/// If ignore_weights is true, model weight files will be skipped.
+/// Returns the path to the model files.
 pub async fn from_hf(name: impl AsRef<Path>, ignore_weights: bool) -> anyhow::Result<PathBuf> {
     let name = name.as_ref();
     let model_name = name.display().to_string();
 
-    // In offline mode, check cache first and return immediately if found
+    // Cache-first: skip the remote round-trip when the snapshot is already on disk.
+    if let Some(cached_path) = get_cached_model_path(&model_name, ignore_weights) {
+        tracing::info!("Using cached model '{model_name}' at {cached_path:?}");
+        return Ok(cached_path);
+    }
+
     if is_offline_mode() {
-        if let Some(cached_path) = get_cached_model_path(&model_name, ignore_weights) {
-            tracing::info!(
-                "Offline mode: using cached model '{model_name}' without API validation"
-            );
-            return Ok(cached_path);
-        }
         tracing::warn!(
             "Offline mode enabled but model '{model_name}' not found in cache, attempting download anyway"
         );
@@ -236,5 +233,110 @@ mod tests {
             // Clean up
             env::remove_var(env_model::huggingface::HF_HOME);
         }
+    }
+
+    /// Materialize a minimal HF cache snapshot at `cache_root` for `repo_id`,
+    /// optionally including a fake weight file. Local writes only, no network.
+    fn write_fake_snapshot(cache_root: &Path, repo_id: &str, include_weights: bool) -> PathBuf {
+        let folder = format!("models--{}", repo_id.replace('/', "--"));
+        let repo_dir = cache_root.join(&folder);
+        let sha = "deadbeefcafebabe1234567890abcdef12345678";
+        let snapshot_dir = repo_dir.join("snapshots").join(sha);
+        std::fs::create_dir_all(&snapshot_dir).unwrap();
+        std::fs::create_dir_all(repo_dir.join("refs")).unwrap();
+        std::fs::write(repo_dir.join("refs").join("main"), sha).unwrap();
+        std::fs::write(snapshot_dir.join("config.json"), r#"{"model_type":"test"}"#).unwrap();
+        std::fs::write(snapshot_dir.join("tokenizer.json"), "{}").unwrap();
+        if include_weights {
+            std::fs::write(snapshot_dir.join("model.safetensors"), b"fake-weights").unwrap();
+        }
+        snapshot_dir
+    }
+
+    /// Set HF_HUB_CACHE to `path` and clear sibling vars that would otherwise take
+    /// precedence in `get_model_express_cache_dir`.
+    fn force_hf_hub_cache(path: &Path) {
+        unsafe {
+            env::remove_var(env_model::huggingface::HF_HOME);
+            env::remove_var(env_model::model_express::MODEL_EXPRESS_CACHE_PATH);
+            env::set_var(env_model::huggingface::HF_HUB_CACHE, path);
+        }
+    }
+
+    fn clear_hf_hub_cache() {
+        unsafe {
+            env::remove_var(env_model::huggingface::HF_HUB_CACHE);
+        }
+    }
+
+    #[serial_test::serial]
+    #[test]
+    fn test_get_cached_model_path_finds_populated_snapshot() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let snapshot = write_fake_snapshot(temp.path(), "test-org/test-model", true);
+        force_hf_hub_cache(temp.path());
+
+        let resolved = get_cached_model_path("test-org/test-model", false);
+
+        clear_hf_hub_cache();
+
+        let resolved = resolved.expect("expected cache hit on fully populated snapshot");
+        assert_eq!(resolved, snapshot);
+    }
+
+    #[serial_test::serial]
+    #[test]
+    fn test_get_cached_model_path_missing_model_returns_none() {
+        let temp = tempfile::TempDir::new().unwrap();
+        force_hf_hub_cache(temp.path());
+
+        let resolved = get_cached_model_path("nonexistent-org/nonexistent-model", false);
+
+        clear_hf_hub_cache();
+
+        assert!(
+            resolved.is_none(),
+            "expected no cache hit when model is absent"
+        );
+    }
+
+    #[serial_test::serial]
+    #[test]
+    fn test_get_cached_model_path_weights_requirement() {
+        // Snapshot has config + tokenizer but no weight files. Required-weights
+        // mode misses; ignore_weights mode hits.
+        let temp = tempfile::TempDir::new().unwrap();
+        write_fake_snapshot(temp.path(), "test-org/tokenizer-only", false);
+        force_hf_hub_cache(temp.path());
+
+        let weights_required = get_cached_model_path("test-org/tokenizer-only", false);
+        let weights_optional = get_cached_model_path("test-org/tokenizer-only", true);
+
+        clear_hf_hub_cache();
+
+        assert!(
+            weights_required.is_none(),
+            "ignore_weights=false should miss when weight files are absent",
+        );
+        assert!(
+            weights_optional.is_some(),
+            "ignore_weights=true should hit on config + tokenizer alone",
+        );
+    }
+
+    #[serial_test::serial]
+    #[tokio::test]
+    async fn test_from_hf_returns_cached_path_without_network() {
+        // Made-up repo that doesn't exist on HF — Ok result proves cache-first bypassed the network.
+        let temp = tempfile::TempDir::new().unwrap();
+        let snapshot = write_fake_snapshot(temp.path(), "test-org/cache-first-only", true);
+        force_hf_hub_cache(temp.path());
+
+        let resolved = from_hf("test-org/cache-first-only", false).await;
+
+        clear_hf_hub_cache();
+
+        let path = resolved.expect("expected cache-first to succeed without network");
+        assert_eq!(path, snapshot);
     }
 }


### PR DESCRIPTION
#### Overview:

When a complete snapshot of a model is already in the local HF cache, `from_hf()` now returns that path directly — no ModelExpress, no HuggingFace round-trip. Remote calls happen only when the cache is missing. This eliminates avoidable per-call latency and removes the remote dependency from model registration paths in deployments where the cache is materialized externally (sidecar prefetch, shared volume, prior successful download).

#### Details:

Today `from_hf()` unconditionally calls the ModelExpress server (with HF fallback) on every invocation and only uses the cache as a passive byproduct of the download. That makes every model registration depend on remote reachability — even when every file the function needs is already on disk.

Without this change, a transient remote failure (rate limit, 5xx, network blip, ModelExpress outage) during model registration leaves `from_hf()` returning `Err` even when the requested snapshot is on disk. Callers that don't retry on subsequent worker events — for example, the frontend's discovery watcher, which logs `Error adding model from discovery` and stops attempting registration after its retry budget — then leave `/v1/models` empty for the affected model and `/v1/chat/completions` returning `404 model or resource not found` until the pod is recreated.

This PR moves the cache lookup to the top of `from_hf()`. Behavior priority is now:

```
local cache (hit) → done
cache miss → ModelExpress server → direct HF download → error
```

The lookup reuses `get_cached_model_path()` — the same helper that already backed the explicit `HF_HUB_OFFLINE=1` opt-in path — so the same "complete snapshot" definition (config + tokenizer, plus weights unless `ignore_weights`) gates both. With cache-first as the universal default, the offline-mode block collapses to just a single warn-on-miss; the duplicate cache check it used to do is now redundant.

Notes on tradeoffs:

- The cached revision may be stale relative to upstream HF. For the common case (sidecar prefetch / shared cache volume / `HF_HUB_CACHE` pointed at a curated location), the cached revision is the intended revision; the previous "always check remote" behavior was paying a round-trip for no correctness benefit. Operators who explicitly need the latest revision can flush the cache or bypass it.
- This does not affect first-fetch behavior: if the cache is empty, the remote path runs exactly as it does today.

Three new unit tests on `get_cached_model_path()` plus one end-to-end test on `from_hf()`, all run offline (no network access, no HF tokens required):

- populated snapshot returns `Some(snapshot_path)`
- missing model returns `None`
- weight requirement: required-weights mode misses if weights absent; `ignore_weights` mode hits on config + tokenizer alone
- `from_hf()` end-to-end: returns the cached path for a fake repo that doesn't exist on HF, proving the cache-first path bypasses the network

Local result:

```
$ cargo test -p dynamo-llm --no-default-features --lib hub::
running 7 tests
test hub::tests::test_get_cached_model_path_finds_populated_snapshot ... ok
test hub::tests::test_get_cached_model_path_missing_model_returns_none ... ok
test hub::tests::test_get_cached_model_path_weights_requirement ... ok
test hub::tests::test_from_hf_returns_cached_path_without_network ... ok
test hub::tests::test_from_hf_with_model_express ... ok
test hub::tests::test_get_model_express_cache_dir ... ok
test hub::tests::test_get_model_express_cache_dir_with_hf_home ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured
```

Possible follow-up work (intentionally out of scope here, happy to file separately):

- The frontend's discovery watcher gives up on registration after a fixed retry budget and does not requeue across subsequent worker `Added` events. Retry-with-backoff would address that.
- `/health` does not reflect served-model registration state — operationally useful to surface "I have workers in discovery but no model registered."

#### Where should the reviewer start?

Single file: `lib/llm/src/hub.rs`.

- **The behavior change**: top of `from_hf()` — a 4-line cache-lookup block before the existing offline-mode and ModelExpress paths. Net `from_hf()` becomes ~10 lines shorter because the offline-mode block's own duplicate cache check is no longer needed.
- **The tests**: bottom `#[cfg(test)] mod tests` block. The four new tests share two small helpers — `write_fake_snapshot()` (lays out files at the HF cache layout paths under a `tempfile::TempDir`) and `force_hf_hub_cache()` / `clear_hf_hub_cache()` (env mutations under `#[serial_test::serial]`, matching the pattern of the existing `test_get_model_express_cache_dir_with_hf_home` test).

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

N/A