### PR TITLE
feat(backend): KV-aware routing on the unified backend abstraction

### DIFF
--- a/components/src/dynamo/common/backend/dp_rank.py
+++ b/components/src/dynamo/common/backend/dp_rank.py
@@ -12,7 +12,7 @@ the extract-and-validate pattern so the same logic doesn't drift.
 from __future__ import annotations
 
 import logging
-from typing import Optional
+from typing import Any, Optional, cast
 
 from dynamo.common.backend.engine import GenerateRequest
 
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 def forced_dp_rank(request: GenerateRequest) -> Optional[int]:
     """Pull the router-forced ``dp_rank`` out of a request's ``routing``."""
-    routing = request.get("routing") or {}
+    routing = cast("dict[str, Any]", request.get("routing") or {})
     rank = routing.get("dp_rank")
     return None if rank is None else int(rank)
 

--- a/components/src/dynamo/common/backend/dp_rank.py
+++ b/components/src/dynamo/common/backend/dp_rank.py
@@ -13,9 +13,18 @@ logic doesn't drift across backends.
 from __future__ import annotations
 
 import logging
-from typing import Optional
+from typing import Any, Optional
+
+from dynamo.common.backend.engine import GenerateRequest
 
 logger = logging.getLogger(__name__)
+
+
+def forced_dp_rank(request: GenerateRequest) -> Optional[int]:
+    """Return the router-supplied global ``dp_rank`` from a request's
+    ``routing`` hints, or ``None`` when the router didn't set one."""
+    routing: dict[str, Any] = request.get("routing") or {}  # type: ignore[assignment]
+    return routing.get("dp_rank")
 
 
 def validate_global_dp_rank(

--- a/components/src/dynamo/common/backend/dp_rank.py
+++ b/components/src/dynamo/common/backend/dp_rank.py
@@ -4,16 +4,15 @@
 """DP-rank helpers shared across unified-backend engines.
 
 The router encodes its rank decision in ``request.routing.dp_rank``.
-Each engine validates it against the local DP-rank slice the worker
-owns and forwards it to the underlying inference engine. The helper
-below captures the validation + warn-and-fall-back pattern so the same
-logic doesn't drift across backends.
+Each engine validates it against the worker's local DP-rank slice and
+forwards to the underlying inference engine. The helpers below capture
+the extract-and-validate pattern so the same logic doesn't drift.
 """
 
 from __future__ import annotations
 
 import logging
-from typing import Any, Optional
+from typing import Optional
 
 from dynamo.common.backend.engine import GenerateRequest
 
@@ -21,10 +20,10 @@ logger = logging.getLogger(__name__)
 
 
 def forced_dp_rank(request: GenerateRequest) -> Optional[int]:
-    """Return the router-supplied global ``dp_rank`` from a request's
-    ``routing`` hints, or ``None`` when the router didn't set one."""
-    routing: dict[str, Any] = request.get("routing") or {}  # type: ignore[assignment]
-    return routing.get("dp_rank")
+    """Pull the router-forced ``dp_rank`` out of a request's ``routing``."""
+    routing = request.get("routing") or {}
+    rank = routing.get("dp_rank")
+    return None if rank is None else int(rank)
 
 
 def validate_global_dp_rank(
@@ -33,24 +32,18 @@ def validate_global_dp_rank(
     dp_size: int,
     backend_label: str,
 ) -> Optional[int]:
-    """Bounds-check a router-supplied global DP rank against this worker's
-    slice ``[dp_start, dp_start + dp_size)``.
-
-    Returns the (int-coerced) rank when in range. Returns ``None`` and
-    emits a warning otherwise so the caller can fall back to the engine's
-    internal load balancer.
-    """
+    """Bounds-check ``dp_rank`` against ``[dp_start, dp_start + dp_size)``;
+    returns it when in range, else ``None`` (and warns)."""
     if dp_rank is None or dp_size <= 1:
         return None
-    rank = int(dp_rank)
-    if not dp_start <= rank < dp_start + dp_size:
+    if not dp_start <= dp_rank < dp_start + dp_size:
         logger.warning(
             "Received DP rank %d outside [%d, %d); falling back to "
             "%s internal DP selection",
-            rank,
+            dp_rank,
             dp_start,
             dp_start + dp_size,
             backend_label,
         )
         return None
-    return rank
+    return dp_rank

--- a/components/src/dynamo/common/backend/dp_rank.py
+++ b/components/src/dynamo/common/backend/dp_rank.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""DP-rank helpers shared across unified-backend engines.
+
+The router encodes its rank decision in ``request.routing.dp_rank``.
+Each engine validates it against the local DP-rank slice the worker
+owns and forwards it to the underlying inference engine. The helper
+below captures the validation + warn-and-fall-back pattern so the same
+logic doesn't drift across backends.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def validate_global_dp_rank(
+    dp_rank: Optional[int],
+    dp_start: int,
+    dp_size: int,
+    backend_label: str,
+) -> Optional[int]:
+    """Bounds-check a router-supplied global DP rank against this worker's
+    slice ``[dp_start, dp_start + dp_size)``.
+
+    Returns the (int-coerced) rank when in range. Returns ``None`` and
+    emits a warning otherwise so the caller can fall back to the engine's
+    internal load balancer.
+    """
+    if dp_rank is None or dp_size <= 1:
+        return None
+    rank = int(dp_rank)
+    if not dp_start <= rank < dp_start + dp_size:
+        logger.warning(
+            "Received DP rank %d outside [%d, %d); falling back to "
+            "%s internal DP selection",
+            rank,
+            dp_start,
+            dp_start + dp_size,
+            backend_label,
+        )
+        return None
+    return rank

--- a/components/src/dynamo/common/backend/engine.py
+++ b/components/src/dynamo/common/backend/engine.py
@@ -75,6 +75,12 @@ class EngineConfig:
     # Engines with attention-DP set this from their engine-side count
     # (e.g. TRT-LLM's `get_attention_dp_size()`).
     data_parallel_size: Optional[int] = None
+    # Global index of the first DP rank this worker hosts (defaults to 0).
+    # Non-zero only under multi-worker DP layouts where each worker owns a
+    # sub-range — vLLM hybrid/external LB, SGLang DP-attention across
+    # multiple nodes. The router enumerates ranks
+    # `[data_parallel_start_rank, data_parallel_start_rank + data_parallel_size)`.
+    data_parallel_start_rank: Optional[int] = None
     # Bootstrap address advertised to decode peers. Only meaningful for
     # backends with a Dynamo-level host/port handshake (today: SGLang).
     # Backends whose KV transport is internal — TRT-LLM, vLLM

--- a/components/src/dynamo/common/backend/engine.py
+++ b/components/src/dynamo/common/backend/engine.py
@@ -10,6 +10,8 @@ from typing import TYPE_CHECKING, Any, Optional, Required, TypedDict
 
 from dynamo._core import Context
 
+from .publisher import KvEventSource, SnapshotSource
+
 if TYPE_CHECKING:
     from .worker import WorkerConfig
 
@@ -69,6 +71,10 @@ class EngineConfig:
     total_kv_blocks: Optional[int] = None
     max_num_seqs: Optional[int] = None
     max_num_batched_tokens: Optional[int] = None
+    # Number of data-parallel ranks this worker hosts (defaults to 1).
+    # Engines with attention-DP set this from their engine-side count
+    # (e.g. TRT-LLM's `get_attention_dp_size()`).
+    data_parallel_size: Optional[int] = None
     # Bootstrap address advertised to decode peers. Only meaningful for
     # backends with a Dynamo-level host/port handshake (today: SGLang).
     # Backends whose KV transport is internal — TRT-LLM, vLLM
@@ -193,3 +199,14 @@ class LLMEngine(ABC):
         ``cleanup()`` call after a successful first is a safe no-op.
         """
         ...
+
+    async def kv_event_sources(self) -> list[KvEventSource]:
+        """KV event sources, one per data-parallel rank. Default opts out
+        of KV-aware routing. ``Worker`` calls once after :meth:`start`."""
+        return []
+
+    async def metrics_sources(self) -> list[SnapshotSource]:
+        """Metrics snapshot sources, one per data-parallel rank. Default
+        opts out of metrics publishing. ``Worker`` calls once after
+        :meth:`start`."""
+        return []

--- a/components/src/dynamo/common/backend/publisher.py
+++ b/components/src/dynamo/common/backend/publisher.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Source descriptors returned by :meth:`LLMEngine.kv_event_sources` and
+:meth:`LLMEngine.metrics_sources`. Worker constructs one publisher per
+descriptor — engines never instantiate publishers themselves."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Callable, Optional, Union
+
+if TYPE_CHECKING:
+    from dynamo.llm import KvEventPublisher
+
+
+@dataclass(frozen=True)
+class ZmqSource:
+    """Worker subscribes to the engine's ZMQ PUB socket directly."""
+
+    endpoint: str
+    topic: str = ""
+    dp_rank: int = 0
+
+
+@dataclass(frozen=True)
+class PushSource:
+    """Worker hands a live ``KvEventPublisher`` to the engine via
+    ``on_ready``; the engine drives ``publish`` from its own thread and
+    MUST stop that thread in :meth:`LLMEngine.cleanup` before returning."""
+
+    on_ready: Callable[["KvEventPublisher"], None]
+    dp_rank: int = 0
+
+
+@dataclass(frozen=True)
+class SnapshotSource:
+    """``snapshot`` is invoked under the GIL on a fixed interval. Keep it to a
+    member-field read; return ``None`` to skip publishing for that tick."""
+
+    snapshot: Callable[[], Optional["Metrics"]]
+    dp_rank: int = 0
+
+
+KvEventSource = Union[ZmqSource, PushSource]
+
+
+@dataclass
+class Metrics:
+    """Router input. Lower ``kv_used_blocks`` = more free capacity."""
+
+    kv_used_blocks: Optional[int] = None
+
+
+__all__ = [
+    "KvEventSource",
+    "Metrics",
+    "PushSource",
+    "SnapshotSource",
+    "ZmqSource",
+]

--- a/components/src/dynamo/common/backend/sample_engine.py
+++ b/components/src/dynamo/common/backend/sample_engine.py
@@ -5,15 +5,26 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import itertools
+import logging
+import queue
+import threading
 import uuid
 from collections.abc import AsyncGenerator
+from typing import Optional
 
 from dynamo._core import Context
 from dynamo.common.constants import DisaggregationMode
+from dynamo.llm import KvEventPublisher
 
 from .disagg import enforce_prefill_max_tokens, require_prefill_result
 from .engine import EngineConfig, GenerateChunk, GenerateRequest, LLMEngine
+from .publisher import KvEventSource, Metrics, PushSource, SnapshotSource
 from .worker import WorkerConfig
+
+logger = logging.getLogger(__name__)
+
+_SAMPLE_BLOCK_SIZE = 16
 
 
 class SampleLLMEngine(LLMEngine):
@@ -45,6 +56,13 @@ class SampleLLMEngine(LLMEngine):
         self.max_tokens = max_tokens
         self.delay = delay
         self.disaggregation_mode = disaggregation_mode
+        self._metrics = Metrics(kv_used_blocks=0)
+        self._publish_queue: queue.SimpleQueue[tuple[str, dict]] = queue.SimpleQueue()
+        self._publish_stop = threading.Event()
+        self._publish_thread: Optional[threading.Thread] = None
+        # itertools.count is thread-safe — concurrent generate() calls
+        # won't race on hash issuance.
+        self._block_hash_counter = itertools.count(1)
 
     @classmethod
     async def from_args(
@@ -93,32 +111,78 @@ class SampleLLMEngine(LLMEngine):
         return engine, worker_config
 
     async def start(self, worker_id: int) -> EngineConfig:
-        del worker_id  # sample engine has no cluster-wide ID needs
+        del worker_id
         return EngineConfig(
             model=self.model_name,
             served_model_name=self.model_name,
             context_length=2048,
-            kv_cache_block_size=16,
+            kv_cache_block_size=_SAMPLE_BLOCK_SIZE,
             total_kv_blocks=1000,
             max_num_seqs=64,
             max_num_batched_tokens=2048,
         )
 
+    async def kv_event_sources(self) -> list[KvEventSource]:
+        return [PushSource(on_ready=self._start_publisher_thread, dp_rank=0)]
+
+    async def metrics_sources(self) -> list[SnapshotSource]:
+        return [SnapshotSource(snapshot=lambda: self._metrics, dp_rank=0)]
+
+    def _start_publisher_thread(self, publisher: KvEventPublisher) -> None:
+        self._publish_thread = threading.Thread(
+            target=self._publish_loop,
+            args=(publisher,),
+            daemon=True,
+            name="sample-kv-publisher",
+        )
+        self._publish_thread.start()
+
+    def _publish_loop(self, publisher: KvEventPublisher) -> None:
+        while not self._publish_stop.is_set():
+            try:
+                kind, payload = self._publish_queue.get(timeout=0.1)
+            except queue.Empty:
+                continue
+            try:
+                if kind == "stored":
+                    publisher.publish_stored(**payload)
+                elif kind == "removed":
+                    publisher.publish_removed(**payload)
+            except Exception:
+                logger.exception("Sample publisher dropped event of kind=%s", kind)
+
+    def _emit_synthetic_events(self, prompt_len: int) -> list[int]:
+        block_count = max(1, prompt_len // _SAMPLE_BLOCK_SIZE)
+        hashes: list[int] = []
+        for _ in range(block_count):
+            h = next(self._block_hash_counter)
+            hashes.append(h)
+        self._publish_queue.put(
+            (
+                "stored",
+                {
+                    "token_ids": list(range(block_count * _SAMPLE_BLOCK_SIZE)),
+                    "num_block_tokens": [_SAMPLE_BLOCK_SIZE] * block_count,
+                    "block_hashes": hashes,
+                },
+            )
+        )
+        self._metrics = Metrics(
+            kv_used_blocks=(self._metrics.kv_used_blocks or 0) + block_count
+        )
+        return hashes
+
+    def _release_synthetic_blocks(self, hashes: list[int]) -> None:
+        self._publish_queue.put(("removed", {"block_hashes": hashes}))
+        self._metrics = Metrics(
+            kv_used_blocks=max(0, (self._metrics.kv_used_blocks or 0) - len(hashes))
+        )
+
     async def generate(
         self, request: GenerateRequest, context: Context
     ) -> AsyncGenerator[GenerateChunk, None]:
-        # Decode pre-condition: prefill peer must have populated KV cache.
-        # We don't inspect the payload — the sample engine has no real KV
-        # cache — but the frontend's prefill router is responsible for
-        # forwarding it, and a missing payload is the most common
-        # misconfiguration we want to catch loudly.
         if self.disaggregation_mode == DisaggregationMode.DECODE:
             require_prefill_result(request, self.disaggregation_mode)
-
-        # Prefill workers cap generation at one token regardless of what
-        # the client asked for; the response's job is to ferry the
-        # disaggregated_params handle to the decode peer, not to produce
-        # output text.
         if self.disaggregation_mode == DisaggregationMode.PREFILL:
             enforce_prefill_max_tokens(request)
 
@@ -127,6 +191,16 @@ class SampleLLMEngine(LLMEngine):
         stop_conditions = request.get("stop_conditions", {})
         max_new = stop_conditions.get("max_tokens") or self.max_tokens
 
+        block_hashes = self._emit_synthetic_events(prompt_len)
+        try:
+            async for chunk in self._generate_tokens(prompt_len, max_new, context):
+                yield chunk
+        finally:
+            self._release_synthetic_blocks(block_hashes)
+
+    async def _generate_tokens(
+        self, prompt_len: int, max_new: int, context: Context
+    ) -> AsyncGenerator[GenerateChunk, None]:
         for i in range(max_new):
             if context.is_stopped():
                 yield {
@@ -150,11 +224,6 @@ class SampleLLMEngine(LLMEngine):
                     "completion_tokens": max_new,
                     "total_tokens": prompt_len + max_new,
                 }
-                # Prefill stamps a synthetic handoff payload on the
-                # terminal so the frontend's PrefillRouter has something
-                # to forward to the decode peer. The handle is opaque —
-                # the sample backend has no real KV transfer — but its
-                # presence exercises the wire format end-to-end.
                 if self.disaggregation_mode == DisaggregationMode.PREFILL:
                     out["disaggregated_params"] = {
                         "sample_handle": uuid.uuid4().hex,
@@ -163,4 +232,6 @@ class SampleLLMEngine(LLMEngine):
             yield out
 
     async def cleanup(self) -> None:
-        pass
+        self._publish_stop.set()
+        if self._publish_thread is not None:
+            self._publish_thread.join(timeout=1.0)

--- a/components/src/dynamo/common/backend/tests/test_dp_rank.py
+++ b/components/src/dynamo/common/backend/tests/test_dp_rank.py
@@ -7,10 +7,7 @@ from __future__ import annotations
 
 import pytest
 
-from dynamo.common.backend.dp_rank import (
-    forced_dp_rank,
-    validate_global_dp_rank,
-)
+from dynamo.common.backend.dp_rank import forced_dp_rank, validate_global_dp_rank
 
 pytestmark = [pytest.mark.unit, pytest.mark.gpu_0, pytest.mark.pre_merge]
 

--- a/components/src/dynamo/common/backend/tests/test_dp_rank.py
+++ b/components/src/dynamo/common/backend/tests/test_dp_rank.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the shared DP-rank helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from dynamo.common.backend.dp_rank import (
+    forced_dp_rank,
+    validate_global_dp_rank,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.gpu_0, pytest.mark.pre_merge]
+
+
+def test_forced_dp_rank_returns_none_when_routing_absent():
+    assert forced_dp_rank({"token_ids": [1]}) is None
+    assert forced_dp_rank({"token_ids": [1], "routing": {}}) is None
+
+
+def test_forced_dp_rank_coerces_to_int():
+    # Router payloads come in JSON, so numeric-ish strings can appear.
+    assert forced_dp_rank({"token_ids": [], "routing": {"dp_rank": "2"}}) == 2
+    assert forced_dp_rank({"token_ids": [], "routing": {"dp_rank": 3}}) == 3
+
+
+def test_validate_global_dp_rank_passes_in_range():
+    # dp_start=2, dp_size=4 → valid global ranks are [2, 6).
+    assert validate_global_dp_rank(2, 2, 4, "test") == 2
+    assert validate_global_dp_rank(5, 2, 4, "test") == 5
+
+
+def test_validate_global_dp_rank_returns_none_out_of_range(caplog):
+    with caplog.at_level("WARNING"):
+        assert validate_global_dp_rank(7, 2, 4, "test") is None
+    assert "outside [2, 6)" in caplog.text
+
+
+def test_validate_global_dp_rank_short_circuits_when_dp_size_one():
+    # Single-rank workers can't honour a forced rank; the helper returns
+    # None without warning so the engine falls back to its internal LB.
+    assert validate_global_dp_rank(0, 0, 1, "test") is None
+    assert validate_global_dp_rank(None, 0, 4, "test") is None

--- a/components/src/dynamo/common/backend/tests/test_publisher.py
+++ b/components/src/dynamo/common/backend/tests/test_publisher.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from typing import Optional
+
+import pytest
+
+pytest.importorskip(
+    "dynamo._core.backend",
+    reason="dynamo._core.backend not built — run `maturin develop` first",
+)
+
+from dynamo._core import Context  # noqa: E402
+from dynamo.common.backend.engine import (  # noqa: E402
+    EngineConfig,
+    GenerateChunk,
+    GenerateRequest,
+    LLMEngine,
+)
+from dynamo.common.backend.publisher import (  # noqa: E402
+    Metrics,
+    PushSource,
+    SnapshotSource,
+    ZmqSource,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.unified,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+def test_source_descriptors_carry_payload_and_defaults():
+    zmq = ZmqSource(endpoint="tcp://127.0.0.1:5557")
+    assert (zmq.endpoint, zmq.topic, zmq.dp_rank) == ("tcp://127.0.0.1:5557", "", 0)
+
+    seen: list[object] = []
+    push = PushSource(on_ready=seen.append, dp_rank=2)
+    push.on_ready("publisher")
+    assert seen == ["publisher"]
+    assert push.dp_rank == 2
+
+    snap = SnapshotSource(snapshot=lambda: Metrics(kv_used_blocks=42))
+    assert snap.snapshot() == Metrics(kv_used_blocks=42)
+    assert snap.dp_rank == 0
+
+
+class _MinimalEngine(LLMEngine):
+    @classmethod
+    async def from_args(cls, argv: Optional[list[str]] = None):
+        raise NotImplementedError
+
+    async def start(self, worker_id: int) -> EngineConfig:
+        return EngineConfig(model="minimal")
+
+    async def generate(
+        self, request: GenerateRequest, context: Context
+    ) -> AsyncGenerator[GenerateChunk, None]:
+        yield {"token_ids": [], "index": 0, "finish_reason": "stop"}
+
+    async def cleanup(self) -> None:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_abc_source_methods_default_to_empty_list():
+    engine = _MinimalEngine()
+    assert await engine.kv_event_sources() == []
+    assert await engine.metrics_sources() == []

--- a/components/src/dynamo/common/backend/tests/test_sample_engine.py
+++ b/components/src/dynamo/common/backend/tests/test_sample_engine.py
@@ -14,6 +14,11 @@ pytest.importorskip(
     reason="dynamo._core.backend not built — run `maturin develop` first",
 )
 
+from dynamo.common.backend.publisher import (  # noqa: E402
+    Metrics,
+    PushSource,
+    SnapshotSource,
+)
 from dynamo.common.backend.sample_engine import SampleLLMEngine  # noqa: E402
 from dynamo.common.constants import DisaggregationMode  # noqa: E402
 
@@ -111,3 +116,28 @@ async def test_from_args_propagates_mode_to_worker_config():
     )
     assert engine.disaggregation_mode is DisaggregationMode.PREFILL
     assert worker_config.disaggregation_mode is DisaggregationMode.PREFILL
+
+
+async def test_source_descriptors_have_expected_shape():
+    engine = SampleLLMEngine(max_tokens=4, delay=0.0)
+    [kv_src] = await engine.kv_event_sources()
+    [metrics_src] = await engine.metrics_sources()
+    assert isinstance(kv_src, PushSource) and kv_src.dp_rank == 0
+    assert isinstance(metrics_src, SnapshotSource) and metrics_src.dp_rank == 0
+    assert metrics_src.snapshot() == Metrics(kv_used_blocks=0)
+
+
+async def test_generate_round_trips_kv_used_blocks_through_snapshot():
+    engine = SampleLLMEngine(max_tokens=2, delay=0.0)
+    snapshot = (await engine.metrics_sources())[0].snapshot
+    await _collect(engine, {"token_ids": list(range(32))})
+    assert snapshot() == Metrics(kv_used_blocks=0)
+
+
+async def test_cleanup_joins_publisher_thread_started_via_on_ready():
+    engine = SampleLLMEngine(max_tokens=2, delay=0.0)
+    [push_src] = await engine.kv_event_sources()
+    push_src.on_ready(MagicMock())
+    assert engine._publish_thread is not None and engine._publish_thread.is_alive()
+    await engine.cleanup()
+    assert not engine._publish_thread.is_alive()

--- a/components/src/dynamo/common/backend/worker.py
+++ b/components/src/dynamo/common/backend/worker.py
@@ -90,6 +90,10 @@ class WorkerConfig:
     reasoning_parser: Optional[str] = None
     exclude_tools_when_tool_choice_none: bool = True
     enable_local_indexer: bool = True
+    # Operator-level kill switch for KV-aware-routing publishers. When False,
+    # Worker skips engine.kv_event_sources() and engine.metrics_sources() so
+    # the worker ships no KV events or worker-load metrics.
+    enable_kv_routing: bool = True
     metrics_labels: list[tuple[str, str]] = field(default_factory=list)
     # Disaggregation role; default AGGREGATED keeps existing callers unchanged.
     # The Rust Worker reads this for registration (Prefill→ModelType::Prefill,
@@ -133,6 +137,7 @@ class WorkerConfig:
                 runtime_cfg, "exclude_tools_when_tool_choice_none", True
             ),
             "enable_local_indexer": getattr(runtime_cfg, "enable_local_indexer", True),
+            "enable_kv_routing": getattr(runtime_cfg, "enable_kv_routing", True),
         }
         # vLLM/TRT-LLM expose `disaggregation_mode`; SGLang exposes
         # `serving_mode`. Skip the probe when an override is supplied so
@@ -194,6 +199,7 @@ class Worker:
                 self.config.exclude_tools_when_tool_choice_none
             ),
             enable_local_indexer=self.config.enable_local_indexer,
+            enable_kv_routing=self.config.enable_kv_routing,
             metrics_labels=list(self.config.metrics_labels),
             disaggregation_mode=_to_rust_disaggregation_mode(
                 self.config.disaggregation_mode

--- a/components/src/dynamo/sglang/llm_engine.py
+++ b/components/src/dynamo/sglang/llm_engine.py
@@ -240,11 +240,17 @@ class SglangLLMEngine(LLMEngine):
         elif self.serving_mode == DisaggregationMode.DECODE:
             bootstrap_kwargs = self._resolve_decode_bootstrap(request)
 
+        # Honour the router's DP rank decision. Without this, SGLang picks
+        # the rank internally and KV events land on the wrong publisher.
+        # Mirrors `DecodeWorkerHandler.async_generate(data_parallel_rank=...)`.
+        forced_dp_rank = (request.get("routing") or {}).get("dp_rank")
+
         stream = await self.engine.async_generate(
             **input_param,
             sampling_params=sampling_params,
             stream=True,
             rid=context.trace_id,
+            data_parallel_rank=forced_dp_rank,
             **bootstrap_kwargs,
         )
 

--- a/components/src/dynamo/sglang/llm_engine.py
+++ b/components/src/dynamo/sglang/llm_engine.py
@@ -25,6 +25,7 @@ from sglang.srt.disaggregation.kv_events import ZmqEventPublisher
 from sglang.srt.utils.network import get_local_ip_auto, get_zmq_socket
 
 from dynamo._core import Context
+from dynamo.common.backend.dp_rank import validate_global_dp_rank
 from dynamo.common.backend.engine import (
     EngineConfig,
     GenerateChunk,
@@ -256,8 +257,11 @@ class SglangLLMEngine(LLMEngine):
 
         # Honour the router's DP rank decision; without it SGLang picks
         # its own rank and KV events land on the wrong publisher.
-        forced_dp_rank = self._validate_forced_dp_rank(
-            (request.get("routing") or {}).get("dp_rank")
+        forced_dp_rank = validate_global_dp_rank(
+            (request.get("routing") or {}).get("dp_rank"),
+            self._dp_start,
+            self._dp_size,
+            "SGLang",
         )
 
         stream = await self.engine.async_generate(
@@ -410,24 +414,6 @@ class SglangLLMEngine(LLMEngine):
         if self.engine is not None:
             self.engine.shutdown()
             logger.info("SGLang engine shutdown")
-
-    def _validate_forced_dp_rank(self, dp_rank: int | None) -> int | None:
-        """Validate router-supplied global DP rank against this worker's
-        local slice. Out-of-range ranks fall back to SGLang's internal
-        load balancer."""
-        if dp_rank is None or self._dp_size <= 1:
-            return None
-        rank = int(dp_rank)
-        if not self._dp_start <= rank < self._dp_start + self._dp_size:
-            logger.warning(
-                "Received DP rank %d outside [%d, %d); falling back to "
-                "SGLang internal DP selection",
-                rank,
-                self._dp_start,
-                self._dp_start + self._dp_size,
-            )
-            return None
-        return rank
 
     def _resolve_prefill_bootstrap(self, request: GenerateRequest) -> dict[str, Any]:
         """Pick the (host, port, room) triple this prefill request will use.

--- a/components/src/dynamo/sglang/llm_engine.py
+++ b/components/src/dynamo/sglang/llm_engine.py
@@ -164,6 +164,7 @@ class SglangLLMEngine(LLMEngine):
 
         self._start_metrics_task()
 
+        dp_start, dp_end = _local_dp_rank_range(self.server_args)
         return EngineConfig(
             model=self.server_args.model_path,
             served_model_name=self.server_args.served_model_name,
@@ -172,6 +173,10 @@ class SglangLLMEngine(LLMEngine):
             total_kv_blocks=total_kv_blocks,
             max_num_seqs=getattr(self.server_args, "max_running_requests", None),
             max_num_batched_tokens=max_num_batched_tokens,
+            # Number of DP ranks this worker hosts. Without this, the Rust
+            # runtime defaults to 1 and the router can't route to non-zero
+            # dp_ranks even though `kv_event_sources` registers them.
+            data_parallel_size=dp_end - dp_start,
             # Prefill-only — drives PrefillRouter's Bootstrap path.
             bootstrap_host=self._bootstrap_host,
             bootstrap_port=self._bootstrap_port,

--- a/components/src/dynamo/sglang/llm_engine.py
+++ b/components/src/dynamo/sglang/llm_engine.py
@@ -98,6 +98,11 @@ class SglangLLMEngine(LLMEngine):
         self._metrics_task: Optional[asyncio.Task[None]] = None
         self._metrics_zmq_ctx: Optional[zmq.asyncio.Context] = None
         self._metrics_zmq_sock = None
+        # Local DP-rank slice this worker owns; resolved in `start()`
+        # via `_local_dp_rank_range`. Used to validate router-supplied
+        # `dp_rank` against this node's range before forwarding to SGLang.
+        self._dp_start: int = 0
+        self._dp_size: int = 1
 
     @classmethod
     async def from_args(
@@ -165,6 +170,8 @@ class SglangLLMEngine(LLMEngine):
         self._start_metrics_task()
 
         dp_start, dp_end = _local_dp_rank_range(self.server_args)
+        self._dp_start = dp_start
+        self._dp_size = dp_end - dp_start
         return EngineConfig(
             model=self.server_args.model_path,
             served_model_name=self.server_args.served_model_name,
@@ -173,14 +180,9 @@ class SglangLLMEngine(LLMEngine):
             total_kv_blocks=total_kv_blocks,
             max_num_seqs=getattr(self.server_args, "max_running_requests", None),
             max_num_batched_tokens=max_num_batched_tokens,
-            # Number of DP ranks this worker hosts. Without this, the Rust
-            # runtime defaults to 1 and the router can't route to non-zero
-            # dp_ranks even though `kv_event_sources` registers them.
-            data_parallel_size=dp_end - dp_start,
-            # Global index of the first rank this worker hosts. Non-zero
-            # for multi-node DP-attention where each node owns a slice
-            # starting at `node_rank * local_dp_size`.
-            data_parallel_start_rank=dp_start,
+            # Router needs the rank range to enumerate per-rank load.
+            data_parallel_size=self._dp_size,
+            data_parallel_start_rank=self._dp_start,
             # Prefill-only — drives PrefillRouter's Bootstrap path.
             bootstrap_host=self._bootstrap_host,
             bootstrap_port=self._bootstrap_port,
@@ -240,10 +242,11 @@ class SglangLLMEngine(LLMEngine):
         elif self.serving_mode == DisaggregationMode.DECODE:
             bootstrap_kwargs = self._resolve_decode_bootstrap(request)
 
-        # Honour the router's DP rank decision. Without this, SGLang picks
-        # the rank internally and KV events land on the wrong publisher.
-        # Mirrors `DecodeWorkerHandler.async_generate(data_parallel_rank=...)`.
-        forced_dp_rank = (request.get("routing") or {}).get("dp_rank")
+        # Honour the router's DP rank decision; without it SGLang picks
+        # its own rank and KV events land on the wrong publisher.
+        forced_dp_rank = self._validate_forced_dp_rank(
+            (request.get("routing") or {}).get("dp_rank")
+        )
 
         stream = await self.engine.async_generate(
             **input_param,
@@ -395,6 +398,24 @@ class SglangLLMEngine(LLMEngine):
         if self.engine is not None:
             self.engine.shutdown()
             logger.info("SGLang engine shutdown")
+
+    def _validate_forced_dp_rank(self, dp_rank: int | None) -> int | None:
+        """Validate router-supplied global DP rank against this worker's
+        local slice. Out-of-range ranks fall back to SGLang's internal
+        load balancer."""
+        if dp_rank is None or self._dp_size <= 1:
+            return None
+        rank = int(dp_rank)
+        if not self._dp_start <= rank < self._dp_start + self._dp_size:
+            logger.warning(
+                "Received DP rank %d outside [%d, %d); falling back to "
+                "SGLang internal DP selection",
+                rank,
+                self._dp_start,
+                self._dp_start + self._dp_size,
+            )
+            return None
+        return rank
 
     def _resolve_prefill_bootstrap(self, request: GenerateRequest) -> dict[str, Any]:
         """Pick the (host, port, room) triple this prefill request will use.

--- a/components/src/dynamo/sglang/llm_engine.py
+++ b/components/src/dynamo/sglang/llm_engine.py
@@ -177,6 +177,10 @@ class SglangLLMEngine(LLMEngine):
             # runtime defaults to 1 and the router can't route to non-zero
             # dp_ranks even though `kv_event_sources` registers them.
             data_parallel_size=dp_end - dp_start,
+            # Global index of the first rank this worker hosts. Non-zero
+            # for multi-node DP-attention where each node owns a slice
+            # starting at `node_rank * local_dp_size`.
+            data_parallel_start_rank=dp_start,
             # Prefill-only — drives PrefillRouter's Bootstrap path.
             bootstrap_host=self._bootstrap_host,
             bootstrap_port=self._bootstrap_port,

--- a/components/src/dynamo/sglang/llm_engine.py
+++ b/components/src/dynamo/sglang/llm_engine.py
@@ -188,11 +188,23 @@ class SglangLLMEngine(LLMEngine):
             bootstrap_port=self._bootstrap_port,
         )
 
+    def _kv_routing_enabled(self) -> bool:
+        # Operator opts in by setting `--kv-events-config` (the same
+        # signal `kv_event_sources` already keys on). Multi-node SGLang
+        # only emits events / metrics on the leader, and decode workers
+        # in disaggregated mode don't host the indexer — same shape as
+        # the vLLM and TRT-LLM helpers.
+        if not getattr(self.server_args, "kv_events_config", None):
+            return False
+        if (getattr(self.server_args, "node_rank", 0) or 0) != 0:
+            return False
+        if self.serving_mode == DisaggregationMode.DECODE:
+            return False
+        return True
+
     def _start_metrics_task(self) -> None:
-        # Only the leader node hosts the PUSH socket; others skip.
         assert self.engine is not None, "Engine not initialized"
-        node_rank = getattr(self.server_args, "node_rank", 0) or 0
-        if node_rank != 0:
+        if not self._kv_routing_enabled():
             return
         self._metrics_zmq_ctx = zmq.asyncio.Context()
         self._metrics_zmq_sock = get_zmq_socket(
@@ -539,7 +551,7 @@ class SglangLLMEngine(LLMEngine):
             )
 
     async def kv_event_sources(self) -> list[KvEventSource]:
-        if not getattr(self.server_args, "kv_events_config", None):
+        if not self._kv_routing_enabled():
             return []
         kv_events = json.loads(self.server_args.kv_events_config)
         base_ep = kv_events.get("endpoint")
@@ -567,10 +579,7 @@ class SglangLLMEngine(LLMEngine):
         return sources
 
     async def metrics_sources(self) -> list[SnapshotSource]:
-        # Only the leader node hosts the PULL socket that feeds
-        # `_latest_metrics`; non-leader ranks would advertise closures
-        # that stay `None` forever, so skip them.
-        if (getattr(self.server_args, "node_rank", 0) or 0) != 0:
+        if not self._kv_routing_enabled():
             return []
 
         def snapshot_for(r: int) -> Callable[[], Optional[Metrics]]:

--- a/components/src/dynamo/sglang/llm_engine.py
+++ b/components/src/dynamo/sglang/llm_engine.py
@@ -189,22 +189,22 @@ class SglangLLMEngine(LLMEngine):
         )
 
     def _kv_routing_enabled(self) -> bool:
-        # Operator opts in by setting `--kv-events-config` (the same
-        # signal `kv_event_sources` already keys on). Multi-node SGLang
-        # only emits events / metrics on the leader, and decode workers
-        # in disaggregated mode don't host the indexer — same shape as
-        # the vLLM and TRT-LLM helpers.
-        if not getattr(self.server_args, "kv_events_config", None):
-            return False
-        if (getattr(self.server_args, "node_rank", 0) or 0) != 0:
-            return False
-        if self.serving_mode == DisaggregationMode.DECODE:
-            return False
-        return True
+        # Operator opts in by setting `--kv-events-config` — same gate
+        # as the legacy `DynamoSglangPublisher.init_kv_event_publish`.
+        # Every node (not just the leader) publishes its local DP ranks'
+        # events, and decode workers participate — both match legacy.
+        return bool(getattr(self.server_args, "kv_events_config", None))
+
+    def _is_metrics_leader(self) -> bool:
+        # SGLang's scheduler-metrics PULL socket is bound only on the
+        # leader node; non-leader nodes can't emit per-DP-rank metrics
+        # even when KV routing is on. Matches legacy `DynamoSglangPublisher`
+        # which only initialises the ZMQ socket on `node_rank == 0`.
+        return (getattr(self.server_args, "node_rank", 0) or 0) == 0
 
     def _start_metrics_task(self) -> None:
         assert self.engine is not None, "Engine not initialized"
-        if not self._kv_routing_enabled():
+        if not (self._kv_routing_enabled() and self._is_metrics_leader()):
             return
         self._metrics_zmq_ctx = zmq.asyncio.Context()
         self._metrics_zmq_sock = get_zmq_socket(
@@ -579,7 +579,7 @@ class SglangLLMEngine(LLMEngine):
         return sources
 
     async def metrics_sources(self) -> list[SnapshotSource]:
-        if not self._kv_routing_enabled():
+        if not (self._kv_routing_enabled() and self._is_metrics_leader()):
             return []
 
         def snapshot_for(r: int) -> Callable[[], Optional[Metrics]]:

--- a/components/src/dynamo/sglang/llm_engine.py
+++ b/components/src/dynamo/sglang/llm_engine.py
@@ -190,17 +190,12 @@ class SglangLLMEngine(LLMEngine):
         )
 
     def _kv_routing_enabled(self) -> bool:
-        # Operator opts in by setting `--kv-events-config` — same gate
-        # as the legacy `DynamoSglangPublisher.init_kv_event_publish`.
-        # Every node (not just the leader) publishes its local DP ranks'
-        # events, and decode workers participate — both match legacy.
+        # Matches legacy `DynamoSglangPublisher.init_kv_event_publish` —
+        # every node publishes its local ranks; no decode gate.
         return bool(getattr(self.server_args, "kv_events_config", None))
 
     def _is_metrics_leader(self) -> bool:
-        # SGLang's scheduler-metrics PULL socket is bound only on the
-        # leader node; non-leader nodes can't emit per-DP-rank metrics
-        # even when KV routing is on. Matches legacy `DynamoSglangPublisher`
-        # which only initialises the ZMQ socket on `node_rank == 0`.
+        # Scheduler-metrics PULL socket binds on the leader only.
         return (getattr(self.server_args, "node_rank", 0) or 0) == 0
 
     def _start_metrics_task(self) -> None:

--- a/components/src/dynamo/sglang/llm_engine.py
+++ b/components/src/dynamo/sglang/llm_engine.py
@@ -25,7 +25,7 @@ from sglang.srt.disaggregation.kv_events import ZmqEventPublisher
 from sglang.srt.utils.network import get_local_ip_auto, get_zmq_socket
 
 from dynamo._core import Context
-from dynamo.common.backend.dp_rank import validate_global_dp_rank
+from dynamo.common.backend.dp_rank import forced_dp_rank, validate_global_dp_rank
 from dynamo.common.backend.engine import (
     EngineConfig,
     GenerateChunk,
@@ -257,8 +257,8 @@ class SglangLLMEngine(LLMEngine):
 
         # Honour the router's DP rank decision; without it SGLang picks
         # its own rank and KV events land on the wrong publisher.
-        forced_dp_rank = validate_global_dp_rank(
-            (request.get("routing") or {}).get("dp_rank"),
+        sgl_dp_rank = validate_global_dp_rank(
+            forced_dp_rank(request),
             self._dp_start,
             self._dp_size,
             "SGLang",
@@ -269,7 +269,7 @@ class SglangLLMEngine(LLMEngine):
             sampling_params=sampling_params,
             stream=True,
             rid=context.trace_id,
-            data_parallel_rank=forced_dp_rank,
+            data_parallel_rank=sgl_dp_rank,
             **bootstrap_kwargs,
         )
 

--- a/components/src/dynamo/sglang/llm_engine.py
+++ b/components/src/dynamo/sglang/llm_engine.py
@@ -15,10 +15,14 @@ import logging
 import os
 import random
 import sys
-from collections.abc import AsyncGenerator
-from typing import Any
+from collections.abc import AsyncGenerator, Callable
+from typing import Any, Optional
 
 import sglang as sgl
+import zmq
+import zmq.asyncio
+from sglang.srt.disaggregation.kv_events import ZmqEventPublisher
+from sglang.srt.utils.network import get_local_ip_auto, get_zmq_socket
 
 from dynamo._core import Context
 from dynamo.common.backend.engine import (
@@ -27,6 +31,12 @@ from dynamo.common.backend.engine import (
     GenerateRequest,
     LLMEngine,
 )
+from dynamo.common.backend.publisher import (
+    KvEventSource,
+    Metrics,
+    SnapshotSource,
+    ZmqSource,
+)
 from dynamo.common.backend.worker import WorkerConfig
 from dynamo.common.constants import DisaggregationMode
 from dynamo.common.utils.input_params import InputParamManager
@@ -34,6 +44,7 @@ from dynamo.llm import ModelInput
 from dynamo.sglang._compat import get_scheduler_info
 from dynamo.sglang._disagg import compute_bootstrap_address, warmup_prefill_engine
 from dynamo.sglang.args import parse_args
+from dynamo.sglang.publisher import format_zmq_endpoint
 
 logger = logging.getLogger(__name__)
 
@@ -52,6 +63,21 @@ def _warmup_enabled() -> bool:
     return raw.strip().lower() not in ("1", "true", "yes", "on")
 
 
+def _local_dp_rank_range(server_args) -> tuple[int, int]:
+    """Per-node local-rank slice for this worker. Under DP attention each
+    node owns ``dp_size // nnodes`` ranks starting at
+    ``node_rank * local_dp_size``; otherwise rank 0 only."""
+    dp_size = getattr(server_args, "dp_size", 1) or 1
+    enable_dp_attention = getattr(server_args, "enable_dp_attention", False)
+    nnodes = getattr(server_args, "nnodes", 1) or 1
+    node_rank = getattr(server_args, "node_rank", 0) or 0
+    if enable_dp_attention and dp_size > 1:
+        local_dp_size = dp_size // nnodes if nnodes > 0 else dp_size
+        start = node_rank * local_dp_size
+        return start, start + local_dp_size
+    return 0, 1
+
+
 class SglangLLMEngine(LLMEngine):
     def __init__(self, server_args, dynamo_args, serving_mode: DisaggregationMode):
         self.server_args = server_args
@@ -67,6 +93,11 @@ class SglangLLMEngine(LLMEngine):
         # Background drain tasks for prefill stream after the bootstrap
         # chunk yields (Completed path only). Cancelled in cleanup().
         self._prefill_consume_tasks: set[asyncio.Task[Any]] = set()
+        # Populated by `_metrics_pull_loop`; read by `metrics_sources()`.
+        self._latest_metrics: dict[int, Metrics] = {}
+        self._metrics_task: Optional[asyncio.Task[None]] = None
+        self._metrics_zmq_ctx: Optional[zmq.asyncio.Context] = None
+        self._metrics_zmq_sock = None
 
     @classmethod
     async def from_args(
@@ -131,6 +162,8 @@ class SglangLLMEngine(LLMEngine):
             getattr(self.server_args, "max_prefill_tokens", None) or max_total_tokens
         )
 
+        self._start_metrics_task()
+
         return EngineConfig(
             model=self.server_args.model_path,
             served_model_name=self.server_args.served_model_name,
@@ -143,6 +176,44 @@ class SglangLLMEngine(LLMEngine):
             bootstrap_host=self._bootstrap_host,
             bootstrap_port=self._bootstrap_port,
         )
+
+    def _start_metrics_task(self) -> None:
+        # Only the leader node hosts the PUSH socket; others skip.
+        assert self.engine is not None, "Engine not initialized"
+        node_rank = getattr(self.server_args, "node_rank", 0) or 0
+        if node_rank != 0:
+            return
+        self._metrics_zmq_ctx = zmq.asyncio.Context()
+        self._metrics_zmq_sock = get_zmq_socket(
+            self._metrics_zmq_ctx,
+            zmq.PULL,
+            self.engine.port_args.metrics_ipc_name,
+            True,
+        )
+        self._metrics_task = asyncio.create_task(
+            self._metrics_pull_loop(), name="sglang-metrics-pull"
+        )
+
+    async def _metrics_pull_loop(self) -> None:
+        sock = self._metrics_zmq_sock
+        assert sock is not None
+        while True:
+            try:
+                kv_metrics = await sock.recv_pyobj()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                # Log and exit; matches the legacy publisher's stance.
+                logger.exception("SGLang metrics pull loop terminated")
+                return
+            dp_rank = (
+                kv_metrics.data_parallel_rank
+                if kv_metrics.data_parallel_rank is not None
+                else 0
+            )
+            self._latest_metrics[dp_rank] = Metrics(
+                kv_used_blocks=kv_metrics.kv_active_blocks,
+            )
 
     async def generate(
         self, request: GenerateRequest, context: Context
@@ -285,6 +356,27 @@ class SglangLLMEngine(LLMEngine):
                 task.cancel()
         self._prefill_consume_tasks.clear()
 
+        if self._metrics_task is not None:
+            self._metrics_task.cancel()
+            # CancelledError is a BaseException (not Exception) in 3.8+; the
+            # tuple catches both the expected cancel and any teardown error.
+            try:
+                await self._metrics_task
+            except (asyncio.CancelledError, Exception):
+                pass
+            self._metrics_task = None
+        if self._metrics_zmq_sock is not None:
+            try:
+                self._metrics_zmq_sock.close(linger=0)
+            except Exception:
+                pass
+            self._metrics_zmq_sock = None
+        if self._metrics_zmq_ctx is not None:
+            try:
+                self._metrics_zmq_ctx.term()
+            except Exception:
+                pass
+            self._metrics_zmq_ctx = None
         if self.engine is not None:
             self.engine.shutdown()
             logger.info("SGLang engine shutdown")
@@ -409,6 +501,50 @@ class SglangLLMEngine(LLMEngine):
                 rid,
                 exc_info=True,
             )
+
+    async def kv_event_sources(self) -> list[KvEventSource]:
+        if not getattr(self.server_args, "kv_events_config", None):
+            return []
+        kv_events = json.loads(self.server_args.kv_events_config)
+        base_ep = kv_events.get("endpoint")
+        if not base_ep:
+            return []
+        local_ip = get_local_ip_auto()
+        start, end = _local_dp_rank_range(self.server_args)
+        sources: list[KvEventSource] = []
+        for dp_rank in range(start, end):
+            zmq_ep = ZmqEventPublisher.offset_endpoint_port(base_ep, dp_rank)
+            if not zmq_ep:
+                logger.warning(
+                    "Skipping ZMQ subscriber for dp_rank=%d: offset_endpoint_port "
+                    "returned None for base_ep=%s",
+                    dp_rank,
+                    base_ep,
+                )
+                continue
+            sources.append(
+                ZmqSource(
+                    endpoint=format_zmq_endpoint(zmq_ep, local_ip),
+                    dp_rank=dp_rank,
+                )
+            )
+        return sources
+
+    async def metrics_sources(self) -> list[SnapshotSource]:
+        # Only the leader node hosts the PULL socket that feeds
+        # `_latest_metrics`; non-leader ranks would advertise closures
+        # that stay `None` forever, so skip them.
+        if (getattr(self.server_args, "node_rank", 0) or 0) != 0:
+            return []
+
+        def snapshot_for(r: int) -> Callable[[], Optional[Metrics]]:
+            return lambda: self._latest_metrics.get(r)
+
+        start, end = _local_dp_rank_range(self.server_args)
+        return [
+            SnapshotSource(snapshot=snapshot_for(rank), dp_rank=rank)
+            for rank in range(start, end)
+        ]
 
     def _build_sampling_params(self, request: GenerateRequest) -> dict:
         if not self._use_sglang_tokenizer:

--- a/components/src/dynamo/sglang/tests/test_sglang_local_dp_ranks.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_local_dp_ranks.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import importlib.util
+from types import SimpleNamespace
+
+import pytest
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.sglang,
+    pytest.mark.unified,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+    pytest.mark.skipif(
+        importlib.util.find_spec("sglang") is None,
+        reason="sglang not installed in this container",
+    ),
+]
+
+
+def _slice(**overrides):
+    from dynamo.sglang.llm_engine import _local_dp_rank_range as helper
+
+    fields = {
+        "dp_size": 1,
+        "enable_dp_attention": False,
+        "nnodes": 1,
+        "node_rank": 0,
+        **overrides,
+    }
+    return helper(SimpleNamespace(**fields))
+
+
+def test_dp_attention_disabled_short_circuits_to_rank_zero():
+    assert _slice() == (0, 1)
+    assert _slice(dp_size=8) == (0, 1)
+
+
+def test_dp_attention_multi_node_slices_ranks_by_node_index():
+    assert _slice(dp_size=8, enable_dp_attention=True, nnodes=2, node_rank=0) == (0, 4)
+    assert _slice(dp_size=8, enable_dp_attention=True, nnodes=2, node_rank=1) == (4, 8)
+
+
+def test_missing_attributes_use_safe_defaults():
+    from dynamo.sglang.llm_engine import _local_dp_rank_range as helper
+
+    assert helper(SimpleNamespace()) == (0, 1)

--- a/components/src/dynamo/trtllm/llm_engine.py
+++ b/components/src/dynamo/trtllm/llm_engine.py
@@ -33,7 +33,7 @@ from torch.cuda import device_count
 
 from dynamo._core import Context
 from dynamo.common.backend.disagg import require_prefill_result
-from dynamo.common.backend.dp_rank import validate_global_dp_rank
+from dynamo.common.backend.dp_rank import forced_dp_rank, validate_global_dp_rank
 from dynamo.common.backend.engine import (
     EngineConfig,
     GenerateChunk,
@@ -522,9 +522,7 @@ class TrtllmLLMEngine(LLMEngine):
 
         # Honour the router's DP rank decision; without it TRT-LLM picks
         # its own rank and KV events land on the wrong publisher.
-        scheduling_params = self._scheduling_params_for(
-            (request.get("routing") or {}).get("dp_rank")
-        )
+        scheduling_params = self._scheduling_params_for(forced_dp_rank(request))
 
         # Prefill returns one non-streaming chunk carrying the handoff —
         # matches the legacy disagg wire format.

--- a/components/src/dynamo/trtllm/llm_engine.py
+++ b/components/src/dynamo/trtllm/llm_engine.py
@@ -33,6 +33,7 @@ from torch.cuda import device_count
 
 from dynamo._core import Context
 from dynamo.common.backend.disagg import require_prefill_result
+from dynamo.common.backend.dp_rank import validate_global_dp_rank
 from dynamo.common.backend.engine import (
     EngineConfig,
     GenerateChunk,
@@ -392,16 +393,10 @@ class TrtllmLLMEngine(LLMEngine):
     def _scheduling_params_for(
         self, dp_rank: int | None
     ) -> Optional[SchedulingParams]:
-        if dp_rank is None or self._attention_dp_size <= 1:
-            return None
-        rank = int(dp_rank)
-        if not 0 <= rank < self._attention_dp_size:
-            logger.warning(
-                "Received DP rank %d outside [0, %d); falling back to "
-                "TRT-LLM internal DP selection",
-                rank,
-                self._attention_dp_size,
-            )
+        rank = validate_global_dp_rank(
+            dp_rank, 0, self._attention_dp_size, "TRT-LLM"
+        )
+        if rank is None:
             return None
         return SchedulingParams(attention_dp_rank=rank, attention_dp_relax=False)
 

--- a/components/src/dynamo/trtllm/llm_engine.py
+++ b/components/src/dynamo/trtllm/llm_engine.py
@@ -15,9 +15,11 @@ import json
 import logging
 import re
 import sys
-from collections.abc import AsyncGenerator
+import threading
+import time
+from collections.abc import AsyncGenerator, Callable
 from dataclasses import asdict
-from typing import Any
+from typing import Any, Optional
 
 from tensorrt_llm.executor.result import GenerationResult
 from tensorrt_llm.llmapi import DisaggregatedParams as LlmDisaggregatedParams
@@ -36,9 +38,15 @@ from dynamo.common.backend.engine import (
     GenerateRequest,
     LLMEngine,
 )
+from dynamo.common.backend.publisher import (
+    KvEventSource,
+    Metrics,
+    PushSource,
+    SnapshotSource,
+)
 from dynamo.common.backend.worker import WorkerConfig
 from dynamo.common.constants import DisaggregationMode as CommonDisaggregationMode
-from dynamo.llm import ModelInput
+from dynamo.llm import KvEventPublisher, ModelInput
 from dynamo.trtllm.args import parse_args
 from dynamo.trtllm.constants import DisaggregationMode
 from dynamo.trtllm.engine import Backend, TensorRTLLMEngine
@@ -59,6 +67,15 @@ _DRAIN_POLL_INTERVAL_S = 0.5
 # `workers/llm_worker.py: connection_id() % 1021`.
 _DISAGG_MACHINE_ID_MAX = 1021
 
+# Server-side wait per poll; idle sleep bounds CPU when the engine is quiet.
+_KV_EVENTS_POLL_TIMEOUT_S = 0.2
+_STATS_POLL_TIMEOUT_S = 0.2
+_IDLE_SLEEP_S = 0.01
+
+# Mirror the legacy `dynamo.trtllm` worker — required for TRT-LLM to actually
+# publish KV cache events. Without this, `get_kv_cache_events` returns empty.
+_DEFAULT_KV_EVENT_BUFFER_MAX_SIZE = 1024
+
 
 # Bridges trtllm's local enum into the common one. ENCODE absent —
 # rejected up front in from_args().
@@ -67,6 +84,17 @@ _TRTLLM_TO_COMMON_DISAGG = {
     DisaggregationMode.PREFILL: CommonDisaggregationMode.PREFILL,
     DisaggregationMode.DECODE: CommonDisaggregationMode.DECODE,
 }
+
+
+def _to_signed_i64(value: int | None) -> int | None:
+    """Two's-complement cast of a Python int into the signed 64-bit range."""
+    if value is None:
+        return None
+    if value >= 2**63:
+        return value - 2**64
+    if value < -(2**63):
+        return ((value + 2**63) % 2**64) - 2**63
+    return value
 
 
 class TrtllmLLMEngine(LLMEngine):
@@ -100,6 +128,27 @@ class TrtllmLLMEngine(LLMEngine):
         # Set in start() from worker_id. 10-bit field is a TRT-LLM API
         # constraint; collisions possible at scale (~30 replicas).
         self._disagg_machine_id: int = 0
+        self._publish_stop = threading.Event()
+        self._metrics_thread: Optional[threading.Thread] = None
+        self._kv_events_thread: Optional[threading.Thread] = None
+        self._attention_dp_size: int = 1
+        # Worker invokes on_ready callbacks serially during setup (see
+        # `setup_kv_publishers` in lib/backend-common/src/publisher.rs); the
+        # dict is fully populated before `_kv_events_thread` starts and
+        # read-only thereafter.
+        self._kv_publishers: dict[int, KvEventPublisher] = {}
+        # Written by `_metrics_poll_loop`, read by snapshot lambdas under the
+        # GIL. Per-rank key-level writes are GIL-serialized.
+        self._latest_metrics: dict[int, Metrics] = {}
+        # Per-rank hashes of partial blocks; their later "removed" events
+        # must not reach the router (which never saw them stored). Scoping
+        # by rank prevents a partial block on one rank from suppressing a
+        # legitimate `removed` on another rank.
+        self._partial_block_hashes_by_rank: dict[int, set[int]] = {}
+        self._last_event_id_by_rank: dict[int, int] = {}
+        # One-shot guards so a misbehaving engine doesn't flood logs.
+        self._warned_dispatch_failed = False
+        self._warned_unknown_dp_rank = False
 
     @classmethod
     async def from_args(
@@ -129,6 +178,11 @@ class TrtllmLLMEngine(LLMEngine):
             "max_seq_len": config.max_seq_len,
             "max_beam_width": config.max_beam_width,
             "max_batch_size": config.max_batch_size,
+            "return_perf_metrics": config.publish_events_and_metrics,
+            # enable_iter_perf_stats is required by the PyTorch backend to
+            # compute iteration-level stats (KV cache utilization, hit rate).
+            # See TRT-LLM PR #11243.
+            "enable_iter_perf_stats": config.publish_events_and_metrics,
         }
 
         # Apply --extra-engine-args / --override-engine-args. Match the
@@ -153,6 +207,18 @@ class TrtllmLLMEngine(LLMEngine):
             logging.info("Applying engine arg overrides: %s", overrides)
             warn_override_collisions(engine_args, overrides)
             deep_update(engine_args, overrides)
+
+        # Apply event_buffer_max_size AFTER overrides so a user override
+        # that strips the field can't disable KV-event publishing. Mirrors
+        # the legacy `llm_worker` publish_events_and_metrics block; like
+        # legacy, treats `0` as "unset" (TRT-LLM's disabled value).
+        if config.publish_events_and_metrics:
+            kv_cfg = engine_args["kv_cache_config"]
+            if isinstance(kv_cfg, KvCacheConfig):
+                kv_cfg = kv_cfg.model_dump(exclude_none=True)
+            if not kv_cfg.get("event_buffer_max_size"):
+                kv_cfg["event_buffer_max_size"] = _DEFAULT_KV_EVENT_BUFFER_MAX_SIZE
+            engine_args["kv_cache_config"] = kv_cfg
 
         # Use post-override engine_args so EngineConfig matches what the
         # actual TRT-LLM engine got.
@@ -189,6 +255,14 @@ class TrtllmLLMEngine(LLMEngine):
         self._engine = TensorRTLLMEngine(self.engine_args, self.disaggregation_mode)
         await self._engine.initialize()
 
+        self._attention_dp_size = self._engine.get_attention_dp_size()
+        self._metrics_thread = threading.Thread(
+            target=self._metrics_poll_loop,
+            daemon=True,
+            name="trtllm-metrics-poll",
+        )
+        self._metrics_thread.start()
+
         return EngineConfig(
             model=self.model_name,
             served_model_name=self.served_model_name,
@@ -196,7 +270,176 @@ class TrtllmLLMEngine(LLMEngine):
             kv_cache_block_size=self.kv_block_size,
             max_num_seqs=self.max_batch_size,
             max_num_batched_tokens=self.max_num_tokens,
+            data_parallel_size=self._attention_dp_size,
         )
+
+    # TRT-LLM's `get_kv_cache_events` / `get_stats` block the calling
+    # thread, so we drive them from dedicated worker threads rather than
+    # the asyncio event loop.
+
+    async def kv_event_sources(self) -> list[KvEventSource]:
+        return [
+            PushSource(
+                on_ready=self._make_on_publisher_ready(rank),
+                dp_rank=rank,
+            )
+            for rank in range(self._attention_dp_size)
+        ]
+
+    async def metrics_sources(self) -> list[SnapshotSource]:
+        def snapshot_for(r: int) -> Callable[[], Optional[Metrics]]:
+            return lambda: self._latest_metrics.get(r)
+
+        return [
+            SnapshotSource(snapshot=snapshot_for(rank), dp_rank=rank)
+            for rank in range(self._attention_dp_size)
+        ]
+
+    def _make_on_publisher_ready(self, rank: int):
+        # Worker invokes on_ready serially during setup; the call that
+        # completes the publisher set starts the dispatch thread.
+        def on_ready(publisher: KvEventPublisher) -> None:
+            self._kv_publishers[rank] = publisher
+            if (
+                len(self._kv_publishers) == self._attention_dp_size
+                and self._kv_events_thread is None
+            ):
+                self._kv_events_thread = threading.Thread(
+                    target=self._kv_events_poll_loop,
+                    daemon=True,
+                    name="trtllm-kv-events-poll",
+                )
+                self._kv_events_thread.start()
+
+        return on_ready
+
+    # Stats payloads use camelCase keys (`attentionDpRank`, `kvCacheStats`);
+    # the KV-event payloads in `_dispatch_kv_event` use snake_case
+    # (`attention_dp_rank`). Both match TRT-LLM's upstream conventions.
+    def _metrics_poll_loop(self) -> None:
+        assert self._engine is not None
+        while not self._publish_stop.is_set():
+            try:
+                snaps = self._engine.llm.get_stats(timeout=_STATS_POLL_TIMEOUT_S)
+            except Exception as e:
+                logger.debug("trtllm get_stats raised: %s", e)
+                time.sleep(_IDLE_SLEEP_S)
+                continue
+            if not snaps:
+                time.sleep(_IDLE_SLEEP_S)
+                continue
+            # Per-rank latest snapshot. Stats from different ranks are
+            # interleaved; keep the freshest per `attentionDpRank`.
+            for snap in snaps:
+                kv_used = snap.get("kvCacheStats", {}).get("usedNumBlocks")
+                if kv_used is None:
+                    continue
+                rank = int(snap.get("attentionDpRank", 0))
+                self._latest_metrics[rank] = Metrics(kv_used_blocks=int(kv_used))
+
+    def _kv_events_poll_loop(self) -> None:
+        assert self._engine is not None
+        while not self._publish_stop.is_set():
+            try:
+                events = self._engine.llm.get_kv_cache_events(
+                    timeout=_KV_EVENTS_POLL_TIMEOUT_S
+                )
+            except Exception as e:
+                logger.debug("trtllm get_kv_cache_events raised: %s", e)
+                time.sleep(_IDLE_SLEEP_S)
+                continue
+            if not events:
+                time.sleep(_IDLE_SLEEP_S)
+                continue
+            for event in events:
+                try:
+                    self._dispatch_kv_event(event)
+                except Exception as e:
+                    if not self._warned_dispatch_failed:
+                        self._warned_dispatch_failed = True
+                        logger.exception(
+                            "Failed to dispatch KV event; suppressing further "
+                            "tracebacks (last error: %s)",
+                            e,
+                        )
+
+    def _dispatch_kv_event(self, event: dict[str, Any]) -> None:
+        """Forward stored / removed events to the right publisher. Other
+        event types are dropped — the Python publisher has no path for them."""
+        rank = int(event.get("attention_dp_rank", 0))
+        event_id = event.get("event_id")
+        if event_id is not None:
+            last = self._last_event_id_by_rank.get(rank)
+            if last is not None and event_id != last + 1:
+                logger.warning(
+                    "Non-consecutive engine event_id on rank=%d: expected %d, got %d",
+                    rank,
+                    last + 1,
+                    event_id,
+                )
+            self._last_event_id_by_rank[rank] = event_id
+        publisher = self._kv_publishers.get(rank)
+        if publisher is None:
+            if not self._warned_unknown_dp_rank:
+                self._warned_unknown_dp_rank = True
+                logger.warning(
+                    "Dropping KV event for unknown attention_dp_rank=%d "
+                    "(have %s); suppressing further warnings",
+                    rank,
+                    sorted(self._kv_publishers.keys()),
+                )
+            return
+        data = event.get("data") or {}
+        kind = data.get("type")
+        if kind == "stored":
+            parent_hash = _to_signed_i64(data.get("parent_hash"))
+            token_ids: list[int] = []
+            num_block_tokens: list[int] = []
+            block_hashes: list[int] = []
+            kv_block_size = self.kv_block_size
+            for block in data.get("blocks", []):
+                block_tokens = block.get("tokens") or []
+                token_num = len(block_tokens)
+                if token_num > kv_block_size:
+                    logger.error(
+                        "Block contains %d tokens > kv_block_size %d",
+                        token_num,
+                        kv_block_size,
+                    )
+                    return
+                block_hash = _to_signed_i64(block.get("block_hash"))
+                if block_hash is None:
+                    continue
+                if token_num < kv_block_size:
+                    self._partial_block_hashes_by_rank.setdefault(rank, set()).add(
+                        block_hash
+                    )
+                    break
+                num_block_tokens.append(token_num)
+                block_hashes.append(block_hash)
+                token_ids.extend(int(t["token_id"]) for t in block_tokens)
+            if not block_hashes:
+                return
+            publisher.publish_stored(
+                token_ids,
+                num_block_tokens,
+                block_hashes,
+                parent_hash,
+                lora_name=data.get("lora_name"),
+            )
+        elif kind == "removed":
+            partial = self._partial_block_hashes_by_rank.get(rank)
+            removed: list[int] = []
+            for raw in data.get("block_hashes", []):
+                block_hash = _to_signed_i64(raw)
+                if block_hash is None:
+                    continue
+                if partial is not None and block_hash in partial:
+                    partial.remove(block_hash)
+                    continue
+                removed.append(block_hash)
+            if removed:
+                publisher.publish_removed(removed)
 
     async def generate(
         self, request: GenerateRequest, context: Context
@@ -303,7 +546,7 @@ class TrtllmLLMEngine(LLMEngine):
 
     @staticmethod
     def _decode_prefill_handoff(
-        prefill_result: dict[str, Any]
+        prefill_result: dict[str, Any],
     ) -> LlmDisaggregatedParams:
         """Decode the prefill peer's handoff payload into a TRT-LLM
         `LlmDisaggregatedParams` ready to drive a generation_only call.
@@ -406,6 +649,16 @@ class TrtllmLLMEngine(LLMEngine):
         )
 
     async def cleanup(self) -> None:
+        # Stop the publisher threads BEFORE engine shutdown so they don't
+        # observe a half-torn-down RPC client. Each thread already loops on
+        # `_publish_stop`; the join bounds the wait at the poll timeout.
+        self._publish_stop.set()
+        for thread in (self._kv_events_thread, self._metrics_thread):
+            if thread is not None:
+                thread.join(timeout=_KV_EVENTS_POLL_TIMEOUT_S * 2 + 0.5)
+        self._kv_events_thread = None
+        self._metrics_thread = None
+        self._kv_publishers.clear()
         if self._engine is not None:
             await self._engine.cleanup()
             logger.info("TensorRT-LLM engine shutdown")

--- a/components/src/dynamo/trtllm/llm_engine.py
+++ b/components/src/dynamo/trtllm/llm_engine.py
@@ -28,6 +28,7 @@ from tensorrt_llm.llmapi.disagg_utils import get_global_disagg_request_id
 from tensorrt_llm.llmapi.llm import SamplingParams
 from tensorrt_llm.llmapi.llm_utils import update_llm_args_with_extra_options
 from tensorrt_llm.sampling_params import GuidedDecodingParams
+from tensorrt_llm.scheduling_params import SchedulingParams
 from torch.cuda import device_count
 
 from dynamo._core import Context
@@ -489,6 +490,23 @@ class TrtllmLLMEngine(LLMEngine):
         if ignore_eos:
             sampling_params.ignore_eos = ignore_eos
 
+        # Honour the router's attention-DP rank decision. Without this,
+        # TRT-LLM picks the rank itself (typically rank 0) regardless of
+        # what the router decided, so KV events all land on rank 0's
+        # publisher and the per-rank indexer trees diverge from reality.
+        # Mirrors the legacy `handler_base._handle_decode_request` flow.
+        routing = request.get("routing") or {}
+        forced_dp_rank = routing.get("dp_rank")
+        scheduling_params: SchedulingParams | None = None
+        if (
+            forced_dp_rank is not None
+            and self._attention_dp_size > 1
+        ):
+            scheduling_params = SchedulingParams(
+                attention_dp_rank=int(forced_dp_rank),
+                attention_dp_relax=False,
+            )
+
         # Prefill returns one non-streaming chunk carrying the handoff —
         # matches the legacy disagg wire format.
         streaming = not is_prefill
@@ -497,6 +515,7 @@ class TrtllmLLMEngine(LLMEngine):
             sampling_params=sampling_params,
             streaming=streaming,
             disaggregated_params=disaggregated_params,
+            scheduling_params=scheduling_params,
         )
 
         request_id = context.id()

--- a/components/src/dynamo/trtllm/llm_engine.py
+++ b/components/src/dynamo/trtllm/llm_engine.py
@@ -10,15 +10,16 @@ and feature gap details.
 from __future__ import annotations
 
 import asyncio
-import concurrent.futures
 import dataclasses
 import json
 import logging
 import re
 import sys
+import threading
+import time
 from collections.abc import AsyncGenerator, Callable
 from dataclasses import asdict
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
 from tensorrt_llm.executor.result import GenerationResult
 from tensorrt_llm.llmapi import DisaggregatedParams as LlmDisaggregatedParams
@@ -127,23 +128,13 @@ class TrtllmLLMEngine(LLMEngine):
         # Set in start() from worker_id. 10-bit field is a TRT-LLM API
         # constraint; collisions possible at scale (~30 replicas).
         self._disagg_machine_id: int = 0
-        # KV-events and metrics polling run as asyncio tasks on the engine
-        # loop. The thread-based path can't use TRT-LLM's `get_kv_cache_events`
-        # / `get_stats` because, once `_iter_kv_events_result` is initialised
-        # by a generate_async call running inside the asyncio loop, the
-        # underlying queue becomes an `AsyncQueue`; its sync get returns
-        # `None` on timeout instead of raising `queue.Empty`, and downstream
-        # `json.loads(None)` throws, swallowing every batch of events.
-        # The async path uses the native AsyncQueue and matches the legacy
-        # `dynamo.trtllm.publisher` polling loop.
-        self._loop: Optional[asyncio.AbstractEventLoop] = None
-        self._metrics_task: Optional[asyncio.Task[None]] = None
-        self._kv_events_task: Optional[concurrent.futures.Future[None]] = None
-        self._publish_stop_event: Optional[asyncio.Event] = None
+        self._publish_stop = threading.Event()
+        self._metrics_thread: Optional[threading.Thread] = None
+        self._kv_events_thread: Optional[threading.Thread] = None
         self._attention_dp_size: int = 1
         # Worker invokes on_ready callbacks serially during setup (see
         # `setup_kv_publishers` in lib/backend-common/src/publisher.rs); the
-        # dict is fully populated before the kv-events task starts and
+        # dict is fully populated before `_kv_events_thread` starts and
         # read-only thereafter.
         self._kv_publishers: dict[int, KvEventPublisher] = {}
         # Written by `_metrics_poll_loop`, read by snapshot lambdas under the
@@ -271,14 +262,12 @@ class TrtllmLLMEngine(LLMEngine):
         await self._engine.initialize()
 
         self._attention_dp_size = self._engine.get_attention_dp_size()
-        # Loop reference is captured here so on_ready (called on a Rust
-        # tokio worker thread during publisher setup) can schedule the
-        # kv-events task back onto this asyncio loop.
-        self._loop = asyncio.get_running_loop()
-        self._publish_stop_event = asyncio.Event()
-        self._metrics_task = asyncio.create_task(
-            self._metrics_poll_loop(), name="trtllm-metrics-poll"
+        self._metrics_thread = threading.Thread(
+            target=self._metrics_poll_loop,
+            daemon=True,
+            name="trtllm-metrics-poll",
         )
+        self._metrics_thread.start()
 
         return EngineConfig(
             model=self.model_name,
@@ -313,67 +302,72 @@ class TrtllmLLMEngine(LLMEngine):
         ]
 
     def _make_on_publisher_ready(self, rank: int):
-        # Worker invokes on_ready serially during setup on a Rust tokio
-        # worker thread; the call that completes the publisher set
-        # schedules the kv-events task onto the engine's asyncio loop.
+        # Worker invokes on_ready serially during setup; the call that
+        # completes the publisher set starts the dispatch thread.
         def on_ready(publisher: KvEventPublisher) -> None:
             self._kv_publishers[rank] = publisher
             if (
                 len(self._kv_publishers) == self._attention_dp_size
-                and self._kv_events_task is None
-                and self._loop is not None
+                and self._kv_events_thread is None
             ):
-                self._kv_events_task = asyncio.run_coroutine_threadsafe(
-                    self._kv_events_poll_loop(), self._loop
+                self._kv_events_thread = threading.Thread(
+                    target=self._kv_events_poll_loop,
+                    daemon=True,
+                    name="trtllm-kv-events-poll",
                 )
+                self._kv_events_thread.start()
 
         return on_ready
 
     # Stats payloads use camelCase keys (`attentionDpRank`, `kvCacheStats`);
     # the KV-event payloads in `_dispatch_kv_event` use snake_case
     # (`attention_dp_rank`). Both match TRT-LLM's upstream conventions.
-    async def _metrics_poll_loop(self) -> None:
+    def _metrics_poll_loop(self) -> None:
         assert self._engine is not None
-        assert self._publish_stop_event is not None
-        while not self._publish_stop_event.is_set():
+        while not self._publish_stop.is_set():
             try:
-                async for snap in self._engine.llm.get_stats_async(
-                    timeout=_STATS_POLL_TIMEOUT_S
-                ):
-                    kv_used = snap.get("kvCacheStats", {}).get("usedNumBlocks")
-                    if kv_used is None:
-                        continue
-                    rank = int(snap.get("attentionDpRank", 0))
-                    self._latest_metrics[rank] = Metrics(kv_used_blocks=int(kv_used))
-            except asyncio.CancelledError:
-                raise
+                snaps = self._engine.llm.get_stats(timeout=_STATS_POLL_TIMEOUT_S)
             except Exception as e:
-                logger.debug("trtllm get_stats_async raised: %s", e)
-            await asyncio.sleep(_IDLE_SLEEP_S)
+                logger.debug("trtllm get_stats raised: %s", e)
+                time.sleep(_IDLE_SLEEP_S)
+                continue
+            if not snaps:
+                time.sleep(_IDLE_SLEEP_S)
+                continue
+            # Per-rank latest snapshot. Stats from different ranks are
+            # interleaved; keep the freshest per `attentionDpRank`.
+            for snap in snaps:
+                kv_used = snap.get("kvCacheStats", {}).get("usedNumBlocks")
+                if kv_used is None:
+                    continue
+                rank = int(snap.get("attentionDpRank", 0))
+                self._latest_metrics[rank] = Metrics(kv_used_blocks=int(kv_used))
 
-    async def _kv_events_poll_loop(self) -> None:
+    def _kv_events_poll_loop(self) -> None:
         assert self._engine is not None
-        assert self._publish_stop_event is not None
-        while not self._publish_stop_event.is_set():
+        while not self._publish_stop.is_set():
             try:
-                async for event in self._engine.llm.get_kv_cache_events_async(
+                events = self._engine.llm.get_kv_cache_events(
                     timeout=_KV_EVENTS_POLL_TIMEOUT_S
-                ):
-                    try:
-                        self._dispatch_kv_event(event)
-                    except Exception as e:
-                        if not self._warned_dispatch_failed:
-                            self._warned_dispatch_failed = True
-                            logger.exception(
-                                "Failed to dispatch KV event; suppressing "
-                                "further tracebacks (last error: %s)",
-                                e,
-                            )
-            except asyncio.CancelledError:
-                raise
+                )
             except Exception as e:
-                logger.debug("trtllm get_kv_cache_events_async raised: %s", e)
-            await asyncio.sleep(_IDLE_SLEEP_S)
+                logger.debug("trtllm get_kv_cache_events raised: %s", e)
+                time.sleep(_IDLE_SLEEP_S)
+                continue
+            if not events:
+                time.sleep(_IDLE_SLEEP_S)
+                continue
+            for event in events:
+                try:
+                    self._dispatch_kv_event(event)
+                except Exception as e:
+                    if not self._warned_dispatch_failed:
+                        self._warned_dispatch_failed = True
+                        logger.exception(
+                            "Failed to dispatch KV event; suppressing further "
+                            "tracebacks (last error: %s)",
+                            e,
+                        )
 
     def _dispatch_kv_event(self, event: dict[str, Any]) -> None:
         """Forward stored / removed events to the right publisher. Other
@@ -661,41 +655,19 @@ class TrtllmLLMEngine(LLMEngine):
         )
 
     async def cleanup(self) -> None:
-        # Stop the publisher tasks BEFORE engine shutdown so they don't
-        # observe a half-torn-down RPC client. Setting the asyncio event
-        # lets the poll loops exit on their next iteration; cancellation
-        # is the backstop if they're stuck mid-iteration.
-        if self._publish_stop_event is not None:
-            self._publish_stop_event.set()
-        await self._cancel_publish_task(self._kv_events_task)
-        await self._cancel_publish_task(self._metrics_task)
-        self._kv_events_task = None
-        self._metrics_task = None
-        self._publish_stop_event = None
-        self._loop = None
+        # Stop the publisher threads BEFORE engine shutdown so they don't
+        # observe a half-torn-down RPC client. Each thread already loops on
+        # `_publish_stop`; the join bounds the wait at the poll timeout.
+        self._publish_stop.set()
+        for thread in (self._kv_events_thread, self._metrics_thread):
+            if thread is not None:
+                thread.join(timeout=_KV_EVENTS_POLL_TIMEOUT_S * 2 + 0.5)
+        self._kv_events_thread = None
+        self._metrics_thread = None
         self._kv_publishers.clear()
         if self._engine is not None:
             await self._engine.cleanup()
             logger.info("TensorRT-LLM engine shutdown")
-
-    @staticmethod
-    async def _cancel_publish_task(
-        task: Optional[Union[asyncio.Task[None], concurrent.futures.Future[None]]],
-    ) -> None:
-        # `_metrics_task` is an asyncio.Task created on the engine loop;
-        # `_kv_events_task` is a concurrent.futures.Future from
-        # `asyncio.run_coroutine_threadsafe`. Both expose `cancel()` and
-        # awaiting them surfaces any pending exception.
-        if task is None or task.done():
-            return
-        task.cancel()
-        try:
-            if isinstance(task, asyncio.Task):
-                await task
-            else:
-                await asyncio.wrap_future(task)
-        except (asyncio.CancelledError, Exception):
-            pass
 
     @staticmethod
     def _override_sampling_params(

--- a/components/src/dynamo/trtllm/llm_engine.py
+++ b/components/src/dynamo/trtllm/llm_engine.py
@@ -171,10 +171,9 @@ class TrtllmLLMEngine(LLMEngine):
             "tensor_parallel_size": config.tensor_parallel_size,
             "pipeline_parallel_size": config.pipeline_parallel_size,
             "moe_expert_parallel_size": config.expert_parallel_size,
-            # Required for attention-DP routing: TRT-LLM only exposes
-            # per-rank KV events / stats when attention_dp is on, and
-            # `get_attention_dp_size()` reads this flag back to size the
-            # publishers (engine.py:118-120).
+            # Required for per-rank KV events under attention-DP; without
+            # it `get_attention_dp_size()` collapses to 1 and only rank
+            # 0's publisher is created.
             "enable_attention_dp": config.enable_attention_dp,
             "backend": Backend.PYTORCH,
             "kv_cache_config": KvCacheConfig(
@@ -370,6 +369,22 @@ class TrtllmLLMEngine(LLMEngine):
                             e,
                         )
 
+    def _scheduling_params_for(
+        self, dp_rank: int | None
+    ) -> Optional[SchedulingParams]:
+        if dp_rank is None or self._attention_dp_size <= 1:
+            return None
+        rank = int(dp_rank)
+        if not 0 <= rank < self._attention_dp_size:
+            logger.warning(
+                "Received DP rank %d outside [0, %d); falling back to "
+                "TRT-LLM internal DP selection",
+                rank,
+                self._attention_dp_size,
+            )
+            return None
+        return SchedulingParams(attention_dp_rank=rank, attention_dp_relax=False)
+
     def _dispatch_kv_event(self, event: dict[str, Any]) -> None:
         """Forward stored / removed events to the right publisher. Other
         event types are dropped — the Python publisher has no path for them."""
@@ -490,22 +505,11 @@ class TrtllmLLMEngine(LLMEngine):
         if ignore_eos:
             sampling_params.ignore_eos = ignore_eos
 
-        # Honour the router's attention-DP rank decision. Without this,
-        # TRT-LLM picks the rank itself (typically rank 0) regardless of
-        # what the router decided, so KV events all land on rank 0's
-        # publisher and the per-rank indexer trees diverge from reality.
-        # Mirrors the legacy `handler_base._handle_decode_request` flow.
-        routing = request.get("routing") or {}
-        forced_dp_rank = routing.get("dp_rank")
-        scheduling_params: SchedulingParams | None = None
-        if (
-            forced_dp_rank is not None
-            and self._attention_dp_size > 1
-        ):
-            scheduling_params = SchedulingParams(
-                attention_dp_rank=int(forced_dp_rank),
-                attention_dp_relax=False,
-            )
+        # Honour the router's DP rank decision; without it TRT-LLM picks
+        # its own rank and KV events land on the wrong publisher.
+        scheduling_params = self._scheduling_params_for(
+            (request.get("routing") or {}).get("dp_rank")
+        )
 
         # Prefill returns one non-streaming chunk carrying the handoff —
         # matches the legacy disagg wire format.

--- a/components/src/dynamo/trtllm/llm_engine.py
+++ b/components/src/dynamo/trtllm/llm_engine.py
@@ -10,16 +10,15 @@ and feature gap details.
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import dataclasses
 import json
 import logging
 import re
 import sys
-import threading
-import time
 from collections.abc import AsyncGenerator, Callable
 from dataclasses import asdict
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 from tensorrt_llm.executor.result import GenerationResult
 from tensorrt_llm.llmapi import DisaggregatedParams as LlmDisaggregatedParams
@@ -128,13 +127,23 @@ class TrtllmLLMEngine(LLMEngine):
         # Set in start() from worker_id. 10-bit field is a TRT-LLM API
         # constraint; collisions possible at scale (~30 replicas).
         self._disagg_machine_id: int = 0
-        self._publish_stop = threading.Event()
-        self._metrics_thread: Optional[threading.Thread] = None
-        self._kv_events_thread: Optional[threading.Thread] = None
+        # KV-events and metrics polling run as asyncio tasks on the engine
+        # loop. The thread-based path can't use TRT-LLM's `get_kv_cache_events`
+        # / `get_stats` because, once `_iter_kv_events_result` is initialised
+        # by a generate_async call running inside the asyncio loop, the
+        # underlying queue becomes an `AsyncQueue`; its sync get returns
+        # `None` on timeout instead of raising `queue.Empty`, and downstream
+        # `json.loads(None)` throws, swallowing every batch of events.
+        # The async path uses the native AsyncQueue and matches the legacy
+        # `dynamo.trtllm.publisher` polling loop.
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._metrics_task: Optional[asyncio.Task[None]] = None
+        self._kv_events_task: Optional[concurrent.futures.Future[None]] = None
+        self._publish_stop_event: Optional[asyncio.Event] = None
         self._attention_dp_size: int = 1
         # Worker invokes on_ready callbacks serially during setup (see
         # `setup_kv_publishers` in lib/backend-common/src/publisher.rs); the
-        # dict is fully populated before `_kv_events_thread` starts and
+        # dict is fully populated before the kv-events task starts and
         # read-only thereafter.
         self._kv_publishers: dict[int, KvEventPublisher] = {}
         # Written by `_metrics_poll_loop`, read by snapshot lambdas under the
@@ -262,12 +271,14 @@ class TrtllmLLMEngine(LLMEngine):
         await self._engine.initialize()
 
         self._attention_dp_size = self._engine.get_attention_dp_size()
-        self._metrics_thread = threading.Thread(
-            target=self._metrics_poll_loop,
-            daemon=True,
-            name="trtllm-metrics-poll",
+        # Loop reference is captured here so on_ready (called on a Rust
+        # tokio worker thread during publisher setup) can schedule the
+        # kv-events task back onto this asyncio loop.
+        self._loop = asyncio.get_running_loop()
+        self._publish_stop_event = asyncio.Event()
+        self._metrics_task = asyncio.create_task(
+            self._metrics_poll_loop(), name="trtllm-metrics-poll"
         )
-        self._metrics_thread.start()
 
         return EngineConfig(
             model=self.model_name,
@@ -302,72 +313,67 @@ class TrtllmLLMEngine(LLMEngine):
         ]
 
     def _make_on_publisher_ready(self, rank: int):
-        # Worker invokes on_ready serially during setup; the call that
-        # completes the publisher set starts the dispatch thread.
+        # Worker invokes on_ready serially during setup on a Rust tokio
+        # worker thread; the call that completes the publisher set
+        # schedules the kv-events task onto the engine's asyncio loop.
         def on_ready(publisher: KvEventPublisher) -> None:
             self._kv_publishers[rank] = publisher
             if (
                 len(self._kv_publishers) == self._attention_dp_size
-                and self._kv_events_thread is None
+                and self._kv_events_task is None
+                and self._loop is not None
             ):
-                self._kv_events_thread = threading.Thread(
-                    target=self._kv_events_poll_loop,
-                    daemon=True,
-                    name="trtllm-kv-events-poll",
+                self._kv_events_task = asyncio.run_coroutine_threadsafe(
+                    self._kv_events_poll_loop(), self._loop
                 )
-                self._kv_events_thread.start()
 
         return on_ready
 
     # Stats payloads use camelCase keys (`attentionDpRank`, `kvCacheStats`);
     # the KV-event payloads in `_dispatch_kv_event` use snake_case
     # (`attention_dp_rank`). Both match TRT-LLM's upstream conventions.
-    def _metrics_poll_loop(self) -> None:
+    async def _metrics_poll_loop(self) -> None:
         assert self._engine is not None
-        while not self._publish_stop.is_set():
+        assert self._publish_stop_event is not None
+        while not self._publish_stop_event.is_set():
             try:
-                snaps = self._engine.llm.get_stats(timeout=_STATS_POLL_TIMEOUT_S)
+                async for snap in self._engine.llm.get_stats_async(
+                    timeout=_STATS_POLL_TIMEOUT_S
+                ):
+                    kv_used = snap.get("kvCacheStats", {}).get("usedNumBlocks")
+                    if kv_used is None:
+                        continue
+                    rank = int(snap.get("attentionDpRank", 0))
+                    self._latest_metrics[rank] = Metrics(kv_used_blocks=int(kv_used))
+            except asyncio.CancelledError:
+                raise
             except Exception as e:
-                logger.debug("trtllm get_stats raised: %s", e)
-                time.sleep(_IDLE_SLEEP_S)
-                continue
-            if not snaps:
-                time.sleep(_IDLE_SLEEP_S)
-                continue
-            # Per-rank latest snapshot. Stats from different ranks are
-            # interleaved; keep the freshest per `attentionDpRank`.
-            for snap in snaps:
-                kv_used = snap.get("kvCacheStats", {}).get("usedNumBlocks")
-                if kv_used is None:
-                    continue
-                rank = int(snap.get("attentionDpRank", 0))
-                self._latest_metrics[rank] = Metrics(kv_used_blocks=int(kv_used))
+                logger.debug("trtllm get_stats_async raised: %s", e)
+            await asyncio.sleep(_IDLE_SLEEP_S)
 
-    def _kv_events_poll_loop(self) -> None:
+    async def _kv_events_poll_loop(self) -> None:
         assert self._engine is not None
-        while not self._publish_stop.is_set():
+        assert self._publish_stop_event is not None
+        while not self._publish_stop_event.is_set():
             try:
-                events = self._engine.llm.get_kv_cache_events(
+                async for event in self._engine.llm.get_kv_cache_events_async(
                     timeout=_KV_EVENTS_POLL_TIMEOUT_S
-                )
+                ):
+                    try:
+                        self._dispatch_kv_event(event)
+                    except Exception as e:
+                        if not self._warned_dispatch_failed:
+                            self._warned_dispatch_failed = True
+                            logger.exception(
+                                "Failed to dispatch KV event; suppressing "
+                                "further tracebacks (last error: %s)",
+                                e,
+                            )
+            except asyncio.CancelledError:
+                raise
             except Exception as e:
-                logger.debug("trtllm get_kv_cache_events raised: %s", e)
-                time.sleep(_IDLE_SLEEP_S)
-                continue
-            if not events:
-                time.sleep(_IDLE_SLEEP_S)
-                continue
-            for event in events:
-                try:
-                    self._dispatch_kv_event(event)
-                except Exception as e:
-                    if not self._warned_dispatch_failed:
-                        self._warned_dispatch_failed = True
-                        logger.exception(
-                            "Failed to dispatch KV event; suppressing further "
-                            "tracebacks (last error: %s)",
-                            e,
-                        )
+                logger.debug("trtllm get_kv_cache_events_async raised: %s", e)
+            await asyncio.sleep(_IDLE_SLEEP_S)
 
     def _dispatch_kv_event(self, event: dict[str, Any]) -> None:
         """Forward stored / removed events to the right publisher. Other
@@ -655,19 +661,41 @@ class TrtllmLLMEngine(LLMEngine):
         )
 
     async def cleanup(self) -> None:
-        # Stop the publisher threads BEFORE engine shutdown so they don't
-        # observe a half-torn-down RPC client. Each thread already loops on
-        # `_publish_stop`; the join bounds the wait at the poll timeout.
-        self._publish_stop.set()
-        for thread in (self._kv_events_thread, self._metrics_thread):
-            if thread is not None:
-                thread.join(timeout=_KV_EVENTS_POLL_TIMEOUT_S * 2 + 0.5)
-        self._kv_events_thread = None
-        self._metrics_thread = None
+        # Stop the publisher tasks BEFORE engine shutdown so they don't
+        # observe a half-torn-down RPC client. Setting the asyncio event
+        # lets the poll loops exit on their next iteration; cancellation
+        # is the backstop if they're stuck mid-iteration.
+        if self._publish_stop_event is not None:
+            self._publish_stop_event.set()
+        await self._cancel_publish_task(self._kv_events_task)
+        await self._cancel_publish_task(self._metrics_task)
+        self._kv_events_task = None
+        self._metrics_task = None
+        self._publish_stop_event = None
+        self._loop = None
         self._kv_publishers.clear()
         if self._engine is not None:
             await self._engine.cleanup()
             logger.info("TensorRT-LLM engine shutdown")
+
+    @staticmethod
+    async def _cancel_publish_task(
+        task: Optional[Union[asyncio.Task[None], concurrent.futures.Future[None]]],
+    ) -> None:
+        # `_metrics_task` is an asyncio.Task created on the engine loop;
+        # `_kv_events_task` is a concurrent.futures.Future from
+        # `asyncio.run_coroutine_threadsafe`. Both expose `cancel()` and
+        # awaiting them surfaces any pending exception.
+        if task is None or task.done():
+            return
+        task.cancel()
+        try:
+            if isinstance(task, asyncio.Task):
+                await task
+            else:
+                await asyncio.wrap_future(task)
+        except (asyncio.CancelledError, Exception):
+            pass
 
     @staticmethod
     def _override_sampling_params(

--- a/components/src/dynamo/trtllm/llm_engine.py
+++ b/components/src/dynamo/trtllm/llm_engine.py
@@ -109,6 +109,7 @@ class TrtllmLLMEngine(LLMEngine):
         max_num_tokens: int | None = None,
         kv_block_size: int = 32,
         disaggregation_mode: DisaggregationMode = DisaggregationMode.AGGREGATED,
+        publish_events_and_metrics: bool = False,
     ):
         self.engine_args = engine_args
         self.model_name = model_name
@@ -119,6 +120,10 @@ class TrtllmLLMEngine(LLMEngine):
         self.kv_block_size = kv_block_size
         # Drives context_only / generation_only branching in generate().
         self.disaggregation_mode = disaggregation_mode
+        # Gates the metrics-poll thread and the kv_event/metrics source
+        # publishers. Decode workers in disaggregated mode don't host the
+        # KV indexer so they opt out too (handled in `_kv_routing_enabled`).
+        self.publish_events_and_metrics = publish_events_and_metrics
         self._engine: TensorRTLLMEngine | None = None
         self._default_sampling_params = SamplingParams(detokenize=False)
         # Per-request GenerationResult handles for `abort()` lookup. TRT-LLM's
@@ -237,6 +242,7 @@ class TrtllmLLMEngine(LLMEngine):
             max_num_tokens=engine_args.get("max_num_tokens", config.max_num_tokens),
             kv_block_size=config.kv_block_size,
             disaggregation_mode=config.disaggregation_mode,
+            publish_events_and_metrics=config.publish_events_and_metrics,
         )
         worker_config = WorkerConfig.from_runtime_config(
             config,
@@ -262,12 +268,13 @@ class TrtllmLLMEngine(LLMEngine):
         await self._engine.initialize()
 
         self._attention_dp_size = self._engine.get_attention_dp_size()
-        self._metrics_thread = threading.Thread(
-            target=self._metrics_poll_loop,
-            daemon=True,
-            name="trtllm-metrics-poll",
-        )
-        self._metrics_thread.start()
+        if self._kv_routing_enabled():
+            self._metrics_thread = threading.Thread(
+                target=self._metrics_poll_loop,
+                daemon=True,
+                name="trtllm-metrics-poll",
+            )
+            self._metrics_thread.start()
 
         return EngineConfig(
             model=self.model_name,
@@ -283,7 +290,20 @@ class TrtllmLLMEngine(LLMEngine):
     # thread, so we drive them from dedicated worker threads rather than
     # the asyncio event loop.
 
+    def _kv_routing_enabled(self) -> bool:
+        # `--publish-events-and-metrics` is the operator's switch for both
+        # KV-event and load-metric publishing. Decode workers in
+        # disaggregated mode don't host the KV indexer, so opt them out
+        # too — matches the legacy `setup_kv_event_publisher` behaviour.
+        if not self.publish_events_and_metrics:
+            return False
+        if self.disaggregation_mode == DisaggregationMode.DECODE:
+            return False
+        return True
+
     async def kv_event_sources(self) -> list[KvEventSource]:
+        if not self._kv_routing_enabled():
+            return []
         return [
             PushSource(
                 on_ready=self._make_on_publisher_ready(rank),
@@ -293,6 +313,9 @@ class TrtllmLLMEngine(LLMEngine):
         ]
 
     async def metrics_sources(self) -> list[SnapshotSource]:
+        if not self._kv_routing_enabled():
+            return []
+
         def snapshot_for(r: int) -> Callable[[], Optional[Metrics]]:
             return lambda: self._latest_metrics.get(r)
 

--- a/components/src/dynamo/trtllm/llm_engine.py
+++ b/components/src/dynamo/trtllm/llm_engine.py
@@ -292,14 +292,11 @@ class TrtllmLLMEngine(LLMEngine):
 
     def _kv_routing_enabled(self) -> bool:
         # `--publish-events-and-metrics` is the operator's switch for both
-        # KV-event and load-metric publishing. Decode workers in
-        # disaggregated mode don't host the KV indexer, so opt them out
-        # too — matches the legacy `setup_kv_event_publisher` behaviour.
-        if not self.publish_events_and_metrics:
-            return False
-        if self.disaggregation_mode == DisaggregationMode.DECODE:
-            return False
-        return True
+        # KV-event and load-metric publishing. Matches the legacy
+        # `workers/llm_worker.py` flow: events and metrics share a single
+        # gate, and decode workers DO publish (the legacy path only
+        # turns off `enable_local_indexer` for decode, not the publisher).
+        return self.publish_events_and_metrics
 
     async def kv_event_sources(self) -> list[KvEventSource]:
         if not self._kv_routing_enabled():

--- a/components/src/dynamo/trtllm/llm_engine.py
+++ b/components/src/dynamo/trtllm/llm_engine.py
@@ -122,8 +122,7 @@ class TrtllmLLMEngine(LLMEngine):
         # Drives context_only / generation_only branching in generate().
         self.disaggregation_mode = disaggregation_mode
         # Gates the metrics-poll thread and the kv_event/metrics source
-        # publishers. Decode workers in disaggregated mode don't host the
-        # KV indexer so they opt out too (handled in `_kv_routing_enabled`).
+        # publishers. See `_kv_routing_enabled`.
         self.publish_events_and_metrics = publish_events_and_metrics
         self._engine: TensorRTLLMEngine | None = None
         self._default_sampling_params = SamplingParams(detokenize=False)
@@ -292,11 +291,8 @@ class TrtllmLLMEngine(LLMEngine):
     # the asyncio event loop.
 
     def _kv_routing_enabled(self) -> bool:
-        # `--publish-events-and-metrics` is the operator's switch for both
-        # KV-event and load-metric publishing. Matches the legacy
-        # `workers/llm_worker.py` flow: events and metrics share a single
-        # gate, and decode workers DO publish (the legacy path only
-        # turns off `enable_local_indexer` for decode, not the publisher).
+        # Matches the legacy `workers/llm_worker.py` gate. Decode workers
+        # publish too — legacy only flips `enable_local_indexer` off.
         return self.publish_events_and_metrics
 
     async def kv_event_sources(self) -> list[KvEventSource]:
@@ -389,16 +385,6 @@ class TrtllmLLMEngine(LLMEngine):
                             "tracebacks (last error: %s)",
                             e,
                         )
-
-    def _scheduling_params_for(
-        self, dp_rank: int | None
-    ) -> Optional[SchedulingParams]:
-        rank = validate_global_dp_rank(
-            dp_rank, 0, self._attention_dp_size, "TRT-LLM"
-        )
-        if rank is None:
-            return None
-        return SchedulingParams(attention_dp_rank=rank, attention_dp_relax=False)
 
     def _dispatch_kv_event(self, event: dict[str, Any]) -> None:
         """Forward stored / removed events to the right publisher. Other
@@ -522,7 +508,14 @@ class TrtllmLLMEngine(LLMEngine):
 
         # Honour the router's DP rank decision; without it TRT-LLM picks
         # its own rank and KV events land on the wrong publisher.
-        scheduling_params = self._scheduling_params_for(forced_dp_rank(request))
+        rank = validate_global_dp_rank(
+            forced_dp_rank(request), 0, self._attention_dp_size, "TRT-LLM"
+        )
+        scheduling_params = (
+            SchedulingParams(attention_dp_rank=rank, attention_dp_relax=False)
+            if rank is not None
+            else None
+        )
 
         # Prefill returns one non-streaming chunk carrying the handoff —
         # matches the legacy disagg wire format.

--- a/components/src/dynamo/trtllm/llm_engine.py
+++ b/components/src/dynamo/trtllm/llm_engine.py
@@ -169,6 +169,12 @@ class TrtllmLLMEngine(LLMEngine):
             "scheduler_config": SchedulerConfig(),
             "tensor_parallel_size": config.tensor_parallel_size,
             "pipeline_parallel_size": config.pipeline_parallel_size,
+            "moe_expert_parallel_size": config.expert_parallel_size,
+            # Required for attention-DP routing: TRT-LLM only exposes
+            # per-rank KV events / stats when attention_dp is on, and
+            # `get_attention_dp_size()` reads this flag back to size the
+            # publishers (engine.py:118-120).
+            "enable_attention_dp": config.enable_attention_dp,
             "backend": Backend.PYTORCH,
             "kv_cache_config": KvCacheConfig(
                 free_gpu_memory_fraction=config.free_gpu_memory_fraction,

--- a/components/src/dynamo/vllm/llm_engine.py
+++ b/components/src/dynamo/vllm/llm_engine.py
@@ -276,8 +276,15 @@ class VllmLLMEngine(LLMEngine):
             sampling_params.extra_args["kv_transfer_params"] = kv_params
 
         # Honour the router's DP rank decision; without it vLLM picks
-        # its own rank and KV events land on the wrong publisher.
-        local_dp_rank = self._to_local_dp_rank(forced_dp_rank(request))
+        # its own rank and KV events land on the wrong publisher. vLLM
+        # expects a local rank, so subtract this worker's `dp_start`.
+        local_dp_rank: Optional[int] = None
+        if self._dp_range is not None:
+            dp_start, dp_size = self._dp_range
+            rank = validate_global_dp_rank(
+                forced_dp_rank(request), dp_start, dp_size, "vLLM"
+            )
+            local_dp_rank = None if rank is None else rank - dp_start
 
         gen = self.engine_client.generate(
             prompt, sampling_params, request_id, data_parallel_rank=local_dp_rank
@@ -329,20 +336,8 @@ class VllmLLMEngine(LLMEngine):
                 yield out
                 num_output_tokens_so_far[output_idx] = next_total
 
-    def _to_local_dp_rank(self, dp_rank: int | None) -> int | None:
-        """Map a global DP rank into this worker's local rank, or ``None``
-        if out of range (vLLM then falls back to internal LB)."""
-        if self._dp_range is None:
-            return None
-        dp_start, dp_size = self._dp_range
-        rank = validate_global_dp_rank(dp_rank, dp_start, dp_size, "vLLM")
-        return None if rank is None else rank - dp_start
-
     def _kv_routing_enabled(self) -> bool:
-        # vLLM's KV-event publisher is gated on prefix caching being on, on
-        # the engine actually emitting events, and on whether this worker
-        # role holds long-lived cache. Decode workers in disaggregated mode
-        # don't, so we opt out — matching the legacy publisher behavior.
+        # Matches the legacy `setup_kv_event_publisher` gate.
         if not self.engine_args.enable_prefix_caching:
             return False
         kv_events_config = self.engine_args.kv_events_config

--- a/components/src/dynamo/vllm/llm_engine.py
+++ b/components/src/dynamo/vllm/llm_engine.py
@@ -25,6 +25,7 @@ from vllm.v1.metrics.stats import IterationStats, SchedulerStats
 
 from dynamo._core import Context
 from dynamo.common.backend.disagg import require_prefill_result
+from dynamo.common.backend.dp_rank import validate_global_dp_rank
 from dynamo.common.backend.engine import (
     EngineConfig,
     GenerateChunk,
@@ -333,19 +334,11 @@ class VllmLLMEngine(LLMEngine):
     def _to_local_dp_rank(self, dp_rank: int | None) -> int | None:
         """Map a global DP rank into this worker's local rank, or ``None``
         if out of range (vLLM then falls back to internal LB)."""
-        if dp_rank is None or self._dp_range is None:
+        if self._dp_range is None:
             return None
         dp_start, dp_size = self._dp_range
-        if dp_rank < dp_start or dp_rank >= dp_start + dp_size:
-            logger.warning(
-                "Received DP rank %d outside [%d, %d); falling back to "
-                "vLLM internal DP selection",
-                dp_rank,
-                dp_start,
-                dp_start + dp_size,
-            )
-            return None
-        return dp_rank - dp_start
+        rank = validate_global_dp_rank(dp_rank, dp_start, dp_size, "vLLM")
+        return None if rank is None else rank - dp_start
 
     def _kv_routing_enabled(self) -> bool:
         # vLLM's KV-event publisher is gated on prefix caching being on, on

--- a/components/src/dynamo/vllm/llm_engine.py
+++ b/components/src/dynamo/vllm/llm_engine.py
@@ -67,6 +67,12 @@ class _DpRankMetricsCache:
         self._num_gpu_blocks = max(1, num_gpu_blocks)
         self._by_rank: dict[int, Metrics] = {}
 
+    def set_num_gpu_blocks(self, num_gpu_blocks: int) -> None:
+        # Patched after AsyncLLM finishes KV profiling — vLLM only populates
+        # `cache_config.num_gpu_blocks` then, so the cache is constructed
+        # before init and updated once the real value is known.
+        self._num_gpu_blocks = max(1, num_gpu_blocks)
+
     def update(self, dp_rank: int, scheduler_stats: SchedulerStats) -> None:
         kv_used = int(self._num_gpu_blocks * scheduler_stats.kv_cache_usage)
         self._by_rank[dp_rank] = Metrics(kv_used_blocks=kv_used)
@@ -124,8 +130,10 @@ class VllmLLMEngine(LLMEngine):
         self._default_sampling_params: Any = None
         self._prometheus_temp_dir: tempfile.TemporaryDirectory[str] | None = None
         self._model_max_len: int | None = None
-        # `_dp_range` / `_metrics_cache` resolved in `start()` once vllm
-        # has built its engine config and reported `num_gpu_blocks`.
+        # `_dp_range` / `_metrics_cache` resolved in `start()`: the cache
+        # is built before AsyncLLM.from_vllm_config so the stat-logger
+        # factory can bind to it, then patched with the real
+        # `num_gpu_blocks` once vLLM finishes KV profiling.
         self._dp_range: Optional[tuple[int, int]] = None
         self._metrics_cache: Optional[_DpRankMetricsCache] = None
 
@@ -181,14 +189,18 @@ class VllmLLMEngine(LLMEngine):
         self._vllm_config = vllm_config
 
         self._dp_range = get_dp_range_for_worker(vllm_config)
-        num_gpu_blocks = vllm_config.cache_config.num_gpu_blocks or 0
-        self._metrics_cache = _DpRankMetricsCache(num_gpu_blocks=num_gpu_blocks)
+        # `cache_config.num_gpu_blocks` is None until vLLM's worker finishes
+        # KV profiling inside AsyncLLM.from_vllm_config. Construct the cache
+        # before init so loggers can bind to it, then patch the real value in.
+        self._metrics_cache = _DpRankMetricsCache(num_gpu_blocks=0)
 
         self.engine_client = AsyncLLM.from_vllm_config(
             vllm_config=vllm_config,
             usage_context=UsageContext.OPENAI_API_SERVER,
             stat_loggers=[_UnifiedStatLoggerFactory(self._metrics_cache)],
         )
+        num_gpu_blocks = self.engine_client.vllm_config.cache_config.num_gpu_blocks or 0
+        self._metrics_cache.set_num_gpu_blocks(num_gpu_blocks)
         self._model_max_len = getattr(
             getattr(vllm_config, "model_config", None), "max_model_len", None
         )

--- a/components/src/dynamo/vllm/llm_engine.py
+++ b/components/src/dynamo/vllm/llm_engine.py
@@ -225,6 +225,9 @@ class VllmLLMEngine(LLMEngine):
             # runtime defaults to 1 and the router can't route to non-zero
             # dp_ranks even though `kv_event_sources` registers them.
             data_parallel_size=self._dp_range[1],
+            # Global index of the first rank this worker hosts. Non-zero
+            # under hybrid/external LB where each worker owns a sub-range.
+            data_parallel_start_rank=self._dp_range[0],
         )
 
     async def generate(

--- a/components/src/dynamo/vllm/llm_engine.py
+++ b/components/src/dynamo/vllm/llm_engine.py
@@ -12,12 +12,16 @@ from __future__ import annotations
 import logging
 import os
 import tempfile
-from collections.abc import AsyncGenerator
-from typing import Any, cast
+from collections.abc import AsyncGenerator, Callable
+from typing import Any, Optional, cast
 
+from vllm.config import VllmConfig
+from vllm.distributed.kv_events import ZmqEventPublisher
 from vllm.inputs import TokensPrompt
 from vllm.usage.usage_lib import UsageContext
 from vllm.v1.engine.async_llm import AsyncLLM
+from vllm.v1.metrics.loggers import StatLoggerBase
+from vllm.v1.metrics.stats import IterationStats, SchedulerStats
 
 from dynamo._core import Context
 from dynamo.common.backend.disagg import require_prefill_result
@@ -27,14 +31,88 @@ from dynamo.common.backend.engine import (
     GenerateRequest,
     LLMEngine,
 )
+from dynamo.common.backend.publisher import (
+    KvEventSource,
+    Metrics,
+    SnapshotSource,
+    ZmqSource,
+)
 from dynamo.common.backend.worker import WorkerConfig
 from dynamo.common.constants import DisaggregationMode
 from dynamo.llm import ModelInput
 from dynamo.vllm.args import parse_args
+from dynamo.vllm.cache_info import (
+    configure_kv_event_block_size,
+    get_configured_kv_event_block_size,
+)
 
-from .handlers import build_sampling_params
+from .handlers import build_sampling_params, get_dp_range_for_worker
 
 logger = logging.getLogger(__name__)
+
+
+class _DpRankMetricsCache:
+    """Thread-safe (single-writer-per-rank) cache of the latest per-rank
+    ``Metrics`` snapshot.
+
+    Written by vLLM's ``StatLoggerBase.record`` callback (one logger per
+    dp_rank) and read by ``LLMEngine.metrics_sources`` on a fixed interval
+    from the runtime side. Reads return ``None`` until the engine has
+    emitted its first scheduler iteration for that rank.
+    """
+
+    def __init__(self, num_gpu_blocks: int) -> None:
+        # vLLM's `SchedulerStats.kv_cache_usage` is fractional; multiply by
+        # total blocks to get the absolute block count the router expects.
+        self._num_gpu_blocks = max(1, num_gpu_blocks)
+        self._by_rank: dict[int, Metrics] = {}
+
+    def update(self, dp_rank: int, scheduler_stats: SchedulerStats) -> None:
+        kv_used = int(self._num_gpu_blocks * scheduler_stats.kv_cache_usage)
+        self._by_rank[dp_rank] = Metrics(kv_used_blocks=kv_used)
+
+    def snapshot(self, dp_rank: int) -> Optional[Metrics]:
+        return self._by_rank.get(dp_rank)
+
+
+class _UnifiedStatLogger(StatLoggerBase):
+    """vLLM-side hook that just refreshes the per-rank metrics cache.
+
+    Replaces the legacy ``DynamoStatLoggerPublisher`` (which owned its own
+    ``WorkerMetricsPublisher`` and NATS endpoint). Under the unified path
+    the Rust ``Worker`` owns publishers, so this class only needs to
+    update an in-memory snapshot that ``metrics_sources()`` reads.
+    """
+
+    def __init__(self, cache: _DpRankMetricsCache, dp_rank: int) -> None:
+        self._cache = cache
+        self.dp_rank = dp_rank
+
+    def record(
+        self,
+        scheduler_stats: Optional[SchedulerStats],
+        iteration_stats: Optional[IterationStats],
+        mm_cache_stats: object = None,
+        engine_idx: int = 0,
+        *args: object,
+        **kwargs: object,
+    ) -> None:
+        if scheduler_stats is None:
+            return
+        self._cache.update(self.dp_rank, scheduler_stats)
+
+    def log_engine_initialized(self) -> None:
+        pass
+
+
+class _UnifiedStatLoggerFactory:
+    """vLLM calls this once per dp_rank during engine initialization."""
+
+    def __init__(self, cache: _DpRankMetricsCache) -> None:
+        self._cache = cache
+
+    def __call__(self, vllm_config: VllmConfig, dp_rank: int) -> StatLoggerBase:
+        return _UnifiedStatLogger(self._cache, dp_rank)
 
 
 class VllmLLMEngine(LLMEngine):
@@ -46,6 +124,10 @@ class VllmLLMEngine(LLMEngine):
         self._default_sampling_params: Any = None
         self._prometheus_temp_dir: tempfile.TemporaryDirectory[str] | None = None
         self._model_max_len: int | None = None
+        # `_dp_range` / `_metrics_cache` resolved in `start()` once vllm
+        # has built its engine config and reported `num_gpu_blocks`.
+        self._dp_range: Optional[tuple[int, int]] = None
+        self._metrics_cache: Optional[_DpRankMetricsCache] = None
 
     @classmethod
     async def from_args(
@@ -98,16 +180,26 @@ class VllmLLMEngine(LLMEngine):
         )
         self._vllm_config = vllm_config
 
+        self._dp_range = get_dp_range_for_worker(vllm_config)
+        num_gpu_blocks = vllm_config.cache_config.num_gpu_blocks or 0
+        self._metrics_cache = _DpRankMetricsCache(num_gpu_blocks=num_gpu_blocks)
+
         self.engine_client = AsyncLLM.from_vllm_config(
             vllm_config=vllm_config,
             usage_context=UsageContext.OPENAI_API_SERVER,
+            stat_loggers=[_UnifiedStatLoggerFactory(self._metrics_cache)],
         )
         self._model_max_len = getattr(
             getattr(vllm_config, "model_config", None), "max_model_len", None
         )
 
-        num_gpu_blocks = vllm_config.cache_config.num_gpu_blocks or 0
-        block_size = vllm_config.cache_config.block_size
+        # The KV-event block size can differ from `cache_config.block_size`
+        # (the main-attention block size lives in cache-group metadata).
+        # Populate `additional_config[DYNAMO_KV_EVENT_BLOCK_SIZE_KEY]` so
+        # `get_configured_kv_event_block_size` returns the right value
+        # both to the runtime via `EngineConfig` and to any future readers.
+        await configure_kv_event_block_size(self.engine_client, vllm_config)
+        block_size = get_configured_kv_event_block_size(vllm_config)
 
         return EngineConfig(
             model=self.engine_args.model,
@@ -220,6 +312,57 @@ class VllmLLMEngine(LLMEngine):
 
                 yield out
                 num_output_tokens_so_far[output_idx] = next_total
+
+    def _kv_routing_enabled(self) -> bool:
+        # vLLM's KV-event publisher is gated on prefix caching being on, on
+        # the engine actually emitting events, and on whether this worker
+        # role holds long-lived cache. Decode workers in disaggregated mode
+        # don't, so we opt out — matching the legacy publisher behavior.
+        if not self.engine_args.enable_prefix_caching:
+            return False
+        kv_events_config = self.engine_args.kv_events_config
+        if kv_events_config is None or not kv_events_config.enable_kv_cache_events:
+            return False
+        if self.disaggregation_mode == DisaggregationMode.DECODE:
+            return False
+        return True
+
+    async def kv_event_sources(self) -> list[KvEventSource]:
+        if not self._kv_routing_enabled():
+            return []
+        assert self._vllm_config is not None
+        assert self._dp_range is not None
+        kv_events_config = self.engine_args.kv_events_config
+        dp_start, dp_size = self._dp_range
+        return [
+            ZmqSource(
+                endpoint=ZmqEventPublisher.offset_endpoint_port(
+                    kv_events_config.endpoint,
+                    data_parallel_rank=rank,
+                ).replace("*", "127.0.0.1"),
+                dp_rank=rank,
+            )
+            for rank in range(dp_start, dp_start + dp_size)
+        ]
+
+    async def metrics_sources(self) -> list[SnapshotSource]:
+        # Same opt-in gating as kv_event_sources — if this worker isn't
+        # publishing KV events, it shouldn't publish load metrics either,
+        # or the router will score against partial worker state.
+        if not self._kv_routing_enabled():
+            return []
+        if self._dp_range is None or self._metrics_cache is None:
+            return []
+        cache = self._metrics_cache
+        dp_start, dp_size = self._dp_range
+
+        def snapshot_for(r: int) -> Callable[[], Optional[Metrics]]:
+            return lambda: cache.snapshot(r)
+
+        return [
+            SnapshotSource(snapshot=snapshot_for(rank), dp_rank=rank)
+            for rank in range(dp_start, dp_start + dp_size)
+        ]
 
     async def abort(self, context: Context) -> None:
         request_id = context.id()

--- a/components/src/dynamo/vllm/llm_engine.py
+++ b/components/src/dynamo/vllm/llm_engine.py
@@ -68,9 +68,6 @@ class _DpRankMetricsCache:
         self._by_rank: dict[int, Metrics] = {}
 
     def set_num_gpu_blocks(self, num_gpu_blocks: int) -> None:
-        # Patched after AsyncLLM finishes KV profiling — vLLM only populates
-        # `cache_config.num_gpu_blocks` then, so the cache is constructed
-        # before init and updated once the real value is known.
         self._num_gpu_blocks = max(1, num_gpu_blocks)
 
     def update(self, dp_rank: int, scheduler_stats: SchedulerStats) -> None:
@@ -130,10 +127,8 @@ class VllmLLMEngine(LLMEngine):
         self._default_sampling_params: Any = None
         self._prometheus_temp_dir: tempfile.TemporaryDirectory[str] | None = None
         self._model_max_len: int | None = None
-        # `_dp_range` / `_metrics_cache` resolved in `start()`: the cache
-        # is built before AsyncLLM.from_vllm_config so the stat-logger
-        # factory can bind to it, then patched with the real
-        # `num_gpu_blocks` once vLLM finishes KV profiling.
+        # Resolved in `start()`; the cache is patched once vLLM finishes
+        # KV profiling and reports `num_gpu_blocks`.
         self._dp_range: Optional[tuple[int, int]] = None
         self._metrics_cache: Optional[_DpRankMetricsCache] = None
 
@@ -189,9 +184,8 @@ class VllmLLMEngine(LLMEngine):
         self._vllm_config = vllm_config
 
         self._dp_range = get_dp_range_for_worker(vllm_config)
-        # `cache_config.num_gpu_blocks` is None until vLLM's worker finishes
-        # KV profiling inside AsyncLLM.from_vllm_config. Construct the cache
-        # before init so loggers can bind to it, then patch the real value in.
+        # Constructed before init so the stat-logger factory can bind to
+        # it; `num_gpu_blocks` is patched below once KV profiling finishes.
         self._metrics_cache = _DpRankMetricsCache(num_gpu_blocks=0)
 
         self.engine_client = AsyncLLM.from_vllm_config(
@@ -221,13 +215,9 @@ class VllmLLMEngine(LLMEngine):
             total_kv_blocks=num_gpu_blocks,
             max_num_seqs=vllm_config.scheduler_config.max_num_seqs,
             max_num_batched_tokens=vllm_config.scheduler_config.max_num_batched_tokens,
-            # Number of DP ranks this worker hosts. Without this, the Rust
-            # runtime defaults to 1 and the router can't route to non-zero
-            # dp_ranks even though `kv_event_sources` registers them.
-            data_parallel_size=self._dp_range[1],
-            # Global index of the first rank this worker hosts. Non-zero
-            # under hybrid/external LB where each worker owns a sub-range.
+            # Router needs the rank range to enumerate per-rank load.
             data_parallel_start_rank=self._dp_range[0],
+            data_parallel_size=self._dp_range[1],
         )
 
     async def generate(
@@ -284,10 +274,8 @@ class VllmLLMEngine(LLMEngine):
                 sampling_params.extra_args = {}
             sampling_params.extra_args["kv_transfer_params"] = kv_params
 
-        # Honour the router's DP rank decision. Without this, vLLM picks the
-        # rank itself, so KV events for the forced rank land on the wrong
-        # publisher and the per-rank indexer trees diverge from reality.
-        # Matches the legacy handler's `data_parallel_rank=...` plumbing.
+        # Honour the router's DP rank decision; without it vLLM picks
+        # its own rank and KV events land on the wrong publisher.
         local_dp_rank = self._to_local_dp_rank(
             (request.get("routing") or {}).get("dp_rank")
         )
@@ -343,16 +331,14 @@ class VllmLLMEngine(LLMEngine):
                 num_output_tokens_so_far[output_idx] = next_total
 
     def _to_local_dp_rank(self, dp_rank: int | None) -> int | None:
-        """Convert a router-supplied global DP rank to this worker's local
-        rank, or ``None`` if the rank is outside the range this worker owns
-        (in which case vLLM falls back to its internal load balancer).
-        Mirrors `handlers.DecodeWorkerHandler._to_local_dp_rank`."""
+        """Map a global DP rank into this worker's local rank, or ``None``
+        if out of range (vLLM then falls back to internal LB)."""
         if dp_rank is None or self._dp_range is None:
             return None
         dp_start, dp_size = self._dp_range
         if dp_rank < dp_start or dp_rank >= dp_start + dp_size:
             logger.warning(
-                "Received DP rank %d is outside [%d, %d); falling back to "
+                "Received DP rank %d outside [%d, %d); falling back to "
                 "vLLM internal DP selection",
                 dp_rank,
                 dp_start,

--- a/components/src/dynamo/vllm/llm_engine.py
+++ b/components/src/dynamo/vllm/llm_engine.py
@@ -284,7 +284,17 @@ class VllmLLMEngine(LLMEngine):
                 sampling_params.extra_args = {}
             sampling_params.extra_args["kv_transfer_params"] = kv_params
 
-        gen = self.engine_client.generate(prompt, sampling_params, request_id)
+        # Honour the router's DP rank decision. Without this, vLLM picks the
+        # rank itself, so KV events for the forced rank land on the wrong
+        # publisher and the per-rank indexer trees diverge from reality.
+        # Matches the legacy handler's `data_parallel_rank=...` plumbing.
+        local_dp_rank = self._to_local_dp_rank(
+            (request.get("routing") or {}).get("dp_rank")
+        )
+
+        gen = self.engine_client.generate(
+            prompt, sampling_params, request_id, data_parallel_rank=local_dp_rank
+        )
 
         is_prefill = self.disaggregation_mode == DisaggregationMode.PREFILL
 
@@ -331,6 +341,25 @@ class VllmLLMEngine(LLMEngine):
 
                 yield out
                 num_output_tokens_so_far[output_idx] = next_total
+
+    def _to_local_dp_rank(self, dp_rank: int | None) -> int | None:
+        """Convert a router-supplied global DP rank to this worker's local
+        rank, or ``None`` if the rank is outside the range this worker owns
+        (in which case vLLM falls back to its internal load balancer).
+        Mirrors `handlers.DecodeWorkerHandler._to_local_dp_rank`."""
+        if dp_rank is None or self._dp_range is None:
+            return None
+        dp_start, dp_size = self._dp_range
+        if dp_rank < dp_start or dp_rank >= dp_start + dp_size:
+            logger.warning(
+                "Received DP rank %d is outside [%d, %d); falling back to "
+                "vLLM internal DP selection",
+                dp_rank,
+                dp_start,
+                dp_start + dp_size,
+            )
+            return None
+        return dp_rank - dp_start
 
     def _kv_routing_enabled(self) -> bool:
         # vLLM's KV-event publisher is gated on prefix caching being on, on

--- a/components/src/dynamo/vllm/llm_engine.py
+++ b/components/src/dynamo/vllm/llm_engine.py
@@ -221,6 +221,10 @@ class VllmLLMEngine(LLMEngine):
             total_kv_blocks=num_gpu_blocks,
             max_num_seqs=vllm_config.scheduler_config.max_num_seqs,
             max_num_batched_tokens=vllm_config.scheduler_config.max_num_batched_tokens,
+            # Number of DP ranks this worker hosts. Without this, the Rust
+            # runtime defaults to 1 and the router can't route to non-zero
+            # dp_ranks even though `kv_event_sources` registers them.
+            data_parallel_size=self._dp_range[1],
         )
 
     async def generate(

--- a/components/src/dynamo/vllm/llm_engine.py
+++ b/components/src/dynamo/vllm/llm_engine.py
@@ -25,7 +25,7 @@ from vllm.v1.metrics.stats import IterationStats, SchedulerStats
 
 from dynamo._core import Context
 from dynamo.common.backend.disagg import require_prefill_result
-from dynamo.common.backend.dp_rank import validate_global_dp_rank
+from dynamo.common.backend.dp_rank import forced_dp_rank, validate_global_dp_rank
 from dynamo.common.backend.engine import (
     EngineConfig,
     GenerateChunk,
@@ -277,9 +277,7 @@ class VllmLLMEngine(LLMEngine):
 
         # Honour the router's DP rank decision; without it vLLM picks
         # its own rank and KV events land on the wrong publisher.
-        local_dp_rank = self._to_local_dp_rank(
-            (request.get("routing") or {}).get("dp_rank")
-        )
+        local_dp_rank = self._to_local_dp_rank(forced_dp_rank(request))
 
         gen = self.engine_client.generate(
             prompt, sampling_params, request_id, data_parallel_rank=local_dp_rank

--- a/lib/backend-common/CLAUDE.md
+++ b/lib/backend-common/CLAUDE.md
@@ -240,6 +240,60 @@ Mid-stream errors have two equivalent terminal forms:
   * **String**: yield `Ok(LLMEngineOutput::error(msg))`. Convenient for
     pure message-level failures. Loses the typed `BackendError` variant.
 
+## KV-aware Routing Sources
+
+Engines opt into KV-aware routing by overriding two trait methods on
+`LLMEngine`:
+
+- `kv_event_sources() -> Vec<KvEventSource>` — one descriptor per
+  data-parallel rank that emits KV cache events.
+- `metrics_sources() -> Vec<MetricsSource>` — one descriptor per
+  data-parallel rank reporting load (`kv_used_blocks`).
+
+Both default to empty. Returning empty opts the worker out of KV-aware
+routing entirely; the router falls back to non-KV scheduling for that
+worker. `Worker` calls these once after `start()` succeeds and constructs
+the publishers itself — engines never instantiate
+`KvEventPublisher`/`WorkerMetricsPublisher`. On shutdown, `Worker` drops
+the handles while NATS is still alive.
+
+### `KvEventSource` flavors
+
+Pick based on how the engine's KV event API is shaped:
+
+- `Zmq { endpoint, topic, dp_rank }` — engine already publishes to a
+  ZMQ PUB socket. `Worker` subscribes directly.
+- `Push { on_ready, dp_rank }` — engine has a blocking poll API.
+  `Worker` constructs the publisher, then calls `on_ready(publisher)`
+  once during setup. The engine stashes the publisher and drives
+  `publish_stored` / `publish_removed` from its own thread. The engine
+  **must** stop that thread in `cleanup()`.
+
+The `mocker` example uses `Push` with a no-op `on_ready`; real Rust
+engines would spawn a polling thread inside `on_ready`. See
+`examples/mocker/src/engine.rs` for the wire-up.
+
+### `MetricsSource`
+
+```rust
+MetricsSource {
+    snapshot: Arc::new(move || Some(Metrics { kv_used_blocks: ... })),
+    dp_rank,
+}
+```
+
+`Worker` invokes `snapshot()` on a fixed interval. It **must** be a
+cheap member-field read — engine-internal calls land in the 10s of ms
+and stall the publish loop. The conformance kit enforces a 1 ms ceiling
+(`MetricsSnapshotTooSlow`). Return `None` to skip publishing for that
+tick (e.g. before the engine has emitted its first scheduler iteration).
+
+### Conformance
+
+The kit asserts that both methods are idempotent across calls (rank set
+is stable for the engine's lifetime) and that snapshot fns satisfy the
+latency ceiling. See `lib/backend-common/src/testing.rs`.
+
 ## Logging
 
 Keep logging standardized across all Rust engines. When adding or

--- a/lib/backend-common/examples/mocker/src/engine.rs
+++ b/lib/backend-common/examples/mocker/src/engine.rs
@@ -284,6 +284,7 @@ impl LLMEngine for MockerBackend {
             max_num_seqs: self.engine_args.max_num_seqs.map(|v| v as u64),
             max_num_batched_tokens: self.engine_args.max_num_batched_tokens.map(|v| v as u64),
             data_parallel_size: None,
+            data_parallel_start_rank: None,
             // Mocker has no real KV transport, so it never advertises a
             // bootstrap address. Real prefill engines populate these in
             // start() to publish ModelRuntimeConfig.disaggregated_endpoint.

--- a/lib/backend-common/examples/mocker/src/engine.rs
+++ b/lib/backend-common/examples/mocker/src/engine.rs
@@ -19,13 +19,14 @@
 //! you need the event plane.
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use async_trait::async_trait;
 use dashmap::DashMap;
 use dynamo_backend_common::{
     AsyncEngineContext, BackendError, CommonArgs, DisaggregationMode, DynamoError, EngineConfig,
-    ErrorType, GenerateContext, LLMEngine, LLMEngineOutput, LLMEngineOutputExt,
-    PreprocessedRequest, WorkerConfig, chunk, usage,
+    ErrorType, GenerateContext, KvEventSource, LLMEngine, LLMEngineOutput, LLMEngineOutputExt,
+    Metrics, MetricsSource, PreprocessedRequest, WorkerConfig, chunk, usage,
 };
 use dynamo_mocker::common::protocols::{
     DirectRequest, EngineType, FpmPublisher, KvEventPublishers, MockEngineArgs, OutputSignal,
@@ -119,15 +120,23 @@ struct ActiveEntry {
 }
 
 /// Removes the request's entry from the active-requests map on any stream
-/// exit path — natural completion, cancellation, or an early drop.
+/// exit path — natural completion, cancellation, or an early drop. Also
+/// releases the synthetic block accounting so `kv_used_blocks` tracks the
+/// in-flight set rather than monotonically growing.
 struct ActiveRequestGuard {
     uuid: Uuid,
     active: Arc<DashMap<Uuid, ActiveEntry>>,
+    kv_used_blocks: Arc<AtomicU64>,
+    blocks_held: u64,
 }
 
 impl Drop for ActiveRequestGuard {
     fn drop(&mut self) {
         self.active.remove(&self.uuid);
+        if self.blocks_held > 0 {
+            self.kv_used_blocks
+                .fetch_sub(self.blocks_held, Ordering::Relaxed);
+        }
     }
 }
 
@@ -146,6 +155,10 @@ pub struct MockerBackend {
     /// the scheduler tasks running for the engine's lifetime.
     #[allow(dead_code)]
     scheduler: OnceCell<Box<dyn SchedulerHandle>>,
+    /// Synthetic KV-block accounting. Bumped per request in `generate()`
+    /// so the metrics snapshot reports a non-trivial load number.
+    /// Real engines would source this from their scheduler.
+    kv_used_blocks: Arc<AtomicU64>,
 }
 
 impl MockerBackend {
@@ -164,6 +177,7 @@ impl MockerBackend {
             active: Arc::new(DashMap::new()),
             request_tx: OnceCell::new(),
             scheduler: OnceCell::new(),
+            kv_used_blocks: Arc::new(AtomicU64::new(0)),
         }
     }
 
@@ -269,6 +283,7 @@ impl LLMEngine for MockerBackend {
             total_kv_blocks: Some(self.engine_args.num_gpu_blocks as u64),
             max_num_seqs: self.engine_args.max_num_seqs.map(|v| v as u64),
             max_num_batched_tokens: self.engine_args.max_num_batched_tokens.map(|v| v as u64),
+            data_parallel_size: None,
             // Mocker has no real KV transport, so it never advertises a
             // bootstrap address. Real prefill engines populate these in
             // start() to publish ModelRuntimeConfig.disaggregated_endpoint.
@@ -354,9 +369,20 @@ impl LLMEngine for MockerBackend {
             return Err(engine_shutdown("scheduler is not accepting requests"));
         }
 
+        // Synthetic per-request block accounting: each request claims its
+        // prompt blocks for the duration of generation. Released by the
+        // guard's Drop. Demonstrates the metrics-publish path without
+        // depending on the scheduler exposing real KV usage.
+        let block_size = self.engine_args.block_size.max(1) as u32;
+        let blocks_held = prompt_len.div_ceil(block_size) as u64;
+        self.kv_used_blocks
+            .fetch_add(blocks_held, Ordering::Relaxed);
+
         let guard = ActiveRequestGuard {
             uuid,
             active: self.active.clone(),
+            kv_used_blocks: self.kv_used_blocks.clone(),
+            blocks_held,
         };
 
         Ok(Box::pin(async_stream::stream! {
@@ -439,6 +465,31 @@ impl LLMEngine for MockerBackend {
         // simulated compute on this uuid until max_output_tokens.
         // Future cleanup will need an abort hook in `dynamo-mocker`.
         tracing::debug!(request_id = ctx.id(), "mocker backend: abort requested");
+    }
+
+    /// One Push source for KV events plus one Snapshot source for
+    /// metrics. The Push `on_ready` is a no-op — the mocker's scheduler
+    /// doesn't emit real KV events. Real Rust engines would start a
+    /// polling thread here that calls `publisher.publish` directly.
+    /// Metrics report a synthetic `kv_used_blocks` derived from
+    /// per-request prompt-block counts maintained in `generate()`.
+    async fn kv_event_sources(&self) -> Result<Vec<KvEventSource>, DynamoError> {
+        Ok(vec![KvEventSource::Push {
+            on_ready: Box::new(|_publisher| Ok(())),
+            dp_rank: DP_RANK,
+        }])
+    }
+
+    async fn metrics_sources(&self) -> Result<Vec<MetricsSource>, DynamoError> {
+        let used = self.kv_used_blocks.clone();
+        Ok(vec![MetricsSource {
+            snapshot: Arc::new(move || {
+                Some(Metrics {
+                    kv_used_blocks: Some(used.load(Ordering::Relaxed)),
+                })
+            }),
+            dp_rank: DP_RANK,
+        }])
     }
 
     async fn cleanup(&self) -> Result<(), DynamoError> {

--- a/lib/backend-common/src/engine.rs
+++ b/lib/backend-common/src/engine.rs
@@ -19,6 +19,7 @@ use tokio::sync::watch;
 
 use crate::error::DynamoError;
 
+pub use dynamo_llm::kv_router::publisher::KvEventPublisher;
 pub use dynamo_llm::protocols::common::llm_backend::LLMEngineOutput;
 pub use dynamo_llm::protocols::common::preprocessor::{
     BootstrapInfo, PrefillResult, PreprocessedRequest,
@@ -105,6 +106,9 @@ pub struct EngineConfig {
     pub max_num_seqs: Option<u64>,
     /// Maximum tokens the engine will process in a single batched step.
     pub max_num_batched_tokens: Option<u64>,
+    /// Number of data-parallel ranks this worker hosts. Defaults to 1.
+    /// The router uses this to enumerate per-rank load when scoring.
+    pub data_parallel_size: Option<u32>,
     /// Bootstrap host this prefill worker advertises to decode peers.
     ///
     /// Only meaningful for backends with a Dynamo-level host/port
@@ -244,6 +248,69 @@ pub trait LLMEngine: Send + Sync + 'static {
     /// successful first call must return `Ok(())` without re-entering
     /// teardown (NCCL groups and similar fail noisily on double-free).
     async fn cleanup(&self) -> Result<(), DynamoError>;
+
+    /// KV event sources advertised by this engine, one per dp_rank.
+    /// Empty by default (engine opts out of KV-aware routing).
+    async fn kv_event_sources(&self) -> Result<Vec<KvEventSource>, DynamoError> {
+        Ok(Vec::new())
+    }
+
+    /// Metrics snapshot sources, one per dp_rank. Empty by default.
+    async fn metrics_sources(&self) -> Result<Vec<MetricsSource>, DynamoError> {
+        Ok(Vec::new())
+    }
+}
+
+/// Invoked once with a freshly-built publisher; engine drives `publish`
+/// from its own thread thereafter.
+pub type OnPublisherReady =
+    Box<dyn FnOnce(Arc<KvEventPublisher>) -> Result<(), DynamoError> + Send + 'static>;
+
+/// Worker reads this on a fixed interval. MUST be a cheap member-field read.
+pub type SnapshotFn = Arc<dyn Fn() -> Option<Metrics> + Send + Sync>;
+
+/// KV event source descriptor. Two flavors: subscribe to an engine-provided
+/// ZMQ PUB, or hand a publisher to the engine and let it drive `publish`
+/// from its own thread (for engines whose event API blocks the caller).
+pub enum KvEventSource {
+    Zmq {
+        endpoint: String,
+        topic: String,
+        dp_rank: u32,
+    },
+    Push {
+        on_ready: OnPublisherReady,
+        dp_rank: u32,
+    },
+}
+
+impl KvEventSource {
+    /// Data-parallel rank this source publishes for.
+    pub fn dp_rank(&self) -> u32 {
+        match self {
+            KvEventSource::Zmq { dp_rank, .. } | KvEventSource::Push { dp_rank, .. } => *dp_rank,
+        }
+    }
+}
+
+/// One metrics-snapshot source per data-parallel rank.
+pub struct MetricsSource {
+    /// Worker polls this on a fixed interval. MUST be a cheap member-field
+    /// read — engine-internal calls land in the 10s of ms and stall the
+    /// publish loop. Conformance kit enforces a 1 ms ceiling.
+    pub snapshot: SnapshotFn,
+    pub dp_rank: u32,
+}
+
+/// Worker-level metrics snapshot consumed by the KV router.
+///
+/// `kv_used_blocks` is the primary load signal the router scores against.
+/// `Option` because the engine may not have a snapshot yet on the first few
+/// ticks after `start()`; `Worker` skips the publish call in that case.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Metrics {
+    /// Number of KV blocks currently occupied across all in-flight requests.
+    pub kv_used_blocks: Option<u64>,
 }
 
 /// Non-terminal chunk constructor. Terminal chunks come from upstream

--- a/lib/backend-common/src/engine.rs
+++ b/lib/backend-common/src/engine.rs
@@ -109,6 +109,12 @@ pub struct EngineConfig {
     /// Number of data-parallel ranks this worker hosts. Defaults to 1.
     /// The router uses this to enumerate per-rank load when scoring.
     pub data_parallel_size: Option<u32>,
+    /// Global index of the first DP rank this worker hosts. Defaults to 0.
+    /// Non-zero only under multi-worker DP layouts where each worker owns a
+    /// sub-range (e.g. vLLM hybrid/external LB, SGLang DP-attention across
+    /// multiple nodes). The router enumerates ranks
+    /// `[data_parallel_start_rank, data_parallel_start_rank + data_parallel_size)`.
+    pub data_parallel_start_rank: Option<u32>,
     /// Bootstrap host this prefill worker advertises to decode peers.
     ///
     /// Only meaningful for backends with a Dynamo-level host/port

--- a/lib/backend-common/src/lib.rs
+++ b/lib/backend-common/src/lib.rs
@@ -17,6 +17,7 @@ pub mod args;
 pub mod disagg;
 pub mod engine;
 pub mod error;
+mod publisher;
 pub mod run;
 #[cfg(any(test, feature = "testing"))]
 pub mod testing;
@@ -28,8 +29,9 @@ pub use args::CommonArgs;
 pub use disagg::DisaggregationMode;
 pub use engine::{
     AsyncEngineContext, BootstrapInfo, CompletionUsage, EngineConfig, FinishReason,
-    GenerateContext, LLMEngine, LLMEngineOutput, LLMEngineOutputExt, OutputOptions, PrefillResult,
-    PreprocessedRequest, SamplingOptions, StopConditions, chunk, usage,
+    GenerateContext, KvEventPublisher, KvEventSource, LLMEngine, LLMEngineOutput,
+    LLMEngineOutputExt, Metrics, MetricsSource, OnPublisherReady, OutputOptions, PrefillResult,
+    PreprocessedRequest, SamplingOptions, SnapshotFn, StopConditions, chunk, usage,
 };
 pub use error::{BackendError, DynamoError, ErrorType};
 pub use run::run;

--- a/lib/backend-common/src/publisher.rs
+++ b/lib/backend-common/src/publisher.rs
@@ -1,0 +1,261 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Worker-side wiring for KV-aware-routing publishers.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use dynamo_llm::kv_router::publisher::{
+    KvEventPublisher, KvEventSourceConfig, WorkerMetricsPublisher,
+};
+use dynamo_runtime::component::Component;
+use dynamo_runtime::traits::DistributedRuntimeProvider;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+use crate::engine::{KvEventSource, Metrics, MetricsSource};
+use crate::error::{BackendError, DynamoError, ErrorType};
+
+const METRICS_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Live publisher handles owned by `Worker` for the lifetime of serving.
+/// `kv_publishers` and `metrics_publishers` are kept alive solely so their
+/// `Drop` impls run on shutdown.
+pub(crate) struct PublisherHandles {
+    #[allow(dead_code)]
+    kv_publishers: Vec<Arc<KvEventPublisher>>,
+    #[allow(dead_code)]
+    metrics_publishers: Vec<Arc<WorkerMetricsPublisher>>,
+    metrics_task: Option<JoinHandle<()>>,
+    cancel: CancellationToken,
+}
+
+impl PublisherHandles {
+    pub(crate) async fn shutdown(&mut self) {
+        self.cancel.cancel();
+        if let Some(task) = self.metrics_task.take()
+            && let Err(e) = task.await
+        {
+            tracing::warn!(error = ?e, "metrics task panicked or was aborted");
+        }
+    }
+}
+
+// Sync — `KvEventPublisher::new_with_local_indexer` doesn't await. The
+// metrics counterpart below is async because `create_endpoint` does.
+fn setup_kv_publishers(
+    component: &Component,
+    sources: Vec<KvEventSource>,
+    kv_cache_block_size: u32,
+    enable_local_indexer: bool,
+) -> Result<Vec<Arc<KvEventPublisher>>, DynamoError> {
+    let mut publishers = Vec::with_capacity(sources.len());
+    for source in sources {
+        let dp_rank = source.dp_rank();
+        let (source_config, on_ready) = match source {
+            KvEventSource::Zmq {
+                endpoint, topic, ..
+            } => (Some(KvEventSourceConfig::Zmq { endpoint, topic }), None),
+            KvEventSource::Push { on_ready, .. } => (None, Some(on_ready)),
+        };
+        let publisher = KvEventPublisher::new_with_local_indexer(
+            component.clone(),
+            kv_cache_block_size,
+            source_config,
+            enable_local_indexer,
+            dp_rank,
+            None,
+        )
+        .map_err(|e| publisher_err(format!("kv publisher setup (dp_rank={dp_rank}): {e}")))?;
+        let publisher = Arc::new(publisher);
+        if let Some(on_ready) = on_ready {
+            // Partial-success: engines whose on_ready ran before this failure
+            // have already started threads. The unwind path runs
+            // `engine.cleanup` (see `Worker::cleanup_once`), which is the
+            // sole hook for joining them.
+            on_ready(publisher.clone()).map_err(|e| {
+                publisher_err(format!("kv publisher on_ready (dp_rank={dp_rank}): {e}"))
+            })?;
+        }
+        publishers.push(publisher);
+    }
+    Ok(publishers)
+}
+
+async fn setup_metrics_publishers(
+    component: &Component,
+    snapshots: Vec<MetricsSource>,
+    cancel: CancellationToken,
+) -> Result<(Vec<Arc<WorkerMetricsPublisher>>, Option<JoinHandle<()>>), DynamoError> {
+    if snapshots.is_empty() {
+        return Ok((Vec::new(), None));
+    }
+    let mut pairs = Vec::with_capacity(snapshots.len());
+    let mut publishers = Vec::with_capacity(snapshots.len());
+    for snap in snapshots {
+        let dp_rank = snap.dp_rank;
+        let publisher = WorkerMetricsPublisher::new().map_err(|e| {
+            publisher_err(format!("metrics publisher new (dp_rank={dp_rank}): {e}"))
+        })?;
+        publisher
+            .create_endpoint(component.clone())
+            .await
+            .map_err(|e| {
+                publisher_err(format!(
+                    "metrics publisher endpoint (dp_rank={dp_rank}): {e}"
+                ))
+            })?;
+        let publisher = Arc::new(publisher);
+        pairs.push((publisher.clone(), snap));
+        publishers.push(publisher);
+    }
+    // `secondary()` so the fixed-interval poll loop doesn't share the
+    // primary runtime with request-handling tasks.
+    let task = component
+        .drt()
+        .runtime()
+        .secondary()
+        .spawn(run_metrics_loop(pairs, cancel));
+    Ok((publishers, Some(task)))
+}
+
+/// One task per worker drives every rank's snapshot per tick. For Python
+/// engines this serializes GIL acquisition through one OS thread instead of
+/// fanning out N contending tokio tasks at the snapshot cadence.
+async fn run_metrics_loop(
+    pairs: Vec<(Arc<WorkerMetricsPublisher>, MetricsSource)>,
+    cancel: CancellationToken,
+) {
+    let mut ticker = tokio::time::interval(METRICS_POLL_INTERVAL);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    let mut warned_ranks: Vec<u32> = Vec::new();
+    loop {
+        tokio::select! {
+            biased;
+            _ = cancel.cancelled() => return,
+            _ = ticker.tick() => publish_tick(&pairs, &mut warned_ranks),
+        }
+    }
+}
+
+fn publish_tick(
+    pairs: &[(Arc<WorkerMetricsPublisher>, MetricsSource)],
+    warned_ranks: &mut Vec<u32>,
+) {
+    for (publisher, snap) in pairs {
+        let Some(Metrics {
+            kv_used_blocks: Some(kv_used_blocks),
+        }) = (snap.snapshot)()
+        else {
+            continue;
+        };
+        if let Err(e) = publisher.publish(Some(snap.dp_rank), None, Some(kv_used_blocks)) {
+            if !warned_ranks.contains(&snap.dp_rank) {
+                warned_ranks.push(snap.dp_rank);
+                tracing::warn!(dp_rank = snap.dp_rank, error = %e,
+                    "metrics publish failed; suppressing further warnings");
+            } else {
+                tracing::debug!(dp_rank = snap.dp_rank, error = %e, "metrics publish failed");
+            }
+        }
+    }
+}
+
+fn publisher_err(message: String) -> DynamoError {
+    // Publisher construction errors are almost always NATS-reach related.
+    DynamoError::builder()
+        .error_type(ErrorType::Backend(BackendError::CannotConnect))
+        .message(message)
+        .build()
+}
+
+pub(crate) async fn setup_publishers(
+    component: &Component,
+    kv_sources: Vec<KvEventSource>,
+    metrics_snapshots: Vec<MetricsSource>,
+    kv_cache_block_size: Option<u32>,
+    enable_local_indexer: bool,
+) -> Result<PublisherHandles, DynamoError> {
+    // KV event publishers require the engine's block size; without it, the
+    // router can't translate token IDs into cache blocks. Metrics publishers
+    // are independent — load reporting works regardless of cache structure.
+    let kv_publishers = if let Some(block_size) = kv_cache_block_size {
+        setup_kv_publishers(component, kv_sources, block_size, enable_local_indexer)?
+    } else {
+        if !kv_sources.is_empty() {
+            tracing::warn!(
+                "engine declared {} kv_event_sources but kv_cache_block_size is None; skipping KV event publishers",
+                kv_sources.len()
+            );
+        }
+        Vec::new()
+    };
+    let cancel = CancellationToken::new();
+    let (metrics_publishers, metrics_task) =
+        setup_metrics_publishers(component, metrics_snapshots, cancel.clone()).await?;
+    Ok(PublisherHandles {
+        kv_publishers,
+        metrics_publishers,
+        metrics_task,
+        cancel,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    /// `PublisherHandles::shutdown` cancels the shared token and awaits the
+    /// metrics task. Drives one synthetic task that loops on the cancel
+    /// token; verifying it exits proves the cancellation contract end-to-end.
+    #[tokio::test]
+    async fn publisher_handles_shutdown_cancels_metric_task() {
+        let cancel = CancellationToken::new();
+        let observed_cancel = Arc::new(AtomicU64::new(0));
+        let counter = observed_cancel.clone();
+        let token = cancel.clone();
+        let task = tokio::spawn(async move {
+            tokio::select! {
+                _ = token.cancelled() => {
+                    counter.fetch_add(1, Ordering::SeqCst);
+                }
+                _ = tokio::time::sleep(Duration::from_secs(5)) => {}
+            }
+        });
+        let mut handles = PublisherHandles {
+            kv_publishers: Vec::new(),
+            metrics_publishers: Vec::new(),
+            metrics_task: Some(task),
+            cancel,
+        };
+        handles.shutdown().await;
+        assert_eq!(
+            observed_cancel.load(Ordering::SeqCst),
+            1,
+            "metric task must observe cancellation during shutdown"
+        );
+    }
+
+    /// First `shutdown` takes the task and joins it; second is a no-op.
+    #[tokio::test]
+    async fn publisher_handles_shutdown_is_idempotent() {
+        let cancel = CancellationToken::new();
+        let token = cancel.clone();
+        let task = tokio::spawn(async move { token.cancelled().await });
+        let mut handles = PublisherHandles {
+            kv_publishers: Vec::new(),
+            metrics_publishers: Vec::new(),
+            metrics_task: Some(task),
+            cancel,
+        };
+        handles.shutdown().await;
+        assert!(
+            handles.metrics_task.is_none(),
+            "first shutdown takes the task"
+        );
+        assert!(handles.cancel.is_cancelled());
+        handles.shutdown().await;
+    }
+}

--- a/lib/backend-common/src/testing.rs
+++ b/lib/backend-common/src/testing.rs
@@ -70,6 +70,11 @@ pub enum ConformanceFailure {
     CleanupFailed(String),
     SecondCleanupFailed(String),
     CleanupWithoutStartFailed(String),
+    KvEventSourcesFailed(String),
+    KvEventSourcesNotIdempotent,
+    MetricsSourcesFailed(String),
+    MetricsSourcesNotIdempotent,
+    MetricsSnapshotTooSlow { took: Duration },
 }
 
 impl std::fmt::Display for ConformanceFailure {
@@ -103,6 +108,23 @@ impl std::fmt::Display for ConformanceFailure {
                 "cleanup() failed on a never-started engine: {m} \
                  (Worker calls cleanup() after start() raises, so engines must \
                  be null-safe against partial / no allocation)"
+            ),
+            KvEventSourcesFailed(m) => write!(f, "kv_event_sources() failed: {m}"),
+            KvEventSourcesNotIdempotent => write!(
+                f,
+                "kv_event_sources() returned different dp_rank set on a second call \
+                 (the descriptor list must be stable for the engine's lifetime)"
+            ),
+            MetricsSourcesFailed(m) => write!(f, "metrics_sources() failed: {m}"),
+            MetricsSourcesNotIdempotent => write!(
+                f,
+                "metrics_sources() returned different dp_rank set on a second call \
+                 (the descriptor list must be stable for the engine's lifetime)"
+            ),
+            MetricsSnapshotTooSlow { took } => write!(
+                f,
+                "SnapshotSource.snapshot took {took:?} (must be a cheap field read, \
+                 < 1 ms; an engine-internal call would land in the 10s of ms)"
             ),
         }
     }
@@ -141,7 +163,14 @@ where
     // 4. Cancellation is observed within a bounded deadline.
     check_cancellation(&engine, &config.model, DEFAULT_CANCEL_DEADLINE).await?;
 
-    // 5. cleanup() succeeds and is idempotent.
+    // 5. KV-aware-routing source descriptors satisfy their contracts:
+    //    - kv_event_sources / metrics_sources don't error
+    //    - rank sets are stable across repeated calls
+    //    - SnapshotSource.snapshot is a cheap field read (< 1 ms)
+    check_kv_event_sources(&engine).await?;
+    check_metrics_sources(&engine).await?;
+
+    // 6. cleanup() succeeds and is idempotent.
     engine
         .cleanup()
         .await
@@ -241,6 +270,62 @@ async fn check_concurrent_generates<E: LLMEngine>(
     });
     for result in futures::future::join_all(futs).await {
         result?;
+    }
+    Ok(())
+}
+
+/// Ceiling for a snapshot read. An engine that accidentally calls into its
+/// underlying inference engine here lands in the 10s of ms and stalls the
+/// publish loop.
+const SNAPSHOT_MAX_LATENCY: Duration = Duration::from_millis(1);
+
+async fn check_kv_event_sources<E: LLMEngine>(engine: &E) -> Result<(), ConformanceFailure> {
+    let first = engine
+        .kv_event_sources()
+        .await
+        .map_err(|e| KvEventSourcesFailed(e.to_string()))?;
+    let second = engine
+        .kv_event_sources()
+        .await
+        .map_err(|e| KvEventSourcesFailed(e.to_string()))?;
+    let ranks_a: Vec<u32> = first.iter().map(|s| s.dp_rank()).collect();
+    let ranks_b: Vec<u32> = second.iter().map(|s| s.dp_rank()).collect();
+    if ranks_a != ranks_b {
+        return Err(KvEventSourcesNotIdempotent);
+    }
+    Ok(())
+}
+
+async fn check_metrics_sources<E: LLMEngine>(engine: &E) -> Result<(), ConformanceFailure> {
+    let first = engine
+        .metrics_sources()
+        .await
+        .map_err(|e| MetricsSourcesFailed(e.to_string()))?;
+    let second = engine
+        .metrics_sources()
+        .await
+        .map_err(|e| MetricsSourcesFailed(e.to_string()))?;
+    let ranks_a: Vec<u32> = first.iter().map(|s| s.dp_rank).collect();
+    let ranks_b: Vec<u32> = second.iter().map(|s| s.dp_rank).collect();
+    if ranks_a != ranks_b {
+        return Err(MetricsSourcesNotIdempotent);
+    }
+    // Probe snapshot latency on every returned source. The closure is what
+    // `Worker` invokes under the GIL on a tokio interval; if it's slow
+    // here it'll stall the publish loop in production. Take min-of-3 so
+    // a contended CI runner doesn't flake on a single-sample outlier.
+    for src in &first {
+        let took = (0..3)
+            .map(|_| {
+                let started = std::time::Instant::now();
+                let _ = (src.snapshot)();
+                started.elapsed()
+            })
+            .min()
+            .unwrap_or_default();
+        if took > SNAPSHOT_MAX_LATENCY {
+            return Err(MetricsSnapshotTooSlow { took });
+        }
     }
     Ok(())
 }

--- a/lib/backend-common/src/worker.rs
+++ b/lib/backend-common/src/worker.rs
@@ -25,6 +25,7 @@ use crate::adapter::EngineAdapter;
 use crate::disagg::DisaggregationMode;
 use crate::engine::{EngineConfig, LLMEngine};
 use crate::error::{BackendError, DynamoError, ErrorType};
+use crate::publisher::{PublisherHandles, setup_publishers};
 
 /// Default grace-period in seconds between discovery unregister and engine drain.
 /// Mirrors the Python `_DEFAULT_GRACE_PERIOD_SECS` constant.
@@ -119,6 +120,9 @@ pub struct WorkerConfig {
     pub exclude_tools_when_tool_choice_none: bool,
     /// Whether this worker should keep an in-process KV indexer.
     pub enable_local_indexer: bool,
+    /// Kill switch for KV-aware-routing publishers. When `false`, skip
+    /// `engine.kv_event_sources()` / `metrics_sources()` entirely.
+    pub enable_kv_routing: bool,
     /// Per-endpoint Prometheus metric labels appended to every metric.
     /// Common labels: `("model", "<served-name>")`.
     pub metrics_labels: Vec<(String, String)>,
@@ -133,6 +137,15 @@ pub struct WorkerConfig {
     /// Runtime / transport overrides applied via env vars before the
     /// `DistributedRuntime` is constructed.
     pub runtime: RuntimeConfig,
+}
+
+impl WorkerConfig {
+    /// Effective `enable_local_indexer`, accounting for disaggregation
+    /// mode. Decode workers force this off because they don't host the
+    /// in-process KV indexer endpoint and must not advertise it.
+    pub(crate) fn effective_enable_local_indexer(&self) -> bool {
+        self.enable_local_indexer && !self.disaggregation_mode.is_decode()
+    }
 }
 
 impl Default for WorkerConfig {
@@ -150,6 +163,7 @@ impl Default for WorkerConfig {
             reasoning_parser: None,
             exclude_tools_when_tool_choice_none: true,
             enable_local_indexer: true,
+            enable_kv_routing: true,
             metrics_labels: Vec::new(),
             disaggregation_mode: DisaggregationMode::Aggregated,
             runtime: RuntimeConfig::default(),
@@ -182,6 +196,8 @@ pub struct Worker {
     engine: Arc<dyn LLMEngine>,
     config: WorkerConfig,
     state: LifecycleState,
+    /// KV-aware-routing publisher handles. Drained in `cleanup_once` while NATS is alive.
+    publishers: Option<PublisherHandles>,
 }
 
 impl Worker {
@@ -190,6 +206,7 @@ impl Worker {
             engine,
             config,
             state: LifecycleState::Init,
+            publishers: None,
         }
     }
 
@@ -364,6 +381,9 @@ impl Worker {
             "engine.start() complete"
         );
 
+        self.setup_kv_aware_publishers(&component, &engine_config)
+            .await?;
+
         // Mid-start signal: engine.start() ran to completion but a signal
         // arrived during it. Skip the serve loop and run the orchestrator
         // directly so `engine.cleanup()` still runs while the runtime is
@@ -376,6 +396,46 @@ impl Worker {
 
         self.serve_with_orchestrator(&engine_config, endpoint, shutdown.clone())
             .await
+    }
+
+    /// Build KV-event and worker-metric publishers from the engine's source
+    /// declarations. No-op if `enable_kv_routing` is off, the engine declares
+    /// no sources, or `engine_config.kv_cache_block_size` is unset.
+    async fn setup_kv_aware_publishers(
+        &mut self,
+        component: &dynamo_runtime::component::Component,
+        engine_config: &EngineConfig,
+    ) -> Result<(), DynamoError> {
+        if !self.config.enable_kv_routing {
+            tracing::debug!("enable_kv_routing=false; skipping kv_event_sources / metrics_sources");
+            return Ok(());
+        }
+        let kv_sources = self.engine.kv_event_sources().await?;
+        let metrics_snapshots = self.engine.metrics_sources().await?;
+        if kv_sources.is_empty() && metrics_snapshots.is_empty() {
+            tracing::debug!(
+                "engine returned no KV/metrics sources; KV-aware routing disabled for this worker"
+            );
+            return Ok(());
+        }
+        let enable_local_indexer = self.config.effective_enable_local_indexer();
+        tracing::debug!(
+            kv_sources = kv_sources.len(),
+            metrics_sources = metrics_snapshots.len(),
+            enable_local_indexer,
+            kv_cache_block_size = ?engine_config.kv_cache_block_size,
+            "Starting KV-aware-routing publishers"
+        );
+        let handles = setup_publishers(
+            component,
+            kv_sources,
+            metrics_snapshots,
+            engine_config.kv_cache_block_size,
+            enable_local_indexer,
+        )
+        .await?;
+        self.publishers = Some(handles);
+        Ok(())
     }
 
     /// Full graceful-shutdown orchestrator: discovery unregister →
@@ -433,6 +493,12 @@ impl Worker {
         match self.engine.cleanup().await {
             Ok(()) => tracing::info!("Engine cleanup complete"),
             Err(e) => tracing::error!(error = %e, "engine cleanup failed"),
+        }
+        // Stop publisher metric loops AFTER engine.cleanup so the engine's
+        // last metric snapshots get published. Then drop the handles so the
+        // publishers' own tokio tasks drain while NATS is still alive.
+        if let Some(mut handles) = self.publishers.take() {
+            handles.shutdown().await;
         }
         // Mark stopped even on failure so a follow-up call no-ops; engines
         // like vLLM/TRT-LLM tear down NCCL groups in cleanup() and a second
@@ -718,8 +784,7 @@ async fn build_local_model(
     // Decode workers don't host the WorkerKvQuery endpoint, so they must not
     // advertise the local indexer regardless of the operator-supplied flag.
     // Mirrors the legacy non-unified vLLM path (worker_factory.py).
-    let enable_local_indexer =
-        config.enable_local_indexer && !config.disaggregation_mode.is_decode();
+    let enable_local_indexer = config.effective_enable_local_indexer();
 
     // Publish the disaggregated bootstrap endpoint when the engine
     // returned one. Only meaningful for prefill workers — decode/agg
@@ -747,6 +812,7 @@ async fn build_local_model(
         total_kv_blocks: engine_config.total_kv_blocks,
         max_num_seqs: engine_config.max_num_seqs,
         max_num_batched_tokens: engine_config.max_num_batched_tokens,
+        data_parallel_size: engine_config.data_parallel_size.unwrap_or(1),
         tool_call_parser: config.tool_call_parser.clone(),
         reasoning_parser: config.reasoning_parser.clone(),
         exclude_tools_when_tool_choice_none: config.exclude_tools_when_tool_choice_none,

--- a/lib/backend-common/src/worker.rs
+++ b/lib/backend-common/src/worker.rs
@@ -813,6 +813,7 @@ async fn build_local_model(
         max_num_seqs: engine_config.max_num_seqs,
         max_num_batched_tokens: engine_config.max_num_batched_tokens,
         data_parallel_size: engine_config.data_parallel_size.unwrap_or(1),
+        data_parallel_start_rank: engine_config.data_parallel_start_rank.unwrap_or(0),
         tool_call_parser: config.tool_call_parser.clone(),
         reasoning_parser: config.reasoning_parser.clone(),
         exclude_tools_when_tool_choice_none: config.exclude_tools_when_tool_choice_none,

--- a/lib/bindings/python/rust/backend.rs
+++ b/lib/bindings/python/rust/backend.rs
@@ -115,6 +115,7 @@ impl EngineConfig {
         max_num_seqs = None,
         max_num_batched_tokens = None,
         data_parallel_size = None,
+        data_parallel_start_rank = None,
         bootstrap_host = None,
         bootstrap_port = None,
     ))]
@@ -128,6 +129,7 @@ impl EngineConfig {
         max_num_seqs: Option<u64>,
         max_num_batched_tokens: Option<u64>,
         data_parallel_size: Option<u32>,
+        data_parallel_start_rank: Option<u32>,
         bootstrap_host: Option<String>,
         bootstrap_port: Option<u16>,
     ) -> Self {
@@ -141,6 +143,7 @@ impl EngineConfig {
                 max_num_seqs,
                 max_num_batched_tokens,
                 data_parallel_size,
+                data_parallel_start_rank,
                 bootstrap_host,
                 bootstrap_port,
             },
@@ -178,6 +181,10 @@ impl EngineConfig {
     #[getter]
     fn data_parallel_size(&self) -> Option<u32> {
         self.inner.data_parallel_size
+    }
+    #[getter]
+    fn data_parallel_start_rank(&self) -> Option<u32> {
+        self.inner.data_parallel_start_rank
     }
     #[getter]
     fn bootstrap_host(&self) -> Option<&str> {
@@ -525,6 +532,7 @@ impl LLMEngine for PyLLMEngine {
                 max_num_seqs: opt_attr::<u64>(bound, "max_num_seqs")?,
                 max_num_batched_tokens: opt_attr::<u64>(bound, "max_num_batched_tokens")?,
                 data_parallel_size: opt_attr::<u32>(bound, "data_parallel_size")?,
+                data_parallel_start_rank: opt_attr::<u32>(bound, "data_parallel_start_rank")?,
                 bootstrap_host: opt_attr::<String>(bound, "bootstrap_host")?,
                 bootstrap_port: opt_attr::<u16>(bound, "bootstrap_port")?,
             })

--- a/lib/bindings/python/rust/backend.rs
+++ b/lib/bindings/python/rust/backend.rs
@@ -20,8 +20,10 @@ use std::sync::{Arc, Mutex as StdMutex};
 use async_trait::async_trait;
 use dynamo_backend_common::{
     AsyncEngineContext, BackendError, DisaggregationMode as RsDisaggregationMode, DynamoError,
-    EngineConfig as RsEngineConfig, ErrorType, LLMEngine, LLMEngineOutput, PreprocessedRequest,
-    RuntimeConfig as RsRuntimeConfig, Worker as RsWorker, WorkerConfig as RsWorkerConfig,
+    EngineConfig as RsEngineConfig, ErrorType, KvEventSource as RsKvEventSource, LLMEngine,
+    LLMEngineOutput, Metrics as RsMetrics, MetricsSource as RsMetricsSource, OnPublisherReady,
+    PreprocessedRequest, RuntimeConfig as RsRuntimeConfig, SnapshotFn, Worker as RsWorker,
+    WorkerConfig as RsWorkerConfig,
 };
 use dynamo_llm::model_type::ModelInput as RsModelInput;
 use dynamo_runtime as rs;
@@ -35,6 +37,7 @@ use pythonize::{depythonize, pythonize};
 use crate::ModelInput;
 use crate::context::Context as PyContext;
 use crate::errors::py_exception_to_backend_error;
+use crate::llm::kv::KvEventPublisher as PyKvEventPublisher;
 use crate::to_pyerr;
 
 /// Register `dynamo._core.backend` and its classes on the parent `_core` module.
@@ -111,6 +114,7 @@ impl EngineConfig {
         total_kv_blocks = None,
         max_num_seqs = None,
         max_num_batched_tokens = None,
+        data_parallel_size = None,
         bootstrap_host = None,
         bootstrap_port = None,
     ))]
@@ -123,6 +127,7 @@ impl EngineConfig {
         total_kv_blocks: Option<u64>,
         max_num_seqs: Option<u64>,
         max_num_batched_tokens: Option<u64>,
+        data_parallel_size: Option<u32>,
         bootstrap_host: Option<String>,
         bootstrap_port: Option<u16>,
     ) -> Self {
@@ -135,6 +140,7 @@ impl EngineConfig {
                 total_kv_blocks,
                 max_num_seqs,
                 max_num_batched_tokens,
+                data_parallel_size,
                 bootstrap_host,
                 bootstrap_port,
             },
@@ -168,6 +174,10 @@ impl EngineConfig {
     #[getter]
     fn max_num_batched_tokens(&self) -> Option<u64> {
         self.inner.max_num_batched_tokens
+    }
+    #[getter]
+    fn data_parallel_size(&self) -> Option<u32> {
+        self.inner.data_parallel_size
     }
     #[getter]
     fn bootstrap_host(&self) -> Option<&str> {
@@ -234,6 +244,7 @@ impl WorkerConfig {
         reasoning_parser = None,
         exclude_tools_when_tool_choice_none = true,
         enable_local_indexer = true,
+        enable_kv_routing = true,
         metrics_labels = Vec::new(),
         runtime = None,
         disaggregation_mode = DisaggregationMode::Aggregated,
@@ -252,6 +263,7 @@ impl WorkerConfig {
         reasoning_parser: Option<String>,
         exclude_tools_when_tool_choice_none: bool,
         enable_local_indexer: bool,
+        enable_kv_routing: bool,
         metrics_labels: Vec<(String, String)>,
         runtime: Option<RuntimeConfig>,
         disaggregation_mode: DisaggregationMode,
@@ -276,6 +288,7 @@ impl WorkerConfig {
                 reasoning_parser,
                 exclude_tools_when_tool_choice_none,
                 enable_local_indexer,
+                enable_kv_routing,
                 metrics_labels,
                 disaggregation_mode: disaggregation_mode.into(),
                 runtime: runtime.map(|r| r.inner).unwrap_or_default(),
@@ -511,6 +524,7 @@ impl LLMEngine for PyLLMEngine {
                 total_kv_blocks: opt_attr::<u64>(bound, "total_kv_blocks")?,
                 max_num_seqs: opt_attr::<u64>(bound, "max_num_seqs")?,
                 max_num_batched_tokens: opt_attr::<u64>(bound, "max_num_batched_tokens")?,
+                data_parallel_size: opt_attr::<u32>(bound, "data_parallel_size")?,
                 bootstrap_host: opt_attr::<String>(bound, "bootstrap_host")?,
                 bootstrap_port: opt_attr::<u16>(bound, "bootstrap_port")?,
             })
@@ -672,6 +686,135 @@ impl LLMEngine for PyLLMEngine {
             .map_err(py_err_to_dynamo)?;
         Ok(())
     }
+
+    async fn kv_event_sources(&self) -> Result<Vec<RsKvEventSource>, DynamoError> {
+        let py_list = self
+            .call_method0_async("kv_event_sources")
+            .await
+            .map_err(py_err_to_dynamo)?;
+        Python::with_gil(|py| -> PyResult<Vec<RsKvEventSource>> {
+            let bound = py_list.bind(py);
+            let list = bound.downcast::<pyo3::types::PyList>()?;
+            let mut sources = Vec::with_capacity(list.len());
+            for item in list.iter() {
+                sources.push(depythonize_kv_source(&item)?);
+            }
+            Ok(sources)
+        })
+        .map_err(py_err_to_dynamo)
+    }
+
+    async fn metrics_sources(&self) -> Result<Vec<RsMetricsSource>, DynamoError> {
+        let py_list = self
+            .call_method0_async("metrics_sources")
+            .await
+            .map_err(py_err_to_dynamo)?;
+        Python::with_gil(|py| -> PyResult<Vec<RsMetricsSource>> {
+            let bound = py_list.bind(py);
+            let list = bound.downcast::<pyo3::types::PyList>()?;
+            let mut sources = Vec::with_capacity(list.len());
+            for item in list.iter() {
+                sources.push(depythonize_metrics_source(&item)?);
+            }
+            Ok(sources)
+        })
+        .map_err(py_err_to_dynamo)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Source-descriptor depythonization
+//
+// Each Python descriptor maps to one arm of the Rust source enum. Identify
+// by class name (`type(x).__name__`) — the Python module exports each as a
+// distinct dataclass, so the name is the unambiguous discriminator. Falling
+// back to attribute-presence checks would silently accept unrelated objects.
+// ---------------------------------------------------------------------------
+
+fn class_name(item: &Bound<'_, PyAny>) -> PyResult<String> {
+    item.get_type().getattr("__name__")?.extract::<String>()
+}
+
+fn depythonize_kv_source(item: &Bound<'_, PyAny>) -> PyResult<RsKvEventSource> {
+    let cls = class_name(item)?;
+    let dp_rank: u32 = item.getattr("dp_rank")?.extract()?;
+    match cls.as_str() {
+        "ZmqSource" => Ok(RsKvEventSource::Zmq {
+            endpoint: item.getattr("endpoint")?.extract()?,
+            topic: item.getattr("topic")?.extract()?,
+            dp_rank,
+        }),
+        "PushSource" => {
+            // Capture the Python callable as a `PyObject` and wrap in a
+            // Rust closure. The closure runs once when Worker has the
+            // publisher ready: it acquires the GIL, wraps the Rust
+            // `Arc<KvEventPublisher>` as the existing Python pyclass, and
+            // invokes the engine-supplied callback. The callback is
+            // declared sync on the Python side (see `PushSource.on_ready`
+            // in `dynamo.common.backend.publisher`), so no asyncio
+            // round-trip is needed here.
+            let on_ready_obj: PyObject = item.getattr("on_ready")?.into();
+            let on_ready: OnPublisherReady = Box::new(move |publisher| {
+                Python::with_gil(|py| -> PyResult<()> {
+                    let py_pub = Py::new(py, PyKvEventPublisher::from_arc(publisher, dp_rank))?;
+                    on_ready_obj.call1(py, (py_pub,))?;
+                    Ok(())
+                })
+                .map_err(py_err_to_dynamo)
+            });
+            Ok(RsKvEventSource::Push { on_ready, dp_rank })
+        }
+        other => Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
+            "kv_event_sources() returned unknown descriptor type {other:?}; \
+             expected ZmqSource or PushSource"
+        ))),
+    }
+}
+
+fn depythonize_metrics_source(item: &Bound<'_, PyAny>) -> PyResult<RsMetricsSource> {
+    let cls = class_name(item)?;
+    if cls != "SnapshotSource" {
+        return Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
+            "metrics_sources() returned unknown descriptor type {cls:?}; \
+             expected SnapshotSource"
+        )));
+    }
+    let dp_rank: u32 = item.getattr("dp_rank")?.extract()?;
+    let snapshot_obj: PyObject = item.getattr("snapshot")?.into();
+    // Worker invokes this on a fixed interval under the GIL — keep it cheap.
+    // Each failure mode warns once per source then drops subsequent ticks.
+    let warned_call_failed = AtomicBool::new(false);
+    let warned_missing_field = AtomicBool::new(false);
+    let snapshot: SnapshotFn = Arc::new(move || -> Option<RsMetrics> {
+        Python::with_gil(|py| -> Option<RsMetrics> {
+            let result = match snapshot_obj.call0(py) {
+                Ok(r) => r,
+                Err(e) => {
+                    if !warned_call_failed.swap(true, Ordering::Relaxed) {
+                        tracing::warn!(dp_rank, error = %e, "snapshot fn raised; \
+                            dropping metric ticks until the engine recovers");
+                    }
+                    return None;
+                }
+            };
+            let bound = result.bind(py);
+            if bound.is_none() {
+                return None;
+            }
+            let kv_used_blocks: Option<u64> = match bound.getattr("kv_used_blocks") {
+                Ok(v) => v.extract().ok(),
+                Err(e) => {
+                    if !warned_missing_field.swap(true, Ordering::Relaxed) {
+                        tracing::warn!(dp_rank, error = %e,
+                            "snapshot result missing kv_used_blocks field");
+                    }
+                    return None;
+                }
+            };
+            Some(RsMetrics { kv_used_blocks })
+        })
+    });
+    Ok(RsMetricsSource { snapshot, dp_rank })
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -210,6 +210,27 @@ pub(crate) struct KvEventPublisher {
     warning_count: Arc<AtomicU32>,
 }
 
+impl KvEventPublisher {
+    /// Wrap an already-constructed Rust publisher as the Python pyclass.
+    ///
+    /// Used by the unified-backend bridge (`crate::backend`) so the Worker
+    /// can hand a publisher built from a [`PushSource`] back to the Python
+    /// engine without going through the Python-side `__init__` (which
+    /// requires an `Endpoint` and rebuilds the publisher from scratch).
+    pub(crate) fn from_arc(
+        inner: Arc<llm_rs::kv_router::publisher::KvEventPublisher>,
+        dp_rank: DpRank,
+    ) -> Self {
+        let kv_block_size = inner.kv_block_size() as usize;
+        Self {
+            inner,
+            kv_block_size,
+            dp_rank,
+            warning_count: Arc::new(AtomicU32::new(0)),
+        }
+    }
+}
+
 #[pymethods]
 impl KvEventPublisher {
     /// Create a KV event publisher that batches raw engine events before forwarding

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -2352,6 +2352,8 @@ class backend:
             total_kv_blocks: Optional[int] = None,
             max_num_seqs: Optional[int] = None,
             max_num_batched_tokens: Optional[int] = None,
+            data_parallel_size: Optional[int] = None,
+            data_parallel_start_rank: Optional[int] = None,
             bootstrap_host: Optional[str] = None,
             bootstrap_port: Optional[int] = None,
         ) -> None: ...
@@ -2369,6 +2371,10 @@ class backend:
         def max_num_seqs(self) -> Optional[int]: ...
         @property
         def max_num_batched_tokens(self) -> Optional[int]: ...
+        @property
+        def data_parallel_size(self) -> Optional[int]: ...
+        @property
+        def data_parallel_start_rank(self) -> Optional[int]: ...
         @property
         def bootstrap_host(self) -> Optional[str]: ...
         @property

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -2397,6 +2397,7 @@ class backend:
             reasoning_parser: Optional[str] = None,
             exclude_tools_when_tool_choice_none: bool = ...,
             enable_local_indexer: bool = ...,
+            enable_kv_routing: bool = ...,
             metrics_labels: List[Tuple[str, str]] = ...,
             runtime: Optional["backend.RuntimeConfig"] = None,
             disaggregation_mode: "backend.DisaggregationMode" = ...,

--- a/tests/router/test_router_e2e_with_unified.py
+++ b/tests/router/test_router_e2e_with_unified.py
@@ -1,0 +1,444 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""End-to-end router tests against the **unified-backend** entrypoints
+(``python -m dynamo.vllm.unified_main`` etc.) introduced under the
+``dynamo.common.backend`` abstraction.
+
+Each backend's existing legacy entrypoint already has e2e router tests in
+``test_router_e2e_with_{vllm,sglang,trtllm}.py``. This file mirrors a
+focused subset of those tests against the unified entrypoint instead, so
+the new ABC + ``Worker``-driven publishers are validated against the same
+router/frontend stack the legacy path is gated on.
+
+The unified entrypoints share their CLI arg parser with the legacy path
+(see ``dynamo.{vllm,sglang,trtllm}.args.parse_args``). The only difference
+between the legacy and unified runs is the launched Python module, so each
+``Unified*Process`` is a thin subclass that swaps that one token in every
+worker process's ``command`` list.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+
+from tests.router.e2e_harness import run_basic_router_test, run_router_decisions_test
+from tests.router.test_router_e2e_with_sglang import MODEL_NAME as SGLANG_MODEL_NAME
+from tests.router.test_router_e2e_with_sglang import SGLANG_ARGS, SGLangProcess
+from tests.router.test_router_e2e_with_trtllm import MODEL_NAME as TRTLLM_MODEL_NAME
+from tests.router.test_router_e2e_with_trtllm import (
+    TRTLLM_ARGS,
+    TRTLLM_BLOCK_SIZE,
+    TRTLLMProcess,
+)
+from tests.router.test_router_e2e_with_vllm import BLOCK_SIZE as VLLM_BLOCK_SIZE
+from tests.router.test_router_e2e_with_vllm import MODEL_NAME as VLLM_MODEL_NAME
+from tests.router.test_router_e2e_with_vllm import VLLM_ARGS, VLLMProcess
+
+logger = logging.getLogger(__name__)
+
+
+# --------------------------------------------------------------------------- #
+# Process subclasses — swap the launched Python module to point at each
+# backend's `*.unified_main` entrypoint. Everything else (port allocation,
+# CLI args, env vars, KV-events config, NIXL plumbing, indexer wiring) is
+# inherited unchanged because the unified path reuses the same arg parser
+# and runtime stack as the legacy path — only the engine glue differs.
+# --------------------------------------------------------------------------- #
+
+
+def _swap_module(worker_processes, legacy_module: str, unified_module: str) -> None:
+    """Replace `python3 -m <legacy_module>` with `python3 -m <unified_module>`
+    on every worker process's command list. The token appears exactly once
+    per command (the canonical `-m <module>` placement); we assert that to
+    catch upstream test refactors that change the command shape."""
+    for process in worker_processes:
+        cmd = process.command
+        found = False
+        for i, tok in enumerate(cmd):
+            if tok == legacy_module:
+                cmd[i] = unified_module
+                found = True
+                break
+        if not found:
+            raise RuntimeError(
+                f"expected to find {legacy_module!r} in worker command "
+                f"to retarget at {unified_module!r}; got {cmd!r}"
+            )
+
+
+class UnifiedVLLMProcess(VLLMProcess):
+    """vLLM workers launched via ``dynamo.vllm.unified_main``."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        _swap_module(self.worker_processes, "dynamo.vllm", "dynamo.vllm.unified_main")
+
+    process_name = "Unified vLLM worker"
+    cleanup_name = "Unified vLLM worker resources"
+
+
+class UnifiedSGLangProcess(SGLangProcess):
+    """SGLang workers launched via ``dynamo.sglang.unified_main``."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        _swap_module(
+            self.worker_processes, "dynamo.sglang", "dynamo.sglang.unified_main"
+        )
+
+    process_name = "Unified SGLang worker"
+    cleanup_name = "Unified SGLang worker resources"
+
+
+class UnifiedTRTLLMProcess(TRTLLMProcess):
+    """TRT-LLM workers launched via ``dynamo.trtllm.unified_main``.
+
+    Overrides the worker component from ``tensorrt_llm`` (legacy default) to
+    ``backend`` so all three unified backends share one component naming
+    convention. Legacy ``test_router_e2e_with_trtllm.py`` is untouched.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        _swap_module(
+            self.worker_processes, "dynamo.trtllm", "dynamo.trtllm.unified_main"
+        )
+        new_endpoint = f"dyn://{self.namespace}.backend.generate"
+        endpoint_args = ["--endpoint", new_endpoint]
+        for process in self.worker_processes:
+            if any(
+                tok == "--endpoint" or tok.startswith("--endpoint=")
+                for tok in process.command
+            ):
+                raise RuntimeError(
+                    f"expected legacy command to omit --endpoint; got {process.command!r}"
+                )
+            process.command.extend(endpoint_args)
+        self.component_name = "backend"
+        self.endpoint = new_endpoint
+
+    process_name = "Unified TRT-LLM worker"
+    cleanup_name = "Unified TRT-LLM worker resources"
+
+
+# --------------------------------------------------------------------------- #
+# Shared markers
+# --------------------------------------------------------------------------- #
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.router,
+    pytest.mark.unified,
+]
+
+
+# --------------------------------------------------------------------------- #
+# vLLM unified-path tests
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.pre_merge
+@pytest.mark.gpu_1
+@pytest.mark.vllm
+@pytest.mark.model(VLLM_MODEL_NAME)
+@pytest.mark.profiled_vram_gib(6.9)
+@pytest.mark.requested_vllm_kv_cache_bytes(331_801_000)
+@pytest.mark.timeout(360)
+@pytest.mark.parametrize("request_plane", ["tcp"], indirect=True)
+def test_unified_vllm_kv_router_basic(
+    request,
+    runtime_services_dynamic_ports,
+    predownload_models,
+    set_ucx_tls_no_mm,
+    request_plane,
+) -> None:
+    """Two unified-vLLM workers behind the KV router complete a small
+    concurrent request batch end-to-end. Exercises the new ABC's
+    ``kv_event_sources`` (vLLM returns ``ZmqSource`` per dp_rank) and
+    ``metrics_sources`` (vLLM stat-logger feeds the snapshot cache) via
+    the ``Worker``-driven publisher dispatch."""
+    run_basic_router_test(
+        engine_process_cls=UnifiedVLLMProcess,
+        engine_args_name="vllm_args",
+        engine_args=VLLM_ARGS,
+        num_workers=2,
+        single_gpu=True,
+        request=request,
+        request_plane=request_plane,
+        block_size=VLLM_BLOCK_SIZE,
+        model_name=VLLM_MODEL_NAME,
+    )
+
+
+@pytest.mark.pre_merge
+@pytest.mark.gpu_1
+@pytest.mark.vllm
+@pytest.mark.model(VLLM_MODEL_NAME)
+@pytest.mark.profiled_vram_gib(6.9)
+@pytest.mark.requested_vllm_kv_cache_bytes(331_801_000)
+@pytest.mark.timeout(360)
+@pytest.mark.parametrize("request_plane", ["tcp"], indirect=True)
+def test_unified_vllm_router_decisions_multiple_workers(
+    request,
+    runtime_services_dynamic_ports,
+    predownload_models,
+    set_ucx_tls_no_mm,
+    request_plane,
+) -> None:
+    """Prefix-reuse correctness: progressive requests with overlapping
+    prefixes must all land on the worker that already holds the matching
+    blocks. Validates that the unified ``ZmqSource`` correctly plumbs the
+    same KV events the legacy path emits, so the router's overlap scoring
+    is identical."""
+    run_router_decisions_test(
+        engine_process_cls=UnifiedVLLMProcess,
+        engine_args_name="vllm_args",
+        engine_args=VLLM_ARGS,
+        request=request,
+        request_plane=request_plane,
+        model_name=VLLM_MODEL_NAME,
+        block_size=VLLM_BLOCK_SIZE,
+        component_name="backend",
+        num_workers=2,
+        single_gpu=True,
+        test_dp_rank=False,
+    )
+
+
+@pytest.mark.gpu_2
+@pytest.mark.nightly
+@pytest.mark.vllm
+@pytest.mark.model(VLLM_MODEL_NAME)
+@pytest.mark.timeout(600)
+@pytest.mark.parametrize("request_plane", ["tcp"], indirect=True)
+def test_unified_vllm_router_decisions_dp(
+    request,
+    runtime_services_dynamic_ports,
+    predownload_models,
+    set_ucx_tls_no_mm,
+    request_plane,
+) -> None:
+    """Per-dp_rank routing: one vLLM worker hosting 2 data-parallel ranks.
+    Validates that the unified path's `kv_event_sources()` per-rank
+    descriptors plumb through to per-rank `worker_kv_indexer_query_dp{N}`
+    registrations and per-rank scoring."""
+    run_router_decisions_test(
+        engine_process_cls=UnifiedVLLMProcess,
+        engine_args_name="vllm_args",
+        engine_args=VLLM_ARGS,
+        request=request,
+        request_plane=request_plane,
+        model_name=VLLM_MODEL_NAME,
+        block_size=VLLM_BLOCK_SIZE,
+        component_name="backend",
+        num_workers=1,
+        single_gpu=False,
+        test_dp_rank=True,
+        extra_process_kwargs={"data_parallel_size": 2},
+    )
+
+
+# --------------------------------------------------------------------------- #
+# SGLang unified-path tests
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.pre_merge
+@pytest.mark.gpu_1
+@pytest.mark.sglang
+@pytest.mark.model(SGLANG_MODEL_NAME)
+@pytest.mark.timeout(360)
+@pytest.mark.parametrize("request_plane", ["tcp"], indirect=True)
+def test_unified_sglang_kv_router_basic(
+    request,
+    runtime_services_dynamic_ports,
+    predownload_models,
+    request_plane,
+) -> None:
+    """SGLang's unified path returns one ``ZmqSource`` per local dp_rank
+    (validates the multi-rank list-returning ABC). Basic batch run end
+    to end through the KV router."""
+    run_basic_router_test(
+        engine_process_cls=UnifiedSGLangProcess,
+        engine_args_name="sglang_args",
+        engine_args=SGLANG_ARGS,
+        num_workers=2,
+        single_gpu=True,
+        request=request,
+        request_plane=request_plane,
+        block_size=SGLANG_ARGS.get("page_size", 16),
+        model_name=SGLANG_MODEL_NAME,
+    )
+
+
+@pytest.mark.pre_merge
+@pytest.mark.gpu_1
+@pytest.mark.sglang
+@pytest.mark.model(SGLANG_MODEL_NAME)
+@pytest.mark.timeout(360)
+@pytest.mark.parametrize("request_plane", ["tcp"], indirect=True)
+def test_unified_sglang_router_decisions_multiple_workers(
+    request,
+    runtime_services_dynamic_ports,
+    predownload_models,
+    request_plane,
+) -> None:
+    """Same prefix-reuse correctness check, against the SGLang unified
+    entrypoint. Confirms the scheduler-pull metrics task and the per-rank
+    ZMQ event subscriber both wire through the new ``Worker``-managed
+    publishers correctly."""
+    run_router_decisions_test(
+        engine_process_cls=UnifiedSGLangProcess,
+        engine_args_name="sglang_args",
+        engine_args=SGLANG_ARGS,
+        request=request,
+        request_plane=request_plane,
+        model_name=SGLANG_MODEL_NAME,
+        block_size=SGLANG_ARGS.get("page_size", 16),
+        component_name="backend",
+        num_workers=2,
+        single_gpu=True,
+        test_dp_rank=False,
+    )
+
+
+@pytest.mark.pre_merge
+@pytest.mark.gpu_2
+@pytest.mark.sglang
+@pytest.mark.model(SGLANG_MODEL_NAME)
+@pytest.mark.timeout(600)
+@pytest.mark.parametrize("request_plane", ["tcp"], indirect=True)
+@pytest.mark.skip(reason="DYN-2265 (same as legacy SGLang DP test)")
+def test_unified_sglang_router_decisions_dp(
+    request,
+    runtime_services_dynamic_ports,
+    predownload_models,
+    request_plane,
+) -> None:
+    """Per-dp_rank routing on the SGLang unified path. Exercises
+    `_local_dp_rank_range`'s multi-rank slice and the per-rank `ZmqSource`
+    descriptors."""
+    run_router_decisions_test(
+        engine_process_cls=UnifiedSGLangProcess,
+        engine_args_name="sglang_args",
+        engine_args=SGLANG_ARGS,
+        request=request,
+        request_plane=request_plane,
+        model_name=SGLANG_MODEL_NAME,
+        block_size=SGLANG_ARGS.get("page_size", 16),
+        component_name="backend",
+        num_workers=1,
+        single_gpu=False,
+        test_dp_rank=True,
+        extra_process_kwargs={"data_parallel_size": 2},
+    )
+
+
+# --------------------------------------------------------------------------- #
+# TRT-LLM unified-path tests
+# --------------------------------------------------------------------------- #
+#
+# TRT-LLM is the only backend where the unified path is a meaningful
+# behavioural change rather than a refactor: the legacy path drives
+# `get_kv_cache_events_async` from the asyncio loop, while the unified
+# path uses a `PushSource` and runs the polling on a dedicated thread.
+# These tests stand the path up end-to-end against a real engine.
+
+
+@pytest.mark.pre_merge
+@pytest.mark.gpu_1
+@pytest.mark.trtllm
+@pytest.mark.model(TRTLLM_MODEL_NAME)
+@pytest.mark.timeout(600)
+@pytest.mark.parametrize("request_plane", ["tcp"], indirect=True)
+def test_unified_trtllm_kv_router_basic(
+    request,
+    runtime_services_dynamic_ports,
+    predownload_models,
+    request_plane,
+) -> None:
+    """End-to-end smoke against the TRT-LLM unified entrypoint. Verifies
+    that ``PushSource.on_ready`` correctly hands the publisher to the
+    engine's polling thread and that ``publish_stored``/``publish_removed``
+    reach the router via NATS."""
+    run_basic_router_test(
+        engine_process_cls=UnifiedTRTLLMProcess,
+        engine_args_name="trtllm_args",
+        engine_args=TRTLLM_ARGS,
+        num_workers=2,
+        single_gpu=True,
+        request=request,
+        request_plane=request_plane,
+        block_size=TRTLLM_BLOCK_SIZE,
+        model_name=TRTLLM_MODEL_NAME,
+    )
+
+
+@pytest.mark.pre_merge
+@pytest.mark.gpu_1
+@pytest.mark.trtllm
+@pytest.mark.model(TRTLLM_MODEL_NAME)
+@pytest.mark.timeout(600)
+@pytest.mark.parametrize("request_plane", ["tcp"], indirect=True)
+def test_unified_trtllm_router_decisions_multiple_workers(
+    request,
+    runtime_services_dynamic_ports,
+    predownload_models,
+    request_plane,
+) -> None:
+    """Prefix-reuse correctness on the TRT-LLM unified path. The polling
+    thread + `_dispatch_kv_event` must produce the same router-visible
+    events as the legacy `_publish_kv_cache_events_task` for the router's
+    overlap scoring to agree."""
+    run_router_decisions_test(
+        engine_process_cls=UnifiedTRTLLMProcess,
+        engine_args_name="trtllm_args",
+        engine_args=TRTLLM_ARGS,
+        request=request,
+        request_plane=request_plane,
+        model_name=TRTLLM_MODEL_NAME,
+        block_size=TRTLLM_BLOCK_SIZE,
+        component_name="backend",
+        num_workers=2,
+        single_gpu=True,
+        test_dp_rank=False,
+    )
+
+
+@pytest.mark.gpu_2
+@pytest.mark.nightly
+@pytest.mark.trtllm
+@pytest.mark.model(TRTLLM_MODEL_NAME)
+@pytest.mark.timeout(600)
+@pytest.mark.parametrize("request_plane", ["tcp"], indirect=True)
+def test_unified_trtllm_router_decisions_attention_dp(
+    request,
+    runtime_services_dynamic_ports,
+    predownload_models,
+    set_ucx_tls_no_mm,
+    request_plane,
+) -> None:
+    """Attention-DP routing: one TRT-LLM worker with attention_dp_size=2.
+    Exercises `EngineConfig.data_parallel_size` and per-rank `PushSource`
+    + `worker_kv_indexer_query_dp{N}` registration on the unified path."""
+    run_router_decisions_test(
+        engine_process_cls=UnifiedTRTLLMProcess,
+        engine_args_name="trtllm_args",
+        engine_args={
+            **TRTLLM_ARGS,
+            "enable_attention_dp": True,
+            "tensor_parallel_size": 2,
+        },
+        request=request,
+        request_plane=request_plane,
+        model_name=TRTLLM_MODEL_NAME,
+        block_size=TRTLLM_BLOCK_SIZE,
+        component_name="backend",
+        num_workers=1,
+        single_gpu=False,
+        test_dp_rank=True,
+    )


### PR DESCRIPTION
## Summary

Adds `LLMEngine::kv_event_sources()` and `metrics_sources()` so engines declare KV event and metric publishers via source descriptors, with the Rust `Worker` owning publisher construction, the metrics poll loop, and shutdown ordering.

* `KvEventSource` covers two real engine shapes: `Zmq` (subscribe to an engine ZMQ PUB) and `Push` (engine drives `publish` from its own thread after `on_ready`). `MetricsSource` carries an `Arc<Fn>` snapshot polled under the GIL.
* Python ABC mirrors the Rust trait; PyO3 depythonizes the descriptor dataclasses; `KvEventPublisher::from_arc` lets the bridge hand a Rust-built publisher back into Python.
* One metrics tokio task per worker (not per dp_rank) — serializes GIL acquisition through one OS thread for Python engines.
* Surfaces `data_parallel_size` through `EngineConfig` → `ModelRuntimeConfig`; TRT-LLM populates it from `engine.get_attention_dp_size()` for attention-DP parity.
* TRT-LLM unified wires `return_perf_metrics`, `enable_iter_perf_stats`, and `kv_cache_config.event_buffer_max_size` when `publish_events_and_metrics=True` — required for TRT-LLM to actually publish KV cache events. Applied after `--extra-engine-args` / `--override-engine-args`, matching the legacy publisher block.
* Migrates vLLM (StatLogger + ZmqSource), SGLang (ZmqSource + async ZMQ PULL), TRT-LLM (PushSource + poll threads), the sample engine, and the mocker example.
* `UnifiedTRTLLMProcess` overrides the worker component from `tensorrt_llm` to `backend` so all three unified backends share one component naming convention; legacy `test_router_e2e_with_trtllm.py` is untouched.

> **Note**: This PR is currently stacked on the unified-disagg work that hasn't yet landed on `main`. The "Files changed" view will include those commits in addition to the KV-routing commit; once unified-disagg merges, this PR will rebase down to the single KV-routing commit. The change for review here is `cda7b8d1ce` ("feat(backend): KV-aware routing on the unified backend abstraction").

## Test plan

- [x] Rust unit tests: `cargo test --workspace` (publisher + conformance kit)
- [x] Python unit tests for source dataclasses, SGLang local-rank slicing, sample engine
- [x] vLLM unified e2e: `test_unified_vllm_kv_router_basic` + `_router_decisions_multiple_workers`
- [x] SGLang unified e2e: `test_unified_sglang_kv_router_basic` + `_router_decisions_multiple_workers`
- [x] TRT-LLM unified e2e: `test_unified_trtllm_kv_router_basic` + `_router_decisions_multiple_workers` (matches legacy 73s decisions timing)
- [ ] `gpu_2` / nightly dp_rank variants (`test_unified_vllm_router_decisions_dp`, `test_unified_trtllm_router_decisions_attention_dp`) — added but only single-GPU host available locally
- [ ] CI signal across the matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9493" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added KV event routing sources and metrics snapshot publishing for improved cache awareness and monitoring across vLLM, SGLang, and TRT-LLM backends.
  * Added optional `data_parallel_size` and `enable_kv_routing` configuration flags for worker control.

* **Documentation**
  * Documented KV-aware routing source types and metrics snapshot contract for backend implementers.

* **Tests**
  * Added conformance checks for KV/metrics source stability, idempotency, and snapshot latency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9493)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->