### PR TITLE
fix(trtllm): replace modulo-hash disagg_machine_id with disk-backed slot allocator

### DIFF
--- a/components/src/dynamo/trtllm/machine_id_allocator.py
+++ b/components/src/dynamo/trtllm/machine_id_allocator.py
@@ -14,8 +14,13 @@ class DisaggMachineIdAllocator:
     """Allocates unique 10-bit slots (1-1024) for disagg_machine_id.
 
     Uses O_CREAT | O_EXCL lock files under pool_dir to guarantee that no
-    two live workers share a slot.  Slot 0 is the sentinel (unset) value
-    and is never allocated.
+    two live workers (in the same process or different processes) share a
+    slot.
+
+    The lock file is named ``slot_{N}.lock`` so that O_EXCL atomicity is
+    scoped to the slot number, not the connection ID.  The connection ID is
+    stored as the file *contents* to enable orphan recovery across process
+    restarts.  Slot 0 is the sentinel (unset) value and is never allocated.
     """
 
     def __init__(self, pool_dir: str, max_slots: int = 1024) -> None:
@@ -24,53 +29,55 @@ class DisaggMachineIdAllocator:
         self._lock = threading.Lock()
         self._pool_dir.mkdir(parents=True, exist_ok=True)
 
-    def _slot_file(self, connection_id: int) -> Path:
-        return self._pool_dir / f"{connection_id}.slot"
+    def _slot_lock_file(self, slot: int) -> Path:
+        return self._pool_dir / f"slot_{slot}.lock"
 
     def allocate(self, connection_id: int) -> int:
         """Allocate a unique slot for connection_id.
 
-        Recovers orphaned slots (connection_id already has a file).
-        Raises RuntimeError when the pool is exhausted (>1024 workers).
-        Raises FileExistsError on collision (defensive; O_EXCL should prevent).
+        Recovers orphaned slots when this connection_id already owns one.
+        Raises RuntimeError when the pool is exhausted (>1024 live workers).
         """
         with self._lock:
-            sf = self._slot_file(connection_id)
-            # Recover orphaned slot (process died but file survived)
-            if sf.exists():
-                return int(sf.read_text().strip())
-
-            # Find smallest free slot >= 1
-            allocated: set[int] = set()
+            # Recovery: check whether this connection_id already owns a slot.
             for f in self._pool_dir.iterdir():
-                if f.suffix == ".slot" and f.name != ".slot":
-                    try:
-                        allocated.add(int(f.read_text().strip()))
-                    except (ValueError, OSError):
-                        continue
+                if not (f.name.startswith("slot_") and f.suffix == ".lock"):
+                    continue
+                try:
+                    if f.read_text().strip() == str(connection_id):
+                        return int(f.stem[5:])  # "slot_{N}" -> N
+                except (ValueError, OSError):
+                    continue
 
+            # Claim the smallest free slot atomically.
+            # O_EXCL on slot_{N}.lock ensures cross-process uniqueness:
+            # at most one caller can successfully create a given slot file.
             for slot in range(1, self._max_slots + 1):
-                if slot not in allocated:
-                    # Atomic slot file creation
-                    try:
-                        fd = os.open(
-                            str(sf), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644
-                        )
-                        os.write(fd, str(slot).encode())
-                        os.close(fd)
-                    except FileExistsError:
-                        # Another worker grabbed first; recover their slot
-                        return int(sf.read_text().strip())
+                lock_file = self._slot_lock_file(slot)
+                try:
+                    fd = os.open(
+                        str(lock_file), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644
+                    )
+                    os.write(fd, str(connection_id).encode())
+                    os.close(fd)
                     return slot
+                except FileExistsError:
+                    continue  # Slot claimed by another worker; try next.
 
             raise RuntimeError("disagg_machine_id pool exhausted (1024 workers live)")
 
     def free(self, connection_id: int) -> None:
-        """Remove the lock file for connection_id, freeing the slot."""
+        """Release the slot owned by connection_id."""
         with self._lock:
-            sf = self._slot_file(connection_id)
-            if sf.exists():
-                sf.unlink()
+            for f in self._pool_dir.iterdir():
+                if not (f.name.startswith("slot_") and f.suffix == ".lock"):
+                    continue
+                try:
+                    if f.read_text().strip() == str(connection_id):
+                        f.unlink()
+                        return
+                except (ValueError, OSError):
+                    continue
 
     @property
     def num_allocated(self) -> int:
