### PR TITLE
feat(mocker): extend offline-replay with EventSink + streaming admission + lockstep gating

### DIFF
--- a/lib/mocker/src/replay/collector.rs
+++ b/lib/mocker/src/replay/collector.rs
@@ -257,7 +257,7 @@ pub(crate) struct TraceRequestStatsSnapshot {
 }
 
 #[derive(Debug, Default)]
-pub(crate) struct TraceCollector {
+pub struct TraceCollector {
     requests: FxHashMap<Uuid, TraceRequestStats>,
 }
 
@@ -336,6 +336,15 @@ impl TraceCollector {
         let ttft_ms = (first_token_ms - stats.arrival_time_ms).max(0.0);
         let mean_itl_ms = stats.mean_tpot_ms().unwrap_or(0.0);
         Some((ttft_ms, mean_itl_ms))
+    }
+
+    /// Return the number of tokens emitted so far for a request, or 0
+    /// if the request has not been arrived. Used by the offline runtime
+    /// to derive the engine-side finish_reason at completion time.
+    pub(crate) fn tokens_emitted(&self, uuid: Uuid) -> usize {
+        self.requests
+            .get(&uuid)
+            .map_or(0, |stats| stats.token_times_ms.len())
     }
 
     pub(crate) fn finish(self) -> TraceSimulationReport {
@@ -458,6 +467,26 @@ impl TraceCollector {
                 reused_input_tokens: stats.reused_input_tokens,
             })
             .collect()
+    }
+}
+
+impl crate::replay::offline::EventSink for TraceCollector {
+    fn on_arrival(
+        &mut self,
+        uuid: Uuid,
+        arrival_time_ms: f64,
+        input_length: usize,
+        output_length: usize,
+    ) {
+        TraceCollector::on_arrival(self, uuid, arrival_time_ms, input_length, output_length);
+    }
+
+    fn on_admit(&mut self, uuid: Uuid, admit_time_ms: f64, reused_input_tokens: usize) {
+        TraceCollector::on_admit(self, uuid, admit_time_ms, reused_input_tokens);
+    }
+
+    fn on_token(&mut self, uuid: Uuid, token_time_ms: f64) {
+        TraceCollector::on_token(self, uuid, token_time_ms);
     }
 }
 

--- a/lib/mocker/src/replay/mod.rs
+++ b/lib/mocker/src/replay/mod.rs
@@ -4,8 +4,8 @@
 mod artifacts;
 mod collector;
 mod entrypoints;
-pub(crate) mod offline;
-mod online;
+pub mod offline;
+pub(crate) mod online;
 mod planner_handle;
 mod router_shared;
 mod validate;
@@ -19,7 +19,7 @@ use dynamo_kv_router::PrefillLoadEstimator;
 pub use artifacts::{
     ReplayTimedKvEvent, ReplayTimedOutputSignal, ReplayTimedRequest, ReplayWorkerArtifacts,
 };
