### PR TITLE
fix(planner): wait for benchmark endpoint discovery

### DIFF
--- a/components/src/dynamo/planner/monitoring/perf_metrics.py
+++ b/components/src/dynamo/planner/monitoring/perf_metrics.py
@@ -127,9 +127,7 @@ async def _try_endpoint(
 
     try:
         endpoint_name = f"{namespace}.{worker_info.component_name}.get_perf_metrics"
-        endpoint = runtime.endpoint(  # type: ignore[attr-defined]
-            endpoint_name
-        )
+        endpoint = runtime.endpoint(endpoint_name)  # type: ignore[attr-defined]
         client = await endpoint.client()
         if not await _wait_for_endpoint_instances(client, endpoint_name):
             return []
@@ -181,7 +179,7 @@ async def _wait_for_endpoint_instances(
         instance_ids = await asyncio.wait_for(
             client.wait_for_instances(), timeout=timeout_s  # type: ignore[attr-defined]
         )
-    except TimeoutError:
+    except asyncio.TimeoutError:
         logger.info(
             "Timed out after %.1fs waiting for get_perf_metrics endpoint instances: %s",
             timeout_s,

--- a/components/src/dynamo/planner/monitoring/perf_metrics.py
+++ b/components/src/dynamo/planner/monitoring/perf_metrics.py
@@ -29,6 +29,8 @@ from dynamo.planner.monitoring.worker_info import WorkerInfo
 
 logger = logging.getLogger(__name__)
 
+_ENDPOINT_DISCOVERY_TIMEOUT_S = 10.0
+
 
 async def fetch_pre_deployment_metrics(
     runtime: "object",  # DistributedRuntime; typed loosely to avoid hard import
@@ -124,11 +126,13 @@ async def _try_endpoint(
         return []
 
     try:
+        endpoint_name = f"{namespace}.{worker_info.component_name}.get_perf_metrics"
         endpoint = runtime.endpoint(  # type: ignore[attr-defined]
-            f"{namespace}.{worker_info.component_name}.get_perf_metrics"
+            endpoint_name
         )
         client = await endpoint.client()
-        await asyncio.sleep(0.1)
+        if not await _wait_for_endpoint_instances(client, endpoint_name):
+            return []
 
         response_stream = await client.round_robin(None)
         benchmark_data = None
@@ -161,6 +165,31 @@ async def _try_endpoint(
     except Exception as e:
         logger.warning(f"get_perf_metrics unexpected error: {e}")
         return []
+
+
+async def _wait_for_endpoint_instances(
+    client: object,
+    endpoint_name: str,
+    timeout_s: float = _ENDPOINT_DISCOVERY_TIMEOUT_S,
+) -> bool:
+    """Wait for Kubernetes discovery to surface at least one endpoint instance."""
+    instance_ids = client.instance_ids()  # type: ignore[attr-defined]
+    if instance_ids:
+        return True
+
+    try:
+        instance_ids = await asyncio.wait_for(
+            client.wait_for_instances(), timeout=timeout_s  # type: ignore[attr-defined]
+        )
+    except TimeoutError:
+        logger.info(
+            "Timed out after %.1fs waiting for get_perf_metrics endpoint instances: %s",
+            timeout_s,
+            endpoint_name,
+        )
+        return False
+
+    return bool(instance_ids or client.instance_ids())  # type: ignore[attr-defined]
 
 
 def _extract_fpms_from_benchmark(

--- a/components/src/dynamo/planner/tests/unit/test_perf_metrics_priority.py
+++ b/components/src/dynamo/planner/tests/unit/test_perf_metrics_priority.py
@@ -9,7 +9,8 @@ Order (highest → lowest):
     3. File fallback (NPZ / JSON under ``profile_results_dir``)
 """
 
-from unittest.mock import MagicMock, patch
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -44,6 +45,21 @@ def _make_spec() -> AICInterpolationSpec:
 def _fpm():
     """Opaque sentinel FPM — identity comparison is enough for these tests."""
     return object()
+
+
+class _OneItemStream:
+    def __init__(self, item):
+        self._item = item
+        self._sent = False
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._sent:
+            raise StopAsyncIteration
+        self._sent = True
+        return self._item
 
 
 class TestPriorityChain:
@@ -175,3 +191,50 @@ class TestPriorityChain:
                     aic_spec=None,
                 )
         mock_aic.assert_not_called()
+
+
+class TestEndpointDiscoveryWait:
+    @pytest.mark.asyncio
+    async def test_waits_for_endpoint_instance_before_round_robin(self):
+        endpoint_fpms = [_fpm()]
+        response = MagicMock()
+        response.data.return_value = {"results": []}
+
+        client = MagicMock()
+        client.instance_ids.return_value = []
+        client.wait_for_instances = AsyncMock(return_value=[123])
+        client.round_robin = AsyncMock(return_value=_OneItemStream(response))
+
+        endpoint = MagicMock()
+        endpoint.client = AsyncMock(return_value=client)
+        runtime = MagicMock()
+        runtime.endpoint.return_value = endpoint
+
+        with patch.object(
+            pm, "_extract_fpms_from_benchmark", return_value=endpoint_fpms
+        ):
+            got = await pm._try_endpoint(
+                runtime=runtime,
+                namespace="dynamo",
+                worker_info=MagicMock(component_name="backend"),
+                component_type=SubComponentType.DECODE,
+            )
+
+        assert got is endpoint_fpms
+        client.wait_for_instances.assert_awaited_once()
+        client.round_robin.assert_awaited_once_with(None)
+
+    @pytest.mark.asyncio
+    async def test_endpoint_wait_timeout_returns_empty(self):
+        class NeverReadyClient:
+            def instance_ids(self):
+                return []
+
+            async def wait_for_instances(self):
+                await asyncio.sleep(1)
+
+        got = await pm._wait_for_endpoint_instances(
+            NeverReadyClient(), "dynamo.backend.get_perf_metrics", timeout_s=0.001
+        )
+
+        assert got is False

--- a/components/src/dynamo/planner/tests/unit/test_perf_metrics_priority.py
+++ b/components/src/dynamo/planner/tests/unit/test_perf_metrics_priority.py
@@ -67,13 +67,11 @@ class TestPriorityChain:
     async def test_endpoint_wins(self):
         """When the endpoint returns FPMs, AIC and files are never consulted."""
         endpoint_fpms = [_fpm(), _fpm()]
-        with patch.object(
-            pm, "_try_endpoint", return_value=endpoint_fpms
-        ) as mock_ep, patch.object(
-            pm, "_try_aic_interpolation"
-        ) as mock_aic, patch.object(
-            pm, "_convert_profiling_data_to_fpms"
-        ) as mock_files:
+        with (
+            patch.object(pm, "_try_endpoint", return_value=endpoint_fpms) as mock_ep,
+            patch.object(pm, "_try_aic_interpolation") as mock_aic,
+            patch.object(pm, "_convert_profiling_data_to_fpms") as mock_files,
+        ):
             got = await pm.fetch_pre_deployment_metrics(
                 runtime=MagicMock(),
                 namespace="dynamo",
@@ -91,11 +89,13 @@ class TestPriorityChain:
     async def test_aic_fallback_when_endpoint_empty(self):
         """Endpoint returns [] → AIC runs. Files never consulted."""
         aic_fpms = [_fpm()]
-        with patch.object(pm, "_try_endpoint", return_value=[]), patch.object(
-            pm, "_try_aic_interpolation", return_value=aic_fpms
-        ) as mock_aic, patch.object(
-            pm, "_convert_profiling_data_to_fpms"
-        ) as mock_files:
+        with (
+            patch.object(pm, "_try_endpoint", return_value=[]),
+            patch.object(
+                pm, "_try_aic_interpolation", return_value=aic_fpms
+            ) as mock_aic,
+            patch.object(pm, "_convert_profiling_data_to_fpms") as mock_files,
+        ):
             got = await pm.fetch_pre_deployment_metrics(
                 runtime=MagicMock(),
                 namespace="dynamo",
@@ -112,11 +112,13 @@ class TestPriorityChain:
     async def test_file_fallback_when_no_spec(self):
         """Endpoint returns [] and aic_spec is None → files load."""
         file_fpms = [_fpm()]
-        with patch.object(pm, "_try_endpoint", return_value=[]), patch.object(
-            pm, "_try_aic_interpolation"
-        ) as mock_aic, patch.object(
-            pm, "_convert_profiling_data_to_fpms", return_value=file_fpms
-        ) as mock_files:
+        with (
+            patch.object(pm, "_try_endpoint", return_value=[]),
+            patch.object(pm, "_try_aic_interpolation") as mock_aic,
+            patch.object(
+                pm, "_convert_profiling_data_to_fpms", return_value=file_fpms
+            ) as mock_files,
+        ):
             got = await pm.fetch_pre_deployment_metrics(
                 runtime=MagicMock(),
                 namespace="dynamo",
@@ -133,11 +135,15 @@ class TestPriorityChain:
     async def test_file_fallback_when_aic_fails(self):
         """Endpoint empty, AIC raises at runtime → files are consulted."""
         file_fpms = [_fpm()]
-        with patch.object(pm, "_try_endpoint", return_value=[]), patch.object(
-            pm, "_try_aic_interpolation", side_effect=RuntimeError("aic boom")
-        ), patch.object(
-            pm, "_convert_profiling_data_to_fpms", return_value=file_fpms
-        ) as mock_files:
+        with (
+            patch.object(pm, "_try_endpoint", return_value=[]),
+            patch.object(
+                pm, "_try_aic_interpolation", side_effect=RuntimeError("aic boom")
+            ),
+            patch.object(
+                pm, "_convert_profiling_data_to_fpms", return_value=file_fpms
+            ) as mock_files,
+        ):
             got = await pm.fetch_pre_deployment_metrics(
                 runtime=MagicMock(),
                 namespace="dynamo",
@@ -153,13 +159,17 @@ class TestPriorityChain:
     async def test_aic_missing_package_falls_through_to_files(self):
         """aiconfigurator not installed → ImportError is caught, files run."""
         file_fpms = [_fpm()]
-        with patch.object(pm, "_try_endpoint", return_value=[]), patch.object(
-            pm,
-            "_try_aic_interpolation",
-            side_effect=ImportError("no module named aiconfigurator"),
-        ), patch.object(
-            pm, "_convert_profiling_data_to_fpms", return_value=file_fpms
-        ) as mock_files:
+        with (
+            patch.object(pm, "_try_endpoint", return_value=[]),
+            patch.object(
+                pm,
+                "_try_aic_interpolation",
+                side_effect=ImportError("no module named aiconfigurator"),
+            ),
+            patch.object(
+                pm, "_convert_profiling_data_to_fpms", return_value=file_fpms
+            ) as mock_files,
+        ):
             got = await pm.fetch_pre_deployment_metrics(
                 runtime=MagicMock(),
                 namespace="dynamo",
@@ -174,12 +184,14 @@ class TestPriorityChain:
     @pytest.mark.asyncio
     async def test_all_fail_raises(self):
         """No endpoint, no spec, no files → RuntimeError."""
-        with patch.object(pm, "_try_endpoint", return_value=[]), patch.object(
-            pm, "_try_aic_interpolation"
-        ) as mock_aic, patch.object(
-            pm,
-            "_convert_profiling_data_to_fpms",
-            side_effect=FileNotFoundError("no npz"),
+        with (
+            patch.object(pm, "_try_endpoint", return_value=[]),
+            patch.object(pm, "_try_aic_interpolation") as mock_aic,
+            patch.object(
+                pm,
+                "_convert_profiling_data_to_fpms",
+                side_effect=FileNotFoundError("no npz"),
+            ),
         ):
             with pytest.raises(RuntimeError, match="Failed to obtain"):
                 await pm.fetch_pre_deployment_metrics(
@@ -225,6 +237,7 @@ class TestEndpointDiscoveryWait:
         client.round_robin.assert_awaited_once_with(None)
 
     @pytest.mark.asyncio
+    @pytest.mark.timeout(5)
     async def test_endpoint_wait_timeout_returns_empty(self):
         class NeverReadyClient:
             def instance_ids(self):


### PR DESCRIPTION
## Overview
Planner self-benchmark bootstrap could miss `get_perf_metrics` on cold start because the Kubernetes discovery informer had not surfaced the worker endpoint yet.

## Details
- Replaces the fixed short sleep with bounded endpoint-instance polling.
- Catches endpoint discovery timeout as `asyncio.TimeoutError` and returns an empty endpoint result so fallback paths still work.
- Adds a timeout marker to the timeout-path unit test.
- Applies Black formatting required by pre-commit.

## Where should the reviewer start
Start with `components/src/dynamo/planner/monitoring/perf_metrics.py`, then the new endpoint discovery tests in `components/src/dynamo/planner/tests/unit/test_perf_metrics_priority.py`.

## Related Issues
- None.

## Testing
- `uvx isort ...`
- `uvx black ...`
- `uvx ruff check ...`
- `python3 -m py_compile ...`