@@ -78,5 +85,5 @@ class DisaggMachineIdAllocator:
             return sum(
                 1
                 for f in self._pool_dir.iterdir()
-                if f.suffix == ".slot" and f.name != ".slot"
+                if f.name.startswith("slot_") and f.suffix == ".lock"
             )

--- a/components/src/dynamo/trtllm/machine_id_allocator.py
+++ b/components/src/dynamo/trtllm/machine_id_allocator.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Disk-backed disagg_machine_id slot allocator for TRT-LLM workers."""
 
 from __future__ import annotations
@@ -5,7 +8,6 @@ from __future__ import annotations
 import os
 import threading
 from pathlib import Path
-from typing import Optional
 
 
 class DisaggMachineIdAllocator:
@@ -51,7 +53,9 @@ class DisaggMachineIdAllocator:
                 if slot not in allocated:
                     # Atomic slot file creation
                     try:
-                        fd = os.open(str(sf), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+                        fd = os.open(
+                            str(sf), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644
+                        )
                         os.write(fd, str(slot).encode())
                         os.close(fd)
                     except FileExistsError:
@@ -72,6 +76,7 @@ class DisaggMachineIdAllocator:
     def num_allocated(self) -> int:
         with self._lock:
             return sum(
-                1 for f in self._pool_dir.iterdir()
+                1
+                for f in self._pool_dir.iterdir()
                 if f.suffix == ".slot" and f.name != ".slot"
             )

--- a/components/src/dynamo/trtllm/machine_id_allocator.py
+++ b/components/src/dynamo/trtllm/machine_id_allocator.py
@@ -1,0 +1,77 @@
+"""Disk-backed disagg_machine_id slot allocator for TRT-LLM workers."""
+
+from __future__ import annotations
+
+import os
+import threading
+from pathlib import Path
+from typing import Optional
+
+
+class DisaggMachineIdAllocator:
+    """Allocates unique 10-bit slots (1-1024) for disagg_machine_id.
+
+    Uses O_CREAT | O_EXCL lock files under pool_dir to guarantee that no
+    two live workers share a slot.  Slot 0 is the sentinel (unset) value
+    and is never allocated.
+    """
+
+    def __init__(self, pool_dir: str, max_slots: int = 1024) -> None:
+        self._pool_dir = Path(pool_dir)
+        self._max_slots = max_slots
+        self._lock = threading.Lock()
+        self._pool_dir.mkdir(parents=True, exist_ok=True)
+
+    def _slot_file(self, connection_id: int) -> Path:
+        return self._pool_dir / f"{connection_id}.slot"
+
+    def allocate(self, connection_id: int) -> int:
+        """Allocate a unique slot for connection_id.
+
+        Recovers orphaned slots (connection_id already has a file).
+        Raises RuntimeError when the pool is exhausted (>1024 workers).
+        Raises FileExistsError on collision (defensive; O_EXCL should prevent).
+        """
+        with self._lock:
+            sf = self._slot_file(connection_id)
+            # Recover orphaned slot (process died but file survived)
+            if sf.exists():
+                return int(sf.read_text().strip())
+
+            # Find smallest free slot >= 1
+            allocated: set[int] = set()
+            for f in self._pool_dir.iterdir():
+                if f.suffix == ".slot" and f.name != ".slot":
+                    try:
+                        allocated.add(int(f.read_text().strip()))
+                    except (ValueError, OSError):
+                        continue
+
+            for slot in range(1, self._max_slots + 1):
+                if slot not in allocated:
+                    # Atomic slot file creation
+                    try:
+                        fd = os.open(str(sf), os.O_CREAT | os.O_EXCL, 0o644)
+                        os.write(fd, str(slot).encode())
+                        os.close(fd)
+                    except FileExistsError:
+                        # Another worker grabbed first; recover their slot
+                        return int(sf.read_text().strip())
+                    return slot
+
+            raise RuntimeError("disagg_machine_id pool exhausted (1024 workers live)")
+
+    def free(self, connection_id: int) -> None:
+        """Remove the lock file for connection_id, freeing the slot."""
+        with self._lock:
+            sf = self._slot_file(connection_id)
+            if sf.exists():
+                sf.unlink()
+
+    @property
+    def num_allocated(self) -> int:
+        with self._lock:
+            return sum(
+                1 for f in self._pool_dir.iterdir()
+                if f.suffix == ".slot" and f.name != ".slot"
+            )

--- a/components/src/dynamo/trtllm/machine_id_allocator.py
+++ b/components/src/dynamo/trtllm/machine_id_allocator.py
@@ -51,7 +51,7 @@ class DisaggMachineIdAllocator:
                 if slot not in allocated:
                     # Atomic slot file creation
                     try:
-                        fd = os.open(str(sf), os.O_CREAT | os.O_EXCL, 0o644)
+                        fd = os.open(str(sf), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
                         os.write(fd, str(slot).encode())
                         os.close(fd)
                     except FileExistsError:

--- a/components/src/dynamo/trtllm/tests/test_machine_id_allocator.py
+++ b/components/src/dynamo/trtllm/tests/test_machine_id_allocator.py
@@ -1,13 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for DisaggMachineIdAllocator."""
 
 from __future__ import annotations
 
 import tempfile
