### PR TITLE
fix: recommend threshold flags in 503 all-workers-busy message

### DIFF
--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -2720,21 +2720,20 @@ mod tests {
         use dynamo_runtime::error::{DynamoError, ErrorType};
         use dynamo_runtime::pipeline::error::PipelineError;
 
-        let cause = PipelineError::ServiceOverloaded(
-            "All workers are busy, please retry later".to_string(),
-        );
+        let msg = "All workers are busy, please retry later. \
+            To increase capacity, raise or disable the busy thresholds \
+            (e.g. --active-decode-blocks-threshold None \
+            --active-prefill-tokens-threshold None).";
+        let cause = PipelineError::ServiceOverloaded(msg.to_string());
         let err: anyhow::Error = DynamoError::builder()
             .error_type(ErrorType::ResourceExhausted)
-            .message("All workers are busy, please retry later")
+            .message(msg)
             .cause(cause)
             .build()
             .into();
         let response = ErrorMessage::from_anyhow(err, BACKUP_ERROR_MESSAGE);
         assert_eq!(response.0, StatusCode::SERVICE_UNAVAILABLE);
-        assert_eq!(
-            response.1.message,
-            "ResourceExhausted: All workers are busy, please retry later"
-        );
+        assert_eq!(response.1.message, format!("ResourceExhausted: {msg}"));
     }
 
     #[test]

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -818,12 +818,14 @@ where
                         total_workers = all_instances.len(),
                         "Rejecting request: all workers are busy"
                     );
-                    let cause = PipelineError::ServiceOverloaded(
-                        "All workers are busy, please retry later".to_string(),
-                    );
+                    let msg = "All workers are busy, please retry later. \
+                        To increase capacity, raise or disable the busy thresholds \
+                        (e.g. --active-decode-blocks-threshold None \
+                        --active-prefill-tokens-threshold None).";
+                    let cause = PipelineError::ServiceOverloaded(msg.to_string());
                     return Err(DynamoError::builder()
                         .error_type(ErrorType::ResourceExhausted)
-                        .message("All workers are busy, please retry later")
+                        .message(msg)
                         .cause(cause)
                         .build()
                         .into());


### PR DESCRIPTION
Surface the --active-decode-blocks-threshold and --active-prefill-tokens-threshold flags in the 503 ResourceExhausted response so users hitting "All workers are busy" know how to raise or disable the busy-detection thresholds.

#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
