### PR TITLE
fix(sglang): add drain() to prevent NIXL KV transfer races on prefill SIGTERM

### DIFF
--- a/components/src/dynamo/sglang/llm_engine.py
+++ b/components/src/dynamo/sglang/llm_engine.py
@@ -277,7 +277,12 @@ class SglangLLMEngine(LLMEngine):
                     scheduler = getattr(
                         self.engine.tokenizer_manager, "scheduler", None
                     )
-                    if scheduler is not None and scheduler.is_idle():
+                    if scheduler is None:
+                        logger.debug(
+                            "SGLang scheduler not yet available; skipping drain poll"
+                        )
+                        break
+                    if scheduler.is_idle():
                         logger.info("All in-flight SGLang requests drained")
                         break
                     total = getattr(scheduler, "get_total_usage", lambda: None)() or 0

--- a/components/src/dynamo/sglang/llm_engine.py
+++ b/components/src/dynamo/sglang/llm_engine.py
@@ -35,6 +35,10 @@ from dynamo.sglang._compat import get_scheduler_info
 from dynamo.sglang._disagg import compute_bootstrap_address, warmup_prefill_engine
 from dynamo.sglang.args import parse_args
 
+# Maximum time (seconds) to wait for in-flight requests to drain during shutdown.
+_DRAIN_TIMEOUT_S = 30.0
+_DRAIN_POLL_INTERVAL_S = 0.5
+
 logger = logging.getLogger(__name__)
 
 # Bound on prefill drain during graceful shutdown. After this, force-cancel
@@ -255,7 +259,44 @@ class SglangLLMEngine(LLMEngine):
             logger.debug("Aborted request %s", rid)
 
     async def drain(self) -> None:
-        """Await background prefill consume tasks before cleanup (#7319)."""
+        """Wait for all in-flight work to complete before GPU memory is freed.
+
+        Two phases, each with a 30-second timeout:
+
+        1. Poll the SGLang scheduler until idle — ensures no active NIXL KV
+           transfers are in flight before cleanup() frees GPU memory (#9345).
+        2. Await background prefill consume tasks (#7319).
+
+        On timeout, cleanup proceeds; some NIXL transfers may not complete.
+        """
+        # Phase 1: scheduler idle check (NIXL transfer safety, #9345)
+        if self.engine is not None:
+            deadline = asyncio.get_running_loop().time() + _DRAIN_TIMEOUT_S
+            while asyncio.get_running_loop().time() < deadline:
+                try:
+                    scheduler = getattr(
+                        self.engine.tokenizer_manager, "scheduler", None
+                    )
+                    if scheduler is not None and scheduler.is_idle():
+                        logger.info("All in-flight SGLang requests drained")
+                        break
+                    total = getattr(scheduler, "get_total_usage", lambda: None)() or 0
+                    logger.debug(
+                        "Waiting for SGLang scheduler to drain (usage=%d)", total
+                    )
+                except Exception as e:
+                    logger.debug("Scheduler poll failed during drain: %s", e)
+                await asyncio.sleep(_DRAIN_POLL_INTERVAL_S)
+            else:
+                logger.warning(
+                    "SGLang scheduler drain timeout (%.1fs) reached; "
+                    "some NIXL transfers may still be in flight.",
+                    _DRAIN_TIMEOUT_S,
+                )
+        else:
+            logger.info("SGLang engine not initialised; skipping scheduler drain")
+
+        # Phase 2: background prefill consume tasks (#7319)
         pending = [t for t in self._prefill_consume_tasks if not t.done()]
         if not pending:
             return

--- a/components/src/dynamo/sglang/llm_engine.py
+++ b/components/src/dynamo/sglang/llm_engine.py
@@ -271,17 +271,14 @@ class SglangLLMEngine(LLMEngine):
         """
         # Phase 1: scheduler idle check (NIXL transfer safety, #9345)
         if self.engine is not None:
-            deadline = asyncio.get_running_loop().time() + _DRAIN_TIMEOUT_S
-            while asyncio.get_running_loop().time() < deadline:
-                try:
-                    scheduler = getattr(
-                        self.engine.tokenizer_manager, "scheduler", None
-                    )
-                    if scheduler is None:
-                        logger.debug(
-                            "SGLang scheduler not yet available; skipping drain poll"
-                        )
-                        break
+            tokenizer_manager = getattr(self.engine, "tokenizer_manager", None)
+            scheduler = getattr(tokenizer_manager, "scheduler", None)
+            if scheduler is None:
+                logger.info("SGLang scheduler unavailable; skipping scheduler drain")
+            else:
+                loop = asyncio.get_running_loop()
+                deadline = loop.time() + _DRAIN_TIMEOUT_S
+                while loop.time() < deadline:
                     if scheduler.is_idle():
                         logger.info("All in-flight SGLang requests drained")
                         break
@@ -289,15 +286,13 @@ class SglangLLMEngine(LLMEngine):
                     logger.debug(
                         "Waiting for SGLang scheduler to drain (usage=%d)", total
                     )
-                except Exception as e:
-                    logger.debug("Scheduler poll failed during drain: %s", e)
-                await asyncio.sleep(_DRAIN_POLL_INTERVAL_S)
-            else:
-                logger.warning(
-                    "SGLang scheduler drain timeout (%.1fs) reached; "
-                    "some NIXL transfers may still be in flight.",
-                    _DRAIN_TIMEOUT_S,
-                )
+                    await asyncio.sleep(_DRAIN_POLL_INTERVAL_S)
+                else:
+                    logger.warning(
+                        "SGLang scheduler drain timeout (%.1fs) reached; "
+                        "some NIXL transfers may still be in flight.",
+                        _DRAIN_TIMEOUT_S,
+                    )
         else:
             logger.info("SGLang engine not initialised; skipping scheduler drain")
 


### PR DESCRIPTION
## Summary

- `SglangLLMEngine.drain()` polls `scheduler.is_idle()` every 0.5s until idle or 30s timeout, then proceeds with shutdown. Merges the scheduler-idle check (#9345) with the prefill consume-task drain (#7319) into a single two-phase drain method.
- Prevents GPU memory tear-down on prefill-side SIGTERM while decode peers may be mid-NIXL-pull on prefill-side KV cache.
- Rust unit tests for drain/cleanup ordering pass; Python pre-commit all passed.

Closes #9345

## Testing

- Rust: `shutdown_steps_run_drain_before_cleanup` asserts drain runs before cleanup
- Python: pre-commit (ruff, black, marker-report) all pass
- Runtime disagg smoke test pending when compute credentials are available
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9523" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced LLM engine shutdown procedure with multi-phase request completion process and timeout protection for improved stability during graceful shutdown.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9523)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->