-import threading
+
 import pytest
-from pathlib import Path
 
 from dynamo.trtllm.machine_id_allocator import DisaggMachineIdAllocator
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.trtllm,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
 
 
 class TestDisaggMachineIdAllocator:

--- a/components/src/dynamo/trtllm/tests/test_machine_id_allocator.py
+++ b/components/src/dynamo/trtllm/tests/test_machine_id_allocator.py
@@ -1,0 +1,58 @@
+"""Tests for DisaggMachineIdAllocator."""
+
+from __future__ import annotations
+
+import tempfile
+import threading
+import pytest
+from pathlib import Path
+
+from dynamo.trtllm.machine_id_allocator import DisaggMachineIdAllocator
+
+
+class TestDisaggMachineIdAllocator:
+    def test_allocate_unique_slots(self):
+        """All allocated slots are distinct."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            alloc = DisaggMachineIdAllocator(tmpdir)
+            ids = [alloc.allocate(i) for i in range(100)]
+            assert len(set(ids)) == 100
+            for slot in ids:
+                assert 1 <= slot <= 1024
+
+    def test_allocate_recovers_orphaned_file(self):
+        """If connection_id file already exists, allocate() returns that slot."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            alloc = DisaggMachineIdAllocator(tmpdir)
+            slot = alloc.allocate(42)
+            # Simulate process death: re-allocate same connection_id
+            slot2 = alloc.allocate(42)
+            assert slot == slot2
+
+    def test_free_makes_slot_available(self):
+        """Free releases the slot for reuse by another connection_id."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            alloc = DisaggMachineIdAllocator(tmpdir)
+            slot1 = alloc.allocate(1)
+            alloc.free(1)
+            slot2 = alloc.allocate(2)
+            assert slot1 == slot2  # slot was reclaimed
+
+    def test_exhaustion_raises(self):
+        """Allocate all 1024 slots; next allocate raises RuntimeError."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            alloc = DisaggMachineIdAllocator(tmpdir)
+            allocated = []
+            for cid in range(1, 1025):
+                allocated.append(alloc.allocate(cid))
+            assert len(set(allocated)) == 1024
+            with pytest.raises(RuntimeError, match="pool exhausted"):
+                alloc.allocate(9999)
+
+    def test_zero_slot_never_allocated(self):
+        """Slot 0 is never allocated; it is the HandlerBase sentinel."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            alloc = DisaggMachineIdAllocator(tmpdir)
+            for cid in range(500):
+                slot = alloc.allocate(cid)
+                assert slot != 0

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -74,7 +74,24 @@ DEFAULT_KV_EVENT_BUFFER_MAX_SIZE = 1024
 # All connections must allocate from the same pool so that slot numbers are
 # unique across workers — a per-connection pool directory would let every
 # connection receive slot 1 from its own empty pool.
-_DEFAULT_POOL_DIR = "/var/run/dynamo/disagg_machine_id"
+# Prefer /var/run/dynamo (system-managed, survives reboots) but fall back to
+# a user-writable tmp path when the directory can't be created (e.g. in CI
+# containers that run without root).
+_PREFERRED_POOL_DIR = "/var/run/dynamo/disagg_machine_id"
+_FALLBACK_POOL_DIR = os.path.join(
+    os.environ.get("TMPDIR", "/tmp"), "dynamo", "disagg_machine_id"
+)
+
+
+def _resolve_pool_dir() -> str:
+    try:
+        os.makedirs(_PREFERRED_POOL_DIR, exist_ok=True)
+        return _PREFERRED_POOL_DIR
+    except OSError:
+        return _FALLBACK_POOL_DIR
+
+
+_DEFAULT_POOL_DIR = _resolve_pool_dir()
 _pools: dict[str, DisaggMachineIdAllocator] = {}
 _pool_lock = threading.Lock()
 

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -84,11 +84,23 @@ _FALLBACK_POOL_DIR = os.path.join(
 
 
 def _resolve_pool_dir() -> str:
-    try:
-        os.makedirs(_PREFERRED_POOL_DIR, exist_ok=True)
-        return _PREFERRED_POOL_DIR
-    except OSError:
-        return _FALLBACK_POOL_DIR
+    """Return the pool directory, falling back to tmp when preferred is non-writable.
+
+    ``os.makedirs(..., exist_ok=True)`` succeeds even for an existing directory
+    that is owned by another user and has no write permission for us, so we probe
+    writability by creating and immediately removing a temporary file.
+    """
+    for candidate in (_PREFERRED_POOL_DIR, _FALLBACK_POOL_DIR):
+        try:
+            os.makedirs(candidate, exist_ok=True)
+            probe = os.path.join(candidate, ".write_probe")
+            fd = os.open(probe, os.O_CREAT | os.O_WRONLY, 0o600)
+            os.close(fd)
+            os.unlink(probe)
+            return candidate
+        except OSError:
+            continue
+    return _FALLBACK_POOL_DIR
 
 
 _DEFAULT_POOL_DIR = _resolve_pool_dir()
@@ -109,6 +121,14 @@ def _get_disagg_machine_id(endpoint, pool_dir: str = _DEFAULT_POOL_DIR) -> int:
         if pool_dir not in _pools:
             _pools[pool_dir] = DisaggMachineIdAllocator(pool_dir)
     return _pools[pool_dir].allocate(cid)
+
+
+def _free_disagg_machine_id(endpoint, pool_dir: str = _DEFAULT_POOL_DIR) -> None:
+    """Release the slot held by this endpoint's connection_id."""
+    cid = int(endpoint.connection_id())
+    with _pool_lock:
+        if pool_dir in _pools:
+            _pools[pool_dir].free(cid)
 
 
 def build_kv_connector_config(config: Config):
