### PR TITLE
feat: parsing images from the tool call result

### DIFF
--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -651,6 +651,7 @@ impl OpenAIPreprocessor {
         builder: &mut PreprocessedRequestBuilder,
         formatted_prompt: Option<String>,
     ) -> Result<Vec<MmImageEntry>> {
+        let mut converted_tool_parts: Vec<ChatCompletionRequestUserMessageContentPart>;
         let mut media_map: MultimodalDataMap = HashMap::new();
         let mut fetch_tasks: Vec<(String, ChatCompletionRequestUserMessageContentPart)> =
             Vec::new();

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -225,7 +225,7 @@ fn extract_images_from_tool_parts(
         }
     }
 
-    return user_parts;
+    user_parts
 }
 
 pub struct OpenAIPreprocessor {

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -22,6 +22,7 @@ use anyhow::{Result, bail};
 
 use dynamo_protocols::types::{
     ChatCompletionMessageContent, ChatCompletionRequestMessage,
+    ChatCompletionRequestToolMessageContent, ChatCompletionRequestToolMessageContentPart,
     ChatCompletionRequestUserMessageContent, ChatCompletionRequestUserMessageContentPart,
     ChatCompletionToolChoiceOption, EncodingFormat,
 };
@@ -205,6 +206,27 @@ static DIM_FETCH_HTTP_CLIENT: std::sync::LazyLock<reqwest::Client> =
             .build_http_client()
             .expect("dim-fetch http client construction failed")
     });
