### PR TITLE
docs(parsers): clarify Dynamo vs engine-fallback parser use cases and polish examples

### DIFF
--- a/docs/reasoning/README.md
+++ b/docs/reasoning/README.md
@@ -15,8 +15,8 @@ Dynamo's own registry or in the upstream engine (vLLM, SGLang).
 
 | Path | When to use | Page |
 |------|-------------|------|
-| **Dynamo** | Dynamo ships a Rust parser for the model's reasoning format. Lowest latency, KV-routable, the default path. | [Reasoning Parsing (Dynamo)](dynamo.md) |
-| **Engine Fallback** | Dynamo does not have a parser, but the upstream engine (vLLM or SGLang) does. Tokenization stays on the frontend, parsing delegates to the engine's Python preprocessor. | [Reasoning Parsing (Engine Fallback)](engine-fallback.md) |
+| **Dynamo** | Dynamo ships a Rust parser for the model's reasoning format. Lowest latency, the default path. | [Reasoning Parsing (Dynamo)](dynamo.md) |
+| **Engine Fallback** | Use the framework's implementation (vLLM or SGLang) for pre/post processing, including tool call and reasoning parsing - ensure consistency with framework behavior. | [Reasoning Parsing (Engine Fallback)](engine-fallback.md) |
 
 Start with the Dynamo path. Fall back to the engine path only when Dynamo's
 registry does not list a parser for your model.

--- a/docs/reasoning/README.md
+++ b/docs/reasoning/README.md
@@ -8,8 +8,7 @@ subtitle: Separate reasoning content from assistant output for chain-of-thought 
 Some models emit reasoning or thinking content separately from their final
 response. Dynamo can split that output into `reasoning_content` and normal
 assistant content by configuring a reasoning parser. As with tool calling,
-there are two ways to do this depending on whether the parser lives in
-Dynamo's own registry or in the upstream engine (vLLM, SGLang).
+there are two ways to do this to ensure wide coverage and day0 model support.
 
 ## Choose a parsing path
 

--- a/docs/reasoning/dynamo.md
+++ b/docs/reasoning/dynamo.md
@@ -78,7 +78,7 @@ Reasoning parsing happens before tool call parsing. If a model emits both reason
 ### Launch Dynamo Frontend and Backend
 
 ```bash
-# launch backend worker
+# launch backend worker (or dynamo.sglang)
 python -m dynamo.vllm --model Qwen/Qwen3.5-4B --dyn-tool-call-parser qwen3_coder --dyn-reasoning-parser qwen3
 
 # launch frontend worker

--- a/docs/reasoning/dynamo.md
+++ b/docs/reasoning/dynamo.md
@@ -88,7 +88,7 @@ python -m dynamo.frontend
 ### Reasoning Request Example
 
 ```bash
-curl -s http://localhost:8081/v1/chat/completions \
+curl -s http://localhost:8000/v1/chat/completions \
   -H 'Content-Type: application/json' \
   -d '{
     "model": "Qwen/Qwen3.5-4B",

--- a/docs/reasoning/dynamo.md
+++ b/docs/reasoning/dynamo.md
@@ -78,9 +78,39 @@ Reasoning parsing happens before tool call parsing. If a model emits both reason
 ### Launch Dynamo Frontend and Backend
 
 ```bash
-# launch backend worker (or dynamo.sglang)
-python -m dynamo.vllm --model Qwen/Qwen3.5-4B --dyn-tool-call-parser qwen3_coder --dyn-reasoning-parser qwen3
+# launch backend worker (or dynamo.vllm)
+python -m dynamo.sglang --model Qwen/Qwen3.5-4B --dyn-tool-call-parser qwen3_coder --dyn-reasoning-parser qwen3
 
 # launch frontend worker
 python -m dynamo.frontend
+```
+
+### Reasoning Request Example
+
+```bash
+curl -s http://localhost:8081/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "Qwen/Qwen3.5-4B",
+    "messages": [{"role": "user", "content": "If a train leaves at 3pm going 60 mph and another leaves at 4pm going 80 mph, when does the second catch up?"}]
+  }'
+```
+
+Dynamo splits the model output so the chain-of-thought lands in
+`reasoning_content` and the user-facing answer stays in `content`:
+
+```json
+{
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "reasoning_content": "The first train has a 1-hour head start at 60 mph, so it is 60 miles ahead at 4pm. The second train closes the gap at 80 - 60 = 20 mph. 60 / 20 = 3 hours after 4pm.",
+        "content": "The second train catches up at 7pm."
+      },
+      "finish_reason": "stop"
+    }
+  ]
+}
 ```

