### PR TITLE
refactor(parity): move divergences into YAML, delete KNOWN_DIVERGENCES (Variant D)

### DIFF
--- a/tests/parity/README.md
+++ b/tests/parity/README.md
@@ -104,7 +104,7 @@ Both servers receive identical chat-completion requests with `structured_outputs
 | **CI markers** | (TBD) | `unit, pre_merge, gpu_0` | `e2e, pre_merge, gpu_1` |
 
 All three methods (when implemented) share the same fixtures,
-`ParseResult` shape, and `KNOWN_DIVERGENCES` registry pattern.
+`ParseResult` shape, and per-case `expected.<impl>` divergence blocks in YAML.
 They're stacked diagnostics:
 
 - M2 says: *"the parser class disagrees"*
@@ -130,7 +130,7 @@ PR description.
 Cell values show divergence from Dynamo (the oracle):
 
 - `✓` — both vLLM and SGLang match Dynamo's expected output.
-- `V` — vLLM diverges (xfailed via `KNOWN_DIVERGENCES`).
+- `V` — vLLM diverges (xfailed via `expected.vllm.diverges: true` in the case's YAML).
 - `S` — SGLang diverges.
 - `VS` — both diverge.
 - `n/a` — **not applicable**: no peer parser registered for that
@@ -226,14 +226,14 @@ to run (otherwise they skip cleanly).
 container with `docker ps --format '{{.Names}}' | grep vsc-dynamo2 | head -1`.
 
 **Baseline:** on `main` post-#9338, expect ~378 passed / ~299 skipped
-/ ~64 xfailed in ~5 s. The **xfailed count is the size of `KNOWN_DIVERGENCES`**
+/ ~64 xfailed in ~5 s. The **xfailed count is the number of `diverges: true` entries**
 — perfect parity is when that count is zero (all three impls produce
 byte-identical output on every fixture).
 
 ## Resolving divergences (8 steps)
 
 Each non-`✓` cell in the matrix above is an entry in
-`KNOWN_DIVERGENCES` (`tests/parity/parser/test_parity_parser.py`).
+the per-case `expected.<impl>` block in the family's YAML fixture.
 Goal: drive that count to zero. Walk these steps for one cell at a
 time. Worked example: `kimi_k2 / PARSER.batch.8.b → V` (vLLM drops
 trailing text after the wrapper).
@@ -263,7 +263,7 @@ PARSER.batch.8.b:
   expected:
     calls: [...]
     normal_text: <Dynamo's output>
-  # TODO(research): vllm diverges — <reason from KNOWN_DIVERGENCES>
+  # TODO(research): vllm diverges — <reason from expected.vllm.reason in the YAML>
   # vllm produces:
   #   calls: [...]
   #   normal_text: <vLLM's actual output>
@@ -330,15 +330,20 @@ as stale:
 ```text
 FAILED ...test_parity[kimi_k2/PARSER.batch.8.b#vllm]
        XPASS-strict: known divergence (vllm,kimi_k2,PARSER.batch.8.b)
-       now matches expected — remove from KNOWN_DIVERGENCES.
+       now matches dynamo — remove the `expected.vllm` block from the fixture.
 ```
 
 ### 8. Remove the entry + add spec_ref + refresh comments + commit
 
-Delete the line from `KNOWN_DIVERGENCES`:
+Delete the `expected.vllm` (or `expected.sglang`) block from the case's YAML fixture:
 
 ```python
-("vllm", "kimi_k2", "PARSER.batch.8.b"): "...",   # ← delete
+expected:
+  dynamo:
+    calls: [...]
+  vllm:                # ← delete this block
+    diverges: true
+    reason: "..."
 ```
 
 Add a `spec_ref:` field to the case's INPUTS entry in
@@ -465,7 +470,7 @@ sub-cases) does NOT carry `ref` — those entries predate the convention.
 #### Embedded divergence comments
 
 Each per-sub-case fixture for which there's a registered cross-impl
-divergence (`KNOWN_DIVERGENCES` in `test_parity_parser.py`) carries a
+divergence (`expected.<impl>` block in the family's YAML fixture) carries a
 YAML comment block right after the case's `expected:` data showing what
 the diverging impl actually produces, marked `TODO(research)`:
 
@@ -494,7 +499,7 @@ PYTHONPATH=lib/bindings/python/src python3 -m tests.parity.parser.embed_divergen
 Case keys are the full IDs from
 [`lib/parsers/PARSER_CASES.md`](../../lib/parsers/PARSER_CASES.md)
 (`PARSER.batch.1` … `PARSER.batch.10`, plus sub-cases like
-`PARSER.batch.8.a`). They match the `KNOWN_DIVERGENCES` keys and pytest
+`PARSER.batch.8.a`). They match the pytest
 parametrize IDs directly, so a single `grep PARSER.batch.8.a` finds the
 case across docs, fixtures, and Rust source comments.
 
@@ -572,7 +577,7 @@ qwen3_coder/batch.4 expected.calls[0].arguments = {"location": "NYC"}
 
 Both are valid per-family Dynamo contracts. Cross-impl divergences
 (vLLM and SGLang doing something *different* from Dynamo on the
-same case) are tracked in each test's `KNOWN_DIVERGENCES` registry
+same case) are tracked in each case's `expected.<impl>` block in the YAML fixture
 as `xfail` entries with a one-sentence reason.
 
 **3. `tools`** — sometimes minor parameter-name differences
@@ -697,5 +702,5 @@ real value-add is the cross-impl half (vLLM and SGLang).
    `_FAMILY_TO_VLLM_KEY` (`vllm.py`) and
    `_FAMILY_TO_SGLANG_DETECTOR` (`sglang.py`).
 6. Run pytest. Any cross-impl divergences surface as failures —
-   classify each, add a one-sentence reason to `KNOWN_DIVERGENCES`,
+   classify each, add a one-sentence reason to the case's `expected.<impl>` block in the YAML fixture,
    and the test goes to xfail.

--- a/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.2.yaml
@@ -31,14 +31,15 @@ cases:
           timezone:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
   PARSER.batch.2.b:
     description: Two back-to-back fence pairs
     ref: dynamo
@@ -54,14 +55,15 @@ cases:
     - *id001
     - *id002
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
   PARSER.batch.2.c:
     description: With surrounding narration
     ref: dynamo
@@ -77,14 +79,18 @@ cases:
     - *id001
     - *id002
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: 'Both: '
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: 'Both: '
+      sglang:
+        diverges: true
+        reason: "trims trailing space from preceding normal_text"
   PARSER.batch.2.d:
     description: Same-name twice
     ref: dynamo
@@ -100,11 +106,12 @@ cases:
     - *id001
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: ''

--- a/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.4.yaml
@@ -17,8 +17,15 @@ cases:
           location:
             type: string
     expected:
-      calls: []
-      normal_text: <｜tool▁calls▁begin｜>nonsense<｜tool▁calls▁end｜>
+      dynamo:
+        calls: []
+        normal_text: <｜tool▁calls▁begin｜>nonsense<｜tool▁calls▁end｜>
+      vllm:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
+      sglang:
+        diverges: true
+        reason: "sglang nullifies normal_text on malformed/recovery shapes where Dynamo preserves input"
     # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
     # vllm produces:
     #   calls: []
@@ -34,12 +41,16 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: |-
-        <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
-        ```json
-        {"location": "NYC"
-        ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+      dynamo:
+        calls: []
+        normal_text: |-
+          <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+          ```json
+          {"location": "NYC"
+          ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+      vllm:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
     # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
     # vllm produces:
     #   calls: [{'name': 'get_weather', 'arguments': '{"location": "NYC"'}]
@@ -55,12 +66,19 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: |-
-        <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>
-        ```json
-        {"location": "NYC"}
-        ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+      dynamo:
+        calls: []
+        normal_text: |-
+          <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>
+          ```json
+          {"location": "NYC"}
+          ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+      vllm:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
+      sglang:
+        diverges: true
+        reason: "sglang nullifies normal_text on malformed/recovery shapes where Dynamo preserves input"
     # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
     # vllm produces:
     #   calls: [{'name': '', 'arguments': {'location': 'NYC'}}]
@@ -74,11 +92,18 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
+      sglang:
+        diverges: true
+        reason: "sglang nullifies normal_text on malformed/recovery shapes where Dynamo preserves input"
     # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
     # vllm produces:
     #   calls: []

--- a/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.5.yaml
@@ -21,12 +21,19 @@ cases:
           location:
             type: string
     expected:
-      calls: []
-      normal_text: |-
-        <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
-        ```json
-        {"location": "NYC"}
-        ```
+      dynamo:
+        calls: []
+        normal_text: |-
+          <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+          ```json
+          {"location": "NYC"}
+          ```
+      vllm:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
+      sglang:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
     # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
     # vllm produces:
     #   calls: []
@@ -42,12 +49,13 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: |-
-        <｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
-        ```json
-        {"location": "NYC"}
-        ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+      dynamo:
+        calls: []
+        normal_text: |-
+          <｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+          ```json
+          {"location": "NYC"}
+          ```<｜tool▁call▁end｜><｜tool▁calls▁end｜>
   PARSER.batch.5.c:
     description: Truncation mid-arguments JSON inside fenced block
     ref: dynamo
@@ -58,11 +66,18 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: |-
-        <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
-        ```json
-        {"loc
+      dynamo:
+        calls: []
+        normal_text: |-
+          <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
+          ```json
+          {"loc
+      vllm:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
+      sglang:
+        diverges: true
+        reason: "sglang nullifies normal_text on malformed/recovery shapes where Dynamo preserves input"
     # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
     # vllm produces:
     #   calls: []

--- a/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.6.yaml
@@ -19,10 +19,11 @@ cases:
         type: object
         properties: {}
     expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_time
+          arguments: {}
+        normal_text: ''
   PARSER.batch.6.b:
     description: Whitespace inside empty { } (newlines)
     ref: dynamo
@@ -35,10 +36,14 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_time
+          arguments: {}
+        normal_text: ''
+      vllm:
+        diverges: true
+        reason: "vLLM rejects whitespace inside empty {} when wrapped in fenced ```json``` block"
     # TODO(research): vllm diverges — vLLM rejects whitespace inside empty {} when wrapped in fenced ```json``` block
     # vllm produces:
     #   calls: []
@@ -50,8 +55,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_time<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+      dynamo:
+        calls: []
+        normal_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_time<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+      vllm:
+        diverges: true
+        reason: "both return calls=[]; vLLM nullifies normal_text on this recovery path, Dynamo preserves the raw input as normal_text"
     # TODO(research): vllm diverges — both return calls=[]; vLLM nullifies normal_text on this recovery path, Dynamo preserves the raw input as normal_text
     # vllm produces:
     #   calls: []

--- a/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.7.yaml
@@ -24,13 +24,14 @@ cases:
           first_class:
             type: boolean
     expected:
-      calls:
-      - name: book_flight
-        arguments:
-          destination: Paris
-          passengers: 2
-          first_class: true
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: book_flight
+          arguments:
+            destination: Paris
+            passengers: 2
+            first_class: true
+        normal_text: ''
   PARSER.batch.7.b:
     description: Unicode + escaped chars
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L302
@@ -47,11 +48,12 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: Tōkyō "central"
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Tōkyō "central"
+        normal_text: ''
   PARSER.batch.7.c:
     description: Schema mismatch — string value where schema declares integer
     ref: dynamo
@@ -68,11 +70,12 @@ cases:
           celsius:
             type: integer
     expected:
-      calls:
-      - name: set_temperature
-        arguments:
-          celsius: '20'
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: set_temperature
+          arguments:
+            celsius: '20'
+        normal_text: ''
   PARSER.batch.7.d:
     description: Nested object + array (existing)
     ref: dynamo
@@ -91,13 +94,14 @@ cases:
           config:
             type: object
     expected:
-      calls:
-      - name: process_data
-        arguments:
-          items:
-          - 1
-          - 2
-          - 3
-          config:
-            nested: true
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: process_data
+          arguments:
+            items:
+            - 1
+            - 2
+            - 3
+            config:
+              nested: true
+        normal_text: ''

--- a/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.8.yaml
@@ -21,11 +21,15 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: 'I will check the weather. '
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: 'I will check the weather. '
+      sglang:
+        diverges: true
+        reason: "trims trailing space from preceding normal_text"
   PARSER.batch.8.b:
     description: Narration after tool call only
     ref: dynamo
@@ -37,11 +41,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
   PARSER.batch.8.c:
     description: Narration both before and after (sandwich)
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L282
@@ -53,11 +58,15 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: 'I will check the weather. '
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: 'I will check the weather. '
+      sglang:
+        diverges: true
+        reason: "trims trailing space from preceding normal_text"
   PARSER.batch.8.d:
     description: Narration between multiple tool calls
     ref: dynamo
@@ -72,11 +81,15 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-      normal_text: 'I will check the weather. '
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: 'I will check the weather. '
+      sglang:
+        diverges: true
+        reason: "trims trailing space from preceding normal_text"

--- a/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3/PARSER.batch.yaml
@@ -20,27 +20,30 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: Hello, how can I help you today?
+      dynamo:
+        calls: []
+        normal_text: Hello, how can I help you today?
   PARSER.batch.9:
     description: Empty input
     model_text: ''
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
   PARSER.batch.10:
     description: Duplicate calls (same name twice)
     model_text: |-
@@ -54,11 +57,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: ''

--- a/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.2.yaml
@@ -24,14 +24,15 @@ cases:
           timezone:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
   PARSER.batch.2.b:
     description: Two back-to-back fence pairs
     ref: dynamo
@@ -40,14 +41,15 @@ cases:
     - *id001
     - *id002
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
   PARSER.batch.2.c:
     description: Parallel with surrounding narration
     ref: dynamo
@@ -57,14 +59,18 @@ cases:
     - *id001
     - *id002
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: 'Both: '
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: 'Both: '
+      sglang:
+        diverges: true
+        reason: "trims trailing space from preceding normal_text"
   PARSER.batch.2.d:
     description: Same-name twice (id distinctness)
     ref: dynamo
@@ -73,11 +79,12 @@ cases:
     - *id001
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: ''

--- a/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.4.yaml
@@ -17,8 +17,15 @@ cases:
           location:
             type: string
     expected:
-      calls: []
-      normal_text: <｜tool▁calls▁begin｜>nonsense<｜tool▁calls▁end｜>
+      dynamo:
+        calls: []
+        normal_text: <｜tool▁calls▁begin｜>nonsense<｜tool▁calls▁end｜>
+      vllm:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
+      sglang:
+        diverges: true
+        reason: "sglang nullifies normal_text on malformed/recovery shapes where Dynamo preserves input"
     # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
     # vllm produces:
     #   calls: []
@@ -30,8 +37,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+      dynamo:
+        calls: []
+        normal_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+      vllm:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
     # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
     # vllm produces:
     #   calls: [{'name': 'get_weather', 'arguments': '{"location":"NYC'}]
@@ -43,8 +54,15 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜><｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+      dynamo:
+        calls: []
+        normal_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜><｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+      vllm:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
+      sglang:
+        diverges: true
+        reason: "sglang nullifies normal_text on malformed/recovery shapes where Dynamo preserves input"
     # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
     # vllm produces:
     #   calls: [{'name': '', 'arguments': {'location': 'NYC'}}]
@@ -56,8 +74,15 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁calls▁end｜>
+      dynamo:
+        calls: []
+        normal_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁calls▁end｜>
+      vllm:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
+      sglang:
+        diverges: true
+        reason: "sglang nullifies normal_text on malformed/recovery shapes where Dynamo preserves input"
     # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
     # vllm produces:
     #   calls: []

--- a/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.5.yaml
@@ -17,8 +17,15 @@ cases:
           location:
             type: string
     expected:
-      calls: []
-      normal_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜>
+      dynamo:
+        calls: []
+        normal_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜>
+      vllm:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
+      sglang:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
     # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
     # vllm produces:
     #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}]
@@ -30,8 +37,9 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: <｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+      dynamo:
+        calls: []
+        normal_text: <｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
   PARSER.batch.5.c:
     description: Truncation mid-arguments JSON
     ref: dynamo
@@ -39,8 +47,15 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"loc
+      dynamo:
+        calls: []
+        normal_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"loc
+      vllm:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
+      sglang:
+        diverges: true
+        reason: "sglang nullifies normal_text on malformed/recovery shapes where Dynamo preserves input"
     # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
     # vllm produces:
     #   calls: []

--- a/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.6.yaml
@@ -15,10 +15,11 @@ cases:
         type: object
         properties: {}
     expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_time
+          arguments: {}
+        normal_text: ''
   PARSER.batch.6.b:
     description: Whitespace inside empty { }
     ref: dynamo
@@ -26,10 +27,11 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_time
+          arguments: {}
+        normal_text: ''
   PARSER.batch.6.c:
     description: No tool_sep / args section
     ref: dynamo
@@ -37,8 +39,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_time<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+      dynamo:
+        calls: []
+        normal_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_time<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+      vllm:
+        diverges: true
+        reason: "both return calls=[]; vLLM nullifies normal_text on this recovery path, Dynamo preserves the raw input as normal_text"
     # TODO(research): vllm diverges — both return calls=[]; vLLM nullifies normal_text on this recovery path, Dynamo preserves the raw input as normal_text
     # vllm produces:
     #   calls: []

--- a/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.7.yaml
@@ -20,13 +20,14 @@ cases:
           first_class:
             type: boolean
     expected:
-      calls:
-      - name: book_flight
-        arguments:
-          destination: Paris
-          passengers: 2
-          first_class: true
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: book_flight
+          arguments:
+            destination: Paris
+            passengers: 2
+            first_class: true
+        normal_text: ''
   PARSER.batch.7.b:
     description: Unicode + escaped chars
     ref: dynamo
@@ -39,11 +40,12 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: Tōkyō "central"
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Tōkyō "central"
+        normal_text: ''
   PARSER.batch.7.c:
     description: Schema mismatch — string value where schema declares integer
     ref: dynamo
@@ -56,11 +58,12 @@ cases:
           celsius:
             type: integer
     expected:
-      calls:
-      - name: set_temperature
-        arguments:
-          celsius: '20'
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: set_temperature
+          arguments:
+            celsius: '20'
+        normal_text: ''
   PARSER.batch.7.d:
     description: Nested object + array (existing)
     ref: dynamo
@@ -75,13 +78,14 @@ cases:
           config:
             type: object
     expected:
-      calls:
-      - name: process_data
-        arguments:
-          items:
-          - 1
-          - 2
-          - 3
-          config:
-            nested: true
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: process_data
+          arguments:
+            items:
+            - 1
+            - 2
+            - 3
+            config:
+              nested: true
+        normal_text: ''

--- a/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.8.yaml
@@ -17,11 +17,15 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: 'I will check the weather. '
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: 'I will check the weather. '
+      sglang:
+        diverges: true
+        reason: "trims trailing space from preceding normal_text"
   PARSER.batch.8.b:
     description: Narration after tool call only
     ref: dynamo
@@ -30,11 +34,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
   PARSER.batch.8.c:
     description: Narration both before and after (sandwich)
     ref: dynamo
@@ -43,11 +48,15 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: 'I will check the weather. '
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: 'I will check the weather. '
+      sglang:
+        diverges: true
+        reason: "trims trailing space from preceding normal_text"
   PARSER.batch.8.d:
     description: Narration between multiple tool calls
     ref: dynamo
@@ -56,11 +65,15 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-      normal_text: 'I will check the weather. '
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: 'I will check the weather. '
+      sglang:
+        diverges: true
+        reason: "trims trailing space from preceding normal_text"

--- a/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_1/PARSER.batch.yaml
@@ -16,38 +16,42 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: Hello, how can I help you today?
+      dynamo:
+        calls: []
+        normal_text: Hello, how can I help you today?
   PARSER.batch.9:
     description: Empty input
     model_text: ''
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
   PARSER.batch.10:
     description: Duplicate calls (same name twice)
     model_text: <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"NYC"}<｜tool▁call▁end｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location":"LA"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: ''

--- a/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.2.yaml
@@ -36,14 +36,15 @@ cases:
           timezone:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
   PARSER.batch.2.b:
     description: Two back-to-back function_calls wrappers
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_deepseekv32_tool_parser.py#L327
@@ -62,15 +63,22 @@ cases:
     - *id001
     - *id002
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      # `|2+` below = "\n" (see file header)
-      normal_text: |2+
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        # `|2+` below = "\n" (see file header)
+        normal_text: |2+
+      vllm:
+        diverges: true
+        reason: "vLLM deepseek_v3_2 does not restart parsing on a second back-to-back fence pair"
+      sglang:
+        diverges: true
+        reason: "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)"
 
     # TODO(research): vllm diverges — vLLM deepseek_v3_2 does not restart parsing on a second back-to-back fence pair
     # vllm produces:
@@ -92,14 +100,21 @@ cases:
     - *id001
     - *id002
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: 'Both:  Done.'
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: 'Both:  Done.'
+      vllm:
+        diverges: true
+        reason: "drops trailing normal_text after tool-call wrapper end"
+      sglang:
+        diverges: true
+        reason: "trims trailing space from preceding normal_text"
     # TODO(research): vllm diverges — drops trailing normal_text after tool-call wrapper end
     # vllm produces:
     #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}, {'name': 'get_time', 'arguments': {'timezone': 'EST'}}]
@@ -120,11 +135,12 @@ cases:
     - *id001
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: ''

--- a/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.4.yaml
@@ -20,8 +20,12 @@ cases:
           location:
             type: string
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
     # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
     # vllm produces:
     #   calls: []
@@ -39,8 +43,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
     # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
     # vllm produces:
     #   calls: []
@@ -57,7 +65,8 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments: {}
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments: {}
+        normal_text: ''

--- a/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.5.yaml
@@ -21,8 +21,12 @@ cases:
           location:
             type: string
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
     # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
     # vllm produces:
     #   calls: []
@@ -38,12 +42,13 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: |-
-        <｜DSML｜invoke name="get_weather">
-        <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
-        </｜DSML｜invoke>
-        </｜DSML｜function_calls>
+      dynamo:
+        calls: []
+        normal_text: |-
+          <｜DSML｜invoke name="get_weather">
+          <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+          </｜DSML｜invoke>
+          </｜DSML｜function_calls>
   PARSER.batch.5.c:
     description: Truncation mid-parameter value
     ref: dynamo
@@ -54,8 +59,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
     # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
     # vllm produces:
     #   calls: []

--- a/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.6.yaml
@@ -19,10 +19,11 @@ cases:
         type: object
         properties: {}
     expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_time
+          arguments: {}
+        normal_text: ''
   PARSER.batch.6.b:
     description: Invoke with extra newline
     ref: dynamo
@@ -35,7 +36,8 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_time
+          arguments: {}
+        normal_text: ''

--- a/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.7.yaml
@@ -27,13 +27,17 @@ cases:
           first_class:
             type: boolean
     expected:
-      calls:
-      - name: book_flight
-        arguments:
-          destination: Paris
-          passengers: 2
-          first_class: true
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: book_flight
+          arguments:
+            destination: Paris
+            passengers: 2
+            first_class: true
+        normal_text: ''
+      vllm:
+        diverges: true
+        reason: "vLLM emits JSON-typed parameter values as raw strings; Dynamo coerces nested object/array types"
     # TODO(research): vllm diverges — vLLM emits JSON-typed parameter values as raw strings; Dynamo coerces nested object/array types
     # vllm produces:
     #   calls: [{'name': 'book_flight', 'arguments': {'destination': 'Paris', 'passengers': '2', 'first_class': 'true'}}]
@@ -55,8 +59,9 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: Tōkyō central
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Tōkyō central
+        normal_text: ''

--- a/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.8.yaml
@@ -22,11 +22,15 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: 'I will check the weather. '
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: 'I will check the weather. '
+      sglang:
+        diverges: true
+        reason: "drops trailing normal_text after tool-call wrapper end"
   PARSER.batch.8.b:
     description: Narration after tool call only
     ref: dynamo
@@ -39,11 +43,18 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ' Let me know if you need more.'
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ' Let me know if you need more.'
+      vllm:
+        diverges: true
+        reason: "TODO(research): vLLM returns null normal_text where Dynamo surfaces the narration string"
+      sglang:
+        diverges: true
+        reason: "drops trailing normal_text after tool-call wrapper end"
     # TODO(research): vllm diverges — TODO(research): vLLM returns null normal_text where Dynamo surfaces the narration string
     # vllm produces:
     #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}]
@@ -60,11 +71,18 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: I will check the weather.  Let me know if you need more.
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: I will check the weather.  Let me know if you need more.
+      vllm:
+        diverges: true
+        reason: "TODO(research): vLLM returns null normal_text where Dynamo surfaces the narration string"
+      sglang:
+        diverges: true
+        reason: "drops trailing normal_text after tool-call wrapper end"
     # TODO(research): vllm diverges — TODO(research): vLLM returns null normal_text where Dynamo surfaces the narration string
     # vllm produces:
     #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}]
@@ -85,14 +103,21 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-      normal_text: 'I will check the weather.  Then check LA weather. '
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: 'I will check the weather.  Then check LA weather. '
+      vllm:
+        diverges: true
+        reason: "TODO(research): vLLM returns null normal_text where Dynamo surfaces the narration string"
+      sglang:
+        diverges: true
+        reason: "drops trailing normal_text after tool-call wrapper end"
     # TODO(research): vllm diverges — TODO(research): vLLM returns null normal_text where Dynamo surfaces the narration string
     # vllm produces:
     #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}, {'name': 'get_weather', 'arguments': {'location': 'LA'}}]

--- a/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v3_2/PARSER.batch.yaml
@@ -21,27 +21,30 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: Hello, how can I help you today?
+      dynamo:
+        calls: []
+        normal_text: Hello, how can I help you today?
   PARSER.batch.9:
     description: Empty input
     model_text: ''
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
   PARSER.batch.10:
     description: Duplicate calls (same name twice)
     model_text: |-
@@ -56,11 +59,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: ''

--- a/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.2.yaml
@@ -36,14 +36,15 @@ cases:
           timezone:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
   PARSER.batch.2.b:
     description: Two back-to-back tool_calls wrappers
     ref: dynamo
@@ -62,15 +63,19 @@ cases:
     - *id001
     - *id002
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      # `|2+` below = "\n" (see file header)
-      normal_text: |2+
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        # `|2+` below = "\n" (see file header)
+        normal_text: |2+
+      vllm:
+        diverges: true
+        reason: "vLLM deepseek_v4 does not restart parsing on a second back-to-back fence pair"
 
     # TODO(research): vllm diverges — vLLM deepseek_v4 does not restart parsing on a second back-to-back fence pair
     # vllm produces:
@@ -92,14 +97,18 @@ cases:
     - *id001
     - *id002
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: 'Both:  Done.'
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: 'Both:  Done.'
+      vllm:
+        diverges: true
+        reason: "drops trailing normal_text after tool-call wrapper end"
     # TODO(research): vllm diverges — drops trailing normal_text after tool-call wrapper end
     # vllm produces:
     #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}, {'name': 'get_time', 'arguments': {'timezone': 'EST'}}]
@@ -120,11 +129,12 @@ cases:
     - *id001
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: ''

--- a/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.4.yaml
@@ -20,8 +20,12 @@ cases:
           location:
             type: string
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
     # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
     # vllm produces:
     #   calls: []
@@ -39,8 +43,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
     # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
     # vllm produces:
     #   calls: []
@@ -57,7 +65,8 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments: {}
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments: {}
+        normal_text: ''

--- a/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.5.yaml
@@ -21,8 +21,12 @@ cases:
           location:
             type: string
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
     # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
     # vllm produces:
     #   calls: []
@@ -38,12 +42,13 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: |-
-        <｜DSML｜invoke name="get_weather">
-        <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
-        </｜DSML｜invoke>
-        </｜DSML｜tool_calls>
+      dynamo:
+        calls: []
+        normal_text: |-
+          <｜DSML｜invoke name="get_weather">
+          <｜DSML｜parameter name="location" string="true">NYC</｜DSML｜parameter>
+          </｜DSML｜invoke>
+          </｜DSML｜tool_calls>
   PARSER.batch.5.c:
     description: Truncation mid-parameter value
     ref: dynamo
@@ -54,8 +59,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
     # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
     # vllm produces:
     #   calls: []

--- a/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.6.yaml
@@ -19,10 +19,11 @@ cases:
         type: object
         properties: {}
     expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_time
+          arguments: {}
+        normal_text: ''
   PARSER.batch.6.b:
     description: Invoke with extra newline
     ref: dynamo
@@ -35,7 +36,8 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_time
+          arguments: {}
+        normal_text: ''

--- a/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.7.yaml
@@ -27,13 +27,17 @@ cases:
           first_class:
             type: boolean
     expected:
-      calls:
-      - name: book_flight
-        arguments:
-          destination: Paris
-          passengers: 2
-          first_class: true
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: book_flight
+          arguments:
+            destination: Paris
+            passengers: 2
+            first_class: true
+        normal_text: ''
+      vllm:
+        diverges: true
+        reason: "vLLM emits JSON-typed parameter values as raw strings; Dynamo coerces nested object/array types"
     # TODO(research): vllm diverges — vLLM emits JSON-typed parameter values as raw strings; Dynamo coerces nested object/array types
     # vllm produces:
     #   calls: [{'name': 'book_flight', 'arguments': {'destination': 'Paris', 'passengers': '2', 'first_class': 'true'}}]
@@ -55,8 +59,9 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: Tōkyō central
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Tōkyō central
+        normal_text: ''

--- a/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.8.yaml
@@ -22,11 +22,12 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: 'I will check the weather. '
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: 'I will check the weather. '
   PARSER.batch.8.b:
     description: Narration after tool call only
     ref: dynamo
@@ -39,11 +40,15 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ' Let me know if you need more.'
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ' Let me know if you need more.'
+      vllm:
+        diverges: true
+        reason: "TODO(research): vLLM returns null normal_text where Dynamo surfaces the narration string"
     # TODO(research): vllm diverges — TODO(research): vLLM returns null normal_text where Dynamo surfaces the narration string
     # vllm produces:
     #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}]
@@ -60,11 +65,15 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: I will check the weather.  Let me know if you need more.
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: I will check the weather.  Let me know if you need more.
+      vllm:
+        diverges: true
+        reason: "TODO(research): vLLM returns null normal_text where Dynamo surfaces the narration string"
     # TODO(research): vllm diverges — TODO(research): vLLM returns null normal_text where Dynamo surfaces the narration string
     # vllm produces:
     #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}]
@@ -85,14 +94,18 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-      normal_text: 'I will check the weather.  Then check LA weather. '
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: 'I will check the weather.  Then check LA weather. '
+      vllm:
+        diverges: true
+        reason: "TODO(research): vLLM returns null normal_text where Dynamo surfaces the narration string"
     # TODO(research): vllm diverges — TODO(research): vLLM returns null normal_text where Dynamo surfaces the narration string
     # vllm produces:
     #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}, {'name': 'get_weather', 'arguments': {'location': 'LA'}}]

--- a/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/deepseek_v4/PARSER.batch.yaml
@@ -21,27 +21,30 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: Hello, how can I help you today?
+      dynamo:
+        calls: []
+        normal_text: Hello, how can I help you today?
   PARSER.batch.9:
     description: Empty input
     model_text: ''
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
   PARSER.batch.10:
     description: Duplicate calls (same name twice)
     model_text: |-
@@ -56,11 +59,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: ''

--- a/tests/parity/parser/fixtures/gemma4/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/gemma4/PARSER.batch.2.yaml
@@ -24,14 +24,15 @@ cases:
           timezone:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
   PARSER.batch.2.c:
     description: With surrounding narration
     ref: dynamo
@@ -41,14 +42,18 @@ cases:
     - *id001
     - *id002
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: 'Both:  Done.'
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: 'Both:  Done.'
+      vllm:
+        diverges: true
+        reason: "drops trailing normal_text after tool-call wrapper end"
     # TODO(research): vllm diverges — drops trailing normal_text after tool-call wrapper end
     # vllm produces:
     #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}, {'name': 'get_time', 'arguments': {'timezone': 'EST'}}]
@@ -61,11 +66,12 @@ cases:
     - *id001
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: ''

--- a/tests/parity/parser/fixtures/gemma4/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/gemma4/PARSER.batch.4.yaml
@@ -17,8 +17,9 @@ cases:
           location:
             type: string
     expected:
-      calls: []
-      normal_text: <|tool_call>nonsense<tool_call|>
+      dynamo:
+        calls: []
+        normal_text: <|tool_call>nonsense<tool_call|>
   PARSER.batch.4.b:
     description: Missing close brace in body
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_gemma4_tool_parser.py#L572
@@ -26,8 +27,9 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|><tool_call|>
+      dynamo:
+        calls: []
+        normal_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|><tool_call|>
   PARSER.batch.4.c:
     description: No call:name prefix
     ref: dynamo
@@ -35,8 +37,9 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: <|tool_call>{location:<|"|>NYC<|"|>}<tool_call|>
+      dynamo:
+        calls: []
+        normal_text: <|tool_call>{location:<|"|>NYC<|"|>}<tool_call|>
   PARSER.batch.4.d:
     description: Mismatched sentinels
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_gemma4_tool_parser.py#L252
@@ -44,5 +47,6 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}
+      dynamo:
+        calls: []
+        normal_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}

