### PR TITLE
fix: benchmark docs to use DYN_TOKENIZER env var

### DIFF
--- a/benchmarks/frontend/README.md
+++ b/benchmarks/frontend/README.md
@@ -235,7 +235,7 @@ artifacts/sweep_20260330_143000/
 
 The `dgd/templates/` directory contains DynamoGraphDeployment YAML templates
 for k8s mode. Template variables (e.g., `${DGD_NAME}`, `${IMAGE}`,
-`${DYN_TOKENIZER_BACKEND}`) are substituted by the sweep runner at deploy time.
+`${DYN_TOKENIZER}`) are substituted by the sweep runner at deploy time.
 
 | Template | Backend | GPU required | Description |
 |----------|---------|-------------|-------------|

--- a/benchmarks/frontend/dgd/templates/mocker.yaml
+++ b/benchmarks/frontend/dgd/templates/mocker.yaml
@@ -6,7 +6,7 @@
 # Template variables (substituted by sweep_runner.py --deploy-template):
 #   ${DGD_NAME}              - DynamoGraphDeployment name
 #   ${IMAGE}                 - Container image
-#   ${DYN_TOKENIZER_BACKEND} - "default" (hf) or "fast"
+#   ${DYN_TOKENIZER}         - "default" (hf) or "fastokens"
 #   ${FRONTEND_PORT}         - Frontend HTTP port
 #   ${ROUTER_MODE}           - Frontend router mode
 #   ${MODEL_PATH}            - HF model ID
@@ -41,8 +41,8 @@ ${FRONTEND_IMAGE_PULL_SECRETS_BLOCK}
           args:
             - python3 -m dynamo.frontend --router-mode ${ROUTER_MODE} --http-port ${FRONTEND_PORT}
           env:
-            - name: DYN_TOKENIZER_BACKEND
-              value: "${DYN_TOKENIZER_BACKEND}"
+            - name: DYN_TOKENIZER
+              value: "${DYN_TOKENIZER}"
             - name: DYN_PERF_DIAG
               value: "1"
             - name: HF_TOKEN

--- a/benchmarks/frontend/dgd/templates/vllm-gpt-oss-20b.yaml
+++ b/benchmarks/frontend/dgd/templates/vllm-gpt-oss-20b.yaml
@@ -12,7 +12,7 @@
 # Template variables (substituted by sweep_runner.py --deploy-template):
 #   ${DGD_NAME}              - DynamoGraphDeployment name
 #   ${IMAGE}                 - Container image
-#   ${DYN_TOKENIZER_BACKEND} - "default" (hf) or "fast"
+#   ${DYN_TOKENIZER}         - "default" (hf) or "fastokens"
 #   ${FRONTEND_PORT}         - Frontend HTTP port (default: 8000)
 #   ${ROUTER_MODE}           - Frontend router mode (default: round-robin)
 #   ${MODEL}                 - Model path (HF ID or local path on PVC)
@@ -57,8 +57,8 @@ ${FRONTEND_IMAGE_PULL_SECRETS_BLOCK}
           args:
             - python3 -m dynamo.frontend --router-mode ${ROUTER_MODE} --http-port ${FRONTEND_PORT}
           env:
-            - name: DYN_TOKENIZER_BACKEND
-              value: "${DYN_TOKENIZER_BACKEND}"
+            - name: DYN_TOKENIZER
+              value: "${DYN_TOKENIZER}"
             - name: DYN_PERF_DIAG
               value: "1"
             - name: HF_HOME

--- a/benchmarks/frontend/dgd/templates/vllm.yaml
+++ b/benchmarks/frontend/dgd/templates/vllm.yaml
@@ -6,7 +6,7 @@
 # Template variables (substituted by sweep_runner.py --deploy-template):
 #   ${DGD_NAME}              - DynamoGraphDeployment name
 #   ${IMAGE}                 - Container image
-#   ${DYN_TOKENIZER_BACKEND} - "default" (hf) or "fast"
+#   ${DYN_TOKENIZER}         - "default" (hf) or "fastokens"
 #   ${FRONTEND_PORT}         - Frontend HTTP port
 #   ${ROUTER_MODE}           - Frontend router mode
 #   ${MODEL}                 - HF model ID
@@ -40,8 +40,8 @@ ${FRONTEND_IMAGE_PULL_SECRETS_BLOCK}
           args:
             - python3 -m dynamo.frontend --router-mode ${ROUTER_MODE} --http-port ${FRONTEND_PORT}
           env:
-            - name: DYN_TOKENIZER_BACKEND
-              value: "${DYN_TOKENIZER_BACKEND}"
+            - name: DYN_TOKENIZER
+              value: "${DYN_TOKENIZER}"
             - name: DYN_PERF_DIAG
               value: "1"
             - name: HF_TOKEN

--- a/benchmarks/frontend/scripts/scaling-test.md
+++ b/benchmarks/frontend/scripts/scaling-test.md
@@ -128,7 +128,7 @@ spec:
           command: ["/bin/sh", "-c"]
           args: ["python3 -m dynamo.frontend --router-mode round-robin --http-port 8000"]
           env:
-            - name: DYN_TOKENIZER_BACKEND
+            - name: DYN_TOKENIZER
               value: "default"
             - name: DYN_PERF_DIAG
               value: "1"
@@ -333,7 +333,7 @@ python3 sweep_runner.py --mode k8s \
 
 The template substitutes these variables at deploy time:
 `${DGD_NAME}`, `${IMAGE}`, `${MODEL}`, `${MODEL_NAME}`,
-`${WORKER_REPLICAS}`, `${DYN_TOKENIZER_BACKEND}`, `${FRONTEND_PORT}`,
+`${WORKER_REPLICAS}`, `${DYN_TOKENIZER}`, `${FRONTEND_PORT}`,
 `${ROUTER_MODE}`.
 
 ---

--- a/benchmarks/frontend/scripts/sweep_k8s/dgd.py
+++ b/benchmarks/frontend/scripts/sweep_k8s/dgd.py
@@ -27,12 +27,13 @@ from sweep_k8s.kubectl import (
     wait_pod,
 )
 
-# Tokenizer backend name mapping for DGD env vars
+# Tokenizer name mapping for DGD env vars (DYN_TOKENIZER accepts
+# "default" or "fastokens")
 TOKENIZER_BACKEND_MAP = {
     "hf": "default",
     "default": "default",
-    "fast": "fast",
-    "fastokens": "fast",
+    "fast": "fastokens",
+    "fastokens": "fastokens",
 }
 
 
@@ -165,7 +166,7 @@ def dgd_switch_backend(
 ) -> None:
     """Switch tokenizer backend on a DynamoGraphDeployment.
 
-    Patches the DGD spec to set DYN_TOKENIZER_BACKEND; the Grove operator
+    Patches the DGD spec to set DYN_TOKENIZER; the Grove operator
     recreates the frontend pod automatically.
     """
     mapped_backend = TOKENIZER_BACKEND_MAP.get(backend, backend)
@@ -173,7 +174,7 @@ def dgd_switch_backend(
         f"\n--- Switching DGD tokenizer backend -> {mapped_backend} (dgd={dgd_name}) ---"
     )
 
-    # Find the index of DYN_TOKENIZER_BACKEND in the Frontend env array
+    # Find the index of DYN_TOKENIZER in the Frontend env array
     try:
         dgd_json = get_json("dgd", dgd_name, namespace)
         env_list = (
@@ -186,7 +187,7 @@ def dgd_switch_backend(
         )
         idx = None
         for i, env_var in enumerate(env_list):
-            if env_var.get("name") == "DYN_TOKENIZER_BACKEND":
+            if env_var.get("name") == "DYN_TOKENIZER":
                 idx = i
                 break
     except Exception:
@@ -221,7 +222,7 @@ def dgd_switch_backend(
                 {
                     "op": "add",
                     "path": "/spec/services/Frontend/extraPodSpec/mainContainer/env/-",
-                    "value": {"name": "DYN_TOKENIZER_BACKEND", "value": mapped_backend},
+                    "value": {"name": "DYN_TOKENIZER", "value": mapped_backend},
                 }
             ],
         )

--- a/benchmarks/frontend/scripts/sweep_k8s/template.py
+++ b/benchmarks/frontend/scripts/sweep_k8s/template.py
@@ -17,12 +17,13 @@ from typing import Dict
 from sweep_core.models import DeployDimension, SweepConfig
 from sweep_k8s.kubectl import apply_yaml
 
-# Tokenizer backend mapping for template substitution
+# Tokenizer name mapping for template substitution (DYN_TOKENIZER accepts
+# "default" or "fastokens")
 TOKENIZER_TEMPLATE_MAP = {
     "hf": "default",
     "default": "default",
-    "fast": "fast",
-    "fastokens": "fast",
+    "fast": "fastokens",
+    "fastokens": "fastokens",
 }
 
 DEFAULT_HF_TOKEN_SECRET_NAME = "hf-token-secret"