--- a/docs/reasoning/dynamo.md
+++ b/docs/reasoning/dynamo.md
@@ -72,3 +72,15 @@ Some models need both parsers configured together. Common pairings include:
 ## Tool Calling Interplay
 
 Reasoning parsing happens before tool call parsing. If a model emits both reasoning content and tool calls, configure both parsers so Dynamo can first separate reasoning text and then parse tool calls from the remaining assistant output.
+
+## Examples
+
+### Launch Dynamo Frontend and Backend
+
+```bash
+# launch backend worker
+python -m dynamo.vllm --model Qwen/Qwen3.5-4B --dyn-tool-call-parser qwen3_coder --dyn-reasoning-parser qwen3
+
+# launch frontend worker
+python -m dynamo.frontend
+```

--- a/docs/reasoning/engine-fallback.md
+++ b/docs/reasoning/engine-fallback.md
@@ -13,13 +13,6 @@ For Dynamo-native parsers, see [Reasoning Parsing (Dynamo)](dynamo.md). For
 the equivalent tool-call fallback, see
 [Tool Call Parsing (Engine Fallback)](../tool-calling/engine-fallback.md).
 
-> [!NOTE]
-> `--dyn-reasoning-parser` selects the **Dynamo-native** parser path, while
-> `--reasoning-parser` selects the **engine fallback** (vLLM or SGLang)
-> parser path. The accepted values for each flag come from a different
-> registry and may differ slightly based on the definitions from each
-> framework (e.g., vLLM's `nemotron_v3` vs Dynamo's `nemotron3`).
-
 > [!WARNING]
 > **Known Issue:** Engine-fallback reasoning parsing does not currently work
 > with [disaggregated serving](../features/disaggregated-serving/README.md).
@@ -32,6 +25,13 @@ the equivalent tool-call fallback, see
 |---|---|---|---|---|
 | **vLLM chat processor** | `--dyn-chat-processor vllm --reasoning-parser <name>` | *(none)* | Yes | Parsing runs in vLLM's Python preprocessor. See [vLLM Chat Processor](../backends/vllm/vllm-chat-processor.md). |
 | **SGLang chat processor** | `--dyn-chat-processor sglang --reasoning-parser <name>` | *(none)* | Yes | Parsing runs in SGLang's Python preprocessor. See [SGLang Chat Processor](../backends/sglang/sglang-chat-processor.md). |
+
+> [!NOTE]
+> `--dyn-reasoning-parser` selects the **Dynamo-native** parser path, while
+> `--reasoning-parser` selects the **engine fallback** (vLLM or SGLang)
+> parser path. The accepted values for each flag come from a different
+> registry and may differ slightly based on the definitions from each
+> framework (e.g., vLLM's `nemotron_v3` vs Dynamo's `nemotron3`).
 
 ## Examples
 

--- a/docs/reasoning/engine-fallback.md
+++ b/docs/reasoning/engine-fallback.md
@@ -13,6 +13,13 @@ For Dynamo-native parsers, see [Reasoning Parsing (Dynamo)](dynamo.md). For
 the equivalent tool-call fallback, see
 [Tool Call Parsing (Engine Fallback)](../tool-calling/engine-fallback.md).
 