--- a/tests/parity/parser/fixtures/gemma4/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/gemma4/PARSER.batch.5.yaml
@@ -17,8 +17,9 @@ cases:
           location:
             type: string
     expected:
-      calls: []
-      normal_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}
+      dynamo:
+        calls: []
+        normal_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}
   PARSER.batch.5.b:
     description: Closing <tool_call|> without matching <|tool_call> open
     ref: dynamo
@@ -26,8 +27,9 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: call:get_weather{location:<|"|>NYC<|"|>}<tool_call|>
+      dynamo:
+        calls: []
+        normal_text: call:get_weather{location:<|"|>NYC<|"|>}<tool_call|>
   PARSER.batch.5.c:
     description: Truncation mid-argument value
     ref: dynamo
@@ -35,5 +37,6 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: <|tool_call>call:get_weather{location:<|"|>N
+      dynamo:
+        calls: []
+        normal_text: <|tool_call>call:get_weather{location:<|"|>N

--- a/tests/parity/parser/fixtures/gemma4/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/gemma4/PARSER.batch.6.yaml
@@ -15,10 +15,11 @@ cases:
         type: object
         properties: {}
     expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_time
+          arguments: {}
+        normal_text: ''
   PARSER.batch.6.b:
     description: Whitespace inside empty {}
     ref: dynamo
@@ -26,10 +27,11 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_time
+          arguments: {}
+        normal_text: ''
   PARSER.batch.6.c:
     description: No body (just call:name)
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_gemma4_tool_parser.py#L280
@@ -37,5 +39,6 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: <|tool_call>call:get_time<tool_call|>
+      dynamo:
+        calls: []
+        normal_text: <|tool_call>call:get_time<tool_call|>

--- a/tests/parity/parser/fixtures/gemma4/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/gemma4/PARSER.batch.7.yaml
@@ -20,13 +20,14 @@ cases:
           first_class:
             type: boolean
     expected:
-      calls:
-      - name: book_flight
-        arguments:
-          destination: Paris
-          passengers: 2
-          first_class: true
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: book_flight
+          arguments:
+            destination: Paris
+            passengers: 2
+            first_class: true
+        normal_text: ''
   PARSER.batch.7.b:
     description: Unicode in value
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_gemma4_tool_parser.py#L630
@@ -39,11 +40,12 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: Tōkyō central
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Tōkyō central
+        normal_text: ''
   PARSER.batch.7.c:
     description: Schema mismatch — string value where schema declares integer
     ref: dynamo
@@ -56,11 +58,12 @@ cases:
           celsius:
             type: integer
     expected:
-      calls:
-      - name: set_temperature
-        arguments:
-          celsius: '20'
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: set_temperature
+          arguments:
+            celsius: '20'
+        normal_text: ''
   PARSER.batch.7.d:
     description: Nested object + array (existing)
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_gemma4_tool_parser.py#L179
@@ -75,13 +78,14 @@ cases:
           config:
             type: object
     expected:
-      calls:
-      - name: process_data
-        arguments:
-          items:
-          - 1
-          - 2
-          - 3
-          config:
-            nested: true
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: process_data
+          arguments:
+            items:
+            - 1
+            - 2
+            - 3
+            config:
+              nested: true
+        normal_text: ''

--- a/tests/parity/parser/fixtures/gemma4/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/gemma4/PARSER.batch.8.yaml
@@ -17,11 +17,12 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: I will check the weather.
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: I will check the weather.
   PARSER.batch.8.b:
     description: Narration after tool call only
     ref: dynamo
@@ -29,11 +30,15 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: Let me know if you need more.
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: Let me know if you need more.
+      vllm:
+        diverges: true
+        reason: "drops trailing normal_text after tool-call wrapper end"
     # TODO(research): vllm diverges — drops trailing normal_text after tool-call wrapper end
     # vllm produces:
     #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}]
@@ -46,11 +51,15 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: I will check the weather.  Let me know if you need more.
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: I will check the weather.  Let me know if you need more.
+      vllm:
+        diverges: true
+        reason: "drops trailing normal_text after tool-call wrapper end"
     # TODO(research): vllm diverges — drops trailing normal_text after tool-call wrapper end
     # vllm produces:
     #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}]
@@ -63,14 +72,18 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-      normal_text: I will check the weather.  Then check LA weather.
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: I will check the weather.  Then check LA weather.
+      vllm:
+        diverges: true
+        reason: "drops trailing normal_text after tool-call wrapper end"
     # TODO(research): vllm diverges — drops trailing normal_text after tool-call wrapper end
     # vllm produces:
     #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}, {'name': 'get_weather', 'arguments': {'location': 'LA'}}]

--- a/tests/parity/parser/fixtures/gemma4/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/gemma4/PARSER.batch.yaml
@@ -16,38 +16,42 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: Hello, how can I help you today?
+      dynamo:
+        calls: []
+        normal_text: Hello, how can I help you today?
   PARSER.batch.9:
     description: Empty input
     model_text: ''
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
   PARSER.batch.10:
     description: Duplicate calls (same name twice)
     model_text: <|tool_call>call:get_weather{location:<|"|>NYC<|"|>}<tool_call|><|tool_call>call:get_weather{location:<|"|>LA<|"|>}<tool_call|>
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: ''

--- a/tests/parity/parser/fixtures/glm47/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/glm47/PARSER.batch.2.yaml
@@ -24,14 +24,15 @@ cases:
           timezone:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
   PARSER.batch.2.c:
     description: Parallel calls with surrounding narration
     ref: dynamo
@@ -41,14 +42,18 @@ cases:
     - *id001
     - *id002
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: 'Checking:  Done.'
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: 'Checking:  Done.'
+      vllm:
+        diverges: true
+        reason: "drops trailing normal_text after tool-call wrapper end"
     # TODO(research): vllm diverges — drops trailing normal_text after tool-call wrapper end
     # vllm produces:
     #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}, {'name': 'get_time', 'arguments': {'timezone': 'EST'}}]
@@ -61,11 +66,12 @@ cases:
     - *id001
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: ''

--- a/tests/parity/parser/fixtures/glm47/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/glm47/PARSER.batch.4.yaml
@@ -17,8 +17,15 @@ cases:
           location:
             type: string
     expected:
-      calls: []
-      normal_text: <tool_call><arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>
+      dynamo:
+        calls: []
+        normal_text: <tool_call><arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>
+      vllm:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
+      sglang:
+        diverges: true
+        reason: "sglang nullifies normal_text on malformed/recovery shapes where Dynamo preserves input"
     # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
     # vllm produces:
     #   calls: [{'name': '<arg_key>location</arg_key><arg_value>NYC</arg_value>', 'arguments': {}}]
@@ -30,7 +37,8 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments: {}
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments: {}
+        normal_text: ''

--- a/tests/parity/parser/fixtures/glm47/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/glm47/PARSER.batch.5.yaml
@@ -17,11 +17,18 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
+      sglang:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
     # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
     # vllm produces:
     #   calls: []
@@ -33,8 +40,9 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>
+      dynamo:
+        calls: []
+        normal_text: get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call>
   PARSER.batch.5.c:
     description: Truncation mid-arg_value
     ref: dynamo
@@ -42,10 +50,17 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments: {}
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments: {}
+        normal_text: ''
+      vllm:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
+      sglang:
+        diverges: true
+        reason: "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)"
     # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
     # vllm produces:
     #   calls: []

--- a/tests/parity/parser/fixtures/glm47/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/glm47/PARSER.batch.6.yaml
@@ -15,10 +15,11 @@ cases:
         type: object
         properties: {}
     expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_time
+          arguments: {}
+        normal_text: ''
   PARSER.batch.6.b:
     description: Function-only with whitespace
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_glm47_moe_tool_parser.py#L68
@@ -26,7 +27,11 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_time
+          arguments: {}
+        normal_text: ''
+      sglang:
+        diverges: true
+        reason: "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)"

--- a/tests/parity/parser/fixtures/glm47/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/glm47/PARSER.batch.7.yaml
@@ -20,13 +20,14 @@ cases:
           first_class:
             type: boolean
     expected:
-      calls:
-      - name: book_flight
-        arguments:
-          first_class: true
-          passengers: 2
-          destination: Paris
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: book_flight
+          arguments:
+            first_class: true
+            passengers: 2
+            destination: Paris
+        normal_text: ''
   PARSER.batch.7.b:
     description: Unicode in arg value
     ref: dynamo
@@ -39,8 +40,9 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: Tōkyō central
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Tōkyō central
+        normal_text: ''

--- a/tests/parity/parser/fixtures/glm47/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/glm47/PARSER.batch.8.yaml
@@ -17,11 +17,15 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: I will check the weather.
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: I will check the weather.
+      vllm:
+        diverges: true
+        reason: "drops trailing normal_text after tool-call wrapper end"
     # TODO(research): vllm diverges — drops trailing normal_text after tool-call wrapper end
     # vllm produces:
     #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}]
@@ -34,11 +38,15 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: Let me know if you need more.
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: Let me know if you need more.
+      vllm:
+        diverges: true
+        reason: "drops trailing normal_text after tool-call wrapper end"
     # TODO(research): vllm diverges — drops trailing normal_text after tool-call wrapper end
     # vllm produces:
     #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}]
@@ -51,11 +59,15 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: I will check the weather.  Let me know if you need more.
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: I will check the weather.  Let me know if you need more.
+      vllm:
+        diverges: true
+        reason: "drops trailing normal_text after tool-call wrapper end"
     # TODO(research): vllm diverges — drops trailing normal_text after tool-call wrapper end
     # vllm produces:
     #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}]
@@ -68,14 +80,18 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-      normal_text: I will check the weather.  Then check LA weather.
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: I will check the weather.  Then check LA weather.
+      vllm:
+        diverges: true
+        reason: "drops trailing normal_text after tool-call wrapper end"
     # TODO(research): vllm diverges — drops trailing normal_text after tool-call wrapper end
     # vllm produces:
     #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}, {'name': 'get_weather', 'arguments': {'location': 'LA'}}]

--- a/tests/parity/parser/fixtures/glm47/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/glm47/PARSER.batch.yaml
@@ -16,38 +16,42 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: Hello, how can I help you today?
+      dynamo:
+        calls: []
+        normal_text: Hello, how can I help you today?
   PARSER.batch.9:
     description: Empty input
     model_text: ''
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
   PARSER.batch.10:
     description: Duplicate calls (same name twice)
     model_text: <tool_call>get_weather<arg_key>location</arg_key><arg_value>NYC</arg_value></tool_call><tool_call>get_weather<arg_key>location</arg_key><arg_value>LA</arg_value></tool_call>
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: ''

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.2.yaml
@@ -25,9 +25,13 @@ cases:
           timezone:
             type: string
     expected:
-      calls: []
-      normal_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|><|start|>assistant<|channel|>commentary
-        to=functions.get_time <|constrain|>json<|message|>{"timezone":"EST"}<|call|>
+      dynamo:
+        calls: []
+        normal_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|><|start|>assistant<|channel|>commentary
+          to=functions.get_time <|constrain|>json<|message|>{"timezone":"EST"}<|call|>
+      sglang:
+        diverges: true
+        reason: "Dynamo drops back-to-back commentary blocks; SGLang extracts them"
   PARSER.batch.2.c:
     description: With surrounding narration
     ref: dynamo
@@ -37,9 +41,13 @@ cases:
     - *id001
     - *id002
     expected:
-      calls: []
-      normal_text: I need both. <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|><|start|>assistant<|channel|>commentary
-        to=functions.get_time <|constrain|>json<|message|>{"timezone":"EST"}<|call|> Done.
+      dynamo:
+        calls: []
+        normal_text: I need both. <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|><|start|>assistant<|channel|>commentary
+          to=functions.get_time <|constrain|>json<|message|>{"timezone":"EST"}<|call|> Done.
+      sglang:
+        diverges: true
+        reason: "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)"
   PARSER.batch.2.d:
     description: Same-name twice
     ref: dynamo
@@ -49,6 +57,10 @@ cases:
     - *id001
     - *id001
     expected:
-      calls: []
-      normal_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|><|start|>assistant<|channel|>commentary
-        to=functions.get_weather <|constrain|>json<|message|>{"location":"LA"}<|call|>
+      dynamo:
+        calls: []
+        normal_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|><|start|>assistant<|channel|>commentary
+          to=functions.get_weather <|constrain|>json<|message|>{"location":"LA"}<|call|>
+      sglang:
+        diverges: true
+        reason: "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)"

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.4.yaml
@@ -17,9 +17,13 @@ cases:
           location:
             type: string
     expected:
-      calls: []
-      normal_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>not json at
-        all<|call|>
+      dynamo:
+        calls: []
+        normal_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>not json at
+          all<|call|>
+      sglang:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
   PARSER.batch.4.b:
     description: Unterminated JSON in message body
     ref: dynamo
@@ -27,8 +31,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC<|call|>
+      dynamo:
+        calls: []
+        normal_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC<|call|>
+      sglang:
+        diverges: true
+        reason: "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)"
   PARSER.batch.4.c:
     description: No to=functions.X recipient
     ref: dynamo
@@ -36,5 +44,6 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.5.yaml
@@ -17,8 +17,12 @@ cases:
           location:
             type: string
     expected:
-      calls: []
-      normal_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}
+      dynamo:
+        calls: []
+        normal_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}
+      sglang:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
   PARSER.batch.5.b:
     description: Bare <|call|> without preceding channel envelope
     ref: dynamo
