### PR TITLE
fix(router): use reservoir sampling for tie-breaks

### DIFF
--- a/lib/kv-router/src/scheduling/selector.rs
+++ b/lib/kv-router/src/scheduling/selector.rs
@@ -280,25 +280,29 @@ impl<C: WorkerConfigLike> WorkerSelector<C> for DefaultWorkerSelector {
             });
 
         let (best_worker, best_logit) = if temperature == 0.0 {
-            let mut min_workers = Vec::new();
-            let mut min_score = f64::INFINITY;
+            let mut best_worker = None;
+            let mut best_logit = f64::INFINITY;
+            let mut tie_count = 0usize;
+            let mut rng = rand::rng();
             for worker in worker_iter {
                 let score = get_score(worker);
-                if score < min_score {
-                    min_workers.clear();
-                    min_workers.push(worker);
-                    min_score = score;
-                } else if score == min_score {
-                    min_workers.push(worker);
+                if score < best_logit {
+                    best_worker = Some(worker);
+                    best_logit = score;
+                    tie_count = 1;
+                    continue;
+                }
+
+                if score == best_logit {
+                    tie_count += 1;
+                    // Reservoir sampling keeps tied minima uniform without collecting workers.
+                    if rng.random_range(0..tie_count) == 0 {
+                        best_worker = Some(worker);
+                    }
                 }
             }
 
-            if min_workers.len() > 1 {
-                let idx = rand::rng().random_range(0..min_workers.len());
-                (min_workers[idx], min_score)
-            } else {
-                (min_workers[0], min_score)
-            }
+            (best_worker.expect("worker_iter non-empty"), best_logit)
         } else {
             let mut worker_logits = FxHashMap::default();
             for worker in worker_iter {
@@ -485,6 +489,59 @@ mod tests {
 
         let result = softmax_sample_with_sample(&logits, temperature, sample);
         assert_eq!(result, entries[target_idx]);
+    }
+
+    #[test]
+    fn test_default_selector_randomizes_zero_temperature_ties() {
+        use crate::test_utils::SimpleWorkerConfig;
+
+        let config = KvRouterConfig {
+            router_temperature: 0.0,
+            ..Default::default()
+        };
+        let selector = DefaultWorkerSelector::new(Some(config), "test");
+        let workers = HashMap::from([
+            (10, SimpleWorkerConfig::default()),
+            (20, SimpleWorkerConfig::default()),
+            (30, SimpleWorkerConfig::default()),
+        ]);
+        let request = SchedulingRequest {
+            maybe_request_id: Some("test".into()),
+            token_seq: None,
+            isl_tokens: 16,
+            tier_overlap_blocks: Default::default(),
+            effective_overlap_blocks: HashMap::default(),
+            effective_cached_tokens: HashMap::default(),
+            decode_blocks: FxHashMap::default(),
+            prefill_tokens: FxHashMap::default(),
+            track_prefill_tokens: true,
+            router_config_override: None,
+            update_states: false,
+            lora_name: None,
+            priority_jump: 0.0,
+            expected_output_tokens: None,
+            pinned_worker: None,
+            allowed_worker_ids: None,
+            shared_cache_hits: None,
+            resp_tx: None,
+        };
+        let mut selected = [false; 3];
+
+        for _ in 0..120 {
+            let result = selector.select_worker(&workers, &request, 16).unwrap();
+            match result.worker.worker_id {
+                10 => selected[0] = true,
+                20 => selected[1] = true,
+                30 => selected[2] = true,
+                worker_id => panic!("unexpected worker id: {worker_id}"),
+            }
+        }
+
+        let selected_count = selected.into_iter().filter(|seen| *seen).count();
+        assert!(
+            selected_count > 1,
+            "zero-temperature tie-breaking should not always select the same worker"
+        );
     }
 
     /// Test the scoring formula with shared cache hits.

--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -12,6 +12,7 @@ use anyhow::Result;
 use arc_swap::ArcSwap;
 use dashmap::DashMap;
 use futures::StreamExt;
+use rand::Rng;
 
 use crate::component::{Endpoint, Instance};
 use crate::discovery::{DiscoveryEvent, DiscoveryInstance, DiscoveryInstanceId};
@@ -34,7 +35,28 @@ impl RoutingOccupancyState {
 
     pub(crate) async fn select_exact_min_and_increment(&self, instance_ids: &[u64]) -> Option<u64> {
         let _guard = self.exact_selection_lock.lock().await;
-        let id = *instance_ids.iter().min_by_key(|&&id| self.load(id))?;
+
+        let mut min_load = u64::MAX;
+        let mut min_ids = Vec::new();
+        for &id in instance_ids {
+            let load = self.load(id);
+            if load < min_load {
+                min_load = load;
+                min_ids.clear();
+                min_ids.push(id);
+                continue;
+            }
+
+            if load == min_load {
+                min_ids.push(id);
+            }
+        }
+
+        if min_ids.is_empty() {
+            return None;
+        }
+
+        let id = min_ids[rand::rng().random_range(0..min_ids.len())];
         self.increment(id);
         Some(id)
     }
@@ -551,6 +573,31 @@ mod tests {
         assert_eq!(state.load(100), 30);
         assert_eq!(state.load(200), 30);
         assert_eq!(state.load(300), 30);
+    }
+
+    #[tokio::test]
+    async fn test_select_exact_min_and_increment_randomizes_ties() {
+        let mut selected = [false; 3];
+
+        for _ in 0..120 {
+            let state = RoutingOccupancyState::default();
+            let picked = state
+                .select_exact_min_and_increment(&[10, 20, 30])
+                .await
+                .unwrap();
+            match picked {
+                10 => selected[0] = true,
+                20 => selected[1] = true,
+                30 => selected[2] = true,
+                _ => panic!("unexpected worker id: {picked}"),
+            }
+        }
+
+        let selected_count = selected.into_iter().filter(|seen| *seen).count();
+        assert!(
+            selected_count > 1,
+            "tie-breaking should not always select the first minimum-load worker"
+        );
     }
 
     #[tokio::test]

--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -37,26 +37,28 @@ impl RoutingOccupancyState {
         let _guard = self.exact_selection_lock.lock().await;
 
         let mut min_load = u64::MAX;
-        let mut min_ids = Vec::new();
+        let mut selected = None;
+        let mut tie_count = 0usize;
+        let mut rng = rand::rng();
         for &id in instance_ids {
             let load = self.load(id);
             if load < min_load {
                 min_load = load;
-                min_ids.clear();
-                min_ids.push(id);
+                selected = Some(id);
+                tie_count = 1;
                 continue;
             }
 
             if load == min_load {
-                min_ids.push(id);
+                tie_count += 1;
+                // Reservoir sampling keeps tied minima uniform without allocating in this locked hot path.
+                if rng.random_range(0..tie_count) == 0 {
+                    selected = Some(id);
+                }
             }
         }
 
-        if min_ids.is_empty() {
-            return None;
-        }
-
-        let id = min_ids[rand::rng().random_range(0..min_ids.len())];
+        let id = selected?;
         self.increment(id);
         Some(id)
     }


### PR DESCRIPTION
Randomizes tie-breaking for least-loaded routing when multiple workers have the same local in-flight load, while preserving the existing selection lock and increment ordering. Adds a regression test for deterministic first-worker tie behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved load balancing to fairly distribute requests among equally-loaded instances instead of consistently favoring the first one.

* **Tests**
  * Added test coverage verifying balanced distribution across multiple equal-load candidates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9516)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->