### PR TITLE
fix(planner): use started requests for throughput load

### DIFF
--- a/components/src/dynamo/planner/monitoring/traffic_metrics.py
+++ b/components/src/dynamo/planner/monitoring/traffic_metrics.py
@@ -99,6 +99,30 @@ class PrometheusAPIClient:
         self.dynamo_namespace = dynamo_namespace
         self.metrics_source = metrics_source  # "frontend" | "router"
 
+    def _frontend_metric_name(self, metric_name: str) -> str:
+        if metric_name.startswith(prometheus_names.name_prefix.FRONTEND):
+            return metric_name
+        return f"{prometheus_names.name_prefix.FRONTEND}_{metric_name}"
+
+    def _sum_frontend_metric(self, result, model_name: str) -> Optional[float]:
+        if not result:
+            return None
+
+        metrics_containers = parse_frontend_metric_containers(result)
+        total = 0.0
+        matched = False
+        for container in metrics_containers:
+            # Frontend lowercases model names in Prometheus labels.
+            if (
+                container.metric.model
+                and container.metric.model.lower() == model_name.lower()
+                and container.metric.dynamo_namespace == self.dynamo_namespace
+                and not math.isnan(container.value[1])
+            ):
+                matched = True
+                total += container.value[1]
+        return total if matched else None
+
     def _get_average_metric(
         self,
         full_metric_name: str,
@@ -246,30 +270,34 @@ class PrometheusAPIClient:
             except Exception as e:
                 logger.error(f"Error getting avg request count: {e}")
                 return 0
-        # This function follows a different query pattern than the other metrics
+        # This function follows a different query pattern than the other metrics:
+        # use frontend-started requests so throughput planning sees offered load,
+        # not only completed responses.
         try:
-            requests_total_metric = prometheus_names.frontend_service.REQUESTS_TOTAL
-            # Prepend the frontend metric prefix if not already present
-            if not requests_total_metric.startswith(
-                prometheus_names.name_prefix.FRONTEND
-            ):
-                requests_total_metric = (
-                    f"{prometheus_names.name_prefix.FRONTEND}_{requests_total_metric}"
-                )
-            raw_res = self.prom.custom_query(
+            requests_started_metric = self._frontend_metric_name(
+                prometheus_names.frontend_service.REQUESTS_STARTED_TOTAL
+            )
+            started_res = self.prom.custom_query(
+                query=f"increase({requests_started_metric}[{interval}])"
+            )
+            started_count = self._sum_frontend_metric(started_res, model_name)
+            if started_count is not None:
+                return started_count
+
+            logger.warning(
+                f"No prometheus metric data available for {requests_started_metric} "
+                f"with model {model_name} and dynamo namespace "
+                f"{self.dynamo_namespace}; falling back to completed request count"
+            )
+
+            requests_total_metric = self._frontend_metric_name(
+                prometheus_names.frontend_service.REQUESTS_TOTAL
+            )
+            completed_res = self.prom.custom_query(
                 query=f"increase({requests_total_metric}[{interval}])"
             )
-            metrics_containers = parse_frontend_metric_containers(raw_res)
-            total_count = 0.0
-            for container in metrics_containers:
-                # Frontend lowercases model names for Prometheus labels so we need to do case-insensitive comparison
-                if (
-                    container.metric.model
-                    and container.metric.model.lower() == model_name.lower()
-                    and container.metric.dynamo_namespace == self.dynamo_namespace
-                ):
-                    total_count += container.value[1]
-            return total_count
+            completed_count = self._sum_frontend_metric(completed_res, model_name)
+            return completed_count or 0
         except Exception as e:
             logger.error(f"Error getting avg request count: {e}")
             return 0

--- a/components/src/dynamo/planner/tests/unit/test_prometheus.py
+++ b/components/src/dynamo/planner/tests/unit/test_prometheus.py
@@ -260,6 +260,64 @@ def test_get_average_metric_multiple_matching_containers(mock_prometheus_result)
         assert result == expected
 
 
+def test_get_avg_request_count_uses_started_requests():
+    """Frontend request count uses started requests, not completed responses."""
+    client = PrometheusAPIClient("http://localhost:9090", "target_namespace")
+
+    started = [
+        {
+            "metric": {
+                "dynamo_namespace": "target_namespace",
+                "model": "target_model",
+            },
+            "value": [1758857776.071, 150.0],
+        },
+        {
+            "metric": {
+                "dynamo_namespace": "other_namespace",
+                "model": "target_model",
+            },
+            "value": [1758857776.071, 1000.0],
+        },
+    ]
+
+    with patch.object(client.prom, "custom_query") as mock_query:
+        mock_query.return_value = started
+
+        result = client.get_avg_request_count("30s", "TARGET_MODEL")
+
+    assert result == 150.0
+    queries = [call.kwargs["query"] for call in mock_query.call_args_list]
+    assert "dynamo_frontend_requests_started_total" in queries[0]
+    assert "increase(" in queries[0]
+    assert len(queries) == 1
+
+
+def test_get_avg_request_count_falls_back_to_completed_when_started_missing():
+    """Older frontend images without started counter still report completed count."""
+    client = PrometheusAPIClient("http://localhost:9090", "target_namespace")
+
+    completed = [
+        {
+            "metric": {
+                "dynamo_namespace": "target_namespace",
+                "model": "target_model",
+            },
+            "value": [1758857776.071, 73.0],
+        }
+    ]
+
+    with patch.object(client.prom, "custom_query") as mock_query:
+        mock_query.side_effect = [[], completed]
+
+        result = client.get_avg_request_count("30s", "target_model")
+
+    assert result == 73.0
+    queries = [call.kwargs["query"] for call in mock_query.call_args_list]
+    assert "dynamo_frontend_requests_started_total" in queries[0]
+    assert "dynamo_frontend_requests_total" in queries[1]
+
+
 # ---------------------------------------------------------------------------
 # Router metrics source tests
 # ---------------------------------------------------------------------------

--- a/lib/bindings/python/src/dynamo/prometheus_names.py
+++ b/lib/bindings/python/src/dynamo/prometheus_names.py
@@ -76,6 +76,8 @@ class frontend_service:
     METRICS_PREFIX_ENV = "DYN_METRICS_PREFIX"
     # Total number of LLM requests processed
     REQUESTS_TOTAL = "requests_total"
+    # Total number of LLM requests accepted by the frontend handler
+    REQUESTS_STARTED_TOTAL = "requests_started_total"
     # Number of requests waiting in HTTP queue before receiving the first response (gauge)
     QUEUED_REQUESTS = "queued_requests"
     # Number of inflight/concurrent requests going to the engine (vLLM, SGLang, ...)

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -250,6 +250,7 @@ struct MetricsHandlerState {
 }
 
 pub struct Metrics {
+    request_started_counter: IntCounterVec,
     request_counter: IntCounterVec,
     /// Deprecated: use `active_requests_gauge`. Kept for backwards compatibility until Phase 3.
     inflight_gauge: IntGaugeVec,
@@ -497,6 +498,15 @@ impl Metrics {
         )
         .unwrap();
 
+        let request_started_counter = IntCounterVec::new(
+            Opts::new(
+                frontend_metric_name(frontend_service::REQUESTS_STARTED_TOTAL),
+                "Total number of LLM requests accepted by the frontend handler",
+            ),
+            &["model", "endpoint", "request_type"],
+        )
+        .unwrap();
+
         let inflight_gauge = IntGaugeVec::new(
             Opts::new(
                 frontend_metric_name(frontend_service::INFLIGHT_REQUESTS),
@@ -731,6 +741,7 @@ impl Metrics {
         .unwrap();
 
         Metrics {
+            request_started_counter,
             request_counter,
             inflight_gauge,
             active_requests_gauge,
@@ -805,6 +816,18 @@ impl Metrics {
             .inc()
     }
 
+    /// Increment the counter for requests accepted by the frontend handler.
+    fn inc_request_started_counter(
+        &self,
+        model: &str,
+        endpoint: &Endpoint,
+        request_type: &RequestType,
+    ) {
+        self.request_started_counter
+            .with_label_values(&[model, endpoint.as_str(), request_type.as_str()])
+            .inc()
+    }
+
     /// Get the number if inflight requests for the given model
     pub fn get_inflight_count(&self, model: &str) -> i64 {
         self.inflight_gauge.with_label_values(&[model]).get()
@@ -839,6 +862,7 @@ impl Metrics {
     }
 
     pub fn register(&self, registry: &Registry) -> Result<(), prometheus::Error> {
+        registry.register(Box::new(self.request_started_counter.clone()))?;
         registry.register(Box::new(self.request_counter.clone()))?;
         registry.register(Box::new(self.inflight_gauge.clone()))?;
         registry.register(Box::new(self.active_requests_gauge.clone()))?;
@@ -1065,6 +1089,7 @@ impl InflightGuard {
     ) -> Self {
         let timer = Instant::now();
         metrics.inc_inflight_gauge(&model);
+        metrics.inc_request_started_counter(&model, &endpoint, &request_type);
 
         tracing::Span::current().record("model", model.as_str());
 
@@ -2320,6 +2345,16 @@ mod tests {
             ])
             .get();
         assert_eq!(counter_value, 1);
+
+        let started_counter_value = metrics
+            .request_started_counter
+            .with_label_values(&[
+                model,
+                Endpoint::ChatCompletions.as_str(),
+                RequestType::Unary.as_str(),
+            ])
+            .get();
+        assert_eq!(started_counter_value, 1);
     }
 
     #[test]

--- a/lib/llm/tests/http_metrics.rs
+++ b/lib/llm/tests/http_metrics.rs
@@ -113,6 +113,7 @@ async fn test_metrics_prefix_default() {
             .unwrap();
 
         // Assert metrics that are actually present in the default configuration
+        assert!(body.contains("dynamo_frontend_requests_started_total"));
         assert!(body.contains("dynamo_frontend_requests_total"));
         assert!(body.contains("dynamo_frontend_inflight_requests"));
         assert!(body.contains("dynamo_frontend_request_duration_seconds"));
@@ -151,6 +152,7 @@ async fn test_metrics_prefix_custom() {
             .text()
             .await
             .unwrap();
+        assert!(body.contains("custom_prefix_requests_started_total"));
         assert!(body.contains("custom_prefix_requests_total"));
         assert!(!body.contains("dynamo_frontend_requests_total"));
 
@@ -500,6 +502,7 @@ mod integration_tests {
 
         // Assert basic metrics are present (using service_name from the model)
         let model_name = model.service_name();
+        assert!(metrics_body.contains("dynamo_frontend_requests_started_total"));
         assert!(metrics_body.contains("dynamo_frontend_requests_total"));
         assert!(metrics_body.contains(&format!("model=\"{}\"", model_name)));
         assert!(metrics_body.contains("dynamo_frontend_inflight_requests"));

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -170,6 +170,9 @@ pub mod frontend_service {
     /// Total number of LLM requests processed
     pub const REQUESTS_TOTAL: &str = "requests_total";
 
+    /// Total number of LLM requests accepted by the frontend handler
+    pub const REQUESTS_STARTED_TOTAL: &str = "requests_started_total";
+
     /// Number of requests waiting in HTTP queue before receiving the first response (gauge)
     pub const QUEUED_REQUESTS: &str = "queued_requests";
 


### PR DESCRIPTION
## Summary
- Add frontend started-request Prometheus counters.
- Prefer started request count for planner throughput load so long-running requests do not under-report incoming RPS.
- Keep finished-token metrics for ISL/OSL estimates.

## Testing
- Validated as part of the combined branch in the hzhou cluster debugging session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new metric to track LLM requests accepted by the frontend handler, exposing request acceptance patterns in the monitoring endpoint
  * Enhanced throughput planning by preferring started requests metric for more accurate offered load calculations; falls back to completed requests when necessary

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9526)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->