### PR TITLE
docs(backend): add Rust + Python unified backend guides

### DIFF
--- a/components/src/dynamo/common/backend/README.md
+++ b/components/src/dynamo/common/backend/README.md
@@ -1,10 +1,13 @@
 # Dynamo Python Backend
 
-> **Work in progress.** The unified backend supports aggregated and
-> disaggregated (prefill/decode) inference; multimodal, LoRA, logprobs,
-> guided decoding, and engine-level metrics are still on the
-> non-unified path. See [Feature Gaps](#feature-gaps) for the full
-> matrix.
+**Supported today:** aggregated inference, disaggregated
+(prefill/decode) serving with bootstrap (SGLang) or internal KV
+transport (vLLM, TRT-LLM), request cancellation, graceful shutdown,
+`drain()` hook, error chain wrapping.
+
+> **Work in progress.** Multimodal, LoRA, logprobs, guided decoding,
+> and engine-level metrics are still on the non-unified path. See
+> [Feature Gaps](#feature-gaps) for the full matrix.
 
 > **Looking for a walkthrough?** Start with the
 > [Writing a Python Unified Backend](../../../../../docs/development/python-backend-guide.md)

--- a/components/src/dynamo/common/backend/README.md
+++ b/components/src/dynamo/common/backend/README.md
@@ -1,21 +1,30 @@
 # Dynamo Python Backend
 
-> **Work in progress.** The unified backend currently supports minimal
-> aggregated inference only. See [Feature Gaps](#feature-gaps) at the bottom
-> for what remains to be implemented.
+> **Work in progress.** The unified backend supports aggregated and
+> disaggregated (prefill/decode) inference; multimodal, LoRA, logprobs,
+> guided decoding, and engine-level metrics are still on the
+> non-unified path. See [Feature Gaps](#feature-gaps) for the full
+> matrix.
+
+> **Looking for a walkthrough?** Start with the
+> [Writing a Python Unified Backend](../../../../../docs/development/python-backend-guide.md)
+> guide. This README is the in-tree reference: file layout, per-engine
+> cancellation cookbook, disaggregation contract, error-handling table,
+> and the feature-gap matrix.
 
 A two-class abstraction that separates **runtime integration** (common across
 all backends) from **engine logic** (vLLM, SGLang, TensorRT-LLM, etc.).
 
 ## Architecture
 
-```
+```text
 LLMEngine (ABC)                <-- engine boundary (engine.py)
     |   - from_args(argv) -> (LLMEngine, WorkerConfig)  (factory)
-    |   - start() -> EngineConfig        (start engine, return metadata)
-    |   - generate(request, context)    (streaming inference)
-    |   - abort(context)                (cancel request, optional)
-    |   - cleanup()                     (shutdown)
+    |   - start(worker_id) -> EngineConfig    (start engine, return metadata)
+    |   - generate(request, context)         (streaming inference)
+    |   - abort(context)                     (cancel request, optional)
+    |   - drain()                            (pre-cleanup drain, optional)
+    |   - cleanup()                          (shutdown)
     |
     +-- VllmLLMEngine          <-- vllm/llm_engine.py
     +-- SglangLLMEngine        <-- sglang/llm_engine.py
@@ -26,9 +35,9 @@ Worker                  <-- runtime integration (worker.py)
     - receives WorkerConfig from from_args()
     - creates DistributedRuntime
     - sets up endpoints, signal handlers
-    - calls engine.start(), registers model
+    - calls engine.start(worker_id), registers model
     - serves generate endpoint with cancellation monitoring
-    - calls engine.cleanup() on shutdown
+    - calls engine.drain() then engine.cleanup() on shutdown
 ```
 
 ## Quick Start
@@ -80,13 +89,16 @@ class MyEngine(LLMEngine):
         )
         return engine, worker_config
 
-    async def start(self) -> EngineConfig:
+    async def start(self, worker_id: int) -> EngineConfig:
         # Start the engine, return metadata for model registration.
         # After this returns, generate() MUST be ready to accept calls.
+        # `worker_id` is an opaque per-worker key; most engines ignore it.
         return EngineConfig(
             model="my-model",
             context_length=4096,
             kv_cache_block_size=16,
+            # Populate `bootstrap_host` / `bootstrap_port` here on prefill
+            # workers that advertise a Dynamo-level handshake address.
         )
 
     async def generate(self, request, context):
@@ -283,33 +295,37 @@ differently.
 
 ## File Index
 
-```
+```text
 common/backend/
     __init__.py          # Re-exports: LLMEngine, EngineConfig,
+                         #   GenerateChunk, GenerateRequest,
                          #   Worker, WorkerConfig
-    engine.py            # LLMEngine ABC + EngineConfig dataclass
-    worker.py            # Worker + WorkerConfig
+    engine.py            # LLMEngine ABC + EngineConfig dataclass +
+                         #   GenerateRequest/GenerateChunk TypedDicts
+    worker.py            # Worker + WorkerConfig (incl. disaggregation_mode)
     disagg.py            # Disagg request helpers (prefill clamp,
                          #   prefill_result extraction)
     run.py               # Common entry point: run(engine_cls)
     sample_engine.py     # SampleLLMEngine (reference impl)
     sample_main.py       # Entry point for sample engine
+    tests/               # test_backend_bindings, test_disagg_helpers,
+                         #   test_sample_engine
+    CLAUDE.md            # Design notes (rationale, invariants)
 
-vllm/llm_engine.py       # VllmLLMEngine
+vllm/llm_engine.py       # VllmLLMEngine (agg + disagg)
 vllm/unified_main.py     # Entry point -> run(VllmLLMEngine)
 
-sglang/llm_engine.py     # SglangLLMEngine
+sglang/llm_engine.py     # SglangLLMEngine (agg + disagg, bootstrap handshake)
 sglang/unified_main.py   # Entry point -> run(SglangLLMEngine)
 
-trtllm/llm_engine.py     # TrtllmLLMEngine
+trtllm/llm_engine.py     # TrtllmLLMEngine (agg + disagg)
 trtllm/unified_main.py   # Entry point -> run(TrtllmLLMEngine)
 ```
 
 ## Feature Gaps
 
-The unified path currently supports **minimal aggregated inference** only.
-Below is a summary of what the existing (non-unified) backends provide that
-the unified path does not yet support.
+Below is a summary of what the existing (non-unified) backends provide
+that the unified path does not yet support.
 
 ### What works today
 

--- a/docs/backends/mocker_backend/README.md
+++ b/docs/backends/mocker_backend/README.md
@@ -71,28 +71,9 @@ reachable via `NATS_SERVER` / `ETCD_ENDPOINTS` env vars.
 
 ## Writing your own Rust backend
 
-1. New crate depending on `dynamo-backend-common`; place under `lib/`.
-2. Implement
-   [`LLMEngine`](../../../lib/backend-common/src/engine.rs)
-   plus an inherent
-   `from_args(argv) -> Result<(Self, WorkerConfig), DynamoError>`.
-3. Mirror the mocker example's three-line `main.rs`.
-4. Run the conformance kit in your tests:
-
-   ```toml
-   [dev-dependencies]
-   dynamo-backend-common = { workspace = true, features = ["testing"] }
-   ```
-
-   ```rust
-   #[tokio::test]
-   async fn my_engine_satisfies_contract() {
-       let engine = MyEngine::new_for_test();
-       dynamo_backend_common::testing::run_conformance(engine)
-           .await
-           .expect("conformance");
-   }
-   ```
+See [Writing a Rust Unified Backend](../../development/rust-backend-guide.md)
+— a step-by-step walkthrough that uses this mocker example as its
+reference engine.
 
 ## Layout
 

--- a/docs/development/backend-guide.md
+++ b/docs/development/backend-guide.md
@@ -8,6 +8,17 @@ subtitle: Create custom Python workers and engines for Dynamo
 
 # Writing Python Workers in Dynamo
 
+> **Lower-level Python worker path.** This guide documents the
+> `@dynamo_worker()` + `register_model()` + `endpoint.serve_endpoint()`
+> entry point. For new engines, prefer Dynamo's
+> [unified Python backend](python-backend-guide.md) (or
+> [unified Rust backend](rust-backend-guide.md)) — those put the
+> framework in charge of lifecycle, signal handling, cancellation
+> monitoring, and registration. Stay on this path for workloads that
+> depend on multimodal, LoRA, logprobs, guided decoding, metrics,
+> OTEL tracing, or engine routes — features the unified backend does
+> not yet cover.
+
 This guide explains how to create your own Python worker in Dynamo.
 
 The [dynamo](https://pypi.org/project/ai-dynamo/) Python library allows you to build your own engine and attach it to Dynamo.

--- a/docs/development/python-backend-guide.md
+++ b/docs/development/python-backend-guide.md
@@ -466,28 +466,33 @@ class _StubContext:
 async def test_generate_emits_terminal_chunk():
     engine = MyBackend(model_name="m", max_tokens=3)
     await engine.start(worker_id=0)
-    chunks = [
-        chunk
-        async for chunk in engine.generate(
-            {"token_ids": [1, 2, 3]}, _StubContext()
-        )
-    ]
-    assert chunks[-1]["finish_reason"] in ("stop", "length")
-    assert chunks[-1]["completion_usage"]["completion_tokens"] == 3
-    await engine.cleanup()
+    try:
+        chunks = [
+            chunk
+            async for chunk in engine.generate(
+                {"token_ids": [1, 2, 3]}, _StubContext()
+            )
+        ]
+        assert chunks[-1]["finish_reason"] in ("stop", "length")
+        assert chunks[-1]["completion_usage"]["completion_tokens"] == 3
+    finally:
+        await engine.cleanup()
 
 
 @pytest.mark.asyncio
 async def test_generate_observes_cancellation():
     engine = MyBackend(model_name="m", max_tokens=1000)
-    ctx = _StubContext()
-    collected = []
-    async for chunk in engine.generate({"token_ids": [1]}, ctx):
-        collected.append(chunk)
-        if len(collected) >= 2:
-            ctx.stop()
-    assert collected[-1]["finish_reason"] == "cancelled"
-    await engine.cleanup()
+    await engine.start(worker_id=0)
+    try:
+        ctx = _StubContext()
+        collected = []
+        async for chunk in engine.generate({"token_ids": [1]}, ctx):
+            collected.append(chunk)
+            if len(collected) >= 2:
+                ctx.stop()
+        assert collected[-1]["finish_reason"] == "cancelled"
+    finally:
+        await engine.cleanup()
 ```
 
 Cover the happy path, cancellation, and any backend-specific edge

--- a/docs/development/python-backend-guide.md
+++ b/docs/development/python-backend-guide.md
@@ -346,9 +346,22 @@ no-op.
 
 ### `cleanup()`
 
-Called once on shutdown, exactly once if `start()` succeeded. The
-framework's state machine guarantees no concurrent or repeat calls,
-so your implementation doesn't need to defend against them:
+Two real requirements, both pinned by the Rust-side conformance kit:
+
+- **Null-safe against partial `start()` failure.** If `start()` raises
+  partway through, fields you allocate incrementally may still be
+  `None`. `cleanup()` must guard each resource (`if self._engine is
+  not None: …`) so the post-failure call doesn't crash on
+  half-initialized state.
+- **Idempotent.** A second call after a successful first must return
+  cleanly without re-entering teardown.
+
+The Rust `Worker` drives both: it calls `cleanup()` after `start()`
+returns Ok on shutdown, and the conformance kit (`run_conformance`)
+additionally calls `cleanup()` on a never-started engine and twice in a
+row, failing your tests with `CleanupWithoutStartFailed` /
+`SecondCleanupFailed` if either invariant breaks. The guarded
+single-shot pattern below covers both:
 
 ```python
 async def cleanup(self) -> None:

--- a/docs/development/python-backend-guide.md
+++ b/docs/development/python-backend-guide.md
@@ -12,13 +12,17 @@ title: Writing a Python Unified Backend
 > a shared `LLMEngine` ABC that vLLM, SGLang, TRT-LLM, and a sample
 > engine already implement, and that any custom Python engine can plug
 > into the same way. For the Rust version of the same contract see
-> [Writing a Rust Unified Backend](rust-backend-guide.md).
+> [Writing a Rust Unified Backend](rust-backend-guide.md). For the
+> older lower-level Python worker path (`register_model` +
+> `serve_endpoint`) — still the right choice for features the unified
+> backend does not yet cover — see
+> [Writing Python Workers](backend-guide.md).
 >
 > **Beta — actively under development.** The unified backend surface
-> is beta quality, currently supports minimal aggregated inference
-> (see "Feature gaps" in the
-> [package README](../../components/src/dynamo/common/backend/README.md)),
-> and may change without backwards compatibility between releases.
+> is beta quality and may change without backwards compatibility
+> between releases. See [Feature gaps](#feature-gaps) below for what
+> the unified path covers today versus the existing (non-unified)
+> backend paths.
 
 This guide walks through building a Python backend for an inference
 engine that plugs into Dynamo's distributed runtime via
@@ -47,7 +51,49 @@ alongside this guide.
   — in-tree reference: `GenerateRequest` / `GenerateChunk` field
   definitions, per-engine cancellation cookbook (vLLM / SGLang /
   TRT-LLM), full `DynamoException` table, file index, and the
-  current feature-gap matrix.
+  per-engine feature-gap matrix.
+
+## Feature gaps
+
+The unified backend is in beta and does not yet cover the full feature
+set of Dynamo's existing (non-unified) backend paths. The summary
+below is the common contract — what every engine on the unified path
+gets. Per-engine gaps (vLLM, SGLang, TRT-LLM specifics like LoRA,
+diffusion, attention DP scheduling) live in the
+[package README](../../components/src/dynamo/common/backend/README.md#feature-gaps).
+
+**Supported today**
+
+- Aggregated token-in-token-out inference
+- Disaggregated serving (`agg` / `prefill` / `decode`) with bootstrap
+  (SGLang) or internal KV transport (vLLM, TRT-LLM)
+- Model registration with discovery and endpoint types
+- Request cancellation via `abort()` + `context.is_stopped()`
+- `DynamoException` error chain wrapping
+- Graceful shutdown with signal handling
+- Finish reason normalization (handled by the Rust layer)
+
+**Not yet on the unified path**
+
+| Feature | What's missing |
+|---------|----------------|
+| Metrics & Prometheus | Engine-level metrics, KV utilization gauges, multiprocess registry |
+| KV event publishing | Prefix cache events (BlockStored / Removed) to router via ZMQ or NATS |
+| Health check payloads | Per-engine custom health probes (BOS token probe, etc.) |
+| Logprobs | Selected + top-k logprob extraction and streaming |
+| Guided decoding | JSON schema, regex, grammar, choice constraints |
+| OpenTelemetry tracing | Trace headers, request perf metrics, OTEL propagation |
+| Engine routes | Profiling, memory release/resume, weight updates (disk/tensor/distributed/IPC) |
+| Data-parallel routing | DP rank extraction, DP-aware scheduling |
+| Text-in-text-out mode | OpenAI-compatible chat/completion with engine-side tokenization |
+| Custom Jinja chat templates | `--custom-jinja-template` for model-specific prompt formatting |
+| Snapshot/checkpoint | CRIU-based engine state save/restore |
+| Multimodal | Images, video, embeddings, separate encode workers |
+| LoRA adapters | Dynamic load/unload, ModelDeploymentCard publishing, per-adapter serialization |
+
+If you need one of these features today, keep that workload on the
+existing per-engine entry point (`dynamo.<backend>.main`) until the
+unified path catches up.
 
 ## What you're building
 

--- a/docs/development/python-backend-guide.md
+++ b/docs/development/python-backend-guide.md
@@ -1,0 +1,572 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: Writing a Python Unified Backend
+---
+
+# Writing a Python Unified Backend
+
+> **New — Dynamo's unified backend.** This guide covers the new
+> **unified backend** infrastructure in
+> [`dynamo.common.backend`](../../components/src/dynamo/common/backend/):
+> a shared `LLMEngine` ABC that vLLM, SGLang, TRT-LLM, and a sample
+> engine already implement, and that any custom Python engine can plug
+> into the same way. For the Rust version of the same contract see
+> [Writing a Rust Unified Backend](rust-backend-guide.md).
+>
+> **Beta — actively under development.** The unified backend surface
+> is beta quality, currently supports minimal aggregated inference
+> (see "Feature gaps" in the
+> [package README](../../components/src/dynamo/common/backend/README.md)),
+> and may change without backwards compatibility between releases.
+
+This guide walks through building a Python backend for an inference
+engine that plugs into Dynamo's distributed runtime via
+`dynamo.common.backend`. A "unified backend" is a Python entry point
+that implements the shared `LLMEngine` ABC and lets the framework own
+runtime lifecycle (signal handling, model registration, graceful
+shutdown, cancellation monitoring) — your code just owns inference.
+
+Your backend lives in its own package and **does not need to be part
+of the dynamo repository**. It depends on `ai-dynamo` from PyPI (or
+the git source) and imports `dynamo.common.backend`. The steps below
+assume you're starting a fresh package in your own repo.
+
+The reference example is the **sample engine** at
+[`sample_engine.py`](../../components/src/dynamo/common/backend/sample_engine.py)
+— a complete, runnable implementation under 120 lines. Read it
+alongside this guide.
+
+**Where to look for what:**
+
+- This guide — step-by-step walkthrough for someone starting a new
+  backend from scratch.
+- [`LLMEngine` ABC docstrings](../../components/src/dynamo/common/backend/engine.py)
+  — authoritative method-by-method contract.
+- [Package README](../../components/src/dynamo/common/backend/README.md)
+  — in-tree reference: `GenerateRequest` / `GenerateChunk` field
+  definitions, per-engine cancellation cookbook (vLLM / SGLang /
+  TRT-LLM), full `DynamoException` table, file index, and the
+  current feature-gap matrix.
+
+## What you're building
+
+A backend is two things:
+
+1. **An engine class** that subclasses `LLMEngine` — owns the model,
+   accepts preprocessed token requests, streams output chunks.
+2. **A `main.py` entry point** — a three-line shim that hands the
+   engine class to `run()` from `dynamo.common.backend.run`, which
+   drives the lifecycle.
+
+The `dynamo.common.backend` package handles everything else: signal
+handling, distributed runtime setup, model registration with
+discovery, the serving loop, graceful shutdown, cancellation
+monitoring, and error chain wrapping. (The lifecycle state machine
+actually lives in Rust; `dynamo.common.backend.Worker` is a thin
+Python shim over it.)
+
+```text
+from_args  →  start()  →  generate() / abort()  →  drain()  →  cleanup()
+   |            |               |                     |           |
+parse argv,  start engine,  serve requests       pre-cleanup    release
+return       return            (concurrent)       drain          resources
+engine       metadata
+```
+
+## Prerequisites
+
+- Python 3.11 or newer. `dynamo` uses `typing.Required`, which is 3.11+.
+- NATS and etcd reachable for end-to-end runs. The dynamo repo's
+  `deploy/docker-compose.yml` brings up both in one command if you
+  don't already have them running.
+- `uv` or `pip` for installing dependencies.
+- Familiarity with `async` Python (`asyncio`, async generators) and
+  `argparse`.
+
+## Step 1: Create the package
+
+```text
+my-backend/
+├── pyproject.toml
+└── src/
+    └── my_backend/
+        ├── __init__.py
+        ├── engine.py
+        └── main.py
+```
+
+Minimal `pyproject.toml`:
+
+```toml
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "my-backend"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    # ai-dynamo bundles dynamo.common.backend. Pin to the release whose
+    # LLMEngine contract you tested against — the surface is still beta
+    # and may change between releases.
+    "ai-dynamo>=1.2.0",
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=8", "pytest-asyncio>=0.23"]
+
+[project.scripts]
+my-backend = "my_backend.main:main"
+```
+
+For a bleeding-edge dependency on the dynamo source tree, install
+the runtime wheel from a clone:
+
+```bash
+git clone https://github.com/ai-dynamo/dynamo.git
+pip install maturin
+cd dynamo/lib/bindings/python && maturin build --release --out /tmp/wheels
+pip install /tmp/wheels/*.whl       # ai-dynamo-runtime
+pip install /path/to/dynamo         # ai-dynamo (components/ tree)
+```
+
+Building the wheel needs a Rust toolchain plus `clang`, `cmake`,
+`protobuf-compiler`, and `libssl-dev`.
+
+## Step 2: Subclass `LLMEngine`
+
+In `src/my_backend/engine.py`, declare a class that subclasses
+`LLMEngine` and owns whatever state your engine needs. Construction
+must be cheap and side-effect-free — heavy work goes in `start()`.
+
+```python
+# src/my_backend/engine.py
+from __future__ import annotations
+
+import argparse
+import asyncio
+from collections.abc import AsyncGenerator
+
+from dynamo._core import Context
+from dynamo.common.backend import (
+    EngineConfig,
+    GenerateChunk,
+    GenerateRequest,
+    LLMEngine,
+    WorkerConfig,
+)
+
+
+class MyBackend(LLMEngine):
+    def __init__(self, model_name: str, max_tokens: int = 16):
+        self.model_name = model_name
+        self.max_tokens = max_tokens
+        # Heavy state (engine handles, schedulers, KV allocators) is
+        # left None here and initialized in start().
+        self._engine = None
+```
+
+`GenerateRequest` and `GenerateChunk` are `TypedDict`s describing the
+shared shape — see Step 4 for the fields.
+
+## Step 3: Implement `from_args`
+
+`from_args` is a classmethod factory that parses CLI args and returns
+`(engine, WorkerConfig)`. The engine is constructed but **not
+started**.
+
+```python
+@classmethod
+async def from_args(
+    cls, argv: list[str] | None = None
+) -> tuple[MyBackend, WorkerConfig]:
+    parser = argparse.ArgumentParser(prog="my-backend")
+    parser.add_argument("--model-name", default="my-model")
+    parser.add_argument("--max-tokens", type=int, default=16)
+    # Runtime / discovery flags — every unified backend needs these.
+    parser.add_argument("--namespace", default="dynamo")
+    parser.add_argument("--component", default="backend")
+    parser.add_argument("--endpoint", default="generate")
+    parser.add_argument("--endpoint-types", default="chat,completions")
+    parser.add_argument("--discovery-backend", default="etcd")
+    parser.add_argument("--request-plane", default="tcp")
+    parser.add_argument("--event-plane", default=None)
+    args = parser.parse_args(argv)
+
+    engine = cls(model_name=args.model_name, max_tokens=args.max_tokens)
+    worker_config = WorkerConfig(
+        namespace=args.namespace,
+        component=args.component,
+        endpoint=args.endpoint,
+        model_name=args.model_name,
+        served_model_name=args.model_name,
+        endpoint_types=args.endpoint_types,
+        discovery_backend=args.discovery_backend,
+        request_plane=args.request_plane,
+        event_plane=args.event_plane,
+    )
+    return engine, worker_config
+```
+
+`from_args` is `async` to match the ABC; you can `await` from it if
+your CLI parsing reads config from a file or hits an API. Most
+backends don't need to.
+
+For backends that already have a `DynamoRuntimeConfig`-shaped
+config object (e.g. ones derived from vLLM's, SGLang's, or
+TRT-LLM's existing config), prefer the
+`WorkerConfig.from_runtime_config(runtime_cfg, model_name=...)`
+helper — it pulls the shared discovery / request-plane / parser
+fields off the config in one line.
+
+## Step 4: Implement `LLMEngine` methods
+
+The ABC has three required methods (`start`, `generate`, `cleanup`)
+plus two with default no-op implementations (`abort`, `drain`).
+
+### `start()`
+
+Start the engine and return `EngineConfig` metadata. After this
+returns, `generate()` MUST be ready for concurrent calls.
+
+```python
+async def start(self, worker_id: int) -> EngineConfig:
+    # ... load weights, build scheduler, warm up CUDA, etc.
+    # Heavy: may take minutes. Emit logger.info checkpoints so
+    # operators see progress (Worker logs around start() but not
+    # inside it).
+    self._engine = await heavy_init(self.model_name)
+
+    return EngineConfig(
+        model=self.model_name,
+        served_model_name=self.model_name,
+        context_length=8192,
+        kv_cache_block_size=16,    # None if no block-structured KV
+        total_kv_blocks=1024,
+        max_num_seqs=64,
+        max_num_batched_tokens=8192,
+    )
+```
+
+`worker_id` is an opaque per-worker identifier — most engines ignore
+it. Backends needing a stable cluster-wide key (e.g. TRT-LLM's
+`disagg_machine_id` snowflake) should derive from it instead of
+hashing host/pid or asking operators for a CLI override.
+
+Every `EngineConfig` field except `model` is optional. `None` means
+"don't advertise"; KV-aware routing falls back to round-robin when KV
+fields are unset.
+
+### `generate()`
+
+An async generator that yields `GenerateChunk` dicts for a single
+request. Called concurrently for multiple in-flight requests.
+
+**Contract** (chunk shape is defined by the `GenerateChunk` TypedDict
+— see
+[Request / Response Types](../../components/src/dynamo/common/backend/README.md#request--response-types)
+in the package README for the field reference):
+
+- Every chunk carries `token_ids` and `index` (use `0` for single
+  choice).
+- The final chunk additionally carries `finish_reason` and
+  `completion_usage`.
+- The framework's cancellation monitor calls `engine.abort(context)`
+  when the client disconnects or cancels; your loop should also poll
+  `context.is_stopped()` between yields and exit cleanly with a
+  `finish_reason="cancelled"` chunk.
+
+```python
+async def generate(
+    self, request: GenerateRequest, context: Context
+) -> AsyncGenerator[GenerateChunk, None]:
+    prompt_tokens = list(request.get("token_ids", []))
+    prompt_len = len(prompt_tokens)
+
+    stop_conditions = request.get("stop_conditions") or {}
+    max_new = stop_conditions.get("max_tokens") or self.max_tokens
+
+    def _usage(completion_tokens: int) -> dict[str, int]:
+        return {
+            "prompt_tokens": prompt_len,
+            "completion_tokens": completion_tokens,
+            "total_tokens": prompt_len + completion_tokens,
+        }
+
+    for i in range(max_new):
+        if context.is_stopped():
+            yield {
+                "token_ids": [],
+                "index": 0,
+                "finish_reason": "cancelled",
+                "completion_usage": _usage(i),
+            }
+            return
+
+        token_id = await self._next_token(prompt_tokens)
+
+        chunk: GenerateChunk = {"token_ids": [token_id], "index": 0}
+        if i == max_new - 1:
+            chunk["finish_reason"] = "length"
+            chunk["completion_usage"] = _usage(max_new)
+        yield chunk
+```
+
+Finish reason normalization (`"abort"` → `"cancelled"`, etc.) is
+handled by the Rust layer — emit whatever your engine uses
+natively.
+
+### `abort(context)` — optional
+
+Called by the framework only when the client disconnects or the
+request is cancelled. NOT called on silent stream drops. Override to
+release engine-side resources (KV slots, scheduler entries, remote
+schedulers):
+
+```python
+async def abort(self, context: Context) -> None:
+    request_id = context.id()
+    await self._engine.cancel(request_id)
+```
+
+For cleanup that must run on every drop path — including silent
+drops — use a `try/finally` or a context manager inside `generate`,
+not `abort`. The sample engine doesn't override `abort` because it
+has no engine-side state to release; the default is a no-op.
+
+### `drain()` — optional
+
+Runs once before shutdown, after the discovery unregister +
+grace-period sleep, while NATS/etcd are still alive. Use it for
+backend-side draining that must complete before transport teardown
+(e.g. in-flight NIXL KV transfers on prefill workers). Default is
+no-op.
+
+### `cleanup()`
+
+Called once on shutdown, exactly once if `start()` succeeded. The
+framework's state machine guarantees no concurrent or repeat calls,
+so your implementation doesn't need to defend against them:
+
+```python
+async def cleanup(self) -> None:
+    if self._engine is not None:
+        await self._engine.shutdown()
+        self._engine = None
+```
+
+## Step 5: Write `main.py`
+
+Three lines.
+
+```python
+# src/my_backend/main.py
+from dynamo.common.backend.run import run
+from .engine import MyBackend
+
+
+def main() -> None:
+    run(MyBackend)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+`run` installs signal handlers, builds the distributed runtime,
+calls `engine.start(worker_id)` with a runtime-allocated identifier,
+registers the model with discovery, serves the endpoint, and runs the
+graceful-shutdown orchestrator on SIGTERM/SIGINT.
+
+Pair this with the `[project.scripts]` entry from Step 1's
+`pyproject.toml` so `my-backend ...` works as a console command.
+
+## Step 6: Errors and logging
+
+**Errors**: the framework wraps non-`DynamoException` errors raised
+from `generate()` (or lifecycle methods) as `Unknown`. For typed
+error reporting, raise a `DynamoException` subclass directly from
+[`dynamo.llm.exceptions`](../../components/src/dynamo/common/backend/README.md#error-handling)
+— it propagates unchanged through the Rust bridge:
+
+```python
+from dynamo.llm.exceptions import InvalidArgument
+
+async def generate(self, request, context):
+    if not request.get("token_ids"):
+        raise InvalidArgument("empty prompt")
+    ...
+```
+
+The package README has the full table of exception types and which
+lifecycle phase raises which one. Engine-init failures should raise
+`EngineShutdown` from `start()`. Cleanup shouldn't normally raise —
+log and swallow if a subsystem fails.
+
+**Logging**: keep levels consistent across unified backends so
+operators see the same surface regardless of which engine they're
+running:
+
+- `logger.info` — lifecycle milestones (engine init complete,
+  serving started, engine shutdown).
+- `logger.debug` — per-request events (request abort, cancellation).
+- `logger.warning` — recoverable problems (empty outputs, unexpected
+  finish reasons).
+- `logger.error` — unrecoverable failures only.
+
+The framework also configures `dynamo.runtime.logging` for you; you
+just call `logger = logging.getLogger(__name__)` at the top of your
+module and use it.
+
+## Step 7: Test your engine
+
+Install the dev extras (`pytest`, `pytest-asyncio`) declared in Step 1:
+
+```bash
+pip install -e ".[dev]"
+```
+
+The sample engine has a unit-test
+[suite](../../components/src/dynamo/common/backend/tests/test_engine.py)
+that you can copy as a starting point. The shape of a useful test:
+
+```python
+import pytest
+
+from my_backend import MyBackend
+
+
+class _StubContext:
+    def __init__(self, stopped: bool = False) -> None:
+        self._stopped = stopped
+
+    def is_stopped(self) -> bool:
+        return self._stopped
+
+    def stop(self) -> None:
+        self._stopped = True
+
+
+@pytest.mark.asyncio
+async def test_generate_emits_terminal_chunk():
+    engine = MyBackend(model_name="m", max_tokens=3)
+    await engine.start(worker_id=0)
+    chunks = [
+        chunk
+        async for chunk in engine.generate(
+            {"token_ids": [1, 2, 3]}, _StubContext()
+        )
+    ]
+    assert chunks[-1]["finish_reason"] in ("stop", "length")
+    assert chunks[-1]["completion_usage"]["completion_tokens"] == 3
+    await engine.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_generate_observes_cancellation():
+    engine = MyBackend(model_name="m", max_tokens=1000)
+    ctx = _StubContext()
+    collected = []
+    async for chunk in engine.generate({"token_ids": [1]}, ctx):
+        collected.append(chunk)
+        if len(collected) >= 2:
+            ctx.stop()
+    assert collected[-1]["finish_reason"] == "cancelled"
+    await engine.cleanup()
+```
+
+Cover the happy path, cancellation, and any backend-specific edge
+cases (stop tokens, max-tokens cap, empty prompt). Three to five
+focused tests is plenty — the framework already pins the lifecycle
+state machine and cancellation contract with Rust-side tests in
+`lib/backend-common`.
+
+## Step 8: Run it locally
+
+Three moving parts need to come up: NATS + etcd (discovery and the
+event/request planes), the Dynamo frontend (HTTP → backend
+discovery), and your backend.
+
+```bash
+pip install -e .
+
+# Ensure NATS + etcd are reachable (NATS_SERVER, ETCD_ENDPOINTS).
+# --model-name must be a valid HuggingFace repo (or local path); the
+# framework fetches the tokenizer + chat template from it on startup.
+# Pick a small public repo for smoke tests.
+my-backend --model-name Qwen/Qwen3-0.6B --namespace dynamo
+
+# In another shell, start the Dynamo frontend:
+python -m dynamo.frontend --http-port 8000
+```
+
+Then send a request:
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+    -H 'Content-Type: application/json' \
+    -d '{
+          "model": "Qwen/Qwen3-0.6B",
+          "messages": [{"role": "user", "content": "hello"}],
+          "max_tokens": 32
+        }'
+```
+
+A successful response has non-empty `choices[0].message.content`
+and a `finish_reason` of `stop` or `length`.
+`jq -e '.choices[0].finish_reason'` is a good one-liner for a CI
+smoke test.
+
+If your backend looks silent, set `DYN_LOG=info` (or
+`DYN_LOG=debug,dynamo=debug` for finer scoping) before launching —
+the framework configures `tracing` from `DYN_LOG`.
+
+## Reference: the sample engine
+
+[`sample_engine.py`](../../components/src/dynamo/common/backend/sample_engine.py)
+is the canonical minimal reference. Run it as-is:
+
+```bash
+python -m dynamo.common.backend.sample_main --model-name test-model
+```
+
+It generates rotating token IDs with no ML dependencies, so it's a
+useful stand-in for AIPerf / end-to-end pipeline smoke tests. Lift
+these patterns:
+
+- `from_args` parses CLI args and returns `(engine, WorkerConfig)`
+  with no awaits.
+- `start()` returns an `EngineConfig` whose KV fields are
+  illustrative but not load-bearing (no real KV cache).
+- `generate()` polls `context.is_stopped()` between yields and
+  emits a `cancelled` terminal on observation.
+- `cleanup()` is a no-op because the engine holds no resources.
+
+## Checklist
+
+Before shipping:
+
+- [ ] `LLMEngine` subclassed; `from_args` returns
+      `(engine, WorkerConfig)`.
+- [ ] `start()` returns `EngineConfig` with at least a non-empty
+      `model`.
+- [ ] `generate()` polls `context.is_stopped()` between yields and
+      emits a `"cancelled"` terminal on observation.
+- [ ] Final chunk has `finish_reason` and `completion_usage`.
+- [ ] Typed `DynamoException` subclasses used for error reporting
+      where the category matters.
+- [ ] `cleanup()` releases all engine resources.
+- [ ] Logging levels match the standards in Step 6.
+
+## See also
+
+- [`LLMEngine` ABC](../../components/src/dynamo/common/backend/engine.py)
+  — authoritative contract.
+- [Package README](../../components/src/dynamo/common/backend/README.md)
+  — feature gaps, error model, request/response contract.
+- [Sample engine](../../components/src/dynamo/common/backend/sample_engine.py)
+  — example user guide.
+- [Writing a Rust Unified Backend](rust-backend-guide.md) — the Rust
+  counterpart, same contract, lower-level.

--- a/docs/development/rust-backend-guide.md
+++ b/docs/development/rust-backend-guide.md
@@ -14,8 +14,10 @@ title: Writing a Rust Unified Backend
 > same way.
 >
 > **Beta — actively under development.** The Rust native backend
-> surface is beta quality, does not yet cover the full Dynamo feature
-> set, and may change without backwards compatibility between releases.
+> surface is beta quality and may change without backwards
+> compatibility between releases. See [Feature gaps](#feature-gaps)
+> below for what the unified path covers today versus the existing
+> (non-unified) backend paths.
 
 This guide walks through building a Rust unified backend for an
 inference engine that plugs into Dynamo's distributed runtime. A
@@ -32,6 +34,13 @@ git or path dependency. The steps below assume you're starting a fresh
 crate in your own repo; an optional note in Step 1 covers the in-tree
 variant for contributors landing a backend inside `ai-dynamo/dynamo`.
 
+For a Python engine, use
+[Writing a Python Unified Backend](python-backend-guide.md) — same
+contract, lighter setup. The non-unified fallback for feature gaps
+(multimodal, LoRA, logprobs, etc.) is Python-only; see
+[Writing Python Workers](backend-guide.md) if you need one of those
+today.
+
 The reference example is the **mocker backend** at
 [`lib/backend-common/examples/mocker`](../../lib/backend-common/examples/mocker/)
 — a small, complete, pure-Rust implementation. Read it alongside this
@@ -47,7 +56,53 @@ guide.
   reference: architecture, file index, disaggregation contract,
   error taxonomy, conformance kit.
 - [`backend-common` design notes](../../lib/backend-common/CLAUDE.md)
-  — rationale, invariants, phase plans.
+  — rationale and invariants.
+
+## Feature gaps
+
+The unified backend is in beta and does not yet cover the full feature
+set of Dynamo's existing (non-unified) backend paths. The summary
+below is the common contract — what every engine on the unified path
+gets, whether written in Rust directly or plugged in from Python via
+the PyO3 `Worker` shim. Per-engine gaps (vLLM, SGLang, TRT-LLM
+specifics like LoRA, diffusion, attention DP scheduling) live in the
+[Python package README](../../components/src/dynamo/common/backend/README.md#feature-gaps).
+
+**Supported today**
+
+- Aggregated token-in-token-out inference
+- Disaggregated serving (`Aggregated` / `Prefill` / `Decode`) with
+  bootstrap (SGLang) or internal KV transport (vLLM, TRT-LLM); the
+  Rust [mocker example](../../lib/backend-common/examples/mocker/)
+  exercises the same wire format CPU-only
+- Model registration with discovery and endpoint types
+- Request cancellation via in-stream `ctx.is_stopped()` polling plus
+  the framework's out-of-band `abort()` monitor
+- Typed `DynamoError` with `ErrorType::Backend(BackendError::X)`
+- Graceful shutdown with signal handling, `drain()` hook, and 3-phase
+  distributed-runtime teardown
+- Debug-build stream validator and the `testing::run_conformance` kit
+
+**Not yet on the unified path**
+
+| Feature | What's missing |
+|---------|----------------|
+| Metrics & Prometheus | Engine-level metrics, KV utilization gauges, multiprocess registry |
+| KV event publishing | Prefix cache events (BlockStored / Removed) to router via ZMQ or NATS |
+| Health check payloads | Per-engine custom health probes |
+| Logprobs | Selected + top-k logprob extraction and streaming |
+| Guided decoding | JSON schema, regex, grammar, choice constraints |
+| OpenTelemetry tracing | Trace headers, request perf metrics, OTEL propagation |
+| Engine routes | Profiling, memory release/resume, weight updates (disk/tensor/distributed/IPC) |
+| Data-parallel routing | DP rank extraction, DP-aware scheduling |
+| Text-in-text-out mode | `ModelInput::Text` is rejected at startup — `Tokens` only |
+| Custom Jinja chat templates | Plumbed through `WorkerConfig` but not yet honored end-to-end |
+| Snapshot/checkpoint | CRIU-based engine state save/restore |
+| Multimodal | Images, video, embeddings, separate encode workers |
+| LoRA adapters | Dynamic load/unload, per-adapter serialization |
+
+If you need one of these features today, keep that workload on the
+existing per-engine entry point until the unified path catches up.
 
 ## What you're building
 
@@ -730,8 +785,8 @@ Before shipping:
 - [Crate README](../../lib/backend-common/README.md) — in-tree
   reference (architecture, file index, contracts at a glance).
 - [`LLMEngine` trait](../../lib/backend-common/src/engine.rs) — authoritative contract.
-- [Design notes](../../lib/backend-common/CLAUDE.md) — rationale,
-  invariants, phase-2 PyO3 plans.
+- [Design notes](../../lib/backend-common/CLAUDE.md) — rationale and
+  invariants.
 - [`Worker`](../../lib/backend-common/src/worker.rs) — runtime
   lifecycle internals (signal handling, graceful shutdown, model
   registration).

--- a/docs/development/rust-backend-guide.md
+++ b/docs/development/rust-backend-guide.md
@@ -282,6 +282,10 @@ impl MyBackend {
             endpoint: args.common.endpoint,
             endpoint_types: args.common.endpoint_types,
             custom_jinja_template: args.common.custom_jinja_template,
+            // Pass `--disaggregation-mode` from `CommonArgs` through to the
+            // Worker — without this line the worker silently registers as
+            // Aggregated regardless of what the operator passed.
+            disaggregation_mode: args.common.disaggregation_mode,
             model_name: args.model,
             served_model_name: args.served_model_name,
             ..Default::default()
@@ -296,6 +300,11 @@ impl MyBackend {
 which is the only mode `Worker` currently supports — the framework
 validates this at startup. Engines needing raw text or tensor inputs
 aren't supported yet.
+
+If your engine branches on the disaggregation role inside `generate`
+(prefill vs decode), keep the same `DisaggregationMode` on your engine
+struct so the runtime registration (`WorkerConfig`) and the per-request
+dispatch stay in lockstep.
 
 ## Step 4: Implement the `LLMEngine` trait
 

--- a/docs/development/rust-backend-guide.md
+++ b/docs/development/rust-backend-guide.md
@@ -37,10 +37,17 @@ The reference example is the **mocker backend** at
 — a small, complete, pure-Rust implementation. Read it alongside this
 guide.
 
-The authoritative contract lives in the
-[`LLMEngine` trait doc comments](../../lib/backend-common/src/engine.rs)
-and the [`backend-common` design notes](../../lib/backend-common/CLAUDE.md).
-This guide is the on-ramp.
+**Where to look for what:**
+
+- This guide — step-by-step walkthrough for someone starting a new
+  backend from scratch.
+- [`LLMEngine` trait doc comments](../../lib/backend-common/src/engine.rs)
+  — authoritative method-by-method contract.
+- [Crate README](../../lib/backend-common/README.md) — in-tree
+  reference: architecture, file index, disaggregation contract,
+  error taxonomy, conformance kit.
+- [`backend-common` design notes](../../lib/backend-common/CLAUDE.md)
+  — rationale, invariants, phase plans.
 
 ## What you're building
 
@@ -711,6 +718,8 @@ Before shipping:
 
 ## See also
 
+- [Crate README](../../lib/backend-common/README.md) — in-tree
+  reference (architecture, file index, contracts at a glance).
 - [`LLMEngine` trait](../../lib/backend-common/src/engine.rs) — authoritative contract.
 - [Design notes](../../lib/backend-common/CLAUDE.md) — rationale,
   invariants, phase-2 PyO3 plans.
@@ -720,3 +729,5 @@ Before shipping:
 - [Conformance kit](../../lib/backend-common/src/testing.rs) —
   `run_conformance`, `mock_context`, `cancelling_context`.
 - [Mocker backend](../backends/mocker_backend/README.md) — example user guide.
+- [Python sibling](../../components/src/dynamo/common/backend/README.md)
+  — Python ABC layered over this crate.

--- a/docs/development/rust-backend-guide.md
+++ b/docs/development/rust-backend-guide.md
@@ -1,0 +1,722 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: Writing a Rust Unified Backend
+---
+
+# Writing a Rust Unified Backend
+
+> **New — Dynamo's unified backend.** This guide covers the new
+> **unified backend** infrastructure in
+> [`dynamo-backend-common`](../../lib/backend-common/): a shared
+> `LLMEngine` contract that vLLM, SGLang, TRT-LLM, and the mocker
+> already implement, and that any custom engine can plug into the
+> same way.
+>
+> **Beta — actively under development.** The Rust native backend
+> surface is beta quality, does not yet cover the full Dynamo feature
+> set, and may change without backwards compatibility between releases.
+
+This guide walks through building a Rust unified backend for an
+inference engine that plugs into Dynamo's distributed runtime. A
+unified backend is a standalone Rust binary that owns its engine and
+serves requests via the shared
+[`LLMEngine`](../../lib/backend-common/src/engine.rs) contract in
+[`dynamo-backend-common`](../../lib/backend-common/) — no Python
+worker runtime required. For the Python version of the same contract
+see [Writing a Python Unified Backend](python-backend-guide.md).
+
+Your backend lives in its own crate and **does not need to be part of
+the dynamo repository**. It pulls `dynamo-backend-common` in as a normal
+git or path dependency. The steps below assume you're starting a fresh
+crate in your own repo; an optional note in Step 1 covers the in-tree
+variant for contributors landing a backend inside `ai-dynamo/dynamo`.
+
+The reference example is the **mocker backend** at
+[`lib/backend-common/examples/mocker`](../../lib/backend-common/examples/mocker/)
+— a small, complete, pure-Rust implementation. Read it alongside this
+guide.
+
+The authoritative contract lives in the
+[`LLMEngine` trait doc comments](../../lib/backend-common/src/engine.rs)
+and the [`backend-common` design notes](../../lib/backend-common/CLAUDE.md).
+This guide is the on-ramp.
+
+## What you're building
+
+A backend is two things:
+
+1. **An engine type** that implements the `LLMEngine` trait — owns the
+   model, accepts preprocessed token requests, streams output tokens.
+2. **A `main.rs` entry point** — a three-line shim that hands the
+   engine to `dynamo_backend_common::run`, which drives the lifecycle.
+
+The `dynamo-backend-common` crate handles everything else: signal
+handling, model registration with discovery, the serving loop, graceful
+shutdown, metrics, cancellation plumbing, and the debug-mode contract
+validator.
+
+Engines work directly with `PreprocessedRequest` and `LLMEngineOutput`
+— the same types used by Dynamo's preprocessing, routing, and frontend.
+No Python-shaped translation layer.
+
+```text
+construct  →  start()  →  generate() / abort()  →  drain() →  cleanup()
+   |            |               |                      |          |
+parse args   start engine,  serve requests       pre-cleanup   release
+return       return            (concurrent)       drain        resources
+engine       metadata
+```
+
+## Prerequisites
+
+- Rust 1.85 or newer (the dynamo workspace is edition 2024). The
+  toolchain pin in Step 1 locks this in for you; older toolchains will
+  fail with `feature edition2024 is required` deep inside the build.
+- NATS and etcd reachable for end-to-end runs. The dynamo repo's
+  `deploy/docker-compose.yml` brings up both in one command if you
+  don't already have them running.
+- Familiarity with `async` Rust, `tokio`, and `clap`. The trait uses
+  `async_trait`, and the framework expects a `tokio` runtime.
+
+## Step 1: Create the crate
+
+Your backend is a standalone Rust binary crate. It can live in its own
+repository — the dynamo repo is **not** required to be your parent
+workspace. Pick whatever layout you prefer:
+
+```text
+my-backend/
+├── Cargo.toml
+└── src/
+    ├── main.rs
+    └── engine.rs        # (or my_engine.rs — whatever you call it)
+```
+
+`cargo new --bin my-backend` is the fastest starting point; add
+`src/engine.rs` yourself afterwards.
+
+### Getting the `dynamo-backend-common` crate
+
+`dynamo-backend-common` lives in the
+[ai-dynamo/dynamo](https://github.com/ai-dynamo/dynamo) repository and
+is not on crates.io. Depend on it via git:
+
+```toml
+[package]
+name = "my-backend"
+version = "0.1.0"
+edition = "2024"
+
+[[bin]]
+name = "my-backend"
+path = "src/main.rs"
+
+[dependencies]
+# Replace <SHA> with the dynamo commit you want to build against.
+# `branch = "main"` works too but moves under you on every rebuild.
+dynamo-backend-common = { git = "https://github.com/ai-dynamo/dynamo.git", rev = "<SHA>" }
+
+anyhow = "1"
+async-stream = "0.3"
+async-trait = "0.1"
+clap = { version = "4", features = ["derive", "env"] }
+futures = "0.3"
+# Must match the version pinned by dynamo-runtime — it relies on
+# tokio_unstable runtime metrics that change shape across releases.
+tokio = { version = "=1.48.0", features = ["full"] }
+tracing = "0.1"
+
+[dev-dependencies]
+dynamo-backend-common = { git = "https://github.com/ai-dynamo/dynamo.git", rev = "<SHA>", features = ["testing"] }
+```
+
+The `testing` feature pulls in the conformance kit used in Step 7.
+
+Pick a SHA with:
+
+```bash
+git ls-remote https://github.com/ai-dynamo/dynamo.git main
+```
+
+> **No release tags yet.** `dynamo-backend-common` landed after the last
+> tagged release (`v1.1.1`), so `tag = "v1.1.1"` won't resolve the
+> crate. Track `main` or pin to a specific SHA until a release tag ships
+> that includes the crate.
+
+### Two build-time requirements you cannot skip
+
+These are easy to miss and surface as confusing compile errors deep
+inside `dynamo-runtime`:
+
+1. **`tokio_unstable` cfg flag.** `dynamo-runtime` uses tokio's
+   unstable runtime-metrics API. Create `.cargo/config.toml` in your
+   crate root:
+
+   ```toml
+   [build]
+   rustflags = ["--cfg", "tokio_unstable"]
+   ```
+
+   Without it, you'll see errors like `method blocking_queue_depth not
+   found on RuntimeMetrics` while compiling `dynamo-runtime`.
+
+2. **Rust toolchain pin.** Match dynamo's toolchain so workspace-edition
+   crates compile. Create `rust-toolchain.toml`:
+
+   ```toml
+   [toolchain]
+   channel = "1.93.1"
+   ```
+
+   Older toolchains fail with `feature edition2024 is required`.
+
+> **Tip — local development**: while iterating against an unreleased
+> change in `dynamo-backend-common`, point the dep at a local clone:
+> `dynamo-backend-common = { path = "/path/to/dynamo/lib/backend-common" }`.
+> Switch back to the git dep before publishing your crate.
+
+If you'd rather develop *inside* the dynamo workspace as a new
+sub-crate, drop your crate under `dynamo/lib/` and use
+`dynamo-backend-common = { workspace = true }` instead. The trait
+contract is identical, and the `.cargo/config.toml` plus toolchain
+pin in the dynamo repo cover the two requirements above for you.
+
+## Step 2: Define your engine struct
+
+In `src/engine.rs` (or whatever you named it), declare a struct that
+owns whatever state your engine needs. Anything you allocate inside
+`start()` later must live behind interior mutability so the trait's
+`&self` methods can reach it.
+
+```rust
+use async_trait::async_trait;
+use dynamo_backend_common::engine::GenerateContext;
+use dynamo_backend_common::{
+    BackendError, CommonArgs, DynamoError, EngineConfig, ErrorType, FinishReason, LLMEngine,
+    LLMEngineOutput, LLMEngineOutputExt, PreprocessedRequest, WorkerConfig, chunk, usage,
+};
+use futures::stream::BoxStream;
+use tokio::sync::RwLock;
+
+pub struct MyBackend {
+    model: String,
+    inner: RwLock<Option<Inner>>,   // allocated in start()
+}
+
+// Replace this with whatever your engine owns — handle, scheduler,
+// client, channel sender, etc. Fields go here. Truly stateless
+// engines can skip `Inner` and `inner` entirely.
+struct Inner {}
+```
+
+`async-trait` lets the trait use `async fn` (still required for
+object-safety with `Arc<dyn LLMEngine>`); `async-stream`'s `stream!`
+macro lets the `generate` body yield items from inside an `async` block.
+
+The mocker example uses `OnceCell` for `Inner`; `RwLock<Option<_>>`
+also works — pick whichever fits your shutdown semantics.
+
+## Step 3: Wire up CLI arguments
+
+Every backend's CLI shares a common base (`--namespace`, `--component`,
+`--endpoint`, etc.) provided by `CommonArgs`. Flatten that into your
+engine's `Args` struct and add your engine-specific flags.
+
+```rust
+#[derive(clap::Parser, Debug)]
+#[command(
+    name = env!("CARGO_BIN_NAME"),
+    about = "My Dynamo Rust backend."
+)]
+struct Args {
+    #[command(flatten)]
+    common: CommonArgs,
+
+    /// HF repo or local model directory.
+    #[arg(value_name = "MODEL")]
+    model: String,
+
+    /// Public-facing model name advertised to clients.
+    #[arg(long)]
+    served_model_name: Option<String>,
+
+    // ... engine-specific flags here.
+}
+```
+
+Define an inherent `from_args` constructor that parses the args and
+returns both the engine and a `WorkerConfig`. **`from_args` is not on
+the trait** — it stays inherent so the trait can remain object-safe
+(`Arc<dyn LLMEngine>` must work).
+
+The snippet below calls a tiny `invalid_arg` helper that builds a
+typed `BackendError::InvalidArgument`. Its full definition lives in
+Step 6 — for now, mentally substitute "any function that returns a
+`DynamoError` with category `InvalidArgument`."
+
+```rust
+impl MyBackend {
+    pub fn from_args(argv: Option<Vec<String>>) -> Result<(Self, WorkerConfig), DynamoError> {
+        let args = match argv {
+            Some(a) => <Args as clap::Parser>::try_parse_from(a),
+            None => <Args as clap::Parser>::try_parse(),
+        }
+        .map_err(|e| invalid_arg(e.to_string()))?;
+
+        let engine = Self {
+            model: args.model.clone(),
+            inner: RwLock::new(None),
+        };
+
+        let config = WorkerConfig {
+            namespace: args.common.namespace,
+            component: args.common.component,
+            endpoint: args.common.endpoint,
+            endpoint_types: args.common.endpoint_types,
+            custom_jinja_template: args.common.custom_jinja_template,
+            model_name: args.model,
+            served_model_name: args.served_model_name,
+            ..Default::default()
+        };
+
+        Ok((engine, config))
+    }
+}
+```
+
+`WorkerConfig::default()` sets `model_input` to `ModelInput::Tokens`,
+which is the only mode `Worker` currently supports — the framework
+validates this at startup. Engines needing raw text or tensor inputs
+aren't supported yet.
+
+## Step 4: Implement the `LLMEngine` trait
+
+The trait has three required methods (`start`, `generate`, `cleanup`)
+plus two with default implementations you can override (`abort`, `drain`).
+
+### `start()`
+
+Start the engine and return `EngineConfig` metadata. After this
+returns, the engine MUST be ready for concurrent `generate()` calls.
+Use interior mutability for anything you initialize here.
+
+```rust
+async fn start(&self, _worker_id: u64) -> Result<EngineConfig, DynamoError> {
+    tracing::info!(model = %self.model, "starting my backend");
+
+    // ... start your engine (may take minutes for real backends — emit
+    // tracing::info! checkpoints so operators see progress).
+    let inner = init_engine(&self.model).await?;
+    *self.inner.write().await = Some(inner);
+
+    Ok(EngineConfig {
+        model: self.model.clone(),
+        served_model_name: Some(self.model.clone()),
+        context_length: Some(8192),
+        kv_cache_block_size: Some(64),     // None if no block-structured KV
+        total_kv_blocks: Some(16384),
+        max_num_seqs: Some(256),
+        max_num_batched_tokens: Some(8192),
+        ..Default::default()
+    })
+}
+```
+
+`worker_id` is an opaque per-worker identifier — most engines ignore
+it with `_worker_id`. Backends needing a stable cluster-wide key
+(e.g. TRT-LLM's `disagg_machine_id` snowflake) should derive from it.
+
+Every `EngineConfig` field except `model` is optional. `None` means
+"don't advertise"; KV-aware routing falls back to round-robin when KV
+fields are unset. Engines wrapping an external runtime can read these
+values from the live engine after it comes up, instead of hard-coding
+them. The `..Default::default()` is load-bearing: `EngineConfig`
+sometimes grows new fields (e.g. `bootstrap_host`/`bootstrap_port`
+for SGLang disagg) and the default keeps existing engines compiling.
+
+### `generate()`
+
+Yield a stream of `Result<LLMEngineOutput, DynamoError>` items for a
+single request. Called concurrently for multiple in-flight requests.
+
+`ctx: GenerateContext` is a thin wrapper that `Deref`s to
+`dyn AsyncEngineContext`, so the cancellation methods (`stopped()`,
+`is_stopped()`, `id()`) you'd expect are still there. The wrapper
+additionally exposes `notify_first_token()` for decode-mode requests
+— most engines can ignore it; the framework auto-fires on the first
+non-empty chunk.
+
+**Contract** (the [debug-mode validator](../../lib/backend-common/src/validate.rs)
+panics on violations):
+
+- Exactly one **terminal item** must be the last item yielded. A
+  terminal is either an `Ok(chunk)` with `finish_reason` set, or an
+  `Err(DynamoError)`. No items may be yielded after a terminal.
+- Non-terminal chunks use `chunk::token(id)` and leave `finish_reason`
+  unset.
+- The returned stream is `'static`: clone or move any state from
+  `&self` or `request` into the stream body before constructing it.
+
+Terminal chunks come from one of four `LLMEngineOutput` constructors,
+optionally chained with the `LLMEngineOutputExt` setters
+(`.with_tokens(...)`, `.with_usage(...)`):
+
+- `LLMEngineOutput::stop()` — natural completion (e.g. you reached your
+  echo limit, the engine hit a stop string).
+- `LLMEngineOutput::length()` — `max_tokens` cap reached.
+- `LLMEngineOutput::cancelled()` — you observed `ctx.stopped()`.
+- `LLMEngineOutput::error(msg)` — message-only error terminal (loses
+  the typed `BackendError` variant — yield `Err(DynamoError)` instead
+  when the category matters).
+
+Non-terminal chunks use `chunk::token(id)` (single-token convenience).
+
+A streaming-`generate` template:
+
+```rust
+async fn generate(
+    &self,
+    request: PreprocessedRequest,
+    ctx: GenerateContext,
+) -> Result<BoxStream<'static, Result<LLMEngineOutput, DynamoError>>, DynamoError> {
+    // Destructure once and move fields into the stream — no extra clones
+    // (the stream is 'static and outlives `request`).
+    let PreprocessedRequest { token_ids, stop_conditions, .. } = request;
+    let prompt_tokens = token_ids.len() as u32;
+    let mut output_rx = self.submit_to_engine(token_ids, stop_conditions).await?;
+
+    Ok(Box::pin(async_stream::stream! {
+        let mut completion_tokens = 0_u32;
+        loop {
+            tokio::select! {
+                biased;
+
+                // Cancellation: emit FinishReason::Cancelled terminal.
+                _ = ctx.stopped() => {
+                    yield Ok(LLMEngineOutput::cancelled()
+                        .with_usage(usage(prompt_tokens, completion_tokens)));
+                    break;
+                }
+
+                // Next item from the engine.
+                next = output_rx.recv() => {
+                    let Some(engine_output) = next else {
+                        yield Ok(LLMEngineOutput::error(
+                            "engine stream ended without a terminal".into()
+                        ));
+                        break;
+                    };
+
+                    // Translate your engine's per-step output into LLMEngineOutput.
+                    // For a terminal step set `finish_reason`; otherwise leave it None.
+                    let mut out = LLMEngineOutput {
+                        token_ids: engine_output.tokens,
+                        finish_reason: engine_output.terminal_reason,
+                        ..Default::default()
+                    };
+                    completion_tokens += out.token_ids.len() as u32;
+
+                    if out.finish_reason.is_some() {
+                        out = out.with_usage(usage(prompt_tokens, completion_tokens));
+                        yield Ok(out);
+                        break;
+                    }
+                    yield Ok(out);
+                }
+            }
+        }
+    }))
+}
+```
+
+`biased` is load-bearing for the channel-receiving pattern above:
+
+1. When cancellation and a pending token are both ready, yield the
+   cancellation, not one more token.
+2. During cleanup the stream sees both `ctx.stopped()` and
+   `rx.recv() -> None` simultaneously; `biased` picks the clean
+   cancellation path instead of erroring on a closed channel. The
+   mocker's [stream body](../../lib/backend-common/examples/mocker/src/engine.rs)
+   spells this out.
+
+If your engine doesn't have a receiver — e.g. you're computing tokens
+inline like a deterministic echo backend — the body collapses to a
+plain loop that polls cancellation between yields:
+
+```rust
+Ok(Box::pin(async_stream::stream! {
+    for (i, token_id) in tokens_to_emit.iter().enumerate() {
+        tokio::select! {
+            biased;
+            _ = ctx.stopped() => {
+                yield Ok(LLMEngineOutput::cancelled()
+                    .with_usage(usage(prompt_tokens, i as u32)));
+                return;
+            }
+            _ = tokio::time::sleep(delay), if !delay.is_zero() => {}
+        }
+        if i == tokens_to_emit.len() - 1 {
+            yield Ok(LLMEngineOutput::stop()
+                .with_tokens(vec![*token_id])
+                .with_usage(usage(prompt_tokens, (i + 1) as u32)));
+        } else {
+            yield Ok(chunk::token(*token_id));
+        }
+    }
+}))
+```
+
+No channel-close race to worry about; `biased` is still cheap and
+recommended for consistency.
+
+**Cancellation rules**:
+
+- The stream **must** poll `ctx.is_stopped()` (or `await ctx.stopped()`)
+  between yields.
+- On cancellation, emit a terminal with `FinishReason::Cancelled` — not
+  `Length` or `Stop`. The conformance kit treats any other terminal
+  after cancellation as ignoring the signal.
+
+**Typed errors vs. string errors**:
+
+```rust
+// Typed (preferred): preserves BackendError variant end-to-end.
+yield Err(DynamoError::builder()
+    .error_type(ErrorType::Backend(BackendError::InvalidArgument))
+    .message("bad request")
+    .build());
+
+// String: convenient, loses the typed variant.
+yield Ok(LLMEngineOutput::error("something went wrong".into()));
+```
+
+Use typed errors when the failure category matters to the caller. Use
+string errors when it doesn't.
+
+### `abort()` and per-request cleanup
+
+`abort` is called by the framework **only** when `ctx.stopped()` or
+`ctx.killed()` fires — i.e. an explicit client/operator cancel. It is
+NOT called when the stream is silently dropped (TCP reset, consumer
+timeout without cancellation).
+
+**For cleanup that must run on any drop path** (releasing a scheduler
+slot, freeing a request handle), use RAII inside the `generate` stream
+body:
+
+```rust
+struct RequestGuard { /* ... */ }
+impl Drop for RequestGuard {
+    fn drop(&mut self) {
+        // Always runs when the stream is dropped, however that happens.
+    }
+}
+
+Ok(Box::pin(async_stream::stream! {
+    let _guard = RequestGuard { /* ... */ };
+    // ... your stream body
+}))
+```
+
+The mocker's `ActiveRequestGuard` is the canonical example.
+
+Use `abort` only for out-of-band notifications (e.g. telling a remote
+scheduler to stop computing for this request).
+
+### `drain()` and `cleanup()`
+
+- `drain()` runs once before shutdown, after the discovery
+  unregister + grace-period sleep, while NATS/etcd are still alive.
+  Use it for backend-side draining that must complete before the
+  transport layer goes away (e.g. in-flight NIXL KV transfers on
+  prefill workers). Default is no-op.
+- `cleanup()` is called once on shutdown. Release all engine
+  resources. The framework guarantees `cleanup()` runs exactly once if
+  `start()` succeeded — even if registration or serve fails afterward.
+
+Make `cleanup()` idempotent and tolerant of being called from a
+half-initialized state. Engines like vLLM/TRT-LLM tear down NCCL groups
+in `cleanup()` and a second attempt can hang.
+
+## Step 5: Write `main.rs`
+
+Three lines. That's it.
+
+```rust
+use std::sync::Arc;
+
+mod engine;
+
+fn main() -> anyhow::Result<()> {
+    let (engine, config) = engine::MyBackend::from_args(None)?;
+    dynamo_backend_common::run(Arc::new(engine), config)
+}
+```
+
+`run` installs signal handlers, builds the distributed runtime, calls
+`engine.start()`, registers the model with discovery, serves the
+endpoint, and runs the full graceful-shutdown orchestrator on
+SIGTERM/SIGINT.
+
+## Step 6: Errors and logging
+
+**Errors**: every error returned from `start`, `generate`, `cleanup`,
+and `from_args` uses `ErrorType::Backend(BackendError::X)`. From the
+frontend's perspective, anything bubbling up through the backend has
+"originated from the backend" — engine code vs. framework code is not
+distinguished. Top-level `ErrorType::X` variants are reserved for
+non-backend paths.
+
+A small helper module per backend keeps the call sites clean:
+
+```rust
+pub(crate) fn invalid_arg(msg: impl Into<String>) -> DynamoError {
+    DynamoError::builder()
+        .error_type(ErrorType::Backend(BackendError::InvalidArgument))
+        .message(msg)
+        .build()
+}
+```
+
+Common nested categories: `InvalidArgument`, `CannotConnect`,
+`EngineShutdown`, `StreamIncomplete`, `Cancelled`, `ResponseTimeout`,
+`Disconnected`, `ConnectionTimeout`, `Unknown`.
+
+**Logging**: keep levels consistent across Rust backends so operators
+see the same surface everywhere.
+
+- `tracing::info!` for lifecycle milestones (engine started, cleanup
+  complete). `Worker` already logs "Serving {model} on …" and "Engine
+  cleanup complete" — add your own only for events those don't cover.
+- `tracing::debug!` for per-request events (cancellation, abort).
+- `tracing::warn!` for recoverable problems.
+- `tracing::error!` only for unrecoverable failures.
+
+## Step 7: Run the conformance kit
+
+Before merging, prove your engine satisfies the contract. The
+conformance kit is one call:
+
+```rust
+#[tokio::test]
+async fn my_engine_passes_conformance() {
+    // `run_conformance` takes a factory closure rather than a built
+    // engine — the kit constructs a second pristine engine for its
+    // "cleanup-without-start" check.
+    dynamo_backend_common::testing::run_conformance(|| {
+        MyBackend::new(/* your defaults */).expect("construct")
+    })
+    .await
+    .expect("conformance");
+}
+```
+
+The kit runs `start`/`generate`/`cleanup` directly against your engine
+— no external service is involved. If your engine needs a real GPU,
+remote model server, or other heavyweight resource to construct, gate
+the test with `#[ignore]` and require an explicit opt-in env var.
+
+What it asserts:
+
+| Check | Failure mode |
+|---|---|
+| `start()` returns a non-empty `EngineConfig.model` | `EmptyModelInConfig` |
+| Single `generate()` ends in a terminal chunk | `NoTerminalChunk` |
+| No chunks after the terminal | `ChunkAfterTerminal` |
+| Interleaved `generate()` calls all succeed | `ConcurrentGenerateFailed` |
+| Mid-stream cancel terminates within 2s | `CancellationNotObserved` |
+| Cancelled stream's terminal is `FinishReason::Cancelled` | `CancellationIgnored` |
+| `cleanup()` succeeds twice (idempotent) | `SecondCleanupFailed` |
+| `cleanup()` on a never-started engine succeeds | `CleanupWithoutStartFailed` |
+
+For tests that don't need a real engine, use `testing::mock_context()`
+or `testing::cancelling_context(after)` to drive `generate` manually.
+
+## Step 8: Run it locally
+
+Three moving parts need to come up: NATS + etcd (discovery and the
+event/request planes), the Dynamo Python frontend (HTTP → backend
+discovery), and your backend.
+
+The fastest path is to copy the **mocker example's
+[`docker-compose.yml`](../../lib/backend-common/examples/mocker/docker-compose.yml)
+and [`Dockerfile.frontend`](../../lib/backend-common/examples/mocker/Dockerfile.frontend)**,
+swap in your image, and run `docker compose up --build`. That brings
+up NATS + etcd + the Python frontend (built from the dynamo workspace
+at the same SHA as your backend) + your backend, all on one network.
+
+For a non-Docker dev loop:
+
+```bash
+cargo build --release
+
+# Ensure NATS + etcd are reachable (NATS_SERVER, ETCD_ENDPOINTS).
+./target/release/my-backend Qwen/Qwen3-0.6B \
+    --namespace dynamo \
+    --component backend \
+    --endpoint generate
+
+# In another shell, start the Python frontend from the dynamo repo:
+python -m dynamo.frontend --http-port 8000
+```
+
+Then send a request:
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+    -H 'Content-Type: application/json' \
+    -d '{
+          "model": "Qwen/Qwen3-0.6B",
+          "messages": [{"role": "user", "content": "hello"}],
+          "max_tokens": 32
+        }'
+```
+
+A successful response has non-empty `choices[0].message.content` and a
+`finish_reason` of `stop` or `length`. `jq -e '.choices[0].finish_reason'`
+is a good one-liner for a CI smoke test.
+
+`run` initializes `tracing` from the `DYN_LOG` env var (defaults to
+`info`); set `DYN_LOG=debug` or
+`DYN_LOG=info,dynamo_backend_common=trace` for more detail. `RUST_LOG`
+is not honored — `DYN_LOG` replaces it.
+
+## Reference: the mocker backend
+
+[`lib/backend-common/examples/mocker`](../../lib/backend-common/examples/mocker/)
+is the canonical small-but-complete reference. Lift these patterns:
+
+- Single shared scheduler driving many concurrent streams via a
+  fan-out task and per-request `mpsc` channels.
+- `ActiveRequestGuard` for RAII cleanup that runs on any stream drop.
+- `biased` select with `ctx.stopped()` first, channel second — the
+  shutdown-race fix discussed in Step 4.
+- `cleanup()` signals every active stream via `ctx.stop_generating()`
+  so each yields a clean `Cancelled` terminal instead of an error from
+  channel-close.
+
+## Checklist
+
+Before shipping:
+
+- [ ] `LLMEngine` implemented; `from_args` is inherent (not on the trait).
+- [ ] All errors use `ErrorType::Backend(BackendError::X)`.
+- [ ] `generate` polls `ctx.is_stopped()` between yields and emits
+      `FinishReason::Cancelled` on cancel.
+- [ ] Per-request cleanup uses RAII guards, not just `abort`.
+- [ ] `cleanup` is idempotent.
+- [ ] Conformance kit runs green: `testing::run_conformance(|| ...)`.
+- [ ] Logging levels match the standards in Step 6.
+
+## See also
+
+- [`LLMEngine` trait](../../lib/backend-common/src/engine.rs) — authoritative contract.
+- [Design notes](../../lib/backend-common/CLAUDE.md) — rationale,
+  invariants, phase-2 PyO3 plans.
+- [`Worker`](../../lib/backend-common/src/worker.rs) — runtime
+  lifecycle internals (signal handling, graceful shutdown, model
+  registration).
+- [Conformance kit](../../lib/backend-common/src/testing.rs) —
+  `run_conformance`, `mock_context`, `cancelling_context`.
+- [Mocker backend](../backends/mocker_backend/README.md) — example user guide.

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -246,6 +246,10 @@ navigation:
             path: benchmarks/mocker-trace-replay.md
       - page: Writing Python Workers
         path: development/backend-guide.md
+      - page: Writing Python Unified Backends
+        path: development/python-backend-guide.md
+      - page: Writing Rust Unified Backends
+        path: development/rust-backend-guide.md
 
   # ==================== Backends ====================
   - section: Backends

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -244,7 +244,7 @@ navigation:
             path: mocker/mocker.md
           - page: Mocker Offline Trace Replay
             path: benchmarks/mocker-trace-replay.md
-      - page: Writing Python Workers
+      - page: Writing Python Workers (lower-level)
         path: development/backend-guide.md
       - page: Writing Python Unified Backends
         path: development/python-backend-guide.md

--- a/lib/backend-common/CLAUDE.md
+++ b/lib/backend-common/CLAUDE.md
@@ -12,37 +12,55 @@ Python-shaped request/response wrappers.
 ## Engine Lifecycle
 
 ```
-construct (e.g. from_args)  ->  start()  ->  generate() / abort()  ->  cleanup()
-         |                        |                |                        |
-    parse args,            start engine,     serve requests           shutdown,
-    return engine          return metadata   (concurrent)             release resources
+construct  ->  start(worker_id)  ->  generate() / abort()  ->  drain()  ->  cleanup()
+    |                |                       |                    |            |
+parse args,    start engine,           serve requests       pre-cleanup    shutdown,
+return engine  return metadata         (concurrent)         drain          release
 ```
 
-The trait has four methods. `from_args` is NOT on the trait — each
+The trait has five methods. `from_args` is NOT on the trait — each
 backend exposes a backend-specific constructor (typically a sync
 `from_args(argv) -> Result<(Self, WorkerConfig)>` inherent method).
 This keeps the trait fully object-safe without a `where Self: Sized`
 opt-out and lets `run.rs` stay non-generic.
 
-- `start(&self) -> Result<EngineConfig, DynamoError>` — interior mutability
-  over `&self` so `Arc<dyn LLMEngine>` can drive the lifecycle.
-- `generate(&self, request, ctx) -> Result<BoxStream<'static, LLMEngineOutput>, DynamoError>`
-  — streaming inference. Author returns a plain stream; the framework wraps
-  it in `Annotated` and plumbs cancellation.
-- `abort(&self, ctx)` — optional, default no-op. Called by the framework
-  ONLY when `ctx.stopped()` or `ctx.killed()` fires during an active
-  request — NOT on silent stream drops (TCP reset, consumer-side
-  timeout, etc.). For per-request cleanup that must run on ANY drop
-  path (releasing a scheduler slot, freeing an engine handle), put the
-  release logic inside the `generate` stream body using RAII; use
-  `abort` only for out-of-band notifications (e.g. telling a remote
-  scheduler to cancel compute early).
+- `start(&self, worker_id: u64) -> Result<EngineConfig, DynamoError>` —
+  interior mutability over `&self` so `Arc<dyn LLMEngine>` can drive
+  the lifecycle. `worker_id` is an opaque runtime-allocated identifier;
+  most engines ignore it. Backends needing a stable cluster-wide key
+  (e.g. TRT-LLM's `disagg_machine_id` snowflake) derive from it.
+- `generate(&self, request, ctx: GenerateContext) -> Result<BoxStream<'static, Result<LLMEngineOutput, DynamoError>>, DynamoError>`
+  — streaming inference. `GenerateContext` derefs to
+  `dyn AsyncEngineContext` (`ctx.stopped()`, `ctx.is_stopped()`,
+  `ctx.id()` work transparently); it additionally exposes
+  `notify_first_token()` for decode-mode requests. Author returns a
+  plain stream; the framework wraps it in `Annotated` and plumbs
+  cancellation.
+- `abort(&self, ctx: Arc<dyn AsyncEngineContext>)` — optional, default
+  no-op. Note the type asymmetry: `generate` takes `GenerateContext`,
+  `abort` takes the unwrapped `Arc<dyn AsyncEngineContext>`. Called by
+  the framework ONLY when `ctx.stopped()` or `ctx.killed()` fires
+  during an active request — NOT on silent stream drops (TCP reset,
+  consumer-side timeout, etc.). For per-request cleanup that must run
+  on ANY drop path (releasing a scheduler slot, freeing an engine
+  handle), put the release logic inside the `generate` stream body
+  using RAII; use `abort` only for out-of-band notifications (e.g.
+  telling a remote scheduler to cancel compute early).
+- `drain(&self) -> Result<(), DynamoError>` — optional, default no-op.
+  Called once during graceful shutdown after the discovery unregister
+  + grace-period sleep, but BEFORE `cleanup`. Use it for backend-side
+  draining that must complete while NATS / etcd are still alive — e.g.
+  prefill workers polling-until-idle so in-flight NIXL KV transfers
+  finish before GPU memory is released (issue #7319). Failures are
+  logged and swallowed; shutdown proceeds regardless.
 - `cleanup(&self) -> Result<(), DynamoError>` — called exactly once.
   Runs after `start()` returns Ok on shutdown (even if registration /
   serve fails), **and** after `start()` raises — so implementations
   must be null-safe against partial state (inner LLM, sockets,
   background tasks). Must also be idempotent: a second call after a
-  successful first returns `Ok(())` without re-entering teardown.
+  successful first returns `Ok(())` without re-entering teardown. The
+  conformance kit pins both — `CleanupWithoutStartFailed` and
+  `SecondCleanupFailed`.
 
 ## Contract for `generate`
 
@@ -133,9 +151,11 @@ aggregates it when present. `usage(prompt, completion)` computes
   take `&self`. Constructors are backend-specific, not on the trait.
 
 - **Non-generic `Worker`, `EngineAdapter`, and `run()`.** All hold
-  `Arc<dyn LLMEngine>`. This is load-bearing for phase 2 (PyO3
-  bindings): a Python engine will plug in through a `PyLLMEngine`
-  adapter that implements the same trait.
+  `Arc<dyn LLMEngine>`. This is load-bearing for the PyO3 path:
+  `components/src/dynamo/common/backend/worker.py` is a thin shim
+  over `dynamo._core.backend.Worker` (this crate), so Python engines
+  plug in through the same `Arc<dyn LLMEngine>` slot via a
+  `PyLLMEngine` adapter.
 
 - **Reuse `DynamoError`.** Trait methods return `DynamoError`
   (`dynamo_runtime::error`), the workspace-wide standardized error.
@@ -303,18 +323,22 @@ Also available: `testing::mock_context()` and
 
 | File | What it does |
 |------|-------------|
-| `engine.rs` | `LLMEngine` trait, `EngineConfig`, `chunk::token`, `LLMEngineOutputExt` setters, `usage()` helper. Re-exports `PreprocessedRequest` / `LLMEngineOutput` / `FinishReason` / etc. |
-| `worker.rs` | `Worker` — runtime lifecycle: create `DistributedRuntime`, register model, serve endpoint, cleanup. `WorkerConfig` lives here. |
+| `engine.rs` | `LLMEngine` trait, `EngineConfig`, `GenerateContext`, `chunk::token`, `LLMEngineOutputExt` setters, `usage()` helper. Re-exports `PreprocessedRequest` / `LLMEngineOutput` / `FinishReason` / `PrefillResult` / `BootstrapInfo` / etc. |
+| `worker.rs` | `Worker` — runtime lifecycle: create `DistributedRuntime`, register model (with `disaggregation_mode` adjustments), serve endpoint, orchestrate drain + cleanup. `WorkerConfig` lives here. |
 | `adapter.rs` | `EngineAdapter` — bridges `LLMEngine` to `AsyncEngine`. Cancellation monitor + debug-build validator wrapping. |
 | `run.rs` | `pub fn run(engine, config)` — entry point used by all per-backend `main.rs`. Non-generic. |
-| `args.rs` | `CommonArgs` — shared CLI flags (`--namespace`, `--component`, etc.) that every engine's `Args` flattens in. |
+| `args.rs` | `CommonArgs` — shared CLI flags (`--namespace`, `--component`, `--disaggregation-mode`, etc.) that every engine's `Args` flattens in. |
+| `disagg.rs` | `DisaggregationMode` enum (`Aggregated` / `Prefill` / `Decode`) with `clap::ValueEnum` derive. |
 | `error.rs` | Re-exports `DynamoError`, `ErrorType`, `BackendError` from `dynamo-runtime`. No custom error types. |
 | `validate.rs` | Debug-build stream validator. Compiled out in release. |
 | `testing.rs` | Conformance test kit. Gated behind the `testing` feature. |
 
-## Phase 2
+## PyO3 binding
 
-PyO3 bindings are planned that let the Python backend runtime become
-a thin wrapper over this crate. The trait and data types are designed
-to support that without restructuring — do not pre-build phase-2
-scaffolding here.
+Shipped: `dynamo._core.backend.Worker` is a PyO3 binding that hands a
+`PyLLMEngine` (Python-implemented) into the same `Arc<dyn LLMEngine>`
+slot the Rust path uses. The Python-side
+`dynamo.common.backend.Worker` (`components/src/dynamo/common/backend/worker.py`)
+is a thin wrapper that drives this. The lifecycle state machine,
+signal handling, and graceful-shutdown orchestrator live entirely in
+this crate — Python adds no lifecycle logic.

--- a/lib/backend-common/README.md
+++ b/lib/backend-common/README.md
@@ -1,0 +1,333 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Dynamo Rust Backend (`dynamo-backend-common`)
+
+> **Work in progress.** The unified backend supports aggregated and
+> disaggregated (prefill/decode) inference; multimodal, LoRA, logprobs,
+> guided decoding, and engine-level metrics are still on the
+> non-unified path. The Python `Worker`
+> ([`dynamo.common.backend`](../../components/src/dynamo/common/backend/))
+> is a thin shim over this crate.
+
+> **Looking for a walkthrough?** Start with
+> [Writing a Rust Unified Backend](../../docs/development/rust-backend-guide.md).
+> This README is the in-tree reference: trait shape, file layout,
+> disaggregation contract, error taxonomy, and the conformance kit.
+
+A two-type abstraction that separates **runtime integration** (common
+across all backends) from **engine logic** (vLLM, SGLang, TRT-LLM, your
+custom engine, etc.).
+
+## Architecture
+
+```text
+LLMEngine (trait)              <-- engine boundary (engine.rs)
+    |   - start(worker_id) -> Result<EngineConfig, DynamoError>
+    |   - generate(request, ctx) -> Result<BoxStream<...>, DynamoError>
+    |   - abort(ctx)                            (optional, default no-op)
+    |   - drain() -> Result<(), DynamoError>    (optional, default no-op)
+    |   - cleanup() -> Result<(), DynamoError>
+    |
+    +-- MockerBackend          <-- examples/mocker/src/engine.rs
+    +-- <your backend>         <-- a separate crate
+
+Worker (concrete, non-generic)  <-- runtime integration (worker.rs)
+    - receives WorkerConfig from the per-backend `from_args`
+    - creates DistributedRuntime
+    - installs SIGTERM/SIGINT handlers
+    - calls engine.start(worker_id), registers model with discovery
+    - serves the generate endpoint with cancellation monitoring
+    - on shutdown: discovery unregister -> grace period
+                   -> engine.drain() -> engine.cleanup()
+                   -> 3-phase distributed-runtime teardown
+
+run(engine, config)             <-- src/run.rs
+    - Single entry point used by each backend's `main.rs`.
+    - Non-generic; holds `Arc<dyn LLMEngine>` so PyO3-wrapped engines
+      plug in through the same path.
+```
+
+`from_args` is **not** on the trait — each backend exposes an inherent
+constructor that returns `(Self, WorkerConfig)`. This keeps the trait
+fully object-safe (`Arc<dyn LLMEngine>` must work) and lets `run` stay
+non-generic.
+
+`generate` takes `GenerateContext` while `abort` takes
+`Arc<dyn AsyncEngineContext>`. `GenerateContext` derefs to
+`AsyncEngineContext`, so cancellation calls (`ctx.stopped()`,
+`ctx.is_stopped()`, `ctx.id()`) work the same in both. Override
+`abort` only if you need engine-side cancel notification — most
+backends rely on the default no-op plus in-stream polling.
+
+## Quick Start
+
+### Running the mocker example
+
+```bash
+cargo run -p dynamo-mocker-backend --release -- \
+    --model-path Qwen/Qwen3-0.6B
+```
+
+The mocker is a CPU-only reference engine: it wraps the
+`dynamo-mocker` scheduler in the `LLMEngine` trait and emits randomized
+token IDs at a configurable rate. Useful as a stand-in for AIPerf /
+end-to-end pipeline smoke tests without any ML dependencies.
+
+A one-command docker-compose stack (NATS + etcd + frontend + mocker)
+lives at
+[`examples/mocker/docker-compose.yml`](examples/mocker/docker-compose.yml).
+
+### Running your own backend
+
+```bash
+# In your backend crate (which may live in its own repo):
+cargo run --release -- --help
+```
+
+See the [walkthrough](../../docs/development/rust-backend-guide.md) for
+how to set up the crate (Cargo.toml, `tokio_unstable` cfg flag, toolchain
+pin) and write the engine.
+
+## Implementing a New Backend
+
+Implement the `LLMEngine` trait on your engine struct, expose an
+inherent `from_args`, and write a three-line `main.rs`:
+
+```rust
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use dynamo_backend_common::engine::GenerateContext;
+use dynamo_backend_common::{
+    DynamoError, EngineConfig, LLMEngine, LLMEngineOutput, PreprocessedRequest,
+    WorkerConfig,
+};
+use futures::stream::BoxStream;
+
+pub struct MyBackend { /* engine state */ }
+
+impl MyBackend {
+    pub fn from_args(argv: Option<Vec<String>>) -> Result<(Self, WorkerConfig), DynamoError> {
+        // parse CLI args, build the engine + WorkerConfig
+        todo!()
+    }
+}
+
+#[async_trait]
+impl LLMEngine for MyBackend {
+    async fn start(&self, _worker_id: u64) -> Result<EngineConfig, DynamoError> {
+        todo!() // start the engine, return registration metadata
+    }
+
+    async fn generate(
+        &self,
+        _request: PreprocessedRequest,
+        _ctx: GenerateContext,
+    ) -> Result<BoxStream<'static, Result<LLMEngineOutput, DynamoError>>, DynamoError> {
+        todo!() // yield streaming chunks
+    }
+
+    async fn cleanup(&self) -> Result<(), DynamoError> {
+        todo!() // release engine resources
+    }
+}
+
+fn main() -> anyhow::Result<()> {
+    let (engine, config) = MyBackend::from_args(None)?;
+    dynamo_backend_common::run(Arc::new(engine), config)
+}
+```
+
+See [`examples/mocker/src/engine.rs`](examples/mocker/src/engine.rs)
+for a complete, runnable reference and the
+[walkthrough](../../docs/development/rust-backend-guide.md) for the
+step-by-step including Cargo.toml, `tokio_unstable` cfg, and the
+conformance kit.
+
+## Disaggregated Serving
+
+The Rust crate supports prefill / decode worker splits. A backend
+declares its role via `WorkerConfig.disaggregation_mode` and branches on
+it inside `generate`:
+
+```rust
+use dynamo_backend_common::{DisaggregationMode, WorkerConfig};
+
+let config = WorkerConfig {
+    namespace: "dynamo".into(),
+    component: "prefill".into(),
+    endpoint: "generate".into(),
+    disaggregation_mode: DisaggregationMode::Prefill, // or Decode / Aggregated
+    ..Default::default()
+};
+```
+
+Roles and `Worker` behavior:
+
+| Mode | Role | Worker effects |
+| --- | --- | --- |
+| `Aggregated` | Self-contained inference (default) | Standard registration; KV indexer enabled |
+| `Prefill`    | Run prompt → emit 1 token + KV handoff | Registers as `ModelType::Prefill`; advertises `bootstrap_host`/`port` if set in `EngineConfig` |
+| `Decode`     | Resume from a prefill peer's KV | Disables the local indexer (KV is owned by the prefill peer) |
+
+The crate re-exports `PrefillResult` and `BootstrapInfo` from
+[`dynamo-llm`'s protocol types](../llm/src/protocols/common/preprocessor.rs);
+these decorate `PreprocessedRequest` on decode-bound requests. Prefill
+terminals carry their handoff payload via the engine's terminal chunk
+(e.g. `disaggregated_params`).
+
+For backends with an internal KV transport (vLLM `NixlConnector`,
+TRT-LLM's transceiver), leave `EngineConfig.bootstrap_host`/`port` `None`
+— only SGLang uses the Dynamo-level handshake today.
+
+## Request / Response Contract
+
+The trait works with the same `PreprocessedRequest` / `LLMEngineOutput`
+types used across preprocessing, routing, and the frontend — no
+Python-shaped wrappers.
+
+`generate` returns a `BoxStream<'static, Result<LLMEngineOutput, DynamoError>>`:
+
+- Exactly one **terminal item** must be the last item yielded. A
+  terminal is either:
+  - `Ok(chunk)` with `finish_reason` set (`stop` / `length` /
+    `cancelled` / `error`), or
+  - `Err(DynamoError)` carrying a typed mid-stream failure.
+- Non-terminal items are `Ok(chunk)` with `finish_reason` unset.
+- No items may follow a terminal.
+
+Terminal chunks come from
+`LLMEngineOutput::stop()` / `::length()` / `::cancelled()` / `::error(msg)`,
+optionally chained with `LLMEngineOutputExt::with_tokens(...)` /
+`with_usage(usage(prompt, completion))`. Non-terminal chunks use
+`chunk::token(id)`.
+
+In debug builds, the framework wraps the stream in a validator
+([`src/validate.rs`](src/validate.rs)) that panics if a chunk is yielded
+after a terminal. Loud failures in dev and test, compiled out in
+release.
+
+## Cancellation Contract
+
+The framework runs a per-request cancellation monitor that watches
+`ctx.stopped()` / `ctx.killed()` and calls `engine.abort(ctx)` when
+either fires. Engines also **must** poll `ctx.is_stopped()` (or
+`await ctx.stopped()`) between yields and emit a terminal with
+`FinishReason::Cancelled` when they observe it — the conformance kit
+treats any other terminal after cancellation as ignoring the signal.
+
+For cleanup that must run on **any** drop path (TCP reset, consumer
+timeout without cancellation), use RAII inside the `generate` stream
+body, not `abort` — `abort` only fires on explicit cancel. The mocker's
+`ActiveRequestGuard` is the canonical example.
+
+## Error Handling
+
+Errors returned from `start`, `generate`, `cleanup`, and `from_args`
+use `ErrorType::Backend(BackendError::X)` from
+[`dynamo-runtime`](../runtime/). Common variants:
+
+| Variant | When |
+| --- | --- |
+| `InvalidArgument` | Engine or setup rejected the input |
+| `CannotConnect` | Can't reach discovery / a dependency |
+| `EngineShutdown` | Engine failed to start / crashed |
+| `StreamIncomplete` | Stream ended before the engine could finish |
+| `Cancelled` | Request was cancelled |
+| `ResponseTimeout`, `Disconnected`, `ConnectionTimeout` | Transport failures |
+| `Unknown` | Uncategorized |
+
+Mid-stream errors have two equivalent terminal forms:
+
+- **Typed** (preferred): yield `Err(DynamoError)` from the stream.
+  Forwarded as `Annotated::error` with the `BackendError` variant
+  preserved end-to-end.
+- **String**: yield `Ok(LLMEngineOutput::error(msg))`. Convenient for
+  pure message-level failures. Loses the typed `BackendError` variant.
+
+A tiny helper per backend keeps call sites clean — see the
+[guide's Step 6](../../docs/development/rust-backend-guide.md) for the
+`invalid_arg` pattern.
+
+## Conformance Kit
+
+Enable the `testing` cargo feature to pull in the kit:
+
+```toml
+[dev-dependencies]
+dynamo-backend-common = { workspace = true, features = ["testing"] }
+```
+
+```rust
+#[tokio::test]
+async fn my_engine_passes_conformance() {
+    dynamo_backend_common::testing::run_conformance(|| {
+        MyBackend::new(/* defaults */).expect("construct")
+    })
+    .await
+    .expect("conformance");
+}
+```
+
+The kit asserts:
+
+| Check | Failure mode |
+| --- | --- |
+| `start()` returns a non-empty `EngineConfig.model` | `EmptyModelInConfig` |
+| Single `generate()` ends in a terminal chunk | `NoTerminalChunk` |
+| No chunks after the terminal | `ChunkAfterTerminal` |
+| Interleaved `generate()` calls all succeed | `ConcurrentGenerateFailed` |
+| Mid-stream cancel terminates within 2s | `CancellationNotObserved` |
+| Cancelled stream's terminal is `FinishReason::Cancelled` | `CancellationIgnored` |
+| `cleanup()` succeeds twice (idempotent) | `SecondCleanupFailed` |
+| `cleanup()` on a never-started engine succeeds | `CleanupWithoutStartFailed` |
+
+`testing::mock_context()` and `testing::cancelling_context(after)` are
+available for hand-written tests.
+
+## File Index
+
+```text
+lib/backend-common/
+    Cargo.toml
+    CLAUDE.md            # Design notes (rationale, invariants, phase plans)
+    README.md            # This file
+    src/
+        lib.rs           # Module wiring + public re-exports
+        engine.rs        # LLMEngine trait, EngineConfig, GenerateContext,
+                         #   chunk::token, LLMEngineOutputExt setters,
+                         #   usage() helper, PreprocessedRequest / Output
+                         #   re-exports
+        worker.rs        # Worker concrete + WorkerConfig (incl.
+                         #   disaggregation_mode); lifecycle state machine;
+                         #   signal handling + graceful shutdown orchestrator
+        run.rs           # `pub fn run(engine, config) -> anyhow::Result<()>`
+        adapter.rs       # EngineAdapter — bridges LLMEngine to AsyncEngine;
+                         #   cancellation monitor + debug stream validator
+        args.rs          # CommonArgs — shared CLI flags every engine flattens
+        disagg.rs        # DisaggregationMode enum + clap value-parser
+        error.rs         # Re-exports DynamoError / ErrorType / BackendError
+        validate.rs      # Debug-build stream validator (compiled out in release)
+        testing.rs       # Conformance kit (`testing` feature)
+    examples/
+        mocker/          # CPU-only reference backend + docker-compose stack
+```
+
+The Python `Worker` shim that drives this crate from `dynamo.*.unified_main`
+entry points lives at
+[`components/src/dynamo/common/backend/worker.py`](../../components/src/dynamo/common/backend/worker.py).
+
+## See Also
+
+- [Writing a Rust Unified Backend](../../docs/development/rust-backend-guide.md)
+  — step-by-step walkthrough.
+- [`CLAUDE.md`](CLAUDE.md) — design notes (rationale, invariants,
+  Phase 2 PyO3 plans).
+- [Mocker example](examples/mocker/) — reference engine + compose stack.
+- [Python sibling](../../components/src/dynamo/common/backend/README.md)
+  — `dynamo.common.backend`, the Python ABC layered over this crate.
+- [DEP #8251](https://github.com/ai-dynamo/dynamo/issues/8251) —
+  Backend Interface proposal and ongoing status.


### PR DESCRIPTION
## Summary

- Adds two parallel walkthroughs at `docs/development/` for writing a custom **unified backend** — one in [Rust](docs/development/rust-backend-guide.md) (against `lib/backend-common`) and one in [Python](docs/development/python-backend-guide.md) (against `dynamo.common.backend`). Both follow the same 8-step structure: create the crate/package → subclass the trait/ABC → wire CLI args → implement methods → write the entry-point shim → errors + logging → run the conformance/test kit → run end-to-end.
- Both guides are validated end-to-end. I built a fresh crate (`~/my_repos/guide_test_backend`) by following the Rust guide literally — conformance kit passes against `origin/main`'s `dynamo-backend-common`. Same for the Python guide (`~/my_repos/py_guide_test_backend`) against PyPI `ai-dynamo` 1.2.0: imports resolve, the Step 7 pytest snippet passes, and the backend starts cleanly, fetches the HF tokenizer for `Qwen/Qwen3-0.6B`, and registers with NATS/etcd.
- Registers both guides in the User Guides sidebar (`docs/index.yml`) next to the existing "Writing Python Workers" entry.
- Refreshes `components/src/dynamo/common/backend/README.md` for landed signatures (`start(worker_id)`, `drain()` hook, new `EngineConfig` fields) and adds a cross-link to the new walkthrough; keeps the rich disaggregation section that PR #9249 landed intact.
- Replaces the duplicated "Writing your own Rust backend" recipe in `docs/backends/mocker_backend/README.md` (which had a stale `run_conformance(engine)` snippet) with a one-line pointer to the new Rust guide.

The Rust and Python guides cross-link each other; both READMEs cross-link the relevant guide.

## Test plan

- [x] Followed the Rust guide literally; `cargo test` (incl. conformance) passes against current `origin/main` (`976dc4d068`).
- [x] Followed the Python guide literally; `pytest` passes; `my-backend --help` and `my-backend --model-name Qwen/Qwen3-0.6B` start cleanly against `ai-dynamo` 1.2.0.
- [x] All relative cross-links resolve (verified by script).
- [x] Code-block language tags consistent (`text` for ASCII diagrams, language tags for code).
- [ ] Fern preview renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9492" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive guides for implementing Python and Rust unified backends, covering project structure, lifecycle methods, streaming contracts, error handling, and testing
  * Updated Dynamo Python Backend README with expanded unified backend capabilities, architectural changes, and file organization details
  * Refreshed mocker backend documentation to reference the new centralized backend guides
  * Enhanced navigation with new backend development guides for improved discoverability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9492)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->