@@ -26,8 +30,9 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: <|call|>
+      dynamo:
+        calls: []
+        normal_text: <|call|>
   PARSER.batch.5.c:
     description: Truncation mid-message JSON
     ref: dynamo
@@ -35,5 +40,9 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"loc
+      dynamo:
+        calls: []
+        normal_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"loc
+      sglang:
+        diverges: true
+        reason: "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)"

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.6.yaml
@@ -15,10 +15,14 @@ cases:
         type: object
         properties: {}
     expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_time
+          arguments: {}
+        normal_text: ''
+      sglang:
+        diverges: true
+        reason: "SGLang's GptOssDetector bot_token requires '<|start|>assistant<|channel|>commentary' envelope; Dynamo accepts the bare '<|channel|>commentary' variant"
   PARSER.batch.6.b:
     description: Whitespace inside empty {}
     ref: dynamo
@@ -26,10 +30,14 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_time
+          arguments: {}
+        normal_text: ''
+      sglang:
+        diverges: true
+        reason: "SGLang's GptOssDetector bot_token requires '<|start|>assistant<|channel|>commentary' envelope; Dynamo accepts the bare '<|channel|>commentary' variant"
   PARSER.batch.6.c:
     description: No <|message|> body
     ref: dynamo
@@ -37,5 +45,6 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: <|channel|>commentary to=functions.get_time <|constrain|>json
+      dynamo:
+        calls: []
+        normal_text: <|channel|>commentary to=functions.get_time <|constrain|>json

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.7.yaml
@@ -20,13 +20,17 @@ cases:
           first_class:
             type: boolean
     expected:
-      calls:
-      - name: book_flight
-        arguments:
-          destination: Paris
-          passengers: 2
-          first_class: true
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: book_flight
+          arguments:
+            destination: Paris
+            passengers: 2
+            first_class: true
+        normal_text: ''
+      sglang:
+        diverges: true
+        reason: "drops analysis-channel content from normal_text"
   PARSER.batch.7.b:
     description: Unicode + escaped chars
     ref: dynamo
@@ -39,11 +43,15 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: Tōkyō "central"
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Tōkyō "central"
+        normal_text: ''
+      sglang:
+        diverges: true
+        reason: "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)"
   PARSER.batch.7.c:
     description: Schema mismatch — string value where schema declares integer
     ref: dynamo
@@ -56,11 +64,15 @@ cases:
           celsius:
             type: integer
     expected:
-      calls:
-      - name: set_temperature
-        arguments:
-          celsius: '20'
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: set_temperature
+          arguments:
+            celsius: '20'
+        normal_text: ''
+      sglang:
+        diverges: true
+        reason: "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)"
   PARSER.batch.7.d:
     description: Nested object + array
     ref: dynamo
@@ -75,13 +87,17 @@ cases:
           config:
             type: object
     expected:
-      calls:
-      - name: process_data
-        arguments:
-          items:
-          - 1
-          - 2
-          - 3
-          config:
-            nested: true
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: process_data
+          arguments:
+            items:
+            - 1
+            - 2
+            - 3
+            config:
+              nested: true
+        normal_text: ''
+      sglang:
+        diverges: true
+        reason: "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)"

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.8.yaml
@@ -18,9 +18,13 @@ cases:
           location:
             type: string
     expected:
-      calls: []
-      normal_text: I will check the weather. <|channel|>analysis<|message|>Need to use function get_weather.<|end|><|start|>assistant<|channel|>commentary
-        to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|>
+      dynamo:
+        calls: []
+        normal_text: I will check the weather. <|channel|>analysis<|message|>Need to use function get_weather.<|end|><|start|>assistant<|channel|>commentary
+          to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|>
+      sglang:
+        diverges: true
+        reason: "SGLang's GptOssDetector bot_token requires '<|start|>assistant<|channel|>commentary' envelope; Dynamo accepts the bare '<|channel|>commentary' variant"
   PARSER.batch.8.b:
     description: Narration after tool call only
     ref: dynamo
@@ -29,9 +33,13 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: <|channel|>analysis<|message|>Need to use function get_weather.<|end|><|start|>assistant<|channel|>commentary
-        to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|> Let me know if you need more.
+      dynamo:
+        calls: []
+        normal_text: <|channel|>analysis<|message|>Need to use function get_weather.<|end|><|start|>assistant<|channel|>commentary
+          to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|> Let me know if you need more.
+      sglang:
+        diverges: true
+        reason: "SGLang's GptOssDetector bot_token requires '<|start|>assistant<|channel|>commentary' envelope; Dynamo accepts the bare '<|channel|>commentary' variant"
   PARSER.batch.8.c:
     description: Narration both before and after (sandwich)
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_openai_tool_parser.py#L220
@@ -40,9 +48,13 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: I will check the weather. <|channel|>analysis<|message|>Need to use function get_weather.<|end|><|start|>assistant<|channel|>commentary
-        to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|> Let me know if you need more.
+      dynamo:
+        calls: []
+        normal_text: I will check the weather. <|channel|>analysis<|message|>Need to use function get_weather.<|end|><|start|>assistant<|channel|>commentary
+          to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|> Let me know if you need more.
+      sglang:
+        diverges: true
+        reason: "SGLang's GptOssDetector bot_token requires '<|start|>assistant<|channel|>commentary' envelope; Dynamo accepts the bare '<|channel|>commentary' variant"
   PARSER.batch.8.d:
     description: Narration between multiple tool calls
     ref: dynamo
@@ -52,7 +64,11 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: I will check the weather. <|channel|>analysis<|message|>Need to use function get_weather.<|end|><|start|>assistant<|channel|>commentary
-        to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|> Then check LA weather. <|channel|>commentary
-        to=functions.get_weather <|constrain|>json<|message|>{"location":"LA"}<|call|>
+      dynamo:
+        calls: []
+        normal_text: I will check the weather. <|channel|>analysis<|message|>Need to use function get_weather.<|end|><|start|>assistant<|channel|>commentary
+          to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|> Then check LA weather. <|channel|>commentary
+          to=functions.get_weather <|constrain|>json<|message|>{"location":"LA"}<|call|>
+      sglang:
+        diverges: true
+        reason: "SGLang's GptOssDetector bot_token requires '<|start|>assistant<|channel|>commentary' envelope; Dynamo accepts the bare '<|channel|>commentary' variant"

--- a/tests/parity/parser/fixtures/harmony/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/harmony/PARSER.batch.yaml
@@ -16,27 +16,33 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        diverges: true
+        reason: "SGLang's GptOssDetector bot_token requires '<|start|>assistant<|channel|>commentary' envelope; Dynamo accepts the bare '<|channel|>commentary' variant"
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: Hello, how can I help you today?
+      dynamo:
+        calls: []
+        normal_text: Hello, how can I help you today?
   PARSER.batch.9:
     description: Empty input
     model_text: ''
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
   PARSER.batch.10:
     description: Duplicate calls (same name twice)
     model_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|><|start|>assistant<|channel|>commentary
@@ -44,6 +50,10 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|><|start|>assistant<|channel|>commentary
-        to=functions.get_weather <|constrain|>json<|message|>{"location":"LA"}<|call|>
+      dynamo:
+        calls: []
+        normal_text: <|start|>assistant<|channel|>commentary to=functions.get_weather <|constrain|>json<|message|>{"location":"NYC"}<|call|><|start|>assistant<|channel|>commentary
+          to=functions.get_weather <|constrain|>json<|message|>{"location":"LA"}<|call|>
+      sglang:
+        diverges: true
+        reason: "Dynamo drops back-to-back commentary blocks; SGLang extracts them"

--- a/tests/parity/parser/fixtures/hermes/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/hermes/PARSER.batch.2.yaml
@@ -25,14 +25,15 @@ cases:
           timezone:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
   PARSER.batch.2.c:
     description: With surrounding narration
     ref: dynamo
@@ -42,14 +43,18 @@ cases:
     - *id001
     - *id002
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: 'Both:'
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: 'Both:'
+      vllm:
+        diverges: true
+        reason: "drops trailing normal_text after tool-call wrapper end"
     # TODO(research): vllm diverges — drops trailing normal_text after tool-call wrapper end
     # vllm produces:
     #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}, {'name': 'get_time', 'arguments': {'timezone': 'EST'}}]
@@ -63,11 +68,12 @@ cases:
     - *id001
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: ''

--- a/tests/parity/parser/fixtures/hermes/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/hermes/PARSER.batch.4.yaml
@@ -17,8 +17,9 @@ cases:
           location:
             type: string
     expected:
-      calls: []
-      normal_text: <tool_call>not even json</tool_call>
+      dynamo:
+        calls: []
+        normal_text: <tool_call>not even json</tool_call>
   PARSER.batch.4.b:
     description: Missing close brace in JSON body
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_hermes_tool_parser.py#L376
@@ -26,11 +27,18 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
+      sglang:
+        diverges: true
+        reason: "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)"
     # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
     # vllm produces:
     #   calls: []
@@ -42,8 +50,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: '<tool_call>{"arguments": {"location": "NYC"}}</tool_call>'
+      dynamo:
+        calls: []
+        normal_text: '<tool_call>{"arguments": {"location": "NYC"}}</tool_call>'
+      sglang:
+        diverges: true
+        reason: "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)"
   PARSER.batch.4.d:
     description: Missing </tool_call> close
     ref: dynamo
@@ -51,8 +63,9 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''

--- a/tests/parity/parser/fixtures/hermes/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/hermes/PARSER.batch.5.yaml
@@ -17,11 +17,12 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
   PARSER.batch.5.b:
     description: Closing </tool_call> without matching <tool_call> open
     ref: dynamo
@@ -29,8 +30,9 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>'
+      dynamo:
+        calls: []
+        normal_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>'
   PARSER.batch.5.c:
     description: Truncation mid-arguments JSON
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_hermes_tool_parser.py#L356
@@ -38,5 +40,6 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: '<tool_call>{"name": "get_weather", "arguments": {"loc'
+      dynamo:
+        calls: []
+        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"loc'

--- a/tests/parity/parser/fixtures/hermes/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/hermes/PARSER.batch.6.yaml
@@ -15,10 +15,11 @@ cases:
         type: object
         properties: {}
     expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_time
+          arguments: {}
+        normal_text: ''
   PARSER.batch.6.b:
     description: Whitespace inside arguments {}
     ref: dynamo
@@ -26,10 +27,11 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_time
+          arguments: {}
+        normal_text: ''
   PARSER.batch.6.c:
     description: No arguments key
     ref: dynamo
@@ -37,5 +39,9 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: '<tool_call>{"name": "get_time"}</tool_call>'
+      dynamo:
+        calls: []
+        normal_text: '<tool_call>{"name": "get_time"}</tool_call>'
+      sglang:
+        diverges: true
+        reason: "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)"

--- a/tests/parity/parser/fixtures/hermes/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/hermes/PARSER.batch.7.yaml
@@ -21,13 +21,14 @@ cases:
           first_class:
             type: boolean
     expected:
-      calls:
-      - name: book_flight
-        arguments:
-          first_class: true
-          passengers: 2
-          destination: Paris
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: book_flight
+          arguments:
+            first_class: true
+            passengers: 2
+            destination: Paris
+        normal_text: ''
   PARSER.batch.7.b:
     description: Unicode + escaped chars
     ref: dynamo
@@ -40,11 +41,12 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: Tōkyō "central"
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Tōkyō "central"
+        normal_text: ''
   PARSER.batch.7.c:
     description: Schema mismatch — string value where schema declares integer
     ref: dynamo
@@ -57,11 +59,12 @@ cases:
           celsius:
             type: integer
     expected:
-      calls:
-      - name: set_temperature
-        arguments:
-          celsius: '20'
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: set_temperature
+          arguments:
+            celsius: '20'
+        normal_text: ''
   PARSER.batch.7.d:
     description: Nested object + array
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_hermes_tool_parser.py#L284
@@ -76,13 +79,14 @@ cases:
           config:
             type: object
     expected:
-      calls:
-      - name: process_data
-        arguments:
-          items:
-          - 1
-          - 2
-          - 3
-          config:
-            nested: true
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: process_data
+          arguments:
+            items:
+            - 1
+            - 2
+            - 3
+            config:
+              nested: true
+        normal_text: ''

--- a/tests/parity/parser/fixtures/hermes/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/hermes/PARSER.batch.8.yaml
@@ -17,11 +17,15 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: I will check the weather.
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: I will check the weather.
+      vllm:
+        diverges: true
+        reason: "drops trailing normal_text after tool-call wrapper end"
     # TODO(research): vllm diverges — drops trailing normal_text after tool-call wrapper end
     # vllm produces:
     #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}]
@@ -34,11 +38,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
   PARSER.batch.8.c:
     description: Narration both before and after (sandwich)
     ref: dynamo
@@ -47,11 +52,15 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: I will check the weather.
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: I will check the weather.
+      vllm:
+        diverges: true
+        reason: "drops trailing normal_text after tool-call wrapper end"
     # TODO(research): vllm diverges — drops trailing normal_text after tool-call wrapper end
     # vllm produces:
     #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}]
@@ -64,14 +73,18 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-      normal_text: I will check the weather.
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: I will check the weather.
+      vllm:
+        diverges: true
+        reason: "drops trailing normal_text after tool-call wrapper end"
     # TODO(research): vllm diverges — drops trailing normal_text after tool-call wrapper end
     # vllm produces:
     #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}, {'name': 'get_weather', 'arguments': {'location': 'LA'}}]

--- a/tests/parity/parser/fixtures/hermes/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/hermes/PARSER.batch.yaml
@@ -16,27 +16,30 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: Hello, how can I help you today?
+      dynamo:
+        calls: []
+        normal_text: Hello, how can I help you today?
   PARSER.batch.9:
     description: Empty input
     model_text: ''
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
   PARSER.batch.10:
     description: Duplicate calls (same name twice)
     model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name": "get_weather",
@@ -44,11 +47,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: ''

--- a/tests/parity/parser/fixtures/jamba/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/jamba/PARSER.batch.2.yaml
@@ -25,14 +25,15 @@ cases:
           timezone:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
   PARSER.batch.2.c:
     description: With surrounding narration
     ref: dynamo
@@ -42,14 +43,18 @@ cases:
     - *id001
     - *id002
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: 'Both:'
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: 'Both:'
+      vllm:
+        diverges: true
+        reason: "drops trailing normal_text after tool-call wrapper end"
     # TODO(research): vllm diverges — drops trailing normal_text after tool-call wrapper end
     # vllm produces:
     #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}, {'name': 'get_time', 'arguments': {'timezone': 'EST'}}]
@@ -63,11 +68,12 @@ cases:
     - *id001
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: ''

--- a/tests/parity/parser/fixtures/jamba/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/jamba/PARSER.batch.4.yaml
@@ -17,8 +17,9 @@ cases:
           location:
             type: string
     expected:
-      calls: []
-      normal_text: <tool_calls>not a json array</tool_calls>
+      dynamo:
+        calls: []
+        normal_text: <tool_calls>not a json array</tool_calls>
   PARSER.batch.4.b:
     description: Missing close brace in JSON
     ref: dynamo
@@ -26,8 +27,9 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"]</tool_calls>'
+      dynamo:
+        calls: []
+        normal_text: '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"]</tool_calls>'
   PARSER.batch.4.c:
     description: Missing name key
     ref: dynamo
@@ -35,8 +37,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
     # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
     # vllm produces:
     #   calls: []
@@ -48,11 +54,15 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
     # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
     # vllm produces:
     #   calls: []

--- a/tests/parity/parser/fixtures/jamba/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/jamba/PARSER.batch.5.yaml
@@ -17,11 +17,15 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
     # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
     # vllm produces:
     #   calls: []
@@ -33,8 +37,9 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: '[{"name": "get_weather", "arguments": {"location": "NYC"}}]</tool_calls>'
+      dynamo:
+        calls: []
+        normal_text: '[{"name": "get_weather", "arguments": {"location": "NYC"}}]</tool_calls>'
   PARSER.batch.5.c:
     description: Truncation mid-arguments JSON
     ref: dynamo
@@ -42,5 +47,6 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: '<tool_calls>[{"name": "get_weather", "arguments": {"loc'
+      dynamo:
+        calls: []
+        normal_text: '<tool_calls>[{"name": "get_weather", "arguments": {"loc'

--- a/tests/parity/parser/fixtures/jamba/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/jamba/PARSER.batch.6.yaml
@@ -15,10 +15,11 @@ cases:
         type: object
         properties: {}
     expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_time
+          arguments: {}
+        normal_text: ''
   PARSER.batch.6.b:
     description: Whitespace inside arguments {}
     ref: dynamo
@@ -26,10 +27,11 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_time
+          arguments: {}
+        normal_text: ''
   PARSER.batch.6.c:
     description: No arguments key
     ref: dynamo
@@ -37,8 +39,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
+        diverges: true
+        reason: "both return calls=[]; vLLM preserves raw input as normal_text on this recovery path, Dynamo emits empty"
     # TODO(research): vllm diverges — both return calls=[]; vLLM preserves raw input as normal_text on this recovery path, Dynamo emits empty
     # vllm produces:
     #   calls: []

--- a/tests/parity/parser/fixtures/jamba/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/jamba/PARSER.batch.7.yaml
@@ -21,13 +21,14 @@ cases:
           first_class:
             type: boolean
     expected:
-      calls:
-      - name: book_flight
-        arguments:
-          first_class: true
-          destination: Paris
-          passengers: 2
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: book_flight
+          arguments:
+            first_class: true
+            destination: Paris
+            passengers: 2
+        normal_text: ''
   PARSER.batch.7.b:
     description: Unicode + escaped chars
     ref: dynamo
@@ -40,11 +41,12 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: Tōkyō "central"
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Tōkyō "central"
+        normal_text: ''
   PARSER.batch.7.c:
     description: Schema mismatch — string value where schema declares integer
     ref: dynamo
@@ -57,11 +59,12 @@ cases:
           celsius:
             type: integer
     expected:
-      calls:
-      - name: set_temperature
-        arguments:
-          celsius: '20'
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: set_temperature
+          arguments:
+            celsius: '20'
+        normal_text: ''
   PARSER.batch.7.d:
     description: Nested object + array
     ref: dynamo
@@ -76,13 +79,14 @@ cases:
           config:
             type: object
     expected:
-      calls:
-      - name: process_data
-        arguments:
-          items:
-          - 1
-          - 2
-          - 3
-          config:
-            nested: true
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: process_data
+          arguments:
+            items:
+            - 1
+            - 2
+            - 3
+            config:
+              nested: true
+        normal_text: ''

--- a/tests/parity/parser/fixtures/jamba/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/jamba/PARSER.batch.8.yaml
@@ -17,11 +17,15 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: I will check the weather.
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: I will check the weather.
+      vllm:
+        diverges: true
+        reason: "drops trailing normal_text after tool-call wrapper end"
     # TODO(research): vllm diverges — drops trailing normal_text after tool-call wrapper end
     # vllm produces:
     #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}]
@@ -34,11 +38,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
   PARSER.batch.8.c:
     description: Narration both before and after (sandwich)
     ref: dynamo
@@ -47,11 +52,15 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: I will check the weather.
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: I will check the weather.
+      vllm:
+        diverges: true
+        reason: "drops trailing normal_text after tool-call wrapper end"
     # TODO(research): vllm diverges — drops trailing normal_text after tool-call wrapper end
     # vllm produces:
     #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}]
@@ -64,8 +73,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: I will check the weather.
+      dynamo:
+        calls: []
+        normal_text: I will check the weather.
+      vllm:
+        diverges: true
+        reason: "drops trailing normal_text after tool-call wrapper end"
     # TODO(research): vllm diverges — drops trailing normal_text after tool-call wrapper end
     # vllm produces:
     #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}]