+> [!NOTE]
+> `--dyn-reasoning-parser` selects the **Dynamo-native** parser path, while
+> `--reasoning-parser` selects the **engine fallback** (vLLM or SGLang)
+> parser path. The accepted values for each flag come from a different
+> registry and may differ slightly based on the definitions from each
+> framework (e.g., vLLM's `nemotron_v3` vs Dynamo's `nemotron3`).
+
 > [!WARNING]
 > **Known Issue:** Engine-fallback reasoning parsing does not currently work
 > with [disaggregated serving](../features/disaggregated-serving/README.md).
@@ -25,11 +32,6 @@ the equivalent tool-call fallback, see
 |---|---|---|---|---|
 | **vLLM chat processor** | `--dyn-chat-processor vllm --reasoning-parser <name>` | *(none)* | Yes | Parsing runs in vLLM's Python preprocessor. See [vLLM Chat Processor](../backends/vllm/vllm-chat-processor.md). |
 | **SGLang chat processor** | `--dyn-chat-processor sglang --reasoning-parser <name>` | *(none)* | Yes | Parsing runs in SGLang's Python preprocessor. See [SGLang Chat Processor](../backends/sglang/sglang-chat-processor.md). |
-
-Upstream parser names come from the engine's registry and may differ from
-Dynamo's name for the same model (e.g., vLLM's `nemotron_v3` vs Dynamo's
-`nemotron3`). They are pinned to the engine version shipped in the Dynamo
-container.
 
 ## Examples
 

--- a/docs/tool-calling/README.md
+++ b/docs/tool-calling/README.md
@@ -17,8 +17,8 @@ parser lives in Dynamo's own registry or in the upstream engine (vLLM, SGLang).
 
 | Path | When to use | Page |
 |------|-------------|------|
-| **Dynamo** | Dynamo ships a Rust parser for the model's tool-call format. Lowest latency, KV-routable, the default path. | [Tool Call Parsing (Dynamo)](dynamo.md) |
-| **Engine Fallback** | Dynamo does not have a parser, but the upstream engine (vLLM or SGLang) does. Tokenization stays on the frontend, parsing delegates to the engine's Python preprocessor. | [Tool Call Parsing (Engine Fallback)](engine-fallback.md) |
+| **Dynamo** | Dynamo ships a Rust parser for the model's tool-call format. Lowest latency, the default path. | [Tool Call Parsing (Dynamo)](dynamo.md) |
+| **Engine Fallback** | Use the framework's implementation (vLLM or SGLang) for pre/post processing, including tool call and reasoning parsing - ensure consistency with framework behavior. | [Tool Call Parsing (Engine Fallback)](engine-fallback.md) |
 
 Start with the Dynamo path. Fall back to the engine path only when Dynamo's
 registry does not list a parser for your model.

--- a/docs/tool-calling/dynamo.md
+++ b/docs/tool-calling/dynamo.md
@@ -28,9 +28,6 @@ To enable this feature, you should set the following flag while launching the ba
 python -m dynamo.<backend> --help
 ```
 
-> [!NOTE]
-> If no tool call parser is provided by the user, Dynamo will try to use default tool call parsing based on &lt;TOOLCALL&gt; and &lt;|python_tag|&gt; tool tags.
-
 > [!TIP]
 > If your model's default chat template doesn't support tool calling, but the model itself does, you can specify a custom chat template per worker
 > with `python -m dynamo.<backend> --custom-jinja-template </path/to/template.jinja>`.

--- a/docs/tool-calling/dynamo.md
+++ b/docs/tool-calling/dynamo.md
@@ -119,7 +119,9 @@ OpenAI-compatible `tool_calls` entries on the response:
     {
       "index": 0,
       "message": {
+        "role": "assistant",
         "content": null,
+        "reasoning_content": "The user is asking about the weather in two cities: San Francisco and New York. I need to call the get_weather function for each city. I'll make two separate function calls to get the weather information for both locations.\n",
         "tool_calls": [
           {
             "id": "call-56223a95-3d14-4433-a94e-011f106c0e40",
@@ -137,9 +139,7 @@ OpenAI-compatible `tool_calls` entries on the response:
               "arguments": "{\"location\":\"New York\"}"
             }
           }
-        ],
-        "role": "assistant",
-        "reasoning_content": "The user is asking about the weather in two cities: San Francisco and New York. I need to call the get_weather function for each city. I'll make two separate function calls to get the weather information for both locations.\n"
+        ]
       },
       "finish_reason": "tool_calls",
       "logprobs": null

--- a/docs/tool-calling/dynamo.md
+++ b/docs/tool-calling/dynamo.md
@@ -91,7 +91,7 @@ curl -s http://localhost:8000/v1/chat/completions \
   -d '{
     "model": "Qwen/Qwen3.5-4B",
     "messages": [
-      {"role": "user", "content": "What is the weather in San Francisco?"}
+      {"role": "user", "content": "What is the weather in San Francisco and New York?"}
     ],
     "tools": [{
       "type": "function",
@@ -109,30 +109,44 @@ curl -s http://localhost:8000/v1/chat/completions \
   }'
 ```
 