+
+fn extract_images_from_tool_parts(
+    tool_parts: &[ChatCompletionRequestToolMessageContentPart],
+) -> Vec<ChatCompletionRequestUserMessageContentPart> {
+    // Process Tool Call messages with image content.
+    // Due to structure of multimodal types the most laconic solution is to "convert" tool's images to the user's ones.
+    let mut user_parts: Vec<ChatCompletionRequestUserMessageContentPart> = Vec::new();
+
+    for part in tool_parts.iter() {
+        match part {
+            ChatCompletionRequestToolMessageContentPart::Text(_) => continue,
+            ChatCompletionRequestToolMessageContentPart::ImageUrl(image_content) => {
+                user_parts.push(ChatCompletionRequestUserMessageContentPart::ImageUrl(
+                    image_content.clone(),
+                ));
+            }
+        }
+    }
+
+    return user_parts;
+}
 
 pub struct OpenAIPreprocessor {
     mdcsum: String,
@@ -630,7 +652,7 @@ impl OpenAIPreprocessor {
         formatted_prompt: Option<String>,
     ) -> Result<Vec<MmImageEntry>> {
         let mut media_map: MultimodalDataMap = HashMap::new();
-        let mut fetch_tasks: Vec<(String, &ChatCompletionRequestUserMessageContentPart)> =
+        let mut fetch_tasks: Vec<(String, ChatCompletionRequestUserMessageContentPart)> =
             Vec::new();
         // Per-image (mm_hash, width, height) for the lightseek MM-routing path.
         // Accumulated in message order so we don't walk messages twice.
@@ -668,6 +690,14 @@ impl OpenAIPreprocessor {
                     ChatCompletionRequestUserMessageContent::Array(parts) => parts,
                     _ => continue,
                 },
+                ChatCompletionRequestMessage::Tool(t) => match &t.content {
+                    ChatCompletionRequestToolMessageContent::Array(tool_parts) => {
+                        converted_tool_parts =
+                            extract_images_from_tool_parts(tool_parts.as_slice());
+                        &converted_tool_parts
+                    }
+                    _ => continue,
+                },
                 _ => continue,
             };
             for content_part in content_parts.iter() {
@@ -682,7 +712,7 @@ impl OpenAIPreprocessor {
                     if type_str == "image_url" {
                         total_image_count += 1;
                     }
-                    fetch_tasks.push((type_str.to_string(), content_part));
+                    fetch_tasks.push((type_str.to_string(), content_part.clone()));
                 } else {
                     let (type_str, url) = match content_part {
                         ChatCompletionRequestUserMessageContentPart::ImageUrl(p) => {
@@ -2720,6 +2750,70 @@ mod strip_tests {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_extract_images_from_tool_parts() {
+        use dynamo_protocols::types::{
+            ChatCompletionRequestMessageContentPartImage,
+            ChatCompletionRequestMessageContentPartText,
+            ChatCompletionRequestToolMessageContentPart,
+            ChatCompletionRequestUserMessageContentPart, ImageUrl,
+        };
+
+        // Tool call result with text and image content
+        let tool_parts = vec![
+            ChatCompletionRequestToolMessageContentPart::Text(
+                ChatCompletionRequestMessageContentPartText {
+                    text: "Some text...".to_string(),
+                },
+            ),
+            ChatCompletionRequestToolMessageContentPart::ImageUrl(
+                ChatCompletionRequestMessageContentPartImage {
+                    image_url: ImageUrl::from("https://example.com/image1.jpg"),
+                },
+            ),
+            ChatCompletionRequestToolMessageContentPart::Text(
+                ChatCompletionRequestMessageContentPartText {
+                    text: "Some text...".to_string(),
+                },
+            ),
+            ChatCompletionRequestToolMessageContentPart::ImageUrl(
+                ChatCompletionRequestMessageContentPartImage {
+                    image_url: ImageUrl::from("data:image/png;base64,dGVzdA=="),
+                },
+            ),
+        ];
+
+        let result = extract_images_from_tool_parts(&tool_parts);
+
+        // Parse only multimodal data (images only)
+        assert_eq!(result.len(), 2);
+
+        match &result[0] {
+            ChatCompletionRequestUserMessageContentPart::ImageUrl(img) => {
+                assert_eq!(
+                    img.image_url.url.to_string(),
+                    "https://example.com/image1.jpg"
+                );
+            }
+            _ => panic!("Expected ImageUrl content part"),
+        }
+
+        match &result[1] {
+            ChatCompletionRequestUserMessageContentPart::ImageUrl(img) => {
+                assert_eq!(
+                    img.image_url.url.to_string(),
+                    "data:image/png;base64,dGVzdA=="
+                );
+            }
+            _ => panic!("Expected ImageUrl content part"),
+        }
+
+        // Checking empty content
+        let empty_parts: Vec<ChatCompletionRequestToolMessageContentPart> = vec![];
+        let empty_result = extract_images_from_tool_parts(&empty_parts);
+        assert_eq!(empty_result.len(), 0);
+    }
 
     /// PRE.1 — `skip_special_tokens` default. See `lib/llm/PREPROCESSOR_CASES.md`.
     #[test]

--- a/lib/protocols/src/types/chat.rs
+++ b/lib/protocols/src/types/chat.rs
@@ -45,10 +45,6 @@ pub use async_openai::types::chat::{
     ChatCompletionRequestSystemMessageArgs,
     ChatCompletionRequestSystemMessageContent,
     ChatCompletionRequestSystemMessageContentPart,
-    ChatCompletionRequestToolMessage,
-    ChatCompletionRequestToolMessageArgs,
-    ChatCompletionRequestToolMessageContent,
-    ChatCompletionRequestToolMessageContentPart,
     ChatCompletionResponseMessageAudio,
     ChatCompletionTokenLogprob,
     Choice,
@@ -334,6 +330,55 @@ pub struct ChatCompletionTool {
     #[builder(default = "ChatCompletionToolType::Function")]
     pub r#type: ChatCompletionToolType,
     pub function: FunctionObject,
+}
+
+// ---------------------------------------------------------------------------
+// Tool message content parts (local extension)
+// ---------------------------------------------------------------------------
+/// Tool message content part with image support.
+///
+/// Extends upstream tool message parts to allow `image_url` entries, which
+/// enables passing image URLs produced by tools into the multimodal pipeline.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(tag = "type")]
+#[serde(rename_all = "snake_case")]
+pub enum ChatCompletionRequestToolMessageContentPart {
+    Text(ChatCompletionRequestMessageContentPartText),
+    ImageUrl(ChatCompletionRequestMessageContentPartImage),
+}
+
+/// Tool message content.
+///
+/// Mirrors the upstream shape but uses our locally extended to support
+/// images as a tool call result.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(untagged)]
+pub enum ChatCompletionRequestToolMessageContent {
+    /// The text contents of the tool message.
+    Text(String),
+    /// A list of structured content parts (now supports `image_url`).
+    Array(Vec<ChatCompletionRequestToolMessageContentPart>),
+}
+
+impl Default for ChatCompletionRequestToolMessageContent {
+    fn default() -> Self {
+        Self::Text(String::new())
+    }
+}
+
+/// Tool message.
+///
+/// Kept locally so tool messages can carry `image_url` parts in their `content`.
+#[derive(Debug, Serialize, Deserialize, Default, Clone, Builder, PartialEq)]
+#[builder(name = "ChatCompletionRequestToolMessageArgs")]
+#[builder(pattern = "mutable")]
+#[builder(setter(into, strip_option), default)]
+#[builder(derive(Debug))]
+#[builder(build_fn(error = "OpenAIError"))]
+pub struct ChatCompletionRequestToolMessage {
+    /// The contents of the tool message.
+    pub content: ChatCompletionRequestToolMessageContent,
+    pub tool_call_id: String,
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/protocols/src/types/impls.rs
+++ b/lib/protocols/src/types/impls.rs
@@ -99,7 +99,26 @@ impl From<async_openai::types::chat::ChatCompletionRequestToolMessage>
     for ChatCompletionRequestMessage
 {
     fn from(value: async_openai::types::chat::ChatCompletionRequestToolMessage) -> Self {
-        Self::Tool(value)
+        Self::Tool(super::ChatCompletionRequestToolMessage {
+            content: match value.content {
+                async_openai::types::chat::ChatCompletionRequestToolMessageContent::Text(s) => {
+                    super::ChatCompletionRequestToolMessageContent::Text(s)
+                }
+                async_openai::types::chat::ChatCompletionRequestToolMessageContent::Array(parts) => {
+                    super::ChatCompletionRequestToolMessageContent::Array(
+                        parts
+                            .into_iter()
+                            .map(|p| match p {
+                                async_openai::types::chat::ChatCompletionRequestToolMessageContentPart::Text(t) => {
+                                    super::ChatCompletionRequestToolMessageContentPart::Text(t)
+                                }
+                            })
+                            .collect(),
+                    )
+                }
+            },
+            tool_call_id: value.tool_call_id,
+        })
     }
 }
 


### PR DESCRIPTION
#### Overview:

Enable tool call results to return images in a structured way and have those images participate in the existing multimodal preprocessing path. This lets a tool response include `image_url` parts (not just text) and ensures those images are discovered and forwarded to downstream backends consistently.

#### Details:

- Protocol types (tool message extensions)
  - Extend [`ChatCompletionRequestToolMessageContentPart`](lib/protocols/src/types/chat.rs:348) to include an `ImageUrl` variant (in addition to `Text`).
  - Replace upstream tool message wrappers with local types so tool content arrays are typed as `Vec<ChatCompletionRequestToolMessageContentPart>`:
    - [`ChatCompletionRequestToolMessageContent`](lib/protocols/src/types/chat.rs:356)
    - [`ChatCompletionRequestToolMessage`](lib/protocols/src/types/chat.rs:372)
  - Provide a default for tool message content so builders can derive `Default` cleanly.

- Compatibility / conversions
  - Update the `async-openai` -> `dynamo_protocols` conversion so upstream tool messages (currently text-only) are converted into our local tool message type:
    - [`From<async_openai::types::chat::ChatCompletionRequestToolMessage> for ChatCompletionRequestMessage`](lib/protocols/src/types/impls.rs:98)

- Multimodal preprocessing
  - Convert tool message image parts into user-style image parts and reuse the existing multimodal extraction pipeline:
    - [`extract_images_from_tool_parts()`](lib/llm/src/preprocessor.rs:210)
  - Integrate tool message handling into multimodal collection so tool-produced images can be fetched/decoded or passed through as URLs:
    - [`OpenAIPreprocessor::gather_multi_modal_data()`](lib/llm/src/preprocessor.rs:648)

#### Where should the reviewer start?

1. Protocol changes (core type wiring)
   - [`ChatCompletionRequestToolMessageContentPart`](lib/protocols/src/types/chat.rs:348)
   - [`ChatCompletionRequestToolMessageContent`](lib/protocols/src/types/chat.rs:356)
   - [`ChatCompletionRequestToolMessage`](lib/protocols/src/types/chat.rs:372)

2. Conversion boundary (ensuring upstream inputs still work)
   - [`From<async_openai::...ChatCompletionRequestToolMessage> for ChatCompletionRequestMessage`](lib/protocols/src/types/impls.rs:98)

3. Preprocessor behavior (ensuring tool images are actually discovered and forwarded)
   - [`extract_images_from_tool_parts()`](lib/llm/src/preprocessor.rs:210)
   - [`OpenAIPreprocessor::gather_multi_modal_data()`](lib/llm/src/preprocessor.rs:648)

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9562" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->