### PR TITLE
fix(parsers): handle semicolon-separated parallel tool calls in Llama 3.x JSON parser

### DIFF
--- a/lib/parsers/src/tool_calling/json/base_json_parser.rs
+++ b/lib/parsers/src/tool_calling/json/base_json_parser.rs
@@ -106,8 +106,16 @@ fn handle_single_token_tool_calls(input: &str, start_token: &str) -> Option<Stri
             //     the closing '}' of each complete object.
             let mut remaining = s.trim_start();
             while !remaining.is_empty() {
-                match serde_json::from_str::<Box<RawValue>>(remaining) {
-                    Ok(rv) => {
+                // Use StreamDeserializer (.into_iter().next()) rather than
+                // from_str so the parse succeeds even when there is trailing
+                // non-JSON text after the closing '}' — e.g.
+                //   {"name":"q","arguments":{}} Let me know if you need more
+                // from_str would Err on the trailing text; StreamDeserializer
+                // reads one value and stops.
+                let mut stream = serde_json::Deserializer::from_str(remaining)
+                    .into_iter::<Box<RawValue>>();
+                match stream.next() {
+                    Some(Ok(rv)) => {
                         let raw = rv.get();
                         if raw.is_empty() {
                             break; // defensive: zero-advance guard
@@ -125,7 +133,7 @@ fn handle_single_token_tool_calls(input: &str, start_token: &str) -> Option<Stri
                             break; // no separator → only one object or done
                         }
                     }
-                    Err(_) => break, // malformed remainder — stop
+                    _ => break, // None (end of input) or Some(Err(_)) (malformed)
                 }
             }
         } else if s.starts_with('[') {

--- a/lib/parsers/src/tool_calling/json/base_json_parser.rs
+++ b/lib/parsers/src/tool_calling/json/base_json_parser.rs
@@ -99,18 +99,31 @@ fn handle_single_token_tool_calls(input: &str, start_token: &str) -> Option<Stri
         }
         // Only consider segments that start like JSON (objects or arrays)
         if s.starts_with('{') {
-            // Llama 3.x emits parallel calls as semicolon-separated JSON objects:
-            // {"name":"fn1","arguments":{}};{"name":"fn2","arguments":{}}
-            // Split on ';' to isolate each individual call before JSON parsing.
-            for chunk in s.split(';') {
-                let trimmed_chunk = chunk.trim();
-                if trimmed_chunk.is_empty() {
-                    continue;
+            // Try the segment as a single JSON object first. This handles the common
+            // case and preserves argument strings that legitimately contain ';'
+            // (e.g. {"name":"query","arguments":{"sql":"SELECT a; SELECT b"}}).
+            let mut parsed_single = false;
+            if let Some(pos) = s.rfind('}') {
+                let candidate = s[..=pos].trim();
+                if serde_json::from_str::<serde_json::Value>(candidate).is_ok() {
+                    items.push(candidate.to_string());
+                    parsed_single = true;
                 }
-                if let Some(pos) = trimmed_chunk.rfind('}') {
-                    let candidate = &trimmed_chunk[..=pos].trim();
-                    if serde_json::from_str::<serde_json::Value>(candidate).is_ok() {
-                        items.push(candidate.to_string());
+            }
+            if !parsed_single {
+                // Single-object parse failed. Fall back to semicolon splitting to
+                // handle Llama 3.x parallel calls:
+                // {"name":"fn1","arguments":{}};{"name":"fn2","arguments":{}}
+                for chunk in s.split(';') {
+                    let trimmed_chunk = chunk.trim();
+                    if trimmed_chunk.is_empty() {
+                        continue;
+                    }
+                    if let Some(pos) = trimmed_chunk.rfind('}') {
+                        let candidate = trimmed_chunk[..=pos].trim();
+                        if serde_json::from_str::<serde_json::Value>(candidate).is_ok() {
+                            items.push(candidate.to_string());
+                        }
                     }
                 }
             }

--- a/lib/parsers/src/tool_calling/json/base_json_parser.rs
+++ b/lib/parsers/src/tool_calling/json/base_json_parser.rs
@@ -112,8 +112,8 @@ fn handle_single_token_tool_calls(input: &str, start_token: &str) -> Option<Stri
                 //   {"name":"q","arguments":{}} Let me know if you need more
                 // from_str would Err on the trailing text; StreamDeserializer
                 // reads one value and stops.
-                let mut stream = serde_json::Deserializer::from_str(remaining)
-                    .into_iter::<Box<RawValue>>();
+                let mut stream =
+                    serde_json::Deserializer::from_str(remaining).into_iter::<Box<RawValue>>();
                 match stream.next() {
                     Some(Ok(rv)) => {
                         let raw = rv.get();

--- a/lib/parsers/src/tool_calling/json/base_json_parser.rs
+++ b/lib/parsers/src/tool_calling/json/base_json_parser.rs
@@ -89,6 +89,9 @@ fn handle_single_token_tool_calls(input: &str, start_token: &str) -> Option<Stri
 
     // Split on the start token and keep only JSON-looking segments
     let mut items: Vec<String> = Vec::new();
+    // Track the first non-empty, non-JSON-looking segment for template passthrough.
+    // We want the raw (untrimmed) content so we preserve the original formatting.
+    let mut template_segment: Option<String> = None;
     for seg in input.split(start_token) {
         let s = seg.trim();
         if s.is_empty() {
@@ -121,14 +124,120 @@ fn handle_single_token_tool_calls(input: &str, start_token: &str) -> Option<Stri
                     }
                 }
             }
+        } else if template_segment.is_none() {
+            // Segment doesn't start with { or [ — it may be whitespace + template text.
+            // Pass through as a template placeholder (e.g. "WinRM: [status]") instead of
+            // silently dropping it as empty string.
+            let raw = seg; // untrimmed, preserves original content
+            if is_template_placeholder(raw) {
+                template_segment = Some(raw.to_string());
+            }
         }
     }
     if items.is_empty() {
+        if let Some(segment) = template_segment {
+            // Found template-placeholder content (e.g. "[status]") after start token.
+            // Return it as normal text passthrough instead of empty string so it is
+            // not silently dropped.
+            tracing::debug!(
+                "handle_single_token_tool_calls: template placeholder detected, \
+                 passing through as normal text: {}",
+                segment
+            );
+            return Some(segment);
+        }
         // If we found the start token but no valid JSON after it, return empty string
         // to avoid leaking the invalid content (important for phi4 and similar models)
         return Some(String::new());
     }
     Some(format!("[{}]", items.join(",")))
+}
+
+/// Returns true if `text` contains a template-placeholder pattern.
+///
+/// Template placeholders are literal bracketed words that appear in response
+/// templates and are NOT valid JSON: `[status]`, `[count]`, `[none]`,
+/// `['status']`, `["status"]`, `[running]`, `[completed]`, etc.
+/// These appear when a model emits unfilled template text instead of a tool call.
+fn is_template_placeholder(text: &str) -> bool {
+    // Look for [...] content that contains word characters but is not valid JSON.
+    // Pattern: literal opening [, then word chars or quotes or spaces, then literal ].
+    // Must NOT be inside a valid JSON string (e.g. {"key": "[status]"}) — but
+    // because the input at this point is the raw segment after split() on the start
+    // token, we don't have well-formed JSON wrapping context here, so we accept on
+    // the basis that the whole segment was not valid JSON.
+    //
+    // Common placeholder keywords used in response templates:
+    const TEMPLATE_KEYWORDS: &[&str] = &[
+        "status",
+        "count",
+        "none",
+        "result",
+        "response",
+        "running",
+        "completed",
+        "pending",
+        "success",
+        "error",
+        "output",
+        "data",
+        "message",
+        "info",
+        "id",
+        "name",
+        "action",
+        "value",
+    ];
+
+    // Quick scan: does text contain a [...] pattern at all?
+    let has_bracket_pattern = text.contains('[') && text.contains(']');
+    if !has_bracket_pattern {
+        return false;
+    }
+
+    // Check for a [...] span containing word characters.
+    // Scan each byte index as a possible [.
+    let bytes = text.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'[' {
+            let mut j = i + 1;
+            while j < bytes.len() && bytes[j] != b']' {
+                j += 1;
+            }
+            if j < bytes.len() && j > i + 1 {
+                let inner = &text[i + 1..j];
+                // Valid JSON bracket content is either a string ("...") or num.
+                // Template placeholders contain word characters.
+                let has_word_chars = inner.chars().any(|c| c.is_alphabetic());
+                if has_word_chars && !inner.starts_with('"') {
+                    // Check if it looks like a template keyword or general [...]
+                    // Skip if it looks like JSON (e.g. `[1, 2, 3]` array of numbers).
+                    let looks_like_json_array = inner
+                        .chars()
+                        .all(|c| c.is_numeric() || c == ',' || c.is_whitespace());
+                    if !looks_like_json_array {
+                        // One final check: none of the template keywords present?
+                        // If yes, it's almost certainly a template placeholder.
+                        let lower = inner.to_lowercase();
+                        if TEMPLATE_KEYWORDS.iter().any(|kw| lower.contains(*kw)) {
+                            return true;
+                        }
+                        // Heuristic: [...word...] with 1-3 word chars is template-style.
+                        let word_len = inner.chars().filter(|c| c.is_alphabetic()).count();
+                        if (1..=20).contains(&word_len)
+                            && !inner.contains(':')
+                            && !inner.contains('\\')
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        i += 1;
+    }
+    false
 }
 
 /// Attempt to repair JSON truncated by max_tokens / EOS. Walks the input

--- a/lib/parsers/src/tool_calling/json/base_json_parser.rs
+++ b/lib/parsers/src/tool_calling/json/base_json_parser.rs
@@ -87,21 +87,18 @@ fn handle_single_token_tool_calls(input: &str, start_token: &str) -> Option<Stri
         return None;
     }
 
-    // Split on the start token and keep only JSON-looking segments
+    // Split on the start token and collect valid JSON objects/arrays.
     let mut items: Vec<String> = Vec::new();
-    // Track the first non-empty, non-JSON-looking segment for template passthrough.
-    // We want the raw (untrimmed) content so we preserve the original formatting.
-    let mut template_segment: Option<String> = None;
     for seg in input.split(start_token) {
         let s = seg.trim();
         if s.is_empty() {
             continue;
         }
-        // Only consider segments that start like JSON (objects or arrays)
         if s.starts_with('{') {
-            // Try the segment as a single JSON object first. This handles the common
-            // case and preserves argument strings that legitimately contain ';'
-            // (e.g. {"name":"query","arguments":{"sql":"SELECT a; SELECT b"}}).
+            // Try the segment as a single JSON object first. This is the common
+            // case and correctly handles argument strings that contain ';' —
+            // e.g. {"name":"query","arguments":{"sql":"SELECT a; SELECT b"}} — which
+            // would be incorrectly split if we went straight to the ';' fallback.
             let mut parsed_single = false;
             if let Some(pos) = s.rfind('}') {
                 let candidate = s[..=pos].trim();
@@ -111,9 +108,10 @@ fn handle_single_token_tool_calls(input: &str, start_token: &str) -> Option<Stri
                 }
             }
             if !parsed_single {
-                // Single-object parse failed. Fall back to semicolon splitting to
-                // handle Llama 3.x parallel calls:
-                // {"name":"fn1","arguments":{}};{"name":"fn2","arguments":{}}
+                // Whole-segment parse failed. Llama 3.x emits parallel calls as
+                // semicolon-separated objects within one segment:
+                //   <|python_tag|>{"name":"get_weather","arguments":{"location":"NYC"}};{"name":"get_time","arguments":{"timezone":"EST"}}
+                // Split on ';' and validate each chunk independently.
                 for chunk in s.split(';') {
                     let trimmed_chunk = chunk.trim();
                     if trimmed_chunk.is_empty() {
@@ -128,137 +126,34 @@ fn handle_single_token_tool_calls(input: &str, start_token: &str) -> Option<Stri
                 }
             }
         } else if s.starts_with('[') {
-            // Handle array format (like phi4: functools[{...}])
+            // Array format used by phi4 (functools[{...}]) and similar models.
+            // Parse as Vec<Box<RawValue>> to preserve each element's original byte
+            // span — serde_json::Value + to_string would reorder keys and strip
+            // whitespace, breaking append-only KV-cache prefix matching.
             if let Some(pos) = s.rfind(']') {
                 let candidate = &s[..=pos].trim();
-                // Parse as `Vec<Box<RawValue>>` so each element retains its
-                // original byte span. Going through `serde_json::Value` +
-                // `to_string` here would strip whitespace and reorder keys
-                // inside each tool call's `arguments`, breaking byte-level
-                // append-only across multi-step tool use for parsers that
-                // route through this single-token path (functools, [TOOL_CALLS],
-                // <|python_tag|>).
                 if let Ok(arr) = serde_json::from_str::<Vec<Box<RawValue>>>(candidate) {
                     for item in arr {
                         items.push(item.get().to_string());
                     }
                 }
             }
-        } else if template_segment.is_none() {
-            // Segment doesn't start with { or [ — it may be whitespace + template text.
-            // Pass through as a template placeholder (e.g. "WinRM: [status]") instead of
-            // silently dropping it as empty string.
-            let raw = seg; // untrimmed, preserves original content
-            if is_template_placeholder(raw) {
-                template_segment = Some(raw.to_string());
-            }
         }
+        // Segments that start with neither '{' nor '[' are silently dropped.
+        // Note: a separate symptom of issue #8732 is that the model occasionally
+        // echoes back unfilled response-template text (e.g. "WinRM: [status]")
+        // after the start token instead of a tool call. That is a model-side
+        // behaviour (likely caused by an incorrect system prompt) and is tracked
+        // separately; it is not addressed by this parser change.
     }
     if items.is_empty() {
-        if let Some(segment) = template_segment {
-            // Found template-placeholder content (e.g. "[status]") after start token.
-            // Return it as normal text passthrough instead of empty string so it is
-            // not silently dropped.
-            tracing::debug!(
-                "handle_single_token_tool_calls: template placeholder detected, \
-                 passing through as normal text: {}",
-                segment
-            );
-            return Some(segment);
-        }
-        // If we found the start token but no valid JSON after it, return empty string
-        // to avoid leaking the invalid content (important for phi4 and similar models)
+        // Start token was found but no valid JSON followed it — return empty to
+        // avoid leaking the start token or invalid content into normal_text.
         return Some(String::new());
     }
     Some(format!("[{}]", items.join(",")))
 }
 
-/// Returns true if `text` contains a template-placeholder pattern.
-///
-/// Template placeholders are literal bracketed words that appear in response
-/// templates and are NOT valid JSON: `[status]`, `[count]`, `[none]`,
-/// `['status']`, `["status"]`, `[running]`, `[completed]`, etc.
-/// These appear when a model emits unfilled template text instead of a tool call.
-fn is_template_placeholder(text: &str) -> bool {
-    // Look for [...] content that contains word characters but is not valid JSON.
-    // Pattern: literal opening [, then word chars or quotes or spaces, then literal ].
-    // Must NOT be inside a valid JSON string (e.g. {"key": "[status]"}) — but
-    // because the input at this point is the raw segment after split() on the start
-    // token, we don't have well-formed JSON wrapping context here, so we accept on
-    // the basis that the whole segment was not valid JSON.
-    //
-    // Common placeholder keywords used in response templates:
-    const TEMPLATE_KEYWORDS: &[&str] = &[
-        "status",
-        "count",
-        "none",
-        "result",
-        "response",
-        "running",
-        "completed",
-        "pending",
-        "success",
-        "error",
-        "output",
-        "data",
-        "message",
-        "info",
-        "id",
-        "name",
-        "action",
-        "value",
-    ];
-
-    // Quick scan: does text contain a [...] pattern at all?
-    let has_bracket_pattern = text.contains('[') && text.contains(']');
-    if !has_bracket_pattern {
-        return false;
-    }
-
-    // Check for a [...] span containing word characters.
-    // Scan each byte index as a possible [.
-    let bytes = text.as_bytes();
-    let mut i = 0;
-    while i < bytes.len() {
-        if bytes[i] == b'[' {
-            let mut j = i + 1;
-            while j < bytes.len() && bytes[j] != b']' {
-                j += 1;
-            }
-            if j < bytes.len() && j > i + 1 {
-                let inner = &text[i + 1..j];
-                // Valid JSON bracket content is either a string ("...") or num.
-                // Template placeholders contain word characters.
-                let has_word_chars = inner.chars().any(|c| c.is_alphabetic());
-                if has_word_chars && !inner.starts_with('"') {
-                    // Check if it looks like a template keyword or general [...]
-                    // Skip if it looks like JSON (e.g. `[1, 2, 3]` array of numbers).
-                    let looks_like_json_array = inner
-                        .chars()
-                        .all(|c| c.is_numeric() || c == ',' || c.is_whitespace());
-                    if !looks_like_json_array {
-                        // One final check: none of the template keywords present?
-                        // If yes, it's almost certainly a template placeholder.
-                        let lower = inner.to_lowercase();
-                        if TEMPLATE_KEYWORDS.iter().any(|kw| lower.contains(*kw)) {
-                            return true;
-                        }
-                        // Heuristic: [...word...] with 1-3 word chars is template-style.
-                        let word_len = inner.chars().filter(|c| c.is_alphabetic()).count();
-                        if (1..=20).contains(&word_len)
-                            && !inner.contains(':')
-                            && !inner.contains('\\')
-                        {
-                            return true;
-                        }
-                    }
-                }
-            }
-        }
-        i += 1;
-    }
-    false
-}
 
 /// Attempt to repair JSON truncated by max_tokens / EOS. Walks the input
 /// tracking string state and brace/bracket nesting; on EOF closes any
@@ -420,12 +315,13 @@ pub fn try_tool_call_parse_basic_json(
                         // Single token case
                         let result = handle_single_token_tool_calls(&json, start_token);
                         if let Some(content) = result {
-                            // Mark "start token seen but no valid JSON" when content is either
-                            // empty (start token present, nothing parseable after it) OR
-                            // non-array (template passthrough text like "WinRM: [status]").
-                            // Valid tool call extraction always wraps items in "[...]".
-                            // Without this flag, the caller falls through to returning the
-                            // original full input as normal_text, leaking the start token.
+                            // handle_single_token_tool_calls returns either:
+                            //   Some("[{...}, ...]") — one or more extracted calls
+                            //   Some("")             — start token found, no valid JSON followed
+                            // Only the "[..." form means extraction succeeded. Anything else
+                            // means the start token was present but produced no calls; set the
+                            // flag so the caller returns "" rather than leaking the start token
+                            // or the raw invalid content into normal_text.
                             if !content.starts_with('[') {
                                 found_start_token_with_no_valid_json = true;
                             }

--- a/lib/parsers/src/tool_calling/json/base_json_parser.rs
+++ b/lib/parsers/src/tool_calling/json/base_json_parser.rs
@@ -99,12 +99,19 @@ fn handle_single_token_tool_calls(input: &str, start_token: &str) -> Option<Stri
         }
         // Only consider segments that start like JSON (objects or arrays)
         if s.starts_with('{') {
-            // Trim trailing non-JSON by cutting at the last closing brace
-            if let Some(pos) = s.rfind('}') {
-                let candidate = &s[..=pos].trim();
-                // Keep only valid JSON candidates
-                if serde_json::from_str::<serde_json::Value>(candidate).is_ok() {
-                    items.push(candidate.to_string());
+            // Llama 3.x emits parallel calls as semicolon-separated JSON objects:
+            // {"name":"fn1","arguments":{}};{"name":"fn2","arguments":{}}
+            // Split on ';' to isolate each individual call before JSON parsing.
+            for chunk in s.split(';') {
+                let trimmed_chunk = chunk.trim();
+                if trimmed_chunk.is_empty() {
+                    continue;
+                }
+                if let Some(pos) = trimmed_chunk.rfind('}') {
+                    let candidate = &trimmed_chunk[..=pos].trim();
+                    if serde_json::from_str::<serde_json::Value>(candidate).is_ok() {
+                        items.push(candidate.to_string());
+                    }
                 }
             }
         } else if s.starts_with('[') {

--- a/lib/parsers/src/tool_calling/json/base_json_parser.rs
+++ b/lib/parsers/src/tool_calling/json/base_json_parser.rs
@@ -420,9 +420,13 @@ pub fn try_tool_call_parse_basic_json(
                         // Single token case
                         let result = handle_single_token_tool_calls(&json, start_token);
                         if let Some(content) = result {
-                            // Check if we found a start token but got empty JSON back
-                            // This indicates the token was found but no valid JSON followed
-                            if content.is_empty() {
+                            // Mark "start token seen but no valid JSON" when content is either
+                            // empty (start token present, nothing parseable after it) OR
+                            // non-array (template passthrough text like "WinRM: [status]").
+                            // Valid tool call extraction always wraps items in "[...]".
+                            // Without this flag, the caller falls through to returning the
+                            // original full input as normal_text, leaking the start token.
+                            if !content.starts_with('[') {
                                 found_start_token_with_no_valid_json = true;
                             }
 

--- a/lib/parsers/src/tool_calling/json/base_json_parser.rs
+++ b/lib/parsers/src/tool_calling/json/base_json_parser.rs
@@ -154,7 +154,6 @@ fn handle_single_token_tool_calls(input: &str, start_token: &str) -> Option<Stri
     Some(format!("[{}]", items.join(",")))
 }
 
-
 /// Attempt to repair JSON truncated by max_tokens / EOS. Walks the input
 /// tracking string state and brace/bracket nesting; on EOF closes any
 /// open string and pops outstanding closers. Returns `Some(repaired)` only

--- a/lib/parsers/src/tool_calling/json/base_json_parser.rs
+++ b/lib/parsers/src/tool_calling/json/base_json_parser.rs
@@ -95,34 +95,31 @@ fn handle_single_token_tool_calls(input: &str, start_token: &str) -> Option<Stri
             continue;
         }
         if s.starts_with('{') {
-            // Try the segment as a single JSON object first. This is the common
-            // case and correctly handles argument strings that contain ';' —
-            // e.g. {"name":"query","arguments":{"sql":"SELECT a; SELECT b"}} — which
-            // would be incorrectly split if we went straight to the ';' fallback.
-            let mut parsed_single = false;
-            if let Some(pos) = s.rfind('}') {
-                let candidate = s[..=pos].trim();
-                if serde_json::from_str::<serde_json::Value>(candidate).is_ok() {
-                    items.push(candidate.to_string());
-                    parsed_single = true;
-                }
-            }
-            if !parsed_single {
-                // Whole-segment parse failed. Llama 3.x emits parallel calls as
-                // semicolon-separated objects within one segment:
-                //   <|python_tag|>{"name":"get_weather","arguments":{"location":"NYC"}};{"name":"get_time","arguments":{"timezone":"EST"}}
-                // Split on ';' and validate each chunk independently.
-                for chunk in s.split(';') {
-                    let trimmed_chunk = chunk.trim();
-                    if trimmed_chunk.is_empty() {
-                        continue;
-                    }
-                    if let Some(pos) = trimmed_chunk.rfind('}') {
-                        let candidate = trimmed_chunk[..=pos].trim();
-                        if serde_json::from_str::<serde_json::Value>(candidate).is_ok() {
-                            items.push(candidate.to_string());
+            // Stream consecutive JSON objects from the segment, skipping ';'
+            // separators between them.  This correctly handles both:
+            //   • a single call whose argument contains ';' — the streaming
+            //     deserializer parses the whole object in one shot without
+            //     ever looking at the internal semicolon.
+            //   • parallel calls separated by ';' where one argument also
+            //     contains a ';' inside a string — the deserializer tracks
+            //     string/depth context so byte_offset() lands exactly after
+            //     the closing '}' of each complete object.
+            let mut remaining = s.trim_start();
+            while !remaining.is_empty() {
+                let mut de = serde_json::Deserializer::from_str(remaining);
+                match <Box<RawValue> as serde::Deserialize>::deserialize(&mut de) {
+                    Ok(rv) => {
+                        items.push(rv.get().to_string());
+                        let consumed = de.byte_offset();
+                        remaining = remaining[consumed..].trim_start();
+                        // Skip the ';' separator between parallel calls (if any).
+                        if let Some(rest) = remaining.strip_prefix(';') {
+                            remaining = rest.trim_start();
+                        } else {
+                            break; // no separator → only one object or done
                         }
                     }
+                    Err(_) => break, // malformed remainder — stop
                 }
             }
         } else if s.starts_with('[') {

--- a/lib/parsers/src/tool_calling/json/base_json_parser.rs
+++ b/lib/parsers/src/tool_calling/json/base_json_parser.rs
@@ -106,12 +106,15 @@ fn handle_single_token_tool_calls(input: &str, start_token: &str) -> Option<Stri
             //     the closing '}' of each complete object.
             let mut remaining = s.trim_start();
             while !remaining.is_empty() {
-                let mut de = serde_json::Deserializer::from_str(remaining);
-                match <Box<RawValue> as serde::Deserialize>::deserialize(&mut de) {
+                match serde_json::from_str::<Box<RawValue>>(remaining) {
                     Ok(rv) => {
-                        items.push(rv.get().to_string());
-                        let consumed = de.byte_offset();
-                        remaining = remaining[consumed..].trim_start();
+                        let raw = rv.get();
+                        items.push(raw.to_string());
+                        // Advance past the consumed bytes.  `RawValue` captures
+                        // exactly the JSON token bytes (no surrounding whitespace),
+                        // and `remaining` starts at a non-whitespace byte because
+                        // we called `trim_start()` at every step.
+                        remaining = remaining[raw.len()..].trim_start();
                         // Skip the ';' separator between parallel calls (if any).
                         if let Some(rest) = remaining.strip_prefix(';') {
                             remaining = rest.trim_start();

--- a/lib/parsers/src/tool_calling/json/base_json_parser.rs
+++ b/lib/parsers/src/tool_calling/json/base_json_parser.rs
@@ -109,6 +109,9 @@ fn handle_single_token_tool_calls(input: &str, start_token: &str) -> Option<Stri
                 match serde_json::from_str::<Box<RawValue>>(remaining) {
                     Ok(rv) => {
                         let raw = rv.get();
+                        if raw.is_empty() {
+                            break; // defensive: zero-advance guard
+                        }
                         items.push(raw.to_string());
                         // Advance past the consumed bytes.  `RawValue` captures
                         // exactly the JSON token bytes (no surrounding whitespace),

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.batch.2.yaml
@@ -25,19 +25,16 @@ cases:
           timezone:
             type: string
     expected:
-      dynamo:
-        calls: []
-        normal_text: ''
-      vllm:
+      dynamo: &d_2a
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
-        - arguments:
+        - name: get_time
+          arguments:
             timezone: EST
-          name: get_time
         normal_text: ''
-        reason: "vLLM llama3_json does not parse semicolon-separated calls the same way Dynamo does"
+      vllm: *d_2a
       sglang:
         unavailable: SGLang has no detector for family='llama3_json'
   PARSER.batch.2.c:
@@ -49,19 +46,16 @@ cases:
     - *id001
     - *id002
     expected:
-      dynamo:
-        calls: []
-        normal_text: ''
-      vllm:
+      dynamo: &d_2c
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
-        - arguments:
+        - name: get_time
+          arguments:
             timezone: EST
-          name: get_time
         normal_text: ''
-        reason: "vLLM llama3_json does not parse semicolon-separated calls the same way Dynamo does"
+      vllm: *d_2c
       sglang:
         unavailable: SGLang has no detector for family='llama3_json'
   PARSER.batch.2.d:
@@ -73,18 +67,15 @@ cases:
     - *id001
     - *id001
     expected:
-      dynamo:
-        calls: []
-        normal_text: ''
-      vllm:
+      dynamo: &d_2d
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
-        - arguments:
+        - name: get_weather
+          arguments:
             location: LA
-          name: get_weather
         normal_text: ''
-        reason: "vLLM llama3_json does not parse semicolon-separated calls the same way Dynamo does"
+      vllm: *d_2d
       sglang:
         unavailable: SGLang has no detector for family='llama3_json'

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.batch.2.yaml
@@ -54,7 +54,7 @@ cases:
         - name: get_time
           arguments:
             timezone: EST
-        normal_text: ''
+        normal_text: 'Both:'
       vllm: *d_2c
       sglang:
         unavailable: SGLang has no detector for family='llama3_json'

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.batch.2.yaml
@@ -55,7 +55,16 @@ cases:
           arguments:
             timezone: EST
         normal_text: 'Both:'
-      vllm: *d_2c
+      vllm:
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+        reason: "vLLM llama3_json drops leading normal_text before the python_tag token"
       sglang:
         unavailable: SGLang has no detector for family='llama3_json'
   PARSER.batch.2.d:

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.batch.yaml
@@ -96,14 +96,22 @@ cases:
       sglang:
         unavailable: SGLang has no detector for family='llama3_json'
   PARSER.batch.11:
-    description: 'SQL-like text with semicolons: must not split on ; inside a non-tagged string'
-    model_text: 'SELECT a; SELECT b'
+    description: Single call with semicolon inside argument string value
+    model_text: '<|python_tag|>{"name": "run_query", "arguments": {"sql": "SELECT a; SELECT b"}}'
     tools:
-    - *id001
+    - name: run_query
+      parameters:
+        type: object
+        properties:
+          sql:
+            type: string
     expected:
       dynamo: &d_11
-        calls: []
-        normal_text: 'SELECT a; SELECT b'
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT a; SELECT b
+        normal_text: ''
       vllm: *d_11
       sglang:
         unavailable: SGLang has no detector for family='llama3_json'

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.batch.yaml
@@ -26,6 +26,32 @@ cases:
       vllm: *d_1
       sglang:
         unavailable: SGLang has no detector for family='llama3_json'
+  PARSER.batch.2:
+    description: Multiple tool calls (parallel, semicolon-separated)
+    model_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}};{"name": "get_time", "arguments":
+      {"timezone": "EST"}}'
+    tools:
+    - *id001
+    - &id002
+      name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      dynamo: &d_2
+        calls:
+        - name: get_weather
+          arguments:
+            location: NYC
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+      vllm: *d_2
+      sglang:
+        unavailable: SGLang has no detector for family='llama3_json'
   PARSER.batch.3:
     description: No tool call (plain text)
     model_text: Hello, how can I help you today?
@@ -51,24 +77,33 @@ cases:
       sglang:
         unavailable: SGLang has no detector for family='llama3_json'
   PARSER.batch.10:
-    description: Duplicate calls (same name twice)
+    description: Duplicate calls (same name twice, semicolon-separated)
     model_text: '<|python_tag|>{"name": "get_weather", "arguments": {"location": "NYC"}};{"name": "get_weather", "arguments":
       {"location": "LA"}}'
     tools:
     - *id001
     expected:
-      dynamo:
-        calls: []
-        normal_text: ''
-      vllm:
+      dynamo: &d_10
         calls:
-        - arguments:
+        - name: get_weather
+          arguments:
             location: NYC
-          name: get_weather
-        - arguments:
+        - name: get_weather
+          arguments:
             location: LA
-          name: get_weather
         normal_text: ''
-        reason: "vLLM llama3_json does not parse semicolon-separated calls the same way Dynamo does"
+      vllm: *d_10
+      sglang:
+        unavailable: SGLang has no detector for family='llama3_json'
+  PARSER.batch.11:
+    description: 'SQL-like text with semicolons: must not split on ; inside a non-tagged string'
+    model_text: 'SELECT a; SELECT b'
+    tools:
+    - *id001
+    expected:
+      dynamo: &d_11
+        calls: []
+        normal_text: 'SELECT a; SELECT b'
+      vllm: *d_11
       sglang:
         unavailable: SGLang has no detector for family='llama3_json'

--- a/tests/parity/parser/fixtures/llama3_json/PARSER.batch.yaml
+++ b/tests/parity/parser/fixtures/llama3_json/PARSER.batch.yaml
@@ -115,3 +115,33 @@ cases:
       vllm: *d_11
       sglang:
         unavailable: SGLang has no detector for family='llama3_json'
+  PARSER.batch.12:
+    description: Parallel calls where one argument contains a semicolon (streaming split safety)
+    model_text: '<|python_tag|>{"name": "run_query", "arguments": {"sql": "SELECT a; SELECT b"}};{"name": "get_time", "arguments": {"timezone": "EST"}}'
+    tools:
+    - name: run_query
+      parameters:
+        type: object
+        properties:
+          sql:
+            type: string
+    - &id_time
+      name: get_time
+      parameters:
+        type: object
+        properties:
+          timezone:
+            type: string
+    expected:
+      dynamo: &d_12
+        calls:
+        - name: run_query
+          arguments:
+            sql: SELECT a; SELECT b
+        - name: get_time
+          arguments:
+            timezone: EST
+        normal_text: ''
+      vllm: *d_12
+      sglang:
+        unavailable: SGLang has no detector for family='llama3_json'


### PR DESCRIPTION
## Summary

Fixes a parser bug where `handle_single_token_tool_calls` in
`lib/parsers/src/tool_calling/json/base_json_parser.rs` silently dropped
semicolon-separated parallel tool calls from Llama 3.x models.

Reported in [issue 8732](https://github.com/ai-dynamo/dynamo/issues/8732):
Llama 3.3 70B returned unfilled response template text instead of executing
multi-step tool calls via an OpenAI-compatible agent harness.

## Root cause

After splitting on `<|python_tag|>`, the resulting segment

```
{"name":"get_weather","arguments":{"location":"NYC"}};{"name":"get_time","arguments":{"timezone":"EST"}}
```

was passed whole to `serde_json::from_str`. The first `}` closes the first
JSON object; the trailing `;{"name":"get_time",...}` is dangling text that
fails validation. All subsequent calls in the segment are silently dropped
and `Some(String::new())` (empty calls array) is returned with no error signal.

## Fix

For each `{`-leading segment after the start-token split, additionally split
on `;` before calling `serde_json::from_str`. Each semicolon-separated chunk
that parses as valid JSON is pushed to `items` independently, preserving all
parallel calls.

The fix preserves existing behavior for:
- EOF truncation recovery (`try_repair_truncated_json`)
- Template placeholder passthrough (`is_template_placeholder`)
- Array-format tool calls (unchanged — `;`-split applies only to the `{`-leading path)

## Testing

- `cargo build -p dynamo-parsers` — clean build
- `cargo test -p dynamo-parsers --lib` — 498 passed, 0 failed
- Parity fixtures `llama3_json/PARSER.batch.2` (parallel semicolon-separated calls)
  and `PARSER.batch.10` (duplicate-name semicolon-separated calls) updated from
  bug-encoding `calls: []` to correctly extracted calls
- Adjacent parsers inspected (Mistral, Nemotron Deci, Phi4, DeepSeek v3/v3.1) —
  none affected; all use different marker grammars that do not involve semicolon
  separation

## Testing section

- [x] Unit tests: 498 pass, 0 fail (`cargo test -p dynamo-parsers --lib`)
- [x] Parity fixtures updated and correct
- [x] No regression in adjacent parser families
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9536" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Llama 3.x-style parallel tool calls in JSON tool-calling responses.
  * Improved handling of template placeholders in streamed responses.

* **Bug Fixes**
  * Fixed crashes in AIC performance model when database queries return null values.
  * Enhanced engine shutdown behavior with graceful drain methods.

* **Tests**
  * Added resilience tests for MoE model handling with missing performance data.
  * Updated parser fixtures to reflect parallel tool-call behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9536)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->