-Dynamo parses the tool call out of the model output and surfaces it as an
-OpenAI-compatible `tool_calls` entry on the response:
+Dynamo parses the tool calls out of the model output and surfaces them as
+OpenAI-compatible `tool_calls` entries on the response:
 
 ```json
 {
+  "id": "chatcmpl-b415caad-9be0-4d9e-ac6d-9d23bfe57703",
   "choices": [
     {
       "index": 0,
       "message": {
-        "role": "assistant",
         "content": null,
         "tool_calls": [
           {
-            "id": "call_0",
+            "id": "call-56223a95-3d14-4433-a94e-011f106c0e40",
             "type": "function",
             "function": {
               "name": "get_weather",
-              "arguments": "{\"location\": \"San Francisco\"}"
+              "arguments": "{\"location\":\"San Francisco\"}"
+            }
+          },
+          {
+            "id": "call-d5b5772b-6b0c-4120-ad01-623278a937fe",
+            "type": "function",
+            "function": {
+              "name": "get_weather",
+              "arguments": "{\"location\":\"New York\"}"
             }
           }
-        ]
+        ],
+        "role": "assistant",
+        "reasoning_content": "The user is asking about the weather in two cities: San Francisco and New York. I need to call the get_weather function for each city. I'll make two separate function calls to get the weather information for both locations.\n"
       },
-      "finish_reason": "tool_calls"
+      "finish_reason": "tool_calls",
+      "logprobs": null
     }
-  ]
+  ],
+  "created": 1778653281,
+  "model": "Qwen/Qwen3.5-4B",
+  ...
 }
 ```

--- a/docs/tool-calling/dynamo.md
+++ b/docs/tool-calling/dynamo.md
@@ -85,41 +85,54 @@ python -m dynamo.frontend
 
 ### Tool Calling Request Example
 
