### PR TITLE
feat(vllm): add cross-cluster disaggregated serving example

### DIFF
--- a/docs/backends/vllm/vllm-cross-cluster-disagg.md
+++ b/docs/backends/vllm/vllm-cross-cluster-disagg.md
@@ -1,0 +1,144 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: Cross-Cluster Disaggregated Serving
+subtitle: Run a vLLM prefill service and decode service in separate bare-metal or Slurm clusters.
+---
+
+This example runs prefill and decode in independently managed clusters. A shared Dynamo namespace joins the processes through etcd discovery, the frontend routes every request through a remote prefill endpoint, and vLLM transfers the resulting KV cache to the selected decode endpoint through NIXL. This arrangement is sometimes called Prefill as a Service (PFaS).
+
+The example uses ordinary processes rather than Kubernetes resources. It is intended for a pair of bare-metal or Slurm clusters that can route TCP traffic between their compute nodes.
+
+```mermaid
+flowchart LR
+    C[Client] --> F[Frontend<br/>decode cluster]
+    F -->|Dynamo request plane| P[Prefill worker<br/>prefill cluster]
+    P -->|NIXL and UCX over TCP| D[Decode worker<br/>decode cluster]
+    F --> D
+    F -. discovery .-> E[(etcd)]
+    P -. discovery and events .-> E
+    D -. discovery .-> E
+    P -. KV events .-> N[(NATS)]
+    F -. KV events .-> N
+```
+
+## Requirements
+
+The two sides must use the same Dynamo runtime, model revision, served model name, KV block size, tensor-parallel shape, and `KV_TRANSFER_CONFIG`. The default connector configuration uses vLLM's direct `NixlConnector`; it does not use KVBM.
+
+Both clusters need access to one etcd service and one NATS service. The decode/frontend node must be able to reach the prefill worker's Dynamo TCP port and NIXL side-channel port. The scripts assign fixed ports so firewall requirements remain explicit.
+
+| Listener | Default port | Required path |
+|---|---:|---|
+| etcd client | 2379 | both clusters to infrastructure host |
+| NATS client | 4222 | both clusters to infrastructure host |
+| frontend HTTP | 8000 | clients to decode cluster |
+| decode request plane | 8791 | frontend to decode worker |
+| prefill request plane | 8792 | frontend to prefill worker |
+| NIXL side channel | 20097 | decode worker to prefill worker |
+
+The runtime image must contain vLLM, Dynamo, NIXL, and the UCX plugin. Mount the model into the same container path on both clusters. Model downloads should run on cluster storage rather than through the machine from which the Slurm jobs are submitted.
+
+## Start the Coordination Services
+
+For a development run, place the `etcd` and `nats-server` executables on a CPU allocation or on the prefill node, then run:
+
+```bash
+export INFRA_IP=<address-reachable-from-both-clusters>
+export INFRA_STATE_DIR=/path/on/cluster/scratch/pfaas-infra
+export ETCD_BIN=/path/to/etcd
+export NATS_BIN=/path/to/nats-server
+
+./examples/backends/vllm/launch/disagg_multi_cluster_infra.sh
+```
+
+The helper prints `ETCD_ENDPOINTS` and `NATS_SERVER` after both services pass their health checks. It runs single-node development services and does not provide production availability or access control.
+
+Use a unique namespace for each run so stale registrations from another experiment cannot be selected:
+
+```bash
+export DYN_NAMESPACE="pfaas-${USER}-$(date +%s)"
+export ETCD_ENDPOINTS=http://<infra-ip>:2379
+export NATS_SERVER=nats://<infra-ip>:4222
+export MODEL=/path/to/the/same/model-snapshot
+export SERVED_MODEL_NAME=Qwen/Qwen3-32B
+export BLOCK_SIZE=16
+export MAX_MODEL_LEN=8192
+```
+
+Export the same values on both clusters. The scripts explicitly select etcd discovery, the TCP request plane, and the NATS event plane.
+
+## Start Prefill
+
+On the prefill cluster, select an address that the decode cluster can reach. On multi-NIC systems, verify the route from the decode node rather than relying on the first address returned by `hostname -I`.
+
+```bash
+export VLLM_NIXL_SIDE_CHANNEL_HOST=<reachable-prefill-address>
+export DYN_TCP_RPC_HOST="$VLLM_NIXL_SIDE_CHANNEL_HOST"
+export PREFILL_GPUS=0,1
+export PREFILL_TP_SIZE=2
+
+./examples/backends/vllm/launch/disagg_multi_cluster_prefill.sh
+```
+
+The vLLM engine publishes its events to a process-local ZMQ endpoint. Dynamo consumes that endpoint and republishes the events through the NATS event plane, avoiding a cross-cluster ZMQ listener. The prefill worker also advertises a fixed Dynamo TCP endpoint. Start another prefill endpoint by running the script on another host with the same namespace. When two endpoints share a host, give each process distinct `PREFILL_TCP_PORT`, `PREFILL_SYSTEM_PORT`, `VLLM_NIXL_SIDE_CHANNEL_PORT`, and `KV_EVENTS_PORT` values.
+
+## Start Decode and Frontend
+
+On the decode cluster:
+
+```bash
+export VLLM_NIXL_SIDE_CHANNEL_HOST=<decode-node-address>
+export DYN_TCP_RPC_HOST="$VLLM_NIXL_SIDE_CHANNEL_HOST"
+export DECODE_GPUS=0,1
+export DECODE_TP_SIZE=2
+
+./examples/backends/vllm/launch/disagg_multi_cluster_decode.sh
+```
+
+The frontend uses `--router-mode kv --enforce-disagg`. A request therefore fails while no prefill endpoint is registered instead of falling through to decode-only prefill. The frontend lets the operating system choose its internal request-plane port; only its HTTP port and the worker ports need fixed assignments in this example.
+
+## Verify the Route
+
+Before sending an inference request, verify the coordination services and the advertised prefill ports from the decode node:
+
+```bash
+curl --fail http://<infra-ip>:2379/health
+curl --fail http://<infra-ip>:8222/healthz
+nc -vz <prefill-ip> 8792
+nc -vz <prefill-ip> 20097
+```
+
+Then submit a request to the frontend:
+
+```bash
+curl --fail http://127.0.0.1:8000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "Qwen/Qwen3-32B",
+    "messages": [{"role": "user", "content": "Name the three stages of a compiler."}],
+    "max_tokens": 64,
+    "stream": false
+  }'
+```
+
+A successful response with strict disaggregation enabled establishes that the frontend found a prefill endpoint and did not use decode-only prefill. Retain the prefill, decode, and frontend logs for the run; they provide the worker registrations, selected endpoints, NIXL connection, and any transfer failure.
+
+## UCX Transport
+
+The launch scripts default to `UCX_TLS=tcp,cuda_copy,self`. `tcp` provides the inter-cluster transport, while `cuda_copy` lets UCX handle GPU buffers when transports are specified explicitly. `UCX_SOCKADDR_TLS_PRIORITY=tcp` keeps connection establishment on TCP. The scripts also set `UCX_RCACHE_MAX_UNRELEASED=1024` before NIXL loads, which matches the value vLLM requests for its NIXL connector. Set `UCX_NET_DEVICES` on both sides when a multi-NIC node would otherwise select an interface that is not routable between the clusters.
+
+The example assumes compatible GPU and software configurations and therefore leaves vLLM's NIXL handshake checks enabled. Do not set `enforce_handshake_compat` to false merely to bypass a failed handshake; first compare the model revision, vLLM and NIXL versions, tensor parallelism, KV dtype, block size, and connector configuration.
+
+As a diagnostic for environments where UCX cannot register GPU memory over the available TCP path, the connector can use a host-memory transfer buffer:
+
+```bash
+export KV_TRANSFER_CONFIG='{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_buffer_device":"cpu"}'
+export UCX_TLS=tcp,self
+```
+
+Apply that change to both workers. Host-buffer and GPU-buffer runs are not performance-comparable, so record the setting with any measurements.
+
+## Shutdown
+
+Stop the decode, prefill, and infrastructure scripts with `SIGTERM` or `Ctrl-C`. Each script terminates the processes it started. Remove the development infrastructure state directory only after every process from the run has stopped.

