### PR TITLE
fix(container): backport vllm PR #40932 to unblock Qwen3-VL disagg multimodal

### DIFF
--- a/container/deps/vllm/install_vllm.sh
+++ b/container/deps/vllm/install_vllm.sh
@@ -251,12 +251,21 @@ if [ "$DEVICE" = "cpu" ]; then
     uv pip install dist/*.whl
 fi
 
-# Apply vendored patches for this vLLM ref. Used to carry upstream fixes that
-# are missing from the pinned release wheel (e.g. PR backports dropped between
-# rc and final tags). Each subdir is keyed by --vllm-ref so a version bump
-# automatically stops applying stale patches.
+# Apply vendored vLLM patches for this ref. Used to carry upstream fixes
+# that are missing from the pinned release wheel (e.g. PR backports
+# dropped between rc and final tags). Skipped when:
+#   - VLLM_VER is >= 0.21.0  (upstream fix expected to be merged by then)
+#   - no patches/<VLLM_REF>/ subdir exists, or it has no *.patch files
+#
+# rc/post/dev/+ suffixes are stripped before comparison (so v0.21.0rc0
+# also trips the skip). Non-semver refs (commit SHA, branch name) fall
+# through to the directory-existence check.
+VLLM_VER_BASE=$(echo "$VLLM_VER" | sed -E 's/(rc|\.post|\.dev|\+).*//')
 PATCH_DIR="/tmp/deps/vllm/patches/${VLLM_REF}"
