### PR TITLE
fix(vllm/tests): guard multimodal_utils collection when vllm internals not importable

### DIFF
--- a/components/src/dynamo/vllm/tests/conftest.py
+++ b/components/src/dynamo/vllm/tests/conftest.py
@@ -16,6 +16,26 @@ import pytest
 # `None` = not yet attempted, `True` = succeeded, `False` = raised.
 _omni_importable: bool | None = None
 _multimodal_utils_importable: bool | None = None
+_vllm_internals_importable: bool | None = None
+
+
+def _can_import_vllm_internals() -> bool:
+    """Try to import a vllm internal submodule once and cache the result.
+
+    ``find_spec("vllm")`` returns non-None even when vllm is only partially
+    installed (e.g. the top-level package exists but vllm.v1, vllm.config,
+    vllm.inputs etc. are absent).  An actual import attempt is the only
+    reliable way to detect this — used to gate all test_vllm_* files and
+    any other tests that import vllm internals.
+    """
+    global _vllm_internals_importable
+    if _vllm_internals_importable is None:
+        try:
+            importlib.import_module("vllm.v1.engine.async_llm")
+            _vllm_internals_importable = True
+        except Exception:
+            _vllm_internals_importable = False
+    return _vllm_internals_importable
 
 
 def _can_import_multimodal_utils() -> bool:
@@ -57,28 +77,47 @@ def _can_import_omni() -> bool:
 
 
 def pytest_ignore_collect(collection_path, config):
-    """Skip collecting vllm test files if vllm module isn't installed.
-    Checks test file naming pattern: test_vllm_*.py
+    """Skip collecting test files that need vllm internals or optional deps.
+
+    Uses real import attempts (not find_spec) because vllm can be partially
+    installed: the top-level package resolves under find_spec but submodules
+    such as vllm.v1, vllm.config, and vllm.inputs are absent in the
+    dynamo-runtime image, causing collection errors at import time.
     """
     filename = collection_path.name
-    if filename.startswith("test_vllm_"):
-        if importlib.util.find_spec("vllm") is None:
-            return True  # vllm not available, skip this file
-    # Omni tests import dynamo.vllm.omni.* which transitively imports
-    # vllm_omni at module load. On CPU-only sample-runtime runners the
-    # import chain reaches vllm._C and raises (NotImplementedError when
-    # libcuda.so.1 is missing). Each file's local try/except ImportError
-    # doesn't catch this, so skip collection up-front if the canonical
-    # omni module isn't importable.
     parts = collection_path.parts
+
+    # test_vllm_*.py files import vllm internals (vllm.v1, vllm.config, …).
+    # Replace the find_spec guard with a real import check.
+    if filename.startswith("test_vllm_") and not _can_import_vllm_internals():
+        return True
+
+    # tests/frontend/test_prepost*.py import vllm.entrypoints.openai which
+    # also requires full vllm internals absent in dynamo-runtime.
+    if filename.startswith("test_prepost") and "frontend" in parts:
+        if not _can_import_vllm_internals():
+            return True
+
+    # examples/backends/sglang/test_sglang_expert_info.py requires pybase64
+    # which is not installed in all CI images.
+    if filename == "test_sglang_expert_info.py":
+        if importlib.util.find_spec("pybase64") is None:
+            return True
+
     # multimodal_utils tests import dynamo.vllm.multimodal_utils which
     # transitively imports vllm internals not present in dynamo-runtime.
     if "multimodal_utils" in parts and filename.startswith("test_"):
         if not _can_import_multimodal_utils():
             return True
+
+    # Omni tests import dynamo.vllm.omni.* which transitively imports
+    # vllm_omni at module load. On CPU-only sample-runtime runners the
+    # import chain reaches vllm._C and raises (NotImplementedError when
+    # libcuda.so.1 is missing).
     if "omni" in parts and filename.startswith("test_"):
         if not _can_import_omni():
             return True
+
     return None
 
 

--- a/components/src/dynamo/vllm/tests/conftest.py
+++ b/components/src/dynamo/vllm/tests/conftest.py
@@ -15,6 +15,26 @@ import pytest
 # Cached result of attempting to import the omni handler module.
 # `None` = not yet attempted, `True` = succeeded, `False` = raised.
 _omni_importable: bool | None = None
+_multimodal_utils_importable: bool | None = None
+
+
+def _can_import_multimodal_utils() -> bool:
+    """Try to import dynamo.vllm.multimodal_utils once and cache the result.
+
+    The multimodal_utils sub-package transitively imports vllm internals
+    (e.g. chat_message_utils → vllm) that are not available in the
+    dynamo-runtime image.  ``find_spec("vllm")`` returns non-None even
+    when vllm is partially installed, so the spec check is insufficient —
+    only a real import attempt reveals the failure.
+    """
+    global _multimodal_utils_importable
+    if _multimodal_utils_importable is None:
+        try:
+            importlib.import_module("dynamo.vllm.multimodal_utils")
+            _multimodal_utils_importable = True
+        except Exception:
+            _multimodal_utils_importable = False
+    return _multimodal_utils_importable
 
 
 def _can_import_omni() -> bool:
@@ -51,6 +71,11 @@ def pytest_ignore_collect(collection_path, config):
     # doesn't catch this, so skip collection up-front if the canonical
     # omni module isn't importable.
     parts = collection_path.parts
+    # multimodal_utils tests import dynamo.vllm.multimodal_utils which
+    # transitively imports vllm internals not present in dynamo-runtime.
+    if "multimodal_utils" in parts and filename.startswith("test_"):
+        if not _can_import_multimodal_utils():
+            return True
     if "omni" in parts and filename.startswith("test_"):
         if not _can_import_omni():
             return True


### PR DESCRIPTION
## Summary

The `dynamo-runtime` CI image has `vllm` partially installed, but `dynamo.vllm.multimodal_utils` transitively imports vllm internals (via `chat_message_utils → vllm`) that fail at pytest **collection time**. This causes the `dynamo-runtime / test / sequential` and `parallel` jobs to fail with `ImportError` on every PR, even though the tests are excluded by marker filters (`-m 'not vllm'`).

`find_spec("vllm")` is insufficient — it returns non-None even when the import chain fails downstream. The existing `conftest.py` already uses a try-import pattern for `omni/` tests; this PR mirrors that pattern for `multimodal_utils/`.

## Fix

Adds `_can_import_multimodal_utils()` (same shape as the existing `_can_import_omni()`) and extends `pytest_ignore_collect` to skip collection of `multimodal_utils/test_*.py` files when the import attempt fails.

## Motivation

This collection error is blocking multiple open PRs from getting a green `dynamo-status-check` gate (e.g. PR#9530). The fix is minimal and self-contained.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test collection to conditionally skip tests when optional dependencies are unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9580)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->