### PR TITLE
test(serve): assert cached_tokens on chat-processor + frontend-decode MM routes

### DIFF
--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -135,7 +135,7 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                 profiled_vram_gib=18.7,
                 requested_vllm_kv_cache_bytes=1_719_075_000,
                 env={"SINGLE_GPU": "true"},
-                tests=[MmCase(payload=make_image_payload(["green"]))],
+                tests=[MmCase(payload=make_image_payload_cached_tokens(["green"]))],
             ),
             # Frontend-decode variant: same `agg_multimodal_router.sh` as
             # `agg_router`, but `VLLM_EXTRA_ARGS=--frontend-decoding` so
@@ -155,7 +155,7 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                     "SINGLE_GPU": "true",
                     "VLLM_EXTRA_ARGS": "--frontend-decoding",
                 },
-                tests=[MmCase(payload=make_image_payload(["green"]))],
+                tests=[MmCase(payload=make_image_payload_cached_tokens(["green"]))],
             ),
             "e_pd": TopologyConfig(
                 marks=[pytest.mark.post_merge],


### PR DESCRIPTION
## Summary

- Upgrade the `agg_router_chat_processor` and `agg_router_frontend_decode` MM topology smoke tests to use `make_image_payload_cached_tokens`, matching the Rust-path sibling `agg_router`.
- Two-line change in `tests/serve/multimodal_profiles/vllm.py`. No test logic or infra change.

## Why

`agg_router_chat_processor` and `agg_router_frontend_decode` currently use `make_image_payload(["green"])`, which only asserts the response contains "green." A silent MM routing regression — e.g., `mm_routing_info` getting dropped or misinterpreted on the path — would still produce a "green" description from any worker the request happened to land on. Cache affinity silently lost, test passes.

The Rust-path sibling (`agg_router`) already uses `make_image_payload_cached_tokens(["green"])` which additionally asserts `usage.prompt_tokens_details.cached_tokens >= 1` on the second request. That catches exactly the regression class above. Both chat-processor and frontend-decode variants exercise the same MM-aware routing code path under different frontend modes, so they deserve the same assertion strength.

Both topologies stay on `post_merge` — no CI footprint change.

## Test plan

- [ ] `pytest tests/serve/test_vllm.py -v -k "mm_agg_router_chat_processor_qwen3-vl-2b" -m post_merge` passes in a dynamo dev container with a single GPU.
- [ ] `pytest tests/serve/test_vllm.py -v -k "mm_agg_router_frontend_decode_qwen3-vl-2b" -m post_merge` passes likewise.
- [ ] No new pre-merge CI cost (mark unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test validation for multimodal routing functionality to better verify cached token handling and key-value routing behavior in image-based scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9539)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->