### PR TITLE
feat(planner): make PrometheusConnect SSL verification configurable

### DIFF
--- a/components/src/dynamo/planner/config/defaults.py
+++ b/components/src/dynamo/planner/config/defaults.py
@@ -54,6 +54,15 @@ class SLAPlannerDefaults(BasePlannerDefaults):
     # that rotate, use a token_file knob instead (separate config field
     # planned as follow-up).
     metric_pulling_prometheus_token = os.environ.get("PROMETHEUS_TOKEN")
+    # Verify the upstream Prometheus TLS certificate. Default False preserves
+    # the previous PrometheusConnect(disable_ssl=True) behavior so existing
+    # deployments are unaffected. Set to True (or env PROMETHEUS_SSL_VERIFY=1)
+    # for hardened monitoring stacks where you want the request to fail
+    # closed on a bad cert. Pair with PROMETHEUS_CA_BUNDLE if the upstream
+    # uses a private CA.
+    metric_pulling_prometheus_ssl_verify = os.environ.get(
+        "PROMETHEUS_SSL_VERIFY", "false"
+    ).lower() in ("1", "true", "yes")
     profile_results_dir = "profiling_results"
 
     isl = 3000  # in number of tokens

--- a/components/src/dynamo/planner/config/planner_config.py
+++ b/components/src/dynamo/planner/config/planner_config.py
@@ -56,9 +56,9 @@ class PlannerConfig(BaseModel):
         description='Controls pre-deployment sweeping mode for planner in-depth profiling. "none" means no pre-deployment sweep (only load-based scaling). "rapid" uses AI Configurator to simulate engine performance. "thorough" uses real GPUs to measure engine performance (takes several hours).',
     )
 
-    environment: Literal["kubernetes", "virtual", "global-planner"] = (
-        SLAPlannerDefaults.environment
-    )
+    environment: Literal[
+        "kubernetes", "virtual", "global-planner"
+    ] = SLAPlannerDefaults.environment
     namespace: str = Field(
         default_factory=lambda: os.environ.get("DYN_NAMESPACE", "dynamo"),
         exclude=True,
@@ -171,9 +171,9 @@ class PlannerConfig(BaseModel):
     metric_reporting_prometheus_port: int = Field(
         default_factory=lambda: int(os.environ.get("PLANNER_PROMETHEUS_PORT", 0))
     )
-    throughput_metrics_source: Literal["frontend", "router"] = (
-        SLAPlannerDefaults.throughput_metrics_source
-    )
+    throughput_metrics_source: Literal[
+        "frontend", "router"
+    ] = SLAPlannerDefaults.throughput_metrics_source
 
     model_name: Optional[str] = None
 

--- a/components/src/dynamo/planner/config/planner_config.py
+++ b/components/src/dynamo/planner/config/planner_config.py
@@ -30,6 +30,14 @@ from dynamo.planner.config.defaults import SLAPlannerDefaults
 logger = logging.getLogger(__name__)
 
 
+def _prometheus_ssl_verify_default() -> bool:
+    return os.environ.get("PROMETHEUS_SSL_VERIFY", "false").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+
+
 class PlannerPreDeploymentSweepMode(str, Enum):
     None_ = "none"
     Rapid = "rapid"
@@ -48,9 +56,9 @@ class PlannerConfig(BaseModel):
         description='Controls pre-deployment sweeping mode for planner in-depth profiling. "none" means no pre-deployment sweep (only load-based scaling). "rapid" uses AI Configurator to simulate engine performance. "thorough" uses real GPUs to measure engine performance (takes several hours).',
     )
 
-    environment: Literal[
-        "kubernetes", "virtual", "global-planner"
-    ] = SLAPlannerDefaults.environment
+    environment: Literal["kubernetes", "virtual", "global-planner"] = (
+        SLAPlannerDefaults.environment
+    )
     namespace: str = Field(
         default_factory=lambda: os.environ.get("DYN_NAMESPACE", "dynamo"),
         exclude=True,
@@ -151,8 +159,7 @@ class PlannerConfig(BaseModel):
         ),
     )
     metric_pulling_prometheus_ssl_verify: bool = Field(
-        default_factory=lambda: os.environ.get("PROMETHEUS_SSL_VERIFY", "false").lower()
-        in ("1", "true", "yes"),
+        default_factory=_prometheus_ssl_verify_default,
         exclude=True,
         description=(
             "Verify the upstream Prometheus TLS certificate. Default False "
@@ -164,9 +171,9 @@ class PlannerConfig(BaseModel):
     metric_reporting_prometheus_port: int = Field(
         default_factory=lambda: int(os.environ.get("PLANNER_PROMETHEUS_PORT", 0))
     )
-    throughput_metrics_source: Literal[
-        "frontend", "router"
-    ] = SLAPlannerDefaults.throughput_metrics_source
+    throughput_metrics_source: Literal["frontend", "router"] = (
+        SLAPlannerDefaults.throughput_metrics_source
+    )
 
     model_name: Optional[str] = None
 

--- a/components/src/dynamo/planner/config/planner_config.py
+++ b/components/src/dynamo/planner/config/planner_config.py
@@ -150,6 +150,17 @@ class PlannerConfig(BaseModel):
             "read once at startup."
         ),
     )