--- a/tests/parity/parser/fixtures/jamba/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/jamba/PARSER.batch.yaml
@@ -16,27 +16,30 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: Hello, how can I help you today?
+      dynamo:
+        calls: []
+        normal_text: Hello, how can I help you today?
   PARSER.batch.9:
     description: Empty input
     model_text: ''
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
   PARSER.batch.10:
     description: Duplicate calls (same name twice)
     model_text: '<tool_calls>[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_weather", "arguments":
@@ -44,11 +47,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: ''

--- a/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.2.yaml
@@ -24,14 +24,15 @@ cases:
           timezone:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
   PARSER.batch.2.b:
     description: Two back-to-back sections (each with one call)
     ref: dynamo
@@ -40,14 +41,15 @@ cases:
     - *id001
     - *id002
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
   PARSER.batch.2.c:
     description: Parallel calls with surrounding narration
     ref: dynamo
@@ -57,14 +59,21 @@ cases:
     - *id001
     - *id002
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: I will check both.  Done.
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: I will check both.  Done.
+      vllm:
+        diverges: true
+        reason: "drops trailing normal_text after tool-call wrapper end"
+      sglang:
+        diverges: true
+        reason: "trims trailing space from preceding normal_text"
     # TODO(research): vllm diverges — drops trailing normal_text after tool-call wrapper end
     # vllm produces:
     #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}, {'name': 'get_time', 'arguments': {'timezone': 'EST'}}]
@@ -77,11 +86,12 @@ cases:
     - *id001
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: ''

--- a/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.4.yaml
@@ -17,8 +17,9 @@ cases:
           location:
             type: string
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
   PARSER.batch.4.b:
     description: Invalid JSON args (missing close brace)
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_kimi_k2_tool_parser.py#L151
@@ -26,10 +27,14 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments: '{"location":"NYC"'
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments: '{"location":"NYC"'
+        normal_text: ''
+      sglang:
+        diverges: true
+        reason: "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)"
   PARSER.batch.4.c:
     description: Missing function name (call_begin without functions.X:N)
     ref: dynamo
@@ -37,8 +42,9 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
   PARSER.batch.4.d:
     description: Mismatched fences (call_end before call_begin closes)
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_kimi_k2_tool_parser.py#L165
@@ -46,5 +52,6 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''

--- a/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.5.yaml
@@ -17,11 +17,12 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
   PARSER.batch.5.b:
     description: Closing section_end without matching section_begin
     ref: dynamo
@@ -29,8 +30,9 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: <|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>
+      dynamo:
+        calls: []
+        normal_text: <|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_calls_section_end|>
   PARSER.batch.5.c:
     description: Truncation mid-arguments (incomplete JSON body)
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_kimi_k2_tool_parser.py#L413
@@ -38,5 +40,6 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''

--- a/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.6.yaml
@@ -15,10 +15,11 @@ cases:
         type: object
         properties: {}
     expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_time
+          arguments: {}
+        normal_text: ''
   PARSER.batch.6.b:
     description: Whitespace inside empty {}
     ref: dynamo
@@ -26,10 +27,11 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_time
+          arguments: {}
+        normal_text: ''
   PARSER.batch.6.c:
     description: No argument body (skip argument_begin → end)
     ref: dynamo
@@ -37,5 +39,6 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''

--- a/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.7.yaml
@@ -20,13 +20,14 @@ cases:
           first_class:
             type: boolean
     expected:
-      calls:
-      - name: book_flight
-        arguments:
-          destination: Paris
-          passengers: 2
-          first_class: true
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: book_flight
+          arguments:
+            destination: Paris
+            passengers: 2
+            first_class: true
+        normal_text: ''
   PARSER.batch.7.b:
     description: Unicode + escaped chars in string value
     ref: dynamo
@@ -40,11 +41,12 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: Tōkyō "central"
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Tōkyō "central"
+        normal_text: ''
   PARSER.batch.7.c:
     description: Schema mismatch — string value where schema declares integer
     ref: dynamo
@@ -57,11 +59,12 @@ cases:
           celsius:
             type: integer
     expected:
-      calls:
-      - name: set_temperature
-        arguments:
-          celsius: '20'
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: set_temperature
+          arguments:
+            celsius: '20'
+        normal_text: ''
   PARSER.batch.7.d:
     description: Nested object + array (existing shape)
     ref: dynamo
@@ -76,13 +79,14 @@ cases:
           config:
             type: object
     expected:
-      calls:
-      - name: process_data
-        arguments:
-          items:
-          - 1
-          - 2
-          - 3
-          config:
-            nested: true
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: process_data
+          arguments:
+            items:
+            - 1
+            - 2
+            - 3
+            config:
+              nested: true
+        normal_text: ''

--- a/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.8.yaml
@@ -17,11 +17,18 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: Dallas
-      normal_text: I'll check the weather.
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Dallas
+        normal_text: I'll check the weather.
+      vllm:
+        diverges: true
+        reason: "preserves trailing space; Dynamo trims it"
+      sglang:
+        diverges: true
+        reason: "TODO(research): SGLang diverges on this case; investigate vs Dynamo's expected"
     # TODO(research): vllm diverges — preserves trailing space; Dynamo trims it
     # vllm produces:
     #   calls: [{'name': 'get_weather', 'arguments': {'location': 'Dallas'}}]
@@ -34,11 +41,18 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: Dallas
-      normal_text: Let me know if you need more.
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Dallas
+        normal_text: Let me know if you need more.
+      vllm:
+        diverges: true
+        reason: "drops trailing normal_text after tool-call wrapper end"
+      sglang:
+        diverges: true
+        reason: "TODO(research): SGLang diverges on this case; investigate vs Dynamo's expected"
     # TODO(research): vllm diverges — drops trailing normal_text after tool-call wrapper end
     # vllm produces:
     #   calls: [{'name': 'get_weather', 'arguments': {'location': 'Dallas'}}]
@@ -51,11 +65,18 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: Dallas
-      normal_text: I'll check the weather.  Let me know if you need more.
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Dallas
+        normal_text: I'll check the weather.  Let me know if you need more.
+      vllm:
+        diverges: true
+        reason: "drops trailing normal_text after tool-call wrapper end"
+      sglang:
+        diverges: true
+        reason: "TODO(research): SGLang diverges on this case; investigate vs Dynamo's expected"
     # TODO(research): vllm diverges — drops trailing normal_text after tool-call wrapper end
     # vllm produces:
     #   calls: [{'name': 'get_weather', 'arguments': {'location': 'Dallas'}}]
@@ -68,14 +89,21 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: Dallas
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: First check Dallas.  Then check NYC.
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Dallas
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: First check Dallas.  Then check NYC.
+      vllm:
+        diverges: true
+        reason: "drops trailing normal_text after tool-call wrapper end"
+      sglang:
+        diverges: true
+        reason: "TODO(research): SGLang diverges on this case; investigate vs Dynamo's expected"
     # TODO(research): vllm diverges — drops trailing normal_text after tool-call wrapper end
     # vllm produces:
     #   calls: [{'name': 'get_weather', 'arguments': {'location': 'Dallas'}}, {'name': 'get_weather', 'arguments': {'location': 'NYC'}}]

--- a/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/kimi_k2/PARSER.batch.yaml
@@ -16,38 +16,42 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: Hello, how can I help you today?
+      dynamo:
+        calls: []
+        normal_text: Hello, how can I help you today?
   PARSER.batch.9:
     description: Empty input
     model_text: ''
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
   PARSER.batch.10:
     description: Duplicate calls (same name twice)
     model_text: <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"location":"NYC"}<|tool_call_end|><|tool_call_begin|>functions.get_weather:1<|tool_call_argument_begin|>{"location":"LA"}<|tool_call_end|><|tool_calls_section_end|>
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: ''

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.batch.2.yaml
@@ -25,8 +25,12 @@ cases:
           timezone:
             type: string
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
+        diverges: true
+        reason: "vLLM llama3_json does not parse semicolon-separated calls the same way Dynamo does"
     # TODO(research): vllm diverges — vLLM llama3_json does not parse semicolon-separated calls the same way Dynamo does
     # vllm produces:
     #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}, {'name': 'get_time', 'arguments': {'timezone': 'EST'}}]
@@ -40,8 +44,12 @@ cases:
     - *id001
     - *id002
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
+        diverges: true
+        reason: "vLLM llama3_json does not parse semicolon-separated calls the same way Dynamo does"
     # TODO(research): vllm diverges — vLLM llama3_json does not parse semicolon-separated calls the same way Dynamo does
     # vllm produces:
     #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}, {'name': 'get_time', 'arguments': {'timezone': 'EST'}}]
@@ -55,8 +63,12 @@ cases:
     - *id001
     - *id001
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
+        diverges: true
+        reason: "vLLM llama3_json does not parse semicolon-separated calls the same way Dynamo does"
     # TODO(research): vllm diverges — vLLM llama3_json does not parse semicolon-separated calls the same way Dynamo does
     # vllm produces:
     #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}, {'name': 'get_weather', 'arguments': {'location': 'LA'}}]

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.batch.4.yaml
@@ -17,8 +17,12 @@ cases:
           location:
             type: string
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
     # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
     # vllm produces:
     #   calls: []
@@ -30,8 +34,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
     # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
     # vllm produces:
     #   calls: []
@@ -43,8 +51,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
     # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
     # vllm produces:
     #   calls: []

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.batch.5.yaml
@@ -17,8 +17,12 @@ cases:
           location:
             type: string
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
     # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
     # vllm produces:
     #   calls: []
@@ -30,8 +34,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
     # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
     # vllm produces:
     #   calls: []

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.batch.6.yaml
@@ -15,10 +15,11 @@ cases:
         type: object
         properties: {}
     expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_time
+          arguments: {}
+        normal_text: ''
   PARSER.batch.6.b:
     description: Whitespace inside arguments {}
     ref: dynamo
@@ -26,10 +27,11 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_time
+          arguments: {}
+        normal_text: ''
   PARSER.batch.6.c:
     description: No arguments key
     ref: dynamo
@@ -37,8 +39,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
+        diverges: true
+        reason: "both return calls=[]; vLLM preserves raw input as normal_text on this recovery path, Dynamo emits empty"
     # TODO(research): vllm diverges — both return calls=[]; vLLM preserves raw input as normal_text on this recovery path, Dynamo emits empty
     # vllm produces:
     #   calls: []

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.batch.7.yaml
@@ -21,13 +21,14 @@ cases:
           first_class:
             type: boolean
     expected:
-      calls:
-      - name: book_flight
-        arguments:
-          destination: Paris
-          first_class: true
-          passengers: 2
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: book_flight
+          arguments:
+            destination: Paris
+            first_class: true
+            passengers: 2
+        normal_text: ''
   PARSER.batch.7.b:
     description: Unicode + escaped chars
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_llama3_json_tool_parser.py#L217
@@ -40,11 +41,12 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: Tōkyō "central"
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Tōkyō "central"
+        normal_text: ''
   PARSER.batch.7.c:
     description: Schema mismatch — string value where schema declares integer
     ref: dynamo
@@ -57,11 +59,12 @@ cases:
           celsius:
             type: integer
     expected:
-      calls:
-      - name: set_temperature
-        arguments:
-          celsius: '20'
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: set_temperature
+          arguments:
+            celsius: '20'
+        normal_text: ''
   PARSER.batch.7.d:
     description: Nested object + array
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_llama3_json_tool_parser.py#L146
@@ -76,13 +79,14 @@ cases:
           config:
             type: object
     expected:
-      calls:
-      - name: process_data
-        arguments:
-          config:
-            nested: true
-          items:
-          - 1
-          - 2
-          - 3
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: process_data
+          arguments:
+            config:
+              nested: true
+            items:
+            - 1
+            - 2
+            - 3
+        normal_text: ''

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.batch.8.yaml
@@ -17,11 +17,15 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: I will check the weather.
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: I will check the weather.
+      vllm:
+        diverges: true
+        reason: "TODO(research): vLLM returns null normal_text where Dynamo surfaces the narration string"
     # TODO(research): vllm diverges — TODO(research): vLLM returns null normal_text where Dynamo surfaces the narration string
     # vllm produces:
     #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}]
@@ -33,11 +37,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
   PARSER.batch.8.c:
     description: Narration both before and after (sandwich)
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_llama3_json_tool_parser.py#L128
@@ -46,11 +51,15 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: I will check the weather.
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: I will check the weather.
+      vllm:
+        diverges: true
+        reason: "TODO(research): vLLM returns null normal_text where Dynamo surfaces the narration string"
     # TODO(research): vllm diverges — TODO(research): vLLM returns null normal_text where Dynamo surfaces the narration string
     # vllm produces:
     #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}]