@@ -56,7 +57,7 @@ def build_substitution_dict(
     hf_token_secret_name = DEFAULT_HF_TOKEN_SECRET_NAME
     variables: Dict[str, str] = {
         # Deploy dimensions
-        "DYN_TOKENIZER_BACKEND": TOKENIZER_TEMPLATE_MAP.get(
+        "DYN_TOKENIZER": TOKENIZER_TEMPLATE_MAP.get(
             deploy.tokenizer, deploy.tokenizer
         ),
         "NUM_WORKERS": str(deploy.workers),

--- a/benchmarks/frontend/scripts/sweep_k8s/template.py
+++ b/benchmarks/frontend/scripts/sweep_k8s/template.py
@@ -57,9 +57,7 @@ def build_substitution_dict(
     hf_token_secret_name = DEFAULT_HF_TOKEN_SECRET_NAME
     variables: Dict[str, str] = {
         # Deploy dimensions
-        "DYN_TOKENIZER": TOKENIZER_TEMPLATE_MAP.get(
-            deploy.tokenizer, deploy.tokenizer
-        ),
+        "DYN_TOKENIZER": TOKENIZER_TEMPLATE_MAP.get(deploy.tokenizer, deploy.tokenizer),
         "NUM_WORKERS": str(deploy.workers),
         # Model info
         "MODEL": config.model,

--- a/docs/features/tokenizer/README.md
+++ b/docs/features/tokenizer/README.md
@@ -148,7 +148,7 @@ See the [frontend benchmarking guide](https://github.com/ai-dynamo/dynamo/tree/m
 ## Troubleshooting
 
 **I enabled `fastokens`, but the logs do not show `Using fastokens tokenizer backend`.**
-Make sure the setting is applied to the frontend process, not only to the backend worker. For local launches, pass `--tokenizer fastokens` to `python -m dynamo.frontend` or set `DYN_TOKENIZER=fastokens` before starting the frontend. For benchmark DGD templates, use `DYN_TOKENIZER_BACKEND=fast`; the sweep runner maps `--tokenizers fastokens` to that value and restarts the frontend pod.
+Make sure the setting is applied to the frontend process, not only to the backend worker. For local launches, pass `--tokenizer fastokens` to `python -m dynamo.frontend` or set `DYN_TOKENIZER=fastokens` before starting the frontend. For benchmark DGD templates, use `DYN_TOKENIZER=fastokens`; the sweep runner maps `--tokenizers fastokens` to that value and restarts the frontend pod.
 
 **The frontend logs `Failed to load fastokens, falling back to HuggingFace`.**
 The model's tokenizer file uses a feature that `fastokens` does not support, or it is not a BPE `tokenizer.json` path. Dynamo has already fallen back to HuggingFace and should keep serving traffic. Check the tokenizer format, compare against the [tested models list](https://github.com/crusoecloud/fastokens#tested-models), and use `--tokenizer default` if you want to avoid the warning.
@@ -163,7 +163,7 @@ The `fastokens` flag has no effect for TikToken-format tokenizers. Dynamo uses t
 First confirm the fast path is active in logs. If it is, tokenization may not be the bottleneck for this workload. Check prompt length, cache hit rate, backend prefill time, frontend CPU saturation, and the `dynamo_frontend_tokenizer_latency_ms` metric. Short prompts and decode-heavy traffic often show little end-to-end change.
 
 **The benchmark shows no difference between `hf` and `fastokens`.**
-Inspect each run artifact and frontend log to confirm the backend actually changed. In Kubernetes mode, the DGD frontend pod must be replaced after `DYN_TOKENIZER_BACKEND` changes. In local mocker mode, start with larger ISL values such as 8192 or higher so tokenization is large enough to measure.
+Inspect each run artifact and frontend log to confirm the backend actually changed. In Kubernetes mode, the DGD frontend pod must be replaced after `DYN_TOKENIZER` changes. In local mocker mode, start with larger ISL values such as 8192 or higher so tokenization is large enough to measure.
 
 **Token IDs differ between backends.**
 Do not roll out that model with `fastokens`. Reproduce the mismatch with a minimal prompt and file an issue with the model name, tokenizer file, prompt, and whether the model appears on the tested models list.


### PR DESCRIPTION
#### Overview:

`DYN_TOKENIZER_BACKEND` was deprecated in favor of `DYN_TOKENIZER`. This PR updates the benchmark sweep tooling, DGD templates, and tokenizer docs to use the supported env var and its valid values (`default` / `fastokens`).

#### Details:

- **`benchmarks/frontend/scripts/sweep_k8s/dgd.py`** and **`template.py`**: rename the injected env var from `DYN_TOKENIZER_BACKEND` to `DYN_TOKENIZER`, and update the tokenizer name map so `fast`/`fastokens` resolve to `fastokens` (previously emitted `fast`, which the frontend rejects with `Unrecognized DYN_TOKENIZER value`).
- **DGD templates** (`mocker.yaml`, `vllm.yaml`, `vllm-gpt-oss-20b.yaml`): rename the `env` entry and update header comments to reflect valid values (`default` or `fastokens`).
- **`benchmarks/frontend/README.md`** and **`benchmarks/frontend/scripts/scaling-test.md`**: update env var references in narrative and inline YAML snippets.
- **`docs/features/tokenizer/README.md`**: replace deprecated env var in the troubleshooting section so guidance points users at `DYN_TOKENIZER=fastokens` instead of the obsolete `DYN_TOKENIZER_BACKEND=fast`.

#### Where should the reviewer start?

1. **`benchmarks/frontend/scripts/sweep_k8s/dgd.py`** and **`template.py`** — confirm the rename plus the value remap (`fast` -> `fastokens`) is correct; this is the behavioral fix that makes the sweep runner actually flip the frontend tokenizer.
2. **`benchmarks/frontend/dgd/templates/*.yaml`** — verify the `env` key matches what `dgd_switch_backend` patches, so the Grove operator finds and replaces it in place.
3. **`docs/features/tokenizer/README.md`** — sanity-check the troubleshooting wording.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated tokenizer configuration documentation to reflect new variable naming conventions.

* **Chores**
  * Standardized tokenizer environment variable naming across deployment templates and scripts.
  * Updated tokenizer backend value mappings for consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9477)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->