### PR TITLE
fix(trtllm): skip NIXL initialization in aggregated mode

### DIFF
--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -449,9 +449,7 @@ async def init_llm_worker(
             )
             connector = None
     else:
-        logging.info(
-            "Skipping NIXL Connect initialization (aggregated mode)."
-        )
+        logging.info("Skipping NIXL Connect initialization (aggregated mode).")
 
     dump_config(
         config.dump_config_to, {"engine_args": engine_args, "dynamo_args": config}

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -436,7 +436,18 @@ async def init_llm_worker(
         default_sampling_params.detokenize = False
 
     connector = None
-    if config.disaggregation_mode != DisaggregationMode.AGGREGATED:
+    needs_nixl = config.disaggregation_mode != DisaggregationMode.AGGREGATED or (
+        config.modality == Modality.MULTIMODAL
+        and (
+            config.frontend_decoding
+            or config.disaggregation_mode == DisaggregationMode.ENCODE
+            or (
+                config.disaggregation_mode == DisaggregationMode.PREFILL
+                and bool(config.encode_endpoint)
+            )
+        )
+    )
+    if needs_nixl:
         try:
             logging.info("Initializing NIXL Connect.")
             connector = nixl_connect.Connector()

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -436,8 +436,22 @@ async def init_llm_worker(
         default_sampling_params.detokenize = False
 
     connector = None
-    logging.info("Initializing NIXL Connect.")
-    connector = nixl_connect.Connector()
+    if config.disaggregation_mode != DisaggregationMode.AGGREGATED:
+        try:
+            logging.info("Initializing NIXL Connect.")
+            connector = nixl_connect.Connector()
+            await connector._create_connection()
+        except Exception:
+            logging.warning(
+                "Failed to initialize NIXL Connect; "
+                "KV-cache transfer will be unavailable.",
+                exc_info=True,
+            )
+            connector = None
+    else:
+        logging.info(
+            "Skipping NIXL Connect initialization (aggregated mode)."
+        )
 
     dump_config(
         config.dump_config_to, {"engine_args": engine_args, "dynamo_args": config}


### PR DESCRIPTION
## Summary

- Skip `nixl_connect.Connector()` creation entirely in AGGREGATED mode — it is never used for KV-cache transfer in single-node deployments
- Wrap disaggregated-mode NIXL init in try/except with an eager `_create_connection()` probe so failures (e.g. no IB/RDMA hardware) surface at init time with a warning instead of crashing on first request with an unhandled `nixlBackendError`
- Downstream handlers already handle `connector is None` gracefully (e.g. `PrefillHandler` falls back to local embedding loading)

## Test plan

- [x] Repro 1 verified: PREFILL mode + `UCX_TLS=rc,dc` (no IB) — before: `nixlBackendError` crash; after: warning logged, `connector=None`, worker continues
- [x] Repro 2 verified: AGGREGATED mode — before: unnecessary `Connector()` created; after: skipped with log message
- [x] Existing unit tests: 9/9 sync tests pass (5 async tests have pre-existing `pytest-asyncio` config issue in container, unrelated)

Closes #4734
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9501" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error handling for distributed system connector initialization—system now gracefully handles connection failures and continues operation.
  * Improved diagnostic logging for troubleshooting connection issues based on system configuration mode.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9501)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->