### PR TITLE
feat(kv-router): expose router overlap scores

### DIFF
--- a/components/src/dynamo/router/README.md
+++ b/components/src/dynamo/router/README.md
@@ -32,12 +32,13 @@ All router options use the `--router-*` prefix (e.g., `--router-block-size`, `--
 
 ## Architecture
 
-The standalone router exposes two endpoints via the Dynamo runtime:
+The standalone router exposes three endpoints via the Dynamo runtime:
 
 1. **`generate`**: Routes requests to the best worker and streams back generation results (KV-aware routing).
 2. **`best_worker_id`**: Given token IDs, returns the best worker ID for the request without routing; useful for debugging or custom routing logic.
+3. **`get_overlap_scores`**: Given token IDs, returns per-worker/per-DP-rank matched block counts for device, host-pinned, disk, and configured shared-cache tiers without routing.
 
-Clients call the `generate` endpoint to stream completions, or call `best_worker_id` to decide which worker to use and then contact that worker directly.
+Clients call the `generate` endpoint to stream completions, call `best_worker_id` to decide which worker to use and then contact that worker directly, or call `get_overlap_scores` when an external scheduler wants the raw tiered overlap signal.
 
 ## Example: Manual Disaggregated Serving (Alternative Setup)
 

--- a/components/src/dynamo/router/__main__.py
+++ b/components/src/dynamo/router/__main__.py
@@ -155,6 +155,28 @@ class StandaloneRouterHandler:
 
         yield worker_id
 
+    async def get_overlap_scores(self, request):
+        """
+        Get per-worker KV overlap by storage tier without routing the request.
+
+        This endpoint returns matched blocks for each worker_id/dp_rank pair.
+        Shared-cache hits are request-global and are also reported per row as
+        blocks beyond that rank's device-local prefix.
+        """
+        if self.kv_router is None:
+            logger.error("KvRouter not initialized - cannot get overlap scores")
+            raise RuntimeError("Router not initialized")
+
+        scores = await self.kv_router.get_overlap_scores(
+            request["token_ids"],
+            request.get("router_config_override"),
+            request.get("block_mm_infos"),
+            request.get("lora_name"),
+            request.get("include_shared", True),
+        )
+
+        yield scores
+
 
 def parse_args(argv=None) -> DynamoRouterConfig:
     """Parse router CLI arguments (compatibility shim delegating to args.parse_args)."""
@@ -200,6 +222,9 @@ async def worker(runtime: DistributedRuntime):
     # Create endpoints
     generate_endpoint = runtime.endpoint(f"{config.namespace}.router.generate")
     best_worker_endpoint = runtime.endpoint(f"{config.namespace}.router.best_worker_id")
+    overlap_scores_endpoint = runtime.endpoint(
+        f"{config.namespace}.router.get_overlap_scores"
+    )
 
     logger.debug("Starting to serve endpoints...")
 
@@ -213,6 +238,11 @@ async def worker(runtime: DistributedRuntime):
             ),
             best_worker_endpoint.serve_endpoint(
                 handler.best_worker_id,
+                graceful_shutdown=True,
+                metrics_labels=[("service", "router")],
+            ),
+            overlap_scores_endpoint.serve_endpoint(
+                handler.get_overlap_scores,
                 graceful_shutdown=True,
                 metrics_labels=[("service", "router")],
             ),

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -1192,6 +1192,48 @@ impl KvRouter {
         })
     }
 
+    #[pyo3(signature = (token_ids, router_config_override=None, block_mm_infos=None, lora_name=None, include_shared=true))]
+    fn get_overlap_scores<'p>(
+        &self,
+        py: Python<'p>,
+        token_ids: Vec<u32>,
+        router_config_override: Option<PyObject>,
+        block_mm_infos: Option<PyObject>,
+        lora_name: Option<String>,
+        include_shared: bool,
+    ) -> PyResult<Bound<'p, PyAny>> {
+        let router_config_override = if let Some(obj) = router_config_override {
+            let override_config: RouterConfigOverride =
+                depythonize(obj.bind(py)).map_err(to_pyerr)?;
+            Some(override_config)
+        } else {
+            None
+        };
+        let block_mm_infos = block_mm_infos
+            .map(|obj| depythonize_block_mm_infos(obj.bind(py)))
+            .transpose()?;
+        let chooser = self.inner.chooser.clone();
+
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let scores = chooser
+                .get_overlap_scores(
+                    &token_ids,
+                    router_config_override.as_ref(),
+                    block_mm_infos.as_deref(),
+                    lora_name.as_deref(),
+                    include_shared,
+                )
+                .await
+                .map_err(to_pyerr)?;
+
+            Python::with_gil(|py| {
+                pythonize(py, &scores)
+                    .map(|obj| obj.unbind())
+                    .map_err(to_pyerr)
+            })
+        })
+    }
+
     /// Dump all events from the KV router's indexer as a JSON string
     fn dump_events<'p>(&self, py: Python<'p>) -> PyResult<Bound<'p, PyAny>> {
         let chooser = self.inner.chooser.clone();

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -2113,6 +2113,33 @@ class KvRouter:
         """
         ...
 
+    async def get_overlap_scores(
+        self,
+        token_ids: List[int],
+        router_config_override: Optional[JsonLike] = None,
+        block_mm_infos: Optional[List[Optional[Dict[str, Any]]]] = None,
+        lora_name: Optional[str] = None,
+        include_shared: bool = True,
+    ) -> Dict[str, Any]:
+        """
+        Get per-worker KV overlap by storage tier.
+
+        Args:
+            token_ids: List of token IDs to evaluate.
+            router_config_override: Optional router configuration override for
+                                   score-credit fields.
+            block_mm_infos: Optional block-level multimodal metadata aligned to
+                           request blocks.
+            lora_name: Optional LoRA adapter name for adapter-aware matching.
+            include_shared: Whether to query the configured shared cache.
+
+        Returns:
+            A dictionary containing block_size, num_blocks, shared_cache, and
+            workers. Each worker row is keyed by worker_id and dp_rank and
+            reports device, host-pinned, disk, and shared-cache overlap blocks.
+        """
+        ...
+
     async def dump_events(self) -> str:
         """
         Dump all events from the KV router's indexer.

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -15,8 +15,8 @@ use dynamo_kv_router::{
     protocols::KV_EVENT_SUBJECT,
     protocols::{
         BlockExtraInfo, BlockHashOptions, DpRank, LocalBlockHash, PrefillLoadHint, RouterEvent,
-        RouterRequest, RouterResponse, TokensWithHashes, WorkerId, WorkerWithDpRank,
-        compute_block_hash_for_seq,
+        RouterRequest, RouterResponse, TokensWithHashes, WorkerConfigLike, WorkerId,
+        WorkerWithDpRank, compute_block_hash_for_seq,
     },
     scheduling::TierOverlapBlocks,
 };
@@ -32,6 +32,7 @@ use dynamo_runtime::{
     traits::DistributedRuntimeProvider,
 };
 use futures::stream;
+use serde::Serialize;
 use tracing::Instrument;
 use validator::Validate;
 
@@ -109,6 +110,35 @@ struct CacheHitEstimates {
 pub(crate) struct BestMatchDetails {
     pub worker: WorkerWithDpRank,
     pub cache_hit: WorkerCacheHitEstimate,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct WorkerOverlapScore {
+    pub worker_id: WorkerId,
+    pub dp_rank: DpRank,
+    pub device_blocks: usize,
+    pub host_pinned_blocks: usize,
+    pub disk_blocks: usize,
+    pub host_pinned_extension_blocks: usize,
+    pub disk_extension_blocks: usize,
+    pub shared_beyond_device_blocks: Option<u32>,
+    pub router_credit_blocks: f64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SharedCacheOverlapScore {
+    pub enabled: bool,
+    pub total_hit_blocks: u32,
+    pub ranges: Vec<(u32, u32)>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct OverlapScoresResponse {
+    pub block_size: u32,
+    pub num_blocks: usize,
+    pub workers: Vec<WorkerOverlapScore>,
+    pub shared_cache: SharedCacheOverlapScore,
 }
 
 fn cache_hit_weight_for_tier(
@@ -232,6 +262,32 @@ fn tier_overlap_blocks_from_tiered_matches(
     }
 
     tier_overlap_blocks
+}
+
+fn shared_cache_overlap_score(
+    enabled: bool,
+    hits: Option<&dynamo_kv_router::protocols::SharedCacheHits>,
+    error: Option<String>,
+) -> SharedCacheOverlapScore {
+    let Some(hits) = hits else {
+        return SharedCacheOverlapScore {
+            enabled,
+            total_hit_blocks: 0,
+            ranges: Vec::new(),
+            error,
+        };
+    };
+
+    SharedCacheOverlapScore {
+        enabled,
+        total_hit_blocks: hits.total_hits,
+        ranges: hits
+            .ranges
+            .iter()
+            .map(|range| (range.start, range.end))
+            .collect(),
+        error,
+    }
 }
 
 /// Generates a dp_rank-specific endpoint name for the worker KV indexer query service.
@@ -860,6 +916,137 @@ where
         ))
     }
 
+    /// Return per-worker KV overlap by storage tier.
+    ///
+    /// Device, host-pinned, and disk values are keyed by `(worker_id, dp_rank)`.
+    /// Shared-cache hits are global to the request, so each worker row reports
+    /// only the shared blocks beyond that rank's device-local prefix.
+    pub async fn get_overlap_scores(
+        &self,
+        tokens: &[u32],
+        router_config_override: Option<&RouterConfigOverride>,
+        block_mm_infos: Option<&[Option<BlockExtraInfo>]>,
+        lora_name: Option<&str>,
+        include_shared: bool,
+    ) -> Result<OverlapScoresResponse, KvRouterError> {
+        let hash_options = BlockHashOptions {
+            block_mm_infos,
+            lora_name,
+            is_eagle: Some(self.is_eagle),
+        };
+        let block_hashes = compute_block_hash_for_seq(tokens, self.block_size, hash_options);
+        let num_blocks = block_hashes.len();
+
+        let tiered_matches = self.indexer.find_matches_by_tier(block_hashes).await?;
+
+        let (shared_hits, shared_error) = if include_shared {
+            if let Some(shared_cache) = self.shared_cache.as_ref() {
+                match shared_cache.check_blocks(tokens, self.block_size).await {
+                    Ok(hits) => (Some(hits), None),
+                    Err(err) => {
+                        tracing::warn!(error = %err, "Shared cache overlap query failed");
+                        (None, Some(err.to_string()))
+                    }
+                }
+            } else {
+                (None, None)
+            }
+        } else {
+            (None, None)
+        };
+
+        let shared_enabled = include_shared && self.shared_cache.is_some();
+        let shared_cache =
+            shared_cache_overlap_score(shared_enabled, shared_hits.as_ref(), shared_error);
+        let shared_hits = shared_hits.as_ref();
+
+        let overlap_score_credit = router_config_override
+            .and_then(|cfg| cfg.overlap_score_credit)
+            .unwrap_or(self.kv_router_config.overlap_score_credit);
+        let shared_cache_multiplier = router_config_override
+            .and_then(|cfg| cfg.shared_cache_multiplier)
+            .unwrap_or(self.kv_router_config.shared_cache_multiplier);
+
+        let device = &tiered_matches.device.overlap_scores;
+        let host_extension = tiered_matches
+            .lower_tier
+            .get(&dynamo_kv_router::protocols::StorageTier::HostPinned);
+
+        let mut disk_extensions: HashMap<WorkerWithDpRank, usize> = HashMap::new();
+        for tier in [
+            dynamo_kv_router::protocols::StorageTier::Disk,
+            dynamo_kv_router::protocols::StorageTier::External,
+        ] {
+            if let Some(matches) = tiered_matches.lower_tier.get(&tier) {
+                for (worker, hits) in &matches.hits {
+                    *disk_extensions.entry(*worker).or_default() += *hits;
+                }
+            }
+        }
+
+        let mut workers = HashSet::new();
+        {
+            let configs = self.workers_with_configs.borrow();
+            for (&worker_id, config) in configs.iter() {
+                let start_rank = config.data_parallel_start_rank();
+                let end_rank = start_rank + config.data_parallel_size();
+                for dp_rank in start_rank..end_rank {
+                    workers.insert(WorkerWithDpRank::new(worker_id, dp_rank));
+                }
+            }
+        }
+        workers.extend(device.scores.keys().copied());
+        if let Some(host_matches) = host_extension {
+            workers.extend(host_matches.hits.keys().copied());
+        }
+        workers.extend(disk_extensions.keys().copied());
+
+        let mut workers: Vec<_> = workers.into_iter().collect();
+        workers.sort_by_key(|worker| (worker.worker_id, worker.dp_rank));
+
+        let workers = workers
+            .into_iter()
+            .map(|worker| {
+                let device_blocks = device.scores.get(&worker).copied().unwrap_or(0) as usize;
+                let host_pinned_extension_blocks = host_extension
+                    .and_then(|matches| matches.hits.get(&worker))
+                    .copied()
+                    .unwrap_or(0);
+                let disk_extension_blocks = disk_extensions.get(&worker).copied().unwrap_or(0);
+                let host_pinned_blocks = device_blocks + host_pinned_extension_blocks;
+                let disk_blocks = host_pinned_blocks + disk_extension_blocks;
+                let shared_beyond_device_blocks =
+                    shared_hits.map(|hits| hits.hits_beyond(device_blocks as u32));
+                let shared_credit_blocks =
+                    shared_beyond_device_blocks.unwrap_or(0) as f64 * shared_cache_multiplier;
+                let router_credit_blocks = overlap_score_credit * device_blocks as f64
+                    + self.kv_router_config.host_cache_hit_weight
+                        * host_pinned_extension_blocks as f64
+                    + self.kv_router_config.disk_cache_hit_weight * disk_extension_blocks as f64
+                    + shared_credit_blocks;
+
+                WorkerOverlapScore {
+                    worker_id: worker.worker_id,
+                    dp_rank: worker.dp_rank,
+                    device_blocks,
+                    host_pinned_blocks,
+                    disk_blocks,
+                    host_pinned_extension_blocks,
+                    disk_extension_blocks,
+                    shared_beyond_device_blocks,
+                    router_credit_blocks,
+                }
+            })
+            .collect();
+
+        Ok(OverlapScoresResponse {
+            block_size: self.block_size,
+            num_blocks,
+            workers,
+            shared_cache,
+        })
+    }
+
     /// Dump all events from the indexer
     pub async fn dump_events(&self) -> Result<Vec<RouterEvent>, KvRouterError> {
         self.indexer.dump_events().await
@@ -1163,5 +1350,46 @@ mod tests {
 
         assert_eq!(worker, WorkerWithDpRank::from_worker_id(0));
         assert_eq!(overlap, 0);
+    }
+
+    #[tokio::test]
+    async fn test_get_overlap_scores_returns_tiered_rows_and_shared_hits() {
+        let router = make_test_router(
+            InspectingSelector {
+                expected_hits: None,
+                selected_worker: WorkerWithDpRank::from_worker_id(0),
+            },
+            Some(Box::new(FakeSharedCache {
+                #[allow(clippy::single_range_in_vec_init)]
+                hits: Some(dynamo_kv_router::protocols::SharedCacheHits::from_ranges(
+                    vec![0..2],
+                )),
+                should_error: false,
+            })),
+        )
+        .await;
+
+        let scores = router
+            .get_overlap_scores(&[11, 12, 21, 22], None, None, None, true)
+            .await
+            .unwrap();
+
+        assert_eq!(scores.block_size, 2);
+        assert_eq!(scores.num_blocks, 2);
+        assert!(scores.shared_cache.enabled);
+        assert_eq!(scores.shared_cache.total_hit_blocks, 2);
+        assert_eq!(scores.shared_cache.ranges, vec![(0, 2)]);
+        assert_eq!(scores.shared_cache.error, None);
+        assert_eq!(scores.workers.len(), 2);
+
+        for worker in scores.workers {
+            assert_eq!(worker.device_blocks, 0);
+            assert_eq!(worker.host_pinned_blocks, 0);
+            assert_eq!(worker.disk_blocks, 0);
+            assert_eq!(worker.host_pinned_extension_blocks, 0);
+            assert_eq!(worker.disk_extension_blocks, 0);
+            assert_eq!(worker.shared_beyond_device_blocks, Some(2));
+            assert!((worker.router_credit_blocks - 1.0).abs() < f64::EPSILON);
+        }
     }
 }

--- a/tests/router/common.py
+++ b/tests/router/common.py
@@ -57,6 +57,32 @@ def min_initial_workers_env(min_initial_workers: int):
             os.environ[MIN_INITIAL_WORKERS_ENV] = previous
 
 
+async def _assert_overlap_scores(
+    kv_router,
+    token_ids: list[int],
+    block_size: int,
+    expected_device_blocks: dict[tuple[int, int], int],
+    label: str,
+):
+    scores = await kv_router.get_overlap_scores(token_ids, include_shared=False)
+
+    assert scores["block_size"] == block_size
+    assert scores["num_blocks"] == len(token_ids) // block_size
+    assert scores["shared_cache"]["enabled"] is False
+
+    rows = {(row["worker_id"], row["dp_rank"]): row for row in scores["workers"]}
+
+    for key, expected in expected_device_blocks.items():
+        assert key in rows, f"{label}: missing overlap row for {key}"
+        row = rows[key]
+        assert (
+            row["device_blocks"] == expected
+        ), f"{label}: expected {key} device_blocks={expected}, got {row}"
+        assert row["host_pinned_extension_blocks"] == 0
+        assert row["disk_extension_blocks"] == 0
+        assert row["shared_beyond_device_blocks"] is None
+
+
 ########################################################
 # Test templates
 ########################################################
@@ -601,6 +627,12 @@ def _test_remote_indexer_decisions(
             (consumer_router, A + C + D + F, None, None, 2.0),
             (consumer_router, A + C + E + G, None, None, 2.0),
         ]
+        dp_a = dp_rank_a if dp_rank_a is not None else 0
+        dp_b = dp_rank_b if dp_rank_b is not None else 0
+        expected_overlap_by_request = {
+            4: {(worker_a_id, dp_a): 3, (worker_b_id, dp_b): 2},
+            5: {(worker_a_id, dp_a): 2, (worker_b_id, dp_b): 3},
+        }
 
         responses: list[dict[str, Optional[int]]] = []
         for i, (
@@ -624,6 +656,14 @@ def _test_remote_indexer_decisions(
                     else ""
                 ),
             )
+            if i in expected_overlap_by_request:
+                await _assert_overlap_scores(
+                    kv_router,
+                    token_ids,
+                    block_size,
+                    expected_overlap_by_request[i],
+                    f"request {i}",
+                )
             result = await send_request_via_python_kv_router(
                 kv_python_router=kv_router,
                 model_name=model_name,
@@ -2412,6 +2452,12 @@ def _test_router_decisions(
                 2.0,
             ),  # req5: router picks (worker b should win)
         ]
+        dp_a = dp_rank_a if dp_rank_a is not None else 0
+        dp_b = dp_rank_b if dp_rank_b is not None else 0
+        expected_overlap_by_request = {
+            4: {(worker_a_id, dp_a): 3, (worker_b_id, dp_b): 2},
+            5: {(worker_a_id, dp_a): 2, (worker_b_id, dp_b): 3},
+        }
 
         response_worker_ids: list[dict[str, Optional[int]]] = []
 
@@ -2424,6 +2470,16 @@ def _test_router_decisions(
                 if dp_override is not None:
                     log_msg += f", dp_rank={dp_override}"
             logger.info(log_msg)
+
+            request_idx = i + 1
+            if request_idx in expected_overlap_by_request:
+                await _assert_overlap_scores(
+                    kv_router,
+                    token_ids,
+                    block_size,
+                    expected_overlap_by_request[request_idx],
+                    f"request {request_idx}",
+                )
 
             result = await send_request_via_python_kv_router(
                 kv_python_router=kv_router,


### PR DESCRIPTION
Adds a KvRouter overlap-scores API and standalone router endpoint that returns per-worker tiered KV overlap, including optional shared-cache hit context.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9538" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `get_overlap_scores` endpoint to the router service for querying per-worker KV cache overlap statistics across storage tiers (device, host-pinned, disk, and shared-cache). Includes support for router configuration overrides and LoRA adapters.

* **Documentation**
  * Updated architecture documentation to reflect the new endpoint.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9538)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->