### PR TITLE
feat: disable caching inactive blocks toggles: pool-level and per-block

### DIFF
--- a/lib/kvbm-logical/src/blocks/immutable.rs
+++ b/lib/kvbm-logical/src/blocks/immutable.rs
@@ -232,9 +232,7 @@ impl<T: BlockMetadata + Sync> ImmutableBlock<T> {
     /// This is unavoidable — the dropping `Inner` is on another thread
     /// mid-`Drop` and its atomic is unreachable.
     pub fn set_evict_on_reset(&self, value: bool) {
-        self.inner
-            .reset_on_release
-            .store(value, Ordering::Relaxed);
+        self.inner.reset_on_release.store(value, Ordering::Relaxed);
     }
 
     /// Type-erased lifecycle pin for cross-policy use.

--- a/lib/kvbm-logical/src/blocks/immutable.rs
+++ b/lib/kvbm-logical/src/blocks/immutable.rs
@@ -21,7 +21,6 @@
 //! resurrecting an evicted block from the store's inactive pool through
 //! the registry (slow path).
 
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Weak};
 
 use crate::ManagerId;
@@ -32,6 +31,12 @@ use crate::pools::{BlockStore, store::upgrade_or_resurrect};
 /// Internal owner of a registered slot. Every clone of an
 /// [`ImmutableBlock`] shares an `Arc<ImmutableBlockInner<T>>`. When the
 /// last `Arc` is dropped the slot transitions per `is_primary`.
