### PR TITLE
feat(frontend): Support disagg with vllm processor

### DIFF
--- a/components/src/dynamo/frontend/main.py
+++ b/components/src/dynamo/frontend/main.py
@@ -53,8 +53,6 @@ MIN_INITIAL_WORKERS_ENV = "DYN_ROUTER_MIN_INITIAL_WORKERS"
 
 
 def setup_engine_factory(
-    runtime: DistributedRuntime,
-    router_config: RouterConfig,
     config: FrontendConfig,
     vllm_flags: Namespace,
 ) -> "EngineFactory":
@@ -64,7 +62,7 @@ def setup_engine_factory(
     """
     from .vllm_processor import EngineFactory
 
-    return EngineFactory(runtime, router_config, config, vllm_flags)
+    return EngineFactory(config, vllm_flags)
 
 
 def setup_sglang_engine_factory(
@@ -282,7 +280,7 @@ async def async_main():
             vllm_flags is not None
         ), "vllm_flags is required when chat processor is vllm"
         chat_engine_factory = setup_engine_factory(
-            runtime, router_config, config, vllm_flags
+            config, vllm_flags
         ).chat_engine_factory
         kwargs["chat_engine_factory"] = chat_engine_factory
     elif config.chat_processor == "sglang":

--- a/components/src/dynamo/frontend/sglang_processor.py
+++ b/components/src/dynamo/frontend/sglang_processor.py
@@ -24,6 +24,7 @@ from dynamo.llm import (
     KvRouter,
     ModelCardInstanceId,
     PythonAsyncEngine,
+    RoutedEngine,
     RouterConfig,
     RouterMode,
     fetch_model,
@@ -629,7 +630,7 @@ class SglangEngineFactory:
         self,
         instance_id: ModelCardInstanceId,
         mdc: ModelDeploymentCard,
-        routed_engine: Any | None,
+        routed_engine: RoutedEngine,
     ) -> PythonAsyncEngine:
         """Called by Rust when a model is discovered."""
         model_type = mdc.model_type()

--- a/components/src/dynamo/frontend/sglang_processor.py
+++ b/components/src/dynamo/frontend/sglang_processor.py
@@ -629,6 +629,7 @@ class SglangEngineFactory:
         self,
         instance_id: ModelCardInstanceId,
         mdc: ModelDeploymentCard,
+        routed_engine: Any | None,
     ) -> PythonAsyncEngine:
         """Called by Rust when a model is discovered."""
         model_type = mdc.model_type()

--- a/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
@@ -174,12 +174,10 @@ class TestReasoningParserMetadata:
         assert parser_kwargs == {"chat_template_kwargs": {"reasoning_effort": "high"}}
 
     def test_kv_router_copies_reasoning_metadata_to_extra_args(self):
-        from dynamo.frontend.vllm_processor import (
-            _copy_reasoning_metadata_to_extra_args,
-        )
+        from dynamo.frontend.vllm_processor import _inject_routing_metadata
 
         kv_kwargs = {"extra_args": {"mm_hashes": [123]}}
-        _copy_reasoning_metadata_to_extra_args(
+        _inject_routing_metadata(
             {
                 "reasoning_ended": False,
                 "reasoning_parser_kwargs": {
@@ -196,3 +194,172 @@ class TestReasoningParserMetadata:
                 "chat_template_kwargs": {"reasoning_effort": "high"}
             },
         }
+
+
+async def _async_iter(items):
+    for item in items:
+        yield item
+
+
+class _FakeRoutedEngine:
+    def __init__(self, items=None):
+        self.items = items or [{"token_ids": [101], "index": 0}]
+        self.requests = []
+        self.kwargs = []
+
+    async def generate(self, preprocessed, **kwargs):
+        self.requests.append(preprocessed)
+        self.kwargs.append(kwargs)
+        return _async_iter(self.items)
+
+
+class _FakeOutputProcessor:
+    def __init__(self):
+        self.request_states = {}
+        self.added_requests = []
+        self.aborted_requests = []
+
+    def add_request(self, preproc, *args, **kwargs):
+        self.added_requests.append((preproc, args, kwargs))
+        self.request_states[preproc.request_id] = object()
+
+    def process_outputs(self, outputs):
+        return SimpleNamespace(
+            reqs_to_abort=[],
+            request_outputs=[SimpleNamespace(outputs=[SimpleNamespace(index=0)])],
+        )
+
+    def abort_requests(self, request_ids, internal=False):
+        self.aborted_requests.append((request_ids, internal))
+        for request_id in request_ids:
+            self.request_states.pop(request_id, None)
+
+
+class _FakePostProcessor:
+    def process_output(self, output):
+        return {
+            "index": output.index,
+            "delta": {"content": "x"},
+            "finish_reason": None,
+        }
+
+
+@pytest.fixture
+def vllm_processor_module(monkeypatch):
+    import dynamo.frontend.vllm_processor as module
+
+    class FakeEngineCoreOutput:
+        __struct_fields__ = ()
+
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    monkeypatch.setattr(module, "EngineCoreOutput", FakeEngineCoreOutput)
+    monkeypatch.setattr(module._nvtx, "start_range", lambda *args, **kwargs: object())
+    monkeypatch.setattr(module._nvtx, "end_range", lambda rng: None)
+    return module
+
+
+def _make_processor(module, routed_engine, router, *, is_kv_router):
+    processor = module.VllmProcessor.__new__(module.VllmProcessor)
+    processor.routed_engine = routed_engine
+    processor.router = router
+    processor.is_kv_router = is_kv_router
+    processor.output_processor = _FakeOutputProcessor()
+    return processor
+
+
+def _base_preproc():
+    return {
+        "model": MODEL,
+        "token_ids": [1, 2, 3],
+        "stop_conditions": {"max_tokens": 4},
+        "sampling_options": {"temperature": 0.0},
+        "output_options": {},
+        "eos_token_ids": [],
+        "annotations": [],
+        "routing": None,
+    }
+
+
+async def _run_generate(processor, preproc, *, mm_routing_info=None, context=None):
+    vllm_preproc = SimpleNamespace(
+        sampling_params=SimpleNamespace(n=1),
+        request_id="vllm-request",
+        external_req_id=None,
+    )
+    post_processors = {0: _FakePostProcessor()}
+
+    return [
+        item
+        async for item in processor._generate_and_stream(
+            "request-id",
+            {"model": MODEL},
+            preproc,
+            preproc["token_ids"],
+            vllm_preproc,
+            post_processors,
+            mm_routing_info=mm_routing_info,
+            context=context,
+        )
+    ]
+
+
+class TestRoutedEnginePath:
+    @pytest.mark.asyncio
+    async def test_routed_engine_gets_extra_args_metadata(self, vllm_processor_module):
+        routed_engine = _FakeRoutedEngine()
+        processor = _make_processor(
+            vllm_processor_module,
+            routed_engine,
+            None,
+            is_kv_router=True,
+        )
+        preproc = _base_preproc()
+        preproc["extra_args"] = {"mm_hashes": [123]}
+        preproc["reasoning_ended"] = False
+        preproc["reasoning_parser_kwargs"] = {
+            "chat_template_kwargs": {"reasoning_effort": "high"}
+        }
+        preproc["mm_processor_kwargs"] = {"use_audio_in_video": True}
+
+        await _run_generate(processor, preproc)
+
+        assert routed_engine.requests[0]["extra_args"] == {
+            "mm_hashes": [123],
+            "reasoning_ended": False,
+            "reasoning_parser_kwargs": {
+                "chat_template_kwargs": {"reasoning_effort": "high"}
+            },
+            "mm_processor_kwargs": {"use_audio_in_video": True},
+        }
+
+    @pytest.mark.asyncio
+    async def test_routed_stream_produces_openai_chunks(self, vllm_processor_module):
+        routed_engine = _FakeRoutedEngine(
+            [{"token_ids": [101], "index": 0, "finish_reason": None}]
+        )
+        processor = _make_processor(
+            vllm_processor_module,
+            routed_engine,
+            None,
+            is_kv_router=False,
+        )
+
+        chunks = await _run_generate(processor, _base_preproc())
+
+        assert chunks == [
+            {
+                "id": "request-id",
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"content": "x"},
+                        "finish_reason": None,
+                    }
+                ],
+                "created": chunks[0]["created"],
+                "model": MODEL,
+                "object": "chat.completion.chunk",
+            }
+        ]

--- a/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
@@ -285,11 +285,9 @@ def vllm_processor_module(monkeypatch):
     return module
 
 
-def _make_processor(module, routed_engine, router, *, is_kv_router):
+def _make_processor(module, routed_engine):
     processor = module.VllmProcessor.__new__(module.VllmProcessor)
     processor.routed_engine = routed_engine
-    processor.router = router
-    processor.is_kv_router = is_kv_router
     processor.output_processor = _FakeOutputProcessor()
     return processor
 
@@ -334,12 +332,7 @@ class TestRoutedEnginePath:
     @pytest.mark.asyncio
     async def test_routed_engine_gets_extra_args_metadata(self, vllm_processor_module):
         routed_engine = _FakeRoutedEngine()
-        processor = _make_processor(
-            vllm_processor_module,
-            routed_engine,
-            None,
-            is_kv_router=True,
-        )
+        processor = _make_processor(vllm_processor_module, routed_engine)
         preproc = _base_preproc()
         preproc["extra_args"] = {"mm_hashes": [123]}
         preproc["reasoning_ended"] = False
@@ -364,12 +357,7 @@ class TestRoutedEnginePath:
         routed_engine = _FakeRoutedEngine(
             [{"token_ids": [101], "index": 0, "finish_reason": None}]
         )
-        processor = _make_processor(
-            vllm_processor_module,
-            routed_engine,
-            None,
-            is_kv_router=False,
-        )
+        processor = _make_processor(vllm_processor_module, routed_engine)
 
         chunks = await _run_generate(processor, _base_preproc())
 

--- a/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
@@ -201,9 +201,34 @@ async def _async_iter(items):
         yield item
 
 
+class _FakeRoutedItem:
+    """Mimics a real routed-engine item with is_error/comments/data methods."""
+
+    def __init__(self, data, is_error=False, comments=None):
+        self._data = data
+        self._is_error = is_error
+        self._comments = comments or []
+
+    def is_error(self):
+        return self._is_error
+
+    def comments(self):
+        return self._comments
+
+    def data(self):
+        return self._data
+
+
 class _FakeRoutedEngine:
     def __init__(self, items=None):
-        self.items = items or [{"token_ids": [101], "index": 0}]
+        if items is None:
+            items = [_FakeRoutedItem({"token_ids": [101], "index": 0})]
+        else:
+            items = [
+                item if isinstance(item, _FakeRoutedItem) else _FakeRoutedItem(item)
+                for item in items
+            ]
+        self.items = items
         self.requests = []
         self.kwargs = []
 

--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -629,7 +629,7 @@ class VllmProcessor:
             else:
                 with _nvtx.annotate("mm_frontend:client_generate", color="red"):
                     dynamo_stream = await self.router.generate(
-                        dynamo_preproc, annotated=False
+                        dynamo_preproc, annotated=False, context=context
                     )
 
             rng_stream = _nvtx.start_range(

--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -104,25 +104,27 @@ def _build_reasoning_parser_metadata(
     return reasoning_parser.is_reasoning_end(prompt_token_ids), parser_kwargs
 
 
-def _copy_reasoning_metadata_to_extra_args(
-    dynamo_preproc: dict[str, Any], kv_kwargs: dict[str, Any]
+def _inject_routing_metadata(
+    dynamo_preproc: dict[str, Any],
+    target: dict[str, Any],
+    mm_routing_info: dict[str, Any] | None = None,
 ) -> None:
-    reasoning_extra_args: dict[str, Any] = {}
-    if "reasoning_ended" in dynamo_preproc:
-        reasoning_extra_args["reasoning_ended"] = dynamo_preproc["reasoning_ended"]
-    if "reasoning_parser_kwargs" in dynamo_preproc:
-        reasoning_extra_args["reasoning_parser_kwargs"] = dynamo_preproc[
-            "reasoning_parser_kwargs"
-        ]
+    extra_updates: dict[str, Any] = {}
+    for key in ("reasoning_ended", "reasoning_parser_kwargs"):
+        if key in dynamo_preproc:
+            extra_updates[key] = dynamo_preproc[key]
+    if dynamo_preproc.get("mm_processor_kwargs") is not None:
+        extra_updates["mm_processor_kwargs"] = dynamo_preproc["mm_processor_kwargs"]
 
-    if not reasoning_extra_args:
-        return
+    if extra_updates:
+        extra_args = target.get("extra_args")
+        if not isinstance(extra_args, dict):
+            extra_args = {}
+            target["extra_args"] = extra_args
+        extra_args.update(extra_updates)
 
-    extra_args = kv_kwargs.get("extra_args")
-    if not isinstance(extra_args, dict):
-        extra_args = {}
-        kv_kwargs["extra_args"] = extra_args
-    extra_args.update(reasoning_extra_args)
+    if mm_routing_info is not None:
+        target["mm_routing_info"] = mm_routing_info
 
 
 class VllmProcessor:
@@ -134,6 +136,7 @@ class VllmProcessor:
         output_processor: OutputProcessor,
         tool_parser_class: type[ToolParser] | None,
         reasoning_parser_class: type[ReasoningParser] | None,
+        routed_engine: Any | None = None,
         block_size: int = 16,
         enable_auto_tool_choice: bool = False,
     ):
@@ -141,6 +144,7 @@ class VllmProcessor:
         self.input_processor = input_processor
         self.router = router
         self.is_kv_router = isinstance(router, KvRouter)
+        self.routed_engine = routed_engine
         self.output_processor = output_processor
         self.tool_parser_class = tool_parser_class
         self.reasoning_parser_class = reasoning_parser_class
@@ -291,18 +295,18 @@ class VllmProcessor:
     # it has a lot of fields.
     # request: dynamo.NVCreateChatCompletionRequest
     async def generator(
-        self, request: dict[str, Any]
+        self, request: dict[str, Any], context: Any | None = None
     ) -> AsyncGenerator[dict[str, Any], None]:
         """
         Run a single request through the engine. Does pre and post processing on this machine, delegates
         model inference to a backend using the router.
         """
         with _nvtx.annotate("mm_frontend:generator", color="blue"):
-            async for item in self._generator_inner(request):
+            async for item in self._generator_inner(request, context=context):
                 yield item
 
     async def _generator_inner(
-        self, request: dict[str, Any]
+        self, request: dict[str, Any], context: Any | None = None
     ) -> AsyncGenerator[dict[str, Any], None]:
         request_id = random_uuid()
 
@@ -513,6 +517,7 @@ class VllmProcessor:
                 vllm_preproc,
                 post_processors,
                 mm_routing_info=mm_routing_info,
+                context=context,
             ):
                 yield item
         finally:
@@ -528,6 +533,7 @@ class VllmProcessor:
         vllm_preproc: EngineCoreRequest,
         post_processors: dict[int, StreamingPostProcessor],
         mm_routing_info: dict[str, Any] | None = None,
+        context: Any | None = None,
     ) -> AsyncGenerator[dict[str, Any], None]:
         sp = vllm_preproc.sampling_params
         output_request_ids: dict[int, str]
@@ -577,53 +583,54 @@ class VllmProcessor:
                 registered_request_ids.append(child_request_id)
 
         try:
-            rng_route = _nvtx.start_range("mm_frontend:kv_router_generate", color="red")
-            if self.is_kv_router:
-                kv_kwargs: dict[str, Any] = {
-                    "token_ids": tokens,
-                    "model": dynamo_preproc["model"],
-                    "stop_conditions": dynamo_preproc["stop_conditions"],
-                    "sampling_options": dynamo_preproc["sampling_options"],
-                    "output_options": dynamo_preproc["output_options"],
-                    "multi_modal_data": dynamo_preproc.get("multi_modal_data"),
-                }
-                if dynamo_preproc.get("extra_args"):
-                    kv_kwargs["extra_args"] = dynamo_preproc["extra_args"]
-                    ea = dynamo_preproc["extra_args"]
-                    logger.debug(
-                        "[mm-routing] extra_args keys=%s, has_nixl=%s, "
-                        "n_hashes=%d, n_placeholders=%d",
-                        list(ea.keys()),
-                        "mm_kwargs_nixl" in ea,
-                        len(ea.get("mm_hashes", [])),
-                        len(ea.get("mm_placeholders", [])),
-                    )
-                _copy_reasoning_metadata_to_extra_args(dynamo_preproc, kv_kwargs)
-                # Forward mm_processor_kwargs (e.g. use_audio_in_video) to backend.
-                mm_proc_kwargs = dynamo_preproc.get("mm_processor_kwargs")
-                if mm_proc_kwargs is not None:
-                    if "extra_args" not in kv_kwargs or kv_kwargs["extra_args"] is None:
-                        kv_kwargs["extra_args"] = {}
-                    kv_kwargs["extra_args"]["mm_processor_kwargs"] = mm_proc_kwargs
-                if mm_routing_info is not None:
-                    kv_kwargs["mm_routing_info"] = mm_routing_info
-                    logger.debug(
-                        "[mm-routing] KvRouter.generate() called with "
-                        "mm_routing_info (%d routing tokens, %d blocks)",
-                        len(mm_routing_info.get("routing_token_ids", [])),
-                        len(mm_routing_info.get("block_mm_infos", [])),
-                    )
-                else:
-                    logger.debug(
-                        "[mm-routing] KvRouter.generate() called without "
-                        "mm_routing_info (text-only)"
-                    )
-                dynamo_stream = await self.router.generate(**kv_kwargs)
-            else:
-                dynamo_stream = await self.router.generate(
-                    dynamo_preproc, annotated=False
+            if self.routed_engine is not None:
+                _inject_routing_metadata(
+                    dynamo_preproc, dynamo_preproc, mm_routing_info
                 )
-            _nvtx.end_range(rng_route)
+                with _nvtx.annotate("mm_frontend:routed_engine_generate", color="red"):
+                    dynamo_stream = await self.routed_engine.generate(
+                        dynamo_preproc, context=context
+                    )
+            elif self.is_kv_router:
+                with _nvtx.annotate("mm_frontend:kv_router_generate", color="red"):
+                    kv_kwargs: dict[str, Any] = {
+                        "token_ids": tokens,
+                        "model": dynamo_preproc["model"],
+                        "stop_conditions": dynamo_preproc["stop_conditions"],
+                        "sampling_options": dynamo_preproc["sampling_options"],
+                        "output_options": dynamo_preproc["output_options"],
+                        "multi_modal_data": dynamo_preproc.get("multi_modal_data"),
+                    }
+                    if dynamo_preproc.get("extra_args"):
+                        kv_kwargs["extra_args"] = dynamo_preproc["extra_args"]
+                        ea = dynamo_preproc["extra_args"]
+                        logger.debug(
+                            "[mm-routing] extra_args keys=%s, has_nixl=%s, "
+                            "n_hashes=%d, n_placeholders=%d",
+                            list(ea.keys()),
+                            "mm_kwargs_nixl" in ea,
+                            len(ea.get("mm_hashes", [])),
+                            len(ea.get("mm_placeholders", [])),
+                        )
+                    _inject_routing_metadata(dynamo_preproc, kv_kwargs, mm_routing_info)
+                    if mm_routing_info is not None:
+                        logger.debug(
+                            "[mm-routing] KvRouter.generate() called with "
+                            "mm_routing_info (%d routing tokens, %d blocks)",
+                            len(mm_routing_info.get("routing_token_ids", [])),
+                            len(mm_routing_info.get("block_mm_infos", [])),
+                        )
+                    else:
+                        logger.debug(
+                            "[mm-routing] KvRouter.generate() called without "
+                            "mm_routing_info (text-only)"
+                        )
+                    dynamo_stream = await self.router.generate(**kv_kwargs)
+            else:
+                with _nvtx.annotate("mm_frontend:client_generate", color="red"):
+                    dynamo_stream = await self.router.generate(
+                        dynamo_preproc, annotated=False
+                    )
 
             rng_stream = _nvtx.start_range(
                 "mm_frontend:stream_response", color="purple"
@@ -754,6 +761,7 @@ class EngineFactory:
         self,
         instance_id: ModelCardInstanceId,
         mdc: ModelDeploymentCard,
+        routed_engine: Any | None,
     ) -> PythonAsyncEngine:
         """
         Called by Rust when a model is discovered.
@@ -883,6 +891,7 @@ class EngineFactory:
             output_processor,
             tool_parser_class,
             reasoning_parser_class,
+            routed_engine=routed_engine,
             block_size=block_size,
             enable_auto_tool_choice=enable_auto_tool_choice,
         )