-```python
-from openai import OpenAI
-import json
-
-client = OpenAI(base_url="http://localhost:8000/v1", api_key="dummy")
-
-def get_weather(location: str, unit: str):
-    return f"Getting the weather for {location} in {unit}..."
-tool_functions = {"get_weather": get_weather}
-
-tools = [{
-    "type": "function",
-    "function": {
+```bash
+curl -s http://localhost:8000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "Qwen/Qwen3.5-4B",
+    "messages": [
+      {"role": "user", "content": "What is the weather in San Francisco?"}
+    ],
+    "tools": [{
+      "type": "function",
+      "function": {
         "name": "get_weather",
-        "description": "Get the current weather in a given location",
+        "description": "Get the current weather for a location.",
         "parameters": {
-            "type": "object",
-            "properties": {
-                "location": {"type": "string", "description": "City and state, e.g., 'San Francisco, CA'"},
-                "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}
-            },
-            "required": ["location", "unit"]
+          "type": "object",
+          "properties": {"location": {"type": "string"}},
+          "required": ["location"]
         }
-    }
-}]
+      }
+    }],
+    "tool_choice": "auto"
+  }'
+```
 
-response = client.chat.completions.create(
-    model="Qwen/Qwen3.5-4B",
-    messages=[{"role": "user", "content": "What's the weather like in San Francisco in Celsius?"}],
-    tools=tools,
-    tool_choice="auto",
-    max_tokens=10000
-)
-tool_call = response.choices[0].message.tool_calls[0].function
-print(f"Function called: {tool_call.name}")
-print(f"Arguments: {tool_call.arguments}")
-print(f"Result: {tool_functions[tool_call.name](**json.loads(tool_call.arguments))}")
+Dynamo parses the tool call out of the model output and surfaces it as an
+OpenAI-compatible `tool_calls` entry on the response:
+
+```json
+{
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": null,
+        "tool_calls": [
+          {
+            "id": "call_0",
+            "type": "function",
+            "function": {
+              "name": "get_weather",
+              "arguments": "{\"location\": \"San Francisco\"}"
+            }
+          }
+        ]
+      },
+      "finish_reason": "tool_calls"
+    }
+  ]
+}
 ```

--- a/docs/tool-calling/dynamo.md
+++ b/docs/tool-calling/dynamo.md
@@ -76,8 +76,8 @@ parser exists for this format.
 ### Launch Dynamo Frontend and Backend
 
 ```bash
-# launch backend worker
-python -m dynamo.vllm --model Qwen/Qwen3.5-4B --dyn-tool-call-parser qwen3_coder --dyn-reasoning-parser qwen3
+# launch backend worker (or dynamo.vllm)
+python -m dynamo.sglang --model Qwen/Qwen3.5-4B --dyn-tool-call-parser qwen3_coder --dyn-reasoning-parser qwen3
 
 # launch frontend worker
 python -m dynamo.frontend

--- a/docs/tool-calling/dynamo.md
+++ b/docs/tool-calling/dynamo.md
@@ -89,7 +89,7 @@ python -m dynamo.frontend
 from openai import OpenAI
 import json
 
-client = OpenAI(base_url="http://localhost:8081/v1", api_key="dummy")
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="dummy")
 
 def get_weather(location: str, unit: str):
     return f"Getting the weather for {location} in {unit}..."

