### PR TITLE
fix(planner): correct decode benchmark FPM accounting

### DIFF
--- a/components/src/dynamo/vllm/instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/instrumented_scheduler.py
@@ -489,7 +489,8 @@ class InstrumentedScheduler(AsyncScheduler):
         """Synthetic decode benchmark requests register as new requests."""
         return (
             getattr(self, "_bench_active", False)
-            and getattr(self, "_bench_phase", _BenchPhase.IDLE) == _BenchPhase.DECODE_SWEEP
+            and getattr(self, "_bench_phase", _BenchPhase.IDLE)
+            == _BenchPhase.DECODE_SWEEP
             and req_id in getattr(self, "_bench_active_req_ids", set())
         )
 

--- a/components/src/dynamo/vllm/instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/instrumented_scheduler.py
@@ -456,6 +456,9 @@ class InstrumentedScheduler(AsyncScheduler):
         decode_kv = WelfordAccumulator()
 
         for req in new_reqs:
+            if self._bench_new_request_counts_as_decode(req.req_id):
+                decode_kv.add(req.num_computed_tokens)
+                continue
             num_prefill += 1
             sum_prefill_tokens += num_scheduled.get(req.req_id, 0)
             prompt_len = len(req.prompt_token_ids) if req.prompt_token_ids else 0
@@ -480,6 +483,14 @@ class InstrumentedScheduler(AsyncScheduler):
             num_decode_requests=decode_kv.n,
             sum_decode_kv_tokens=decode_kv.s,
             var_decode_kv_tokens=decode_kv.variance(),
+        )
+
+    def _bench_new_request_counts_as_decode(self, req_id: str) -> bool:
+        """Synthetic decode benchmark requests register as new requests."""
+        return (
+            getattr(self, "_bench_active", False)
+            and getattr(self, "_bench_phase", _BenchPhase.IDLE) == _BenchPhase.DECODE_SWEEP
+            and req_id in getattr(self, "_bench_active_req_ids", set())
         )
 
     def _compute_queued(self) -> QueuedRequestMetrics:

--- a/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
@@ -67,6 +67,81 @@ def _run_compute_queued(waiting, skipped_waiting):
     return InstrumentedScheduler._compute_queued(stub)
 
 
+class _CachedRequestStub:
+    def __init__(self, req_ids=None, num_computed_tokens=None, context_phase_ids=None):
+        self.req_ids = req_ids or []
+        self.num_computed_tokens = num_computed_tokens or []
+        self._context_phase_ids = set(context_phase_ids or [])
+
+    def is_context_phase(self, req_id):
+        return req_id in self._context_phase_ids
+
+
+def _make_new_request(req_id: str, prompt_len: int, num_computed_tokens: int):
+    return SimpleNamespace(
+        req_id=req_id,
+        prompt_token_ids=[0] * prompt_len,
+        num_computed_tokens=num_computed_tokens,
+    )
+
+
+def _run_extract_scheduled(
+    new_reqs,
+    num_scheduled_tokens,
+    *,
+    cached=None,
+    bench_decode_ids=None,
+):
+    stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
+    stub._prompt_len_per_req = {}
+    stub._bench_active = bench_decode_ids is not None
+    stub._bench_phase = (
+        _BenchPhase.DECODE_SWEEP if bench_decode_ids is not None else _BenchPhase.IDLE
+    )
+    stub._bench_active_req_ids = set(bench_decode_ids or [])
+    output = SimpleNamespace(
+        scheduled_new_reqs=new_reqs,
+        scheduled_cached_reqs=cached or _CachedRequestStub(),
+        num_scheduled_tokens=num_scheduled_tokens,
+    )
+    return InstrumentedScheduler._extract_scheduled(stub, output)
+
+
+# ---------------------------------------------------------------------------
+# scheduled_requests classification
+# ---------------------------------------------------------------------------
+
+
+def test_extract_scheduled_counts_normal_new_requests_as_prefill():
+    metrics = _run_extract_scheduled(
+        [_make_new_request("req-1", prompt_len=128, num_computed_tokens=0)],
+        {"req-1": 128},
+    )
+
+    assert metrics.num_prefill_requests == 1
+    assert metrics.sum_prefill_tokens == 128
+    assert metrics.sum_prefill_kv_tokens == 0
+    assert metrics.num_decode_requests == 0
+    assert metrics.sum_decode_kv_tokens == 0
+
+
+def test_extract_scheduled_counts_benchmark_decode_new_requests_as_decode():
+    metrics = _run_extract_scheduled(
+        [
+            _make_new_request("__bench_0", prompt_len=17, num_computed_tokens=16),
+            _make_new_request("__bench_1", prompt_len=17, num_computed_tokens=16),
+        ],
+        {"__bench_0": 1, "__bench_1": 1},
+        bench_decode_ids={"__bench_0", "__bench_1"},
+    )
+
+    assert metrics.num_prefill_requests == 0
+    assert metrics.sum_prefill_tokens == 0
+    assert metrics.sum_prefill_kv_tokens == 0
+    assert metrics.num_decode_requests == 2
+    assert metrics.sum_decode_kv_tokens == 32
+
+
 # ---------------------------------------------------------------------------
 # self.waiting classification (existing behaviour — regression coverage)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Overview
Decode self-benchmark rows were being recorded like prefill rows, which made planner decode capacity interpolation too optimistic or otherwise distorted.

## Details
- Classifies active decode-sweep synthetic requests as decode work in FPM accounting.
- Keeps normal new-request accounting as prefill outside decode benchmark mode.
- Applies Black formatting required by pre-commit.

## Where should the reviewer start
Start with `components/src/dynamo/vllm/instrumented_scheduler.py`, then the focused scheduler tests in `components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py`.

## Related Issues
- None.

## Testing
- `uvx isort ...`
- `uvx black ...`
- `uvx ruff check ...`
- `python3 -m py_compile ...`