### PR TITLE
feat(mocker): add pareto sweep + AIC comparison tool

### DIFF
--- a/benchmarks/mocker/README.md
+++ b/benchmarks/mocker/README.md
@@ -31,17 +31,37 @@ this tool don't have to relearn anything.
 ## Outputs (in `--save-dir`)
 
 ```
-raw_mocker.csv      every mocker-evaluated (parallelism, bs) point
-pareto_mocker.csv   mocker's Pareto-front subset (under TTFT/TPOT SLA)
-raw_aic.csv         every AIC-evaluated (parallelism, bs) point
-pareto_aic.csv      AIC's Pareto-front subset
-pareto_plot.png     dual-curve plot (AIC blue / mocker orange)
-sweep_meta.json     invocation args + AIC + mocker version pins
+raw_mocker.csv             every mocker-evaluated (parallelism, bs) point
+pareto_mocker.csv          mocker's Pareto-front subset (under TTFT/TPOT SLA)
+best_topn_mocker.csv       top-N STRICT-SLA configs by tok/s/gpu (mocker)
+raw_aic.csv                every AIC-evaluated point
+pareto_aic.csv             AIC's Pareto-front subset
+best_topn_aic.csv          top-N STRICT-SLA configs by tok/s/gpu (AIC)
+pareto_plot.png            dual-curve plot (AIC blue / mocker orange)
+sweep_meta.json            invocation args + AIC + mocker version pins
 ```
 
+When `--mode {disagg, both}`, the same set is also written with a
+`_disagg` suffix (`raw_mocker_disagg.csv`, etc.).
+
 Axes are `tokens/s/user` (X) vs `tokens/s/gpu` (Y), matching AIC's own
-`pareto_frontier.png` convention. SLA filtering: TTFT is always enforced;
-pass `--strict-sla` to also enforce TPOT.
+`pareto_frontier.png` convention. SLA filtering: TTFT is always enforced
+for the Pareto; pass `--strict-sla` to also enforce TPOT on the Pareto.
+The **top-N CSVs always enforce both TTFT and TPOT strictly** — the top-N is
+the practitioner's "which configs would I actually deploy?" answer.
+
+## Top-N recommendations
+
+By default both scripts also emit a top-`N` list of the SLA-compliant
+configurations ranked by `tokens/s/gpu`, matching the semantics of
+`aiconfigurator cli default --top-n`. Configure with `--top-n N` (default
+`5`). Echoed to stdout as e.g.
+
+```
+=== Top 5 recommendations (mocker agg) ===
+  #1: tp=8 dp=1 moe_tp=8 moe_ep=1 bs=32 gpus=8 | TTFT=739ms TPOT=45.6ms | tok/s/user=22.62 tok/s/gpu=86.4
+  ...
+```
 
 ## Current limitations (v1)
 

--- a/benchmarks/mocker/README.md
+++ b/benchmarks/mocker/README.md
@@ -1,0 +1,161 @@
+# AIC vs Mocker Pareto Comparison
+
+Run the same parallelism × batch-size sweep through two perf predictors —
+AIC's analytical model and dynamo's mocker simulator — and plot their
+Pareto fronts on a single figure.
+
+## Scripts
+
+| File | Purpose |
+|---|---|
+| `lib/bindings/python/src/dynamo/replay/pareto.py` | Mocker-only sweep. Importable as a library; runnable as `python -m dynamo.replay.pareto`. Produces `raw_mocker.csv` + `pareto_mocker.csv`. |
+| `benchmarks/mocker/pareto_comparison.py` | Driver that calls mocker pareto + AIC's `InferenceSession` Python API, then plots both. Produces additional `raw_aic.csv` + `pareto_aic.csv` + `pareto_plot.png` + `sweep_meta.json`. |
+
+## Usage
+
+```bash
+python benchmarks/mocker/pareto_comparison.py \
+    --model moonshotai/Kimi-K2.5 \
+    --system b200_sxm \
+    --backend vllm \
+    --backend-version 0.19.0 \
+    --total-gpus 8 \
+    --isl 8192 --osl 1024 \
+    --ttft 1000 --tpot 50 \
+    --save-dir results/kimi_b200_compare
+```
+
+The CLI mirrors `aiconfigurator cli default` so users moving between AIC and
+this tool don't have to relearn anything.
+
+## Outputs (in `--save-dir`)
+
+```
+raw_mocker.csv      every mocker-evaluated (parallelism, bs) point
+pareto_mocker.csv   mocker's Pareto-front subset (under TTFT/TPOT SLA)
+raw_aic.csv         every AIC-evaluated (parallelism, bs) point
+pareto_aic.csv      AIC's Pareto-front subset
+pareto_plot.png     dual-curve plot (AIC blue / mocker orange)
+sweep_meta.json     invocation args + AIC + mocker version pins
+```
+
+Axes are `tokens/s/user` (X) vs `tokens/s/gpu` (Y), matching AIC's own
+`pareto_frontier.png` convention. SLA filtering: TTFT is always enforced;
+pass `--strict-sla` to also enforce TPOT.
+
+## Current limitations (v1)
+
+These are intentional trade-offs for the first iteration. They affect how
+faithfully the two paretos can be compared:
+
+### Sweep coverage
+
+- **Batch size grid is powers of 2 [1, 2, 4, …, 256].**
+  AIC's `find_best_agg_result_under_constraints` internally sweeps a much
+  denser list (~45 values from `b_list_default` in each backend file). We
+  use the coarser power-of-2 grid for speed. We stop at bs=256 because
+  mocker's per-config wall time scales with `bs × num_requests` (where
+  `num_requests = max(50, 5*bs)`), and bs=512 alone takes many minutes per
+  config. With `--workers > 1` (default = half of `cpu_count`) the high-bs
+  tier parallelizes naturally. Both AIC and mocker see this same coarse
+  grid, so the comparison is well-defined on these points, but the
+  resulting Pareto fronts will look coarser than AIC's own
+  `aiconfigurator cli default` output, and the highest-bs regime (bs=512+)
+  is not represented in v1.
+
+- **`ctx_tokens` is held fixed per config.** AIC's sweep is 2D: for each
+  bs it also sweeps `ctx_tokens` (vllm: `max_num_batched_tokens`) with
+  step 512 up to `max(8192, 4*isl)`. We do not sweep this dimension at
+  all — we set `max_num_batched_tokens = max(bs*2, 8192)` per point. This
+  means deployments whose optimal operating point lies at unusual ctx_tokens
+  values won't be discovered here.
+
+- **`max_batch_size` capped at 512.** AIC notes in source comments that
+  perf-DB coverage degrades past 1024, so it also drops 1024 in practice
+  when `max_batch_size=512` (the default). We mirror this cap.
+
+### Deployment-mode coverage
+
+- **`--mode {agg, disagg, both}`** — agg is the default. Disagg sweeps the
+  cross-product of prefill / decode parallelism × prefill_bs × decode_bs ×
+  decode_workers, filtered by total_gpus and the invariant
+  `decode.num_gpus × decode_workers ≥ prefill.num_gpus × prefill_workers`
+  (decode is the throughput bottleneck; configs where decode has fewer GPUs
+  than prefill are rarely interesting). `prefill_workers` is held at 1 in
+  v1 to keep the search space tractable; bump
+  `DISAGG_PREFILL_WORKERS` in `pareto.py` for asymmetric replica counts.
+
+  Disagg constants (v1):
+    - `DISAGG_PREFILL_BS = (1, 2, 4, 8)`
+    - `DISAGG_DECODE_BS  = (32, 64, 128)`
+    - `DISAGG_PREFILL_WORKERS = (1,)`
+    - `DISAGG_DECODE_WORKERS  = (1, 2, 4)`
+
+  Empirically on Kimi-K2.5 / b200 / 8 GPUs these produce ~540 viable points
+  and finish in ~10-15 min with `--workers 6`.
+
+- **Backend-aware parallelism grid is a subset of AIC's.** Our
+  `_derive_parallel_grid` covers dense vs MoE, GB200/GB300 widening, and
+  the wideep code paths for trtllm/sglang. It does **not** replicate AIC's
+  full `TaskConfigFactory._agg_defaults_layer` logic (e.g., GQA+MoE vs
+  MLA+MoE heuristics, system-version-specific quirks). For mainline models
+  on supported systems the two grids agree; for edge cases (notably
+  DeepSeek MLA on non-default configs) AIC may explore configs we skip.
+
+### Engine-args fidelity (mocker side)
+
+- **`dp_size` forced to 1 in MockEngineArgs.** Mocker's concurrency-replay
+  validator rejects any other value (`validate.rs:55-60`). The deployment's
+  actual DP world size is carried via `--num-workers N` (replay-level pool)
+  and `aic_attention_dp_size: N` inside engine-args (AIC perf-model side).
+  This is correct but worth knowing if you read the emitted JSON.
+
+- **KV cache dtype is not modeled by mocker's MockEngineArgs.** AIC's perf
+  model accounts for KV dtype via the `aic_backend` hookup, so the timing
+  predictions still reflect KV quant correctly, but mocker's scheduling /
+  KV-cache-capacity calculations use vllm/sglang defaults. If your
+  comparison hinges on KV-dtype sensitivity, AIC's analytical side is the
+  more trustworthy half.
+
+- **`enable_prefix_caching` is forced false.** AIC's `--prefix` flag is
+  not plumbed through. Workloads with significant prefix reuse aren't
+  modeled accurately on either side.
+
+### Workload coverage
+
+- **No quantization sweep.** Both AIC and mocker use whatever quant the
+  model's `config.json` declares. To compare quant variants, run the sweep
+  multiple times.
+
+- **No speculative decoding / MTP.** AIC supports `--nextn` (draft tokens);
+  mocker does not model speculative decoding. Sweeps assume `nextn=0`.
+
+- **Fixed ISL/OSL per run.** AIC's `cli default` supports varying request
+  patterns via experiment YAML; we take a single `--isl --osl` pair.
+
+### Numerical / reproducibility
+
+- **Single mocker run per (parallelism, bs).** No averaging across multiple
+  random seeds. Mocker's sim is deterministic per seed but the default
+  could mask noise if it's introduced later.
+
+- **AIC's pareto on our grid ≠ AIC's pareto from `cli default`.** The
+  driver computes AIC's pareto from the per-point `run_agg` calls on our
+  coarse grid. AIC's own `aiconfigurator cli default` uses the denser bs
+  grid + ctx_tokens sweep, so its `pareto_frontier.png` may show a denser /
+  shifted front than `pareto_aic.csv` here. Compare against AIC's own
+  output if you want the analytical-best AIC pareto.
+
+## Roadmap
+
+In rough priority order, these are the natural next iterations:
+
+1. Add disagg coverage (`--mode disagg`), wiring `--prefill-engine-args` +
+   `--decode-engine-args` per config.
+2. Add a `--bs-mode {pow2, aic}` flag toggling between the coarse v1 grid
+   and AIC's verbatim `b_list_default`.
+3. Sweep `ctx_tokens` as an inner loop, matching AIC's 2D grid.
+4. Plumb `--prefix`, `--nextn`, `--enable-chunked-prefill` so they round-trip
+   through both evaluators.
+5. Optional parallel execution (`multiprocessing.Pool`) to cut wall time
+   for the denser grids.

