### PR TITLE
fix(tokenspeed): launch AsyncLLM directly

### DIFF
--- a/components/src/dynamo/tokenspeed/llm_engine.py
+++ b/components/src/dynamo/tokenspeed/llm_engine.py
@@ -5,9 +5,11 @@
 
 from __future__ import annotations
 
+import atexit
 import importlib
 import json
 import logging
+import os
 import re
 from collections.abc import AsyncGenerator
 from typing import Any
@@ -31,9 +33,13 @@ logger = logging.getLogger(__name__)
 class TokenspeedLLMEngine(LLMEngine):
     def __init__(self, server_args: Any):
         self.server_args = server_args
-        self.engine = None
+        self.async_llm = None
+        self.scheduler_info: dict[str, Any] = {}
         self._model_max_len: int | None = None
         self._active_rids_by_context: dict[str, list[str]] = {}
+        self._tokenspeed_process_tree_owned = False
+        self._atexit_cleanup_callback = self._cleanup_tokenspeed_subprocesses
+        self._atexit_cleanup_registered = False
 
     @classmethod
     async def from_args(
@@ -53,14 +59,26 @@ class TokenspeedLLMEngine(LLMEngine):
         del worker_id  # tokenspeed has no cluster-wide ID needs
         # The Dynamo response layer expects per-chunk token deltas.
         self.server_args.stream_output = True
-        self.engine = _tokenspeed_engine_cls()(server_args=self.server_args)
+        self._tokenspeed_process_tree_owned = True
+        try:
+            self.async_llm, self.scheduler_info = _launch_tokenspeed_subprocesses(
+                self.server_args
+            )
+        except Exception:
+            self._cleanup_tokenspeed_subprocesses()
+            raise
+        if self.async_llm is None:
+            self._cleanup_tokenspeed_subprocesses()
+            raise RuntimeError(
+                "TokenSpeed _launch_subprocesses returned no AsyncLLM; "
+                "only rank 0 can serve Dynamo requests"
+            )
+        self._register_atexit_cleanup()
 
-        scheduler_info = getattr(self.engine, "scheduler_info", {}) or {}
+        scheduler_info = self.scheduler_info or {}
         self._model_max_len = _optional_int(
             scheduler_info.get("max_model_len")
-            or getattr(
-                getattr(self.engine, "tokenizer_manager", None), "context_len", None
-            )
+            or getattr(self.async_llm, "context_len", None)
             or getattr(self.server_args, "max_model_len", None)
         )
 
@@ -97,7 +115,7 @@ class TokenspeedLLMEngine(LLMEngine):
     async def generate(
         self, request: GenerateRequest, context: Context
     ) -> AsyncGenerator[GenerateChunk, None]:
-        assert self.engine is not None, "Engine not initialized"
+        assert self.async_llm is not None, "Engine not initialized"
 
         _validate_single_choice_sampling(request)
         sampling_params = build_sampling_params(request, self._model_max_len)
@@ -115,7 +133,7 @@ class TokenspeedLLMEngine(LLMEngine):
 
         emitted_completion_tokens = 0
         try:
-            async for out in self.engine.tokenizer_manager.generate_request(obj):
+            async for out in self.async_llm.generate_request(obj):
                 delta_out, emitted_completion_tokens = _completion_delta_output(
                     out, emitted_completion_tokens
                 )
@@ -126,18 +144,36 @@ class TokenspeedLLMEngine(LLMEngine):
 
     async def abort(self, context: Context) -> None:
         request_id = context.id()
-        if self.engine is None or request_id is None:
+        if self.async_llm is None or request_id is None:
             return
 
         rids = self._active_rids_by_context.get(request_id, [request_id])
         for rid in rids:
-            self.engine.tokenizer_manager.abort_request(rid)
+            self.async_llm.abort_request(rid)
             logger.debug("Aborted TokenSpeed request %s", rid)
 
     async def cleanup(self) -> None:
-        if self.engine is not None:
-            self.engine.shutdown()
-            logger.info("TokenSpeed engine shutdown")
+        self._cleanup_tokenspeed_subprocesses()
+        self._unregister_atexit_cleanup()
+
+    def _cleanup_tokenspeed_subprocesses(self) -> None:
+        if not self._tokenspeed_process_tree_owned:
+            return
+        _kill_tokenspeed_process_tree()
+        self.async_llm = None
+        self.scheduler_info = {}
+        self._tokenspeed_process_tree_owned = False
+        logger.info("TokenSpeed engine shutdown")
+
+    def _register_atexit_cleanup(self) -> None:
+        if not self._atexit_cleanup_registered:
+            atexit.register(self._atexit_cleanup_callback)
+            self._atexit_cleanup_registered = True
+
+    def _unregister_atexit_cleanup(self) -> None:
+        if self._atexit_cleanup_registered:
+            atexit.unregister(self._atexit_cleanup_callback)
+            self._atexit_cleanup_registered = False
 
 
 def build_sampling_params(
@@ -337,9 +373,24 @@ def _optional_int(value: Any) -> int | None:
     return int(value)
 
 
-def _tokenspeed_engine_cls() -> Any:
+def _launch_tokenspeed_subprocesses(server_args: Any) -> tuple[Any, dict[str, Any]]:
     module = importlib.import_module("tokenspeed.runtime.entrypoints.engine")
-    return module.Engine
+    port_args = _tokenspeed_port_args_cls().init_new(server_args)
+    async_llm, _, scheduler_info = module._launch_subprocesses(
+        server_args=server_args,
+        port_args=port_args,
+    )
+    return async_llm, scheduler_info or {}
+
+
+def _tokenspeed_port_args_cls() -> Any:
+    module = importlib.import_module("tokenspeed.runtime.utils.server_args")
+    return module.PortArgs
+
+
+def _kill_tokenspeed_process_tree() -> None:
+    module = importlib.import_module("tokenspeed.runtime.utils.process")
+    module.kill_process_tree(os.getpid(), include_parent=False)
 
 
 def _generate_req_input_cls() -> Any:

--- a/components/src/dynamo/tokenspeed/tests/test_tokenspeed_llm_engine.py
+++ b/components/src/dynamo/tokenspeed/tests/test_tokenspeed_llm_engine.py
@@ -1,12 +1,16 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
 import json
+from types import SimpleNamespace
 
 import pytest
 
+import dynamo.tokenspeed.llm_engine as tokenspeed_llm_engine
 from dynamo.llm.exceptions import InvalidArgument
 from dynamo.tokenspeed.llm_engine import (
+    TokenspeedLLMEngine,
     _completion_delta_output,
     _validate_single_choice_sampling,
     build_sampling_params,
@@ -14,6 +18,219 @@ from dynamo.tokenspeed.llm_engine import (
 )
 
 pytestmark = [pytest.mark.unit, pytest.mark.gpu_0, pytest.mark.pre_merge]
+
+
+class _FakeAsyncLLM:
+    def __init__(self, outputs=None, context_len=2048):
+        self.outputs = outputs or []
+        self.context_len = context_len
+        self.requests = []
+        self.aborted = []
+
+    async def generate_request(self, obj):
+        self.requests.append(obj)
+        for output in self.outputs:
+            yield output
+
+    def abort_request(self, rid):
+        self.aborted.append(rid)
+
+
+class _FakeContext:
+    def __init__(self, request_id="req-1"):
+        self._request_id = request_id
+
+    def id(self):
+        return self._request_id
+
+
+class _FakeGenerateReqInput:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+def _server_args(**overrides):
+    values = {
+        "model": "token-speed-model",
+        "served_model_name": "served-token-speed-model",
+        "max_model_len": 4096,
+        "block_size": 16,
+        "max_total_tokens": None,
+        "chunked_prefill_size": None,
+        "max_prefill_tokens": None,
+        "max_num_seqs": None,
+        "stream_output": False,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_start_launches_tokenspeed_subprocesses_directly(monkeypatch):
+    async_llm = _FakeAsyncLLM(context_len=2048)
+    server_args = _server_args()
+    engine = TokenspeedLLMEngine(server_args)
+    kills = []
+
+    def launch(subprocess_server_args):
+        assert subprocess_server_args is server_args
+        assert subprocess_server_args.stream_output is True
+        return async_llm, {
+            "max_total_num_tokens": 160,
+            "chunked_prefill_size": 32,
+            "max_num_seqs": 4,
+        }
+
+    monkeypatch.setattr(
+        tokenspeed_llm_engine, "_launch_tokenspeed_subprocesses", launch
+    )
+    monkeypatch.setattr(
+        tokenspeed_llm_engine,
+        "_kill_tokenspeed_process_tree",
+        lambda: kills.append(1),
+    )
+
+    config = asyncio.run(engine.start(7))
+
+    assert engine.async_llm is async_llm
+    assert config.model == "token-speed-model"
+    assert config.served_model_name == "served-token-speed-model"
+    assert config.context_length == 2048
+    assert config.kv_cache_block_size == 16
+    assert config.total_kv_blocks == 10
+    assert config.max_num_seqs == 4
+    assert config.max_num_batched_tokens == 32
+
+    asyncio.run(engine.cleanup())
+    assert kills == [1]
+    assert engine._tokenspeed_process_tree_owned is False
+
+
+def test_start_rejects_non_serving_tokenspeed_rank(monkeypatch):
+    engine = TokenspeedLLMEngine(_server_args())
+    kills = []
+
+    monkeypatch.setattr(
+        tokenspeed_llm_engine,
+        "_launch_tokenspeed_subprocesses",
+        lambda _server_args: (None, {}),
+    )
+    monkeypatch.setattr(
+        tokenspeed_llm_engine,
+        "_kill_tokenspeed_process_tree",
+        lambda: kills.append(1),
+    )
+
+    with pytest.raises(RuntimeError, match="rank 0"):
+        asyncio.run(engine.start(0))
+
+    assert kills == [1]
+    assert engine.async_llm is None
+    assert engine.scheduler_info == {}
+    assert engine._tokenspeed_process_tree_owned is False
+
+
+def test_start_cleans_up_tokenspeed_process_tree_when_launch_fails(monkeypatch):
+    engine = TokenspeedLLMEngine(_server_args())
+    kills = []
+
+    def launch(_server_args):
+        raise RuntimeError("scheduler failed")
+
+    monkeypatch.setattr(
+        tokenspeed_llm_engine, "_launch_tokenspeed_subprocesses", launch
+    )
+    monkeypatch.setattr(
+        tokenspeed_llm_engine,
+        "_kill_tokenspeed_process_tree",
+        lambda: kills.append(1),
+    )
+
+    with pytest.raises(RuntimeError, match="scheduler failed"):
+        asyncio.run(engine.start(0))
+
+    assert kills == [1]
+    assert engine._tokenspeed_process_tree_owned is False
+
+
+def test_generate_streams_from_async_llm(monkeypatch):
+    async_llm = _FakeAsyncLLM(
+        outputs=[
+            {"output_ids": [11, 12, 99], "meta_info": {"completion_tokens": 1}},
+            {
+                "output_ids": [100],
+                "meta_info": {
+                    "finish_reason": "length",
+                    "prompt_tokens": 2,
+                    "completion_tokens": 2,
+                },
+            },
+        ]
+    )
+    engine = TokenspeedLLMEngine(_server_args())
+    engine.async_llm = async_llm
+    engine._model_max_len = 16
+    monkeypatch.setattr(
+        tokenspeed_llm_engine,
+        "_generate_req_input_cls",
+        lambda: _FakeGenerateReqInput,
+    )
+
+    async def collect_chunks():
+        chunks = []
+        async for chunk in engine.generate(
+            {
+                "token_ids": [11, 12],
+                "sampling_options": {"temperature": 0.0},
+                "stop_conditions": {"max_tokens": 2},
+            },
+            _FakeContext("generate-1"),
+        ):
+            chunks.append(chunk)
+        return chunks
+
+    chunks = asyncio.run(collect_chunks())
+
+    assert async_llm.requests[0].input_ids == [11, 12]
+    assert async_llm.requests[0].sampling_params["temperature"] == 0.0
+    assert async_llm.requests[0].sampling_params["max_new_tokens"] == 2
+    assert async_llm.requests[0].stream is True
+    assert async_llm.requests[0].rid == "generate-1"
+    assert chunks[0]["token_ids"] == [99]
+    assert chunks[1]["token_ids"] == [100]
+    assert chunks[1]["finish_reason"] == "length"
+    assert "generate-1" not in engine._active_rids_by_context
+
+
+def test_abort_forwards_active_request_ids():
+    async_llm = _FakeAsyncLLM()
+    engine = TokenspeedLLMEngine(_server_args())
+    engine.async_llm = async_llm
+    engine._active_rids_by_context["ctx-1"] = ["rid-a", "rid-b"]
+
+    asyncio.run(engine.abort(_FakeContext("ctx-1")))
+
+    assert async_llm.aborted == ["rid-a", "rid-b"]
+
+
+def test_cleanup_kills_tokenspeed_process_tree_once(monkeypatch):
+    engine = TokenspeedLLMEngine(_server_args())
+    engine.async_llm = _FakeAsyncLLM()
+    engine.scheduler_info = {"max_num_seqs": 4}
+    engine._tokenspeed_process_tree_owned = True
+    kills = []
+    monkeypatch.setattr(
+        tokenspeed_llm_engine,
+        "_kill_tokenspeed_process_tree",
+        lambda: kills.append(1),
+    )
+
+    asyncio.run(engine.cleanup())
+    asyncio.run(engine.cleanup())
+
+    assert kills == [1]
+    assert engine.async_llm is None
+    assert engine.scheduler_info == {}
+    assert engine._tokenspeed_process_tree_owned is False
 
 
 def test_build_sampling_params_maps_dynamo_request():


### PR DESCRIPTION
## Summary
- launch TokenSpeed via `tokenspeed.runtime.entrypoints.engine._launch_subprocesses(...)` from the Python Dynamo worker
- call the returned `AsyncLLM` directly for generate/abort instead of constructing the higher-level `Engine` wrapper
- add unit coverage for direct launch, non-serving rank handling, streaming generation, abort, and cleanup

## Testing
- `python3 -m compileall components/src/dynamo/tokenspeed`
- `git diff --check`
- `PYTHONPATH=components/src python3 -m pytest components/src/dynamo/tokenspeed/tests/test_tokenspeed_llm_engine.py` inside the TokenSpeed dev container: 16 passed
- E2E in the TokenSpeed dev container with Kimi K2.5 NVFP4:
  - `python3 -m dynamo.frontend`
  - `python3 -m dynamo.tokenspeed --dyn-reasoning-parser kimi_k25 --dyn-tool-call-parser kimi_k2 ...`
  - `/v1/chat/completions` returned `content='Hello my friend'`, nonempty `reasoning_content`, and `finish_reason='stop'`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling and resource cleanup during engine initialization and shutdown processes

* **Refactor**
  * Improved engine resource management and lifecycle operations for greater stability and reliability

* **Tests**
  * Added comprehensive test coverage for engine startup, request generation, streaming behavior, and cleanup operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9541?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->