### PR TITLE
test(parity): document minimax sglang separator behavior

### DIFF
--- a/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.2.yaml
+++ b/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.2.yaml
@@ -83,6 +83,7 @@ cases:
             timezone: EST
         normal_text: |2+
 
+        reason: "SGLang parser preserves the newline separator between adjacent MiniMax tool-call wrappers (`</minimax:tool_call>\\n<minimax:tool_call>`)."
   PARSER.batch.2.c:
     description: Parallel with surrounding narration
     ref: dynamo
@@ -118,6 +119,7 @@ cases:
           arguments:
             timezone: EST
         normal_text: 'Both:  Done.'
+        reason: "SGLang preserves normal text after parsed MiniMax tool-call wrappers; Dynamo aligns with vLLM by keeping only text before the first parsed tool call."
   PARSER.batch.2.d:
     description: Same-name twice
     ref: originated from https://github.com/vllm-project/vllm/blob/b53c507bc91f87e28b03e9b54bbff7c76e97d58b/tests/tool_parsers/test_minimax_m2_tool_parser.py#L331

--- a/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.8.yaml
+++ b/tests/parity/parser/fixtures/minimax_m2/PARSER.batch.8.yaml
@@ -55,6 +55,7 @@ cases:
           arguments:
             location: NYC
         normal_text: ' Let me know if you need more.'
+        reason: "SGLang preserves normal text after parsed MiniMax tool-call wrappers; Dynamo aligns with vLLM by keeping only text before the first parsed tool call."
   PARSER.batch.8.c:
     description: Narration both before and after (sandwich)
     ref: dynamo
@@ -80,6 +81,7 @@ cases:
           arguments:
             location: NYC
         normal_text: I will check the weather.  Let me know if you need more.
+        reason: "SGLang preserves normal text after parsed MiniMax tool-call wrappers; Dynamo aligns with vLLM by keeping only text before the first parsed tool call."
   PARSER.batch.8.d:
     description: Narration between multiple tool calls
     ref: dynamo
@@ -115,3 +117,4 @@ cases:
           arguments:
             location: LA
         normal_text: 'I will check the weather.  Then check LA weather. '
+        reason: "SGLang preserves normal text after parsed MiniMax tool-call wrappers; Dynamo aligns with vLLM by keeping only text before the first parsed tool call."


### PR DESCRIPTION
#### Overview:

Document why MiniMax SGLang parser output differs from Dynamo/vLLM for `PARSER.batch.2.b`, `2.c`, `8.b`, `8.c`, and `8.d`. This PR classifies the existing SGLang differences with `reason:` fields.

#### Details:

`PARSER.batch.2.b` has two adjacent MiniMax tool-call wrappers:

```xml
<minimax:tool_call>
<invoke name="get_weather">
<parameter name="location">NYC</parameter>
</invoke>
</minimax:tool_call>
<minimax:tool_call>
<invoke name="get_time">
<parameter name="timezone">EST</parameter>
</invoke>
</minimax:tool_call>
```

Dynamo and vLLM parse both calls and treat the newline between wrappers as a structural separator:

```json
{
  "calls": [
    {"name": "get_weather", "arguments": {"location": "NYC"}},
    {"name": "get_time", "arguments": {"timezone": "EST"}}
  ],
  "normal_text": ""
}
```

SGLang parses both calls but preserves that separator:

```json
{
  "calls": [
    {"name": "get_weather", "arguments": {"location": "NYC"}},
    {"name": "get_time", "arguments": {"timezone": "EST"}}
  ],
  "normal_text": "\n"
}
```

We keep Dynamo aligned with vLLM because this newline is not semantic assistant text.

`PARSER.batch.2.c`, `8.b`, `8.c`, and `8.d` cover real normal text around parsed MiniMax tool-call wrappers. SGLang preserves post-wrapper/inter-wrapper narration in `normal_text`; Dynamo and vLLM keep only the content prefix before the first parsed tool call.

Example:

```xml
I will check the weather. <minimax:tool_call>
<invoke name="get_weather">
<parameter name="location">NYC</parameter>
</invoke>
</minimax:tool_call> Then check LA weather. <minimax:tool_call>
<invoke name="get_weather">
<parameter name="location">LA</parameter>
</invoke>
</minimax:tool_call>
```

Dynamo/vLLM:

```json
{
  "calls": [
    {"name": "get_weather", "arguments": {"location": "NYC"}},
    {"name": "get_weather", "arguments": {"location": "LA"}}
  ],
  "normal_text": "I will check the weather. "
}
```

SGLang:

```json
{
  "calls": [
    {"name": "get_weather", "arguments": {"location": "NYC"}},
    {"name": "get_weather", "arguments": {"location": "LA"}}
  ],
  "normal_text": "I will check the weather.  Then check LA weather. "
}
```

Per the alignment-target rubric added in #9583:

- No MiniMax spec clearly requires surfacing post-wrapper narration as `message.content`.
- This is not a tool-call tag leak; SGLang preserves natural text, not protocol markup.
- No customer-specific engine override applies here.
- vLLM and SGLang disagree, so Dynamo keeps the existing vLLM-aligned behavior and records the reason in the fixture.

#### Where should the reviewer start?

Start with the MiniMax fixture reason fields:

- `tests/parity/parser/fixtures/minimax_m2/PARSER.batch.2.yaml`
- `tests/parity/parser/fixtures/minimax_m2/PARSER.batch.8.yaml`

#### Related Issues:

Related rubric/context: https://github.com/ai-dynamo/dynamo/pull/9583

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9585" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated parser test documentation to clarify SGLang behavior with adjacent MiniMax tool-call wrappers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9585)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->