@@ -63,14 +72,18 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-      normal_text: I will check the weather.
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: I will check the weather.
+      vllm:
+        diverges: true
+        reason: "TODO(research): vLLM returns null normal_text where Dynamo surfaces the narration string"
     # TODO(research): vllm diverges — TODO(research): vLLM returns null normal_text where Dynamo surfaces the narration string
     # vllm produces:
     #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}, {'name': 'get_weather', 'arguments': {'location': 'LA'}}]

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.batch.yaml
@@ -16,27 +16,30 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: Hello, how can I help you today?
+      dynamo:
+        calls: []
+        normal_text: Hello, how can I help you today?
   PARSER.batch.9:
     description: Empty input
     model_text: ''
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
   PARSER.batch.10:
     description: Duplicate calls (same name twice)
     model_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}};{"name": "get_weather", "arguments":
@@ -44,5 +47,9 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
+        diverges: true
+        reason: "vLLM llama3_json does not parse semicolon-separated calls the same way Dynamo does"

--- a/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.2.yaml
@@ -32,14 +32,15 @@ cases:
           timezone:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
   PARSER.batch.2.b:
     description: Two back-to-back tool_call wrappers
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_minimax_m2_tool_parser.py#L207
@@ -58,14 +59,18 @@ cases:
     - *id001
     - *id002
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+      sglang:
+        diverges: true
+        reason: "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)"
   PARSER.batch.2.c:
     description: Parallel with surrounding narration
     ref: dynamo
@@ -82,14 +87,18 @@ cases:
     - *id001
     - *id002
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: 'Both: '
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: 'Both: '
+      sglang:
+        diverges: true
+        reason: "trims trailing space from preceding normal_text"
   PARSER.batch.2.d:
     description: Same-name twice
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_minimax_m2_tool_parser.py#L331
@@ -106,11 +115,12 @@ cases:
     - *id001
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: ''

--- a/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.4.yaml
@@ -20,8 +20,12 @@ cases:
           location:
             type: string
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
     # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
     # vllm produces:
     #   calls: []
@@ -39,8 +43,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
     # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
     # vllm produces:
     #   calls: []
@@ -56,11 +64,15 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
     # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
     # vllm produces:
     #   calls: []

--- a/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.5.yaml
@@ -21,11 +21,18 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
+      sglang:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
     # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
     # vllm produces:
     #   calls: []
@@ -41,12 +48,13 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: |-
-        <invoke name="get_weather">
-        <parameter name="location">NYC</parameter>
-        </invoke>
-        </minimax:tool_call>
+      dynamo:
+        calls: []
+        normal_text: |-
+          <invoke name="get_weather">
+          <parameter name="location">NYC</parameter>
+          </invoke>
+          </minimax:tool_call>
   PARSER.batch.5.c:
     description: Truncation mid-parameter value
     ref: dynamo
@@ -57,11 +65,18 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NY
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NY
+        normal_text: ''
+      vllm:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
+      sglang:
+        diverges: true
+        reason: "sglang nullifies normal_text on malformed/recovery shapes where Dynamo preserves input"
     # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
     # vllm produces:
     #   calls: []

--- a/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.6.yaml
@@ -19,10 +19,11 @@ cases:
         type: object
         properties: {}
     expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_time
+          arguments: {}
+        normal_text: ''
   PARSER.batch.6.b:
     description: Invoke with extra newline
     ref: dynamo
@@ -35,7 +36,8 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_time
+          arguments: {}
+        normal_text: ''

--- a/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.7.yaml
@@ -27,13 +27,17 @@ cases:
           first_class:
             type: boolean
     expected:
-      calls:
-      - name: book_flight
-        arguments:
-          destination: Paris
-          first_class: true
-          passengers: 2
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: book_flight
+          arguments:
+            destination: Paris
+            first_class: true
+            passengers: 2
+        normal_text: ''
+      vllm:
+        diverges: true
+        reason: "vLLM emits JSON-typed parameter values as raw strings; Dynamo coerces nested object/array types"
     # TODO(research): vllm diverges — vLLM emits JSON-typed parameter values as raw strings; Dynamo coerces nested object/array types
     # vllm produces:
     #   calls: [{'name': 'book_flight', 'arguments': {'destination': 'Paris', 'passengers': '2', 'first_class': 'true'}}]
@@ -55,8 +59,9 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: Tōkyō central
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Tōkyō central
+        normal_text: ''

--- a/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.8.yaml
@@ -22,11 +22,12 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: 'I will check the weather. '
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: 'I will check the weather. '
   PARSER.batch.8.b:
     description: Narration after tool call only
     ref: dynamo
@@ -39,11 +40,15 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        diverges: true
+        reason: "sglang preserves trailing normal_text after wrapper end; Dynamo trims it (post-#9350)"
   PARSER.batch.8.c:
     description: Narration both before and after (sandwich)
     ref: dynamo
@@ -56,11 +61,15 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: 'I will check the weather. '
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: 'I will check the weather. '
+      sglang:
+        diverges: true
+        reason: "sglang preserves trailing normal_text after wrapper end; Dynamo trims it (post-#9350)"
   PARSER.batch.8.d:
     description: Narration between multiple tool calls
     ref: dynamo
@@ -77,11 +86,15 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-      normal_text: 'I will check the weather. '
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: 'I will check the weather. '
+      sglang:
+        diverges: true
+        reason: "sglang preserves trailing normal_text after wrapper end; Dynamo trims it (post-#9350)"

--- a/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.yaml
@@ -21,27 +21,30 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: Hello, how can I help you today?
+      dynamo:
+        calls: []
+        normal_text: Hello, how can I help you today?
   PARSER.batch.9:
     description: Empty input
     model_text: ''
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
   PARSER.batch.10:
     description: Duplicate calls (same name twice)
     model_text: |-
@@ -56,11 +59,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: ''

--- a/tests/parity/parser/fixtures/mistral/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/mistral/PARSER.batch.2.yaml
@@ -25,14 +25,18 @@ cases:
           timezone:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+      sglang:
+        diverges: true
+        reason: "SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits"
   PARSER.batch.2.c:
     description: With surrounding narration
     ref: dynamo
@@ -42,14 +46,21 @@ cases:
     - *id001
     - *id002
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: 'Both:'
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: 'Both:'
+      vllm:
+        diverges: true
+        reason: "drops trailing normal_text after tool-call wrapper end"
+      sglang:
+        diverges: true
+        reason: "trims trailing space from preceding normal_text"
     # TODO(research): vllm diverges — drops trailing normal_text after tool-call wrapper end
     # vllm produces:
     #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}, {'name': 'get_time', 'arguments': {'timezone': 'EST'}}]
@@ -63,11 +74,15 @@ cases:
     - *id001
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: ''
+      sglang:
+        diverges: true
+        reason: "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)"

--- a/tests/parity/parser/fixtures/mistral/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/mistral/PARSER.batch.4.yaml
@@ -17,8 +17,15 @@ cases:
           location:
             type: string
     expected:
-      calls: []
-      normal_text: '[TOOL_CALLS]not a json array[/TOOL_CALLS]'
+      dynamo:
+        calls: []
+        normal_text: '[TOOL_CALLS]not a json array[/TOOL_CALLS]'
+      vllm:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
+      sglang:
+        diverges: true
+        reason: "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)"
     # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
     # vllm produces:
     #   calls: []
@@ -30,8 +37,15 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"][/TOOL_CALLS]'
+      dynamo:
+        calls: []
+        normal_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"][/TOOL_CALLS]'
+      vllm:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
+      sglang:
+        diverges: true
+        reason: "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)"
     # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
     # vllm produces:
     #   calls: []
@@ -43,8 +57,13 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
+        diverges: true
+        reason: "vLLM mistral_tool_parser raises KeyError when 'name' key is missing"
+        expected_error_pattern: "KeyError"
     # TODO(research): vllm diverges — EXPECTS_ERROR(KeyError): vLLM mistral_tool_parser raises KeyError when 'name' key is missing
     # vllm produces:
     #   error: KeyError: 'name'
@@ -55,8 +74,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        diverges: true
+        reason: "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)"

--- a/tests/parity/parser/fixtures/mistral/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/mistral/PARSER.batch.5.yaml
@@ -17,11 +17,15 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
   PARSER.batch.5.b:
     description: Closing [/TOOL_CALLS] without matching [TOOL_CALLS] open
     ref: dynamo
@@ -29,8 +33,9 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: '[{"name": "get_weather", "arguments": {"location": "NYC"}}][/TOOL_CALLS]'
+      dynamo:
+        calls: []
+        normal_text: '[{"name": "get_weather", "arguments": {"location": "NYC"}}][/TOOL_CALLS]'
   PARSER.batch.5.c:
     description: Truncation mid-arguments JSON
     ref: dynamo
@@ -38,8 +43,15 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"loc'
+      dynamo:
+        calls: []
+        normal_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"loc'
+      vllm:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
+      sglang:
+        diverges: true
+        reason: "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)"
     # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
     # vllm produces:
     #   calls: []

--- a/tests/parity/parser/fixtures/mistral/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/mistral/PARSER.batch.6.yaml
@@ -15,10 +15,14 @@ cases:
         type: object
         properties: {}
     expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_time
+          arguments: {}
+        normal_text: ''
+      sglang:
+        diverges: true
+        reason: "SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits"
   PARSER.batch.6.b:
     description: Whitespace inside arguments {}
     ref: dynamo
@@ -26,10 +30,14 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_time
+          arguments: {}
+        normal_text: ''
+      sglang:
+        diverges: true
+        reason: "SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits"
   PARSER.batch.6.c:
     description: No arguments key
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_mistral_tool_parser.py#L514
@@ -37,8 +45,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
+        diverges: true
+        reason: "vLLM accepts call with missing arguments key as having empty args; Dynamo returns calls=[]"
     # TODO(research): vllm diverges — vLLM accepts call with missing arguments key as having empty args; Dynamo returns calls=[]
     # vllm produces:
     #   calls: [{'name': 'get_time', 'arguments': {}}]

--- a/tests/parity/parser/fixtures/mistral/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/mistral/PARSER.batch.7.yaml
@@ -21,13 +21,17 @@ cases:
           first_class:
             type: boolean
     expected:
-      calls:
-      - name: book_flight
-        arguments:
-          destination: Paris
-          first_class: true
-          passengers: 2
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: book_flight
+          arguments:
+            destination: Paris
+            first_class: true
+            passengers: 2
+        normal_text: ''
+      sglang:
+        diverges: true
+        reason: "SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits"
   PARSER.batch.7.b:
     description: Unicode + escaped chars
     ref: dynamo
@@ -40,11 +44,15 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: Tōkyō "central"
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Tōkyō "central"
+        normal_text: ''
+      sglang:
+        diverges: true
+        reason: "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)"
   PARSER.batch.7.c:
     description: Schema mismatch — string value where schema declares integer
     ref: dynamo
@@ -57,11 +65,15 @@ cases:
           celsius:
             type: integer
     expected:
-      calls:
-      - name: set_temperature
-        arguments:
-          celsius: '20'
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: set_temperature
+          arguments:
+            celsius: '20'
+        normal_text: ''
+      sglang:
+        diverges: true
+        reason: "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)"
   PARSER.batch.7.d:
     description: Nested object + array
     ref: dynamo
@@ -76,13 +88,17 @@ cases:
           config:
             type: object
     expected:
-      calls:
-      - name: process_data
-        arguments:
-          items:
-          - 1
-          - 2
-          - 3
-          config:
-            nested: true
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: process_data
+          arguments:
+            items:
+            - 1
+            - 2
+            - 3
+            config:
+              nested: true
+        normal_text: ''
+      sglang:
+        diverges: true
+        reason: "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)"

--- a/tests/parity/parser/fixtures/mistral/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/mistral/PARSER.batch.8.yaml
@@ -17,11 +17,18 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: I will check the weather.
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: I will check the weather.
+      vllm:
+        diverges: true
+        reason: "drops trailing normal_text after tool-call wrapper end"
+      sglang:
+        diverges: true
+        reason: "drops trailing normal_text after tool-call wrapper end"
     # TODO(research): vllm diverges — drops trailing normal_text after tool-call wrapper end
     # vllm produces:
     #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}]
@@ -34,11 +41,15 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        diverges: true
+        reason: "drops trailing normal_text after tool-call wrapper end"
   PARSER.batch.8.c:
     description: Narration both before and after (sandwich)
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_mistral_tool_parser.py#L1858
@@ -47,11 +58,18 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: I will check the weather.
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: I will check the weather.
+      vllm:
+        diverges: true
+        reason: "drops trailing normal_text after tool-call wrapper end"
+      sglang:
+        diverges: true
+        reason: "drops trailing normal_text after tool-call wrapper end"
     # TODO(research): vllm diverges — drops trailing normal_text after tool-call wrapper end
     # vllm produces:
     #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}]
@@ -64,8 +82,13 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: I will check the weather.
+      dynamo:
+        calls: []
+        normal_text: I will check the weather.
+      vllm:
+        diverges: true
+        reason: "vLLM mistral_tool_parser raises ValueError on two consecutive [TOOL_CALLS] envelopes"
+        expected_error_pattern: "Only one BOT token"
     # TODO(research): vllm diverges — EXPECTS_ERROR(Only one BOT token): vLLM mistral_tool_parser raises ValueError on two consecutive [TOOL_CALLS] envelopes
     # vllm produces:
     #   error: ValueError: Only one BOT token should have been outputted, but got I will check the weather. [TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}][/TOOL_CALLS] Then check LA weather.

--- a/tests/parity/parser/fixtures/mistral/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/mistral/PARSER.batch.yaml
@@ -16,27 +16,33 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        diverges: true
+        reason: "SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits"
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: Hello, how can I help you today?
+      dynamo:
+        calls: []
+        normal_text: Hello, how can I help you today?
   PARSER.batch.9:
     description: Empty input
     model_text: ''
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
   PARSER.batch.10:
     description: Duplicate calls (same name twice)
     model_text: '[TOOL_CALLS][{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_weather", "arguments":
@@ -44,11 +50,15 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: ''
+      sglang:
+        diverges: true
+        reason: "SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits"

--- a/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.2.yaml
@@ -25,14 +25,15 @@ cases:
           timezone:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
   PARSER.batch.2.b:
     description: Two back-to-back TOOLCALL wrappers
     ref: dynamo
@@ -42,8 +43,9 @@ cases:
     - *id001
     - *id002
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
     # NOTE: Dynamo's nemotron_deci parser does not restart on back-to-back
     # <TOOLCALL>...</TOOLCALL> wrappers (handles multi-call within ONE wrapper
     # — see 2.a — but not multiple wrappers). Known parser limitation; the
@@ -59,14 +61,15 @@ cases:
     - *id001
     - *id002
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: 'Both:'
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: 'Both:'
   PARSER.batch.2.d:
     description: Same-name twice
     ref: dynamo
@@ -76,11 +79,12 @@ cases:
     - *id001
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: ''

--- a/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.4.yaml
@@ -17,8 +17,9 @@ cases:
           location:
             type: string
     expected:
-      calls: []
-      normal_text: <TOOLCALL>not a json array</TOOLCALL>
+      dynamo:
+        calls: []
+        normal_text: <TOOLCALL>not a json array</TOOLCALL>
   PARSER.batch.4.b:
     description: Unterminated JSON string in args
     ref: dynamo
@@ -26,11 +27,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
   PARSER.batch.4.c:
     description: Missing name key in JSON
     ref: dynamo
@@ -38,8 +40,9 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
   PARSER.batch.4.d:
     description: Mismatched JSON brackets
     ref: dynamo
@@ -47,8 +50,9 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''

--- a/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.5.yaml
@@ -17,11 +17,12 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
   PARSER.batch.5.b:
     description: Closing </TOOLCALL> without matching <TOOLCALL> open
     ref: dynamo
@@ -29,8 +30,9 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: '[{"name": "get_weather", "arguments": {"location": "NYC"}}]</TOOLCALL>'
+      dynamo:
+        calls: []
+        normal_text: '[{"name": "get_weather", "arguments": {"location": "NYC"}}]</TOOLCALL>'
   PARSER.batch.5.c:
     description: Truncation mid-arguments JSON
     ref: dynamo
@@ -38,5 +40,6 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"loc'
+      dynamo:
+        calls: []
+        normal_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"loc'

--- a/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.6.yaml
@@ -15,10 +15,11 @@ cases:
         type: object
         properties: {}
     expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_time
+          arguments: {}
+        normal_text: ''
   PARSER.batch.6.b:
     description: Whitespace inside arguments {}
     ref: dynamo
@@ -26,10 +27,11 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_time
+          arguments: {}
+        normal_text: ''
   PARSER.batch.6.c:
     description: No arguments key
     ref: dynamo
@@ -37,5 +39,6 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''

--- a/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.7.yaml
@@ -21,13 +21,14 @@ cases:
           first_class:
             type: boolean
     expected:
-      calls:
-      - name: book_flight
-        arguments:
-          first_class: true
-          destination: Paris
-          passengers: 2
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: book_flight
+          arguments:
+            first_class: true
+            destination: Paris
+            passengers: 2
+        normal_text: ''
   PARSER.batch.7.b:
     description: Unicode + escaped chars
     ref: dynamo
@@ -40,11 +41,12 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: Tōkyō "central"
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Tōkyō "central"
+        normal_text: ''
   PARSER.batch.7.c:
     description: Schema mismatch — string value where schema declares integer
     ref: dynamo
@@ -57,11 +59,12 @@ cases:
           celsius:
             type: integer
     expected:
-      calls:
-      - name: set_temperature
-        arguments:
-          celsius: '20'
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: set_temperature
+          arguments:
+            celsius: '20'
+        normal_text: ''
   PARSER.batch.7.d:
     description: Nested object + array (existing)
     ref: dynamo
@@ -76,13 +79,14 @@ cases:
           config:
             type: object
     expected:
-      calls:
-      - name: process_data
-        arguments:
-          items:
-          - 1
-          - 2
-          - 3
-          config:
-            nested: true
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: process_data
+          arguments:
+            items:
+            - 1
+            - 2
+            - 3
+            config:
+              nested: true
+        normal_text: ''

--- a/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.8.yaml
@@ -17,11 +17,12 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: I will check the weather.
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: I will check the weather.
   PARSER.batch.8.b:
     description: Narration after tool call only
     ref: dynamo
@@ -30,11 +31,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
   PARSER.batch.8.c:
     description: Narration both before and after (sandwich)
     ref: dynamo
@@ -43,11 +45,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: I will check the weather.
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: I will check the weather.
   PARSER.batch.8.d:
     description: Narration between multiple tool calls
     ref: dynamo
@@ -56,5 +59,6 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: I will check the weather.
+      dynamo:
+        calls: []
+        normal_text: I will check the weather.

--- a/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/nemotron_deci/PARSER.batch.yaml
@@ -16,27 +16,30 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: Hello, how can I help you today?
+      dynamo:
+        calls: []
+        normal_text: Hello, how can I help you today?
   PARSER.batch.9:
     description: Empty input
     model_text: ''
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
   PARSER.batch.10:
     description: Duplicate calls (same name twice)
     model_text: '<TOOLCALL>[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_weather", "arguments":
@@ -44,11 +47,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: ''

--- a/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.2.yaml
@@ -38,14 +38,15 @@ cases:
           timezone:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
   PARSER.batch.2.c:
     description: With surrounding narration
     ref: dynamo
@@ -68,14 +69,15 @@ cases:
     - *id001
     - *id002
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: 'Both: '
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: 'Both: '
   PARSER.batch.2.d:
     description: Same-name twice
     ref: dynamo
@@ -98,11 +100,12 @@ cases:
     - *id001
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: ''

--- a/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.4.yaml
@@ -20,8 +20,9 @@ cases:
           location:
             type: string
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
   PARSER.batch.4.d:
     description: Missing </parameter> closing tag
     ref: dynamo
@@ -35,8 +36,9 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''

--- a/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.5.yaml
@@ -23,11 +23,12 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
   PARSER.batch.5.b:
     description: Closing </tool_call> without matching <tool_call> open
     ref: dynamo
@@ -41,14 +42,15 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: |-
-        <function=get_weather>
-        <parameter=location>
-        NYC
-        </parameter>
-        </function>
-        </tool_call>
+      dynamo:
+        calls: []
+        normal_text: |-
+          <function=get_weather>
+          <parameter=location>
+          NYC
+          </parameter>
+          </function>
+          </tool_call>
   PARSER.batch.5.c:
     description: Truncation mid-parameter value
     ref: dynamo
@@ -60,8 +62,9 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NY
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NY
+        normal_text: ''

--- a/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.6.yaml
@@ -19,10 +19,11 @@ cases:
         type: object
         properties: {}
     expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_time
+          arguments: {}
+        normal_text: ''
   PARSER.batch.6.b:
     description: Function block with extra whitespace inside
     ref: dynamo
@@ -35,7 +36,8 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_time
+          arguments: {}
+        normal_text: ''

--- a/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.7.yaml
@@ -33,13 +33,14 @@ cases:
           first_class:
             type: boolean
     expected:
-      calls:
-      - name: book_flight
-        arguments:
-          destination: Paris
-          passengers: 2
-          first_class: true
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: book_flight
+          arguments:
+            destination: Paris
+            passengers: 2
+            first_class: true
+        normal_text: ''
   PARSER.batch.7.b:
     description: Unicode in parameter
     ref: dynamo
@@ -59,8 +60,9 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: Tōkyō central
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Tōkyō central
+        normal_text: ''

--- a/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.8.yaml
@@ -24,11 +24,12 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: 'I will check the weather. '
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: 'I will check the weather. '
   PARSER.batch.8.b:
     description: Narration after tool call only
     ref: dynamo
@@ -43,11 +44,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
   PARSER.batch.8.c:
     description: Narration both before and after (sandwich)
     ref: dynamo
@@ -62,11 +64,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: 'I will check the weather. '
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: 'I will check the weather. '
   PARSER.batch.8.d:
     description: Narration between multiple tool calls
     ref: dynamo
@@ -87,11 +90,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-      normal_text: 'I will check the weather. '
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: 'I will check the weather. '

--- a/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/nemotron_nano/PARSER.batch.yaml
@@ -23,27 +23,30 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: Hello, how can I help you today?
+      dynamo:
+        calls: []
+        normal_text: Hello, how can I help you today?
   PARSER.batch.9:
     description: Empty input
     model_text: ''
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
   PARSER.batch.10:
     description: Duplicate calls (same name twice)
     model_text: |-
@@ -64,11 +67,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: ''

--- a/tests/parity/parser/fixtures/phi4/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/phi4/PARSER.batch.2.yaml
@@ -25,14 +25,15 @@ cases:
           timezone:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
   PARSER.batch.2.c:
     description: With surrounding narration
     ref: dynamo
@@ -42,14 +43,18 @@ cases:
     - *id001
     - *id002
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: 'Both:'
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: 'Both:'
+      vllm:
+        diverges: true
+        reason: "drops trailing normal_text after tool-call wrapper end"
     # TODO(research): vllm diverges — drops trailing normal_text after tool-call wrapper end
     # vllm produces:
     #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}, {'name': 'get_time', 'arguments': {'timezone': 'EST'}}]
@@ -63,11 +68,12 @@ cases:
     - *id001
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: ''

--- a/tests/parity/parser/fixtures/phi4/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/phi4/PARSER.batch.4.yaml
@@ -17,8 +17,9 @@ cases:
           location:
             type: string
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
   PARSER.batch.4.b:
     description: Missing close brace
     ref: dynamo
@@ -26,8 +27,9 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
   PARSER.batch.4.c:
     description: Missing name key
     ref: dynamo
@@ -35,8 +37,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
     # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
     # vllm produces:
     #   calls: []
@@ -48,8 +54,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
     # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
     # vllm produces:
     #   calls: []

--- a/tests/parity/parser/fixtures/phi4/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/phi4/PARSER.batch.5.yaml
@@ -17,8 +17,12 @@ cases:
           location:
             type: string
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
     # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
     # vllm produces:
     #   calls: []
@@ -30,11 +34,15 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
     # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
     # vllm produces:
     #   calls: []
@@ -46,8 +54,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
     # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
     # vllm produces:
     #   calls: []

--- a/tests/parity/parser/fixtures/phi4/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/phi4/PARSER.batch.6.yaml
@@ -15,10 +15,11 @@ cases:
         type: object
         properties: {}
     expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_time
+          arguments: {}
+        normal_text: ''
   PARSER.batch.6.b:
     description: Whitespace inside arguments {}
     ref: dynamo
@@ -26,10 +27,11 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_time
+          arguments: {}
+        normal_text: ''
   PARSER.batch.6.c:
     description: No arguments key
     ref: dynamo
@@ -37,8 +39,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
+        diverges: true
+        reason: "both return calls=[]; vLLM preserves raw input as normal_text on this recovery path, Dynamo emits empty"
     # TODO(research): vllm diverges — both return calls=[]; vLLM preserves raw input as normal_text on this recovery path, Dynamo emits empty
     # vllm produces:
     #   calls: []

--- a/tests/parity/parser/fixtures/phi4/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/phi4/PARSER.batch.7.yaml
@@ -20,13 +20,14 @@ cases:
           first_class:
             type: boolean
     expected:
-      calls:
-      - name: book_flight
-        arguments:
-          destination: Paris
-          passengers: 2
-          first_class: true
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: book_flight
+          arguments:
+            destination: Paris
+            passengers: 2
+            first_class: true
+        normal_text: ''
   PARSER.batch.7.b:
     description: Unicode + escaped chars
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L302
@@ -39,11 +40,12 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: Tōkyō "central"
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Tōkyō "central"
+        normal_text: ''
   PARSER.batch.7.c:
     description: Schema mismatch — string value where schema declares integer
     ref: dynamo
@@ -56,11 +58,12 @@ cases:
           celsius:
             type: integer
     expected:
-      calls:
-      - name: set_temperature
-        arguments:
-          celsius: '20'
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: set_temperature
+          arguments:
+            celsius: '20'
+        normal_text: ''
   PARSER.batch.7.d:
     description: Nested object + array
     ref: dynamo
@@ -75,16 +78,20 @@ cases:
           config:
             type: object
     expected:
-      calls:
-      - name: process_data
-        arguments:
-          config:
-            nested: true
-          items:
-          - 1
-          - 2
-          - 3
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: process_data
+          arguments:
+            config:
+              nested: true
+            items:
+            - 1
+            - 2
+            - 3
+        normal_text: ''
+      vllm:
+        diverges: true
+        reason: "vLLM emits JSON-typed parameter values as raw strings; Dynamo coerces nested object/array types"
     # TODO(research): vllm diverges — vLLM emits JSON-typed parameter values as raw strings; Dynamo coerces nested object/array types
     # vllm produces:
     #   calls: []

--- a/tests/parity/parser/fixtures/phi4/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/phi4/PARSER.batch.8.yaml
@@ -17,11 +17,15 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: I will check the weather.
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: I will check the weather.
+      vllm:
+        diverges: true
+        reason: "drops trailing normal_text after tool-call wrapper end"
     # TODO(research): vllm diverges — drops trailing normal_text after tool-call wrapper end
     # vllm produces:
     #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}]
@@ -33,11 +37,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
   PARSER.batch.8.c:
     description: Narration both before and after (sandwich)
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L282
@@ -46,11 +51,15 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: I will check the weather.
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: I will check the weather.
+      vllm:
+        diverges: true
+        reason: "drops trailing normal_text after tool-call wrapper end"
     # TODO(research): vllm diverges — drops trailing normal_text after tool-call wrapper end
     # vllm produces:
     #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}]
@@ -63,14 +72,18 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-      normal_text: I will check the weather.
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: I will check the weather.
+      vllm:
+        diverges: true
+        reason: "drops trailing normal_text after tool-call wrapper end"
     # TODO(research): vllm diverges — drops trailing normal_text after tool-call wrapper end
     # vllm produces:
     #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}]

--- a/tests/parity/parser/fixtures/phi4/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/phi4/PARSER.batch.yaml
@@ -16,27 +16,30 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: Hello, how can I help you today?
+      dynamo:
+        calls: []
+        normal_text: Hello, how can I help you today?
   PARSER.batch.9:
     description: Empty input
     model_text: ''
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
   PARSER.batch.10:
     description: Duplicate calls (same name twice)
     model_text: 'functools[{"name": "get_weather", "arguments": {"location": "NYC"}}, {"name": "get_weather", "arguments":
@@ -44,11 +47,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: ''

--- a/tests/parity/parser/fixtures/pythonic/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/pythonic/PARSER.batch.2.yaml
@@ -24,14 +24,15 @@ cases:
           timezone:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
   PARSER.batch.2.c:
     description: With surrounding narration
     ref: dynamo
@@ -40,14 +41,21 @@ cases:
     - *id001
     - *id002
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: 'Both:'
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: 'Both:'
+      vllm:
+        diverges: true
+        reason: "vLLM rejects bracket-call form when surrounded by interleaved text; Dynamo extracts the calls"
+      sglang:
+        diverges: true
+        reason: "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)"
     # TODO(research): vllm diverges — vLLM rejects bracket-call form when surrounded by interleaved text; Dynamo extracts the calls
     # vllm produces:
     #   calls: []
@@ -60,11 +68,12 @@ cases:
     - *id001
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: ''

--- a/tests/parity/parser/fixtures/pythonic/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/pythonic/PARSER.batch.4.yaml
@@ -17,8 +17,9 @@ cases:
           location:
             type: string
     expected:
-      calls: []
-      normal_text: '[not a valid python call]'
+      dynamo:
+        calls: []
+        normal_text: '[not a valid python call]'
   PARSER.batch.4.b:
     description: Missing closing bracket
     ref: dynamo
@@ -26,8 +27,9 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: '[get_weather(location="NYC"'
+      dynamo:
+        calls: []
+        normal_text: '[get_weather(location="NYC"'
   PARSER.batch.4.d:
     description: Mismatched paren / bracket
     ref: dynamo
@@ -35,5 +37,6 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: '[get_weather(location="NYC"]'
+      dynamo:
+        calls: []
+        normal_text: '[get_weather(location="NYC"]'

--- a/tests/parity/parser/fixtures/pythonic/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/pythonic/PARSER.batch.5.yaml
@@ -17,8 +17,9 @@ cases:
           location:
             type: string
     expected:
-      calls: []
-      normal_text: '[get_weather(location="NYC")'
+      dynamo:
+        calls: []
+        normal_text: '[get_weather(location="NYC")'
   PARSER.batch.5.b:
     description: Closing `]` without matching `[` open
     ref: dynamo
@@ -26,8 +27,9 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: get_weather(location="NYC")]
+      dynamo:
+        calls: []
+        normal_text: get_weather(location="NYC")]
   PARSER.batch.5.c:
     description: Truncation mid-argument value
     ref: dynamo
@@ -35,5 +37,6 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: '[get_weather(location="N'
+      dynamo:
+        calls: []
+        normal_text: '[get_weather(location="N'

--- a/tests/parity/parser/fixtures/pythonic/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/pythonic/PARSER.batch.6.yaml
@@ -15,10 +15,11 @@ cases:
         type: object
         properties: {}
     expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_time
+          arguments: {}
+        normal_text: ''
   PARSER.batch.6.b:
     description: Whitespace inside parens
     ref: dynamo
@@ -26,5 +27,6 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: '[get_time( )]'
+      dynamo:
+        calls: []
+        normal_text: '[get_time( )]'

--- a/tests/parity/parser/fixtures/pythonic/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/pythonic/PARSER.batch.7.yaml
@@ -20,13 +20,14 @@ cases:
           first_class:
             type: boolean
     expected:
