### PR TITLE
fix(gms): make _allocator_ext PEP 703 (free-threading) ready

### DIFF
--- a/lib/gpu_memory_service/client/torch/extensions/allocator.cpp
+++ b/lib/gpu_memory_service/client/torch/extensions/allocator.cpp
@@ -14,9 +14,11 @@
 //
 // PEP 703 (free-threaded CPython) note: the callback pair is held in a magic-
 // statics singleton, so reads from my_malloc/my_free are data-race-free without
-// explicit synchronization. The first call to init_module wins; subsequent calls
-// are silent no-ops on the stored callbacks. The Python wrapper
-// _ensure_callbacks_initialized already enforces one-shot init in practice.
+// explicit synchronization. The C++ contract is "first call to callbacks() wins";
+// in practice that is init_module, because the Python wrapper
+// _ensure_callbacks_initialized invokes init_module synchronously before any
+// allocation path can reach my_malloc / my_free. Subsequent calls to callbacks()
+// with new arguments are silent no-ops on the stored pointers.
 
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
@@ -114,8 +116,9 @@ py_init_module(PyObject* self, PyObject* args)
     return nullptr;
   }
 
-  // First call wins; subsequent calls are silent no-ops by design (matches the
-  // single-init contract enforced by _ensure_callbacks_initialized).
+  // First call to callbacks() wins; subsequent calls do not rebind the stored
+  // pointers. In practice this is invoked exactly once by the Python wrapper
+  // _ensure_callbacks_initialized.
   callbacks(malloc_cb, free_cb);
 
   Py_RETURN_NONE;

--- a/lib/gpu_memory_service/client/torch/extensions/allocator.cpp
+++ b/lib/gpu_memory_service/client/torch/extensions/allocator.cpp
@@ -11,28 +11,56 @@
 // cuMemUnmap) are synchronous and globally visible - they don't have per-stream
 // semantics like cudaMallocAsync. We keep the parameter to match PyTorch's
 // CUDAPluggableAllocator interface signature.
+//
+// PEP 703 (free-threaded CPython) note: the callback pair is held in a magic-
+// statics singleton, so reads from my_malloc/my_free are data-race-free without
+// explicit synchronization. The first call to init_module wins; subsequent calls
+// are silent no-ops on the stored callbacks. The Python wrapper
+// _ensure_callbacks_initialized already enforces one-shot init in practice.
 
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 #include <cstdint>
 
-static PyObject* g_malloc_callback = nullptr;
-static PyObject* g_free_callback = nullptr;
+namespace {
+
+struct Callbacks {
+  PyObject* malloc_cb;
+  PyObject* free_cb;
+};
+
+// Magic-statics singleton: thread-safe lazy construction is guaranteed by
+// C++11 [stmt.dcl]/4, and the resulting happens-before makes all subsequent
+// reads data-race-free. New refs to the captured callables are taken inside
+// the lambda so the singleton owns them for the program lifetime.
+const Callbacks&
+callbacks(PyObject* m = nullptr, PyObject* f = nullptr)
+{
+  static const Callbacks instance = [&]() {
+    Py_XINCREF(m);
+    Py_XINCREF(f);
+    return Callbacks{m, f};
+  }();
+  return instance;
+}
+
+}  // namespace
 
 extern "C" {
 
 void*
 my_malloc(ssize_t size, int device, void* stream)
 {
-  if (!g_malloc_callback) {
+  const Callbacks& cb = callbacks();
+  if (!cb.malloc_cb) {
     return nullptr;
   }
 
   PyGILState_STATE gstate = PyGILState_Ensure();
 
   PyObject* args = Py_BuildValue("(niK)", size, device, (unsigned long long)stream);
-  PyObject* result = PyObject_CallObject(g_malloc_callback, args);
+  PyObject* result = PyObject_CallObject(cb.malloc_cb, args);
   Py_DECREF(args);
 
   void* ptr = nullptr;
@@ -52,14 +80,15 @@ my_malloc(ssize_t size, int device, void* stream)
 void
 my_free(void* ptr, ssize_t size, int device, void* stream)
 {
-  if (!g_free_callback) {
+  const Callbacks& cb = callbacks();
+  if (!cb.free_cb) {
     return;
   }
 
   PyGILState_STATE gstate = PyGILState_Ensure();
 
   PyObject* args = Py_BuildValue("(KniK)", (unsigned long long)ptr, size, device, (unsigned long long)stream);
-  PyObject* result = PyObject_CallObject(g_free_callback, args);
+  PyObject* result = PyObject_CallObject(cb.free_cb, args);
   Py_DECREF(args);
   Py_XDECREF(result);
 
@@ -85,13 +114,9 @@ py_init_module(PyObject* self, PyObject* args)
     return nullptr;
   }
 
-  Py_XINCREF(malloc_cb);
-  Py_XINCREF(free_cb);
-  Py_XDECREF(g_malloc_callback);
-  Py_XDECREF(g_free_callback);
-
-  g_malloc_callback = malloc_cb;
-  g_free_callback = free_cb;
+  // First call wins; subsequent calls are silent no-ops by design (matches the
+  // single-init contract enforced by _ensure_callbacks_initialized).
+  callbacks(malloc_cb, free_cb);
 
   Py_RETURN_NONE;
 }
@@ -105,7 +130,16 @@ static struct PyModuleDef allocator_module = {
 PyMODINIT_FUNC
 PyInit__allocator_ext(void)
 {
-  return PyModule_Create(&allocator_module);
+  PyObject* m = PyModule_Create(&allocator_module);
+  if (m == nullptr) {
+    return nullptr;
+  }
+
+#ifdef Py_GIL_DISABLED
+  PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
+#endif
+
+  return m;
 }
 
 }  // extern "C"


### PR DESCRIPTION
The C++ extension that backs PyTorch's CUDAPluggableAllocator integration
was not safe to import into a free-threaded CPython interpreter:

- single-phase init with no Py_mod_gil declaration, so importing on a
  3.13+ no-GIL build flipped the GIL back on for the rest of the process
- two module-level callback pointers were mutated in py_init_module and
  read concurrently from my_malloc / my_free, a torn-pointer race once
  the GIL is gone

Replace the raw globals with a magic-statics singleton holding the
callback pair. C++11 [stmt.dcl]/4 guarantees thread-safe lazy construction
and a happens-before relationship to every subsequent read, so the hot
path stays data-race-free with no mutex or atomic. The first init_module
call wins; subsequent calls are silent no-ops on the stored callbacks
(the Python-side wrapper _ensure_callbacks_initialized already enforces
one-shot init in practice).

Add PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED) after PyModule_Create,
guarded on Py_GIL_DISABLED since that is where the symbol is declared.

Refs DYN-3039

Signed-off-by: Nicolas 'Pixel' Noble <nicolas@nobis-crew.org>

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9575" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal GPU memory allocation callback handling for improved resource management and efficiency.
  * Enhanced compatibility with no-GIL Python implementations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9575)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->