### PR TITLE
test(kv-router): add overload debug logs

### DIFF
--- a/lib/llm/src/discovery/worker_monitor.rs
+++ b/lib/llm/src/discovery/worker_monitor.rs
@@ -633,34 +633,14 @@ impl WorkerLoadMonitor for KvWorkerMonitor {
 
                         // Update worker load state per dp_rank (for busy detection only)
                         // Note: Prometheus gauges are updated directly by sequence.rs
-                        let (worker_busy, total_blocks) = {
+                        let total_blocks = {
                             let mut state = worker_load_states.entry(worker_id).or_default();
                             state.update_from_active_load(
                                 &active_load,
                                 cfg.active_decode_blocks_threshold,
                             );
-                            let total_blocks = state.kv_total_blocks.get(&dp_rank).copied();
-                            let worker_busy = state.is_busy(
-                                cfg.active_decode_blocks_threshold,
-                                cfg.active_prefill_tokens_threshold,
-                                cfg.active_prefill_tokens_threshold_frac,
-                            );
-                            (worker_busy, total_blocks)
+                            state.kv_total_blocks.get(&dp_rank).copied()
                         };
-
-                        tracing::debug!(
-                            worker_id,
-                            dp_rank,
-                            active_decode_blocks = ?active_load.active_decode_blocks,
-                            kv_used_blocks = ?active_load.kv_used_blocks,
-                            active_prefill_tokens = ?active_load.active_prefill_tokens,
-                            total_blocks = ?total_blocks,
-                            active_decode_blocks_threshold = ?cfg.active_decode_blocks_threshold,
-                            active_prefill_tokens_threshold = ?cfg.active_prefill_tokens_threshold,
-                            active_prefill_tokens_threshold_frac = ?cfg.active_prefill_tokens_threshold_frac,
-                            worker_busy,
-                            "processed active load update"
-                        );
 
                         // Recalculate all busy instances and update
                         let busy_instances: Vec<u64> = worker_load_states
@@ -676,6 +656,23 @@ impl WorkerLoadMonitor for KvWorkerMonitor {
                                     .then_some(*entry.key())
                             })
                             .collect();
+
+                        if tracing::enabled!(tracing::Level::DEBUG) {
+                            let worker_busy = busy_instances.contains(&worker_id);
+                            tracing::debug!(
+                                worker_id,
+                                dp_rank,
+                                active_decode_blocks = ?active_load.active_decode_blocks,
+                                kv_used_blocks = ?active_load.kv_used_blocks,
+                                active_prefill_tokens = ?active_load.active_prefill_tokens,
+                                total_blocks = ?total_blocks,
+                                active_decode_blocks_threshold = ?cfg.active_decode_blocks_threshold,
+                                active_prefill_tokens_threshold = ?cfg.active_prefill_tokens_threshold,
+                                active_prefill_tokens_threshold_frac = ?cfg.active_prefill_tokens_threshold_frac,
+                                worker_busy,
+                                "processed active load update"
+                            );
+                        }
 
                         // Only update if busy_instances has changed
                         if busy_instances != previous_busy_instances {

--- a/lib/llm/src/discovery/worker_monitor.rs
+++ b/lib/llm/src/discovery/worker_monitor.rs
@@ -633,13 +633,34 @@ impl WorkerLoadMonitor for KvWorkerMonitor {
 
                         // Update worker load state per dp_rank (for busy detection only)
                         // Note: Prometheus gauges are updated directly by sequence.rs
-                        {
+                        let (worker_busy, total_blocks) = {
                             let mut state = worker_load_states.entry(worker_id).or_default();
                             state.update_from_active_load(
                                 &active_load,
                                 cfg.active_decode_blocks_threshold,
                             );
-                        }
+                            let total_blocks = state.kv_total_blocks.get(&dp_rank).copied();
+                            let worker_busy = state.is_busy(
+                                cfg.active_decode_blocks_threshold,
+                                cfg.active_prefill_tokens_threshold,
+                                cfg.active_prefill_tokens_threshold_frac,
+                            );
+                            (worker_busy, total_blocks)
+                        };
+
+                        tracing::debug!(
+                            worker_id,
+                            dp_rank,
+                            active_decode_blocks = ?active_load.active_decode_blocks,
+                            kv_used_blocks = ?active_load.kv_used_blocks,
+                            active_prefill_tokens = ?active_load.active_prefill_tokens,
+                            total_blocks = ?total_blocks,
+                            active_decode_blocks_threshold = ?cfg.active_decode_blocks_threshold,
+                            active_prefill_tokens_threshold = ?cfg.active_prefill_tokens_threshold,
+                            active_prefill_tokens_threshold_frac = ?cfg.active_prefill_tokens_threshold_frac,
+                            worker_busy,
+                            "processed active load update"
+                        );
 
                         // Recalculate all busy instances and update
                         let busy_instances: Vec<u64> = worker_load_states
@@ -658,8 +679,15 @@ impl WorkerLoadMonitor for KvWorkerMonitor {
 
                         // Only update if busy_instances has changed
                         if busy_instances != previous_busy_instances {
-                            tracing::debug!("Busy instances changed: {:?}", busy_instances);
+                            let total_workers = client.instance_ids().len();
                             client.update_free_instances(&busy_instances);
+                            let free_workers = client.instance_ids_free().len();
+                            tracing::debug!(
+                                busy_instances = ?busy_instances,
+                                free_workers,
+                                total_workers,
+                                "busy instances changed"
+                            );
                             previous_busy_instances = busy_instances;
                         }
                     }

--- a/lib/llm/src/mocker.rs
+++ b/lib/llm/src/mocker.rs
@@ -647,7 +647,13 @@ impl MockEngine {
                             ) {
                                 tracing::warn!("Failed to publish metrics for DP rank {}: {e}", metrics.dp_rank);
                             } else {
-                                tracing::trace!("Published metrics for DP rank {}", metrics.dp_rank);
+                                tracing::debug!(
+                                    dp_rank = metrics.dp_rank,
+                                    active_decode_blocks = metrics.active_decode_blocks,
+                                    total_blocks = metrics.total_blocks,
+                                    gpu_cache_usage_perc = metrics.gpu_cache_usage_perc,
+                                    "published mocker load metrics"
+                                );
                             }
                         }
                         _ = cancel_token.cancelled() => {

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -809,6 +809,16 @@ where
         // Check if all workers are busy (when fault detection is enabled).
         if self.fault_detection_enabled {
             let free_instances = self.client.instance_ids_free();
+            if tracing::enabled!(tracing::Level::DEBUG) {
+                tracing::debug!(
+                    request_id = %request_id,
+                    instance_id,
+                    router_mode = ?self.router_mode,
+                    free_workers = free_instances.len(),
+                    total_workers = self.client.instance_ids().len(),
+                    "checked worker busy state"
+                );
+            }
             if free_instances.is_empty() {
                 // Check if we actually have any instances at all
                 let all_instances = self.client.instance_ids();

--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -68,6 +68,13 @@ BASE_PORT_BOOTSTRAP = 10100  # Base port for disagg bootstrap rendezvous
 BASE_PORT_ZMQ = 11100  # Base port for ZMQ KV event publishing
 NUM_REQUESTS = 100
 BLOCK_SIZE = 16
+ROUTER_OVERLOAD_DEBUG_DYN_LOG = (
+    "info,"
+    "dynamo_llm::discovery::worker_monitor=debug,"
+    "dynamo_llm::kv_router=debug,"
+    "dynamo_runtime::pipeline::network::egress::push_router=debug,"
+    "dynamo_mocker=debug"
+)
 PLANNER_PROFILE_DATA_DIR = (
     Path(__file__).resolve().parents[2]
     / "components/src/dynamo/planner/tests/data/profiling_results/H200_TP1P_TP1D"
@@ -1068,9 +1075,14 @@ def test_mocker_two_kv_router(
 )  # Use NATS Core (local indexer)
 @pytest.mark.timeout(45)  # ~3x average (~13.10s), rounded up (when enabled)
 def test_mocker_kv_router_overload_503(
-    request, runtime_services_dynamic_ports, predownload_tokenizers, durable_kv_events
+    request,
+    runtime_services_dynamic_ports,
+    predownload_tokenizers,
+    durable_kv_events,
+    monkeypatch,
 ):
     """Test that KV router returns 503 when mocker workers are overloaded."""
+    monkeypatch.setenv("DYN_LOG", ROUTER_OVERLOAD_DEBUG_DYN_LOG)
     logger.info("Starting mocker KV router overload test for 503 status")
     # Create mocker args dictionary with limited resources - use local indexer (NATS Core mode)
     mocker_args = {

--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -73,7 +73,7 @@ ROUTER_OVERLOAD_DEBUG_DYN_LOG = (
     "dynamo_llm::discovery::worker_monitor=debug,"
     "dynamo_llm::kv_router=debug,"
     "dynamo_runtime::pipeline::network::egress::push_router=debug,"
-    "dynamo_mocker=debug"
+    "dynamo_llm::mocker=debug"
 )
 PLANNER_PROFILE_DATA_DIR = (
     Path(__file__).resolve().parents[2]


### PR DESCRIPTION
Adds scoped debug logging for the mocker KV-router overload test so CI failures show active-load, busy-worker, and push-router rejection state. The logging is enabled only for the flaky overload test via a test-local DYN_LOG override.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9549" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved system observability with enhanced debug logging for worker load metrics, instance availability, and load tracking to enable better diagnostics.
  * Added structured logging to metrics publishing for clearer visibility into system behavior.

* **Tests**
  * Updated router overload testing with enhanced debug logging configuration for improved diagnostic capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9549)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->