### PR TITLE
fix(gms): coordinate sidecar lifecycle via lock state machine, not probes

### DIFF
--- a/components/src/dynamo/sglang/tests/test_sglang_gms_memory_saver.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_gms_memory_saver.py
@@ -46,8 +46,8 @@ class _FakeManager:
         self.calls.append("abort")
         self.granted_lock_type = None
 
-    def connect(self, lock_type) -> None:
-        self.calls.append(("connect", lock_type))
+    def connect(self, lock_type, timeout_ms=None) -> None:
+        self.calls.append(("connect", lock_type, timeout_ms))
         self.granted_lock_type = GrantedLockType(lock_type.value)
         self.is_unmapped = False
 
@@ -141,13 +141,13 @@ def test_pause_resume_routes_only_managed_tags(build_impl):
     assert weights.calls == [
         "unmap_all_vas",
         "abort",
-        ("connect", RequestedLockType.RO),
+        ("connect", RequestedLockType.RO, None),
         "remap_all_vas",
     ]
     assert kv_cache.calls == [
         "unmap_all_vas",
         "abort",
-        ("connect", RequestedLockType.RW),
+        ("connect", RequestedLockType.RW, None),
         ("reallocate_all_handles", "kv_cache"),
         "remap_all_vas",
     ]

--- a/deploy/operator/internal/checkpoint/checkpoint_test.go
+++ b/deploy/operator/internal/checkpoint/checkpoint_test.go
@@ -611,28 +611,27 @@ func TestInjectCheckpointIntoPodSpec(t *testing.T) {
 		require.NoError(t, InjectCheckpointIntoPodSpec(context.Background(), reader, testNamespace, podSpec, info, snapshotprotocol.DefaultSeccompLocalhostProfile))
 		require.NoError(t, InjectCheckpointIntoPodSpec(context.Background(), reader, testNamespace, podSpec, info, snapshotprotocol.DefaultSeccompLocalhostProfile))
 		gmsServer := findContainer(podSpec, gms.ServerContainerName)
-		require.NotNil(t, gmsServer)
+		require.NotNil(t, gmsServer, "gms-server is a native sidecar (init+restartPolicy=Always)")
 		loader := findContainer(podSpec, GMSLoaderContainer)
-		require.NotNil(t, loader)
-		serverCount := 0
-		loaderCount := 0
+		require.NotNil(t, loader, "gms-loader is a regular sidecar")
+		serverInitCount := 0
 		for _, container := range podSpec.InitContainers {
-			switch container.Name {
-			case gms.ServerContainerName:
-				serverCount++
-			case GMSLoaderContainer:
+			if container.Name == gms.ServerContainerName {
+				serverInitCount++
+			}
+		}
+		loaderCount := 0
+		for _, container := range podSpec.Containers {
+			if container.Name == GMSLoaderContainer {
 				loaderCount++
 			}
 		}
-		assert.Equal(t, 1, serverCount)
-		assert.Equal(t, 1, loaderCount)
+		assert.Equal(t, 1, serverInitCount, "injection is idempotent for server")
+		assert.Equal(t, 1, loaderCount, "injection is idempotent for loader")
 
-		// Restore: server and loader are init sidecars (restartPolicy=Always)
-		assert.NotNil(t, gmsServer.RestartPolicy, "restore gms-server should have RestartPolicy")
 		assert.Equal(t, corev1.ContainerRestartPolicyAlways, *gmsServer.RestartPolicy)
-		assert.Nil(t, gmsServer.StartupProbe, "restore gms-server should not have StartupProbe")
-		assert.NotNil(t, loader.RestartPolicy, "restore gms-loader should have RestartPolicy")
-		assert.Equal(t, corev1.ContainerRestartPolicyAlways, *loader.RestartPolicy)
+		assert.Nil(t, gmsServer.StartupProbe, "no StartupProbe — clients drive readiness via connect-retry")
+		assert.Nil(t, loader.RestartPolicy, "loader is a regular sidecar; pod RestartPolicy applies")
 
 		mounts := map[string]string{}
 		for _, mount := range loader.VolumeMounts {

--- a/deploy/operator/internal/checkpoint/gms.go
+++ b/deploy/operator/internal/checkpoint/gms.go
@@ -27,9 +27,9 @@ const (
 	envCheckpointDir = "GMS_CHECKPOINT_DIR"
 )
 
-// EnsureGMSRestoreSidecars appends restartable init sidecars for GMS restore.
-// The server must be ready before CRIU resumes the target process, while the
-// loader continues running alongside regular containers.
+// EnsureGMSRestoreSidecars adds the GMS server init sidecar and loader.
+// The loader is a regular sidecar; the GMS RO lock — not init-phase ordering —
+// gates the restored engine on weight load. Idempotent.
 func EnsureGMSRestoreSidecars(
 	podSpec *corev1.PodSpec,
 	mainContainer *corev1.Container,
@@ -39,27 +39,16 @@ func EnsureGMSRestoreSidecars(
 		return
 	}
 
-	// Re-append restore sidecars in a deterministic order.
-	initContainers := podSpec.InitContainers[:0]
-	for _, container := range podSpec.InitContainers {
-		if container.Name != gms.ServerContainerName && container.Name != GMSLoaderContainer {
-			initContainers = append(initContainers, container)
-		}
-	}
-	podSpec.InitContainers = initContainers
-	gms.EnsureSharedVolume(podSpec, mainContainer)
-
+	podSpec.InitContainers = removeGMSManagedContainers(podSpec.InitContainers, gms.ServerContainerName)
+	podSpec.Containers = removeGMSManagedContainers(podSpec.Containers, GMSLoaderContainer)
+	gms.EnsureServerSidecar(podSpec, mainContainer)
 	snapshotprotocol.InjectCheckpointVolume(podSpec, storage.PVCName)
-
-	server := gms.Container(gms.ServerContainerName, gms.ServerModule, mainContainer.Image)
-	server.RestartPolicy = ptr.To(corev1.ContainerRestartPolicyAlways)
 
 	loader := gms.Container(GMSLoaderContainer, gmsCheckpointLoaderModule, mainContainer.Image)
 	loader.VolumeMounts = append(loader.VolumeMounts, corev1.VolumeMount{Name: snapshotprotocol.CheckpointVolumeName, MountPath: storage.BasePath})
 	loader.Env = append(loader.Env, corev1.EnvVar{Name: envCheckpointDir, Value: resolveGMSArtifactDir(storage)})
-	loader.RestartPolicy = ptr.To(corev1.ContainerRestartPolicyAlways)
 
-	podSpec.InitContainers = append(podSpec.InitContainers, server, loader)
+	podSpec.Containers = append(podSpec.Containers, loader)
 }
 
 // EnsureGMSCheckpointJobSidecars adds GMS server (init) + saver containers
@@ -102,4 +91,19 @@ func resolveGMSArtifactDir(storage snapshotprotocol.Storage) string {
 	artifactVersion := filepath.Base(storage.Location)
 	checkpointID := filepath.Base(filepath.Dir(filepath.Dir(storage.Location)))
 	return filepath.Join(storage.BasePath, "gms", checkpointID, "versions", artifactVersion)
+}
+
+func removeGMSManagedContainers(containers []corev1.Container, names ...string) []corev1.Container {
+	managed := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		managed[name] = struct{}{}
+	}
+	filtered := containers[:0]
+	for _, c := range containers {
+		if _, ok := managed[c.Name]; ok {
+			continue
+		}
+		filtered = append(filtered, c)
+	}
+	return filtered
 }

--- a/deploy/operator/internal/checkpoint/gms.go
+++ b/deploy/operator/internal/checkpoint/gms.go
@@ -38,15 +38,18 @@ func EnsureGMSRestoreSidecars(
 		return
 	}
 
-	podSpec.InitContainers = removeGMSManagedContainers(podSpec.InitContainers, gms.ServerContainerName)
-	podSpec.Containers = removeGMSManagedContainers(podSpec.Containers, GMSLoaderContainer)
 	gms.EnsureServerSidecar(podSpec, mainContainer)
 	snapshotprotocol.InjectCheckpointVolume(podSpec, storage.PVCName)
+
+	for _, c := range podSpec.Containers {
+		if c.Name == GMSLoaderContainer {
+			return
+		}
+	}
 
 	loader := gms.Container(GMSLoaderContainer, gmsCheckpointLoaderModule, mainContainer.Image)
 	loader.VolumeMounts = append(loader.VolumeMounts, corev1.VolumeMount{Name: snapshotprotocol.CheckpointVolumeName, MountPath: storage.BasePath})
 	loader.Env = append(loader.Env, corev1.EnvVar{Name: envCheckpointDir, Value: resolveGMSArtifactDir(storage)})
-
 	podSpec.Containers = append(podSpec.Containers, loader)
 }
 
@@ -87,19 +90,4 @@ func resolveGMSArtifactDir(storage snapshotprotocol.Storage) string {
 	artifactVersion := filepath.Base(storage.Location)
 	checkpointID := filepath.Base(filepath.Dir(filepath.Dir(storage.Location)))
 	return filepath.Join(storage.BasePath, "gms", checkpointID, "versions", artifactVersion)
-}
-
-func removeGMSManagedContainers(containers []corev1.Container, names ...string) []corev1.Container {
-	managed := make(map[string]struct{}, len(names))
-	for _, name := range names {
-		managed[name] = struct{}{}
-	}
-	filtered := containers[:0]
-	for _, c := range containers {
-		if _, ok := managed[c.Name]; ok {
-			continue
-		}
-		filtered = append(filtered, c)
-	}
-	return filtered
 }

--- a/deploy/operator/internal/checkpoint/gms.go
+++ b/deploy/operator/internal/checkpoint/gms.go
@@ -12,7 +12,6 @@ import (
 	gms "github.com/ai-dynamo/dynamo/deploy/operator/internal/gms"
 	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/utils/ptr"
 )
 
 const (
@@ -51,8 +50,9 @@ func EnsureGMSRestoreSidecars(
 	podSpec.Containers = append(podSpec.Containers, loader)
 }
 
-// EnsureGMSCheckpointJobSidecars adds GMS server (init) + saver containers
-// to the pod spec for a checkpoint job.
+// EnsureGMSCheckpointJobSidecars adds the GMS server init sidecar and saver
+// as a regular Job container. Saver is a regular container (not init+sleep)
+// so Job completion gates on tensor write.
 func EnsureGMSCheckpointJobSidecars(
 	podSpec *corev1.PodSpec,
 	mainContainer *corev1.Container,
@@ -76,11 +76,7 @@ func EnsureGMSCheckpointJobSidecars(
 	saver := gms.Container(GMSSaverContainer, gmsCheckpointSaverModule, mainContainer.Image)
 	saver.VolumeMounts = append(saver.VolumeMounts, corev1.VolumeMount{Name: snapshotprotocol.CheckpointVolumeName, MountPath: storage.BasePath})
 	saver.Env = append(saver.Env, corev1.EnvVar{Name: envCheckpointDir, Value: gmsArtifactDir})
-	// The saver is an init sidecar (restartPolicy=Always) so it doesn't
-	// affect pod Ready (only the worker's probe matters) and doesn't block
-	// Job completion. It saves, then sleeps until the pod terminates.
-	saver.RestartPolicy = ptr.To(corev1.ContainerRestartPolicyAlways)
-	podSpec.InitContainers = append(podSpec.InitContainers, saver)
+	podSpec.Containers = append(podSpec.Containers, saver)
 	return nil
 }
 

--- a/deploy/operator/internal/controller/dynamocheckpoint_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocheckpoint_controller_test.go
@@ -369,7 +369,7 @@ func TestBuildCheckpointJobAddsGMSSidecars(t *testing.T) {
 
 	main := requireCheckpointContainer(t, job.Spec.Template.Spec.Containers, consts.MainContainerName)
 	weightsServer := requireCheckpointContainer(t, job.Spec.Template.Spec.InitContainers, gms.ServerContainerName)
-	saver := requireCheckpointContainer(t, job.Spec.Template.Spec.InitContainers, checkpoint.GMSSaverContainer)
+	saver := requireCheckpointContainer(t, job.Spec.Template.Spec.Containers, checkpoint.GMSSaverContainer)
 
 	volNames := map[string]bool{}
 	for _, v := range job.Spec.Template.Spec.Volumes {
@@ -389,6 +389,7 @@ func TestBuildCheckpointJobAddsGMSSidecars(t *testing.T) {
 	assert.Equal(t, corev1.ContainerRestartPolicyAlways, *weightsServer.RestartPolicy)
 	assert.Nil(t, weightsServer.StartupProbe, "no probe — clients drive readiness via connect-retry")
 	assert.Equal(t, []string{"python3", "-m", "gpu_memory_service.cli.snapshot.saver"}, saver.Command)
+	assert.Nil(t, saver.RestartPolicy, "saver runs as a regular Job container so Job completion waits for it")
 
 	saverMounts := map[string]string{}
 	for _, m := range saver.VolumeMounts {

--- a/deploy/operator/internal/controller/dynamocheckpoint_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocheckpoint_controller_test.go
@@ -387,7 +387,7 @@ func TestBuildCheckpointJobAddsGMSSidecars(t *testing.T) {
 
 	assert.Equal(t, []string{"python3", "-m", "gpu_memory_service.cli.server"}, weightsServer.Command)
 	assert.Equal(t, corev1.ContainerRestartPolicyAlways, *weightsServer.RestartPolicy)
-	require.NotNil(t, weightsServer.StartupProbe)
+	assert.Nil(t, weightsServer.StartupProbe, "no probe — clients drive readiness via connect-retry")
 	assert.Equal(t, []string{"python3", "-m", "gpu_memory_service.cli.snapshot.saver"}, saver.Command)
 
 	saverMounts := map[string]string{}

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -1738,12 +1738,16 @@ func TestDynamoComponentDeploymentReconciler_generatePodTemplateSpec_RestoreLabe
 		if got := gmsServer.Command; len(got) != 3 || got[0] != "python3" || got[1] != "-m" || got[2] != "gpu_memory_service.cli.server" { //nolint:goconst
 			t.Fatalf("expected weights server to run python module, got %#v", got)
 		}
-		// Restore: gms-server and loader are init sidecars (restartPolicy=Always)
+		// gms-server is a native sidecar (init + restartPolicy=Always); no probe.
 		if gmsServer.RestartPolicy == nil || *gmsServer.RestartPolicy != corev1.ContainerRestartPolicyAlways {
 			t.Fatalf("expected restore gms-server to have RestartPolicy=Always, got %#v", gmsServer.RestartPolicy)
 		}
 		if gmsServer.StartupProbe != nil {
 			t.Fatalf("expected restore gms-server to have no StartupProbe")
+		}
+		// gms-loader is a regular sidecar (no container-level RestartPolicy override).
+		if loader.RestartPolicy != nil {
+			t.Fatalf("expected restore gms-loader to have no container-level RestartPolicy, got %#v", loader.RestartPolicy)
 		}
 		if got := loader.Command; len(got) != 3 || got[0] != "python3" || got[1] != "-m" || got[2] != "gpu_memory_service.cli.snapshot.loader" {
 			t.Fatalf("expected loader to run python module, got %#v", got)

--- a/deploy/operator/internal/gms/gms.go
+++ b/deploy/operator/internal/gms/gms.go
@@ -8,8 +8,6 @@
 package gms
 
 import (
-	"path/filepath"
-
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dra"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
@@ -33,12 +31,14 @@ const (
 
 	// ServerModule is the Python module for the GMS server entry point.
 	ServerModule = "gpu_memory_service.cli.server"
-
-	readyFile = "gms-ready"
 )
 
-// EnsureServerSidecar adds the GMS server as a restartable init sidecar with a
-// startup probe. Idempotent — safe to call from both the DGD and checkpoint paths.
+// EnsureServerSidecar adds the GMS server as a native sidecar (init +
+// restartPolicy=Always). With no StartupProbe, kubelet considers it Started
+// as soon as the process is running — clients ride out the sub-second
+// socket-bind via connect-retry. Native sidecar status is kept so kubelet
+// terminates the server when the Job's regular containers exit; a regular
+// container here would keep the Pod in Running forever. Idempotent.
 func EnsureServerSidecar(podSpec *corev1.PodSpec, mainContainer *corev1.Container) {
 	if podSpec == nil || mainContainer == nil {
 		return
@@ -48,15 +48,6 @@ func EnsureServerSidecar(podSpec *corev1.PodSpec, mainContainer *corev1.Containe
 
 	sidecar := Container(ServerContainerName, ServerModule, mainContainer.Image)
 	sidecar.RestartPolicy = ptr.To(corev1.ContainerRestartPolicyAlways)
-	sidecar.StartupProbe = &corev1.Probe{
-		ProbeHandler: corev1.ProbeHandler{
-			Exec: &corev1.ExecAction{
-				Command: []string{"test", "-f", filepath.Join(SharedMountPath, readyFile)},
-			},
-		},
-		PeriodSeconds:    1,
-		FailureThreshold: 300, // 1s * 300 = 5 min
-	}
 	for i := range podSpec.InitContainers {
 		if podSpec.InitContainers[i].Name == sidecar.Name {
 			return

--- a/deploy/operator/internal/gms/gms_test.go
+++ b/deploy/operator/internal/gms/gms_test.go
@@ -6,7 +6,6 @@
 package gms
 
 import (
-	"path/filepath"
 	"testing"
 
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dra"
@@ -34,9 +33,7 @@ func TestEnsureServerSidecar(t *testing.T) {
 	assert.Equal(t, ServerContainerName, server.Name)
 	assert.Equal(t, []string{"python3", "-m", ServerModule}, server.Command)
 	assert.Equal(t, corev1.ContainerRestartPolicyAlways, *server.RestartPolicy)
-	require.NotNil(t, server.StartupProbe)
-	assert.Equal(t, []string{"test", "-f", filepath.Join(SharedMountPath, readyFile)},
-		server.StartupProbe.Exec.Command)
+	assert.Nil(t, server.StartupProbe, "clients drive readiness via connect-retry")
 
 	// DRA claim on server
 	assert.Len(t, server.Resources.Claims, 1)

--- a/lib/gpu_memory_service/README.md
+++ b/lib/gpu_memory_service/README.md
@@ -604,3 +604,11 @@ To force read-only mode (import only, never load from disk), pass `gms_read_only
 ```
 
 This forces `RO` lock mode instead of the default `RW_OR_RO` auto-detection. The engine will only import existing committed weights and fail if none are available.
+
+To bound how long a restored engine waits for the published weights layout before remapping, pass `gms_ro_connect_timeout_ms`:
+
+```bash
+--model-loader-extra-config '{"gms_ro_connect_timeout_ms": 300000}'
+```
+
+The default is `null`, which waits indefinitely. Set an integer value to fail after that many milliseconds.

--- a/lib/gpu_memory_service/cli/server.py
+++ b/lib/gpu_memory_service/cli/server.py
@@ -3,23 +3,21 @@
 
 """GMS server entry point.
 
-Launches two GMS server processes per GPU (one for weights, one for kv_cache).
-Writes a ready file once all expected UDS sockets are present. Runs until
-SIGTERM (pod termination kills it).
+Launches two GMS server processes per GPU (one for weights, one for kv_cache),
+then supervises them: terminates the rest if any child exits, and propagates
+the first non-zero exit code. Runs until SIGTERM (pod termination kills it)
+or until a child exits.
 """
 
 from __future__ import annotations
 
 import logging
-import os
 import signal
 import subprocess
 import sys
 import time
-from pathlib import Path
 
 from gpu_memory_service.common.cuda_utils import list_devices
-from gpu_memory_service.common.utils import get_socket_path
 
 logging.basicConfig(
     level=logging.INFO,
@@ -28,13 +26,9 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 _TAGS = ("weights", "kv_cache")
-_READY_FILE = "gms-ready"
 
 
 def main() -> None:
-    ready_file = Path(os.environ.get("GMS_SOCKET_DIR", "/tmp")) / _READY_FILE
-    ready_file.unlink(missing_ok=True)
-
     devices = list_devices()
     processes = []
     for device in devices:
@@ -65,18 +59,7 @@ def main() -> None:
     signal.signal(signal.SIGTERM, terminate)
     signal.signal(signal.SIGINT, terminate)
 
-    ready_written = False
     while True:
-        if not ready_written:
-            sockets_ready = all(
-                os.path.exists(get_socket_path(device, tag))
-                for device in devices
-                for tag in _TAGS
-            )
-            if sockets_ready:
-                ready_file.write_text("ready", encoding="utf-8")
-                ready_written = True
-
         running = False
         for process in processes:
             exit_code = process.poll()

--- a/lib/gpu_memory_service/cli/snapshot/loader.py
+++ b/lib/gpu_memory_service/cli/snapshot/loader.py
@@ -3,9 +3,10 @@
 
 """GMS checkpoint loader entry point.
 
-Waits for the GMS server UDS socket on each device, then loads saved GMS
-state from a checkpoint directory into the running GMS servers. Devices
-are loaded in parallel to saturate PVC bandwidth.
+Loads saved GMS state from a checkpoint directory into the running GMS
+servers. Devices are loaded in parallel to saturate PVC bandwidth. Runs as
+a regular sidecar; the GMS RO lock — not init-phase ordering — gates the
+restored engine on weight load.
 """
 
 from __future__ import annotations
@@ -18,7 +19,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from gpu_memory_service.common.cuda_utils import list_devices
-from gpu_memory_service.common.utils import get_socket_path, wait_for_weights_socket
+from gpu_memory_service.common.utils import get_socket_path
 from gpu_memory_service.snapshot.storage_client import GMSStorageClient
 
 logging.basicConfig(
@@ -29,7 +30,6 @@ logger = logging.getLogger(__name__)
 
 
 def _load_device(checkpoint_dir: str, device: int, max_workers: int) -> None:
-    wait_for_weights_socket(device)
     input_dir = os.path.join(checkpoint_dir, f"device-{device}")
     logger.info("Loading GMS checkpoint: device=%d input_dir=%s", device, input_dir)
     t0 = time.monotonic()

--- a/lib/gpu_memory_service/cli/snapshot/saver.py
+++ b/lib/gpu_memory_service/cli/snapshot/saver.py
@@ -18,7 +18,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from gpu_memory_service.common.cuda_utils import list_devices
-from gpu_memory_service.common.utils import get_socket_path, wait_for_weights_socket
+from gpu_memory_service.common.utils import get_socket_path
 from gpu_memory_service.snapshot.storage_client import GMSStorageClient
 
 logging.basicConfig(
@@ -29,7 +29,6 @@ logger = logging.getLogger(__name__)
 
 
 def _save_device(checkpoint_dir: str, device: int, max_workers: int) -> None:
-    wait_for_weights_socket(device)
     output_dir = os.path.join(checkpoint_dir, f"device-{device}")
     logger.info("Saving GMS checkpoint: device=%d output_dir=%s", device, output_dir)
     t0 = time.monotonic()

--- a/lib/gpu_memory_service/cli/snapshot/saver.py
+++ b/lib/gpu_memory_service/cli/snapshot/saver.py
@@ -25,8 +25,15 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+# How long the saver waits for the engine to commit weights before giving up
+# and failing the Job. Without a bound, an engine that crashes before commit
+# would leave the saver blocked indefinitely and the Job stuck Running.
+DEFAULT_SAVE_LOCK_TIMEOUT_MS = 30 * 60 * 1000  # 30 minutes
 
-def _save_device(checkpoint_dir: str, device: int, max_workers: int) -> None:
+
+def _save_device(
+    checkpoint_dir: str, device: int, max_workers: int, lock_timeout_ms: int
+) -> None:
     output_dir = os.path.join(checkpoint_dir, f"device-{device}")
     logger.info("Saving GMS checkpoint: device=%d output_dir=%s", device, output_dir)
     t0 = time.monotonic()
@@ -34,6 +41,7 @@ def _save_device(checkpoint_dir: str, device: int, max_workers: int) -> None:
         output_dir,
         socket_path=get_socket_path(device),
         device=device,
+        timeout_ms=lock_timeout_ms,
     ).save(max_workers=max_workers)
     elapsed = time.monotonic() - t0
     logger.info("GMS checkpoint saved: device=%d elapsed=%.2fs", device, elapsed)
@@ -42,13 +50,22 @@ def _save_device(checkpoint_dir: str, device: int, max_workers: int) -> None:
 def main() -> None:
     checkpoint_dir = os.environ["GMS_CHECKPOINT_DIR"]
     max_workers = int(os.environ.get("GMS_SAVE_WORKERS", "8"))
+    lock_timeout_ms = int(
+        os.environ.get("GMS_SAVE_LOCK_TIMEOUT_MS", str(DEFAULT_SAVE_LOCK_TIMEOUT_MS))
+    )
 
     devices = list_devices()
-    logger.info("Starting GMS save for %d devices", len(devices))
+    logger.info(
+        "Starting GMS save for %d devices (lock_timeout_ms=%d)",
+        len(devices),
+        lock_timeout_ms,
+    )
     t0 = time.monotonic()
     with ThreadPoolExecutor(max_workers=len(devices)) as pool:
         futures = {
-            pool.submit(_save_device, checkpoint_dir, dev, max_workers): dev
+            pool.submit(
+                _save_device, checkpoint_dir, dev, max_workers, lock_timeout_ms
+            ): dev
             for dev in devices
         }
         for future in as_completed(futures):

--- a/lib/gpu_memory_service/cli/snapshot/saver.py
+++ b/lib/gpu_memory_service/cli/snapshot/saver.py
@@ -4,16 +4,14 @@
 """GMS checkpoint saver entry point.
 
 Waits for committed GMS weights on each device, then saves GPU memory state
-to the checkpoint directory. Runs as an init sidecar — sleeps after saving
-until the pod terminates.
+to the checkpoint directory. Runs as a regular Job container that exits
+after save so the Job completes once tensors are on disk.
 """
 
 from __future__ import annotations
 
 import logging
 import os
-import signal
-import sys
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
@@ -57,11 +55,7 @@ def main() -> None:
             future.result()
     elapsed = time.monotonic() - t0
     logger.info("All %d devices saved in %.2fs", len(devices), elapsed)
-
-    logger.info("Save complete; sleeping until pod terminates")
-    signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
-    while True:
-        time.sleep(3600)
+    logger.info("Save complete; exiting")
 
 
 if __name__ == "__main__":

--- a/lib/gpu_memory_service/client/rpc.py
+++ b/lib/gpu_memory_service/client/rpc.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import logging
 import os
 import socket
+import time
 from typing import Optional, Tuple, Type, TypeVar
 
 from gpu_memory_service.common.locks import RequestedLockType
@@ -39,20 +40,37 @@ class _GMSRPCTransport:
     def is_connected(self) -> bool:
         return self._socket is not None
 
-    def connect(self) -> None:
-        self._socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        try:
-            self._socket.connect(self.socket_path)
-        except FileNotFoundError:
-            self._socket.close()
-            self._socket = None
-            raise ConnectionError(
-                f"GMS server not running at {self.socket_path}"
-            ) from None
-        except Exception as exc:
-            self._socket.close()
-            self._socket = None
-            raise ConnectionError(f"Failed to connect to GMS: {exc}") from exc
+    def connect(self, timeout_ms: int = 0) -> None:
+        """Open the UDS socket, retrying while the server is not yet listening.
+
+        timeout_ms=0 (default) fails fast like the pre-retry behavior. A
+        positive value retries on FileNotFoundError / ConnectionRefusedError
+        until the deadline.
+        """
+        deadline = time.monotonic() + timeout_ms / 1000
+        logged_wait = False
+        while True:
+            self._socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            try:
+                self._socket.connect(self.socket_path)
+                if logged_wait:
+                    logger.info("Connected to GMS server at %s", self.socket_path)
+                return
+            except (FileNotFoundError, ConnectionRefusedError):
+                self._socket.close()
+                self._socket = None
+                if timeout_ms <= 0 or time.monotonic() >= deadline:
+                    raise ConnectionError(
+                        f"GMS server not running at {self.socket_path}"
+                    ) from None
+                if not logged_wait:
+                    logger.info("Waiting for GMS server at %s", self.socket_path)
+                    logged_wait = True
+                time.sleep(min(0.05, max(0.0, deadline - time.monotonic())))
+            except Exception as exc:
+                self._socket.close()
+                self._socket = None
+                raise ConnectionError(f"Failed to connect to GMS: {exc}") from exc
 
     def handshake(
         self,

--- a/lib/gpu_memory_service/client/session.py
+++ b/lib/gpu_memory_service/client/session.py
@@ -57,7 +57,9 @@ class _GMSClientSession:
         # Use the caller's timeout_ms (or 5 min default if None) as the socket
         # connect-retry bound; the handshake gets the caller's timeout_ms
         # directly.
-        self._transport.connect(timeout_ms=300_000 if timeout_ms is None else timeout_ms)
+        self._transport.connect(
+            timeout_ms=300_000 if timeout_ms is None else timeout_ms
+        )
         try:
             response = self._transport.handshake(lock_type, timeout_ms)
         except Exception:

--- a/lib/gpu_memory_service/client/session.py
+++ b/lib/gpu_memory_service/client/session.py
@@ -71,9 +71,7 @@ class _GMSClientSession:
         #     (engine loading weights, loader committing, etc.) and can be
         #     minutes for large models. We deliberately don't impose a
         #     server-availability ceiling on a workload-shaped wait.
-        self._transport.connect(
-            timeout_ms=30_000 if timeout_ms is None else timeout_ms
-        )
+        self._transport.connect(timeout_ms=30_000 if timeout_ms is None else timeout_ms)
         try:
             response = self._transport.handshake(lock_type, timeout_ms)
         except Exception:

--- a/lib/gpu_memory_service/client/session.py
+++ b/lib/gpu_memory_service/client/session.py
@@ -54,7 +54,10 @@ class _GMSClientSession:
     ):
         self._requested_lock_type = lock_type
         self._transport = _GMSRPCTransport(socket_path)
-        self._transport.connect()
+        # Use the caller's timeout_ms (or 5 min default if None) as the socket
+        # connect-retry bound; the handshake gets the caller's timeout_ms
+        # directly.
+        self._transport.connect(timeout_ms=300_000 if timeout_ms is None else timeout_ms)
         try:
             response = self._transport.handshake(lock_type, timeout_ms)
         except Exception:

--- a/lib/gpu_memory_service/client/session.py
+++ b/lib/gpu_memory_service/client/session.py
@@ -54,11 +54,25 @@ class _GMSClientSession:
     ):
         self._requested_lock_type = lock_type
         self._transport = _GMSRPCTransport(socket_path)
-        # Use the caller's timeout_ms (or 5 min default if None) as the socket
-        # connect-retry bound; the handshake gets the caller's timeout_ms
-        # directly.
+        # Two distinct timeouts apply to this session, and they're asymmetric on
+        # purpose:
+        #
+        #   socket connect (here) — bounded by 30 s when the caller passes None.
+        #     This is the wait for the GMS server's UDS socket to be listening.
+        #     The server is a native sidecar in the same pod (intra-pod GMS) or a
+        #     sister pod under the same Grove gang-schedule (inter-pod GMS), so
+        #     the actual ready window is sub-second to a few seconds in the
+        #     normal case. A 30 s ceiling produces a clean ConnectionError on a
+        #     missing-server misconfiguration instead of an indefinite hang.
+        #
+        #   handshake / lock acquisition (below) — passes the caller's timeout_ms
+        #     through unchanged, including None which means "wait indefinitely."
+        #     The handshake wait depends on what other clients are doing
+        #     (engine loading weights, loader committing, etc.) and can be
+        #     minutes for large models. We deliberately don't impose a
+        #     server-availability ceiling on a workload-shaped wait.
         self._transport.connect(
-            timeout_ms=300_000 if timeout_ms is None else timeout_ms
+            timeout_ms=30_000 if timeout_ms is None else timeout_ms
         )
         try:
             response = self._transport.handshake(lock_type, timeout_ms)

--- a/lib/gpu_memory_service/common/utils.py
+++ b/lib/gpu_memory_service/common/utils.py
@@ -71,12 +71,3 @@ def get_socket_path(device: int, tag: str = "weights") -> str:
         _uuid_cache[device] = uuid
     socket_dir = os.environ.get("GMS_SOCKET_DIR") or tempfile.gettempdir()
     return os.path.join(socket_dir, f"gms_{uuid}_{tag}.sock")
-
-
-def wait_for_weights_socket(device: int) -> None:
-    """Block until the GMS weights socket for the given device exists."""
-    import time
-
-    path = get_socket_path(device, "weights")
-    while not os.path.exists(path):
-        time.sleep(0.1)

--- a/lib/gpu_memory_service/integrations/common/utils.py
+++ b/lib/gpu_memory_service/integrations/common/utils.py
@@ -34,7 +34,14 @@ def get_gms_lock_mode(extra_config: dict):
 def get_gms_ro_connect_timeout_ms(extra_config: dict) -> int | None:
     """Weight RO reconnect timeout in ms. None waits indefinitely."""
     raw = extra_config.get("gms_ro_connect_timeout_ms")
-    return None if raw is None else int(raw)
+    if raw is None:
+        return None
+    timeout_ms = int(raw)
+    if timeout_ms < 0:
+        raise ValueError(
+            f"gms_ro_connect_timeout_ms must be non-negative, got {timeout_ms}"
+        )
+    return timeout_ms
 
 
 def strip_gms_model_loader_config(load_config, load_format: str):

--- a/lib/gpu_memory_service/integrations/common/utils.py
+++ b/lib/gpu_memory_service/integrations/common/utils.py
@@ -31,6 +31,12 @@ def get_gms_lock_mode(extra_config: dict):
     return RequestedLockType.RW_OR_RO
 
 
+def get_gms_ro_connect_timeout_ms(extra_config: dict) -> int | None:
+    """Weight RO reconnect timeout in ms. None waits indefinitely."""
+    raw = extra_config.get("gms_ro_connect_timeout_ms")
+    return None if raw is None else int(raw)
+
+
 def strip_gms_model_loader_config(load_config, load_format: str):
     """Copy a loader config with GMS-only keys removed for backend loaders."""
     extra_config = getattr(load_config, "model_loader_extra_config", {}) or {}

--- a/lib/gpu_memory_service/integrations/sglang/__init__.py
+++ b/lib/gpu_memory_service/integrations/sglang/__init__.py
@@ -20,9 +20,10 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Module-level GMS lock mode, set by setup_gms() before loader is instantiated.
-# Read by patches.py when creating GMSMemorySaverImpl.
+# Module-level GMS lock mode + RO reconnect timeout, set by setup_gms() before
+# loader is instantiated. Read by patches.py when creating GMSMemorySaverImpl.
 _gms_lock_mode = None
+_gms_ro_connect_timeout_ms = None
 _gms_initialized = False
 
 
@@ -56,8 +57,10 @@ def setup_gms(server_args) -> Type["GMSModelLoader"]:
             "Cannot use --enable-draft-weights-cpu-backup with --load-format gms."
         )
 
-    # Resolve lock mode from model_loader_extra_config before patches fire
+    # Resolve lock mode and RO reconnect timeout from model_loader_extra_config
+    # before patches fire.
     global _gms_lock_mode
+    global _gms_ro_connect_timeout_ms
     extra = getattr(server_args, "model_loader_extra_config", None)
     if isinstance(extra, str):
         import json
@@ -65,9 +68,13 @@ def setup_gms(server_args) -> Type["GMSModelLoader"]:
         extra = json.loads(extra) if extra else {}
     extra = extra or {}
 
-    from gpu_memory_service.integrations.common.utils import get_gms_lock_mode
+    from gpu_memory_service.integrations.common.utils import (
+        get_gms_lock_mode,
+        get_gms_ro_connect_timeout_ms,
+    )
 
     _gms_lock_mode = get_gms_lock_mode(extra)
+    _gms_ro_connect_timeout_ms = get_gms_ro_connect_timeout_ms(extra)
 
     # Import triggers patches at module level
     from gpu_memory_service.integrations.sglang.model_loader import GMSModelLoader

--- a/lib/gpu_memory_service/integrations/sglang/memory_saver.py
+++ b/lib/gpu_memory_service/integrations/sglang/memory_saver.py
@@ -67,9 +67,11 @@ class GMSMemorySaverImpl:
         self,
         device_index: int,
         mode=None,
+        ro_connect_timeout_ms=None,
     ):
         self._device = torch.device("cuda", device_index)
         self.imported_weights_bytes = 0
+        self.ro_connect_timeout_ms = ro_connect_timeout_ms
         requested_mode = mode or RequestedLockType.RW_OR_RO
         self.allocators = {
             tag: get_or_create_gms_client_memory_manager(
@@ -170,7 +172,10 @@ class GMSMemorySaverImpl:
                 continue
 
             logger.info("[GMS] Remapping %s", target_tag)
-            self.allocators[target_tag].connect(_TAG_LOCK_TYPES[target_tag])
+            timeout_ms = self.ro_connect_timeout_ms if target_tag == "weights" else None
+            self.allocators[target_tag].connect(
+                _TAG_LOCK_TYPES[target_tag], timeout_ms=timeout_ms
+            )
             if target_tag == "kv_cache":
                 # KV cache resumes into a new RW layout epoch, so the handles
                 # must be re-created before the VA range is mapped again.

--- a/lib/gpu_memory_service/integrations/sglang/patches.py
+++ b/lib/gpu_memory_service/integrations/sglang/patches.py
@@ -72,6 +72,7 @@ def patch_torch_memory_saver() -> None:
             gms_impl = GMSMemorySaverImpl(
                 device_index=device_index,
                 mode=gms_sglang._gms_lock_mode,
+                ro_connect_timeout_ms=gms_sglang._gms_ro_connect_timeout_ms,
             )
 
             # Set _impl directly (accessible via gms_impl property)

--- a/lib/gpu_memory_service/integrations/vllm/worker.py
+++ b/lib/gpu_memory_service/integrations/vllm/worker.py
@@ -31,7 +31,11 @@ from gpu_memory_service.client.torch.allocator import (
 from gpu_memory_service.common.locks import RequestedLockType
 from gpu_memory_service.common.utils import get_socket_path, is_scratch_kv_enabled
 from gpu_memory_service.integrations.common import patch_empty_cache
-from gpu_memory_service.integrations.common.utils import GMS_TAGS, get_gms_lock_mode
+from gpu_memory_service.integrations.common.utils import (
+    GMS_TAGS,
+    get_gms_lock_mode,
+    get_gms_ro_connect_timeout_ms,
+)
 from gpu_memory_service.integrations.vllm.model_loader import register_gms_loader
 from gpu_memory_service.integrations.vllm.patches import (
     apply_scratch_kv_patches,
@@ -78,6 +82,7 @@ class GMSWorker(Worker):
             getattr(self.vllm_config.load_config, "model_loader_extra_config", {}) or {}
         )
         mode = get_gms_lock_mode(extra)
+        self.gms_ro_connect_timeout_ms = get_gms_ro_connect_timeout_ms(extra)
         get_or_create_gms_client_memory_manager(
             get_socket_path(device, "weights"),
             device,
@@ -238,7 +243,10 @@ class GMSWorker(Worker):
             # the worker cannot serve requests without weights. sys.exit(1)
             # ensures clean termination so the orchestrator (K8s) can restart.
             try:
-                weights_manager.connect(RequestedLockType.RO, timeout_ms=30_000)
+                weights_manager.connect(
+                    RequestedLockType.RO,
+                    timeout_ms=getattr(self, "gms_ro_connect_timeout_ms", None),
+                )
                 weights_manager.remap_all_vas()
             except TimeoutError:
                 logger.error(


### PR DESCRIPTION
#### Overview:

Restructure GMS sidecar lifecycles so the GMS lock state machine — not kubelet probes or init-phase ordering — coordinates the engine, loader, saver, and server. Along the way, fix two existing bugs on `main`: a Job-completion race on the saver, and a hardcoded 30 s RO reconnect timeout that's too short for large models.

#### Details:

Five focused commits, each independently meaningful:

1. **`refactor(gms): drop gms-server StartupProbe`** — the server's `exec test -f gms-ready` probe with 5 min FailureThreshold gated regular containers on a sentinel file. With client connect-retry (next commit), it's redundant. The container stays a native sidecar (init + restartPolicy=Always) so kubelet still terminates it when the Job's regular containers exit — that's what lets checkpoint Jobs reach Succeeded.

2. **`feat(gms): client connect-retry replaces wait_for_weights_socket`** — `_GMSRPCTransport.connect(timeout_ms)` retries on `FileNotFoundError` / `ConnectionRefusedError` until a deadline. `_GMSClientSession` threads the caller's `timeout_ms` through (default 5 min when None). Drops the legacy `wait_for_weights_socket` filesystem poll the saver/loader called before connecting.

3. **`refactor(gms): run restore loader as a regular sidecar`** — was an init sidecar with restartPolicy=Always that slept after loading. With clients tolerating a not-yet-listening server, init-phase ordering isn't load-bearing — the GMS RO lock (held by the loader until commit) gates the restored engine on weight load instead. Also factors out `removeGMSManagedContainers` so repeated injection across reconciles stays idempotent across both container lists.

4. **`fix(gms): run checkpoint saver as a regular Job container`** — was an init sidecar with restartPolicy=Always that slept forever after writing tensors. That made Job completion gate on the engine container's exit rather than on the saver finishing — the snapshot agent's SIGKILL of the engine after CRIU dump could race with the saver still flushing weights to the PVC. Now the saver is a regular Job container that exits after save; the Job completes exactly when both engine and saver are done.

5. **`feat(gms): configure RO reconnect timeout via model_loader_extra_config`** — the post-restore RO reconnect in vLLM's `wake_up` and SGLang's `resume` used a hardcoded 30 s timeout. For large models where the GMS loader takes longer than that to read tensors from the PVC and release the RW lock, the restored engine `sys.exit(1)`'d before the loader was done, triggering a Pod restart loop. Read the timeout from `model_loader_extra_config.gms_ro_connect_timeout_ms` instead. Default is `null` (wait indefinitely); set a finite int for fail-fast behavior.

#### Where should the reviewer start?

- `deploy/operator/internal/gms/gms.go` — `EnsureServerSidecar` change (commit 1).
- `lib/gpu_memory_service/client/rpc.py` — the retry loop (commit 2). `client/session.py` thread-through is one-liner.
- `deploy/operator/internal/checkpoint/gms.go` — `EnsureGMSRestoreSidecars` + `EnsureGMSCheckpointJobSidecars` shape (commits 3 + 4).
- `lib/gpu_memory_service/integrations/{common,vllm,sglang}/` — RO timeout wiring (commit 5).

#### Validation:

- `cd deploy/operator && CGO_ENABLED=0 go test ./internal/checkpoint/... ./internal/gms/... ./internal/dynamo/... ./internal/controller -run "GMS|Checkpoint" -count=1` — all green.
- `python3 -m py_compile` on every changed `.py` file — all green.

#### Related Issues:

None.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9514" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable timeout option for read-only memory connections during weight restoration, with indefinite wait as default.

* **Improvements**
  * Enhanced checkpoint sidecar injection to be idempotent, preventing duplicate containers on repeated operations.
  * Refactored checkpoint restore and save components to run as regular containers for improved reliability and execution control.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9514)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->