### PR TITLE
fix(snapshot): per-target ready gating + OCI runtime container-ID fallback

### DIFF
--- a/deploy/snapshot/internal/controller/controller.go
+++ b/deploy/snapshot/internal/controller/controller.go
@@ -186,9 +186,6 @@ func (w *NodeController) reconcileCheckpointPod(ctx context.Context, pod *corev1
 	if pod.Spec.NodeName != w.config.NodeName {
 		return
 	}
-	if !isPodReady(pod) {
-		return
-	}
 
 	podKey := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
 
@@ -216,6 +213,9 @@ func (w *NodeController) reconcileCheckpointPod(ctx context.Context, pod *corev1
 		return
 	}
 	containerName := targets[0]
+	if !isContainerReady(pod, containerName) {
+		return
+	}
 
 	if !w.tryAcquire(podKey) {
 		return

--- a/deploy/snapshot/internal/controller/controller.go
+++ b/deploy/snapshot/internal/controller/controller.go
@@ -51,6 +51,12 @@ type checkpointLocations struct {
 	ContainerPath string
 }
 
+const (
+	restoreContainerResolveInterval  = 50 * time.Millisecond
+	restoreContainerResolveTimeout   = 30 * time.Second
+	restoreContainerResolveKeySuffix = "resolve"
+)
+
 // NewNodeController creates the node-local controller that runs inside snapshot-agent.
 func NewNodeController(
 	cfg *types.AgentConfig,
@@ -297,19 +303,79 @@ func (w *NodeController) maybeStartRestoreForContainer(
 	checkpointID string,
 	podKey string,
 ) {
-	containerID := ""
-	for _, cs := range pod.Status.ContainerStatuses {
-		if cs.Name != containerName || cs.ContainerID == "" {
-			continue
-		}
-		containerID = snapshotruntime.StripCRIScheme(cs.ContainerID)
-		break
-	}
+	containerID := restoreContainerIDFromStatus(pod, containerName)
 	if containerID == "" {
-		w.log.V(1).Info("Restore pod has no running container yet", "pod", podKey, "container", containerName)
+		w.maybeStartRestoreContainerResolver(ctx, pod.DeepCopy(), containerName, checkpointID, podKey)
 		return
 	}
 
+	w.startRestoreForContainer(ctx, pod, containerName, containerID, checkpointID, podKey)
+}
+
+func restoreContainerIDFromStatus(pod *corev1.Pod, containerName string) string {
+	for _, cs := range pod.Status.ContainerStatuses {
+		if cs.Name == containerName && cs.ContainerID != "" {
+			return snapshotruntime.StripCRIScheme(cs.ContainerID)
+		}
+	}
+	return ""
+}
+
+func (w *NodeController) maybeStartRestoreContainerResolver(
+	ctx context.Context,
+	pod *corev1.Pod,
+	containerName string,
+	checkpointID string,
+	podKey string,
+) {
+	resolveKey := fmt.Sprintf("%s/%s/%s", podKey, containerName, restoreContainerResolveKeySuffix)
+	if !w.tryAcquire(resolveKey) {
+		return
+	}
+
+	w.log.V(1).Info("Restore pod has no running container in Kubernetes status yet; resolving via node runtime",
+		"pod", podKey,
+		"container", containerName,
+	)
+
+	go func() {
+		defer w.release(resolveKey)
+
+		resolveCtx, cancel := context.WithTimeout(ctx, restoreContainerResolveTimeout)
+		defer cancel()
+
+		ticker := time.NewTicker(restoreContainerResolveInterval)
+		defer ticker.Stop()
+
+		for {
+			containerID, err := w.runtime.ResolveContainerIDByPod(resolveCtx, pod.Name, pod.Namespace, containerName)
+			if err == nil && containerID != "" {
+				w.startRestoreForContainer(ctx, pod, containerName, containerID, checkpointID, podKey)
+				return
+			}
+
+			select {
+			case <-resolveCtx.Done():
+				w.log.V(1).Info("Timed out resolving restore container via node runtime",
+					"pod", podKey,
+					"container", containerName,
+					"err", err,
+				)
+				return
+			case <-ticker.C:
+			}
+		}
+	}()
+}
+
+func (w *NodeController) startRestoreForContainer(
+	ctx context.Context,
+	pod *corev1.Pod,
+	containerName string,
+	containerID string,
+	checkpointID string,
+	podKey string,
+) {
 	annotationKeys, err := snapshotprotocol.RestoreStatusAnnotationKeysFor(containerName)
 	if err != nil {
 		w.log.Error(err, "Restore target container name cannot be used in restore status annotation key", "pod", podKey, "container", containerName)
@@ -376,7 +442,7 @@ func (w *NodeController) maybeStartRestoreForContainer(
 //  2. Resolve the container ID and host PID
 //  3. Call executor.Checkpoint (inspect → configure → CUDA lock/checkpoint → CRIU dump → rootfs diff)
 //  4. Write a snapshot-complete sentinel into the pod's snapshot-control
-//     volume on success (observed by the workload via inotify), or SIGKILL
+//     volume on success (observed by the workload via polling), or SIGKILL
 //     on failure (unrecoverable CUDA-locked process)
 //  5. Mark job as completed or failed
 func (w *NodeController) runCheckpoint(ctx context.Context, pod *corev1.Pod, job *batchv1.Job, checkpointID, containerName, podKey string, startedAt time.Time) error {
@@ -505,7 +571,6 @@ func (w *NodeController) runCheckpoint(ctx context.Context, pod *corev1.Pod, job
 		}
 		return nil
 	}
-
 	// Step 2: Sentinel on success. Workload observes via polling on the
 	// snapshot-control volume; containerPID is a PID inside the container's
 	// mount namespace, which is all the /host/proc/<pid>/root write path
@@ -528,8 +593,17 @@ func (w *NodeController) runCheckpoint(ctx context.Context, pod *corev1.Pod, job
 	return nil
 }
 
-// runRestore restores one target container. Kubernetes readiness is gated by
-// the shaped startup probe, not by the snapshot-agent worker.
+// runRestore runs the full restore workflow for a pod:
+//  1. Mark the current container instance as in_progress
+//  2. Call executor.Restore (inspect placeholder → nsrestore inside namespace)
+//  3. Write a restore-complete sentinel into the pod's snapshot-control
+//     volume to wake the workload (observed via polling)
+//  4. Mark the container instance as completed
+//
+// Kubernetes readiness is gated separately: each restore-target container's
+// startup probe waits on the restore-complete sentinel, then its normal
+// readiness probe (if any) decides when the container is ready. The pod only
+// becomes Ready once every restored and cold-started container is ready.
 func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, containerName, containerID, checkpointID string, checkpointLocation checkpointLocations, restoreAttemptKey string, startedAt time.Time) error {
 	releaseOnExit := true
 	defer func() {
@@ -605,7 +679,6 @@ func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, contai
 		}
 		return nil
 	}
-
 	// Any PID inside the container mount namespace reaches the control
 	// volume through /host/proc/<pid>/root.
 	if err := snapshotruntime.WriteControlSentinel(placeholderHostPID, snapshotprotocol.RestoreCompleteFile); err != nil {

--- a/deploy/snapshot/internal/controller/controller.go
+++ b/deploy/snapshot/internal/controller/controller.go
@@ -585,7 +585,9 @@ func (w *NodeController) runCheckpoint(ctx context.Context, pod *corev1.Pod, job
 // runRestore runs the full restore workflow for one target container:
 //  1. Annotate the pod with restore in_progress
 //  2. Call executor.Restore (inspect placeholder → nsrestore inside namespace)
-//  3. Write a restore-complete sentinel to wake the workload (polled)
+//  3. Write a restore-complete sentinel: the CRIU-restored process resumes
+//     inside the polling loop that waits on this file, exits quiescence,
+//     and resumes the engine
 //  4. Annotate the pod with restore completed
 func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, containerName, containerID, checkpointID string, checkpointLocation checkpointLocations, restoreAttemptKey string, startedAt time.Time) error {
 	releaseOnExit := true

--- a/deploy/snapshot/internal/controller/controller.go
+++ b/deploy/snapshot/internal/controller/controller.go
@@ -295,10 +295,8 @@ func (w *NodeController) reconcileRestorePod(ctx context.Context, pod *corev1.Po
 }
 
 // maybeStartRestoreForContainer starts one restore worker per fresh container.
-// If pod.Status doesn't carry the ContainerID yet (the kubelet's status patch
-// can lag container exec by 1-5 s), poll the OCI runtime directly. The
-// resolveKey lease prevents the chatty pod-informer from fanning out into
-// many concurrent pollers for the same (pod, container).
+// Falls back to polling the OCI runtime when pod.Status hasn't published the
+// ContainerID yet (the kubelet status patch can lag exec by 1-5 s).
 func (w *NodeController) maybeStartRestoreForContainer(
 	ctx context.Context,
 	pod *corev1.Pod,
@@ -584,17 +582,11 @@ func (w *NodeController) runCheckpoint(ctx context.Context, pod *corev1.Pod, job
 	return nil
 }
 
-// runRestore runs the full restore workflow for a pod:
-//  1. Mark the current container instance as in_progress
+// runRestore runs the full restore workflow for one target container:
+//  1. Annotate the pod with restore in_progress
 //  2. Call executor.Restore (inspect placeholder → nsrestore inside namespace)
-//  3. Write a restore-complete sentinel into the pod's snapshot-control
-//     volume to wake the workload (observed via polling)
-//  4. Mark the container instance as completed
-//
-// Kubernetes readiness is gated separately: each restore-target container's
-// startup probe waits on the restore-complete sentinel, then its normal
-// readiness probe (if any) decides when the container is ready. The pod only
-// becomes Ready once every restored and cold-started container is ready.
+//  3. Write a restore-complete sentinel to wake the workload (polled)
+//  4. Annotate the pod with restore completed
 func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, containerName, containerID, checkpointID string, checkpointLocation checkpointLocations, restoreAttemptKey string, startedAt time.Time) error {
 	releaseOnExit := true
 	defer func() {

--- a/deploy/snapshot/internal/controller/controller.go
+++ b/deploy/snapshot/internal/controller/controller.go
@@ -52,9 +52,8 @@ type checkpointLocations struct {
 }
 
 const (
-	restoreContainerResolveInterval  = 50 * time.Millisecond
-	restoreContainerResolveTimeout   = 30 * time.Second
-	restoreContainerResolveKeySuffix = "resolve"
+	restoreContainerResolveInterval = 50 * time.Millisecond
+	restoreContainerResolveTimeout  = 30 * time.Second
 )
 
 // NewNodeController creates the node-local controller that runs inside snapshot-agent.
@@ -296,6 +295,10 @@ func (w *NodeController) reconcileRestorePod(ctx context.Context, pod *corev1.Po
 }
 
 // maybeStartRestoreForContainer starts one restore worker per fresh container.
+// If pod.Status doesn't carry the ContainerID yet (the kubelet's status patch
+// can lag container exec by 1-5 s), poll the OCI runtime directly. The
+// resolveKey lease prevents the chatty pod-informer from fanning out into
+// many concurrent pollers for the same (pod, container).
 func (w *NodeController) maybeStartRestoreForContainer(
 	ctx context.Context,
 	pod *corev1.Pod,
@@ -303,13 +306,20 @@ func (w *NodeController) maybeStartRestoreForContainer(
 	checkpointID string,
 	podKey string,
 ) {
-	containerID := restoreContainerIDFromStatus(pod, containerName)
-	if containerID == "" {
-		w.maybeStartRestoreContainerResolver(ctx, pod.DeepCopy(), containerName, checkpointID, podKey)
+	if containerID := restoreContainerIDFromStatus(pod, containerName); containerID != "" {
+		w.startRestoreForContainer(ctx, pod, containerName, containerID, checkpointID, podKey)
 		return
 	}
 
-	w.startRestoreForContainer(ctx, pod, containerName, containerID, checkpointID, podKey)
+	resolveKey := fmt.Sprintf("%s/%s/resolve", podKey, containerName)
+	if !w.tryAcquire(resolveKey) {
+		return
+	}
+	w.log.V(1).Info("Restore pod has no running container in Kubernetes status yet; polling node runtime",
+		"pod", podKey,
+		"container", containerName,
+	)
+	go w.pollForContainerID(ctx, pod.DeepCopy(), containerName, checkpointID, podKey, resolveKey)
 }
 
 func restoreContainerIDFromStatus(pod *corev1.Pod, containerName string) string {
@@ -321,51 +331,32 @@ func restoreContainerIDFromStatus(pod *corev1.Pod, containerName string) string 
 	return ""
 }
 
-func (w *NodeController) maybeStartRestoreContainerResolver(
+func (w *NodeController) pollForContainerID(
 	ctx context.Context,
 	pod *corev1.Pod,
-	containerName string,
-	checkpointID string,
-	podKey string,
+	containerName, checkpointID, podKey, resolveKey string,
 ) {
-	resolveKey := fmt.Sprintf("%s/%s/%s", podKey, containerName, restoreContainerResolveKeySuffix)
-	if !w.tryAcquire(resolveKey) {
-		return
-	}
-
-	w.log.V(1).Info("Restore pod has no running container in Kubernetes status yet; resolving via node runtime",
-		"pod", podKey,
-		"container", containerName,
-	)
-
-	go func() {
-		defer w.release(resolveKey)
-
-		resolveCtx, cancel := context.WithTimeout(ctx, restoreContainerResolveTimeout)
-		defer cancel()
-
-		ticker := time.NewTicker(restoreContainerResolveInterval)
-		defer ticker.Stop()
-
-		for {
-			containerID, err := w.runtime.ResolveContainerIDByPod(resolveCtx, pod.Name, pod.Namespace, containerName)
-			if err == nil && containerID != "" {
-				w.startRestoreForContainer(ctx, pod, containerName, containerID, checkpointID, podKey)
+	defer w.release(resolveKey)
+	deadline := time.After(restoreContainerResolveTimeout)
+	tick := time.NewTicker(restoreContainerResolveInterval)
+	defer tick.Stop()
+	for {
+		select {
+		case <-deadline:
+			w.log.V(1).Info("Timed out polling node runtime for restore container",
+				"pod", podKey,
+				"container", containerName,
+			)
+			return
+		case <-ctx.Done():
+			return
+		case <-tick.C:
+			if id, err := w.runtime.ResolveContainerIDByPod(ctx, pod.Name, pod.Namespace, containerName); err == nil && id != "" {
+				w.startRestoreForContainer(ctx, pod, containerName, id, checkpointID, podKey)
 				return
-			}
-
-			select {
-			case <-resolveCtx.Done():
-				w.log.V(1).Info("Timed out resolving restore container via node runtime",
-					"pod", podKey,
-					"container", containerName,
-					"err", err,
-				)
-				return
-			case <-ticker.C:
 			}
 		}
-	}()
+	}
 }
 
 func (w *NodeController) startRestoreForContainer(

--- a/deploy/snapshot/internal/controller/controller.go
+++ b/deploy/snapshot/internal/controller/controller.go
@@ -52,8 +52,9 @@ type checkpointLocations struct {
 }
 
 const (
-	restoreContainerResolveInterval = 50 * time.Millisecond
-	restoreContainerResolveTimeout  = 30 * time.Second
+	restoreContainerResolveInterval       = 50 * time.Millisecond
+	restoreContainerResolveAttemptTimeout = 1 * time.Second
+	restoreContainerResolveTimeout        = 30 * time.Second
 )
 
 // NewNodeController creates the node-local controller that runs inside snapshot-agent.
@@ -335,12 +336,27 @@ func (w *NodeController) pollForContainerID(
 	containerName, checkpointID, podKey, resolveKey string,
 ) {
 	defer w.release(resolveKey)
-	deadline := time.After(restoreContainerResolveTimeout)
+	deadlineAt := time.Now().Add(restoreContainerResolveTimeout)
+	deadline := time.NewTimer(time.Until(deadlineAt))
+	defer deadline.Stop()
 	tick := time.NewTicker(restoreContainerResolveInterval)
 	defer tick.Stop()
 	for {
+		resolveCtx, cancel := restoreContainerResolveAttemptContext(ctx, deadlineAt)
+		containerID, err := w.runtime.ResolveContainerIDByPod(resolveCtx, pod.Name, pod.Namespace, containerName)
+		cancel()
+		if err == nil && containerID != "" {
+			w.log.V(1).Info("Resolved restore container via node runtime",
+				"pod", podKey,
+				"container", containerName,
+				"container_id", containerID,
+			)
+			w.startRestoreForContainer(ctx, pod, containerName, containerID, checkpointID, podKey)
+			return
+		}
+
 		select {
-		case <-deadline:
+		case <-deadline.C:
 			w.log.V(1).Info("Timed out polling node runtime for restore container",
 				"pod", podKey,
 				"container", containerName,
@@ -349,12 +365,16 @@ func (w *NodeController) pollForContainerID(
 		case <-ctx.Done():
 			return
 		case <-tick.C:
-			if id, err := w.runtime.ResolveContainerIDByPod(ctx, pod.Name, pod.Namespace, containerName); err == nil && id != "" {
-				w.startRestoreForContainer(ctx, pod, containerName, id, checkpointID, podKey)
-				return
-			}
 		}
 	}
+}
+
+func restoreContainerResolveAttemptContext(ctx context.Context, deadlineAt time.Time) (context.Context, context.CancelFunc) {
+	attemptDeadline := time.Now().Add(restoreContainerResolveAttemptTimeout)
+	if deadlineAt.Before(attemptDeadline) {
+		attemptDeadline = deadlineAt
+	}
+	return context.WithDeadline(ctx, attemptDeadline)
 }
 
 func (w *NodeController) startRestoreForContainer(
@@ -615,6 +635,12 @@ func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, contai
 				return fmt.Errorf("failed to persist terminal restore status %q: %w", value, err)
 			}
 			return fmt.Errorf("failed to update restore status %q: %w", value, err)
+		}
+		if value == snapshotprotocol.RestoreStatusCompleted || value == snapshotprotocol.RestoreStatusFailed {
+			// Keep the attempt key for this controller lifetime so a stale
+			// runtime resolver cannot start the same container again after
+			// terminal status has been persisted.
+			releaseOnExit = false
 		}
 		return nil
 	}

--- a/deploy/snapshot/internal/controller/controller_test.go
+++ b/deploy/snapshot/internal/controller/controller_test.go
@@ -732,6 +732,46 @@ func TestReconcileRestorePodResolvesContainerBeforePodStatus(t *testing.T) {
 	t.Fatalf("expected RestoreRequested event after node-runtime container resolution; actions=%#v", clientset.Actions())
 }
 
+func TestPollForContainerIDSkipsWhenRestoreAttemptAlreadyHeld(t *testing.T) {
+	checkpointID := "abc123"
+	labels := map[string]string{
+		snapshotprotocol.CheckpointIDLabel: checkpointID,
+	}
+	stalePod := makePod("test-pod", "default", testNodeName, corev1.PodRunning, false, labels, nil)
+	stalePod.Status.ContainerStatuses = nil
+
+	w := makeTestController(t)
+	w.runtime = &fakeRuntime{containerIDByPod: testContainerID}
+	clientset := w.clientset.(*fake.Clientset)
+	dir := filepath.Join(w.config.Storage.BasePath, checkpointID, "versions", snapshotprotocol.DefaultCheckpointArtifactVersion)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("failed to create checkpoint dir: %v", err)
+	}
+
+	resolveKey := "default/test-pod/main/resolve"
+	restoreAttemptKey := "default/test-pod/main/" + testContainerID
+	w.inFlight[resolveKey] = struct{}{}
+	w.inFlight[restoreAttemptKey] = struct{}{}
+	w.pollForContainerID(context.Background(), stalePod, "main", checkpointID, "default/test-pod", resolveKey)
+
+	if _, held := w.inFlight[resolveKey]; held {
+		t.Fatal("expected resolver key to be released")
+	}
+	if _, held := w.inFlight[restoreAttemptKey]; !held {
+		t.Fatal("expected existing restore attempt key to remain held")
+	}
+	for _, action := range clientset.Actions() {
+		create, ok := action.(clientgotesting.CreateAction)
+		if !ok || create.GetResource().Resource != "events" {
+			continue
+		}
+		event, ok := create.GetObject().(*corev1.Event)
+		if ok && event.Reason == "RestoreRequested" {
+			t.Fatalf("stale resolver should not start restore while attempt key is held; actions=%#v", clientset.Actions())
+		}
+	}
+}
+
 func TestRunCheckpointKeepsLeaseAndInFlightOnTerminalStatusPatchFailure(t *testing.T) {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/deploy/snapshot/internal/controller/controller_test.go
+++ b/deploy/snapshot/internal/controller/controller_test.go
@@ -28,13 +28,21 @@ const testNodeName = "test-node"
 const testContainerID = "test-container"
 
 // fakeRuntime is a minimal Runtime implementation for controller reconciliation
-// tests. Resolve paths aren't exercised by the reconciler filter tests.
-type fakeRuntime struct{}
+// tests.
+type fakeRuntime struct {
+	containerIDByPod string
+}
 
 var _ snapshotruntime.Runtime = (*fakeRuntime)(nil)
 
 func (r *fakeRuntime) ResolveContainer(ctx context.Context, id string) (int, *specs.Spec, error) {
 	return 0, nil, errors.New("not implemented")
+}
+func (r *fakeRuntime) ResolveContainerIDByPod(ctx context.Context, pod, ns, ctr string) (string, error) {
+	if r.containerIDByPod != "" {
+		return r.containerIDByPod, nil
+	}
+	return "", errors.New("not implemented")
 }
 func (r *fakeRuntime) ResolveContainerByPod(ctx context.Context, pod, ns, ctr string) (int, *specs.Spec, error) {
 	return 0, nil, errors.New("not implemented")
@@ -688,6 +696,40 @@ func TestReconcileRestorePodRejectsTargetNameThatCannotFitStatusAnnotation(t *te
 	if len(w.inFlight) != 0 {
 		t.Fatalf("expected restore not to start for overlong annotation key, got inFlight=%v", w.inFlight)
 	}
+}
+
+func TestReconcileRestorePodResolvesContainerBeforePodStatus(t *testing.T) {
+	labels := map[string]string{
+		snapshotprotocol.CheckpointIDLabel: "abc123",
+	}
+	w := makeTestController(t)
+	w.runtime = &fakeRuntime{containerIDByPod: testContainerID}
+	clientset := w.clientset.(*fake.Clientset)
+
+	pod := makePod("test-pod", "default", testNodeName, corev1.PodRunning, false, labels, nil)
+	pod.Status.ContainerStatuses = nil
+	dir := filepath.Join(w.config.Storage.BasePath, "abc123", "versions", snapshotprotocol.DefaultCheckpointArtifactVersion)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("failed to create checkpoint dir: %v", err)
+	}
+
+	w.reconcileRestorePod(context.Background(), pod)
+
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		for _, action := range clientset.Actions() {
+			create, ok := action.(clientgotesting.CreateAction)
+			if !ok || create.GetResource().Resource != "events" {
+				continue
+			}
+			event, ok := create.GetObject().(*corev1.Event)
+			if ok && event.Reason == "RestoreRequested" {
+				return
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("expected RestoreRequested event after node-runtime container resolution; actions=%#v", clientset.Actions())
 }
 
 func TestRunCheckpointKeepsLeaseAndInFlightOnTerminalStatusPatchFailure(t *testing.T) {

--- a/deploy/snapshot/internal/controller/controller_test.go
+++ b/deploy/snapshot/internal/controller/controller_test.go
@@ -113,6 +113,9 @@ func makePod(name, namespace, nodeName string, phase corev1.PodPhase, ready bool
 		Status: corev1.PodStatus{
 			Phase:      phase,
 			Conditions: conditions,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "main", Ready: ready, ContainerID: "containerd://" + testContainerID},
+			},
 		},
 	}
 }

--- a/deploy/snapshot/internal/controller/util.go
+++ b/deploy/snapshot/internal/controller/util.go
@@ -48,13 +48,13 @@ func podFromInformerObj(obj interface{}) (*corev1.Pod, bool) {
 	return pod, ok
 }
 
-func isPodReady(pod *corev1.Pod) bool {
+func isContainerReady(pod *corev1.Pod, containerName string) bool {
 	if pod.Status.Phase != corev1.PodRunning {
 		return false
 	}
-	for _, cond := range pod.Status.Conditions {
-		if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
-			return true
+	for _, status := range pod.Status.ContainerStatuses {
+		if status.Name == containerName {
+			return status.Ready
 		}
 	}
 	return false

--- a/deploy/snapshot/internal/runtime/oci_containerd.go
+++ b/deploy/snapshot/internal/runtime/oci_containerd.go
@@ -51,6 +51,32 @@ func (r *ContainerdRuntime) ResolveContainer(ctx context.Context, containerID st
 }
 
 func (r *ContainerdRuntime) ResolveContainerByPod(ctx context.Context, podName, podNamespace, containerName string) (int, *specs.Spec, error) {
+	container, err := r.findRunningContainerByPod(ctx, podName, podNamespace, containerName)
+	if err != nil {
+		return 0, nil, err
+	}
+	ctx = namespaces.WithNamespace(ctx, k8sNamespace)
+
+	task, err := container.Task(ctx, nil)
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to get task for container %s (pod %s/%s): %w", container.ID(), podNamespace, podName, err)
+	}
+	spec, err := container.Spec(ctx)
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to get spec for container %s (pod %s/%s): %w", container.ID(), podNamespace, podName, err)
+	}
+	return int(task.Pid()), spec, nil
+}
+
+func (r *ContainerdRuntime) ResolveContainerIDByPod(ctx context.Context, podName, podNamespace, containerName string) (string, error) {
+	container, err := r.findRunningContainerByPod(ctx, podName, podNamespace, containerName)
+	if err != nil {
+		return "", err
+	}
+	return container.ID(), nil
+}
+
+func (r *ContainerdRuntime) findRunningContainerByPod(ctx context.Context, podName, podNamespace, containerName string) (containerd.Container, error) {
 	ctx = namespaces.WithNamespace(ctx, k8sNamespace)
 
 	filter := fmt.Sprintf("labels.\"io.kubernetes.pod.name\"==%s,labels.\"io.kubernetes.pod.namespace\"==%s,labels.\"io.kubernetes.container.name\"==%s",
@@ -58,24 +84,18 @@ func (r *ContainerdRuntime) ResolveContainerByPod(ctx context.Context, podName, 
 
 	containers, err := r.client.Containers(ctx, filter)
 	if err != nil {
-		return 0, nil, fmt.Errorf("failed to list containers for pod %s/%s: %w", podNamespace, podName, err)
+		return nil, fmt.Errorf("failed to list containers for pod %s/%s: %w", podNamespace, podName, err)
 	}
 	if len(containers) == 0 {
-		return 0, nil, fmt.Errorf("no container found for pod %s/%s container %s", podNamespace, podName, containerName)
+		return nil, fmt.Errorf("no container found for pod %s/%s container %s", podNamespace, podName, containerName)
 	}
 
 	// During container restarts, both the old and new container may be listed;
 	// pick the first with a live task.
 	for _, c := range containers {
-		task, err := c.Task(ctx, nil)
-		if err != nil {
-			continue
+		if _, err := c.Task(ctx, nil); err == nil {
+			return c, nil
 		}
-		spec, err := c.Spec(ctx)
-		if err != nil {
-			continue
-		}
-		return int(task.Pid()), spec, nil
 	}
-	return 0, nil, fmt.Errorf("no running container found for pod %s/%s container %s (%d candidates)", podNamespace, podName, containerName, len(containers))
+	return nil, fmt.Errorf("no running container found for pod %s/%s container %s (%d candidates)", podNamespace, podName, containerName, len(containers))
 }

--- a/deploy/snapshot/internal/runtime/oci_crio.go
+++ b/deploy/snapshot/internal/runtime/oci_crio.go
@@ -48,6 +48,31 @@ func (r *CRIORuntime) ResolveContainer(ctx context.Context, id string) (int, *sp
 // ResolveContainerByPod picks the first RUNNING container matching the pod +
 // container-name label filter; errors if none qualify.
 func (r *CRIORuntime) ResolveContainerByPod(ctx context.Context, podName, podNamespace, containerName string) (int, *specs.Spec, error) {
+	running, err := r.findRunningContainerByPod(ctx, podName, podNamespace, containerName)
+	if err != nil {
+		return 0, nil, err
+	}
+	ctx, cancel := context.WithTimeout(ctx, crioCallTimeout)
+	defer cancel()
+
+	statusResp, err := r.svc.ContainerStatus(ctx, running.GetId(), true)
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to get status for container %s (pod %s/%s): %w", running.GetId(), podNamespace, podName, err)
+	}
+	return parseCRIOStatus(running.GetId(), statusResp.GetInfo())
+}
+
+func (r *CRIORuntime) ResolveContainerIDByPod(ctx context.Context, podName, podNamespace, containerName string) (string, error) {
+	running, err := r.findRunningContainerByPod(ctx, podName, podNamespace, containerName)
+	if err != nil {
+		return "", err
+	}
+	return running.GetId(), nil
+}
+
+// findRunningContainerByPod picks the first RUNNING container matching the pod
+// + container-name label filter; errors if none qualify.
+func (r *CRIORuntime) findRunningContainerByPod(ctx context.Context, podName, podNamespace, containerName string) (*runtimeapi.Container, error) {
 	ctx, cancel := context.WithTimeout(ctx, crioCallTimeout)
 	defer cancel()
 
@@ -60,10 +85,10 @@ func (r *CRIORuntime) ResolveContainerByPod(ctx context.Context, podName, podNam
 	}
 	containers, err := r.svc.ListContainers(ctx, filter)
 	if err != nil {
-		return 0, nil, fmt.Errorf("failed to list containers for pod %s/%s: %w", podNamespace, podName, err)
+		return nil, fmt.Errorf("failed to list containers for pod %s/%s: %w", podNamespace, podName, err)
 	}
 	if len(containers) == 0 {
-		return 0, nil, fmt.Errorf("no container found for pod %s/%s container %s", podNamespace, podName, containerName)
+		return nil, fmt.Errorf("no container found for pod %s/%s container %s", podNamespace, podName, containerName)
 	}
 
 	var running *runtimeapi.Container
@@ -74,14 +99,9 @@ func (r *CRIORuntime) ResolveContainerByPod(ctx context.Context, podName, podNam
 		}
 	}
 	if running == nil {
-		return 0, nil, fmt.Errorf("no running container found for pod %s/%s container %s (%d candidates)", podNamespace, podName, containerName, len(containers))
+		return nil, fmt.Errorf("no running container found for pod %s/%s container %s (%d candidates)", podNamespace, podName, containerName, len(containers))
 	}
-
-	statusResp, err := r.svc.ContainerStatus(ctx, running.GetId(), true)
-	if err != nil {
-		return 0, nil, fmt.Errorf("failed to get status for container %s (pod %s/%s): %w", running.GetId(), podNamespace, podName, err)
-	}
-	return parseCRIOStatus(running.GetId(), statusResp.GetInfo())
+	return running, nil
 }
 
 // crioInfo is the JSON shape CRI-O writes into ContainerStatus.Info["info"]

--- a/deploy/snapshot/internal/runtime/runtime.go
+++ b/deploy/snapshot/internal/runtime/runtime.go
@@ -24,6 +24,7 @@ const (
 // Resolve methods return non-nil *specs.Spec with PID > 0 on success, or an error.
 type Runtime interface {
 	ResolveContainer(ctx context.Context, id string) (int, *specs.Spec, error)
+	ResolveContainerIDByPod(ctx context.Context, pod, ns, ctr string) (string, error)
 	ResolveContainerByPod(ctx context.Context, pod, ns, ctr string) (int, *specs.Spec, error)
 	Close() error
 }


### PR DESCRIPTION
## What

Two snapshot-agent fixes extracted from #8833, both targeting `main` directly.

**1. Checkpoint gates on the target container, not the whole Pod.**
`reconcileCheckpointPod` previously waited for `isPodReady`, which AND's every container's readiness. With probe-less GMS sidecars in the Job Pod, that flipped to True before the engine was actually warm (risk: CRIU-dumping a half-initialized process), and flipped back to False when the saver exited cleanly (risk: missing the polling window entirely). Now gates on the configured workload container's `Ready` status only.

**2. Restore resolves container ID from the OCI runtime when `pod.Status` lags.**
When a restore-target Pod goes Running, the kubelet takes 1-5 s to publish `ContainerStatuses`. Previously the reconciler just logged and waited for the next informer event, costing seconds of restore latency. Now adds a `Runtime.ResolveContainerIDByPod` (containerd + CRI-O) and, when pod.Status doesn't carry the ID, polls the node runtime every 50 ms with a 30 s deadline under the existing `tryAcquire` lease.

## Why

Both are correctness/latency bugs that the rest of the #8833 split shouldn't have to carry. They're independent of #9514 (GMS sidecar lifecycle) and have no dependency on each other.

## Not in scope

GMS-side lifecycle changes, the 100→50 ms sentinel poll, inter-pod GMS restore, and engine-side admission — all stay in follow-up PRs.

## Validation

`GOOS=linux CGO_ENABLED=0 go build ./...`, `go vet ./internal/...`, and `go test -c ./internal/controller/...` all clean.