-      calls:
-      - name: book_flight
-        arguments:
-          destination: Paris
-          passengers: 2
-          first_class: true
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: book_flight
+          arguments:
+            destination: Paris
+            passengers: 2
+            first_class: true
+        normal_text: ''
   PARSER.batch.7.b:
     description: Unicode + escaped chars
     ref: dynamo
@@ -39,11 +40,12 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: Tōkyō "central"
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Tōkyō "central"
+        normal_text: ''
   PARSER.batch.7.c:
     description: Schema mismatch — string value where schema declares integer
     ref: dynamo
@@ -56,11 +58,12 @@ cases:
           celsius:
             type: integer
     expected:
-      calls:
-      - name: set_temperature
-        arguments:
-          celsius: '20'
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: set_temperature
+          arguments:
+            celsius: '20'
+        normal_text: ''
   PARSER.batch.7.d:
     description: Nested dict + array (existing)
     ref: dynamo
@@ -75,13 +78,14 @@ cases:
           config:
             type: object
     expected:
-      calls:
-      - name: process_data
-        arguments:
-          items:
-          - 1
-          - 2
-          - 3
-          config:
-            nested: true
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: process_data
+          arguments:
+            items:
+            - 1
+            - 2
+            - 3
+            config:
+              nested: true
+        normal_text: ''

--- a/tests/parity/parser/fixtures/pythonic/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/pythonic/PARSER.batch.8.yaml
@@ -17,11 +17,18 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: I will check the weather.
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: I will check the weather.
+      vllm:
+        diverges: true
+        reason: "vLLM rejects bracket-call form when surrounded by interleaved text; Dynamo extracts the call"
+      sglang:
+        diverges: true
+        reason: "drops trailing normal_text after tool-call wrapper end"
     # TODO(research): vllm diverges — vLLM rejects bracket-call form when surrounded by interleaved text; Dynamo extracts the call
     # vllm produces:
     #   calls: []
@@ -33,11 +40,18 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      vllm:
+        diverges: true
+        reason: "vLLM rejects bracket-call form when surrounded by interleaved text; Dynamo extracts the call"
+      sglang:
+        diverges: true
+        reason: "drops trailing normal_text after tool-call wrapper end"
     # TODO(research): vllm diverges — vLLM rejects bracket-call form when surrounded by interleaved text; Dynamo extracts the call
     # vllm produces:
     #   calls: []
@@ -49,11 +63,18 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: I will check the weather.
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: I will check the weather.
+      vllm:
+        diverges: true
+        reason: "vLLM rejects bracket-call form when surrounded by interleaved text; Dynamo extracts the call"
+      sglang:
+        diverges: true
+        reason: "drops trailing normal_text after tool-call wrapper end"
     # TODO(research): vllm diverges — vLLM rejects bracket-call form when surrounded by interleaved text; Dynamo extracts the call
     # vllm produces:
     #   calls: []
@@ -65,11 +86,18 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: I will check the weather.
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: I will check the weather.
+      vllm:
+        diverges: true
+        reason: "vLLM rejects bracket-call form when surrounded by interleaved text; Dynamo extracts the call"
+      sglang:
+        diverges: true
+        reason: "drops trailing normal_text after tool-call wrapper end"
     # TODO(research): vllm diverges — vLLM rejects bracket-call form when surrounded by interleaved text; Dynamo extracts the call
     # vllm produces:
     #   calls: []

--- a/tests/parity/parser/fixtures/pythonic/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/pythonic/PARSER.batch.yaml
@@ -16,38 +16,42 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: Hello, how can I help you today?
+      dynamo:
+        calls: []
+        normal_text: Hello, how can I help you today?
   PARSER.batch.9:
     description: Empty input
     model_text: ''
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
   PARSER.batch.10:
     description: Duplicate calls (same name twice)
     model_text: '[get_weather(location="NYC"), get_weather(location="LA")]'
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: ''

--- a/tests/parity/parser/fixtures/qwen25/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/qwen25/PARSER.batch.2.yaml
@@ -25,14 +25,18 @@ cases:
           timezone:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+      sglang:
+        diverges: true
+        reason: "SGLang Qwen25Detector returns calls=[] on the hermes-style <tool_call>...</tool_call> format Dynamo emits"
   PARSER.batch.2.c:
     description: With surrounding narration
     ref: dynamo
@@ -42,14 +46,18 @@ cases:
     - *id001
     - *id002
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: 'Both:'
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: 'Both:'
+      sglang:
+        diverges: true
+        reason: "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)"
   PARSER.batch.2.d:
     description: Same-name twice
     ref: dynamo
@@ -59,11 +67,15 @@ cases:
     - *id001
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: ''
+      sglang:
+        diverges: true
+        reason: "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)"

--- a/tests/parity/parser/fixtures/qwen25/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/qwen25/PARSER.batch.4.yaml
@@ -17,8 +17,9 @@ cases:
           location:
             type: string
     expected:
-      calls: []
-      normal_text: <tool_call>not even json</tool_call>
+      dynamo:
+        calls: []
+        normal_text: <tool_call>not even json</tool_call>
   PARSER.batch.4.b:
     description: Missing close brace in JSON body
     ref: dynamo
@@ -26,11 +27,15 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        diverges: true
+        reason: "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)"
   PARSER.batch.4.c:
     description: Missing name key
     ref: dynamo
@@ -38,8 +43,9 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: '<tool_call>{"arguments": {"location": "NYC"}}</tool_call>'
+      dynamo:
+        calls: []
+        normal_text: '<tool_call>{"arguments": {"location": "NYC"}}</tool_call>'
   PARSER.batch.4.d:
     description: Missing </tool_call> close
     ref: dynamo
@@ -47,8 +53,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        diverges: true
+        reason: "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)"

--- a/tests/parity/parser/fixtures/qwen25/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/qwen25/PARSER.batch.5.yaml
@@ -17,11 +17,15 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
   PARSER.batch.5.b:
     description: Closing </tool_call> without matching <tool_call> open
     ref: dynamo
@@ -29,8 +33,9 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>'
+      dynamo:
+        calls: []
+        normal_text: '{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call>'
   PARSER.batch.5.c:
     description: Truncation mid-arguments JSON
     ref: dynamo
@@ -38,5 +43,6 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: '<tool_call>{"name": "get_weather", "arguments": {"loc'
+      dynamo:
+        calls: []
+        normal_text: '<tool_call>{"name": "get_weather", "arguments": {"loc'

--- a/tests/parity/parser/fixtures/qwen25/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/qwen25/PARSER.batch.6.yaml
@@ -15,10 +15,14 @@ cases:
         type: object
         properties: {}
     expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_time
+          arguments: {}
+        normal_text: ''
+      sglang:
+        diverges: true
+        reason: "SGLang Qwen25Detector returns calls=[] on the hermes-style <tool_call>...</tool_call> format Dynamo emits"
   PARSER.batch.6.b:
     description: Whitespace inside arguments {}
     ref: dynamo
@@ -26,10 +30,14 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_time
+          arguments: {}
+        normal_text: ''
+      sglang:
+        diverges: true
+        reason: "SGLang Qwen25Detector returns calls=[] on the hermes-style <tool_call>...</tool_call> format Dynamo emits"
   PARSER.batch.6.c:
     description: No arguments key
     ref: dynamo
@@ -37,5 +45,6 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: '<tool_call>{"name": "get_time"}</tool_call>'
+      dynamo:
+        calls: []
+        normal_text: '<tool_call>{"name": "get_time"}</tool_call>'

--- a/tests/parity/parser/fixtures/qwen25/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/qwen25/PARSER.batch.7.yaml
@@ -21,13 +21,17 @@ cases:
           first_class:
             type: boolean
     expected:
-      calls:
-      - name: book_flight
-        arguments:
-          destination: Paris
-          passengers: 2
-          first_class: true
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: book_flight
+          arguments:
+            destination: Paris
+            passengers: 2
+            first_class: true
+        normal_text: ''
+      sglang:
+        diverges: true
+        reason: "SGLang Qwen25Detector returns calls=[] on the hermes-style <tool_call>...</tool_call> format Dynamo emits"
   PARSER.batch.7.b:
     description: Unicode + escaped chars
     ref: dynamo
@@ -40,11 +44,15 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: Tōkyō "central"
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Tōkyō "central"
+        normal_text: ''
+      sglang:
+        diverges: true
+        reason: "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)"
   PARSER.batch.7.c:
     description: Schema mismatch — string value where schema declares integer
     ref: dynamo
@@ -57,11 +65,15 @@ cases:
           celsius:
             type: integer
     expected:
-      calls:
-      - name: set_temperature
-        arguments:
-          celsius: '20'
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: set_temperature
+          arguments:
+            celsius: '20'
+        normal_text: ''
+      sglang:
+        diverges: true
+        reason: "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)"
   PARSER.batch.7.d:
     description: Nested object + array
     ref: dynamo
@@ -76,13 +88,17 @@ cases:
           config:
             type: object
     expected:
-      calls:
-      - name: process_data
-        arguments:
-          items:
-          - 1
-          - 2
-          - 3
-          config:
-            nested: true
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: process_data
+          arguments:
+            items:
+            - 1
+            - 2
+            - 3
+            config:
+              nested: true
+        normal_text: ''
+      sglang:
+        diverges: true
+        reason: "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)"

--- a/tests/parity/parser/fixtures/qwen25/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/qwen25/PARSER.batch.8.yaml
@@ -17,11 +17,15 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: I will check the weather.
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: I will check the weather.
+      sglang:
+        diverges: true
+        reason: "drops trailing normal_text after tool-call wrapper end"
   PARSER.batch.8.b:
     description: Narration after tool call only
     ref: dynamo
@@ -30,11 +34,15 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        diverges: true
+        reason: "drops trailing normal_text after tool-call wrapper end"
   PARSER.batch.8.c:
     description: Narration both before and after (sandwich)
     ref: dynamo
@@ -43,11 +51,15 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: I will check the weather.
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: I will check the weather.
+      sglang:
+        diverges: true
+        reason: "drops trailing normal_text after tool-call wrapper end"
   PARSER.batch.8.d:
     description: Narration between multiple tool calls
     ref: dynamo
@@ -56,11 +68,15 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-      normal_text: I will check the weather.
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: I will check the weather.
+      sglang:
+        diverges: true
+        reason: "drops trailing normal_text after tool-call wrapper end"

--- a/tests/parity/parser/fixtures/qwen25/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/qwen25/PARSER.batch.yaml
@@ -16,27 +16,33 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
+      sglang:
+        diverges: true
+        reason: "SGLang Qwen25Detector returns calls=[] on the hermes-style <tool_call>...</tool_call> format Dynamo emits"
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: Hello, how can I help you today?
+      dynamo:
+        calls: []
+        normal_text: Hello, how can I help you today?
   PARSER.batch.9:
     description: Empty input
     model_text: ''
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
   PARSER.batch.10:
     description: Duplicate calls (same name twice)
     model_text: '<tool_call>{"name": "get_weather", "arguments": {"location": "NYC"}}</tool_call><tool_call>{"name": "get_weather",
@@ -44,11 +50,15 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: ''
+      sglang:
+        diverges: true
+        reason: "SGLang Qwen25Detector returns calls=[] on the hermes-style <tool_call>...</tool_call> format Dynamo emits"

--- a/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.2.yaml
@@ -38,14 +38,15 @@ cases:
           timezone:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
   PARSER.batch.2.c:
     description: Parallel calls with surrounding narration
     ref: dynamo
@@ -68,14 +69,15 @@ cases:
     - *id001
     - *id002
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_time
-        arguments:
-          timezone: EST
-      normal_text: 'Both queries: '
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: 'Both queries: '
   PARSER.batch.2.d:
     description: Same-name twice (id distinctness)
     ref: dynamo
@@ -98,11 +100,12 @@ cases:
     - *id001
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: ''

--- a/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.4.yaml
+++ b/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.4.yaml
@@ -20,8 +20,12 @@ cases:
           location:
             type: string
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
+      vllm:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
     # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
     # vllm produces:
     #   calls: []
@@ -39,8 +43,9 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''

--- a/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.5.yaml
+++ b/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.5.yaml
@@ -23,11 +23,12 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
   PARSER.batch.5.b:
     description: Closing </tool_call> without matching <tool_call> open
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_qwen3coder_tool_parser.py#L943
@@ -41,14 +42,18 @@ cases:
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: |-
-        <function=get_weather>
-        <parameter=location>
-        NYC
-        </parameter>
-        </function>
-        </tool_call>
+      dynamo:
+        calls: []
+        normal_text: |-
+          <function=get_weather>
+          <parameter=location>
+          NYC
+          </parameter>
+          </function>
+          </tool_call>
+      vllm:
+        diverges: true
+        reason: "impl-defined recovery contract (see PARSER_CASES.md)"
     # TODO(research): vllm diverges — impl-defined recovery contract (see PARSER_CASES.md)
     # vllm produces:
     #   calls: [{'name': 'get_weather', 'arguments': {'location': 'NYC'}}]
@@ -64,8 +69,9 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NY
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NY
+        normal_text: ''

--- a/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.6.yaml
+++ b/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.6.yaml
@@ -19,10 +19,11 @@ cases:
         type: object
         properties: {}
     expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_time
+          arguments: {}
+        normal_text: ''
   PARSER.batch.6.b:
     description: Function block with extra whitespace inside
     ref: dynamo
@@ -35,7 +36,8 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_time
-        arguments: {}
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_time
+          arguments: {}
+        normal_text: ''

--- a/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.7.yaml
+++ b/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.7.yaml
@@ -33,13 +33,20 @@ cases:
           first_class:
             type: boolean
     expected:
-      calls:
-      - name: book_flight
-        arguments:
-          destination: Paris
-          first_class: true
-          passengers: 2
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: book_flight
+          arguments:
+            destination: Paris
+            first_class: true
+            passengers: 2
+        normal_text: ''
+      vllm:
+        diverges: true
+        reason: "vLLM emits JSON-typed parameter values as raw strings; Dynamo coerces nested object/array types"
+      sglang:
+        diverges: true
+        reason: "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)"
     # TODO(research): vllm diverges — vLLM emits JSON-typed parameter values as raw strings; Dynamo coerces nested object/array types
     # vllm produces:
     #   calls: [{'name': 'book_flight', 'arguments': {'destination': 'Paris', 'passengers': '2', 'first_class': 'true'}}]
@@ -63,8 +70,9 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: Tōkyō central
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: Tōkyō central
+        normal_text: ''

--- a/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.8.yaml
@@ -24,11 +24,12 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: 'I will check the weather. '
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: 'I will check the weather. '
   PARSER.batch.8.b:
     description: Narration after tool call only
     ref: dynamo
@@ -43,11 +44,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
   PARSER.batch.8.c:
     description: Narration both before and after (sandwich)
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/common_tests.py#L282
@@ -62,11 +64,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: 'I will check the weather. '
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: 'I will check the weather. '
   PARSER.batch.8.d:
     description: Narration between multiple tool calls
     ref: dynamo
@@ -87,11 +90,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-      normal_text: 'I will check the weather. '
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: 'I will check the weather. '

--- a/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/qwen3_coder/PARSER.batch.yaml
@@ -23,27 +23,30 @@ cases:
           location:
             type: string
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        normal_text: ''
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: Hello, how can I help you today?
+      dynamo:
+        calls: []
+        normal_text: Hello, how can I help you today?
   PARSER.batch.9:
     description: Empty input
     model_text: ''
     tools:
     - *id001
     expected:
-      calls: []
-      normal_text: ''
+      dynamo:
+        calls: []
+        normal_text: ''
   PARSER.batch.10:
     description: Duplicate calls (same name twice)
     model_text: |-
@@ -64,11 +67,12 @@ cases:
     tools:
     - *id001
     expected:
-      calls:
-      - name: get_weather
-        arguments:
-          location: NYC
-      - name: get_weather
-        arguments:
-          location: LA
-      normal_text: ''
+      dynamo:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_weather
+          arguments:
+            location: LA
+        normal_text: ''

--- a/tests/parity/parser/regenerate_fixtures.py
+++ b/tests/parity/parser/regenerate_fixtures.py
@@ -2584,7 +2584,19 @@ async def main(overwrite_if_exists: bool = False) -> None:
                 merged_case["ref"] = entry.get("ref", "dynamo")
             merged_case["model_text"] = entry["text"]
             merged_case["tools"] = entry["tools"]
-            merged_case["expected"] = expected
+            # Variant D schema: `expected` is keyed by impl. Dynamo is the
+            # oracle and always present; peers (vllm/sglang) are added by
+            # hand when they diverge. Regen only writes the dynamo block —
+            # existing peer overrides on disk are preserved via the merge
+            # path below (step 2) when re-running with `--overwrite`.
+            preserved_peers = {}
+            if case_id in existing:
+                old_expected = existing[case_id].get("expected", {})
+                if isinstance(old_expected, dict):
+                    for peer in ("vllm", "sglang"):
+                        if peer in old_expected:
+                            preserved_peers[peer] = old_expected[peer]
+            merged_case["expected"] = {"dynamo": expected, **preserved_peers}
             merged[case_id] = merged_case
             n_written += 1
 