+    metric_pulling_prometheus_ssl_verify: bool = Field(
+        default_factory=lambda: os.environ.get("PROMETHEUS_SSL_VERIFY", "false").lower()
+        in ("1", "true", "yes"),
+        exclude=True,
+        description=(
+            "Verify the upstream Prometheus TLS certificate. Default False "
+            "preserves the previous PrometheusConnect(disable_ssl=True) "
+            "behavior. Set True for hardened monitoring stacks; pair with "
+            "an injected CA bundle if the upstream uses a private CA."
+        ),
+    )
     metric_reporting_prometheus_port: int = Field(
         default_factory=lambda: int(os.environ.get("PLANNER_PROMETHEUS_PORT", 0))
     )

--- a/components/src/dynamo/planner/core/base.py
+++ b/components/src/dynamo/planner/core/base.py
@@ -149,6 +149,7 @@ class NativePlannerBase:
             config.namespace,
             metrics_source=config.throughput_metrics_source,
             bearer_token=config.metric_pulling_prometheus_token,
+            ssl_verify=config.metric_pulling_prometheus_ssl_verify,
         )
         if config.throughput_metrics_source == "router":
             self.prometheus_traffic_client.warn_if_router_not_scraped()

--- a/components/src/dynamo/planner/monitoring/traffic_metrics.py
+++ b/components/src/dynamo/planner/monitoring/traffic_metrics.py
@@ -98,8 +98,12 @@ class PrometheusAPIClient:
         dynamo_namespace: str,
         metrics_source: str = "frontend",
         bearer_token: Optional[str] = None,
+        ssl_verify: bool = False,
     ):
-        self.prom = PrometheusConnect(url=url, disable_ssl=True)
+        # disable_ssl=True (default) preserves prior behavior; flip via the
+        # ssl_verify config knob (env: PROMETHEUS_SSL_VERIFY) when the
+        # upstream cert can be validated.
+        self.prom = PrometheusConnect(url=url, disable_ssl=not ssl_verify)
         if bearer_token:
             self.prom._session.headers["Authorization"] = f"Bearer {bearer_token}"
         self.dynamo_namespace = dynamo_namespace


### PR DESCRIPTION
#### Overview:

Makes Planner's Prometheus client TLS verification configurable. Currently `traffic_metrics.PrometheusAPIClient` hardcodes `PrometheusConnect(disable_ssl=True)`, which silently accepts any certificate the upstream Prometheus presents. That's fine for kube-prometheus-stack on plain `http://`, but a real concern on hardened monitoring stacks where fail-closed cert validation is expected.

#### Details:

- Adds `metric_pulling_prometheus_ssl_verify` to `PlannerConfig` (env: `PROMETHEUS_SSL_VERIFY`).
- When `True`, requests against the configured `metric_pulling_prometheus_endpoint` validate the upstream TLS chain.
- Default is `False`, preserving the previous behavior — no-op for existing deployments.
- For private/internal CAs (OpenShift service-ca, corp roots), this knob on its own isn't sufficient. A sibling PR adds `metric_pulling_prometheus_ca_bundle` for that case; the two compose cleanly (ca_bundle alone implicitly enables verification by setting `verify=<path>`; ssl_verify alone uses the system trust store).

#### Where should the reviewer start?

- `components/src/dynamo/planner/monitoring/traffic_metrics.py` — `PrometheusAPIClient.__init__` accepts an optional `ssl_verify` and passes `disable_ssl=not ssl_verify` to `PrometheusConnect`.
- `components/src/dynamo/planner/config/planner_config.py` and `config/defaults.py` — config field + env-var default.
- `components/src/dynamo/planner/core/base.py` — threads the config field into the `PrometheusAPIClient` constructor.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none filed.
