### PR TITLE
fix(planner): resolve worker runtime namespace

### DIFF
--- a/components/src/dynamo/planner/connectors/global_planner.py
+++ b/components/src/dynamo/planner/connectors/global_planner.py
@@ -306,6 +306,13 @@ class GlobalPlannerConnector(PlannerConnector):
             decode_component_name=decode_component_name,
         )
 
+    def get_worker_runtime_namespace(self, base_dynamo_namespace: str) -> str:
+        """Resolve the pool-local worker runtime namespace when available."""
+        local = self._get_local_k8s_connector()
+        if local is None:
+            return base_dynamo_namespace
+        return local.get_worker_runtime_namespace(base_dynamo_namespace)
+
     def get_worker_info(
         self,
         sub_component_type: SubComponentType,

--- a/components/src/dynamo/planner/connectors/kubernetes.py
+++ b/components/src/dynamo/planner/connectors/kubernetes.py
@@ -48,6 +48,7 @@ configure_dynamo_logging()
 logger = logging.getLogger(__name__)
 
 CURRENT_WORKER_HASH_ANNOTATION = "nvidia.com/current-worker-hash"
+CURRENT_WORKER_HASH_V2_ANNOTATION = "nvidia.com/current-worker-hash-v2"
 LEGACY_WORKER_HASH = "legacy"
 
 
@@ -92,6 +93,8 @@ class KubernetesConnector(PlannerConnector):
         deployment = self.kube_api.get_graph_deployment(self.graph_deployment_name)
         annotations = deployment.get("metadata", {}).get("annotations", {}) or {}
         worker_hash = annotations.get(CURRENT_WORKER_HASH_ANNOTATION)
+        if not worker_hash or worker_hash == LEGACY_WORKER_HASH:
+            worker_hash = annotations.get(CURRENT_WORKER_HASH_V2_ANNOTATION)
         if not worker_hash or worker_hash == LEGACY_WORKER_HASH:
             return base_dynamo_namespace
         return f"{base_dynamo_namespace}-{worker_hash}"

--- a/components/src/dynamo/planner/connectors/kubernetes.py
+++ b/components/src/dynamo/planner/connectors/kubernetes.py
@@ -47,6 +47,9 @@ from dynamo.runtime.logging import configure_dynamo_logging
 configure_dynamo_logging()
 logger = logging.getLogger(__name__)
 
+CURRENT_WORKER_HASH_ANNOTATION = "nvidia.com/current-worker-hash"
+LEGACY_WORKER_HASH = "legacy"
+
 
 class KubernetesConnector(PlannerConnector):
     def __init__(
@@ -77,6 +80,21 @@ class KubernetesConnector(PlannerConnector):
 
         # For backwards compatibility
         self.graph_deployment_name = self.parent_dgd_name
+
+    def get_worker_runtime_namespace(self, base_dynamo_namespace: str) -> str:
+        """Return the Dynamo namespace used by the current worker generation.
+
+        Managed DGD rolling updates run worker components in
+        ``<base_namespace>-<worker_hash>`` while non-worker components, including
+        the frontend metrics labels, stay on ``base_namespace``.  The active hash
+        is stored on the parent DGD so planners can discover it dynamically.
+        """
+        deployment = self.kube_api.get_graph_deployment(self.graph_deployment_name)
+        annotations = deployment.get("metadata", {}).get("annotations", {}) or {}
+        worker_hash = annotations.get(CURRENT_WORKER_HASH_ANNOTATION)
+        if not worker_hash or worker_hash == LEGACY_WORKER_HASH:
+            return base_dynamo_namespace
+        return f"{base_dynamo_namespace}-{worker_hash}"
 
     async def add_component(
         self, sub_component_type: SubComponentType, blocking: bool = True

--- a/components/src/dynamo/planner/core/adapters.py
+++ b/components/src/dynamo/planner/core/adapters.py
@@ -28,7 +28,7 @@ class PrefillPlanner(NativePlannerBase):
         try:
             fpms = await fetch_pre_deployment_metrics(
                 runtime=self.runtime,
-                namespace=self.namespace,
+                namespace=self.runtime_namespace,
                 worker_info=self.prefill_worker_info,
                 profile_results_dir=self.config.profile_results_dir,
                 component_type=SubComponentType.PREFILL,
@@ -67,7 +67,7 @@ class DecodePlanner(NativePlannerBase):
         try:
             fpms = await fetch_pre_deployment_metrics(
                 runtime=self.runtime,
-                namespace=self.namespace,
+                namespace=self.runtime_namespace,
                 worker_info=self.decode_worker_info,
                 profile_results_dir=self.config.profile_results_dir,
                 component_type=SubComponentType.DECODE,
@@ -106,7 +106,7 @@ class AggPlanner(NativePlannerBase):
         try:
             fpms = await fetch_pre_deployment_metrics(
                 runtime=self.runtime,
-                namespace=self.namespace,
+                namespace=self.runtime_namespace,
                 worker_info=self.decode_worker_info,
                 profile_results_dir=self.config.profile_results_dir,
                 component_type=SubComponentType.DECODE,
@@ -154,7 +154,7 @@ class DisaggPlanner(NativePlannerBase):
             try:
                 fpms = await fetch_pre_deployment_metrics(
                     runtime=self.runtime,
-                    namespace=self.namespace,
+                    namespace=self.runtime_namespace,
                     worker_info=worker_info,
                     profile_results_dir=self.config.profile_results_dir,
                     component_type=component,

--- a/components/src/dynamo/planner/core/base.py
+++ b/components/src/dynamo/planner/core/base.py
@@ -21,6 +21,8 @@ import time
 from typing import TYPE_CHECKING, Optional, Union
 
 import aiohttp.web
+from kubernetes.client import ApiException
+from kubernetes.config.config_exception import ConfigException
 from prometheus_client import start_http_server
 
 from dynamo.planner.config.backend_components import WORKER_COMPONENT_NAMES
@@ -42,6 +44,7 @@ from dynamo.planner.core.types import (
     WorkerCapabilities,
     WorkerCounts,
 )
+from dynamo.planner.errors import PlannerError
 from dynamo.planner.monitoring.diagnostics_recorder import DiagnosticsRecorder
 from dynamo.planner.monitoring.live_dashboard import start_live_dashboard
 from dynamo.planner.monitoring.planner_metrics import PlannerPrometheusMetrics
@@ -74,9 +77,9 @@ def _engine_caps(
         return None
     return EngineCapabilities(
         num_gpu=num_gpu,
-        max_num_batched_tokens=worker_info.max_num_batched_tokens
-        if worker_info
-        else None,
+        max_num_batched_tokens=(
+            worker_info.max_num_batched_tokens if worker_info else None
+        ),
         max_num_seqs=worker_info.max_num_seqs if worker_info else None,
         context_length=worker_info.context_length if worker_info else None,
         max_kv_tokens=worker_info.max_kv_tokens if worker_info else None,
@@ -317,20 +320,21 @@ class NativePlannerBase:
 
     def _resolve_runtime_namespace(self) -> str:
         if hasattr(self.connector, "get_worker_runtime_namespace"):
-            try:
-                return self.connector.get_worker_runtime_namespace(  # type: ignore[attr-defined]
-                    self.namespace
-                )
-            except Exception as e:
-                logger.warning(
-                    f"Failed to resolve worker runtime namespace from connector: {e}; "
-                    f"using base namespace {self.namespace}"
-                )
+            return self.connector.get_worker_runtime_namespace(  # type: ignore[attr-defined]
+                self.namespace
+            )
         return self.namespace
 
     async def _refresh_runtime_namespace(self) -> None:
         """Refresh worker runtime namespace and rebind runtime handles if needed."""
-        runtime_namespace = self._resolve_runtime_namespace()
+        try:
+            runtime_namespace = self._resolve_runtime_namespace()
+        except (ApiException, ConfigException, PlannerError) as e:
+            logger.warning(
+                f"Failed to resolve worker runtime namespace from connector: {e}; "
+                f"keeping current runtime namespace {self.runtime_namespace}"
+            )
+            return
         if runtime_namespace == self.runtime_namespace:
             return
 
@@ -338,6 +342,10 @@ class NativePlannerBase:
         self.runtime_namespace = runtime_namespace
         self._prefill_client = None
         self._decode_client = None
+        if self._prefill_fpm_sub is not None:
+            self._prefill_fpm_sub.shutdown()
+        if self._decode_fpm_sub is not None:
+            self._decode_fpm_sub.shutdown()
         self._prefill_fpm_sub = None
         self._decode_fpm_sub = None
         logger.info(

--- a/components/src/dynamo/planner/core/base.py
+++ b/components/src/dynamo/planner/core/base.py
@@ -115,6 +115,7 @@ class NativePlannerBase:
         self.config = config
         self.runtime = runtime
         self.namespace = config.namespace
+        self.runtime_namespace = config.namespace
         self.model_name: Optional[str] = None
 
         # Connector
@@ -259,6 +260,7 @@ class NativePlannerBase:
             require_decode=self.require_decode,
         )
         await self.connector.wait_for_deployment_ready(include_planner=False)
+        await self._refresh_runtime_namespace()
 
         # Resolve WorkerInfo once from the connector.  For K8s this populates
         # runtime_config fields from MDC CRDs; for Virtual it returns backend
@@ -313,6 +315,42 @@ class NativePlannerBase:
             self.decode_worker_info.model_name or self.prefill_worker_info.model_name
         )
 
+    def _resolve_runtime_namespace(self) -> str:
+        if hasattr(self.connector, "get_worker_runtime_namespace"):
+            try:
+                return self.connector.get_worker_runtime_namespace(  # type: ignore[attr-defined]
+                    self.namespace
+                )
+            except Exception as e:
+                logger.warning(
+                    f"Failed to resolve worker runtime namespace from connector: {e}; "
+                    f"using base namespace {self.namespace}"
+                )
+        return self.namespace
+
+    async def _refresh_runtime_namespace(self) -> None:
+        """Refresh worker runtime namespace and rebind runtime handles if needed."""
+        runtime_namespace = self._resolve_runtime_namespace()
+        if runtime_namespace == self.runtime_namespace:
+            return
+
+        old_namespace = self.runtime_namespace
+        self.runtime_namespace = runtime_namespace
+        self._prefill_client = None
+        self._decode_client = None
+        self._prefill_fpm_sub = None
+        self._decode_fpm_sub = None
+        logger.info(
+            f"Worker runtime namespace changed: {old_namespace} -> {runtime_namespace}"
+        )
+
+        if self.runtime is None or self.model_name is None:
+            return
+        if self.require_prefill:
+            await self._init_fpm_subscriber("prefill")
+        if self.require_decode:
+            await self._init_fpm_subscriber("decode")
+
     async def _init_fpm_subscriber(self, component: str) -> None:
         from dynamo.llm import FpmEventSubscriber
 
@@ -329,12 +367,13 @@ class NativePlannerBase:
 
         assert self.runtime is not None
         endpoint = self.runtime.endpoint(
-            f"{self.namespace}.{worker_info.component_name}.{worker_info.endpoint}"
+            f"{self.runtime_namespace}.{worker_info.component_name}.{worker_info.endpoint}"
         )
         sub = FpmEventSubscriber(endpoint)
         sub.start_tracking()
         logger.info(
-            f"FPM tracker started for {worker_info.component_name}.{worker_info.endpoint}"
+            f"FPM tracker started for "
+            f"{self.runtime_namespace}.{worker_info.component_name}.{worker_info.endpoint}"
         )
 
         if component == "prefill":
@@ -434,7 +473,7 @@ class NativePlannerBase:
     async def _get_or_create_client(self, component_name: str, endpoint_name: str):
         assert self.runtime is not None
         client = await self.runtime.endpoint(
-            f"{self.namespace}.{component_name}.{endpoint_name}"
+            f"{self.runtime_namespace}.{component_name}.{endpoint_name}"
         ).client()
         await asyncio.sleep(0.1)
         return client
@@ -832,6 +871,7 @@ class NativePlannerBase:
                     await asyncio.sleep(min(next_tick.at_s - now, poll_interval))
                     continue
 
+                await self._refresh_runtime_namespace()
                 self._refresh_worker_info_from_connector()
 
                 tick_input = await self._gather_tick_input(next_tick)

--- a/components/src/dynamo/planner/tests/unit/test_kubernetes_connector.py
+++ b/components/src/dynamo/planner/tests/unit/test_kubernetes_connector.py
@@ -124,6 +124,37 @@ def test_get_worker_runtime_namespace_legacy_hash(kubernetes_connector, mock_kub
     assert namespace == "base-ns"
 
 
+def test_get_worker_runtime_namespace_with_v2_hash(kubernetes_connector, mock_kube_api):
+    mock_kube_api.get_graph_deployment.return_value = {
+        "metadata": {
+            "annotations": {
+                "nvidia.com/current-worker-hash-v2": "v2abc",
+            }
+        }
+    }
+
+    namespace = kubernetes_connector.get_worker_runtime_namespace("base-ns")
+
+    assert namespace == "base-ns-v2abc"
+
+
+def test_get_worker_runtime_namespace_with_legacy_v1_and_v2_hash(
+    kubernetes_connector, mock_kube_api
+):
+    mock_kube_api.get_graph_deployment.return_value = {
+        "metadata": {
+            "annotations": {
+                "nvidia.com/current-worker-hash": "legacy",
+                "nvidia.com/current-worker-hash-v2": "v2abc",
+            }
+        }
+    }
+
+    namespace = kubernetes_connector.get_worker_runtime_namespace("base-ns")
+
+    assert namespace == "base-ns-v2abc"
+
+
 def test_get_service_name_from_sub_component_type(kubernetes_connector):
     deployment = {
         "metadata": {"name": "test-graph"},

--- a/components/src/dynamo/planner/tests/unit/test_kubernetes_connector.py
+++ b/components/src/dynamo/planner/tests/unit/test_kubernetes_connector.py
@@ -81,6 +81,49 @@ def test_kubernetes_connector_no_env_var():
     }
 
 
+def test_get_worker_runtime_namespace_with_current_hash(
+    kubernetes_connector, mock_kube_api
+):
+    mock_kube_api.get_graph_deployment.return_value = {
+        "metadata": {
+            "annotations": {
+                "nvidia.com/current-worker-hash": "abc123",
+            }
+        }
+    }
+
+    namespace = kubernetes_connector.get_worker_runtime_namespace("base-ns")
+
+    assert namespace == "base-ns-abc123"
+    mock_kube_api.get_graph_deployment.assert_called_with("test-graph")
+
+
+def test_get_worker_runtime_namespace_without_hash(kubernetes_connector, mock_kube_api):
+    mock_kube_api.get_graph_deployment.return_value = {
+        "metadata": {
+            "annotations": {},
+        }
+    }
+
+    namespace = kubernetes_connector.get_worker_runtime_namespace("base-ns")
+
+    assert namespace == "base-ns"
+
+
+def test_get_worker_runtime_namespace_legacy_hash(kubernetes_connector, mock_kube_api):
+    mock_kube_api.get_graph_deployment.return_value = {
+        "metadata": {
+            "annotations": {
+                "nvidia.com/current-worker-hash": "legacy",
+            }
+        }
+    }
+
+    namespace = kubernetes_connector.get_worker_runtime_namespace("base-ns")
+
+    assert namespace == "base-ns"
+
+
 def test_get_service_name_from_sub_component_type(kubernetes_connector):
     deployment = {
         "metadata": {"name": "test-graph"},

--- a/components/src/dynamo/planner/tests/unit/test_remote_planner.py
+++ b/components/src/dynamo/planner/tests/unit/test_remote_planner.py
@@ -543,3 +543,35 @@ def test_connector_get_actual_worker_counts_out_of_cluster_fallback(connector_ru
         )
 
     assert counts == (0, 0, True)
+
+
+def test_connector_get_worker_runtime_namespace_delegates_to_local_k8s(
+    connector_runtime,
+):
+    """GlobalPlannerConnector should resolve the pool-local worker namespace."""
+    c = GlobalPlannerConnector(connector_runtime, "ns", "gns", "GP", model_name="test")
+    fake_local = MagicMock()
+    fake_local.get_worker_runtime_namespace = MagicMock(return_value="ns-hash")
+    c._local_k8s_connector = fake_local
+    c._local_k8s_init_attempted = True
+
+    namespace = c.get_worker_runtime_namespace("ns")
+
+    assert namespace == "ns-hash"
+    fake_local.get_worker_runtime_namespace.assert_called_once_with("ns")
+
+
+def test_connector_get_worker_runtime_namespace_out_of_cluster_fallback(
+    connector_runtime,
+):
+    """Fallback to base namespace when no pool-local KubernetesConnector exists."""
+    with patch(
+        "dynamo.planner.connectors.global_planner.KubernetesConnector",
+        side_effect=DeploymentValidationError(["forced test failure"]),
+    ):
+        c = GlobalPlannerConnector(
+            connector_runtime, "ns", "gns", "GP", model_name="test"
+        )
+        namespace = c.get_worker_runtime_namespace("ns")
+
+    assert namespace == "ns"


### PR DESCRIPTION
## Overview
Managed worker rollouts can register worker endpoints under a suffixed runtime namespace while frontend metrics and planner registration stay on the base namespace.

## Details
- Reads the active worker hash from DGD annotations, including the v2 annotation fallback.
- Uses the resolved worker runtime namespace for worker clients, FPM subscriptions, and benchmark endpoint discovery.
- Keeps the configured base namespace for frontend traffic metrics and planner registration.
- Handles transient namespace-resolution failures without rebinding back to the base namespace.
- Shuts down old FPM subscribers before replacing them on namespace changes.
- Delegates namespace resolution through `GlobalPlannerConnector` to the pool-local Kubernetes connector.

## Where should the reviewer start
Start with `components/src/dynamo/planner/core/base.py`, then `components/src/dynamo/planner/connectors/kubernetes.py` and `components/src/dynamo/planner/connectors/global_planner.py`.

## Related Issues
- None.

## Testing
- `uvx isort ...`
- `uvx black ...`
- `uvx ruff check ...`
- `python3 -m py_compile ...`
- Validated in hzhou cluster before PR split: planner switched to the suffixed worker namespace, loaded prefill/decode benchmark FPMs, and observed both FPM engines.