--- a/benchmarks/mocker/pareto_comparison.py
+++ b/benchmarks/mocker/pareto_comparison.py
@@ -63,6 +63,8 @@ from dynamo.replay.pareto import (
     _derive_disagg_grid,
     _derive_parallel_grid,
     _detect_is_moe,
+    _format_top_n,
+    compute_top_n,
     sweep_pareto,
 )
 
@@ -482,6 +484,13 @@ def _build_parser() -> argparse.ArgumentParser:
         default=max(1, (os.cpu_count() or 2) // 2),
         help="Worker processes for the mocker sweep (default: half of cpu_count).",
     )
+    p.add_argument(
+        "--top-n",
+        type=int,
+        default=5,
+        help="Write top-N STRICT-SLA-passing configs (sorted by tok/s/gpu) "
+        "to best_topn_{mocker,aic}[_disagg].csv and echo to stdout (default: 5).",
+    )
     return p
 
 
@@ -544,6 +553,14 @@ def main(argv: list[str] | None = None) -> int:
             aic_raw_agg=len(aic_raw),
             aic_pareto_agg=len(aic_pareto),
         )
+        aic_top = compute_top_n(
+            aic_raw.to_dict(orient="records"),
+            ttft=args.ttft,
+            tpot=args.tpot,
+            top_n=args.top_n,
+        )
+        aic_top.to_csv(save_dir / "best_topn_aic.csv", index=False)
+        print(_format_top_n(aic_top, label="AIC agg", is_disagg=False))
 
     if args.mode in ("disagg", "both"):
         mocker_raw_d = pd.read_csv(save_dir / "raw_mocker_disagg.csv")
@@ -557,6 +574,14 @@ def main(argv: list[str] | None = None) -> int:
             aic_raw_disagg=len(aic_raw_d),
             aic_pareto_disagg=len(aic_pareto_d),
         )
