### PR TITLE
feat(planner): support fixed extra query params for Prometheus

### DIFF
--- a/components/src/dynamo/planner/config/defaults.py
+++ b/components/src/dynamo/planner/config/defaults.py
@@ -63,6 +63,9 @@ class SLAPlannerDefaults(BasePlannerDefaults):
     metric_pulling_prometheus_ssl_verify = os.environ.get(
         "PROMETHEUS_SSL_VERIFY", "false"
     ).lower() in ("1", "true", "yes")
+    metric_pulling_prometheus_extra_query_params = os.environ.get(
+        "PROMETHEUS_EXTRA_QUERY_PARAMS"
+    )
     profile_results_dir = "profiling_results"
 
     isl = 3000  # in number of tokens

--- a/components/src/dynamo/planner/config/planner_config.py
+++ b/components/src/dynamo/planner/config/planner_config.py
@@ -19,7 +19,8 @@ import math
 import os
 from enum import Enum
 from pathlib import Path
-from typing import Literal, Optional
+from typing import Dict, Literal, Optional
+from urllib.parse import parse_qsl
 
 import yaml
 from pydantic import AliasChoices, BaseModel, Field, model_validator
@@ -166,6 +167,23 @@ class PlannerConfig(BaseModel):
             "preserves the previous PrometheusConnect(disable_ssl=True) "
             "behavior. Set True for hardened monitoring stacks; pair with "
             "an injected CA bundle if the upstream uses a private CA."
+        ),
+    )
+    metric_pulling_prometheus_extra_query_params: Optional[Dict[str, str]] = Field(
+        default_factory=lambda: (
+            dict(
+                parse_qsl(
+                    os.environ.get("PROMETHEUS_EXTRA_QUERY_PARAMS", ""),
+                    strict_parsing=True,
+                )
+            )
+            or None
+        ),
+        exclude=True,
+        description=(
+            "Fixed key/value pairs appended as URL query parameters on every PromQL "
+            "request. Set via PROMETHEUS_EXTRA_QUERY_PARAMS as a URL query string, "
+            "e.g. `namespace=my-ns&tenant=foo`."
         ),
     )
     metric_reporting_prometheus_port: int = Field(

--- a/components/src/dynamo/planner/core/base.py
+++ b/components/src/dynamo/planner/core/base.py
@@ -150,6 +150,7 @@ class NativePlannerBase:
             metrics_source=config.throughput_metrics_source,
             bearer_token=config.metric_pulling_prometheus_token,
             ssl_verify=config.metric_pulling_prometheus_ssl_verify,
+            extra_query_params=config.metric_pulling_prometheus_extra_query_params,
         )
         if config.throughput_metrics_source == "router":
             self.prometheus_traffic_client.warn_if_router_not_scraped()

--- a/components/src/dynamo/planner/monitoring/traffic_metrics.py
+++ b/components/src/dynamo/planner/monitoring/traffic_metrics.py
@@ -18,7 +18,7 @@ import logging
 import math
 import typing
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Dict, Optional
 
 import aiohttp
 from prometheus_api_client import PrometheusConnect
@@ -99,6 +99,7 @@ class PrometheusAPIClient:
         metrics_source: str = "frontend",
         bearer_token: Optional[str] = None,
         ssl_verify: bool = False,
+        extra_query_params: Optional[Dict[str, str]] = None,
     ):
         # disable_ssl=True (default) preserves prior behavior; flip via the
         # ssl_verify config knob (env: PROMETHEUS_SSL_VERIFY) when the
@@ -106,6 +107,8 @@ class PrometheusAPIClient:
         self.prom = PrometheusConnect(url=url, disable_ssl=not ssl_verify)
         if bearer_token:
             self.prom._session.headers["Authorization"] = f"Bearer {bearer_token}"
+        if extra_query_params:
+            self.prom._session.params = dict(extra_query_params)
         self.dynamo_namespace = dynamo_namespace
         self.metrics_source = metrics_source  # "frontend" | "router"
 


### PR DESCRIPTION
#### Overview:

Adds support for fixed extra URL query parameters on every PromQL request the Planner sends. Some Prometheus front-ends enforce tenancy via a fixed query argument — `prom-label-proxy` (and the tenancy ports it fronts in Thanos) require a `namespace=<tenant>` argument on every query and reject requests that try to inline a namespace label selector instead. Without a native knob, deployments behind one of those proxies need an external sidecar to rewrite the query string. A native config avoids that proxy.

#### Details:

- Adds `metric_pulling_prometheus_extra_query_params` to `PlannerConfig` (env: `PROMETHEUS_EXTRA_QUERY_PARAMS`).
- When set, the key/value pairs are attached to the underlying `requests.Session.params`, which the `requests` library merges into the URL query string on every request the session makes. PrometheusConnect uses this same shared session so it carries through automatically.
- The env var accepts a comma-separated `key=value` list (e.g. `PROMETHEUS_EXTRA_QUERY_PARAMS=namespace=foo,team=bar`). Empty segments are skipped; missing `=` or empty keys raise `ValueError` so misconfiguration fails loudly at startup rather than silently dropping the tenancy arg.
- Composes cleanly with the sibling Prometheus auth/TLS knobs (`ssl_verify`, `ca_bundle`, `token`, `token_file`) — the four cover the proxy/auth/TLS path; this one covers the tenancy / shared-Prometheus path.
- Default is unchanged — no extra params attached unless the knob is set. No behavior change for existing deployments.

#### Where should the reviewer start?

- `components/src/dynamo/planner/monitoring/traffic_metrics.py` — `PrometheusAPIClient.__init__` accepts an optional `extra_query_params` dict and sets `self.prom._session.params = dict(extra_query_params)` after construction.
- `components/src/dynamo/planner/config/planner_config.py` — new field plus a `_parse_extra_query_params` helper that turns the env var's comma-separated string into a `Dict[str, str]`.
- `components/src/dynamo/planner/config/defaults.py` — env var default.
- `components/src/dynamo/planner/core/base.py` — threads the config field into the `PrometheusAPIClient` constructor.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none filed.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9557" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring additional Prometheus query parameters through the `PROMETHEUS_EXTRA_QUERY_PARAMS` environment variable. These parameters will be automatically included in all Prometheus metric requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9557)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->