### PR TITLE
fix(operator): gate DCD readiness on observed generation

### DIFF
--- a/deploy/operator/api/v1alpha1/dynamocomponentdeployment_types.go
+++ b/deploy/operator/api/v1alpha1/dynamocomponentdeployment_types.go
@@ -264,8 +264,10 @@ func init() {
 }
 
 func (s *DynamoComponentDeployment) IsReady() (bool, string) {
-	ready, reason := s.Status.IsReady()
-	return ready, reason
+	if s.Status.ObservedGeneration < s.Generation {
+		return false, fmt.Sprintf("spec not yet processed: generation=%d, observedGeneration=%d", s.Generation, s.Status.ObservedGeneration)
+	}
+	return s.Status.IsReady()
 }
 
 // GetState returns "ready" or "not_ready" based on conditions

--- a/deploy/operator/api/v1beta1/dynamocomponentdeployment_types.go
+++ b/deploy/operator/api/v1beta1/dynamocomponentdeployment_types.go
@@ -253,8 +253,11 @@ func init() {
 	SchemeBuilder.Register(&DynamoComponentDeployment{}, &DynamoComponentDeploymentList{})
 }
 
-// IsReady returns true if the component is `Available`.
+// IsReady returns true if the component has processed its latest spec and is `Available`.
 func (s *DynamoComponentDeployment) IsReady() (bool, string) {
+	if s.Status.ObservedGeneration < s.Generation {
+		return false, fmt.Sprintf("spec not yet processed: generation=%d, observedGeneration=%d", s.Generation, s.Status.ObservedGeneration)
+	}
 	return s.Status.IsReady()
 }
 

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -148,6 +148,33 @@ func TestIsDeploymentReady(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "not ready (old replicas remain after update)",
+			args: args{
+				deployment: &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Generation: 2,
+					},
+					Spec: appsv1.DeploymentSpec{
+						Replicas: &[]int32{2}[0],
+					},
+					Status: appsv1.DeploymentStatus{
+						ObservedGeneration: 2,
+						UpdatedReplicas:    2,
+						ReadyReplicas:      2,
+						AvailableReplicas:  2,
+						Replicas:           3,
+						Conditions: []appsv1.DeploymentCondition{
+							{
+								Type:   appsv1.DeploymentAvailable,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
 			name: "ready",
 			args: args{
 				deployment: &appsv1.Deployment{

--- a/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
@@ -2557,6 +2557,68 @@ func Test_reconcileDynamoComponentsDeployments(t *testing.T) {
 			},
 		},
 		{
+			name: "single service - DCD stale observed generation stays pending",
+			dgdSpec: v1alpha1.DynamoGraphDeploymentSpec{
+				BackendFramework: "vllm",
+				Services: map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{
+					"frontend": {
+						ServiceName:     "frontend",
+						DynamoNamespace: ptr.To("default"),
+						ComponentType:   string(commonconsts.ComponentTypeFrontend),
+						Replicas:        ptr.To(int32(2)),
+					},
+				},
+			},
+			existingDCDs: []client.Object{
+				betaDCD(t, &v1alpha1.DynamoComponentDeployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "test-dgd-frontend",
+						Namespace:  "default",
+						Generation: 2,
+					},
+					Spec: v1alpha1.DynamoComponentDeploymentSpec{
+						BackendFramework: "vllm",
+						DynamoComponentDeploymentSharedSpec: v1alpha1.DynamoComponentDeploymentSharedSpec{
+							ServiceName: "frontend",
+							Replicas:    ptr.To(int32(2)),
+						},
+					},
+					Status: v1alpha1.DynamoComponentDeploymentStatus{
+						ObservedGeneration: 1,
+						Conditions: []metav1.Condition{
+							{
+								Type:   v1alpha1.DynamoGraphDeploymentConditionTypeAvailable,
+								Status: metav1.ConditionTrue,
+							},
+						},
+						Service: &v1alpha1.ServiceReplicaStatus{
+							ComponentKind:     v1alpha1.ComponentKindDeployment,
+							ComponentNames:    []string{"test-dgd-frontend-deployment"},
+							Replicas:          2,
+							UpdatedReplicas:   2,
+							ReadyReplicas:     ptr.To(int32(2)),
+							AvailableReplicas: ptr.To(int32(2)),
+						},
+					},
+				}),
+			},
+			wantReconcileResult: ReconcileResult{
+				State:   v1beta1.DGDStatePending,
+				Reason:  "some_resources_are_not_ready",
+				Message: "Resources not ready: test-dgd-frontend: spec not yet processed: generation=2, observedGeneration=1",
+				ComponentStatus: map[string]v1beta1.ComponentReplicaStatus{
+					"frontend": {
+						ComponentKind:     v1beta1.ComponentKindDeployment,
+						ComponentNames:    []string{"test-dgd-frontend-deployment"},
+						Replicas:          2,
+						UpdatedReplicas:   2,
+						ReadyReplicas:     ptr.To(int32(2)),
+						AvailableReplicas: ptr.To(int32(2)),
+					},
+				},
+			},
+		},
+		{
 			name: "single service - DCD not ready (Available condition = False)",
 			dgdSpec: v1alpha1.DynamoGraphDeploymentSpec{
 				BackendFramework: "vllm",


### PR DESCRIPTION
## Summary
- Prevent DGD from reporting `Successful` using stale child DCD status after a spec update
- Gate DCD readiness on `status.observedGeneration >= metadata.generation`
- Add regression coverage for stale DCD status and old Deployment replicas during rollout

Closes #3567 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Component deployment readiness checks now verify that configuration changes have been fully processed before marking a deployment as ready, preventing premature ready status when pending updates exist.

* **Tests**
  * Added test coverage for deployments with pending configuration updates and stale processing states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9499)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->