+        aic_top_d = compute_top_n(
+            aic_raw_d.to_dict(orient="records"),
+            ttft=args.ttft,
+            tpot=args.tpot,
+            top_n=args.top_n,
+        )
+        aic_top_d.to_csv(save_dir / "best_topn_aic_disagg.csv", index=False)
+        print(_format_top_n(aic_top_d, label="AIC disagg", is_disagg=True))
 
     plot_path = save_dir / "pareto_plot.png"
     title = (

--- a/benchmarks/mocker/pareto_comparison.py
+++ b/benchmarks/mocker/pareto_comparison.py
@@ -1,0 +1,583 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+AIC vs Mocker Pareto comparison driver.
+
+This script sweeps the same (parallelism, batch_size) grid through two perf
+predictors — AIC's analytical model and dynamo's mocker simulator — and plots
+their respective Pareto fronts side by side on a single figure so disagreements
+are visible at a glance.
+
+The mocker side is run by importing ``dynamo.replay.pareto.sweep_pareto``; the
+AIC side is run by driving ``aiconfigurator.sdk.inference_session.InferenceSession``
+in-process. The two outputs use the same Pareto algorithm
+(``aiconfigurator.sdk.pareto_analysis.get_pareto_front``) so any divergence is
+purely model-disagreement, not algorithmic.
+
+Usage::
+
+    python benchmarks/mocker/pareto_comparison.py \
+        --model moonshotai/Kimi-K2.5 \
+        --system b200_sxm \
+        --backend vllm \
+        --backend-version 0.19.0 \
+        --total-gpus 8 \
+        --isl 8192 --osl 1024 \
+        --ttft 1000 --tpot 50 \
+        --save-dir results/kimi_b200_compare
+
+Outputs in ``--save-dir`` (in addition to mocker's own raw/pareto CSVs)::
+
+    raw_aic.csv         every AIC-evaluated (parallelism, bs) point
+    pareto_aic.csv      AIC's Pareto-front subset
+    pareto_plot.png     dual-curve plot (AIC + Mocker)
+    sweep_meta.json     invocation args + AIC + mocker version pins
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import pandas as pd
+from aiconfigurator.sdk.backends.factory import get_backend
+from aiconfigurator.sdk.config import ModelConfig, RuntimeConfig
+from aiconfigurator.sdk.inference_session import (
+    DisaggInferenceSession,
+    InferenceSession,
+)
+from aiconfigurator.sdk.models import get_model
+from aiconfigurator.sdk.pareto_analysis import get_pareto_front
+from aiconfigurator.sdk.perf_database import get_database
+
+from dynamo.replay.pareto import (
+    BATCH_SIZES,
+    DisaggPoint,
+    ParallelConfig,
+    _derive_disagg_grid,
+    _derive_parallel_grid,
+    _detect_is_moe,
+    sweep_pareto,
+)
+
+X_COL = "tokens/s/user"
+Y_COL = "tokens/s/gpu"
+
+
+_AIC_METRIC_KEYS = ("ttft_ms", "tpot_ms", "request_latency_ms", X_COL, Y_COL)
+
+
+def _empty_aic_row(parallel_cfg: ParallelConfig, bs: int, error: str) -> dict:
+    return {
+        "tp": parallel_cfg.tp,
+        "pp": parallel_cfg.pp,
+        "dp": parallel_cfg.dp,
+        "moe_tp": parallel_cfg.moe_tp,
+        "moe_ep": parallel_cfg.moe_ep,
+        "bs": bs,
+        "num_gpus": parallel_cfg.num_gpus,
+        **{k: None for k in _AIC_METRIC_KEYS},
+        "error": error,
+    }
+
+
+def _evaluate_aic_point(
+    session: InferenceSession,
+    parallel_cfg: ParallelConfig,
+    bs: int,
+    *,
+    isl: int,
+    osl: int,
+    ttft: float,
+    tpot: float,
+) -> dict:
+    """Run AIC's analytical perf model for one (parallelism, bs) point.
+
+    AIC's ``run_agg`` requires ``ctx_tokens`` as a kwarg (the per-step prefill
+    token budget for IFB scheduling, analogous to vllm's
+    ``--max-num-batched-tokens``). We use ``ctx_tokens=isl`` — one full
+    prefill per step at this bs level, which is the natural operating point
+    for vllm-style IFB with chunked-prefill disabled. Earlier versions used
+    ``max(isl, 8192)`` which inflated TTFT predictions at low bs because AIC
+    simulated a larger-than-needed forward pass per step.
+    """
+    rt = RuntimeConfig(batch_size=bs, isl=isl, osl=osl, ttft=ttft, tpot=tpot)
+    ctx_tokens = isl
+    try:
+        summary = session.run_agg(rt, ctx_tokens=ctx_tokens)
+        df = summary.get_summary_df()
+    except Exception as exc:
+        return _empty_aic_row(parallel_cfg, bs, f"{type(exc).__name__}: {exc}")
+
+    if df is None or df.empty:
+        return _empty_aic_row(parallel_cfg, bs, "empty summary")
+
+    row = df.iloc[0].to_dict()
+    return {
+        "tp": parallel_cfg.tp,
+        "pp": parallel_cfg.pp,
+        "dp": parallel_cfg.dp,
+        "moe_tp": parallel_cfg.moe_tp,
+        "moe_ep": parallel_cfg.moe_ep,
+        "bs": bs,
+        "num_gpus": parallel_cfg.num_gpus,
+        "ttft_ms": row.get("ttft"),
+        "tpot_ms": row.get("tpot"),
+        "request_latency_ms": row.get("request_latency"),
+        X_COL: row.get(X_COL),
+        Y_COL: row.get(Y_COL),
+        "error": None,
+    }
+
+
+def evaluate_aic(args: argparse.Namespace) -> list[dict]:
+    """Evaluate AIC's analytical model on the same parallelism × bs grid."""
+    is_moe = _detect_is_moe(args.model_path)
+    grid = _derive_parallel_grid(
+        args.total_gpus, args.system, args.backend, is_moe, args.enable_wideep
+    )
+    print(f"AIC: evaluating {len(grid)} parallelism configs × {len(BATCH_SIZES)} bs.")
+
+    database = get_database(
+        system=args.system, backend=args.backend, version=args.backend_version
+    )
+    backend_obj = get_backend(args.backend)
+
+    rows: list[dict] = []
+    total = len(grid) * len(BATCH_SIZES)
+    done = 0
+    for parallel_cfg in grid:
+        model_cfg = ModelConfig(
+            tp_size=parallel_cfg.tp,
+            pp_size=parallel_cfg.pp,
+            attention_dp_size=parallel_cfg.dp,
+            moe_tp_size=parallel_cfg.moe_tp,
+            moe_ep_size=parallel_cfg.moe_ep,
+            enable_wideep=args.enable_wideep,
+        )
+        try:
+            model = get_model(
+                model_path=args.model_path,
+                model_config=model_cfg,
+                backend_name=args.backend,
+            )
+            session = InferenceSession(model, database, backend_obj)
+        except Exception as exc:
+            done += len(BATCH_SIZES)
+            err = f"model init: {type(exc).__name__}: {exc}"
+            print(
+                f"  skip tp={parallel_cfg.tp} dp={parallel_cfg.dp} "
+                f"moe_tp={parallel_cfg.moe_tp} moe_ep={parallel_cfg.moe_ep}: {err}",
+                flush=True,
+            )
+            for bs in BATCH_SIZES:
+                rows.append(_empty_aic_row(parallel_cfg, bs, err))
+            continue
+
+        for bs in BATCH_SIZES:
+            done += 1
+            print(
+                f"[AIC {done}/{total}] tp={parallel_cfg.tp} pp={parallel_cfg.pp} "
+                f"dp={parallel_cfg.dp} moe_tp={parallel_cfg.moe_tp} "
+                f"moe_ep={parallel_cfg.moe_ep} bs={bs}",
+                flush=True,
+            )
+            rows.append(
+                _evaluate_aic_point(
+                    session,
+                    parallel_cfg,
+                    bs,
+                    isl=args.isl,
+                    osl=args.osl,
+                    ttft=args.ttft,
+                    tpot=args.tpot,
+                )
+            )
+
+    return rows
+
+
+def _filter_sla(
+    df: pd.DataFrame, ttft: float, tpot: float, strict: bool
+) -> pd.DataFrame:
+    candidates = df.dropna(subset=[X_COL, Y_COL])
+    candidates = candidates[candidates["ttft_ms"] <= ttft]
+    if strict:
+        candidates = candidates[candidates["tpot_ms"] <= tpot]
+    return candidates
+
+
+_DISAGG_AIC_METRIC_KEYS = ("ttft_ms", "tpot_ms", "request_latency_ms", X_COL, Y_COL)
+
+
+def _empty_disagg_row(point: DisaggPoint, error: str) -> dict:
+    return {
+        "p_tp": point.prefill.tp,
+        "p_pp": point.prefill.pp,
+        "p_dp": point.prefill.dp,
+        "p_moe_tp": point.prefill.moe_tp,
+        "p_moe_ep": point.prefill.moe_ep,
+        "p_bs": point.prefill_bs,
+        "p_workers": point.prefill_workers,
+        "d_tp": point.decode.tp,
+        "d_pp": point.decode.pp,
+        "d_dp": point.decode.dp,
+        "d_moe_tp": point.decode.moe_tp,
+        "d_moe_ep": point.decode.moe_ep,
+        "d_bs": point.decode_bs,
+        "d_workers": point.decode_workers,
+        "total_gpus": point.total_gpus,
+        **{k: None for k in _DISAGG_AIC_METRIC_KEYS},
+        "error": error,
+    }
+
+
+def _evaluate_aic_disagg_point(
+    session: DisaggInferenceSession,
+    point: DisaggPoint,
+    *,
+    model_path: str,
+    isl: int,
+    osl: int,
+    ttft: float,
+    tpot: float,
+) -> dict:
+    """Run AIC's disagg analytical model for one (prefill, decode, workers, bs) point."""
+    rt = RuntimeConfig(batch_size=None, isl=isl, osl=osl, ttft=ttft, tpot=tpot)
+    p_cfg = ModelConfig(
+        tp_size=point.prefill.tp,
+        pp_size=point.prefill.pp,
+        attention_dp_size=point.prefill.dp,
+        moe_tp_size=point.prefill.moe_tp,
+        moe_ep_size=point.prefill.moe_ep,
+    )
+    d_cfg = ModelConfig(
+        tp_size=point.decode.tp,
+        pp_size=point.decode.pp,
+        attention_dp_size=point.decode.dp,
+        moe_tp_size=point.decode.moe_tp,
+        moe_ep_size=point.decode.moe_ep,
+    )
+    try:
+        summary = session.run_disagg(
+            model_path=model_path,
+            runtime_config=rt,
+            prefill_model_config=p_cfg,
+            prefill_batch_size=point.prefill_bs,
+            prefill_num_worker=point.prefill_workers,
+            decode_model_config=d_cfg,
+            decode_batch_size=point.decode_bs,
+            decode_num_worker=point.decode_workers,
+        )
+        df = summary.get_summary_df()
+    except Exception as exc:
+        return _empty_disagg_row(point, f"{type(exc).__name__}: {exc}")
+
+    if df is None or df.empty:
+        return _empty_disagg_row(point, "empty summary")
+
+    row = df.iloc[0].to_dict()
+    return {
+        "p_tp": point.prefill.tp,
+        "p_pp": point.prefill.pp,
+        "p_dp": point.prefill.dp,
+        "p_moe_tp": point.prefill.moe_tp,
+        "p_moe_ep": point.prefill.moe_ep,
+        "p_bs": point.prefill_bs,
+        "p_workers": point.prefill_workers,
+        "d_tp": point.decode.tp,
+        "d_pp": point.decode.pp,
+        "d_dp": point.decode.dp,
+        "d_moe_tp": point.decode.moe_tp,
+        "d_moe_ep": point.decode.moe_ep,
+        "d_bs": point.decode_bs,
+        "d_workers": point.decode_workers,
+        "total_gpus": point.total_gpus,
+        "ttft_ms": row.get("ttft"),
+        "tpot_ms": row.get("tpot"),
+        "request_latency_ms": row.get("request_latency"),
+        X_COL: row.get(X_COL),
+        Y_COL: row.get(Y_COL),
+        "error": None,
+    }
+
+
+def evaluate_aic_disagg(args: argparse.Namespace) -> list[dict]:
+    """Evaluate AIC's analytical model on the disagg search space."""
+    is_moe = _detect_is_moe(args.model_path)
+    grid = _derive_parallel_grid(
+        args.total_gpus, args.system, args.backend, is_moe, args.enable_wideep
+    )
+    points = _derive_disagg_grid(grid, args.total_gpus)
+    print(f"AIC disagg: evaluating {len(points)} points.")
+
+    database = get_database(
+        system=args.system, backend=args.backend, version=args.backend_version
+    )
+    backend_obj = get_backend(args.backend)
+    # Same database + backend for prefill and decode (single-system v1).
+    session = DisaggInferenceSession(
+        prefill_database=database,
+        prefill_backend=backend_obj,
+        decode_database=database,
+        decode_backend=backend_obj,
+    )
+
+    rows: list[dict] = []
+    for done, point in enumerate(points, start=1):
+        if done % 25 == 0 or done == 1:
+            print(f"[AIC disagg {done}/{len(points)}]", flush=True)
+        rows.append(
+            _evaluate_aic_disagg_point(
+                session,
+                point,
+                model_path=args.model_path,
+                isl=args.isl,
+                osl=args.osl,
+                ttft=args.ttft,
+                tpot=args.tpot,
+            )
+        )
+    return rows
+
+
+_CURVE_STYLE = {
+    # (raw_color, raw_alpha, pareto_color, pareto_marker, pareto_linestyle)
+    "agg_aic": ("C0", 0.2, "C0", "o", "-"),
+    "agg_mocker": ("C1", 0.2, "C1", "s", "--"),
+    "disagg_aic": ("C2", 0.2, "C2", "^", "-"),
+    "disagg_mocker": ("C3", 0.2, "C3", "D", "--"),
+}
+
+
+def _plot_curve(
+    ax,
+    label: str,
+    *,
+    raw: pd.DataFrame | None,
+    pareto: pd.DataFrame | None,
+    style_key: str,
+) -> None:
+    raw_color, raw_alpha, p_color, p_marker, p_ls = _CURVE_STYLE[style_key]
+    if raw is not None and not raw.empty:
+        ax.scatter(
+            raw[X_COL],
+            raw[Y_COL],
+            alpha=raw_alpha,
+            color=raw_color,
+            s=15,
+            label=f"{label} raw",
+        )
+    if pareto is not None and not pareto.empty:
+        sorted_p = pareto.sort_values(X_COL)
+        ax.plot(
+            sorted_p[X_COL],
+            sorted_p[Y_COL],
+            marker=p_marker,
+            linewidth=2,
+            color=p_color,
+            linestyle=p_ls,
+            label=f"{label} pareto",
+        )
+
+
+def _plot_pareto(
+    save_path: Path,
+    *,
+    curves: dict[str, dict[str, pd.DataFrame | None]],
+    title: str,
+) -> None:
+    """Plot up to 4 curves on a single figure.
+
+    ``curves`` maps style_key (e.g. ``"agg_aic"``) to a dict with
+    ``"raw"`` and ``"pareto"`` DataFrames (either may be None to skip).
+    """
+    fig, ax = plt.subplots(figsize=(10, 6.5))
+
+    label_map = {
+        "agg_aic": "AIC agg",
+        "agg_mocker": "Mocker agg",
+        "disagg_aic": "AIC disagg",
+        "disagg_mocker": "Mocker disagg",
+    }
+    for key, dfs in curves.items():
+        _plot_curve(
+            ax,
+            label_map.get(key, key),
+            raw=dfs.get("raw"),
+            pareto=dfs.get("pareto"),
+            style_key=key,
+        )
+
+    ax.set_xlabel(f"{X_COL} (tokens/s/user)")
+    ax.set_ylabel(f"{Y_COL} (tokens/s/gpu)")
+    ax.set_title(title)
+    ax.grid(True, alpha=0.3)
+    ax.legend(loc="best", fontsize=9)
+    fig.tight_layout()
+    fig.savefig(save_path, dpi=150)
+    plt.close(fig)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="pareto_comparison.py",
+        description="Run AIC + mocker Pareto sweeps over the same config grid and plot both.",
+    )
+    p.add_argument(
+        "--model",
+        "--model-path",
+        dest="model_path",
+        required=True,
+        help="HF model id or local model directory.",
+    )
+    p.add_argument("--system", required=True, help="GPU system (e.g., b200_sxm).")
+    p.add_argument(
+        "--backend",
+        required=True,
+        choices=("vllm", "trtllm", "sglang"),
+        help="Inference backend.",
+    )
+    p.add_argument(
+        "--backend-version",
+        default=None,
+        help="AIC backend DB version (default: latest available).",
+    )
+    p.add_argument("--total-gpus", type=int, required=True, help="Total GPUs budget.")
+    p.add_argument("--isl", type=int, default=4000, help="Input sequence length.")
+    p.add_argument("--osl", type=int, default=1000, help="Output sequence length.")
+    p.add_argument("--ttft", type=float, default=2000.0, help="TTFT SLA target (ms).")
+    p.add_argument("--tpot", type=float, default=30.0, help="TPOT SLA target (ms).")
+    p.add_argument(
+        "--strict-sla",
+        action="store_true",
+        help="Also filter the Pareto frontier by TPOT (TTFT is always enforced).",
+    )
+    p.add_argument(
+        "--enable-wideep",
+        action="store_true",
+        help="Enable Wide Expert Parallelism for MoE models.",
+    )
+    p.add_argument(
+        "--mode",
+        default="agg",
+        choices=("agg", "disagg", "both"),
+        help="Deployment mode. 'agg' (default), 'disagg', or 'both'.",
+    )
+    p.add_argument("--save-dir", required=True, help="Output directory.")
+    p.add_argument(
+        "--skip-mocker",
+        action="store_true",
+        help="Skip mocker sweep; expects raw_mocker.csv/pareto_mocker.csv already in save-dir.",
+    )
+    p.add_argument(
+        "--workers",
+        type=int,
+        default=max(1, (os.cpu_count() or 2) // 2),
+        help="Worker processes for the mocker sweep (default: half of cpu_count).",
+    )
+    return p
+
+
+def _run_aic_agg(
+    args: argparse.Namespace, save_dir: Path
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    rows = evaluate_aic(args)
+    raw = pd.DataFrame(rows)
+    raw.to_csv(save_dir / "raw_aic.csv", index=False)
+    cand = _filter_sla(raw, args.ttft, args.tpot, args.strict_sla)
+    pareto = (
+        get_pareto_front(
+            cand, x_col=X_COL, y_col=Y_COL, maximize_x=True, maximize_y=True
+        )
+        if not cand.empty
+        else cand
+    )
+    pareto.to_csv(save_dir / "pareto_aic.csv", index=False)
+    return raw, pareto
+
+
+def _run_aic_disagg(
+    args: argparse.Namespace, save_dir: Path
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    rows = evaluate_aic_disagg(args)
+    raw = pd.DataFrame(rows)
+    raw.to_csv(save_dir / "raw_aic_disagg.csv", index=False)
+    cand = _filter_sla(raw, args.ttft, args.tpot, args.strict_sla)
+    pareto = (
+        get_pareto_front(
+            cand, x_col=X_COL, y_col=Y_COL, maximize_x=True, maximize_y=True
+        )
+        if not cand.empty
+        else cand
+    )
+    pareto.to_csv(save_dir / "pareto_aic_disagg.csv", index=False)
+    return raw, pareto
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    save_dir = Path(args.save_dir)
+    save_dir.mkdir(parents=True, exist_ok=True)
+
+    if not args.skip_mocker:
+        sweep_pareto(args)
+
+    curves: dict[str, dict] = {}
+    counts: dict[str, int] = {}
+
+    if args.mode in ("agg", "both"):
+        mocker_raw = pd.read_csv(save_dir / "raw_mocker.csv")
+        mocker_pareto = pd.read_csv(save_dir / "pareto_mocker.csv")
+        aic_raw, aic_pareto = _run_aic_agg(args, save_dir)
+        curves["agg_aic"] = {"raw": aic_raw, "pareto": aic_pareto}
+        curves["agg_mocker"] = {"raw": mocker_raw, "pareto": mocker_pareto}
+        counts.update(
+            mocker_raw_agg=len(mocker_raw),
+            mocker_pareto_agg=len(mocker_pareto),
+            aic_raw_agg=len(aic_raw),
+            aic_pareto_agg=len(aic_pareto),
+        )
+
+    if args.mode in ("disagg", "both"):
+        mocker_raw_d = pd.read_csv(save_dir / "raw_mocker_disagg.csv")
+        mocker_pareto_d = pd.read_csv(save_dir / "pareto_mocker_disagg.csv")
+        aic_raw_d, aic_pareto_d = _run_aic_disagg(args, save_dir)
+        curves["disagg_aic"] = {"raw": aic_raw_d, "pareto": aic_pareto_d}
+        curves["disagg_mocker"] = {"raw": mocker_raw_d, "pareto": mocker_pareto_d}
+        counts.update(
+            mocker_raw_disagg=len(mocker_raw_d),
+            mocker_pareto_disagg=len(mocker_pareto_d),
+            aic_raw_disagg=len(aic_raw_d),
+            aic_pareto_disagg=len(aic_pareto_d),
+        )
+
+    plot_path = save_dir / "pareto_plot.png"
+    title = (
+        f"{args.model_path} on {args.system} | "
+        f"backend={args.backend} v={args.backend_version or 'latest'} | "
+        f"ISL={args.isl} OSL={args.osl} | "
+        f"TTFT≤{args.ttft}ms TPOT≤{args.tpot}ms | mode={args.mode}"
+    )
+    _plot_pareto(plot_path, curves=curves, title=title)
+
+    meta = {
+        "timestamp": datetime.now().isoformat(),
+        "args": vars(args),
+        "counts": counts,
+    }
+    (save_dir / "sweep_meta.json").write_text(json.dumps(meta, indent=2) + "\n")
+
+    print(f"\nWrote plot: {plot_path}")
+    print(f"Wrote meta: {save_dir / 'sweep_meta.json'}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lib/bindings/python/src/dynamo/replay/pareto.py
+++ b/lib/bindings/python/src/dynamo/replay/pareto.py
@@ -1,0 +1,729 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Mocker-based parallelism + batch-size sweep producing a Pareto front.
+
+For each (parallelism config, batch_size) point that AIC's enumeration would
+produce for a given (model, system, backend, total_gpus), this script runs
+dynamo's mock engine (`run_synthetic_trace_replay`) with AIC-driven timing,
+collects throughput / latency, and writes the non-dominated frontier on
+(tokens/s/user, tokens/s/gpu) axes.
+
+The CLI surface mirrors `aiconfigurator cli default` to make side-by-side
+comparison with AIC straightforward; the companion script
+`benchmarks/mocker/pareto_comparison.py` runs both AIC and mocker and plots
+the two Pareto curves together.
+
+Usage::
+
+    python -m dynamo.replay.pareto \
+        --model moonshotai/Kimi-K2.5 \
+        --system b200_sxm \
+        --backend vllm \
+        --backend-version 0.19.0 \
+        --total-gpus 8 \
+        --isl 8192 --osl 1024 \
+        --ttft 1000 --tpot 50 \
+        --save-dir results/kimi_b200
+
+Outputs in ``--save-dir``:
+    raw_mocker.csv      every evaluated (parallelism, bs) point
+    pareto_mocker.csv   Pareto-front subset on (tokens/s/user, tokens/s/gpu)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from dataclasses import dataclass
+from pathlib import Path
+
+import pandas as pd
+from aiconfigurator.sdk import common
+from aiconfigurator.sdk.pareto_analysis import get_pareto_front
+from aiconfigurator.sdk.utils import enumerate_parallel_config
+
+from dynamo.llm import MockEngineArgs
+from dynamo.replay import run_synthetic_trace_replay
+
+# v1 agg batch-size sweep: powers of 2 up to 256.
+# Coarse subset of AIC's internal `b_list_default` (~45 values; see
+# vllm_backend.py:474, trtllm_backend.py:548, sglang_backend.py:474).
+# We stop at 256 because mocker's per-config wall time scales with
+# bs × num_requests (where num_requests = max(50, 5*bs)); at bs=512 a single
+# config can take many minutes to simulate. With --workers > 1 the high-bs
+# tier parallelizes naturally. Tradeoffs documented in
+# benchmarks/mocker/README.md.
+BATCH_SIZES: tuple[int, ...] = (1, 2, 4, 8, 16, 32, 64, 128, 256)
+
+# Disagg sweep grids. Kept tight in v1 to bound wall time — the disagg cross
+# product (prefill_parallel × decode_parallel × prefill_bs × decode_bs ×
+# prefill_workers × decode_workers) explodes quickly. Prefill is typically
+# small-batch / latency-bound; decode benefits from larger batches.
+# Empirically on Kimi-K2.5 / b200_sxm / 8 GPUs these tight caps yield
+# ~150-300 viable points after the total_gpus filter, ~10-15 min wall time
+# with --workers 6. Loosen if you want denser coverage.
+DISAGG_PREFILL_BS: tuple[int, ...] = (1, 2, 4, 8)
+DISAGG_DECODE_BS: tuple[int, ...] = (32, 64, 128)
+DISAGG_PREFILL_WORKERS: tuple[int, ...] = (1,)
+DISAGG_DECODE_WORKERS: tuple[int, ...] = (1, 2, 4)
+
+
+@dataclass(frozen=True)
+class ParallelConfig:
+    tp: int
+    pp: int
+    dp: int
+    moe_tp: int
+    moe_ep: int
+
+    @property
+    def num_gpus(self) -> int:
+        return self.tp * self.pp * self.dp
+
+
+@dataclass(frozen=True)
+class DisaggPoint:
+    prefill: ParallelConfig
+    decode: ParallelConfig
+    prefill_bs: int
+    decode_bs: int
+    prefill_workers: int
+    decode_workers: int
+
+    @property
+    def total_gpus(self) -> int:
+        return (
+            self.prefill.num_gpus * self.prefill_workers
+            + self.decode.num_gpus * self.decode_workers
+        )
+
+
+_MOE_KEYS = (
+    "num_experts",
+    "num_local_experts",
+    "moe_num_experts",
+    "num_routed_experts",
+    "n_routed_experts",
+    "moe_intermediate_size",
+    "moe_layer_freq",
+    "num_experts_per_tok",
+)
+
+
+def _detect_is_moe(model_path: str) -> bool:
+    """Detect MoE from a model's HF config.json (local dir or HF id).
+
+    Walks nested dicts because multimodal models (e.g., Kimi-K2.5) put the
+    MoE-relevant keys under a `text_config` sub-block, not at the top level.
+    """
+    cfg_path = Path(model_path) / "config.json"
+    if cfg_path.is_file():
+        cfg = json.loads(cfg_path.read_text())
+    else:
+        from huggingface_hub import hf_hub_download
+
+        local = hf_hub_download(repo_id=model_path, filename="config.json")
+        cfg = json.loads(Path(local).read_text())
+
+    def _walk(node: object) -> bool:
+        if isinstance(node, dict):
+            if any(k in node for k in _MOE_KEYS):
+                return True
+            return any(_walk(v) for v in node.values())
+        return False
+
+    return _walk(cfg)
+
+
+def _derive_parallel_grid(
+    total_gpus: int,
+    system: str,
+    backend: str,
+    is_moe: bool,
+    enable_wideep: bool,
+) -> list[ParallelConfig]:
+    """Build the parallelism grid via AIC's enumerator with backend-aware lists."""
+    if system in ("gb200", "gb300") and not is_moe:
+        tp_list = [1, 2, 4, 8, 16]
+        num_gpu_per_worker = [1, 2, 4, 8, 16]
+    else:
+        tp_list = [1, 2, 4, 8]
+        num_gpu_per_worker = [1, 2, 4, 8]
+
+    pp_list = [1]
+    dp_list = [1, 2, 4, 8] if is_moe else [1]
+    moe_tp_list = [1, 2, 4, 8] if is_moe else [1]
+    moe_ep_list = [1, 2, 4, 8] if is_moe else [1]
+
+    if is_moe and enable_wideep and backend in ("trtllm", "sglang"):
+        num_gpu_per_worker = [2, 4, 8, 16, 32, 64]
+        dp_list = [2, 4, 8, 16, 32, 64]
+        moe_tp_list = [1]
+        moe_ep_list = [2, 4, 8, 16, 32, 64]
+
+    configs = enumerate_parallel_config(
+        num_gpu_list=num_gpu_per_worker,
+        tp_list=tp_list,
+        pp_list=pp_list,
+        dp_list=dp_list,
+        moe_tp_list=moe_tp_list,
+        moe_ep_list=moe_ep_list,
+        is_moe=is_moe,
+        backend=common.BackendName(backend),
+        enable_wideep=enable_wideep,
+        real_silicon_sweep=True,
+        max_num_gpus=total_gpus,
+    )
+    return [
+        ParallelConfig(tp=c[0], pp=c[1], dp=c[2], moe_tp=c[3], moe_ep=c[4])
+        for c in configs
+    ]
+
+
+def _build_engine_args(
+    parallel_cfg: ParallelConfig,
+    bs: int,
+    *,
+    backend: str,
+    backend_version: str | None,
+    system: str,
+    model_path: str,
+    worker_type: str | None = None,
+) -> dict:
+    """Build the MockEngineArgs JSON for one (parallelism, bs) point.
+
+    ``worker_type`` is set for disagg points only (``"prefill"`` or
+    ``"decode"``); leave None for agg.
+    """
+    # MockEngineArgs.engine_type accepts only vllm/sglang; trtllm sources use vllm
+    # as a structural placeholder while aic_backend="trtllm" drives the timing model.
+    engine_type = "sglang" if backend == "sglang" else "vllm"
+
+    args: dict = {
+        "engine_type": engine_type,
+        "max_num_seqs": bs,
+        "max_num_batched_tokens": max(bs * 2, 8192),
+        "enable_prefix_caching": False,
+        "block_size": 64 if engine_type == "sglang" else 16,
+        # Mocker requires dp_size=1 in MockEngineArgs even when the deployment
+        # has DP>1; deployment DP is carried via num-workers and aic_attention_dp_size.
+        "dp_size": 1,
+        "aic_backend": backend,
+        "aic_system": system,
+        "aic_model_path": model_path,
+        "aic_tp_size": parallel_cfg.tp,
+    }
+    if worker_type is not None:
+        args["worker_type"] = worker_type
+    if backend_version is not None:
+        args["aic_backend_version"] = backend_version
+    # Always populate the parallelism fields explicitly (even when ==1).
+    # Mocker's AIC callback multiplies these internally; leaving any as None
+    # crashes with `TypeError: unsupported operand type(s) for *: 'NoneType' and 'int'`.
+    args["aic_attention_dp_size"] = parallel_cfg.dp
+    args["aic_moe_tp_size"] = parallel_cfg.moe_tp
+    args["aic_moe_ep_size"] = parallel_cfg.moe_ep
+    return args
+
+
+def _evaluate_one(
+    parallel_cfg: ParallelConfig,
+    bs: int,
+    *,
+    isl: int,
+    osl: int,
+    backend: str,
+    backend_version: str | None,
+    system: str,
+    model_path: str,
+) -> dict:
+    """Run mocker for one (parallelism, bs) point. Returns a flat metrics dict."""
+    engine_args = _build_engine_args(
+        parallel_cfg,
+        bs,
+        backend=backend,
+        backend_version=backend_version,
+        system=system,
+        model_path=model_path,
+    )
+    num_requests = max(50, 5 * bs)
+
+    base_row = {
+        "tp": parallel_cfg.tp,
+        "pp": parallel_cfg.pp,
+        "dp": parallel_cfg.dp,
+        "moe_tp": parallel_cfg.moe_tp,
+        "moe_ep": parallel_cfg.moe_ep,
+        "bs": bs,
+        "num_gpus": parallel_cfg.num_gpus,
+    }
+
+    try:
+        report = run_synthetic_trace_replay(
+            isl,
+            osl,
+            num_requests,
+            extra_engine_args=MockEngineArgs.from_json(json.dumps(engine_args)),
+            num_workers=max(parallel_cfg.dp, 1),
+            replay_concurrency=bs,
+            replay_mode="offline",
+            router_mode="kv_router" if parallel_cfg.dp > 1 else "round_robin",
+        )
+    except Exception as exc:
+        return {
+            **base_row,
+            "ttft_ms": None,
+            "tpot_ms": None,
+            "request_latency_ms": None,
+            "tokens/s/user": None,
+            "tokens/s/gpu": None,
+            "output_throughput_tok_s": None,
+            "completed_requests": None,
+            "error": f"{type(exc).__name__}: {exc}",
+        }
+
+    num_gpus = parallel_cfg.num_gpus
+    output_throughput = report.get("output_throughput_tok_s") or 0.0
+    return {
+        **base_row,
+        "ttft_ms": report.get("mean_ttft_ms"),
+        "tpot_ms": report.get("mean_itl_ms"),
+        "request_latency_ms": report.get("mean_e2e_latency_ms"),
+        "tokens/s/user": report.get("mean_output_token_throughput_per_user"),
+        "tokens/s/gpu": (output_throughput / num_gpus) if num_gpus > 0 else None,
+        "output_throughput_tok_s": output_throughput,
+        "completed_requests": report.get("completed_requests"),
+        "error": None,
+    }
+
+
+def _describe_task(parallel_cfg: ParallelConfig, bs: int) -> str:
+    return (
+        f"tp={parallel_cfg.tp} pp={parallel_cfg.pp} "
+        f"dp={parallel_cfg.dp} moe_tp={parallel_cfg.moe_tp} "
+        f"moe_ep={parallel_cfg.moe_ep} bs={bs}"
+    )
+
+
+def _describe_disagg_point(point: DisaggPoint) -> str:
+    return (
+        f"P[tp={point.prefill.tp} dp={point.prefill.dp} "
+        f"moe_tp={point.prefill.moe_tp} moe_ep={point.prefill.moe_ep} "
+        f"bs={point.prefill_bs} w={point.prefill_workers}] "
+        f"D[tp={point.decode.tp} dp={point.decode.dp} "
+        f"moe_tp={point.decode.moe_tp} moe_ep={point.decode.moe_ep} "
+        f"bs={point.decode_bs} w={point.decode_workers}] "
+        f"gpus={point.total_gpus}"
+    )
+
+
+def _derive_disagg_grid(
+    grid: list[ParallelConfig], total_gpus: int
+) -> list[DisaggPoint]:
+    """Enumerate viable disagg (prefill, decode, workers, bs) combinations.
+
+    Invariants enforced (v1, keeps the cross-product manageable):
+      * total GPUs used ≤ ``total_gpus``
+      * ``decode.num_gpus * decode_workers >= prefill.num_gpus * prefill_workers``
+        — decode is the throughput bottleneck in disagg; configurations
+        where decode has fewer GPUs than prefill are rarely interesting
+        and explode the search space without adding insight.
+    """
+    points: list[DisaggPoint] = []
+    for p in grid:
+        for pw in DISAGG_PREFILL_WORKERS:
+            p_gpus = p.num_gpus * pw
+            if p_gpus > total_gpus:
+                continue
+            remaining = total_gpus - p_gpus
+            for d in grid:
+                for dw in DISAGG_DECODE_WORKERS:
+                    d_gpus = d.num_gpus * dw
+                    if d_gpus > remaining:
+                        continue
+                    if d_gpus < p_gpus:
+                        continue
+                    for pbs in DISAGG_PREFILL_BS:
+                        for dbs in DISAGG_DECODE_BS:
+                            points.append(
+                                DisaggPoint(
+                                    prefill=p,
+                                    decode=d,
+                                    prefill_bs=pbs,
+                                    decode_bs=dbs,
+                                    prefill_workers=pw,
+                                    decode_workers=dw,
+                                )
+                            )
+    return points
+
+
+def _disagg_base_row(point: DisaggPoint) -> dict:
+    return {
+        "p_tp": point.prefill.tp,
+        "p_pp": point.prefill.pp,
+        "p_dp": point.prefill.dp,
+        "p_moe_tp": point.prefill.moe_tp,
+        "p_moe_ep": point.prefill.moe_ep,
+        "p_bs": point.prefill_bs,
+        "p_workers": point.prefill_workers,
+        "d_tp": point.decode.tp,
+        "d_pp": point.decode.pp,
+        "d_dp": point.decode.dp,
+        "d_moe_tp": point.decode.moe_tp,
+        "d_moe_ep": point.decode.moe_ep,
+        "d_bs": point.decode_bs,
+        "d_workers": point.decode_workers,
+        "total_gpus": point.total_gpus,
+    }
+
+
+def _evaluate_one_disagg(
+    point: DisaggPoint,
+    *,
+    isl: int,
+    osl: int,
+    backend: str,
+    backend_version: str | None,
+    system: str,
+    model_path: str,
+) -> dict:
+    """Run mocker for one disagg point. Returns a flat metrics dict."""
+    p_args = _build_engine_args(
+        point.prefill,
+        point.prefill_bs,
+        backend=backend,
+        backend_version=backend_version,
+        system=system,
+        model_path=model_path,
+        worker_type="prefill",
+    )
+    d_args = _build_engine_args(
+        point.decode,
+        point.decode_bs,
+        backend=backend,
+        backend_version=backend_version,
+        system=system,
+        model_path=model_path,
+        worker_type="decode",
+    )
+    # Drive enough in-flight load to saturate the decode pool. num_requests
+    # scales with the heavier (decode) side per the same heuristic as agg.
+    target_in_flight = point.decode_bs * point.decode_workers
+    num_requests = max(50, 5 * target_in_flight)
+    base_row = _disagg_base_row(point)
+
+    try:
+        report = run_synthetic_trace_replay(
+            isl,
+            osl,
+            num_requests,
+            prefill_engine_args=MockEngineArgs.from_json(json.dumps(p_args)),
+            decode_engine_args=MockEngineArgs.from_json(json.dumps(d_args)),
+            num_prefill_workers=point.prefill_workers,
+            num_decode_workers=point.decode_workers,
+            replay_concurrency=target_in_flight,
+            replay_mode="offline",
+            router_mode="kv_router",
+        )
+    except Exception as exc:
+        return {
+            **base_row,
+            "ttft_ms": None,
+            "tpot_ms": None,
+            "request_latency_ms": None,
+            "tokens/s/user": None,
+            "tokens/s/gpu": None,
+            "output_throughput_tok_s": None,
+            "completed_requests": None,
+            "error": f"{type(exc).__name__}: {exc}",
+        }
+
+    output_throughput = report.get("output_throughput_tok_s") or 0.0
+    return {
+        **base_row,
+        "ttft_ms": report.get("mean_ttft_ms"),
+        "tpot_ms": report.get("mean_itl_ms"),
+        "request_latency_ms": report.get("mean_e2e_latency_ms"),
+        "tokens/s/user": report.get("mean_output_token_throughput_per_user"),
+        "tokens/s/gpu": (
+            output_throughput / point.total_gpus if point.total_gpus > 0 else None
+        ),
+        "output_throughput_tok_s": output_throughput,
+        "completed_requests": report.get("completed_requests"),
+        "error": None,
+    }
+
+
+def _run_parallel_sweep(
+    tasks: list,
+    evaluator,
+    common_kwargs: dict,
+    *,
+    workers: int,
+    describe,
+    fallback_row,
+) -> list[dict]:
+    """Generic parallel/serial sweep runner used by both agg and disagg paths."""
+    total = len(tasks)
+    rows: list[dict] = []
+    if workers <= 1:
+        for done, task in enumerate(tasks, start=1):
+            print(f"[{done}/{total}] {describe(task)}", flush=True)
+            rows.append(
+                evaluator(*task, **common_kwargs)
+                if isinstance(task, tuple)
+                else evaluator(task, **common_kwargs)
+            )
+        return rows
+
+    print(f"Parallel sweep with {workers} workers ({total} tasks).", flush=True)
+    with ProcessPoolExecutor(max_workers=workers) as pool:
+        future_to_task = {}
+        for task in tasks:
+            if isinstance(task, tuple):
+                fut = pool.submit(evaluator, *task, **common_kwargs)
+            else:
+                fut = pool.submit(evaluator, task, **common_kwargs)
+            future_to_task[fut] = task
+        done = 0
+        for fut in as_completed(future_to_task):
+            done += 1
+            task = future_to_task[fut]
+            try:
+                rows.append(fut.result())
+            except Exception as exc:
+                rows.append(fallback_row(task, f"worker: {type(exc).__name__}: {exc}"))
+            print(f"[{done}/{total}] {describe(task)}", flush=True)
+    return rows
+
+
+def _agg_fallback_row(task, error: str) -> dict:
+    parallel_cfg, bs = task
+    return {
+        "tp": parallel_cfg.tp,
+        "pp": parallel_cfg.pp,
+        "dp": parallel_cfg.dp,
+        "moe_tp": parallel_cfg.moe_tp,
+        "moe_ep": parallel_cfg.moe_ep,
+        "bs": bs,
+        "num_gpus": parallel_cfg.num_gpus,
+        "ttft_ms": None,
+        "tpot_ms": None,
+        "request_latency_ms": None,
+        "tokens/s/user": None,
+        "tokens/s/gpu": None,
+        "output_throughput_tok_s": None,
+        "completed_requests": None,
+        "error": error,
+    }
+
+
+def _disagg_fallback_row(point: DisaggPoint, error: str) -> dict:
+    return {
+        **_disagg_base_row(point),
+        "ttft_ms": None,
+        "tpot_ms": None,
+        "request_latency_ms": None,
+        "tokens/s/user": None,
+        "tokens/s/gpu": None,
+        "output_throughput_tok_s": None,
+        "completed_requests": None,
+        "error": error,
+    }
+
+
+def _compute_pareto_and_save(
+    rows: list[dict],
+    *,
+    save_dir: Path,
+    raw_name: str,
+    pareto_name: str,
+    ttft: float,
+    tpot: float,
+    strict_sla: bool,
+) -> tuple[Path, Path, int, int]:
+    raw_df = pd.DataFrame(rows)
+    raw_path = save_dir / raw_name
+    raw_df.to_csv(raw_path, index=False)
+
+    candidates = raw_df.dropna(subset=["tokens/s/user", "tokens/s/gpu"])
+    candidates = candidates[candidates["ttft_ms"] <= ttft]
+    if strict_sla:
+        candidates = candidates[candidates["tpot_ms"] <= tpot]
+
+    pareto_df = (
+        get_pareto_front(
+            candidates,
+            x_col="tokens/s/user",
+            y_col="tokens/s/gpu",
+            maximize_x=True,
+            maximize_y=True,
+        )
+        if not candidates.empty
+        else candidates
+    )
+    pareto_path = save_dir / pareto_name
+    pareto_df.to_csv(pareto_path, index=False)
+    return raw_path, pareto_path, len(raw_df), len(pareto_df)
+
+
+def sweep_pareto(args: argparse.Namespace) -> dict[str, Path]:
+    """Run the mocker sweep(s) per ``args.mode`` and write CSVs."""
+    save_dir = Path(args.save_dir)
+    save_dir.mkdir(parents=True, exist_ok=True)
+
+    is_moe = _detect_is_moe(args.model_path)
+    grid = _derive_parallel_grid(
+        args.total_gpus, args.system, args.backend, is_moe, args.enable_wideep
+    )
+    print(
+        f"Enumerated {len(grid)} parallelism configs "
+        f"(model={args.model_path}, is_moe={is_moe}, total_gpus={args.total_gpus})."
+    )
+
+    workers = max(1, args.workers)
+    common_kwargs = {
+        "isl": args.isl,
+        "osl": args.osl,
+        "backend": args.backend,
+        "backend_version": args.backend_version,
+        "system": args.system,
+        "model_path": args.model_path,
+    }
+    outputs: dict[str, Path] = {}
+
+    if args.mode in ("agg", "both"):
+        print("\n=== AGG SWEEP ===")
+        agg_tasks = [(parallel_cfg, bs) for parallel_cfg in grid for bs in BATCH_SIZES]
+        agg_rows = _run_parallel_sweep(
+            agg_tasks,
+            _evaluate_one,
+            common_kwargs,
+            workers=workers,
+            describe=lambda t: _describe_task(t[0], t[1]),
+            fallback_row=_agg_fallback_row,
+        )
+        raw_p, pareto_p, n_raw, n_pareto = _compute_pareto_and_save(
+            agg_rows,
+            save_dir=save_dir,
+            raw_name="raw_mocker.csv",
+            pareto_name="pareto_mocker.csv",
+            ttft=args.ttft,
+            tpot=args.tpot,
+            strict_sla=args.strict_sla,
+        )
+        outputs["raw"] = raw_p
+        outputs["pareto"] = pareto_p
+        print(f"\nWrote {n_raw} agg raw points to {raw_p}")
+        print(f"Wrote {n_pareto} agg pareto points to {pareto_p}")
+
+    if args.mode in ("disagg", "both"):
+        print("\n=== DISAGG SWEEP ===")
+        disagg_points = _derive_disagg_grid(grid, args.total_gpus)
+        print(f"Enumerated {len(disagg_points)} disagg points.")
+        disagg_rows = _run_parallel_sweep(
+            disagg_points,
+            _evaluate_one_disagg,
+            common_kwargs,
+            workers=workers,
+            describe=_describe_disagg_point,
+            fallback_row=_disagg_fallback_row,
+        )
+        raw_p, pareto_p, n_raw, n_pareto = _compute_pareto_and_save(
+            disagg_rows,
+            save_dir=save_dir,
+            raw_name="raw_mocker_disagg.csv",
+            pareto_name="pareto_mocker_disagg.csv",
+            ttft=args.ttft,
+            tpot=args.tpot,
+            strict_sla=args.strict_sla,
+        )
+        outputs["raw_disagg"] = raw_p
+        outputs["pareto_disagg"] = pareto_p
+        print(f"\nWrote {n_raw} disagg raw points to {raw_p}")
+        print(f"Wrote {n_pareto} disagg pareto points to {pareto_p}")
+
+    return outputs
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m dynamo.replay.pareto",
+        description=(
+            "Mocker-based parallelism + batch-size sweep producing a Pareto "
+            "front on (tokens/s/user, tokens/s/gpu)."
+        ),
+    )
+    p.add_argument(
+        "--model",
+        "--model-path",
+        dest="model_path",
+        required=True,
+        help="HF model id (e.g., 'moonshotai/Kimi-K2.5') or local model directory.",
+    )
+    p.add_argument("--system", required=True, help="GPU system (e.g., b200_sxm).")
+    p.add_argument(
+        "--backend",
+        required=True,
+        choices=("vllm", "trtllm", "sglang"),
+        help="Inference backend.",
+    )
+    p.add_argument(
+        "--backend-version",
+        default=None,
+        help="AIC backend DB version (default: latest available).",
+    )
+    p.add_argument(
+        "--total-gpus",
+        type=int,
+        required=True,
+        help="Total GPUs budget for parallelism enumeration.",
+    )
+    p.add_argument("--isl", type=int, default=4000, help="Input sequence length.")
+    p.add_argument("--osl", type=int, default=1000, help="Output sequence length.")
+    p.add_argument("--ttft", type=float, default=2000.0, help="TTFT SLA target (ms).")
+    p.add_argument("--tpot", type=float, default=30.0, help="TPOT SLA target (ms).")
+    p.add_argument(
+        "--strict-sla",
+        action="store_true",
+        help="Filter the Pareto frontier to TPOT-compliant configs as well "
+        "(TTFT is always enforced).",
+    )
+    p.add_argument(
+        "--enable-wideep",
+        action="store_true",
+        help="Enable Wide Expert Parallelism for MoE models.",
+    )
+    p.add_argument(
+        "--mode",
+        default="agg",
+        choices=("agg", "disagg", "both"),
+        help="Deployment mode. 'agg' (default) sweeps aggregated deployments; "
+        "'disagg' sweeps disaggregated prefill/decode pools; 'both' runs each "
+        "and writes separate CSVs (raw_mocker[_disagg].csv etc.).",
+    )
+    p.add_argument("--save-dir", required=True, help="Output directory.")
+    p.add_argument(
+        "--workers",
+        type=int,
+        default=max(1, (os.cpu_count() or 2) // 2),
+        help="Number of worker processes for the mocker sweep "
+        "(default: half of os.cpu_count). Use 1 for serial.",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    sweep_pareto(args)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lib/bindings/python/src/dynamo/replay/pareto.py
+++ b/lib/bindings/python/src/dynamo/replay/pareto.py
@@ -573,6 +573,52 @@ def _compute_pareto_and_save(
     return raw_path, pareto_path, len(raw_df), len(pareto_df)
 
 
+def compute_top_n(
+    rows: list[dict], *, ttft: float, tpot: float, top_n: int
+) -> pd.DataFrame:
+    """Top-N deployable recommendations: STRICT SLA-pass, sorted by tok/s/gpu.
+
+    Always enforces both TTFT and TPOT (unlike the Pareto front, which can
+    optionally relax TPOT via --strict-sla). The top-N is the practitioner's
+    answer to "if I had to pick N configs to deploy, which?".
+    """
+    df = pd.DataFrame(rows)
+    cand = df.dropna(subset=["tokens/s/user", "tokens/s/gpu"])
+    cand = cand[(cand["ttft_ms"] <= ttft) & (cand["tpot_ms"] <= tpot)]
+    return cand.sort_values("tokens/s/gpu", ascending=False).head(top_n)
+
+
+def _format_top_n(top: pd.DataFrame, *, label: str, is_disagg: bool) -> str:
+    if top.empty:
+        return (
+            f"\n=== Top recommendations ({label}) ===\n  (no SLA-compliant configs)\n"
+        )
+    lines = [f"\n=== Top {len(top)} recommendations ({label}) ==="]
+    for rank, (_, r) in enumerate(top.iterrows(), start=1):
+        if is_disagg:
+            lines.append(
+                f"  #{rank}: "
+                f"P[tp={int(r['p_tp'])} dp={int(r['p_dp'])} "
+                f"moe_tp={int(r['p_moe_tp'])} moe_ep={int(r['p_moe_ep'])} "
+                f"bs={int(r['p_bs'])} w={int(r['p_workers'])}] "
+                f"D[tp={int(r['d_tp'])} dp={int(r['d_dp'])} "
+                f"moe_tp={int(r['d_moe_tp'])} moe_ep={int(r['d_moe_ep'])} "
+                f"bs={int(r['d_bs'])} w={int(r['d_workers'])}] "
+                f"gpus={int(r['total_gpus'])} | "
+                f"TTFT={r['ttft_ms']:.0f}ms TPOT={r['tpot_ms']:.1f}ms | "
+                f"tok/s/user={r['tokens/s/user']:.2f} tok/s/gpu={r['tokens/s/gpu']:.1f}"
+            )
+        else:
+            lines.append(
+                f"  #{rank}: tp={int(r['tp'])} dp={int(r['dp'])} "
+                f"moe_tp={int(r['moe_tp'])} moe_ep={int(r['moe_ep'])} bs={int(r['bs'])} "
+                f"gpus={int(r['num_gpus'])} | "
+                f"TTFT={r['ttft_ms']:.0f}ms TPOT={r['tpot_ms']:.1f}ms | "
+                f"tok/s/user={r['tokens/s/user']:.2f} tok/s/gpu={r['tokens/s/gpu']:.1f}"
+            )
+    return "\n".join(lines) + "\n"
+
+
 def sweep_pareto(args: argparse.Namespace) -> dict[str, Path]:
     """Run the mocker sweep(s) per ``args.mode`` and write CSVs."""
     save_dir = Path(args.save_dir)
@@ -623,6 +669,13 @@ def sweep_pareto(args: argparse.Namespace) -> dict[str, Path]:
         print(f"\nWrote {n_raw} agg raw points to {raw_p}")
         print(f"Wrote {n_pareto} agg pareto points to {pareto_p}")
 
+        top = compute_top_n(agg_rows, ttft=args.ttft, tpot=args.tpot, top_n=args.top_n)
+        top_path = save_dir / "best_topn_mocker.csv"
+        top.to_csv(top_path, index=False)
+        outputs["top_n"] = top_path
+        print(_format_top_n(top, label="mocker agg", is_disagg=False))
+        print(f"Wrote top-{args.top_n} mocker agg recommendations to {top_path}")
+
     if args.mode in ("disagg", "both"):
         print("\n=== DISAGG SWEEP ===")
         disagg_points = _derive_disagg_grid(grid, args.total_gpus)
@@ -648,6 +701,15 @@ def sweep_pareto(args: argparse.Namespace) -> dict[str, Path]:
         outputs["pareto_disagg"] = pareto_p
         print(f"\nWrote {n_raw} disagg raw points to {raw_p}")
         print(f"Wrote {n_pareto} disagg pareto points to {pareto_p}")
+
+        top = compute_top_n(
+            disagg_rows, ttft=args.ttft, tpot=args.tpot, top_n=args.top_n
+        )
+        top_path = save_dir / "best_topn_mocker_disagg.csv"
+        top.to_csv(top_path, index=False)
+        outputs["top_n_disagg"] = top_path
+        print(_format_top_n(top, label="mocker disagg", is_disagg=True))
+        print(f"Wrote top-{args.top_n} mocker disagg recommendations to {top_path}")
 
     return outputs
 
@@ -715,6 +777,14 @@ def _build_parser() -> argparse.ArgumentParser:
         default=max(1, (os.cpu_count() or 2) // 2),
         help="Number of worker processes for the mocker sweep "
         "(default: half of os.cpu_count). Use 1 for serial.",
+    )
+    p.add_argument(
+        "--top-n",
+        type=int,
+        default=5,
+        help="Write top-N STRICT-SLA-passing configs (sorted by tok/s/gpu) "
+        "to best_topn_mocker[_disagg].csv and echo to stdout (default: 5). "
+        "Matches AIC's `aiconfigurator cli default --top-n` semantics.",
     )
     return p
 


### PR DESCRIPTION
## Summary

Adds two new entry points for analysing inference deployment configurations without launching the engine:

- **`python -m dynamo.replay.pareto …`** — mocker-driven sweep over parallelism × batch-size, writes the Pareto front on (tokens/s/user, tokens/s/gpu) for a given (model, system, backend, total_gpus, ISL, OSL, TTFT/TPOT SLA).
- **`python benchmarks/mocker/pareto_comparison.py …`** — driver that runs the mocker sweep + AIC's analytical model (\`aiconfigurator cli estimate\` analog, in-process via \`InferenceSession\`) over the same config grid, then overlays the two Pareto curves on one figure for direct comparison.

The CLI surface mirrors \`aiconfigurator cli default\` so users can swap predictors with the same flags. Mocker side parallelises across worker processes (\`--workers\`, default = half of cpu_count).

\`--mode {agg, disagg, both}\` is supported. Disagg sweeps prefill × decode × workers × bs subject to \`decode_gpus ≥ prefill_gpus\` (search-space caps in pareto.py constants).

Prompt to be passed to agent:
> Can you generate the pareto + top N with aic and mocker on b200_sxm 8GPU for agg+disagg for nvidia/MiniMax-M2.5-NVFP4, SLA TTFT 1000ms, TPOT 100ms?

## What it produces

In \`--save-dir\`:

\`\`\`
raw_mocker.csv          every mocker-evaluated (parallelism, bs) point
pareto_mocker.csv       mocker Pareto-front subset
raw_aic.csv             every AIC-evaluated point (driver only)
pareto_aic.csv          AIC Pareto-front subset (driver only)
raw_mocker_disagg.csv   disagg analogs when --mode={disagg, both}
pareto_mocker_disagg.csv
raw_aic_disagg.csv
pareto_aic_disagg.csv
pareto_plot.png         dual-curve / quad-curve matplotlib figure
sweep_meta.json         invocation args + counts
\`\`\`

## Why

AIC predicts perf analytically; mocker simulates discretely. Surfacing where they disagree (low-bs scheduler overhead, high-bs perf-DB interpolation gaps, MoE EP scaling, …) helps both projects calibrate.

## Notable design choices (documented in \`benchmarks/mocker/README.md\`)

- \`BATCH_SIZES = (1, 2, 4, 8, 16, 32, 64, 128, 256)\` — coarse subset of AIC's internal \`b_list_default\`. v1 tradeoff for runtime.
- \`MockEngineArgs.dp_size\` always 1 (mocker's \`validate.rs\` rejects anything else); deployment DP is carried via \`--num-workers\` + \`aic_attention_dp_size\` in engine-args.
- \`ctx_tokens = isl\` for AIC's \`run_agg\` (one prefill per step at the picked bs; matches vllm-style IFB with chunked-prefill disabled).
- Disagg: \`DISAGG_PREFILL_WORKERS=(1,)\`, \`DISAGG_DECODE_WORKERS=(1,2,4)\`, \`DISAGG_PREFILL_BS=(1,2,4,8)\`, \`DISAGG_DECODE_BS=(32,64,128)\` for v1; bump in pareto.py for denser coverage.

## Test plan

- [x] \`python -m dynamo.replay.pareto --help\` and \`python benchmarks/mocker/pareto_comparison.py --help\` both render the documented CLI surface.
- [x] Exercised end-to-end on Kimi-K2.5 across multiple systems:
  - b200_sxm 8 GPUs / ISL=8192 OSL=1024 / agg → 81 mocker + 81 AIC points, 14m26s wall time with \`--workers 6\`
  - gb200 8 GPUs / ISL=1024 OSL=1024 / --mode both → 81 agg + 540 disagg points, ~14 min total
  - b300_sxm 32 GPUs / ISL=1024 OSL=1024 / agg → 81 mocker + 81 AIC points, ~1 min wall time
- [x] Both single-config replay (no sweep) and full pareto driver produce non-empty Pareto fronts on at least one common SLA setting.
- [x] Ran with \`RUST_LOG=warn\` to suppress kv_router INFO logging (large speedup at high concurrency).

## Known limitations

See \`benchmarks/mocker/README.md\` for the candid v1 limitations list. Highlights:
- No \`stream_interval\` modeling (real-system TTFT includes stream-batching overhead neither AIC nor mocker reproduces).
- No \`enforce_eager\` / \`cudagraph_mode\` / \`async_scheduling\` differentiation (real cudagraph vs eager perf delta is invisible to both).
- KV-cache dtype not in MockEngineArgs; AIC's perf model handles it via aic_backend hookup.
- Disagg search-space caps are intentionally tight; loosen by editing constants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)