### PR TITLE
test: skip flaky LLaVA agg_router multimodal tests

### DIFF
--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -344,8 +344,22 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
             # workers, one per GPU on the gpu_2 runner (no SINGLE_GPU
             # packing — 7B × 2 would exceed 24 GiB on a single card). Each
             # worker peaks ~19 GiB; the 24 GiB L4 tier has headroom.
+            #
+            # Skipped: LLaVA-1.5 on vLLM 0.20 is flaky — the model
+            # degenerates into "No." / newline-padded output even at
+            # temperature=0 (see PR #9336 for the e_pd manifestation
+            # and the comment block above on color-naming variance).
+            # The agg_router routing path is already covered by the
+            # Qwen3-VL-2B / Qwen2.5-VL-3B / Qwen2-VL-2B / Phi-3-vision
+            # profiles above without the LLaVA flake.
             "agg_router": TopologyConfig(
-                marks=[pytest.mark.post_merge],
+                marks=[
+                    pytest.mark.skip(
+                        reason="LLaVA-1.5 flake on vLLM 0.20 (see PR #9336); "
+                        "agg_router routing path is covered by Qwen and Phi-3 profiles"
+                    ),
+                    pytest.mark.post_merge,
+                ],
                 timeout_s=600,
                 gpu_marker="gpu_2",
                 profiled_vram_gib=19.2,
@@ -447,12 +461,23 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
     # LLaVA-NeXT covers a separate lightseek processor (LlavaNextProcessor,
     # anyres multi-crop) vs LLaVA-1.5's plain LlavaProcessor. Same gpu_2
     # multi-GPU layout as LLaVA-1.5 agg_router above; ~14 GiB / GPU.
+    #
+    # Skipped: LLaVA-NeXT inherits the same LLaVA-on-vLLM-0.20 output
+    # flake as LLaVA-1.5 (see PR #9336); the agg_router routing path is
+    # covered by the Qwen and Phi-3 profiles above.
     MultimodalModelProfile(
         name="llava-hf/llava-v1.6-mistral-7b-hf",
         short_name="llava-next-mistral-7b",
         topologies={
             "agg_router": TopologyConfig(
-                marks=[pytest.mark.post_merge],
+                marks=[
+                    pytest.mark.skip(
+                        reason="LLaVA-NeXT inherits LLaVA-1.5 flake on vLLM 0.20 "
+                        "(see PR #9336); agg_router routing path is covered by "
+                        "Qwen and Phi-3 profiles"
+                    ),
+                    pytest.mark.post_merge,
+                ],
                 timeout_s=600,
                 gpu_marker="gpu_2",
                 profiled_vram_gib=19.2,


### PR DESCRIPTION
## Why

The two `mm_agg_router_llava-*` cases land in the top-slowest post-merge slots while LLaVA-1.5 / LLaVA-NeXT on vLLM 0.20 still degenerate into `"No."` / newline-padded responses (the same flake that prompted PR #9336 moving llava `e_pd` to nightly).

by our accounting, this 2 tests are the flakiest ones currently.

```

Rank | Count / Total | Test | PR history — oldest → newest
-- | -- | -- | --
1 | 45 / 4924 | tests/serve/test_vllm.py::test_serve_deployment[mm_agg_router_llava-next-mistral-7b] | 
2 | 38 / 4924 | tests/serve/test_vllm.py::test_serve_deployment[mm_agg_router_llava-1.5-7b] |
```

<img width="1037" height="125" alt="image" src="https://github.com/user-attachments/assets/93184e03-0ad2-466f-afbb-9e14e1d1d00a" />


## What Change

- Add `pytest.mark.skip(reason=...)` to both LLaVA `agg_router` topologies.
- Keep `post_merge` underneath so removing only the skip line re-enables them.

## Test Plan

- `pytest --collect-only -q tests/serve/test_vllm.py | grep mm_agg_router_llava` shows both as `SKIPPED`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Skipped routing path tests for LLaVA model profiles due to a known vLLM 0.20 compatibility issue. Equivalent test coverage is maintained through alternative test profiles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9544)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->