### PR TITLE
chore: Force frame pointers to ease profiling and debugging

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,11 +7,11 @@ rustflags = ["--cfg", "tokio_unstable"]
 
 # Target Haswell (2013) era+ machines. That gets us AVX-2
 [target.x86_64-unknown-linux-gnu]
-rustflags = ["-C", "target-cpu=x86-64-v3", "--cfg", "tokio_unstable"]
+rustflags = ["-C", "target-cpu=x86-64-v3", "-C", "force-frame-pointers=yes", "--cfg", "tokio_unstable"]
 
 # Target Graviton 2 / Ampere Altra + machines. NEON vector, and LSE atomics.
 [target.aarch64-unknown-linux-gnu]
-rustflags = ["-C", "target-cpu=neoverse-n1", "--cfg", "tokio_unstable"]
+rustflags = ["-C", "target-cpu=neoverse-n1", "-C", "force-frame-pointers=yes", "--cfg", "tokio_unstable"]
 
 # Static-link pcre2 C library (used by the fastokens tokenizer crate).
 # Without this, pcre2-sys tries to find a system libpcre2 via pkg-config,


### PR DESCRIPTION
> The Rust callers are not directly visible because release builds elide frame pointers

Makes work like https://github.com/ai-dynamo/dynamo/issues/9466 more effective.

Strongly recommended by performance guru Brendan Gregg: [details and analysis](https://www.brendangregg.com/blog/2024-03-17/the-return-of-the-frame-pointers.html)

Fedora, Ubuntu and [Python](https://peps.python.org/pep-0831/) all enable them these days.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9489" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration settings for targeted platforms to optimize compilation and runtime performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9489)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->