### PR TITLE
ci(epp): enable sccache on frontend multi-arch build

### DIFF
--- a/.github/workflows/shared-build-image.yml
+++ b/.github/workflows/shared-build-image.yml
@@ -226,6 +226,8 @@ jobs:
         env:
           ECR_HOSTNAME: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_DEFAULT_REGION }}.amazonaws.com
           IMAGE_REPOSITORY: ai-dynamo/dynamo
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          SCCACHE_S3_BUCKET: ${{ secrets.SCCACHE_S3_BUCKET }}
         timeout-minutes: 20
         run: |
           set -x
@@ -241,10 +243,28 @@ jobs:
             CACHE_ARGS+="--cache-to type=registry,ref=${ECR_HOSTNAME}/${EPP_REPOSITORY}:cache,mode=max "
           fi
 
+          # Enable sccache to match the runtime image build path
+          # (.github/actions/docker-remote-build). The runner pod injects
+          # AWS_WEB_IDENTITY_TOKEN_FILE + AWS_ROLE_ARN via IRSA; the Makefile
+          # forwards them to BuildKit as --secret mounts when both are set.
+          # If IRSA is unavailable, sccache will fail to start inside the
+          # container and the build proceeds without cache (never with a
+          # stale one) -- same fallback as the wheel_builder Rust steps.
+          SCCACHE_MAKE_ARGS=""
+          if [ -n "${SCCACHE_S3_BUCKET:-}" ] \
+              && [ -n "${AWS_WEB_IDENTITY_TOKEN_FILE:-}" ] \
+              && [ -f "${AWS_WEB_IDENTITY_TOKEN_FILE}" ] \
+              && [ -n "${AWS_ROLE_ARN:-}" ]; then
+            SCCACHE_MAKE_ARGS="USE_SCCACHE=true SCCACHE_BUCKET=${SCCACHE_S3_BUCKET} SCCACHE_REGION=${AWS_DEFAULT_REGION}"
+          else
+            echo "::warning::sccache prerequisites missing (bucket or IRSA token); EPP Rust build will run without sccache"
+          fi
+
           make -C deploy/inference-gateway/epp image-multiarch-push \
             IMAGE_REPO="${EPP_IMAGE_REPO}" \
             GIT_TAG="${EPP_IMAGE_TAG}" \
             DOCKER_PROXY="${ECR_HOSTNAME}/dockerhub/" \
+            ${SCCACHE_MAKE_ARGS} \
             EXTRA_BUILD_ARGS="${CACHE_ARGS}"
       - name: Refresh BuildKit builder (For Frontend Only)
         if: ${{ inputs.target == 'frontend' }}


### PR DESCRIPTION
## Summary

Restores the EPP sccache wiring that was added in #8604 and silently lost in #8115 when the EPP build was migrated to `shared-build-image.yml`.

### Timeline

- **#8604** (2026-04-23, `nv-anants`) added sccache to the EPP build across three files: `build-frontend-image.yaml` (env + `USE_SCCACHE`/`SCCACHE_BUCKET`/`SCCACHE_REGION` make args), `deploy/inference-gateway/epp/Dockerfile`, and `deploy/inference-gateway/epp/Makefile`. Worked correctly.
- **#8115** (2026-04-27, `dillon-cullinan`, *ci: Migrate post-merge and nightly to shared flows*) deleted `build-frontend-image.yaml` (-257 lines) and re-implemented the step inside `shared-build-image.yml` (+35 lines). The Makefile/Dockerfile halves of #8604 stayed in tree and remained correct, but the workflow-side env block and the three `KEY=VALUE` trailing args on the `make image-multiarch-push` invocation did not survive. The Makefile's `USE_SCCACHE ?=` saw an empty string, the Dockerfile's `if [ "$USE_SCCACHE" = "true" ]` branches no-op'd, and EPP CI silently regressed to cold cargo builds (~7.5 min per arch) for ~17 days until the recent 20-min `timeout-minutes` failures.

### What this PR changes

Essentially a re-application of #8604's workflow-side changes, adapted to the new file location:

- Add `AWS_DEFAULT_REGION` and `SCCACHE_S3_BUCKET` to the step `env:` block (`SCCACHE_S3_BUCKET` is already declared as a workflow-level secret at `shared-build-image.yml:106`).
- Pass `USE_SCCACHE=true SCCACHE_BUCKET=… SCCACHE_REGION=…` to the `make image-multiarch-push` invocation, matching the pattern in `.github/actions/docker-remote-build/action.yml:108-112`.
- **New vs. #8604:** guard the wiring on `SCCACHE_S3_BUCKET` + IRSA token + `AWS_ROLE_ARN`. If any are missing, emit a workflow warning and continue without cache — same fallback as `docker-remote-build/action.yml:144-152` and the `wheel_builder.Dockerfile` Rust steps. This keeps the workflow usable in forks without the IRSA-backed S3 bucket.

Registry layer cache (`--cache-from` always, `--cache-to` gated to `main`) is unchanged.

## Test plan

- [ ] CI on this PR builds the frontend job with `USE_SCCACHE=true` — look for `sccache --show-stats "libdynamo_llm"` output inside the `#30` (arm64) and `#58` (amd64) `rust-builder 9/9` stages.
- [ ] Confirm the cargo build wall-time in the BuildKit log drops well below the 7-7.5 min cold figure on a second run of the same SHA.
- [ ] Confirm the warning path on a fork without `SCCACHE_S3_BUCKET`: step should print `::warning::sccache prerequisites missing …` and finish without cache rather than fail.
- [ ] After merge to `main`, subsequent PRs should land warm S3 prefixes for `epp-amd64` / `epp-arm64`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)