### PR TITLE
docs: document DGDR DGD env overrides

### DIFF
--- a/docs/components/profiler/profiler-examples.md
+++ b/docs/components/profiler/profiler-examples.md
@@ -163,7 +163,7 @@ spec:
               effect: NoSchedule
 ```
 
-**Override the generated DynamoGraphDeployment** (e.g., to use a custom worker image):
+**Override the generated DynamoGraphDeployment** (e.g., to inject worker environment variables):
 
 ```yaml
 spec:
@@ -173,9 +173,12 @@ spec:
       apiVersion: nvidia.com/v1alpha1
       kind: DynamoGraphDeployment
       spec:
+        envs:
+          - name: TRITON_PTXAS_PATH
+            value: "/usr/local/cuda/bin/ptxas"
         services:
           VllmWorker:
-            extraEnvs:
+            envs:
               - name: CUSTOM_ENV
                 value: "my-value"
 ```

--- a/docs/kubernetes/dgdr.md
+++ b/docs/kubernetes/dgdr.md
@@ -77,6 +77,55 @@ spec:
 
 For the complete CRD spec, see the [API Reference](api-reference.md).
 
+### Generated DGD Overrides
+
+Use `spec.overrides.dgd` when the generated `DynamoGraphDeployment` needs a
+field that DGDR does not expose directly. The value is a partial
+`nvidia.com/v1alpha1` DGD object that is merged into the profiler-generated
+deployment after Dynamo selects a configuration.
+
+For example, to inject an environment variable into every generated service:
+
+```yaml
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeploymentRequest
+metadata:
+  name: qwen3-sglang
+spec:
+  model: Qwen/Qwen3-30B-A3B
+  backend: sglang
+  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.1.1"
+  overrides:
+    dgd:
+      apiVersion: nvidia.com/v1alpha1
+      kind: DynamoGraphDeployment
+      spec:
+        envs:
+          - name: TRITON_PTXAS_PATH
+            value: /usr/local/cuda/bin/ptxas
+```
+
+Use `spec.envs` for variables that should apply to all generated services. To
+target a single service, override that service's `envs` entry instead:
+
+```yaml
+spec:
+  overrides:
+    dgd:
+      apiVersion: nvidia.com/v1alpha1
+      kind: DynamoGraphDeployment
+      spec:
+        services:
+          decode:  # replace with the generated service name
+            envs:
+              - name: CUSTOM_WORKER_ENV
+                value: "enabled"
+```
+
+> [!NOTE]
+> `overrides.profilingJob` only customizes the profiling Job. Use
+> `overrides.dgd` for settings that must appear on the deployed worker pods.
+
 ### SKU Format
 
 When providing hardware configuration manually, use lowercase underscore format:


### PR DESCRIPTION
## Summary

Document how to use `spec.overrides.dgd` on a DGDR to inject environment variables into the generated DGD worker pods.

## Changes

- Added a DGDR reference section with global `spec.envs` and service-specific `envs` examples.
- Updated the profiler examples to use the current DGD `envs` field instead of stale `extraEnvs`.

Closes: #6794 
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9496" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Profiler Examples documentation to clarify configuration options for injecting worker environment variables through overrides.
  * Added "Generated DGD Overrides" section to Kubernetes documentation with practical examples for environment variable injection across services and targeting specific deployments, including override behavior guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9496)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->