### PR TITLE
docs(parsers): reorder parser tables and note TRTLLM/disagg fallback gaps

### DIFF
--- a/docs/reasoning/dynamo.md
+++ b/docs/reasoning/dynamo.md
@@ -41,21 +41,21 @@ require the opening tag to be present in the model output.
 | Parser Name | Models | Upstream name | Force-reasoning | Notes |
 |---|---|---|---|---|
 | `kimi_k25` | Kimi K2.5 | Dynamo-only | Yes | `<think>...</think>` with force-reasoning |
-| `qwen3` | Qwen3.5, QwQ-32B, Qwen3-Think, Qwen3-Coder | | No | `<think>...</think>` |
-| `deepseek_v4` | DeepSeek V4 Pro / Flash | vLLM: `deepseek_v4`; SGLang: `deepseek-v4` | No | `<think>...</think>`. Aliases: `deepseek-v4`, `deepseekv4` |
-| `basic` | Generic CoT models | Dynamo-only | No | Plain `<think>...</think>` |
-| `deepseek_r1` | DeepSeek R1, DeepSeek V3.1, DeepSeek V3.2 | | Yes | Pass explicitly for V3.1/V3.2 (no alias) |
-| `gemma4` | Google Gemma 4 (thinking models) | vLLM: `gemma4` | No | `<\|channel>thought\n...<channel\|>` with `thought\n` role label stripped. Aliases: `gemma-4` |
-| `glm45` | GLM-4.5, GLM-4.7 | Dynamo-only | No | Alias for `nemotron_deci`. `<think>...</think>` |
-| `gpt_oss` | gpt-oss-20b / -120b | Dynamo-only | No | Harmony channel reasoning format |
-| `granite` | Granite 3.x | | No | `Here's my thought process:` / `Here's my response:` |
 | `kimi` | Kimi K2 Instruct / Thinking | Dynamo-only | No | `◁think▷...◁/think▷` |
 | `minimax_append_think` | MiniMax M2 / M2.1 | Dynamo-only | No | Implicit opening `<think>` prepended |
-| `mistral` | Magistral | | Yes | `[THINK]...[/THINK]` |
+| `deepseek_v4` | DeepSeek V4 Pro / Flash | vLLM: `deepseek_v4`; SGLang: `deepseek-v4` | No | `<think>...</think>`. Aliases: `deepseek-v4`, `deepseekv4` |
+| `deepseek_r1` | DeepSeek R1, DeepSeek V3.1, DeepSeek V3.2 | | Yes | Pass explicitly for V3.1/V3.2 (no alias) |
+| `qwen3` | Qwen3.5, QwQ-32B, Qwen3-Think, Qwen3-Coder | | No | `<think>...</think>` |
+| `glm45` | GLM-4.5, GLM-4.7 | Dynamo-only | No | Alias for `nemotron_deci`. `<think>...</think>` |
 | `nemotron3` | Nemotron-3 / Mini | vLLM: `nemotron_v3` | Yes | Alias for `deepseek_r1`. Also accepts `nemotron_v3` |
 | `nemotron_deci` | Nemotron-Super / -Ultra / -Deci, Llama-Nemotron | Dynamo-only | No | `<think>...</think>` |
 | `nemotron_nano` | Nemotron-Nano | Dynamo-only | Yes | Alias for `deepseek_r1` |
+| `gemma4` | Google Gemma 4 (thinking models) | vLLM: `gemma4` | No | `<\|channel>thought\n...<channel\|>` with `thought\n` role label stripped. Aliases: `gemma-4` |
+| `gpt_oss` | gpt-oss-20b / -120b | Dynamo-only | No | Harmony channel reasoning format |
+| `mistral` | Magistral | | Yes | `[THINK]...[/THINK]` |
+| `granite` | Granite 3.x | | No | `Here's my thought process:` / `Here's my response:` |
 | `step3` | Step-3 / Step-3-Reasoning | Dynamo-only | Yes | `<think>...</think>` |
+| `basic` | Generic CoT models | Dynamo-only | No | Plain `<think>...</think>` |
 
 ## Common Parser Pairings
 

--- a/docs/reasoning/engine-fallback.md
+++ b/docs/reasoning/engine-fallback.md
@@ -15,9 +15,9 @@ the equivalent tool-call fallback, see
 
 > [!WARNING]
 > **Known Issue:** Engine-fallback reasoning parsing does not currently work