@@ -626,6 +646,10 @@ async def init_llm_worker(
         )
         logging.debug("DYNAMO_COMPONENT_REGISTRY callback registered successfully")
 
+        # Allocate a unique disagg_machine_id; released in the finally block
+        # below so slot_*.lock files don't persist across worker restarts.
+        _machine_id = _get_disagg_machine_id(endpoint)
+
         # publisher will be set later if publishing is enabled.
         handler_config = RequestHandlerConfig(
             engine=engine,
@@ -643,7 +667,7 @@ async def init_llm_worker(
             encoder_cache_capacity_gb=config.multimodal_embedding_cache_capacity_gb,
             additional_metrics=additional_metrics,
             max_seq_len=config.max_seq_len,
-            disagg_machine_id=_get_disagg_machine_id(endpoint),
+            disagg_machine_id=_machine_id,
         )
 
         media_decoder = None
@@ -737,11 +761,14 @@ async def init_llm_worker(
                         model_name=model_name_for_metrics,
                         component_name=config.component,
                     )
-                await endpoint.serve_endpoint(
-                    handler.generate,
-                    metrics_labels=metrics_labels,
-                    health_check_payload=health_check_payload,
-                )
+                try:
+                    await endpoint.serve_endpoint(
+                        handler.generate,
+                        metrics_labels=metrics_labels,
+                        health_check_payload=health_check_payload,
+                    )
+                finally:
+                    _free_disagg_machine_id(endpoint)
 
             # Shutdown consolidator publisher if it was created
             if consolidator_publisher:
@@ -750,6 +777,9 @@ async def init_llm_worker(
             handler = RequestHandlerFactory().get_request_handler(handler_config)
             if config.load_format == "gms":
                 _register_memory_routes(runtime, handler)
-            await endpoint.serve_endpoint(
-                handler.generate, health_check_payload=health_check_payload
-            )
+            try:
+                await endpoint.serve_endpoint(
+                    handler.generate, health_check_payload=health_check_payload
+                )
+            finally:
+                _free_disagg_machine_id(endpoint)

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -12,6 +12,7 @@ import json
 import logging
 import os
 import sys
+import threading
 from typing import Optional
 
 from prometheus_client import REGISTRY
@@ -58,6 +59,7 @@ from dynamo.trtllm.constants import DisaggregationMode, Modality
 from dynamo.trtllm.engine import Backend, get_llm_engine
 from dynamo.trtllm.health_check import TrtllmHealthCheckPayload
 from dynamo.trtllm.multimodal_processor import MultimodalRequestProcessor
+from dynamo.trtllm.machine_id_allocator import DisaggMachineIdAllocator
 from dynamo.trtllm.publisher import DYNAMO_COMPONENT_REGISTRY, get_publisher
 from dynamo.trtllm.request_handlers.handlers import (
     RequestHandlerConfig,
@@ -67,6 +69,19 @@ from dynamo.trtllm.utils.trtllm_utils import deep_update
 
 # Default buffer size for kv cache events.
 DEFAULT_KV_EVENT_BUFFER_MAX_SIZE = 1024
+
+_pools: dict[int, DisaggMachineIdAllocator] = {}
+_pool_lock = threading.Lock()
+
+
+def _get_disagg_machine_id(endpoint) -> int:
+    cid = int(endpoint.connection_id())
+    with _pool_lock:
+        if cid not in _pools:
+            _pools[cid] = DisaggMachineIdAllocator(
+                f"/var/run/dynamo/disagg_machine_id/{cid}"
+            )
+    return _pools[cid].allocate(cid)
 
 
 def build_kv_connector_config(config: Config):
@@ -601,7 +616,7 @@ async def init_llm_worker(
             encoder_cache_capacity_gb=config.multimodal_embedding_cache_capacity_gb,
             additional_metrics=additional_metrics,
             max_seq_len=config.max_seq_len,
-            disagg_machine_id=int(endpoint.connection_id()) % 1021,
+            disagg_machine_id=_get_disagg_machine_id(endpoint),
         )
 
         media_decoder = None

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -58,8 +58,8 @@ from dynamo.trtllm.args import Config
 from dynamo.trtllm.constants import DisaggregationMode, Modality
 from dynamo.trtllm.engine import Backend, get_llm_engine
 from dynamo.trtllm.health_check import TrtllmHealthCheckPayload
-from dynamo.trtllm.multimodal_processor import MultimodalRequestProcessor
 from dynamo.trtllm.machine_id_allocator import DisaggMachineIdAllocator
+from dynamo.trtllm.multimodal_processor import MultimodalRequestProcessor
 from dynamo.trtllm.publisher import DYNAMO_COMPONENT_REGISTRY, get_publisher
 from dynamo.trtllm.request_handlers.handlers import (
     RequestHandlerConfig,
@@ -70,18 +70,28 @@ from dynamo.trtllm.utils.trtllm_utils import deep_update
 # Default buffer size for kv cache events.
 DEFAULT_KV_EVENT_BUFFER_MAX_SIZE = 1024
 
-_pools: dict[int, DisaggMachineIdAllocator] = {}
+# Shared pool directory for all TRT-LLM workers in this process.
+# All connections must allocate from the same pool so that slot numbers are
+# unique across workers — a per-connection pool directory would let every
+# connection receive slot 1 from its own empty pool.
+_DEFAULT_POOL_DIR = "/var/run/dynamo/disagg_machine_id"
+_pools: dict[str, DisaggMachineIdAllocator] = {}
 _pool_lock = threading.Lock()
 
 
-def _get_disagg_machine_id(endpoint) -> int:
+def _get_disagg_machine_id(endpoint, pool_dir: str = _DEFAULT_POOL_DIR) -> int:
+    """Return a unique disagg_machine_id for *endpoint*.
+
+    All callers within a process share a single :class:`DisaggMachineIdAllocator`
+    backed by *pool_dir*.  The allocator is cached by pool directory so that
+    the same on-disk pool is reused across connections, guaranteeing that no
+    two live workers receive the same slot.
+    """
     cid = int(endpoint.connection_id())
     with _pool_lock:
-        if cid not in _pools:
-            _pools[cid] = DisaggMachineIdAllocator(
-                f"/var/run/dynamo/disagg_machine_id/{cid}"
-            )
-    return _pools[cid].allocate(cid)
+        if pool_dir not in _pools:
+            _pools[pool_dir] = DisaggMachineIdAllocator(pool_dir)
+    return _pools[pool_dir].allocate(cid)
 
 
 def build_kv_connector_config(config: Config):

--- a/components/src/dynamo/vllm/tests/conftest.py
+++ b/components/src/dynamo/vllm/tests/conftest.py
@@ -16,6 +16,26 @@ import pytest
 # `None` = not yet attempted, `True` = succeeded, `False` = raised.
 _omni_importable: bool | None = None
 _multimodal_utils_importable: bool | None = None
+_vllm_internals_importable: bool | None = None
+
+
+def _can_import_vllm_internals() -> bool:
+    """Try to import a vllm internal submodule once and cache the result.
+
+    ``find_spec("vllm")`` returns non-None even when vllm is only partially
+    installed (e.g. the top-level package exists but vllm.v1, vllm.config,
+    vllm.inputs etc. are absent).  An actual import attempt is the only
+    reliable way to detect this — used to gate all test_vllm_* files and
+    any other tests that import vllm internals.
+    """
+    global _vllm_internals_importable
+    if _vllm_internals_importable is None:
+        try:
+            importlib.import_module("vllm.v1.engine.async_llm")
+            _vllm_internals_importable = True
+        except Exception:
+            _vllm_internals_importable = False
+    return _vllm_internals_importable
 
 
 def _can_import_multimodal_utils() -> bool:
@@ -57,28 +77,47 @@ def _can_import_omni() -> bool:
 
 
 def pytest_ignore_collect(collection_path, config):
-    """Skip collecting vllm test files if vllm module isn't installed.
-    Checks test file naming pattern: test_vllm_*.py
+    """Skip collecting test files that need vllm internals or optional deps.
+
+    Uses real import attempts (not find_spec) because vllm can be partially
+    installed: the top-level package resolves under find_spec but submodules
+    such as vllm.v1, vllm.config, and vllm.inputs are absent in the
+    dynamo-runtime image, causing collection errors at import time.
     """
     filename = collection_path.name
-    if filename.startswith("test_vllm_"):
-        if importlib.util.find_spec("vllm") is None:
-            return True  # vllm not available, skip this file
-    # Omni tests import dynamo.vllm.omni.* which transitively imports
-    # vllm_omni at module load. On CPU-only sample-runtime runners the
-    # import chain reaches vllm._C and raises (NotImplementedError when
-    # libcuda.so.1 is missing). Each file's local try/except ImportError
-    # doesn't catch this, so skip collection up-front if the canonical
-    # omni module isn't importable.
     parts = collection_path.parts
+
+    # test_vllm_*.py files import vllm internals (vllm.v1, vllm.config, …).
+    # Replace the find_spec guard with a real import check.
+    if filename.startswith("test_vllm_") and not _can_import_vllm_internals():
+        return True
+
+    # tests/frontend/test_prepost*.py import vllm.entrypoints.openai which
+    # also requires full vllm internals absent in dynamo-runtime.
+    if filename.startswith("test_prepost") and "frontend" in parts:
+        if not _can_import_vllm_internals():
+            return True
+
+    # examples/backends/sglang/test_sglang_expert_info.py requires pybase64
+    # which is not installed in all CI images.
+    if filename == "test_sglang_expert_info.py":
+        if importlib.util.find_spec("pybase64") is None:
+            return True
+
     # multimodal_utils tests import dynamo.vllm.multimodal_utils which
     # transitively imports vllm internals not present in dynamo-runtime.
     if "multimodal_utils" in parts and filename.startswith("test_"):
         if not _can_import_multimodal_utils():
             return True
+
+    # Omni tests import dynamo.vllm.omni.* which transitively imports
+    # vllm_omni at module load. On CPU-only sample-runtime runners the
+    # import chain reaches vllm._C and raises (NotImplementedError when
+    # libcuda.so.1 is missing).
     if "omni" in parts and filename.startswith("test_"):
         if not _can_import_omni():
             return True
+
     return None
 
 

--- a/components/src/dynamo/vllm/tests/conftest.py
+++ b/components/src/dynamo/vllm/tests/conftest.py
@@ -92,18 +92,6 @@ def pytest_ignore_collect(collection_path, config):
     if filename.startswith("test_vllm_") and not _can_import_vllm_internals():
         return True
 
-    # tests/frontend/test_prepost*.py import vllm.entrypoints.openai which
-    # also requires full vllm internals absent in dynamo-runtime.
-    if filename.startswith("test_prepost") and "frontend" in parts:
-        if not _can_import_vllm_internals():
-            return True
-
-    # examples/backends/sglang/test_sglang_expert_info.py requires pybase64
-    # which is not installed in all CI images.
-    if filename == "test_sglang_expert_info.py":
-        if importlib.util.find_spec("pybase64") is None:
-            return True
-
     # multimodal_utils tests import dynamo.vllm.multimodal_utils which
     # transitively imports vllm internals not present in dynamo-runtime.
     if "multimodal_utils" in parts and filename.startswith("test_"):

--- a/components/src/dynamo/vllm/tests/conftest.py
+++ b/components/src/dynamo/vllm/tests/conftest.py
@@ -15,6 +15,26 @@ import pytest
 # Cached result of attempting to import the omni handler module.
 # `None` = not yet attempted, `True` = succeeded, `False` = raised.
 _omni_importable: bool | None = None
+_multimodal_utils_importable: bool | None = None
+
+
+def _can_import_multimodal_utils() -> bool:
+    """Try to import dynamo.vllm.multimodal_utils once and cache the result.
+
+    The multimodal_utils sub-package transitively imports vllm internals
+    (e.g. chat_message_utils → vllm) that are not available in the
+    dynamo-runtime image.  ``find_spec("vllm")`` returns non-None even
+    when vllm is partially installed, so the spec check is insufficient —
+    only a real import attempt reveals the failure.
+    """
+    global _multimodal_utils_importable
+    if _multimodal_utils_importable is None:
+        try:
+            importlib.import_module("dynamo.vllm.multimodal_utils")
+            _multimodal_utils_importable = True
+        except Exception:
+            _multimodal_utils_importable = False
+    return _multimodal_utils_importable
 
 
 def _can_import_omni() -> bool:
@@ -51,6 +71,11 @@ def pytest_ignore_collect(collection_path, config):
     # doesn't catch this, so skip collection up-front if the canonical
     # omni module isn't importable.
     parts = collection_path.parts
+    # multimodal_utils tests import dynamo.vllm.multimodal_utils which
+    # transitively imports vllm internals not present in dynamo-runtime.
+    if "multimodal_utils" in parts and filename.startswith("test_"):
+        if not _can_import_multimodal_utils():
+            return True
     if "omni" in parts and filename.startswith("test_"):
         if not _can_import_omni():
             return True

--- a/conftest.py
+++ b/conftest.py
@@ -11,9 +11,45 @@ sglang scheduler) inherit that and crash on `from vllm.v1 ...`.
 from __future__ import annotations
 
 import importlib
+import importlib.util
 import os
 import sys
 from pathlib import Path
+
+_vllm_internals_importable: bool | None = None
+
+
+def _can_import_vllm_internals() -> bool:
+    """Try to import a vllm internal submodule once and cache the result."""
+    global _vllm_internals_importable
+    if _vllm_internals_importable is None:
+        try:
+            importlib.import_module("vllm.v1.engine.async_llm")
+            _vllm_internals_importable = True
+        except Exception:
+            _vllm_internals_importable = False
+    return _vllm_internals_importable
+
+
+def pytest_ignore_collect(collection_path, config):
+    """Skip test files that need optional deps not available in all CI images."""
+    filename = collection_path.name
+    parts = collection_path.parts
+
+    # tests/frontend/test_prepost*.py import vllm.entrypoints.openai which
+    # requires full vllm internals absent in dynamo-runtime.
+    if filename.startswith("test_prepost") and "frontend" in parts:
+        if not _can_import_vllm_internals():
+            return True
+
+    # examples/backends/sglang/test_sglang_expert_info.py requires pybase64
+    # which is not installed in all CI images.
+    if filename == "test_sglang_expert_info.py":
+        if importlib.util.find_spec("pybase64") is None:
+            return True
+
+    return None
+
 
 # Seed sys.modules with the venv copies before pytest collection runs.
 for _name in ("vllm", "sglang"):


### PR DESCRIPTION
Replaces modulo-hash disagg_machine_id assignment with a disk-backed slot allocator to eliminate ID collisions in multi-node disaggregated TRT-LLM deployments.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9530" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a machine ID allocation system for disaggregated worker management, enabling concurrent worker processes to safely claim unique identifiers from a shared pool.

* **Tests**
  * Added comprehensive test suite validating machine ID allocation, slot recovery after process failures, slot reuse, and pool exhaustion handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9530)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->