--- a/tests/parity/parser/test_parity_parser.py
+++ b/tests/parity/parser/test_parity_parser.py
@@ -4,8 +4,24 @@
 """Parser-mode parity tests — Method 2 of the cross-impl parity (parser) effort.
 
 For each fixture, run the same input through Dynamo's Rust parser (via PyO3)
-and the upstream Python parsers (vLLM + SGLang). Diff against the recorded
-expected output and against each other.
+and the upstream Python parsers (vLLM + SGLang). Each case's YAML carries an
+`expected:` block keyed by impl name (Variant D schema):
+
+    expected:
+      dynamo:                          # oracle, always required
+        calls: [...]
+        normal_text: '...'
+      vllm:                            # OPTIONAL: only when vLLM diverges
+        diverges: true
+        reason: "<why>"
+        expected_error_pattern: "..."  # OPTIONAL: with EXPECTS_ERROR contract
+      sglang:                          # OPTIONAL: only when SGLang diverges
+        diverges: true
+        reason: "..."
+
+If an impl key is absent, the impl is expected to match `dynamo`. If
+`diverges: true` is set, the case xfails for that impl (and XPASS-strict
+turns on if it later starts matching `dynamo`).
 
 Run:
     pytest tests/parity/parser/test_parity_parser.py -v
@@ -14,6 +30,7 @@ Run:
 from __future__ import annotations
 
 import importlib
+import re
 from pathlib import Path
 from typing import Any
 
@@ -26,7 +43,6 @@ pytestmark = [pytest.mark.unit, pytest.mark.pre_merge, pytest.mark.gpu_0]
 
 FIXTURES_ROOT = Path(__file__).parent / "fixtures"
 
-
 # Impl name → optional package whose absence is a legitimate skip. Anything
 # else that fails inside the wrapper module (e.g. a stale `from vllm.X import
 # Y` after vLLM renamed Y) is a real bug and must surface as a test ERROR,
@@ -37,770 +53,6 @@ _PACKAGE: dict[str, str] = {
     "dynamo": "dynamo._core",
     "vllm": "vllm",
     "sglang": "sglang",
-}
-
-
-# (impl, family, case_id) -> reason. Surfaced findings from running the harness;
-# each entry is a real behavioral divergence we've chosen to document rather
-# than fix. Promote to a tracked bug before removing.
-#
-# Pattern: vLLM and SGLang both truncate normal_text at the *end* of the
-# tool-call wrapper for some parser families. Dynamo preserves text that
-# appears after the closing wrapper token for the families still listed below.
-_TRAILING_NORMAL_TEXT_DROP = "drops trailing normal_text after tool-call wrapper end"
-_HARMONY_REQUIRES_ASSISTANT_PREFIX = (
-    "SGLang's GptOssDetector bot_token requires '<|start|>assistant<|channel|>commentary' "
-    "envelope; Dynamo accepts the bare '<|channel|>commentary' variant"
-)
-# PARSER.batch.4 (malformed JSON) and PARSER.batch.5 (missing end-token) are
-# impl-defined recovery contracts per PARSER_CASES.md. Each parser picks its
-# own behavior (drop, recover-best-effort, fall back to string args, surface
-# error). Cross-impl parity is not expected; we record divergences as a map
-# of "what each impl does" rather than asserting one truth.
-_RECOVERY_CONTRACT = "impl-defined recovery contract (see PARSER_CASES.md)"
-
-KNOWN_DIVERGENCES: dict[tuple[str, str, str], str] = {
-    # vLLM and SGLang both truncate normal_text at the *end* of the tool-call
-    # wrapper for these parser families. Only Dynamo preserves text after
-    # the closing wrapper token.
-    #
-    # kimi_k2 PARSER.batch.8 sub-cases (SGLang has no kimi_k2 detector → skips):
-    #   .a (pre-text only)   — vLLM preserves trailing whitespace; Dynamo trims
-    #   .b (post-text only)  — vLLM drops the trailing text entirely
-    #   .c (sandwich)        — vLLM preserves leading text but drops trailing
-    #   .d (between calls)   — vLLM drops inter-call text after first close
-    (
-        "vllm",
-        "kimi_k2",
-        "PARSER.batch.8.a",
-    ): "preserves trailing space; Dynamo trims it",
-    ("vllm", "kimi_k2", "PARSER.batch.8.b"): _TRAILING_NORMAL_TEXT_DROP,
-    ("vllm", "kimi_k2", "PARSER.batch.8.c"): _TRAILING_NORMAL_TEXT_DROP,
-    ("vllm", "kimi_k2", "PARSER.batch.8.d"): _TRAILING_NORMAL_TEXT_DROP,
-    ("vllm", "glm47", "PARSER.batch.8.a"): _TRAILING_NORMAL_TEXT_DROP,
-    ("vllm", "glm47", "PARSER.batch.8.b"): _TRAILING_NORMAL_TEXT_DROP,
-    ("vllm", "glm47", "PARSER.batch.8.c"): _TRAILING_NORMAL_TEXT_DROP,
-    ("vllm", "glm47", "PARSER.batch.8.d"): _TRAILING_NORMAL_TEXT_DROP,
-    # SGLang's GptOssDetector requires a strict '<|start|>assistant<|channel|>commentary'
-    # bot_token; bare '<|channel|>commentary' variants (PARSER.batch.1, .6, .13)
-    # are not detected at all.
-    ("sglang", "harmony", "PARSER.batch.1"): _HARMONY_REQUIRES_ASSISTANT_PREFIX,
-    ("sglang", "harmony", "PARSER.batch.6.a"): _HARMONY_REQUIRES_ASSISTANT_PREFIX,
-    ("sglang", "harmony", "PARSER.batch.6.b"): _HARMONY_REQUIRES_ASSISTANT_PREFIX,
-    ("sglang", "harmony", "PARSER.batch.8.a"): _HARMONY_REQUIRES_ASSISTANT_PREFIX,
-    ("sglang", "harmony", "PARSER.batch.8.b"): _HARMONY_REQUIRES_ASSISTANT_PREFIX,
-    ("sglang", "harmony", "PARSER.batch.8.c"): _HARMONY_REQUIRES_ASSISTANT_PREFIX,
-    ("sglang", "harmony", "PARSER.batch.8.d"): _HARMONY_REQUIRES_ASSISTANT_PREFIX,
-    # SGLang's GptOssDetector drops the analysis-channel preamble entirely;
-    # Dynamo surfaces it as normal_text.
-    # Inverse of the bare-envelope finding: when the input *does* have the
-    # assistant prefix and contains back-to-back commentary blocks, SGLang
-    # extracts both calls — Dynamo's harmony parser drops them and treats the
-    # raw input as normal_text. Dynamo bug class; see harmony_parser.rs comment
-    # block above test_parse_harmony_multiple_calls_recovers.
-    (
-        "sglang",
-        "harmony",
-        "PARSER.batch.10",
-    ): "Dynamo drops back-to-back commentary blocks; SGLang extracts them",
-    # Whitespace handling on text immediately preceding the bot_token:
-    # - SGLang on DeepSeek variants trims one trailing space; Dynamo keeps it.
-    (
-        "sglang",
-        "deepseek_v3_1",
-        "PARSER.batch.8.a",
-    ): "trims trailing space from preceding normal_text",
-    (
-        "sglang",
-        "deepseek_v3_1",
-        "PARSER.batch.8.c",
-    ): "trims trailing space from preceding normal_text",
-    (
-        "sglang",
-        "deepseek_v3_1",
-        "PARSER.batch.8.d",
-    ): "trims trailing space from preceding normal_text",
-    (
-        "sglang",
-        "deepseek_v3",
-        "PARSER.batch.8.a",
-    ): "trims trailing space from preceding normal_text",
-    (
-        "sglang",
-        "deepseek_v3",
-        "PARSER.batch.8.c",
-    ): "trims trailing space from preceding normal_text",
-    (
-        "sglang",
-        "deepseek_v3",
-        "PARSER.batch.8.d",
-    ): "trims trailing space from preceding normal_text",
-    ("sglang", "pythonic", "PARSER.batch.8.a"): _TRAILING_NORMAL_TEXT_DROP,
-    ("sglang", "pythonic", "PARSER.batch.8.b"): _TRAILING_NORMAL_TEXT_DROP,
-    ("sglang", "pythonic", "PARSER.batch.8.c"): _TRAILING_NORMAL_TEXT_DROP,
-    ("sglang", "pythonic", "PARSER.batch.8.d"): _TRAILING_NORMAL_TEXT_DROP,
-    # Inverse of the XML-family pattern: post-#9350 Dynamo trims trailing
-    # text after wrapper-end on minimax_m2; SGLang preserves it. Only .a
-    # matches (no trailing text in that shape).
-    (
-        "sglang",
-        "minimax_m2",
-        "PARSER.batch.8.b",
-    ): "sglang preserves trailing normal_text after wrapper end; Dynamo trims it (post-#9350)",
-    (
-        "sglang",
-        "minimax_m2",
-        "PARSER.batch.8.c",
-    ): "sglang preserves trailing normal_text after wrapper end; Dynamo trims it (post-#9350)",
-    (
-        "sglang",
-        "minimax_m2",
-        "PARSER.batch.8.d",
-    ): "sglang preserves trailing normal_text after wrapper end; Dynamo trims it (post-#9350)",
-    ("vllm", "gemma4", "PARSER.batch.8.b"): _TRAILING_NORMAL_TEXT_DROP,
-    ("vllm", "gemma4", "PARSER.batch.8.c"): _TRAILING_NORMAL_TEXT_DROP,
-    ("vllm", "gemma4", "PARSER.batch.8.d"): _TRAILING_NORMAL_TEXT_DROP,
-    # vLLM's pythonic parser rejects the whole input when the bracket-call form
-    # is surrounded by interleaved text — calls=[], normal_text=raw input.
-    # Dynamo's pythonic parser extracts the call and surfaces the surrounding
-    # text in normal_text (matches the upstream Llama 4 / pythonic_detector
-    # behavior — vLLM is the outlier here).
-    (
-        "vllm",
-        "pythonic",
-        "PARSER.batch.8.a",
-    ): "vLLM rejects bracket-call form when surrounded by interleaved text; Dynamo extracts the call",
-    (
-        "vllm",
-        "pythonic",
-        "PARSER.batch.8.b",
-    ): "vLLM rejects bracket-call form when surrounded by interleaved text; Dynamo extracts the call",
-    (
-        "vllm",
-        "pythonic",
-        "PARSER.batch.8.c",
-    ): "vLLM rejects bracket-call form when surrounded by interleaved text; Dynamo extracts the call",
-    (
-        "vllm",
-        "pythonic",
-        "PARSER.batch.8.d",
-    ): "vLLM rejects bracket-call form when surrounded by interleaved text; Dynamo extracts the call",
-    # PARSER.batch.4 (malformed) — impl-defined recovery contract.
-    # PARSER.batch.5 (missing end-token recovery) — impl-defined. Dynamo's
-    # PyO3 batch binding now uses `detect_and_parse_tool_call_with_recovery`
-    # so the registered `expected` reflects the recovered call; impls that
-    # still drop on the missing end-token diverge here.
-    # vllm/sglang qwen3_coder.batch.5 both recover to the same call as
-    # Dynamo and match the new expected — intentionally NOT registered.
-    # PARSER.batch.5 sub-cases — recovery contract (impl-defined; see PARSER_CASES.md).
-    # vllm divergences from harness; sglang .a inherited from prior bare-key registry,
-    # additional sglang .b/.c entries to be added as CI surfaces them.
-    ("vllm", "deepseek_v3", "PARSER.batch.5.a"): _RECOVERY_CONTRACT,
-    ("vllm", "deepseek_v3", "PARSER.batch.5.c"): _RECOVERY_CONTRACT,
-    ("vllm", "deepseek_v3_1", "PARSER.batch.5.a"): _RECOVERY_CONTRACT,
-    ("vllm", "deepseek_v3_1", "PARSER.batch.5.c"): _RECOVERY_CONTRACT,
-    ("vllm", "deepseek_v3_2", "PARSER.batch.5.a"): _RECOVERY_CONTRACT,
-    ("vllm", "deepseek_v3_2", "PARSER.batch.5.c"): _RECOVERY_CONTRACT,
-    ("vllm", "deepseek_v4", "PARSER.batch.5.a"): _RECOVERY_CONTRACT,
-    ("vllm", "deepseek_v4", "PARSER.batch.5.c"): _RECOVERY_CONTRACT,
-    ("vllm", "glm47", "PARSER.batch.5.a"): _RECOVERY_CONTRACT,
-    ("vllm", "glm47", "PARSER.batch.5.c"): _RECOVERY_CONTRACT,
-    ("vllm", "jamba", "PARSER.batch.5.a"): _RECOVERY_CONTRACT,
-    ("vllm", "llama3_json", "PARSER.batch.5.a"): _RECOVERY_CONTRACT,
-    ("vllm", "llama3_json", "PARSER.batch.5.c"): _RECOVERY_CONTRACT,
-    ("vllm", "minimax_m2", "PARSER.batch.5.a"): _RECOVERY_CONTRACT,
-    ("vllm", "minimax_m2", "PARSER.batch.5.c"): _RECOVERY_CONTRACT,
-    ("vllm", "mistral", "PARSER.batch.5.c"): _RECOVERY_CONTRACT,
-    ("vllm", "phi4", "PARSER.batch.5.a"): _RECOVERY_CONTRACT,
-    ("vllm", "phi4", "PARSER.batch.5.b"): _RECOVERY_CONTRACT,
-    ("vllm", "phi4", "PARSER.batch.5.c"): _RECOVERY_CONTRACT,
-    ("vllm", "qwen3_coder", "PARSER.batch.5.b"): _RECOVERY_CONTRACT,
-    ("sglang", "deepseek_v3", "PARSER.batch.5.a"): _RECOVERY_CONTRACT,
-    ("sglang", "deepseek_v3_1", "PARSER.batch.5.a"): _RECOVERY_CONTRACT,
-    ("sglang", "glm47", "PARSER.batch.5.a"): _RECOVERY_CONTRACT,
-    ("sglang", "harmony", "PARSER.batch.5.a"): _RECOVERY_CONTRACT,
-    ("sglang", "minimax_m2", "PARSER.batch.5.a"): _RECOVERY_CONTRACT,
-    ("sglang", "mistral", "PARSER.batch.5.a"): _RECOVERY_CONTRACT,
-    ("sglang", "qwen25", "PARSER.batch.5.a"): _RECOVERY_CONTRACT,
-    # PARSER.batch.4 sub-cases — malformed/partial JSON args; recovery contract impl-defined.
-    # vllm divergences from harness; sglang provisional .a entries inherited from prior bare-key set.
-    ("vllm", "deepseek_v3", "PARSER.batch.4.a"): _RECOVERY_CONTRACT,
-    ("vllm", "deepseek_v3", "PARSER.batch.4.b"): _RECOVERY_CONTRACT,
-    ("vllm", "deepseek_v3", "PARSER.batch.4.c"): _RECOVERY_CONTRACT,
-    ("vllm", "deepseek_v3", "PARSER.batch.4.d"): _RECOVERY_CONTRACT,
-    ("vllm", "deepseek_v3_1", "PARSER.batch.4.a"): _RECOVERY_CONTRACT,
-    ("vllm", "deepseek_v3_1", "PARSER.batch.4.b"): _RECOVERY_CONTRACT,
-    ("vllm", "deepseek_v3_1", "PARSER.batch.4.c"): _RECOVERY_CONTRACT,
-    ("vllm", "deepseek_v3_1", "PARSER.batch.4.d"): _RECOVERY_CONTRACT,
-    ("vllm", "deepseek_v3_2", "PARSER.batch.4.a"): _RECOVERY_CONTRACT,
-    ("vllm", "deepseek_v3_2", "PARSER.batch.4.c"): _RECOVERY_CONTRACT,
-    ("vllm", "deepseek_v4", "PARSER.batch.4.a"): _RECOVERY_CONTRACT,
-    ("vllm", "deepseek_v4", "PARSER.batch.4.c"): _RECOVERY_CONTRACT,
-    ("vllm", "glm47", "PARSER.batch.4.a"): _RECOVERY_CONTRACT,
-    ("vllm", "hermes", "PARSER.batch.4.b"): _RECOVERY_CONTRACT,
-    ("vllm", "jamba", "PARSER.batch.4.c"): _RECOVERY_CONTRACT,
-    ("vllm", "jamba", "PARSER.batch.4.d"): _RECOVERY_CONTRACT,
-    ("vllm", "llama3_json", "PARSER.batch.4.a"): _RECOVERY_CONTRACT,
-    ("vllm", "llama3_json", "PARSER.batch.4.b"): _RECOVERY_CONTRACT,
-    ("vllm", "llama3_json", "PARSER.batch.4.c"): _RECOVERY_CONTRACT,
-    ("vllm", "minimax_m2", "PARSER.batch.4.a"): _RECOVERY_CONTRACT,
-    ("vllm", "minimax_m2", "PARSER.batch.4.c"): _RECOVERY_CONTRACT,
-    ("vllm", "minimax_m2", "PARSER.batch.4.d"): _RECOVERY_CONTRACT,
-    ("vllm", "mistral", "PARSER.batch.4.a"): _RECOVERY_CONTRACT,
-    ("vllm", "mistral", "PARSER.batch.4.b"): _RECOVERY_CONTRACT,
-    (
-        "vllm",
-        "mistral",
-        "PARSER.batch.4.c",
-    ): "EXPECTS_ERROR(KeyError): vLLM mistral_tool_parser raises KeyError when 'name' key is missing",
-    ("vllm", "phi4", "PARSER.batch.4.c"): _RECOVERY_CONTRACT,
-    ("vllm", "phi4", "PARSER.batch.4.d"): _RECOVERY_CONTRACT,
-    ("vllm", "qwen3_coder", "PARSER.batch.4.a"): _RECOVERY_CONTRACT,
-    ("sglang", "harmony", "PARSER.batch.4.a"): _RECOVERY_CONTRACT,
-    # PARSER.batch.2 sub-cases — multi-call shape variations.
-    # .c (with surrounding narration): same trailing-space-vs-trim divergence
-    # as batch.8.c on most XML/JSON families. .b (multi-section back-to-back):
-    # vLLM's deepseek_v3_2/v4 parsers don't restart on second tool_calls fence.
-    # llama3_json across .a/.c/.d: semicolon-separated parsing differs.
-    (
-        "vllm",
-        "deepseek_v3_2",
-        "PARSER.batch.2.b",
-    ): "vLLM deepseek_v3_2 does not restart parsing on a second back-to-back fence pair",
-    ("vllm", "deepseek_v3_2", "PARSER.batch.2.c"): _TRAILING_NORMAL_TEXT_DROP,
-    (
-        "vllm",
-        "deepseek_v4",
-        "PARSER.batch.2.b",
-    ): "vLLM deepseek_v4 does not restart parsing on a second back-to-back fence pair",
-    ("vllm", "deepseek_v4", "PARSER.batch.2.c"): _TRAILING_NORMAL_TEXT_DROP,
-    ("vllm", "gemma4", "PARSER.batch.2.c"): _TRAILING_NORMAL_TEXT_DROP,
-    ("vllm", "glm47", "PARSER.batch.2.c"): _TRAILING_NORMAL_TEXT_DROP,
-    ("vllm", "hermes", "PARSER.batch.2.c"): _TRAILING_NORMAL_TEXT_DROP,
-    ("vllm", "jamba", "PARSER.batch.2.c"): _TRAILING_NORMAL_TEXT_DROP,
-    ("vllm", "kimi_k2", "PARSER.batch.2.c"): _TRAILING_NORMAL_TEXT_DROP,
-    (
-        "vllm",
-        "llama3_json",
-        "PARSER.batch.2.a",
-    ): "vLLM llama3_json does not parse semicolon-separated calls the same way Dynamo does",
-    (
-        "vllm",
-        "llama3_json",
-        "PARSER.batch.2.c",
-    ): "vLLM llama3_json does not parse semicolon-separated calls the same way Dynamo does",
-    (
-        "vllm",
-        "llama3_json",
-        "PARSER.batch.2.d",
-    ): "vLLM llama3_json does not parse semicolon-separated calls the same way Dynamo does",
-    ("vllm", "mistral", "PARSER.batch.2.c"): _TRAILING_NORMAL_TEXT_DROP,
-    ("vllm", "phi4", "PARSER.batch.2.c"): _TRAILING_NORMAL_TEXT_DROP,
-    (
-        "vllm",
-        "pythonic",
-        "PARSER.batch.2.c",
-    ): "vLLM rejects bracket-call form when surrounded by interleaved text; Dynamo extracts the calls",
-    # sglang provisional sub-case entries (carried over from prior bare-key registry).
-    # CI will surface .b/.c/.d if they diverge separately.
-    (
-        "sglang",
-        "harmony",
-        "PARSER.batch.2.a",
-    ): "Dynamo drops back-to-back commentary blocks; SGLang extracts them",
-    (
-        "sglang",
-        "mistral",
-        "PARSER.batch.2.a",
-    ): "SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits",
-    (
-        "sglang",
-        "qwen25",
-        "PARSER.batch.2.a",
-    ): "SGLang Qwen25Detector returns calls=[] on the hermes-style <tool_call>...</tool_call> format Dynamo emits",
-    # PARSER.batch.7 sub-cases — complex argument types.
-    # .a (multi-arg standard types): vLLM's XML-grammar parsers (deepseek_v3_2/v4,
-    # minimax_m2, qwen3_coder) emit JSON-typed values as raw strings while Dynamo
-    # coerces per the schema. Same pattern as old bare-key entries, now scoped to .a/.d.
-    (
-        "vllm",
-        "deepseek_v3_2",
-        "PARSER.batch.7.a",
-    ): "vLLM emits JSON-typed parameter values as raw strings; Dynamo coerces nested object/array types",
-    (
-        "vllm",
-        "deepseek_v4",
-        "PARSER.batch.7.a",
-    ): "vLLM emits JSON-typed parameter values as raw strings; Dynamo coerces nested object/array types",
-    (
-        "vllm",
-        "minimax_m2",
-        "PARSER.batch.7.a",
-    ): "vLLM emits JSON-typed parameter values as raw strings; Dynamo coerces nested object/array types",
-    (
-        "vllm",
-        "qwen3_coder",
-        "PARSER.batch.7.a",
-    ): "vLLM emits JSON-typed parameter values as raw strings; Dynamo coerces nested object/array types",
-    (
-        "vllm",
-        "phi4",
-        "PARSER.batch.7.d",
-    ): "vLLM emits JSON-typed parameter values as raw strings; Dynamo coerces nested object/array types",
-    # sglang provisional .a entries (carried over from prior bare-key registry).
-    (
-        "sglang",
-        "harmony",
-        "PARSER.batch.7.a",
-    ): "drops analysis-channel content from normal_text",
-    (
-        "sglang",
-        "mistral",
-        "PARSER.batch.7.a",
-    ): "SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits",
-    (
-        "sglang",
-        "qwen25",
-        "PARSER.batch.7.a",
-    ): "SGLang Qwen25Detector returns calls=[] on the hermes-style <tool_call>...</tool_call> format Dynamo emits",
-    # Bulk-registered sglang sub-case divergences surfaced by CI on PR #9363.
-    # Patterns: TRIM = sglang trims trailing space from preceding normal_text;
-    # NULL = sglang nullifies normal_text on malformed/recovery shapes where Dynamo preserves input;
-    # OTHER = misc sglang-specific divergences (see CI log for per-case diff).
-    (
-        "sglang",
-        "deepseek_v3",
-        "PARSER.batch.2.c",
-    ): "trims trailing space from preceding normal_text",
-    (
-        "sglang",
-        "deepseek_v3",
-        "PARSER.batch.4.a",
-    ): "sglang nullifies normal_text on malformed/recovery shapes where Dynamo preserves input",
-    (
-        "sglang",
-        "deepseek_v3",
-        "PARSER.batch.4.c",
-    ): "sglang nullifies normal_text on malformed/recovery shapes where Dynamo preserves input",
-    (
-        "sglang",
-        "deepseek_v3",
-        "PARSER.batch.4.d",
-    ): "sglang nullifies normal_text on malformed/recovery shapes where Dynamo preserves input",
-    (
-        "sglang",
-        "deepseek_v3",
-        "PARSER.batch.5.c",
-    ): "sglang nullifies normal_text on malformed/recovery shapes where Dynamo preserves input",
-    (
-        "sglang",
-        "deepseek_v3_1",
-        "PARSER.batch.2.c",
-    ): "trims trailing space from preceding normal_text",
-    (
-        "sglang",
-        "deepseek_v3_1",
-        "PARSER.batch.4.a",
-    ): "sglang nullifies normal_text on malformed/recovery shapes where Dynamo preserves input",
-    (
-        "sglang",
-        "deepseek_v3_1",
-        "PARSER.batch.4.c",
-    ): "sglang nullifies normal_text on malformed/recovery shapes where Dynamo preserves input",
-    (
-        "sglang",
-        "deepseek_v3_1",
-        "PARSER.batch.4.d",
-    ): "sglang nullifies normal_text on malformed/recovery shapes where Dynamo preserves input",
-    (
-        "sglang",
-        "deepseek_v3_1",
-        "PARSER.batch.5.c",
-    ): "sglang nullifies normal_text on malformed/recovery shapes where Dynamo preserves input",
-    (
-        "sglang",
-        "deepseek_v3_2",
-        "PARSER.batch.2.b",
-    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
-    (
-        "sglang",
-        "deepseek_v3_2",
-        "PARSER.batch.2.c",
-    ): "trims trailing space from preceding normal_text",
-    (
-        "sglang",
-        "glm47",
-        "PARSER.batch.4.a",
-    ): "sglang nullifies normal_text on malformed/recovery shapes where Dynamo preserves input",
-    (
-        "sglang",
-        "glm47",
-        "PARSER.batch.5.c",
-    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
-    (
-        "sglang",
-        "glm47",
-        "PARSER.batch.6.b",
-    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
-    (
-        "sglang",
-        "harmony",
-        "PARSER.batch.2.c",
-    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
-    (
-        "sglang",
-        "harmony",
-        "PARSER.batch.2.d",
-    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
-    (
-        "sglang",
-        "harmony",
-        "PARSER.batch.4.b",
-    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
-    (
-        "sglang",
-        "harmony",
-        "PARSER.batch.5.c",
-    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
-    (
-        "sglang",
-        "harmony",
-        "PARSER.batch.7.b",
-    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
-    (
-        "sglang",
-        "harmony",
-        "PARSER.batch.7.c",
-    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
-    (
-        "sglang",
-        "harmony",
-        "PARSER.batch.7.d",
-    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
-    (
-        "sglang",
-        "hermes",
-        "PARSER.batch.4.b",
-    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
-    (
-        "sglang",
-        "hermes",
-        "PARSER.batch.4.c",
-    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
-    (
-        "sglang",
-        "hermes",
-        "PARSER.batch.6.c",
-    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
-    (
-        "sglang",
-        "kimi_k2",
-        "PARSER.batch.2.c",
-    ): "trims trailing space from preceding normal_text",
-    (
-        "sglang",
-        "kimi_k2",
-        "PARSER.batch.4.b",
-    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
-    (
-        "sglang",
-        "minimax_m2",
-        "PARSER.batch.2.b",
-    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
-    (
-        "sglang",
-        "minimax_m2",
-        "PARSER.batch.2.c",
-    ): "trims trailing space from preceding normal_text",
-    (
-        "sglang",
-        "minimax_m2",
-        "PARSER.batch.5.c",
-    ): "sglang nullifies normal_text on malformed/recovery shapes where Dynamo preserves input",
-    (
-        "sglang",
-        "mistral",
-        "PARSER.batch.2.c",
-    ): "trims trailing space from preceding normal_text",
-    (
-        "sglang",
-        "mistral",
-        "PARSER.batch.2.d",
-    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
-    (
-        "sglang",
-        "mistral",
-        "PARSER.batch.4.a",
-    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
-    (
-        "sglang",
-        "mistral",
-        "PARSER.batch.4.b",
-    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
-    (
-        "sglang",
-        "mistral",
-        "PARSER.batch.4.d",
-    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
-    (
-        "sglang",
-        "mistral",
-        "PARSER.batch.5.c",
-    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
-    (
-        "sglang",
-        "mistral",
-        "PARSER.batch.7.b",
-    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
-    (
-        "sglang",
-        "mistral",
-        "PARSER.batch.7.c",
-    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
-    (
-        "sglang",
-        "mistral",
-        "PARSER.batch.7.d",
-    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
-    (
-        "sglang",
-        "pythonic",
-        "PARSER.batch.2.c",
-    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
-    (
-        "sglang",
-        "qwen25",
-        "PARSER.batch.2.c",
-    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
-    (
-        "sglang",
-        "qwen25",
-        "PARSER.batch.2.d",
-    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
-    (
-        "sglang",
-        "qwen25",
-        "PARSER.batch.4.b",
-    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
-    (
-        "sglang",
-        "qwen25",
-        "PARSER.batch.4.d",
-    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
-    (
-        "sglang",
-        "qwen25",
-        "PARSER.batch.7.b",
-    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
-    (
-        "sglang",
-        "qwen25",
-        "PARSER.batch.7.c",
-    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
-    (
-        "sglang",
-        "qwen25",
-        "PARSER.batch.7.d",
-    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
-    (
-        "sglang",
-        "qwen3_coder",
-        "PARSER.batch.7.a",
-    ): "sglang diverges on this sub-case (CI-surfaced; see KNOWN_DIVERGENCES log for diff)",
-    # PARSER.batch.6 sub-cases — empty-args edge cases.
-    # .c (no arguments key) flips on impl: most parsers treat missing-key as
-    # malformed, vLLM accepts as empty {}. .b (whitespace inside {}) only
-    # flips for deepseek_v3 because the fenced ```json ... ``` body is
-    # whitespace-sensitive. Other families' .a/.b match across impls.
-    (
-        "vllm",
-        "jamba",
-        "PARSER.batch.6.c",
-    ): "both return calls=[]; vLLM preserves raw input as normal_text on this recovery path, Dynamo emits empty",
-    (
-        "vllm",
-        "llama3_json",
-        "PARSER.batch.6.c",
-    ): "both return calls=[]; vLLM preserves raw input as normal_text on this recovery path, Dynamo emits empty",
-    (
-        "vllm",
-        "mistral",
-        "PARSER.batch.6.c",
-    ): "vLLM accepts call with missing arguments key as having empty args; Dynamo returns calls=[]",
-    (
-        "vllm",
-        "phi4",
-        "PARSER.batch.6.c",
-    ): "both return calls=[]; vLLM preserves raw input as normal_text on this recovery path, Dynamo emits empty",
-    (
-        "vllm",
-        "deepseek_v3",
-        "PARSER.batch.6.c",
-    ): "both return calls=[]; vLLM nullifies normal_text on this recovery path, Dynamo preserves the raw input as normal_text",
-    (
-        "vllm",
-        "deepseek_v3_1",
-        "PARSER.batch.6.c",
-    ): "both return calls=[]; vLLM nullifies normal_text on this recovery path, Dynamo preserves the raw input as normal_text",
-    (
-        "vllm",
-        "deepseek_v3",
-        "PARSER.batch.6.b",
-    ): "vLLM rejects whitespace inside empty {} when wrapped in fenced ```json``` block",
-    # ----- new families: hermes / qwen25 / mistral / jamba / llama3_json / phi4 / nemotron_nano / deepseek_v3_2 -----
-    ("vllm", "hermes", "PARSER.batch.8.a"): _TRAILING_NORMAL_TEXT_DROP,
-    ("vllm", "hermes", "PARSER.batch.8.c"): _TRAILING_NORMAL_TEXT_DROP,
-    ("vllm", "hermes", "PARSER.batch.8.d"): _TRAILING_NORMAL_TEXT_DROP,
-    ("vllm", "jamba", "PARSER.batch.8.a"): _TRAILING_NORMAL_TEXT_DROP,
-    ("vllm", "jamba", "PARSER.batch.8.c"): _TRAILING_NORMAL_TEXT_DROP,
-    ("vllm", "jamba", "PARSER.batch.8.d"): _TRAILING_NORMAL_TEXT_DROP,
-    (
-        "vllm",
-        "llama3_json",
-        "PARSER.batch.10",
-    ): "vLLM llama3_json does not parse semicolon-separated calls the same way Dynamo does",
-    ("vllm", "mistral", "PARSER.batch.8.a"): _TRAILING_NORMAL_TEXT_DROP,
-    ("vllm", "mistral", "PARSER.batch.8.c"): _TRAILING_NORMAL_TEXT_DROP,
-    # `("vllm", "mistral", "PARSER.batch.8.d")` lives in the TODO(research) block below
-    # — vLLM raises ValueError on two `[TOOL_CALLS]` envelopes; classified differently
-    # than .a/.c.
-    ("vllm", "phi4", "PARSER.batch.8.a"): _TRAILING_NORMAL_TEXT_DROP,
-    ("vllm", "phi4", "PARSER.batch.8.c"): _TRAILING_NORMAL_TEXT_DROP,
-    ("vllm", "phi4", "PARSER.batch.8.d"): _TRAILING_NORMAL_TEXT_DROP,
-    ("sglang", "deepseek_v3_2", "PARSER.batch.8.a"): _TRAILING_NORMAL_TEXT_DROP,
-    ("sglang", "deepseek_v3_2", "PARSER.batch.8.b"): _TRAILING_NORMAL_TEXT_DROP,
-    ("sglang", "deepseek_v3_2", "PARSER.batch.8.c"): _TRAILING_NORMAL_TEXT_DROP,
-    ("sglang", "deepseek_v3_2", "PARSER.batch.8.d"): _TRAILING_NORMAL_TEXT_DROP,
-    # SGLang's MistralDetector and Qwen25Detector both return empty `calls`
-    # on the bare wire formats Dynamo emits — format-detection failure rather
-    # than a recovery-contract divergence. The exact reason (different start
-    # token, schema-shape mismatch, missing chat-format envelope) is not
-    # investigated here; the cells are recorded as `X` so the matrix reflects
-    # the observed behavior.
-    (
-        "sglang",
-        "mistral",
-        "PARSER.batch.1",
-    ): "SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits",
-    (
-        "sglang",
-        "mistral",
-        "PARSER.batch.6.a",
-    ): "SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits",
-    (
-        "sglang",
-        "mistral",
-        "PARSER.batch.6.b",
-    ): "SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits",
-    ("sglang", "mistral", "PARSER.batch.8.a"): _TRAILING_NORMAL_TEXT_DROP,
-    ("sglang", "mistral", "PARSER.batch.8.b"): _TRAILING_NORMAL_TEXT_DROP,
-    ("sglang", "mistral", "PARSER.batch.8.c"): _TRAILING_NORMAL_TEXT_DROP,
-    (
-        "sglang",
-        "mistral",
-        "PARSER.batch.10",
-    ): "SGLang MistralDetector returns calls=[] on the bare [TOOL_CALLS]...[/TOOL_CALLS] format Dynamo emits",
-    (
-        "sglang",
-        "qwen25",
-        "PARSER.batch.1",
-    ): "SGLang Qwen25Detector returns calls=[] on the hermes-style <tool_call>...</tool_call> format Dynamo emits",
-    (
-        "sglang",
-        "qwen25",
-        "PARSER.batch.6.a",
-    ): "SGLang Qwen25Detector returns calls=[] on the hermes-style <tool_call>...</tool_call> format Dynamo emits",
-    (
-        "sglang",
-        "qwen25",
-        "PARSER.batch.6.b",
-    ): "SGLang Qwen25Detector returns calls=[] on the hermes-style <tool_call>...</tool_call> format Dynamo emits",
-    ("sglang", "qwen25", "PARSER.batch.8.a"): _TRAILING_NORMAL_TEXT_DROP,
-    ("sglang", "qwen25", "PARSER.batch.8.b"): _TRAILING_NORMAL_TEXT_DROP,
-    ("sglang", "qwen25", "PARSER.batch.8.c"): _TRAILING_NORMAL_TEXT_DROP,
-    ("sglang", "qwen25", "PARSER.batch.8.d"): _TRAILING_NORMAL_TEXT_DROP,
-    (
-        "sglang",
-        "qwen25",
-        "PARSER.batch.10",
-    ): "SGLang Qwen25Detector returns calls=[] on the hermes-style <tool_call>...</tool_call> format Dynamo emits",
-    (
-        "vllm",
-        "deepseek_v3_2",
-        "PARSER.batch.8.b",
-    ): "TODO(research): vLLM returns null normal_text where Dynamo surfaces the narration string",
-    (
-        "vllm",
-        "deepseek_v3_2",
-        "PARSER.batch.8.c",
-    ): "TODO(research): vLLM returns null normal_text where Dynamo surfaces the narration string",
-    (
-        "vllm",
-        "deepseek_v3_2",
-        "PARSER.batch.8.d",
-    ): "TODO(research): vLLM returns null normal_text where Dynamo surfaces the narration string",
-    (
-        "vllm",
-        "deepseek_v4",
-        "PARSER.batch.8.b",
-    ): "TODO(research): vLLM returns null normal_text where Dynamo surfaces the narration string",
-    (
-        "vllm",
-        "deepseek_v4",
-        "PARSER.batch.8.c",
-    ): "TODO(research): vLLM returns null normal_text where Dynamo surfaces the narration string",
-    (
-        "vllm",
-        "deepseek_v4",
-        "PARSER.batch.8.d",
-    ): "TODO(research): vLLM returns null normal_text where Dynamo surfaces the narration string",
-    (
-        "vllm",
-        "llama3_json",
-        "PARSER.batch.8.a",
-    ): "TODO(research): vLLM returns null normal_text where Dynamo surfaces the narration string",
-    (
-        "vllm",
-        "llama3_json",
-        "PARSER.batch.8.c",
-    ): "TODO(research): vLLM returns null normal_text where Dynamo surfaces the narration string",
-    (
-        "vllm",
-        "llama3_json",
-        "PARSER.batch.8.d",
-    ): "TODO(research): vLLM returns null normal_text where Dynamo surfaces the narration string",
-    (
-        "vllm",
-        "mistral",
-        "PARSER.batch.8.d",
-    ): "EXPECTS_ERROR(Only one BOT token): vLLM mistral_tool_parser raises ValueError on two consecutive [TOOL_CALLS] envelopes",
-    # SGLang divergences surfaced by CI (cuda{12.9,13.0} arm64). Reasons are
-    # placeholders pending per-case investigation; concrete divergence shape
-    # to be filled in by `embed_divergence_comments.py` runs against SGLang.
-    # (`sglang/deepseek_v3.b`, `sglang/deepseek_v3_1.b`, and `sglang/mistral.d`
-    # are already registered above as "trims trailing space"-class divergences;
-    # if CI still flags them XPASS-strict, those entries will need updating
-    # rather than re-adding here.)
-    (
-        "sglang",
-        "kimi_k2",
-        "PARSER.batch.8.a",
-    ): "TODO(research): SGLang diverges on this case; investigate vs Dynamo's expected",
-    (
-        "sglang",
-        "kimi_k2",
-        "PARSER.batch.8.b",
-    ): "TODO(research): SGLang diverges on this case; investigate vs Dynamo's expected",
-    (
-        "sglang",
-        "kimi_k2",
-        "PARSER.batch.8.c",
-    ): "TODO(research): SGLang diverges on this case; investigate vs Dynamo's expected",
-    (
-        "sglang",
-        "kimi_k2",
-        "PARSER.batch.8.d",
-    ): "TODO(research): SGLang diverges on this case; investigate vs Dynamo's expected",
 }
 
 
@@ -827,9 +79,9 @@ def _load_fixtures() -> list[tuple[str, str, dict[str, Any]]]:
     Both schemas are
         {family: "...", mode: "batch", cases: {PARSER.batch.<id>: {...}, ...}}
     Case keys are the full PARSER_CASES.md ID (e.g. `PARSER.batch.1` or
-    `PARSER.batch.8.a`) so they match KNOWN_DIVERGENCES keys and parametrize
-    IDs directly. The merge across the two layouts is conflict-free as long
-    as a given case ID lives in exactly one file.
+    `PARSER.batch.8.a`) so they match parametrize IDs directly. The merge
+    across the two layouts is conflict-free as long as a given case ID
+    lives in exactly one file.
     """
     out = []
     for fp in sorted(FIXTURES_ROOT.glob("*/PARSER.*.yaml")):