--- a/docs/tool-calling/dynamo.md
+++ b/docs/tool-calling/dynamo.md
@@ -77,7 +77,7 @@ parser exists for this format.
 
 ```bash
 # launch backend worker
-python -m dynamo.vllm --model openai/gpt-oss-20b --dyn-tool-call-parser harmony
+python -m dynamo.vllm --model Qwen/Qwen3.5-4B --dyn-tool-call-parser qwen3_coder --dyn-reasoning-parser qwen3
 
 # launch frontend worker
 python -m dynamo.frontend
@@ -112,7 +112,7 @@ tools = [{
 }]
 
 response = client.chat.completions.create(
-    model="openai/gpt-oss-20b",
+    model="Qwen/Qwen3.5-4B",
     messages=[{"role": "user", "content": "What's the weather like in San Francisco in Celsius?"}],
     tools=tools,
     tool_choice="auto",

--- a/docs/tool-calling/engine-fallback.md
+++ b/docs/tool-calling/engine-fallback.md
@@ -13,6 +13,13 @@ For Dynamo-native parsers, see [Tool Call Parsing (Dynamo)](dynamo.md). For
 the equivalent reasoning fallback, see
 [Reasoning Parsing (Engine Fallback)](../reasoning/engine-fallback.md).
 
+> [!NOTE]
+> `--dyn-tool-call-parser` selects the **Dynamo-native** parser path, while
+> `--tool-call-parser` selects the **engine fallback** (vLLM or SGLang)
+> parser path. The accepted values for each flag come from a different
+> registry and may differ slightly based on the definitions from each
+> framework (e.g., SGLang's `deepseekv3` vs Dynamo's `deepseek_v3`).
+
 > [!WARNING]
 > **Known Issue:** Engine-fallback tool call parsing does not currently work
 > with [disaggregated serving](../features/disaggregated-serving/README.md).

--- a/docs/tool-calling/engine-fallback.md
+++ b/docs/tool-calling/engine-fallback.md
@@ -13,13 +13,6 @@ For Dynamo-native parsers, see [Tool Call Parsing (Dynamo)](dynamo.md). For
 the equivalent reasoning fallback, see
 [Reasoning Parsing (Engine Fallback)](../reasoning/engine-fallback.md).
 
-> [!NOTE]
-> `--dyn-tool-call-parser` selects the **Dynamo-native** parser path, while
-> `--tool-call-parser` selects the **engine fallback** (vLLM or SGLang)
-> parser path. The accepted values for each flag come from a different
-> registry and may differ slightly based on the definitions from each
-> framework (e.g., SGLang's `deepseekv3` vs Dynamo's `deepseek_v3`).
-
 > [!WARNING]
 > **Known Issue:** Engine-fallback tool call parsing does not currently work
 > with [disaggregated serving](../features/disaggregated-serving/README.md).
@@ -32,6 +25,13 @@ the equivalent reasoning fallback, see
 |---|---|---|---|---|
 | **vLLM chat processor** | `--dyn-chat-processor vllm --tool-call-parser <name>` | *(none)* | Yes | Parsing runs in vLLM's Python preprocessor. See [vLLM Chat Processor](../backends/vllm/vllm-chat-processor.md). |
 | **SGLang chat processor** | `--dyn-chat-processor sglang --tool-call-parser <name>` | *(none)* | Yes | Parsing runs in SGLang's Python preprocessor. See [SGLang Chat Processor](../backends/sglang/sglang-chat-processor.md). |
+
+> [!NOTE]
+> `--dyn-tool-call-parser` selects the **Dynamo-native** parser path, while
+> `--tool-call-parser` selects the **engine fallback** (vLLM or SGLang)
+> parser path. The accepted values for each flag come from a different
+> registry and may differ slightly based on the definitions from each
+> framework (e.g., SGLang's `deepseekv3` vs Dynamo's `deepseek_v3`).
 
 ## Examples
 

--- a/docs/tool-calling/engine-fallback.md
+++ b/docs/tool-calling/engine-fallback.md
@@ -33,11 +33,6 @@ the equivalent reasoning fallback, see
 | **vLLM chat processor** | `--dyn-chat-processor vllm --tool-call-parser <name>` | *(none)* | Yes | Parsing runs in vLLM's Python preprocessor. See [vLLM Chat Processor](../backends/vllm/vllm-chat-processor.md). |
 | **SGLang chat processor** | `--dyn-chat-processor sglang --tool-call-parser <name>` | *(none)* | Yes | Parsing runs in SGLang's Python preprocessor. See [SGLang Chat Processor](../backends/sglang/sglang-chat-processor.md). |
 
-Upstream parser names come from the engine's registry and may differ from
-Dynamo's name for the same model (e.g., SGLang's `deepseekv3` vs Dynamo's
-`deepseek_v3`). They are pinned to the engine version shipped in the Dynamo
-container.
-
 ## Examples
 
 ```bash


### PR DESCRIPTION
## Summary

- Drop the inaccurate "KV-routable" descriptor from the Dynamo row in both `docs/tool-calling/README.md` and `docs/reasoning/README.md` (KV routing is independent of which parser path is used).
- Reword the Engine Fallback row to describe what the path actually does: use the framework's implementation (vLLM or SGLang) for pre/post processing, including tool call and reasoning parsing - to ensure consistency with framework behavior.

## Test plan

- [ ] Render the Fern docs and confirm the two parser README tables read correctly.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9476" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined guidance on configuring and selecting parsing approaches for reasoning and tool-calling features
  * Clarified recommended use cases and benefits for different parsing path options

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9476)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->