### PR TITLE
test: skip online replay smoke variants (intermittent hang)

### DIFF
--- a/lib/bindings/python/tests/replay/test_replay_smoke.py
+++ b/lib/bindings/python/tests/replay/test_replay_smoke.py
@@ -30,6 +30,13 @@ pytestmark = [
 ]
 
 
+@pytest.fixture(autouse=True)
+def _skip_online(request):
+    callspec = getattr(request.node, "callspec", None)
+    if callspec and callspec.params.get("replay_mode") == "online":
+        pytest.skip("intermittent hang in online replay mode (#9548)")
+
+
 @pytest.mark.parametrize("engine_type", ["vllm", "sglang"])
 @pytest.mark.parametrize("replay_mode", ["offline", "online"])
 @pytest.mark.parametrize("router_mode", ["round_robin", "kv_router"])


### PR DESCRIPTION
#### Overview

Skips all online replay smoke test variants via an autouse fixture. Online variants intermittently hang on CPU-only CI runners, consuming the full 30-minute job timeout:

- `multiturn_workloads[online]`: https://github.com/ai-dynamo/dynamo/actions/runs/25769033852/job/75690450269
- `multiturn_sessions[online]`: https://github.com/ai-dynamo/dynamo/actions/runs/25892626974/job/76099921305

The online parametrizations are kept so they show as `SKIPPED` in CI output (not silently removed), making it easy to track when they should be re-enabled.

#### Related Issues
- #9548