### PR TITLE
feat(planner): support a static bearer token for Prometheus

### DIFF
--- a/components/src/dynamo/planner/config/defaults.py
+++ b/components/src/dynamo/planner/config/defaults.py
@@ -47,6 +47,13 @@ class SLAPlannerDefaults(BasePlannerDefaults):
         "PROMETHEUS_ENDPOINT",
         "http://prometheus-kube-prometheus-prometheus.monitoring.svc.cluster.local:9090",
     )
+    # Optional bearer token sent as `Authorization: Bearer <token>` on every
+    # PromQL request. Useful for hardened monitoring stacks that require
+    # token auth (OpenShift thanos-querier, anything fronted by an OAuth
+    # proxy). When set, the token is read once at startup; for SA tokens
+    # that rotate, use a token_file knob instead (separate config field
+    # planned as follow-up).
+    metric_pulling_prometheus_token = os.environ.get("PROMETHEUS_TOKEN")
     profile_results_dir = "profiling_results"
 
     isl = 3000  # in number of tokens

--- a/components/src/dynamo/planner/config/planner_config.py
+++ b/components/src/dynamo/planner/config/planner_config.py
@@ -140,6 +140,16 @@ class PlannerConfig(BaseModel):
         ),
         exclude=True,
     )
+    metric_pulling_prometheus_token: Optional[str] = Field(
+        default_factory=lambda: os.environ.get("PROMETHEUS_TOKEN"),
+        exclude=True,
+        description=(
+            "Optional bearer token sent as `Authorization: Bearer <token>` on "
+            "every PromQL request. Useful for hardened monitoring stacks "
+            "(OpenShift thanos-querier, OAuth-proxied Prometheus). Token is "
+            "read once at startup."
+        ),
+    )
     metric_reporting_prometheus_port: int = Field(
         default_factory=lambda: int(os.environ.get("PLANNER_PROMETHEUS_PORT", 0))
     )

--- a/components/src/dynamo/planner/core/base.py
+++ b/components/src/dynamo/planner/core/base.py
@@ -148,6 +148,7 @@ class NativePlannerBase:
             config.metric_pulling_prometheus_endpoint,
             config.namespace,
             metrics_source=config.throughput_metrics_source,
+            bearer_token=config.metric_pulling_prometheus_token,
         )
         if config.throughput_metrics_source == "router":
             self.prometheus_traffic_client.warn_if_router_not_scraped()

--- a/components/src/dynamo/planner/monitoring/traffic_metrics.py
+++ b/components/src/dynamo/planner/monitoring/traffic_metrics.py
@@ -99,8 +99,9 @@ class PrometheusAPIClient:
         metrics_source: str = "frontend",
         bearer_token: Optional[str] = None,
     ):
-        headers = {"Authorization": f"Bearer {bearer_token}"} if bearer_token else None
-        self.prom = PrometheusConnect(url=url, disable_ssl=True, headers=headers)
+        self.prom = PrometheusConnect(url=url, disable_ssl=True)
+        if bearer_token:
+            self.prom._session.headers["Authorization"] = f"Bearer {bearer_token}"
         self.dynamo_namespace = dynamo_namespace
         self.metrics_source = metrics_source  # "frontend" | "router"
 

--- a/components/src/dynamo/planner/monitoring/traffic_metrics.py
+++ b/components/src/dynamo/planner/monitoring/traffic_metrics.py
@@ -93,9 +93,14 @@ class FrontendMetricContainer(BaseModel):
 
 class PrometheusAPIClient:
     def __init__(
-        self, url: str, dynamo_namespace: str, metrics_source: str = "frontend"
+        self,
+        url: str,
+        dynamo_namespace: str,
+        metrics_source: str = "frontend",
+        bearer_token: Optional[str] = None,
     ):
-        self.prom = PrometheusConnect(url=url, disable_ssl=True)
+        headers = {"Authorization": f"Bearer {bearer_token}"} if bearer_token else None
+        self.prom = PrometheusConnect(url=url, disable_ssl=True, headers=headers)
         self.dynamo_namespace = dynamo_namespace
         self.metrics_source = metrics_source  # "frontend" | "router"
 


### PR DESCRIPTION
#### Overview:

Adds an optional bearer-token config to Planner's Prometheus client. The Planner currently hardcodes `PrometheusConnect(disable_ssl=True)` with no support for sending `Authorization: Bearer <token>` headers on PromQL queries. Hardened monitoring stacks — OpenShift Thanos, OAuth-proxied Prometheus, anything fronted by an auth proxy — require this header on every request, so deployments on those stacks currently need an external proxy to inject the token. A native config knob avoids the need for that proxy.

#### Details:

- Adds `metric_pulling_prometheus_token` to `PlannerConfig` (env: `PROMETHEUS_TOKEN`).
- When set, the field is passed as `headers={"Authorization": f"Bearer {token}"}` to `PrometheusConnect`, which the underlying `prometheus_api_client` library propagates onto every request via the shared `requests.Session`.
- Token is read once at startup. For ServiceAccount tokens that rotate (Kubernetes projected-token case), a sibling PR adds `metric_pulling_prometheus_token_file` to re-read from disk on every query.
- Default is unchanged — no header attached unless the knob is set. No behavior change for existing deployments.

#### Where should the reviewer start?

- `components/src/dynamo/planner/monitoring/traffic_metrics.py` — `PrometheusAPIClient.__init__` accepts an optional `bearer_token` and constructs `PrometheusConnect(..., headers=…)` when provided.
- `components/src/dynamo/planner/config/planner_config.py` and `config/defaults.py` — config field + env-var default.
- `components/src/dynamo/planner/core/base.py` — threads the config field into the `PrometheusAPIClient` constructor.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none filed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional bearer-token authentication for Planner's Prometheus metric pulling
  * New `PROMETHEUS_TOKEN` environment variable to set the token (defaults to unset, preserving previous no-auth behavior)
  * Companion `metric_pulling_prometheus_token_file` knob for rotating tokens is in a sibling PR

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9512)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
