### PR TITLE
fix(operator): preserve embedded pod template metadata in CRDs

### DIFF
--- a/deploy/helm/charts/platform/components/operator/crds/nvidia.com_dynamocheckpoints.yaml
+++ b/deploy/helm/charts/platform/components/operator/crds/nvidia.com_dynamocheckpoints.yaml
@@ -165,6 +165,23 @@ spec:
                           description: |-
                             Standard object's metadata.
                             More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            finalizers:
+                              items:
+                                type: string
+                              type: array
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            name:
+                              type: string
+                            namespace:
+                              type: string
                           type: object
                         spec:
                           description: |-
@@ -6837,6 +6854,23 @@ spec:
                                               May contain labels and annotations that will be copied into the PVC
                                               when creating it. No other fields are allowed and will be rejected during
                                               validation.
+                                            properties:
+                                              annotations:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                              finalizers:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              labels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                              name:
+                                                type: string
+                                              namespace:
+                                                type: string
                                             type: object
                                           spec:
                                             description: |-

--- a/deploy/helm/charts/platform/components/operator/crds/nvidia.com_dynamocomponentdeployments.yaml
+++ b/deploy/helm/charts/platform/components/operator/crds/nvidia.com_dynamocomponentdeployments.yaml
@@ -9210,6 +9210,23 @@ spec:
                                       May contain labels and annotations that will be copied into the PVC
                                       when creating it. No other fields are allowed and will be rejected during
                                       validation.
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      finalizers:
+                                        items:
+                                          type: string
+                                        type: array
+                                      labels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      name:
+                                        type: string
+                                      namespace:
+                                        type: string
                                     type: object
                                   spec:
                                     description: |-
@@ -11918,6 +11935,23 @@ spec:
                       description: |-
                         Standard object's metadata.
                         More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        finalizers:
+                          items:
+                            type: string
+                          type: array
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        name:
+                          type: string
+                        namespace:
+                          type: string
                       type: object
                     spec:
                       description: |-
@@ -18590,6 +18624,23 @@ spec:
                                           May contain labels and annotations that will be copied into the PVC
                                           when creating it. No other fields are allowed and will be rejected during
                                           validation.
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          finalizers:
+                                            items:
+                                              type: string
+                                            type: array
+                                          labels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          name:
+                                            type: string
+                                          namespace:
+                                            type: string
                                         type: object
                                       spec:
                                         description: |-

--- a/deploy/helm/charts/platform/components/operator/crds/nvidia.com_dynamographdeploymentrequests.yaml
+++ b/deploy/helm/charts/platform/components/operator/crds/nvidia.com_dynamographdeploymentrequests.yaml
@@ -1096,8 +1096,24 @@ spec:
                               description: |-
                                 Standard object's metadata.
                                 More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                finalizers:
+                                  items:
+                                    type: string
+                                  type: array
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
                               type: object
-                              x-kubernetes-preserve-unknown-fields: true
                             spec:
                               description: |-
                                 Specification of the desired behavior of the pod.
@@ -7769,6 +7785,23 @@ spec:
                                                   May contain labels and annotations that will be copied into the PVC
                                                   when creating it. No other fields are allowed and will be rejected during
                                                   validation.
+                                                properties:
+                                                  annotations:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  finalizers:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  labels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  name:
+                                                    type: string
+                                                  namespace:
+                                                    type: string
                                                 type: object
                                               spec:
                                                 description: |-

--- a/deploy/helm/charts/platform/components/operator/crds/nvidia.com_dynamographdeployments.yaml
+++ b/deploy/helm/charts/platform/components/operator/crds/nvidia.com_dynamographdeployments.yaml
@@ -9433,6 +9433,23 @@ spec:
                                             May contain labels and annotations that will be copied into the PVC
                                             when creating it. No other fields are allowed and will be rejected during
                                             validation.
+                                          properties:
+                                            annotations:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            finalizers:
+                                              items:
+                                                type: string
+                                              type: array
+                                            labels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            name:
+                                              type: string
+                                            namespace:
+                                              type: string
                                           type: object
                                         spec:
                                           description: |-
@@ -12268,6 +12285,23 @@ spec:
                             description: |-
                               Standard object's metadata.
                               More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              finalizers:
+                                items:
+                                  type: string
+                                type: array
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              name:
+                                type: string
+                              namespace:
+                                type: string
                             type: object
                           spec:
                             description: |-
@@ -18940,6 +18974,23 @@ spec:
                                                 May contain labels and annotations that will be copied into the PVC
                                                 when creating it. No other fields are allowed and will be rejected during
                                                 validation.
+                                              properties:
+                                                annotations:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                                finalizers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                labels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                                name:
+                                                  type: string
+                                                namespace:
+                                                  type: string
                                               type: object
                                             spec:
                                               description: |-

--- a/deploy/operator/Makefile
+++ b/deploy/operator/Makefile
@@ -75,7 +75,7 @@ tilt-up: kubectl helm ## Start Tilt for local operator development.
 manifests: controller-gen yq ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	# Use a large maxDescLen to ensure all field comments are included as OpenAPI descriptions
 	# allowDangerousTypes=true is needed for the EndpointPickerConfig from gateway-api-inference-extension which contains float fields
-	$(CONTROLLER_GEN) rbac:roleName=manager-role crd:maxDescLen=100000,allowDangerousTypes=true webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) rbac:roleName=manager-role crd:maxDescLen=100000,allowDangerousTypes=true,generateEmbeddedObjectMeta=true webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 	echo "Removing name from mainContainer required fields"
 	for file in config/crd/bases/*.yaml; do \
 		$(YQ) eval '(.. | select(has("mainContainer")) | .mainContainer.required) |= (. - ["name"])' -i --indent 2 $$file || exit 1; \
@@ -89,10 +89,6 @@ manifests: controller-gen yq ## Generate WebhookConfiguration, ClusterRole and C
 	echo "Fixing PluginSpec parameters field: json.RawMessage needs x-kubernetes-preserve-unknown-fields instead of type: string"
 	for file in config/crd/bases/*.yaml; do \
 		$(YQ) eval '(.. | select(has("parameters")) | .parameters | select(has("format") and .format == "byte")) |= (del(.format) | del(.type) | .x-kubernetes-preserve-unknown-fields = true)' -i --indent 2 $$file || exit 1; \
-	done
-	echo "Fixing profilingJob template metadata: controller-gen emits bare type: object for metav1.ObjectMeta, add x-kubernetes-preserve-unknown-fields so labels/annotations are accepted"
-	for file in config/crd/bases/*.yaml; do \
-		$(YQ) eval '(.. | select(has("profilingJob")) | .profilingJob.properties.template.properties.metadata)."x-kubernetes-preserve-unknown-fields" = true' -i --indent 2 $$file || exit 1; \
 	done
 	echo "Adding NVIDIA header to CRD files"
 	for file in config/crd/bases/*.yaml; do \

--- a/deploy/operator/config/crd/bases/nvidia.com_dynamocheckpoints.yaml
+++ b/deploy/operator/config/crd/bases/nvidia.com_dynamocheckpoints.yaml
@@ -165,6 +165,23 @@ spec:
                           description: |-
                             Standard object's metadata.
                             More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            finalizers:
+                              items:
+                                type: string
+                              type: array
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            name:
+                              type: string
+                            namespace:
+                              type: string
                           type: object
                         spec:
                           description: |-
@@ -6837,6 +6854,23 @@ spec:
                                               May contain labels and annotations that will be copied into the PVC
                                               when creating it. No other fields are allowed and will be rejected during
                                               validation.
+                                            properties:
+                                              annotations:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                              finalizers:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              labels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                              name:
+                                                type: string
+                                              namespace:
+                                                type: string
                                             type: object
                                           spec:
                                             description: |-

--- a/deploy/operator/config/crd/bases/nvidia.com_dynamocomponentdeployments.yaml
+++ b/deploy/operator/config/crd/bases/nvidia.com_dynamocomponentdeployments.yaml
@@ -9210,6 +9210,23 @@ spec:
                                       May contain labels and annotations that will be copied into the PVC
                                       when creating it. No other fields are allowed and will be rejected during
                                       validation.
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      finalizers:
+                                        items:
+                                          type: string
+                                        type: array
+                                      labels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                      name:
+                                        type: string
+                                      namespace:
+                                        type: string
                                     type: object
                                   spec:
                                     description: |-
@@ -11918,6 +11935,23 @@ spec:
                       description: |-
                         Standard object's metadata.
                         More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        finalizers:
+                          items:
+                            type: string
+                          type: array
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        name:
+                          type: string
+                        namespace:
+                          type: string
                       type: object
                     spec:
                       description: |-
@@ -18590,6 +18624,23 @@ spec:
                                           May contain labels and annotations that will be copied into the PVC
                                           when creating it. No other fields are allowed and will be rejected during
                                           validation.
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          finalizers:
+                                            items:
+                                              type: string
+                                            type: array
+                                          labels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                          name:
+                                            type: string
+                                          namespace:
+                                            type: string
                                         type: object
                                       spec:
                                         description: |-

--- a/deploy/operator/config/crd/bases/nvidia.com_dynamographdeploymentrequests.yaml
+++ b/deploy/operator/config/crd/bases/nvidia.com_dynamographdeploymentrequests.yaml
@@ -1096,8 +1096,24 @@ spec:
                               description: |-
                                 Standard object's metadata.
                                 More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                finalizers:
+                                  items:
+                                    type: string
+                                  type: array
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
                               type: object
-                              x-kubernetes-preserve-unknown-fields: true
                             spec:
                               description: |-
                                 Specification of the desired behavior of the pod.
@@ -7769,6 +7785,23 @@ spec:
                                                   May contain labels and annotations that will be copied into the PVC
                                                   when creating it. No other fields are allowed and will be rejected during
                                                   validation.
+                                                properties:
+                                                  annotations:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  finalizers:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  labels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                  name:
+                                                    type: string
+                                                  namespace:
+                                                    type: string
                                                 type: object
                                               spec:
                                                 description: |-

--- a/deploy/operator/config/crd/bases/nvidia.com_dynamographdeployments.yaml
+++ b/deploy/operator/config/crd/bases/nvidia.com_dynamographdeployments.yaml
@@ -9433,6 +9433,23 @@ spec:
                                             May contain labels and annotations that will be copied into the PVC
                                             when creating it. No other fields are allowed and will be rejected during
                                             validation.
+                                          properties:
+                                            annotations:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            finalizers:
+                                              items:
+                                                type: string
+                                              type: array
+                                            labels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            name:
+                                              type: string
+                                            namespace:
+                                              type: string
                                           type: object
                                         spec:
                                           description: |-
@@ -12268,6 +12285,23 @@ spec:
                             description: |-
                               Standard object's metadata.
                               More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              finalizers:
+                                items:
+                                  type: string
+                                type: array
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              name:
+                                type: string
+                              namespace:
+                                type: string
                             type: object
                           spec:
                             description: |-
@@ -18940,6 +18974,23 @@ spec:
                                                 May contain labels and annotations that will be copied into the PVC
                                                 when creating it. No other fields are allowed and will be rejected during
                                                 validation.
+                                              properties:
+                                                annotations:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                                finalizers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                labels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                                name:
+                                                  type: string
+                                                namespace:
+                                                  type: string
                                               type: object
                                             spec:
                                               description: |-


### PR DESCRIPTION
## Summary

Enable `generateEmbeddedObjectMeta=true` for operator CRD generation so embedded Kubernetes `ObjectMeta` fields preserve labels and annotations, including `spec.components[].podTemplate.metadata.annotations` and generated DCD pod template metadata.

## Details

Without this, controller-gen emitted embedded `metadata` as only `type: object`, so the apiserver pruned nested fields like `metadata.annotations`. This broke DGD-level annotation propagation in v1beta1, notably `nvidia.com/dynamo-kube-discovery-mode: container`, which prevented GMS intra-pod failover engine containers from receiving `DYN_KUBE_DISCOVERY_MODE=container`.

Also removed the now-redundant profilingJob metadata post-processing patch.

## Validation

- Ran `make manifests`
- Ran `git diff --check`
- Redeployed locally and confirmed generated DCD/Deployment/pod preserve `nvidia.com/dynamo-kube-discovery-mode: container`
- Confirmed both failover engine containers receive `DYN_KUBE_DISCOVERY_MODE=container`

Closes DYN-3035

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9553" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->