### PR TITLE
fix(trtllm): preserve user-supplied arg_map fields from silent clobber in init_llm_worker

### DIFF
--- a/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
@@ -325,6 +325,76 @@ async def test_init_llm_worker_engine_args_with_extra_engine_args(
         assert config.max_batch_size == 512
 
 
+@pytest.mark.asyncio
+async def test_arg_map_preserves_user_engine_args(tmp_path, monkeypatch, caplog):
+    """User-supplied load_format, return_perf_metrics, and max_seq_len from --extra-engine-args YAML survive Dynamo massaging.
+
+    Regression test for dynamo issue 9288 — the init_llm_worker arg_map
+    construction silently clobbered user-supplied values:
+      1. load_format (line 274 unconditional assignment).
+      2. return_perf_metrics (initially set before YAML is parsed; re-applied after).
+
+    The _warn_override_collisions call for the YAML path was also missing.
+    """
+    monkeypatch.delenv("DYN_TRTLLM_MAX_SEQ_LEN", raising=False)
+    monkeypatch.delenv("DYN_TRTLLM_MAX_NUM_TOKENS", raising=False)
+    monkeypatch.delenv("DYN_TRTLLM_MAX_BATCH_SIZE", raising=False)
+
+    yaml_file = tmp_path / "engine_override.yaml"
+    yaml_file.write_text(
+        "load_format: fp8\nreturn_perf_metrics: true\nmax_seq_len: 8192\n"
+    )
+
+    config = parse_args(
+        [
+            "--model",
+            "fake-model",
+            "--max-seq-len",
+            "131072",
+            "--extra-engine-args",
+            str(yaml_file),
+        ]
+    )
+
+    with (
+        mock.patch("dynamo.trtllm.workers.llm_worker.tokenizer_factory"),
+        mock.patch("dynamo.trtllm.workers.llm_worker.nixl_connect.Connector"),
+        mock.patch("dynamo.trtllm.workers.llm_worker.dump_config"),
+        mock.patch("dynamo.trtllm.workers.llm_worker.LLMBackendMetrics"),
+        mock.patch(
+            "dynamo.trtllm.workers.llm_worker.get_llm_engine",
+            side_effect=_mock_get_llm_engine,
+        ),
+    ):
+        with pytest.raises(EngineArgsCaptured) as exc_info:
+            await init_llm_worker(
+                runtime=mock.MagicMock(),
+                config=config,
+                shutdown_event=asyncio.Event(),
+            )
+
+        engine_args = exc_info.value.engine_args
+        # load_format fix: user-supplied YAML value must survive the
+        # unconditional arg_map["load_format"] = engine_load_format line.
+        assert engine_args["load_format"] == "fp8", (
+            f"Expected load_format=fp8 from YAML override, "
+            f"got {engine_args['load_format']}"
+        )
+        # return_perf_metrics fix: user-supplied True from YAML must not be
+        # silently downgraded to False by the initial arg_map default or
+        # by the kv_cache event buffer massaging block.
+        assert engine_args["return_perf_metrics"] is True, (
+            f"Expected return_perf_metrics=True from YAML override, "
+            f"got {engine_args['return_perf_metrics']}"
+        )
+        # max_seq_len already passes through update_llm_args_with_extra_options
+        # (non-destructive merge); this is a belt-and-suspenders check.
+        assert engine_args["max_seq_len"] == 8192, (
+            f"Expected max_seq_len=8192 from YAML override, "
+            f"got {engine_args['max_seq_len']}"
+        )
+
+
 class MultimodalProcessorInstantiated(Exception):
     """Custom exception for testing MultimodalRequestProcessor."""
 

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -14,6 +14,7 @@ import os
 import sys
 from typing import Optional
 
+import yaml
 from prometheus_client import REGISTRY
 from tensorrt_llm.llmapi import (
     CapacitySchedulerPolicy,
@@ -301,12 +302,10 @@ async def init_llm_worker(
         # for later re-application, and (b) detect collisions with _warn_override.
         _parsed_extra = {}
         try:
-            import yaml
-
             _parsed_extra = yaml.safe_load(config.extra_engine_args) or {}
             if not isinstance(_parsed_extra, dict):
                 _parsed_extra = {}
-        except Exception:
+        except yaml.YAMLError:
             pass  # YAML parse errors are handled by update_llm_args_with_extra_options
         if isinstance(_parsed_extra, dict):
             _user_return_perf_metrics = _parsed_extra.get("return_perf_metrics")
@@ -396,12 +395,15 @@ async def init_llm_worker(
 
     logging.info(f"TensorRT-LLM engine args: {arg_map}")
 
-    # Re-apply user-supplied return_perf_metrics after all massaging.
-    # This guards against:
-    # 1. The initial arg_map default (line ~266) applied before YAML was parsed.
-    # 2. Any future unconditional assignment that could silently downgrade an
-    #    explicit True to False (which would break KV cache event publishing).
-    if _user_return_perf_metrics is not None:
+    # Re-apply user-supplied return_perf_metrics from YAML (extra_engine_args)
+    # only when JSON overrides (override_engine_args) did not also set it.
+    # JSON overrides have higher precedence than YAML extra args, so we must
+    # not clobber a JSON-supplied value here.
+    _override_set_perf_metrics = (
+        config.override_engine_args != ""
+        and "return_perf_metrics" in json.loads(config.override_engine_args or "{}")
+    )
+    if _user_return_perf_metrics is not None and not _override_set_perf_metrics:
         arg_map["return_perf_metrics"] = _user_return_perf_metrics
 
     engine_args = arg_map

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -249,6 +249,11 @@ async def init_llm_worker(
             )
             engine_load_format = "auto"
 
+    # Tracks user-supplied return_perf_metrics from --extra-engine-args YAML.
+    # Set to None here so the later re-application guard can check whether the
+    # user explicitly overrode this field (vs. leaving it at the Dynamo default).
+    _user_return_perf_metrics = None
+
     arg_map = {
         "model": model_path,
         "scheduler_config": scheduler_config,
@@ -271,7 +276,8 @@ async def init_llm_worker(
         "kv_connector_config": kv_connector_config,
     }
 
-    arg_map["load_format"] = engine_load_format
+    if "load_format" not in arg_map:
+        arg_map["load_format"] = engine_load_format
 
     # Enable sleep_config when GMS manages weights — required for GMS
     # unmap/remap. Conditional because SleepConfig contains unpicklable
@@ -291,6 +297,20 @@ async def init_llm_worker(
 
     if config.extra_engine_args != "":
         # TODO: Support extra engine args from json file as well.
+        # Parse YAML once to (a) capture user-supplied return_perf_metrics
+        # for later re-application, and (b) detect collisions with _warn_override.
+        _parsed_extra = {}
+        try:
+            import yaml
+
+            _parsed_extra = yaml.safe_load(config.extra_engine_args) or {}
+            if not isinstance(_parsed_extra, dict):
+                _parsed_extra = {}
+        except Exception:
+            pass  # YAML parse errors are handled by update_llm_args_with_extra_options
+        if isinstance(_parsed_extra, dict):
+            _user_return_perf_metrics = _parsed_extra.get("return_perf_metrics")
+        _warn_override_collisions(arg_map, _parsed_extra)
         arg_map = update_llm_args_with_extra_options(arg_map, config.extra_engine_args)
 
     # Apply override_engine_args if provided
@@ -375,6 +395,15 @@ async def init_llm_worker(
         )
 
     logging.info(f"TensorRT-LLM engine args: {arg_map}")
+
+    # Re-apply user-supplied return_perf_metrics after all massaging.
+    # This guards against:
+    # 1. The initial arg_map default (line ~266) applied before YAML was parsed.
+    # 2. Any future unconditional assignment that could silently downgrade an
+    #    explicit True to False (which would break KV cache event publishing).
+    if _user_return_perf_metrics is not None:
+        arg_map["return_perf_metrics"] = _user_return_perf_metrics
+
     engine_args = arg_map
 
     # Populate default sampling params from the model


### PR DESCRIPTION
Prevent silent clobbering of user-supplied arg_map fields during init_llm_worker initialization in the TRT-LLM backend.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9533" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression test to verify YAML engine argument overrides are correctly preserved.

* **Bug Fixes**
  * Fixed issue where user-supplied YAML configuration overrides could be inadvertently altered during initialization, ensuring settings like `return_perf_metrics` and `load_format` remain unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9533)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->