-if [ -d "$PATCH_DIR" ] && compgen -G "$PATCH_DIR/*.patch" > /dev/null; then
+if [[ "$VLLM_VER_BASE" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && \
+   printf '%s\n%s\n' "0.21.0" "$VLLM_VER_BASE" | sort -V | head -n1 | grep -qx "0.21.0"; then
+    echo "vLLM $VLLM_VER >= 0.21 — skipping vendored patches (assumed merged upstream)"
+elif [ -d "$PATCH_DIR" ] && compgen -G "$PATCH_DIR/*.patch" > /dev/null; then
     echo "\n=== Applying vendored vLLM patches from $PATCH_DIR ==="
     VLLM_SITE_PACKAGES=$(python3 -c "import vllm, os; print(os.path.dirname(os.path.dirname(vllm.__file__)))")
     for p in "$PATCH_DIR"/*.patch; do

--- a/container/deps/vllm/install_vllm.sh
+++ b/container/deps/vllm/install_vllm.sh
@@ -267,7 +267,15 @@ if [[ "$VLLM_VER_BASE" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && \
     echo "vLLM $VLLM_VER >= 0.21 — skipping vendored patches (assumed merged upstream)"
 elif [ -d "$PATCH_DIR" ] && compgen -G "$PATCH_DIR/*.patch" > /dev/null; then
     echo "\n=== Applying vendored vLLM patches from $PATCH_DIR ==="
-    VLLM_SITE_PACKAGES=$(python3 -c "import vllm, os; print(os.path.dirname(os.path.dirname(vllm.__file__)))")
+    # Run from / so cwd isn't ahead of the venv on sys.path. The build
+    # script is still inside the $INSTALLATION_DIR/vllm source clone here
+    # (from the earlier `cd vllm`), and that clone contains a `vllm/`
+    # package directory. Without the cd, `import vllm` resolves the
+    # source clone, vllm.__file__ points at /opt/vllm/vllm/__init__.py,
+    # and the patch lands on the build-only source tree — not on the
+    # installed wheel that the runtime actually imports. Same pattern as
+    # the post-install verification block above.
+    VLLM_SITE_PACKAGES=$(cd / && python3 -c "import vllm, os; print(os.path.dirname(os.path.dirname(vllm.__file__)))")
     for p in "$PATCH_DIR"/*.patch; do
         echo "  $(basename "$p")"
         patch -p1 -d "$VLLM_SITE_PACKAGES" < "$p"

--- a/container/deps/vllm/install_vllm.sh
+++ b/container/deps/vllm/install_vllm.sh
@@ -278,7 +278,24 @@ elif [ -d "$PATCH_DIR" ] && compgen -G "$PATCH_DIR/*.patch" > /dev/null; then
     VLLM_SITE_PACKAGES=$(cd / && python3 -c "import vllm, os; print(os.path.dirname(os.path.dirname(vllm.__file__)))")
     for p in "$PATCH_DIR"/*.patch; do
         echo "  $(basename "$p")"
-        patch -p1 -d "$VLLM_SITE_PACKAGES" < "$p"
+        # --batch: suppress interactive prompts. Without it, an unmatched
+        #          file path in a hunk produces `File to patch:` on stdin
+        #          and hangs `docker build`.
+        # --forward: skip patches that already appear applied or reversed —
+        #          benign for re-runs and for wheels that already carry
+        #          the fix (e.g. a v0.20.1.post1 hotfix).
+        #
+        # GNU patch exit codes: 0 = clean apply, 1 = hunks rejected or
+        # skipped via --forward, >=2 = fatal. Accept rc=1 (so the patches
+        # block doesn't become a brittle build gate); propagate >=2.
+        rc=0
+        patch -p1 --batch --forward -d "$VLLM_SITE_PACKAGES" < "$p" || rc=$?
+        if [ "$rc" -ge 2 ]; then
+            echo "    fatal: patch exited $rc"
+            exit "$rc"
+        elif [ "$rc" -eq 1 ]; then
+            echo "    (already applied or partial; continuing)"
+        fi
     done
     echo "✓ vLLM patches applied"
 fi

--- a/container/deps/vllm/install_vllm.sh
+++ b/container/deps/vllm/install_vllm.sh
@@ -250,6 +250,22 @@ if [ "$DEVICE" = "cpu" ]; then
     python3 setup.py bdist_wheel --dist-dir=dist --py-limited-api=cp38
     uv pip install dist/*.whl
 fi
+
+# Apply vendored patches for this vLLM ref. Used to carry upstream fixes that
+# are missing from the pinned release wheel (e.g. PR backports dropped between
+# rc and final tags). Each subdir is keyed by --vllm-ref so a version bump
+# automatically stops applying stale patches.
+PATCH_DIR="/tmp/deps/vllm/patches/${VLLM_REF}"
+if [ -d "$PATCH_DIR" ] && compgen -G "$PATCH_DIR/*.patch" > /dev/null; then
+    echo "\n=== Applying vendored vLLM patches from $PATCH_DIR ==="
+    VLLM_SITE_PACKAGES=$(python3 -c "import vllm, os; print(os.path.dirname(os.path.dirname(vllm.__file__)))")
+    for p in "$PATCH_DIR"/*.patch; do
+        echo "  $(basename "$p")"
+        patch -p1 -d "$VLLM_SITE_PACKAGES" < "$p"
+    done
+    echo "✓ vLLM patches applied"
+fi
+
 echo "✓ vLLM installation completed"
 
 echo "\n=== Installing LMCache from source ==="

--- a/container/deps/vllm/patches/v0.20.1/0001-pr40932-remove-invalid-deepstack-boundary-check-for-qwen3-vl.patch
+++ b/container/deps/vllm/patches/v0.20.1/0001-pr40932-remove-invalid-deepstack-boundary-check-for-qwen3-vl.patch
@@ -1,0 +1,73 @@
+From 22631f80a01a04b06398952e77d7890ab660ab10 Mon Sep 17 00:00:00 2001
+From: Isotr0py <mozf@mail2.sysu.edu.cn>
+Date: Mon, 27 Apr 2026 15:27:06 +0800
+Subject: [PATCH] [Bugfix] Remove invalid deepstack boundary check for Qwen3-VL
+ (#40932)
+
+Signed-off-by: Isotr0py <mozf@mail2.sysu.edu.cn>
+---
+ vllm/model_executor/models/qwen3_omni_moe_thinker.py | 11 -----------
+ vllm/model_executor/models/qwen3_vl.py               | 11 -----------
+ 2 files changed, 22 deletions(-)
+
+diff --git a/vllm/model_executor/models/qwen3_omni_moe_thinker.py b/vllm/model_executor/models/qwen3_omni_moe_thinker.py
+index ff8962c82..44e656ab8 100755
+--- a/vllm/model_executor/models/qwen3_omni_moe_thinker.py
++++ b/vllm/model_executor/models/qwen3_omni_moe_thinker.py
+@@ -1778,11 +1778,6 @@ class Qwen3OmniMoeThinkerForConditionalGeneration(
+             return None  # If vision tower is skipped
+         if getattr(self, "deepstack_input_embeds_num_tokens", 0) == 0:
+             return None
+-        if num_tokens > self.deepstack_input_embeds_num_tokens:
+-            raise ValueError(
+-                "Requested more deepstack tokens than available in buffer: "
+-                f"{num_tokens=} > {self.deepstack_input_embeds_num_tokens=}"
+-            )
+ 
+         # get deepstack_input_embeds from buffer, and clear the buffer
+         return IntermediateTensors(
+@@ -1824,12 +1819,6 @@ class Qwen3OmniMoeThinkerForConditionalGeneration(
+ 
+         # clear deepstack_input_embeds in buffer
+         if num_tokens > 0:
+-            if num_tokens > self.deepstack_input_embeds_num_tokens:
+-                raise ValueError(
+-                    "Requested to clear more deepstack tokens than available in "
+-                    "buffer: "
+-                    f"{num_tokens=} > {self.deepstack_input_embeds_num_tokens=}"
+-                )
+             for idx in range(self.deepstack_num_level):
+                 self.deepstack_input_embeds[idx][:num_tokens].zero_()
+             self.deepstack_input_embeds_num_tokens = 0
+diff --git a/vllm/model_executor/models/qwen3_vl.py b/vllm/model_executor/models/qwen3_vl.py
+index 4a0de15f0..2575f634b 100644
+--- a/vllm/model_executor/models/qwen3_vl.py
++++ b/vllm/model_executor/models/qwen3_vl.py
+@@ -1716,11 +1716,6 @@ class Qwen3VLForConditionalGeneration(
+             return None  # If vision tower is skipped
+         if getattr(self, "deepstack_input_embeds_num_tokens", 0) == 0:
+             return None
+-        if num_tokens > self.deepstack_input_embeds_num_tokens:
+-            raise ValueError(
+-                "Requested more deepstack tokens than available in buffer: "
+-                f"{num_tokens=} > {self.deepstack_input_embeds_num_tokens=}"
+-            )
+ 
+         # get deepstack_input_embeds from buffer, and clear the buffer
+         return IntermediateTensors(
+@@ -1762,12 +1757,6 @@ class Qwen3VLForConditionalGeneration(
+ 
+         # clear deepstack_input_embeds in buffer
+         if num_tokens > 0:
+-            if num_tokens > self.deepstack_input_embeds_num_tokens:
+-                raise ValueError(
+-                    "Requested to clear more deepstack tokens than available in "
+-                    "buffer: "
+-                    f"{num_tokens=} > {self.deepstack_input_embeds_num_tokens=}"
+-                )
+             for idx in range(self.deepstack_num_level):
+                 self.deepstack_input_embeds[idx][:num_tokens].zero_()
+             self.deepstack_input_embeds_num_tokens = 0
+-- 
+2.43.0
+

--- a/container/deps/vllm/patches/v0.20.1/0001-pr40932-remove-invalid-deepstack-boundary-check-for-qwen3-vl.patch
+++ b/container/deps/vllm/patches/v0.20.1/0001-pr40932-remove-invalid-deepstack-boundary-check-for-qwen3-vl.patch
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-License-Identifier: Apache-2.0
+
 From 22631f80a01a04b06398952e77d7890ab660ab10 Mon Sep 17 00:00:00 2001
 From: Isotr0py <mozf@mail2.sysu.edu.cn>
 Date: Mon, 27 Apr 2026 15:27:06 +0800


### PR DESCRIPTION
## Why

The vllm-runtime image pins `vllm_ref: v0.20.1`, which is missing upstream vllm-project/vllm#40932 (`[Bugfix] Remove invalid deepstack boundary check for Qwen3-VL`). That fix removes a strict size check originally added by vllm-project/vllm#40145 (`[Opt] Optimize deepstack buffer handling for multimodal Qwen3 models`). #40932 landed on `main` and shipped on the `v0.20.1rc0` tag, but it was dropped between rc0 and the final `v0.20.1` tag — so the 1.2.0rc0 image inherits the regression.

Symptom: the EngineCore crashes on the first inference of any disaggregated multimodal request to a Qwen3-VL model: `ValueError: Requested more deepstack tokens than available in buffer: num_tokens=288 > self.deepstack_input_embeds_num_tokens=276` — the gap is cudagraph capture-bucket padding the scheduler can't avoid.

A clean `vllm_ref` bump isn't an option: `v0.20.1rc0` predates `v0.20.1` on the release branch (regresses unrelated commits), `main` carries unrelated changes, and there's no patched-v0.20.1 tag.

## What Change

- Add per-vllm-ref `container/deps/vllm/patches/<ref>/` directory
- Vendor vllm-project/vllm#40932 as `0001-pr40932-...patch` under `patches/v0.20.1/`
- `install_vllm.sh` applies any matching patches after the PyPI wheel install; skipped when `VLLM_VER >= 0.21.0` (assumes upstream merges by then)

## Test Plan

- Applied same patch to a v0.20.1 image, ran `disagg_multimodal_e_pd.sh --model Qwen/Qwen3-VL-2B-Instruct` on 2 GPUs with cudagraph active (bucket 288 captured)
- 3/3 multimodal chat completions returned 200 with correct image descriptions; 0 `Requested more deepstack` / `EngineCore encountered a fatal error` lines in logs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed invalid boundary validation checks in Qwen3 model processing that could trigger unexpected errors during inference.

* **Chores**
  * Improved vLLM installation process with smart patch management that automatically applies version-specific patches for enhanced compatibility with different vLLM releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9491)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->