@@ -846,12 +98,7 @@ FIXTURES = _load_fixtures()
 def _marks_for(impl: str) -> list:
     """Per-param marks. Only the impl marker (`vllm`/`sglang`) — used by CI
     shards to filter via `-m vllm` / `-m sglang`. `dynamo` gets no marker so
-    it runs in every shard (it's the reference we compare against).
-
-    Known-divergence xfail handling is intentionally NOT a parametrize-time
-    mark — it lives inline in the test body (see `XPASS-strict` block) so a
-    parser/runtime crash on a known-divergence case still hits `pytest.fail`
-    hard instead of being swallowed by an outer `xfail` wrapper."""
+    it runs in every shard (it's the reference we compare against)."""
     if impl in ("vllm", "sglang"):
         return [getattr(pytest.mark, impl)]
     return []
@@ -885,56 +132,55 @@ def test_parity(
     parse_mod = importlib.import_module(f"tests.parity.parser.{impl_name}")
     got = parse_mod.parse(family, fixture["model_text"], fixture.get("tools"))
 
-    # Runtime / parser errors. Wrappers prefix the env-shaped case
-    # ("impl has no parser registered for this family") with `UNAVAILABLE:`
-    # so we can still skip those cleanly.
-    #
-    # Errors on cases NOT in KNOWN_DIVERGENCES are real bugs → fail HARD.
-    #
-    # Errors on cases IN KNOWN_DIVERGENCES are absorbed as xfail ONLY when the
-    # divergence entry's reason explicitly opts into error-absorption via the
-    # `EXPECTS_ERROR(<pattern>):` prefix and the actual error matches the
-    # pattern. Plain-string divergences (the common case — value mismatches)
-    # do NOT absorb errors. This keeps an unrelated wrapper/runtime crash
-    # (e.g. an upstream API rename) from passing silently on a row that's
-    # only supposed to diverge on output values.
-    #
-    # Example entry that DOES absorb a specific error:
-    #   ("vllm", "mistral", "PARSER.batch.8.d"):
-    #       "EXPECTS_ERROR(Only one BOT token): vllm raises ValueError on two TOOL_CALLS envelopes"
-    div = KNOWN_DIVERGENCES.get((impl_name, family, case_id))
-    if got.error:
-        if got.error.startswith("UNAVAILABLE:"):
-            pytest.skip(f"{impl_name} unavailable for {family}: {got.error}")
-        if div is not None:
-            import re as _re
+    # Per-impl expected from YAML. Missing peer key → peer must match dynamo.
+    expected_map = fixture["expected"]
+    spec = expected_map.get(impl_name) or expected_map["dynamo"]
+    is_divergent = isinstance(spec, dict) and spec.get("diverges") is True
 
-            m = _re.match(r"^EXPECTS_ERROR\((.+?)\):\s*(.*)$", div, _re.DOTALL)
-            if m and _re.search(m.group(1), got.error):
+    # Wrapper-level "no peer parser for this family" — clean skip.
+    if got.error and got.error.startswith("UNAVAILABLE:"):
+        pytest.skip(f"{impl_name} unavailable for {family}: {got.error}")
+
+    # Errors absorbed only when the YAML opts in via `expected_error_pattern`
+    # and the actual error matches the pattern. Otherwise, errors are real
+    # bugs and fail HARD (an unrelated wrapper/runtime crash must not hide
+    # behind a divergence entry that's only supposed to differ on values).
+    if got.error:
+        if is_divergent and (pat := spec.get("expected_error_pattern")):
+            if re.search(pat, got.error):
                 pytest.xfail(
-                    f"known divergence (error matched /{m.group(1)}/): {m.group(2)}"
+                    f"known divergence (error matched /{pat}/): {spec.get('reason', '')}"
                 )
         pytest.fail(f"{impl_name} crashed on {family}/{case_id}: {got.error}")
 
-    expected = common.ParseResult(
-        calls=fixture["expected"]["calls"],
-        normal_text=fixture["expected"].get("normal_text"),
-    )
     got_canonical = common.canonical(got.to_dict())
-    expected_canonical = common.canonical(expected.to_dict())
+    dynamo_spec = expected_map["dynamo"]
+    dynamo_canonical = common.canonical(
+        common.ParseResult(
+            calls=dynamo_spec["calls"],
+            normal_text=dynamo_spec.get("normal_text"),
+        ).to_dict()
+    )
 
-    # Known divergences: xfail the value-diff assertion only. If the values
-    # now match, surface that as a registry-staleness failure (XPASS-strict
-    # equivalent) instead of silently passing.
-    if div is not None:
-        if got_canonical == expected_canonical:
+    # Divergent peer (no concrete expected output recorded yet): the peer
+    # must produce SOMETHING different from dynamo. If it now matches dynamo,
+    # the YAML override is stale — surface as XPASS-strict failure.
+    if is_divergent:
+        if got_canonical == dynamo_canonical:
             pytest.fail(
-                f"XPASS-strict: known divergence ({impl_name},{family},{case_id}) "
-                f"now matches expected — remove from KNOWN_DIVERGENCES. "
-                f"Reason was: {div}"
+                f"XPASS-strict: ({impl_name},{family},{case_id}) now matches dynamo — "
+                f"remove the `expected.{impl_name}` block from the fixture. "
+                f"Reason was: {spec.get('reason', '<no reason>')}"
             )
-        pytest.xfail(f"known divergence: {div}")
+        pytest.xfail(f"known divergence: {spec.get('reason', '<no reason>')}")
 
+    # Non-divergent peer (or dynamo itself): must match the recorded expected.
+    expected_canonical = common.canonical(
+        common.ParseResult(
+            calls=spec["calls"],
+            normal_text=spec.get("normal_text"),
+        ).to_dict()
+    )
     assert got_canonical == expected_canonical, (
         f"\nimpl:     {impl_name}\n"
         f"family:   {family}\n"


### PR DESCRIPTION
#### Overview:

Moves all 218 `KNOWN_DIVERGENCES` registry entries from `tests/parity/parser/test_parity_parser.py` into per-case YAML blocks, restructuring `expected:` to be keyed by impl. Test file drops 944 → 190 lines (-79%); divergence info now lives next to the `model_text` that produced it.

#### Details:

- **How is this fixed?** Variant D schema: each case's `expected:` is now a dict keyed by impl. `dynamo` is the always-present oracle. Peer keys (`vllm`, `sglang`) are added only when they diverge; absence means "peer must match dynamo." Divergent peer blocks carry `diverges: true` + `reason: "..."` (+ optional `expected_error_pattern: "..."` for the old `EXPECTS_ERROR(<pat>):` contract). The test dispatch becomes plain "look up `expected.<impl>`, fall back to `expected.dynamo`, compare or xfail" — ~30 lines instead of the prior 70 + the 740-line dict.

```yaml
expected:
  dynamo:                          # oracle, always required
    calls: [...]
    normal_text: '...'
  vllm:                            # OPTIONAL: only when vLLM diverges
    diverges: true
    reason: "<why>"
    expected_error_pattern: "..."  # OPTIONAL: EXPECTS_ERROR contract
  sglang:                          # OPTIONAL: only when SGLang diverges
    diverges: true
    reason: "..."
```

- `KNOWN_DIVERGENCES` (218 entries) deleted entirely. Each entry migrated 1:1 into the corresponding case's `expected.<impl>` block.
- `regenerate_fixtures.py` emits Variant D and preserves any on-disk peer overrides across regen runs (so a re-run with `--overwrite` doesn't clobber hand-curated divergence blocks).
- README updated: 12 references to `KNOWN_DIVERGENCES` rewritten to point at the `expected.<impl>` YAML blocks. The "add a divergence" / "remove an XPASS-strict divergence" recipes now show the YAML edit instead of the Python dict edit.
- Migration was text-based (not yaml round-trip) — anchors `&id001` / `*id001` and inline comments preserved across all 133 fixtures.
- `EXPECTS_ERROR(<pat>):` reason prefixes split into `expected_error_pattern: <pat>` + `reason: <rest>`. XPASS-strict semantics unchanged: a peer that newly matches dynamo fails noisily, pointing at the YAML block to delete.

#### Verification:

Static-load all 450 cases across 133 fixtures: every case has `expected.dynamo`; 218 peer divergence entries present (matches original `KNOWN_DIVERGENCES` count). Test file parses + collects cleanly. No container runtime verification yet — CI will exercise the dynamo path; vLLM/SGLang paths exercise on the framework matrix.

#### Where should the reviewer start?

`tests/parity/parser/test_parity_parser.py` (the 880-line shrink), then `tests/parity/README.md` (schema doc), then any one fixture e.g. `tests/parity/parser/fixtures/kimi_k2/PARSER.batch.8.yaml` to see the new per-case shape on a high-divergence file.

/coderabbit profile chill
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9472" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reorganized parser parity test framework to track implementation-specific behavior differences directly within test fixture declarations rather than through a centralized registry.

* **Documentation**
  * Updated parity testing documentation to reflect the new fixture-based divergence tracking approach and revised workflows for identifying and resolving parser implementation differences.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9472)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->