### PR TITLE
docs: restore OpenAI API reference links in backend guide

### DIFF
--- a/docs/development/backend-guide.md
+++ b/docs/development/backend-guide.md
@@ -67,8 +67,8 @@ The `model_input` can be:
 - ModelInput.Text. Your engine expects raw text input and handles its own tokenization and pre-processing.
 
 The `model_type` can be:
-- ModelType.Chat. Your `generate` method receives a `request` and must return a response dict of type [OpenAI Chat Completion](https://platform.openai.com/docs/api-reference/chat/completions).
-- ModelType.Completions. Your `generate` method receives a `request` and must return a response dict of the older [Completions](https://platform.openai.com/docs/api-reference/completions).
+- ModelType.Chat. Your `generate` method receives a `request` and must return a response dict of type [OpenAI Chat Completion](https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create).
+- ModelType.Completions. Your `generate` method receives a `request` and must return a response dict of the older [Completions](https://developers.openai.com/api/reference/resources/completions/methods/create).
 
 `register_model` can also take the following kwargs:
 - `model_name`: The name to call the model. Your incoming HTTP requests model name must match this. Defaults to the hugging face repo name or the folder name.


### PR DESCRIPTION
## Summary
- Reapplies the fix from #9273. The lychee `Docs link check` job on `main` is failing because two `platform.openai.com/docs/api-reference/...` URLs return 404 (see [run 25783539033](https://github.com/ai-dynamo/dynamo/actions/runs/25783539033/job/75731398426)).
- #9273 originally swapped them to the canonical `developers.openai.com/api/reference/...` URLs (which return 200). Two later PRs touching the same lines unintentionally reverted that fix:
  - #8416 restored the original broken `platform.openai.com/docs/api-reference/chat` and `.../completions` URLs.
  - #9305 then changed `.../chat` to `.../chat/completions` (still 404).
- Restoring the `developers.openai.com` URLs makes the link checker green again.

## Test plan
- [x] `lychee` run against `docs/development/backend-guide.md` locally: both URLs report `[200]`.
- [ ] `Docs link check` CI passes on this PR.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9482" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API reference links in backend development documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9482)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->