+///
+/// The per-block "reset on release" override is *not* stored here —
+/// it lives in `BlockStore::reset_on_release[block_id]` and is read by
+/// `release_primary` under the store mutex. This keeps the override
+/// visible to the lookup-driven eager `Primary → Inactive` path even
+/// when this Inner is mid-drop.
 pub(crate) struct ImmutableBlockInner<T: BlockMetadata> {
     store: Arc<BlockStore<T>>,
     block_id: BlockId,
@@ -42,15 +47,6 @@ pub(crate) struct ImmutableBlockInner<T: BlockMetadata> {
     /// the primary cannot transition to `Inactive` (and thus be evicted)
     /// while any duplicate is alive.
     _primary_keepalive: Option<Arc<ImmutableBlockInner<T>>>,
-    /// When `true` *and* this is the last clone of a primary inner, the
-    /// slot bypasses the inactive pool and goes straight back to the
-    /// reset/free list (matches `release_duplicate` semantics). Mutated
-    /// via [`ImmutableBlock::set_evict_on_reset`] with `Relaxed`
-    /// ordering: only this Inner's `Drop` reads it, and `Drop` cannot
-    /// race with any `set_evict_on_reset` because the latter requires a
-    /// live `ImmutableBlock` clone (Arc strong ≥ 1) while `Drop` fires
-    /// at strong = 0. Initialized from `BlockStore::default_reset_on_release`.
-    reset_on_release: AtomicBool,
 }
 
 impl<T: BlockMetadata + Sync> ImmutableBlockInner<T> {
@@ -60,7 +56,6 @@ impl<T: BlockMetadata + Sync> ImmutableBlockInner<T> {
         seq_hash: SequenceHash,
         handle: BlockRegistrationHandle,
     ) -> Arc<Self> {
-        let reset_on_release = AtomicBool::new(store.default_reset_on_release());
         Arc::new(Self {
             store,
             block_id,
@@ -68,30 +63,6 @@ impl<T: BlockMetadata + Sync> ImmutableBlockInner<T> {
             handle,
             is_primary: true,
             _primary_keepalive: None,
-            reset_on_release,
-        })
-    }
-
-    /// Resurrection constructor: the slot is being promoted
-    /// `Inactive → Primary`. The `reset_on_release` flag is the value
-    /// captured into `SlotState::Inactive` from the previous holder's
-    /// last drop — *not* the store default. This makes a per-block
-    /// `set_evict_on_reset` override sticky across the cache-hit cycle.
-    pub(crate) fn new_primary_resurrected(
-        store: Arc<BlockStore<T>>,
-        block_id: BlockId,
-        seq_hash: SequenceHash,
-        handle: BlockRegistrationHandle,
-        reset_on_release: bool,
-    ) -> Arc<Self> {
-        Arc::new(Self {
-            store,
-            block_id,
-            seq_hash,
-            handle,
-            is_primary: true,
-            _primary_keepalive: None,
-            reset_on_release: AtomicBool::new(reset_on_release),
         })
     }
 
@@ -102,10 +73,6 @@ impl<T: BlockMetadata + Sync> ImmutableBlockInner<T> {
         handle: BlockRegistrationHandle,
         primary: Arc<ImmutableBlockInner<T>>,
     ) -> Arc<Self> {
-        // Duplicates always reset on drop regardless of this flag (see
-        // `release_duplicate`), but initialize from the store default for
-        // symmetry so any reader sees a consistent value.
-        let reset_on_release = AtomicBool::new(store.default_reset_on_release());
         Arc::new(Self {
             store,
             block_id,
@@ -113,7 +80,6 @@ impl<T: BlockMetadata + Sync> ImmutableBlockInner<T> {
             handle,
             is_primary: false,
             _primary_keepalive: Some(primary),
-            reset_on_release,
         })
     }
 
@@ -142,13 +108,12 @@ impl<T: BlockMetadata> Drop for ImmutableBlockInner<T> {
         // self_ptr identifies *this* Inner so the store can verify slot
         // identity before transitioning. If a concurrent
         // `acquire_for_hash` already eagerly completed the transition,
-        // the store call is a no-op.
+        // the store call is a no-op. The destination decision (Inactive
+        // vs Reset) is taken inside `release_primary` from the
+        // store-owned per-slot atomic.
         let self_ptr = self as *const ImmutableBlockInner<T> as *const ();
         if self.is_primary {
-            // `&mut self` excludes concurrent access; plain field read.
-            let reset_on_release = *self.reset_on_release.get_mut();
-            self.store
-                .release_primary(self.block_id, self_ptr, reset_on_release);
+            self.store.release_primary(self.block_id, self_ptr);
         } else {
             self.store.release_duplicate(self.block_id, self_ptr);
         }
@@ -212,27 +177,26 @@ impl<T: BlockMetadata + Sync> ImmutableBlock<T> {
     ///
     /// The override is sticky across cache-hit resurrections: if the
     /// block lands in the inactive pool and is later matched, the
-    /// resurrected `ImmutableBlock` inherits this value rather than
-    /// reading the store default. The override is discarded only when
-    /// the slot truly leaves the inactive pool (eviction back to
-    /// `Mutable`) or when the slot is reset.
+    /// resurrected `ImmutableBlock` inherits this value. The override
+    /// is reset to the store-wide default only when the slot truly
+    /// leaves the inactive pool (eviction back to `Mutable`).
     ///
-    /// Best-effort, lock-free: stored with `Ordering::Relaxed`. While
-    /// other clones exist, this block can still be matched by sequence
-    /// hash and acquired by other consumers — only the *last* drop
-    /// honors the flag. The flag is shared across clones via the
-    /// underlying `Arc`, so concurrent setters race with
-    /// last-writer-wins semantics.
+    /// Briefly acquires the store mutex to publish the write. Not a hot
+    /// path — typically called at most once per block. Concurrent
+    /// setters race with last-writer-wins semantics under the mutex.
     ///
-    /// There is one narrow race where the override is lost: if a
+    /// Race-window guarantee: the override is preserved even when a
     /// concurrent `match_blocks` drives the eager `Primary → Inactive`
     /// transition (because this `Inner`'s `Arc` strong-count went to 0
-    /// before `release_primary` ran), the new `Inactive` slot is
-    /// initialised from the store default instead of this override.
-    /// This is unavoidable — the dropping `Inner` is on another thread
-    /// mid-`Drop` and its atomic is unreachable.
+    /// before `release_primary` ran). The eager path leaves the
+    /// per-slot value untouched, and every reader of that value also
+    /// goes through the same store mutex — so visibility comes from
+    /// release-acquire on the mutex, not from any assumption about
+    /// `Arc::drop` / `Weak::upgrade` ordering.
     pub fn set_evict_on_reset(&self, value: bool) {
-        self.inner.reset_on_release.store(value, Ordering::Relaxed);
+        self.inner
+            .store
+            .store_reset_on_release(self.inner.block_id, value);
     }
 
     /// Type-erased lifecycle pin for cross-policy use.

--- a/lib/kvbm-logical/src/blocks/immutable.rs
+++ b/lib/kvbm-logical/src/blocks/immutable.rs
@@ -21,6 +21,7 @@
 //! resurrecting an evicted block from the store's inactive pool through
 //! the registry (slow path).
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Weak};
 
 use crate::ManagerId;
@@ -41,6 +42,15 @@ pub(crate) struct ImmutableBlockInner<T: BlockMetadata> {
     /// the primary cannot transition to `Inactive` (and thus be evicted)
     /// while any duplicate is alive.
     _primary_keepalive: Option<Arc<ImmutableBlockInner<T>>>,
+    /// When `true` *and* this is the last clone of a primary inner, the
+    /// slot bypasses the inactive pool and goes straight back to the
+    /// reset/free list (matches `release_duplicate` semantics). Mutated
+    /// via [`ImmutableBlock::set_evict_on_reset`] with `Relaxed`
+    /// ordering: only this Inner's `Drop` reads it, and `Drop` cannot
+    /// race with any `set_evict_on_reset` because the latter requires a
+    /// live `ImmutableBlock` clone (Arc strong ≥ 1) while `Drop` fires
+    /// at strong = 0. Initialized from `BlockStore::default_reset_on_release`.
+    reset_on_release: AtomicBool,
 }
 
 impl<T: BlockMetadata + Sync> ImmutableBlockInner<T> {
@@ -50,6 +60,7 @@ impl<T: BlockMetadata + Sync> ImmutableBlockInner<T> {
         seq_hash: SequenceHash,
         handle: BlockRegistrationHandle,
     ) -> Arc<Self> {
+        let reset_on_release = AtomicBool::new(store.default_reset_on_release());
         Arc::new(Self {
             store,
             block_id,
@@ -57,6 +68,30 @@ impl<T: BlockMetadata + Sync> ImmutableBlockInner<T> {
             handle,
             is_primary: true,
             _primary_keepalive: None,
+            reset_on_release,
+        })
+    }
+
+    /// Resurrection constructor: the slot is being promoted
+    /// `Inactive → Primary`. The `reset_on_release` flag is the value
+    /// captured into `SlotState::Inactive` from the previous holder's
+    /// last drop — *not* the store default. This makes a per-block
+    /// `set_evict_on_reset` override sticky across the cache-hit cycle.
+    pub(crate) fn new_primary_resurrected(
+        store: Arc<BlockStore<T>>,
+        block_id: BlockId,
+        seq_hash: SequenceHash,
+        handle: BlockRegistrationHandle,
+        reset_on_release: bool,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            store,
+            block_id,
+            seq_hash,
+            handle,
+            is_primary: true,
+            _primary_keepalive: None,
+            reset_on_release: AtomicBool::new(reset_on_release),
         })
     }
 
@@ -67,6 +102,10 @@ impl<T: BlockMetadata + Sync> ImmutableBlockInner<T> {
         handle: BlockRegistrationHandle,
         primary: Arc<ImmutableBlockInner<T>>,
     ) -> Arc<Self> {
+        // Duplicates always reset on drop regardless of this flag (see
+        // `release_duplicate`), but initialize from the store default for
+        // symmetry so any reader sees a consistent value.
+        let reset_on_release = AtomicBool::new(store.default_reset_on_release());
         Arc::new(Self {
             store,
             block_id,
@@ -74,6 +113,7 @@ impl<T: BlockMetadata + Sync> ImmutableBlockInner<T> {
             handle,
             is_primary: false,
             _primary_keepalive: Some(primary),
+            reset_on_release,
         })
     }
 
@@ -105,7 +145,10 @@ impl<T: BlockMetadata> Drop for ImmutableBlockInner<T> {
         // the store call is a no-op.
         let self_ptr = self as *const ImmutableBlockInner<T> as *const ();
         if self.is_primary {
-            self.store.release_primary(self.block_id, self_ptr);
+            // `&mut self` excludes concurrent access; plain field read.
+            let reset_on_release = *self.reset_on_release.get_mut();
+            self.store
+                .release_primary(self.block_id, self_ptr, reset_on_release);
         } else {
             self.store.release_duplicate(self.block_id, self_ptr);
         }
@@ -158,6 +201,40 @@ impl<T: BlockMetadata + Sync> ImmutableBlock<T> {
     /// inner.
     pub fn use_count(&self) -> usize {
         Arc::strong_count(&self.inner)
+    }
+
+    /// Set the per-block "reset on release" override.
+    ///
+    /// When the last clone of this block drops, the slot transitions to
+    /// the reset/free list (`true`) or to the inactive cache (`false`),
+    /// overriding the store-wide default set by
+    /// `BlockManagerConfigBuilder::with_default_reset_on_release`.
+    ///
+    /// The override is sticky across cache-hit resurrections: if the
+    /// block lands in the inactive pool and is later matched, the
+    /// resurrected `ImmutableBlock` inherits this value rather than
+    /// reading the store default. The override is discarded only when
+    /// the slot truly leaves the inactive pool (eviction back to
+    /// `Mutable`) or when the slot is reset.
+    ///
+    /// Best-effort, lock-free: stored with `Ordering::Relaxed`. While
+    /// other clones exist, this block can still be matched by sequence
+    /// hash and acquired by other consumers — only the *last* drop
+    /// honors the flag. The flag is shared across clones via the
+    /// underlying `Arc`, so concurrent setters race with
+    /// last-writer-wins semantics.
+    ///
+    /// There is one narrow race where the override is lost: if a
+    /// concurrent `match_blocks` drives the eager `Primary → Inactive`
+    /// transition (because this `Inner`'s `Arc` strong-count went to 0
+    /// before `release_primary` ran), the new `Inactive` slot is
+    /// initialised from the store default instead of this override.
+    /// This is unavoidable — the dropping `Inner` is on another thread
+    /// mid-`Drop` and its atomic is unreachable.
+    pub fn set_evict_on_reset(&self, value: bool) {
+        self.inner
+            .reset_on_release
+            .store(value, Ordering::Relaxed);
     }
 
     /// Type-erased lifecycle pin for cross-policy use.

--- a/lib/kvbm-logical/src/manager/builder.rs
+++ b/lib/kvbm-logical/src/manager/builder.rs
@@ -108,6 +108,13 @@ pub struct BlockManagerConfigBuilder<T: BlockMetadata> {
     /// Optional metrics aggregator for prometheus export
     aggregator: Option<MetricsAggregator>,
 
+    /// Default value of the per-block `reset_on_release` flag. When
+    /// `Some(true)`, every `ImmutableBlock` constructed by this manager
+    /// starts with the flag set, so its last drop bypasses the inactive
+    /// pool and resets the slot directly. Individual blocks can still
+    /// override via [`ImmutableBlock::set_evict_on_reset`].
+    default_reset_on_release: Option<bool>,
+
     /// Phantom data for type parameter
     _phantom: std::marker::PhantomData<T>,
 }
@@ -121,6 +128,7 @@ impl<T: BlockMetadata> Default for BlockManagerConfigBuilder<T> {
             inactive_backend: None,
             duplication_policy: None,
             aggregator: None,
+            default_reset_on_release: None,
             _phantom: std::marker::PhantomData,
         }
     }
@@ -258,6 +266,22 @@ impl<T: BlockMetadata> BlockManagerConfigBuilder<T> {
         self
     }
 
+    /// Set the default value of the per-block `reset_on_release` flag.
+    ///
+    /// When `true`, every `ImmutableBlock` constructed by this manager
+    /// starts with the flag set. On its last drop, the slot bypasses
+    /// the inactive pool and is reset back to the free list directly
+    /// (matching `release_duplicate` semantics for primary releases).
+    ///
+    /// Individual blocks can still override via
+    /// [`crate::blocks::ImmutableBlock::set_evict_on_reset`].
+    ///
+    /// Default: `false`.
+    pub fn with_default_reset_on_release(mut self, value: bool) -> Self {
+        self.default_reset_on_release = Some(value);
+        self
+    }
+
     /// Validate the configuration.
     fn validate(&self) -> Result<(), String> {
         let registry = self.registry.as_ref().ok_or("registry is required")?;
@@ -379,7 +403,13 @@ impl<T: BlockMetadata> BlockManagerConfigBuilder<T> {
         };
 
         // Construct unified store
-        let store = BlockStore::new(block_count, block_size, backend, metrics.clone());
+        let store = BlockStore::new(
+            block_count,
+            block_size,
+            backend,
+            metrics.clone(),
+            self.default_reset_on_release.unwrap_or(false),
+        );
 
         // Register with aggregator if provided
         if let Some(ref aggregator) = self.aggregator {

--- a/lib/kvbm-logical/src/manager/tests.rs
+++ b/lib/kvbm-logical/src/manager/tests.rs
@@ -3400,4 +3400,369 @@ mod reset_on_release_tests {
         drop(primary);
         assert_eq!(store.inactive_len(), inactive_before + 1);
     }
+
+    /// Override survives two full `Inactive → Primary → Inactive`
+    /// hops. Extends `opt_out_survives_inactive_resurrection` (one hop)
+    /// to guarantee the carry path in `acquire_for_hash` /
+    /// `match_blocks` is idempotent across repeated cache hits.
+    #[test]
+    fn override_survives_multiple_resurrection_cycles() {
+        let manager =
+            create_test_manager_with_default_reset_on_release::<TestBlockData>(4, true);
+        let token = create_test_token_block_from_iota(50_010);
+        let hash = token.kvbm_sequence_hash();
+
+        let mutables = manager.allocate_blocks(1).unwrap();
+        let complete = mutables
+            .into_iter()
+            .next()
+            .unwrap()
+            .complete(&token)
+            .unwrap();
+        let imm = manager
+            .register_blocks(vec![complete])
+            .into_iter()
+            .next()
+            .unwrap();
+        imm.set_evict_on_reset(false); // opt out of store-wide default
+        drop(imm);
+
+        let store = manager.store_for_test();
+        assert_eq!(store.inactive_len(), 1, "first drop landed in inactive");
+        assert_eq!(store.reset_len(), 3);
+
+        // First resurrection
+        let r1 = manager.match_blocks(&[hash]);
+        assert_eq!(r1.len(), 1);
+        assert_eq!(store.inactive_len(), 0);
+        drop(r1);
+        assert_eq!(
+            store.inactive_len(),
+            1,
+            "override survived first resurrection"
+        );
+        assert_eq!(store.reset_len(), 3);
+
+        // Second resurrection — same path, must still honor the override.
+        let r2 = manager.match_blocks(&[hash]);
+        assert_eq!(r2.len(), 1);
+        assert_eq!(store.inactive_len(), 0);
+        drop(r2);
+        assert_eq!(
+            store.inactive_len(),
+            1,
+            "override survived second resurrection"
+        );
+        assert_eq!(store.reset_len(), 3);
+        assert!(store.has_inactive(hash));
+        assert!(manager.block_registry().is_registered(hash));
+    }
+
+    /// Calling `set_evict_on_reset` on a resurrected `ImmutableBlock`
+    /// must take effect — the resurrected Inner's atomic is the
+    /// authoritative one. Resurrect with an inherited `false`, then
+    /// flip to `true` and drop: slot must reset, not stay in inactive.
+    ///
+    /// Guards against a regression where `new_primary_resurrected` is
+    /// decoupled from the setter (e.g. wrong Arc, wrong field).
+    #[test]
+    fn set_evict_on_reset_on_resurrected_inner_takes_effect() {
+        let manager =
+            create_test_manager_with_default_reset_on_release::<TestBlockData>(4, true);
+        let token = create_test_token_block_from_iota(50_011);
+        let hash = token.kvbm_sequence_hash();
+
+        let mutables = manager.allocate_blocks(1).unwrap();
+        let complete = mutables
+            .into_iter()
+            .next()
+            .unwrap()
+            .complete(&token)
+            .unwrap();
+        let imm = manager
+            .register_blocks(vec![complete])
+            .into_iter()
+            .next()
+            .unwrap();
+        imm.set_evict_on_reset(false);
+        drop(imm);
+
+        let store = manager.store_for_test();
+        assert_eq!(store.inactive_len(), 1);
+
+        // Resurrect: inherited override is `false`.
+        let resurrected = manager.match_blocks(&[hash]);
+        assert_eq!(resurrected.len(), 1);
+
+        // Flip on the *resurrected* Inner. If the setter wires through
+        // correctly, the next drop honors `true` and resets.
+        resurrected[0].set_evict_on_reset(true);
+        drop(resurrected);
+
+        assert_eq!(
+            store.inactive_len(),
+            0,
+            "resurrected-Inner setter took effect"
+        );
+        assert_eq!(store.reset_len(), 4, "slot returned to free list");
+        assert!(!manager.block_registry().is_registered(hash));
+    }
+
+    /// Three blocks registered in a single `register_blocks` call must
+    /// honor independent per-block flags. Guards against any future
+    /// refactor that shares state across the registration loop.
+    #[test]
+    fn mixed_flags_in_single_register_blocks_call() {
+        let manager = create_test_manager(4);
+        let t0 = create_test_token_block_from_iota(50_020);
+        let t1 = create_test_token_block_from_iota(50_021);
+        let t2 = create_test_token_block_from_iota(50_022);
+        let h0 = t0.kvbm_sequence_hash();
+        let h1 = t1.kvbm_sequence_hash();
+        let h2 = t2.kvbm_sequence_hash();
+
+        let mutables = manager.allocate_blocks(3).unwrap();
+        let mut iter = mutables.into_iter();
+        let c0 = iter.next().unwrap().complete(&t0).unwrap();
+        let c1 = iter.next().unwrap().complete(&t1).unwrap();
+        let c2 = iter.next().unwrap().complete(&t2).unwrap();
+
+        let immutables = manager.register_blocks(vec![c0, c1, c2]);
+        assert_eq!(immutables.len(), 3);
+        immutables[0].set_evict_on_reset(true);
+        // immutables[1] left at default (false)
+        immutables[2].set_evict_on_reset(true);
+
+        let store = manager.store_for_test();
+        assert_eq!(store.inactive_len(), 0);
+        assert_eq!(store.reset_len(), 1, "1 of 4 slots still free");
+
+        drop(immutables);
+
+        assert_eq!(
+            store.inactive_len(),
+            1,
+            "only the default-flag block kept in inactive"
+        );
+        assert_eq!(
+            store.reset_len(),
+            3,
+            "two flagged blocks reset + one originally free"
+        );
+        assert!(!store.has_inactive(h0), "flagged block 0 not in inactive");
+        assert!(store.has_inactive(h1), "default-flag block 1 in inactive");
+        assert!(!store.has_inactive(h2), "flagged block 2 not in inactive");
+        assert!(!manager.block_registry().is_registered(h0));
+        assert!(manager.block_registry().is_registered(h1));
+        assert!(!manager.block_registry().is_registered(h2));
+    }
+
+    /// The per-block override must be discarded when the slot leaves
+    /// `Inactive` via eviction back to `Mutable`. A subsequent fresh
+    /// registration on the same `BlockId` must read the store default,
+    /// not inherit the previous holder's override.
+    ///
+    /// Documented invariant from `pools/store.rs`: "The flag is
+    /// discarded when the slot leaves `Inactive` via eviction
+    /// (`Inactive → Mutable`); a future fresh registration on the same
+    /// `BlockId` reads the store default again."
+    #[test]
+    fn override_discarded_on_eviction_back_to_mutable() {
+        // block_count=1 so the second allocate must evict from inactive.
+        let manager =
+            create_test_manager_with_default_reset_on_release::<TestBlockData>(1, true);
+        let store = manager.store_for_test().clone();
+
+        // First registration: opt OUT of the store default → Inactive(false).
+        let token1 = create_test_token_block_from_iota(50_030);
+        let hash1 = token1.kvbm_sequence_hash();
+        {
+            let mutables = manager.allocate_blocks(1).unwrap();
+            let complete = mutables
+                .into_iter()
+                .next()
+                .unwrap()
+                .complete(&token1)
+                .unwrap();
+            let imm = manager
+                .register_blocks(vec![complete])
+                .into_iter()
+                .next()
+                .unwrap();
+            imm.set_evict_on_reset(false);
+            drop(imm);
+        }
+        assert_eq!(store.inactive_len(), 1, "first drop kept in inactive");
+        assert_eq!(store.reset_len(), 0);
+
+        // Force eviction: only slot is in inactive, allocate must evict.
+        let mutables = manager.allocate_blocks(1).unwrap();
+        assert_eq!(store.inactive_len(), 0, "inactive evicted to mutable");
+        assert!(!manager.block_registry().is_registered(hash1));
+
+        // Re-register on the same BlockId with a fresh hash. The fresh
+        // Inner is constructed via `new_primary` (not resurrected) and
+        // must read the store default (true) — NOT inherit the discarded
+        // `false` override.
+        let token2 = create_test_token_block_from_iota(50_031);
+        let hash2 = token2.kvbm_sequence_hash();
+        let complete = mutables
+            .into_iter()
+            .next()
+            .unwrap()
+            .complete(&token2)
+            .unwrap();
+        let imm = manager
+            .register_blocks(vec![complete])
+            .into_iter()
+            .next()
+            .unwrap();
+        // No explicit `set_evict_on_reset` — fresh Inner must read the
+        // store default (true) from `BlockStore::default_reset_on_release`.
+        drop(imm);
+
+        assert_eq!(
+            store.reset_len(),
+            1,
+            "fresh Inner used store default — slot reset, not inactive"
+        );
+        assert_eq!(store.inactive_len(), 0);
+        assert!(!store.has_inactive(hash2));
+        assert!(!manager.block_registry().is_registered(hash2));
+    }
+
+    /// Calling `set_evict_on_reset(true)` on a *duplicate* must not
+    /// affect its drop (always resets via `release_duplicate`) and must
+    /// not affect the *primary*'s atomic — they live on separate Inners.
+    /// Guards against a refactor that unifies primary/duplicate Inner
+    /// state and silently makes the duplicate's flag observable on the
+    /// primary.
+    #[test]
+    fn duplicate_set_evict_on_reset_is_noop() {
+        let registry = crate::registry::BlockRegistry::builder()
+            .frequency_tracker(
+                crate::manager::FrequencyTrackingCapacity::default().create_tracker(),
+            )
+            .build();
+        let manager = BlockManager::<TestBlockData>::builder()
+            .block_count(4)
+            .block_size(4)
+            .registry(registry)
+            .with_lru_backend()
+            .duplication_policy(BlockDuplicationPolicy::Allow)
+            .build()
+            .expect("Should build manager");
+
+        let token = create_test_token_block_from_iota(50_040);
+        let hash = token.kvbm_sequence_hash();
+
+        // Primary
+        let m1 = manager.allocate_blocks(1).unwrap();
+        let c1 = m1.into_iter().next().unwrap().complete(&token).unwrap();
+        let primary = manager
+            .register_blocks(vec![c1])
+            .into_iter()
+            .next()
+            .unwrap();
+
+        // Duplicate
+        let m2 = manager.allocate_blocks(1).unwrap();
+        let c2 = m2.into_iter().next().unwrap().complete(&token).unwrap();
+        let dup = manager
+            .register_blocks(vec![c2])
+            .into_iter()
+            .next()
+            .unwrap();
+        assert_ne!(primary.block_id(), dup.block_id());
+
+        // Flag on the duplicate — must be a no-op at drop.
+        dup.set_evict_on_reset(true);
+
+        let store = manager.store_for_test();
+        let reset_before = store.reset_len();
+        let inactive_before = store.inactive_len();
+
+        drop(dup);
+        assert_eq!(
+            store.reset_len(),
+            reset_before + 1,
+            "duplicate drop resets regardless of flag"
+        );
+        assert_eq!(
+            store.inactive_len(),
+            inactive_before,
+            "duplicate drop never enters inactive"
+        );
+
+        // Primary must be entirely unaffected by the duplicate's flag:
+        // still matchable, its own atomic still at default (false), so
+        // dropping it lands in inactive.
+        let matched = manager.match_blocks(&[hash]);
+        assert_eq!(matched.len(), 1, "primary still matchable after dup drop");
+        assert_eq!(matched[0].block_id(), primary.block_id());
+        drop(matched);
+        drop(primary);
+
+        assert_eq!(
+            store.inactive_len(),
+            inactive_before + 1,
+            "primary drop honors its own flag (default false → inactive), \
+             unaffected by duplicate's flag"
+        );
+    }
+
+    /// Pool gauges (`inflight_immutable`, `inactive_pool_size`,
+    /// `reset_pool_size`) must stay coherent across the full lifecycle
+    /// when the reset-on-release flag fires. Regression-protects the
+    /// metric plumbing in `release_primary`.
+    #[test]
+    fn metric_gauges_stay_coherent_under_reset_flag() {
+        let manager = create_test_manager(4);
+        let m = manager.metrics();
+        let token = create_test_token_block_from_iota(50_050);
+
+        // Baseline: 4 free slots, nothing in flight.
+        let s = m.snapshot();
+        assert_eq!(s.inflight_immutable, 0);
+        assert_eq!(s.inactive_pool_size, 0);
+        assert_eq!(s.reset_pool_size, 4);
+
+        // Allocate 1 mutable → reset pool decrements; no immutable yet.
+        let mutables = manager.allocate_blocks(1).unwrap();
+        let s = m.snapshot();
+        assert_eq!(s.inflight_immutable, 0, "no immutable until register");
+        assert_eq!(s.inactive_pool_size, 0);
+        assert_eq!(s.reset_pool_size, 3);
+
+        // Complete + register → 1 in flight.
+        let complete = mutables
+            .into_iter()
+            .next()
+            .unwrap()
+            .complete(&token)
+            .unwrap();
+        let imm = manager
+            .register_blocks(vec![complete])
+            .into_iter()
+            .next()
+            .unwrap();
+        let s = m.snapshot();
+        assert_eq!(s.inflight_immutable, 1);
+        assert_eq!(s.inactive_pool_size, 0);
+        assert_eq!(s.reset_pool_size, 3);
+
+        // Flip the flag — pure state change, no gauge movement.
+        imm.set_evict_on_reset(true);
+        let s = m.snapshot();
+        assert_eq!(s.inflight_immutable, 1);
+        assert_eq!(s.inactive_pool_size, 0);
+        assert_eq!(s.reset_pool_size, 3);
+
+        // Drop with flag=true → bypasses inactive, slot returns to reset.
+        drop(imm);
+        let s = m.snapshot();
+        assert_eq!(s.inflight_immutable, 0, "drop decremented immutable");
+        assert_eq!(s.inactive_pool_size, 0, "inactive gauge unchanged");
+        assert_eq!(s.reset_pool_size, 4, "reset gauge incremented, not inactive");
+    }
 }

--- a/lib/kvbm-logical/src/manager/tests.rs
+++ b/lib/kvbm-logical/src/manager/tests.rs
@@ -3152,8 +3152,7 @@ mod reset_on_release_tests {
     /// Store-wide default: every primary release bypasses inactive.
     #[test]
     fn store_wide_default_resets_on_release() {
-        let manager =
-            create_test_manager_with_default_reset_on_release::<TestBlockData>(4, true);
+        let manager = create_test_manager_with_default_reset_on_release::<TestBlockData>(4, true);
         let token = create_test_token_block_from_iota(50_005);
         let hash = token.kvbm_sequence_hash();
 
@@ -3189,8 +3188,7 @@ mod reset_on_release_tests {
     /// "Preserve per-block opt-out across inactive hits".
     #[test]
     fn opt_out_survives_inactive_resurrection() {
-        let manager =
-            create_test_manager_with_default_reset_on_release::<TestBlockData>(4, true);
+        let manager = create_test_manager_with_default_reset_on_release::<TestBlockData>(4, true);
         let token = create_test_token_block_from_iota(50_009);
         let hash = token.kvbm_sequence_hash();
 
@@ -3237,8 +3235,7 @@ mod reset_on_release_tests {
     /// Holder can opt out of the store-wide default for a specific block.
     #[test]
     fn per_block_can_opt_out_of_store_default() {
-        let manager =
-            create_test_manager_with_default_reset_on_release::<TestBlockData>(4, true);
+        let manager = create_test_manager_with_default_reset_on_release::<TestBlockData>(4, true);
         let token = create_test_token_block_from_iota(50_006);
         let hash = token.kvbm_sequence_hash();
 
@@ -3407,8 +3404,7 @@ mod reset_on_release_tests {
     /// `match_blocks` is idempotent across repeated cache hits.
     #[test]
     fn override_survives_multiple_resurrection_cycles() {
-        let manager =
-            create_test_manager_with_default_reset_on_release::<TestBlockData>(4, true);
+        let manager = create_test_manager_with_default_reset_on_release::<TestBlockData>(4, true);
         let token = create_test_token_block_from_iota(50_010);
         let hash = token.kvbm_sequence_hash();
 
@@ -3467,8 +3463,7 @@ mod reset_on_release_tests {
     /// decoupled from the setter (e.g. wrong Arc, wrong field).
     #[test]
     fn set_evict_on_reset_on_resurrected_inner_takes_effect() {
-        let manager =
-            create_test_manager_with_default_reset_on_release::<TestBlockData>(4, true);
+        let manager = create_test_manager_with_default_reset_on_release::<TestBlockData>(4, true);
         let token = create_test_token_block_from_iota(50_011);
         let hash = token.kvbm_sequence_hash();
 
@@ -3569,8 +3564,7 @@ mod reset_on_release_tests {
     #[test]
     fn override_discarded_on_eviction_back_to_mutable() {
         // block_count=1 so the second allocate must evict from inactive.
-        let manager =
-            create_test_manager_with_default_reset_on_release::<TestBlockData>(1, true);
+        let manager = create_test_manager_with_default_reset_on_release::<TestBlockData>(1, true);
         let store = manager.store_for_test().clone();
 
         // First registration: opt OUT of the store default → Inactive(false).
@@ -3763,6 +3757,9 @@ mod reset_on_release_tests {
         let s = m.snapshot();
         assert_eq!(s.inflight_immutable, 0, "drop decremented immutable");
         assert_eq!(s.inactive_pool_size, 0, "inactive gauge unchanged");
-        assert_eq!(s.reset_pool_size, 4, "reset gauge incremented, not inactive");
+        assert_eq!(
+            s.reset_pool_size, 4,
+            "reset gauge incremented, not inactive"
+        );
     }
 }

--- a/lib/kvbm-logical/src/manager/tests.rs
+++ b/lib/kvbm-logical/src/manager/tests.rs
@@ -3261,13 +3261,17 @@ mod reset_on_release_tests {
     }
 
     /// Eager-resurrection path (concurrent lookup observes Arc strong=0
-    /// before Drop's `release_primary` fires) ignores the flag. The
-    /// resurrected block is a fresh Inner with the store default.
+    /// before Drop's `release_primary` fires) preserves the per-block
+    /// override. The override lives in the store-owned per-slot atomic
+    /// (not on the dropping Inner), so the eager `Primary → Inactive`
+    /// transition rides over the race window without losing the flag.
+    /// The resurrected block reads the same atomic on its own drop.
     ///
     /// Mirrors `eager_primary_to_inactive_is_deterministic_with_pause_hook`
-    /// in `race_regression_tests`.
+    /// in `race_regression_tests`. Regression test for the review finding
+    /// at https://github.com/ai-dynamo/dynamo/pull/9504#discussion_r3238515930.
     #[test]
-    fn eager_resurrection_ignores_flag() {
+    fn eager_resurrection_preserves_flag() {
         use std::sync::Arc;
         use std::thread;
 
@@ -3299,9 +3303,10 @@ mod reset_on_release_tests {
             std::thread::yield_now();
         }
 
-        // Concurrent lookup drives the eager transition. Even though the
-        // dropping Inner had flag=true, the eager path takes the Inactive
-        // branch (someone wants the block right now).
+        // Concurrent lookup drives the eager `Primary → Inactive`
+        // transition. The dropping Inner had flag=true; the eager path
+        // leaves the per-slot atomic untouched, so the override rides
+        // over the race window.
         let matched = manager.match_blocks(&[hash]);
         assert_eq!(matched.len(), 1, "eager resurrection must succeed");
 
@@ -3315,22 +3320,28 @@ mod reset_on_release_tests {
         drop_t.join().unwrap();
 
         // The parked drop saw a slot that no longer matched its self_ptr
-        // and no-opped — its flag had no effect.
+        // and no-opped — its destination decision was preempted by the
+        // eager path.
         let snap_after = manager.metrics().snapshot();
         assert_eq!(snap_after.release_primary_noop_total, 1);
 
-        // The new Inner (held by `matched`) inherited the *store
-        // default* (false), not the previous holder's `true`. Drop it
-        // and assert it lands in the inactive pool, not reset.
+        // The resurrected Inner reads the per-slot atomic on its own
+        // drop. Because the original holder had set the override to
+        // `true`, this drop must bypass the inactive pool and reset the
+        // slot — proving the override survived the race window.
         drop(matched);
 
         let store = manager.store_for_test();
         assert_eq!(
             store.inactive_len(),
-            1,
-            "resurrected block uses store default (false), goes to inactive"
+            0,
+            "override preserved — block bypasses inactive on drop",
         );
-        assert_eq!(store.reset_len(), 3);
+        assert_eq!(store.reset_len(), 4);
+        assert!(
+            !manager.block_registry().is_registered(hash),
+            "registry handle marked absent",
+        );
     }
 
     /// Duplicate blocks always reset on drop regardless of the flag —

--- a/lib/kvbm-logical/src/manager/tests.rs
+++ b/lib/kvbm-logical/src/manager/tests.rs
@@ -28,7 +28,7 @@ fn create_test_token_block_8_from_iota(start: u32) -> dynamo_tokens::TokenBlock 
 
 /// Helper function to create a basic manager for testing
 fn create_test_manager(block_count: usize) -> BlockManager<TestBlockData> {
-    testing::create_test_manager::<TestBlockData>(block_count)
+    testing::create_test_manager(block_count)
 }
 
 // ============================================================================
@@ -2769,7 +2769,7 @@ mod audit_counter_tests {
             reported_len: 2, // lie: claims 2, allocate() returns 0
         };
         let store: Arc<BlockStore<TestBlockData>> =
-            BlockStore::new(4, 4, Box::new(backend), metrics.clone());
+            BlockStore::new(4, 4, Box::new(backend), metrics.clone(), false);
 
         // free.len() is 4 (all reset). Asking for 5 forces from_inactive=1
         // which trips into the allocate path → backend lies → rollback.
@@ -2930,7 +2930,7 @@ mod audit_counter_tests {
         // backend.allocate(3) returns 2 → rollback fires and reinserts
         // those 2 partial pairs into the inactive index.
         let store: Arc<BlockStore<TestBlockData>> =
-            BlockStore::new(4, 4, Box::new(backend), metrics.clone());
+            BlockStore::new(4, 4, Box::new(backend), metrics.clone(), false);
 
         let result = store.allocate_atomic(7);
         assert!(result.is_none(), "rollback returns None");
@@ -2945,5 +2945,459 @@ mod audit_counter_tests {
         // The partial pairs were reinserted into the index — exercises
         // the `for (h, id) in evicted_pairs { inner.inactive.insert ... }`
         // loop body in the rollback path.
+    }
+}
+
+// ============================================================================
+// RESET-ON-RELEASE TESTS
+// ============================================================================
+//
+// `ImmutableBlock::set_evict_on_reset(true)` and the store-wide
+// `with_default_reset_on_release(true)` cause the last drop of a primary
+// to bypass the inactive pool and return the slot straight to the
+// reset/free list (matching `release_duplicate`).
+
+mod reset_on_release_tests {
+    use super::*;
+    use crate::testing::create_test_manager_with_default_reset_on_release;
+
+    /// Per-block opt-in: a flagged block goes straight to reset on its
+    /// last drop. The inactive pool stays empty and the seq_hash is no
+    /// longer registered or matchable.
+    #[test]
+    fn per_block_flag_bypasses_inactive_pool() {
+        let manager = create_test_manager(4);
+        let m = manager.metrics();
+        let token = create_test_token_block_from_iota(50_000);
+        let hash = token.kvbm_sequence_hash();
+
+        let mutables = manager.allocate_blocks(1).unwrap();
+        let complete = mutables
+            .into_iter()
+            .next()
+            .unwrap()
+            .complete(&token)
+            .unwrap();
+        let immutable = manager
+            .register_blocks(vec![complete])
+            .into_iter()
+            .next()
+            .unwrap();
+
+        immutable.set_evict_on_reset(true);
+
+        let store = manager.store_for_test();
+        assert_eq!(store.inactive_len(), 0);
+        assert_eq!(store.reset_len(), 3);
+
+        drop(immutable);
+
+        assert_eq!(store.inactive_len(), 0, "inactive pool stays empty");
+        assert_eq!(store.reset_len(), 4, "slot returned to free list");
+        assert!(
+            !store.has_inactive(hash),
+            "hash not present in inactive index"
+        );
+        assert!(
+            !manager.block_registry().is_registered(hash),
+            "registry handle marked absent"
+        );
+        assert!(
+            manager.match_blocks(&[hash]).is_empty(),
+            "block cannot be matched after reset"
+        );
+
+        let snap = m.snapshot();
+        assert_eq!(snap.inflight_immutable, 0);
+        assert_eq!(snap.inactive_pool_size, 0);
+        assert_eq!(snap.reset_pool_size, 4);
+    }
+
+    /// Flag does not prevent in-flight sharing. While clones exist, the
+    /// block is matchable. Only the *last* drop honors the flag.
+    #[test]
+    fn flag_does_not_prevent_inflight_sharing() {
+        let manager = create_test_manager(4);
+        let token = create_test_token_block_from_iota(50_001);
+        let hash = token.kvbm_sequence_hash();
+
+        let mutables = manager.allocate_blocks(1).unwrap();
+        let complete = mutables
+            .into_iter()
+            .next()
+            .unwrap()
+            .complete(&token)
+            .unwrap();
+        let a = manager
+            .register_blocks(vec![complete])
+            .into_iter()
+            .next()
+            .unwrap();
+        let b = a.clone();
+        a.set_evict_on_reset(true);
+
+        // Drop only `a`. `b` is still alive; slot stays Primary.
+        drop(a);
+        let store = manager.store_for_test();
+        assert_eq!(store.inactive_len(), 0);
+        assert_eq!(store.reset_len(), 3);
+
+        // Lookup must still succeed — flag has no effect while clones live.
+        let matched = manager.match_blocks(&[hash]);
+        assert_eq!(matched.len(), 1);
+        drop(matched);
+        drop(b);
+
+        // Now the last clone is gone — flag fires, slot resets.
+        assert_eq!(store.inactive_len(), 0);
+        assert_eq!(store.reset_len(), 4);
+        assert!(!manager.block_registry().is_registered(hash));
+    }
+
+    /// The flag is shared across clones via the Arc-backed AtomicBool.
+    /// Last setter wins.
+    #[test]
+    fn last_writer_wins_across_clones() {
+        let manager = create_test_manager(4);
+        let token = create_test_token_block_from_iota(50_002);
+        let hash = token.kvbm_sequence_hash();
+
+        let mutables = manager.allocate_blocks(1).unwrap();
+        let complete = mutables
+            .into_iter()
+            .next()
+            .unwrap()
+            .complete(&token)
+            .unwrap();
+        let a = manager
+            .register_blocks(vec![complete])
+            .into_iter()
+            .next()
+            .unwrap();
+        let b = a.clone();
+
+        a.set_evict_on_reset(true);
+        b.set_evict_on_reset(false); // overrides — clones share one atomic
+
+        drop(a);
+        drop(b);
+
+        let store = manager.store_for_test();
+        // Last writer was `false`, so the block went to the inactive
+        // pool, not the reset pool.
+        assert_eq!(store.inactive_len(), 1);
+        assert_eq!(store.reset_len(), 3);
+        assert!(store.has_inactive(hash));
+    }
+
+    /// Resetting one block's slot does NOT poison a future registration
+    /// of the same `BlockId`. The next holder starts with the store's
+    /// default (`false` here).
+    #[test]
+    fn no_poisoning_across_registrations() {
+        let manager = create_test_manager(1);
+        let store = manager.store_for_test();
+
+        // First registration: flag = true, reset on drop.
+        let token1 = create_test_token_block_from_iota(50_003);
+        let hash1 = token1.kvbm_sequence_hash();
+        {
+            let mutables = manager.allocate_blocks(1).unwrap();
+            let complete = mutables
+                .into_iter()
+                .next()
+                .unwrap()
+                .complete(&token1)
+                .unwrap();
+            let imm = manager
+                .register_blocks(vec![complete])
+                .into_iter()
+                .next()
+                .unwrap();
+            imm.set_evict_on_reset(true);
+            drop(imm);
+        }
+        assert_eq!(store.reset_len(), 1, "first registration reset");
+        assert!(!manager.block_registry().is_registered(hash1));
+
+        // Second registration: same BlockId (only one available),
+        // different hash. Must NOT inherit the previous flag.
+        let token2 = create_test_token_block_from_iota(50_004);
+        let hash2 = token2.kvbm_sequence_hash();
+        let mutables = manager.allocate_blocks(1).unwrap();
+        let complete = mutables
+            .into_iter()
+            .next()
+            .unwrap()
+            .complete(&token2)
+            .unwrap();
+        let imm = manager
+            .register_blocks(vec![complete])
+            .into_iter()
+            .next()
+            .unwrap();
+        drop(imm);
+
+        // If poisoning happened, this would reset; with the default
+        // (false), the block should land in the inactive pool.
+        assert_eq!(
+            store.inactive_len(),
+            1,
+            "second block went to inactive, flag NOT inherited"
+        );
+        assert_eq!(store.reset_len(), 0);
+        assert!(store.has_inactive(hash2));
+    }
+
+    /// Store-wide default: every primary release bypasses inactive.
+    #[test]
+    fn store_wide_default_resets_on_release() {
+        let manager =
+            create_test_manager_with_default_reset_on_release::<TestBlockData>(4, true);
+        let token = create_test_token_block_from_iota(50_005);
+        let hash = token.kvbm_sequence_hash();
+
+        let mutables = manager.allocate_blocks(1).unwrap();
+        let complete = mutables
+            .into_iter()
+            .next()
+            .unwrap()
+            .complete(&token)
+            .unwrap();
+        let imm = manager
+            .register_blocks(vec![complete])
+            .into_iter()
+            .next()
+            .unwrap();
+        // No explicit set_evict_on_reset call — relying on the store default.
+        drop(imm);
+
+        let store = manager.store_for_test();
+        assert_eq!(store.inactive_len(), 0);
+        assert_eq!(store.reset_len(), 4);
+        assert!(!manager.block_registry().is_registered(hash));
+    }
+
+    /// Sticky override: with store default = true, a holder opts out
+    /// via `set_evict_on_reset(false)`. After Drop the block lands in
+    /// the inactive pool (correct). A later `match_blocks` resurrects
+    /// it; the resurrected `ImmutableBlock` inherits the *stored*
+    /// override, NOT the store default. Dropping the resurrected clone
+    /// must keep the block in the inactive pool, not reset it.
+    ///
+    /// Regression test for the Codex review finding:
+    /// "Preserve per-block opt-out across inactive hits".
+    #[test]
+    fn opt_out_survives_inactive_resurrection() {
+        let manager =
+            create_test_manager_with_default_reset_on_release::<TestBlockData>(4, true);
+        let token = create_test_token_block_from_iota(50_009);
+        let hash = token.kvbm_sequence_hash();
+
+        let mutables = manager.allocate_blocks(1).unwrap();
+        let complete = mutables
+            .into_iter()
+            .next()
+            .unwrap()
+            .complete(&token)
+            .unwrap();
+        let imm = manager
+            .register_blocks(vec![complete])
+            .into_iter()
+            .next()
+            .unwrap();
+        imm.set_evict_on_reset(false); // opt out of store-wide default
+        drop(imm);
+
+        let store = manager.store_for_test();
+        assert_eq!(store.inactive_len(), 1, "opt-out kept block in inactive");
+        assert_eq!(store.reset_len(), 3);
+
+        // Resurrect via the inactive cache.
+        let resurrected = manager.match_blocks(&[hash]);
+        assert_eq!(resurrected.len(), 1);
+        assert_eq!(store.inactive_len(), 0, "resurrection drained inactive");
+
+        // Drop the resurrected clone. The override stored in
+        // SlotState::Inactive must have travelled into the new Inner —
+        // so this drop also keeps the block in the inactive pool
+        // instead of resetting per the store default.
+        drop(resurrected);
+
+        assert_eq!(
+            store.inactive_len(),
+            1,
+            "override survived resurrection — block stayed in inactive"
+        );
+        assert_eq!(store.reset_len(), 3);
+        assert!(store.has_inactive(hash));
+        assert!(manager.block_registry().is_registered(hash));
+    }
+
+    /// Holder can opt out of the store-wide default for a specific block.
+    #[test]
+    fn per_block_can_opt_out_of_store_default() {
+        let manager =
+            create_test_manager_with_default_reset_on_release::<TestBlockData>(4, true);
+        let token = create_test_token_block_from_iota(50_006);
+        let hash = token.kvbm_sequence_hash();
+
+        let mutables = manager.allocate_blocks(1).unwrap();
+        let complete = mutables
+            .into_iter()
+            .next()
+            .unwrap()
+            .complete(&token)
+            .unwrap();
+        let imm = manager
+            .register_blocks(vec![complete])
+            .into_iter()
+            .next()
+            .unwrap();
+        imm.set_evict_on_reset(false); // overrides store default
+        drop(imm);
+
+        let store = manager.store_for_test();
+        assert_eq!(store.inactive_len(), 1, "kept in inactive despite default");
+        assert_eq!(store.reset_len(), 3);
+        assert!(store.has_inactive(hash));
+    }
+
+    /// Eager-resurrection path (concurrent lookup observes Arc strong=0
+    /// before Drop's `release_primary` fires) ignores the flag. The
+    /// resurrected block is a fresh Inner with the store default.
+    ///
+    /// Mirrors `eager_primary_to_inactive_is_deterministic_with_pause_hook`
+    /// in `race_regression_tests`.
+    #[test]
+    fn eager_resurrection_ignores_flag() {
+        use std::sync::Arc;
+        use std::thread;
+
+        let manager = Arc::new(create_test_manager(4));
+        let token = create_test_token_block_from_iota(50_007);
+        let hash = token.kvbm_sequence_hash();
+
+        let mutables = manager.allocate_blocks(1).unwrap();
+        let complete = mutables
+            .into_iter()
+            .next()
+            .unwrap()
+            .complete(&token)
+            .unwrap();
+        let immutable = manager
+            .register_blocks(vec![complete])
+            .into_iter()
+            .next()
+            .unwrap();
+        immutable.set_evict_on_reset(true);
+
+        let store = manager.store_for_test().clone();
+
+        let gate = store.pause_release_primary();
+        let arrivals_before = store.release_primary_arrivals();
+        let drop_t = thread::spawn(move || drop(immutable));
+
+        while store.release_primary_arrivals() == arrivals_before {
+            std::thread::yield_now();
+        }
+
+        // Concurrent lookup drives the eager transition. Even though the
+        // dropping Inner had flag=true, the eager path takes the Inactive
+        // branch (someone wants the block right now).
+        let matched = manager.match_blocks(&[hash]);
+        assert_eq!(matched.len(), 1, "eager resurrection must succeed");
+
+        let snap_mid = manager.metrics().snapshot();
+        assert_eq!(
+            snap_mid.eager_primary_to_inactive_total, 1,
+            "eager transition fired"
+        );
+
+        drop(gate);
+        drop_t.join().unwrap();
+
+        // The parked drop saw a slot that no longer matched its self_ptr
+        // and no-opped — its flag had no effect.
+        let snap_after = manager.metrics().snapshot();
+        assert_eq!(snap_after.release_primary_noop_total, 1);
+
+        // The new Inner (held by `matched`) inherited the *store
+        // default* (false), not the previous holder's `true`. Drop it
+        // and assert it lands in the inactive pool, not reset.
+        drop(matched);
+
+        let store = manager.store_for_test();
+        assert_eq!(
+            store.inactive_len(),
+            1,
+            "resurrected block uses store default (false), goes to inactive"
+        );
+        assert_eq!(store.reset_len(), 3);
+    }
+
+    /// Duplicate blocks always reset on drop regardless of the flag —
+    /// this is the pre-existing `release_duplicate` behavior and the
+    /// shared helper. The store-wide default does not change it.
+    #[test]
+    fn duplicate_release_still_resets_with_default_false() {
+        // Use Allow policy so duplicates are created.
+        let registry = crate::registry::BlockRegistry::builder()
+            .frequency_tracker(
+                crate::manager::FrequencyTrackingCapacity::default().create_tracker(),
+            )
+            .build();
+        let manager = BlockManager::<TestBlockData>::builder()
+            .block_count(4)
+            .block_size(4)
+            .registry(registry)
+            .with_lru_backend()
+            .duplication_policy(BlockDuplicationPolicy::Allow)
+            .build()
+            .expect("Should build manager");
+
+        let token = create_test_token_block_from_iota(50_008);
+        let _hash = token.kvbm_sequence_hash();
+
+        // Primary
+        let m1 = manager.allocate_blocks(1).unwrap();
+        let c1 = m1.into_iter().next().unwrap().complete(&token).unwrap();
+        let primary = manager
+            .register_blocks(vec![c1])
+            .into_iter()
+            .next()
+            .unwrap();
+
+        // Duplicate (same hash on a different BlockId)
+        let m2 = manager.allocate_blocks(1).unwrap();
+        let c2 = m2.into_iter().next().unwrap().complete(&token).unwrap();
+        let dup = manager
+            .register_blocks(vec![c2])
+            .into_iter()
+            .next()
+            .unwrap();
+        assert_eq!(dup.block_id(), 1);
+        assert_ne!(primary.block_id(), dup.block_id());
+
+        let store = manager.store_for_test();
+        let reset_before = store.reset_len();
+        let inactive_before = store.inactive_len();
+
+        // Drop duplicate first — always resets, never enters inactive.
+        drop(dup);
+        assert_eq!(
+            store.reset_len(),
+            reset_before + 1,
+            "duplicate drop returned to reset pool"
+        );
+        assert_eq!(
+            store.inactive_len(),
+            inactive_before,
+            "duplicate never enters inactive"
+        );
+
+        // Primary drop (flag = false default) → goes to inactive normally.
+        drop(primary);
+        assert_eq!(store.inactive_len(), inactive_before + 1);
     }
 }

--- a/lib/kvbm-logical/src/pools/inactive/mod.rs
+++ b/lib/kvbm-logical/src/pools/inactive/mod.rs
@@ -4,6 +4,13 @@
 //! Inactive-pool eviction backends. The pool itself is part of the unified
 //! [`BlockStore`](super::store::BlockStore); this module only houses the
 //! pluggable [`InactiveIndex`](super::store::InactiveIndex) implementations.
+//!
+//! Note: *whether* a released primary block enters the inactive index at
+//! all is decided at the [`BlockStore`](super::store::BlockStore) level
+//! (per-block flag on [`ImmutableBlockInner`](crate::blocks::ImmutableBlockInner)
+//! plus a store-wide default), not by the backend. A backend cannot see
+//! slot state, the free list, or registration handles — see
+//! [`BlockStore::release_primary`](super::store::BlockStore).
 
 pub mod backends;
 

--- a/lib/kvbm-logical/src/pools/store.rs
+++ b/lib/kvbm-logical/src/pools/store.rs
@@ -529,8 +529,7 @@ impl<T: BlockMetadata + Sync> BlockStore<T> {
         // backends) instead of allocating a one-element slice + Vec.
         let block_id = inner.inactive.find_match(seq_hash, touch)?.1;
         self.metrics.dec_inactive_pool_size();
-        let (handle, reset_on_release) =
-            take_inactive_handle(&mut inner.slots[block_id], block_id);
+        let (handle, reset_on_release) = take_inactive_handle(&mut inner.slots[block_id], block_id);
         // Resurrection: preserve any per-block override the previous
         // holder stored when releasing into the inactive index.
         let inner_arc = ImmutableBlockInner::new_primary_resurrected(

--- a/lib/kvbm-logical/src/pools/store.rs
+++ b/lib/kvbm-logical/src/pools/store.rs
@@ -126,19 +126,24 @@ pub(crate) enum SlotState<T: BlockMetadata> {
     },
     /// Idle, evictable, registered. In the inactive index under `seq_hash`.
     ///
-    /// `reset_on_release` is the per-block "reset on last drop" override
-    /// captured from the dropping `ImmutableBlockInner` at the moment of
-    /// `release_primary`. It is preserved across the
-    /// `Primary → Inactive → Primary` cache-hit cycle: resurrection (via
-    /// `acquire_for_hash` / `promote_inactive`) constructs the new
-    /// `ImmutableBlockInner` with this stored value rather than the
-    /// store-wide default. The flag is discarded when the slot leaves
-    /// `Inactive` via eviction (`Inactive → Mutable`); a future fresh
-    /// registration on the same `BlockId` reads the store default again.
+    /// The per-block "reset on last drop" override lives in
+    /// `BlockStoreInner::reset_on_release[block_id]` (a parallel `Vec<bool>`
+    /// under the same mutex as this variant) rather than in the variant
+    /// itself, so the override survives every transition into and out of
+    /// `Inactive` without an extra hand-off:
+    ///
+    /// - `Primary → Inactive` (both `release_primary` and the
+    ///   lookup-driven eager path): the bool is untouched, so the value
+    ///   the last holder set via `set_evict_on_reset` is preserved.
+    /// - `Inactive → Primary` (resurrection): the bool is untouched, so
+    ///   the new `ImmutableBlockInner` reads the carried value on its
+    ///   own drop.
+    /// - `Inactive → Mutable` (eviction): the bool is reset to the
+    ///   store-wide default, since a fresh tenant should not inherit a
+    ///   previous holder's override.
     Inactive {
         seq_hash: SequenceHash,
         handle: BlockRegistrationHandle,
-        reset_on_release: bool,
     },
 }
 
@@ -184,6 +189,25 @@ pub(crate) struct BlockStoreInner<T: BlockMetadata> {
     /// Primary `block_id` for each currently-registered sequence hash.
     /// Updated atomically with the slot's `Primary`/`Inactive` state.
     active_by_hash: HashMap<SequenceHash, BlockId>,
+    /// Per-slot "reset on last drop" override, indexed by `BlockId`.
+    /// Length is fixed to `total_blocks` at construction.
+    ///
+    /// Written by [`crate::blocks::ImmutableBlock::set_evict_on_reset`]
+    /// (which acquires this same mutex for the write); read by
+    /// `release_primary` to choose the `Primary → Inactive` vs
+    /// `Primary → Reset` transition. The eager `Primary → Inactive`
+    /// path does *not* touch this field — it just transitions the slot
+    /// — so a per-block override set by the dropping holder is
+    /// preserved across the race window where a concurrent lookup
+    /// beats `release_primary` to the mutex. The value rides through
+    /// `Primary → Inactive → Primary` (resurrection) untouched, and is
+    /// reset to the store-wide default on every transition into
+    /// `Mutable` so a fresh tenant starts clean.
+    ///
+    /// Both writes and reads happen under the store mutex, so all
+    /// visibility comes from the mutex's release-acquire semantics —
+    /// no atomic-ordering subtleties.
+    reset_on_release: Vec<bool>,
 }
 
 /// Single-mutex bookkeeping store for the reset, active, and inactive
@@ -197,10 +221,9 @@ pub(crate) struct BlockStore<T: BlockMetadata> {
     block_size: usize,
     total_blocks: usize,
     metrics: Arc<BlockPoolMetrics>,
-    /// Default value of `ImmutableBlockInner::reset_on_release` for every
-    /// fresh `Primary`/`Duplicate` Inner constructed by this store. When
-    /// `true`, every primary release bypasses the inactive pool and goes
-    /// straight to `Reset` (mirrors `release_duplicate`). Individual
+    /// Store-wide default for the per-slot "reset on last drop" override.
+    /// When `true`, every primary release bypasses the inactive pool and
+    /// goes straight to `Reset` (mirrors `release_duplicate`). Individual
     /// holders can still override per-block via
     /// `ImmutableBlock::set_evict_on_reset`.
     default_reset_on_release: bool,
@@ -242,6 +265,7 @@ impl<T: BlockMetadata + Sync> BlockStore<T> {
             });
             free.push_back(i);
         }
+        let reset_on_release = vec![default_reset_on_release; total_blocks];
         Arc::new(Self {
             id: crate::ManagerId::next(),
             inner: Mutex::new(BlockStoreInner {
@@ -249,6 +273,7 @@ impl<T: BlockMetadata + Sync> BlockStore<T> {
                 free,
                 inactive,
                 active_by_hash: HashMap::new(),
+                reset_on_release,
             }),
             block_size,
             total_blocks,
@@ -261,12 +286,23 @@ impl<T: BlockMetadata + Sync> BlockStore<T> {
         })
     }
 
-    /// Default value for the per-Inner `reset_on_release` flag. Read by
-    /// `ImmutableBlockInner::new_primary` / `new_duplicate` at
-    /// construction. `true` makes the store discard registered blocks on
-    /// release instead of caching them in the inactive pool.
+    /// Store-wide default for the per-slot "reset on last drop" override.
+    /// `true` makes registered blocks bypass the inactive pool on release
+    /// (mirrors `release_duplicate`) unless a holder explicitly opts out
+    /// via `ImmutableBlock::set_evict_on_reset(false)`.
     pub(crate) fn default_reset_on_release(&self) -> bool {
         self.default_reset_on_release
+    }
+
+    /// Set the per-block "reset on last drop" override for `block_id`.
+    /// Backs [`crate::blocks::ImmutableBlock::set_evict_on_reset`].
+    ///
+    /// Acquires the store mutex so the write is published to any future
+    /// mutex acquirer through release-acquire on the mutex itself —
+    /// the per-slot value lives inside `BlockStoreInner` and is only
+    /// read under that same mutex.
+    pub(crate) fn store_reset_on_release(&self, block_id: BlockId, value: bool) {
+        self.inner.lock().reset_on_release[block_id] = value;
     }
 
     /// Stable, process-unique identifier of this store. See
@@ -342,6 +378,7 @@ impl<T: BlockMetadata + Sync> BlockStore<T> {
         for _ in 0..take {
             let id = inner.free.pop_front().unwrap();
             inner.slots[id].state = SlotState::Mutable;
+            inner.reset_on_release[id] = self.default_reset_on_release;
             let block_size = inner.slots[id].block_size;
             out.push(MutableBlock::from_store(self.clone(), id, block_size));
         }
@@ -405,6 +442,7 @@ impl<T: BlockMetadata + Sync> BlockStore<T> {
         let mut blocks = Vec::with_capacity(count);
         for id in reset_ids {
             inner.slots[id].state = SlotState::Mutable;
+            inner.reset_on_release[id] = self.default_reset_on_release;
             let block_size = inner.slots[id].block_size;
             blocks.push(MutableBlock::from_store(self.clone(), id, block_size));
         }
@@ -412,9 +450,9 @@ impl<T: BlockMetadata + Sync> BlockStore<T> {
         let mut handles = Vec::with_capacity(from_inactive);
         for (seq_hash, block_id) in evicted_pairs {
             // Eviction discards the override; the slot leaves Inactive.
-            let (handle, _reset_on_release) =
-                take_inactive_handle(&mut inner.slots[block_id], block_id);
+            let handle = take_inactive_handle(&mut inner.slots[block_id], block_id);
             inner.slots[block_id].state = SlotState::Mutable;
+            inner.reset_on_release[block_id] = self.default_reset_on_release;
             let block_size = inner.slots[block_id].block_size;
             blocks.push(MutableBlock::from_store(self.clone(), block_id, block_size));
             evicted.push(seq_hash);
@@ -446,9 +484,9 @@ impl<T: BlockMetadata + Sync> BlockStore<T> {
         let mut out = Vec::with_capacity(count);
         for (_seq_hash, block_id) in drained {
             // Eviction discards the override; the slot leaves Inactive.
-            let (handle, _reset_on_release) =
-                take_inactive_handle(&mut inner.slots[block_id], block_id);
+            let handle = take_inactive_handle(&mut inner.slots[block_id], block_id);
             inner.slots[block_id].state = SlotState::Mutable;
+            inner.reset_on_release[block_id] = self.default_reset_on_release;
             handles.push(handle);
             let block_size = inner.slots[block_id].block_size;
             out.push(MutableBlock::from_store(self.clone(), block_id, block_size));
@@ -529,16 +567,13 @@ impl<T: BlockMetadata + Sync> BlockStore<T> {
         // backends) instead of allocating a one-element slice + Vec.
         let block_id = inner.inactive.find_match(seq_hash, touch)?.1;
         self.metrics.dec_inactive_pool_size();
-        let (handle, reset_on_release) = take_inactive_handle(&mut inner.slots[block_id], block_id);
-        // Resurrection: preserve any per-block override the previous
-        // holder stored when releasing into the inactive index.
-        let inner_arc = ImmutableBlockInner::new_primary_resurrected(
-            self.clone(),
-            block_id,
-            seq_hash,
-            handle.clone(),
-            reset_on_release,
-        );
+        let handle = take_inactive_handle(&mut inner.slots[block_id], block_id);
+        // Resurrection: the per-slot `reset_on_release` atomic carries
+        // the previous holder's override across this transition
+        // untouched, so the new `ImmutableBlockInner` will read the
+        // right value on its own drop.
+        let inner_arc =
+            ImmutableBlockInner::new_primary(self.clone(), block_id, seq_hash, handle.clone());
         inner.slots[block_id].state = SlotState::Primary {
             seq_hash,
             handle,
@@ -664,16 +699,15 @@ impl<T: BlockMetadata + Sync> BlockStore<T> {
             SlotState::Primary { handle, .. } => handle.clone(),
             other => panic!("eager_primary_to_inactive: slot {block_id} was {other:?}"),
         };
-        // The dropping `ImmutableBlockInner` is on another thread mid-Drop;
-        // its `Arc` is at strong=0 so the per-block `reset_on_release`
-        // override is unreachable from here. Fall back to the store-wide
-        // default. This is a best-effort race window documented on
-        // `ImmutableBlock::set_evict_on_reset`.
-        slot.state = SlotState::Inactive {
-            seq_hash,
-            handle,
-            reset_on_release: self.default_reset_on_release,
-        };
+        // The per-block `reset_on_release` override lives in
+        // `inner.reset_on_release[block_id]`, not in the dropping
+        // `ImmutableBlockInner`. We leave it untouched here so the value
+        // the holder set via `set_evict_on_reset` rides through this
+        // race-window transition. Visibility: both `set_evict_on_reset`
+        // and the eventual `release_primary` read go through this same
+        // store mutex, so the value is published reliably regardless of
+        // which thread wins the race for the lock.
+        slot.state = SlotState::Inactive { seq_hash, handle };
         inner.inactive.insert(seq_hash, block_id);
         inner.active_by_hash.remove(&seq_hash);
         self.metrics.inc_inactive_pool_size();
@@ -720,17 +754,14 @@ impl<T: BlockMetadata + Sync> BlockStore<T> {
         matched
             .into_iter()
             .map(|(seq_hash, block_id)| {
-                let (handle, reset_on_release) =
-                    take_inactive_handle(&mut inner.slots[block_id], block_id);
-                // Resurrection: preserve any per-block override the
-                // previous holder stored when releasing into the
-                // inactive index.
-                let inner_arc = ImmutableBlockInner::new_primary_resurrected(
+                let handle = take_inactive_handle(&mut inner.slots[block_id], block_id);
+                // Resurrection: the per-slot `reset_on_release` atomic
+                // carries the previous holder's override untouched.
+                let inner_arc = ImmutableBlockInner::new_primary(
                     self.clone(),
                     block_id,
                     seq_hash,
                     handle.clone(),
-                    reset_on_release,
                 );
                 inner.slots[block_id].state = SlotState::Primary {
                     seq_hash,
@@ -772,6 +803,9 @@ impl<T: BlockMetadata + Sync> BlockStore<T> {
             SlotState::Staged { .. }
         ));
         inner.slots[block_id].state = SlotState::Mutable;
+        // Defensive: the Staged → Mutable rollback opens this slot to a
+        // fresh tenant. Clear any leftover per-slot override.
+        inner.reset_on_release[block_id] = self.default_reset_on_release;
         self.metrics.inc_inflight_mutable();
     }
 
@@ -794,18 +828,13 @@ impl<T: BlockMetadata + Sync> BlockStore<T> {
     /// slot has since been resurrected to a different Inner), this is a
     /// no-op.
     ///
-    /// `reset_on_release` selects the destination:
+    /// Reads `reset_on_release[block_id]` to select the destination:
     /// - `false` (default) → `SlotState::Inactive` + insert into the
     ///   inactive index, available for cache hits and cold eviction.
     /// - `true` → `SlotState::Reset` + push to free list +
     ///   `handle.mark_absent::<T>()`. Mirrors `release_duplicate`. The
     ///   block is *not* cached and cannot be matched/resurrected later.
-    pub(crate) fn release_primary(
-        &self,
-        block_id: BlockId,
-        self_ptr: *const (),
-        reset_on_release: bool,
-    ) {
+    pub(crate) fn release_primary(&self, block_id: BlockId, self_ptr: *const ()) {
         // Test-only deterministic race-window widening:
         //   1. Bump the arrival counter so a coordinating test can
         //      observe "the drop has entered release_primary" without
@@ -834,6 +863,12 @@ impl<T: BlockMetadata + Sync> BlockStore<T> {
                     return;
                 }
             };
+            // Read the per-slot override. Both the writer
+            // (`set_evict_on_reset`) and this read go through the store
+            // mutex, so visibility comes from the mutex's
+            // release-acquire — no atomic-ordering assumptions about
+            // `Arc::drop` or `Weak::upgrade`.
+            let reset_on_release = inner.reset_on_release[block_id];
             if reset_on_release {
                 self.reset_slot_locked(&mut inner, block_id);
                 // Only the primary owns the `active_by_hash` mapping;
@@ -843,15 +878,10 @@ impl<T: BlockMetadata + Sync> BlockStore<T> {
                 tracing::trace!(?seq_hash, block_id, "Primary released to reset pool");
                 Some(handle)
             } else {
-                // Carry the dropping Inner's `reset_on_release` into the
-                // `Inactive` slot so a future resurrection inherits it.
-                // This is what makes a per-block `set_evict_on_reset`
-                // override sticky across the cache-hit cycle.
-                inner.slots[block_id].state = SlotState::Inactive {
-                    seq_hash,
-                    handle,
-                    reset_on_release,
-                };
+                // The atomic carries the holder's override into the
+                // Inactive period untouched; a future resurrection will
+                // inherit it via the same atomic.
+                inner.slots[block_id].state = SlotState::Inactive { seq_hash, handle };
                 inner.inactive.insert(seq_hash, block_id);
                 inner.active_by_hash.remove(&seq_hash);
                 self.metrics.inc_inactive_pool_size();
@@ -920,24 +950,17 @@ impl<T: BlockMetadata> std::fmt::Debug for BlockStore<T> {
 
 // ---------- helpers ----------
 
-/// Clone the [`BlockRegistrationHandle`] out of an `Inactive` slot. The
-/// caller must overwrite `slot.state` before releasing the store lock.
-/// Read the `(handle, reset_on_release)` pair out of an `Inactive` slot
-/// without consuming the slot itself. Resurrection callers pass
-/// `reset_on_release` to `ImmutableBlockInner::new_primary_resurrected`
-/// so the per-block override survives the cache hit; eviction callers
-/// (Inactive → Mutable) simply discard the bool. The caller must
-/// overwrite `slot.state` before releasing the store lock.
+/// Clone the [`BlockRegistrationHandle`] out of an `Inactive` slot
+/// without consuming the slot itself. The per-block `reset_on_release`
+/// override no longer rides in this variant — it lives in the
+/// store-owned atomic array and is read directly via `BlockStore::reset_on_release`.
+/// The caller must overwrite `slot.state` before releasing the store lock.
 fn take_inactive_handle<T: BlockMetadata>(
     slot: &mut BlockSlot<T>,
     block_id: BlockId,
-) -> (BlockRegistrationHandle, bool) {
+) -> BlockRegistrationHandle {
     match &slot.state {
-        SlotState::Inactive {
-            handle,
-            reset_on_release,
-            ..
-        } => (handle.clone(), *reset_on_release),
+        SlotState::Inactive { handle, .. } => handle.clone(),
         other => panic!("expected Inactive state for slot {block_id}, got {other:?}"),
     }
 }

--- a/lib/kvbm-logical/src/pools/store.rs
+++ b/lib/kvbm-logical/src/pools/store.rs
@@ -125,9 +125,20 @@ pub(crate) enum SlotState<T: BlockMetadata> {
         inner: Weak<ImmutableBlockInner<T>>,
     },
     /// Idle, evictable, registered. In the inactive index under `seq_hash`.
+    ///
+    /// `reset_on_release` is the per-block "reset on last drop" override
+    /// captured from the dropping `ImmutableBlockInner` at the moment of
+    /// `release_primary`. It is preserved across the
+    /// `Primary → Inactive → Primary` cache-hit cycle: resurrection (via
+    /// `acquire_for_hash` / `promote_inactive`) constructs the new
+    /// `ImmutableBlockInner` with this stored value rather than the
+    /// store-wide default. The flag is discarded when the slot leaves
+    /// `Inactive` via eviction (`Inactive → Mutable`); a future fresh
+    /// registration on the same `BlockId` reads the store default again.
     Inactive {
         seq_hash: SequenceHash,
         handle: BlockRegistrationHandle,
+        reset_on_release: bool,
     },
 }
 
@@ -186,6 +197,13 @@ pub(crate) struct BlockStore<T: BlockMetadata> {
     block_size: usize,
     total_blocks: usize,
     metrics: Arc<BlockPoolMetrics>,
+    /// Default value of `ImmutableBlockInner::reset_on_release` for every
+    /// fresh `Primary`/`Duplicate` Inner constructed by this store. When
+    /// `true`, every primary release bypasses the inactive pool and goes
+    /// straight to `Reset` (mirrors `release_duplicate`). Individual
+    /// holders can still override per-block via
+    /// `ImmutableBlock::set_evict_on_reset`.
+    default_reset_on_release: bool,
     /// Test-only hook to deterministically widen the
     /// "Arc strong=0 but `release_primary` not yet run" race window.
     /// `release_primary` acquires this gate *before* taking the store
@@ -213,6 +231,7 @@ impl<T: BlockMetadata + Sync> BlockStore<T> {
         block_size: usize,
         inactive: Box<dyn InactiveIndex>,
         metrics: Arc<BlockPoolMetrics>,
+        default_reset_on_release: bool,
     ) -> Arc<Self> {
         let mut slots = Vec::with_capacity(total_blocks);
         let mut free = VecDeque::with_capacity(total_blocks);
@@ -234,11 +253,20 @@ impl<T: BlockMetadata + Sync> BlockStore<T> {
             block_size,
             total_blocks,
             metrics,
+            default_reset_on_release,
             #[cfg(test)]
             release_primary_gate: Mutex::new(()),
             #[cfg(test)]
             release_primary_arrivals: std::sync::atomic::AtomicU64::new(0),
         })
+    }
+
+    /// Default value for the per-Inner `reset_on_release` flag. Read by
+    /// `ImmutableBlockInner::new_primary` / `new_duplicate` at
+    /// construction. `true` makes the store discard registered blocks on
+    /// release instead of caching them in the inactive pool.
+    pub(crate) fn default_reset_on_release(&self) -> bool {
+        self.default_reset_on_release
     }
 
     /// Stable, process-unique identifier of this store. See
@@ -383,7 +411,9 @@ impl<T: BlockMetadata + Sync> BlockStore<T> {
         let mut evicted = Vec::with_capacity(from_inactive);
         let mut handles = Vec::with_capacity(from_inactive);
         for (seq_hash, block_id) in evicted_pairs {
-            let handle = take_inactive_handle(&mut inner.slots[block_id], block_id);
+            // Eviction discards the override; the slot leaves Inactive.
+            let (handle, _reset_on_release) =
+                take_inactive_handle(&mut inner.slots[block_id], block_id);
             inner.slots[block_id].state = SlotState::Mutable;
             let block_size = inner.slots[block_id].block_size;
             blocks.push(MutableBlock::from_store(self.clone(), block_id, block_size));
@@ -415,7 +445,9 @@ impl<T: BlockMetadata + Sync> BlockStore<T> {
         let mut handles = Vec::with_capacity(count);
         let mut out = Vec::with_capacity(count);
         for (_seq_hash, block_id) in drained {
-            let handle = take_inactive_handle(&mut inner.slots[block_id], block_id);
+            // Eviction discards the override; the slot leaves Inactive.
+            let (handle, _reset_on_release) =
+                take_inactive_handle(&mut inner.slots[block_id], block_id);
             inner.slots[block_id].state = SlotState::Mutable;
             handles.push(handle);
             let block_size = inner.slots[block_id].block_size;
@@ -497,9 +529,17 @@ impl<T: BlockMetadata + Sync> BlockStore<T> {
         // backends) instead of allocating a one-element slice + Vec.
         let block_id = inner.inactive.find_match(seq_hash, touch)?.1;
         self.metrics.dec_inactive_pool_size();
-        let handle = take_inactive_handle(&mut inner.slots[block_id], block_id);
-        let inner_arc =
-            ImmutableBlockInner::new_primary(self.clone(), block_id, seq_hash, handle.clone());
+        let (handle, reset_on_release) =
+            take_inactive_handle(&mut inner.slots[block_id], block_id);
+        // Resurrection: preserve any per-block override the previous
+        // holder stored when releasing into the inactive index.
+        let inner_arc = ImmutableBlockInner::new_primary_resurrected(
+            self.clone(),
+            block_id,
+            seq_hash,
+            handle.clone(),
+            reset_on_release,
+        );
         inner.slots[block_id].state = SlotState::Primary {
             seq_hash,
             handle,
@@ -625,7 +665,16 @@ impl<T: BlockMetadata + Sync> BlockStore<T> {
             SlotState::Primary { handle, .. } => handle.clone(),
             other => panic!("eager_primary_to_inactive: slot {block_id} was {other:?}"),
         };
-        slot.state = SlotState::Inactive { seq_hash, handle };
+        // The dropping `ImmutableBlockInner` is on another thread mid-Drop;
+        // its `Arc` is at strong=0 so the per-block `reset_on_release`
+        // override is unreachable from here. Fall back to the store-wide
+        // default. This is a best-effort race window documented on
+        // `ImmutableBlock::set_evict_on_reset`.
+        slot.state = SlotState::Inactive {
+            seq_hash,
+            handle,
+            reset_on_release: self.default_reset_on_release,
+        };
         inner.inactive.insert(seq_hash, block_id);
         inner.active_by_hash.remove(&seq_hash);
         self.metrics.inc_inactive_pool_size();
@@ -672,12 +721,17 @@ impl<T: BlockMetadata + Sync> BlockStore<T> {
         matched
             .into_iter()
             .map(|(seq_hash, block_id)| {
-                let handle = take_inactive_handle(&mut inner.slots[block_id], block_id);
-                let inner_arc = ImmutableBlockInner::new_primary(
+                let (handle, reset_on_release) =
+                    take_inactive_handle(&mut inner.slots[block_id], block_id);
+                // Resurrection: preserve any per-block override the
+                // previous holder stored when releasing into the
+                // inactive index.
+                let inner_arc = ImmutableBlockInner::new_primary_resurrected(
                     self.clone(),
                     block_id,
                     seq_hash,
                     handle.clone(),
+                    reset_on_release,
                 );
                 inner.slots[block_id].state = SlotState::Primary {
                     seq_hash,
@@ -734,11 +788,25 @@ impl<T: BlockMetadata + Sync> BlockStore<T> {
         self.metrics.inc_reset_pool_size();
     }
 
-    /// Drop transition for the last clone of a primary `ImmutableBlockInner`:
-    /// `Primary` → `Inactive`, but only if the slot still references this
-    /// specific Inner. If a concurrent `acquire_for_hash` already eagerly
-    /// transitioned the slot, this is a no-op.
-    pub(crate) fn release_primary(&self, block_id: BlockId, self_ptr: *const ()) {
+    /// Drop transition for the last clone of a primary `ImmutableBlockInner`.
+    ///
+    /// Identity-checked against `self_ptr`. If a concurrent
+    /// `acquire_for_hash` already eagerly transitioned the slot (or the
+    /// slot has since been resurrected to a different Inner), this is a
+    /// no-op.
+    ///
+    /// `reset_on_release` selects the destination:
+    /// - `false` (default) → `SlotState::Inactive` + insert into the
+    ///   inactive index, available for cache hits and cold eviction.
+    /// - `true` → `SlotState::Reset` + push to free list +
+    ///   `handle.mark_absent::<T>()`. Mirrors `release_duplicate`. The
+    ///   block is *not* cached and cannot be matched/resurrected later.
+    pub(crate) fn release_primary(
+        &self,
+        block_id: BlockId,
+        self_ptr: *const (),
+        reset_on_release: bool,
+    ) {
         // Test-only deterministic race-window widening:
         //   1. Bump the arrival counter so a coordinating test can
         //      observe "the drop has entered release_primary" without
@@ -752,26 +820,52 @@ impl<T: BlockMetadata + Sync> BlockStore<T> {
             .fetch_add(1, std::sync::atomic::Ordering::Release);
         #[cfg(test)]
         let _gate = self.release_primary_gate.lock();
-        let mut inner = self.inner.lock();
-        let slot = &mut inner.slots[block_id];
-        let (seq_hash, handle) = match &slot.state {
-            SlotState::Primary {
-                seq_hash,
-                handle,
-                inner: weak,
-            } if weak.as_ptr() as *const () == self_ptr => (*seq_hash, handle.clone()),
-            // Eager lookup-driven transition already ran, OR this slot has
-            // since been resurrected to a different Inner. No-op.
-            _ => {
-                self.metrics.inc_release_primary_noop();
-                return;
+        let handle_to_mark_absent = {
+            let mut inner = self.inner.lock();
+            let (seq_hash, handle) = match &inner.slots[block_id].state {
+                SlotState::Primary {
+                    seq_hash,
+                    handle,
+                    inner: weak,
+                } if weak.as_ptr() as *const () == self_ptr => (*seq_hash, handle.clone()),
+                // Eager lookup-driven transition already ran, OR this slot has
+                // since been resurrected to a different Inner. No-op.
+                _ => {
+                    self.metrics.inc_release_primary_noop();
+                    return;
+                }
+            };
+            if reset_on_release {
+                self.reset_slot_locked(&mut inner, block_id);
+                // Only the primary owns the `active_by_hash` mapping;
+                // duplicates have a different `block_id` under the same
+                // hash and must never clear it.
+                inner.active_by_hash.remove(&seq_hash);
+                tracing::trace!(?seq_hash, block_id, "Primary released to reset pool");
+                Some(handle)
+            } else {
+                // Carry the dropping Inner's `reset_on_release` into the
+                // `Inactive` slot so a future resurrection inherits it.
+                // This is what makes a per-block `set_evict_on_reset`
+                // override sticky across the cache-hit cycle.
+                inner.slots[block_id].state = SlotState::Inactive {
+                    seq_hash,
+                    handle,
+                    reset_on_release,
+                };
+                inner.inactive.insert(seq_hash, block_id);
+                inner.active_by_hash.remove(&seq_hash);
+                self.metrics.inc_inactive_pool_size();
+                tracing::trace!(?seq_hash, block_id, "Block stored in inactive pool");
+                None
             }
         };
-        slot.state = SlotState::Inactive { seq_hash, handle };
-        inner.inactive.insert(seq_hash, block_id);
-        inner.active_by_hash.remove(&seq_hash);
-        self.metrics.inc_inactive_pool_size();
-        tracing::trace!(?seq_hash, block_id, "Block stored in inactive pool");
+        // mark_absent takes the attachments lock; lock-order
+        // (attachments → store) is satisfied because the store lock has
+        // already been released. Matches the `release_duplicate` pattern.
+        if let Some(handle) = handle_to_mark_absent {
+            handle.mark_absent::<T>();
+        }
     }
 
     /// Drop transition for the last clone of a duplicate `ImmutableBlockInner`:
@@ -779,8 +873,7 @@ impl<T: BlockMetadata + Sync> BlockStore<T> {
     pub(crate) fn release_duplicate(&self, block_id: BlockId, self_ptr: *const ()) {
         let handle = {
             let mut inner = self.inner.lock();
-            let slot = &mut inner.slots[block_id];
-            let handle = match &slot.state {
+            let handle = match &inner.slots[block_id].state {
                 SlotState::Duplicate {
                     handle,
                     inner: weak,
@@ -794,12 +887,26 @@ impl<T: BlockMetadata + Sync> BlockStore<T> {
                     return;
                 }
             };
-            slot.state = SlotState::Reset;
-            inner.free.push_back(block_id);
-            self.metrics.inc_reset_pool_size();
+            // Duplicates do NOT clear `active_by_hash` — that mapping
+            // belongs to the primary, which has a different `block_id`
+            // and is kept alive by `_primary_keepalive` until this drop.
+            self.reset_slot_locked(&mut inner, block_id);
             handle
         };
         handle.mark_absent::<T>();
+    }
+
+    /// Slot transition shared by `release_primary` (when
+    /// `reset_on_release = true`) and `release_duplicate`:
+    /// `*` → `SlotState::Reset`, push to the free list, bump the
+    /// reset-pool gauge. Does **not** touch `active_by_hash` — callers
+    /// that own that mapping (the primary release path) must clear it
+    /// themselves. Callers must invoke `handle.mark_absent::<T>()`
+    /// *after* the store lock is released.
+    fn reset_slot_locked(&self, inner: &mut BlockStoreInner<T>, block_id: BlockId) {
+        inner.slots[block_id].state = SlotState::Reset;
+        inner.free.push_back(block_id);
+        self.metrics.inc_reset_pool_size();
     }
 }
 
@@ -816,12 +923,22 @@ impl<T: BlockMetadata> std::fmt::Debug for BlockStore<T> {
 
 /// Clone the [`BlockRegistrationHandle`] out of an `Inactive` slot. The
 /// caller must overwrite `slot.state` before releasing the store lock.
+/// Read the `(handle, reset_on_release)` pair out of an `Inactive` slot
+/// without consuming the slot itself. Resurrection callers pass
+/// `reset_on_release` to `ImmutableBlockInner::new_primary_resurrected`
+/// so the per-block override survives the cache hit; eviction callers
+/// (Inactive → Mutable) simply discard the bool. The caller must
+/// overwrite `slot.state` before releasing the store lock.
 fn take_inactive_handle<T: BlockMetadata>(
     slot: &mut BlockSlot<T>,
     block_id: BlockId,
-) -> BlockRegistrationHandle {
+) -> (BlockRegistrationHandle, bool) {
     match &slot.state {
-        SlotState::Inactive { handle, .. } => handle.clone(),
+        SlotState::Inactive {
+            handle,
+            reset_on_release,
+            ..
+        } => (handle.clone(), *reset_on_release),
         other => panic!("expected Inactive state for slot {block_id}, got {other:?}"),
     }
 }

--- a/lib/kvbm-logical/src/testing/managers.rs
+++ b/lib/kvbm-logical/src/testing/managers.rs
@@ -25,6 +25,27 @@ pub fn create_test_manager<T: BlockMetadata>(block_count: usize) -> BlockManager
         .expect("Should build manager")
 }
 
+/// Create a test manager with the store-wide `default_reset_on_release`
+/// flag set. Every primary release on this manager goes straight back to
+/// the reset pool (bypasses the inactive index).
+pub fn create_test_manager_with_default_reset_on_release<T: BlockMetadata>(
+    block_count: usize,
+    default_reset_on_release: bool,
+) -> BlockManager<T> {
+    let registry = BlockRegistry::builder()
+        .frequency_tracker(FrequencyTrackingCapacity::default().create_tracker())
+        .build();
+
+    BlockManager::<T>::builder()
+        .block_count(block_count)
+        .block_size(4)
+        .registry(registry)
+        .with_lru_backend()
+        .with_default_reset_on_release(default_reset_on_release)
+        .build()
+        .expect("Should build manager")
+}
+
 /// Create a test manager with custom block size.
 pub fn create_test_manager_with_block_size<T: BlockMetadata>(
     block_count: usize,

--- a/lib/kvbm-logical/src/testing/mod.rs
+++ b/lib/kvbm-logical/src/testing/mod.rs
@@ -58,6 +58,7 @@ pub const TEST_SALT: u64 = 42;
 // pub items — usable by downstream crates via the testing feature
 pub use managers::{
     create_test_manager, create_test_manager_metered, create_test_manager_with_block_size,
+    create_test_manager_with_default_reset_on_release,
 };
 pub use sequences::BlockSequenceBuilder;
 pub use token_blocks::{

--- a/lib/kvbm-logical/src/testing/pools.rs
+++ b/lib/kvbm-logical/src/testing/pools.rs
@@ -25,6 +25,9 @@ pub(crate) struct TestPoolSetup {
 
     #[builder(default = "4")]
     pub(crate) block_size: usize,
+
+    #[builder(default = "false")]
+    pub(crate) default_reset_on_release: bool,
 }
 
 impl TestPoolSetup {
@@ -33,6 +36,12 @@ impl TestPoolSetup {
         let reuse_policy = Box::new(FifoReusePolicy::new());
         let backend = Box::new(HashMapBackend::new(reuse_policy));
         let metrics = Arc::new(BlockPoolMetrics::new(short_type_name::<T>()));
-        BlockStore::new(self.block_count, self.block_size, backend, metrics)
+        BlockStore::new(
+            self.block_count,
+            self.block_size,
+            backend,
+            metrics,
+            self.default_reset_on_release,
+        )
     }
 }


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9504" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configurable default reset-on-release behavior for block managers.
  * New per-block control method for reset-on-release override.
  * Reset-on-release preference now maintained across cache resurrections.

* **Tests**
  * Comprehensive regression coverage for reset-on-release behavior and flag interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9504)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->