### PR TITLE
docs: bump SGLang references to 0.5.11 on main

### DIFF
--- a/docs/backends/sglang/agents.md
+++ b/docs/backends/sglang/agents.md
@@ -175,7 +175,7 @@ Session control is request-driven. The router's `AgentController` (session lifec
 > Session control is currently supported only on the SGLang backend. vLLM and TensorRT-LLM do not yet expose the streaming session API.
 
 > [!IMPORTANT]
-> Streaming sessions require SGLang changes from [sgl-project/sglang#21875](https://github.com/sgl-project/sglang/pull/21875) (session-aware cache, race condition fixes, session metrics). This is merged to SGLang main but not yet in a release. Until a version after `0.5.10.post1` is published, build SGLang from source (`pip install -e "python"` from the SGLang repo).
+> Streaming sessions require SGLang `0.5.11` or later, which includes changes from [sgl-project/sglang#21875](https://github.com/sgl-project/sglang/pull/21875) (session-aware cache, race condition fixes, session metrics).
 
 **SGLang worker:**
 

--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -31,7 +31,7 @@ The following table shows the backend framework versions included with each Dyna
 
 | **Dynamo** | **SGLang** | **TensorRT-LLM** | **vLLM** | **NIXL** |
 | :--- | :--- | :--- | :--- | :--- |
-| **main (ToT)** | `0.5.10.post1` | `1.3.0rc14` | `0.20.1` | `0.10.1` (TRT-LLM, vLLM); `1.0.1` (SGLang) |
+| **main (ToT)** | `0.5.11` | `1.3.0rc14` | `0.20.1` | `0.10.1` (TRT-LLM, vLLM); `1.0.1` (SGLang) |
 | **v1.2.0-deepseek-v4-dev.3** *(experimental, partial)* | upstream DSv4 preview | — | `0.20.1` | `0.10.1` |
 | **v1.2.0-deepseek-v4-dev.2** *(experimental, partial)* | upstream DSv4 preview | — | `0.20.0` | `0.10.1` |
 | **v1.1.1** | `0.5.10.post1` | `1.3.0rc11` | `0.19.0` | `0.10.1` (TRT-LLM, vLLM); `1.0.1` (SGLang) |

--- a/recipes/glm-5-nvfp4/Dockerfile
+++ b/recipes/glm-5-nvfp4/Dockerfile
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-ARG BASE_IMAGE="lmsysorg/sglang:v0.5.11-cu130"
+# TODO: bump to lmsysorg/sglang:v0.5.11-cu130
+ARG BASE_IMAGE="lmsysorg/sglang:v0.5.10.post1-cu130"
 ARG ARCH=arm64
 ARG DYNAMO_COMMIT="main"
 ARG CARGO_BUILD_JOBS="16"

--- a/recipes/glm-5-nvfp4/Dockerfile
+++ b/recipes/glm-5-nvfp4/Dockerfile
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-ARG BASE_IMAGE="lmsysorg/sglang:v0.5.10.post1-cu130"
+ARG BASE_IMAGE="lmsysorg/sglang:v0.5.11-cu130"
 ARG ARCH=arm64
 ARG DYNAMO_COMMIT="main"
 ARG CARGO_BUILD_JOBS="16"


### PR DESCRIPTION
#### Overview
Main now tracks SGLang 0.5.11 (`pyproject.toml`, `container/context.yaml` already updated), but a few docs and the GLM-5 recipe Dockerfile still referenced 0.5.10.post1. This cleans those up.

#### Changes
- **Support matrix** - `main (ToT)` row: `0.5.10.post1` -> `0.5.11`
- **Agents doc** - streaming session note said "not yet in a release, build from source"; 0.5.11 includes the fix, so simplified the callout
- **GLM-5 Dockerfile** - base image bumped to `v0.5.11-cu130`

Historical release rows (v1.1.1, v1.1.0, etc.) left as-is since they reflect what shipped.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9546" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Session Control documentation to reflect SGLang 0.5.11 requirements.
  * Updated backend dependencies support matrix to reflect version changes.

* **Chores**
  * Updated Docker recipe configuration to use SGLang 0.5.11.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9546)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->