### PR TITLE
fix(docs): move SPDX header into frontmatter in efa.md

### DIFF
--- a/docs/kubernetes/cloud-providers/eks/efa.md
+++ b/docs/kubernetes/cloud-providers/eks/efa.md
@@ -1,11 +1,8 @@
 ---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 title: EFA (RDMA over AWS Fabric) on EKS
 ---
-
-<!--
-SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-SPDX-License-Identifier: Apache-2.0
--->
 
 # EFA (RDMA over AWS Fabric) on EKS
 


### PR DESCRIPTION
## Summary

- The HTML comment block `<!-- ... -->` at the top of `docs/kubernetes/cloud-providers/eks/efa.md` trips Fern's MDX parser with `Unexpected character `!` (U+0021)`, which has been breaking the **Fern Docs** publish job on `main` since PR #9521 merged (runs [25875849962](https://github.com/ai-dynamo/dynamo/actions/runs/25875849962), [25878882544](https://github.com/ai-dynamo/dynamo/actions/runs/25878882544), and most recently [25889744864](https://github.com/ai-dynamo/dynamo/actions/runs/25889744864)).
- Move the SPDX header inside the YAML frontmatter as `#` comments, matching the convention already used in e.g. `docs/digest/tokenspeed/tokenspeed-day-0.md`.

The publish step only runs when the bot detects a docs diff vs. `docs-website`, so non-docs merges silently "passed" with the bad content sitting on the branch — that's why this looked intermittent.

## Test plan

- [ ] Fern Docs workflow goes green on this PR's preview step (`fern generate --docs --preview`).
- [ ] After merge, the next push to `main` produces a successful `Publish Docs` step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/9589" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated EFA on EKS documentation metadata structure for better organization and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/dynamo/pull/9589)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->