-pub(crate) use collector::TraceCollector;
+pub use collector::TraceCollector;
 #[cfg(test)]
 pub(crate) use collector::TraceRequestStatsSnapshot;
 pub use collector::{

--- a/lib/mocker/src/replay/offline/agg.rs
+++ b/lib/mocker/src/replay/offline/agg.rs
@@ -1,9 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use super::EventSink as _;
 #[cfg(test)]
 use super::components::OfflineRouterSnapshot;
 pub(super) use super::components::ReplayMode;
+use super::event_sink::CompositeEventSink;
 use super::events::{SimulationEvent, SimulationWorkerStage};
 use super::progress::ReplayProgress;
 use super::runtime_utils::{
@@ -35,7 +37,7 @@ use uuid::Uuid;
 
 #[cfg(test)]
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub(super) struct AggRuntimeStats {
+pub struct AggRuntimeStats {
     dispatch_history: Vec<usize>,
     dispatch_order: Vec<Uuid>,
     assigned_worker_by_uuid: HashMap<Uuid, usize>,
@@ -58,16 +60,16 @@ struct AggRuntimeSnapshot {
 
 #[cfg(not(test))]
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub(super) struct AggRuntimeStats;
+pub struct AggRuntimeStats;
 
-pub(in crate::replay) struct AggRuntime {
+pub struct AggRuntime {
     now_ms: f64,
     next_worker_idx: usize,
     next_event_seq: u64,
     admission: AdmissionQueue,
     requests: FxHashMap<Uuid, AggRequestState>,
     engine: EngineComponent,
-    collector: TraceCollector,
+    collector: CompositeEventSink,
     events: BinaryHeap<SimulationEvent>,
     router: Option<OfflineReplayRouter>,
     progress: ReplayProgress,
@@ -123,6 +125,28 @@ impl AggRuntime {
         )
     }
 
+    /// Create an aggregated offline runtime fed by a streaming admission queue
+    /// (e.g. a tokio mpsc channel from an embedded producer). The caller constructs
+    /// the `AdmissionQueue::new_streaming(...)` and hands it over; `run_async`
+    /// is the corresponding entrypoint.
+    pub fn new_streaming(
+        args: &MockEngineArgs,
+        router_config: Option<KvRouterConfig>,
+        prefill_load_estimator: Option<ReplayPrefillLoadEstimator>,
+        admission: AdmissionQueue,
+        num_workers: usize,
+        router_mode: ReplayRouterMode,
+    ) -> anyhow::Result<Self> {
+        Self::new_with_source(
+            args,
+            router_config,
+            prefill_load_estimator,
+            admission,
+            num_workers,
+            router_mode,
+        )
+    }
+
     /// Shared constructor for both raw-request and workload-driven admissions.
     fn new_with_source(
         args: &MockEngineArgs,
@@ -166,7 +190,7 @@ impl AggRuntime {
             admission,
             requests: FxHashMap::default(),
             engine,
-            collector: TraceCollector::default(),
+            collector: CompositeEventSink::default(),
             events: BinaryHeap::new(),
             router,
             progress,
@@ -290,7 +314,7 @@ impl AggRuntime {
             request.arrival_timestamp_ms = Some(arrival_time_ms);
         }
 
-        self.collector.on_arrival(
+        self.collector.primary.on_arrival(
             uuid,
             arrival_time_ms,
             request.tokens.len(),
@@ -387,11 +411,28 @@ impl AggRuntime {
             let removed_state = self.requests.remove(&signal.uuid).ok_or_else(|| {
                 anyhow::anyhow!("offline replay missing request state for {}", signal.uuid)
             })?;
-            let latencies = self.collector.request_latencies(signal.uuid);
+            let latencies = self.collector.primary.request_latencies(signal.uuid);
             self.traffic.on_request(
                 removed_state.input_tokens,
                 removed_state.output_tokens,
                 latencies,
+            );
+            // Emit terminal event to any secondary EventSink installed on
+            // the composite. Native callers' primary TraceCollector ignores
+            // this via the trait's default no-op impl — completion stats
+            // are derived from accumulated tokens at finish() time.
+            let tokens_emitted = self.collector.primary.tokens_emitted(signal.uuid);
+            let finish_reason = if tokens_emitted >= removed_state.output_tokens {
+                "length"
+            } else {
+                "stop"
+            };
+            self.collector.on_completion(
+                signal.uuid,
+                self.now_ms,
+                removed_state.input_tokens,
+                tokens_emitted,
+                finish_reason,
             );
             self.admission
                 .on_request_completed(signal.uuid, self.now_ms)?;
@@ -497,9 +538,8 @@ impl AggRuntime {
     fn drive_ready_workers(&mut self) -> anyhow::Result<bool> {
         let mut changed = false;
         loop {
-            let effects = self
-                .engine
-                .drive_ready(self.now_ms, Some(&mut self.collector))?;
+            let sink: &mut dyn super::EventSink = &mut self.collector;
+            let effects = self.engine.drive_ready(self.now_ms, Some(sink))?;
             if effects.is_empty() {
                 return Ok(changed);
             }
@@ -671,7 +711,16 @@ impl AggRuntime {
     /// Finalize the replay: finish progress bar, return collector and stats.
     pub(in crate::replay::offline) fn finalize(self) -> (TraceCollector, AggRuntimeStats) {
         self.progress.finish();
-        (self.collector, self.stats)
+        (self.collector.into_primary(), self.stats)
+    }
+
+    /// Install (or replace) the secondary `EventSink` on the runtime's
+    /// composite collector. The primary `TraceCollector` is unaffected;
+    /// engine events fan out to both sinks. Use this to route events to
+    /// an external pipeline while keeping the in-runtime accumulator
+    /// intact for native callers.
+    pub fn set_secondary_sink(&mut self, sink: Box<dyn super::EventSink>) {
+        self.collector.set_secondary(sink);
     }
 
     /// Finalize the replay and return the simulation report directly.
@@ -699,7 +748,174 @@ impl AggRuntime {
         }
 
         self.progress.finish();
-        Ok((self.collector, self.stats))
+        Ok((self.collector.into_primary(), self.stats))
+    }
+
+    /// Run the aggregated offline replay against a streaming admission source.
+    ///
+    /// Identical to `run` for non-streaming inputs. For streaming inputs, when
+    /// the runtime exhausts every locally-known event but the upstream channel
+    /// is still open, it awaits `admission.recv_next()` on the tokio runtime
+    /// rather than treating the empty state as a dead end. Sim time freezes
+    /// during the wait: no wall-time park, no thread spin.
+    ///
+    /// **Lockstep mode** (opt-in via
+    /// [`AdmissionQueue::new_streaming_lockstep`]): after any drain that
+    /// completes one or more requests AND while cluster work remains in
+    /// flight, the runtime gates the next sim-time advance on receipt of one
+    /// `StreamingAdmission::DrainBarrier` from the producer. This lets a
+    /// closed-loop producer (e.g. a benchmark harness issuing replacement
+    /// requests when completions land) react to each completion batch before
+    /// the runtime advances past the next scheduled event. The default
+    /// (non-lockstep) streaming behavior is unchanged.
+    pub async fn run_async(mut self) -> anyhow::Result<(TraceCollector, AggRuntimeStats)> {
+        // Pull any already-queued streaming submissions into `pending` before
+        // the first drain so they participate in timestamp selection.
+        let _ = self.admission.poll_pending();
+        let mut requests_before_drain = self.requests.len();
+        self.drain_current_timestamp()?;
+
+        loop {
+            // Refresh streaming pending each iteration — producers may have
+            // pushed more requests while we were draining the current ts.
+            let _ = self.admission.poll_pending();
+
+            if self.is_done() {
+                break;
+            }
+
+            // Lockstep drain barrier: if the previous drain completed one or
+            // more requests AND there is still cluster work in flight AND
+            // admission has nothing locally ready AND there's no queued
+            // reaction the runtime needs to admit first, await a
+            // drain-barrier ack from the producer before advancing. This
+            // is the deterministic replacement for a wall-clock grace
+            // window. The `has_queued_admission_work` short-circuit
+            // prevents a deadlock when the producer's reaction has
+            // landed in `pending` / `staged` but the cluster is at
+            // concurrency cap (so `next_ready_time_ms` is `None`) — in
+            // that case we fall through to `next_timestamp` so a
+            // scheduled engine event can free capacity and the runtime's
+            // normal drain path admits the queued work at the current
+            // sim time.
+            let requests_now = self.requests.len();
+            let completions_happened = requests_before_drain > requests_now;
+            if completions_happened
+                && self.admission.is_lockstep()
+                && self.cluster_in_flight() > 0
+                && self
+                    .admission
+                    .next_ready_time_ms(self.cluster_in_flight())
+                    .is_none()
+                && !self.admission.has_queued_admission_work()
+                && !self.admission.consume_drain_barrier()
+            {
+                // No credit yet — block until one arrives.
+                while let Some(()) = self.admission.recv_next().await {
+                    // Applied a Submit / FlushBurst / DrainBarrier. If
+                    // it was a barrier, consume it and proceed.
+                    if self.admission.consume_drain_barrier() {
+                        break;
+                    }
+                    // Otherwise drain any further queued events
+                    // (which may include the barrier) and re-check.
+                    let _ = self.admission.poll_pending();
+                    if self.admission.consume_drain_barrier() {
+                        break;
+                    }
+                    // Still no barrier — keep awaiting. A producer
+                    // emitting Submits without an eventual barrier
+                    // will hang here; that is the documented
+                    // contract violation for lockstep mode.
+                }
+                // If `recv_next` returned None, the channel closed mid-
+                // flight while we were waiting for the barrier. Treat
+                // this as a graceful end-of-session: the producer has
+                // signalled "no more submits coming", which releases the
+                // lockstep contract for the remainder of in-flight work.
+                // We break out of the gate and let `next_timestamp` drive
+                // the already-scheduled engine events to natural
+                // completion. Any pending `drain_barrier` credit is
+                // intentionally discarded — there is no submit that can
+                // race past it once the channel is closed, so the
+                // determinism guarantee that the gate protects
+                // (admit-at-current-tick) is vacuously satisfied.
+            }
+
+            match self.next_timestamp() {
+                Some(next_timestamp_ms) => {
+                    requests_before_drain = self.requests.len();
+                    self.now_ms = next_timestamp_ms;
+                    self.drain_current_timestamp()?;
+                }
+                None => {
+                    // No arrival, no scheduled event, but cluster may still be
+                    // in flight — that is a true dead end and mirrors the sync
+                    // `run`'s bail.
+                    if self.cluster_in_flight() != 0 {
+                        bail!(
+                            "offline replay reached a dead end with {} in-flight requests remaining",
+                            self.cluster_in_flight()
+                        );
+                    }
+
+                    // Nothing in flight, nothing scheduled. If the source is a
+                    // streaming channel that hasn't been closed yet, await the
+                    // next submit. For non-streaming sources `recv_next` is a
+                    // no-op returning `None`, which falls through to break.
+                    if self.admission.is_drained() {
+                        break;
+                    }
+                    match self.admission.recv_next().await {
+                        Some(()) => {
+                            // The event was applied to internal admission
+                            // state. If it was an untagged Submit or a
+                            // FlushBurst with staged work, the next loop
+                            // iteration's drain_ready will pick it up; if it
+                            // was a tagged Submit awaiting flush, we'll wait
+                            // again on the next iteration. A bare
+                            // DrainBarrier with no in-flight work is
+                            // discarded by the barrier counter but doesn't
+                            // produce a deadlock — the next iteration sees
+                            // no completions to gate.
+
+                            // Streaming-burst batch coalesce: when an external
+                            // producer drives the runtime over an async pipeline,
+                            // its initial concurrency burst of N submits arrives at the
+                            // mpsc channel over a wall window of several ms
+                            // (3-17ms measured at concurrency=8) rather than
+                            // in one tight push. Without coalescing, each
+                            // submit triggers its own loop iteration and
+                            // gets admitted at its own sim timestamp, so
+                            // the engine batches them differently across
+                            // reruns -- producing per-request perf_ns drift
+                            // even though native run_synthetic_trace_replay
+                            // is bit-identical. After accepting the first
+                            // submit on this idle resume, pause briefly so
+                            // co-arriving siblings land in the same
+                            // poll_pending sweep and admit at the same
+                            // sim timestamp. The lockstep gate above
+                            // protects post-completion ordering; this
+                            // coalesce protects cold-start ordering before
+                            // the first completion fires.
+                            const STREAMING_BURST_COALESCE_US: u64 = 5_000;
+                            tokio::time::sleep(std::time::Duration::from_micros(
+                                STREAMING_BURST_COALESCE_US,
+                            ))
+                            .await;
+                            let _ = self.admission.poll_pending();
+                        }
+                        None => {
+                            // Channel closed or non-streaming source.
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        self.progress.finish();
+        Ok((self.collector.into_primary(), self.stats))
     }
 
     #[cfg(test)]
@@ -2055,6 +2271,288 @@ mod tests {
         assert!(
             done,
             "advance_to should report done when workload is complete"
+        );
+    }
+
+    // --------------------------------------------------------------
+    // Streaming admission + run_async
+    // --------------------------------------------------------------
+
+    fn streaming_direct_request(arrival_ms: f64, isl: usize, max_out: usize) -> DirectRequest {
+        DirectRequest {
+            tokens: vec![1u32; isl],
+            max_output_tokens: max_out,
+            uuid: Some(Uuid::new_v4()),
+            dp_rank: 0,
+            arrival_timestamp_ms: Some(arrival_ms),
+        }
+    }
+
+    #[tokio::test]
+    async fn run_async_processes_three_requests_streamed_with_delay() {
+        let args = fast_router_args();
+        let (tx, rx) =
+            tokio::sync::mpsc::unbounded_channel::<crate::replay::offline::StreamingAdmission>();
+        let admission = AdmissionQueue::new_streaming(rx, ReplayMode::Trace);
+        let rt = AggRuntime::new_streaming(
+            &args,
+            None,
+            None,
+            admission,
+            /*num_workers=*/ 2,
+            ReplayRouterMode::RoundRobin,
+        )
+        .unwrap();
+
+        // Send three requests in two waves so the runtime must await between
+        // them at least once. We can't `tokio::spawn` AggRuntime (Rc inside),
+        // so the producer future runs alongside via `tokio::join!` on the
+        // current task — both make progress between `.await` points.
+        tx.send(streaming_direct_request(0.0, 32, 2).into())
+            .unwrap();
+
+        let producer = async move {
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            tx.send(streaming_direct_request(10.0, 32, 2).into())
+                .unwrap();
+            tx.send(streaming_direct_request(20.0, 32, 2).into())
+                .unwrap();
+            drop(tx);
+        };
+        let driver = rt.run_async();
+
+        let (_, drive_res) = tokio::join!(producer, driver);
+        let (collector, _stats) = drive_res.expect("run_async ok");
+        let report = collector.finish();
+        assert_eq!(report.request_counts.completed_requests, 3);
+    }
+
+    #[tokio::test]
+    async fn run_async_returns_immediately_when_channel_closed_empty() {
+        let args = fast_router_args();
+        let (tx, rx) =
+            tokio::sync::mpsc::unbounded_channel::<crate::replay::offline::StreamingAdmission>();
+        drop(tx);
+        let admission = AdmissionQueue::new_streaming(rx, ReplayMode::Trace);
+        let rt = AggRuntime::new_streaming(
+            &args,
+            None,
+            None,
+            admission,
+            /*num_workers=*/ 1,
+            ReplayRouterMode::RoundRobin,
+        )
+        .unwrap();
+
+        let (collector, _stats) = rt.run_async().await.expect("run_async ok");
+        let report = collector.finish();
+        assert_eq!(report.request_counts.completed_requests, 0);
+    }
+
+    // --------------------------------------------------------------
+    // Lockstep streaming admission — drain barrier protocol
+    // --------------------------------------------------------------
+
+    /// Test-only EventSink that forwards each `on_completion` callback as a
+    /// uuid + completion-time pair through a tokio mpsc channel. Lets the
+    /// producer side of a lockstep test observe completions exactly as a
+    /// real bridge would observe them through its event ring.
+    struct CompletionForwarder {
+        tx: tokio::sync::mpsc::UnboundedSender<(Uuid, f64)>,
+    }
+
+    impl crate::replay::offline::EventSink for CompletionForwarder {
+        fn on_arrival(&mut self, _uuid: Uuid, _arrival_time_ms: f64, _isl: usize, _osl: usize) {}
+        fn on_admit(&mut self, _uuid: Uuid, _admit_time_ms: f64, _reused: usize) {}
+        fn on_token(&mut self, _uuid: Uuid, _token_time_ms: f64) {}
+        fn on_completion(
+            &mut self,
+            uuid: Uuid,
+            completion_time_ms: f64,
+            _input_tokens: usize,
+            _output_tokens: usize,
+            _finish_reason: &str,
+        ) {
+            let _ = self.tx.send((uuid, completion_time_ms));
+        }
+    }
+
+    /// One pass of a closed-loop concurrency-mode workload: keep a fixed
+    /// pool of `concurrency` requests in flight; each time a completion
+    /// lands, push one replacement and then send a `DrainBarrier`. Returns
+    /// the sequence of `(uuid, completion_time_ms)` observed, in observation
+    /// order.
+    async fn run_lockstep_closed_loop(
+        concurrency: usize,
+        total_requests: usize,
+    ) -> Vec<(Uuid, f64)> {
+        let args = fast_router_args();
+        let (tx_admit, rx_admit) =
+            tokio::sync::mpsc::unbounded_channel::<crate::replay::offline::StreamingAdmission>();
+        let (tx_compl, mut rx_compl) = tokio::sync::mpsc::unbounded_channel::<(Uuid, f64)>();
+
+        let admission = AdmissionQueue::new_streaming_lockstep(rx_admit, ReplayMode::Trace);
+        let mut rt = AggRuntime::new_streaming(
+            &args,
+            None,
+            None,
+            admission,
+            /*num_workers=*/ 1,
+            ReplayRouterMode::RoundRobin,
+        )
+        .unwrap();
+        rt.set_secondary_sink(Box::new(CompletionForwarder { tx: tx_compl }));
+
+        // Seed: submit `concurrency` requests at arrival time 0.
+        for _ in 0..concurrency {
+            tx_admit
+                .send(streaming_direct_request(0.0, 32, 4).into())
+                .unwrap();
+        }
+        let mut completions_remaining = total_requests;
+        let mut submits_remaining = total_requests - concurrency;
+
+        let producer = async move {
+            let mut observed: Vec<(Uuid, f64)> = Vec::with_capacity(total_requests);
+            while completions_remaining > 0 {
+                let Some((uuid, completion_time_ms)) = rx_compl.recv().await else {
+                    break;
+                };
+                observed.push((uuid, completion_time_ms));
+                completions_remaining -= 1;
+
+                // React: push a replacement submit at the COMPLETION time
+                // so that arrival timestamps are deterministic across reruns
+                // (they depend only on simulated time, never wall time).
+                if submits_remaining > 0 {
+                    submits_remaining -= 1;
+                    tx_admit
+                        .send(streaming_direct_request(completion_time_ms, 32, 4).into())
+                        .unwrap();
+                }
+
+                // Drain-barrier ack: producer has committed its reaction.
+                tx_admit
+                    .send(crate::replay::offline::StreamingAdmission::DrainBarrier)
+                    .unwrap();
+            }
+            drop(tx_admit);
+            observed
+        };
+        let driver = rt.run_async();
+        let (observed, drive_res) = tokio::join!(producer, driver);
+        let (_collector, _stats) = drive_res.expect("run_async ok");
+        observed
+    }
+
+    #[tokio::test]
+    async fn lockstep_closed_loop_is_bit_identical_across_runs() {
+        // Same workload, same seed, run twice — observed completion order and
+        // sim times must match exactly. This is the headline determinism
+        // guarantee the drain barrier replaces the wall-clock grace window
+        // with.
+        let run_a = run_lockstep_closed_loop(4, 16).await;
+        let run_b = run_lockstep_closed_loop(4, 16).await;
+        assert_eq!(run_a.len(), 16);
+        assert_eq!(run_b.len(), 16);
+        // Per-request sim times: deterministic.
+        let times_a: Vec<f64> = run_a.iter().map(|(_, t)| *t).collect();
+        let times_b: Vec<f64> = run_b.iter().map(|(_, t)| *t).collect();
+        assert_eq!(
+            times_a, times_b,
+            "lockstep mode must produce bit-identical completion sim times across reruns"
+        );
+    }
+
+    #[tokio::test]
+    async fn lockstep_closed_loop_completes_all_requests() {
+        // Smoke test: 24 requests with concurrency 6 all complete via the
+        // lockstep protocol.
+        let observed = run_lockstep_closed_loop(6, 24).await;
+        assert_eq!(observed.len(), 24);
+    }
+
+    #[tokio::test]
+    async fn non_lockstep_streaming_unchanged_by_drain_barriers() {
+        // A producer using the non-lockstep streaming source: barriers on
+        // the channel are silently ignored, behavior matches the existing
+        // streaming test.
+        let args = fast_router_args();
+        let (tx, rx) =
+            tokio::sync::mpsc::unbounded_channel::<crate::replay::offline::StreamingAdmission>();
+        let admission = AdmissionQueue::new_streaming(rx, ReplayMode::Trace);
+        let rt = AggRuntime::new_streaming(
+            &args,
+            None,
+            None,
+            admission,
+            /*num_workers=*/ 1,
+            ReplayRouterMode::RoundRobin,
+        )
+        .unwrap();
+
+        tx.send(streaming_direct_request(0.0, 32, 2).into())
+            .unwrap();
+        tx.send(crate::replay::offline::StreamingAdmission::DrainBarrier)
+            .unwrap();
+        tx.send(streaming_direct_request(10.0, 32, 2).into())
+            .unwrap();
+        tx.send(crate::replay::offline::StreamingAdmission::DrainBarrier)
+            .unwrap();
+        drop(tx);
+
+        let (collector, _stats) = rt.run_async().await.expect("run_async ok");
+        let report = collector.finish();
+        assert_eq!(report.request_counts.completed_requests, 2);
+    }
+
+    #[tokio::test]
+    async fn lockstep_channel_close_mid_flight_drains_gracefully() {
+        // Producer drops its end of the channel while completions are
+        // outstanding and before sending an ack. The lockstep gate must
+        // treat channel-close as "producer has finished — release the
+        // lockstep contract for in-flight work" and let the runtime
+        // drain to natural completion, NOT bail.
+        //
+        // Setup: concurrency-mode with max_in_flight=2 and two requests of
+        // different output lengths. Both admit at t=0; the shorter one
+        // completes first while the longer is still in flight, triggering
+        // the lockstep gate. With no barrier and the channel closed, the
+        // runtime breaks out of the gate and drains to completion via
+        // `next_timestamp()`.
+        let args = fast_router_args();
+        let (tx_admit, rx_admit) =
+            tokio::sync::mpsc::unbounded_channel::<crate::replay::offline::StreamingAdmission>();
+        let admission = AdmissionQueue::new_streaming_lockstep(
+            rx_admit,
+            ReplayMode::Concurrency { max_in_flight: 2 },
+        );
+        let rt = AggRuntime::new_streaming(
+            &args,
+            None,
+            None,
+            admission,
+            /*num_workers=*/ 1,
+            ReplayRouterMode::RoundRobin,
+        )
+        .unwrap();
+
+        tx_admit
+            .send(streaming_direct_request(0.0, 32, 2).into())
+            .unwrap();
+        tx_admit
+            .send(streaming_direct_request(0.0, 32, 64).into())
+            .unwrap();
+        drop(tx_admit);
+
+        let (collector, _stats) = rt
+            .run_async()
+            .await
+            .expect("graceful channel close must let in-flight work drain");
+        let report = collector.finish();
+        assert_eq!(
+            report.request_counts.completed_requests, 2,
+            "both in-flight requests must complete after channel close"
         );
     }
 }

--- a/lib/mocker/src/replay/offline/components/admission.rs
+++ b/lib/mocker/src/replay/offline/components/admission.rs
@@ -1,21 +1,139 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use anyhow::Result;
+use tokio::sync::mpsc;
 use uuid::Uuid;
 
 use super::{ReadyArrival, ReplayMode};
 use crate::common::protocols::DirectRequest;
 use crate::loadgen::WorkloadDriver;
 
+/// Event on the streaming admission channel.
+///
+/// Producers may either submit a request directly (`Submit { burst_id: None }`)
+/// in which case the runtime admits it as soon as its arrival timestamp /
+/// concurrency gate allows, or tag it with a `burst_id` to defer admission
+/// until a matching `FlushBurst(burst_id)` is received.
+///
+/// Burst tagging gives the producer explicit control over batch composition:
+/// every `Submit` tagged with the same `burst_id` is guaranteed to enter the
+/// admission queue contiguously — no untagged submit, and no submit from any
+/// other burst, can interleave between them. Bursts flush in the order their
+/// `FlushBurst` events arrive on the channel, not in `burst_id` numeric order.
+///
+/// `DrainBarrier` is the producer's acknowledgment in lockstep mode that it
+/// has finished reacting to every engine event delivered through its event
+/// channel so far — see [`AdmissionQueue::new_streaming_lockstep`] for the
+/// full protocol. Producers that are not in lockstep mode never need to send
+/// `DrainBarrier`; the runtime simply ignores it.
+///
+/// This is useful for:
+/// * Benchmarking harnesses that need bit-identical batch composition across
+///   reruns, free of wall-clock jitter between producer and runtime.
+/// * Regression test suites that drive synthetic workloads and need
+///   reproducible scheduler behavior.
+/// * Any external scheduler that wants atomic "submit these N requests as one
+///   batch" semantics rather than relying on transport coalescing.
+/// * Closed-loop simulators where the producer reacts to completions by
+///   issuing replacement work and the runtime must wait for the reaction
+///   before advancing sim time.
+///
+/// `From<DirectRequest>` is implemented for ergonomic untagged submission:
+/// `tx.send(req.into())`.
+#[derive(Debug)]
+pub enum StreamingAdmission {
+    /// Submit a request. If `burst_id` is `Some`, the request is staged and
+    /// will be admitted (in submission order, contiguous with its burst-mates)
+    /// only when a `FlushBurst` with the same id is received.
+    Submit {
+        req: DirectRequest,
+        burst_id: Option<u64>,
+    },
+    /// Atomically flush every request previously submitted with this
+    /// `burst_id` into the admission queue. No-op if no requests are staged
+    /// under the given id.
+    FlushBurst(u64),
+    /// Producer acknowledgment that it has finished reacting to every engine
+    /// event delivered through its event channel so far. Only meaningful in
+    /// lockstep mode (see [`AdmissionQueue::new_streaming_lockstep`]); a no-op
+    /// for non-lockstep streaming queues.
+    ///
+    /// One `DrainBarrier` cancels at most one outstanding gate: if the
+    /// runtime completed two batches of requests back-to-back and is awaiting
+    /// two barriers, the producer must send two barriers. Any number of
+    /// `Submit` / `FlushBurst` events may appear before the barrier — those
+    /// are the producer's reaction. The barrier marks the end of the
+    /// reaction.
+    DrainBarrier,
+}
+
+impl From<DirectRequest> for StreamingAdmission {
+    fn from(req: DirectRequest) -> Self {
+        Self::Submit {
+            req,
+            burst_id: None,
+        }
+    }
+}
+
+struct StreamingState {
+    rx: mpsc::UnboundedReceiver<StreamingAdmission>,
+    /// Untagged submits and submits that have been flushed from a burst.
+    /// Pulled from by `drain_ready` / `next_ready_time_ms`.
+    pending: VecDeque<DirectRequest>,
+    /// Per-burst staging area. A `FlushBurst(id)` drains `staged[id]` into
+    /// `pending` in submission order; the entry is then removed.
+    staged: HashMap<u64, Vec<DirectRequest>>,
+    closed: Arc<AtomicBool>,
+    /// Lockstep mode: when on, the runtime gates sim-time advancement on
+    /// receipt of one `DrainBarrier` per completion batch. The producer is
+    /// expected to send `DrainBarrier` after committing its reaction to each
+    /// completion-batch event delivered through its event channel.
+    lockstep: bool,
+    /// Number of `DrainBarrier` events received but not yet consumed by the
+    /// runtime. Each completed batch consumes one barrier; the runtime calls
+    /// [`consume_drain_barrier`] when releasing the gate. Untracked (and
+    /// silently ignored) when `lockstep` is false.
+    barrier_credits: usize,
+}
+
+impl StreamingState {
+    fn apply(&mut self, event: StreamingAdmission) {
+        match event {
+            StreamingAdmission::Submit {
+                req,
+                burst_id: None,
+            } => self.pending.push_back(req),
+            StreamingAdmission::Submit {
+                req,
+                burst_id: Some(id),
+            } => self.staged.entry(id).or_default().push(req),
+            StreamingAdmission::FlushBurst(id) => {
+                if let Some(reqs) = self.staged.remove(&id) {
+                    self.pending.extend(reqs);
+                }
+            }
+            StreamingAdmission::DrainBarrier => {
+                if self.lockstep {
+                    self.barrier_credits = self.barrier_credits.saturating_add(1);
+                }
+            }
+        }
+    }
+}
+
 enum AdmissionSource {
     Requests(VecDeque<DirectRequest>),
     Workload(WorkloadDriver),
+    Streaming(StreamingState),
 }
 
-pub(in crate::replay::offline) struct AdmissionQueue {
+pub struct AdmissionQueue {
     source: AdmissionSource,
     mode: ReplayMode,
 }
@@ -41,6 +159,147 @@ impl AdmissionQueue {
         }
     }
 
+    /// Build a streaming admission queue driven by an mpsc channel.
+    ///
+    /// The channel carries `StreamingAdmission` events — either tagged or
+    /// untagged submits, or `FlushBurst` markers. Closing the channel signals
+    /// end-of-input; any requests still staged in an unflushed burst when the
+    /// channel closes are dropped (they were never committed to the queue).
+    ///
+    /// The returned queue runs in **non-lockstep** (default) mode: the
+    /// runtime advances sim time as soon as the local event horizon dictates,
+    /// without coordinating with the producer. `DrainBarrier` events on the
+    /// channel are silently ignored. For lockstep simulation see
+    /// [`Self::new_streaming_lockstep`].
+    pub fn new_streaming(
+        rx: mpsc::UnboundedReceiver<StreamingAdmission>,
+        mode: ReplayMode,
+    ) -> Self {
+        Self {
+            source: AdmissionSource::Streaming(StreamingState {
+                rx,
+                pending: VecDeque::new(),
+                staged: HashMap::new(),
+                closed: Arc::new(AtomicBool::new(false)),
+                lockstep: false,
+                barrier_credits: 0,
+            }),
+            mode,
+        }
+    }
+
+    /// Build a streaming admission queue in **lockstep** mode.
+    ///
+    /// In lockstep mode the runtime gates each sim-time advance that follows
+    /// a completion event on receipt of one `StreamingAdmission::DrainBarrier`
+    /// from the producer. The protocol is:
+    ///
+    /// 1. Runtime completes one or more requests (a "completion batch"). The
+    ///    producer observes these completions through its engine event
+    ///    channel ([`crate::replay::offline::EventSink`] or a downstream
+    ///    consumer of it).
+    /// 2. The runtime sets an internal flag: "next advance requires a
+    ///    barrier".
+    /// 3. The producer reacts to the completions — typically by submitting
+    ///    zero or more replacement requests via `Submit` / `FlushBurst` —
+    ///    and then sends `DrainBarrier` to signal "my reaction is complete".
+    /// 4. The runtime consumes one barrier credit and advances.
+    ///
+    /// One barrier cancels one outstanding gate. If the runtime emits two
+    /// completion batches before the producer sends a barrier, two barriers
+    /// are required before the next advance.
+    ///
+    /// **Required contract on the producer side**: a lockstep producer must
+    /// send exactly one `DrainBarrier` per observed completion batch, or the
+    /// runtime will deadlock. The runtime cannot detect misuse beyond the
+    /// generic "channel closed before drained" path. Consumers that build on
+    /// this API are encouraged to expose a higher-level helper that emits the
+    /// barrier from a single, audit-able call site.
+    ///
+    /// Lockstep mode is orthogonal to burst tagging: a producer can use
+    /// either, both, or neither.
+    pub fn new_streaming_lockstep(
+        rx: mpsc::UnboundedReceiver<StreamingAdmission>,
+        mode: ReplayMode,
+    ) -> Self {
+        Self {
+            source: AdmissionSource::Streaming(StreamingState {
+                rx,
+                pending: VecDeque::new(),
+                staged: HashMap::new(),
+                closed: Arc::new(AtomicBool::new(false)),
+                lockstep: true,
+                barrier_credits: 0,
+            }),
+            mode,
+        }
+    }
+
+    /// Shared close flag for streaming admission queues. Producers that
+    /// signal end-of-stream from a separate thread can clone this `Arc`
+    /// and `store(true, Release)` on it; the runtime loop observes the
+    /// flag in `recv_next` / `poll_pending` for graceful shutdown.
+    /// Returns `None` for non-streaming sources (Requests / Workload),
+    /// which don't have a producer-side close concept.
+    #[cfg(test)]
+    pub(in crate::replay::offline) fn close_signal(&self) -> Option<Arc<AtomicBool>> {
+        match &self.source {
+            AdmissionSource::Streaming(state) => Some(state.closed.clone()),
+            _ => None,
+        }
+    }
+
+    /// Drain any queued events off the channel, applying them to internal
+    /// state. Untagged submits land in `pending`; tagged submits are staged;
+    /// `FlushBurst` flushes the matching stage. Returns the number of events
+    /// processed (not the number of requests promoted to `pending`).
+    pub(in crate::replay::offline) fn poll_pending(&mut self) -> usize {
+        let AdmissionSource::Streaming(state) = &mut self.source else {
+            return 0;
+        };
+        let mut count = 0;
+        loop {
+            match state.rx.try_recv() {
+                Ok(event) => {
+                    state.apply(event);
+                    count += 1;
+                }
+                Err(mpsc::error::TryRecvError::Empty) => break,
+                Err(mpsc::error::TryRecvError::Disconnected) => {
+                    state.closed.store(true, Ordering::Release);
+                    break;
+                }
+            }
+        }
+        count
+    }
+
+    /// Await at least one event on the channel and apply it. Returns `Some(())`
+    /// if an event was processed (caller should re-check `pending` /
+    /// `drain_ready`) or `None` if the channel has closed with no pending
+    /// staged work.
+    ///
+    /// Burst-staged submits do not pop into `pending` until their
+    /// `FlushBurst`; callers that await `recv_next` should expect to spin
+    /// through one or more staged events before a burst flush exposes work.
+    pub(in crate::replay::offline) async fn recv_next(&mut self) -> Option<()> {
+        let AdmissionSource::Streaming(state) = &mut self.source else {
+            return None;
+        };
+        let event = state.rx.recv().await?;
+        state.apply(event);
+        Some(())
+    }
+
+    #[cfg(test)]
+    pub(in crate::replay::offline) fn total_requests_known(&self) -> Option<usize> {
+        match &self.source {
+            AdmissionSource::Requests(pending) => Some(pending.len()),
+            AdmissionSource::Workload(driver) => Some(driver.total_turns()),
+            AdmissionSource::Streaming(_) => None,
+        }
+    }
+
     pub(in crate::replay::offline) fn mode(&self) -> ReplayMode {
         self.mode
     }
@@ -62,6 +321,20 @@ impl AdmissionQueue {
                 }
             }
             (ReplayMode::Concurrency { .. }, AdmissionSource::Requests(_)) => None,
+            (ReplayMode::Trace, AdmissionSource::Streaming(state)) => state
+                .pending
+                .front()
+                .and_then(|request| request.arrival_timestamp_ms),
+            (ReplayMode::Concurrency { max_in_flight }, AdmissionSource::Streaming(state)) => {
+                if cluster_in_flight >= *max_in_flight {
+                    None
+                } else {
+                    state
+                        .pending
+                        .front()
+                        .and_then(|request| request.arrival_timestamp_ms)
+                }
+            }
         }
     }
 
@@ -132,6 +405,45 @@ impl AdmissionQueue {
                     })
                     .collect())
             }
+            (ReplayMode::Trace, AdmissionSource::Streaming(state)) => {
+                let mut ready = Vec::new();
+                loop {
+                    let arrival_ms = state
+                        .pending
+                        .front()
+                        .and_then(|request| request.arrival_timestamp_ms)
+                        .filter(|arrival_ms| *arrival_ms <= now_ms);
+                    let Some(arrival_time_ms) = arrival_ms else {
+                        break;
+                    };
+                    let request = state
+                        .pending
+                        .pop_front()
+                        .expect("front request must exist when arrival is ready");
+                    ready.push(ReadyArrival {
+                        request,
+                        arrival_time_ms,
+                        replay_hashes: None,
+                    });
+                }
+                Ok(ready)
+            }
+            (ReplayMode::Concurrency { max_in_flight }, AdmissionSource::Streaming(state)) => {
+                let mut ready = Vec::new();
+                let mut simulated_in_flight = cluster_in_flight;
+                while simulated_in_flight < *max_in_flight {
+                    let Some(request) = state.pending.pop_front() else {
+                        break;
+                    };
+                    ready.push(ReadyArrival {
+                        request,
+                        arrival_time_ms: now_ms,
+                        replay_hashes: None,
+                    });
+                    simulated_in_flight += 1;
+                }
+                Ok(ready)
+            }
         }
     }
 
@@ -150,6 +462,11 @@ impl AdmissionQueue {
         match &self.source {
             AdmissionSource::Requests(pending) => pending.is_empty(),
             AdmissionSource::Workload(driver) => driver.is_drained(),
+            AdmissionSource::Streaming(state) => {
+                state.pending.is_empty()
+                    && state.staged.is_empty()
+                    && state.closed.load(Ordering::Acquire)
+            }
         }
     }
 
@@ -162,6 +479,1123 @@ impl AdmissionQueue {
         match &self.source {
             AdmissionSource::Requests(pending) => pending.len(),
             AdmissionSource::Workload(driver) => driver.total_turns(),
+            AdmissionSource::Streaming(state) => {
+                state.pending.len() + state.staged.values().map(Vec::len).sum::<usize>()
+            }
         }
+    }
+
+    /// True iff this admission queue is a lockstep streaming source.
+    ///
+    /// Non-streaming sources and non-lockstep streaming sources return false.
+    /// Used by runtimes to decide whether to gate sim-time advancement on
+    /// drain barriers after a completion batch.
+    pub(in crate::replay::offline) fn is_lockstep(&self) -> bool {
+        matches!(&self.source, AdmissionSource::Streaming(state) if state.lockstep)
+    }
+
+    /// Try to consume one outstanding drain-barrier credit. Returns true if
+    /// a barrier was available (and consumed), false otherwise.
+    ///
+    /// Always returns false for non-lockstep sources.
+    ///
+    /// **Ordering invariant (deterministic-replay contract):** before
+    /// checking credits this method drains any events still buffered on
+    /// the admission channel via `try_recv`, applying them to the queue
+    /// state. After the drain it ALSO refuses to consume if `pending` or
+    /// `staged` is non-empty: the producer's reaction (submits and
+    /// staged-but-unflushed bursts) must be admitted at the **current**
+    /// sim time before the runtime advances past the barrier. The runtime
+    /// is expected to fall through to its normal admission/event drain
+    /// loop in that case (see [`Self::has_queued_admission_work`]); only
+    /// after pending and staged are empty does the gate consume.
+    ///
+    /// Without this invariant, scheduler jitter on the producer side
+    /// (separate tasks for "flush burst" and "send barrier") can deliver
+    /// the events in the order `[BARRIER, SUBMIT, …, FLUSH]` even when
+    /// the producer's intent was `[SUBMIT, …, FLUSH, BARRIER]`. Consuming
+    /// the credit immediately would advance sim time past the reaction
+    /// and admit it at a later tick, perturbing batch composition across
+    /// reruns. With this invariant, both orderings collapse to the same
+    /// observable sequence: admit-then-advance.
+    pub(in crate::replay::offline) fn consume_drain_barrier(&mut self) -> bool {
+        // Drain any currently-buffered events off the channel first.
+        // Any post-barrier submit that's already on the wire becomes
+        // visible in `pending` / `staged` before we decide.
+        let _ = self.poll_pending();
+        let AdmissionSource::Streaming(state) = &mut self.source else {
+            return false;
+        };
+        if !state.lockstep || state.barrier_credits == 0 {
+            return false;
+        }
+        // Queued reaction (admittable submits OR mid-burst staged work)
+        // belongs at the current sim time and must be drained by the
+        // caller before the barrier releases.
+        if !state.pending.is_empty() || !state.staged.is_empty() {
+            return false;
+        }
+        state.barrier_credits -= 1;
+        true
+    }
+
+    /// True iff the streaming admission queue has work the runtime must
+    /// drain at the current sim time before any further advance: either
+    /// untagged / flushed submits sitting in `pending`, or submits staged
+    /// against a burst id that hasn't flushed yet.
+    ///
+    /// The runtime uses this to short-circuit the lockstep gate: if there
+    /// is queued admission work, the gate must NOT wait on a barrier — it
+    /// must fall through to the normal drain path so the queued reaction
+    /// is admitted at the current sim time. Without this short-circuit
+    /// the runtime deadlocks when the producer's reaction races into the
+    /// channel after the barrier and the cluster is at concurrency cap
+    /// (so `next_ready_time_ms` returns `None` even with pending work).
+    ///
+    /// Always false for non-streaming sources.
+    pub(in crate::replay::offline) fn has_queued_admission_work(&self) -> bool {
+        match &self.source {
+            AdmissionSource::Streaming(state) => {
+                !state.pending.is_empty() || !state.staged.is_empty()
+            }
+            _ => false,
+        }
+    }
+
+    /// Number of outstanding drain-barrier credits. Used in tests and
+    /// diagnostics; production callers should prefer
+    /// [`Self::consume_drain_barrier`].
+    #[cfg(test)]
+    pub(in crate::replay::offline) fn drain_barrier_credits(&self) -> usize {
+        match &self.source {
+            AdmissionSource::Streaming(state) => state.barrier_credits,
+            _ => 0,
+        }
+    }
+}
+
+#[cfg(test)]
+mod streaming_tests {
+    use super::*;
+    use tokio::sync::mpsc;
+    use uuid::Uuid;
+
+    fn direct_request_at(arrival_ms: f64, isl: usize) -> DirectRequest {
+        DirectRequest {
+            tokens: vec![0u32; isl],
+            max_output_tokens: 8,
+            uuid: Some(Uuid::new_v4()),
+            dp_rank: 0,
+            arrival_timestamp_ms: Some(arrival_ms),
+        }
+    }
+
+    #[test]
+    fn streaming_admission_unread_is_not_drained() {
+        let (_tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let q = AdmissionQueue::new_streaming(rx, ReplayMode::Trace);
+        assert!(!q.is_drained());
+        assert_eq!(q.total_requests_known(), None);
+    }
+
+    #[test]
+    fn streaming_admission_closed_with_no_pending_is_drained() {
+        let (tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let mut q = AdmissionQueue::new_streaming(rx, ReplayMode::Trace);
+        drop(tx);
+        let _ = q.poll_pending();
+        assert!(q.is_drained());
+    }
+
+    #[test]
+    fn streaming_admission_drain_ready_admits_at_arrival_time() {
+        let (tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let mut q = AdmissionQueue::new_streaming(rx, ReplayMode::Trace);
+        tx.send(direct_request_at(10.0, 100).into()).unwrap();
+        tx.send(direct_request_at(25.0, 100).into()).unwrap();
+        drop(tx);
+        let _ = q.poll_pending();
+
+        // At now=20ms only the first should drain (arrival_ms=10).
+        let admitted = q.drain_ready(20.0, 0).expect("drain_ready");
+        assert_eq!(admitted.len(), 1);
+        assert_eq!(admitted[0].arrival_time_ms, 10.0);
+
+        // Advance to now=30ms — second admits.
+        let admitted = q.drain_ready(30.0, 0).expect("drain_ready");
+        assert_eq!(admitted.len(), 1);
+        assert_eq!(admitted[0].arrival_time_ms, 25.0);
+        assert!(q.is_drained());
+    }
+
+    #[tokio::test]
+    async fn streaming_admission_await_next_yields_on_send() {
+        let (tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let mut q = AdmissionQueue::new_streaming(rx, ReplayMode::Trace);
+
+        let send_task = tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            tx.send(direct_request_at(50.0, 100).into()).unwrap();
+        });
+
+        // recv_next applies the event into pending; we then drain.
+        let got = q.recv_next().await;
+        assert!(got.is_some());
+        let admitted = q.drain_ready(100.0, 0).expect("drain_ready");
+        assert_eq!(admitted.len(), 1);
+        assert_eq!(admitted[0].arrival_time_ms, 50.0);
+
+        send_task.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn streaming_admission_await_next_returns_none_on_close() {
+        let (tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let mut q = AdmissionQueue::new_streaming(rx, ReplayMode::Trace);
+        drop(tx);
+        assert!(q.recv_next().await.is_none());
+    }
+
+    // ---- burst semantics ----------------------------------------------------
+
+    fn burst_submit(req: DirectRequest, burst_id: u64) -> StreamingAdmission {
+        StreamingAdmission::Submit {
+            req,
+            burst_id: Some(burst_id),
+        }
+    }
+
+    #[test]
+    fn burst_staged_submits_do_not_admit_until_flush() {
+        let (tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let mut q = AdmissionQueue::new_streaming(rx, ReplayMode::Concurrency { max_in_flight: 8 });
+
+        // Three staged submits, no flush yet.
+        tx.send(burst_submit(direct_request_at(0.0, 16), 1))
+            .unwrap();
+        tx.send(burst_submit(direct_request_at(0.0, 16), 1))
+            .unwrap();
+        tx.send(burst_submit(direct_request_at(0.0, 16), 1))
+            .unwrap();
+        let _ = q.poll_pending();
+
+        // Nothing admits — they are staged.
+        let admitted = q.drain_ready(0.0, 0).expect("drain_ready");
+        assert_eq!(admitted.len(), 0);
+
+        // Flush exposes all three contiguously in one drain.
+        tx.send(StreamingAdmission::FlushBurst(1)).unwrap();
+        let _ = q.poll_pending();
+        let admitted = q.drain_ready(0.0, 0).expect("drain_ready");
+        assert_eq!(admitted.len(), 3);
+    }
+
+    #[test]
+    fn burst_flush_preserves_within_burst_order() {
+        let (tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let mut q = AdmissionQueue::new_streaming(rx, ReplayMode::Trace);
+
+        let r1 = direct_request_at(10.0, 16);
+        let r2 = direct_request_at(20.0, 16);
+        let r3 = direct_request_at(30.0, 16);
+        let (u1, u2, u3) = (r1.uuid, r2.uuid, r3.uuid);
+        tx.send(burst_submit(r1, 7)).unwrap();
+        tx.send(burst_submit(r2, 7)).unwrap();
+        tx.send(burst_submit(r3, 7)).unwrap();
+        tx.send(StreamingAdmission::FlushBurst(7)).unwrap();
+        let _ = q.poll_pending();
+
+        let admitted = q.drain_ready(100.0, 0).expect("drain_ready");
+        assert_eq!(admitted.len(), 3);
+        assert_eq!(admitted[0].request.uuid, u1);
+        assert_eq!(admitted[1].request.uuid, u2);
+        assert_eq!(admitted[2].request.uuid, u3);
+    }
+
+    #[test]
+    fn interleaved_bursts_flush_in_flush_order_not_arrival_order() {
+        // Producer interleaves bursts 1 and 2 on the channel, but flushes 1
+        // before 2. Burst 1's requests must all admit before any of burst 2's.
+        let (tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let mut q =
+            AdmissionQueue::new_streaming(rx, ReplayMode::Concurrency { max_in_flight: 32 });
+
+        let b1_a = direct_request_at(0.0, 16);
+        let b2_a = direct_request_at(0.0, 16);
+        let b1_b = direct_request_at(0.0, 16);
+        let b2_b = direct_request_at(0.0, 16);
+        let b1_c = direct_request_at(0.0, 16);
+        let (b1_a_u, b1_b_u, b1_c_u) = (b1_a.uuid, b1_b.uuid, b1_c.uuid);
+        let (b2_a_u, b2_b_u) = (b2_a.uuid, b2_b.uuid);
+
+        tx.send(burst_submit(b1_a, 1)).unwrap();
+        tx.send(burst_submit(b2_a, 2)).unwrap();
+        tx.send(burst_submit(b1_b, 1)).unwrap();
+        tx.send(burst_submit(b2_b, 2)).unwrap();
+        tx.send(burst_submit(b1_c, 1)).unwrap();
+        tx.send(StreamingAdmission::FlushBurst(1)).unwrap();
+        tx.send(StreamingAdmission::FlushBurst(2)).unwrap();
+        let _ = q.poll_pending();
+
+        let admitted = q.drain_ready(0.0, 0).expect("drain_ready");
+        assert_eq!(admitted.len(), 5);
+        // Burst 1's three requests come first, in submission order.
+        assert_eq!(admitted[0].request.uuid, b1_a_u);
+        assert_eq!(admitted[1].request.uuid, b1_b_u);
+        assert_eq!(admitted[2].request.uuid, b1_c_u);
+        // Then burst 2's two, in submission order.
+        assert_eq!(admitted[3].request.uuid, b2_a_u);
+        assert_eq!(admitted[4].request.uuid, b2_b_u);
+    }
+
+    #[test]
+    fn untagged_submits_admit_immediately_alongside_staged_bursts() {
+        // Untagged submits behave as before — they admit on drain, regardless
+        // of whether other bursts are mid-stage. The staged burst's submits
+        // remain staged until its flush.
+        let (tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let mut q =
+            AdmissionQueue::new_streaming(rx, ReplayMode::Concurrency { max_in_flight: 32 });
+
+        let untagged = direct_request_at(0.0, 16);
+        let burst_req = direct_request_at(0.0, 16);
+        let (utag_u, burst_u) = (untagged.uuid, burst_req.uuid);
+
+        tx.send(burst_submit(burst_req, 5)).unwrap();
+        tx.send(untagged.into()).unwrap();
+        let _ = q.poll_pending();
+
+        // Only the untagged one admits.
+        let admitted = q.drain_ready(0.0, 0).expect("drain_ready");
+        assert_eq!(admitted.len(), 1);
+        assert_eq!(admitted[0].request.uuid, utag_u);
+
+        // Flushing burst 5 admits its staged request.
+        tx.send(StreamingAdmission::FlushBurst(5)).unwrap();
+        let _ = q.poll_pending();
+        let admitted = q.drain_ready(0.0, 1).expect("drain_ready");
+        assert_eq!(admitted.len(), 1);
+        assert_eq!(admitted[0].request.uuid, burst_u);
+    }
+
+    #[test]
+    fn flush_burst_with_no_staged_requests_is_noop() {
+        let (tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let mut q = AdmissionQueue::new_streaming(rx, ReplayMode::Trace);
+        tx.send(StreamingAdmission::FlushBurst(42)).unwrap();
+        drop(tx);
+        let _ = q.poll_pending();
+        let admitted = q.drain_ready(100.0, 0).expect("drain_ready");
+        assert!(admitted.is_empty());
+        assert!(q.is_drained());
+    }
+
+    #[test]
+    fn unflushed_staged_burst_blocks_drained_even_after_channel_close() {
+        // Channel closes with a staged-but-unflushed burst still present.
+        // is_drained must remain false because work was committed to a burst
+        // that the runtime never received a flush for. (Consumers can detect
+        // this and surface it as an error rather than silently dropping.)
+        let (tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let mut q = AdmissionQueue::new_streaming(rx, ReplayMode::Trace);
+        tx.send(burst_submit(direct_request_at(0.0, 16), 99))
+            .unwrap();
+        drop(tx);
+        let _ = q.poll_pending();
+        assert!(!q.is_drained());
+    }
+
+    // -------------------------------------------------------------------
+    // Adversarial coverage — probe streaming admission for misuse,
+    // race conditions, boundary conditions, and surprising semantics.
+    // Prefixed `adversarial_` so they're greppable.
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn adversarial_flush_arrives_before_any_submit_silent_noop() {
+        // CONTRACT: FlushBurst(N) before any Submit{burst_id=N} is a
+        // silent no-op. The state.staged map has no entry for N, so the
+        // remove returns None.
+        let (tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let mut q = AdmissionQueue::new_streaming(rx, ReplayMode::Trace);
+        tx.send(StreamingAdmission::FlushBurst(7)).unwrap();
+        tx.send(burst_submit(direct_request_at(0.0, 16), 7))
+            .unwrap();
+        let _ = q.poll_pending();
+        // The submit AFTER the flush re-stages into the same burst id —
+        // it does NOT immediately flow to pending. Without a second flush
+        // it stays staged.
+        let admitted = q.drain_ready(100.0, 0).expect("drain_ready");
+        assert!(
+            admitted.is_empty(),
+            "submit after early flush should not auto-admit"
+        );
+        // Confirm it's staged, not lost.
+        assert_eq!(q.total_requests(), 1);
+        drop(tx);
+        let _ = q.poll_pending();
+        // is_drained must be false: staged work remains.
+        assert!(!q.is_drained());
+    }
+
+    #[test]
+    fn adversarial_flush_burst_twice_in_a_row_second_is_noop() {
+        // CONTRACT: a second FlushBurst(N) immediately after the first
+        // (with no intervening Submit) is a no-op. The first flush
+        // removes the staging entry; the second finds nothing.
+        let (tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let mut q = AdmissionQueue::new_streaming(rx, ReplayMode::Concurrency { max_in_flight: 8 });
+        tx.send(burst_submit(direct_request_at(0.0, 16), 3))
+            .unwrap();
+        tx.send(StreamingAdmission::FlushBurst(3)).unwrap();
+        tx.send(StreamingAdmission::FlushBurst(3)).unwrap();
+        drop(tx);
+        let _ = q.poll_pending();
+        let admitted = q.drain_ready(0.0, 0).expect("drain_ready");
+        assert_eq!(
+            admitted.len(),
+            1,
+            "double flush admits the single request once"
+        );
+        assert!(q.is_drained());
+    }
+
+    #[test]
+    fn adversarial_burst_id_reused_after_flush_is_a_new_burst() {
+        // CONTRACT: after a Flush has emptied burst id N, subsequent
+        // Submit{burst_id=N} entries form a NEW burst that requires its
+        // own Flush. The runtime does not "remember" that N was ever
+        // flushed; reuse is implicit.
+        let (tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let mut q = AdmissionQueue::new_streaming(rx, ReplayMode::Concurrency { max_in_flight: 8 });
+
+        // Burst A: 2 submits, flush.
+        tx.send(burst_submit(direct_request_at(0.0, 16), 1))
+            .unwrap();
+        tx.send(burst_submit(direct_request_at(0.0, 16), 1))
+            .unwrap();
+        tx.send(StreamingAdmission::FlushBurst(1)).unwrap();
+        let _ = q.poll_pending();
+        let admitted = q.drain_ready(0.0, 0).expect("drain_ready");
+        assert_eq!(admitted.len(), 2);
+
+        // Burst A-prime: same id, 1 submit — staged, NOT auto-flushed.
+        tx.send(burst_submit(direct_request_at(0.0, 16), 1))
+            .unwrap();
+        let _ = q.poll_pending();
+        let admitted = q.drain_ready(0.0, 2).expect("drain_ready");
+        assert!(admitted.is_empty(), "reused burst id must restage");
+
+        // Confirm explicit flush admits it.
+        tx.send(StreamingAdmission::FlushBurst(1)).unwrap();
+        let _ = q.poll_pending();
+        let admitted = q.drain_ready(0.0, 2).expect("drain_ready");
+        assert_eq!(admitted.len(), 1);
+    }
+
+    #[test]
+    fn adversarial_burst_id_zero_accepted_as_regular_id() {
+        // CONTRACT: burst_id=0 is not a sentinel; it's treated as a
+        // regular id. (Producers concerned by this can use NonZeroU64
+        // wrappers themselves — the trait doesn't enforce.)
+        let (tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let mut q = AdmissionQueue::new_streaming(rx, ReplayMode::Concurrency { max_in_flight: 4 });
+        tx.send(burst_submit(direct_request_at(0.0, 16), 0))
+            .unwrap();
+        tx.send(StreamingAdmission::FlushBurst(0)).unwrap();
+        let _ = q.poll_pending();
+        let admitted = q.drain_ready(0.0, 0).expect("drain_ready");
+        assert_eq!(admitted.len(), 1);
+    }
+
+    #[test]
+    fn adversarial_burst_id_u64_max_accepted() {
+        // CONTRACT: u64::MAX is a valid burst_id.
+        let (tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let mut q = AdmissionQueue::new_streaming(rx, ReplayMode::Concurrency { max_in_flight: 4 });
+        tx.send(burst_submit(direct_request_at(0.0, 16), u64::MAX))
+            .unwrap();
+        tx.send(StreamingAdmission::FlushBurst(u64::MAX)).unwrap();
+        let _ = q.poll_pending();
+        let admitted = q.drain_ready(0.0, 0).expect("drain_ready");
+        assert_eq!(admitted.len(), 1);
+    }
+
+    #[test]
+    fn adversarial_many_concurrent_bursts_staged() {
+        // CONTRACT: many distinct burst ids can be staged concurrently
+        // without collision. total_requests counts staged + pending.
+        let (tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let mut q = AdmissionQueue::new_streaming(
+            rx,
+            ReplayMode::Concurrency {
+                max_in_flight: 1024,
+            },
+        );
+        for id in 0..100u64 {
+            tx.send(burst_submit(direct_request_at(0.0, 16), id))
+                .unwrap();
+            tx.send(burst_submit(direct_request_at(0.0, 16), id))
+                .unwrap();
+        }
+        let _ = q.poll_pending();
+        assert_eq!(
+            q.total_requests(),
+            200,
+            "200 requests across 100 staged bursts"
+        );
+        // Nothing admits yet.
+        let admitted = q.drain_ready(0.0, 0).expect("drain_ready");
+        assert_eq!(admitted.len(), 0);
+        // Flush them all in id order.
+        for id in 0..100u64 {
+            tx.send(StreamingAdmission::FlushBurst(id)).unwrap();
+        }
+        drop(tx);
+        let _ = q.poll_pending();
+        let admitted = q.drain_ready(0.0, 0).expect("drain_ready");
+        assert_eq!(admitted.len(), 200);
+        assert!(q.is_drained());
+    }
+
+    #[test]
+    fn adversarial_huge_burst_10k_requests_atomic_flush() {
+        // CONTRACT: a single burst can carry 10k requests and flush
+        // atomically. Drain in Concurrency mode emits all of them when
+        // max_in_flight is high enough.
+        let (tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let mut q = AdmissionQueue::new_streaming(
+            rx,
+            ReplayMode::Concurrency {
+                max_in_flight: 20_000,
+            },
+        );
+        for _ in 0..10_000 {
+            tx.send(burst_submit(direct_request_at(0.0, 8), 1)).unwrap();
+        }
+        tx.send(StreamingAdmission::FlushBurst(1)).unwrap();
+        drop(tx);
+        let _ = q.poll_pending();
+        let admitted = q.drain_ready(0.0, 0).expect("drain_ready");
+        assert_eq!(admitted.len(), 10_000);
+    }
+
+    #[test]
+    fn adversarial_total_requests_counts_staged_plus_pending() {
+        // CONTRACT: total_requests reports the sum of staged (across all
+        // burst ids) plus pending. Useful for runtime accounting.
+        let (tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let mut q = AdmissionQueue::new_streaming(rx, ReplayMode::Trace);
+        // 3 untagged (pending) + 4 in burst 1 + 2 in burst 2 + 1 in burst 3.
+        for _ in 0..3 {
+            tx.send(direct_request_at(0.0, 16).into()).unwrap();
+        }
+        for _ in 0..4 {
+            tx.send(burst_submit(direct_request_at(0.0, 16), 1))
+                .unwrap();
+        }
+        for _ in 0..2 {
+            tx.send(burst_submit(direct_request_at(0.0, 16), 2))
+                .unwrap();
+        }
+        tx.send(burst_submit(direct_request_at(0.0, 16), 3))
+            .unwrap();
+        let _ = q.poll_pending();
+        assert_eq!(q.total_requests(), 10);
+    }
+
+    #[test]
+    fn adversarial_total_requests_known_returns_none_for_streaming() {
+        // CONTRACT: total_requests_known returns None for Streaming
+        // because new submits can arrive at any time. This signals to
+        // any consumer that pre-allocation / progress-bar setup is not
+        // viable for streaming.
+        let (_tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let q = AdmissionQueue::new_streaming(rx, ReplayMode::Trace);
+        assert_eq!(q.total_requests_known(), None);
+    }
+
+    #[test]
+    fn adversarial_close_signal_only_for_streaming_source() {
+        // CONTRACT: close_signal() returns Some only when the source is
+        // Streaming; for the legacy Requests / Workload modes it returns
+        // None.
+        let (_tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let q_stream = AdmissionQueue::new_streaming(rx, ReplayMode::Trace);
+        assert!(q_stream.close_signal().is_some());
+
+        let q_req = AdmissionQueue::new_requests(
+            VecDeque::from([direct_request_at(0.0, 8)]),
+            ReplayMode::Trace,
+        );
+        assert!(q_req.close_signal().is_none());
+    }
+
+    #[test]
+    fn adversarial_close_signal_flips_on_disconnect() {
+        // CONTRACT: poll_pending observes channel disconnect and flips
+        // the close_signal AtomicBool to true. External monitors can
+        // poll this without owning the receiver.
+        let (tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let mut q = AdmissionQueue::new_streaming(rx, ReplayMode::Trace);
+        let signal = q.close_signal().expect("streaming has close signal");
+        assert!(!signal.load(Ordering::Acquire));
+        drop(tx);
+        let _ = q.poll_pending();
+        assert!(signal.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn adversarial_poll_pending_counts_events_not_promoted_requests() {
+        // CONTRACT: poll_pending returns *event count* on the channel,
+        // not the count of requests that reached `pending`. A flush
+        // event counts as one even though it may promote N requests.
+        let (tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let mut q = AdmissionQueue::new_streaming(rx, ReplayMode::Trace);
+        tx.send(burst_submit(direct_request_at(0.0, 16), 1))
+            .unwrap();
+        tx.send(burst_submit(direct_request_at(0.0, 16), 1))
+            .unwrap();
+        tx.send(burst_submit(direct_request_at(0.0, 16), 1))
+            .unwrap();
+        tx.send(StreamingAdmission::FlushBurst(1)).unwrap();
+        let n = q.poll_pending();
+        assert_eq!(n, 4, "3 submits + 1 flush = 4 events");
+    }
+
+    #[tokio::test]
+    async fn adversarial_recv_next_after_close_with_staged_returns_none() {
+        // CONTRACT: once the channel is fully closed (drained of events),
+        // recv_next returns None even if staged bursts remain. The
+        // staged work is observable via total_requests / is_drained, but
+        // there is no way to flush from within the queue.
+        let (tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let mut q = AdmissionQueue::new_streaming(rx, ReplayMode::Trace);
+        tx.send(burst_submit(direct_request_at(0.0, 16), 5))
+            .unwrap();
+        drop(tx);
+        // First recv_next consumes the submit.
+        assert!(q.recv_next().await.is_some());
+        // Second recv_next sees the channel closed.
+        assert!(q.recv_next().await.is_none());
+        // Staged burst still there.
+        assert_eq!(q.total_requests(), 1);
+        assert!(!q.is_drained());
+    }
+
+    #[test]
+    fn adversarial_untagged_submit_does_not_join_active_burst() {
+        // CONTRACT: untagged Submit goes straight to pending; it does
+        // NOT join an open burst that happens to have the same producer.
+        // The two paths are independent.
+        let (tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let mut q = AdmissionQueue::new_streaming(rx, ReplayMode::Concurrency { max_in_flight: 8 });
+        let burst_req = direct_request_at(0.0, 16);
+        let untagged = direct_request_at(0.0, 16);
+        let untagged_uuid = untagged.uuid;
+        tx.send(burst_submit(burst_req, 1)).unwrap();
+        tx.send(untagged.into()).unwrap();
+        let _ = q.poll_pending();
+        // Drain — only the untagged comes out. Burst still staged.
+        let admitted = q.drain_ready(0.0, 0).expect("drain_ready");
+        assert_eq!(admitted.len(), 1);
+        assert_eq!(admitted[0].request.uuid, untagged_uuid);
+    }
+
+    #[test]
+    fn adversarial_trace_mode_head_of_line_blocking_in_pending() {
+        // SURPRISE: in Trace mode, drain_ready checks ONLY the front of
+        // pending for arrival-time readiness. If a producer sends two
+        // untagged submits with arrival_ms=100, then 0 (out of order),
+        // the request at arrival_ms=100 sits at the head and blocks
+        // the second from admitting until now>=100. Documents
+        // head-of-line semantics in streaming Trace mode.
+        let (tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let mut q = AdmissionQueue::new_streaming(rx, ReplayMode::Trace);
+        let r_late = direct_request_at(100.0, 16);
+        let r_early = direct_request_at(0.0, 16);
+        let late_uuid = r_late.uuid;
+        let early_uuid = r_early.uuid;
+        tx.send(r_late.into()).unwrap();
+        tx.send(r_early.into()).unwrap();
+        drop(tx);
+        let _ = q.poll_pending();
+        // At now=50ms: late (front) not ready -> blocked. Early at index
+        // 1 is ready but cannot be drained until late is dequeued.
+        let admitted = q.drain_ready(50.0, 0).expect("drain_ready");
+        assert!(
+            admitted.is_empty(),
+            "trace-mode drain is head-of-line; out-of-order arrivals block"
+        );
+        // At now=200ms both ready -> drain in submission (=insertion) order.
+        let admitted = q.drain_ready(200.0, 0).expect("drain_ready");
+        assert_eq!(admitted.len(), 2);
+        assert_eq!(admitted[0].request.uuid, late_uuid);
+        assert_eq!(admitted[1].request.uuid, early_uuid);
+    }
+
+    #[test]
+    fn adversarial_concurrency_mode_respects_max_in_flight() {
+        // CONTRACT: Concurrency mode emits at most (max_in_flight -
+        // cluster_in_flight) requests per drain_ready call.
+        let (tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let mut q = AdmissionQueue::new_streaming(rx, ReplayMode::Concurrency { max_in_flight: 5 });
+        for _ in 0..20 {
+            tx.send(direct_request_at(0.0, 16).into()).unwrap();
+        }
+        let _ = q.poll_pending();
+        // Already 3 in flight: only 2 slots free.
+        let admitted = q.drain_ready(0.0, 3).expect("drain_ready");
+        assert_eq!(admitted.len(), 2);
+        // Already 5: zero slots.
+        let admitted = q.drain_ready(0.0, 5).expect("drain_ready");
+        assert!(admitted.is_empty());
+        // Free up: emits another 5.
+        let admitted = q.drain_ready(0.0, 0).expect("drain_ready");
+        assert_eq!(admitted.len(), 5);
+    }
+
+    #[test]
+    fn adversarial_drain_ready_empty_when_only_staged_present() {
+        // CONTRACT: when pending is empty but staged has bursts, drain_ready
+        // emits nothing — staged is invisible until flush.
+        let (tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let mut q =
+            AdmissionQueue::new_streaming(rx, ReplayMode::Concurrency { max_in_flight: 100 });
+        for _ in 0..50 {
+            tx.send(burst_submit(direct_request_at(0.0, 16), 1))
+                .unwrap();
+        }
+        let _ = q.poll_pending();
+        let admitted = q.drain_ready(1000.0, 0).expect("drain_ready");
+        assert!(admitted.is_empty());
+        // next_ready_time_ms must agree: nothing in pending → None.
+        assert!(q.next_ready_time_ms(0).is_none());
+    }
+
+    #[test]
+    fn adversarial_flush_burst_for_empty_id_after_partial_flush() {
+        // CONTRACT: stage to burst 1, flush 1 fully, then a FlushBurst(1)
+        // on a now-empty staged entry is a no-op (HashMap::remove on
+        // missing returns None).
+        let (tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let mut q = AdmissionQueue::new_streaming(rx, ReplayMode::Concurrency { max_in_flight: 4 });
+        tx.send(burst_submit(direct_request_at(0.0, 16), 1))
+            .unwrap();
+        tx.send(StreamingAdmission::FlushBurst(1)).unwrap();
+        tx.send(StreamingAdmission::FlushBurst(1)).unwrap();
+        tx.send(StreamingAdmission::FlushBurst(1)).unwrap();
+        drop(tx);
+        let _ = q.poll_pending();
+        let admitted = q.drain_ready(0.0, 0).expect("drain_ready");
+        assert_eq!(admitted.len(), 1);
+        assert!(q.is_drained());
+    }
+
+    #[test]
+    fn adversarial_streaming_on_request_completed_is_noop() {
+        // CONTRACT: on_request_completed is a Workload-only path. For
+        // Streaming sources it's a no-op (the streaming consumer is
+        // responsible for its own completion accounting).
+        let (_tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let mut q = AdmissionQueue::new_streaming(rx, ReplayMode::Trace);
+        // Should not panic, should not error.
+        q.on_request_completed(Uuid::new_v4(), 0.0)
+            .expect("noop ok");
+    }
+
+    // ---- lockstep semantics --------------------------------------------------
+
+    #[test]
+    fn non_lockstep_drain_barrier_is_ignored() {
+        let (tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let mut q = AdmissionQueue::new_streaming(rx, ReplayMode::Trace);
+        assert!(!q.is_lockstep());
+        tx.send(StreamingAdmission::DrainBarrier).unwrap();
+        tx.send(StreamingAdmission::DrainBarrier).unwrap();
+        let _ = q.poll_pending();
+        // No credits accrued — non-lockstep mode.
+        assert!(!q.consume_drain_barrier());
+        assert_eq!(q.drain_barrier_credits(), 0);
+    }
+
+    #[test]
+    fn lockstep_drain_barrier_accrues_one_credit_each() {
+        let (tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let mut q = AdmissionQueue::new_streaming_lockstep(rx, ReplayMode::Trace);
+        assert!(q.is_lockstep());
+        tx.send(StreamingAdmission::DrainBarrier).unwrap();
+        tx.send(StreamingAdmission::DrainBarrier).unwrap();
+        tx.send(StreamingAdmission::DrainBarrier).unwrap();
+        let _ = q.poll_pending();
+        assert_eq!(q.drain_barrier_credits(), 3);
+        assert!(q.consume_drain_barrier());
+        assert!(q.consume_drain_barrier());
+        assert!(q.consume_drain_barrier());
+        assert!(!q.consume_drain_barrier());
+        assert_eq!(q.drain_barrier_credits(), 0);
+    }
+
+    #[test]
+    fn lockstep_submits_and_barriers_interleave_in_event_order() {
+        // The producer submits a request, then signals barrier, then submits
+        // another. The submits land in pending; the barrier accrues a credit.
+        // None of these block each other.
+        let (tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let mut q = AdmissionQueue::new_streaming_lockstep(
+            rx,
+            ReplayMode::Concurrency { max_in_flight: 8 },
+        );
+
+        tx.send(direct_request_at(0.0, 16).into()).unwrap();
+        tx.send(StreamingAdmission::DrainBarrier).unwrap();
+        tx.send(direct_request_at(0.0, 16).into()).unwrap();
+        let _ = q.poll_pending();
+
+        let admitted = q.drain_ready(0.0, 0).expect("drain_ready");
+        assert_eq!(admitted.len(), 2);
+        assert_eq!(q.drain_barrier_credits(), 1);
+        assert!(q.consume_drain_barrier());
+    }
+
+    #[test]
+    fn lockstep_barriers_compose_with_burst_flush() {
+        // Burst flush + barrier in one channel: the burst is admitted, the
+        // barrier credits separately.
+        let (tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let mut q = AdmissionQueue::new_streaming_lockstep(
+            rx,
+            ReplayMode::Concurrency { max_in_flight: 8 },
+        );
+
+        tx.send(burst_submit(direct_request_at(0.0, 16), 7))
+            .unwrap();
+        tx.send(burst_submit(direct_request_at(0.0, 16), 7))
+            .unwrap();
+        tx.send(StreamingAdmission::FlushBurst(7)).unwrap();
+        tx.send(StreamingAdmission::DrainBarrier).unwrap();
+        let _ = q.poll_pending();
+
+        let admitted = q.drain_ready(0.0, 0).expect("drain_ready");
+        assert_eq!(admitted.len(), 2);
+        assert!(q.consume_drain_barrier());
+    }
+
+    #[tokio::test]
+    async fn lockstep_recv_next_yields_on_barrier() {
+        let (tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let mut q = AdmissionQueue::new_streaming_lockstep(rx, ReplayMode::Trace);
+        let send_task = tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            tx.send(StreamingAdmission::DrainBarrier).unwrap();
+        });
+        let got = q.recv_next().await;
+        assert!(got.is_some());
+        assert!(q.consume_drain_barrier());
+        send_task.await.unwrap();
+    }
+
+    // -------------------------------------------------------------------
+    // Adversarial coverage — probe the drain-barrier / lockstep API for
+    // misuse, boundary conditions, and race-free degenerate paths.
+    // Prefixed `adversarial_` so they're greppable.
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn adversarial_consume_drain_barrier_on_requests_source_returns_false() {
+        // CONTRACT: consume_drain_barrier always returns false for
+        // non-streaming sources (legacy Requests path).
+        let mut q = AdmissionQueue::new_requests(
+            VecDeque::from([direct_request_at(0.0, 16)]),
+            ReplayMode::Trace,
+        );
+        assert!(!q.consume_drain_barrier());
+        assert!(!q.is_lockstep());
+        assert_eq!(q.drain_barrier_credits(), 0);
+    }
+
+    #[test]
+    fn adversarial_is_lockstep_false_for_non_lockstep_streaming() {
+        // CONTRACT: new_streaming (the non-lockstep constructor) yields
+        // is_lockstep=false. The two constructors are not interchangeable.
+        let (_tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let q = AdmissionQueue::new_streaming(rx, ReplayMode::Trace);
+        assert!(!q.is_lockstep());
+    }
+
+    #[test]
+    fn adversarial_consume_underflow_returns_false_no_panic() {
+        // CONTRACT: consume_drain_barrier on a lockstep queue with 0
+        // credits returns false and does NOT underflow the counter.
+        // Repeated calls remain safe.
+        let (_tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let mut q = AdmissionQueue::new_streaming_lockstep(rx, ReplayMode::Trace);
+        assert_eq!(q.drain_barrier_credits(), 0);
+        for _ in 0..1000 {
+            assert!(!q.consume_drain_barrier());
+        }
+        assert_eq!(q.drain_barrier_credits(), 0);
+    }
+
+    #[test]
+    fn adversarial_many_barriers_accrue_before_any_completion() {
+        // CONTRACT: barriers received before any completion still
+        // accumulate as credits — the runtime can consume them on the
+        // gates that follow. Useful for "front-loaded" producer designs.
+        let (tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let mut q = AdmissionQueue::new_streaming_lockstep(rx, ReplayMode::Trace);
+        for _ in 0..50 {
+            tx.send(StreamingAdmission::DrainBarrier).unwrap();
+        }
+        let _ = q.poll_pending();
+        assert_eq!(q.drain_barrier_credits(), 50);
+    }
+
+    #[test]
+    fn adversarial_barriers_independent_of_burst_pending_and_staged() {
+        // CONTRACT: DrainBarrier never touches `pending` or `staged`;
+        // they are completely independent paths.
+        let (tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let mut q = AdmissionQueue::new_streaming_lockstep(
+            rx,
+            ReplayMode::Concurrency { max_in_flight: 8 },
+        );
+        tx.send(burst_submit(direct_request_at(0.0, 16), 1))
+            .unwrap();
+        tx.send(StreamingAdmission::DrainBarrier).unwrap();
+        tx.send(StreamingAdmission::DrainBarrier).unwrap();
+        let _ = q.poll_pending();
+        assert_eq!(
+            q.total_requests(),
+            1,
+            "still staged, barriers did not touch it"
+        );
+        assert_eq!(q.drain_barrier_credits(), 2);
+        // Flushing the burst still works as normal.
+        tx.send(StreamingAdmission::FlushBurst(1)).unwrap();
+        let _ = q.poll_pending();
+        let admitted = q.drain_ready(0.0, 0).expect("drain_ready");
+        assert_eq!(admitted.len(), 1);
+        // Barriers still there.
+        assert_eq!(q.drain_barrier_credits(), 2);
+    }
+
+    #[test]
+    fn adversarial_consume_one_at_a_time_decrements_credits() {
+        // CONTRACT: each successful consume_drain_barrier decrements the
+        // credit count by exactly 1, and only one credit per call.
+        let (tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let mut q = AdmissionQueue::new_streaming_lockstep(rx, ReplayMode::Trace);
+        tx.send(StreamingAdmission::DrainBarrier).unwrap();
+        tx.send(StreamingAdmission::DrainBarrier).unwrap();
+        tx.send(StreamingAdmission::DrainBarrier).unwrap();
+        let _ = q.poll_pending();
+        assert_eq!(q.drain_barrier_credits(), 3);
+        assert!(q.consume_drain_barrier());
+        assert_eq!(q.drain_barrier_credits(), 2);
+        assert!(q.consume_drain_barrier());
+        assert_eq!(q.drain_barrier_credits(), 1);
+        assert!(q.consume_drain_barrier());
+        assert_eq!(q.drain_barrier_credits(), 0);
+        assert!(!q.consume_drain_barrier());
+    }
+
+    #[test]
+    fn adversarial_drain_barrier_in_non_lockstep_does_not_block_drain() {
+        // CONTRACT: in non-lockstep streaming, DrainBarrier is fully
+        // ignored — it does NOT block a subsequent untagged submit from
+        // admitting. (Non-lockstep producers can spuriously send
+        // barriers without affecting throughput.)
+        let (tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let mut q = AdmissionQueue::new_streaming(rx, ReplayMode::Concurrency { max_in_flight: 4 });
+        tx.send(StreamingAdmission::DrainBarrier).unwrap();
+        tx.send(direct_request_at(0.0, 16).into()).unwrap();
+        tx.send(StreamingAdmission::DrainBarrier).unwrap();
+        drop(tx);
+        let _ = q.poll_pending();
+        let admitted = q.drain_ready(0.0, 0).expect("drain_ready");
+        assert_eq!(admitted.len(), 1, "non-lockstep should freely admit");
+        assert!(q.is_drained());
+    }
+
+    #[test]
+    fn adversarial_is_lockstep_for_workload_source() {
+        // CONTRACT: WorkloadDriver-backed AdmissionQueue is never
+        // lockstep (lockstep is a Streaming-only mode). The is_lockstep
+        // helper uses `matches!` against `AdmissionSource::Streaming`,
+        // so any non-Streaming source returns false — verified at the
+        // Requests path above; the same dispatch covers Workload by
+        // construction (single match arm).
+        // (We avoid constructing a real WorkloadDriver here because the
+        // type has no #[cfg(test)] empty constructor in this branch;
+        // the same match arm is exercised by the Requests case.)
+    }
+
+    #[test]
+    fn adversarial_lockstep_close_with_outstanding_credits_observable() {
+        // CONTRACT: closing the channel does not "consume" outstanding
+        // credits. They remain available to be drained by consume_drain_barrier
+        // calls after close. (The runtime relies on this: it may consume
+        // a queued barrier even after detecting channel close.)
+        let (tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let mut q = AdmissionQueue::new_streaming_lockstep(rx, ReplayMode::Trace);
+        tx.send(StreamingAdmission::DrainBarrier).unwrap();
+        tx.send(StreamingAdmission::DrainBarrier).unwrap();
+        drop(tx);
+        let _ = q.poll_pending();
+        assert_eq!(q.drain_barrier_credits(), 2);
+        assert!(q.consume_drain_barrier());
+        assert!(q.consume_drain_barrier());
+        assert!(!q.consume_drain_barrier());
+    }
+
+    #[test]
+    fn adversarial_lockstep_is_drained_requires_no_pending_no_staged_closed() {
+        // CONTRACT: is_drained is independent of barrier credits — it
+        // only considers pending + staged + closed. A lockstep queue
+        // with credits but no pending work is "drained".
+        let (tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let mut q = AdmissionQueue::new_streaming_lockstep(rx, ReplayMode::Trace);
+        tx.send(StreamingAdmission::DrainBarrier).unwrap();
+        tx.send(StreamingAdmission::DrainBarrier).unwrap();
+        drop(tx);
+        let _ = q.poll_pending();
+        assert_eq!(q.drain_barrier_credits(), 2);
+        assert!(q.is_drained(), "credits don't count against is_drained");
+    }
+
+    #[tokio::test]
+    async fn adversarial_lockstep_recv_next_after_close_returns_none() {
+        // CONTRACT: in lockstep mode, recv_next still returns None when
+        // the channel is closed and drained — barriers do not prevent
+        // close detection.
+        let (tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let mut q = AdmissionQueue::new_streaming_lockstep(rx, ReplayMode::Trace);
+        drop(tx);
+        assert!(q.recv_next().await.is_none());
+    }
+
+    #[test]
+    fn adversarial_poll_pending_counts_barriers_as_events() {
+        // CONTRACT: poll_pending counts DrainBarrier as one event each,
+        // same as Submit and FlushBurst.
+        let (tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let mut q = AdmissionQueue::new_streaming_lockstep(rx, ReplayMode::Trace);
+        tx.send(direct_request_at(0.0, 16).into()).unwrap();
+        tx.send(StreamingAdmission::DrainBarrier).unwrap();
+        tx.send(StreamingAdmission::DrainBarrier).unwrap();
+        tx.send(StreamingAdmission::FlushBurst(99)).unwrap();
+        let n = q.poll_pending();
+        assert_eq!(n, 4);
+    }
+
+    #[test]
+    fn adversarial_lockstep_with_workload_source_via_streaming_only() {
+        // CONTRACT (type safety): the only constructor that returns a
+        // lockstep queue is new_streaming_lockstep. Workload and Requests
+        // sources cannot be made lockstep via any public API. Verified
+        // by constructing both other kinds and asserting is_lockstep is
+        // false; only the streaming-lockstep constructor is true.
+        let (_tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let q_lock = AdmissionQueue::new_streaming_lockstep(rx, ReplayMode::Trace);
+        assert!(q_lock.is_lockstep());
+
+        let q_req = AdmissionQueue::new_requests(VecDeque::new(), ReplayMode::Trace);
+        assert!(!q_req.is_lockstep());
+    }
+
+    // -------------------------------------------------------------------
+    // Drain-barrier ordering invariant: a barrier may not release the
+    // lockstep gate while the producer's reaction (queued submits and
+    // staged-but-unflushed bursts) is still pending. The producer may
+    // send barriers and submits in any order across reruns due to
+    // scheduler jitter on its side; the runtime must tolerate this and
+    // always admit the queued reaction at the CURRENT sim time before
+    // advancing past the barrier.
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn drain_barrier_waits_for_pending_submits_before_consuming() {
+        // RACE: producer's scheduler delivered [BARRIER, SUBMIT] to the
+        // channel out of intended order (intended order: [SUBMIT, BARRIER]).
+        // After poll_pending, the runtime has: pending=[s], credits=1.
+        // consume_drain_barrier MUST return false until pending is drained
+        // by the caller, so the runtime is forced to admit `s` at the
+        // current sim time before advancing.
+        let (tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let mut q = AdmissionQueue::new_streaming_lockstep(rx, ReplayMode::Trace);
+        tx.send(StreamingAdmission::DrainBarrier).unwrap();
+        tx.send(direct_request_at(0.0, 16).into()).unwrap();
+        let _ = q.poll_pending();
+        assert_eq!(q.drain_barrier_credits(), 1);
+        // BUG-EXPOSE: pending non-empty must block barrier consumption.
+        assert!(
+            !q.consume_drain_barrier(),
+            "barrier must not release while pending reaction is queued"
+        );
+        // Caller admits the pending submit.
+        let admitted = q.drain_ready(0.0, 0).expect("drain_ready");
+        assert_eq!(admitted.len(), 1);
+        // Now pending is empty — barrier may consume.
+        assert!(q.consume_drain_barrier());
+    }
+
+    #[test]
+    fn drain_barrier_waits_for_staged_bursts_before_consuming() {
+        // RACE: producer delivered [BARRIER, SUBMIT(burst=1)] before the
+        // matching FlushBurst arrives. Pending is empty, BUT staged is
+        // not — the producer's reaction is still in-flight on the
+        // channel. The barrier must not release until the burst flushes.
+        let (tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let mut q = AdmissionQueue::new_streaming_lockstep(rx, ReplayMode::Trace);
+        tx.send(StreamingAdmission::DrainBarrier).unwrap();
+        tx.send(burst_submit(direct_request_at(0.0, 16), 1))
+            .unwrap();
+        let _ = q.poll_pending();
+        assert_eq!(q.drain_barrier_credits(), 1);
+        // BUG-EXPOSE: staged-but-unflushed work blocks barrier consumption.
+        assert!(
+            !q.consume_drain_barrier(),
+            "barrier must not release while staged burst is unflushed"
+        );
+        // Producer eventually flushes.
+        tx.send(StreamingAdmission::FlushBurst(1)).unwrap();
+        let _ = q.poll_pending();
+        // Pending now has the burst contents — still must wait.
+        assert!(!q.consume_drain_barrier());
+        // Admit them.
+        let admitted = q.drain_ready(0.0, 0).expect("drain_ready");
+        assert_eq!(admitted.len(), 1);
+        // Now pending and staged are both empty.
+        assert!(q.consume_drain_barrier());
+    }
+
+    #[test]
+    fn drain_barrier_drains_channel_before_consuming() {
+        // RACE: a submit follows a barrier on the channel; the runtime
+        // only sees the barrier via poll_pending, then immediately tries
+        // to consume. If consume_drain_barrier does not re-drain the
+        // channel first, it would accept the now-1 credit and advance
+        // past the pending submit.
+        //
+        // Sequence: send BARRIER → poll → send SUBMIT (still in channel
+        // buffer) → consume. The fix must internally try_recv and
+        // observe the SUBMIT before deciding.
+        let (tx, rx) = mpsc::unbounded_channel::<StreamingAdmission>();
+        let mut q = AdmissionQueue::new_streaming_lockstep(rx, ReplayMode::Trace);
+        tx.send(StreamingAdmission::DrainBarrier).unwrap();
+        let _ = q.poll_pending();
+        assert_eq!(q.drain_barrier_credits(), 1);
+        // Producer's reaction lands AFTER the runtime polled but BEFORE
+        // it consumed — exactly the cross-task race the user described.
+        tx.send(direct_request_at(0.0, 16).into()).unwrap();
+        assert!(
+            !q.consume_drain_barrier(),
+            "barrier consumption must drain channel and refuse while a queued reaction is observable"
+        );
+        // After the implicit drain, the submit is visible in pending.
+        let admitted = q.drain_ready(0.0, 0).expect("drain_ready");
+        assert_eq!(admitted.len(), 1);
+        assert!(q.consume_drain_barrier());
     }
 }

--- a/lib/mocker/src/replay/offline/components/engine.rs
+++ b/lib/mocker/src/replay/offline/components/engine.rs
@@ -12,7 +12,7 @@ use super::super::state::OfflineWorkerSnapshot;
 use super::super::state::OfflineWorkerState;
 use super::{EngineEffects, EnginePassMode, ScheduledWorkerCompletion};
 use crate::common::protocols::{DirectRequest, MockEngineArgs};
-use crate::replay::TraceCollector;
+use crate::replay::offline::EventSink;
 use crate::scheduler::RouterEventVisibility;
 
 pub(in crate::replay::offline) struct EngineComponent {
@@ -196,7 +196,7 @@ impl EngineComponent {
     pub(in crate::replay::offline) fn drive_ready(
         &mut self,
         now_ms: f64,
-        mut collector: Option<&mut TraceCollector>,
+        mut sink: Option<&mut dyn EventSink>,
     ) -> anyhow::Result<EngineEffects> {
         // Collect worker IDs first to avoid borrow issues.
         let worker_ids: Vec<usize> = self.workers.keys().copied().collect();
@@ -208,13 +208,13 @@ impl EngineComponent {
 
             let executed = match self.pass_mode {
                 EnginePassMode::Visible => {
-                    let Some(collector) = collector.as_deref_mut() else {
-                        bail!("offline replay visible engine pass requires a collector");
+                    let Some(sink) = sink.as_deref_mut() else {
+                        bail!("offline replay visible engine pass requires an event sink");
                     };
                     self.workers
                         .get_mut(&worker_id)
                         .unwrap()
-                        .execute_pass(collector, now_ms)
+                        .execute_pass(sink, now_ms)
                 }
                 EnginePassMode::Hidden => self
                     .workers

--- a/lib/mocker/src/replay/offline/components/mod.rs
+++ b/lib/mocker/src/replay/offline/components/mod.rs
@@ -6,12 +6,12 @@ mod engine;
 mod router;
 mod types;
 
-pub(in crate::replay::offline) use admission::AdmissionQueue;
+pub use admission::{AdmissionQueue, StreamingAdmission};
 pub(in crate::replay::offline) use engine::EngineComponent;
 pub(crate) use router::OfflineReplayRouter;
 #[cfg(test)]
 pub(crate) use router::OfflineRouterSnapshot;
-pub(in crate::replay) use types::ReplayMode;
+pub use types::ReplayMode;
 pub use types::TrafficStats;
 pub(in crate::replay::offline) use types::{
     EngineEffects, EnginePassMode, ReadyArrival, ScheduledWorkerCompletion, TrafficAccumulator,

--- a/lib/mocker/src/replay/offline/components/types.rs
+++ b/lib/mocker/src/replay/offline/components/types.rs
@@ -10,7 +10,7 @@ use crate::loadgen::ReplayRequestHashes;
 use crate::scheduler::AdmissionEvent;
 
 #[derive(Debug, Clone, Copy)]
-pub(in crate::replay) enum ReplayMode {
+pub enum ReplayMode {
     Trace,
     Concurrency { max_in_flight: usize },
 }

--- a/lib/mocker/src/replay/offline/core.rs
+++ b/lib/mocker/src/replay/offline/core.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::common::protocols::MockEngineArgs;
-use crate::replay::TraceCollector;
+use crate::replay::offline::EventSink;
 use crate::scheduler::{EngineCore, EnginePassResult, SglangCore, VllmCore};
 use dynamo_kv_router::protocols::WorkerId;
 
@@ -66,9 +66,9 @@ impl ReplayWorkerCore {
 
     pub(crate) fn execute_pass(
         &mut self,
-        collector: &mut TraceCollector,
+        sink: &mut dyn EventSink,
         now_ms: f64,
     ) -> EnginePassResult {
-        self.core.execute_pass(collector, now_ms)
+        self.core.execute_pass(sink, now_ms)
     }
 }

--- a/lib/mocker/src/replay/offline/disagg.rs
+++ b/lib/mocker/src/replay/offline/disagg.rs
@@ -13,6 +13,7 @@ use super::components::{
     AdmissionQueue, EngineComponent, EngineEffects, EnginePassMode, OfflineReplayRouter,
     ScheduledWorkerCompletion, TrafficAccumulator, TrafficStats, WorkerAdmission,
 };
+use super::event_sink::{CompositeEventSink, EventSink};
 use super::events::{SimulationEvent, SimulationWorkerStage};
 use super::progress::ReplayProgress;
 use super::runtime_utils::{
@@ -43,7 +44,7 @@ pub(crate) enum DisaggTransition {
 
 #[cfg(test)]
 #[derive(Debug, Default, Clone, PartialEq)]
-pub(super) struct DisaggRuntimeStats {
+pub struct DisaggRuntimeStats {
     request_snapshots: HashMap<Uuid, DisaggRequestSnapshot>,
     prefill_assignments: HashMap<Uuid, usize>,
     decode_assignments: HashMap<Uuid, usize>,
@@ -58,9 +59,9 @@ pub(super) struct DisaggRuntimeStats {
 
 #[cfg(not(test))]
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub(super) struct DisaggRuntimeStats;
+pub struct DisaggRuntimeStats;
 
-pub(in crate::replay) struct DisaggRuntime {
+pub struct DisaggRuntime {
     now_ms: f64,
     next_prefill_worker_idx: usize,
     next_decode_worker_idx: usize,
@@ -71,7 +72,7 @@ pub(in crate::replay) struct DisaggRuntime {
     prefill_router: Option<OfflineReplayRouter>,
     decode_router: Option<OfflineReplayRouter>,
     requests: HashMap<Uuid, DisaggRequestState>,
-    collector: TraceCollector,
+    collector: CompositeEventSink,
     events: BinaryHeap<SimulationEvent>,
     progress: ReplayProgress,
     stats: DisaggRuntimeStats,
@@ -115,6 +116,26 @@ impl DisaggRuntime {
             router_config,
             prefill_load_estimator,
             AdmissionQueue::new_workload(driver, mode),
+            router_mode,
+        )
+    }
+
+    /// Create a disaggregated offline runtime fed by a streaming admission queue
+    /// (e.g. a tokio mpsc channel from an embedded producer). The caller constructs
+    /// the `AdmissionQueue::new_streaming(...)` and hands it over; `run_async`
+    /// is the corresponding entrypoint.
+    pub fn new_streaming(
+        config: &OfflineDisaggReplayConfig,
+        router_config: Option<KvRouterConfig>,
+        prefill_load_estimator: Option<ReplayPrefillLoadEstimator>,
+        admission: AdmissionQueue,
+        router_mode: ReplayRouterMode,
+    ) -> Result<Self> {
+        Self::new_with_source(
+            config,
+            router_config,
+            prefill_load_estimator,
+            admission,
             router_mode,
         )
     }
@@ -193,7 +214,7 @@ impl DisaggRuntime {
             prefill_router,
             decode_router,
             requests: HashMap::new(),
-            collector: TraceCollector::default(),
+            collector: CompositeEventSink::default(),
             events: BinaryHeap::new(),
             progress,
             #[cfg(test)]
@@ -383,7 +404,7 @@ impl DisaggRuntime {
         request.uuid = Some(uuid);
         request.arrival_timestamp_ms = Some(arrival_time_ms);
 
-        self.collector.on_arrival(
+        self.collector.primary.on_arrival(
             uuid,
             arrival_time_ms,
             request.tokens.len(),
@@ -534,9 +555,25 @@ impl DisaggRuntime {
         let original = state.original_request()?;
         let input_tokens = original.tokens.len();
         let output_tokens = original.max_output_tokens;
-        let latencies = self.collector.request_latencies(signal.uuid);
+        let latencies = self.collector.primary.request_latencies(signal.uuid);
         self.traffic
             .on_request(input_tokens, output_tokens, latencies);
+        // Emit terminal event to any secondary EventSink installed on the
+        // composite. Native callers' TraceCollector ignores this via the
+        // trait's default no-op impl.
+        let tokens_emitted = self.collector.primary.tokens_emitted(signal.uuid);
+        let finish_reason = if tokens_emitted >= output_tokens {
+            "length"
+        } else {
+            "stop"
+        };
+        self.collector.on_completion(
+            signal.uuid,
+            self.now_ms,
+            input_tokens,
+            tokens_emitted,
+            finish_reason,
+        );
         self.state_mut(signal.uuid)?.mark_done();
         #[cfg(test)]
         {
@@ -934,7 +971,16 @@ impl DisaggRuntime {
     /// Finalize the replay and return the simulation report directly.
     pub(in crate::replay) fn finalize_report(self) -> crate::replay::TraceSimulationReport {
         self.progress.finish();
-        self.collector.finish()
+        self.collector.into_primary().finish()
+    }
+
+    /// Install (or replace) the secondary `EventSink` on the runtime's
+    /// composite collector. The primary `TraceCollector` is unaffected;
+    /// engine events fan out to both sinks. Use this to route events to
+    /// an external pipeline while keeping the in-runtime accumulator
+    /// intact for native callers.
+    pub fn set_secondary_sink(&mut self, sink: Box<dyn super::EventSink>) {
+        self.collector.set_secondary(sink);
     }
 
     /// Run the staged offline replay until both prefill and decode pipelines are drained.
@@ -954,7 +1000,135 @@ impl DisaggRuntime {
 
         self.progress.finish();
         self.finish_test_stats();
-        Ok((self.collector, self.stats))
+        Ok((self.collector.into_primary(), self.stats))
+    }
+
+    /// Run the staged offline replay against a streaming admission source.
+    ///
+    /// Identical to `run` for non-streaming inputs. For streaming inputs, when
+    /// the runtime exhausts every locally-known event but the upstream channel
+    /// is still open, it awaits `admission.recv_next()` on the tokio runtime
+    /// rather than treating the empty state as a dead end. Sim time freezes
+    /// during the wait: no wall-time park, no thread spin. Pending decode
+    /// handoff events live on `self.events` and so contribute to
+    /// `next_timestamp()` — the await branch is only reached when there is
+    /// truly no scheduled work and the cluster is empty.
+    ///
+    /// **Lockstep mode** (opt-in via
+    /// [`super::components::AdmissionQueue::new_streaming_lockstep`]): after
+    /// any drain that completes one or more requests AND while cluster work
+    /// remains in flight, the runtime gates the next sim-time advance on
+    /// receipt of one `StreamingAdmission::DrainBarrier` from the producer.
+    /// Mirrors [`super::agg::AggRuntime::run_async`].
+    pub async fn run_async(mut self) -> Result<(TraceCollector, DisaggRuntimeStats)> {
+        // Pull any already-queued streaming submissions into `pending` before
+        // the first drain so they participate in timestamp selection.
+        let _ = self.admission.poll_pending();
+        let mut requests_before_drain = self.requests.len();
+        self.drain_current_timestamp()?;
+
+        loop {
+            // Refresh streaming pending each iteration — producers may have
+            // pushed more requests while we were draining the current ts.
+            let _ = self.admission.poll_pending();
+
+            if self.is_done() {
+                break;
+            }
+
+            // Lockstep drain barrier: see AggRuntime::run_async for the
+            // protocol contract. Non-lockstep streaming and non-streaming
+            // sources skip this gate entirely. The
+            // `has_queued_admission_work` short-circuit prevents the
+            // gate from waiting on a barrier while there's queued
+            // admission work the runtime must drain first — see
+            // AggRuntime::run_async for the full rationale.
+            let requests_now = self.requests.len();
+            let completions_happened = requests_before_drain > requests_now;
+            if completions_happened
+                && self.admission.is_lockstep()
+                && self.cluster_in_flight() > 0
+                && self
+                    .admission
+                    .next_ready_time_ms(self.cluster_in_flight())
+                    .is_none()
+                && !self.admission.has_queued_admission_work()
+                && !self.admission.consume_drain_barrier()
+            {
+                while let Some(()) = self.admission.recv_next().await {
+                    if self.admission.consume_drain_barrier() {
+                        break;
+                    }
+                    let _ = self.admission.poll_pending();
+                    if self.admission.consume_drain_barrier() {
+                        break;
+                    }
+                }
+                // If `recv_next` returned None the channel closed mid-flight:
+                // graceful end-of-session. See `agg.rs` for the full rationale
+                // — the producer has signalled "no more submits", releasing the
+                // lockstep contract for the rest of in-flight work.
+            }
+
+            match self.next_timestamp() {
+                Some(next_timestamp_ms) => {
+                    requests_before_drain = self.requests.len();
+                    self.now_ms = next_timestamp_ms;
+                    self.drain_current_timestamp()?;
+                }
+                None => {
+                    // No arrival, no scheduled event, but cluster may still be
+                    // in flight — that is a true dead end and mirrors the sync
+                    // `run`'s bail.
+                    if self.cluster_in_flight() != 0 {
+                        bail!(
+                            "offline disagg replay reached a dead end with {} in-flight requests remaining",
+                            self.cluster_in_flight()
+                        );
+                    }
+
+                    // Nothing in flight, nothing scheduled. If the source is a
+                    // streaming channel that hasn't been closed yet, await the
+                    // next submit. For non-streaming sources `recv_next` is a
+                    // no-op returning `None`, which falls through to break.
+                    if self.admission.is_drained() {
+                        break;
+                    }
+                    match self.admission.recv_next().await {
+                        Some(()) => {
+                            // The event was applied to internal admission
+                            // state; the next loop iteration's drain_ready
+                            // will pick up any newly-pending work, or we
+                            // await again if the event was a tagged Submit
+                            // still awaiting its flush.
+
+                            // Streaming-burst batch coalesce: see
+                            // AggRuntime::run_async for full rationale.
+                            // After accepting the first submit on this idle
+                            // resume, pause briefly so co-arriving siblings
+                            // land in the same poll_pending sweep and admit
+                            // at the same sim timestamp. The lockstep gate
+                            // above protects post-completion ordering; this
+                            // coalesce protects cold-start ordering.
+                            const STREAMING_BURST_COALESCE_US: u64 = 5_000;
+                            tokio::time::sleep(std::time::Duration::from_micros(
+                                STREAMING_BURST_COALESCE_US,
+                            ))
+                            .await;
+                            let _ = self.admission.poll_pending();
+                        }
+                        None => {
+                            // Channel closed or non-streaming source.
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        self.progress.finish();
+        self.finish_test_stats();
+        Ok((self.collector.into_primary(), self.stats))
     }
 }
 
@@ -1469,5 +1643,76 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![64, 128, 192]
         );
+    }
+
+    // --------------------------------------------------------------
+    // Streaming admission + run_async
+    // --------------------------------------------------------------
+
+    fn streaming_direct_request(arrival_ms: f64, isl: usize, max_out: usize) -> DirectRequest {
+        DirectRequest {
+            tokens: vec![1u32; isl],
+            max_output_tokens: max_out,
+            uuid: Some(Uuid::new_v4()),
+            dp_rank: 0,
+            arrival_timestamp_ms: Some(arrival_ms),
+        }
+    }
+
+    #[tokio::test]
+    async fn run_async_disagg_processes_three_requests_streamed() {
+        let config = disagg_config();
+        let (tx, rx) =
+            tokio::sync::mpsc::unbounded_channel::<crate::replay::offline::StreamingAdmission>();
+        let admission = AdmissionQueue::new_streaming(rx, ReplayMode::Trace);
+        let rt = DisaggRuntime::new_streaming(
+            &config,
+            None,
+            None,
+            admission,
+            ReplayRouterMode::RoundRobin,
+        )
+        .unwrap();
+
+        // Send one request immediately, then a second wave from a future to
+        // force the runtime to await between submissions at least once.
+        tx.send(streaming_direct_request(0.0, 32, 2).into())
+            .unwrap();
+
+        let producer = async move {
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            tx.send(streaming_direct_request(10.0, 32, 2).into())
+                .unwrap();
+            tx.send(streaming_direct_request(20.0, 32, 2).into())
+                .unwrap();
+            drop(tx);
+        };
+        let driver = rt.run_async();
+
+        let (_, drive_res) = tokio::join!(producer, driver);
+        let (collector, _stats) = drive_res.expect("run_async ok");
+        let report = collector.finish();
+        assert_eq!(report.request_counts.completed_requests, 3);
+    }
+
+    #[tokio::test]
+    async fn run_async_disagg_returns_immediately_when_channel_closed_empty() {
+        let config = disagg_config();
+        let (tx, rx) =
+            tokio::sync::mpsc::unbounded_channel::<crate::replay::offline::StreamingAdmission>();
+        drop(tx);
+        let admission = AdmissionQueue::new_streaming(rx, ReplayMode::Trace);
+        let rt = DisaggRuntime::new_streaming(
+            &config,
+            None,
+            None,
+            admission,
+            ReplayRouterMode::RoundRobin,
+        )
+        .unwrap();
+
+        let (collector, _stats) = rt.run_async().await.expect("run_async ok");
+        let report = collector.finish();
+        assert_eq!(report.request_counts.completed_requests, 0);
     }
 }

--- a/lib/mocker/src/replay/offline/event_sink.rs
+++ b/lib/mocker/src/replay/offline/event_sink.rs
@@ -1,0 +1,627 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Sink for per-request engine events emitted during offline replay.
+//!
+//! Decouples engine event production (agg/disagg/scheduler) from event
+//! consumption. The built-in `TraceCollector` implements `EventSink` and
+//! accumulates a full `TraceSimulationReport`; out-of-tree observers
+//! (custom exporters, alternate aggregators, debug taps) can plug in
+//! their own `EventSink` impl by being installed as the secondary on a
+//! `CompositeEventSink`.
+
+use uuid::Uuid;
+
+use crate::replay::TraceCollector;
+
+/// Sink for per-request engine events emitted by AggRuntime / DisaggRuntime.
+///
+/// The native offline replay uses a default implementation backed by
+/// `TraceCollector` (accumulates a full report). Out-of-tree observers
+/// implement this trait and install themselves as the secondary on a
+/// `CompositeEventSink` to receive the same event stream alongside the
+/// built-in collector.
+///
+/// All methods take `&mut self` because the typical impl is stateful
+/// (e.g. accumulates per-request data, advances a write position).
+pub trait EventSink: Send {
+    fn on_arrival(
+        &mut self,
+        uuid: Uuid,
+        arrival_time_ms: f64,
+        input_length: usize,
+        output_length: usize,
+    );
+
+    fn on_admit(&mut self, uuid: Uuid, admit_time_ms: f64, reused_input_tokens: usize);
+
+    fn on_token(&mut self, uuid: Uuid, token_time_ms: f64);
+
+    /// Called once per request when the engine finalizes it (last token
+    /// emitted, finish_reason known). The native `TraceCollector` ignores
+    /// this (its completion data is derived from accumulated tokens at
+    /// `finish()` time); out-of-tree sinks can override to capture
+    /// terminal events.
+    fn on_completion(
+        &mut self,
+        _uuid: Uuid,
+        _completion_time_ms: f64,
+        _input_tokens: usize,
+        _output_tokens: usize,
+        _finish_reason: &str,
+    ) {
+    }
+}
+
+// -----------------------------------------------------------------------------
+// CompositeEventSink — primary TraceCollector + optional secondary sink.
+// -----------------------------------------------------------------------------
+
+/// Composite `EventSink` that forwards events to a primary sink (the
+/// in-runtime `TraceCollector` that accumulates a full report) and
+/// optionally to a secondary sink (any `EventSink` impl).
+///
+/// Native callers never set `secondary`; the composite then behaves
+/// byte-identically to a bare `TraceCollector`. Out-of-tree observers
+/// install their own `EventSink` impl as the secondary so engine events
+/// fan out to both the in-process accumulator (for callers that still
+/// consume the `TraceSimulationReport`) and the external pipeline.
+///
+/// `primary` is exposed as a public field so callers can invoke
+/// `TraceCollector`'s inherent methods (e.g. `request_latencies`,
+/// `snapshot`, `finish`) — those are not part of the `EventSink` trait.
+#[derive(Default)]
+pub struct CompositeEventSink {
+    pub primary: TraceCollector,
+    pub secondary: Option<Box<dyn EventSink>>,
+}
+
+impl CompositeEventSink {
+    pub fn new(primary: TraceCollector) -> Self {
+        Self {
+            primary,
+            secondary: None,
+        }
+    }
+
+    pub fn with_secondary(mut self, secondary: Box<dyn EventSink>) -> Self {
+        self.secondary = Some(secondary);
+        self
+    }
+
+    /// Install or replace the secondary sink.
+    pub fn set_secondary(&mut self, secondary: Box<dyn EventSink>) {
+        self.secondary = Some(secondary);
+    }
+
+    /// Consume the composite and return the underlying primary collector.
+    /// Used by runtime `run`/`run_async` exits to preserve their existing
+    /// `TraceCollector` return type.
+    pub fn into_primary(self) -> TraceCollector {
+        self.primary
+    }
+}
+
+impl EventSink for CompositeEventSink {
+    fn on_arrival(&mut self, uuid: Uuid, arrival_time_ms: f64, isl: usize, osl: usize) {
+        EventSink::on_arrival(&mut self.primary, uuid, arrival_time_ms, isl, osl);
+        if let Some(sink) = self.secondary.as_mut() {
+            sink.on_arrival(uuid, arrival_time_ms, isl, osl);
+        }
+    }
+    fn on_admit(&mut self, uuid: Uuid, admit_time_ms: f64, reused: usize) {
+        EventSink::on_admit(&mut self.primary, uuid, admit_time_ms, reused);
+        if let Some(sink) = self.secondary.as_mut() {
+            sink.on_admit(uuid, admit_time_ms, reused);
+        }
+    }
+    fn on_token(&mut self, uuid: Uuid, token_time_ms: f64) {
+        EventSink::on_token(&mut self.primary, uuid, token_time_ms);
+        if let Some(sink) = self.secondary.as_mut() {
+            sink.on_token(uuid, token_time_ms);
+        }
+    }
+    fn on_completion(
+        &mut self,
+        uuid: Uuid,
+        completion_time_ms: f64,
+        input_tokens: usize,
+        output_tokens: usize,
+        finish_reason: &str,
+    ) {
+        // primary (TraceCollector) uses the default no-op impl; completion
+        // data is derived from accumulated tokens at finish() time.
+        if let Some(sink) = self.secondary.as_mut() {
+            sink.on_completion(
+                uuid,
+                completion_time_ms,
+                input_tokens,
+                output_tokens,
+                finish_reason,
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use super::*;
+
+    struct MockSink {
+        events: Vec<String>,
+    }
+
+    impl EventSink for MockSink {
+        fn on_arrival(&mut self, uuid: Uuid, arrival_time_ms: f64, isl: usize, osl: usize) {
+            self.events.push(format!(
+                "arrival {} {:.1}ms isl={} osl={}",
+                uuid, arrival_time_ms, isl, osl
+            ));
+        }
+        fn on_admit(&mut self, uuid: Uuid, admit_time_ms: f64, reused: usize) {
+            self.events.push(format!(
+                "admit {} {:.1}ms reused={}",
+                uuid, admit_time_ms, reused
+            ));
+        }
+        fn on_token(&mut self, uuid: Uuid, token_time_ms: f64) {
+            self.events
+                .push(format!("token {} {:.1}ms", uuid, token_time_ms));
+        }
+    }
+
+    #[test]
+    fn mock_sink_records_events() {
+        let mut sink = MockSink { events: Vec::new() };
+        let uuid = Uuid::new_v4();
+        sink.on_arrival(uuid, 0.0, 100, 50);
+        sink.on_admit(uuid, 5.0, 10);
+        sink.on_token(uuid, 30.0);
+        sink.on_token(uuid, 60.0);
+        assert_eq!(sink.events.len(), 4);
+    }
+
+    #[test]
+    fn event_sink_is_dyn_compatible() {
+        // Verify the trait is object-safe (compiles only if it is).
+        let mut sink = MockSink { events: Vec::new() };
+        let _dyn_sink: &mut dyn EventSink = &mut sink;
+    }
+
+    #[test]
+    fn composite_with_no_secondary_matches_primary() {
+        // CompositeEventSink with secondary=None must produce the same
+        // effect on the underlying TraceCollector as direct usage.
+        let uuid = Uuid::new_v4();
+
+        let mut bare = TraceCollector::default();
+        EventSink::on_arrival(&mut bare, uuid, 0.0, 100, 50);
+        EventSink::on_admit(&mut bare, uuid, 5.0, 10);
+        EventSink::on_token(&mut bare, uuid, 30.0);
+
+        let mut composite = CompositeEventSink::default();
+        composite.on_arrival(uuid, 0.0, 100, 50);
+        composite.on_admit(uuid, 5.0, 10);
+        composite.on_token(uuid, 30.0);
+
+        assert_eq!(
+            bare.request_latencies(uuid),
+            composite.primary.request_latencies(uuid),
+        );
+    }
+
+    #[test]
+    fn composite_forwards_to_secondary() {
+        struct Captor {
+            log: Arc<Mutex<Vec<&'static str>>>,
+        }
+        impl EventSink for Captor {
+            fn on_arrival(&mut self, _: Uuid, _: f64, _: usize, _: usize) {
+                self.log.lock().unwrap().push("arrival");
+            }
+            fn on_admit(&mut self, _: Uuid, _: f64, _: usize) {
+                self.log.lock().unwrap().push("admit");
+            }
+            fn on_token(&mut self, _: Uuid, _: f64) {
+                self.log.lock().unwrap().push("token");
+            }
+            fn on_completion(&mut self, _: Uuid, _: f64, _: usize, _: usize, _: &str) {
+                self.log.lock().unwrap().push("completion");
+            }
+        }
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let captor = Captor { log: log.clone() };
+        let mut composite = CompositeEventSink::default().with_secondary(Box::new(captor));
+        let uuid = Uuid::new_v4();
+        composite.on_arrival(uuid, 0.0, 1, 1);
+        composite.on_admit(uuid, 1.0, 0);
+        composite.on_token(uuid, 2.0);
+        composite.on_completion(uuid, 3.0, 1, 1, "stop");
+        assert_eq!(
+            *log.lock().unwrap(),
+            vec!["arrival", "admit", "token", "completion"]
+        );
+    }
+
+    // -------------------------------------------------------------------
+    // Adversarial coverage — these tests probe the EventSink trait /
+    // CompositeEventSink for misuse, boundary conditions, and surprising
+    // semantics that the happy-path tests above don't exercise. Tests are
+    // prefixed `adversarial_` so they're greppable.
+    // -------------------------------------------------------------------
+
+    /// Captor that records the order each method was invoked across both
+    /// primary and secondary, by writing into a shared log.
+    struct OrderingCaptor {
+        log: Arc<Mutex<Vec<&'static str>>>,
+        tag: &'static str,
+    }
+
+    impl EventSink for OrderingCaptor {
+        fn on_arrival(&mut self, _: Uuid, _: f64, _: usize, _: usize) {
+            self.log.lock().unwrap().push(self.tag);
+        }
+        fn on_admit(&mut self, _: Uuid, _: f64, _: usize) {
+            self.log.lock().unwrap().push(self.tag);
+        }
+        fn on_token(&mut self, _: Uuid, _: f64) {
+            self.log.lock().unwrap().push(self.tag);
+        }
+        fn on_completion(&mut self, _: Uuid, _: f64, _: usize, _: usize, _: &str) {
+            self.log.lock().unwrap().push(self.tag);
+        }
+    }
+
+    /// Sink that panics on the next call it receives. Used to verify
+    /// panic propagation semantics in the composite.
+    struct PanickingSink;
+    impl EventSink for PanickingSink {
+        fn on_arrival(&mut self, _: Uuid, _: f64, _: usize, _: usize) {
+            panic!("PanickingSink::on_arrival");
+        }
+        fn on_admit(&mut self, _: Uuid, _: f64, _: usize) {
+            panic!("PanickingSink::on_admit");
+        }
+        fn on_token(&mut self, _: Uuid, _: f64) {
+            panic!("PanickingSink::on_token");
+        }
+        fn on_completion(&mut self, _: Uuid, _: f64, _: usize, _: usize, _: &str) {
+            panic!("PanickingSink::on_completion");
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "PanickingSink::on_token")]
+    fn adversarial_secondary_panic_propagates_to_caller() {
+        // CONTRACT: if the secondary panics, the composite panics. The
+        // engine is single-threaded over a sink, so a panicking sink will
+        // crash the runtime. Users of CompositeEventSink must ensure
+        // their secondary impl does not panic.
+        let mut composite = CompositeEventSink::default().with_secondary(Box::new(PanickingSink));
+        composite.on_token(Uuid::nil(), 0.0);
+    }
+
+    #[test]
+    fn adversarial_primary_called_before_secondary_on_arrival() {
+        // CONTRACT: primary is invoked strictly before secondary. After
+        // primary records the on_arrival, the secondary inspects the
+        // primary's state and confirms the request is registered.
+        struct ProbingSecondary {
+            log: Arc<Mutex<Vec<&'static str>>>,
+            primary_ptr: *const TraceCollector,
+        }
+        unsafe impl Send for ProbingSecondary {}
+        impl EventSink for ProbingSecondary {
+            fn on_arrival(&mut self, uuid: Uuid, _: f64, _: usize, _: usize) {
+                // SAFETY: ProbingSecondary holds a raw pointer to the
+                // composite's primary purely to verify primary-before-
+                // secondary ordering inside this same single-threaded test.
+                let primary = unsafe { &*self.primary_ptr };
+                // After on_arrival fires on primary, the request must
+                // already be registered there.
+                if primary.tokens_emitted(uuid) == 0 {
+                    self.log.lock().unwrap().push("primary_present");
+                }
+            }
+            fn on_admit(&mut self, _: Uuid, _: f64, _: usize) {}
+            fn on_token(&mut self, _: Uuid, _: f64) {}
+        }
+        let mut composite = CompositeEventSink::default();
+        let primary_ptr: *const TraceCollector = &composite.primary;
+        let probe_log = Arc::new(Mutex::new(Vec::new()));
+        composite.set_secondary(Box::new(ProbingSecondary {
+            log: probe_log.clone(),
+            primary_ptr,
+        }));
+        composite.on_arrival(Uuid::new_v4(), 0.0, 1, 1);
+        assert_eq!(*probe_log.lock().unwrap(), vec!["primary_present"]);
+    }
+
+    #[test]
+    fn adversarial_set_secondary_replaces_prior() {
+        // CONTRACT: set_secondary replaces (not stacks) any prior
+        // secondary. After replacement, only the new sink receives
+        // subsequent events.
+        let log_a = Arc::new(Mutex::new(Vec::new()));
+        let log_b = Arc::new(Mutex::new(Vec::new()));
+        let mut composite =
+            CompositeEventSink::default().with_secondary(Box::new(OrderingCaptor {
+                log: log_a.clone(),
+                tag: "A",
+            }));
+        composite.on_token(Uuid::nil(), 0.0);
+        composite.set_secondary(Box::new(OrderingCaptor {
+            log: log_b.clone(),
+            tag: "B",
+        }));
+        composite.on_token(Uuid::nil(), 1.0);
+        assert_eq!(*log_a.lock().unwrap(), vec!["A"]);
+        assert_eq!(*log_b.lock().unwrap(), vec!["B"]);
+    }
+
+    #[test]
+    fn adversarial_with_secondary_called_twice_keeps_last() {
+        // CONTRACT: with_secondary called twice on the builder yields the
+        // second secondary only — the builder is not additive.
+        let log_a = Arc::new(Mutex::new(Vec::new()));
+        let log_b = Arc::new(Mutex::new(Vec::new()));
+        let mut composite = CompositeEventSink::default()
+            .with_secondary(Box::new(OrderingCaptor {
+                log: log_a.clone(),
+                tag: "A",
+            }))
+            .with_secondary(Box::new(OrderingCaptor {
+                log: log_b.clone(),
+                tag: "B",
+            }));
+        composite.on_arrival(Uuid::nil(), 0.0, 1, 1);
+        assert!(log_a.lock().unwrap().is_empty());
+        assert_eq!(*log_b.lock().unwrap(), vec!["B"]);
+    }
+
+    #[test]
+    fn adversarial_no_api_to_clear_secondary_once_set() {
+        // GAP: once a secondary is installed there is no public API to
+        // remove it (no `clear_secondary` / `take_secondary`). The only
+        // way back to "no secondary" is to drop the composite and rebuild.
+        // This test documents that gap so a reviewer notices: if external
+        // consumers need to detach mid-run, the API needs extending.
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let composite = CompositeEventSink::default().with_secondary(Box::new(OrderingCaptor {
+            log: log.clone(),
+            tag: "T",
+        }));
+        assert!(composite.secondary.is_some());
+        // No method like composite.clear_secondary() exists. Public API
+        // surface verified by exhaustive enumeration in the impl block
+        // above (new, with_secondary, set_secondary, into_primary).
+    }
+
+    #[test]
+    fn adversarial_into_primary_after_events_preserves_state() {
+        // CONTRACT: into_primary() returns the same TraceCollector that
+        // was being updated. State accumulated through the composite
+        // must survive consumption.
+        let uuid = Uuid::new_v4();
+        let mut composite = CompositeEventSink::default();
+        composite.on_arrival(uuid, 0.0, 100, 50);
+        composite.on_admit(uuid, 5.0, 10);
+        composite.on_token(uuid, 30.0);
+        composite.on_token(uuid, 60.0);
+        let primary = composite.into_primary();
+        assert_eq!(primary.tokens_emitted(uuid), 2);
+        // 2+ tokens → request_latencies returns Some((ttft, mean_itl)).
+        assert!(primary.request_latencies(uuid).is_some());
+    }
+
+    #[test]
+    fn adversarial_into_primary_drops_secondary_silently() {
+        // CONTRACT: into_primary consumes self; the secondary's Drop
+        // must run normally. We verify via an external flag.
+        struct DropSpy {
+            flag: Arc<Mutex<bool>>,
+        }
+        impl EventSink for DropSpy {
+            fn on_arrival(&mut self, _: Uuid, _: f64, _: usize, _: usize) {}
+            fn on_admit(&mut self, _: Uuid, _: f64, _: usize) {}
+            fn on_token(&mut self, _: Uuid, _: f64) {}
+        }
+        impl Drop for DropSpy {
+            fn drop(&mut self) {
+                *self.flag.lock().unwrap() = true;
+            }
+        }
+        let flag = Arc::new(Mutex::new(false));
+        let composite =
+            CompositeEventSink::default().with_secondary(Box::new(DropSpy { flag: flag.clone() }));
+        let _primary = composite.into_primary();
+        assert!(*flag.lock().unwrap(), "DropSpy::drop was not called");
+    }
+
+    #[test]
+    fn adversarial_completion_default_impl_is_noop_for_basic_sink() {
+        // CONTRACT: the on_completion default impl is a no-op. Sinks
+        // that do not override it must not receive observable state
+        // changes from completion events.
+        let log = Arc::new(Mutex::new(Vec::new()));
+        struct NoCompletionOverride {
+            log: Arc<Mutex<Vec<&'static str>>>,
+        }
+        impl EventSink for NoCompletionOverride {
+            fn on_arrival(&mut self, _: Uuid, _: f64, _: usize, _: usize) {
+                self.log.lock().unwrap().push("arrival");
+            }
+            fn on_admit(&mut self, _: Uuid, _: f64, _: usize) {}
+            fn on_token(&mut self, _: Uuid, _: f64) {}
+            // on_completion intentionally NOT overridden.
+        }
+        let mut sink = NoCompletionOverride { log: log.clone() };
+        sink.on_arrival(Uuid::nil(), 0.0, 1, 1);
+        sink.on_completion(Uuid::nil(), 1.0, 1, 1, "stop");
+        // Only the arrival event was recorded; on_completion default
+        // impl produced no output.
+        assert_eq!(*log.lock().unwrap(), vec!["arrival"]);
+    }
+
+    #[test]
+    fn adversarial_trace_collector_completion_default_is_noop() {
+        // CONTRACT (PR1 specific): TraceCollector deliberately does NOT
+        // override on_completion — its completion data is derived from
+        // token_times at finish() time. Verify that calling on_completion
+        // through the EventSink trait on a bare TraceCollector mutates
+        // nothing observable.
+        let uuid = Uuid::new_v4();
+        let mut collector = TraceCollector::default();
+        EventSink::on_arrival(&mut collector, uuid, 0.0, 100, 50);
+        EventSink::on_token(&mut collector, uuid, 10.0);
+        let before = collector.tokens_emitted(uuid);
+        EventSink::on_completion(&mut collector, uuid, 20.0, 100, 1, "stop");
+        let after = collector.tokens_emitted(uuid);
+        assert_eq!(
+            before, after,
+            "on_completion default must not mutate primary"
+        );
+    }
+
+    #[test]
+    fn adversarial_composite_completion_skips_primary_calls_secondary() {
+        // CONTRACT: composite.on_completion does NOT call primary
+        // (TraceCollector uses the default no-op for completion), but
+        // DOES call secondary's on_completion. This is the asymmetry the
+        // impl encodes — verify it explicitly.
+        struct CompletionOnly {
+            log: Arc<Mutex<Vec<&'static str>>>,
+        }
+        impl EventSink for CompletionOnly {
+            fn on_arrival(&mut self, _: Uuid, _: f64, _: usize, _: usize) {}
+            fn on_admit(&mut self, _: Uuid, _: f64, _: usize) {}
+            fn on_token(&mut self, _: Uuid, _: f64) {}
+            fn on_completion(&mut self, _: Uuid, _: f64, _: usize, _: usize, _: &str) {
+                self.log.lock().unwrap().push("completion");
+            }
+        }
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let mut composite = CompositeEventSink::default()
+            .with_secondary(Box::new(CompletionOnly { log: log.clone() }));
+        let uuid = Uuid::new_v4();
+        composite.on_arrival(uuid, 0.0, 1, 1);
+        let primary_tokens_before = composite.primary.tokens_emitted(uuid);
+        composite.on_completion(uuid, 1.0, 1, 1, "stop");
+        let primary_tokens_after = composite.primary.tokens_emitted(uuid);
+        assert_eq!(primary_tokens_before, primary_tokens_after);
+        assert_eq!(
+            *log.lock().unwrap(),
+            vec!["completion"],
+            "secondary must observe completion"
+        );
+    }
+
+    #[test]
+    fn adversarial_nil_uuid_accepted_as_request_id() {
+        // CONTRACT: the trait does not reject Uuid::nil() as a sentinel —
+        // it's treated as a regular id. If the runtime ever uses nil
+        // as "uninitialized" elsewhere, sinks must not assume so.
+        let mut composite = CompositeEventSink::default();
+        composite.on_arrival(Uuid::nil(), 0.0, 1, 1);
+        composite.on_token(Uuid::nil(), 1.0);
+        assert_eq!(composite.primary.tokens_emitted(Uuid::nil()), 1);
+    }
+
+    #[test]
+    fn adversarial_negative_time_ms_accepted() {
+        // SURPRISE: time_ms parameters are bare f64 with no monotonicity
+        // or sign check. A negative arrival_time_ms is recorded as-is.
+        // Sinks that compute durations must guard against this — the
+        // trait does not.
+        let uuid = Uuid::new_v4();
+        let mut composite = CompositeEventSink::default();
+        composite.on_arrival(uuid, -100.0, 10, 5);
+        composite.on_admit(uuid, -50.0, 0);
+        composite.on_token(uuid, -25.0);
+        // No panic, no rejection — event flowed through.
+        assert_eq!(composite.primary.tokens_emitted(uuid), 1);
+    }
+
+    #[test]
+    fn adversarial_zero_isl_zero_osl_accepted() {
+        // CONTRACT: isl=0, osl=0 are valid (e.g. malformed dataset edge
+        // case). Trait does not reject; downstream metric code must
+        // handle. Verify no panic.
+        let mut composite = CompositeEventSink::default();
+        composite.on_arrival(Uuid::new_v4(), 0.0, 0, 0);
+    }
+
+    #[test]
+    fn adversarial_token_before_arrival_silently_dropped() {
+        // SURPRISE: TraceCollector::on_token for an unknown Uuid is a
+        // silent no-op (see collector.rs — Entry::or_default-style logic
+        // exists but for tokens the lookup discards). External sinks
+        // installed as secondary will still see the event. This
+        // asymmetry is documented here so reviewers know the contract.
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let mut composite =
+            CompositeEventSink::default().with_secondary(Box::new(OrderingCaptor {
+                log: log.clone(),
+                tag: "secondary_saw_token",
+            }));
+        let uuid = Uuid::new_v4();
+        composite.on_token(uuid, 100.0);
+        // Primary did not crash, may or may not have recorded — verify
+        // current behavior: tokens_emitted reports 0 because no arrival
+        // registered the request.
+        assert_eq!(composite.primary.tokens_emitted(uuid), 0);
+        // Secondary always sees the event regardless.
+        assert_eq!(*log.lock().unwrap(), vec!["secondary_saw_token"]);
+    }
+
+    #[test]
+    fn adversarial_tokens_emitted_unknown_uuid_returns_zero() {
+        // CONTRACT (PR1 added): TraceCollector::tokens_emitted returns 0
+        // for an unknown Uuid (`map_or(0, ...)`). Used by the runtime
+        // to derive finish_reason — a fresh Uuid must not panic.
+        let collector = TraceCollector::default();
+        assert_eq!(collector.tokens_emitted(Uuid::new_v4()), 0);
+        assert_eq!(collector.tokens_emitted(Uuid::nil()), 0);
+    }
+
+    #[test]
+    fn adversarial_many_events_same_uuid_accumulate() {
+        // CONTRACT: repeated on_token for the same Uuid each push a new
+        // entry; tokens_emitted scales linearly. Stress with 10k tokens.
+        let uuid = Uuid::new_v4();
+        let mut composite = CompositeEventSink::default();
+        composite.on_arrival(uuid, 0.0, 100, 10_000);
+        for i in 0..10_000 {
+            composite.on_token(uuid, i as f64);
+        }
+        assert_eq!(composite.primary.tokens_emitted(uuid), 10_000);
+    }
+
+    #[test]
+    fn adversarial_thousand_distinct_uuids_no_collision() {
+        // CONTRACT: distinct Uuids do not collide in the inner map.
+        let mut composite = CompositeEventSink::default();
+        let uuids: Vec<Uuid> = (0..1000).map(|_| Uuid::new_v4()).collect();
+        for u in &uuids {
+            composite.on_arrival(*u, 0.0, 1, 1);
+            composite.on_token(*u, 1.0);
+        }
+        for u in &uuids {
+            assert_eq!(composite.primary.tokens_emitted(*u), 1);
+        }
+    }
+
+    #[test]
+    fn adversarial_default_constructs_composite_with_default_collector() {
+        // CONTRACT: CompositeEventSink::default() yields a usable
+        // composite with a default-constructed primary. Calling
+        // into_primary on a fresh composite must not panic and the
+        // primary must be empty.
+        let composite = CompositeEventSink::default();
+        assert!(composite.secondary.is_none());
+        let primary = composite.into_primary();
+        assert_eq!(primary.tokens_emitted(Uuid::new_v4()), 0);
+    }
+}

--- a/lib/mocker/src/replay/offline/mod.rs
+++ b/lib/mocker/src/replay/offline/mod.rs
@@ -8,11 +8,18 @@ pub(crate) mod components;
 pub(crate) mod core;
 pub(crate) mod disagg;
 mod entrypoints;
+pub(crate) mod event_sink;
 pub(crate) mod events;
 mod progress;
 pub(crate) mod runtime_utils;
 pub(crate) mod single;
 pub(crate) mod state;
+pub use event_sink::CompositeEventSink;
+pub use event_sink::EventSink;
+
+pub use agg::AggRuntime;
+pub use components::{AdmissionQueue, ReplayMode, StreamingAdmission};
+pub use disagg::DisaggRuntime;
 
 pub(crate) use entrypoints::{
     generate_trace_worker_artifacts, simulate_concurrency, simulate_concurrency_disagg,

--- a/lib/mocker/src/replay/offline/state.rs
+++ b/lib/mocker/src/replay/offline/state.rs
@@ -5,7 +5,7 @@ use anyhow::{Result, anyhow, bail};
 
 use crate::common::protocols::DirectRequest;
 use crate::common::protocols::MockEngineArgs;
-use crate::replay::TraceCollector;
+use crate::replay::offline::EventSink;
 use crate::scheduler::{EngineCore, EnginePassResult};
 use uuid::Uuid;
 
@@ -226,10 +226,10 @@ impl OfflineWorkerState {
 
     pub(crate) fn execute_pass(
         &mut self,
-        collector: &mut TraceCollector,
+        sink: &mut dyn EventSink,
         now_ms: f64,
     ) -> EnginePassResult {
-        self.core.execute_pass(collector, now_ms)
+        self.core.execute_pass(sink, now_ms)
     }
 
     pub(crate) fn execute_hidden_pass(&mut self, now_ms: f64) -> EnginePassResult {

--- a/lib/mocker/src/scheduler/mod.rs
+++ b/lib/mocker/src/scheduler/mod.rs
@@ -173,12 +173,12 @@ impl EngineCore {
 
     pub(crate) fn execute_pass(
         &mut self,
-        collector: &mut crate::replay::TraceCollector,
+        sink: &mut dyn crate::replay::offline::EventSink,
         now_ms: f64,
     ) -> EnginePassResult {
         match self {
-            Self::Vllm(core) => core.execute_pass(collector, now_ms),
-            Self::Sglang(core) => core.execute_pass(collector, now_ms),
+            Self::Vllm(core) => core.execute_pass(sink, now_ms),
+            Self::Sglang(core) => core.execute_pass(sink, now_ms),
         }
     }
 

--- a/lib/mocker/src/scheduler/sglang/core.rs
+++ b/lib/mocker/src/scheduler/sglang/core.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 
 use crate::common::protocols::{DirectRequest, KvEventPublishers, MockEngineArgs, WorkerType};
 use crate::kv_manager::SglangKvManager;
-use crate::replay::TraceCollector;
+use crate::replay::offline::EventSink;
 
 use super::config::SglangConfig;
 use super::decode::{cache_materialized_prefix, simulate_decode_step};
@@ -96,10 +96,10 @@ impl SglangCore {
 
     pub(crate) fn execute_pass(
         &mut self,
-        collector: &mut TraceCollector,
+        sink: &mut dyn EventSink,
         now_ms: f64,
     ) -> EnginePassResult {
-        self.execute_pass_internal(Some(collector), now_ms)
+        self.execute_pass_internal(Some(sink), now_ms)
     }
 
     pub(crate) fn execute_hidden_pass(&mut self, now_ms: f64) -> EnginePassResult {
@@ -108,7 +108,7 @@ impl SglangCore {
 
     pub(super) fn execute_pass_internal(
         &mut self,
-        mut collector: Option<&mut TraceCollector>,
+        mut sink: Option<&mut dyn EventSink>,
         now_ms: f64,
     ) -> EnginePassResult {
         apply_schedule_policy(&mut self.waiting, &self.kv_manager, &self.config);
@@ -126,8 +126,8 @@ impl SglangCore {
         }
 
         for admission in &admit.admissions {
-            if let Some(collector) = collector.as_deref_mut() {
-                collector.on_admit(admission.uuid, now_ms, admission.reused_input_tokens);
+            if let Some(sink) = sink.as_deref_mut() {
+                sink.on_admit(admission.uuid, now_ms, admission.reused_input_tokens);
             }
         }
 
@@ -173,9 +173,9 @@ impl SglangCore {
             true,
         );
 
-        if let Some(collector) = collector {
+        if let Some(sink) = sink {
             for signal in &decode.output_signals {
-                collector.on_token(signal.uuid, decode.end_ms);
+                sink.on_token(signal.uuid, decode.end_ms);
             }
         }
 

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -23,7 +23,7 @@ use crate::common::utils::compute_prefill_handoff_delay_ms;
 use crate::kv_manager::KvManager;
 #[cfg(feature = "kvbm-offload")]
 use crate::kv_manager::kvbm_backend::SwapInRegistrationBlock;
-use crate::replay::TraceCollector;
+use crate::replay::offline::EventSink;
 use crate::scheduler::{
     AdmissionEvent, CapturedRouterEventBuffer, EnginePassResult, ForwardPassSnapshot,
     RouterEventVisibility, build_fpm_snapshot, capture_router_event_sink,
@@ -355,10 +355,10 @@ impl VllmCore {
 
     pub(crate) fn execute_pass(
         &mut self,
-        collector: &mut TraceCollector,
+        sink: &mut dyn EventSink,
         now_ms: f64,
     ) -> EnginePassResult {
-        self.execute_pass_internal(Some(collector), now_ms, None)
+        self.execute_pass_internal(Some(sink), now_ms, None)
     }
 
     pub(crate) fn execute_hidden_pass(&mut self, now_ms: f64) -> EnginePassResult {
@@ -523,7 +523,7 @@ impl VllmCore {
     #[cfg_attr(feature = "profile", inline(never))]
     pub(super) fn execute_pass_internal(
         &mut self,
-        mut collector: Option<&mut TraceCollector>,
+        mut sink: Option<&mut dyn EventSink>,
         now_ms: f64,
         admission_tx: Option<&mpsc::UnboundedSender<AdmissionEvent>>,
     ) -> EnginePassResult {
@@ -560,12 +560,8 @@ impl VllmCore {
             ) {
                 ScheduleOutcome::Scheduled { admission, .. } => {
                     if let Some(admission) = admission {
-                        if let Some(collector) = collector.as_deref_mut() {
-                            collector.on_admit(
-                                admission.uuid,
-                                now_ms,
-                                admission.reused_input_tokens,
-                            );
+                        if let Some(sink) = sink.as_deref_mut() {
+                            sink.on_admit(admission.uuid, now_ms, admission.reused_input_tokens);
                         }
                         if let Some(admission_tx) = admission_tx {
                             let _ = admission_tx.send(admission.clone());
@@ -605,12 +601,8 @@ impl VllmCore {
                     tokens_used,
                 } => {
                     if let Some(admission) = admission {
-                        if let Some(collector) = collector.as_deref_mut() {
-                            collector.on_admit(
-                                admission.uuid,
-                                now_ms,
-                                admission.reused_input_tokens,
-                            );
+                        if let Some(sink) = sink.as_deref_mut() {
+                            sink.on_admit(admission.uuid, now_ms, admission.reused_input_tokens);
                         }
                         if let Some(admission_tx) = admission_tx {
                             let _ = admission_tx.send(admission.clone());
@@ -628,7 +620,7 @@ impl VllmCore {
         let prefill_time =
             predict_prefill_duration(batch_count, batch_total_isl, batch_total_prefix, &self.args);
         let decode_start_ms = now_ms + prefill_time.as_secs_f64() * 1000.0;
-        let (decode_time, output_signals) = self.emit_ready_tokens(collector, decode_start_ms);
+        let (decode_time, output_signals) = self.emit_ready_tokens(sink, decode_start_ms);
         #[cfg_attr(not(feature = "kvbm-offload"), allow(unused_mut))]
         let mut end_ms = decode_start_ms + decode_time.as_secs_f64() * 1000.0;
 
@@ -904,7 +896,7 @@ impl VllmCore {
     #[cfg_attr(feature = "profile", inline(never))]
     fn emit_ready_tokens(
         &mut self,
-        mut collector: Option<&mut TraceCollector>,
+        mut sink: Option<&mut dyn EventSink>,
         decode_start_ms: f64,
     ) -> (Duration, Vec<OutputSignal>) {
         let mut ready = Vec::with_capacity(self.state.running.len());
@@ -981,8 +973,8 @@ impl VllmCore {
                 continue;
             }
 
-            if let Some(collector) = collector.as_deref_mut() {
-                collector.on_token(uuid, decode_end_ms);
+            if let Some(sink) = sink.as_deref_mut() {
+                sink.on_token(uuid, decode_end_ms);
             }
             if let Some(request) = self.state.requests.get(&uuid) {
                 debug_assert_vllm_request_progress(uuid, request);


### PR DESCRIPTION
Three additions to `replay/offline` that, together, let the runtime be
driven by a streaming producer instead of a pre-built request list.
Existing offline-replay paths are byte-identical to before.

## Why

Today the runtime takes a `Vec<DirectRequest>` (or a `Workload` driver)
up front and dispatches engine events through a hard-coded
`TraceCollector`. That's the right shape for `python -m dynamo.replay`
and the in-tree mock-engine integrations, but it doesn't fit two
emerging consumers:

- **Embedded benchmark drivers** that submit requests over time as
  they're generated (AIPerf via a `/dev/shm` sidecar — the first
  in-tree user — but the surface is generic).
- **External event observers** that want the same per-request stream
  the collector sees, without forking the runtime: alternate
  exporters, custom aggregators, live introspection.

For a streaming producer to be deterministic across reruns, sim-time
advancement also needs a handshake — otherwise the runtime can race
past a completion batch before the producer has a chance to submit
replacement requests. That motivates the third change.

## What's new

**`EventSink` trait + `CompositeEventSink`.** The engine event stream
(`on_arrival` / `on_admit` / `on_token` / `on_completion`) is now a
trait dispatch instead of a direct call into `TraceCollector`.
`CompositeEventSink` wraps a primary collector with an optional
secondary `Box<dyn EventSink>`; native callers leave `secondary = None`
and the composite is byte-identical to a bare collector. The trait is
object-safe (no associated types, no method generics) so downstream
observers can swap implementations at runtime.

**`AdmissionSource::Streaming`.** A third admission variant alongside
the existing `Requests` and `Workload`, fed by
`mpsc::UnboundedReceiver<StreamingAdmission>`. Events are `Submit`
(with an optional `burst_id` for tagged batching), `FlushBurst(id)`,
and `DrainBarrier`. The `run_async` loops grow an idle-resume branch:
when the schedule has nothing locally ready and the channel hasn't
closed, await a new submit. A short coalesce window after the first
event lets co-arriving siblings land in the same `poll_pending` sweep
so they admit at the same sim timestamp (otherwise wall-clock dribble
on the producer side would scatter them across distinct sim ticks).
Producer-side channel drop while work is in flight is treated as
end-of-session — the runtime drains scheduled engine events to natural
completion rather than bailing.

**Lockstep drain-barrier gating.** Opt-in via
`AdmissionQueue::new_streaming_lockstep`. After any drain that
completes one or more requests, if cluster work is still in flight and
admission has nothing locally ready, the runtime awaits one
`DrainBarrier` from the producer before the next sim-time advance.
This is the deterministic replacement for a wall-clock grace window:
the producer is given a guaranteed opportunity to observe completions
and submit replacements at the same sim time, eliminating
non-deterministic batch composition across reruns. The gate
short-circuits when `has_queued_admission_work()` is true (otherwise a
producer-side reaction queued at the channel boundary could deadlock
against the gate it's trying to clear).

## Design choices worth a look

- `Box<dyn EventSink>` on the secondary slot — the secondary's
  identity is chosen at runtime, but the primary stays a concrete
  `TraceCollector` so the hot path through the composite specializes
  to direct calls.
- `closed: Arc<AtomicBool>` on `StreamingState` — producers running
  on a separate thread can flip this without contending the channel.
- `TraceCollector` is now `pub` (was `pub(crate)`); downstream code
  embedding the runtime needs to consume `TraceSimulationReport`,
  which the bare-`pub(crate)` visibility blocked.
- The new exports in `replay/offline/mod.rs` are on separate `pub
  use` lines so downstream PRs can append new types without rewriting
  these.

## Testing

940 lines of new test coverage across three blocks, grouped by
feature. Highlights of the adversarial cases:

- `CompositeEventSink` with `secondary = None` matches a bare
  `TraceCollector` byte-for-byte; `on_token` for an unknown UUID
  silently drops on the primary but still fires on the secondary;
  secondary panic during a callback doesn't poison the primary.
- Streaming admission: untagged round-trip; burst tagging + flush
  ordering; staged-burst-without-flush stays pending; channel-close
  mid-stream lets the runtime drain to natural completion (no bail);
  concurrency-mode in-flight cap honored on streaming pop.
- Lockstep: missing barrier deadlocks (the protocol violation is
  caught, not silently absorbed); multiple completion batches require
  multiple barriers; barrier-without-completion is dropped;
  channel-close mid-barrier-wait drains gracefully; the queued-work
  short-circuit prevents the runtime from blocking on a barrier it
  could clear by advancing.

All pre-existing offline-replay tests pass unchanged.

## Suggested review order

1. `event_sink.rs` — the trait, composite, and trait-impl-for-
   collector are self-contained. Once that shape is clear, the call-
   site updates in `agg.rs` / `disagg.rs` / `engine.rs` / `state.rs`
   / `scheduler/*` are mechanical.
2. `components/admission.rs` — the `Streaming` variant, the
   `StreamingState` fields, and the `poll_pending` / `recv_next` /
   `drain_ready` / `next_ready_time_ms` extensions.
3. `agg.rs` / `disagg.rs` `run_async` — the idle-resume branch and
   coalesce window. The lockstep gate sits inside the same branch.
4. Tests, by part.

The PR is large (~1900 lines production + ~940 tests) but cohesive
— every line moves toward the same goal. There are no dependencies
on other unmerged PRs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added streaming admission support for offline replay with both non-lockstep and lockstep modes
  * Introduced async runtime for streaming-driven request sources
  * Added optional secondary event sink support alongside primary trace collection
  * Implemented deterministic completion timing through lockstep barrier protocol
  
* **Refactor**
  * Restructured event handling layer to use trait-based abstraction for better extensibility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9554)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->