--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -34,15 +34,7 @@ from dynamo.common.multimodal.mm_kwargs_transfer import (
 from dynamo.common.multimodal.routing_utils import build_mm_routing_info_from_features
 from dynamo.common.utils import nvtx_utils as _nvtx
 from dynamo.frontend.frontend_args import FrontendConfig
-from dynamo.llm import (
-    KvRouter,
-    ModelCardInstanceId,
-    PythonAsyncEngine,
-    RouterConfig,
-    RouterMode,
-    fetch_model,
-)
-from dynamo.runtime import Client, DistributedRuntime
+from dynamo.llm import ModelCardInstanceId, PythonAsyncEngine, RoutedEngine, fetch_model
 
 from .prepost import StreamingPostProcessor, preprocess_chat_request
 from .utils import (
@@ -132,18 +124,15 @@ class VllmProcessor:
         self,
         tokenizer: TokenizerLike,
         input_processor: InputProcessor,
-        router: Any,  # Client or KvRouter
         output_processor: OutputProcessor,
         tool_parser_class: type[ToolParser] | None,
         reasoning_parser_class: type[ReasoningParser] | None,
-        routed_engine: Any | None = None,
+        routed_engine: RoutedEngine,
         block_size: int = 16,
         enable_auto_tool_choice: bool = False,
     ):
         self.tokenizer = tokenizer
         self.input_processor = input_processor
-        self.router = router
-        self.is_kv_router = isinstance(router, KvRouter)
         self.routed_engine = routed_engine
         self.output_processor = output_processor
         self.tool_parser_class = tool_parser_class
@@ -198,7 +187,7 @@ class VllmProcessor:
         nixl_transferred = False
 
         rng_routing = _nvtx.start_range("mm_frontend:build_routing_info", color="cyan")
-        if self.is_kv_router and vllm_preproc.mm_features:
+        if vllm_preproc.mm_features:
             mm_routing_info = build_mm_routing_info_from_features(
                 vllm_preproc.mm_features,
                 prompt_token_ids=list(vllm_preproc.prompt_token_ids),
@@ -285,7 +274,7 @@ class VllmProcessor:
                     )
                     cleanup_items = []
 
-        elif self.is_kv_router:
+        else:
             logger.debug("[mm-routing] No mm_features — text-only request")
         _nvtx.end_range(rng_routing)
 
@@ -583,73 +572,27 @@ class VllmProcessor:
                 registered_request_ids.append(child_request_id)
 
         try:
-            if self.routed_engine is not None:
-                _inject_routing_metadata(
-                    dynamo_preproc, dynamo_preproc, mm_routing_info
+            _inject_routing_metadata(dynamo_preproc, dynamo_preproc, mm_routing_info)
+            with _nvtx.annotate("mm_frontend:routed_engine_generate", color="red"):
+                dynamo_stream = await self.routed_engine.generate(
+                    dynamo_preproc, context=context
                 )
-                with _nvtx.annotate("mm_frontend:routed_engine_generate", color="red"):
-                    dynamo_stream = await self.routed_engine.generate(
-                        dynamo_preproc, context=context
-                    )
-            elif self.is_kv_router:
-                with _nvtx.annotate("mm_frontend:kv_router_generate", color="red"):
-                    kv_kwargs: dict[str, Any] = {
-                        "token_ids": tokens,
-                        "model": dynamo_preproc["model"],
-                        "stop_conditions": dynamo_preproc["stop_conditions"],
-                        "sampling_options": dynamo_preproc["sampling_options"],
-                        "output_options": dynamo_preproc["output_options"],
-                        "multi_modal_data": dynamo_preproc.get("multi_modal_data"),
-                    }
-                    if dynamo_preproc.get("extra_args"):
-                        kv_kwargs["extra_args"] = dynamo_preproc["extra_args"]
-                        ea = dynamo_preproc["extra_args"]
-                        logger.debug(
-                            "[mm-routing] extra_args keys=%s, has_nixl=%s, "
-                            "n_hashes=%d, n_placeholders=%d",
-                            list(ea.keys()),
-                            "mm_kwargs_nixl" in ea,
-                            len(ea.get("mm_hashes", [])),
-                            len(ea.get("mm_placeholders", [])),
-                        )
-                    _inject_routing_metadata(dynamo_preproc, kv_kwargs, mm_routing_info)
-                    if mm_routing_info is not None:
-                        logger.debug(
-                            "[mm-routing] KvRouter.generate() called with "
-                            "mm_routing_info (%d routing tokens, %d blocks)",
-                            len(mm_routing_info.get("routing_token_ids", [])),
-                            len(mm_routing_info.get("block_mm_infos", [])),
-                        )
-                    else:
-                        logger.debug(
-                            "[mm-routing] KvRouter.generate() called without "
-                            "mm_routing_info (text-only)"
-                        )
-                    dynamo_stream = await self.router.generate(**kv_kwargs)
-            else:
-                with _nvtx.annotate("mm_frontend:client_generate", color="red"):
-                    dynamo_stream = await self.router.generate(
-                        dynamo_preproc, annotated=False, context=context
-                    )
 
             rng_stream = _nvtx.start_range(
                 "mm_frontend:stream_response", color="purple"
             )
             async for dynamo_response in dynamo_stream:
-                if self.routed_engine is None:
-                    engine_response = dynamo_response
-                else:
-                    if dynamo_response.is_error():
-                        comments = dynamo_response.comments() or []
-                        message = "; ".join(comments) or "unknown routed_engine error"
-                        logger.error(
-                            "routed_engine error for request %s: %s",
-                            request_id,
-                            message,
-                        )
-                        yield make_internal_error(request_id, message)
-                        break
-                    engine_response = dynamo_response.data()
+                if dynamo_response.is_error():
+                    comments = dynamo_response.comments() or []
+                    message = "; ".join(comments) or "unknown routed_engine error"
+                    logger.error(
+                        "routed_engine error for request %s: %s",
+                        request_id,
+                        message,
+                    )
+                    yield make_internal_error(request_id, message)
+                    break
+                engine_response = dynamo_response.data()
 
                 if engine_response is None or "token_ids" not in engine_response:
                     yield handle_engine_error(engine_response, request_id, logger)
@@ -744,13 +687,9 @@ class VllmProcessor:
 class EngineFactory:
     def __init__(
         self,
-        runtime: DistributedRuntime,
-        router_config: RouterConfig,
         config: FrontendConfig,
         flags: Namespace,
     ):
-        self.runtime = runtime
-        self.router_config = router_config
         self.config = config
         self.flags = flags
         self.stream_interval = 20
@@ -769,7 +708,7 @@ class EngineFactory:
         self,
         instance_id: ModelCardInstanceId,
         mdc: ModelDeploymentCard,
-        routed_engine: Any | None,
+        routed_engine: RoutedEngine,
     ) -> PythonAsyncEngine:
         """
         Called by Rust when a model is discovered.
@@ -874,32 +813,15 @@ class EngineFactory:
         else:
             reasoning_parser_class = None
 
-        namespace_name, component_name, endpoint_name = instance_id.triple()
-        generate_endpoint = self.runtime.endpoint(
-            f"{namespace_name}.{component_name}.{endpoint_name}"
-        )
-        router: Client | KvRouter
-        if self.router_config.router_mode == RouterMode.KV:
-            router = KvRouter(
-                endpoint=generate_endpoint,
-                block_size=self.config.kv_cache_block_size or 16,
-                kv_router_config=self.router_config.kv_router_config,
-            )
-        else:
-            router = await generate_endpoint.client(
-                router_mode=self.router_config.router_mode
-            )
-
         block_size = self.config.kv_cache_block_size or 16
 
         gen = VllmProcessor(
             tokenizer,
             input_processor,
-            router,
             output_processor,
             tool_parser_class,
             reasoning_parser_class,
-            routed_engine=routed_engine,
+            routed_engine,
             block_size=block_size,
             enable_auto_tool_choice=enable_auto_tool_choice,
         )

--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -636,12 +636,20 @@ class VllmProcessor:
                 "mm_frontend:stream_response", color="purple"
             )
             async for dynamo_response in dynamo_stream:
-                if self.is_kv_router:
+                if self.routed_engine is None:
                     engine_response = dynamo_response
-                elif hasattr(dynamo_response, "data"):
-                    engine_response = dynamo_response.data()
                 else:
-                    engine_response = dynamo_response
+                    if dynamo_response.is_error():
+                        comments = dynamo_response.comments() or []
+                        message = "; ".join(comments) or "unknown routed_engine error"
+                        logger.error(
+                            "routed_engine error for request %s: %s",
+                            request_id,
+                            message,
+                        )
+                        yield make_internal_error(request_id, message)
+                        break
+                    engine_response = dynamo_response.data()
 
                 if engine_response is None or "token_ids" not in engine_response:
                     yield handle_engine_error(engine_response, request_id, logger)

--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -594,7 +594,15 @@ class VllmProcessor:
                     break
                 engine_response = dynamo_response.data()
 
-                if engine_response is None or "token_ids" not in engine_response:
+                if engine_response is None:
+                    if dynamo_response.is_error():
+                        yield handle_engine_error(engine_response, request_id, logger)
+                        break
+                    # No data or error fields, means we may have a comment or other kind of event.
+                    # I'm not sure what those are used for, so TODO. Skip for now.
+                    continue
+
+                if "token_ids" not in engine_response:
                     yield handle_engine_error(engine_response, request_id, logger)
                     break
 

--- a/examples/backends/vllm/launch/disagg_same_gpu.sh
+++ b/examples/backends/vllm/launch/disagg_same_gpu.sh
@@ -52,6 +52,9 @@ FRONTEND_ARGS=()
 if [[ -n "${DYN_CHAT_PROCESSOR:-}" ]]; then
     FRONTEND_ARGS+=(--dyn-chat-processor "$DYN_CHAT_PROCESSOR")
 fi
+if [[ -n "${DYN_ROUTER_MODE:-}" ]]; then
+    FRONTEND_ARGS+=(--router-mode "$DYN_ROUTER_MODE")
+fi
 python3 -m dynamo.frontend "${FRONTEND_ARGS[@]}" &
 
 # run decode worker with metrics on port 8081

--- a/examples/backends/vllm/launch/disagg_same_gpu.sh
+++ b/examples/backends/vllm/launch/disagg_same_gpu.sh
@@ -47,7 +47,12 @@ print_launch_banner "Launching Disaggregated on Same GPU (1 GPU)" "$MODEL" "$HTT
 
 # run ingress
 # dynamo.frontend accepts either --http-port flag or DYN_HTTP_PORT env var (defaults to 8000)
-python3 -m dynamo.frontend &
+# Set DYN_CHAT_PROCESSOR=vllm to exercise the Python pre/post processor instead of Rust.
+FRONTEND_ARGS=()
+if [[ -n "${DYN_CHAT_PROCESSOR:-}" ]]; then
+    FRONTEND_ARGS+=(--dyn-chat-processor "$DYN_CHAT_PROCESSOR")
+fi
+python3 -m dynamo.frontend "${FRONTEND_ARGS[@]}" &
 
 # run decode worker with metrics on port 8081
 # --enforce-eager is added for quick deployment. for production use, need to remove this flag

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -198,6 +198,7 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<ModelType>()?;
     m.add_class::<ModelInput>()?;
     m.add_class::<llm::kv::KvRouter>()?;
+    m.add_class::<llm::routed_engine::RoutedEngine>()?;
     m.add_class::<RouterMode>()?;
     m.add_class::<kserve_grpc::KserveGrpcService>()?;
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;

--- a/lib/bindings/python/rust/llm.rs
+++ b/lib/bindings/python/rust/llm.rs
@@ -32,3 +32,4 @@ pub mod lora;
 pub mod model_card;
 pub mod preprocessor;
 pub mod replay;
+pub mod routed_engine;

--- a/lib/bindings/python/rust/llm/entrypoint.rs
+++ b/lib/bindings/python/rust/llm/entrypoint.rs
@@ -15,10 +15,10 @@ use dynamo_kv_router::config::{
     apply_deprecated_overlap_score_weight_override,
 };
 use dynamo_llm::discovery::LoadThresholdConfig as RsLoadThresholdConfig;
-use dynamo_llm::entrypoint::ChatEngineFactoryCallback;
 use dynamo_llm::entrypoint::EngineConfig as RsEngineConfig;
 use dynamo_llm::entrypoint::RouterConfig as RsRouterConfig;
 use dynamo_llm::entrypoint::input::Input;
+use dynamo_llm::entrypoint::{ChatEngineFactoryCallback, PrefillRoutedEngine};
 use dynamo_llm::local_model::DEFAULT_HTTP_PORT;
 use dynamo_llm::local_model::{LocalModel, LocalModelBuilder};
 use dynamo_llm::mocker::make_mocker_engine;
@@ -559,7 +559,8 @@ fn py_engine_factory_to_callback(factory: PyEngineFactory) -> ChatEngineFactoryC
 
     Arc::new(
         move |instance_id: RsModelCardInstanceId,
-              card: RsModelDeploymentCard|
+              card: RsModelDeploymentCard,
+              routed_engine: PrefillRoutedEngine|
               -> Pin<
             Box<dyn Future<Output = anyhow::Result<OpenAIChatCompletionsStreamingEngine>> + Send>,
         > {
@@ -577,10 +578,15 @@ fn py_engine_factory_to_callback(factory: PyEngineFactory) -> ChatEngineFactoryC
                     let py_card = ModelDeploymentCard { inner: card };
                     let py_card_obj = Py::new(py, py_card)
                         .map_err(|e| anyhow::anyhow!("Failed to create Python MDC: {e}"))?;
+                    let py_routed = Py::new(
+                        py,
+                        crate::llm::routed_engine::RoutedEngine::new(routed_engine),
+                    )
+                    .map_err(|e| anyhow::anyhow!("Failed to create Python RoutedEngine: {e}"))?;
 
                     // Call Python async function to get a coroutine
                     let coroutine = callback
-                        .call1(py, (py_instance_id, py_card_obj))
+                        .call1(py, (py_instance_id, py_card_obj, py_routed))
                         .map_err(|e| anyhow::anyhow!("Failed to call chat_engine_factory: {e}"))?;
 
                     // Use the TaskLocals captured at registration time

--- a/lib/bindings/python/rust/llm/routed_engine.rs
+++ b/lib/bindings/python/rust/llm/routed_engine.rs
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use pyo3::prelude::*;
+use pythonize::{depythonize, pythonize};
+use tokio_stream::StreamExt;
+
+use dynamo_llm::entrypoint::PrefillRoutedEngine;
+use dynamo_llm::protocols::common::preprocessor::PreprocessedRequest;
+use dynamo_runtime::pipeline::{AsyncEngineContextProvider, SingleIn};
+use dynamo_runtime::protocols::annotated::Annotated as RsAnnotated;
+
+use crate::to_pyerr;
+
+#[pyclass]
+pub struct RoutedEngine {
+    inner: PrefillRoutedEngine,
+}
+
+impl RoutedEngine {
+    pub fn new(inner: PrefillRoutedEngine) -> Self {
+        Self { inner }
+    }
+}
+
+#[pymethods]
+impl RoutedEngine {
+    /// Send a preprocessed request through the Rust prefill-routed pipeline.
+    #[pyo3(signature = (preprocessed, context=None))]
+    fn generate<'p>(
+        &self,
+        py: Python<'p>,
+        preprocessed: PyObject,
+        context: Option<crate::context::Context>,
+    ) -> PyResult<Bound<'p, PyAny>> {
+        let request: PreprocessedRequest = depythonize(preprocessed.bind(py)).map_err(to_pyerr)?;
+        let request_context = if let Some(parent_context) = context.as_ref() {
+            let parent_context = parent_context.inner();
+            let child_context = SingleIn::with_id(request, parent_context.id().to_string());
+            let child_controller = child_context.context();
+            parent_context.link_child(child_controller.clone());
+            if parent_context.is_killed() {
+                child_controller.kill();
+            } else if parent_context.is_stopped() {
+                child_controller.stop_generating();
+            }
+            child_context
+        } else {
+            SingleIn::new(request)
+        };
+        let inner = self.inner.clone();
+
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let mut stream = inner.generate(request_context).await.map_err(to_pyerr)?;
+            let task_context = stream.context();
+            let (tx, rx) = tokio::sync::mpsc::channel::<RsAnnotated<PyObject>>(32);
+
+            tokio::spawn(async move {
+                loop {
+                    let response = tokio::select! {
+                        _ = tx.closed() => {
+                            task_context.stop_generating();
+                            break;
+                        }
+                        response = stream.next() => response,
+                    };
+
+                    let Some(response) = response else {
+                        break;
+                    };
+
+                    let py_response = Python::with_gil(|py| {
+                        response.map_data(|data| {
+                            pythonize(py, &data)
+                                .map(|obj| obj.unbind())
+                                .map_err(|e| format!("pythonize failed: {e}"))
+                        })
+                    });
+
+                    if tx.send(py_response).await.is_err() {
+                        task_context.stop_generating();
+                        break;
+                    }
+                }
+            });
+
+            Ok(crate::AsyncResponseStream::new(rx, true))
+        })
+    }
+}

--- a/lib/bindings/python/src/dynamo/llm/__init__.py
+++ b/lib/bindings/python/src/dynamo/llm/__init__.py
@@ -4,6 +4,8 @@
 # flake8: noqa
 
 import logging
+from collections.abc import AsyncIterator
+from typing import Any, Protocol
 
 from dynamo._core import AicPerfConfig as AicPerfConfig
 from dynamo._core import EngineType
@@ -45,6 +47,12 @@ from dynamo._core import run_mocker_trace_replay as _run_mocker_trace_replay
 from dynamo._core import unregister_model as unregister_model
 
 from .exceptions import HttpError
+
+
+class RoutedEngine(Protocol):
+    async def generate(self, request: Any, **kwargs: Any) -> AsyncIterator[Any]:
+        ...
+
 
 # Backward-compatible aliases
 fetch_llm = fetch_model

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -721,70 +721,78 @@ impl ModelWatcher {
             // handle Chat or Completions requests, so handle whatever the model supports.
 
             let endpoint = component.endpoint(&mcid.endpoint);
-            // Create the KV router whenever any local routed pipeline will be built.
-            // The chat factory builds its own router, but completions currently always
-            // uses the local routed pipeline and therefore still needs a chooser.
-            let needs_local_chat_pipeline =
-                card.model_type.supports_chat() && self.chat_engine_factory.is_none();
-            let needs_local_completions_pipeline = card.model_type.supports_completions();
-            let kv_chooser = if router_config.router_mode == RouterMode::KV
-                && (needs_local_chat_pipeline || needs_local_completions_pipeline)
-            {
-                Some(
-                    self.manager
-                        .kv_chooser_for(
-                            &endpoint,
-                            card.kv_cache_block_size,
-                            Some(router_config.kv_router_config.clone()),
-                            self.prefill_load_estimator.clone(),
-                            WORKER_TYPE_DECODE, // This is the decode router
-                            Some(card.display_name.clone()),
-                            card.runtime_config.enable_eagle,
-                        )
-                        .await?,
-                )
-            } else {
-                None
-            };
-
             // Loading the tokenizer is expensive (~10 MiB JSON), so only do it
             // once and only when a local pipeline actually needs it.  Models
             // without tokenizer.json (e.g. Qwen3-Omni) set tokenizer = None;
             // they rely on a Python chat_engine_factory for tokenization.
             // When a chat_engine_factory handles chat and no completions are
             // needed, skip tokenizer loading entirely — even if the file exists.
-            let needs_rust_tokenizer =
-                needs_local_chat_pipeline || needs_local_completions_pipeline;
-            let tokenizer = if needs_rust_tokenizer && card.has_tokenizer() {
+            let needs_local_chat_pipeline =
+                card.model_type.supports_chat() && self.chat_engine_factory.is_none();
+            let needs_local_completions_pipeline = card.model_type.supports_completions();
+            let tokenizer = if (needs_local_chat_pipeline || needs_local_completions_pipeline)
+                && card.has_tokenizer()
+            {
                 Some(card.tokenizer().context("tokenizer")?)
             } else {
                 None
             };
 
+            // Routing is required whenever any pipeline (factory chat or local) will exist.
+            // tokenizer.is_some() implies a local chat or completions pipeline will be built.
+            let needs_factory_chat_pipeline =
+                card.model_type.supports_chat() && self.chat_engine_factory.is_some();
+            let needs_preprocessed_routing = needs_factory_chat_pipeline || tokenizer.is_some();
+
+            // Create the KV router whenever any routed pipeline will be built.
+            // Python chat factories receive a Rust-routed engine, so they also
+            // need the shared chooser in KV mode.
+            let kv_chooser =
+                if router_config.router_mode == RouterMode::KV && needs_preprocessed_routing {
+                    Some(
+                        self.manager
+                            .kv_chooser_for(
+                                &endpoint,
+                                card.kv_cache_block_size,
+                                Some(router_config.kv_router_config.clone()),
+                                self.prefill_load_estimator.clone(),
+                                WORKER_TYPE_DECODE, // This is the decode router
+                                Some(card.display_name.clone()),
+                                card.runtime_config.enable_eagle,
+                            )
+                            .await?,
+                    )
+                } else {
+                    None
+                };
+
             // Create prefill chooser once if we're building pipelines
             // Both chat and completions will share the same prefill chooser instance
             let model_name = card.name().to_string();
-            let prefill_chooser = self
-                .manager
-                .register_prefill_router(&model_name, &namespace)
-                .map(|rx| {
-                    // Create prefill-specific config with track_active_blocks disabled
-                    let mut prefill_config = router_config.kv_router_config.clone();
-                    prefill_config.router_track_active_blocks = false;
+            let prefill_chooser = if needs_preprocessed_routing {
+                self.manager
+                    .register_prefill_router(&model_name, &namespace)
+                    .map(|rx| {
+                        // Create prefill-specific config with track_active_blocks disabled
+                        let mut prefill_config = router_config.kv_router_config.clone();
+                        prefill_config.router_track_active_blocks = false;
 
-                    PrefillRouter::new(
-                        rx,
-                        self.manager.clone(),
-                        router_config.router_mode,
-                        card.kv_cache_block_size,
-                        Some(prefill_config),
-                        self.prefill_load_estimator.clone(),
-                        router_config.enforce_disagg,
-                        model_name.clone(),
-                        namespace.clone(),
-                        card.runtime_config.enable_eagle,
-                    )
-                });
+                        PrefillRouter::new(
+                            rx,
+                            self.manager.clone(),
+                            router_config.router_mode,
+                            card.kv_cache_block_size,
+                            Some(prefill_config),
+                            self.prefill_load_estimator.clone(),
+                            router_config.enforce_disagg,
+                            model_name.clone(),
+                            namespace.clone(),
+                            card.runtime_config.enable_eagle,
+                        )
+                    })
+            } else {
+                None
+            };
 
             // Create a new worker monitor for this WorkerSet. Each WorkerSet gets its own
             // monitor (1-to-1) since each monitor is scoped to this WorkerSet's Client/namespace.
@@ -796,14 +804,18 @@ impl ModelWatcher {
             // PushRouter, which also uses the KvRouter's Client (see common.rs:258-263).
             // Using a different Client instance would cause the PushRouter to never see
             // busy workers, since each Client::new() creates independent ArcSwap state.
-            let monitor_client = kv_chooser
-                .as_ref()
-                .map(|chooser| chooser.client().clone())
-                .unwrap_or_else(|| client.clone());
-            let worker_monitor = Some(KvWorkerMonitor::new(
-                monitor_client,
-                router_config.load_threshold_config.clone(),
-            ));
+            let worker_monitor = if needs_preprocessed_routing {
+                let monitor_client = kv_chooser
+                    .as_ref()
+                    .map(|chooser| chooser.client().clone())
+                    .unwrap_or_else(|| client.clone());
+                Some(KvWorkerMonitor::new(
+                    monitor_client,
+                    router_config.load_threshold_config.clone(),
+                ))
+            } else {
+                None
+            };
 
             // Store KV router, worker monitor, and prefill router on the WorkerSet.
             // The prefill router is stored so the watcher can deactivate/reactivate it
@@ -812,19 +824,36 @@ impl ModelWatcher {
             worker_set.worker_monitor = worker_monitor.clone();
             worker_set.prefill_router = prefill_chooser.clone();
 
+            let preprocessed_routing = if needs_preprocessed_routing {
+                Some(
+                    entrypoint::build_preprocessed_routing(
+                        &client,
+                        self.manager.clone(),
+                        router_config.router_mode,
+                        worker_monitor.clone(),
+                        kv_chooser.clone(),
+                        prefill_chooser.clone(),
+                        router_config.enforce_disagg,
+                    )
+                    .await
+                    .context("build_preprocessed_routing")?,
+                )
+            } else {
+                None
+            };
+
             // Add chat engine only if the model supports chat
             if card.model_type.supports_chat() {
-                let factory_engine = if let Some(ref factory) = self.chat_engine_factory {
-                    match factory(mcid.clone(), card.clone()).await {
-                        Ok(engine) => Some(engine),
-                        Err(err) => return Err(err).context("python chat_engine_factory"),
-                    }
-                } else {
-                    None
-                };
-
-                let chat_engine = if let Some(engine) = factory_engine {
-                    engine
+                let routing = preprocessed_routing.as_ref().ok_or_else(|| {
+                    anyhow::anyhow!("chat pipeline requires preprocessed routing")
+                })?;
+                let chat_engine = if let Some(ref factory) = self.chat_engine_factory {
+                    let routed_engine = routing
+                        .build_prefill_pipeline()
+                        .context("PreprocessedRouting::build_prefill_pipeline")?;
+                    factory(mcid.clone(), card.clone(), routed_engine)
+                        .await
+                        .context("python chat_engine_factory")?
                 } else {
                     let tk = tokenizer.clone().ok_or_else(|| {
                         anyhow::anyhow!(
@@ -833,25 +862,24 @@ impl ModelWatcher {
                              tokenizer file (tokenizer.json, tiktoken.model, or *.tiktoken)."
                         )
                     })?;
-                    entrypoint::build_routed_pipeline::<
-                        NvCreateChatCompletionRequest,
-                        NvCreateChatCompletionStreamResponse,
-                    >(
-                        card,
-                        &client,
-                        self.manager.clone(),
-                        router_config.router_mode,
-                        worker_monitor.clone(),
-                        kv_chooser.clone(),
-                        tk,
-                        prefill_chooser.clone(),
-                        router_config.enforce_disagg,
-                        self.migration_limit,
-                        self.migration_max_seq_len,
-                        self.metrics.clone(),
-                    )
-                    .await
-                    .context("build_routed_pipeline")?
+                    let PromptFormatter::OAI(formatter) =
+                        PromptFormatter::from_mdc(card).context("PromptFormatter.from_mdc")?;
+                    let preprocessor =
+                        OpenAIPreprocessor::new_with_parts(card.clone(), formatter, tk.clone())
+                            .context("OpenAIPreprocessor.new_with_parts")?;
+                    routing
+                        .build_pipeline::<
+                            NvCreateChatCompletionRequest,
+                            NvCreateChatCompletionStreamResponse,
+                        >(
+                            card,
+                            preprocessor,
+                            tk,
+                            self.migration_limit,
+                            self.migration_max_seq_len,
+                            self.metrics.clone(),
+                        )
+                        .context("PreprocessedRouting::build_pipeline")?
                 };
                 worker_set.chat_engine = Some(chat_engine);
                 tracing::info!("Chat completions is ready");
@@ -866,26 +894,19 @@ impl ModelWatcher {
                     let preprocessor =
                         OpenAIPreprocessor::new_with_parts(card.clone(), formatter, tk.clone())
                             .context("OpenAIPreprocessor::new_with_parts")?;
-                    let completions_engine = entrypoint::build_routed_pipeline_with_preprocessor::<
-                        NvCreateCompletionRequest,
-                        NvCreateCompletionResponse,
-                    >(
-                        card,
-                        &client,
-                        self.manager.clone(),
-                        router_config.router_mode,
-                        worker_monitor,
-                        kv_chooser,
-                        preprocessor,
-                        tk,
-                        prefill_chooser,
-                        router_config.enforce_disagg,
-                        self.migration_limit,
-                        self.migration_max_seq_len,
-                        self.metrics.clone(),
-                    )
-                    .await
-                    .context("build_routed_pipeline_with_preprocessor")?;
+                    let routing = preprocessed_routing.as_ref().ok_or_else(|| {
+                        anyhow::anyhow!("completions pipeline requires preprocessed routing")
+                    })?;
+                    let completions_engine = routing
+                        .build_pipeline::<NvCreateCompletionRequest, NvCreateCompletionResponse>(
+                            card,
+                            preprocessor,
+                            tk,
+                            self.migration_limit,
+                            self.migration_max_seq_len,
+                            self.metrics.clone(),
+                        )
+                        .context("PreprocessedRouting::build_pipeline")?;
                     worker_set.completions_engine = Some(completions_engine);
                     tracing::info!("Completions is ready");
                 } else {

--- a/lib/llm/src/entrypoint.rs
+++ b/lib/llm/src/entrypoint.rs
@@ -6,7 +6,7 @@
 //! - Connect it to an Input
 
 pub mod input;
-pub use input::{build_routed_pipeline, build_routed_pipeline_with_preprocessor};
+pub use input::{PreprocessedRouting, build_preprocessed_routing};
 
 use std::future::Future;
 use std::pin::Pin;
@@ -23,10 +23,18 @@ use crate::{
 };
 
 /// Callback type for chat engine factory (async)
+pub type PrefillRoutedEngine = dynamo_runtime::pipeline::ServiceEngine<
+    dynamo_runtime::pipeline::SingleIn<crate::protocols::common::preprocessor::PreprocessedRequest>,
+    dynamo_runtime::pipeline::ManyOut<
+        crate::types::Annotated<crate::protocols::common::llm_backend::LLMEngineOutput>,
+    >,
+>;
+
 pub type ChatEngineFactoryCallback = Arc<
     dyn Fn(
             ModelCardInstanceId,
             ModelDeploymentCard,
+            PrefillRoutedEngine,
         ) -> Pin<
             Box<dyn Future<Output = anyhow::Result<OpenAIChatCompletionsStreamingEngine>> + Send>,
         > + Send

--- a/lib/llm/src/entrypoint/input.rs
+++ b/lib/llm/src/entrypoint/input.rs
@@ -14,7 +14,7 @@ use std::{
 };
 
 mod common;
-pub use common::{build_routed_pipeline, build_routed_pipeline_with_preprocessor};
+pub use common::{PreprocessedRouting, build_preprocessed_routing};
 pub mod endpoint;
 pub mod grpc;
 pub mod http;

--- a/lib/llm/src/entrypoint/input/common.rs
+++ b/lib/llm/src/entrypoint/input/common.rs
@@ -28,18 +28,33 @@ use crate::{
     },
 };
 
-use anyhow::Context as _;
 use dynamo_kv_router::config::min_initial_workers_from_env;
 use dynamo_runtime::{
     DistributedRuntime,
     component::Client,
     engine::{AsyncEngineStream, Data},
     pipeline::{
-        Context, ManyOut, Operator, PushRouter, RouterMode, SegmentSource, ServiceBackend,
-        ServiceEngine, ServiceFrontend, SingleIn, Source,
+        Context, ManyOut, Operator, PipelineOperator, PushRouter, RouterMode, SegmentSource,
+        ServiceBackend, ServiceEngine, ServiceFrontend, SingleIn, Source,
     },
 };
 use std::sync::Arc;
+
+type LlmPushRouter = PushRouter<PreprocessedRequest, Annotated<LLMEngineOutput>>;
+
+type PrefillOp = PipelineOperator<
+    SingleIn<PreprocessedRequest>,
+    ManyOut<Annotated<LLMEngineOutput>>,
+    SingleIn<PreprocessedRequest>,
+    ManyOut<Annotated<LLMEngineOutput>>,
+>;
+
+#[derive(Clone)]
+pub struct PreprocessedRouting {
+    backend:
+        Arc<ServiceBackend<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutput>>>>,
+    prefill_op: Arc<PrefillOp>,
+}
 
 pub struct PreparedEngine {
     pub service_name: String,
@@ -85,6 +100,88 @@ async fn wait_for_min_initial_workers(
                 )
             })?;
     }
+}
+
+fn router_client(
+    client: &Client,
+    router_mode: RouterMode,
+    chooser: Option<&Arc<KvRouter>>,
+) -> anyhow::Result<Client> {
+    if router_mode == RouterMode::KV {
+        let Some(chooser) = chooser else {
+            anyhow::bail!("RouterMode::KV requires KVRouter to not be null");
+        };
+        Ok(chooser.client().clone())
+    } else {
+        Ok(client.clone())
+    }
+}
+
+#[allow(clippy::type_complexity)]
+fn preprocessed_backend(
+    router: LlmPushRouter,
+    router_mode: RouterMode,
+    chooser: Option<Arc<KvRouter>>,
+) -> anyhow::Result<
+    Arc<ServiceBackend<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutput>>>>,
+> {
+    let backend = match router_mode {
+        RouterMode::Direct => {
+            ServiceBackend::from_engine(Arc::new(DirectRoutingRouter::new(router)))
+        }
+        RouterMode::Random
+        | RouterMode::RoundRobin
+        | RouterMode::PowerOfTwoChoices
+        | RouterMode::LeastLoaded
+        | RouterMode::DeviceAwareWeighted => ServiceBackend::from_engine(Arc::new(router)),
+        RouterMode::KV => {
+            let Some(chooser) = chooser else {
+                anyhow::bail!("RouterMode::KV requires KVRouter to not be null");
+            };
+            ServiceBackend::from_engine(Arc::new(KvPushRouter::new(router, chooser)))
+        }
+    };
+
+    Ok(backend)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn build_preprocessed_routing(
+    client: &Client,
+    model_manager: Arc<crate::discovery::ModelManager>,
+    router_mode: RouterMode,
+    worker_monitor: Option<KvWorkerMonitor>,
+    chooser: Option<Arc<KvRouter>>,
+    prefill_chooser: Option<Arc<PrefillRouter>>,
+    enforce_disagg: bool,
+) -> anyhow::Result<PreprocessedRouting> {
+    let min_initial_workers = min_initial_workers_from_env()?;
+    let router_client = router_client(client, router_mode, chooser.as_ref())?;
+
+    wait_for_min_initial_workers(&router_client, min_initial_workers).await?;
+
+    let monitor_arc =
+        worker_monitor.map(|m| Arc::new(m) as Arc<dyn dynamo_runtime::pipeline::WorkerLoadMonitor>);
+
+    let router =
+        LlmPushRouter::from_client_with_monitor(router_client, router_mode, monitor_arc).await?;
+
+    // Eagerly register router request metrics so they appear as zeros even in
+    // non-KV modes (Direct, Random, RoundRobin) where KvPushRouter is never created.
+    // In KV mode, KvPushRouter::new() also calls from_component() (idempotent via
+    // OnceLock), which covers the standalone router path as well.
+    RouterRequestMetrics::from_component(client.endpoint.component());
+
+    let prefill_router = prefill_chooser
+        .unwrap_or_else(|| PrefillRouter::disabled(model_manager, router_mode, enforce_disagg));
+
+    let backend = preprocessed_backend(router, router_mode, chooser)?;
+    let prefill_op = prefill_router.into_operator();
+
+    Ok(PreprocessedRouting {
+        backend,
+        prefill_op,
+    })
 }
 
 /// Turns an EngineConfig into an OpenAI chat-completions and completions supported StreamingEngine.
@@ -233,150 +330,63 @@ where
         .link(frontend)?)
 }
 
-#[allow(clippy::too_many_arguments)]
-pub async fn build_routed_pipeline<Req, Resp>(
-    card: &ModelDeploymentCard,
-    client: &Client,
-    model_manager: Arc<crate::discovery::ModelManager>,
-    router_mode: RouterMode,
-    worker_monitor: Option<KvWorkerMonitor>,
-    chooser: Option<Arc<KvRouter>>,
-    tokenizer: crate::tokenizers::Tokenizer,
-    prefill_chooser: Option<Arc<PrefillRouter>>,
-    enforce_disagg: bool,
-    migration_limit: u32,
-    migration_max_seq_len: Option<u32>,
-    metrics: Arc<Metrics>,
-) -> anyhow::Result<ServiceEngine<SingleIn<Req>, ManyOut<Annotated<Resp>>>>
-where
-    Req: Data,
-    Resp: Data,
-    OpenAIPreprocessor: Operator<
-            Context<Req>,
-            Pin<Box<dyn AsyncEngineStream<Annotated<Resp>>>>,
-            Context<PreprocessedRequest>,
-            Pin<Box<dyn AsyncEngineStream<Annotated<BackendOutput>>>>,
-        >,
-{
-    let PromptFormatter::OAI(formatter) =
-        PromptFormatter::from_mdc(card).context("PromptFormatter.from_mdc")?;
-    let preprocessor =
-        OpenAIPreprocessor::new_with_parts(card.clone(), formatter, tokenizer.clone())
-            .context("OpenAIPreprocessor.new_with_parts")?;
-    build_routed_pipeline_with_preprocessor(
-        card,
-        client,
-        model_manager,
-        router_mode,
-        worker_monitor,
-        chooser,
-        preprocessor,
-        tokenizer,
-        prefill_chooser,
-        enforce_disagg,
-        migration_limit,
-        migration_max_seq_len,
-        metrics,
-    )
-    .await
-}
+impl PreprocessedRouting {
+    pub fn build_pipeline<Req, Resp>(
+        &self,
+        card: &ModelDeploymentCard,
+        preprocessor: Arc<OpenAIPreprocessor>,
+        tokenizer: crate::tokenizers::Tokenizer,
+        migration_limit: u32,
+        migration_max_seq_len: Option<u32>,
+        metrics: Arc<Metrics>,
+    ) -> anyhow::Result<ServiceEngine<SingleIn<Req>, ManyOut<Annotated<Resp>>>>
+    where
+        Req: Data,
+        Resp: Data,
+        OpenAIPreprocessor: Operator<
+                Context<Req>,
+                Pin<Box<dyn AsyncEngineStream<Annotated<Resp>>>>,
+                Context<PreprocessedRequest>,
+                Pin<Box<dyn AsyncEngineStream<Annotated<BackendOutput>>>>,
+            >,
+    {
+        let frontend = SegmentSource::<SingleIn<Req>, ManyOut<Annotated<Resp>>>::new();
+        let preprocessor_op = preprocessor.into_operator();
+        let token_backend = Backend::from_tokenizer(tokenizer).into_operator();
+        let migration = Migration::from_mdc(card, migration_limit, migration_max_seq_len, metrics)
+            .into_operator();
 
-#[allow(clippy::too_many_arguments)]
-pub async fn build_routed_pipeline_with_preprocessor<Req, Resp>(
-    card: &ModelDeploymentCard,
-    client: &Client,
-    model_manager: Arc<crate::discovery::ModelManager>,
-    router_mode: RouterMode,
-    worker_monitor: Option<KvWorkerMonitor>,
-    chooser: Option<Arc<KvRouter>>,
-    preprocessor: Arc<OpenAIPreprocessor>,
-    tokenizer: crate::tokenizers::Tokenizer,
-    prefill_chooser: Option<Arc<PrefillRouter>>,
-    enforce_disagg: bool,
-    migration_limit: u32,
-    migration_max_seq_len: Option<u32>,
-    metrics: Arc<Metrics>,
-) -> anyhow::Result<ServiceEngine<SingleIn<Req>, ManyOut<Annotated<Resp>>>>
-where
-    Req: Data,
-    Resp: Data,
-    OpenAIPreprocessor: Operator<
-            Context<Req>,
-            Pin<Box<dyn AsyncEngineStream<Annotated<Resp>>>>,
-            Context<PreprocessedRequest>,
-            Pin<Box<dyn AsyncEngineStream<Annotated<BackendOutput>>>>,
-        >,
-{
-    let frontend = SegmentSource::<SingleIn<Req>, ManyOut<Annotated<Resp>>>::new();
-    let preprocessor_op = preprocessor.into_operator();
-    let backend = Backend::from_tokenizer(tokenizer).into_operator();
-    let migration =
-        Migration::from_mdc(card, migration_limit, migration_max_seq_len, metrics).into_operator();
-    let min_initial_workers = min_initial_workers_from_env()?;
+        let engine = frontend
+            .link(preprocessor_op.forward_edge())?
+            .link(migration.forward_edge())?
+            .link(token_backend.forward_edge())?
+            .link(self.prefill_op.clone().forward_edge())?
+            .link(self.backend.clone())?
+            .link(self.prefill_op.clone().backward_edge())?
+            .link(token_backend.backward_edge())?
+            .link(migration.backward_edge())?
+            .link(preprocessor_op.backward_edge())?
+            .link(frontend)?;
 
-    // For KV routing, use the client from the chooser to ensure shared state
-    let router_client = if router_mode == RouterMode::KV {
-        let Some(ref chooser) = chooser else {
-            anyhow::bail!("RouterMode::KV requires KVRouter to not be null");
-        };
-        chooser.client().clone()
-    } else {
-        client.clone()
-    };
+        Ok(engine)
+    }
 
-    wait_for_min_initial_workers(&router_client, min_initial_workers).await?;
+    pub fn build_prefill_pipeline(
+        &self,
+    ) -> anyhow::Result<
+        ServiceEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutput>>>,
+    > {
+        let frontend = SegmentSource::<
+            SingleIn<PreprocessedRequest>,
+            ManyOut<Annotated<LLMEngineOutput>>,
+        >::new();
 
-    let monitor_arc =
-        worker_monitor.map(|m| Arc::new(m) as Arc<dyn dynamo_runtime::pipeline::WorkerLoadMonitor>);
+        let engine = frontend
+            .link(self.prefill_op.clone().forward_edge())?
+            .link(self.backend.clone())?
+            .link(self.prefill_op.clone().backward_edge())?
+            .link(frontend)?;
 
-    let router =
-        PushRouter::<PreprocessedRequest, Annotated<LLMEngineOutput>>::from_client_with_monitor(
-            router_client,
-            router_mode,
-            monitor_arc,
-        )
-        .await?;
-
-    // Eagerly register router request metrics so they appear as zeros even in
-    // non-KV modes (Direct, Random, RoundRobin) where KvPushRouter is never created.
-    // In KV mode, KvPushRouter::new() also calls from_component() (idempotent via
-    // OnceLock), which covers the standalone router path as well.
-    RouterRequestMetrics::from_component(client.endpoint.component());
-
-    let service_backend = match router_mode {
-        RouterMode::Direct => {
-            ServiceBackend::from_engine(Arc::new(DirectRoutingRouter::new(router)))
-        }
-        RouterMode::Random
-        | RouterMode::RoundRobin
-        | RouterMode::PowerOfTwoChoices
-        | RouterMode::LeastLoaded
-        | RouterMode::DeviceAwareWeighted => ServiceBackend::from_engine(Arc::new(router)),
-        RouterMode::KV => {
-            let Some(chooser) = chooser else {
-                anyhow::bail!("RouterMode::KV requires KVRouter to not be null");
-            };
-            ServiceBackend::from_engine(Arc::new(KvPushRouter::new(router, chooser)))
-        }
-    };
-
-    // Use the provided prefill chooser, or create a disabled one if not provided
-    let prefill_chooser = prefill_chooser
-        .unwrap_or_else(|| PrefillRouter::disabled(model_manager, router_mode, enforce_disagg));
-    let prefill_op = prefill_chooser.into_operator();
-
-    // Link with prefill chooser including backward edge for response flow
-    let engine = frontend
-        .link(preprocessor_op.forward_edge())?
-        .link(migration.forward_edge())?
-        .link(backend.forward_edge())?
-        .link(prefill_op.forward_edge())?
-        .link(service_backend)?
-        .link(prefill_op.backward_edge())?
-        .link(backend.backward_edge())?
-        .link(migration.backward_edge())?
-        .link(preprocessor_op.backward_edge())?
-        .link(frontend)?;
-
-    Ok(engine)
+        Ok(engine)
+    }
 }

--- a/lib/llm/src/entrypoint/input/common.rs
+++ b/lib/llm/src/entrypoint/input/common.rs
@@ -34,8 +34,8 @@ use dynamo_runtime::{
     component::Client,
     engine::{AsyncEngineStream, Data},
     pipeline::{
-        Context, ManyOut, Operator, PushRouter, RouterMode, SegmentSource,
-        ServiceBackend, ServiceEngine, ServiceFrontend, SingleIn, Source,
+        Context, ManyOut, Operator, PushRouter, RouterMode, SegmentSource, ServiceBackend,
+        ServiceEngine, ServiceFrontend, SingleIn, Source,
     },
 };
 use std::sync::Arc;

--- a/lib/llm/src/entrypoint/input/common.rs
+++ b/lib/llm/src/entrypoint/input/common.rs
@@ -34,7 +34,7 @@ use dynamo_runtime::{
     component::Client,
     engine::{AsyncEngineStream, Data},
     pipeline::{
-        Context, ManyOut, Operator, PipelineOperator, PushRouter, RouterMode, SegmentSource,
+        Context, ManyOut, Operator, PushRouter, RouterMode, SegmentSource,
         ServiceBackend, ServiceEngine, ServiceFrontend, SingleIn, Source,
     },
 };
@@ -42,18 +42,11 @@ use std::sync::Arc;
 
 type LlmPushRouter = PushRouter<PreprocessedRequest, Annotated<LLMEngineOutput>>;
 
-type PrefillOp = PipelineOperator<
-    SingleIn<PreprocessedRequest>,
-    ManyOut<Annotated<LLMEngineOutput>>,
-    SingleIn<PreprocessedRequest>,
-    ManyOut<Annotated<LLMEngineOutput>>,
->;
-
 #[derive(Clone)]
 pub struct PreprocessedRouting {
-    backend:
-        Arc<ServiceBackend<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutput>>>>,
-    prefill_op: Arc<PrefillOp>,
+    backend_engine:
+        ServiceEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutput>>>,
+    prefill_router: Arc<PrefillRouter>,
 }
 
 pub struct PreparedEngine {
@@ -117,32 +110,28 @@ fn router_client(
     }
 }
 
-#[allow(clippy::type_complexity)]
-fn preprocessed_backend(
+fn preprocessed_backend_engine(
     router: LlmPushRouter,
     router_mode: RouterMode,
     chooser: Option<Arc<KvRouter>>,
-) -> anyhow::Result<
-    Arc<ServiceBackend<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutput>>>>,
-> {
-    let backend = match router_mode {
-        RouterMode::Direct => {
-            ServiceBackend::from_engine(Arc::new(DirectRoutingRouter::new(router)))
-        }
+) -> anyhow::Result<ServiceEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutput>>>>
+{
+    let engine: ServiceEngine<_, _> = match router_mode {
+        RouterMode::Direct => Arc::new(DirectRoutingRouter::new(router)),
         RouterMode::Random
         | RouterMode::RoundRobin
         | RouterMode::PowerOfTwoChoices
         | RouterMode::LeastLoaded
-        | RouterMode::DeviceAwareWeighted => ServiceBackend::from_engine(Arc::new(router)),
+        | RouterMode::DeviceAwareWeighted => Arc::new(router),
         RouterMode::KV => {
             let Some(chooser) = chooser else {
                 anyhow::bail!("RouterMode::KV requires KVRouter to not be null");
             };
-            ServiceBackend::from_engine(Arc::new(KvPushRouter::new(router, chooser)))
+            Arc::new(KvPushRouter::new(router, chooser))
         }
     };
 
-    Ok(backend)
+    Ok(engine)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -175,12 +164,11 @@ pub async fn build_preprocessed_routing(
     let prefill_router = prefill_chooser
         .unwrap_or_else(|| PrefillRouter::disabled(model_manager, router_mode, enforce_disagg));
 
-    let backend = preprocessed_backend(router, router_mode, chooser)?;
-    let prefill_op = prefill_router.into_operator();
+    let backend_engine = preprocessed_backend_engine(router, router_mode, chooser)?;
 
     Ok(PreprocessedRouting {
-        backend,
-        prefill_op,
+        backend_engine,
+        prefill_router,
     })
 }
 
@@ -355,14 +343,16 @@ impl PreprocessedRouting {
         let token_backend = Backend::from_tokenizer(tokenizer).into_operator();
         let migration = Migration::from_mdc(card, migration_limit, migration_max_seq_len, metrics)
             .into_operator();
+        let prefill_op = self.prefill_router.into_operator();
+        let backend = ServiceBackend::from_engine(self.backend_engine.clone());
 
         let engine = frontend
             .link(preprocessor_op.forward_edge())?
             .link(migration.forward_edge())?
             .link(token_backend.forward_edge())?
-            .link(self.prefill_op.clone().forward_edge())?
-            .link(self.backend.clone())?
-            .link(self.prefill_op.clone().backward_edge())?
+            .link(prefill_op.forward_edge())?
+            .link(backend)?
+            .link(prefill_op.backward_edge())?
             .link(token_backend.backward_edge())?
             .link(migration.backward_edge())?
             .link(preprocessor_op.backward_edge())?
@@ -380,11 +370,13 @@ impl PreprocessedRouting {
             SingleIn<PreprocessedRequest>,
             ManyOut<Annotated<LLMEngineOutput>>,
         >::new();
+        let prefill_op = self.prefill_router.into_operator();
+        let backend = ServiceBackend::from_engine(self.backend_engine.clone());
 
         let engine = frontend
-            .link(self.prefill_op.clone().forward_edge())?
-            .link(self.backend.clone())?
-            .link(self.prefill_op.clone().backward_edge())?
+            .link(prefill_op.forward_edge())?
+            .link(backend)?
+            .link(prefill_op.backward_edge())?
             .link(frontend)?;
 
         Ok(engine)

--- a/lib/runtime/src/protocols/annotated.rs
+++ b/lib/runtime/src/protocols/annotated.rs
@@ -93,10 +93,6 @@ impl<R> Annotated<R> {
         self.event.as_deref() != Some("error")
     }
 
-    pub fn is_err(&self) -> bool {
-        !self.is_ok()
-    }
-
     pub fn is_event(&self) -> bool {
         self.event.is_some()
     }

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -367,6 +367,31 @@ vllm_configs = {
             completion_payload_default(),
         ],
     ),
+    "disaggregated_same_gpu_chat_processor_kv_router": VLLMConfig(
+        name="disaggregated_same_gpu_chat_processor_kv_router",
+        directory=vllm_dir,
+        script_name="disagg_same_gpu.sh",
+        marks=[
+            pytest.mark.gpu_1,
+            pytest.mark.profiled_vram_gib(7.3),
+            pytest.mark.requested_vllm_kv_cache_bytes(1_023_525_000),
+            pytest.mark.timeout(300),
+            pytest.mark.post_merge,
+        ],
+        model="Qwen/Qwen3-0.6B",
+        delayed_start=10,
+        health_check_workers=True,
+        env={
+            "DYN_CHAT_PROCESSOR": "vllm",
+            "DYN_ROUTER_MODE": "kv",
+            # Deterministic hash for KV event IDs, matches disagg_router.sh.
+            "PYTHONHASHSEED": "0",
+        },
+        request_payloads=[
+            chat_payload_default(),
+            completion_payload_default(),
+        ],
+    ),
     "deepep": VLLMConfig(
         name="deepep",
         directory=vllm_dir,

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -347,6 +347,26 @@ vllm_configs = {
             completion_payload_default(),
         ],
     ),
+    "disaggregated_same_gpu_chat_processor": VLLMConfig(
+        name="disaggregated_same_gpu_chat_processor",
+        directory=vllm_dir,
+        script_name="disagg_same_gpu.sh",
+        marks=[
+            pytest.mark.gpu_1,
+            pytest.mark.profiled_vram_gib(7.3),
+            pytest.mark.requested_vllm_kv_cache_bytes(1_023_525_000),
+            pytest.mark.timeout(300),
+            pytest.mark.post_merge,
+        ],
+        model="Qwen/Qwen3-0.6B",
+        delayed_start=10,
+        health_check_workers=True,
+        env={"DYN_CHAT_PROCESSOR": "vllm"},
+        request_payloads=[
+            chat_payload_default(),
+            completion_payload_default(),
+        ],
+    ),
     "deepep": VLLMConfig(
         name="deepep",
         directory=vllm_dir,


### PR DESCRIPTION
All the details in #9440 .

Closes: #9440

Before, the vllm/sglang pre-processor would do it's thing, and then call either `Client::generate` or `KvRouter::generate` which are both in Rust and push the tokenized request to the backend.

Now it calls new `RoutedEngine::generate` in exactly the same way, which is also Rust. This wraps `Client` or kv router with `PrefillRouter` which adds disagg support. It is quite elegant, the Python hardly changes.

Later we will add `Migation` in that `RoutedEngine`.

Tested locally with and without kv-routing.

Assisted-By: Claude Opus/4.7 (plan, review)
Assisted-By: Codex GPT/5.5 (spec, execute plan, review)
... and the trusty Code Rabbit of course.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9503" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9503)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->