### PR TITLE
test(kv-router): wait for indexer before peer recovery

### DIFF
--- a/tests/router/common.py
+++ b/tests/router/common.py
@@ -1514,6 +1514,61 @@ def _test_router_indexers_sync(
             )
             await engine_workers.launch_workers_with_indexer(tmp_endpoint)
 
+        def sort_key(event):
+            data = event["event"]["data"]["stored"]
+            blocks = data["blocks"]
+            first_block = blocks[0]
+            return (
+                event["worker_id"],
+                first_block["tokens_hash"],
+                data["parent_hash"],
+            )
+
+        expected_standalone_key = f"{model_name}:default"
+
+        async def fetch_standalone_events(session, indexer_url, indexer_label):
+            async with session.get(f"{indexer_url}/dump") as resp:
+                assert resp.status == 200, f"GET /dump failed: {resp.status}"
+                dump = await resp.json()
+
+            assert expected_standalone_key in dump, (
+                f"{indexer_label} missing dump key '{expected_standalone_key}', "
+                f"got keys={list(dump.keys())}"
+            )
+            for k, v in dump.items():
+                assert (
+                    isinstance(v, dict) and "events" in v
+                ), f"{indexer_label} dump key '{k}' returned unexpected format: {v}"
+            return sorted(dump[expected_standalone_key]["events"], key=sort_key)
+
+        async def wait_for_standalone_events(
+            indexer_url, expected_events, expected_label, actual_label
+        ):
+            last_error = None
+            async with aiohttp.ClientSession() as session:
+                for attempt in range(50):
+                    actual_events = await fetch_standalone_events(
+                        session, indexer_url, actual_label
+                    )
+                    logger.info(
+                        f"{actual_label} has {len(actual_events)} events "
+                        f"(attempt {attempt + 1})"
+                    )
+                    try:
+                        assert_event_dumps_equal(
+                            expected_events,
+                            actual_events,
+                            expected_label,
+                            actual_label,
+                        )
+                        return actual_events
+                    except AssertionError as exc:
+                        last_error = exc
+                        await asyncio.sleep(0.2)
+
+            assert last_error is not None
+            raise last_error
+
         async def send_requests_to_router(router, num_requests, router_name, endpoint):
             # Now send the actual requests
             tasks = []
@@ -1639,6 +1694,22 @@ def _test_router_indexers_sync(
                 await nc.close()
         else:
             await asyncio.sleep(1)
+
+        if standalone_indexer_url and standalone_indexer_b_url:
+            logger.info(
+                "Waiting for Standalone A to match Router 1 before launching Indexer B"
+            )
+            state1_before_peer_json = await kv_router1.dump_events()
+            sorted_state1_before_peer = sorted(
+                json.loads(state1_before_peer_json), key=sort_key
+            )
+            await wait_for_standalone_events(
+                standalone_indexer_url,
+                sorted_state1_before_peer,
+                "Router 1",
+                "Standalone A",
+            )
+            logger.info("Standalone A matches Router 1 before Indexer B recovery")
 
         # Create second runtime and endpoint for router 2
         logger.info("Creating second KV router with its own runtime")
@@ -1777,16 +1848,6 @@ def _test_router_indexers_sync(
         state1 = json.loads(state1_json)
         state2 = json.loads(state2_json)
 
-        def sort_key(event):
-            data = event["event"]["data"]["stored"]
-            blocks = data["blocks"]
-            first_block = blocks[0]
-            return (
-                event["worker_id"],
-                first_block["tokens_hash"],
-                data["parent_hash"],
-            )
-
         sorted_state1 = sorted(state1, key=sort_key)
         sorted_state2 = sorted(state2, key=sort_key)
 
@@ -1798,52 +1859,6 @@ def _test_router_indexers_sync(
 
         # Verify standalone HTTP indexers build the same tree (via ZMQ)
         if standalone_indexer_url:
-            # /dump returns {model:tenant -> {"block_size": N, "events": [...]}}
-            expected_key = f"{model_name}:default"
-
-            async def fetch_standalone_events(session, indexer_url, indexer_label):
-                async with session.get(f"{indexer_url}/dump") as resp:
-                    assert resp.status == 200, f"GET /dump failed: {resp.status}"
-                    dump = await resp.json()
-
-                assert expected_key in dump, (
-                    f"{indexer_label} missing dump key '{expected_key}', "
-                    f"got keys={list(dump.keys())}"
-                )
-                for k, v in dump.items():
-                    assert (
-                        isinstance(v, dict) and "events" in v
-                    ), f"{indexer_label} dump key '{k}' returned unexpected format: {v}"
-                return sorted(dump[expected_key]["events"], key=sort_key)
-
-            async def wait_for_standalone_events(
-                indexer_url, expected_events, expected_label, actual_label
-            ):
-                last_error = None
-                async with aiohttp.ClientSession() as session:
-                    for attempt in range(50):
-                        actual_events = await fetch_standalone_events(
-                            session, indexer_url, actual_label
-                        )
-                        logger.info(
-                            f"{actual_label} has {len(actual_events)} events "
-                            f"(attempt {attempt + 1})"
-                        )
-                        try:
-                            assert_event_dumps_equal(
-                                expected_events,
-                                actual_events,
-                                expected_label,
-                                actual_label,
-                            )
-                            return actual_events
-                        except AssertionError as exc:
-                            last_error = exc
-                            await asyncio.sleep(0.2)
-
-                assert last_error is not None
-                raise last_error
-
             sorted_standalone_a = await wait_for_standalone_events(
                 standalone_indexer_url, sorted_state1, "Router 1", "Standalone A"
             )

--- a/tests/router/common.py
+++ b/tests/router/common.py
@@ -1547,14 +1547,14 @@ def _test_router_indexers_sync(
             last_error = None
             async with aiohttp.ClientSession() as session:
                 for attempt in range(50):
-                    actual_events = await fetch_standalone_events(
-                        session, indexer_url, actual_label
-                    )
-                    logger.info(
-                        f"{actual_label} has {len(actual_events)} events "
-                        f"(attempt {attempt + 1})"
-                    )
                     try:
+                        actual_events = await fetch_standalone_events(
+                            session, indexer_url, actual_label
+                        )
+                        logger.info(
+                            f"{actual_label} has {len(actual_events)} events "
+                            f"(attempt {attempt + 1})"
+                        )
                         assert_event_dumps_equal(
                             expected_events,
                             actual_events,
@@ -1562,7 +1562,7 @@ def _test_router_indexers_sync(
                             actual_label,
                         )
                         return actual_events
-                    except AssertionError as exc:
+                    except (AssertionError, aiohttp.ClientError) as exc:
                         last_error = exc
                         await asyncio.sleep(0.2)
 


### PR DESCRIPTION
Wait for Standalone A to match Router 1 before launching Indexer B so peer recovery snapshots a fully replayed indexer state.

Example CI failures: 
```
FAILED tests/router/test_router_e2e_with_mockers.py::test_indexers_sync[nats_core] - AssertionError: Standalone A has 103 events, Standalone B has 93 events
```
and
```
FAILED tests/router/test_router_e2e_with_mockers.py::test_indexers_sync[file] - AssertionError: Router 1 has 78 events, Standalone A has 71 events
```


<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9494" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by refactoring shared verification logic for router indexers, reducing code duplication and enhancing test sequencing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9494)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->