### PR TITLE
fix(trtllm): escalate poisoned KV cache transfer to worker shutdown

### DIFF
--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -195,6 +195,48 @@ class _DeferredAbort:
         logging.debug("Deferred abort: background task completed, abort fired")
 
 
+# Fatal CUDA error patterns from PR #8342 — unrecoverable hardware/driver
+# state that should restart the worker rather than being swallowed as a
+# per-request WARN. cudaErrorMemoryAllocation (OOM) is intentionally NOT
+# listed: TRT-LLM aborts the offending request and frees KV, so the engine
+# stays healthy.
+FATAL_CUDA_ERROR_PATTERNS = re.compile(
+    "|".join(
+        [
+            r"cudaErrorNvlinkUncorrectable",
+            r"cudaErrorNoDevice",
+            r"cudaErrorECCUncorrectable",
+            r"cudaErrorIllegalAddress",
+            r"cudaErrorAssert",
+            r"cudaErrorUnknown",
+            r"cudaErrorLaunchTimeout",
+            r"cudaErrorMisalignedAddress",
+            r"cudaErrorHardwareStackError",
+        ]
+    ),
+    re.IGNORECASE,
+)
+
+# Fatal KV-cache-transfer error patterns. When TRT-LLM's NIXL/UCX cache
+# transfer buffer is poisoned by a mid-transfer prefill failure, every
+# subsequent buffer allocation raises this RequestError. Per TRT-LLM
+# source (cpp/tensorrt_llm/batch_manager/baseTransBuffer.cpp), the only
+# safe recovery is a process restart — so escalate it the same way as a
+# fatal CUDA error: cleanup + os._exit(1), let k8s/docker restart the
+# container.
+FATAL_KV_TRANSFER_ERROR_PATTERNS = re.compile(
+    "|".join(
+        [
+            r"Cannot assign cache transfer buffer.*poisoned",
+            r"previous transfer left the buffer pool poisoned",
+            r"Poisoned .* cache transfer buffer",
+            r"process must restart before these memory ranges",
+        ]
+    ),
+    re.IGNORECASE,
+)
+
+
 @dataclass
 class RequestHandlerConfig:
     """
@@ -898,6 +940,41 @@ class HandlerBase(BaseGenerativeHandler):
             logging.critical("Forcing process exit for restart")
             os._exit(1)
 
+    async def _handle_per_request_error(
+        self, error: "RequestError", request_id: str
+    ) -> "AsyncGenerator[dict, None]":
+        """Emit the error chunk for a TRT-LLM RequestError, escalating to
+        worker shutdown if the message matches FATAL_CUDA_ERROR_PATTERNS or
+        FATAL_KV_TRANSFER_ERROR_PATTERNS.
+
+        Modeled on ai-dynamo/dynamo PR #8342. Extended here to also escalate
+        TRT-LLM poisoned-cache-transfer-buffer errors, which TRT-LLM itself
+        documents as requiring a process restart.
+        """
+        error_msg = str(error)
+        fatal_cuda = FATAL_CUDA_ERROR_PATTERNS.search(error_msg) is not None
+        fatal_kv = FATAL_KV_TRANSFER_ERROR_PATTERNS.search(error_msg) is not None
+        if fatal_cuda or fatal_kv:
+            kind = "CUDA" if fatal_cuda else "KV cache transfer"
+            logging.error(
+                f"Fatal {kind} error in request {request_id} "
+                f"(caught as RequestError): {error_msg}",
+                exc_info=True,
+            )
+        else:
+            logging.warning(f"Request {request_id} error: {error_msg}")
+        try:
+            yield {"finish_reason": {"error": error_msg}, "token_ids": []}
+        except Exception as emit_err:  # noqa: BLE001
+            logging.debug(
+                "Failed to emit error chunk for request %s: %s",
+                request_id,
+                emit_err,
+            )
+        if fatal_cuda or fatal_kv:
+            await self._initiate_shutdown(error)
+
+
     async def generate_locally(
         self,
         request: dict,
@@ -1289,13 +1366,12 @@ class HandlerBase(BaseGenerativeHandler):
             return  # Just stop, no error response
 
         # 2. Per-request errors - send to client, don't shutdown
+        #    UNLESS the error indicates fatal/unrecoverable state
+        #    (CUDA hardware/driver fault or poisoned KV-cache transfer
+        #    buffer), in which case escalate to graceful shutdown.
         except RequestError as e:
-            error_msg = str(e)
-            logging.warning(f"Request {request_id} error: {error_msg}")
-            yield {
-                "finish_reason": {"error": error_msg},
-                "token_ids": [],
-            }
+            async for chunk in self._handle_per_request_error(e, request_id):
+                yield chunk
 
         # 3. EngineShutdown - let it propagate to the Rust bridge
         except EngineShutdown:

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -227,10 +227,20 @@ FATAL_CUDA_ERROR_PATTERNS = re.compile(
 FATAL_KV_TRANSFER_ERROR_PATTERNS = re.compile(
     "|".join(
         [
+            # C++ error strings (these typically appear in TRT-LLM logs but
+            # are masked by the Python wrapper below; included so we still
+            # match if a future TRT-LLM release surfaces them through to
+            # the Python RequestError):
             r"Cannot assign cache transfer buffer.*poisoned",
             r"previous transfer left the buffer pool poisoned",
             r"Poisoned .* cache transfer buffer",
             r"process must restart before these memory ranges",
+            # Python wrapper string that TRT-LLM's _check_disagg_*_status
+            # actually raises to dynamo as a RequestError. In disaggregated
+            # mode, any "Error in kv cache transfer" (context or generation)
+            # is the practical signal that the worker is in an unrecoverable
+            # state — restart it.
+            r"Error in kv cache transfer for (context|generation) requests",
         ]
     ),
     re.IGNORECASE,


### PR DESCRIPTION
## Summary

When TRT-LLM raises a `RequestError` for an unrecoverable KV cache transfer failure (poisoned NIXL/UCX buffer pool), the dynamo TRT-LLM handler currently swallows it as a per-request warning and keeps serving with a corrupted buffer pool. This results in a wedge where every subsequent generation request gets `Cannot assign cache transfer buffer kind=kv` and clients see HTTP 500.

This PR extends the existing `FATAL_CUDA_ERROR_PATTERNS` design (ai-dynamo#8342) to also escalate poisoned-KV-cache-transfer-buffer errors. On a match, the worker logs the fatal, emits the error chunk, and calls `_initiate_shutdown()` so k8s/docker can restart the container.

## Validation

Validated against the 1P/1D production-like canary reproducer that wedges with current main:

- Image built with this patch on top of TRT-LLM PR NVIDIA/TensorRT-LLM#13713 head
- Trigger result: `round=0 decode_poison=1 decode_cannot=0 decode_restarts=1` (vs unpatched: `decode_restarts=0` with repeated `Cannot assign cache transfer buffer`)
- 15-minute no-manual-restart soak: 30/30 HTTP 200 probes; decode self-recovered
- Full verdict: `docs/disagg-pr13713-v9-poison-restart-verdict-2026-05-12.md` (in dynamo-gb200-test repo)

## Patterns

The regex matches both the C++ log strings (kept for backward compat) and the Python wrapper that surfaces to the `RequestError`:

- C++ strings from `baseTransBuffer.cpp`: `Cannot assign cache transfer buffer.*poisoned`, `previous transfer left the buffer pool poisoned`, `Poisoned .* cache transfer buffer`, `process must restart before these memory ranges`
- Python wrapper from `py_executor.py`: `Error in kv cache transfer for (context|generation) requests` (matches both pre-PR-13713-v10 plain wrappers and post-v10 poison-aware wrappers since they share the prefix)

## Test plan
- [x] Reproducer triggers `decode_restarts=1` on first poison hit (was 0)
- [x] 15-min soak: 30/30 probes succeed after self-recovery
- [x] Final sanity probes 3/3 OK
- [ ] Side-by-side burst-sweep test against unpatched dynamo main to confirm no regression on non-poison KV transfer errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)