-> with [disaggregated serving](../features/disaggregated-serving/README.md).
-> Use the [Dynamo-native reasoning parser](dynamo.md) for disaggregated
-> deployments.
+> with [disaggregated serving](../features/disaggregated-serving/README.md)
+> (support coming soon). Use the [Dynamo-native reasoning parser](dynamo.md)
+> for disaggregated deployments today.
 
 ## Configurations
 
@@ -25,6 +25,7 @@ the equivalent tool-call fallback, see
 |---|---|---|---|---|
 | **vLLM chat processor** | `--dyn-chat-processor vllm --reasoning-parser <name>` | *(none)* | Yes | Parsing runs in vLLM's Python preprocessor. See [vLLM Chat Processor](../backends/vllm/vllm-chat-processor.md). |
 | **SGLang chat processor** | `--dyn-chat-processor sglang --reasoning-parser <name>` | *(none)* | Yes | Parsing runs in SGLang's Python preprocessor. See [SGLang Chat Processor](../backends/sglang/sglang-chat-processor.md). |
+| **TRTLLM chat processor** | *(work in progress)* | *(work in progress)* | -- | Engine-fallback support for TRTLLM is in progress. Use the [Dynamo-native reasoning parser](dynamo.md) for TRTLLM today. |
 
 > [!NOTE]
 > `--dyn-reasoning-parser` selects the **Dynamo-native** parser path, while

--- a/docs/tool-calling/dynamo.md
+++ b/docs/tool-calling/dynamo.md
@@ -47,24 +47,24 @@ parser exists for this format.
 | Parser Name | Models | Upstream name | Notes |
 |---|---|---|---|
 | `kimi_k2` | Kimi K2 Instruct/Thinking, Kimi K2.5 | | Pair with `--dyn-reasoning-parser kimi` or `kimi_k25` |
-| `qwen3_coder` | Qwen3.5, Qwen3-Coder | | XML `<tool_call><function=...>` |
+| `minimax_m2` | MiniMax M2 / M2.1 | vLLM: `minimax` | XML `<minimax:tool_call>` |
 | `deepseek_v4` | DeepSeek V4 Pro / Flash | vLLM: `deepseek_v4`; SGLang: `deepseekv4` | DSML tags (`<｜DSML｜tool_calls>...`). Aliases: `deepseek-v4`, `deepseekv4` |
 | `deepseek_v3` | DeepSeek V3, DeepSeek R1-0528+ | SGLang: `deepseekv3` | Special Unicode markers |
 | `deepseek_v3_1` | DeepSeek V3.1 | Dynamo-only | JSON separators |
 | `deepseek_v3_2` | DeepSeek V3.2+ | Dynamo-only | DSML tags (`<｜DSML｜function_calls>...`) |
-| `default` | *(fallback)* | Dynamo-only | Empty JSON config (no start/end tokens). Prefer a model-specific parser for production use. |
-| `gemma4` | Google Gemma 4 (thinking models) | vLLM: `gemma4` | Custom non-JSON grammar with `<\|"\|>` string delimiters and `<\|tool_call>...<tool_call\|>` markers. Aliases: `gemma-4`. Pair with `--dyn-reasoning-parser gemma4` and `--custom-jinja-template examples/chat_templates/gemma4_tool.jinja` |
+| `qwen3_coder` | Qwen3.5, Qwen3-Coder | | XML `<tool_call><function=...>` |
 | `glm47` | GLM-4.5, GLM-4.7 | Dynamo-only | XML `<arg_key>/<arg_value>` |
-| `harmony` | gpt-oss-20b / -120b | Dynamo-only | Harmony channel format |
-| `hermes` | Qwen2.5-\*, QwQ-32B, Qwen3-Instruct, Qwen3-Think, NousHermes-2/3 | vLLM: `qwen2_5`; SGLang: `qwen25` (for Qwen models) | `<tool_call>` JSON |
-| `jamba` | Jamba 1.5 / 1.6 / 1.7 | Dynamo-only | `<tool_calls>` JSON |
-| `llama3_json` | Llama 3 / 3.1 / 3.2 / 3.3 Instruct | | `<\|python_tag\|>` tool syntax |
-| `minimax_m2` | MiniMax M2 / M2.1 | vLLM: `minimax` | XML `<minimax:tool_call>` |
-| `mistral` | Mistral / Mixtral / Mistral-Nemo, Magistral | | `[TOOL_CALLS]...[/TOOL_CALLS]` |
 | `nemotron_deci` | Nemotron-Super / -Ultra / -Deci, Llama-Nemotron-Ultra / -Super | Dynamo-only | `<TOOLCALL>` JSON |
 | `nemotron_nano` | Nemotron-Nano | Dynamo-only | Alias for `qwen3_coder` |
