### PR TITLE
fix(sglang): treat usage metadata as optional in streamed final/error chunks

### DIFF
--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -147,6 +147,30 @@ def _extract_sglang_stop_reason(
     return None
 
 
+def _build_completion_usage(meta_info: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Build a completion_usage payload from SGLang meta_info, treating fields as optional.
+
+    Under larger generation load SGLang may omit ``prompt_tokens`` /
+    ``completion_tokens`` on final or error chunks (see #8550). Returning
+    ``None`` when either is missing lets the caller skip emitting
+    ``completion_usage`` rather than propagate a partial record.
+    """
+    prompt_tokens = meta_info.get("prompt_tokens")
+    completion_tokens = meta_info.get("completion_tokens")
+    if prompt_tokens is None or completion_tokens is None:
+        return None
+    cached_tokens = meta_info.get("cached_tokens")
+    prefill_prompt_tokens_details = None
+    if cached_tokens is not None and cached_tokens > 0:
+        prefill_prompt_tokens_details = {"cached_tokens": cached_tokens}
+    return {
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "total_tokens": prompt_tokens + completion_tokens,
+        "prompt_tokens_details": prefill_prompt_tokens_details,
+    }
+
+
 class DecodeWorkerHandler(BaseWorkerHandler):
     """Handler for decode workers in both aggregated and disaggregated serving modes."""
 
@@ -184,9 +208,9 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         # Engine.async_generate does not declare it (notably the deepseek_v4
         # branch). Doing this at init keeps the per-request hot path free of
         # signature inspection.
-        self._routed_experts_kwargs: Dict[
-            str, Any
-        ] = self._resolve_routed_experts_kwargs(self.engine, self.config.server_args)
+        self._routed_experts_kwargs: Dict[str, Any] = (
+            self._resolve_routed_experts_kwargs(self.engine, self.config.server_args)
+        )
         self._enable_frontend_decoding = enable_frontend_decoding
         self._image_loader: Optional[ImageLoader] = None
         if self._enable_frontend_decoding:
@@ -651,18 +675,9 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                     # Internal transport field consumed by frontend nvext mapping.
                     out["disaggregated_params"] = {"routed_experts": routed_experts}
                 if finish_reason:
-                    input_tokens = res["meta_info"]["prompt_tokens"]
-                    completion_tokens = res["meta_info"]["completion_tokens"]
-                    cached_tokens = res["meta_info"]["cached_tokens"]
-                    prefill_prompt_tokens_details = None
-                    if cached_tokens is not None and cached_tokens > 0:
-                        prefill_prompt_tokens_details = {"cached_tokens": cached_tokens}
-                    out["completion_usage"] = {
-                        "prompt_tokens": input_tokens,
-                        "completion_tokens": completion_tokens,
-                        "total_tokens": input_tokens + completion_tokens,
-                        "prompt_tokens_details": prefill_prompt_tokens_details,
-                    }
+                    completion_usage = _build_completion_usage(res["meta_info"])
+                    if completion_usage is not None:
+                        out["completion_usage"] = completion_usage
                 if not context.is_stopped():
                     yield out
 

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -9,6 +9,7 @@ import pytest
 
 from dynamo.sglang.request_handlers.llm.decode_handler import (
     DecodeWorkerHandler,
+    _build_completion_usage,
     _extract_media_urls,
     _extract_sglang_stop_reason,
     _openai_stop_sampling_params,
@@ -110,6 +111,62 @@ def test_openai_stop_sampling_params_preserves_string_stops():
     assert _openai_stop_sampling_params({"stop": ["token_id:576"]}) == {
         "stop": ["token_id:576"]
     }
+
+
+def test_build_completion_usage_full_payload():
+    assert _build_completion_usage(
+        {
+            "prompt_tokens": 12,
+            "completion_tokens": 7,
+            "cached_tokens": 3,
+            "finish_reason": {"type": "stop"},
+        }
+    ) == {
+        "prompt_tokens": 12,
+        "completion_tokens": 7,
+        "total_tokens": 19,
+        "prompt_tokens_details": {"cached_tokens": 3},
+    }
+
+
+@pytest.mark.parametrize("cached_tokens", [None, 0])
+def test_build_completion_usage_omits_details_when_no_cache(cached_tokens):
+    assert _build_completion_usage(
+        {
+            "prompt_tokens": 5,
+            "completion_tokens": 2,
+            "cached_tokens": cached_tokens,
+        }
+    ) == {
+        "prompt_tokens": 5,
+        "completion_tokens": 2,
+        "total_tokens": 7,
+        "prompt_tokens_details": None,
+    }
+
+
+@pytest.mark.parametrize(
+    "meta_info",
+    [
+        {"completion_tokens": 7, "cached_tokens": 0},
+        {"prompt_tokens": 12, "cached_tokens": 0},
+        {"prompt_tokens": None, "completion_tokens": 7},
+        {"prompt_tokens": 12, "completion_tokens": None},
+        {},
+    ],
+    ids=[
+        "no_prompt_tokens",
+        "no_completion_tokens",
+        "prompt_tokens_is_none",
+        "completion_tokens_is_none",
+        "empty_meta_info",
+    ],
+)
+def test_build_completion_usage_returns_none_when_required_field_missing(meta_info):
+    """Regression for #8550: SGLang's final/error chunks may omit usage fields
+    under larger generation load. Returning None lets the caller skip emitting
+    completion_usage rather than KeyError or propagate a partial record."""
+    assert _build_completion_usage(meta_info) is None
 
 
 def test_openai_stop_sampling_params_maps_token_id_stop_array():


### PR DESCRIPTION
## Summary

Closes #8550. Under larger generation load SGLang's streamed decode path occasionally omits `prompt_tokens` / `completion_tokens` / `cached_tokens` from `meta_info` on final or error chunks. The current handler reads these with `[...]` indexing and raises `KeyError`, surfacing as backend errors and frontend `500`s.

## Fix

Extract `_build_completion_usage(meta_info)` as a module-level helper in `request_handlers/llm/decode_handler.py` that returns `None` whenever `prompt_tokens` or `completion_tokens` is missing/None. The caller emits `completion_usage` only when the helper returns a payload — mirroring the optional-emission contract the frontend's `.get("completion_usage")` already assumes in `sglang_processor.py:535`. `cached_tokens` stays optional (matching the prior `is not None and > 0` guard).

## Test plan

CPU unit tests added to `test_sglang_decode_handler.py`:

- full payload (all three fields present)
- `cached_tokens` absent / 0 — no `prompt_tokens_details` emitted
- 5 missing-required-field shapes (`prompt_tokens` / `completion_tokens` absent or None, plus empty meta_info) — all return None, regression for #8550

Tests live next to the existing free-function tests in the same file and follow the same parametrize style.

## Notes

- DCO signed off
- `ruff format` / `ruff check` clean on changed files
- Behavioral logic verified locally via a pure-Python reproducer; full pytest run requires the `dynamo._core` Rust binding so CI exercises the new tests
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9552" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of token usage reporting to avoid emitting incomplete data when required fields are missing.
  * Enhanced accuracy of token accounting when cached tokens are present.

* **Tests**
  * Added comprehensive test coverage for token usage calculations and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9552)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->