--- a/docs/backends/vllm/vllm-cross-cluster-disagg.md
+++ b/docs/backends/vllm/vllm-cross-cluster-disagg.md
@@ -81,7 +81,7 @@ export PREFILL_TP_SIZE=2
 ./examples/backends/vllm/launch/disagg_multi_cluster_prefill.sh
 ```
 
-The vLLM engine publishes its events to a process-local ZMQ endpoint. Dynamo consumes that endpoint and republishes the events through the NATS event plane, avoiding a cross-cluster ZMQ listener. The prefill worker also advertises a fixed Dynamo TCP endpoint. Start another prefill endpoint by running the script on another host with the same namespace. When two endpoints share a host, give each process distinct `PREFILL_TCP_PORT`, `PREFILL_SYSTEM_PORT`, `VLLM_NIXL_SIDE_CHANNEL_PORT`, and `KV_EVENTS_PORT` values.
+The vLLM engine publishes its events to a ZMQ endpoint on the worker host. Dynamo consumes that endpoint on the same host and republishes the events through the NATS event plane, avoiding a cross-cluster ZMQ listener. The prefill worker also advertises a fixed Dynamo TCP endpoint. Start another prefill endpoint by running the script on another host with the same namespace. When two endpoints share a host, give each process distinct `PREFILL_TCP_PORT`, `PREFILL_SYSTEM_PORT`, `VLLM_NIXL_SIDE_CHANNEL_PORT`, and `KV_EVENTS_PORT` values.
 
 ## Start Decode and Frontend
 

--- a/docs/backends/vllm/vllm-examples.md
+++ b/docs/backends/vllm/vllm-examples.md
@@ -92,6 +92,10 @@ bash launch/disagg_router.sh
 
 The frontend runs in KV routing mode and automatically detects prefill workers to activate an internal prefill router.
 
+### Cross-Cluster Disaggregated Serving
+
+Run prefill and decode as independently managed services in separate bare-metal or Slurm clusters. The [cross-cluster disaggregated serving guide](vllm-cross-cluster-disagg.md) covers shared discovery, fixed network ports, NIXL over an inter-cluster TCP path, and strict disaggregated-route verification.
+
 ### Data Parallel / Expert Parallelism
 
 Launches 4 data-parallel workers with expert parallelism behind a KV-aware router. Uses a Mixture-of-Experts model (`Qwen/Qwen3-30B-A3B`). Requires 4 GPUs.

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -392,6 +392,8 @@ navigation:
                 path: backends/vllm/vllm-logits-processing.md
               - page: Examples
                 path: backends/vllm/vllm-examples.md
+              - page: Cross-Cluster Disaggregated Serving
+                path: backends/vllm/vllm-cross-cluster-disagg.md
               - page: KV Cache Offloading
                 path: backends/vllm/vllm-kv-offloading.md
               - page: Observability

--- a/examples/backends/vllm/launch/disagg_multi_cluster_decode.sh
+++ b/examples/backends/vllm/launch/disagg_multi_cluster_decode.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Launch the frontend and one vLLM decode endpoint for cross-cluster
+# disaggregated serving. Run disagg_multi_cluster_prefill.sh on the prefill
+# cluster with matching configuration.
+
+set -euo pipefail
+
+MODEL="${MODEL:-Qwen/Qwen3-0.6B}"
+SERVED_MODEL_NAME="${SERVED_MODEL_NAME:-$MODEL}"
+DECODE_GPUS="${DECODE_GPUS:-0}"
+DECODE_TP_SIZE="${DECODE_TP_SIZE:-1}"
+BLOCK_SIZE="${BLOCK_SIZE:-16}"
+GPU_MEMORY_UTILIZATION="${GPU_MEMORY_UTILIZATION:-0.90}"
+MAX_MODEL_LEN="${MAX_MODEL_LEN:-}"
+KV_TRANSFER_CONFIG="${KV_TRANSFER_CONFIG:-{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\"}}"
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+source "$SCRIPT_DIR/../../../common/launch_utils.sh"
+
+pick_worker_module dynamo.vllm dynamo.vllm.unified_main "$@"
+set -- "${REMAINING_ARGS[@]}"
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    cat <<'EOF'
+Usage: ETCD_ENDPOINTS=<url> NATS_SERVER=<url> \
+       VLLM_NIXL_SIDE_CHANNEL_HOST=<reachable-ip> \
+       ./disagg_multi_cluster_decode.sh [--unified] [vLLM arguments]
+
+The frontend uses strict disaggregated routing: requests fail until a prefill
+endpoint is registered. Set DECODE_GPUS and DECODE_TP_SIZE for a tensor-parallel
+decode endpoint. DYN_TCP_RPC_HOST defaults to VLLM_NIXL_SIDE_CHANNEL_HOST.
+EOF
+    exit 0
+fi
+
+: "${ETCD_ENDPOINTS:?ETCD_ENDPOINTS must be reachable from both clusters}"
+: "${NATS_SERVER:?NATS_SERVER must be reachable from both clusters}"
+: "${VLLM_NIXL_SIDE_CHANNEL_HOST:?Set this to the decode node address}"
+
+export DYN_NAMESPACE="${DYN_NAMESPACE:-dynamo-cross-cluster}"
+export DYN_DISCOVERY_BACKEND="etcd"
+export DYN_REQUEST_PLANE="tcp"
+export DYN_EVENT_PLANE="nats"
+export DYN_TCP_RPC_HOST="${DYN_TCP_RPC_HOST:-$VLLM_NIXL_SIDE_CHANNEL_HOST}"
+export PYTHONHASHSEED="${PYTHONHASHSEED:-0}"
+export UCX_TLS="${UCX_TLS:-tcp,cuda_copy,self}"
+export UCX_SOCKADDR_TLS_PRIORITY="${UCX_SOCKADDR_TLS_PRIORITY:-tcp}"
+export UCX_RCACHE_MAX_UNRELEASED="${UCX_RCACHE_MAX_UNRELEASED:-1024}"
+
+HTTP_PORT="${DYN_HTTP_PORT:-8000}"
+DECODE_TCP_PORT="${DECODE_TCP_PORT:-8791}"
+DECODE_SYSTEM_PORT="${DECODE_SYSTEM_PORT:-8081}"
+VLLM_NIXL_SIDE_CHANNEL_PORT="${VLLM_NIXL_SIDE_CHANNEL_PORT:-20097}"
+
+worker_args=(
+    --model "$MODEL"
+    --served-model-name "$SERVED_MODEL_NAME"
+    --tensor-parallel-size "$DECODE_TP_SIZE"
+    --block-size "$BLOCK_SIZE"
+    --gpu-memory-utilization "$GPU_MEMORY_UTILIZATION"
+    --disaggregation-mode decode
+    --kv-transfer-config "$KV_TRANSFER_CONFIG"
+)
+if [[ -n "$MAX_MODEL_LEN" ]]; then
+    worker_args+=(--max-model-len "$MAX_MODEL_LEN")
+fi
+
+child_pids=()
+cleanup() {
+    trap - EXIT INT TERM
+    echo "Stopping cross-cluster decode and frontend"
+    for pid in "${child_pids[@]}"; do
+        kill "$pid" 2>/dev/null || true
+    done
+    wait "${child_pids[@]}" 2>/dev/null || true
+}
+on_signal() {
+    cleanup
+    exit 0
+}
+trap cleanup EXIT
+trap on_signal INT TERM
+
+# The frontend only exposes HTTP in this example. Let its internal request-plane
+# server bind an OS-assigned port; the decode and prefill workers retain fixed
+# ports because traffic crosses process and cluster boundaries to reach them.
+python3 -m dynamo.frontend \
+    --http-port "$HTTP_PORT" \
+    --router-mode kv \
+    --router-reset-states \
+    --enforce-disagg &
+child_pids+=("$!")
+
+DYN_TCP_RPC_PORT="$DECODE_TCP_PORT" \
+DYN_SYSTEM_PORT="$DECODE_SYSTEM_PORT" \
+CUDA_VISIBLE_DEVICES="$DECODE_GPUS" \
+VLLM_NIXL_SIDE_CHANNEL_PORT="$VLLM_NIXL_SIDE_CHANNEL_PORT" \
+python3 -m "$WORKER_MODULE" "${worker_args[@]}" "$@" &
+child_pids+=("$!")
+
+# The shared wait_any_exit helper signals the entire process group, which also
+# terminates an enclosing srun. Keep cleanup scoped to this launcher's children.
+wait_rc=0
+wait -n || wait_rc=$?
+exit "$wait_rc"

--- a/examples/backends/vllm/launch/disagg_multi_cluster_infra.sh
+++ b/examples/backends/vllm/launch/disagg_multi_cluster_infra.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Development-only coordination services for the cross-cluster disaggregated
+# serving example. Production deployments should use managed or highly
+# available etcd and NATS services instead.
+
+set -euo pipefail
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    cat <<'EOF'
+Usage: INFRA_IP=<reachable-ip> ./disagg_multi_cluster_infra.sh
+
+Required:
+  INFRA_IP          Address reachable from the prefill and decode clusters.
+
+Optional:
+  ETCD_BIN          etcd executable (default: etcd)
+  NATS_BIN          nats-server executable (default: nats-server)
+  INFRA_STATE_DIR   State directory (default: /tmp/dynamo-cross-cluster-infra)
+  ETCD_CLIENT_PORT  etcd client port (default: 2379)
+  ETCD_PEER_PORT    etcd peer port (default: 2380)
+  NATS_PORT         NATS client port (default: 4222)
+  NATS_MONITOR_PORT NATS monitoring port (default: 8222)
+EOF
+    exit 0
+fi
+
+: "${INFRA_IP:?INFRA_IP must be an address reachable from both clusters}"
+
+ETCD_BIN="${ETCD_BIN:-etcd}"
+NATS_BIN="${NATS_BIN:-nats-server}"
+INFRA_STATE_DIR="${INFRA_STATE_DIR:-${TMPDIR:-/tmp}/dynamo-cross-cluster-infra}"
+ETCD_CLIENT_PORT="${ETCD_CLIENT_PORT:-2379}"
+ETCD_PEER_PORT="${ETCD_PEER_PORT:-2380}"
+NATS_PORT="${NATS_PORT:-4222}"
+NATS_MONITOR_PORT="${NATS_MONITOR_PORT:-8222}"
+
+command -v "$ETCD_BIN" >/dev/null || {
+    echo "etcd executable not found: $ETCD_BIN" >&2
+    exit 1
+}
+command -v "$NATS_BIN" >/dev/null || {
+    echo "nats-server executable not found: $NATS_BIN" >&2
+    exit 1
+}
+command -v curl >/dev/null || {
+    echo "curl is required for readiness checks" >&2
+    exit 1
+}
+
+mkdir -p "$INFRA_STATE_DIR/etcd" "$INFRA_STATE_DIR/nats"
+
+etcd_pid=""
+nats_pid=""
+cleanup() {
+    trap - EXIT INT TERM
+    [[ -n "$etcd_pid" ]] && kill "$etcd_pid" 2>/dev/null || true
+    [[ -n "$nats_pid" ]] && kill "$nats_pid" 2>/dev/null || true
+    wait "$etcd_pid" "$nats_pid" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+"$ETCD_BIN" \
+    --name cross-cluster \
+    --data-dir "$INFRA_STATE_DIR/etcd" \
+    --listen-client-urls "http://0.0.0.0:${ETCD_CLIENT_PORT}" \
+    --advertise-client-urls "http://${INFRA_IP}:${ETCD_CLIENT_PORT}" \
+    --listen-peer-urls "http://127.0.0.1:${ETCD_PEER_PORT}" \
+    --initial-advertise-peer-urls "http://127.0.0.1:${ETCD_PEER_PORT}" \
+    --initial-cluster "cross-cluster=http://127.0.0.1:${ETCD_PEER_PORT}" &
+etcd_pid=$!
+
+"$NATS_BIN" \
+    --jetstream \
+    --store_dir "$INFRA_STATE_DIR/nats" \
+    --addr 0.0.0.0 \
+    --port "$NATS_PORT" \
+    --http_port "$NATS_MONITOR_PORT" &
+nats_pid=$!
+
+for _ in $(seq 1 30); do
+    if curl --fail --silent "http://127.0.0.1:${ETCD_CLIENT_PORT}/health" >/dev/null \
+        && curl --fail --silent "http://127.0.0.1:${NATS_MONITOR_PORT}/healthz" >/dev/null; then
+        break
+    fi
+    sleep 1
+done
+
+curl --fail --silent --show-error "http://127.0.0.1:${ETCD_CLIENT_PORT}/health"
+echo
+curl --fail --silent --show-error "http://127.0.0.1:${NATS_MONITOR_PORT}/healthz"
+echo
+echo "ETCD_ENDPOINTS=http://${INFRA_IP}:${ETCD_CLIENT_PORT}"
+echo "NATS_SERVER=nats://${INFRA_IP}:${NATS_PORT}"
+
+# Stop both services if either one exits.
+wait -n "$etcd_pid" "$nats_pid"

--- a/examples/backends/vllm/launch/disagg_multi_cluster_infra.sh
+++ b/examples/backends/vllm/launch/disagg_multi_cluster_infra.sh
@@ -20,6 +20,11 @@
 
 set -euo pipefail
 
+if [[ "${BASH_VERSINFO[0]}" -lt 4 || ( "${BASH_VERSINFO[0]}" -eq 4 && "${BASH_VERSINFO[1]}" -lt 3 ) ]]; then
+    echo "This script requires bash 4.3+ (for wait -n), found ${BASH_VERSION}" >&2
+    exit 1
+fi
+
 if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
     cat <<'EOF'
 Usage: INFRA_IP=<reachable-ip> ./disagg_multi_cluster_infra.sh
@@ -107,5 +112,6 @@ echo
 echo "ETCD_ENDPOINTS=http://${INFRA_IP}:${ETCD_CLIENT_PORT}"
 echo "NATS_SERVER=nats://${INFRA_IP}:${NATS_PORT}"
 
-# Stop both services if either one exits.
-wait -n "$etcd_pid" "$nats_pid"
+# Stop both services if either one exits. Bare `wait -n` covers exactly the
+# two children above; `wait -n <pid>...` would require bash 5.1.
+wait -n

--- a/examples/backends/vllm/launch/disagg_multi_cluster_prefill.sh
+++ b/examples/backends/vllm/launch/disagg_multi_cluster_prefill.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Launch one vLLM prefill endpoint for cross-cluster disaggregated serving.
+# Run disagg_multi_cluster_decode.sh on the decode cluster with the same
+# namespace, model, block size, and KV connector configuration.
+
+set -euo pipefail
+
+MODEL="${MODEL:-Qwen/Qwen3-0.6B}"
+SERVED_MODEL_NAME="${SERVED_MODEL_NAME:-$MODEL}"
+PREFILL_GPUS="${PREFILL_GPUS:-0}"
+PREFILL_TP_SIZE="${PREFILL_TP_SIZE:-1}"
+BLOCK_SIZE="${BLOCK_SIZE:-16}"
+GPU_MEMORY_UTILIZATION="${GPU_MEMORY_UTILIZATION:-0.90}"
+MAX_MODEL_LEN="${MAX_MODEL_LEN:-}"
+KV_EVENTS_PORT="${KV_EVENTS_PORT:-20081}"
+KV_EVENTS_CONFIG="${KV_EVENTS_CONFIG:-{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:${KV_EVENTS_PORT}\",\"enable_kv_cache_events\":true}}"
+KV_TRANSFER_CONFIG="${KV_TRANSFER_CONFIG:-{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\"}}"
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+source "$SCRIPT_DIR/../../../common/launch_utils.sh"
+
+pick_worker_module dynamo.vllm dynamo.vllm.unified_main "$@"
+set -- "${REMAINING_ARGS[@]}"
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    cat <<'EOF'
+Usage: ETCD_ENDPOINTS=<url> NATS_SERVER=<url> \
+       VLLM_NIXL_SIDE_CHANNEL_HOST=<reachable-ip> \
+       ./disagg_multi_cluster_prefill.sh [--unified] [vLLM arguments]
+
+The worker uses etcd discovery, the TCP request plane, a local vLLM ZMQ event
+publisher bridged to Dynamo's NATS event plane, and NIXL/UCX KV transfer. Set
+PREFILL_GPUS and PREFILL_TP_SIZE for a tensor-parallel endpoint.
+DYN_TCP_RPC_HOST defaults to VLLM_NIXL_SIDE_CHANNEL_HOST.
+EOF
+    exit 0
+fi
+
+: "${ETCD_ENDPOINTS:?ETCD_ENDPOINTS must be reachable from both clusters}"
+: "${NATS_SERVER:?NATS_SERVER must be reachable from both clusters}"
+: "${VLLM_NIXL_SIDE_CHANNEL_HOST:?Set this to the prefill address reachable from the decode cluster}"
+
+export DYN_NAMESPACE="${DYN_NAMESPACE:-dynamo-cross-cluster}"
+export DYN_DISCOVERY_BACKEND="etcd"
+export DYN_REQUEST_PLANE="tcp"
+export DYN_EVENT_PLANE="nats"
+export DYN_TCP_RPC_HOST="${DYN_TCP_RPC_HOST:-$VLLM_NIXL_SIDE_CHANNEL_HOST}"
+export PYTHONHASHSEED="${PYTHONHASHSEED:-0}"
+
+# UCX needs an AM-capable network transport and a CUDA transport when the NIXL
+# buffer remains in GPU memory. UCX_NET_DEVICES may be set by the operator when
+# a multi-NIC host needs an explicit TCP interface.
+export UCX_TLS="${UCX_TLS:-tcp,cuda_copy,self}"
+export UCX_SOCKADDR_TLS_PRIORITY="${UCX_SOCKADDR_TLS_PRIORITY:-tcp}"
+export UCX_RCACHE_MAX_UNRELEASED="${UCX_RCACHE_MAX_UNRELEASED:-1024}"
+
+VLLM_NIXL_SIDE_CHANNEL_PORT="${VLLM_NIXL_SIDE_CHANNEL_PORT:-20097}"
+PREFILL_TCP_PORT="${PREFILL_TCP_PORT:-8792}"
+PREFILL_SYSTEM_PORT="${PREFILL_SYSTEM_PORT:-8082}"
+
+worker_args=(
+    --model "$MODEL"
+    --served-model-name "$SERVED_MODEL_NAME"
+    --tensor-parallel-size "$PREFILL_TP_SIZE"
+    --block-size "$BLOCK_SIZE"
+    --gpu-memory-utilization "$GPU_MEMORY_UTILIZATION"
+    --disaggregation-mode prefill
+    --kv-transfer-config "$KV_TRANSFER_CONFIG"
+    --kv-events-config "$KV_EVENTS_CONFIG"
+)
+if [[ -n "$MAX_MODEL_LEN" ]]; then
+    worker_args+=(--max-model-len "$MAX_MODEL_LEN")
+fi
+
+child_pids=()
+cleanup() {
+    trap - EXIT INT TERM
+    echo "Stopping cross-cluster prefill"
+    for pid in "${child_pids[@]}"; do
+        kill "$pid" 2>/dev/null || true
+    done
+    wait "${child_pids[@]}" 2>/dev/null || true
+}
+on_signal() {
+    cleanup
+    exit 0
+}
+trap cleanup EXIT
+trap on_signal INT TERM
+
+DYN_TCP_RPC_PORT="$PREFILL_TCP_PORT" \
+DYN_SYSTEM_PORT="$PREFILL_SYSTEM_PORT" \
+CUDA_VISIBLE_DEVICES="$PREFILL_GPUS" \
+VLLM_NIXL_SIDE_CHANNEL_PORT="$VLLM_NIXL_SIDE_CHANNEL_PORT" \
+python3 -m "$WORKER_MODULE" "${worker_args[@]}" "$@" &
+child_pids+=("$!")
+
+# The shared wait_any_exit helper signals the entire process group, which also
+# terminates an enclosing srun. Keep cleanup scoped to this launcher's children.
+wait_rc=0
+wait -n || wait_rc=$?
+exit "$wait_rc"


### PR DESCRIPTION
## Summary

- Add separate infrastructure, prefill, and decode/frontend launchers for cross-cluster disaggregated vLLM serving on bare-metal or Slurm systems.
- Use etcd discovery, the Dynamo TCP request plane, the NATS event plane, strict disaggregated routing, and direct `NixlConnector` KV transfer over UCX/TCP.
- Keep the vLLM KV event publisher process-local over ZMQ and bridge its events through Dynamo to NATS.
- Add a cross-cluster operating guide, fixed worker ports, transport guidance, and documentation navigation.
- Replace the historical Kubernetes and KVBM experiment with a focused current-main example. Profiling and publication results remain separate work.

## Validation

- `bash -n` passed for all three launchers.
- Each launcher's `--help` path executed successfully.
- `git diff --check` passed.
- `docs/index.yml` parsed successfully as YAML.
- `uv run --no-project --with pre-commit pre-commit run --files <six changed files>` passed all applicable hooks.
- A live smoke ran prefill and coordination services in one Slurm cluster and the frontend plus decode worker in a second Slurm cluster. Both workers used `Qwen/Qwen3-32B` revision `9216db5781bf21249d130ec9da846c4624c16137`, TP1, BF16, an 8,192-token maximum sequence length, and `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1` (OCI index digest `sha256:975e0c31422bb94afa0efe60f1ab2835044a8ad59e21cd4d0f1c8d4440e36819`).
- With `--enforce-disagg` active, the frontend selected distinct prefill and decode workers. The decode log recorded a passed NIXL compatibility check, one successful 8 MiB GPU-buffer transfer over the UCX backend, and HTTP 200. The response content was `READY`, and the final decode/frontend Slurm job completed with exit code `0:0`.

The runtime emitted a non-fatal `get_kv_cache_group_metadata` error and fell back to the configured vLLM block size. vLLM also emitted multiprocessing/NCCL cleanup warnings while shutting down after the successful request; the enclosing Slurm job still completed with exit code `0:0`. This validation is a functional smoke, not a performance study.

Tracking: DYN-3363
