### PR TITLE
ci(lychee): ignore platform.openai.com canonical endpoint URLs (CDN-flake)

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -7,3 +7,11 @@
 # Ignore placeholder URLs in docs templates
 ^https://\.\.\./
 ^https://github\.com/\.\.\.
+
+# OpenAI's docs CDN intermittently returns 404 for these canonical endpoint
+# reference paths (the workflow already accepts 403 from anti-bot, but 404 is
+# rejected and bypasses retries when the CDN is in a bad state). The URLs are
+# the right thing for humans to follow; mute them for the link checker.
+# Referenced from docs/development/backend-guide.md.
+^https://platform\.openai\.com/docs/api-reference/chat/completions$
+^https://platform\.openai\.com/docs/api-reference/completions$


### PR DESCRIPTION
## Summary

The `Docs link check` (lychee) workflow already accepts `403` (the response OpenAI's docs return to non-browser User-Agents — anti-bot), but the same two URLs return `404` intermittently from the OpenAI CDN — even with `--max-retries 4 --retry-wait-time 3`. Recent main runs flip between success and failure on the same commit set; here's mine flipping pass→fail→pass across two attempts of the same PR commit:

- `gh run view 25777217321 -R ai-dynamo/dynamo` — attempt 1 failed on these two URLs, attempt 2 (no code change) passed.

When the CDN is in the 404 state, every PR fails the check with no recourse except a re-run from a maintainer. That's painful for contributors and adds nothing — the URLs are stable enough for humans, the question is just whether to gate CI on OpenAI's CDN mood.

## Fix

Add the two failing canonical paths to `.lycheeignore`. The regexes are anchored, so deeper links like `/api-reference/chat/completions/create` are still verified — only the bare-endpoint roots are muted.

```
^https://platform\.openai\.com/docs/api-reference/chat/completions$
^https://platform\.openai\.com/docs/api-reference/completions$
```

Both are referenced from `docs/development/backend-guide.md` (lines 70–71).

## Test plan

- [x] Verified `.lycheeignore` regex syntax matches existing entries' pattern.
- [x] No source-code change; docs read identically; CI link check stops being a coin-flip for the two known-flake URLs.

## Discovery context

Surfaced while landing #9470 (responses-EasyInputMessage fix). That PR's first attempt failed lychee; second attempt passed with no change. Filing this so the next PR author doesn't burn cycles on it.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9471" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated link checking configuration for documentation reference endpoints.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9471)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->