+| `gemma4` | Google Gemma 4 (thinking models) | vLLM: `gemma4` | Custom non-JSON grammar with `<\|"\|>` string delimiters and `<\|tool_call>...<tool_call\|>` markers. Aliases: `gemma-4`. Pair with `--dyn-reasoning-parser gemma4` and `--custom-jinja-template examples/chat_templates/gemma4_tool.jinja` |
+| `harmony` | gpt-oss-20b / -120b | Dynamo-only | Harmony channel format |
+| `hermes` | Qwen2.5-\*, QwQ-32B, Qwen3-Instruct, Qwen3-Think, NousHermes-2/3 | vLLM: `qwen2_5`; SGLang: `qwen25` (for Qwen models) | `<tool_call>` JSON |
 | `phi4` | Phi-4, Phi-4-mini, Phi-4-mini-reasoning | vLLM: `phi4_mini_json` | `functools[...]` JSON |
 | `pythonic` | Llama 4 (Scout / Maverick) | | Python-list tool syntax |
+| `llama3_json` | Llama 3 / 3.1 / 3.2 / 3.3 Instruct | | `<\|python_tag\|>` tool syntax |
+| `mistral` | Mistral / Mixtral / Mistral-Nemo, Magistral | | `[TOOL_CALLS]...[/TOOL_CALLS]` |
+| `jamba` | Jamba 1.5 / 1.6 / 1.7 | Dynamo-only | `<tool_calls>` JSON |
+| `default` | *(fallback)* | Dynamo-only | Empty JSON config (no start/end tokens). Prefer a model-specific parser for production use. |
 
 > [!TIP]
 > For Kimi K2.5 thinking models, pair `--dyn-tool-call-parser kimi_k2` with

--- a/docs/tool-calling/engine-fallback.md
+++ b/docs/tool-calling/engine-fallback.md
@@ -15,9 +15,9 @@ the equivalent reasoning fallback, see
 
 > [!WARNING]
 > **Known Issue:** Engine-fallback tool call parsing does not currently work
-> with [disaggregated serving](../features/disaggregated-serving/README.md).
-> Use the [Dynamo-native tool call parser](dynamo.md) for disaggregated
-> deployments.
+> with [disaggregated serving](../features/disaggregated-serving/README.md)
+> (support coming soon). Use the [Dynamo-native tool call parser](dynamo.md)
+> for disaggregated deployments today.
 
 ## Configurations
 
@@ -25,6 +25,7 @@ the equivalent reasoning fallback, see
 |---|---|---|---|---|
 | **vLLM chat processor** | `--dyn-chat-processor vllm --tool-call-parser <name>` | *(none)* | Yes | Parsing runs in vLLM's Python preprocessor. See [vLLM Chat Processor](../backends/vllm/vllm-chat-processor.md). |
 | **SGLang chat processor** | `--dyn-chat-processor sglang --tool-call-parser <name>` | *(none)* | Yes | Parsing runs in SGLang's Python preprocessor. See [SGLang Chat Processor](../backends/sglang/sglang-chat-processor.md). |
+| **TRTLLM chat processor** | *(work in progress)* | *(work in progress)* | -- | Engine-fallback support for TRTLLM is in progress. Use the [Dynamo-native tool call parser](dynamo.md) for TRTLLM today. |
 
 > [!NOTE]
 > `--dyn-tool-call-parser` selects the **Dynamo-native** parser path, while


### PR DESCRIPTION
## Why

Product/customer feedback - put the most popular parsers first, and mention TRTLLM chat processor status in support matrix for awareness

## Summary
- Re-sort the Dynamo-native tool-call and reasoning parser tables into a model-family order (Kimi → Minimax → DeepSeek → Qwen → GLM → Nemotron → Gemma → Harmony → Hermes → phi4 → pythonic → llama3 → mistral → leftovers → fallback) so the most commonly used parsers are surfaced first.
- Add a **TRTLLM chat processor** row to both engine-fallback configuration tables marked *(work in progress)* with a pointer back to the Dynamo-native parser for TRTLLM today.
- Update the disaggregated-serving warning on both engine-fallback pages to note that support is coming soon.

## Test plan
- [ ] Render `docs/tool-calling/dynamo.md`, `docs/tool-calling/engine-fallback.md`, `docs/reasoning/dynamo.md`, and `docs/reasoning/engine-fallback.md` in the Fern docs preview and confirm the tables and notes render correctly.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9540" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->