### PR TITLE
feat(frontend): Support disagg for sglang processor

### DIFF
--- a/components/src/dynamo/frontend/main.py
+++ b/components/src/dynamo/frontend/main.py
@@ -66,8 +66,6 @@ def setup_engine_factory(
 
 
 def setup_sglang_engine_factory(
-    runtime: DistributedRuntime,
-    router_config: RouterConfig,
     config: FrontendConfig,
     sglang_flags: Optional[Namespace] = None,
 ):
@@ -81,8 +79,6 @@ def setup_sglang_engine_factory(
     reasoning_parser = getattr(sglang_flags, "reasoning_parser", None)
 
     return SglangEngineFactory(
-        runtime,
-        router_config,
         config,
         debug_perf=config.debug_perf,
         tool_call_parser_name=tool_call_parser,
@@ -285,7 +281,7 @@ async def async_main():
         kwargs["chat_engine_factory"] = chat_engine_factory
     elif config.chat_processor == "sglang":
         chat_engine_factory = setup_sglang_engine_factory(
-            runtime, router_config, config, sglang_flags
+            config, sglang_flags
         ).chat_engine_factory
         kwargs["chat_engine_factory"] = chat_engine_factory
 

--- a/components/src/dynamo/frontend/sglang_processor.py
+++ b/components/src/dynamo/frontend/sglang_processor.py
@@ -17,20 +17,10 @@ from typing import Any
 
 from sglang.srt.utils.hf_transformers_utils import get_tokenizer
 
-from dynamo._core import Client
 from dynamo._internal import ModelDeploymentCard
 from dynamo.frontend.frontend_args import FrontendConfig
-from dynamo.llm import (
-    KvRouter,
-    ModelCardInstanceId,
-    PythonAsyncEngine,
-    RoutedEngine,
-    RouterConfig,
-    RouterMode,
-    fetch_model,
-)
+from dynamo.llm import ModelCardInstanceId, PythonAsyncEngine, RoutedEngine, fetch_model
 from dynamo.llm.exceptions import InvalidArgument, Unknown
-from dynamo.runtime import DistributedRuntime
 
 from .sglang_prepost import (
     SglangStreamingPostProcessor,
@@ -45,6 +35,8 @@ from .sglang_prepost import (
 from .utils import (
     PreprocessError,
     extract_mm_urls,
+    handle_engine_error,
+    make_internal_error,
     nvext_extra_field_requested,
     random_uuid,
     worker_warmup,
@@ -66,17 +58,6 @@ def _runtime_config_parser_name(
 
 def _unsupported_n_message(n: int) -> str:
     return f"Unsupported value: 'n={n}'. " "This endpoint currently supports only n=1."
-
-
-def _engine_error_message(
-    engine_response: Any,
-    request_id: str,
-) -> str:
-    """Extract a human-readable message from an invalid engine response."""
-    if isinstance(engine_response, dict) and engine_response.get("status") == "error":
-        backend_msg = engine_response.get("message") or "unknown backend error"
-        return f"Backend error for request {request_id}: {backend_msg}"
-    return f"Invalid engine response for request {request_id}"
 
 
 _FINISH_REASON_MAP: dict[str, str] = {
@@ -276,7 +257,7 @@ class SglangProcessor:
     def __init__(
         self,
         tokenizer,
-        router,  # Client or KvRouter
+        routed_engine: RoutedEngine,
         tool_call_parser_name: str | None,
         reasoning_parser_name: str | None,
         eos_token_id: int | None,
@@ -300,8 +281,7 @@ class SglangProcessor:
                 "separate_reasoning=false or "
                 "chat_template_kwargs.enable_thinking=false)."
             )
-        self.router = router
-        self.is_kv_router = isinstance(router, KvRouter)
+        self.routed_engine = routed_engine
         self.tool_call_parser_name = tool_call_parser_name
         self.reasoning_parser_name = reasoning_parser_name
         self.exclude_tools_when_tool_choice_none = True
@@ -317,7 +297,7 @@ class SglangProcessor:
             self._worker_semaphore = None
 
     async def generator(
-        self, request: dict[str, Any]
+        self, request: dict[str, Any], context: Any | None = None
     ) -> AsyncGenerator[dict[str, Any], None]:
         """Main entry point: preprocess, route, post-process a chat request."""
         if self.debug_perf:
@@ -332,10 +312,10 @@ class SglangProcessor:
 
         try:
             if self.preprocess_pool is None:
-                async for item in self._generator_inner(request):
+                async for item in self._generator_inner(request, context=context):
                     yield item
             else:
-                async for item in self._generator_inner_pool(request):
+                async for item in self._generator_inner_pool(request, context=context):
                     yield item
         finally:
             if self.debug_perf:
@@ -348,7 +328,7 @@ class SglangProcessor:
                 )
 
     async def _generator_inner(
-        self, request: dict[str, Any]
+        self, request: dict[str, Any], context: Any | None = None
     ) -> AsyncGenerator[dict[str, Any], None]:
         """Single-process path: preprocess, dispatch, stream post-process."""
         request_id = random_uuid()
@@ -407,12 +387,12 @@ class SglangProcessor:
         )
 
         async for item in self._generate_and_stream(
-            request_id, request, dynamo_preproc, tokens, post
+            request_id, request, dynamo_preproc, tokens, post, context=context
         ):
             yield item
 
     async def _generator_inner_pool(
-        self, request: dict[str, Any]
+        self, request: dict[str, Any], context: Any | None = None
     ) -> AsyncGenerator[dict[str, Any], None]:
         """Pool path: preprocess in worker, stream in main process."""
         request_id = random_uuid()
@@ -468,6 +448,7 @@ class SglangProcessor:
             preproc_result.dynamo_preproc,
             preproc_result.prompt_token_ids,
             post,
+            context=context,
         ):
             yield item
 
@@ -478,6 +459,7 @@ class SglangProcessor:
         dynamo_preproc: dict[str, Any],
         tokens: list[int],
         post: SglangStreamingPostProcessor,
+        context: Any | None = None,
     ) -> AsyncGenerator[dict[str, Any], None]:
         """Shared streaming logic for both single-process and pool paths."""
         token_count = 0
@@ -486,19 +468,9 @@ class SglangProcessor:
         stream_interval = self.stream_interval
 
         try:
-            if self.is_kv_router:
-                dynamo_stream = await self.router.generate(
-                    token_ids=tokens,
-                    model=dynamo_preproc["model"],
-                    stop_conditions=dynamo_preproc["stop_conditions"],
-                    sampling_options=dynamo_preproc["sampling_options"],
-                    output_options=dynamo_preproc["output_options"],
-                    multi_modal_data=dynamo_preproc.get("multi_modal_data"),
-                )
-            else:
-                dynamo_stream = await self.router.generate(
-                    dynamo_preproc, annotated=False
-                )
+            dynamo_stream = await self.routed_engine.generate(
+                dynamo_preproc, context=context
+            )
 
             # Accumulate tokens for batched detokenization when
             # stream_interval > 1.  Flush every N tokens or on
@@ -509,24 +481,29 @@ class SglangProcessor:
             first_chunk = True
 
             async for dynamo_response in dynamo_stream:
-                if self.is_kv_router:
-                    engine_response = dynamo_response
-                elif hasattr(dynamo_response, "data"):
-                    engine_response = dynamo_response.data()
-                else:
-                    engine_response = dynamo_response
+                if dynamo_response.is_error():
+                    comments = dynamo_response.comments() or []
+                    message = "; ".join(comments) or "unknown routed_engine error"
+                    logger.error(
+                        "routed_engine error for request %s: %s",
+                        request_id,
+                        message,
+                    )
+                    yield make_internal_error(request_id, message)
+                    break
+                engine_response = dynamo_response.data()
+
+                if engine_response is None:
+                    # No data or error fields, means we may have a comment or other kind of event.
+                    # Skip for now.
+                    continue
 
                 if (
                     not isinstance(engine_response, dict)
                     or "token_ids" not in engine_response
                 ):
-                    msg = _engine_error_message(engine_response, request_id)
-                    logger.error(
-                        "Engine returned an invalid response for request %s: %s",
-                        request_id,
-                        engine_response,
-                    )
-                    raise Unknown(msg)
+                    yield handle_engine_error(engine_response, request_id, logger)
+                    break
 
                 new_ids = engine_response["token_ids"]
                 raw_finish = engine_response.get("finish_reason")
@@ -599,15 +576,11 @@ class SglangProcessor:
 class SglangEngineFactory:
     def __init__(
         self,
-        runtime: DistributedRuntime,
-        router_config: RouterConfig,
         config: FrontendConfig,
         debug_perf: bool = False,
         tool_call_parser_name: str | None = None,
         reasoning_parser_name: str | None = None,
     ):
-        self.runtime = runtime
-        self.router_config = router_config
         self.config = config
         self.debug_perf = debug_perf
         self.tool_call_parser_name = tool_call_parser_name
@@ -673,22 +646,6 @@ class SglangEngineFactory:
         if reasoning_parser_name:
             logger.info("SGLang reasoning parser: %s", reasoning_parser_name)
 
-        (namespace_name, component_name, endpoint_name) = instance_id.triple()
-        generate_endpoint = self.runtime.endpoint(
-            f"{namespace_name}.{component_name}.{endpoint_name}"
-        )
-        router: Client | KvRouter
-        if self.router_config.router_mode == RouterMode.KV:
-            router = KvRouter(
-                endpoint=generate_endpoint,
-                block_size=self.config.kv_cache_block_size or 16,
-                kv_router_config=self.router_config.kv_router_config,
-            )
-        else:
-            router = await generate_endpoint.client(
-                router_mode=self.router_config.router_mode
-            )
-
         preprocess_pool = None
         preprocess_workers = self.config.preprocess_workers
         if preprocess_workers > 0:
@@ -734,7 +691,7 @@ class SglangEngineFactory:
 
         gen = SglangProcessor(
             tokenizer,
-            router,
+            routed_engine,
             tool_call_parser_name,
             reasoning_parser_name,
             eos_token_id,

--- a/components/src/dynamo/frontend/tests/_routed_engine_fakes.py
+++ b/components/src/dynamo/frontend/tests/_routed_engine_fakes.py
@@ -1,0 +1,46 @@
+#  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+"""Shared fakes for RoutedEngine in processor unit tests."""
+
+
+async def _async_iter(items):
+    for item in items:
+        yield item
+
+
+class FakeRoutedItem:
+    """Mimics a real routed-engine item with is_error/comments/data methods."""
+
+    def __init__(self, data, is_error=False, comments=None):
+        self._data = data
+        self._is_error = is_error
+        self._comments = comments or []
+
+    def is_error(self):
+        return self._is_error
+
+    def comments(self):
+        return self._comments
+
+    def data(self):
+        return self._data
+
+
+class FakeRoutedEngine:
+    def __init__(self, items=None):
+        if items is None:
+            items = [FakeRoutedItem({"token_ids": [101], "index": 0})]
+        else:
+            items = [
+                item if isinstance(item, FakeRoutedItem) else FakeRoutedItem(item)
+                for item in items
+            ]
+        self.items = items
+        self.requests = []
+        self.kwargs = []
+
+    async def generate(self, preprocessed, **kwargs):
+        self.requests.append(preprocessed)
+        self.kwargs.append(kwargs)
+        return _async_iter(self.items)

--- a/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
@@ -16,7 +16,7 @@ import sys
 import types
 
 import pytest
-from _routed_engine_fakes import FakeRoutedEngine
+from _routed_engine_fakes import FakeRoutedEngine, FakeRoutedItem
 from sglang.srt.function_call.function_call_parser import FunctionCallParser
 from sglang.srt.function_call.json_array_parser import JsonArrayParser
 from sglang.srt.utils.hf_transformers_utils import get_tokenizer
@@ -1682,6 +1682,61 @@ class TestIncrementalDetokenization:  # FRONTEND.6 — token-id stream → text
         assert len(items) == 1
         assert items[0]["nvext"]["stop_reason"] == "END"
         assert "stop_reason" not in items[0]["choices"][0]
+
+    def _run_stream(self, tokenizer, items):
+        processor = SglangProcessor(
+            tokenizer=tokenizer,
+            routed_engine=FakeRoutedEngine(items=items),
+            tool_call_parser_name=None,
+            reasoning_parser_name=None,
+            eos_token_id=None,
+        )
+        post = SglangStreamingPostProcessor(
+            tokenizer=tokenizer, tool_call_parser=None, reasoning_parser=None
+        )
+
+        async def collect():
+            return [
+                item
+                async for item in processor._generate_and_stream(
+                    "req-err", {"model": "test-model"}, {}, [], post
+                )
+            ]
+
+        return asyncio.run(collect())
+
+    def test_routed_engine_is_error_yields_internal_error(self, tokenizer):
+        """is_error() True yields a single internal_error chunk with the comment text."""
+        items = self._run_stream(
+            tokenizer,
+            [FakeRoutedItem(None, is_error=True, comments=["backend disconnected"])],
+        )
+        assert len(items) == 1
+        err = items[0]["error"]
+        assert err["type"] == "internal_error"
+        assert "backend disconnected" in err["message"]
+
+    def test_routed_engine_none_data_is_skipped(self, tokenizer):
+        """data() is None (e.g. comment-only event) is skipped, not yielded as error."""
+        items = self._run_stream(
+            tokenizer,
+            [
+                FakeRoutedItem(None),
+                {"token_ids": [], "finish_reason": "stop"},
+            ],
+        )
+        # Only the real chunk is yielded; the None-data item is dropped silently.
+        assert len(items) == 1
+        assert items[0]["choices"][0]["finish_reason"] == "stop"
+
+    def test_malformed_engine_response_yields_engine_error(self, tokenizer):
+        """A response dict missing token_ids goes through handle_engine_error."""
+        items = self._run_stream(
+            tokenizer,
+            [{"status": "error", "message": "kv cache exhausted"}],
+        )
+        assert len(items) == 1
+        assert "error" in items[0]
 
     def test_lookback_trimming(self, tokenizer):
         """Verify _all_token_ids doesn't grow unbounded."""

--- a/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
@@ -16,6 +16,7 @@ import sys
 import types
 
 import pytest
+from _routed_engine_fakes import FakeRoutedEngine
 from sglang.srt.function_call.function_call_parser import FunctionCallParser
 from sglang.srt.function_call.json_array_parser import JsonArrayParser
 from sglang.srt.utils.hf_transformers_utils import get_tokenizer
@@ -1645,8 +1646,6 @@ class TestIncrementalDetokenization:  # FRONTEND.6 — token-id stream → text
 
     def test_stop_reason_emits_in_nvext_when_requested(self, tokenizer):
         """Frontend emits backend stop_reason under nvext when requested."""
-
-        from _routed_engine_fakes import FakeRoutedEngine
 
         async def collect():
             processor = SglangProcessor(

--- a/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
@@ -1646,18 +1646,20 @@ class TestIncrementalDetokenization:  # FRONTEND.6 — token-id stream → text
     def test_stop_reason_emits_in_nvext_when_requested(self, tokenizer):
         """Frontend emits backend stop_reason under nvext when requested."""
 
-        class FakeRouter:
-            async def generate(self, *args, **kwargs):
-                yield {
-                    "token_ids": [],
-                    "finish_reason": "stop",
-                    "stop_reason": "END",
-                }
+        from _routed_engine_fakes import FakeRoutedEngine
 
         async def collect():
             processor = SglangProcessor(
                 tokenizer=tokenizer,
-                router=FakeRouter(),
+                routed_engine=FakeRoutedEngine(
+                    items=[
+                        {
+                            "token_ids": [],
+                            "finish_reason": "stop",
+                            "stop_reason": "END",
+                        }
+                    ]
+                ),
                 tool_call_parser_name=None,
                 reasoning_parser_name=None,
                 eos_token_id=None,

--- a/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
@@ -10,6 +10,7 @@ tool_choice='none' and the exclude_tools_when_tool_choice_none flag.
 from types import SimpleNamespace
 
 import pytest
+from _routed_engine_fakes import FakeRoutedEngine as _FakeRoutedEngine
 from transformers import AutoTokenizer
 
 from dynamo.frontend.prepost import _prepare_request
@@ -194,48 +195,6 @@ class TestReasoningParserMetadata:
                 "chat_template_kwargs": {"reasoning_effort": "high"}
             },
         }
-
-
-async def _async_iter(items):
-    for item in items:
-        yield item
-
-
-class _FakeRoutedItem:
-    """Mimics a real routed-engine item with is_error/comments/data methods."""
-
-    def __init__(self, data, is_error=False, comments=None):
-        self._data = data
-        self._is_error = is_error
-        self._comments = comments or []
-
-    def is_error(self):
-        return self._is_error
-
-    def comments(self):
-        return self._comments
-
-    def data(self):
-        return self._data
-
-
-class _FakeRoutedEngine:
-    def __init__(self, items=None):
-        if items is None:
-            items = [_FakeRoutedItem({"token_ids": [101], "index": 0})]
-        else:
-            items = [
-                item if isinstance(item, _FakeRoutedItem) else _FakeRoutedItem(item)
-                for item in items
-            ]
-        self.items = items
-        self.requests = []
-        self.kwargs = []
-
-    async def generate(self, preprocessed, **kwargs):
-        self.requests.append(preprocessed)
-        self.kwargs.append(kwargs)
-        return _async_iter(self.items)
 
 
 class _FakeOutputProcessor:

--- a/examples/backends/sglang/launch/disagg_same_gpu.sh
+++ b/examples/backends/sglang/launch/disagg_same_gpu.sh
@@ -42,7 +42,15 @@ print_launch_banner "Launching Disaggregated (same GPU)" "$MODEL" "$HTTP_PORT" \
 
 # run ingress
 # dynamo.frontend accepts either --http-port flag or DYN_HTTP_PORT env var (defaults to 8000)
-python3 -m dynamo.frontend &
+# Set DYN_CHAT_PROCESSOR=sglang to exercise the Python pre/post processor instead of Rust.
+FRONTEND_ARGS=()
+if [[ -n "${DYN_CHAT_PROCESSOR:-}" ]]; then
+    FRONTEND_ARGS+=(--dyn-chat-processor "$DYN_CHAT_PROCESSOR")
+fi
+if [[ -n "${DYN_ROUTER_MODE:-}" ]]; then
+    FRONTEND_ARGS+=(--router-mode "$DYN_ROUTER_MODE")
+fi
+python3 -m dynamo.frontend "${FRONTEND_ARGS[@]}" &
 
 # NOTE: Each worker picks a random NCCL port (get_free_port) for torch.distributed.
 # This has a TOCTOU race — the port can be grabbed before init_process_group binds it,

--- a/lib/llm/src/migration.rs
+++ b/lib/llm/src/migration.rs
@@ -1018,6 +1018,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         ));
 
         // MidStreamFail after 3 tokens: without the fix, migration would succeed and

--- a/lib/llm/src/protocols/common.rs
+++ b/lib/llm/src/protocols/common.rs
@@ -373,6 +373,10 @@ pub struct GuidedDecodingOptions {
     /// If specified, whitespace pattern to use for guided decoding. Can be a string or null.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub whitespace_pattern: Option<String>,
+
+    /// Guided decoding related (sglang only right now)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub structural_tag: Option<serde_json::Value>,
 }
 
 impl GuidedDecodingOptions {
@@ -384,6 +388,7 @@ impl GuidedDecodingOptions {
         grammar: Option<String>,
         backend: Option<String>,
         whitespace_pattern: Option<String>,
+        structural_tag: Option<serde_json::Value>,
     ) -> Self {
         Self {
             json,
@@ -392,6 +397,7 @@ impl GuidedDecodingOptions {
             grammar,
             backend,
             whitespace_pattern,
+            structural_tag,
         }
     }
 
@@ -403,8 +409,17 @@ impl GuidedDecodingOptions {
         grammar: Option<String>,
         backend: Option<String>,
         whitespace_pattern: Option<String>,
+        structural_tag: Option<serde_json::Value>,
     ) -> Result<Self> {
-        let instance = Self::new(json, regex, choice, grammar, backend, whitespace_pattern);
+        let instance = Self::new(
+            json,
+            regex,
+            choice,
+            grammar,
+            backend,
+            whitespace_pattern,
+            structural_tag,
+        );
         instance.validate()?;
         Ok(instance)
     }
@@ -417,6 +432,7 @@ impl GuidedDecodingOptions {
         grammar: Option<String>,
         backend: Option<String>,
         whitespace_pattern: Option<String>,
+        structural_tag: Option<serde_json::Value>,
     ) -> Result<Option<Self>> {
         let is_empty_choice = choice.as_ref().is_none_or(|v| v.is_empty());
         if json.is_none()
@@ -424,10 +440,19 @@ impl GuidedDecodingOptions {
             && is_empty_choice
             && grammar.is_none()
             && whitespace_pattern.is_none()
+            && structural_tag.is_none()
         {
             return Ok(None);
         }
-        let instance = Self::validated(json, regex, choice, grammar, backend, whitespace_pattern)?;
+        let instance = Self::validated(
+            json,
+            regex,
+            choice,
+            grammar,
+            backend,
+            whitespace_pattern,
+            structural_tag,
+        )?;
         Ok(Some(instance))
     }
 
@@ -440,6 +465,7 @@ impl GuidedDecodingOptions {
             self.choice.as_ref().is_some_and(|v| !v.is_empty()),
             self.grammar.is_some(),
             self.whitespace_pattern.is_some(),
+            self.structural_tag.is_some(),
         ]
         .iter()
         .filter(|&&v| v)
@@ -447,7 +473,7 @@ impl GuidedDecodingOptions {
 
         if count > 1 {
             return Err(anyhow::anyhow!(
-                "Only one of json, regex, choice, or grammar can be set, but multiple are specified: {:?}",
+                "Only one of json, regex, choice, grammar, or structural_tag can be set, but multiple are specified: {:?}",
                 self
             ));
         }
@@ -746,6 +772,7 @@ mod tests {
             None,
             backend.clone(),
             None,
+            None,
         );
         assert!(opts.is_ok());
         let opts = opts.unwrap();
@@ -758,7 +785,8 @@ mod tests {
 
         // Only regex set
         let regex = Some(r"\d+".to_string());
-        let opts = GuidedDecodingOptions::validated(None, regex.clone(), None, None, None, None);
+        let opts =
+            GuidedDecodingOptions::validated(None, regex.clone(), None, None, None, None, None);
         assert!(opts.is_ok());
         let opts = opts.unwrap();
         assert_eq!(opts.regex, regex);
@@ -769,7 +797,8 @@ mod tests {
 
         // Only choice set
         let choice = Some(vec!["A".to_string(), "B".to_string()]);
-        let opts = GuidedDecodingOptions::validated(None, None, choice.clone(), None, None, None);
+        let opts =
+            GuidedDecodingOptions::validated(None, None, choice.clone(), None, None, None, None);
         assert!(opts.is_ok());
         let opts = opts.unwrap();
         assert_eq!(opts.choice, choice);
@@ -780,7 +809,8 @@ mod tests {
 
         // Only grammar set
         let grammar = Some("root ::= 'yes' | 'no'".to_string());
-        let opts = GuidedDecodingOptions::validated(None, None, None, grammar.clone(), None, None);
+        let opts =
+            GuidedDecodingOptions::validated(None, None, None, grammar.clone(), None, None, None);
         assert!(opts.is_ok());
         let opts = opts.unwrap();
         assert_eq!(opts.grammar, grammar);
@@ -798,6 +828,7 @@ mod tests {
             None,
             None,
             whitespace_pattern.clone(),
+            None,
         );
         assert!(opts.is_ok());
         let opts = opts.unwrap();
@@ -815,6 +846,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         assert!(opts.is_err());
 
@@ -822,6 +854,7 @@ mod tests {
             None,
             Some(r"\d+".to_string()),
             Some(vec!["A".to_string()]),
+            None,
             None,
             None,
             None,
@@ -835,25 +868,26 @@ mod tests {
             Some("root ::= 'yes'".to_string()),
             None,
             None,
+            None,
         );
         assert!(opts.is_err());
 
         // All fields None (should be ok, but not useful)
-        let opts = GuidedDecodingOptions::validated(None, None, None, None, None, None);
+        let opts = GuidedDecodingOptions::validated(None, None, None, None, None, None, None);
         assert!(opts.is_ok());
     }
 
     #[test]
     fn test_guided_decoding_options_from_optional() {
         // All None returns Ok(None)
-        let opts = GuidedDecodingOptions::from_optional(None, None, None, None, None, None);
+        let opts = GuidedDecodingOptions::from_optional(None, None, None, None, None, None, None);
         assert!(opts.is_ok());
         assert!(opts.unwrap().is_none());
 
         // Only one set returns Ok(Some)
         let regex = Some(r"\w+".to_string());
         let opts =
-            GuidedDecodingOptions::from_optional(None, regex.clone(), None, None, None, None);
+            GuidedDecodingOptions::from_optional(None, regex.clone(), None, None, None, None, None);
         assert!(opts.is_ok());
         let val = opts.unwrap();
         assert!(val.is_some());
@@ -868,11 +902,13 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         assert!(opts.is_err());
 
         // Choice set but empty vector should not count as set
-        let opts = GuidedDecodingOptions::from_optional(None, None, Some(vec![]), None, None, None);
+        let opts =
+            GuidedDecodingOptions::from_optional(None, None, Some(vec![]), None, None, None, None);
         assert!(opts.is_ok());
         let val = opts.unwrap();
         assert!(val.is_none());
@@ -882,6 +918,7 @@ mod tests {
             None,
             None,
             Some(vec!["A".to_string()]),
+            None,
             None,
             None,
             None,
@@ -896,7 +933,8 @@ mod tests {
     #[test]
     fn test_guided_grammar_deep_nesting_rejected() {
         let grammar = "(".repeat(501) + "a" + &")".repeat(501);
-        let result = GuidedDecodingOptions::validated(None, None, None, Some(grammar), None, None);
+        let result =
+            GuidedDecodingOptions::validated(None, None, None, Some(grammar), None, None, None);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("nesting depth"));
     }
@@ -904,7 +942,8 @@ mod tests {
     #[test]
     fn test_guided_grammar_acceptable_nesting_ok() {
         let grammar = "(".repeat(500) + "a" + &")".repeat(500);
-        let result = GuidedDecodingOptions::validated(None, None, None, Some(grammar), None, None);
+        let result =
+            GuidedDecodingOptions::validated(None, None, None, Some(grammar), None, None, None);
         assert!(result.is_ok());
     }
 }

--- a/lib/llm/src/protocols/openai.rs
+++ b/lib/llm/src/protocols/openai.rs
@@ -152,6 +152,7 @@ impl<T: OpenAISamplingOptionsProvider + CommonExtProvider> SamplingOptionsProvid
             guided_grammar,
             guided_decoding_backend,
             guided_whitespace_pattern,
+            None,
         ) {
             Ok(options) => options,
             Err(e) => {

--- a/tests/serve/test_sglang.py
+++ b/tests/serve/test_sglang.py
@@ -189,6 +189,65 @@ sglang_configs = {
             ),
         ],
     ),
+    "disaggregated_same_gpu_chat_processor": SGLangConfig(
+        # Same as disaggregated_same_gpu but routes chat through the Python
+        # sglang_processor (DYN_CHAT_PROCESSOR=sglang) instead of the default
+        # Rust pre/post processor.
+        name="disaggregated_same_gpu_chat_processor",
+        directory=sglang_dir,
+        script_name="disagg_same_gpu.sh",
+        marks=[
+            pytest.mark.gpu_1,
+            pytest.mark.profiled_vram_gib(9.9),
+            pytest.mark.requested_sglang_kv_tokens(37472),
+            pytest.mark.timeout(420),
+            pytest.mark.post_merge,
+            pytest.mark.skipif(
+                _is_cuda13(),
+                reason="torch-memory-saver preload .so links libcudart.so.12, missing in cuda13 images",
+            ),
+        ],
+        model="Qwen/Qwen3-0.6B",
+        delayed_start=10,
+        health_check_workers=True,
+        env={"DYN_CHAT_PROCESSOR": "sglang"},
+        frontend_port=DefaultPort.FRONTEND.value,
+        request_payloads=[
+            chat_payload_default(),
+            completion_payload_default(),
+        ],
+    ),
+    "disaggregated_same_gpu_chat_processor_kv_router": SGLangConfig(
+        # sglang Python chat processor + KV router.
+        name="disaggregated_same_gpu_chat_processor_kv_router",
+        directory=sglang_dir,
+        script_name="disagg_same_gpu.sh",
+        marks=[
+            pytest.mark.gpu_1,
+            pytest.mark.profiled_vram_gib(9.9),
+            pytest.mark.requested_sglang_kv_tokens(37472),
+            pytest.mark.timeout(420),
+            pytest.mark.post_merge,
+            pytest.mark.skipif(
+                _is_cuda13(),
+                reason="torch-memory-saver preload .so links libcudart.so.12, missing in cuda13 images",
+            ),
+        ],
+        model="Qwen/Qwen3-0.6B",
+        delayed_start=10,
+        health_check_workers=True,
+        env={
+            "DYN_CHAT_PROCESSOR": "sglang",
+            "DYN_ROUTER_MODE": "kv",
+            # Deterministic hash for KV event IDs.
+            "PYTHONHASHSEED": "0",
+        },
+        frontend_port=DefaultPort.FRONTEND.value,
+        request_payloads=[
+            chat_payload_default(),
+            completion_payload_default(),
+        ],
+    ),
     "kv_events": SGLangConfig(
         name="kv_events",
         directory=sglang_dir,


### PR DESCRIPTION
The sglang version of vllm's #9503. Most of the work is shared, and done in that one.

Full details are in Issue #9440 .

Closes: #9573

Note this also adds structural_tag to support guided decoding. That was added earlier only for the python side and was missing from the Rust parts which we now use more fully.


<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9577" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for `structural_tag` option in guided decoding for enhanced structured output configuration.

* **Improvements**
  * Enhanced request context propagation and error handling throughout the request processing pipeline.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9577)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->