### PR TITLE
fix(replay): trim online replay diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,0 @@
-# Dynamo Repository Guidance
-
-## Logging
-
-- Do not add `tracing::info!` logs solely for debugging, flaky-test diagnosis, or CI visibility. Use `tracing::debug!` for those breadcrumbs, and keep them scoped and high-signal.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Dynamo Repository Guidance
+
+## Logging
+
+- Do not add `tracing::info!` logs solely for debugging, flaky-test diagnosis, or CI visibility. Use `tracing::debug!` for those breadcrumbs, and keep them scoped and high-signal.

--- a/lib/bindings/python/tests/replay/test_replay_smoke.py
+++ b/lib/bindings/python/tests/replay/test_replay_smoke.py
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import time
-
 import pytest
 
 from dynamo.llm import MockEngineArgs
@@ -288,8 +286,6 @@ def test_run_synthetic_trace_replay_invariant_counts_match(
 
 @pytest.mark.parametrize("replay_mode", ["offline", "online"])
 def test_run_synthetic_trace_replay_supports_multiturn_workloads(tmp_path, replay_mode):
-    print(f"[replay_smoke] starting mode={replay_mode} workers=2 router=kv_router")
-    t0 = time.monotonic()
     report = run_synthetic_trace_replay(
         64,
         2,
@@ -302,9 +298,6 @@ def test_run_synthetic_trace_replay_supports_multiturn_workloads(tmp_path, repla
         inter_turn_delay_ms=5.0,
         shared_prefix_ratio=0.5,
         num_prefix_groups=2,
-    )
-    print(
-        f"[replay_smoke] finished mode={replay_mode} elapsed={time.monotonic() - t0:.3f}s"
     )
 
     _assert_basic_report_counts(

--- a/lib/mocker/src/replay/online/demux.rs
+++ b/lib/mocker/src/replay/online/demux.rs
@@ -28,7 +28,7 @@ async fn process_output_signal(
     };
 
     if state.mark_first_token_once() {
-        tracing::info!(uuid = %output.uuid, "replay_diag: demux on_first_token start");
+        tracing::debug!(uuid = %output.uuid, "replay_diag: demux on_first_token start");
         match router.on_first_token(output.uuid).await {
             Ok(true) => stats.record_prefill_marked(),
             Ok(false) => {}
@@ -38,14 +38,13 @@ async fn process_output_signal(
                 "online replay failed to mark prefill completed"
             ),
         }
-        tracing::info!(uuid = %output.uuid, "replay_diag: demux on_first_token done");
     }
 
     if !output.completed || !state.mark_completed_once() {
         return;
     }
 
-    tracing::info!(uuid = %output.uuid, "replay_diag: demux on_complete start");
+    tracing::debug!(uuid = %output.uuid, "replay_diag: demux on_complete start");
     match router.on_complete(output.uuid).await {
         Ok(true) => stats.record_freed(),
         Ok(false) => {}
@@ -55,7 +54,6 @@ async fn process_output_signal(
             "online replay failed to free completed request"
         ),
     }
-    tracing::info!(uuid = %output.uuid, "replay_diag: demux on_complete done, notifying");
     state.notify_completion();
 }
 

--- a/lib/mocker/src/replay/online/live_runtime.rs
+++ b/lib/mocker/src/replay/online/live_runtime.rs
@@ -216,7 +216,7 @@ impl LiveRuntime {
             workload: Some(Arc::clone(&workload)),
         };
 
-        tracing::info!(
+        tracing::debug!(
             total_turns,
             num_workers = self.senders.len(),
             "replay_diag: workload loop starting"
@@ -226,11 +226,6 @@ impl LiveRuntime {
             let now = now_ms(start);
             let ready_turns = workload.driver.lock().unwrap().pop_ready(now, usize::MAX);
             if !ready_turns.is_empty() {
-                tracing::info!(
-                    count = ready_turns.len(),
-                    tasks_active = tasks.len(),
-                    "replay_diag: spawning ready turns"
-                );
                 for ready_turn in ready_turns {
                     let guard = cap_enabled.then(|| {
                         InFlightGuard::new(Arc::clone(&workload), ready_turn.request_uuid)
@@ -256,7 +251,7 @@ impl LiveRuntime {
                 (driver.is_drained(), driver.next_ready_time_ms())
             };
             if is_drained {
-                tracing::info!(
+                tracing::debug!(
                     tasks_remaining = tasks.len(),
                     "replay_diag: workload drained, waiting for tasks"
                 );
@@ -266,25 +261,20 @@ impl LiveRuntime {
             wait_for_workload_progress(next_ready_ms, start, wake.as_mut()).await;
         }
 
-        let mut completed_tasks = 0usize;
         while let Some(result) = tasks.join_next().await {
-            completed_tasks += 1;
             result.map_err(|e| anyhow!("online replay request task failed: {e}"))??;
         }
-        tracing::info!(completed_tasks, "replay_diag: all tasks joined");
 
         drop(arrival_tx);
-        tracing::info!("replay_diag: shutdown — cancelling workers");
         self.cancel_token.cancel();
         self.schedulers.clear();
 
-        tracing::info!("replay_diag: shutdown — awaiting demux");
+        tracing::debug!("replay_diag: shutdown awaiting demux");
         let report = demux_task
             .await
             .map_err(|e| anyhow!("online replay demux task failed: {e}"))?;
-        tracing::info!("replay_diag: shutdown — demux done, shutting down router");
+        tracing::debug!("replay_diag: shutdown awaiting router");
         router.shutdown().await?;
-        tracing::info!("replay_diag: shutdown complete");
         Ok((report, stats.snapshot()))
     }
 }

--- a/lib/mocker/src/replay/online/task.rs
+++ b/lib/mocker/src/replay/online/task.rs
@@ -108,9 +108,8 @@ pub(super) async fn run_request_task(
     }
 
     ctx.stats.record_dispatch(worker_idx);
-    tracing::info!(%uuid, worker_idx, "replay_diag: request dispatched, awaiting completion");
+    tracing::debug!(%uuid, worker_idx, "replay_diag: request dispatched, awaiting completion");
     state.wait_for_completion().await;
-    tracing::info!(%uuid, "replay_diag: request completed");
     ctx.stats.record_completion();
     ctx.requests.remove(&uuid);
     if let Some(workload) = ctx.workload.as_ref() {


### PR DESCRIPTION
## Summary
- remove the Python replay smoke print/timing breadcrumbs from PR #9548
- keep `pytest.mark.timeout(120)` in place
- demote the remaining Rust `replay_diag` breadcrumbs to `debug!` and keep only higher-signal phase markers

## Validation
- `cargo fmt --all`
- `git diff --check`
- tests not run per request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Reduced diagnostic logging verbosity to decrease log output noise and improve readability of standard logs.
  * Cleaned up test timing measurements and diagnostic output for improved test execution clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9565)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->